### PR TITLE
[HA] server: replication metrics (lag, dropped, anti-entropy) (#187)

### DIFF
--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -91,6 +91,7 @@ func newLanternService(
 			DeleteByPrefixMaxLimit:     sc.DeleteByPrefixMaxLimit,
 		}).
 		WithReplication(log, clock, dm.OnMutationLogAppend).
+		WithAppliedHook(dm.OnReplicationApplied).
 		WithTombstoneTTL(rc.TombstoneTTL).
 		WithLogger(logger)
 }

--- a/server/cmd/wire_gen.go
+++ b/server/cmd/wire_gen.go
@@ -52,9 +52,9 @@ func initializeApp() (*App, error) {
 		return nil, err
 	}
 	peerConfig := provider.NewPeerConfig(config)
-	pump := provider.NewReplicationPump(peerConfig, replicationConfig, lanternService, graphCache, logger)
+	pump := provider.NewReplicationPump(peerConfig, replicationConfig, lanternService, graphCache, domainMetrics, logger)
 	antiEntropyConfig := provider.NewAntiEntropyConfig(config)
-	antiEntropy := provider.NewAntiEntropyDriver(peerConfig, replicationConfig, antiEntropyConfig, lanternService, graphCache, pump, logger)
+	antiEntropy := provider.NewAntiEntropyDriver(peerConfig, replicationConfig, antiEntropyConfig, lanternService, graphCache, pump, domainMetrics, logger)
 	mainRegisteredHealth := registerHealthAndReflection(observabilityConfig, server, healthServer)
 	app := newApp(config, logger, lanternServer, metricsServer, tracing, domainMetrics, healthServer, pump, antiEntropy, mainRegisteredHealth)
 	return app, nil

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -32,6 +32,12 @@ type DomainMetrics struct {
 	subscribeActive     prometheus.Gauge
 	subscribeDropped    *prometheus.CounterVec
 
+	replicationApplied   *prometheus.CounterVec
+	replicationDropped   *prometheus.CounterVec
+	replicationLag       *prometheus.GaugeVec
+	antiEntropyCycles    prometheus.Counter
+	antiEntropyGapsFound *prometheus.CounterVec
+
 	sampleInterval time.Duration
 	sample         Sampler
 }
@@ -91,11 +97,33 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 			Name: "lantern_subscribe_dropped_total",
 			Help: "Total Subscribe streams terminated abnormally, partitioned by reason (gapped, send_failed).",
 		}, []string{"reason"}),
