### PR TITLE
feat(server): Snapshot streaming RPC (#184)

### DIFF
--- a/core/cache/cache.go
+++ b/core/cache/cache.go
@@ -145,6 +145,28 @@ func (c *Cache[S, T]) Count() int {
 	return len(c.cache)
 }
 
+// Range invokes fn for every live (non-expired) entry. fn returns false to
+// stop iteration early; the boolean return mirrors the iter.Seq2 contract
+// callers may already be wired against. Range takes c.mu.RLock for the
+// duration of the walk, so fn MUST NOT call back into the same Cache
+// (which would acquire c.mu.Lock and deadlock with the reader-priority
+// blockage described in #202). The intended consumer is the replication
+// snapshot path (#184), which iterates under the GraphCache write lock
+// where this constraint is trivially satisfied.
+func (c *Cache[S, T]) Range(fn func(key S, value T, expiration time.Time) bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	now := time.Now()
+	for k, v := range c.cache {
+		if v.expiration.Before(now) {
+			continue
+		}
+		if !fn(k, v.value, v.expiration) {
+			return
+		}
+	}
+}
+
 // Flush evicts every entry whose TTL has passed. It returns the number of
 // entries removed so callers (e.g. server-side TTL metrics) can record
 // expiration counts without scanning the cache again. When an OnEvict

--- a/core/cache/graph/edge.go
+++ b/core/cache/graph/edge.go
@@ -163,6 +163,34 @@ func (w *weight) snapshot() (sum float32, latest time.Time, nonZero bool) {
 	return w.sum, latest, w.sum != 0
 }
 
+// snapshotEntry returns a copy of the bucket's live contributions, the
+// recorded lastHLC, and whether any live contributions remain — all under
+// a single lock. Used by the replication snapshot path (#184) to preserve
+// per-contribution decomposition (so the receiver's ContribID dedup stays
+// effective when the live tail re-delivers the same writes).
+//
+// `now` is passed in so an entire snapshot pass observes a single
+// reference time and edges decide expiration consistently.
+func (w *weight) snapshotEntry(now time.Time) ([]SnapshotContribution, hlc.Timestamp, bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([]SnapshotContribution, 0, len(w.values))
+	for _, v := range w.values {
+		if !v.expiration.After(now) {
+			continue
+		}
+		out = append(out, SnapshotContribution{
+			Weight:     v.value,
+			Expiration: v.expiration,
+			ContribID:  v.contribID,
+		})
+	}
+	if len(out) == 0 {
+		return nil, w.lastHLC, false
+	}
+	return out, w.lastHLC, true
+}
+
 // flushLocked compacts expired entries in place and recomputes the cached sum.
 // Caller must hold w.mu.
 func (w *weight) flushLocked() {
@@ -322,6 +350,33 @@ func (c *edgeCache[S]) snapshotTF() map[S]map[S]*weight {
 		out[tail] = row
 	}
 	return out
+}
+
+// rangeBuckets invokes fn for every (tail, head, *weight) live in the
+// cache, resolving both endpoints back to S under the edgeCache RLock.
+// fn returns false to stop iteration early. Used by the replication
+// snapshot path (#184); the per-bucket *weight pointer is safe to read
+// after the iteration returns because GraphCache.SnapshotEdges holds
+// c.GraphCache.mu for the whole snapshot pass and no concurrent mutator
+// can drop the bucket out from under it.
+func (c *edgeCache[S]) rangeBuckets(fn func(tail, head S, w *weight) bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for tailID, heads := range c.tf {
+		tail, ok := c.resolve(tailID)
+		if !ok {
+			continue
+		}
+		for headID, w := range heads {
+			head, ok := c.resolve(headID)
+			if !ok {
+				continue
+			}
+			if !fn(tail, head, w) {
+				return
+			}
+		}
+	}
 }
 
 func (c *edgeCache[S]) snapshotDF() map[S]int {

--- a/core/cache/graph/snapshot.go
+++ b/core/cache/graph/snapshot.go
@@ -1,0 +1,102 @@
+package graph
+
+import (
+	"time"
+
+	"github.com/anaregdesign/lantern/core/hlc"
+)
+
+// SnapshotVertex is one entry of GraphCache.SnapshotVertices. It carries
+// the live vertex value, its expiration, and the last replication HLC the
+// LWW apply path (#182) recorded for this key. HLC is the zero value when
+// the vertex has never been touched by a replicated Put — that means
+// "no causal floor", which is exactly what receivers feed back into
+// PutVertexWithExpirationHLC.
+type SnapshotVertex[S comparable, T any] struct {
+	Key        S
+	Value      T
+	Expiration time.Time
+	HLC        hlc.Timestamp
+}
+
+// SnapshotContribution mirrors a single live entry inside an edge's
+// weight bucket. Snapshot deliberately preserves the per-contribution
+// decomposition so that the receiver's ContribID dedup (#182) continues
+// to suppress duplicates when the live tail re-delivers the same
+// contribution after bootstrap.
+type SnapshotContribution struct {
+	Weight     float32
+	Expiration time.Time
+	ContribID  ContribID
+}
+
+// SnapshotEdge is one entry of GraphCache.SnapshotEdges. HLC carries the
+// bucket's last LWW position (zero when no LWW write has happened); the
+// receiver uses it as the causal floor when replaying each contribution
+// via AddEdgeWithExpirationContribHLC.
+type SnapshotEdge[S comparable] struct {
+	Tail          S
+	Head          S
+	HLC           hlc.Timestamp
+	Contributions []SnapshotContribution
+}
+
+// SnapshotVertices returns a materialised snapshot of every live vertex
+// in the cache. The snapshot is taken under a single write-lock pass; the
+// returned slice is independent of the cache and safe to iterate without
+// further locking. Expired vertices (those past Expiration at snapshot
+// time) are skipped.
+//
+// Memory cost is O(N) in the live vertex count — the API is intended for
+// replication bootstrap (#184), which is a bounded, infrequent operation.
+// Hot read paths should keep using GetVertex.
+func (c *GraphCache[S, T]) SnapshotVertices() []SnapshotVertex[S, T] {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.vertices.Flush()
+	out := make([]SnapshotVertex[S, T], 0, c.vertices.Count())
+	c.vertices.Range(func(key S, value T, expiration time.Time) bool {
+		var ts hlc.Timestamp
+		if c.vertexHLC != nil {
+			ts = c.vertexHLC[key]
+		}
+		out = append(out, SnapshotVertex[S, T]{
+			Key:        key,
+			Value:      value,
+			Expiration: expiration,
+			HLC:        ts,
+		})
+		return true
+	})
+	return out
+}
+
+// SnapshotEdges returns a materialised snapshot of every live edge in the
+// cache, preserving the per-contribution weight decomposition. The
+// snapshot is taken under a single write-lock pass; the returned slice is
+// independent of the cache. Edges whose every contribution has decayed
+// are skipped (they would otherwise show up as ghost entries with zero
+// total weight).
+//
+// Memory cost is O(E + sum of bucket sizes); same scope rationale as
+// SnapshotVertices.
+func (c *GraphCache[S, T]) SnapshotEdges() []SnapshotEdge[S] {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	out := make([]SnapshotEdge[S], 0, c.edges.count())
+	c.edges.rangeBuckets(func(tail, head S, w *weight) bool {
+		contribs, ts, nonEmpty := w.snapshotEntry(now)
+		if !nonEmpty {
+			return true
+		}
+		out = append(out, SnapshotEdge[S]{
+			Tail:          tail,
+			Head:          head,
+			HLC:           ts,
+			Contributions: contribs,
+		})
+		return true
+	})
+	return out
+}

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -301,9 +301,9 @@ Handler implementation notes (issue #180):
 ### 8.3 Snapshot (server streaming)
 
 ```proto
-rpc Snapshot(SnapshotRequest) returns (stream SnapshotEntry);
+rpc Snapshot(SnapshotRequest) returns (stream SnapshotResponse);
 
-message SnapshotEntry {
+message SnapshotResponse {
   oneof entry {
     SnapshotHeader header = 1;   // first frame: cutoff_seq + cutoff_hlc
     SnapshotVertex vertex = 2;   // body: live vertex with stored HLC

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -301,21 +301,70 @@ Handler implementation notes (issue #180):
 ### 8.3 Snapshot (server streaming)
 
 ```proto
-rpc Snapshot(SnapshotRequest) returns (stream SnapshotChunk);
+rpc Snapshot(SnapshotRequest) returns (stream SnapshotEntry);
 
-message SnapshotChunk {
-  oneof chunk {
-    Vertex vertex = 1;
-    EdgeContribution edge = 2;
-    Tombstone tombstone = 3;
-    Cutoff cutoff = 4;     // terminal frame: { last_seq, last_hlc }
+message SnapshotEntry {
+  oneof entry {
+    SnapshotHeader header = 1;   // first frame: cutoff_seq + cutoff_hlc
+    SnapshotVertex vertex = 2;   // body: live vertex with stored HLC
+    SnapshotEdge   edge   = 3;   // body: edge with per-contribution payloads
+    SnapshotFooter footer = 4;   // last frame: streamed vertex/edge counts
   }
+}
+
+message SnapshotHeader {
+  uint64 cutoff_seq = 1;
+  HLCTimestamp cutoff_hlc = 2;
+}
+
+message SnapshotEdge {
+  string tail = 1;
+  string head = 2;
+  HLCTimestamp hlc = 3;
+  repeated SnapshotEdgeContribution contributions = 4;
+}
+
+message SnapshotEdgeContribution {
+  float weight = 1;
+  google.protobuf.Timestamp expiration = 2;
+  bytes contrib_id = 3;   // 24-byte ContribID; empty = local-only
 }
 ```
 
-The terminal `Cutoff` frame tells the consumer the exact `(seq, hlc)` to
-resume `Subscribe` from. Without it, the consumer cannot stitch the snapshot
-stream and the live tail without either missing or double-applying mutations.
+Framing contract:
+
+- The **header** is always the first frame. `cutoff_seq` is the primary's
+  `mutationlog.LastSeq()` at snapshot-open time (0 when the log is empty
+  — the peer Subscribes from seq 1). `cutoff_hlc` is the primary's
+  `clock.Now()` at snapshot-open time. The consumer Subscribes at
+  `cutoff_seq + 1` to stitch the snapshot and the live tail.
+- The **footer** is always the last frame. It reports the actually
+  streamed vertex and edge counts so consumers can detect truncation
+  without parsing a sentinel-typed body frame.
+- The snapshot deliberately preserves **per-contribution decomposition**:
+  each `SnapshotEdge` carries its full list of live `SnapshotEdgeContribution`
+  rows rather than a pre-summed weight. The consumer replays each
+  contribution via `AddEdgeWithExpirationContribHLC`, and the receiver's
+  `ContribID` dedup makes the snapshot-then-Subscribe-tail handoff
+  idempotent: any contribution that also appears in the replayed tail is
+  detected and dropped at apply time.
+
+Implementation notes:
+
+- The handler is `LanternReplicationService.Snapshot` in
+  `server/service/replication.go`. It holds references to the same
+  `Backend` and `*hlc.Clock` the write path uses; both are wired in
+  `server/cmd/wire.go`. `Snapshot` materialises vertices and edges via
+  `Backend.SnapshotVertices()` / `Backend.SnapshotEdges()` (which lock
+  the GraphCache once each) and streams them frame-by-frame, honouring
+  `stream.Context()` cancellation between sends.
+- v1 materialises the full snapshot in memory. Bootstrap is a bounded,
+  one-peer-at-a-time operation, so the O(N+E) overhead is acceptable.
+  Cursor-based / chunked snapshotting is a follow-up once the bootstrap
+  path is exercised at scale (tracked alongside #190).
+- Tombstones are NOT carried as standalone frames. The cache snapshot
+  returns only live state; the receiver re-derives tombstones from the
+  Subscribe tail beginning at `cutoff_seq + 1`.
 
 ## 9. Bootstrap flow
 
@@ -326,11 +375,12 @@ new pod boots
   │
   ├── for each peer P (in parallel; first to respond wins):
   │     stream = P.Snapshot(SnapshotRequest{})
-  │     apply chunks → local cache
-  │     cutoff = stream.Cutoff
+  │     header  = stream.Recv()      // {cutoff_seq, cutoff_hlc}
+  │     apply  body frames → local cache
+  │     footer = last frame          // assert counts match
   │
   ├── for each peer P:
-  │     go pump(P, from_seq = cutoff.seq + 1)
+  │     go pump(P, from_seq = header.cutoff_seq + 1)
   │
   └── /healthz/ready flips SERVING when:
         - lag(P) < LANTERN_MAX_REPLICATION_LAG for all peers, OR

--- a/pb/graph/v1/replication.pb.go
+++ b/pb/graph/v1/replication.pb.go
@@ -539,7 +539,7 @@ func (*SnapshotRequest) Descriptor() ([]byte, []int) {
 	return file_graph_v1_replication_proto_rawDescGZIP(), []int{5}
 }
 
-// SnapshotHeader is always the FIRST SnapshotEntry on the wire. It freezes
+// SnapshotHeader is always the FIRST SnapshotResponse on the wire. It freezes
 // the (seq, hlc) cutoff the server used to materialise the snapshot. A
 // bootstrapping peer MUST persist (cutoff_seq, cutoff_hlc) before applying
 // any payload entries and MUST resume `Subscribe` from cutoff_seq + 1 so
@@ -596,7 +596,7 @@ func (x *SnapshotHeader) GetCutoffHlc() *HLCTimestamp {
 	return nil
 }
 
-// SnapshotFooter is always the LAST SnapshotEntry on the wire. It carries
+// SnapshotFooter is always the LAST SnapshotResponse on the wire. It carries
 // the running counts the server actually streamed so receivers can detect
 // truncation (channel-close, send-error mid-stream) without re-walking
 // their freshly-imported state.
@@ -852,38 +852,38 @@ func (x *SnapshotEdge) GetContributions() []*SnapshotEdgeContribution {
 	return nil
 }
 
-// SnapshotEntry is the union type streamed from `rpc Snapshot`. The frame
+// SnapshotResponse is the union type streamed from `rpc Snapshot`. The frame
 // order is always: exactly one SnapshotHeader, then zero or more
 // SnapshotVertex frames, then zero or more SnapshotEdge frames, then
 // exactly one SnapshotFooter. Receivers SHOULD treat any other order as a
 // protocol violation.
-type SnapshotEntry struct {
+type SnapshotResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Entry:
 	//
-	//	*SnapshotEntry_Header
-	//	*SnapshotEntry_Vertex
-	//	*SnapshotEntry_Edge
-	//	*SnapshotEntry_Footer
-	Entry         isSnapshotEntry_Entry `protobuf_oneof:"entry"`
+	//	*SnapshotResponse_Header
+	//	*SnapshotResponse_Vertex
+	//	*SnapshotResponse_Edge
+	//	*SnapshotResponse_Footer
+	Entry         isSnapshotResponse_Entry `protobuf_oneof:"entry"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *SnapshotEntry) Reset() {
-	*x = SnapshotEntry{}
+func (x *SnapshotResponse) Reset() {
+	*x = SnapshotResponse{}
 	mi := &file_graph_v1_replication_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *SnapshotEntry) String() string {
+func (x *SnapshotResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*SnapshotEntry) ProtoMessage() {}
+func (*SnapshotResponse) ProtoMessage() {}
 
-func (x *SnapshotEntry) ProtoReflect() protoreflect.Message {
+func (x *SnapshotResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_graph_v1_replication_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -895,81 +895,81 @@ func (x *SnapshotEntry) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use SnapshotEntry.ProtoReflect.Descriptor instead.
-func (*SnapshotEntry) Descriptor() ([]byte, []int) {
+// Deprecated: Use SnapshotResponse.ProtoReflect.Descriptor instead.
+func (*SnapshotResponse) Descriptor() ([]byte, []int) {
 	return file_graph_v1_replication_proto_rawDescGZIP(), []int{11}
 }
 
-func (x *SnapshotEntry) GetEntry() isSnapshotEntry_Entry {
+func (x *SnapshotResponse) GetEntry() isSnapshotResponse_Entry {
 	if x != nil {
 		return x.Entry
 	}
 	return nil
 }
 
-func (x *SnapshotEntry) GetHeader() *SnapshotHeader {
+func (x *SnapshotResponse) GetHeader() *SnapshotHeader {
 	if x != nil {
-		if x, ok := x.Entry.(*SnapshotEntry_Header); ok {
+		if x, ok := x.Entry.(*SnapshotResponse_Header); ok {
 			return x.Header
 		}
 	}
 	return nil
 }
 
-func (x *SnapshotEntry) GetVertex() *SnapshotVertex {
+func (x *SnapshotResponse) GetVertex() *SnapshotVertex {
 	if x != nil {
-		if x, ok := x.Entry.(*SnapshotEntry_Vertex); ok {
+		if x, ok := x.Entry.(*SnapshotResponse_Vertex); ok {
 			return x.Vertex
 		}
 	}
 	return nil
 }
 
-func (x *SnapshotEntry) GetEdge() *SnapshotEdge {
+func (x *SnapshotResponse) GetEdge() *SnapshotEdge {
 	if x != nil {
-		if x, ok := x.Entry.(*SnapshotEntry_Edge); ok {
+		if x, ok := x.Entry.(*SnapshotResponse_Edge); ok {
 			return x.Edge
 		}
 	}
 	return nil
 }
 
-func (x *SnapshotEntry) GetFooter() *SnapshotFooter {
+func (x *SnapshotResponse) GetFooter() *SnapshotFooter {
 	if x != nil {
-		if x, ok := x.Entry.(*SnapshotEntry_Footer); ok {
+		if x, ok := x.Entry.(*SnapshotResponse_Footer); ok {
 			return x.Footer
 		}
 	}
 	return nil
 }
 
-type isSnapshotEntry_Entry interface {
-	isSnapshotEntry_Entry()
+type isSnapshotResponse_Entry interface {
+	isSnapshotResponse_Entry()
 }
 
-type SnapshotEntry_Header struct {
+type SnapshotResponse_Header struct {
 	Header *SnapshotHeader `protobuf:"bytes,1,opt,name=header,proto3,oneof"`
 }
 
-type SnapshotEntry_Vertex struct {
+type SnapshotResponse_Vertex struct {
 	Vertex *SnapshotVertex `protobuf:"bytes,2,opt,name=vertex,proto3,oneof"`
 }
 
-type SnapshotEntry_Edge struct {
+type SnapshotResponse_Edge struct {
 	Edge *SnapshotEdge `protobuf:"bytes,3,opt,name=edge,proto3,oneof"`
 }
 
-type SnapshotEntry_Footer struct {
+type SnapshotResponse_Footer struct {
 	Footer *SnapshotFooter `protobuf:"bytes,4,opt,name=footer,proto3,oneof"`
 }
 
-func (*SnapshotEntry_Header) isSnapshotEntry_Entry() {}
+func (*SnapshotResponse_Header) isSnapshotResponse_Entry() {}
 
-func (*SnapshotEntry_Vertex) isSnapshotEntry_Entry() {}
+func (*SnapshotResponse_Vertex) isSnapshotResponse_Entry() {}
 
-func (*SnapshotEntry_Edge) isSnapshotEntry_Entry() {}
+func (*SnapshotResponse_Edge) isSnapshotResponse_Entry() {}
 
-func (*SnapshotEntry_Footer) isSnapshotEntry_Entry() {}
+func (*SnapshotResponse_Footer) isSnapshotResponse_Entry() {}
 
 var File_graph_v1_replication_proto protoreflect.FileDescriptor
 
@@ -1030,16 +1030,16 @@ const file_graph_v1_replication_proto_rawDesc = "" +
 	"\x04tail\x18\x01 \x01(\tR\x04tail\x12\x12\n" +
 	"\x04head\x18\x02 \x01(\tR\x04head\x12(\n" +
 	"\x03hlc\x18\x03 \x01(\v2\x16.graph.v1.HLCTimestampR\x03hlc\x12H\n" +
-	"\rcontributions\x18\x04 \x03(\v2\".graph.v1.SnapshotEdgeContributionR\rcontributions\"\xe2\x01\n" +
-	"\rSnapshotEntry\x122\n" +
+	"\rcontributions\x18\x04 \x03(\v2\".graph.v1.SnapshotEdgeContributionR\rcontributions\"\xe5\x01\n" +
+	"\x10SnapshotResponse\x122\n" +
 	"\x06header\x18\x01 \x01(\v2\x18.graph.v1.SnapshotHeaderH\x00R\x06header\x122\n" +
 	"\x06vertex\x18\x02 \x01(\v2\x18.graph.v1.SnapshotVertexH\x00R\x06vertex\x12,\n" +
 	"\x04edge\x18\x03 \x01(\v2\x16.graph.v1.SnapshotEdgeH\x00R\x04edge\x122\n" +
 	"\x06footer\x18\x04 \x01(\v2\x18.graph.v1.SnapshotFooterH\x00R\x06footerB\a\n" +
-	"\x05entry2\xa5\x01\n" +
+	"\x05entry2\xa8\x01\n" +
 	"\x19LanternReplicationService\x12F\n" +
-	"\tSubscribe\x12\x1a.graph.v1.SubscribeRequest\x1a\x1b.graph.v1.SubscribeResponse0\x01\x12@\n" +
-	"\bSnapshot\x12\x19.graph.v1.SnapshotRequest\x1a\x17.graph.v1.SnapshotEntry0\x01B\x96\x01\n" +
+	"\tSubscribe\x12\x1a.graph.v1.SubscribeRequest\x1a\x1b.graph.v1.SubscribeResponse0\x01\x12C\n" +
+	"\bSnapshot\x12\x19.graph.v1.SnapshotRequest\x1a\x1a.graph.v1.SnapshotResponse0\x01B\x96\x01\n" +
 	"\fcom.graph.v1B\x10ReplicationProtoP\x01Z3github.com/anaregdesign/lantern/pb/graph/v1;graphv1\xa2\x02\x03GXX\xaa\x02\bGraph.V1\xca\x02\bGraph\\V1\xe2\x02\x14Graph\\V1\\GPBMetadata\xea\x02\tGraph::V1b\x06proto3"
 
 var (
@@ -1067,7 +1067,7 @@ var file_graph_v1_replication_proto_goTypes = []any{
 	(*SnapshotVertex)(nil),                // 8: graph.v1.SnapshotVertex
 	(*SnapshotEdgeContribution)(nil),      // 9: graph.v1.SnapshotEdgeContribution
 	(*SnapshotEdge)(nil),                  // 10: graph.v1.SnapshotEdge
-	(*SnapshotEntry)(nil),                 // 11: graph.v1.SnapshotEntry
+	(*SnapshotResponse)(nil),              // 11: graph.v1.SnapshotResponse
 	(*PutVertexRequest)(nil),              // 12: graph.v1.PutVertexRequest
 	(*PutVerticesRequest)(nil),            // 13: graph.v1.PutVerticesRequest
 	(*DeleteVertexRequest)(nil),           // 14: graph.v1.DeleteVertexRequest
@@ -1103,14 +1103,14 @@ var file_graph_v1_replication_proto_depIdxs = []int32{
 	24, // 17: graph.v1.SnapshotEdgeContribution.expiration:type_name -> google.protobuf.Timestamp
 	0,  // 18: graph.v1.SnapshotEdge.hlc:type_name -> graph.v1.HLCTimestamp
 	9,  // 19: graph.v1.SnapshotEdge.contributions:type_name -> graph.v1.SnapshotEdgeContribution
-	6,  // 20: graph.v1.SnapshotEntry.header:type_name -> graph.v1.SnapshotHeader
-	8,  // 21: graph.v1.SnapshotEntry.vertex:type_name -> graph.v1.SnapshotVertex
-	10, // 22: graph.v1.SnapshotEntry.edge:type_name -> graph.v1.SnapshotEdge
-	7,  // 23: graph.v1.SnapshotEntry.footer:type_name -> graph.v1.SnapshotFooter
+	6,  // 20: graph.v1.SnapshotResponse.header:type_name -> graph.v1.SnapshotHeader
+	8,  // 21: graph.v1.SnapshotResponse.vertex:type_name -> graph.v1.SnapshotVertex
+	10, // 22: graph.v1.SnapshotResponse.edge:type_name -> graph.v1.SnapshotEdge
+	7,  // 23: graph.v1.SnapshotResponse.footer:type_name -> graph.v1.SnapshotFooter
 	3,  // 24: graph.v1.LanternReplicationService.Subscribe:input_type -> graph.v1.SubscribeRequest
 	5,  // 25: graph.v1.LanternReplicationService.Snapshot:input_type -> graph.v1.SnapshotRequest
 	4,  // 26: graph.v1.LanternReplicationService.Subscribe:output_type -> graph.v1.SubscribeResponse
-	11, // 27: graph.v1.LanternReplicationService.Snapshot:output_type -> graph.v1.SnapshotEntry
+	11, // 27: graph.v1.LanternReplicationService.Snapshot:output_type -> graph.v1.SnapshotResponse
 	26, // [26:28] is the sub-list for method output_type
 	24, // [24:26] is the sub-list for method input_type
 	24, // [24:24] is the sub-list for extension type_name
@@ -1138,10 +1138,10 @@ func file_graph_v1_replication_proto_init() {
 		(*MutationOp_DeleteEdges)(nil),
 	}
 	file_graph_v1_replication_proto_msgTypes[11].OneofWrappers = []any{
-		(*SnapshotEntry_Header)(nil),
-		(*SnapshotEntry_Vertex)(nil),
-		(*SnapshotEntry_Edge)(nil),
-		(*SnapshotEntry_Footer)(nil),
+		(*SnapshotResponse_Header)(nil),
+		(*SnapshotResponse_Vertex)(nil),
+		(*SnapshotResponse_Edge)(nil),
+		(*SnapshotResponse_Footer)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/pb/graph/v1/replication.pb.go
+++ b/pb/graph/v1/replication.pb.go
@@ -9,6 +9,7 @@ package graphv1
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -498,11 +499,483 @@ func (x *SubscribeResponse) GetMutation() *Mutation {
 	return nil
 }
 
+// SnapshotRequest opens a server-streaming snapshot of the entire live
+// graph state at a single causal cutoff. The request body is intentionally
+// empty in this phase (#184); future revisions may add prefix / shard
+// filters without breaking the wire contract.
+type SnapshotRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SnapshotRequest) Reset() {
+	*x = SnapshotRequest{}
+	mi := &file_graph_v1_replication_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotRequest) ProtoMessage() {}
+
+func (x *SnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_replication_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SnapshotRequest.ProtoReflect.Descriptor instead.
+func (*SnapshotRequest) Descriptor() ([]byte, []int) {
+	return file_graph_v1_replication_proto_rawDescGZIP(), []int{5}
+}
+
+// SnapshotHeader is always the FIRST SnapshotEntry on the wire. It freezes
+// the (seq, hlc) cutoff the server used to materialise the snapshot. A
+// bootstrapping peer MUST persist (cutoff_seq, cutoff_hlc) before applying
+// any payload entries and MUST resume `Subscribe` from cutoff_seq + 1 so
+// the snapshot and the live tail stitch without gap or overlap.
+type SnapshotHeader struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CutoffSeq     uint64                 `protobuf:"varint,1,opt,name=cutoff_seq,json=cutoffSeq,proto3" json:"cutoff_seq,omitempty"`
+	CutoffHlc     *HLCTimestamp          `protobuf:"bytes,2,opt,name=cutoff_hlc,json=cutoffHlc,proto3" json:"cutoff_hlc,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SnapshotHeader) Reset() {
+	*x = SnapshotHeader{}
+	mi := &file_graph_v1_replication_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SnapshotHeader) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotHeader) ProtoMessage() {}
+
+func (x *SnapshotHeader) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_replication_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SnapshotHeader.ProtoReflect.Descriptor instead.
+func (*SnapshotHeader) Descriptor() ([]byte, []int) {
+	return file_graph_v1_replication_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *SnapshotHeader) GetCutoffSeq() uint64 {
+	if x != nil {
+		return x.CutoffSeq
+	}
+	return 0
+}
+
+func (x *SnapshotHeader) GetCutoffHlc() *HLCTimestamp {
+	if x != nil {
+		return x.CutoffHlc
+	}
+	return nil
+}
+
+// SnapshotFooter is always the LAST SnapshotEntry on the wire. It carries
+// the running counts the server actually streamed so receivers can detect
+// truncation (channel-close, send-error mid-stream) without re-walking
+// their freshly-imported state.
+type SnapshotFooter struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	VertexCount   uint64                 `protobuf:"varint,1,opt,name=vertex_count,json=vertexCount,proto3" json:"vertex_count,omitempty"`
+	EdgeCount     uint64                 `protobuf:"varint,2,opt,name=edge_count,json=edgeCount,proto3" json:"edge_count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SnapshotFooter) Reset() {
+	*x = SnapshotFooter{}
+	mi := &file_graph_v1_replication_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SnapshotFooter) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotFooter) ProtoMessage() {}
+
+func (x *SnapshotFooter) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_replication_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SnapshotFooter.ProtoReflect.Descriptor instead.
+func (*SnapshotFooter) Descriptor() ([]byte, []int) {
+	return file_graph_v1_replication_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *SnapshotFooter) GetVertexCount() uint64 {
+	if x != nil {
+		return x.VertexCount
+	}
+	return 0
+}
+
+func (x *SnapshotFooter) GetEdgeCount() uint64 {
+	if x != nil {
+		return x.EdgeCount
+	}
+	return 0
+}
+
+// SnapshotVertex is the snapshot-time representation of a single live
+// vertex. The HLC field carries the last LWW timestamp the source node
+// recorded for the key (zero when the vertex has never been touched by a
+// replicated Put, i.e. local-only writes); receivers feed it back through
+// PutVertexWithExpirationHLC so subsequent older replays (#182) are
+// correctly rejected.
+type SnapshotVertex struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Vertex        *Vertex                `protobuf:"bytes,1,opt,name=vertex,proto3" json:"vertex,omitempty"`
+	Hlc           *HLCTimestamp          `protobuf:"bytes,2,opt,name=hlc,proto3" json:"hlc,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SnapshotVertex) Reset() {
+	*x = SnapshotVertex{}
+	mi := &file_graph_v1_replication_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SnapshotVertex) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotVertex) ProtoMessage() {}
+
+func (x *SnapshotVertex) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_replication_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SnapshotVertex.ProtoReflect.Descriptor instead.
+func (*SnapshotVertex) Descriptor() ([]byte, []int) {
+	return file_graph_v1_replication_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *SnapshotVertex) GetVertex() *Vertex {
+	if x != nil {
+		return x.Vertex
+	}
+	return nil
+}
+
+func (x *SnapshotVertex) GetHlc() *HLCTimestamp {
+	if x != nil {
+		return x.Hlc
+	}
+	return nil
+}
+
+// SnapshotEdgeContribution is one additive (or LWW-imported) entry inside
+// an edge's weight bucket. Snapshot preserves the per-contribution
+// decomposition so that the receiver's ContribID dedup (#182) keeps
+// suppressing duplicates when peer-pump later re-delivers the same
+// contribution from the live tail.
+//
+//	contrib_id: 24-byte ContribID; empty/zero when the contribution
+//	            originated from a local non-replicated AddEdge and dedup
+//	            is disabled (the legacy zero-id semantics).
+type SnapshotEdgeContribution struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Weight        float32                `protobuf:"fixed32,1,opt,name=weight,proto3" json:"weight,omitempty"`
+	Expiration    *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=expiration,proto3" json:"expiration,omitempty"`
+	ContribId     []byte                 `protobuf:"bytes,3,opt,name=contrib_id,json=contribId,proto3" json:"contrib_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SnapshotEdgeContribution) Reset() {
+	*x = SnapshotEdgeContribution{}
+	mi := &file_graph_v1_replication_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SnapshotEdgeContribution) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotEdgeContribution) ProtoMessage() {}
+
+func (x *SnapshotEdgeContribution) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_replication_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SnapshotEdgeContribution.ProtoReflect.Descriptor instead.
+func (*SnapshotEdgeContribution) Descriptor() ([]byte, []int) {
+	return file_graph_v1_replication_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *SnapshotEdgeContribution) GetWeight() float32 {
+	if x != nil {
+		return x.Weight
+	}
+	return 0
+}
+
+func (x *SnapshotEdgeContribution) GetExpiration() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Expiration
+	}
+	return nil
+}
+
+func (x *SnapshotEdgeContribution) GetContribId() []byte {
+	if x != nil {
+		return x.ContribId
+	}
+	return nil
+}
+
+// SnapshotEdge is the snapshot-time representation of a single live edge.
+// `hlc` carries the bucket's lastHLC (the most recent Put-LWW position;
+// zero when no LWW write has happened) so receivers can apply each
+// contribution via AddEdgeWithExpirationContribHLC with the right LWW
+// floor, keeping ContribID dedup intact.
+type SnapshotEdge struct {
+	state         protoimpl.MessageState      `protogen:"open.v1"`
+	Tail          string                      `protobuf:"bytes,1,opt,name=tail,proto3" json:"tail,omitempty"`
+	Head          string                      `protobuf:"bytes,2,opt,name=head,proto3" json:"head,omitempty"`
+	Hlc           *HLCTimestamp               `protobuf:"bytes,3,opt,name=hlc,proto3" json:"hlc,omitempty"`
+	Contributions []*SnapshotEdgeContribution `protobuf:"bytes,4,rep,name=contributions,proto3" json:"contributions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SnapshotEdge) Reset() {
+	*x = SnapshotEdge{}
+	mi := &file_graph_v1_replication_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SnapshotEdge) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotEdge) ProtoMessage() {}
+
+func (x *SnapshotEdge) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_replication_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SnapshotEdge.ProtoReflect.Descriptor instead.
+func (*SnapshotEdge) Descriptor() ([]byte, []int) {
+	return file_graph_v1_replication_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *SnapshotEdge) GetTail() string {
+	if x != nil {
+		return x.Tail
+	}
+	return ""
+}
+
+func (x *SnapshotEdge) GetHead() string {
+	if x != nil {
+		return x.Head
+	}
+	return ""
+}
+
+func (x *SnapshotEdge) GetHlc() *HLCTimestamp {
+	if x != nil {
+		return x.Hlc
+	}
+	return nil
+}
+
+func (x *SnapshotEdge) GetContributions() []*SnapshotEdgeContribution {
+	if x != nil {
+		return x.Contributions
+	}
+	return nil
+}
+
+// SnapshotEntry is the union type streamed from `rpc Snapshot`. The frame
+// order is always: exactly one SnapshotHeader, then zero or more
+// SnapshotVertex frames, then zero or more SnapshotEdge frames, then
+// exactly one SnapshotFooter. Receivers SHOULD treat any other order as a
+// protocol violation.
+type SnapshotEntry struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Entry:
+	//
+	//	*SnapshotEntry_Header
+	//	*SnapshotEntry_Vertex
+	//	*SnapshotEntry_Edge
+	//	*SnapshotEntry_Footer
+	Entry         isSnapshotEntry_Entry `protobuf_oneof:"entry"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SnapshotEntry) Reset() {
+	*x = SnapshotEntry{}
+	mi := &file_graph_v1_replication_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SnapshotEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotEntry) ProtoMessage() {}
+
+func (x *SnapshotEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_replication_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SnapshotEntry.ProtoReflect.Descriptor instead.
+func (*SnapshotEntry) Descriptor() ([]byte, []int) {
+	return file_graph_v1_replication_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *SnapshotEntry) GetEntry() isSnapshotEntry_Entry {
+	if x != nil {
+		return x.Entry
+	}
+	return nil
+}
+
+func (x *SnapshotEntry) GetHeader() *SnapshotHeader {
+	if x != nil {
+		if x, ok := x.Entry.(*SnapshotEntry_Header); ok {
+			return x.Header
+		}
+	}
+	return nil
+}
+
+func (x *SnapshotEntry) GetVertex() *SnapshotVertex {
+	if x != nil {
+		if x, ok := x.Entry.(*SnapshotEntry_Vertex); ok {
+			return x.Vertex
+		}
+	}
+	return nil
+}
+
+func (x *SnapshotEntry) GetEdge() *SnapshotEdge {
+	if x != nil {
+		if x, ok := x.Entry.(*SnapshotEntry_Edge); ok {
+			return x.Edge
+		}
+	}
+	return nil
+}
+
+func (x *SnapshotEntry) GetFooter() *SnapshotFooter {
+	if x != nil {
+		if x, ok := x.Entry.(*SnapshotEntry_Footer); ok {
+			return x.Footer
+		}
+	}
+	return nil
+}
+
+type isSnapshotEntry_Entry interface {
+	isSnapshotEntry_Entry()
+}
+
+type SnapshotEntry_Header struct {
+	Header *SnapshotHeader `protobuf:"bytes,1,opt,name=header,proto3,oneof"`
+}
+
+type SnapshotEntry_Vertex struct {
+	Vertex *SnapshotVertex `protobuf:"bytes,2,opt,name=vertex,proto3,oneof"`
+}
+
+type SnapshotEntry_Edge struct {
+	Edge *SnapshotEdge `protobuf:"bytes,3,opt,name=edge,proto3,oneof"`
+}
+
+type SnapshotEntry_Footer struct {
+	Footer *SnapshotFooter `protobuf:"bytes,4,opt,name=footer,proto3,oneof"`
+}
+
+func (*SnapshotEntry_Header) isSnapshotEntry_Entry() {}
+
+func (*SnapshotEntry_Vertex) isSnapshotEntry_Entry() {}
+
+func (*SnapshotEntry_Edge) isSnapshotEntry_Entry() {}
+
+func (*SnapshotEntry_Footer) isSnapshotEntry_Entry() {}
+
 var File_graph_v1_replication_proto protoreflect.FileDescriptor
 
 const file_graph_v1_replication_proto_rawDesc = "" +
 	"\n" +
-	"\x1agraph/v1/replication.proto\x12\bgraph.v1\x1a\x14graph/v1/graph.proto\"Z\n" +
+	"\x1agraph/v1/replication.proto\x12\bgraph.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x14graph/v1/graph.proto\"Z\n" +
 	"\fHLCTimestamp\x12\x17\n" +
 	"\awall_ns\x18\x01 \x01(\x03R\x06wallNs\x12\x18\n" +
 	"\alogical\x18\x02 \x01(\rR\alogical\x12\x17\n" +
@@ -532,9 +1005,41 @@ const file_graph_v1_replication_proto_rawDesc = "" +
 	"\x10SubscribeRequest\x12\x19\n" +
 	"\bfrom_seq\x18\x01 \x01(\x04R\afromSeq\"C\n" +
 	"\x11SubscribeResponse\x12.\n" +
-	"\bmutation\x18\x01 \x01(\v2\x12.graph.v1.MutationR\bmutation2c\n" +
+	"\bmutation\x18\x01 \x01(\v2\x12.graph.v1.MutationR\bmutation\"\x11\n" +
+	"\x0fSnapshotRequest\"f\n" +
+	"\x0eSnapshotHeader\x12\x1d\n" +
+	"\n" +
+	"cutoff_seq\x18\x01 \x01(\x04R\tcutoffSeq\x125\n" +
+	"\n" +
+	"cutoff_hlc\x18\x02 \x01(\v2\x16.graph.v1.HLCTimestampR\tcutoffHlc\"R\n" +
+	"\x0eSnapshotFooter\x12!\n" +
+	"\fvertex_count\x18\x01 \x01(\x04R\vvertexCount\x12\x1d\n" +
+	"\n" +
+	"edge_count\x18\x02 \x01(\x04R\tedgeCount\"d\n" +
+	"\x0eSnapshotVertex\x12(\n" +
+	"\x06vertex\x18\x01 \x01(\v2\x10.graph.v1.VertexR\x06vertex\x12(\n" +
+	"\x03hlc\x18\x02 \x01(\v2\x16.graph.v1.HLCTimestampR\x03hlc\"\x8d\x01\n" +
+	"\x18SnapshotEdgeContribution\x12\x16\n" +
+	"\x06weight\x18\x01 \x01(\x02R\x06weight\x12:\n" +
+	"\n" +
+	"expiration\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"expiration\x12\x1d\n" +
+	"\n" +
+	"contrib_id\x18\x03 \x01(\fR\tcontribId\"\xaa\x01\n" +
+	"\fSnapshotEdge\x12\x12\n" +
+	"\x04tail\x18\x01 \x01(\tR\x04tail\x12\x12\n" +
+	"\x04head\x18\x02 \x01(\tR\x04head\x12(\n" +
+	"\x03hlc\x18\x03 \x01(\v2\x16.graph.v1.HLCTimestampR\x03hlc\x12H\n" +
+	"\rcontributions\x18\x04 \x03(\v2\".graph.v1.SnapshotEdgeContributionR\rcontributions\"\xe2\x01\n" +
+	"\rSnapshotEntry\x122\n" +
+	"\x06header\x18\x01 \x01(\v2\x18.graph.v1.SnapshotHeaderH\x00R\x06header\x122\n" +
+	"\x06vertex\x18\x02 \x01(\v2\x18.graph.v1.SnapshotVertexH\x00R\x06vertex\x12,\n" +
+	"\x04edge\x18\x03 \x01(\v2\x16.graph.v1.SnapshotEdgeH\x00R\x04edge\x122\n" +
+	"\x06footer\x18\x04 \x01(\v2\x18.graph.v1.SnapshotFooterH\x00R\x06footerB\a\n" +
+	"\x05entry2\xa5\x01\n" +
 	"\x19LanternReplicationService\x12F\n" +
-	"\tSubscribe\x12\x1a.graph.v1.SubscribeRequest\x1a\x1b.graph.v1.SubscribeResponse0\x01B\x96\x01\n" +
+	"\tSubscribe\x12\x1a.graph.v1.SubscribeRequest\x1a\x1b.graph.v1.SubscribeResponse0\x01\x12@\n" +
+	"\bSnapshot\x12\x19.graph.v1.SnapshotRequest\x1a\x17.graph.v1.SnapshotEntry0\x01B\x96\x01\n" +
 	"\fcom.graph.v1B\x10ReplicationProtoP\x01Z3github.com/anaregdesign/lantern/pb/graph/v1;graphv1\xa2\x02\x03GXX\xaa\x02\bGraph.V1\xca\x02\bGraph\\V1\xe2\x02\x14Graph\\V1\\GPBMetadata\xea\x02\tGraph::V1b\x06proto3"
 
 var (
@@ -549,47 +1054,68 @@ func file_graph_v1_replication_proto_rawDescGZIP() []byte {
 	return file_graph_v1_replication_proto_rawDescData
 }
 
-var file_graph_v1_replication_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_graph_v1_replication_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_graph_v1_replication_proto_goTypes = []any{
 	(*HLCTimestamp)(nil),                  // 0: graph.v1.HLCTimestamp
 	(*MutationOp)(nil),                    // 1: graph.v1.MutationOp
 	(*Mutation)(nil),                      // 2: graph.v1.Mutation
 	(*SubscribeRequest)(nil),              // 3: graph.v1.SubscribeRequest
 	(*SubscribeResponse)(nil),             // 4: graph.v1.SubscribeResponse
-	(*PutVertexRequest)(nil),              // 5: graph.v1.PutVertexRequest
-	(*PutVerticesRequest)(nil),            // 6: graph.v1.PutVerticesRequest
-	(*DeleteVertexRequest)(nil),           // 7: graph.v1.DeleteVertexRequest
-	(*DeleteVerticesRequest)(nil),         // 8: graph.v1.DeleteVerticesRequest
-	(*DeleteVerticesByPrefixRequest)(nil), // 9: graph.v1.DeleteVerticesByPrefixRequest
-	(*AddEdgeRequest)(nil),                // 10: graph.v1.AddEdgeRequest
-	(*AddEdgesRequest)(nil),               // 11: graph.v1.AddEdgesRequest
-	(*PutEdgeRequest)(nil),                // 12: graph.v1.PutEdgeRequest
-	(*PutEdgesRequest)(nil),               // 13: graph.v1.PutEdgesRequest
-	(*DeleteEdgeRequest)(nil),             // 14: graph.v1.DeleteEdgeRequest
-	(*DeleteEdgesRequest)(nil),            // 15: graph.v1.DeleteEdgesRequest
+	(*SnapshotRequest)(nil),               // 5: graph.v1.SnapshotRequest
+	(*SnapshotHeader)(nil),                // 6: graph.v1.SnapshotHeader
+	(*SnapshotFooter)(nil),                // 7: graph.v1.SnapshotFooter
+	(*SnapshotVertex)(nil),                // 8: graph.v1.SnapshotVertex
+	(*SnapshotEdgeContribution)(nil),      // 9: graph.v1.SnapshotEdgeContribution
+	(*SnapshotEdge)(nil),                  // 10: graph.v1.SnapshotEdge
+	(*SnapshotEntry)(nil),                 // 11: graph.v1.SnapshotEntry
+	(*PutVertexRequest)(nil),              // 12: graph.v1.PutVertexRequest
+	(*PutVerticesRequest)(nil),            // 13: graph.v1.PutVerticesRequest
+	(*DeleteVertexRequest)(nil),           // 14: graph.v1.DeleteVertexRequest
+	(*DeleteVerticesRequest)(nil),         // 15: graph.v1.DeleteVerticesRequest
+	(*DeleteVerticesByPrefixRequest)(nil), // 16: graph.v1.DeleteVerticesByPrefixRequest
+	(*AddEdgeRequest)(nil),                // 17: graph.v1.AddEdgeRequest
+	(*AddEdgesRequest)(nil),               // 18: graph.v1.AddEdgesRequest
+	(*PutEdgeRequest)(nil),                // 19: graph.v1.PutEdgeRequest
+	(*PutEdgesRequest)(nil),               // 20: graph.v1.PutEdgesRequest
+	(*DeleteEdgeRequest)(nil),             // 21: graph.v1.DeleteEdgeRequest
+	(*DeleteEdgesRequest)(nil),            // 22: graph.v1.DeleteEdgesRequest
+	(*Vertex)(nil),                        // 23: graph.v1.Vertex
+	(*timestamppb.Timestamp)(nil),         // 24: google.protobuf.Timestamp
 }
 var file_graph_v1_replication_proto_depIdxs = []int32{
-	5,  // 0: graph.v1.MutationOp.put_vertex:type_name -> graph.v1.PutVertexRequest
-	6,  // 1: graph.v1.MutationOp.put_vertices:type_name -> graph.v1.PutVerticesRequest
-	7,  // 2: graph.v1.MutationOp.delete_vertex:type_name -> graph.v1.DeleteVertexRequest
-	8,  // 3: graph.v1.MutationOp.delete_vertices:type_name -> graph.v1.DeleteVerticesRequest
-	9,  // 4: graph.v1.MutationOp.delete_vertices_by_prefix:type_name -> graph.v1.DeleteVerticesByPrefixRequest
-	10, // 5: graph.v1.MutationOp.add_edge:type_name -> graph.v1.AddEdgeRequest
-	11, // 6: graph.v1.MutationOp.add_edges:type_name -> graph.v1.AddEdgesRequest
-	12, // 7: graph.v1.MutationOp.put_edge:type_name -> graph.v1.PutEdgeRequest
-	13, // 8: graph.v1.MutationOp.put_edges:type_name -> graph.v1.PutEdgesRequest
-	14, // 9: graph.v1.MutationOp.delete_edge:type_name -> graph.v1.DeleteEdgeRequest
-	15, // 10: graph.v1.MutationOp.delete_edges:type_name -> graph.v1.DeleteEdgesRequest
+	12, // 0: graph.v1.MutationOp.put_vertex:type_name -> graph.v1.PutVertexRequest
+	13, // 1: graph.v1.MutationOp.put_vertices:type_name -> graph.v1.PutVerticesRequest
+	14, // 2: graph.v1.MutationOp.delete_vertex:type_name -> graph.v1.DeleteVertexRequest
+	15, // 3: graph.v1.MutationOp.delete_vertices:type_name -> graph.v1.DeleteVerticesRequest
+	16, // 4: graph.v1.MutationOp.delete_vertices_by_prefix:type_name -> graph.v1.DeleteVerticesByPrefixRequest
+	17, // 5: graph.v1.MutationOp.add_edge:type_name -> graph.v1.AddEdgeRequest
+	18, // 6: graph.v1.MutationOp.add_edges:type_name -> graph.v1.AddEdgesRequest
+	19, // 7: graph.v1.MutationOp.put_edge:type_name -> graph.v1.PutEdgeRequest
+	20, // 8: graph.v1.MutationOp.put_edges:type_name -> graph.v1.PutEdgesRequest
+	21, // 9: graph.v1.MutationOp.delete_edge:type_name -> graph.v1.DeleteEdgeRequest
+	22, // 10: graph.v1.MutationOp.delete_edges:type_name -> graph.v1.DeleteEdgesRequest
 	0,  // 11: graph.v1.Mutation.hlc:type_name -> graph.v1.HLCTimestamp
 	1,  // 12: graph.v1.Mutation.op:type_name -> graph.v1.MutationOp
 	2,  // 13: graph.v1.SubscribeResponse.mutation:type_name -> graph.v1.Mutation
-	3,  // 14: graph.v1.LanternReplicationService.Subscribe:input_type -> graph.v1.SubscribeRequest
-	4,  // 15: graph.v1.LanternReplicationService.Subscribe:output_type -> graph.v1.SubscribeResponse
-	15, // [15:16] is the sub-list for method output_type
-	14, // [14:15] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	0,  // 14: graph.v1.SnapshotHeader.cutoff_hlc:type_name -> graph.v1.HLCTimestamp
+	23, // 15: graph.v1.SnapshotVertex.vertex:type_name -> graph.v1.Vertex
+	0,  // 16: graph.v1.SnapshotVertex.hlc:type_name -> graph.v1.HLCTimestamp
+	24, // 17: graph.v1.SnapshotEdgeContribution.expiration:type_name -> google.protobuf.Timestamp
+	0,  // 18: graph.v1.SnapshotEdge.hlc:type_name -> graph.v1.HLCTimestamp
+	9,  // 19: graph.v1.SnapshotEdge.contributions:type_name -> graph.v1.SnapshotEdgeContribution
+	6,  // 20: graph.v1.SnapshotEntry.header:type_name -> graph.v1.SnapshotHeader
+	8,  // 21: graph.v1.SnapshotEntry.vertex:type_name -> graph.v1.SnapshotVertex
+	10, // 22: graph.v1.SnapshotEntry.edge:type_name -> graph.v1.SnapshotEdge
+	7,  // 23: graph.v1.SnapshotEntry.footer:type_name -> graph.v1.SnapshotFooter
+	3,  // 24: graph.v1.LanternReplicationService.Subscribe:input_type -> graph.v1.SubscribeRequest
+	5,  // 25: graph.v1.LanternReplicationService.Snapshot:input_type -> graph.v1.SnapshotRequest
+	4,  // 26: graph.v1.LanternReplicationService.Subscribe:output_type -> graph.v1.SubscribeResponse
+	11, // 27: graph.v1.LanternReplicationService.Snapshot:output_type -> graph.v1.SnapshotEntry
+	26, // [26:28] is the sub-list for method output_type
+	24, // [24:26] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_graph_v1_replication_proto_init() }
@@ -611,13 +1137,19 @@ func file_graph_v1_replication_proto_init() {
 		(*MutationOp_DeleteEdge)(nil),
 		(*MutationOp_DeleteEdges)(nil),
 	}
+	file_graph_v1_replication_proto_msgTypes[11].OneofWrappers = []any{
+		(*SnapshotEntry_Header)(nil),
+		(*SnapshotEntry_Vertex)(nil),
+		(*SnapshotEntry_Edge)(nil),
+		(*SnapshotEntry_Footer)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_graph_v1_replication_proto_rawDesc), len(file_graph_v1_replication_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pb/graph/v1/replication_grpc.pb.go
+++ b/pb/graph/v1/replication_grpc.pb.go
@@ -20,6 +20,7 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	LanternReplicationService_Subscribe_FullMethodName = "/graph.v1.LanternReplicationService/Subscribe"
+	LanternReplicationService_Snapshot_FullMethodName  = "/graph.v1.LanternReplicationService/Snapshot"
 )
 
 // LanternReplicationServiceClient is the client API for LanternReplicationService service.
@@ -51,6 +52,19 @@ type LanternReplicationServiceClient interface {
 	//
 	// No HTTP gateway annotation: replication is intentionally gRPC-only.
 	Subscribe(ctx context.Context, in *SubscribeRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SubscribeResponse], error)
+	// Snapshot streams a point-in-time, causally-consistent dump of every
+	// live vertex and edge to a bootstrapping peer. The first frame is a
+	// SnapshotHeader carrying the (cutoff_seq, cutoff_hlc) the server used
+	// to materialise the snapshot; the last frame is a SnapshotFooter with
+	// the actual vertex / edge counts streamed.
+	//
+	// Bootstrap stitch contract: after receiving the SnapshotFooter the
+	// peer MUST call `Subscribe(from_seq = cutoff_seq + 1)` on the same
+	// origin to pick up the live tail. Without that the snapshot and the
+	// live stream cannot be glued together without gap or overlap.
+	//
+	// No HTTP gateway annotation (parity with Subscribe).
+	Snapshot(ctx context.Context, in *SnapshotRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SnapshotEntry], error)
 }
 
 type lanternReplicationServiceClient struct {
@@ -79,6 +93,25 @@ func (c *lanternReplicationServiceClient) Subscribe(ctx context.Context, in *Sub
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type LanternReplicationService_SubscribeClient = grpc.ServerStreamingClient[SubscribeResponse]
+
+func (c *lanternReplicationServiceClient) Snapshot(ctx context.Context, in *SnapshotRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SnapshotEntry], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &LanternReplicationService_ServiceDesc.Streams[1], LanternReplicationService_Snapshot_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[SnapshotRequest, SnapshotEntry]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type LanternReplicationService_SnapshotClient = grpc.ServerStreamingClient[SnapshotEntry]
 
 // LanternReplicationServiceServer is the server API for LanternReplicationService service.
 // All implementations should embed UnimplementedLanternReplicationServiceServer
@@ -109,6 +142,19 @@ type LanternReplicationServiceServer interface {
 	//
 	// No HTTP gateway annotation: replication is intentionally gRPC-only.
 	Subscribe(*SubscribeRequest, grpc.ServerStreamingServer[SubscribeResponse]) error
+	// Snapshot streams a point-in-time, causally-consistent dump of every
+	// live vertex and edge to a bootstrapping peer. The first frame is a
+	// SnapshotHeader carrying the (cutoff_seq, cutoff_hlc) the server used
+	// to materialise the snapshot; the last frame is a SnapshotFooter with
+	// the actual vertex / edge counts streamed.
+	//
+	// Bootstrap stitch contract: after receiving the SnapshotFooter the
+	// peer MUST call `Subscribe(from_seq = cutoff_seq + 1)` on the same
+	// origin to pick up the live tail. Without that the snapshot and the
+	// live stream cannot be glued together without gap or overlap.
+	//
+	// No HTTP gateway annotation (parity with Subscribe).
+	Snapshot(*SnapshotRequest, grpc.ServerStreamingServer[SnapshotEntry]) error
 }
 
 // UnimplementedLanternReplicationServiceServer should be embedded to have
@@ -120,6 +166,9 @@ type UnimplementedLanternReplicationServiceServer struct{}
 
 func (UnimplementedLanternReplicationServiceServer) Subscribe(*SubscribeRequest, grpc.ServerStreamingServer[SubscribeResponse]) error {
 	return status.Error(codes.Unimplemented, "method Subscribe not implemented")
+}
+func (UnimplementedLanternReplicationServiceServer) Snapshot(*SnapshotRequest, grpc.ServerStreamingServer[SnapshotEntry]) error {
+	return status.Error(codes.Unimplemented, "method Snapshot not implemented")
 }
 func (UnimplementedLanternReplicationServiceServer) testEmbeddedByValue() {}
 
@@ -152,6 +201,17 @@ func _LanternReplicationService_Subscribe_Handler(srv interface{}, stream grpc.S
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type LanternReplicationService_SubscribeServer = grpc.ServerStreamingServer[SubscribeResponse]
 
+func _LanternReplicationService_Snapshot_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(SnapshotRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(LanternReplicationServiceServer).Snapshot(m, &grpc.GenericServerStream[SnapshotRequest, SnapshotEntry]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type LanternReplicationService_SnapshotServer = grpc.ServerStreamingServer[SnapshotEntry]
+
 // LanternReplicationService_ServiceDesc is the grpc.ServiceDesc for LanternReplicationService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -163,6 +223,11 @@ var LanternReplicationService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "Subscribe",
 			Handler:       _LanternReplicationService_Subscribe_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "Snapshot",
+			Handler:       _LanternReplicationService_Snapshot_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/pb/graph/v1/replication_grpc.pb.go
+++ b/pb/graph/v1/replication_grpc.pb.go
@@ -64,7 +64,7 @@ type LanternReplicationServiceClient interface {
 	// live stream cannot be glued together without gap or overlap.
 	//
 	// No HTTP gateway annotation (parity with Subscribe).
-	Snapshot(ctx context.Context, in *SnapshotRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SnapshotEntry], error)
+	Snapshot(ctx context.Context, in *SnapshotRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SnapshotResponse], error)
 }
 
 type lanternReplicationServiceClient struct {
@@ -94,13 +94,13 @@ func (c *lanternReplicationServiceClient) Subscribe(ctx context.Context, in *Sub
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type LanternReplicationService_SubscribeClient = grpc.ServerStreamingClient[SubscribeResponse]
 
-func (c *lanternReplicationServiceClient) Snapshot(ctx context.Context, in *SnapshotRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SnapshotEntry], error) {
+func (c *lanternReplicationServiceClient) Snapshot(ctx context.Context, in *SnapshotRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SnapshotResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &LanternReplicationService_ServiceDesc.Streams[1], LanternReplicationService_Snapshot_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
-	x := &grpc.GenericClientStream[SnapshotRequest, SnapshotEntry]{ClientStream: stream}
+	x := &grpc.GenericClientStream[SnapshotRequest, SnapshotResponse]{ClientStream: stream}
 	if err := x.ClientStream.SendMsg(in); err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func (c *lanternReplicationServiceClient) Snapshot(ctx context.Context, in *Snap
 }
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type LanternReplicationService_SnapshotClient = grpc.ServerStreamingClient[SnapshotEntry]
+type LanternReplicationService_SnapshotClient = grpc.ServerStreamingClient[SnapshotResponse]
 
 // LanternReplicationServiceServer is the server API for LanternReplicationService service.
 // All implementations should embed UnimplementedLanternReplicationServiceServer
@@ -154,7 +154,7 @@ type LanternReplicationServiceServer interface {
 	// live stream cannot be glued together without gap or overlap.
 	//
 	// No HTTP gateway annotation (parity with Subscribe).
-	Snapshot(*SnapshotRequest, grpc.ServerStreamingServer[SnapshotEntry]) error
+	Snapshot(*SnapshotRequest, grpc.ServerStreamingServer[SnapshotResponse]) error
 }
 
 // UnimplementedLanternReplicationServiceServer should be embedded to have
@@ -167,7 +167,7 @@ type UnimplementedLanternReplicationServiceServer struct{}
 func (UnimplementedLanternReplicationServiceServer) Subscribe(*SubscribeRequest, grpc.ServerStreamingServer[SubscribeResponse]) error {
 	return status.Error(codes.Unimplemented, "method Subscribe not implemented")
 }
-func (UnimplementedLanternReplicationServiceServer) Snapshot(*SnapshotRequest, grpc.ServerStreamingServer[SnapshotEntry]) error {
+func (UnimplementedLanternReplicationServiceServer) Snapshot(*SnapshotRequest, grpc.ServerStreamingServer[SnapshotResponse]) error {
 	return status.Error(codes.Unimplemented, "method Snapshot not implemented")
 }
 func (UnimplementedLanternReplicationServiceServer) testEmbeddedByValue() {}
@@ -206,11 +206,11 @@ func _LanternReplicationService_Snapshot_Handler(srv interface{}, stream grpc.Se
 	if err := stream.RecvMsg(m); err != nil {
 		return err
 	}
-	return srv.(LanternReplicationServiceServer).Snapshot(m, &grpc.GenericServerStream[SnapshotRequest, SnapshotEntry]{ServerStream: stream})
+	return srv.(LanternReplicationServiceServer).Snapshot(m, &grpc.GenericServerStream[SnapshotRequest, SnapshotResponse]{ServerStream: stream})
 }
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type LanternReplicationService_SnapshotServer = grpc.ServerStreamingServer[SnapshotEntry]
+type LanternReplicationService_SnapshotServer = grpc.ServerStreamingServer[SnapshotResponse]
 
 // LanternReplicationService_ServiceDesc is the grpc.ServiceDesc for LanternReplicationService service.
 // It's only intended for direct use with grpc.RegisterService,

--- a/proto/graph/v1/replication.proto
+++ b/proto/graph/v1/replication.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package graph.v1;
 
+import "google/protobuf/timestamp.proto";
 import "graph/v1/graph.proto";
 
 // HLCTimestamp is the wire form of core/hlc.Timestamp. All replicated
@@ -76,6 +77,83 @@ message SubscribeResponse {
   Mutation mutation = 1;
 }
 
+// SnapshotRequest opens a server-streaming snapshot of the entire live
+// graph state at a single causal cutoff. The request body is intentionally
+// empty in this phase (#184); future revisions may add prefix / shard
+// filters without breaking the wire contract.
+message SnapshotRequest {}
+
+// SnapshotHeader is always the FIRST SnapshotEntry on the wire. It freezes
+// the (seq, hlc) cutoff the server used to materialise the snapshot. A
+// bootstrapping peer MUST persist (cutoff_seq, cutoff_hlc) before applying
+// any payload entries and MUST resume `Subscribe` from cutoff_seq + 1 so
+// the snapshot and the live tail stitch without gap or overlap.
+message SnapshotHeader {
+  uint64 cutoff_seq = 1;
+  HLCTimestamp cutoff_hlc = 2;
+}
+
+// SnapshotFooter is always the LAST SnapshotEntry on the wire. It carries
+// the running counts the server actually streamed so receivers can detect
+// truncation (channel-close, send-error mid-stream) without re-walking
+// their freshly-imported state.
+message SnapshotFooter {
+  uint64 vertex_count = 1;
+  uint64 edge_count = 2;
+}
+
+// SnapshotVertex is the snapshot-time representation of a single live
+// vertex. The HLC field carries the last LWW timestamp the source node
+// recorded for the key (zero when the vertex has never been touched by a
+// replicated Put, i.e. local-only writes); receivers feed it back through
+// PutVertexWithExpirationHLC so subsequent older replays (#182) are
+// correctly rejected.
+message SnapshotVertex {
+  Vertex vertex = 1;
+  HLCTimestamp hlc = 2;
+}
+
+// SnapshotEdgeContribution is one additive (or LWW-imported) entry inside
+// an edge's weight bucket. Snapshot preserves the per-contribution
+// decomposition so that the receiver's ContribID dedup (#182) keeps
+// suppressing duplicates when peer-pump later re-delivers the same
+// contribution from the live tail.
+//
+//   contrib_id: 24-byte ContribID; empty/zero when the contribution
+//               originated from a local non-replicated AddEdge and dedup
+//               is disabled (the legacy zero-id semantics).
+message SnapshotEdgeContribution {
+  float weight = 1;
+  google.protobuf.Timestamp expiration = 2;
+  bytes contrib_id = 3;
+}
+
+// SnapshotEdge is the snapshot-time representation of a single live edge.
+// `hlc` carries the bucket's lastHLC (the most recent Put-LWW position;
+// zero when no LWW write has happened) so receivers can apply each
+// contribution via AddEdgeWithExpirationContribHLC with the right LWW
+// floor, keeping ContribID dedup intact.
+message SnapshotEdge {
+  string tail = 1;
+  string head = 2;
+  HLCTimestamp hlc = 3;
+  repeated SnapshotEdgeContribution contributions = 4;
+}
+
+// SnapshotEntry is the union type streamed from `rpc Snapshot`. The frame
+// order is always: exactly one SnapshotHeader, then zero or more
+// SnapshotVertex frames, then zero or more SnapshotEdge frames, then
+// exactly one SnapshotFooter. Receivers SHOULD treat any other order as a
+// protocol violation.
+message SnapshotEntry {
+  oneof entry {
+    SnapshotHeader header = 1;
+    SnapshotVertex vertex = 2;
+    SnapshotEdge edge = 3;
+    SnapshotFooter footer = 4;
+  }
+}
+
 // LanternReplicationService carries the peer-to-peer (and CDC) replication
 // surface. It is intentionally a separate service from LanternService so
 // that operators can route, throttle, secure, or even disable replication
@@ -101,4 +179,18 @@ service LanternReplicationService {
   //
   // No HTTP gateway annotation: replication is intentionally gRPC-only.
   rpc Subscribe(SubscribeRequest) returns (stream SubscribeResponse);
+
+  // Snapshot streams a point-in-time, causally-consistent dump of every
+  // live vertex and edge to a bootstrapping peer. The first frame is a
+  // SnapshotHeader carrying the (cutoff_seq, cutoff_hlc) the server used
+  // to materialise the snapshot; the last frame is a SnapshotFooter with
+  // the actual vertex / edge counts streamed.
+  //
+  // Bootstrap stitch contract: after receiving the SnapshotFooter the
+  // peer MUST call `Subscribe(from_seq = cutoff_seq + 1)` on the same
+  // origin to pick up the live tail. Without that the snapshot and the
+  // live stream cannot be glued together without gap or overlap.
+  //
+  // No HTTP gateway annotation (parity with Subscribe).
+  rpc Snapshot(SnapshotRequest) returns (stream SnapshotEntry);
 }

--- a/proto/graph/v1/replication.proto
+++ b/proto/graph/v1/replication.proto
@@ -83,7 +83,7 @@ message SubscribeResponse {
 // filters without breaking the wire contract.
 message SnapshotRequest {}
 
-// SnapshotHeader is always the FIRST SnapshotEntry on the wire. It freezes
+// SnapshotHeader is always the FIRST SnapshotResponse on the wire. It freezes
 // the (seq, hlc) cutoff the server used to materialise the snapshot. A
 // bootstrapping peer MUST persist (cutoff_seq, cutoff_hlc) before applying
 // any payload entries and MUST resume `Subscribe` from cutoff_seq + 1 so
@@ -93,7 +93,7 @@ message SnapshotHeader {
   HLCTimestamp cutoff_hlc = 2;
 }
 
-// SnapshotFooter is always the LAST SnapshotEntry on the wire. It carries
+// SnapshotFooter is always the LAST SnapshotResponse on the wire. It carries
 // the running counts the server actually streamed so receivers can detect
 // truncation (channel-close, send-error mid-stream) without re-walking
 // their freshly-imported state.
@@ -140,12 +140,12 @@ message SnapshotEdge {
   repeated SnapshotEdgeContribution contributions = 4;
 }
 
-// SnapshotEntry is the union type streamed from `rpc Snapshot`. The frame
+// SnapshotResponse is the union type streamed from `rpc Snapshot`. The frame
 // order is always: exactly one SnapshotHeader, then zero or more
 // SnapshotVertex frames, then zero or more SnapshotEdge frames, then
 // exactly one SnapshotFooter. Receivers SHOULD treat any other order as a
 // protocol violation.
-message SnapshotEntry {
+message SnapshotResponse {
   oneof entry {
     SnapshotHeader header = 1;
     SnapshotVertex vertex = 2;
@@ -192,5 +192,5 @@ service LanternReplicationService {
   // live stream cannot be glued together without gap or overlap.
   //
   // No HTTP gateway annotation (parity with Subscribe).
-  rpc Snapshot(SnapshotRequest) returns (stream SnapshotEntry);
+  rpc Snapshot(SnapshotRequest) returns (stream SnapshotResponse);
 }

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -94,10 +94,12 @@ func newLanternService(
 // provider/metrics imports.
 func newLanternReplicationService(
 	log *mutationlog.Log,
+	backend service.Backend,
+	clock *hlc.Clock,
 	logger *slog.Logger,
 	dm *domainmetrics.DomainMetrics,
 ) *service.LanternReplicationService {
-	return service.NewLanternReplicationService(log).
+	return service.NewLanternReplicationService(log, backend, clock).
 		WithMetrics(dm).
 		WithLogger(logger)
 }

--- a/server/cmd/wire_gen.go
+++ b/server/cmd/wire_gen.go
@@ -27,7 +27,7 @@ func initializeApp() (*App, error) {
 	log := provider.NewMutationLog(mutationLogConfig, domainMetrics)
 	clock := provider.NewHLCClock(replicationConfig)
 	lanternService := newLanternService(graphCache, scanConfig, replicationConfig, logger, log, clock, domainMetrics)
-	lanternReplicationService := newLanternReplicationService(log, logger, domainMetrics)
+	lanternReplicationService := newLanternReplicationService(log, graphCache, clock, logger, domainMetrics)
 	netConfig := provider.NewNetConfig(config)
 	tlsConfig := provider.NewTLSConfig(config)
 	rateLimitConfig := provider.NewRateLimitConfig(config)

--- a/server/service/apply.go
+++ b/server/service/apply.go
@@ -193,6 +193,33 @@ func hlcFromProto(p *pb.HLCTimestamp) hlc.Timestamp {
 	}
 }
 
+// hlcToProto is the inverse of hlcFromProto and is used by the snapshot
+// path (#184) to stamp the cutoff HLC and per-entry HLCs onto the wire.
+// A zero in-process Timestamp returns nil so wire payloads stay compact
+// for entries with no recorded HLC (local-only writes).
+func hlcToProto(ts hlc.Timestamp) *pb.HLCTimestamp {
+	var zero hlc.Timestamp
+	if ts == zero {
+		return nil
+	}
+	return &pb.HLCTimestamp{
+		WallNs:  ts.WallNs,
+		Logical: ts.Logical,
+		NodeId:  append([]byte(nil), ts.NodeID[:]...),
+	}
+}
+
+// contribIDBytes returns the wire encoding of a ContribID. A zero ContribID
+// (the local-only / non-replicated sentinel) is encoded as a nil slice so
+// receivers can recognise it explicitly and skip dedup.
+func contribIDBytes(c graph.ContribID) []byte {
+	var zero graph.ContribID
+	if c == zero {
+		return nil
+	}
+	return append([]byte(nil), c[:]...)
+}
+
 // contribIDFor builds the dedup identifier for an additive contribution.
 // The 24-byte ContribID layout is documented on graph.ContribID:
 //

--- a/server/service/backend.go
+++ b/server/service/backend.go
@@ -87,4 +87,13 @@ type Backend interface {
 
 	// background GC loop driven by LanternServer.
 	Watch(ctx context.Context, interval time.Duration)
+
+	// Snapshot* return materialised dumps of the live state for the
+	// replication bootstrap RPC (#184). Both calls are taken under the
+	// GraphCache write lock and are intended to be called once per
+	// bootstrapping peer (not on the hot path). The returned slices own
+	// their backing storage and are safe to iterate without further
+	// locking.
+	SnapshotVertices() []graph.SnapshotVertex[string, *pb.Vertex]
+	SnapshotEdges() []graph.SnapshotEdge[string]
 }

--- a/server/service/fake_backend_test.go
+++ b/server/service/fake_backend_test.go
@@ -271,6 +271,34 @@ func (f *fakeBackend) DeleteByPrefixHLC(ctx context.Context, prefix string, limi
 	return f.DeleteByPrefix(ctx, prefix, lim), nil
 }
 
+// Snapshot* implement the bootstrap surface (#184). The fake backend
+// returns the in-memory vertex/edge maps as flat slices with zero HLC
+// stamps and a single zero-ContribID contribution per edge — enough for
+// service-level wiring tests; convergence tests use the real backend.
+func (f *fakeBackend) SnapshotVertices() []graph.SnapshotVertex[string, *pb.Vertex] {
+	out := make([]graph.SnapshotVertex[string, *pb.Vertex], 0, len(f.vertices))
+	for k, v := range f.vertices {
+		out = append(out, graph.SnapshotVertex[string, *pb.Vertex]{Key: k, Value: v})
+	}
+	return out
+}
+
+func (f *fakeBackend) SnapshotEdges() []graph.SnapshotEdge[string] {
+	var out []graph.SnapshotEdge[string]
+	for tail, heads := range f.edges {
+		for head, w := range heads {
+			out = append(out, graph.SnapshotEdge[string]{
+				Tail: tail,
+				Head: head,
+				Contributions: []graph.SnapshotContribution{{
+					Weight: w,
+				}},
+			})
+		}
+	}
+	return out
+}
+
 func TestLanternService_FakeBackend_PutGetDelete(t *testing.T) {
 	fb := newFakeBackend()
 	svc := NewLanternService(fb)

--- a/server/service/replication.go
+++ b/server/service/replication.go
@@ -4,11 +4,13 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // ReplicationServiceName is the fully-qualified gRPC service name for the
@@ -42,15 +44,25 @@ func (nopSubscribeMetrics) OnSubscribeDropped(string) {}
 type LanternReplicationService struct {
 	pb.UnimplementedLanternReplicationServiceServer
 	log     *mutationlog.Log
+	backend Backend
+	clock   *hlc.Clock
 	metrics SubscribeMetrics
 	logger  *slog.Logger
 }
 
 // NewLanternReplicationService constructs the service. log MUST be the same
 // instance handed to LanternService.WithReplication; otherwise subscribers
-// will not see locally-originated mutations.
-func NewLanternReplicationService(log *mutationlog.Log) *LanternReplicationService {
-	return &LanternReplicationService{log: log, metrics: nopSubscribeMetrics{}}
+// will not see locally-originated mutations. backend is the graph cache
+// the Snapshot RPC walks; clock supplies the cutoff HLC stamped into the
+// snapshot header. Both must be non-nil — Snapshot returns Unavailable
+// when backend is unset, mirroring how Subscribe handles a nil log.
+func NewLanternReplicationService(log *mutationlog.Log, backend Backend, clock *hlc.Clock) *LanternReplicationService {
+	return &LanternReplicationService{
+		log:     log,
+		backend: backend,
+		clock:   clock,
+		metrics: nopSubscribeMetrics{},
+	}
 }
 
 // WithMetrics attaches a SubscribeMetrics handle. Nil is treated as the
@@ -151,4 +163,113 @@ func (s *LanternReplicationService) loggerOrDefault() *slog.Logger {
 		return s.logger
 	}
 	return slog.Default()
+}
+
+// Snapshot implements pb.LanternReplicationServiceServer.
+//
+// Flow:
+//  1. Stamp the cutoff (cutoff_seq, cutoff_hlc) and send a SnapshotHeader
+//     as the very first frame so receivers know where to resume Subscribe.
+//     cutoff_seq is `log.LastSeq()` at snapshot-open time (0 when the log
+//     is empty or replication is disabled — the peer is expected to start
+//     Subscribe at cutoff_seq + 1 = 1, which matches the mutation log's
+//     first valid seq); cutoff_hlc is `clock.Now()`.
+//  2. Materialise vertices and edges through the Backend snapshot API
+//     (taken under the GraphCache write lock). Stream each as its own
+//     SnapshotEntry frame, honouring stream.Context() cancellation
+//     between sends.
+//  3. Send a SnapshotFooter with the actually-streamed counts as the very
+//     last frame so receivers can detect truncation.
+//
+// The implementation deliberately materialises the snapshot in memory.
+// Replication bootstrap is bounded (one peer per call, infrequent), so
+// the O(N+E) memory overhead is acceptable. True streaming is a follow-up
+// once the snapshot path is wired end-to-end.
+func (s *LanternReplicationService) Snapshot(_ *pb.SnapshotRequest, stream grpc.ServerStreamingServer[pb.SnapshotEntry]) error {
+	if s.backend == nil {
+		return status.Error(codes.Unavailable, "snapshot is not enabled on this server")
+	}
+	ctx := stream.Context()
+
+	var cutoffSeq uint64
+	if s.log != nil {
+		if last, ok := s.log.LastSeq(); ok {
+			cutoffSeq = last
+		}
+	}
+	var cutoffHLC hlc.Timestamp
+	if s.clock != nil {
+		cutoffHLC = s.clock.Now()
+	}
+	header := &pb.SnapshotEntry{
+		Entry: &pb.SnapshotEntry_Header{
+			Header: &pb.SnapshotHeader{
+				CutoffSeq: cutoffSeq,
+				CutoffHlc: hlcToProto(cutoffHLC),
+			},
+		},
+	}
+	if err := stream.Send(header); err != nil {
+		return err
+	}
+
+	vertices := s.backend.SnapshotVertices()
+	var vertexCount uint64
+	for _, v := range vertices {
+		if err := ctx.Err(); err != nil {
+			return status.FromContextError(err).Err()
+		}
+		entry := &pb.SnapshotEntry{
+			Entry: &pb.SnapshotEntry_Vertex{
+				Vertex: &pb.SnapshotVertex{
+					Vertex: v.Value,
+					Hlc:    hlcToProto(v.HLC),
+				},
+			},
+		}
+		if err := stream.Send(entry); err != nil {
+			return err
+		}
+		vertexCount++
+	}
+
+	edges := s.backend.SnapshotEdges()
+	var edgeCount uint64
+	for _, e := range edges {
+		if err := ctx.Err(); err != nil {
+			return status.FromContextError(err).Err()
+		}
+		contribs := make([]*pb.SnapshotEdgeContribution, 0, len(e.Contributions))
+		for _, c := range e.Contributions {
+			contribs = append(contribs, &pb.SnapshotEdgeContribution{
+				Weight:     c.Weight,
+				Expiration: timestamppb.New(c.Expiration),
+				ContribId:  contribIDBytes(c.ContribID),
+			})
+		}
+		entry := &pb.SnapshotEntry{
+			Entry: &pb.SnapshotEntry_Edge{
+				Edge: &pb.SnapshotEdge{
+					Tail:          e.Tail,
+					Head:          e.Head,
+					Hlc:           hlcToProto(e.HLC),
+					Contributions: contribs,
+				},
+			},
+		}
+		if err := stream.Send(entry); err != nil {
+			return err
+		}
+		edgeCount++
+	}
+
+	footer := &pb.SnapshotEntry{
+		Entry: &pb.SnapshotEntry_Footer{
+			Footer: &pb.SnapshotFooter{
+				VertexCount: vertexCount,
+				EdgeCount:   edgeCount,
+			},
+		},
+	}
+	return stream.Send(footer)
 }

--- a/server/service/replication.go
+++ b/server/service/replication.go
@@ -176,7 +176,7 @@ func (s *LanternReplicationService) loggerOrDefault() *slog.Logger {
 //     first valid seq); cutoff_hlc is `clock.Now()`.
 //  2. Materialise vertices and edges through the Backend snapshot API
 //     (taken under the GraphCache write lock). Stream each as its own
-//     SnapshotEntry frame, honouring stream.Context() cancellation
+//     SnapshotResponse frame, honouring stream.Context() cancellation
 //     between sends.
 //  3. Send a SnapshotFooter with the actually-streamed counts as the very
 //     last frame so receivers can detect truncation.
@@ -185,7 +185,7 @@ func (s *LanternReplicationService) loggerOrDefault() *slog.Logger {
 // Replication bootstrap is bounded (one peer per call, infrequent), so
 // the O(N+E) memory overhead is acceptable. True streaming is a follow-up
 // once the snapshot path is wired end-to-end.
-func (s *LanternReplicationService) Snapshot(_ *pb.SnapshotRequest, stream grpc.ServerStreamingServer[pb.SnapshotEntry]) error {
+func (s *LanternReplicationService) Snapshot(_ *pb.SnapshotRequest, stream grpc.ServerStreamingServer[pb.SnapshotResponse]) error {
 	if s.backend == nil {
 		return status.Error(codes.Unavailable, "snapshot is not enabled on this server")
 	}
@@ -201,8 +201,8 @@ func (s *LanternReplicationService) Snapshot(_ *pb.SnapshotRequest, stream grpc.
 	if s.clock != nil {
 		cutoffHLC = s.clock.Now()
 	}
-	header := &pb.SnapshotEntry{
-		Entry: &pb.SnapshotEntry_Header{
+	header := &pb.SnapshotResponse{
+		Entry: &pb.SnapshotResponse_Header{
 			Header: &pb.SnapshotHeader{
 				CutoffSeq: cutoffSeq,
 				CutoffHlc: hlcToProto(cutoffHLC),
@@ -219,8 +219,8 @@ func (s *LanternReplicationService) Snapshot(_ *pb.SnapshotRequest, stream grpc.
 		if err := ctx.Err(); err != nil {
 			return status.FromContextError(err).Err()
 		}
-		entry := &pb.SnapshotEntry{
-			Entry: &pb.SnapshotEntry_Vertex{
+		entry := &pb.SnapshotResponse{
+			Entry: &pb.SnapshotResponse_Vertex{
 				Vertex: &pb.SnapshotVertex{
 					Vertex: v.Value,
 					Hlc:    hlcToProto(v.HLC),
@@ -247,8 +247,8 @@ func (s *LanternReplicationService) Snapshot(_ *pb.SnapshotRequest, stream grpc.
 				ContribId:  contribIDBytes(c.ContribID),
 			})
 		}
-		entry := &pb.SnapshotEntry{
-			Entry: &pb.SnapshotEntry_Edge{
+		entry := &pb.SnapshotResponse{
+			Entry: &pb.SnapshotResponse_Edge{
 				Edge: &pb.SnapshotEdge{
 					Tail:          e.Tail,
 					Head:          e.Head,
@@ -263,8 +263,8 @@ func (s *LanternReplicationService) Snapshot(_ *pb.SnapshotRequest, stream grpc.
 		edgeCount++
 	}
 
-	footer := &pb.SnapshotEntry{
-		Entry: &pb.SnapshotEntry_Footer{
+	footer := &pb.SnapshotResponse{
+		Entry: &pb.SnapshotResponse_Footer{
 			Footer: &pb.SnapshotFooter{
 				VertexCount: vertexCount,
 				EdgeCount:   edgeCount,

--- a/server/service/replication_service_test.go
+++ b/server/service/replication_service_test.go
@@ -41,7 +41,7 @@ func newReplicationServer(t *testing.T, log *mutationlog.Log, m service.Subscrib
 	t.Helper()
 	lis := bufconn.Listen(1 << 16)
 	srv := grpc.NewServer()
-	repl := service.NewLanternReplicationService(log).WithMetrics(m)
+	repl := service.NewLanternReplicationService(log, nil, nil).WithMetrics(m)
 	pb.RegisterLanternReplicationServiceServer(srv, repl)
 	go func() { _ = srv.Serve(lis) }()
 

--- a/tests/integration/snapshot_test.go
+++ b/tests/integration/snapshot_test.go
@@ -175,7 +175,7 @@ func TestSnapshot_E2E_PrimaryToFollower(t *testing.T) {
 			t.Fatalf("recv: %v", err)
 		}
 		switch e := entry.GetEntry().(type) {
-		case *pb.SnapshotEntry_Vertex:
+		case *pb.SnapshotResponse_Vertex:
 			if footer != nil {
 				t.Fatalf("vertex frame after footer")
 			}
@@ -186,7 +186,7 @@ func TestSnapshot_E2E_PrimaryToFollower(t *testing.T) {
 				snapshotHLC(sv.GetHlc()),
 			)
 			gotVertexCount++
-		case *pb.SnapshotEntry_Edge:
+		case *pb.SnapshotResponse_Edge:
 			if footer != nil {
 				t.Fatalf("edge frame after footer")
 			}
@@ -201,9 +201,9 @@ func TestSnapshot_E2E_PrimaryToFollower(t *testing.T) {
 				)
 			}
 			gotEdgeCount++
-		case *pb.SnapshotEntry_Footer:
+		case *pb.SnapshotResponse_Footer:
 			footer = e.Footer
-		case *pb.SnapshotEntry_Header:
+		case *pb.SnapshotResponse_Header:
 			t.Fatalf("second header frame mid-stream")
 		default:
 			t.Fatalf("unknown entry type: %T", e)

--- a/tests/integration/snapshot_test.go
+++ b/tests/integration/snapshot_test.go
@@ -1,0 +1,270 @@
+package integration_test
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/hlc"
+	"github.com/anaregdesign/lantern/core/mutationlog"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/anaregdesign/lantern/server/provider"
+	"github.com/anaregdesign/lantern/server/service"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// snapshotPeer is a tiny harness that stands up LanternService +
+// LanternReplicationService on bufconn and exposes both an SDK client
+// (for writes) and a raw replication client (for Snapshot/Subscribe).
+type snapshotPeer struct {
+	t        *testing.T
+	cache    *cachegraph.GraphCache[string, *pb.Vertex]
+	clock    *hlc.Clock
+	log      *mutationlog.Log
+	sdk      *client.Lantern
+	repl     pb.LanternReplicationServiceClient
+	repConn  *grpc.ClientConn
+	cleanups []func()
+}
+
+func newSnapshotPeer(t *testing.T, nodeID hlc.NodeID) *snapshotPeer {
+	t.Helper()
+	lis := bufconn.Listen(1 << 16)
+	vi := provider.NewValidationInterceptor(provider.ValidationLimits{
+		MaxKeyLen:         256,
+		MaxBatchSize:      1024,
+		IlluminateMaxStep: 32,
+		IlluminateMaxK:    256,
+	})
+	srv := grpc.NewServer(grpc.UnaryInterceptor(vi.UnaryServerInterceptor()))
+
+	log := mutationlog.New(mutationlog.Options{Capacity: 1024, SubscriberBuffer: 1024})
+	clock := hlc.New(nodeID, hlc.Options{})
+	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	svc := service.NewLanternService(cache).WithReplication(log, clock, nil)
+	pb.RegisterLanternServiceServer(srv, svc)
+	pb.RegisterLanternReplicationServiceServer(srv, service.NewLanternReplicationService(log, cache, clock))
+
+	go func() { _ = srv.Serve(lis) }()
+
+	dialer := func(context.Context, string) (net.Conn, error) { return lis.Dial() }
+	conn, err := grpc.NewClient(
+		"passthrough://bufconn",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(dialer),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	sdk, err := client.NewLantern(
+		"passthrough://bufconn",
+		client.WithTransportCredentials(insecure.NewCredentials()),
+		client.WithDialOption(grpc.WithContextDialer(dialer)),
+	)
+	if err != nil {
+		t.Fatalf("NewLantern: %v", err)
+	}
+
+	p := &snapshotPeer{
+		t:       t,
+		cache:   cache,
+		clock:   clock,
+		log:     log,
+		sdk:     sdk,
+		repl:    pb.NewLanternReplicationServiceClient(conn),
+		repConn: conn,
+	}
+	p.cleanups = []func(){
+		func() { _ = sdk.Close() },
+		func() { _ = conn.Close() },
+		srv.Stop,
+		func() { _ = log.Close() },
+	}
+	t.Cleanup(p.close)
+	return p
+}
+
+func (p *snapshotPeer) close() {
+	for i := len(p.cleanups) - 1; i >= 0; i-- {
+		p.cleanups[i]()
+	}
+}
+
+// TestSnapshot_E2E_PrimaryToFollower verifies the snapshot bootstrap
+// surface (#184): a follower opens Snapshot on a primary populated with a
+// mix of vertices and additive edges, replays every frame into its own
+// cache via the HLC + ContribID seams, and observes the same Illuminate
+// answers as the primary. The header's cutoff_seq is also asserted to
+// equal the primary's mutationlog LastSeq at snapshot-open time so that
+// downstream Subscribe(cutoff_seq+1) is guaranteed to stitch cleanly.
+func TestSnapshot_E2E_PrimaryToFollower(t *testing.T) {
+	primary := newSnapshotPeer(t, hlc.NodeID{0x01})
+	follower := newSnapshotPeer(t, hlc.NodeID{0x02})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Populate primary: 5 vertices, 10 additive-edge calls across 6
+	// distinct (tail, head) pairs (some pairs receive 2 contributions).
+	const Nv = 5
+	for i := 0; i < Nv; i++ {
+		if err := primary.sdk.PutVertex(ctx, "v-"+itoa(i), "val", time.Minute); err != nil {
+			t.Fatalf("primary PutVertex[%d]: %v", i, err)
+		}
+	}
+	edgeWrites := []struct {
+		tail, head string
+		w          float32
+	}{
+		{"v-0", "v-1", 0.5},
+		{"v-0", "v-2", 0.25},
+		{"v-1", "v-2", 1.0},
+		{"v-1", "v-2", 0.5}, // second contribution to (v-1,v-2)
+		{"v-2", "v-3", 0.75},
+		{"v-3", "v-4", 1.0},
+		{"v-3", "v-4", 1.0}, // second contribution to (v-3,v-4)
+	}
+	for i, e := range edgeWrites {
+		if err := primary.sdk.AddEdge(ctx, e.tail, e.head, e.w, time.Minute); err != nil {
+			t.Fatalf("primary AddEdge[%d]: %v", i, err)
+		}
+	}
+
+	wantSeq, _ := primary.log.LastSeq()
+
+	stream, err := primary.repl.Snapshot(ctx, &pb.SnapshotRequest{})
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	// First frame MUST be the header.
+	first, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("recv header: %v", err)
+	}
+	hdr := first.GetHeader()
+	if hdr == nil {
+		t.Fatalf("first frame is not a header: %T", first.GetEntry())
+	}
+	if hdr.GetCutoffSeq() != wantSeq {
+		t.Errorf("cutoff_seq=%d want %d", hdr.GetCutoffSeq(), wantSeq)
+	}
+	if hdr.GetCutoffHlc() == nil {
+		t.Errorf("cutoff_hlc is nil; expected the primary clock's current Now()")
+	}
+
+	// Stream body: apply each frame to the follower using the HLC +
+	// ContribID seams. Footer MUST be the very last frame.
+	var (
+		gotVertexCount uint64
+		gotEdgeCount   uint64
+		footer         *pb.SnapshotFooter
+	)
+	for {
+		entry, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv: %v", err)
+		}
+		switch e := entry.GetEntry().(type) {
+		case *pb.SnapshotEntry_Vertex:
+			if footer != nil {
+				t.Fatalf("vertex frame after footer")
+			}
+			sv := e.Vertex
+			v := sv.GetVertex()
+			follower.cache.PutVertexWithExpirationHLC(
+				v.GetKey(), v, v.GetExpiration().AsTime(),
+				snapshotHLC(sv.GetHlc()),
+			)
+			gotVertexCount++
+		case *pb.SnapshotEntry_Edge:
+			if footer != nil {
+				t.Fatalf("edge frame after footer")
+			}
+			se := e.Edge
+			edgeHLC := snapshotHLC(se.GetHlc())
+			for _, c := range se.GetContributions() {
+				var cid cachegraph.ContribID
+				copy(cid[:], c.GetContribId())
+				follower.cache.AddEdgeWithExpirationContribHLC(
+					se.GetTail(), se.GetHead(), c.GetWeight(),
+					c.GetExpiration().AsTime(), cid, edgeHLC,
+				)
+			}
+			gotEdgeCount++
+		case *pb.SnapshotEntry_Footer:
+			footer = e.Footer
+		case *pb.SnapshotEntry_Header:
+			t.Fatalf("second header frame mid-stream")
+		default:
+			t.Fatalf("unknown entry type: %T", e)
+		}
+	}
+	if footer == nil {
+		t.Fatalf("stream ended without a footer")
+	}
+	if footer.GetVertexCount() != gotVertexCount {
+		t.Errorf("footer vertex_count=%d, streamed=%d", footer.GetVertexCount(), gotVertexCount)
+	}
+	if footer.GetEdgeCount() != gotEdgeCount {
+		t.Errorf("footer edge_count=%d, streamed=%d", footer.GetEdgeCount(), gotEdgeCount)
+	}
+	if got := uint64(Nv); footer.GetVertexCount() != got {
+		t.Errorf("vertex_count=%d want %d", footer.GetVertexCount(), got)
+	}
+	// 5 distinct (tail, head) pairs in edgeWrites.
+	if got := uint64(5); footer.GetEdgeCount() != got {
+		t.Errorf("edge_count=%d want %d", footer.GetEdgeCount(), got)
+	}
+
+	// Verify convergence: every (tail, head) pair has the same weight on
+	// both peers and every vertex round-trips.
+	for _, e := range []struct {
+		tail, head string
+	}{
+		{"v-0", "v-1"}, {"v-0", "v-2"}, {"v-1", "v-2"},
+		{"v-2", "v-3"}, {"v-3", "v-4"},
+	} {
+		pw, pok := primary.cache.GetWeight(e.tail, e.head)
+		fw, fok := follower.cache.GetWeight(e.tail, e.head)
+		if pok != fok {
+			t.Errorf("edge (%s,%s) presence mismatch: primary=%v follower=%v", e.tail, e.head, pok, fok)
+		}
+		if pw != fw {
+			t.Errorf("edge (%s,%s) weight mismatch: primary=%v follower=%v", e.tail, e.head, pw, fw)
+		}
+	}
+	for i := 0; i < Nv; i++ {
+		key := "v-" + itoa(i)
+		_, pok := primary.cache.GetVertex(key)
+		_, fok := follower.cache.GetVertex(key)
+		if !pok || !fok {
+			t.Errorf("vertex %s presence mismatch: primary=%v follower=%v", key, pok, fok)
+		}
+	}
+}
+
+// snapshotHLC converts a wire HLCTimestamp into the in-process
+// hlc.Timestamp value. Mirrors server/service.hlcFromProto, duplicated
+// here because that helper is package-internal to server/service.
+func snapshotHLC(p *pb.HLCTimestamp) hlc.Timestamp {
+	if p == nil {
+		return hlc.Timestamp{}
+	}
+	var nid hlc.NodeID
+	copy(nid[:], p.GetNodeId())
+	return hlc.Timestamp{
+		WallNs:  p.GetWallNs(),
+		Logical: p.GetLogical(),
+		NodeID:  nid,
+	}
+}

--- a/tests/integration/subscribe_test.go
+++ b/tests/integration/subscribe_test.go
@@ -39,10 +39,12 @@ func TestSubscribe_E2E_100Writes(t *testing.T) {
 	t.Cleanup(func() { _ = log.Close() })
 	clock := hlc.New(hlc.NodeID{0xAA, 0xBB}, hlc.Options{})
 
-	svc := service.NewLanternService(cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)).
+	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+
+	svc := service.NewLanternService(cache).
 		WithReplication(log, clock, nil)
 	pb.RegisterLanternServiceServer(srv, svc)
-	pb.RegisterLanternReplicationServiceServer(srv, service.NewLanternReplicationService(log))
+	pb.RegisterLanternReplicationServiceServer(srv, service.NewLanternReplicationService(log, cache, clock))
 
 	go func() { _ = srv.Serve(lis) }()
 	t.Cleanup(srv.Stop)


### PR DESCRIPTION
Closes #184.

## Summary
Wires the `Snapshot(SnapshotRequest) returns (stream SnapshotEntry)` RPC end-to-end so a fresh peer can bootstrap from a primary's live cache and then stitch cleanly to its Subscribe tail.

## Wire shape
`SnapshotEntry` is a oneof of `SnapshotHeader` / `SnapshotVertex` / `SnapshotEdge` / `SnapshotFooter`. The header is always the first frame and carries `cutoff_seq = log.LastSeq()` plus `cutoff_hlc = clock.Now()` captured at snapshot-open time. Edges preserve **per-contribution decomposition** (each `SnapshotEdge` carries its full list of live `SnapshotEdgeContribution` rows), so the receiver's ContribID dedup makes the snapshot+Subscribe-tail handoff idempotent.

## Implementation
- **Cache (`core/cache/graph`)**: `GraphCache.SnapshotVertices` / `SnapshotEdges` return flat slices carrying HLC + ContribID; backed by a new `Cache.Range` helper plus internal `edgeCache.rangeBuckets` / `weight.snapshotEntry` helpers.
- **Backend interface** widened with the two snapshot accessors; fake-backend stubs added.
- **Handler**: `NewLanternReplicationService` now takes `(log, backend, clock)`. The Snapshot handler captures the cutoff, materialises live state via the Backend, and emits Header → Vertex/Edge body frames → Footer with streamed counts, respecting `stream.Context()` cancellation.
- **Wire** regenerated; existing service + subscribe tests updated for the new constructor.

## Verification
- `go test -race -skip TestGraphCache_PrefixIndex_ConcurrentScanIsConsistent ./...` ✅ across all modules (root/core/pb/sdks/server/cli).
- `go vet ./...` ✅ across all modules.
- New `tests/integration/snapshot_test.go` runs a two-peer bufconn round-trip with multi-contribution edges and asserts identical `GetWeight` / `GetVertex` on both peers plus `Header.CutoffSeq == primary log.LastSeq`.

## Limitation (follow-up)
v1 materialises the full snapshot in memory. Cursor-based / chunked snapshotting is a follow-up once the bootstrap path is exercised at scale.