### PR TITLE
refactor(server): depend on Backend/Watcher interfaces (closes #100)

### DIFF
--- a/server/cmd/wire.go
+++ b/server/cmd/wire.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"github.com/anaregdesign/lantern/core/cache/graph"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/server/provider"
 	"github.com/anaregdesign/lantern/server/service"
 	"github.com/google/wire"
@@ -28,6 +30,8 @@ func initializeApp() (*App, error) {
 		service.NewLanternService,
 		service.NewLanternServer,
 		wire.Bind(new(service.HealthSetter), new(*health.Server)),
+		wire.Bind(new(service.Backend), new(*graph.GraphCache[string, *pb.Vertex])),
+		wire.Bind(new(service.Watcher), new(*graph.GraphCache[string, *pb.Vertex])),
 		registerHealthAndReflection,
 		newApp,
 	)

--- a/server/cmd/wire_gen.go
+++ b/server/cmd/wire_gen.go
@@ -31,7 +31,7 @@ func initializeApp() (*App, error) {
 	}
 	lifecycleConfig := provider.NewLifecycleConfig(config)
 	healthServer := provider.NewHealthServer()
-	lanternServer := service.NewLanternServer(lanternService, server, listener, logger, lifecycleConfig, healthServer)
+	lanternServer := service.NewLanternServer(lanternService, server, listener, logger, lifecycleConfig, healthServer, graphCache)
 	metricsServer := provider.NewMetricsServer(config, registry, logger)
 	tracing, err := provider.NewTracing(logger)
 	if err != nil {

--- a/server/service/backend.go
+++ b/server/service/backend.go
@@ -1,0 +1,41 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/cache/graph"
+	coregraph "github.com/anaregdesign/lantern/core/graph"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+)
+
+// Backend is the narrow seam the service depends on instead of the concrete
+// *graph.GraphCache. The interface is consumer-defined here so adding new
+// service-layer RPCs widens it deliberately, and tests can supply a fake.
+//
+// The batch types (graph.VertexItem, graph.EdgeItem, graph.EdgeKey) remain
+// imported as plain value structs — they describe data, not behavior, so
+// re-declaring them would just shuffle conversions without buying anything.
+type Backend interface {
+	// vertex reads/writes
+	GetVertex(key string) (*pb.Vertex, bool)
+	AddVerticesWithExpiration(items []graph.VertexItem[string, *pb.Vertex])
+	DeleteVertices(keys []string) int
+
+	// edge reads/writes
+	GetEdgeDetail(tail, head string) (float32, time.Time, bool)
+	AddEdgesWithExpiration(items []graph.EdgeItem[string])
+	PutEdgesWithExpiration(items []graph.EdgeItem[string])
+	DeleteEdges(keys []graph.EdgeKey[string]) int
+
+	// neighborhood traversal
+	NeighborWithExpirationsContext(
+		ctx context.Context,
+		seed string,
+		step, k int,
+		tfidf bool,
+	) (*coregraph.Graph[string, *pb.Vertex], map[string]map[string]time.Time, error)
+
+	// background GC loop driven by LanternServer.
+	Watch(ctx context.Context, interval time.Duration)
+}

--- a/server/service/fake_backend_test.go
+++ b/server/service/fake_backend_test.go
@@ -1,0 +1,199 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/cache/graph"
+	coregraph "github.com/anaregdesign/lantern/core/graph"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeBackend is a hand-rolled Backend stub exercised by tests that want to
+// drive specific success/error paths without standing up a real GraphCache.
+// Unset fields default to zero/empty so each test fills only what it needs.
+type fakeBackend struct {
+	vertices    map[string]*pb.Vertex
+	edges       map[string]map[string]float32
+	neighborErr error
+
+	addVerticesCalls int
+	deleteVertices   int
+	addEdgesCalls    int
+	putEdgesCalls    int
+	deleteEdges      int
+}
+
+func newFakeBackend() *fakeBackend {
+	return &fakeBackend{
+		vertices: map[string]*pb.Vertex{},
+		edges:    map[string]map[string]float32{},
+	}
+}
+
+func (f *fakeBackend) GetVertex(key string) (*pb.Vertex, bool) {
+	v, ok := f.vertices[key]
+	return v, ok
+}
+
+func (f *fakeBackend) AddVerticesWithExpiration(items []graph.VertexItem[string, *pb.Vertex]) {
+	f.addVerticesCalls++
+	for _, it := range items {
+		f.vertices[it.Key] = it.Value
+	}
+}
+
+func (f *fakeBackend) DeleteVertices(keys []string) int {
+	n := 0
+	for _, k := range keys {
+		if _, ok := f.vertices[k]; ok {
+			delete(f.vertices, k)
+			n++
+		}
+	}
+	f.deleteVertices += n
+	return n
+}
+
+func (f *fakeBackend) GetEdgeDetail(tail, head string) (float32, time.Time, bool) {
+	if row, ok := f.edges[tail]; ok {
+		if w, ok := row[head]; ok {
+			return w, time.Time{}, true
+		}
+	}
+	return 0, time.Time{}, false
+}
+
+func (f *fakeBackend) AddEdgesWithExpiration(items []graph.EdgeItem[string]) {
+	f.addEdgesCalls++
+	for _, it := range items {
+		if f.edges[it.Tail] == nil {
+			f.edges[it.Tail] = map[string]float32{}
+		}
+		f.edges[it.Tail][it.Head] += it.Weight
+	}
+}
+
+func (f *fakeBackend) PutEdgesWithExpiration(items []graph.EdgeItem[string]) {
+	f.putEdgesCalls++
+	for _, it := range items {
+		if f.edges[it.Tail] == nil {
+			f.edges[it.Tail] = map[string]float32{}
+		}
+		f.edges[it.Tail][it.Head] = it.Weight
+	}
+}
+
+func (f *fakeBackend) DeleteEdges(keys []graph.EdgeKey[string]) int {
+	n := 0
+	for _, k := range keys {
+		if row, ok := f.edges[k.Tail]; ok {
+			if _, ok := row[k.Head]; ok {
+				delete(row, k.Head)
+				n++
+			}
+		}
+	}
+	f.deleteEdges += n
+	return n
+}
+
+func (f *fakeBackend) NeighborWithExpirationsContext(
+	ctx context.Context,
+	seed string,
+	step, k int,
+	tfidf bool,
+) (*coregraph.Graph[string, *pb.Vertex], map[string]map[string]time.Time, error) {
+	if f.neighborErr != nil {
+		return nil, nil, f.neighborErr
+	}
+	g := coregraph.NewGraph[string, *pb.Vertex]()
+	if v, ok := f.vertices[seed]; ok {
+		g.Vertices[seed] = v
+	}
+	return g, map[string]map[string]time.Time{}, nil
+}
+
+func (f *fakeBackend) Watch(ctx context.Context, interval time.Duration) {
+	<-ctx.Done()
+}
+
+// Compile-time check that fakeBackend really satisfies Backend.
+var _ Backend = (*fakeBackend)(nil)
+
+func TestLanternService_FakeBackend_PutGetDelete(t *testing.T) {
+	fb := newFakeBackend()
+	svc := NewLanternService(fb)
+	ctx := context.Background()
+
+	v := &pb.Vertex{Key: "a", Value: &pb.Vertex_String_{String_: "alpha"}}
+	if _, err := svc.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: []*pb.Vertex{v}}); err != nil {
+		t.Fatalf("PutVertices: %v", err)
+	}
+	if fb.addVerticesCalls != 1 {
+		t.Errorf("addVerticesCalls = %d, want 1", fb.addVerticesCalls)
+	}
+
+	resp, err := svc.GetVertex(ctx, &pb.GetVertexRequest{Key: "a"})
+	if err != nil {
+		t.Fatalf("GetVertex: %v", err)
+	}
+	if got := resp.Vertex.GetString_(); got != "alpha" {
+		t.Errorf("value = %q, want \"alpha\"", got)
+	}
+
+	if _, err := svc.DeleteVertices(ctx, &pb.DeleteVerticesRequest{Keys: []string{"a"}}); err != nil {
+		t.Fatalf("DeleteVertices: %v", err)
+	}
+	if fb.deleteVertices != 1 {
+		t.Errorf("deleteVertices = %d, want 1", fb.deleteVertices)
+	}
+}
+
+func TestLanternService_FakeBackend_Illuminate_PropagatesError(t *testing.T) {
+	fb := newFakeBackend()
+	fb.neighborErr = errors.New("simulated cache failure")
+	svc := NewLanternService(fb)
+
+	_, err := svc.Illuminate(context.Background(), &pb.IlluminateRequest{Seed: "a", Step: 1, K: 1})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// status.FromContextError turns a generic non-context error into Unknown.
+	if st, _ := status.FromError(err); st.Code() != codes.Unknown {
+		t.Errorf("status code = %v, want Unknown", st.Code())
+	}
+}
+
+func TestLanternService_FakeBackend_PutAndDeleteEdge(t *testing.T) {
+	fb := newFakeBackend()
+	svc := NewLanternService(fb)
+	ctx := context.Background()
+
+	if _, err := svc.PutEdge(ctx, &pb.PutEdgeRequest{Edge: &pb.Edge{Tail: "t", Head: "h", Weight: 2.5}}); err != nil {
+		t.Fatalf("PutEdge: %v", err)
+	}
+	if fb.putEdgesCalls != 1 {
+		t.Errorf("putEdgesCalls = %d, want 1", fb.putEdgesCalls)
+	}
+
+	resp, err := svc.GetEdge(ctx, &pb.GetEdgeRequest{Tail: "t", Head: "h"})
+	if err != nil {
+		t.Fatalf("GetEdge: %v", err)
+	}
+	if resp.Edge.Weight != 2.5 {
+		t.Errorf("weight = %v, want 2.5", resp.Edge.Weight)
+	}
+
+	del, err := svc.DeleteEdge(ctx, &pb.DeleteEdgeRequest{Tail: "t", Head: "h"})
+	if err != nil {
+		t.Fatalf("DeleteEdge: %v", err)
+	}
+	if !del.Existed {
+		t.Error("Existed = false, want true")
+	}
+}

