### PR TITLE
docs(#54): clarify Vertex_Nil tombstone vs ErrNotFound in SDK godoc

### DIFF
--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -157,8 +157,16 @@ func wrapStatus(err error) error {
 	return err
 }
 
-// GetVertex fetches the vertex at key. Returns an error wrapping ErrNotFound
-// when the key is absent.
+// GetVertex fetches the vertex at key.
+//
+// Presence vs. nil-value semantics:
+//   - Absent key  → returns (nil, err) where errors.Is(err, ErrNotFound) is true.
+//   - Present key holding an explicit nil value (the proto Vertex_Nil tombstone,
+//     written by passing a Go nil to PutVertex/PutVertexAt) → returns a
+//     non-nil *Vertex whose Kind() reports VertexKindNil and a nil error.
+//
+// Callers that need to distinguish "missing" from "present-but-nil" must
+// check errors.Is(err, ErrNotFound) rather than only the returned pointer.
 func (l *Lantern) GetVertex(ctx context.Context, key string) (*Vertex, error) {
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()

--- a/sdks/go/value.go
+++ b/sdks/go/value.go
@@ -81,6 +81,11 @@ func (v nativeVertex) asVertex() (*pb.Vertex, error) {
 
 // Vertex is a thin type alias over the generated protobuf Vertex that adds
 // Go-friendly value accessors. Convert a *pb.Vertex with (*Vertex)(p).
+//
+// A Vertex whose Kind() reports VertexKindNil is a present tombstone, not a
+// missing entry: GetVertex returns it with a nil error. "Key absent" is
+// signalled separately by an error wrapping ErrNotFound. See GetVertex for
+// the full presence vs. nil-value contract.
 type Vertex pb.Vertex
 
 // VertexKind identifies which oneof variant is set on a Vertex. Use
@@ -99,6 +104,10 @@ const (
 	VertexKindString
 	VertexKindBytes
 	VertexKindTimestamp
+	// VertexKindNil indicates a present vertex whose value is the proto
+	// Vertex_Nil tombstone (created by passing a Go nil to PutVertex /
+	// PutVertexAt). This is distinct from a missing key, which is reported
+	// by GetVertex as an error wrapping ErrNotFound.
 	VertexKindNil
 	VertexKindDuration
 )


### PR DESCRIPTION
Closes #54.

`GetVertex` returns:

- `(nil, err)` where `errors.Is(err, ErrNotFound)` is true when the key is **absent**, and
- a non-nil `*Vertex` with `Kind() == VertexKindNil` and a nil error when the key is **present** and holds the proto `Vertex_Nil` tombstone (written by passing a Go `nil` to `PutVertex` / `PutVertexAt`).

This contract was not documented, so callers had no obvious cue to distinguish missing from present-but-nil. Adds godoc on `GetVertex`, on the `Vertex` type, and on the `VertexKindNil` constant. Pure documentation \u2014 no API or behavioural changes.