### PR TITLE
refactor(server): replace Illuminate optimization switch with strategy registry

### DIFF
--- a/server/service/optimizer.go
+++ b/server/service/optimizer.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"context"
+	"math"
+
+	coregraph "github.com/anaregdesign/lantern/core/graph"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+)
+
+// optimizer post-processes the illuminated subgraph for a given seed.
+// Implementations may rebuild the graph (e.g. spanning trees, shortest-path
+// trees) and must honour ctx for cancellation.
+type optimizer func(ctx context.Context, g *coregraph.Graph[string, *pb.Vertex], seed string) (*coregraph.Graph[string, *pb.Vertex], error)
+
+// optimizers maps each pb.Optimization variant to its strategy. The zero /
+// UNSPECIFIED variant is intentionally absent: callers treat a nil lookup
+// result as "no optimization", which preserves the original behaviour where
+// the switch's default branch was a no-op.
+//
+// Adding a new optimization is now a single map entry — no service-handler
+// edit required.
+var optimizers = map[pb.Optimization]optimizer{
+	pb.Optimization_OPTIMIZATION_MINIMUM_SPANNING_TREE: func(ctx context.Context, g *coregraph.Graph[string, *pb.Vertex], seed string) (*coregraph.Graph[string, *pb.Vertex], error) {
+		return g.MinimumSpanningTreeContext(ctx, seed)
+	},
+	pb.Optimization_OPTIMIZATION_MAXIMUM_SPANNING_TREE: func(ctx context.Context, g *coregraph.Graph[string, *pb.Vertex], seed string) (*coregraph.Graph[string, *pb.Vertex], error) {
+		return g.MaximumSpanningTreeContext(ctx, seed)
+	},
+	pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE: func(ctx context.Context, g *coregraph.Graph[string, *pb.Vertex], seed string) (*coregraph.Graph[string, *pb.Vertex], error) {
+		return g.ShortestPathTreeContext(ctx, seed, identityCost)
+	},
+	pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE: func(ctx context.Context, g *coregraph.Graph[string, *pb.Vertex], seed string) (*coregraph.Graph[string, *pb.Vertex], error) {
+		return g.ShortestPathTreeContext(ctx, seed, inverseCost)
+	},
+}
+
+func identityCost(weight float32) float32 { return weight }
+
+func inverseCost(weight float32) float32 {
+	if weight == 0 {
+		return math.MaxFloat32
+	}
+	return 1 / weight
+}

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"log/slog"
-	"math"
 	"net"
 	"time"
 
@@ -52,25 +51,11 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 		return nil, status.FromContextError(err).Err()
 	}
 
-	switch request.GetOptimization() {
-	case pb.Optimization_OPTIMIZATION_UNSPECIFIED:
-		// do nothing
-	case pb.Optimization_OPTIMIZATION_MINIMUM_SPANNING_TREE:
-		g, err = g.MinimumSpanningTreeContext(ctx, request.GetSeed())
-	case pb.Optimization_OPTIMIZATION_MAXIMUM_SPANNING_TREE:
-		g, err = g.MaximumSpanningTreeContext(ctx, request.GetSeed())
-	case pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE:
-		g, err = g.ShortestPathTreeContext(ctx, request.GetSeed(), func(weight float32) float32 { return weight })
-	case pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE:
-		g, err = g.ShortestPathTreeContext(ctx, request.GetSeed(), func(weight float32) float32 {
-			if weight == 0 {
-				return math.MaxFloat32
-			}
-			return 1 / weight
-		})
-	}
-	if err != nil {
-		return nil, status.FromContextError(err).Err()
+	if opt := optimizers[request.GetOptimization()]; opt != nil {
+		g, err = opt(ctx, g, request.GetSeed())
+		if err != nil {
+			return nil, status.FromContextError(err).Err()
+		}
 	}
 
 	if err := ctx.Err(); err != nil {


### PR DESCRIPTION
Closes #102.

## Summary
Replace the 5-arm `switch request.GetOptimization()` in `LanternService.Illuminate` with a package-level registry:

```go
var optimizers = map[pb.Optimization]optimizer{
    pb.Optimization_OPTIMIZATION_MINIMUM_SPANNING_TREE: ...,
    pb.Optimization_OPTIMIZATION_MAXIMUM_SPANNING_TREE: ...,
    pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE:         ...,
    pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE: ...,
}
```

The handler becomes a single map lookup. Adding a new optimization variant is now a one-entry change with no edit to the service handler — pure OCP.

## Behaviour preservation
- `OPTIMIZATION_UNSPECIFIED` is intentionally absent from the map. A nil lookup is treated as 'no optimization', matching the previous default-branch no-op.
- Unknown enum values (e.g. future variants from a newer client) also fall through as no-op — same as today's switch.
- Cost transforms for SPT/SPT_INVERSE are now named package-level funcs (`identityCost`, `inverseCost`) instead of inline closures.

## Verification
- `go build ./...` ✅
- `go test ./...` ✅ (root + server module both green)
- Covered by existing `TestBufconn_Illuminate_AllOptimizations` which exercises every enum variant end-to-end via bufconn.