### PR TITLE
test(core/cache/graph): add memory and throughput benchmarks

### DIFF
--- a/core/cache/graph/bench_test.go
+++ b/core/cache/graph/bench_test.go
@@ -1,0 +1,169 @@
+package graph
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// makeKey returns a string of length n. It mimics a normalized URL by
+// prefixing with a fixed scheme and padding the rest with the deterministic
+// index so each key is unique and the byte content cannot be deduplicated by
+// chance.
+func makeKey(prefix string, idx int, length int) string {
+	tail := fmt.Sprintf("/%010d", idx)
+	if len(prefix)+len(tail) >= length {
+		return (prefix + tail)[:length]
+	}
+	var b strings.Builder
+	b.Grow(length)
+	b.WriteString(prefix)
+	b.WriteString(tail)
+	for b.Len() < length {
+		b.WriteByte('a' + byte(idx%26))
+	}
+	return b.String()[:length]
+}
+
+// benchScale lets a single benchmark function cover several workload sizes
+// while staying small enough to run in CI when -short is passed.
+type benchScale struct {
+	name     string
+	vertices int
+	degree   int
+	keyLen   int
+}
+
+func smallScales(short bool) []benchScale {
+	if short {
+		return []benchScale{
+			{name: "v1k_d8_k80", vertices: 1_000, degree: 8, keyLen: 80},
+		}
+	}
+	return []benchScale{
+		{name: "v1k_d8_k80", vertices: 1_000, degree: 8, keyLen: 80},
+		{name: "v10k_d16_k80", vertices: 10_000, degree: 16, keyLen: 80},
+		{name: "v100k_d32_k80", vertices: 100_000, degree: 32, keyLen: 80},
+	}
+}
+
+// populate fills the cache with `s.vertices` vertices and `s.vertices*s.degree`
+// edges. Heads are picked deterministically (round-robin offset) so the graph
+// is dense enough to exercise the inner edge map without becoming pathological.
+func populate(b *testing.B, c *GraphCache[string, string], s benchScale) []string {
+	b.Helper()
+	keys := make([]string, s.vertices)
+	for i := 0; i < s.vertices; i++ {
+		keys[i] = makeKey("https://example.com", i, s.keyLen)
+	}
+	expiration := time.Now().Add(time.Hour)
+	vs := make([]VertexItem[string, string], s.vertices)
+	for i, k := range keys {
+		vs[i] = VertexItem[string, string]{Key: k, Value: "", Expiration: expiration}
+	}
+	c.AddVerticesWithExpiration(vs)
+
+	es := make([]EdgeItem[string], 0, s.vertices*s.degree)
+	for i := 0; i < s.vertices; i++ {
+		for j := 1; j <= s.degree; j++ {
+			head := keys[(i+j)%s.vertices]
+			es = append(es, EdgeItem[string]{
+				Tail:       keys[i],
+				Head:       head,
+				Weight:     1,
+				Expiration: expiration,
+			})
+		}
+	}
+	c.AddEdgesWithExpiration(es)
+	return keys
+}
+
+// reportHeap captures the heap-in-use delta caused by populating the cache.
+// It is the single most important number this file produces: it is what
+// every subsequent optimization PR must move downward.
+func reportHeap(b *testing.B, before, after runtime.MemStats, scale benchScale) {
+	b.Helper()
+	heapDelta := after.HeapInuse - before.HeapInuse
+	allocDelta := after.TotalAlloc - before.TotalAlloc
+	edges := scale.vertices * scale.degree
+	b.ReportMetric(float64(heapDelta), "heap_inuse_B")
+	if edges > 0 {
+		b.ReportMetric(float64(heapDelta)/float64(edges), "heap_inuse_B/edge")
+	}
+	if scale.vertices > 0 {
+		b.ReportMetric(float64(heapDelta)/float64(scale.vertices), "heap_inuse_B/vertex")
+	}
+	b.ReportMetric(float64(allocDelta), "alloc_B")
+}
+
+// BenchmarkGraphCacheMemory reports heap-in-use after populating a cache at
+// several scales. Run with:
+//
+//	go test -bench=BenchmarkGraphCacheMemory -benchmem -benchtime=1x ./core/cache/graph
+//
+// The b.N loop iteration count is forced to 1 by -benchtime=1x so the heap
+// snapshot reflects exactly one populated cache. Without -benchtime=1x the
+// reported numbers still scale linearly with b.N — divide accordingly.
+func BenchmarkGraphCacheMemory(b *testing.B) {
+	for _, s := range smallScales(testing.Short()) {
+		s := s
+		b.Run(s.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				var before, after runtime.MemStats
+				runtime.GC()
+				runtime.ReadMemStats(&before)
+				c := NewGraphCache[string, string](time.Hour)
+				populate(b, c, s)
+				runtime.GC()
+				runtime.ReadMemStats(&after)
+				reportHeap(b, before, after, s)
+				runtime.KeepAlive(c)
+			}
+		})
+	}
+}
+
+// BenchmarkGraphCacheAddEdges measures throughput of the additive edge
+// path, which is the hot ingest path. Allocations per op are the headline
+// metric here.
+func BenchmarkGraphCacheAddEdges(b *testing.B) {
+	for _, s := range smallScales(testing.Short()) {
+		s := s
+		b.Run(s.name, func(b *testing.B) {
+			c := NewGraphCache[string, string](time.Hour)
+			keys := make([]string, s.vertices)
+			for i := range keys {
+				keys[i] = makeKey("https://example.com", i, s.keyLen)
+			}
+			expiration := time.Now().Add(time.Hour)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				tail := keys[i%s.vertices]
+				head := keys[(i+1)%s.vertices]
+				c.AddEdgeWithExpiration(tail, head, 1, expiration)
+			}
+		})
+	}
+}
+
+// BenchmarkGraphCacheGetWeight measures the lookup hot path.
+func BenchmarkGraphCacheGetWeight(b *testing.B) {
+	for _, s := range smallScales(testing.Short()) {
+		s := s
+		b.Run(s.name, func(b *testing.B) {
+			c := NewGraphCache[string, string](time.Hour)
+			keys := populate(b, c, s)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				tail := keys[i%s.vertices]
+				head := keys[(i+1)%s.vertices]
+				_, _ = c.GetWeight(tail, head)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a baseline benchmark harness for `GraphCache` so the upcoming internal-vertexID refactor (Phase 2 — shared dictionary between vertices and edges) can be evaluated with hard numbers.

### New benchmarks

- `BenchmarkGraphCacheMemory` — populates the cache at v=1k/10k/100k with 80B keys and reports `heap_inuse_B/edge` and `heap_inuse_B/vertex` via `b.ReportMetric`.
- `BenchmarkGraphCacheAddEdges` — ingest hot path, alloc/op via `b.ReportAllocs`.
- `BenchmarkGraphCacheGetWeight` — lookup hot path.

### Baseline (Apple M3 Max, 80B keys)

| scale | B/edge | B/vertex |
|---|---:|---:|
| v=1k,   deg=8  |   163 |  1.3 KB |
| v=10k,  deg=16 |   165 |  2.6 KB |
| v=100k, deg=32 |   150 |  4.8 KB |

Extrapolated, 10M vertices × deg 50 ≈ 75 GB — the headroom that motivates Phase 2.

### Scope

- Test-only change. **No production code touched.**
- Run with: `(cd core && go test -bench=BenchmarkGraphCache -benchmem -benchtime=1x ./cache/graph/)`
- Honours `-short` (CI keeps the small scale only).