### PR TITLE
testbed: add Compose HA smoke + failure-recovery SDK tests

### DIFF
--- a/testbed/ha-recovery/main.go
+++ b/testbed/ha-recovery/main.go
@@ -1,0 +1,246 @@
+// Compose HA failure-recovery test:
+//  1. seed baseline data via round-robin LB
+//  2. stop compose-lantern-2 (one of three replicas)
+//  3. write new data while it is down (only 2 replicas accept)
+//  4. start compose-lantern-2 again
+//  5. wait for catch-up via Subscribe replay / Snapshot
+//  6. assert the restarted replica has every vertex/edge
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"time"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+const victimContainer = "compose-lantern-2"
+
+var containers = []string{"compose-lantern-1", "compose-lantern-2", "compose-lantern-3"}
+
+func docker(args ...string) {
+	out, err := exec.Command("docker", args...).CombinedOutput()
+	if err != nil {
+		log.Fatalf("docker %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+// hostPort returns the localhost port mapped to the container's :6380.
+func hostPort(container string) string {
+	out, err := exec.Command("docker", "port", container, "6380/tcp").Output()
+	if err != nil {
+		log.Fatalf("docker port %s: %v", container, err)
+	}
+	// e.g. "0.0.0.0:6384\n[::]:6384\n"
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if i := strings.LastIndex(line, ":"); i >= 0 {
+			return "localhost:" + strings.TrimSpace(line[i+1:])
+		}
+	}
+	log.Fatalf("docker port %s: no mapping in %q", container, string(out))
+	return ""
+}
+
+func waitReady(ep string, timeout time.Duration) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		cli, err := client.NewLantern(ep)
+		if err == nil {
+			if err := cli.PutVertex(ctx, "__probe__", 1, 5*time.Second); err == nil {
+				_, _ = cli.DeleteVertex(ctx, "__probe__")
+				_ = cli.Close()
+				return
+			}
+			_ = cli.Close()
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	log.Fatalf("waitReady(%s): timeout after %s", ep, timeout)
+}
+
+func seedBaseline(ctx context.Context, c *client.Lantern) {
+	for _, k := range []string{"v1", "v2", "v3"} {
+		if err := c.PutVertex(ctx, k, k+"-baseline", 5*time.Minute); err != nil {
+			log.Fatalf("seed PutVertex %q: %v", k, err)
+		}
+	}
+	if err := c.AddEdge(ctx, "v1", "v2", 1.0, 5*time.Minute); err != nil {
+		log.Fatalf("seed AddEdge v1->v2: %v", err)
+	}
+	if err := c.AddEdge(ctx, "v2", "v3", 2.0, 5*time.Minute); err != nil {
+		log.Fatalf("seed AddEdge v2->v3: %v", err)
+	}
+}
+
+func writeDuringOutage(ctx context.Context, eps []string) {
+	cli, err := client.NewLanternWithEndpoints(eps)
+	if err != nil {
+		log.Fatalf("survivor client: %v", err)
+	}
+	defer func() { _ = cli.Close() }()
+	for _, k := range []string{"new1", "new2", "new3", "new4", "new5"} {
+		if err := cli.PutVertex(ctx, k, k+"-during-outage", 5*time.Minute); err != nil {
+			log.Fatalf("outage-write PutVertex %q: %v", k, err)
+		}
+	}
+	if err := cli.AddEdge(ctx, "v3", "new1", 3.0, 5*time.Minute); err != nil {
+		log.Fatalf("outage-write AddEdge v3->new1: %v", err)
+	}
+	if err := cli.AddEdge(ctx, "new1", "new2", 4.0, 5*time.Minute); err != nil {
+		log.Fatalf("outage-write AddEdge new1->new2: %v", err)
+	}
+	// Mutate a baseline vertex during outage to check converging replace.
+	if err := cli.PutVertex(ctx, "v1", "v1-mutated", 5*time.Minute); err != nil {
+		log.Fatalf("outage-write PutVertex v1 mutate: %v", err)
+	}
+}
+
+func assertHasAll(ep string, vertices []string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cli, err := client.NewLantern(ep)
+	if err != nil {
+		log.Fatalf("NewLantern(%s): %v", ep, err)
+	}
+	defer func() { _ = cli.Close() }()
+	for _, k := range vertices {
+		v, err := cli.GetVertex(ctx, k)
+		if err != nil {
+			log.Fatalf("[%s] missing %q after recovery: %v", ep, k, err)
+		}
+		_ = v
+	}
+	// Check the mutated value is the new one.
+	v, err := cli.GetVertex(ctx, "v1")
+	if err != nil {
+		log.Fatalf("[%s] missing v1: %v", ep, err)
+	}
+	s, _ := client.StringValue(v)
+	if s != "v1-mutated" {
+		log.Fatalf("[%s] v1 = %q, want %q (mutation did not converge)", ep, s, "v1-mutated")
+	}
+	// Check edge weight.
+	g, err := cli.Illuminate(ctx, "v1", client.WithStep(5), client.WithK(100))
+	if err != nil {
+		log.Fatalf("[%s] Illuminate: %v", ep, err)
+	}
+	if _, ok := g.Vertices["new2"]; !ok {
+		log.Fatalf("[%s] new2 not reachable from v1 after recovery (vertices=%v)", ep, keys(g.Vertices))
+	}
+}
+
+func keys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func metricsFor(container string) string {
+	out, err := exec.Command("docker", "exec", container, "wget", "-qO-", "http://localhost:9090/metrics").Output()
+	if err != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "lantern_vertices ") ||
+			strings.HasPrefix(line, "lantern_edges ") ||
+			strings.HasPrefix(line, "lantern_replication_applied_total") ||
+			strings.HasPrefix(line, "lantern_replication_lag_seq") ||
+			strings.HasPrefix(line, "lantern_anti_entropy_cycles_total") ||
+			strings.HasPrefix(line, "lantern_subscribe_active_streams") {
+			b.WriteString("    " + line + "\n")
+		}
+	}
+	return b.String()
+}
+
+func main() {
+	ctx := context.Background()
+
+	// Resolve dynamic host-port mappings (mode:host range allocation drifts
+	// between compose restarts).
+	endpointByContainer := map[string]string{}
+	for _, c := range containers {
+		endpointByContainer[c] = hostPort(c)
+	}
+	allEndpoints := []string{
+		endpointByContainer["compose-lantern-1"],
+		endpointByContainer["compose-lantern-2"],
+		endpointByContainer["compose-lantern-3"],
+	}
+	victimEndpoint := endpointByContainer[victimContainer]
+	survivorEndpoints := []string{}
+	for _, c := range containers {
+		if c != victimContainer {
+			survivorEndpoints = append(survivorEndpoints, endpointByContainer[c])
+		}
+	}
+	fmt.Printf("endpoints: all=%v victim=%s survivors=%v\n", allEndpoints, victimEndpoint, survivorEndpoints)
+
+	// 0) Wait for all 3 replicas to be ready (caller is expected to have
+	//    already run `docker compose up -d`).
+	for _, ep := range allEndpoints {
+		waitReady(ep, 30*time.Second)
+	}
+	fmt.Println("✓ all 3 replicas reachable")
+
+	// 1) Seed baseline via round-robin LB.
+	rr, err := client.NewLanternWithEndpoints(allEndpoints)
+	if err != nil {
+		log.Fatal(err)
+	}
+	seedBaseline(ctx, rr)
+	_ = rr.Close()
+	time.Sleep(500 * time.Millisecond)
+	fmt.Println("✓ baseline seeded (v1,v2,v3 + 2 edges)")
+
+	// 2) Stop one replica.
+	fmt.Printf("\n--- stopping %s ---\n", victimContainer)
+	docker("stop", victimContainer)
+	// Give the LB a moment to evict the dead subchannel.
+	time.Sleep(1 * time.Second)
+	fmt.Printf("✓ %s stopped\n", victimContainer)
+
+	// 3) Write new data via the surviving 2 replicas only.
+	writeDuringOutage(ctx, survivorEndpoints)
+	fmt.Println("✓ wrote new1..new5 + 2 edges + mutated v1 while victim was down")
+
+	// 4) Confirm survivors converged on the new state.
+	for _, ep := range survivorEndpoints {
+		assertHasAll(ep, []string{"v1", "v2", "v3", "new1", "new2", "new3", "new4", "new5"})
+		fmt.Printf("✓ survivor %s has all expected state\n", ep)
+	}
+
+	// 5) Restart the victim.
+	fmt.Printf("\n--- starting %s ---\n", victimContainer)
+	docker("start", victimContainer)
+	// Compose's mode:host reassigns the host port on restart — re-resolve.
+	victimEndpoint = hostPort(victimContainer)
+	fmt.Printf("    (post-restart host port: %s)\n", victimEndpoint)
+	waitReady(victimEndpoint, 60*time.Second)
+	fmt.Printf("✓ %s back online\n", victimContainer)
+
+	// 6) Allow catch-up time for snapshot/subscribe replay.
+	fmt.Println("... waiting 5s for catch-up via snapshot/subscribe replay ...")
+	time.Sleep(5 * time.Second)
+
+	// 7) Assert the recovered replica has every write made during outage.
+	assertHasAll(victimEndpoint, []string{"v1", "v2", "v3", "new1", "new2", "new3", "new4", "new5"})
+	fmt.Printf("✓ recovered replica %s caught up to full state\n", victimEndpoint)
+
+	// 8) Per-replica metric dump.
+	fmt.Println("\n--- per-replica metrics ---")
+	for _, c := range []string{"compose-lantern-1", "compose-lantern-2", "compose-lantern-3"} {
+		fmt.Printf("=== %s ===\n%s", c, metricsFor(c))
+	}
+
+	fmt.Println("\nFAILURE-RECOVERY TEST PASSED")
+}

