### PR TITLE
feat(#41): propagate ctx cancellation into Illuminate graph ops

### DIFF
--- a/core/cache/graph/cache.go
+++ b/core/cache/graph/cache.go
@@ -141,12 +141,25 @@ func (c *GraphCache[S, T]) flush() {
 }
 
 func (c *GraphCache[S, T]) Neighbor(seed S, step int, k int, tfidf bool) *graph.Graph[S, T] {
+	g, _ := c.NeighborContext(context.Background(), seed, step, k, tfidf)
+	return g
+}
+
+// NeighborContext is the context-aware variant of Neighbor. It returns
+// ctx.Err() as soon as the context is cancelled or its deadline has expired
+// — checked between BFS expansion steps — so handlers can short-circuit
+// large traversals when the caller has given up.
+func (c *GraphCache[S, T]) NeighborContext(ctx context.Context, seed S, step int, k int, tfidf bool) (*graph.Graph[S, T], error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	g := graph.NewGraph[S, T]()
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	if v, ok := c.vertices.Get(seed); !ok {
-		return g
+		return g, nil
 	} else {
 		g.Vertices[seed] = v
 	}
@@ -161,6 +174,9 @@ func (c *GraphCache[S, T]) Neighbor(seed S, step int, k int, tfidf bool) *graph.
 	tf := c.edges.snapshotTF()
 	df := c.edges.snapshotDF()
 	for range step {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 
 		for _, tail := range targets.Values() {
 			// Skip if already seen
@@ -218,7 +234,7 @@ func (c *GraphCache[S, T]) Neighbor(seed S, step int, k int, tfidf bool) *graph.
 		}
 	}
 
-	return g
+	return g, nil
 }
 
 func (c *GraphCache[S, T]) Watch(ctx context.Context, interval time.Duration) {

--- a/core/cache/graph/context_test.go
+++ b/core/cache/graph/context_test.go
@@ -1,0 +1,22 @@
+package graph
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestGraphCache_NeighborContextCancelled(t *testing.T) {
+	c := NewGraphCache[string, int](time.Minute)
+	c.PutVertex("a", 1)
+	c.PutVertex("b", 2)
+	c.AddEdge("a", "b", 1.0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := c.NeighborContext(ctx, "a", 5, 10, false); !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+}

--- a/core/graph/context_test.go
+++ b/core/graph/context_test.go
@@ -1,0 +1,41 @@
+package graph
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestGraph_ContextCancelled(t *testing.T) {
+	g := NewGraph[string, int]()
+	g.PutEdge("a", "b", 1.0)
+	g.PutEdge("b", "c", 1.0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cases := []struct {
+		name string
+		run  func() error
+	}{
+		{"ConnectedGraphContext", func() error {
+			_, err := g.ConnectedGraphContext(ctx, "a")
+			return err
+		}},
+		{"MinimumSpanningTreeContext", func() error {
+			_, err := g.MinimumSpanningTreeContext(ctx, "a", false)
+			return err
+		}},
+		{"ShortestPathTreeContext", func() error {
+			_, err := g.ShortestPathTreeContext(ctx, "a", func(w float32) float32 { return w })
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.run(); !errors.Is(err, context.Canceled) {
+				t.Fatalf("want context.Canceled, got %v", err)
+			}
+		})
+	}
+}

--- a/core/graph/model.go
+++ b/core/graph/model.go
@@ -2,6 +2,8 @@ package graph
 
 import (
 	"container/heap"
+	"context"
+
 	"github.com/anaregdesign/lantern/core/collection/pq"
 	"github.com/anaregdesign/lantern/core/collection/set"
 )
@@ -40,6 +42,14 @@ func (g *Graph[S, T]) PutEdge(tail, head S, weight float32) {
 }
 
 func (g *Graph[S, T]) ConnectedGraph(seed S) *Graph[S, T] {
+	connected, _ := g.ConnectedGraphContext(context.Background(), seed)
+	return connected
+}
+
+// ConnectedGraphContext is the context-aware variant of ConnectedGraph.
+// It returns ctx.Err() as soon as the context is cancelled or its deadline
+// has expired, so callers can short-circuit large traversals.
+func (g *Graph[S, T]) ConnectedGraphContext(ctx context.Context, seed S) (*Graph[S, T], error) {
 	targets := set.NewSet[S]()
 	seen := set.NewSet[S]()
 	connected := NewGraph[S, T]()
@@ -47,6 +57,9 @@ func (g *Graph[S, T]) ConnectedGraph(seed S) *Graph[S, T] {
 
 	targets.Add(seed)
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		for _, tail := range targets.Values() {
 			if seen.Has(tail) {
 				continue
@@ -69,7 +82,7 @@ func (g *Graph[S, T]) ConnectedGraph(seed S) *Graph[S, T] {
 		}
 	}
 
-	return connected
+	return connected, nil
 }
 
 // MinimumSpanningTree
@@ -79,7 +92,17 @@ func (g *Graph[S, T]) ConnectedGraph(seed S) *Graph[S, T] {
  * If negate is true, the maximum spanning tree is returned.
  */
 func (g *Graph[S, T]) MinimumSpanningTree(seed S, negate bool) *Graph[S, T] {
-	connected := g.ConnectedGraph(seed)
+	mst, _ := g.MinimumSpanningTreeContext(context.Background(), seed, negate)
+	return mst
+}
+
+// MinimumSpanningTreeContext is the context-aware variant of
+// MinimumSpanningTree.
+func (g *Graph[S, T]) MinimumSpanningTreeContext(ctx context.Context, seed S, negate bool) (*Graph[S, T], error) {
+	connected, err := g.ConnectedGraphContext(ctx, seed)
+	if err != nil {
+		return nil, err
+	}
 
 	type edge struct {
 		tail   S
@@ -94,6 +117,9 @@ func (g *Graph[S, T]) MinimumSpanningTree(seed S, negate bool) *Graph[S, T] {
 
 	mst.PutVertex(seed, connected.Vertices[seed])
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if len(mst.Vertices) == len(connected.Vertices) {
 			break
 		}
@@ -141,7 +167,7 @@ func (g *Graph[S, T]) MinimumSpanningTree(seed S, negate bool) *Graph[S, T] {
 		mst.PutEdge(pickedUp.tail, pickedUp.head, pickedUp.weight)
 
 	}
-	return mst
+	return mst, nil
 }
 
 // ShortestPathTree
@@ -152,7 +178,16 @@ func (g *Graph[S, T]) MinimumSpanningTree(seed S, negate bool) *Graph[S, T] {
  * It is calculated by Dijkstra's algorithm, so the costFunc must return a positive value.
  */
 func (g *Graph[S, T]) ShortestPathTree(seed S, costFunc func(x float32) float32) *Graph[S, T] {
-	connected := g.ConnectedGraph(seed)
+	spt, _ := g.ShortestPathTreeContext(context.Background(), seed, costFunc)
+	return spt
+}
+
+// ShortestPathTreeContext is the context-aware variant of ShortestPathTree.
+func (g *Graph[S, T]) ShortestPathTreeContext(ctx context.Context, seed S, costFunc func(x float32) float32) (*Graph[S, T], error) {
+	connected, err := g.ConnectedGraphContext(ctx, seed)
+	if err != nil {
+		return nil, err
+	}
 	spt := NewGraph[S, T]()
 	spt.PutVertex(seed, connected.Vertices[seed])
 
@@ -168,6 +203,9 @@ func (g *Graph[S, T]) ShortestPathTree(seed S, costFunc func(x float32) float32)
 	pivot := seed
 	position := float32(0.0)
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if len(spt.Vertices) == len(connected.Vertices) {
 			break
 		}
@@ -209,7 +247,7 @@ func (g *Graph[S, T]) ShortestPathTree(seed S, costFunc func(x float32) float32)
 		position = pickedUp.Priority
 	}
 
-	return spt
+	return spt, nil
 }
 
 func (g *Graph[S, T]) Render(key2int func(k S) int, value2string func(v T) string) GraphView {

--- a/go.work.sum
+++ b/go.work.sum
@@ -33,6 +33,7 @@ github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8w
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opentelemetry.io/contrib/detectors/gcp v1.42.0/go.mod h1:W9zQ439utxymRrXsUOzZbFX4JhLxXU4+ZnCt8GG7yA8=
+go.opentelemetry.io/otel/metric/x v0.66.0/go.mod h1:d1+BDj9t96do0/1LoU1ayfCv79ZgNE41qbhBvnMOBZk=
 golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
 golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8/go.mod h1:CQ1k9gNrJ50XIzaKCRR2hssIjF07kZFEiieALBM/ARQ=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -46,24 +46,30 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 		return nil, status.FromContextError(err).Err()
 	}
 
-	g := s.cache.Neighbor(request.GetSeed(), int(request.GetStep()), int(request.GetK()), request.GetTfidf())
+	g, err := s.cache.NeighborContext(ctx, request.GetSeed(), int(request.GetStep()), int(request.GetK()), request.GetTfidf())
+	if err != nil {
+		return nil, status.FromContextError(err).Err()
+	}
 
 	switch request.GetOptimization() {
 	case pb.Optimization_OPTIMIZATION_UNSPECIFIED:
 		// do nothing
 	case pb.Optimization_OPTIMIZATION_MINIMUM_SPANNING_TREE:
-		g = g.MinimumSpanningTree(request.GetSeed(), false)
+		g, err = g.MinimumSpanningTreeContext(ctx, request.GetSeed(), false)
 	case pb.Optimization_OPTIMIZATION_MAXIMUM_SPANNING_TREE:
-		g = g.MinimumSpanningTree(request.GetSeed(), true)
+		g, err = g.MinimumSpanningTreeContext(ctx, request.GetSeed(), true)
 	case pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE:
-		g = g.ShortestPathTree(request.GetSeed(), func(weight float32) float32 { return weight })
+		g, err = g.ShortestPathTreeContext(ctx, request.GetSeed(), func(weight float32) float32 { return weight })
 	case pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE:
-		g = g.ShortestPathTree(request.GetSeed(), func(weight float32) float32 {
+		g, err = g.ShortestPathTreeContext(ctx, request.GetSeed(), func(weight float32) float32 {
 			if weight == 0 {
 				return math.MaxFloat32
 			}
 			return 1 / weight
 		})
+	}
+	if err != nil {
+		return nil, status.FromContextError(err).Err()
 	}
 
 	if err := ctx.Err(); err != nil {


### PR DESCRIPTION
Closes #41.

Adds context-aware variants of the graph traversal/optimization primitives so cancelled or timed-out Illuminate requests stop doing work instead of running to completion and discarding the result.

### Changes
- `core/graph`: new `ConnectedGraphContext`, `MinimumSpanningTreeContext`, `ShortestPathTreeContext`. Existing methods remain as thin wrappers (pass `context.Background()`) so external callers are unaffected.
- `core/cache/graph`: new `NeighborContext` checking `ctx.Err()` between BFS steps.
- `server/service.Illuminate`: now uses the `*Context` variants and surfaces context errors via `status.FromContextError`.

### Tests
- `core/graph/context_test.go` and `core/cache/graph/context_test.go` — cancel before call returns `context.Canceled` for all four entry points.
- Full `go test ./core/... ./server/...` passes.