### PR TITLE
GraphCache: stop spawning goroutines from getDetail

### DIFF
--- a/core/cache/graph/edge.go
+++ b/core/cache/graph/edge.go
@@ -176,7 +176,9 @@ func (c *edgeCache[S]) getDetail(tail, head S) (float32, time.Time, bool) {
 
 	sum, latest, nonZero := w.snapshot()
 	if !nonZero {
-		go c.delete(tail, head)
+		// The edge has fully decayed. Leave physical reclamation to the
+		// next GC tick (edges.flush) so the read path stays allocation
+		// free and avoids spawning a goroutine per hot-path read.
 		return 0, time.Time{}, false
 	}
 	return sum, latest, true

--- a/core/cache/graph/edge_test.go
+++ b/core/cache/graph/edge_test.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -454,4 +455,29 @@ func Test_weight_snapshot(t *testing.T) {
 			t.Fatalf("snapshot all expired = (%v, %v, %v), want (0, zero, false)", sum, latest, nonZero)
 		}
 	})
+}
+
+func Test_edgeCache_getDetail_noGoroutineForExpired(t *testing.T) {
+	c := newEdgeCache[string](time.Minute, newDictionary[string]())
+	c.addWithExpiration("a", "b", 1, time.Now().Add(-time.Second))
+
+	before := runtime.NumGoroutine()
+	for i := 0; i < 100; i++ {
+		if _, _, ok := c.getDetail("a", "b"); ok {
+			t.Fatalf("expected expired edge to report ok=false on iteration %d", i)
+		}
+	}
+	// Goroutine count must not drift upward: previously each call spawned
+	// `go c.delete(...)`. Allow a small slack for runtime housekeeping.
+	after := runtime.NumGoroutine()
+	if after > before+2 {
+		t.Fatalf("goroutine count grew: before=%d after=%d", before, after)
+	}
+
+	// The edge bucket may still be present until the next flush — that is the
+	// intended trade.
+	c.flush()
+	if got := c.count(); got != 0 {
+		t.Fatalf("flush should reclaim expired edge, count=%d", got)
+	}
 }


### PR DESCRIPTION
Closes #136

## What

Remove the inline `go c.delete(tail, head)` from `edgeCache.getDetail` when a read encounters a fully-decayed edge.

## Why

`getDetail` is on every `GetEdge` / `Illuminate` read. Spawning one goroutine per read just to evict an already-expired bucket is pure scheduler overhead — `edges.flush()` already reclaims those buckets on every GC tick.

## Test

- New `Test_edgeCache_getDetail_noGoroutineForExpired` asserts that 100 successive reads against an expired edge do not grow the goroutine count, and that a subsequent `flush()` still reclaims the bucket.
- Full quality gate green.