--- a/testbed/ha-smoke/main.go
+++ b/testbed/ha-smoke/main.go
@@ -1,0 +1,147 @@
+// Compose HA smoke test: hammer all 3 replicas via SDK round-robin LB,
+// then verify replication by hitting each per-replica endpoint and
+// confirming vertex/edge state agrees.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+func main() {
+	ctx := context.Background()
+	endpoints := []string{"localhost:6380", "localhost:6381", "localhost:6382"}
+
+	// 1) Round-robin client across all 3 replicas.
+	rr, err := client.NewLanternWithEndpoints(endpoints)
+	if err != nil {
+		log.Fatalf("NewLanternWithEndpoints: %v", err)
+	}
+	defer func() { _ = rr.Close() }()
+
+	// 2) Write vertices of every supported kind via round-robin LB.
+	now := time.Now()
+	type kv struct {
+		key string
+		val any
+	}
+	puts := []kv{
+		{"str", "hello"},
+		{"int", 42},
+		{"uint", uint(7)},
+		{"float", 3.14},
+		{"bool", true},
+		{"bytes", []byte("xyz")},
+		{"time", now},
+		{"dur", 5 * time.Second},
+		{"nil", nil},
+	}
+	for _, p := range puts {
+		if err := rr.PutVertex(ctx, p.key, p.val, 1*time.Minute); err != nil {
+			log.Fatalf("PutVertex %q: %v", p.key, err)
+		}
+	}
+	fmt.Printf("✓ PutVertex × %d via round-robin\n", len(puts))
+
+	// 3) Build a small graph: A -> B -> C, plus an additive duplicate A -> B.
+	for _, k := range []string{"A", "B", "C"} {
+		if err := rr.PutVertex(ctx, k, k, 1*time.Minute); err != nil {
+			log.Fatalf("PutVertex %q: %v", k, err)
+		}
+	}
+	if err := rr.AddEdge(ctx, "A", "B", 1.0, 1*time.Minute); err != nil {
+		log.Fatalf("AddEdge A->B: %v", err)
+	}
+	if err := rr.AddEdge(ctx, "A", "B", 1.0, 1*time.Minute); err != nil {
+		log.Fatalf("AddEdge A->B (2): %v", err)
+	}
+	if err := rr.AddEdge(ctx, "B", "C", 2.5, 1*time.Minute); err != nil {
+		log.Fatalf("AddEdge B->C: %v", err)
+	}
+	fmt.Printf("✓ AddEdge A->B (×2 additive) + B->C\n")
+
+	// 4) Round-trip read via LB.
+	v, err := rr.GetVertex(ctx, "str")
+	if err != nil {
+		log.Fatalf("GetVertex str: %v", err)
+	}
+	if got, _ := client.StringValue(v); got != "hello" {
+		log.Fatalf("GetVertex str: want %q got %q", "hello", got)
+	}
+	fmt.Printf("✓ GetVertex str = hello\n")
+
+	// 5) Illuminate from A — should walk A,B,C.
+	g, err := rr.Illuminate(ctx, "A", client.WithStep(5), client.WithK(100))
+	if err != nil {
+		log.Fatalf("Illuminate: %v", err)
+	}
+	fmt.Printf("✓ Illuminate(A): %d vertices, %d source-rows of edges\n", len(g.Vertices), len(g.Edges))
+	for src, dsts := range g.Edges {
+		for dst, w := range dsts {
+			fmt.Printf("    %s -> %s  weight=%g\n", src, dst, w)
+		}
+	}
+
+	// 6) Give the replication pump a beat to converge.
+	time.Sleep(1500 * time.Millisecond)
+
+	// 7) Verify EACH replica sees the same state, by talking to them
+	//    directly (no LB) and confirming our writes are present.
+	for _, ep := range endpoints {
+		direct, err := client.NewLantern(ep)
+		if err != nil {
+			log.Fatalf("NewLantern(%s): %v", ep, err)
+		}
+		// Read the canonical "str" vertex.
+		v, err := direct.GetVertex(ctx, "str")
+		if err != nil {
+			log.Fatalf("[%s] GetVertex str: %v", ep, err)
+		}
+		s, _ := client.StringValue(v)
+
+		// Illuminate from A and assert A,B,C reachable + A->B weight is additive.
+		g, err := direct.Illuminate(ctx, "A", client.WithStep(5), client.WithK(100))
+		if err != nil {
+			log.Fatalf("[%s] Illuminate: %v", ep, err)
+		}
+		abWeight := float32(-1)
+		if dsts, ok := g.Edges["A"]; ok {
+			abWeight = dsts["B"]
+		}
+		_, hasC := g.Vertices["C"]
+		fmt.Printf("✓ %s: str=%q vertices=%d  A->B=%g  hasC=%v\n",
+			ep, s, len(g.Vertices), abWeight, hasC)
+
+		if s != "hello" {
+			log.Fatalf("[%s] replication missed 'str' vertex", ep)
+		}
+		if !hasC {
+			log.Fatalf("[%s] replication missed C vertex via Illuminate", ep)
+		}
+		if abWeight < 1.99 { // additive: 1.0 + 1.0 = 2.0
+			log.Fatalf("[%s] A->B weight = %g, want ~2.0 (additive)", ep, abWeight)
+		}
+		_ = direct.Close()
+	}
+
+	// 8) Delete via LB; verify delete propagates.
+	if _, err := rr.DeleteVertex(ctx, "str"); err != nil {
+		log.Fatalf("DeleteVertex str: %v", err)
+	}
+	time.Sleep(1500 * time.Millisecond)
+	for _, ep := range endpoints {
+		direct, _ := client.NewLantern(ep)
+		_, err := direct.GetVertex(ctx, "str")
+		if err == nil {
+			log.Fatalf("[%s] delete did not propagate: vertex still present", ep)
+		}
+		fmt.Printf("✓ %s: 'str' delete propagated (got expected error: %v)\n", ep, err)
+		_ = direct.Close()
+	}
+
+	fmt.Println("\nALL CHECKS PASSED")
+}


### PR DESCRIPTION
Closes #215.

Adds two black-box programs under `testbed/` exercising the Tier-A Compose HA stack via the SDK's round-robin LB:

- **`testbed/ha-smoke`** — verifies PutVertex / AddEdge / Illuminate / DeleteVertex propagate to every replica (per-endpoint direct reads).
- **`testbed/ha-recovery`** — seed → `docker stop` one replica → mutate via survivors → `docker start` → assert catch-up incl. baseline mutation. Dynamically re-resolves Compose host ports (mode:host reassigns on restart).

No production code touched; `testbed/` only. See #215 for full rationale.