### PR TITLE
obs: hot-path metrics (illuminate, scan, batch)

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -123,6 +123,12 @@ runtime, process, and `grpc_server_*` collectors):
 | `lantern_replication_lag_seq` | gauge | `peer`, `origin` | Per-(peer, origin) lag in seq units. |
 | `lantern_anti_entropy_cycles_total` | counter | — | Anti-entropy ticks. |
 | `lantern_anti_entropy_gaps_found_total` | counter | `peer`, `origin` | Ticks observing a non-zero gap. |
+| `lantern_illuminate_visited_vertices` | histogram | `optimization` | Vertices visited per `Illuminate` call. |
+| `lantern_illuminate_visited_edges` | histogram | `optimization` | Edges visited per `Illuminate` call. |
+| `lantern_illuminate_duration_seconds` | histogram | `optimization`, `phase` | Per-phase (`traversal`, `optimize`) wall-clock; `optimize` only emitted for non-unspecified optimizations. |
+| `lantern_scan_results` | histogram | `op` | Result counts for prefix scans (`ScanVertices`, `ScanEdges`, `DeleteVerticesByPrefix`). |
+| `lantern_scan_duration_seconds` | histogram | `op` | Wall-clock for the same scan ops. |
+| `lantern_batch_size` | histogram | `op` | Batch size for plural RPCs (`GetVertices`, `PutVertices`, `DeleteVertices`, `GetEdges`, `AddEdges`, `PutEdges`, `DeleteEdges`). Singular forwarders are NOT instrumented to avoid double-counting. |
 
 Tracing is wired via `otelgrpc.NewServerHandler` so any `OTEL_*` env var the
 OpenTelemetry Go SDK honours will Just Work. Per-call logging goes through

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -93,6 +93,7 @@ func newLanternService(
 		WithReplication(log, clock, dm.OnMutationLogAppend).
 		WithAppliedHook(dm.OnReplicationApplied).
 		WithTombstoneTTL(rc.TombstoneTTL).
+		WithHotPathMetrics(dm).
 		WithLogger(logger)
 }
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -38,9 +38,47 @@ type DomainMetrics struct {
 	antiEntropyCycles    prometheus.Counter
 	antiEntropyGapsFound *prometheus.CounterVec
 
+	// Hot-path RPC observability (#220). Wired by the service layer via
+	// the HotPathMetrics interface in server/service. Histograms are
+	// label-pre-warmed so dashboards render the full set of variants from
+	// process start, before any traffic arrives.
+	illuminateVisitedVertices *prometheus.HistogramVec
+	illuminateVisitedEdges    *prometheus.HistogramVec
+	illuminateDuration        *prometheus.HistogramVec
+	scanResults               *prometheus.HistogramVec
+	scanDuration              *prometheus.HistogramVec
+	batchSize                 *prometheus.HistogramVec
+
 	sampleInterval time.Duration
 	sample         Sampler
 }
+
+// Hot-path label values. Exposed so the service layer can reference the
+// canonical string set without importing prometheus.
+//
+// optimizationLabels covers every pb.Optimization variant. Service code
+// translates the enum into one of these strings and passes it to
+// OnIlluminate; unknown variants are normalised to "unspecified" so a new
+// optimization added in proto without a metrics update cannot break label
+// pre-warming on existing dashboards.
+var (
+	optimizationLabels = []string{"unspecified", "mst", "max_mst", "spt", "spt_inverse"}
+	illuminatePhases   = []string{"traversal", "optimize"}
+	scanOps            = []string{
+		"ScanVertices",
+		"ScanEdges",
+		"DeleteVerticesByPrefix",
+	}
+	batchOps = []string{
+		"GetVertices",
+		"PutVertices",
+		"DeleteVertices",
+		"GetEdges",
+		"AddEdges",
+		"PutEdges",
+		"DeleteEdges",
+	}
+)
 
 // Options configures DomainMetrics. Version/Commit fall back to debug.BuildInfo
 // fields when left empty so a tagged release reports the right values without
@@ -117,13 +155,45 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 			Name: "lantern_anti_entropy_gaps_found_total",
 			Help: "Total anti-entropy ticks that observed a non-zero gap, partitioned by peer address and origin (HLC NodeID, lowercase hex).",
 		}, []string{"peer", "origin"}),
