### PR TITLE
feat: batch delete RPCs, gzip, govulncheck, SIGTERM

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -93,3 +93,17 @@ jobs:
             echo "::error::generated files are stale; run 'go generate ./...' and commit the result"
             exit 1
           fi
+
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          check-latest: true
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck
+        run: govulncheck ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,8 @@ USER lantern
 # 6380 = gRPC, 9090 = Prometheus /metrics + /healthz + /readyz
 EXPOSE 6380 9090
 
+# Be explicit: the server installs SIGTERM/SIGINT handlers; make sure the
+# container runtime forwards SIGTERM (not the alpine default SIGQUIT) to PID 1.
+STOPSIGNAL SIGTERM
+
 ENTRYPOINT ["/app/lantern"]

--- a/README.md
+++ b/README.md
@@ -195,10 +195,12 @@ Defined in [proto/graph/v1/graph.proto](proto/graph/v1/graph.proto), served by
 | `PutVertex` | Upsert one or more vertices with TTL | Last write wins |
 | `GetVertex` | Fetch a vertex by key | `NotFound` if expired/missing |
 | `DeleteVertex` | Remove a vertex | Edges to/from it are GC'd on next `Watch` tick |
+| `DeleteVertices` | Batch remove vertices in one round-trip | SDK auto-chunks at `WithBatchChunkSize`; idempotent (retried automatically) |
 | `AddEdge` | **Append** a weighted contribution | Not idempotent — see §1.2 above |
 | `PutEdge` | Idempotent replace (delete + add) | Use when you want one-and-only-one weight |
 | `GetEdge` | Read current live weight | Sum of unexpired contributions |
 | `DeleteEdge` | Remove an edge outright | |
+| `DeleteEdges` | Batch remove edges in one round-trip | Takes `[]EdgeRef{Tail, Head}`; SDK auto-chunks; idempotent |
 | `Illuminate` | Walk the graph from a seed | `step`, `k`, `tfidf`, and `Optimization` (none / MST / max-ST / SPT / inverse-SPT) |
 
 Vertices auto-materialize on `AddEdge`/`PutEdge` if the endpoint key does not

--- a/client/client.go
+++ b/client/client.go
@@ -199,6 +199,24 @@ func (l *Lantern) DeleteVertex(ctx context.Context, key string) error {
 	return err
 }
 
+// DeleteVertices removes a batch of vertices. Automatically chunked to
+// respect the server's MaxBatchSize cap. Edges incident to removed vertices
+// are reaped lazily by the server's GC loop.
+func (l *Lantern) DeleteVertices(ctx context.Context, keys []string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	for _, chunk := range chunkSlice(keys, l.opts.batchChunkSize) {
+		ctx, cancel := l.applyTimeout(ctx)
+		_, err := l.client.DeleteVertices(ctx, &pb.DeleteVerticesRequest{Keys: chunk})
+		cancel()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // GetEdge fetches the edge weight (and any expiration) between tail and head.
 func (l *Lantern) GetEdge(ctx context.Context, tail string, head string) (*Edge, error) {
 	ctx, cancel := l.applyTimeout(ctx)
@@ -280,6 +298,33 @@ func (l *Lantern) DeleteEdge(ctx context.Context, tail string, head string) erro
 	defer cancel()
 	_, err := l.client.DeleteEdge(ctx, &pb.DeleteEdgeRequest{Tail: tail, Head: head})
 	return err
+}
+
+// EdgeRef identifies an edge by its (tail, head) pair without weight.
+// Used by DeleteEdges.
+type EdgeRef struct {
+	Tail string
+	Head string
+}
+
+// DeleteEdges removes a batch of edges. Automatically chunked.
+func (l *Lantern) DeleteEdges(ctx context.Context, refs []EdgeRef) error {
+	if len(refs) == 0 {
+		return nil
+	}
+	keys := make([]*pb.EdgeKey, 0, len(refs))
+	for _, r := range refs {
+		keys = append(keys, &pb.EdgeKey{Tail: r.Tail, Head: r.Head})
+	}
+	for _, chunk := range chunkSlice(keys, l.opts.batchChunkSize) {
+		ctx, cancel := l.applyTimeout(ctx)
+		_, err := l.client.DeleteEdges(ctx, &pb.DeleteEdgesRequest{Edges: chunk})
+		cancel()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Illuminate runs a k-bounded BFS from seed, returning the resulting subgraph.

--- a/client/options.go
+++ b/client/options.go
@@ -5,6 +5,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	_ "google.golang.org/grpc/encoding/gzip" // register gzip so WithCompression("gzip") works
 )
 
 // defaultServiceConfig enables transparent gRPC retries on idempotent RPCs.
@@ -20,6 +21,8 @@ const defaultServiceConfig = `{
         {"service": "graph.v1.LanternService", "method": "PutEdge"},
         {"service": "graph.v1.LanternService", "method": "DeleteVertex"},
         {"service": "graph.v1.LanternService", "method": "DeleteEdge"},
+        {"service": "graph.v1.LanternService", "method": "DeleteVertices"},
+        {"service": "graph.v1.LanternService", "method": "DeleteEdges"},
         {"service": "graph.v1.LanternService", "method": "Illuminate"}
       ],
       "retryPolicy": {
@@ -84,6 +87,18 @@ func WithBatchChunkSize(n int) Option {
 	return func(o *options) {
 		if n > 0 {
 			o.batchChunkSize = n
+		}
+	}
+}
+
+// WithCompression enables a per-call default compressor (e.g. "gzip"). The
+// named compressor must be registered (gzip is registered automatically by
+// this package). Pass "" to disable.
+func WithCompression(name string) Option {
+	return func(o *options) {
+		if name != "" {
+			o.dialOptions = append(o.dialOptions,
+				grpc.WithDefaultCallOptions(grpc.UseCompressor(name)))
 		}
 	}
 }

--- a/gen/go/graph/v1/graph.pb.go
+++ b/gen/go/graph/v1/graph.pb.go
@@ -829,6 +829,98 @@ func (*DeleteVertexResponse) Descriptor() ([]byte, []int) {
 	return file_graph_v1_graph_proto_rawDescGZIP(), []int{10}
 }
 
+// DeleteVerticesRequest removes several vertices in one round trip. Same
+// cascade semantics as DeleteVertex (edges reaped lazily by the GC loop).
+// Subject to the same MaxBatchSize / MaxKeyLen guard rails as the put RPCs.
+type DeleteVerticesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Keys          []string               `protobuf:"bytes,1,rep,name=keys,proto3" json:"keys,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteVerticesRequest) Reset() {
+	*x = DeleteVerticesRequest{}
+	mi := &file_graph_v1_graph_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteVerticesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteVerticesRequest) ProtoMessage() {}
+
+func (x *DeleteVerticesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteVerticesRequest.ProtoReflect.Descriptor instead.
+func (*DeleteVerticesRequest) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *DeleteVerticesRequest) GetKeys() []string {
+	if x != nil {
+		return x.Keys
+	}
+	return nil
+}
+
+type DeleteVerticesResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Number of keys the server attempted to delete (equals len(keys) on success).
+	Deleted       int32 `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteVerticesResponse) Reset() {
+	*x = DeleteVerticesResponse{}
+	mi := &file_graph_v1_graph_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteVerticesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteVerticesResponse) ProtoMessage() {}
+
+func (x *DeleteVerticesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteVerticesResponse.ProtoReflect.Descriptor instead.
+func (*DeleteVerticesResponse) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *DeleteVerticesResponse) GetDeleted() int32 {
+	if x != nil {
+		return x.Deleted
+	}
+	return 0
+}
+
 type GetEdgeRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Tail          string                 `protobuf:"bytes,1,opt,name=tail,proto3" json:"tail,omitempty"`
@@ -839,7 +931,7 @@ type GetEdgeRequest struct {
 
 func (x *GetEdgeRequest) Reset() {
 	*x = GetEdgeRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[11]
+	mi := &file_graph_v1_graph_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -851,7 +943,7 @@ func (x *GetEdgeRequest) String() string {
 func (*GetEdgeRequest) ProtoMessage() {}
 
 func (x *GetEdgeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[11]
+	mi := &file_graph_v1_graph_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -864,7 +956,7 @@ func (x *GetEdgeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEdgeRequest.ProtoReflect.Descriptor instead.
 func (*GetEdgeRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{11}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *GetEdgeRequest) GetTail() string {
@@ -890,7 +982,7 @@ type GetEdgeResponse struct {
 
 func (x *GetEdgeResponse) Reset() {
 	*x = GetEdgeResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[12]
+	mi := &file_graph_v1_graph_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -902,7 +994,7 @@ func (x *GetEdgeResponse) String() string {
 func (*GetEdgeResponse) ProtoMessage() {}
 
 func (x *GetEdgeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[12]
+	mi := &file_graph_v1_graph_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -915,7 +1007,7 @@ func (x *GetEdgeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEdgeResponse.ProtoReflect.Descriptor instead.
 func (*GetEdgeResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{12}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *GetEdgeResponse) GetEdge() *Edge {
@@ -935,7 +1027,7 @@ type DeleteEdgeRequest struct {
 
 func (x *DeleteEdgeRequest) Reset() {
 	*x = DeleteEdgeRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[13]
+	mi := &file_graph_v1_graph_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -947,7 +1039,7 @@ func (x *DeleteEdgeRequest) String() string {
 func (*DeleteEdgeRequest) ProtoMessage() {}
 
 func (x *DeleteEdgeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[13]
+	mi := &file_graph_v1_graph_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -960,7 +1052,7 @@ func (x *DeleteEdgeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEdgeRequest.ProtoReflect.Descriptor instead.
 func (*DeleteEdgeRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{13}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *DeleteEdgeRequest) GetTail() string {
@@ -985,7 +1077,7 @@ type DeleteEdgeResponse struct {
 
 func (x *DeleteEdgeResponse) Reset() {
 	*x = DeleteEdgeResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[14]
+	mi := &file_graph_v1_graph_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -997,7 +1089,7 @@ func (x *DeleteEdgeResponse) String() string {
 func (*DeleteEdgeResponse) ProtoMessage() {}
 
 func (x *DeleteEdgeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[14]
+	mi := &file_graph_v1_graph_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1010,7 +1102,151 @@ func (x *DeleteEdgeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEdgeResponse.ProtoReflect.Descriptor instead.
 func (*DeleteEdgeResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{14}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{16}
+}
+
+// EdgeKey identifies an edge by its (tail, head) pair without weight.
+type EdgeKey struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Tail          string                 `protobuf:"bytes,1,opt,name=tail,proto3" json:"tail,omitempty"`
+	Head          string                 `protobuf:"bytes,2,opt,name=head,proto3" json:"head,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EdgeKey) Reset() {
+	*x = EdgeKey{}
+	mi := &file_graph_v1_graph_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EdgeKey) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EdgeKey) ProtoMessage() {}
+
+func (x *EdgeKey) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EdgeKey.ProtoReflect.Descriptor instead.
+func (*EdgeKey) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *EdgeKey) GetTail() string {
+	if x != nil {
+		return x.Tail
+	}
+	return ""
+}
+
+func (x *EdgeKey) GetHead() string {
+	if x != nil {
+		return x.Head
+	}
+	return ""
+}
+
+// DeleteEdgesRequest removes several edges in one round trip. Subject to the
+// MaxBatchSize / MaxKeyLen guard rails.
+type DeleteEdgesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Edges         []*EdgeKey             `protobuf:"bytes,1,rep,name=edges,proto3" json:"edges,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteEdgesRequest) Reset() {
+	*x = DeleteEdgesRequest{}
+	mi := &file_graph_v1_graph_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteEdgesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteEdgesRequest) ProtoMessage() {}
+
+func (x *DeleteEdgesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteEdgesRequest.ProtoReflect.Descriptor instead.
+func (*DeleteEdgesRequest) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *DeleteEdgesRequest) GetEdges() []*EdgeKey {
+	if x != nil {
+		return x.Edges
+	}
+	return nil
+}
+
+type DeleteEdgesResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Number of edges the server attempted to delete (equals len(edges) on success).
+	Deleted       int32 `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteEdgesResponse) Reset() {
+	*x = DeleteEdgesResponse{}
+	mi := &file_graph_v1_graph_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteEdgesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteEdgesResponse) ProtoMessage() {}
+
+func (x *DeleteEdgesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteEdgesResponse.ProtoReflect.Descriptor instead.
+func (*DeleteEdgesResponse) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *DeleteEdgesResponse) GetDeleted() int32 {
+	if x != nil {
+		return x.Deleted
+	}
+	return 0
 }
 
 // AddEdgeRequest accumulates weight onto each (tail, head) pair: repeated
