### PR TITLE
perf(core/graph): linear-time BFS for ConnectedGraphContext

### DIFF
--- a/core/graph/graph_test.go
+++ b/core/graph/graph_test.go
@@ -50,6 +50,59 @@ func TestGraph_ConnectedGraph(t *testing.T) {
 	}
 }
 
+// TestGraph_ConnectedGraph_DeepChain exercises a path that previously required
+// many "rounds" in the old algorithm and now drains through a single FIFO BFS.
+// All chain vertices plus a cycle edge must be reached; an unreachable side
+// component must be excluded.
+func TestGraph_ConnectedGraph_DeepChain(t *testing.T) {
+	g := NewGraph[string, int]()
+	chain := []string{"v0", "v1", "v2", "v3", "v4", "v5", "v6"}
+	for i, v := range chain {
+		g.PutVertex(v, i)
+	}
+	for i := 0; i < len(chain)-1; i++ {
+		g.PutEdge(chain[i], chain[i+1], 1)
+	}
+	// back-edge forming a cycle
+	g.PutEdge("v6", "v3", 1)
+	// unreachable component
+	g.PutEdge("x", "y", 1)
+
+	c := g.ConnectedGraph("v0")
+
+	for _, want := range chain {
+		if _, ok := c.Vertices[want]; !ok {
+			t.Errorf("missing reachable vertex %q", want)
+		}
+	}
+	for _, dont := range []string{"x", "y"} {
+		if _, ok := c.Vertices[dont]; ok {
+			t.Errorf("unreachable vertex %q must not be included", dont)
+		}
+	}
+	// cycle edge must be preserved
+	if _, ok := c.Edges["v6"]["v3"]; !ok {
+		t.Errorf("cycle edge v6->v3 must be preserved")
+	}
+}
+
+// TestGraph_ConnectedGraph_SelfLoop pins behavior for self-loops: the loop
+// edge is preserved and traversal terminates.
+func TestGraph_ConnectedGraph_SelfLoop(t *testing.T) {
+	g := NewGraph[string, int]()
+	g.PutVertex("a", 1)
+	g.PutEdge("a", "a", 1)
+	g.PutEdge("a", "b", 1)
+
+	c := g.ConnectedGraph("a")
+	if _, ok := c.Edges["a"]["a"]; !ok {
+		t.Errorf("self-loop a->a must be preserved")
+	}
+	if _, ok := c.Vertices["b"]; !ok {
+		t.Errorf("neighbor b must be reached")
+	}
+}
+
 func TestGraph_MinimumSpanningTree(t *testing.T) {
 	// Triangle: a-b=1, b-c=2, a-c=10. MST picks (a-b) + (b-c) = total 3.
 	g := NewGraph[string, int]()

--- a/core/graph/model.go
+++ b/core/graph/model.go
@@ -49,36 +49,35 @@ func (g *Graph[S, T]) ConnectedGraph(seed S) *Graph[S, T] {
 // ConnectedGraphContext is the context-aware variant of ConnectedGraph.
 // It returns ctx.Err() as soon as the context is cancelled or its deadline
 // has expired, so callers can short-circuit large traversals.
+//
+// Implementation: classic FIFO-queue BFS. Each reachable vertex is enqueued
+// exactly once, each outgoing edge is visited exactly once, giving O(V+E)
+// time and O(V) auxiliary memory. The prior round-based loop re-scanned
+// connected.Edges every iteration for O(V·(V+E)).
 func (g *Graph[S, T]) ConnectedGraphContext(ctx context.Context, seed S) (*Graph[S, T], error) {
-	targets := set.NewSet[S]()
-	seen := set.NewSet[S]()
 	connected := NewGraph[S, T]()
 	connected.PutVertex(seed, g.Vertices[seed])
 
-	targets.Add(seed)
-	for {
+	seen := set.NewSet[S]()
+	seen.Add(seed)
+
+	queue := make([]S, 0, 16)
+	queue = append(queue, seed)
+
+	for len(queue) > 0 {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		for _, tail := range targets.Values() {
-			if seen.Has(tail) {
-				continue
-			}
+		tail := queue[0]
+		queue = queue[1:]
 
-			for head, weight := range g.Edges[tail] {
+		for head, weight := range g.Edges[tail] {
+			if !seen.Has(head) {
 				connected.PutVertex(head, g.Vertices[head])
-				connected.PutEdge(tail, head, weight)
+				seen.Add(head)
+				queue = append(queue, head)
 			}
-			seen.Add(tail)
-		}
-		for _, heads := range connected.Edges {
-			for head := range heads {
-				targets.Add(head)
-			}
-		}
-
-		if targets.Size() == seen.Size() {
-			break
+			connected.PutEdge(tail, head, weight)
 		}
 	}
 


### PR DESCRIPTION
Closes #128

## Problem
`ConnectedGraphContext` rebuilt the `targets` frontier each round by re-iterating **all of `connected.Edges`**, giving **O(V·(V+E))** time with per-round `targets.Values()` snapshots. This runs as a prelude inside every MST / MaxST / SPT call, so the cost compounds.

## Change
Replace the round-based loop with a standard FIFO-queue BFS: each reachable vertex is enqueued exactly once and each outgoing edge visited exactly once. **O(V+E)** time, O(V) memory.

## Behavioral parity
- Same reachable vertex and edge set.
- Self-loops and back-edges preserved.
- `ctx.Err()` still checked on each iteration.

## Tests
- Existing `TestGraph_ConnectedGraph` still passes.
- New `TestGraph_ConnectedGraph_DeepChain` — chain + cycle + unreachable component.
- New `TestGraph_ConnectedGraph_SelfLoop` — self-loop edge preserved, traversal terminates.