### PR TITLE
fix(server): wire OTel TracerProvider with OTLP exporter (closes #91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,8 +323,14 @@ Lantern ships production-grade observability out of the box:
   Kubernetes probes and `grpc_health_probe` work.
 - **Distributed tracing** — OpenTelemetry server instrumentation via
   `otelgrpc.NewServerHandler()` (modern stats-handler API; the deprecated
-  unary/stream interceptors are not used). Wire up an exporter via the standard
-  `OTEL_EXPORTER_OTLP_*` env vars to ship traces.
+  unary/stream interceptors are not used). Set `OTEL_EXPORTER_OTLP_ENDPOINT`
+  (or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`) to install an OTLP exporter and
+  start shipping spans; without it the global tracer provider stays at noop
+  so there is zero export overhead. `OTEL_EXPORTER_OTLP_PROTOCOL` selects
+  `grpc` (default) or `http/protobuf`, and all standard OTel SDK env vars
+  (`OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_INSECURE`,
+  `OTEL_EXPORTER_OTLP_TIMEOUT`, …) are honoured. The tracer provider is
+  flushed on graceful shutdown.
 - **gRPC reflection** — registered by default; turn off with
   `LANTERN_REFLECTION=false` for hardened deployments.
 - **Keepalive + panic recovery** — sensible `keepalive.ServerParameters` and

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/anaregdesign/lantern/server/provider"
 	"github.com/anaregdesign/lantern/server/service"
@@ -22,6 +23,7 @@ type App struct {
 	logger  *slog.Logger
 	grpc    *service.LanternServer
 	metrics *provider.MetricsServer
+	tracing *provider.Tracing
 	health  *health.Server
 }
 
@@ -30,6 +32,7 @@ func newApp(
 	logger *slog.Logger,
 	grpcServer *service.LanternServer,
 	metricsServer *provider.MetricsServer,
+	tracing *provider.Tracing,
 	hs *health.Server,
 	_ registeredHealth,
 ) *App {
@@ -38,6 +41,7 @@ func newApp(
 		logger:  logger,
 		grpc:    grpcServer,
 		metrics: metricsServer,
+		tracing: tracing,
 		health:  hs,
 	}
 }
@@ -63,6 +67,11 @@ func (a *App) Run(ctx context.Context) error {
 		<-gctx.Done()
 		a.health.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
 		a.health.Shutdown()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := a.tracing.Shutdown(shutdownCtx); err != nil {
+			a.logger.Warn("otel tracer shutdown returned error", slog.Any("err", err))
+		}
 		return nil
 	})
 	return g.Wait()

--- a/server/cmd/wire.go
+++ b/server/cmd/wire.go
@@ -14,6 +14,7 @@ func initializeApp() (*App, error) {
 	wire.Build(
 		provider.NewConfig,
 		provider.NewLogger,
+		provider.NewTracing,
 		provider.NewGraphCache,
 		provider.NewListener,
 		provider.NewPrometheusRegistry,

--- a/server/cmd/wire_gen.go
+++ b/server/cmd/wire_gen.go
@@ -33,7 +33,11 @@ func initializeApp() (*App, error) {
 	healthServer := provider.NewHealthServer()
 	lanternServer := service.NewLanternServer(lanternService, server, listener, logger, lifecycleConfig, healthServer)
 	metricsServer := provider.NewMetricsServer(config, registry, logger)
+	tracing, err := provider.NewTracing(logger)
+	if err != nil {
+		return nil, err
+	}
 	mainRegisteredHealth := registerHealthAndReflection(config, server, healthServer)
-	app := newApp(config, logger, lanternServer, metricsServer, healthServer, mainRegisteredHealth)
+	app := newApp(config, logger, lanternServer, metricsServer, tracing, healthServer, mainRegisteredHealth)
 	return app, nil
 }

--- a/server/go.mod
+++ b/server/go.mod
@@ -10,6 +10,11 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
 	github.com/prometheus/client_golang v1.23.2
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0
+	go.opentelemetry.io/otel v1.44.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0
+	go.opentelemetry.io/otel/sdk v1.44.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
 	google.golang.org/grpc v1.81.1
@@ -18,10 +23,12 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/subcommands v1.2.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -29,9 +36,9 @@ require (
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,5 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -55,6 +57,12 @@ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.6
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0/go.mod h1:D7J12YRapIekYyPWgGPlA/23pRmpSEZC5xJC/TTLI9U=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 h1:4YsVu3B8+3qtWYYrsUYgn0OG78pN0rnNPRGX4SbokQI=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0/go.mod h1:+wnlSn0mD1ADVMe3v9Z/WIaiz6q6gL2J/ejaAmdmv80=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 h1:qazEJlUOQzhCpzQpFETGby7EdqjI1wsd0W+6Gg1SCTU=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0/go.mod h1:fOD2Yefuxixkx3ahVNf0O/PERb6r4OlbxfATVnYvzCo=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0 h1:lgh3PiVrRUWMLOVSkQicxzZll5NjF1r+AtsX1XRIHw0=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0/go.mod h1:5Cnhth3m/AgOeTgE3ex12pPmiu/gGtZit03kSzx9X7s=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/sdk v1.44.0 h1:nHYwb9lK+fJPU/dnT6s7W7Z8itMWyqrnVfbheVYrZ58=
@@ -63,6 +71,8 @@ go.opentelemetry.io/otel/sdk/metric v1.44.0 h1:3LlKgI+VjbVsjNRFZJZAJ30WjXC5VkNRk
 go.opentelemetry.io/otel/sdk/metric v1.44.0/go.mod h1:5B5pMARnXxKhltooO4xUuCBorl65a4EpnTalObqOigA=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
+go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
+go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=

--- a/server/provider/tracing.go
+++ b/server/provider/tracing.go
@@ -1,0 +1,131 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"runtime/debug"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+// Tracing owns the optional OpenTelemetry TracerProvider. The zero value (and
+// a nil receiver) represent "tracing disabled" — Shutdown is a no-op.
+type Tracing struct {
+	tp     *sdktrace.TracerProvider
+	logger *slog.Logger
+}
+
+// NewTracing installs an OTLP tracer provider when the standard OTel env vars
+// are present, hooks it into the global otel.SetTracerProvider so the
+// existing otelgrpc stats handler actually exports spans, and returns a
+// handle whose Shutdown is wired into App's graceful-stop path.
+//
+// Activation rules:
+//   - OTEL_EXPORTER_OTLP_ENDPOINT (or the trace-specific
+//     OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) must be set; otherwise no provider
+//     is installed and the global default (noop) stays in place.
+//   - OTEL_EXPORTER_OTLP_PROTOCOL (or _TRACES_PROTOCOL) selects the wire
+//     protocol — `grpc` (default) or `http/protobuf`.
+//
+// All other OTel SDK env vars (insecure, headers, timeout, …) are honoured by
+// the exporters out of the box.
+func NewTracing(logger *slog.Logger) (*Tracing, error) {
+	endpoint := firstNonEmpty(
+		os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"),
+		os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
+	)
+	if endpoint == "" {
+		logger.Info("otel tracing disabled (OTEL_EXPORTER_OTLP_ENDPOINT unset)")
+		return &Tracing{logger: logger}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	protocol := firstNonEmpty(
+		os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"),
+		os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL"),
+		"grpc",
+	)
+
+	var (
+		exp otlptrace.Client
+	)
+	switch protocol {
+	case "grpc":
+		exp = otlptracegrpc.NewClient()
+	case "http/protobuf", "http":
+		exp = otlptracehttp.NewClient()
+	default:
+		return nil, fmt.Errorf("unsupported OTEL_EXPORTER_OTLP_PROTOCOL=%q (want grpc|http/protobuf)", protocol)
+	}
+
+	exporter, err := otlptrace.New(ctx, exp)
+	if err != nil {
+		return nil, fmt.Errorf("init otlp trace exporter: %w", err)
+	}
+
+	res, err := resource.Merge(
+		resource.Default(),
+		resource.NewSchemaless(
+			semconv.ServiceName("lantern"),
+			semconv.ServiceVersion(buildVersion()),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build otel resource: %w", err)
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tp)
+	// Propagate W3C tracecontext + baggage so spans link across services.
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	logger.Info("otel tracing enabled",
+		slog.String("endpoint", endpoint),
+		slog.String("protocol", protocol),
+	)
+	return &Tracing{tp: tp, logger: logger}, nil
+}
+
+// Shutdown flushes pending spans and tears down the exporter. Safe to call on
+// a nil receiver or when tracing was never enabled.
+func (t *Tracing) Shutdown(ctx context.Context) error {
+	if t == nil || t.tp == nil {
+		return nil
+	}
+	return t.tp.Shutdown(ctx)
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func buildVersion() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok || bi.Main.Version == "" {
+		return "(devel)"
+	}
+	return bi.Main.Version
+}


### PR DESCRIPTION
Closes #91.

## Summary

The server already installs `otelgrpc.NewServerHandler()` as a gRPC stats handler, but no SDK `TracerProvider` was ever registered, so every span went to the global noop and nothing was ever exported.

This PR adds an opt-in OTLP tracer provider that activates when the standard OTel env vars are set.

## Changes

- `server/provider/tracing.go` (new): `NewTracing(logger)` reads `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. If unset, returns a no-op handle (zero overhead). If set, builds an OTLP exporter (`grpc` default or `http/protobuf` via `OTEL_EXPORTER_OTLP_PROTOCOL`), constructs a batching `sdktrace.TracerProvider` with `service.name=lantern` + version resource attrs, installs it globally, and registers W3C tracecontext + baggage propagators.
- `server/cmd/wire.go` / `wire_gen.go`: wired `provider.NewTracing` into the App graph.
- `server/cmd/server.go`: `App` now holds `*provider.Tracing` and calls `Shutdown` with a 5s deadline from the graceful-stop goroutine to flush pending spans.
- `README.md`: Observability section updated with activation rules.

## Test

```
go build ./...
go test ./...   # all packages green (root + server)
```

Tracing remains disabled by default — no behavior change for existing deployments.