### PR TITLE
GraphCache: collapse weight read into a single snapshot

### DIFF
--- a/core/cache/graph/edge.go
+++ b/core/cache/graph/edge.go
@@ -71,6 +71,23 @@ func (w *weight) isZero() bool {
 	return w.sum == 0
 }
 
+// snapshot returns the cached sum, the furthest-future expiration among the
+// live contributions, and whether any live contributions remain — all under
+// a single lock acquisition and a single flush pass. Read-hot callers
+// (getDetail) should prefer this over chaining isZero / value /
+// latestExpiration, which triple-lock and triple-scan.
+func (w *weight) snapshot() (sum float32, latest time.Time, nonZero bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.flushLocked()
+	for _, v := range w.values {
+		if v.expiration.After(latest) {
+			latest = v.expiration
+		}
+	}
+	return w.sum, latest, w.sum != 0
+}
+
 // flushLocked compacts expired entries in place and recomputes the cached sum.
 // Caller must hold w.mu.
 func (w *weight) flushLocked() {
@@ -157,11 +174,12 @@ func (c *edgeCache[S]) getDetail(tail, head S) (float32, time.Time, bool) {
 		return 0, time.Time{}, false
 	}
 
-	if w.isZero() {
+	sum, latest, nonZero := w.snapshot()
+	if !nonZero {
 		go c.delete(tail, head)
 		return 0, time.Time{}, false
 	}
-	return w.value(), w.latestExpiration(), true
+	return sum, latest, true
 }
 
 // snapshotTF returns a shallow copy of the tail->heads map keyed by S so

--- a/core/cache/graph/edge_test.go
+++ b/core/cache/graph/edge_test.go
@@ -420,3 +420,38 @@ func Test_weight_addWithTTL(t *testing.T) {
 		})
 	}
 }
+
+func Test_weight_snapshot(t *testing.T) {
+	now := time.Now()
+	t.Run("empty", func(t *testing.T) {
+		w := newWeight()
+		sum, latest, nonZero := w.snapshot()
+		if sum != 0 || !latest.IsZero() || nonZero {
+			t.Fatalf("snapshot empty = (%v, %v, %v), want (0, zero, false)", sum, latest, nonZero)
+		}
+	})
+	t.Run("agrees with value/latestExpiration/isZero on live contributions", func(t *testing.T) {
+		w := newWeight()
+		w.addWithExpiration(1.5, now.Add(time.Minute))
+		w.addWithExpiration(2.5, now.Add(2*time.Minute))
+		w.addWithExpiration(7, now.Add(-time.Minute)) // already expired
+		sum, latest, nonZero := w.snapshot()
+		if got, want := sum, w.value(); got != want {
+			t.Errorf("snapshot.sum = %v, want %v", got, want)
+		}
+		if !latest.Equal(w.latestExpiration()) {
+			t.Errorf("snapshot.latest = %v, want %v", latest, w.latestExpiration())
+		}
+		if nonZero == w.isZero() {
+			t.Errorf("snapshot.nonZero = %v, isZero = %v (should be opposite)", nonZero, w.isZero())
+		}
+	})
+	t.Run("all expired collapses to zero", func(t *testing.T) {
+		w := newWeight()
+		w.addWithExpiration(3, now.Add(-time.Minute))
+		sum, latest, nonZero := w.snapshot()
+		if sum != 0 || !latest.IsZero() || nonZero {
+			t.Fatalf("snapshot all expired = (%v, %v, %v), want (0, zero, false)", sum, latest, nonZero)
+		}
+	})
+}


### PR DESCRIPTION
Closes #135

## What

Add `weight.snapshot()` returning `(sum, latestExpiration, nonZero)` under a single mutex acquisition and single `flushLocked` scan. Refactor `edgeCache.getDetail` to use it.

## Why

`getDetail` is on the GetEdge / Illuminate hot path. The previous implementation called `isZero()`, then `value()`, then `latestExpiration()` — three lock cycles and three linear scans over `weight.values` per read.

## Test

- New `Test_weight_snapshot` (empty / live mix / all expired) verifies agreement with existing accessors.
- Full quality gate green: `gofmt -l` clean, `go test ./...` in root + core/ + pb/ + sdks/go/ + server/.