### PR TITLE
refactor(sdks/go): alias pb types and move accessors to free functions (#106)

### DIFF
--- a/cli/cmd/edge.go
+++ b/cli/cmd/edge.go
@@ -82,7 +82,7 @@ EXAMPLES
 			"tail":       args[0],
 			"head":       args[1],
 			"weight":     e.Weight,
-			"expiration": e.ExpirationTime().Format(time.RFC3339),
+			"expiration": client.EdgeExpiration(e).Format(time.RFC3339),
 		}
 		return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
 	},

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -29,14 +29,17 @@ var ErrInvalidArgument = errors.New("invalid argument")
 // before retrying.
 var ErrResourceExhausted = errors.New("resource exhausted")
 
-// Edge is a thin type alias over the generated protobuf Edge that lets the
-// client return the full record (including Expiration) instead of just the
-// weight.
-type Edge pb.Edge
+// Edge re-exports the generated protobuf Edge type so SDK callers do not
+// need to import the pb package directly. It is a true Go type alias, not a
+// parallel struct: client.Edge and pb.Edge are the same type, freely
+// interchangeable without conversion.
+//
+// Use EdgeExpiration to read the Expiration field as a Go time.Time.
+type Edge = pb.Edge
 
-// ExpirationTime returns the absolute expiration carried by e, or the zero
+// EdgeExpiration returns the absolute expiration carried by e, or the zero
 // time if no expiration was set on the server response.
