### PR TITLE
pubsub: fix lastViewedAt stamping, Nack semantics, Subscribe re-entry

### DIFF
--- a/core/concurrent/pubsub/message.go
+++ b/core/concurrent/pubsub/message.go
@@ -28,10 +28,16 @@ func (m *Message[T]) CreatedAt() time.Time {
 	return m.createdAt
 }
 
+// Ack marks the message as successfully processed and removes it from the
+// subscription's in-flight set, so the salvage path will no longer try to
+// redeliver it.
 func (m *Message[T]) Ack() {
 	m.subscription.ack(m)
 }
 
+// Nack signals that processing failed and the message should be retried.
+// The message is re-queued immediately on the subscription channel; the
+// salvage timer is not involved.
 func (m *Message[T]) Nack() {
 	m.subscription.nack(m)
 }

--- a/core/concurrent/pubsub/subscription.go
+++ b/core/concurrent/pubsub/subscription.go
@@ -3,6 +3,7 @@ package pubsub
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/anaregdesign/lantern/core/model/function"
@@ -13,6 +14,7 @@ import (
 type Subscription[T any] struct {
 	mu          sync.RWMutex
 	wg          sync.WaitGroup
+	started     atomic.Bool
 	name        string
 	topic       *Topic[T]
 	ch          chan string
@@ -30,7 +32,19 @@ func (s *Subscription[T]) Topic() *Topic[T] {
 	return s.topic
 }
 
+// Subscribe drains the subscription queue and dispatches messages to consumer
+// until ctx is cancelled. It is single-flight per *Subscription: concurrent or
+// reentrant calls return immediately without dispatching. After Subscribe
+// returns (ctx done) the subscription may be Subscribe'd to again.
 func (s *Subscription[T]) Subscribe(ctx context.Context, consumer function.Consumer[*Message[T]]) {
+	if !s.started.CompareAndSwap(false, true) {
+		// Another goroutine already owns the dispatcher for this
+		// subscription; the second caller's ch reads would steal messages
+		// from the first. Refuse silently and let the first finish.
+		return
+	}
+	defer s.started.Store(false)
+
 	sem := semaphore.NewWeighted(int64(s.concurrency))
 	s.register()
 	go s.watch(ctx, s.interval, s.ttl)
@@ -38,7 +52,7 @@ func (s *Subscription[T]) Subscribe(ctx context.Context, consumer function.Consu
 	for {
 		select {
 		case id := <-s.ch:
-			message := s.message(id)
+			message := s.dispatch(id)
 			if message == nil {
 				// Already acked (e.g. salvaged past TTL) between publish and lookup.
 				continue
@@ -87,6 +101,23 @@ func (s *Subscription[T]) message(id string) *Message[T] {
 	return s.messages[id]
 }
 
+// dispatch atomically looks up id and stamps lastViewedAt so the salvage path
+// can tell whether the message has been recently handed to a consumer. It is
+// the only correct way for the Subscribe loop to take a message off s.ch; a
+// plain message() read leaves lastViewedAt at the zero value forever, which
+// makes salvage re-push the same id every interval tick (#229).
+func (s *Subscription[T]) dispatch(id string) *Message[T] {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	m, ok := s.messages[id]
+	if !ok {
+		return nil
+	}
+	m.lastViewedAt = time.Now()
+	return m
+}
+
 func (s *Subscription[T]) publish(message *Message[T]) {
 	s.mu.Lock()
 	s.messages[message.id] = message
@@ -105,6 +136,10 @@ func (s *Subscription[T]) ack(message *Message[T]) {
 }
 
 func (s *Subscription[T]) nack(message *Message[T]) {
+	// Re-queue immediately so the consumer can retry without waiting for the
+	// salvage interval. The message stays in s.messages (no ack), so a
+	// subsequent salvage tick will also still see it.
+	s.remind(message)
 }
 
 func (s *Subscription[T]) remind(message *Message[T]) {

--- a/core/concurrent/pubsub/subscription_test.go
+++ b/core/concurrent/pubsub/subscription_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"github.com/anaregdesign/lantern/core/model/function"
 	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -134,6 +136,7 @@ func TestSubscription_nack(t *testing.T) {
 			name: "TestSubscription_nack",
 			s: Subscription[int]{
 				name: "test",
+				ch:   make(chan string, 1),
 				messages: map[string]*Message[int]{
 					"uuid": {id: "uuid", body: 1},
 				},
@@ -145,6 +148,14 @@ func TestSubscription_nack(t *testing.T) {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			tt.s.nack(tt.args.message)
+			select {
+			case id := <-tt.s.ch:
+				if id != tt.args.message.id {
+					t.Fatalf("nack should requeue id %q, got %q", tt.args.message.id, id)
+				}
+			default:
+				t.Fatal("nack should requeue the message on s.ch")
+			}
 		})
 	}
 }
@@ -347,5 +358,130 @@ func TestSubscription_watch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			go tt.s.watch(tt.args.ctx, tt.args.interval, tt.args.ttl)
 		})
+	}
+}
+
+// TestSubscription_SalvageRespectsLastViewedAt is a regression test for #229.
+// salvage previously re-published every in-flight message every tick because
+// Message.lastViewedAt was never written, so now.Sub(zeroTime) > interval was
+// always true. This test exercises the read path (dispatch) directly and then
+// invokes salvage() so the assertion is independent of goroutine scheduling.
+func TestSubscription_SalvageRespectsLastViewedAt(t *testing.T) {
+	topic := NewTopic[int]("t")
+	sub := topic.NewSubscription("s", 1, 50*time.Millisecond, time.Hour)
+
+	// Publish without a Subscribe loop: the message is parked in s.messages
+	// and its id sits on s.ch. Drain s.ch manually so a later remind() can
+	// observe whether salvage re-queued it.
+	topic.Publish(7)
+	id := <-sub.ch
+
+	// Simulate a consumer pickup: dispatch must stamp lastViewedAt.
+	m := sub.dispatch(id)
+	if m == nil {
+		t.Fatalf("dispatch returned nil for id %q (message missing from map)", id)
+	}
+	if m.lastViewedAt.IsZero() {
+		t.Fatal("dispatch must stamp lastViewedAt; got zero (regression #229)")
+	}
+
+	// salvage interval is 50ms; we just dispatched so the message is fresh.
+	// Bug: lastViewedAt would be zero, predicate true, message re-queued.
+	// Fix: predicate false, ch stays empty.
+	sub.salvage(50*time.Millisecond, time.Hour)
+
+	select {
+	case stray := <-sub.ch:
+		t.Fatalf("salvage re-queued a freshly-viewed message (id=%q); lastViewedAt stamping broken", stray)
+	default:
+	}
+}
+
+// TestSubscription_NackTriggersImmediateRedelivery is a regression test for
+// #229. Before the fix, Nack() was a silent no-op so the message would only
+// be retried after the salvage interval elapsed (and even then, only because
+// of the lastViewedAt bug). The new contract: Nack re-queues immediately.
+func TestSubscription_NackTriggersImmediateRedelivery(t *testing.T) {
+	topic := NewTopic[int]("t")
+	// Long interval — we want to assert that redelivery is driven by Nack,
+	// not by the salvage timer.
+	sub := topic.NewSubscription("s", 1, time.Hour, time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var attempt atomic.Int64
+	done := make(chan struct{})
+	go sub.Subscribe(ctx, func(m *Message[int]) {
+		n := attempt.Add(1)
+		switch n {
+		case 1:
+			m.Nack()
+		case 2:
+			m.Ack()
+			close(done)
+		}
+	})
+
+	// Allow Subscribe to start before publishing.
+	time.Sleep(20 * time.Millisecond)
+	topic.Publish(1)
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("Nack did not redeliver within 500ms (attempts=%d)", attempt.Load())
+	}
+}
+
+// TestSubscription_SubscribeIsSingleFlight is a regression test for #229.
+// Two concurrent Subscribe calls on the same *Subscription previously shared
+// s.ch / s.wg silently, producing nondeterministic delivery split across two
+// consumer functions. The new contract: the second concurrent call is a
+// no-op (returns immediately).
+func TestSubscription_SubscribeIsSingleFlight(t *testing.T) {
+	topic := NewTopic[int]("t")
+	sub := topic.NewSubscription("s", 1, time.Hour, time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		mu          sync.Mutex
+		consumerHit = map[string]int{"primary": 0, "secondary": 0}
+	)
+	consumer := func(label string) function.Consumer[*Message[int]] {
+		return func(m *Message[int]) {
+			mu.Lock()
+			consumerHit[label]++
+			mu.Unlock()
+			m.Ack()
+		}
+	}
+
+	go sub.Subscribe(ctx, consumer("primary"))
+	go sub.Subscribe(ctx, consumer("secondary"))
+
+	// Let both Subscribe calls race to register before publishing.
+	time.Sleep(20 * time.Millisecond)
+
+	const N = 20
+	for i := 0; i < N; i++ {
+		topic.Publish(i)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	total := consumerHit["primary"] + consumerHit["secondary"]
+	if total != N {
+		t.Fatalf("expected %d total deliveries, got %d (primary=%d secondary=%d)",
+			N, total, consumerHit["primary"], consumerHit["secondary"])
+	}
+	// The second Subscribe call must have observed exactly zero messages.
+	if consumerHit["primary"] != 0 && consumerHit["secondary"] != 0 {
+		t.Fatalf("expected single-flight Subscribe; both consumers received messages (primary=%d secondary=%d)",
+			consumerHit["primary"], consumerHit["secondary"])
 	}
 }


### PR DESCRIPTION
Closes #229.

## What

Three correctness fixes in `core/concurrent/pubsub`, with one regression test per fix appended to `subscription_test.go`.

### 1. `Message.lastViewedAt` was never written
`Subscribe` was reading ids from `s.ch` and looking up the message via the read-locked `message(id)`, which never stamped `lastViewedAt`. The watchdog's `salvage` then evaluated `now.Sub(zeroTime) > interval`, which is always true, and re-pushed every in-flight id every tick — saturating the channel under sustained publishing.

Fix: new `dispatch(id)` method stamps `lastViewedAt` under a write-lock and is the only path `Subscribe` uses. `message(id)` is retained (used by existing tests) but no longer on the read path.

### 2. `Nack()` was a silent no-op
`(*Subscription).nack` had an empty body, so calling `Message.Nack()` did nothing — the consumer just leaked the in-flight message until the salvage timer fired (and even then only because of bug #1).

Fix: `nack` now calls `remind` to immediately re-queue the id on `s.ch`. Godoc on `Message.Ack`/`Message.Nack` documents the new contract.

### 3. `Subscribe` had no re-entry guard
Two concurrent `Subscribe` calls on the same `*Subscription` would both read from the shared `s.ch` and `s.wg`, stealing each other's messages and starting two watchdogs.

Fix: `started atomic.Bool` with CAS guard at the top of `Subscribe`; second callers return silently. The guard resets on `ctx.Done` so the subscription can be re-Subscribe'd after cancellation.

## Tests

Appended to `subscription_test.go` (per AGENTS.md rule 9 — no sibling files):
- `TestSubscription_SalvageRespectsLastViewedAt` — drives `dispatch` + `salvage` directly, asserts no re-queue after a fresh view.
- `TestSubscription_NackTriggersImmediateRedelivery` — asserts the second delivery arrives within 500ms (Nack-driven, not salvage-driven).
- `TestSubscription_SubscribeIsSingleFlight` — spawns two `Subscribe` goroutines, publishes N messages, asserts exactly N total deliveries and that one consumer received 0.

The existing `TestSubscription_nack` was updated to expect requeue on `s.ch` (it previously asserted the no-op).

## Verification

- `go test ./concurrent/pubsub/ -race` ✅
- gofmt clean across `cli core pb sdks server tests`
- Per-module `go test ./...` green: root, core, pb, sdks/go, server.

## Out of scope (sub-issues from #228)

- #230 Publish fan-out
- #231 Hot-path throughput (uint64 IDs, sync.Pool, worker-pool)
- #232 Salvage min-heap + functional-options API