### PR TITLE
obs: add replication observability collectors (#221)

### DIFF
--- a/core/mutationlog/mutationlog.go
+++ b/core/mutationlog/mutationlog.go
@@ -103,6 +103,7 @@ type Log struct {
 	ring        []Entry
 	firstSeq    uint64 // seq of ring[0] when len(ring) > 0; otherwise next-to-assign
 	lastSeq     uint64 // seq of last appended entry; 0 means none appended yet
+	evicted     uint64 // total entries dropped by ring-buffer eviction
 	hasEntries  bool
 	closed      bool
 	subscribers map[*subscription]struct{}
@@ -159,6 +160,29 @@ func (l *Log) LastSeq() (uint64, bool) {
 	return l.lastSeq, true
 }
 
+// Cap returns the configured ring-buffer capacity.
+func (l *Log) Cap() int {
+	// capacity is set once at construction; no lock needed.
+	return l.capacity
+}
+
+// Len returns the number of entries currently resident in the ring buffer.
+// 0 <= Len() <= Cap().
+func (l *Log) Len() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.ring)
+}
+
+// Evicted returns the cumulative count of entries dropped from the ring
+// buffer because Append at full capacity displaced the oldest entry. The
+// counter is monotonic for the lifetime of the Log.
+func (l *Log) Evicted() uint64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.evicted
+}
+
 // Append assigns the next sequence number to op, persists the entry through
 // the WAL hook, stores it in the ring buffer, and fans it out to every live
 // subscriber. The returned [Entry] carries the assigned Seq.
@@ -197,6 +221,7 @@ func (l *Log) storeLocked(entry Entry) {
 	copy(l.ring, l.ring[1:])
 	l.ring[len(l.ring)-1] = entry
 	l.firstSeq = l.ring[0].Seq
+	l.evicted++
 }
 
 // fanoutLocked delivers entry to every subscriber. A subscriber that cannot

--- a/server/README.md
+++ b/server/README.md
@@ -123,6 +123,15 @@ runtime, process, and `grpc_server_*` collectors):
 | `lantern_replication_lag_seq` | gauge | `peer`, `origin` | Per-(peer, origin) lag in seq units. |
 | `lantern_anti_entropy_cycles_total` | counter | — | Anti-entropy ticks. |
 | `lantern_anti_entropy_gaps_found_total` | counter | `peer`, `origin` | Ticks observing a non-zero gap. |
