### PR TITLE
Add MarshalJSON to client.Vertex so CLI output stops leaking proto field names

### DIFF
--- a/cli/cmd/vertex.go
+++ b/cli/cmd/vertex.go
@@ -38,8 +38,9 @@ OUTPUT
   JSON object on stdout with the fields:
     {
       "key":        "<key>",
-      "value":      <typed value: string|number|bool|object|array|null>,
-      "expiration": "<RFC3339 timestamp>"
+      "type":       "string"|"int64"|"float64"|"bool"|"bytes"|"timestamp"|"nil"|...,
+      "value":      <typed value: string|number|bool|base64|null>,
+      "expiration": "<RFC3339Nano timestamp>"
     }
 
 ERRORS
@@ -65,12 +66,7 @@ EXAMPLES
 			}
 			return err
 		}
-		out := map[string]any{
-			"key":        args[0],
-			"value":      v.Value,
-			"expiration": v.Expiration.AsTime().Format(time.RFC3339),
-		}
-		return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(v)
 	},
 }
 

--- a/client/value.go
+++ b/client/value.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"errors"
 	"math"
 	"time"
@@ -237,4 +238,60 @@ func (v *Vertex) IsNil() bool {
 		return x.Nil
 	}
 	return false
+}
+
+// MarshalJSON renders a Vertex as a stable, human-readable JSON object so
+// callers don't have to peek at protobuf-generated oneof field names (e.g.
+// "String_", "Int64", "Nil"). The shape is:
+//
+//	{
+//	  "key":        "<key>",                // omitted when empty
+//	  "type":       "string"|"int32"|...,   // VertexKind in lowercase
+//	  "value":      <typed JSON value>,     // null for nil/unset
+//	  "expiration": "<RFC3339Nano>"         // omitted when zero
+//	}
+//
+// Bytes are base64-encoded (Go's default for []byte); timestamps are RFC3339Nano.
+func (v *Vertex) MarshalJSON() ([]byte, error) {
+	out := struct {
+		Key        string `json:"key,omitempty"`
+		Type       string `json:"type"`
+		Value      any    `json:"value"`
+		Expiration string `json:"expiration,omitempty"`
+	}{}
+	if v == nil {
+		out.Type = "unset"
+		return json.Marshal(out)
+	}
+	out.Key = v.Key
+	if t := v.ExpirationTime(); !t.IsZero() {
+		out.Expiration = t.Format(time.RFC3339Nano)
+	}
+	switch x := v.Value.(type) {
+	case *pb.Vertex_Float32:
+		out.Type, out.Value = "float32", x.Float32
+	case *pb.Vertex_Float64:
+		out.Type, out.Value = "float64", x.Float64
+	case *pb.Vertex_Int32:
+		out.Type, out.Value = "int32", x.Int32
+	case *pb.Vertex_Int64:
+		out.Type, out.Value = "int64", x.Int64
+	case *pb.Vertex_Uint32:
+		out.Type, out.Value = "uint32", x.Uint32
+	case *pb.Vertex_Uint64:
+		out.Type, out.Value = "uint64", x.Uint64
+	case *pb.Vertex_Bool:
+		out.Type, out.Value = "bool", x.Bool
+	case *pb.Vertex_String_:
+		out.Type, out.Value = "string", x.String_
+	case *pb.Vertex_Bytes:
+		out.Type, out.Value = "bytes", x.Bytes
+	case *pb.Vertex_Timestamp:
+		out.Type, out.Value = "timestamp", x.Timestamp.AsTime().Format(time.RFC3339Nano)
+	case *pb.Vertex_Nil:
+		out.Type, out.Value = "nil", nil
+	default:
+		out.Type, out.Value = "unset", nil
+	}
+	return json.Marshal(out)
 }

--- a/client/value_test.go
+++ b/client/value_test.go
@@ -315,3 +315,65 @@ func Test_nativeVertex_asVertex(t *testing.T) {
 		})
 	}
 }
+
+func TestVertex_MarshalJSON(t *testing.T) {
+	exp := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	ts := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		v    *Vertex
+		want string
+	}{
+		{
+			name: "string with key and expiration",
+			v: &Vertex{
+				Key:        "a",
+				Expiration: timestamppb.New(exp),
+				Value:      &pb.Vertex_String_{String_: "A"},
+			},
+			want: `{"key":"a","type":"string","value":"A","expiration":"2026-01-02T03:04:05Z"}`,
+		},
+		{
+			name: "int64 without expiration",
+			v:    &Vertex{Value: &pb.Vertex_Int64{Int64: 42}},
+			want: `{"type":"int64","value":42}`,
+		},
+		{
+			name: "bool true",
+			v:    &Vertex{Value: &pb.Vertex_Bool{Bool: true}},
+			want: `{"type":"bool","value":true}`,
+		},
+		{
+			name: "bytes base64",
+			v:    &Vertex{Value: &pb.Vertex_Bytes{Bytes: []byte("hi")}},
+			want: `{"type":"bytes","value":"aGk="}`,
+		},
+		{
+			name: "timestamp RFC3339Nano",
+			v:    &Vertex{Value: &pb.Vertex_Timestamp{Timestamp: timestamppb.New(ts)}},
+			want: `{"type":"timestamp","value":"2026-06-01T00:00:00Z"}`,
+		},
+		{
+			name: "nil sentinel",
+			v:    &Vertex{Value: &pb.Vertex_Nil{Nil: true}},
+			want: `{"type":"nil","value":null}`,
+		},
+		{
+			name: "nil vertex",
+			v:    nil,
+			want: `{"type":"unset","value":null}`,
+		},
+	}
+	for i := range tests {
+		tt := &tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.v.MarshalJSON()
+			if err != nil {
+				t.Fatalf("MarshalJSON() error = %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("MarshalJSON() got = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously CLI commands that JSON-encoded a *Vertex emitted protobuf-generated
oneof field names (e.g. "String_", "Int64", "Nil"), which is ugly and
exposes internal naming quirks.

Add (*Vertex).MarshalJSON that renders a stable shape:
  {"key":..., "type":<kind>, "value":<typed>, "expiration":<RFC3339Nano>}

Types map to lowercase VertexKind names (string, int32, int64, uint32, uint64,
float32, float64, bool, bytes, timestamp, nil). Bytes use Go's default base64
[]byte encoding; timestamps use RFC3339Nano.

This automatically fixes 'illuminate' output (Graph.Vertices values are
*Vertex) and simplifies 'vertex get' to a single encode call.
