### PR TITLE
test: fill coverage gaps in pq, graph, service, and client

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,154 @@
+package client
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	pb "github.com/anaregdesign/lantern/gen/go/graph/v1"
+	"github.com/anaregdesign/lantern/server/service"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// newInProcessClient wires a Lantern client to an in-process gRPC server
+// backed by a real LanternService, so we exercise the actual wire format.
+func newInProcessClient(t *testing.T) (*Lantern, func()) {
+	t.Helper()
+
+	lis := bufconn.Listen(1 << 16)
+	srv := grpc.NewServer()
+	svc := service.NewLanternService(cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute))
+	pb.RegisterLanternServiceServer(srv, svc)
+
+	go func() {
+		if err := srv.Serve(lis); err != nil {
+			t.Logf("grpc Serve returned: %v", err)
+		}
+	}()
+
+	dialer := func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}
+	conn, err := grpc.NewClient(
+		"passthrough://bufconn",
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	l := &Lantern{conn: conn, client: pb.NewLanternServiceClient(conn)}
+	cleanup := func() {
+		_ = l.Close()
+		srv.Stop()
+		_ = lis.Close()
+	}
+	return l, cleanup
+}
+
+func TestLantern_PutGetDeleteVertex(t *testing.T) {
+	l, cleanup := newInProcessClient(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := l.PutVertex(ctx, "k", "v", time.Minute); err != nil {
+		t.Fatalf("PutVertex: %v", err)
+	}
+
+	v, err := l.GetVertex(ctx, "k")
+	if err != nil {
+		t.Fatalf("GetVertex: %v", err)
+	}
+	got, err := v.StringValue()
+	if err != nil {
+		t.Fatalf("StringValue: %v", err)
+	}
+	if got != "v" {
+		t.Errorf("StringValue = %q, want \"v\"", got)
+	}
+
+	if err := l.DeleteVertex(ctx, "k"); err != nil {
+		t.Fatalf("DeleteVertex: %v", err)
+	}
+	if _, err := l.GetVertex(ctx, "k"); err == nil {
+		t.Error("expected error after DeleteVertex, got nil")
+	}
+}
+
+func TestLantern_AddPutDeleteEdge(t *testing.T) {
+	l, cleanup := newInProcessClient(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := l.AddEdge(ctx, "a", "b", 1.5, time.Minute); err != nil {
+		t.Fatalf("AddEdge: %v", err)
+	}
+	w, err := l.GetEdge(ctx, "a", "b")
+	if err != nil {
+		t.Fatalf("GetEdge: %v", err)
+	}
+	if w != 1.5 {
+		t.Errorf("weight = %v, want 1.5", w)
+	}
+
+	// PutEdge replaces.
+	if err := l.PutEdge(ctx, "a", "b", 9, time.Minute); err != nil {
+		t.Fatalf("PutEdge: %v", err)
+	}
+	w, err = l.GetEdge(ctx, "a", "b")
+	if err != nil {
+		t.Fatalf("GetEdge: %v", err)
+	}
+	if w != 9 {
+		t.Errorf("weight after PutEdge = %v, want 9", w)
+	}
+
+	if err := l.DeleteEdge(ctx, "a", "b"); err != nil {
+		t.Fatalf("DeleteEdge: %v", err)
+	}
+	if _, err := l.GetEdge(ctx, "a", "b"); err == nil {
+		t.Error("expected error after DeleteEdge, got nil")
+	}
+}
+
+func TestLantern_Illuminate(t *testing.T) {
+	l, cleanup := newInProcessClient(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	for _, k := range []string{"a", "b", "c"} {
+		if err := l.PutVertex(ctx, k, k, time.Minute); err != nil {
+			t.Fatalf("PutVertex %s: %v", k, err)
+		}
+	}
+	if err := l.PutEdge(ctx, "a", "b", 1, time.Minute); err != nil {
+		t.Fatalf("PutEdge a->b: %v", err)
+	}
+	if err := l.PutEdge(ctx, "b", "c", 1, time.Minute); err != nil {
+		t.Fatalf("PutEdge b->c: %v", err)
+	}
+
+	g, err := l.Illuminate(ctx, "a", 3, 10, false)
+	if err != nil {
+		t.Fatalf("Illuminate: %v", err)
+	}
+	for _, want := range []string{"a", "b", "c"} {
+		if _, ok := g.Vertices[want]; !ok {
+			t.Errorf("Illuminate result missing vertex %q (got %v)", want, g.Vertices)
+		}
+	}
+	if _, ok := g.Edges["a"]["b"]; !ok {
+		t.Errorf("Illuminate missing edge a->b (got %v)", g.Edges)
+	}
+}

--- a/core/collection/pq/pq_test.go
+++ b/core/collection/pq/pq_test.go
@@ -1,0 +1,91 @@
+package pq
+
+import (
+	"container/heap"
+	"testing"
+)
+
+func TestPriorityQueue_PushPopOrder(t *testing.T) {
+	q := make(PriorityQueue[string, int], 0)
+	heap.Init(&q)
+
+	heap.Push(&q, &Item[string, int]{Value: "low", Priority: 1})
+	heap.Push(&q, &Item[string, int]{Value: "high", Priority: 10})
+	heap.Push(&q, &Item[string, int]{Value: "mid", Priority: 5})
+
+	if got, want := q.Len(), 3; got != want {
+		t.Fatalf("Len() = %d, want %d", got, want)
+	}
+
+	want := []string{"high", "mid", "low"}
+	for i, w := range want {
+		it := heap.Pop(&q).(*Item[string, int])
+		if it.Value != w {
+			t.Errorf("Pop[%d] = %q, want %q", i, it.Value, w)
+		}
+		if it.Index != -1 {
+			t.Errorf("Pop[%d].Index = %d, want -1 (sentinel)", i, it.Index)
+		}
+	}
+	if q.Len() != 0 {
+		t.Errorf("Len() after draining = %d, want 0", q.Len())
+	}
+}
+
+func TestPriorityQueue_Update(t *testing.T) {
+	q := make(PriorityQueue[string, int], 0)
+	heap.Init(&q)
+
+	a := &Item[string, int]{Value: "a", Priority: 1}
+	b := &Item[string, int]{Value: "b", Priority: 2}
+	c := &Item[string, int]{Value: "c", Priority: 3}
+	heap.Push(&q, a)
+	heap.Push(&q, b)
+	heap.Push(&q, c)
+
+	// Promote "a" to highest priority.
+	q.update(a, "a*", 100)
+
+	got := heap.Pop(&q).(*Item[string, int])
+	if got.Value != "a*" || got.Priority != 100 {
+		t.Errorf("after update, Pop() = (%q, %d), want (\"a*\", 100)", got.Value, got.Priority)
+	}
+}
+
+func TestPriorityQueue_SwapMaintainsIndex(t *testing.T) {
+	q := PriorityQueue[string, int]{
+		{Value: "x", Priority: 1, Index: 0},
+		{Value: "y", Priority: 2, Index: 1},
+	}
+	q.Swap(0, 1)
+	if q[0].Value != "y" || q[0].Index != 0 {
+		t.Errorf("q[0] = (%q, idx=%d), want (\"y\", 0)", q[0].Value, q[0].Index)
+	}
+	if q[1].Value != "x" || q[1].Index != 1 {
+		t.Errorf("q[1] = (%q, idx=%d), want (\"x\", 1)", q[1].Value, q[1].Index)
+	}
+}
+
+func TestSortableMap_Top_KSmallerThanLen(t *testing.T) {
+	m := SortableMap[string, float64]{
+		"a": 1, "b": 2, "c": 3, "d": 4, "e": 5,
+	}
+	got := m.Top(2)
+	if len(got) != 2 {
+		t.Fatalf("len(Top(2)) = %d, want 2", len(got))
+	}
+	if _, ok := got["e"]; !ok {
+		t.Errorf("Top(2) missing \"e\" (priority 5): %v", got)
+	}
+	if _, ok := got["d"]; !ok {
+		t.Errorf("Top(2) missing \"d\" (priority 4): %v", got)
+	}
+}
+
+func TestSortableMap_Top_Empty(t *testing.T) {
+	m := NewSortableMap[string, int]()
+	got := m.Top(5)
+	if len(got) != 0 {
+		t.Errorf("Top on empty map = %v, want empty", got)
+	}
+}

--- a/core/graph/graph_test.go
+++ b/core/graph/graph_test.go
@@ -1,0 +1,153 @@
+package graph
+
+import (
+	"sort"
+	"strconv"
+	"testing"
+)
+
+func TestGraph_PutVertex(t *testing.T) {
+	g := NewGraph[string, int]()
+	g.PutVertex("a", 1)
+	g.PutVertex("a", 2) // overwrite
+	if got, want := g.Vertices["a"], 2; got != want {
+		t.Errorf("Vertices[\"a\"] = %d, want %d", got, want)
+	}
+}
+
+func TestGraph_PutEdge_AutoCreatesVertices(t *testing.T) {
+	g := NewGraph[string, int]()
+	g.PutEdge("a", "b", 0.5)
+	if _, ok := g.Vertices["a"]; !ok {
+		t.Errorf("PutEdge should create tail vertex \"a\"")
+	}
+	if _, ok := g.Vertices["b"]; !ok {
+		t.Errorf("PutEdge should create head vertex \"b\"")
+	}
+	if w := g.Edges["a"]["b"]; w != 0.5 {
+		t.Errorf("Edges[a][b] = %v, want 0.5", w)
+	}
+}
+
+func TestGraph_ConnectedGraph(t *testing.T) {
+	g := NewGraph[string, int]()
+	g.PutVertex("a", 1)
+	g.PutVertex("b", 2)
+	g.PutVertex("c", 3)
+	g.PutVertex("isolated", 99)
+	g.PutEdge("a", "b", 1)
+	g.PutEdge("b", "c", 1)
+
+	c := g.ConnectedGraph("a")
+
+	if _, ok := c.Vertices["isolated"]; ok {
+		t.Errorf("ConnectedGraph should not include disconnected vertex")
+	}
+	for _, want := range []string{"a", "b", "c"} {
+		if _, ok := c.Vertices[want]; !ok {
+			t.Errorf("ConnectedGraph missing %q", want)
+		}
+	}
+}
+
+func TestGraph_MinimumSpanningTree(t *testing.T) {
+	// Triangle: a-b=1, b-c=2, a-c=10. MST picks (a-b) + (b-c) = total 3.
+	g := NewGraph[string, int]()
+	g.PutEdge("a", "b", 1)
+	g.PutEdge("b", "a", 1)
+	g.PutEdge("b", "c", 2)
+	g.PutEdge("c", "b", 2)
+	g.PutEdge("a", "c", 10)
+	g.PutEdge("c", "a", 10)
+
+	mst := g.MinimumSpanningTree("a", false)
+
+	total := float32(0)
+	for _, heads := range mst.Edges {
+		for _, w := range heads {
+			total += w
+		}
+	}
+	if total != 3 {
+		t.Errorf("MST total weight = %v, want 3 (edges=%v)", total, mst.Edges)
+	}
+	if len(mst.Vertices) != 3 {
+		t.Errorf("MST vertices = %d, want 3", len(mst.Vertices))
+	}
+}
+
+func TestGraph_MaximumSpanningTree(t *testing.T) {
+	// Same triangle; max spanning tree picks (a-c)=10 + (b-c)=2 = 12 (avoids a-b=1).
+	g := NewGraph[string, int]()
+	g.PutEdge("a", "b", 1)
+	g.PutEdge("b", "a", 1)
+	g.PutEdge("b", "c", 2)
+	g.PutEdge("c", "b", 2)
+	g.PutEdge("a", "c", 10)
+	g.PutEdge("c", "a", 10)
+
+	mst := g.MinimumSpanningTree("a", true)
+
+	total := float32(0)
+	for _, heads := range mst.Edges {
+		for _, w := range heads {
+			total += w
+		}
+	}
+	if total != 12 {
+		t.Errorf("Max spanning tree total = %v, want 12 (edges=%v)", total, mst.Edges)
+	}
+}
+
+func TestGraph_ShortestPathTree(t *testing.T) {
+	// a -1- b -1- c, a -10- c. Dijkstra with cost = weight should still visit
+	// c via b because (1+1)=2 < 10.
+	g := NewGraph[string, int]()
+	g.PutEdge("a", "b", 1)
+	g.PutEdge("b", "c", 1)
+	g.PutEdge("a", "c", 10)
+
+	spt := g.ShortestPathTree("a", func(w float32) float32 { return w })
+
+	if _, ok := spt.Edges["a"]["b"]; !ok {
+		t.Errorf("SPT should contain a->b edge, got %v", spt.Edges)
+	}
+	if _, ok := spt.Edges["b"]["c"]; !ok {
+		t.Errorf("SPT should contain b->c edge, got %v", spt.Edges)
+	}
+	if _, ok := spt.Edges["a"]["c"]; ok {
+		t.Errorf("SPT should NOT contain expensive a->c edge, got %v", spt.Edges)
+	}
+}
+
+func TestGraph_Render(t *testing.T) {
+	g := NewGraph[string, int]()
+	g.PutVertex("a", 1)
+	g.PutVertex("b", 2)
+	g.PutEdge("a", "b", 0.5)
+
+	keyToID := func(k string) int { return int(k[0]) }
+	valToStr := func(v int) string { return strconv.Itoa(v) }
+
+	view := g.Render(keyToID, valToStr)
+	if len(view.Vertices) != 2 {
+		t.Errorf("Render vertices = %d, want 2", len(view.Vertices))
+	}
+	if len(view.Edges) != 1 {
+		t.Errorf("Render edges = %d, want 1", len(view.Edges))
+	}
+
+	labels := make([]string, 0, len(view.Vertices))
+	for _, v := range view.Vertices {
+		labels = append(labels, v.Label)
+	}
+	sort.Strings(labels)
+	if labels[0] != "1" || labels[1] != "2" {
+		t.Errorf("Render labels = %v, want [1 2]", labels)
+	}
+
+	e := view.Edges[0]
+	if e.From != int('a') || e.To != int('b') || e.Value != 0.5 {
+		t.Errorf("Render edge = %+v, want From=%d To=%d Value=0.5", e, int('a'), int('b'))
+	}
+}

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -1,0 +1,225 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/cache/graph"
+	pb "github.com/anaregdesign/lantern/gen/go/graph/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func newTestService(t *testing.T) *LanternService {
+	t.Helper()
+	return NewLanternService(graph.NewGraphCache[string, *pb.Vertex](time.Minute))
+}
+
+func futureTs(d time.Duration) *timestamppb.Timestamp {
+	return timestamppb.New(time.Now().Add(d))
+}
+
+func TestLanternService_PutAndGetVertex(t *testing.T) {
+	s := newTestService(t)
+	ctx := context.Background()
+
+	v := &pb.Vertex{
+		Key:        "k1",
+		Value:      &pb.Vertex_String_{String_: "hello"},
+		Expiration: futureTs(time.Minute),
+	}
+	if _, err := s.PutVertex(ctx, &pb.PutVertexRequest{Vertices: []*pb.Vertex{v}}); err != nil {
+		t.Fatalf("PutVertex: %v", err)
+	}
+
+	resp, err := s.GetVertex(ctx, &pb.GetVertexRequest{Key: "k1"})
+	if err != nil {
+		t.Fatalf("GetVertex: %v", err)
+	}
+	if got := resp.Vertex.GetString_(); got != "hello" {
+		t.Errorf("GetVertex value = %q, want \"hello\"", got)
+	}
+	if resp.Status != pb.Status_STATUS_OK {
+		t.Errorf("status = %v, want OK", resp.Status)
+	}
+}
+
+func TestLanternService_GetVertex_NotFound(t *testing.T) {
+	s := newTestService(t)
+	_, err := s.GetVertex(context.Background(), &pb.GetVertexRequest{Key: "missing"})
+	if err == nil {
+		t.Fatal("expected error for missing vertex, got nil")
+	}
+	if st, _ := status.FromError(err); st.Code() != codes.NotFound {
+		t.Errorf("status code = %v, want NotFound", st.Code())
+	}
+}
+
+func TestLanternService_DeleteVertex(t *testing.T) {
+	s := newTestService(t)
+	ctx := context.Background()
+	v := &pb.Vertex{Key: "x", Value: &pb.Vertex_Int64{Int64: 1}, Expiration: futureTs(time.Minute)}
+	if _, err := s.PutVertex(ctx, &pb.PutVertexRequest{Vertices: []*pb.Vertex{v}}); err != nil {
+		t.Fatalf("PutVertex: %v", err)
+	}
+	if _, err := s.DeleteVertex(ctx, &pb.DeleteVertexRequest{Key: "x"}); err != nil {
+		t.Fatalf("DeleteVertex: %v", err)
+	}
+	if _, err := s.GetVertex(ctx, &pb.GetVertexRequest{Key: "x"}); err == nil {
+		t.Error("expected NotFound after delete, got nil error")
+	}
+}
+
+func TestLanternService_AddAndGetEdge(t *testing.T) {
+	s := newTestService(t)
+	ctx := context.Background()
+	edge := &pb.Edge{Tail: "a", Head: "b", Weight: 1.25, Expiration: futureTs(time.Minute)}
+	if _, err := s.AddEdge(ctx, &pb.AddEdgeRequest{Edges: []*pb.Edge{edge}}); err != nil {
+		t.Fatalf("AddEdge: %v", err)
+	}
+	resp, err := s.GetEdge(ctx, &pb.GetEdgeRequest{Tail: "a", Head: "b"})
+	if err != nil {
+		t.Fatalf("GetEdge: %v", err)
+	}
+	if resp.Edge.Weight != 1.25 {
+		t.Errorf("Weight = %v, want 1.25", resp.Edge.Weight)
+	}
+}
+
+func TestLanternService_GetEdge_NotFound(t *testing.T) {
+	s := newTestService(t)
+	_, err := s.GetEdge(context.Background(), &pb.GetEdgeRequest{Tail: "no", Head: "such"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if st, _ := status.FromError(err); st.Code() != codes.NotFound {
+		t.Errorf("code = %v, want NotFound", st.Code())
+	}
+}
+
+func TestLanternService_AddEdge_Additive(t *testing.T) {
+	// AddEdge is additive: two adds of weight 2 each should accumulate to 4.
+	s := newTestService(t)
+	ctx := context.Background()
+	e := &pb.Edge{Tail: "a", Head: "b", Weight: 2, Expiration: futureTs(time.Minute)}
+	if _, err := s.AddEdge(ctx, &pb.AddEdgeRequest{Edges: []*pb.Edge{e}}); err != nil {
+		t.Fatalf("AddEdge: %v", err)
+	}
+	if _, err := s.AddEdge(ctx, &pb.AddEdgeRequest{Edges: []*pb.Edge{e}}); err != nil {
+		t.Fatalf("AddEdge2: %v", err)
+	}
+	resp, err := s.GetEdge(ctx, &pb.GetEdgeRequest{Tail: "a", Head: "b"})
+	if err != nil {
+		t.Fatalf("GetEdge: %v", err)
+	}
+	if resp.Edge.Weight != 4 {
+		t.Errorf("Weight = %v, want 4 (additive)", resp.Edge.Weight)
+	}
+}
+
+func TestLanternService_PutEdge_Replaces(t *testing.T) {
+	// PutEdge deletes-then-adds: repeated calls with the same weight stay at that weight.
+	s := newTestService(t)
+	ctx := context.Background()
+	e := &pb.Edge{Tail: "a", Head: "b", Weight: 7, Expiration: futureTs(time.Minute)}
+	if _, err := s.PutEdge(ctx, &pb.PutEdgeRequest{Edges: []*pb.Edge{e}}); err != nil {
+		t.Fatalf("PutEdge: %v", err)
+	}
+	if _, err := s.PutEdge(ctx, &pb.PutEdgeRequest{Edges: []*pb.Edge{e}}); err != nil {
+		t.Fatalf("PutEdge2: %v", err)
+	}
+	resp, err := s.GetEdge(ctx, &pb.GetEdgeRequest{Tail: "a", Head: "b"})
+	if err != nil {
+		t.Fatalf("GetEdge: %v", err)
+	}
+	if resp.Edge.Weight != 7 {
+		t.Errorf("Weight = %v, want 7 (replaced, not accumulated)", resp.Edge.Weight)
+	}
+}
+
+func TestLanternService_DeleteEdge(t *testing.T) {
+	s := newTestService(t)
+	ctx := context.Background()
+	e := &pb.Edge{Tail: "a", Head: "b", Weight: 1, Expiration: futureTs(time.Minute)}
+	if _, err := s.AddEdge(ctx, &pb.AddEdgeRequest{Edges: []*pb.Edge{e}}); err != nil {
+		t.Fatalf("AddEdge: %v", err)
+	}
+	if _, err := s.DeleteEdge(ctx, &pb.DeleteEdgeRequest{Tail: "a", Head: "b"}); err != nil {
+		t.Fatalf("DeleteEdge: %v", err)
+	}
+	if _, err := s.GetEdge(ctx, &pb.GetEdgeRequest{Tail: "a", Head: "b"}); err == nil {
+		t.Error("expected NotFound after delete")
+	}
+}
+
+func seedTriangle(t *testing.T, s *LanternService) {
+	t.Helper()
+	ctx := context.Background()
+	exp := futureTs(time.Minute)
+	verts := []*pb.Vertex{
+		{Key: "a", Value: &pb.Vertex_String_{String_: "A"}, Expiration: exp},
+		{Key: "b", Value: &pb.Vertex_String_{String_: "B"}, Expiration: exp},
+		{Key: "c", Value: &pb.Vertex_String_{String_: "C"}, Expiration: exp},
+	}
+	if _, err := s.PutVertex(ctx, &pb.PutVertexRequest{Vertices: verts}); err != nil {
+		t.Fatalf("PutVertex: %v", err)
+	}
+	edges := []*pb.Edge{
+		{Tail: "a", Head: "b", Weight: 1, Expiration: exp},
+		{Tail: "b", Head: "a", Weight: 1, Expiration: exp},
+		{Tail: "b", Head: "c", Weight: 2, Expiration: exp},
+		{Tail: "c", Head: "b", Weight: 2, Expiration: exp},
+		{Tail: "a", Head: "c", Weight: 10, Expiration: exp},
+		{Tail: "c", Head: "a", Weight: 10, Expiration: exp},
+	}
+	if _, err := s.PutEdge(ctx, &pb.PutEdgeRequest{Edges: edges}); err != nil {
+		t.Fatalf("PutEdge: %v", err)
+	}
+}
+
+func TestLanternService_Illuminate_Unspecified(t *testing.T) {
+	s := newTestService(t)
+	seedTriangle(t, s)
+
+	resp, err := s.Illuminate(context.Background(), &pb.IlluminateRequest{
+		Seed:         "a",
+		Step:         3,
+		K:            10,
+		Optimization: pb.Optimization_OPTIMIZATION_UNSPECIFIED,
+	})
+	if err != nil {
+		t.Fatalf("Illuminate: %v", err)
+	}
+	if len(resp.Graph.Vertices) != 3 {
+		t.Errorf("vertices = %d, want 3", len(resp.Graph.Vertices))
+	}
+}
+
+func TestLanternService_Illuminate_AllOptimizations(t *testing.T) {
+	cases := []pb.Optimization{
+		pb.Optimization_OPTIMIZATION_MINIMUM_SPANNING_TREE,
+		pb.Optimization_OPTIMIZATION_MAXIMUM_SPANNING_TREE,
+		pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE,
+		pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE,
+	}
+	for _, opt := range cases {
+		t.Run(opt.String(), func(t *testing.T) {
+			s := newTestService(t)
+			seedTriangle(t, s)
+			resp, err := s.Illuminate(context.Background(), &pb.IlluminateRequest{
+				Seed:         "a",
+				Step:         3,
+				K:            10,
+				Optimization: opt,
+			})
+			if err != nil {
+				t.Fatalf("Illuminate(%v): %v", opt, err)
+			}
+			if len(resp.Graph.Vertices) == 0 {
+				t.Errorf("Illuminate(%v) returned empty vertices", opt)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- core/collection/pq: cover PriorityQueue Push/Pop ordering, update,
  Swap index maintenance, and SortableMap edge cases (k<len, empty).
  Coverage 6.1% -> 100.0%.
- core/graph: cover PutVertex/PutEdge auto-create, ConnectedGraph,
  MinimumSpanningTree (min and max), ShortestPathTree, and Render.
  Coverage 0% -> 95.1%.
- server/service: direct handler tests with a real GraphCache covering
  Put/Get/Delete for vertices and edges, Add-vs-Put semantics, NotFound
  paths, and all five Illuminate optimizations. Coverage 0% -> 77.8%.
- client: in-process bufconn gRPC test exercising Put/Get/Delete and
  Illuminate via the real wire. Coverage 18.9% -> 61.1%.
