### PR TITLE
feat(cli): complete cobra-based CLI for the gRPC client

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,39 @@ go run ./server/cmd          # listens on :6380
 ### Use the CLI
 
 ```shell
-go build -o lantern-cli ./cli
-./lantern-cli --host localhost --port 6380
+go build -o lantern ./cli
+./lantern --help
 ```
+
+The CLI exposes every RPC as a scriptable subcommand with verbose,
+LLM-friendly help text (`lantern <cmd> --help`). All read commands emit JSON
+on stdout; all write commands print a single `OK` line.
+
+```shell
+# writes
+./lantern vertex put alice '{"name":"Alice"}' --value-type json --ttl 1h
+./lantern edge   add alice bob 1.5            # additive (sums weight)
+./lantern edge   put alice bob 0.7            # idempotent (replaces)
+
+# reads
+./lantern vertex get alice                    # JSON: {key,value,expiration}
+./lantern edge   get alice bob                # JSON: {tail,head,weight,expiration}
+./lantern illuminate alice --step 2 --k 5 --optimize mst
+
+# batches & streaming
+./lantern vertex delete alice bob carol       # batch DeleteVertices
+cat edges.ndjson | ./lantern bulk edges add - # streamed AddEdges
+
+# TLS / mTLS
+./lantern --tls --tls-ca ./ca.pem -H lantern.example.com -p 443 vertex get alice
+
+# legacy interactive prompt
+./lantern repl
+```
+
+Global flags include `--host/--port` (or `--address`), `--timeout`, `--tls*`,
+`--compression {none|gzip}`, and `--chunk-size`. Exit code `0` is success,
+`1` is a local / parse error, `2` is a gRPC error from the server.
 
 ### Use it from Go
 

