### PR TITLE
feat(#81): add singular PutVertex / AddEdge / PutEdge RPCs as facades over plural ones

### DIFF
--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -83,6 +83,16 @@ message GetVerticesResponse {
   repeated string missing = 2;
 }
 
+// PutVertexRequest writes a single vertex with upsert semantics. The
+// Vertex.key field selects the target row and Vertex.expiration controls
+// the TTL (absolute time). This is the singular convenience wrapper over
+// PutVertices and shares its guard rails.
+message PutVertexRequest {
+  Vertex vertex = 1;
+}
+
+message PutVertexResponse {}
+
 // PutVerticesRequest writes vertices with upsert semantics: each Vertex.key
 // replaces any existing value at that key. Use the Vertex.expiration field
 // (absolute time) to control TTL.
@@ -174,6 +184,15 @@ message DeleteEdgesResponse {
   int32 deleted = 1;
 }
 
+// AddEdgeRequest accumulates weight onto a single (tail, head) pair: repeated
+// calls with the same endpoints sum their weights. This is the singular
+// convenience wrapper over AddEdges and shares its non-idempotent semantics.
+message AddEdgeRequest {
+  Edge edge = 1;
+}
+
+message AddEdgeResponse {}
+
 // AddEdgesRequest accumulates weight onto each (tail, head) pair: repeated
 // calls with the same endpoints sum their weights. This operation is
 // non-idempotent.
@@ -185,6 +204,15 @@ message AddEdgesResponse {
   // Number of edges whose weight contributions were accepted.
   int32 written = 1;
 }
+
+// PutEdgeRequest overwrites a single (tail, head) pair, replacing any
+// existing weight and expiration. This is the singular convenience wrapper
+// over PutEdges and shares its idempotent semantics.
+message PutEdgeRequest {
+  Edge edge = 1;
+}
+
+message PutEdgeResponse {}
 
 // PutEdgesRequest overwrites each (tail, head) pair, replacing any existing
 // weight and expiration. This operation is idempotent.
@@ -210,6 +238,14 @@ service LanternService {
   rpc GetVertices(GetVerticesRequest) returns (GetVerticesResponse) {
     option (google.api.http) = {
       post: "/v1/vertices/get"
+      body: "*"
+    };
+  }
+
+  // PutVertex writes a single vertex. Thin facade over PutVertices.
+  rpc PutVertex(PutVertexRequest) returns (PutVertexResponse) {
+    option (google.api.http) = {
+      put: "/v1/vertices/{vertex.key}"
       body: "*"
     };
   }
@@ -245,10 +281,26 @@ service LanternService {
     };
   }
 
+  // AddEdge is non-idempotent (accumulates weight). Thin facade over AddEdges.
+  rpc AddEdge(AddEdgeRequest) returns (AddEdgeResponse) {
+    option (google.api.http) = {
+      post: "/v1/edges/{edge.tail}/{edge.head}/add"
+      body: "*"
+    };
+  }
+
   // AddEdges is non-idempotent (accumulates weight). POST per REST conventions.
   rpc AddEdges(AddEdgesRequest) returns (AddEdgesResponse) {
     option (google.api.http) = {
       post: "/v1/edges/add"
+      body: "*"
+    };
+  }
+
+  // PutEdge is idempotent (replaces weight). Thin facade over PutEdges.
+  rpc PutEdge(PutEdgeRequest) returns (PutEdgeResponse) {
+    option (google.api.http) = {
+      put: "/v1/edges/{edge.tail}/{edge.head}"
       body: "*"
     };
   }

--- a/sdks/go/gen/graph/v1/graph.pb.go
+++ b/sdks/go/gen/graph/v1/graph.pb.go
@@ -769,6 +769,90 @@ func (x *GetVerticesResponse) GetMissing() []string {
 	return nil
 }
 
+// PutVertexRequest writes a single vertex with upsert semantics. The
+// Vertex.key field selects the target row and Vertex.expiration controls
+// the TTL (absolute time). This is the singular convenience wrapper over
+// PutVertices and shares its guard rails.
+type PutVertexRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Vertex        *Vertex                `protobuf:"bytes,1,opt,name=vertex,proto3" json:"vertex,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PutVertexRequest) Reset() {
+	*x = PutVertexRequest{}
+	mi := &file_graph_v1_graph_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PutVertexRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PutVertexRequest) ProtoMessage() {}
+
+func (x *PutVertexRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PutVertexRequest.ProtoReflect.Descriptor instead.
+func (*PutVertexRequest) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *PutVertexRequest) GetVertex() *Vertex {
+	if x != nil {
+		return x.Vertex
+	}
+	return nil
+}
+
+type PutVertexResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PutVertexResponse) Reset() {
+	*x = PutVertexResponse{}
+	mi := &file_graph_v1_graph_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PutVertexResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PutVertexResponse) ProtoMessage() {}
+
+func (x *PutVertexResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PutVertexResponse.ProtoReflect.Descriptor instead.
+func (*PutVertexResponse) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{10}
+}
+
 // PutVerticesRequest writes vertices with upsert semantics: each Vertex.key
 // replaces any existing value at that key. Use the Vertex.expiration field
 // (absolute time) to control TTL.
@@ -781,7 +865,7 @@ type PutVerticesRequest struct {
 
 func (x *PutVerticesRequest) Reset() {
 	*x = PutVerticesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[9]
+	mi := &file_graph_v1_graph_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -793,7 +877,7 @@ func (x *PutVerticesRequest) String() string {
 func (*PutVerticesRequest) ProtoMessage() {}
 
 func (x *PutVerticesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[9]
+	mi := &file_graph_v1_graph_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -806,7 +890,7 @@ func (x *PutVerticesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutVerticesRequest.ProtoReflect.Descriptor instead.
 func (*PutVerticesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{9}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *PutVerticesRequest) GetVertices() []*Vertex {
@@ -828,7 +912,7 @@ type PutVerticesResponse struct {
 
 func (x *PutVerticesResponse) Reset() {
 	*x = PutVerticesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[10]
+	mi := &file_graph_v1_graph_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -840,7 +924,7 @@ func (x *PutVerticesResponse) String() string {
 func (*PutVerticesResponse) ProtoMessage() {}
 
 func (x *PutVerticesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[10]
+	mi := &file_graph_v1_graph_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -853,7 +937,7 @@ func (x *PutVerticesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutVerticesResponse.ProtoReflect.Descriptor instead.
 func (*PutVerticesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{10}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *PutVerticesResponse) GetWritten() int32 {
@@ -876,7 +960,7 @@ type DeleteVertexRequest struct {
 
 func (x *DeleteVertexRequest) Reset() {
 	*x = DeleteVertexRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[11]
+	mi := &file_graph_v1_graph_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -888,7 +972,7 @@ func (x *DeleteVertexRequest) String() string {
 func (*DeleteVertexRequest) ProtoMessage() {}
 
 func (x *DeleteVertexRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[11]
+	mi := &file_graph_v1_graph_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -901,7 +985,7 @@ func (x *DeleteVertexRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteVertexRequest.ProtoReflect.Descriptor instead.
 func (*DeleteVertexRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{11}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *DeleteVertexRequest) GetKey() string {
@@ -921,7 +1005,7 @@ type DeleteVertexResponse struct {
 
 func (x *DeleteVertexResponse) Reset() {
 	*x = DeleteVertexResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[12]
+	mi := &file_graph_v1_graph_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -933,7 +1017,7 @@ func (x *DeleteVertexResponse) String() string {
 func (*DeleteVertexResponse) ProtoMessage() {}
 
 func (x *DeleteVertexResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[12]
+	mi := &file_graph_v1_graph_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -946,7 +1030,7 @@ func (x *DeleteVertexResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteVertexResponse.ProtoReflect.Descriptor instead.
 func (*DeleteVertexResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{12}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *DeleteVertexResponse) GetExisted() bool {
@@ -968,7 +1052,7 @@ type DeleteVerticesRequest struct {
 
 func (x *DeleteVerticesRequest) Reset() {
 	*x = DeleteVerticesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[13]
+	mi := &file_graph_v1_graph_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -980,7 +1064,7 @@ func (x *DeleteVerticesRequest) String() string {
 func (*DeleteVerticesRequest) ProtoMessage() {}
 
 func (x *DeleteVerticesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[13]
+	mi := &file_graph_v1_graph_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -993,7 +1077,7 @@ func (x *DeleteVerticesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteVerticesRequest.ProtoReflect.Descriptor instead.
 func (*DeleteVerticesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{13}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *DeleteVerticesRequest) GetKeys() []string {
@@ -1013,7 +1097,7 @@ type DeleteVerticesResponse struct {
 
 func (x *DeleteVerticesResponse) Reset() {
 	*x = DeleteVerticesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[14]
+	mi := &file_graph_v1_graph_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1025,7 +1109,7 @@ func (x *DeleteVerticesResponse) String() string {
 func (*DeleteVerticesResponse) ProtoMessage() {}
 
 func (x *DeleteVerticesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[14]
+	mi := &file_graph_v1_graph_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1038,7 +1122,7 @@ func (x *DeleteVerticesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteVerticesResponse.ProtoReflect.Descriptor instead.
 func (*DeleteVerticesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{14}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *DeleteVerticesResponse) GetDeleted() int32 {
@@ -1058,7 +1142,7 @@ type GetEdgeRequest struct {
 
 func (x *GetEdgeRequest) Reset() {
 	*x = GetEdgeRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[15]
+	mi := &file_graph_v1_graph_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1070,7 +1154,7 @@ func (x *GetEdgeRequest) String() string {
 func (*GetEdgeRequest) ProtoMessage() {}
 
 func (x *GetEdgeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[15]
+	mi := &file_graph_v1_graph_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1083,7 +1167,7 @@ func (x *GetEdgeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEdgeRequest.ProtoReflect.Descriptor instead.
 func (*GetEdgeRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{15}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *GetEdgeRequest) GetTail() string {
@@ -1109,7 +1193,7 @@ type GetEdgeResponse struct {
 
 func (x *GetEdgeResponse) Reset() {
 	*x = GetEdgeResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[16]
+	mi := &file_graph_v1_graph_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1121,7 +1205,7 @@ func (x *GetEdgeResponse) String() string {
 func (*GetEdgeResponse) ProtoMessage() {}
 
 func (x *GetEdgeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[16]
+	mi := &file_graph_v1_graph_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1134,7 +1218,7 @@ func (x *GetEdgeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEdgeResponse.ProtoReflect.Descriptor instead.
 func (*GetEdgeResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{16}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *GetEdgeResponse) GetEdge() *Edge {
@@ -1155,7 +1239,7 @@ type GetEdgesRequest struct {
 
 func (x *GetEdgesRequest) Reset() {
 	*x = GetEdgesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[17]
+	mi := &file_graph_v1_graph_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1167,7 +1251,7 @@ func (x *GetEdgesRequest) String() string {
 func (*GetEdgesRequest) ProtoMessage() {}
 
 func (x *GetEdgesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[17]
+	mi := &file_graph_v1_graph_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1180,7 +1264,7 @@ func (x *GetEdgesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEdgesRequest.ProtoReflect.Descriptor instead.
 func (*GetEdgesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{17}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *GetEdgesRequest) GetEdges() []*EdgeKey {
@@ -1205,7 +1289,7 @@ type GetEdgesResponse struct {
 
 func (x *GetEdgesResponse) Reset() {
 	*x = GetEdgesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[18]
+	mi := &file_graph_v1_graph_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1217,7 +1301,7 @@ func (x *GetEdgesResponse) String() string {
 func (*GetEdgesResponse) ProtoMessage() {}
 
 func (x *GetEdgesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[18]
+	mi := &file_graph_v1_graph_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1230,7 +1314,7 @@ func (x *GetEdgesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEdgesResponse.ProtoReflect.Descriptor instead.
 func (*GetEdgesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{18}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *GetEdgesResponse) GetEdges() []*Edge {
@@ -1257,7 +1341,7 @@ type DeleteEdgeRequest struct {
 
 func (x *DeleteEdgeRequest) Reset() {
 	*x = DeleteEdgeRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[19]
+	mi := &file_graph_v1_graph_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1269,7 +1353,7 @@ func (x *DeleteEdgeRequest) String() string {
 func (*DeleteEdgeRequest) ProtoMessage() {}
 
 func (x *DeleteEdgeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[19]
+	mi := &file_graph_v1_graph_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1282,7 +1366,7 @@ func (x *DeleteEdgeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEdgeRequest.ProtoReflect.Descriptor instead.
 func (*DeleteEdgeRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{19}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *DeleteEdgeRequest) GetTail() string {
@@ -1309,7 +1393,7 @@ type DeleteEdgeResponse struct {
 
 func (x *DeleteEdgeResponse) Reset() {
 	*x = DeleteEdgeResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[20]
+	mi := &file_graph_v1_graph_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1321,7 +1405,7 @@ func (x *DeleteEdgeResponse) String() string {
 func (*DeleteEdgeResponse) ProtoMessage() {}
 
 func (x *DeleteEdgeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[20]
+	mi := &file_graph_v1_graph_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1334,7 +1418,7 @@ func (x *DeleteEdgeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEdgeResponse.ProtoReflect.Descriptor instead.
 func (*DeleteEdgeResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{20}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *DeleteEdgeResponse) GetExisted() bool {
@@ -1355,7 +1439,7 @@ type EdgeKey struct {
 
 func (x *EdgeKey) Reset() {
 	*x = EdgeKey{}
-	mi := &file_graph_v1_graph_proto_msgTypes[21]
+	mi := &file_graph_v1_graph_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1367,7 +1451,7 @@ func (x *EdgeKey) String() string {
 func (*EdgeKey) ProtoMessage() {}
 
 func (x *EdgeKey) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[21]
+	mi := &file_graph_v1_graph_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1380,7 +1464,7 @@ func (x *EdgeKey) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EdgeKey.ProtoReflect.Descriptor instead.
 func (*EdgeKey) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{21}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *EdgeKey) GetTail() string {
@@ -1408,7 +1492,7 @@ type DeleteEdgesRequest struct {
 
 func (x *DeleteEdgesRequest) Reset() {
 	*x = DeleteEdgesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[22]
+	mi := &file_graph_v1_graph_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1420,7 +1504,7 @@ func (x *DeleteEdgesRequest) String() string {
 func (*DeleteEdgesRequest) ProtoMessage() {}
 
 func (x *DeleteEdgesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[22]
+	mi := &file_graph_v1_graph_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1433,7 +1517,7 @@ func (x *DeleteEdgesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEdgesRequest.ProtoReflect.Descriptor instead.
 func (*DeleteEdgesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{22}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *DeleteEdgesRequest) GetEdges() []*EdgeKey {
@@ -1453,7 +1537,7 @@ type DeleteEdgesResponse struct {
 
 func (x *DeleteEdgesResponse) Reset() {
 	*x = DeleteEdgesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[23]
+	mi := &file_graph_v1_graph_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1465,7 +1549,7 @@ func (x *DeleteEdgesResponse) String() string {
 func (*DeleteEdgesResponse) ProtoMessage() {}
 
 func (x *DeleteEdgesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[23]
+	mi := &file_graph_v1_graph_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1478,7 +1562,7 @@ func (x *DeleteEdgesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEdgesResponse.ProtoReflect.Descriptor instead.
 func (*DeleteEdgesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{23}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *DeleteEdgesResponse) GetDeleted() int32 {
@@ -1486,6 +1570,89 @@ func (x *DeleteEdgesResponse) GetDeleted() int32 {
 		return x.Deleted
 	}
 	return 0
+}
+
+// AddEdgeRequest accumulates weight onto a single (tail, head) pair: repeated
+// calls with the same endpoints sum their weights. This is the singular
+// convenience wrapper over AddEdges and shares its non-idempotent semantics.
+type AddEdgeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Edge          *Edge                  `protobuf:"bytes,1,opt,name=edge,proto3" json:"edge,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddEdgeRequest) Reset() {
+	*x = AddEdgeRequest{}
+	mi := &file_graph_v1_graph_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddEdgeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddEdgeRequest) ProtoMessage() {}
+
+func (x *AddEdgeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddEdgeRequest.ProtoReflect.Descriptor instead.
+func (*AddEdgeRequest) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *AddEdgeRequest) GetEdge() *Edge {
+	if x != nil {
+		return x.Edge
+	}
+	return nil
+}
+
+type AddEdgeResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddEdgeResponse) Reset() {
+	*x = AddEdgeResponse{}
+	mi := &file_graph_v1_graph_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddEdgeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddEdgeResponse) ProtoMessage() {}
+
+func (x *AddEdgeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddEdgeResponse.ProtoReflect.Descriptor instead.
+func (*AddEdgeResponse) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{27}
 }
 
 // AddEdgesRequest accumulates weight onto each (tail, head) pair: repeated
