### PR TITLE
obs: add validation/rate-limit/tombstone-clamp rejection counters (#222)

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -138,6 +138,9 @@ runtime, process, and `grpc_server_*` collectors):
 | `lantern_scan_results` | histogram | `op` | Result counts for prefix scans (`ScanVertices`, `ScanEdges`, `DeleteVerticesByPrefix`). |
 | `lantern_scan_duration_seconds` | histogram | `op` | Wall-clock for the same scan ops. |
 | `lantern_batch_size` | histogram | `op` | Batch size for plural RPCs (`GetVertices`, `PutVertices`, `DeleteVertices`, `GetEdges`, `AddEdges`, `PutEdges`, `DeleteEdges`). Singular forwarders are NOT instrumented to avoid double-counting. |
+| `lantern_validation_rejected_total` | counter | `reason` | Requests rejected by the validation interceptor or service-layer guards. Reasons: `empty_key`, `key_too_long`, `empty_batch`, `batch_too_large`, `nil_item`, `bad_weight`, `step_too_large`, `k_too_large`, `bad_ttl`, `bad_cursor`. Unknown reasons fold onto `unknown`. Pre-warmed at startup. |
+| `lantern_rate_limit_rejected_total` | counter | — | RPCs rejected with `ResourceExhausted` by the process-wide token-bucket rate limiter (`LANTERN_RATE_LIMIT_RPS`). |
+| `lantern_tombstone_clamp_rejected_total` | counter | — | HLC `Put*` / `Add*` mutations rejected because a newer tombstone or LWW value already covered the key/edge (only counted while `LANTERN_TOMBSTONE_TTL_SECONDS > 0`). |
 
 Tracing is wired via `otelgrpc.NewServerHandler` so any `OTEL_*` env var the
 OpenTelemetry Go SDK honours will Just Work. Per-call logging goes through

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -93,6 +93,8 @@ func newLanternService(
 		WithReplication(log, clock, dm.OnMutationLogAppend).
 		WithAppliedHook(dm.OnReplicationApplied).
 		WithReplicationApplyHook(dm.OnReplicationApply).
+		WithValidationRejectHook(dm.OnValidationRejected).
+		WithTombstoneClampRejectHook(dm.OnTombstoneClampRejected).
 		WithTombstoneTTL(rc.TombstoneTTL).
 		WithHotPathMetrics(dm).
 		WithLogger(logger)

--- a/server/cmd/wire_gen.go
+++ b/server/cmd/wire_gen.go
@@ -33,7 +33,7 @@ func initializeApp() (*App, error) {
 	rateLimitConfig := provider.NewRateLimitConfig(config)
 	validationLimits := provider.NewValidationLimits(config)
 	serverMetrics := provider.NewGrpcServerMetrics(registry)
-	v, err := provider.NewGrpcServerOptions(netConfig, tlsConfig, rateLimitConfig, validationLimits, logger, serverMetrics)
+	v, err := provider.NewGrpcServerOptions(netConfig, tlsConfig, rateLimitConfig, validationLimits, logger, serverMetrics, domainMetrics)
 	if err != nil {
 		return nil, err
 	}

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -59,6 +59,16 @@ type DomainMetrics struct {
 	mutationLogEvicted    prometheus.Counter
 	originStatesCount     prometheus.Gauge
 
+	// Validation / back-pressure rejection counters (#222). Bumped on
+	// every InvalidArgument / ResourceExhausted / tombstone-clamp drop
+	// the server emits before the request reaches its handler
+	// (validation, rate limit) or before the apply commits
+	// (tombstone clamp). Pre-warmed so dashboards render the full reason
+	// set as 0 from process start.
+	validationRejected     *prometheus.CounterVec
+	rateLimitRejected      prometheus.Counter
+	tombstoneClampRejected prometheus.Counter
+
 	// Hot-path RPC observability (#220). Wired by the service layer via
 	// the HotPathMetrics interface in server/service. Histograms are
 	// label-pre-warmed so dashboards render the full set of variants from
@@ -119,6 +129,26 @@ var (
 		"PutEdges",
 		"DeleteEdge",
 		"DeleteEdges",
+	}
+	// validationRejectReasons is the bounded reason set bumped on
+	// lantern_validation_rejected_total. Sources:
+	//   - ValidationInterceptor (server/provider/extra.go): empty_key,
+	//     key_too_long, empty_batch, batch_too_large, nil_item,
+	//     bad_weight, step_too_large, k_too_large
+	//   - service.LanternService.validateExpiration: bad_ttl
+	//   - service prefix-scan cursor decode: bad_cursor
+	// Unknown labels fall through to "unknown" via sanitizeLabel.
+	validationRejectReasons = []string{
+		"empty_key",
+		"key_too_long",
+		"empty_batch",
+		"batch_too_large",
+		"nil_item",
+		"bad_weight",
+		"step_too_large",
+		"k_too_large",
+		"bad_ttl",
+		"bad_cursor",
 	}
 )
 
@@ -266,6 +296,18 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 			Name: "lantern_origin_states_count",
 			Help: "Number of distinct origin NodeIDs the local apply path has recorded in its per-origin watermark table.",
 		}),
+		validationRejected: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "lantern_validation_rejected_total",
+			Help: "Total requests rejected by server-side input validation, partitioned by reason (empty_key, key_too_long, empty_batch, batch_too_large, nil_item, bad_weight, step_too_large, k_too_large, bad_ttl, bad_cursor). Counted before the handler runs (ValidationInterceptor) or during validateExpiration / cursor decode in the service layer.",
+		}, []string{"reason"}),
+		rateLimitRejected: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "lantern_rate_limit_rejected_total",
+			Help: "Total RPCs rejected by the process-wide token-bucket rate limiter (codes.ResourceExhausted). Registered at 0 even when LANTERN_RATE_LIMIT_RPS=0 so dashboards can compare deployments uniformly.",
+		}),
+		tombstoneClampRejected: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "lantern_tombstone_clamp_rejected_total",
+			Help: "Total ApplyMutation Put/Add operations dropped on the tombstone-aware HLC path because the incoming mutation lost the LWW comparison against an existing tombstone or a strictly-newer live HLC. A sustained rate indicates causally-late replication frames or clock skew larger than LANTERN_TOMBSTONE_TTL.",
+		}),
 		sampleInterval: opts.SampleInterval,
 	}
 
