### PR TITLE
fix(#87): surface existed/deleted from CLI delete commands

### DIFF
--- a/cli/cmd/edge.go
+++ b/cli/cmd/edge.go
@@ -207,7 +207,13 @@ When more than one pair is given the batch RPC (DeleteEdges) is used,
 chunked at --chunk-size (default 1000).
 
 OUTPUT
-  Prints "OK <n>" on success, where <n> is the number of pairs submitted.
+  Single-pair form: prints "OK existed=true" if the edge was present
+  (and therefore removed) or "OK existed=false" if it was already
+  absent. Either way the exit code is 0 — delete is idempotent.
+
+  Batch form: prints "OK <n>" where <n> is the number of pairs that
+  actually existed and were removed (as reported by the server),
+  which may be smaller than the number of pairs submitted.
 
 EXAMPLES
   lantern edge delete alice:bob
@@ -236,15 +242,18 @@ EXAMPLES
 		defer func() { _ = cli.Close() }()
 
 		if len(refs) == 1 {
-			if _, err := cli.DeleteEdge(cmd.Context(), refs[0].Tail, refs[0].Head); err != nil {
+			existed, err := cli.DeleteEdge(cmd.Context(), refs[0].Tail, refs[0].Head)
+			if err != nil {
 				return err
 			}
-		} else {
-			if err := cli.DeleteEdges(cmd.Context(), refs); err != nil {
-				return err
-			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK existed=%t\n", existed)
+			return nil
 		}
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK %d\n", len(refs))
+		deleted, err := cli.DeleteEdges(cmd.Context(), refs)
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK %d\n", deleted)
 		return nil
 	},
 }

--- a/cli/cmd/vertex.go
+++ b/cli/cmd/vertex.go
@@ -149,7 +149,13 @@ EDGE CLEANUP
   immediately after DeleteVertex may still return the edge briefly.
 
 OUTPUT
-  Prints "OK <n>" on success, where <n> is the number of keys submitted.
+  Single-key form: prints "OK existed=true" if the key was present (and
+  therefore removed) or "OK existed=false" if it was already absent.
+  Either way the exit code is 0 — delete is idempotent.
+
+  Batch form: prints "OK <n>" where <n> is the number of keys that
+  actually existed and were removed (as reported by the server),
+  which may be smaller than the number of keys submitted.
 
 EXAMPLES
   lantern vertex delete alice                       # single
@@ -165,15 +171,18 @@ EXAMPLES
 		defer func() { _ = cli.Close() }()
 
 		if len(args) == 1 {
-			if _, err := cli.DeleteVertex(cmd.Context(), args[0]); err != nil {
+			existed, err := cli.DeleteVertex(cmd.Context(), args[0])
+			if err != nil {
 				return err
 			}
-		} else {
-			if err := cli.DeleteVertices(cmd.Context(), args); err != nil {
-				return err
-			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK existed=%t\n", existed)
+			return nil
 		}
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK %d\n", len(args))
+		deleted, err := cli.DeleteVertices(cmd.Context(), args)
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK %d\n", deleted)
 		return nil
 	},
 }

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -245,24 +245,30 @@ func (l *Lantern) DeleteVertex(ctx context.Context, key string) (bool, error) {
 // respect the server's MaxBatchSize cap. Edges incident to removed vertices
 // are reaped lazily by the server's GC loop.
 //
+// Returns the number of keys that actually existed and were therefore
+// removed (summed across chunks). Keys absent at call time are silently
+// skipped — they do not appear in the count and do not produce errors.
+//
 // Partial-write semantics: chunks are sent sequentially. On failure the
 // returned error is a *BatchError whose Written field records the number of
 // keys already deleted, so callers can resume with keys[err.Written:].
-func (l *Lantern) DeleteVertices(ctx context.Context, keys []string) error {
+func (l *Lantern) DeleteVertices(ctx context.Context, keys []string) (int, error) {
 	if len(keys) == 0 {
-		return nil
+		return 0, nil
 	}
 	written := 0
+	deleted := 0
 	for _, chunk := range chunkSlice(keys, l.opts.batchChunkSize) {
 		ctx, cancel := l.applyTimeout(ctx)
-		_, err := l.client.DeleteVertices(ctx, &pb.DeleteVerticesRequest{Keys: chunk})
+		resp, err := l.client.DeleteVertices(ctx, &pb.DeleteVerticesRequest{Keys: chunk})
 		cancel()
 		if err != nil {
-			return &BatchError{Written: written, Err: wrapStatus(err)}
+			return deleted, &BatchError{Written: written, Err: wrapStatus(err)}
 		}
 		written += len(chunk)
+		deleted += int(resp.GetDeleted())
 	}
-	return nil
+	return deleted, nil
 }
 
 // GetVertices reads a batch of vertices in one (or a few chunked) round
@@ -402,28 +408,34 @@ type EdgeRef struct {
 
 // DeleteEdges removes a batch of edges. Automatically chunked.
 //
+// Returns the number of edges that actually existed and were therefore
+// removed (summed across chunks). Edges absent at call time are silently
+// skipped — they do not appear in the count and do not produce errors.
+//
 // Partial-write semantics: chunks are sent sequentially. On failure the
 // returned error is a *BatchError whose Written field records the number of
 // edges already deleted, so callers can resume with refs[err.Written:].
-func (l *Lantern) DeleteEdges(ctx context.Context, refs []EdgeRef) error {
+func (l *Lantern) DeleteEdges(ctx context.Context, refs []EdgeRef) (int, error) {
 	if len(refs) == 0 {
-		return nil
+		return 0, nil
 	}
 	keys := make([]*pb.EdgeKey, 0, len(refs))
 	for _, r := range refs {
 		keys = append(keys, &pb.EdgeKey{Tail: r.Tail, Head: r.Head})
 	}
 	written := 0
+	deleted := 0
 	for _, chunk := range chunkSlice(keys, l.opts.batchChunkSize) {
 		ctx, cancel := l.applyTimeout(ctx)
-		_, err := l.client.DeleteEdges(ctx, &pb.DeleteEdgesRequest{Edges: chunk})
+		resp, err := l.client.DeleteEdges(ctx, &pb.DeleteEdgesRequest{Edges: chunk})
 		cancel()
 		if err != nil {
-			return &BatchError{Written: written, Err: wrapStatus(err)}
+			return deleted, &BatchError{Written: written, Err: wrapStatus(err)}
 		}
 		written += len(chunk)
+		deleted += int(resp.GetDeleted())
 	}
-	return nil
+	return deleted, nil
 }
 
 // GetEdges reads a batch of edges in one (or a few chunked) round trips.

--- a/tests/integration/middleware_chain_test.go
+++ b/tests/integration/middleware_chain_test.go
@@ -183,8 +183,10 @@ func TestIntegration_BatchDeletes(t *testing.T) {
 				t.Fatalf("PutVertex(%s): %v", k, err)
 			}
 		}
-		if err := c.DeleteVertices(ctx, keys); err != nil {
+		if n, err := c.DeleteVertices(ctx, keys); err != nil {
 			t.Fatalf("DeleteVertices: %v", err)
+		} else if n != len(keys) {
+			t.Errorf("DeleteVertices n = %d, want %d", n, len(keys))
 		}
 		for _, k := range keys {
 			if _, err := c.GetVertex(ctx, k); status.Code(err) != codes.NotFound {
@@ -206,8 +208,10 @@ func TestIntegration_BatchDeletes(t *testing.T) {
 			t.Fatalf("PutEdge: %v", err)
 		}
 		refs := []client.EdgeRef{{Tail: "ea", Head: "eb"}, {Tail: "ea", Head: "ex"}}
-		if err := c.DeleteEdges(ctx, refs); err != nil {
+		if n, err := c.DeleteEdges(ctx, refs); err != nil {
 			t.Fatalf("DeleteEdges: %v", err)
+		} else if n != len(refs) {
+			t.Errorf("DeleteEdges n = %d, want %d", n, len(refs))
 		}
 		for _, r := range refs {
 			if _, err := c.GetEdge(ctx, r.Tail, r.Head); status.Code(err) != codes.NotFound {
@@ -217,14 +221,18 @@ func TestIntegration_BatchDeletes(t *testing.T) {
 	})
 
 	t.Run("delete vertices empty is no-op", func(t *testing.T) {
-		if err := c.DeleteVertices(ctx, nil); err != nil {
+		if n, err := c.DeleteVertices(ctx, nil); err != nil {
 			t.Errorf("DeleteVertices(nil): %v", err)
+		} else if n != 0 {
+			t.Errorf("DeleteVertices(nil) n = %d, want 0", n)
 		}
 	})
 
 	t.Run("delete edges empty is no-op", func(t *testing.T) {
-		if err := c.DeleteEdges(ctx, nil); err != nil {
+		if n, err := c.DeleteEdges(ctx, nil); err != nil {
 			t.Errorf("DeleteEdges(nil): %v", err)
+		} else if n != 0 {
+			t.Errorf("DeleteEdges(nil) n = %d, want 0", n)
 		}
 	})
 
@@ -245,7 +253,7 @@ func TestIntegration_BatchDeletes(t *testing.T) {
 		for i := range keys {
 			keys[i] = string(rune('a' + i))
 		}
-		if err := bigClient.DeleteVertices(ctx, keys); status.Code(err) != codes.InvalidArgument {
+		if _, err := bigClient.DeleteVertices(ctx, keys); status.Code(err) != codes.InvalidArgument {
 			t.Errorf("DeleteVertices(6) code = %v, want InvalidArgument", status.Code(err))
 		}
 	})
@@ -265,7 +273,7 @@ func TestIntegration_BatchDeletes(t *testing.T) {
 		for i := range refs {
 			refs[i] = client.EdgeRef{Tail: string(rune('a' + i)), Head: "z"}
 		}
-		if err := bigClient.DeleteEdges(ctx, refs); status.Code(err) != codes.InvalidArgument {
+		if _, err := bigClient.DeleteEdges(ctx, refs); status.Code(err) != codes.InvalidArgument {
 			t.Errorf("DeleteEdges(6) code = %v, want InvalidArgument", status.Code(err))
 		}
 	})


### PR DESCRIPTION
Closes #87.

The CLI's `vertex delete` and `edge delete` swallowed the boolean returned by the singular RPCs and printed `OK <len(args)>` for batch deletes, which lied when some keys were already absent.

### Changes

- **SDK** (`sdks/go`): `DeleteVertices` / `DeleteEdges` now return `(int, error)`, summing `DeleteVerticesResponse.Deleted` / `DeleteEdgesResponse.Deleted` across chunks. **Breaking** for direct SDK consumers (callers must add `_, ` or capture the count).
- **CLI**: singular form prints `OK existed=true|false`; batch form prints `OK <n>` using the server-reported count.
- **Integration tests**: assert the new return values, including the empty-input no-op case.

### Verification
- `go build ./...` ✓
- `go test ./...` ✓ (cli/cmd + tests/integration both green)