### PR TITLE
feat(core/cache/graph): add internal vertexID dictionary

### DIFF
--- a/core/cache/graph/dict.go
+++ b/core/cache/graph/dict.go
@@ -1,0 +1,161 @@
+package graph
+
+import "sync"
+
+// vertexID is the internal handle used to refer to a vertex key without
+// keeping a copy of its (potentially large) underlying string. It is
+// minted by dictionary.intern and recycled when refcount drops to zero.
+//
+// vertexID is intentionally uint32: 4 GiB of distinct live vertices is
+// already a far larger scale than any single Lantern node is expected to
+// hold, and halving the per-edge bookkeeping cost from 8 B to 4 B is the
+// whole point of introducing the indirection. If a future workload ever
+// demands more, widen this single typedef.
+type vertexID uint32
+
+// dictionary[S] is a bidirectional, refcounted key↔id table shared by the
+// vertex cache and the edge cache inside a single GraphCache. Centralising
+// the table guarantees that "the vertex with key K" and "the edge endpoint
+// with key K" always resolve to the same vertexID — which is what lets
+// edges store endpoints as 4 B integers without losing the auto-create
+// invariant.
+//
+// Concurrency: dictionary uses a single sync.RWMutex. Refcount mutations
+// (intern / acquire / release) take the write lock; resolve / lookup take
+// the read lock. The expected workload is read-dominated (every edge
+// lookup resolves both endpoints), so RWMutex is the right primitive for
+// the initial implementation. Sharding can be layered on later without
+// changing the public API of this type if profiling shows contention.
+//
+// vertexID lifecycle:
+//
+//	intern(K)     refcount 0 -> 1, returns fresh id (or recycles freed id)
+//	intern(K) again refcount n -> n+1, returns same id
+//	acquire(id)    refcount n -> n+1 (panics if id is not live)
+//	release(id)    refcount n -> n-1, frees the id when it hits 0
+//
+// "Free" means: the id is pushed onto the freelist and the forward/reverse
+// table entries are cleared. The id will be handed out again by a
+// subsequent intern of a new key. Callers must never use an id after the
+// release call that freed it.
+type dictionary[S comparable] struct {
+	mu       sync.RWMutex
+	forward  map[S]vertexID
+	reverse  []S
+	refcount []uint32
+	free     []vertexID
+}
+
+// newDictionary returns an empty dictionary. Capacity hints can be added
+// later if profiling shows the initial growth cost matters; the zero
+// value already works.
+func newDictionary[S comparable]() *dictionary[S] {
+	return &dictionary[S]{
+		forward: make(map[S]vertexID),
+	}
+}
+
+// intern returns the vertexID for key, allocating a new one if necessary,
+// and increments its refcount by one. Callers MUST pair every intern with
+// exactly one release once they stop referring to the key.
+func (d *dictionary[S]) intern(key S) vertexID {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if id, ok := d.forward[key]; ok {
+		d.refcount[id]++
+		return id
+	}
+	return d.allocateLocked(key)
+}
+
+// acquire increments the refcount of an already-live id by one. It panics
+// if id is not currently allocated, because that always indicates a
+// caller bug: the only way to obtain an id is via intern (which gives the
+// caller the first reference), and the only legitimate use for acquire is
+// to add a second reference to an id the caller already holds.
+func (d *dictionary[S]) acquire(id vertexID) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if int(id) >= len(d.refcount) || d.refcount[id] == 0 {
+		panic("dictionary: acquire of unallocated vertexID")
+	}
+	d.refcount[id]++
+}
+
+// lookup returns the id for key without changing its refcount. Useful for
+// read paths that need to translate a key to an id but do not own a
+// reference (e.g. GetEdge where the caller has not interned anything).
+func (d *dictionary[S]) lookup(key S) (vertexID, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	id, ok := d.forward[key]
+	return id, ok
+}
+
+// resolve returns the key for id. It returns the zero value of S and
+// false if id is not currently allocated (either never minted or already
+// freed).
+func (d *dictionary[S]) resolve(id vertexID) (S, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	if int(id) >= len(d.refcount) || d.refcount[id] == 0 {
+		var zero S
+		return zero, false
+	}
+	return d.reverse[id], true
+}
+
+// release decrements the refcount of id by one and frees the id when the
+// count reaches zero. It returns true iff the id was freed by this call.
+// It panics if id is not currently allocated, because over-release is a
+// caller bug that silently corrupts the refcount accounting.
+func (d *dictionary[S]) release(id vertexID) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if int(id) >= len(d.refcount) || d.refcount[id] == 0 {
+		panic("dictionary: release of unallocated vertexID")
+	}
+	d.refcount[id]--
+	if d.refcount[id] > 0 {
+		return false
+	}
+	key := d.reverse[id]
+	delete(d.forward, key)
+	var zero S
+	d.reverse[id] = zero // drop the string reference so the GC can reclaim it
+	d.free = append(d.free, id)
+	return true
+}
+
+// len returns the number of currently live vertexIDs (i.e. ids with a
+// non-zero refcount). It is intended for tests and metrics; it acquires
+// the read lock and walks no maps.
+func (d *dictionary[S]) len() int {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return len(d.forward)
+}
+
+// allocateLocked mints a fresh id (or recycles one from the freelist),
+// records the forward/reverse mapping, and sets refcount to 1. The
+// caller MUST hold d.mu for writing.
+func (d *dictionary[S]) allocateLocked(key S) vertexID {
+	if n := len(d.free); n > 0 {
+		id := d.free[n-1]
+		d.free = d.free[:n-1]
+		d.forward[key] = id
+		d.reverse[id] = key
+		d.refcount[id] = 1
+		return id
+	}
+	id := vertexID(len(d.reverse))
+	d.forward[key] = id
+	d.reverse = append(d.reverse, key)
+	d.refcount = append(d.refcount, 1)
+	return id
+}

