### PR TITLE
ci: pin Go to 1.26.4

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.4'
           check-latest: true
       - name: Vet
         run: go vet ./...
@@ -121,7 +121,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.4'
           check-latest: true
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.4'
           check-latest: true
 
       - name: Verify formatting
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.4'
           check-latest: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.4'
           check-latest: true
       - uses: bufbuild/buf-setup-action@v1
         with:
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.4'
           check-latest: true
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest


### PR DESCRIPTION
Unblocks govulncheck (failing on GO-2026-5039 and GO-2026-5037, both fixed in go1.26.4). The setup-go manifest hasn't picked up 1.26.4 under the floating '1.26' tag yet, so pin explicitly until it catches up.