### PR TITLE
fix: atomic PutEdge + JSON object/array values in CLI

### DIFF
--- a/cli/cmd/bulk.go
+++ b/cli/cmd/bulk.go
@@ -127,8 +127,21 @@ Lines are accumulated into batches of --chunk-size and sent via PutVertices.
 			if err != nil {
 				return fmt.Errorf("line %d: ttl: %w", lineNo, err)
 			}
+			// Lantern's wire format has no nested value variant. Re-encode
+			// object/array values as compact JSON strings so the batch RPC
+			// does not reject the whole batch with ErrInvalidType. Scalars
+			// pass through.
+			value := v.Value
+			switch value.(type) {
+			case map[string]any, []any:
+				b, err := json.Marshal(value)
+				if err != nil {
+					return fmt.Errorf("line %d: re-encode value: %w", lineNo, err)
+				}
+				value = string(b)
+			}
 			batch = append(batch, client.VertexInput{
-				Key: v.Key, Value: v.Value, Expiration: time.Now().Add(ttl),
+				Key: v.Key, Value: value, Expiration: time.Now().Add(ttl),
 			})
 			if len(batch) >= flagChunkSize {
 				if err := flush(); err != nil {

--- a/cli/cmd/value.go
+++ b/cli/cmd/value.go
@@ -16,7 +16,10 @@ import (
 //	float     strconv.ParseFloat (float64)
 //	bool      strconv.ParseBool
 //	datetime  time.Parse(time.RFC3339, ...)
-//	json      json.Unmarshal — supports objects, arrays, scalars
+//	json      json.Unmarshal — supports objects, arrays, scalars. Objects
+//	          and arrays are re-encoded as a compact JSON string before
+//	          being sent (the Lantern wire format has no nested value
+//	          variant); scalars pass through as their natural Go type.
 //
 // auto is the default. It is unambiguous for most string keys/values, but if
 // you need to insist on a string that *looks* like a number, pass
@@ -74,7 +77,20 @@ func parseValue(raw, valueType string) (any, error) {
 		if err := json.Unmarshal([]byte(raw), &v); err != nil {
 			return nil, fmt.Errorf("--value-type=json: %w", err)
 		}
-		return v, nil
+		// Lantern's wire format has no nested value variant. Re-encode
+		// objects and arrays as a compact JSON string so they round-trip
+		// cleanly through PutVertex/GetVertex. Scalars (bool, float64,
+		// string, nil) are forwarded as-is.
+		switch v.(type) {
+		case map[string]any, []any:
+			b, err := json.Marshal(v)
+			if err != nil {
+				return nil, fmt.Errorf("--value-type=json re-encode: %w", err)
+			}
+			return string(b), nil
+		default:
+			return v, nil
+		}
 	default:
 		return nil, fmt.Errorf("unknown --value-type %q (want auto|string|int|float|bool|datetime|duration|json)", valueType)
 	}

--- a/cli/cmd/value_test.go
+++ b/cli/cmd/value_test.go
@@ -39,10 +39,16 @@ func TestParseValue(t *testing.T) {
 		// datetime
 		{"datetime/ok", rfc, "datetime", parsedTime, false},
 		{"datetime/err", "yesterday", "datetime", nil, true},
-		// json
-		{"json/object", `{"a":1}`, "json", map[string]any{"a": float64(1)}, false},
-		{"json/array", `[1,2]`, "json", []any{float64(1), float64(2)}, false},
-		{"json/scalar", `"hi"`, "json", "hi", false},
+		// json — objects and arrays are re-encoded as compact JSON strings
+		// because the wire format has no nested value variant; scalars
+		// pass through as their natural Go type.
+		{"json/object", `{"a":1}`, "json", `{"a":1}`, false},
+		{"json/object-spaces", `{ "a" : 1 }`, "json", `{"a":1}`, false},
+		{"json/array", `[1,2]`, "json", `[1,2]`, false},
+		{"json/scalar-string", `"hi"`, "json", "hi", false},
+		{"json/scalar-number", `1.5`, "json", float64(1.5), false},
+		{"json/scalar-bool", `true`, "json", true, false},
+		{"json/scalar-null", `null`, "json", nil, false},
 		{"json/err", `{`, "json", nil, true},
 		// unknown
 		{"unknown-type", "x", "weird", nil, true},

--- a/client/value_test.go
+++ b/client/value_test.go
@@ -1,12 +1,13 @@
 package client
 
 import (
-	pb "github.com/anaregdesign/lantern/gen/go/graph/v1"
-	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"reflect"
 	"testing"
 	"time"
+
+	pb "github.com/anaregdesign/lantern/gen/go/graph/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestVertex_BoolValue(t *testing.T) {

--- a/core/cache/graph/cache.go
+++ b/core/cache/graph/cache.go
@@ -91,6 +91,29 @@ func (c *GraphCache[S, T]) AddEdge(tail, head S, w float32) {
 	c.AddEdgeWithTTL(tail, head, w, c.defaultTTL)
 }
 
+// PutEdgeWithExpiration atomically replaces the (tail, head) edge weight.
+// AddEdgeWithExpiration is additive (Add semantics) so a naive
+// "DeleteEdge + AddEdgeWithExpiration" sequence performed by callers
+// exposes a window in which concurrent GetEdge readers observe a spurious
+// NotFound. PutEdgeWithExpiration takes the write lock once and performs
+// the delete + add under the same lock, restoring atomicity for the
+// idempotent Put semantics.
+func (c *GraphCache[S, T]) PutEdgeWithExpiration(tail, head S, w float32, expiration time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Same endpoint auto-creation invariant as AddEdgeWithExpiration.
+	if !c.vertices.Has(tail) {
+		var noop T
+		c.vertices.PutWithExpiration(tail, noop, expiration)
+	}
+	if !c.vertices.Has(head) {
+		var noop T
+		c.vertices.PutWithExpiration(head, noop, expiration)
+	}
+	c.edges.delete(tail, head)
+	c.edges.addWithExpiration(tail, head, w, expiration)
+}
+
 func (c *GraphCache[S, T]) DeleteVertex(key S) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/core/cache/graph/put_edge_atomic_test.go
+++ b/core/cache/graph/put_edge_atomic_test.go
@@ -1,0 +1,68 @@
+package graph
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestPutEdgeWithExpiration_Atomic asserts that a reader observing an edge
+// that is being continually replaced via PutEdgeWithExpiration NEVER sees a
+// transient "missing" state. The previous service-level implementation
+// performed DeleteEdge + AddEdgeWithExpiration as two separate cache calls,
+// which exposed a window where concurrent GetEdge readers observed a
+// spurious NotFound. Run with -race to also catch any introduced races.
+func TestPutEdgeWithExpiration_Atomic(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	exp := time.Now().Add(time.Minute)
+	// Seed an edge so the first reader iterations are guaranteed to see it.
+	c.AddEdgeWithExpiration("T", "H", 1, exp)
+
+	const writers = 4
+	const readers = 16
+	const writesPerWriter = 2000
+
+	var wg sync.WaitGroup
+	var missing int64
+	var reads int64
+	stop := make(chan struct{})
+
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_, _, ok := c.GetEdgeDetail("T", "H")
+				if !ok {
+					atomic.AddInt64(&missing, 1)
+				}
+				atomic.AddInt64(&reads, 1)
+			}
+		}()
+	}
+
+	var writerWG sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		writerWG.Add(1)
+		go func(w int) {
+			defer writerWG.Done()
+			for i := 0; i < writesPerWriter; i++ {
+				c.PutEdgeWithExpiration("T", "H", float32(w*1000+i+1), exp)
+			}
+		}(w)
+	}
+	writerWG.Wait()
+	close(stop)
+	wg.Wait()
+
+	if missing != 0 {
+		t.Fatalf("PutEdgeWithExpiration leaked NotFound to readers: %d of %d reads observed a missing edge",
+			missing, reads)
+	}
+}

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -179,8 +179,10 @@ func (s *LanternService) PutEdge(ctx context.Context, request *pb.PutEdgeRequest
 	}
 	var written int32
 	for _, e := range request.GetEdges() {
-		s.cache.DeleteEdge(e.GetTail(), e.GetHead())
-		s.cache.AddEdgeWithExpiration(e.GetTail(), e.GetHead(), e.GetWeight(), e.GetExpiration().AsTime())
+		// PutEdgeWithExpiration locks the cache once and performs the
+		// delete + add atomically, so concurrent GetEdge readers never
+		// observe a transient NotFound between the two operations.
+		s.cache.PutEdgeWithExpiration(e.GetTail(), e.GetHead(), e.GetWeight(), e.GetExpiration().AsTime())
 		written++
 	}
 	return &pb.PutEdgeResponse{Written: written}, nil


### PR DESCRIPTION
## Summary

Post-v0.5.0 QA pass uncovered two defects:

1. **Server concurrency bug — non-atomic `PutEdge`.** The service handler ran `cache.DeleteEdge` followed by `cache.AddEdgeWithExpiration` as two separate write-lock acquisitions. A focused stress harness (16 readers vs 1 writer churning `PutEdge`) reproduced **145 spurious `NotFound` out of 80,739 reads** (~0.18%).
2. **CLI/SDK functional bug — JSON objects/arrays rejected.** `pb.Vertex` (oneof) has no nested variant, so passing a parsed `map[string]any` / `[]any` straight through made the SDK return `ErrInvalidType`. This caused ``lantern vertex put k '{\"a\":1}' --value-type=json`` to exit 1 and aborted the entire ``lantern bulk vertices`` stream on the first nested-JSON line.

## Fixes

- ``GraphCache.PutEdgeWithExpiration`` (new) — performs delete + add under a single ``c.mu.Lock()``, preserving the endpoint auto-create invariant from ``AddEdgeWithExpiration``. ``service.PutEdge`` calls it.
- CLI ``--value-type=json`` and ``bulk vertices`` now re-encode object/array values as a compact JSON string before sending; scalars (bool, float64, string, nil) pass through as their natural Go type. Help text updated.

## Validation

- New ``TestPutEdgeWithExpiration_Atomic`` (16 readers × 4 writers × 2,000 ``PutEdge`` each) reports zero missing reads under ``-race``.
- End-to-end stress harness drops from ``notFound=145`` to ``notFound=0`` against the patched server.
- ``go test -race ./...`` green across the workspace.
- ``TestParseValue`` extended with object / array / scalar / spacing cases (all green).
- Live container smoke test:
  - ``vertex put j '{\"a\":1,\"b\":[1,2]}' --value-type=json`` → stored as compact JSON string, round-trips via ``vertex get``.
  - ``bulk vertices`` with mixed scalar + nested-JSON NDJSON lines now reports ``OK 3``.