### PR TITLE
feat(#53): BatchError reports partial-write progress for chunked batch helpers

### DIFF
--- a/sdks/go/batch_error.go
+++ b/sdks/go/batch_error.go
@@ -1,0 +1,33 @@
+package client
+
+import "fmt"
+
+// BatchError reports a partial-write failure from a chunked batch helper
+// (PutVertices, AddEdges, PutEdges, DeleteVertices, DeleteEdges).
+//
+// Lantern's batch helpers split large inputs into chunks (see
+// WithBatchChunkSize) and send them sequentially. If the Nth chunk fails,
+// chunks 0..N-1 have already been committed server-side. BatchError records
+// the number of fully-written input entries in Written so callers can:
+//
+//   - resume by re-sending input[Written:],
+//   - surface the partial progress in logs/metrics,
+//   - branch on errors.Is for the underlying gRPC sentinel
+//     (ErrInvalidArgument / ErrResourceExhausted / ...).
+//
+// BatchError wraps the underlying error, so errors.Is and errors.Unwrap
+// continue to work transparently.
+type BatchError struct {
+	// Written is the number of input entries successfully committed before
+	// the failure. Always 0 <= Written < len(input).
+	Written int
+	// Err is the underlying error returned by the failing chunk RPC, already
+	// passed through wrapStatus so SDK sentinels match via errors.Is.
+	Err error
+}
+
+func (e *BatchError) Error() string {
+	return fmt.Sprintf("lantern: batch partially written (%d entries committed): %v", e.Written, e.Err)
+}
+
+func (e *BatchError) Unwrap() error { return e.Err }

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -188,6 +188,13 @@ func (l *Lantern) PutVertexAt(ctx context.Context, key string, value any, expira
 
 // PutVertices upserts a batch of vertices. Large batches are automatically
 // chunked according to WithBatchChunkSize (default 1000).
+//
+// Partial-write semantics: chunks are sent sequentially. If chunk N fails,
+// the entries from chunks 0..N-1 are already committed server-side. The
+// returned error is a *BatchError whose Written field records the number of
+// successfully committed inputs, so callers can resume with
+// inputs[err.Written:]. errors.Is / errors.As continue to work against the
+// wrapped gRPC sentinel.
 func (l *Lantern) PutVertices(ctx context.Context, inputs []VertexInput) error {
 	if len(inputs) == 0 {
 		return nil
@@ -200,13 +207,15 @@ func (l *Lantern) PutVertices(ctx context.Context, inputs []VertexInput) error {
 		}
 		vs = append(vs, v)
 	}
+	written := 0
 	for _, chunk := range chunkSlice(vs, l.opts.batchChunkSize) {
 		ctx, cancel := l.applyTimeout(ctx)
 		_, err := l.client.PutVertex(ctx, &pb.PutVertexRequest{Vertices: chunk})
 		cancel()
 		if err != nil {
-			return wrapStatus(err)
+			return &BatchError{Written: written, Err: wrapStatus(err)}
 		}
+		written += len(chunk)
 	}
 	return nil
 }
@@ -227,17 +236,23 @@ func (l *Lantern) DeleteVertex(ctx context.Context, key string) (bool, error) {
 // DeleteVertices removes a batch of vertices. Automatically chunked to
 // respect the server's MaxBatchSize cap. Edges incident to removed vertices
 // are reaped lazily by the server's GC loop.
+//
+// Partial-write semantics: chunks are sent sequentially. On failure the
+// returned error is a *BatchError whose Written field records the number of
+// keys already deleted, so callers can resume with keys[err.Written:].
 func (l *Lantern) DeleteVertices(ctx context.Context, keys []string) error {
 	if len(keys) == 0 {
 		return nil
 	}
+	written := 0
 	for _, chunk := range chunkSlice(keys, l.opts.batchChunkSize) {
 		ctx, cancel := l.applyTimeout(ctx)
 		_, err := l.client.DeleteVertices(ctx, &pb.DeleteVerticesRequest{Keys: chunk})
 		cancel()
 		if err != nil {
-			return wrapStatus(err)
+			return &BatchError{Written: written, Err: wrapStatus(err)}
 		}
+		written += len(chunk)
 	}
 	return nil
 }
@@ -294,18 +309,26 @@ func (l *Lantern) AddEdgeAt(ctx context.Context, tail string, head string, weigh
 }
 
 // AddEdges accumulates weight onto a batch of edges. Automatically chunked.
+//
+// Partial-write semantics: chunks are sent sequentially. On failure the
+// returned error is a *BatchError whose Written field records the number of
+// edges already committed, so callers can resume with inputs[err.Written:].
+// Note that because AddEdge is additive (not idempotent), naively retrying
+// from index 0 will double-count weight for the already-committed prefix.
 func (l *Lantern) AddEdges(ctx context.Context, inputs []EdgeInput) error {
 	if len(inputs) == 0 {
 		return nil
 	}
 	edges := edgesFrom(inputs)
+	written := 0
 	for _, chunk := range chunkSlice(edges, l.opts.batchChunkSize) {
 		ctx, cancel := l.applyTimeout(ctx)
 		_, err := l.client.AddEdge(ctx, &pb.AddEdgeRequest{Edges: chunk})
 		cancel()
 		if err != nil {
-			return wrapStatus(err)
+			return &BatchError{Written: written, Err: wrapStatus(err)}
 		}
+		written += len(chunk)
 	}
 	return nil
 }
@@ -326,18 +349,26 @@ func (l *Lantern) PutEdgeAt(ctx context.Context, tail string, head string, weigh
 }
 
 // PutEdges overwrites a batch of edges. Automatically chunked.
+//
+// Partial-write semantics: chunks are sent sequentially. On failure the
+// returned error is a *BatchError whose Written field records the number of
+// edges already overwritten, so callers can resume with inputs[err.Written:].
+// Unlike AddEdges, PutEdges is idempotent, so a full retry from index 0 is
+// also safe (it will overwrite the already-committed prefix).
 func (l *Lantern) PutEdges(ctx context.Context, inputs []EdgeInput) error {
 	if len(inputs) == 0 {
 		return nil
 	}
 	edges := edgesFrom(inputs)
+	written := 0
 	for _, chunk := range chunkSlice(edges, l.opts.batchChunkSize) {
 		ctx, cancel := l.applyTimeout(ctx)
 		_, err := l.client.PutEdge(ctx, &pb.PutEdgeRequest{Edges: chunk})
 		cancel()
 		if err != nil {
-			return wrapStatus(err)
+			return &BatchError{Written: written, Err: wrapStatus(err)}
 		}
+		written += len(chunk)
 	}
 	return nil
 }
@@ -362,6 +393,10 @@ type EdgeRef struct {
 }
 
 // DeleteEdges removes a batch of edges. Automatically chunked.
+//
+// Partial-write semantics: chunks are sent sequentially. On failure the
+// returned error is a *BatchError whose Written field records the number of
+// edges already deleted, so callers can resume with refs[err.Written:].
 func (l *Lantern) DeleteEdges(ctx context.Context, refs []EdgeRef) error {
 	if len(refs) == 0 {
 		return nil
@@ -370,13 +405,15 @@ func (l *Lantern) DeleteEdges(ctx context.Context, refs []EdgeRef) error {
 	for _, r := range refs {
 		keys = append(keys, &pb.EdgeKey{Tail: r.Tail, Head: r.Head})
 	}
+	written := 0
 	for _, chunk := range chunkSlice(keys, l.opts.batchChunkSize) {
 		ctx, cancel := l.applyTimeout(ctx)
 		_, err := l.client.DeleteEdges(ctx, &pb.DeleteEdgesRequest{Edges: chunk})
 		cancel()
 		if err != nil {
-			return wrapStatus(err)
+			return &BatchError{Written: written, Err: wrapStatus(err)}
 		}
+		written += len(chunk)
 	}
 	return nil
 }

--- a/tests/integration/batch_error_test.go
+++ b/tests/integration/batch_error_test.go
@@ -1,0 +1,103 @@
+package integration_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	pb "github.com/anaregdesign/lantern/sdks/go/gen/graph/v1"
+	"github.com/anaregdesign/lantern/server/provider"
+	"github.com/anaregdesign/lantern/server/service"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// newInProcessClientChunked is like newInProcessClient but lets the test
+// force a custom batchChunkSize so partial-write scenarios can be exercised
+// with a small input.
+func newInProcessClientChunked(t *testing.T, chunkSize int) (*client.Lantern, func()) {
+	t.Helper()
+
+	lis := bufconn.Listen(1 << 16)
+	vi := provider.NewValidationInterceptor(provider.ValidationLimits{
+		MaxKeyLen:         256,
+		MaxBatchSize:      1024,
+		IlluminateMaxStep: 32,
+		IlluminateMaxK:    256,
+	})
+	srv := grpc.NewServer(grpc.UnaryInterceptor(vi.UnaryServerInterceptor()))
+	svc := service.NewLanternService(cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute))
+	pb.RegisterLanternServiceServer(srv, svc)
+
+	go func() {
+		if err := srv.Serve(lis); err != nil {
+			t.Logf("grpc Serve returned: %v", err)
+		}
+	}()
+
+	dialer := func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}
+	l, err := client.NewLantern(
+		"passthrough://bufconn",
+		client.WithTransportCredentials(insecure.NewCredentials()),
+		client.WithDialOption(grpc.WithContextDialer(dialer)),
+		client.WithBatchChunkSize(chunkSize),
+	)
+	if err != nil {
+		t.Fatalf("NewLantern: %v", err)
+	}
+
+	cleanup := func() {
+		_ = l.Close()
+		srv.Stop()
+		_ = lis.Close()
+	}
+	return l, cleanup
+}
+
+// TestBatchError_PartialWrite verifies that when a later chunk fails, the
+// SDK returns a *BatchError whose Written field reflects fully-committed
+// prior chunks, and that the wrapped error still satisfies errors.Is for the
+// underlying sentinel.
+func TestBatchError_PartialWrite(t *testing.T) {
+	l, cleanup := newInProcessClientChunked(t, 2)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	exp := time.Now().Add(time.Minute)
+	inputs := []client.VertexInput{
+		{Key: "ok-1", Value: "v", Expiration: exp},
+		{Key: "ok-2", Value: "v", Expiration: exp},
+		{Key: "", Value: "v", Expiration: exp}, // empty key trips the server-side validator
+		{Key: "ok-4", Value: "v", Expiration: exp},
+	}
+	err := l.PutVertices(ctx, inputs)
+	if err == nil {
+		t.Fatal("PutVertices: expected BatchError, got nil")
+	}
+
+	var be *client.BatchError
+	if !errors.As(err, &be) {
+		t.Fatalf("PutVertices: expected *BatchError, got %T: %v", err, err)
+	}
+	if be.Written != 2 {
+		t.Errorf("BatchError.Written = %d, want 2 (first chunk committed)", be.Written)
+	}
+	if !errors.Is(err, client.ErrInvalidArgument) {
+		t.Errorf("expected errors.Is(err, ErrInvalidArgument) to be true; err = %v", err)
+	}
+
+	// Confirm the first chunk did commit.
+	v, gerr := l.GetVertex(ctx, "ok-1")
+	if gerr != nil || v == nil {
+		t.Errorf("ok-1 should exist after partial write; v=%v err=%v", v, gerr)
+	}
+}


### PR DESCRIPTION
Closes #53.

Batch helpers (`PutVertices`, `AddEdges`, `PutEdges`, `DeleteVertices`, `DeleteEdges`) split inputs per `WithBatchChunkSize` and send chunks sequentially. Previously, when chunk N failed the caller only saw the underlying gRPC error and had no way to learn that chunks 0..N-1 had already been committed.

This PR introduces `*BatchError{Written int, Err error}`:

- Returned by all five chunked batch helpers on chunk failure.
- `Written` records how many input entries were committed before the failure, so callers can resume with `input[err.Written:]`.
- Wraps the underlying gRPC error, so `errors.Is(err, ErrInvalidArgument)` and friends still work.
- Documents the partial-write semantics in each method's godoc, including the AddEdges caveat that retrying from index 0 will double-count weight.
- Adds a `tests/integration` regression that forces a mid-batch `InvalidArgument` with chunk size 2 and asserts both `errors.As` / `Written` and `errors.Is`.