### PR TITLE
refactor(sdk): extract runBatchWrite/runBatchRead helpers

### DIFF
--- a/sdks/go/batch.go
+++ b/sdks/go/batch.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"context"
+)
+
+// runBatchWrite splits items into chunks of l.opts.batchChunkSize, invokes
+// fn for each chunk with the per-call timeout applied, sums the returned
+// per-chunk counts, and wraps any failure as a *BatchError whose Written
+// field records the number of inputs that were fully committed before the
+// failing chunk.
+//
+// Used by PutVertices / DeleteVertices / AddEdges / PutEdges / DeleteEdges:
+// the four pure writes ignore the returned int (fn returns 0), and the two
+// deletes use it to report the server-side "actually existed and removed"
+// count.
+func runBatchWrite[T any](
+	ctx context.Context,
+	l *Lantern,
+	items []T,
+	fn func(ctx context.Context, chunk []T) (int32, error),
+) (int, error) {
+	if len(items) == 0 {
+		return 0, nil
+	}
+	written, total := 0, 0
+	for _, chunk := range chunkSlice(items, l.opts.batchChunkSize) {
+		cctx, cancel := l.applyTimeout(ctx)
+		n, err := fn(cctx, chunk)
+		cancel()
+		if err != nil {
+			return total, &BatchError{Written: written, Err: wrapStatus(err)}
+		}
+		written += len(chunk)
+		total += int(n)
+	}
+	return total, nil
+}
+
+// runBatchRead splits items into chunks and invokes fn for each chunk with
+// the per-call timeout applied. Read paths abort on the first failure with a
+// wrapped gRPC error (no *BatchError) — they have no partial-result contract
+// to expose. Callers accumulate into their own variables via the closure.
+func runBatchRead[T any](
+	ctx context.Context,
+	l *Lantern,
+	items []T,
+	fn func(ctx context.Context, chunk []T) error,
+) error {
+	if len(items) == 0 {
+		return nil
+	}
+	for _, chunk := range chunkSlice(items, l.opts.batchChunkSize) {
+		cctx, cancel := l.applyTimeout(ctx)
+		err := fn(cctx, chunk)
+		cancel()
+		if err != nil {
+			return wrapStatus(err)
+		}
+	}
+	return nil
+}

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -215,17 +215,11 @@ func (l *Lantern) PutVertices(ctx context.Context, inputs []VertexInput) error {
 		}
 		vs = append(vs, v)
 	}
-	written := 0
-	for _, chunk := range chunkSlice(vs, l.opts.batchChunkSize) {
-		ctx, cancel := l.applyTimeout(ctx)
+	_, err := runBatchWrite(ctx, l, vs, func(ctx context.Context, chunk []*pb.Vertex) (int32, error) {
 		_, err := l.client.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: chunk})
-		cancel()
-		if err != nil {
-			return &BatchError{Written: written, Err: wrapStatus(err)}
-		}
-		written += len(chunk)
-	}
-	return nil
+		return 0, err
+	})
+	return err
 }
 
 // DeleteVertex removes the vertex identified by key. The returned
