### PR TITLE
feat(#47): add batch GetVertices / GetEdges RPCs

### DIFF
--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -69,6 +69,20 @@ message GetVertexResponse {
   Vertex vertex = 1;
 }
 
+// GetVerticesRequest reads several vertices in one round trip. Subject to
+// the same MaxBatchSize / MaxKeyLen guard rails as the write RPCs.
+message GetVerticesRequest {
+  repeated string keys = 1;
+}
+
+message GetVerticesResponse {
+  // vertices contains every key that was present at the time of the call.
+  // Order is unspecified; clients should match by Vertex.key.
+  repeated Vertex vertices = 1;
+  // missing lists the requested keys that did not exist (or had expired).
+  repeated string missing = 2;
+}
+
 // PutVertexRequest writes vertices with upsert semantics: each Vertex.key
 // replaces any existing value at that key. Use the Vertex.expiration field
 // (absolute time) to control TTL.
@@ -115,6 +129,22 @@ message GetEdgeRequest {
 
 message GetEdgeResponse {
   Edge edge = 1;
+}
+
+// GetEdgesRequest reads several edges in one round trip. Subject to the
+// same MaxBatchSize / MaxKeyLen guard rails as the write RPCs.
+message GetEdgesRequest {
+  repeated EdgeKey edges = 1;
+}
+
+message GetEdgesResponse {
+  // edges contains every (tail, head) pair that was present at the time of
+  // the call. Order is unspecified; clients should match by (Edge.tail,
+  // Edge.head).
+  repeated Edge edges = 1;
+  // missing lists the requested (tail, head) pairs that did not exist (or
+  // had expired).
+  repeated EdgeKey missing = 2;
 }
 
 message DeleteEdgeRequest {
@@ -176,6 +206,14 @@ service LanternService {
     option (google.api.http) = {get: "/v1/vertices/{key}"};
   }
 
+  // GetVertices reads several vertices in one round trip.
+  rpc GetVertices(GetVerticesRequest) returns (GetVerticesResponse) {
+    option (google.api.http) = {
+      post: "/v1/vertices/get"
+      body: "*"
+    };
+  }
+
   rpc PutVertex(PutVertexRequest) returns (PutVertexResponse) {
     option (google.api.http) = {
       put: "/v1/vertices"
@@ -197,6 +235,14 @@ service LanternService {
 
   rpc GetEdge(GetEdgeRequest) returns (GetEdgeResponse) {
     option (google.api.http) = {get: "/v1/edges/{tail}/{head}"};
+  }
+
+  // GetEdges reads several edges in one round trip.
+  rpc GetEdges(GetEdgesRequest) returns (GetEdgesResponse) {
+    option (google.api.http) = {
+      post: "/v1/edges/get"
+      body: "*"
+    };
   }
 
   // AddEdge is non-idempotent (accumulates weight). POST per REST conventions.

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -222,6 +222,30 @@ func (l *Lantern) DeleteVertices(ctx context.Context, keys []string) error {
 	return nil
 }
 
+// GetVertices reads a batch of vertices in one (or a few chunked) round
+// trips. Vertices present at call time are returned in found; keys that did
+// not exist (or had expired) are returned in missing. Order is unspecified;
+// callers should match by Vertex.Key. Automatically chunked to respect the
+// server's MaxBatchSize cap.
+func (l *Lantern) GetVertices(ctx context.Context, keys []string) (found []*Vertex, missing []string, err error) {
+	if len(keys) == 0 {
+		return nil, nil, nil
+	}
+	for _, chunk := range chunkSlice(keys, l.opts.batchChunkSize) {
+		cctx, cancel := l.applyTimeout(ctx)
+		resp, rerr := l.client.GetVertices(cctx, &pb.GetVerticesRequest{Keys: chunk})
+		cancel()
+		if rerr != nil {
+			return nil, nil, rerr
+		}
+		for _, v := range resp.GetVertices() {
+			found = append(found, (*Vertex)(v))
+		}
+		missing = append(missing, resp.GetMissing()...)
+	}
+	return found, missing, nil
+}
+
 // GetEdge fetches the edge weight (and any expiration) between tail and head.
 func (l *Lantern) GetEdge(ctx context.Context, tail string, head string) (*Edge, error) {
 	ctx, cancel := l.applyTimeout(ctx)
@@ -335,6 +359,36 @@ func (l *Lantern) DeleteEdges(ctx context.Context, refs []EdgeRef) error {
 		}
 	}
 	return nil
+}
+
+// GetEdges reads a batch of edges in one (or a few chunked) round trips.
+// Pairs present at call time are returned in found; pairs that did not exist
+// (or had expired) are returned in missing. Order is unspecified; callers
+// should match by (Edge.Tail, Edge.Head). Automatically chunked to respect
+// the server's MaxBatchSize cap.
+func (l *Lantern) GetEdges(ctx context.Context, refs []EdgeRef) (found []*Edge, missing []EdgeRef, err error) {
+	if len(refs) == 0 {
+		return nil, nil, nil
+	}
+	keys := make([]*pb.EdgeKey, 0, len(refs))
+	for _, r := range refs {
+		keys = append(keys, &pb.EdgeKey{Tail: r.Tail, Head: r.Head})
+	}
+	for _, chunk := range chunkSlice(keys, l.opts.batchChunkSize) {
+		cctx, cancel := l.applyTimeout(ctx)
+		resp, rerr := l.client.GetEdges(cctx, &pb.GetEdgesRequest{Edges: chunk})
+		cancel()
+		if rerr != nil {
+			return nil, nil, rerr
+		}
+		for _, e := range resp.GetEdges() {
+			found = append(found, (*Edge)(e))
+		}
+		for _, m := range resp.GetMissing() {
+			missing = append(missing, EdgeRef{Tail: m.GetTail(), Head: m.GetHead()})
+		}
+	}
+	return found, missing, nil
 }
 
 // Graph is the SDK-native representation of an Illuminate response. It mirrors

--- a/sdks/go/gen/graph/v1/graph.pb.go
+++ b/sdks/go/gen/graph/v1/graph.pb.go
@@ -668,6 +668,107 @@ func (x *GetVertexResponse) GetVertex() *Vertex {
 	return nil
 }
 
+// GetVerticesRequest reads several vertices in one round trip. Subject to
+// the same MaxBatchSize / MaxKeyLen guard rails as the write RPCs.
+type GetVerticesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Keys          []string               `protobuf:"bytes,1,rep,name=keys,proto3" json:"keys,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetVerticesRequest) Reset() {
+	*x = GetVerticesRequest{}
+	mi := &file_graph_v1_graph_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetVerticesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetVerticesRequest) ProtoMessage() {}
+
+func (x *GetVerticesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetVerticesRequest.ProtoReflect.Descriptor instead.
+func (*GetVerticesRequest) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *GetVerticesRequest) GetKeys() []string {
+	if x != nil {
+		return x.Keys
+	}
+	return nil
+}
+
+type GetVerticesResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// vertices contains every key that was present at the time of the call.
+	// Order is unspecified; clients should match by Vertex.key.
+	Vertices []*Vertex `protobuf:"bytes,1,rep,name=vertices,proto3" json:"vertices,omitempty"`
+	// missing lists the requested keys that did not exist (or had expired).
+	Missing       []string `protobuf:"bytes,2,rep,name=missing,proto3" json:"missing,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetVerticesResponse) Reset() {
+	*x = GetVerticesResponse{}
+	mi := &file_graph_v1_graph_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetVerticesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetVerticesResponse) ProtoMessage() {}
+
+func (x *GetVerticesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetVerticesResponse.ProtoReflect.Descriptor instead.
+func (*GetVerticesResponse) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *GetVerticesResponse) GetVertices() []*Vertex {
+	if x != nil {
+		return x.Vertices
+	}
+	return nil
+}
+
+func (x *GetVerticesResponse) GetMissing() []string {
+	if x != nil {
+		return x.Missing
+	}
+	return nil
+}
+
 // PutVertexRequest writes vertices with upsert semantics: each Vertex.key
 // replaces any existing value at that key. Use the Vertex.expiration field
 // (absolute time) to control TTL.
@@ -680,7 +781,7 @@ type PutVertexRequest struct {
 
 func (x *PutVertexRequest) Reset() {
 	*x = PutVertexRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[7]
+	mi := &file_graph_v1_graph_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -692,7 +793,7 @@ func (x *PutVertexRequest) String() string {
 func (*PutVertexRequest) ProtoMessage() {}
 
 func (x *PutVertexRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[7]
+	mi := &file_graph_v1_graph_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -705,7 +806,7 @@ func (x *PutVertexRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutVertexRequest.ProtoReflect.Descriptor instead.
 func (*PutVertexRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{7}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *PutVertexRequest) GetVertices() []*Vertex {
@@ -727,7 +828,7 @@ type PutVertexResponse struct {
 
 func (x *PutVertexResponse) Reset() {
 	*x = PutVertexResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[8]
+	mi := &file_graph_v1_graph_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -739,7 +840,7 @@ func (x *PutVertexResponse) String() string {
 func (*PutVertexResponse) ProtoMessage() {}
 
 func (x *PutVertexResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[8]
+	mi := &file_graph_v1_graph_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -752,7 +853,7 @@ func (x *PutVertexResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutVertexResponse.ProtoReflect.Descriptor instead.
 func (*PutVertexResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{8}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *PutVertexResponse) GetWritten() int32 {
@@ -775,7 +876,7 @@ type DeleteVertexRequest struct {
 
 func (x *DeleteVertexRequest) Reset() {
 	*x = DeleteVertexRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[9]
+	mi := &file_graph_v1_graph_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -787,7 +888,7 @@ func (x *DeleteVertexRequest) String() string {
 func (*DeleteVertexRequest) ProtoMessage() {}
 
 func (x *DeleteVertexRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[9]
+	mi := &file_graph_v1_graph_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -800,7 +901,7 @@ func (x *DeleteVertexRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteVertexRequest.ProtoReflect.Descriptor instead.
 func (*DeleteVertexRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{9}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *DeleteVertexRequest) GetKey() string {
@@ -820,7 +921,7 @@ type DeleteVertexResponse struct {
 
 func (x *DeleteVertexResponse) Reset() {
 	*x = DeleteVertexResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[10]
+	mi := &file_graph_v1_graph_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -832,7 +933,7 @@ func (x *DeleteVertexResponse) String() string {
 func (*DeleteVertexResponse) ProtoMessage() {}
 
 func (x *DeleteVertexResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[10]
+	mi := &file_graph_v1_graph_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -845,7 +946,7 @@ func (x *DeleteVertexResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteVertexResponse.ProtoReflect.Descriptor instead.
 func (*DeleteVertexResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{10}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *DeleteVertexResponse) GetExisted() bool {
@@ -867,7 +968,7 @@ type DeleteVerticesRequest struct {
 
 func (x *DeleteVerticesRequest) Reset() {
 	*x = DeleteVerticesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[11]
+	mi := &file_graph_v1_graph_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -879,7 +980,7 @@ func (x *DeleteVerticesRequest) String() string {
 func (*DeleteVerticesRequest) ProtoMessage() {}
 
 func (x *DeleteVerticesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[11]
+	mi := &file_graph_v1_graph_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -892,7 +993,7 @@ func (x *DeleteVerticesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteVerticesRequest.ProtoReflect.Descriptor instead.
 func (*DeleteVerticesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{11}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *DeleteVerticesRequest) GetKeys() []string {
@@ -912,7 +1013,7 @@ type DeleteVerticesResponse struct {
 
 func (x *DeleteVerticesResponse) Reset() {
 	*x = DeleteVerticesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[12]
+	mi := &file_graph_v1_graph_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -924,7 +1025,7 @@ func (x *DeleteVerticesResponse) String() string {
 func (*DeleteVerticesResponse) ProtoMessage() {}
 
 func (x *DeleteVerticesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[12]
+	mi := &file_graph_v1_graph_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -937,7 +1038,7 @@ func (x *DeleteVerticesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteVerticesResponse.ProtoReflect.Descriptor instead.
 func (*DeleteVerticesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{12}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *DeleteVerticesResponse) GetDeleted() int32 {
@@ -957,7 +1058,7 @@ type GetEdgeRequest struct {
 
 func (x *GetEdgeRequest) Reset() {
 	*x = GetEdgeRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[13]
+	mi := &file_graph_v1_graph_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -969,7 +1070,7 @@ func (x *GetEdgeRequest) String() string {
 func (*GetEdgeRequest) ProtoMessage() {}
 
 func (x *GetEdgeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[13]
+	mi := &file_graph_v1_graph_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -982,7 +1083,7 @@ func (x *GetEdgeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEdgeRequest.ProtoReflect.Descriptor instead.
 func (*GetEdgeRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{13}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *GetEdgeRequest) GetTail() string {
@@ -1008,7 +1109,7 @@ type GetEdgeResponse struct {
 
 func (x *GetEdgeResponse) Reset() {
 	*x = GetEdgeResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[14]
+	mi := &file_graph_v1_graph_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1020,7 +1121,7 @@ func (x *GetEdgeResponse) String() string {
 func (*GetEdgeResponse) ProtoMessage() {}
 
 func (x *GetEdgeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[14]
+	mi := &file_graph_v1_graph_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1033,12 +1134,115 @@ func (x *GetEdgeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEdgeResponse.ProtoReflect.Descriptor instead.
 func (*GetEdgeResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{14}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GetEdgeResponse) GetEdge() *Edge {
 	if x != nil {
 		return x.Edge
+	}
+	return nil
+}
+
+// GetEdgesRequest reads several edges in one round trip. Subject to the
+// same MaxBatchSize / MaxKeyLen guard rails as the write RPCs.
+type GetEdgesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Edges         []*EdgeKey             `protobuf:"bytes,1,rep,name=edges,proto3" json:"edges,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetEdgesRequest) Reset() {
+	*x = GetEdgesRequest{}
+	mi := &file_graph_v1_graph_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetEdgesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetEdgesRequest) ProtoMessage() {}
+
+func (x *GetEdgesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetEdgesRequest.ProtoReflect.Descriptor instead.
+func (*GetEdgesRequest) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *GetEdgesRequest) GetEdges() []*EdgeKey {
+	if x != nil {
+		return x.Edges
+	}
+	return nil
+}
+
+type GetEdgesResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// edges contains every (tail, head) pair that was present at the time of
+	// the call. Order is unspecified; clients should match by (Edge.tail,
+	// Edge.head).
+	Edges []*Edge `protobuf:"bytes,1,rep,name=edges,proto3" json:"edges,omitempty"`
+	// missing lists the requested (tail, head) pairs that did not exist (or
+	// had expired).
+	Missing       []*EdgeKey `protobuf:"bytes,2,rep,name=missing,proto3" json:"missing,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetEdgesResponse) Reset() {
+	*x = GetEdgesResponse{}
+	mi := &file_graph_v1_graph_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetEdgesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetEdgesResponse) ProtoMessage() {}
+
+func (x *GetEdgesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetEdgesResponse.ProtoReflect.Descriptor instead.
+func (*GetEdgesResponse) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *GetEdgesResponse) GetEdges() []*Edge {
+	if x != nil {
+		return x.Edges
+	}
+	return nil
+}
+
+func (x *GetEdgesResponse) GetMissing() []*EdgeKey {
+	if x != nil {
+		return x.Missing
 	}
 	return nil
 }
@@ -1053,7 +1257,7 @@ type DeleteEdgeRequest struct {
 
 func (x *DeleteEdgeRequest) Reset() {
 	*x = DeleteEdgeRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[15]
+	mi := &file_graph_v1_graph_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1065,7 +1269,7 @@ func (x *DeleteEdgeRequest) String() string {
 func (*DeleteEdgeRequest) ProtoMessage() {}
 
 func (x *DeleteEdgeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[15]
+	mi := &file_graph_v1_graph_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1078,7 +1282,7 @@ func (x *DeleteEdgeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEdgeRequest.ProtoReflect.Descriptor instead.
 func (*DeleteEdgeRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{15}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *DeleteEdgeRequest) GetTail() string {
@@ -1105,7 +1309,7 @@ type DeleteEdgeResponse struct {
 
 func (x *DeleteEdgeResponse) Reset() {
 	*x = DeleteEdgeResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[16]
+	mi := &file_graph_v1_graph_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1117,7 +1321,7 @@ func (x *DeleteEdgeResponse) String() string {
 func (*DeleteEdgeResponse) ProtoMessage() {}
 
 func (x *DeleteEdgeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[16]
+	mi := &file_graph_v1_graph_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1130,7 +1334,7 @@ func (x *DeleteEdgeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEdgeResponse.ProtoReflect.Descriptor instead.
 func (*DeleteEdgeResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{16}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *DeleteEdgeResponse) GetExisted() bool {
@@ -1151,7 +1355,7 @@ type EdgeKey struct {
 
 func (x *EdgeKey) Reset() {
 	*x = EdgeKey{}
-	mi := &file_graph_v1_graph_proto_msgTypes[17]
+	mi := &file_graph_v1_graph_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1163,7 +1367,7 @@ func (x *EdgeKey) String() string {
 func (*EdgeKey) ProtoMessage() {}
 
 func (x *EdgeKey) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[17]
+	mi := &file_graph_v1_graph_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1176,7 +1380,7 @@ func (x *EdgeKey) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EdgeKey.ProtoReflect.Descriptor instead.
 func (*EdgeKey) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{17}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *EdgeKey) GetTail() string {
@@ -1204,7 +1408,7 @@ type DeleteEdgesRequest struct {
 
 func (x *DeleteEdgesRequest) Reset() {
 	*x = DeleteEdgesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[18]
+	mi := &file_graph_v1_graph_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1216,7 +1420,7 @@ func (x *DeleteEdgesRequest) String() string {
 func (*DeleteEdgesRequest) ProtoMessage() {}
 
 func (x *DeleteEdgesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[18]
+	mi := &file_graph_v1_graph_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1229,7 +1433,7 @@ func (x *DeleteEdgesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEdgesRequest.ProtoReflect.Descriptor instead.
 func (*DeleteEdgesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{18}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *DeleteEdgesRequest) GetEdges() []*EdgeKey {
@@ -1249,7 +1453,7 @@ type DeleteEdgesResponse struct {
 
 func (x *DeleteEdgesResponse) Reset() {
 	*x = DeleteEdgesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[19]
+	mi := &file_graph_v1_graph_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1261,7 +1465,7 @@ func (x *DeleteEdgesResponse) String() string {
 func (*DeleteEdgesResponse) ProtoMessage() {}
 
 func (x *DeleteEdgesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[19]
+	mi := &file_graph_v1_graph_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1274,7 +1478,7 @@ func (x *DeleteEdgesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEdgesResponse.ProtoReflect.Descriptor instead.
 func (*DeleteEdgesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{19}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *DeleteEdgesResponse) GetDeleted() int32 {
@@ -1296,7 +1500,7 @@ type AddEdgeRequest struct {
 
 func (x *AddEdgeRequest) Reset() {
 	*x = AddEdgeRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[20]
+	mi := &file_graph_v1_graph_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1308,7 +1512,7 @@ func (x *AddEdgeRequest) String() string {
 func (*AddEdgeRequest) ProtoMessage() {}
 
 func (x *AddEdgeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[20]
+	mi := &file_graph_v1_graph_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1321,7 +1525,7 @@ func (x *AddEdgeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddEdgeRequest.ProtoReflect.Descriptor instead.
 func (*AddEdgeRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{20}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *AddEdgeRequest) GetEdges() []*Edge {
@@ -1341,7 +1545,7 @@ type AddEdgeResponse struct {
 
 func (x *AddEdgeResponse) Reset() {
 	*x = AddEdgeResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[21]
+	mi := &file_graph_v1_graph_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1353,7 +1557,7 @@ func (x *AddEdgeResponse) String() string {
 func (*AddEdgeResponse) ProtoMessage() {}
 
 func (x *AddEdgeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[21]
+	mi := &file_graph_v1_graph_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1366,7 +1570,7 @@ func (x *AddEdgeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddEdgeResponse.ProtoReflect.Descriptor instead.
 func (*AddEdgeResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{21}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *AddEdgeResponse) GetWritten() int32 {
@@ -1387,7 +1591,7 @@ type PutEdgeRequest struct {
 
 func (x *PutEdgeRequest) Reset() {
 	*x = PutEdgeRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[22]
+	mi := &file_graph_v1_graph_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1399,7 +1603,7 @@ func (x *PutEdgeRequest) String() string {
 func (*PutEdgeRequest) ProtoMessage() {}
 
 func (x *PutEdgeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[22]
+	mi := &file_graph_v1_graph_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1412,7 +1616,7 @@ func (x *PutEdgeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutEdgeRequest.ProtoReflect.Descriptor instead.
 func (*PutEdgeRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{22}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *PutEdgeRequest) GetEdges() []*Edge {
@@ -1432,7 +1636,7 @@ type PutEdgeResponse struct {
 
 func (x *PutEdgeResponse) Reset() {
 	*x = PutEdgeResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[23]
+	mi := &file_graph_v1_graph_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1444,7 +1648,7 @@ func (x *PutEdgeResponse) String() string {
 func (*PutEdgeResponse) ProtoMessage() {}
 
 func (x *PutEdgeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[23]
+	mi := &file_graph_v1_graph_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1457,7 +1661,7 @@ func (x *PutEdgeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutEdgeResponse.ProtoReflect.Descriptor instead.
 func (*PutEdgeResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{23}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *PutEdgeResponse) GetWritten() int32 {
@@ -1512,7 +1716,12 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\x10GetVertexRequest\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\"=\n" +
 	"\x11GetVertexResponse\x12(\n" +
-	"\x06vertex\x18\x01 \x01(\v2\x10.graph.v1.VertexR\x06vertex\"@\n" +
+	"\x06vertex\x18\x01 \x01(\v2\x10.graph.v1.VertexR\x06vertex\"(\n" +
+	"\x12GetVerticesRequest\x12\x12\n" +
+	"\x04keys\x18\x01 \x03(\tR\x04keys\"]\n" +
+	"\x13GetVerticesResponse\x12,\n" +
+	"\bvertices\x18\x01 \x03(\v2\x10.graph.v1.VertexR\bvertices\x12\x18\n" +
+	"\amissing\x18\x02 \x03(\tR\amissing\"@\n" +
 	"\x10PutVertexRequest\x12,\n" +
 	"\bvertices\x18\x01 \x03(\v2\x10.graph.v1.VertexR\bvertices\"-\n" +
 	"\x11PutVertexResponse\x12\x18\n" +
@@ -1529,7 +1738,12 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\x04tail\x18\x01 \x01(\tR\x04tail\x12\x12\n" +
 	"\x04head\x18\x02 \x01(\tR\x04head\"5\n" +
 	"\x0fGetEdgeResponse\x12\"\n" +
-	"\x04edge\x18\x01 \x01(\v2\x0e.graph.v1.EdgeR\x04edge\";\n" +
+	"\x04edge\x18\x01 \x01(\v2\x0e.graph.v1.EdgeR\x04edge\":\n" +
+	"\x0fGetEdgesRequest\x12'\n" +
+	"\x05edges\x18\x01 \x03(\v2\x11.graph.v1.EdgeKeyR\x05edges\"e\n" +
+	"\x10GetEdgesResponse\x12$\n" +
+	"\x05edges\x18\x01 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\x12+\n" +
+	"\amissing\x18\x02 \x03(\v2\x11.graph.v1.EdgeKeyR\amissing\";\n" +
 	"\x11DeleteEdgeRequest\x12\x12\n" +
 	"\x04tail\x18\x01 \x01(\tR\x04tail\x12\x12\n" +
 	"\x04head\x18\x02 \x01(\tR\x04head\".\n" +
@@ -1555,15 +1769,17 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\"OPTIMIZATION_MINIMUM_SPANNING_TREE\x10\x01\x12&\n" +
 	"\"OPTIMIZATION_MAXIMUM_SPANNING_TREE\x10\x02\x12#\n" +
 	"\x1fOPTIMIZATION_SHORTEST_PATH_TREE\x10\x03\x12+\n" +
-	"'OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE\x10\x042\x81\b\n" +
+	"'OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE\x10\x042\xc7\t\n" +
 	"\x0eLanternService\x12f\n" +
 	"\n" +
 	"Illuminate\x12\x1b.graph.v1.IlluminateRequest\x1a\x1c.graph.v1.IlluminateResponse\"\x1d\x82\xd3\xe4\x93\x02\x17\x12\x15/v1/illuminate/{seed}\x12`\n" +
-	"\tGetVertex\x12\x1a.graph.v1.GetVertexRequest\x1a\x1b.graph.v1.GetVertexResponse\"\x1a\x82\xd3\xe4\x93\x02\x14\x12\x12/v1/vertices/{key}\x12]\n" +
+	"\tGetVertex\x12\x1a.graph.v1.GetVertexRequest\x1a\x1b.graph.v1.GetVertexResponse\"\x1a\x82\xd3\xe4\x93\x02\x14\x12\x12/v1/vertices/{key}\x12g\n" +
+	"\vGetVertices\x12\x1c.graph.v1.GetVerticesRequest\x1a\x1d.graph.v1.GetVerticesResponse\"\x1b\x82\xd3\xe4\x93\x02\x15:\x01*\"\x10/v1/vertices/get\x12]\n" +
 	"\tPutVertex\x12\x1a.graph.v1.PutVertexRequest\x1a\x1b.graph.v1.PutVertexResponse\"\x17\x82\xd3\xe4\x93\x02\x11:\x01*\x1a\f/v1/vertices\x12i\n" +
 	"\fDeleteVertex\x12\x1d.graph.v1.DeleteVertexRequest\x1a\x1e.graph.v1.DeleteVertexResponse\"\x1a\x82\xd3\xe4\x93\x02\x14*\x12/v1/vertices/{key}\x12s\n" +
 	"\x0eDeleteVertices\x12\x1f.graph.v1.DeleteVerticesRequest\x1a .graph.v1.DeleteVerticesResponse\"\x1e\x82\xd3\xe4\x93\x02\x18:\x01*\"\x13/v1/vertices/delete\x12_\n" +
-	"\aGetEdge\x12\x18.graph.v1.GetEdgeRequest\x1a\x19.graph.v1.GetEdgeResponse\"\x1f\x82\xd3\xe4\x93\x02\x19\x12\x17/v1/edges/{tail}/{head}\x12X\n" +
+	"\aGetEdge\x12\x18.graph.v1.GetEdgeRequest\x1a\x19.graph.v1.GetEdgeResponse\"\x1f\x82\xd3\xe4\x93\x02\x19\x12\x17/v1/edges/{tail}/{head}\x12[\n" +
+	"\bGetEdges\x12\x19.graph.v1.GetEdgesRequest\x1a\x1a.graph.v1.GetEdgesResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\"\r/v1/edges/get\x12X\n" +
 	"\aAddEdge\x12\x18.graph.v1.AddEdgeRequest\x1a\x19.graph.v1.AddEdgeResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\"\r/v1/edges/add\x12X\n" +
 	"\aPutEdge\x12\x18.graph.v1.PutEdgeRequest\x1a\x19.graph.v1.PutEdgeResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\x1a\r/v1/edges/put\x12h\n" +
 	"\n" +
@@ -1585,7 +1801,7 @@ func file_graph_v1_graph_proto_rawDescGZIP() []byte {
 }
 
 var file_graph_v1_graph_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_graph_v1_graph_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_graph_v1_graph_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
 var file_graph_v1_graph_proto_goTypes = []any{
 	(Optimization)(0),              // 0: graph.v1.Optimization
 	(*Vertex)(nil),                 // 1: graph.v1.Vertex
@@ -1595,66 +1811,78 @@ var file_graph_v1_graph_proto_goTypes = []any{
 	(*IlluminateResponse)(nil),     // 5: graph.v1.IlluminateResponse
 	(*GetVertexRequest)(nil),       // 6: graph.v1.GetVertexRequest
 	(*GetVertexResponse)(nil),      // 7: graph.v1.GetVertexResponse
-	(*PutVertexRequest)(nil),       // 8: graph.v1.PutVertexRequest
-	(*PutVertexResponse)(nil),      // 9: graph.v1.PutVertexResponse
-	(*DeleteVertexRequest)(nil),    // 10: graph.v1.DeleteVertexRequest
-	(*DeleteVertexResponse)(nil),   // 11: graph.v1.DeleteVertexResponse
-	(*DeleteVerticesRequest)(nil),  // 12: graph.v1.DeleteVerticesRequest
-	(*DeleteVerticesResponse)(nil), // 13: graph.v1.DeleteVerticesResponse
-	(*GetEdgeRequest)(nil),         // 14: graph.v1.GetEdgeRequest
-	(*GetEdgeResponse)(nil),        // 15: graph.v1.GetEdgeResponse
-	(*DeleteEdgeRequest)(nil),      // 16: graph.v1.DeleteEdgeRequest
-	(*DeleteEdgeResponse)(nil),     // 17: graph.v1.DeleteEdgeResponse
-	(*EdgeKey)(nil),                // 18: graph.v1.EdgeKey
-	(*DeleteEdgesRequest)(nil),     // 19: graph.v1.DeleteEdgesRequest
-	(*DeleteEdgesResponse)(nil),    // 20: graph.v1.DeleteEdgesResponse
-	(*AddEdgeRequest)(nil),         // 21: graph.v1.AddEdgeRequest
-	(*AddEdgeResponse)(nil),        // 22: graph.v1.AddEdgeResponse
-	(*PutEdgeRequest)(nil),         // 23: graph.v1.PutEdgeRequest
-	(*PutEdgeResponse)(nil),        // 24: graph.v1.PutEdgeResponse
-	(*timestamppb.Timestamp)(nil),  // 25: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),    // 26: google.protobuf.Duration
+	(*GetVerticesRequest)(nil),     // 8: graph.v1.GetVerticesRequest
+	(*GetVerticesResponse)(nil),    // 9: graph.v1.GetVerticesResponse
+	(*PutVertexRequest)(nil),       // 10: graph.v1.PutVertexRequest
+	(*PutVertexResponse)(nil),      // 11: graph.v1.PutVertexResponse
+	(*DeleteVertexRequest)(nil),    // 12: graph.v1.DeleteVertexRequest
+	(*DeleteVertexResponse)(nil),   // 13: graph.v1.DeleteVertexResponse
+	(*DeleteVerticesRequest)(nil),  // 14: graph.v1.DeleteVerticesRequest
+	(*DeleteVerticesResponse)(nil), // 15: graph.v1.DeleteVerticesResponse
+	(*GetEdgeRequest)(nil),         // 16: graph.v1.GetEdgeRequest
+	(*GetEdgeResponse)(nil),        // 17: graph.v1.GetEdgeResponse
+	(*GetEdgesRequest)(nil),        // 18: graph.v1.GetEdgesRequest
+	(*GetEdgesResponse)(nil),       // 19: graph.v1.GetEdgesResponse
+	(*DeleteEdgeRequest)(nil),      // 20: graph.v1.DeleteEdgeRequest
+	(*DeleteEdgeResponse)(nil),     // 21: graph.v1.DeleteEdgeResponse
+	(*EdgeKey)(nil),                // 22: graph.v1.EdgeKey
+	(*DeleteEdgesRequest)(nil),     // 23: graph.v1.DeleteEdgesRequest
+	(*DeleteEdgesResponse)(nil),    // 24: graph.v1.DeleteEdgesResponse
+	(*AddEdgeRequest)(nil),         // 25: graph.v1.AddEdgeRequest
+	(*AddEdgeResponse)(nil),        // 26: graph.v1.AddEdgeResponse
+	(*PutEdgeRequest)(nil),         // 27: graph.v1.PutEdgeRequest
+	(*PutEdgeResponse)(nil),        // 28: graph.v1.PutEdgeResponse
+	(*timestamppb.Timestamp)(nil),  // 29: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),    // 30: google.protobuf.Duration
 }
 var file_graph_v1_graph_proto_depIdxs = []int32{
-	25, // 0: graph.v1.Vertex.expiration:type_name -> google.protobuf.Timestamp
-	25, // 1: graph.v1.Vertex.timestamp:type_name -> google.protobuf.Timestamp
-	26, // 2: graph.v1.Vertex.duration:type_name -> google.protobuf.Duration
-	25, // 3: graph.v1.Edge.expiration:type_name -> google.protobuf.Timestamp
+	29, // 0: graph.v1.Vertex.expiration:type_name -> google.protobuf.Timestamp
+	29, // 1: graph.v1.Vertex.timestamp:type_name -> google.protobuf.Timestamp
+	30, // 2: graph.v1.Vertex.duration:type_name -> google.protobuf.Duration
+	29, // 3: graph.v1.Edge.expiration:type_name -> google.protobuf.Timestamp
 	1,  // 4: graph.v1.Graph.vertices:type_name -> graph.v1.Vertex
 	2,  // 5: graph.v1.Graph.edges:type_name -> graph.v1.Edge
 	0,  // 6: graph.v1.IlluminateRequest.optimization:type_name -> graph.v1.Optimization
 	3,  // 7: graph.v1.IlluminateResponse.graph:type_name -> graph.v1.Graph
 	1,  // 8: graph.v1.GetVertexResponse.vertex:type_name -> graph.v1.Vertex
-	1,  // 9: graph.v1.PutVertexRequest.vertices:type_name -> graph.v1.Vertex
-	2,  // 10: graph.v1.GetEdgeResponse.edge:type_name -> graph.v1.Edge
-	18, // 11: graph.v1.DeleteEdgesRequest.edges:type_name -> graph.v1.EdgeKey
-	2,  // 12: graph.v1.AddEdgeRequest.edges:type_name -> graph.v1.Edge
-	2,  // 13: graph.v1.PutEdgeRequest.edges:type_name -> graph.v1.Edge
-	4,  // 14: graph.v1.LanternService.Illuminate:input_type -> graph.v1.IlluminateRequest
-	6,  // 15: graph.v1.LanternService.GetVertex:input_type -> graph.v1.GetVertexRequest
-	8,  // 16: graph.v1.LanternService.PutVertex:input_type -> graph.v1.PutVertexRequest
-	10, // 17: graph.v1.LanternService.DeleteVertex:input_type -> graph.v1.DeleteVertexRequest
-	12, // 18: graph.v1.LanternService.DeleteVertices:input_type -> graph.v1.DeleteVerticesRequest
-	14, // 19: graph.v1.LanternService.GetEdge:input_type -> graph.v1.GetEdgeRequest
-	21, // 20: graph.v1.LanternService.AddEdge:input_type -> graph.v1.AddEdgeRequest
-	23, // 21: graph.v1.LanternService.PutEdge:input_type -> graph.v1.PutEdgeRequest
-	16, // 22: graph.v1.LanternService.DeleteEdge:input_type -> graph.v1.DeleteEdgeRequest
-	19, // 23: graph.v1.LanternService.DeleteEdges:input_type -> graph.v1.DeleteEdgesRequest
-	5,  // 24: graph.v1.LanternService.Illuminate:output_type -> graph.v1.IlluminateResponse
-	7,  // 25: graph.v1.LanternService.GetVertex:output_type -> graph.v1.GetVertexResponse
-	9,  // 26: graph.v1.LanternService.PutVertex:output_type -> graph.v1.PutVertexResponse
-	11, // 27: graph.v1.LanternService.DeleteVertex:output_type -> graph.v1.DeleteVertexResponse
-	13, // 28: graph.v1.LanternService.DeleteVertices:output_type -> graph.v1.DeleteVerticesResponse
-	15, // 29: graph.v1.LanternService.GetEdge:output_type -> graph.v1.GetEdgeResponse
-	22, // 30: graph.v1.LanternService.AddEdge:output_type -> graph.v1.AddEdgeResponse
-	24, // 31: graph.v1.LanternService.PutEdge:output_type -> graph.v1.PutEdgeResponse
-	17, // 32: graph.v1.LanternService.DeleteEdge:output_type -> graph.v1.DeleteEdgeResponse
-	20, // 33: graph.v1.LanternService.DeleteEdges:output_type -> graph.v1.DeleteEdgesResponse
-	24, // [24:34] is the sub-list for method output_type
-	14, // [14:24] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	1,  // 9: graph.v1.GetVerticesResponse.vertices:type_name -> graph.v1.Vertex
+	1,  // 10: graph.v1.PutVertexRequest.vertices:type_name -> graph.v1.Vertex
+	2,  // 11: graph.v1.GetEdgeResponse.edge:type_name -> graph.v1.Edge
+	22, // 12: graph.v1.GetEdgesRequest.edges:type_name -> graph.v1.EdgeKey
+	2,  // 13: graph.v1.GetEdgesResponse.edges:type_name -> graph.v1.Edge
+	22, // 14: graph.v1.GetEdgesResponse.missing:type_name -> graph.v1.EdgeKey
+	22, // 15: graph.v1.DeleteEdgesRequest.edges:type_name -> graph.v1.EdgeKey
+	2,  // 16: graph.v1.AddEdgeRequest.edges:type_name -> graph.v1.Edge
+	2,  // 17: graph.v1.PutEdgeRequest.edges:type_name -> graph.v1.Edge
+	4,  // 18: graph.v1.LanternService.Illuminate:input_type -> graph.v1.IlluminateRequest
+	6,  // 19: graph.v1.LanternService.GetVertex:input_type -> graph.v1.GetVertexRequest
+	8,  // 20: graph.v1.LanternService.GetVertices:input_type -> graph.v1.GetVerticesRequest
+	10, // 21: graph.v1.LanternService.PutVertex:input_type -> graph.v1.PutVertexRequest
+	12, // 22: graph.v1.LanternService.DeleteVertex:input_type -> graph.v1.DeleteVertexRequest
+	14, // 23: graph.v1.LanternService.DeleteVertices:input_type -> graph.v1.DeleteVerticesRequest
+	16, // 24: graph.v1.LanternService.GetEdge:input_type -> graph.v1.GetEdgeRequest
+	18, // 25: graph.v1.LanternService.GetEdges:input_type -> graph.v1.GetEdgesRequest
+	25, // 26: graph.v1.LanternService.AddEdge:input_type -> graph.v1.AddEdgeRequest
+	27, // 27: graph.v1.LanternService.PutEdge:input_type -> graph.v1.PutEdgeRequest
+	20, // 28: graph.v1.LanternService.DeleteEdge:input_type -> graph.v1.DeleteEdgeRequest
+	23, // 29: graph.v1.LanternService.DeleteEdges:input_type -> graph.v1.DeleteEdgesRequest
+	5,  // 30: graph.v1.LanternService.Illuminate:output_type -> graph.v1.IlluminateResponse
+	7,  // 31: graph.v1.LanternService.GetVertex:output_type -> graph.v1.GetVertexResponse
+	9,  // 32: graph.v1.LanternService.GetVertices:output_type -> graph.v1.GetVerticesResponse
+	11, // 33: graph.v1.LanternService.PutVertex:output_type -> graph.v1.PutVertexResponse
+	13, // 34: graph.v1.LanternService.DeleteVertex:output_type -> graph.v1.DeleteVertexResponse
+	15, // 35: graph.v1.LanternService.DeleteVertices:output_type -> graph.v1.DeleteVerticesResponse
+	17, // 36: graph.v1.LanternService.GetEdge:output_type -> graph.v1.GetEdgeResponse
+	19, // 37: graph.v1.LanternService.GetEdges:output_type -> graph.v1.GetEdgesResponse
+	26, // 38: graph.v1.LanternService.AddEdge:output_type -> graph.v1.AddEdgeResponse
+	28, // 39: graph.v1.LanternService.PutEdge:output_type -> graph.v1.PutEdgeResponse
+	21, // 40: graph.v1.LanternService.DeleteEdge:output_type -> graph.v1.DeleteEdgeResponse
+	24, // 41: graph.v1.LanternService.DeleteEdges:output_type -> graph.v1.DeleteEdgesResponse
+	30, // [30:42] is the sub-list for method output_type
+	18, // [18:30] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_graph_v1_graph_proto_init() }
@@ -1682,7 +1910,7 @@ func file_graph_v1_graph_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_graph_v1_graph_proto_rawDesc), len(file_graph_v1_graph_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   24,
+			NumMessages:   28,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sdks/go/gen/graph/v1/graph.pb.gw.go
+++ b/sdks/go/gen/graph/v1/graph.pb.gw.go
@@ -127,6 +127,33 @@ func local_request_LanternService_GetVertex_0(ctx context.Context, marshaler run
 	return msg, metadata, err
 }
 
+func request_LanternService_GetVertices_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetVerticesRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.GetVertices(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_LanternService_GetVertices_0(ctx context.Context, marshaler runtime.Marshaler, server LanternServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetVerticesRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.GetVertices(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_LanternService_PutVertex_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq PutVertexRequest
@@ -272,6 +299,33 @@ func local_request_LanternService_GetEdge_0(ctx context.Context, marshaler runti
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "head", err)
 	}
 	msg, err := server.GetEdge(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_LanternService_GetEdges_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetEdgesRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.GetEdges(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_LanternService_GetEdges_0(ctx context.Context, marshaler runtime.Marshaler, server LanternServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetEdgesRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.GetEdges(ctx, &protoReq)
 	return msg, metadata, err
 }
 
@@ -457,6 +511,26 @@ func RegisterLanternServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 		}
 		forward_LanternService_GetVertex_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_LanternService_GetVertices_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/graph.v1.LanternService/GetVertices", runtime.WithHTTPPathPattern("/v1/vertices/get"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_LanternService_GetVertices_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LanternService_GetVertices_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPut, pattern_LanternService_PutVertex_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -536,6 +610,26 @@ func RegisterLanternServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 			return
 		}
 		forward_LanternService_GetEdge_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_LanternService_GetEdges_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/graph.v1.LanternService/GetEdges", runtime.WithHTTPPathPattern("/v1/edges/get"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_LanternService_GetEdges_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LanternService_GetEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodPost, pattern_LanternService_AddEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -691,6 +785,23 @@ func RegisterLanternServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 		}
 		forward_LanternService_GetVertex_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_LanternService_GetVertices_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/graph.v1.LanternService/GetVertices", runtime.WithHTTPPathPattern("/v1/vertices/get"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_LanternService_GetVertices_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LanternService_GetVertices_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPut, pattern_LanternService_PutVertex_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -758,6 +869,23 @@ func RegisterLanternServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 			return
 		}
 		forward_LanternService_GetEdge_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_LanternService_GetEdges_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/graph.v1.LanternService/GetEdges", runtime.WithHTTPPathPattern("/v1/edges/get"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_LanternService_GetEdges_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LanternService_GetEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodPost, pattern_LanternService_AddEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -833,10 +961,12 @@ func RegisterLanternServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 var (
 	pattern_LanternService_Illuminate_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "illuminate", "seed"}, ""))
 	pattern_LanternService_GetVertex_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "vertices", "key"}, ""))
+	pattern_LanternService_GetVertices_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "vertices", "get"}, ""))
 	pattern_LanternService_PutVertex_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "vertices"}, ""))
 	pattern_LanternService_DeleteVertex_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "vertices", "key"}, ""))
 	pattern_LanternService_DeleteVertices_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "vertices", "delete"}, ""))
 	pattern_LanternService_GetEdge_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "edges", "tail", "head"}, ""))
+	pattern_LanternService_GetEdges_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "get"}, ""))
 	pattern_LanternService_AddEdge_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "add"}, ""))
 	pattern_LanternService_PutEdge_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "put"}, ""))
 	pattern_LanternService_DeleteEdge_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "edges", "tail", "head"}, ""))
@@ -846,10 +976,12 @@ var (
 var (
 	forward_LanternService_Illuminate_0     = runtime.ForwardResponseMessage
 	forward_LanternService_GetVertex_0      = runtime.ForwardResponseMessage
+	forward_LanternService_GetVertices_0    = runtime.ForwardResponseMessage
 	forward_LanternService_PutVertex_0      = runtime.ForwardResponseMessage
 	forward_LanternService_DeleteVertex_0   = runtime.ForwardResponseMessage
 	forward_LanternService_DeleteVertices_0 = runtime.ForwardResponseMessage
 	forward_LanternService_GetEdge_0        = runtime.ForwardResponseMessage
+	forward_LanternService_GetEdges_0       = runtime.ForwardResponseMessage
 	forward_LanternService_AddEdge_0        = runtime.ForwardResponseMessage
 	forward_LanternService_PutEdge_0        = runtime.ForwardResponseMessage
 	forward_LanternService_DeleteEdge_0     = runtime.ForwardResponseMessage

--- a/sdks/go/gen/graph/v1/graph_grpc.pb.go
+++ b/sdks/go/gen/graph/v1/graph_grpc.pb.go
@@ -21,10 +21,12 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	LanternService_Illuminate_FullMethodName     = "/graph.v1.LanternService/Illuminate"
 	LanternService_GetVertex_FullMethodName      = "/graph.v1.LanternService/GetVertex"
+	LanternService_GetVertices_FullMethodName    = "/graph.v1.LanternService/GetVertices"
 	LanternService_PutVertex_FullMethodName      = "/graph.v1.LanternService/PutVertex"
 	LanternService_DeleteVertex_FullMethodName   = "/graph.v1.LanternService/DeleteVertex"
 	LanternService_DeleteVertices_FullMethodName = "/graph.v1.LanternService/DeleteVertices"
 	LanternService_GetEdge_FullMethodName        = "/graph.v1.LanternService/GetEdge"
+	LanternService_GetEdges_FullMethodName       = "/graph.v1.LanternService/GetEdges"
 	LanternService_AddEdge_FullMethodName        = "/graph.v1.LanternService/AddEdge"
 	LanternService_PutEdge_FullMethodName        = "/graph.v1.LanternService/PutEdge"
 	LanternService_DeleteEdge_FullMethodName     = "/graph.v1.LanternService/DeleteEdge"
@@ -37,11 +39,15 @@ const (
 type LanternServiceClient interface {
 	Illuminate(ctx context.Context, in *IlluminateRequest, opts ...grpc.CallOption) (*IlluminateResponse, error)
 	GetVertex(ctx context.Context, in *GetVertexRequest, opts ...grpc.CallOption) (*GetVertexResponse, error)
+	// GetVertices reads several vertices in one round trip.
+	GetVertices(ctx context.Context, in *GetVerticesRequest, opts ...grpc.CallOption) (*GetVerticesResponse, error)
 	PutVertex(ctx context.Context, in *PutVertexRequest, opts ...grpc.CallOption) (*PutVertexResponse, error)
 	DeleteVertex(ctx context.Context, in *DeleteVertexRequest, opts ...grpc.CallOption) (*DeleteVertexResponse, error)
 	// DeleteVertices removes several vertices in one round trip.
 	DeleteVertices(ctx context.Context, in *DeleteVerticesRequest, opts ...grpc.CallOption) (*DeleteVerticesResponse, error)
 	GetEdge(ctx context.Context, in *GetEdgeRequest, opts ...grpc.CallOption) (*GetEdgeResponse, error)
+	// GetEdges reads several edges in one round trip.
+	GetEdges(ctx context.Context, in *GetEdgesRequest, opts ...grpc.CallOption) (*GetEdgesResponse, error)
 	// AddEdge is non-idempotent (accumulates weight). POST per REST conventions.
 	AddEdge(ctx context.Context, in *AddEdgeRequest, opts ...grpc.CallOption) (*AddEdgeResponse, error)
 	// PutEdge is idempotent (replaces weight). PUT per REST conventions.
@@ -73,6 +79,16 @@ func (c *lanternServiceClient) GetVertex(ctx context.Context, in *GetVertexReque
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetVertexResponse)
 	err := c.cc.Invoke(ctx, LanternService_GetVertex_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *lanternServiceClient) GetVertices(ctx context.Context, in *GetVerticesRequest, opts ...grpc.CallOption) (*GetVerticesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetVerticesResponse)
+	err := c.cc.Invoke(ctx, LanternService_GetVertices_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -113,6 +129,16 @@ func (c *lanternServiceClient) GetEdge(ctx context.Context, in *GetEdgeRequest, 
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetEdgeResponse)
 	err := c.cc.Invoke(ctx, LanternService_GetEdge_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *lanternServiceClient) GetEdges(ctx context.Context, in *GetEdgesRequest, opts ...grpc.CallOption) (*GetEdgesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetEdgesResponse)
+	err := c.cc.Invoke(ctx, LanternService_GetEdges_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -165,11 +191,15 @@ func (c *lanternServiceClient) DeleteEdges(ctx context.Context, in *DeleteEdgesR
 type LanternServiceServer interface {
 	Illuminate(context.Context, *IlluminateRequest) (*IlluminateResponse, error)
 	GetVertex(context.Context, *GetVertexRequest) (*GetVertexResponse, error)
+	// GetVertices reads several vertices in one round trip.
+	GetVertices(context.Context, *GetVerticesRequest) (*GetVerticesResponse, error)
 	PutVertex(context.Context, *PutVertexRequest) (*PutVertexResponse, error)
 	DeleteVertex(context.Context, *DeleteVertexRequest) (*DeleteVertexResponse, error)
 	// DeleteVertices removes several vertices in one round trip.
 	DeleteVertices(context.Context, *DeleteVerticesRequest) (*DeleteVerticesResponse, error)
 	GetEdge(context.Context, *GetEdgeRequest) (*GetEdgeResponse, error)
+	// GetEdges reads several edges in one round trip.
+	GetEdges(context.Context, *GetEdgesRequest) (*GetEdgesResponse, error)
 	// AddEdge is non-idempotent (accumulates weight). POST per REST conventions.
 	AddEdge(context.Context, *AddEdgeRequest) (*AddEdgeResponse, error)
 	// PutEdge is idempotent (replaces weight). PUT per REST conventions.
@@ -192,6 +222,9 @@ func (UnimplementedLanternServiceServer) Illuminate(context.Context, *Illuminate
 func (UnimplementedLanternServiceServer) GetVertex(context.Context, *GetVertexRequest) (*GetVertexResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetVertex not implemented")
 }
+func (UnimplementedLanternServiceServer) GetVertices(context.Context, *GetVerticesRequest) (*GetVerticesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetVertices not implemented")
+}
 func (UnimplementedLanternServiceServer) PutVertex(context.Context, *PutVertexRequest) (*PutVertexResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PutVertex not implemented")
 }
@@ -203,6 +236,9 @@ func (UnimplementedLanternServiceServer) DeleteVertices(context.Context, *Delete
 }
 func (UnimplementedLanternServiceServer) GetEdge(context.Context, *GetEdgeRequest) (*GetEdgeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetEdge not implemented")
+}
+func (UnimplementedLanternServiceServer) GetEdges(context.Context, *GetEdgesRequest) (*GetEdgesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetEdges not implemented")
 }
 func (UnimplementedLanternServiceServer) AddEdge(context.Context, *AddEdgeRequest) (*AddEdgeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AddEdge not implemented")
@@ -268,6 +304,24 @@ func _LanternService_GetVertex_Handler(srv interface{}, ctx context.Context, dec
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(LanternServiceServer).GetVertex(ctx, req.(*GetVertexRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _LanternService_GetVertices_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetVerticesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LanternServiceServer).GetVertices(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: LanternService_GetVertices_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LanternServiceServer).GetVertices(ctx, req.(*GetVerticesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -340,6 +394,24 @@ func _LanternService_GetEdge_Handler(srv interface{}, ctx context.Context, dec f
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(LanternServiceServer).GetEdge(ctx, req.(*GetEdgeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _LanternService_GetEdges_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetEdgesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LanternServiceServer).GetEdges(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: LanternService_GetEdges_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LanternServiceServer).GetEdges(ctx, req.(*GetEdgesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -432,6 +504,10 @@ var LanternService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _LanternService_GetVertex_Handler,
 		},
 		{
+			MethodName: "GetVertices",
+			Handler:    _LanternService_GetVertices_Handler,
+		},
+		{
 			MethodName: "PutVertex",
 			Handler:    _LanternService_PutVertex_Handler,
 		},
@@ -446,6 +522,10 @@ var LanternService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetEdge",
 			Handler:    _LanternService_GetEdge_Handler,
+		},
+		{
+			MethodName: "GetEdges",
+			Handler:    _LanternService_GetEdges_Handler,
 		},
 		{
 			MethodName: "AddEdge",

--- a/sdks/go/gen/openapiv2/graph/v1/graph.swagger.json
+++ b/sdks/go/gen/openapiv2/graph/v1/graph.swagger.json
@@ -84,6 +84,40 @@
         ]
       }
     },
+    "/v1/edges/get": {
+      "post": {
+        "summary": "GetEdges reads several edges in one round trip.",
+        "operationId": "LanternService_GetEdges",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetEdgesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "GetEdgesRequest reads several edges in one round trip. Subject to the\nsame MaxBatchSize / MaxKeyLen guard rails as the write RPCs.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetEdgesRequest"
+            }
+          }
+        ],
+        "tags": [
+          "LanternService"
+        ]
+      }
+    },
     "/v1/edges/put": {
       "put": {
         "summary": "PutEdge is idempotent (replaces weight). PUT per REST conventions.",
@@ -319,6 +353,40 @@
         ]
       }
     },
+    "/v1/vertices/get": {
+      "post": {
+        "summary": "GetVertices reads several vertices in one round trip.",
+        "operationId": "LanternService_GetVertices",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetVerticesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "GetVerticesRequest reads several vertices in one round trip. Subject to\nthe same MaxBatchSize / MaxKeyLen guard rails as the write RPCs.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetVerticesRequest"
+            }
+          }
+        ],
+        "tags": [
+          "LanternService"
+        ]
+      }
+    },
     "/v1/vertices/{key}": {
       "get": {
         "operationId": "LanternService_GetVertex",
@@ -532,11 +600,77 @@
         }
       }
     },
+    "v1GetEdgesRequest": {
+      "type": "object",
+      "properties": {
+        "edges": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EdgeKey"
+          }
+        }
+      },
+      "description": "GetEdgesRequest reads several edges in one round trip. Subject to the\nsame MaxBatchSize / MaxKeyLen guard rails as the write RPCs."
+    },
+    "v1GetEdgesResponse": {
+      "type": "object",
+      "properties": {
+        "edges": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Edge"
+          },
+          "description": "edges contains every (tail, head) pair that was present at the time of\nthe call. Order is unspecified; clients should match by (Edge.tail,\nEdge.head)."
+        },
+        "missing": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EdgeKey"
+          },
+          "description": "missing lists the requested (tail, head) pairs that did not exist (or\nhad expired)."
+        }
+      }
+    },
     "v1GetVertexResponse": {
       "type": "object",
       "properties": {
         "vertex": {
           "$ref": "#/definitions/v1Vertex"
+        }
+      }
+    },
+    "v1GetVerticesRequest": {
+      "type": "object",
+      "properties": {
+        "keys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "GetVerticesRequest reads several vertices in one round trip. Subject to\nthe same MaxBatchSize / MaxKeyLen guard rails as the write RPCs."
+    },
+    "v1GetVerticesResponse": {
+      "type": "object",
+      "properties": {
+        "vertices": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Vertex"
+          },
+          "description": "vertices contains every key that was present at the time of the call.\nOrder is unspecified; clients should match by Vertex.key."
+        },
+        "missing": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "missing lists the requested keys that did not exist (or had expired)."
         }
       }
     },

--- a/server/provider/extra.go
+++ b/server/provider/extra.go
@@ -70,6 +70,15 @@ func (v *ValidationInterceptor) validate(req any) error {
 	switch r := req.(type) {
 	case *pb.GetVertexRequest:
 		return v.checkKey("key", r.GetKey())
+	case *pb.GetVerticesRequest:
+		if err := v.checkBatch(len(r.GetKeys())); err != nil {
+			return err
+		}
+		for i, k := range r.GetKeys() {
+			if err := v.checkKey(fmt.Sprintf("keys[%d]", i), k); err != nil {
+				return err
+			}
+		}
 	case *pb.DeleteVertexRequest:
 		return v.checkKey("key", r.GetKey())
 	case *pb.DeleteVerticesRequest:
@@ -98,6 +107,21 @@ func (v *ValidationInterceptor) validate(req any) error {
 			return err
 		}
 		return v.checkKey("head", r.GetHead())
+	case *pb.GetEdgesRequest:
+		if err := v.checkBatch(len(r.GetEdges())); err != nil {
+			return err
+		}
+		for i, e := range r.GetEdges() {
+			if e == nil {
+				return status.Errorf(codes.InvalidArgument, "edges[%d] is nil", i)
+			}
+			if err := v.checkKey(fmt.Sprintf("edges[%d].tail", i), e.GetTail()); err != nil {
+				return err
+			}
+			if err := v.checkKey(fmt.Sprintf("edges[%d].head", i), e.GetHead()); err != nil {
+				return err
+			}
+		}
 	case *pb.DeleteEdgeRequest:
 		if err := v.checkKey("tail", r.GetTail()); err != nil {
 			return err

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -118,6 +118,33 @@ func (s *LanternService) GetVertex(ctx context.Context, request *pb.GetVertexReq
 	return &pb.GetVertexResponse{Vertex: v}, nil
 }
 
+// GetVertices reads several vertices in one round trip. Keys present at call
+// time are returned in Vertices; missing (or expired) keys are reported in
+// Missing. Order within either slice is not guaranteed to follow request
+// order — clients should match by Vertex.key.
+func (s *LanternService) GetVertices(ctx context.Context, request *pb.GetVerticesRequest) (*pb.GetVerticesResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, status.FromContextError(err).Err()
+	}
+	keys := request.GetKeys()
+	resp := &pb.GetVerticesResponse{
+		Vertices: make([]*pb.Vertex, 0, len(keys)),
+	}
+	for _, k := range keys {
+		v, ok := s.cache.GetVertex(k)
+		if !ok {
+			resp.Missing = append(resp.Missing, k)
+			continue
+		}
+		if v == nil {
+			resp.Vertices = append(resp.Vertices, &pb.Vertex{Key: k, Value: &pb.Vertex_Nil{Nil: true}})
+		} else {
+			resp.Vertices = append(resp.Vertices, v)
+		}
+	}
+	return resp, nil
+}
+
 func (s *LanternService) PutVertex(ctx context.Context, request *pb.PutVertexRequest) (*pb.PutVertexResponse, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
@@ -165,6 +192,32 @@ func (s *LanternService) GetEdge(ctx context.Context, request *pb.GetEdgeRequest
 		edge.Expiration = timestamppb.New(exp)
 	}
 	return &pb.GetEdgeResponse{Edge: edge}, nil
+}
+
+// GetEdges reads several edges in one round trip. Pairs present at call time
+// are returned in Edges; missing (or expired) pairs are reported in Missing.
+// Order within either slice is not guaranteed to follow request order.
+func (s *LanternService) GetEdges(ctx context.Context, request *pb.GetEdgesRequest) (*pb.GetEdgesResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, status.FromContextError(err).Err()
+	}
+	in := request.GetEdges()
+	resp := &pb.GetEdgesResponse{
+		Edges: make([]*pb.Edge, 0, len(in)),
+	}
+	for _, k := range in {
+		w, exp, ok := s.cache.GetEdgeDetail(k.GetTail(), k.GetHead())
+		if !ok {
+			resp.Missing = append(resp.Missing, &pb.EdgeKey{Tail: k.GetTail(), Head: k.GetHead()})
+			continue
+		}
+		edge := &pb.Edge{Tail: k.GetTail(), Head: k.GetHead(), Weight: w}
+		if !exp.IsZero() {
+			edge.Expiration = timestamppb.New(exp)
+		}
+		resp.Edges = append(resp.Edges, edge)
+	}
+	return resp, nil
 }
 
 func (s *LanternService) AddEdge(ctx context.Context, request *pb.AddEdgeRequest) (*pb.AddEdgeResponse, error) {

--- a/server/service/service_bufconn_test.go
+++ b/server/service/service_bufconn_test.go
@@ -220,3 +220,63 @@ func TestBufconn_DeleteEdges_HappyPath(t *testing.T) {
 		}
 	}
 }
+
+func TestBufconn_GetVertices_PartialMiss(t *testing.T) {
+	c, ctx, cleanup := newBufconnClient(t)
+	defer cleanup()
+
+	vs := []*pb.Vertex{
+		{Key: "a", Value: &pb.Vertex_Int64{Int64: 1}, Expiration: bufconnExp(time.Minute)},
+		{Key: "b", Value: &pb.Vertex_Nil{Nil: true}, Expiration: bufconnExp(time.Minute)},
+	}
+	if _, err := c.PutVertex(ctx, &pb.PutVertexRequest{Vertices: vs}); err != nil {
+		t.Fatalf("PutVertex: %v", err)
+	}
+
+	resp, err := c.GetVertices(ctx, &pb.GetVerticesRequest{Keys: []string{"a", "b", "missing"}})
+	if err != nil {
+		t.Fatalf("GetVertices: %v", err)
+	}
+	if got, want := len(resp.GetVertices()), 2; got != want {
+		t.Fatalf("len(Vertices) = %d, want %d", got, want)
+	}
+	gotKeys := map[string]bool{}
+	for _, v := range resp.GetVertices() {
+		gotKeys[v.GetKey()] = true
+	}
+	if !gotKeys["a"] || !gotKeys["b"] {
+		t.Errorf("Vertices keys = %v, want a+b", gotKeys)
+	}
+	if len(resp.GetMissing()) != 1 || resp.GetMissing()[0] != "missing" {
+		t.Errorf("Missing = %v, want [missing]", resp.GetMissing())
+	}
+}
+
+func TestBufconn_GetEdges_PartialMiss(t *testing.T) {
+	c, ctx, cleanup := newBufconnClient(t)
+	defer cleanup()
+
+	edges := []*pb.Edge{
+		{Tail: "a", Head: "b", Weight: 1.5, Expiration: bufconnExp(time.Minute)},
+		{Tail: "b", Head: "c", Weight: 2, Expiration: bufconnExp(time.Minute)},
+	}
+	if _, err := c.AddEdge(ctx, &pb.AddEdgeRequest{Edges: edges}); err != nil {
+		t.Fatalf("AddEdge: %v", err)
+	}
+
+	resp, err := c.GetEdges(ctx, &pb.GetEdgesRequest{Edges: []*pb.EdgeKey{
+		{Tail: "a", Head: "b"},
+		{Tail: "b", Head: "c"},
+		{Tail: "x", Head: "y"},
+	}})
+	if err != nil {
+		t.Fatalf("GetEdges: %v", err)
+	}
+	if got, want := len(resp.GetEdges()), 2; got != want {
+		t.Fatalf("len(Edges) = %d, want %d", got, want)
+	}
+	if len(resp.GetMissing()) != 1 ||
+		resp.GetMissing()[0].GetTail() != "x" || resp.GetMissing()[0].GetHead() != "y" {
+		t.Errorf("Missing = %v, want [{x y}]", resp.GetMissing())
+	}
+}

--- a/tests/integration/client_test.go
+++ b/tests/integration/client_test.go
@@ -152,3 +152,55 @@ func TestLantern_Illuminate(t *testing.T) {
 		t.Errorf("Illuminate missing edge a->b (got %v)", g.Edges)
 	}
 }
+
+func TestLantern_GetVertices_BatchPartialMiss(t *testing.T) {
+	l, cleanup := newInProcessClient(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := l.PutVertex(ctx, "a", int64(1), time.Minute); err != nil {
+		t.Fatalf("PutVertex a: %v", err)
+	}
+	if err := l.PutVertex(ctx, "b", "two", time.Minute); err != nil {
+		t.Fatalf("PutVertex b: %v", err)
+	}
+
+	found, missing, err := l.GetVertices(ctx, []string{"a", "b", "missing"})
+	if err != nil {
+		t.Fatalf("GetVertices: %v", err)
+	}
+	if len(found) != 2 {
+		t.Fatalf("found = %d, want 2", len(found))
+	}
+	if len(missing) != 1 || missing[0] != "missing" {
+		t.Errorf("missing = %v, want [missing]", missing)
+	}
+}
+
+func TestLantern_GetEdges_BatchPartialMiss(t *testing.T) {
+	l, cleanup := newInProcessClient(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := l.AddEdge(ctx, "a", "b", 1.5, time.Minute); err != nil {
+		t.Fatalf("AddEdge: %v", err)
+	}
+
+	found, missing, err := l.GetEdges(ctx, []client.EdgeRef{
+		{Tail: "a", Head: "b"},
+		{Tail: "x", Head: "y"},
+	})
+	if err != nil {
+		t.Fatalf("GetEdges: %v", err)
+	}
+	if len(found) != 1 || found[0].Tail != "a" || found[0].Head != "b" {
+		t.Fatalf("found = %v, want one a->b", found)
+	}
+	if len(missing) != 1 || missing[0] != (client.EdgeRef{Tail: "x", Head: "y"}) {
+		t.Errorf("missing = %v, want [{x y}]", missing)
+	}
+}


### PR DESCRIPTION
Closes #47.

Adds `GetVertices` / `GetEdges` so callers can resolve many keys in a single round trip.

**Response shape:** `{ found, missing }` — explicit `missing` list lets callers detect absent keys without aligning by index. Nil-valued vertices surface as `Vertex_Nil` to match `GetVertex`.

**Guard rails:** The existing `ValidationInterceptor` (MaxBatchSize / MaxKeyLen) is extended to cover the new request types, so the same limits apply with no per-handler logic.

**SDK:** `GetVertices(keys)` / `GetEdges(refs)` chunk by `batchChunkSize` like the delete-batch APIs and merge per-chunk responses.

**Tests:** bufconn server tests + SDK integration tests cover happy path and partial miss for both RPCs. Full suite green in both modules.