@@ -1025,7 +1261,7 @@ type AddEdgeRequest struct {
 
 func (x *AddEdgeRequest) Reset() {
 	*x = AddEdgeRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[15]
+	mi := &file_graph_v1_graph_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1037,7 +1273,7 @@ func (x *AddEdgeRequest) String() string {
 func (*AddEdgeRequest) ProtoMessage() {}
 
 func (x *AddEdgeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[15]
+	mi := &file_graph_v1_graph_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1050,7 +1286,7 @@ func (x *AddEdgeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddEdgeRequest.ProtoReflect.Descriptor instead.
 func (*AddEdgeRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{15}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *AddEdgeRequest) GetEdges() []*Edge {
@@ -1070,7 +1306,7 @@ type AddEdgeResponse struct {
 
 func (x *AddEdgeResponse) Reset() {
 	*x = AddEdgeResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[16]
+	mi := &file_graph_v1_graph_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1082,7 +1318,7 @@ func (x *AddEdgeResponse) String() string {
 func (*AddEdgeResponse) ProtoMessage() {}
 
 func (x *AddEdgeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[16]
+	mi := &file_graph_v1_graph_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1095,7 +1331,7 @@ func (x *AddEdgeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddEdgeResponse.ProtoReflect.Descriptor instead.
 func (*AddEdgeResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{16}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *AddEdgeResponse) GetWritten() int32 {
@@ -1116,7 +1352,7 @@ type PutEdgeRequest struct {
 
 func (x *PutEdgeRequest) Reset() {
 	*x = PutEdgeRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[17]
+	mi := &file_graph_v1_graph_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1128,7 +1364,7 @@ func (x *PutEdgeRequest) String() string {
 func (*PutEdgeRequest) ProtoMessage() {}
 
 func (x *PutEdgeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[17]
+	mi := &file_graph_v1_graph_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1141,7 +1377,7 @@ func (x *PutEdgeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutEdgeRequest.ProtoReflect.Descriptor instead.
 func (*PutEdgeRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{17}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *PutEdgeRequest) GetEdges() []*Edge {
@@ -1161,7 +1397,7 @@ type PutEdgeResponse struct {
 
 func (x *PutEdgeResponse) Reset() {
 	*x = PutEdgeResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[18]
+	mi := &file_graph_v1_graph_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1173,7 +1409,7 @@ func (x *PutEdgeResponse) String() string {
 func (*PutEdgeResponse) ProtoMessage() {}
 
 func (x *PutEdgeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[18]
+	mi := &file_graph_v1_graph_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1186,7 +1422,7 @@ func (x *PutEdgeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutEdgeResponse.ProtoReflect.Descriptor instead.
 func (*PutEdgeResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{18}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *PutEdgeResponse) GetWritten() int32 {
@@ -1247,7 +1483,11 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\awritten\x18\x01 \x01(\x05R\awritten\"'\n" +
 	"\x13DeleteVertexRequest\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\"\x16\n" +
-	"\x14DeleteVertexResponse\"8\n" +
+	"\x14DeleteVertexResponse\"+\n" +
+	"\x15DeleteVerticesRequest\x12\x12\n" +
+	"\x04keys\x18\x01 \x03(\tR\x04keys\"2\n" +
+	"\x16DeleteVerticesResponse\x12\x18\n" +
+	"\adeleted\x18\x01 \x01(\x05R\adeleted\"8\n" +
 	"\x0eGetEdgeRequest\x12\x12\n" +
 	"\x04tail\x18\x01 \x01(\tR\x04tail\x12\x12\n" +
 	"\x04head\x18\x02 \x01(\tR\x04head\"5\n" +
@@ -1256,7 +1496,14 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\x11DeleteEdgeRequest\x12\x12\n" +
 	"\x04tail\x18\x01 \x01(\tR\x04tail\x12\x12\n" +
 	"\x04head\x18\x02 \x01(\tR\x04head\"\x14\n" +
-	"\x12DeleteEdgeResponse\"6\n" +
+	"\x12DeleteEdgeResponse\"1\n" +
+	"\aEdgeKey\x12\x12\n" +
+	"\x04tail\x18\x01 \x01(\tR\x04tail\x12\x12\n" +
+	"\x04head\x18\x02 \x01(\tR\x04head\"=\n" +
+	"\x12DeleteEdgesRequest\x12'\n" +
+	"\x05edges\x18\x01 \x03(\v2\x11.graph.v1.EdgeKeyR\x05edges\"/\n" +
+	"\x13DeleteEdgesResponse\x12\x18\n" +
+	"\adeleted\x18\x01 \x01(\x05R\adeleted\"6\n" +
 	"\x0eAddEdgeRequest\x12$\n" +
 	"\x05edges\x18\x01 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\"+\n" +
 	"\x0fAddEdgeResponse\x12\x18\n" +
@@ -1270,18 +1517,20 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\"OPTIMIZATION_MINIMUM_SPANNING_TREE\x10\x01\x12&\n" +
 	"\"OPTIMIZATION_MAXIMUM_SPANNING_TREE\x10\x02\x12#\n" +
 	"\x1fOPTIMIZATION_SHORTEST_PATH_TREE\x10\x03\x12+\n" +
-	"'OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE\x10\x042\xa3\x06\n" +
+	"'OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE\x10\x042\x81\b\n" +
 	"\x0eLanternService\x12f\n" +
 	"\n" +
 	"Illuminate\x12\x1b.graph.v1.IlluminateRequest\x1a\x1c.graph.v1.IlluminateResponse\"\x1d\x82\xd3\xe4\x93\x02\x17\x12\x15/v1/illuminate/{seed}\x12`\n" +
 	"\tGetVertex\x12\x1a.graph.v1.GetVertexRequest\x1a\x1b.graph.v1.GetVertexResponse\"\x1a\x82\xd3\xe4\x93\x02\x14\x12\x12/v1/vertices/{key}\x12]\n" +
 	"\tPutVertex\x12\x1a.graph.v1.PutVertexRequest\x1a\x1b.graph.v1.PutVertexResponse\"\x17\x82\xd3\xe4\x93\x02\x11:\x01*\x1a\f/v1/vertices\x12i\n" +
-	"\fDeleteVertex\x12\x1d.graph.v1.DeleteVertexRequest\x1a\x1e.graph.v1.DeleteVertexResponse\"\x1a\x82\xd3\xe4\x93\x02\x14*\x12/v1/vertices/{key}\x12_\n" +
+	"\fDeleteVertex\x12\x1d.graph.v1.DeleteVertexRequest\x1a\x1e.graph.v1.DeleteVertexResponse\"\x1a\x82\xd3\xe4\x93\x02\x14*\x12/v1/vertices/{key}\x12s\n" +
+	"\x0eDeleteVertices\x12\x1f.graph.v1.DeleteVerticesRequest\x1a .graph.v1.DeleteVerticesResponse\"\x1e\x82\xd3\xe4\x93\x02\x18:\x01*\"\x13/v1/vertices/delete\x12_\n" +
 	"\aGetEdge\x12\x18.graph.v1.GetEdgeRequest\x1a\x19.graph.v1.GetEdgeResponse\"\x1f\x82\xd3\xe4\x93\x02\x19\x12\x17/v1/edges/{tail}/{head}\x12X\n" +
 	"\aAddEdge\x12\x18.graph.v1.AddEdgeRequest\x1a\x19.graph.v1.AddEdgeResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\"\r/v1/edges/add\x12X\n" +
 	"\aPutEdge\x12\x18.graph.v1.PutEdgeRequest\x1a\x19.graph.v1.PutEdgeResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\x1a\r/v1/edges/put\x12h\n" +
 	"\n" +
-	"DeleteEdge\x12\x1b.graph.v1.DeleteEdgeRequest\x1a\x1c.graph.v1.DeleteEdgeResponse\"\x1f\x82\xd3\xe4\x93\x02\x19*\x17/v1/edges/{tail}/{head}B\x94\x01\n" +
+	"DeleteEdge\x12\x1b.graph.v1.DeleteEdgeRequest\x1a\x1c.graph.v1.DeleteEdgeResponse\"\x1f\x82\xd3\xe4\x93\x02\x19*\x17/v1/edges/{tail}/{head}\x12g\n" +
+	"\vDeleteEdges\x12\x1c.graph.v1.DeleteEdgesRequest\x1a\x1d.graph.v1.DeleteEdgesResponse\"\x1b\x82\xd3\xe4\x93\x02\x15:\x01*\"\x10/v1/edges/deleteB\x94\x01\n" +
 	"\fcom.graph.v1B\n" +
 	"GraphProtoP\x01Z7github.com/anaregdesign/lantern/gen/go/graph/v1;graphv1\xa2\x02\x03GXX\xaa\x02\bGraph.V1\xca\x02\bGraph\\V1\xe2\x02\x14Graph\\V1\\GPBMetadata\xea\x02\tGraph::V1b\x06proto3"
 
@@ -1298,34 +1547,39 @@ func file_graph_v1_graph_proto_rawDescGZIP() []byte {
 }
 
 var file_graph_v1_graph_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_graph_v1_graph_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
+var file_graph_v1_graph_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_graph_v1_graph_proto_goTypes = []any{
-	(Optimization)(0),             // 0: graph.v1.Optimization
-	(*Vertex)(nil),                // 1: graph.v1.Vertex
-	(*Edge)(nil),                  // 2: graph.v1.Edge
-	(*Graph)(nil),                 // 3: graph.v1.Graph
-	(*IlluminateRequest)(nil),     // 4: graph.v1.IlluminateRequest
-	(*IlluminateResponse)(nil),    // 5: graph.v1.IlluminateResponse
-	(*GetVertexRequest)(nil),      // 6: graph.v1.GetVertexRequest
-	(*GetVertexResponse)(nil),     // 7: graph.v1.GetVertexResponse
-	(*PutVertexRequest)(nil),      // 8: graph.v1.PutVertexRequest
-	(*PutVertexResponse)(nil),     // 9: graph.v1.PutVertexResponse
-	(*DeleteVertexRequest)(nil),   // 10: graph.v1.DeleteVertexRequest
-	(*DeleteVertexResponse)(nil),  // 11: graph.v1.DeleteVertexResponse
-	(*GetEdgeRequest)(nil),        // 12: graph.v1.GetEdgeRequest
-	(*GetEdgeResponse)(nil),       // 13: graph.v1.GetEdgeResponse
-	(*DeleteEdgeRequest)(nil),     // 14: graph.v1.DeleteEdgeRequest
-	(*DeleteEdgeResponse)(nil),    // 15: graph.v1.DeleteEdgeResponse
-	(*AddEdgeRequest)(nil),        // 16: graph.v1.AddEdgeRequest
-	(*AddEdgeResponse)(nil),       // 17: graph.v1.AddEdgeResponse
-	(*PutEdgeRequest)(nil),        // 18: graph.v1.PutEdgeRequest
-	(*PutEdgeResponse)(nil),       // 19: graph.v1.PutEdgeResponse
-	(*timestamppb.Timestamp)(nil), // 20: google.protobuf.Timestamp
+	(Optimization)(0),              // 0: graph.v1.Optimization
+	(*Vertex)(nil),                 // 1: graph.v1.Vertex
+	(*Edge)(nil),                   // 2: graph.v1.Edge
+	(*Graph)(nil),                  // 3: graph.v1.Graph
+	(*IlluminateRequest)(nil),      // 4: graph.v1.IlluminateRequest
+	(*IlluminateResponse)(nil),     // 5: graph.v1.IlluminateResponse
+	(*GetVertexRequest)(nil),       // 6: graph.v1.GetVertexRequest
+	(*GetVertexResponse)(nil),      // 7: graph.v1.GetVertexResponse
+	(*PutVertexRequest)(nil),       // 8: graph.v1.PutVertexRequest
+	(*PutVertexResponse)(nil),      // 9: graph.v1.PutVertexResponse
+	(*DeleteVertexRequest)(nil),    // 10: graph.v1.DeleteVertexRequest
+	(*DeleteVertexResponse)(nil),   // 11: graph.v1.DeleteVertexResponse
+	(*DeleteVerticesRequest)(nil),  // 12: graph.v1.DeleteVerticesRequest
+	(*DeleteVerticesResponse)(nil), // 13: graph.v1.DeleteVerticesResponse
+	(*GetEdgeRequest)(nil),         // 14: graph.v1.GetEdgeRequest
+	(*GetEdgeResponse)(nil),        // 15: graph.v1.GetEdgeResponse
+	(*DeleteEdgeRequest)(nil),      // 16: graph.v1.DeleteEdgeRequest
+	(*DeleteEdgeResponse)(nil),     // 17: graph.v1.DeleteEdgeResponse
+	(*EdgeKey)(nil),                // 18: graph.v1.EdgeKey
+	(*DeleteEdgesRequest)(nil),     // 19: graph.v1.DeleteEdgesRequest
+	(*DeleteEdgesResponse)(nil),    // 20: graph.v1.DeleteEdgesResponse
+	(*AddEdgeRequest)(nil),         // 21: graph.v1.AddEdgeRequest
+	(*AddEdgeResponse)(nil),        // 22: graph.v1.AddEdgeResponse
+	(*PutEdgeRequest)(nil),         // 23: graph.v1.PutEdgeRequest
+	(*PutEdgeResponse)(nil),        // 24: graph.v1.PutEdgeResponse
+	(*timestamppb.Timestamp)(nil),  // 25: google.protobuf.Timestamp
 }
 var file_graph_v1_graph_proto_depIdxs = []int32{
-	20, // 0: graph.v1.Vertex.expiration:type_name -> google.protobuf.Timestamp
-	20, // 1: graph.v1.Vertex.timestamp:type_name -> google.protobuf.Timestamp
-	20, // 2: graph.v1.Edge.expiration:type_name -> google.protobuf.Timestamp
+	25, // 0: graph.v1.Vertex.expiration:type_name -> google.protobuf.Timestamp
+	25, // 1: graph.v1.Vertex.timestamp:type_name -> google.protobuf.Timestamp
+	25, // 2: graph.v1.Edge.expiration:type_name -> google.protobuf.Timestamp
 	1,  // 3: graph.v1.Graph.vertices:type_name -> graph.v1.Vertex
 	2,  // 4: graph.v1.Graph.edges:type_name -> graph.v1.Edge
 	0,  // 5: graph.v1.IlluminateRequest.optimization:type_name -> graph.v1.Optimization
@@ -1333,29 +1587,34 @@ var file_graph_v1_graph_proto_depIdxs = []int32{
 	1,  // 7: graph.v1.GetVertexResponse.vertex:type_name -> graph.v1.Vertex
 	1,  // 8: graph.v1.PutVertexRequest.vertices:type_name -> graph.v1.Vertex
 	2,  // 9: graph.v1.GetEdgeResponse.edge:type_name -> graph.v1.Edge
-	2,  // 10: graph.v1.AddEdgeRequest.edges:type_name -> graph.v1.Edge
-	2,  // 11: graph.v1.PutEdgeRequest.edges:type_name -> graph.v1.Edge
-	4,  // 12: graph.v1.LanternService.Illuminate:input_type -> graph.v1.IlluminateRequest
-	6,  // 13: graph.v1.LanternService.GetVertex:input_type -> graph.v1.GetVertexRequest
-	8,  // 14: graph.v1.LanternService.PutVertex:input_type -> graph.v1.PutVertexRequest
-	10, // 15: graph.v1.LanternService.DeleteVertex:input_type -> graph.v1.DeleteVertexRequest
-	12, // 16: graph.v1.LanternService.GetEdge:input_type -> graph.v1.GetEdgeRequest
-	16, // 17: graph.v1.LanternService.AddEdge:input_type -> graph.v1.AddEdgeRequest
-	18, // 18: graph.v1.LanternService.PutEdge:input_type -> graph.v1.PutEdgeRequest
-	14, // 19: graph.v1.LanternService.DeleteEdge:input_type -> graph.v1.DeleteEdgeRequest
-	5,  // 20: graph.v1.LanternService.Illuminate:output_type -> graph.v1.IlluminateResponse
-	7,  // 21: graph.v1.LanternService.GetVertex:output_type -> graph.v1.GetVertexResponse
-	9,  // 22: graph.v1.LanternService.PutVertex:output_type -> graph.v1.PutVertexResponse
-	11, // 23: graph.v1.LanternService.DeleteVertex:output_type -> graph.v1.DeleteVertexResponse
-	13, // 24: graph.v1.LanternService.GetEdge:output_type -> graph.v1.GetEdgeResponse
-	17, // 25: graph.v1.LanternService.AddEdge:output_type -> graph.v1.AddEdgeResponse
-	19, // 26: graph.v1.LanternService.PutEdge:output_type -> graph.v1.PutEdgeResponse
-	15, // 27: graph.v1.LanternService.DeleteEdge:output_type -> graph.v1.DeleteEdgeResponse
-	20, // [20:28] is the sub-list for method output_type
-	12, // [12:20] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	18, // 10: graph.v1.DeleteEdgesRequest.edges:type_name -> graph.v1.EdgeKey
+	2,  // 11: graph.v1.AddEdgeRequest.edges:type_name -> graph.v1.Edge
+	2,  // 12: graph.v1.PutEdgeRequest.edges:type_name -> graph.v1.Edge
+	4,  // 13: graph.v1.LanternService.Illuminate:input_type -> graph.v1.IlluminateRequest
+	6,  // 14: graph.v1.LanternService.GetVertex:input_type -> graph.v1.GetVertexRequest
+	8,  // 15: graph.v1.LanternService.PutVertex:input_type -> graph.v1.PutVertexRequest
+	10, // 16: graph.v1.LanternService.DeleteVertex:input_type -> graph.v1.DeleteVertexRequest
+	12, // 17: graph.v1.LanternService.DeleteVertices:input_type -> graph.v1.DeleteVerticesRequest
+	14, // 18: graph.v1.LanternService.GetEdge:input_type -> graph.v1.GetEdgeRequest
+	21, // 19: graph.v1.LanternService.AddEdge:input_type -> graph.v1.AddEdgeRequest
+	23, // 20: graph.v1.LanternService.PutEdge:input_type -> graph.v1.PutEdgeRequest
+	16, // 21: graph.v1.LanternService.DeleteEdge:input_type -> graph.v1.DeleteEdgeRequest
+	19, // 22: graph.v1.LanternService.DeleteEdges:input_type -> graph.v1.DeleteEdgesRequest
+	5,  // 23: graph.v1.LanternService.Illuminate:output_type -> graph.v1.IlluminateResponse
+	7,  // 24: graph.v1.LanternService.GetVertex:output_type -> graph.v1.GetVertexResponse
+	9,  // 25: graph.v1.LanternService.PutVertex:output_type -> graph.v1.PutVertexResponse
+	11, // 26: graph.v1.LanternService.DeleteVertex:output_type -> graph.v1.DeleteVertexResponse
+	13, // 27: graph.v1.LanternService.DeleteVertices:output_type -> graph.v1.DeleteVerticesResponse
+	15, // 28: graph.v1.LanternService.GetEdge:output_type -> graph.v1.GetEdgeResponse
+	22, // 29: graph.v1.LanternService.AddEdge:output_type -> graph.v1.AddEdgeResponse
+	24, // 30: graph.v1.LanternService.PutEdge:output_type -> graph.v1.PutEdgeResponse
+	17, // 31: graph.v1.LanternService.DeleteEdge:output_type -> graph.v1.DeleteEdgeResponse
+	20, // 32: graph.v1.LanternService.DeleteEdges:output_type -> graph.v1.DeleteEdgesResponse
+	23, // [23:33] is the sub-list for method output_type
+	13, // [13:23] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_graph_v1_graph_proto_init() }
@@ -1382,7 +1641,7 @@ func file_graph_v1_graph_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_graph_v1_graph_proto_rawDesc), len(file_graph_v1_graph_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   19,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/go/graph/v1/graph.pb.gw.go
+++ b/gen/go/graph/v1/graph.pb.gw.go
@@ -193,6 +193,33 @@ func local_request_LanternService_DeleteVertex_0(ctx context.Context, marshaler 
 	return msg, metadata, err
 }
 
+func request_LanternService_DeleteVertices_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq DeleteVerticesRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.DeleteVertices(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_LanternService_DeleteVertices_0(ctx context.Context, marshaler runtime.Marshaler, server LanternServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq DeleteVerticesRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.DeleteVertices(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_LanternService_GetEdge_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq GetEdgeRequest
@@ -357,6 +384,33 @@ func local_request_LanternService_DeleteEdge_0(ctx context.Context, marshaler ru
 	return msg, metadata, err
 }
 
+func request_LanternService_DeleteEdges_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq DeleteEdgesRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.DeleteEdges(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_LanternService_DeleteEdges_0(ctx context.Context, marshaler runtime.Marshaler, server LanternServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq DeleteEdgesRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.DeleteEdges(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterLanternServiceHandlerServer registers the http handlers for service LanternService to "mux".
 // UnaryRPC     :call LanternServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -443,6 +497,26 @@ func RegisterLanternServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 		}
 		forward_LanternService_DeleteVertex_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_LanternService_DeleteVertices_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/graph.v1.LanternService/DeleteVertices", runtime.WithHTTPPathPattern("/v1/vertices/delete"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_LanternService_DeleteVertices_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LanternService_DeleteVertices_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_LanternService_GetEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -522,6 +596,26 @@ func RegisterLanternServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 			return
 		}
 		forward_LanternService_DeleteEdge_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_LanternService_DeleteEdges_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/graph.v1.LanternService/DeleteEdges", runtime.WithHTTPPathPattern("/v1/edges/delete"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_LanternService_DeleteEdges_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LanternService_DeleteEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -631,6 +725,23 @@ func RegisterLanternServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 		}
 		forward_LanternService_DeleteVertex_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_LanternService_DeleteVertices_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/graph.v1.LanternService/DeleteVertices", runtime.WithHTTPPathPattern("/v1/vertices/delete"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_LanternService_DeleteVertices_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LanternService_DeleteVertices_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_LanternService_GetEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -699,27 +810,48 @@ func RegisterLanternServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 		}
 		forward_LanternService_DeleteEdge_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_LanternService_DeleteEdges_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/graph.v1.LanternService/DeleteEdges", runtime.WithHTTPPathPattern("/v1/edges/delete"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_LanternService_DeleteEdges_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LanternService_DeleteEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
 var (
-	pattern_LanternService_Illuminate_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "illuminate", "seed"}, ""))
-	pattern_LanternService_GetVertex_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "vertices", "key"}, ""))
-	pattern_LanternService_PutVertex_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "vertices"}, ""))
-	pattern_LanternService_DeleteVertex_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "vertices", "key"}, ""))
-	pattern_LanternService_GetEdge_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "edges", "tail", "head"}, ""))
-	pattern_LanternService_AddEdge_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "add"}, ""))
-	pattern_LanternService_PutEdge_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "put"}, ""))
-	pattern_LanternService_DeleteEdge_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "edges", "tail", "head"}, ""))
+	pattern_LanternService_Illuminate_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "illuminate", "seed"}, ""))
+	pattern_LanternService_GetVertex_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "vertices", "key"}, ""))
+	pattern_LanternService_PutVertex_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "vertices"}, ""))
+	pattern_LanternService_DeleteVertex_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "vertices", "key"}, ""))
+	pattern_LanternService_DeleteVertices_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "vertices", "delete"}, ""))
+	pattern_LanternService_GetEdge_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "edges", "tail", "head"}, ""))
+	pattern_LanternService_AddEdge_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "add"}, ""))
+	pattern_LanternService_PutEdge_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "put"}, ""))
+	pattern_LanternService_DeleteEdge_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "edges", "tail", "head"}, ""))
+	pattern_LanternService_DeleteEdges_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "delete"}, ""))
 )
 
 var (
-	forward_LanternService_Illuminate_0   = runtime.ForwardResponseMessage
-	forward_LanternService_GetVertex_0    = runtime.ForwardResponseMessage
-	forward_LanternService_PutVertex_0    = runtime.ForwardResponseMessage
-	forward_LanternService_DeleteVertex_0 = runtime.ForwardResponseMessage
-	forward_LanternService_GetEdge_0      = runtime.ForwardResponseMessage
-	forward_LanternService_AddEdge_0      = runtime.ForwardResponseMessage
-	forward_LanternService_PutEdge_0      = runtime.ForwardResponseMessage
-	forward_LanternService_DeleteEdge_0   = runtime.ForwardResponseMessage
+	forward_LanternService_Illuminate_0     = runtime.ForwardResponseMessage
+	forward_LanternService_GetVertex_0      = runtime.ForwardResponseMessage
+	forward_LanternService_PutVertex_0      = runtime.ForwardResponseMessage
+	forward_LanternService_DeleteVertex_0   = runtime.ForwardResponseMessage
+	forward_LanternService_DeleteVertices_0 = runtime.ForwardResponseMessage
+	forward_LanternService_GetEdge_0        = runtime.ForwardResponseMessage
+	forward_LanternService_AddEdge_0        = runtime.ForwardResponseMessage
+	forward_LanternService_PutEdge_0        = runtime.ForwardResponseMessage
+	forward_LanternService_DeleteEdge_0     = runtime.ForwardResponseMessage
+	forward_LanternService_DeleteEdges_0    = runtime.ForwardResponseMessage
 )

