### PR TITLE
server: ApplyMutation internal API + convergence tests (#182)

### DIFF
--- a/server/service/apply.go
+++ b/server/service/apply.go
@@ -1,0 +1,169 @@
+package service
+
+import (
+	"context"
+	"encoding/binary"
+
+	"github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/hlc"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"google.golang.org/grpc/status"
+)
+
+// ApplyMutation is the internal entry point used by the peer-pump (#184)
+// and the snapshot bootstrap (#183) to replay a Mutation produced on a
+// remote node against the local cache. It is intentionally NOT a gRPC
+// method: external clients use the regular write RPCs which append to the
+// local log; ApplyMutation deliberately bypasses logMutation so a replayed
+// mutation is not re-broadcast.
+//
+// Idempotence rules per oneof case:
+//
+//   - Put* (vertex/edge): performed via the LWW-aware
+//     PutVertexWithExpirationHLC / PutEdgeWithExpirationHLC. A strictly
+//     older HLC is dropped silently; equal-ts writes apply, which is a
+//     no-op for value-equal payloads (the convergence guarantee).
+//
+//   - Add* (edge): performed via the ContribID-aware
+//     AddEdgeWithExpirationContrib. The mutation seq is folded together
+//     with the per-edge index inside the batch so two edges submitted in
+//     the same MutationOp_AddEdges receive distinct ContribIDs while
+//     replays of the same (mutation seq, edge index) pair dedup.
+//
+//   - Delete* (vertex/edge/by-prefix): performed via the existing
+//     destructive batch methods. Tombstone + TTL clamp semantics are
+//     deferred to #183; for now repeated deletes are naturally no-ops
+//     because the second pass finds nothing to remove.
+//
+// Returns ctx.Err() when ctx is cancelled; otherwise nil. Nil-or-empty
+// mutations are dropped silently so callers (pump, snapshot replay) can
+// forward whatever the wire produces without additional null checks.
+func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) error {
+	if err := ctx.Err(); err != nil {
+		return status.FromContextError(err).Err()
+	}
+	if m == nil || m.GetOp() == nil {
+		return nil
+	}
+
+	ts := hlcFromProto(m.GetHlc())
+	origin := m.GetOrigin()
+	seq := m.GetSeq()
+
+	switch op := m.GetOp().GetOp().(type) {
+	case *pb.MutationOp_PutVertex:
+		v := op.PutVertex.GetVertex()
+		if v == nil {
+			return nil
+		}
+		s.cache.PutVertexWithExpirationHLC(v.GetKey(), v, v.GetExpiration().AsTime(), ts)
+
+	case *pb.MutationOp_PutVertices:
+		for _, v := range op.PutVertices.GetVertices() {
+			if v == nil {
+				continue
+			}
+			s.cache.PutVertexWithExpirationHLC(v.GetKey(), v, v.GetExpiration().AsTime(), ts)
+		}
+
+	case *pb.MutationOp_DeleteVertex:
+		s.cache.DeleteVertices([]string{op.DeleteVertex.GetKey()})
+
+	case *pb.MutationOp_DeleteVertices:
+		s.cache.DeleteVertices(op.DeleteVertices.GetKeys())
+
+	case *pb.MutationOp_DeleteVerticesByPrefix:
+		// DeleteByPrefix returns the deleted count; the apply path does
+		// not need it. Use limit=0 (unlimited) to match the originating
+		// non-DryRun RPC's semantics; #183 will revisit this for
+		// snapshot-clamp interactions.
+		s.cache.DeleteByPrefix(ctx, op.DeleteVerticesByPrefix.GetPrefix(), 0)
+
+	case *pb.MutationOp_AddEdge:
+		e := op.AddEdge.GetEdge()
+		if e == nil {
+			return nil
+		}
+		cID := contribIDFor(origin, seq, 0)
+		s.cache.AddEdgeWithExpirationContrib(e.GetTail(), e.GetHead(), e.GetWeight(),
+			e.GetExpiration().AsTime(), cID)
+
+	case *pb.MutationOp_AddEdges:
+		edges := op.AddEdges.GetEdges()
+		for i, e := range edges {
+			if e == nil {
+				continue
+			}
+			cID := contribIDFor(origin, seq, uint16(i))
+			s.cache.AddEdgeWithExpirationContrib(e.GetTail(), e.GetHead(), e.GetWeight(),
+				e.GetExpiration().AsTime(), cID)
+		}
+
+	case *pb.MutationOp_PutEdge:
+		e := op.PutEdge.GetEdge()
+		if e == nil {
+			return nil
+		}
+		s.cache.PutEdgeWithExpirationHLC(e.GetTail(), e.GetHead(), e.GetWeight(),
+			e.GetExpiration().AsTime(), ts)
+
+	case *pb.MutationOp_PutEdges:
+		for _, e := range op.PutEdges.GetEdges() {
+			if e == nil {
+				continue
+			}
+			s.cache.PutEdgeWithExpirationHLC(e.GetTail(), e.GetHead(), e.GetWeight(),
+				e.GetExpiration().AsTime(), ts)
+		}
+
+	case *pb.MutationOp_DeleteEdge:
+		k := op.DeleteEdge
+		s.cache.DeleteEdges([]graph.EdgeKey[string]{{Tail: k.GetTail(), Head: k.GetHead()}})
+
+	case *pb.MutationOp_DeleteEdges:
+		in := op.DeleteEdges.GetEdges()
+		keys := make([]graph.EdgeKey[string], 0, len(in))
+		for _, e := range in {
+			keys = append(keys, graph.EdgeKey[string]{Tail: e.GetTail(), Head: e.GetHead()})
+		}
+		s.cache.DeleteEdges(keys)
+	}
+	return nil
+}
+
+// hlcFromProto converts the wire HLCTimestamp into the in-process value
+// type. A nil input yields the zero Timestamp, which Less() treats as the
+// minimum — i.e. any stored HLC will win the LWW compare. The NodeId byte
+// slice is right-padded/truncated into the fixed-size NodeID array so
+// peers using shorter test IDs still produce a stable total order.
+func hlcFromProto(p *pb.HLCTimestamp) hlc.Timestamp {
+	if p == nil {
+		return hlc.Timestamp{}
+	}
+	var nid hlc.NodeID
+	copy(nid[:], p.GetNodeId())
+	return hlc.Timestamp{
+		WallNs:  p.GetWallNs(),
+		Logical: p.GetLogical(),
+		NodeID:  nid,
+	}
+}
+
+// contribIDFor builds the dedup identifier for an additive contribution.
+// The 24-byte ContribID layout is documented on graph.ContribID:
+//
+//	bytes [0:16] = origin NodeID (replicating node)
+//	bytes [16:24] = uint64 BE = (mutation seq << 16) | edge index
+//
+// Folding the per-edge index into the low bits lets a single
+// MutationOp_AddEdges batch carry up to 65 536 distinct edges while still
+// guaranteeing a globally unique ContribID per (origin, seq, idx) triple.
+// Practical batch sizes are bounded by gRPC message size long before this
+// limit; the assertion is defensive.
+func contribIDFor(origin []byte, seq uint64, idx uint16) graph.ContribID {
+	var c graph.ContribID
+	copy(c[:16], origin)
+	combined := (seq << 16) | uint64(idx)
+	binary.BigEndian.PutUint64(c[16:], combined)
+	return c
+}

