### PR TITLE
feat(#48): default client keepalive + WithKeepaliveParams option

### DIFF
--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -81,12 +81,14 @@ func NewLantern(target string, opts ...Option) (*Lantern, error) {
 	o := options{
 		batchChunkSize:    defaultBatchChunkSize,
 		serviceConfigJSON: defaultServiceConfig,
+		keepalive:         defaultKeepalive,
 	}
 	for _, apply := range opts {
 		apply(&o)
 	}
 
-	dialOpts := make([]grpc.DialOption, 0, len(o.dialOptions)+2)
+	dialOpts := make([]grpc.DialOption, 0, len(o.dialOptions)+3)
+	dialOpts = append(dialOpts, grpc.WithKeepaliveParams(o.keepalive))
 	if o.transportCreds != nil {
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(o.transportCreds))
 	} else {

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -6,6 +6,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	_ "google.golang.org/grpc/encoding/gzip" // register gzip so WithCompression("gzip") works
+	"google.golang.org/grpc/keepalive"
 )
 
 // defaultServiceConfig enables transparent gRPC retries on idempotent RPCs.
@@ -42,6 +43,16 @@ const defaultServiceConfig = `{
 // per-message overhead.
 const defaultBatchChunkSize = 1000
 
+// defaultKeepalive matches the server-side policy (MinTime: 10s,
+// MaxConnectionIdle: 15m). Time: 30s keeps a ping well clear of the server's
+// MinTime so we never trip ENHANCE_YOUR_CALM, and PermitWithoutStream: true
+// keeps long-idle connections alive instead of being silently torn down.
+var defaultKeepalive = keepalive.ClientParameters{
+	Time:                30 * time.Second,
+	Timeout:             10 * time.Second,
+	PermitWithoutStream: true,
+}
+
 // options collects all knobs settable via WithXxx. Zero values keep the
 // previous defaults (insecure transport, no per-call timeout, default
 // chunking).
@@ -51,6 +62,7 @@ type options struct {
 	defaultTimeout    time.Duration
 	batchChunkSize    int
 	serviceConfigJSON string
+	keepalive         keepalive.ClientParameters
 }
 
 // Option configures a Lantern client. Pass options to NewLantern.
@@ -88,6 +100,16 @@ func WithBatchChunkSize(n int) Option {
 		if n > 0 {
 			o.batchChunkSize = n
 		}
+	}
+}
+
+// WithKeepaliveParams overrides the default client-side keepalive policy.
+// The SDK defaults to Time: 30s / Timeout: 10s / PermitWithoutStream: true,
+// chosen to sit safely above the server's 10s MinTime while keeping long-idle
+// connections from being silently reaped.
+func WithKeepaliveParams(kp keepalive.ClientParameters) Option {
+	return func(o *options) {
+		o.keepalive = kp
 	}
 }
 

--- a/sdks/go/options_test.go
+++ b/sdks/go/options_test.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/keepalive"
+)
+
+func TestDefaultKeepaliveAboveServerMinTime(t *testing.T) {
+	// Server enforces MinTime: 10s; SDK default must stay safely above it.
+	if defaultKeepalive.Time < 10*time.Second {
+		t.Errorf("defaultKeepalive.Time = %v, must be >= 10s (server MinTime)", defaultKeepalive.Time)
+	}
+	if !defaultKeepalive.PermitWithoutStream {
+		t.Error("defaultKeepalive.PermitWithoutStream must be true")
+	}
+}
+
+func TestWithKeepaliveParamsOverrides(t *testing.T) {
+	custom := keepalive.ClientParameters{Time: time.Minute, Timeout: 5 * time.Second, PermitWithoutStream: false}
+	var o options
+	WithKeepaliveParams(custom)(&o)
+	if o.keepalive != custom {
+		t.Errorf("keepalive = %+v, want %+v", o.keepalive, custom)
+	}
+}


### PR DESCRIPTION
Closes #48.

Adds a sensible default client-side keepalive (Time: 30s, Timeout: 10s, PermitWithoutStream: true) that sits safely above the server's 10s MinTime, plus a `WithKeepaliveParams` override for callers with stricter NAT/proxy timeouts.

Without this, long-idle clients could be silently torn down or hit ENHANCE_YOUR_CALM under bursty traffic.