### PR TITLE
pubsub: uint64 IDs + sync.Pool + worker-pool consumer

### DIFF
--- a/core/concurrent/pubsub/message.go
+++ b/core/concurrent/pubsub/message.go
@@ -5,14 +5,17 @@ import (
 )
 
 type Message[T any] struct {
-	id           string
+	id           uint64
 	body         T
 	subscription *Subscription[T]
 	lastViewedAt time.Time
 	createdAt    time.Time
 }
 
-func (m *Message[T]) ID() string {
+// ID returns the message's per-subscription monotonic identifier. IDs are
+// unique within a single *Subscription but not across subscriptions or across
+// process restarts (#231 — replaced the prior UUID string for hot-path cost).
+func (m *Message[T]) ID() uint64 {
 	return m.id
 }
 
@@ -31,6 +34,10 @@ func (m *Message[T]) CreatedAt() time.Time {
 // Ack marks the message as successfully processed and removes it from the
 // subscription's in-flight set, so the salvage path will no longer try to
 // redeliver it.
+//
+// After Ack (or Nack), the receiver must not be retained: the *Message[T] is
+// returned to a sync.Pool and may be reused by a later Publish (#231). Read
+// any fields you need before calling Ack/Nack.
 func (m *Message[T]) Ack() {
 	m.subscription.ack(m)
 }
@@ -38,6 +45,9 @@ func (m *Message[T]) Ack() {
 // Nack signals that processing failed and the message should be retried.
 // The message is re-queued immediately on the subscription channel; the
 // salvage timer is not involved.
+//
+// After Nack returns the receiver may be re-dispatched concurrently to
+// another worker. Do not retain it. See Ack for the pooling contract.
 func (m *Message[T]) Nack() {
 	m.subscription.nack(m)
 }

--- a/core/concurrent/pubsub/message_test.go
+++ b/core/concurrent/pubsub/message_test.go
@@ -59,15 +59,15 @@ func TestMessage_ID(t *testing.T) {
 	type testCase[T any] struct {
 		name string
 		m    Message[T]
-		want string
+		want uint64
 	}
 	tests := []testCase[int]{
 		{
 			name: "TestMessage_ID",
 			m: Message[int]{
-				id: "uuid",
+				id: 42,
 			},
-			want: "uuid",
+			want: 42,
 		},
 	}
 	for _, tt := range tests {

--- a/core/concurrent/pubsub/subscription.go
+++ b/core/concurrent/pubsub/subscription.go
@@ -7,18 +7,18 @@ import (
 	"time"
 
 	"github.com/anaregdesign/lantern/core/model/function"
-	"github.com/google/uuid"
-	"golang.org/x/sync/semaphore"
 )
 
 type Subscription[T any] struct {
 	mu          sync.RWMutex
 	wg          sync.WaitGroup
 	started     atomic.Bool
+	nextID      atomic.Uint64
 	name        string
 	topic       *Topic[T]
-	ch          chan string
-	messages    map[string]*Message[T]
+	ch          chan uint64
+	messages    map[uint64]*Message[T]
+	pool        sync.Pool
 	concurrency int
 	interval    time.Duration
 	ttl         time.Duration
@@ -36,6 +36,11 @@ func (s *Subscription[T]) Topic() *Topic[T] {
 // until ctx is cancelled. It is single-flight per *Subscription: concurrent or
 // reentrant calls return immediately without dispatching. After Subscribe
 // returns (ctx done) the subscription may be Subscribe'd to again.
+//
+// Concurrency is enforced by a fixed worker pool of size s.concurrency that
+// drains s.ch directly (#231). The prior model of one goroutine per message,
+// gated by a sync semaphore, allocated a goroutine and paid a sync.Cond
+// wake-up on every Publish; the worker pool amortises both costs to zero.
 func (s *Subscription[T]) Subscribe(ctx context.Context, consumer function.Consumer[*Message[T]]) {
 	if !s.started.CompareAndSwap(false, true) {
 		// Another goroutine already owns the dispatcher for this
@@ -45,36 +50,36 @@ func (s *Subscription[T]) Subscribe(ctx context.Context, consumer function.Consu
 	}
 	defer s.started.Store(false)
 
-	sem := semaphore.NewWeighted(int64(s.concurrency))
 	s.register()
 	go s.watch(ctx, s.interval, s.ttl)
 
-	for {
-		select {
-		case id := <-s.ch:
-			message := s.dispatch(id)
-			if message == nil {
-				// Already acked (e.g. salvaged past TTL) between publish and lookup.
-				continue
-			}
-
-			s.wg.Add(1)
-			if err := sem.Acquire(ctx, 1); err != nil {
-				s.wg.Done()
-				continue
-			}
-			go func(m *Message[T]) {
-				defer sem.Release(1)
-				defer s.wg.Done()
-				consumer(m)
-			}(message)
-
-		case <-ctx.Done():
-			s.wg.Wait()
-			s.unregister()
-			return
-		}
+	workers := s.concurrency
+	if workers < 1 {
+		workers = 1
 	}
+	for i := 0; i < workers; i++ {
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			for {
+				select {
+				case id := <-s.ch:
+					m := s.dispatch(id)
+					if m == nil {
+						// Already acked (e.g. salvaged past TTL) between publish and lookup.
+						continue
+					}
+					consumer(m)
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	<-ctx.Done()
+	s.wg.Wait()
+	s.unregister()
 }
 
 func (s *Subscription[T]) register() {
@@ -85,16 +90,24 @@ func (s *Subscription[T]) unregister() {
 	s.topic.unregister(s)
 }
 
+// newMessage allocates (or recycles) a *Message[T] for body. Envelopes come
+// from s.pool to keep the hot path allocation-free (#231); ack returns them
+// after the map delete. The id is a per-Subscription monotonic counter, which
+// is sufficient because the messages map is per-subscription.
 func (s *Subscription[T]) newMessage(body T) *Message[T] {
-	return &Message[T]{
-		id:           uuid.New().String(),
-		body:         body,
-		subscription: s,
-		createdAt:    time.Now(),
+	m, _ := s.pool.Get().(*Message[T])
+	if m == nil {
+		m = &Message[T]{}
 	}
+	m.id = s.nextID.Add(1)
+	m.body = body
+	m.subscription = s
+	m.createdAt = time.Now()
+	m.lastViewedAt = time.Time{}
+	return m
 }
 
-func (s *Subscription[T]) message(id string) *Message[T] {
+func (s *Subscription[T]) message(id uint64) *Message[T] {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -106,7 +119,7 @@ func (s *Subscription[T]) message(id string) *Message[T] {
 // the only correct way for the Subscribe loop to take a message off s.ch; a
 // plain message() read leaves lastViewedAt at the zero value forever, which
 // makes salvage re-push the same id every interval tick (#229).
-func (s *Subscription[T]) dispatch(id string) *Message[T] {
+func (s *Subscription[T]) dispatch(id uint64) *Message[T] {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -130,9 +143,15 @@ func (s *Subscription[T]) publish(message *Message[T]) {
 
 func (s *Subscription[T]) ack(message *Message[T]) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	delete(s.messages, message.id)
+	s.mu.Unlock()
+
+	// Return the envelope to the pool. The consumer contract on Message.Ack
+	// is "do not retain after Ack" (#231); zero the body so a stale
+	// reference cannot keep a large T alive.
+	var zero T
+	message.body = zero
+	s.pool.Put(message)
 }
 
 func (s *Subscription[T]) nack(message *Message[T]) {

--- a/core/concurrent/pubsub/subscription_test.go
+++ b/core/concurrent/pubsub/subscription_test.go
@@ -107,11 +107,11 @@ func TestSubscription_ack(t *testing.T) {
 			name: "TestSubscription_ack",
 			s: Subscription[int]{
 				name: "test",
-				messages: map[string]*Message[int]{
-					"uuid": {id: "uuid", body: 1},
+				messages: map[uint64]*Message[int]{
+					1: {id: 1, body: 1},
 				},
 			},
-			args: args[int]{message: &Message[int]{id: "uuid", body: 1}},
+			args: args[int]{message: &Message[int]{id: 1, body: 1}},
 		},
 	}
 	for i := range tests {
@@ -136,12 +136,12 @@ func TestSubscription_nack(t *testing.T) {
 			name: "TestSubscription_nack",
 			s: Subscription[int]{
 				name: "test",
-				ch:   make(chan string, 1),
-				messages: map[string]*Message[int]{
-					"uuid": {id: "uuid", body: 1},
+				ch:   make(chan uint64, 1),
+				messages: map[uint64]*Message[int]{
+					1: {id: 1, body: 1},
 				},
 			},
-			args: args[int]{message: &Message[int]{id: "uuid", body: 1}},
+			args: args[int]{message: &Message[int]{id: 1, body: 1}},
 		},
 	}
 	for i := range tests {
@@ -151,7 +151,7 @@ func TestSubscription_nack(t *testing.T) {
 			select {
 			case id := <-tt.s.ch:
 				if id != tt.args.message.id {
-					t.Fatalf("nack should requeue id %q, got %q", tt.args.message.id, id)
+					t.Fatalf("nack should requeue id %d, got %d", tt.args.message.id, id)
 				}
 			default:
 				t.Fatal("nack should requeue the message on s.ch")
@@ -204,10 +204,10 @@ func TestSubscription_publish(t *testing.T) {
 			name: "TestSubscription_publish",
 			s: Subscription[int]{
 				name:     "test",
-				ch:       make(chan string, 10),
-				messages: map[string]*Message[int]{},
+				ch:       make(chan uint64, 10),
+				messages: map[uint64]*Message[int]{},
 			},
-			args: args[int]{message: &Message[int]{id: "uuid", body: 1}},
+			args: args[int]{message: &Message[int]{id: 1, body: 1}},
 		},
 	}
 	for i := range tests {
@@ -257,12 +257,12 @@ func TestSubscription_remind(t *testing.T) {
 			name: "TestSubscription_remind",
 			s: Subscription[int]{
 				name: "test",
-				ch:   make(chan string, 10),
-				messages: map[string]*Message[int]{
-					"uuid": {id: "uuid", body: 1},
+				ch:   make(chan uint64, 10),
+				messages: map[uint64]*Message[int]{
+					1: {id: 1, body: 1},
 				},
 			},
-			args: args[int]{message: &Message[int]{id: "uuid", body: 1}},
+			args: args[int]{message: &Message[int]{id: 1, body: 1}},
 		},
 	}
 	for i := range tests {
@@ -288,9 +288,9 @@ func TestSubscription_salvage(t *testing.T) {
 			name: "TestSubscription_salvage",
 			s: Subscription[int]{
 				name: "test",
-				ch:   make(chan string, 10),
-				messages: map[string]*Message[int]{
-					"uuid": {id: "uuid", body: 1},
+				ch:   make(chan uint64, 10),
+				messages: map[uint64]*Message[int]{
+					1: {id: 1, body: 1},
 				},
 			},
 			args: args{interval: time.Second, ttl: time.Second},
@@ -379,7 +379,7 @@ func TestSubscription_SalvageRespectsLastViewedAt(t *testing.T) {
 	// Simulate a consumer pickup: dispatch must stamp lastViewedAt.
 	m := sub.dispatch(id)
 	if m == nil {
-		t.Fatalf("dispatch returned nil for id %q (message missing from map)", id)
+		t.Fatalf("dispatch returned nil for id %d (message missing from map)", id)
 	}
 	if m.lastViewedAt.IsZero() {
 		t.Fatal("dispatch must stamp lastViewedAt; got zero (regression #229)")
@@ -392,7 +392,7 @@ func TestSubscription_SalvageRespectsLastViewedAt(t *testing.T) {
 
 	select {
 	case stray := <-sub.ch:
-		t.Fatalf("salvage re-queued a freshly-viewed message (id=%q); lastViewedAt stamping broken", stray)
+		t.Fatalf("salvage re-queued a freshly-viewed message (id=%d); lastViewedAt stamping broken", stray)
 	default:
 	}
 }
@@ -484,4 +484,65 @@ func TestSubscription_SubscribeIsSingleFlight(t *testing.T) {
 		t.Fatalf("expected single-flight Subscribe; both consumers received messages (primary=%d secondary=%d)",
 			consumerHit["primary"], consumerHit["secondary"])
 	}
+}
+
+// BenchmarkSubscription_PublishConsumeUint64 measures the Publish→consume hot
+// path after the #231 throughput refactor (uint64 IDs, sync.Pool envelopes,
+// fixed worker pool). Compare against the pre-#231 baseline captured in the
+// PR body using benchstat.
+func BenchmarkSubscription_PublishConsumeUint64(b *testing.B) {
+	topic := NewTopic[int]("bench")
+	sub := topic.NewSubscription("s", 4, time.Hour, time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var done sync.WaitGroup
+	done.Add(b.N)
+	go sub.Subscribe(ctx, func(m *Message[int]) {
+		m.Ack()
+		done.Done()
+	})
+
+	// Let workers start before timing.
+	time.Sleep(10 * time.Millisecond)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		topic.Publish(i)
+	}
+	done.Wait()
+	b.StopTimer()
+}
+
+// BenchmarkSubscription_PublishConsumeUint64Parallel amortizes per-publish
+// goroutine spawn (introduced for fan-out safety in #230) across producer
+// goroutines, isolating the consumer-side wins from #231 (pool + worker
+// pool). This is the bench whose ratio the PR body cites for the ≥ 2x goal.
+func BenchmarkSubscription_PublishConsumeUint64Parallel(b *testing.B) {
+	topic := NewTopic[int]("bench")
+	sub := topic.NewSubscription("s", 4, time.Hour, time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var done sync.WaitGroup
+	done.Add(b.N)
+	go sub.Subscribe(ctx, func(m *Message[int]) {
+		m.Ack()
+		done.Done()
+	})
+
+	time.Sleep(10 * time.Millisecond)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			topic.Publish(i)
+			i++
+		}
+	})
+	done.Wait()
+	b.StopTimer()
 }

--- a/core/concurrent/pubsub/topic.go
+++ b/core/concurrent/pubsub/topic.go
@@ -65,8 +65,8 @@ func (t *Topic[T]) NewSubscription(name string, concurrency int, interval time.D
 		t.subscriptions[name] = &Subscription[T]{
 			name:        name,
 			topic:       t,
-			ch:          make(chan string, 65536),
-			messages:    make(map[string]*Message[T]),
+			ch:          make(chan uint64, 65536),
+			messages:    make(map[uint64]*Message[T]),
 			concurrency: concurrency,
 			interval:    interval,
 			ttl:         ttl,

--- a/core/concurrent/pubsub/topic_test.go
+++ b/core/concurrent/pubsub/topic_test.go
@@ -90,8 +90,8 @@ func TestTopic_NewSubscription(t1 *testing.T) {
 			want: &Subscription[int]{
 				name:        "test",
 				concurrency: 8,
-				ch:          make(chan string, 65536),
-				messages:    make(map[string]*Message[int]),
+				ch:          make(chan uint64, 65536),
+				messages:    make(map[uint64]*Message[int]),
 				interval:    time.Minute,
 				ttl:         time.Minute,
 				topic:       topic,
@@ -233,20 +233,20 @@ func TestTopic_PublishFansOutWithoutBlocking(t *testing.T) {
 	subA := &Subscription[int]{
 		name:     "a",
 		topic:    topic,
-		ch:       make(chan string, 1),
-		messages: make(map[string]*Message[int]),
+		ch:       make(chan uint64, 1),
+		messages: make(map[uint64]*Message[int]),
 	}
 	subB := &Subscription[int]{
 		name:     "b",
 		topic:    topic,
-		ch:       make(chan string, 1),
-		messages: make(map[string]*Message[int]),
+		ch:       make(chan uint64, 1),
+		messages: make(map[uint64]*Message[int]),
 	}
 	topic.register(subA)
 	topic.register(subB)
 
 	// Saturate subA so any further send would block forever.
-	subA.ch <- "blocker"
+	subA.ch <- 0
 
 	topic.Publish(42)
 

--- a/core/go.mod
+++ b/core/go.mod
@@ -2,7 +2,4 @@ module github.com/anaregdesign/lantern/core
 
 go 1.26
 
-require (
-	github.com/google/uuid v1.6.0
-	golang.org/x/sync v0.20.0
-)
+require golang.org/x/sync v0.20.0

--- a/core/go.sum
+++ b/core/go.sum
@@ -1,4 +1,2 @@
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=


### PR DESCRIPTION
Closes #231. Part of #228 epic (#229 ✓, #230 ✓, #231 = this PR, #232 next).

## What

Three coupled hot-path changes in `core/concurrent/pubsub`:

1. **uint64 monotonic IDs.** `Subscription[T]` now holds an `atomic.Uint64` counter; `s.ch` is `chan uint64`, `s.messages` is `map[uint64]*Message[T]`. The `google/uuid` dependency is dropped from this package — IDs only need to be unique per Subscription (the map is per-sub).
2. **sync.Pool[*Message[T]] envelopes.** `newMessage` checks out from a per-Subscription pool and stamps id/body/timestamps; `ack` returns to the pool after the map delete. Documented contract on `Ack`/`Nack` godoc: **receivers must not retain `*Message` past Ack/Nack** — pool reuse means the pointer may alias a later Publish.
3. **Worker-pool consumer.** `Subscribe` spawns `s.concurrency` long-lived worker goroutines that loop on `s.ch`. The `semaphore.Acquire` + `go func()-per-message` model is gone. `golang.org/x/sync/semaphore` is no longer used by this package. Concurrency cap is now enforced structurally by worker count.

## Tests

- All existing tests updated for `uint64` IDs (`message_test.go`, `subscription_test.go`, `topic_test.go`) and pass under `-race -count=1`.
- Added `BenchmarkSubscription_PublishConsumeUint64` and `...Parallel` per #231 spec, appended to `subscription_test.go` (AGENTS.md rule 9: no sibling `_bench_test.go`).

## Verification

```
gofmt -l . cli core pb sdks server tests   # clean
(cd core && go test ./... -count=1)         # ok
(cd . && go test ./... -count=1)            # ok
(cd pb && go test ./... -count=1)           # ok
(cd sdks/go && go test ./... -count=1)      # ok
(cd server && go test ./... -count=1 && go vet ./...)  # ok
(cd core/concurrent/pubsub && go test -race -count=1 ./...)  # ok
```

### Benchmark (M3 Max, 5 runs, benchstat)

```
                                             │ baseline (main) │     after (#231)     │
                                             │     sec/op      │  sec/op    vs base   │
Subscription_PublishConsumeUint64-16              2.092µ ± ∞ ¹   1.390µ ± ∞ ¹  -33.56%
Subscription_PublishConsumeUint64Parallel-16      2.136µ ± ∞ ¹   1.392µ ± ∞ ¹  -34.83%
geomean                                           2.114µ         1.391µ        -34.20%
```

## Trade-offs

- **2x target not met (~1.5x measured).** The mandatory per-publish fan-out goroutine introduced in #230 (one goroutine per subscriber per Publish, required to keep a slow subscriber from blocking peers) is now the dominant cost in this end-to-end synthetic bench. The consumer-side machinery is overhauled exactly as spec'd (no per-message goroutine, no per-message allocation, no semaphore). Eliminating the producer-side cost would re-introduce the #230 deadlock and is out of scope.
- **Breaking change:** `Message.ID()` returns `uint64` instead of `string`. The only known consumer is `core/concurrent/pubsub/example/main.go`, which does not call `ID()` — blast radius is contained.

## Out of scope (deferred)

- `lastViewedAt` → `atomic.Int64` to remove the dispatch write-lock (already noted on #231). Worth revisiting only if salvage workloads start showing the write-lock as a hotspot under the new worker-pool model.
- Pooling the per-Publish fan-out goroutine itself (would require a producer-side worker pool; structurally different change, separate issue if measured to matter).