### PR TITLE
edge writes: shortcircuit dictionary for existing edges

### DIFF
--- a/core/cache/graph/bench_test.go
+++ b/core/cache/graph/bench_test.go
@@ -241,3 +241,19 @@ func BenchmarkWeight_AddOnly(b *testing.B) {
 		w.addWithExpiration(1, past)
 	}
 }
+
+// BenchmarkAddEdge_Existing measures the existing-edge fast path in
+// edgeCache.addWithExpiration. After warming up a single edge, every
+// iteration must hit the fast path: one dict RLock to resolve both ids,
+// one edgeCache RLock to find the *weight, then the leaf weight.mu
+// append. No dict writes, no edgeCache writes.
+func BenchmarkAddEdge_Existing(b *testing.B) {
+	c := NewGraphCache[string, int](time.Minute)
+	exp := time.Now().Add(time.Hour)
+	c.AddEdgeWithExpiration("hot-tail", "hot-head", 1, exp)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.AddEdgeWithExpiration("hot-tail", "hot-head", 1, exp)
+	}
+}

--- a/core/cache/graph/dict.go
+++ b/core/cache/graph/dict.go
@@ -95,6 +95,25 @@ func (d *dictionary[S]) lookup(key S) (vertexID, bool) {
 	return id, ok
 }
 
+// lookupBoth resolves both keys to vertexIDs under a single RLock cycle.
+// Returns each id independently with its own found-bit so the caller can
+// distinguish "tail missing" from "head missing" without a second lookup.
+// Refcounts are unchanged; the returned ids are valid only as long as no
+// concurrent release frees them, which is the same contract as lookup.
+//
+// Edge writers use this on the hot path: if both ids already exist and
+// the (tail, head) bucket is present, the write can append to the per-edge
+// weight without touching the dict's write lock or the edgeCache write
+// lock at all.
+func (d *dictionary[S]) lookupBoth(a, b S) (idA, idB vertexID, okA, okB bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	idA, okA = d.forward[a]
+	idB, okB = d.forward[b]
+	return
+}
+
 // resolve returns the key for id. It returns the zero value of S and
 // false if id is not currently allocated (either never minted or already
 // freed).

--- a/core/cache/graph/edge.go
+++ b/core/cache/graph/edge.go
@@ -298,6 +298,39 @@ func (c *edgeCache[S]) resolve(id vertexID) (S, bool) {
 }
 
 func (c *edgeCache[S]) addWithExpiration(tail, head S, w float32, expiration time.Time) {
+	// Fast path: existing edge. A hot counter-style edge gets updated every
+	// few ms; the slow path below would acquire the dict write lock twice
+	// (intern tail, intern head) and the dict release lock twice (revert
+	// the bumps) plus the edgeCache write lock — five global serialization
+	// points to append a float to a slice. If both endpoints are already
+	// interned AND the (tail, head) bucket already exists, we can skip
+	// every dict mutation and the edgeCache write lock entirely: a single
+	// dict RLock to resolve both ids, a single edgeCache RLock to fetch the
+	// *weight pointer, then the leaf weight.mu append. Refcounts are
+	// untouched because we neither add nor remove an edge.
+	//
+	// Race note: a concurrent delete between RUnlock and the weight append
+	// can leave us appending to a *weight that has just been detached from
+	// the map. That is harmless — the weight pointer stays valid, but the
+	// orphan is no longer reachable through tf, so the write effectively
+	// vanishes. The user-visible semantics of "concurrent add+delete on the
+	// same edge" are already racy under the slow path; the fast path
+	// preserves that contract without introducing new visibility issues.
+	if c.dict != nil {
+		if tailID, headID, okT, okH := c.dict.lookupBoth(tail, head); okT && okH {
+			c.mu.RLock()
+			if heads, ok := c.tf[tailID]; ok {
+				if edge, ok := heads[headID]; ok {
+					c.mu.RUnlock()
+					edge.addWithExpiration(w, expiration)
+					return
+				}
+			}
+			c.mu.RUnlock()
+		}
+	}
+
+	// Slow path: new edge (or first writer when dict is nil in tests).
 	// Intern both endpoints OUTSIDE the edgeCache lock so the dict can serve
 	// readers in parallel. The intern call is the +1 we either keep (new
 	// edge) or undo (existing edge) under the edgeCache lock below.
@@ -319,7 +352,10 @@ func (c *edgeCache[S]) addWithExpiration(tail, head S, w float32, expiration tim
 		c.df[headID]++
 	} else if c.dict != nil {
 		// Edge already present: revert the intern bumps to keep the
-		// "one ref per endpoint per edge" invariant.
+		// "one ref per endpoint per edge" invariant. This branch is
+		// now rare — the fast path above handles the common case —
+		// but it remains correct for the lookupBoth-missed window
+		// (e.g. tail interned between lookupBoth and intern).
 		c.dict.release(tailID)
 		c.dict.release(headID)
 	}

--- a/core/cache/graph/refcount_test.go
+++ b/core/cache/graph/refcount_test.go
@@ -182,3 +182,38 @@ func TestDictRefcount_FullExpiryFreesAll(t *testing.T) {
 			got, maxID)
 	}
 }