-func (e *Edge) ExpirationTime() time.Time {
+func EdgeExpiration(e *Edge) time.Time {
 	if e == nil || e.Expiration == nil {
 		return time.Time{}
 	}
@@ -174,7 +177,7 @@ func (l *Lantern) GetVertex(ctx context.Context, key string) (*Vertex, error) {
 	if err != nil {
 		return nil, wrapStatus(err)
 	}
-	return (*Vertex)(result.Vertex), nil
+	return result.Vertex, nil
 }
 
 // PutVertex upserts a single vertex with a relative TTL.
@@ -267,9 +270,7 @@ func (l *Lantern) GetVertices(ctx context.Context, keys []string) (found []*Vert
 		if rerr != nil {
 			return rerr
 		}
-		for _, v := range resp.GetVertices() {
-			found = append(found, (*Vertex)(v))
-		}
+		found = append(found, resp.GetVertices()...)
 		missing = append(missing, resp.GetMissing()...)
 		return nil
 	})
@@ -287,7 +288,7 @@ func (l *Lantern) GetEdge(ctx context.Context, tail string, head string) (*Edge,
 	if err != nil {
 		return nil, wrapStatus(err)
 	}
-	return (*Edge)(result.Edge), nil
+	return result.Edge, nil
 }
 
 // AddEdge accumulates weight onto the (tail, head) pair: repeated calls with
@@ -420,9 +421,7 @@ func (l *Lantern) GetEdges(ctx context.Context, refs []EdgeRef) (found []*Edge, 
 		if rerr != nil {
 			return rerr
 		}
-		for _, e := range resp.GetEdges() {
-			found = append(found, (*Edge)(e))
-		}
+		found = append(found, resp.GetEdges()...)
 		for _, m := range resp.GetMissing() {
 			missing = append(missing, EdgeRef{Tail: m.GetTail(), Head: m.GetHead()})
 		}
@@ -509,7 +508,7 @@ func (l *Lantern) Illuminate(ctx context.Context, seed string, opts ...Illuminat
 	}
 	g := NewGraph()
 	for _, v := range result.Graph.Vertices {
-		g.Vertices[v.Key] = (*Vertex)(v)
+		g.Vertices[v.Key] = v
 	}
 	for _, e := range result.Graph.Edges {
 		if _, ok := g.Edges[e.Tail]; !ok {

--- a/sdks/go/doc.go
+++ b/sdks/go/doc.go
@@ -1,0 +1,44 @@
+// Package client is the Go SDK for the Lantern graph service.
+//
+// # Model definition policy
+//
+// This SDK follows a strict "no parallel models" rule: wherever a protobuf
+// message already expresses a domain concept, the SDK re-exports the pb type
+// directly via a Go alias rather than introducing a parallel struct. As of
+// today this applies to:
+//
+//   - Vertex     = pb.Vertex     (see value.go)
+//   - Edge       = pb.Edge       (see client.go)
+//   - Optimization = pb.Optimization (see client.go)
+//
+// Because these are true aliases (declared with `type X = pb.X`, not
+// `type X pb.X`), client.Vertex and pb.Vertex are the same type and require
+// no conversion at the boundary. Go-friendly accessors that would normally
+// be methods are exposed as free functions in this package (Kind, IntValue,
+// StringValue, ExpirationTime, MarshalVertexJSON, EdgeExpiration, …),
+// because methods cannot be attached to aliases of types declared in
+// another package.
+//
+// A few SDK-only types remain and are intentional, not redundant:
+//
+//   - VertexInput / EdgeInput
+//     Ergonomic input shapes that accept Go-native values (any, time.Time,
+//     time.Duration) and let the SDK pick the correct pb.Vertex_* oneof
+//     variant or build a timestamppb.Timestamp. They exist to spare callers
+//     from constructing protobuf oneof wrappers by hand.
+//
+//   - EdgeRef
+//     A small comparable struct (Tail, Head string) used in batch results.
+//     pb.EdgeKey is not used here because it embeds protoimpl state, which
+//     makes it unsafe to compare with `==` in user code or to place in a
+//     map key.
+//
+//   - Graph
+//     A keyed/adjacency-map shape (map[string]*Vertex, map[string]map[string]float32)
+//     that is more convenient for client-side traversal than pb.Graph's flat
+//     slice shape. This is a deliberate shape transformation, not a duplicate
+//     data definition.
+//
+// See https://github.com/anaregdesign/lantern/issues/106 for the design
+// discussion.
+package client

--- a/sdks/go/example/main.go
+++ b/sdks/go/example/main.go
@@ -61,49 +61,49 @@ func main() {
 	*/
 	// string value
 	if vertex, err := cli.GetVertex(ctx, "string"); err == nil {
-		if v, err := vertex.StringValue(); err == nil {
+		if v, err := client.StringValue(vertex); err == nil {
 			log.Printf("%s: %s\n", vertex.Key, v)
 		}
 	}
 
 	// int value
 	if vertex, err := cli.GetVertex(ctx, "int"); err == nil {
-		if v, err := vertex.IntValue(); err == nil {
+		if v, err := client.IntValue(vertex); err == nil {
 			log.Printf("%s: %d\n", vertex.Key, v)
 		}
 	}
 
 	// float value
 	if vertex, err := cli.GetVertex(ctx, "float"); err == nil {
-		if v, err := vertex.FloatValue(); err == nil {
+		if v, err := client.FloatValue(vertex); err == nil {
 			log.Printf("%s: %f\n", vertex.Key, v)
 		}
 	}
 
 	// bool value
 	if vertex, err := cli.GetVertex(ctx, "bool"); err == nil {
-		if v, err := vertex.BoolValue(); err == nil {
+		if v, err := client.BoolValue(vertex); err == nil {
 			log.Printf("%s: %t\n", vertex.Key, v)
 		}
 	}
 
 	// time.Time value
 	if value, err := cli.GetVertex(ctx, "time"); err == nil {
-		if v, err := value.TimeValue(); err == nil {
+		if v, err := client.TimeValue(value); err == nil {
 			log.Printf("%s: %s\n", value.Key, v)
 		}
 	}
 
 	// []byte value
 	if vertex, err := cli.GetVertex(ctx, "[]byte"); err == nil {
-		if v, err := vertex.BytesValue(); err == nil {
+		if v, err := client.BytesValue(vertex); err == nil {
 			log.Printf("%s: %s\n", vertex.Key, v)
 		}
 	}
 
 	// nil value
 	if vertex, err := cli.GetVertex(ctx, "nil"); err == nil {
-		log.Printf("%s: %t\n", vertex.Key, vertex.IsNil())
+		log.Printf("%s: %t\n", vertex.Key, client.IsNil(vertex))
 	}
 
 	/*

--- a/sdks/go/value.go
+++ b/sdks/go/value.go
@@ -79,17 +79,23 @@ func (v nativeVertex) asVertex() (*pb.Vertex, error) {
 	}
 }
 
-// Vertex is a thin type alias over the generated protobuf Vertex that adds
-// Go-friendly value accessors. Convert a *pb.Vertex with (*Vertex)(p).
+// Vertex re-exports the generated protobuf Vertex type so SDK callers do not
+// need to import the pb package directly. It is a true Go type alias, not a
+// parallel struct: client.Vertex and pb.Vertex are the same type, freely
+// interchangeable without conversion.
 //
-// A Vertex whose Kind() reports VertexKindNil is a present tombstone, not a
+// Go-friendly accessors (Kind, IntValue, StringValue, ExpirationTime, …) are
+// defined as free functions in this package because methods cannot be added
+// to aliases of types declared in another package.
+//
+// A Vertex whose Kind reports VertexKindNil is a present tombstone, not a
 // missing entry: GetVertex returns it with a nil error. "Key absent" is
 // signalled separately by an error wrapping ErrNotFound. See GetVertex for
 // the full presence vs. nil-value contract.
-type Vertex pb.Vertex
+type Vertex = pb.Vertex
 
-// VertexKind identifies which oneof variant is set on a Vertex. Use
-// Vertex.Kind to dispatch without writing a switch over Value.(type).
+// VertexKind identifies which oneof variant is set on a Vertex. Use Kind to
+// dispatch without writing a switch over Value.(type).
 type VertexKind int
 
 const (
@@ -113,7 +119,7 @@ const (
 )
 
 // Kind reports which oneof variant is set on v.
-func (v *Vertex) Kind() VertexKind {
+func Kind(v *Vertex) VertexKind {
 	if v == nil {
 		return VertexKindUnset
 	}
@@ -147,19 +153,22 @@ func (v *Vertex) Kind() VertexKind {
 	}
 }
 
-// ExpirationTime returns the absolute expiration carried by v, or the zero
+// VertexExpiration returns the absolute expiration carried by v, or the zero
 // time if no expiration was set on the server response.
-func (v *Vertex) ExpirationTime() time.Time {
+func VertexExpiration(v *Vertex) time.Time {
 	if v == nil || v.Expiration == nil {
 		return time.Time{}
 	}
 	return v.Expiration.AsTime()
 }
 
-// IntValue returns the underlying signed integer value. It also accepts
+// IntValue returns the underlying signed integer value of v. It also accepts
 // unsigned variants and reports ErrOverflow when a Uint64 value exceeds
 // math.MaxInt64.
-func (v *Vertex) IntValue() (int, error) {
+func IntValue(v *Vertex) (int, error) {
+	if v == nil {
+		return 0, ErrInvalidType
+	}
 	switch x := v.Value.(type) {
 	case *pb.Vertex_Int32:
 		return int(x.Int32), nil
@@ -177,9 +186,12 @@ func (v *Vertex) IntValue() (int, error) {
 	}
 }
 
-// UIntValue returns the underlying unsigned integer value. It also accepts
-// signed variants and reports ErrOverflow when the value is negative.
-func (v *Vertex) UIntValue() (uint, error) {
+// UIntValue returns the underlying unsigned integer value of v. It also
+// accepts signed variants and reports ErrOverflow when the value is negative.
+func UIntValue(v *Vertex) (uint, error) {
+	if v == nil {
+		return 0, ErrInvalidType
+	}
 	switch x := v.Value.(type) {
 	case *pb.Vertex_Uint32:
 		return uint(x.Uint32), nil
@@ -200,8 +212,11 @@ func (v *Vertex) UIntValue() (uint, error) {
 	}
 }
 
-// FloatValue widens any numeric oneof variant to float64.
-func (v *Vertex) FloatValue() (float64, error) {
+// FloatValue widens any numeric oneof variant of v to float64.
+func FloatValue(v *Vertex) (float64, error) {
+	if v == nil {
+		return 0, ErrInvalidType
+	}
 	switch x := v.Value.(type) {
 	case *pb.Vertex_Int64:
 		return float64(x.Int64), nil
@@ -220,51 +235,76 @@ func (v *Vertex) FloatValue() (float64, error) {
 	}
 }
 
-func (v *Vertex) StringValue() (string, error) {
+// StringValue returns the underlying string value of v.
+func StringValue(v *Vertex) (string, error) {
+	if v == nil {
+		return "", ErrInvalidType
+	}
 	if x, ok := v.Value.(*pb.Vertex_String_); ok {
 		return x.String_, nil
 	}
 	return "", ErrInvalidType
 }
 
-func (v *Vertex) BoolValue() (bool, error) {
+// BoolValue returns the underlying bool value of v.
+func BoolValue(v *Vertex) (bool, error) {
+	if v == nil {
+		return false, ErrInvalidType
+	}
 	if x, ok := v.Value.(*pb.Vertex_Bool); ok {
 		return x.Bool, nil
 	}
 	return false, ErrInvalidType
 }
 
-func (v *Vertex) BytesValue() ([]byte, error) {
+// BytesValue returns the underlying bytes value of v.
+func BytesValue(v *Vertex) ([]byte, error) {
+	if v == nil {
+		return nil, ErrInvalidType
+	}
 	if x, ok := v.Value.(*pb.Vertex_Bytes); ok {
 		return x.Bytes, nil
 	}
 	return nil, ErrInvalidType
 }
 
-func (v *Vertex) TimeValue() (time.Time, error) {
+// TimeValue returns the underlying timestamp value of v as time.Time.
+func TimeValue(v *Vertex) (time.Time, error) {
+	if v == nil {
+		return time.Time{}, ErrInvalidType
+	}
 	if x, ok := v.Value.(*pb.Vertex_Timestamp); ok {
 		return x.Timestamp.AsTime(), nil
 	}
 	return time.Time{}, ErrInvalidType
 }
 
-func (v *Vertex) DurationValue() (time.Duration, error) {
+// DurationValue returns the underlying duration value of v as time.Duration.
+func DurationValue(v *Vertex) (time.Duration, error) {
+	if v == nil {
+		return 0, ErrInvalidType
+	}
 	if x, ok := v.Value.(*pb.Vertex_Duration); ok {
 		return x.Duration.AsDuration(), nil
 	}
 	return 0, ErrInvalidType
 }
 
-func (v *Vertex) IsNil() bool {
+// IsNil reports whether v carries the proto Vertex_Nil tombstone (a present
+// vertex whose value was explicitly set to nil).
+func IsNil(v *Vertex) bool {
+	if v == nil {
+		return false
+	}
 	if x, ok := v.Value.(*pb.Vertex_Nil); ok {
 		return x.Nil
 	}
 	return false
 }
 
-// MarshalJSON renders a Vertex as a stable, human-readable JSON object so
-// callers don't have to peek at protobuf-generated oneof field names (e.g.
-// "String_", "Int64", "Nil"). The shape is:
+// MarshalVertexJSON renders a Vertex as a stable, human-readable JSON object
+// so callers don't have to peek at protobuf-generated oneof field names
+// (e.g. "String_", "Int64", "Nil"). The shape is:
 //
 //	{
 //	  "key":        "<key>",                // omitted when empty
@@ -274,7 +314,12 @@ func (v *Vertex) IsNil() bool {
 //	}
 //
 // Bytes are base64-encoded (Go's default for []byte); timestamps are RFC3339Nano.
-func (v *Vertex) MarshalJSON() ([]byte, error) {
+//
+// MarshalVertexJSON exists as a free function (rather than a MarshalJSON
+// method) because Vertex is an alias of pb.Vertex and methods cannot be added
+// to aliases of types declared in another package. Callers that want this
+// shape from encoding/json should invoke MarshalVertexJSON explicitly.
+func MarshalVertexJSON(v *Vertex) ([]byte, error) {
 	out := struct {
 		Key        string `json:"key,omitempty"`
 		Type       string `json:"type"`
@@ -286,7 +331,7 @@ func (v *Vertex) MarshalJSON() ([]byte, error) {
 		return json.Marshal(out)
 	}
 	out.Key = v.Key
-	if t := v.ExpirationTime(); !t.IsZero() {
+	if t := VertexExpiration(v); !t.IsZero() {
 		out.Expiration = t.Format(time.RFC3339Nano)
 	}
 	switch x := v.Value.(type) {

--- a/sdks/go/value_kind_test.go
+++ b/sdks/go/value_kind_test.go
@@ -33,8 +33,7 @@ func TestNativeVertex_AsVertex_IntegerWidths(t *testing.T) {
 			if err != nil {
 				t.Fatalf("asVertex: %v", err)
 			}
-			wrapped := (*Vertex)(v)
-			if got := wrapped.Kind(); got != tc.kind {
+			if got := Kind(v); got != tc.kind {
 				t.Errorf("Kind = %v, want %v", got, tc.kind)
 			}
 		})
@@ -43,21 +42,21 @@ func TestNativeVertex_AsVertex_IntegerWidths(t *testing.T) {
 
 func TestVertex_IntValue_Overflow(t *testing.T) {
 	v := &Vertex{Value: &pb.Vertex_Uint64{Uint64: math.MaxUint64}}
-	if _, err := v.IntValue(); !errors.Is(err, ErrOverflow) {
+	if _, err := IntValue(v); !errors.Is(err, ErrOverflow) {
 		t.Errorf("err = %v, want ErrOverflow", err)
 	}
 }
 
 func TestVertex_UIntValue_Overflow(t *testing.T) {
 	v := &Vertex{Value: &pb.Vertex_Int64{Int64: -1}}
-	if _, err := v.UIntValue(); !errors.Is(err, ErrOverflow) {
+	if _, err := UIntValue(v); !errors.Is(err, ErrOverflow) {
 		t.Errorf("err = %v, want ErrOverflow", err)
 	}
 }
 
 func TestVertex_IntValue_CrossWidth(t *testing.T) {
 	v := &Vertex{Value: &pb.Vertex_Uint32{Uint32: 42}}
-	got, err := v.IntValue()
+	got, err := IntValue(v)
 	if err != nil {
 		t.Fatalf("IntValue: %v", err)
 	}
@@ -81,18 +80,18 @@ func TestVertex_Kind(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.v.Kind(); got != tc.want {
+			if got := Kind(tc.v); got != tc.want {
 				t.Errorf("Kind = %v, want %v", got, tc.want)
 			}
 		})
 	}
 }
 
-func TestVertex_ExpirationTime(t *testing.T) {
-	if got := (*Vertex)(nil).ExpirationTime(); !got.IsZero() {
+func TestVertexExpiration(t *testing.T) {
+	if got := VertexExpiration(nil); !got.IsZero() {
 		t.Errorf("nil vertex expiration = %v, want zero", got)
 	}
-	if got := (&Vertex{}).ExpirationTime(); !got.IsZero() {
+	if got := VertexExpiration(&Vertex{}); !got.IsZero() {
 		t.Errorf("empty expiration = %v, want zero", got)
 	}
 }

--- a/sdks/go/value_test.go
+++ b/sdks/go/value_test.go
@@ -31,7 +31,7 @@ func TestVertex_BoolValue(t *testing.T) {
 	for i := range tests {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.v.BoolValue()
+			got, err := BoolValue(&tt.v)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BoolValue() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -64,7 +64,7 @@ func TestVertex_BytesValue(t *testing.T) {
 	for i := range tests {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.v.BytesValue()
+			got, err := BytesValue(&tt.v)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BytesValue() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -97,7 +97,7 @@ func TestVertex_FloatValue(t *testing.T) {
 	for i := range tests {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.v.FloatValue()
+			got, err := FloatValue(&tt.v)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FloatValue() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -130,7 +130,7 @@ func TestVertex_IntValue(t *testing.T) {
 	for i := range tests {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.v.IntValue()
+			got, err := IntValue(&tt.v)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("IntValue() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -161,7 +161,7 @@ func TestVertex_IsNil(t *testing.T) {
 	for i := range tests {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.v.IsNil(); got != tt.want {
+			if got := IsNil(&tt.v); got != tt.want {
 				t.Errorf("IsNil() = %v, want %v", got, tt.want)
 			}
 		})
@@ -189,7 +189,7 @@ func TestVertex_StringValue(t *testing.T) {
 	for i := range tests {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.v.StringValue()
+			got, err := StringValue(&tt.v)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("StringValue() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -223,7 +223,7 @@ func TestVertex_TimeValue(t *testing.T) {
 	for i := range tests {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.v.TimeValue()
+			got, err := TimeValue(&tt.v)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("TimeValue() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -263,7 +263,7 @@ func TestVertex_DurationValue(t *testing.T) {
 	for i := range tests {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.v.DurationValue()
+			got, err := DurationValue(&tt.v)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DurationValue() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -296,7 +296,7 @@ func TestVertex_UIntValue(t *testing.T) {
 	for i := range tests {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.v.UIntValue()
+			got, err := UIntValue(&tt.v)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("UIntValue() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -358,7 +358,7 @@ func Test_nativeVertex_asVertex(t *testing.T) {
 	}
 }
 
-func TestVertex_MarshalJSON(t *testing.T) {
+func TestMarshalVertexJSON(t *testing.T) {
 	exp := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	ts := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
 	tests := []struct {
@@ -414,12 +414,12 @@ func TestVertex_MarshalJSON(t *testing.T) {
 	for i := range tests {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.v.MarshalJSON()
+			got, err := MarshalVertexJSON(tt.v)
 			if err != nil {
-				t.Fatalf("MarshalJSON() error = %v", err)
+				t.Fatalf("MarshalVertexJSON() error = %v", err)
 			}
 			if string(got) != tt.want {
-				t.Errorf("MarshalJSON() got = %s, want %s", got, tt.want)
+				t.Errorf("MarshalVertexJSON() got = %s, want %s", got, tt.want)
 			}
 		})
 	}

--- a/testbed/scripts/exercise-sdk.go
+++ b/testbed/scripts/exercise-sdk.go
@@ -100,7 +100,7 @@ func run() error {
 		if err != nil {
 			return err
 		}
-		got, err := v.StringValue()
+		got, err := client.StringValue(v)
 		if err != nil {
 			return err
 		}
@@ -114,7 +114,7 @@ func run() error {
 		if err != nil {
 			return err
 		}
-		got, err := v.IntValue()
+		got, err := client.IntValue(v)
 		if err != nil {
 			return err
 		}
@@ -128,7 +128,7 @@ func run() error {
 		if err != nil {
 			return err
 		}
-		b, err := v.BytesValue()
+		b, err := client.BytesValue(v)
 		if err != nil {
 			return err
 		}
@@ -142,7 +142,7 @@ func run() error {
 		if err != nil {
 			return err
 		}
-		t, err := v.TimeValue()
+		t, err := client.TimeValue(v)
 		if err != nil {
 			return err
 		}
@@ -156,7 +156,7 @@ func run() error {
 		if err != nil {
 			return err
 		}
-		if !v.IsNil() {
+		if !client.IsNil(v) {
 			return fmt.Errorf("expected IsNil true")
 		}
 		return nil

--- a/tests/integration/client_options_test.go
+++ b/tests/integration/client_options_test.go
@@ -131,7 +131,7 @@ func TestClient_RetryOnUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetVertex: %v", err)
 	}
-	if got, _ := v.StringValue(); got != "v" {
+	if got, _ := client.StringValue(v); got != "v" {
 		t.Errorf("StringValue = %q, want %q", got, "v")
 	}
 	if attempts < 2 {

--- a/tests/integration/client_test.go
+++ b/tests/integration/client_test.go
@@ -74,7 +74,7 @@ func TestLantern_PutGetDeleteVertex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetVertex: %v", err)
 	}
-	got, err := v.StringValue()
+	got, err := client.StringValue(v)
 	if err != nil {
 		t.Fatalf("StringValue: %v", err)
 	}

--- a/tests/integration/middleware_chain_test.go
+++ b/tests/integration/middleware_chain_test.go
@@ -78,7 +78,7 @@ func TestIntegration_FullMiddlewareChain(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetVertex: %v", err)
 		}
-		if got, _ := v.StringValue(); got != "hello" {
+		if got, _ := client.StringValue(v); got != "hello" {
 			t.Errorf("StringValue = %q, want %q", got, "hello")
 		}
 	})


### PR DESCRIPTION
Closes #106.

## What

Resolves issue #106 by adopting **Option 1 (Direct alias / no parallel models)** from the issue body, applied as deeply as possible in the SDK.

- `type Vertex pb.Vertex` → `type Vertex = pb.Vertex` (true Go alias)
- `type Edge pb.Edge` → `type Edge = pb.Edge` (true Go alias)
- All methods previously hung on these named types are moved to free functions, since methods cannot be attached to aliases of types declared in another package.
- All `(*Vertex)(p)` / `(*Edge)(p)` casts in `client.go` are removed — pb values flow through unchanged.

## API change table

| Before | After |
|---|---|
| `v.Kind()` | `Kind(v)` |
| `v.IntValue()` | `IntValue(v)` |
| `v.UIntValue()` | `UIntValue(v)` |
| `v.FloatValue()` | `FloatValue(v)` |
| `v.StringValue()` | `StringValue(v)` |
| `v.BoolValue()` | `BoolValue(v)` |
| `v.BytesValue()` | `BytesValue(v)` |
| `v.TimeValue()` | `TimeValue(v)` |
| `v.DurationValue()` | `DurationValue(v)` |
| `v.IsNil()` | `IsNil(v)` |
| `v.ExpirationTime()` | `VertexExpiration(v)` |
| `v.MarshalJSON()` | `MarshalVertexJSON(v)` |
| `e.ExpirationTime()` | `EdgeExpiration(e)` |

## Why

> 出来るだけ冗長なモデル定義を避ける形で SDK を実装してください．

The previous named-type wrappers introduced a *separate type identity* from pb, forcing casts at every boundary (`(*Vertex)(result.Vertex)`) even though they added zero data fields. With aliases, the SDK now reuses the pb types verbatim — there is exactly one Vertex type in the system.

## What remains as SDK-only (documented in new `sdks/go/doc.go`)

These are not redundant — they are deliberate shape/ergonomic transformations and are explained in the package doc:

- **VertexInput / EdgeInput** — Go-native input ergonomics (`any`, `time.Time`, `time.Duration`); spare callers from constructing pb oneof wrappers by hand.
- **EdgeRef** — comparable `(Tail, Head)` struct usable as a map key and with `==`; pb.EdgeKey embeds protoimpl state and is not safely comparable.
- **Graph** — adjacency-map shape (`map[string]*Vertex`, `map[string]map[string]float32`) suited to client-side traversal vs. pb.Graph's flat slices.

## Compatibility

Breaking change for `sdks/go` callers. SDK is pre-v1.0 (no `sdks/go/v1.0.0` tag yet) so this is the right time per the issue.

## Verification

Local quality gate run before push: `gofmt`, `go vet`, all tests across all 5 modules (root, core, pb, sdks/go, server) — green.