### PR TITLE
feat(#45): return existed for singular DeleteVertex/DeleteEdge RPCs

### DIFF
--- a/cli/cmd/edge.go
+++ b/cli/cmd/edge.go
@@ -236,7 +236,7 @@ EXAMPLES
 		defer func() { _ = cli.Close() }()
 
 		if len(refs) == 1 {
-			if err := cli.DeleteEdge(cmd.Context(), refs[0].Tail, refs[0].Head); err != nil {
+			if _, err := cli.DeleteEdge(cmd.Context(), refs[0].Tail, refs[0].Head); err != nil {
 				return err
 			}
 		} else {

--- a/cli/cmd/vertex.go
+++ b/cli/cmd/vertex.go
@@ -165,7 +165,7 @@ EXAMPLES
 		defer func() { _ = cli.Close() }()
 
 		if len(args) == 1 {
-			if err := cli.DeleteVertex(cmd.Context(), args[0]); err != nil {
+			if _, err := cli.DeleteVertex(cmd.Context(), args[0]); err != nil {
 				return err
 			}
 		} else {

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -153,7 +153,7 @@ func (c *CLIService) Run(ctx context.Context, str string) error {
 				fmt.Printf("Error: %s\n", err)
 				return ErrDeleteVertex
 			}
-			if err := c.client.DeleteVertex(ctx, p.Key); err != nil {
+			if _, err := c.client.DeleteVertex(ctx, p.Key); err != nil {
 				fmt.Printf("Error: %s\n", err)
 				return ErrConnection
 			}
@@ -165,7 +165,7 @@ func (c *CLIService) Run(ctx context.Context, str string) error {
 				fmt.Printf("Error: %s\n", err)
 				return ErrDeleteEdge
 			}
-			if err := c.client.DeleteEdge(ctx, p.Tail, p.Head); err != nil {
+			if _, err := c.client.DeleteEdge(ctx, p.Tail, p.Head); err != nil {
 				fmt.Printf("Error: %s\n", err)
 				return ErrConnection
 			}

--- a/core/cache/cache.go
+++ b/core/cache/cache.go
@@ -61,11 +61,17 @@ func (c *Cache[S, T]) Put(key S, value T) {
 	c.PutWithTTL(key, value, c.defaultTTL)
 }
 
-func (c *Cache[S, T]) Delete(key S) {
+// Delete removes the entry for key. It returns true if the key was
+// present (and therefore removed by this call), false otherwise.
+func (c *Cache[S, T]) Delete(key S) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if _, ok := c.cache[key]; !ok {
+		return false
+	}
 	delete(c.cache, key)
+	return true
 }
 
 func (c *Cache[S, T]) Has(key S) bool {

--- a/core/cache/graph/cache.go
+++ b/core/cache/graph/cache.go
@@ -114,18 +114,20 @@ func (c *GraphCache[S, T]) PutEdgeWithExpiration(tail, head S, w float32, expira
 	c.edges.addWithExpiration(tail, head, w, expiration)
 }
 
-func (c *GraphCache[S, T]) DeleteVertex(key S) {
+// DeleteVertex removes the vertex (by key) and returns whether it was present.
+func (c *GraphCache[S, T]) DeleteVertex(key S) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.vertices.Delete(key)
+	return c.vertices.Delete(key)
 }
 
-func (c *GraphCache[S, T]) DeleteEdge(tail, head S) {
+// DeleteEdge removes the (tail, head) edge and returns whether it was present.
+func (c *GraphCache[S, T]) DeleteEdge(tail, head S) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.edges.delete(tail, head)
+	return c.edges.delete(tail, head)
 }
 func (c *GraphCache[S, T]) flush() {
 	c.mu.Lock()

--- a/core/cache/graph/edge.go
+++ b/core/cache/graph/edge.go
@@ -180,21 +180,23 @@ func (c *edgeCache[S]) add(tail, head S, w float32) {
 	c.addWithTTL(tail, head, w, c.defaultTTL)
 }
 
-func (c *edgeCache[S]) delete(tail, head S) {
+// delete removes the (tail, head) edge. It returns true if the edge
+// was present (and therefore removed by this call), false otherwise.
+func (c *edgeCache[S]) delete(tail, head S) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.deleteLocked(tail, head)
+	return c.deleteLocked(tail, head)
 }
 
 // deleteLocked performs the same work as delete but assumes the caller already
 // holds c.mu in write mode.
-func (c *edgeCache[S]) deleteLocked(tail, head S) {
+func (c *edgeCache[S]) deleteLocked(tail, head S) bool {
 	heads, ok := c.tf[tail]
 	if !ok {
-		return
+		return false
 	}
 	if _, ok := heads[head]; !ok {
-		return
+		return false
 	}
 
 	delete(heads, head)
@@ -205,6 +207,7 @@ func (c *edgeCache[S]) deleteLocked(tail, head S) {
 	if len(heads) == 0 {
 		delete(c.tf, tail)
 	}
+	return true
 }
 
 func (c *edgeCache[S]) flush() {

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -91,7 +91,10 @@ message DeleteVertexRequest {
   string key = 1;
 }
 
-message DeleteVertexResponse {}
+message DeleteVertexResponse {
+  // existed is true if the vertex was present and removed by this call.
+  bool existed = 1;
+}
 
 // DeleteVerticesRequest removes several vertices in one round trip. Same
 // cascade semantics as DeleteVertex (edges reaped lazily by the GC loop).
@@ -119,7 +122,10 @@ message DeleteEdgeRequest {
   string head = 2;
 }
 
-message DeleteEdgeResponse {}
+message DeleteEdgeResponse {
+  // existed is true if the edge was present and removed by this call.
+  bool existed = 1;
+}
 
 // EdgeKey identifies an edge by its (tail, head) pair without weight.
 message EdgeKey {

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -191,11 +191,17 @@ func (l *Lantern) PutVertices(ctx context.Context, inputs []VertexInput) error {
 	return nil
 }
 
-func (l *Lantern) DeleteVertex(ctx context.Context, key string) error {
+// DeleteVertex removes the vertex identified by key. The returned
+// bool reports whether the vertex existed (and was therefore removed
+// by this call).
+func (l *Lantern) DeleteVertex(ctx context.Context, key string) (bool, error) {
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	_, err := l.client.DeleteVertex(ctx, &pb.DeleteVertexRequest{Key: key})
-	return err
+	resp, err := l.client.DeleteVertex(ctx, &pb.DeleteVertexRequest{Key: key})
+	if err != nil {
+		return false, err
+	}
+	return resp.GetExisted(), nil
 }
 
 // DeleteVertices removes a batch of vertices. Automatically chunked to
@@ -292,11 +298,16 @@ func (l *Lantern) PutEdges(ctx context.Context, inputs []EdgeInput) error {
 	return nil
 }
 
-func (l *Lantern) DeleteEdge(ctx context.Context, tail string, head string) error {
+// DeleteEdge removes the (tail, head) edge. The returned bool reports
+// whether the edge existed (and was therefore removed by this call).
+func (l *Lantern) DeleteEdge(ctx context.Context, tail string, head string) (bool, error) {
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	_, err := l.client.DeleteEdge(ctx, &pb.DeleteEdgeRequest{Tail: tail, Head: head})
-	return err
+	resp, err := l.client.DeleteEdge(ctx, &pb.DeleteEdgeRequest{Tail: tail, Head: head})
+	if err != nil {
+		return false, err
+	}
+	return resp.GetExisted(), nil
 }
 
 // EdgeRef identifies an edge by its (tail, head) pair without weight.

--- a/sdks/go/example/main.go
+++ b/sdks/go/example/main.go
@@ -109,8 +109,10 @@ func main() {
 		DeleteVertex:
 	*/
 
-	if err := cli.DeleteVertex(ctx, "string"); err != nil {
+	if existed, err := cli.DeleteVertex(ctx, "string"); err != nil {
 		log.Fatal(err)
+	} else {
+		log.Printf("DeleteVertex(\"string\"): existed=%v\n", existed)
 	}
 
 	if _, err := cli.GetVertex(ctx, "string"); err != nil {
@@ -182,8 +184,10 @@ func main() {
 		log.Printf("weight of a->b: %f\n", w.Weight)
 	}
 
-	if err := cli.DeleteEdge(ctx, "a", "b"); err != nil {
+	if existed, err := cli.DeleteEdge(ctx, "a", "b"); err != nil {
 		log.Fatal(err)
+	} else {
+		log.Printf("DeleteEdge(\"a\", \"b\"): existed=%v\n", existed)
 	}
 
 	// If edge is deleted, weight of edge is 0

--- a/sdks/go/gen/graph/v1/graph.pb.go
+++ b/sdks/go/gen/graph/v1/graph.pb.go
@@ -811,7 +811,9 @@ func (x *DeleteVertexRequest) GetKey() string {
 }
 
 type DeleteVertexResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// existed is true if the vertex was present and removed by this call.
+	Existed       bool `protobuf:"varint,1,opt,name=existed,proto3" json:"existed,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -844,6 +846,13 @@ func (x *DeleteVertexResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use DeleteVertexResponse.ProtoReflect.Descriptor instead.
 func (*DeleteVertexResponse) Descriptor() ([]byte, []int) {
 	return file_graph_v1_graph_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *DeleteVertexResponse) GetExisted() bool {
+	if x != nil {
+		return x.Existed
+	}
+	return false
 }
 
 // DeleteVerticesRequest removes several vertices in one round trip. Same
@@ -1087,7 +1096,9 @@ func (x *DeleteEdgeRequest) GetHead() string {
 }
 
 type DeleteEdgeResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// existed is true if the edge was present and removed by this call.
+	Existed       bool `protobuf:"varint,1,opt,name=existed,proto3" json:"existed,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1120,6 +1131,13 @@ func (x *DeleteEdgeResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use DeleteEdgeResponse.ProtoReflect.Descriptor instead.
 func (*DeleteEdgeResponse) Descriptor() ([]byte, []int) {
 	return file_graph_v1_graph_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *DeleteEdgeResponse) GetExisted() bool {
+	if x != nil {
+		return x.Existed
+	}
+	return false
 }
 
 // EdgeKey identifies an edge by its (tail, head) pair without weight.
@@ -1500,8 +1518,9 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\x11PutVertexResponse\x12\x18\n" +
 	"\awritten\x18\x01 \x01(\x05R\awritten\"'\n" +
 	"\x13DeleteVertexRequest\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\"\x16\n" +
-	"\x14DeleteVertexResponse\"+\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\"0\n" +
+	"\x14DeleteVertexResponse\x12\x18\n" +
+	"\aexisted\x18\x01 \x01(\bR\aexisted\"+\n" +
 	"\x15DeleteVerticesRequest\x12\x12\n" +
 	"\x04keys\x18\x01 \x03(\tR\x04keys\"2\n" +
 	"\x16DeleteVerticesResponse\x12\x18\n" +
@@ -1513,8 +1532,9 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\x04edge\x18\x01 \x01(\v2\x0e.graph.v1.EdgeR\x04edge\";\n" +
 	"\x11DeleteEdgeRequest\x12\x12\n" +
 	"\x04tail\x18\x01 \x01(\tR\x04tail\x12\x12\n" +
-	"\x04head\x18\x02 \x01(\tR\x04head\"\x14\n" +
-	"\x12DeleteEdgeResponse\"1\n" +
+	"\x04head\x18\x02 \x01(\tR\x04head\".\n" +
+	"\x12DeleteEdgeResponse\x12\x18\n" +
+	"\aexisted\x18\x01 \x01(\bR\aexisted\"1\n" +
 	"\aEdgeKey\x12\x12\n" +
 	"\x04tail\x18\x01 \x01(\tR\x04tail\x12\x12\n" +
 	"\x04head\x18\x02 \x01(\tR\x04head\"=\n" +

--- a/sdks/go/gen/openapiv2/graph/v1/graph.swagger.json
+++ b/sdks/go/gen/openapiv2/graph/v1/graph.swagger.json
@@ -431,7 +431,13 @@
       }
     },
     "v1DeleteEdgeResponse": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "existed": {
+          "type": "boolean",
+          "description": "existed is true if the edge was present and removed by this call."
+        }
+      }
     },
     "v1DeleteEdgesRequest": {
       "type": "object",
@@ -457,7 +463,13 @@
       }
     },
     "v1DeleteVertexResponse": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "existed": {
+          "type": "boolean",
+          "description": "existed is true if the vertex was present and removed by this call."
+        }
+      }
     },
     "v1DeleteVerticesRequest": {
       "type": "object",

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -136,8 +136,8 @@ func (s *LanternService) DeleteVertex(ctx context.Context, in *pb.DeleteVertexRe
 	}
 	// Per the proto contract, deleting a vertex leaves its edges orphaned;
 	// the periodic GC loop reaps any tf/df rows whose endpoints disappear.
-	s.cache.DeleteVertex(in.GetKey())
-	return &pb.DeleteVertexResponse{}, nil
+	existed := s.cache.DeleteVertex(in.GetKey())
+	return &pb.DeleteVertexResponse{Existed: existed}, nil
 }
 
 func (s *LanternService) DeleteVertices(ctx context.Context, in *pb.DeleteVerticesRequest) (*pb.DeleteVerticesResponse, error) {
@@ -198,8 +198,8 @@ func (s *LanternService) DeleteEdge(ctx context.Context, in *pb.DeleteEdgeReques
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
-	s.cache.DeleteEdge(in.GetTail(), in.GetHead())
-	return &pb.DeleteEdgeResponse{}, nil
+	existed := s.cache.DeleteEdge(in.GetTail(), in.GetHead())
+	return &pb.DeleteEdgeResponse{Existed: existed}, nil
 }
 
 func (s *LanternService) DeleteEdges(ctx context.Context, in *pb.DeleteEdgesRequest) (*pb.DeleteEdgesResponse, error) {

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -61,11 +61,23 @@ func TestLanternService_DeleteVertex(t *testing.T) {
 	if _, err := s.PutVertex(ctx, &pb.PutVertexRequest{Vertices: []*pb.Vertex{v}}); err != nil {
 		t.Fatalf("PutVertex: %v", err)
 	}
-	if _, err := s.DeleteVertex(ctx, &pb.DeleteVertexRequest{Key: "x"}); err != nil {
+	dResp, err := s.DeleteVertex(ctx, &pb.DeleteVertexRequest{Key: "x"})
+	if err != nil {
 		t.Fatalf("DeleteVertex: %v", err)
+	}
+	if !dResp.GetExisted() {
+		t.Errorf("DeleteVertex.Existed = false, want true (vertex was present)")
 	}
 	if _, err := s.GetVertex(ctx, &pb.GetVertexRequest{Key: "x"}); err == nil {
 		t.Error("expected NotFound after delete, got nil error")
+	}
+	// Second delete of the same key must report existed=false.
+	dResp2, err := s.DeleteVertex(ctx, &pb.DeleteVertexRequest{Key: "x"})
+	if err != nil {
+		t.Fatalf("DeleteVertex(repeat): %v", err)
+	}
+	if dResp2.GetExisted() {
+		t.Errorf("DeleteVertex.Existed = true on second call, want false")
 	}
 }
 
@@ -143,11 +155,23 @@ func TestLanternService_DeleteEdge(t *testing.T) {
 	if _, err := s.AddEdge(ctx, &pb.AddEdgeRequest{Edges: []*pb.Edge{e}}); err != nil {
 		t.Fatalf("AddEdge: %v", err)
 	}
-	if _, err := s.DeleteEdge(ctx, &pb.DeleteEdgeRequest{Tail: "a", Head: "b"}); err != nil {
+	dResp, err := s.DeleteEdge(ctx, &pb.DeleteEdgeRequest{Tail: "a", Head: "b"})
+	if err != nil {
 		t.Fatalf("DeleteEdge: %v", err)
+	}
+	if !dResp.GetExisted() {
+		t.Errorf("DeleteEdge.Existed = false, want true (edge was present)")
 	}
 	if _, err := s.GetEdge(ctx, &pb.GetEdgeRequest{Tail: "a", Head: "b"}); err == nil {
 		t.Error("expected NotFound after delete")
+	}
+	// Second delete reports existed=false.
+	dResp2, err := s.DeleteEdge(ctx, &pb.DeleteEdgeRequest{Tail: "a", Head: "b"})
+	if err != nil {
+		t.Fatalf("DeleteEdge(repeat): %v", err)
+	}
+	if dResp2.GetExisted() {
+		t.Errorf("DeleteEdge.Existed = true on second call, want false")
 	}
 }
 

--- a/tests/integration/client_test.go
+++ b/tests/integration/client_test.go
@@ -74,7 +74,7 @@ func TestLantern_PutGetDeleteVertex(t *testing.T) {
 		t.Errorf("StringValue = %q, want \"v\"", got)
 	}
 
-	if err := l.DeleteVertex(ctx, "k"); err != nil {
+	if _, err := l.DeleteVertex(ctx, "k"); err != nil {
 		t.Fatalf("DeleteVertex: %v", err)
 	}
 	if _, err := l.GetVertex(ctx, "k"); err == nil {
@@ -112,7 +112,7 @@ func TestLantern_AddPutDeleteEdge(t *testing.T) {
 		t.Errorf("weight after PutEdge = %v, want 9", e.Weight)
 	}
 
-	if err := l.DeleteEdge(ctx, "a", "b"); err != nil {
+	if _, err := l.DeleteEdge(ctx, "a", "b"); err != nil {
 		t.Fatalf("DeleteEdge: %v", err)
 	}
 	if _, err := l.GetEdge(ctx, "a", "b"); err == nil {


### PR DESCRIPTION
Closes #45.

`DeleteVertexResponse` and `DeleteEdgeResponse` now carry `bool existed = 1` so callers can tell whether the key was actually present at delete time (a question the batch RPCs already answer via `Deleted`).

### Changes
- **proto**: add `bool existed = 1` to both response messages (regenerated `sdks/go/gen/...`).
- **core/cache**: `Cache.Delete`, `edgeCache.delete`, `GraphCache.DeleteVertex`, `GraphCache.DeleteEdge` now return `bool` (existed).
- **server/service**: `DeleteVertex` / `DeleteEdge` handlers thread the bool into `Existed`.
- **sdks/go**: `Lantern.DeleteVertex` / `Lantern.DeleteEdge` now return `(bool, error)` — single source-level break in the SDK, propagated to CLI, example, and integration tests.
- **tests**: extended `TestLanternService_DeleteVertex` / `TestLanternService_DeleteEdge` to assert `Existed=true` on first delete and `false` on the immediate second delete.

### Notes
- Batch `DeleteVertices` / `DeleteEdges` semantics intentionally unchanged (out of scope for this issue).
- `Existed` is backwards-compatible on the wire (proto3 default false), so old clients see no behavior change.