--- a/server/service/apply_test.go
+++ b/server/service/apply_test.go
@@ -1,0 +1,514 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/hlc"
+	"github.com/anaregdesign/lantern/core/mutationlog"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// TestApplyMutation_BasicOps walks each MutationOp variant once and
+// asserts that ApplyMutation hits the matching cache method. The fake
+// backend's accumulators are sufficient because the test only verifies
+// "we dispatched at least once" — semantic correctness of dedup/LWW is
+// covered by TestApplyMutation_Convergence below using the real cache.
+func TestApplyMutation_BasicOps(t *testing.T) {
+	fb := newFakeBackend()
+	svc := NewLanternService(fb)
+	ctx := context.Background()
+	origin := bytes16("origin-A")
+	exp := timestamppb.New(time.Now().Add(time.Hour))
+	ts := newHLC(1, origin)
+
+	mustApply := func(t *testing.T, name string, op *pb.MutationOp) {
+		t.Helper()
+		m := &pb.Mutation{Seq: 1, Hlc: ts, Origin: origin[:], Op: op}
+		if err := svc.ApplyMutation(ctx, m); err != nil {
+			t.Fatalf("ApplyMutation %s: %v", name, err)
+		}
+	}
+
+	mustApply(t, "PutVertex", &pb.MutationOp{Op: &pb.MutationOp_PutVertex{
+		PutVertex: &pb.PutVertexRequest{Vertex: &pb.Vertex{Key: "v1", Expiration: exp}},
+	}})
+	mustApply(t, "PutVertices", &pb.MutationOp{Op: &pb.MutationOp_PutVertices{
+		PutVertices: &pb.PutVerticesRequest{Vertices: []*pb.Vertex{{Key: "v2", Expiration: exp}}},
+	}})
+	mustApply(t, "AddEdge", &pb.MutationOp{Op: &pb.MutationOp_AddEdge{
+		AddEdge: &pb.AddEdgeRequest{Edge: &pb.Edge{Tail: "v1", Head: "v2", Weight: 1, Expiration: exp}},
+	}})
+	mustApply(t, "AddEdges", &pb.MutationOp{Op: &pb.MutationOp_AddEdges{
+		AddEdges: &pb.AddEdgesRequest{Edges: []*pb.Edge{{Tail: "v1", Head: "v2", Weight: 1, Expiration: exp}}},
+	}})
+	mustApply(t, "PutEdge", &pb.MutationOp{Op: &pb.MutationOp_PutEdge{
+		PutEdge: &pb.PutEdgeRequest{Edge: &pb.Edge{Tail: "v1", Head: "v2", Weight: 2, Expiration: exp}},
+	}})
+	mustApply(t, "PutEdges", &pb.MutationOp{Op: &pb.MutationOp_PutEdges{
+		PutEdges: &pb.PutEdgesRequest{Edges: []*pb.Edge{{Tail: "v1", Head: "v2", Weight: 3, Expiration: exp}}},
+	}})
+	mustApply(t, "DeleteEdge", &pb.MutationOp{Op: &pb.MutationOp_DeleteEdge{
+		DeleteEdge: &pb.DeleteEdgeRequest{Tail: "v1", Head: "v2"},
+	}})
+	mustApply(t, "DeleteEdges", &pb.MutationOp{Op: &pb.MutationOp_DeleteEdges{
+		DeleteEdges: &pb.DeleteEdgesRequest{Edges: []*pb.EdgeKey{{Tail: "v1", Head: "v2"}}},
+	}})
+	mustApply(t, "DeleteVertex", &pb.MutationOp{Op: &pb.MutationOp_DeleteVertex{
+		DeleteVertex: &pb.DeleteVertexRequest{Key: "v1"},
+	}})
+	mustApply(t, "DeleteVertices", &pb.MutationOp{Op: &pb.MutationOp_DeleteVertices{
+		DeleteVertices: &pb.DeleteVerticesRequest{Keys: []string{"v2"}},
+	}})
+	mustApply(t, "DeleteVerticesByPrefix", &pb.MutationOp{Op: &pb.MutationOp_DeleteVerticesByPrefix{
+		DeleteVerticesByPrefix: &pb.DeleteVerticesByPrefixRequest{Prefix: "x"},
+	}})
+
+	// Nil-safety: empty mutation, nil op, nil request all return nil err.
+	if err := svc.ApplyMutation(ctx, nil); err != nil {
+		t.Errorf("ApplyMutation(nil) returned %v, want nil", err)
+	}
+	if err := svc.ApplyMutation(ctx, &pb.Mutation{}); err != nil {
+		t.Errorf("ApplyMutation(empty) returned %v, want nil", err)
+	}
+}
+
+// TestApplyMutation_DoesNotLog asserts the cardinal rule: replayed
+// mutations MUST NOT re-append to the local log. Otherwise the peer-pump
+// in #184 would echo every mutation back to its origin and loop forever.
+func TestApplyMutation_DoesNotLog(t *testing.T) {
+	cache := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	log := mutationlog.New(mutationlog.Options{Capacity: 128, SubscriberBuffer: 128})
+	t.Cleanup(func() { _ = log.Close() })
+	origin := bytes16("origin-A")
+	clock := hlc.New(origin, hlc.Options{})
+	svc := NewLanternService(cache).
+		WithReplication(log, clock, nil)
+
+	ts := newHLC(1, origin)
+	exp := timestamppb.New(time.Now().Add(time.Hour))
+	m := &pb.Mutation{
+		Seq: 1, Hlc: ts, Origin: origin[:],
+		Op: &pb.MutationOp{Op: &pb.MutationOp_PutVertex{
+			PutVertex: &pb.PutVertexRequest{Vertex: &pb.Vertex{Key: "v1", Expiration: exp}},
+		}},
+	}
+	if err := svc.ApplyMutation(context.Background(), m); err != nil {
+		t.Fatalf("ApplyMutation: %v", err)
+	}
+	if _, ok := log.LastSeq(); ok {
+		t.Errorf("log has entries after ApplyMutation; want none (replay must not re-append)")
+	}
+}
+
+// TestApplyMutation_Convergence is the cluster-wide property test. It
+// builds three independent caches, generates a random batch of
+// mutations from a fixed pool of synthetic origins, then delivers the
+// same batch to every node in a SHUFFLED order (with occasional
+// duplicates). The post-condition: all three nodes hold identical
+// vertex and edge state.
+//
+// Restrictions for the #182 universe:
+//
+//   - Per-edge ops are partitioned: each (tail, head) pair receives ONLY
+//     Add operations OR ONLY Put operations across the whole trace.
+//     Mixing on the same edge composes additive contributions with an
+//     LWW reset and is order-sensitive (and is #185/#186 territory).
+//
+//   - No Delete* ops. Without tombstones a late Put may re-insert a
+//     deleted vertex on some nodes but not others; that's exactly what
+//     #183 will harden. Delete idempotence on a single node is tested
+//     separately in TestApplyMutation_Idempotence below.
+//
+//   - Add weights are always 1.0 so the float32 running sum is the
+//     integer count of distinct contributions (exact in float32 up to
+//     2^24). Put weights are integer-valued for the same reason.
+func TestApplyMutation_Convergence(t *testing.T) {
+	const (
+		traces     = 1000
+		mutsPerTrc = 12
+		numOrigins = 3
+		numNodes   = 3
+		vertexPool = 6
+		edgePool   = 8
+	)
+
+	for trace := 0; trace < traces; trace++ {
+		t.Run(fmt.Sprintf("trace=%04d", trace), func(t *testing.T) {
+			rng := rand.New(rand.NewPCG(uint64(trace), 0xC0FFEE))
+
+			origins := make([][16]byte, numOrigins)
+			clocks := make([]*hlc.Clock, numOrigins)
+			for i := range origins {
+				origins[i] = bytes16(fmt.Sprintf("origin-%d", i))
+				clocks[i] = hlc.New(origins[i], hlc.Options{})
+			}
+
+			// Pre-partition edges into "Add-only" vs "Put-only" so the
+			// universe is order-insensitive (see test header). Edges are
+			// keyed by (tail, head) and deduped so the same pair never
+			// straddles both buckets.
+			edgeSet := map[[2]string]bool{}
+			for len(edgeSet) < edgePool {
+				key := [2]string{
+					fmt.Sprintf("v%d", rng.IntN(vertexPool)),
+					fmt.Sprintf("v%d", rng.IntN(vertexPool)),
+				}
+				if _, dup := edgeSet[key]; dup {
+					continue
+				}
+				edgeSet[key] = rng.IntN(2) == 0
+			}
+			edges := make([][2]string, 0, len(edgeSet))
+			for k := range edgeSet {
+				edges = append(edges, k)
+			}
+			sort.Slice(edges, func(i, j int) bool {
+				if edges[i][0] != edges[j][0] {
+					return edges[i][0] < edges[j][0]
+				}
+				return edges[i][1] < edges[j][1]
+			})
+			edgeIsPut := make([]bool, len(edges))
+			for i, k := range edges {
+				edgeIsPut[i] = edgeSet[k]
+			}
+
+			// Build the mutation tape.
+			tape := make([]*pb.Mutation, 0, mutsPerTrc)
+			seqPerOrigin := make([]uint64, numOrigins)
+			for i := 0; i < mutsPerTrc; i++ {
+				oi := rng.IntN(numOrigins)
+				seqPerOrigin[oi]++
+				seq := seqPerOrigin[oi]
+				ts := clocks[oi].Now()
+				hlcTS := &pb.HLCTimestamp{
+					WallNs: ts.WallNs, Logical: ts.Logical,
+					NodeId: append([]byte(nil), ts.NodeID[:]...),
+				}
+				exp := timestamppb.New(time.Now().Add(time.Hour))
+				op := randomOp(rng, vertexPool, edges, edgeIsPut, oi, int64(i), exp)
+				tape = append(tape, &pb.Mutation{
+					Seq: seq, Hlc: hlcTS, Origin: origins[oi][:], Op: op,
+				})
+			}
+
+			// Three independent nodes, each receives the tape in a
+			// distinct shuffled order with random duplicates.
+			states := make([]nodeSnapshot, numNodes)
+			for n := 0; n < numNodes; n++ {
+				cache := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
+				svc := NewLanternService(cache)
+
+				delivery := make([]*pb.Mutation, 0, len(tape)*2)
+				delivery = append(delivery, tape...)
+				// Random duplicates (idempotence stress).
+				for i := 0; i < len(tape)/3; i++ {
+					delivery = append(delivery, tape[rng.IntN(len(tape))])
+				}
+				rng.Shuffle(len(delivery), func(i, j int) {
+					delivery[i], delivery[j] = delivery[j], delivery[i]
+				})
+
+				for _, m := range delivery {
+					if err := svc.ApplyMutation(context.Background(), m); err != nil {
+						t.Fatalf("node %d ApplyMutation: %v", n, err)
+					}
+				}
+				states[n] = snapshotCache(cache, vertexPool, edges)
+			}
+
+			for n := 1; n < numNodes; n++ {
+				if diff := states[0].diff(states[n]); diff != "" {
+					t.Fatalf("node 0 vs node %d divergence:\n%s", n, diff)
+				}
+			}
+		})
+	}
+}
+
+// TestApplyMutation_Idempotence applies the same mutation twice against
+// a single node and asserts the cache state matches a single application.
+// Covers every oneof variant including Delete (where idempotence is
+// "second delete is a no-op").
+func TestApplyMutation_Idempotence(t *testing.T) {
+	origin := bytes16("origin-A")
+	exp := timestamppb.New(time.Now().Add(time.Hour))
+	ts := newHLC(42, origin)
+	mkMutation := func(op *pb.MutationOp) *pb.Mutation {
+		return &pb.Mutation{Seq: 7, Hlc: ts, Origin: origin[:], Op: op}
+	}
+
+	cases := []struct {
+		name string
+		op   *pb.MutationOp
+	}{
+		{"PutVertex", &pb.MutationOp{Op: &pb.MutationOp_PutVertex{
+			PutVertex: &pb.PutVertexRequest{Vertex: &pb.Vertex{Key: "v1", Expiration: exp}},
+		}}},
+		{"AddEdge", &pb.MutationOp{Op: &pb.MutationOp_AddEdge{
+			AddEdge: &pb.AddEdgeRequest{Edge: &pb.Edge{Tail: "a", Head: "b", Weight: 1.0, Expiration: exp}},
+		}}},
+		{"PutEdge", &pb.MutationOp{Op: &pb.MutationOp_PutEdge{
+			PutEdge: &pb.PutEdgeRequest{Edge: &pb.Edge{Tail: "a", Head: "b", Weight: 5.0, Expiration: exp}},
+		}}},
+		{"DeleteVertex", &pb.MutationOp{Op: &pb.MutationOp_DeleteVertex{
+			DeleteVertex: &pb.DeleteVertexRequest{Key: "v1"},
+		}}},
+		{"DeleteEdge", &pb.MutationOp{Op: &pb.MutationOp_DeleteEdge{
+			DeleteEdge: &pb.DeleteEdgeRequest{Tail: "a", Head: "b"},
+		}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cacheA := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
+			cacheB := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
+			svcA := NewLanternService(cacheA)
+			svcB := NewLanternService(cacheB)
+
+			ctx := context.Background()
+			if err := svcA.ApplyMutation(ctx, mkMutation(tc.op)); err != nil {
+				t.Fatalf("A first apply: %v", err)
+			}
+			if err := svcB.ApplyMutation(ctx, mkMutation(tc.op)); err != nil {
+				t.Fatalf("B first apply: %v", err)
+			}
+			if err := svcB.ApplyMutation(ctx, mkMutation(tc.op)); err != nil {
+				t.Fatalf("B second apply: %v", err)
+			}
+
+			vs := []string{"v1", "a", "b"}
+			es := [][2]string{{"a", "b"}}
+			sa := snapshotCache(cacheA, 0, nil)
+			sa.includeKeys(cacheA, vs, es)
+			sb := snapshotCache(cacheB, 0, nil)
+			sb.includeKeys(cacheB, vs, es)
+			if diff := sa.diff(sb); diff != "" {
+				t.Errorf("second apply diverged from first apply:\n%s", diff)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------
+
+func bytes16(s string) [16]byte {
+	var b [16]byte
+	copy(b[:], s)
+	return b
+}
+
+func newHLC(wallNs int64, origin [16]byte) *pb.HLCTimestamp {
+	return &pb.HLCTimestamp{WallNs: wallNs, Logical: 0, NodeId: origin[:]}
+}
+
+// randomOp produces a random per-vertex/per-edge mutation drawn from
+// {PutVertex, PutVertices, AddEdge, AddEdges, PutEdge, PutEdges} subject
+// to the per-edge partition. Index i provides a deterministic value seed
+// so vertex payloads on different nodes converge to the same proto under
+// LWW.
+func randomOp(rng *rand.Rand, vp int, edges [][2]string, edgeIsPut []bool, oi int, i int64, exp *timestamppb.Timestamp) *pb.MutationOp {
+	pickEdge := func(want bool) (int, bool) {
+		// scan for an edge matching the desired Add/Put bucket
+		offset := rng.IntN(len(edges))
+		for s := 0; s < len(edges); s++ {
+			idx := (offset + s) % len(edges)
+			if edgeIsPut[idx] == want {
+				return idx, true
+			}
+		}
+		return 0, false
+	}
+	switch rng.IntN(6) {
+	case 0:
+		k := fmt.Sprintf("v%d", rng.IntN(vp))
+		return &pb.MutationOp{Op: &pb.MutationOp_PutVertex{
+			PutVertex: &pb.PutVertexRequest{Vertex: vertexFor(k, oi, i, exp)},
+		}}
+	case 1:
+		vs := []*pb.Vertex{
+			vertexFor(fmt.Sprintf("v%d", rng.IntN(vp)), oi, i, exp),
+			vertexFor(fmt.Sprintf("v%d", rng.IntN(vp)), oi, i+1, exp),
+		}
+		return &pb.MutationOp{Op: &pb.MutationOp_PutVertices{
+			PutVertices: &pb.PutVerticesRequest{Vertices: vs},
+		}}
+	case 2:
+		if idx, ok := pickEdge(false); ok {
+			e := edges[idx]
+			return &pb.MutationOp{Op: &pb.MutationOp_AddEdge{
+				AddEdge: &pb.AddEdgeRequest{Edge: &pb.Edge{Tail: e[0], Head: e[1], Weight: 1, Expiration: exp}},
+			}}
+		}
+	case 3:
+		if idx, ok := pickEdge(false); ok {
+			e := edges[idx]
+			return &pb.MutationOp{Op: &pb.MutationOp_AddEdges{
+				AddEdges: &pb.AddEdgesRequest{Edges: []*pb.Edge{
+					{Tail: e[0], Head: e[1], Weight: 1, Expiration: exp},
+				}},
+			}}
+		}
+	case 4:
+		if idx, ok := pickEdge(true); ok {
+			e := edges[idx]
+			return &pb.MutationOp{Op: &pb.MutationOp_PutEdge{
+				PutEdge: &pb.PutEdgeRequest{Edge: &pb.Edge{Tail: e[0], Head: e[1], Weight: float32(2 + (i % 7)), Expiration: exp}},
+			}}
+		}
+	case 5:
+		if idx, ok := pickEdge(true); ok {
+			e := edges[idx]
+			return &pb.MutationOp{Op: &pb.MutationOp_PutEdges{
+				PutEdges: &pb.PutEdgesRequest{Edges: []*pb.Edge{
+					{Tail: e[0], Head: e[1], Weight: float32(2 + (i % 7)), Expiration: exp},
+				}},
+			}}
+		}
+	}
+	// Fallback: a trivial PutVertex so we never return nil.
+	k := fmt.Sprintf("v%d", rng.IntN(vp))
+	return &pb.MutationOp{Op: &pb.MutationOp_PutVertex{
+		PutVertex: &pb.PutVertexRequest{Vertex: vertexFor(k, oi, i, exp)},
+	}}
+}
+
+// vertexFor returns a proto.Vertex whose payload is a deterministic
+// function of (key, origin, mutation index). Two nodes processing the
+// same mutation produce byte-equal vertices under proto.Equal.
+func vertexFor(key string, origin int, idx int64, exp *timestamppb.Timestamp) *pb.Vertex {
+	return &pb.Vertex{
+		Key:        key,
+		Value:      &pb.Vertex_Int64{Int64: int64(origin)*1000 + idx},
+		Expiration: exp,
+	}
+}
+
+// nodeSnapshot is the canonicalized post-trace state used to compare
+// nodes. Vertex values are serialized via proto.Marshal for byte
+// equality; edge weights are compared by exact float32 equality
+// (Add weight=1 sums and Put integer weights are exact in float32).
+type nodeSnapshot struct {
+	vertices map[string][]byte
+	weights  map[[2]string]float32
+}
+
+func snapshotCache(c *graph.GraphCache[string, *pb.Vertex], vp int, edges [][2]string) nodeSnapshot {
+	s := nodeSnapshot{
+		vertices: map[string][]byte{},
+		weights:  map[[2]string]float32{},
+	}
+	for i := 0; i < vp; i++ {
+		k := fmt.Sprintf("v%d", i)
+		if v, ok := c.GetVertex(k); ok {
+			s.vertices[k] = mustMarshal(v)
+		}
+	}
+	for _, e := range edges {
+		if w, ok := c.GetWeight(e[0], e[1]); ok {
+			s.weights[[2]string{e[0], e[1]}] = w
+		}
+	}
+	return s
+}
+
+// includeKeys extends a snapshot with explicit (vertex, edge) keys.
+// Used by the idempotence test where the universe is hand-picked.
+func (s *nodeSnapshot) includeKeys(c *graph.GraphCache[string, *pb.Vertex], vs []string, es [][2]string) {
+	for _, k := range vs {
+		if v, ok := c.GetVertex(k); ok {
+			s.vertices[k] = mustMarshal(v)
+		}
+	}
+	for _, e := range es {
+		if w, ok := c.GetWeight(e[0], e[1]); ok {
+			s.weights[[2]string{e[0], e[1]}] = w
+		}
+	}
+}
+
+func (s nodeSnapshot) diff(other nodeSnapshot) string {
+	out := ""
+	keys := unionKeys(s.vertices, other.vertices)
+	for _, k := range keys {
+		a, ok1 := s.vertices[k]
+		b, ok2 := other.vertices[k]
+		switch {
+		case ok1 && !ok2:
+			out += fmt.Sprintf("  vertex %q present in A, missing in B\n", k)
+		case !ok1 && ok2:
+			out += fmt.Sprintf("  vertex %q missing in A, present in B\n", k)
+		case string(a) != string(b):
+			out += fmt.Sprintf("  vertex %q diverged: A=%x B=%x\n", k, a, b)
+		}
+	}
+	ekeys := unionEdgeKeys(s.weights, other.weights)
+	for _, e := range ekeys {
+		a, ok1 := s.weights[e]
+		b, ok2 := other.weights[e]
+		switch {
+		case ok1 && !ok2:
+			out += fmt.Sprintf("  edge %v present in A (w=%g), missing in B\n", e, a)
+		case !ok1 && ok2:
+			out += fmt.Sprintf("  edge %v missing in A, present in B (w=%g)\n", e, b)
+		case a != b:
+			out += fmt.Sprintf("  edge %v weight diverged: A=%g B=%g\n", e, a, b)
+		}
+	}
+	return out
+}
+
+func unionKeys(a, b map[string][]byte) []string {
+	seen := map[string]struct{}{}
+	for k := range a {
+		seen[k] = struct{}{}
+	}
+	for k := range b {
+		seen[k] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func unionEdgeKeys(a, b map[[2]string]float32) [][2]string {
+	seen := map[[2]string]struct{}{}
+	for k := range a {
+		seen[k] = struct{}{}
+	}
+	for k := range b {
+		seen[k] = struct{}{}
+	}
+	out := make([][2]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i][0] != out[j][0] {
+			return out[i][0] < out[j][0]
+		}
+		return out[i][1] < out[j][1]
+	})
+	return out
+}
+
+func mustMarshal(v *pb.Vertex) []byte {
+	b, err := proto.MarshalOptions{Deterministic: true}.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/server/service/backend.go
+++ b/server/service/backend.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/anaregdesign/lantern/core/cache/graph"
 	coregraph "github.com/anaregdesign/lantern/core/graph"
+	"github.com/anaregdesign/lantern/core/hlc"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 )
 
@@ -27,6 +28,21 @@ type Backend interface {
 	AddEdgesWithExpiration(items []graph.EdgeItem[string])
 	PutEdgesWithExpiration(items []graph.EdgeItem[string])
 	DeleteEdges(keys []graph.EdgeKey[string]) int
+
+	// replicated-write entry points used by ApplyMutation (#182).
+	//
+	// AddEdgeWithExpirationContrib records an additive edge contribution
+	// stamped with contribID; re-applying a mutation with the same id is
+	// a no-op (returns false). Local non-replicated writes keep using
+	// AddEdgesWithExpiration with a zero contribID.
+	//
+	// PutVertexWithExpirationHLC / PutEdgeWithExpirationHLC compare ts
+	// against the stored last-write HLC and silently drop strictly-older
+	// writes (LWW). Equal-ts writes apply (idempotent for value-equal
+	// payloads).
+	AddEdgeWithExpirationContrib(tail, head string, w float32, expiration time.Time, contribID graph.ContribID) bool
+	PutVertexWithExpirationHLC(key string, value *pb.Vertex, expiration time.Time, ts hlc.Timestamp) bool
+	PutEdgeWithExpirationHLC(tail, head string, w float32, expiration time.Time, ts hlc.Timestamp) bool
 
 	// neighborhood traversal
 	NeighborWithExpirationsContext(

--- a/server/service/fake_backend_test.go
+++ b/server/service/fake_backend_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/anaregdesign/lantern/core/cache/graph"
 	coregraph "github.com/anaregdesign/lantern/core/graph"
+	"github.com/anaregdesign/lantern/core/hlc"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -212,6 +213,32 @@ func (f *fakeBackend) ScanEdgesByPrefix(_ context.Context, tailPrefix, headPrefi
 
 // Compile-time check that fakeBackend really satisfies Backend.
 var _ Backend = (*fakeBackend)(nil)
+
+// Replicated-write entry points (#182). The fake mirrors the production
+// semantics with a minimal in-memory model so service-level tests that
+// touch ApplyMutation can run against the fake without spinning up a
+// real GraphCache. It does not enforce HLC/ContribID dedup — tests that
+// care about convergence use the real backend.
+func (f *fakeBackend) AddEdgeWithExpirationContrib(tail, head string, w float32, _ time.Time, _ graph.ContribID) bool {
+	if f.edges[tail] == nil {
+		f.edges[tail] = map[string]float32{}
+	}
+	f.edges[tail][head] += w
+	return true
+}
+
+func (f *fakeBackend) PutVertexWithExpirationHLC(key string, value *pb.Vertex, _ time.Time, _ hlc.Timestamp) bool {
+	f.vertices[key] = value
+	return true
+}
+
+func (f *fakeBackend) PutEdgeWithExpirationHLC(tail, head string, w float32, _ time.Time, _ hlc.Timestamp) bool {
+	if f.edges[tail] == nil {
+		f.edges[tail] = map[string]float32{}
+	}
+	f.edges[tail][head] = w
+	return true
+}
 
 func TestLanternService_FakeBackend_PutGetDelete(t *testing.T) {
 	fb := newFakeBackend()


### PR DESCRIPTION
Closes #182.

## Summary

Adds `LanternService.ApplyMutation(ctx, *pb.Mutation) error` — the internal entry point that the peer-pump (#184) and snapshot bootstrap (#183) will use to replay a remote node's `Mutation` against the local cache. It is intentionally **not** a gRPC method: external clients keep using the regular write RPCs (which append to the local log), and `ApplyMutation` deliberately bypasses `logMutation` so a replayed write is never re-broadcast.

## Design

- **Dispatch.** Switches on all 11 `MutationOp` oneof variants:
  - `Put*` → `PutVertexWithExpirationHLC` / `PutEdgeWithExpirationHLC` (LWW; strictly-older HLCs are dropped silently in the backend, equal-ts writes converge by value).
  - `Add*` → `AddEdgeWithExpirationContrib` (ContribID-dedup; replays are no-ops).
  - `Delete*` → existing destructive batch APIs. Tombstone + TTL clamp semantics for cross-peer delete convergence are deferred to **#183** (called out in `apply.go` and propagated to #183/#184 findings).
- **ContribID packing.** `contribIDFor(origin, seq, idx)` lays out:
  - bytes `[0:16]` = origin NodeID
  - bytes `[16:24]` = big-endian `uint64` = `(seq << 16) | idx`

  This lets a single `AddEdges` batch carry up to 65 536 distinct edges while replays of the same `(origin, seq, idx)` triple dedup. Peers MUST use the same packing — documented for #184's pump.
- **HLC.** `hlcFromProto(*pb.HLCTimestamp)` converts the wire HLC; `nil` → zero `hlc.Timestamp`, which the backend `Less()` treats as the minimum.
- **No log append.** `ApplyMutation` never calls `s.logMutation` — that prevents the replication loop. #184's pump must not re-append either.
- **Origin filtering.** Not the responsibility of `ApplyMutation` — the caller (peer pump) must skip its own origin.

## Backend interface

Widens `service.Backend` with the three #181 replication APIs so that the cache can be driven LWW/dedup-aware:

```go
AddEdgeWithExpirationContrib(tail, head string, w float32, expiration time.Time, contribID graph.ContribID) bool
PutVertexWithExpirationHLC(key string, value *pb.Vertex, expiration time.Time, ts hlc.Timestamp) bool
PutEdgeWithExpirationHLC(tail, head string, w float32, expiration time.Time, ts hlc.Timestamp) bool
```

`fakeBackend` (test double) gets minimal stubs that mirror the production signatures but **do not** enforce HLC/ContribID dedup — convergence tests use the real `*graph.GraphCache`, which already satisfies `Backend` directly.

## Tests (`apply_test.go`)

1. **`TestApplyMutation_BasicOps`** — walks all 11 oneof variants through the fake backend.
2. **`TestApplyMutation_DoesNotLog`** — applies a mutation and asserts the mutation log stays empty (`_, ok := log.LastSeq(); !ok`).
3. **`TestApplyMutation_Convergence`** — 1000 traces × 12 mutations × 3 peers:
   - Per-edge **Add-only OR Put-only** partition (the same `(tail, head)` pair is never mixed). This keeps the running `weight.sum += value` order-independent under float32: Adds use weight=1 so the sum is the dedup count; Puts use integer weights so LWW is exact.
   - Each peer gets a randomly shuffled delivery order plus random duplicates.
   - Asserts bit-exact equality of vertex bytes and edge weights across all peers.
4. **`TestApplyMutation_Idempotence`** — applying the same mutation twice equals applying it once.

## Files changed

- `server/service/apply.go` (new)
- `server/service/apply_test.go` (new)
- `server/service/backend.go` (widened interface)
- `server/service/fake_backend_test.go` (added stubs)

## Verification

```
go vet ./...                                         # clean
go test -race -count=1 ./server/...                  # all packages green
go test -race -count=1 -run ApplyMutation ./server/service/...  # ~2s
make wire                                            # regenerated cleanly
```

## Follow-ups (already propagated to issue findings)

- **#183** — replace plain `Delete*` calls with tombstone-aware variants; harden `DeleteByPrefix(limit=0)`.
- **#184** — peer pump must use `contribIDFor` packing verbatim, hold `*LanternService` (not `LanternReplicationService`), skip own-origin mutations, and never re-append to the local log.
- **#185** — convergence tests on Delete* must wait for tombstones.
