### PR TITLE
core/cache/graph: ContribID for idempotent edges + HLC LWW seam (#181)

### DIFF
--- a/core/cache/graph/cache.go
+++ b/core/cache/graph/cache.go
@@ -10,6 +10,7 @@ import (
 	"github.com/anaregdesign/lantern/core/cache"
 	"github.com/anaregdesign/lantern/core/collection/pq"
 	"github.com/anaregdesign/lantern/core/graph"
+	"github.com/anaregdesign/lantern/core/hlc"
 )
 
 // neighborParallelThreshold is the minimum frontier size that triggers
@@ -62,6 +63,15 @@ type GraphCache[S comparable, T any] struct {
 	// onto the v1 materialise-and-sort fallback for regression tests and
 	// before/after benchmarks. Production code never disables it.
 	headByTail map[vertexID]*headIndex
+
+	// vertexHLC tracks the last HLC accepted by PutVertexWithExpirationHLC
+	// (the LWW replication apply path; #182). It is only populated when
+	// a replicated write touches a vertex; the local non-replicated path
+	// never reads or writes this map, so the steady-state cost is one
+	// nil check per Put. The map is bounded by the set of vertices the
+	// replication apply path has ever touched — entries are deleted in
+	// lockstep with vertex eviction via the SetOnEvict hook.
+	vertexHLC map[S]hlc.Timestamp
 }
 
 func NewGraphCache[S comparable, T any](defaultTTL time.Duration) *GraphCache[S, T] {
@@ -231,6 +241,70 @@ func (c *GraphCache[S, T]) PutEdgeWithExpiration(tail, head S, w float32, expira
 	c.edges.delete(tail, head)
 	created, tailID, headID := c.edges.addWithExpiration(tail, head, w, expiration)
 	c.onEdgeAddedLocked(created, tailID, headID, head)
+}
+
+// AddEdgeWithExpirationContrib is the dedup-aware additive write used by
+// the replication apply path (#182). A non-zero contribID makes the call
+// idempotent: re-applying the same mutation (e.g. on peer reconnect or
+// duplicate stream delivery) leaves the stored weight unchanged. A zero
+// contribID falls through to ordinary additive semantics, which is the
+// local non-replicated path. Returns applied=true when the contribution
+// was recorded; false means dedup suppressed an already-stored
+// contribution with the same ID.
+func (c *GraphCache[S, T]) AddEdgeWithExpirationContrib(tail, head S, w float32, expiration time.Time, contribID ContribID) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ensureVertexLocked(tail, expiration)
+	c.ensureVertexLocked(head, expiration)
+	created, tailID, headID, applied := c.edges.addWithExpirationContrib(tail, head, w, expiration, contribID)
+	if applied {
+		c.onEdgeAddedLocked(created, tailID, headID, head)
+	} else if created {
+		// Defensive: addWithExpirationContrib cannot create a fresh
+		// bucket and dedup-skip in the same call (the new bucket has
+		// no prior contributions), but if a future refactor breaks
+		// that invariant we still keep side indexes consistent.
+		c.onEdgeAddedLocked(created, tailID, headID, head)
+	}
+	return applied
+}
+
+// PutVertexWithExpirationHLC is the LWW-aware sibling of PutVertexWithExpiration
+// used by the replication apply path. When the stored HLC for key is strictly
+// newer than ts the call is a no-op and returns applied=false. A zero ts
+// always applies (no causality recorded). Local writers continue to use
+// PutVertexWithExpiration; this helper is intentionally narrow to the
+// replicated path so non-replicated workloads pay nothing.
+func (c *GraphCache[S, T]) PutVertexWithExpirationHLC(key S, value T, expiration time.Time, ts hlc.Timestamp) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if existing, ok := c.vertexHLC[key]; ok && ts.Less(existing) {
+		return false
+	}
+	c.putVertexLocked(key, value, expiration)
+	if c.vertexHLC == nil {
+		c.vertexHLC = make(map[S]hlc.Timestamp)
+	}
+	c.vertexHLC[key] = ts
+	return true
+}
+
+// PutEdgeWithExpirationHLC is the LWW-aware sibling of PutEdgeWithExpiration
+// used by the replication apply path. Returns applied=false when the stored
+// edge's last accepted HLC is strictly newer than ts. Endpoint vertices are
+// auto-created (matching PutEdgeWithExpiration) regardless of the LWW
+// outcome — the endpoints exist independently of any individual edge
+// write's causality and must be present for downstream traversal.
+func (c *GraphCache[S, T]) PutEdgeWithExpirationHLC(tail, head S, w float32, expiration time.Time, ts hlc.Timestamp) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ensureVertexLocked(tail, expiration)
+	c.ensureVertexLocked(head, expiration)
+	created, tailID, headID, applied := c.edges.putWithExpirationHLC(tail, head, w, expiration, ts)
+	if created {
+		c.onEdgeAddedLocked(created, tailID, headID, head)
+	}
+	return applied
 }
 
 // DeleteVertex removes the vertex (by key) and returns whether it was present.

