### PR TITLE
API cleanup: drop Status enum, AddEdge=POST, expand client SDK

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -65,7 +65,7 @@ jobs:
           go-version: '1.26'
           check-latest: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
           args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,17 @@
+version: "2"
+
+linters:
+  default: standard
+  settings:
+    staticcheck:
+      checks:
+        - all
+        # Suggestions for stylistic loop-condition lifting are noisy and
+        # not bug-finding.
+        - "-QF1006"
+        # Stylistic checks (package comments, naming, doc-comment format,
+        # dot imports) are intentionally relaxed for this repo.
+        - "-ST1000"
+        - "-ST1001"
+        - "-ST1003"
+        - "-ST1020"

--- a/cli/parser/source.go
+++ b/cli/parser/source.go
@@ -16,8 +16,7 @@ type Source struct {
 }
 
 func NewSource(str string) *Source {
-	var ss string
-	ss = strings.TrimSpace(str)
+	ss := strings.TrimSpace(str)
 	s := strings.Split(ss, " ")
 	return &Source{
 		s:      s,

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -76,12 +76,12 @@ func (c *CLIService) Run(ctx context.Context, str string) error {
 				fmt.Printf("Error: %s\n", err)
 				return ErrGetEdge
 			}
-			weight, err := c.client.GetEdge(ctx, p.Tail, p.Head)
+			edge, err := c.client.GetEdge(ctx, p.Tail, p.Head)
 			if err != nil {
 				fmt.Printf("Error: %s\n", err)
 				return ErrConnection
 			}
-			fmt.Printf("%f\n", weight)
+			fmt.Printf("%f\n", edge.Weight)
 			return nil
 
 		default:
@@ -184,7 +184,7 @@ func (c *CLIService) Run(ctx context.Context, str string) error {
 			fmt.Printf("Error: %s\n", err)
 			return ErrIlluminate
 		}
-		g, err := c.client.Illuminate(ctx, p.Seed, p.Step, p.K, p.Tfidf)
+		g, err := c.client.Illuminate(ctx, p.Seed, uint32(p.Step), uint32(p.K), p.Tfidf)
 		if err != nil {
 			fmt.Printf("Error: %s\n", err)
 			return ErrConnection

--- a/client/client.go
+++ b/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"net"
 	"strconv"
 	"time"
@@ -9,9 +10,59 @@ import (
 	model "github.com/anaregdesign/lantern/core/graph"
 	pb "github.com/anaregdesign/lantern/gen/go/graph/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// ErrNotFound is returned by GetVertex / GetEdge when the requested key or
+// edge does not exist. Use errors.Is to detect it; the underlying gRPC error
+// (with codes.NotFound) is wrapped for callers that need the full detail.
+var ErrNotFound = errors.New("not found")
+
+// Edge is a thin type alias over the generated protobuf Edge that lets the
+// client return the full record (including Expiration) instead of just the
+// weight.
+type Edge pb.Edge
+
+// ExpirationTime returns the absolute expiration carried by e, or the zero
+// time if no expiration was set on the server response.
+func (e *Edge) ExpirationTime() time.Time {
+	if e == nil || e.Expiration == nil {
+		return time.Time{}
+	}
+	return e.Expiration.AsTime()
+}
+
+// Optimization re-exports the server-side Optimization enum so SDK callers do
+// not need to import the generated proto package directly.
+type Optimization = pb.Optimization
+
+const (
+	OptimizationUnspecified             = pb.Optimization_OPTIMIZATION_UNSPECIFIED
+	OptimizationMinimumSpanningTree     = pb.Optimization_OPTIMIZATION_MINIMUM_SPANNING_TREE
+	OptimizationMaximumSpanningTree     = pb.Optimization_OPTIMIZATION_MAXIMUM_SPANNING_TREE
+	OptimizationShortestPathTree        = pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE
+	OptimizationShortestPathTreeInverse = pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE
+)
+
+// VertexInput describes one vertex for the batch PutVertices API. Use
+// Expiration to set an absolute deadline; for relative TTLs, prefer the
+// single-shot PutVertex helper or convert via time.Now().Add(ttl).
+type VertexInput struct {
+	Key        string
+	Value      any
+	Expiration time.Time
+}
+
+// EdgeInput describes one edge for the batch AddEdges / PutEdges APIs.
+type EdgeInput struct {
+	Tail       string
+	Head       string
+	Weight     float32
+	Expiration time.Time
+}
 
 type Lantern struct {
 	conn   *grpc.ClientConn
@@ -41,125 +92,165 @@ func (l *Lantern) Close() error {
 	return l.conn.Close()
 }
 
+// wrapNotFound converts a codes.NotFound gRPC error into one that satisfies
+// errors.Is(err, ErrNotFound) while preserving the original detail.
+func wrapNotFound(err error) error {
+	if err == nil {
+		return nil
+	}
+	if status.Code(err) == codes.NotFound {
+		return errors.Join(ErrNotFound, err)
+	}
+	return err
+}
+
+// GetVertex fetches the vertex at key. Returns an error wrapping ErrNotFound
+// when the key is absent.
 func (l *Lantern) GetVertex(ctx context.Context, key string) (*Vertex, error) {
 	result, err := l.client.GetVertex(ctx, &pb.GetVertexRequest{Key: key})
 	if err != nil {
-		return nil, err
+		return nil, wrapNotFound(err)
 	}
-	p := &Vertex{}
-	p.Key = result.Vertex.Key
-	p.Value = result.Vertex.Value
-	return p, nil
+	return (*Vertex)(result.Vertex), nil
 }
 
+// PutVertex upserts a single vertex with a relative TTL. The vertex is
+// overwritten if key already exists; see PutVertices for batched writes and
+// PutVertexAt for absolute expirations.
 func (l *Lantern) PutVertex(ctx context.Context, key string, value any, ttl time.Duration) error {
-	v, err := nativeVertex{
-		key:        key,
-		value:      value,
-		expiration: time.Now().Add(ttl),
-	}.asVertex()
+	return l.PutVertexAt(ctx, key, value, time.Now().Add(ttl))
+}
+
+// PutVertexAt upserts a single vertex with an absolute expiration time.
+func (l *Lantern) PutVertexAt(ctx context.Context, key string, value any, expiration time.Time) error {
+	v, err := nativeVertex{key: key, value: value, expiration: expiration}.asVertex()
 	if err != nil {
 		return err
 	}
+	_, err = l.client.PutVertex(ctx, &pb.PutVertexRequest{Vertices: []*pb.Vertex{v}})
+	return err
+}
 
-	request := &pb.PutVertexRequest{
-		Vertices: []*pb.Vertex{v},
+// PutVertices upserts a batch of vertices in a single RPC.
+func (l *Lantern) PutVertices(ctx context.Context, inputs []VertexInput) error {
+	if len(inputs) == 0 {
+		return nil
 	}
-	if _, err := l.client.PutVertex(ctx, request); err != nil {
-		return err
+	vs := make([]*pb.Vertex, 0, len(inputs))
+	for _, in := range inputs {
+		v, err := nativeVertex{key: in.Key, value: in.Value, expiration: in.Expiration}.asVertex()
+		if err != nil {
+			return err
+		}
+		vs = append(vs, v)
 	}
-	return nil
+	_, err := l.client.PutVertex(ctx, &pb.PutVertexRequest{Vertices: vs})
+	return err
 }
 
 func (l *Lantern) DeleteVertex(ctx context.Context, key string) error {
-	request := &pb.DeleteVertexRequest{
-		Key: key,
-	}
-	if _, err := l.client.DeleteVertex(ctx, request); err != nil {
-		return err
-	}
-	return nil
+	_, err := l.client.DeleteVertex(ctx, &pb.DeleteVertexRequest{Key: key})
+	return err
 }
 
-func (l *Lantern) GetEdge(ctx context.Context, tail string, head string) (float32, error) {
+// GetEdge fetches the edge weight (and any expiration) between tail and head.
+// Returns an error wrapping ErrNotFound when the edge does not exist.
+func (l *Lantern) GetEdge(ctx context.Context, tail string, head string) (*Edge, error) {
 	result, err := l.client.GetEdge(ctx, &pb.GetEdgeRequest{Tail: tail, Head: head})
 	if err != nil {
-		return 0, err
+		return nil, wrapNotFound(err)
 	}
-	return result.Edge.Weight, nil
+	return (*Edge)(result.Edge), nil
 }
 
+// AddEdge accumulates weight onto the (tail, head) pair: repeated calls with
+// the same endpoints sum their weights. Use PutEdge for replace semantics.
 func (l *Lantern) AddEdge(ctx context.Context, tail string, head string, weight float32, ttl time.Duration) error {
-	request := &pb.AddEdgeRequest{
-		Edges: []*pb.Edge{
-			{
-				Tail:       tail,
-				Head:       head,
-				Weight:     weight,
-				Expiration: timestamppb.New(time.Now().Add(ttl)),
-			},
-		},
-	}
-	if _, err := l.client.AddEdge(ctx, request); err != nil {
-		return err
-	}
-	return nil
+	return l.AddEdgeAt(ctx, tail, head, weight, time.Now().Add(ttl))
 }
 
+// AddEdgeAt is AddEdge with an absolute expiration.
+func (l *Lantern) AddEdgeAt(ctx context.Context, tail string, head string, weight float32, expiration time.Time) error {
+	_, err := l.client.AddEdge(ctx, &pb.AddEdgeRequest{
+		Edges: []*pb.Edge{{Tail: tail, Head: head, Weight: weight, Expiration: timestamppb.New(expiration)}},
+	})
+	return err
+}
+
+// AddEdges accumulates weight onto a batch of edges in a single RPC.
+func (l *Lantern) AddEdges(ctx context.Context, inputs []EdgeInput) error {
+	if len(inputs) == 0 {
+		return nil
+	}
+	edges := make([]*pb.Edge, 0, len(inputs))
+	for _, in := range inputs {
+		edges = append(edges, &pb.Edge{Tail: in.Tail, Head: in.Head, Weight: in.Weight, Expiration: timestamppb.New(in.Expiration)})
+	}
+	_, err := l.client.AddEdge(ctx, &pb.AddEdgeRequest{Edges: edges})
+	return err
+}
+
+// PutEdge overwrites the (tail, head) pair, replacing any existing weight and
+// expiration. Use AddEdge to accumulate instead.
 func (l *Lantern) PutEdge(ctx context.Context, tail string, head string, weight float32, ttl time.Duration) error {
-	request := &pb.PutEdgeRequest{
-		Edges: []*pb.Edge{
-			{
-				Tail:       tail,
-				Head:       head,
-				Weight:     weight,
-				Expiration: timestamppb.New(time.Now().Add(ttl)),
-			},
-		},
+	return l.PutEdgeAt(ctx, tail, head, weight, time.Now().Add(ttl))
+}
+
+// PutEdgeAt is PutEdge with an absolute expiration.
+func (l *Lantern) PutEdgeAt(ctx context.Context, tail string, head string, weight float32, expiration time.Time) error {
+	_, err := l.client.PutEdge(ctx, &pb.PutEdgeRequest{
+		Edges: []*pb.Edge{{Tail: tail, Head: head, Weight: weight, Expiration: timestamppb.New(expiration)}},
+	})
+	return err
+}
+
+// PutEdges overwrites a batch of edges in a single RPC.
+func (l *Lantern) PutEdges(ctx context.Context, inputs []EdgeInput) error {
+	if len(inputs) == 0 {
+		return nil
 	}
-	if _, err := l.client.PutEdge(ctx, request); err != nil {
-		return err
+	edges := make([]*pb.Edge, 0, len(inputs))
+	for _, in := range inputs {
+		edges = append(edges, &pb.Edge{Tail: in.Tail, Head: in.Head, Weight: in.Weight, Expiration: timestamppb.New(in.Expiration)})
 	}
-	return nil
+	_, err := l.client.PutEdge(ctx, &pb.PutEdgeRequest{Edges: edges})
+	return err
 }
 
 func (l *Lantern) DeleteEdge(ctx context.Context, tail string, head string) error {
-	request := &pb.DeleteEdgeRequest{
-		Tail: tail,
-		Head: head,
-	}
-	if _, err := l.client.DeleteEdge(ctx, request); err != nil {
-		return err
-	}
-	return nil
+	_, err := l.client.DeleteEdge(ctx, &pb.DeleteEdgeRequest{Tail: tail, Head: head})
+	return err
 }
 
-func (l *Lantern) Illuminate(ctx context.Context, seed string, step int, k int, tfidf bool) (*model.Graph[string, *Vertex], error) {
-	// In go-client, optimization is not implemented, but there is a native implementation in core.
+// Illuminate runs a k-bounded BFS from seed, returning the resulting subgraph.
+// Use IlluminateWithOptimization to request a server-side spanning tree or
+// shortest-path-tree transform on the response.
+func (l *Lantern) Illuminate(ctx context.Context, seed string, step uint32, k uint32, tfidf bool) (*model.Graph[string, *Vertex], error) {
+	return l.IlluminateWithOptimization(ctx, seed, step, k, tfidf, OptimizationUnspecified)
+}
+
+// IlluminateWithOptimization is Illuminate with an explicit server-side
+// post-processing strategy. Pass OptimizationUnspecified to disable it.
+func (l *Lantern) IlluminateWithOptimization(ctx context.Context, seed string, step uint32, k uint32, tfidf bool, opt Optimization) (*model.Graph[string, *Vertex], error) {
 	result, err := l.client.Illuminate(ctx, &pb.IlluminateRequest{
-		Seed:  seed,
-		Step:  uint32(step),
-		K:     uint32(k),
-		Tfidf: tfidf,
+		Seed:         seed,
+		Step:         step,
+		K:            k,
+		Tfidf:        tfidf,
+		Optimization: opt,
 	})
 	if err != nil {
 		return nil, err
 	}
 	g := model.NewGraph[string, *Vertex]()
 	for _, v := range result.Graph.Vertices {
-		g.Vertices[v.Key] = &Vertex{
-			Key:   v.Key,
-			Value: v.Value,
-		}
+		g.Vertices[v.Key] = (*Vertex)(v)
 	}
-
 	for _, e := range result.Graph.Edges {
 		if _, ok := g.Edges[e.Tail]; !ok {
 			g.Edges[e.Tail] = make(map[string]float32)
 		}
 		g.Edges[e.Tail][e.Head] = e.Weight
 	}
-
 	return g, nil
-
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -92,24 +92,24 @@ func TestLantern_AddPutDeleteEdge(t *testing.T) {
 	if err := l.AddEdge(ctx, "a", "b", 1.5, time.Minute); err != nil {
 		t.Fatalf("AddEdge: %v", err)
 	}
-	w, err := l.GetEdge(ctx, "a", "b")
+	e, err := l.GetEdge(ctx, "a", "b")
 	if err != nil {
 		t.Fatalf("GetEdge: %v", err)
 	}
-	if w != 1.5 {
-		t.Errorf("weight = %v, want 1.5", w)
+	if e.Weight != 1.5 {
+		t.Errorf("weight = %v, want 1.5", e.Weight)
 	}
 
 	// PutEdge replaces.
 	if err := l.PutEdge(ctx, "a", "b", 9, time.Minute); err != nil {
 		t.Fatalf("PutEdge: %v", err)
 	}
-	w, err = l.GetEdge(ctx, "a", "b")
+	e, err = l.GetEdge(ctx, "a", "b")
 	if err != nil {
 		t.Fatalf("GetEdge: %v", err)
 	}
-	if w != 9 {
-		t.Errorf("weight after PutEdge = %v, want 9", w)
+	if e.Weight != 9 {
+		t.Errorf("weight after PutEdge = %v, want 9", e.Weight)
 	}
 
 	if err := l.DeleteEdge(ctx, "a", "b"); err != nil {

--- a/client/example/main.go
+++ b/client/example/main.go
@@ -150,7 +150,7 @@ func main() {
 
 	// weight of edge a->b is 2
 	if weight, err := cli.GetEdge(ctx, "a", "b"); err == nil {
-		log.Printf("weight at t=1: %f\n", weight)
+		log.Printf("weight at t=1: %f\n", weight.Weight)
 	}
 
 	// 2 seconds later, first edge is expired
@@ -158,7 +158,7 @@ func main() {
 
 	// weight of edge a->b is 1
 	if weight, err := cli.GetEdge(ctx, "a", "b"); err == nil {
-		log.Printf("weight at t=3: %f\n", weight)
+		log.Printf("weight at t=3: %f\n", weight.Weight)
 	}
 
 	// 1 seconds later, second edge is expired
@@ -166,7 +166,7 @@ func main() {
 
 	// weight of edge a->b is 0
 	if weight, err := cli.GetEdge(ctx, "a", "b"); err == nil {
-		log.Printf("weight at t=4: %f\n", weight)
+		log.Printf("weight at t=4: %f\n", weight.Weight)
 	}
 
 	/*
@@ -179,7 +179,7 @@ func main() {
 	}
 
 	if w, err := cli.GetEdge(ctx, "a", "b"); err == nil {
-		log.Printf("weight of a->b: %f\n", w)
+		log.Printf("weight of a->b: %f\n", w.Weight)
 	}
 
 	if err := cli.DeleteEdge(ctx, "a", "b"); err != nil {
@@ -190,7 +190,7 @@ func main() {
 	if w, err := cli.GetEdge(ctx, "a", "b"); err != nil {
 		log.Printf("Error: %s\n", err)
 	} else {
-		log.Printf("weight of a->b: %f\n", w)
+		log.Printf("weight of a->b: %f\n", w.Weight)
 	}
 
 	/*
@@ -207,7 +207,7 @@ func main() {
 
 	// weight of edge a->b is 1
 	if weight, err := cli.GetEdge(ctx, "a", "b"); err == nil {
-		log.Printf("weight at t=1: %f\n", weight)
+		log.Printf("weight at t=1: %f\n", weight.Weight)
 	}
 
 	time.Sleep(1 * time.Second)

--- a/client/value.go
+++ b/client/value.go
@@ -2,13 +2,27 @@ package client
 
 import (
 	"errors"
+	"math"
+	"time"
+
 	pb "github.com/anaregdesign/lantern/gen/go/graph/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"time"
 )
 
+// ErrInvalidType is returned by a Vertex.*Value method when the underlying
+// oneof variant does not match the requested Go type and no safe coercion is
+// available.
 var ErrInvalidType = errors.New("invalid type")
 
+// ErrOverflow is returned when a value is read into a Go type that cannot
+// represent it (e.g. reading a negative int64 as uint, or a uint64 above
+// math.MaxInt64 as int).
+var ErrOverflow = errors.New("value overflow")
+
+// nativeVertex bridges a Go-native value into a protobuf Vertex. The type
+// switch in asVertex is the authoritative mapping from Go types to oneof
+// variants — when adding a new type, update both this switch and the matching
+// Vertex.*Value reader so round-trips stay consistent.
 type nativeVertex struct {
 	key        string
 	value      any
@@ -16,210 +30,211 @@ type nativeVertex struct {
 }
 
 func (v nativeVertex) asVertex() (*pb.Vertex, error) {
+	exp := timestamppb.New(v.expiration)
 	switch x := v.value.(type) {
 	case int:
-		return &pb.Vertex{
-			Key: v.key,
-			Value: &pb.Vertex_Int64{
-				Int64: int64(x),
-			},
-			Expiration: timestamppb.New(v.expiration),
-		}, nil
-
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Int64{Int64: int64(x)}}, nil
+	case int8:
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Int32{Int32: int32(x)}}, nil
+	case int16:
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Int32{Int32: int32(x)}}, nil
 	case int32:
-		return &pb.Vertex{
-			Key: v.key,
-			Value: &pb.Vertex_Int32{
-				Int32: x,
-			},
-			Expiration: timestamppb.New(v.expiration),
-		}, nil
-
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Int32{Int32: x}}, nil
 	case int64:
-		return &pb.Vertex{
-			Key: v.key,
-			Value: &pb.Vertex_Int64{
-				Int64: x,
-			},
-			Expiration: timestamppb.New(v.expiration),
-		}, nil
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Int64{Int64: x}}, nil
+
+	case uint:
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Uint64{Uint64: uint64(x)}}, nil
+	case uint8:
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Uint32{Uint32: uint32(x)}}, nil
+	case uint16:
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Uint32{Uint32: uint32(x)}}, nil
+	case uint32:
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Uint32{Uint32: x}}, nil
+	case uint64:
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Uint64{Uint64: x}}, nil
 
 	case float32:
-		return &pb.Vertex{
-			Key: v.key,
-			Value: &pb.Vertex_Float32{
-				Float32: x,
-			},
-			Expiration: timestamppb.New(v.expiration),
-		}, nil
-
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Float32{Float32: x}}, nil
 	case float64:
-		return &pb.Vertex{
-			Key: v.key,
-			Value: &pb.Vertex_Float64{
-				Float64: x,
-			},
-			Expiration: timestamppb.New(v.expiration),
-		}, nil
-
-	case uint32:
-		return &pb.Vertex{
-			Key: v.key,
-			Value: &pb.Vertex_Uint32{
-				Uint32: x,
-			},
-			Expiration: timestamppb.New(v.expiration),
-		}, nil
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Float64{Float64: x}}, nil
 
 	case string:
-		return &pb.Vertex{
-			Key: v.key,
-			Value: &pb.Vertex_String_{
-				String_: x,
-			},
-			Expiration: timestamppb.New(v.expiration),
-		}, nil
-
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_String_{String_: x}}, nil
 	case bool:
-		return &pb.Vertex{
-			Key: v.key,
-			Value: &pb.Vertex_Bool{
-				Bool: x,
-			},
-			Expiration: timestamppb.New(v.expiration),
-		}, nil
-
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Bool{Bool: x}}, nil
 	case []byte:
-		return &pb.Vertex{
-			Key: v.key,
-			Value: &pb.Vertex_Bytes{
-				Bytes: x,
-			},
-			Expiration: timestamppb.New(v.expiration),
-		}, nil
-
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Bytes{Bytes: x}}, nil
 	case time.Time:
-		return &pb.Vertex{
-			Key: v.key,
-			Value: &pb.Vertex_Timestamp{
-				Timestamp: timestamppb.New(x),
-			},
-			Expiration: timestamppb.New(v.expiration),
-		}, nil
-
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Timestamp{Timestamp: timestamppb.New(x)}}, nil
 	case nil:
-		return &pb.Vertex{
-			Key: v.key,
-			Value: &pb.Vertex_Nil{
-				Nil: true,
-			},
-			Expiration: timestamppb.New(v.expiration),
-		}, nil
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Nil{Nil: true}}, nil
 
 	default:
 		return nil, ErrInvalidType
 	}
 }
 
+// Vertex is a thin type alias over the generated protobuf Vertex that adds
+// Go-friendly value accessors. Convert a *pb.Vertex with (*Vertex)(p).
 type Vertex pb.Vertex
 
+// VertexKind identifies which oneof variant is set on a Vertex. Use
+// Vertex.Kind to dispatch without writing a switch over Value.(type).
+type VertexKind int
+
+const (
+	VertexKindUnset VertexKind = iota
+	VertexKindFloat32
+	VertexKindFloat64
+	VertexKindInt32
+	VertexKindInt64
+	VertexKindUint32
+	VertexKindUint64
+	VertexKindBool
+	VertexKindString
+	VertexKindBytes
+	VertexKindTimestamp
+	VertexKindNil
+)
+
+// Kind reports which oneof variant is set on v.
+func (v *Vertex) Kind() VertexKind {
+	if v == nil {
+		return VertexKindUnset
+	}
+	switch v.Value.(type) {
+	case *pb.Vertex_Float32:
+		return VertexKindFloat32
+	case *pb.Vertex_Float64:
+		return VertexKindFloat64
+	case *pb.Vertex_Int32:
+		return VertexKindInt32
+	case *pb.Vertex_Int64:
+		return VertexKindInt64
+	case *pb.Vertex_Uint32:
+		return VertexKindUint32
+	case *pb.Vertex_Uint64:
+		return VertexKindUint64
+	case *pb.Vertex_Bool:
+		return VertexKindBool
+	case *pb.Vertex_String_:
+		return VertexKindString
+	case *pb.Vertex_Bytes:
+		return VertexKindBytes
+	case *pb.Vertex_Timestamp:
+		return VertexKindTimestamp
+	case *pb.Vertex_Nil:
+		return VertexKindNil
+	default:
+		return VertexKindUnset
+	}
+}
+
+// ExpirationTime returns the absolute expiration carried by v, or the zero
+// time if no expiration was set on the server response.
+func (v *Vertex) ExpirationTime() time.Time {
+	if v == nil || v.Expiration == nil {
+		return time.Time{}
+	}
+	return v.Expiration.AsTime()
+}
+
+// IntValue returns the underlying signed integer value. It also accepts
+// unsigned variants and reports ErrOverflow when a Uint64 value exceeds
+// math.MaxInt64.
 func (v *Vertex) IntValue() (int, error) {
 	switch x := v.Value.(type) {
-	case *pb.Vertex_Int64:
-		return int(x.Int64), nil
-
 	case *pb.Vertex_Int32:
 		return int(x.Int32), nil
-
+	case *pb.Vertex_Int64:
+		return int(x.Int64), nil
+	case *pb.Vertex_Uint32:
+		return int(x.Uint32), nil
+	case *pb.Vertex_Uint64:
+		if x.Uint64 > math.MaxInt64 {
+			return 0, ErrOverflow
+		}
+		return int(x.Uint64), nil
 	default:
 		return 0, ErrInvalidType
 	}
 }
 
+// UIntValue returns the underlying unsigned integer value. It also accepts
+// signed variants and reports ErrOverflow when the value is negative.
 func (v *Vertex) UIntValue() (uint, error) {
 	switch x := v.Value.(type) {
 	case *pb.Vertex_Uint32:
 		return uint(x.Uint32), nil
-
 	case *pb.Vertex_Uint64:
 		return uint(x.Uint64), nil
-
+	case *pb.Vertex_Int32:
+		if x.Int32 < 0 {
+			return 0, ErrOverflow
+		}
+		return uint(x.Int32), nil
+	case *pb.Vertex_Int64:
+		if x.Int64 < 0 {
+			return 0, ErrOverflow
+		}
+		return uint(x.Int64), nil
 	default:
 		return 0, ErrInvalidType
 	}
 }
 
+// FloatValue widens any numeric oneof variant to float64.
 func (v *Vertex) FloatValue() (float64, error) {
 	switch x := v.Value.(type) {
 	case *pb.Vertex_Int64:
 		return float64(x.Int64), nil
-
 	case *pb.Vertex_Int32:
 		return float64(x.Int32), nil
-
 	case *pb.Vertex_Uint32:
 		return float64(x.Uint32), nil
-
 	case *pb.Vertex_Uint64:
 		return float64(x.Uint64), nil
-
 	case *pb.Vertex_Float32:
 		return float64(x.Float32), nil
-
 	case *pb.Vertex_Float64:
 		return x.Float64, nil
-
 	default:
 		return 0, ErrInvalidType
 	}
 }
 
 func (v *Vertex) StringValue() (string, error) {
-	switch x := v.Value.(type) {
-	case *pb.Vertex_String_:
+	if x, ok := v.Value.(*pb.Vertex_String_); ok {
 		return x.String_, nil
-
-	default:
-		return "", ErrInvalidType
 	}
+	return "", ErrInvalidType
 }
 
 func (v *Vertex) BoolValue() (bool, error) {
-	switch x := v.Value.(type) {
-	case *pb.Vertex_Bool:
+	if x, ok := v.Value.(*pb.Vertex_Bool); ok {
 		return x.Bool, nil
-
-	default:
-		return false, ErrInvalidType
 	}
+	return false, ErrInvalidType
 }
 
 func (v *Vertex) BytesValue() ([]byte, error) {
-	switch x := v.Value.(type) {
-	case *pb.Vertex_Bytes:
+	if x, ok := v.Value.(*pb.Vertex_Bytes); ok {
 		return x.Bytes, nil
-
-	default:
-		return nil, ErrInvalidType
 	}
+	return nil, ErrInvalidType
 }
 
 func (v *Vertex) TimeValue() (time.Time, error) {
-	switch x := v.Value.(type) {
-	case *pb.Vertex_Timestamp:
+	if x, ok := v.Value.(*pb.Vertex_Timestamp); ok {
 		return x.Timestamp.AsTime(), nil
-
-	default:
-		return time.Time{}, ErrInvalidType
 	}
+	return time.Time{}, ErrInvalidType
 }
 
 func (v *Vertex) IsNil() bool {
-	switch x := v.Value.(type) {
-	case *pb.Vertex_Nil:
+	if x, ok := v.Value.(*pb.Vertex_Nil); ok {
 		return x.Nil
-
-	default:
-		return false
 	}
+	return false
 }

--- a/client/value_kind_test.go
+++ b/client/value_kind_test.go
@@ -1,0 +1,98 @@
+package client
+
+import (
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	pb "github.com/anaregdesign/lantern/gen/go/graph/v1"
+)
+
+func TestNativeVertex_AsVertex_IntegerWidths(t *testing.T) {
+	exp := time.Now().Add(time.Minute)
+	cases := []struct {
+		name string
+		in   any
+		kind VertexKind
+	}{
+		{"int", int(7), VertexKindInt64},
+		{"int8", int8(7), VertexKindInt32},
+		{"int16", int16(7), VertexKindInt32},
+		{"int32", int32(7), VertexKindInt32},
+		{"int64", int64(7), VertexKindInt64},
+		{"uint", uint(7), VertexKindUint64},
+		{"uint8", uint8(7), VertexKindUint32},
+		{"uint16", uint16(7), VertexKindUint32},
+		{"uint32", uint32(7), VertexKindUint32},
+		{"uint64", uint64(7), VertexKindUint64},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := nativeVertex{key: "k", value: tc.in, expiration: exp}.asVertex()
+			if err != nil {
+				t.Fatalf("asVertex: %v", err)
+			}
+			wrapped := (*Vertex)(v)
+			if got := wrapped.Kind(); got != tc.kind {
+				t.Errorf("Kind = %v, want %v", got, tc.kind)
+			}
+		})
+	}
+}
+
+func TestVertex_IntValue_Overflow(t *testing.T) {
+	v := &Vertex{Value: &pb.Vertex_Uint64{Uint64: math.MaxUint64}}
+	if _, err := v.IntValue(); !errors.Is(err, ErrOverflow) {
+		t.Errorf("err = %v, want ErrOverflow", err)
+	}
+}
+
+func TestVertex_UIntValue_Overflow(t *testing.T) {
+	v := &Vertex{Value: &pb.Vertex_Int64{Int64: -1}}
+	if _, err := v.UIntValue(); !errors.Is(err, ErrOverflow) {
+		t.Errorf("err = %v, want ErrOverflow", err)
+	}
+}
+
+func TestVertex_IntValue_CrossWidth(t *testing.T) {
+	v := &Vertex{Value: &pb.Vertex_Uint32{Uint32: 42}}
+	got, err := v.IntValue()
+	if err != nil {
+		t.Fatalf("IntValue: %v", err)
+	}
+	if got != 42 {
+		t.Errorf("got %d, want 42", got)
+	}
+}
+
+func TestVertex_Kind(t *testing.T) {
+	cases := []struct {
+		name string
+		v    *Vertex
+		want VertexKind
+	}{
+		{"nil-vertex", nil, VertexKindUnset},
+		{"unset", &Vertex{}, VertexKindUnset},
+		{"string", &Vertex{Value: &pb.Vertex_String_{String_: "x"}}, VertexKindString},
+		{"bool", &Vertex{Value: &pb.Vertex_Bool{Bool: true}}, VertexKindBool},
+		{"bytes", &Vertex{Value: &pb.Vertex_Bytes{Bytes: []byte{1}}}, VertexKindBytes},
+		{"nil-value", &Vertex{Value: &pb.Vertex_Nil{Nil: true}}, VertexKindNil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.v.Kind(); got != tc.want {
+				t.Errorf("Kind = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVertex_ExpirationTime(t *testing.T) {
+	if got := (*Vertex)(nil).ExpirationTime(); !got.IsZero() {
+		t.Errorf("nil vertex expiration = %v, want zero", got)
+	}
+	if got := (&Vertex{}).ExpirationTime(); !got.IsZero() {
+		t.Errorf("empty expiration = %v, want zero", got)
+	}
+}

--- a/core/cache/graph/edge.go
+++ b/core/cache/graph/edge.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"context"
 	"maps"
 	"sync"
 	"time"
@@ -55,12 +54,6 @@ func (w *weight) isZero() bool {
 	defer w.mu.Unlock()
 	w.flushLocked()
 	return w.sum == 0
-}
-
-func (w *weight) flush() {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	w.flushLocked()
 }
 
 // flushLocked compacts expired entries in place and recomputes the cached sum.
@@ -200,19 +193,6 @@ func (c *edgeCache[S]) flush() {
 			if w.isZero() {
 				c.deleteLocked(tail, head)
 			}
-		}
-	}
-}
-
-func (c *edgeCache[S]) watch(ctx context.Context, interval time.Duration) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			c.flush()
-		case <-ctx.Done():
-			return
 		}
 	}
 }

--- a/core/collection/set/set.go
+++ b/core/collection/set/set.go
@@ -57,7 +57,7 @@ func (s *Set[T]) Values() []T {
 	defer s.mu.RUnlock()
 
 	values := make([]T, 0, len(s.set))
-	for k, _ := range s.set {
+	for k := range s.set {
 		values = append(values, k)
 	}
 	return values
@@ -76,7 +76,7 @@ func (s *Set[T]) Filter(predicate function.Predicate[T]) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	for k, _ := range s.set {
+	for k := range s.set {
 		if !predicate(k) {
 			delete(s.set, k)
 		}

--- a/core/concurrent/pubsub/message.go
+++ b/core/concurrent/pubsub/message.go
@@ -35,7 +35,3 @@ func (m *Message[T]) Ack() {
 func (m *Message[T]) Nack() {
 	m.subscription.nack(m)
 }
-
-func (m *Message[T]) touch() {
-	m.lastViewedAt = time.Now()
-}

--- a/core/concurrent/pubsub/topic.go
+++ b/core/concurrent/pubsub/topic.go
@@ -76,7 +76,5 @@ func (t *Topic[T]) unregister(subscription *Subscription[T]) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if _, ok := t.subscriptions[subscription.name]; ok {
-		delete(t.subscriptions, subscription.name)
-	}
+	delete(t.subscriptions, subscription.name)
 }

--- a/core/nlp/dictionary.go
+++ b/core/nlp/dictionary.go
@@ -43,7 +43,7 @@ func (d *Dictionary) Words2CBOW(words []string, window int) CBOW {
 	d.AddWords(words)
 
 	bows := make([]BOW, len(words))
-	for i, _ := range words {
+	for i := range words {
 		bows[i] = NewBOW()
 		for j := i - window; j <= i+window; j++ {
 			if j < 0 || j >= len(words) || j == i {

--- a/gen/go/graph/v1/graph.pb.go
+++ b/gen/go/graph/v1/graph.pb.go
@@ -1164,7 +1164,7 @@ var File_graph_v1_graph_proto protoreflect.FileDescriptor
 
 const file_graph_v1_graph_proto_rawDesc = "" +
 	"\n" +
-	"\x14graph/v1/graph.proto\x12\bgraph.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cgoogle/api/annotations.proto\"\x93\x03\n" +
+	"\x14graph/v1/graph.proto\x12\bgraph.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x93\x03\n" +
 	"\x06Vertex\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12:\n" +
 	"\n" +

--- a/gen/go/graph/v1/graph.pb.go
+++ b/gen/go/graph/v1/graph.pb.go
@@ -78,58 +78,6 @@ func (Optimization) EnumDescriptor() ([]byte, []int) {
 	return file_graph_v1_graph_proto_rawDescGZIP(), []int{0}
 }
 
-type Status int32
-
-const (
-	Status_STATUS_UNSPECIFIED           Status = 0
-	Status_STATUS_OK                    Status = 1
-	Status_STATUS_INTERNAL_SERVER_ERROR Status = 2
-	Status_STATUS_INVALID_REQUEST       Status = 3
-)
-
-// Enum value maps for Status.
-var (
-	Status_name = map[int32]string{
-		0: "STATUS_UNSPECIFIED",
-		1: "STATUS_OK",
-		2: "STATUS_INTERNAL_SERVER_ERROR",
-		3: "STATUS_INVALID_REQUEST",
-	}
-	Status_value = map[string]int32{
-		"STATUS_UNSPECIFIED":           0,
-		"STATUS_OK":                    1,
-		"STATUS_INTERNAL_SERVER_ERROR": 2,
-		"STATUS_INVALID_REQUEST":       3,
-	}
-)
-
-func (x Status) Enum() *Status {
-	p := new(Status)
-	*p = x
-	return p
-}
-
-func (x Status) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (Status) Descriptor() protoreflect.EnumDescriptor {
-	return file_graph_v1_graph_proto_enumTypes[1].Descriptor()
-}
-
-func (Status) Type() protoreflect.EnumType {
-	return &file_graph_v1_graph_proto_enumTypes[1]
-}
-
-func (x Status) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use Status.Descriptor instead.
-func (Status) EnumDescriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{1}
-}
-
 type Vertex struct {
 	state      protoimpl.MessageState `protogen:"open.v1"`
 	Key        string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
@@ -571,7 +519,6 @@ func (x *IlluminateRequest) GetOptimization() Optimization {
 type IlluminateResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Graph         *Graph                 `protobuf:"bytes,1,opt,name=graph,proto3" json:"graph,omitempty"`
-	Status        Status                 `protobuf:"varint,2,opt,name=status,proto3,enum=graph.v1.Status" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -611,13 +558,6 @@ func (x *IlluminateResponse) GetGraph() *Graph {
 		return x.Graph
 	}
 	return nil
-}
-
-func (x *IlluminateResponse) GetStatus() Status {
-	if x != nil {
-		return x.Status
-	}
-	return Status_STATUS_UNSPECIFIED
 }
 
 type GetVertexRequest struct {
@@ -667,7 +607,6 @@ func (x *GetVertexRequest) GetKey() string {
 type GetVertexResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Vertex        *Vertex                `protobuf:"bytes,1,opt,name=vertex,proto3" json:"vertex,omitempty"`
-	Status        Status                 `protobuf:"varint,2,opt,name=status,proto3,enum=graph.v1.Status" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -709,13 +648,9 @@ func (x *GetVertexResponse) GetVertex() *Vertex {
 	return nil
 }
 
-func (x *GetVertexResponse) GetStatus() Status {
-	if x != nil {
-		return x.Status
-	}
-	return Status_STATUS_UNSPECIFIED
-}
-
+// PutVertexRequest writes vertices with upsert semantics: each Vertex.key
+// replaces any existing value at that key. Use the Vertex.expiration field
+// (absolute time) to control TTL.
 type PutVertexRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Vertices      []*Vertex              `protobuf:"bytes,1,rep,name=vertices,proto3" json:"vertices,omitempty"`
@@ -762,7 +697,6 @@ func (x *PutVertexRequest) GetVertices() []*Vertex {
 
 type PutVertexResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Status        Status                 `protobuf:"varint,1,opt,name=status,proto3,enum=graph.v1.Status" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -795,13 +729,6 @@ func (x *PutVertexResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use PutVertexResponse.ProtoReflect.Descriptor instead.
 func (*PutVertexResponse) Descriptor() ([]byte, []int) {
 	return file_graph_v1_graph_proto_rawDescGZIP(), []int{8}
-}
-
-func (x *PutVertexResponse) GetStatus() Status {
-	if x != nil {
-		return x.Status
-	}
-	return Status_STATUS_UNSPECIFIED
 }
 
 type DeleteVertexRequest struct {
@@ -850,7 +777,6 @@ func (x *DeleteVertexRequest) GetKey() string {
 
 type DeleteVertexResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Status        Status                 `protobuf:"varint,1,opt,name=status,proto3,enum=graph.v1.Status" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -883,13 +809,6 @@ func (x *DeleteVertexResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use DeleteVertexResponse.ProtoReflect.Descriptor instead.
 func (*DeleteVertexResponse) Descriptor() ([]byte, []int) {
 	return file_graph_v1_graph_proto_rawDescGZIP(), []int{10}
-}
-
-func (x *DeleteVertexResponse) GetStatus() Status {
-	if x != nil {
-		return x.Status
-	}
-	return Status_STATUS_UNSPECIFIED
 }
 
 type GetEdgeRequest struct {
@@ -1042,7 +961,6 @@ func (x *DeleteEdgeRequest) GetHead() string {
 
 type DeleteEdgeResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Status        Status                 `protobuf:"varint,1,opt,name=status,proto3,enum=graph.v1.Status" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1077,13 +995,9 @@ func (*DeleteEdgeResponse) Descriptor() ([]byte, []int) {
 	return file_graph_v1_graph_proto_rawDescGZIP(), []int{14}
 }
 
-func (x *DeleteEdgeResponse) GetStatus() Status {
-	if x != nil {
-		return x.Status
-	}
-	return Status_STATUS_UNSPECIFIED
-}
-
+// AddEdgeRequest accumulates weight onto each (tail, head) pair: repeated
+// calls with the same endpoints sum their weights. This operation is
+// non-idempotent.
 type AddEdgeRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Edges         []*Edge                `protobuf:"bytes,1,rep,name=edges,proto3" json:"edges,omitempty"`
@@ -1130,7 +1044,6 @@ func (x *AddEdgeRequest) GetEdges() []*Edge {
 
 type AddEdgeResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Status        Status                 `protobuf:"varint,1,opt,name=status,proto3,enum=graph.v1.Status" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1165,13 +1078,8 @@ func (*AddEdgeResponse) Descriptor() ([]byte, []int) {
 	return file_graph_v1_graph_proto_rawDescGZIP(), []int{16}
 }
 
-func (x *AddEdgeResponse) GetStatus() Status {
-	if x != nil {
-		return x.Status
-	}
-	return Status_STATUS_UNSPECIFIED
-}
-
+// PutEdgeRequest overwrites each (tail, head) pair, replacing any existing
+// weight and expiration. This operation is idempotent.
 type PutEdgeRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Edges         []*Edge                `protobuf:"bytes,1,rep,name=edges,proto3" json:"edges,omitempty"`
@@ -1218,7 +1126,6 @@ func (x *PutEdgeRequest) GetEdges() []*Edge {
 
 type PutEdgeResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Status        Status                 `protobuf:"varint,1,opt,name=status,proto3,enum=graph.v1.Status" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1251,13 +1158,6 @@ func (x *PutEdgeResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use PutEdgeResponse.ProtoReflect.Descriptor instead.
 func (*PutEdgeResponse) Descriptor() ([]byte, []int) {
 	return file_graph_v1_graph_proto_rawDescGZIP(), []int{18}
-}
-
-func (x *PutEdgeResponse) GetStatus() Status {
-	if x != nil {
-		return x.Status
-	}
-	return Status_STATUS_UNSPECIFIED
 }
 
 var File_graph_v1_graph_proto protoreflect.FileDescriptor
@@ -1298,23 +1198,19 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\x04step\x18\x02 \x01(\rR\x04step\x12\f\n" +
 	"\x01k\x18\x03 \x01(\rR\x01k\x12\x14\n" +
 	"\x05tfidf\x18\x04 \x01(\bR\x05tfidf\x12:\n" +
-	"\foptimization\x18\x05 \x01(\x0e2\x16.graph.v1.OptimizationR\foptimization\"e\n" +
+	"\foptimization\x18\x05 \x01(\x0e2\x16.graph.v1.OptimizationR\foptimization\";\n" +
 	"\x12IlluminateResponse\x12%\n" +
-	"\x05graph\x18\x01 \x01(\v2\x0f.graph.v1.GraphR\x05graph\x12(\n" +
-	"\x06status\x18\x02 \x01(\x0e2\x10.graph.v1.StatusR\x06status\"$\n" +
+	"\x05graph\x18\x01 \x01(\v2\x0f.graph.v1.GraphR\x05graph\"$\n" +
 	"\x10GetVertexRequest\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\"g\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\"=\n" +
 	"\x11GetVertexResponse\x12(\n" +
-	"\x06vertex\x18\x01 \x01(\v2\x10.graph.v1.VertexR\x06vertex\x12(\n" +
-	"\x06status\x18\x02 \x01(\x0e2\x10.graph.v1.StatusR\x06status\"@\n" +
+	"\x06vertex\x18\x01 \x01(\v2\x10.graph.v1.VertexR\x06vertex\"@\n" +
 	"\x10PutVertexRequest\x12,\n" +
-	"\bvertices\x18\x01 \x03(\v2\x10.graph.v1.VertexR\bvertices\"=\n" +
-	"\x11PutVertexResponse\x12(\n" +
-	"\x06status\x18\x01 \x01(\x0e2\x10.graph.v1.StatusR\x06status\"'\n" +
+	"\bvertices\x18\x01 \x03(\v2\x10.graph.v1.VertexR\bvertices\"\x13\n" +
+	"\x11PutVertexResponse\"'\n" +
 	"\x13DeleteVertexRequest\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\"@\n" +
-	"\x14DeleteVertexResponse\x12(\n" +
-	"\x06status\x18\x01 \x01(\x0e2\x10.graph.v1.StatusR\x06status\"8\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\"\x16\n" +
+	"\x14DeleteVertexResponse\"8\n" +
 	"\x0eGetEdgeRequest\x12\x12\n" +
 	"\x04tail\x18\x01 \x01(\tR\x04tail\x12\x12\n" +
 	"\x04head\x18\x02 \x01(\tR\x04head\"5\n" +
@@ -1322,28 +1218,20 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\x04edge\x18\x01 \x01(\v2\x0e.graph.v1.EdgeR\x04edge\";\n" +
 	"\x11DeleteEdgeRequest\x12\x12\n" +
 	"\x04tail\x18\x01 \x01(\tR\x04tail\x12\x12\n" +
-	"\x04head\x18\x02 \x01(\tR\x04head\">\n" +
-	"\x12DeleteEdgeResponse\x12(\n" +
-	"\x06status\x18\x01 \x01(\x0e2\x10.graph.v1.StatusR\x06status\"6\n" +
+	"\x04head\x18\x02 \x01(\tR\x04head\"\x14\n" +
+	"\x12DeleteEdgeResponse\"6\n" +
 	"\x0eAddEdgeRequest\x12$\n" +
-	"\x05edges\x18\x01 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\";\n" +
-	"\x0fAddEdgeResponse\x12(\n" +
-	"\x06status\x18\x01 \x01(\x0e2\x10.graph.v1.StatusR\x06status\"6\n" +
+	"\x05edges\x18\x01 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\"\x11\n" +
+	"\x0fAddEdgeResponse\"6\n" +
 	"\x0ePutEdgeRequest\x12$\n" +
-	"\x05edges\x18\x01 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\";\n" +
-	"\x0fPutEdgeResponse\x12(\n" +
-	"\x06status\x18\x01 \x01(\x0e2\x10.graph.v1.StatusR\x06status*\xce\x01\n" +
+	"\x05edges\x18\x01 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\"\x11\n" +
+	"\x0fPutEdgeResponse*\xce\x01\n" +
 	"\fOptimization\x12\x1c\n" +
 	"\x18OPTIMIZATION_UNSPECIFIED\x10\x00\x12&\n" +
 	"\"OPTIMIZATION_MINIMUM_SPANNING_TREE\x10\x01\x12&\n" +
 	"\"OPTIMIZATION_MAXIMUM_SPANNING_TREE\x10\x02\x12#\n" +
 	"\x1fOPTIMIZATION_SHORTEST_PATH_TREE\x10\x03\x12+\n" +
-	"'OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE\x10\x04*m\n" +
-	"\x06Status\x12\x16\n" +
-	"\x12STATUS_UNSPECIFIED\x10\x00\x12\r\n" +
-	"\tSTATUS_OK\x10\x01\x12 \n" +
-	"\x1cSTATUS_INTERNAL_SERVER_ERROR\x10\x02\x12\x1a\n" +
-	"\x16STATUS_INVALID_REQUEST\x10\x032\xa3\x06\n" +
+	"'OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE\x10\x042\xa3\x06\n" +
 	"\x0eLanternService\x12f\n" +
 	"\n" +
 	"Illuminate\x12\x1b.graph.v1.IlluminateRequest\x1a\x1c.graph.v1.IlluminateResponse\"\x1d\x82\xd3\xe4\x93\x02\x17\x12\x15/v1/illuminate/{seed}\x12`\n" +
@@ -1351,7 +1239,7 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\tPutVertex\x12\x1a.graph.v1.PutVertexRequest\x1a\x1b.graph.v1.PutVertexResponse\"\x17\x82\xd3\xe4\x93\x02\x11:\x01*\x1a\f/v1/vertices\x12i\n" +
 	"\fDeleteVertex\x12\x1d.graph.v1.DeleteVertexRequest\x1a\x1e.graph.v1.DeleteVertexResponse\"\x1a\x82\xd3\xe4\x93\x02\x14*\x12/v1/vertices/{key}\x12_\n" +
 	"\aGetEdge\x12\x18.graph.v1.GetEdgeRequest\x1a\x19.graph.v1.GetEdgeResponse\"\x1f\x82\xd3\xe4\x93\x02\x19\x12\x17/v1/edges/{tail}/{head}\x12X\n" +
-	"\aAddEdge\x12\x18.graph.v1.AddEdgeRequest\x1a\x19.graph.v1.AddEdgeResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\x1a\r/v1/edges/add\x12X\n" +
+	"\aAddEdge\x12\x18.graph.v1.AddEdgeRequest\x1a\x19.graph.v1.AddEdgeResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\"\r/v1/edges/add\x12X\n" +
 	"\aPutEdge\x12\x18.graph.v1.PutEdgeRequest\x1a\x19.graph.v1.PutEdgeResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\x1a\r/v1/edges/put\x12h\n" +
 	"\n" +
 	"DeleteEdge\x12\x1b.graph.v1.DeleteEdgeRequest\x1a\x1c.graph.v1.DeleteEdgeResponse\"\x1f\x82\xd3\xe4\x93\x02\x19*\x17/v1/edges/{tail}/{head}B\x94\x01\n" +
@@ -1370,73 +1258,65 @@ func file_graph_v1_graph_proto_rawDescGZIP() []byte {
 	return file_graph_v1_graph_proto_rawDescData
 }
 
-var file_graph_v1_graph_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_graph_v1_graph_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_graph_v1_graph_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
 var file_graph_v1_graph_proto_goTypes = []any{
 	(Optimization)(0),             // 0: graph.v1.Optimization
-	(Status)(0),                   // 1: graph.v1.Status
-	(*Vertex)(nil),                // 2: graph.v1.Vertex
-	(*Edge)(nil),                  // 3: graph.v1.Edge
-	(*Graph)(nil),                 // 4: graph.v1.Graph
-	(*IlluminateRequest)(nil),     // 5: graph.v1.IlluminateRequest
-	(*IlluminateResponse)(nil),    // 6: graph.v1.IlluminateResponse
-	(*GetVertexRequest)(nil),      // 7: graph.v1.GetVertexRequest
-	(*GetVertexResponse)(nil),     // 8: graph.v1.GetVertexResponse
-	(*PutVertexRequest)(nil),      // 9: graph.v1.PutVertexRequest
-	(*PutVertexResponse)(nil),     // 10: graph.v1.PutVertexResponse
-	(*DeleteVertexRequest)(nil),   // 11: graph.v1.DeleteVertexRequest
-	(*DeleteVertexResponse)(nil),  // 12: graph.v1.DeleteVertexResponse
-	(*GetEdgeRequest)(nil),        // 13: graph.v1.GetEdgeRequest
-	(*GetEdgeResponse)(nil),       // 14: graph.v1.GetEdgeResponse
-	(*DeleteEdgeRequest)(nil),     // 15: graph.v1.DeleteEdgeRequest
-	(*DeleteEdgeResponse)(nil),    // 16: graph.v1.DeleteEdgeResponse
-	(*AddEdgeRequest)(nil),        // 17: graph.v1.AddEdgeRequest
-	(*AddEdgeResponse)(nil),       // 18: graph.v1.AddEdgeResponse
-	(*PutEdgeRequest)(nil),        // 19: graph.v1.PutEdgeRequest
-	(*PutEdgeResponse)(nil),       // 20: graph.v1.PutEdgeResponse
-	(*timestamppb.Timestamp)(nil), // 21: google.protobuf.Timestamp
+	(*Vertex)(nil),                // 1: graph.v1.Vertex
+	(*Edge)(nil),                  // 2: graph.v1.Edge
+	(*Graph)(nil),                 // 3: graph.v1.Graph
+	(*IlluminateRequest)(nil),     // 4: graph.v1.IlluminateRequest
+	(*IlluminateResponse)(nil),    // 5: graph.v1.IlluminateResponse
+	(*GetVertexRequest)(nil),      // 6: graph.v1.GetVertexRequest
+	(*GetVertexResponse)(nil),     // 7: graph.v1.GetVertexResponse
+	(*PutVertexRequest)(nil),      // 8: graph.v1.PutVertexRequest
+	(*PutVertexResponse)(nil),     // 9: graph.v1.PutVertexResponse
+	(*DeleteVertexRequest)(nil),   // 10: graph.v1.DeleteVertexRequest
+	(*DeleteVertexResponse)(nil),  // 11: graph.v1.DeleteVertexResponse
+	(*GetEdgeRequest)(nil),        // 12: graph.v1.GetEdgeRequest
+	(*GetEdgeResponse)(nil),       // 13: graph.v1.GetEdgeResponse
+	(*DeleteEdgeRequest)(nil),     // 14: graph.v1.DeleteEdgeRequest
+	(*DeleteEdgeResponse)(nil),    // 15: graph.v1.DeleteEdgeResponse
+	(*AddEdgeRequest)(nil),        // 16: graph.v1.AddEdgeRequest
+	(*AddEdgeResponse)(nil),       // 17: graph.v1.AddEdgeResponse
+	(*PutEdgeRequest)(nil),        // 18: graph.v1.PutEdgeRequest
+	(*PutEdgeResponse)(nil),       // 19: graph.v1.PutEdgeResponse
+	(*timestamppb.Timestamp)(nil), // 20: google.protobuf.Timestamp
 }
 var file_graph_v1_graph_proto_depIdxs = []int32{
-	21, // 0: graph.v1.Vertex.expiration:type_name -> google.protobuf.Timestamp
-	21, // 1: graph.v1.Vertex.timestamp:type_name -> google.protobuf.Timestamp
-	21, // 2: graph.v1.Edge.expiration:type_name -> google.protobuf.Timestamp
-	2,  // 3: graph.v1.Graph.vertices:type_name -> graph.v1.Vertex
-	3,  // 4: graph.v1.Graph.edges:type_name -> graph.v1.Edge
+	20, // 0: graph.v1.Vertex.expiration:type_name -> google.protobuf.Timestamp
+	20, // 1: graph.v1.Vertex.timestamp:type_name -> google.protobuf.Timestamp
+	20, // 2: graph.v1.Edge.expiration:type_name -> google.protobuf.Timestamp
+	1,  // 3: graph.v1.Graph.vertices:type_name -> graph.v1.Vertex
+	2,  // 4: graph.v1.Graph.edges:type_name -> graph.v1.Edge
 	0,  // 5: graph.v1.IlluminateRequest.optimization:type_name -> graph.v1.Optimization
-	4,  // 6: graph.v1.IlluminateResponse.graph:type_name -> graph.v1.Graph
-	1,  // 7: graph.v1.IlluminateResponse.status:type_name -> graph.v1.Status
-	2,  // 8: graph.v1.GetVertexResponse.vertex:type_name -> graph.v1.Vertex
-	1,  // 9: graph.v1.GetVertexResponse.status:type_name -> graph.v1.Status
-	2,  // 10: graph.v1.PutVertexRequest.vertices:type_name -> graph.v1.Vertex
-	1,  // 11: graph.v1.PutVertexResponse.status:type_name -> graph.v1.Status
-	1,  // 12: graph.v1.DeleteVertexResponse.status:type_name -> graph.v1.Status
-	3,  // 13: graph.v1.GetEdgeResponse.edge:type_name -> graph.v1.Edge
-	1,  // 14: graph.v1.DeleteEdgeResponse.status:type_name -> graph.v1.Status
-	3,  // 15: graph.v1.AddEdgeRequest.edges:type_name -> graph.v1.Edge
-	1,  // 16: graph.v1.AddEdgeResponse.status:type_name -> graph.v1.Status
-	3,  // 17: graph.v1.PutEdgeRequest.edges:type_name -> graph.v1.Edge
-	1,  // 18: graph.v1.PutEdgeResponse.status:type_name -> graph.v1.Status
-	5,  // 19: graph.v1.LanternService.Illuminate:input_type -> graph.v1.IlluminateRequest
-	7,  // 20: graph.v1.LanternService.GetVertex:input_type -> graph.v1.GetVertexRequest
-	9,  // 21: graph.v1.LanternService.PutVertex:input_type -> graph.v1.PutVertexRequest
-	11, // 22: graph.v1.LanternService.DeleteVertex:input_type -> graph.v1.DeleteVertexRequest
-	13, // 23: graph.v1.LanternService.GetEdge:input_type -> graph.v1.GetEdgeRequest
-	17, // 24: graph.v1.LanternService.AddEdge:input_type -> graph.v1.AddEdgeRequest
-	19, // 25: graph.v1.LanternService.PutEdge:input_type -> graph.v1.PutEdgeRequest
-	15, // 26: graph.v1.LanternService.DeleteEdge:input_type -> graph.v1.DeleteEdgeRequest
-	6,  // 27: graph.v1.LanternService.Illuminate:output_type -> graph.v1.IlluminateResponse
-	8,  // 28: graph.v1.LanternService.GetVertex:output_type -> graph.v1.GetVertexResponse
-	10, // 29: graph.v1.LanternService.PutVertex:output_type -> graph.v1.PutVertexResponse
-	12, // 30: graph.v1.LanternService.DeleteVertex:output_type -> graph.v1.DeleteVertexResponse
-	14, // 31: graph.v1.LanternService.GetEdge:output_type -> graph.v1.GetEdgeResponse
-	18, // 32: graph.v1.LanternService.AddEdge:output_type -> graph.v1.AddEdgeResponse
-	20, // 33: graph.v1.LanternService.PutEdge:output_type -> graph.v1.PutEdgeResponse
-	16, // 34: graph.v1.LanternService.DeleteEdge:output_type -> graph.v1.DeleteEdgeResponse
-	27, // [27:35] is the sub-list for method output_type
-	19, // [19:27] is the sub-list for method input_type
-	19, // [19:19] is the sub-list for extension type_name
-	19, // [19:19] is the sub-list for extension extendee
-	0,  // [0:19] is the sub-list for field type_name
+	3,  // 6: graph.v1.IlluminateResponse.graph:type_name -> graph.v1.Graph
+	1,  // 7: graph.v1.GetVertexResponse.vertex:type_name -> graph.v1.Vertex
+	1,  // 8: graph.v1.PutVertexRequest.vertices:type_name -> graph.v1.Vertex
+	2,  // 9: graph.v1.GetEdgeResponse.edge:type_name -> graph.v1.Edge
+	2,  // 10: graph.v1.AddEdgeRequest.edges:type_name -> graph.v1.Edge
+	2,  // 11: graph.v1.PutEdgeRequest.edges:type_name -> graph.v1.Edge
+	4,  // 12: graph.v1.LanternService.Illuminate:input_type -> graph.v1.IlluminateRequest
+	6,  // 13: graph.v1.LanternService.GetVertex:input_type -> graph.v1.GetVertexRequest
+	8,  // 14: graph.v1.LanternService.PutVertex:input_type -> graph.v1.PutVertexRequest
+	10, // 15: graph.v1.LanternService.DeleteVertex:input_type -> graph.v1.DeleteVertexRequest
+	12, // 16: graph.v1.LanternService.GetEdge:input_type -> graph.v1.GetEdgeRequest
+	16, // 17: graph.v1.LanternService.AddEdge:input_type -> graph.v1.AddEdgeRequest
+	18, // 18: graph.v1.LanternService.PutEdge:input_type -> graph.v1.PutEdgeRequest
+	14, // 19: graph.v1.LanternService.DeleteEdge:input_type -> graph.v1.DeleteEdgeRequest
+	5,  // 20: graph.v1.LanternService.Illuminate:output_type -> graph.v1.IlluminateResponse
+	7,  // 21: graph.v1.LanternService.GetVertex:output_type -> graph.v1.GetVertexResponse
+	9,  // 22: graph.v1.LanternService.PutVertex:output_type -> graph.v1.PutVertexResponse
+	11, // 23: graph.v1.LanternService.DeleteVertex:output_type -> graph.v1.DeleteVertexResponse
+	13, // 24: graph.v1.LanternService.GetEdge:output_type -> graph.v1.GetEdgeResponse
+	17, // 25: graph.v1.LanternService.AddEdge:output_type -> graph.v1.AddEdgeResponse
+	19, // 26: graph.v1.LanternService.PutEdge:output_type -> graph.v1.PutEdgeResponse
+	15, // 27: graph.v1.LanternService.DeleteEdge:output_type -> graph.v1.DeleteEdgeResponse
+	20, // [20:28] is the sub-list for method output_type
+	12, // [12:20] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_graph_v1_graph_proto_init() }
@@ -1462,7 +1342,7 @@ func file_graph_v1_graph_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_graph_v1_graph_proto_rawDesc), len(file_graph_v1_graph_proto_rawDesc)),
-			NumEnums:      2,
+			NumEnums:      1,
 			NumMessages:   19,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/gen/go/graph/v1/graph.pb.gw.go
+++ b/gen/go/graph/v1/graph.pb.gw.go
@@ -463,7 +463,7 @@ func RegisterLanternServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 		}
 		forward_LanternService_GetEdge_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPut, pattern_LanternService_AddEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPost, pattern_LanternService_AddEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
@@ -648,7 +648,7 @@ func RegisterLanternServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 		}
 		forward_LanternService_GetEdge_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPut, pattern_LanternService_AddEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPost, pattern_LanternService_AddEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)

--- a/gen/go/graph/v1/graph_grpc.pb.go
+++ b/gen/go/graph/v1/graph_grpc.pb.go
@@ -38,7 +38,9 @@ type LanternServiceClient interface {
 	PutVertex(ctx context.Context, in *PutVertexRequest, opts ...grpc.CallOption) (*PutVertexResponse, error)
 	DeleteVertex(ctx context.Context, in *DeleteVertexRequest, opts ...grpc.CallOption) (*DeleteVertexResponse, error)
 	GetEdge(ctx context.Context, in *GetEdgeRequest, opts ...grpc.CallOption) (*GetEdgeResponse, error)
+	// AddEdge is non-idempotent (accumulates weight). POST per REST conventions.
 	AddEdge(ctx context.Context, in *AddEdgeRequest, opts ...grpc.CallOption) (*AddEdgeResponse, error)
+	// PutEdge is idempotent (replaces weight). PUT per REST conventions.
 	PutEdge(ctx context.Context, in *PutEdgeRequest, opts ...grpc.CallOption) (*PutEdgeResponse, error)
 	DeleteEdge(ctx context.Context, in *DeleteEdgeRequest, opts ...grpc.CallOption) (*DeleteEdgeResponse, error)
 }
@@ -140,7 +142,9 @@ type LanternServiceServer interface {
 	PutVertex(context.Context, *PutVertexRequest) (*PutVertexResponse, error)
 	DeleteVertex(context.Context, *DeleteVertexRequest) (*DeleteVertexResponse, error)
 	GetEdge(context.Context, *GetEdgeRequest) (*GetEdgeResponse, error)
+	// AddEdge is non-idempotent (accumulates weight). POST per REST conventions.
 	AddEdge(context.Context, *AddEdgeRequest) (*AddEdgeResponse, error)
+	// PutEdge is idempotent (replaces weight). PUT per REST conventions.
 	PutEdge(context.Context, *PutEdgeRequest) (*PutEdgeResponse, error)
 	DeleteEdge(context.Context, *DeleteEdgeRequest) (*DeleteEdgeResponse, error)
 }

--- a/gen/openapiv2/graph/v1/graph.swagger.json
+++ b/gen/openapiv2/graph/v1/graph.swagger.json
@@ -17,7 +17,8 @@
   ],
   "paths": {
     "/v1/edges/add": {
-      "put": {
+      "post": {
+        "summary": "AddEdge is non-idempotent (accumulates weight). POST per REST conventions.",
         "operationId": "LanternService_AddEdge",
         "responses": {
           "200": {
@@ -29,13 +30,14 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
         "parameters": [
           {
             "name": "body",
+            "description": "AddEdgeRequest accumulates weight onto each (tail, head) pair: repeated\ncalls with the same endpoints sum their weights. This operation is\nnon-idempotent.",
             "in": "body",
             "required": true,
             "schema": {
@@ -50,6 +52,7 @@
     },
     "/v1/edges/put": {
       "put": {
+        "summary": "PutEdge is idempotent (replaces weight). PUT per REST conventions.",
         "operationId": "LanternService_PutEdge",
         "responses": {
           "200": {
@@ -61,13 +64,14 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
         "parameters": [
           {
             "name": "body",
+            "description": "PutEdgeRequest overwrites each (tail, head) pair, replacing any existing\nweight and expiration. This operation is idempotent.",
             "in": "body",
             "required": true,
             "schema": {
@@ -93,7 +97,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -127,7 +131,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -163,7 +167,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -227,13 +231,14 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
         "parameters": [
           {
             "name": "body",
+            "description": "PutVertexRequest writes vertices with upsert semantics: each Vertex.key\nreplaces any existing value at that key. Use the Vertex.expiration field\n(absolute time) to control TTL.",
             "in": "body",
             "required": true,
             "schema": {
@@ -259,7 +264,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -287,7 +292,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googleRpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -306,7 +311,16 @@
     }
   },
   "definitions": {
-    "googleRpcStatus": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
       "type": "object",
       "properties": {
         "code": {
@@ -325,25 +339,6 @@
         }
       }
     },
-    "graphV1Status": {
-      "type": "string",
-      "enum": [
-        "STATUS_UNSPECIFIED",
-        "STATUS_OK",
-        "STATUS_INTERNAL_SERVER_ERROR",
-        "STATUS_INVALID_REQUEST"
-      ],
-      "default": "STATUS_UNSPECIFIED"
-    },
-    "protobufAny": {
-      "type": "object",
-      "properties": {
-        "@type": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": {}
-    },
     "v1AddEdgeRequest": {
       "type": "object",
       "properties": {
@@ -354,31 +349,17 @@
             "$ref": "#/definitions/v1Edge"
           }
         }
-      }
+      },
+      "description": "AddEdgeRequest accumulates weight onto each (tail, head) pair: repeated\ncalls with the same endpoints sum their weights. This operation is\nnon-idempotent."
     },
     "v1AddEdgeResponse": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "$ref": "#/definitions/graphV1Status"
-        }
-      }
+      "type": "object"
     },
     "v1DeleteEdgeResponse": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "$ref": "#/definitions/graphV1Status"
-        }
-      }
+      "type": "object"
     },
     "v1DeleteVertexResponse": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "$ref": "#/definitions/graphV1Status"
-        }
-      }
+      "type": "object"
     },
     "v1Edge": {
       "type": "object",
@@ -412,9 +393,6 @@
       "properties": {
         "vertex": {
           "$ref": "#/definitions/v1Vertex"
-        },
-        "status": {
-          "$ref": "#/definitions/graphV1Status"
         }
       }
     },
@@ -442,9 +420,6 @@
       "properties": {
         "graph": {
           "$ref": "#/definitions/v1Graph"
-        },
-        "status": {
-          "$ref": "#/definitions/graphV1Status"
         }
       }
     },
@@ -469,15 +444,11 @@
             "$ref": "#/definitions/v1Edge"
           }
         }
-      }
+      },
+      "description": "PutEdgeRequest overwrites each (tail, head) pair, replacing any existing\nweight and expiration. This operation is idempotent."
     },
     "v1PutEdgeResponse": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "$ref": "#/definitions/graphV1Status"
-        }
-      }
+      "type": "object"
     },
     "v1PutVertexRequest": {
       "type": "object",
@@ -489,15 +460,11 @@
             "$ref": "#/definitions/v1Vertex"
           }
         }
-      }
+      },
+      "description": "PutVertexRequest writes vertices with upsert semantics: each Vertex.key\nreplaces any existing value at that key. Use the Vertex.expiration field\n(absolute time) to control TTL."
     },
     "v1PutVertexResponse": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "$ref": "#/definitions/graphV1Status"
-        }
-      }
+      "type": "object"
     },
     "v1Vertex": {
       "type": "object",

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -2,172 +2,157 @@ syntax = "proto3";
 
 package graph.v1;
 
-import "google/protobuf/timestamp.proto";
 import "google/api/annotations.proto";
+import "google/protobuf/timestamp.proto";
 
 message Vertex {
-    string key = 1;
-    google.protobuf.Timestamp expiration = 2;
-    oneof value {
-        double float64 = 10;
-        float float32 = 11;
-        int32 int32 = 12;
-        int64 int64 = 13;
-        uint32 uint32 = 14;
-        uint64 uint64 = 15;
-        bool bool = 16;
-        string string = 17;
-        bytes bytes = 18;
-        google.protobuf.Timestamp timestamp = 19;
+  string key = 1;
+  google.protobuf.Timestamp expiration = 2;
+  oneof value {
+    double float64 = 10;
+    float float32 = 11;
+    int32 int32 = 12;
+    int64 int64 = 13;
+    uint32 uint32 = 14;
+    uint64 uint64 = 15;
+    bool bool = 16;
+    string string = 17;
+    bytes bytes = 18;
+    google.protobuf.Timestamp timestamp = 19;
 
-        bool nil = 30;
-    }
+    bool nil = 30;
+  }
 }
 
 message Edge {
-    string tail = 1;
-    string head = 2;
-    float weight = 3;
-    google.protobuf.Timestamp expiration = 4;
+  string tail = 1;
+  string head = 2;
+  float weight = 3;
+  google.protobuf.Timestamp expiration = 4;
 }
 
 message Graph {
-    repeated Vertex vertices = 1;
-    repeated Edge edges = 2;
+  repeated Vertex vertices = 1;
+  repeated Edge edges = 2;
 }
 
 enum Optimization {
-    OPTIMIZATION_UNSPECIFIED = 0;
-    OPTIMIZATION_MINIMUM_SPANNING_TREE = 1;
-    OPTIMIZATION_MAXIMUM_SPANNING_TREE = 2;
-    OPTIMIZATION_SHORTEST_PATH_TREE = 3;
-    OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE = 4;
+  OPTIMIZATION_UNSPECIFIED = 0;
+  OPTIMIZATION_MINIMUM_SPANNING_TREE = 1;
+  OPTIMIZATION_MAXIMUM_SPANNING_TREE = 2;
+  OPTIMIZATION_SHORTEST_PATH_TREE = 3;
+  OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE = 4;
 }
 
 message IlluminateRequest {
-    string seed = 1;
-    uint32 step = 2;
-    uint32 k = 3;
-    bool tfidf = 4;
-    Optimization optimization = 5;
+  string seed = 1;
+  uint32 step = 2;
+  uint32 k = 3;
+  bool tfidf = 4;
+  Optimization optimization = 5;
 }
 
 message IlluminateResponse {
-    Graph graph = 1;
+  Graph graph = 1;
 }
 
 message GetVertexRequest {
-    string key = 1;
+  string key = 1;
 }
 
 message GetVertexResponse {
-    Vertex vertex = 1;
+  Vertex vertex = 1;
 }
 
 // PutVertexRequest writes vertices with upsert semantics: each Vertex.key
 // replaces any existing value at that key. Use the Vertex.expiration field
 // (absolute time) to control TTL.
 message PutVertexRequest {
-    repeated Vertex vertices = 1;
+  repeated Vertex vertices = 1;
 }
 
-message PutVertexResponse {
-}
+message PutVertexResponse {}
 
 message DeleteVertexRequest {
-    string key = 1;
+  string key = 1;
 }
 
-message DeleteVertexResponse {
-}
+message DeleteVertexResponse {}
 
 message GetEdgeRequest {
-    string tail = 1;
-    string head = 2;
+  string tail = 1;
+  string head = 2;
 }
 
 message GetEdgeResponse {
-    Edge edge = 1;
+  Edge edge = 1;
 }
 
 message DeleteEdgeRequest {
-    string tail = 1;
-    string head = 2;
+  string tail = 1;
+  string head = 2;
 }
 
-message DeleteEdgeResponse {
-}
+message DeleteEdgeResponse {}
 
 // AddEdgeRequest accumulates weight onto each (tail, head) pair: repeated
 // calls with the same endpoints sum their weights. This operation is
 // non-idempotent.
 message AddEdgeRequest {
-    repeated Edge edges = 1;
+  repeated Edge edges = 1;
 }
 
-message AddEdgeResponse {
-}
+message AddEdgeResponse {}
 
 // PutEdgeRequest overwrites each (tail, head) pair, replacing any existing
 // weight and expiration. This operation is idempotent.
 message PutEdgeRequest {
-    repeated Edge edges = 1;
+  repeated Edge edges = 1;
 }
 
-message PutEdgeResponse {
-}
+message PutEdgeResponse {}
 
 service LanternService {
-    rpc Illuminate (IlluminateRequest) returns (IlluminateResponse) {
-        option (google.api.http) = {
-            get: "/v1/illuminate/{seed}"
-        };
-    }
+  rpc Illuminate(IlluminateRequest) returns (IlluminateResponse) {
+    option (google.api.http) = {get: "/v1/illuminate/{seed}"};
+  }
 
-    rpc GetVertex (GetVertexRequest) returns (GetVertexResponse) {
-        option (google.api.http) = {
-            get: "/v1/vertices/{key}"
-        };
-    }
+  rpc GetVertex(GetVertexRequest) returns (GetVertexResponse) {
+    option (google.api.http) = {get: "/v1/vertices/{key}"};
+  }
 
-    rpc PutVertex (PutVertexRequest) returns (PutVertexResponse) {
-        option (google.api.http) = {
-            put: "/v1/vertices"
-            body: "*"
-        };
-    }
+  rpc PutVertex(PutVertexRequest) returns (PutVertexResponse) {
+    option (google.api.http) = {
+      put: "/v1/vertices"
+      body: "*"
+    };
+  }
 
-    rpc DeleteVertex(DeleteVertexRequest) returns (DeleteVertexResponse) {
-        option (google.api.http) = {
-            delete: "/v1/vertices/{key}"
-        };
-    }
+  rpc DeleteVertex(DeleteVertexRequest) returns (DeleteVertexResponse) {
+    option (google.api.http) = {delete: "/v1/vertices/{key}"};
+  }
 
-    rpc GetEdge (GetEdgeRequest) returns (GetEdgeResponse) {
-        option (google.api.http) = {
-            get: "/v1/edges/{tail}/{head}"
-        };
-    }
+  rpc GetEdge(GetEdgeRequest) returns (GetEdgeResponse) {
+    option (google.api.http) = {get: "/v1/edges/{tail}/{head}"};
+  }
 
-    // AddEdge is non-idempotent (accumulates weight). POST per REST conventions.
-    rpc AddEdge (AddEdgeRequest) returns (AddEdgeResponse) {
-        option (google.api.http) = {
-            post: "/v1/edges/add"
-            body: "*"
-        };
-    }
+  // AddEdge is non-idempotent (accumulates weight). POST per REST conventions.
+  rpc AddEdge(AddEdgeRequest) returns (AddEdgeResponse) {
+    option (google.api.http) = {
+      post: "/v1/edges/add"
+      body: "*"
+    };
+  }
 
-    // PutEdge is idempotent (replaces weight). PUT per REST conventions.
-    rpc PutEdge (PutEdgeRequest) returns (PutEdgeResponse) {
-        option (google.api.http) = {
-            put: "/v1/edges/put"
-            body: "*"
-        };
-    }
+  // PutEdge is idempotent (replaces weight). PUT per REST conventions.
+  rpc PutEdge(PutEdgeRequest) returns (PutEdgeResponse) {
+    option (google.api.http) = {
+      put: "/v1/edges/put"
+      body: "*"
+    };
+  }
 
-    rpc DeleteEdge(DeleteEdgeRequest) returns (DeleteEdgeResponse) {
-        option (google.api.http) = {
-            delete: "/v1/edges/{tail}/{head}"
-        };
-    }
+  rpc DeleteEdge(DeleteEdgeRequest) returns (DeleteEdgeResponse) {
+    option (google.api.http) = {delete: "/v1/edges/{tail}/{head}"};
+  }
 }

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -44,13 +44,6 @@ enum Optimization {
     OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE = 4;
 }
 
-enum Status {
-    STATUS_UNSPECIFIED = 0;
-    STATUS_OK = 1;
-    STATUS_INTERNAL_SERVER_ERROR = 2;
-    STATUS_INVALID_REQUEST = 3;
-}
-
 message IlluminateRequest {
     string seed = 1;
     uint32 step = 2;
@@ -61,7 +54,6 @@ message IlluminateRequest {
 
 message IlluminateResponse {
     Graph graph = 1;
-    Status status = 2;
 }
 
 message GetVertexRequest {
@@ -70,15 +62,16 @@ message GetVertexRequest {
 
 message GetVertexResponse {
     Vertex vertex = 1;
-    Status status = 2;
 }
 
+// PutVertexRequest writes vertices with upsert semantics: each Vertex.key
+// replaces any existing value at that key. Use the Vertex.expiration field
+// (absolute time) to control TTL.
 message PutVertexRequest {
     repeated Vertex vertices = 1;
 }
 
 message PutVertexResponse {
-    Status status = 1;
 }
 
 message DeleteVertexRequest {
@@ -86,7 +79,6 @@ message DeleteVertexRequest {
 }
 
 message DeleteVertexResponse {
-    Status status = 1;
 }
 
 message GetEdgeRequest {
@@ -104,23 +96,25 @@ message DeleteEdgeRequest {
 }
 
 message DeleteEdgeResponse {
-    Status status = 1;
 }
 
+// AddEdgeRequest accumulates weight onto each (tail, head) pair: repeated
+// calls with the same endpoints sum their weights. This operation is
+// non-idempotent.
 message AddEdgeRequest {
     repeated Edge edges = 1;
 }
 
 message AddEdgeResponse {
-    Status status = 1;
 }
 
+// PutEdgeRequest overwrites each (tail, head) pair, replacing any existing
+// weight and expiration. This operation is idempotent.
 message PutEdgeRequest {
     repeated Edge edges = 1;
 }
 
 message PutEdgeResponse {
-    Status status = 1;
 }
 
 service LanternService {
@@ -155,13 +149,15 @@ service LanternService {
         };
     }
 
+    // AddEdge is non-idempotent (accumulates weight). POST per REST conventions.
     rpc AddEdge (AddEdgeRequest) returns (AddEdgeResponse) {
         option (google.api.http) = {
-            put: "/v1/edges/add"
+            post: "/v1/edges/add"
             body: "*"
         };
     }
 
+    // PutEdge is idempotent (replaces weight). PUT per REST conventions.
     rpc PutEdge (PutEdgeRequest) returns (PutEdgeResponse) {
         option (google.api.http) = {
             put: "/v1/edges/put"

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -69,8 +69,7 @@ func (s *LanternService) Illuminate(_ context.Context, request *IlluminateReques
 	}
 
 	return &IlluminateResponse{
-		Graph:  &Graph{Vertices: vertices, Edges: edges},
-		Status: Status_STATUS_OK,
+		Graph: &Graph{Vertices: vertices, Edges: edges},
 	}, nil
 }
 
@@ -82,22 +81,21 @@ func (s *LanternService) GetVertex(_ context.Context, request *GetVertexRequest)
 	if v == nil {
 		return &GetVertexResponse{
 			Vertex: &Vertex{Key: request.GetKey(), Value: &Vertex_Nil{Nil: true}},
-			Status: Status_STATUS_OK,
 		}, nil
 	}
-	return &GetVertexResponse{Vertex: v, Status: Status_STATUS_OK}, nil
+	return &GetVertexResponse{Vertex: v}, nil
 }
 
 func (s *LanternService) PutVertex(_ context.Context, request *PutVertexRequest) (*PutVertexResponse, error) {
 	for _, v := range request.Vertices {
 		s.cache.AddVertexWithExpiration(v.Key, v, v.Expiration.AsTime())
 	}
-	return &PutVertexResponse{Status: Status_STATUS_OK}, nil
+	return &PutVertexResponse{}, nil
 }
 
 func (s *LanternService) DeleteVertex(_ context.Context, in *DeleteVertexRequest) (*DeleteVertexResponse, error) {
 	s.cache.DeleteVertex(in.GetKey())
-	return &DeleteVertexResponse{Status: Status_STATUS_OK}, nil
+	return &DeleteVertexResponse{}, nil
 }
 
 func (s *LanternService) GetEdge(_ context.Context, request *GetEdgeRequest) (*GetEdgeResponse, error) {
@@ -114,7 +112,7 @@ func (s *LanternService) AddEdge(_ context.Context, request *AddEdgeRequest) (*A
 	for _, e := range request.Edges {
 		s.cache.AddEdgeWithExpiration(e.Tail, e.Head, e.Weight, e.Expiration.AsTime())
 	}
-	return &AddEdgeResponse{Status: Status_STATUS_OK}, nil
+	return &AddEdgeResponse{}, nil
 }
 
 func (s *LanternService) PutEdge(_ context.Context, request *PutEdgeRequest) (*PutEdgeResponse, error) {
@@ -122,12 +120,12 @@ func (s *LanternService) PutEdge(_ context.Context, request *PutEdgeRequest) (*P
 		s.cache.DeleteEdge(e.Tail, e.Head)
 		s.cache.AddEdgeWithExpiration(e.Tail, e.Head, e.Weight, e.Expiration.AsTime())
 	}
-	return &PutEdgeResponse{Status: Status_STATUS_OK}, nil
+	return &PutEdgeResponse{}, nil
 }
 
 func (s *LanternService) DeleteEdge(_ context.Context, in *DeleteEdgeRequest) (*DeleteEdgeResponse, error) {
 	s.cache.DeleteEdge(in.Tail, in.Head)
-	return &DeleteEdgeResponse{Status: Status_STATUS_OK}, nil
+	return &DeleteEdgeResponse{}, nil
 }
 
 // LanternServer ties the gRPC server, its listener, and the cache GC loop

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -41,9 +41,6 @@ func TestLanternService_PutAndGetVertex(t *testing.T) {
 	if got := resp.Vertex.GetString_(); got != "hello" {
 		t.Errorf("GetVertex value = %q, want \"hello\"", got)
 	}
-	if resp.Status != pb.Status_STATUS_OK {
-		t.Errorf("status = %v, want OK", resp.Status)
-	}
 }
 
 func TestLanternService_GetVertex_NotFound(t *testing.T) {


### PR DESCRIPTION
Sweep of P0–P2 fixes surfaced during the API review.

### Proto / server (commit 1)
- **Drop `Status` enum and all `status` response fields.** Errors already travel as gRPC status codes; an in-payload OK/error flag was dead weight that every client had to ignore.
- **`AddEdge` HTTP binding changed from `PUT` to `POST`.** `AddEdge` accumulates weight on repeat calls — it is not idempotent, so PUT was semantically wrong (PutEdge keeps PUT).
- **Doc comments on `AddEdge` vs `PutEdge`** so SDK consumers do not have to read the server impl to know which one accumulates.

### Client value layer (commit 2)
- `nativeVertex.asVertex` now accepts all Go integer widths (int8/16/32/64, uint, uint8/16/32/64). Narrow ints promote to Int32/Uint32 → lossless round-trip.
- New `ErrOverflow` sentinel. `IntValue` / `UIntValue` now do cross-width reads and surface overflow explicitly instead of silently truncating.
- New `VertexKind` enum + `Vertex.Kind()` for dispatch without poking at the generated oneof wrapper.
- New `Vertex.ExpirationTime()` helper (nil-safe).

### Client SDK + CLI (commit 3)
- `ErrNotFound` sentinel wraps `codes.NotFound` → `errors.Is(err, client.ErrNotFound)`.
- `GetEdge` now returns `*Edge` (Weight **and** Expiration), replacing the float32-only return that dropped the server-supplied expiration.
- Batch APIs: `PutVertices`, `AddEdges`, `PutEdges`. The proto already accepts repeated payloads; the SDK now exposes that.
- Absolute-time variants: `PutVertexAt`, `AddEdgeAt`, `PutEdgeAt`.
- `Illuminate` step/k are `uint32` (matching proto); new `IlluminateWithOptimization` exposes the previously-ignored Optimization param. Five `Optimization*` consts re-exported.
- Doc comments on every exported method explaining verb semantics.
- CLI and example updated to match.

### Breaking changes
- `GetEdge` return type (`float32 → *Edge`).
- `Illuminate` step/k types (`int → uint32`).
- `Status` enum removal in proto (responses are smaller; client code that ignored `.Status` is unaffected).

### Verification
- `go build ./...` ✓
- `go vet ./...` ✓
- `go test ./...` ✓ (existing service + client suites plus new value tests for ErrOverflow / Kind / integer-width round-trips)