+		illuminateVisitedVertices: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "lantern_illuminate_visited_vertices",
+			Help:    "Vertices in the subgraph returned by Illuminate, partitioned by post-traversal optimization.",
+			Buckets: prometheus.ExponentialBuckets(1, 4, 10), // 1 .. ~262K
+		}, []string{"optimization"}),
+		illuminateVisitedEdges: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "lantern_illuminate_visited_edges",
+			Help:    "Edges in the subgraph returned by Illuminate, partitioned by post-traversal optimization.",
+			Buckets: prometheus.ExponentialBuckets(1, 4, 10),
+		}, []string{"optimization"}),
+		illuminateDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "lantern_illuminate_duration_seconds",
+			Help:    "Wall-clock duration of Illuminate, partitioned by optimization and phase (traversal | optimize).",
+			Buckets: prometheus.ExponentialBuckets(0.0001, 4, 8), // 0.1ms .. ~1.6s
+		}, []string{"optimization", "phase"}),
+		scanResults: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "lantern_scan_results",
+			Help:    "Number of results returned by a prefix scan RPC, partitioned by op (ScanVertices | ScanEdges | DeleteVerticesByPrefix).",
+			Buckets: prometheus.ExponentialBuckets(1, 4, 10),
+		}, []string{"op"}),
+		scanDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "lantern_scan_duration_seconds",
+			Help:    "Wall-clock duration of a prefix scan RPC, partitioned by op.",
+			Buckets: prometheus.ExponentialBuckets(0.0001, 4, 8),
+		}, []string{"op"}),
+		batchSize: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "lantern_batch_size",
+			Help:    "Item count of a single plural-RPC batch (PutVertices, PutEdges, AddEdges, GetVertices, GetEdges, DeleteVertices, DeleteEdges). Singular RPC forwarders are not double-counted.",
+			Buckets: prometheus.ExponentialBuckets(1, 4, 10),
+		}, []string{"op"}),
 		sampleInterval: opts.SampleInterval,
 	}
 
 	reg.MustRegister(m.vertices, m.edges, m.expirations, m.gcDuration, m.buildInfo,
 		m.mutationLogEntries, m.mutationLogCapacity, m.subscribeActive, m.subscribeDropped,
 		m.replicationApplied, m.replicationDropped, m.replicationLag,
-		m.antiEntropyCycles, m.antiEntropyGapsFound)
+		m.antiEntropyCycles, m.antiEntropyGapsFound,
+		m.illuminateVisitedVertices, m.illuminateVisitedEdges, m.illuminateDuration,
+		m.scanResults, m.scanDuration, m.batchSize)
 
 	// Pre-create label rows so empty counters scrape as 0.
 	for _, r := range []string{"gapped", "send_failed"} {
@@ -133,6 +203,25 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 	// Pre-create label rows so empty counters are still scraped as 0.
 	for _, k := range []string{"vertex", "edge", "dangling_edge"} {
 		m.expirations.WithLabelValues(k)
+	}
+
+	// Pre-create hot-path histogram label rows so /metrics renders the
+	// full variant set on a fresh process. Histograms emit count/sum/
+	// bucket families lazily per label; observing a no-op is the
+	// idiomatic way to materialise the row.
+	for _, opt := range optimizationLabels {
+		m.illuminateVisitedVertices.WithLabelValues(opt)
+		m.illuminateVisitedEdges.WithLabelValues(opt)
+		for _, ph := range illuminatePhases {
+			m.illuminateDuration.WithLabelValues(opt, ph)
+		}
+	}
+	for _, op := range scanOps {
+		m.scanResults.WithLabelValues(op)
+		m.scanDuration.WithLabelValues(op)
+	}
+	for _, op := range batchOps {
+		m.batchSize.WithLabelValues(op)
 	}
 
 	version, commit := opts.Version, opts.Commit
@@ -275,6 +364,53 @@ func (m *DomainMetrics) OnPumpDropSelfEcho(peer string) {
 }
 
 func (m *DomainMetrics) OnPumpSnapshotReplayed(string, uint64, uint64) {}
+
+// --- Hot-path RPC observability (#220) ---
+//
+// These methods implement the HotPathMetrics interface consumed by
+// server/service.LanternService. Unknown label values fall back to a safe
+// constant so a stale enum or typo cannot blow up the registry.
+
+func sanitizeLabel(v string, allowed []string, fallback string) string {
+	for _, a := range allowed {
+		if a == v {
+			return v
+		}
+	}
+	return fallback
+}
+
+// OnIlluminate records one Illuminate RPC: visited vertex/edge counts and
+// the wall-clock duration of the two phases (traversal: neighbour walk;
+// optimize: post-processing such as spanning trees). optimize may be 0
+// when no optimization was requested.
+func (m *DomainMetrics) OnIlluminate(optimization string, visitedVertices, visitedEdges int, traversal, optimize time.Duration) {
+	opt := sanitizeLabel(optimization, optimizationLabels, "unspecified")
+	m.illuminateVisitedVertices.WithLabelValues(opt).Observe(float64(visitedVertices))
+	m.illuminateVisitedEdges.WithLabelValues(opt).Observe(float64(visitedEdges))
+	m.illuminateDuration.WithLabelValues(opt, "traversal").Observe(traversal.Seconds())
+	if optimize > 0 {
+		m.illuminateDuration.WithLabelValues(opt, "optimize").Observe(optimize.Seconds())
+	}
+}
+
+// OnScan records one prefix-scan RPC: result count and wall-clock
+// duration, partitioned by op (ScanVertices | ScanEdges |
+// DeleteVerticesByPrefix).
+func (m *DomainMetrics) OnScan(op string, results int, duration time.Duration) {
+	o := sanitizeLabel(op, scanOps, op) // pass-through unknowns to surface in dashboards
+	m.scanResults.WithLabelValues(o).Observe(float64(results))
+	m.scanDuration.WithLabelValues(o).Observe(duration.Seconds())
+}
+
+// OnBatch records the batch size for one plural RPC. Singular RPC
+// forwarders (GetVertex / PutVertex / ...) must NOT call this — the
+// canonical plural implementation owns the metric. See AGENTS.md for the
+// invariant.
+func (m *DomainMetrics) OnBatch(op string, size int) {
+	o := sanitizeLabel(op, batchOps, op)
+	m.batchSize.WithLabelValues(o).Observe(float64(size))
+}
 
 // BindSampler stores the gauge-population callback. Must be called before
 // Run; safe to call exactly once during wiring.

--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 )
 
 func TestDomainMetrics_ExposesLanternFamilies(t *testing.T) {
@@ -132,5 +133,114 @@ func TestDomainMetrics_ReplicationFamilies(t *testing.T) {
 	// CaughtUp reset the lag back to 0 after the Behind tick set it to 42.
 	if got := testutil.ToFloat64(m.replicationLag.WithLabelValues("peer-a:7000", "aabbccdd")); got != 0 {
 		t.Errorf("replication_lag_seq after CaughtUp = %v, want 0", got)
+	}
+}
+
+// TestDomainMetrics_HotPathFamilies asserts the #220 hot-path collectors
+// register with the expected family names, that the label set is
+// pre-warmed (so dashboards render the full variant set from process
+// start), and that the OnIlluminate / OnScan / OnBatch adapters emit on
+// the right histograms.
+func TestDomainMetrics_HotPathFamilies(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := New(reg, Options{SampleInterval: time.Hour})
+
+	m.OnIlluminate("mst", 17, 42, 5*time.Millisecond, 2*time.Millisecond)
+	m.OnIlluminate("unspecified", 1, 0, 100*time.Microsecond, 0) // optimize=0 → no observation on optimize phase
+	m.OnScan("ScanVertices", 64, 750*time.Microsecond)
+	m.OnScan("ScanEdges", 128, time.Millisecond)
+	m.OnScan("DeleteVerticesByPrefix", 32, 200*time.Microsecond)
+	m.OnBatch("PutVertices", 8)
+	m.OnBatch("AddEdges", 4)
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	names := map[string]bool{}
+	for _, mf := range mfs {
+		names[mf.GetName()] = true
+	}
+	for _, want := range []string{
+		"lantern_illuminate_visited_vertices",
+		"lantern_illuminate_visited_edges",
+		"lantern_illuminate_duration_seconds",
+		"lantern_scan_results",
+		"lantern_scan_duration_seconds",
+		"lantern_batch_size",
+	} {
+		if !names[want] {
+			t.Errorf("metric family %q not registered", want)
+		}
+	}
+
+	// Pre-warming: every optimization label should have a histogram row
+	// for the traversal phase even though only "mst" and "unspecified"
+	// have been observed.
+	for _, opt := range optimizationLabels {
+		if got := testutil.CollectAndCount(m.illuminateDuration.WithLabelValues(opt, "traversal").(prometheus.Histogram)); got == 0 {
+			t.Errorf("illuminate_duration{optimization=%q,phase=traversal} row not pre-warmed", opt)
+		}
+	}
+
+	// Observed values land on the right rows.
+	if got := histSampleCount(t, m.illuminateVisitedVertices.WithLabelValues("mst")); got != 1 {
+		t.Errorf("illuminate_visited_vertices{mst} sample count = %v, want 1", got)
+	}
+	if got := histSampleCount(t, m.illuminateDuration.WithLabelValues("mst", "optimize")); got != 1 {
+		t.Errorf("illuminate_duration{mst,optimize} sample count = %v, want 1", got)
+	}
+	// optimize=0 must NOT record on the optimize phase (it would skew
+	// p99 toward zero on RPCs that didn't run an optimizer).
+	if got := histSampleCount(t, m.illuminateDuration.WithLabelValues("unspecified", "optimize")); got != 0 {
+		t.Errorf("illuminate_duration{unspecified,optimize} sample count = %v, want 0 (optimize=0 must not observe)", got)
+	}
+
+	for _, op := range scanOps {
+		if got := histSampleCount(t, m.scanResults.WithLabelValues(op)); got != 1 {
+			t.Errorf("scan_results{%s} sample count = %v, want 1", op, got)
+		}
+	}
+
+	if got := histSampleCount(t, m.batchSize.WithLabelValues("PutVertices")); got != 1 {
+		t.Errorf("batch_size{PutVertices} sample count = %v, want 1", got)
+	}
+	if got := histSampleCount(t, m.batchSize.WithLabelValues("AddEdges")); got != 1 {
+		t.Errorf("batch_size{AddEdges} sample count = %v, want 1", got)
+	}
+}
+
+// histSampleCount extracts the observation count from a histogram via
+// the dto round-trip. testutil.CollectAndCount counts series, not
+// samples — which is the opposite of what these assertions need.
+func histSampleCount(t *testing.T, o prometheus.Observer) uint64 {
+	t.Helper()
+	h, ok := o.(prometheus.Histogram)
+	if !ok {
+		t.Fatalf("observer is not a Histogram: %T", o)
+	}
+	var m dto.Metric
+	if err := h.Write(&m); err != nil {
+		t.Fatalf("histogram write: %v", err)
+	}
+	if m.Histogram == nil {
+		return 0
+	}
+	return m.Histogram.GetSampleCount()
+}
+
+// TestDomainMetrics_HotPathSanitizesUnknownOptimization confirms a stale
+// or typo'd optimization label folds onto "unspecified" rather than
+// inflating the cardinality of the histogram.
+func TestDomainMetrics_HotPathSanitizesUnknownOptimization(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := New(reg, Options{SampleInterval: time.Hour})
+
+	m.OnIlluminate("bogus", 1, 1, time.Microsecond, 0)
+	if got := histSampleCount(t, m.illuminateVisitedVertices.WithLabelValues("unspecified")); got != 1 {
+		t.Errorf("unknown optimization should fall back to unspecified; sample count = %v, want 1", got)
+	}
+	if got := histSampleCount(t, m.illuminateVisitedVertices.WithLabelValues("bogus")); got != 0 {
+		t.Errorf("unknown optimization should NOT route observations to its own row; sample count = %v, want 0", got)
 	}
 }

--- a/server/service/optimizer.go
+++ b/server/service/optimizer.go
@@ -43,3 +43,23 @@ func inverseCost(weight float32) float32 {
 	}
 	return 1 / weight
 }
