### PR TITLE
docs: refresh stale Vertex value-type and TLS claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,10 @@ The module path in `go.mod` is still `github.com/anaregdesign/lantern`. All exte
 
 ## Architecture notes
 
-- **gRPC service**: [server/service/service.go](server/service/service.go) implements `LanternService` (`Illuminate`, `GetVertex`, `PutVertex`, `AddEdge`, `PutEdge`, `DeleteVertex`, `DeleteEdge`).
+- **gRPC service**: [server/service/service.go](server/service/service.go) implements `LanternService` (`Illuminate`, `GetVertex`, `PutVertex`, `DeleteVertex`, `DeleteVertices`, `GetEdge`, `AddEdge`, `PutEdge`, `DeleteEdge`, `DeleteEdges`).
 - **DI**: [google/wire](https://github.com/google/wire). [server/cmd/wire.go](server/cmd/wire.go) holds the definitions; [server/cmd/wire_gen.go](server/cmd/wire_gen.go) is generated — **never edit it by hand**. After changing providers, regenerate with `go generate ./...` (or `make wire` for just the wire step). Wire itself is pulled in via the `tool` directive in `go.mod`, so no install is required.
 - **Providers**: [server/provider/provider.go](server/provider/provider.go) assembles `Config` (env vars `LANTERN_PORT`, `LANTERN_DEFAULT_TTL_SECONDS`), `net.Listener`, `grpc.Server`, and `core/cache/graph.GraphCache`. `NewListener` now receives the wire-injected `*Config`.
-- **Client SDK**: [client/client.go](client/client.go) is a thin gRPC wrapper. [client/value.go](client/value.go) handles Go-native ↔ `pb.Vertex` conversion via `nativeVertex.asVertex()` and `Vertex.*Value()`. **When adding a new value type, update both directions** (`asVertex` and each `*Value()` method).
+- **Client SDK**: [client/client.go](client/client.go) is a thin gRPC wrapper. [client/value.go](client/value.go) handles Go-native ↔ `pb.Vertex` conversion via `nativeVertex.asVertex()` and `Vertex.*Value()`, and renders Go-friendly JSON via `Vertex.MarshalJSON` (shape: `{key,type,value,expiration}`). **When adding a new value type, update all three:** `asVertex` (Go → proto), the matching `*Value()` accessor plus `Kind()` / `VertexKind*` constant (proto → Go), and the `MarshalJSON` switch.
 - **Decay model**: edges are **additive** and carry their own TTL. Be mindful of the difference between `AddEdge` and `PutEdge` (idempotency) — see the discussion in [client/example/main.go](client/example/main.go).
 
 ## Build / Run / Test / Generate

--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ defer cli.Close()
 
 ctx := context.Background()
 
-// Vertices accept string, int, float, bool, time.Time, []byte, or nil.
+// Vertices accept string, int (signed/unsigned), float, bool, time.Time,
+// time.Duration, []byte, or nil.
 _ = cli.PutVertex(ctx, "user:42", "alice", 1*time.Hour)
 _ = cli.PutVertex(ctx, "item:7",  "lamp",  1*time.Hour)
 
@@ -222,7 +223,7 @@ Defined in [proto/graph/v1/graph.proto](proto/graph/v1/graph.proto), served by
 
 | RPC | Purpose | Notes |
 |---|---|---|
-| `PutVertex` | Upsert one or more vertices with TTL | Last write wins |
+| `PutVertex` | Upsert a vertex with TTL | Last write wins |
 | `GetVertex` | Fetch a vertex by key | `NotFound` if expired/missing |
 | `DeleteVertex` | Remove a vertex | Edges to/from it are GC'd on next `Watch` tick |
 | `DeleteVertices` | Batch remove vertices in one round-trip | SDK auto-chunks at `WithBatchChunkSize`; idempotent (retried automatically) |
@@ -442,8 +443,10 @@ After loading a richer graph:
 - **Single-process, in-memory only.** Multi-node sharding and replication are
   not built in. Production deployments typically replay events from a durable
   log (Kafka, etc.) into Lantern on boot.
-- **No auth / TLS in the default build.** Front it with a service mesh or
-  envoy-style sidecar for production exposure.
+- **No authn / authz built in.** TLS and mTLS *are* supported out of the
+  box via the `LANTERN_TLS_*` env vars (and the matching `--tls*` client
+  flags), but per-RPC authentication is not — front it with a service mesh
+  or envoy-style sidecar if you need identity-based access control.
 - **Single global `sync.RWMutex` on the graph cache** plus per-edge mutexes on
   weight aggregation. Read-heavy workloads scale well; write-very-hot keys
   serialize.


### PR DESCRIPTION
After PR #33 (Vertex.MarshalJSON) and PR #34 (Duration variant) the docs had drifted in a few small places. This PR brings them back in sync; no code changes.

### README
- **"Use it from Go"** \u2014 the accepted Vertex value-type list now mentions `time.Duration` and signed/unsigned ints.
- **gRPC surface table** \u2014 `PutVertex` is single-vertex, not batch (`DeleteVertices` / `DeleteEdges` are already listed as the batch RPCs).
- **Roadmap & limitations** \u2014 the "no auth / TLS" bullet is stale: TLS / mTLS *are* supported via `LANTERN_TLS_*` env vars and the matching `--tls*` client flags. Reworded to say only per-RPC authn is missing.

### AGENTS.md
- Bring the `LanternService` method list in line with the actual proto surface (adds `DeleteVertices`, `GetEdge`, `DeleteEdges`).
- Document the **three-place** sync rule for new Vertex value variants (`asVertex` / `*Value`+`Kind` / `MarshalJSON`), matching the reality after #33 and #34.

Docs-only; `go build ./...` still passes locally.