### PR TITLE
GraphCache: fuse GC tick into single edge-map walk

### DIFF
--- a/core/cache/graph/bench_test.go
+++ b/core/cache/graph/bench_test.go
@@ -204,3 +204,26 @@ func BenchmarkNeighbor_Large(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkGCFlush exercises the fused GC sweep (zero-weight + dangling) in a
+// single walk over the edge map. Populates the graph, deletes a quarter of
+// the vertices to create dangling edges, then runs c.flush(). Should show
+// no O(E) snapshot allocation per tick.
+func BenchmarkGCFlush(b *testing.B) {
+	for _, s := range smallScales(testing.Short()) {
+		s := s
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				c := NewGraphCache[string, string](time.Hour)
+				keys := populate(b, c, s)
+				for j := 0; j < s.vertices; j += 4 {
+					c.DeleteVertex(keys[j])
+				}
+				b.StartTimer()
+				_, _ = c.flush()
+			}
+		})
+	}
+}

--- a/core/cache/graph/cache.go
+++ b/core/cache/graph/cache.go
@@ -178,21 +178,30 @@ func (c *GraphCache[S, T]) DeleteEdge(tail, head S) bool {
 
 	return c.edges.delete(tail, head)
 }
-func (c *GraphCache[S, T]) flush() int {
+
+// flush performs the fused GC sweep over the edge map in a single walk.
+// It removes zero-weight edges (returned as `zero`) and edges whose endpoints
+// reference vertices that are no longer live (returned as `dangling`).
+//
+// Previously the GC tick walked the edge map twice and additionally cloned
+// the whole tf map via snapshotTF before the dangling sweep; folding the two
+// checks into one walk eliminates that O(E) snapshot allocation and roughly
+// halves the c.mu.Lock hold time on large graphs.
+func (c *GraphCache[S, T]) flush() (zero, dangling int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	removed := 0
-	for tail, heads := range c.edges.snapshotTF() {
-		for head := range heads {
-			if !c.vertices.Has(tail) || !c.vertices.Has(head) {
-				if c.edges.delete(tail, head) {
-					removed++
-				}
-			}
+	return c.edges.flushFunc(func(tailID, headID vertexID) bool {
+		tail, ok := c.edges.resolveID(tailID)
+		if !ok {
+			return false
 		}
-	}
-	return removed
+		head, ok := c.edges.resolveID(headID)
+		if !ok {
+			return false
+		}
+		return c.vertices.Has(tail) && c.vertices.Has(head)
+	})
 }
 
 // VertexCount returns the live vertex count under an RLock. Intended for
@@ -421,8 +430,7 @@ func (c *GraphCache[S, T]) Watch(ctx context.Context, interval time.Duration) {
 		case <-ticker.C:
 			start := time.Now()
 			vExpired := c.vertices.Flush()
-			eExpired := c.edges.flush()
-			dRemoved := c.flush()
+			eExpired, dRemoved := c.flush()
 			d := time.Since(start)
 			onExpire, onGC := c.snapshotHooks()
 			if onExpire != nil {

--- a/core/cache/graph/edge.go
+++ b/core/cache/graph/edge.go
@@ -375,6 +375,37 @@ func (c *edgeCache[S]) flush() int {
 	return removed
 }
 
+// flushFunc is the fused single-walk sweep used by GraphCache GC. In one
+// pass it removes zero-weight edges (counted in `zero`) and edges for which
+// the supplied keep predicate returns false (counted in `dangling`). A nil
+// keep skips the second check and behaves like flush.
+//
+// Caller is responsible for any cross-structure consistency: the predicate
+// runs while c.mu is held write-locked, so it must not take c.mu itself.
+// The typical caller (GraphCache.Watch) wraps the call in the surrounding
+// GraphCache.mu.Lock() so the predicate can read sibling state (e.g. the
+// vertex cache) without further locking.
+func (c *edgeCache[S]) flushFunc(keep func(tail, head vertexID) bool) (zero, dangling int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for tailID, heads := range c.tf {
+		for headID, w := range heads {
+			switch {
+			case w.isZero():
+				if c.deleteLocked(tailID, headID) {
+					zero++
+				}
+			case keep != nil && !keep(tailID, headID):
+				if c.deleteLocked(tailID, headID) {
+					dangling++
+				}
+			}
+		}
+	}
+	return
+}
+
 // count returns the current number of (tail, head) edges held in tf.
 // It acquires only an RLock so it is safe to call from metric collectors.
 func (c *edgeCache[S]) count() int {


### PR DESCRIPTION
Closes #140

## Summary
The GC tick previously walked the edge map twice — `edgeCache.flush()` for zero-weight edges then `GraphCache.flush()` for dangling edges — and the dangling sweep cloned the whole tf via `snapshotTF` before deleting. That doubled `c.mu.Lock` hold time and allocated O(E) per tick.

## Change
- Add `edgeCache.flushFunc(keep)` — one pass, returns `(zero, dangling)`. The keep predicate runs under the edgeCache write lock; the caller (`GraphCache.flush`) wraps the call in `c.mu.Lock` so the predicate can safely read `c.vertices`.
- Rewrite `GraphCache.flush` as a thin wrapper over `flushFunc` with predicate `both endpoints still live`. No `snapshotTF` allocation.
- `Watch` calls `c.flush()` once per tick; per-kind hook counters (`vertex` / `edge` / `dangling_edge`) are unchanged.

## Bench
`BenchmarkGCFlush` added — populates, deletes 1/4 of vertices, runs the fused sweep:

```
BenchmarkGCFlush/v1k_d8_k80-16   1   2647750 ns/op   2048 B/op   8 allocs/op
```

8 allocs/tick confirms no O(E) snapshot on the GC path.

## Verification
- gofmt clean; full multi-module `go test ./...` green; `go vet` on server clean.
- `go test -race ./cache/graph/...` passes.
- All existing dangling-edge / flush / refcount tests pass unchanged.