+
+// optimizationLabel maps a pb.Optimization enum value to the canonical
+// metrics label string. Unknown variants fall back to "unspecified" so
+// adding a new enum without a metrics update is non-fatal — dashboards
+// just bucket the new variant alongside no-op runs until the label set
+// expands.
+func optimizationLabel(o pb.Optimization) string {
+	switch o {
+	case pb.Optimization_OPTIMIZATION_MINIMUM_SPANNING_TREE:
+		return "mst"
+	case pb.Optimization_OPTIMIZATION_MAXIMUM_SPANNING_TREE:
+		return "max_mst"
+	case pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE:
+		return "spt"
+	case pb.Optimization_OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE:
+		return "spt_inverse"
+	default:
+		return "unspecified"
+	}
+}

--- a/server/service/prefix.go
+++ b/server/service/prefix.go
@@ -25,6 +25,7 @@ func (s *LanternService) ScanVertices(ctx context.Context, in *pb.ScanVerticesRe
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
+	start := time.Now()
 	limit := clampLimit(in.GetLimit(), s.scan.ScanDefaultLimit, s.scan.ScanMaxLimit)
 
 	cursor, err := decodeCursor(in.GetCursor())
@@ -67,6 +68,7 @@ func (s *LanternService) ScanVertices(ctx context.Context, in *pb.ScanVerticesRe
 	if hitLimit && lastKey != "" {
 		resp.NextCursor = encodeCursor(scanCursor{LastKey: lastKey})
 	}
+	s.metrics.OnScan("ScanVertices", len(vertices), time.Since(start))
 	return resp, nil
 }
 
@@ -94,6 +96,7 @@ func (s *LanternService) DeleteVerticesByPrefix(ctx context.Context, in *pb.Dele
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
+	start := time.Now()
 	limit := clampLimit(in.GetLimit(), s.scan.DeleteByPrefixDefaultLimit, s.scan.DeleteByPrefixMaxLimit)
 
 	if in.GetDryRun() {
@@ -101,6 +104,7 @@ func (s *LanternService) DeleteVerticesByPrefix(ctx context.Context, in *pb.Dele
 		if n > uint64(limit) {
 			n = uint64(limit)
 		}
+		s.metrics.OnScan("DeleteVerticesByPrefix", int(n), time.Since(start))
 		return &pb.DeleteVerticesByPrefixResponse{Deleted: n}, nil
 	}
 	deleted := 0
@@ -114,6 +118,7 @@ func (s *LanternService) DeleteVerticesByPrefix(ctx context.Context, in *pb.Dele
 		deleted = s.cache.DeleteByPrefix(ctx, in.GetPrefix(), int(limit))
 	}
 	s.logMutation(&pb.MutationOp{Op: &pb.MutationOp_DeleteVerticesByPrefix{DeleteVerticesByPrefix: in}})
+	s.metrics.OnScan("DeleteVerticesByPrefix", deleted, time.Since(start))
 	return &pb.DeleteVerticesByPrefixResponse{Deleted: uint64(deleted)}, nil
 }
 
@@ -147,6 +152,7 @@ func (s *LanternService) ScanEdges(ctx context.Context, in *pb.ScanEdgesRequest)
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
+	start := time.Now()
 	limit := clampLimit(in.GetLimit(), s.scan.ScanDefaultLimit, s.scan.ScanMaxLimit)
 
 	cursor, err := decodeEdgesCursor(in.GetCursor())
@@ -186,5 +192,6 @@ func (s *LanternService) ScanEdges(ctx context.Context, in *pb.ScanEdgesRequest)
 	if hitLimit && (lastTail != "" || lastHead != "") {
 		resp.NextCursor = encodeEdgesCursor(scanEdgesCursor{LastTail: lastTail, LastHead: lastHead})
 	}
+	s.metrics.OnScan("ScanEdges", len(edges), time.Since(start))
 	return resp, nil
 }

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -41,7 +41,26 @@ type LanternService struct {
 	tombstoneTTL time.Duration
 	origins      *originStateTracker
 	onApplied    func(origin string)
+	metrics      HotPathMetrics
 }
+
+// HotPathMetrics is the narrow observability surface consumed by the
+// hot-path handlers (#220). Implemented by *server/metrics.DomainMetrics in
+// production; tests can install a fake to assert per-RPC instrumentation
+// fires.
+//
+// Implementations must be safe for concurrent use.
+type HotPathMetrics interface {
+	OnIlluminate(optimization string, visitedVertices, visitedEdges int, traversal, optimize time.Duration)
+	OnScan(op string, results int, duration time.Duration)
+	OnBatch(op string, size int)
+}
+
+type noopHotPathMetrics struct{}
+
+func (noopHotPathMetrics) OnIlluminate(string, int, int, time.Duration, time.Duration) {}
+func (noopHotPathMetrics) OnScan(string, int, time.Duration)                           {}
+func (noopHotPathMetrics) OnBatch(string, int)                                         {}
 
 // ScanLimits caps the per-call pagination knobs for the prefix RPCs. It is
 // a value struct rather than a pointer-to-provider type so the service
@@ -64,7 +83,7 @@ func defaultScanLimits() ScanLimits {
 }
 
 func NewLanternService(cache Backend) *LanternService {
-	return &LanternService{cache: cache, scan: defaultScanLimits(), origins: newOriginStateTracker()}
+	return &LanternService{cache: cache, scan: defaultScanLimits(), origins: newOriginStateTracker(), metrics: noopHotPathMetrics{}}
 }
 
 // WithScanLimits returns s with its prefix-RPC limits replaced. Intended
@@ -101,7 +120,17 @@ func (s *LanternService) WithLogger(l *slog.Logger) *LanternService {
 	return s
 }
 
-// WithTombstoneTTL configures the maximum retention window for delete
+// WithHotPathMetrics installs the hot-path observability sink (#220).
+// Defaults to a no-op so unit tests can construct the service without
+// pulling in the metrics package.
+func (s *LanternService) WithHotPathMetrics(m HotPathMetrics) *LanternService {
+	if m == nil {
+		s.metrics = noopHotPathMetrics{}
+	} else {
+		s.metrics = m
+	}
+	return s
+}
 
 // WithTombstoneTTL configures the maximum retention window for delete
 // tombstones AND the upper bound on caller-supplied Expiration on the
@@ -221,13 +250,18 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 		return nil, status.FromContextError(err).Err()
 	}
 