+| `lantern_peer_connected` | gauge | `peer` | 1 while the local pump holds a `Subscribe` stream to `peer`; 0 after disconnect. Flips back to 1 on reconnect. |
+| `lantern_replication_apply_total` | counter | `op` | Per-`MutationOp` apply count (`PutVertex`, `PutVertices`, `DeleteVertex`, `DeleteVertices`, `DeleteVerticesByPrefix`, `AddEdge`, `AddEdges`, `PutEdge`, `PutEdges`, `DeleteEdge`, `DeleteEdges`). Unknown ops fold onto `unknown`. Pre-warmed at startup. |
+| `lantern_snapshot_replayed_total` | counter | `peer` | Snapshots fully replayed from `peer` (after initial bootstrap or reconnect). |
+| `lantern_snapshot_vertices` | histogram | `peer` | Vertex count per replayed snapshot (exp buckets `(1, 4, 10)`). |
+| `lantern_snapshot_edges` | histogram | `peer` | Edge count per replayed snapshot (same bucketing). |
+| `lantern_snapshot_duration_seconds` | histogram | `peer` | Wall-clock from `Snapshot()` RPC start to last-frame applied (exp buckets `(0.001, 4, 9)`). |
+| `lantern_mutation_log_fill_ratio` | gauge | — | `len(log) / cap(log)` in `[0, 1]`. ≥ 0.8 sustained means peers risk needing a Snapshot reseed. |
+| `lantern_mutation_log_evicted_total` | counter | — | Ring-buffer evictions since process start. Monotonic; sampler resets are tolerated. |
+| `lantern_origin_states_count` | gauge | — | Distinct origins tracked in `originStateTracker` (1 per writer ever observed). Steady-state ≈ peer-set size. |
 | `lantern_illuminate_visited_vertices` | histogram | `optimization` | Vertices visited per `Illuminate` call. |
 | `lantern_illuminate_visited_edges` | histogram | `optimization` | Edges visited per `Illuminate` call. |
 | `lantern_illuminate_duration_seconds` | histogram | `optimization`, `phase` | Per-phase (`traversal`, `optimize`) wall-clock; `optimize` only emitted for non-unspecified optimizations. |

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -83,7 +83,7 @@ func newLanternService(
 	clock *hlc.Clock,
 	dm *domainmetrics.DomainMetrics,
 ) *service.LanternService {
-	return service.NewLanternService(backend).
+	svc := service.NewLanternService(backend).
 		WithScanLimits(service.ScanLimits{
 			ScanDefaultLimit:           sc.ScanDefaultLimit,
 			ScanMaxLimit:               sc.ScanMaxLimit,
@@ -92,9 +92,23 @@ func newLanternService(
 		}).
 		WithReplication(log, clock, dm.OnMutationLogAppend).
 		WithAppliedHook(dm.OnReplicationApplied).
+		WithReplicationApplyHook(dm.OnReplicationApply).
 		WithTombstoneTTL(rc.TombstoneTTL).
 		WithHotPathMetrics(dm).
 		WithLogger(logger)
+	// Bind the mutation-log + origin-state samplers so DomainMetrics.Run
+	// can populate lantern_mutation_log_fill_ratio,
+	// lantern_mutation_log_evicted_total, and
+	// lantern_origin_states_count on its tick interval (#221). Done here
+	// because newLanternService is the only provider with access to both
+	// the log/service and the DomainMetrics instance.
+	if log != nil {
+		dm.BindMutationLogSampler(func() (int, int, uint64) {
+			return log.Len(), log.Cap(), log.Evicted()
+		})
+	}
+	dm.BindOriginStatesSampler(svc.OriginStatesCount)
+	return svc
 }
 
 // newLanternReplicationService wires the streaming replication surface so it

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -18,6 +18,16 @@ import (
 // vertex/edge counts off the cache.
 type Sampler func() (vertices int, edges int)
 
+// MutationLogSampler reports the current ring-buffer occupancy. fill is
+// the number of entries resident; capacity is the configured ring size.
+// A nil sampler disables the lantern_mutation_log_fill_ratio gauge.
+type MutationLogSampler func() (fill int, capacity int, evicted uint64)
+
+// OriginStatesSampler reports the current cardinality of the per-origin
+// watermark table maintained by the apply path. A nil sampler disables
+// the lantern_origin_states_count gauge.
+type OriginStatesSampler func() int
+
 // DomainMetrics owns the Lantern-specific collectors. Construct with New and
 // pass the returned callbacks to GraphCache.SetGCHooks plus Start to begin
 // gauge sampling.
@@ -38,6 +48,17 @@ type DomainMetrics struct {
 	antiEntropyCycles    prometheus.Counter
 	antiEntropyGapsFound *prometheus.CounterVec
 
+	// Replication / mutation-log / back-pressure observability (#221).
+	peerConnected         *prometheus.GaugeVec
+	replicationApplyTotal *prometheus.CounterVec
+	snapshotReplayedTotal *prometheus.CounterVec
+	snapshotVertices      *prometheus.HistogramVec
+	snapshotEdges         *prometheus.HistogramVec
+	snapshotDuration      *prometheus.HistogramVec
+	mutationLogFillRatio  prometheus.Gauge
+	mutationLogEvicted    prometheus.Counter
+	originStatesCount     prometheus.Gauge
+
 	// Hot-path RPC observability (#220). Wired by the service layer via
 	// the HotPathMetrics interface in server/service. Histograms are
 	// label-pre-warmed so dashboards render the full set of variants from
@@ -51,6 +72,9 @@ type DomainMetrics struct {
 
 	sampleInterval time.Duration
 	sample         Sampler
+	mlogSample     MutationLogSampler
+	originSample   OriginStatesSampler
+	lastEvicted    uint64 // last observed cumulative eviction count
 }
 
 // Hot-path label values. Exposed so the service layer can reference the
@@ -76,6 +100,24 @@ var (
 		"GetEdges",
 		"AddEdges",
 		"PutEdges",
+		"DeleteEdges",
+	}
+	// replicationApplyOps covers every pb.MutationOp oneof variant. The
+	// service layer translates the proto-internal case selector into one
+	// of these strings; unknown variants fall through to "unknown" so a
+	// new MutationOp added in proto without a metrics update still
+	// scrapes without exploding the registry.
+	replicationApplyOps = []string{
+		"PutVertex",
+		"PutVertices",
+		"DeleteVertex",
+		"DeleteVertices",
+		"DeleteVerticesByPrefix",
+		"AddEdge",
+		"AddEdges",
+		"PutEdge",
+		"PutEdges",
+		"DeleteEdge",
 		"DeleteEdges",
 	}
 )
@@ -185,6 +227,45 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 			Help:    "Item count of a single plural-RPC batch (PutVertices, PutEdges, AddEdges, GetVertices, GetEdges, DeleteVertices, DeleteEdges). Singular RPC forwarders are not double-counted.",
 			Buckets: prometheus.ExponentialBuckets(1, 4, 10),
 		}, []string{"op"}),
+		peerConnected: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "lantern_peer_connected",
+			Help: "1 when the local replication pump currently holds an open Subscribe (or Subscribe+Snapshot) session to the named peer; 0 otherwise. Updated on every pump connect/disconnect lifecycle event.",
+		}, []string{"peer"}),
+		replicationApplyTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "lantern_replication_apply_total",
+			Help: "Total mutations applied locally via ApplyMutation, partitioned by MutationOp oneof variant. Both pump-delivered remote mutations and locally-originated ones increment this counter.",
+		}, []string{"op"}),
+		snapshotReplayedTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "lantern_snapshot_replayed_total",
+			Help: "Total Snapshot RPC streams the pump has fully replayed from the named peer.",
+		}, []string{"peer"}),
+		snapshotVertices: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "lantern_snapshot_vertices",
+			Help:    "Vertex count replayed from a single Snapshot stream, partitioned by source peer.",
+			Buckets: prometheus.ExponentialBuckets(1, 4, 10),
+		}, []string{"peer"}),
+		snapshotEdges: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "lantern_snapshot_edges",
+			Help:    "Edge count replayed from a single Snapshot stream, partitioned by source peer.",
+			Buckets: prometheus.ExponentialBuckets(1, 4, 10),
+		}, []string{"peer"}),
+		snapshotDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "lantern_snapshot_duration_seconds",
+			Help:    "Wall-clock duration of a single Snapshot stream replay, partitioned by source peer.",
+			Buckets: prometheus.ExponentialBuckets(0.001, 4, 9), // 1ms .. ~65s
+		}, []string{"peer"}),
+		mutationLogFillRatio: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "lantern_mutation_log_fill_ratio",
+			Help: "Current ring-buffer occupancy of the in-memory mutation log, expressed as fill/capacity in [0, 1]. Sampled on the same cadence as lantern_vertices / lantern_edges.",
+		}),
+		mutationLogEvicted: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "lantern_mutation_log_evicted_total",
+			Help: "Total mutation-log entries dropped from the ring buffer because Append at full capacity displaced the oldest entry. A non-zero rate indicates subscribers cannot keep up with append throughput and risk hitting ErrGapped.",
+		}),
+		originStatesCount: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "lantern_origin_states_count",
+			Help: "Number of distinct origin NodeIDs the local apply path has recorded in its per-origin watermark table.",
+		}),
 		sampleInterval: opts.SampleInterval,
 	}
 