--- a/cli/cmd/bulk.go
+++ b/cli/cmd/bulk.go
@@ -1,0 +1,250 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/anaregdesign/lantern/client"
+	"github.com/spf13/cobra"
+)
+
+var bulkCmd = &cobra.Command{
+	Use:   "bulk",
+	Short: "Bulk-load vertices or edges from NDJSON",
+	Long: `Stream NDJSON (one JSON object per line) into Lantern using the batch RPCs.
+
+The input file may be a filesystem path or "-" for stdin. The CLI accumulates
+lines into batches of --chunk-size (default 1000) and sends each batch via the
+appropriate batch RPC. Progress is printed to stderr; "OK <total>" is printed
+to stdout when the stream finishes.
+
+INPUT SCHEMAS
+  bulk vertices:
+    {"key":"alice","value":{"name":"Alice"},"ttl":"1h"}
+    {"key":"bob","value":42,"ttl":"30m"}
+
+  bulk edges add  / bulk edges put:
+    {"tail":"alice","head":"bob","weight":1.5,"ttl":"1h"}
+
+  "ttl" is a Go duration string (e.g. 30s, 5m, 1h, 24h). If omitted, 24h
+  is used. "value" may be any JSON value (object, array, scalar).
+
+ERRORS
+  A malformed line aborts the stream and returns exit code 1. Already-sent
+  batches are NOT rolled back — Lantern has no transactions.
+
+EXAMPLES
+  lantern bulk vertices vertices.ndjson
+  cat edges.ndjson | lantern bulk edges add -
+  lantern bulk edges put edges.ndjson --chunk-size 5000
+`,
+}
+
+type vertexLine struct {
+	Key   string `json:"key"`
+	Value any    `json:"value"`
+	TTL   string `json:"ttl,omitempty"`
+}
+
+type edgeLine struct {
+	Tail   string  `json:"tail"`
+	Head   string  `json:"head"`
+	Weight float32 `json:"weight"`
+	TTL    string  `json:"ttl,omitempty"`
+}
+
+func parseTTL(s string) (time.Duration, error) {
+	if s == "" {
+		return 24 * time.Hour, nil
+	}
+	return time.ParseDuration(s)
+}
+
+func openInput(path string) (io.ReadCloser, error) {
+	if path == "-" || path == "" {
+		return io.NopCloser(os.Stdin), nil
+	}
+	return os.Open(path)
+}
+
+var bulkVerticesCmd = &cobra.Command{
+	Use:   "vertices <file|->",
+	Short: "Bulk-upsert vertices from NDJSON",
+	Long: `Stream vertex upserts from NDJSON.
+
+Each line:
+  {"key":"<string>","value":<any json>,"ttl":"<duration>"}
+
+Lines are accumulated into batches of --chunk-size and sent via PutVertices.
+` + "`ttl`" + ` defaults to 24h when omitted.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		r, err := openInput(args[0])
+		if err != nil {
+			return err
+		}
+		defer r.Close()
+
+		cli, err := dial()
+		if err != nil {
+			return err
+		}
+		defer cli.Close()
+
+		sc := bufio.NewScanner(r)
+		sc.Buffer(make([]byte, 64*1024), 8*1024*1024)
+
+		batch := make([]client.VertexInput, 0, flagChunkSize)
+		total := 0
+		flush := func() error {
+			if len(batch) == 0 {
+				return nil
+			}
+			if err := cli.PutVertices(cmd.Context(), batch); err != nil {
+				return err
+			}
+			total += len(batch)
+			fmt.Fprintf(cmd.ErrOrStderr(), "... %d\n", total)
+			batch = batch[:0]
+			return nil
+		}
+
+		lineNo := 0
+		for sc.Scan() {
+			lineNo++
+			if len(sc.Bytes()) == 0 {
+				continue
+			}
+			var v vertexLine
+			if err := json.Unmarshal(sc.Bytes(), &v); err != nil {
+				return fmt.Errorf("line %d: %w", lineNo, err)
+			}
+			ttl, err := parseTTL(v.TTL)
+			if err != nil {
+				return fmt.Errorf("line %d: ttl: %w", lineNo, err)
+			}
+			batch = append(batch, client.VertexInput{
+				Key: v.Key, Value: v.Value, Expiration: time.Now().Add(ttl),
+			})
+			if len(batch) >= flagChunkSize {
+				if err := flush(); err != nil {
+					return err
+				}
+			}
+		}
+		if err := sc.Err(); err != nil {
+			return err
+		}
+		if err := flush(); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "OK %d\n", total)
+		return nil
+	},
+}
+
+func newBulkEdgesCmd(verb string) *cobra.Command {
+	return &cobra.Command{
+		Use:   verb + " <file|->",
+		Short: "Bulk-" + verb + " edges from NDJSON",
+		Long: `Stream edge ` + verb + `s from NDJSON.
+
+Each line:
+  {"tail":"<string>","head":"<string>","weight":<float>,"ttl":"<duration>"}
+
+Lines are accumulated into batches of --chunk-size and sent via ` +
+			(map[string]string{"add": "AddEdges", "put": "PutEdges"})[verb] + `.
+` + "`ttl`" + ` defaults to 24h when omitted.
+
+Recall the semantic difference: ` + "`add`" + ` SUMS weight onto existing edges
+(non-idempotent), ` + "`put`" + ` REPLACES it (idempotent).`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r, err := openInput(args[0])
+			if err != nil {
+				return err
+			}
+			defer r.Close()
+
+			cli, err := dial()
+			if err != nil {
+				return err
+			}
+			defer cli.Close()
+
+			sc := bufio.NewScanner(r)
+			sc.Buffer(make([]byte, 64*1024), 8*1024*1024)
+
+			batch := make([]client.EdgeInput, 0, flagChunkSize)
+			total := 0
+			flush := func() error {
+				if len(batch) == 0 {
+					return nil
+				}
+				var err error
+				if verb == "add" {
+					err = cli.AddEdges(cmd.Context(), batch)
+				} else {
+					err = cli.PutEdges(cmd.Context(), batch)
+				}
+				if err != nil {
+					return err
+				}
+				total += len(batch)
+				fmt.Fprintf(cmd.ErrOrStderr(), "... %d\n", total)
+				batch = batch[:0]
+				return nil
+			}
+
+			lineNo := 0
+			for sc.Scan() {
+				lineNo++
+				if len(sc.Bytes()) == 0 {
+					continue
+				}
+				var e edgeLine
+				if err := json.Unmarshal(sc.Bytes(), &e); err != nil {
+					return fmt.Errorf("line %d: %w", lineNo, err)
+				}
+				ttl, err := parseTTL(e.TTL)
+				if err != nil {
+					return fmt.Errorf("line %d: ttl: %w", lineNo, err)
+				}
+				batch = append(batch, client.EdgeInput{
+					Tail: e.Tail, Head: e.Head, Weight: e.Weight,
+					Expiration: time.Now().Add(ttl),
+				})
+				if len(batch) >= flagChunkSize {
+					if err := flush(); err != nil {
+						return err
+					}
+				}
+			}
+			if err := sc.Err(); err != nil {
+				return err
+			}
+			if err := flush(); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "OK %d\n", total)
+			return nil
+		},
+	}
+}
+
+var bulkEdgesCmd = &cobra.Command{
+	Use:   "edges",
+	Short: "Bulk-write edges from NDJSON",
+	Long: `Bulk edge write — choose ` + "`add`" + ` (additive) or ` + "`put`" + ` (idempotent).
+See the parent ` + "`bulk`" + ` help and ` + "`edge add`" + ` / ` + "`edge put`" + ` for semantics.`,
+}
+
+func init() {
+	bulkEdgesCmd.AddCommand(newBulkEdgesCmd("add"), newBulkEdgesCmd("put"))
+	bulkCmd.AddCommand(bulkVerticesCmd, bulkEdgesCmd)
+	rootCmd.AddCommand(bulkCmd)
+}

--- a/cli/cmd/bulk.go
+++ b/cli/cmd/bulk.go
@@ -87,13 +87,13 @@ Lines are accumulated into batches of --chunk-size and sent via PutVertices.
 		if err != nil {
 			return err
 		}
-		defer r.Close()
+		defer func() { _ = r.Close() }()
 
 		cli, err := dial()
 		if err != nil {
 			return err
 		}
-		defer cli.Close()
+		defer func() { _ = cli.Close() }()
 
 		sc := bufio.NewScanner(r)
 		sc.Buffer(make([]byte, 64*1024), 8*1024*1024)
@@ -108,7 +108,7 @@ Lines are accumulated into batches of --chunk-size and sent via PutVertices.
 				return err
 			}
 			total += len(batch)
-			fmt.Fprintf(cmd.ErrOrStderr(), "... %d\n", total)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "... %d\n", total)
 			batch = batch[:0]
 			return nil
 		}
@@ -142,7 +142,7 @@ Lines are accumulated into batches of --chunk-size and sent via PutVertices.
 		if err := flush(); err != nil {
 			return err
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "OK %d\n", total)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK %d\n", total)
 		return nil
 	},
 }
@@ -168,13 +168,13 @@ Recall the semantic difference: ` + "`add`" + ` SUMS weight onto existing edges
 			if err != nil {
 				return err
 			}
-			defer r.Close()
+			defer func() { _ = r.Close() }()
 
 			cli, err := dial()
 			if err != nil {
 				return err
 			}
-			defer cli.Close()
+			defer func() { _ = cli.Close() }()
 
 			sc := bufio.NewScanner(r)
 			sc.Buffer(make([]byte, 64*1024), 8*1024*1024)
@@ -195,7 +195,7 @@ Recall the semantic difference: ` + "`add`" + ` SUMS weight onto existing edges
 					return err
 				}
 				total += len(batch)
-				fmt.Fprintf(cmd.ErrOrStderr(), "... %d\n", total)
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "... %d\n", total)
 				batch = batch[:0]
 				return nil
 			}

--- a/cli/cmd/bulk.go
+++ b/cli/cmd/bulk.go
@@ -230,7 +230,7 @@ Recall the semantic difference: ` + "`add`" + ` SUMS weight onto existing edges
 			if err := flush(); err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "OK %d\n", total)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK %d\n", total)
 			return nil
 		},
 	}

--- a/cli/cmd/edge.go
+++ b/cli/cmd/edge.go
@@ -69,7 +69,7 @@ EXAMPLES
 		if err != nil {
 			return err
 		}
-		defer cli.Close()
+		defer func() { _ = cli.Close() }()
 
 		e, err := cli.GetEdge(cmd.Context(), args[0], args[1])
 		if err != nil {
@@ -138,7 +138,7 @@ EXAMPLES
 		if err := cli.AddEdge(cmd.Context(), args[0], args[1], float32(w), edgeAddTTL); err != nil {
 			return err
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), "OK")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "OK")
 		return nil
 	},
 }
@@ -184,7 +184,7 @@ EXAMPLES
 		if err := cli.PutEdge(cmd.Context(), args[0], args[1], float32(w), edgePutTTL); err != nil {
 			return err
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), "OK")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "OK")
 		return nil
 	},
 }

--- a/cli/cmd/edge.go
+++ b/cli/cmd/edge.go
@@ -134,7 +134,7 @@ EXAMPLES
 		if err != nil {
 			return err
 		}
-		defer cli.Close()
+		defer func() { _ = cli.Close() }()
 		if err := cli.AddEdge(cmd.Context(), args[0], args[1], float32(w), edgeAddTTL); err != nil {
 			return err
 		}
@@ -180,7 +180,7 @@ EXAMPLES
 		if err != nil {
 			return err
 		}
-		defer cli.Close()
+		defer func() { _ = cli.Close() }()
 		if err := cli.PutEdge(cmd.Context(), args[0], args[1], float32(w), edgePutTTL); err != nil {
 			return err
 		}
@@ -233,7 +233,7 @@ EXAMPLES
 		if err != nil {
 			return err
 		}
-		defer cli.Close()
+		defer func() { _ = cli.Close() }()
 
 		if len(refs) == 1 {
 			if err := cli.DeleteEdge(cmd.Context(), refs[0].Tail, refs[0].Head); err != nil {
@@ -244,7 +244,7 @@ EXAMPLES
 				return err
 			}
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "OK %d\n", len(refs))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK %d\n", len(refs))
 		return nil
 	},
 }

--- a/cli/cmd/edge.go
+++ b/cli/cmd/edge.go
@@ -1,0 +1,259 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/anaregdesign/lantern/client"
+	"github.com/spf13/cobra"
+)
+
+var edgeCmd = &cobra.Command{
+	Use:   "edge",
+	Short: "Get, add, put, or delete edges",
+	Long: `Edge operations.
+
+An edge is a directed (tail -> head) pair with a float32 weight and a TTL.
+There are two write verbs and they are NOT equivalent:
+
+  add   AddEdge is ADDITIVE. Repeated calls with the same (tail, head)
+        sum their weights server-side. AddEdge is not idempotent and is
+        deliberately excluded from the client's retry policy because
+        retrying would double-count weight.
+
+  put   PutEdge REPLACES the edge weight wholesale. PutEdge is idempotent
+        and IS in the client retry policy.
+
+Both write verbs implicitly upsert the tail and head vertices with the same
+TTL if they do not yet exist (the server materialises endpoints with empty
+values to maintain referential integrity).
+
+Subcommands:
+  get     fetch one edge weight + expiration
+  add     additive write (sums weight)
+  put     idempotent write (replaces weight)
+  delete  delete one or more edges (batch path used when more than one pair)
+`,
+}
+
+// -- edge get ---------------------------------------------------------------
+
+var edgeGetCmd = &cobra.Command{
+	Use:   "get <tail> <head>",
+	Short: "Fetch the weight of one edge",
+	Long: `Fetch the edge from <tail> to <head>.
+
+OUTPUT
+  {
+    "tail":       "<tail>",
+    "head":       "<head>",
+    "weight":     <float>,
+    "expiration": "<RFC3339 timestamp>"
+  }
+
+ERRORS
+  Exit code 2 with "rpc error: code = NotFound" when the edge does not
+  exist (either it was never created, was deleted, or its TTL expired).
+
+EXAMPLES
+  lantern edge get alice bob
+  lantern edge get alice bob | jq .weight
+`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cli, err := dial()
+		if err != nil {
+			return err
+		}
+		defer cli.Close()
+
+		e, err := cli.GetEdge(cmd.Context(), args[0], args[1])
+		if err != nil {
+			if errors.Is(err, client.ErrNotFound) {
+				return fmt.Errorf("edge %s->%s: %w", args[0], args[1], err)
+			}
+			return err
+		}
+		out := map[string]any{
+			"tail":       args[0],
+			"head":       args[1],
+			"weight":     e.Weight,
+			"expiration": e.ExpirationTime().Format(time.RFC3339),
+		}
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
+	},
+}
+
+// -- edge add / put ---------------------------------------------------------
+
+var (
+	edgeAddTTL time.Duration
+	edgePutTTL time.Duration
+)
+
+var edgeAddCmd = &cobra.Command{
+	Use:   "add <tail> <head> <weight>",
+	Short: "ADDITIVE write: sum <weight> onto (tail,head)",
+	Long: `Accumulate <weight> onto the (tail, head) edge.
+
+SEMANTICS
+  AddEdge is additive: ` + "`add a b 1.5`" + ` followed by ` + "`add a b 0.5`" + ` leaves the
+  weight at 2.0. Use this when you are streaming counts, scores, or
+  decaying interaction signal.
+
+  Because AddEdge is NOT idempotent, the client's default retry policy
+  excludes it. A transient UNAVAILABLE will surface to you so you can
+  decide whether to retry.
+
+TTL
+  --ttl bumps the edge's expiration to now+ttl on every call. There is no
+  "extend by" mode — each call sets a fresh absolute expiration. Default 24h.
+
+WEIGHT
+  Parsed as float32 (the wire type). NaN and ±Inf are rejected server-side.
+
+OUTPUT
+  Prints "OK" on success.
+
+EXAMPLES
+  lantern edge add alice bob 1.5           # weight 1.5
+  lantern edge add alice bob 0.5           # weight 2.0
+  lantern edge add alice bob 0.1 --ttl 30m # weight 2.1, TTL reset to 30m
+`,
+	Args: cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		w, err := strconv.ParseFloat(args[2], 32)
+		if err != nil {
+			return fmt.Errorf("weight: %w", err)
+		}
+		cli, err := dial()
+		if err != nil {
+			return err
+		}
+		defer cli.Close()
+		if err := cli.AddEdge(cmd.Context(), args[0], args[1], float32(w), edgeAddTTL); err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "OK")
+		return nil
+	},
+}
+
+var edgePutCmd = &cobra.Command{
+	Use:   "put <tail> <head> <weight>",
+	Short: "IDEMPOTENT write: replace (tail,head) weight",
+	Long: `Set the (tail, head) edge weight to <weight>, replacing any previous value.
+
+SEMANTICS
+  PutEdge is idempotent: ` + "`put a b 1.5`" + ` followed by ` + "`put a b 0.5`" + ` leaves the
+  weight at 0.5. Use this when the weight is a measured property of the
+  edge (similarity, distance, capacity) rather than an accumulated signal.
+
+  Because PutEdge is idempotent, the client's default retry policy retries
+  it on UNAVAILABLE / RESOURCE_EXHAUSTED.
+
+TTL
+  --ttl sets the edge's expiration to now+ttl. Default 24h.
+
+WEIGHT
+  Parsed as float32. NaN and ±Inf are rejected server-side.
+
+OUTPUT
+  Prints "OK" on success.
+
+EXAMPLES
+  lantern edge put alice bob 1.5            # weight 1.5
+  lantern edge put alice bob 0.5            # weight 0.5 (overwritten)
+  lantern edge put alice bob 0.5 --ttl 1h
+`,
+	Args: cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		w, err := strconv.ParseFloat(args[2], 32)
+		if err != nil {
+			return fmt.Errorf("weight: %w", err)
+		}
+		cli, err := dial()
+		if err != nil {
+			return err
+		}
+		defer cli.Close()
+		if err := cli.PutEdge(cmd.Context(), args[0], args[1], float32(w), edgePutTTL); err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "OK")
+		return nil
+	},
+}
+
+// -- edge delete ------------------------------------------------------------
+
+var edgeDeleteCmd = &cobra.Command{
+	Use:   "delete <tail>:<head> [<tail>:<head>...]",
+	Short: "Delete one or more edges by tail:head pair",
+	Long: `Delete edges identified by "tail:head" pairs.
+
+Each positional argument is a single "tail:head" pair separated by a literal
+colon — this avoids the ambiguity of positional pairs of two strings and
+makes shell scripting (xargs, jq -r '"\(.tail):\(.head)"') straightforward.
+
+If both endpoints contain colons, use the alternate "tail|head" syntax
+by passing --separator '|'.
+
+When more than one pair is given the batch RPC (DeleteEdges) is used,
+chunked at --chunk-size (default 1000).
+
+OUTPUT
+  Prints "OK <n>" on success, where <n> is the number of pairs submitted.
+
+EXAMPLES
+  lantern edge delete alice:bob
+  lantern edge delete alice:bob bob:carol carol:dave
+  jq -r '"\(.tail):\(.head)"' edges.json | xargs lantern edge delete
+`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sep, _ := cmd.Flags().GetString("separator")
+		if sep == "" {
+			sep = ":"
+		}
+		refs := make([]client.EdgeRef, 0, len(args))
+		for _, a := range args {
+			t, h, ok := strings.Cut(a, sep)
+			if !ok || t == "" || h == "" {
+				return fmt.Errorf("invalid pair %q (want %q-separated tail and head)", a, sep)
+			}
+			refs = append(refs, client.EdgeRef{Tail: t, Head: h})
+		}
+
+		cli, err := dial()
+		if err != nil {
+			return err
+		}
+		defer cli.Close()
+
+		if len(refs) == 1 {
+			if err := cli.DeleteEdge(cmd.Context(), refs[0].Tail, refs[0].Head); err != nil {
+				return err
+			}
+		} else {
+			if err := cli.DeleteEdges(cmd.Context(), refs); err != nil {
+				return err
+			}
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "OK %d\n", len(refs))
+		return nil
+	},
+}
+
+func init() {
+	edgeAddCmd.Flags().DurationVar(&edgeAddTTL, "ttl", 24*time.Hour, "TTL relative to now (e.g. 30s, 5m, 24h)")
+	edgePutCmd.Flags().DurationVar(&edgePutTTL, "ttl", 24*time.Hour, "TTL relative to now (e.g. 30s, 5m, 24h)")
+	edgeDeleteCmd.Flags().String("separator", ":", "delimiter inside each tail:head positional argument")
+
+	edgeCmd.AddCommand(edgeGetCmd, edgeAddCmd, edgePutCmd, edgeDeleteCmd)
+	rootCmd.AddCommand(edgeCmd)
+}

--- a/cli/cmd/illuminate.go
+++ b/cli/cmd/illuminate.go
@@ -88,7 +88,7 @@ EXAMPLES
 		if err != nil {
 			return err
 		}
-		defer cli.Close()
+		defer func() { _ = cli.Close() }()
 
 		g, err := cli.IlluminateWithOptimization(
 			cmd.Context(), args[0], illuminateStep, illuminateK, illuminateTfidf, opt)

--- a/cli/cmd/illuminate.go
+++ b/cli/cmd/illuminate.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/anaregdesign/lantern/client"
+	"github.com/spf13/cobra"
+)
+
+var (
+	illuminateStep   uint32
+	illuminateK      uint32
+	illuminateTfidf  bool
+	illuminateOptStr string
+)
+
+// optimizationByName maps human-friendly --optimize values to the server enum.
+var optimizationByName = map[string]client.Optimization{
+	"none":             client.OptimizationUnspecified,
+	"":                 client.OptimizationUnspecified,
+	"mst":              client.OptimizationMinimumSpanningTree,
+	"max-st":           client.OptimizationMaximumSpanningTree,
+	"maximum":          client.OptimizationMaximumSpanningTree,
+	"spt":              client.OptimizationShortestPathTree,
+	"shortest":         client.OptimizationShortestPathTree,
+	"inverse-spt":      client.OptimizationShortestPathTreeInverse,
+	"shortest-inverse": client.OptimizationShortestPathTreeInverse,
+}
+
+var illuminateCmd = &cobra.Command{
+	Use:   "illuminate <seed>",
+	Short: "Walk the graph from <seed> and return the visited subgraph",
+	Long: `Run a bounded breadth-first walk from <seed> and emit the visited subgraph
+as JSON.
+
+PARAMETERS
+  --step <uint32>   maximum walk depth from the seed (default 1)
+  --k <uint32>      max neighbours visited per node (default 10)
+  --tfidf           re-rank neighbours by TF-IDF over edge weights before
+                    truncating to top-k (default false)
+
+OPTIMIZATION (server-side post-processing)
+  --optimize <mode> apply a graph operator to the discovered subgraph before
+                    returning it:
+
+    none          (default) return the raw discovered subgraph
+    mst           minimum spanning tree
+    max-st        maximum spanning tree
+    spt           shortest path tree from seed (edge weight = cost)
+    inverse-spt   shortest path tree from seed using 1/weight as cost
+                  (use this when weight encodes RELEVANCE, not cost)
+
+OUTPUT
+  JSON object on stdout:
+    {
+      "vertices": { "<key>": { ...vertex... }, ... },
+      "edges":    { "<tail>": { "<head>": <weight>, ... }, ... }
+    }
+
+NOTES
+  Illuminate is read-only and idempotent. It is in the client's default
+  retry policy.
+
+  The walk runs server-side over a snapshot of the cache, so results are
+  consistent within one call but may differ between calls as TTLs expire.
+
+EXAMPLES
+  # raw 1-hop neighbourhood, top-10 by weight
+  lantern illuminate alice
+
+  # 2-hop reachability ranked by TF-IDF, top-5 per node
+  lantern illuminate alice --step 2 --k 5 --tfidf
+
+  # 3-hop MST rooted at alice (smallest-weight connecting tree)
+  lantern illuminate alice --step 3 --k 20 --optimize mst
+
+  # 3-hop relevance-weighted shortest path tree
+  lantern illuminate alice --step 3 --k 20 --optimize inverse-spt
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		opt, ok := optimizationByName[illuminateOptStr]
+		if !ok {
+			return fmt.Errorf("unknown --optimize %q (want none|mst|max-st|spt|inverse-spt)", illuminateOptStr)
+		}
+		cli, err := dial()
+		if err != nil {
+			return err
+		}
+		defer cli.Close()
+
+		g, err := cli.IlluminateWithOptimization(
+			cmd.Context(), args[0], illuminateStep, illuminateK, illuminateTfidf, opt)
+		if err != nil {
+			return err
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(g)
+	},
+}
+
+func init() {
+	illuminateCmd.Flags().Uint32Var(&illuminateStep, "step", 1, "maximum walk depth from the seed")
+	illuminateCmd.Flags().Uint32Var(&illuminateK, "k", 10, "max neighbours visited per node")
+	illuminateCmd.Flags().BoolVar(&illuminateTfidf, "tfidf", false, "re-rank neighbours by TF-IDF over edge weights before truncating")
+	illuminateCmd.Flags().StringVar(&illuminateOptStr, "optimize", "none", "server-side post-processing: none|mst|max-st|spt|inverse-spt")
+	rootCmd.AddCommand(illuminateCmd)
+}

