### PR TITLE
feat(#52): (*Lantern).Ping health-check helper

### DIFF
--- a/sdks/go/health.go
+++ b/sdks/go/health.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"context"
+
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// Ping issues a gRPC health check against the server's grpc.health.v1 service
+// and returns nil iff the server reports SERVING. Useful as a readiness probe
+// or as a one-liner connectivity test.
+//
+// The default service ("") is queried, which on Lantern's server is wired to
+// the overall server status. Pass a context with a deadline to bound the call.
+func (l *Lantern) Ping(ctx context.Context) error {
+	ctx, cancel := l.applyTimeout(ctx)
+	defer cancel()
+	resp, err := healthpb.NewHealthClient(l.conn).Check(ctx, &healthpb.HealthCheckRequest{})
+	if err != nil {
+		return wrapStatus(err)
+	}
+	if resp.GetStatus() != healthpb.HealthCheckResponse_SERVING {
+		return &healthStatusError{status: resp.GetStatus()}
+	}
+	return nil
+}
+
+type healthStatusError struct {
+	status healthpb.HealthCheckResponse_ServingStatus
+}
+
+func (e *healthStatusError) Error() string {
+	return "lantern: server health status = " + e.status.String()
+}

--- a/tests/integration/health_test.go
+++ b/tests/integration/health_test.go
@@ -1,0 +1,85 @@
+package integration_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	pb "github.com/anaregdesign/lantern/sdks/go/gen/graph/v1"
+	"github.com/anaregdesign/lantern/server/provider"
+	"github.com/anaregdesign/lantern/server/service"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// newInProcessClientWithHealth is like newInProcessClient but additionally
+// registers the grpc.health.v1 service so the SDK's Ping helper can be
+// exercised end-to-end.
+func newInProcessClientWithHealth(t *testing.T, serving bool) (*client.Lantern, func()) {
+	t.Helper()
+
+	lis := bufconn.Listen(1 << 16)
+	srv := grpc.NewServer()
+	svc := service.NewLanternService(cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute))
+	pb.RegisterLanternServiceServer(srv, svc)
+
+	hs := provider.NewHealthServer()
+	provider.RegisterHealth(srv, hs)
+	if serving {
+		hs.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	} else {
+		hs.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
+	}
+
+	go func() {
+		if err := srv.Serve(lis); err != nil {
+			t.Logf("grpc Serve returned: %v", err)
+		}
+	}()
+
+	dialer := func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}
+	l, err := client.NewLantern(
+		"passthrough://bufconn",
+		client.WithTransportCredentials(insecure.NewCredentials()),
+		client.WithDialOption(grpc.WithContextDialer(dialer)),
+	)
+	if err != nil {
+		t.Fatalf("NewLantern: %v", err)
+	}
+
+	cleanup := func() {
+		_ = l.Close()
+		srv.Stop()
+		_ = lis.Close()
+	}
+	return l, cleanup
+}
+
+func TestLantern_Ping_Serving(t *testing.T) {
+	l, cleanup := newInProcessClientWithHealth(t, true)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := l.Ping(ctx); err != nil {
+		t.Fatalf("Ping when SERVING: unexpected error %v", err)
+	}
+}
+
+func TestLantern_Ping_NotServing(t *testing.T) {
+	l, cleanup := newInProcessClientWithHealth(t, false)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := l.Ping(ctx); err == nil {
+		t.Fatal("Ping when NOT_SERVING: expected error, got nil")
+	}
+}


### PR DESCRIPTION
Closes #52.

Server already registers grpc.health.v1; this exposes it as a one-liner SDK method backed by the standard healthpb client, with end-to-end tests for SERVING and NOT_SERVING outcomes.