### PR TITLE
fix(#89): publish both v-prefixed and bare Docker tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,7 +68,13 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Publish BOTH v-prefixed and bare tag families so consumers can
+          # use the canonical git-style "vX.Y.Z" form (which matches `git tag`
+          # and `gh release`) AND the SemVer-pure form. See #89.
           tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}

--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ flowchart LR
 docker run --rm -p 6380:6380 ghcr.io/anaregdesign/lantern:latest
 ```
 
+Released images are published to `ghcr.io/anaregdesign/lantern` on every
+`vX.Y.Z` git tag. **Both** tag families are available from `v0.8.0` onward:
+
+- `vX.Y.Z` / `vX.Y` / `vX` — matches the git tag and `gh release` URL.
+- `X.Y.Z` / `X.Y` / `X` — bare SemVer (the only form for `v0.5.0`–`v0.7.0`).
+
+Plus `latest` (most recent release) and `sha-<short>` for each build.
+
 Or build from source:
 
 ```shell


### PR DESCRIPTION
Closes #89.

Git tags use `vX.Y.Z` but the Docker workflow's `docker/metadata-action` config silently dropped the `v` prefix from v0.5.0 onward, so `docker pull ghcr.io/anaregdesign/lantern:v0.7.0` returned `manifest unknown`.

### Change

The workflow now publishes both tag families per release:
- `vX.Y.Z` / `vX.Y` / `vX` — matches git tags and `gh release` URLs
- `X.Y.Z` / `X.Y` / `X` — bare SemVer (the only form for v0.5.0–v0.7.0)

Plus `latest` and `sha-<short>`.

Effective from v0.8.0 onward; older releases are not back-filled (issue notes this is acceptable).

### Files

- `.github/workflows/docker-publish.yml` — added `type=semver,pattern=v{{...}}` siblings alongside the existing bare patterns.
- `README.md` — documents both tag families.

### Verification
Yaml-only change; no Go build needed. The metadata-action `v{{version}}` / `v{{major}}.{{minor}}` / `v{{major}}` syntax is the canonical pattern documented for re-prefixing.