### PR TITLE
feat(#168): reject cross-fed Scan* cursors with INVALID_ARGUMENT

### DIFF
--- a/pb/graph/v1/graph.pb.go
+++ b/pb/graph/v1/graph.pb.go
@@ -1139,10 +1139,13 @@ func (x *DeleteVerticesResponse) GetDeleted() int32 {
 // opaque bytes by clients — pass back exactly what the previous response
 // returned in `next_cursor`. An empty `cursor` starts from the beginning.
 type ScanVerticesRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Prefix        string                 `protobuf:"bytes,1,opt,name=prefix,proto3" json:"prefix,omitempty"`
-	Limit         uint32                 `protobuf:"varint,2,opt,name=limit,proto3" json:"limit,omitempty"`
-	Cursor        []byte                 `protobuf:"bytes,3,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Prefix string                 `protobuf:"bytes,1,opt,name=prefix,proto3" json:"prefix,omitempty"`
+	Limit  uint32                 `protobuf:"varint,2,opt,name=limit,proto3" json:"limit,omitempty"`
+	// NOTE: opaque to the caller; not interchangeable with cursors from
+	// other Scan* RPCs (e.g. ScanEdges). Cross-feeding is rejected with
+	// INVALID_ARGUMENT rather than silently restarting the scan.
+	Cursor        []byte `protobuf:"bytes,3,opt,name=cursor,proto3" json:"cursor,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1817,11 +1820,14 @@ func (x *EdgeKey) GetHead() string {
 // reported in the standard scan histogram so operators can spot
 // pathological filters.
 type ScanEdgesRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	TailPrefix    string                 `protobuf:"bytes,1,opt,name=tail_prefix,json=tailPrefix,proto3" json:"tail_prefix,omitempty"`
-	HeadPrefix    string                 `protobuf:"bytes,2,opt,name=head_prefix,json=headPrefix,proto3" json:"head_prefix,omitempty"`
-	Limit         uint32                 `protobuf:"varint,3,opt,name=limit,proto3" json:"limit,omitempty"`
-	Cursor        []byte                 `protobuf:"bytes,4,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	TailPrefix string                 `protobuf:"bytes,1,opt,name=tail_prefix,json=tailPrefix,proto3" json:"tail_prefix,omitempty"`
+	HeadPrefix string                 `protobuf:"bytes,2,opt,name=head_prefix,json=headPrefix,proto3" json:"head_prefix,omitempty"`
+	Limit      uint32                 `protobuf:"varint,3,opt,name=limit,proto3" json:"limit,omitempty"`
+	// NOTE: opaque to the caller; not interchangeable with cursors from
+	// other Scan* RPCs (e.g. ScanVertices). Cross-feeding is rejected with
+	// INVALID_ARGUMENT rather than silently restarting the scan.
+	Cursor        []byte `protobuf:"bytes,4,opt,name=cursor,proto3" json:"cursor,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/pb/openapiv2/graph/v1/graph.swagger.json
+++ b/pb/openapiv2/graph/v1/graph.swagger.json
@@ -1176,7 +1176,8 @@
         },
         "cursor": {
           "type": "string",
-          "format": "byte"
+          "format": "byte",
+          "description": "NOTE: opaque to the caller; not interchangeable with cursors from\nother Scan* RPCs (e.g. ScanVertices). Cross-feeding is rejected with\nINVALID_ARGUMENT rather than silently restarting the scan."
         }
       },
       "description": "ScanEdgesRequest streams edges whose tail key starts with `tail_prefix`\nAND whose head key starts with `head_prefix`, in ascending (tail, head)\norder. Either prefix may be empty to disable the corresponding filter\n(both empty scans every edge). `limit` caps the number returned in one\ncall; the server enforces a default when `limit == 0` and a hard maximum\n(see ScanConfig on the server). `cursor` MUST be treated as opaque bytes\nby clients — pass back exactly what the previous response returned in\n`next_cursor`. An empty `cursor` starts from the beginning.\n\nImplementation note: v1 walks the tail-side prefix index and applies\n`head_prefix` as a post-filter; for highly selective `head_prefix`\nqueries the server may visit many tails to fill one page. Latency is\nreported in the standard scan histogram so operators can spot\npathological filters."
