### PR TITLE
feat(server): expose lantern_* domain Prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,16 @@ Lantern ships production-grade observability out of the box:
   logging interceptor.
 - **Prometheus metrics** — gRPC server metrics (including a handling-time
   histogram) plus Go runtime and process collectors, exposed on
-  `LANTERN_METRICS_ADDR` at `/metrics`.
+  `LANTERN_METRICS_ADDR` at `/metrics`. Lantern also publishes its own
+  domain collectors so you can chart cache load and GC pressure directly:
+
+  | Metric | Type | Labels | Description |
+  |---|---|---|---|
+  | `lantern_vertices` | gauge | — | Live vertex count in the in-memory cache. |
+  | `lantern_edges` | gauge | — | Live edge count in the in-memory cache. |
+  | `lantern_ttl_expirations_total` | counter | `kind` (`vertex`, `edge`, `dangling_edge`) | Entries reaped per GC tick, partitioned by kind. |
+  | `lantern_gc_duration_seconds` | histogram | — | Wall-clock duration of a single GC tick (buckets `0.1ms..~1.6s`). |
+  | `lantern_build_info` | gauge (=1) | `version`, `commit`, `go_version` | Build metadata for the running server. |
 - **Health checks** — gRPC standard health service (`grpc.health.v1.Health`)
   *and* HTTP `/healthz` + `/readyz` on the metrics listener, so both
   Kubernetes probes and `grpc_health_probe` work.

--- a/core/cache/cache.go
+++ b/core/cache/cache.go
@@ -93,13 +93,18 @@ func (c *Cache[S, T]) Count() int {
 	return len(c.cache)
 }
 
