### PR TITLE
perf(#44): avoid per-edge expiration re-lookup in Illuminate

### DIFF
--- a/core/cache/graph/cache.go
+++ b/core/cache/graph/cache.go
@@ -150,16 +150,33 @@ func (c *GraphCache[S, T]) Neighbor(seed S, step int, k int, tfidf bool) *graph.
 // — checked between BFS expansion steps — so handlers can short-circuit
 // large traversals when the caller has given up.
 func (c *GraphCache[S, T]) NeighborContext(ctx context.Context, seed S, step int, k int, tfidf bool) (*graph.Graph[S, T], error) {
+	g, _, err := c.neighborContext(ctx, seed, step, k, tfidf, false)
+	return g, err
+}
+
+// NeighborWithExpirationsContext returns the same subgraph as
+// NeighborContext together with a parallel expirations map keyed by
+// (tail, head). Both are computed under a single RLock so handlers can
+// compose responses without re-acquiring the cache lock per edge.
+//
+// The expirations map only contains entries for edges that ended up in
+// the returned graph; a missing or zero value means the edge has no
+// known expiration.
+func (c *GraphCache[S, T]) NeighborWithExpirationsContext(ctx context.Context, seed S, step int, k int, tfidf bool) (*graph.Graph[S, T], map[S]map[S]time.Time, error) {
+	return c.neighborContext(ctx, seed, step, k, tfidf, true)
+}
+
+func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int, k int, tfidf bool, collectExpirations bool) (*graph.Graph[S, T], map[S]map[S]time.Time, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	g := graph.NewGraph[S, T]()
 
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if v, ok := c.vertices.Get(seed); !ok {
-		return g, nil
+		return g, nil, nil
 	} else {
 		g.Vertices[seed] = v
 	}
@@ -175,7 +192,7 @@ func (c *GraphCache[S, T]) NeighborContext(ctx context.Context, seed S, step int
 	df := c.edges.snapshotDF()
 	for range step {
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		for _, tail := range targets.Values() {
@@ -234,7 +251,28 @@ func (c *GraphCache[S, T]) NeighborContext(ctx context.Context, seed S, step int
 		}
 	}
 
-	return g, nil
+	// Collect expirations under the same RLock so the handler can compose
+	// edges without re-locking the cache O(E) times. Only edges that
+	// survived the Top-k filter are queried.
+	var expirations map[S]map[S]time.Time
+	if collectExpirations {
+		expirations = make(map[S]map[S]time.Time, len(g.Edges))
+		for tail, heads := range g.Edges {
+			if len(heads) == 0 {
+				continue
+			}
+			row := make(map[S]time.Time, len(heads))
+			tfRow := tf[tail]
+			for head := range heads {
+				if w, ok := tfRow[head]; ok {
+					row[head] = w.latestExpiration()
+				}
+			}
+			expirations[tail] = row
+		}
+	}
+
+	return g, expirations, nil
 }
 
 func (c *GraphCache[S, T]) Watch(ctx context.Context, interval time.Duration) {

--- a/core/cache/graph/neighbor_expirations_test.go
+++ b/core/cache/graph/neighbor_expirations_test.go
@@ -1,0 +1,71 @@
+package graph
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Asserts that NeighborWithExpirationsContext returns expiration data
+// aligned to the same (tail, head) pairs present in the returned graph,
+// so handlers do not need a second per-edge cache lookup.
+func TestGraphCache_NeighborWithExpirationsContext_ReturnsAlignedMap(t *testing.T) {
+	c := NewGraphCache[string, int](time.Minute)
+	c.PutVertex("a", 1)
+	c.PutVertex("b", 2)
+	c.PutVertex("c", 3)
+
+	expAB := time.Now().Add(30 * time.Second).Truncate(time.Microsecond)
+	expAC := time.Now().Add(45 * time.Second).Truncate(time.Microsecond)
+	c.AddEdgeWithExpiration("a", "b", 1.0, expAB)
+	c.AddEdgeWithExpiration("a", "c", 2.0, expAC)
+
+	g, exps, err := c.NeighborWithExpirationsContext(context.Background(), "a", 2, 10, false)
+	if err != nil {
+		t.Fatalf("NeighborWithExpirationsContext: %v", err)
+	}
+	if exps == nil {
+		t.Fatal("expirations map is nil")
+	}
+
+	for tail, heads := range g.Edges {
+		row, ok := exps[tail]
+		if !ok {
+			t.Errorf("missing expirations row for %q", tail)
+			continue
+		}
+		for head := range heads {
+			got, ok := row[head]
+			if !ok {
+				t.Errorf("missing expiration for edge %q->%q", tail, head)
+				continue
+			}
+			if got.IsZero() {
+				t.Errorf("expiration for edge %q->%q is zero", tail, head)
+			}
+		}
+	}
+
+	if got, want := exps["a"]["b"].Unix(), expAB.Unix(); got != want {
+		t.Errorf("exp a->b unix = %d, want %d", got, want)
+	}
+	if got, want := exps["a"]["c"].Unix(), expAC.Unix(); got != want {
+		t.Errorf("exp a->c unix = %d, want %d", got, want)
+	}
+}
+
+// Smoke test: the plain Neighbor / NeighborContext paths still work.
+func TestGraphCache_NeighborContext_StillWorksAfterRefactor(t *testing.T) {
+	c := NewGraphCache[string, int](time.Minute)
+	c.PutVertex("a", 1)
+	c.PutVertex("b", 2)
+	c.AddEdge("a", "b", 1.0)
+
+	g, err := c.NeighborContext(context.Background(), "a", 2, 10, false)
+	if err != nil {
+		t.Fatalf("NeighborContext: %v", err)
+	}
+	if len(g.Edges["a"]) != 1 {
+		t.Errorf("len(g.Edges[a]) = %d, want 1", len(g.Edges["a"]))
+	}
+}

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -46,7 +46,7 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 		return nil, status.FromContextError(err).Err()
 	}
 
-	g, err := s.cache.NeighborContext(ctx, request.GetSeed(), int(request.GetStep()), int(request.GetK()), request.GetTfidf())
+	g, expirations, err := s.cache.NeighborWithExpirationsContext(ctx, request.GetSeed(), int(request.GetStep()), int(request.GetK()), request.GetTfidf())
 	if err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
@@ -87,10 +87,10 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 
 	var edges []*pb.Edge
 	for tail, heads := range g.Edges {
+		expRow := expirations[tail]
 		for head, weight := range heads {
-			_, exp, ok := s.cache.GetEdgeDetail(tail, head)
 			edge := &pb.Edge{Tail: tail, Head: head, Weight: weight}
-			if ok && !exp.IsZero() {
+			if exp, ok := expRow[head]; ok && !exp.IsZero() {
 				edge.Expiration = timestamppb.New(exp)
 			}
 			edges = append(edges, edge)


### PR DESCRIPTION
Closes #44.

Illuminate previously called `s.cache.GetEdgeDetail(tail, head)` for every edge in the response, re-acquiring the cache RLock O(E) times.

Adds `GraphCache.NeighborWithExpirationsContext` returning a parallel `map[S]map[S]time.Time` of expirations, computed under the same RLock used for the BFS snapshot. `Illuminate` composes `pb.Edge` directly from that map — the hot path now takes the cache lock exactly once regardless of E.

`NeighborContext` is preserved as a thin wrapper for callers (and tests) that don't need expirations, so the existing API surface is intact.