@@ -1500,7 +1667,7 @@ type AddEdgesRequest struct {
 
 func (x *AddEdgesRequest) Reset() {
 	*x = AddEdgesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[24]
+	mi := &file_graph_v1_graph_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1512,7 +1679,7 @@ func (x *AddEdgesRequest) String() string {
 func (*AddEdgesRequest) ProtoMessage() {}
 
 func (x *AddEdgesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[24]
+	mi := &file_graph_v1_graph_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1525,7 +1692,7 @@ func (x *AddEdgesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddEdgesRequest.ProtoReflect.Descriptor instead.
 func (*AddEdgesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{24}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *AddEdgesRequest) GetEdges() []*Edge {
@@ -1545,7 +1712,7 @@ type AddEdgesResponse struct {
 
 func (x *AddEdgesResponse) Reset() {
 	*x = AddEdgesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[25]
+	mi := &file_graph_v1_graph_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1557,7 +1724,7 @@ func (x *AddEdgesResponse) String() string {
 func (*AddEdgesResponse) ProtoMessage() {}
 
 func (x *AddEdgesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[25]
+	mi := &file_graph_v1_graph_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1570,7 +1737,7 @@ func (x *AddEdgesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddEdgesResponse.ProtoReflect.Descriptor instead.
 func (*AddEdgesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{25}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *AddEdgesResponse) GetWritten() int32 {
@@ -1578,6 +1745,89 @@ func (x *AddEdgesResponse) GetWritten() int32 {
 		return x.Written
 	}
 	return 0
+}
+
+// PutEdgeRequest overwrites a single (tail, head) pair, replacing any
+// existing weight and expiration. This is the singular convenience wrapper
+// over PutEdges and shares its idempotent semantics.
+type PutEdgeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Edge          *Edge                  `protobuf:"bytes,1,opt,name=edge,proto3" json:"edge,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PutEdgeRequest) Reset() {
+	*x = PutEdgeRequest{}
+	mi := &file_graph_v1_graph_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PutEdgeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PutEdgeRequest) ProtoMessage() {}
+
+func (x *PutEdgeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PutEdgeRequest.ProtoReflect.Descriptor instead.
+func (*PutEdgeRequest) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *PutEdgeRequest) GetEdge() *Edge {
+	if x != nil {
+		return x.Edge
+	}
+	return nil
+}
+
+type PutEdgeResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PutEdgeResponse) Reset() {
+	*x = PutEdgeResponse{}
+	mi := &file_graph_v1_graph_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PutEdgeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PutEdgeResponse) ProtoMessage() {}
+
+func (x *PutEdgeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PutEdgeResponse.ProtoReflect.Descriptor instead.
+func (*PutEdgeResponse) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{31}
 }
 
 // PutEdgesRequest overwrites each (tail, head) pair, replacing any existing
@@ -1591,7 +1841,7 @@ type PutEdgesRequest struct {
 
 func (x *PutEdgesRequest) Reset() {
 	*x = PutEdgesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[26]
+	mi := &file_graph_v1_graph_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1603,7 +1853,7 @@ func (x *PutEdgesRequest) String() string {
 func (*PutEdgesRequest) ProtoMessage() {}
 
 func (x *PutEdgesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[26]
+	mi := &file_graph_v1_graph_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1616,7 +1866,7 @@ func (x *PutEdgesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutEdgesRequest.ProtoReflect.Descriptor instead.
 func (*PutEdgesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{26}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *PutEdgesRequest) GetEdges() []*Edge {
@@ -1636,7 +1886,7 @@ type PutEdgesResponse struct {
 
 func (x *PutEdgesResponse) Reset() {
 	*x = PutEdgesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[27]
+	mi := &file_graph_v1_graph_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1648,7 +1898,7 @@ func (x *PutEdgesResponse) String() string {
 func (*PutEdgesResponse) ProtoMessage() {}
 
 func (x *PutEdgesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[27]
+	mi := &file_graph_v1_graph_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1661,7 +1911,7 @@ func (x *PutEdgesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutEdgesResponse.ProtoReflect.Descriptor instead.
 func (*PutEdgesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{27}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *PutEdgesResponse) GetWritten() int32 {
@@ -1721,7 +1971,10 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\x04keys\x18\x01 \x03(\tR\x04keys\"]\n" +
 	"\x13GetVerticesResponse\x12,\n" +
 	"\bvertices\x18\x01 \x03(\v2\x10.graph.v1.VertexR\bvertices\x12\x18\n" +
-	"\amissing\x18\x02 \x03(\tR\amissing\"B\n" +
+	"\amissing\x18\x02 \x03(\tR\amissing\"<\n" +
+	"\x10PutVertexRequest\x12(\n" +
+	"\x06vertex\x18\x01 \x01(\v2\x10.graph.v1.VertexR\x06vertex\"\x13\n" +
+	"\x11PutVertexResponse\"B\n" +
 	"\x12PutVerticesRequest\x12,\n" +
 	"\bvertices\x18\x01 \x03(\v2\x10.graph.v1.VertexR\bvertices\"/\n" +
 	"\x13PutVerticesResponse\x12\x18\n" +
@@ -1755,11 +2008,17 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\x12DeleteEdgesRequest\x12'\n" +
 	"\x05edges\x18\x01 \x03(\v2\x11.graph.v1.EdgeKeyR\x05edges\"/\n" +
 	"\x13DeleteEdgesResponse\x12\x18\n" +
-	"\adeleted\x18\x01 \x01(\x05R\adeleted\"7\n" +
+	"\adeleted\x18\x01 \x01(\x05R\adeleted\"4\n" +
+	"\x0eAddEdgeRequest\x12\"\n" +
+	"\x04edge\x18\x01 \x01(\v2\x0e.graph.v1.EdgeR\x04edge\"\x11\n" +
+	"\x0fAddEdgeResponse\"7\n" +
 	"\x0fAddEdgesRequest\x12$\n" +
 	"\x05edges\x18\x01 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\",\n" +
 	"\x10AddEdgesResponse\x12\x18\n" +
-	"\awritten\x18\x01 \x01(\x05R\awritten\"7\n" +
+	"\awritten\x18\x01 \x01(\x05R\awritten\"4\n" +
+	"\x0ePutEdgeRequest\x12\"\n" +
+	"\x04edge\x18\x01 \x01(\v2\x0e.graph.v1.EdgeR\x04edge\"\x11\n" +
+	"\x0fPutEdgeResponse\"7\n" +
 	"\x0fPutEdgesRequest\x12$\n" +
 	"\x05edges\x18\x01 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\",\n" +
 	"\x10PutEdgesResponse\x12\x18\n" +
@@ -1769,18 +2028,21 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\"OPTIMIZATION_MINIMUM_SPANNING_TREE\x10\x01\x12&\n" +
 	"\"OPTIMIZATION_MAXIMUM_SPANNING_TREE\x10\x02\x12#\n" +
 	"\x1fOPTIMIZATION_SHORTEST_PATH_TREE\x10\x03\x12+\n" +
-	"'OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE\x10\x042\xd3\t\n" +
+	"'OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE\x10\x042\x9f\f\n" +
 	"\x0eLanternService\x12f\n" +
 	"\n" +
 	"Illuminate\x12\x1b.graph.v1.IlluminateRequest\x1a\x1c.graph.v1.IlluminateResponse\"\x1d\x82\xd3\xe4\x93\x02\x17\x12\x15/v1/illuminate/{seed}\x12`\n" +
 	"\tGetVertex\x12\x1a.graph.v1.GetVertexRequest\x1a\x1b.graph.v1.GetVertexResponse\"\x1a\x82\xd3\xe4\x93\x02\x14\x12\x12/v1/vertices/{key}\x12g\n" +
-	"\vGetVertices\x12\x1c.graph.v1.GetVerticesRequest\x1a\x1d.graph.v1.GetVerticesResponse\"\x1b\x82\xd3\xe4\x93\x02\x15:\x01*\"\x10/v1/vertices/get\x12c\n" +
+	"\vGetVertices\x12\x1c.graph.v1.GetVerticesRequest\x1a\x1d.graph.v1.GetVerticesResponse\"\x1b\x82\xd3\xe4\x93\x02\x15:\x01*\"\x10/v1/vertices/get\x12j\n" +
+	"\tPutVertex\x12\x1a.graph.v1.PutVertexRequest\x1a\x1b.graph.v1.PutVertexResponse\"$\x82\xd3\xe4\x93\x02\x1e:\x01*\x1a\x19/v1/vertices/{vertex.key}\x12c\n" +
 	"\vPutVertices\x12\x1c.graph.v1.PutVerticesRequest\x1a\x1d.graph.v1.PutVerticesResponse\"\x17\x82\xd3\xe4\x93\x02\x11:\x01*\x1a\f/v1/vertices\x12i\n" +
 	"\fDeleteVertex\x12\x1d.graph.v1.DeleteVertexRequest\x1a\x1e.graph.v1.DeleteVertexResponse\"\x1a\x82\xd3\xe4\x93\x02\x14*\x12/v1/vertices/{key}\x12s\n" +
 	"\x0eDeleteVertices\x12\x1f.graph.v1.DeleteVerticesRequest\x1a .graph.v1.DeleteVerticesResponse\"\x1e\x82\xd3\xe4\x93\x02\x18:\x01*\"\x13/v1/vertices/delete\x12_\n" +
 	"\aGetEdge\x12\x18.graph.v1.GetEdgeRequest\x1a\x19.graph.v1.GetEdgeResponse\"\x1f\x82\xd3\xe4\x93\x02\x19\x12\x17/v1/edges/{tail}/{head}\x12[\n" +
-	"\bGetEdges\x12\x19.graph.v1.GetEdgesRequest\x1a\x1a.graph.v1.GetEdgesResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\"\r/v1/edges/get\x12[\n" +
-	"\bAddEdges\x12\x19.graph.v1.AddEdgesRequest\x1a\x1a.graph.v1.AddEdgesResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\"\r/v1/edges/add\x12[\n" +
+	"\bGetEdges\x12\x19.graph.v1.GetEdgesRequest\x1a\x1a.graph.v1.GetEdgesResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\"\r/v1/edges/get\x12p\n" +
+	"\aAddEdge\x12\x18.graph.v1.AddEdgeRequest\x1a\x19.graph.v1.AddEdgeResponse\"0\x82\xd3\xe4\x93\x02*:\x01*\"%/v1/edges/{edge.tail}/{edge.head}/add\x12[\n" +
+	"\bAddEdges\x12\x19.graph.v1.AddEdgesRequest\x1a\x1a.graph.v1.AddEdgesResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\"\r/v1/edges/add\x12l\n" +
+	"\aPutEdge\x12\x18.graph.v1.PutEdgeRequest\x1a\x19.graph.v1.PutEdgeResponse\",\x82\xd3\xe4\x93\x02&:\x01*\x1a!/v1/edges/{edge.tail}/{edge.head}\x12[\n" +
 	"\bPutEdges\x12\x19.graph.v1.PutEdgesRequest\x1a\x1a.graph.v1.PutEdgesResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\x1a\r/v1/edges/put\x12h\n" +
 	"\n" +
 	"DeleteEdge\x12\x1b.graph.v1.DeleteEdgeRequest\x1a\x1c.graph.v1.DeleteEdgeResponse\"\x1f\x82\xd3\xe4\x93\x02\x19*\x17/v1/edges/{tail}/{head}\x12g\n" +
@@ -1801,7 +2063,7 @@ func file_graph_v1_graph_proto_rawDescGZIP() []byte {
 }
 
 var file_graph_v1_graph_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_graph_v1_graph_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_graph_v1_graph_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
 var file_graph_v1_graph_proto_goTypes = []any{
 	(Optimization)(0),              // 0: graph.v1.Optimization
 	(*Vertex)(nil),                 // 1: graph.v1.Vertex
@@ -1813,76 +2075,91 @@ var file_graph_v1_graph_proto_goTypes = []any{
 	(*GetVertexResponse)(nil),      // 7: graph.v1.GetVertexResponse
 	(*GetVerticesRequest)(nil),     // 8: graph.v1.GetVerticesRequest
 	(*GetVerticesResponse)(nil),    // 9: graph.v1.GetVerticesResponse
-	(*PutVerticesRequest)(nil),     // 10: graph.v1.PutVerticesRequest
-	(*PutVerticesResponse)(nil),    // 11: graph.v1.PutVerticesResponse
-	(*DeleteVertexRequest)(nil),    // 12: graph.v1.DeleteVertexRequest
-	(*DeleteVertexResponse)(nil),   // 13: graph.v1.DeleteVertexResponse
-	(*DeleteVerticesRequest)(nil),  // 14: graph.v1.DeleteVerticesRequest
-	(*DeleteVerticesResponse)(nil), // 15: graph.v1.DeleteVerticesResponse
-	(*GetEdgeRequest)(nil),         // 16: graph.v1.GetEdgeRequest
-	(*GetEdgeResponse)(nil),        // 17: graph.v1.GetEdgeResponse
-	(*GetEdgesRequest)(nil),        // 18: graph.v1.GetEdgesRequest
-	(*GetEdgesResponse)(nil),       // 19: graph.v1.GetEdgesResponse
-	(*DeleteEdgeRequest)(nil),      // 20: graph.v1.DeleteEdgeRequest
-	(*DeleteEdgeResponse)(nil),     // 21: graph.v1.DeleteEdgeResponse
-	(*EdgeKey)(nil),                // 22: graph.v1.EdgeKey
-	(*DeleteEdgesRequest)(nil),     // 23: graph.v1.DeleteEdgesRequest
-	(*DeleteEdgesResponse)(nil),    // 24: graph.v1.DeleteEdgesResponse
-	(*AddEdgesRequest)(nil),        // 25: graph.v1.AddEdgesRequest
-	(*AddEdgesResponse)(nil),       // 26: graph.v1.AddEdgesResponse
-	(*PutEdgesRequest)(nil),        // 27: graph.v1.PutEdgesRequest
-	(*PutEdgesResponse)(nil),       // 28: graph.v1.PutEdgesResponse
-	(*timestamppb.Timestamp)(nil),  // 29: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),    // 30: google.protobuf.Duration
+	(*PutVertexRequest)(nil),       // 10: graph.v1.PutVertexRequest
+	(*PutVertexResponse)(nil),      // 11: graph.v1.PutVertexResponse
+	(*PutVerticesRequest)(nil),     // 12: graph.v1.PutVerticesRequest
+	(*PutVerticesResponse)(nil),    // 13: graph.v1.PutVerticesResponse
+	(*DeleteVertexRequest)(nil),    // 14: graph.v1.DeleteVertexRequest
+	(*DeleteVertexResponse)(nil),   // 15: graph.v1.DeleteVertexResponse
+	(*DeleteVerticesRequest)(nil),  // 16: graph.v1.DeleteVerticesRequest
+	(*DeleteVerticesResponse)(nil), // 17: graph.v1.DeleteVerticesResponse
+	(*GetEdgeRequest)(nil),         // 18: graph.v1.GetEdgeRequest
+	(*GetEdgeResponse)(nil),        // 19: graph.v1.GetEdgeResponse
+	(*GetEdgesRequest)(nil),        // 20: graph.v1.GetEdgesRequest
+	(*GetEdgesResponse)(nil),       // 21: graph.v1.GetEdgesResponse
+	(*DeleteEdgeRequest)(nil),      // 22: graph.v1.DeleteEdgeRequest
+	(*DeleteEdgeResponse)(nil),     // 23: graph.v1.DeleteEdgeResponse
+	(*EdgeKey)(nil),                // 24: graph.v1.EdgeKey
+	(*DeleteEdgesRequest)(nil),     // 25: graph.v1.DeleteEdgesRequest
+	(*DeleteEdgesResponse)(nil),    // 26: graph.v1.DeleteEdgesResponse
+	(*AddEdgeRequest)(nil),         // 27: graph.v1.AddEdgeRequest
+	(*AddEdgeResponse)(nil),        // 28: graph.v1.AddEdgeResponse
+	(*AddEdgesRequest)(nil),        // 29: graph.v1.AddEdgesRequest
+	(*AddEdgesResponse)(nil),       // 30: graph.v1.AddEdgesResponse
+	(*PutEdgeRequest)(nil),         // 31: graph.v1.PutEdgeRequest
+	(*PutEdgeResponse)(nil),        // 32: graph.v1.PutEdgeResponse
+	(*PutEdgesRequest)(nil),        // 33: graph.v1.PutEdgesRequest
+	(*PutEdgesResponse)(nil),       // 34: graph.v1.PutEdgesResponse
+	(*timestamppb.Timestamp)(nil),  // 35: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),    // 36: google.protobuf.Duration
 }
 var file_graph_v1_graph_proto_depIdxs = []int32{
-	29, // 0: graph.v1.Vertex.expiration:type_name -> google.protobuf.Timestamp
-	29, // 1: graph.v1.Vertex.timestamp:type_name -> google.protobuf.Timestamp
-	30, // 2: graph.v1.Vertex.duration:type_name -> google.protobuf.Duration
-	29, // 3: graph.v1.Edge.expiration:type_name -> google.protobuf.Timestamp
+	35, // 0: graph.v1.Vertex.expiration:type_name -> google.protobuf.Timestamp
+	35, // 1: graph.v1.Vertex.timestamp:type_name -> google.protobuf.Timestamp
+	36, // 2: graph.v1.Vertex.duration:type_name -> google.protobuf.Duration
+	35, // 3: graph.v1.Edge.expiration:type_name -> google.protobuf.Timestamp
 	1,  // 4: graph.v1.Graph.vertices:type_name -> graph.v1.Vertex
 	2,  // 5: graph.v1.Graph.edges:type_name -> graph.v1.Edge
 	0,  // 6: graph.v1.IlluminateRequest.optimization:type_name -> graph.v1.Optimization
 	3,  // 7: graph.v1.IlluminateResponse.graph:type_name -> graph.v1.Graph
 	1,  // 8: graph.v1.GetVertexResponse.vertex:type_name -> graph.v1.Vertex
 	1,  // 9: graph.v1.GetVerticesResponse.vertices:type_name -> graph.v1.Vertex
-	1,  // 10: graph.v1.PutVerticesRequest.vertices:type_name -> graph.v1.Vertex
-	2,  // 11: graph.v1.GetEdgeResponse.edge:type_name -> graph.v1.Edge
-	22, // 12: graph.v1.GetEdgesRequest.edges:type_name -> graph.v1.EdgeKey
-	2,  // 13: graph.v1.GetEdgesResponse.edges:type_name -> graph.v1.Edge
-	22, // 14: graph.v1.GetEdgesResponse.missing:type_name -> graph.v1.EdgeKey
-	22, // 15: graph.v1.DeleteEdgesRequest.edges:type_name -> graph.v1.EdgeKey
-	2,  // 16: graph.v1.AddEdgesRequest.edges:type_name -> graph.v1.Edge
-	2,  // 17: graph.v1.PutEdgesRequest.edges:type_name -> graph.v1.Edge
-	4,  // 18: graph.v1.LanternService.Illuminate:input_type -> graph.v1.IlluminateRequest
-	6,  // 19: graph.v1.LanternService.GetVertex:input_type -> graph.v1.GetVertexRequest
-	8,  // 20: graph.v1.LanternService.GetVertices:input_type -> graph.v1.GetVerticesRequest
-	10, // 21: graph.v1.LanternService.PutVertices:input_type -> graph.v1.PutVerticesRequest
-	12, // 22: graph.v1.LanternService.DeleteVertex:input_type -> graph.v1.DeleteVertexRequest
-	14, // 23: graph.v1.LanternService.DeleteVertices:input_type -> graph.v1.DeleteVerticesRequest
-	16, // 24: graph.v1.LanternService.GetEdge:input_type -> graph.v1.GetEdgeRequest
-	18, // 25: graph.v1.LanternService.GetEdges:input_type -> graph.v1.GetEdgesRequest
-	25, // 26: graph.v1.LanternService.AddEdges:input_type -> graph.v1.AddEdgesRequest
-	27, // 27: graph.v1.LanternService.PutEdges:input_type -> graph.v1.PutEdgesRequest
-	20, // 28: graph.v1.LanternService.DeleteEdge:input_type -> graph.v1.DeleteEdgeRequest
-	23, // 29: graph.v1.LanternService.DeleteEdges:input_type -> graph.v1.DeleteEdgesRequest
-	5,  // 30: graph.v1.LanternService.Illuminate:output_type -> graph.v1.IlluminateResponse
-	7,  // 31: graph.v1.LanternService.GetVertex:output_type -> graph.v1.GetVertexResponse
-	9,  // 32: graph.v1.LanternService.GetVertices:output_type -> graph.v1.GetVerticesResponse
-	11, // 33: graph.v1.LanternService.PutVertices:output_type -> graph.v1.PutVerticesResponse
-	13, // 34: graph.v1.LanternService.DeleteVertex:output_type -> graph.v1.DeleteVertexResponse
-	15, // 35: graph.v1.LanternService.DeleteVertices:output_type -> graph.v1.DeleteVerticesResponse
-	17, // 36: graph.v1.LanternService.GetEdge:output_type -> graph.v1.GetEdgeResponse
-	19, // 37: graph.v1.LanternService.GetEdges:output_type -> graph.v1.GetEdgesResponse
-	26, // 38: graph.v1.LanternService.AddEdges:output_type -> graph.v1.AddEdgesResponse
-	28, // 39: graph.v1.LanternService.PutEdges:output_type -> graph.v1.PutEdgesResponse
-	21, // 40: graph.v1.LanternService.DeleteEdge:output_type -> graph.v1.DeleteEdgeResponse
-	24, // 41: graph.v1.LanternService.DeleteEdges:output_type -> graph.v1.DeleteEdgesResponse
-	30, // [30:42] is the sub-list for method output_type
-	18, // [18:30] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	1,  // 10: graph.v1.PutVertexRequest.vertex:type_name -> graph.v1.Vertex
+	1,  // 11: graph.v1.PutVerticesRequest.vertices:type_name -> graph.v1.Vertex
+	2,  // 12: graph.v1.GetEdgeResponse.edge:type_name -> graph.v1.Edge
+	24, // 13: graph.v1.GetEdgesRequest.edges:type_name -> graph.v1.EdgeKey
+	2,  // 14: graph.v1.GetEdgesResponse.edges:type_name -> graph.v1.Edge
+	24, // 15: graph.v1.GetEdgesResponse.missing:type_name -> graph.v1.EdgeKey
+	24, // 16: graph.v1.DeleteEdgesRequest.edges:type_name -> graph.v1.EdgeKey
+	2,  // 17: graph.v1.AddEdgeRequest.edge:type_name -> graph.v1.Edge
+	2,  // 18: graph.v1.AddEdgesRequest.edges:type_name -> graph.v1.Edge
+	2,  // 19: graph.v1.PutEdgeRequest.edge:type_name -> graph.v1.Edge
+	2,  // 20: graph.v1.PutEdgesRequest.edges:type_name -> graph.v1.Edge
+	4,  // 21: graph.v1.LanternService.Illuminate:input_type -> graph.v1.IlluminateRequest
+	6,  // 22: graph.v1.LanternService.GetVertex:input_type -> graph.v1.GetVertexRequest
+	8,  // 23: graph.v1.LanternService.GetVertices:input_type -> graph.v1.GetVerticesRequest
+	10, // 24: graph.v1.LanternService.PutVertex:input_type -> graph.v1.PutVertexRequest
+	12, // 25: graph.v1.LanternService.PutVertices:input_type -> graph.v1.PutVerticesRequest
+	14, // 26: graph.v1.LanternService.DeleteVertex:input_type -> graph.v1.DeleteVertexRequest
+	16, // 27: graph.v1.LanternService.DeleteVertices:input_type -> graph.v1.DeleteVerticesRequest
+	18, // 28: graph.v1.LanternService.GetEdge:input_type -> graph.v1.GetEdgeRequest
+	20, // 29: graph.v1.LanternService.GetEdges:input_type -> graph.v1.GetEdgesRequest
+	27, // 30: graph.v1.LanternService.AddEdge:input_type -> graph.v1.AddEdgeRequest
+	29, // 31: graph.v1.LanternService.AddEdges:input_type -> graph.v1.AddEdgesRequest
+	31, // 32: graph.v1.LanternService.PutEdge:input_type -> graph.v1.PutEdgeRequest
+	33, // 33: graph.v1.LanternService.PutEdges:input_type -> graph.v1.PutEdgesRequest
+	22, // 34: graph.v1.LanternService.DeleteEdge:input_type -> graph.v1.DeleteEdgeRequest
+	25, // 35: graph.v1.LanternService.DeleteEdges:input_type -> graph.v1.DeleteEdgesRequest
+	5,  // 36: graph.v1.LanternService.Illuminate:output_type -> graph.v1.IlluminateResponse
+	7,  // 37: graph.v1.LanternService.GetVertex:output_type -> graph.v1.GetVertexResponse
+	9,  // 38: graph.v1.LanternService.GetVertices:output_type -> graph.v1.GetVerticesResponse
+	11, // 39: graph.v1.LanternService.PutVertex:output_type -> graph.v1.PutVertexResponse
+	13, // 40: graph.v1.LanternService.PutVertices:output_type -> graph.v1.PutVerticesResponse
+	15, // 41: graph.v1.LanternService.DeleteVertex:output_type -> graph.v1.DeleteVertexResponse
+	17, // 42: graph.v1.LanternService.DeleteVertices:output_type -> graph.v1.DeleteVerticesResponse
+	19, // 43: graph.v1.LanternService.GetEdge:output_type -> graph.v1.GetEdgeResponse
+	21, // 44: graph.v1.LanternService.GetEdges:output_type -> graph.v1.GetEdgesResponse
+	28, // 45: graph.v1.LanternService.AddEdge:output_type -> graph.v1.AddEdgeResponse
+	30, // 46: graph.v1.LanternService.AddEdges:output_type -> graph.v1.AddEdgesResponse
+	32, // 47: graph.v1.LanternService.PutEdge:output_type -> graph.v1.PutEdgeResponse
+	34, // 48: graph.v1.LanternService.PutEdges:output_type -> graph.v1.PutEdgesResponse
+	23, // 49: graph.v1.LanternService.DeleteEdge:output_type -> graph.v1.DeleteEdgeResponse
+	26, // 50: graph.v1.LanternService.DeleteEdges:output_type -> graph.v1.DeleteEdgesResponse
+	36, // [36:51] is the sub-list for method output_type
+	21, // [21:36] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_graph_v1_graph_proto_init() }
@@ -1910,7 +2187,7 @@ func file_graph_v1_graph_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_graph_v1_graph_proto_rawDesc), len(file_graph_v1_graph_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   28,
+			NumMessages:   34,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sdks/go/gen/graph/v1/graph.pb.gw.go
+++ b/sdks/go/gen/graph/v1/graph.pb.gw.go
@@ -154,6 +154,51 @@ func local_request_LanternService_GetVertices_0(ctx context.Context, marshaler r
 	return msg, metadata, err
 }
 
+func request_LanternService_PutVertex_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq PutVertexRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["vertex.key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "vertex.key")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "vertex.key", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "vertex.key", err)
+	}
+	msg, err := client.PutVertex(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_LanternService_PutVertex_0(ctx context.Context, marshaler runtime.Marshaler, server LanternServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq PutVertexRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["vertex.key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "vertex.key")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "vertex.key", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "vertex.key", err)
+	}
+	msg, err := server.PutVertex(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_LanternService_PutVertices_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq PutVerticesRequest
@@ -329,6 +374,67 @@ func local_request_LanternService_GetEdges_0(ctx context.Context, marshaler runt
 	return msg, metadata, err
 }
 
+func request_LanternService_AddEdge_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq AddEdgeRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["edge.tail"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "edge.tail")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "edge.tail", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "edge.tail", err)
+	}
+	val, ok = pathParams["edge.head"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "edge.head")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "edge.head", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "edge.head", err)
+	}
+	msg, err := client.AddEdge(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_LanternService_AddEdge_0(ctx context.Context, marshaler runtime.Marshaler, server LanternServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq AddEdgeRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["edge.tail"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "edge.tail")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "edge.tail", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "edge.tail", err)
+	}
+	val, ok = pathParams["edge.head"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "edge.head")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "edge.head", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "edge.head", err)
+	}
+	msg, err := server.AddEdge(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_LanternService_AddEdges_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq AddEdgesRequest
@@ -353,6 +459,67 @@ func local_request_LanternService_AddEdges_0(ctx context.Context, marshaler runt
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	msg, err := server.AddEdges(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_LanternService_PutEdge_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq PutEdgeRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["edge.tail"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "edge.tail")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "edge.tail", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "edge.tail", err)
+	}
+	val, ok = pathParams["edge.head"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "edge.head")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "edge.head", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "edge.head", err)
+	}
+	msg, err := client.PutEdge(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_LanternService_PutEdge_0(ctx context.Context, marshaler runtime.Marshaler, server LanternServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq PutEdgeRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["edge.tail"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "edge.tail")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "edge.tail", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "edge.tail", err)
+	}
+	val, ok = pathParams["edge.head"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "edge.head")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "edge.head", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "edge.head", err)
+	}
+	msg, err := server.PutEdge(ctx, &protoReq)
 	return msg, metadata, err
 }
 
@@ -531,6 +698,26 @@ func RegisterLanternServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 		}
 		forward_LanternService_GetVertices_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPut, pattern_LanternService_PutVertex_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/graph.v1.LanternService/PutVertex", runtime.WithHTTPPathPattern("/v1/vertices/{vertex.key}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_LanternService_PutVertex_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LanternService_PutVertex_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPut, pattern_LanternService_PutVertices_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -631,6 +818,26 @@ func RegisterLanternServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 		}
 		forward_LanternService_GetEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_LanternService_AddEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/graph.v1.LanternService/AddEdge", runtime.WithHTTPPathPattern("/v1/edges/{edge.tail}/{edge.head}/add"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_LanternService_AddEdge_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LanternService_AddEdge_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_LanternService_AddEdges_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -650,6 +857,26 @@ func RegisterLanternServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 			return
 		}
 		forward_LanternService_AddEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPut, pattern_LanternService_PutEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/graph.v1.LanternService/PutEdge", runtime.WithHTTPPathPattern("/v1/edges/{edge.tail}/{edge.head}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_LanternService_PutEdge_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LanternService_PutEdge_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodPut, pattern_LanternService_PutEdges_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -802,6 +1029,23 @@ func RegisterLanternServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 		}
 		forward_LanternService_GetVertices_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPut, pattern_LanternService_PutVertex_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/graph.v1.LanternService/PutVertex", runtime.WithHTTPPathPattern("/v1/vertices/{vertex.key}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_LanternService_PutVertex_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LanternService_PutVertex_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPut, pattern_LanternService_PutVertices_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -887,6 +1131,23 @@ func RegisterLanternServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 		}
 		forward_LanternService_GetEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_LanternService_AddEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/graph.v1.LanternService/AddEdge", runtime.WithHTTPPathPattern("/v1/edges/{edge.tail}/{edge.head}/add"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_LanternService_AddEdge_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LanternService_AddEdge_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_LanternService_AddEdges_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -903,6 +1164,23 @@ func RegisterLanternServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 			return
 		}
 		forward_LanternService_AddEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPut, pattern_LanternService_PutEdge_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/graph.v1.LanternService/PutEdge", runtime.WithHTTPPathPattern("/v1/edges/{edge.tail}/{edge.head}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_LanternService_PutEdge_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LanternService_PutEdge_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodPut, pattern_LanternService_PutEdges_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -962,12 +1240,15 @@ var (
 	pattern_LanternService_Illuminate_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "illuminate", "seed"}, ""))
 	pattern_LanternService_GetVertex_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "vertices", "key"}, ""))
 	pattern_LanternService_GetVertices_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "vertices", "get"}, ""))