+	traversalStart := time.Now()
 	g, expirations, err := s.cache.NeighborWithExpirationsContext(ctx, request.GetSeed(), int(request.GetStep()), int(request.GetK()), request.GetTfidf())
+	traversalDur := time.Since(traversalStart)
 	if err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
 
+	var optimizeDur time.Duration
 	if opt := optimizers[request.GetOptimization()]; opt != nil {
+		optStart := time.Now()
 		g, err = opt(ctx, g, request.GetSeed())
+		optimizeDur = time.Since(optStart)
 		if err != nil {
 			return nil, status.FromContextError(err).Err()
 		}
@@ -247,6 +281,7 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 	}
 
 	var edges []*pb.Edge
+	edgeCount := 0
 	for tail, heads := range g.Edges {
 		expRow := expirations[tail]
 		for head, weight := range heads {
@@ -255,8 +290,11 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 				edge.Expiration = timestamppb.New(exp)
 			}
 			edges = append(edges, edge)
+			edgeCount++
 		}
 	}
+
+	s.metrics.OnIlluminate(optimizationLabel(request.GetOptimization()), len(vertices), edgeCount, traversalDur, optimizeDur)
 
 	return &pb.IlluminateResponse{
 		Graph: &pb.Graph{Vertices: vertices, Edges: edges},
@@ -283,6 +321,7 @@ func (s *LanternService) GetVertices(ctx context.Context, request *pb.GetVertice
 		return nil, status.FromContextError(err).Err()
 	}
 	keys := request.GetKeys()
+	s.metrics.OnBatch("GetVertices", len(keys))
 	resp := &pb.GetVerticesResponse{
 		Vertices: make([]*pb.Vertex, 0, len(keys)),
 	}
@@ -313,6 +352,7 @@ func (s *LanternService) PutVertices(ctx context.Context, request *pb.PutVertice
 		return nil, status.FromContextError(err).Err()
 	}
 	in := request.GetVertices()
+	s.metrics.OnBatch("PutVertices", len(in))
 	items := make([]graph.VertexItem[string, *pb.Vertex], 0, len(in))
 	for _, v := range in {
 		if err := s.validateExpiration(v.GetExpiration().AsTime()); err != nil {
@@ -343,6 +383,7 @@ func (s *LanternService) DeleteVertices(ctx context.Context, in *pb.DeleteVertic
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
+	s.metrics.OnBatch("DeleteVertices", len(in.GetKeys()))
 	var n int
 	if s.clock != nil && s.tombstoneTTL > 0 {
 		// Replicated path: stamp tombstones at clock.Now() so peers
@@ -376,6 +417,7 @@ func (s *LanternService) GetEdges(ctx context.Context, request *pb.GetEdgesReque
 		return nil, status.FromContextError(err).Err()
 	}
 	in := request.GetEdges()
+	s.metrics.OnBatch("GetEdges", len(in))
 	resp := &pb.GetEdgesResponse{
 		Edges: make([]*pb.Edge, 0, len(in)),
 	}
@@ -406,6 +448,7 @@ func (s *LanternService) AddEdges(ctx context.Context, request *pb.AddEdgesReque
 		return nil, status.FromContextError(err).Err()
 	}
 	in := request.GetEdges()
+	s.metrics.OnBatch("AddEdges", len(in))
 	items := make([]graph.EdgeItem[string], 0, len(in))
 	for _, e := range in {
 		if err := s.validateExpiration(e.GetExpiration().AsTime()); err != nil {
@@ -435,6 +478,7 @@ func (s *LanternService) PutEdges(ctx context.Context, request *pb.PutEdgesReque
 		return nil, status.FromContextError(err).Err()
 	}
 	in := request.GetEdges()
+	s.metrics.OnBatch("PutEdges", len(in))
 	items := make([]graph.EdgeItem[string], 0, len(in))
 	for _, e := range in {
 		if err := s.validateExpiration(e.GetExpiration().AsTime()); err != nil {
@@ -470,6 +514,7 @@ func (s *LanternService) DeleteEdges(ctx context.Context, in *pb.DeleteEdgesRequ
 		return nil, status.FromContextError(err).Err()
 	}
 	inEdges := in.GetEdges()
+	s.metrics.OnBatch("DeleteEdges", len(inEdges))
 	keys := make([]graph.EdgeKey[string], 0, len(inEdges))
 	for _, e := range inEdges {
 		keys = append(keys, graph.EdgeKey[string]{Tail: e.GetTail(), Head: e.GetHead()})

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -624,3 +624,129 @@ func itoa(i int) string {
 	}
 	return string(b[pos:])
 }
+
+// fakeHotPathMetrics captures one observation per RPC so tests can assert
+// the service-layer instrumentation hooks fire on the right callbacks.
+type fakeHotPathMetrics struct {
+	illuminate []illuminateObs
+	scan       []scanObs
+	batch      []batchObs
+}
+
+type illuminateObs struct {
+	optimization                  string
+	visitedVertices, visitedEdges int
+	traversal, optimize           time.Duration
+}
+
+type scanObs struct {
+	op       string
+	results  int
+	duration time.Duration
+}
+
+type batchObs struct {
+	op   string
+	size int
+}
+
+func (f *fakeHotPathMetrics) OnIlluminate(opt string, vV, vE int, traversal, optimize time.Duration) {
+	f.illuminate = append(f.illuminate, illuminateObs{opt, vV, vE, traversal, optimize})
+}
+func (f *fakeHotPathMetrics) OnScan(op string, results int, d time.Duration) {
+	f.scan = append(f.scan, scanObs{op, results, d})
+}
+func (f *fakeHotPathMetrics) OnBatch(op string, size int) {
+	f.batch = append(f.batch, batchObs{op, size})
+}
+
+func TestLanternService_HotPathMetrics_EmitsOnceForBatchAndIlluminate(t *testing.T) {
+	fm := &fakeHotPathMetrics{}
+	s := NewLanternService(graph.NewGraphCache[string, *pb.Vertex](time.Minute)).
+		WithHotPathMetrics(fm)
+
+	ctx := context.Background()
+
+	// PutVertices → one batch observation.
+	if _, err := s.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: []*pb.Vertex{
+		{Key: "a", Value: &pb.Vertex_Int64{Int64: 1}, Expiration: futureTs(time.Minute)},
+		{Key: "b", Value: &pb.Vertex_Int64{Int64: 2}, Expiration: futureTs(time.Minute)},
+	}}); err != nil {
+		t.Fatalf("PutVertices: %v", err)
+	}
+	// AddEdges → one batch observation.
+	if _, err := s.AddEdges(ctx, &pb.AddEdgesRequest{Edges: []*pb.Edge{
+		{Tail: "a", Head: "b", Weight: 1, Expiration: futureTs(time.Minute)},
+	}}); err != nil {
+		t.Fatalf("AddEdges: %v", err)
+	}
+
+	if len(fm.batch) != 2 {
+		t.Fatalf("batch observations = %d, want 2 (PutVertices, AddEdges)", len(fm.batch))
+	}
+	if fm.batch[0].op != "PutVertices" || fm.batch[0].size != 2 {
+		t.Errorf("batch[0] = %+v, want {PutVertices, 2}", fm.batch[0])
+	}
+	if fm.batch[1].op != "AddEdges" || fm.batch[1].size != 1 {
+		t.Errorf("batch[1] = %+v, want {AddEdges, 1}", fm.batch[1])
+	}
+
+	// Illuminate → exactly one illuminate observation with the right label.
+	if _, err := s.Illuminate(ctx, &pb.IlluminateRequest{
+		Seed:         "a",
+		Step:         2,
+		K:            10,
+		Optimization: pb.Optimization_OPTIMIZATION_MINIMUM_SPANNING_TREE,
+	}); err != nil {
+		t.Fatalf("Illuminate: %v", err)
+	}
+	if len(fm.illuminate) != 1 {
+		t.Fatalf("illuminate observations = %d, want 1", len(fm.illuminate))
+	}
+	if got := fm.illuminate[0]; got.optimization != "mst" || got.visitedVertices < 1 {
+		t.Errorf("illuminate[0] = %+v, want optimization=mst & visitedVertices≥1", got)
+	}
+
+	// Singular forwarders must NOT double-instrument: GetVertex forwards
+	// to GetVertices; one batch observation is expected, not two.
+	prev := len(fm.batch)
+	if _, err := s.GetVertex(ctx, &pb.GetVertexRequest{Key: "a"}); err != nil {
+		t.Fatalf("GetVertex: %v", err)
+	}
+	if added := len(fm.batch) - prev; added != 1 {
+		t.Errorf("singular GetVertex emitted %d batch observations, want 1 (must not double-count via plural)", added)
+	}
+}
+
+func TestLanternService_HotPathMetrics_EmitsOnScan(t *testing.T) {
+	fm := &fakeHotPathMetrics{}
+	fb := newFakeBackend()
+	fb.vertices["p:1"] = &pb.Vertex{Key: "p:1", Value: &pb.Vertex_Int64{Int64: 1}}
+	fb.vertices["p:2"] = &pb.Vertex{Key: "p:2", Value: &pb.Vertex_Int64{Int64: 2}}
+	s := NewLanternService(fb).WithHotPathMetrics(fm)
+	ctx := context.Background()
+	if _, err := s.ScanVertices(ctx, &pb.ScanVerticesRequest{Prefix: "p:", Limit: 100}); err != nil {
+		t.Fatalf("ScanVertices: %v", err)
+	}
+	if _, err := s.ScanEdges(ctx, &pb.ScanEdgesRequest{Limit: 100}); err != nil {
+		t.Fatalf("ScanEdges: %v", err)
+	}
+	if _, err := s.DeleteVerticesByPrefix(ctx, &pb.DeleteVerticesByPrefixRequest{Prefix: "p:", Limit: 100}); err != nil {
+		t.Fatalf("DeleteVerticesByPrefix: %v", err)
+	}
+	if len(fm.scan) != 3 {
+		t.Fatalf("scan observations = %d, want 3", len(fm.scan))
+	}
+	wantOps := []string{"ScanVertices", "ScanEdges", "DeleteVerticesByPrefix"}
+	for i, want := range wantOps {
+		if fm.scan[i].op != want {
+			t.Errorf("scan[%d].op = %q, want %q", i, fm.scan[i].op, want)
+		}
+	}
+	if fm.scan[0].results != 2 {
+		t.Errorf("ScanVertices results = %d, want 2", fm.scan[0].results)
+	}
+	if fm.scan[2].results != 2 {
+		t.Errorf("DeleteVerticesByPrefix results = %d, want 2", fm.scan[2].results)
+	}
+}


### PR DESCRIPTION
Closes #220.

## Summary

Six new `lantern_*` collectors covering the three RPC families that dominate server cost (Illuminate, prefix scans, batched plural RPCs).

| Metric | Labels | Notes |
| --- | --- | --- |
| `lantern_illuminate_visited_vertices` / `_visited_edges` | `optimization` | Per call. |
| `lantern_illuminate_duration_seconds` | `optimization`, `phase` | `phase` ∈ {`traversal`, `optimize`}; `optimize` is only observed when an optimization actually runs (skipped for `unspecified`). |
| `lantern_scan_results` / `_scan_duration_seconds` | `op` | `op` ∈ {`ScanVertices`, `ScanEdges`, `DeleteVerticesByPrefix`}. |
| `lantern_batch_size` | `op` | One observation per plural RPC; singulars NOT instrumented. |

## Design

- New `HotPathMetrics` interface in `server/service`, with a `noopHotPathMetrics` default — existing callers/tests unchanged.
- `*LanternService.WithHotPathMetrics(m)` wither installs the real `*DomainMetrics` from `server/cmd/server.go`. Structural typing means no new wire provider was needed.
- Label cardinality is bounded by allow-lists and **pre-warmed at start** so dashboards render all rows at zero load.
- `optimizationLabel(pb.Optimization)` lives in `service/optimizer.go` — `pb` import deliberately stays out of `server/metrics`.

## Deferred from #220

`lantern_gc_scanned_total` — the existing GC Watch loop only exposes `vExpired` / `eExpired` / `dRemoved`; there is no "scanned" count without an API extension on `core/cache/graph`. Tracking as a follow-up rather than expanding the surface here.

## Tests

- `server/metrics`: family registration + pre-warm sample-count + unknown-label sanitize fallback.
- `server/service`: fake `HotPathMetrics` records emissions; asserts (a) one observation per plural RPC, (b) singular forwarders do **not** double-count via the plural, (c) all three scan ops emit.

## Quality gate

- `gofmt -l` clean
- `go vet ./...` clean (server)
- All 5 module test suites pass.