### PR TITLE
GraphCache: drop whole-graph snapshot from neighborContext

### DIFF
--- a/core/cache/graph/cache.go
+++ b/core/cache/graph/cache.go
@@ -265,13 +265,21 @@ func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int
 	var mu sync.Mutex
 	// targets / seen are accessed only from the main goroutine (between
 	// wg.Wait barriers), so plain maps suffice — no need for the locked
-	// set.Set wrapper. mu still protects concurrent writes to g.Edges.
+	// set.Set wrapper. mu protects concurrent writes to g.Edges and
+	// (when requested) expirations.
 	targets := map[S]struct{}{seed: {}}
 	seen := make(map[S]struct{})
-	// Snapshot edge maps once per Neighbor call. The TF clone is shallow so the
-	// per-edge *weight values remain shared and internally thread-safe.
-	tf := c.edges.snapshotTF()
-	df := c.edges.snapshotDF()
+	// expirations is allocated up front so per-tail goroutines can publish
+	// their surviving heads without an extra coordination pass.
+	var expirations map[S]map[S]time.Time
+	if collectExpirations {
+		expirations = make(map[S]map[S]time.Time)
+	}
+	// We deliberately do NOT clone the entire edge table here: with c.mu
+	// held read-locked, no writer can mutate c.edges.tf, so the per-tail
+	// edgeCache.headsOf / docFreq accessors are safe to call directly.
+	// This turns the per-call cost from O(V+E) (snapshotTF + snapshotDF)
+	// into O(sum of degrees of visited tails).
 	for range step {
 		if err := ctx.Err(); err != nil {
 			return nil, nil, err
@@ -291,23 +299,51 @@ func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int
 			wg.Add(1)
 			go func(t S) {
 				defer wg.Done()
-				heads := tf[t]
-				if len(heads) == 0 {
+				heads, ok := c.edges.headsOf(t)
+				if !ok || len(heads) == 0 {
 					return
 				}
 				edges := make(pq.SortableMap[S, float32], len(heads))
-				for head, w := range heads {
+				var expRow map[S]time.Time
+				if collectExpirations {
+					expRow = make(map[S]time.Time, len(heads))
+				}
+				for headID, w := range heads {
+					head, ok := c.edges.resolveID(headID)
+					if !ok {
+						continue
+					}
+					sum, latest, nonZero := w.snapshot()
+					if !nonZero {
+						continue
+					}
 					if tfidf {
-						edges[head] = w.value() / float32(math.Log2(float64(1+df[head])))
+						edges[head] = sum / float32(math.Log2(float64(1+c.edges.docFreq(headID))))
 					} else {
-						edges[head] = w.value()
+						edges[head] = sum
+					}
+					if expRow != nil {
+						expRow[head] = latest
 					}
 				}
 
-				// Filter light edges
+				// Filter light edges; trim expirations to the survivors.
 				edges = edges.Top(k)
+				if expRow != nil {
+					filtered := make(map[S]time.Time, len(edges))
+					for head := range edges {
+						if exp, has := expRow[head]; has {
+							filtered[head] = exp
+						}
+					}
+					expRow = filtered
+				}
+
 				mu.Lock()
 				g.Edges[t] = edges
+				if expRow != nil {
+					expirations[t] = expRow
+				}
 				mu.Unlock()
 			}(tail)
 		}
@@ -335,27 +371,6 @@ func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int
 		g.Vertices[tail], _ = c.vertices.Get(tail)
 		for head := range heads {
 			g.Vertices[head], _ = c.vertices.Get(head)
-		}
-	}
-
-	// Collect expirations under the same RLock so the handler can compose
-	// edges without re-locking the cache O(E) times. Only edges that
-	// survived the Top-k filter are queried.
-	var expirations map[S]map[S]time.Time
-	if collectExpirations {
-		expirations = make(map[S]map[S]time.Time, len(g.Edges))
-		for tail, heads := range g.Edges {
-			if len(heads) == 0 {
-				continue
-			}
-			row := make(map[S]time.Time, len(heads))
-			tfRow := tf[tail]
-			for head := range heads {
-				if w, ok := tfRow[head]; ok {
-					row[head] = w.latestExpiration()
-				}
-			}
-			expirations[tail] = row
 		}
 	}
 

--- a/core/cache/graph/edge.go
+++ b/core/cache/graph/edge.go
@@ -184,6 +184,40 @@ func (c *edgeCache[S]) getDetail(tail, head S) (float32, time.Time, bool) {
 	return sum, latest, true
 }
 
+// headsOf returns the raw vertexID->*weight head map for `tail` without
+// acquiring the edgeCache lock. The caller must hold the surrounding
+// GraphCache.mu (R or W); under that lock, all edgeCache mutators are
+// serialized so c.tf is stable for the duration of the read. Intended for
+// the Neighbor read path, which only visits a small subset of tails and
+// would otherwise pay the O(V+E) cost of snapshotTF on every call.
+func (c *edgeCache[S]) headsOf(tail S) (map[vertexID]*weight, bool) {
+	if c.dict == nil {
+		return nil, false
+	}
+	tailID, ok := c.dict.lookup(tail)
+	if !ok {
+		return nil, false
+	}
+	heads, ok := c.tf[tailID]
+	return heads, ok
+}
+
+// docFreq returns df[head] without locking the edgeCache. Same lock
+// contract as headsOf: caller must hold the surrounding GraphCache.mu.
+func (c *edgeCache[S]) docFreq(head vertexID) int {
+	return c.df[head]
+}
+
+// resolveID resolves a vertexID back to S without locking the edgeCache.
+// Same lock contract as headsOf.
+func (c *edgeCache[S]) resolveID(id vertexID) (S, bool) {
+	if c.dict == nil {
+		var zero S
+		return zero, false
+	}
+	return c.dict.resolve(id)
+}
+
 // snapshotTF returns a shallow copy of the tail->heads map keyed by S so
 // callers can iterate without holding the edgeCache lock. The inner *weight
 // values are shared and remain individually thread-safe.


### PR DESCRIPTION
Closes #138

## What

Add three new lock-free accessors on `*edgeCache` with an explicit lock contract — caller must hold the surrounding `GraphCache.mu` (R or W):

- `headsOf(tail S) (map[vertexID]*weight, bool)`
- `docFreq(head vertexID) int`
- `resolveID(id vertexID) (S, bool)`

Rewrite `neighborContext` to use these accessors instead of cloning the entire edge table via `snapshotTF` + `snapshotDF` on every call.

## Why

Per-call work for `Neighbor` / `Illuminate` drops from O(V+E) (clone every edge + resolve every endpoint via the dictionary) to O(sum of degrees of the BFS frontier). For large graphs where a Neighbor query only touches a tiny subgraph, this eliminates two big allocations and a full dictionary-resolve pass — a pure read-path win.

The lock contract is sound: `c.mu.RLock()` is already held by `neighborContext` for the whole call, and every `edgeCache` mutator goes through `GraphCache` write methods that take `c.mu.Lock()`. So `c.edges.tf` / `c.edges.df` cannot mutate while `neighborContext` reads them.

`snapshotTF` / `snapshotDF` remain — they are still used by `GraphCache.flush` (dangling-edge sweep) and the refcount test.

## Test

- All existing `core/cache/graph` tests pass.
- `go test -race ./cache/graph/...` passes.
- Full quality gate green across all 5 modules.