@@ -193,7 +274,10 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 		m.replicationApplied, m.replicationDropped, m.replicationLag,
 		m.antiEntropyCycles, m.antiEntropyGapsFound,
 		m.illuminateVisitedVertices, m.illuminateVisitedEdges, m.illuminateDuration,
-		m.scanResults, m.scanDuration, m.batchSize)
+		m.scanResults, m.scanDuration, m.batchSize,
+		m.peerConnected, m.replicationApplyTotal, m.snapshotReplayedTotal,
+		m.snapshotVertices, m.snapshotEdges, m.snapshotDuration,
+		m.mutationLogFillRatio, m.mutationLogEvicted, m.originStatesCount)
 
 	// Pre-create label rows so empty counters scrape as 0.
 	for _, r := range []string{"gapped", "send_failed"} {
@@ -222,6 +306,13 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 	}
 	for _, op := range batchOps {
 		m.batchSize.WithLabelValues(op)
+	}
+	// Pre-warm the replication-apply counter so dashboards render every
+	// MutationOp variant from process start. Per-peer collectors
+	// (peer_connected, snapshot_*) cannot be pre-warmed because peer
+	// addresses are discovered at runtime.
+	for _, op := range replicationApplyOps {
+		m.replicationApplyTotal.WithLabelValues(op)
 	}
 
 	version, commit := opts.Version, opts.Commit