@@ -1211,7 +1212,8 @@
         },
         "cursor": {
           "type": "string",
-          "format": "byte"
+          "format": "byte",
+          "description": "NOTE: opaque to the caller; not interchangeable with cursors from\nother Scan* RPCs (e.g. ScanEdges). Cross-feeding is rejected with\nINVALID_ARGUMENT rather than silently restarting the scan."
         }
       },
       "description": "ScanVerticesRequest streams vertices whose key starts with `prefix` in\nlexicographic order. `limit` caps the number returned in one call; the\nserver enforces a default when `limit == 0` and a hard maximum (see\nRateLimitConfig / ScanConfig on the server). `cursor` MUST be treated as\nopaque bytes by clients — pass back exactly what the previous response\nreturned in `next_cursor`. An empty `cursor` starts from the beginning."

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -141,6 +141,9 @@ message DeleteVerticesResponse {
 message ScanVerticesRequest {
   string prefix = 1;
   uint32 limit = 2;
+  // NOTE: opaque to the caller; not interchangeable with cursors from
+  // other Scan* RPCs (e.g. ScanEdges). Cross-feeding is rejected with
+  // INVALID_ARGUMENT rather than silently restarting the scan.
   bytes cursor = 3;
 }
 
@@ -237,6 +240,9 @@ message ScanEdgesRequest {
   string tail_prefix = 1;
   string head_prefix = 2;
   uint32 limit = 3;
+  // NOTE: opaque to the caller; not interchangeable with cursors from
+  // other Scan* RPCs (e.g. ScanVertices). Cross-feeding is rejected with
+  // INVALID_ARGUMENT rather than silently restarting the scan.
   bytes cursor = 4;
 }
 

--- a/server/service/cursor.go
+++ b/server/service/cursor.go
@@ -43,26 +43,61 @@ func encodeCursor(c scanCursor) []byte {
 	return out
 }
 
+// cursorEnvelope is the union of every Scan* RPC's cursor payload shape.
+// We decode through it once so we can detect cross-RPC cursor reuse (e.g.
+// a ScanVertices next_cursor being fed back into ScanEdges) and return a
+// friendly error rather than silently restarting the scan. Each Scan* RPC
+// owns exactly one shape:
+//
+//   - ScanVertices  -> {v, k}           (LastKey populated)
+//   - ScanEdges     -> {v, t, h}        (LastTail and/or LastHead populated)
+//
+// json.Unmarshal silently ignores unknown fields, so a vertex cursor parsed
+// as scanEdgesCursor would otherwise yield an all-zero "start over" cursor
+// — exactly the bug #168 is about.
+type cursorEnvelope struct {
+	Version  uint8  `json:"v"`
+	LastKey  string `json:"k,omitempty"`
+	LastTail string `json:"t,omitempty"`
+	LastHead string `json:"h,omitempty"`
+}
+
+// decodeEnvelope is the shared base64+JSON+version unwrapper used by both
+// concrete cursor decoders. It returns the populated envelope so callers
+// can apply the shape check appropriate to their RPC.
+func decodeEnvelope(b []byte) (cursorEnvelope, error) {
+	raw := make([]byte, base64.RawURLEncoding.DecodedLen(len(b)))
+	n, err := base64.RawURLEncoding.Decode(raw, b)
+	if err != nil {
+		return cursorEnvelope{}, fmt.Errorf("decode cursor: %w", err)
+	}
+	var env cursorEnvelope
+	if err := json.Unmarshal(raw[:n], &env); err != nil {
+		return cursorEnvelope{}, fmt.Errorf("decode cursor: %w", err)
+	}
+	if env.Version != cursorVersion {
+		return cursorEnvelope{}, fmt.Errorf("decode cursor: unsupported version %d", env.Version)
+	}
+	return env, nil
+}
+
 // decodeCursor unpacks the bytes a client sent back. Empty input is the
 // "start from the beginning" sentinel and is not an error. Malformed input
 // is rejected so misbehaving clients cannot silently restart their scan.
+// A cursor issued by a different Scan* RPC is also rejected — see
+// cursorEnvelope.
 func decodeCursor(b []byte) (scanCursor, error) {
 	if len(b) == 0 {
 		return scanCursor{}, nil
 	}
-	raw := make([]byte, base64.RawURLEncoding.DecodedLen(len(b)))
-	n, err := base64.RawURLEncoding.Decode(raw, b)
+	env, err := decodeEnvelope(b)
 	if err != nil {
-		return scanCursor{}, fmt.Errorf("decode cursor: %w", err)
+		return scanCursor{}, err
 	}
-	var c scanCursor
-	if err := json.Unmarshal(raw[:n], &c); err != nil {
-		return scanCursor{}, fmt.Errorf("decode cursor: %w", err)
+	if env.LastTail != "" || env.LastHead != "" {
+		return scanCursor{}, fmt.Errorf("decode cursor: cursor was issued by a different Scan RPC (expected ScanVertices cursor)")
 	}
-	if c.Version != cursorVersion {
-		return scanCursor{}, fmt.Errorf("decode cursor: unsupported version %d", c.Version)
-	}
-	return c, nil
+	return scanCursor{Version: env.Version, LastKey: env.LastKey}, nil
 }
 
 // scanEdgesCursor pages ScanEdges by the last (tail, head) pair returned.
@@ -91,17 +126,12 @@ func decodeEdgesCursor(b []byte) (scanEdgesCursor, error) {
 	if len(b) == 0 {
 		return scanEdgesCursor{}, nil
 	}
-	raw := make([]byte, base64.RawURLEncoding.DecodedLen(len(b)))
-	n, err := base64.RawURLEncoding.Decode(raw, b)
+	env, err := decodeEnvelope(b)
 	if err != nil {
-		return scanEdgesCursor{}, fmt.Errorf("decode cursor: %w", err)
+		return scanEdgesCursor{}, err
 	}
-	var c scanEdgesCursor
-	if err := json.Unmarshal(raw[:n], &c); err != nil {
-		return scanEdgesCursor{}, fmt.Errorf("decode cursor: %w", err)
+	if env.LastKey != "" {
+		return scanEdgesCursor{}, fmt.Errorf("decode cursor: cursor was issued by a different Scan RPC (expected ScanEdges cursor)")
 	}
-	if c.Version != cursorVersion {
-		return scanEdgesCursor{}, fmt.Errorf("decode cursor: unsupported version %d", c.Version)
-	}
-	return c, nil
+	return scanEdgesCursor{Version: env.Version, LastTail: env.LastTail, LastHead: env.LastHead}, nil
 }

--- a/server/service/cursor_test.go
+++ b/server/service/cursor_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"encoding/base64"
+	"strings"
 	"testing"
 )
 
@@ -55,5 +56,27 @@ func TestCursor_RejectUnknownVersion(t *testing.T) {
 	b := []byte(base64.RawURLEncoding.EncodeToString(raw))
 	if _, err := decodeCursor(b); err == nil {
 		t.Errorf("expected error for unknown version")
+	}
+}
+
+// TestCursor_RejectCrossRPC pins the #168 behaviour: an edge cursor
+// (LastTail / LastHead populated) handed to decodeCursor — and a vertex
+// cursor (LastKey populated) handed to decodeEdgesCursor — must each be
+// rejected with a friendly error, not silently re-anchored to the start
+// of the scan. The error string is asserted because handlers forward it
+// verbatim into the codes.InvalidArgument status returned to clients.
+func TestCursor_RejectCrossRPC(t *testing.T) {
+	edgeCursor := encodeEdgesCursor(scanEdgesCursor{LastTail: "users/", LastHead: "posts/42"})
+	if _, err := decodeCursor(edgeCursor); err == nil {
+		t.Fatalf("decodeCursor(edge cursor) = nil error, want rejection")
+	} else if !strings.Contains(err.Error(), "different Scan RPC") {
+		t.Errorf("decodeCursor(edge cursor) error = %q, want 'different Scan RPC'", err)
+	}
+
+	vertexCursor := encodeCursor(scanCursor{LastKey: "users/42"})
+	if _, err := decodeEdgesCursor(vertexCursor); err == nil {
+		t.Fatalf("decodeEdgesCursor(vertex cursor) = nil error, want rejection")
+	} else if !strings.Contains(err.Error(), "different Scan RPC") {
+		t.Errorf("decodeEdgesCursor(vertex cursor) error = %q, want 'different Scan RPC'", err)
 	}
 }

--- a/tests/integration/cursor_cross_rpc_test.go
+++ b/tests/integration/cursor_cross_rpc_test.go
@@ -1,0 +1,70 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestSDK_Cursor_CrossRPC_Rejected is the end-to-end pin for #168: a
+// next_cursor minted by ScanVertices, fed back into ScanEdges (and vice
+// versa), must surface as INVALID_ARGUMENT rather than silently restart
+// the scan. Exercises the full bufconn wire path so the proto comments
+// and server-side discriminator decode stay honest.
+func TestSDK_Cursor_CrossRPC_Rejected(t *testing.T) {
+	l, cleanup := newPrefixSDKClient(t)
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Seed enough vertices that limit=1 forces a non-empty NextCursor.
+	seedPrefixVertices(t, ctx, l, []string{"a/1", "a/2", "a/3"})
+	// And enough edges that an edge scan can also paginate.
+	seedPrefixEdges(t, ctx, l, [][2]string{
+		{"a/1", "b/1"}, {"a/2", "b/2"},
+	})
+
+	_, vertexCursor, err := l.ScanVertices(ctx, "a/", client.WithScanLimit(1))
+	if err != nil {
+		t.Fatalf("ScanVertices: %v", err)
+	}
+	if len(vertexCursor) == 0 {
+		t.Fatalf("ScanVertices returned empty cursor; cannot exercise cross-feed")
+	}
+
+	_, edgeCursor, err := l.ScanEdges(ctx,
+		client.WithEdgeScanTailPrefix("a/"),
+		client.WithEdgeScanLimit(1),
+	)
+	if err != nil {
+		t.Fatalf("ScanEdges: %v", err)
+	}
+	if len(edgeCursor) == 0 {
+		t.Fatalf("ScanEdges returned empty cursor; cannot exercise cross-feed")
+	}
+
+	// Vertex cursor -> ScanEdges must reject.
+	if _, _, err := l.ScanEdges(ctx,
+		client.WithEdgeScanTailPrefix("a/"),
+		client.WithEdgeScanLimit(1),
+		client.WithEdgeScanCursor(vertexCursor),
+	); err == nil {
+		t.Fatalf("ScanEdges(vertex cursor) = nil error, want InvalidArgument")
+	} else if got := status.Code(err); got != codes.InvalidArgument {
+		t.Errorf("ScanEdges(vertex cursor) code = %s, want InvalidArgument", got)
+	}
+
+	// Edge cursor -> ScanVertices must reject.
+	if _, _, err := l.ScanVertices(ctx, "a/",
+		client.WithScanLimit(1),
+		client.WithScanCursor(edgeCursor),
+	); err == nil {
+		t.Fatalf("ScanVertices(edge cursor) = nil error, want InvalidArgument")
+	} else if got := status.Code(err); got != codes.InvalidArgument {
+		t.Errorf("ScanVertices(edge cursor) code = %s, want InvalidArgument", got)
+	}
+}


### PR DESCRIPTION
Closes #168.

## Problem

A `next_cursor` minted by `ScanVertices` and accidentally fed into `ScanEdges` (or vice versa) used to silently restart the scan from the beginning of the keyspace, because each decoder ignored fields it didn't care about. This is a real footgun for paginating clients.

## Fix

Make cursors self-describe their originating RPC at decode time, without changing the on-wire format.

- **`server/service/cursor.go`** — introduce a `cursorEnvelope` discriminator that unmarshals all four possible fields (`v`, `k`, `t`, `h`) and then dispatches based on which is populated. `decodeCursor` rejects cursors carrying `LastTail`/`LastHead`; `decodeEdgesCursor` rejects cursors carrying `LastKey`. Both emit a friendly `different Scan RPC` error that the existing `prefix.go` handlers already forward as `codes.InvalidArgument`.
- **`proto/graph/v1/graph.proto`** — `NOTE` comments on both `ScanVerticesRequest.cursor` and `ScanEdgesRequest.cursor` documenting opacity and non-interchangeability. Regenerated `pb/graph/v1/graph.pb.go` and the openapi swagger.
- **`server/service/cursor_test.go`** — new `TestCursor_RejectCrossRPC` pinning both directions at the decode layer.
- **`tests/integration/cursor_cross_rpc_test.go`** — bufconn end-to-end test that mints a real `ScanVertices` cursor, feeds it into `ScanEdges` (and the mirror case), and asserts `codes.InvalidArgument` over the wire.

## Wire-format preserving

`cursorVersion` stays at `1`; existing valid cursors continue to round-trip unchanged. Only cross-RPC reuse is rejected. This honors the issue's explicit "Out of scope: Changing the on-wire cursor format in a way that breaks existing clients" clause.

## Test

```
gofmt -l . cli core pb sdks server tests   # clean
(cd server && go vet ./... && go test ./...)   # PASS
(cd core    && go test ./...)                  # PASS
(cd pb      && go test ./...)                  # PASS
(cd sdks/go && go test ./...)                  # PASS
go test ./...                                  # PASS (cli + tests/integration)
```