### PR TITLE
test(#42): add bufconn-based gRPC tests for service layer

### DIFF
--- a/server/service/service_bufconn_test.go
+++ b/server/service/service_bufconn_test.go
@@ -1,0 +1,222 @@
+package service_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	pb "github.com/anaregdesign/lantern/sdks/go/gen/graph/v1"
+	"github.com/anaregdesign/lantern/server/service"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// newBufconnClient spins LanternService up on bufconn and returns a raw
+// LanternServiceClient. This complements the in-process tests in
+// service_test.go by also exercising the actual gRPC wire format.
+func newBufconnClient(t *testing.T) (pb.LanternServiceClient, context.Context, func()) {
+	t.Helper()
+
+	lis := bufconn.Listen(1 << 16)
+	srv := grpc.NewServer()
+	svc := service.NewLanternService(cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute))
+	pb.RegisterLanternServiceServer(srv, svc)
+	go func() {
+		if err := srv.Serve(lis); err != nil {
+			t.Logf("grpc Serve returned: %v", err)
+		}
+	}()
+
+	dialer := func(context.Context, string) (net.Conn, error) { return lis.Dial() }
+	conn, err := grpc.NewClient(
+		"passthrough://bufconn",
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	cleanup := func() {
+		cancel()
+		_ = conn.Close()
+		srv.Stop()
+		_ = lis.Close()
+	}
+	return pb.NewLanternServiceClient(conn), ctx, cleanup
+}
+
+func bufconnExp(d time.Duration) *timestamppb.Timestamp {
+	return timestamppb.New(time.Now().Add(d))
+}
+
+func TestBufconn_PutGetVertex_NilValueRoundTrip(t *testing.T) {
+	c, ctx, cleanup := newBufconnClient(t)
+	defer cleanup()
+
+	v := &pb.Vertex{Key: "n", Value: &pb.Vertex_Nil{Nil: true}, Expiration: bufconnExp(time.Minute)}
+	if _, err := c.PutVertex(ctx, &pb.PutVertexRequest{Vertices: []*pb.Vertex{v}}); err != nil {
+		t.Fatalf("PutVertex: %v", err)
+	}
+
+	got, err := c.GetVertex(ctx, &pb.GetVertexRequest{Key: "n"})
+	if err != nil {
+		t.Fatalf("GetVertex: %v", err)
+	}
+	if _, ok := got.GetVertex().GetValue().(*pb.Vertex_Nil); !ok {
+		t.Errorf("value = %T, want *Vertex_Nil", got.GetVertex().GetValue())
+	}
+}
+
+func TestBufconn_GetVertex_NotFound(t *testing.T) {
+	c, ctx, cleanup := newBufconnClient(t)
+	defer cleanup()
+
+	_, err := c.GetVertex(ctx, &pb.GetVertexRequest{Key: "missing"})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("code = %v, want NotFound", status.Code(err))
+	}
+}
+
+func TestBufconn_AddEdge_IsAdditive(t *testing.T) {
+	c, ctx, cleanup := newBufconnClient(t)
+	defer cleanup()
+
+	edge := &pb.Edge{Tail: "a", Head: "b", Weight: 1.5, Expiration: bufconnExp(time.Minute)}
+	for i := 0; i < 2; i++ {
+		if _, err := c.AddEdge(ctx, &pb.AddEdgeRequest{Edges: []*pb.Edge{edge}}); err != nil {
+			t.Fatalf("AddEdge %d: %v", i, err)
+		}
+	}
+
+	got, err := c.GetEdge(ctx, &pb.GetEdgeRequest{Tail: "a", Head: "b"})
+	if err != nil {
+		t.Fatalf("GetEdge: %v", err)
+	}
+	if w := got.GetEdge().GetWeight(); w != 3.0 {
+		t.Errorf("weight after two adds = %v, want 3.0", w)
+	}
+}
+
+func TestBufconn_PutEdge_IsIdempotent(t *testing.T) {
+	c, ctx, cleanup := newBufconnClient(t)
+	defer cleanup()
+
+	first := &pb.Edge{Tail: "a", Head: "b", Weight: 1.5, Expiration: bufconnExp(time.Minute)}
+	second := &pb.Edge{Tail: "a", Head: "b", Weight: 9.0, Expiration: bufconnExp(time.Minute)}
+	if _, err := c.PutEdge(ctx, &pb.PutEdgeRequest{Edges: []*pb.Edge{first}}); err != nil {
+		t.Fatalf("PutEdge 1: %v", err)
+	}
+	if _, err := c.PutEdge(ctx, &pb.PutEdgeRequest{Edges: []*pb.Edge{second}}); err != nil {
+		t.Fatalf("PutEdge 2: %v", err)
+	}
+
+	got, err := c.GetEdge(ctx, &pb.GetEdgeRequest{Tail: "a", Head: "b"})
+	if err != nil {
+		t.Fatalf("GetEdge: %v", err)
+	}
+	if w := got.GetEdge().GetWeight(); w != 9.0 {
+		t.Errorf("weight = %v, want 9.0 (last write wins)", w)
+	}
+}
+
+func TestBufconn_Illuminate_AllOptimizations(t *testing.T) {
+	c, ctx, cleanup := newBufconnClient(t)
+	defer cleanup()
+
+	edges := []*pb.Edge{
+		{Tail: "a", Head: "b", Weight: 1, Expiration: bufconnExp(time.Minute)},
+		{Tail: "b", Head: "c", Weight: 1, Expiration: bufconnExp(time.Minute)},
+		{Tail: "a", Head: "c", Weight: 3, Expiration: bufconnExp(time.Minute)},
+	}
+	if _, err := c.PutEdge(ctx, &pb.PutEdgeRequest{Edges: edges}); err != nil {
+		t.Fatalf("PutEdge seed: %v", err)
+	}
+
+	opts := []pb.Optimization{
+		pb.Optimization_OPTIMIZATION_UNSPECIFIED,
+		pb.Optimization_OPTIMIZATION_MINIMUM_SPANNING_TREE,
+		pb.Optimization_OPTIMIZATION_MAXIMUM_SPANNING_TREE,
+		pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE,
+		pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE,
+	}
+	for _, opt := range opts {
+		t.Run(opt.String(), func(t *testing.T) {
+			resp, err := c.Illuminate(ctx, &pb.IlluminateRequest{
+				Seed: "a", Step: 3, K: 10, Optimization: opt,
+			})
+			if err != nil {
+				t.Fatalf("Illuminate(%s): %v", opt, err)
+			}
+			got := map[string]bool{}
+			for _, v := range resp.GetGraph().GetVertices() {
+				got[v.GetKey()] = true
+			}
+			for _, want := range []string{"a", "b", "c"} {
+				if !got[want] {
+					t.Errorf("Illuminate(%s) missing vertex %q (got %v)", opt, want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestBufconn_DeleteVertices_HappyPath(t *testing.T) {
+	c, ctx, cleanup := newBufconnClient(t)
+	defer cleanup()
+
+	vs := []*pb.Vertex{
+		{Key: "a", Value: &pb.Vertex_Int64{Int64: 1}, Expiration: bufconnExp(time.Minute)},
+		{Key: "b", Value: &pb.Vertex_Int64{Int64: 2}, Expiration: bufconnExp(time.Minute)},
+	}
+	if _, err := c.PutVertex(ctx, &pb.PutVertexRequest{Vertices: vs}); err != nil {
+		t.Fatalf("PutVertex: %v", err)
+	}
+	resp, err := c.DeleteVertices(ctx, &pb.DeleteVerticesRequest{Keys: []string{"a", "b"}})
+	if err != nil {
+		t.Fatalf("DeleteVertices: %v", err)
+	}
+	if resp.GetDeleted() != 2 {
+		t.Errorf("Deleted = %d, want 2", resp.GetDeleted())
+	}
+	for _, k := range []string{"a", "b"} {
+		if _, err := c.GetVertex(ctx, &pb.GetVertexRequest{Key: k}); status.Code(err) != codes.NotFound {
+			t.Errorf("GetVertex %q after delete: code = %v, want NotFound", k, status.Code(err))
+		}
+	}
+}
+
+func TestBufconn_DeleteEdges_HappyPath(t *testing.T) {
+	c, ctx, cleanup := newBufconnClient(t)
+	defer cleanup()
+
+	edges := []*pb.Edge{
+		{Tail: "a", Head: "b", Weight: 1, Expiration: bufconnExp(time.Minute)},
+		{Tail: "b", Head: "c", Weight: 1, Expiration: bufconnExp(time.Minute)},
+	}
+	if _, err := c.AddEdge(ctx, &pb.AddEdgeRequest{Edges: edges}); err != nil {
+		t.Fatalf("AddEdge: %v", err)
+	}
+	resp, err := c.DeleteEdges(ctx, &pb.DeleteEdgesRequest{Edges: []*pb.EdgeKey{
+		{Tail: "a", Head: "b"},
+		{Tail: "b", Head: "c"},
+	}})
+	if err != nil {
+		t.Fatalf("DeleteEdges: %v", err)
+	}
+	if resp.GetDeleted() != 2 {
+		t.Errorf("Deleted = %d, want 2", resp.GetDeleted())
+	}
+	for _, e := range edges {
+		if _, err := c.GetEdge(ctx, &pb.GetEdgeRequest{Tail: e.GetTail(), Head: e.GetHead()}); status.Code(err) != codes.NotFound {
+			t.Errorf("GetEdge after delete: code = %v, want NotFound", status.Code(err))
+		}
+	}
+}


### PR DESCRIPTION
Closes #42.

Complements the existing in-process `service_test.go` by spinning `LanternService` up on `grpc.NewServer` + `bufconn` and exercising the real gRPC wire format.

Covers:
- `PutVertex`/`GetVertex` round-trip including the `Vertex_Nil` case
- `GetVertex` NotFound returns `codes.NotFound`
- `AddEdge` is additive (two adds = sum of weights)
- `PutEdge` is idempotent (last write wins)
- `Illuminate` across every `Optimization` enum value
- `DeleteVertices` / `DeleteEdges` happy paths returning NotFound after delete

No new dependencies — `bufconn` was already in `go.mod` via the integration tests.