@@ -277,7 +319,8 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 		m.scanResults, m.scanDuration, m.batchSize,
 		m.peerConnected, m.replicationApplyTotal, m.snapshotReplayedTotal,
 		m.snapshotVertices, m.snapshotEdges, m.snapshotDuration,
-		m.mutationLogFillRatio, m.mutationLogEvicted, m.originStatesCount)
+		m.mutationLogFillRatio, m.mutationLogEvicted, m.originStatesCount,
+		m.validationRejected, m.rateLimitRejected, m.tombstoneClampRejected)
 
 	// Pre-create label rows so empty counters scrape as 0.
 	for _, r := range []string{"gapped", "send_failed"} {
@@ -314,6 +357,14 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 	for _, op := range replicationApplyOps {
 		m.replicationApplyTotal.WithLabelValues(op)
 	}
+	// Pre-warm the validation-rejection counter (#222) so the full
+	// reason set scrapes as 0 before any traffic arrives. Plus the
+	// "unknown" bucket sanitizeLabel falls back to so a future reason
+	// added without a metrics update still shows up.
+	for _, r := range validationRejectReasons {
+		m.validationRejected.WithLabelValues(r)
+	}
+	m.validationRejected.WithLabelValues("unknown")
 
 	version, commit := opts.Version, opts.Commit
 	if version == "" || commit == "" {
@@ -473,6 +524,33 @@ func (m *DomainMetrics) OnPumpSnapshotReplayed(peer string, vertices, edges uint
 func (m *DomainMetrics) OnReplicationApply(op string) {
 	o := sanitizeLabel(op, replicationApplyOps, "unknown")
 	m.replicationApplyTotal.WithLabelValues(o).Inc()
+}
+
+// OnValidationRejected increments lantern_validation_rejected_total for
+// one rejected request. reason must be one of validationRejectReasons;
+// unknown values are bucketed as "unknown" to keep label cardinality
+// bounded. Wired into ValidationInterceptor (server/provider) and into
+// service.validateExpiration / prefix-scan cursor decode via
+// WithValidationRejectHook.
+func (m *DomainMetrics) OnValidationRejected(reason string) {
+	r := sanitizeLabel(reason, validationRejectReasons, "unknown")
+	m.validationRejected.WithLabelValues(r).Inc()
+}
+
+// OnRateLimitRejected increments lantern_rate_limit_rejected_total when
+// the token-bucket interceptor returns codes.ResourceExhausted. The
+// counter is registered even when LANTERN_RATE_LIMIT_RPS=0 so dashboards
+// can compare deployments uniformly.
+func (m *DomainMetrics) OnRateLimitRejected() {
+	m.rateLimitRejected.Inc()
+}
+
+// OnTombstoneClampRejected increments lantern_tombstone_clamp_rejected_total
+// when an ApplyMutation Put/Add on the tombstone-aware HLC path is
+// dropped because the incoming HLC lost the LWW comparison (either
+// against a live tombstone or against a strictly-newer existing entry).
+func (m *DomainMetrics) OnTombstoneClampRejected() {
+	m.tombstoneClampRejected.Inc()
 }
 
 // --- Hot-path RPC observability (#220) ---

--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -381,3 +381,55 @@ func TestDomainMetrics_MutationLogEvictedMonotonic(t *testing.T) {
 		t.Errorf("after reset+3: counter = %v, want 15 (12+3)", got)
 	}
 }
+
+// TestDomainMetrics_RejectionFamilies asserts the #222 rejection
+// collectors register, the validation reason label is pre-warmed for
+// every canonical reason (plus the "unknown" fallback row), and the
+// three adapters increment exactly the right counters.
+func TestDomainMetrics_RejectionFamilies(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := New(reg, Options{SampleInterval: time.Hour})
+
+	for _, r := range validationRejectReasons {
+		m.OnValidationRejected(r)
+	}
+	m.OnValidationRejected("bogus-reason") // → "unknown"
+	m.OnRateLimitRejected()
+	m.OnRateLimitRejected()
+	m.OnTombstoneClampRejected()
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	names := map[string]bool{}
+	for _, mf := range mfs {
+		names[mf.GetName()] = true
+	}
+	for _, want := range []string{
+		"lantern_validation_rejected_total",
+		"lantern_rate_limit_rejected_total",
+		"lantern_tombstone_clamp_rejected_total",
+	} {
+		if !names[want] {
+			t.Errorf("metric family %q not registered", want)
+		}
+	}
+
+	// Pre-warming: every canonical reason has a row visible from the
+	// start (so dashboards never have to wait for the first reject).
+	for _, r := range validationRejectReasons {
+		if got := testutil.ToFloat64(m.validationRejected.WithLabelValues(r)); got != 1 {
+			t.Errorf("validation_rejected_total{reason=%q} = %v, want 1", r, got)
+		}
+	}
+	if got := testutil.ToFloat64(m.validationRejected.WithLabelValues("unknown")); got != 1 {
+		t.Errorf("validation_rejected_total{reason=unknown} = %v, want 1 (bogus reason should fold)", got)
+	}
+	if got := testutil.ToFloat64(m.rateLimitRejected); got != 2 {
+		t.Errorf("rate_limit_rejected_total = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(m.tombstoneClampRejected); got != 1 {
+		t.Errorf("tombstone_clamp_rejected_total = %v, want 1", got)
+	}
+}

--- a/server/provider/extra.go
+++ b/server/provider/extra.go
@@ -42,11 +42,33 @@ type ValidationLimits struct {
 }
 
 type ValidationInterceptor struct {
-	limits ValidationLimits
+	limits     ValidationLimits
+	rejectHook func(reason string)
 }
 
 func NewValidationInterceptor(l ValidationLimits) *ValidationInterceptor {
 	return &ValidationInterceptor{limits: l}
+}
+
+// WithRejectHook registers a callback invoked once per rejected request
+// with the canonical reason label (one of empty_key, key_too_long,
+// empty_batch, batch_too_large, nil_item, bad_weight, step_too_large,
+// k_too_large). Used by provider/metrics to bump
+// lantern_validation_rejected_total{reason}. A nil hook disables the
+// callback; safe to call exactly once during wiring.
+func (v *ValidationInterceptor) WithRejectHook(f func(reason string)) *ValidationInterceptor {
+	v.rejectHook = f
+	return v
+}
+
+// reject fires the registered hook (if any) and returns the constructed
+// gRPC status error. Centralised so every validation rejection path is
+// counted exactly once.
+func (v *ValidationInterceptor) reject(reason string, format string, args ...any) error {
+	if v.rejectHook != nil {
+		v.rejectHook(reason)
+	}
+	return status.Errorf(codes.InvalidArgument, format, args...)
 }
 
 func (v *ValidationInterceptor) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
@@ -96,7 +118,7 @@ func (v *ValidationInterceptor) validate(req any) error {
 		}
 		for i, vx := range r.GetVertices() {
 			if vx == nil {
-				return status.Errorf(codes.InvalidArgument, "vertices[%d] is nil", i)
+				return v.reject("nil_item", "vertices[%d] is nil", i)
 			}
 			if err := v.checkKey(fmt.Sprintf("vertices[%d].key", i), vx.GetKey()); err != nil {
 				return err
@@ -113,7 +135,7 @@ func (v *ValidationInterceptor) validate(req any) error {
 		}
 		for i, e := range r.GetEdges() {
 			if e == nil {
-				return status.Errorf(codes.InvalidArgument, "edges[%d] is nil", i)
+				return v.reject("nil_item", "edges[%d] is nil", i)
 			}
 			if err := v.checkKey(fmt.Sprintf("edges[%d].tail", i), e.GetTail()); err != nil {
 				return err
@@ -133,7 +155,7 @@ func (v *ValidationInterceptor) validate(req any) error {
 		}
 		for i, e := range r.GetEdges() {
 			if e == nil {
-				return status.Errorf(codes.InvalidArgument, "edges[%d] is nil", i)
+				return v.reject("nil_item", "edges[%d] is nil", i)
 			}
 			if err := v.checkKey(fmt.Sprintf("edges[%d].tail", i), e.GetTail()); err != nil {
 				return err
@@ -151,10 +173,10 @@ func (v *ValidationInterceptor) validate(req any) error {
 			return err
 		}
 		if v.limits.IlluminateMaxStep > 0 && int(r.GetStep()) > v.limits.IlluminateMaxStep {
-			return status.Errorf(codes.InvalidArgument, "step %d exceeds max %d", r.GetStep(), v.limits.IlluminateMaxStep)
+			return v.reject("step_too_large", "step %d exceeds max %d", r.GetStep(), v.limits.IlluminateMaxStep)
 		}
 		if v.limits.IlluminateMaxK > 0 && int(r.GetK()) > v.limits.IlluminateMaxK {
-			return status.Errorf(codes.InvalidArgument, "k %d exceeds max %d", r.GetK(), v.limits.IlluminateMaxK)
+			return v.reject("k_too_large", "k %d exceeds max %d", r.GetK(), v.limits.IlluminateMaxK)
 		}
 	}
 	return nil
@@ -166,7 +188,7 @@ func (v *ValidationInterceptor) validateEdges(edges []*pb.Edge) error {
 	}
 	for i, e := range edges {
 		if e == nil {
-			return status.Errorf(codes.InvalidArgument, "edges[%d] is nil", i)
+			return v.reject("nil_item", "edges[%d] is nil", i)
 		}
 		if err := v.checkKey(fmt.Sprintf("edges[%d].tail", i), e.GetTail()); err != nil {
 			return err
@@ -176,7 +198,7 @@ func (v *ValidationInterceptor) validateEdges(edges []*pb.Edge) error {
 		}
 		w := float64(e.GetWeight())
 		if math.IsNaN(w) || math.IsInf(w, 0) {
-			return status.Errorf(codes.InvalidArgument, "edges[%d].weight must be finite, got %v", i, e.GetWeight())
+			return v.reject("bad_weight", "edges[%d].weight must be finite, got %v", i, e.GetWeight())
 		}
 	}
 	return nil
@@ -184,20 +206,20 @@ func (v *ValidationInterceptor) validateEdges(edges []*pb.Edge) error {
 
 func (v *ValidationInterceptor) checkKey(field, value string) error {
 	if value == "" {
-		return status.Errorf(codes.InvalidArgument, "%s must not be empty", field)
+		return v.reject("empty_key", "%s must not be empty", field)
 	}
 	if v.limits.MaxKeyLen > 0 && len(value) > v.limits.MaxKeyLen {
-		return status.Errorf(codes.InvalidArgument, "%s length %d exceeds max %d", field, len(value), v.limits.MaxKeyLen)
+		return v.reject("key_too_long", "%s length %d exceeds max %d", field, len(value), v.limits.MaxKeyLen)
 	}
 	return nil
 }
 
 func (v *ValidationInterceptor) checkBatch(n int) error {
 	if n == 0 {
-		return status.Error(codes.InvalidArgument, "request batch must not be empty")
+		return v.reject("empty_batch", "request batch must not be empty")
 	}
 	if v.limits.MaxBatchSize > 0 && n > v.limits.MaxBatchSize {
-		return status.Errorf(codes.InvalidArgument, "batch size %d exceeds max %d", n, v.limits.MaxBatchSize)
+		return v.reject("batch_too_large", "batch size %d exceeds max %d", n, v.limits.MaxBatchSize)
 	}
 	return nil
 }
@@ -210,7 +232,8 @@ func (v *ValidationInterceptor) checkBatch(n int) error {
 // the bucket return codes.ResourceExhausted so well-behaved clients (and the
 // SDK's default retry policy) can back off.
 type RateLimitInterceptor struct {
-	lim *rate.Limiter
+	lim        *rate.Limiter
+	rejectHook func()
 }
 
 func NewRateLimitInterceptor(rps float64, burst int) *RateLimitInterceptor {
@@ -223,9 +246,21 @@ func NewRateLimitInterceptor(rps float64, burst int) *RateLimitInterceptor {
 	return &RateLimitInterceptor{lim: rate.NewLimiter(rate.Limit(rps), burst)}
 }
 
+// WithRejectHook registers a callback invoked once per rejected RPC
+// before codes.ResourceExhausted is returned. Used by provider/metrics
+// to bump lantern_rate_limit_rejected_total. A nil hook disables the
+// callback; safe to call exactly once during wiring.
+func (r *RateLimitInterceptor) WithRejectHook(f func()) *RateLimitInterceptor {
+	r.rejectHook = f
+	return r
+}
+
 func (r *RateLimitInterceptor) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if !r.lim.Allow() {
+			if r.rejectHook != nil {
+				r.rejectHook()
+			}
 			return nil, status.Error(codes.ResourceExhausted, "rate limit exceeded")
 		}
 		return handler(ctx, req)
@@ -235,6 +270,9 @@ func (r *RateLimitInterceptor) UnaryServerInterceptor() grpc.UnaryServerIntercep
 func (r *RateLimitInterceptor) StreamServerInterceptor() grpc.StreamServerInterceptor {
 	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if !r.lim.Allow() {
+			if r.rejectHook != nil {
+				r.rejectHook()
+			}
 			return status.Error(codes.ResourceExhausted, "rate limit exceeded")
 		}
 		return handler(srv, ss)

--- a/server/provider/extra_test.go
+++ b/server/provider/extra_test.go
@@ -1,0 +1,191 @@
+package provider
+
+import (
+	"context"
+	"math"
+	"strings"
+	"testing"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestValidationInterceptor_RejectHookFiresPerReason walks every
+// canonical reason exposed by lantern_validation_rejected_total{reason}
+// (excluding bad_ttl and bad_cursor which the service layer owns) and
+// asserts that (a) the interceptor returns InvalidArgument and (b) the
+// registered hook is invoked with the matching reason exactly once.
+func TestValidationInterceptor_RejectHookFiresPerReason(t *testing.T) {
+	limits := ValidationLimits{
+		MaxKeyLen:         4,
+		MaxBatchSize:      2,
+		IlluminateMaxStep: 3,
+		IlluminateMaxK:    5,
+	}
+	cases := []struct {
+		name   string
+		want   string
+		req    any
+		anyMsg string // optional substring assertion on error message
+	}{
+		{
+			name: "empty_key",
+			want: "empty_key",
+			req:  &pb.GetVertexRequest{Key: ""},
+		},
+		{
+			name: "key_too_long",
+			want: "key_too_long",
+			req:  &pb.GetVertexRequest{Key: "abcdef"}, // 6 > MaxKeyLen=4
+		},
+		{
+			name: "empty_batch",
+			want: "empty_batch",
+			req:  &pb.PutVerticesRequest{Vertices: nil},
+		},
+		{
+			name: "batch_too_large",
+			want: "batch_too_large",
+			req: &pb.PutVerticesRequest{Vertices: []*pb.Vertex{
+				{Key: "a"}, {Key: "b"}, {Key: "c"}, // 3 > MaxBatchSize=2
+			}},
+		},
+		{
+			name: "nil_item",
+			want: "nil_item",
+			req: &pb.PutVerticesRequest{Vertices: []*pb.Vertex{
+				{Key: "a"}, nil,
+			}},
+		},
+		{
+			name: "bad_weight",
+			want: "bad_weight",
+			req: &pb.AddEdgesRequest{Edges: []*pb.Edge{
+				{Tail: "a", Head: "b", Weight: float32(math.NaN())},
+			}},
+		},
+		{
+			name: "step_too_large",
+			want: "step_too_large",
+			req:  &pb.IlluminateRequest{Seed: "s", Step: 99}, // > IlluminateMaxStep=3
+		},
+		{
+			name: "k_too_large",
+			want: "k_too_large",
+			req:  &pb.IlluminateRequest{Seed: "s", Step: 1, K: 99}, // > IlluminateMaxK=5
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var got string
+			v := NewValidationInterceptor(limits).
+				WithRejectHook(func(reason string) { got = reason })
+			interceptor := v.UnaryServerInterceptor()
+			handler := func(ctx context.Context, req any) (any, error) {
+				t.Fatal("handler called on rejected request")
+				return nil, nil
+			}
+			_, err := interceptor(context.Background(), c.req, &grpc.UnaryServerInfo{}, handler)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if code := status.Code(err); code != codes.InvalidArgument {
+				t.Errorf("status code = %s, want InvalidArgument", code)
+			}
+			if got != c.want {
+				t.Errorf("reject hook reason = %q, want %q", got, c.want)
+			}
+			if c.anyMsg != "" && !strings.Contains(err.Error(), c.anyMsg) {
+				t.Errorf("error %q does not contain %q", err.Error(), c.anyMsg)
+			}
+		})
+	}
+}
+
+// TestValidationInterceptor_AcceptedRequestDoesNotFireHook asserts the
+// hook stays silent when validation passes (handler runs, no reason
+// recorded).
+func TestValidationInterceptor_AcceptedRequestDoesNotFireHook(t *testing.T) {
+	var got string
+	v := NewValidationInterceptor(ValidationLimits{MaxKeyLen: 16}).
+		WithRejectHook(func(reason string) { got = reason })
+	interceptor := v.UnaryServerInterceptor()
+	called := false
+	handler := func(ctx context.Context, req any) (any, error) {
+		called = true
+		return "ok", nil
+	}
+	if _, err := interceptor(context.Background(), &pb.GetVertexRequest{Key: "k"}, &grpc.UnaryServerInfo{}, handler); err != nil {
+		t.Fatalf("interceptor: %v", err)
+	}
+	if !called {
+		t.Errorf("handler not invoked on valid request")
+	}
+	if got != "" {
+		t.Errorf("reject hook fired on success path: reason=%q", got)
+	}
+}
+
+// TestValidationInterceptor_NilHookSafe asserts the reject path does
+// not panic when no hook was registered.
+func TestValidationInterceptor_NilHookSafe(t *testing.T) {
+	v := NewValidationInterceptor(ValidationLimits{})
+	interceptor := v.UnaryServerInterceptor()
+	handler := func(ctx context.Context, req any) (any, error) { return nil, nil }
+	_, err := interceptor(context.Background(), &pb.GetVertexRequest{Key: ""}, &grpc.UnaryServerInfo{}, handler)
+	if err == nil || status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v", err)
+	}
+}
+
+// TestRateLimitInterceptor_RejectHookFires asserts the limiter fires
+// the registered hook once per ResourceExhausted return on both the
+// unary and the stream interceptor.
+func TestRateLimitInterceptor_RejectHookFires(t *testing.T) {
+	// rps = small, burst = 1: first call passes, second call blocked.
+	r := NewRateLimitInterceptor(0.0001, 1)
+	var n int
+	r.WithRejectHook(func() { n++ })
+
+	unary := r.UnaryServerInterceptor()
+	handler := func(ctx context.Context, req any) (any, error) { return "ok", nil }
+	if _, err := unary(context.Background(), nil, &grpc.UnaryServerInfo{}, handler); err != nil {
+		t.Fatalf("first unary call: %v", err)
+	}
+	if _, err := unary(context.Background(), nil, &grpc.UnaryServerInfo{}, handler); err == nil {
+		t.Fatal("second unary call: expected ResourceExhausted")
+	} else if status.Code(err) != codes.ResourceExhausted {
+		t.Errorf("second unary call: code = %s, want ResourceExhausted", status.Code(err))
+	}
+	if n != 1 {
+		t.Errorf("hook calls after unary = %d, want 1", n)
+	}
+
+	stream := r.StreamServerInterceptor()
+	streamHandler := func(srv any, ss grpc.ServerStream) error { return nil }
+	if err := stream(nil, nil, &grpc.StreamServerInfo{}, streamHandler); err == nil {
+		t.Fatal("stream call: expected ResourceExhausted")
+	} else if status.Code(err) != codes.ResourceExhausted {
+		t.Errorf("stream call: code = %s, want ResourceExhausted", status.Code(err))
+	}
+	if n != 2 {
+		t.Errorf("hook calls after stream = %d, want 2", n)
+	}
+}
+
+// TestRateLimitInterceptor_NilHookSafe asserts the reject path does
+// not panic when no hook was registered.
+func TestRateLimitInterceptor_NilHookSafe(t *testing.T) {
+	r := NewRateLimitInterceptor(0.0001, 1)
+	unary := r.UnaryServerInterceptor()
+	handler := func(ctx context.Context, req any) (any, error) { return "ok", nil }
+	if _, err := unary(context.Background(), nil, &grpc.UnaryServerInfo{}, handler); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if _, err := unary(context.Background(), nil, &grpc.UnaryServerInfo{}, handler); err == nil || status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("second call: expected ResourceExhausted, got %v", err)
+	}
+}

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -301,6 +301,7 @@ func NewGrpcServerOptions(
 	limits ValidationLimits,
 	logger *slog.Logger,
 	metrics *grpcprom.ServerMetrics,
+	dm *domainmetrics.DomainMetrics,
 ) ([]grpc.ServerOption, error) {
 	logOpts := []logging.Option{
 		logging.WithLogOnEvents(logging.StartCall, logging.FinishCall),
@@ -312,7 +313,8 @@ func NewGrpcServerOptions(
 		}),
 	}
 
-	validator := NewValidationInterceptor(limits)
+	validator := NewValidationInterceptor(limits).
+		WithRejectHook(dm.OnValidationRejected)
 
 	unary := []grpc.UnaryServerInterceptor{
 		recovery.UnaryServerInterceptor(recoveryOpts...),
@@ -326,7 +328,8 @@ func NewGrpcServerOptions(
 	}
 
 	if rl.RPS > 0 {
-		rli := NewRateLimitInterceptor(rl.RPS, rl.Burst)
+		rli := NewRateLimitInterceptor(rl.RPS, rl.Burst).
+			WithRejectHook(dm.OnRateLimitRejected)
 		unary = append(unary, validator.UnaryServerInterceptor(), rli.UnaryServerInterceptor())
 		stream = append(stream, validator.StreamServerInterceptor(), rli.StreamServerInterceptor())
 	} else {

--- a/server/service/apply.go
+++ b/server/service/apply.go
@@ -77,7 +77,10 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 		if v == nil {
 			return nil
 		}
-		s.cache.PutVertexWithExpirationHLC(v.GetKey(), v, v.GetExpiration().AsTime(), ts)
+		applied := s.cache.PutVertexWithExpirationHLC(v.GetKey(), v, v.GetExpiration().AsTime(), ts)
+		if !applied && useTomb && s.onTombstoneClampReject != nil {
+			s.onTombstoneClampReject()
+		}
 		opName = "PutVertex"
 
 	case *pb.MutationOp_PutVertices:
@@ -85,7 +88,10 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 			if v == nil {
 				continue
 			}
-			s.cache.PutVertexWithExpirationHLC(v.GetKey(), v, v.GetExpiration().AsTime(), ts)
+			applied := s.cache.PutVertexWithExpirationHLC(v.GetKey(), v, v.GetExpiration().AsTime(), ts)
+			if !applied && useTomb && s.onTombstoneClampReject != nil {
+				s.onTombstoneClampReject()
+			}
 		}
 		opName = "PutVertices"
 
@@ -122,8 +128,11 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 		}
 		cID := contribIDFor(origin, seq, 0)
 		if useTomb {
-			s.cache.AddEdgeWithExpirationContribHLC(e.GetTail(), e.GetHead(), e.GetWeight(),
+			applied := s.cache.AddEdgeWithExpirationContribHLC(e.GetTail(), e.GetHead(), e.GetWeight(),
 				e.GetExpiration().AsTime(), cID, ts)
+			if !applied && s.onTombstoneClampReject != nil {
+				s.onTombstoneClampReject()
+			}
 		} else {
 			s.cache.AddEdgeWithExpirationContrib(e.GetTail(), e.GetHead(), e.GetWeight(),
 				e.GetExpiration().AsTime(), cID)
@@ -138,8 +147,11 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 			}
 			cID := contribIDFor(origin, seq, uint16(i))
 			if useTomb {
-				s.cache.AddEdgeWithExpirationContribHLC(e.GetTail(), e.GetHead(), e.GetWeight(),
+				applied := s.cache.AddEdgeWithExpirationContribHLC(e.GetTail(), e.GetHead(), e.GetWeight(),
 					e.GetExpiration().AsTime(), cID, ts)
+				if !applied && s.onTombstoneClampReject != nil {
+					s.onTombstoneClampReject()
+				}
 			} else {
 				s.cache.AddEdgeWithExpirationContrib(e.GetTail(), e.GetHead(), e.GetWeight(),
 					e.GetExpiration().AsTime(), cID)
@@ -152,8 +164,11 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 		if e == nil {
 			return nil
 		}
-		s.cache.PutEdgeWithExpirationHLC(e.GetTail(), e.GetHead(), e.GetWeight(),
+		applied := s.cache.PutEdgeWithExpirationHLC(e.GetTail(), e.GetHead(), e.GetWeight(),
 			e.GetExpiration().AsTime(), ts)
+		if !applied && useTomb && s.onTombstoneClampReject != nil {
+			s.onTombstoneClampReject()
+		}
 		opName = "PutEdge"
 
 	case *pb.MutationOp_PutEdges:
@@ -161,8 +176,11 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 			if e == nil {
 				continue
 			}
-			s.cache.PutEdgeWithExpirationHLC(e.GetTail(), e.GetHead(), e.GetWeight(),
+			applied := s.cache.PutEdgeWithExpirationHLC(e.GetTail(), e.GetHead(), e.GetWeight(),
 				e.GetExpiration().AsTime(), ts)
+			if !applied && useTomb && s.onTombstoneClampReject != nil {
+				s.onTombstoneClampReject()
+			}
 		}
 		opName = "PutEdges"
 

--- a/server/service/apply_test.go
+++ b/server/service/apply_test.go
@@ -582,3 +582,107 @@ func mustMarshal(v *pb.Vertex) []byte {
 	}
 	return b
 }
+
+// TestApplyMutation_TombstoneClampRejectHook covers the #222
+// tombstone-clamp counter wiring: any HLC Put/Add path that loses LWW
+// inside the s.tombstoneTTL>0 branch must fire the registered hook
+// exactly once per rejected case (per-entry in the plural variants).
+// Each scenario applies a "winner" mutation at a high HLC first, then
+// a strictly-older "loser" mutation for the same key/edge and asserts
+// the hook count.
+func TestApplyMutation_TombstoneClampRejectHook(t *testing.T) {
+	exp := timestamppb.New(time.Now().Add(time.Hour))
+	origin := bytes16("origin-A")
+
+	newSvc := func(tsCount *int) *LanternService {
+		cache := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
+		return NewLanternService(cache).
+			WithTombstoneTTL(time.Hour).
+			WithTombstoneClampRejectHook(func() { *tsCount++ })
+	}
+
+	apply := func(t *testing.T, svc *LanternService, seq uint64, op *pb.MutationOp) {
+		t.Helper()
+		m := &pb.Mutation{Seq: seq, Hlc: newHLC(int64(seq), origin), Origin: origin[:], Op: op}
+		if err := svc.ApplyMutation(context.Background(), m); err != nil {
+			t.Fatalf("ApplyMutation seq=%d: %v", seq, err)
+		}
+	}
+
+	t.Run("PutVertex", func(t *testing.T) {
+		var n int
+		svc := newSvc(&n)
+		put := func(seq uint64) *pb.MutationOp {
+			return &pb.MutationOp{Op: &pb.MutationOp_PutVertex{
+				PutVertex: &pb.PutVertexRequest{Vertex: &pb.Vertex{Key: "k", Value: &pb.Vertex_Nil{Nil: true}, Expiration: exp}},
+			}}
+		}
+		apply(t, svc, 5, put(5)) // winner
+		apply(t, svc, 1, put(1)) // loser
+		if n != 1 {
+			t.Fatalf("hook fired %d times, want 1", n)
+		}
+	})
+
+	t.Run("PutVertices", func(t *testing.T) {
+		var n int
+		svc := newSvc(&n)
+		put := func() *pb.MutationOp {
+			return &pb.MutationOp{Op: &pb.MutationOp_PutVertices{
+				PutVertices: &pb.PutVerticesRequest{Vertices: []*pb.Vertex{
+					{Key: "k1", Value: &pb.Vertex_Nil{Nil: true}, Expiration: exp},
+					{Key: "k2", Value: &pb.Vertex_Nil{Nil: true}, Expiration: exp},
+				}},
+			}}
+		}
+		apply(t, svc, 5, put()) // both win
+		apply(t, svc, 1, put()) // both lose
+		if n != 2 {
+			t.Fatalf("hook fired %d times, want 2 (one per entry)", n)
+		}
+	})
+
+	t.Run("PutEdge", func(t *testing.T) {
+		var n int
+		svc := newSvc(&n)
+		put := func() *pb.MutationOp {
+			return &pb.MutationOp{Op: &pb.MutationOp_PutEdge{
+				PutEdge: &pb.PutEdgeRequest{Edge: &pb.Edge{Tail: "a", Head: "b", Weight: 1, Expiration: exp}},
+			}}
+		}
+		apply(t, svc, 5, put())
+		apply(t, svc, 1, put())
+		if n != 1 {
+			t.Fatalf("hook fired %d times, want 1", n)
+		}
+	})
+
+	t.Run("WinnerDoesNotFire", func(t *testing.T) {
+		var n int
+		svc := newSvc(&n)
+		apply(t, svc, 1, &pb.MutationOp{Op: &pb.MutationOp_PutVertex{
+			PutVertex: &pb.PutVertexRequest{Vertex: &pb.Vertex{Key: "k", Value: &pb.Vertex_Nil{Nil: true}, Expiration: exp}},
+		}})
+		if n != 0 {
+			t.Fatalf("hook fired %d times on first apply, want 0", n)
+		}
+	})
+
+	t.Run("ClampDisabledNeverFires", func(t *testing.T) {
+		var n int
+		cache := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
+		svc := NewLanternService(cache).
+			WithTombstoneClampRejectHook(func() { n++ })
+		// useTomb=false: the non-HLC backend path is taken, hook stays at 0.
+		put := func(seq uint64) *pb.MutationOp {
+			return &pb.MutationOp{Op: &pb.MutationOp_PutVertex{
+				PutVertex: &pb.PutVertexRequest{Vertex: &pb.Vertex{Key: "k", Value: &pb.Vertex_Nil{Nil: true}, Expiration: exp}},
+			}}
+		}
+		apply(t, svc, 5, put(5))
+		apply(t, svc, 1, put(1))
+		if n != 0 {
+			t.Fatalf("hook fired %d times with clamp disabled, want 0", n)
+		}
+	})
+}

--- a/server/service/prefix.go
+++ b/server/service/prefix.go
@@ -30,6 +30,9 @@ func (s *LanternService) ScanVertices(ctx context.Context, in *pb.ScanVerticesRe
 
 	cursor, err := decodeCursor(in.GetCursor())
 	if err != nil {
+		if s.onValidationReject != nil {
+			s.onValidationReject("bad_cursor")
+		}
 		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
@@ -157,6 +160,9 @@ func (s *LanternService) ScanEdges(ctx context.Context, in *pb.ScanEdgesRequest)
 
 	cursor, err := decodeEdgesCursor(in.GetCursor())
 	if err != nil {
+		if s.onValidationReject != nil {
+			s.onValidationReject("bad_cursor")
+		}
 		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 

--- a/server/service/prefix_test.go
+++ b/server/service/prefix_test.go
@@ -137,3 +137,24 @@ func TestDeleteVerticesByPrefix_DryRunAndReal(t *testing.T) {
 		t.Errorf("cache still has %d entries after delete", len(fb.vertices))
 	}
 }
+
+// TestScan_BadCursorFiresValidationRejectHook covers the #222
+// bad_cursor hook fires from both ScanVertices and ScanEdges when the
+// caller passes a malformed cursor.
+func TestScan_BadCursorFiresValidationRejectHook(t *testing.T) {
+	fb := newFakeBackend()
+	var got []string
+	svc := NewLanternService(fb).
+		WithValidationRejectHook(func(reason string) { got = append(got, reason) })
+	ctx := context.Background()
+
+	if _, err := svc.ScanVertices(ctx, &pb.ScanVerticesRequest{Prefix: "x", Cursor: []byte("not-base64-or-anything-valid!!!")}); err == nil {
+		t.Fatal("ScanVertices with bad cursor: expected error")
+	}
+	if _, err := svc.ScanEdges(ctx, &pb.ScanEdgesRequest{TailPrefix: "x", Cursor: []byte("not-base64-or-anything-valid!!!")}); err == nil {
+		t.Fatal("ScanEdges with bad cursor: expected error")
+	}
+	if len(got) != 2 || got[0] != "bad_cursor" || got[1] != "bad_cursor" {
+		t.Fatalf("reject hook calls = %v, want [bad_cursor bad_cursor]", got)
+	}
+}

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -31,18 +31,20 @@ const ServiceName = "graph.v1.LanternService"
 // a fake without standing up the real cache.
 type LanternService struct {
 	pb.UnimplementedLanternServiceServer
-	cache              Backend
-	scan               ScanLimits
-	log                *mutationlog.Log
-	clock              *hlc.Clock
-	origin             []byte
-	onAppend           func()
-	logger             *slog.Logger
-	tombstoneTTL       time.Duration
-	origins            *originStateTracker
-	onApplied          func(origin string)
-	onReplicationApply func(op string)
-	metrics            HotPathMetrics
+	cache                  Backend
+	scan                   ScanLimits
+	log                    *mutationlog.Log
+	clock                  *hlc.Clock
+	origin                 []byte
+	onAppend               func()
+	logger                 *slog.Logger
+	tombstoneTTL           time.Duration
+	origins                *originStateTracker
+	onApplied              func(origin string)
+	onReplicationApply     func(op string)
+	onValidationReject     func(reason string)
+	onTombstoneClampReject func()
+	metrics                HotPathMetrics
 }
 
 // HotPathMetrics is the narrow observability surface consumed by the
@@ -165,6 +167,30 @@ func (s *LanternService) WithReplicationApplyHook(f func(op string)) *LanternSer
 	return s
 }
 
+// WithValidationRejectHook registers a callback invoked once per
+// rejected request, naming the canonical reason (one of
+// metrics.validationRejectReasons). Used by provider/metrics to bump
+// lantern_validation_rejected_total{reason}. A nil hook disables the
+// callback. The hook MUST be non-blocking — it runs synchronously on
+// the RPC critical path. Called from validateExpiration (#183) and the
+// prefix-scan cursor decode (server/service/prefix.go).
+func (s *LanternService) WithValidationRejectHook(f func(reason string)) *LanternService {
+	s.onValidationReject = f
+	return s
+}
+
+// WithTombstoneClampRejectHook registers a callback invoked once per
+// ApplyMutation Put/Add operation that the tombstone-aware HLC path
+// drops because the incoming HLC lost the LWW comparison (against a
+// live tombstone OR against a strictly-newer existing entry). Used by
+// provider/metrics to bump lantern_tombstone_clamp_rejected_total.
+// A nil hook disables the callback. Only fires inside the s.tombstoneTTL > 0
+// branch of apply.go — the non-HLC fast path never rejects.
+func (s *LanternService) WithTombstoneClampRejectHook(f func()) *LanternService {
+	s.onTombstoneClampReject = f
+	return s
+}
+
 // validateExpiration enforces the LANTERN_TOMBSTONE_TTL clamp on
 // caller-supplied per-entry expirations. A zero expiration (the proto
 // default — "no expiration") is always accepted; otherwise the
@@ -176,6 +202,9 @@ func (s *LanternService) validateExpiration(exp time.Time) error {
 		return nil
 	}
 	if exp.After(time.Now().Add(s.tombstoneTTL)) {
+		if s.onValidationReject != nil {
+			s.onValidationReject("bad_ttl")
+		}
 		return status.Errorf(codes.InvalidArgument,
 			"expiration %s exceeds LANTERN_TOMBSTONE_TTL=%s",
 			exp.UTC().Format(time.RFC3339Nano), s.tombstoneTTL)

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -750,3 +750,36 @@ func TestLanternService_HotPathMetrics_EmitsOnScan(t *testing.T) {
 		t.Errorf("DeleteVerticesByPrefix results = %d, want 2", fm.scan[2].results)
 	}
 }
+
+// TestExpirationClamp_FiresValidationRejectHook covers the #222
+// bad_ttl hook fire from validateExpiration. The hook MUST run before
+// the InvalidArgument status is returned and MUST NOT fire when the
+// expiration is within the clamp.
+func TestExpirationClamp_FiresValidationRejectHook(t *testing.T) {
+	const ttl = time.Hour
+	var got []string
+	s := NewLanternService(graph.NewGraphCache[string, *pb.Vertex](time.Minute)).
+		WithTombstoneTTL(ttl).
+		WithValidationRejectHook(func(reason string) { got = append(got, reason) })
+
+	bad := timestamppb.New(time.Now().Add(2 * ttl))
+	if _, err := s.PutVertices(context.Background(), &pb.PutVerticesRequest{
+		Vertices: []*pb.Vertex{{Key: "v", Value: &pb.Vertex_Nil{Nil: true}, Expiration: bad}},
+	}); err == nil {
+		t.Fatal("PutVertices over TTL: expected error")
+	}
+	if len(got) != 1 || got[0] != "bad_ttl" {
+		t.Fatalf("reject hook calls = %v, want [bad_ttl]", got)
+	}
+
+	got = nil
+	ok := timestamppb.New(time.Now().Add(ttl / 2))
+	if _, err := s.PutVertices(context.Background(), &pb.PutVerticesRequest{
+		Vertices: []*pb.Vertex{{Key: "v", Value: &pb.Vertex_Nil{Nil: true}, Expiration: ok}},
+	}); err != nil {
+		t.Fatalf("PutVertices within TTL: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("reject hook fired on success path: %v", got)
+	}
+}


### PR DESCRIPTION
Adds three counter families exposing why the server rejects work, so dashboards and alerts can distinguish client misuse from peer-side / backpressure issues:

- `lantern_validation_rejected_total{reason}` — interceptor + service-layer validation rejections. Canonical reasons: `empty_key`, `key_too_long`, `empty_batch`, `batch_too_large`, `nil_item`, `bad_weight`, `step_too_large`, `k_too_large`, `bad_ttl`, `bad_cursor`. Unknown reasons fold onto `unknown`. Pre-warmed at startup.
- `lantern_rate_limit_rejected_total` — RPCs blocked by the process-wide token-bucket limiter (`LANTERN_RATE_LIMIT_RPS`); fires for both unary and stream interceptors.
- `lantern_tombstone_clamp_rejected_total` — HLC Put*/Add* mutations rejected because a newer tombstone or LWW value already covered the key/edge (only counted while `LANTERN_TOMBSTONE_TTL_SECONDS > 0`).

### Implementation seams
- `ValidationInterceptor.WithRejectHook` / `RateLimitInterceptor.WithRejectHook` — added in `server/provider/extra.go`, so the counter wiring lives in `provider/metrics.go` and the interceptors are unit-testable without a real server.
- New `reject(reason, fmt, args...)` helper inside `ValidationInterceptor` routes every error path through one counter bump, avoiding plumbing the reason through every check function signature.
- Service-layer guards (`validateExpiration` → `bad_ttl`, `Scan{Vertices,Edges}` cursor decode → `bad_cursor`) call the same hook via `WithValidationRejectHook`.
- Apply paths call `WithTombstoneClampRejectHook` whenever a HLC backend write returns `applied=false` inside the `useTomb` branch (per-entry in plural ops).

### Tests
- `server/provider/extra_test.go` (new, 1:1 pairing for previously-untested `extra.go`): per-reason interceptor coverage, accepted-request silence, nil-hook safety, rate-limit unary+stream hook fires, rate-limit nil-hook safety.
- `server/metrics/metrics_test.go`: `TestDomainMetrics_RejectionFamilies` walks every canonical reason + `unknown` fallback + both bare counters.
- `server/service/service_test.go`: `TestExpirationClamp_FiresValidationRejectHook` (`bad_ttl`).
- `server/service/prefix_test.go`: `TestScan_BadCursorFiresValidationRejectHook` (`bad_cursor` for both `ScanVertices` and `ScanEdges`).
- `server/service/apply_test.go`: `TestApplyMutation_TombstoneClampRejectHook` — uses real `GraphCache` + LWW conflict to exercise PutVertex, PutVertices (per-entry), PutEdge, plus the winner-doesn't-fire and clamp-disabled-never-fires control cases.

### Quality gate
All four gates green locally:
- `gofmt -l . cli core pb sdks server tests` — clean.
- `(cd server && go vet ./... && go test ./...)` — pass.
- `go test ./... && (cd core && go test ./...) && (cd pb && go test ./...) && (cd sdks/go && go test ./...)` — pass.

### Design notes deferred to #223
- `PutVertexHLC` / `AddEdgeHLC` return a single `bool` that conflates tombstone-clamp rejection with LWW-loss. The counter therefore aggregates both causes; disambiguation requires an upstream enum return and is out of scope here.

Closes #222