-func (c *Cache[S, T]) Flush() {
+// Flush evicts every entry whose TTL has passed. It returns the number of
+// entries removed so callers (e.g. server-side TTL metrics) can record
+// expiration counts without scanning the cache again.
+func (c *Cache[S, T]) Flush() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	before := len(c.cache)
 	maps.DeleteFunc(c.cache, func(_ S, v volatile[T]) bool {
 		return v.IsExpired()
 	})
+	return before - len(c.cache)
 }
 
 func (c *Cache[S, T]) Watch(ctx context.Context, interval time.Duration) {

--- a/core/cache/graph/cache.go
+++ b/core/cache/graph/cache.go
@@ -17,6 +17,18 @@ type GraphCache[S comparable, T any] struct {
 	defaultTTL time.Duration
 	vertices   *cache.Cache[S, T]
 	edges      *edgeCache[S]
+
+	// GC observability hooks. Both are optional; the cache stays metrics-free
+	// by default. The server wires Prometheus collectors via SetGCHooks so
+	// reporting lives outside core.
+	//
+	// onExpire is invoked once per Watch tick per kind ("vertex" | "edge" |
+	// "dangling_edge") with the number of entries the tick removed.
+	// onGCDuration is invoked once per Watch tick with the wall-clock time
+	// spent inside the tick.
+	hookMu       sync.RWMutex
+	onExpire     func(kind string, n int)
+	onGCDuration func(d time.Duration)
 }
 
 func NewGraphCache[S comparable, T any](defaultTTL time.Duration) *GraphCache[S, T] {
@@ -129,17 +141,53 @@ func (c *GraphCache[S, T]) DeleteEdge(tail, head S) bool {
 
 	return c.edges.delete(tail, head)
 }
-func (c *GraphCache[S, T]) flush() {
+func (c *GraphCache[S, T]) flush() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	removed := 0
 	for tail, heads := range c.edges.snapshotTF() {
 		for head := range heads {
 			if !c.vertices.Has(tail) || !c.vertices.Has(head) {
-				c.edges.delete(tail, head)
+				if c.edges.delete(tail, head) {
+					removed++
+				}
 			}
 		}
 	}
+	return removed
+}
+
+// VertexCount returns the live vertex count under an RLock. Intended for
+// Prometheus gauges that sample the cache periodically.
+func (c *GraphCache[S, T]) VertexCount() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.vertices.Count()
+}
+
+// EdgeCount returns the live (tail, head) edge count under an RLock. Like
+// VertexCount it is intended for periodic gauge sampling, not hot paths.
+func (c *GraphCache[S, T]) EdgeCount() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.edges.count()
+}
+
+// SetGCHooks installs optional observability callbacks invoked from Watch
+// after every GC tick. Either argument may be nil. Hooks must not call back
+// into the cache (re-entrant locking would deadlock). Safe for concurrent use.
+func (c *GraphCache[S, T]) SetGCHooks(onExpire func(kind string, n int), onGCDuration func(d time.Duration)) {
+	c.hookMu.Lock()
+	defer c.hookMu.Unlock()
+	c.onExpire = onExpire
+	c.onGCDuration = onGCDuration
+}
+
+func (c *GraphCache[S, T]) snapshotHooks() (func(string, int), func(time.Duration)) {
+	c.hookMu.RLock()
+	defer c.hookMu.RUnlock()
+	return c.onExpire, c.onGCDuration
 }
 
 func (c *GraphCache[S, T]) Neighbor(seed S, step int, k int, tfidf bool) *graph.Graph[S, T] {
@@ -284,9 +332,26 @@ func (c *GraphCache[S, T]) Watch(ctx context.Context, interval time.Duration) {
 	for {
 		select {
 		case <-ticker.C:
-			c.vertices.Flush()
-			c.edges.flush()
-			c.flush()
+			start := time.Now()
+			vExpired := c.vertices.Flush()
+			eExpired := c.edges.flush()
+			dRemoved := c.flush()
+			d := time.Since(start)
+			onExpire, onGC := c.snapshotHooks()
+			if onExpire != nil {
+				if vExpired > 0 {
+					onExpire("vertex", vExpired)
+				}
+				if eExpired > 0 {
+					onExpire("edge", eExpired)
+				}
+				if dRemoved > 0 {
+					onExpire("dangling_edge", dRemoved)
+				}
+			}
+			if onGC != nil {
+				onGC(d)
+			}
 
 		case <-ctx.Done():
 			return

--- a/core/cache/graph/edge.go
+++ b/core/cache/graph/edge.go
@@ -210,15 +210,30 @@ func (c *edgeCache[S]) deleteLocked(tail, head S) bool {
 	return true
 }
 
-func (c *edgeCache[S]) flush() {
+func (c *edgeCache[S]) flush() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	removed := 0
 	for tail, heads := range c.tf {
 		for head, w := range heads {
 			if w.isZero() {
 				c.deleteLocked(tail, head)
+				removed++
 			}
 		}
 	}
+	return removed
+}
+
+// count returns the current number of (tail, head) edges held in tf.
+// It acquires only an RLock so it is safe to call from metric collectors.
+func (c *edgeCache[S]) count() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	n := 0
+	for _, heads := range c.tf {
+		n += len(heads)
+	}
+	return n
 }

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/anaregdesign/lantern/server/provider"
 	"github.com/anaregdesign/lantern/server/service"
+	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
@@ -24,6 +25,7 @@ type App struct {
 	grpc    *service.LanternServer
 	metrics *provider.MetricsServer
 	tracing *provider.Tracing
+	domain  *domainmetrics.DomainMetrics
 	health  *health.Server
 }
 
@@ -33,6 +35,7 @@ func newApp(
 	grpcServer *service.LanternServer,
 	metricsServer *provider.MetricsServer,
 	tracing *provider.Tracing,
+	domain *domainmetrics.DomainMetrics,
 	hs *health.Server,
 	_ registeredHealth,
 ) *App {
@@ -42,6 +45,7 @@ func newApp(
 		grpc:    grpcServer,
 		metrics: metricsServer,
 		tracing: tracing,
+		domain:  domain,
 		health:  hs,
 	}
 }
@@ -63,6 +67,7 @@ func (a *App) Run(ctx context.Context) error {
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error { return a.grpc.Run(gctx) })
 	g.Go(func() error { return a.metrics.Run(gctx) })
+	g.Go(func() error { a.domain.Run(gctx); return nil })
 	g.Go(func() error {
 		<-gctx.Done()
 		a.health.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -8,9 +8,9 @@ import (
 	"syscall"
 	"time"
 
+	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
 	"github.com/anaregdesign/lantern/server/provider"
 	"github.com/anaregdesign/lantern/server/service"
-	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"

--- a/server/cmd/wire.go
+++ b/server/cmd/wire.go
@@ -16,6 +16,7 @@ func initializeApp() (*App, error) {
 		provider.NewLogger,
 		provider.NewTracing,
 		provider.NewGraphCache,
+		provider.NewDomainMetrics,
 		provider.NewListener,
 		provider.NewPrometheusRegistry,
 		provider.NewGrpcServerMetrics,

--- a/server/cmd/wire_gen.go
+++ b/server/cmd/wire_gen.go
@@ -37,7 +37,8 @@ func initializeApp() (*App, error) {
 	if err != nil {
 		return nil, err
 	}
+	domainMetrics := provider.NewDomainMetrics(registry, graphCache)
 	mainRegisteredHealth := registerHealthAndReflection(config, server, healthServer)
-	app := newApp(config, logger, lanternServer, metricsServer, tracing, healthServer, mainRegisteredHealth)
+	app := newApp(config, logger, lanternServer, metricsServer, tracing, domainMetrics, healthServer, mainRegisteredHealth)
 	return app, nil
 }

--- a/server/go.mod
+++ b/server/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/google/subcommands v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1,0 +1,168 @@
+// Package metrics defines the Lantern-specific Prometheus collectors exposed
+// on the /metrics endpoint. It deliberately knows nothing about the cache
+// implementation: callers wire it up by installing the returned sampler and
+// hook callbacks on the GraphCache.
+package metrics
+
+import (
+	"context"
+	"runtime"
+	"runtime/debug"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Sampler is the gauge-population callback installed by the server. It is
+// invoked on a fixed cadence (defaults to the GC interval) and reads the live
+// vertex/edge counts off the cache.
+type Sampler func() (vertices int, edges int)
+
+// DomainMetrics owns the Lantern-specific collectors. Construct with New and
+// pass the returned callbacks to GraphCache.SetGCHooks plus Start to begin
+// gauge sampling.
+type DomainMetrics struct {
+	vertices    prometheus.Gauge
+	edges       prometheus.Gauge
+	expirations *prometheus.CounterVec
+	gcDuration  prometheus.Histogram
+	buildInfo   *prometheus.GaugeVec
+
+	sampleInterval time.Duration
+	sample         Sampler
+}
+
+// Options configures DomainMetrics. Version/Commit fall back to debug.BuildInfo
+// fields when left empty so a tagged release reports the right values without
+// extra plumbing.
+type Options struct {
+	Version        string
+	Commit         string
+	SampleInterval time.Duration
+}
+
+// New registers the five `lantern_*` collectors on the supplied registerer and
+// emits `lantern_build_info` immediately. Returns the DomainMetrics handle
+// callers wire into the cache.
+func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
+	if opts.SampleInterval <= 0 {
+		opts.SampleInterval = 15 * time.Second
+	}
+
+	m := &DomainMetrics{
+		vertices: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "lantern_vertices",
+			Help: "Number of vertices currently held by the in-memory graph cache.",
+		}),
+		edges: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "lantern_edges",
+			Help: "Number of edges currently held by the in-memory graph cache.",
+		}),
+		expirations: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "lantern_ttl_expirations_total",
+			Help: "Total entries reaped by the periodic GC tick, partitioned by kind (vertex, edge, dangling_edge).",
+		}, []string{"kind"}),
+		gcDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "lantern_gc_duration_seconds",
+			Help:    "Wall-clock duration of a single GraphCache GC tick.",
+			Buckets: prometheus.ExponentialBuckets(0.0001, 4, 8), // 0.1ms .. ~1.6s
+		}),
+		buildInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "lantern_build_info",
+			Help: "Build metadata for the running Lantern server. Always 1; inspect labels for version/commit/go_version.",
+		}, []string{"version", "commit", "go_version"}),
+		sampleInterval: opts.SampleInterval,
+	}
+
+	reg.MustRegister(m.vertices, m.edges, m.expirations, m.gcDuration, m.buildInfo)
+
+	// Pre-create label rows so empty counters are still scraped as 0.
+	for _, k := range []string{"vertex", "edge", "dangling_edge"} {
+		m.expirations.WithLabelValues(k)
+	}
+
+	version, commit := opts.Version, opts.Commit
+	if version == "" || commit == "" {
+		v, c := readBuildInfo()
+		if version == "" {
+			version = v
+		}
+		if commit == "" {
+			commit = c
+		}
+	}
+	m.buildInfo.WithLabelValues(version, commit, runtime.Version()).Set(1)
+
+	return m
+}
+
+// OnExpire records reaped entries from a single GC tick.
+func (m *DomainMetrics) OnExpire(kind string, n int) {
+	if n <= 0 {
+		return
+	}
+	m.expirations.WithLabelValues(kind).Add(float64(n))
+}
+
+// OnGCDuration records the wall-clock duration of a single GC tick.
+func (m *DomainMetrics) OnGCDuration(d time.Duration) {
+	m.gcDuration.Observe(d.Seconds())
+}
+
+// BindSampler stores the gauge-population callback. Must be called before
+// Run; safe to call exactly once during wiring.
+func (m *DomainMetrics) BindSampler(s Sampler) {
+	m.sample = s
+}
+
+// Run drives the gauge sampler on the configured cadence until ctx is done.
+// Safe to launch as a goroutine. A nil sampler is treated as a no-op so
+// tests can construct the collectors without wiring a cache.
+func (m *DomainMetrics) Run(ctx context.Context) {
+	if m.sample == nil {
+		<-ctx.Done()
+		return
+	}
+	// Take an immediate sample so /metrics has live values before the first tick.
+	m.tick()
+	t := time.NewTicker(m.sampleInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			m.tick()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (m *DomainMetrics) tick() {
+	v, e := m.sample()
+	m.vertices.Set(float64(v))
+	m.edges.Set(float64(e))
+}
+
+// readBuildInfo extracts the module version and vcs.revision from the binary's
+// embedded build info. Returns "(devel)"/"unknown" when fields are absent.
+func readBuildInfo() (version, commit string) {
+	version = "(devel)"
+	commit = "unknown"
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	if bi.Main.Version != "" {
+		version = bi.Main.Version
+	}
+	for _, s := range bi.Settings {
+		if s.Key == "vcs.revision" && s.Value != "" {
+			commit = s.Value
+			if len(commit) > 12 {
+				commit = commit[:12]
+			}
+			break
+		}
+	}
+	return
+}

--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -1,0 +1,79 @@
+package metrics
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestDomainMetrics_ExposesLanternFamilies(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := New(reg, Options{Version: "v0.7.0", Commit: "deadbeef", SampleInterval: time.Hour})
+	m.BindSampler(func() (int, int) { return 12, 34 })
+
+	// Drive one tick directly so gauges have values without spinning up Run.
+	m.tick()
+	m.OnExpire("vertex", 2)
+	m.OnExpire("edge", 5)
+	m.OnExpire("dangling_edge", 1)
+	m.OnGCDuration(7 * time.Millisecond)
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	names := make(map[string]bool, len(mfs))
+	for _, mf := range mfs {
+		names[mf.GetName()] = true
+	}
+	for _, want := range []string{
+		"lantern_vertices",
+		"lantern_edges",
+		"lantern_ttl_expirations_total",
+		"lantern_gc_duration_seconds",
+		"lantern_build_info",
+	} {
+		if !names[want] {
+			t.Errorf("metric family %q not registered", want)
+		}
+	}
+
+	if got := testutil.ToFloat64(m.vertices); got != 12 {
+		t.Errorf("lantern_vertices = %v, want 12", got)
+	}
+	if got := testutil.ToFloat64(m.edges); got != 34 {
+		t.Errorf("lantern_edges = %v, want 34", got)
+	}
+	if got := testutil.ToFloat64(m.expirations.WithLabelValues("vertex")); got != 2 {
+		t.Errorf("expirations[vertex] = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(m.expirations.WithLabelValues("edge")); got != 5 {
+		t.Errorf("expirations[edge] = %v, want 5", got)
+	}
+	if got := testutil.ToFloat64(m.expirations.WithLabelValues("dangling_edge")); got != 1 {
+		t.Errorf("expirations[dangling_edge] = %v, want 1", got)
+	}
+
+	// build_info should be exactly 1 with the labels we passed.
+	if got := testutil.ToFloat64(m.buildInfo.WithLabelValues("v0.7.0", "deadbeef", runtime.Version())); got != 1 {
+		t.Errorf("lantern_build_info gauge = %v, want 1", got)
+	}
+}
+
+func TestDomainMetrics_Run_NoSampler_StopsOnContextCancel(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := New(reg, Options{SampleInterval: time.Millisecond})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { m.Run(ctx); close(done) }()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+}

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/anaregdesign/lantern/core/cache/graph"
 	v1 "github.com/anaregdesign/lantern/pb/graph/v1"
+	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
@@ -187,6 +188,23 @@ func NewLogger(c *Config) *slog.Logger {
 
 func NewGraphCache(c *Config) *graph.GraphCache[string, *v1.Vertex] {
 	return graph.NewGraphCache[string, *v1.Vertex](c.TTL)
+}
+
+// NewDomainMetrics registers the Lantern-specific `lantern_*` collectors on
+// the shared Prometheus registry and wires the GraphCache GC hooks so each
+// Watch tick updates the eviction counters and histogram. The gauge sampler
+// runs from DomainMetrics.Run, started by App alongside the other long-lived
+// goroutines.
+func NewDomainMetrics(
+	reg *prometheus.Registry,
+	cache *graph.GraphCache[string, *v1.Vertex],
+) *domainmetrics.DomainMetrics {
+	m := domainmetrics.New(reg, domainmetrics.Options{})
+	m.BindSampler(func() (int, int) {
+		return cache.VertexCount(), cache.EdgeCount()
+	})
+	cache.SetGCHooks(m.OnExpire, m.OnGCDuration)
+	return m
 }
 
 func NewListener(c *Config) (net.Listener, error) {


### PR DESCRIPTION
Closes #90.

Adds a dedicated `server/metrics` package that registers five Lantern-specific collectors on the existing `/metrics` endpoint:

| Metric | Type | Labels |
|---|---|---|
| `lantern_vertices` | gauge | — |
| `lantern_edges` | gauge | — |
| `lantern_ttl_expirations_total` | counter | `kind` (vertex/edge/dangling_edge, pre-warmed) |
| `lantern_gc_duration_seconds` | histogram | — (buckets 0.1ms..~1.6s) |
| `lantern_build_info` | gauge=1 | `version`, `commit`, `go_version` |

### Design

- `core/cache/graph` stays metrics-free. New `VertexCount` / `EdgeCount` accessors plus a `SetGCHooks(onExpire, onGCDuration)` surface let the server own all Prometheus wiring — keeps the dep direction clean.
- Each `Watch` tick now times itself and reports per-kind reap counts; hooks are only invoked when a count is positive (duration is always observed).
- `Cache.Flush` / edge `flush` were updated to return the number of evicted entries. All existing call sites use statement form, so this is non-breaking.
- Provider `NewDomainMetrics` binds the cache sampler and hooks; `App.Run` launches `DomainMetrics.Run` alongside the gRPC and HTTP servers.

### Verification

- `go build ./...` + `go test ./...` green across all five modules.
- New unit tests in `server/metrics/metrics_test.go` cover registration of the five families, counter/gauge population, build_info labels, and `Run` context-cancel semantics.
- Manual smoke: `curl -s :9090/metrics | grep '^lantern_'` lists all five families with pre-warmed zero counter rows for vertex/edge/dangling_edge.

### Sibling issues

Verified the acceptance criteria for #91 (OTEL tracer provider) are unaffected by this PR.