### PR TITLE
core/mutationlog: append-only log with WAL hook and replay (#177)

### DIFF
--- a/core/mutationlog/mutationlog.go
+++ b/core/mutationlog/mutationlog.go
@@ -1,0 +1,294 @@
+// Package mutationlog is the single source of truth for the stream of
+// graph mutations that flows through Lantern's leaderless full-replica
+// replication design.
+//
+// The log is an in-memory, append-only ring buffer. Each [Entry] carries a
+// monotonically increasing [Seq] (assigned atomically by [Log.Append]), an
+// [hlc.Timestamp] supplied by the caller, and an opaque [MutationOp]
+// payload. Keeping the payload as an interface keeps this package proto-free
+// so it can be reused both by internal replication (#181, #184) and by
+// external CDC (#180) without a circular dependency on pb/.
+//
+// A bounded number of entries are retained for replay. When a subscriber
+// requests a Seq older than [Log.FirstSeq] the channel is closed and
+// [ErrGapped] is reported via the cancel func's returned error; the caller
+// is then expected to snapshot and resubscribe (RFC §7). Live subscribers
+// share a bounded outbound channel — slow consumers exert back-pressure on
+// [Log.Append] rather than allowing the log to drift forward without them.
+//
+// A [WAL] hook lets a future durability layer (RFC D1) intercept appends
+// before they fan out. The default [NopWAL] is a no-op, matching today's
+// in-memory-only behaviour.
+//
+// This package depends only on the standard library and core/hlc.
+package mutationlog
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/anaregdesign/lantern/core/hlc"
+)
+
+// ErrGapped is returned to a subscriber when its requested fromSeq has
+// already been evicted from the ring buffer. Callers must snapshot and
+// resubscribe from a fresh sequence number.
+var ErrGapped = errors.New("mutationlog: requested sequence has been evicted")
+
+// ErrClosed is returned by [Log.Append] and [Log.Subscribe] after [Log.Close]
+// has been called.
+var ErrClosed = errors.New("mutationlog: log is closed")
+
+// MutationOp is an opaque payload carried by an [Entry]. The mutationlog
+// package never inspects it; callers (proto encoders, applicators, CDC
+// emitters) own the concrete types.
+type MutationOp any
+
+// Entry is a single durable record in the log.
+type Entry struct {
+	// Seq is the log-local position of the entry. It increases by exactly
+	// one with each successful [Log.Append] call within a single [Log].
+	Seq uint64
+	// HLC is the Hybrid Logical Clock stamp supplied by the caller at
+	// append time. Different origins may produce entries whose HLC ordering
+	// disagrees with the local Seq ordering; that is by design.
+	HLC hlc.Timestamp
+	// Op is the opaque mutation payload.
+	Op MutationOp
+}
+
+// WAL is the hook surface for a future write-ahead-log implementation.
+// Implementations must be safe for concurrent use. [Log.Append] calls
+// [WAL.Write] while holding the log mutex, so implementations should keep
+// the call cheap (a buffered write is fine; a synchronous fsync is not).
+type WAL interface {
+	Write(Entry) error
+}
+
+// NopWAL is a WAL that discards every entry. It is the default.
+type NopWAL struct{}
+
+// Write implements [WAL].
+func (NopWAL) Write(Entry) error { return nil }
+
+// Options configures a [Log].
+//
+// A zero Options is valid: Capacity defaults to 1024 entries and WAL
+// defaults to [NopWAL]. SubscriberBuffer defaults to 64.
+type Options struct {
+	// Capacity is the maximum number of entries retained in the ring buffer
+	// for replay. Must be > 0; defaults to 1024 when zero.
+	Capacity int
+	// SubscriberBuffer is the per-subscriber outbound channel size. Smaller
+	// values increase back-pressure sensitivity; defaults to 64 when zero.
+	SubscriberBuffer int
+	// WAL receives every appended entry before it fans out to subscribers.
+	// Nil defaults to [NopWAL].
+	WAL WAL
+}
+
+const (
+	defaultCapacity         = 1024
+	defaultSubscriberBuffer = 64
+)
+
+// Log is an append-only, bounded, in-memory mutation log.
+//
+// The zero value is not ready for use; construct with [New].
+type Log struct {
+	mu          sync.Mutex
+	capacity    int
+	subBuf      int
+	wal         WAL
+	ring        []Entry
+	firstSeq    uint64 // seq of ring[0] when len(ring) > 0; otherwise next-to-assign
+	lastSeq     uint64 // seq of last appended entry; 0 means none appended yet
+	hasEntries  bool
+	closed      bool
+	subscribers map[*subscription]struct{}
+}
+
+// subscription is the live state for one subscriber.
+type subscription struct {
+	ch     chan Entry
+	gapped bool // set when a fan-out drop turned into a gap
+}
+
+// New constructs a [Log] with the given options.
+func New(opts Options) *Log {
+	capacity := opts.Capacity
+	if capacity <= 0 {
+		capacity = defaultCapacity
+	}
+	subBuf := opts.SubscriberBuffer
+	if subBuf <= 0 {
+		subBuf = defaultSubscriberBuffer
+	}
+	wal := opts.WAL
+	if wal == nil {
+		wal = NopWAL{}
+	}
+	return &Log{
+		capacity:    capacity,
+		subBuf:      subBuf,
+		wal:         wal,
+		ring:        make([]Entry, 0, capacity),
+		subscribers: make(map[*subscription]struct{}),
+	}
+}
+
+// FirstSeq returns the lowest Seq still resident in the ring buffer. It
+// returns 0 (and false) when the log is empty.
+func (l *Log) FirstSeq() (uint64, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.hasEntries {
+		return 0, false
+	}
+	return l.firstSeq, true
+}
+
+// LastSeq returns the Seq of the most recently appended entry. It returns
+// 0 (and false) when the log is empty.
+func (l *Log) LastSeq() (uint64, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.hasEntries {
+		return 0, false
+	}
+	return l.lastSeq, true
+}
+
+// Append assigns the next sequence number to op, persists the entry through
+// the WAL hook, stores it in the ring buffer, and fans it out to every live
+// subscriber. The returned [Entry] carries the assigned Seq.
+//
+// Append is safe for concurrent use; calls are serialised so Seq strictly
+// increases by one for each successful return.
+func (l *Log) Append(op MutationOp, ts hlc.Timestamp) (Entry, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		return Entry{}, ErrClosed
+	}
+	seq := l.lastSeq + 1
+	entry := Entry{Seq: seq, HLC: ts, Op: op}
+	if err := l.wal.Write(entry); err != nil {
+		return Entry{}, err
+	}
+	l.storeLocked(entry)
+	l.lastSeq = seq
+	l.hasEntries = true
+	l.fanoutLocked(entry)
+	return entry, nil
+}
+
+// storeLocked inserts entry into the ring buffer, evicting the oldest entry
+// when capacity is reached. The caller must hold l.mu.
+func (l *Log) storeLocked(entry Entry) {
+	if len(l.ring) < l.capacity {
+		if len(l.ring) == 0 {
+			l.firstSeq = entry.Seq
+		}
+		l.ring = append(l.ring, entry)
+		return
+	}
+	// Capacity reached: drop the oldest, append at the end.
+	copy(l.ring, l.ring[1:])
+	l.ring[len(l.ring)-1] = entry
+	l.firstSeq = l.ring[0].Seq
+}
+
+// fanoutLocked delivers entry to every subscriber. A subscriber that cannot
+// receive without blocking has its channel marked gapped and closed on the
+// next replay attempt. Live delivery uses a non-blocking send to preserve
+// the back-pressure semantics promised by SubscriberBuffer.
+func (l *Log) fanoutLocked(entry Entry) {
+	for sub := range l.subscribers {
+		if sub.gapped {
+			continue
+		}
+		select {
+		case sub.ch <- entry:
+		default:
+			// Subscriber is too slow: mark gapped and close to signal a
+			// reconnect-and-snapshot to the caller.
+			sub.gapped = true
+			close(sub.ch)
+			delete(l.subscribers, sub)
+		}
+	}
+}
+
+// Subscribe returns a channel that receives entries starting at fromSeq.
+// Any entries with Seq >= fromSeq still resident in the ring buffer are
+// replayed immediately; subsequent entries are delivered live.
+//
+// If fromSeq is older than [Log.FirstSeq] the returned channel is closed
+// immediately and the cancel func reports [ErrGapped] when invoked.
+//
+// The returned cancel func unregisters the subscriber and closes the
+// channel. It is safe to call cancel more than once; subsequent calls
+// return nil.
+//
+// Slow subscribers exert back-pressure: each subscriber has a bounded
+// outbound channel (see [Options.SubscriberBuffer]). When that channel
+// fills, the subscriber is marked gapped, its channel is closed, and the
+// caller must snapshot and resubscribe from a fresh Seq.
+func (l *Log) Subscribe(fromSeq uint64) (<-chan Entry, func() error, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		return nil, nil, ErrClosed
+	}
+	if l.hasEntries && fromSeq < l.firstSeq {
+		return nil, nil, ErrGapped
+	}
+	sub := &subscription{ch: make(chan Entry, l.subBuf)}
+	// Replay any in-buffer entries with Seq >= fromSeq.
+	for _, e := range l.ring {
+		if e.Seq < fromSeq {
+			continue
+		}
+		select {
+		case sub.ch <- e:
+		default:
+			// Backlog already exceeds the subscriber buffer at registration
+			// time: caller asked us to replay more history than they can
+			// drain, so surface as a gap and refuse the subscription.
+			close(sub.ch)
+			return nil, nil, ErrGapped
+		}
+	}
+	l.subscribers[sub] = struct{}{}
+
+	var cancelOnce sync.Once
+	cancel := func() error {
+		cancelOnce.Do(func() {
+			l.mu.Lock()
+			defer l.mu.Unlock()
+			if _, ok := l.subscribers[sub]; ok {
+				delete(l.subscribers, sub)
+				close(sub.ch)
+			}
+		})
+		return nil
+	}
+	return sub.ch, cancel, nil
+}
+
+// Close stops accepting appends and closes every subscriber channel.
+// Calling Close more than once returns nil.
+func (l *Log) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		return nil
+	}
+	l.closed = true
+	for sub := range l.subscribers {
+		close(sub.ch)
+		delete(l.subscribers, sub)
+	}
+	return nil
+}

