### PR TITLE
Add google.protobuf.Duration as a Vertex value variant

### DIFF
--- a/cli/cmd/value.go
+++ b/cli/cmd/value.go
@@ -63,6 +63,12 @@ func parseValue(raw, valueType string) (any, error) {
 			return nil, fmt.Errorf("--value-type=datetime (RFC3339): %w", err)
 		}
 		return v, nil
+	case "duration":
+		v, err := time.ParseDuration(raw)
+		if err != nil {
+			return nil, fmt.Errorf("--value-type=duration: %w", err)
+		}
+		return v, nil
 	case "json":
 		var v any
 		if err := json.Unmarshal([]byte(raw), &v); err != nil {
@@ -70,6 +76,6 @@ func parseValue(raw, valueType string) (any, error) {
 		}
 		return v, nil
 	default:
-		return nil, fmt.Errorf("unknown --value-type %q (want auto|string|int|float|bool|datetime|json)", valueType)
+		return nil, fmt.Errorf("unknown --value-type %q (want auto|string|int|float|bool|datetime|duration|json)", valueType)
 	}
 }

--- a/cli/cmd/vertex.go
+++ b/cli/cmd/vertex.go
@@ -38,7 +38,7 @@ OUTPUT
   JSON object on stdout with the fields:
     {
       "key":        "<key>",
-      "type":       "string"|"int64"|"float64"|"bool"|"bytes"|"timestamp"|"nil"|...,
+      "type":       "string"|"int64"|"float64"|"bool"|"bytes"|"timestamp"|"duration"|"nil"|...,
       "value":      <typed value: string|number|bool|base64|null>,
       "expiration": "<RFC3339Nano timestamp>"
     }
@@ -92,6 +92,7 @@ VALUE TYPING
     --value-type=float    IEEE 754 double
     --value-type=bool     true / false / 1 / 0
     --value-type=datetime RFC3339, e.g. 2025-01-01T00:00:00Z
+    --value-type=duration Go duration, e.g. 30s, 5m, 1h30m
     --value-type=json     parse <value> as JSON (object, array, scalar)
 
 TTL SEMANTICS
@@ -179,7 +180,7 @@ EXAMPLES
 
 func init() {
 	vertexPutCmd.Flags().DurationVar(&vertexPutTTL, "ttl", 24*time.Hour, "TTL relative to now (e.g. 30s, 5m, 24h)")
-	vertexPutCmd.Flags().StringVar(&vertexPutValueType, "value-type", "auto", "type of <value>: auto|string|int|float|bool|datetime|json")
+	vertexPutCmd.Flags().StringVar(&vertexPutValueType, "value-type", "auto", "type of <value>: auto|string|int|float|bool|datetime|duration|json")
 
 	vertexCmd.AddCommand(vertexGetCmd, vertexPutCmd, vertexDeleteCmd)
 	rootCmd.AddCommand(vertexCmd)

--- a/client/value.go
+++ b/client/value.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	pb "github.com/anaregdesign/lantern/gen/go/graph/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -68,6 +69,8 @@ func (v nativeVertex) asVertex() (*pb.Vertex, error) {
 		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Bytes{Bytes: x}}, nil
 	case time.Time:
 		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Timestamp{Timestamp: timestamppb.New(x)}}, nil
+	case time.Duration:
+		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Duration{Duration: durationpb.New(x)}}, nil
 	case nil:
 		return &pb.Vertex{Key: v.key, Expiration: exp, Value: &pb.Vertex_Nil{Nil: true}}, nil
 
@@ -97,6 +100,7 @@ const (
 	VertexKindBytes
 	VertexKindTimestamp
 	VertexKindNil
+	VertexKindDuration
 )
 
 // Kind reports which oneof variant is set on v.
