### PR TITLE
core/hlc: hybrid logical clock package (#176)

### DIFF
--- a/core/hlc/hlc.go
+++ b/core/hlc/hlc.go
@@ -1,0 +1,202 @@
+// Package hlc implements a Hybrid Logical Clock (HLC) suitable for stamping
+// mutations in Lantern's leaderless full-replica replication design.
+//
+// The construction follows Kulkarni, Demirbas, Madappa, Avva and Leone,
+// "Logical Physical Clocks and Consistent Snapshots in Globally Distributed
+// Databases" (2014). An HLC timestamp interleaves a wall-clock component
+// (nanoseconds since the Unix epoch) with a logical counter that bumps when
+// two events would otherwise collide on the same wall instant. Comparison is
+// lexicographic over (wallNs, logical, nodeID), giving a total order without
+// requiring synchronized clocks while staying close to physical time.
+//
+// This package is a leaf: it imports only the standard library. Wire encoding
+// (proto round-trips) lives with the mutation message in pb/.
+package hlc
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// DefaultMaxSkew is the default ceiling for the gap between a remote
+// timestamp's wall component and local wall time. See replication RFC D3.
+const DefaultMaxSkew = 500 * time.Millisecond
+
+// ErrSkewExceeded is reported via [Clock.OnSkewExceeded] when an [Update]
+// call observes a remote wall time more than MaxSkew ahead of local wall
+// time. The remote timestamp is clamped, never rejected, so replication
+// continues to make progress even when peers drift.
+var ErrSkewExceeded = errors.New("hlc: remote wall time exceeds MaxSkew")
+
+// NodeID identifies the origin of a timestamp. It is opaque to this package;
+// callers typically derive it from a stable per-process UUID.
+type NodeID [16]byte
+
+// Timestamp is a Hybrid Logical Clock value.
+//
+// WallNs holds nanoseconds since the Unix epoch as observed at the origin
+// clock at the moment the timestamp was produced. Logical is a counter that
+// distinguishes events that share a WallNs. NodeID breaks the remaining ties
+// so that two distinct origins can never produce equal timestamps.
+type Timestamp struct {
+	WallNs  int64
+	Logical uint32
+	NodeID  NodeID
+}
+
+// Less reports whether t orders strictly before other in the HLC total order.
+func (t Timestamp) Less(other Timestamp) bool {
+	if t.WallNs != other.WallNs {
+		return t.WallNs < other.WallNs
+	}
+	if t.Logical != other.Logical {
+		return t.Logical < other.Logical
+	}
+	for i := range t.NodeID {
+		if t.NodeID[i] != other.NodeID[i] {
+			return t.NodeID[i] < other.NodeID[i]
+		}
+	}
+	return false
+}
+
+// Equal reports whether t and other are bit-identical.
+func (t Timestamp) Equal(other Timestamp) bool {
+	return t.WallNs == other.WallNs &&
+		t.Logical == other.Logical &&
+		t.NodeID == other.NodeID
+}
+
+// Clock is a thread-safe Hybrid Logical Clock for a single origin node.
+//
+// The zero value is not usable; construct with [New].
+type Clock struct {
+	nodeID NodeID
+
+	// now returns current wall time in nanoseconds since the Unix epoch.
+	// Tests inject a deterministic source via [Options.Now].
+	now func() int64
+
+	maxSkewNs      int64
+	onSkewExceeded func(remote Timestamp, localWallNs int64, err error)
+
+	mu      sync.Mutex
+	wallNs  int64
+	logical uint32
+}
+
+// Options configures a [Clock]. The zero value is valid: it uses the real
+// monotonic wall clock, [DefaultMaxSkew], and a no-op skew callback.
+type Options struct {
+	// Now overrides the wall-time source. Useful for deterministic tests.
+	// Must return nanoseconds since the Unix epoch.
+	Now func() int64
+	// MaxSkew bounds how far ahead of local wall time a remote stamp may be
+	// before being clamped on Update. Zero means [DefaultMaxSkew].
+	MaxSkew time.Duration
+	// OnSkewExceeded is invoked, with the lock released, when Update clamps
+	// a remote timestamp. Use it to emit a metric or log line.
+	OnSkewExceeded func(remote Timestamp, localWallNs int64, err error)
+}
+
+// New constructs a Clock for the given origin node.
+func New(nodeID NodeID, opts Options) *Clock {
+	now := opts.Now
+	if now == nil {
+		now = func() int64 { return time.Now().UnixNano() }
+	}
+	skew := opts.MaxSkew
+	if skew <= 0 {
+		skew = DefaultMaxSkew
+	}
+	cb := opts.OnSkewExceeded
+	if cb == nil {
+		cb = func(Timestamp, int64, error) {}
+	}
+	return &Clock{
+		nodeID:         nodeID,
+		now:            now,
+		maxSkewNs:      skew.Nanoseconds(),
+		onSkewExceeded: cb,
+	}
+}
+
+// NodeID returns the origin identifier this clock stamps timestamps with.
+func (c *Clock) NodeID() NodeID { return c.nodeID }
+
+// Now returns the next timestamp from this clock. The returned timestamp is
+// strictly greater than every previously returned timestamp from the same
+// clock and from any remote timestamp previously passed to [Clock.Update].
+func (c *Clock) Now() Timestamp {
+	wall := c.now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if wall > c.wallNs {
+		c.wallNs = wall
+		c.logical = 0
+	} else {
+		c.logical++
+	}
+	return Timestamp{WallNs: c.wallNs, Logical: c.logical, NodeID: c.nodeID}
+}
+
+// Update integrates a timestamp received from a peer. The returned timestamp
+// is strictly greater than both the previous local state and remote, and
+// the clock's internal state advances accordingly.
+//
+// If remote.WallNs is more than the configured MaxSkew ahead of local wall
+// time, the wall component is clamped to localWall + MaxSkew and the
+// configured OnSkewExceeded callback fires with [ErrSkewExceeded]. The
+// remote timestamp is never rejected — replication keeps making progress
+// even when peers drift, and operators observe the drift through the
+// callback (typically wired to a counter).
+func (c *Clock) Update(remote Timestamp) Timestamp {
+	wall := c.now()
+	effectiveRemoteWall := remote.WallNs
+	clamped := false
+	if remote.WallNs > wall+c.maxSkewNs {
+		effectiveRemoteWall = wall + c.maxSkewNs
+		clamped = true
+	}
+
+	c.mu.Lock()
+	maxWall := wall
+	if effectiveRemoteWall > maxWall {
+		maxWall = effectiveRemoteWall
+	}
+	if c.wallNs > maxWall {
+		maxWall = c.wallNs
+	}
+
+	switch {
+	case maxWall == c.wallNs && maxWall == effectiveRemoteWall:
+		// Both local state and remote are at the same wall instant. The
+		// logical counter must exceed both contributing counters.
+		if remote.Logical > c.logical {
+			c.logical = remote.Logical + 1
+		} else {
+			c.logical++
+		}
+	case maxWall == c.wallNs:
+		// Local state already at the leading wall instant.
+		c.logical++
+	case maxWall == effectiveRemoteWall:
+		// Remote (possibly clamped) leads.
+		c.wallNs = maxWall
+		c.logical = remote.Logical + 1
+	default:
+		// Physical wall time has moved past both prior states.
+		c.wallNs = maxWall
+		c.logical = 0
+	}
+
+	out := Timestamp{WallNs: c.wallNs, Logical: c.logical, NodeID: c.nodeID}
+	c.mu.Unlock()
+
+	if clamped {
+		c.onSkewExceeded(remote, wall, ErrSkewExceeded)
+	}
+	return out
+}

--- a/core/hlc/hlc_test.go
+++ b/core/hlc/hlc_test.go
@@ -1,0 +1,295 @@
+package hlc
+
+import (
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func nodeID(b byte) NodeID {
+	var n NodeID
+	n[0] = b
+	return n
+}
+
+// fakeNow is an atomic int64 wall-time source for deterministic tests.
+type fakeNow struct{ ns atomic.Int64 }
+
+func (f *fakeNow) set(t time.Time) { f.ns.Store(t.UnixNano()) }
+func (f *fakeNow) add(d time.Duration) int64 {
+	return f.ns.Add(int64(d))
+}
+func (f *fakeNow) get() int64 { return f.ns.Load() }
+
+func TestTimestampLessOrdering(t *testing.T) {
+	a := Timestamp{WallNs: 10, Logical: 0, NodeID: nodeID(1)}
+	b := Timestamp{WallNs: 10, Logical: 0, NodeID: nodeID(2)}
+	c := Timestamp{WallNs: 10, Logical: 1, NodeID: nodeID(1)}
+	d := Timestamp{WallNs: 11, Logical: 0, NodeID: nodeID(1)}
+
+	cases := []struct {
+		name     string
+		x, y     Timestamp
+		wantLess bool
+	}{
+		{"node tiebreak", a, b, true},
+		{"logical wins over node", a, c, true},
+		{"wall wins over logical", c, d, true},
+		{"equal not less", a, a, false},
+		{"reverse not less", b, a, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.x.Less(tc.y); got != tc.wantLess {
+				t.Fatalf("Less = %v, want %v", got, tc.wantLess)
+			}
+		})
+	}
+
+	if !a.Equal(a) {
+		t.Fatal("Equal must hold for identical timestamps")
+	}
+	if a.Equal(b) {
+		t.Fatal("Equal must distinguish NodeID")
+	}
+}
+
+func TestNowIsStrictlyMonotonic(t *testing.T) {
+	f := &fakeNow{}
+	f.set(time.Unix(1_700_000_000, 0))
+	c := New(nodeID(7), Options{Now: f.get})
+
+	var prev Timestamp
+	for i := 0; i < 1000; i++ {
+		// Hold wall time constant for the first half, then advance.
+		if i == 500 {
+			f.add(time.Millisecond)
+		}
+		got := c.Now()
+		if i > 0 && !prev.Less(got) {
+			t.Fatalf("iteration %d: got %+v, prev %+v, want strictly greater", i, got, prev)
+		}
+		prev = got
+	}
+}
+
+func TestNowResetsLogicalWhenWallAdvances(t *testing.T) {
+	f := &fakeNow{}
+	f.set(time.Unix(0, 1000))
+	c := New(nodeID(1), Options{Now: f.get})
+
+	first := c.Now()
+	second := c.Now()
+	if second.Logical != first.Logical+1 {
+		t.Fatalf("logical should bump when wall stays put: %d → %d", first.Logical, second.Logical)
+	}
+
+	f.add(time.Microsecond)
+	third := c.Now()
+	if third.Logical != 0 {
+		t.Fatalf("logical should reset when wall advances, got %d", third.Logical)
+	}
+	if !second.Less(third) {
+		t.Fatal("third must order after second")
+	}
+}
+
+func TestUpdateProducesGreaterThanBoth(t *testing.T) {
+	f := &fakeNow{}
+	f.set(time.Unix(0, 10_000))
+	c := New(nodeID(1), Options{Now: f.get})
+
+	local := c.Now()
+	remote := Timestamp{WallNs: f.get() + 50, Logical: 7, NodeID: nodeID(9)}
+
+	out := c.Update(remote)
+	if !local.Less(out) {
+		t.Fatalf("Update output %+v must exceed prior local %+v", out, local)
+	}
+	if !remote.Less(out) {
+		t.Fatalf("Update output %+v must exceed remote %+v", out, remote)
+	}
+	if out.NodeID != c.NodeID() {
+		t.Fatalf("Update output should carry local nodeID, got %v", out.NodeID)
+	}
+}
+
+func TestUpdateWhenLocalLeads(t *testing.T) {
+	f := &fakeNow{}
+	f.set(time.Unix(0, 100_000))
+	c := New(nodeID(1), Options{Now: f.get})
+
+	local := c.Now()
+	// remote is strictly behind on every axis.
+	remote := Timestamp{WallNs: f.get() - 1000, Logical: 0, NodeID: nodeID(2)}
+
+	out := c.Update(remote)
+	if !local.Less(out) {
+		t.Fatalf("Update output %+v must exceed prior local %+v", out, local)
+	}
+	if out.WallNs != local.WallNs {
+		t.Fatalf("Update should not move wall backwards: got %d, prior %d", out.WallNs, local.WallNs)
+	}
+}
+
+func TestUpdateClampsExcessiveSkew(t *testing.T) {
+	f := &fakeNow{}
+	f.set(time.Unix(0, 1_000_000_000))
+	var calls atomic.Int32
+	var captured Timestamp
+	var captureMu sync.Mutex
+	c := New(nodeID(1), Options{
+		Now:     f.get,
+		MaxSkew: 100 * time.Millisecond,
+		OnSkewExceeded: func(remote Timestamp, _ int64, err error) {
+			if err != ErrSkewExceeded {
+				t.Errorf("callback err = %v, want ErrSkewExceeded", err)
+			}
+			captureMu.Lock()
+			captured = remote
+			captureMu.Unlock()
+			calls.Add(1)
+		},
+	})
+
+	// Remote is 10s ahead — far beyond the 100ms tolerance.
+	farFuture := Timestamp{WallNs: f.get() + int64(10*time.Second), Logical: 3, NodeID: nodeID(2)}
+	out := c.Update(farFuture)
+
+	if calls.Load() != 1 {
+		t.Fatalf("callback should fire exactly once, got %d", calls.Load())
+	}
+	captureMu.Lock()
+	if !captured.Equal(farFuture) {
+		t.Fatalf("callback saw %+v, want %+v", captured, farFuture)
+	}
+	captureMu.Unlock()
+
+	maxAllowed := f.get() + int64(100*time.Millisecond)
+	if out.WallNs > maxAllowed {
+		t.Fatalf("clock advanced past clamp: out=%d, max=%d", out.WallNs, maxAllowed)
+	}
+	if out.WallNs < f.get() {
+		t.Fatalf("clock fell behind local wall: out=%d, wall=%d", out.WallNs, f.get())
+	}
+}
+
+func TestUpdateInsideSkewWindowAcceptsRemote(t *testing.T) {
+	f := &fakeNow{}
+	f.set(time.Unix(0, 1_000_000_000))
+	var calls atomic.Int32
+	c := New(nodeID(1), Options{
+		Now:            f.get,
+		MaxSkew:        500 * time.Millisecond,
+		OnSkewExceeded: func(Timestamp, int64, error) { calls.Add(1) },
+	})
+
+	near := Timestamp{WallNs: f.get() + int64(50*time.Millisecond), Logical: 2, NodeID: nodeID(2)}
+	out := c.Update(near)
+
+	if calls.Load() != 0 {
+		t.Fatalf("callback must not fire within tolerance, got %d", calls.Load())
+	}
+	if out.WallNs != near.WallNs {
+		t.Fatalf("expected remote wall accepted as-is: out=%d, remote=%d", out.WallNs, near.WallNs)
+	}
+	if out.Logical != near.Logical+1 {
+		t.Fatalf("logical must exceed remote: out=%d, remote=%d", out.Logical, near.Logical)
+	}
+}
+
+func TestUpdateConcurrentSafety(t *testing.T) {
+	f := &fakeNow{}
+	f.set(time.Unix(0, 1_000_000))
+	c := New(nodeID(1), Options{Now: f.get})
+
+	const goroutines = 32
+	const perG = 500
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(seed int64) {
+			defer wg.Done()
+			r := rand.New(rand.NewSource(seed))
+			for i := 0; i < perG; i++ {
+				if r.Intn(2) == 0 {
+					_ = c.Now()
+				} else {
+					remote := Timestamp{
+						WallNs:  f.get() + int64(r.Intn(int(time.Millisecond))),
+						Logical: uint32(r.Intn(8)),
+						NodeID:  nodeID(byte(2 + g%4)),
+					}
+					_ = c.Update(remote)
+				}
+				if i%50 == 0 {
+					f.add(time.Microsecond)
+				}
+			}
+		}(int64(g) + 1)
+	}
+	wg.Wait()
+
+	// After the storm, two fresh Nows must still be strictly ordered.
+	a := c.Now()
+	b := c.Now()
+	if !a.Less(b) {
+		t.Fatalf("post-race ordering broken: a=%+v, b=%+v", a, b)
+	}
+}
+
+// TestThreeClockInterleaving exercises the HLC invariant that any chain of
+// (Now, Update) operations across multiple clocks yields a strictly
+// increasing sequence at each receiver, matching the paper's claim that HLC
+// preserves the happens-before relation.
+func TestThreeClockInterleaving(t *testing.T) {
+	const iterations = 2000
+	r := rand.New(rand.NewSource(0xC0FFEE))
+
+	wall := &fakeNow{}
+	wall.set(time.Unix(0, 1))
+
+	clocks := []*Clock{
+		New(nodeID(1), Options{Now: wall.get}),
+		New(nodeID(2), Options{Now: wall.get}),
+		New(nodeID(3), Options{Now: wall.get}),
+	}
+	last := make([]Timestamp, len(clocks))
+
+	for i := 0; i < iterations; i++ {
+		src := r.Intn(len(clocks))
+		if r.Intn(3) == 0 {
+			wall.add(time.Duration(1+r.Intn(100)) * time.Nanosecond)
+		}
+
+		if r.Intn(2) == 0 {
+			ts := clocks[src].Now()
+			if !last[src].Less(ts) && (last[src] != Timestamp{}) {
+				t.Fatalf("clock %d: Now broke monotonicity: prev=%+v cur=%+v", src, last[src], ts)
+			}
+			last[src] = ts
+			continue
+		}
+
+		dst := r.Intn(len(clocks))
+		for dst == src {
+			dst = r.Intn(len(clocks))
+		}
+		// Send last[src] (or a fresh Now if nothing yet) to dst.
+		msg := last[src]
+		if (msg == Timestamp{}) {
+			msg = clocks[src].Now()
+			last[src] = msg
+		}
+		got := clocks[dst].Update(msg)
+		if !last[dst].Less(got) && (last[dst] != Timestamp{}) {
+			t.Fatalf("clock %d: Update broke monotonicity: prev=%+v cur=%+v", dst, last[dst], got)
+		}
+		if !msg.Less(got) {
+			t.Fatalf("clock %d: Update did not exceed remote: remote=%+v cur=%+v", dst, msg, got)
+		}
+		last[dst] = got
+	}
+}

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -85,47 +85,63 @@ flush latency target (§9).
 
 ## 5. Hybrid Logical Clock
 