@@ -345,15 +436,19 @@ func (m *DomainMetrics) OnAntiEntropyError(peer, reason string) {
 // --- replication.Metrics (pump) adapter ---
 //
 // The pump's narrow Metrics surface is satisfied by these methods so
-// provider/replication.go can pass *DomainMetrics directly. Only the two
-// events that map onto the dropped_total counter spec'd in #187 emit
-// metric updates; the connect/apply/snapshot hooks are reserved for
-// future expansion (per-peer connect gauges, snapshot counters) and
-// currently no-op so the pump compiles against the same handle.
+// provider/replication.go can pass *DomainMetrics directly. Connect /
+// disconnect drive the per-peer lantern_peer_connected gauge; snapshot
+// replay drives the lantern_snapshot_* family; the pump-apply hook is
+// reserved for future per-peer accounting (the canonical apply counter
+// is lantern_replication_apply_total, populated by OnReplicationApply
+// from ApplyMutation itself).
 
-func (m *DomainMetrics) OnPumpConnect(string) {}
+func (m *DomainMetrics) OnPumpConnect(peer string) {
+	m.peerConnected.WithLabelValues(peer).Set(1)
+}
 
 func (m *DomainMetrics) OnPumpDisconnect(peer, reason string) {
+	m.peerConnected.WithLabelValues(peer).Set(0)
 	m.OnReplicationDropped(peer, reason)
 }
 
@@ -363,7 +458,22 @@ func (m *DomainMetrics) OnPumpDropSelfEcho(peer string) {
 	m.OnReplicationDropped(peer, "self_echo")
 }
 
-func (m *DomainMetrics) OnPumpSnapshotReplayed(string, uint64, uint64) {}
+func (m *DomainMetrics) OnPumpSnapshotReplayed(peer string, vertices, edges uint64, duration time.Duration) {
+	m.snapshotReplayedTotal.WithLabelValues(peer).Inc()
+	m.snapshotVertices.WithLabelValues(peer).Observe(float64(vertices))
+	m.snapshotEdges.WithLabelValues(peer).Observe(float64(edges))
+	m.snapshotDuration.WithLabelValues(peer).Observe(duration.Seconds())
+}
+
+// OnReplicationApply increments lantern_replication_apply_total for one
+// applied MutationOp. The op label is the proto oneof variant name
+// (e.g. "PutVertex", "AddEdges"). Unknown labels are bucketed as
+// "unknown" so a new MutationOp added without a metrics update cannot
+// silently inflate the registry.
+func (m *DomainMetrics) OnReplicationApply(op string) {
+	o := sanitizeLabel(op, replicationApplyOps, "unknown")
+	m.replicationApplyTotal.WithLabelValues(o).Inc()
+}
 
 // --- Hot-path RPC observability (#220) ---
 //
@@ -418,11 +528,26 @@ func (m *DomainMetrics) BindSampler(s Sampler) {
 	m.sample = s
 }
 
+// BindMutationLogSampler installs the mutation-log occupancy callback.
+// Must be called before Run; safe to call exactly once during wiring.
+// A nil sampler leaves lantern_mutation_log_fill_ratio /
+// lantern_mutation_log_evicted_total unsampled.
+func (m *DomainMetrics) BindMutationLogSampler(s MutationLogSampler) {
+	m.mlogSample = s
+}
+
+// BindOriginStatesSampler installs the per-origin watermark cardinality
+// callback. Must be called before Run; safe to call exactly once during
+// wiring. A nil sampler leaves lantern_origin_states_count unsampled.
+func (m *DomainMetrics) BindOriginStatesSampler(s OriginStatesSampler) {
+	m.originSample = s
+}
+
 // Run drives the gauge sampler on the configured cadence until ctx is done.
 // Safe to launch as a goroutine. A nil sampler is treated as a no-op so
 // tests can construct the collectors without wiring a cache.
 func (m *DomainMetrics) Run(ctx context.Context) {
-	if m.sample == nil {
+	if m.sample == nil && m.mlogSample == nil && m.originSample == nil {
 		<-ctx.Done()
 		return
 	}
@@ -441,9 +566,33 @@ func (m *DomainMetrics) Run(ctx context.Context) {
 }
 
 func (m *DomainMetrics) tick() {
-	v, e := m.sample()
-	m.vertices.Set(float64(v))
-	m.edges.Set(float64(e))
+	if m.sample != nil {
+		v, e := m.sample()
+		m.vertices.Set(float64(v))
+		m.edges.Set(float64(e))
+	}
+	if m.mlogSample != nil {
+		fill, capacity, evicted := m.mlogSample()
+		if capacity > 0 {
+			m.mutationLogFillRatio.Set(float64(fill) / float64(capacity))
+		} else {
+			m.mutationLogFillRatio.Set(0)
+		}
+		// Counter is monotonic; advance to the cumulative source-of-truth.
+		// We use a delta-add against a remembered prior sample because
+		// prometheus.Counter has no Set.
+		delta := evicted - m.lastEvicted
+		if evicted < m.lastEvicted { // sampler reset (e.g. log re-instantiated in tests)
+			delta = evicted
+		}
+		if delta > 0 {
+			m.mutationLogEvicted.Add(float64(delta))
+		}
+		m.lastEvicted = evicted
+	}
+	if m.originSample != nil {
+		m.originStatesCount.Set(float64(m.originSample()))
+	}
 }
 
 // readBuildInfo extracts the module version and vcs.revision from the binary's

--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -244,3 +244,140 @@ func TestDomainMetrics_HotPathSanitizesUnknownOptimization(t *testing.T) {
 		t.Errorf("unknown optimization should NOT route observations to its own row; sample count = %v, want 0", got)
 	}
 }
+
+// TestDomainMetrics_ReplicationObservabilityFamilies asserts the #221
+// collectors register, the per-MutationOp counter is pre-warmed, the
+// pump adapter flips the per-peer gauge and emits the snapshot
+// histograms, and the periodic tick populates mutation-log + origin
+// gauges from the bound samplers.
+func TestDomainMetrics_ReplicationObservabilityFamilies(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := New(reg, Options{SampleInterval: time.Hour})
+
+	// Adapter paths.
+	m.OnPumpConnect("peer-a:7000")
+	m.OnPumpConnect("peer-b:7000")
+	m.OnPumpSnapshotReplayed("peer-a:7000", 100, 250, 5*time.Millisecond)
+	m.OnPumpDisconnect("peer-b:7000", "ctx_cancel")
+	for _, op := range []string{"PutVertex", "PutVertices", "AddEdge", "DeleteEdges"} {
+		m.OnReplicationApply(op)
+	}
+	m.OnReplicationApply("bogus-op") // → "unknown"
+
+	// Periodic tick should pick up bound samplers.
+	m.BindMutationLogSampler(func() (int, int, uint64) { return 750, 1000, 42 })
+	m.BindOriginStatesSampler(func() int { return 3 })
+	m.tick()
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	names := map[string]bool{}
+	for _, mf := range mfs {
+		names[mf.GetName()] = true
+	}
+	for _, want := range []string{
+		"lantern_peer_connected",
+		"lantern_replication_apply_total",
+		"lantern_snapshot_replayed_total",
+		"lantern_snapshot_vertices",
+		"lantern_snapshot_edges",
+		"lantern_snapshot_duration_seconds",
+		"lantern_mutation_log_fill_ratio",
+		"lantern_mutation_log_evicted_total",
+		"lantern_origin_states_count",
+	} {
+		if !names[want] {
+			t.Errorf("metric family %q not registered", want)
+		}
+	}
+
+	// peer-a connected → 1, peer-b disconnected → 0.
+	if got := testutil.ToFloat64(m.peerConnected.WithLabelValues("peer-a:7000")); got != 1 {
+		t.Errorf("peer_connected{peer-a} = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.peerConnected.WithLabelValues("peer-b:7000")); got != 0 {
+		t.Errorf("peer_connected{peer-b} = %v, want 0", got)
+	}
+	// Disconnect with reason fans out to replication_dropped_total.
+	if got := testutil.ToFloat64(m.replicationDropped.WithLabelValues("peer-b:7000", "ctx_cancel")); got != 1 {
+		t.Errorf("replication_dropped_total{peer-b,ctx_cancel} = %v, want 1", got)
+	}
+
+	// Snapshot counter + histograms.
+	if got := testutil.ToFloat64(m.snapshotReplayedTotal.WithLabelValues("peer-a:7000")); got != 1 {
+		t.Errorf("snapshot_replayed_total{peer-a} = %v, want 1", got)
+	}
+	if got := histSampleCount(t, m.snapshotVertices.WithLabelValues("peer-a:7000")); got != 1 {
+		t.Errorf("snapshot_vertices{peer-a} sample count = %v, want 1", got)
+	}
+	if got := histSampleCount(t, m.snapshotEdges.WithLabelValues("peer-a:7000")); got != 1 {
+		t.Errorf("snapshot_edges{peer-a} sample count = %v, want 1", got)
+	}
+	if got := histSampleCount(t, m.snapshotDuration.WithLabelValues("peer-a:7000")); got != 1 {
+		t.Errorf("snapshot_duration_seconds{peer-a} sample count = %v, want 1", got)
+	}
+
+	// Per-MutationOp counter: pre-warmed for all 11 variants and the
+	// observed ones incremented exactly once.
+	for _, op := range replicationApplyOps {
+		if testutil.ToFloat64(m.replicationApplyTotal.WithLabelValues(op)) < 0 {
+			t.Errorf("replication_apply_total{op=%q} not pre-warmed", op)
+		}
+	}
+	for _, want := range []struct {
+		op  string
+		exp float64
+	}{
+		{"PutVertex", 1},
+		{"PutVertices", 1},
+		{"AddEdge", 1},
+		{"DeleteEdges", 1},
+		{"unknown", 1},
+	} {
+		if got := testutil.ToFloat64(m.replicationApplyTotal.WithLabelValues(want.op)); got != want.exp {
+			t.Errorf("replication_apply_total{op=%q} = %v, want %v", want.op, got, want.exp)
+		}
+	}
+
+	// Sampler-driven gauges populated by tick().
+	if got := testutil.ToFloat64(m.mutationLogFillRatio); got != 0.75 {
+		t.Errorf("mutation_log_fill_ratio = %v, want 0.75", got)
+	}
+	if got := testutil.ToFloat64(m.mutationLogEvicted); got != 42 {
+		t.Errorf("mutation_log_evicted_total = %v, want 42", got)
+	}
+	if got := testutil.ToFloat64(m.originStatesCount); got != 3 {
+		t.Errorf("origin_states_count = %v, want 3", got)
+	}
+}
+
+// TestDomainMetrics_MutationLogEvictedMonotonic confirms the
+// Counter.Add path delta-applies cumulative evicted samples and
+// recovers gracefully from a sampler reset (e.g. log rebuild).
+func TestDomainMetrics_MutationLogEvictedMonotonic(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := New(reg, Options{SampleInterval: time.Hour})
+
+	var evicted uint64
+	m.BindMutationLogSampler(func() (int, int, uint64) { return 1, 10, evicted })
+
+	evicted = 5
+	m.tick()
+	if got := testutil.ToFloat64(m.mutationLogEvicted); got != 5 {
+		t.Errorf("after first tick (5): counter = %v, want 5", got)
+	}
+
+	evicted = 12 // +7 since last sample
+	m.tick()
+	if got := testutil.ToFloat64(m.mutationLogEvicted); got != 12 {
+		t.Errorf("after second tick (12): counter = %v, want 12", got)
+	}
+
+	evicted = 3 // sampler reset; treat as a fresh +3
+	m.tick()
+	if got := testutil.ToFloat64(m.mutationLogEvicted); got != 15 {
+		t.Errorf("after reset+3: counter = %v, want 15 (12+3)", got)
+	}
+}

--- a/server/provider/readiness.go
+++ b/server/provider/readiness.go
@@ -1,6 +1,8 @@
 package provider
 
 import (
+	"time"
+
 	"github.com/anaregdesign/lantern/server/internal/envconfig"
 	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
 	"github.com/anaregdesign/lantern/server/readiness"
@@ -72,9 +74,9 @@ func (f *pumpMetricsFanOut) OnPumpDropSelfEcho(peer string) {
 	f.gate.OnPumpDropSelfEcho(peer)
 }
 
-func (f *pumpMetricsFanOut) OnPumpSnapshotReplayed(peer string, vertices, edges uint64) {
-	f.dm.OnPumpSnapshotReplayed(peer, vertices, edges)
-	f.gate.OnPumpSnapshotReplayed(peer, vertices, edges)
+func (f *pumpMetricsFanOut) OnPumpSnapshotReplayed(peer string, vertices, edges uint64, duration time.Duration) {
+	f.dm.OnPumpSnapshotReplayed(peer, vertices, edges, duration)
+	f.gate.OnPumpSnapshotReplayed(peer, vertices, edges, duration)
 }
 
 // antiEntropyMetricsFanOut delegates AntiEntropyMetrics events to both

--- a/server/readiness/gate.go
+++ b/server/readiness/gate.go
@@ -17,6 +17,7 @@ package readiness
 import (
 	"sync"
 	"sync/atomic"
+	"time"
 
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
@@ -201,4 +202,4 @@ func (g *Gate) OnPumpDropSelfEcho(string) {}
 
 // OnPumpSnapshotReplayed marks bootstrap complete. A finished bootstrap
 // snapshot is the strongest "we have caught up" signal the pump emits.
-func (g *Gate) OnPumpSnapshotReplayed(string, uint64, uint64) { g.MarkBootstrapped() }
+func (g *Gate) OnPumpSnapshotReplayed(string, uint64, uint64, time.Duration) { g.MarkBootstrapped() }

--- a/server/replication/pump.go
+++ b/server/replication/pump.go
@@ -74,16 +74,16 @@ type Metrics interface {
 	OnPumpDisconnect(peer string, reason string)
 	OnPumpApply(peer string)
 	OnPumpDropSelfEcho(peer string)
-	OnPumpSnapshotReplayed(peer string, vertices, edges uint64)
+	OnPumpSnapshotReplayed(peer string, vertices, edges uint64, duration time.Duration)
 }
 
 type nopMetrics struct{}
 
-func (nopMetrics) OnPumpConnect(string)                          {}
-func (nopMetrics) OnPumpDisconnect(string, string)               {}
-func (nopMetrics) OnPumpApply(string)                            {}
-func (nopMetrics) OnPumpDropSelfEcho(string)                     {}
-func (nopMetrics) OnPumpSnapshotReplayed(string, uint64, uint64) {}
+func (nopMetrics) OnPumpConnect(string)                                         {}
+func (nopMetrics) OnPumpDisconnect(string, string)                              {}
+func (nopMetrics) OnPumpApply(string)                                           {}
+func (nopMetrics) OnPumpDropSelfEcho(string)                                    {}
+func (nopMetrics) OnPumpSnapshotReplayed(string, uint64, uint64, time.Duration) {}
 
 // Config groups the inputs every Pump goroutine needs. All fields
 // except Peers are required to be valid; NewPump fills sensible
@@ -369,6 +369,7 @@ func (p *Pump) snapshot(ctx context.Context, cli pb.LanternReplicationServiceCli
 	if err != nil {
 		return 0, err
 	}
+	start := time.Now()
 	var (
 		cutoff       uint64
 		gotHeader    bool
@@ -449,7 +450,7 @@ func (p *Pump) snapshot(ctx context.Context, cli pb.LanternReplicationServiceCli
 			slog.Uint64("edges_applied", edgeCount),
 			slog.Uint64("edges_footer", footerCounts.e))
 	}
-	p.cfg.Metrics.OnPumpSnapshotReplayed(addr, vertexCount, edgeCount)
+	p.cfg.Metrics.OnPumpSnapshotReplayed(addr, vertexCount, edgeCount, time.Since(start))
 	return cutoff, nil
 }
 

--- a/server/service/apply.go
+++ b/server/service/apply.go
@@ -63,6 +63,14 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 		tombExp = time.Now().Add(s.tombstoneTTL)
 	}
 
+	// opName is set by each case after it commits to a backend call so
+	// the replication-apply hook only fires for genuinely-applied
+	// mutations (nil-payload early returns above the switch and inside
+	// each arm leave opName empty and skip the counter bump). Per-case
+	// strings mirror the proto MutationOp oneof variant names so the
+	// metric label matches the wire schema.
+	var opName string
+
 	switch op := m.GetOp().GetOp().(type) {
 	case *pb.MutationOp_PutVertex:
 		v := op.PutVertex.GetVertex()
@@ -70,6 +78,7 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 			return nil
 		}
 		s.cache.PutVertexWithExpirationHLC(v.GetKey(), v, v.GetExpiration().AsTime(), ts)
+		opName = "PutVertex"
 
 	case *pb.MutationOp_PutVertices:
 		for _, v := range op.PutVertices.GetVertices() {
@@ -78,6 +87,7 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 			}
 			s.cache.PutVertexWithExpirationHLC(v.GetKey(), v, v.GetExpiration().AsTime(), ts)
 		}
+		opName = "PutVertices"
 
 	case *pb.MutationOp_DeleteVertex:
 		if useTomb {
@@ -85,6 +95,7 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 		} else {
 			s.cache.DeleteVertices([]string{op.DeleteVertex.GetKey()})
 		}
+		opName = "DeleteVertex"
 
 	case *pb.MutationOp_DeleteVertices:
 		if useTomb {
@@ -92,19 +103,17 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 		} else {
 			s.cache.DeleteVertices(op.DeleteVertices.GetKeys())
 		}
+		opName = "DeleteVertices"
 
 	case *pb.MutationOp_DeleteVerticesByPrefix:
 		if useTomb {
-			// Errors from DeleteByPrefixHLC only surface ctx
-			// cancellation; the outer ctx.Err() check at the top of
-			// ApplyMutation already handled the entry-point case, so
-			// propagate any new cancellation that occurred mid-scan.
 			if _, err := s.cache.DeleteByPrefixHLC(ctx, op.DeleteVerticesByPrefix.GetPrefix(), 0, ts, tombExp); err != nil {
 				return status.FromContextError(err).Err()
 			}
 		} else {
 			s.cache.DeleteByPrefix(ctx, op.DeleteVerticesByPrefix.GetPrefix(), 0)
 		}
+		opName = "DeleteVerticesByPrefix"
 
 	case *pb.MutationOp_AddEdge:
 		e := op.AddEdge.GetEdge()
@@ -119,6 +128,7 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 			s.cache.AddEdgeWithExpirationContrib(e.GetTail(), e.GetHead(), e.GetWeight(),
 				e.GetExpiration().AsTime(), cID)
 		}
+		opName = "AddEdge"
 
 	case *pb.MutationOp_AddEdges:
 		edges := op.AddEdges.GetEdges()
@@ -135,6 +145,7 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 					e.GetExpiration().AsTime(), cID)
 			}
 		}
