### PR TITLE
feat(#49): error sentinels for InvalidArgument and ResourceExhausted

### DIFF
--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -18,6 +18,17 @@ import (
 // (with codes.NotFound) is wrapped for callers that need the full detail.
 var ErrNotFound = errors.New("not found")
 
+// ErrInvalidArgument wraps gRPC codes.InvalidArgument responses from the
+// server (typically raised by the ValidationInterceptor for empty/oversized
+// keys or batch entries above MaxBatchSize). Use errors.Is to branch on
+// caller-fixable input errors vs. transient failures.
+var ErrInvalidArgument = errors.New("invalid argument")
+
+// ErrResourceExhausted wraps gRPC codes.ResourceExhausted responses (rate
+// limiter, server-side back-pressure). Callers that see this should back off
+// before retrying.
+var ErrResourceExhausted = errors.New("resource exhausted")
+
 // Edge is a thin type alias over the generated protobuf Edge that lets the
 // client return the full record (including Expiration) instead of just the
 // weight.
@@ -127,14 +138,21 @@ func (l *Lantern) applyTimeout(ctx context.Context) (context.Context, context.Ca
 	return context.WithTimeout(ctx, l.opts.defaultTimeout)
 }
 
-// wrapNotFound converts a codes.NotFound gRPC error into one that satisfies
-// errors.Is(err, ErrNotFound) while preserving the original detail.
-func wrapNotFound(err error) error {
+// wrapStatus converts a gRPC status error into one that satisfies
+// errors.Is against the matching SDK sentinel (ErrNotFound /
+// ErrInvalidArgument / ErrResourceExhausted) while preserving the original
+// gRPC error for callers that want full status detail.
+func wrapStatus(err error) error {
 	if err == nil {
 		return nil
 	}
-	if status.Code(err) == codes.NotFound {
+	switch status.Code(err) {
+	case codes.NotFound:
 		return errors.Join(ErrNotFound, err)
+	case codes.InvalidArgument:
+		return errors.Join(ErrInvalidArgument, err)
+	case codes.ResourceExhausted:
+		return errors.Join(ErrResourceExhausted, err)
 	}
 	return err
 }
@@ -146,7 +164,7 @@ func (l *Lantern) GetVertex(ctx context.Context, key string) (*Vertex, error) {
 	defer cancel()
 	result, err := l.client.GetVertex(ctx, &pb.GetVertexRequest{Key: key})
 	if err != nil {
-		return nil, wrapNotFound(err)
+		return nil, wrapStatus(err)
 	}
 	return (*Vertex)(result.Vertex), nil
 }
@@ -165,7 +183,7 @@ func (l *Lantern) PutVertexAt(ctx context.Context, key string, value any, expira
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
 	_, err = l.client.PutVertex(ctx, &pb.PutVertexRequest{Vertices: []*pb.Vertex{v}})
-	return err
+	return wrapStatus(err)
 }
 
 // PutVertices upserts a batch of vertices. Large batches are automatically
@@ -187,7 +205,7 @@ func (l *Lantern) PutVertices(ctx context.Context, inputs []VertexInput) error {
 		_, err := l.client.PutVertex(ctx, &pb.PutVertexRequest{Vertices: chunk})
 		cancel()
 		if err != nil {
-			return err
+			return wrapStatus(err)
 		}
 	}
 	return nil
@@ -201,7 +219,7 @@ func (l *Lantern) DeleteVertex(ctx context.Context, key string) (bool, error) {
 	defer cancel()
 	resp, err := l.client.DeleteVertex(ctx, &pb.DeleteVertexRequest{Key: key})
 	if err != nil {
-		return false, err
+		return false, wrapStatus(err)
 	}
 	return resp.GetExisted(), nil
 }
@@ -218,7 +236,7 @@ func (l *Lantern) DeleteVertices(ctx context.Context, keys []string) error {
 		_, err := l.client.DeleteVertices(ctx, &pb.DeleteVerticesRequest{Keys: chunk})
 		cancel()
 		if err != nil {
-			return err
+			return wrapStatus(err)
 		}
 	}
 	return nil
@@ -238,7 +256,7 @@ func (l *Lantern) GetVertices(ctx context.Context, keys []string) (found []*Vert
 		resp, rerr := l.client.GetVertices(cctx, &pb.GetVerticesRequest{Keys: chunk})
 		cancel()
 		if rerr != nil {
-			return nil, nil, rerr
+			return nil, nil, wrapStatus(rerr)
 		}
 		for _, v := range resp.GetVertices() {
 			found = append(found, (*Vertex)(v))
@@ -254,7 +272,7 @@ func (l *Lantern) GetEdge(ctx context.Context, tail string, head string) (*Edge,
 	defer cancel()
 	result, err := l.client.GetEdge(ctx, &pb.GetEdgeRequest{Tail: tail, Head: head})
 	if err != nil {
-		return nil, wrapNotFound(err)
+		return nil, wrapStatus(err)
 	}
 	return (*Edge)(result.Edge), nil
 }
@@ -272,7 +290,7 @@ func (l *Lantern) AddEdgeAt(ctx context.Context, tail string, head string, weigh
 	_, err := l.client.AddEdge(ctx, &pb.AddEdgeRequest{
 		Edges: []*pb.Edge{{Tail: tail, Head: head, Weight: weight, Expiration: timestamppb.New(expiration)}},
 	})
-	return err
+	return wrapStatus(err)
 }
 
 // AddEdges accumulates weight onto a batch of edges. Automatically chunked.
@@ -286,7 +304,7 @@ func (l *Lantern) AddEdges(ctx context.Context, inputs []EdgeInput) error {
 		_, err := l.client.AddEdge(ctx, &pb.AddEdgeRequest{Edges: chunk})
 		cancel()
 		if err != nil {
-			return err
+			return wrapStatus(err)
 		}
 	}
 	return nil
@@ -304,7 +322,7 @@ func (l *Lantern) PutEdgeAt(ctx context.Context, tail string, head string, weigh
 	_, err := l.client.PutEdge(ctx, &pb.PutEdgeRequest{
 		Edges: []*pb.Edge{{Tail: tail, Head: head, Weight: weight, Expiration: timestamppb.New(expiration)}},
 	})
-	return err
+	return wrapStatus(err)
 }
 
 // PutEdges overwrites a batch of edges. Automatically chunked.
@@ -318,7 +336,7 @@ func (l *Lantern) PutEdges(ctx context.Context, inputs []EdgeInput) error {
 		_, err := l.client.PutEdge(ctx, &pb.PutEdgeRequest{Edges: chunk})
 		cancel()
 		if err != nil {
-			return err
+			return wrapStatus(err)
 		}
 	}
 	return nil
@@ -331,7 +349,7 @@ func (l *Lantern) DeleteEdge(ctx context.Context, tail string, head string) (boo
 	defer cancel()
 	resp, err := l.client.DeleteEdge(ctx, &pb.DeleteEdgeRequest{Tail: tail, Head: head})
 	if err != nil {
-		return false, err
+		return false, wrapStatus(err)
 	}
 	return resp.GetExisted(), nil
 }
@@ -357,7 +375,7 @@ func (l *Lantern) DeleteEdges(ctx context.Context, refs []EdgeRef) error {
 		_, err := l.client.DeleteEdges(ctx, &pb.DeleteEdgesRequest{Edges: chunk})
 		cancel()
 		if err != nil {
-			return err
+			return wrapStatus(err)
 		}
 	}
 	return nil
@@ -381,7 +399,7 @@ func (l *Lantern) GetEdges(ctx context.Context, refs []EdgeRef) (found []*Edge, 
 		resp, rerr := l.client.GetEdges(cctx, &pb.GetEdgesRequest{Edges: chunk})
 		cancel()
 		if rerr != nil {
-			return nil, nil, rerr
+			return nil, nil, wrapStatus(rerr)
 		}
 		for _, e := range resp.GetEdges() {
 			found = append(found, (*Edge)(e))
@@ -428,7 +446,7 @@ func (l *Lantern) IlluminateWithOptimization(ctx context.Context, seed string, s
 		Optimization: opt,
 	})
 	if err != nil {
-		return nil, err
+		return nil, wrapStatus(err)
 	}
 	g := NewGraph()
 	for _, v := range result.Graph.Vertices {

--- a/tests/integration/client_test.go
+++ b/tests/integration/client_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 	"time"
@@ -9,6 +10,7 @@ import (
 	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
 	client "github.com/anaregdesign/lantern/sdks/go"
 	pb "github.com/anaregdesign/lantern/sdks/go/gen/graph/v1"
+	"github.com/anaregdesign/lantern/server/provider"
 	"github.com/anaregdesign/lantern/server/service"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -21,7 +23,13 @@ func newInProcessClient(t *testing.T) (*client.Lantern, func()) {
 	t.Helper()
 
 	lis := bufconn.Listen(1 << 16)
-	srv := grpc.NewServer()
+	vi := provider.NewValidationInterceptor(provider.ValidationLimits{
+		MaxKeyLen:         256,
+		MaxBatchSize:      1024,
+		IlluminateMaxStep: 32,
+		IlluminateMaxK:    256,
+	})
+	srv := grpc.NewServer(grpc.UnaryInterceptor(vi.UnaryServerInterceptor()))
 	svc := service.NewLanternService(cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute))
 	pb.RegisterLanternServiceServer(srv, svc)
 
@@ -202,5 +210,29 @@ func TestLantern_GetEdges_BatchPartialMiss(t *testing.T) {
 	}
 	if len(missing) != 1 || missing[0] != (client.EdgeRef{Tail: "x", Head: "y"}) {
 		t.Errorf("missing = %v, want [{x y}]", missing)
+	}
+}
+
+func TestLantern_ErrorSentinels(t *testing.T) {
+	l, cleanup := newInProcessClient(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// NotFound: GetVertex on missing key.
+	if _, err := l.GetVertex(ctx, "absent"); err == nil {
+		t.Fatal("expected error for missing key")
+	} else if !errors.Is(err, client.ErrNotFound) {
+		t.Errorf("want errors.Is(err, ErrNotFound); got %v", err)
+	}
+
+	// InvalidArgument: empty key trips ValidationInterceptor (checkKey).
+	err := l.PutVertex(ctx, "", "v", time.Minute)
+	if err == nil {
+		t.Fatal("expected error for empty key")
+	}
+	if !errors.Is(err, client.ErrInvalidArgument) {
+		t.Errorf("want errors.Is(err, ErrInvalidArgument); got %v", err)
 	}
 }


### PR DESCRIPTION
Closes #49.

Adds `ErrInvalidArgument` and `ErrResourceExhausted` SDK sentinels and routes every RPC call through a unified `wrapStatus` helper (replacing the single-purpose `wrapNotFound`). Callers can now use `errors.Is` to branch on input fixup vs. backoff:

```go
if err := l.PutVertex(ctx, key, val, ttl); err != nil {
    switch {
    case errors.Is(err, client.ErrInvalidArgument):
        // fix the request
    case errors.Is(err, client.ErrResourceExhausted):
        // back off and retry
    }
}
```

Integration test covers both sentinels through a bufconn server with the real `ValidationInterceptor` installed.