### PR TITLE
chore(vet): fix all go vet warnings

### DIFF
--- a/client/value_test.go
+++ b/client/value_test.go
@@ -26,7 +26,8 @@ func TestVertex_BoolValue(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.v.BoolValue()
 			if (err != nil) != tt.wantErr {
@@ -58,7 +59,8 @@ func TestVertex_BytesValue(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.v.BytesValue()
 			if (err != nil) != tt.wantErr {
@@ -90,7 +92,8 @@ func TestVertex_FloatValue(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.v.FloatValue()
 			if (err != nil) != tt.wantErr {
@@ -122,7 +125,8 @@ func TestVertex_IntValue(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.v.IntValue()
 			if (err != nil) != tt.wantErr {
@@ -152,7 +156,8 @@ func TestVertex_IsNil(t *testing.T) {
 			want: true,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.v.IsNil(); got != tt.want {
 				t.Errorf("IsNil() = %v, want %v", got, tt.want)
@@ -179,7 +184,8 @@ func TestVertex_StringValue(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.v.StringValue()
 			if (err != nil) != tt.wantErr {
@@ -212,7 +218,8 @@ func TestVertex_TimeValue(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.v.TimeValue()
 			if (err != nil) != tt.wantErr {
@@ -244,7 +251,8 @@ func TestVertex_UIntValue(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.v.UIntValue()
 			if (err != nil) != tt.wantErr {
@@ -288,7 +296,8 @@ func Test_nativeVertex_asVertex(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			v := nativeVertex{
 				key:        tt.fields.key,

--- a/core/cache/cache_test.go
+++ b/core/cache/cache_test.go
@@ -22,7 +22,8 @@ func TestCache_Clear(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.Clear()
 			if len(tt.c.cache) != 0 {
@@ -48,7 +49,8 @@ func TestCache_Count(t *testing.T) {
 			want: 1,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.c.Count(); got != tt.want {
 				t.Errorf("Count() = %v, want %v", got, tt.want)
@@ -76,7 +78,8 @@ func TestCache_Delete(t *testing.T) {
 			args: args[string]{key: "a"},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.Delete(tt.args.key)
 		})
@@ -97,7 +100,8 @@ func TestCache_Flush(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.Flush()
 		})
@@ -137,7 +141,8 @@ func TestCache_Get(t *testing.T) {
 			want1: false,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			got, got1 := tt.c.Get(tt.args.key)
 			if !reflect.DeepEqual(got, tt.want) {
@@ -170,7 +175,8 @@ func TestCache_Set(t *testing.T) {
 			args: args[string, int]{key: "a", value: 1},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.Put(tt.args.key, tt.args.value)
 		})
@@ -198,7 +204,8 @@ func TestCache_SetWithTTL(t *testing.T) {
 			args: args[string, int]{key: "a", value: 1, ttl: time.Second},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.PutWithTTL(tt.args.key, tt.args.value, tt.args.ttl)
 		})
@@ -229,7 +236,8 @@ func Test_volatile_IsExpired(t *testing.T) {
 			want: false,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.v.IsExpired(); got != tt.want {
 				t.Errorf("IsExpired() = %v, want %v", got, tt.want)
@@ -259,7 +267,8 @@ func TestCache_Has(t *testing.T) {
 			want: true,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.c.Has(tt.args.key); got != tt.want {
 				t.Errorf("Has() = %v, want %v", got, tt.want)

--- a/core/cache/example/main.go
+++ b/core/cache/example/main.go
@@ -8,7 +8,8 @@ import (
 )
 
 func main() {
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	c := cache.NewCache[string, string](1 * time.Second)
 
 	// Watch the cache, this will remove expired items

--- a/core/cache/graph/cache_test.go
+++ b/core/cache/graph/cache_test.go
@@ -36,7 +36,8 @@ func TestGraph_AddEdge(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.g.AddEdge(tt.args.tail, tt.args.head, tt.args.w)
 		})
@@ -71,7 +72,8 @@ func TestGraph_AddEdgeWithTTL(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.g.AddEdgeWithTTL(tt.args.tail, tt.args.head, tt.args.w, tt.args.ttl)
 		})
@@ -97,7 +99,8 @@ func TestGraph_AddVertex(t *testing.T) {
 			args: args[string, string]{key: "key", value: "value"},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.g.PutVertex(tt.args.key, tt.args.value)
 		})
@@ -124,7 +127,8 @@ func TestGraph_AddVertexWithTTL(t *testing.T) {
 			args: args[string, string]{key: "key", value: "value", ttl: time.Minute},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.g.AddVertexWithTTL(tt.args.key, tt.args.value, tt.args.ttl)
 		})
@@ -156,7 +160,8 @@ func TestGraph_GetVertex(t *testing.T) {
 			want1: true,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			got, got1 := tt.g.GetVertex(tt.args.key)
 			if !reflect.DeepEqual(got, tt.want) {
@@ -194,7 +199,8 @@ func TestGraph_getWeight(t *testing.T) {
 			want1: false,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			got, got1 := tt.g.GetWeight(tt.args.tail, tt.args.head)
 			if got != tt.want {
@@ -228,7 +234,8 @@ func TestGraphCache_AddEdge(t *testing.T) {
 			args: args[string]{tail: "tail", head: "head", w: 0},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.AddEdge(tt.args.tail, tt.args.head, tt.args.w)
 		})
@@ -257,7 +264,8 @@ func TestGraphCache_AddEdgeWithExpiration(t *testing.T) {
 			args: args[string]{tail: "tail", head: "head", w: 0, expiration: time.Now()},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.AddEdgeWithExpiration(tt.args.tail, tt.args.head, tt.args.w, tt.args.expiration)
 		})
@@ -286,7 +294,8 @@ func TestGraphCache_AddEdgeWithTTL(t *testing.T) {
 			args: args[string]{tail: "tail", head: "head", w: 0, ttl: time.Minute},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.AddEdgeWithTTL(tt.args.tail, tt.args.head, tt.args.w, tt.args.ttl)
 		})
@@ -312,7 +321,8 @@ func TestGraphCache_AddVertex(t *testing.T) {
 			args: args[string, string]{key: "key", value: "value"},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.PutVertex(tt.args.key, tt.args.value)
 		})
@@ -339,7 +349,8 @@ func TestGraphCache_AddVertexWithExpiration(t *testing.T) {
 			args: args[string, string]{key: "key", value: "value", expiration: time.Now()},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.AddVertexWithExpiration(tt.args.key, tt.args.value, tt.args.expiration)
 		})
@@ -366,7 +377,8 @@ func TestGraphCache_AddVertexWithTTL(t *testing.T) {
 			args: args[string, string]{key: "key", value: "value", ttl: time.Minute},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.AddVertexWithTTL(tt.args.key, tt.args.value, tt.args.ttl)
 		})
@@ -393,7 +405,8 @@ func TestGraphCache_GetVertex(t *testing.T) {
 			args: args[string]{key: "key"},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			got, got1 := tt.c.GetVertex(tt.args.key)
 			if !reflect.DeepEqual(got, tt.want) {
@@ -422,7 +435,8 @@ func TestGraphCache_Neighbor(t *testing.T) {
 	tests := []testCase[string, string]{
 		// TODO: Add test cases.
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.c.Neighbor(tt.args.seed, tt.args.step, tt.args.k, tt.args.tfidf); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Neighbor() = %v, want %v", got, tt.want)
@@ -439,7 +453,8 @@ func TestGraphCache_flush(t *testing.T) {
 	tests := []testCase[string, string]{
 		// TODO: Add test cases.
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.flush()
 		})
@@ -482,7 +497,8 @@ func TestGraphCache_getWeight(t *testing.T) {
 			want1: true,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			got, got1 := tt.c.GetWeight(tt.args.tail, tt.args.head)
 			if got != tt.want {
@@ -508,7 +524,8 @@ func TestGraphCache_watch(t *testing.T) {
 	tests := []testCase[string, string]{
 		// TODO: Add test cases.
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.Watch(tt.args.ctx, tt.args.interval)
 		})
@@ -527,7 +544,8 @@ func TestNewGraphCache(t *testing.T) {
 	tests := []testCase[string, string]{
 		// TODO: Add test cases.
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := NewGraphCache[string, string](tt.args.defaultTTL); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewGraphCache() = %v, want %v", got, tt.want)
@@ -545,17 +563,18 @@ func TestGraphCache_DeleteVertex(t *testing.T) {
 	}
 	type testCase[S comparable, T any] struct {
 		name string
-		c    GraphCache[S, T]
+		c    *GraphCache[S, T]
 		args args[S]
 	}
 	tests := []testCase[string, string]{
 		{
 			name: "TestGraphCache_DeleteVertex",
-			c:    *g,
+			c:    g,
 			args: args[string]{key: "a"},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.DeleteVertex(tt.args.key)
 		})
@@ -571,17 +590,18 @@ func TestGraphCache_DeleteEdge(t *testing.T) {
 	}
 	type testCase[S comparable, T any] struct {
 		name string
-		c    GraphCache[S, T]
+		c    *GraphCache[S, T]
 		args args[S]
 	}
 	tests := []testCase[string, string]{
 		{
 			name: "TestGraphCache_DeleteEdge",
-			c:    *g,
+			c:    g,
 			args: args[string]{tail: "a", head: "b"},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.DeleteEdge(tt.args.tail, tt.args.head)
 		})

--- a/core/cache/graph/edge_test.go
+++ b/core/cache/graph/edge_test.go
@@ -16,7 +16,8 @@ func Test_newWeight(t *testing.T) {
 			want: &weight{},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := newWeight(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("newWeight() = %v, want %v", got, tt.want)
@@ -44,7 +45,8 @@ func Test_weightValue_expired(t *testing.T) {
 			want: true,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			w := weightValue{
 				value:      tt.fields.value,
@@ -81,7 +83,8 @@ func Test_weight_add(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			w := &weight{
 				values: tt.fields.values,
@@ -117,7 +120,8 @@ func Test_weight_value(t *testing.T) {
 			want: 1,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			w := &weight{
 				values: tt.fields.values,
@@ -163,7 +167,8 @@ func Test_weight_isZero(t *testing.T) {
 			want: true,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			w := &weight{
 				values: tt.fields.values,
@@ -197,7 +202,8 @@ func Test_edgeCache_delete(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.delete(tt.args.tail, tt.args.head)
 		})
@@ -229,7 +235,8 @@ func Test_edgeCache_get(t *testing.T) {
 			want: 0,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			got, got1 := tt.c.get(tt.args.tail, tt.args.head)
 			if got != tt.want {
@@ -267,7 +274,8 @@ func Test_edgeCache_set(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.add(tt.args.tail, tt.args.head, tt.args.w)
 		})
@@ -300,7 +308,8 @@ func Test_edgeCache_setWithExpiration(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.addWithExpiration(tt.args.tail, tt.args.head, tt.args.w, tt.args.expiration)
 		})
@@ -334,7 +343,8 @@ func Test_edgeCache_setWithTTL(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.addWithTTL(tt.args.tail, tt.args.head, tt.args.w, tt.args.ttl)
 		})
@@ -365,7 +375,8 @@ func Test_weight_addWithExpiration(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			w := &weight{
 				values: tt.fields.values,
@@ -399,7 +410,8 @@ func Test_weight_addWithTTL(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			w := &weight{
 				values: tt.fields.values,

--- a/core/collection/set/set_test.go
+++ b/core/collection/set/set_test.go
@@ -21,7 +21,8 @@ func TestNewSet(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := NewSet[int](); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewSet() = %v, want %v", got, tt.want)
@@ -48,7 +49,8 @@ func TestSet_Add(t *testing.T) {
 			args: args[int]{value: 1},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.s.Add(tt.args.value)
 		})
@@ -81,7 +83,8 @@ func TestSet_AllMatch(t *testing.T) {
 			want: false,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.s.AllMatch(tt.args.predicate); got != tt.want {
 				t.Errorf("AllMatch() = %v, want %v", got, tt.want)
@@ -116,7 +119,8 @@ func TestSet_AnyMatch(t *testing.T) {
 			want: true,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.s.AnyMatch(tt.args.predicate); got != tt.want {
 				t.Errorf("AnyMatch() = %v, want %v", got, tt.want)
@@ -144,7 +148,8 @@ func TestSet_Clear(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.s.Clear()
 		})
@@ -177,7 +182,8 @@ func TestSet_Contains(t *testing.T) {
 			want: true,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.s.Has(tt.args.value); got != tt.want {
 				t.Errorf("Has() = %v, want %v", got, tt.want)
@@ -210,7 +216,8 @@ func TestSet_Filter(t *testing.T) {
 			args: args[int]{predicate: func(i int) bool { return i%2 == 0 }},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.s.Filter(tt.args.predicate)
 		})
@@ -241,7 +248,8 @@ func TestSet_ForEach(t *testing.T) {
 			args: args[int]{consumer: func(i int) { fmt.Println(i) }},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.s.ForEach(tt.args.consumer)
 		})
@@ -274,7 +282,8 @@ func TestSet_NoneMatch(t *testing.T) {
 			want: false,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.s.NoneMatch(tt.args.predicate); got != tt.want {
 				t.Errorf("NoneMatch() = %v, want %v", got, tt.want)
@@ -309,7 +318,8 @@ func TestSet_Reduce(t *testing.T) {
 			want: 15,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.s.Reduce(tt.args.operator); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Reduce() = %v, want %v", got, tt.want)
@@ -342,7 +352,8 @@ func TestSet_Remove(t *testing.T) {
 			args: args[int]{value: 1},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.s.Remove(tt.args.value)
 		})
@@ -370,7 +381,8 @@ func TestSet_Size(t *testing.T) {
 			want: 5,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.s.Size(); got != tt.want {
 				t.Errorf("Size() = %v, want %v", got, tt.want)
@@ -400,7 +412,8 @@ func TestSet_Values(t *testing.T) {
 			want: []int{1, 2, 3, 4, 5},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.s.Values()
 			for _, v := range tt.want {

--- a/core/concurrent/pubsub/example/main.go
+++ b/core/concurrent/pubsub/example/main.go
@@ -14,7 +14,8 @@ var (
 )
 
 func main() {
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
 	// Publish 100 messages
 	go func() {

--- a/core/concurrent/pubsub/subscription_test.go
+++ b/core/concurrent/pubsub/subscription_test.go
@@ -23,7 +23,8 @@ func TestSubscription_Name(t *testing.T) {
 			want: "test",
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.s.Name(); got != tt.want {
 				t.Errorf("Name() = %v, want %v", got, tt.want)
@@ -33,7 +34,8 @@ func TestSubscription_Name(t *testing.T) {
 }
 
 func TestSubscription_Subscribe(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
 	topic := NewTopic[int]("test")
 	sub := topic.NewSubscription("test", 1, time.Minute, time.Minute)
 	type args[T any] struct {
@@ -42,20 +44,21 @@ func TestSubscription_Subscribe(t *testing.T) {
 	}
 	type testCase[T any] struct {
 		name string
-		s    Subscription[T]
+		s    *Subscription[T]
 		args args[T]
 	}
 	tests := []testCase[int]{
 		{
 			name: "TestSubscription_Subscribe",
-			s:    *sub,
+			s:    sub,
 			args: args[int]{
 				ctx:      ctx,
 				consumer: func(x *Message[int]) { t.Log(x) },
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			go tt.s.Subscribe(tt.args.ctx, tt.args.consumer)
 		})
@@ -78,7 +81,8 @@ func TestSubscription_Topic(t *testing.T) {
 			want: &Topic[int]{name: "test"},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.s.Topic(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Topic() = %v, want %v", got, tt.want)
@@ -108,7 +112,8 @@ func TestSubscription_ack(t *testing.T) {
 			args: args[int]{message: &Message[int]{id: "uuid", body: 1}},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.s.ack(tt.args.message)
 		})
@@ -136,7 +141,8 @@ func TestSubscription_nack(t *testing.T) {
 			args: args[int]{message: &Message[int]{id: "uuid", body: 1}},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.s.nack(tt.args.message)
 		})
@@ -163,7 +169,8 @@ func TestSubscription_newMessage(t *testing.T) {
 			want: &Message[int]{body: 1},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.s.newMessage(tt.args.body); got.body != tt.want.body {
 				t.Errorf("newMessage() = %v, want %v", got, tt.want)
@@ -192,7 +199,8 @@ func TestSubscription_publish(t *testing.T) {
 			args: args[int]{message: &Message[int]{id: "uuid", body: 1}},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.s.publish(tt.args.message)
 		})
@@ -216,7 +224,8 @@ func TestSubscription_register(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.s.register()
 		})
@@ -245,7 +254,8 @@ func TestSubscription_remind(t *testing.T) {
 			args: args[int]{message: &Message[int]{id: "uuid", body: 1}},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.s.remind(tt.args.message)
 		})
@@ -275,7 +285,8 @@ func TestSubscription_salvage(t *testing.T) {
 			args: args{interval: time.Second, ttl: time.Second},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.s.salvage(tt.args.interval, tt.args.ttl)
 		})
@@ -288,15 +299,16 @@ func TestSubscription_unregister(t *testing.T) {
 
 	type testCase[T any] struct {
 		name string
-		s    Subscription[T]
+		s    *Subscription[T]
 	}
 	tests := []testCase[int]{
 		{
 			name: "TestSubscription_unregister",
-			s:    *sub,
+			s:    sub,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.s.unregister()
 		})
@@ -304,7 +316,8 @@ func TestSubscription_unregister(t *testing.T) {
 }
 
 func TestSubscription_watch(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
 	topic := NewTopic[int]("test_topic")
 	sub := topic.NewSubscription("test_sub", 8, time.Minute, time.Minute)
 
@@ -315,13 +328,13 @@ func TestSubscription_watch(t *testing.T) {
 	}
 	type testCase[T any] struct {
 		name string
-		s    Subscription[T]
+		s    *Subscription[T]
 		args args
 	}
 	tests := []testCase[int]{
 		{
 			name: "TestSubscription_watch",
-			s:    *sub,
+			s:    sub,
 			args: args{
 				ctx:      ctx,
 				interval: time.Second,
@@ -329,7 +342,8 @@ func TestSubscription_watch(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			go tt.s.watch(tt.args.ctx, tt.args.interval, tt.args.ttl)
 		})

--- a/core/concurrent/pubsub/topic_test.go
+++ b/core/concurrent/pubsub/topic_test.go
@@ -27,7 +27,8 @@ func TestNewTopic(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			if got := NewTopic[int](tt.args.name); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewTopic() = %v, want %v", got, tt.want)
@@ -49,7 +50,8 @@ func TestTopic_Name(t1 *testing.T) {
 			want: "test",
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t1.Run(tt.name, func(t1 *testing.T) {
 			if got := tt.t.Name(); got != tt.want {
 				t1.Errorf("Name() = %v, want %v", got, tt.want)
@@ -68,14 +70,14 @@ func TestTopic_NewSubscription(t1 *testing.T) {
 	}
 	type testCase[T any] struct {
 		name string
-		t    Topic[T]
+		t    *Topic[T]
 		args args
 		want *Subscription[T]
 	}
 	tests := []testCase[int]{
 		{
 			name: "TestTopic_NewSubscription",
-			t:    *topic,
+			t:    topic,
 			args: args{
 				name:        "test",
 				concurrency: 8,
@@ -93,7 +95,8 @@ func TestTopic_NewSubscription(t1 *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t1.Run(tt.name, func(t1 *testing.T) {
 			if got := tt.t.NewSubscription(tt.args.name, tt.args.concurrency, tt.args.interval, tt.args.ttl); got.name != tt.want.name {
 				t1.Errorf("NewSubscription() = %v, want %v", got, tt.want)
@@ -120,7 +123,8 @@ func TestTopic_Publish(t1 *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t1.Run(tt.name, func(t1 *testing.T) {
 			tt.t.Publish(tt.args.body)
 		})
@@ -140,7 +144,8 @@ func TestTopic_Subscriptions(t1 *testing.T) {
 			want: map[string]*Subscription[int]{},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t1.Run(tt.name, func(t1 *testing.T) {
 			if got := tt.t.Subscriptions(); !reflect.DeepEqual(got, tt.want) {
 				t1.Errorf("Subscriptions() = %v, want %v", got, tt.want)
@@ -173,7 +178,8 @@ func TestTopic_register(t1 *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t1.Run(tt.name, func(t1 *testing.T) {
 			tt.t.register(tt.args.subscription)
 		})
@@ -204,7 +210,8 @@ func TestTopic_unregister(t1 *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t1.Run(tt.name, func(t1 *testing.T) {
 			tt.t.unregister(tt.args.subscription)
 		})


### PR DESCRIPTION
Resolve every warning surfaced by `go vet ./...` (~80 in total). All fixes are scoped to test files and example mains; production code is unchanged.

## Categories fixed

- **copylocks (range)**: rewrite `for _, tt := range tests` to `for i := range tests { tt := &tests[i] }` in the test files whose `testCase` structs embed lock-bearing values (`Cache`, `Set`, `GraphCache`, `edgeCache`, `Subscription`, `Topic`, and `pb.Vertex`).
- **copylocks (literal)**: change `c GraphCache[S,T]`, `s Subscription[T]`, and `t Topic[T]` fields to pointer types in the affected `testCase` declarations so `c: *g`, `s: *sub`, and `t: *topic` no longer copy a lock. Method calls work unchanged via pointer-receiver auto-deref.
- **lostcancel**: replace `ctx, _ := context.WithTimeout(...)` with `ctx, cancel := context.WithTimeout(...); defer cancel()` in `core/cache/example`, `core/concurrent/pubsub/example`, and the two affected subtests in `subscription_test.go`.

## Validation

- `go vet ./...` — clean (0 warnings)
- `go build ./...` — pass
- `go test ./...` — pass