### PR TITLE
Phase 4: Go SDK prefix scan wrappers + ScanVerticesAll iterator (#157)

### DIFF
--- a/sdks/go/example/main.go
+++ b/sdks/go/example/main.go
@@ -254,6 +254,57 @@ func main() {
 		log.Fatal(err)
 	}
 
+	/*
+		Prefix scan: enumerate, count, and bulk-delete vertices whose key
+		starts with a common prefix. Requires the server to have the prefix
+		index enabled (production wiring does this automatically).
+
+		IMPORTANT: when seeding vertices for a scan, ALWAYS pass a non-zero
+		Expiration (or use the helper Lantern.PutVertex with a positive TTL).
+		Without it, the proto Expiration defaults to the zero timestamp
+		(1970-01-01) and the cache treats every vertex as born-expired —
+		CountVerticesByPrefix will return a non-zero count (radix only) while
+		ScanVertices silently yields nothing.
+	*/
+	exp := time.Now().Add(1 * time.Hour)
+	prefixSeed := []client.VertexInput{
+		{Key: "users/alice", Value: "alice", Expiration: exp},
+		{Key: "users/bob", Value: "bob", Expiration: exp},
+		{Key: "users/carol", Value: "carol", Expiration: exp},
+		{Key: "orders/1", Value: 1, Expiration: exp},
+		{Key: "orders/2", Value: 2, Expiration: exp},
+	}
+	if err := cli.PutVertices(ctx, prefixSeed); err != nil {
+		log.Fatal(err)
+	}
+
+	if n, err := cli.CountVerticesByPrefix(ctx, "users/"); err == nil {
+		log.Printf("count users/ = %d\n", n) // 3
+	}
+
+	// Single page scan with explicit cursor.
+	if vs, next, err := cli.ScanVertices(ctx, "users/", client.WithScanLimit(2)); err == nil {
+		log.Printf("first page returned %d vertices; more=%v", len(vs), len(next) > 0)
+	}
+
+	// Iterator covering every page.
+	total := 0
+	for batch, err := range cli.ScanVerticesAll(ctx, "users/", 2) {
+		if err != nil {
+			log.Fatal(err)
+		}
+		total += len(batch)
+	}
+	log.Printf("iterator total = %d\n", total) // 3
+
+	// Dry-run delete first, then real delete.
+	if matched, err := cli.DeleteVerticesByPrefix(ctx, "orders/", client.WithDryRun()); err == nil {
+		log.Printf("would delete %d orders/ vertices\n", matched)
+	}
+	if deleted, err := cli.DeleteVerticesByPrefix(ctx, "orders/"); err == nil {
+		log.Printf("deleted %d orders/ vertices\n", deleted)
+	}
+
 	// illuminate from a with step 2 and k 2
 	if graph, err := cli.Illuminate(ctx, "a", client.WithStep(2), client.WithK(2)); err == nil {
 		if jsonString, err := json.MarshalIndent(graph, "", "\t"); err == nil {

--- a/sdks/go/prefix.go
+++ b/sdks/go/prefix.go
@@ -1,0 +1,169 @@
+package client
+
+import (
+	"context"
+	"iter"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+)
+
+// ScanOption configures Lantern.ScanVertices. Use WithScanLimit /
+// WithScanCursor to page through a large prefix range.
+type ScanOption func(*scanOptions)
+
+type scanOptions struct {
+	limit  uint32
+	cursor []byte
+}
+
+// WithScanLimit caps the number of vertices the server returns in one
+// ScanVertices response. 0 (the default) lets the server apply its
+// configured default (see LANTERN_SCAN_DEFAULT_LIMIT). Values above the
+// server's configured maximum are clamped down server-side.
+func WithScanLimit(n uint32) ScanOption {
+	return func(o *scanOptions) { o.limit = n }
+}
+
+// WithScanCursor resumes a paginated scan from the cursor returned by a
+// previous ScanVertices call. Treat the cursor as opaque bytes — do not
+// inspect or modify it. An empty cursor (the default) starts from the
+// beginning of the prefix range.
+func WithScanCursor(c []byte) ScanOption {
+	return func(o *scanOptions) { o.cursor = c }
+}
+
+// DeleteByPrefixOption configures Lantern.DeleteVerticesByPrefix.
+type DeleteByPrefixOption func(*deleteByPrefixOptions)
+
+type deleteByPrefixOptions struct {
+	limit  uint32
+	dryRun bool
+}
+
+// WithDeleteByPrefixLimit caps the number of vertices a single
+// DeleteVerticesByPrefix call may remove. 0 (the default) lets the server
+// apply its configured default (see LANTERN_DELETE_BY_PREFIX_DEFAULT_LIMIT).
+// Values above the server's configured maximum are clamped down server-side.
+func WithDeleteByPrefixLimit(n uint32) DeleteByPrefixOption {
+	return func(o *deleteByPrefixOptions) { o.limit = n }
+}
+
+// WithDryRun asks the server to report the number of vertices that WOULD be
+// deleted without actually deleting them. The returned count from
+// DeleteVerticesByPrefix is the matched count; no mutation occurs.
+func WithDryRun() DeleteByPrefixOption {
+	return func(o *deleteByPrefixOptions) { o.dryRun = true }
+}
+
+// ScanVertices returns one page of vertices whose key starts with prefix, in
+// ascending key order. nextCursor is non-empty when more pages are available;
+// pass it via WithScanCursor on the next call to continue. An empty
+// nextCursor signals end of stream.
+//
+// For most callers, ScanVerticesAll is the more ergonomic API — use this
+// method only when you need explicit control over a single page (e.g. for
+// implementing a UI "next page" button).
+func (l *Lantern) ScanVertices(ctx context.Context, prefix string, opts ...ScanOption) (vertices []*Vertex, nextCursor []byte, err error) {
+	o := scanOptions{}
+	for _, apply := range opts {
+		apply(&o)
+	}
+	ctx, cancel := l.applyTimeout(ctx)
+	defer cancel()
+	resp, err := l.client.ScanVertices(ctx, &pb.ScanVerticesRequest{
+		Prefix: prefix,
+		Limit:  o.limit,
+		Cursor: o.cursor,
+	})
+	if err != nil {
+		return nil, nil, wrapStatus(err)
+	}
+	return resp.GetVertices(), resp.GetNextCursor(), nil
+}
+
+// CountVerticesByPrefix returns the number of live vertices whose key starts
+// with prefix. The implementation is radix-only and does NOT cross-check
+// vertex liveness per entry, so under heavy expiration churn the count may
+// transiently overshoot the number ScanVertices would actually return. Treat
+// the value as a fast estimate, not as a hard invariant for ScanVertices.
+func (l *Lantern) CountVerticesByPrefix(ctx context.Context, prefix string) (uint64, error) {
+	ctx, cancel := l.applyTimeout(ctx)
+	defer cancel()
+	resp, err := l.client.CountVerticesByPrefix(ctx, &pb.CountVerticesByPrefixRequest{Prefix: prefix})
+	if err != nil {
+		return 0, wrapStatus(err)
+	}
+	return resp.GetCount(), nil
+}
+
+// DeleteVerticesByPrefix removes up to the configured limit of vertices
+// whose key starts with prefix, returning the number actually removed (or,
+// with WithDryRun, the number that WOULD have been removed).
+//
+// Operational notes:
+//   - This is a destructive bulk operation. Always run with WithDryRun first
+//     to confirm the matched count before issuing a real delete.
+//   - The call is excluded from the SDK's default retry policy because a
+//     partial-success retry could over-delete (server already removed N when
+//     UNAVAILABLE was returned; the retry would remove the next N).
+//   - To remove EVERY matching vertex when the prefix exceeds the server's
+//     max delete-by-prefix limit, call repeatedly until the returned count is
+//     zero — the server applies the limit per call.
+func (l *Lantern) DeleteVerticesByPrefix(ctx context.Context, prefix string, opts ...DeleteByPrefixOption) (uint64, error) {
+	o := deleteByPrefixOptions{}
+	for _, apply := range opts {
+		apply(&o)
+	}
+	ctx, cancel := l.applyTimeout(ctx)
+	defer cancel()
+	resp, err := l.client.DeleteVerticesByPrefix(ctx, &pb.DeleteVerticesByPrefixRequest{
+		Prefix: prefix,
+		Limit:  o.limit,
+		DryRun: o.dryRun,
+	})
+	if err != nil {
+		return 0, wrapStatus(err)
+	}
+	return resp.GetDeleted(), nil
+}
+
+// ScanVerticesAll returns a Go 1.23+ iter.Seq2 that yields successive pages
+// of ScanVertices results until the prefix range is exhausted or ctx is
+// cancelled. Each yielded value is one server response's vertex slice (never
+// nil, but possibly empty on the final page); errors short-circuit
+// iteration. batchSize is forwarded to the server as the per-call limit
+// (0 = server default).
+//
+// Typical use:
+//
+//	for batch, err := range cli.ScanVerticesAll(ctx, "users/", 500) {
+//	    if err != nil { return err }
+//	    for _, v := range batch { ... }
+//	}
+//
+// Stop conditions: empty next_cursor from the server (clean end of stream),
+// any error from the server, or the consumer returning false from yield
+// (i.e. `break` out of the for-range).
+func (l *Lantern) ScanVerticesAll(ctx context.Context, prefix string, batchSize uint32) iter.Seq2[[]*Vertex, error] {
+	return func(yield func([]*Vertex, error) bool) {
+		var cursor []byte
+		for {
+			if ctx.Err() != nil {
+				yield(nil, ctx.Err())
+				return
+			}
+			vs, next, err := l.ScanVertices(ctx, prefix, WithScanLimit(batchSize), WithScanCursor(cursor))
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if !yield(vs, nil) {
+				return
+			}
+			if len(next) == 0 {
+				return
+			}
+			cursor = next
+		}
+	}
+}

--- a/sdks/go/prefix_test.go
+++ b/sdks/go/prefix_test.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"testing"
+)
+
+func TestScanOptions_Defaults(t *testing.T) {
+	o := scanOptions{}
+	if o.limit != 0 {
+		t.Errorf("default limit = %d, want 0", o.limit)
+	}
+	if o.cursor != nil {
+		t.Errorf("default cursor = %v, want nil", o.cursor)
+	}
+}
+
+func TestScanOptions_Apply(t *testing.T) {
+	o := scanOptions{}
+	for _, apply := range []ScanOption{
+		WithScanLimit(42),
+		WithScanCursor([]byte("opaque")),
+	} {
+		apply(&o)
+	}
+	if o.limit != 42 {
+		t.Errorf("limit = %d, want 42", o.limit)
+	}
+	if string(o.cursor) != "opaque" {
+		t.Errorf("cursor = %q, want %q", o.cursor, "opaque")
+	}
+}
+
+func TestDeleteByPrefixOptions_Defaults(t *testing.T) {
+	o := deleteByPrefixOptions{}
+	if o.limit != 0 || o.dryRun {
+		t.Errorf("defaults = %+v, want zero-value", o)
+	}
+}
+
+func TestDeleteByPrefixOptions_Apply(t *testing.T) {
+	o := deleteByPrefixOptions{}
+	for _, apply := range []DeleteByPrefixOption{
+		WithDeleteByPrefixLimit(7),
+		WithDryRun(),
+	} {
+		apply(&o)
+	}
+	if o.limit != 7 {
+		t.Errorf("limit = %d, want 7", o.limit)
+	}
+	if !o.dryRun {
+		t.Errorf("dryRun = false, want true")
+	}
+}

--- a/tests/integration/prefix_sdk_test.go
+++ b/tests/integration/prefix_sdk_test.go
@@ -1,0 +1,242 @@
+package integration_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/anaregdesign/lantern/server/service"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// newPrefixSDKClient wires the high-level SDK to an in-process server whose
+// cache has the prefix index enabled. Mirrors newPrefixScanRaw but goes
+// through *client.Lantern so we exercise the Phase 4 wrappers end-to-end.
+func newPrefixSDKClient(t *testing.T) (*client.Lantern, func()) {
+	t.Helper()
+
+	lis := bufconn.Listen(1 << 16)
+	gc := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	gc.EnablePrefixIndex(func(s string) string { return s })
+
+	srv := grpc.NewServer()
+	pb.RegisterLanternServiceServer(srv, service.NewLanternService(gc))
+	go func() { _ = srv.Serve(lis) }()
+
+	dialer := func(context.Context, string) (net.Conn, error) { return lis.Dial() }
+	l, err := client.NewLantern(
+		"passthrough://bufconn",
+		client.WithTransportCredentials(insecure.NewCredentials()),
+		client.WithDialOption(grpc.WithContextDialer(dialer)),
+	)
+	if err != nil {
+		t.Fatalf("NewLantern: %v", err)
+	}
+	cleanup := func() {
+		_ = l.Close()
+		srv.Stop()
+		_ = lis.Close()
+	}
+	return l, cleanup
+}
+
+// seedPrefixVertices upserts keys with an explicit one-hour Expiration.
+// Without an explicit Expiration, pb.Vertex defaults to the zero timestamp
+// (1970-01-01), so the cache treats every vertex as born-expired:
+// CountVerticesByPrefix would lie (radix-only) while ScanVertices returns
+// nothing. See /memories/repo/lantern.md "GraphCache vertex seeding gotcha"
+// for the full diagnosis.
+func seedPrefixVertices(t *testing.T, ctx context.Context, l *client.Lantern, keys []string) {
+	t.Helper()
+	inputs := make([]client.VertexInput, len(keys))
+	exp := time.Now().Add(time.Hour)
+	for i, k := range keys {
+		inputs[i] = client.VertexInput{Key: k, Value: k, Expiration: exp}
+	}
+	if err := l.PutVertices(ctx, inputs); err != nil {
+		t.Fatalf("PutVertices: %v", err)
+	}
+}
+
+func TestSDK_CountVerticesByPrefix(t *testing.T) {
+	l, cleanup := newPrefixSDKClient(t)
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	seedPrefixVertices(t, ctx, l, []string{
+		"users/1", "users/2", "users/3",
+		"orders/1", "orders/2",
+	})
+
+	n, err := l.CountVerticesByPrefix(ctx, "users/")
+	if err != nil {
+		t.Fatalf("CountVerticesByPrefix: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("count users/ = %d, want 3", n)
+	}
+	n2, err := l.CountVerticesByPrefix(ctx, "missing/")
+	if err != nil {
+		t.Fatalf("CountVerticesByPrefix missing: %v", err)
+	}
+	if n2 != 0 {
+		t.Errorf("count missing/ = %d, want 0", n2)
+	}
+}
+
+func TestSDK_ScanVertices_SinglePage(t *testing.T) {
+	l, cleanup := newPrefixSDKClient(t)
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	seedPrefixVertices(t, ctx, l, []string{"a/1", "a/2", "a/3", "b/1"})
+
+	vs, next, err := l.ScanVertices(ctx, "a/", client.WithScanLimit(10))
+	if err != nil {
+		t.Fatalf("ScanVertices: %v", err)
+	}
+	if len(vs) != 3 {
+		t.Fatalf("got %d vertices, want 3", len(vs))
+	}
+	if len(next) != 0 {
+		t.Errorf("expected empty next cursor (single page), got %x", next)
+	}
+	want := []string{"a/1", "a/2", "a/3"}
+	for i, v := range vs {
+		if v.GetKey() != want[i] {
+			t.Errorf("vs[%d].Key = %q, want %q", i, v.GetKey(), want[i])
+		}
+	}
+}
+
+func TestSDK_ScanVertices_PaginatedCursor(t *testing.T) {
+	l, cleanup := newPrefixSDKClient(t)
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	seed := []string{"k/1", "k/2", "k/3", "k/4", "k/5"}
+	seedPrefixVertices(t, ctx, l, seed)
+
+	got := []string{}
+	var cursor []byte
+	pages := 0
+	for {
+		pages++
+		if pages > 10 {
+			t.Fatalf("pagination did not terminate: got %v", got)
+		}
+		vs, next, err := l.ScanVertices(ctx, "k/", client.WithScanLimit(2), client.WithScanCursor(cursor))
+		if err != nil {
+			t.Fatalf("ScanVertices page %d: %v", pages, err)
+		}
+		for _, v := range vs {
+			got = append(got, v.GetKey())
+		}
+		if len(next) == 0 {
+			break
+		}
+		cursor = next
+	}
+	if len(got) != len(seed) {
+		t.Fatalf("got %v, want %v", got, seed)
+	}
+	for i := range seed {
+		if got[i] != seed[i] {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], seed[i])
+		}
+	}
+}
+
+func TestSDK_ScanVerticesAll_Iterator(t *testing.T) {
+	l, cleanup := newPrefixSDKClient(t)
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	seed := []string{"u/1", "u/2", "u/3", "u/4", "u/5", "u/6", "u/7"}
+	seedPrefixVertices(t, ctx, l, seed)
+
+	got := []string{}
+	batches := 0
+	for batch, err := range l.ScanVerticesAll(ctx, "u/", 3) {
+		if err != nil {
+			t.Fatalf("iterator yielded error: %v", err)
+		}
+		batches++
+		for _, v := range batch {
+			got = append(got, v.GetKey())
+		}
+	}
+	if len(got) != len(seed) {
+		t.Fatalf("iterator yielded %v, want %v", got, seed)
+	}
+	for i := range seed {
+		if got[i] != seed[i] {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], seed[i])
+		}
+	}
+	if batches < 2 {
+		t.Errorf("expected >=2 batches with batchSize=3 and 7 items, got %d", batches)
+	}
+}
+
+func TestSDK_ScanVerticesAll_EarlyBreak(t *testing.T) {
+	l, cleanup := newPrefixSDKClient(t)
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	seedPrefixVertices(t, ctx, l, []string{"x/1", "x/2", "x/3", "x/4", "x/5"})
+
+	seen := 0
+	for batch, err := range l.ScanVerticesAll(ctx, "x/", 2) {
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		seen += len(batch)
+		break // consumer aborts after first batch
+	}
+	if seen == 0 {
+		t.Errorf("expected at least one vertex from first batch, got 0")
+	}
+}
+
+func TestSDK_DeleteVerticesByPrefix_DryRunVsReal(t *testing.T) {
+	l, cleanup := newPrefixSDKClient(t)
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	seedPrefixVertices(t, ctx, l, []string{"d/1", "d/2", "d/3"})
+
+	matched, err := l.DeleteVerticesByPrefix(ctx, "d/", client.WithDryRun())
+	if err != nil {
+		t.Fatalf("DeleteVerticesByPrefix dry: %v", err)
+	}
+	if matched != 3 {
+		t.Errorf("dry matched = %d, want 3", matched)
+	}
+	if n, _ := l.CountVerticesByPrefix(ctx, "d/"); n != 3 {
+		t.Errorf("count after dry run = %d, want 3 (no mutation)", n)
+	}
+
+	deleted, err := l.DeleteVerticesByPrefix(ctx, "d/")
+	if err != nil {
+		t.Fatalf("DeleteVerticesByPrefix real: %v", err)
+	}
+	if deleted != 3 {
+		t.Errorf("deleted = %d, want 3", deleted)
+	}
+	if n, _ := l.CountVerticesByPrefix(ctx, "d/"); n != 0 {
+		t.Errorf("count after real delete = %d, want 0", n)
+	}
+}