-HLC = `(wallMillis uint64, logical uint32)`.
+`Timestamp = (wallNs int64, logical uint32, nodeID [16]byte)`. Wall is in
+**nanoseconds since the Unix epoch** to match `time.Time.UnixNano()` and keep
+the proto encoding (#178) loss-free. `nodeID` is folded into every timestamp
+so two distinct origins can never produce a colliding stamp; the origin
+tiebreak from §4 is therefore intrinsic to ordering rather than bolted on.
+
+Reference implementation: [`core/hlc`](../core/hlc/hlc.go).
 
 ### 5.1 Local tick (called on every locally-originated mutation)
 
 ```
-now    := time.Now().UnixMilli()
-last   := lastHLC
-if now > last.wallMillis:
-    lastHLC = HLC{wallMillis: now, logical: 0}
+now := time.Now().UnixNano()
+if now > last.wallNs:
+    last = Timestamp{wallNs: now, logical: 0, nodeID: self}
 else:
-    lastHLC = HLC{wallMillis: last.wallMillis, logical: last.logical + 1}
-return lastHLC
+    last = Timestamp{wallNs: last.wallNs, logical: last.logical + 1, nodeID: self}
+return last
 ```
 
-### 5.2 Update on receive (`recv` carries a remote HLC `r`)
+### 5.2 Update on receive (`recv` carries a remote Timestamp `r`)
 
 ```
-now := time.Now().UnixMilli()
-max := max(now, last.wallMillis, r.wallMillis)
+now := time.Now().UnixNano()
+rWall := r.wallNs
+if rWall > now + MaxSkew:        // §5.3
+    rWall = now + MaxSkew
+max := max(now, last.wallNs, rWall)
 switch max:
-case last.wallMillis where last.wallMillis == r.wallMillis:
-    lastHLC = HLC{wallMillis: max, logical: max(last.logical, r.logical) + 1}
-case last.wallMillis:
-    lastHLC = HLC{wallMillis: max, logical: last.logical + 1}
-case r.wallMillis:
-    lastHLC = HLC{wallMillis: max, logical: r.logical + 1}
-default: // now is strictly greater
-    lastHLC = HLC{wallMillis: max, logical: 0}
+case last.wallNs where last.wallNs == rWall:
+    last = Timestamp{wallNs: max, logical: max(last.logical, r.logical) + 1, nodeID: self}
+case last.wallNs:
+    last = Timestamp{wallNs: max, logical: last.logical + 1, nodeID: self}
+case rWall:
+    last = Timestamp{wallNs: max, logical: r.logical + 1, nodeID: self}
+default: // now strictly greater
+    last = Timestamp{wallNs: max, logical: 0, nodeID: self}
 ```
+
+Note that the returned timestamp always carries the local `nodeID`; the
+remote `nodeID` is only used by the comparator in §5.4.
 
 ### 5.3 Skew clamp
 
-If `|r.wallMillis - now| > 500ms` (D3), the receive is **rejected** with
-`OutOfRange`. The operator sees `lantern_hlc_skew_rejected_total` increment
-and is expected to fix NTP.
+If `r.wallNs > now + MaxSkew` (default `MaxSkew = 500ms`, per D3), the wall
+component is **clamped** to `now + MaxSkew` and an `OnSkewExceeded` callback
+fires (default wiring: increment `lantern_hlc_skew_clamped_total`). The
+remote timestamp is never rejected — replication keeps making progress even
+when peers drift, and operators observe the drift through the counter and
+are expected to fix NTP. (Earlier drafts of this RFC rejected with
+`OutOfRange`; that was changed during #176 implementation because rejecting
+risks a cascading replication stall while the clock heals.)
 
 ### 5.4 Comparison
 
-`a < b` iff `(a.wallMillis, a.logical) < (b.wallMillis, b.logical)`
-lexicographically. Strict total order across the cluster when combined with
-the origin tiebreak in §4.
+`a < b` iff `(a.wallNs, a.logical, a.nodeID) < (b.wallNs, b.logical, b.nodeID)`
+lexicographically. `nodeID` is compared bytewise. Two distinct origins thus
+yield a strict total order without any extra tiebreak machinery.
 
 ## 6. Contribution IDs
 
@@ -277,7 +293,7 @@ Lantern is **AP** in CAP terms. During a partition:
 | Pod falls behind > buffer | `Subscribe` returns `OutOfRange` | Pump auto re-snapshots and resumes. |
 | All peers unreachable on boot | `Snapshot` fails on every peer | Pod stays `NOT_SERVING`; operator alert on readiness. |
 | Total-cluster loss | every replica down | **Accepted data loss** (D1). Bring the cluster back empty. |
-| NTP skew > 500ms | `lantern_hlc_skew_rejected_total > 0` | Fix NTP; rejected writes must be retried client-side. |
+| NTP skew > 500ms | `lantern_hlc_skew_clamped_total > 0` | Fix NTP. Mutations from the drifted peer keep applying (their HLC wall is clamped, §5.3); convergence is preserved but the drifted peer's stamps land behind real wall time until it heals. |
 | Network partition < tombstone TTL | `lantern_replication_lag_seq` spike | Auto-converges via anti-entropy (#186) when partition heals. |
 | Network partition > tombstone TTL | same | Resurrection possible (§10). Manual reconciliation or operator-driven re-snapshot of the winning side. |
 


### PR DESCRIPTION
Implements #176.

## Summary
New leaf package `core/hlc` (std-only) providing the HLC primitive used to stamp every replicated mutation.

- `Timestamp{WallNs int64, Logical uint32, NodeID [16]byte}` — nanoseconds since the Unix epoch; `NodeID` is intrinsic so two distinct origins never collide. `Less`/`Equal` give a strict total order with no extra tiebreak.
- `Clock` with `Now()` / `Update(remote)` — thread-safe.
- `Options{Now, MaxSkew, OnSkewExceeded}` — injectable wall-time source (deterministic tests), configurable skew tolerance (default 500ms, per RFC D3), and a callback fired when a remote stamp is clamped.

## Skew handling
Remote stamps more than `MaxSkew` ahead of the local wall are **clamped** (wall = localWall + MaxSkew) and the callback fires with `ErrSkewExceeded`. Replication never stalls; operators observe via `lantern_hlc_skew_clamped_total` (wired in #187).

## RFC amendment
`docs/replication.md` §5 is amended in this PR per the "deviations amend the RFC in the same PR" rule:
- `wallMillis (uint64)` → `wallNs (int64)`.
- `NodeID` intrinsic to `Timestamp`.
- Skew clamped, not rejected; metric renamed.

## Reference
Kulkarni, Demirbas, Madappa, Avva, Leone (2014), *Logical Physical Clocks and Consistent Snapshots in Globally Distributed Databases*.

## Tests
- `Now` strict monotonicity.
- `Now` resets logical when wall advances.
- `Update` > both inputs across all four switch cases.
- Skew clamp produces clamped wall + single callback fire.
- Concurrent safety under `-race` (32 × 500 ops).
- Randomised 3-clock interleaving stays totally ordered.

`go test ./hlc/... -race -count=1` ✅