--- a/core/cache/graph/dict_test.go
+++ b/core/cache/graph/dict_test.go
@@ -1,0 +1,195 @@
+package graph
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestDictionary_InternReturnsStableID(t *testing.T) {
+	d := newDictionary[string]()
+	a := d.intern("a")
+	b := d.intern("b")
+	a2 := d.intern("a")
+	if a != a2 {
+		t.Fatalf("intern of same key returned different ids: %d vs %d", a, a2)
+	}
+	if a == b {
+		t.Fatalf("intern of different keys returned same id: %d", a)
+	}
+	if got := d.len(); got != 2 {
+		t.Fatalf("len=%d, want 2", got)
+	}
+}
+
+func TestDictionary_ResolveAndLookup(t *testing.T) {
+	d := newDictionary[string]()
+	id := d.intern("hello")
+
+	if got, ok := d.lookup("hello"); !ok || got != id {
+		t.Fatalf("lookup(hello)=(%d,%v), want (%d,true)", got, ok, id)
+	}
+	if _, ok := d.lookup("nope"); ok {
+		t.Fatalf("lookup(nope) returned ok=true unexpectedly")
+	}
+	if got, ok := d.resolve(id); !ok || got != "hello" {
+		t.Fatalf("resolve(%d)=(%q,%v), want (hello,true)", id, got, ok)
+	}
+	if _, ok := d.resolve(vertexID(999)); ok {
+		t.Fatalf("resolve of out-of-range id returned ok=true")
+	}
+}
+
+func TestDictionary_RefcountAndRelease(t *testing.T) {
+	d := newDictionary[string]()
+	id := d.intern("x") // refcount = 1
+	d.acquire(id)       // refcount = 2
+	_ = d.intern("x")   // refcount = 3 (same key, same id)
+
+	if got := d.release(id); got {
+		t.Fatalf("release at refcount 3->2 reported freed=true")
+	}
+	if got := d.release(id); got {
+		t.Fatalf("release at refcount 2->1 reported freed=true")
+	}
+	if _, ok := d.lookup("x"); !ok {
+		t.Fatalf("key was forgotten while refcount > 0")
+	}
+	if got := d.release(id); !got {
+		t.Fatalf("release at refcount 1->0 reported freed=false")
+	}
+	if _, ok := d.lookup("x"); ok {
+		t.Fatalf("key still resolvable after final release")
+	}
+	if _, ok := d.resolve(id); ok {
+		t.Fatalf("id still resolvable after final release")
+	}
+	if got := d.len(); got != 0 {
+		t.Fatalf("len=%d after final release, want 0", got)
+	}
+}
+
+func TestDictionary_FreelistReuse(t *testing.T) {
+	d := newDictionary[string]()
+	id1 := d.intern("a")
+	_ = d.release(id1)
+	id2 := d.intern("b")
+	if id1 != id2 {
+		t.Fatalf("freed id was not recycled: id1=%d id2=%d", id1, id2)
+	}
+	// And the reverse mapping must reflect the *new* key, not the old one.
+	if got, _ := d.resolve(id2); got != "b" {
+		t.Fatalf("resolve after reuse returned stale key %q", got)
+	}
+}
+
+func TestDictionary_DoesNotLeakStringAfterFree(t *testing.T) {
+	d := newDictionary[string]()
+	id := d.intern("payload")
+	if d.reverse[id] != "payload" {
+		t.Fatalf("reverse entry not populated")
+	}
+	_ = d.release(id)
+	var zero string
+	if d.reverse[id] != zero {
+		t.Fatalf("reverse entry not cleared after release: %q", d.reverse[id])
+	}
+}
+
+func TestDictionary_AcquireOfUnallocatedPanics(t *testing.T) {
+	d := newDictionary[string]()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("acquire of unallocated id did not panic")
+		}
+	}()
+	d.acquire(vertexID(0))
+}
+
+func TestDictionary_ReleaseOfUnallocatedPanics(t *testing.T) {
+	d := newDictionary[string]()
+	id := d.intern("x")
+	_ = d.release(id)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("over-release did not panic")
+		}
+	}()
+	_ = d.release(id)
+}
+
+func TestDictionary_ConcurrentInternIsAtomic(t *testing.T) {
+	// All goroutines intern the same N keys; each key should end up with
+	// a single id and a refcount equal to the number of interns minus the
+	// number of releases. We over-intern then release down to a known
+	// baseline and check len() matches.
+	const goroutines = 32
+	const keys = 64
+	const opsPerGoroutine = 1000
+
+	d := newDictionary[string]()
+	keyNames := make([]string, keys)
+	for i := range keyNames {
+		keyNames[i] = fmt.Sprintf("k-%d", i)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	var observedIDs [keys]atomic.Uint64
+	for g := 0; g < goroutines; g++ {
+		go func(gi int) {
+			defer wg.Done()
+			for i := 0; i < opsPerGoroutine; i++ {
+				k := (gi + i) % keys
+				id := d.intern(keyNames[k])
+				// All interns of the same key must agree on the id.
+				prev := observedIDs[k].Swap(uint64(id) + 1)
+				if prev != 0 && prev != uint64(id)+1 {
+					panic(fmt.Sprintf("id changed for key %s: %d -> %d", keyNames[k], prev-1, id))
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	if got := d.len(); got != keys {
+		t.Fatalf("len=%d after concurrent intern, want %d", got, keys)
+	}
+	// Drain all interns to verify accounting balances.
+	for k := 0; k < keys; k++ {
+		id, ok := d.lookup(keyNames[k])
+		if !ok {
+			t.Fatalf("key %s missing after concurrent intern", keyNames[k])
+		}
+		// Each goroutine interned this key floor(opsPerGoroutine / keys) or
+		// ceil times; computing the exact expected refcount is fiddly, so
+		// just release until we hit zero and confirm no panic.
+		for {
+			freed := d.release(id)
+			if freed {
+				break
+			}
+		}
+	}
+	if got := d.len(); got != 0 {
+		t.Fatalf("len=%d after draining, want 0", got)
+	}
+}
+
+func TestDictionary_GenericNonStringKey(t *testing.T) {
+	type composite struct {
+		a int
+		b string
+	}
+	d := newDictionary[composite]()
+	id1 := d.intern(composite{1, "x"})
+	id2 := d.intern(composite{1, "x"})
+	id3 := d.intern(composite{2, "x"})
+	if id1 != id2 {
+		t.Fatalf("equal struct keys mapped to different ids: %d %d", id1, id2)
+	}
+	if id1 == id3 {
+		t.Fatalf("distinct struct keys mapped to same id: %d", id1)
+	}
+}


### PR DESCRIPTION
Phase 2 of the memory-efficiency refactor, step 1 of 3.

This PR adds an unexported, refcounted, bidirectional key↔`vertexID` table to `core/cache/graph`. The dictionary will be **shared between the vertex cache and the edge cache** in follow-up PRs so that:

- edges store endpoints as 4-byte `vertexID uint32` instead of the full key (the dominant win — projected −24 GB at 10M×50);
- vertex auto-create on `AddEdge` cannot drift, because there is exactly one id space for both sides.

### API (all unexported)

| Method | Effect |
|---|---|
| `newDictionary[S comparable]()` | empty table |
| `intern(key)` | refcount +1, returns id; recycles freed ids |
| `acquire(id)` | refcount +1 on an already-live id |
| `lookup(key)` | id without refcount change |
| `resolve(id)` | key without refcount change |
| `release(id)` | refcount −1; frees id on 0; returns whether freed |
| `len()` | live id count |

### Design notes (captured in doc comments)

- `vertexID = uint32` — 4 GiB live vertices is far past Lantern's single-node target. Going wider would defeat the point.
- Single `sync.RWMutex`. Sharding is a **non-API-breaking** future change if profiling shows lock contention at 10M+ ingest scale.
- Freed ids are recycled via a freelist; `reverse[]` slot is cleared so the GC can reclaim the underlying string.

### Tests

`TestDictionary_*` covers: id stability, refcount accounting, freelist recycle, string release after free, panic on over-release / acquire of unallocated, concurrent intern (`go test -race`), generic non-string keys.

### Scope

- **No production wiring.** Existing call sites unchanged; all current tests continue to pin `GraphCache[string, ...]`.
- Follow-ups: PR-C (re-key `edgeCache` by `vertexID`), PR-D (re-key vertex `cache.Cache` by `vertexID`).

Baseline (from PR #118): v=100k × deg32 → 150 B/edge. Target after PR-C: ≲ 50 B/edge.