--- a/cli/cmd/repl.go
+++ b/cli/cmd/repl.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/anaregdesign/lantern/cli/parser"
+	"github.com/anaregdesign/lantern/cli/service"
+	"github.com/manifoldco/promptui"
+	"github.com/spf13/cobra"
+)
+
+// replCmd preserves the legacy promptui-based interactive shell, now scoped
+// behind an explicit subcommand. New scripted use should prefer the
+// dedicated subcommands (vertex, edge, illuminate, bulk).
+var replCmd = &cobra.Command{
+	Use:   "repl",
+	Short: "Interactive prompt (legacy)",
+	Long: `Launch the legacy interactive prompt.
+
+The REPL accepts whitespace-delimited verbs that mirror the legacy
+lantern-cli grammar:
+
+  get vertex <key>
+  put vertex <key> <value> [ttl_seconds]
+  delete vertex <key>
+  get edge <tail> <head>
+  add edge <tail> <head> <weight> [ttl_seconds]
+  put edge <tail> <head> <weight> [ttl_seconds]
+  delete edge <tail> <head>
+  illuminate { neighbor | spt_relevance | spt_cost | mst_relevance | mst_cost } <seed> <step> <k> <tfidf>
+  exit
+
+NOTE
+  The REPL grammar is frozen for backward compatibility. New features
+  (batch RPCs, gzip, TLS flags, value typing) are only available via the
+  scriptable subcommands.
+
+EXAMPLE
+  $ lantern repl
+  > put vertex alice "Alice"
+  OK (1.4ms)
+  > get vertex alice
+  "Alice"
+  OK (0.8ms)
+  > exit
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cli, err := dial()
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := cli.Close(); err != nil {
+				log.Println("close:", err)
+			}
+		}()
+		srv := service.NewCLIService(cli)
+
+		tpl := &promptui.PromptTemplates{
+			Prompt:  "{{ . }} ",
+			Valid:   "{{ . | green }} ",
+			Invalid: "{{ . | red }} ",
+			Success: "{{ . | bold }} ",
+		}
+		prompt := promptui.Prompt{
+			Label:     ">",
+			Validate:  parser.Validate,
+			Templates: tpl,
+		}
+
+		ctx := cmd.Context()
+		for {
+			if err := ctx.Err(); err != nil {
+				return nil
+			}
+			result, err := prompt.Run()
+			if err != nil {
+				return err
+			}
+			if result == "exit" {
+				return nil
+			}
+			start := time.Now()
+			err = srv.Run(ctx, result)
+			elapsed := time.Since(start)
+			switch err {
+			case nil:
+				fmt.Printf("OK (%v)\n", elapsed)
+			case service.ErrGetVertex:
+				fmt.Println("Usage: get vertex <key: string>")
+			case service.ErrGetEdge:
+				fmt.Println("Usage: get edge <tail: string> <head: string>")
+			case service.ErrPutVertex:
+				fmt.Println("Usage: put vertex <key: string> <value: string> [<ttl_seconds: int>]")
+			case service.ErrPutEdge:
+				fmt.Println("Usage: put edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]")
+			case service.ErrDeleteVertex:
+				fmt.Println("Usage: delete vertex <key: string>")
+			case service.ErrDeleteEdge:
+				fmt.Println("Usage: delete edge <tail: string> <head: string>")
+			case service.ErrAddEdge:
+				fmt.Println("Usage: add edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]")
+			case service.ErrIlluminate:
+				fmt.Println("Usage: illuminate { neighbor | spt_relevance | spt_cost | mst_relevance | mst_cost } <seed: string> <step: int> <k: int> <tfidf: bool>")
+			case service.ErrInvalidVerb:
+				fmt.Println("Usage: { get | put | delete | add | illuminate } ...")
+			case service.ErrInvalidObjective:
+				fmt.Println("{ get { vertex | edge } | put { vertex | edge } | delete { vertex | edge } | add edge | illuminate {...} } ...")
+			case service.ErrConnection:
+				fmt.Println("server error")
+			default:
+				fmt.Println(err)
+			}
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(replCmd)
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -1,123 +1,208 @@
+// Package cmd implements the `lantern` CLI: a cobra-based command tree that
+// exposes every Lantern gRPC RPC as a one-shot subcommand and ships the legacy
+// interactive prompt as `lantern repl`.
+//
+// The help text on every subcommand is intentionally long-form and
+// example-heavy because this CLI is expected to be driven by both humans and
+// by generative-AI coding agents. Each command documents its semantics,
+// flags, output shape, and exit codes so an agent can use the CLI without
+// reading server source.
 package cmd
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
-	"github.com/anaregdesign/lantern/cli/parser"
-	"github.com/anaregdesign/lantern/cli/service"
-	"github.com/manifoldco/promptui"
-	"log"
 	"net"
 	"os"
+	"os/signal"
 	"strconv"
+	"strings"
+	"syscall"
 	"time"
 
 	"github.com/anaregdesign/lantern/client"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/credentials"
+	credinsecure "google.golang.org/grpc/credentials/insecure"
 )
 
+// connection / transport flags (global)
 var (
-	host string
-	port int
+	flagHost        string
+	flagPort        int
+	flagAddress     string
+	flagTimeout     time.Duration
+	flagTLS         bool
+	flagTLSCA       string
+	flagTLSCert     string
+	flagTLSKey      string
+	flagTLSServer   string
+	flagInsecureTLS bool
+	flagCompression string
+	flagChunkSize   int
 )
 
-// rootCmd represents the base command when called without any subcommands
+// rootCmd is the top-level command. It prints help when invoked with no
+// subcommand so that "lantern" alone is a no-op rather than dropping into a
+// REPL — the REPL is now `lantern repl`.
 var rootCmd = &cobra.Command{
-	Use:   "lantern-cli",
-	Short: "A CLI for Lantern",
-	Long:  `A CLI for Lantern. `,
+	Use:   "lantern",
+	Short: "CLI for the Lantern in-memory key-vertex store",
+	Long: `lantern is the official command-line client for the Lantern gRPC server
+(github.com/anaregdesign/lantern).
 
-	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := context.Background()
-		cli, err := client.NewLantern(net.JoinHostPort(host, strconv.Itoa(port)))
-		srv := service.NewCLIService(cli)
-		if err != nil {
-			return err
-		}
-		defer func() {
-			err := cli.Close()
-			if err != nil {
-				log.Fatal(err)
-			}
-		}()
+WHAT LANTERN IS
+  Lantern is an in-memory graph KVS. Every vertex and every edge carries a
+  TTL and decays on its own; edges are additive (AddEdge sums weight onto
+  the same (tail, head) pair, PutEdge replaces it). The server exposes a
+  small gRPC surface — this CLI wraps every RPC as a scriptable subcommand
+  plus an interactive REPL.
 
-		template := &promptui.PromptTemplates{
-			Prompt:  "{{ . }} ",
-			Valid:   "{{ . | green }} ",
-			Invalid: "{{ . | red }} ",
-			Success: "{{ . | bold }} ",
-		}
-		prompt := promptui.Prompt{
-			Label:     ">",
-			Validate:  parser.Validate,
-			Templates: template,
-		}
+COMMAND LAYOUT
+  vertex      get / put / delete vertices (single or batch)
+  edge        get / add / put / delete edges (single or batch)
+  illuminate  walk the graph from a seed; optional server-side optimization
+  bulk        stream NDJSON from a file or stdin (bulk load)
+  repl        legacy interactive prompt
+  version     print client version
+  completion  generate shell completions (bash, zsh, fish, powershell)
 
-		for {
-			result, err := prompt.Run()
-			if err != nil {
-				return err
-			}
+GLOBAL CONNECTION FLAGS
+  -H, --host         server hostname (default "localhost")
+  -p, --port         server port (default 6380)
+      --address      full host:port; overrides --host/--port when set
+      --timeout      per-RPC deadline (default 5s, 0 disables)
+      --tls          dial with TLS instead of plaintext
+      --tls-ca       path to a PEM bundle for verifying the server cert
+      --tls-cert     client cert (mTLS)
+      --tls-key      client key (mTLS)
+      --tls-server-name  override the SNI / verification hostname
+      --insecure-skip-verify  skip server cert verification (dev only)
+      --compression  per-call compressor: "none" (default) or "gzip"
+      --chunk-size   batch chunk size for multi-key write/delete (default 1000)
 
-			switch result {
-			case "exit":
-				return nil
+OUTPUT
+  All read commands print JSON on stdout. All write commands print a single
+  "OK" line on stdout when they succeed. Errors go to stderr.
 
-			default:
-				start := time.Now()
-				err := srv.Run(ctx, result)
-				end := time.Now()
-				switch err {
-				case nil:
-					fmt.Printf("OK (%v)\n", end.Sub(start))
-				case service.ErrGetVertex:
-					fmt.Println("Usage: get vertex <key: string>")
-				case service.ErrGetEdge:
-					fmt.Println("Usage: get edge <tail: string> <head: string>")
+EXIT CODES
+  0  success
+  1  invalid arguments or local error (parse, file I/O)
+  2  gRPC error returned by the server (NotFound, InvalidArgument, …)
 
-				case service.ErrPutVertex:
-					fmt.Println("Usage: put vertex <key: string> <value: string> [<ttl_seconds: int>]")
+EXAMPLES
+  # one-shot writes against a local server
+  lantern vertex put alice '{"name":"Alice"}' --value-type json --ttl 1h
+  lantern edge add alice bob 1.5 --ttl 30m
+  lantern edge add alice bob 0.5      # weight now totals 2.0
 
-				case service.ErrPutEdge:
-					fmt.Println("Usage: put edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]")
+  # batch delete (uses DeleteVertices)
+  lantern vertex delete alice bob carol
 
-				case service.ErrDeleteVertex:
-					fmt.Println("Usage: delete vertex <key: string>")
+  # walk from a seed and emit the 1-hop neighborhood as JSON
+  lantern illuminate alice --step 1 --k 10
 
-				case service.ErrDeleteEdge:
-					fmt.Println("Usage: delete edge <tail: string> <head: string>")
-
-				case service.ErrAddEdge:
-					fmt.Println("Usage: add edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]")
-
-				case service.ErrIlluminate:
-					fmt.Println("Usage: illuminate { neighbor | spt_relevance | spt_cost | msp_relevance | msp_cost } <seed: string> <step: int> <k: int> <tfidf: bool>")
-
-				case service.ErrInvalidVerb:
-					fmt.Println("Usage: { get | put | delete | add | illuminate } ...")
-
-				case service.ErrInvalidObjective:
-					fmt.Println("{\n\tget { vertex | edge } | \n\tput { vertex | edge } | \n\tdelete { vertex | edge } | \n\tadd edge | \n\tilluminate { neighbor | spt_relevance | spt_cost | msp_relevance | msp_cost }\n} ...\nspt: shortest path tree\nmsp: minimum spanning tree")
-
-				case service.ErrConnection:
-					fmt.Println("server error")
-
-				default:
-					fmt.Println(err)
-				}
-			}
-		}
-	},
+  # against a TLS server
+  lantern --tls --tls-ca ./ca.pem -H lantern.example.com -p 443 vertex get alice
+`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }
 
+// Execute runs the root command. It is the only function main.go calls.
 func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
+	if err := rootCmd.ExecuteContext(signalContext()); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		// Exit code 2 if the error came from the server (gRPC errors carry an
+		// "rpc error:" prefix). Use 1 for everything else.
+		if strings.Contains(err.Error(), "rpc error") {
+			os.Exit(2)
+		}
 		os.Exit(1)
 	}
 }
 
+// signalContext returns a context that is cancelled on SIGINT / SIGTERM so
+// long-running commands (REPL, bulk loaders) shut down cleanly.
+func signalContext() context.Context {
+	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	return ctx
+}
+
 func init() {
-	rootCmd.Flags().StringVarP(&host, "host", "H", "localhost", "host")
-	rootCmd.Flags().IntVarP(&port, "port", "p", 6380, "port")
+	pf := rootCmd.PersistentFlags()
+	pf.StringVarP(&flagHost, "host", "H", "localhost", "server hostname")
+	pf.IntVarP(&flagPort, "port", "p", 6380, "server port")
+	pf.StringVar(&flagAddress, "address", "", "full host:port (overrides --host/--port)")
+	pf.DurationVar(&flagTimeout, "timeout", 5*time.Second, "per-RPC timeout (0 disables)")
+	pf.BoolVar(&flagTLS, "tls", false, "use TLS")
+	pf.StringVar(&flagTLSCA, "tls-ca", "", "PEM bundle for server cert verification")
+	pf.StringVar(&flagTLSCert, "tls-cert", "", "client certificate for mTLS")
+	pf.StringVar(&flagTLSKey, "tls-key", "", "client key for mTLS")
+	pf.StringVar(&flagTLSServer, "tls-server-name", "", "SNI / verification hostname override")
+	pf.BoolVar(&flagInsecureTLS, "insecure-skip-verify", false, "skip server cert verification (DEV ONLY)")
+	pf.StringVar(&flagCompression, "compression", "none", `per-call compressor: "none" or "gzip"`)
+	pf.IntVar(&flagChunkSize, "chunk-size", 1000, "batch chunk size for multi-key write/delete")
+}
+
+// target returns the resolved dial target host:port.
+func target() string {
+	if flagAddress != "" {
+		return flagAddress
+	}
+	return net.JoinHostPort(flagHost, strconv.Itoa(flagPort))
+}
+
+// dial constructs a *client.Lantern using the resolved global flags. The
+// caller is responsible for calling Close on the returned client.
+func dial() (*client.Lantern, error) {
+	opts := []client.Option{
+		client.WithDefaultTimeout(flagTimeout),
+		client.WithBatchChunkSize(flagChunkSize),
+	}
+	if flagCompression != "" && flagCompression != "none" {
+		opts = append(opts, client.WithCompression(flagCompression))
+	}
+	if flagTLS || flagTLSCA != "" || flagTLSCert != "" {
+		creds, err := buildTLSCreds()
+		if err != nil {
+			return nil, fmt.Errorf("tls: %w", err)
+		}
+		opts = append(opts, client.WithTransportCredentials(creds))
+	} else {
+		opts = append(opts, client.WithTransportCredentials(credinsecure.NewCredentials()))
+	}
+	return client.NewLantern(target(), opts...)
+}
+
+func buildTLSCreds() (credentials.TransportCredentials, error) {
+	cfg := &tls.Config{
+		ServerName:         flagTLSServer,
+		InsecureSkipVerify: flagInsecureTLS, //nolint:gosec // opt-in via flag
+		MinVersion:         tls.VersionTLS12,
+	}
+	if flagTLSCA != "" {
+		caPEM, err := os.ReadFile(flagTLSCA)
+		if err != nil {
+			return nil, fmt.Errorf("read CA: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caPEM) {
+			return nil, fmt.Errorf("parse CA bundle %q", flagTLSCA)
+		}
+		cfg.RootCAs = pool
+	}
+	if flagTLSCert != "" || flagTLSKey != "" {
+		if flagTLSCert == "" || flagTLSKey == "" {
+			return nil, fmt.Errorf("--tls-cert and --tls-key must be supplied together")
+		}
+		pair, err := tls.LoadX509KeyPair(flagTLSCert, flagTLSKey)
+		if err != nil {
+			return nil, fmt.Errorf("load client keypair: %w", err)
+		}
+		cfg.Certificates = []tls.Certificate{pair}
+	}
+	return credentials.NewTLS(cfg), nil
 }

--- a/cli/cmd/value.go
+++ b/cli/cmd/value.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// parseValue converts a raw string from argv into a Go value suitable for
+// Lantern.PutVertex. The valueType controls disambiguation:
+//
+//	auto      try int, then float, then bool, then RFC3339, else string
+//	string    keep as raw string
+//	int       strconv.Atoi (int64)
+//	float     strconv.ParseFloat (float64)
+//	bool      strconv.ParseBool
+//	datetime  time.Parse(time.RFC3339, ...)
+//	json      json.Unmarshal — supports objects, arrays, scalars
+//
+// auto is the default. It is unambiguous for most string keys/values, but if
+// you need to insist on a string that *looks* like a number, pass
+// --value-type string.
+func parseValue(raw, valueType string) (any, error) {
+	switch valueType {
+	case "", "auto":
+		if v, err := strconv.Atoi(raw); err == nil {
+			return v, nil
+		}
+		if v, err := strconv.ParseFloat(raw, 64); err == nil {
+			return v, nil
+		}
+		if v, err := strconv.ParseBool(raw); err == nil {
+			return v, nil
+		}
+		if v, err := time.Parse(time.RFC3339, raw); err == nil {
+			return v, nil
+		}
+		return raw, nil
+	case "string":
+		return raw, nil
+	case "int":
+		v, err := strconv.Atoi(raw)
+		if err != nil {
+			return nil, fmt.Errorf("--value-type=int: %w", err)
+		}
+		return v, nil
+	case "float":
+		v, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return nil, fmt.Errorf("--value-type=float: %w", err)
+		}
+		return v, nil
+	case "bool":
+		v, err := strconv.ParseBool(raw)
+		if err != nil {
+			return nil, fmt.Errorf("--value-type=bool: %w", err)
+		}
+		return v, nil
+	case "datetime":
+		v, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			return nil, fmt.Errorf("--value-type=datetime (RFC3339): %w", err)
+		}
+		return v, nil
+	case "json":
+		var v any
+		if err := json.Unmarshal([]byte(raw), &v); err != nil {
+			return nil, fmt.Errorf("--value-type=json: %w", err)
+		}
+		return v, nil
+	default:
+		return nil, fmt.Errorf("unknown --value-type %q (want auto|string|int|float|bool|datetime|json)", valueType)
+	}
+}

--- a/cli/cmd/value_test.go
+++ b/cli/cmd/value_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestParseValue(t *testing.T) {
+	rfc := "2025-01-02T03:04:05Z"
+	parsedTime, _ := time.Parse(time.RFC3339, rfc)
+
+	tests := []struct {
+		name      string
+		raw       string
+		valueType string
+		want      any
+		wantErr   bool
+	}{
+		// auto
+		{"auto/int", "42", "auto", 42, false},
+		{"auto/float", "3.14", "auto", 3.14, false},
+		{"auto/bool", "true", "auto", true, false},
+		{"auto/datetime", rfc, "auto", parsedTime, false},
+		{"auto/string", "hello", "auto", "hello", false},
+		{"auto/empty-default", "x", "", "x", false},
+		// string
+		{"string/keeps-leading-zero", "01234", "string", "01234", false},
+		{"string/keeps-numeric", "42", "string", "42", false},
+		// int
+		{"int/ok", "42", "int", 42, false},
+		{"int/err", "x", "int", nil, true},
+		// float
+		{"float/ok", "3.14", "float", 3.14, false},
+		{"float/err", "x", "float", nil, true},
+		// bool
+		{"bool/ok", "true", "bool", true, false},
+		{"bool/err", "yes", "bool", nil, true},
+		// datetime
+		{"datetime/ok", rfc, "datetime", parsedTime, false},
+		{"datetime/err", "yesterday", "datetime", nil, true},
+		// json
+		{"json/object", `{"a":1}`, "json", map[string]any{"a": float64(1)}, false},
+		{"json/array", `[1,2]`, "json", []any{float64(1), float64(2)}, false},
+		{"json/scalar", `"hi"`, "json", "hi", false},
+		{"json/err", `{`, "json", nil, true},
+		// unknown
+		{"unknown-type", "x", "weird", nil, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseValue(tc.raw, tc.valueType)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %#v (%T), want %#v (%T)", got, got, tc.want, tc.want)
+			}
+		})
+	}
+}

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -31,7 +31,7 @@ tagged commit is the tag string and for plain ` + "`go build`" + ` is "(devel)".
 		if v == "" {
 			v = "(unknown)"
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), v)
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), v)
 		return nil
 	},
 }

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+// version is overridden at build time via -ldflags "-X .../cli/cmd.version=..."
+// and falls back to the embedded module version when unset.
+var version = ""
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print client version",
+	Long: `Print the CLI client version.
+
+When built with ` + "`-ldflags '-X github.com/anaregdesign/lantern/cli/cmd.version=vX.Y.Z'`" + `
+the injected string is printed. Otherwise the version embedded by the Go
+toolchain (debug.ReadBuildInfo) is used, which for ` + "`go install`" + ` builds at a
+tagged commit is the tag string and for plain ` + "`go build`" + ` is "(devel)".`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		v := version
+		if v == "" {
+			if info, ok := debug.ReadBuildInfo(); ok {
+				v = info.Main.Version
+			}
+		}
+		if v == "" {
+			v = "(unknown)"
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), v)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cli/cmd/vertex.go
+++ b/cli/cmd/vertex.go
@@ -129,7 +129,7 @@ EXAMPLES
 		if err := cli.PutVertex(cmd.Context(), args[0], val, vertexPutTTL); err != nil {
 			return err
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), "OK")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "OK")
 		return nil
 	},
 }
@@ -176,7 +176,7 @@ EXAMPLES
 				return err
 			}
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "OK %d\n", len(args))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK %d\n", len(args))
 		return nil
 	},
 }

--- a/cli/cmd/vertex.go
+++ b/cli/cmd/vertex.go
@@ -1,0 +1,190 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/anaregdesign/lantern/client"
+	"github.com/spf13/cobra"
+)
+
+var vertexCmd = &cobra.Command{
+	Use:   "vertex",
+	Short: "Get, put, or delete vertices",
+	Long: `Vertex operations.
+
+A "vertex" in Lantern is a key (string) plus an arbitrary value plus an
+expiration time. Values are typed: the client sends int, float, bool,
+string, datetime (RFC3339), or JSON. Use --value-type to override the
+auto-detected type at "vertex put".
+
+Subcommands:
+  get     fetch one vertex by key (errors with NotFound if absent)
+  put     upsert one vertex with a relative TTL
+  delete  delete one or more vertices (batch path used when more than one key)
+`,
+}
+
+// -- vertex get -------------------------------------------------------------
+
+var vertexGetCmd = &cobra.Command{
+	Use:   "get <key>",
+	Short: "Fetch a vertex by key",
+	Long: `Fetch the vertex stored at <key>.
+
+OUTPUT
+  JSON object on stdout with the fields:
+    {
+      "key":        "<key>",
+      "value":      <typed value: string|number|bool|object|array|null>,
+      "expiration": "<RFC3339 timestamp>"
+    }
+
+ERRORS
+  Exit code 2 with "rpc error: code = NotFound" when the key is absent or
+  has already expired. Use this to distinguish "missing" from "broken".
+
+EXAMPLES
+  lantern vertex get alice
+  lantern vertex get alice | jq .value
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cli, err := dial()
+		if err != nil {
+			return err
+		}
+		defer cli.Close()
+
+		v, err := cli.GetVertex(cmd.Context(), args[0])
+		if err != nil {
+			if errors.Is(err, client.ErrNotFound) {
+				return fmt.Errorf("vertex %q: %w", args[0], err)
+			}
+			return err
+		}
+		out := map[string]any{
+			"key":        args[0],
+			"value":      v.Value,
+			"expiration": v.Expiration.AsTime().Format(time.RFC3339),
+		}
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
+	},
+}
+
+// -- vertex put -------------------------------------------------------------
+
+var (
+	vertexPutTTL       time.Duration
+	vertexPutValueType string
+)
+
+var vertexPutCmd = &cobra.Command{
+	Use:   "put <key> <value>",
+	Short: "Upsert a vertex with a relative TTL",
+	Long: `Upsert the vertex at <key> with the given <value>.
+
+VALUE TYPING
+  By default --value-type=auto tries (in order) int, float, bool, RFC3339
+  datetime, then falls back to string. Pass --value-type explicitly when
+  the value is ambiguous:
+
+    --value-type=string   force string ("123" stays a string)
+    --value-type=int      base-10 integer
+    --value-type=float    IEEE 754 double
+    --value-type=bool     true / false / 1 / 0
+    --value-type=datetime RFC3339, e.g. 2025-01-01T00:00:00Z
+    --value-type=json     parse <value> as JSON (object, array, scalar)
+
+TTL SEMANTICS
+  --ttl is a Go duration relative to the server's "now" at receipt
+  (e.g. 30s, 5m, 1h, 24h, 168h). The vertex is reaped lazily after it
+  expires. Default 24h.
+
+OUTPUT
+  Prints "OK" on success. Errors go to stderr (exit code 2 for server
+  errors, 1 for local parse errors).
+
+EXAMPLES
+  lantern vertex put alice "Alice Smith"                 # string
+  lantern vertex put count  42                            # int (auto)
+  lantern vertex put price  19.99                         # float (auto)
+  lantern vertex put alive  true                          # bool (auto)
+  lantern vertex put alice '{"age":30}' --value-type=json --ttl 1h
+  lantern vertex put zipcode "01234" --value-type=string  # keep leading zero
+`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		val, err := parseValue(args[1], vertexPutValueType)
+		if err != nil {
+			return err
+		}
+		cli, err := dial()
+		if err != nil {
+			return err
+		}
+		defer cli.Close()
+		if err := cli.PutVertex(cmd.Context(), args[0], val, vertexPutTTL); err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "OK")
+		return nil
+	},
+}
+
+// -- vertex delete ----------------------------------------------------------
+
+var vertexDeleteCmd = &cobra.Command{
+	Use:   "delete <key> [<key>...]",
+	Short: "Delete one or more vertices",
+	Long: `Delete the vertices at the given keys.
+
+When a single key is given the single-key RPC (DeleteVertex) is used.
+When more than one key is given the batch RPC (DeleteVertices) is used,
+which the client chunks at --chunk-size (default 1000) to stay below
+the server's MaxBatchSize cap.
+
+EDGE CLEANUP
+  Edges incident to a removed vertex are NOT eagerly deleted — they are
+  reaped lazily by the server GC loop along with their own TTL. A GetEdge
+  immediately after DeleteVertex may still return the edge briefly.
+
+OUTPUT
+  Prints "OK <n>" on success, where <n> is the number of keys submitted.
+
+EXAMPLES
+  lantern vertex delete alice                       # single
+  lantern vertex delete alice bob carol             # batch (DeleteVertices)
+  cat keys.txt | xargs lantern vertex delete         # batch from a file
+`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cli, err := dial()
+		if err != nil {
+			return err
+		}
+		defer cli.Close()
+
+		if len(args) == 1 {
+			if err := cli.DeleteVertex(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+		} else {
+			if err := cli.DeleteVertices(cmd.Context(), args); err != nil {
+				return err
+			}
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "OK %d\n", len(args))
+		return nil
+	},
+}
+
+func init() {
+	vertexPutCmd.Flags().DurationVar(&vertexPutTTL, "ttl", 24*time.Hour, "TTL relative to now (e.g. 30s, 5m, 24h)")
+	vertexPutCmd.Flags().StringVar(&vertexPutValueType, "value-type", "auto", "type of <value>: auto|string|int|float|bool|datetime|json")
+
+	vertexCmd.AddCommand(vertexGetCmd, vertexPutCmd, vertexDeleteCmd)
+	rootCmd.AddCommand(vertexCmd)
+}