--- a/gen/go/graph/v1/graph_grpc.pb.go
+++ b/gen/go/graph/v1/graph_grpc.pb.go
@@ -19,14 +19,16 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	LanternService_Illuminate_FullMethodName   = "/graph.v1.LanternService/Illuminate"
-	LanternService_GetVertex_FullMethodName    = "/graph.v1.LanternService/GetVertex"
-	LanternService_PutVertex_FullMethodName    = "/graph.v1.LanternService/PutVertex"
-	LanternService_DeleteVertex_FullMethodName = "/graph.v1.LanternService/DeleteVertex"
-	LanternService_GetEdge_FullMethodName      = "/graph.v1.LanternService/GetEdge"
-	LanternService_AddEdge_FullMethodName      = "/graph.v1.LanternService/AddEdge"
-	LanternService_PutEdge_FullMethodName      = "/graph.v1.LanternService/PutEdge"
-	LanternService_DeleteEdge_FullMethodName   = "/graph.v1.LanternService/DeleteEdge"
+	LanternService_Illuminate_FullMethodName     = "/graph.v1.LanternService/Illuminate"
+	LanternService_GetVertex_FullMethodName      = "/graph.v1.LanternService/GetVertex"
+	LanternService_PutVertex_FullMethodName      = "/graph.v1.LanternService/PutVertex"
+	LanternService_DeleteVertex_FullMethodName   = "/graph.v1.LanternService/DeleteVertex"
+	LanternService_DeleteVertices_FullMethodName = "/graph.v1.LanternService/DeleteVertices"
+	LanternService_GetEdge_FullMethodName        = "/graph.v1.LanternService/GetEdge"
+	LanternService_AddEdge_FullMethodName        = "/graph.v1.LanternService/AddEdge"
+	LanternService_PutEdge_FullMethodName        = "/graph.v1.LanternService/PutEdge"
+	LanternService_DeleteEdge_FullMethodName     = "/graph.v1.LanternService/DeleteEdge"
+	LanternService_DeleteEdges_FullMethodName    = "/graph.v1.LanternService/DeleteEdges"
 )
 
 // LanternServiceClient is the client API for LanternService service.
