### PR TITLE
perf(core/graph): Dijkstra with relaxation for ShortestPathTreeContext

### DIFF
--- a/core/graph/graph_test.go
+++ b/core/graph/graph_test.go
@@ -224,6 +224,45 @@ func TestGraph_ShortestPathTree(t *testing.T) {
 	}
 }
 
+func TestGraph_ShortestPathTree_IndirectCheaper(t *testing.T) {
+	// 4-vertex graph where the indirect path strictly beats the direct edge,
+	// and the indirect path is discovered AFTER the direct edge has already
+	// been pushed onto the priority queue. Exercises Dijkstra's relaxation
+	// step: dist[b] must be updated from 10 (a->b) to 3 (a->c->d->b), and
+	// the reconstructed predecessor of b must be d, not a.
+	g := NewGraph[string, int]()
+	g.PutEdge("a", "b", 10)
+	g.PutEdge("a", "c", 1)
+	g.PutEdge("c", "d", 1)
+	g.PutEdge("d", "b", 1)
+
+	spt := g.ShortestPathTree("a", func(w float32) float32 { return w })
+
+	if len(spt.Vertices) != 4 {
+		t.Errorf("SPT vertices = %d, want 4 (vertices=%v)", len(spt.Vertices), spt.Vertices)
+	}
+	if _, ok := spt.Edges["a"]["b"]; ok {
+		t.Errorf("SPT should NOT contain direct a->b edge (relaxation failed), got %v", spt.Edges)
+	}
+	if _, ok := spt.Edges["d"]["b"]; !ok {
+		t.Errorf("SPT should contain d->b edge as b's shortest predecessor, got %v", spt.Edges)
+	}
+	if _, ok := spt.Edges["a"]["c"]; !ok {
+		t.Errorf("SPT should contain a->c edge, got %v", spt.Edges)
+	}
+	if _, ok := spt.Edges["c"]["d"]; !ok {
+		t.Errorf("SPT should contain c->d edge, got %v", spt.Edges)
+	}
+	// Resulting tree has exactly 3 directed edges for 4 vertices.
+	totalEdges := 0
+	for _, m := range spt.Edges {
+		totalEdges += len(m)
+	}
+	if totalEdges != 3 {
+		t.Errorf("SPT total edges = %d, want 3 (edges=%v)", totalEdges, spt.Edges)
+	}
+}
+
 func TestGraph_Render(t *testing.T) {
 	g := NewGraph[string, int]()
 	g.PutVertex("a", 1)

--- a/core/graph/model.go
+++ b/core/graph/model.go
@@ -182,70 +182,66 @@ func (g *Graph[S, T]) ShortestPathTree(seed S, costFunc func(x float32) float32)
 }
 
 // ShortestPathTreeContext is the context-aware variant of ShortestPathTree.
