### PR TITLE
feat(#46): add MaximumSpanningTree to core/graph

### DIFF
--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -235,7 +235,7 @@ func (c *CLIService) Run(ctx context.Context, str string) error {
 				return nil
 			}
 		case "mst_relevance":
-			mg = mg.MinimumSpanningTree(p.Seed, true)
+				mg = mg.MaximumSpanningTree(p.Seed)
 			if jsonString, err := json.MarshalIndent(mg, "", "\t"); err != nil {
 				return err
 			} else {

--- a/core/graph/graph_test.go
+++ b/core/graph/graph_test.go
@@ -86,7 +86,7 @@ func TestGraph_MaximumSpanningTree(t *testing.T) {
 	g.PutEdge("a", "c", 10)
 	g.PutEdge("c", "a", 10)
 
-	mst := g.MinimumSpanningTree("a", true)
+	mst := g.MaximumSpanningTree("a")
 
 	total := float32(0)
 	for _, heads := range mst.Edges {

--- a/core/graph/model.go
+++ b/core/graph/model.go
@@ -85,19 +85,32 @@ func (g *Graph[S, T]) ConnectedGraphContext(ctx context.Context, seed S) (*Graph
 	return connected, nil
 }
 
-// MinimumSpanningTree
-/*
- * MinimumSpanningTree returns a minimum spanning tree of the graph.
- * The seed is the starting point of the tree.
- * If negate is true, the maximum spanning tree is returned.
- */
+// MinimumSpanningTree returns a minimum spanning tree of the graph rooted at seed.
+//
+// Deprecated: the `negate` flag is semantically confusing — for the maximum
+// spanning tree, call [Graph.MaximumSpanningTree] instead. This method is
+// retained for backward compatibility and will continue to work, but new code
+// should not pass `negate=true`.
 func (g *Graph[S, T]) MinimumSpanningTree(seed S, negate bool) *Graph[S, T] {
 	mst, _ := g.MinimumSpanningTreeContext(context.Background(), seed, negate)
 	return mst
 }
 
-// MinimumSpanningTreeContext is the context-aware variant of
-// MinimumSpanningTree.
+// MaximumSpanningTree returns a maximum spanning tree of the graph rooted at seed.
+func (g *Graph[S, T]) MaximumSpanningTree(seed S) *Graph[S, T] {
+	mst, _ := g.MinimumSpanningTreeContext(context.Background(), seed, true)
+	return mst
+}
+
+// MaximumSpanningTreeContext is the context-aware variant of [Graph.MaximumSpanningTree].
+func (g *Graph[S, T]) MaximumSpanningTreeContext(ctx context.Context, seed S) (*Graph[S, T], error) {
+	return g.MinimumSpanningTreeContext(ctx, seed, true)
+}
+
+// MinimumSpanningTreeContext is the context-aware variant of [Graph.MinimumSpanningTree].
+//
+// Deprecated: the `negate` flag is semantically confusing — for the maximum
+// spanning tree, call [Graph.MaximumSpanningTreeContext] instead.
 func (g *Graph[S, T]) MinimumSpanningTreeContext(ctx context.Context, seed S, negate bool) (*Graph[S, T], error) {
 	connected, err := g.ConnectedGraphContext(ctx, seed)
 	if err != nil {

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -57,7 +57,7 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 	case pb.Optimization_OPTIMIZATION_MINIMUM_SPANNING_TREE:
 		g, err = g.MinimumSpanningTreeContext(ctx, request.GetSeed(), false)
 	case pb.Optimization_OPTIMIZATION_MAXIMUM_SPANNING_TREE:
-		g, err = g.MinimumSpanningTreeContext(ctx, request.GetSeed(), true)
+		g, err = g.MaximumSpanningTreeContext(ctx, request.GetSeed())
 	case pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE:
 		g, err = g.ShortestPathTreeContext(ctx, request.GetSeed(), func(weight float32) float32 { return weight })
 	case pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE:


### PR DESCRIPTION
Closes #46.

Calling `g.MinimumSpanningTree(seed, true)` to get the maximum spanning tree is semantically misleading. This PR introduces explicit `MaximumSpanningTree` / `MaximumSpanningTreeContext` methods that wrap the existing implementation, deprecates the `negate` flag in doc comments, and switches the in-tree call sites:

- `server/service/service.go` (`Optimization_OPTIMIZATION_MAXIMUM_SPANNING_TREE` branch)
- `cli/service/service.go` (interactive CLI)
- `core/graph/graph_test.go` (`TestGraph_MaximumSpanningTree`)

`MinimumSpanningTree(seed, negate)` is kept for backward compatibility (no behavior change), so this is purely additive at the API level.