### PR TITLE
refactor(server): extract env-var helpers to internal/envconfig package

### DIFF
--- a/server/internal/envconfig/envconfig.go
+++ b/server/internal/envconfig/envconfig.go
@@ -1,0 +1,78 @@
+// Package envconfig is the single place where the server reads typed values
+// out of process environment variables. Keeping these helpers in one
+// dependency-light package makes them trivially unit-testable (no imports
+// from the rest of the server tree) and frees the larger provider layer from
+// reimplementing the same os.Getenv + strconv dance.
+//
+// All helpers fall back to the supplied default when the variable is unset
+// or malformed — they never return an error.
+package envconfig
+
+import (
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Int returns the integer value of the named env var, or def when unset or
+// not a valid base-10 integer.
+func Int(key string, def int) int {
+	if v, err := strconv.Atoi(os.Getenv(key)); err == nil {
+		return v
+	}
+	return def
+}
+
+// Float returns the float64 value of the named env var, or def when unset
+// or not a valid float.
+func Float(key string, def float64) float64 {
+	if v, err := strconv.ParseFloat(os.Getenv(key), 64); err == nil {
+		return v
+	}
+	return def
+}
+
+// String returns the value of the named env var, or def when unset.
+// An explicitly empty value ("") is returned as-is — only a missing variable
+// falls back to the default.
+func String(key, def string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return v
+	}
+	return def
+}
+
+// Bool returns the boolean value of the named env var, or def when unset or
+// not one of the recognised truthy/falsy spellings ("1"/"true"/"yes"/"on"
+// vs "0"/"false"/"no"/"off", case- and whitespace-insensitive).
+func Bool(key string, def bool) bool {
+	v, ok := os.LookupEnv(key)
+	if !ok {
+		return def
+	}
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return def
+	}
+}
+
+// LogLevel parses a slog level from a free-form string ("debug"/"info"/
+// "warn"|"warning"/"error", case- and whitespace-insensitive). Anything
+// unrecognised falls back to slog.LevelInfo.
+func LogLevel(s string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/server/internal/envconfig/envconfig_test.go
+++ b/server/internal/envconfig/envconfig_test.go
@@ -1,0 +1,163 @@
+package envconfig
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func TestInt(t *testing.T) {
+	const key = "LANTERN_TEST_INT"
+	cases := []struct {
+		name   string
+		set    bool
+		value  string
+		def    int
+		expect int
+	}{
+		{"unset returns default", false, "", 7, 7},
+		{"valid value", true, "42", 7, 42},
+		{"empty value falls back", true, "", 7, 7},
+		{"non-numeric falls back", true, "abc", 7, 7},
+		{"negative value", true, "-3", 0, -3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(key, tc.value)
+			} else {
+					unset(t, key)
+			}
+			if got := Int(key, tc.def); got != tc.expect {
+				t.Fatalf("Int(%q)=%d, want %d", tc.value, got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestFloat(t *testing.T) {
+	const key = "LANTERN_TEST_FLOAT"
+	cases := []struct {
+		name   string
+		set    bool
+		value  string
+		def    float64
+		expect float64
+	}{
+		{"unset returns default", false, "", 1.5, 1.5},
+		{"valid value", true, "3.14", 0, 3.14},
+		{"int parses as float", true, "10", 0, 10},
+		{"garbage falls back", true, "not-a-float", 2.5, 2.5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(key, tc.value)
+			} else {
+				unset(t, key)
+			}
+			if got := Float(key, tc.def); got != tc.expect {
+				t.Fatalf("Float(%q)=%v, want %v", tc.value, got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	const key = "LANTERN_TEST_STRING"
+	t.Run("unset returns default", func(t *testing.T) {
+		unset(t, key)
+		if got := String(key, "fallback"); got != "fallback" {
+			t.Fatalf("got %q, want fallback", got)
+		}
+	})
+	t.Run("set value wins", func(t *testing.T) {
+		t.Setenv(key, "explicit")
+		if got := String(key, "fallback"); got != "explicit" {
+			t.Fatalf("got %q, want explicit", got)
+		}
+	})
+	t.Run("empty string is honoured", func(t *testing.T) {
+		t.Setenv(key, "")
+		if got := String(key, "fallback"); got != "" {
+			t.Fatalf("got %q, want empty string", got)
+		}
+	})
+}
+
+func TestBool(t *testing.T) {
+	const key = "LANTERN_TEST_BOOL"
+	truthy := []string{"1", "true", "TRUE", " True ", "yes", "on"}
+	falsy := []string{"0", "false", " False ", "no", "off"}
+	for _, v := range truthy {
+		t.Run("truthy_"+v, func(t *testing.T) {
+			t.Setenv(key, v)
+			if !Bool(key, false) {
+				t.Fatalf("Bool(%q) should be true", v)
+			}
+		})
+	}
+	for _, v := range falsy {
+		t.Run("falsy_"+v, func(t *testing.T) {
+			t.Setenv(key, v)
+			if Bool(key, true) {
+				t.Fatalf("Bool(%q) should be false", v)
+			}
+		})
+	}
+	t.Run("unset returns default", func(t *testing.T) {
+		unset(t, key)
+		if !Bool(key, true) {
+			t.Fatal("unset should return default true")
+		}
+		if Bool(key, false) {
+			t.Fatal("unset should return default false")
+		}
+	})
+	t.Run("garbage returns default", func(t *testing.T) {
+		t.Setenv(key, "maybe")
+		if !Bool(key, true) {
+			t.Fatal("garbage should return default")
+		}
+	})
+}
+
+func TestLogLevel(t *testing.T) {
+	cases := []struct {
+		in     string
+		expect slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"DEBUG", slog.LevelDebug},
+		{" info ", slog.LevelInfo},
+		{"warn", slog.LevelWarn},
+		{"warning", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"", slog.LevelInfo},
+		{"verbose", slog.LevelInfo},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := LogLevel(tc.in); got != tc.expect {
+				t.Fatalf("LogLevel(%q)=%v, want %v", tc.in, got, tc.expect)
+			}
+		})
+	}
+}
+
+// unset removes the env var for the duration of the test, restoring its
+// prior value on cleanup.
+func unset(t *testing.T, key string) {
+	t.Helper()
+	prev, had := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, prev)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+}

--- a/server/internal/envconfig/envconfig_test.go
+++ b/server/internal/envconfig/envconfig_test.go
@@ -26,7 +26,7 @@ func TestInt(t *testing.T) {
 			if tc.set {
 				t.Setenv(key, tc.value)
 			} else {
-					unset(t, key)
+				unset(t, key)
 			}
 			if got := Int(key, tc.def); got != tc.expect {
 				t.Fatalf("Int(%q)=%d, want %d", tc.value, got, tc.expect)

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/anaregdesign/lantern/core/cache/graph"
 	v1 "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/server/internal/envconfig"
 	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
@@ -97,31 +98,31 @@ type Config struct {
 }
 
 func NewConfig() *Config {
-	rps := envFloat("LANTERN_RATE_LIMIT_RPS", 0)
-	burst := envInt("LANTERN_RATE_LIMIT_BURST", int(2*rps))
+	rps := envconfig.Float("LANTERN_RATE_LIMIT_RPS", 0)
+	burst := envconfig.Int("LANTERN_RATE_LIMIT_BURST", int(2*rps))
 	if burst <= 0 && rps > 0 {
 		burst = int(2 * rps)
 	}
 	return &Config{
-		Port:             envInt("LANTERN_PORT", 6380),
-		TTL:              time.Duration(envInt("LANTERN_DEFAULT_TTL_SECONDS", 60)) * time.Second,
-		GCInterval:       time.Duration(envInt("LANTERN_GC_INTERVAL_SECONDS", 60)) * time.Second,
-		ShutdownTimeout:  time.Duration(envInt("LANTERN_SHUTDOWN_TIMEOUT_SECONDS", 30)) * time.Second,
-		LogLevel:         parseLogLevel(os.Getenv("LANTERN_LOG_LEVEL")),
-		LogFormat:        envStr("LANTERN_LOG_FORMAT", "json"),
-		MetricsAddr:      envStr("LANTERN_METRICS_ADDR", ":9090"),
-		EnableReflection: envBool("LANTERN_REFLECTION", true),
+		Port:             envconfig.Int("LANTERN_PORT", 6380),
+		TTL:              time.Duration(envconfig.Int("LANTERN_DEFAULT_TTL_SECONDS", 60)) * time.Second,
+		GCInterval:       time.Duration(envconfig.Int("LANTERN_GC_INTERVAL_SECONDS", 60)) * time.Second,
+		ShutdownTimeout:  time.Duration(envconfig.Int("LANTERN_SHUTDOWN_TIMEOUT_SECONDS", 30)) * time.Second,
+		LogLevel:         envconfig.LogLevel(os.Getenv("LANTERN_LOG_LEVEL")),
+		LogFormat:        envconfig.String("LANTERN_LOG_FORMAT", "json"),
+		MetricsAddr:      envconfig.String("LANTERN_METRICS_ADDR", ":9090"),
+		EnableReflection: envconfig.Bool("LANTERN_REFLECTION", true),
 
-		MaxRecvMsgBytes:      envInt("LANTERN_MAX_RECV_MSG_BYTES", 16*1024*1024),
-		MaxSendMsgBytes:      envInt("LANTERN_MAX_SEND_MSG_BYTES", 16*1024*1024),
-		MaxConcurrentStreams: uint32(envInt("LANTERN_MAX_CONCURRENT_STREAMS", 1024)),
+		MaxRecvMsgBytes:      envconfig.Int("LANTERN_MAX_RECV_MSG_BYTES", 16*1024*1024),
+		MaxSendMsgBytes:      envconfig.Int("LANTERN_MAX_SEND_MSG_BYTES", 16*1024*1024),
+		MaxConcurrentStreams: uint32(envconfig.Int("LANTERN_MAX_CONCURRENT_STREAMS", 1024)),
 		RateLimitRPS:         rps,
 		RateLimitBurst:       burst,
 
-		MaxKeyLen:         envInt("LANTERN_MAX_KEY_LEN", 1024),
-		MaxBatchSize:      envInt("LANTERN_MAX_BATCH_SIZE", 10000),
-		IlluminateMaxStep: envInt("LANTERN_ILLUMINATE_MAX_STEP", 16),
-		IlluminateMaxK:    envInt("LANTERN_ILLUMINATE_MAX_K", 1024),
+		MaxKeyLen:         envconfig.Int("LANTERN_MAX_KEY_LEN", 1024),
+		MaxBatchSize:      envconfig.Int("LANTERN_MAX_BATCH_SIZE", 10000),
+		IlluminateMaxStep: envconfig.Int("LANTERN_ILLUMINATE_MAX_STEP", 16),
+		IlluminateMaxK:    envconfig.Int("LANTERN_ILLUMINATE_MAX_K", 1024),
 
 		TLSCertFile:     os.Getenv("LANTERN_TLS_CERT_FILE"),
 		TLSKeyFile:      os.Getenv("LANTERN_TLS_KEY_FILE"),
@@ -129,55 +130,6 @@ func NewConfig() *Config {
 
 		Version: os.Getenv("LANTERN_VERSION"),
 		Commit:  os.Getenv("LANTERN_COMMIT"),
-	}
-}
-
-func envInt(key string, def int) int {
-	if v, err := strconv.Atoi(os.Getenv(key)); err == nil {
-		return v
-	}
-	return def
-}
-
-func envFloat(key string, def float64) float64 {
-	if v, err := strconv.ParseFloat(os.Getenv(key), 64); err == nil {
-		return v
-	}
-	return def
-}
-
-func envStr(key, def string) string {
-	if v, ok := os.LookupEnv(key); ok {
-		return v
-	}
-	return def
-}
-
-func envBool(key string, def bool) bool {
-	v, ok := os.LookupEnv(key)
-	if !ok {
-		return def
-	}
-	switch strings.ToLower(strings.TrimSpace(v)) {
-	case "1", "true", "yes", "on":
-		return true
-	case "0", "false", "no", "off":
-		return false
-	default:
-		return def
-	}
-}
-
-func parseLogLevel(s string) slog.Level {
-	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "debug":
-		return slog.LevelDebug
-	case "warn", "warning":
-		return slog.LevelWarn
-	case "error":
-		return slog.LevelError
-	default:
-		return slog.LevelInfo
 	}
 }
 


### PR DESCRIPTION
Closes #107.

Extracts the env helpers (`envInt`, `envFloat`, `envStr`, `envBool`, `parseLogLevel`) out of `server/provider/provider.go` into a new dependency-light `server/internal/envconfig` package with full unit tests.

- `envconfig.Int/Float/String/Bool` — typed env reads with fallbacks
- `envconfig.LogLevel` — slog level parsing
- Test coverage for unset, valid, empty, malformed, truthy/falsy/garbage, and log-level case/whitespace variants
- `provider.go` now delegates to the package; no behavior change