### PR TITLE
sdks/go: add NewLanternWithEndpoints + round_robin LB (#189)

### DIFF
--- a/sdks/go/doc.go
+++ b/sdks/go/doc.go
@@ -41,4 +41,41 @@
 //
 // See https://github.com/anaregdesign/lantern/issues/106 for the design
 // discussion.
+//
+// # Connection topology
+//
+// Pick the constructor that matches how your deployment exposes Lantern
+// nodes. All three configurations enable the same default retry policy
+// (UNAVAILABLE + RESOURCE_EXHAUSTED retried with capped exponential
+// backoff) and client-side `round_robin` load balancing; only the resolver
+// changes.
+//
+//   - Single endpoint — PaaS (Cloud Run, ACA, App Service single instance)
+//     or any other case where you have one stable URL:
+//
+//     c, err := client.NewLantern("lantern.example.com:50051")
+//
+//   - DNS fan-out — k8s ClusterIP / headless Service, Compose service name,
+//     or any DNS source that resolves a single hostname to N backend
+//     addresses. gRPC re-resolves on connection failure and round_robin
+//     spreads load across every resolved address:
+//
+//     c, err := client.NewLantern("dns:///lantern.default.svc.cluster.local:50051")
+//
+//   - Explicit static list — bare hosts, environment-supplied pod IPs, or
+//     any non-DNS discovery source. Uses gRPC's manual resolver under the
+//     hood; you control the membership list and the SDK round-robins
+//     across it:
+//
+//     c, err := client.NewLanternWithEndpoints([]string{
+//     "10.0.0.11:50051",
+//     "10.0.0.12:50051",
+//     "10.0.0.13:50051",
+//     })
+//
+// All three forms transparently failover: if any backend returns
+// `codes.Unavailable` the default service config retries on the next
+// healthy address, and the readiness gate on each server (HTTP
+// `/healthz/ready`) keeps draining nodes out of rotation until they catch
+// up on replication.
 package client

--- a/sdks/go/endpoints.go
+++ b/sdks/go/endpoints.go
@@ -1,0 +1,119 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
+)
+
+// roundRobinServiceConfig adds round_robin client-side load balancing on top
+// of the default retry policy. Used by NewLanternWithEndpoints and by the
+// "dns:///" form of NewLantern so calls fan out across every backend the
+// resolver reports.
+//
+// Retry semantics match defaultServiceConfig (AddEdge stays excluded because
+// it is additive and not safe to retry blindly).
+const roundRobinServiceConfig = `{
+  "loadBalancingConfig": [{"round_robin": {}}],
+  "methodConfig": [
+    {
+      "name": [
+        {"service": "graph.v1.LanternService", "method": "GetVertex"},
+        {"service": "graph.v1.LanternService", "method": "GetEdge"},
+        {"service": "graph.v1.LanternService", "method": "PutVertex"},
+        {"service": "graph.v1.LanternService", "method": "PutEdge"},
+        {"service": "graph.v1.LanternService", "method": "DeleteVertex"},
+        {"service": "graph.v1.LanternService", "method": "DeleteEdge"},
+        {"service": "graph.v1.LanternService", "method": "DeleteVertices"},
+        {"service": "graph.v1.LanternService", "method": "DeleteEdges"},
+        {"service": "graph.v1.LanternService", "method": "Illuminate"}
+      ],
+      "retryPolicy": {
+        "maxAttempts": 4,
+        "initialBackoff": "0.1s",
+        "maxBackoff": "5s",
+        "backoffMultiplier": 2,
+        "retryableStatusCodes": ["UNAVAILABLE", "RESOURCE_EXHAUSTED"]
+      }
+    }
+  ]
+}`
+
+// NewLanternWithEndpoints dials a fixed set of host:port endpoints and
+// returns a connected Lantern client that fans out RPCs across every
+// reachable backend using gRPC's built-in round_robin load balancer.
+//
+// Use this when:
+//   - You have an explicit list of pod IPs or hosts (e.g. read from
+//     environment, config map, or a non-DNS discovery source) and want
+//     transparent client-side load balancing with automatic failover.
+//   - You want to start sending traffic immediately to a known set of nodes
+//     without depending on DNS TTLs.
+//
+// For single-endpoint and DNS-based discovery, use NewLantern instead:
+//
+//   - NewLantern("pod-a:50051")         → single backend, no LB.
+//   - NewLantern("dns:///lantern:50051") → DNS resolver + round_robin (works
+//     out of the box for k8s Services and Compose service names).
+//   - NewLanternWithEndpoints([]string{"pod-a:50051", "pod-b:50051"})
+//     → explicit static list + round_robin.
+//
+// Empty input is rejected with an error so callers cannot accidentally dial
+// nothing. Retry policy defaults match NewLantern; override with
+// WithDefaultServiceConfig if you need different semantics.
+func NewLanternWithEndpoints(endpoints []string, opts ...Option) (*Lantern, error) {
+	if len(endpoints) == 0 {
+		return nil, errors.New("client: NewLanternWithEndpoints requires at least one endpoint")
+	}
+	for i, ep := range endpoints {
+		if strings.TrimSpace(ep) == "" {
+			return nil, fmt.Errorf("client: NewLanternWithEndpoints endpoint[%d] is empty", i)
+		}
+	}
+
+	o := options{
+		batchChunkSize:    defaultBatchChunkSize,
+		serviceConfigJSON: roundRobinServiceConfig,
+		keepalive:         defaultKeepalive,
+	}
+	for _, apply := range opts {
+		apply(&o)
+	}
+
+	r := manual.NewBuilderWithScheme("lantern-static")
+	addrs := make([]resolver.Address, 0, len(endpoints))
+	for _, ep := range endpoints {
+		addrs = append(addrs, resolver.Address{Addr: ep})
+	}
+	r.InitialState(resolver.State{Addresses: addrs})
+
+	dialOpts := make([]grpc.DialOption, 0, len(o.dialOptions)+4)
+	dialOpts = append(dialOpts, grpc.WithResolvers(r))
+	dialOpts = append(dialOpts, grpc.WithKeepaliveParams(o.keepalive))
+	if o.transportCreds != nil {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(o.transportCreds))
+	} else {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+	if o.serviceConfigJSON != "" {
+		dialOpts = append(dialOpts, grpc.WithDefaultServiceConfig(o.serviceConfigJSON))
+	}
+	dialOpts = append(dialOpts, o.dialOptions...)
+
+	target := r.Scheme() + ":///lantern"
+	conn, err := grpc.NewClient(target, dialOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return &Lantern{
+		conn:   conn,
+		client: pb.NewLanternServiceClient(conn),
+		opts:   o,
+	}, nil
+}

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -10,10 +10,16 @@ import (
 	"google.golang.org/grpc/keepalive"
 )
 
-// defaultServiceConfig enables transparent gRPC retries on idempotent RPCs.
-// AddEdge is deliberately excluded because it is additive (retrying would
-// double-count weight).
+// defaultServiceConfig enables transparent gRPC retries on idempotent RPCs
+// and round_robin client-side load balancing. round_robin is a no-op for
+// single-address targets (pick_first semantics fall out naturally) but
+// becomes meaningful as soon as the target is a `dns:///host:port` URI that
+// resolves to more than one A record — e.g. a k8s headless Service, a
+// Compose service name with multiple replicas, or any other multi-record
+// DNS source. AddEdge stays out of the retry list because it is additive
+// and retrying would double-count weight.
 const defaultServiceConfig = `{
+  "loadBalancingConfig": [{"round_robin": {}}],
   "methodConfig": [
     {
       "name": [

--- a/tests/integration/multi_endpoint_test.go
+++ b/tests/integration/multi_endpoint_test.go
@@ -1,0 +1,176 @@
+package integration_test
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/anaregdesign/lantern/server/provider"
+	"github.com/anaregdesign/lantern/server/service"
+	"google.golang.org/grpc"
+)
+
+type countingServer struct {
+	srv     *grpc.Server
+	lis     net.Listener
+	addr    string
+	calls   atomic.Int64
+	stopped atomic.Bool
+}
+
+func startCountingServer(t *testing.T) *countingServer {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	cs := &countingServer{lis: lis, addr: lis.Addr().String()}
+
+	counter := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		cs.calls.Add(1)
+		return handler(ctx, req)
+	}
+	vi := provider.NewValidationInterceptor(provider.ValidationLimits{
+		MaxKeyLen:         256,
+		MaxBatchSize:      1024,
+		IlluminateMaxStep: 32,
+		IlluminateMaxK:    256,
+	})
+	cs.srv = grpc.NewServer(grpc.ChainUnaryInterceptor(counter, vi.UnaryServerInterceptor()))
+	svc := service.NewLanternService(cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute))
+	pb.RegisterLanternServiceServer(cs.srv, svc)
+	go func() {
+		_ = cs.srv.Serve(lis)
+	}()
+	return cs
+}
+
+func (cs *countingServer) stop() {
+	if cs.stopped.Swap(true) {
+		return
+	}
+	cs.srv.Stop()
+	_ = cs.lis.Close()
+}
+
+// TestNewLanternWithEndpoints_RoundRobin verifies that the explicit-endpoint
+// constructor (a) dials every supplied address, and (b) actually spreads
+// load across them via round_robin. Both server-side counters must observe
+// at least one call after a small batch of RPCs.
+func TestNewLanternWithEndpoints_RoundRobin(t *testing.T) {
+	a := startCountingServer(t)
+	defer a.stop()
+	b := startCountingServer(t)
+	defer b.stop()
+
+	l, err := client.NewLanternWithEndpoints([]string{a.addr, b.addr})
+	if err != nil {
+		t.Fatalf("NewLanternWithEndpoints: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Warm up — first RPC triggers connect to every subconn before
+	// round_robin starts handing out picks.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if err := l.PutVertex(ctx, "warmup", "v", time.Minute); err == nil {
+			break
+		} else if time.Now().After(deadline) {
+			t.Fatalf("warmup PutVertex never succeeded: %v", err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	const n = 50
+	for i := 0; i < n; i++ {
+		if err := l.PutVertex(ctx, "k", "v", time.Minute); err != nil {
+			t.Fatalf("PutVertex[%d]: %v", i, err)
+		}
+	}
+
+	// Allow a short window for round_robin to converge across both subconns.
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if a.calls.Load() > 0 && b.calls.Load() > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if a.calls.Load() == 0 || b.calls.Load() == 0 {
+		t.Fatalf("expected both backends to receive RPCs; got a=%d b=%d", a.calls.Load(), b.calls.Load())
+	}
+}
+
+// TestNewLanternWithEndpoints_FailoverOnNodeLoss kills one backend and
+// verifies that subsequent RPCs continue to succeed against the surviving
+// node thanks to round_robin re-picking + the default retry policy on
+// UNAVAILABLE.
+func TestNewLanternWithEndpoints_FailoverOnNodeLoss(t *testing.T) {
+	a := startCountingServer(t)
+	defer a.stop()
+	b := startCountingServer(t)
+	defer b.stop()
+
+	l, err := client.NewLanternWithEndpoints([]string{a.addr, b.addr})
+	if err != nil {
+		t.Fatalf("NewLanternWithEndpoints: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Establish both subconns first.
+	for i := 0; i < 20; i++ {
+		if err := l.PutVertex(ctx, "warmup", "v", time.Minute); err != nil {
+			// Tolerate connect race on the first iterations.
+			if i > 5 {
+				t.Fatalf("warmup[%d]: %v", i, err)
+			}
+		}
+	}
+
+	// Drop one backend.
+	b.stop()
+
+	// Wait briefly for the balancer to mark the dead subconn as
+	// TransientFailure. Until that happens round_robin may still hand out
+	// a stale pick that fails with UNAVAILABLE on the in-flight RPC.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := l.PutVertex(ctx, "post-failover", "v", time.Minute); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// All subsequent calls must succeed on the survivor.
+	const n = 30
+	for i := 0; i < n; i++ {
+		if err := l.PutVertex(ctx, "post-failover", "v", time.Minute); err != nil {
+			t.Fatalf("PutVertex after failover [%d]: %v", i, err)
+		}
+	}
+	if a.calls.Load() == 0 {
+		t.Fatalf("expected survivor backend to receive RPCs after failover; got 0")
+	}
+}
+
+// TestNewLanternWithEndpoints_RejectsEmpty guards against accidentally
+// constructing a client that would dial nothing.
+func TestNewLanternWithEndpoints_RejectsEmpty(t *testing.T) {
+	if _, err := client.NewLanternWithEndpoints(nil); err == nil {
+		t.Fatalf("expected error for nil endpoints")
+	}
+	if _, err := client.NewLanternWithEndpoints([]string{"  "}); err == nil {
+		t.Fatalf("expected error for blank endpoint")
+	}
+}


### PR DESCRIPTION
Closes #189.

## What

* New constructor `NewLanternWithEndpoints([]string, ...Option)` for SDK callers who have an explicit list of `host:port` backends (pod IPs, Compose service names, env-supplied lists). Uses gRPC's `manual.Resolver` under a synthetic `lantern-static` scheme so the same `grpc.NewClient` retry / keepalive / TLS plumbing applies.
* The default service config now enables `round_robin` so the existing `NewLantern(\"dns:///lantern:50051\")` form (k8s ClusterIP / headless Service, Compose service name) automatically spreads load across every resolved address. `round_robin` is a no-op for single-address targets, so the single-endpoint contract is preserved.
* Retry policy unchanged: idempotent RPCs retry on UNAVAILABLE / RESOURCE_EXHAUSTED with capped exponential backoff; AddEdge stays excluded because it is additive.
* Documented the three connection topologies (single endpoint, DNS fan-out, explicit list) with worked examples in `sdks/go/doc.go`.

## Tests

`tests/integration/multi_endpoint_test.go` brings up two real `net.Listen` gRPC servers backed by full `LanternService` and asserts:

1. `round_robin` actually spreads RPCs across both backends.
2. Stopping one backend keeps subsequent RPCs succeeding on the survivor (the balancer transitions the dead subconn to TransientFailure and the retry policy covers any in-flight mid-flip RPC).
3. Empty / blank endpoint lists are rejected at construction time.

Full `go test ./...` green across every module; `gofmt -l .` clean.

Refs: #189