### PR TITLE
feat(#167): per-tail head radix index for ScanEdgesByPrefix

### DIFF
--- a/core/cache/graph/batch.go
+++ b/core/cache/graph/batch.go
@@ -53,7 +53,8 @@ func (c *GraphCache[S, T]) AddEdgesWithExpiration(items []EdgeItem[S]) {
 	for _, it := range items {
 		c.ensureVertexLocked(it.Tail, it.Expiration)
 		c.ensureVertexLocked(it.Head, it.Expiration)
-		c.edges.addWithExpiration(it.Tail, it.Head, it.Weight, it.Expiration)
+		created, tailID, headID := c.edges.addWithExpiration(it.Tail, it.Head, it.Weight, it.Expiration)
+		c.onEdgeAddedLocked(created, tailID, headID, it.Head)
 	}
 }
 
@@ -71,7 +72,8 @@ func (c *GraphCache[S, T]) PutEdgesWithExpiration(items []EdgeItem[S]) {
 		c.ensureVertexLocked(it.Tail, it.Expiration)
 		c.ensureVertexLocked(it.Head, it.Expiration)
 		c.edges.delete(it.Tail, it.Head)
-		c.edges.addWithExpiration(it.Tail, it.Head, it.Weight, it.Expiration)
+		created, tailID, headID := c.edges.addWithExpiration(it.Tail, it.Head, it.Weight, it.Expiration)
+		c.onEdgeAddedLocked(created, tailID, headID, it.Head)
 	}
 }
 
@@ -105,7 +107,9 @@ func (c *GraphCache[S, T]) DeleteEdges(keys []EdgeKey[S]) int {
 	defer c.mu.Unlock()
 	var n int
 	for _, k := range keys {
-		if c.edges.delete(k.Tail, k.Head) {
+		deleted, tailID, headID := c.edges.delete(k.Tail, k.Head)
+		if deleted {
+			c.onEdgeDeletedLocked(tailID, headID, k.Head)
 			n++
 		}
 	}

--- a/core/cache/graph/cache.go
+++ b/core/cache/graph/cache.go
@@ -49,6 +49,19 @@ type GraphCache[S comparable, T any] struct {
 	// pay no extra cost beyond a single nil check.
 	prefixIndex   *radix
 	prefixExtract func(S) string
+
+	// headByTail is the per-tail head-side prefix index that backs the
+	// head dimension of ScanEdgesByPrefix (Issue #167). It is allocated
+	// alongside prefixIndex by EnablePrefixIndex and maintained in
+	// lockstep with edge mutations under c.mu.Lock — every AddEdge /
+	// PutEdge / DeleteEdge code path (single and batch) that touches the
+	// edge map also touches the matching headIndex entry, so the two
+	// structures never disagree from a reader's perspective.
+	//
+	// Set to nil by disableHeadIndexForTesting to force ScanEdgesByPrefix
+	// onto the v1 materialise-and-sort fallback for regression tests and
+	// before/after benchmarks. Production code never disables it.
+	headByTail map[vertexID]*headIndex
 }
 
 func NewGraphCache[S comparable, T any](defaultTTL time.Duration) *GraphCache[S, T] {
@@ -106,6 +119,7 @@ func (c *GraphCache[S, T]) EnablePrefixIndex(extract func(S) string) {
 	}
 	c.prefixExtract = extract
 	c.prefixIndex = newRadix()
+	c.headByTail = make(map[vertexID]*headIndex)
 }
 
 // putVertexLocked inserts (or refreshes) a vertex entry, interning the key
@@ -185,7 +199,8 @@ func (c *GraphCache[S, T]) AddEdgeWithExpiration(tail, head S, w float32, expira
 	// vertex cache has its own mutex, so calling it while holding c.mu is safe.
 	c.ensureVertexLocked(tail, expiration)
 	c.ensureVertexLocked(head, expiration)
-	c.edges.addWithExpiration(tail, head, w, expiration)
+	created, tailID, headID := c.edges.addWithExpiration(tail, head, w, expiration)
+	c.onEdgeAddedLocked(created, tailID, headID, head)
 }
 
 func (c *GraphCache[S, T]) AddEdgeWithTTL(tail, head S, w float32, ttl time.Duration) {
@@ -209,8 +224,13 @@ func (c *GraphCache[S, T]) PutEdgeWithExpiration(tail, head S, w float32, expira
 	// Same endpoint auto-creation invariant as AddEdgeWithExpiration.
 	c.ensureVertexLocked(tail, expiration)
 	c.ensureVertexLocked(head, expiration)
+	// PutEdge replaces the edge atomically. The head projected string is
+	// unchanged across delete+add (same head key), so the head index needs
+	// no maintenance when the edge already existed — it only changes when
+	// add creates a fresh bucket.
 	c.edges.delete(tail, head)
-	c.edges.addWithExpiration(tail, head, w, expiration)
+	created, tailID, headID := c.edges.addWithExpiration(tail, head, w, expiration)
+	c.onEdgeAddedLocked(created, tailID, headID, head)
 }
 
 // DeleteVertex removes the vertex (by key) and returns whether it was present.
@@ -226,7 +246,11 @@ func (c *GraphCache[S, T]) DeleteEdge(tail, head S) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	return c.edges.delete(tail, head)
+	deleted, tailID, headID := c.edges.delete(tail, head)
+	if deleted {
+		c.onEdgeDeletedLocked(tailID, headID, head)
+	}
+	return deleted
 }
 
 // flush performs the fused GC sweep over the edge map in a single walk.
@@ -251,7 +275,7 @@ func (c *GraphCache[S, T]) flush() (zero, dangling int) {
 			return false
 		}
 		return c.vertices.Has(tail) && c.vertices.Has(head)
-	})
+	}, c.headIndexOnFlushDeleteLocked())
 }
 
 // VertexCount returns the live vertex count under an RLock. Intended for

