### PR TITLE
cleanup: remove dead weightValue.expired()

### DIFF
--- a/core/cache/graph/edge.go
+++ b/core/cache/graph/edge.go
@@ -10,10 +10,6 @@ type weightValue struct {
 	expiration time.Time
 }
 
-func (w weightValue) expired() bool {
-	return time.Now().After(w.expiration)
-}
-
 // weight aggregates additive contributions to an edge, each with its own
 // expiration. It is safe for concurrent use; the cached sum lets readers avoid
 // re-scanning the slice on every call.

--- a/core/cache/graph/edge_test.go
+++ b/core/cache/graph/edge_test.go
@@ -27,39 +27,6 @@ func Test_newWeight(t *testing.T) {
 	}
 }
 
-func Test_weightValue_expired(t *testing.T) {
-	type fields struct {
-		value float32
-		ttl   time.Time
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   bool
-	}{
-		{
-			name: "weightValue_expired",
-			fields: fields{
-				value: 1,
-				ttl:   time.Now().Add(-time.Minute),
-			},
-			want: true,
-		},
-	}
-	for i := range tests {
-		tt := &tests[i]
-		t.Run(tt.name, func(t *testing.T) {
-			w := weightValue{
-				value:      tt.fields.value,
-				expiration: tt.fields.ttl,
-			}
-			if got := w.expired(); got != tt.want {
-				t.Errorf("expired() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func Test_weight_add(t *testing.T) {
 	type fields struct {
 		values []weightValue


### PR DESCRIPTION
Closes #143.

`weightValue.expired()` has no remaining callers. Both `flushLocked` and `snapshot` compare `expiration` directly to a single sampled `time.Now()` so an entire compaction or read batch sees a consistent boundary.

Leaving the helper around invited future contributors to reintroduce per-entry `time.Now()` calls — and the associated wall-clock skew — on hot paths. Cleaner to delete it now.

- Removed `weightValue.expired()` from `core/cache/graph/edge.go`.
- Removed `Test_weightValue_expired` from `core/cache/graph/edge_test.go`.
- `grep -rn 'expired()' core/cache/graph/` → no matches.
- All tests across all 5 modules green; race tests on `core/cache/graph` green.