### PR TITLE
feat(#159): edge prefix scan (ScanEdges) across core/server/sdk/cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ cat edges.ndjson | ./lantern bulk edges add - # streamed AddEdges
 ./lantern vertex delete-prefix tmp/ --dry-run        # preview count
 ./lantern vertex delete-prefix tmp/ --yes            # actually delete
 
+# edge scan (tail/head prefix; either may be empty)
+./lantern edge scan --tail-prefix user: --head-prefix post:  # one page
+./lantern edge scan --tail-prefix user: --all > edges.ndjson # stream every match
+
 # TLS / mTLS
 ./lantern --tls --tls-ca ./ca.pem -H lantern.example.com -p 443 vertex get alice
 

--- a/cli/cmd/edge_prefix.go
+++ b/cli/cmd/edge_prefix.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/spf13/cobra"
+)
+
+var (
+	edgeScanTailPrefix string
+	edgeScanHeadPrefix string
+	edgeScanLimit      uint32
+	edgeScanCursor     string
+	edgeScanAll        bool
+)
+
+var edgeScanCmd = &cobra.Command{
+	Use:   "scan",
+	Short: "Enumerate edges filtered by tail and/or head prefix",
+	Long: `Walk live edges in ascending (tail, head) order and emit each as one
+NDJSON line on stdout (same per-edge schema as "edge get").
+
+PREFIXES
+  --tail-prefix and --head-prefix each narrow the result set on their
+  endpoint. Either may be omitted to leave that dimension unconstrained;
+  omitting both scans every live edge.
+
+  v1 walks the vertex-side prefix index for the tail dimension and
+  applies --head-prefix as a post-filter, so a head-only scan is no
+  cheaper than a full scan. Combine the two prefixes when possible.
+
+PAGINATION
+  Without --all the server returns at most --limit edges and an opaque
+  next-cursor token. If a next page exists, the token is printed to
+  stderr as "next-cursor: <token>"; re-run with "--cursor <token>" to
+  resume.
+
+  With --all the CLI iterates every page through the SDK's iter.Seq2
+  helper and streams edges as they arrive.
+
+CURSOR
+  Edge cursors are opaque and intentionally wire-incompatible with
+  vertex-scan cursors. Do not interchange them.
+
+OUTPUT
+  One JSON object per line on stdout (NDJSON), safe for piping into jq.
+  The cursor (if any, single-page mode only) goes to stderr.
+
+EXAMPLES
+  lantern edge scan --tail-prefix user:
+  lantern edge scan --tail-prefix user: --head-prefix post: --limit 100
+  lantern edge scan --head-prefix post: --all > posts.ndjson
+`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cli, err := dial()
+		if err != nil {
+			return err
+		}
+		defer func() { _ = cli.Close() }()
+
+		out := cmd.OutOrStdout()
+		errw := cmd.ErrOrStderr()
+		enc := json.NewEncoder(out)
+
+		baseOpts := []client.EdgeScanOption{}
+		if edgeScanTailPrefix != "" {
+			baseOpts = append(baseOpts, client.WithEdgeScanTailPrefix(edgeScanTailPrefix))
+		}
+		if edgeScanHeadPrefix != "" {
+			baseOpts = append(baseOpts, client.WithEdgeScanHeadPrefix(edgeScanHeadPrefix))
+		}
+
+		if edgeScanAll {
+			for batch, err := range cli.ScanEdgesAll(cmd.Context(), edgeScanLimit, baseOpts...) {
+				if err != nil {
+					return err
+				}
+				for _, e := range batch {
+					if err := enc.Encode(e); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		}
+
+		opts := append([]client.EdgeScanOption{}, baseOpts...)
+		if edgeScanLimit > 0 {
+			opts = append(opts, client.WithEdgeScanLimit(edgeScanLimit))
+		}
+		if edgeScanCursor != "" {
+			opts = append(opts, client.WithEdgeScanCursor([]byte(edgeScanCursor)))
+		}
+		es, next, err := cli.ScanEdges(cmd.Context(), opts...)
+		if err != nil {
+			return err
+		}
+		for _, e := range es {
+			if err := enc.Encode(e); err != nil {
+				return err
+			}
+		}
+		if len(next) > 0 {
+			_, _ = fmt.Fprintf(errw, "next-cursor: %s\n", string(next))
+		}
+		return nil
+	},
+}
+
+func init() {
+	edgeScanCmd.Flags().StringVar(&edgeScanTailPrefix, "tail-prefix", "", "restrict to edges whose tail starts with this prefix")
+	edgeScanCmd.Flags().StringVar(&edgeScanHeadPrefix, "head-prefix", "", "restrict to edges whose head starts with this prefix")
+	edgeScanCmd.Flags().Uint32Var(&edgeScanLimit, "limit", 0, "per-page request size (0 = server default)")
+	edgeScanCmd.Flags().StringVar(&edgeScanCursor, "cursor", "", "opaque resume token printed by a previous --limit page")
+	edgeScanCmd.Flags().BoolVar(&edgeScanAll, "all", false, "iterate every page through the SDK helper")
+
+	edgeCmd.AddCommand(edgeScanCmd)
+}

--- a/core/cache/graph/edge_prefix.go
+++ b/core/cache/graph/edge_prefix.go
@@ -1,0 +1,100 @@
+package graph
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ScanEdgesByPrefix iterates every live edge whose tail projected key
+// starts with tailPrefix AND whose head projected key starts with
+// headPrefix, in ascending (tail, head) order, invoking fn for each one.
+// Either prefix may be empty to disable the corresponding filter (both
+// empty scans every edge).
+//
+// fn may return false to stop the walk early; iteration also stops when
+// ctx is cancelled. The boolean return is fn's last verdict — true means
+// the caller exhausted the matching set without asking to stop.
+//
+// Implementation: the walk reuses the vertex-side prefix index for the
+// tail dimension. Every edge endpoint is auto-created as a vertex on
+// insert (see AddEdgeWithExpiration / PutEdgeWithExpiration), so the
+// radix already covers all live tails. For each matching tail the heads
+// map is materialised and sorted into projected ascending order, then
+// post-filtered against headPrefix. Edges with zero weight (fully
+// decayed but not yet flushed) are skipped, matching point-read
+// semantics.
+//
+// Locking contract is identical to ScanByPrefix: the walk holds
+// c.mu.RLock for its duration. Callers MUST NOT invoke any GraphCache
+// write method from inside fn. Long-running fn bodies starve writers;
+// callers that need to do non-trivial per-edge work should accumulate
+// into a slice and process after ScanEdgesByPrefix returns.
+//
+// Returns false when the prefix index is not enabled or fn requested an
+// early stop; true on a clean exhaustion of the matching set.
+func (c *GraphCache[S, T]) ScanEdgesByPrefix(
+	ctx context.Context,
+	tailPrefix, headPrefix string,
+	fn func(tailProjected string, tail S, headProjected string, head S, weight float32, expiration time.Time) bool,
+) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.prefixIndex == nil {
+		return false
+	}
+	completed := true
+	c.prefixIndex.walkPrefix(tailPrefix, func(tailProj string) bool {
+		if err := ctx.Err(); err != nil {
+			completed = false
+			return false
+		}
+		tail, ok := c.resolveProjected(tailProj)
+		if !ok {
+			return true
+		}
+		heads, ok := c.edges.headsOf(tail)
+		if !ok || len(heads) == 0 {
+			return true
+		}
+		// Materialise + sort per tail. We keep the temporary slice's
+		// allocation bound to the fan-out of a single tail; in practice
+		// edge fan-outs are small relative to the global vertex count.
+		type headEntry struct {
+			proj string
+			head S
+			w    *weight
+		}
+		entries := make([]headEntry, 0, len(heads))
+		for headID, w := range heads {
+			head, ok := c.edges.resolveID(headID)
+			if !ok {
+				// dict drift: skip rather than crash, same as
+				// ScanByPrefix.
+				continue
+			}
+			proj := c.prefixExtract(head)
+			if headPrefix != "" && !strings.HasPrefix(proj, headPrefix) {
+				continue
+			}
+			entries = append(entries, headEntry{proj: proj, head: head, w: w})
+		}
+		if len(entries) == 0 {
+			return true
+		}
+		sort.Slice(entries, func(i, j int) bool { return entries[i].proj < entries[j].proj })
+		for _, e := range entries {
+			sum, latest, nonZero := e.w.snapshot()
+			if !nonZero {
+				continue
+			}
+			if !fn(tailProj, tail, e.proj, e.head, sum, latest) {
+				completed = false
+				return false
+			}
+		}
+		return true
+	})
+	return completed
+}