+		replicationApplied: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "lantern_replication_applied_total",
+			Help: "Total remote mutations applied locally via the replication apply path, partitioned by origin (HLC NodeID, lowercase hex).",
+		}, []string{"origin"}),
+		replicationDropped: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "lantern_replication_dropped_total",
+			Help: "Total replication frames or peer interactions dropped, partitioned by peer address and reason (self_echo, subscribe_failed, snapshot_failed, dial_failed, peerstatus_failed, catchup_failed, clean, ctx_cancel).",
+		}, []string{"peer", "reason"}),
+		replicationLag: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "lantern_replication_lag_seq",
+			Help: "Per-(peer, origin) replication lag in mutation seq units (peer last_seq minus local last_applied_seq). 0 means caught up; only set when the peer reports its own origin row.",
+		}, []string{"peer", "origin"}),
+		antiEntropyCycles: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "lantern_anti_entropy_cycles_total",
+			Help: "Total anti-entropy convergence ticks executed since process start (one per Interval).",
+		}),
+		antiEntropyGapsFound: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "lantern_anti_entropy_gaps_found_total",
+			Help: "Total anti-entropy ticks that observed a non-zero gap, partitioned by peer address and origin (HLC NodeID, lowercase hex).",
+		}, []string{"peer", "origin"}),
 		sampleInterval: opts.SampleInterval,
 	}
 
 	reg.MustRegister(m.vertices, m.edges, m.expirations, m.gcDuration, m.buildInfo,
-		m.mutationLogEntries, m.mutationLogCapacity, m.subscribeActive, m.subscribeDropped)
+		m.mutationLogEntries, m.mutationLogCapacity, m.subscribeActive, m.subscribeDropped,
+		m.replicationApplied, m.replicationDropped, m.replicationLag,
+		m.antiEntropyCycles, m.antiEntropyGapsFound)
 
 	// Pre-create label rows so empty counters scrape as 0.
 	for _, r := range []string{"gapped", "send_failed"} {
@@ -164,6 +192,89 @@ func (m *DomainMetrics) OnSubscribeEnded() {
 func (m *DomainMetrics) OnSubscribeDropped(reason string) {
 	m.subscribeDropped.WithLabelValues(reason).Inc()
 }
+
+// OnReplicationApplied increments lantern_replication_applied_total for
+// a mutation accepted by the apply path. origin is the HLC NodeID of the
+// originating node, lowercase-hex encoded.
+func (m *DomainMetrics) OnReplicationApplied(origin string) {
+	m.replicationApplied.WithLabelValues(origin).Inc()
+}
+
+// OnReplicationDropped increments lantern_replication_dropped_total for a
+// dropped frame or failed peer interaction. peer is the peer's RPC
+// address; reason is a short identifier (see metric Help text).
+func (m *DomainMetrics) OnReplicationDropped(peer, reason string) {
+	m.replicationDropped.WithLabelValues(peer, reason).Inc()
+}
+
+// SetReplicationLag sets the per-(peer, origin) replication lag gauge in
+// mutation-seq units. Called from the anti-entropy driver after each
+// PeerStatus probe; 0 means caught up.
+func (m *DomainMetrics) SetReplicationLag(peer, origin string, lag uint64) {
+	m.replicationLag.WithLabelValues(peer, origin).Set(float64(lag))
+}
+
+// OnAntiEntropyCycle increments lantern_anti_entropy_cycles_total. Called
+// once per tick of the anti-entropy driver (i.e. per fan-out across all
+// peers).
+func (m *DomainMetrics) OnAntiEntropyCycle() {
+	m.antiEntropyCycles.Inc()
+}
+
+// OnAntiEntropyGapFound increments
+// lantern_anti_entropy_gaps_found_total{peer,origin} when a tick observes
+// a non-zero gap against a peer's own origin row.
+func (m *DomainMetrics) OnAntiEntropyGapFound(peer, origin string) {
+	m.antiEntropyGapsFound.WithLabelValues(peer, origin).Inc()
+}
+
+// --- replication.AntiEntropyMetrics adapter ---
+//
+// The anti-entropy driver's narrow surface (server/replication.AntiEntropyMetrics)
+// is satisfied by these methods so the driver can take *DomainMetrics
+// directly without a wrapper type. Per-cycle and per-peer events map onto
+// the collectors registered above; the per-peer "Tick" event is currently
+// a no-op as the issue spec only requires per-cycle counts.
+
+func (m *DomainMetrics) OnAntiEntropyTick(string) {}
+
+func (m *DomainMetrics) OnAntiEntropyBehind(peer, origin string, gap uint64) {
+	m.SetReplicationLag(peer, origin, gap)
+	m.OnAntiEntropyGapFound(peer, origin)
+}
+
+func (m *DomainMetrics) OnAntiEntropyCaughtUp(peer, origin string, _ uint64) {
+	// Reset the gauge to 0 — the peer is now caught up on the row we
+	// were repairing. Dashboards see a clear edge transition.
+	m.SetReplicationLag(peer, origin, 0)
+}
+
+func (m *DomainMetrics) OnAntiEntropyError(peer, reason string) {
+	m.OnReplicationDropped(peer, reason)
+}
+
+// --- replication.Metrics (pump) adapter ---
+//
+// The pump's narrow Metrics surface is satisfied by these methods so
+// provider/replication.go can pass *DomainMetrics directly. Only the two
+// events that map onto the dropped_total counter spec'd in #187 emit
+// metric updates; the connect/apply/snapshot hooks are reserved for
+// future expansion (per-peer connect gauges, snapshot counters) and
+// currently no-op so the pump compiles against the same handle.
+
+func (m *DomainMetrics) OnPumpConnect(string) {}
+
+func (m *DomainMetrics) OnPumpDisconnect(peer, reason string) {
+	m.OnReplicationDropped(peer, reason)
+}
+
+func (m *DomainMetrics) OnPumpApply(string) {}
+
+func (m *DomainMetrics) OnPumpDropSelfEcho(peer string) {
+	m.OnReplicationDropped(peer, "self_echo")
+}
+
+func (m *DomainMetrics) OnPumpSnapshotReplayed(string, uint64, uint64) {}
 
 // BindSampler stores the gauge-population callback. Must be called before
 // Run; safe to call exactly once during wiring.

--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -77,3 +77,60 @@ func TestDomainMetrics_Run_NoSampler_StopsOnContextCancel(t *testing.T) {
 		t.Fatal("Run did not return after context cancel")
 	}
 }
+
+// TestDomainMetrics_ReplicationFamilies asserts the #187 replication and
+// anti-entropy collectors register with the expected names and that the
+// adapter methods used by the pump (Metrics) and anti-entropy driver
+// (AntiEntropyMetrics) interfaces emit on the right counters/gauges.
+func TestDomainMetrics_ReplicationFamilies(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := New(reg, Options{Version: "v", Commit: "c", SampleInterval: time.Hour})
+
+	// Drive each emission path once.
+	m.OnReplicationApplied("aabbccdd")
+	m.OnReplicationDropped("peer-a:7000", "ctx_cancel")
+	m.OnPumpDropSelfEcho("peer-b:7000") // → dropped{peer,self_echo}
+	m.OnAntiEntropyCycle()
+	m.OnAntiEntropyBehind("peer-a:7000", "aabbccdd", 42)   // gauge=42, gaps=1
+	m.OnAntiEntropyCaughtUp("peer-a:7000", "aabbccdd", 42) // gauge→0
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	names := map[string]bool{}
+	for _, mf := range mfs {
+		names[mf.GetName()] = true
+	}
+	for _, want := range []string{
+		"lantern_replication_applied_total",
+		"lantern_replication_dropped_total",
+		"lantern_replication_lag_seq",
+		"lantern_anti_entropy_cycles_total",
+		"lantern_anti_entropy_gaps_found_total",
+	} {
+		if !names[want] {
+			t.Errorf("metric family %q not registered", want)
+		}
+	}
+
+	if got := testutil.ToFloat64(m.replicationApplied.WithLabelValues("aabbccdd")); got != 1 {
+		t.Errorf("replication_applied_total{origin=aabbccdd} = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.replicationDropped.WithLabelValues("peer-a:7000", "ctx_cancel")); got != 1 {
+		t.Errorf("replication_dropped_total{peer-a,ctx_cancel} = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.replicationDropped.WithLabelValues("peer-b:7000", "self_echo")); got != 1 {
+		t.Errorf("replication_dropped_total{peer-b,self_echo} = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.antiEntropyCycles); got != 1 {
+		t.Errorf("anti_entropy_cycles_total = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.antiEntropyGapsFound.WithLabelValues("peer-a:7000", "aabbccdd")); got != 1 {
+		t.Errorf("anti_entropy_gaps_found_total = %v, want 1", got)
+	}
+	// CaughtUp reset the lag back to 0 after the Behind tick set it to 42.
+	if got := testutil.ToFloat64(m.replicationLag.WithLabelValues("peer-a:7000", "aabbccdd")); got != 0 {
+		t.Errorf("replication_lag_seq after CaughtUp = %v, want 0", got)
+	}
+}

--- a/server/provider/antientropy.go
+++ b/server/provider/antientropy.go
@@ -7,6 +7,7 @@ import (
 	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
 	v1 "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/server/internal/envconfig"
+	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
 	"github.com/anaregdesign/lantern/server/replication"
 	"github.com/anaregdesign/lantern/server/service"
 )
@@ -51,6 +52,7 @@ func NewAntiEntropyDriver(
 	svc *service.LanternService,
 	cache *cachegraph.GraphCache[string, *v1.Vertex],
 	pump *replication.Pump,
+	m *domainmetrics.DomainMetrics,
 	logger *slog.Logger,
 ) *replication.AntiEntropy {
 	_ = pump // forces wire to construct the pump before the driver
@@ -60,5 +62,6 @@ func NewAntiEntropyDriver(
 		Interval:         ac.Interval,
 		SubscribeTimeout: ac.SubscribeTimeout,
 		Logger:           logger,
+		Metrics:          m,
 	}, svc, svc, cache)
 }

--- a/server/provider/pump.go
+++ b/server/provider/pump.go
@@ -8,6 +8,7 @@ import (
 	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
 	v1 "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/server/internal/envconfig"
+	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
 	"github.com/anaregdesign/lantern/server/replication"
 	"github.com/anaregdesign/lantern/server/service"
 )
@@ -65,6 +66,7 @@ func NewReplicationPump(
 	rc ReplicationConfig,
 	svc *service.LanternService,
 	cache *cachegraph.GraphCache[string, *v1.Vertex],
+	m *domainmetrics.DomainMetrics,
 	logger *slog.Logger,
 ) *replication.Pump {
 	return replication.NewPump(replication.Config{
@@ -73,5 +75,6 @@ func NewReplicationPump(
 		BackoffMin: pc.BackoffMin,
 		BackoffMax: pc.BackoffMax,
 		Logger:     logger,
+		Metrics:    m,
 	}, svc, cache)
 }

--- a/server/replication/antientropy.go
+++ b/server/replication/antientropy.go
@@ -29,6 +29,7 @@ package replication
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"io"
 	"log/slog"
@@ -54,19 +55,25 @@ type LocalStateProvider interface {
 // AntiEntropyMetrics is the narrow surface the driver uses to publish
 // per-tick counters. Wired by provider/metrics so the driver stays
 // independent of prometheus.
+//
+// origin is the lowercase-hex encoding of the peer's self HLC NodeID
+// (i.e. the origin row the driver is comparing against). peer is the
+// peer's RPC address as configured in LANTERN_PEERS.
 type AntiEntropyMetrics interface {
+	OnAntiEntropyCycle()
 	OnAntiEntropyTick(peer string)
-	OnAntiEntropyBehind(peer string, gap uint64)
-	OnAntiEntropyCaughtUp(peer string, applied uint64)
-	OnAntiEntropyError(peer string, reason string)
+	OnAntiEntropyBehind(peer, origin string, gap uint64)
+	OnAntiEntropyCaughtUp(peer, origin string, applied uint64)
+	OnAntiEntropyError(peer, reason string)
 }
 
 type nopAntiEntropyMetrics struct{}
 
-func (nopAntiEntropyMetrics) OnAntiEntropyTick(string)             {}
-func (nopAntiEntropyMetrics) OnAntiEntropyBehind(string, uint64)   {}
-func (nopAntiEntropyMetrics) OnAntiEntropyCaughtUp(string, uint64) {}
-func (nopAntiEntropyMetrics) OnAntiEntropyError(string, string)    {}
+func (nopAntiEntropyMetrics) OnAntiEntropyCycle()                          {}
+func (nopAntiEntropyMetrics) OnAntiEntropyTick(string)                     {}
+func (nopAntiEntropyMetrics) OnAntiEntropyBehind(string, string, uint64)   {}
+func (nopAntiEntropyMetrics) OnAntiEntropyCaughtUp(string, string, uint64) {}
+func (nopAntiEntropyMetrics) OnAntiEntropyError(string, string)            {}
 
 // AntiEntropyConfig groups the driver's inputs. All fields except
 // Peers / Interval are optional; NewAntiEntropy fills defaults.
@@ -169,6 +176,7 @@ func (a *AntiEntropy) Run(ctx context.Context) error {
 // Per-peer errors are logged and metric'd but never propagated —
 // anti-entropy is best-effort.
 func (a *AntiEntropy) tickAll(ctx context.Context) {
+	a.cfg.Metrics.OnAntiEntropyCycle()
 	var wg sync.WaitGroup
 	for _, addr := range a.cfg.Peers {
 		wg.Add(1)
@@ -250,7 +258,8 @@ func (a *AntiEntropy) tickPeer(ctx context.Context, addr string) {
 		return
 	}
 	gap := target - localSeq
-	a.cfg.Metrics.OnAntiEntropyBehind(addr, gap)
+	originHex := hex.EncodeToString(peerNID[:])
+	a.cfg.Metrics.OnAntiEntropyBehind(addr, originHex, gap)
 	log.Info("anti-entropy: peer ahead, catching up",
 		slog.Uint64("local_seq", localSeq),
 		slog.Uint64("peer_seq", target),
@@ -263,7 +272,7 @@ func (a *AntiEntropy) tickPeer(ctx context.Context, addr string) {
 		a.cfg.Metrics.OnAntiEntropyError(addr, "catchup_failed")
 		return
 	}
-	a.cfg.Metrics.OnAntiEntropyCaughtUp(addr, applied)
+	a.cfg.Metrics.OnAntiEntropyCaughtUp(addr, originHex, applied)
 	log.Info("anti-entropy: caught up",
 		slog.Uint64("applied", applied),
 		slog.Uint64("target_seq", target))

--- a/server/service/apply.go
+++ b/server/service/apply.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/binary"
+	"encoding/hex"
 	"time"
 
 	"github.com/anaregdesign/lantern/core/cache/graph"
@@ -180,6 +181,9 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 		var nid hlc.NodeID
 		copy(nid[:], origin)
 		s.origins.Record(nid, seq, ts)
+		if s.onApplied != nil {
+			s.onApplied(hex.EncodeToString(nid[:]))
+		}
 	}
 	return nil
 }

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -43,6 +43,7 @@ type LanternService struct {
 	logger       *slog.Logger
 	tombstoneTTL time.Duration
 	origins      *originStateTracker
+	onApplied    func(origin string)
 }
 
 // ScanLimits caps the per-call pagination knobs for the prefix RPCs. It is
@@ -104,12 +105,26 @@ func (s *LanternService) WithLogger(l *slog.Logger) *LanternService {
 }
 
 // WithTombstoneTTL configures the maximum retention window for delete
+
+// WithTombstoneTTL configures the maximum retention window for delete
 // tombstones AND the upper bound on caller-supplied Expiration on the
 // Add*/Put* RPCs (#183). When d <= 0 the clamp is disabled (legacy
 // behaviour) and Delete handlers fall back to the non-HLC backend path.
 // Wired from LANTERN_TOMBSTONE_TTL via provider.ReplicationConfig.
 func (s *LanternService) WithTombstoneTTL(d time.Duration) *LanternService {
 	s.tombstoneTTL = d
+	return s
+}
+
+// WithAppliedHook registers a callback invoked after every successful
+// remote-mutation apply (ApplyMutation path). The hook receives the
+// lowercase-hex encoding of the originating HLC NodeID and is used by
+// provider/metrics to bump lantern_replication_applied_total{origin}.
+// A nil hook (the default) disables the callback. The hook MUST be
+// non-blocking; the apply path holds no locks but synchronously waits
+// for the callback to return.
+func (s *LanternService) WithAppliedHook(f func(origin string)) *LanternService {
+	s.onApplied = f
 	return s
 }
 

--- a/testbed/SKILL.md
+++ b/testbed/SKILL.md
@@ -88,6 +88,14 @@ curl -s http://localhost:9090/metrics \
   | grep -E '^(lantern_(vertices|edges|ttl_expirations_total|gc_duration_seconds_count)|process_resident_memory_bytes)'
 ```
 
+Replication health (#187 — empty on single-instance, populated under
+`testbed/docker-compose.yml` HA mode):
+
+```bash
+curl -s http://localhost:9090/metrics \
+  | grep -E '^lantern_(replication_(applied|dropped)_total|replication_lag_seq|anti_entropy_(cycles|gaps_found)_total)'
+```
+
 Log triage (JSON logs by default — `LANTERN_LOG_FORMAT=json`):
 
 ```bash


### PR DESCRIPTION
Closes #187.

## Summary

Adds the five Prometheus families called out by the issue plus the wiring required to populate them from the existing pump and anti-entropy driver.

```
lantern_replication_applied_total{origin}
lantern_replication_dropped_total{peer,reason}
lantern_replication_lag_seq{peer,origin}
lantern_anti_entropy_cycles_total
lantern_anti_entropy_gaps_found_total{peer,origin}
```

### Mechanics
- `*DomainMetrics` directly implements both `replication.Metrics` (pump) and `replication.AntiEntropyMetrics` (driver), so providers pass the singleton with no wrapper.
- The driver gains `OnAntiEntropyCycle()` plus an `origin` parameter on Behind/CaughtUp; `origin` is the lowercase hex of the peer's HLC NodeID (16 bytes).
- `server/service`: new opt-in `WithAppliedHook(func(origin string))` invoked only from the REMOTE apply path (after `origins.Record`). LOCAL writes intentionally don't bump `applied_total` — the counter measures replication inflow, not local fan-out.
- `server/cmd/server.go` chains the hook in `newLanternService`; `wire_gen.go` regenerated via `go tool wire`.
- Drop reason taxonomy reused from existing pump/driver: `clean`, `ctx_cancel`, `snapshot_failed`, `subscribe_failed`, `self_echo`, `catchup_failed`.

### Single-instance behaviour
With no peers configured the new families register with zero series — gauges/counters are exposed but empty, so dashboards built against them still work uniformly per the issue's requirement.

### Tests
- New `TestDomainMetrics_ReplicationFamilies` drives each emission path once (applied, dropped, self-echo, cycle, behind, caught-up) and asserts on family presence, counter values, and lag-reset semantics.
- `testbed/SKILL.md` extended with a replication-health grep block mirroring the existing GC/cache groupings.

### Verification
- `go build ./...` clean across all modules.
- `go test ./...` and `go test -race -skip TestGraphCache_PrefixIndex_ConcurrentScanIsConsistent ./...` pass in root, `server/`, and `core/`.
- `gofmt -l .` clean.