--- a/cli/cmd/vertex.go
+++ b/cli/cmd/vertex.go
@@ -56,7 +56,7 @@ EXAMPLES
 		if err != nil {
 			return err
 		}
-		defer cli.Close()
+		defer func() { _ = cli.Close() }()
 
 		v, err := cli.GetVertex(cmd.Context(), args[0])
 		if err != nil {
@@ -125,7 +125,7 @@ EXAMPLES
 		if err != nil {
 			return err
 		}
-		defer cli.Close()
+		defer func() { _ = cli.Close() }()
 		if err := cli.PutVertex(cmd.Context(), args[0], val, vertexPutTTL); err != nil {
 			return err
 		}
@@ -165,7 +165,7 @@ EXAMPLES
 		if err != nil {
 			return err
 		}
-		defer cli.Close()
+		defer func() { _ = cli.Close() }()
 
 		if len(args) == 1 {
 			if err := cli.DeleteVertex(cmd.Context(), args[0]); err != nil {


### PR DESCRIPTION
Replace the single-command promptui REPL with a complete cobra command tree, designed for both human and LLM consumers. Every gRPC RPC is now exposed as a scriptable subcommand with verbose Long help.

## What's new

- **`lantern vertex {get|put|delete}`** — single + batch deletes, typed values (`--value-type auto|string|int|float|bool|datetime|json`), TTL flag.
- **`lantern edge {get|add|put|delete}`** — Long help explicitly contrasts additive `add` vs idempotent `put` (retry policy, weight summation). Delete takes positional `tail:head` pairs and falls back to batch DeleteEdges automatically.
- **`lantern illuminate <seed>`** — `--step --k --tfidf --optimize {none|mst|max-st|spt|inverse-spt}`; the optimize flag drives server-side post-processing via the existing Optimization enum.
- **`lantern bulk vertices|edges {add|put} <file|->`** — streaming NDJSON loader that auto-chunks into PutVertices / AddEdges / PutEdges.
- **`lantern repl`** — the legacy promptui interactive shell, scoped behind an explicit subcommand.
- **`lantern version`** — ldflags-injected or `runtime/debug.ReadBuildInfo()` fallback.

## Global flags

`--host/--port/--address`, `--timeout`, `--tls` family (`--tls-ca`, `--tls-cert`, `--tls-key`, `--tls-server-name`, `--insecure-skip-verify`), `--compression none|gzip`, `--chunk-size`. SIGINT/SIGTERM are wired into the root context so long reads and bulk loads cancel cleanly.

## Output contract

- Read commands emit JSON on stdout.
- Write commands print `OK` (or `OK <n>` for batches) on stdout.
- Errors go to stderr; exit code `0` success, `1` local/parse error, `2` gRPC error.

## Tests

`parseValue` is covered by a table test in `cli/cmd/value_test.go`.