### PR TITLE
perf(core/graph): incremental Prim for spanning trees

### DIFF
--- a/core/graph/graph_test.go
+++ b/core/graph/graph_test.go
@@ -129,6 +129,57 @@ func TestGraph_MinimumSpanningTree(t *testing.T) {
 	}
 }
 
+// TestGraph_MinimumSpanningTree_Larger exercises Prim on a 5-vertex graph
+// with a clear optimum, to guard against the incremental-push refactor.
+//
+//	a -1- b
+//	|  \  |
+//	5   2 3
+//	|    \|
+//	d -1- c
+//	      |
+//	      4
+//	      e
+//
+// MST edges: a-b(1), a-c(2), c-d (... wait, encode explicitly)
+func TestGraph_MinimumSpanningTree_Larger(t *testing.T) {
+	g := NewGraph[string, int]()
+	add := func(u, v string, w float32) {
+		g.PutEdge(u, v, w)
+		g.PutEdge(v, u, w)
+	}
+	add("a", "b", 1)
+	add("a", "c", 2)
+	add("a", "d", 5)
+	add("b", "c", 3)
+	add("c", "d", 1)
+	add("c", "e", 4)
+	add("d", "e", 6)
+
+	mst := g.MinimumSpanningTree("a")
+
+	// Count undirected edges (each appears twice in mst.Edges if both
+	// directions present, but Prim only adds one direction).
+	total := float32(0)
+	edges := 0
+	for _, heads := range mst.Edges {
+		for _, w := range heads {
+			total += w
+			edges++
+		}
+	}
+	// Optimal MST: a-b(1) + a-c(2) + c-d(1) + c-e(4) = 8
+	if total != 8 {
+		t.Errorf("MST total = %v, want 8 (edges=%v)", total, mst.Edges)
+	}
+	if len(mst.Vertices) != 5 {
+		t.Errorf("MST vertices = %d, want 5", len(mst.Vertices))
+	}
+	if edges != 4 {
+		t.Errorf("MST directed-edge count = %d, want 4", edges)
+	}
+}
+
 func TestGraph_MaximumSpanningTree(t *testing.T) {
 	// Same triangle; max spanning tree picks (a-c)=10 + (b-c)=2 = 12 (avoids a-b=1).
 	g := NewGraph[string, int]()

--- a/core/graph/model.go
+++ b/core/graph/model.go
@@ -109,6 +109,13 @@ func (g *Graph[S, T]) MaximumSpanningTreeContext(ctx context.Context, seed S) (*
 // spanningTreeContext computes either the minimum (negate=false) or maximum
 // (negate=true) spanning tree rooted at seed. It is the shared implementation
 // behind the exported MinimumSpanningTree / MaximumSpanningTree variants.
+//
+// Implementation: classic Prim. When a vertex enters the MST, only its
+// outgoing edges are pushed onto the priority queue, and stale entries
+// pointing at already-included vertices are skipped at pop time. Each edge
+// is therefore pushed and popped at most once, giving O((V+E) log V).
+// The previous version re-scanned mst.Vertices on every iteration of the
+// outer loop, paying an extra O(V) per added vertex.
 func (g *Graph[S, T]) spanningTreeContext(ctx context.Context, seed S, negate bool) (*Graph[S, T], error) {
 	connected, err := g.ConnectedGraphContext(ctx, seed)
 	if err != nil {
@@ -122,61 +129,42 @@ func (g *Graph[S, T]) spanningTreeContext(ctx context.Context, seed S, negate bo
 	}
 
 	mst := NewGraph[S, T]()
+	mst.PutVertex(seed, connected.Vertices[seed])
+
 	q := make(pq.PriorityQueue[*edge, float32], 0)
 	heap.Init(&q)
-	seen := set.NewSet[S]()
 
-	mst.PutVertex(seed, connected.Vertices[seed])
-	for {
+	// pq is a max-heap; flip sign for the minimum-tree case so that the
+	// smallest original weight surfaces at the top.
+	pushOutgoing := func(tail S) {
+		for head, weight := range connected.Edges[tail] {
+			if _, ok := mst.Vertices[head]; ok {
+				continue
+			}
+			w := weight
+			if !negate {
+				w = -weight
+			}
+			heap.Push(&q, &pq.Item[*edge, float32]{
+				Value:    &edge{tail: tail, head: head, weight: weight},
+				Priority: w,
+			})
+		}
+	}
+	pushOutgoing(seed)
+
+	for q.Len() > 0 && len(mst.Vertices) < len(connected.Vertices) {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		if len(mst.Vertices) == len(connected.Vertices) {
-			break
+		picked := heap.Pop(&q).(*pq.Item[*edge, float32]).Value
+		if _, ok := mst.Vertices[picked.head]; ok {
+			// stale: head already absorbed via a better edge
+			continue
 		}
-
-		for tail := range mst.Vertices {
-			if seen.Has(tail) {
-				continue
-			}
-
-			for head, weight := range connected.Edges[tail] {
-				var w float32
-				if negate {
-					w = weight
-				} else {
-					w = -weight
-				}
-
-				item := &pq.Item[*edge, float32]{
-					Value: &edge{
-						tail:   tail,
-						head:   head,
-						weight: weight,
-					},
-					Priority: w,
-				}
-				heap.Push(&q, item)
-			}
-			seen.Add(tail)
-		}
-
-		var pickedUp *edge
-		for {
-			if q.Len() == 0 {
-				break
-			}
-			pickedUp = heap.Pop(&q).(*pq.Item[*edge, float32]).Value
-			if _, ok := mst.Vertices[pickedUp.head]; !ok {
-				break
-			}
-		}
-		if pickedUp == nil {
-			break
-		}
-		mst.PutVertex(pickedUp.head, connected.Vertices[pickedUp.head])
-		mst.PutEdge(pickedUp.tail, pickedUp.head, pickedUp.weight)
-
+		mst.PutVertex(picked.head, connected.Vertices[picked.head])
+		mst.PutEdge(picked.tail, picked.head, picked.weight)
+		pushOutgoing(picked.head)
 	}
 	return mst, nil
 }


### PR DESCRIPTION
Closes #129

## Problem
`spanningTreeContext` re-scanned the entire `mst.Vertices` map on every outer-loop iteration to find newly added tails. That scan cost O(|MST|) per added vertex, giving roughly **O(V² + E log V)**.

## Change
Rewrite as classic incremental Prim:
- When a vertex enters the MST, push only its outgoing edges.
- Skip stale pops whose `head` is already in the MST.

New cost: **O((V+E) log V)** — each edge pushed/popped at most once.

## Behavioural parity
Same MST weight and same vertex set. The max-heap sign trick (negate weight to compute the MINIMUM tree) is preserved; weights are `float32` so the negation is safe.

## Tests
- Existing `TestGraph_MinimumSpanningTree` / `TestGraph_MaximumSpanningTree` pass unchanged.
- New `TestGraph_MinimumSpanningTree_Larger` — 5-vertex graph, optimum 8 across 4 edges, locks the incremental-push path.