### PR TITLE
fix(#71): un-parameterize MinimumSpanningTree and gofmt cli/service

### DIFF
--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -231,7 +231,7 @@ func (c *CLIService) Run(ctx context.Context, str string) error {
 				return nil
 			}
 		case "mst_cost":
-			mg = mg.MinimumSpanningTree(p.Seed, false)
+			mg = mg.MinimumSpanningTree(p.Seed)
 			if jsonString, err := json.MarshalIndent(mg, "", "\t"); err != nil {
 				return err
 			} else {
@@ -239,7 +239,7 @@ func (c *CLIService) Run(ctx context.Context, str string) error {
 				return nil
 			}
 		case "mst_relevance":
-				mg = mg.MaximumSpanningTree(p.Seed)
+			mg = mg.MaximumSpanningTree(p.Seed)
 			if jsonString, err := json.MarshalIndent(mg, "", "\t"); err != nil {
 				return err
 			} else {

--- a/core/graph/context_test.go
+++ b/core/graph/context_test.go
@@ -23,7 +23,7 @@ func TestGraph_ContextCancelled(t *testing.T) {
 			return err
 		}},
 		{"MinimumSpanningTreeContext", func() error {
-			_, err := g.MinimumSpanningTreeContext(ctx, "a", false)
+			_, err := g.MinimumSpanningTreeContext(ctx, "a")
 			return err
 		}},
 		{"ShortestPathTreeContext", func() error {

--- a/core/graph/example/main.go
+++ b/core/graph/example/main.go
@@ -83,7 +83,7 @@ func main() {
 	*/
 
 	log.Println("Minimum Spanning Tree from vertex 'a'")
-	mst := g.MinimumSpanningTree("a", false)
+	mst := g.MinimumSpanningTree("a")
 	if jsonText, err := json.MarshalIndent(mst, "", "\t"); err == nil {
 		log.Println(string(jsonText))
 	}

--- a/core/graph/graph_test.go
+++ b/core/graph/graph_test.go
@@ -60,7 +60,7 @@ func TestGraph_MinimumSpanningTree(t *testing.T) {
 	g.PutEdge("a", "c", 10)
 	g.PutEdge("c", "a", 10)
 
-	mst := g.MinimumSpanningTree("a", false)
+	mst := g.MinimumSpanningTree("a")
 
 	total := float32(0)
 	for _, heads := range mst.Edges {

--- a/core/graph/model.go
+++ b/core/graph/model.go
@@ -86,32 +86,31 @@ func (g *Graph[S, T]) ConnectedGraphContext(ctx context.Context, seed S) (*Graph
 }
 
 // MinimumSpanningTree returns a minimum spanning tree of the graph rooted at seed.
-//
-// Deprecated: the `negate` flag is semantically confusing — for the maximum
-// spanning tree, call [Graph.MaximumSpanningTree] instead. This method is
-// retained for backward compatibility and will continue to work, but new code
-// should not pass `negate=true`.
-func (g *Graph[S, T]) MinimumSpanningTree(seed S, negate bool) *Graph[S, T] {
-	mst, _ := g.MinimumSpanningTreeContext(context.Background(), seed, negate)
+func (g *Graph[S, T]) MinimumSpanningTree(seed S) *Graph[S, T] {
+	mst, _ := g.spanningTreeContext(context.Background(), seed, false)
 	return mst
 }
 
 // MaximumSpanningTree returns a maximum spanning tree of the graph rooted at seed.
 func (g *Graph[S, T]) MaximumSpanningTree(seed S) *Graph[S, T] {
-	mst, _ := g.MinimumSpanningTreeContext(context.Background(), seed, true)
+	mst, _ := g.spanningTreeContext(context.Background(), seed, true)
 	return mst
+}
+
+// MinimumSpanningTreeContext is the context-aware variant of [Graph.MinimumSpanningTree].
+func (g *Graph[S, T]) MinimumSpanningTreeContext(ctx context.Context, seed S) (*Graph[S, T], error) {
+	return g.spanningTreeContext(ctx, seed, false)
 }
 
 // MaximumSpanningTreeContext is the context-aware variant of [Graph.MaximumSpanningTree].
 func (g *Graph[S, T]) MaximumSpanningTreeContext(ctx context.Context, seed S) (*Graph[S, T], error) {
-	return g.MinimumSpanningTreeContext(ctx, seed, true)
+	return g.spanningTreeContext(ctx, seed, true)
 }
 
-// MinimumSpanningTreeContext is the context-aware variant of [Graph.MinimumSpanningTree].
-//
-// Deprecated: the `negate` flag is semantically confusing — for the maximum
-// spanning tree, call [Graph.MaximumSpanningTreeContext] instead.
-func (g *Graph[S, T]) MinimumSpanningTreeContext(ctx context.Context, seed S, negate bool) (*Graph[S, T], error) {
+// spanningTreeContext computes either the minimum (negate=false) or maximum
+// (negate=true) spanning tree rooted at seed. It is the shared implementation
+// behind the exported MinimumSpanningTree / MaximumSpanningTree variants.
+func (g *Graph[S, T]) spanningTreeContext(ctx context.Context, seed S, negate bool) (*Graph[S, T], error) {
 	connected, err := g.ConnectedGraphContext(ctx, seed)
 	if err != nil {
 		return nil, err

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -55,7 +55,7 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 	case pb.Optimization_OPTIMIZATION_UNSPECIFIED:
 		// do nothing
 	case pb.Optimization_OPTIMIZATION_MINIMUM_SPANNING_TREE:
-		g, err = g.MinimumSpanningTreeContext(ctx, request.GetSeed(), false)
+		g, err = g.MinimumSpanningTreeContext(ctx, request.GetSeed())
 	case pb.Optimization_OPTIMIZATION_MAXIMUM_SPANNING_TREE:
 		g, err = g.MaximumSpanningTreeContext(ctx, request.GetSeed())
 	case pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE:


### PR DESCRIPTION
- Remove negate bool param from exported MinimumSpanningTree[Context];
  the negate flag is now an internal detail of spanningTreeContext, shared
  by both Minimum* and Maximum* exported wrappers. Drops staticcheck SA1019
  at three call sites that legitimately wanted a real MST.
- gofmt -w cli/service/service.go.

Closes #71