+		opName = "AddEdges"
 
 	case *pb.MutationOp_PutEdge:
 		e := op.PutEdge.GetEdge()
@@ -143,6 +154,7 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 		}
 		s.cache.PutEdgeWithExpirationHLC(e.GetTail(), e.GetHead(), e.GetWeight(),
 			e.GetExpiration().AsTime(), ts)
+		opName = "PutEdge"
 
 	case *pb.MutationOp_PutEdges:
 		for _, e := range op.PutEdges.GetEdges() {
@@ -152,6 +164,7 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 			s.cache.PutEdgeWithExpirationHLC(e.GetTail(), e.GetHead(), e.GetWeight(),
 				e.GetExpiration().AsTime(), ts)
 		}
+		opName = "PutEdges"
 
 	case *pb.MutationOp_DeleteEdge:
 		k := op.DeleteEdge
@@ -160,6 +173,7 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 		} else {
 			s.cache.DeleteEdges([]graph.EdgeKey[string]{{Tail: k.GetTail(), Head: k.GetHead()}})
 		}
+		opName = "DeleteEdge"
 
 	case *pb.MutationOp_DeleteEdges:
 		in := op.DeleteEdges.GetEdges()
@@ -172,6 +186,11 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 		} else {
 			s.cache.DeleteEdges(keys)
 		}