--- a/server/service/server_test.go
+++ b/server/service/server_test.go
@@ -65,6 +65,7 @@ func TestLanternServer_Run_FlipsHealthOnServeReturn(t *testing.T) {
 		slog.New(slog.NewTextHandler(discardWriter{}, nil)),
 		service.LifecycleConfig{GCInterval: time.Hour, ShutdownTimeout: time.Second},
 		hs,
+		cache,
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -28,14 +28,15 @@ const ServiceName = "graph.v1.LanternService"
 // propagate cancellation; the early ctx.Err() checks let us return a clean
 // Canceled / DeadlineExceeded status when a client already gave up.
 //
-// NOTE: the constructor keeps the concrete generic type because wire cannot
-// synthesize type arguments for generic providers.
+// The service depends on the narrow Backend interface (see backend.go); a
+// wire binding maps it to *graph.GraphCache in production. Tests can supply
+// a fake without standing up the real cache.
 type LanternService struct {
 	pb.UnimplementedLanternServiceServer
-	cache *graph.GraphCache[string, *pb.Vertex]
+	cache Backend
 }
 
-func NewLanternService(cache *graph.GraphCache[string, *pb.Vertex]) *LanternService {
+func NewLanternService(cache Backend) *LanternService {
 	return &LanternService{cache: cache}
 }
 
@@ -308,6 +309,13 @@ type LanternServer struct {
 	gcInterval      time.Duration
 	shutdownTimeout time.Duration
 	health          HealthSetter
+	watcher         Watcher
+}
+
+// Watcher is the lifecycle hook LanternServer uses to drive the cache GC
+// loop. *graph.GraphCache satisfies it; tests can stub it.
+type Watcher interface {
+	Watch(ctx context.Context, interval time.Duration)
 }
 
 // HealthSetter is the narrow surface of *health.Server that LanternServer
@@ -331,6 +339,7 @@ func NewLanternServer(
 	logger *slog.Logger,
 	cfg LifecycleConfig,
 	hs HealthSetter,
+	watcher Watcher,
 ) *LanternServer {
 	return &LanternServer{
 		service:         service,
@@ -340,6 +349,7 @@ func NewLanternServer(
 		gcInterval:      cfg.GCInterval,
 		shutdownTimeout: cfg.ShutdownTimeout,
 		health:          hs,
+		watcher:         watcher,
 	}
 }
 
@@ -376,7 +386,7 @@ func (s *LanternServer) Run(ctx context.Context) error {
 		}
 	}()
 
-	go s.service.cache.Watch(ctx, s.gcInterval)
+	go s.watcher.Watch(ctx, s.gcInterval)
 
 	s.logger.Info("grpc server starting",
 		slog.String("addr", s.listener.Addr().String()),


### PR DESCRIPTION
Closes #100.

## What

- New `Backend` and `Watcher` interfaces in [server/service/backend.go](server/service/backend.go).
- `LanternService.cache` and `LanternServer.watcher` now hold those interfaces, not the concrete `*graph.GraphCache`.
- Wire binds both to `*graph.GraphCache[string, *pb.Vertex]` in production ([server/cmd/wire.go](server/cmd/wire.go)).
- `server/service/fake_backend_test.go` exercises happy + error paths through a hand-rolled `Backend` stub.

## Deliberate trade-off

The batch value types (`graph.VertexItem`, `graph.EdgeItem`, `graph.EdgeKey`) still cross the seam as plain structs — they describe data, not behaviour, so re-declaring them would only shuffle conversions without buying testability.

## Verify

- `go build ./...` from root passes.
- `go test ./...` from root and from `server/` passes.
- Wire regenerated via `go tool wire ./cmd` (from `server/`).