### PR TITLE
pubsub: fan-out Publish concurrently per subscription

### DIFF
--- a/core/concurrent/pubsub/topic.go
+++ b/core/concurrent/pubsub/topic.go
@@ -2,6 +2,7 @@ package pubsub
 
 import (
 	"maps"
+	"slices"
 	"sync"
 	"time"
 )
@@ -31,17 +32,28 @@ func (t *Topic[T]) Subscriptions() map[string]*Subscription[T] {
 	return maps.Clone(t.subscriptions)
 }
 
+// Publish performs best-effort concurrent fan-out: each subscription receives
+// the message on its own goroutine, so a single slow or saturated subscriber
+// cannot block delivery to its peers (#230). Delivery order across
+// subscriptions is unspecified, matching the prior map-iteration behavior.
+//
+// Publish returns immediately after scheduling the fan-out goroutines; it does
+// not wait for each subscription's channel send to complete. This trades
+// synchronous backpressure (which no caller currently observes) for
+// independence between subscribers. The pattern is intended for topics with
+// tens of subscribers; if you need to fan out to thousands, prefer a
+// long-lived per-subscription delivery goroutine instead.
 func (t *Topic[T]) Publish(body T) {
 	t.mu.RLock()
-	subs := make([]*Subscription[T], 0, len(t.subscriptions))
-	for _, s := range t.subscriptions {
-		subs = append(subs, s)
-	}
+	subs := slices.Collect(maps.Values(t.subscriptions))
 	t.mu.RUnlock()
 
 	for _, s := range subs {
-		message := s.newMessage(body)
-		s.publish(message)
+		s := s
+		go func() {
+			m := s.newMessage(body)
+			s.publish(m)
+		}()
 	}
 }
 

--- a/core/concurrent/pubsub/topic_test.go
+++ b/core/concurrent/pubsub/topic_test.go
@@ -1,7 +1,10 @@
 package pubsub
 
 import (
+	"context"
 	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -215,5 +218,82 @@ func TestTopic_unregister(t1 *testing.T) {
 		t1.Run(tt.name, func(t1 *testing.T) {
 			tt.t.unregister(tt.args.subscription)
 		})
+	}
+}
+
+// TestTopic_PublishFansOutWithoutBlocking pins #230: a slow / saturated
+// subscriber must not block delivery to its peers. We construct two
+// subscriptions with a single-slot channel each, fill subA's channel so any
+// further send to it would block, then assert subB still receives within a
+// short deadline. On main (sequential Publish) subA's blocked send hangs
+// Publish forever and this test times out.
+func TestTopic_PublishFansOutWithoutBlocking(t *testing.T) {
+	topic := NewTopic[int]("fanout")
+
+	subA := &Subscription[int]{
+		name:     "a",
+		topic:    topic,
+		ch:       make(chan string, 1),
+		messages: make(map[string]*Message[int]),
+	}
+	subB := &Subscription[int]{
+		name:     "b",
+		topic:    topic,
+		ch:       make(chan string, 1),
+		messages: make(map[string]*Message[int]),
+	}
+	topic.register(subA)
+	topic.register(subB)
+
+	// Saturate subA so any further send would block forever.
+	subA.ch <- "blocker"
+
+	topic.Publish(42)
+
+	select {
+	case <-subB.ch:
+		// expected: subB received despite subA being blocked.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Publish blocked on saturated subA; subB did not receive within 500ms")
+	}
+}
+
+// TestTopic_PublishConcurrentSafe drives N concurrent Publish callers against
+// a single subscriber and asserts every message is delivered exactly once with
+// no deadlock. Guards against races introduced by the goroutine-per-Publish
+// fan-out (#230).
+func TestTopic_PublishConcurrentSafe(t *testing.T) {
+	const N = 100
+
+	topic := NewTopic[int]("concurrent")
+	sub := topic.NewSubscription("c", 8, time.Hour, time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var received atomic.Int64
+	done := make(chan struct{})
+	go sub.Subscribe(ctx, func(m *Message[int]) {
+		m.Ack()
+		if received.Add(1) == int64(N) {
+			close(done)
+		}
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(v int) {
+			defer wg.Done()
+			topic.Publish(v)
+		}(i)
+	}
+	wg.Wait()
+
+	select {
+	case <-done:
+		// good: N messages delivered.
+	case <-time.After(2 * time.Second):
+		t.Fatalf("only %d/%d messages delivered before timeout", received.Load(), N)
 	}
 }


### PR DESCRIPTION
Closes #230.

## What

Replace the sequential delivery loop in `Topic.Publish` with a per-subscription goroutine so a single slow / saturated subscriber cannot block delivery to its peers. The previous loop ended in `s.publish(message)` → `s.ch <- id`; when one subscriber's channel was full, Publish hung there forever and every subsequent subscriber missed the message.

## Tests

Both appended to `topic_test.go`:

- **TestTopic_PublishFansOutWithoutBlocking** — pins the bug: two subscriptions with a 1-slot channel each; subA is pre-saturated; Publish must still hand the message to subB within 500ms. Fails on `main` (deadlocks → test timeout).
- **TestTopic_PublishConcurrentSafe** — N=100 concurrent Publish callers against one consumer; asserts all N delivered exactly once with no deadlock under `-race`.

## Verification

```
gofmt -l . cli core pb sdks server tests   # clean
go test ./...                              # all 5 modules green
go test ./concurrent/pubsub/ -count=1 -race -timeout=60s   # ok 1.601s
```

## Trade-offs (documented in Publish godoc)

- Goroutine cost per Publish is acceptable for topics with tens of subscribers (best-effort fan-out). If a real workload fans out to thousands, a long-lived per-subscription delivery goroutine is the natural next step — left as future work.
- Delivery order across subscriptions was already unspecified (map iteration); fan-out preserves that contract.
- Publish becomes non-blocking. No caller observes the prior synchronous backpressure today, so this only relaxes constraints.

## Out of scope

- Hot-path throughput (#231) — uint64 IDs, sync.Pool, worker-pool.
- Salvage min-heap + functional options (#232).