+		opName = "DeleteEdges"
+	}
+
+	if opName != "" && s.onReplicationApply != nil {
+		s.onReplicationApply(opName)
 	}
 
 	// Update the per-origin watermark used by PeerStatus (#186). We

--- a/server/service/apply_test.go
+++ b/server/service/apply_test.go
@@ -80,6 +80,76 @@ func TestApplyMutation_BasicOps(t *testing.T) {
 	}
 }
 
+// TestApplyMutation_ReplicationApplyHook asserts the per-MutationOp
+// observability hook (#221) fires exactly once per applied case and
+// records the canonical op name used by the
+// lantern_replication_apply_total counter. Nil-payload mutations and
+// empty mutations must NOT fire the hook (they short-circuit before
+// the backend call).
+func TestApplyMutation_ReplicationApplyHook(t *testing.T) {
+	fb := newFakeBackend()
+	var recorded []string
+	svc := NewLanternService(fb).
+		WithReplicationApplyHook(func(op string) { recorded = append(recorded, op) })
+	ctx := context.Background()
+	origin := bytes16("origin-A")
+	exp := timestamppb.New(time.Now().Add(time.Hour))
+	ts := newHLC(1, origin)
+
+	mustApply := func(t *testing.T, op *pb.MutationOp) {
+		t.Helper()
+		m := &pb.Mutation{Seq: 1, Hlc: ts, Origin: origin[:], Op: op}
+		if err := svc.ApplyMutation(ctx, m); err != nil {
+			t.Fatalf("ApplyMutation: %v", err)
+		}
+	}
+
+	cases := []struct {
+		want string
+		op   *pb.MutationOp
+	}{
+		{"PutVertex", &pb.MutationOp{Op: &pb.MutationOp_PutVertex{PutVertex: &pb.PutVertexRequest{Vertex: &pb.Vertex{Key: "v1", Expiration: exp}}}}},
+		{"PutVertices", &pb.MutationOp{Op: &pb.MutationOp_PutVertices{PutVertices: &pb.PutVerticesRequest{Vertices: []*pb.Vertex{{Key: "v2", Expiration: exp}}}}}},
+		{"AddEdge", &pb.MutationOp{Op: &pb.MutationOp_AddEdge{AddEdge: &pb.AddEdgeRequest{Edge: &pb.Edge{Tail: "v1", Head: "v2", Weight: 1, Expiration: exp}}}}},
+		{"AddEdges", &pb.MutationOp{Op: &pb.MutationOp_AddEdges{AddEdges: &pb.AddEdgesRequest{Edges: []*pb.Edge{{Tail: "v1", Head: "v2", Weight: 1, Expiration: exp}}}}}},
+		{"PutEdge", &pb.MutationOp{Op: &pb.MutationOp_PutEdge{PutEdge: &pb.PutEdgeRequest{Edge: &pb.Edge{Tail: "v1", Head: "v2", Weight: 2, Expiration: exp}}}}},
+		{"PutEdges", &pb.MutationOp{Op: &pb.MutationOp_PutEdges{PutEdges: &pb.PutEdgesRequest{Edges: []*pb.Edge{{Tail: "v1", Head: "v2", Weight: 3, Expiration: exp}}}}}},
+		{"DeleteEdge", &pb.MutationOp{Op: &pb.MutationOp_DeleteEdge{DeleteEdge: &pb.DeleteEdgeRequest{Tail: "v1", Head: "v2"}}}},
+		{"DeleteEdges", &pb.MutationOp{Op: &pb.MutationOp_DeleteEdges{DeleteEdges: &pb.DeleteEdgesRequest{Edges: []*pb.EdgeKey{{Tail: "v1", Head: "v2"}}}}}},
+		{"DeleteVertex", &pb.MutationOp{Op: &pb.MutationOp_DeleteVertex{DeleteVertex: &pb.DeleteVertexRequest{Key: "v1"}}}},
+		{"DeleteVertices", &pb.MutationOp{Op: &pb.MutationOp_DeleteVertices{DeleteVertices: &pb.DeleteVerticesRequest{Keys: []string{"v2"}}}}},
+		{"DeleteVerticesByPrefix", &pb.MutationOp{Op: &pb.MutationOp_DeleteVerticesByPrefix{DeleteVerticesByPrefix: &pb.DeleteVerticesByPrefixRequest{Prefix: "x"}}}},
+	}
+	for _, c := range cases {
+		mustApply(t, c.op)
+	}
+
+	if len(recorded) != len(cases) {
+		t.Fatalf("recorded %d hook calls, want %d (recorded=%v)", len(recorded), len(cases), recorded)
+	}
+	for i, c := range cases {
+		if recorded[i] != c.want {
+			t.Errorf("recorded[%d] = %q, want %q", i, recorded[i], c.want)
+		}
+	}
+
+	// Nil-payload short-circuits and empty mutations must NOT bump the
+	// counter — they don't reach the backend.
+	before := len(recorded)
+	if err := svc.ApplyMutation(ctx, nil); err != nil {
+		t.Errorf("ApplyMutation(nil) returned %v, want nil", err)
+	}
+	if err := svc.ApplyMutation(ctx, &pb.Mutation{}); err != nil {
+		t.Errorf("ApplyMutation(empty) returned %v, want nil", err)
+	}
+	if err := svc.ApplyMutation(ctx, &pb.Mutation{Seq: 2, Hlc: ts, Origin: origin[:], Op: &pb.MutationOp{Op: &pb.MutationOp_PutVertex{PutVertex: nil}}}); err != nil {
+		t.Errorf("ApplyMutation(nil PutVertex) returned %v, want nil", err)
+	}
+	if len(recorded) != before {
+		t.Errorf("hook fired on no-op path: recorded grew from %d to %d", before, len(recorded))
+	}
+}
+
 // TestApplyMutation_DoesNotLog asserts the cardinal rule: replayed
 // mutations MUST NOT re-append to the local log. Otherwise the peer-pump
 // in #184 would echo every mutation back to its origin and loop forever.