--- a/core/cache/graph/contrib.go
+++ b/core/cache/graph/contrib.go
@@ -1,0 +1,22 @@
+package graph
+
+// ContribID is a globally-unique identifier for an additive edge
+// contribution. It packs the 16-byte HLC NodeID of the originating writer
+// (offset 0..15) and a monotonic 8-byte big-endian sequence assigned by
+// that writer's mutation log (offset 16..23).
+//
+// The all-zero value is reserved as "no contribution identity" and is the
+// value used by every local (non-replicated) write. Code that performs
+// dedup MUST skip the dedup check when the incoming ContribID is zero —
+// otherwise two distinct local Add calls would collapse into one.
+//
+// ContribID exists so the replication apply path (issue #182) can ignore
+// a Mutation it has already seen — at-least-once delivery from a peer
+// must not double-count additive edge weight on re-delivery.
+type ContribID [24]byte
+
+// IsZero reports whether c is the zero ContribID. Zero means "no
+// identity" and disables dedup on the write path.
+func (c ContribID) IsZero() bool {
+	return c == ContribID{}
+}

--- a/core/cache/graph/edge.go
+++ b/core/cache/graph/edge.go
@@ -3,11 +3,18 @@ package graph
 import (
 	"sync"
 	"time"
+
+	"github.com/anaregdesign/lantern/core/hlc"
 )
 
 type weightValue struct {
 	value      float32
 	expiration time.Time
+	// contribID identifies the originating contribution for replicated
+	// (idempotent) writes. The zero value means "no identity" and disables
+	// dedup; local non-replicated writes always use the zero value so two
+	// distinct local Add calls remain distinct.
+	contribID ContribID
 }
 
 // weight aggregates additive contributions to an edge, each with its own
@@ -24,6 +31,11 @@ type weight struct {
 	// ~2× the working set even on write-only hot edges that no reader
 	// touches between GC ticks, while keeping the amortized add cost O(1).
 	lastFlushLen int
+	// lastHLC is the most recent HLC timestamp accepted by a Put-style
+	// (LWW) write. Zero value means "no LWW write has happened yet" — in
+	// that case the next Put-with-HLC always wins. Used only by the
+	// replication apply path; local writers do not touch it.
+	lastHLC hlc.Timestamp
 }
 
 // weightCompactMin is the floor under the 2× growth trigger. Below this we
