### PR TITLE
chore(gomod): promote google.golang.org/protobuf to direct require

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/manifoldco/promptui v0.9.0
 	github.com/spf13/cobra v1.10.2
 	google.golang.org/grpc v1.81.1
+	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -47,7 +48,6 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 )
 
 replace (


### PR DESCRIPTION
Trivial `go mod tidy` follow-up.

`tests/integration/prefix_scan_test.go` (root module) directly imports `google.golang.org/protobuf/types/known/timestamppb`, so the require line should not carry the `// indirect` marker. `go mod tidy` performs this fix automatically; the marker was leftover from when the dep entered transitively.

Diff is one line in `go.mod` (move `google.golang.org/protobuf` from the indirect block to the direct block). No code changes.