@@ -37,12 +39,16 @@ type LanternServiceClient interface {
 	GetVertex(ctx context.Context, in *GetVertexRequest, opts ...grpc.CallOption) (*GetVertexResponse, error)
 	PutVertex(ctx context.Context, in *PutVertexRequest, opts ...grpc.CallOption) (*PutVertexResponse, error)
 	DeleteVertex(ctx context.Context, in *DeleteVertexRequest, opts ...grpc.CallOption) (*DeleteVertexResponse, error)
+	// DeleteVertices removes several vertices in one round trip.
+	DeleteVertices(ctx context.Context, in *DeleteVerticesRequest, opts ...grpc.CallOption) (*DeleteVerticesResponse, error)
 	GetEdge(ctx context.Context, in *GetEdgeRequest, opts ...grpc.CallOption) (*GetEdgeResponse, error)
 	// AddEdge is non-idempotent (accumulates weight). POST per REST conventions.
 	AddEdge(ctx context.Context, in *AddEdgeRequest, opts ...grpc.CallOption) (*AddEdgeResponse, error)
 	// PutEdge is idempotent (replaces weight). PUT per REST conventions.
 	PutEdge(ctx context.Context, in *PutEdgeRequest, opts ...grpc.CallOption) (*PutEdgeResponse, error)
 	DeleteEdge(ctx context.Context, in *DeleteEdgeRequest, opts ...grpc.CallOption) (*DeleteEdgeResponse, error)
+	// DeleteEdges removes several edges in one round trip.
+	DeleteEdges(ctx context.Context, in *DeleteEdgesRequest, opts ...grpc.CallOption) (*DeleteEdgesResponse, error)
 }
 
 type lanternServiceClient struct {
@@ -93,6 +99,16 @@ func (c *lanternServiceClient) DeleteVertex(ctx context.Context, in *DeleteVerte
 	return out, nil
 }
 
+func (c *lanternServiceClient) DeleteVertices(ctx context.Context, in *DeleteVerticesRequest, opts ...grpc.CallOption) (*DeleteVerticesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteVerticesResponse)
+	err := c.cc.Invoke(ctx, LanternService_DeleteVertices_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *lanternServiceClient) GetEdge(ctx context.Context, in *GetEdgeRequest, opts ...grpc.CallOption) (*GetEdgeResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetEdgeResponse)
@@ -133,6 +149,16 @@ func (c *lanternServiceClient) DeleteEdge(ctx context.Context, in *DeleteEdgeReq
 	return out, nil
 }
 
+func (c *lanternServiceClient) DeleteEdges(ctx context.Context, in *DeleteEdgesRequest, opts ...grpc.CallOption) (*DeleteEdgesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteEdgesResponse)
+	err := c.cc.Invoke(ctx, LanternService_DeleteEdges_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // LanternServiceServer is the server API for LanternService service.
 // All implementations should embed UnimplementedLanternServiceServer
 // for forward compatibility.
@@ -141,12 +167,16 @@ type LanternServiceServer interface {
 	GetVertex(context.Context, *GetVertexRequest) (*GetVertexResponse, error)
 	PutVertex(context.Context, *PutVertexRequest) (*PutVertexResponse, error)
 	DeleteVertex(context.Context, *DeleteVertexRequest) (*DeleteVertexResponse, error)
+	// DeleteVertices removes several vertices in one round trip.
+	DeleteVertices(context.Context, *DeleteVerticesRequest) (*DeleteVerticesResponse, error)
 	GetEdge(context.Context, *GetEdgeRequest) (*GetEdgeResponse, error)
 	// AddEdge is non-idempotent (accumulates weight). POST per REST conventions.
 	AddEdge(context.Context, *AddEdgeRequest) (*AddEdgeResponse, error)
 	// PutEdge is idempotent (replaces weight). PUT per REST conventions.
 	PutEdge(context.Context, *PutEdgeRequest) (*PutEdgeResponse, error)
 	DeleteEdge(context.Context, *DeleteEdgeRequest) (*DeleteEdgeResponse, error)
+	// DeleteEdges removes several edges in one round trip.
+	DeleteEdges(context.Context, *DeleteEdgesRequest) (*DeleteEdgesResponse, error)
 }
 
 // UnimplementedLanternServiceServer should be embedded to have
@@ -168,6 +198,9 @@ func (UnimplementedLanternServiceServer) PutVertex(context.Context, *PutVertexRe
 func (UnimplementedLanternServiceServer) DeleteVertex(context.Context, *DeleteVertexRequest) (*DeleteVertexResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteVertex not implemented")
 }
+func (UnimplementedLanternServiceServer) DeleteVertices(context.Context, *DeleteVerticesRequest) (*DeleteVerticesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteVertices not implemented")
+}
 func (UnimplementedLanternServiceServer) GetEdge(context.Context, *GetEdgeRequest) (*GetEdgeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetEdge not implemented")
 }
@@ -179,6 +212,9 @@ func (UnimplementedLanternServiceServer) PutEdge(context.Context, *PutEdgeReques
 }
 func (UnimplementedLanternServiceServer) DeleteEdge(context.Context, *DeleteEdgeRequest) (*DeleteEdgeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteEdge not implemented")
+}
+func (UnimplementedLanternServiceServer) DeleteEdges(context.Context, *DeleteEdgesRequest) (*DeleteEdgesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteEdges not implemented")
 }
 func (UnimplementedLanternServiceServer) testEmbeddedByValue() {}
 
@@ -272,6 +308,24 @@ func _LanternService_DeleteVertex_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _LanternService_DeleteVertices_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteVerticesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LanternServiceServer).DeleteVertices(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: LanternService_DeleteVertices_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LanternServiceServer).DeleteVertices(ctx, req.(*DeleteVerticesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _LanternService_GetEdge_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetEdgeRequest)
 	if err := dec(in); err != nil {
@@ -344,6 +398,24 @@ func _LanternService_DeleteEdge_Handler(srv interface{}, ctx context.Context, de
 	return interceptor(ctx, in, info, handler)
 }
 
+func _LanternService_DeleteEdges_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteEdgesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LanternServiceServer).DeleteEdges(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: LanternService_DeleteEdges_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LanternServiceServer).DeleteEdges(ctx, req.(*DeleteEdgesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // LanternService_ServiceDesc is the grpc.ServiceDesc for LanternService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -368,6 +440,10 @@ var LanternService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _LanternService_DeleteVertex_Handler,
 		},
 		{
+			MethodName: "DeleteVertices",
+			Handler:    _LanternService_DeleteVertices_Handler,
+		},
+		{
 			MethodName: "GetEdge",
 			Handler:    _LanternService_GetEdge_Handler,
 		},
@@ -382,6 +458,10 @@ var LanternService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteEdge",
 			Handler:    _LanternService_DeleteEdge_Handler,
+		},
+		{
+			MethodName: "DeleteEdges",
+			Handler:    _LanternService_DeleteEdges_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/gen/openapiv2/graph/v1/graph.swagger.json
+++ b/gen/openapiv2/graph/v1/graph.swagger.json
@@ -50,6 +50,40 @@
         ]
       }
     },
+    "/v1/edges/delete": {
+      "post": {
+        "summary": "DeleteEdges removes several edges in one round trip.",
+        "operationId": "LanternService_DeleteEdges",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DeleteEdgesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "DeleteEdgesRequest removes several edges in one round trip. Subject to the\nMaxBatchSize / MaxKeyLen guard rails.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1DeleteEdgesRequest"
+            }
+          }
+        ],
+        "tags": [
+          "LanternService"
+        ]
+      }
+    },
     "/v1/edges/put": {
       "put": {
         "summary": "PutEdge is idempotent (replaces weight). PUT per REST conventions.",
@@ -251,6 +285,40 @@
         ]
       }
     },