--- a/core/cache/graph/edge.go
+++ b/core/cache/graph/edge.go
@@ -293,33 +293,40 @@ func (c *edgeCache[S]) resolve(id vertexID) (S, bool) {
 	return c.dict.resolve(id)
 }
 
-func (c *edgeCache[S]) addWithExpiration(tail, head S, w float32, expiration time.Time) {
-	// Fast path: existing edge. A hot counter-style edge gets updated every
-	// few ms; the slow path below would acquire the dict write lock twice
-	// (intern tail, intern head) and the dict release lock twice (revert
-	// the bumps) plus the edgeCache write lock — five global serialization
-	// points to append a float to a slice. If both endpoints are already
-	// interned AND the (tail, head) bucket already exists, we can skip
-	// every dict mutation and the edgeCache write lock entirely: a single
-	// dict RLock to resolve both ids, a single edgeCache RLock to fetch the
-	// *weight pointer, then the leaf weight.mu append. Refcounts are
-	// untouched because we neither add nor remove an edge.
-	//
-	// Race note: a concurrent delete between RUnlock and the weight append
-	// can leave us appending to a *weight that has just been detached from
-	// the map. That is harmless — the weight pointer stays valid, but the
-	// orphan is no longer reachable through tf, so the write effectively
-	// vanishes. The user-visible semantics of "concurrent add+delete on the
-	// same edge" are already racy under the slow path; the fast path
-	// preserves that contract without introducing new visibility issues.
+// addWithExpiration appends a (value, expiration) contribution to the
+// (tail, head) edge. It returns:
+//
+//   - created: true if this call created a new (tail, head) bucket (i.e.
+//     this is the first contribution for the edge), false when the bucket
+//     already existed and this call merely appended to its weight.
+//   - tailID, headID: the dict-resolved endpoint IDs, valid whenever a
+//     dict is configured. Callers use these IDs to maintain side indexes
+//     (e.g. the per-tail head radix) without re-entering the dict.
+//
+// Fast path: existing edge. A hot counter-style edge gets updated every
+// few ms; the slow path below would acquire the dict write lock twice
+// (intern tail, intern head) and the dict release lock twice (revert
+// the bumps) plus the edgeCache write lock — five global serialization
+// points to append a float to a slice. If both endpoints are already
+// interned AND the (tail, head) bucket already exists, we can skip
+// every dict mutation and the edgeCache write lock entirely.
+//
+// Race note: a concurrent delete between RUnlock and the weight append
+// can leave us appending to a *weight that has just been detached from
+// the map. That is harmless — the weight pointer stays valid, but the
+// orphan is no longer reachable through tf, so the write effectively
+// vanishes. The user-visible semantics of "concurrent add+delete on the
+// same edge" are already racy under the slow path; the fast path
+// preserves that contract without introducing new visibility issues.
+func (c *edgeCache[S]) addWithExpiration(tail, head S, w float32, expiration time.Time) (created bool, tailID, headID vertexID) {
 	if c.dict != nil {
-		if tailID, headID, okT, okH := c.dict.lookupBoth(tail, head); okT && okH {
+		if tID, hID, okT, okH := c.dict.lookupBoth(tail, head); okT && okH {
 			c.mu.RLock()
-			if heads, ok := c.tf[tailID]; ok {
-				if edge, ok := heads[headID]; ok {
+			if heads, ok := c.tf[tID]; ok {
+				if edge, ok := heads[hID]; ok {
 					c.mu.RUnlock()
 					edge.addWithExpiration(w, expiration)
-					return
+					return false, tID, hID
 				}
 			}
 			c.mu.RUnlock()
@@ -330,7 +337,7 @@ func (c *edgeCache[S]) addWithExpiration(tail, head S, w float32, expiration tim
 	// Intern both endpoints OUTSIDE the edgeCache lock so the dict can serve
 	// readers in parallel. The intern call is the +1 we either keep (new
 	// edge) or undo (existing edge) under the edgeCache lock below.
-	tailID, headID := c.internEndpoints(tail, head)
+	tailID, headID = c.internEndpoints(tail, head)
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -346,6 +353,7 @@ func (c *edgeCache[S]) addWithExpiration(tail, head S, w float32, expiration tim
 		edge = newWeight()
 		heads[headID] = edge
 		c.df[headID]++
+		created = true
 	} else if c.dict != nil {
 		// Edge already present: revert the intern bumps to keep the
 		// "one ref per endpoint per edge" invariant. This branch is
@@ -357,6 +365,7 @@ func (c *edgeCache[S]) addWithExpiration(tail, head S, w float32, expiration tim
 	}
 
 	edge.addWithExpiration(w, expiration)
+	return created, tailID, headID
 }
 
 func (c *edgeCache[S]) internEndpoints(tail, head S) (vertexID, vertexID) {
@@ -374,17 +383,22 @@ func (c *edgeCache[S]) add(tail, head S, w float32) {
 	c.addWithTTL(tail, head, w, c.defaultTTL)
 }
 
-// delete removes the (tail, head) edge. It returns true if the edge
-// was present (and therefore removed by this call), false otherwise.
-// Releases one dict reference per endpoint on a successful removal.
-func (c *edgeCache[S]) delete(tail, head S) bool {
-	tailID, headID, ok := c.lookupIDs(tail, head)
+// delete removes the (tail, head) edge. It returns deleted=true together
+// with the resolved tail/head vertexIDs whenever the edge was present (so
+// callers can maintain side indexes keyed by ID without re-entering the
+// dict). On a successful removal it releases one dict reference per
+// endpoint.
+func (c *edgeCache[S]) delete(tail, head S) (deleted bool, tailID, headID vertexID) {
+	tID, hID, ok := c.lookupIDs(tail, head)
 	if !ok {
-		return false
+		return false, 0, 0
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.deleteLocked(tailID, headID)
+	if c.deleteLocked(tID, hID) {
+		return true, tID, hID
+	}
+	return false, tID, hID
 }
 
 // deleteLocked performs the same work as delete but assumes the caller already
@@ -435,12 +449,19 @@ func (c *edgeCache[S]) flush() int {
 // the supplied keep predicate returns false (counted in `dangling`). A nil
 // keep skips the second check and behaves like flush.
 //
+// onDelete, if non-nil, fires once per successful removal with the
+// (tailID, headID) of the edge just deleted. It runs while c.mu is held
+// write-locked alongside the keep predicate, so it must not take c.mu
+// itself. It exists so callers can maintain side indexes (e.g. the
+// per-tail head radix) under the same critical section as the underlying
+// delete, preserving the atomicity contract observed by ScanEdgesByPrefix.
+//
 // Caller is responsible for any cross-structure consistency: the predicate
 // runs while c.mu is held write-locked, so it must not take c.mu itself.
 // The typical caller (GraphCache.Watch) wraps the call in the surrounding
 // GraphCache.mu.Lock() so the predicate can read sibling state (e.g. the
 // vertex cache) without further locking.
-func (c *edgeCache[S]) flushFunc(keep func(tail, head vertexID) bool) (zero, dangling int) {
+func (c *edgeCache[S]) flushFunc(keep func(tail, head vertexID) bool, onDelete func(tail, head vertexID)) (zero, dangling int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -448,10 +469,16 @@ func (c *edgeCache[S]) flushFunc(keep func(tail, head vertexID) bool) (zero, dan
 		for headID, w := range heads {
 			switch {
 			case w.isZero():
+				if onDelete != nil {
+					onDelete(tailID, headID)
+				}
 				if c.deleteLocked(tailID, headID) {
 					zero++
 				}
 			case keep != nil && !keep(tailID, headID):
+				if onDelete != nil {
+					onDelete(tailID, headID)
+				}
 				if c.deleteLocked(tailID, headID) {
 					dangling++
 				}

--- a/core/cache/graph/edge_prefix.go
+++ b/core/cache/graph/edge_prefix.go
@@ -20,11 +20,12 @@ import (
 // Implementation: the walk reuses the vertex-side prefix index for the
 // tail dimension. Every edge endpoint is auto-created as a vertex on
 // insert (see AddEdgeWithExpiration / PutEdgeWithExpiration), so the
-// radix already covers all live tails. For each matching tail the heads
-// map is materialised and sorted into projected ascending order, then
-// post-filtered against headPrefix. Edges with zero weight (fully
-// decayed but not yet flushed) are skipped, matching point-read
-// semantics.
+// radix already covers all live tails. For each matching tail the head
+// dimension is served by a per-tail head radix (Issue #167) when
+// available — see scanTailHeadsFast — or falls back to the v1
+// materialise-and-sort path (scanTailHeadsFallback) when the head index
+// is disabled. The two paths emit identical (tailProj, headProj) sets
+// for any given graph state.
 //
 // Locking contract is identical to ScanByPrefix: the walk holds
 // c.mu.RLock for its duration. Callers MUST NOT invoke any GraphCache
@@ -58,43 +59,109 @@ func (c *GraphCache[S, T]) ScanEdgesByPrefix(
 		if !ok || len(heads) == 0 {
 			return true
 		}
-		// Materialise + sort per tail. We keep the temporary slice's
-		// allocation bound to the fan-out of a single tail; in practice
-		// edge fan-outs are small relative to the global vertex count.
-		type headEntry struct {
-			proj string
-			head S
-			w    *weight
+		var ok2 bool
+		if c.headByTail != nil {
+			ok2 = c.scanTailHeadsFast(tail, tailProj, headPrefix, heads, fn)
+		} else {
+			ok2 = c.scanTailHeadsFallback(tail, tailProj, headPrefix, heads, fn)
 		}
-		entries := make([]headEntry, 0, len(heads))
-		for headID, w := range heads {
-			head, ok := c.edges.resolveID(headID)
-			if !ok {
-				// dict drift: skip rather than crash, same as
-				// ScanByPrefix.
-				continue
-			}
-			proj := c.prefixExtract(head)
-			if headPrefix != "" && !strings.HasPrefix(proj, headPrefix) {
-				continue
-			}
-			entries = append(entries, headEntry{proj: proj, head: head, w: w})
-		}
-		if len(entries) == 0 {
-			return true
-		}
-		sort.Slice(entries, func(i, j int) bool { return entries[i].proj < entries[j].proj })
-		for _, e := range entries {
-			sum, latest, nonZero := e.w.snapshot()
-			if !nonZero {
-				continue
-			}
-			if !fn(tailProj, tail, e.proj, e.head, sum, latest) {
-				completed = false
-				return false
-			}
+		if !ok2 {
+			completed = false
+			return false
 		}
 		return true
 	})
 	return completed
+}
+
+// scanTailHeadsFast emits matching (tail, head) pairs for one tail using
+// the per-tail head radix. It walks only the head_prefix subtree of the
+// radix instead of materialising every head bucket — the asymptotic win
+// for "1 tail with millions of heads, head_prefix matches a small slice"
+// workloads (Issue #167). Returns false to abort the outer walk.
+func (c *GraphCache[S, T]) scanTailHeadsFast(
+	tail S,
+	tailProj string,
+	headPrefix string,
+	heads map[vertexID]*weight,
+	fn func(tailProjected string, tail S, headProjected string, head S, weight float32, expiration time.Time) bool,
+) bool {
+	tailID, ok := c.edges.dict.lookup(tail)
+	if !ok {
+		return c.scanTailHeadsFallback(tail, tailProj, headPrefix, heads, fn)
+	}
+	hi, ok := c.headByTail[tailID]
+	if !ok || hi == nil {
+		// No per-tail index yet (or out of sync). Fall back to the safe
+		// path so we never silently under-report.
+		return c.scanTailHeadsFallback(tail, tailProj, headPrefix, heads, fn)
+	}
+	keepGoing := true
+	hi.walkPrefix(headPrefix, func(headProj string, headID vertexID) bool {
+		w, ok := heads[headID]
+		if !ok {
+			// Index/edge drift: skip rather than crash. This window is
+			// bounded by c.mu (we hold RLock) so in practice it should
+			// not happen, but defensive coding is cheap here.
+			return true
+		}
+		head, ok := c.edges.resolveID(headID)
+		if !ok {
+			return true
+		}
+		sum, latest, nonZero := w.snapshot()
+		if !nonZero {
+			return true
+		}
+		if !fn(tailProj, tail, headProj, head, sum, latest) {
+			keepGoing = false
+			return false
+		}
+		return true
+	})
+	return keepGoing
+}
+
+// scanTailHeadsFallback is the v1 materialise-and-sort path, preserved
+// verbatim so we can fall back to it when the head index is disabled
+// (disableHeadIndexForTesting) and so benchmarks can A/B the two
+// implementations on identical data.
+func (c *GraphCache[S, T]) scanTailHeadsFallback(
+	tail S,
+	tailProj string,
+	headPrefix string,
+	heads map[vertexID]*weight,
+	fn func(tailProjected string, tail S, headProjected string, head S, weight float32, expiration time.Time) bool,
+) bool {
+	type headEntry struct {
+		proj string
+		head S
+		w    *weight
+	}
+	entries := make([]headEntry, 0, len(heads))
+	for headID, w := range heads {
+		head, ok := c.edges.resolveID(headID)
+		if !ok {
+			continue
+		}
+		proj := c.prefixExtract(head)
+		if headPrefix != "" && !strings.HasPrefix(proj, headPrefix) {
+			continue
+		}
+		entries = append(entries, headEntry{proj: proj, head: head, w: w})
+	}
+	if len(entries) == 0 {
+		return true
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].proj < entries[j].proj })
+	for _, e := range entries {
+		sum, latest, nonZero := e.w.snapshot()
+		if !nonZero {
+			continue
+		}
+		if !fn(tailProj, tail, e.proj, e.head, sum, latest) {
+			return false
+		}
+	}
+	return true
 }

--- a/core/cache/graph/head_index.go
+++ b/core/cache/graph/head_index.go
@@ -1,0 +1,158 @@
+package graph
+
+// headIndex is the per-tail head-side prefix index that backs the head
+// dimension of ScanEdgesByPrefix. For one tail vertex it carries:
+//
+//   - radix:  the projected head strings of every outgoing edge, so a
+//     head_prefix query becomes a Patricia-trie probe of the
+//     matching subtree (instead of a full fan-out post-filter).
+//   - byProj: projected string -> set of head vertexIDs, so an emitted
+//     projected key can be resolved back to the underlying
+//     edge buckets (one bucket per headID in the set) even when
+//     the user-supplied extractor collapses several distinct S
+//     keys onto the same projection.
+//
+// A headIndex is created and mutated only while the surrounding
+// GraphCache holds c.mu.Lock — the radix's own mutex is therefore
+// redundant for our use, but the radix package keeps it for symmetry
+// with the vertex-side prefixIndex and the cost is negligible.
+//
+// When the byProj map becomes empty (tail has no outgoing edges left)
+// the caller drops the *headIndex entry from headByTail entirely, so an
+// untouched cache pays zero memory for tails that have never had a
+// prefix index enabled at all.
+type headIndex struct {
+	radix  *radix
+	byProj map[string]map[vertexID]struct{}
+}
+
+func newHeadIndex() *headIndex {
+	return &headIndex{
+		radix:  newRadix(),
+		byProj: make(map[string]map[vertexID]struct{}),
+	}
+}
+
+// insert records that headID maps to projected. It is idempotent on
+// repeated insertions of the same (projected, headID) pair.
+func (h *headIndex) insert(headID vertexID, projected string) {
+	set, ok := h.byProj[projected]
+	if !ok {
+		set = make(map[vertexID]struct{})
+		h.byProj[projected] = set
+		h.radix.insert(projected)
+	}
+	set[headID] = struct{}{}
+}
+
+// delete removes the (projected, headID) mapping. It reports whether
+// the headIndex is now fully empty so the caller can drop the entry
+// from its outer map.
+func (h *headIndex) delete(headID vertexID, projected string) (empty bool) {
+	set, ok := h.byProj[projected]
+	if !ok {
+		return len(h.byProj) == 0
+	}
+	if _, ok := set[headID]; !ok {
+		return len(h.byProj) == 0
+	}
+	delete(set, headID)
+	if len(set) == 0 {
+		delete(h.byProj, projected)
+		h.radix.delete(projected)
+	}
+	return len(h.byProj) == 0
+}
+
+// walkPrefix invokes fn with every (projected, headID) pair whose
+// projected starts with prefix, in projected-ascending order. The
+// order of headIDs WITHIN the same projected bucket is unspecified
+// (Go map iteration). fn may return false to stop the walk early.
+//
+// Locking: walkPrefix takes the underlying radix's RLock for the whole
+// traversal, so fn must not call insert or delete on this headIndex.
+func (h *headIndex) walkPrefix(prefix string, fn func(projected string, headID vertexID) bool) {
+	stopped := false
+	h.radix.walkPrefix(prefix, func(projected string) bool {
+		if stopped {
+			return false
+		}
+		for headID := range h.byProj[projected] {
+			if !fn(projected, headID) {
+				stopped = true
+				return false
+			}
+		}
+		return true
+	})
+}
+
+// --- GraphCache wiring -----------------------------------------------------
+//
+// The following helpers are mounted on GraphCache and called only by the
+// edge write paths (single + batch + flush). They preserve a single
+// invariant: when c.headByTail != nil, every edge present in c.edges has
+// a matching (projected, headID) entry in c.headByTail[tailID], and vice
+// versa. Callers MUST hold c.mu in write mode (Lock, not RLock).
+
+// onEdgeAddedLocked maintains the per-tail head index after a successful
+// edges.addWithExpiration. When created is false the underlying bucket
+// already existed and the index already reflects it; the call is a no-op.
+func (c *GraphCache[S, T]) onEdgeAddedLocked(created bool, tailID, headID vertexID, head S) {
+	if !created || c.headByTail == nil {
+		return
+	}
+	hi := c.headByTail[tailID]
+	if hi == nil {
+		hi = newHeadIndex()
+		c.headByTail[tailID] = hi
+	}
+	hi.insert(headID, c.prefixExtract(head))
+}
+
+// onEdgeDeletedLocked maintains the per-tail head index after a successful
+// edges.delete (or before a flushFunc deleteLocked). The head argument is
+// the original S key the caller already has in hand, so we never have to
+// resolve it through the dict — which is important because dict refs are
+// released by deleteLocked.
+func (c *GraphCache[S, T]) onEdgeDeletedLocked(tailID, headID vertexID, head S) {
+	if c.headByTail == nil {
+		return
+	}
+	hi, ok := c.headByTail[tailID]
+	if !ok {
+		return
+	}
+	if empty := hi.delete(headID, c.prefixExtract(head)); empty {
+		delete(c.headByTail, tailID)
+	}
+}
+
+// headIndexOnFlushDeleteLocked returns the onDelete callback handed to
+// edgeCache.flushFunc. It captures head S BEFORE deleteLocked runs
+// (flushFunc invokes the callback first), so resolveID is guaranteed to
+// succeed. Returns nil when the head index is disabled, in which case
+// flushFunc skips the call entirely.
+func (c *GraphCache[S, T]) headIndexOnFlushDeleteLocked() func(tailID, headID vertexID) {
+	if c.headByTail == nil {
+		return nil
+	}
+	return func(tailID, headID vertexID) {
+		head, ok := c.edges.resolveID(headID)
+		if !ok {
+			return
+		}
+		c.onEdgeDeletedLocked(tailID, headID, head)
+	}
+}
+
+// disableHeadIndexForTesting drops the per-tail head index so
+// ScanEdgesByPrefix falls back to the v1 materialise-and-sort path. It
+// exists so regression tests and before/after benchmarks can exercise
+// the fallback under identical data. Not part of the public API: lower
+// case on purpose, and never invoked by production code.
+func (c *GraphCache[S, T]) disableHeadIndexForTesting() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.headByTail = nil
+}

--- a/core/cache/graph/head_index_test.go
+++ b/core/cache/graph/head_index_test.go
@@ -1,0 +1,161 @@
+package graph
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestScanEdgesByPrefix_HeadIndexMatchesFallback asserts that the fast
+// (per-tail head radix) path emits exactly the same (tailProj, headProj)
+// set as the v1 materialise-and-sort fallback for any given graph state.
+//
+// We populate a small graph through the normal write surface (so both
+// the head index and the heads map agree), then scan it twice — once
+// with the index enabled and once after disableHeadIndexForTesting —
+// and assert the captured tuples are identical.
+func TestScanEdgesByPrefix_HeadIndexMatchesFallback(t *testing.T) {
+	build := func() *GraphCache[string, string] {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnablePrefixIndex(identityExtract)
+		exp := time.Now().Add(time.Minute)
+		tails := []string{"user:001", "user:002", "user:003", "post:001"}
+		heads := []string{"post:001", "post:002", "post:003", "user:001", "tag:x"}
+		for _, t1 := range tails {
+			for _, h := range heads {
+				if t1 == h {
+					continue
+				}
+				c.AddEdgeWithExpiration(t1, h, 1, exp)
+			}
+		}
+		c.PutEdgeWithExpiration("user:001", "post:002", 3, exp)
+		c.DeleteEdge("user:002", "tag:x")
+		return c
+	}
+
+	cases := []struct {
+		name         string
+		tailP, headP string
+	}{
+		{"all", "", ""},
+		{"narrow head", "user:", "post:00"},
+		{"narrow tail", "user:001", "post:"},
+		{"no match", "user:001", "zzz"},
+		{"head exact", "", "tag:x"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fastC := build()
+			fast := collectScan(fastC, tc.tailP, tc.headP)
+			slowC := build()
+			slowC.disableHeadIndexForTesting()
+			slow := collectScan(slowC, tc.tailP, tc.headP)
+			if len(fast) != len(slow) {
+				t.Fatalf("size mismatch: fast=%d slow=%d\nfast=%v\nslow=%v", len(fast), len(slow), fast, slow)
+			}
+			for i := range fast {
+				if fast[i] != slow[i] {
+					t.Fatalf("entry %d mismatch: fast=%q slow=%q", i, fast[i], slow[i])
+				}
+			}
+		})
+	}
+}
+
+// TestHeadIndex_LifecycleOnPutDelete asserts that after put-then-delete
+// the per-tail bucket is removed entirely so we do not leak empty
+// headIndex objects.
+func TestHeadIndex_LifecycleOnPutDelete(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	c.EnablePrefixIndex(identityExtract)
+	exp := time.Now().Add(time.Minute)
+
+	c.PutEdgeWithExpiration("u:1", "p:1", 1, exp)
+	c.mu.RLock()
+	tailID, ok := c.edges.dict.lookup("u:1")
+	c.mu.RUnlock()
+	if !ok {
+		t.Fatalf("expected tail to be interned")
+	}
+	if c.headByTail[tailID] == nil {
+		t.Fatalf("expected head index for u:1 after put")
+	}
+
+	if !c.DeleteEdge("u:1", "p:1") {
+		t.Fatalf("delete reported nothing removed")
+	}
+	if _, present := c.headByTail[tailID]; present {
+		t.Fatalf("expected per-tail head index to be dropped after last edge removed")
+	}
+}
+
+func collectScan(c *GraphCache[string, string], tailP, headP string) []string {
+	var out []string
+	c.ScanEdgesByPrefix(context.Background(), tailP, headP, func(tp string, _ string, hp string, _ string, _ float32, _ time.Time) bool {
+		out = append(out, tp+"|"+hp)
+		return true
+	})
+	return out
+}
+
+// BenchmarkScanEdgesByPrefix_StarHead exercises the canonical Issue #167
+// shape: a single hub tail with millions of heads, where head_prefix
+// matches a small slice. The fast (head-index) path walks only that
+// slice in the radix; the fallback materialises and sorts every head.
+//
+// Run with:
+//
+//	go test -bench BenchmarkScanEdgesByPrefix_StarHead -run ^$ ./cache/graph/...
+//
+// On a 1-tail / 1M-head graph with a ~0.1% match the fast path should
+// be at least an order of magnitude faster than the fallback.
+func BenchmarkScanEdgesByPrefix_StarHead(b *testing.B) {
+	const n = 100_000 // CI-friendly; bump to 1_000_000 locally for the headline number
+	c := NewGraphCache[string, string](time.Hour)
+	c.EnablePrefixIndex(identityExtract)
+	exp := time.Now().Add(time.Hour)
+	for i := 0; i < n; i++ {
+		c.AddEdgeWithExpiration("hub", fmt.Sprintf("post:%07d", i), 1, exp)
+	}
+	// Match the first 0.1% of heads.
+	headPrefix := "post:00000" // matches 100 / 100_000 = 0.1%
+
+	b.Run("HeadIndex", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			var hits int
+			c.ScanEdgesByPrefix(context.Background(), "", headPrefix, func(_, _, hp, _ string, _ float32, _ time.Time) bool {
+				if !strings.HasPrefix(hp, headPrefix) {
+					b.Fatalf("unexpected head %q", hp)
+				}
+				hits++
+				return true
+			})
+			if hits == 0 {
+				b.Fatalf("expected matches")
+			}
+		}
+	})
+
+	b.Run("Fallback", func(b *testing.B) {
+		c.disableHeadIndexForTesting()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			var hits int
+			c.ScanEdgesByPrefix(context.Background(), "", headPrefix, func(_, _, hp, _ string, _ float32, _ time.Time) bool {
+				if !strings.HasPrefix(hp, headPrefix) {
+					b.Fatalf("unexpected head %q", hp)
+				}
+				hits++
+				return true
+			})
+			if hits == 0 {
+				b.Fatalf("expected matches")
+			}
+		}
+	})
+}


### PR DESCRIPTION
Closes #167.

## What

Adds a per-tail head-side prefix index that turns the head filter in `ScanEdgesByPrefix` from an O(fan_out) post-filter into an O(matches + k_head) radix probe.

## How

- New `headIndex` (per-tail radix keyed by projected head string) in `core/cache/graph/head_index.go`.
- `GraphCache` gains an optional `headByTail map[vertexID]*headIndex` populated by `EnablePrefixIndex` alongside the existing vertex `prefixIndex`.
- All edge mutation paths (`AddEdge` / `PutEdge` / `DeleteEdge`, batch.go counterparts, flush sweeper) keep the index in sync under `c.mu`. `flushFunc` fires `onDelete` BEFORE `deleteLocked` so the callback can still resolve the head string via the edge dict.
- `ScanEdgesByPrefix` dispatches: fast path when `headByTail != nil`, otherwise the v1 materialise-and-sort fallback runs unchanged.

## Tests

- `TestScanEdgesByPrefix_HeadIndexMatchesFallback` — fast and fallback paths produce identical results across five (tailPrefix, headPrefix) shapes.
- `TestHeadIndex_LifecycleOnPutDelete` — per-tail bucket is dropped when the last edge is removed.
- `BenchmarkScanEdgesByPrefix_StarHead` — 100k-head hub tail with a 0.1% match window, run twice (HeadIndex vs Fallback) via a test-only `disableHeadIndexForTesting` hook.

Quality gate (gofmt, vet, all 5 modules' `go test ./...`) is green locally.

No proto / SDK / server surface change.