### PR TITLE
feat(server): implement LanternReplicationService.Subscribe handler (#180)

### DIFF
--- a/docs/replication.md
+++ b/docs/replication.md
@@ -276,6 +276,28 @@ seq, or (b) the consumer's send buffer overflows. In both cases the pump
 (§9) must re-bootstrap via `Snapshot` and resume `Subscribe` from the
 snapshot's cutoff seq.
 
+Handler implementation notes (issue #180):
+
+- The handler is `service.LanternReplicationService` in
+  `server/service/replication.go`; it is wired in `server/cmd/wire.go`
+  alongside `LanternService` and shares the same `*mutationlog.Log` as
+  the write path.
+- The handler maps `mutationlog.ErrGapped` to `codes.FailedPrecondition`
+  with the reason `"gapped"`, both at subscribe time (initial check) and
+  when the in-flight channel is closed by the log's slow-subscriber
+  eviction. This matches the wire contract above.
+- The handler shallow-copies the buffered `*pb.Mutation` into the
+  outbound `SubscribeResponse.Mutation` while overwriting `Seq` with
+  `entry.Seq`. The write path stores `Seq=0` on the buffered Mutation;
+  only Subscribe stamps it. Peer-pump apply (`#182`) must therefore
+  read `Seq` from the streamed envelope.
+- Health: a separate service name `graph.v1.LanternReplicationService`
+  is registered with the grpc health server and flipped to
+  `NOT_SERVING` on shutdown alongside `LanternService`.
+- Metrics: `lantern_subscribe_active_streams` (gauge) and
+  `lantern_subscribe_dropped_total{reason}` (counter; `reason ∈ {gapped,
+  send_failed}`) are pre-rendered in `server/metrics/metrics.go`.
+
 ### 8.3 Snapshot (server streaming)
 
 ```proto

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -86,6 +86,20 @@ func newLanternService(
 		WithLogger(logger)
 }
 
+// newLanternReplicationService wires the streaming replication surface so it
+// shares the same *mutationlog.Log as the write path. Metrics are attached
+// here (rather than inside the service) to keep service/ free of
+// provider/metrics imports.
+func newLanternReplicationService(
+	log *mutationlog.Log,
+	logger *slog.Logger,
+	dm *domainmetrics.DomainMetrics,
+) *service.LanternReplicationService {
+	return service.NewLanternReplicationService(log).
+		WithMetrics(dm).
+		WithLogger(logger)
+}
+
 func (a *App) Run(ctx context.Context) error {
 	a.health.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 

--- a/server/cmd/wire.go
+++ b/server/cmd/wire.go
@@ -40,6 +40,7 @@ func initializeApp() (*App, error) {
 		provider.NewMetricsServer,
 		provider.NewLifecycleConfig,
 		newLanternService,
+		newLanternReplicationService,
 		service.NewLanternServer,
 		wire.Bind(new(service.HealthSetter), new(*health.Server)),
 		wire.Bind(new(service.Backend), new(*graph.GraphCache[string, *pb.Vertex])),

--- a/server/cmd/wire_gen.go
+++ b/server/cmd/wire_gen.go
@@ -27,6 +27,7 @@ func initializeApp() (*App, error) {
 	replicationConfig := provider.NewReplicationConfig(config)
 	clock := provider.NewHLCClock(replicationConfig)
 	lanternService := newLanternService(graphCache, scanConfig, logger, log, clock, domainMetrics)
+	lanternReplicationService := newLanternReplicationService(log, logger, domainMetrics)
 	netConfig := provider.NewNetConfig(config)
 	tlsConfig := provider.NewTLSConfig(config)
 	rateLimitConfig := provider.NewRateLimitConfig(config)
@@ -44,7 +45,7 @@ func initializeApp() (*App, error) {
 	shutdownConfig := provider.NewShutdownConfig(config)
 	lifecycleConfig := provider.NewLifecycleConfig(cacheConfig, shutdownConfig)
 	healthServer := provider.NewHealthServer()
-	lanternServer := service.NewLanternServer(lanternService, server, listener, logger, lifecycleConfig, healthServer, graphCache)
+	lanternServer := service.NewLanternServer(lanternService, lanternReplicationService, server, listener, logger, lifecycleConfig, healthServer, graphCache)
 	metricsServer := provider.NewMetricsServer(observabilityConfig, registry, logger)
 	tracing, err := provider.NewTracing(logger)
 	if err != nil {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -29,6 +29,8 @@ type DomainMetrics struct {
 	buildInfo           *prometheus.GaugeVec
 	mutationLogEntries  prometheus.Counter
 	mutationLogCapacity prometheus.Gauge
+	subscribeActive     prometheus.Gauge
+	subscribeDropped    *prometheus.CounterVec
 
 	sampleInterval time.Duration
 	sample         Sampler
@@ -81,11 +83,24 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 			Name: "lantern_mutation_log_capacity",
 			Help: "Configured capacity (ring buffer slots) of the in-memory mutation log.",
 		}),
+		subscribeActive: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "lantern_subscribe_active_streams",
+			Help: "Number of currently active LanternReplicationService.Subscribe streams.",
+		}),
+		subscribeDropped: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "lantern_subscribe_dropped_total",
+			Help: "Total Subscribe streams terminated abnormally, partitioned by reason (gapped, send_failed).",
+		}, []string{"reason"}),
 		sampleInterval: opts.SampleInterval,
 	}
 
 	reg.MustRegister(m.vertices, m.edges, m.expirations, m.gcDuration, m.buildInfo,
-		m.mutationLogEntries, m.mutationLogCapacity)
+		m.mutationLogEntries, m.mutationLogCapacity, m.subscribeActive, m.subscribeDropped)
+
+	// Pre-create label rows so empty counters scrape as 0.
+	for _, r := range []string{"gapped", "send_failed"} {
+		m.subscribeDropped.WithLabelValues(r)
+	}
 
 	// Pre-create label rows so empty counters are still scraped as 0.
 	for _, k := range []string{"vertex", "edge", "dangling_edge"} {
@@ -130,6 +145,24 @@ func (m *DomainMetrics) OnMutationLogAppend() {
 // slots) of the mutation log. Called once at startup.
 func (m *DomainMetrics) SetMutationLogCapacity(n int) {
 	m.mutationLogCapacity.Set(float64(n))
+}
+
+// OnSubscribeStarted increments the active-streams gauge. Pair with
+// OnSubscribeEnded via defer.
+func (m *DomainMetrics) OnSubscribeStarted() {
+	m.subscribeActive.Inc()
+}
+
+// OnSubscribeEnded decrements the active-streams gauge.
+func (m *DomainMetrics) OnSubscribeEnded() {
+	m.subscribeActive.Dec()
+}
+
+// OnSubscribeDropped increments the dropped-streams counter for the given
+// reason ("gapped" or "send_failed"). Other reasons are accepted but
+// dashboards may not pre-render them.
+func (m *DomainMetrics) OnSubscribeDropped(reason string) {
+	m.subscribeDropped.WithLabelValues(reason).Inc()
 }
 
 // BindSampler stores the gauge-population callback. Must be called before

--- a/server/service/replication.go
+++ b/server/service/replication.go
@@ -1,0 +1,154 @@
+package service
+
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/anaregdesign/lantern/core/mutationlog"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ReplicationServiceName is the fully-qualified gRPC service name for the
+// replication surface. Used for per-service health reporting.
+const ReplicationServiceName = "graph.v1.LanternReplicationService"
+
+// SubscribeMetrics is the narrow surface the replication service uses to
+// publish per-stream metrics. *server/metrics.DomainMetrics satisfies it.
+// Defined here so the service stays independent of provider/metrics.
+type SubscribeMetrics interface {
+	OnSubscribeStarted()
+	OnSubscribeEnded()
+	OnSubscribeDropped(reason string)
+}
+
+// nopSubscribeMetrics is the default when no metrics handle is wired (test
+// path). All methods are no-ops.
+type nopSubscribeMetrics struct{}
+
+func (nopSubscribeMetrics) OnSubscribeStarted()       {}
+func (nopSubscribeMetrics) OnSubscribeEnded()         {}
+func (nopSubscribeMetrics) OnSubscribeDropped(string) {}
+
+// LanternReplicationService implements pb.LanternReplicationServiceServer.
+// It exposes the mutation log as a resumable, back-pressured server-streaming
+// RPC for peer replication and CDC consumers.
+//
+// The service holds a reference to the same *mutationlog.Log that
+// LanternService.WithReplication wired into the write path, so subscribers
+// see every successfully appended mutation in seq order.
+type LanternReplicationService struct {
+	pb.UnimplementedLanternReplicationServiceServer
+	log     *mutationlog.Log
+	metrics SubscribeMetrics
+	logger  *slog.Logger
+}
+
+// NewLanternReplicationService constructs the service. log MUST be the same
+// instance handed to LanternService.WithReplication; otherwise subscribers
+// will not see locally-originated mutations.
+func NewLanternReplicationService(log *mutationlog.Log) *LanternReplicationService {
+	return &LanternReplicationService{log: log, metrics: nopSubscribeMetrics{}}
+}
+
+// WithMetrics attaches a SubscribeMetrics handle. Nil is treated as the
+// no-op implementation so test wiring stays simple.
+func (s *LanternReplicationService) WithMetrics(m SubscribeMetrics) *LanternReplicationService {
+	if m == nil {
+		s.metrics = nopSubscribeMetrics{}
+	} else {
+		s.metrics = m
+	}
+	return s
+}
+
+// WithLogger replaces the slog handle used for replication-side warnings.
+// Defaults to slog.Default() when unset.
+func (s *LanternReplicationService) WithLogger(l *slog.Logger) *LanternReplicationService {
+	s.logger = l
+	return s
+}
+
+// Subscribe implements pb.LanternReplicationServiceServer.
+//
+// Flow:
+//  1. Open a subscription on the mutation log starting at req.FromSeq.
+//     If FromSeq is below the ring's firstSeq the log returns ErrGapped
+//     and we surface FailedPrecondition + reason "gapped" so the client
+//     knows to snapshot and resubscribe (see RFC §8.2).
+//  2. Drain the subscription channel and forward each entry as a
+//     SubscribeResponse. The Mutation stored on the entry already carries
+//     hlc/origin/op; we shallow-copy it to overwrite Seq with the
+//     authoritative value from the log entry (the stored Mutation has
+//     Seq=0 because the log assigns seq at Append time).
+//  3. If the channel is closed mid-stream the subscriber fell behind the
+//     per-subscriber buffer (Options.SubscriberBuffer). Surface this as
+//     FailedPrecondition + "gapped" — symmetric with case 1.
+//  4. Honor stream.Context() cancellation throughout.
+//
+// Send errors terminate the stream and increment dropped{reason="send_failed"}.
+func (s *LanternReplicationService) Subscribe(req *pb.SubscribeRequest, stream grpc.ServerStreamingServer[pb.SubscribeResponse]) error {
+	if s.log == nil {
+		return status.Error(codes.Unavailable, "replication is not enabled on this server")
+	}
+	ch, cancel, err := s.log.Subscribe(req.GetFromSeq())
+	if err != nil {
+		if errors.Is(err, mutationlog.ErrGapped) {
+			s.metrics.OnSubscribeDropped("gapped")
+			return status.Errorf(codes.FailedPrecondition,
+				"gapped: from_seq=%d is older than the first available seq; snapshot and resubscribe",
+				req.GetFromSeq())
+		}
+		return status.Errorf(codes.Unavailable, "subscribe failed: %v", err)
+	}
+	defer func() { _ = cancel() }()
+
+	s.metrics.OnSubscribeStarted()
+	defer s.metrics.OnSubscribeEnded()
+
+	ctx := stream.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return status.FromContextError(ctx.Err()).Err()
+		case entry, ok := <-ch:
+			if !ok {
+				// Slow subscriber: log closed our channel mid-stream.
+				s.metrics.OnSubscribeDropped("gapped")
+				return status.Error(codes.FailedPrecondition,
+					"gapped: subscriber fell behind; snapshot and resubscribe")
+			}
+			mu, ok := entry.Op.(*pb.Mutation)
+			if !ok {
+				l := s.loggerOrDefault()
+				l.Warn("replication: unexpected mutation log entry type",
+					slog.String("type", "non-Mutation payload"),
+					slog.Uint64("seq", entry.Seq))
+				return status.Errorf(codes.Internal,
+					"replication: malformed mutation log entry at seq=%d", entry.Seq)
+			}
+			// Shallow copy so we can stamp Seq without mutating the
+			// shared Mutation pointer other subscribers (or the WAL) may
+			// be observing.
+			out := &pb.Mutation{
+				Seq:    entry.Seq,
+				Hlc:    mu.GetHlc(),
+				Origin: mu.GetOrigin(),
+				Op:     mu.GetOp(),
+			}
+			if err := stream.Send(&pb.SubscribeResponse{Mutation: out}); err != nil {
+				s.metrics.OnSubscribeDropped("send_failed")
+				return err
+			}
+		}
+	}
+}
+
+func (s *LanternReplicationService) loggerOrDefault() *slog.Logger {
+	if s.logger != nil {
+		return s.logger
+	}
+	return slog.Default()
+}

--- a/server/service/replication_service_test.go
+++ b/server/service/replication_service_test.go
@@ -1,0 +1,229 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/hlc"
+	"github.com/anaregdesign/lantern/core/mutationlog"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/server/service"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// recordingMetrics counts metric callbacks so tests can assert on them.
+type recordingMetrics struct {
+	started int64
+	ended   int64
+	dropped map[string]int64
+}
+
+func newRecordingMetrics() *recordingMetrics {
+	return &recordingMetrics{dropped: map[string]int64{}}
+}
+
+func (m *recordingMetrics) OnSubscribeStarted() { atomic.AddInt64(&m.started, 1) }
+func (m *recordingMetrics) OnSubscribeEnded()   { atomic.AddInt64(&m.ended, 1) }
+func (m *recordingMetrics) OnSubscribeDropped(reason string) {
+	m.dropped[reason]++
+}
+
+func newReplicationServer(t *testing.T, log *mutationlog.Log, m service.SubscribeMetrics) (pb.LanternReplicationServiceClient, func()) {
+	t.Helper()
+	lis := bufconn.Listen(1 << 16)
+	srv := grpc.NewServer()
+	repl := service.NewLanternReplicationService(log).WithMetrics(m)
+	pb.RegisterLanternReplicationServiceServer(srv, repl)
+	go func() { _ = srv.Serve(lis) }()
+
+	conn, err := grpc.NewClient(
+		"passthrough://bufconn",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+	)
+	if err != nil {
+		srv.Stop()
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	cleanup := func() {
+		_ = conn.Close()
+		srv.Stop()
+	}
+	return pb.NewLanternReplicationServiceClient(conn), cleanup
+}
+
+// appendMutation appends a single Mutation to the log so subscribers see it.
+// The Mutation mirrors what LanternService.logMutation would produce so the
+// shape on the wire matches production.
+func appendMutation(t *testing.T, log *mutationlog.Log, clock *hlc.Clock, key string) {
+	t.Helper()
+	ts := clock.Now()
+	id := ts.NodeID
+	mu := &pb.Mutation{
+		Hlc: &pb.HLCTimestamp{
+			WallNs:  ts.WallNs,
+			Logical: ts.Logical,
+			NodeId:  append([]byte(nil), id[:]...),
+		},
+		Origin: append([]byte(nil), id[:]...),
+		Op: &pb.MutationOp{Op: &pb.MutationOp_PutVertices{
+			PutVertices: &pb.PutVerticesRequest{Vertices: []*pb.Vertex{{Key: key}}},
+		}},
+	}
+	if _, err := log.Append(mu, ts); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+}
+
+// TestSubscribe_StreamsInOrder verifies the happy path: subscribe from 0,
+// burst N writes, receive N responses with strictly monotone Seq starting
+// at 1 and the originating mutation payload intact.
+func TestSubscribe_StreamsInOrder(t *testing.T) {
+	const N = 50
+
+	log := mutationlog.New(mutationlog.Options{Capacity: 2 * N, SubscriberBuffer: 2 * N})
+	t.Cleanup(func() { _ = log.Close() })
+	clock := hlc.New(hlc.NodeID{0x01, 0x02, 0x03}, hlc.Options{})
+
+	metrics := newRecordingMetrics()
+	client, cleanup := newReplicationServer(t, log, metrics)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Append first, then subscribe from seq=1. Subscribing first with
+	// fromSeq=0 races the handler against the appender: the log treats
+	// fromSeq < firstSeq as gapped, so a slow handler that registers
+	// after the first append would erroneously bail. Append-then-subscribe
+	// is also the realistic CDC path (consumer resumes from a checkpoint).
+	for i := 0; i < N; i++ {
+		appendMutation(t, log, clock, "k"+itoa(i))
+	}
+
+	stream, err := client.Subscribe(ctx, &pb.SubscribeRequest{FromSeq: 1})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	var prev uint64
+	for i := 0; i < N; i++ {
+		resp, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv[%d]: %v", i, err)
+		}
+		got := resp.GetMutation()
+		if got.GetSeq() != prev+1 {
+			t.Fatalf("entry[%d] seq=%d want %d", i, got.GetSeq(), prev+1)
+		}
+		prev = got.GetSeq()
+		if got.GetOp().GetPutVertices() == nil {
+			t.Fatalf("entry[%d] missing PutVertices oneof", i)
+		}
+		if got.GetHlc() == nil {
+			t.Fatalf("entry[%d] missing HLC", i)
+		}
+	}
+
+	if atomic.LoadInt64(&metrics.started) != 1 {
+		t.Errorf("started counter = %d, want 1", metrics.started)
+	}
+}
+
+// TestSubscribe_GappedReturnsFailedPrecondition: when fromSeq is older than
+// the ring's firstSeq the server immediately returns FailedPrecondition so
+// the client knows to snapshot + resubscribe (RFC §8.2).
+func TestSubscribe_GappedReturnsFailedPrecondition(t *testing.T) {
+	// Capacity=2 so a burst of 3 evicts seq=1.
+	log := mutationlog.New(mutationlog.Options{Capacity: 2, SubscriberBuffer: 8})
+	t.Cleanup(func() { _ = log.Close() })
+	clock := hlc.New(hlc.NodeID{}, hlc.Options{})
+	for i := 0; i < 3; i++ {
+		appendMutation(t, log, clock, "k"+itoa(i))
+	}
+
+	metrics := newRecordingMetrics()
+	client, cleanup := newReplicationServer(t, log, metrics)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	stream, err := client.Subscribe(ctx, &pb.SubscribeRequest{FromSeq: 1})
+	if err != nil {
+		t.Fatalf("Subscribe call: %v", err)
+	}
+	_, err = stream.Recv()
+	if err == nil {
+		t.Fatal("Recv returned nil error; want FailedPrecondition")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("error is not a status: %v", err)
+	}
+	if st.Code() != codes.FailedPrecondition {
+		t.Fatalf("code = %s, want FailedPrecondition", st.Code())
+	}
+	if got := metrics.dropped["gapped"]; got != 1 {
+		t.Errorf("dropped[gapped] = %d, want 1", got)
+	}
+}
+
+// TestSubscribe_ClientCancel cleans up server-side resources on client
+// cancellation. We rely on the active-streams counter returning to 0.
+func TestSubscribe_ClientCancel(t *testing.T) {
+	log := mutationlog.New(mutationlog.Options{Capacity: 64, SubscriberBuffer: 64})
+	t.Cleanup(func() { _ = log.Close() })
+
+	metrics := newRecordingMetrics()
+	client, cleanup := newReplicationServer(t, log, metrics)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := client.Subscribe(ctx, &pb.SubscribeRequest{FromSeq: 0})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	// Give the handler a moment to register its subscription.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	_, err = stream.Recv()
+	if err == nil || (!errors.Is(err, context.Canceled) && status.Code(err) != codes.Canceled) {
+		// EOF is also acceptable if the server tore down first.
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("Recv after cancel: got %v, want Canceled or EOF", err)
+		}
+	}
+	// The handler's defer must have flipped the gauge back.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt64(&metrics.ended) == 1 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("ended counter = %d, want 1", metrics.ended)
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [20]byte
+	pos := len(b)
+	for i > 0 {
+		pos--
+		b[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[pos:])
+}

--- a/server/service/server_test.go
+++ b/server/service/server_test.go
@@ -61,7 +61,7 @@ func TestLanternServer_Run_FlipsHealthOnServeReturn(t *testing.T) {
 	hs := &recordingHealth{}
 
 	srv := service.NewLanternServer(
-		svc, grpcSrv, lis,
+		svc, nil, grpcSrv, lis,
 		slog.New(slog.NewTextHandler(discardWriter{}, nil)),
 		service.LifecycleConfig{GCInterval: time.Hour, ShutdownTimeout: time.Second},
 		hs,

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -390,6 +390,7 @@ func (s *LanternService) DeleteEdges(ctx context.Context, in *pb.DeleteEdgesRequ
 // composition root.
 type LanternServer struct {
 	service         *LanternService
+	replication     *LanternReplicationService
 	server          *grpc.Server
 	listener        net.Listener
 	logger          *slog.Logger
@@ -421,6 +422,7 @@ type LifecycleConfig struct {
 
 func NewLanternServer(
 	service *LanternService,
+	replication *LanternReplicationService,
 	server *grpc.Server,
 	listener net.Listener,
 	logger *slog.Logger,
@@ -430,6 +432,7 @@ func NewLanternServer(
 ) *LanternServer {
 	return &LanternServer{
 		service:         service,
+		replication:     replication,
 		server:          server,
 		listener:        listener,
 		logger:          logger,
@@ -446,8 +449,14 @@ func NewLanternServer(
 // a hard close so the process can exit.
 func (s *LanternServer) Run(ctx context.Context) error {
 	pb.RegisterLanternServiceServer(s.server, s.service)
+	if s.replication != nil {
+		pb.RegisterLanternReplicationServiceServer(s.server, s.replication)
+	}
 	if s.health != nil {
 		s.health.SetServingStatus(ServiceName, healthpb.HealthCheckResponse_SERVING)
+		if s.replication != nil {
+			s.health.SetServingStatus(ReplicationServiceName, healthpb.HealthCheckResponse_SERVING)
+		}
 	}
 
 	go s.gracefulShutdown(ctx)
@@ -467,6 +476,9 @@ func (s *LanternServer) Run(ctx context.Context) error {
 	err := s.server.Serve(s.listener)
 	if s.health != nil {
 		s.health.SetServingStatus(ServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
+		if s.replication != nil {
+			s.health.SetServingStatus(ReplicationServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
+		}
 	}
 	return err
 }
@@ -481,6 +493,9 @@ func (s *LanternServer) gracefulShutdown(ctx context.Context) {
 	s.logger.Info("shutting down grpc server", slog.Duration("timeout", s.shutdownTimeout))
 	if s.health != nil {
 		s.health.SetServingStatus(ServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
+		if s.replication != nil {
+			s.health.SetServingStatus(ReplicationServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
+		}
 	}
 	done := make(chan struct{})
 	go func() {

--- a/tests/integration/subscribe_test.go
+++ b/tests/integration/subscribe_test.go
@@ -58,7 +58,7 @@ func TestSubscribe_E2E_100Writes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewClient(sub): %v", err)
 	}
-	defer subConn.Close()
+	defer func() { _ = subConn.Close() }()
 	subCli := pb.NewLanternReplicationServiceClient(subConn)
 
 	// Writer (SDK).
@@ -70,7 +70,7 @@ func TestSubscribe_E2E_100Writes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewLantern: %v", err)
 	}
-	defer l.Close()
+	defer func() { _ = l.Close() }()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/tests/integration/subscribe_test.go
+++ b/tests/integration/subscribe_test.go
@@ -1,0 +1,127 @@
+package integration_test
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/hlc"
+	"github.com/anaregdesign/lantern/core/mutationlog"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/anaregdesign/lantern/server/provider"
+	"github.com/anaregdesign/lantern/server/service"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// TestSubscribe_E2E_100Writes wires a real LanternService + LanternReplicationService
+// over bufconn, drives 100 PutVertex writes through the SDK, and asserts the
+// subscriber sees all 100 mutations in strict Seq order with PutVertices
+// payloads intact. This is the acceptance criterion for issue #180.
+func TestSubscribe_E2E_100Writes(t *testing.T) {
+	const N = 100
+
+	lis := bufconn.Listen(1 << 16)
+	vi := provider.NewValidationInterceptor(provider.ValidationLimits{
+		MaxKeyLen:         256,
+		MaxBatchSize:      1024,
+		IlluminateMaxStep: 32,
+		IlluminateMaxK:    256,
+	})
+	srv := grpc.NewServer(grpc.UnaryInterceptor(vi.UnaryServerInterceptor()))
+
+	log := mutationlog.New(mutationlog.Options{Capacity: 4 * N, SubscriberBuffer: 4 * N})
+	t.Cleanup(func() { _ = log.Close() })
+	clock := hlc.New(hlc.NodeID{0xAA, 0xBB}, hlc.Options{})
+
+	svc := service.NewLanternService(cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)).
+		WithReplication(log, clock, nil)
+	pb.RegisterLanternServiceServer(srv, svc)
+	pb.RegisterLanternReplicationServiceServer(srv, service.NewLanternReplicationService(log))
+
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	dialer := func(context.Context, string) (net.Conn, error) { return lis.Dial() }
+
+	// Subscriber connection (raw gRPC, since the SDK doesn't expose Subscribe).
+	subConn, err := grpc.NewClient(
+		"passthrough://bufconn",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(dialer),
+	)
+	if err != nil {
+		t.Fatalf("NewClient(sub): %v", err)
+	}
+	defer subConn.Close()
+	subCli := pb.NewLanternReplicationServiceClient(subConn)
+
+	// Writer (SDK).
+	l, err := client.NewLantern(
+		"passthrough://bufconn",
+		client.WithTransportCredentials(insecure.NewCredentials()),
+		client.WithDialOption(grpc.WithContextDialer(dialer)),
+	)
+	if err != nil {
+		t.Fatalf("NewLantern: %v", err)
+	}
+	defer l.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Issue writes first so Subscribe can replay them from the in-memory
+	// ring. SubscriberBuffer is sized to fit all entries.
+	for i := 0; i < N; i++ {
+		if err := l.PutVertex(ctx, "k-"+itoa(i), "v", time.Minute); err != nil {
+			t.Fatalf("PutVertex[%d]: %v", i, err)
+		}
+	}
+
+	stream, err := subCli.Subscribe(ctx, &pb.SubscribeRequest{FromSeq: 1})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	var prev uint64
+	for i := 0; i < N; i++ {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			t.Fatalf("stream EOF at %d/%d", i, N)
+		}
+		if err != nil {
+			t.Fatalf("Recv[%d]: %v", i, err)
+		}
+		got := resp.GetMutation()
+		if got.GetSeq() != prev+1 {
+			t.Fatalf("entry[%d] seq=%d want %d", i, got.GetSeq(), prev+1)
+		}
+		prev = got.GetSeq()
+		pv := got.GetOp().GetPutVertices()
+		if pv == nil || len(pv.GetVertices()) != 1 {
+			t.Fatalf("entry[%d] missing PutVertices payload", i)
+		}
+		if want := "k-" + itoa(i); pv.GetVertices()[0].GetKey() != want {
+			t.Errorf("entry[%d] key=%q want %q", i, pv.GetVertices()[0].GetKey(), want)
+		}
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [20]byte
+	pos := len(b)
+	for i > 0 {
+		pos--
+		b[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[pos:])
+}


### PR DESCRIPTION
Closes #180.

## Summary

Implements the server-side Subscribe RPC on the dedicated `LanternReplicationService`, wired alongside `LanternService` and sharing the same `*mutationlog.Log`.

## Notable deviation from issue spec

Issue #180 wrote `codes.OutOfRange` for the gap-detection error. The proto contract (`proto/graph/v1/replication.proto`, merged in #178) documents `FAILED_PRECONDITION` with reason `"gapped"`. **This PR implements the proto contract** so the wire format stays self-consistent. Clients (see #185) snapshot + resubscribe on `FailedPrecondition`.

## Implementation

- `server/service/replication.go` — new `LanternReplicationService`
  - `Subscribe`:
    1. `log.Subscribe(req.FromSeq)`; `ErrGapped` → `FailedPrecondition` + metric `dropped{reason="gapped"}`.
    2. Stream loop: ctx cancel → propagate; channel closed mid-stream → `FailedPrecondition` + `dropped{gapped}`; `stream.Send` error → return + `dropped{send_failed}`.
    3. Shallow-copies the buffered `*pb.Mutation` and stamps `Seq` from `entry.Seq` (write path stores `Seq=0`).
  - `SubscribeMetrics` interface decouples service from provider/metrics imports.
- `server/cmd/{server,wire,wire_gen}.go` — `newLanternReplicationService` provider; wired through wire.
- `server/service/service.go` — `LanternServer` takes the replication service and registers it; `ReplicationServiceName = "graph.v1.LanternReplicationService"` flipped to SERVING/NOT_SERVING in lock-step with `LanternService`.
- `server/metrics/metrics.go` — adds `lantern_subscribe_active_streams` (gauge) and `lantern_subscribe_dropped_total{reason}` (counter; reason ∈ {gapped, send_failed}).

## Tests (all under `-race`)

- `server/service/replication_service_test.go`:
  - `TestSubscribe_StreamsInOrder` — N=50 writes, all received in strict Seq order.
  - `TestSubscribe_GappedReturnsFailedPrecondition` — capacity=2, 3 writes, Subscribe(1) → `FailedPrecondition`.
  - `TestSubscribe_ClientCancel` — ctx cancel cleans up server-side; active gauge returns to 0.
- `tests/integration/subscribe_test.go`:
  - `TestSubscribe_E2E_100Writes` — SDK writer + raw Subscribe subscriber over bufconn; 100 mutations received in order with payloads intact (issue acceptance criterion).

## Docs

`docs/replication.md` §8.2 extended with handler implementation notes (service split, gap mapping, Seq stamping, health, metrics).