--- a/core/cache/graph/edge_prefix_test.go
+++ b/core/cache/graph/edge_prefix_test.go
@@ -1,0 +1,189 @@
+package graph
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+)
+
+// scanEdgesCollect drains ScanEdgesByPrefix into a sorted []string of
+// "tail->head" lines, ignoring weight/expiration. Sorting makes the
+// assertions invariant to per-tail map iteration order (the cache
+// guarantees per-tail head order and global tail order, but consumers
+// rarely care about the exact head subordering when only checking
+// membership).
+func scanEdgesCollect(t *testing.T, c *GraphCache[string, string], tailPrefix, headPrefix string) []string {
+	t.Helper()
+	var got []string
+	ok := c.ScanEdgesByPrefix(context.Background(), tailPrefix, headPrefix,
+		func(tProj string, tail string, hProj string, head string, w float32, _ time.Time) bool {
+			if tProj != tail {
+				t.Errorf("tailProj %q != tail %q (identity extractor)", tProj, tail)
+			}
+			if hProj != head {
+				t.Errorf("headProj %q != head %q (identity extractor)", hProj, head)
+			}
+			got = append(got, fmt.Sprintf("%s->%s=%g", tail, head, w))
+			return true
+		})
+	if !ok {
+		t.Fatalf("ScanEdgesByPrefix did not complete (prefix=%q/%q)", tailPrefix, headPrefix)
+	}
+	return got
+}
+
+func TestGraphCache_ScanEdgesByPrefix_Disabled(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	c.PutEdgeWithExpiration("a", "b", 1.0, time.Now().Add(time.Minute))
+	called := false
+	ok := c.ScanEdgesByPrefix(context.Background(), "", "",
+		func(string, string, string, string, float32, time.Time) bool {
+			called = true
+			return true
+		})
+	if ok || called {
+		t.Fatalf("disabled cache: ok=%v called=%v (want false,false)", ok, called)
+	}
+}
+
+func TestGraphCache_ScanEdgesByPrefix_TailHeadIntersection(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	c.EnablePrefixIndex(identityExtract)
+	exp := time.Now().Add(time.Minute)
+	edges := []struct{ t, h string }{
+		{"user:1", "post:10"},
+		{"user:1", "post:11"},
+		{"user:1", "session:a"},
+		{"user:2", "post:20"},
+		{"user:2", "session:b"},
+		{"admin:1", "post:99"},
+	}
+	for _, e := range edges {
+		c.PutEdgeWithExpiration(e.t, e.h, 1.0, exp)
+	}
+
+	// tail-only filter
+	got := scanEdgesCollect(t, c, "user:", "")
+	want := []string{
+		"user:1->post:10=1", "user:1->post:11=1", "user:1->session:a=1",
+		"user:2->post:20=1", "user:2->session:b=1",
+	}
+	sort.Strings(got)
+	sort.Strings(want)
+	if !equalSlices(got, want) {
+		t.Fatalf("tail-only: got %v want %v", got, want)
+	}
+
+	// head-only filter (no tail constraint)
+	got = scanEdgesCollect(t, c, "", "post:")
+	want = []string{
+		"admin:1->post:99=1",
+		"user:1->post:10=1", "user:1->post:11=1",
+		"user:2->post:20=1",
+	}
+	sort.Strings(got)
+	sort.Strings(want)
+	if !equalSlices(got, want) {
+		t.Fatalf("head-only: got %v want %v", got, want)
+	}
+
+	// intersection
+	got = scanEdgesCollect(t, c, "user:", "post:")
+	want = []string{
+		"user:1->post:10=1", "user:1->post:11=1",
+		"user:2->post:20=1",
+	}
+	sort.Strings(got)
+	sort.Strings(want)
+	if !equalSlices(got, want) {
+		t.Fatalf("intersection: got %v want %v", got, want)
+	}
+
+	// both empty -> all edges
+	got = scanEdgesCollect(t, c, "", "")
+	if len(got) != len(edges) {
+		t.Fatalf("both empty: got %d edges, want %d", len(got), len(edges))
+	}
+}
+
+func TestGraphCache_ScanEdgesByPrefix_TailOrdering(t *testing.T) {
+	// Per-tail head ordering must be ascending so that page-boundary
+	// cursors can resume deterministically.
+	c := NewGraphCache[string, string](time.Minute)
+	c.EnablePrefixIndex(identityExtract)
+	exp := time.Now().Add(time.Minute)
+	for _, h := range []string{"d", "b", "a", "c"} {
+		c.PutEdgeWithExpiration("t1", h, 1.0, exp)
+	}
+	var heads []string
+	ok := c.ScanEdgesByPrefix(context.Background(), "t1", "",
+		func(_ string, _ string, _ string, head string, _ float32, _ time.Time) bool {
+			heads = append(heads, head)
+			return true
+		})
+	if !ok {
+		t.Fatal("did not complete")
+	}
+	want := []string{"a", "b", "c", "d"}
+	if !equalSlices(heads, want) {
+		t.Fatalf("head order: got %v want %v", heads, want)
+	}
+}
+
+func TestGraphCache_ScanEdgesByPrefix_EarlyExitAndCancel(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	c.EnablePrefixIndex(identityExtract)
+	exp := time.Now().Add(time.Minute)
+	for i := 0; i < 5; i++ {
+		c.PutEdgeWithExpiration(fmt.Sprintf("t%d", i), "h", 1.0, exp)
+	}
+	visits := 0
+	ok := c.ScanEdgesByPrefix(context.Background(), "t", "",
+		func(string, string, string, string, float32, time.Time) bool {
+			visits++
+			return visits < 3
+		})
+	if ok {
+		t.Fatal("expected ok=false on early exit")
+	}
+	if visits != 3 {
+		t.Fatalf("visits = %d want 3", visits)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	called := false
+	ok = c.ScanEdgesByPrefix(ctx, "t", "",
+		func(string, string, string, string, float32, time.Time) bool {
+			called = true
+			return true
+		})
+	if ok || called {
+		t.Fatalf("cancelled: ok=%v called=%v (want false,false)", ok, called)
+	}
+}
+
+func TestGraphCache_ScanEdgesByPrefix_ExpiredEdgeSkipped(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	c.EnablePrefixIndex(identityExtract)
+	// Long-lived endpoints so vertex liveness survives; short-lived edge.
+	expVtx := time.Now().Add(time.Minute)
+	c.PutVertexWithExpiration("t", "v", expVtx)
+	c.PutVertexWithExpiration("h", "v", expVtx)
+	c.PutEdgeWithExpiration("t", "h", 1.0, time.Now().Add(-time.Second))
+
+	var got []string
+	ok := c.ScanEdgesByPrefix(context.Background(), "", "",
+		func(_ string, _ string, _ string, head string, _ float32, _ time.Time) bool {
+			got = append(got, head)
+			return true
+		})
+	if !ok {
+		t.Fatal("did not complete")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expired edge surfaced: %v", got)
+	}
+}

--- a/pb/graph/v1/graph.pb.go
+++ b/pb/graph/v1/graph.pb.go
@@ -1802,6 +1802,144 @@ func (x *EdgeKey) GetHead() string {
 	return ""
 }
 
+// ScanEdgesRequest streams edges whose tail key starts with `tail_prefix`
+// AND whose head key starts with `head_prefix`, in ascending (tail, head)
+// order. Either prefix may be empty to disable the corresponding filter
+// (both empty scans every edge). `limit` caps the number returned in one
+// call; the server enforces a default when `limit == 0` and a hard maximum
+// (see ScanConfig on the server). `cursor` MUST be treated as opaque bytes
+// by clients — pass back exactly what the previous response returned in
+// `next_cursor`. An empty `cursor` starts from the beginning.
+//
+// Implementation note: v1 walks the tail-side prefix index and applies
+// `head_prefix` as a post-filter; for highly selective `head_prefix`
+// queries the server may visit many tails to fill one page. Latency is
+// reported in the standard scan histogram so operators can spot
+// pathological filters.
+type ScanEdgesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TailPrefix    string                 `protobuf:"bytes,1,opt,name=tail_prefix,json=tailPrefix,proto3" json:"tail_prefix,omitempty"`
+	HeadPrefix    string                 `protobuf:"bytes,2,opt,name=head_prefix,json=headPrefix,proto3" json:"head_prefix,omitempty"`
+	Limit         uint32                 `protobuf:"varint,3,opt,name=limit,proto3" json:"limit,omitempty"`
+	Cursor        []byte                 `protobuf:"bytes,4,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ScanEdgesRequest) Reset() {
+	*x = ScanEdgesRequest{}
+	mi := &file_graph_v1_graph_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScanEdgesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScanEdgesRequest) ProtoMessage() {}
+
+func (x *ScanEdgesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScanEdgesRequest.ProtoReflect.Descriptor instead.
+func (*ScanEdgesRequest) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *ScanEdgesRequest) GetTailPrefix() string {
+	if x != nil {
+		return x.TailPrefix
+	}
+	return ""
+}
+
+func (x *ScanEdgesRequest) GetHeadPrefix() string {
+	if x != nil {
+		return x.HeadPrefix
+	}
+	return ""
+}
+
+func (x *ScanEdgesRequest) GetLimit() uint32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+func (x *ScanEdgesRequest) GetCursor() []byte {
+	if x != nil {
+		return x.Cursor
+	}
+	return nil
+}
+
+type ScanEdgesResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// edges returned in ascending (tail, head) order. May be shorter than
+	// `limit` when the underlying range is exhausted.
+	Edges []*Edge `protobuf:"bytes,1,rep,name=edges,proto3" json:"edges,omitempty"`
+	// next_cursor is non-empty when more results are available. An empty
+	// value signals end of stream.
+	NextCursor    []byte `protobuf:"bytes,2,opt,name=next_cursor,json=nextCursor,proto3" json:"next_cursor,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ScanEdgesResponse) Reset() {
+	*x = ScanEdgesResponse{}
+	mi := &file_graph_v1_graph_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScanEdgesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScanEdgesResponse) ProtoMessage() {}
+
+func (x *ScanEdgesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScanEdgesResponse.ProtoReflect.Descriptor instead.
+func (*ScanEdgesResponse) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *ScanEdgesResponse) GetEdges() []*Edge {
+	if x != nil {
+		return x.Edges
+	}
+	return nil
+}
+
+func (x *ScanEdgesResponse) GetNextCursor() []byte {
+	if x != nil {
+		return x.NextCursor
+	}
+	return nil
+}
+
 // DeleteEdgesRequest removes several edges in one round trip. Subject to the
 // MaxBatchSize / MaxKeyLen guard rails.
 type DeleteEdgesRequest struct {
@@ -1813,7 +1951,7 @@ type DeleteEdgesRequest struct {
 
 func (x *DeleteEdgesRequest) Reset() {
 	*x = DeleteEdgesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[30]
+	mi := &file_graph_v1_graph_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1825,7 +1963,7 @@ func (x *DeleteEdgesRequest) String() string {
 func (*DeleteEdgesRequest) ProtoMessage() {}
 
 func (x *DeleteEdgesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[30]
+	mi := &file_graph_v1_graph_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1838,7 +1976,7 @@ func (x *DeleteEdgesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEdgesRequest.ProtoReflect.Descriptor instead.
 func (*DeleteEdgesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{30}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *DeleteEdgesRequest) GetEdges() []*EdgeKey {
@@ -1858,7 +1996,7 @@ type DeleteEdgesResponse struct {
 
 func (x *DeleteEdgesResponse) Reset() {
 	*x = DeleteEdgesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[31]
+	mi := &file_graph_v1_graph_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1870,7 +2008,7 @@ func (x *DeleteEdgesResponse) String() string {
 func (*DeleteEdgesResponse) ProtoMessage() {}
 
 func (x *DeleteEdgesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[31]
+	mi := &file_graph_v1_graph_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1883,7 +2021,7 @@ func (x *DeleteEdgesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEdgesResponse.ProtoReflect.Descriptor instead.
 func (*DeleteEdgesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{31}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *DeleteEdgesResponse) GetDeleted() int32 {
@@ -1905,7 +2043,7 @@ type AddEdgeRequest struct {
 
 func (x *AddEdgeRequest) Reset() {
 	*x = AddEdgeRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[32]
+	mi := &file_graph_v1_graph_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1917,7 +2055,7 @@ func (x *AddEdgeRequest) String() string {
 func (*AddEdgeRequest) ProtoMessage() {}
 
 func (x *AddEdgeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[32]
+	mi := &file_graph_v1_graph_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1930,7 +2068,7 @@ func (x *AddEdgeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddEdgeRequest.ProtoReflect.Descriptor instead.
 func (*AddEdgeRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{32}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *AddEdgeRequest) GetEdge() *Edge {
@@ -1948,7 +2086,7 @@ type AddEdgeResponse struct {
 
 func (x *AddEdgeResponse) Reset() {
 	*x = AddEdgeResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[33]
+	mi := &file_graph_v1_graph_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1960,7 +2098,7 @@ func (x *AddEdgeResponse) String() string {
 func (*AddEdgeResponse) ProtoMessage() {}
 
 func (x *AddEdgeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[33]
+	mi := &file_graph_v1_graph_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1973,7 +2111,7 @@ func (x *AddEdgeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddEdgeResponse.ProtoReflect.Descriptor instead.
 func (*AddEdgeResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{33}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{35}
 }
 
 // AddEdgesRequest accumulates weight onto each (tail, head) pair: repeated
@@ -1988,7 +2126,7 @@ type AddEdgesRequest struct {
 
 func (x *AddEdgesRequest) Reset() {
 	*x = AddEdgesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[34]
+	mi := &file_graph_v1_graph_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2000,7 +2138,7 @@ func (x *AddEdgesRequest) String() string {
 func (*AddEdgesRequest) ProtoMessage() {}
 
 func (x *AddEdgesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[34]
+	mi := &file_graph_v1_graph_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2013,7 +2151,7 @@ func (x *AddEdgesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddEdgesRequest.ProtoReflect.Descriptor instead.
 func (*AddEdgesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{34}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *AddEdgesRequest) GetEdges() []*Edge {
@@ -2033,7 +2171,7 @@ type AddEdgesResponse struct {
 
 func (x *AddEdgesResponse) Reset() {
 	*x = AddEdgesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[35]
+	mi := &file_graph_v1_graph_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2045,7 +2183,7 @@ func (x *AddEdgesResponse) String() string {
 func (*AddEdgesResponse) ProtoMessage() {}
 
 func (x *AddEdgesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[35]
+	mi := &file_graph_v1_graph_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2058,7 +2196,7 @@ func (x *AddEdgesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddEdgesResponse.ProtoReflect.Descriptor instead.
 func (*AddEdgesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{35}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *AddEdgesResponse) GetWritten() int32 {
@@ -2080,7 +2218,7 @@ type PutEdgeRequest struct {
 
 func (x *PutEdgeRequest) Reset() {
 	*x = PutEdgeRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[36]
+	mi := &file_graph_v1_graph_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2092,7 +2230,7 @@ func (x *PutEdgeRequest) String() string {
 func (*PutEdgeRequest) ProtoMessage() {}
 
 func (x *PutEdgeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[36]
+	mi := &file_graph_v1_graph_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2105,7 +2243,7 @@ func (x *PutEdgeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutEdgeRequest.ProtoReflect.Descriptor instead.
 func (*PutEdgeRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{36}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *PutEdgeRequest) GetEdge() *Edge {
@@ -2123,7 +2261,7 @@ type PutEdgeResponse struct {
 
 func (x *PutEdgeResponse) Reset() {
 	*x = PutEdgeResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[37]
+	mi := &file_graph_v1_graph_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2135,7 +2273,7 @@ func (x *PutEdgeResponse) String() string {
 func (*PutEdgeResponse) ProtoMessage() {}
 
 func (x *PutEdgeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[37]
+	mi := &file_graph_v1_graph_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2148,7 +2286,7 @@ func (x *PutEdgeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutEdgeResponse.ProtoReflect.Descriptor instead.
 func (*PutEdgeResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{37}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{39}
 }
 
 // PutEdgesRequest overwrites each (tail, head) pair, replacing any existing
@@ -2162,7 +2300,7 @@ type PutEdgesRequest struct {
 
 func (x *PutEdgesRequest) Reset() {
 	*x = PutEdgesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[38]
+	mi := &file_graph_v1_graph_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2174,7 +2312,7 @@ func (x *PutEdgesRequest) String() string {
 func (*PutEdgesRequest) ProtoMessage() {}
 
 func (x *PutEdgesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[38]
+	mi := &file_graph_v1_graph_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2187,7 +2325,7 @@ func (x *PutEdgesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutEdgesRequest.ProtoReflect.Descriptor instead.
 func (*PutEdgesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{38}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *PutEdgesRequest) GetEdges() []*Edge {
@@ -2207,7 +2345,7 @@ type PutEdgesResponse struct {
 
 func (x *PutEdgesResponse) Reset() {
 	*x = PutEdgesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[39]
+	mi := &file_graph_v1_graph_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2219,7 +2357,7 @@ func (x *PutEdgesResponse) String() string {
 func (*PutEdgesResponse) ProtoMessage() {}
 
 func (x *PutEdgesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[39]
+	mi := &file_graph_v1_graph_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2232,7 +2370,7 @@ func (x *PutEdgesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutEdgesResponse.ProtoReflect.Descriptor instead.
 func (*PutEdgesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{39}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *PutEdgesResponse) GetWritten() int32 {
@@ -2343,7 +2481,18 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\aexisted\x18\x01 \x01(\bR\aexisted\"1\n" +
 	"\aEdgeKey\x12\x12\n" +
 	"\x04tail\x18\x01 \x01(\tR\x04tail\x12\x12\n" +
-	"\x04head\x18\x02 \x01(\tR\x04head\"=\n" +
+	"\x04head\x18\x02 \x01(\tR\x04head\"\x82\x01\n" +
+	"\x10ScanEdgesRequest\x12\x1f\n" +
+	"\vtail_prefix\x18\x01 \x01(\tR\n" +
+	"tailPrefix\x12\x1f\n" +
+	"\vhead_prefix\x18\x02 \x01(\tR\n" +
+	"headPrefix\x12\x14\n" +
+	"\x05limit\x18\x03 \x01(\rR\x05limit\x12\x16\n" +
+	"\x06cursor\x18\x04 \x01(\fR\x06cursor\"Z\n" +
+	"\x11ScanEdgesResponse\x12$\n" +
+	"\x05edges\x18\x01 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\x12\x1f\n" +
+	"\vnext_cursor\x18\x02 \x01(\fR\n" +
+	"nextCursor\"=\n" +
 	"\x12DeleteEdgesRequest\x12'\n" +
 	"\x05edges\x18\x01 \x03(\v2\x11.graph.v1.EdgeKeyR\x05edges\"/\n" +
 	"\x13DeleteEdgesResponse\x12\x18\n" +
@@ -2367,7 +2516,7 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\"OPTIMIZATION_MINIMUM_SPANNING_TREE\x10\x01\x12&\n" +
 	"\"OPTIMIZATION_MAXIMUM_SPANNING_TREE\x10\x02\x12#\n" +
 	"\x1fOPTIMIZATION_SHORTEST_PATH_TREE\x10\x03\x12+\n" +
-	"'OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE\x10\x042\xb4\x0f\n" +
+	"'OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE\x10\x042\x95\x10\n" +
 	"\x0eLanternService\x12f\n" +
 	"\n" +
 	"Illuminate\x12\x1b.graph.v1.IlluminateRequest\x1a\x1c.graph.v1.IlluminateResponse\"\x1d\x82\xd3\xe4\x93\x02\x17\x12\x15/v1/illuminate/{seed}\x12`\n" +
@@ -2388,7 +2537,8 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\bPutEdges\x12\x19.graph.v1.PutEdgesRequest\x1a\x1a.graph.v1.PutEdgesResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\x1a\r/v1/edges/put\x12h\n" +
 	"\n" +
 	"DeleteEdge\x12\x1b.graph.v1.DeleteEdgeRequest\x1a\x1c.graph.v1.DeleteEdgeResponse\"\x1f\x82\xd3\xe4\x93\x02\x19*\x17/v1/edges/{tail}/{head}\x12g\n" +
-	"\vDeleteEdges\x12\x1c.graph.v1.DeleteEdgesRequest\x1a\x1d.graph.v1.DeleteEdgesResponse\"\x1b\x82\xd3\xe4\x93\x02\x15:\x01*\"\x10/v1/edges/deleteB\x90\x01\n" +
+	"\vDeleteEdges\x12\x1c.graph.v1.DeleteEdgesRequest\x1a\x1d.graph.v1.DeleteEdgesResponse\"\x1b\x82\xd3\xe4\x93\x02\x15:\x01*\"\x10/v1/edges/delete\x12_\n" +
+	"\tScanEdges\x12\x1a.graph.v1.ScanEdgesRequest\x1a\x1b.graph.v1.ScanEdgesResponse\"\x19\x82\xd3\xe4\x93\x02\x13:\x01*\"\x0e/v1/edges/scanB\x90\x01\n" +
 	"\fcom.graph.v1B\n" +
 	"GraphProtoP\x01Z3github.com/anaregdesign/lantern/pb/graph/v1;graphv1\xa2\x02\x03GXX\xaa\x02\bGraph.V1\xca\x02\bGraph\\V1\xe2\x02\x14Graph\\V1\\GPBMetadata\xea\x02\tGraph::V1b\x06proto3"
 
@@ -2405,7 +2555,7 @@ func file_graph_v1_graph_proto_rawDescGZIP() []byte {
 }
 
 var file_graph_v1_graph_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_graph_v1_graph_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
+var file_graph_v1_graph_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
 var file_graph_v1_graph_proto_goTypes = []any{
 	(Optimization)(0),                      // 0: graph.v1.Optimization
 	(*Vertex)(nil),                         // 1: graph.v1.Vertex
@@ -2438,24 +2588,26 @@ var file_graph_v1_graph_proto_goTypes = []any{
 	(*DeleteEdgeRequest)(nil),              // 28: graph.v1.DeleteEdgeRequest
 	(*DeleteEdgeResponse)(nil),             // 29: graph.v1.DeleteEdgeResponse
 	(*EdgeKey)(nil),                        // 30: graph.v1.EdgeKey
-	(*DeleteEdgesRequest)(nil),             // 31: graph.v1.DeleteEdgesRequest
-	(*DeleteEdgesResponse)(nil),            // 32: graph.v1.DeleteEdgesResponse
-	(*AddEdgeRequest)(nil),                 // 33: graph.v1.AddEdgeRequest
-	(*AddEdgeResponse)(nil),                // 34: graph.v1.AddEdgeResponse
-	(*AddEdgesRequest)(nil),                // 35: graph.v1.AddEdgesRequest
-	(*AddEdgesResponse)(nil),               // 36: graph.v1.AddEdgesResponse
-	(*PutEdgeRequest)(nil),                 // 37: graph.v1.PutEdgeRequest
-	(*PutEdgeResponse)(nil),                // 38: graph.v1.PutEdgeResponse
-	(*PutEdgesRequest)(nil),                // 39: graph.v1.PutEdgesRequest
-	(*PutEdgesResponse)(nil),               // 40: graph.v1.PutEdgesResponse
-	(*timestamppb.Timestamp)(nil),          // 41: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),            // 42: google.protobuf.Duration
+	(*ScanEdgesRequest)(nil),               // 31: graph.v1.ScanEdgesRequest
+	(*ScanEdgesResponse)(nil),              // 32: graph.v1.ScanEdgesResponse
+	(*DeleteEdgesRequest)(nil),             // 33: graph.v1.DeleteEdgesRequest
+	(*DeleteEdgesResponse)(nil),            // 34: graph.v1.DeleteEdgesResponse
+	(*AddEdgeRequest)(nil),                 // 35: graph.v1.AddEdgeRequest
+	(*AddEdgeResponse)(nil),                // 36: graph.v1.AddEdgeResponse
+	(*AddEdgesRequest)(nil),                // 37: graph.v1.AddEdgesRequest
+	(*AddEdgesResponse)(nil),               // 38: graph.v1.AddEdgesResponse
+	(*PutEdgeRequest)(nil),                 // 39: graph.v1.PutEdgeRequest
+	(*PutEdgeResponse)(nil),                // 40: graph.v1.PutEdgeResponse
+	(*PutEdgesRequest)(nil),                // 41: graph.v1.PutEdgesRequest
+	(*PutEdgesResponse)(nil),               // 42: graph.v1.PutEdgesResponse
+	(*timestamppb.Timestamp)(nil),          // 43: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),            // 44: google.protobuf.Duration
 }
 var file_graph_v1_graph_proto_depIdxs = []int32{
-	41, // 0: graph.v1.Vertex.expiration:type_name -> google.protobuf.Timestamp
-	41, // 1: graph.v1.Vertex.timestamp:type_name -> google.protobuf.Timestamp
-	42, // 2: graph.v1.Vertex.duration:type_name -> google.protobuf.Duration
-	41, // 3: graph.v1.Edge.expiration:type_name -> google.protobuf.Timestamp
+	43, // 0: graph.v1.Vertex.expiration:type_name -> google.protobuf.Timestamp
+	43, // 1: graph.v1.Vertex.timestamp:type_name -> google.protobuf.Timestamp
+	44, // 2: graph.v1.Vertex.duration:type_name -> google.protobuf.Duration
+	43, // 3: graph.v1.Edge.expiration:type_name -> google.protobuf.Timestamp
 	1,  // 4: graph.v1.Graph.vertices:type_name -> graph.v1.Vertex
 	2,  // 5: graph.v1.Graph.edges:type_name -> graph.v1.Edge
 	0,  // 6: graph.v1.IlluminateRequest.optimization:type_name -> graph.v1.Optimization
@@ -2469,52 +2621,55 @@ var file_graph_v1_graph_proto_depIdxs = []int32{
 	30, // 14: graph.v1.GetEdgesRequest.edges:type_name -> graph.v1.EdgeKey
 	2,  // 15: graph.v1.GetEdgesResponse.edges:type_name -> graph.v1.Edge
 	30, // 16: graph.v1.GetEdgesResponse.missing:type_name -> graph.v1.EdgeKey
-	30, // 17: graph.v1.DeleteEdgesRequest.edges:type_name -> graph.v1.EdgeKey
-	2,  // 18: graph.v1.AddEdgeRequest.edge:type_name -> graph.v1.Edge
-	2,  // 19: graph.v1.AddEdgesRequest.edges:type_name -> graph.v1.Edge
-	2,  // 20: graph.v1.PutEdgeRequest.edge:type_name -> graph.v1.Edge
-	2,  // 21: graph.v1.PutEdgesRequest.edges:type_name -> graph.v1.Edge
-	4,  // 22: graph.v1.LanternService.Illuminate:input_type -> graph.v1.IlluminateRequest
-	6,  // 23: graph.v1.LanternService.GetVertex:input_type -> graph.v1.GetVertexRequest
-	8,  // 24: graph.v1.LanternService.GetVertices:input_type -> graph.v1.GetVerticesRequest
-	10, // 25: graph.v1.LanternService.PutVertex:input_type -> graph.v1.PutVertexRequest
-	12, // 26: graph.v1.LanternService.PutVertices:input_type -> graph.v1.PutVerticesRequest
-	14, // 27: graph.v1.LanternService.DeleteVertex:input_type -> graph.v1.DeleteVertexRequest
-	16, // 28: graph.v1.LanternService.DeleteVertices:input_type -> graph.v1.DeleteVerticesRequest
-	18, // 29: graph.v1.LanternService.ScanVertices:input_type -> graph.v1.ScanVerticesRequest
-	20, // 30: graph.v1.LanternService.CountVerticesByPrefix:input_type -> graph.v1.CountVerticesByPrefixRequest
-	22, // 31: graph.v1.LanternService.DeleteVerticesByPrefix:input_type -> graph.v1.DeleteVerticesByPrefixRequest
-	24, // 32: graph.v1.LanternService.GetEdge:input_type -> graph.v1.GetEdgeRequest
-	26, // 33: graph.v1.LanternService.GetEdges:input_type -> graph.v1.GetEdgesRequest
-	33, // 34: graph.v1.LanternService.AddEdge:input_type -> graph.v1.AddEdgeRequest
-	35, // 35: graph.v1.LanternService.AddEdges:input_type -> graph.v1.AddEdgesRequest
-	37, // 36: graph.v1.LanternService.PutEdge:input_type -> graph.v1.PutEdgeRequest
-	39, // 37: graph.v1.LanternService.PutEdges:input_type -> graph.v1.PutEdgesRequest
-	28, // 38: graph.v1.LanternService.DeleteEdge:input_type -> graph.v1.DeleteEdgeRequest
-	31, // 39: graph.v1.LanternService.DeleteEdges:input_type -> graph.v1.DeleteEdgesRequest
-	5,  // 40: graph.v1.LanternService.Illuminate:output_type -> graph.v1.IlluminateResponse
-	7,  // 41: graph.v1.LanternService.GetVertex:output_type -> graph.v1.GetVertexResponse
-	9,  // 42: graph.v1.LanternService.GetVertices:output_type -> graph.v1.GetVerticesResponse
-	11, // 43: graph.v1.LanternService.PutVertex:output_type -> graph.v1.PutVertexResponse
-	13, // 44: graph.v1.LanternService.PutVertices:output_type -> graph.v1.PutVerticesResponse
-	15, // 45: graph.v1.LanternService.DeleteVertex:output_type -> graph.v1.DeleteVertexResponse
-	17, // 46: graph.v1.LanternService.DeleteVertices:output_type -> graph.v1.DeleteVerticesResponse
-	19, // 47: graph.v1.LanternService.ScanVertices:output_type -> graph.v1.ScanVerticesResponse
-	21, // 48: graph.v1.LanternService.CountVerticesByPrefix:output_type -> graph.v1.CountVerticesByPrefixResponse
-	23, // 49: graph.v1.LanternService.DeleteVerticesByPrefix:output_type -> graph.v1.DeleteVerticesByPrefixResponse
-	25, // 50: graph.v1.LanternService.GetEdge:output_type -> graph.v1.GetEdgeResponse
-	27, // 51: graph.v1.LanternService.GetEdges:output_type -> graph.v1.GetEdgesResponse
-	34, // 52: graph.v1.LanternService.AddEdge:output_type -> graph.v1.AddEdgeResponse
-	36, // 53: graph.v1.LanternService.AddEdges:output_type -> graph.v1.AddEdgesResponse
-	38, // 54: graph.v1.LanternService.PutEdge:output_type -> graph.v1.PutEdgeResponse
-	40, // 55: graph.v1.LanternService.PutEdges:output_type -> graph.v1.PutEdgesResponse
-	29, // 56: graph.v1.LanternService.DeleteEdge:output_type -> graph.v1.DeleteEdgeResponse
-	32, // 57: graph.v1.LanternService.DeleteEdges:output_type -> graph.v1.DeleteEdgesResponse
-	40, // [40:58] is the sub-list for method output_type
-	22, // [22:40] is the sub-list for method input_type
-	22, // [22:22] is the sub-list for extension type_name
-	22, // [22:22] is the sub-list for extension extendee
-	0,  // [0:22] is the sub-list for field type_name
+	2,  // 17: graph.v1.ScanEdgesResponse.edges:type_name -> graph.v1.Edge
+	30, // 18: graph.v1.DeleteEdgesRequest.edges:type_name -> graph.v1.EdgeKey
+	2,  // 19: graph.v1.AddEdgeRequest.edge:type_name -> graph.v1.Edge
+	2,  // 20: graph.v1.AddEdgesRequest.edges:type_name -> graph.v1.Edge
+	2,  // 21: graph.v1.PutEdgeRequest.edge:type_name -> graph.v1.Edge
+	2,  // 22: graph.v1.PutEdgesRequest.edges:type_name -> graph.v1.Edge
+	4,  // 23: graph.v1.LanternService.Illuminate:input_type -> graph.v1.IlluminateRequest
+	6,  // 24: graph.v1.LanternService.GetVertex:input_type -> graph.v1.GetVertexRequest
+	8,  // 25: graph.v1.LanternService.GetVertices:input_type -> graph.v1.GetVerticesRequest
+	10, // 26: graph.v1.LanternService.PutVertex:input_type -> graph.v1.PutVertexRequest
+	12, // 27: graph.v1.LanternService.PutVertices:input_type -> graph.v1.PutVerticesRequest
+	14, // 28: graph.v1.LanternService.DeleteVertex:input_type -> graph.v1.DeleteVertexRequest
+	16, // 29: graph.v1.LanternService.DeleteVertices:input_type -> graph.v1.DeleteVerticesRequest
+	18, // 30: graph.v1.LanternService.ScanVertices:input_type -> graph.v1.ScanVerticesRequest
+	20, // 31: graph.v1.LanternService.CountVerticesByPrefix:input_type -> graph.v1.CountVerticesByPrefixRequest
+	22, // 32: graph.v1.LanternService.DeleteVerticesByPrefix:input_type -> graph.v1.DeleteVerticesByPrefixRequest
+	24, // 33: graph.v1.LanternService.GetEdge:input_type -> graph.v1.GetEdgeRequest
+	26, // 34: graph.v1.LanternService.GetEdges:input_type -> graph.v1.GetEdgesRequest
+	35, // 35: graph.v1.LanternService.AddEdge:input_type -> graph.v1.AddEdgeRequest
+	37, // 36: graph.v1.LanternService.AddEdges:input_type -> graph.v1.AddEdgesRequest
+	39, // 37: graph.v1.LanternService.PutEdge:input_type -> graph.v1.PutEdgeRequest
+	41, // 38: graph.v1.LanternService.PutEdges:input_type -> graph.v1.PutEdgesRequest
+	28, // 39: graph.v1.LanternService.DeleteEdge:input_type -> graph.v1.DeleteEdgeRequest
+	33, // 40: graph.v1.LanternService.DeleteEdges:input_type -> graph.v1.DeleteEdgesRequest
+	31, // 41: graph.v1.LanternService.ScanEdges:input_type -> graph.v1.ScanEdgesRequest
+	5,  // 42: graph.v1.LanternService.Illuminate:output_type -> graph.v1.IlluminateResponse
+	7,  // 43: graph.v1.LanternService.GetVertex:output_type -> graph.v1.GetVertexResponse
+	9,  // 44: graph.v1.LanternService.GetVertices:output_type -> graph.v1.GetVerticesResponse
+	11, // 45: graph.v1.LanternService.PutVertex:output_type -> graph.v1.PutVertexResponse
+	13, // 46: graph.v1.LanternService.PutVertices:output_type -> graph.v1.PutVerticesResponse
+	15, // 47: graph.v1.LanternService.DeleteVertex:output_type -> graph.v1.DeleteVertexResponse
+	17, // 48: graph.v1.LanternService.DeleteVertices:output_type -> graph.v1.DeleteVerticesResponse
+	19, // 49: graph.v1.LanternService.ScanVertices:output_type -> graph.v1.ScanVerticesResponse
+	21, // 50: graph.v1.LanternService.CountVerticesByPrefix:output_type -> graph.v1.CountVerticesByPrefixResponse
+	23, // 51: graph.v1.LanternService.DeleteVerticesByPrefix:output_type -> graph.v1.DeleteVerticesByPrefixResponse
+	25, // 52: graph.v1.LanternService.GetEdge:output_type -> graph.v1.GetEdgeResponse
+	27, // 53: graph.v1.LanternService.GetEdges:output_type -> graph.v1.GetEdgesResponse
+	36, // 54: graph.v1.LanternService.AddEdge:output_type -> graph.v1.AddEdgeResponse
+	38, // 55: graph.v1.LanternService.AddEdges:output_type -> graph.v1.AddEdgesResponse
+	40, // 56: graph.v1.LanternService.PutEdge:output_type -> graph.v1.PutEdgeResponse
+	42, // 57: graph.v1.LanternService.PutEdges:output_type -> graph.v1.PutEdgesResponse
+	29, // 58: graph.v1.LanternService.DeleteEdge:output_type -> graph.v1.DeleteEdgeResponse
+	34, // 59: graph.v1.LanternService.DeleteEdges:output_type -> graph.v1.DeleteEdgesResponse
+	32, // 60: graph.v1.LanternService.ScanEdges:output_type -> graph.v1.ScanEdgesResponse
+	42, // [42:61] is the sub-list for method output_type
+	23, // [23:42] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_graph_v1_graph_proto_init() }
@@ -2542,7 +2697,7 @@ func file_graph_v1_graph_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_graph_v1_graph_proto_rawDesc), len(file_graph_v1_graph_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   40,
+			NumMessages:   42,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pb/graph/v1/graph.pb.gw.go
+++ b/pb/graph/v1/graph.pb.gw.go
@@ -725,6 +725,33 @@ func local_request_LanternService_DeleteEdges_0(ctx context.Context, marshaler r
 	return msg, metadata, err
 }
 
+func request_LanternService_ScanEdges_0(ctx context.Context, marshaler runtime.Marshaler, client LanternServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ScanEdgesRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ScanEdges(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_LanternService_ScanEdges_0(ctx context.Context, marshaler runtime.Marshaler, server LanternServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ScanEdgesRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ScanEdges(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterLanternServiceHandlerServer registers the http handlers for service LanternService to "mux".
 // UnaryRPC     :call LanternServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -1091,6 +1118,26 @@ func RegisterLanternServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 		}
 		forward_LanternService_DeleteEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_LanternService_ScanEdges_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/graph.v1.LanternService/ScanEdges", runtime.WithHTTPPathPattern("/v1/edges/scan"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_LanternService_ScanEdges_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LanternService_ScanEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 
 	return nil
 }
@@ -1437,6 +1484,23 @@ func RegisterLanternServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 		}
 		forward_LanternService_DeleteEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_LanternService_ScanEdges_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/graph.v1.LanternService/ScanEdges", runtime.WithHTTPPathPattern("/v1/edges/scan"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_LanternService_ScanEdges_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LanternService_ScanEdges_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -1459,6 +1523,7 @@ var (
 	pattern_LanternService_PutEdges_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "put"}, ""))
 	pattern_LanternService_DeleteEdge_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "edges", "tail", "head"}, ""))
 	pattern_LanternService_DeleteEdges_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "delete"}, ""))
+	pattern_LanternService_ScanEdges_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "edges", "scan"}, ""))
 )
 
 var (
@@ -1480,4 +1545,5 @@ var (
 	forward_LanternService_PutEdges_0               = runtime.ForwardResponseMessage
 	forward_LanternService_DeleteEdge_0             = runtime.ForwardResponseMessage
 	forward_LanternService_DeleteEdges_0            = runtime.ForwardResponseMessage
+	forward_LanternService_ScanEdges_0              = runtime.ForwardResponseMessage
 )

--- a/pb/graph/v1/graph_grpc.pb.go
+++ b/pb/graph/v1/graph_grpc.pb.go
@@ -37,6 +37,7 @@ const (
 	LanternService_PutEdges_FullMethodName               = "/graph.v1.LanternService/PutEdges"
 	LanternService_DeleteEdge_FullMethodName             = "/graph.v1.LanternService/DeleteEdge"
 	LanternService_DeleteEdges_FullMethodName            = "/graph.v1.LanternService/DeleteEdges"
+	LanternService_ScanEdges_FullMethodName              = "/graph.v1.LanternService/ScanEdges"
 )
 
 // LanternServiceClient is the client API for LanternService service.
@@ -78,6 +79,10 @@ type LanternServiceClient interface {
 	DeleteEdge(ctx context.Context, in *DeleteEdgeRequest, opts ...grpc.CallOption) (*DeleteEdgeResponse, error)
 	// DeleteEdges removes several edges in one round trip.
 	DeleteEdges(ctx context.Context, in *DeleteEdgesRequest, opts ...grpc.CallOption) (*DeleteEdgesResponse, error)
+	// ScanEdges streams edges whose tail key starts with `tail_prefix` AND
+	// whose head key starts with `head_prefix`, in ascending (tail, head)
+	// order, page by page. Plural-only — prefix scan is inherently plural.
+	ScanEdges(ctx context.Context, in *ScanEdgesRequest, opts ...grpc.CallOption) (*ScanEdgesResponse, error)
 }
 
 type lanternServiceClient struct {
@@ -268,6 +273,16 @@ func (c *lanternServiceClient) DeleteEdges(ctx context.Context, in *DeleteEdgesR
 	return out, nil
 }
 
+func (c *lanternServiceClient) ScanEdges(ctx context.Context, in *ScanEdgesRequest, opts ...grpc.CallOption) (*ScanEdgesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ScanEdgesResponse)
+	err := c.cc.Invoke(ctx, LanternService_ScanEdges_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // LanternServiceServer is the server API for LanternService service.
 // All implementations should embed UnimplementedLanternServiceServer
 // for forward compatibility.
@@ -307,6 +322,10 @@ type LanternServiceServer interface {
 	DeleteEdge(context.Context, *DeleteEdgeRequest) (*DeleteEdgeResponse, error)
 	// DeleteEdges removes several edges in one round trip.
 	DeleteEdges(context.Context, *DeleteEdgesRequest) (*DeleteEdgesResponse, error)
+	// ScanEdges streams edges whose tail key starts with `tail_prefix` AND
+	// whose head key starts with `head_prefix`, in ascending (tail, head)
+	// order, page by page. Plural-only — prefix scan is inherently plural.
+	ScanEdges(context.Context, *ScanEdgesRequest) (*ScanEdgesResponse, error)
 }
 
 // UnimplementedLanternServiceServer should be embedded to have
@@ -369,6 +388,9 @@ func (UnimplementedLanternServiceServer) DeleteEdge(context.Context, *DeleteEdge
 }
 func (UnimplementedLanternServiceServer) DeleteEdges(context.Context, *DeleteEdgesRequest) (*DeleteEdgesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteEdges not implemented")
+}
+func (UnimplementedLanternServiceServer) ScanEdges(context.Context, *ScanEdgesRequest) (*ScanEdgesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ScanEdges not implemented")
 }
 func (UnimplementedLanternServiceServer) testEmbeddedByValue() {}
 
@@ -714,6 +736,24 @@ func _LanternService_DeleteEdges_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _LanternService_ScanEdges_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ScanEdgesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LanternServiceServer).ScanEdges(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: LanternService_ScanEdges_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LanternServiceServer).ScanEdges(ctx, req.(*ScanEdgesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // LanternService_ServiceDesc is the grpc.ServiceDesc for LanternService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -792,6 +832,10 @@ var LanternService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteEdges",
 			Handler:    _LanternService_DeleteEdges_Handler,
+		},
+		{
+			MethodName: "ScanEdges",
+			Handler:    _LanternService_ScanEdges_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pb/openapiv2/graph/v1/graph.swagger.json
+++ b/pb/openapiv2/graph/v1/graph.swagger.json
@@ -152,6 +152,40 @@
         ]
       }
     },
+    "/v1/edges/scan": {
+      "post": {
+        "summary": "ScanEdges streams edges whose tail key starts with `tail_prefix` AND\nwhose head key starts with `head_prefix`, in ascending (tail, head)\norder, page by page. Plural-only — prefix scan is inherently plural.",
+        "operationId": "LanternService_ScanEdges",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ScanEdgesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "ScanEdgesRequest streams edges whose tail key starts with `tail_prefix`\nAND whose head key starts with `head_prefix`, in ascending (tail, head)\norder. Either prefix may be empty to disable the corresponding filter\n(both empty scans every edge). `limit` caps the number returned in one\ncall; the server enforces a default when `limit == 0` and a hard maximum\n(see ScanConfig on the server). `cursor` MUST be treated as opaque bytes\nby clients — pass back exactly what the previous response returned in\n`next_cursor`. An empty `cursor` starts from the beginning.\n\nImplementation note: v1 walks the tail-side prefix index and applies\n`head_prefix` as a post-filter; for highly selective `head_prefix`\nqueries the server may visit many tails to fill one page. Latency is\nreported in the standard scan histogram so operators can spot\npathological filters.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ScanEdgesRequest"
+            }
+          }
+        ],
+        "tags": [
+          "LanternService"
+        ]
+      }
+    },
     "/v1/edges/{edge.tail}/{edge.head}": {
       "put": {
         "summary": "PutEdge is idempotent (replaces weight). Thin facade over PutEdges.",
@@ -1124,6 +1158,44 @@
           "type": "integer",
           "format": "int32",
           "description": "Number of vertices accepted by the server. Currently always equals the\nrequest size on success; reserved for future per-item validation that may\nreport partial writes."
+        }
+      }
+    },
+    "v1ScanEdgesRequest": {
+      "type": "object",
+      "properties": {
+        "tailPrefix": {
+          "type": "string"
+        },
+        "headPrefix": {
+          "type": "string"
+        },
+        "limit": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "cursor": {
+          "type": "string",
+          "format": "byte"
+        }
+      },
+      "description": "ScanEdgesRequest streams edges whose tail key starts with `tail_prefix`\nAND whose head key starts with `head_prefix`, in ascending (tail, head)\norder. Either prefix may be empty to disable the corresponding filter\n(both empty scans every edge). `limit` caps the number returned in one\ncall; the server enforces a default when `limit == 0` and a hard maximum\n(see ScanConfig on the server). `cursor` MUST be treated as opaque bytes\nby clients — pass back exactly what the previous response returned in\n`next_cursor`. An empty `cursor` starts from the beginning.\n\nImplementation note: v1 walks the tail-side prefix index and applies\n`head_prefix` as a post-filter; for highly selective `head_prefix`\nqueries the server may visit many tails to fill one page. Latency is\nreported in the standard scan histogram so operators can spot\npathological filters."
+    },
+    "v1ScanEdgesResponse": {
+      "type": "object",
+      "properties": {
+        "edges": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Edge"
+          },
+          "description": "edges returned in ascending (tail, head) order. May be shorter than\n`limit` when the underlying range is exhausted."
+        },
+        "nextCursor": {
+          "type": "string",
+          "format": "byte",
+          "description": "next_cursor is non-empty when more results are available. An empty\nvalue signals end of stream."
         }
       }
     },

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -219,6 +219,36 @@ message EdgeKey {
   string head = 2;
 }
 
+// ScanEdgesRequest streams edges whose tail key starts with `tail_prefix`
+// AND whose head key starts with `head_prefix`, in ascending (tail, head)
+// order. Either prefix may be empty to disable the corresponding filter
+// (both empty scans every edge). `limit` caps the number returned in one
+// call; the server enforces a default when `limit == 0` and a hard maximum
+// (see ScanConfig on the server). `cursor` MUST be treated as opaque bytes
+// by clients — pass back exactly what the previous response returned in
+// `next_cursor`. An empty `cursor` starts from the beginning.
+//
+// Implementation note: v1 walks the tail-side prefix index and applies
+// `head_prefix` as a post-filter; for highly selective `head_prefix`
+// queries the server may visit many tails to fill one page. Latency is
+// reported in the standard scan histogram so operators can spot
+// pathological filters.
+message ScanEdgesRequest {
+  string tail_prefix = 1;
+  string head_prefix = 2;
+  uint32 limit = 3;
+  bytes cursor = 4;
+}
+
+message ScanEdgesResponse {
+  // edges returned in ascending (tail, head) order. May be shorter than
+  // `limit` when the underlying range is exhausted.
+  repeated Edge edges = 1;
+  // next_cursor is non-empty when more results are available. An empty
+  // value signals end of stream.
+  bytes next_cursor = 2;
+}
+
 // DeleteEdgesRequest removes several edges in one round trip. Subject to the
 // MaxBatchSize / MaxKeyLen guard rails.
 message DeleteEdgesRequest {
@@ -393,6 +423,16 @@ service LanternService {
   rpc DeleteEdges(DeleteEdgesRequest) returns (DeleteEdgesResponse) {
     option (google.api.http) = {
       post: "/v1/edges/delete"
+      body: "*"
+    };
+  }
+
+  // ScanEdges streams edges whose tail key starts with `tail_prefix` AND
+  // whose head key starts with `head_prefix`, in ascending (tail, head)
+  // order, page by page. Plural-only — prefix scan is inherently plural.
+  rpc ScanEdges(ScanEdgesRequest) returns (ScanEdgesResponse) {
+    option (google.api.http) = {
+      post: "/v1/edges/scan"
       body: "*"
     };
   }

--- a/sdks/go/edge_prefix.go
+++ b/sdks/go/edge_prefix.go
@@ -1,0 +1,117 @@
+package client
+
+import (
+	"context"
+	"iter"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+)
+
+// EdgeScanOption configures Lantern.ScanEdges. Use the prefix options to
+// narrow the result set on either endpoint dimension; either prefix may
+// be omitted to leave it unconstrained.
+type EdgeScanOption func(*edgeScanOptions)
+
+type edgeScanOptions struct {
+	tailPrefix string
+	headPrefix string
+	limit      uint32
+	cursor     []byte
+}
+
+// WithEdgeScanTailPrefix restricts the scan to edges whose tail key
+// starts with prefix. Empty (the default) imposes no tail constraint.
+func WithEdgeScanTailPrefix(prefix string) EdgeScanOption {
+	return func(o *edgeScanOptions) { o.tailPrefix = prefix }
+}
+
+// WithEdgeScanHeadPrefix restricts the scan to edges whose head key
+// starts with prefix. v1 evaluates this as a post-filter on the tail
+// walk, so a head-only scan is no cheaper than a full scan; pair with
+// WithEdgeScanTailPrefix when possible.
+func WithEdgeScanHeadPrefix(prefix string) EdgeScanOption {
+	return func(o *edgeScanOptions) { o.headPrefix = prefix }
+}
+
+// WithEdgeScanLimit caps the number of edges the server returns in one
+// ScanEdges response. 0 (the default) lets the server apply its
+// configured ScanDefaultLimit. Values above ScanMaxLimit are clamped
+// down server-side.
+func WithEdgeScanLimit(n uint32) EdgeScanOption {
+	return func(o *edgeScanOptions) { o.limit = n }
+}
+
+// WithEdgeScanCursor resumes a paginated edge scan from the cursor
+// returned by a previous ScanEdges call. Treat the cursor as opaque
+// bytes — do not inspect or modify it, and do not pass a vertex-scan
+// cursor here (the two wire formats are intentionally incompatible).
+func WithEdgeScanCursor(c []byte) EdgeScanOption {
+	return func(o *edgeScanOptions) { o.cursor = c }
+}
+
+// ScanEdges returns one page of edges in ascending (tail, head) order,
+// filtered by the configured tail and head prefixes. nextCursor is
+// non-empty when more pages are available; pass it via
+// WithEdgeScanCursor on the next call to continue. An empty nextCursor
+// signals end of stream.
+//
+// For most callers, ScanEdgesAll is the more ergonomic API — use this
+// method only when you need explicit single-page control.
+func (l *Lantern) ScanEdges(ctx context.Context, opts ...EdgeScanOption) (edges []*Edge, nextCursor []byte, err error) {
+	o := edgeScanOptions{}
+	for _, apply := range opts {
+		apply(&o)
+	}
+	ctx, cancel := l.applyTimeout(ctx)
+	defer cancel()
+	resp, err := l.client.ScanEdges(ctx, &pb.ScanEdgesRequest{
+		TailPrefix: o.tailPrefix,
+		HeadPrefix: o.headPrefix,
+		Limit:      o.limit,
+		Cursor:     o.cursor,
+	})
+	if err != nil {
+		return nil, nil, wrapStatus(err)
+	}
+	return resp.GetEdges(), resp.GetNextCursor(), nil
+}
+
+// ScanEdgesAll returns a Go 1.23+ iter.Seq2 that yields successive pages
+// of ScanEdges results until the matching range is exhausted or ctx is
+// cancelled. batchSize is forwarded to the server as the per-call limit
+// (0 = server default). Stop conditions mirror ScanVerticesAll.
+//
+// Typical use:
+//
+//	for batch, err := range cli.ScanEdgesAll(ctx, 500,
+//	    client.WithEdgeScanTailPrefix("user:"),
+//	    client.WithEdgeScanHeadPrefix("post:"),
+//	) {
+//	    if err != nil { return err }
+//	    for _, e := range batch { ... }
+//	}
+func (l *Lantern) ScanEdgesAll(ctx context.Context, batchSize uint32, opts ...EdgeScanOption) iter.Seq2[[]*Edge, error] {
+	return func(yield func([]*Edge, error) bool) {
+		var cursor []byte
+		for {
+			if ctx.Err() != nil {
+				yield(nil, ctx.Err())
+				return
+			}
+			pageOpts := append([]EdgeScanOption{}, opts...)
+			pageOpts = append(pageOpts, WithEdgeScanLimit(batchSize), WithEdgeScanCursor(cursor))
+			es, next, err := l.ScanEdges(ctx, pageOpts...)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if !yield(es, nil) {
+				return
+			}
+			if len(next) == 0 {
+				return
+			}
+			cursor = next
+		}
+	}
+}

--- a/server/service/backend.go
+++ b/server/service/backend.go
@@ -46,6 +46,14 @@ type Backend interface {
 	CountByPrefix(prefix string) int
 	DeleteByPrefix(ctx context.Context, prefix string, limit int) int
 
+	// edge-side prefix scan. ScanEdgesByPrefix invokes fn for each live
+	// edge whose tail starts with tailPrefix AND whose head starts with
+	// headPrefix, in ascending (tail, head) order. Either prefix may be
+	// empty to disable the corresponding filter. fn returns false to
+	// stop early. Plural-only on the wire (no CountEdges /
+	// DeleteEdgesByPrefix in this phase).
+	ScanEdgesByPrefix(ctx context.Context, tailPrefix, headPrefix string, fn func(tailProjected string, tail string, headProjected string, head string, weight float32, expiration time.Time) bool) bool
+
 	// background GC loop driven by LanternServer.
 	Watch(ctx context.Context, interval time.Duration)
 }

--- a/server/service/cursor.go
+++ b/server/service/cursor.go
@@ -64,3 +64,44 @@ func decodeCursor(b []byte) (scanCursor, error) {
 	}
 	return c, nil
 }
+
+// scanEdgesCursor pages ScanEdges by the last (tail, head) pair returned.
+// Wire format mirrors scanCursor: a versioned, base64-wrapped JSON blob
+// opaque to clients. The next page resumes at the first edge whose
+// (tail, head) is strictly greater (lexicographic, tail dominant) than
+// (LastTail, LastHead) within the request's tail/head prefix.
+type scanEdgesCursor struct {
+	Version  uint8  `json:"v"`
+	LastTail string `json:"t"`
+	LastHead string `json:"h"`
+}
+
+func encodeEdgesCursor(c scanEdgesCursor) []byte {
+	c.Version = cursorVersion
+	raw, err := json.Marshal(c)
+	if err != nil {
+		return nil
+	}
+	out := make([]byte, base64.RawURLEncoding.EncodedLen(len(raw)))
+	base64.RawURLEncoding.Encode(out, raw)
+	return out
+}
+
+func decodeEdgesCursor(b []byte) (scanEdgesCursor, error) {
+	if len(b) == 0 {
+		return scanEdgesCursor{}, nil
+	}
+	raw := make([]byte, base64.RawURLEncoding.DecodedLen(len(b)))
+	n, err := base64.RawURLEncoding.Decode(raw, b)
+	if err != nil {
+		return scanEdgesCursor{}, fmt.Errorf("decode cursor: %w", err)
+	}
+	var c scanEdgesCursor
+	if err := json.Unmarshal(raw[:n], &c); err != nil {
+		return scanEdgesCursor{}, fmt.Errorf("decode cursor: %w", err)
+	}
+	if c.Version != cursorVersion {
+		return scanEdgesCursor{}, fmt.Errorf("decode cursor: unsupported version %d", c.Version)
+	}
+	return c, nil
+}

--- a/server/service/fake_backend_test.go
+++ b/server/service/fake_backend_test.go
@@ -174,6 +174,42 @@ func (f *fakeBackend) DeleteByPrefix(_ context.Context, prefix string, limit int
 	return len(victims)
 }
 
+func (f *fakeBackend) ScanEdgesByPrefix(_ context.Context, tailPrefix, headPrefix string,
+	fn func(string, string, string, string, float32, time.Time) bool,
+) bool {
+	tails := make([]string, 0, len(f.edges))
+	for t := range f.edges {
+		if tailPrefix == "" || (len(t) >= len(tailPrefix) && t[:len(tailPrefix)] == tailPrefix) {
+			tails = append(tails, t)
+		}
+	}
+	for i := 1; i < len(tails); i++ {
+		for j := i; j > 0 && tails[j-1] > tails[j]; j-- {
+			tails[j-1], tails[j] = tails[j], tails[j-1]
+		}
+	}
+	for _, t := range tails {
+		row := f.edges[t]
+		heads := make([]string, 0, len(row))
+		for h := range row {
+			if headPrefix == "" || (len(h) >= len(headPrefix) && h[:len(headPrefix)] == headPrefix) {
+				heads = append(heads, h)
+			}
+		}
+		for i := 1; i < len(heads); i++ {
+			for j := i; j > 0 && heads[j-1] > heads[j]; j-- {
+				heads[j-1], heads[j] = heads[j], heads[j-1]
+			}
+		}
+		for _, h := range heads {
+			if !fn(t, t, h, h, row[h], time.Time{}) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // Compile-time check that fakeBackend really satisfies Backend.
 var _ Backend = (*fakeBackend)(nil)
 

--- a/server/service/prefix.go
+++ b/server/service/prefix.go
@@ -2,10 +2,12 @@ package service
 
 import (
 	"context"
+	"time"
 
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // ScanVertices walks the vertex keyspace in lexicographic order, returning a
@@ -116,4 +118,63 @@ func clampLimit(requested, def, max uint32) uint32 {
 		requested = max
 	}
 	return requested
+}
+
+// ScanEdges walks the edge keyspace in ascending (tail, head) order,
+// returning a single page of edges whose tail key starts with TailPrefix
+// AND whose head key starts with HeadPrefix. Either prefix may be empty.
+//
+// Pagination shares the ScanVertices limits (clamped to (0,
+// ScanMaxLimit]; zero falls back to ScanDefaultLimit). The opaque cursor
+// encodes (LastTail, LastHead) — wire-incompatible with the vertex
+// cursor on purpose so the two pagination streams cannot be swapped.
+//
+// Implementation note: v1 walks the vertex-side prefix index for the
+// tail dimension and applies HeadPrefix as a post-filter. AddEdge /
+// PutEdge auto-create both endpoints as vertices, so the radix already
+// covers every live tail; no parallel edge index exists today.
+func (s *LanternService) ScanEdges(ctx context.Context, in *pb.ScanEdgesRequest) (*pb.ScanEdgesResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, status.FromContextError(err).Err()
+	}
+	limit := clampLimit(in.GetLimit(), s.scan.ScanDefaultLimit, s.scan.ScanMaxLimit)
+
+	cursor, err := decodeEdgesCursor(in.GetCursor())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
+	}
+
+	edges := make([]*pb.Edge, 0, limit)
+	var lastTail, lastHead string
+	hitLimit := false
+	s.cache.ScanEdgesByPrefix(ctx, in.GetTailPrefix(), in.GetHeadPrefix(),
+		func(_ string, tail string, _ string, head string, weight float32, exp time.Time) bool {
+			// Cursor skip: drop everything whose (tail, head) is <=
+			// cursor's last emitted pair. The walk is in ascending
+			// (tail, head) order so once we cross the cursor we never
+			// revisit a smaller pair.
+			if cursor.LastTail != "" || cursor.LastHead != "" {
+				if tail < cursor.LastTail ||
+					(tail == cursor.LastTail && head <= cursor.LastHead) {
+					return true
+				}
+			}
+			if uint32(len(edges)) >= limit {
+				hitLimit = true
+				return false
+			}
+			edge := &pb.Edge{Tail: tail, Head: head, Weight: weight}
+			if !exp.IsZero() {
+				edge.Expiration = timestamppb.New(exp)
+			}
+			edges = append(edges, edge)
+			lastTail, lastHead = tail, head
+			return true
+		})
+
+	resp := &pb.ScanEdgesResponse{Edges: edges}
+	if hitLimit && (lastTail != "" || lastHead != "") {
+		resp.NextCursor = encodeEdgesCursor(scanEdgesCursor{LastTail: lastTail, LastHead: lastHead})
+	}
+	return resp, nil
 }

--- a/tests/integration/edge_prefix_test.go
+++ b/tests/integration/edge_prefix_test.go
@@ -1,0 +1,169 @@
+package integration_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+// seedPrefixEdges creates both endpoints as live vertices and then puts the
+// edges with an explicit non-zero expiration. Edges without an explicit
+// expiration are born-expired (1970-01-01) — see the AGENTS.md note in
+// core/cache/graph for the same trap.
+func seedPrefixEdges(t *testing.T, ctx context.Context, l *client.Lantern, pairs [][2]string) {
+	t.Helper()
+	keySet := map[string]struct{}{}
+	for _, p := range pairs {
+		keySet[p[0]] = struct{}{}
+		keySet[p[1]] = struct{}{}
+	}
+	keys := make([]string, 0, len(keySet))
+	for k := range keySet {
+		keys = append(keys, k)
+	}
+	seedPrefixVertices(t, ctx, l, keys)
+
+	exp := time.Now().Add(time.Hour)
+	edges := make([]client.EdgeInput, len(pairs))
+	for i, p := range pairs {
+		edges[i] = client.EdgeInput{Tail: p[0], Head: p[1], Weight: 1, Expiration: exp}
+	}
+	if err := l.PutEdges(ctx, edges); err != nil {
+		t.Fatalf("PutEdges: %v", err)
+	}
+}
+
+func collectEdges(t *testing.T, ctx context.Context, l *client.Lantern, opts ...client.EdgeScanOption) []string {
+	t.Helper()
+	out := []string{}
+	for batch, err := range l.ScanEdgesAll(ctx, 100, opts...) {
+		if err != nil {
+			t.Fatalf("ScanEdgesAll: %v", err)
+		}
+		for _, e := range batch {
+			out = append(out, e.GetTail()+"->"+e.GetHead())
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestSDK_ScanEdges_TailHeadFilters(t *testing.T) {
+	l, cleanup := newPrefixSDKClient(t)
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	seedPrefixEdges(t, ctx, l, [][2]string{
+		{"user:1", "post:1"},
+		{"user:1", "post:2"},
+		{"user:2", "post:3"},
+		{"user:2", "session:1"},
+		{"admin:1", "post:9"},
+		{"admin:1", "session:7"},
+	})
+
+	cases := []struct {
+		name string
+		opts []client.EdgeScanOption
+		want []string
+	}{
+		{
+			name: "all",
+			want: []string{
+				"admin:1->post:9", "admin:1->session:7",
+				"user:1->post:1", "user:1->post:2",
+				"user:2->post:3", "user:2->session:1",
+			},
+		},
+		{
+			name: "tail user:",
+			opts: []client.EdgeScanOption{client.WithEdgeScanTailPrefix("user:")},
+			want: []string{
+				"user:1->post:1", "user:1->post:2",
+				"user:2->post:3", "user:2->session:1",
+			},
+		},
+		{
+			name: "head post:",
+			opts: []client.EdgeScanOption{client.WithEdgeScanHeadPrefix("post:")},
+			want: []string{
+				"admin:1->post:9",
+				"user:1->post:1", "user:1->post:2",
+				"user:2->post:3",
+			},
+		},
+		{
+			name: "tail user: + head post:",
+			opts: []client.EdgeScanOption{
+				client.WithEdgeScanTailPrefix("user:"),
+				client.WithEdgeScanHeadPrefix("post:"),
+			},
+			want: []string{
+				"user:1->post:1", "user:1->post:2", "user:2->post:3",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collectEdges(t, ctx, l, tc.opts...)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestSDK_ScanEdges_Pagination(t *testing.T) {
+	l, cleanup := newPrefixSDKClient(t)
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pairs := [][2]string{
+		{"t:1", "h:1"}, {"t:1", "h:2"}, {"t:1", "h:3"},
+		{"t:2", "h:1"}, {"t:2", "h:2"},
+	}
+	seedPrefixEdges(t, ctx, l, pairs)
+
+	// Page through with limit=2.
+	seen := []string{}
+	var cursor []byte
+	for {
+		page, next, err := l.ScanEdges(ctx,
+			client.WithEdgeScanTailPrefix("t:"),
+			client.WithEdgeScanLimit(2),
+			client.WithEdgeScanCursor(cursor),
+		)
+		if err != nil {
+			t.Fatalf("ScanEdges: %v", err)
+		}
+		for _, e := range page {
+			seen = append(seen, e.GetTail()+"->"+e.GetHead())
+		}
+		if len(next) == 0 {
+			break
+		}
+		cursor = next
+	}
+	want := []string{
+		"t:1->h:1", "t:1->h:2", "t:1->h:3",
+		"t:2->h:1", "t:2->h:2",
+	}
+	if len(seen) != len(want) {
+		t.Fatalf("paged result %v, want %v", seen, want)
+	}
+	for i := range want {
+		if seen[i] != want[i] {
+			t.Fatalf("paged result %v, want %v", seen, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #159.

Phase 6 of the prefix-scan epic. Adds a single plural RPC, `ScanEdges`, that walks live edges in ascending (tail, head) order filtered by optional `tail_prefix` and `head_prefix`. Either prefix may be empty.

## Layers

- **proto**: `ScanEdgesRequest{tail_prefix, head_prefix, limit, cursor}`, `ScanEdgesResponse{edges, next_cursor}`, `ScanEdges` RPC + HTTP gateway binding (`POST /v1/edges/scan`).
- **core/cache/graph**: `ScanEdgesByPrefix` on `GraphCache` reuses the existing vertex prefix index for tail enumeration (`AddEdge`/`PutEdge` already ensure both endpoints exist as vertices). Heads are sorted per tail before emit so cursor pagination is deterministic.
- **server/service**: `ScanEdges` handler clamps limit via `ScanDefaultLimit` / `ScanMaxLimit` (same knobs as `ScanVertices`) and uses a separate `scanEdgesCursor{LastTail, LastHead}` codec — intentionally wire-incompatible with the vertex cursor.
- **sdks/go**: `ScanEdges` + `ScanEdgesAll` `iter.Seq2` helper with `WithEdgeScan{TailPrefix,HeadPrefix,Limit,Cursor}` options.
- **cli**: `lantern edge scan [--tail-prefix P] [--head-prefix P] [--limit N] [--cursor T] [--all]`; NDJSON to stdout, `next-cursor: <token>` to stderr.

## Tests

- 5 new unit tests on the cache method (intersection, ordering, early-exit/ctx-cancel, expired skip, disabled-without-index).
- 2 new bufconn integration tests (tail-only / head-only / intersection plus pagination roundtrip).
- All existing tests still pass; `gofmt -l` clean across the workspace.

## v1 scope

Out of scope for v1 (explicit per #159):
- `CountEdgesByPrefix`, `DeleteEdgesByPrefix` — deferred.
- Head-side parallel radix — `--head-prefix` is a post-filter in v1, so a head-only scan is no cheaper than a full scan. Combine with `--tail-prefix` when possible.