### PR TITLE
feat(#74): rename PutVertex/AddEdge/PutEdge to plural form

### DIFF
--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -83,14 +83,14 @@ message GetVerticesResponse {
   repeated string missing = 2;
 }
 
-// PutVertexRequest writes vertices with upsert semantics: each Vertex.key
+// PutVerticesRequest writes vertices with upsert semantics: each Vertex.key
 // replaces any existing value at that key. Use the Vertex.expiration field
 // (absolute time) to control TTL.
-message PutVertexRequest {
+message PutVerticesRequest {
   repeated Vertex vertices = 1;
 }
 
-message PutVertexResponse {
+message PutVerticesResponse {
   // Number of vertices accepted by the server. Currently always equals the
   // request size on success; reserved for future per-item validation that may
   // report partial writes.
@@ -174,25 +174,25 @@ message DeleteEdgesResponse {
   int32 deleted = 1;
 }
 
-// AddEdgeRequest accumulates weight onto each (tail, head) pair: repeated
+// AddEdgesRequest accumulates weight onto each (tail, head) pair: repeated
 // calls with the same endpoints sum their weights. This operation is
 // non-idempotent.
-message AddEdgeRequest {
+message AddEdgesRequest {
   repeated Edge edges = 1;
 }
 
-message AddEdgeResponse {
+message AddEdgesResponse {
   // Number of edges whose weight contributions were accepted.
   int32 written = 1;
 }
 
-// PutEdgeRequest overwrites each (tail, head) pair, replacing any existing
+// PutEdgesRequest overwrites each (tail, head) pair, replacing any existing
 // weight and expiration. This operation is idempotent.
-message PutEdgeRequest {
+message PutEdgesRequest {
   repeated Edge edges = 1;
 }
 
-message PutEdgeResponse {
+message PutEdgesResponse {
   // Number of edges accepted (overwritten or created).
   int32 written = 1;
 }
@@ -214,7 +214,7 @@ service LanternService {
     };
   }
 
-  rpc PutVertex(PutVertexRequest) returns (PutVertexResponse) {
+  rpc PutVertices(PutVerticesRequest) returns (PutVerticesResponse) {
     option (google.api.http) = {
       put: "/v1/vertices"
       body: "*"
@@ -245,16 +245,16 @@ service LanternService {
     };
   }
 
-  // AddEdge is non-idempotent (accumulates weight). POST per REST conventions.
-  rpc AddEdge(AddEdgeRequest) returns (AddEdgeResponse) {
+  // AddEdges is non-idempotent (accumulates weight). POST per REST conventions.
+  rpc AddEdges(AddEdgesRequest) returns (AddEdgesResponse) {
     option (google.api.http) = {
       post: "/v1/edges/add"
       body: "*"
     };
   }
 
-  // PutEdge is idempotent (replaces weight). PUT per REST conventions.
-  rpc PutEdge(PutEdgeRequest) returns (PutEdgeResponse) {
+  // PutEdges is idempotent (replaces weight). PUT per REST conventions.
+  rpc PutEdges(PutEdgesRequest) returns (PutEdgesResponse) {
     option (google.api.http) = {
       put: "/v1/edges/put"
       body: "*"

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -190,7 +190,7 @@ func (l *Lantern) PutVertexAt(ctx context.Context, key string, value any, expira
 	}
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	_, err = l.client.PutVertex(ctx, &pb.PutVertexRequest{Vertices: []*pb.Vertex{v}})
+	_, err = l.client.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: []*pb.Vertex{v}})
 	return wrapStatus(err)
 }
 
@@ -218,7 +218,7 @@ func (l *Lantern) PutVertices(ctx context.Context, inputs []VertexInput) error {
 	written := 0
 	for _, chunk := range chunkSlice(vs, l.opts.batchChunkSize) {
 		ctx, cancel := l.applyTimeout(ctx)
-		_, err := l.client.PutVertex(ctx, &pb.PutVertexRequest{Vertices: chunk})
+		_, err := l.client.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: chunk})
 		cancel()
 		if err != nil {
 			return &BatchError{Written: written, Err: wrapStatus(err)}
@@ -310,7 +310,7 @@ func (l *Lantern) AddEdge(ctx context.Context, tail string, head string, weight 
 func (l *Lantern) AddEdgeAt(ctx context.Context, tail string, head string, weight float32, expiration time.Time) error {
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	_, err := l.client.AddEdge(ctx, &pb.AddEdgeRequest{
+	_, err := l.client.AddEdges(ctx, &pb.AddEdgesRequest{
 		Edges: []*pb.Edge{{Tail: tail, Head: head, Weight: weight, Expiration: timestamppb.New(expiration)}},
 	})
 	return wrapStatus(err)
@@ -331,7 +331,7 @@ func (l *Lantern) AddEdges(ctx context.Context, inputs []EdgeInput) error {
 	written := 0
 	for _, chunk := range chunkSlice(edges, l.opts.batchChunkSize) {
 		ctx, cancel := l.applyTimeout(ctx)
-		_, err := l.client.AddEdge(ctx, &pb.AddEdgeRequest{Edges: chunk})
+		_, err := l.client.AddEdges(ctx, &pb.AddEdgesRequest{Edges: chunk})
 		cancel()
 		if err != nil {
 			return &BatchError{Written: written, Err: wrapStatus(err)}
@@ -350,7 +350,7 @@ func (l *Lantern) PutEdge(ctx context.Context, tail string, head string, weight 
 func (l *Lantern) PutEdgeAt(ctx context.Context, tail string, head string, weight float32, expiration time.Time) error {
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	_, err := l.client.PutEdge(ctx, &pb.PutEdgeRequest{
+	_, err := l.client.PutEdges(ctx, &pb.PutEdgesRequest{
 		Edges: []*pb.Edge{{Tail: tail, Head: head, Weight: weight, Expiration: timestamppb.New(expiration)}},
 	})
 	return wrapStatus(err)
@@ -371,7 +371,7 @@ func (l *Lantern) PutEdges(ctx context.Context, inputs []EdgeInput) error {
 	written := 0
 	for _, chunk := range chunkSlice(edges, l.opts.batchChunkSize) {
 		ctx, cancel := l.applyTimeout(ctx)
-		_, err := l.client.PutEdge(ctx, &pb.PutEdgeRequest{Edges: chunk})
+		_, err := l.client.PutEdges(ctx, &pb.PutEdgesRequest{Edges: chunk})
 		cancel()
 		if err != nil {
 			return &BatchError{Written: written, Err: wrapStatus(err)}

--- a/sdks/go/gen/graph/v1/graph.pb.go
+++ b/sdks/go/gen/graph/v1/graph.pb.go
@@ -769,30 +769,30 @@ func (x *GetVerticesResponse) GetMissing() []string {
 	return nil
 }
 
-// PutVertexRequest writes vertices with upsert semantics: each Vertex.key
+// PutVerticesRequest writes vertices with upsert semantics: each Vertex.key
 // replaces any existing value at that key. Use the Vertex.expiration field
 // (absolute time) to control TTL.
-type PutVertexRequest struct {
+type PutVerticesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Vertices      []*Vertex              `protobuf:"bytes,1,rep,name=vertices,proto3" json:"vertices,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *PutVertexRequest) Reset() {
-	*x = PutVertexRequest{}
+func (x *PutVerticesRequest) Reset() {
+	*x = PutVerticesRequest{}
 	mi := &file_graph_v1_graph_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *PutVertexRequest) String() string {
+func (x *PutVerticesRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*PutVertexRequest) ProtoMessage() {}
+func (*PutVerticesRequest) ProtoMessage() {}
 
-func (x *PutVertexRequest) ProtoReflect() protoreflect.Message {
+func (x *PutVerticesRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_graph_v1_graph_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -804,19 +804,19 @@ func (x *PutVertexRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use PutVertexRequest.ProtoReflect.Descriptor instead.
-func (*PutVertexRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use PutVerticesRequest.ProtoReflect.Descriptor instead.
+func (*PutVerticesRequest) Descriptor() ([]byte, []int) {
 	return file_graph_v1_graph_proto_rawDescGZIP(), []int{9}
 }
 
-func (x *PutVertexRequest) GetVertices() []*Vertex {
+func (x *PutVerticesRequest) GetVertices() []*Vertex {
 	if x != nil {
 		return x.Vertices
 	}
 	return nil
 }
 
-type PutVertexResponse struct {
+type PutVerticesResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Number of vertices accepted by the server. Currently always equals the
 	// request size on success; reserved for future per-item validation that may
@@ -826,20 +826,20 @@ type PutVertexResponse struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *PutVertexResponse) Reset() {
-	*x = PutVertexResponse{}
+func (x *PutVerticesResponse) Reset() {
+	*x = PutVerticesResponse{}
 	mi := &file_graph_v1_graph_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *PutVertexResponse) String() string {
+func (x *PutVerticesResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*PutVertexResponse) ProtoMessage() {}
+func (*PutVerticesResponse) ProtoMessage() {}
 
-func (x *PutVertexResponse) ProtoReflect() protoreflect.Message {
+func (x *PutVerticesResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_graph_v1_graph_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -851,12 +851,12 @@ func (x *PutVertexResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use PutVertexResponse.ProtoReflect.Descriptor instead.
-func (*PutVertexResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use PutVerticesResponse.ProtoReflect.Descriptor instead.
+func (*PutVerticesResponse) Descriptor() ([]byte, []int) {
 	return file_graph_v1_graph_proto_rawDescGZIP(), []int{10}
 }
 
-func (x *PutVertexResponse) GetWritten() int32 {
+func (x *PutVerticesResponse) GetWritten() int32 {
 	if x != nil {
 		return x.Written
 	}
@@ -1488,30 +1488,30 @@ func (x *DeleteEdgesResponse) GetDeleted() int32 {
 	return 0
 }
 
-// AddEdgeRequest accumulates weight onto each (tail, head) pair: repeated
+// AddEdgesRequest accumulates weight onto each (tail, head) pair: repeated
 // calls with the same endpoints sum their weights. This operation is
 // non-idempotent.
-type AddEdgeRequest struct {
+type AddEdgesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Edges         []*Edge                `protobuf:"bytes,1,rep,name=edges,proto3" json:"edges,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *AddEdgeRequest) Reset() {
-	*x = AddEdgeRequest{}
+func (x *AddEdgesRequest) Reset() {
+	*x = AddEdgesRequest{}
 	mi := &file_graph_v1_graph_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *AddEdgeRequest) String() string {
+func (x *AddEdgesRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*AddEdgeRequest) ProtoMessage() {}
+func (*AddEdgesRequest) ProtoMessage() {}
 
-func (x *AddEdgeRequest) ProtoReflect() protoreflect.Message {
+func (x *AddEdgesRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_graph_v1_graph_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1523,19 +1523,19 @@ func (x *AddEdgeRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use AddEdgeRequest.ProtoReflect.Descriptor instead.
-func (*AddEdgeRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use AddEdgesRequest.ProtoReflect.Descriptor instead.
+func (*AddEdgesRequest) Descriptor() ([]byte, []int) {
 	return file_graph_v1_graph_proto_rawDescGZIP(), []int{24}
 }
 
-func (x *AddEdgeRequest) GetEdges() []*Edge {
+func (x *AddEdgesRequest) GetEdges() []*Edge {
 	if x != nil {
 		return x.Edges
 	}
 	return nil
 }
 
-type AddEdgeResponse struct {
+type AddEdgesResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Number of edges whose weight contributions were accepted.
 	Written       int32 `protobuf:"varint,1,opt,name=written,proto3" json:"written,omitempty"`
@@ -1543,20 +1543,20 @@ type AddEdgeResponse struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *AddEdgeResponse) Reset() {
-	*x = AddEdgeResponse{}
+func (x *AddEdgesResponse) Reset() {
+	*x = AddEdgesResponse{}
 	mi := &file_graph_v1_graph_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *AddEdgeResponse) String() string {
+func (x *AddEdgesResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*AddEdgeResponse) ProtoMessage() {}
+func (*AddEdgesResponse) ProtoMessage() {}
 
-func (x *AddEdgeResponse) ProtoReflect() protoreflect.Message {
+func (x *AddEdgesResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_graph_v1_graph_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1568,41 +1568,41 @@ func (x *AddEdgeResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use AddEdgeResponse.ProtoReflect.Descriptor instead.
-func (*AddEdgeResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use AddEdgesResponse.ProtoReflect.Descriptor instead.
+func (*AddEdgesResponse) Descriptor() ([]byte, []int) {
 	return file_graph_v1_graph_proto_rawDescGZIP(), []int{25}
 }
 
-func (x *AddEdgeResponse) GetWritten() int32 {
+func (x *AddEdgesResponse) GetWritten() int32 {
 	if x != nil {
 		return x.Written
 	}
 	return 0
 }
 
-// PutEdgeRequest overwrites each (tail, head) pair, replacing any existing
+// PutEdgesRequest overwrites each (tail, head) pair, replacing any existing
 // weight and expiration. This operation is idempotent.
-type PutEdgeRequest struct {
+type PutEdgesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Edges         []*Edge                `protobuf:"bytes,1,rep,name=edges,proto3" json:"edges,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *PutEdgeRequest) Reset() {
-	*x = PutEdgeRequest{}
+func (x *PutEdgesRequest) Reset() {
+	*x = PutEdgesRequest{}
 	mi := &file_graph_v1_graph_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *PutEdgeRequest) String() string {
+func (x *PutEdgesRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*PutEdgeRequest) ProtoMessage() {}
+func (*PutEdgesRequest) ProtoMessage() {}
 
-func (x *PutEdgeRequest) ProtoReflect() protoreflect.Message {
+func (x *PutEdgesRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_graph_v1_graph_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1614,19 +1614,19 @@ func (x *PutEdgeRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use PutEdgeRequest.ProtoReflect.Descriptor instead.
-func (*PutEdgeRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use PutEdgesRequest.ProtoReflect.Descriptor instead.
+func (*PutEdgesRequest) Descriptor() ([]byte, []int) {
 	return file_graph_v1_graph_proto_rawDescGZIP(), []int{26}
 }
 
-func (x *PutEdgeRequest) GetEdges() []*Edge {
+func (x *PutEdgesRequest) GetEdges() []*Edge {
 	if x != nil {
 		return x.Edges
 	}
 	return nil
 }
 
-type PutEdgeResponse struct {
+type PutEdgesResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Number of edges accepted (overwritten or created).
 	Written       int32 `protobuf:"varint,1,opt,name=written,proto3" json:"written,omitempty"`
@@ -1634,20 +1634,20 @@ type PutEdgeResponse struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *PutEdgeResponse) Reset() {
-	*x = PutEdgeResponse{}
+func (x *PutEdgesResponse) Reset() {
+	*x = PutEdgesResponse{}
 	mi := &file_graph_v1_graph_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *PutEdgeResponse) String() string {
+func (x *PutEdgesResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*PutEdgeResponse) ProtoMessage() {}
+func (*PutEdgesResponse) ProtoMessage() {}
 
-func (x *PutEdgeResponse) ProtoReflect() protoreflect.Message {
+func (x *PutEdgesResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_graph_v1_graph_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1659,12 +1659,12 @@ func (x *PutEdgeResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use PutEdgeResponse.ProtoReflect.Descriptor instead.
-func (*PutEdgeResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use PutEdgesResponse.ProtoReflect.Descriptor instead.
+func (*PutEdgesResponse) Descriptor() ([]byte, []int) {
 	return file_graph_v1_graph_proto_rawDescGZIP(), []int{27}
 }
 
-func (x *PutEdgeResponse) GetWritten() int32 {
+func (x *PutEdgesResponse) GetWritten() int32 {
 	if x != nil {
 		return x.Written
 	}
@@ -1721,10 +1721,10 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\x04keys\x18\x01 \x03(\tR\x04keys\"]\n" +
 	"\x13GetVerticesResponse\x12,\n" +
 	"\bvertices\x18\x01 \x03(\v2\x10.graph.v1.VertexR\bvertices\x12\x18\n" +
-	"\amissing\x18\x02 \x03(\tR\amissing\"@\n" +
-	"\x10PutVertexRequest\x12,\n" +
-	"\bvertices\x18\x01 \x03(\v2\x10.graph.v1.VertexR\bvertices\"-\n" +
-	"\x11PutVertexResponse\x12\x18\n" +
+	"\amissing\x18\x02 \x03(\tR\amissing\"B\n" +
+	"\x12PutVerticesRequest\x12,\n" +
+	"\bvertices\x18\x01 \x03(\v2\x10.graph.v1.VertexR\bvertices\"/\n" +
+	"\x13PutVerticesResponse\x12\x18\n" +
 	"\awritten\x18\x01 \x01(\x05R\awritten\"'\n" +
 	"\x13DeleteVertexRequest\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\"0\n" +
@@ -1755,33 +1755,33 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\x12DeleteEdgesRequest\x12'\n" +
 	"\x05edges\x18\x01 \x03(\v2\x11.graph.v1.EdgeKeyR\x05edges\"/\n" +
 	"\x13DeleteEdgesResponse\x12\x18\n" +
-	"\adeleted\x18\x01 \x01(\x05R\adeleted\"6\n" +
-	"\x0eAddEdgeRequest\x12$\n" +
-	"\x05edges\x18\x01 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\"+\n" +
-	"\x0fAddEdgeResponse\x12\x18\n" +
-	"\awritten\x18\x01 \x01(\x05R\awritten\"6\n" +
-	"\x0ePutEdgeRequest\x12$\n" +
-	"\x05edges\x18\x01 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\"+\n" +
-	"\x0fPutEdgeResponse\x12\x18\n" +
+	"\adeleted\x18\x01 \x01(\x05R\adeleted\"7\n" +
+	"\x0fAddEdgesRequest\x12$\n" +
+	"\x05edges\x18\x01 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\",\n" +
+	"\x10AddEdgesResponse\x12\x18\n" +
+	"\awritten\x18\x01 \x01(\x05R\awritten\"7\n" +
+	"\x0fPutEdgesRequest\x12$\n" +
+	"\x05edges\x18\x01 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\",\n" +
+	"\x10PutEdgesResponse\x12\x18\n" +
 	"\awritten\x18\x01 \x01(\x05R\awritten*\xce\x01\n" +
 	"\fOptimization\x12\x1c\n" +
 	"\x18OPTIMIZATION_UNSPECIFIED\x10\x00\x12&\n" +
 	"\"OPTIMIZATION_MINIMUM_SPANNING_TREE\x10\x01\x12&\n" +
 	"\"OPTIMIZATION_MAXIMUM_SPANNING_TREE\x10\x02\x12#\n" +
 	"\x1fOPTIMIZATION_SHORTEST_PATH_TREE\x10\x03\x12+\n" +
-	"'OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE\x10\x042\xc7\t\n" +
+	"'OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE\x10\x042\xd3\t\n" +
 	"\x0eLanternService\x12f\n" +
 	"\n" +
 	"Illuminate\x12\x1b.graph.v1.IlluminateRequest\x1a\x1c.graph.v1.IlluminateResponse\"\x1d\x82\xd3\xe4\x93\x02\x17\x12\x15/v1/illuminate/{seed}\x12`\n" +
 	"\tGetVertex\x12\x1a.graph.v1.GetVertexRequest\x1a\x1b.graph.v1.GetVertexResponse\"\x1a\x82\xd3\xe4\x93\x02\x14\x12\x12/v1/vertices/{key}\x12g\n" +
-	"\vGetVertices\x12\x1c.graph.v1.GetVerticesRequest\x1a\x1d.graph.v1.GetVerticesResponse\"\x1b\x82\xd3\xe4\x93\x02\x15:\x01*\"\x10/v1/vertices/get\x12]\n" +
-	"\tPutVertex\x12\x1a.graph.v1.PutVertexRequest\x1a\x1b.graph.v1.PutVertexResponse\"\x17\x82\xd3\xe4\x93\x02\x11:\x01*\x1a\f/v1/vertices\x12i\n" +
+	"\vGetVertices\x12\x1c.graph.v1.GetVerticesRequest\x1a\x1d.graph.v1.GetVerticesResponse\"\x1b\x82\xd3\xe4\x93\x02\x15:\x01*\"\x10/v1/vertices/get\x12c\n" +
+	"\vPutVertices\x12\x1c.graph.v1.PutVerticesRequest\x1a\x1d.graph.v1.PutVerticesResponse\"\x17\x82\xd3\xe4\x93\x02\x11:\x01*\x1a\f/v1/vertices\x12i\n" +
 	"\fDeleteVertex\x12\x1d.graph.v1.DeleteVertexRequest\x1a\x1e.graph.v1.DeleteVertexResponse\"\x1a\x82\xd3\xe4\x93\x02\x14*\x12/v1/vertices/{key}\x12s\n" +
 	"\x0eDeleteVertices\x12\x1f.graph.v1.DeleteVerticesRequest\x1a .graph.v1.DeleteVerticesResponse\"\x1e\x82\xd3\xe4\x93\x02\x18:\x01*\"\x13/v1/vertices/delete\x12_\n" +
 	"\aGetEdge\x12\x18.graph.v1.GetEdgeRequest\x1a\x19.graph.v1.GetEdgeResponse\"\x1f\x82\xd3\xe4\x93\x02\x19\x12\x17/v1/edges/{tail}/{head}\x12[\n" +
-	"\bGetEdges\x12\x19.graph.v1.GetEdgesRequest\x1a\x1a.graph.v1.GetEdgesResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\"\r/v1/edges/get\x12X\n" +
-	"\aAddEdge\x12\x18.graph.v1.AddEdgeRequest\x1a\x19.graph.v1.AddEdgeResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\"\r/v1/edges/add\x12X\n" +
-	"\aPutEdge\x12\x18.graph.v1.PutEdgeRequest\x1a\x19.graph.v1.PutEdgeResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\x1a\r/v1/edges/put\x12h\n" +
+	"\bGetEdges\x12\x19.graph.v1.GetEdgesRequest\x1a\x1a.graph.v1.GetEdgesResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\"\r/v1/edges/get\x12[\n" +
+	"\bAddEdges\x12\x19.graph.v1.AddEdgesRequest\x1a\x1a.graph.v1.AddEdgesResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\"\r/v1/edges/add\x12[\n" +
+	"\bPutEdges\x12\x19.graph.v1.PutEdgesRequest\x1a\x1a.graph.v1.PutEdgesResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\x1a\r/v1/edges/put\x12h\n" +
 	"\n" +
 	"DeleteEdge\x12\x1b.graph.v1.DeleteEdgeRequest\x1a\x1c.graph.v1.DeleteEdgeResponse\"\x1f\x82\xd3\xe4\x93\x02\x19*\x17/v1/edges/{tail}/{head}\x12g\n" +
 	"\vDeleteEdges\x12\x1c.graph.v1.DeleteEdgesRequest\x1a\x1d.graph.v1.DeleteEdgesResponse\"\x1b\x82\xd3\xe4\x93\x02\x15:\x01*\"\x10/v1/edges/deleteB\x99\x01\n" +
@@ -1813,8 +1813,8 @@ var file_graph_v1_graph_proto_goTypes = []any{
 	(*GetVertexResponse)(nil),      // 7: graph.v1.GetVertexResponse
 	(*GetVerticesRequest)(nil),     // 8: graph.v1.GetVerticesRequest
 	(*GetVerticesResponse)(nil),    // 9: graph.v1.GetVerticesResponse
-	(*PutVertexRequest)(nil),       // 10: graph.v1.PutVertexRequest
-	(*PutVertexResponse)(nil),      // 11: graph.v1.PutVertexResponse
+	(*PutVerticesRequest)(nil),     // 10: graph.v1.PutVerticesRequest
+	(*PutVerticesResponse)(nil),    // 11: graph.v1.PutVerticesResponse
 	(*DeleteVertexRequest)(nil),    // 12: graph.v1.DeleteVertexRequest
 	(*DeleteVertexResponse)(nil),   // 13: graph.v1.DeleteVertexResponse
 	(*DeleteVerticesRequest)(nil),  // 14: graph.v1.DeleteVerticesRequest
@@ -1828,10 +1828,10 @@ var file_graph_v1_graph_proto_goTypes = []any{
 	(*EdgeKey)(nil),                // 22: graph.v1.EdgeKey
 	(*DeleteEdgesRequest)(nil),     // 23: graph.v1.DeleteEdgesRequest
 	(*DeleteEdgesResponse)(nil),    // 24: graph.v1.DeleteEdgesResponse
-	(*AddEdgeRequest)(nil),         // 25: graph.v1.AddEdgeRequest
-	(*AddEdgeResponse)(nil),        // 26: graph.v1.AddEdgeResponse
-	(*PutEdgeRequest)(nil),         // 27: graph.v1.PutEdgeRequest
-	(*PutEdgeResponse)(nil),        // 28: graph.v1.PutEdgeResponse
+	(*AddEdgesRequest)(nil),        // 25: graph.v1.AddEdgesRequest
+	(*AddEdgesResponse)(nil),       // 26: graph.v1.AddEdgesResponse
+	(*PutEdgesRequest)(nil),        // 27: graph.v1.PutEdgesRequest
+	(*PutEdgesResponse)(nil),       // 28: graph.v1.PutEdgesResponse
 	(*timestamppb.Timestamp)(nil),  // 29: google.protobuf.Timestamp
 	(*durationpb.Duration)(nil),    // 30: google.protobuf.Duration
 }
@@ -1846,36 +1846,36 @@ var file_graph_v1_graph_proto_depIdxs = []int32{
 	3,  // 7: graph.v1.IlluminateResponse.graph:type_name -> graph.v1.Graph
 	1,  // 8: graph.v1.GetVertexResponse.vertex:type_name -> graph.v1.Vertex
 	1,  // 9: graph.v1.GetVerticesResponse.vertices:type_name -> graph.v1.Vertex
-	1,  // 10: graph.v1.PutVertexRequest.vertices:type_name -> graph.v1.Vertex
+	1,  // 10: graph.v1.PutVerticesRequest.vertices:type_name -> graph.v1.Vertex
 	2,  // 11: graph.v1.GetEdgeResponse.edge:type_name -> graph.v1.Edge
 	22, // 12: graph.v1.GetEdgesRequest.edges:type_name -> graph.v1.EdgeKey
 	2,  // 13: graph.v1.GetEdgesResponse.edges:type_name -> graph.v1.Edge
 	22, // 14: graph.v1.GetEdgesResponse.missing:type_name -> graph.v1.EdgeKey
 	22, // 15: graph.v1.DeleteEdgesRequest.edges:type_name -> graph.v1.EdgeKey
-	2,  // 16: graph.v1.AddEdgeRequest.edges:type_name -> graph.v1.Edge
-	2,  // 17: graph.v1.PutEdgeRequest.edges:type_name -> graph.v1.Edge
+	2,  // 16: graph.v1.AddEdgesRequest.edges:type_name -> graph.v1.Edge
+	2,  // 17: graph.v1.PutEdgesRequest.edges:type_name -> graph.v1.Edge
 	4,  // 18: graph.v1.LanternService.Illuminate:input_type -> graph.v1.IlluminateRequest
 	6,  // 19: graph.v1.LanternService.GetVertex:input_type -> graph.v1.GetVertexRequest
 	8,  // 20: graph.v1.LanternService.GetVertices:input_type -> graph.v1.GetVerticesRequest
-	10, // 21: graph.v1.LanternService.PutVertex:input_type -> graph.v1.PutVertexRequest
+	10, // 21: graph.v1.LanternService.PutVertices:input_type -> graph.v1.PutVerticesRequest
 	12, // 22: graph.v1.LanternService.DeleteVertex:input_type -> graph.v1.DeleteVertexRequest
 	14, // 23: graph.v1.LanternService.DeleteVertices:input_type -> graph.v1.DeleteVerticesRequest
 	16, // 24: graph.v1.LanternService.GetEdge:input_type -> graph.v1.GetEdgeRequest
 	18, // 25: graph.v1.LanternService.GetEdges:input_type -> graph.v1.GetEdgesRequest
-	25, // 26: graph.v1.LanternService.AddEdge:input_type -> graph.v1.AddEdgeRequest
-	27, // 27: graph.v1.LanternService.PutEdge:input_type -> graph.v1.PutEdgeRequest
+	25, // 26: graph.v1.LanternService.AddEdges:input_type -> graph.v1.AddEdgesRequest
+	27, // 27: graph.v1.LanternService.PutEdges:input_type -> graph.v1.PutEdgesRequest
 	20, // 28: graph.v1.LanternService.DeleteEdge:input_type -> graph.v1.DeleteEdgeRequest
 	23, // 29: graph.v1.LanternService.DeleteEdges:input_type -> graph.v1.DeleteEdgesRequest
 	5,  // 30: graph.v1.LanternService.Illuminate:output_type -> graph.v1.IlluminateResponse
 	7,  // 31: graph.v1.LanternService.GetVertex:output_type -> graph.v1.GetVertexResponse
 	9,  // 32: graph.v1.LanternService.GetVertices:output_type -> graph.v1.GetVerticesResponse
-	11, // 33: graph.v1.LanternService.PutVertex:output_type -> graph.v1.PutVertexResponse
+	11, // 33: graph.v1.LanternService.PutVertices:output_type -> graph.v1.PutVerticesResponse
 	13, // 34: graph.v1.LanternService.DeleteVertex:output_type -> graph.v1.DeleteVertexResponse
 	15, // 35: graph.v1.LanternService.DeleteVertices:output_type -> graph.v1.DeleteVerticesResponse
 	17, // 36: graph.v1.LanternService.GetEdge:output_type -> graph.v1.GetEdgeResponse
 	19, // 37: graph.v1.LanternService.GetEdges:output_type -> graph.v1.GetEdgesResponse
-	26, // 38: graph.v1.LanternService.AddEdge:output_type -> graph.v1.AddEdgeResponse
-	28, // 39: graph.v1.LanternService.PutEdge:output_type -> graph.v1.PutEdgeResponse
+	26, // 38: graph.v1.LanternService.AddEdges:output_type -> graph.v1.AddEdgesResponse
+	28, // 39: graph.v1.LanternService.PutEdges:output_type -> graph.v1.PutEdgesResponse
 	21, // 40: graph.v1.LanternService.DeleteEdge:output_type -> graph.v1.DeleteEdgeResponse
 	24, // 41: graph.v1.LanternService.DeleteEdges:output_type -> graph.v1.DeleteEdgesResponse
 	30, // [30:42] is the sub-list for method output_type

--- a/sdks/go/gen/graph/v1/graph.pb.gw.go
+++ b/sdks/go/gen/graph/v1/graph.pb.gw.go
@@ -154,9 +154,9 @@ func local_request_LanternService_GetVertices_0(ctx context.Context, marshaler r
 	return msg, metadata, err
 }
 
-func request_LanternService_PutVertex_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func request_LanternService_PutVertices_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq PutVertexRequest
+		protoReq PutVerticesRequest
 		metadata runtime.ServerMetadata
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
@@ -165,19 +165,19 @@ func request_LanternService_PutVertex_0(ctx context.Context, marshaler runtime.M
 	if req.Body != nil {
 		_, _ = io.Copy(io.Discard, req.Body)
 	}
-	msg, err := client.PutVertex(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	msg, err := client.PutVertices(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
 
-func local_request_LanternService_PutVertex_0(ctx context.Context, marshaler runtime.Marshaler, server LanternServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func local_request_LanternService_PutVertices_0(ctx context.Context, marshaler runtime.Marshaler, server LanternServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq PutVertexRequest
+		protoReq PutVerticesRequest
 		metadata runtime.ServerMetadata
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	msg, err := server.PutVertex(ctx, &protoReq)
+	msg, err := server.PutVertices(ctx, &protoReq)
 	return msg, metadata, err
 }
 
@@ -329,9 +329,9 @@ func local_request_LanternService_GetEdges_0(ctx context.Context, marshaler runt
 	return msg, metadata, err
 }
 
-func request_LanternService_AddEdge_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func request_LanternService_AddEdges_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq AddEdgeRequest
+		protoReq AddEdgesRequest
 		metadata runtime.ServerMetadata
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
@@ -340,25 +340,25 @@ func request_LanternService_AddEdge_0(ctx context.Context, marshaler runtime.Mar
 	if req.Body != nil {
 		_, _ = io.Copy(io.Discard, req.Body)
 	}
-	msg, err := client.AddEdge(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	msg, err := client.AddEdges(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
 
-func local_request_LanternService_AddEdge_0(ctx context.Context, marshaler runtime.Marshaler, server LanternServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func local_request_LanternService_AddEdges_0(ctx context.Context, marshaler runtime.Marshaler, server LanternServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq AddEdgeRequest
+		protoReq AddEdgesRequest
 		metadata runtime.ServerMetadata
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	msg, err := server.AddEdge(ctx, &protoReq)
+	msg, err := server.AddEdges(ctx, &protoReq)
 	return msg, metadata, err
 }
 
-func request_LanternService_PutEdge_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func request_LanternService_PutEdges_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq PutEdgeRequest
+		protoReq PutEdgesRequest
 		metadata runtime.ServerMetadata
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
@@ -367,19 +367,19 @@ func request_LanternService_PutEdge_0(ctx context.Context, marshaler runtime.Mar
 	if req.Body != nil {
 		_, _ = io.Copy(io.Discard, req.Body)
 	}
-	msg, err := client.PutEdge(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	msg, err := client.PutEdges(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
 
-func local_request_LanternService_PutEdge_0(ctx context.Context, marshaler runtime.Marshaler, server LanternServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func local_request_LanternService_PutEdges_0(ctx context.Context, marshaler runtime.Marshaler, server LanternServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq PutEdgeRequest
+		protoReq PutEdgesRequest
 		metadata runtime.ServerMetadata
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	msg, err := server.PutEdge(ctx, &protoReq)
+	msg, err := server.PutEdges(ctx, &protoReq)
 	return msg, metadata, err
 }
 
@@ -531,25 +531,25 @@ func RegisterLanternServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 		}
 		forward_LanternService_GetVertices_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPut, pattern_LanternService_PutVertex_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPut, pattern_LanternService_PutVertices_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/graph.v1.LanternService/PutVertex", runtime.WithHTTPPathPattern("/v1/vertices"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/graph.v1.LanternService/PutVertices", runtime.WithHTTPPathPattern("/v1/vertices"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := local_request_LanternService_PutVertex_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		resp, md, err := local_request_LanternService_PutVertices_0(annotatedContext, inboundMarshaler, server, req, pathParams)
 		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_LanternService_PutVertex_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_LanternService_PutVertices_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodDelete, pattern_LanternService_DeleteVertex_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -631,45 +631,45 @@ func RegisterLanternServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 		}
 		forward_LanternService_GetEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPost, pattern_LanternService_AddEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPost, pattern_LanternService_AddEdges_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/graph.v1.LanternService/AddEdge", runtime.WithHTTPPathPattern("/v1/edges/add"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/graph.v1.LanternService/AddEdges", runtime.WithHTTPPathPattern("/v1/edges/add"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := local_request_LanternService_AddEdge_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		resp, md, err := local_request_LanternService_AddEdges_0(annotatedContext, inboundMarshaler, server, req, pathParams)
 		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_LanternService_AddEdge_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_LanternService_AddEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPut, pattern_LanternService_PutEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPut, pattern_LanternService_PutEdges_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/graph.v1.LanternService/PutEdge", runtime.WithHTTPPathPattern("/v1/edges/put"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/graph.v1.LanternService/PutEdges", runtime.WithHTTPPathPattern("/v1/edges/put"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := local_request_LanternService_PutEdge_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		resp, md, err := local_request_LanternService_PutEdges_0(annotatedContext, inboundMarshaler, server, req, pathParams)
 		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_LanternService_PutEdge_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_LanternService_PutEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodDelete, pattern_LanternService_DeleteEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -802,22 +802,22 @@ func RegisterLanternServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 		}
 		forward_LanternService_GetVertices_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPut, pattern_LanternService_PutVertex_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPut, pattern_LanternService_PutVertices_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/graph.v1.LanternService/PutVertex", runtime.WithHTTPPathPattern("/v1/vertices"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/graph.v1.LanternService/PutVertices", runtime.WithHTTPPathPattern("/v1/vertices"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_LanternService_PutVertex_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_LanternService_PutVertices_0(annotatedContext, inboundMarshaler, client, req, pathParams)
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_LanternService_PutVertex_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_LanternService_PutVertices_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodDelete, pattern_LanternService_DeleteVertex_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -887,39 +887,39 @@ func RegisterLanternServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 		}
 		forward_LanternService_GetEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPost, pattern_LanternService_AddEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPost, pattern_LanternService_AddEdges_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/graph.v1.LanternService/AddEdge", runtime.WithHTTPPathPattern("/v1/edges/add"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/graph.v1.LanternService/AddEdges", runtime.WithHTTPPathPattern("/v1/edges/add"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_LanternService_AddEdge_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_LanternService_AddEdges_0(annotatedContext, inboundMarshaler, client, req, pathParams)
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_LanternService_AddEdge_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_LanternService_AddEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPut, pattern_LanternService_PutEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPut, pattern_LanternService_PutEdges_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/graph.v1.LanternService/PutEdge", runtime.WithHTTPPathPattern("/v1/edges/put"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/graph.v1.LanternService/PutEdges", runtime.WithHTTPPathPattern("/v1/edges/put"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_LanternService_PutEdge_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_LanternService_PutEdges_0(annotatedContext, inboundMarshaler, client, req, pathParams)
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_LanternService_PutEdge_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_LanternService_PutEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodDelete, pattern_LanternService_DeleteEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -962,13 +962,13 @@ var (
 	pattern_LanternService_Illuminate_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "illuminate", "seed"}, ""))
 	pattern_LanternService_GetVertex_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "vertices", "key"}, ""))
 	pattern_LanternService_GetVertices_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "vertices", "get"}, ""))
-	pattern_LanternService_PutVertex_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "vertices"}, ""))
+	pattern_LanternService_PutVertices_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "vertices"}, ""))
 	pattern_LanternService_DeleteVertex_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "vertices", "key"}, ""))
 	pattern_LanternService_DeleteVertices_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "vertices", "delete"}, ""))
 	pattern_LanternService_GetEdge_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "edges", "tail", "head"}, ""))
 	pattern_LanternService_GetEdges_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "get"}, ""))
-	pattern_LanternService_AddEdge_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "add"}, ""))
-	pattern_LanternService_PutEdge_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "put"}, ""))
+	pattern_LanternService_AddEdges_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "add"}, ""))
+	pattern_LanternService_PutEdges_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "put"}, ""))
 	pattern_LanternService_DeleteEdge_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "edges", "tail", "head"}, ""))
 	pattern_LanternService_DeleteEdges_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "delete"}, ""))
 )
@@ -977,13 +977,13 @@ var (
 	forward_LanternService_Illuminate_0     = runtime.ForwardResponseMessage
 	forward_LanternService_GetVertex_0      = runtime.ForwardResponseMessage
 	forward_LanternService_GetVertices_0    = runtime.ForwardResponseMessage
-	forward_LanternService_PutVertex_0      = runtime.ForwardResponseMessage
+	forward_LanternService_PutVertices_0    = runtime.ForwardResponseMessage
 	forward_LanternService_DeleteVertex_0   = runtime.ForwardResponseMessage
 	forward_LanternService_DeleteVertices_0 = runtime.ForwardResponseMessage
 	forward_LanternService_GetEdge_0        = runtime.ForwardResponseMessage
 	forward_LanternService_GetEdges_0       = runtime.ForwardResponseMessage
-	forward_LanternService_AddEdge_0        = runtime.ForwardResponseMessage
-	forward_LanternService_PutEdge_0        = runtime.ForwardResponseMessage
+	forward_LanternService_AddEdges_0       = runtime.ForwardResponseMessage
+	forward_LanternService_PutEdges_0       = runtime.ForwardResponseMessage
 	forward_LanternService_DeleteEdge_0     = runtime.ForwardResponseMessage
 	forward_LanternService_DeleteEdges_0    = runtime.ForwardResponseMessage
 )

--- a/sdks/go/gen/graph/v1/graph_grpc.pb.go
+++ b/sdks/go/gen/graph/v1/graph_grpc.pb.go
@@ -22,13 +22,13 @@ const (
 	LanternService_Illuminate_FullMethodName     = "/graph.v1.LanternService/Illuminate"
 	LanternService_GetVertex_FullMethodName      = "/graph.v1.LanternService/GetVertex"
 	LanternService_GetVertices_FullMethodName    = "/graph.v1.LanternService/GetVertices"
-	LanternService_PutVertex_FullMethodName      = "/graph.v1.LanternService/PutVertex"
+	LanternService_PutVertices_FullMethodName    = "/graph.v1.LanternService/PutVertices"
 	LanternService_DeleteVertex_FullMethodName   = "/graph.v1.LanternService/DeleteVertex"
 	LanternService_DeleteVertices_FullMethodName = "/graph.v1.LanternService/DeleteVertices"
 	LanternService_GetEdge_FullMethodName        = "/graph.v1.LanternService/GetEdge"
 	LanternService_GetEdges_FullMethodName       = "/graph.v1.LanternService/GetEdges"
-	LanternService_AddEdge_FullMethodName        = "/graph.v1.LanternService/AddEdge"
-	LanternService_PutEdge_FullMethodName        = "/graph.v1.LanternService/PutEdge"
+	LanternService_AddEdges_FullMethodName       = "/graph.v1.LanternService/AddEdges"
+	LanternService_PutEdges_FullMethodName       = "/graph.v1.LanternService/PutEdges"
 	LanternService_DeleteEdge_FullMethodName     = "/graph.v1.LanternService/DeleteEdge"
 	LanternService_DeleteEdges_FullMethodName    = "/graph.v1.LanternService/DeleteEdges"
 )
@@ -41,17 +41,17 @@ type LanternServiceClient interface {
 	GetVertex(ctx context.Context, in *GetVertexRequest, opts ...grpc.CallOption) (*GetVertexResponse, error)
 	// GetVertices reads several vertices in one round trip.
 	GetVertices(ctx context.Context, in *GetVerticesRequest, opts ...grpc.CallOption) (*GetVerticesResponse, error)
-	PutVertex(ctx context.Context, in *PutVertexRequest, opts ...grpc.CallOption) (*PutVertexResponse, error)
+	PutVertices(ctx context.Context, in *PutVerticesRequest, opts ...grpc.CallOption) (*PutVerticesResponse, error)
 	DeleteVertex(ctx context.Context, in *DeleteVertexRequest, opts ...grpc.CallOption) (*DeleteVertexResponse, error)
 	// DeleteVertices removes several vertices in one round trip.
 	DeleteVertices(ctx context.Context, in *DeleteVerticesRequest, opts ...grpc.CallOption) (*DeleteVerticesResponse, error)
 	GetEdge(ctx context.Context, in *GetEdgeRequest, opts ...grpc.CallOption) (*GetEdgeResponse, error)
 	// GetEdges reads several edges in one round trip.
 	GetEdges(ctx context.Context, in *GetEdgesRequest, opts ...grpc.CallOption) (*GetEdgesResponse, error)
-	// AddEdge is non-idempotent (accumulates weight). POST per REST conventions.
-	AddEdge(ctx context.Context, in *AddEdgeRequest, opts ...grpc.CallOption) (*AddEdgeResponse, error)
-	// PutEdge is idempotent (replaces weight). PUT per REST conventions.
-	PutEdge(ctx context.Context, in *PutEdgeRequest, opts ...grpc.CallOption) (*PutEdgeResponse, error)
+	// AddEdges is non-idempotent (accumulates weight). POST per REST conventions.
+	AddEdges(ctx context.Context, in *AddEdgesRequest, opts ...grpc.CallOption) (*AddEdgesResponse, error)
+	// PutEdges is idempotent (replaces weight). PUT per REST conventions.
+	PutEdges(ctx context.Context, in *PutEdgesRequest, opts ...grpc.CallOption) (*PutEdgesResponse, error)
 	DeleteEdge(ctx context.Context, in *DeleteEdgeRequest, opts ...grpc.CallOption) (*DeleteEdgeResponse, error)
 	// DeleteEdges removes several edges in one round trip.
 	DeleteEdges(ctx context.Context, in *DeleteEdgesRequest, opts ...grpc.CallOption) (*DeleteEdgesResponse, error)
@@ -95,10 +95,10 @@ func (c *lanternServiceClient) GetVertices(ctx context.Context, in *GetVerticesR
 	return out, nil
 }
 
-func (c *lanternServiceClient) PutVertex(ctx context.Context, in *PutVertexRequest, opts ...grpc.CallOption) (*PutVertexResponse, error) {
+func (c *lanternServiceClient) PutVertices(ctx context.Context, in *PutVerticesRequest, opts ...grpc.CallOption) (*PutVerticesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(PutVertexResponse)
-	err := c.cc.Invoke(ctx, LanternService_PutVertex_FullMethodName, in, out, cOpts...)
+	out := new(PutVerticesResponse)
+	err := c.cc.Invoke(ctx, LanternService_PutVertices_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -145,20 +145,20 @@ func (c *lanternServiceClient) GetEdges(ctx context.Context, in *GetEdgesRequest
 	return out, nil
 }
 
-func (c *lanternServiceClient) AddEdge(ctx context.Context, in *AddEdgeRequest, opts ...grpc.CallOption) (*AddEdgeResponse, error) {
+func (c *lanternServiceClient) AddEdges(ctx context.Context, in *AddEdgesRequest, opts ...grpc.CallOption) (*AddEdgesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(AddEdgeResponse)
-	err := c.cc.Invoke(ctx, LanternService_AddEdge_FullMethodName, in, out, cOpts...)
+	out := new(AddEdgesResponse)
+	err := c.cc.Invoke(ctx, LanternService_AddEdges_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *lanternServiceClient) PutEdge(ctx context.Context, in *PutEdgeRequest, opts ...grpc.CallOption) (*PutEdgeResponse, error) {
+func (c *lanternServiceClient) PutEdges(ctx context.Context, in *PutEdgesRequest, opts ...grpc.CallOption) (*PutEdgesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(PutEdgeResponse)
-	err := c.cc.Invoke(ctx, LanternService_PutEdge_FullMethodName, in, out, cOpts...)
+	out := new(PutEdgesResponse)
+	err := c.cc.Invoke(ctx, LanternService_PutEdges_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -193,17 +193,17 @@ type LanternServiceServer interface {
 	GetVertex(context.Context, *GetVertexRequest) (*GetVertexResponse, error)
 	// GetVertices reads several vertices in one round trip.
 	GetVertices(context.Context, *GetVerticesRequest) (*GetVerticesResponse, error)
-	PutVertex(context.Context, *PutVertexRequest) (*PutVertexResponse, error)
+	PutVertices(context.Context, *PutVerticesRequest) (*PutVerticesResponse, error)
 	DeleteVertex(context.Context, *DeleteVertexRequest) (*DeleteVertexResponse, error)
 	// DeleteVertices removes several vertices in one round trip.
 	DeleteVertices(context.Context, *DeleteVerticesRequest) (*DeleteVerticesResponse, error)
 	GetEdge(context.Context, *GetEdgeRequest) (*GetEdgeResponse, error)
 	// GetEdges reads several edges in one round trip.
 	GetEdges(context.Context, *GetEdgesRequest) (*GetEdgesResponse, error)
-	// AddEdge is non-idempotent (accumulates weight). POST per REST conventions.
-	AddEdge(context.Context, *AddEdgeRequest) (*AddEdgeResponse, error)
-	// PutEdge is idempotent (replaces weight). PUT per REST conventions.
-	PutEdge(context.Context, *PutEdgeRequest) (*PutEdgeResponse, error)
+	// AddEdges is non-idempotent (accumulates weight). POST per REST conventions.
+	AddEdges(context.Context, *AddEdgesRequest) (*AddEdgesResponse, error)
+	// PutEdges is idempotent (replaces weight). PUT per REST conventions.
+	PutEdges(context.Context, *PutEdgesRequest) (*PutEdgesResponse, error)
 	DeleteEdge(context.Context, *DeleteEdgeRequest) (*DeleteEdgeResponse, error)
 	// DeleteEdges removes several edges in one round trip.
 	DeleteEdges(context.Context, *DeleteEdgesRequest) (*DeleteEdgesResponse, error)
@@ -225,8 +225,8 @@ func (UnimplementedLanternServiceServer) GetVertex(context.Context, *GetVertexRe
 func (UnimplementedLanternServiceServer) GetVertices(context.Context, *GetVerticesRequest) (*GetVerticesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetVertices not implemented")
 }
-func (UnimplementedLanternServiceServer) PutVertex(context.Context, *PutVertexRequest) (*PutVertexResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method PutVertex not implemented")
+func (UnimplementedLanternServiceServer) PutVertices(context.Context, *PutVerticesRequest) (*PutVerticesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PutVertices not implemented")
 }
 func (UnimplementedLanternServiceServer) DeleteVertex(context.Context, *DeleteVertexRequest) (*DeleteVertexResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteVertex not implemented")
@@ -240,11 +240,11 @@ func (UnimplementedLanternServiceServer) GetEdge(context.Context, *GetEdgeReques
 func (UnimplementedLanternServiceServer) GetEdges(context.Context, *GetEdgesRequest) (*GetEdgesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetEdges not implemented")
 }
-func (UnimplementedLanternServiceServer) AddEdge(context.Context, *AddEdgeRequest) (*AddEdgeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method AddEdge not implemented")
+func (UnimplementedLanternServiceServer) AddEdges(context.Context, *AddEdgesRequest) (*AddEdgesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method AddEdges not implemented")
 }
-func (UnimplementedLanternServiceServer) PutEdge(context.Context, *PutEdgeRequest) (*PutEdgeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method PutEdge not implemented")
+func (UnimplementedLanternServiceServer) PutEdges(context.Context, *PutEdgesRequest) (*PutEdgesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PutEdges not implemented")
 }
 func (UnimplementedLanternServiceServer) DeleteEdge(context.Context, *DeleteEdgeRequest) (*DeleteEdgeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteEdge not implemented")
@@ -326,20 +326,20 @@ func _LanternService_GetVertices_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
-func _LanternService_PutVertex_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(PutVertexRequest)
+func _LanternService_PutVertices_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PutVerticesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(LanternServiceServer).PutVertex(ctx, in)
+		return srv.(LanternServiceServer).PutVertices(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: LanternService_PutVertex_FullMethodName,
+		FullMethod: LanternService_PutVertices_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(LanternServiceServer).PutVertex(ctx, req.(*PutVertexRequest))
+		return srv.(LanternServiceServer).PutVertices(ctx, req.(*PutVerticesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -416,38 +416,38 @@ func _LanternService_GetEdges_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
-func _LanternService_AddEdge_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(AddEdgeRequest)
+func _LanternService_AddEdges_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AddEdgesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(LanternServiceServer).AddEdge(ctx, in)
+		return srv.(LanternServiceServer).AddEdges(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: LanternService_AddEdge_FullMethodName,
+		FullMethod: LanternService_AddEdges_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(LanternServiceServer).AddEdge(ctx, req.(*AddEdgeRequest))
+		return srv.(LanternServiceServer).AddEdges(ctx, req.(*AddEdgesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _LanternService_PutEdge_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(PutEdgeRequest)
+func _LanternService_PutEdges_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PutEdgesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(LanternServiceServer).PutEdge(ctx, in)
+		return srv.(LanternServiceServer).PutEdges(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: LanternService_PutEdge_FullMethodName,
+		FullMethod: LanternService_PutEdges_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(LanternServiceServer).PutEdge(ctx, req.(*PutEdgeRequest))
+		return srv.(LanternServiceServer).PutEdges(ctx, req.(*PutEdgesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -508,8 +508,8 @@ var LanternService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _LanternService_GetVertices_Handler,
 		},
 		{
-			MethodName: "PutVertex",
-			Handler:    _LanternService_PutVertex_Handler,
+			MethodName: "PutVertices",
+			Handler:    _LanternService_PutVertices_Handler,
 		},
 		{
 			MethodName: "DeleteVertex",
@@ -528,12 +528,12 @@ var LanternService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _LanternService_GetEdges_Handler,
 		},
 		{
-			MethodName: "AddEdge",
-			Handler:    _LanternService_AddEdge_Handler,
+			MethodName: "AddEdges",
+			Handler:    _LanternService_AddEdges_Handler,
 		},
 		{
-			MethodName: "PutEdge",
-			Handler:    _LanternService_PutEdge_Handler,
+			MethodName: "PutEdges",
+			Handler:    _LanternService_PutEdges_Handler,
 		},
 		{
 			MethodName: "DeleteEdge",

--- a/sdks/go/gen/openapiv2/graph/v1/graph.swagger.json
+++ b/sdks/go/gen/openapiv2/graph/v1/graph.swagger.json
@@ -18,13 +18,13 @@
   "paths": {
     "/v1/edges/add": {
       "post": {
-        "summary": "AddEdge is non-idempotent (accumulates weight). POST per REST conventions.",
-        "operationId": "LanternService_AddEdge",
+        "summary": "AddEdges is non-idempotent (accumulates weight). POST per REST conventions.",
+        "operationId": "LanternService_AddEdges",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1AddEdgeResponse"
+              "$ref": "#/definitions/v1AddEdgesResponse"
             }
           },
           "default": {
@@ -37,11 +37,11 @@
         "parameters": [
           {
             "name": "body",
-            "description": "AddEdgeRequest accumulates weight onto each (tail, head) pair: repeated\ncalls with the same endpoints sum their weights. This operation is\nnon-idempotent.",
+            "description": "AddEdgesRequest accumulates weight onto each (tail, head) pair: repeated\ncalls with the same endpoints sum their weights. This operation is\nnon-idempotent.",
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1AddEdgeRequest"
+              "$ref": "#/definitions/v1AddEdgesRequest"
             }
           }
         ],
@@ -120,13 +120,13 @@
     },
     "/v1/edges/put": {
       "put": {
-        "summary": "PutEdge is idempotent (replaces weight). PUT per REST conventions.",
-        "operationId": "LanternService_PutEdge",
+        "summary": "PutEdges is idempotent (replaces weight). PUT per REST conventions.",
+        "operationId": "LanternService_PutEdges",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1PutEdgeResponse"
+              "$ref": "#/definitions/v1PutEdgesResponse"
             }
           },
           "default": {
@@ -139,11 +139,11 @@
         "parameters": [
           {
             "name": "body",
-            "description": "PutEdgeRequest overwrites each (tail, head) pair, replacing any existing\nweight and expiration. This operation is idempotent.",
+            "description": "PutEdgesRequest overwrites each (tail, head) pair, replacing any existing\nweight and expiration. This operation is idempotent.",
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1PutEdgeRequest"
+              "$ref": "#/definitions/v1PutEdgesRequest"
             }
           }
         ],
@@ -288,12 +288,12 @@
     },
     "/v1/vertices": {
       "put": {
-        "operationId": "LanternService_PutVertex",
+        "operationId": "LanternService_PutVertices",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1PutVertexResponse"
+              "$ref": "#/definitions/v1PutVerticesResponse"
             }
           },
           "default": {
@@ -306,11 +306,11 @@
         "parameters": [
           {
             "name": "body",
-            "description": "PutVertexRequest writes vertices with upsert semantics: each Vertex.key\nreplaces any existing value at that key. Use the Vertex.expiration field\n(absolute time) to control TTL.",
+            "description": "PutVerticesRequest writes vertices with upsert semantics: each Vertex.key\nreplaces any existing value at that key. Use the Vertex.expiration field\n(absolute time) to control TTL.",
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1PutVertexRequest"
+              "$ref": "#/definitions/v1PutVerticesRequest"
             }
           }
         ],
@@ -475,7 +475,7 @@
         }
       }
     },
-    "v1AddEdgeRequest": {
+    "v1AddEdgesRequest": {
       "type": "object",
       "properties": {
         "edges": {
@@ -486,9 +486,9 @@
           }
         }
       },
-      "description": "AddEdgeRequest accumulates weight onto each (tail, head) pair: repeated\ncalls with the same endpoints sum their weights. This operation is\nnon-idempotent."
+      "description": "AddEdgesRequest accumulates weight onto each (tail, head) pair: repeated\ncalls with the same endpoints sum their weights. This operation is\nnon-idempotent."
     },
-    "v1AddEdgeResponse": {
+    "v1AddEdgesResponse": {
       "type": "object",
       "properties": {
         "written": {
@@ -712,7 +712,7 @@
       ],
       "default": "OPTIMIZATION_UNSPECIFIED"
     },
-    "v1PutEdgeRequest": {
+    "v1PutEdgesRequest": {
       "type": "object",
       "properties": {
         "edges": {
@@ -723,9 +723,9 @@
           }
         }
       },
-      "description": "PutEdgeRequest overwrites each (tail, head) pair, replacing any existing\nweight and expiration. This operation is idempotent."
+      "description": "PutEdgesRequest overwrites each (tail, head) pair, replacing any existing\nweight and expiration. This operation is idempotent."
     },
-    "v1PutEdgeResponse": {
+    "v1PutEdgesResponse": {
       "type": "object",
       "properties": {
         "written": {
@@ -735,7 +735,7 @@
         }
       }
     },
-    "v1PutVertexRequest": {
+    "v1PutVerticesRequest": {
       "type": "object",
       "properties": {
         "vertices": {
@@ -746,9 +746,9 @@
           }
         }
       },
-      "description": "PutVertexRequest writes vertices with upsert semantics: each Vertex.key\nreplaces any existing value at that key. Use the Vertex.expiration field\n(absolute time) to control TTL."
+      "description": "PutVerticesRequest writes vertices with upsert semantics: each Vertex.key\nreplaces any existing value at that key. Use the Vertex.expiration field\n(absolute time) to control TTL."
     },
-    "v1PutVertexResponse": {
+    "v1PutVerticesResponse": {
       "type": "object",
       "properties": {
         "written": {

--- a/server/provider/extra.go
+++ b/server/provider/extra.go
@@ -90,7 +90,7 @@ func (v *ValidationInterceptor) validate(req any) error {
 				return err
 			}
 		}
-	case *pb.PutVertexRequest:
+	case *pb.PutVerticesRequest:
 		if err := v.checkBatch(len(r.GetVertices())); err != nil {
 			return err
 		}
@@ -142,9 +142,9 @@ func (v *ValidationInterceptor) validate(req any) error {
 				return err
 			}
 		}
-	case *pb.AddEdgeRequest:
+	case *pb.AddEdgesRequest:
 		return v.validateEdges(r.GetEdges())
-	case *pb.PutEdgeRequest:
+	case *pb.PutEdgesRequest:
 		return v.validateEdges(r.GetEdges())
 	case *pb.IlluminateRequest:
 		if err := v.checkKey("seed", r.GetSeed()); err != nil {

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -145,7 +145,7 @@ func (s *LanternService) GetVertices(ctx context.Context, request *pb.GetVertice
 	return resp, nil
 }
 
-func (s *LanternService) PutVertex(ctx context.Context, request *pb.PutVertexRequest) (*pb.PutVertexResponse, error) {
+func (s *LanternService) PutVertices(ctx context.Context, request *pb.PutVerticesRequest) (*pb.PutVerticesResponse, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
@@ -154,7 +154,7 @@ func (s *LanternService) PutVertex(ctx context.Context, request *pb.PutVertexReq
 		s.cache.AddVertexWithExpiration(v.GetKey(), v, v.GetExpiration().AsTime())
 		written++
 	}
-	return &pb.PutVertexResponse{Written: written}, nil
+	return &pb.PutVerticesResponse{Written: written}, nil
 }
 
 func (s *LanternService) DeleteVertex(ctx context.Context, in *pb.DeleteVertexRequest) (*pb.DeleteVertexResponse, error) {
@@ -220,7 +220,7 @@ func (s *LanternService) GetEdges(ctx context.Context, request *pb.GetEdgesReque
 	return resp, nil
 }
 
-func (s *LanternService) AddEdge(ctx context.Context, request *pb.AddEdgeRequest) (*pb.AddEdgeResponse, error) {
+func (s *LanternService) AddEdges(ctx context.Context, request *pb.AddEdgesRequest) (*pb.AddEdgesResponse, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
@@ -229,10 +229,10 @@ func (s *LanternService) AddEdge(ctx context.Context, request *pb.AddEdgeRequest
 		s.cache.AddEdgeWithExpiration(e.GetTail(), e.GetHead(), e.GetWeight(), e.GetExpiration().AsTime())
 		written++
 	}
-	return &pb.AddEdgeResponse{Written: written}, nil
+	return &pb.AddEdgesResponse{Written: written}, nil
 }
 
-func (s *LanternService) PutEdge(ctx context.Context, request *pb.PutEdgeRequest) (*pb.PutEdgeResponse, error) {
+func (s *LanternService) PutEdges(ctx context.Context, request *pb.PutEdgesRequest) (*pb.PutEdgesResponse, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
@@ -244,7 +244,7 @@ func (s *LanternService) PutEdge(ctx context.Context, request *pb.PutEdgeRequest
 		s.cache.PutEdgeWithExpiration(e.GetTail(), e.GetHead(), e.GetWeight(), e.GetExpiration().AsTime())
 		written++
 	}
-	return &pb.PutEdgeResponse{Written: written}, nil
+	return &pb.PutEdgesResponse{Written: written}, nil
 }
 
 func (s *LanternService) DeleteEdge(ctx context.Context, in *pb.DeleteEdgeRequest) (*pb.DeleteEdgeResponse, error) {

--- a/server/service/service_bufconn_test.go
+++ b/server/service/service_bufconn_test.go
@@ -62,7 +62,7 @@ func TestBufconn_PutGetVertex_NilValueRoundTrip(t *testing.T) {
 	defer cleanup()
 
 	v := &pb.Vertex{Key: "n", Value: &pb.Vertex_Nil{Nil: true}, Expiration: bufconnExp(time.Minute)}
-	if _, err := c.PutVertex(ctx, &pb.PutVertexRequest{Vertices: []*pb.Vertex{v}}); err != nil {
+	if _, err := c.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: []*pb.Vertex{v}}); err != nil {
 		t.Fatalf("PutVertex: %v", err)
 	}
 
@@ -91,7 +91,7 @@ func TestBufconn_AddEdge_IsAdditive(t *testing.T) {
 
 	edge := &pb.Edge{Tail: "a", Head: "b", Weight: 1.5, Expiration: bufconnExp(time.Minute)}
 	for i := 0; i < 2; i++ {
-		if _, err := c.AddEdge(ctx, &pb.AddEdgeRequest{Edges: []*pb.Edge{edge}}); err != nil {
+		if _, err := c.AddEdges(ctx, &pb.AddEdgesRequest{Edges: []*pb.Edge{edge}}); err != nil {
 			t.Fatalf("AddEdge %d: %v", i, err)
 		}
 	}
@@ -111,10 +111,10 @@ func TestBufconn_PutEdge_IsIdempotent(t *testing.T) {
 
 	first := &pb.Edge{Tail: "a", Head: "b", Weight: 1.5, Expiration: bufconnExp(time.Minute)}
 	second := &pb.Edge{Tail: "a", Head: "b", Weight: 9.0, Expiration: bufconnExp(time.Minute)}
-	if _, err := c.PutEdge(ctx, &pb.PutEdgeRequest{Edges: []*pb.Edge{first}}); err != nil {
+	if _, err := c.PutEdges(ctx, &pb.PutEdgesRequest{Edges: []*pb.Edge{first}}); err != nil {
 		t.Fatalf("PutEdge 1: %v", err)
 	}
-	if _, err := c.PutEdge(ctx, &pb.PutEdgeRequest{Edges: []*pb.Edge{second}}); err != nil {
+	if _, err := c.PutEdges(ctx, &pb.PutEdgesRequest{Edges: []*pb.Edge{second}}); err != nil {
 		t.Fatalf("PutEdge 2: %v", err)
 	}
 
@@ -136,7 +136,7 @@ func TestBufconn_Illuminate_AllOptimizations(t *testing.T) {
 		{Tail: "b", Head: "c", Weight: 1, Expiration: bufconnExp(time.Minute)},
 		{Tail: "a", Head: "c", Weight: 3, Expiration: bufconnExp(time.Minute)},
 	}
-	if _, err := c.PutEdge(ctx, &pb.PutEdgeRequest{Edges: edges}); err != nil {
+	if _, err := c.PutEdges(ctx, &pb.PutEdgesRequest{Edges: edges}); err != nil {
 		t.Fatalf("PutEdge seed: %v", err)
 	}
 
@@ -176,7 +176,7 @@ func TestBufconn_DeleteVertices_HappyPath(t *testing.T) {
 		{Key: "a", Value: &pb.Vertex_Int64{Int64: 1}, Expiration: bufconnExp(time.Minute)},
 		{Key: "b", Value: &pb.Vertex_Int64{Int64: 2}, Expiration: bufconnExp(time.Minute)},
 	}
-	if _, err := c.PutVertex(ctx, &pb.PutVertexRequest{Vertices: vs}); err != nil {
+	if _, err := c.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: vs}); err != nil {
 		t.Fatalf("PutVertex: %v", err)
 	}
 	resp, err := c.DeleteVertices(ctx, &pb.DeleteVerticesRequest{Keys: []string{"a", "b"}})
@@ -201,7 +201,7 @@ func TestBufconn_DeleteEdges_HappyPath(t *testing.T) {
 		{Tail: "a", Head: "b", Weight: 1, Expiration: bufconnExp(time.Minute)},
 		{Tail: "b", Head: "c", Weight: 1, Expiration: bufconnExp(time.Minute)},
 	}
-	if _, err := c.AddEdge(ctx, &pb.AddEdgeRequest{Edges: edges}); err != nil {
+	if _, err := c.AddEdges(ctx, &pb.AddEdgesRequest{Edges: edges}); err != nil {
 		t.Fatalf("AddEdge: %v", err)
 	}
 	resp, err := c.DeleteEdges(ctx, &pb.DeleteEdgesRequest{Edges: []*pb.EdgeKey{
@@ -229,7 +229,7 @@ func TestBufconn_GetVertices_PartialMiss(t *testing.T) {
 		{Key: "a", Value: &pb.Vertex_Int64{Int64: 1}, Expiration: bufconnExp(time.Minute)},
 		{Key: "b", Value: &pb.Vertex_Nil{Nil: true}, Expiration: bufconnExp(time.Minute)},
 	}
-	if _, err := c.PutVertex(ctx, &pb.PutVertexRequest{Vertices: vs}); err != nil {
+	if _, err := c.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: vs}); err != nil {
 		t.Fatalf("PutVertex: %v", err)
 	}
 
@@ -260,7 +260,7 @@ func TestBufconn_GetEdges_PartialMiss(t *testing.T) {
 		{Tail: "a", Head: "b", Weight: 1.5, Expiration: bufconnExp(time.Minute)},
 		{Tail: "b", Head: "c", Weight: 2, Expiration: bufconnExp(time.Minute)},
 	}
-	if _, err := c.AddEdge(ctx, &pb.AddEdgeRequest{Edges: edges}); err != nil {
+	if _, err := c.AddEdges(ctx, &pb.AddEdgesRequest{Edges: edges}); err != nil {
 		t.Fatalf("AddEdge: %v", err)
 	}
 

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -30,7 +30,7 @@ func TestLanternService_PutAndGetVertex(t *testing.T) {
 		Value:      &pb.Vertex_String_{String_: "hello"},
 		Expiration: futureTs(time.Minute),
 	}
-	if _, err := s.PutVertex(ctx, &pb.PutVertexRequest{Vertices: []*pb.Vertex{v}}); err != nil {
+	if _, err := s.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: []*pb.Vertex{v}}); err != nil {
 		t.Fatalf("PutVertex: %v", err)
 	}
 
@@ -58,7 +58,7 @@ func TestLanternService_DeleteVertex(t *testing.T) {
 	s := newTestService(t)
 	ctx := context.Background()
 	v := &pb.Vertex{Key: "x", Value: &pb.Vertex_Int64{Int64: 1}, Expiration: futureTs(time.Minute)}
-	if _, err := s.PutVertex(ctx, &pb.PutVertexRequest{Vertices: []*pb.Vertex{v}}); err != nil {
+	if _, err := s.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: []*pb.Vertex{v}}); err != nil {
 		t.Fatalf("PutVertex: %v", err)
 	}
 	dResp, err := s.DeleteVertex(ctx, &pb.DeleteVertexRequest{Key: "x"})
@@ -85,7 +85,7 @@ func TestLanternService_AddAndGetEdge(t *testing.T) {
 	s := newTestService(t)
 	ctx := context.Background()
 	edge := &pb.Edge{Tail: "a", Head: "b", Weight: 1.25, Expiration: futureTs(time.Minute)}
-	if _, err := s.AddEdge(ctx, &pb.AddEdgeRequest{Edges: []*pb.Edge{edge}}); err != nil {
+	if _, err := s.AddEdges(ctx, &pb.AddEdgesRequest{Edges: []*pb.Edge{edge}}); err != nil {
 		t.Fatalf("AddEdge: %v", err)
 	}
 	resp, err := s.GetEdge(ctx, &pb.GetEdgeRequest{Tail: "a", Head: "b"})
@@ -113,10 +113,10 @@ func TestLanternService_AddEdge_Additive(t *testing.T) {
 	s := newTestService(t)
 	ctx := context.Background()
 	e := &pb.Edge{Tail: "a", Head: "b", Weight: 2, Expiration: futureTs(time.Minute)}
-	if _, err := s.AddEdge(ctx, &pb.AddEdgeRequest{Edges: []*pb.Edge{e}}); err != nil {
+	if _, err := s.AddEdges(ctx, &pb.AddEdgesRequest{Edges: []*pb.Edge{e}}); err != nil {
 		t.Fatalf("AddEdge: %v", err)
 	}
-	if _, err := s.AddEdge(ctx, &pb.AddEdgeRequest{Edges: []*pb.Edge{e}}); err != nil {
+	if _, err := s.AddEdges(ctx, &pb.AddEdgesRequest{Edges: []*pb.Edge{e}}); err != nil {
 		t.Fatalf("AddEdge2: %v", err)
 	}
 	resp, err := s.GetEdge(ctx, &pb.GetEdgeRequest{Tail: "a", Head: "b"})
@@ -133,10 +133,10 @@ func TestLanternService_PutEdge_Replaces(t *testing.T) {
 	s := newTestService(t)
 	ctx := context.Background()
 	e := &pb.Edge{Tail: "a", Head: "b", Weight: 7, Expiration: futureTs(time.Minute)}
-	if _, err := s.PutEdge(ctx, &pb.PutEdgeRequest{Edges: []*pb.Edge{e}}); err != nil {
+	if _, err := s.PutEdges(ctx, &pb.PutEdgesRequest{Edges: []*pb.Edge{e}}); err != nil {
 		t.Fatalf("PutEdge: %v", err)
 	}
-	if _, err := s.PutEdge(ctx, &pb.PutEdgeRequest{Edges: []*pb.Edge{e}}); err != nil {
+	if _, err := s.PutEdges(ctx, &pb.PutEdgesRequest{Edges: []*pb.Edge{e}}); err != nil {
 		t.Fatalf("PutEdge2: %v", err)
 	}
 	resp, err := s.GetEdge(ctx, &pb.GetEdgeRequest{Tail: "a", Head: "b"})
@@ -152,7 +152,7 @@ func TestLanternService_DeleteEdge(t *testing.T) {
 	s := newTestService(t)
 	ctx := context.Background()
 	e := &pb.Edge{Tail: "a", Head: "b", Weight: 1, Expiration: futureTs(time.Minute)}
-	if _, err := s.AddEdge(ctx, &pb.AddEdgeRequest{Edges: []*pb.Edge{e}}); err != nil {
+	if _, err := s.AddEdges(ctx, &pb.AddEdgesRequest{Edges: []*pb.Edge{e}}); err != nil {
 		t.Fatalf("AddEdge: %v", err)
 	}
 	dResp, err := s.DeleteEdge(ctx, &pb.DeleteEdgeRequest{Tail: "a", Head: "b"})
@@ -184,7 +184,7 @@ func seedTriangle(t *testing.T, s *LanternService) {
 		{Key: "b", Value: &pb.Vertex_String_{String_: "B"}, Expiration: exp},
 		{Key: "c", Value: &pb.Vertex_String_{String_: "C"}, Expiration: exp},
 	}
-	if _, err := s.PutVertex(ctx, &pb.PutVertexRequest{Vertices: verts}); err != nil {
+	if _, err := s.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: verts}); err != nil {
 		t.Fatalf("PutVertex: %v", err)
 	}
 	edges := []*pb.Edge{
@@ -195,7 +195,7 @@ func seedTriangle(t *testing.T, s *LanternService) {
 		{Tail: "a", Head: "c", Weight: 10, Expiration: exp},
 		{Tail: "c", Head: "a", Weight: 10, Expiration: exp},
 	}
-	if _, err := s.PutEdge(ctx, &pb.PutEdgeRequest{Edges: edges}); err != nil {
+	if _, err := s.PutEdges(ctx, &pb.PutEdgesRequest{Edges: edges}); err != nil {
 		t.Fatalf("PutEdge: %v", err)
 	}
 }
@@ -250,7 +250,7 @@ func TestLanternService_GetEdge_ReturnsExpiration(t *testing.T) {
 	ctx := context.Background()
 	exp := futureTs(2 * time.Minute)
 	e := &pb.Edge{Tail: "a", Head: "b", Weight: 1, Expiration: exp}
-	if _, err := s.AddEdge(ctx, &pb.AddEdgeRequest{Edges: []*pb.Edge{e}}); err != nil {
+	if _, err := s.AddEdges(ctx, &pb.AddEdgesRequest{Edges: []*pb.Edge{e}}); err != nil {
 		t.Fatalf("AddEdge: %v", err)
 	}
 	resp, err := s.GetEdge(ctx, &pb.GetEdgeRequest{Tail: "a", Head: "b"})
@@ -272,7 +272,7 @@ func TestLanternService_WriteResponses_ReportCounts(t *testing.T) {
 	ctx := context.Background()
 	exp := futureTs(time.Minute)
 
-	vresp, err := s.PutVertex(ctx, &pb.PutVertexRequest{Vertices: []*pb.Vertex{
+	vresp, err := s.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: []*pb.Vertex{
 		{Key: "a", Value: &pb.Vertex_Int64{Int64: 1}, Expiration: exp},
 		{Key: "b", Value: &pb.Vertex_Int64{Int64: 2}, Expiration: exp},
 	}})
@@ -283,7 +283,7 @@ func TestLanternService_WriteResponses_ReportCounts(t *testing.T) {
 		t.Errorf("PutVertex Written = %d, want 2", vresp.Written)
 	}
 
-	aresp, err := s.AddEdge(ctx, &pb.AddEdgeRequest{Edges: []*pb.Edge{
+	aresp, err := s.AddEdges(ctx, &pb.AddEdgesRequest{Edges: []*pb.Edge{
 		{Tail: "a", Head: "b", Weight: 1, Expiration: exp},
 	}})
 	if err != nil {
@@ -293,7 +293,7 @@ func TestLanternService_WriteResponses_ReportCounts(t *testing.T) {
 		t.Errorf("AddEdge Written = %d, want 1", aresp.Written)
 	}
 
-	presp, err := s.PutEdge(ctx, &pb.PutEdgeRequest{Edges: []*pb.Edge{
+	presp, err := s.PutEdges(ctx, &pb.PutEdgesRequest{Edges: []*pb.Edge{
 		{Tail: "a", Head: "b", Weight: 3, Expiration: exp},
 	}})
 	if err != nil {


### PR DESCRIPTION
Closes #74

Renames the three write RPCs that already accepted slices so the contract matches their semantics:
- `PutVertex` → `PutVertices`
- `AddEdge` → `AddEdges`
- `PutEdge` → `PutEdges`

HTTP gateway paths and the Go SDK's singular ergonomic helpers (`PutVertex`, `AddEdge`, `PutEdge`) are preserved — the SDK helpers now wrap the plural RPCs internally with a single-element slice.