### PR TITLE
feat(core/cache): add SetOnEvict callback for layered cache notifications

### DIFF
--- a/core/cache/cache.go
+++ b/core/cache/cache.go
@@ -20,6 +20,15 @@ type Cache[S comparable, T any] struct {
 	defaultTTL time.Duration
 	cache      map[S]volatile[T]
 	mu         sync.RWMutex
+
+	// onEvict, if set, is invoked once per key removed by Delete, Clear, or
+	// Flush (TTL expiry). Set via SetOnEvict; protected by hookMu so it can
+	// be installed concurrently with cache operations. Callbacks fire AFTER
+	// the lock on c.mu has been released, so the callback may safely call
+	// back into the same Cache without deadlocking — but it must not block
+	// indefinitely (it runs inline on the caller's goroutine).
+	hookMu  sync.RWMutex
+	onEvict func(S)
 }
 
 func NewCache[S comparable, T any](defaultTTL time.Duration) *Cache[S, T] {
@@ -27,6 +36,26 @@ func NewCache[S comparable, T any](defaultTTL time.Duration) *Cache[S, T] {
 		defaultTTL: defaultTTL,
 		cache:      make(map[S]volatile[T]),
 	}
+}
+
+// SetOnEvict installs (or clears, when nil) a callback invoked once per key
+// removed by Delete, Clear, or Flush. The callback fires after c.mu has been
+// released, so it may re-enter the same Cache without deadlocking. It is
+// invoked inline on the caller's goroutine, so it must not block.
+//
+// Eviction notifications enable layered caches (e.g. GraphCache wiring a
+// shared vertex-id dictionary) to release per-entry resources without
+// scanning the cache each tick.
+func (c *Cache[S, T]) SetOnEvict(fn func(S)) {
+	c.hookMu.Lock()
+	defer c.hookMu.Unlock()
+	c.onEvict = fn
+}
+
+func (c *Cache[S, T]) snapshotOnEvict() func(S) {
+	c.hookMu.RLock()
+	defer c.hookMu.RUnlock()
+	return c.onEvict
 }
 
 func (c *Cache[S, T]) Get(key S) (T, bool) {
@@ -62,15 +91,21 @@ func (c *Cache[S, T]) Put(key S, value T) {
 }
 
 // Delete removes the entry for key. It returns true if the key was
-// present (and therefore removed by this call), false otherwise.
+// present (and therefore removed by this call), false otherwise. When the
+// key was present and an OnEvict callback is installed, the callback fires
+// once after c.mu is released.
 func (c *Cache[S, T]) Delete(key S) bool {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if _, ok := c.cache[key]; !ok {
+		c.mu.Unlock()
 		return false
 	}
 	delete(c.cache, key)
+	c.mu.Unlock()
+
+	if cb := c.snapshotOnEvict(); cb != nil {
+		cb(key)
+	}
 	return true
 }
 
@@ -79,11 +114,28 @@ func (c *Cache[S, T]) Has(key S) bool {
 	_, ok := c.Get(key)
 	return ok
 }
+
+// Clear removes every entry. When an OnEvict callback is installed it is
+// invoked once per removed key after c.mu has been released. Keys are
+// reported in unspecified order.
 func (c *Cache[S, T]) Clear() {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
+	cb := c.snapshotOnEvict()
+	var evicted []S
+	if cb != nil {
+		evicted = make([]S, 0, len(c.cache))
+		for k := range c.cache {
+			evicted = append(evicted, k)
+		}
+	}
 	c.cache = make(map[S]volatile[T])
+	c.mu.Unlock()
+
+	if cb != nil {
+		for _, k := range evicted {
+			cb(k)
+		}
+	}
 }
 
 func (c *Cache[S, T]) Count() int {
@@ -95,16 +147,38 @@ func (c *Cache[S, T]) Count() int {
 
 // Flush evicts every entry whose TTL has passed. It returns the number of
 // entries removed so callers (e.g. server-side TTL metrics) can record
-// expiration counts without scanning the cache again.
+// expiration counts without scanning the cache again. When an OnEvict
+// callback is installed it is invoked once per removed key after c.mu has
+// been released.
 func (c *Cache[S, T]) Flush() int {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
+	cb := c.snapshotOnEvict()
+	var evicted []S
+	if cb != nil {
+		// Two-phase: collect keys under the lock, fire callbacks after release.
+		// maps.DeleteFunc cannot collect because the predicate's S is the live
+		// key but we need to defer the callback past Unlock.
+		for k, v := range c.cache {
+			if v.IsExpired() {
+				evicted = append(evicted, k)
+			}
+		}
+		for _, k := range evicted {
+			delete(c.cache, k)
+		}
+		c.mu.Unlock()
+		for _, k := range evicted {
+			cb(k)
+		}
+		return len(evicted)
+	}
 	before := len(c.cache)
 	maps.DeleteFunc(c.cache, func(_ S, v volatile[T]) bool {
 		return v.IsExpired()
 	})
-	return before - len(c.cache)
+	removed := before - len(c.cache)
+	c.mu.Unlock()
+	return removed
 }
 
 func (c *Cache[S, T]) Watch(ctx context.Context, interval time.Duration) {

--- a/core/cache/on_evict_test.go
+++ b/core/cache/on_evict_test.go
@@ -1,0 +1,169 @@
+package cache
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestCache_OnEvict_Delete verifies the callback fires exactly once when an
+// existing key is deleted, and not at all when an absent key is "deleted".
+func TestCache_OnEvict_Delete(t *testing.T) {
+	c := NewCache[string, int](time.Minute)
+	c.Put("a", 1)
+
+	var got []string
+	var mu sync.Mutex
+	c.SetOnEvict(func(k string) {
+		mu.Lock()
+		defer mu.Unlock()
+		got = append(got, k)
+	})
+
+	if !c.Delete("a") {
+		t.Fatalf("Delete(a) = false, want true")
+	}
+	if c.Delete("missing") {
+		t.Fatalf("Delete(missing) = true, want false")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 1 || got[0] != "a" {
+		t.Fatalf("evicted = %v, want [a]", got)
+	}
+}
+
+// TestCache_OnEvict_Clear verifies the callback fires once per cleared key.
+func TestCache_OnEvict_Clear(t *testing.T) {
+	c := NewCache[string, int](time.Minute)
+	c.Put("a", 1)
+	c.Put("b", 2)
+	c.Put("c", 3)
+
+	var got []string
+	var mu sync.Mutex
+	c.SetOnEvict(func(k string) {
+		mu.Lock()
+		defer mu.Unlock()
+		got = append(got, k)
+	})
+
+	c.Clear()
+
+	mu.Lock()
+	defer mu.Unlock()
+	sort.Strings(got)
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("evicted = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("evicted = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestCache_OnEvict_Flush verifies the callback fires once per key whose TTL
+// has expired, and not for keys still alive.
+func TestCache_OnEvict_Flush(t *testing.T) {
+	c := NewCache[string, int](time.Minute)
+	c.PutWithTTL("alive", 1, time.Hour)
+	c.PutWithExpiration("dead-1", 2, time.Now().Add(-time.Second))
+	c.PutWithExpiration("dead-2", 3, time.Now().Add(-time.Second))
+
+	var got []string
+	var mu sync.Mutex
+	c.SetOnEvict(func(k string) {
+		mu.Lock()
+		defer mu.Unlock()
+		got = append(got, k)
+	})
+
+	removed := c.Flush()
+	if removed != 2 {
+		t.Fatalf("Flush() = %d, want 2", removed)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	sort.Strings(got)
+	want := []string{"dead-1", "dead-2"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("evicted = %v, want %v", got, want)
+	}
+}
+
+// TestCache_OnEvict_NotInstalled verifies Delete / Clear / Flush behave
+// identically to before this commit when no callback is installed: no
+// panic, return values unchanged.
+func TestCache_OnEvict_NotInstalled(t *testing.T) {
+	c := NewCache[string, int](time.Minute)
+	c.Put("a", 1)
+	c.PutWithExpiration("dead", 2, time.Now().Add(-time.Second))
+
+	if !c.Delete("a") {
+		t.Fatalf("Delete(a) = false, want true")
+	}
+	if c.Flush() != 1 {
+		t.Fatalf("Flush() = unexpected, want 1")
+	}
+	c.Put("x", 9)
+	c.Clear()
+	if c.Count() != 0 {
+		t.Fatalf("Count after Clear = %d, want 0", c.Count())
+	}
+}
+
+// TestCache_OnEvict_Reentrant verifies the callback may safely call back into
+// the same Cache without deadlocking (must fire after c.mu is released).
+func TestCache_OnEvict_Reentrant(t *testing.T) {
+	c := NewCache[string, int](time.Minute)
+	c.Put("a", 1)
+	c.Put("b", 2)
+
+	var reentrantCalls atomic.Int32
+	done := make(chan struct{})
+	c.SetOnEvict(func(k string) {
+		// Re-enter: every read API must succeed without deadlock.
+		_, _ = c.Get(k)
+		_ = c.Has(k)
+		_ = c.Count()
+		reentrantCalls.Add(1)
+	})
+
+	go func() {
+		c.Delete("a")
+		c.Clear()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("callback re-entry deadlocked")
+	}
+	// 1 Delete + 1 Clear (which evicts "b") = 2 callbacks.
+	if got := reentrantCalls.Load(); got != 2 {
+		t.Fatalf("reentrantCalls = %d, want 2", got)
+	}
+}
+
+// TestCache_OnEvict_Clearing verifies SetOnEvict(nil) un-installs a previously
+// installed callback.
+func TestCache_OnEvict_Clearing(t *testing.T) {
+	c := NewCache[string, int](time.Minute)
+	c.Put("a", 1)
+
+	var calls atomic.Int32
+	c.SetOnEvict(func(string) { calls.Add(1) })
+	c.SetOnEvict(nil)
+
+	c.Delete("a")
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("calls = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## What

Add `(*cache.Cache).SetOnEvict(func(S))` invoked once per removed key from every removal path:

- `Delete` — fires once when the key was present.
- `Clear` — fires once per cleared key (order unspecified).
- `Flush` — fires once per TTL-expired key.

## Why

Phase 2's edge-id-keyed refactor (#123) wires a shared vertex-id dictionary into `GraphCache`. Releasing a dictionary refcount on every vertex eviction requires per-key notification on **all** removal paths; the existing API only returned bulk counts, forcing a full cache scan per Watch tick to discover which keys actually went away. `SetOnEvict` makes the dictionary refcount maintainable in O(1) per eviction.

This PR delivers the mechanism in isolation. Wiring it from `GraphCache` lands in the follow-up PR for #123.

## Design

- Single callback slot, installed/cleared via `SetOnEvict` (passing `nil` un-installs).
- Callback fires **after** `c.mu` is released. Same non-reentrancy contract that `GraphCache.SetGCHooks` already documents: callers may call back into the same Cache from the callback without deadlock, but must not block.
- Callback slot is guarded by its own `sync.RWMutex` (`hookMu`), snapshotted before unlocking the data lock, so install/clear races cannot turn a non-nil snapshot into a nil call.
- Zero-cost when no callback is installed: `Flush` keeps the original `maps.DeleteFunc` fast path; `Delete` and `Clear` only do the cb-nil check.

## Test plan

New file `core/cache/on_evict_test.go` covers:

- Delete fires exactly once for a present key, zero for an absent key.
- Clear fires once per cleared key (sorted-compared because map iteration is unordered).
- Flush fires once per expired key and not for live keys.
- No callback installed: Delete / Clear / Flush behave identically to before (no panic, counts unchanged).
- Re-entrancy: callback may call `Get`, `Has`, `Count` from inside itself without deadlock (wall-clock guarded, 2 s timeout).
- `SetOnEvict(nil)` un-installs a prior callback.

Local quality gate (gofmt + per-module `go test ./...` across all 5 modules + `go vet` on server) is green.

Closes #120
Refs #123