--- a/server/service/origin_state.go
+++ b/server/service/origin_state.go
@@ -94,3 +94,12 @@ func (t *originStateTracker) LocalSeq(origin hlc.NodeID) uint64 {
 	defer t.mu.RUnlock()
 	return t.m[origin].seq
 }
+
+// OriginCount returns the number of distinct origin NodeIDs currently
+// recorded. Used by provider/metrics to sample
+// lantern_origin_states_count. Safe to call concurrently with Record.
+func (t *originStateTracker) OriginCount() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return len(t.m)
+}

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -31,17 +31,18 @@ const ServiceName = "graph.v1.LanternService"
 // a fake without standing up the real cache.
 type LanternService struct {
 	pb.UnimplementedLanternServiceServer
-	cache        Backend
-	scan         ScanLimits
-	log          *mutationlog.Log
-	clock        *hlc.Clock
-	origin       []byte
-	onAppend     func()
-	logger       *slog.Logger
-	tombstoneTTL time.Duration
-	origins      *originStateTracker
-	onApplied    func(origin string)
-	metrics      HotPathMetrics
+	cache              Backend
+	scan               ScanLimits
+	log                *mutationlog.Log
+	clock              *hlc.Clock
+	origin             []byte
+	onAppend           func()
+	logger             *slog.Logger
+	tombstoneTTL       time.Duration
+	origins            *originStateTracker
+	onApplied          func(origin string)
+	onReplicationApply func(op string)
+	metrics            HotPathMetrics
 }
 
 // HotPathMetrics is the narrow observability surface consumed by the
