### PR TITLE
feat(#76): cache batch APIs with single-lock semantics

### DIFF
--- a/core/cache/graph/batch.go
+++ b/core/cache/graph/batch.go
@@ -1,0 +1,123 @@
+package graph
+
+import "time"
+
+// VertexItem is a single (key, value, expiration) tuple supplied to
+// AddVerticesWithExpiration.
+type VertexItem[S comparable, T any] struct {
+	Key        S
+	Value      T
+	Expiration time.Time
+}
+
+// EdgeItem is a single (tail, head, weight, expiration) tuple supplied to
+// AddEdgesWithExpiration / PutEdgesWithExpiration.
+type EdgeItem[S comparable] struct {
+	Tail       S
+	Head       S
+	Weight     float32
+	Expiration time.Time
+}
+
+// EdgeKey identifies a directed edge for batch deletion via DeleteEdges.
+type EdgeKey[S comparable] struct {
+	Tail S
+	Head S
+}
+
+// AddVerticesWithExpiration writes every supplied vertex under a single
+// write lock. Concurrent readers observe either the pre-batch or the
+// post-batch state — never an intermediate snapshot where some keys are
+// present and others are not.
+func (c *GraphCache[S, T]) AddVerticesWithExpiration(items []VertexItem[S, T]) {
+	if len(items) == 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, it := range items {
+		c.vertices.PutWithExpiration(it.Key, it.Value, it.Expiration)
+	}
+}
+
+// AddEdgesWithExpiration additively writes every supplied edge under a
+// single write lock, auto-creating endpoint vertices on demand (matching
+// the per-edge AddEdgeWithExpiration invariant). Concurrent readers see
+// either the pre-batch or the post-batch state.
+func (c *GraphCache[S, T]) AddEdgesWithExpiration(items []EdgeItem[S]) {
+	if len(items) == 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var noop T
+	for _, it := range items {
+		if !c.vertices.Has(it.Tail) {
+			c.vertices.PutWithExpiration(it.Tail, noop, it.Expiration)
+		}
+		if !c.vertices.Has(it.Head) {
+			c.vertices.PutWithExpiration(it.Head, noop, it.Expiration)
+		}
+		c.edges.addWithExpiration(it.Tail, it.Head, it.Weight, it.Expiration)
+	}
+}
+
+// PutEdgesWithExpiration replaces every supplied edge atomically under a
+// single write lock. Each (tail, head) pair is deleted and re-added so the
+// resulting weight is exactly the supplied weight — matching
+// PutEdgeWithExpiration semantics for each item in the batch.
+func (c *GraphCache[S, T]) PutEdgesWithExpiration(items []EdgeItem[S]) {
+	if len(items) == 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var noop T
+	for _, it := range items {
+		if !c.vertices.Has(it.Tail) {
+			c.vertices.PutWithExpiration(it.Tail, noop, it.Expiration)
+		}
+		if !c.vertices.Has(it.Head) {
+			c.vertices.PutWithExpiration(it.Head, noop, it.Expiration)
+		}
+		c.edges.delete(it.Tail, it.Head)
+		c.edges.addWithExpiration(it.Tail, it.Head, it.Weight, it.Expiration)
+	}
+}
+
+// DeleteVertices removes every supplied vertex under a single write lock
+// and returns the count of keys that were actually present (and therefore
+// deleted). Concurrent readers observe either the pre-batch or the
+// post-batch state.
+func (c *GraphCache[S, T]) DeleteVertices(keys []S) int {
+	if len(keys) == 0 {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var n int
+	for _, k := range keys {
+		if c.vertices.Delete(k) {
+			n++
+		}
+	}
+	return n
+}
+
+// DeleteEdges removes every supplied edge under a single write lock and
+// returns the count of edges that were actually present. Concurrent
+// readers observe either the pre-batch or the post-batch state.
+func (c *GraphCache[S, T]) DeleteEdges(keys []EdgeKey[S]) int {
+	if len(keys) == 0 {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var n int
+	for _, k := range keys {
+		if c.edges.delete(k.Tail, k.Head) {
+			n++
+		}
+	}
+	return n
+}

--- a/core/cache/graph/batch_test.go
+++ b/core/cache/graph/batch_test.go
@@ -1,0 +1,228 @@
+package graph_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/cache/graph"
+)
+
+// TestAddEdgesWithExpiration_AtomicNeighborSnapshot verifies that a
+// concurrent reader using Neighbor (which holds the cache RLock for the
+// duration of a single call) observes either the pre-batch state (no
+// edges) or the post-batch state (all batched edges), never a partial
+// fan-in.
+func TestAddEdgesWithExpiration_AtomicNeighborSnapshot(t *testing.T) {
+	const fanOut = 128
+	c := graph.NewGraphCache[string, int](time.Minute)
+
+	exp := time.Now().Add(time.Minute)
+	c.AddVertexWithExpiration("s", 0, exp)
+
+	addBatch := make([]graph.EdgeItem[string], fanOut)
+	delBatch := make([]graph.EdgeKey[string], fanOut)
+	for i := 0; i < fanOut; i++ {
+		head := "h" + itoa(i)
+		addBatch[i] = graph.EdgeItem[string]{Tail: "s", Head: head, Weight: 1, Expiration: exp}
+		delBatch[i] = graph.EdgeKey[string]{Tail: "s", Head: head}
+	}
+
+	var (
+		stop      atomic.Bool
+		readerWG  sync.WaitGroup
+		violation atomic.Int64
+		reads     atomic.Int64
+	)
+
+	readerWG.Add(4)
+	for r := 0; r < 4; r++ {
+		go func() {
+			defer readerWG.Done()
+			for !stop.Load() {
+				g := c.Neighbor("s", 1, fanOut+1, false)
+				reads.Add(1)
+				if g == nil {
+					continue
+				}
+				count := 0
+				for _, heads := range g.Edges {
+					count += len(heads)
+				}
+				if count != 0 && count != fanOut {
+					violation.Add(1)
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < 100; i++ {
+		c.DeleteEdges(delBatch)
+		c.AddEdgesWithExpiration(addBatch)
+	}
+
+	stop.Store(true)
+	readerWG.Wait()
+
+	if reads.Load() == 0 {
+		t.Fatal("reader never executed; test is meaningless")
+	}
+	if v := violation.Load(); v != 0 {
+		t.Fatalf("reader observed %d intermediate snapshots out of %d reads; batch is not atomic under Neighbor", v, reads.Load())
+	}
+}
+
+// TestDeleteEdges_AtomicNeighborSnapshot is the symmetric test: every
+// Neighbor call sees either all batched edges or none.
+func TestDeleteEdges_AtomicNeighborSnapshot(t *testing.T) {
+	const fanOut = 128
+	c := graph.NewGraphCache[string, int](time.Minute)
+
+	exp := time.Now().Add(time.Minute)
+	c.AddVertexWithExpiration("s", 0, exp)
+
+	addBatch := make([]graph.EdgeItem[string], fanOut)
+	delBatch := make([]graph.EdgeKey[string], fanOut)
+	for i := 0; i < fanOut; i++ {
+		head := "h" + itoa(i)
+		addBatch[i] = graph.EdgeItem[string]{Tail: "s", Head: head, Weight: 1, Expiration: exp}
+		delBatch[i] = graph.EdgeKey[string]{Tail: "s", Head: head}
+	}
+
+	var (
+		stop      atomic.Bool
+		readerWG  sync.WaitGroup
+		violation atomic.Int64
+		reads     atomic.Int64
+	)
+
+	readerWG.Add(4)
+	for r := 0; r < 4; r++ {
+		go func() {
+			defer readerWG.Done()
+			for !stop.Load() {
+				g := c.Neighbor("s", 1, fanOut+1, false)
+				reads.Add(1)
+				if g == nil {
+					continue
+				}
+				count := 0
+				for _, heads := range g.Edges {
+					count += len(heads)
+				}
+				if count != 0 && count != fanOut {
+					violation.Add(1)
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < 100; i++ {
+		c.AddEdgesWithExpiration(addBatch)
+		c.DeleteEdges(delBatch)
+	}
+
+	stop.Store(true)
+	readerWG.Wait()
+
+	if reads.Load() == 0 {
+		t.Fatal("reader never executed; test is meaningless")
+	}
+	if v := violation.Load(); v != 0 {
+		t.Fatalf("reader observed %d intermediate snapshots out of %d reads; batch delete is not atomic under Neighbor", v, reads.Load())
+	}
+}
+
+// TestPutEdgesWithExpiration_NoTransientNotFound verifies the per-edge
+// invariant of PutEdges: callers replacing edges in a batch never expose a
+// transient NotFound where a concurrent GetEdge sees the edge missing
+// between the per-item delete and re-add.
+func TestPutEdgesWithExpiration_NoTransientNotFound(t *testing.T) {
+	const batchSize = 128
+	c := graph.NewGraphCache[string, int](time.Minute)
+
+	items := make([]graph.EdgeItem[string], batchSize)
+	keys := make([]graph.EdgeKey[string], batchSize)
+	for i := 0; i < batchSize; i++ {
+		tail, head := "t"+itoa(i), "h"+itoa(i)
+		items[i] = graph.EdgeItem[string]{Tail: tail, Head: head, Weight: 1, Expiration: time.Now().Add(time.Minute)}
+		keys[i] = graph.EdgeKey[string]{Tail: tail, Head: head}
+	}
+	c.AddEdgesWithExpiration(items)
+
+	var (
+		stop     atomic.Bool
+		readerWG sync.WaitGroup
+		missing  atomic.Int64
+	)
+
+	readerWG.Add(4)
+	for r := 0; r < 4; r++ {
+		go func() {
+			defer readerWG.Done()
+			for !stop.Load() {
+				for _, k := range keys {
+					if _, _, ok := c.GetEdgeDetail(k.Tail, k.Head); !ok {
+						missing.Add(1)
+					}
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < 100; i++ {
+		c.PutEdgesWithExpiration(items)
+	}
+
+	stop.Store(true)
+	readerWG.Wait()
+
+	if m := missing.Load(); m != 0 {
+		t.Fatalf("reader observed %d transient NotFound during PutEdges; batch replace is not atomic", m)
+	}
+}
+
+// TestBatchAPIs_ReturnCounts spot-checks the bookkeeping returned by
+// DeleteVertices / DeleteEdges (count of entries actually removed).
+func TestBatchAPIs_ReturnCounts(t *testing.T) {
+	c := graph.NewGraphCache[string, int](time.Minute)
+	exp := time.Now().Add(time.Minute)
+
+	c.AddVerticesWithExpiration([]graph.VertexItem[string, int]{
+		{Key: "a", Value: 1, Expiration: exp},
+		{Key: "b", Value: 2, Expiration: exp},
+		{Key: "c", Value: 3, Expiration: exp},
+	})
+	if n := c.DeleteVertices([]string{"a", "b", "missing"}); n != 2 {
+		t.Fatalf("DeleteVertices: got %d, want 2", n)
+	}
+
+	c.AddEdgesWithExpiration([]graph.EdgeItem[string]{
+		{Tail: "x", Head: "y", Weight: 1, Expiration: exp},
+		{Tail: "y", Head: "z", Weight: 1, Expiration: exp},
+	})
+	got := c.DeleteEdges([]graph.EdgeKey[string]{
+		{Tail: "x", Head: "y"},
+		{Tail: "nope", Head: "nope"},
+	})
+	if got != 1 {
+		t.Fatalf("DeleteEdges: got %d, want 1", got)
+	}
+}
+
+// itoa avoids pulling in strconv just to label test keys.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	const digits = "0123456789"
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = digits[i%10]
+		i /= 10
+	}
+	return string(buf[pos:])
+}

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -144,12 +144,17 @@ func (s *LanternService) PutVertices(ctx context.Context, request *pb.PutVertice
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
-	var written int32
-	for _, v := range request.GetVertices() {
-		s.cache.AddVertexWithExpiration(v.GetKey(), v, v.GetExpiration().AsTime())
-		written++
+	in := request.GetVertices()
+	items := make([]graph.VertexItem[string, *pb.Vertex], 0, len(in))
+	for _, v := range in {
+		items = append(items, graph.VertexItem[string, *pb.Vertex]{
+			Key:        v.GetKey(),
+			Value:      v,
+			Expiration: v.GetExpiration().AsTime(),
+		})
 	}
-	return &pb.PutVerticesResponse{Written: written}, nil
+	s.cache.AddVerticesWithExpiration(items)
+	return &pb.PutVerticesResponse{Written: int32(len(items))}, nil
 }
 
 func (s *LanternService) DeleteVertex(ctx context.Context, in *pb.DeleteVertexRequest) (*pb.DeleteVertexResponse, error) {
@@ -166,13 +171,8 @@ func (s *LanternService) DeleteVertices(ctx context.Context, in *pb.DeleteVertic
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
-	var n int32
-	for _, k := range in.GetKeys() {
-		if s.cache.DeleteVertex(k) {
-			n++
-		}
-	}
-	return &pb.DeleteVerticesResponse{Deleted: n}, nil
+	n := s.cache.DeleteVertices(in.GetKeys())
+	return &pb.DeleteVerticesResponse{Deleted: int32(n)}, nil
 }
 
 func (s *LanternService) GetEdge(ctx context.Context, request *pb.GetEdgeRequest) (*pb.GetEdgeResponse, error) {
@@ -218,27 +218,39 @@ func (s *LanternService) AddEdges(ctx context.Context, request *pb.AddEdgesReque
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
-	var written int32
-	for _, e := range request.GetEdges() {
-		s.cache.AddEdgeWithExpiration(e.GetTail(), e.GetHead(), e.GetWeight(), e.GetExpiration().AsTime())
-		written++
+	in := request.GetEdges()
+	items := make([]graph.EdgeItem[string], 0, len(in))
+	for _, e := range in {
+		items = append(items, graph.EdgeItem[string]{
+			Tail:       e.GetTail(),
+			Head:       e.GetHead(),
+			Weight:     e.GetWeight(),
+			Expiration: e.GetExpiration().AsTime(),
+		})
 	}
-	return &pb.AddEdgesResponse{Written: written}, nil
+	s.cache.AddEdgesWithExpiration(items)
+	return &pb.AddEdgesResponse{Written: int32(len(items))}, nil
 }
 
 func (s *LanternService) PutEdges(ctx context.Context, request *pb.PutEdgesRequest) (*pb.PutEdgesResponse, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
-	var written int32
-	for _, e := range request.GetEdges() {
-		// PutEdgeWithExpiration locks the cache once and performs the
-		// delete + add atomically, so concurrent GetEdge readers never
-		// observe a transient NotFound between the two operations.
-		s.cache.PutEdgeWithExpiration(e.GetTail(), e.GetHead(), e.GetWeight(), e.GetExpiration().AsTime())
-		written++
+	in := request.GetEdges()
+	items := make([]graph.EdgeItem[string], 0, len(in))
+	for _, e := range in {
+		items = append(items, graph.EdgeItem[string]{
+			Tail:       e.GetTail(),
+			Head:       e.GetHead(),
+			Weight:     e.GetWeight(),
+			Expiration: e.GetExpiration().AsTime(),
+		})
 	}
-	return &pb.PutEdgesResponse{Written: written}, nil
+	// PutEdgesWithExpiration takes the cache write lock once for the whole
+	// batch, so concurrent GetEdge readers never observe a transient
+	// NotFound between the per-edge delete and add.
+	s.cache.PutEdgesWithExpiration(items)
+	return &pb.PutEdgesResponse{Written: int32(len(items))}, nil
 }
 
 func (s *LanternService) DeleteEdge(ctx context.Context, in *pb.DeleteEdgeRequest) (*pb.DeleteEdgeResponse, error) {
@@ -255,13 +267,13 @@ func (s *LanternService) DeleteEdges(ctx context.Context, in *pb.DeleteEdgesRequ
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
-	var n int32
-	for _, e := range in.GetEdges() {
-		if s.cache.DeleteEdge(e.GetTail(), e.GetHead()) {
-			n++
-		}
+	inEdges := in.GetEdges()
+	keys := make([]graph.EdgeKey[string], 0, len(inEdges))
+	for _, e := range inEdges {
+		keys = append(keys, graph.EdgeKey[string]{Tail: e.GetTail(), Head: e.GetHead()})
 	}
-	return &pb.DeleteEdgesResponse{Deleted: n}, nil
+	n := s.cache.DeleteEdges(keys)
+	return &pb.DeleteEdgesResponse{Deleted: int32(n)}, nil
 }
 
 // LanternServer ties the gRPC server, its listener, the cache GC loop, and


### PR DESCRIPTION
Closes #76

Adds batch primitives to  and rewires the plural gRPC handlers to use them so each batched request takes the cache write lock exactly once.

### New cache APIs

- `AddVerticesWithExpiration([]VertexItem)`
- `AddEdgesWithExpiration([]EdgeItem)` — auto-creates missing endpoint vertices, matching the per-edge invariant.
- `PutEdgesWithExpiration([]EdgeItem)` — atomic delete+add per item, no transient NotFound window.
- `DeleteVertices([]string) int` / `DeleteEdges([]EdgeKey) int` — return the count actually removed.

### Server wiring

`PutVertices`, `AddEdges`, `PutEdges`, `DeleteVertices`, `DeleteEdges` in `server/service/service.go` now build the batch slice and call the new primitives instead of looping per element. The singular Get/Delete facades (#75) are unchanged.

### Tests

`core/cache/graph/batch_test.go` runs under `go test -race`:

- A hot `Neighbor` reader against repeated `DeleteEdges+AddEdges` churn — must see 0 or all batched edges, never partial.
- Symmetric `AddEdges+DeleteEdges` churn — same invariant.
- A per-edge `GetEdgeDetail` reader against repeated `PutEdgesWithExpiration` — must never observe a transient NotFound.
- Return-count spot check for `DeleteVertices` / `DeleteEdges`.