### PR TITLE
fix(#43): flip health to NOT_SERVING when grpc Serve returns

### DIFF
--- a/server/service/server_test.go
+++ b/server/service/server_test.go
@@ -1,0 +1,91 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	pb "github.com/anaregdesign/lantern/sdks/go/gen/graph/v1"
+	"github.com/anaregdesign/lantern/server/service"
+	"google.golang.org/grpc"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// recordingHealth captures every SetServingStatus call so we can assert
+// that Run flips NOT_SERVING after Serve returns, regardless of cause.
+type recordingHealth struct {
+	mu     sync.Mutex
+	events []healthpb.HealthCheckResponse_ServingStatus
+}
+
+func (r *recordingHealth) SetServingStatus(_ string, s healthpb.HealthCheckResponse_ServingStatus) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, s)
+}
+
+func (r *recordingHealth) last() healthpb.HealthCheckResponse_ServingStatus {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.events) == 0 {
+		return healthpb.HealthCheckResponse_UNKNOWN
+	}
+	return r.events[len(r.events)-1]
+}
+
+// brokenListener.Accept returns immediately with a non-temporary error,
+// causing grpc.Server.Serve to return without ctx cancellation.
+type brokenListener struct{ addr net.Addr }
+
+func (b *brokenListener) Accept() (net.Conn, error) { return nil, errBroken }
+func (b *brokenListener) Close() error              { return nil }
+func (b *brokenListener) Addr() net.Addr            { return b.addr }
+
+var errBroken = errors.New("listener is broken")
+
+type fakeAddr struct{}
+
+func (fakeAddr) Network() string { return "fake" }
+func (fakeAddr) String() string  { return "fake://broken" }
+
+func TestLanternServer_Run_FlipsHealthOnServeReturn(t *testing.T) {
+	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	svc := service.NewLanternService(cache)
+	grpcSrv := grpc.NewServer()
+	lis := &brokenListener{addr: fakeAddr{}}
+	hs := &recordingHealth{}
+
+	srv := service.NewLanternServer(
+		svc, grpcSrv, lis,
+		slog.New(slog.NewTextHandler(discardWriter{}, nil)),
+		service.LifecycleConfig{GCInterval: time.Hour, ShutdownTimeout: time.Second},
+		hs,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := srv.Run(ctx)
+	if err == nil {
+		t.Fatal("Run returned nil error; want listener error")
+	}
+
+	if got := hs.last(); got != healthpb.HealthCheckResponse_NOT_SERVING {
+		t.Errorf("last health status = %v, want NOT_SERVING", got)
+	}
+	// Must have transitioned through SERVING first.
+	hs.mu.Lock()
+	defer hs.mu.Unlock()
+	if len(hs.events) < 2 || hs.events[0] != healthpb.HealthCheckResponse_SERVING {
+		t.Errorf("expected SERVING then NOT_SERVING, got %v", hs.events)
+	}
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -300,5 +300,14 @@ func (s *LanternServer) Run(ctx context.Context) error {
 		slog.Duration("gc_interval", s.gcInterval),
 		slog.Duration("shutdown_timeout", s.shutdownTimeout),
 	)
-	return s.server.Serve(s.listener)
+	// Serve blocks until the server stops. Whatever the reason — graceful
+	// shutdown, listener error, or fatal panic recovered by grpc — flip the
+	// health gauge to NOT_SERVING so probes don't keep reporting healthy
+	// against a dead server. The shutdown goroutine above also sets this,
+	// but only on ctx cancellation; this covers every other exit path.
+	err := s.server.Serve(s.listener)
+	if s.health != nil {
+		s.health.SetServingStatus(ServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
+	}
+	return err
 }


### PR DESCRIPTION
Closes #43.

`LanternServer.Run` previously only flipped health to `NOT_SERVING` inside the ctx-done goroutine. If `server.Serve` returned for any other reason (listener error, fatal panic recovered by grpc), the health gauge stayed `SERVING`.

This wraps `s.server.Serve(s.listener)` so `NOT_SERVING` is set on every exit path. Added `TestLanternServer_Run_FlipsHealthOnServeReturn` using a broken listener to lock in the behavior.