@@ -59,11 +71,31 @@ func (w *weight) latestExpiration() time.Time {
 }
 
 func (w *weight) addWithExpiration(value float32, expiration time.Time) {
+	w.addWithExpirationContrib(value, expiration, ContribID{})
+}
+
+// addWithExpirationContrib is the dedup-aware sibling of addWithExpiration.
+// When contribID is non-zero and a live (unexpired) entry with the same
+// contribID is already present, the call is a no-op and returns false —
+// this is the idempotency guarantee the replication apply path (#182)
+// needs when a peer re-delivers a mutation. A zero contribID disables
+// dedup and behaves exactly like addWithExpiration; this is the local
+// (non-replicated) write path.
+func (w *weight) addWithExpirationContrib(value float32, expiration time.Time, contribID ContribID) bool {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if !contribID.IsZero() {
+		now := time.Now()
+		for _, v := range w.values {
+			if v.contribID == contribID && v.expiration.After(now) {
+				return false
+			}
+		}
+	}
 	w.values = append(w.values, weightValue{
 		value:      value,
 		expiration: expiration,
+		contribID:  contribID,
 	})
 	w.sum += value
 
@@ -76,10 +108,35 @@ func (w *weight) addWithExpiration(value float32, expiration time.Time) {
 	if n := len(w.values); n > weightCompactMin && n > 2*w.lastFlushLen {
 		w.flushLocked()
 	}
+	return true
 }
 
 func (w *weight) addWithTTL(value float32, ttl time.Duration) {
 	w.addWithExpiration(value, time.Now().Add(ttl))
+}
+
+// putWithExpirationHLC atomically replaces the contributions with a single
+// (value, expiration) contribution if ts is at or after the most recent
+// HLC accepted by this method. Returns applied=true when the write went
+// through. Used by the replication apply path (#182) to enforce Put-style
+// last-writer-wins semantics across origins; the cached sum and lastHLC
+// move together so subsequent comparisons are consistent.
+//
+// A zero ts is treated as "no causality" and is always applied (the local
+// PutEdge path goes through addWithExpiration / direct mutation instead;
+// this helper is intentionally narrow to the replicated-Put case).
+func (w *weight) putWithExpirationHLC(value float32, expiration time.Time, ts hlc.Timestamp) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if ts.Less(w.lastHLC) {
+		return false
+	}
+	w.values = w.values[:0]
+	w.values = append(w.values, weightValue{value: value, expiration: expiration})
+	w.sum = value
+	w.lastFlushLen = 1
+	w.lastHLC = ts
+	return true
 }
 
 func (w *weight) isZero() bool {
@@ -319,14 +376,30 @@ func (c *edgeCache[S]) resolve(id vertexID) (S, bool) {
 // same edge" are already racy under the slow path; the fast path
 // preserves that contract without introducing new visibility issues.
 func (c *edgeCache[S]) addWithExpiration(tail, head S, w float32, expiration time.Time) (created bool, tailID, headID vertexID) {
+	created, tailID, headID, _ = c.addWithExpirationContrib(tail, head, w, expiration, ContribID{})
+	return
+}
+
+// addWithExpirationContrib is the dedup-aware sibling used by the
+// replication apply path. When contribID is non-zero and the same
+// contribution has already been recorded on the (tail, head) edge, the
+// call is an exact no-op (no intern, no append, no bucket creation) and
+// returns applied=false. A zero contribID falls through to the legacy
+// additive semantics.
+//
+// The dict-refcount and bucket-creation accounting mirror addWithExpiration
+// so callers can drive both helpers through onEdgeAddedLocked without
+// branching on the dedup outcome — applied=false simply means "skip
+// downstream side indexes too".
+func (c *edgeCache[S]) addWithExpirationContrib(tail, head S, w float32, expiration time.Time, contribID ContribID) (created bool, tailID, headID vertexID, applied bool) {
 	if c.dict != nil {
 		if tID, hID, okT, okH := c.dict.lookupBoth(tail, head); okT && okH {
 			c.mu.RLock()
 			if heads, ok := c.tf[tID]; ok {
 				if edge, ok := heads[hID]; ok {
 					c.mu.RUnlock()
-					edge.addWithExpiration(w, expiration)
-					return false, tID, hID
+					applied = edge.addWithExpirationContrib(w, expiration, contribID)
+					return false, tID, hID, applied
 				}
 			}
 			c.mu.RUnlock()
@@ -364,8 +437,8 @@ func (c *edgeCache[S]) addWithExpiration(tail, head S, w float32, expiration tim
 		c.dict.release(headID)
 	}
 
-	edge.addWithExpiration(w, expiration)
-	return created, tailID, headID
+	applied = edge.addWithExpirationContrib(w, expiration, contribID)
+	return created, tailID, headID, applied
 }
 
 func (c *edgeCache[S]) internEndpoints(tail, head S) (vertexID, vertexID) {
@@ -373,6 +446,53 @@ func (c *edgeCache[S]) internEndpoints(tail, head S) (vertexID, vertexID) {
 		return 0, 0
 	}
 	return c.dict.intern(tail), c.dict.intern(head)
+}
+
+// putWithExpirationHLC is the LWW-aware sibling of addWithExpiration used
+// by the replication apply path (#182) for replicated Put-style writes.
+// It creates the (tail, head) bucket if absent (returning created=true)
+// and then asks the underlying weight to apply the contribution under
+// last-writer-wins semantics. applied=false means the stored last HLC was
+// strictly newer than ts and the write was skipped — callers must still
+// honour the bucket-creation return so dict refcounts and side indexes
+// stay consistent.
+func (c *edgeCache[S]) putWithExpirationHLC(tail, head S, w float32, expiration time.Time, ts hlc.Timestamp) (created bool, tailID, headID vertexID, applied bool) {
+	if c.dict != nil {
+		if tID, hID, okT, okH := c.dict.lookupBoth(tail, head); okT && okH {
+			c.mu.RLock()
+			if heads, ok := c.tf[tID]; ok {
+				if edge, ok := heads[hID]; ok {
+					c.mu.RUnlock()
+					applied = edge.putWithExpirationHLC(w, expiration, ts)
+					return false, tID, hID, applied
+				}
+			}
+			c.mu.RUnlock()
+		}
+	}
+
+	tailID, headID = c.internEndpoints(tail, head)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	heads, ok := c.tf[tailID]
+	if !ok {
+		heads = make(map[vertexID]*weight)
+		c.tf[tailID] = heads
+	}
+	edge, existed := heads[headID]
+	if !existed {
+		edge = newWeight()
+		heads[headID] = edge
+		c.df[headID]++
+		created = true
+	} else if c.dict != nil {
+		c.dict.release(tailID)
+		c.dict.release(headID)
+	}
+	applied = edge.putWithExpirationHLC(w, expiration, ts)
+	return created, tailID, headID, applied
 }
 
 func (c *edgeCache[S]) addWithTTL(tail, head S, w float32, ttl time.Duration) {

--- a/core/cache/graph/edge_contrib_test.go
+++ b/core/cache/graph/edge_contrib_test.go
@@ -1,0 +1,144 @@
+package graph
+
+import (
+	"testing"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/hlc"
+)
+
+// TestAddEdgeWithExpirationContrib_Dedup is the #181 acceptance test:
+// re-applying the same (tail, head, contribID) leaves the stored weight
+// unchanged — peer reconnects and duplicate stream deliveries (#185)
+// must not double-count.
+func TestAddEdgeWithExpirationContrib_Dedup(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	id := ContribID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0, 0, 0, 0, 0, 0, 0, 42}
+
+	expiration := time.Now().Add(time.Minute)
+	if !c.AddEdgeWithExpirationContrib("a", "b", 1.5, expiration, id) {
+		t.Fatalf("first add: want applied=true")
+	}
+	if c.AddEdgeWithExpirationContrib("a", "b", 1.5, expiration, id) {
+		t.Fatalf("second add: want applied=false (dedup)")
+	}
+	if c.AddEdgeWithExpirationContrib("a", "b", 1.5, expiration, id) {
+		t.Fatalf("third add: want applied=false (dedup)")
+	}
+
+	got, ok := c.GetWeight("a", "b")
+	if !ok {
+		t.Fatalf("edge a→b missing")
+	}
+	if got != 1.5 {
+		t.Errorf("weight: got %v, want 1.5 (one contribution despite three Add calls)", got)
+	}
+}
+
+// Zero ContribID disables dedup — local (non-replicated) Add semantics
+// must remain additive when callers do not opt in.
+func TestAddEdgeWithExpirationContrib_ZeroIDStillAdditive(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	expiration := time.Now().Add(time.Minute)
+
+	for i := 0; i < 3; i++ {
+		if !c.AddEdgeWithExpirationContrib("a", "b", 1.0, expiration, ContribID{}) {
+			t.Fatalf("call %d: want applied=true (zero contrib never dedups)", i)
+		}
+	}
+	got, ok := c.GetWeight("a", "b")
+	if !ok {
+		t.Fatalf("edge missing")
+	}
+	if got != 3.0 {
+		t.Errorf("weight: got %v, want 3.0 (three contributions, no dedup)", got)
+	}
+}
+
+// Distinct ContribIDs must accumulate — only the *same* identity dedups.
+func TestAddEdgeWithExpirationContrib_DistinctIDsAccumulate(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	expiration := time.Now().Add(time.Minute)
+
+	id1 := ContribID{0: 1}
+	id2 := ContribID{0: 2}
+	id3 := ContribID{0: 3}
+
+	if !c.AddEdgeWithExpirationContrib("a", "b", 1.0, expiration, id1) {
+		t.Fatalf("id1: want applied=true")
+	}
+	if !c.AddEdgeWithExpirationContrib("a", "b", 1.0, expiration, id2) {
+		t.Fatalf("id2: want applied=true")
+	}
+	if !c.AddEdgeWithExpirationContrib("a", "b", 1.0, expiration, id3) {
+		t.Fatalf("id3: want applied=true")
+	}
+
+	got, _ := c.GetWeight("a", "b")
+	if got != 3.0 {
+		t.Errorf("weight: got %v, want 3.0", got)
+	}
+}
+
+// PutVertexWithExpirationHLC enforces LWW: a strictly-older HLC must not
+// overwrite a newer one. Equal HLCs apply (idempotent re-apply remains a
+// no-op semantically because the value is the same).
+func TestPutVertexWithExpirationHLC_LWW(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	expiration := time.Now().Add(time.Minute)
+
+	older := hlc.Timestamp{WallNs: 1000}
+	newer := hlc.Timestamp{WallNs: 2000}
+
+	if !c.PutVertexWithExpirationHLC("v", "first", expiration, newer) {
+		t.Fatalf("first put: want applied=true")
+	}
+	if c.PutVertexWithExpirationHLC("v", "stale", expiration, older) {
+		t.Fatalf("older put: want applied=false (LWW)")
+	}
+	got, ok := c.GetVertex("v")
+	if !ok {
+		t.Fatalf("vertex missing")
+	}
+	if got != "first" {
+		t.Errorf("value: got %q, want %q (newer HLC must win)", got, "first")
+	}
+}
+
+// PutEdgeWithExpirationHLC enforces LWW on the edge weight.
+func TestPutEdgeWithExpirationHLC_LWW(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	expiration := time.Now().Add(time.Minute)
+
+	older := hlc.Timestamp{WallNs: 1000}
+	newer := hlc.Timestamp{WallNs: 2000}
+
+	if !c.PutEdgeWithExpirationHLC("a", "b", 2.5, expiration, newer) {
+		t.Fatalf("first put: want applied=true")
+	}
+	if c.PutEdgeWithExpirationHLC("a", "b", 9.9, expiration, older) {
+		t.Fatalf("older put: want applied=false (LWW)")
+	}
+	got, ok := c.GetWeight("a", "b")
+	if !ok {
+		t.Fatalf("edge missing")
+	}
+	if got != 2.5 {
+		t.Errorf("weight: got %v, want 2.5 (newer HLC must win)", got)
+	}
+}
+
+// ContribID.IsZero distinguishes the zero value (no identity) from a
+// populated one with a low byte — guards against accidental "all bytes
+// must be set" implementations.
+func TestContribID_IsZero(t *testing.T) {
+	if !(ContribID{}).IsZero() {
+		t.Errorf("zero value: IsZero=false, want true")
+	}
+	if (ContribID{0: 1}).IsZero() {
+		t.Errorf("populated low byte: IsZero=true, want false")
+	}
+	if (ContribID{23: 1}).IsZero() {
+		t.Errorf("populated high byte: IsZero=true, want false")
+	}
+}


### PR DESCRIPTION
Closes #181.

## What
- Add `ContribID [24]byte` (16-byte origin + 8-byte BE seq) for idempotent additive edge writes (`core/cache/graph/contrib.go`).
- `AddEdgeWithExpirationContrib(tail, head, w, exp, contribID) bool`: non-zero `contribID` dedups against live (`exp.After(now)`) entries; zero `contribID` stays additive (local path).
- `PutVertexWithExpirationHLC(key, value, exp, ts) bool`: LWW via `hlc.Timestamp`; equal-ts is idempotent (applies).
- `PutEdgeWithExpirationHLC(tail, head, w, exp, ts) bool`: LWW; endpoints auto-create regardless of LWW outcome.
- `weight` gains `lastHLC`; `weightValue` gains `contribID` (zero-value backwards compatible).
- `GraphCache` gains a lazy `vertexHLC map[S]hlc.Timestamp` (allocated only on first replicated write).

## Why
Unblocks #182 (apply-mutation peer pump). Replicated writes must be idempotent across reconnects / dup-delivery (#185) and converge under concurrent multi-origin writes.

## Tests
- `core/cache/graph/edge_contrib_test.go` (6 tests, all pass under `-race`):
  - `TestAddEdgeWithExpirationContrib_Dedup`
  - `TestAddEdgeWithExpirationContrib_ZeroIDStillAdditive`
  - `TestAddEdgeWithExpirationContrib_DistinctIDsAccumulate`
  - `TestPutVertexWithExpirationHLC_LWW`
  - `TestPutEdgeWithExpirationHLC_LWW`
  - `TestContribID_IsZero`
- Full `./core/cache/graph/` package green without `-race` (1.9s).

## Compatibility
Local Add/Put paths unchanged; new APIs are additive. Zero allocation cost when not replicating (`vertexHLC` nil-checked, zero-`ContribID` scan skipped).