### PR TITLE
chore(#73): normalize sdks/go import alias

### DIFF
--- a/cli/cmd/edge.go
+++ b/cli/cmd/edge.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/anaregdesign/lantern/sdks/go"
+	client "github.com/anaregdesign/lantern/sdks/go"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/illuminate.go
+++ b/cli/cmd/illuminate.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/anaregdesign/lantern/sdks/go"
+	client "github.com/anaregdesign/lantern/sdks/go"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/vertex.go
+++ b/cli/cmd/vertex.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/anaregdesign/lantern/sdks/go"
+	client "github.com/anaregdesign/lantern/sdks/go"
 	"github.com/spf13/cobra"
 )
 

--- a/sdks/go/example/main.go
+++ b/sdks/go/example/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"github.com/anaregdesign/lantern/sdks/go"
 	"log"
 	"time"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
 )
 
 func main() {

--- a/server/service/integration_test.go
+++ b/server/service/integration_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
-	"github.com/anaregdesign/lantern/sdks/go"
+	client "github.com/anaregdesign/lantern/sdks/go"
 	pb "github.com/anaregdesign/lantern/sdks/go/gen/graph/v1"
 	"github.com/anaregdesign/lantern/server/provider"
 	"github.com/anaregdesign/lantern/server/service"


### PR DESCRIPTION
Closes #73

Use explicit `client "github.com/anaregdesign/lantern/sdks/go"` alias in all 5 files that previously relied on the implicit package name (and fix 2 broken local edits that pointed at a nonexistent `/client` path).

### Verification
- `gofmt -l .` clean in both modules
- `go vet ./...` clean in both modules
- `go test ./...` green in both modules