+    "/v1/vertices/delete": {
+      "post": {
+        "summary": "DeleteVertices removes several vertices in one round trip.",
+        "operationId": "LanternService_DeleteVertices",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DeleteVerticesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "DeleteVerticesRequest removes several vertices in one round trip. Same\ncascade semantics as DeleteVertex (edges reaped lazily by the GC loop).\nSubject to the same MaxBatchSize / MaxKeyLen guard rails as the put RPCs.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1DeleteVerticesRequest"
+            }
+          }
+        ],
+        "tags": [
+          "LanternService"
+        ]
+      }
+    },
     "/v1/vertices/{key}": {
       "get": {
         "operationId": "LanternService_GetVertex",
@@ -365,8 +433,53 @@
     "v1DeleteEdgeResponse": {
       "type": "object"
     },
+    "v1DeleteEdgesRequest": {
+      "type": "object",
+      "properties": {
+        "edges": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EdgeKey"
+          }
+        }
+      },
+      "description": "DeleteEdgesRequest removes several edges in one round trip. Subject to the\nMaxBatchSize / MaxKeyLen guard rails."
+    },
+    "v1DeleteEdgesResponse": {
+      "type": "object",
+      "properties": {
+        "deleted": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of edges the server attempted to delete (equals len(edges) on success)."
+        }
+      }
+    },
     "v1DeleteVertexResponse": {
       "type": "object"
+    },
+    "v1DeleteVerticesRequest": {
+      "type": "object",
+      "properties": {
+        "keys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "DeleteVerticesRequest removes several vertices in one round trip. Same\ncascade semantics as DeleteVertex (edges reaped lazily by the GC loop).\nSubject to the same MaxBatchSize / MaxKeyLen guard rails as the put RPCs."
+    },
+    "v1DeleteVerticesResponse": {
+      "type": "object",
+      "properties": {
+        "deleted": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of keys the server attempted to delete (equals len(keys) on success)."
+        }
+      }
     },
     "v1Edge": {
       "type": "object",
@@ -386,6 +499,18 @@
           "format": "date-time"
         }
       }
