### PR TITLE
feat(deploy): add Helm chart + Compose HA topology (#191)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,50 @@ Or build from source:
 go run ./server/cmd          # listens on :6380
 ```
 
+### Run on Kubernetes (HA mode)
+
+For Tier-A HA (3 replicas with DNS-based peer discovery, anti-entropy
+reconciliation, and a `PodDisruptionBudget`) install the bundled Helm
+chart:
+
+```shell
+helm install lantern deploy/helm/lantern
+# Or render without installing:
+helm template lantern deploy/helm/lantern | less
+```
+
+The chart creates a `StatefulSet`, a headless `Service` for peer
+discovery (`replication.discovery.mode=dns`), a `ClusterIP` `Service`
+for clients (gRPC `:6380`), and an optional `ServiceMonitor`. See
+[`deploy/helm/lantern/README.md`](deploy/helm/lantern/README.md) for
+the full values reference and
+[`docs/replication.md` §9.1](docs/replication.md#91-peer-discovery-190)
+for the discovery semantics.
+
+### Run with Docker Compose (HA mode)
+
+A 3-replica HA topology for local experiments lives in
+[`deploy/compose/`](deploy/compose/):
+
+```shell
+cd deploy/compose
+docker compose up -d
+docker compose up -d --scale lantern=5    # reconciles in ≤1 discovery tick
+```
+
+Each replica is published on its own host port (`6380`, `6381`, …) so
+the Go SDK's round-robin LB (`NewLanternWithEndpoints`) can fan reads
+across them, while Prometheus on `:9091` scrapes every pod via DNS SD.
+
+### Run on serverless container PaaS
+
+For Cloud Run / Azure Container Apps / AWS App Runner / Fly Machines /
+any platform without stable pod identities, deploy a **single
+instance** (or independent shards) without setting any `LANTERN_PEER_*`
+env. Peer discovery requires a stable in-cluster DNS that resolves to
+per-pod IPs, which these platforms do not provide. See the HA runbook
+(issue #192) for the trade-off matrix and Tier-B / Tier-C topologies.
+
 ### Use the CLI
 
 Pre-built binaries for Linux, macOS, and Windows (amd64 + arm64) are

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -1,0 +1,85 @@
+# Docker Compose: HA lantern cluster
+
+3-replica peer-discovery cluster (Tier-A) on a single Docker host. Mirrors
+the Helm chart in [`../helm/lantern/`](../helm/lantern/) for local dev and
+single-host HA experiments.
+
+## Topology
+
+- 3 × `lantern` replicas (`deploy.replicas: 3`), each on host ports
+  `6380`, `6381`, `6382`.
+- Compose's embedded DNS resolves the service name `lantern` to one A
+  per running replica. Each lantern container's peer pump (#190)
+  resolves that name, filters its own IP via `LocalIPSet()`, and opens
+  replication streams to the other peers.
+- `prometheus` scrapes via `dns_sd_configs` so it picks up every
+  replica automatically (no static targets file to maintain).
+
+## Run
+
+```shell
+cd deploy/compose
+docker compose up -d
+docker compose ps
+```
+
+Scale up or down without restarting; each lantern container reconciles
+within one discovery tick (default `LANTERN_PEER_DISCOVERY_INTERVAL_MS=10000`):
+
+```shell
+docker compose up -d --scale lantern=5
+# Logs on any one container should show 4 active peers within ~10s.
+docker compose logs --tail=20 lantern
+```
+
+Tear down:
+
+```shell
+docker compose down -v
+```
+
+## Client access
+
+The example does **not** include an in-cluster client LB sidecar.
+Pick one of:
+
+- **Go SDK** (`#189`): pass all replica endpoints; the SDK uses
+  gRPC's `round_robin` LB policy.
+  ```go
+  c, _ := lantern.NewLanternWithEndpoints([]string{
+      "localhost:6380", "localhost:6381", "localhost:6382",
+  })
+  ```
+- **CLI / grpcurl**: hit any pod directly; writes propagate via the
+  peer pump.
+- **Your own LB** (nginx-plus stream `resolve`, Envoy, HAProxy with
+  DNS resolution): point upstream at `lantern:6380`.
+
+## Verifying peer discovery
+
+```shell
+# Each replica should log "peer_discovery" lines with the other 2 IPs.
+docker compose logs lantern | grep peer_discovery
+
+# Prometheus (http://localhost:9091):
+#   lantern_replication_peer_up         — 1 gauge per active peer link
+#   lantern_replication_lag             — per (peer, origin) lag
+```
+
+## Single-instance fallback
+
+For non-HA development just override the replicas to 1:
+
+```shell
+docker compose up -d --scale lantern=1
+```
+
+`LANTERN_PEER_DNS_NAME=lantern` still resolves — to a single A record
+which `LocalIPSet()` filters as self, so the pump becomes a no-op.
+
+## Cross-references
+
+- Helm chart (production path): [`../helm/lantern/`](../helm/lantern/)
+- Peer discovery spec: [`../../docs/replication.md` §9.1](../../docs/replication.md#91-peer-discovery-190)
+- HA runbook: issue #192 (in flight).
+- Testbed (single-instance observability QA): [`../../testbed/`](../../testbed/)

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -1,0 +1,67 @@
+# Docker Compose: HA topology (3-replica peer-discovery cluster).
+#
+# Mirrors the Helm chart's Tier-A topology for local development and
+# single-host HA experiments. Uses Compose's embedded DNS: the service
+# name `lantern` resolves to one A per replica, and the lantern peer
+# pump (#190) filters its own IP.
+#
+# Clients use the Go SDK's round-robin LB (#189):
+#   c, _ := lantern.NewLanternWithEndpoints(
+#       []string{"localhost:6380", "localhost:6381", "localhost:6382"})
+# There is intentionally no client-side LB sidecar in this example —
+# picking one would push opinions that don't belong in a quickstart.
+#
+# Usage:
+#   cd deploy/compose
+#   docker compose up -d
+#   docker compose up -d --scale lantern=5     # each pod reconciles in ≤1 tick
+#   docker compose down -v
+#
+# Override the image:
+#   LANTERN_IMAGE=ghcr.io/anaregdesign/lantern:v0.7.1 docker compose up -d
+
+services:
+  lantern:
+    image: ${LANTERN_IMAGE:-lantern:local}
+    deploy:
+      replicas: 3
+    # Publish a port range so each replica is reachable on its own host
+    # port (6380, 6381, 6382, ...) — clients can enumerate them all for
+    # SDK round-robin. Compose assigns the next free port to each replica.
+    ports:
+      - target: 6380
+        published: "6380-6389"
+        protocol: tcp
+        mode: host
+    environment:
+      LANTERN_PORT: "6380"
+      LANTERN_METRICS_ADDR: ":9090"
+      LANTERN_DEFAULT_TTL_SECONDS: "3600"
+      LANTERN_LOG_FORMAT: "json"
+      LANTERN_LOG_LEVEL: "info"
+      # Peer discovery (#190): resolve the service name via Compose DNS.
+      LANTERN_PEER_DISCOVERY: "dns"
+      LANTERN_PEER_DNS_NAME: "lantern"
+      LANTERN_PEER_DEFAULT_PORT: "6380"
+      LANTERN_PEER_DISCOVERY_INTERVAL_MS: "10000"
+      # Readiness gating (#188).
+      LANTERN_MAX_REPLICATION_LAG: "10000"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9090/readyz"]
+      interval: 5s
+      timeout: 2s
+      retries: 12
+      start_period: 10s
+
+  prometheus:
+    image: prom/prometheus:v3.5.0
+    ports:
+      - "9091:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.retention.time=1h"
+    depends_on:
+      lantern:
+        condition: service_healthy

--- a/deploy/compose/prometheus.yml
+++ b/deploy/compose/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  # Use Compose's embedded DNS A records so we scrape every replica.
+  - job_name: lantern
+    metrics_path: /metrics
+    dns_sd_configs:
+      - names: ["lantern"]
+        type: A
+        port: 9090
+        refresh_interval: 10s

--- a/deploy/helm/lantern/.helmignore
+++ b/deploy/helm/lantern/.helmignore
@@ -1,0 +1,12 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.idea/
+.vscode/
+*.tgz
+*.tmproj
+*.swp
+*.bak
+*.orig
+README.md.tmpl

--- a/deploy/helm/lantern/Chart.yaml
+++ b/deploy/helm/lantern/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: lantern
+description: |
+  Lantern — time-decaying graph cache with eventually-consistent peer
+  replication. This chart deploys lantern as a StatefulSet behind a
+  headless Service for DNS-based peer discovery (see #190) plus a
+  ClusterIP Service for client traffic, with a PodDisruptionBudget
+  guarding rolling updates.
+type: application
+version: 0.1.0
+appVersion: "latest"
+home: https://github.com/anaregdesign/lantern
+sources:
+  - https://github.com/anaregdesign/lantern
+maintainers:
+  - name: anaregdesign
+    url: https://github.com/anaregdesign
+keywords:
+  - graph
+  - cache
+  - kvs
+  - replication
+  - ha

--- a/deploy/helm/lantern/README.md
+++ b/deploy/helm/lantern/README.md
@@ -1,0 +1,109 @@
+# lantern (Helm chart)
+
+Tier-A HA deployment of [lantern](https://github.com/anaregdesign/lantern)
+on Kubernetes: a `StatefulSet` of 3 pods behind a headless `Service` for
+DNS-based peer discovery (see [docs/replication.md §9.1](../../../docs/replication.md))
+plus a `ClusterIP` `Service` for clients, guarded by a `PodDisruptionBudget`.
+
+## Quick install
+
+```shell
+helm install lantern deploy/helm/lantern
+```
+
+For a one-off render:
+
+```shell
+helm template lantern deploy/helm/lantern | less
+```
+
+To lint:
+
+```shell
+helm lint deploy/helm/lantern
+```
+
+## What gets deployed
+
+| Object                                | Purpose                                                |
+| ------------------------------------- | ------------------------------------------------------ |
+| `StatefulSet/<release>-lantern`       | 3 lantern pods (default), `RollingUpdate` strategy.    |
+| `Service/<release>-lantern`           | `ClusterIP` — client gRPC + scrapeable `/metrics`.     |
+| `Service/<release>-lantern-headless`  | `clusterIP: None` — peer discovery DNS.                |
+| `PodDisruptionBudget/<release>-lantern` | `minAvailable: 2` to keep quorum during drains.      |
+| `ServiceAccount/<release>-lantern`    | Workload identity (token-only by default).             |
+| `ServiceMonitor/<release>-lantern`    | Optional, when `metrics.serviceMonitor.enabled=true`.  |
+
+The pump reads `LANTERN_PEER_DISCOVERY=dns` and resolves the headless
+`Service` FQDN to obtain peer IPs. `LocalIPSet()` in the server filters
+the pod's own IP so the supervisor never dials itself.
+
+## Single-instance fallback
+
+For dev / single-instance topologies set `replicaCount=1` and either
+keep `replication.discovery.mode=dns` (the DNSSource will resolve to
+just the local pod and filter it out — pump becomes a no-op) or set
+`replication.discovery.mode=static` with `replication.peers=[]`. PDB
+can be disabled via `podDisruptionBudget.enabled=false`.
+
+For serverless container PaaS (Cloud Run / Azure Container Apps /
+App Runner) there is no peer topology — do **not** use this chart;
+deploy the container directly without `LANTERN_PEER_*` env. See the
+HA runbook (#192) for the limits.
+
+## Tuning
+
+| Value                                       | Default                | Notes                                              |
+| ------------------------------------------- | ---------------------- | -------------------------------------------------- |
+| `replicaCount`                              | `3`                    | Tier-A HA default.                                 |
+| `image.repository`                          | `ghcr.io/anaregdesign/lantern` | Override for private mirrors.              |
+| `image.tag`                                 | `.Chart.AppVersion`    | Pin to a specific release tag in production.       |
+| `service.port`                              | `6380`                 | gRPC.                                              |
+| `metrics.port`                              | `9090`                 | `/metrics`, `/healthz`, `/readyz`.                 |
+| `replication.discovery.mode`                | `dns`                  | `static` falls back to `LANTERN_PEERS`.            |
+| `replication.discovery.dnsName`             | headless FQDN          | Auto-templated. Override only for cross-ns peers.  |
+| `replication.discovery.defaultPort`         | `"6380"`               | Appended to each resolved IP.                      |
+| `replication.discovery.intervalMs`          | `10000`                | `0` = resolve once at startup.                     |
+| `replication.maxLag`                        | `10000`                | Per-(peer,origin) lag cap before readiness flips.  |
+| `antiEntropy.intervalMs`                    | `30000`                | Background reconciliation cadence.                 |
+| `podDisruptionBudget.minAvailable`          | `2`                    | Quorum-ish.                                        |
+| `metrics.serviceMonitor.enabled`            | `false`                | Requires the prometheus-operator CRD.              |
+
+See [`values.yaml`](values.yaml) for the full set including probes,
+resources, security context, anti-affinity, and `extraEnv`.
+
+## Smoke test
+
+```shell
+kubectl -n default get pods -l app.kubernetes.io/name=lantern
+kubectl -n default get endpoints <release>-lantern-headless
+kubectl -n default port-forward svc/<release>-lantern 6380:6380
+# In another terminal:
+lantern put-vertex --addr localhost:6380 key1 value1
+lantern get-vertex --addr localhost:6380 key1
+```
+
+Then scale and observe convergence:
+
+```shell
+kubectl -n default scale statefulset <release>-lantern --replicas=5
+# Within one discovery tick (default 10s) each pod resolves all 5,
+# filters self, and opens replication streams to the other 4.
+```
+
+## Verifying peer discovery
+
+```shell
+# All pods should see N-1 peer addresses in their logs.
+kubectl -n default logs <release>-lantern-0 | grep peer_discovery
+
+# Prometheus: lantern_replication_peer_up{peer="..."} gauge series
+# should show one per resolved peer, transitioning 0→1 on stream open.
+```
+
+## Cross-references
+
+- RFC: [docs/replication.md](../../../docs/replication.md)
+- Discovery spec: [docs/replication.md §9.1](../../../docs/replication.md#91-peer-discovery-190)
+- Docker Compose alternative: [`deploy/compose/`](../../compose/)
+- HA runbook: see issue #192 (in flight).

--- a/deploy/helm/lantern/templates/NOTES.txt
+++ b/deploy/helm/lantern/templates/NOTES.txt
@@ -1,0 +1,24 @@
+Lantern has been deployed in namespace {{ .Release.Namespace }} as
+StatefulSet {{ include "lantern.fullname" . }} with {{ .Values.replicaCount }} replica(s).
+
+Peer discovery mode: {{ .Values.replication.discovery.mode }}
+{{- if eq .Values.replication.discovery.mode "dns" }}
+Peer DNS name:       {{ include "lantern.discoveryDNSName" . }}
+{{- end }}
+
+Client-facing service (gRPC):
+  {{ include "lantern.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+Headless service (peer discovery):
+  {{ include "lantern.headlessFQDN" . }}
+
+Quick checks:
+  kubectl -n {{ .Release.Namespace }} get statefulset {{ include "lantern.fullname" . }}
+  kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/name={{ include "lantern.name" . }}
+  kubectl -n {{ .Release.Namespace }} get endpoints {{ include "lantern.headlessName" . }}
+
+Port-forward gRPC to localhost:
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "lantern.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+
+See deploy/helm/lantern/README.md for tuning notes and
+docs/replication.md §9.1 for the peer-discovery semantics.

--- a/deploy/helm/lantern/templates/_helpers.tpl
+++ b/deploy/helm/lantern/templates/_helpers.tpl
@@ -1,0 +1,88 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "lantern.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified app name. Truncated at 63 chars.
+*/}}
+{{- define "lantern.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Headless service name (used for peer discovery).
+*/}}
+{{- define "lantern.headlessName" -}}
+{{- if .Values.service.headlessName -}}
+{{- .Values.service.headlessName -}}
+{{- else -}}
+{{- printf "%s-headless" (include "lantern.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+FQDN for the headless service in-cluster.
+*/}}
+{{- define "lantern.headlessFQDN" -}}
+{{- printf "%s.%s.svc.cluster.local" (include "lantern.headlessName" .) .Release.Namespace -}}
+{{- end -}}
+
+{{/*
+The DNS name the peer pump should resolve. Falls back to the headless
+FQDN when replication.discovery.dnsName is empty.
+*/}}
+{{- define "lantern.discoveryDNSName" -}}
+{{- if .Values.replication.discovery.dnsName -}}
+{{- .Values.replication.discovery.dnsName -}}
+{{- else -}}
+{{- include "lantern.headlessFQDN" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart label.
+*/}}
+{{- define "lantern.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "lantern.labels" -}}
+helm.sh/chart: {{ include "lantern.chart" . }}
+{{ include "lantern.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels (stable; used by Service + StatefulSet).
+*/}}
+{{- define "lantern.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lantern.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Service account name.
+*/}}
+{{- define "lantern.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "lantern.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/lantern/templates/pdb.yaml
+++ b/deploy/helm/lantern/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "lantern.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lantern.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "lantern.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/lantern/templates/service.yaml
+++ b/deploy/helm/lantern/templates/service.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lantern.headlessName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lantern.labels" . | nindent 4 }}
+    lantern.anaregdesign.io/role: peer-discovery
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: false
+  selector:
+    {{- include "lantern.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: grpc
+      port: {{ .Values.service.port }}
+      targetPort: grpc
+      protocol: TCP
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lantern.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lantern.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "lantern.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: grpc
+      port: {{ .Values.service.port }}
+      targetPort: grpc
+      protocol: TCP
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP

--- a/deploy/helm/lantern/templates/serviceaccount.yaml
+++ b/deploy/helm/lantern/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lantern.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lantern.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/lantern/templates/servicemonitor.yaml
+++ b/deploy/helm/lantern/templates/servicemonitor.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.metrics.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "lantern.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace }}
+  labels:
+    {{- include "lantern.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "lantern.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/deploy/helm/lantern/templates/statefulset.yaml
+++ b/deploy/helm/lantern/templates/statefulset.yaml
@@ -1,0 +1,131 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "lantern.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lantern.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "lantern.headlessName" . }}
+  replicas: {{ .Values.replicaCount }}
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
+  selector:
+    matchLabels:
+      {{- include "lantern.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lantern.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "lantern.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: 30
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity:
+        {{- if .Values.affinity }}
+        {{- toYaml .Values.affinity | nindent 8 }}
+        {{- else if .Values.defaultPodAntiAffinity }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    {{- include "lantern.selectorLabels" . | nindent 20 }}
+        {{- end }}
+      containers:
+        - name: lantern
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: grpc
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+          env:
+            - name: LANTERN_PORT
+              value: {{ .Values.service.port | quote }}
+            - name: LANTERN_METRICS_ADDR
+              value: {{ printf ":%v" .Values.metrics.port | quote }}
+            - name: LANTERN_LOG_LEVEL
+              value: {{ .Values.log.level | quote }}
+            - name: LANTERN_LOG_FORMAT
+              value: {{ .Values.log.format | quote }}
+            - name: LANTERN_DEFAULT_TTL_SECONDS
+              value: {{ .Values.cache.defaultTtlSeconds | quote }}
+            - name: LANTERN_PEER_DISCOVERY
+              value: {{ .Values.replication.discovery.mode | quote }}
+            {{- if eq .Values.replication.discovery.mode "dns" }}
+            - name: LANTERN_PEER_DNS_NAME
+              value: {{ include "lantern.discoveryDNSName" . | quote }}
+            - name: LANTERN_PEER_DEFAULT_PORT
+              value: {{ .Values.replication.discovery.defaultPort | quote }}
+            - name: LANTERN_PEER_DISCOVERY_INTERVAL_MS
+              value: {{ .Values.replication.discovery.intervalMs | quote }}
+            {{- end }}
+            {{- if and (eq .Values.replication.discovery.mode "static") .Values.replication.peers }}
+            - name: LANTERN_PEERS
+              value: {{ join "," .Values.replication.peers | quote }}
+            {{- end }}
+            - name: LANTERN_MAX_REPLICATION_LAG
+              value: {{ .Values.replication.maxLag | quote }}
+            - name: LANTERN_ANTI_ENTROPY_INTERVAL_MS
+              value: {{ .Values.antiEntropy.intervalMs | quote }}
+            - name: LANTERN_ANTI_ENTROPY_SUBSCRIBE_TIMEOUT_MS
+              value: {{ .Values.antiEntropy.subscribeTimeoutMs | quote }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: metrics
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+            successThreshold: {{ .Values.probes.readiness.successThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/deploy/helm/lantern/values.yaml
+++ b/deploy/helm/lantern/values.yaml
@@ -1,0 +1,133 @@
+# Default values for lantern.
+# Tier-A HA topology: 3-replica StatefulSet + headless Service + PDB.
+# Per RFC #175 D7. Set replicaCount=1 to fall back to single-instance
+# mode (no peer pump, no readiness gating).
+
+image:
+  repository: ghcr.io/anaregdesign/lantern
+  tag: ""        # defaults to .Chart.AppVersion
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Number of lantern pods. 3 is the recommended Tier-A default.
+# Use 1 for single-instance / dev (peer pump becomes a no-op when only
+# the local pod resolves).
+replicaCount: 3
+
+# StatefulSet update strategy. RollingUpdate is required for the PDB
+# minAvailable guarantee to hold during upgrades.
+updateStrategy:
+  type: RollingUpdate
+
+# PodDisruptionBudget for voluntary disruption (node drains, upgrades).
+# minAvailable: 2 keeps quorum-style availability with 3 replicas.
+# Set enabled: false for single-instance deployments.
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2
+
+service:
+  # ClusterIP service exposes the gRPC port to clients.
+  port: 6380
+  # Headless service drives DNS-based peer discovery (#190).
+  # No ClusterIP — DNS returns one A per ready pod.
+  headlessName: ""   # default: <fullname>-headless
+  type: ClusterIP
+  annotations: {}
+
+# Metrics endpoint (Prometheus /metrics + /healthz + /readyz).
+metrics:
+  port: 9090
+  serviceMonitor:
+    enabled: false
+    namespace: ""
+    interval: 30s
+    scrapeTimeout: 10s
+    labels: {}
+
+# Replication / peer discovery. See docs/replication.md §9.1.
+replication:
+  discovery:
+    mode: dns                   # static | dns
+    # DNS hostname the pump resolves to peer IPs. Empty => template
+    # auto-fills with the headless Service FQDN.
+    dnsName: ""
+    defaultPort: "6380"         # appended to each resolved IP
+    intervalMs: 10000           # 0 = resolve once at startup
+  # Static fallback list, used when discovery.mode == "static".
+  peers: []
+  # Cap per-(peer,origin) replication lag before readiness flips false.
+  maxLag: 10000
+
+# Anti-entropy settings (background reconciliation). See #186.
+antiEntropy:
+  intervalMs: 30000
+  subscribeTimeoutMs: 30000
+
+# Graph cache TTL defaults (seconds).
+cache:
+  defaultTtlSeconds: 3600
+
+# Liveness/readiness probes.
+probes:
+  liveness:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 6
+  readiness:
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 3
+    successThreshold: 1
+
+# Resource requests/limits.
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: "2"
+    memory: 2Gi
+
+# Extra environment variables (raw env list, appended after the
+# templated ones). Useful for TLS_* / RATE_LIMIT_* / LOG_* tweaks.
+extraEnv: []
+
+# Pod scheduling.
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Soft anti-affinity by default — schedule pods on different nodes
+# when possible. Set to {} to disable.
+defaultPodAntiAffinity: true
+
+# Pod security.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  fsGroup: 65532
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  readOnlyRootFilesystem: true
+
+# Logging.
+log:
+  level: info
+  format: json
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+podAnnotations: {}
+podLabels: {}


### PR DESCRIPTION
## Summary

Closes #191. Provides first-class HA deployment artifacts that consume the DNS-based peer discovery added in #190.

### `deploy/helm/lantern/` — Tier-A Helm chart

- **StatefulSet** of 3 replicas (`podManagementPolicy: Parallel`, `RollingUpdate`) with downward-API `POD_NAME`/`POD_IP` and full env wiring for replication, anti-entropy, log, and cache subsystems.
- **Two Services**:
  - headless (`clusterIP: None`, `publishNotReadyAddresses: false`) — peer discovery DNS, second line of self-filter defence behind `LocalIPSet()`.
  - `ClusterIP` — client gRPC + scrapeable `/metrics`.
- **PodDisruptionBudget** (`minAvailable: 2`), ServiceAccount, optional ServiceMonitor (gated, `monitoring.coreos.com/v1`).
- `_helpers.tpl` auto-derives the discovery DNS name from the headless FQDN; soft pod anti-affinity by hostname as a safe default.
- Chart pins `LANTERN_PEER_DEFAULT_PORT` to `"6380"` for coherence with `LANTERN_PORT` (the server-side code default is still `"50051"`).
- Chart `README.md` documents Tier-A install / values / smoke / discovery verification.

### `deploy/compose/` — single-host HA topology

- 3-replica `lantern` service using `deploy.replicas` plus Compose embedded DNS so the service name `lantern` yields one A per replica. Same `LANTERN_PEER_DNS_NAME` code path as Kubernetes.
- Per-replica host port range (`6380-6389`) so the Go SDK `round_robin` LB (`NewLanternWithEndpoints`, #189) can fan client RPCs across replicas without an LB sidecar.
- Prometheus via `dns_sd_configs` so scrape membership auto-tracks `--scale` up/down.

### `README.md`

Three new subsections under **Quick start**:
- Run on Kubernetes (HA mode)
- Run with Docker Compose (HA mode)
- Run on serverless container PaaS (single-instance only — peer discovery requires stable in-cluster DNS)

## Validation

- `helm lint deploy/helm/lantern` → 0 fail, 1 info (icon).
- `helm template lantern deploy/helm/lantern` → renders cleanly (1 PDB, 1 SA, 2 Services, 1 StatefulSet); conditional env emission verified with `--set replication.discovery.mode=static`, `--set replication.peers=…`, `--set metrics.serviceMonitor.enabled=true`.
- `docker compose config` → valid.
- `gofmt -l` → clean (no Go files touched).

Refs #190 #188 #189.
