### PR TITLE
cli: refresh `edge scan` help text to reflect per-tail head radix (#172)

### DIFF
--- a/cli/cmd/edge_prefix.go
+++ b/cli/cmd/edge_prefix.go
@@ -27,9 +27,12 @@ PREFIXES
   endpoint. Either may be omitted to leave that dimension unconstrained;
   omitting both scans every live edge.
 
-  v1 walks the vertex-side prefix index for the tail dimension and
-  applies --head-prefix as a post-filter, so a head-only scan is no
-  cheaper than a full scan. Combine the two prefixes when possible.
+  The server walks the vertex-side prefix index for the tail dimension
+  and, for each matching tail, probes a per-tail head radix to honour
+  --head-prefix as an index lookup (not a post-filter). A head-only
+  scan still has to iterate every tail because no global head->tails
+  reverse index exists, so combining both prefixes remains the most
+  efficient shape.
 
 PAGINATION
   Without --all the server returns at most --limit edges and an opaque


### PR DESCRIPTION
Closes #172.

## Summary

`cli/cmd/edge_prefix.go` Long help text claimed `--head-prefix` is applied as a post-filter and that a head-only scan is no cheaper than a full scan. That was true for the v1 implementation, but PR #170 (Issue #167) made the head dimension an index probe via a per-tail head radix.

Updated the text to describe current behavior:

- `--head-prefix` is an index lookup, not a post-filter.
- Head-only scans still iterate every tail because no global head→tails reverse index exists, so combining both prefixes remains the most efficient shape.

## Scope

- Doc-only change in one CLI string literal.
- No code paths touched. No proto / SDK / server change.

## Verification

- `gofmt -l . cli core pb sdks server tests` — clean.
- `go test ./...` in all 5 modules — green.
- `lantern edge scan --help` now describes the post-#167 behavior accurately.