### PR TITLE
server/replication: DNS-based peer discovery (#190)

### DIFF
--- a/docs/replication.md
+++ b/docs/replication.md
@@ -389,6 +389,64 @@ new pod boots
 
 Target steady-state flush latency: **< 100 ms** intra-DC at 1k mut/s.
 
+### 9.1 Peer discovery (#190)
+
+The pump resolves its peer set via `LANTERN_PEER_DISCOVERY`:
+
+| Mode | Env vars consumed | Behaviour |
+|---|---|---|
+| `static` (default) | `LANTERN_PEERS` (CSV `host:port,host:port`) | Resolved once at startup. Empty list → single-instance mode. |
+| `dns` | `LANTERN_PEER_DNS_NAME`, `LANTERN_PEER_DEFAULT_PORT` (default `50051`), `LANTERN_PEER_DISCOVERY_INTERVAL_MS` (default `10000`) | Periodic `net.Resolver.LookupHost` against `LANTERN_PEER_DNS_NAME`. Every A/AAAA record except the local node's interface IPs is treated as a peer. Re-poll on every interval; reconcile via add/cancel against the active per-peer goroutine set. |
+
+DNS mode is the canonical multi-instance path: it works against k8s
+headless Services (`lantern-headless.<ns>.svc.cluster.local`), Docker
+Compose service names (Compose's embedded DNS returns one A per
+replica), and Nomad+Consul DNS. Self-filter uses
+`net.InterfaceAddrs()` for non-loopback IPs; the pump's existing
+HLC-NodeID self-echo guard (§5) remains as defence-in-depth.
+
+A transient resolution error logs at `WARN` and preserves the
+previously-active peer set — established subscriptions are NOT torn
+down on a flapping DNS resolver.
+
+**Manual verification recipe (k8s headless Service).**
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: lantern-headless
+spec:
+  clusterIP: None                      # headless: A records = pod IPs
+  selector: { app: lantern }
+  ports: [{ name: grpc, port: 50051, targetPort: 50051 }]
+---
+# StatefulSet pods set env:
+#   LANTERN_PEER_DISCOVERY=dns
+#   LANTERN_PEER_DNS_NAME=lantern-headless.default.svc.cluster.local
+#   LANTERN_PEER_DEFAULT_PORT=50051
+```
+
+Scale the StatefulSet up/down and observe
+`lantern_replication_peer_up{peer=...}` add/remove series within one
+discovery interval.
+
+**Manual verification recipe (Docker Compose).**
+
+```yaml
+services:
+  lantern:
+    image: lantern:dev
+    deploy: { replicas: 3 }
+    environment:
+      LANTERN_PEER_DISCOVERY: dns
+      LANTERN_PEER_DNS_NAME: lantern             # Compose service name
+      LANTERN_PEER_DEFAULT_PORT: "50051"
+```
+
+`docker compose scale lantern=N` triggers Compose's embedded DNS to
+add/remove A records; the pump converges on the next tick.
+
 ## 10. Partition & split-brain analysis
 
 Lantern is **AP** in CAP terms. During a partition:

--- a/server/provider/pump.go
+++ b/server/provider/pump.go
@@ -12,21 +12,39 @@ import (
 	"github.com/anaregdesign/lantern/server/service"
 )
 
-// PeerConfig groups the outbound peer-replication pump knobs (#185).
+// PeerConfig groups the outbound peer-replication pump knobs (#185, #190).
 //
 //   - LANTERN_PEERS                      CSV list of peer addresses
-//     ("host:port,host:port"). Empty (the default) yields a no-op pump:
-//     the server runs in single-instance mode. Whitespace around each
-//     entry is trimmed; empty entries are dropped.
+//     ("host:port,host:port"). Empty (the default) yields a no-op pump
+//     unless LANTERN_PEER_DISCOVERY=dns; otherwise the server runs in
+//     single-instance mode. Whitespace around each entry is trimmed;
+//     empty entries are dropped.
 //   - LANTERN_PUMP_BACKOFF_MIN_MS        initial reconnect delay after a
 //     pump session error. Default 250ms. Doubles on each successive
 //     failure, capped at LANTERN_PUMP_BACKOFF_MAX_MS.
 //   - LANTERN_PUMP_BACKOFF_MAX_MS        upper cap on the reconnect
 //     delay. Default 30000ms (30s).
+//   - LANTERN_PEER_DISCOVERY             peer discovery mode. "static"
+//     (default) uses LANTERN_PEERS as-is. "dns" periodically resolves
+//     LANTERN_PEER_DNS_NAME to its A/AAAA records and treats every
+//     non-self address as a peer — the standard k8s headless-Service /
+//     Docker Compose service-name pattern (#190).
+//   - LANTERN_PEER_DNS_NAME              hostname for DNS discovery.
+//     Required when LANTERN_PEER_DISCOVERY=dns.
+//   - LANTERN_PEER_DEFAULT_PORT          port appended to every DNS-
+//     resolved IP. Default "50051".
+//   - LANTERN_PEER_DISCOVERY_INTERVAL_MS DNS re-poll cadence. Default
+//     10000ms (10s). A transient resolution failure logs and preserves
+//     the previously-active peer set so established subscriptions are
+//     not torn down.
 type PeerConfig struct {
-	Peers      []string
-	BackoffMin time.Duration
-	BackoffMax time.Duration
+	Peers             []string
+	BackoffMin        time.Duration
+	BackoffMax        time.Duration
+	Discovery         string
+	DNSName           string
+	DefaultPort       string
+	DiscoveryInterval time.Duration
 }
 
 // NewPeerConfig returns the PeerConfig slice of Config.
@@ -46,9 +64,13 @@ func loadPeerConfig() PeerConfig {
 		}
 	}
 	return PeerConfig{
-		Peers:      peers,
-		BackoffMin: time.Duration(envconfig.Int("LANTERN_PUMP_BACKOFF_MIN_MS", 250)) * time.Millisecond,
-		BackoffMax: time.Duration(envconfig.Int("LANTERN_PUMP_BACKOFF_MAX_MS", 30_000)) * time.Millisecond,
+		Peers:             peers,
+		BackoffMin:        time.Duration(envconfig.Int("LANTERN_PUMP_BACKOFF_MIN_MS", 250)) * time.Millisecond,
+		BackoffMax:        time.Duration(envconfig.Int("LANTERN_PUMP_BACKOFF_MAX_MS", 30_000)) * time.Millisecond,
+		Discovery:         strings.ToLower(strings.TrimSpace(envconfig.String("LANTERN_PEER_DISCOVERY", "static"))),
+		DNSName:           strings.TrimSpace(envconfig.String("LANTERN_PEER_DNS_NAME", "")),
+		DefaultPort:       strings.TrimSpace(envconfig.String("LANTERN_PEER_DEFAULT_PORT", "50051")),
+		DiscoveryInterval: time.Duration(envconfig.Int("LANTERN_PEER_DISCOVERY_INTERVAL_MS", 10_000)) * time.Millisecond,
 	}
 }
 
@@ -68,12 +90,31 @@ func NewReplicationPump(
 	m replication.Metrics,
 	logger *slog.Logger,
 ) *replication.Pump {
-	return replication.NewPump(replication.Config{
-		NodeID:     rc.NodeID,
-		Peers:      pc.Peers,
-		BackoffMin: pc.BackoffMin,
-		BackoffMax: pc.BackoffMax,
-		Logger:     logger,
-		Metrics:    m,
-	}, svc, cache)
+	cfg := replication.Config{
+		NodeID:            rc.NodeID,
+		Peers:             pc.Peers,
+		BackoffMin:        pc.BackoffMin,
+		BackoffMax:        pc.BackoffMax,
+		Logger:            logger,
+		Metrics:           m,
+		DiscoveryInterval: pc.DiscoveryInterval,
+	}
+	if pc.Discovery == "dns" && pc.DNSName != "" {
+		selfIPs, err := replication.LocalIPSet()
+		if err != nil {
+			logger.Warn("replication pump: failed to enumerate local IPs for DNS self-filter",
+				slog.Any("err", err))
+			selfIPs = nil
+		}
+		cfg.Source = &replication.DNSSource{
+			Name:    pc.DNSName,
+			Port:    pc.DefaultPort,
+			SelfIPs: selfIPs,
+		}
+		logger.Info("replication pump: DNS peer discovery enabled",
+			slog.String("dns_name", pc.DNSName),
+			slog.String("default_port", pc.DefaultPort),
+			slog.Duration("interval", pc.DiscoveryInterval))
+	}
+	return replication.NewPump(cfg, svc, cache)
 }

--- a/server/replication/discovery.go
+++ b/server/replication/discovery.go
@@ -1,0 +1,249 @@
+package replication
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+)
+
+// PeerSource resolves the current set of peer addresses the pump
+// should subscribe to. Implementations may be static (read once at
+// construction) or dynamic (e.g. periodic DNS lookups for headless
+// k8s services / Compose service names / Nomad+Consul DNS / plain
+// A-record fleets — see #190).
+//
+// Each Resolve call MUST return an absolute set: the supervisor
+// reconciles by diffing the returned set against the currently-active
+// peer goroutines and adding / cancelling as needed. Returning the
+// same set every call is correct and cheap — the supervisor only
+// acts on differences.
+//
+// Returned addresses are passed to grpc.NewClient verbatim, so each
+// entry MUST already be in "host:port" form. Implementations are
+// responsible for any self-filtering (so the local node does not
+// subscribe to itself); the pump's mutation-level self-echo guard
+// is a defence-in-depth backstop, not a substitute.
+type PeerSource interface {
+	Resolve(ctx context.Context) ([]string, error)
+}
+
+// StaticSource is a trivial PeerSource that returns the same address
+// list on every call. It models the historical
+// LANTERN_PEERS=host1:port,host2:port behaviour and is what
+// NewPump.Config.Peers boils down to internally when no explicit
+// Source is supplied.
+type StaticSource struct {
+	Peers []string
+}
+
+// Resolve returns a defensive copy of the configured peers.
+func (s StaticSource) Resolve(context.Context) ([]string, error) {
+	out := make([]string, len(s.Peers))
+	copy(out, s.Peers)
+	return out, nil
+}
+
+// HostLookup is the minimal surface DNSSource needs to resolve a
+// hostname to a set of A/AAAA addresses. *net.Resolver satisfies it
+// directly; tests inject fakes that return a controlled slice and
+// optionally error.
+type HostLookup interface {
+	LookupHost(ctx context.Context, host string) ([]string, error)
+}
+
+// DNSSource resolves a single DNS name to its current A/AAAA
+// records, applies an optional self-IP filter (so the local node
+// does not subscribe to its own listener), and emits the surviving
+// addresses as "ip:port" strings ready for grpc.NewClient.
+//
+// The DNS source is platform-neutral: it works against k8s headless
+// Services (`lantern-headless.<ns>.svc.cluster.local`), Docker
+// Compose service names (Compose's embedded DNS returns one A per
+// replica), HashiCorp Nomad service discovery via Consul DNS, or any
+// plain DNS round-robin A-record list.
+//
+// Serverless container PaaS that do not expose per-instance DNS
+// (Cloud Run, ACA, App Runner) remain explicitly unsupported as
+// multi-instance topologies — see RFC #175 §D7. Those deployments
+// keep using single-instance mode (empty peer list).
+type DNSSource struct {
+	// Name is the DNS hostname to resolve (no port). Example:
+	// "lantern-headless.default.svc.cluster.local".
+	Name string
+
+	// Port is the gRPC port appended to every resolved IP. Must
+	// be non-empty (the wire protocol has no default port).
+	Port string
+
+	// Lookup performs the actual hostname resolution. nil means
+	// net.DefaultResolver, which honours /etc/resolv.conf and the
+	// platform DNS stack.
+	Lookup HostLookup
+
+	// SelfIPs is the set of IP literals that identify the local
+	// node's own listener interfaces. Resolved addresses present
+	// in this set are filtered out before emission. nil disables
+	// self-filtering (acceptable in tests; production wiring
+	// passes LocalIPSet()).
+	SelfIPs map[string]struct{}
+}
+
+// Resolve returns the current peer set: every resolved address from
+// Name, with self-IPs removed, each formatted as "ip:port". A
+// resolution error is propagated verbatim — the supervisor logs and
+// keeps the previous set live, so a transient DNS failure does NOT
+// tear down established peer streams.
+func (d *DNSSource) Resolve(ctx context.Context) ([]string, error) {
+	if d.Name == "" {
+		return nil, errors.New("dns source: empty Name")
+	}
+	if d.Port == "" {
+		return nil, errors.New("dns source: empty Port")
+	}
+	lookup := d.Lookup
+	if lookup == nil {
+		lookup = net.DefaultResolver
+	}
+	ips, err := lookup.LookupHost(ctx, d.Name)
+	if err != nil {
+		return nil, fmt.Errorf("dns source: lookup %q: %w", d.Name, err)
+	}
+	out := make([]string, 0, len(ips))
+	seen := make(map[string]struct{}, len(ips))
+	for _, ip := range ips {
+		ip = strings.TrimSpace(ip)
+		if ip == "" {
+			continue
+		}
+		if _, self := d.SelfIPs[ip]; self {
+			continue
+		}
+		addr := net.JoinHostPort(ip, d.Port)
+		if _, dup := seen[addr]; dup {
+			continue
+		}
+		seen[addr] = struct{}{}
+		out = append(out, addr)
+	}
+	return out, nil
+}
+
+// LocalIPSet enumerates the IPs assigned to every up, non-loopback
+// network interface on this host. The returned set is intended for
+// DNSSource.SelfIPs so the pump never subscribes to its own
+// listener when a headless-Service A-record list happens to include
+// the local pod IP.
+//
+// Loopback addresses are excluded — they cannot appear in a
+// headless-Service or Compose-network resolution anyway, and
+// dropping them keeps the set minimal. Both IPv4 and IPv6 literals
+// are emitted in their canonical String() form so they match the
+// strings net.Resolver.LookupHost returns.
+func LocalIPSet() (map[string]struct{}, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]struct{})
+	for _, ifc := range ifaces {
+		if ifc.Flags&net.FlagUp == 0 {
+			continue
+		}
+		if ifc.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := ifc.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, a := range addrs {
+			var ip net.IP
+			switch v := a.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+			out[ip.String()] = struct{}{}
+		}
+	}
+	return out, nil
+}
+
+// peerSupervisor manages the dynamic set of per-peer pump
+// goroutines. One supervisor instance is created per Pump.Run call.
+type peerSupervisor struct {
+	run func(ctx context.Context, addr string)
+
+	mu      sync.Mutex
+	cancels map[string]context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+func newPeerSupervisor(run func(ctx context.Context, addr string)) *peerSupervisor {
+	return &peerSupervisor{run: run, cancels: make(map[string]context.CancelFunc)}
+}
+
+// reconcile starts goroutines for any address in want that is not
+// currently active and cancels goroutines for any active address
+// missing from want. The parent ctx scopes all spawned per-peer
+// contexts.
+func (s *peerSupervisor) reconcile(parent context.Context, want []string) {
+	wantSet := make(map[string]struct{}, len(want))
+	for _, a := range want {
+		wantSet[a] = struct{}{}
+	}
+
+	s.mu.Lock()
+	// stop departed peers
+	for addr, cancel := range s.cancels {
+		if _, keep := wantSet[addr]; !keep {
+			cancel()
+			delete(s.cancels, addr)
+		}
+	}
+	// start new peers
+	for _, addr := range want {
+		if _, running := s.cancels[addr]; running {
+			continue
+		}
+		peerCtx, cancel := context.WithCancel(parent)
+		s.cancels[addr] = cancel
+		s.wg.Add(1)
+		go func(addr string) {
+			defer s.wg.Done()
+			s.run(peerCtx, addr)
+		}(addr)
+	}
+	s.mu.Unlock()
+}
+
+// active returns a snapshot of the addresses with live goroutines.
+// Used by tests; not part of any production hot path.
+func (s *peerSupervisor) active() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, 0, len(s.cancels))
+	for a := range s.cancels {
+		out = append(out, a)
+	}
+	return out
+}
+
+// shutdown cancels every active peer goroutine and waits for them
+// to exit. Safe to call once after the supervisor loop has returned.
+func (s *peerSupervisor) shutdown() {
+	s.mu.Lock()
+	for addr, cancel := range s.cancels {
+		cancel()
+		delete(s.cancels, addr)
+	}
+	s.mu.Unlock()
+	s.wg.Wait()
+}

--- a/server/replication/discovery_test.go
+++ b/server/replication/discovery_test.go
@@ -1,0 +1,324 @@
+package replication
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeLookup is a HostLookup that returns whatever LookupHost is
+// configured to return at call time. Goroutine-safe so tests can
+// swap responses while a supervisor loop is polling.
+type fakeLookup struct {
+	mu    sync.Mutex
+	hosts []string
+	err   error
+	calls int
+}
+
+func (f *fakeLookup) LookupHost(_ context.Context, _ string) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make([]string, len(f.hosts))
+	copy(out, f.hosts)
+	return out, nil
+}
+
+func (f *fakeLookup) set(hosts []string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.hosts = hosts
+	f.err = err
+}
+
+func TestStaticSource_Resolve_ReturnsCopy(t *testing.T) {
+	src := StaticSource{Peers: []string{"a:1", "b:2"}}
+	got, err := src.Resolve(context.Background())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(got) != 2 || got[0] != "a:1" || got[1] != "b:2" {
+		t.Fatalf("unexpected: %v", got)
+	}
+	// Mutating the result must not affect future calls.
+	got[0] = "MUTATED"
+	got2, _ := src.Resolve(context.Background())
+	if got2[0] != "a:1" {
+		t.Fatalf("Resolve leaked internal slice: %v", got2)
+	}
+}
+
+func TestDNSSource_Resolve_FormatsAddresses(t *testing.T) {
+	lk := &fakeLookup{hosts: []string{"10.0.0.1", "10.0.0.2"}}
+	src := &DNSSource{Name: "lantern.svc", Port: "50051", Lookup: lk}
+	got, err := src.Resolve(context.Background())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	sort.Strings(got)
+	want := []string{"10.0.0.1:50051", "10.0.0.2:50051"}
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestDNSSource_Resolve_FiltersSelfIPs(t *testing.T) {
+	lk := &fakeLookup{hosts: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}}
+	src := &DNSSource{
+		Name:    "lantern.svc",
+		Port:    "50051",
+		Lookup:  lk,
+		SelfIPs: map[string]struct{}{"10.0.0.2": {}},
+	}
+	got, err := src.Resolve(context.Background())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	for _, a := range got {
+		if a == "10.0.0.2:50051" {
+			t.Fatalf("self IP not filtered: %v", got)
+		}
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 peers, got %v", got)
+	}
+}
+
+func TestDNSSource_Resolve_DedupesAndStripsEmpty(t *testing.T) {
+	lk := &fakeLookup{hosts: []string{"10.0.0.1", "", "10.0.0.1", "  ", "10.0.0.2"}}
+	src := &DNSSource{Name: "lantern.svc", Port: "50051", Lookup: lk}
+	got, err := src.Resolve(context.Background())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 unique peers, got %v", got)
+	}
+}
+
+func TestDNSSource_Resolve_PropagatesLookupError(t *testing.T) {
+	lk := &fakeLookup{err: errors.New("nxdomain")}
+	src := &DNSSource{Name: "lantern.svc", Port: "50051", Lookup: lk}
+	_, err := src.Resolve(context.Background())
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestDNSSource_Resolve_RequiresNameAndPort(t *testing.T) {
+	if _, err := (&DNSSource{Port: "50051"}).Resolve(context.Background()); err == nil {
+		t.Fatalf("expected error for empty Name")
+	}
+	if _, err := (&DNSSource{Name: "x"}).Resolve(context.Background()); err == nil {
+		t.Fatalf("expected error for empty Port")
+	}
+}
+
+// TestPeerSupervisor_Reconcile_AddsAndRemoves drives the supervisor
+// through several reconciliations and asserts the expected
+// spawn / cancel transitions land. This is the test #190 specifies
+// as the acceptance criterion for "simulated A-record changes drive
+// correct add/remove".
+func TestPeerSupervisor_Reconcile_AddsAndRemoves(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		started = map[string]int{}
+		stopped = map[string]int{}
+	)
+	stoppedCh := make(chan string, 16)
+
+	run := func(ctx context.Context, addr string) {
+		mu.Lock()
+		started[addr]++
+		mu.Unlock()
+		<-ctx.Done()
+		mu.Lock()
+		stopped[addr]++
+		mu.Unlock()
+		stoppedCh <- addr
+	}
+
+	sup := newPeerSupervisor(run)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// initial: {a, b}
+	sup.reconcile(ctx, []string{"a:1", "b:1"})
+	waitFor(t, "started a+b", func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return started["a:1"] == 1 && started["b:1"] == 1
+	})
+
+	// reconcile to {b, c}: a departs, c joins.
+	sup.reconcile(ctx, []string{"b:1", "c:1"})
+	drainOne(t, stoppedCh, "a:1")
+	waitFor(t, "started c", func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return started["c:1"] == 1
+	})
+
+	got := sup.active()
+	sort.Strings(got)
+	if len(got) != 2 || got[0] != "b:1" || got[1] != "c:1" {
+		t.Fatalf("active() = %v, want [b:1 c:1]", got)
+	}
+
+	// idempotent reconcile: no new spawns, no cancels.
+	sup.reconcile(ctx, []string{"b:1", "c:1"})
+	mu.Lock()
+	if started["b:1"] != 1 || started["c:1"] != 1 {
+		mu.Unlock()
+		t.Fatalf("idempotent reconcile re-spawned: %v", started)
+	}
+	mu.Unlock()
+
+	// shutdown cancels remaining.
+	sup.shutdown()
+	mu.Lock()
+	defer mu.Unlock()
+	if stopped["b:1"] != 1 || stopped["c:1"] != 1 {
+		t.Fatalf("shutdown did not cancel all: stopped=%v", stopped)
+	}
+}
+
+// TestPump_Run_DiscoveryInterval_PollsAndReconciles boots Pump.Run
+// against a fake PeerSource and asserts the supervisor reconciles
+// added / removed peers on each tick. We avoid spinning up real
+// gRPC clients by leaving the runner field on Pump unchanged but
+// pointing peers at unroutable loopback ports — runPeer will fail
+// to dial and back off, which is fine: we only assert the
+// supervisor lifecycle, not connection success.
+func TestPump_Run_DiscoveryInterval_PollsAndReconciles(t *testing.T) {
+	// Use a recordingSource so we can drive add/remove deterministically.
+	src := &recordingSource{addrs: []string{"127.0.0.1:1"}}
+	p := NewPump(Config{
+		Source:            src,
+		DiscoveryInterval: 25 * time.Millisecond,
+		BackoffMin:        1 * time.Hour, // suppress reconnect churn
+		BackoffMax:        1 * time.Hour,
+	}, nil, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		_ = p.Run(ctx)
+		close(done)
+	}()
+
+	// Wait for at least 3 Resolve calls (initial + 2 ticks).
+	waitFor(t, "source polled >=3 times", func() bool {
+		return atomic.LoadInt64(&src.calls) >= 3
+	})
+
+	// Swap the address set; supervisor should converge.
+	src.set([]string{"127.0.0.1:2", "127.0.0.1:3"})
+	waitFor(t, "source observed new set", func() bool {
+		return atomic.LoadInt64(&src.calls) >= 5
+	})
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Pump.Run did not return after cancel")
+	}
+}
+
+// TestPump_Run_DiscoveryError_KeepsPreviousSet asserts that a
+// transient Source error logs but does NOT tear down active peers.
+func TestPump_Run_DiscoveryError_KeepsPreviousSet(t *testing.T) {
+	src := &recordingSource{addrs: []string{"127.0.0.1:1"}}
+	p := NewPump(Config{
+		Source:            src,
+		DiscoveryInterval: 20 * time.Millisecond,
+		BackoffMin:        1 * time.Hour,
+		BackoffMax:        1 * time.Hour,
+	}, nil, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = p.Run(ctx); close(done) }()
+
+	waitFor(t, "initial resolve", func() bool {
+		return atomic.LoadInt64(&src.calls) >= 1
+	})
+
+	src.setErr(errors.New("dns went away"))
+	// Allow several failed ticks; the supervisor must not panic
+	// and Run must keep running.
+	time.Sleep(80 * time.Millisecond)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Pump.Run did not return after cancel")
+	}
+}
+
+// recordingSource is a minimal PeerSource for Pump.Run tests.
+type recordingSource struct {
+	mu    sync.Mutex
+	addrs []string
+	err   error
+	calls int64
+}
+
+func (r *recordingSource) Resolve(context.Context) ([]string, error) {
+	atomic.AddInt64(&r.calls, 1)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err != nil {
+		return nil, r.err
+	}
+	out := make([]string, len(r.addrs))
+	copy(out, r.addrs)
+	return out, nil
+}
+
+func (r *recordingSource) set(a []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.addrs = a
+	r.err = nil
+}
+
+func (r *recordingSource) setErr(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.err = err
+}
+
+func waitFor(t *testing.T, desc string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for: %s", desc)
+}
+
+func drainOne(t *testing.T, ch <-chan string, want string) {
+	t.Helper()
+	select {
+	case got := <-ch:
+		if got != want {
+			t.Fatalf("got stopped=%q, want %q", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timeout waiting for stop of %q", want)
+	}
+}

--- a/server/replication/pump.go
+++ b/server/replication/pump.go
@@ -36,7 +36,6 @@ import (
 	"errors"
 	"io"
 	"log/slog"
-	"sync"
 	"time"
 
 	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
@@ -98,8 +97,26 @@ type Config struct {
 
 	// Peers is the static list of peer addresses to subscribe to.
 	// Each entry is consumed by grpc.NewClient verbatim
-	// ("host:port"). Empty (or nil) yields a no-op pump.
+	// ("host:port"). Empty (or nil) is valid when Source is set;
+	// otherwise yields a no-op pump.
 	Peers []string
+
+	// Source, when non-nil, takes precedence over Peers and is the
+	// dynamic peer-set resolver consulted at startup and (when
+	// DiscoveryInterval > 0) on every tick. The pump reconciles
+	// added / removed addresses by spawning / cancelling per-peer
+	// goroutines. nil means "use StaticSource{Peers}", which
+	// preserves the historical LANTERN_PEERS contract.
+	Source PeerSource
+
+	// DiscoveryInterval is the polling cadence for Source. Zero
+	// means "resolve once at startup and never re-poll" — the
+	// static behaviour. A positive value enables dynamic peer
+	// discovery (e.g. periodic DNS lookups against a k8s headless
+	// Service per #190). Resolution errors are logged and the
+	// previously-active peer set is retained so a transient DNS
+	// failure does not tear down established subscriptions.
+	DiscoveryInterval time.Duration
 
 	// DialOptions are passed to grpc.NewClient for each peer
 	// connection. When empty, insecure transport credentials are
@@ -160,25 +177,71 @@ func NewPump(cfg Config, apply MutationApplier, snap SnapshotApplier) *Pump {
 
 // Run starts one goroutine per peer and blocks until ctx is
 // cancelled. Returns nil after all goroutines have exited. A pump
-// with no configured peers is a no-op and returns immediately.
+// with no configured peers AND no dynamic Source is a no-op and
+// returns immediately.
+//
+// When Config.Source is set (or Config.Peers is non-empty — which
+// is wrapped in a StaticSource), Run:
+//
+//  1. Resolves the initial peer set and spawns one goroutine per
+//     address.
+//  2. If Config.DiscoveryInterval > 0, polls Source on every tick
+//     and reconciles add/remove against the active goroutine set.
+//     A resolution error logs and preserves the previous set
+//     (defensive: a transient DNS failure must not silently drop
+//     established peer streams).
+//  3. On ctx cancellation, cancels every per-peer goroutine and
+//     waits for them to exit before returning.
 func (p *Pump) Run(ctx context.Context) error {
-	if len(p.cfg.Peers) == 0 {
-		p.cfg.Logger.Info("replication pump: no peers configured, running in single-instance mode")
+	source := p.cfg.Source
+	if source == nil {
+		if len(p.cfg.Peers) == 0 {
+			p.cfg.Logger.Info("replication pump: no peers configured, running in single-instance mode")
+			return nil
+		}
+		source = StaticSource{Peers: p.cfg.Peers}
+	}
+
+	sup := newPeerSupervisor(p.runPeer)
+	defer sup.shutdown()
+
+	initial, err := source.Resolve(ctx)
+	if err != nil {
+		p.cfg.Logger.Warn("replication pump: initial peer resolution failed",
+			slog.Any("err", err))
+	}
+	if len(initial) == 0 && p.cfg.DiscoveryInterval == 0 {
+		p.cfg.Logger.Info("replication pump: no peers resolved and no discovery interval, running in single-instance mode")
 		return nil
 	}
-	p.cfg.Logger.Info("replication pump: starting", slog.Int("peers", len(p.cfg.Peers)))
+	sup.reconcile(ctx, initial)
+	p.cfg.Logger.Info("replication pump: starting",
+		slog.Int("peers", len(initial)),
+		slog.Duration("discovery_interval", p.cfg.DiscoveryInterval))
 
-	var wg sync.WaitGroup
-	for _, addr := range p.cfg.Peers {
-		wg.Add(1)
-		go func(addr string) {
-			defer wg.Done()
-			p.runPeer(ctx, addr)
-		}(addr)
+	if p.cfg.DiscoveryInterval <= 0 {
+		<-ctx.Done()
+		p.cfg.Logger.Info("replication pump: stopped")
+		return nil
 	}
-	wg.Wait()
-	p.cfg.Logger.Info("replication pump: stopped")
-	return nil
+
+	ticker := time.NewTicker(p.cfg.DiscoveryInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			p.cfg.Logger.Info("replication pump: stopped")
+			return nil
+		case <-ticker.C:
+			peers, err := source.Resolve(ctx)
+			if err != nil {
+				p.cfg.Logger.Warn("replication pump: peer resolution failed (keeping previous set)",
+					slog.Any("err", err))
+				continue
+			}
+			sup.reconcile(ctx, peers)
+		}
+	}
 }
 
 // runPeer is the per-peer reconnect loop. Each iteration represents


### PR DESCRIPTION
Closes #190.

Implements dynamic peer-set discovery for the replication pump so
multi-instance topologies (k8s headless Services, Docker Compose,
Nomad+Consul DNS) no longer require a static `LANTERN_PEERS` CSV.

## What changed

- **`server/replication/discovery.go`** (new):
  - `PeerSource` interface — periodic resolver consulted by the pump.
  - `StaticSource` — wraps a fixed []string; preserves the historical `LANTERN_PEERS` contract bit-for-bit when `DiscoveryInterval == 0`.
  - `DNSSource` — `net.Resolver.LookupHost` against a configured name, with optional self-IP filter, dedupe, and `host:port` formatting.
  - `LocalIPSet()` — enumerates non-loopback interface IPs for self-filter.
  - `peerSupervisor` — reconciles add/remove transitions: cancels per-peer goroutines for departed addresses, spawns for new ones; idempotent.

- **`server/replication/pump.go`**:
  - `Config` gains `Source PeerSource` and `DiscoveryInterval time.Duration`.
  - `Pump.Run` now drives a supervisor. When `DiscoveryInterval > 0`, polls Source on each tick; transient resolution errors log at WARN and preserve the previous set so flapping DNS does NOT tear down established peer streams.
  - Static behaviour (`Source == nil` or `DiscoveryInterval == 0`) is unchanged.

- **`server/provider/pump.go`** — new env vars:
  - `LANTERN_PEER_DISCOVERY` — `static` (default) or `dns`.
  - `LANTERN_PEER_DNS_NAME` — hostname for DNS discovery.
  - `LANTERN_PEER_DEFAULT_PORT` — port appended to resolved IPs. Default `50051`.
  - `LANTERN_PEER_DISCOVERY_INTERVAL_MS` — re-poll cadence. Default `10000`.

- **`docs/replication.md`** — new §9.1 with topology table and manual verification recipes for k8s headless Service + Docker Compose.

## Tests

- `StaticSource` defensive copy.
- `DNSSource` formatting, self-IP filter, dedupe + whitespace stripping, lookup-error propagation, required-field validation.
- `peerSupervisor` add/remove/idempotent transitions via a fake runner.
- `Pump.Run` polling cadence + retention of previous set on `Source` error.

Race-clean. `go vet ./...` clean. `gofmt -l .` clean.