+    },
+    "v1EdgeKey": {
+      "type": "object",
+      "properties": {
+        "tail": {
+          "type": "string"
+        },
+        "head": {
+          "type": "string"
+        }
+      },
+      "description": "EdgeKey identifies an edge by its (tail, head) pair without weight."
     },
     "v1GetEdgeResponse": {
       "type": "object",

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -91,6 +91,18 @@ message DeleteVertexRequest {
 
 message DeleteVertexResponse {}
 
+// DeleteVerticesRequest removes several vertices in one round trip. Same
+// cascade semantics as DeleteVertex (edges reaped lazily by the GC loop).
+// Subject to the same MaxBatchSize / MaxKeyLen guard rails as the put RPCs.
+message DeleteVerticesRequest {
+  repeated string keys = 1;
+}
+
+message DeleteVerticesResponse {
+  // Number of keys the server attempted to delete (equals len(keys) on success).
+  int32 deleted = 1;
+}
+
 message GetEdgeRequest {
   string tail = 1;
   string head = 2;
@@ -106,6 +118,23 @@ message DeleteEdgeRequest {
 }
 
 message DeleteEdgeResponse {}
+
+// EdgeKey identifies an edge by its (tail, head) pair without weight.
+message EdgeKey {
+  string tail = 1;
+  string head = 2;
+}
+
+// DeleteEdgesRequest removes several edges in one round trip. Subject to the
+// MaxBatchSize / MaxKeyLen guard rails.
+message DeleteEdgesRequest {
+  repeated EdgeKey edges = 1;
+}
+
+message DeleteEdgesResponse {
+  // Number of edges the server attempted to delete (equals len(edges) on success).
+  int32 deleted = 1;
+}
 
 // AddEdgeRequest accumulates weight onto each (tail, head) pair: repeated
 // calls with the same endpoints sum their weights. This operation is
@@ -150,6 +179,14 @@ service LanternService {
     option (google.api.http) = {delete: "/v1/vertices/{key}"};
   }
 
+  // DeleteVertices removes several vertices in one round trip.
+  rpc DeleteVertices(DeleteVerticesRequest) returns (DeleteVerticesResponse) {
+    option (google.api.http) = {
+      post: "/v1/vertices/delete"
+      body: "*"
+    };
+  }
+
   rpc GetEdge(GetEdgeRequest) returns (GetEdgeResponse) {
     option (google.api.http) = {get: "/v1/edges/{tail}/{head}"};
   }
@@ -172,5 +209,13 @@ service LanternService {
 
   rpc DeleteEdge(DeleteEdgeRequest) returns (DeleteEdgeResponse) {
     option (google.api.http) = {delete: "/v1/edges/{tail}/{head}"};
+  }
+
+  // DeleteEdges removes several edges in one round trip.
+  rpc DeleteEdges(DeleteEdgesRequest) returns (DeleteEdgesResponse) {
+    option (google.api.http) = {
+      post: "/v1/edges/delete"
+      body: "*"
+    };
   }
 }

--- a/server/provider/extra.go
+++ b/server/provider/extra.go
@@ -72,6 +72,15 @@ func (v *ValidationInterceptor) validate(req any) error {
 		return v.checkKey("key", r.GetKey())
 	case *pb.DeleteVertexRequest:
 		return v.checkKey("key", r.GetKey())
+	case *pb.DeleteVerticesRequest:
+		if err := v.checkBatch(len(r.GetKeys())); err != nil {
+			return err
+		}
+		for i, k := range r.GetKeys() {
+			if err := v.checkKey(fmt.Sprintf("keys[%d]", i), k); err != nil {
+				return err
+			}
+		}
 	case *pb.PutVertexRequest:
 		if err := v.checkBatch(len(r.GetVertices())); err != nil {
 			return err
@@ -94,6 +103,21 @@ func (v *ValidationInterceptor) validate(req any) error {
 			return err
 		}
 		return v.checkKey("head", r.GetHead())
+	case *pb.DeleteEdgesRequest:
+		if err := v.checkBatch(len(r.GetEdges())); err != nil {
+			return err
+		}
+		for i, e := range r.GetEdges() {
+			if e == nil {
+				return status.Errorf(codes.InvalidArgument, "edges[%d] is nil", i)
+			}
+			if err := v.checkKey(fmt.Sprintf("edges[%d].tail", i), e.GetTail()); err != nil {
+				return err
+			}
+			if err := v.checkKey(fmt.Sprintf("edges[%d].head", i), e.GetHead()); err != nil {
+				return err
+			}
+		}
 	case *pb.AddEdgeRequest:
 		return v.validateEdges(r.GetEdges())
 	case *pb.PutEdgeRequest:

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
+	_ "google.golang.org/grpc/encoding/gzip" // register gzip compressor so clients requesting it work
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"

--- a/server/service/integration_test.go
+++ b/server/service/integration_test.go
@@ -132,3 +132,141 @@ func TestIntegration_FullMiddlewareChain(t *testing.T) {
 		}
 	})
 }
+
+// TestIntegration_BatchDeletes exercises the DeleteVertices and DeleteEdges
+// RPCs end-to-end through bufconn. It uses its own server with no rate
+// limiter so the assertions aren't sensitive to token bucket state from
+// other tests in this file.
+func TestIntegration_BatchDeletes(t *testing.T) {
+	lis := bufconn.Listen(1 << 20)
+	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	svc := service.NewLanternService(cache)
+	val := provider.NewValidationInterceptor(provider.ValidationLimits{
+		MaxKeyLen:         32,
+		MaxBatchSize:      5,
+		IlluminateMaxStep: 4,
+		IlluminateMaxK:    8,
+	})
+
+	srv := grpc.NewServer(grpc.ChainUnaryInterceptor(val.UnaryServerInterceptor()))
+	pb.RegisterLanternServiceServer(srv, svc)
+	go func() {
+		if err := srv.Serve(lis); err != nil {
+			t.Logf("bufconn serve: %v", err)
+		}
+	}()
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+	})
+
+	dialer := func(ctx context.Context, _ string) (net.Conn, error) {
+		return lis.DialContext(ctx)
+	}
+	c, err := client.NewLantern("passthrough://bufnet",
+		client.WithTransportCredentials(insecure.NewCredentials()),
+		client.WithDialOption(grpc.WithContextDialer(dialer)),
+		client.WithDefaultServiceConfig(""),
+	)
+	if err != nil {
+		t.Fatalf("NewLantern: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	t.Run("delete vertices round-trip", func(t *testing.T) {
+		keys := []string{"d1", "d2", "d3"}
+		for _, k := range keys {
+			if err := c.PutVertex(ctx, k, int64(1), time.Minute); err != nil {
+				t.Fatalf("PutVertex(%s): %v", k, err)
+			}
+		}
+		if err := c.DeleteVertices(ctx, keys); err != nil {
+			t.Fatalf("DeleteVertices: %v", err)
+		}
+		for _, k := range keys {
+			if _, err := c.GetVertex(ctx, k); status.Code(err) != codes.NotFound {
+				t.Errorf("GetVertex(%s) after delete: code = %v, want NotFound", k, status.Code(err))
+			}
+		}
+	})
+
+	t.Run("delete edges round-trip", func(t *testing.T) {
+		for _, k := range []string{"ea", "eb", "ex"} {
+			if err := c.PutVertex(ctx, k, int64(0), time.Minute); err != nil {
+				t.Fatalf("PutVertex(%s): %v", k, err)
+			}
+		}
+		if err := c.PutEdge(ctx, "ea", "eb", 1.0, time.Minute); err != nil {
+			t.Fatalf("PutEdge: %v", err)
+		}
+		if err := c.PutEdge(ctx, "ea", "ex", 1.0, time.Minute); err != nil {
+			t.Fatalf("PutEdge: %v", err)
+		}
+		refs := []client.EdgeRef{{Tail: "ea", Head: "eb"}, {Tail: "ea", Head: "ex"}}
+		if err := c.DeleteEdges(ctx, refs); err != nil {
+			t.Fatalf("DeleteEdges: %v", err)
+		}
+		for _, r := range refs {
+			if _, err := c.GetEdge(ctx, r.Tail, r.Head); status.Code(err) != codes.NotFound {
+				t.Errorf("GetEdge(%s,%s) after delete: code = %v, want NotFound", r.Tail, r.Head, status.Code(err))
+			}
+		}
+	})
+
+	t.Run("delete vertices empty is no-op", func(t *testing.T) {
+		if err := c.DeleteVertices(ctx, nil); err != nil {
+			t.Errorf("DeleteVertices(nil): %v", err)
+		}
+	})
+
+	t.Run("delete edges empty is no-op", func(t *testing.T) {
+		if err := c.DeleteEdges(ctx, nil); err != nil {
+			t.Errorf("DeleteEdges(nil): %v", err)
+		}
+	})
+
+	t.Run("validation rejects oversize delete vertices", func(t *testing.T) {
+		// Bypass SDK auto-chunking by raising chunk size, so the server
+		// sees a single >MaxBatchSize request.
+		bigClient, err := client.NewLantern("passthrough://bufnet",
+			client.WithTransportCredentials(insecure.NewCredentials()),
+			client.WithDialOption(grpc.WithContextDialer(dialer)),
+			client.WithDefaultServiceConfig(""),
+			client.WithBatchChunkSize(100),
+		)
+		if err != nil {
+			t.Fatalf("NewLantern: %v", err)
+		}
+		defer func() { _ = bigClient.Close() }()
+		keys := make([]string, 6)
+		for i := range keys {
+			keys[i] = string(rune('a' + i))
+		}
+		if err := bigClient.DeleteVertices(ctx, keys); status.Code(err) != codes.InvalidArgument {
+			t.Errorf("DeleteVertices(6) code = %v, want InvalidArgument", status.Code(err))
+		}
+	})
+
+	t.Run("validation rejects oversize delete edges", func(t *testing.T) {
+		bigClient, err := client.NewLantern("passthrough://bufnet",
+			client.WithTransportCredentials(insecure.NewCredentials()),
+			client.WithDialOption(grpc.WithContextDialer(dialer)),
+			client.WithDefaultServiceConfig(""),
+			client.WithBatchChunkSize(100),
+		)
+		if err != nil {
+			t.Fatalf("NewLantern: %v", err)
+		}
+		defer func() { _ = bigClient.Close() }()
+		refs := make([]client.EdgeRef, 6)
+		for i := range refs {
+			refs[i] = client.EdgeRef{Tail: string(rune('a' + i)), Head: "z"}
+		}
+		if err := bigClient.DeleteEdges(ctx, refs); status.Code(err) != codes.InvalidArgument {
+			t.Errorf("DeleteEdges(6) code = %v, want InvalidArgument", status.Code(err))
+		}
+	})
+}

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -134,6 +134,18 @@ func (s *LanternService) DeleteVertex(ctx context.Context, in *pb.DeleteVertexRe
 	return &pb.DeleteVertexResponse{}, nil
 }
 
