### PR TITLE
obs(#223): structured logs + slow-rpc & AE-gap channels

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -85,6 +85,8 @@ most common knobs:
 | `LANTERN_MAX_RECV_MSG_BYTES` / `LANTERN_MAX_SEND_MSG_BYTES` | `16 MiB` | gRPC message size caps. |
 | `LANTERN_MAX_CONCURRENT_STREAMS` | `1024` | Per-connection stream cap (0 = unlimited). |
 | `LANTERN_RATE_LIMIT_RPS` / `LANTERN_RATE_LIMIT_BURST` | `0` | Process-wide token-bucket rate limit (0 disables). |
+| `LANTERN_SLOW_RPC_THRESHOLD_MS` | `500` | Emit a `slog` warning per unary/stream RPC whose handler exceeds this duration (0 disables). |
+| `LANTERN_ANTI_ENTROPY_GAP_WARN_THRESHOLD` | `1024` | Emit a `slog` warning per anti-entropy tick whose detected peer gap (in seq units) exceeds this value (0 disables). |
 | `LANTERN_METRICS_ADDR` | `:9090` | HTTP listen for `/metrics`, `/healthz`, `/readyz` (empty disables). |
 | `LANTERN_REFLECTION` | `true` | gRPC server reflection. |
 | `LANTERN_LOG_LEVEL` / `LANTERN_LOG_FORMAT` | `info` / `json` | slog handler. |
@@ -146,6 +148,34 @@ Tracing is wired via `otelgrpc.NewServerHandler` so any `OTEL_*` env var the
 OpenTelemetry Go SDK honours will Just Work. Per-call logging goes through
 the `grpc-ecosystem` slog middleware at `info` level on `StartCall` /
 `FinishCall`.
+
+### Structured-log channels (#223)
+
+In addition to the `grpc-ecosystem` per-call logger, the server emits
+targeted `slog` records on the default logger so operators can grep without
+standing up a metrics stack:
+
+| Logger message | Level | Trigger | Key attrs |
+| --- | --- | --- | --- |
+| `slow rpc` | `warn` | Unary or stream handler ran longer than `LANTERN_SLOW_RPC_THRESHOLD_MS`. | `method`, `code`, `duration_ms`, `threshold_ms` |
+| `validation rejected` | `debug` | Validation interceptor returned `InvalidArgument` (also bumps `lantern_validation_rejected_total`). | `reason`, `error` |
+| `graph cache: gc tick` | `info` | One record per `GraphCache.Watch` tick (always fires, even on empty ticks). | `vertices_expired`, `edges_expired`, `dangling_edges_removed`, `vertices_remaining`, `edges_remaining`, `duration_ms` |
+| `anti-entropy: gap exceeds warn threshold` | `warn` | Detected per-origin gap exceeds `LANTERN_ANTI_ENTROPY_GAP_WARN_THRESHOLD`. | `origin`, `gap`, `threshold` |
+| `replication pump: peer transition` | `info` / `warn` | Connect / disconnect / snapshot start / snapshot finish. | `peer`, `transition`, `reason` |
+
+### What to watch in production
+
+- **Replication divergence** — `lantern_anti_entropy_gaps_found_total` rising +
+  the `anti-entropy: gap exceeds warn threshold` slog line both point at
+  the same condition; the metric is the alerting signal, the log is the
+  grep target during triage.
+- **Back-pressure** — `lantern_rate_limit_rejected_total` and the
+  `slow rpc` slog line correlate: rate-limit rejections without slow-RPC
+  warnings mean the limiter is saturating ahead of handler latency,
+  whereas the inverse means handlers are blocking upstream of the limiter.
+- **Hot scans** — `lantern_scan_results` / `lantern_scan_duration_seconds`
+  flag clients fan-paging large prefixes; expect to also see `slow rpc`
+  records for the same `method`.
 
 ## Dependency boundaries (invariants)
 

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -45,6 +45,7 @@ func newApp(
 	pump *replication.Pump,
 	antiEntropy *replication.AntiEntropy,
 	_ registeredHealth,
+	_ provider.CacheGCHooksWired,
 ) *App {
 	return &App{
 		cfg:         cfg,

--- a/server/cmd/wire.go
+++ b/server/cmd/wire.go
@@ -34,6 +34,7 @@ func initializeApp() (*App, error) {
 		provider.NewTracing,
 		provider.NewGraphCache,
 		provider.NewDomainMetrics,
+		provider.WireCacheGCHooks,
 		provider.NewReadinessGate,
 		provider.NewPumpMetrics,
 		provider.NewAntiEntropyMetrics,

--- a/server/cmd/wire_gen.go
+++ b/server/cmd/wire_gen.go
@@ -33,7 +33,7 @@ func initializeApp() (*App, error) {
 	rateLimitConfig := provider.NewRateLimitConfig(config)
 	validationLimits := provider.NewValidationLimits(config)
 	serverMetrics := provider.NewGrpcServerMetrics(registry)
-	v, err := provider.NewGrpcServerOptions(netConfig, tlsConfig, rateLimitConfig, validationLimits, logger, serverMetrics, domainMetrics)
+	v, err := provider.NewGrpcServerOptions(netConfig, tlsConfig, rateLimitConfig, validationLimits, observabilityConfig, logger, serverMetrics, domainMetrics)
 	if err != nil {
 		return nil, err
 	}
@@ -60,6 +60,7 @@ func initializeApp() (*App, error) {
 	antiEntropyMetrics := provider.NewAntiEntropyMetrics(domainMetrics, gate)
 	antiEntropy := provider.NewAntiEntropyDriver(peerConfig, replicationConfig, antiEntropyConfig, lanternService, graphCache, pump, antiEntropyMetrics, logger)
 	mainRegisteredHealth := registerHealthAndReflection(observabilityConfig, server, healthServer)
-	app := newApp(config, logger, lanternServer, metricsServer, tracing, domainMetrics, healthServer, pump, antiEntropy, mainRegisteredHealth)
+	cacheGCHooksWired := provider.WireCacheGCHooks(graphCache, domainMetrics, logger)
+	app := newApp(config, logger, lanternServer, metricsServer, tracing, domainMetrics, healthServer, pump, antiEntropy, mainRegisteredHealth, cacheGCHooksWired)
 	return app, nil
 }

--- a/server/provider/antientropy.go
+++ b/server/provider/antientropy.go
@@ -18,9 +18,15 @@ import (
 //     keeping the rest of the replication stack enabled.
 //   - LANTERN_ANTI_ENTROPY_SUBSCRIBE_TIMEOUT_MS  caps the duration of
 //     a single catch-up Subscribe stream. Default 30000 (30s).
+//   - LANTERN_ANTI_ENTROPY_GAP_WARN_THRESHOLD  when a per-peer catch-up
+//     gap (peer_seq - local_seq) exceeds this many mutations, emit a
+//     warn-level "gap exceeds threshold" log in addition to the
+//     standard info-level catch-up log. Default 1024. Set to 0 to
+//     disable the warn (info log still fires).
 type AntiEntropyConfig struct {
 	Interval         time.Duration
 	SubscribeTimeout time.Duration
+	GapWarnThreshold uint64
 }
 
 // NewAntiEntropyConfig selects the AntiEntropy slice of Config.
@@ -32,6 +38,7 @@ func loadAntiEntropyConfig() AntiEntropyConfig {
 	return AntiEntropyConfig{
 		Interval:         time.Duration(envconfig.Int("LANTERN_ANTI_ENTROPY_INTERVAL_MS", 30_000)) * time.Millisecond,
 		SubscribeTimeout: time.Duration(envconfig.Int("LANTERN_ANTI_ENTROPY_SUBSCRIBE_TIMEOUT_MS", 30_000)) * time.Millisecond,
+		GapWarnThreshold: uint64(envconfig.Int("LANTERN_ANTI_ENTROPY_GAP_WARN_THRESHOLD", 1024)),
 	}
 }
 
@@ -60,6 +67,7 @@ func NewAntiEntropyDriver(
 		Peers:            pc.Peers,
 		Interval:         ac.Interval,
 		SubscribeTimeout: ac.SubscribeTimeout,
+		GapWarnThreshold: ac.GapWarnThreshold,
 		Logger:           logger,
 		Metrics:          m,
 	}, svc, svc, cache)

--- a/server/provider/extra.go
+++ b/server/provider/extra.go
@@ -84,7 +84,7 @@ func (v *ValidationInterceptor) reject(reason string, format string, args ...any
 	if v.logger != nil && v.logger.Enabled(context.Background(), slog.LevelDebug) {
 		v.logger.LogAttrs(context.Background(), slog.LevelDebug, "validation rejected",
 			slog.String("reason", reason),
-			slog.String("msg", status.Convert(err).Message()),
+			slog.String("error", status.Convert(err).Message()),
 		)
 	}
 	return err

--- a/server/provider/extra.go
+++ b/server/provider/extra.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"os"
 
@@ -44,6 +45,7 @@ type ValidationLimits struct {
 type ValidationInterceptor struct {
 	limits     ValidationLimits
 	rejectHook func(reason string)
+	logger     *slog.Logger
 }
 
 func NewValidationInterceptor(l ValidationLimits) *ValidationInterceptor {
@@ -61,6 +63,16 @@ func (v *ValidationInterceptor) WithRejectHook(f func(reason string)) *Validatio
 	return v
 }
 
+// WithLogger registers a logger that receives a debug-level "validation
+// rejected" line per rejection with the canonical reason label and the
+// formatted error message. Operators flip LANTERN_LOG_LEVEL=debug to
+// surface field-level rejection reasons during incident triage; prod
+// stays quiet at the default info level. A nil logger disables emission.
+func (v *ValidationInterceptor) WithLogger(l *slog.Logger) *ValidationInterceptor {
+	v.logger = l
+	return v
+}
+
 // reject fires the registered hook (if any) and returns the constructed
 // gRPC status error. Centralised so every validation rejection path is
 // counted exactly once.
@@ -68,7 +80,14 @@ func (v *ValidationInterceptor) reject(reason string, format string, args ...any
 	if v.rejectHook != nil {
 		v.rejectHook(reason)
 	}
-	return status.Errorf(codes.InvalidArgument, format, args...)
+	err := status.Errorf(codes.InvalidArgument, format, args...)
+	if v.logger != nil && v.logger.Enabled(context.Background(), slog.LevelDebug) {
+		v.logger.LogAttrs(context.Background(), slog.LevelDebug, "validation rejected",
+			slog.String("reason", reason),
+			slog.String("msg", status.Convert(err).Message()),
+		)
+	}
+	return err
 }
 
 func (v *ValidationInterceptor) UnaryServerInterceptor() grpc.UnaryServerInterceptor {

--- a/server/provider/extra_test.go
+++ b/server/provider/extra_test.go
@@ -1,7 +1,9 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"math"
 	"strings"
 	"testing"
@@ -187,5 +189,73 @@ func TestRateLimitInterceptor_NilHookSafe(t *testing.T) {
 	}
 	if _, err := unary(context.Background(), nil, &grpc.UnaryServerInfo{}, handler); err == nil || status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("second call: expected ResourceExhausted, got %v", err)
+	}
+}
+
+// TestValidationInterceptor_LoggerEmitsDebugOnReject asserts that
+// WithLogger() causes reject() to emit one debug-level "validation
+// rejected" record with the documented reason/msg fields, and that
+// successful paths stay silent.
+func TestValidationInterceptor_LoggerEmitsDebugOnReject(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	v := NewValidationInterceptor(ValidationLimits{MaxKeyLen: 4}).WithLogger(logger)
+
+	// success path: no log records.
+	handler := func(ctx context.Context, req any) (any, error) { return "ok", nil }
+	if _, err := v.UnaryServerInterceptor()(context.Background(), &pb.GetVertexRequest{Key: "k"}, &grpc.UnaryServerInfo{}, handler); err != nil {
+		t.Fatalf("success path: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("success path emitted logs: %s", buf.String())
+	}
+
+	// reject path: exactly one debug record with reason + msg.
+	_, err := v.UnaryServerInterceptor()(context.Background(), &pb.GetVertexRequest{Key: ""}, &grpc.UnaryServerInfo{}, handler)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("reject path code = %s, want InvalidArgument", status.Code(err))
+	}
+	recs := decodeRecords(t, &buf)
+	if len(recs) != 1 {
+		t.Fatalf("got %d log records, want 1", len(recs))
+	}
+	rec := recs[0]
+	if rec["msg"] != "validation rejected" {
+		t.Errorf("msg = %v, want %q", rec["msg"], "validation rejected")
+	}
+	if rec["reason"] != "empty_key" {
+		t.Errorf("reason = %v, want %q", rec["reason"], "empty_key")
+	}
+	if got, _ := rec["error"].(string); !strings.Contains(got, "key") {
+		t.Errorf("error field missing or unexpected: %v", rec)
+	}
+}
+
+// TestValidationInterceptor_LoggerSuppressedBelowDebug asserts the gate
+// short-circuits when the logger handler is set above debug, keeping the
+// hot path quiet by default.
+func TestValidationInterceptor_LoggerSuppressedBelowDebug(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	v := NewValidationInterceptor(ValidationLimits{}).WithLogger(logger)
+
+	handler := func(ctx context.Context, req any) (any, error) { return "ok", nil }
+	_, err := v.UnaryServerInterceptor()(context.Background(), &pb.GetVertexRequest{Key: ""}, &grpc.UnaryServerInfo{}, handler)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("reject path code = %s, want InvalidArgument", status.Code(err))
+	}
+	if buf.Len() != 0 {
+		t.Errorf("info-level logger emitted records: %s", buf.String())
+	}
+}
+
+// TestValidationInterceptor_NilLoggerSafe asserts that the reject path
+// stays safe when WithLogger was never invoked (default install).
+func TestValidationInterceptor_NilLoggerSafe(t *testing.T) {
+	v := NewValidationInterceptor(ValidationLimits{})
+	handler := func(ctx context.Context, req any) (any, error) { return "ok", nil }
+	_, err := v.UnaryServerInterceptor()(context.Background(), &pb.GetVertexRequest{Key: ""}, &grpc.UnaryServerInfo{}, handler)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("reject path: %v", err)
 	}
 }

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -75,6 +75,8 @@ type RateLimitConfig struct {
 //   - LANTERN_REFLECTION                 true|false            (default true)
 //   - LANTERN_VERSION                    overrides lantern_build_info{version}
 //   - LANTERN_COMMIT                     overrides lantern_build_info{commit}
+//   - LANTERN_SLOW_RPC_THRESHOLD_MS      milliseconds; RPCs that take longer
+//     emit a warn-level "slow rpc" log. Default 500. Set to 0 to disable.
 type ObservabilityConfig struct {
 	LogLevel         slog.Level
 	LogFormat        string
@@ -82,6 +84,7 @@ type ObservabilityConfig struct {
 	EnableReflection bool
 	Version          string
 	Commit           string
+	SlowRPCThreshold time.Duration
 }
 
 // CacheConfig sizes the GraphCache TTL and its GC tick.
@@ -167,6 +170,7 @@ func NewConfig() *Config {
 			EnableReflection: envconfig.Bool("LANTERN_REFLECTION", true),
 			Version:          os.Getenv("LANTERN_VERSION"),
 			Commit:           os.Getenv("LANTERN_COMMIT"),
+			SlowRPCThreshold: time.Duration(envconfig.Int("LANTERN_SLOW_RPC_THRESHOLD_MS", 500)) * time.Millisecond,
 		},
 		Cache: CacheConfig{
 			TTL:        time.Duration(envconfig.Int("LANTERN_DEFAULT_TTL_SECONDS", 60)) * time.Second,
@@ -234,10 +238,11 @@ func NewGraphCache(c CacheConfig) *graph.GraphCache[string, *v1.Vertex] {
 }
 
 // NewDomainMetrics registers the Lantern-specific `lantern_*` collectors on
-// the shared Prometheus registry and wires the GraphCache GC hooks so each
-// Watch tick updates the eviction counters and histogram. The gauge sampler
-// runs from DomainMetrics.Run, started by App alongside the other long-lived
-// goroutines.
+// the shared Prometheus registry and binds the gauge sampler that reads
+// cache.VertexCount / EdgeCount on each DomainMetrics.Run tick. The GC
+// hooks themselves are installed separately by WireCacheGCHooks so the
+// metrics adapter can be multiplexed with the structured per-tick log
+// (#223).
 func NewDomainMetrics(
 	reg *prometheus.Registry,
 	o ObservabilityConfig,
@@ -250,8 +255,60 @@ func NewDomainMetrics(
 	m.BindSampler(func() (int, int) {
 		return cache.VertexCount(), cache.EdgeCount()
 	})
-	cache.SetGCHooks(m.OnExpire, m.OnGCDuration)
 	return m
+}
+
+// CacheGCHooksWired is a marker returned by WireCacheGCHooks so wire can
+// force ordering: the wiring must happen after both DomainMetrics and the
+// logger are constructed, but the result is not consumed by any downstream
+// provider directly. newApp accepts it as an unused parameter.
+type CacheGCHooksWired struct{}
+
+// WireCacheGCHooks installs a multiplexed pair of GC hooks on the cache:
+// one branch updates DomainMetrics (lantern_cache_evicted_total +
+// lantern_cache_gc_duration_seconds), the other emits one info-level
+// "graph cache: gc tick" slog line per tick summarising the work done
+// (#223). The hooks are fired sequentially by GraphCache.Watch on a
+// single goroutine, so the per-tick accumulator inside the closure is
+// safe without locking.
+func WireCacheGCHooks(
+	cache *graph.GraphCache[string, *v1.Vertex],
+	m *domainmetrics.DomainMetrics,
+	logger *slog.Logger,
+) CacheGCHooksWired {
+	// Per-tick accumulator. GraphCache.Watch calls onExpire 0–3 times
+	// (one per non-empty kind) then onGC once — atomically per tick,
+	// on a single goroutine — so a plain struct is sufficient.
+	var tick struct {
+		vertices int
+		edges    int
+		dangling int
+	}
+	onExpire := func(kind string, n int) {
+		m.OnExpire(kind, n)
+		switch kind {
+		case "vertex":
+			tick.vertices += n
+		case "edge":
+			tick.edges += n
+		case "dangling_edge":
+			tick.dangling += n
+		}
+	}
+	onGC := func(d time.Duration) {
+		m.OnGCDuration(d)
+		logger.LogAttrs(context.Background(), slog.LevelInfo, "graph cache: gc tick",
+			slog.Int("vertices_expired", tick.vertices),
+			slog.Int("edges_expired", tick.edges),
+			slog.Int("dangling_edges_removed", tick.dangling),
+			slog.Int("vertices_remaining", cache.VertexCount()),
+			slog.Int("edges_remaining", cache.EdgeCount()),
+			slog.Int64("duration_ms", d.Milliseconds()),
+		)
+		tick.vertices, tick.edges, tick.dangling = 0, 0, 0
+	}
+	cache.SetGCHooks(onExpire, onGC)
+	return CacheGCHooksWired{}
 }
 
 func NewListener(n NetConfig) (net.Listener, error) {
@@ -299,6 +356,7 @@ func NewGrpcServerOptions(
 	tlsCfg TLSConfig,
 	rl RateLimitConfig,
 	limits ValidationLimits,
+	obs ObservabilityConfig,
 	logger *slog.Logger,
 	metrics *grpcprom.ServerMetrics,
 	dm *domainmetrics.DomainMetrics,
@@ -314,7 +372,8 @@ func NewGrpcServerOptions(
 	}
 
 	validator := NewValidationInterceptor(limits).
-		WithRejectHook(dm.OnValidationRejected)
+		WithRejectHook(dm.OnValidationRejected).
+		WithLogger(logger)
 
 	unary := []grpc.UnaryServerInterceptor{
 		recovery.UnaryServerInterceptor(recoveryOpts...),
@@ -335,6 +394,13 @@ func NewGrpcServerOptions(
 	} else {
 		unary = append(unary, validator.UnaryServerInterceptor())
 		stream = append(stream, validator.StreamServerInterceptor())
+	}
+
+	// Slow-RPC warn log fires last so it observes the full handler
+	// duration including validation + rate-limit decisions (#223).
+	if slow := NewSlowRPCInterceptor(obs.SlowRPCThreshold, logger); slow.Enabled() {
+		unary = append(unary, slow.UnaryServerInterceptor())
+		stream = append(stream, slow.StreamServerInterceptor())
 	}
 
 	opts := []grpc.ServerOption{

--- a/server/provider/provider_test.go
+++ b/server/provider/provider_test.go
@@ -1,0 +1,59 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/cache/graph"
+	v1 "github.com/anaregdesign/lantern/pb/graph/v1"
+	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// TestWireCacheGCHooks_EmitsTickSummary asserts that a single
+// "graph cache: gc tick" info log record is emitted per cache tick
+// after WireCacheGCHooks installs the multiplexed hooks (#223).
+func TestWireCacheGCHooks_EmitsTickSummary(t *testing.T) {
+	cache := graph.NewGraphCache[string, *v1.Vertex](time.Second)
+	reg := prometheus.NewRegistry()
+	dm := domainmetrics.New(reg, domainmetrics.Options{})
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	if got := WireCacheGCHooks(cache, dm, logger); got != (CacheGCHooksWired{}) {
+		t.Fatalf("WireCacheGCHooks return = %+v, want empty marker", got)
+	}
+
+	// Drive the Watch loop on a short interval; expect at least one tick
+	// to fire while we hold the goroutine open.
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		cache.Watch(ctx, 10*time.Millisecond)
+		close(done)
+	}()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	recs := decodeRecords(t, &buf)
+	if len(recs) == 0 {
+		t.Fatalf("no log records emitted; want >=1 'graph cache: gc tick'")
+	}
+	rec := recs[0]
+	if rec["msg"] != "graph cache: gc tick" {
+		t.Errorf("msg = %v, want 'graph cache: gc tick'", rec["msg"])
+	}
+	for _, k := range []string{
+		"vertices_expired", "edges_expired", "dangling_edges_removed",
+		"vertices_remaining", "edges_remaining", "duration_ms",
+	} {
+		if _, ok := rec[k]; !ok {
+			t.Errorf("missing field %q in record: %v", k, rec)
+		}
+	}
+}

--- a/server/provider/slowrpc.go
+++ b/server/provider/slowrpc.go
@@ -1,0 +1,77 @@
+package provider
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+)
+
+// SlowRPCInterceptor measures each RPC's wall-clock duration and emits a
+// warn-level slog line ("slow rpc") whenever the duration exceeds the
+// configured threshold (#223). Threshold == 0 disables emission entirely.
+//
+// Fields:
+//   - method        the gRPC method name (info.FullMethod)
+//   - code          the resulting gRPC status code (string form)
+//   - duration_ms   handler wall-clock in milliseconds (int64)
+//   - threshold_ms  the configured threshold in milliseconds (int64)
+//
+// Slow-RPC accounting is purely a logging signal; it does not affect the
+// response or any Prometheus counter (the existing grpc-middleware
+// histogram already covers latency distributions). The dedicated log
+// makes single-request outliers grep-able in JSON log streams.
+type SlowRPCInterceptor struct {
+	threshold time.Duration
+	logger    *slog.Logger
+}
+
+// NewSlowRPCInterceptor builds an interceptor that emits a warn log per RPC
+// exceeding threshold. A zero/negative threshold disables emission (the
+// interceptor returns the handler directly without measuring time).
+// logger MUST be non-nil; pass slog.Default() if no dedicated logger is
+// available.
+func NewSlowRPCInterceptor(threshold time.Duration, logger *slog.Logger) *SlowRPCInterceptor {
+	return &SlowRPCInterceptor{threshold: threshold, logger: logger}
+}
+
+// Enabled reports whether the interceptor will measure / emit logs. Used by
+// the wiring layer to decide whether to install the interceptor at all,
+// keeping the hot path identical to pre-#223 when the threshold is 0.
+func (s *SlowRPCInterceptor) Enabled() bool { return s != nil && s.threshold > 0 && s.logger != nil }
+
+func (s *SlowRPCInterceptor) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		start := time.Now()
+		resp, err := handler(ctx, req)
+		d := time.Since(start)
+		if d > s.threshold {
+			s.logger.LogAttrs(ctx, slog.LevelWarn, "slow rpc",
+				slog.String("method", info.FullMethod),
+				slog.String("code", status.Code(err).String()),
+				slog.Int64("duration_ms", d.Milliseconds()),
+				slog.Int64("threshold_ms", s.threshold.Milliseconds()),
+			)
+		}
+		return resp, err
+	}
+}
+
+func (s *SlowRPCInterceptor) StreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		start := time.Now()
+		err := handler(srv, ss)
+		d := time.Since(start)
+		if d > s.threshold {
+			s.logger.LogAttrs(ss.Context(), slog.LevelWarn, "slow rpc",
+				slog.String("method", info.FullMethod),
+				slog.String("code", status.Code(err).String()),
+				slog.Int64("duration_ms", d.Milliseconds()),
+				slog.Int64("threshold_ms", s.threshold.Milliseconds()),
+			)
+		}
+		return err
+	}
+}

--- a/server/provider/slowrpc_test.go
+++ b/server/provider/slowrpc_test.go
@@ -1,0 +1,164 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func newJSONLogger(buf *bytes.Buffer, lvl slog.Level) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: lvl}))
+}
+
+// decodeRecords returns one map per JSON line written to buf.
+func decodeRecords(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("decode log line %q: %v", line, err)
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+// TestSlowRPCInterceptor_Enabled asserts the Enabled() gate honours
+// threshold/logger preconditions (drives the wiring branch in
+// NewGrpcServerOptions).
+func TestSlowRPCInterceptor_Enabled(t *testing.T) {
+	var buf bytes.Buffer
+	l := newJSONLogger(&buf, slog.LevelWarn)
+
+	cases := []struct {
+		name string
+		s    *SlowRPCInterceptor
+		want bool
+	}{
+		{"nil_receiver", nil, false},
+		{"zero_threshold", NewSlowRPCInterceptor(0, l), false},
+		{"nil_logger", NewSlowRPCInterceptor(time.Millisecond, nil), false},
+		{"enabled", NewSlowRPCInterceptor(time.Millisecond, l), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.s.Enabled(); got != tc.want {
+				t.Errorf("Enabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSlowRPCInterceptor_UnaryFiresOnSlowHandler asserts a single warn
+// line per slow unary RPC with the documented field schema.
+func TestSlowRPCInterceptor_UnaryFiresOnSlowHandler(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newJSONLogger(&buf, slog.LevelWarn)
+	s := NewSlowRPCInterceptor(5*time.Millisecond, logger)
+
+	handler := func(ctx context.Context, req any) (any, error) {
+		time.Sleep(20 * time.Millisecond)
+		return "ok", status.Error(codes.DeadlineExceeded, "boom")
+	}
+	info := &grpc.UnaryServerInfo{FullMethod: "/lantern.v1.Test/Slow"}
+
+	_, err := s.UnaryServerInterceptor()(context.Background(), nil, info, handler)
+	if status.Code(err) != codes.DeadlineExceeded {
+		t.Fatalf("err code = %s, want DeadlineExceeded", status.Code(err))
+	}
+
+	recs := decodeRecords(t, &buf)
+	if len(recs) != 1 {
+		t.Fatalf("got %d log records, want 1", len(recs))
+	}
+	rec := recs[0]
+	if rec["msg"] != "slow rpc" {
+		t.Errorf("msg = %v, want %q", rec["msg"], "slow rpc")
+	}
+	if rec["method"] != info.FullMethod {
+		t.Errorf("method = %v, want %q", rec["method"], info.FullMethod)
+	}
+	if rec["code"] != codes.DeadlineExceeded.String() {
+		t.Errorf("code = %v, want %s", rec["code"], codes.DeadlineExceeded)
+	}
+	if rec["threshold_ms"] != float64(5) {
+		t.Errorf("threshold_ms = %v, want 5", rec["threshold_ms"])
+	}
+	if d, _ := rec["duration_ms"].(float64); d < 5 {
+		t.Errorf("duration_ms = %v, want >= 5", rec["duration_ms"])
+	}
+}
+
+// TestSlowRPCInterceptor_UnarySilentOnFastHandler asserts that handlers
+// completing within the threshold emit no log records.
+func TestSlowRPCInterceptor_UnarySilentOnFastHandler(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newJSONLogger(&buf, slog.LevelWarn)
+	s := NewSlowRPCInterceptor(500*time.Millisecond, logger)
+
+	handler := func(ctx context.Context, req any) (any, error) { return "ok", nil }
+	info := &grpc.UnaryServerInfo{FullMethod: "/lantern.v1.Test/Fast"}
+
+	if _, err := s.UnaryServerInterceptor()(context.Background(), nil, info, handler); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("unexpected log output: %s", buf.String())
+	}
+}
+
+// fakeServerStream lets us drive StreamServerInterceptor without spinning
+// up a real gRPC server.
+type fakeServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (f *fakeServerStream) Context() context.Context { return f.ctx }
+
+// TestSlowRPCInterceptor_StreamFiresOnSlowHandler asserts the stream
+// interceptor mirrors the unary fields and uses ServerStream.Context()
+// for the log record.
+func TestSlowRPCInterceptor_StreamFiresOnSlowHandler(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newJSONLogger(&buf, slog.LevelWarn)
+	s := NewSlowRPCInterceptor(5*time.Millisecond, logger)
+
+	info := &grpc.StreamServerInfo{FullMethod: "/lantern.v1.Test/StreamSlow"}
+	ss := &fakeServerStream{ctx: context.Background()}
+	handler := func(srv any, ss grpc.ServerStream) error {
+		time.Sleep(20 * time.Millisecond)
+		return errors.New("stream boom")
+	}
+
+	err := s.StreamServerInterceptor()(nil, ss, info, handler)
+	// errors.New() wraps as codes.Unknown.
+	if status.Code(err) != codes.Unknown {
+		t.Fatalf("err code = %s, want Unknown", status.Code(err))
+	}
+
+	recs := decodeRecords(t, &buf)
+	if len(recs) != 1 {
+		t.Fatalf("got %d log records, want 1", len(recs))
+	}
+	rec := recs[0]
+	if rec["method"] != info.FullMethod {
+		t.Errorf("method = %v, want %q", rec["method"], info.FullMethod)
+	}
+	if rec["code"] != codes.Unknown.String() {
+		t.Errorf("code = %v, want %s", rec["code"], codes.Unknown)
+	}
+}

--- a/server/replication/antientropy.go
+++ b/server/replication/antientropy.go
@@ -99,6 +99,13 @@ type AntiEntropyConfig struct {
 	// tick will resume from where we stopped.
 	SubscribeTimeout time.Duration
 
+	// GapWarnThreshold escalates the per-peer catch-up log from
+	// info to an additional warn when (peer_seq - local_seq)
+	// exceeds this many mutations. 0 disables the warn (the
+	// info log still fires). The standard catch-up info log is
+	// always emitted regardless of this knob.
+	GapWarnThreshold uint64
+
 	// DialOptions are passed to grpc.NewClient. Defaults to
 	// insecure credentials (in-cluster Tier-A topology).
 	DialOptions []grpc.DialOption
@@ -264,6 +271,12 @@ func (a *AntiEntropy) tickPeer(ctx context.Context, addr string) {
 		slog.Uint64("local_seq", localSeq),
 		slog.Uint64("peer_seq", target),
 		slog.Uint64("gap", gap))
+	if a.cfg.GapWarnThreshold > 0 && gap > a.cfg.GapWarnThreshold {
+		log.Warn("anti-entropy: gap exceeds warn threshold",
+			slog.String("origin", originHex),
+			slog.Uint64("gap", gap),
+			slog.Uint64("threshold", a.cfg.GapWarnThreshold))
+	}
 
 	applied, err := a.catchUp(ctx, cli, peerNID, localSeq+1, target)
 	if err != nil {

--- a/server/replication/pump.go
+++ b/server/replication/pump.go
@@ -289,6 +289,7 @@ func (p *Pump) runPeer(ctx context.Context, addr string) {
 // next attempt, plus any non-nil error (nil means clean ctx-cancel
 // exit).
 func (p *Pump) session(ctx context.Context, addr string, fromSeq uint64) (uint64, error) {
+	log := p.cfg.Logger.With(slog.String("peer", addr))
 	conn, err := grpc.NewClient(addr, p.cfg.DialOptions...)
 	if err != nil {
 		return fromSeq, err
@@ -297,30 +298,60 @@ func (p *Pump) session(ctx context.Context, addr string, fromSeq uint64) (uint64
 	cli := pb.NewLanternReplicationServiceClient(conn)
 
 	p.cfg.Metrics.OnPumpConnect(addr)
+	log.Info("replication pump: peer transition",
+		slog.String("transition", "connect"),
+		slog.Uint64("from_seq", fromSeq))
 
 	next, err := p.subscribe(ctx, cli, addr, fromSeq)
 	if err == nil {
 		p.cfg.Metrics.OnPumpDisconnect(addr, "clean")
+		log.Info("replication pump: peer transition",
+			slog.String("transition", "disconnect"),
+			slog.String("reason", "clean"),
+			slog.Uint64("next_seq", next))
 		return next, nil
 	}
 	if ctx.Err() != nil {
 		p.cfg.Metrics.OnPumpDisconnect(addr, "ctx_cancel")
+		log.Info("replication pump: peer transition",
+			slog.String("transition", "disconnect"),
+			slog.String("reason", "ctx_cancel"))
 		return next, nil
 	}
 	if status.Code(err) == codes.FailedPrecondition {
 		// gapped: snapshot, then resume from cutoff+1.
+		log.Info("replication pump: peer transition",
+			slog.String("transition", "snapshot_start"),
+			slog.String("reason", "gapped"),
+			slog.Uint64("requested_from_seq", fromSeq))
 		cutoff, sErr := p.snapshot(ctx, cli, addr)
 		if sErr != nil {
 			p.cfg.Metrics.OnPumpDisconnect(addr, "snapshot_failed")
+			log.Warn("replication pump: peer transition",
+				slog.String("transition", "snapshot_finish"),
+				slog.String("reason", "snapshot_failed"),
+				slog.Any("err", sErr))
 			return next, sErr
 		}
+		log.Info("replication pump: peer transition",
+			slog.String("transition", "snapshot_finish"),
+			slog.String("reason", "applied"),
+			slog.Uint64("cutoff_seq", cutoff))
 		next, err = p.subscribe(ctx, cli, addr, cutoff+1)
 		if err == nil {
 			p.cfg.Metrics.OnPumpDisconnect(addr, "clean")
+			log.Info("replication pump: peer transition",
+				slog.String("transition", "disconnect"),
+				slog.String("reason", "clean"),
+				slog.Uint64("next_seq", next))
 			return next, nil
 		}
 	}
 	p.cfg.Metrics.OnPumpDisconnect(addr, "subscribe_failed")
+	log.Warn("replication pump: peer transition",
+		slog.String("transition", "disconnect"),
+		slog.String("reason", "subscribe_failed"),
+		slog.Any("err", err))
 	return next, err
 }
 


### PR DESCRIPTION
Closes #223.

Part D of the observability epic (#219): adds five new `slog` channels and two env knobs so operators can grep production without standing up Prometheus.

## What ships

**Env vars (server/README.md)**
- `LANTERN_SLOW_RPC_THRESHOLD_MS` — default 500, 0 disables. Per-RPC warn log when handler exceeds the threshold.
- `LANTERN_ANTI_ENTROPY_GAP_WARN_THRESHOLD` — default 1024, 0 disables. Per-tick warn log when detected gap (seq units) exceeds threshold.

**Structured log channels (5)**
| Message | Level | Trigger | Key attrs |
| --- | --- | --- | --- |
| `slow rpc` | warn | Unary/stream handler exceeds `LANTERN_SLOW_RPC_THRESHOLD_MS` | method, code, duration_ms, threshold_ms |
| `validation rejected` | debug | Validation interceptor returns InvalidArgument | reason, error |
| `graph cache: gc tick` | info | Every `GraphCache.Watch` tick (always fires) | vertices_expired, edges_expired, dangling_edges_removed, vertices_remaining, edges_remaining, duration_ms |
| `anti-entropy: gap exceeds warn threshold` | warn | Per-origin gap exceeds threshold | origin, gap, threshold |
| `replication pump: peer transition` | info/warn | Connect / disconnect / snapshot start / snapshot finish | peer, transition, reason |

**Wiring**
- New `SlowRPCInterceptor` (`server/provider/slowrpc.go`); appended last in unary+stream chains via `NewGrpcServerOptions` when `Enabled()`.
- `ValidationInterceptor.WithLogger(*slog.Logger)` builder; `reject()` emits debug log gated on level.
- New `WireCacheGCHooks(cache, dm, logger) CacheGCHooksWired` exported marker — wire installs the multiplexed pair (metrics + slog) after both DomainMetrics and the logger are constructed. `newApp` accepts the marker so wire enforces ordering.
- `AntiEntropyConfig.GapWarnThreshold` plumbed end-to-end.
- `peerPump.session()` emits one structured `peer transition` line per state change.

## Spec deviation

GC tick log uses post-tick `cache.VertexCount()`/`EdgeCount()` as `vertices_remaining`/`edges_remaining`. The original spec asked for `*_scanned` but `GraphCache` does not expose scan counts to its hooks — the post-tick population count is the closest operationally useful equivalent.

## Misc
- slog gotcha caught in test: `slog.String("msg", ...)` collides with built-in `Record.Message` and the JSON handler overwrites it. Renamed to `error`.

## Tests
- `server/provider/slowrpc_test.go` (new 1:1 pair per AGENTS.md rule 1) — 4 cases.
- `server/provider/extra_test.go` (appended per rule 9) — 3 cases covering `WithLogger` debug/info/nil paths.
- `server/provider/provider_test.go` — drives a real `Watch` tick and asserts the `graph cache: gc tick` record contains all 6 documented fields.

## Quality gates
- `gofmt -l . cli core pb sdks server tests` ✓ (empty)
- `(cd server && go vet ./... && go test ./...)` ✓
- `go test ./...` (root + core + pb + sdks/go) ✓