@@ -253,22 +247,13 @@ func (l *Lantern) DeleteVertex(ctx context.Context, key string) (bool, error) {
 // returned error is a *BatchError whose Written field records the number of
 // keys already deleted, so callers can resume with keys[err.Written:].
 func (l *Lantern) DeleteVertices(ctx context.Context, keys []string) (int, error) {
-	if len(keys) == 0 {
-		return 0, nil
-	}
-	written := 0
-	deleted := 0
-	for _, chunk := range chunkSlice(keys, l.opts.batchChunkSize) {
-		ctx, cancel := l.applyTimeout(ctx)
+	return runBatchWrite(ctx, l, keys, func(ctx context.Context, chunk []string) (int32, error) {
 		resp, err := l.client.DeleteVertices(ctx, &pb.DeleteVerticesRequest{Keys: chunk})
-		cancel()
 		if err != nil {
-			return deleted, &BatchError{Written: written, Err: wrapStatus(err)}
+			return 0, err
 		}
-		written += len(chunk)
-		deleted += int(resp.GetDeleted())
-	}
-	return deleted, nil
+		return resp.GetDeleted(), nil
+	})
 }
 
 // GetVertices reads a batch of vertices in one (or a few chunked) round
@@ -277,20 +262,19 @@ func (l *Lantern) DeleteVertices(ctx context.Context, keys []string) (int, error
 // callers should match by Vertex.Key. Automatically chunked to respect the
 // server's MaxBatchSize cap.
 func (l *Lantern) GetVertices(ctx context.Context, keys []string) (found []*Vertex, missing []string, err error) {
-	if len(keys) == 0 {
-		return nil, nil, nil
-	}
-	for _, chunk := range chunkSlice(keys, l.opts.batchChunkSize) {
-		cctx, cancel := l.applyTimeout(ctx)
-		resp, rerr := l.client.GetVertices(cctx, &pb.GetVerticesRequest{Keys: chunk})
-		cancel()
+	err = runBatchRead(ctx, l, keys, func(ctx context.Context, chunk []string) error {
+		resp, rerr := l.client.GetVertices(ctx, &pb.GetVerticesRequest{Keys: chunk})
 		if rerr != nil {
-			return nil, nil, wrapStatus(rerr)
+			return rerr
 		}
 		for _, v := range resp.GetVertices() {
 			found = append(found, (*Vertex)(v))
 		}
 		missing = append(missing, resp.GetMissing()...)
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
 	}
 	return found, missing, nil
 }
@@ -333,18 +317,11 @@ func (l *Lantern) AddEdges(ctx context.Context, inputs []EdgeInput) error {
 	if len(inputs) == 0 {
 		return nil
 	}
-	edges := edgesFrom(inputs)
-	written := 0
-	for _, chunk := range chunkSlice(edges, l.opts.batchChunkSize) {
-		ctx, cancel := l.applyTimeout(ctx)
+	_, err := runBatchWrite(ctx, l, edgesFrom(inputs), func(ctx context.Context, chunk []*pb.Edge) (int32, error) {
 		_, err := l.client.AddEdges(ctx, &pb.AddEdgesRequest{Edges: chunk})
-		cancel()
-		if err != nil {
-			return &BatchError{Written: written, Err: wrapStatus(err)}
-		}
-		written += len(chunk)
-	}
-	return nil
+		return 0, err
+	})
+	return err
 }
 
 // PutEdge overwrites the (tail, head) pair.
@@ -373,18 +350,11 @@ func (l *Lantern) PutEdges(ctx context.Context, inputs []EdgeInput) error {
 	if len(inputs) == 0 {
 		return nil
 	}
-	edges := edgesFrom(inputs)
-	written := 0
-	for _, chunk := range chunkSlice(edges, l.opts.batchChunkSize) {
-		ctx, cancel := l.applyTimeout(ctx)
+	_, err := runBatchWrite(ctx, l, edgesFrom(inputs), func(ctx context.Context, chunk []*pb.Edge) (int32, error) {
 		_, err := l.client.PutEdges(ctx, &pb.PutEdgesRequest{Edges: chunk})
-		cancel()
-		if err != nil {
-			return &BatchError{Written: written, Err: wrapStatus(err)}
-		}
-		written += len(chunk)
-	}
-	return nil
+		return 0, err
+	})
+	return err
 }
 
 // DeleteEdge removes the (tail, head) edge. The returned bool reports
@@ -423,19 +393,13 @@ func (l *Lantern) DeleteEdges(ctx context.Context, refs []EdgeRef) (int, error) 
 	for _, r := range refs {
 		keys = append(keys, &pb.EdgeKey{Tail: r.Tail, Head: r.Head})
 	}
-	written := 0
-	deleted := 0
-	for _, chunk := range chunkSlice(keys, l.opts.batchChunkSize) {
-		ctx, cancel := l.applyTimeout(ctx)
+	return runBatchWrite(ctx, l, keys, func(ctx context.Context, chunk []*pb.EdgeKey) (int32, error) {
 		resp, err := l.client.DeleteEdges(ctx, &pb.DeleteEdgesRequest{Edges: chunk})
-		cancel()
 		if err != nil {
-			return deleted, &BatchError{Written: written, Err: wrapStatus(err)}
+			return 0, err
 		}
-		written += len(chunk)
-		deleted += int(resp.GetDeleted())
-	}
-	return deleted, nil
+		return resp.GetDeleted(), nil
+	})
 }
 
 // GetEdges reads a batch of edges in one (or a few chunked) round trips.
@@ -451,12 +415,10 @@ func (l *Lantern) GetEdges(ctx context.Context, refs []EdgeRef) (found []*Edge, 
 	for _, r := range refs {
 		keys = append(keys, &pb.EdgeKey{Tail: r.Tail, Head: r.Head})
 	}
-	for _, chunk := range chunkSlice(keys, l.opts.batchChunkSize) {
-		cctx, cancel := l.applyTimeout(ctx)
-		resp, rerr := l.client.GetEdges(cctx, &pb.GetEdgesRequest{Edges: chunk})
-		cancel()
+	err = runBatchRead(ctx, l, keys, func(ctx context.Context, chunk []*pb.EdgeKey) error {
+		resp, rerr := l.client.GetEdges(ctx, &pb.GetEdgesRequest{Edges: chunk})
 		if rerr != nil {
-			return nil, nil, wrapStatus(rerr)
+			return rerr
 		}
 		for _, e := range resp.GetEdges() {
 			found = append(found, (*Edge)(e))
@@ -464,6 +426,10 @@ func (l *Lantern) GetEdges(ctx context.Context, refs []EdgeRef) (found []*Edge, 
 		for _, m := range resp.GetMissing() {
 			missing = append(missing, EdgeRef{Tail: m.GetTail(), Head: m.GetHead()})
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
 	}
 	return found, missing, nil
 }


### PR DESCRIPTION
## Summary

The seven batch RPC methods in the Go SDK (`PutVertices`, `DeleteVertices`, `GetVertices`, `AddEdges`, `PutEdges`, `DeleteEdges`, `GetEdges`) all share the same chunk + per-call timeout + cancel + error-wrap loop. They split cleanly into two shapes:

- **Writes (incl. deletes-with-count):** build payload, chunk, abort with \`*BatchError{Written, wrapStatus(err)}\` on the first failure.
- **Reads:** chunk, abort with \`wrapStatus(err)\` on first failure (no partial-result contract), let the caller accumulate into closure-captured slices.

This PR introduces \`runBatchWrite[T]\` and \`runBatchRead[T]\` in \`sdks/go/batch.go\` and rewires all seven methods through them. Net diff: **+96 / −68**.

## Behavioural preservation

- \`BatchError.Written\` still records the committed-input count, so callers can resume with \`inputs[err.Written:]\`.
- \`applyTimeout\` is still called per-chunk with \`cancel\` inside the loop (not deferred), preserving the timeout boundary.
- \`wrapStatus\` still translates \`codes.NotFound\` / \`InvalidArgument\` / \`ResourceExhausted\` to the SDK sentinels.
- \`DeleteVertices\` / \`DeleteEdges\` still return the server-reported \"actually existed and removed\" count.

## Tests

- \`go build ./...\` and \`go test ./...\` from the workspace root pass.
- \`go test ./...\` inside \`sdks/go/\` passes (existing \`chunk_test.go\`, \`value_test.go\`, \`options_test.go\`, etc.).
- \`tests/integration/\` (bufconn round-trips, batch error scenarios) pass unchanged.

Closes #101