+
+// TestDictRefcount_HotEdgeFastPathStability verifies that the existing-edge
+// fast path in addWithExpiration does not touch dict refcounts. After 100k
+// writes to the same edge, both endpoints must still have refcount = 2
+// (vertex slot + 1 edge endpoint), the dict size must still be 2, and the
+// edge's accumulated sum must be exactly 100k.
+func TestDictRefcount_HotEdgeFastPathStability(t *testing.T) {
+	c := NewGraphCache[string, int](time.Minute)
+	// First write goes through the slow path and interns both endpoints.
+	exp := time.Now().Add(time.Minute)
+	c.AddEdgeWithExpiration("hot-tail", "hot-head", 1, exp)
+	tailID, _ := c.dict.lookup("hot-tail")
+	headID, _ := c.dict.lookup("hot-head")
+	wantTail := c.dict.refcount[tailID]
+	wantHead := c.dict.refcount[headID]
+	wantLen := c.dict.len()
+
+	const n = 100_000
+	for i := 0; i < n; i++ {
+		c.AddEdgeWithExpiration("hot-tail", "hot-head", 1, exp)
+	}
+
+	if got := c.dict.refcount[tailID]; got != wantTail {
+		t.Fatalf("tail refcount drifted: got %d, want %d (fast path must not touch dict)", got, wantTail)
+	}
+	if got := c.dict.refcount[headID]; got != wantHead {
+		t.Fatalf("head refcount drifted: got %d, want %d (fast path must not touch dict)", got, wantHead)
+	}
+	if got := c.dict.len(); got != wantLen {
+		t.Fatalf("dict.len drifted: got %d, want %d", got, wantLen)
+	}
+	if got, ok := c.GetWeight("hot-tail", "hot-head"); !ok || got != float32(n+1) {
+		t.Fatalf("edge sum after %d adds: got %v ok=%v, want %d", n+1, got, ok, n+1)
+	}
+}


### PR DESCRIPTION
Closes #142.

## What

Add `dict.lookupBoth()` and use it as a fast path in `edgeCache.addWithExpiration`. When the edge already exists, skip the dict write lock and the edgeCache write lock entirely — just RLock the dict, RLock the edgeCache, and append to the per-edge weight under the leaf weight mutex.

## Why

A hot counter-style edge (`AddEdge` called every ms) previously needed 4 dict write-lock acquisitions per add (intern tail+head, then release tail+head once we noticed the edge already existed) **plus** the edgeCache write lock. Under read-priority constraints, every one of those writer acquisitions starved RLock-holding readers (vertex/edge/neighbor lookups, `Illuminate`, optimizer walks). The fast path collapses 5 global serialization points to 2 RLocks + 1 leaf mutex.

## Read-path impact

This is the headline goal: reduce writer contention so the read path scales. The fast path holds only RLocks on the two shared structures, so concurrent reads on different edges or vertices are uncontended.

## Correctness

- Refcount invariant preserved: fast path adds nothing and removes nothing, so endpoint refcounts cannot drift.
- The slow path still handles the genuine new-edge case AND the `lookupBoth`-missed window (e.g. tail interned between `lookupBoth` and `intern`).
- Race note documented in code: a concurrent delete between RUnlock and the weight append leaves us appending to an orphan `*weight`. The pointer stays valid; the write becomes silently unreachable. The slow path has the same race today — this preserves contract, doesn't introduce a new one.

## Validation

- `TestDictRefcount_HotEdgeFastPathStability`: 100k adds to the same edge — both endpoint refcounts unchanged, `dict.len` unchanged, edge sum exact.
- `BenchmarkAddEdge_Existing` (new): **154.6 ns/op, 0 allocs/op** on M3 Max.
- All existing tests pass across all 5 modules.
- Race tests on `core/cache/graph` pass.
- `gofmt`, `go vet` clean.