@@ -125,6 +129,8 @@ func (v *Vertex) Kind() VertexKind {
 		return VertexKindBytes
 	case *pb.Vertex_Timestamp:
 		return VertexKindTimestamp
+	case *pb.Vertex_Duration:
+		return VertexKindDuration
 	case *pb.Vertex_Nil:
 		return VertexKindNil
 	default:
@@ -233,6 +239,13 @@ func (v *Vertex) TimeValue() (time.Time, error) {
 	return time.Time{}, ErrInvalidType
 }
 
+func (v *Vertex) DurationValue() (time.Duration, error) {
+	if x, ok := v.Value.(*pb.Vertex_Duration); ok {
+		return x.Duration.AsDuration(), nil
+	}
+	return 0, ErrInvalidType
+}
+
 func (v *Vertex) IsNil() bool {
 	if x, ok := v.Value.(*pb.Vertex_Nil); ok {
 		return x.Nil
@@ -288,6 +301,8 @@ func (v *Vertex) MarshalJSON() ([]byte, error) {
 		out.Type, out.Value = "bytes", x.Bytes
 	case *pb.Vertex_Timestamp:
 		out.Type, out.Value = "timestamp", x.Timestamp.AsTime().Format(time.RFC3339Nano)
+	case *pb.Vertex_Duration:
+		out.Type, out.Value = "duration", x.Duration.AsDuration().String()
 	case *pb.Vertex_Nil:
 		out.Type, out.Value = "nil", nil
 	default:

--- a/client/value_test.go
+++ b/client/value_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	pb "github.com/anaregdesign/lantern/gen/go/graph/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"reflect"
 	"testing"
@@ -233,6 +234,46 @@ func TestVertex_TimeValue(t *testing.T) {
 	}
 }
 
+func TestVertex_DurationValue(t *testing.T) {
+	d := 90 * time.Minute
+	tests := []struct {
+		name    string
+		v       Vertex
+		want    time.Duration
+		wantErr bool
+	}{
+		{
+			name: "DurationValue",
+			v: Vertex{
+				Value: &pb.Vertex_Duration{
+					Duration: durationpb.New(d),
+				},
+			},
+			want:    d,
+			wantErr: false,
+		},
+		{
+			name:    "wrong type",
+			v:       Vertex{Value: &pb.Vertex_Int64{Int64: 1}},
+			want:    0,
+			wantErr: true,
+		},
+	}
+	for i := range tests {
+		tt := &tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.v.DurationValue()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DurationValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("DurationValue() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestVertex_UIntValue(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -357,6 +398,11 @@ func TestVertex_MarshalJSON(t *testing.T) {
 			name: "nil sentinel",
 			v:    &Vertex{Value: &pb.Vertex_Nil{Nil: true}},
 			want: `{"type":"nil","value":null}`,
+		},
+		{
+			name: "duration",
+			v:    &Vertex{Value: &pb.Vertex_Duration{Duration: durationpb.New(90 * time.Minute)}},
+			want: `{"type":"duration","value":"1h30m0s"}`,
 		},
 		{
 			name: "nil vertex",

--- a/gen/go/graph/v1/graph.pb.go
+++ b/gen/go/graph/v1/graph.pb.go
@@ -10,6 +10,7 @@ import (
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
@@ -94,6 +95,7 @@ type Vertex struct {
 	//	*Vertex_String_
 	//	*Vertex_Bytes
 	//	*Vertex_Timestamp
+	//	*Vertex_Duration
 	//	*Vertex_Nil
 	Value         isVertex_Value `protobuf_oneof:"value"`
 	unknownFields protoimpl.UnknownFields
@@ -241,6 +243,15 @@ func (x *Vertex) GetTimestamp() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *Vertex) GetDuration() *durationpb.Duration {
+	if x != nil {
+		if x, ok := x.Value.(*Vertex_Duration); ok {
+			return x.Duration
+		}
+	}
+	return nil
+}
+
 func (x *Vertex) GetNil() bool {
 	if x != nil {
 		if x, ok := x.Value.(*Vertex_Nil); ok {
@@ -294,6 +305,10 @@ type Vertex_Timestamp struct {
 	Timestamp *timestamppb.Timestamp `protobuf:"bytes,19,opt,name=timestamp,proto3,oneof"`
 }
 
+type Vertex_Duration struct {
+	Duration *durationpb.Duration `protobuf:"bytes,20,opt,name=duration,proto3,oneof"`
+}
+
 type Vertex_Nil struct {
 	// nil signals that the vertex carries no value (an "existence-only"
 	// marker). The bool itself is always true when present; the variant
@@ -320,6 +335,8 @@ func (*Vertex_String_) isVertex_Value() {}
 func (*Vertex_Bytes) isVertex_Value() {}
 
 func (*Vertex_Timestamp) isVertex_Value() {}
+
+func (*Vertex_Duration) isVertex_Value() {}
 
 func (*Vertex_Nil) isVertex_Value() {}
 
@@ -1436,7 +1453,7 @@ var File_graph_v1_graph_proto protoreflect.FileDescriptor
 
 const file_graph_v1_graph_proto_rawDesc = "" +
 	"\n" +
-	"\x14graph/v1/graph.proto\x12\bgraph.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x93\x03\n" +
+	"\x14graph/v1/graph.proto\x12\bgraph.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xcc\x03\n" +
 	"\x06Vertex\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12:\n" +
 	"\n" +
@@ -1452,7 +1469,8 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\x04bool\x18\x10 \x01(\bH\x00R\x04bool\x12\x18\n" +
 	"\x06string\x18\x11 \x01(\tH\x00R\x06string\x12\x16\n" +
 	"\x05bytes\x18\x12 \x01(\fH\x00R\x05bytes\x12:\n" +
-	"\ttimestamp\x18\x13 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\ttimestamp\x12\x12\n" +
+	"\ttimestamp\x18\x13 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\ttimestamp\x127\n" +
+	"\bduration\x18\x14 \x01(\v2\x19.google.protobuf.DurationH\x00R\bduration\x12\x12\n" +
 	"\x03nil\x18\x1e \x01(\bH\x00R\x03nilB\a\n" +
 	"\x05value\"\x82\x01\n" +
 	"\x04Edge\x12\x12\n" +
@@ -1575,46 +1593,48 @@ var file_graph_v1_graph_proto_goTypes = []any{
 	(*PutEdgeRequest)(nil),         // 23: graph.v1.PutEdgeRequest
 	(*PutEdgeResponse)(nil),        // 24: graph.v1.PutEdgeResponse
 	(*timestamppb.Timestamp)(nil),  // 25: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),    // 26: google.protobuf.Duration
 }
 var file_graph_v1_graph_proto_depIdxs = []int32{
 	25, // 0: graph.v1.Vertex.expiration:type_name -> google.protobuf.Timestamp
 	25, // 1: graph.v1.Vertex.timestamp:type_name -> google.protobuf.Timestamp
-	25, // 2: graph.v1.Edge.expiration:type_name -> google.protobuf.Timestamp
-	1,  // 3: graph.v1.Graph.vertices:type_name -> graph.v1.Vertex
-	2,  // 4: graph.v1.Graph.edges:type_name -> graph.v1.Edge
-	0,  // 5: graph.v1.IlluminateRequest.optimization:type_name -> graph.v1.Optimization
-	3,  // 6: graph.v1.IlluminateResponse.graph:type_name -> graph.v1.Graph
-	1,  // 7: graph.v1.GetVertexResponse.vertex:type_name -> graph.v1.Vertex
-	1,  // 8: graph.v1.PutVertexRequest.vertices:type_name -> graph.v1.Vertex
-	2,  // 9: graph.v1.GetEdgeResponse.edge:type_name -> graph.v1.Edge
-	18, // 10: graph.v1.DeleteEdgesRequest.edges:type_name -> graph.v1.EdgeKey
-	2,  // 11: graph.v1.AddEdgeRequest.edges:type_name -> graph.v1.Edge
-	2,  // 12: graph.v1.PutEdgeRequest.edges:type_name -> graph.v1.Edge
-	4,  // 13: graph.v1.LanternService.Illuminate:input_type -> graph.v1.IlluminateRequest
-	6,  // 14: graph.v1.LanternService.GetVertex:input_type -> graph.v1.GetVertexRequest
-	8,  // 15: graph.v1.LanternService.PutVertex:input_type -> graph.v1.PutVertexRequest
-	10, // 16: graph.v1.LanternService.DeleteVertex:input_type -> graph.v1.DeleteVertexRequest
-	12, // 17: graph.v1.LanternService.DeleteVertices:input_type -> graph.v1.DeleteVerticesRequest
-	14, // 18: graph.v1.LanternService.GetEdge:input_type -> graph.v1.GetEdgeRequest
-	21, // 19: graph.v1.LanternService.AddEdge:input_type -> graph.v1.AddEdgeRequest
-	23, // 20: graph.v1.LanternService.PutEdge:input_type -> graph.v1.PutEdgeRequest
-	16, // 21: graph.v1.LanternService.DeleteEdge:input_type -> graph.v1.DeleteEdgeRequest
-	19, // 22: graph.v1.LanternService.DeleteEdges:input_type -> graph.v1.DeleteEdgesRequest
-	5,  // 23: graph.v1.LanternService.Illuminate:output_type -> graph.v1.IlluminateResponse
-	7,  // 24: graph.v1.LanternService.GetVertex:output_type -> graph.v1.GetVertexResponse
-	9,  // 25: graph.v1.LanternService.PutVertex:output_type -> graph.v1.PutVertexResponse
-	11, // 26: graph.v1.LanternService.DeleteVertex:output_type -> graph.v1.DeleteVertexResponse
-	13, // 27: graph.v1.LanternService.DeleteVertices:output_type -> graph.v1.DeleteVerticesResponse
-	15, // 28: graph.v1.LanternService.GetEdge:output_type -> graph.v1.GetEdgeResponse
-	22, // 29: graph.v1.LanternService.AddEdge:output_type -> graph.v1.AddEdgeResponse
-	24, // 30: graph.v1.LanternService.PutEdge:output_type -> graph.v1.PutEdgeResponse
-	17, // 31: graph.v1.LanternService.DeleteEdge:output_type -> graph.v1.DeleteEdgeResponse
-	20, // 32: graph.v1.LanternService.DeleteEdges:output_type -> graph.v1.DeleteEdgesResponse
-	23, // [23:33] is the sub-list for method output_type
-	13, // [13:23] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	26, // 2: graph.v1.Vertex.duration:type_name -> google.protobuf.Duration
+	25, // 3: graph.v1.Edge.expiration:type_name -> google.protobuf.Timestamp
+	1,  // 4: graph.v1.Graph.vertices:type_name -> graph.v1.Vertex
+	2,  // 5: graph.v1.Graph.edges:type_name -> graph.v1.Edge
+	0,  // 6: graph.v1.IlluminateRequest.optimization:type_name -> graph.v1.Optimization
+	3,  // 7: graph.v1.IlluminateResponse.graph:type_name -> graph.v1.Graph
+	1,  // 8: graph.v1.GetVertexResponse.vertex:type_name -> graph.v1.Vertex
+	1,  // 9: graph.v1.PutVertexRequest.vertices:type_name -> graph.v1.Vertex
+	2,  // 10: graph.v1.GetEdgeResponse.edge:type_name -> graph.v1.Edge
+	18, // 11: graph.v1.DeleteEdgesRequest.edges:type_name -> graph.v1.EdgeKey
+	2,  // 12: graph.v1.AddEdgeRequest.edges:type_name -> graph.v1.Edge
+	2,  // 13: graph.v1.PutEdgeRequest.edges:type_name -> graph.v1.Edge
+	4,  // 14: graph.v1.LanternService.Illuminate:input_type -> graph.v1.IlluminateRequest
+	6,  // 15: graph.v1.LanternService.GetVertex:input_type -> graph.v1.GetVertexRequest
+	8,  // 16: graph.v1.LanternService.PutVertex:input_type -> graph.v1.PutVertexRequest
+	10, // 17: graph.v1.LanternService.DeleteVertex:input_type -> graph.v1.DeleteVertexRequest
+	12, // 18: graph.v1.LanternService.DeleteVertices:input_type -> graph.v1.DeleteVerticesRequest
+	14, // 19: graph.v1.LanternService.GetEdge:input_type -> graph.v1.GetEdgeRequest
+	21, // 20: graph.v1.LanternService.AddEdge:input_type -> graph.v1.AddEdgeRequest
+	23, // 21: graph.v1.LanternService.PutEdge:input_type -> graph.v1.PutEdgeRequest
+	16, // 22: graph.v1.LanternService.DeleteEdge:input_type -> graph.v1.DeleteEdgeRequest
+	19, // 23: graph.v1.LanternService.DeleteEdges:input_type -> graph.v1.DeleteEdgesRequest
+	5,  // 24: graph.v1.LanternService.Illuminate:output_type -> graph.v1.IlluminateResponse
+	7,  // 25: graph.v1.LanternService.GetVertex:output_type -> graph.v1.GetVertexResponse
+	9,  // 26: graph.v1.LanternService.PutVertex:output_type -> graph.v1.PutVertexResponse
+	11, // 27: graph.v1.LanternService.DeleteVertex:output_type -> graph.v1.DeleteVertexResponse
+	13, // 28: graph.v1.LanternService.DeleteVertices:output_type -> graph.v1.DeleteVerticesResponse
+	15, // 29: graph.v1.LanternService.GetEdge:output_type -> graph.v1.GetEdgeResponse
+	22, // 30: graph.v1.LanternService.AddEdge:output_type -> graph.v1.AddEdgeResponse
+	24, // 31: graph.v1.LanternService.PutEdge:output_type -> graph.v1.PutEdgeResponse
+	17, // 32: graph.v1.LanternService.DeleteEdge:output_type -> graph.v1.DeleteEdgeResponse
+	20, // 33: graph.v1.LanternService.DeleteEdges:output_type -> graph.v1.DeleteEdgesResponse
+	24, // [24:34] is the sub-list for method output_type
+	14, // [14:24] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_graph_v1_graph_proto_init() }
@@ -1633,6 +1653,7 @@ func file_graph_v1_graph_proto_init() {
 		(*Vertex_String_)(nil),
 		(*Vertex_Bytes)(nil),
 		(*Vertex_Timestamp)(nil),
+		(*Vertex_Duration)(nil),
 		(*Vertex_Nil)(nil),
 	}
 	type x struct{}

--- a/gen/openapiv2/graph/v1/graph.swagger.json
+++ b/gen/openapiv2/graph/v1/graph.swagger.json
@@ -660,6 +660,9 @@
           "type": "string",
           "format": "date-time"
         },
+        "duration": {
+          "type": "string"
+        },
         "nil": {
           "type": "boolean",
           "description": "nil signals that the vertex carries no value (an \"existence-only\"\nmarker). The bool itself is always true when present; the variant\nexists so the oneof can distinguish \"explicitly nil\" from \"unset\"."

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package graph.v1;
 
 import "google/api/annotations.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
 message Vertex {
@@ -19,6 +20,7 @@ message Vertex {
     string string = 17;
     bytes bytes = 18;
     google.protobuf.Timestamp timestamp = 19;
+    google.protobuf.Duration duration = 20;
 
     // nil signals that the vertex carries no value (an "existence-only"
     // marker). The bool itself is always true when present; the variant


### PR DESCRIPTION
Extends the `Vertex` oneof with a `google.protobuf.Duration` variant (tag 20) so callers can store Go `time.Duration` values natively instead of round-tripping through `int64` nanoseconds.

Updates the three sync points called out in [AGENTS.md](AGENTS.md):

- `nativeVertex.asVertex` — new `case time.Duration` → `Vertex_Duration`
- `Vertex.DurationValue()` accessor, `VertexKindDuration` constant, and `Kind()` dispatch
- `MarshalJSON` — emits `{"type":"duration","value":"1h30m0s"}` (via `time.Duration.String()`, round-trippable through `time.ParseDuration`)

CLI `vertex put` gains `--value-type=duration` backed by `time.ParseDuration`.

```shell
lantern vertex put session-timeout 30m --value-type=duration
```

### Why Duration and not Struct/ListValue/Any
Duration is a small, safe addition with a clean Go-native equivalent (`time.Duration`). Struct/ListValue/Any are deferred — they'd materially expand the surface area and UX (encoding, deep equality, schema) and deserve their own PR.

### Tests
`go test ./...` green. Added:
- `TestVertex_DurationValue` (round-trip + wrong-type)
- New `duration` row in `TestVertex_MarshalJSON`