### PR TITLE
refactor(core/cache/graph): rename AddVertex*/AddVertices* → PutVertex*/PutVertices*

### DIFF
--- a/core/cache/graph/batch.go
+++ b/core/cache/graph/batch.go
@@ -3,7 +3,7 @@ package graph
 import "time"
 
 // VertexItem is a single (key, value, expiration) tuple supplied to
-// AddVerticesWithExpiration.
+// PutVerticesWithExpiration.
 type VertexItem[S comparable, T any] struct {
 	Key        S
 	Value      T
@@ -25,11 +25,11 @@ type EdgeKey[S comparable] struct {
 	Head S
 }
 
-// AddVerticesWithExpiration writes every supplied vertex under a single
+// PutVerticesWithExpiration writes every supplied vertex under a single
 // write lock. Concurrent readers observe either the pre-batch or the
 // post-batch state — never an intermediate snapshot where some keys are
 // present and others are not.
-func (c *GraphCache[S, T]) AddVerticesWithExpiration(items []VertexItem[S, T]) {
+func (c *GraphCache[S, T]) PutVerticesWithExpiration(items []VertexItem[S, T]) {
 	if len(items) == 0 {
 		return
 	}

--- a/core/cache/graph/batch_test.go
+++ b/core/cache/graph/batch_test.go
@@ -19,7 +19,7 @@ func TestAddEdgesWithExpiration_AtomicNeighborSnapshot(t *testing.T) {
 	c := graph.NewGraphCache[string, int](time.Minute)
 
 	exp := time.Now().Add(time.Minute)
-	c.AddVertexWithExpiration("s", 0, exp)
+	c.PutVertexWithExpiration("s", 0, exp)
 
 	addBatch := make([]graph.EdgeItem[string], fanOut)
 	delBatch := make([]graph.EdgeKey[string], fanOut)
@@ -80,7 +80,7 @@ func TestDeleteEdges_AtomicNeighborSnapshot(t *testing.T) {
 	c := graph.NewGraphCache[string, int](time.Minute)
 
 	exp := time.Now().Add(time.Minute)
-	c.AddVertexWithExpiration("s", 0, exp)
+	c.PutVertexWithExpiration("s", 0, exp)
 
 	addBatch := make([]graph.EdgeItem[string], fanOut)
 	delBatch := make([]graph.EdgeKey[string], fanOut)
@@ -189,7 +189,7 @@ func TestBatchAPIs_ReturnCounts(t *testing.T) {
 	c := graph.NewGraphCache[string, int](time.Minute)
 	exp := time.Now().Add(time.Minute)
 
-	c.AddVerticesWithExpiration([]graph.VertexItem[string, int]{
+	c.PutVerticesWithExpiration([]graph.VertexItem[string, int]{
 		{Key: "a", Value: 1, Expiration: exp},
 		{Key: "b", Value: 2, Expiration: exp},
 		{Key: "c", Value: 3, Expiration: exp},

--- a/core/cache/graph/bench_test.go
+++ b/core/cache/graph/bench_test.go
@@ -63,7 +63,7 @@ func populate(b *testing.B, c *GraphCache[string, string], s benchScale) []strin
 	for i, k := range keys {
 		vs[i] = VertexItem[string, string]{Key: k, Value: "", Expiration: expiration}
 	}
-	c.AddVerticesWithExpiration(vs)
+	c.PutVerticesWithExpiration(vs)
 
 	es := make([]EdgeItem[string], 0, s.vertices*s.degree)
 	for i := 0; i < s.vertices; i++ {

--- a/core/cache/graph/cache.go
+++ b/core/cache/graph/cache.go
@@ -106,19 +106,19 @@ func (c *GraphCache[S, T]) GetEdgeDetail(tail, head S) (float32, time.Time, bool
 	return c.edges.getDetail(tail, head)
 }
 
-func (c *GraphCache[S, T]) AddVertexWithExpiration(key S, value T, expiration time.Time) {
+func (c *GraphCache[S, T]) PutVertexWithExpiration(key S, value T, expiration time.Time) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.putVertexLocked(key, value, expiration)
 }
 
-func (c *GraphCache[S, T]) AddVertexWithTTL(key S, value T, ttl time.Duration) {
-	c.AddVertexWithExpiration(key, value, time.Now().Add(ttl))
+func (c *GraphCache[S, T]) PutVertexWithTTL(key S, value T, ttl time.Duration) {
+	c.PutVertexWithExpiration(key, value, time.Now().Add(ttl))
 }
 
 func (c *GraphCache[S, T]) PutVertex(key S, value T) {
-	c.AddVertexWithTTL(key, value, c.defaultTTL)
+	c.PutVertexWithTTL(key, value, c.defaultTTL)
 }
 
 func (c *GraphCache[S, T]) AddEdgeWithExpiration(tail, head S, w float32, expiration time.Time) {

--- a/core/cache/graph/cache_test.go
+++ b/core/cache/graph/cache_test.go
@@ -80,7 +80,7 @@ func TestGraph_AddEdgeWithTTL(t *testing.T) {
 	}
 }
 
-func TestGraph_AddVertex(t *testing.T) {
+func TestGraph_PutVertex(t *testing.T) {
 	type args[S comparable, T any] struct {
 		key   S
 		value T
@@ -92,7 +92,7 @@ func TestGraph_AddVertex(t *testing.T) {
 	}
 	tests := []testCase[string, string]{
 		{
-			name: "TestGraph_AddVertex",
+			name: "TestGraph_PutVertex",
 			g: GraphCache[string, string]{
 				vertices: cache.NewCache[string, string](time.Minute),
 			},
@@ -107,7 +107,7 @@ func TestGraph_AddVertex(t *testing.T) {
 	}
 }
 
-func TestGraph_AddVertexWithTTL(t *testing.T) {
+func TestGraph_PutVertexWithTTL(t *testing.T) {
 	type args[S comparable, T any] struct {
 		key   S
 		value T
@@ -120,7 +120,7 @@ func TestGraph_AddVertexWithTTL(t *testing.T) {
 	}
 	tests := []testCase[string, string]{
 		{
-			name: "TestGraph_AddVertexWithTTL",
+			name: "TestGraph_PutVertexWithTTL",
 			g: GraphCache[string, string]{
 				vertices: cache.NewCache[string, string](time.Minute),
 			},
@@ -130,7 +130,7 @@ func TestGraph_AddVertexWithTTL(t *testing.T) {
 	for i := range tests {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			tt.g.AddVertexWithTTL(tt.args.key, tt.args.value, tt.args.ttl)
+			tt.g.PutVertexWithTTL(tt.args.key, tt.args.value, tt.args.ttl)
 		})
 	}
 }
@@ -302,7 +302,7 @@ func TestGraphCache_AddEdgeWithTTL(t *testing.T) {
 	}
 }
 
-func TestGraphCache_AddVertex(t *testing.T) {
+func TestGraphCache_PutVertex(t *testing.T) {
 	type args[S comparable, T any] struct {
 		key   S
 		value T
@@ -314,7 +314,7 @@ func TestGraphCache_AddVertex(t *testing.T) {
 	}
 	tests := []testCase[string, string]{
 		{
-			name: "TestGraphCache_AddVertex",
+			name: "TestGraphCache_PutVertex",
 			c: GraphCache[string, string]{
 				vertices: cache.NewCache[string, string](time.Minute),
 			},
@@ -329,7 +329,7 @@ func TestGraphCache_AddVertex(t *testing.T) {
 	}
 }
 
-func TestGraphCache_AddVertexWithExpiration(t *testing.T) {
+func TestGraphCache_PutVertexWithExpiration(t *testing.T) {
 	type args[S comparable, T any] struct {
 		key        S
 		value      T
@@ -342,7 +342,7 @@ func TestGraphCache_AddVertexWithExpiration(t *testing.T) {
 	}
 	tests := []testCase[string, string]{
 		{
-			name: "TestGraphCache_AddVertexWithExpiration",
+			name: "TestGraphCache_PutVertexWithExpiration",
 			c: GraphCache[string, string]{
 				vertices: cache.NewCache[string, string](time.Minute),
 			},
@@ -352,12 +352,12 @@ func TestGraphCache_AddVertexWithExpiration(t *testing.T) {
 	for i := range tests {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			tt.c.AddVertexWithExpiration(tt.args.key, tt.args.value, tt.args.expiration)
+			tt.c.PutVertexWithExpiration(tt.args.key, tt.args.value, tt.args.expiration)
 		})
 	}
 }
 
-func TestGraphCache_AddVertexWithTTL(t *testing.T) {
+func TestGraphCache_PutVertexWithTTL(t *testing.T) {
 	type args[S comparable, T any] struct {
 		key   S
 		value T
@@ -370,7 +370,7 @@ func TestGraphCache_AddVertexWithTTL(t *testing.T) {
 	}
 	tests := []testCase[string, string]{
 		{
-			name: "TestGraphCache_AddVertexWithTTL",
+			name: "TestGraphCache_PutVertexWithTTL",
 			c: GraphCache[string, string]{
 				vertices: cache.NewCache[string, string](time.Minute),
 			},
@@ -380,7 +380,7 @@ func TestGraphCache_AddVertexWithTTL(t *testing.T) {
 	for i := range tests {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			tt.c.AddVertexWithTTL(tt.args.key, tt.args.value, tt.args.ttl)
+			tt.c.PutVertexWithTTL(tt.args.key, tt.args.value, tt.args.ttl)
 		})
 	}
 }
@@ -546,7 +546,7 @@ func TestNewGraphCache(t *testing.T) {
 
 func TestGraphCache_DeleteVertex(t *testing.T) {
 	g := NewGraphCache[string, string](time.Minute)
-	g.AddVertexWithTTL("a", "A", 60*time.Second)
+	g.PutVertexWithTTL("a", "A", 60*time.Second)
 
 	type args[S comparable] struct {
 		key S

--- a/core/cache/graph/production_gate_test.go
+++ b/core/cache/graph/production_gate_test.go
@@ -82,7 +82,7 @@ func testLivenessHeavyMix(t *testing.T) {
 				defer wg.Done()
 				for i := 0; i < iterations; i++ {
 					k := keyFromInt((w*iterations + i) % 64)
-					c.AddVertexWithExpiration(k, i, exp)
+					c.PutVertexWithExpiration(k, i, exp)
 					c.GetVertex(k)
 					tail := keyFromInt(i % 16)
 					head := keyFromInt((i + 1) % 16)
@@ -173,12 +173,12 @@ func testResourceVertexReaped(t *testing.T) {
 	exp := time.Now().Add(short)
 
 	for i := 0; i < N; i++ {
-		c.AddVertexWithExpiration(keyFromInt(i), i, exp)
+		c.PutVertexWithExpiration(keyFromInt(i), i, exp)
 	}
 	// At least one edge so we can verify cascade.
 	c.AddEdgeWithExpiration("a", "b", 1, exp)
-	c.AddVertexWithExpiration("a", 0, exp)
-	c.AddVertexWithExpiration("b", 0, exp)
+	c.PutVertexWithExpiration("a", 0, exp)
+	c.PutVertexWithExpiration("b", 0, exp)
 
 	// Wait past TTL and trigger reaping the same way Watch does.
 	time.Sleep(short + 80*time.Millisecond)
@@ -245,19 +245,19 @@ func testInputBoundary(t *testing.T) {
 		name string
 		fn   func()
 	}{
-		{"empty-key", func() { c.AddVertexWithExpiration("", 0, now.Add(time.Minute)) }},
+		{"empty-key", func() { c.PutVertexWithExpiration("", 0, now.Add(time.Minute)) }},
 		{"long-key", func() {
 			big := make([]byte, 1<<14)
 			for i := range big {
 				big[i] = 'x'
 			}
-			c.AddVertexWithExpiration(string(big), 0, now.Add(time.Minute))
+			c.PutVertexWithExpiration(string(big), 0, now.Add(time.Minute))
 		}},
 		{"zero-weight-edge", func() { c.AddEdgeWithExpiration("a", "b", 0, now.Add(time.Minute)) }},
 		{"negative-weight-edge", func() { c.AddEdgeWithExpiration("a", "b", -3.14, now.Add(time.Minute)) }},
 		{"self-loop", func() { c.AddEdgeWithExpiration("x", "x", 1, now.Add(time.Minute)) }},
-		{"far-past-expiration", func() { c.AddVertexWithExpiration("past", 0, now.Add(-time.Hour)) }},
-		{"far-future-expiration", func() { c.AddVertexWithExpiration("future", 0, now.Add(100*365*24*time.Hour)) }},
+		{"far-past-expiration", func() { c.PutVertexWithExpiration("past", 0, now.Add(-time.Hour)) }},
+		{"far-future-expiration", func() { c.PutVertexWithExpiration("future", 0, now.Add(100*365*24*time.Hour)) }},
 		{"put-edge-on-missing-endpoints", func() { c.PutEdgeWithExpiration("p", "q", 1, now.Add(time.Minute)) }},
 	}
 	for _, tc := range cases {
@@ -266,7 +266,7 @@ func testInputBoundary(t *testing.T) {
 
 	// The cache must still answer queries.
 	if _, ok := c.GetVertex(""); !ok {
-		t.Fatalf("I1: empty-key vertex unexpectedly missing after AddVertex")
+		t.Fatalf("I1: empty-key vertex unexpectedly missing after PutVertex")
 	}
 	if _, _, ok := c.GetEdgeDetail("x", "x"); !ok {
 		t.Fatalf("I1: self-loop edge unexpectedly missing after AddEdge")
@@ -316,7 +316,7 @@ func testInputDeleteMissing(t *testing.T) {
 	c.DeleteEdge("nope", "nada")
 
 	// State remains coherent: a fresh insert still works.
-	c.AddVertexWithExpiration("real", 1, time.Now().Add(time.Minute))
+	c.PutVertexWithExpiration("real", 1, time.Now().Add(time.Minute))
 	if _, ok := c.GetVertex("real"); !ok {
 		t.Fatalf("I3: cache stopped accepting writes after delete-missing")
 	}
@@ -335,8 +335,8 @@ func testReadConsistencyAfterExpiry(t *testing.T) {
 	short := 30 * time.Millisecond
 	exp := time.Now().Add(short)
 
-	c.AddVertexWithExpiration("a", 1, exp)
-	c.AddVertexWithExpiration("b", 2, exp)
+	c.PutVertexWithExpiration("a", 1, exp)
+	c.PutVertexWithExpiration("b", 2, exp)
 	c.AddEdgeWithExpiration("a", "b", 1, exp)
 
 	time.Sleep(short + 80*time.Millisecond)
@@ -428,7 +428,7 @@ func testIdempotenceConverge(t *testing.T) {
 	exp := time.Now().Add(time.Minute)
 
 	for i := 0; i < 100; i++ {
-		c.AddVertexWithExpiration("k", i, exp) // PutVertex semantics on the inner cache
+		c.PutVertexWithExpiration("k", i, exp) // PutVertex semantics on the inner cache
 	}
 	if v, ok := c.GetVertex("k"); !ok || v != 99 {
 		t.Fatalf("D1: PutVertex did not converge to last write (got %d, ok=%v)", v, ok)

--- a/core/cache/graph/refcount_test.go
+++ b/core/cache/graph/refcount_test.go
@@ -13,7 +13,7 @@ import (
 func TestDictRefcount_VertexPutIsIdempotent(t *testing.T) {
 	c := NewGraphCache[string, int](time.Minute)
 	for i := 0; i < 50; i++ {
-		c.AddVertexWithExpiration("k", i, time.Now().Add(time.Minute))
+		c.PutVertexWithExpiration("k", i, time.Now().Add(time.Minute))
 	}
 	if got := c.dict.len(); got != 1 {
 		t.Fatalf("dict.len after 50 puts of same key = %d, want 1", got)
@@ -69,7 +69,7 @@ func TestDictRefcount_AddEdgeAdditiveBumps(t *testing.T) {
 // references.
 func TestDictRefcount_DeleteReleases(t *testing.T) {
 	c := NewGraphCache[string, int](time.Minute)
-	c.AddVertexWithExpiration("v", 1, time.Now().Add(time.Minute))
+	c.PutVertexWithExpiration("v", 1, time.Now().Add(time.Minute))
 	if got := c.dict.len(); got != 1 {
 		t.Fatalf("dict.len after add = %d, want 1", got)
 	}
@@ -106,7 +106,7 @@ func TestDictRefcount_InsertDeleteInvariant(t *testing.T) {
 		k2 := keys[r.Intn(len(keys))]
 		switch r.Intn(5) {
 		case 0:
-			c.AddVertexWithExpiration(k1, step, time.Now().Add(time.Minute))
+			c.PutVertexWithExpiration(k1, step, time.Now().Add(time.Minute))
 		case 1:
 			c.AddEdgeWithExpiration(k1, k2, 1, time.Now().Add(time.Minute))
 		case 2:
@@ -151,7 +151,7 @@ func TestDictRefcount_FullExpiryFreesAll(t *testing.T) {
 
 	for i := 0; i < N; i++ {
 		k := fmt.Sprintf("v%d", i)
-		c.AddVertexWithExpiration(k, i, deadline)
+		c.PutVertexWithExpiration(k, i, deadline)
 	}
 	for i := 0; i < N; i++ {
 		for j := 0; j < 3; j++ {

--- a/server/service/backend.go
+++ b/server/service/backend.go
@@ -19,7 +19,7 @@ import (
 type Backend interface {
 	// vertex reads/writes
 	GetVertex(key string) (*pb.Vertex, bool)
-	AddVerticesWithExpiration(items []graph.VertexItem[string, *pb.Vertex])
+	PutVerticesWithExpiration(items []graph.VertexItem[string, *pb.Vertex])
 	DeleteVertices(keys []string) int
 
 	// edge reads/writes

--- a/server/service/fake_backend_test.go
+++ b/server/service/fake_backend_test.go
@@ -21,7 +21,7 @@ type fakeBackend struct {
 	edges       map[string]map[string]float32
 	neighborErr error
 
-	addVerticesCalls int
+	putVerticesCalls int
 	deleteVertices   int
 	addEdgesCalls    int
 	putEdgesCalls    int
@@ -40,8 +40,8 @@ func (f *fakeBackend) GetVertex(key string) (*pb.Vertex, bool) {
 	return v, ok
 }
 
-func (f *fakeBackend) AddVerticesWithExpiration(items []graph.VertexItem[string, *pb.Vertex]) {
-	f.addVerticesCalls++
+func (f *fakeBackend) PutVerticesWithExpiration(items []graph.VertexItem[string, *pb.Vertex]) {
+	f.putVerticesCalls++
 	for _, it := range items {
 		f.vertices[it.Key] = it.Value
 	}
@@ -134,8 +134,8 @@ func TestLanternService_FakeBackend_PutGetDelete(t *testing.T) {
 	if _, err := svc.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: []*pb.Vertex{v}}); err != nil {
 		t.Fatalf("PutVertices: %v", err)
 	}
-	if fb.addVerticesCalls != 1 {
-		t.Errorf("addVerticesCalls = %d, want 1", fb.addVerticesCalls)
+	if fb.putVerticesCalls != 1 {
+		t.Errorf("putVerticesCalls = %d, want 1", fb.putVerticesCalls)
 	}
 
 	resp, err := svc.GetVertex(ctx, &pb.GetVertexRequest{Key: "a"})

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -146,7 +146,7 @@ func (s *LanternService) PutVertices(ctx context.Context, request *pb.PutVertice
 			Expiration: v.GetExpiration().AsTime(),
 		})
 	}
-	s.cache.AddVerticesWithExpiration(items)
+	s.cache.PutVerticesWithExpiration(items)
 	return &pb.PutVerticesResponse{Written: int32(len(items))}, nil
 }
 


### PR DESCRIPTION
Closes #121.

Vertex writes are upserts (last write wins), not additive contributions, so they belong under the project's `Put` naming convention. Edges keep `Add` because they sum TTL-stamped weight contributions.

## Renamed (breaking, pre-1.0 core)

| Before | After |
| --- | --- |
| `AddVertexWithExpiration` | `PutVertexWithExpiration` |
| `AddVertexWithTTL` | `PutVertexWithTTL` |
| `AddVerticesWithExpiration` | `PutVerticesWithExpiration` |

`PutVertex(key, value)` (default-TTL convenience) is unchanged. The three `PutVertex*` forms now mirror the existing `AddEdge`/`AddEdgeWithTTL`/`AddEdgeWithExpiration` shape on the edge side. This also resolves the self-contradiction where the `PutVertices` RPC handler was calling `AddVerticesWithExpiration`.

## Scope
- `core/cache/graph`: `cache.go`, `batch.go` + tests/bench.
- `server/service`: `Backend` interface, `service.go` call site, `fake_backend_test.go` (also renamed `addVerticesCalls` counter for consistency).
- Test function names renamed in lockstep.

## Local quality gate (passed)
- `gofmt -l .` clean
- `go vet ./...` + `go test ./...` green in `server/`
- `go test ./...` green at root, `core/`, `pb/`, `sdks/go/`