+func (s *LanternService) DeleteVertices(ctx context.Context, in *pb.DeleteVerticesRequest) (*pb.DeleteVerticesResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, status.FromContextError(err).Err()
+	}
+	var n int32
+	for _, k := range in.GetKeys() {
+		s.cache.DeleteVertex(k)
+		n++
+	}
+	return &pb.DeleteVerticesResponse{Deleted: n}, nil
+}
+
 func (s *LanternService) GetEdge(ctx context.Context, request *pb.GetEdgeRequest) (*pb.GetEdgeResponse, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
@@ -180,6 +192,18 @@ func (s *LanternService) DeleteEdge(ctx context.Context, in *pb.DeleteEdgeReques
 	}
 	s.cache.DeleteEdge(in.GetTail(), in.GetHead())
 	return &pb.DeleteEdgeResponse{}, nil
+}
+
+func (s *LanternService) DeleteEdges(ctx context.Context, in *pb.DeleteEdgesRequest) (*pb.DeleteEdgesResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, status.FromContextError(err).Err()
+	}
+	var n int32
+	for _, e := range in.GetEdges() {
+		s.cache.DeleteEdge(e.GetTail(), e.GetHead())
+		n++
+	}
+	return &pb.DeleteEdgesResponse{Deleted: n}, nil
 }
 
 // LanternServer ties the gRPC server, its listener, the cache GC loop, and


### PR DESCRIPTION
Follow-up to #30. Adds the smaller surface that wasn't worth a separate PR per item.

## Server / proto
- New `DeleteVertices` and `DeleteEdges` RPCs (proto + Go + gRPC-Gateway). Both are idempotent batch deletes that take a single round-trip.
- Validation interceptor extended with `MaxBatchSize` + per-element key length checks for the new shapes.
- Server registers the gzip compressor so clients can opt into payload compression.

## Client SDK
- `DeleteVertices(ctx, []string)` and `DeleteEdges(ctx, []EdgeRef)` helpers with auto-chunking via the existing `WithBatchChunkSize` knob.
- New `WithCompression(name)` option (gzip is pre-imported so the common case needs no extra import).
- Default retry policy extended to cover the new RPCs (idempotent → safe to retry).

## Ops
- Dockerfile: `STOPSIGNAL SIGTERM` so `docker stop` / pod shutdown hits the graceful-stop path instead of being killed.
- CI: new `govulncheck` job on every push/PR.

## Tests
- New `TestIntegration_BatchDeletes` (separate bufconn server, no rate limiter) covering happy path, empty-input short-circuit, and server-side validation rejection.

All existing tests still pass under `go test -race -shuffle=on`.