### PR TITLE
feat(#55): functional options for Lantern.Illuminate

### DIFF
--- a/cli/cmd/illuminate.go
+++ b/cli/cmd/illuminate.go
@@ -90,8 +90,13 @@ EXAMPLES
 		}
 		defer func() { _ = cli.Close() }()
 
-		g, err := cli.IlluminateWithOptimization(
-			cmd.Context(), args[0], illuminateStep, illuminateK, illuminateTfidf, opt)
+		g, err := cli.Illuminate(
+			cmd.Context(), args[0],
+			client.WithStep(illuminateStep),
+			client.WithK(illuminateK),
+			client.WithTFIDF(illuminateTfidf),
+			client.WithOptimization(opt),
+		)
 		if err != nil {
 			return err
 		}

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -185,7 +185,11 @@ func (c *CLIService) Run(ctx context.Context, str string) error {
 			fmt.Printf("Error: %s\n", err)
 			return ErrIlluminate
 		}
-		g, err := c.client.Illuminate(ctx, p.Seed, uint32(p.Step), uint32(p.K), p.Tfidf)
+		g, err := c.client.Illuminate(ctx, p.Seed,
+			client.WithStep(uint32(p.Step)),
+			client.WithK(uint32(p.K)),
+			client.WithTFIDF(p.Tfidf),
+		)
 		if err != nil {
 			fmt.Printf("Error: %s\n", err)
 			return ErrConnection

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -473,22 +473,58 @@ func NewGraph() *Graph {
 	}
 }
 
-// Illuminate runs a k-bounded BFS from seed, returning the resulting subgraph.
-func (l *Lantern) Illuminate(ctx context.Context, seed string, step uint32, k uint32, tfidf bool) (*Graph, error) {
-	return l.IlluminateWithOptimization(ctx, seed, step, k, tfidf, OptimizationUnspecified)
+// IlluminateOption configures a single Illuminate call. Pass any combination
+// of WithStep, WithK, WithTFIDF, and WithOptimization to Illuminate.
+type IlluminateOption func(*illuminateConfig)
+
+type illuminateConfig struct {
+	step         uint32
+	k            uint32
+	tfidf        bool
+	optimization Optimization
 }
 
-// IlluminateWithOptimization is Illuminate with an explicit server-side
-// post-processing strategy. Pass OptimizationUnspecified to disable it.
-func (l *Lantern) IlluminateWithOptimization(ctx context.Context, seed string, step uint32, k uint32, tfidf bool, opt Optimization) (*Graph, error) {
+// WithStep sets the BFS depth for an Illuminate call.
+func WithStep(step uint32) IlluminateOption {
+	return func(c *illuminateConfig) { c.step = step }
+}
+
+// WithK sets the per-hop fan-out (top-k neighbours) for an Illuminate call.
+func WithK(k uint32) IlluminateOption {
+	return func(c *illuminateConfig) { c.k = k }
+}
+
+// WithTFIDF toggles server-side TF-IDF re-weighting of edges before
+// optimization runs.
+func WithTFIDF(tfidf bool) IlluminateOption {
+	return func(c *illuminateConfig) { c.tfidf = tfidf }
+}
+
+// WithOptimization selects the server-side post-processing strategy applied
+// to the illuminated subgraph (e.g. MST, SPT). Pass OptimizationUnspecified
+// to disable it.
+func WithOptimization(opt Optimization) IlluminateOption {
+	return func(c *illuminateConfig) { c.optimization = opt }
+}
+
+// Illuminate runs a k-bounded BFS from seed, returning the resulting subgraph.
+// Configure step, k, TF-IDF, and optimization via IlluminateOption values; any
+// option omitted defaults to its zero value (step=0, k=0, tfidf=false,
+// optimization=OptimizationUnspecified), which the server treats as "no
+// expansion / no optimization".
+func (l *Lantern) Illuminate(ctx context.Context, seed string, opts ...IlluminateOption) (*Graph, error) {
+	cfg := illuminateConfig{optimization: OptimizationUnspecified}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
 	result, err := l.client.Illuminate(ctx, &pb.IlluminateRequest{
 		Seed:         seed,
-		Step:         step,
-		K:            k,
-		Tfidf:        tfidf,
-		Optimization: opt,
+		Step:         cfg.step,
+		K:            cfg.k,
+		Tfidf:        cfg.tfidf,
+		Optimization: cfg.optimization,
 	})
 	if err != nil {
 		return nil, wrapStatus(err)

--- a/sdks/go/example/main.go
+++ b/sdks/go/example/main.go
@@ -254,7 +254,7 @@ func main() {
 	}
 
 	// illuminate from a with step 2 and k 2
-	if graph, err := cli.Illuminate(ctx, "a", 2, 2, false); err == nil {
+	if graph, err := cli.Illuminate(ctx, "a", client.WithStep(2), client.WithK(2)); err == nil {
 		if jsonString, err := json.MarshalIndent(graph, "", "\t"); err == nil {
 			log.Printf("%s\n", jsonString)
 			/*

--- a/server/service/integration_test.go
+++ b/server/service/integration_test.go
@@ -110,7 +110,7 @@ func TestIntegration_FullMiddlewareChain(t *testing.T) {
 	})
 
 	t.Run("illuminate caps enforced", func(t *testing.T) {
-		_, err := c.Illuminate(ctx, "k", 99, 1, false)
+		_, err := c.Illuminate(ctx, "k", client.WithStep(99), client.WithK(1))
 		if status.Code(err) != codes.InvalidArgument {
 			t.Errorf("Illuminate step=99 code = %v, want InvalidArgument", status.Code(err))
 		}

--- a/tests/integration/client_test.go
+++ b/tests/integration/client_test.go
@@ -147,7 +147,7 @@ func TestLantern_Illuminate(t *testing.T) {
 		t.Fatalf("PutEdge b->c: %v", err)
 	}
 
-	g, err := l.Illuminate(ctx, "a", 3, 10, false)
+	g, err := l.Illuminate(ctx, "a", client.WithStep(3), client.WithK(10))
 	if err != nil {
 		t.Fatalf("Illuminate: %v", err)
 	}


### PR DESCRIPTION
Closes #55.

Replaces the positional `Illuminate(ctx, seed, step, k, tfidf)` signature with a single variadic entry point:

```go
g, err := cli.Illuminate(ctx, "a",
    client.WithStep(2),
    client.WithK(10),
    client.WithTFIDF(true),
    client.WithOptimization(client.OptimizationMinimumSpanningTree),
)
```

This eliminates the unreadable trailing bool at call sites and lets callers omit fields they don't care about.

### Note on the deprecation strategy

The issue suggested keeping the old positional signature as a deprecated thin wrapper for one release. Go doesn't allow overloading, so the old `Illuminate(ctx, seed, step, k, tfidf)` and the new `Illuminate(ctx, seed, ...IlluminateOption)` cannot coexist on the same method. The previously-exported `IlluminateWithOptimization` is also removed \u2014 functional options subsume both old shapes.

Pre-1.0 SDK, so a one-shot break is acceptable; all in-tree callers (`cli/cmd`, `cli/service`, `sdks/go/example`, `tests/integration`, `server/service/integration_test`) are migrated in the same commit. External callers update by passing `client.WithStep(step), client.WithK(k), client.WithTFIDF(tfidf)` in place of the positional args. If we'd rather preserve the old name as a wrapper, the right move would be to rename the new variadic API (e.g. `IlluminateOpts`) \u2014 happy to flip if preferred.