### PR TITLE
feat(cli): vertex scan/count/delete-prefix subcommands (#158)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ on stdout; all write commands print a single `OK` line.
 ./lantern vertex delete alice bob carol       # batch DeleteVertices
 cat edges.ndjson | ./lantern bulk edges add - # streamed AddEdges
 
+# prefix scan (key-space enumeration)
+./lantern vertex count  users/                       # radix count for users/*
+./lantern vertex scan   users/ --limit 100           # one page; next-cursor on stderr
+./lantern vertex scan   users/ --all > snap.ndjson   # stream every match as NDJSON
+./lantern vertex delete-prefix tmp/                  # REFUSED (safety gate)
+./lantern vertex delete-prefix tmp/ --dry-run        # preview count
+./lantern vertex delete-prefix tmp/ --yes            # actually delete
+
 # TLS / mTLS
 ./lantern --tls --tls-ca ./ca.pem -H lantern.example.com -p 443 vertex get alice
 

--- a/cli/cmd/prefix.go
+++ b/cli/cmd/prefix.go
@@ -1,0 +1,235 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/spf13/cobra"
+)
+
+// -- vertex scan ------------------------------------------------------------
+
+var (
+	vertexScanLimit  uint32
+	vertexScanCursor string
+	vertexScanAll    bool
+)
+
+var vertexScanCmd = &cobra.Command{
+	Use:   "scan <prefix>",
+	Short: "Enumerate vertices whose key begins with <prefix>",
+	Long: `Walk the prefix index and emit each live vertex as one NDJSON line on
+stdout (same per-vertex schema as "vertex get").
+
+PAGINATION
+  Without --all the server returns at most --limit vertices and an opaque
+  next-cursor token. If a next page exists, the token is printed to stderr
+  as "next-cursor: <token>"; re-run with "--cursor <token>" to resume.
+
+  With --all the CLI iterates every page through the SDK's iter.Seq2
+  helper and streams vertices as they arrive — output is bounded only by
+  how many vertices match. Use --limit to tune the per-page request size.
+
+CURSOR
+  Cursors are opaque base64 tokens managed by the server; do not hand-craft
+  them. They are scoped to a single (prefix, server version) pair.
+
+OUTPUT
+  One JSON object per line on stdout (NDJSON), safe for piping into jq or
+  xargs. The cursor (if any, single-page mode only) goes to stderr.
+
+EXAMPLES
+  lantern vertex scan users/
+  lantern vertex scan users/ --limit 100 | jq -r .key
+  lantern vertex scan users/ --all > snapshot.ndjson
+  lantern vertex scan users/ --limit 50                    # then read stderr
+  lantern vertex scan users/ --limit 50 --cursor "<token>" # resume
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cli, err := dial()
+		if err != nil {
+			return err
+		}
+		defer func() { _ = cli.Close() }()
+
+		prefix := args[0]
+		out := cmd.OutOrStdout()
+		errw := cmd.ErrOrStderr()
+		enc := json.NewEncoder(out)
+
+		if vertexScanAll {
+			for batch, err := range cli.ScanVerticesAll(cmd.Context(), prefix, vertexScanLimit) {
+				if err != nil {
+					return err
+				}
+				for _, v := range batch {
+					if err := enc.Encode(v); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		}
+
+		opts := []client.ScanOption{}
+		if vertexScanLimit > 0 {
+			opts = append(opts, client.WithScanLimit(vertexScanLimit))
+		}
+		if vertexScanCursor != "" {
+			opts = append(opts, client.WithScanCursor([]byte(vertexScanCursor)))
+		}
+		vs, next, err := cli.ScanVertices(cmd.Context(), prefix, opts...)
+		if err != nil {
+			return err
+		}
+		for _, v := range vs {
+			if err := enc.Encode(v); err != nil {
+				return err
+			}
+		}
+		if len(next) > 0 {
+			_, _ = fmt.Fprintf(errw, "next-cursor: %s\n", string(next))
+		}
+		return nil
+	},
+}
+
+// -- vertex count -----------------------------------------------------------
+
+var vertexCountCmd = &cobra.Command{
+	Use:   "count <prefix>",
+	Short: "Count vertices whose key begins with <prefix>",
+	Long: `Return the number of keys in the prefix index for <prefix>.
+
+CAVEAT
+  This count is taken from the radix index and is NOT cross-checked
+  against per-vertex liveness. A vertex that has expired but not yet been
+  reaped by the GC loop is still counted here even though "vertex get"
+  and "vertex scan" will skip it. Use "vertex scan --all | wc -l" if you
+  need the strictly-live count.
+
+OUTPUT
+  Single decimal integer on stdout, no newline-padded JSON.
+
+EXAMPLES
+  lantern vertex count users/
+  lantern vertex count orders/2025/
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cli, err := dial()
+		if err != nil {
+			return err
+		}
+		defer func() { _ = cli.Close() }()
+		n, err := cli.CountVerticesByPrefix(cmd.Context(), args[0])
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%d\n", n)
+		return nil
+	},
+}
+
+// -- vertex delete-prefix ---------------------------------------------------
+
+var (
+	vertexDeletePrefixLimit  uint32
+	vertexDeletePrefixDryRun bool
+	vertexDeletePrefixYes    bool
+)
+
+// errPrefixDeleteUnconfirmed is returned by "vertex delete-prefix" when
+// neither --dry-run nor --yes was supplied. Surfaced separately so tests
+// can assert the safety gate without depending on the human-readable text.
+var errPrefixDeleteUnconfirmed = fmt.Errorf("refusing to delete by prefix without --dry-run or --yes")
+
+// prefixDeleteConfirmed reports whether the supplied flag combination is
+// enough to authorise a destructive prefix delete. Either --dry-run (which
+// mutates nothing) or --yes (explicit confirmation) is sufficient.
+func prefixDeleteConfirmed(dryRun, yes bool) bool { return dryRun || yes }
+
+var vertexDeletePrefixCmd = &cobra.Command{
+	Use:   "delete-prefix <prefix>",
+	Short: "Bulk-delete vertices whose key begins with <prefix> (DESTRUCTIVE)",
+	Long: `Remove every live vertex whose key starts with <prefix>, up to --limit
+matches per call. Edges incident to deleted vertices are NOT eagerly
+removed — they are reaped lazily with their own TTL.
+
+SAFETY GATE
+  Running without either --dry-run or --yes is REFUSED. The command will
+  instead print the current count from "vertex count" and the two
+  recommended next steps, then exit non-zero. This is intentional: bulk
+  delete is irreversible and trivially typo-able.
+
+  --dry-run  count what would be deleted; mutate nothing.
+  --yes      perform the delete.
+
+OUTPUT
+  Dry-run: "would delete <n>".
+  Real:    "deleted <n>".
+
+EXAMPLES
+  lantern vertex delete-prefix tmp/                         # refused, prints suggestion
+  lantern vertex delete-prefix tmp/ --dry-run
+  lantern vertex delete-prefix tmp/ --yes
+  lantern vertex delete-prefix tmp/ --yes --limit 500       # cap per-call
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		prefix := args[0]
+		if !prefixDeleteConfirmed(vertexDeletePrefixDryRun, vertexDeletePrefixYes) {
+			cli, err := dial()
+			if err != nil {
+				return err
+			}
+			defer func() { _ = cli.Close() }()
+			n, cerr := cli.CountVerticesByPrefix(cmd.Context(), prefix)
+			errw := cmd.ErrOrStderr()
+			if cerr == nil {
+				_, _ = fmt.Fprintf(errw, "prefix %q matches %d vertices\n", prefix, n)
+			}
+			_, _ = fmt.Fprintf(errw, "  preview: lantern vertex delete-prefix %q --dry-run\n", prefix)
+			_, _ = fmt.Fprintf(errw, "  execute: lantern vertex delete-prefix %q --yes\n", prefix)
+			return errPrefixDeleteUnconfirmed
+		}
+
+		cli, err := dial()
+		if err != nil {
+			return err
+		}
+		defer func() { _ = cli.Close() }()
+
+		opts := []client.DeleteByPrefixOption{}
+		if vertexDeletePrefixLimit > 0 {
+			opts = append(opts, client.WithDeleteByPrefixLimit(vertexDeletePrefixLimit))
+		}
+		if vertexDeletePrefixDryRun {
+			opts = append(opts, client.WithDryRun())
+		}
+		n, err := cli.DeleteVerticesByPrefix(cmd.Context(), prefix, opts...)
+		if err != nil {
+			return err
+		}
+		verb := "deleted"
+		if vertexDeletePrefixDryRun {
+			verb = "would delete"
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s %d\n", verb, n)
+		return nil
+	},
+}
+
+func init() {
+	vertexScanCmd.Flags().Uint32Var(&vertexScanLimit, "limit", 0, "per-page request size (0 = server default)")
+	vertexScanCmd.Flags().StringVar(&vertexScanCursor, "cursor", "", "opaque resume token printed by a previous --limit page")
+	vertexScanCmd.Flags().BoolVar(&vertexScanAll, "all", false, "iterate every page through the SDK helper")
+
+	vertexDeletePrefixCmd.Flags().Uint32Var(&vertexDeletePrefixLimit, "limit", 0, "max vertices to delete this call (0 = server default)")
+	vertexDeletePrefixCmd.Flags().BoolVar(&vertexDeletePrefixDryRun, "dry-run", false, "count what would be deleted; mutate nothing")
+	vertexDeletePrefixCmd.Flags().BoolVar(&vertexDeletePrefixYes, "yes", false, "confirm destructive delete")
+
+	vertexCmd.AddCommand(vertexScanCmd, vertexCountCmd, vertexDeletePrefixCmd)
+}

--- a/cli/cmd/prefix_test.go
+++ b/cli/cmd/prefix_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestPrefixDeleteConfirmed(t *testing.T) {
+	cases := []struct {
+		name          string
+		dryRun, yes   bool
+		wantConfirmed bool
+	}{
+		{"neither/refused", false, false, false},
+		{"dry-run/ok", true, false, true},
+		{"yes/ok", false, true, true},
+		{"both/ok", true, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := prefixDeleteConfirmed(tc.dryRun, tc.yes); got != tc.wantConfirmed {
+				t.Fatalf("prefixDeleteConfirmed(%v,%v) = %v, want %v",
+					tc.dryRun, tc.yes, got, tc.wantConfirmed)
+			}
+		})
+	}
+}
+
+func TestErrPrefixDeleteUnconfirmedMessage(t *testing.T) {
+	// Operators see this verbatim — keep the failure mode self-explanatory
+	// and make sure the gate names both escape hatches.
+	msg := errPrefixDeleteUnconfirmed.Error()
+	if !strings.Contains(msg, "--dry-run") || !strings.Contains(msg, "--yes") {
+		t.Fatalf("safety-gate error must mention --dry-run and --yes, got: %s", msg)
+	}
+}
+
+func TestVertexPrefixCommandsRegistered(t *testing.T) {
+	// Guard against init() drift: scan/count/delete-prefix must be reachable
+	// as subcommands of `vertex`.
+	want := map[string]bool{"scan": false, "count": false, "delete-prefix": false}
+	for _, c := range vertexCmd.Commands() {
+		if _, ok := want[c.Name()]; ok {
+			want[c.Name()] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("vertex subcommand %q not registered", name)
+		}
+	}
+}
+
+func TestVertexPrefixFlagDefaults(t *testing.T) {
+	// scan
+	if vertexScanLimit != 0 {
+		t.Errorf("scan --limit default = %d, want 0 (server-side default)", vertexScanLimit)
+	}
+	if vertexScanCursor != "" {
+		t.Errorf("scan --cursor default = %q, want empty", vertexScanCursor)
+	}
+	if vertexScanAll {
+		t.Errorf("scan --all default = true, want false")
+	}
+	// delete-prefix — critical: --yes and --dry-run must default to false
+	// so the safety gate is the default behaviour.
+	if vertexDeletePrefixDryRun {
+		t.Fatalf("delete-prefix --dry-run default = true, want false (safety gate must be the default)")
+	}
+	if vertexDeletePrefixYes {
+		t.Fatalf("delete-prefix --yes default = true, want false (safety gate must be the default)")
+	}
+	if vertexDeletePrefixLimit != 0 {
+		t.Errorf("delete-prefix --limit default = %d, want 0", vertexDeletePrefixLimit)
+	}
+}
+
+// sanity: errors.Is unwraps the package-level sentinel as itself.
+func TestErrPrefixDeleteUnconfirmedIs(t *testing.T) {
+	if !errors.Is(errPrefixDeleteUnconfirmed, errPrefixDeleteUnconfirmed) {
+		t.Fatal("errors.Is should reflexively match the sentinel")
+	}
+}


### PR DESCRIPTION
Closes #158. Phase 5 of #153.

Wires the Phase 4 SDK prefix-scan wrappers into the CLI.

## Subcommands
- `lantern vertex scan <prefix> [--limit N] [--cursor T] [--all]` — NDJSON of matching vertices on stdout. Single-page mode prints `next-cursor: <token>` to stderr when more data is available. `--all` streams every page through the SDK `iter.Seq2` helper.
- `lantern vertex count <prefix>` — radix count; docs the not-cross-checked-against-liveness caveat.
- `lantern vertex delete-prefix <prefix> [--limit N] [--dry-run|--yes]` — safety-gated. Bare invocation refuses, prints current count + suggested follow-ups (`--dry-run` / `--yes`), exits non-zero.

## Safety gate
Split into `prefixDeleteConfirmed(dryRun, yes bool) bool` so the policy is unit-testable without a server. Tests cover the truth table, sentinel error wording, subcommand registration, and that `--dry-run`/`--yes` both default to false.

## Cursor opacity
The `--cursor` flag echoes the byte token verbatim; the CLI never reformats it. Operators are not encouraged to hand-craft.

## Born-expired note
`vertex put` already defaults `--ttl` to 24h, so the trap documented in repo memory does not bite CLI users following the normal put → scan/count flow. No CLI-level mitigation needed.

## README
Added a `prefix scan` block to the CLI quickstart with all four recipes.

## Verification
- `gofmt -l . cli core pb sdks server tests` clean
- All 5 modules: vet + tests green (server, core, pb, sdks/go, root)
- 4 new tests in cli/cmd
- Local build of `./lantern vertex --help` shows scan/count/delete-prefix