+	pattern_LanternService_PutVertex_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "vertices", "vertex.key"}, ""))
 	pattern_LanternService_PutVertices_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "vertices"}, ""))
 	pattern_LanternService_DeleteVertex_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "vertices", "key"}, ""))
 	pattern_LanternService_DeleteVertices_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "vertices", "delete"}, ""))
 	pattern_LanternService_GetEdge_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "edges", "tail", "head"}, ""))
 	pattern_LanternService_GetEdges_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "get"}, ""))
+	pattern_LanternService_AddEdge_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"v1", "edges", "edge.tail", "edge.head", "add"}, ""))
 	pattern_LanternService_AddEdges_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "add"}, ""))
+	pattern_LanternService_PutEdge_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "edges", "edge.tail", "edge.head"}, ""))
 	pattern_LanternService_PutEdges_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "put"}, ""))
 	pattern_LanternService_DeleteEdge_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "edges", "tail", "head"}, ""))
 	pattern_LanternService_DeleteEdges_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "delete"}, ""))
@@ -977,12 +1258,15 @@ var (
 	forward_LanternService_Illuminate_0     = runtime.ForwardResponseMessage
 	forward_LanternService_GetVertex_0      = runtime.ForwardResponseMessage
 	forward_LanternService_GetVertices_0    = runtime.ForwardResponseMessage
+	forward_LanternService_PutVertex_0      = runtime.ForwardResponseMessage
 	forward_LanternService_PutVertices_0    = runtime.ForwardResponseMessage
 	forward_LanternService_DeleteVertex_0   = runtime.ForwardResponseMessage
 	forward_LanternService_DeleteVertices_0 = runtime.ForwardResponseMessage
 	forward_LanternService_GetEdge_0        = runtime.ForwardResponseMessage
 	forward_LanternService_GetEdges_0       = runtime.ForwardResponseMessage
+	forward_LanternService_AddEdge_0        = runtime.ForwardResponseMessage
 	forward_LanternService_AddEdges_0       = runtime.ForwardResponseMessage
+	forward_LanternService_PutEdge_0        = runtime.ForwardResponseMessage
 	forward_LanternService_PutEdges_0       = runtime.ForwardResponseMessage
 	forward_LanternService_DeleteEdge_0     = runtime.ForwardResponseMessage
 	forward_LanternService_DeleteEdges_0    = runtime.ForwardResponseMessage

--- a/sdks/go/gen/graph/v1/graph_grpc.pb.go
+++ b/sdks/go/gen/graph/v1/graph_grpc.pb.go
@@ -22,12 +22,15 @@ const (
 	LanternService_Illuminate_FullMethodName     = "/graph.v1.LanternService/Illuminate"
 	LanternService_GetVertex_FullMethodName      = "/graph.v1.LanternService/GetVertex"
 	LanternService_GetVertices_FullMethodName    = "/graph.v1.LanternService/GetVertices"
+	LanternService_PutVertex_FullMethodName      = "/graph.v1.LanternService/PutVertex"
 	LanternService_PutVertices_FullMethodName    = "/graph.v1.LanternService/PutVertices"
 	LanternService_DeleteVertex_FullMethodName   = "/graph.v1.LanternService/DeleteVertex"
 	LanternService_DeleteVertices_FullMethodName = "/graph.v1.LanternService/DeleteVertices"
 	LanternService_GetEdge_FullMethodName        = "/graph.v1.LanternService/GetEdge"
 	LanternService_GetEdges_FullMethodName       = "/graph.v1.LanternService/GetEdges"
+	LanternService_AddEdge_FullMethodName        = "/graph.v1.LanternService/AddEdge"
 	LanternService_AddEdges_FullMethodName       = "/graph.v1.LanternService/AddEdges"
+	LanternService_PutEdge_FullMethodName        = "/graph.v1.LanternService/PutEdge"
 	LanternService_PutEdges_FullMethodName       = "/graph.v1.LanternService/PutEdges"
 	LanternService_DeleteEdge_FullMethodName     = "/graph.v1.LanternService/DeleteEdge"
 	LanternService_DeleteEdges_FullMethodName    = "/graph.v1.LanternService/DeleteEdges"
@@ -41,6 +44,8 @@ type LanternServiceClient interface {
 	GetVertex(ctx context.Context, in *GetVertexRequest, opts ...grpc.CallOption) (*GetVertexResponse, error)
 	// GetVertices reads several vertices in one round trip.
 	GetVertices(ctx context.Context, in *GetVerticesRequest, opts ...grpc.CallOption) (*GetVerticesResponse, error)
+	// PutVertex writes a single vertex. Thin facade over PutVertices.
+	PutVertex(ctx context.Context, in *PutVertexRequest, opts ...grpc.CallOption) (*PutVertexResponse, error)
 	PutVertices(ctx context.Context, in *PutVerticesRequest, opts ...grpc.CallOption) (*PutVerticesResponse, error)
 	DeleteVertex(ctx context.Context, in *DeleteVertexRequest, opts ...grpc.CallOption) (*DeleteVertexResponse, error)
 	// DeleteVertices removes several vertices in one round trip.
@@ -48,8 +53,12 @@ type LanternServiceClient interface {
 	GetEdge(ctx context.Context, in *GetEdgeRequest, opts ...grpc.CallOption) (*GetEdgeResponse, error)
 	// GetEdges reads several edges in one round trip.
 	GetEdges(ctx context.Context, in *GetEdgesRequest, opts ...grpc.CallOption) (*GetEdgesResponse, error)
+	// AddEdge is non-idempotent (accumulates weight). Thin facade over AddEdges.
+	AddEdge(ctx context.Context, in *AddEdgeRequest, opts ...grpc.CallOption) (*AddEdgeResponse, error)
 	// AddEdges is non-idempotent (accumulates weight). POST per REST conventions.
 	AddEdges(ctx context.Context, in *AddEdgesRequest, opts ...grpc.CallOption) (*AddEdgesResponse, error)
+	// PutEdge is idempotent (replaces weight). Thin facade over PutEdges.
+	PutEdge(ctx context.Context, in *PutEdgeRequest, opts ...grpc.CallOption) (*PutEdgeResponse, error)
 	// PutEdges is idempotent (replaces weight). PUT per REST conventions.
 	PutEdges(ctx context.Context, in *PutEdgesRequest, opts ...grpc.CallOption) (*PutEdgesResponse, error)
 	DeleteEdge(ctx context.Context, in *DeleteEdgeRequest, opts ...grpc.CallOption) (*DeleteEdgeResponse, error)
@@ -89,6 +98,16 @@ func (c *lanternServiceClient) GetVertices(ctx context.Context, in *GetVerticesR
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetVerticesResponse)
 	err := c.cc.Invoke(ctx, LanternService_GetVertices_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *lanternServiceClient) PutVertex(ctx context.Context, in *PutVertexRequest, opts ...grpc.CallOption) (*PutVertexResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PutVertexResponse)
+	err := c.cc.Invoke(ctx, LanternService_PutVertex_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -145,10 +164,30 @@ func (c *lanternServiceClient) GetEdges(ctx context.Context, in *GetEdgesRequest
 	return out, nil
 }
 
+func (c *lanternServiceClient) AddEdge(ctx context.Context, in *AddEdgeRequest, opts ...grpc.CallOption) (*AddEdgeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AddEdgeResponse)
+	err := c.cc.Invoke(ctx, LanternService_AddEdge_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *lanternServiceClient) AddEdges(ctx context.Context, in *AddEdgesRequest, opts ...grpc.CallOption) (*AddEdgesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(AddEdgesResponse)
 	err := c.cc.Invoke(ctx, LanternService_AddEdges_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *lanternServiceClient) PutEdge(ctx context.Context, in *PutEdgeRequest, opts ...grpc.CallOption) (*PutEdgeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PutEdgeResponse)
+	err := c.cc.Invoke(ctx, LanternService_PutEdge_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -193,6 +232,8 @@ type LanternServiceServer interface {
 	GetVertex(context.Context, *GetVertexRequest) (*GetVertexResponse, error)
 	// GetVertices reads several vertices in one round trip.
 	GetVertices(context.Context, *GetVerticesRequest) (*GetVerticesResponse, error)
+	// PutVertex writes a single vertex. Thin facade over PutVertices.
+	PutVertex(context.Context, *PutVertexRequest) (*PutVertexResponse, error)
 	PutVertices(context.Context, *PutVerticesRequest) (*PutVerticesResponse, error)
 	DeleteVertex(context.Context, *DeleteVertexRequest) (*DeleteVertexResponse, error)
 	// DeleteVertices removes several vertices in one round trip.
@@ -200,8 +241,12 @@ type LanternServiceServer interface {
 	GetEdge(context.Context, *GetEdgeRequest) (*GetEdgeResponse, error)
 	// GetEdges reads several edges in one round trip.
 	GetEdges(context.Context, *GetEdgesRequest) (*GetEdgesResponse, error)
+	// AddEdge is non-idempotent (accumulates weight). Thin facade over AddEdges.
+	AddEdge(context.Context, *AddEdgeRequest) (*AddEdgeResponse, error)
 	// AddEdges is non-idempotent (accumulates weight). POST per REST conventions.
 	AddEdges(context.Context, *AddEdgesRequest) (*AddEdgesResponse, error)
+	// PutEdge is idempotent (replaces weight). Thin facade over PutEdges.
+	PutEdge(context.Context, *PutEdgeRequest) (*PutEdgeResponse, error)
 	// PutEdges is idempotent (replaces weight). PUT per REST conventions.
 	PutEdges(context.Context, *PutEdgesRequest) (*PutEdgesResponse, error)
 	DeleteEdge(context.Context, *DeleteEdgeRequest) (*DeleteEdgeResponse, error)
@@ -225,6 +270,9 @@ func (UnimplementedLanternServiceServer) GetVertex(context.Context, *GetVertexRe
 func (UnimplementedLanternServiceServer) GetVertices(context.Context, *GetVerticesRequest) (*GetVerticesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetVertices not implemented")
 }
+func (UnimplementedLanternServiceServer) PutVertex(context.Context, *PutVertexRequest) (*PutVertexResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PutVertex not implemented")
+}
 func (UnimplementedLanternServiceServer) PutVertices(context.Context, *PutVerticesRequest) (*PutVerticesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PutVertices not implemented")
 }
@@ -240,8 +288,14 @@ func (UnimplementedLanternServiceServer) GetEdge(context.Context, *GetEdgeReques
 func (UnimplementedLanternServiceServer) GetEdges(context.Context, *GetEdgesRequest) (*GetEdgesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetEdges not implemented")
 }
+func (UnimplementedLanternServiceServer) AddEdge(context.Context, *AddEdgeRequest) (*AddEdgeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method AddEdge not implemented")
+}
 func (UnimplementedLanternServiceServer) AddEdges(context.Context, *AddEdgesRequest) (*AddEdgesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AddEdges not implemented")
+}
+func (UnimplementedLanternServiceServer) PutEdge(context.Context, *PutEdgeRequest) (*PutEdgeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PutEdge not implemented")
 }
 func (UnimplementedLanternServiceServer) PutEdges(context.Context, *PutEdgesRequest) (*PutEdgesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PutEdges not implemented")
@@ -322,6 +376,24 @@ func _LanternService_GetVertices_Handler(srv interface{}, ctx context.Context, d
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(LanternServiceServer).GetVertices(ctx, req.(*GetVerticesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _LanternService_PutVertex_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PutVertexRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LanternServiceServer).PutVertex(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: LanternService_PutVertex_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LanternServiceServer).PutVertex(ctx, req.(*PutVertexRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -416,6 +488,24 @@ func _LanternService_GetEdges_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _LanternService_AddEdge_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AddEdgeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LanternServiceServer).AddEdge(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: LanternService_AddEdge_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LanternServiceServer).AddEdge(ctx, req.(*AddEdgeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _LanternService_AddEdges_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(AddEdgesRequest)
 	if err := dec(in); err != nil {
@@ -430,6 +520,24 @@ func _LanternService_AddEdges_Handler(srv interface{}, ctx context.Context, dec 
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(LanternServiceServer).AddEdges(ctx, req.(*AddEdgesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _LanternService_PutEdge_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PutEdgeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LanternServiceServer).PutEdge(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: LanternService_PutEdge_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LanternServiceServer).PutEdge(ctx, req.(*PutEdgeRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -508,6 +616,10 @@ var LanternService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _LanternService_GetVertices_Handler,
 		},
 		{
+			MethodName: "PutVertex",
+			Handler:    _LanternService_PutVertex_Handler,
+		},
+		{
 			MethodName: "PutVertices",
 			Handler:    _LanternService_PutVertices_Handler,
 		},
@@ -528,8 +640,16 @@ var LanternService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _LanternService_GetEdges_Handler,
 		},
 		{
+			MethodName: "AddEdge",
+			Handler:    _LanternService_AddEdge_Handler,
+		},
+		{
 			MethodName: "AddEdges",
 			Handler:    _LanternService_AddEdges_Handler,
+		},
+		{
+			MethodName: "PutEdge",
+			Handler:    _LanternService_PutEdge_Handler,
 		},
 		{
 			MethodName: "PutEdges",

--- a/sdks/go/gen/openapiv2/graph/v1/graph.swagger.json
+++ b/sdks/go/gen/openapiv2/graph/v1/graph.swagger.json
@@ -152,6 +152,96 @@
         ]
       }
     },
+    "/v1/edges/{edge.tail}/{edge.head}": {
+      "put": {
+        "summary": "PutEdge is idempotent (replaces weight). Thin facade over PutEdges.",
+        "operationId": "LanternService_PutEdge",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1PutEdgeResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "edge.tail",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "edge.head",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LanternServicePutEdgeBody"
+            }
+          }
+        ],
+        "tags": [
+          "LanternService"
+        ]
+      }
+    },
+    "/v1/edges/{edge.tail}/{edge.head}/add": {
+      "post": {
+        "summary": "AddEdge is non-idempotent (accumulates weight). Thin facade over AddEdges.",
+        "operationId": "LanternService_AddEdge",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1AddEdgeResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "edge.tail",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "edge.head",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LanternServiceAddEdgeBody"
+            }
+          }
+        ],
+        "tags": [
+          "LanternService"
+        ]
+      }
+    },
     "/v1/edges/{tail}/{head}": {
       "get": {
         "operationId": "LanternService_GetEdge",
@@ -444,9 +534,146 @@
           "LanternService"
         ]
       }
+    },
+    "/v1/vertices/{vertex.key}": {
+      "put": {
+        "summary": "PutVertex writes a single vertex. Thin facade over PutVertices.",
+        "operationId": "LanternService_PutVertex",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1PutVertexResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "vertex.key",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LanternServicePutVertexBody"
+            }
+          }
+        ],
+        "tags": [
+          "LanternService"
+        ]
+      }
     }
   },
   "definitions": {
+    "LanternServiceAddEdgeBody": {
+      "type": "object",
+      "properties": {
+        "edge": {
+          "type": "object",
+          "properties": {
+            "weight": {
+              "type": "number",
+              "format": "float"
+            },
+            "expiration": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        }
+      },
+      "description": "AddEdgeRequest accumulates weight onto a single (tail, head) pair: repeated\ncalls with the same endpoints sum their weights. This is the singular\nconvenience wrapper over AddEdges and shares its non-idempotent semantics."
+    },
+    "LanternServicePutEdgeBody": {
+      "type": "object",
+      "properties": {
+        "edge": {
+          "type": "object",
+          "properties": {
+            "weight": {
+              "type": "number",
+              "format": "float"
+            },
+            "expiration": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        }
+      },
+      "description": "PutEdgeRequest overwrites a single (tail, head) pair, replacing any\nexisting weight and expiration. This is the singular convenience wrapper\nover PutEdges and shares its idempotent semantics."
+    },
+    "LanternServicePutVertexBody": {
+      "type": "object",
+      "properties": {
+        "vertex": {
+          "type": "object",
+          "properties": {
+            "expiration": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "float64": {
+              "type": "number",
+              "format": "double"
+            },
+            "float32": {
+              "type": "number",
+              "format": "float"
+            },
+            "int32": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "int64": {
+              "type": "string",
+              "format": "int64"
+            },
+            "uint32": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "uint64": {
+              "type": "string",
+              "format": "uint64"
+            },
+            "bool": {
+              "type": "boolean"
+            },
+            "string": {
+              "type": "string"
+            },
+            "bytes": {
+              "type": "string",
+              "format": "byte"
+            },
+            "timestamp": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "duration": {
+              "type": "string"
+            },
+            "nil": {
+              "type": "boolean",
+              "description": "nil signals that the vertex carries no value (an \"existence-only\"\nmarker). The bool itself is always true when present; the variant\nexists so the oneof can distinguish \"explicitly nil\" from \"unset\"."
+            }
+          }
+        }
+      },
+      "description": "PutVertexRequest writes a single vertex with upsert semantics. The\nVertex.key field selects the target row and Vertex.expiration controls\nthe TTL (absolute time). This is the singular convenience wrapper over\nPutVertices and shares its guard rails."
+    },
     "protobufAny": {
       "type": "object",
       "properties": {
@@ -474,6 +701,9 @@
           }
         }
       }
+    },
+    "v1AddEdgeResponse": {
+      "type": "object"
     },
     "v1AddEdgesRequest": {
       "type": "object",
@@ -712,6 +942,9 @@
       ],
       "default": "OPTIMIZATION_UNSPECIFIED"
     },
+    "v1PutEdgeResponse": {
+      "type": "object"
+    },
     "v1PutEdgesRequest": {
       "type": "object",
       "properties": {
@@ -734,6 +967,9 @@
           "description": "Number of edges accepted (overwritten or created)."
         }
       }
+    },
+    "v1PutVertexResponse": {
+      "type": "object"
     },
     "v1PutVerticesRequest": {
       "type": "object",

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -140,6 +140,13 @@ func (s *LanternService) GetVertices(ctx context.Context, request *pb.GetVertice
 	return resp, nil
 }
 
+func (s *LanternService) PutVertex(ctx context.Context, request *pb.PutVertexRequest) (*pb.PutVertexResponse, error) {
+	if _, err := s.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: []*pb.Vertex{request.GetVertex()}}); err != nil {
+		return nil, err
+	}
+	return &pb.PutVertexResponse{}, nil
+}
+
 func (s *LanternService) PutVertices(ctx context.Context, request *pb.PutVerticesRequest) (*pb.PutVerticesResponse, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
@@ -214,6 +221,13 @@ func (s *LanternService) GetEdges(ctx context.Context, request *pb.GetEdgesReque
 	return resp, nil
 }
 
+func (s *LanternService) AddEdge(ctx context.Context, request *pb.AddEdgeRequest) (*pb.AddEdgeResponse, error) {
+	if _, err := s.AddEdges(ctx, &pb.AddEdgesRequest{Edges: []*pb.Edge{request.GetEdge()}}); err != nil {
+		return nil, err
+	}
+	return &pb.AddEdgeResponse{}, nil
+}
+
 func (s *LanternService) AddEdges(ctx context.Context, request *pb.AddEdgesRequest) (*pb.AddEdgesResponse, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
@@ -230,6 +244,13 @@ func (s *LanternService) AddEdges(ctx context.Context, request *pb.AddEdgesReque
 	}
 	s.cache.AddEdgesWithExpiration(items)
 	return &pb.AddEdgesResponse{Written: int32(len(items))}, nil
+}
+
+func (s *LanternService) PutEdge(ctx context.Context, request *pb.PutEdgeRequest) (*pb.PutEdgeResponse, error) {
+	if _, err := s.PutEdges(ctx, &pb.PutEdgesRequest{Edges: []*pb.Edge{request.GetEdge()}}); err != nil {
+		return nil, err
+	}
+	return &pb.PutEdgeResponse{}, nil
 }
 
 func (s *LanternService) PutEdges(ctx context.Context, request *pb.PutEdgesRequest) (*pb.PutEdgesResponse, error) {

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -314,3 +314,54 @@ func TestLanternService_RespectsContextCancel(t *testing.T) {
 		t.Errorf("code = %v, want Canceled", st.Code())
 	}
 }
+
+// TestLanternService_SingularWriteFacades verifies that PutVertex / AddEdge /
+// PutEdge behave like single-element calls to their plural counterparts.
+func TestLanternService_SingularWriteFacades(t *testing.T) {
+	s := newTestService(t)
+	ctx := context.Background()
+	exp := futureTs(time.Minute)
+
+	// PutVertex writes a single vertex visible via GetVertex.
+	if _, err := s.PutVertex(ctx, &pb.PutVertexRequest{
+		Vertex: &pb.Vertex{Key: "k", Value: &pb.Vertex_String_{String_: "v"}, Expiration: exp},
+	}); err != nil {
+		t.Fatalf("PutVertex: %v", err)
+	}
+	if gv, err := s.GetVertex(ctx, &pb.GetVertexRequest{Key: "k"}); err != nil {
+		t.Fatalf("GetVertex: %v", err)
+	} else if got := gv.GetVertex().GetString_(); got != "v" {
+		t.Errorf("vertex value = %q, want %q", got, "v")
+	}
+
+	// AddEdge accumulates weight just like AddEdges.
+	for range 2 {
+		if _, err := s.AddEdge(ctx, &pb.AddEdgeRequest{
+			Edge: &pb.Edge{Tail: "a", Head: "b", Weight: 1.5, Expiration: exp},
+		}); err != nil {
+			t.Fatalf("AddEdge: %v", err)
+		}
+	}
+	if ge, err := s.GetEdge(ctx, &pb.GetEdgeRequest{Tail: "a", Head: "b"}); err != nil {
+		t.Fatalf("GetEdge: %v", err)
+	} else if ge.GetEdge().GetWeight() != 3 {
+		t.Errorf("weight = %v, want 3 (additive)", ge.GetEdge().GetWeight())
+	}
+
+	// PutEdge replaces weight (idempotent) instead of accumulating.
+	if _, err := s.PutEdge(ctx, &pb.PutEdgeRequest{
+		Edge: &pb.Edge{Tail: "a", Head: "b", Weight: 9, Expiration: exp},
+	}); err != nil {
+		t.Fatalf("PutEdge: %v", err)
+	}
+	if _, err := s.PutEdge(ctx, &pb.PutEdgeRequest{
+		Edge: &pb.Edge{Tail: "a", Head: "b", Weight: 9, Expiration: exp},
+	}); err != nil {
+		t.Fatalf("PutEdge(repeat): %v", err)
+	}
+	if ge, err := s.GetEdge(ctx, &pb.GetEdgeRequest{Tail: "a", Head: "b"}); err != nil {
+		t.Fatalf("GetEdge: %v", err)
+	} else if ge.GetEdge().GetWeight() != 9 {
+		t.Errorf("weight = %v, want 9 (replaced)", ge.GetEdge().GetWeight())
+	}
+}


### PR DESCRIPTION
Closes #81.

Completes the singular/plural symmetry across the entire gRPC surface. The read side already had this pattern (`GetVertex` / `GetVertices`, `DeleteVertex` / `DeleteVertices`, etc., introduced in #75); this PR adds it to the three write-side RPCs that were plural-only.

## What's new

| Singular RPC | Wraps | HTTP binding |
|---|---|---|
| `PutVertex` | `PutVertices` | `PUT /v1/vertices/{vertex.key}` |
| `AddEdge` | `AddEdges` | `POST /v1/edges/{edge.tail}/{edge.head}/add` |
| `PutEdge` | `PutEdges` | `PUT /v1/edges/{edge.tail}/{edge.head}` |

Each handler is a thin facade — it wraps the input into a one-element slice and delegates to the plural method, inheriting all validation, locking, and context handling.

## Why

- **Ergonomics**: callers that already have a single `Vertex` / `Edge` no longer need to wrap it in a slice for every write.
- **Symmetry**: matches the pattern already established on the read/delete side.
- **REST surface**: gateway routes for singular writes can target a specific key, which is more idiomatic than the bulk `/add` and `/put` endpoints.

## Non-changes

- The Go SDK already exposed both singular and plural Go-level methods (singular delegated to plural gRPC calls). It is intentionally left alone in this PR — switching the singular SDK methods to call the new singular RPCs is a separate, optional follow-up.
- Plural semantics, response shapes, and `Written` counts are unchanged.

## Tests

- New `TestLanternService_SingularWriteFacades` covers all three new RPCs and asserts the inherited semantics: `PutVertex` round-trip, `AddEdge` accumulates weight, `PutEdge` replaces weight.
- `go test -race -count=1 ./...` green in both the root module and `sdks/go` (incl. `tests/integration`).
- `gofmt -l .` clean, `go vet ./...` clean.