@@ -154,6 +155,16 @@ func (s *LanternService) WithAppliedHook(f func(origin string)) *LanternService 
 	return s
 }
 
+// WithReplicationApplyHook registers a callback invoked after every
+// successful ApplyMutation, naming the MutationOp oneof variant
+// (e.g. "PutVertex", "AddEdges"). Used by provider/metrics to bump
+// lantern_replication_apply_total{op}. A nil hook disables the callback.
+// The hook MUST be non-blocking.
+func (s *LanternService) WithReplicationApplyHook(f func(op string)) *LanternService {
+	s.onReplicationApply = f
+	return s
+}
+
 // validateExpiration enforces the LANTERN_TOMBSTONE_TTL clamp on
 // caller-supplied per-entry expirations. A zero expiration (the proto
 // default — "no expiration") is always accepted; otherwise the
@@ -202,6 +213,16 @@ func (s *LanternService) LocalSeq(origin hlc.NodeID) uint64 {
 		return 0
 	}
 	return s.origins.LocalSeq(origin)
+}
+
+// OriginStatesCount returns the number of distinct origins currently
+// recorded in the per-origin watermark table, or 0 when the tracker is
+// unwired. Used by provider/metrics to sample lantern_origin_states_count.
+func (s *LanternService) OriginStatesCount() int {
+	if s.origins == nil {
+		return 0
+	}
+	return s.origins.OriginCount()
 }
 
 // logMutation appends op to the mutation log after a local commit. The HLC


### PR DESCRIPTION
Closes #221.

Adds the 9 missing observability collectors required to operate leaderless replication. All metrics use the existing custom Prometheus registry and pre-warmed label-set pattern.

## New metrics

| Metric | Type | Labels |
| --- | --- | --- |
| `lantern_peer_connected` | gauge | `peer` |
| `lantern_replication_apply_total` | counter | `op` |
| `lantern_snapshot_replayed_total` | counter | `peer` |
| `lantern_snapshot_vertices` | histogram | `peer` |
| `lantern_snapshot_edges` | histogram | `peer` |
| `lantern_snapshot_duration_seconds` | histogram | `peer` |
| `lantern_mutation_log_fill_ratio` | gauge | — |
| `lantern_mutation_log_evicted_total` | counter | — |
| `lantern_origin_states_count` | gauge | — |

The `replication_apply_total` counter is pre-warmed for all 11 `MutationOp` variants; unknown ops fold onto the `unknown` label so the metric never grows unbounded.

## Wiring

- **core/mutationlog**: `Cap()`, `Len()`, `Evicted()` accessors + per-eviction counter increment.
- **server/replication/pump**: `OnPumpSnapshotReplayed` signature extended with `time.Duration` (measured from `Snapshot()` RPC start to last-frame applied).
- **server/service**: `WithReplicationApplyHook` fires once per committed `MutationOp` (`opName` set after backend commit so nil-payload short-circuits skip the hook). `OriginStatesCount()` accessor surfaces `originStateTracker` cardinality.
- **server/metrics.tick()**: samples log fill ratio + evicted (monotonic delta with reset tolerance) + origin count from bound samplers.
- **server/readiness Gate + server/provider pumpMetricsFanOut**: updated for new pump signature; gate keeps existing 'mark bootstrap' semantics.

## Tests

- `server/metrics`: `TestDomainMetrics_ReplicationObservabilityFamilies` exercises all 8 adapter paths + tick population, asserts 9 family names register and per-peer/per-op label values surface correctly (fill_ratio=0.75, evicted=42, origin_states_count=3).
- `server/metrics`: `TestDomainMetrics_MutationLogEvictedMonotonic` drives a closure sampler 5→12→3-reset and asserts the monotonic counter reads 5→12→15.
- `server/service`: `TestApplyMutation_ReplicationApplyHook` walks all 11 `MutationOp` variants and asserts the per-op hook fires once with the matching opName; nil-payload paths must NOT fire.

## Docs

- `server/README.md` observability table extended with the 9 new rows.

## Quality gate

```
gofmt -l . cli core pb sdks server tests   # clean
go vet ./...                                # clean
per-module go test ./...                    # all green (. core pb sdks/go server)
```