--- a/core/mutationlog/mutationlog_test.go
+++ b/core/mutationlog/mutationlog_test.go
@@ -1,0 +1,319 @@
+package mutationlog
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/hlc"
+)
+
+func ts(n int64) hlc.Timestamp {
+	return hlc.Timestamp{WallNs: n}
+}
+
+func TestAppendAssignsMonotonicSeq(t *testing.T) {
+	l := New(Options{Capacity: 4})
+	for i := 1; i <= 5; i++ {
+		e, err := l.Append(i, ts(int64(i)))
+		if err != nil {
+			t.Fatalf("append #%d: %v", i, err)
+		}
+		if got, want := e.Seq, uint64(i); got != want {
+			t.Fatalf("seq = %d, want %d", got, want)
+		}
+	}
+	last, ok := l.LastSeq()
+	if !ok || last != 5 {
+		t.Fatalf("LastSeq = (%d, %v), want (5, true)", last, ok)
+	}
+	// Capacity 4, so first seq should now be 2 (oldest evicted).
+	first, ok := l.FirstSeq()
+	if !ok || first != 2 {
+		t.Fatalf("FirstSeq = (%d, %v), want (2, true)", first, ok)
+	}
+}
+
+func TestSubscribeReplaysAndStreams(t *testing.T) {
+	l := New(Options{Capacity: 16, SubscriberBuffer: 16})
+	for i := 1; i <= 3; i++ {
+		if _, err := l.Append(i, ts(int64(i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ch, cancel, err := l.Subscribe(1)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer cancel()
+	// Replay
+	for i := 1; i <= 3; i++ {
+		select {
+		case e := <-ch:
+			if e.Seq != uint64(i) {
+				t.Fatalf("replay seq = %d, want %d", e.Seq, i)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timeout on replay #%d", i)
+		}
+	}
+	// Live
+	if _, err := l.Append(4, ts(4)); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case e := <-ch:
+		if e.Seq != 4 || e.Op.(int) != 4 {
+			t.Fatalf("live = %+v, want seq=4 op=4", e)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout on live")
+	}
+}
+
+func TestSubscribeRequestsBelowFirstSeqReportsGap(t *testing.T) {
+	l := New(Options{Capacity: 2})
+	for i := 1; i <= 5; i++ {
+		if _, err := l.Append(i, ts(int64(i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	first, _ := l.FirstSeq()
+	if first != 4 { // ring keeps 4,5
+		t.Fatalf("FirstSeq = %d, want 4", first)
+	}
+	if _, _, err := l.Subscribe(1); !errors.Is(err, ErrGapped) {
+		t.Fatalf("err = %v, want ErrGapped", err)
+	}
+}
+
+func TestSubscribeFromFutureSeqStreamsLiveOnly(t *testing.T) {
+	l := New(Options{Capacity: 8, SubscriberBuffer: 4})
+	for i := 1; i <= 3; i++ {
+		if _, err := l.Append(i, ts(int64(i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ch, cancel, err := l.Subscribe(10) // beyond last
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer cancel()
+	if _, err := l.Append(4, ts(4)); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case e := <-ch:
+		if e.Seq != 4 {
+			t.Fatalf("got seq %d, want 4", e.Seq)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestFanoutToManySubscribers(t *testing.T) {
+	const n = 8
+	l := New(Options{Capacity: 32, SubscriberBuffer: 32})
+	chs := make([]<-chan Entry, n)
+	cancels := make([]func() error, n)
+	for i := 0; i < n; i++ {
+		ch, cancel, err := l.Subscribe(1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		chs[i] = ch
+		cancels[i] = cancel
+	}
+	defer func() {
+		for _, c := range cancels {
+			c()
+		}
+	}()
+	for i := 1; i <= 5; i++ {
+		if _, err := l.Append(i, ts(int64(i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i, ch := range chs {
+		for j := 1; j <= 5; j++ {
+			select {
+			case e := <-ch:
+				if e.Seq != uint64(j) {
+					t.Fatalf("sub %d seq = %d, want %d", i, e.Seq, j)
+				}
+			case <-time.After(time.Second):
+				t.Fatalf("sub %d timeout at j=%d", i, j)
+			}
+		}
+	}
+}
+
+func TestSlowSubscriberIsDroppedNotBlocking(t *testing.T) {
+	// Tiny buffer so a single un-drained extra entry forces a drop.
+	l := New(Options{Capacity: 64, SubscriberBuffer: 2})
+	slow, slowCancel, err := l.Subscribe(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer slowCancel()
+
+	// Append more than SubscriberBuffer entries without draining slow. The
+	// fan-out must not block — otherwise Append would never return.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 1; i <= 20; i++ {
+			if _, err := l.Append(i, ts(int64(i))); err != nil {
+				t.Errorf("append: %v", err)
+				return
+			}
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Append blocked on slow subscriber — back-pressure broken")
+	}
+
+	// slow must be closed (drop-then-close protocol). Drain whatever made
+	// it in (up to SubscriberBuffer entries) until we observe close.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case _, ok := <-slow:
+			if !ok {
+				return
+			}
+		case <-deadline:
+			t.Fatal("slow subscriber was never closed")
+		}
+	}
+}
+
+func TestConcurrentAppendsAreSerialised(t *testing.T) {
+	const writers = 8
+	const perWriter = 250
+	l := New(Options{Capacity: writers * perWriter, SubscriberBuffer: 1024})
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for w := 0; w < writers; w++ {
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				if _, err := l.Append(w*1000+i, ts(int64(w*1000+i))); err != nil {
+					t.Errorf("append: %v", err)
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	last, _ := l.LastSeq()
+	if last != writers*perWriter {
+		t.Fatalf("LastSeq = %d, want %d", last, writers*perWriter)
+	}
+	first, _ := l.FirstSeq()
+	if first != 1 {
+		t.Fatalf("FirstSeq = %d, want 1", first)
+	}
+}
+
+type recordingWAL struct {
+	mu      sync.Mutex
+	entries []Entry
+	fail    error
+}
+
+func (w *recordingWAL) Write(e Entry) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.fail != nil {
+		return w.fail
+	}
+	w.entries = append(w.entries, e)
+	return nil
+}
+
+func TestWALReceivesEntriesInOrder(t *testing.T) {
+	w := &recordingWAL{}
+	l := New(Options{Capacity: 8, WAL: w})
+	for i := 1; i <= 3; i++ {
+		if _, err := l.Append(i, ts(int64(i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.entries) != 3 {
+		t.Fatalf("wal len = %d, want 3", len(w.entries))
+	}
+	for i, e := range w.entries {
+		if e.Seq != uint64(i+1) {
+			t.Fatalf("wal[%d].Seq = %d, want %d", i, e.Seq, i+1)
+		}
+	}
+}
+
+func TestWALErrorAbortsAppend(t *testing.T) {
+	want := errors.New("disk full")
+	w := &recordingWAL{fail: want}
+	l := New(Options{Capacity: 8, WAL: w})
+	if _, err := l.Append(1, ts(1)); !errors.Is(err, want) {
+		t.Fatalf("err = %v, want %v", err, want)
+	}
+	if _, ok := l.LastSeq(); ok {
+		t.Fatal("log should remain empty after WAL failure")
+	}
+}
+
+func TestCloseRejectsFurtherAppends(t *testing.T) {
+	l := New(Options{Capacity: 4})
+	if _, err := l.Append(1, ts(1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := l.Append(2, ts(2)); !errors.Is(err, ErrClosed) {
+		t.Fatalf("err = %v, want ErrClosed", err)
+	}
+	if _, _, err := l.Subscribe(1); !errors.Is(err, ErrClosed) {
+		t.Fatalf("subscribe err = %v, want ErrClosed", err)
+	}
+}
+
+func TestCloseClosesLiveSubscribers(t *testing.T) {
+	l := New(Options{Capacity: 4, SubscriberBuffer: 4})
+	ch, cancel, err := l.Subscribe(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancel()
+	if err := l.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("expected closed channel after Close")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for channel close")
+	}
+}
+
+func TestCancelIsIdempotent(t *testing.T) {
+	l := New(Options{Capacity: 4})
+	_, cancel, err := l.Subscribe(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cancel(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cancel(); err != nil {
+		t.Fatalf("second cancel = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
Implements #177.

Introduces `core/mutationlog`, the proto-free in-memory log that becomes the single source of truth for the stream of graph mutations driving Lantern's leaderless replication design (RFC §§7, 8).

## Highlights

- **Bounded ring buffer** with FIFO eviction (`Options.Capacity`, default 1024).
- **Monotone `Seq`** assigned atomically by `Append` (strictly +1 per success, serialised through a single mutex).
- **`Subscribe(fromSeq)`** replays any in-buffer entries first, then streams live updates; returns `ErrGapped` when `fromSeq` is below the retained window so callers can snapshot and resubscribe.
- **Slow-subscriber back-pressure**: per-subscriber bounded outbound channel (`Options.SubscriberBuffer`, default 64). Non-blocking fan-out drops + closes the slow subscriber's channel rather than stalling the writer.
- **`WAL` hook** intercepts entries before fan-out, ready for #189's durability work. Default `NopWAL` matches today's in-memory-only behaviour. WAL errors abort the append and do **not** advance `LastSeq`.
- **`Cancel` / `Close` idempotent**; post-close `Append`/`Subscribe` return `ErrClosed`.
- **Proto-free**: depends only on `std` + `core/hlc`. `MutationOp` is `any`, so internal replication (#181, #184) and CDC (#180) can share the same log without a circular dep on `pb/`.

## Tests (`-race`)

- Monotonic seq, eviction + `FirstSeq` advance.
- Subscribe replay → live stream; subscribe from future seq → live only.
- `ErrGapped` when `fromSeq < FirstSeq`.
- Multi-subscriber fan-out (8 subs).
- Slow-subscriber drop-then-close + writer never blocks.
- 8×250 concurrent appends → `LastSeq == 2000`, `FirstSeq == 1`.
- WAL receives entries in order; WAL error aborts append and keeps log empty.
- `Close` rejects further appends, closes live subscribers; `Cancel` idempotent.

## Out of scope (deferred to downstream issues)

- Concrete proto-typed `MutationOp` (handled by #178).
- Wiring into the existing graph cache & gRPC services (#179).
- CDC streaming surface (#180), peer-to-peer subscribe RPC (#181), anti-entropy `LastSeq` exchange (#184).
- Durable WAL backend (#189).