### PR DESCRIPTION
Closes #157. Part of #153 (prefix-scan rollout).

Adds the SDK surface for the Phase 3 server RPCs:
- `Lantern.ScanVertices(ctx, prefix, opts...)` — one page, returns next cursor as opaque bytes.
- `Lantern.CountVerticesByPrefix(ctx, prefix)`
- `Lantern.DeleteVerticesByPrefix(ctx, prefix, opts...)` with `WithDryRun()`.
- `Lantern.ScanVerticesAll(ctx, prefix, batchSize) iter.Seq2[[]*Vertex, error]` — Go 1.23+ range-over-func iterator that walks every page until empty cursor.

### Findings from #156 incorporated
- Seed vertices in `sdks/go/example/main.go` and `tests/integration/prefix_sdk_test.go` set an explicit `Expiration` to avoid the born-expired trap (Count lies, Scan empty). Inline comment + repo memory note both reference this.
- Cursor is passed through as opaque `[]byte` — SDK never decodes.
- `DeleteVerticesByPrefix` is deliberately NOT added to the default retry service config: a UNAVAILABLE retry after a partial server-side success would over-delete.
- Iterator stops on empty `next_cursor` (clean end), any error, or consumer `break`.

### Tests
- `sdks/go/prefix_test.go` — option assembly (no network).
- `tests/integration/prefix_sdk_test.go` — six bufconn round-trip cases: Count, single-page Scan, paginated cursor walk, ScanVerticesAll happy path, ScanVerticesAll early-break, DryRun-vs-real DeleteByPrefix.

### Local quality gate
`gofmt` clean, `go vet` clean. `go test ./...` passes in `server/`, `core/`, `pb/`, `sdks/go/`, and root (incl. `tests/integration`).