+//
+// Implementation: classic Dijkstra with relaxation against the original
+// graph. A dist[v] table tracks the best known cost from seed; whenever a
+// shorter path is discovered, dist/prev are updated and a new PQ entry is
+// pushed. Stale entries (top.Priority worse than the current dist[u]) are
+// skipped on pop. Each vertex is therefore settled at most once and each
+// edge is relaxed at most once, giving O((V+E) log V) time and O(V) active
+// PQ entries.
+//
+// The previous implementation called ConnectedGraphContext first (an extra
+// O(V+E) walk plus a full subgraph copy) and used a pivot/position trick
+// without a distance table, which allowed the PQ to grow to O(E). Both are
+// avoided here.
+//
+// PriorityQueue is a max-heap; priorities are negated so the smallest dist
+// surfaces first. costFunc must return non-negative values (Dijkstra
+// precondition).
 func (g *Graph[S, T]) ShortestPathTreeContext(ctx context.Context, seed S, costFunc func(x float32) float32) (*Graph[S, T], error) {
-	connected, err := g.ConnectedGraphContext(ctx, seed)
-	if err != nil {
+	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	spt := NewGraph[S, T]()
-	spt.PutVertex(seed, connected.Vertices[seed])
-
-	type edge struct {
-		tail   S
-		head   S
-		weight float32
+	if _, ok := g.Vertices[seed]; !ok {
+		spt := NewGraph[S, T]()
+		spt.PutVertex(seed, g.Vertices[seed])
+		return spt, nil
 	}
 
-	seen := set.NewSet[S]()
-	q := make(pq.PriorityQueue[*edge, float32], 0)
+	dist := map[S]float32{seed: 0}
+	prev := make(map[S]S)
+
+	q := make(pq.PriorityQueue[S, float32], 0)
 	heap.Init(&q)
-	pivot := seed
-	position := float32(0.0)
-	for {
+	heap.Push(&q, &pq.Item[S, float32]{Value: seed, Priority: 0})
+
+	for q.Len() > 0 {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		if len(spt.Vertices) == len(connected.Vertices) {
-			break
+		top := heap.Pop(&q).(*pq.Item[S, float32])
+		u := top.Value
+		// max-heap: stored priority is -dist[u]; un-negate to compare.
+		if -top.Priority > dist[u] {
+			continue // stale
 		}
-
-		for head, weight := range connected.Edges[pivot] {
-			if seen.Has(head) {
-				continue
-			}
-			cost := costFunc(weight)
-
-			heap.Push(&q, &pq.Item[*edge, float32]{
-				Value: &edge{
-					tail:   pivot,
-					head:   head,
-					weight: weight,
-				},
-				Priority: position - cost,
-			})
-		}
-
-		var pickedUp *pq.Item[*edge, float32]
-		for {
-			if q.Len() == 0 {
-				break
-			}
-			pickedUp = heap.Pop(&q).(*pq.Item[*edge, float32])
-			if _, ok := spt.Vertices[pickedUp.Value.head]; !ok {
-				break
+		for v, w := range g.Edges[u] {
+			alt := dist[u] + costFunc(w)
+			if d, ok := dist[v]; !ok || alt < d {
+				dist[v] = alt
+				prev[v] = u
+				heap.Push(&q, &pq.Item[S, float32]{Value: v, Priority: -alt})
 			}
 		}
-		if pickedUp == nil {
-			break
-		}
-		spt.PutVertex(pickedUp.Value.head, connected.Vertices[pickedUp.Value.head])
-		spt.PutEdge(pickedUp.Value.tail, pickedUp.Value.head, pickedUp.Value.weight)
-
-		seen.Add(pivot)
-		pivot = pickedUp.Value.head
-		position = pickedUp.Priority
 	}
 
+	spt := NewGraph[S, T]()
+	spt.PutVertex(seed, g.Vertices[seed])
+	for v, u := range prev {
+		spt.PutVertex(v, g.Vertices[v])
+		spt.PutEdge(u, v, g.Edges[u][v])
+	}
 	return spt, nil
 }
 


### PR DESCRIPTION
Closes #130

## Problem
`ShortestPathTreeContext` had three inefficiencies:
1. Called `ConnectedGraphContext` first (extra O(V+E) walk + full subgraph copy) before Dijkstra even started.
2. No `dist[v]` table — every distinct edge into a vertex pushed a fresh PQ item, growing the PQ to O(E).
3. Used a pivot/position arithmetic trick instead of actual relaxation.

## Change
Classic relaxation-based Dijkstra against the original graph:
- Maintain `dist[v]` and `prev[v]` maps.
- Push a new PQ item only when a strictly shorter path is discovered.
- Skip stale pops (`-top.Priority > dist[u]`).
- Reconstruct the SPT from `prev[]` at the end.

Cost: **O((V+E) log V)** time, **O(V)** active PQ entries.

The PQ stays the existing max-heap; cost type is `float32` so negating the priority for min-heap semantics is safe.

## Tests
- Existing `TestGraph_ShortestPathTree` passes unchanged.
- New `TestGraph_ShortestPathTree_IndirectCheaper` — 4-vertex graph where the indirect path `a->c->d->b` (cost 3) strictly beats the direct edge `a->b` (cost 10). Verifies that relaxation rewrites `b`'s predecessor to `d` and that the direct edge is excluded.