### PR TITLE
pubsub: heap-based salvage expiry + functional options + full policy

### DIFF
--- a/core/concurrent/pubsub/heap.go
+++ b/core/concurrent/pubsub/heap.go
@@ -1,0 +1,38 @@
+package pubsub
+
+// expEntry is a (id, deadline-unix-nano) pair stored in expHeap. The heap is
+// keyed on deadline only; id is the back-pointer used by salvage to look up
+// the live *Message[T] from Subscription.messages. Acked messages leave their
+// expEntry in the heap as a tombstone — salvage skips entries whose id is no
+// longer in the map. This avoids an O(log N) heap removal on every Ack at
+// the cost of peak-heap-size >= peak-in-flight-count, which is acceptable
+// because the heap holds only 16 bytes per entry (#232).
+type expEntry struct {
+	id       uint64
+	deadline int64
+}
+
+// expHeap is a min-heap of expEntry ordered by deadline. It implements
+// container/heap.Interface. Equal deadlines are tiebroken by id (lower id
+// first) so the heap order is deterministic and matches publish order when
+// the producer is single-threaded — useful for tests and for FullPolicyDropOldest.
+type expHeap []expEntry
+
+func (h expHeap) Len() int { return len(h) }
+func (h expHeap) Less(i, j int) bool {
+	if h[i].deadline != h[j].deadline {
+		return h[i].deadline < h[j].deadline
+	}
+	return h[i].id < h[j].id
+}
+func (h expHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+
+func (h *expHeap) Push(x any) { *h = append(*h, x.(expEntry)) }
+
+func (h *expHeap) Pop() any {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}

--- a/core/concurrent/pubsub/options.go
+++ b/core/concurrent/pubsub/options.go
@@ -1,0 +1,88 @@
+package pubsub
+
+import "time"
+
+// FullPolicy selects the behavior of Publish when a Subscription's delivery
+// channel is full. The default, FullPolicyBlock, preserves the historical
+// contract: Publish blocks until a worker drains the channel. DropNewest and
+// DropOldest trade strict delivery for liveness and are observable via a
+// slog.Warn line on every drop.
+type FullPolicy int
+
+const (
+	// FullPolicyBlock blocks Publish until the channel has room (default).
+	FullPolicyBlock FullPolicy = iota
+	// FullPolicyDropNewest discards the incoming id when the channel is full.
+	// The Message envelope is acked and returned to the pool immediately so
+	// no slot is wasted in the in-flight map.
+	FullPolicyDropNewest
+	// FullPolicyDropOldest discards the oldest queued id and enqueues the
+	// new one. The dropped Message is acked and returned to the pool.
+	FullPolicyDropOldest
+)
+
+// defaultBufferSize matches the historical hardcoded channel capacity so
+// callers that switch to NewSubscriptionWithOptions without WithBufferSize
+// observe identical buffering.
+const defaultBufferSize = 65536
+
+// SubscriptionOption configures a Subscription created via
+// Topic.NewSubscriptionWithOptions. Options compose: later options overwrite
+// earlier ones.
+type SubscriptionOption func(*subscriptionConfig)
+
+type subscriptionConfig struct {
+	concurrency int
+	interval    time.Duration
+	ttl         time.Duration
+	bufferSize  int
+	fullPolicy  FullPolicy
+}
+
+func defaultSubscriptionConfig() subscriptionConfig {
+	return subscriptionConfig{
+		concurrency: 1,
+		interval:    time.Minute,
+		ttl:         time.Minute,
+		bufferSize:  defaultBufferSize,
+		fullPolicy:  FullPolicyBlock,
+	}
+}
+
+// WithConcurrency sets the number of worker goroutines that Subscribe spawns
+// to drain the delivery channel. Values < 1 are clamped to 1 at Subscribe
+// time. The historical positional constructor maps its concurrency argument
+// to this option.
+func WithConcurrency(n int) SubscriptionOption {
+	return func(c *subscriptionConfig) { c.concurrency = n }
+}
+
+// WithSalvageInterval sets the period of the watch ticker that drives expiry
+// eviction and re-delivery reminders.
+func WithSalvageInterval(d time.Duration) SubscriptionOption {
+	return func(c *subscriptionConfig) { c.interval = d }
+}
+
+// WithTTL sets the maximum age of an in-flight Message before salvage evicts
+// it (acks on the consumer's behalf and returns the envelope to the pool).
+func WithTTL(d time.Duration) SubscriptionOption {
+	return func(c *subscriptionConfig) { c.ttl = d }
+}
+
+// WithBufferSize sets the capacity of the delivery channel. Values < 1 are
+// clamped to 1 to keep the channel buffered (an unbuffered channel would
+// serialise every Publish against every worker).
+func WithBufferSize(n int) SubscriptionOption {
+	return func(c *subscriptionConfig) {
+		if n < 1 {
+			n = 1
+		}
+		c.bufferSize = n
+	}
+}
+
+// WithFullPolicy selects the behavior of Publish when the delivery channel is
+// full. See FullPolicy for the available modes.
+func WithFullPolicy(p FullPolicy) SubscriptionOption {
+	return func(c *subscriptionConfig) { c.fullPolicy = p }
+}

--- a/core/concurrent/pubsub/subscription.go
+++ b/core/concurrent/pubsub/subscription.go
@@ -1,7 +1,9 @@
 package pubsub
 
 import (
+	"container/heap"
 	"context"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -22,6 +24,16 @@ type Subscription[T any] struct {
 	concurrency int
 	interval    time.Duration
 	ttl         time.Duration
+	bufferSize  int
+	fullPolicy  FullPolicy
+
+	// expMu guards exp. Kept separate from s.mu so the salvage path can
+	// peek/pop heap entries without blocking the consumer's dispatch path
+	// (which holds s.mu in write mode to stamp lastViewedAt). Always acquire
+	// expMu first and release it before touching s.mu to avoid a lock-order
+	// inversion.
+	expMu sync.Mutex
+	exp   expHeap
 }
 
 func (s *Subscription[T]) Name() string {
@@ -136,9 +148,65 @@ func (s *Subscription[T]) publish(message *Message[T]) {
 	s.messages[message.id] = message
 	s.mu.Unlock()
 
-	// Send outside the lock: a full channel would otherwise block while the
+	// Record the expiry deadline so salvage can find the earliest-expiring
+	// message in O(log N) instead of scanning all in-flight messages (#232).
+	// Ack leaves the heap entry behind as a tombstone — salvage skips ids
+	// that are no longer in s.messages.
+	s.expMu.Lock()
+	heap.Push(&s.exp, expEntry{id: message.id, deadline: message.createdAt.Add(s.ttl).UnixNano()})
+	s.expMu.Unlock()
+
+	// Send outside the locks: a full channel would otherwise block while a
 	// lock is held, deadlocking any concurrent ack/message lookup.
-	s.ch <- message.id
+	s.enqueue(message)
+}
+
+// enqueue routes message.id onto s.ch according to s.fullPolicy. The default
+// FullPolicyBlock preserves the historical blocking semantics; the drop
+// policies trade strict delivery for liveness and ack the dropped envelope
+// so its pool slot and map entry are released (#232).
+func (s *Subscription[T]) enqueue(message *Message[T]) {
+	switch s.fullPolicy {
+	case FullPolicyDropNewest:
+		select {
+		case s.ch <- message.id:
+		default:
+			slog.Warn("pubsub: drop newest (channel full)",
+				"topic", s.topic.name, "subscription", s.name)
+			s.ack(message)
+		}
+	case FullPolicyDropOldest:
+		select {
+		case s.ch <- message.id:
+		default:
+			// Single non-blocking drain + retry. Looping unbounded would
+			// let a fast publisher starve the consumer indefinitely.
+			select {
+			case droppedID := <-s.ch:
+				slog.Warn("pubsub: drop oldest (channel full)",
+					"topic", s.topic.name, "subscription", s.name)
+				if dropped := s.message(droppedID); dropped != nil {
+					s.ack(dropped)
+				}
+				select {
+				case s.ch <- message.id:
+				default:
+					// A concurrent publisher refilled the slot; treat
+					// this publish as a newest-drop fallback rather
+					// than spinning on the channel.
+					slog.Warn("pubsub: drop newest after oldest drop (still full)",
+						"topic", s.topic.name, "subscription", s.name)
+					s.ack(message)
+				}
+			default:
+				// Channel drained between the full-select and the drain
+				// attempt; just send.
+				s.ch <- message.id
+			}
+		}
+	default: // FullPolicyBlock
+		s.ch <- message.id
+	}
 }
 
 func (s *Subscription[T]) ack(message *Message[T]) {
@@ -162,11 +230,55 @@ func (s *Subscription[T]) nack(message *Message[T]) {
 }
 
 func (s *Subscription[T]) remind(message *Message[T]) {
-	s.ch <- message.id
+	if s.fullPolicy == FullPolicyBlock {
+		s.ch <- message.id
+		return
+	}
+	// Under a drop policy, never block the salvage goroutine on a full
+	// channel: the message stays in s.messages and the next interval tick
+	// will retry the remind.
+	select {
+	case s.ch <- message.id:
+	default:
+	}
 }
 
 func (s *Subscription[T]) salvage(interval time.Duration, ttl time.Duration) {
-	// Snapshot under the lock so we can iterate without racing publish/ack.
+	now := time.Now()
+	nowNano := now.UnixNano()
+
+	// Expiry path: pop every heap entry whose deadline has passed and ack
+	// the corresponding live message. Tombstones (entries for already-acked
+	// messages) are popped and skipped. Cost is O(K log N) where K is the
+	// number of expirations on this tick (#232).
+	for {
+		s.expMu.Lock()
+		if s.exp.Len() == 0 || s.exp[0].deadline > nowNano {
+			s.expMu.Unlock()
+			break
+		}
+		entry := heap.Pop(&s.exp).(expEntry)
+		s.expMu.Unlock()
+
+		// Look up under s.mu; ack also takes s.mu so we release expMu first
+		// to keep lock order (expMu -> s.mu, never the reverse).
+		m := s.message(entry.id)
+		if m == nil {
+			continue
+		}
+		// Re-verify against the live createdAt: a Nack does not reset the
+		// envelope, so the heap entry is still authoritative, but checking
+		// keeps us safe if the policy ever changes.
+		if now.Sub(m.createdAt) > ttl {
+			s.ack(m)
+		}
+	}
+
+	// Remind path: re-push ids whose consumer has been silent for at least
+	// one interval. This still scans the in-flight map because lastViewedAt
+	// changes mid-flight and would require an indexable structure to track
+	// efficiently; the heap optimisation targets the expiry hot path, which
+	// dominates when ttl >> interval (#232).
 	s.mu.RLock()
 	snapshot := make([]*Message[T], 0, len(s.messages))
 	for _, m := range s.messages {
@@ -174,12 +286,7 @@ func (s *Subscription[T]) salvage(interval time.Duration, ttl time.Duration) {
 	}
 	s.mu.RUnlock()
 
-	now := time.Now()
 	for _, message := range snapshot {
-		if now.Sub(message.createdAt) > ttl {
-			s.ack(message)
-			continue
-		}
 		if now.Sub(message.lastViewedAt) > interval {
 			s.remind(message)
 		}

--- a/core/concurrent/pubsub/subscription_test.go
+++ b/core/concurrent/pubsub/subscription_test.go
@@ -546,3 +546,286 @@ func BenchmarkSubscription_PublishConsumeUint64Parallel(b *testing.B) {
 	done.Wait()
 	b.StopTimer()
 }
+
+// --- #232: salvage heap + functional options + full-policy ---
+
+// waitFor polls cond up to d, returning true if it ever becomes true. It
+// avoids time.Sleep tuning per test by letting the test fail fast when the
+// invariant is violated.
+func waitFor(d time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return cond()
+}
+
+func TestNewSubscriptionWithOptions_Defaults(t *testing.T) {
+	topic := NewTopic[int]("opts-defaults")
+	sub := topic.NewSubscriptionWithOptions("s")
+	if sub.concurrency != 1 {
+		t.Errorf("default concurrency = %d, want 1", sub.concurrency)
+	}
+	if sub.interval != time.Minute {
+		t.Errorf("default interval = %v, want 1m", sub.interval)
+	}
+	if sub.ttl != time.Minute {
+		t.Errorf("default ttl = %v, want 1m", sub.ttl)
+	}
+	if sub.bufferSize != defaultBufferSize {
+		t.Errorf("default bufferSize = %d, want %d", sub.bufferSize, defaultBufferSize)
+	}
+	if sub.fullPolicy != FullPolicyBlock {
+		t.Errorf("default fullPolicy = %v, want FullPolicyBlock", sub.fullPolicy)
+	}
+	if cap(sub.ch) != defaultBufferSize {
+		t.Errorf("default channel cap = %d, want %d", cap(sub.ch), defaultBufferSize)
+	}
+}
+
+func TestNewSubscriptionWithOptions_AllSetters(t *testing.T) {
+	topic := NewTopic[int]("opts-all")
+	sub := topic.NewSubscriptionWithOptions("s",
+		WithConcurrency(4),
+		WithSalvageInterval(7*time.Millisecond),
+		WithTTL(99*time.Millisecond),
+		WithBufferSize(8),
+		WithFullPolicy(FullPolicyDropNewest),
+	)
+	if sub.concurrency != 4 {
+		t.Errorf("concurrency = %d, want 4", sub.concurrency)
+	}
+	if sub.interval != 7*time.Millisecond {
+		t.Errorf("interval = %v, want 7ms", sub.interval)
+	}
+	if sub.ttl != 99*time.Millisecond {
+		t.Errorf("ttl = %v, want 99ms", sub.ttl)
+	}
+	if sub.bufferSize != 8 {
+		t.Errorf("bufferSize = %d, want 8", sub.bufferSize)
+	}
+	if cap(sub.ch) != 8 {
+		t.Errorf("channel cap = %d, want 8", cap(sub.ch))
+	}
+	if sub.fullPolicy != FullPolicyDropNewest {
+		t.Errorf("fullPolicy = %v, want FullPolicyDropNewest", sub.fullPolicy)
+	}
+}
+
+func TestNewSubscriptionWithOptions_BufferSizeClampedToOne(t *testing.T) {
+	topic := NewTopic[int]("opts-clamp")
+	sub := topic.NewSubscriptionWithOptions("s", WithBufferSize(0))
+	if sub.bufferSize != 1 {
+		t.Errorf("bufferSize = %d, want 1 (clamped)", sub.bufferSize)
+	}
+	if cap(sub.ch) != 1 {
+		t.Errorf("channel cap = %d, want 1", cap(sub.ch))
+	}
+}
+
+func TestNewSubscription_PositionalStillWorks(t *testing.T) {
+	// The positional NewSubscription must continue to compile and route
+	// through the options API with matching defaults so existing callers
+	// (notably core/concurrent/pubsub/example) keep working.
+	topic := NewTopic[int]("opts-positional")
+	sub := topic.NewSubscription("s", 3, 11*time.Millisecond, 22*time.Millisecond)
+	if sub.concurrency != 3 || sub.interval != 11*time.Millisecond || sub.ttl != 22*time.Millisecond {
+		t.Errorf("positional wrapper did not propagate args: got concurrency=%d interval=%v ttl=%v",
+			sub.concurrency, sub.interval, sub.ttl)
+	}
+	if sub.bufferSize != defaultBufferSize || sub.fullPolicy != FullPolicyBlock {
+		t.Errorf("positional wrapper changed defaults: bufferSize=%d fullPolicy=%v",
+			sub.bufferSize, sub.fullPolicy)
+	}
+}
+
+func TestSubscription_SalvageHeapEvictsExpired(t *testing.T) {
+	// Publish with short TTL and no consumer; salvage must ack-evict the
+	// message and drop it from s.messages (#232 heap path).
+	topic := NewTopic[int]("salvage-heap-evict")
+	sub := topic.NewSubscriptionWithOptions("s",
+		WithSalvageInterval(5*time.Millisecond),
+		WithTTL(10*time.Millisecond),
+		WithBufferSize(16),
+	)
+	// Drive publish directly so the message lands in s.messages without
+	// needing a Subscribe loop (which would drain it).
+	m := sub.newMessage(42)
+	sub.publish(m)
+
+	// Trigger salvage manually after TTL elapses; this exercises the heap
+	// pop path without racing the watch ticker.
+	time.Sleep(15 * time.Millisecond)
+	sub.salvage(sub.interval, sub.ttl)
+
+	sub.mu.RLock()
+	n := len(sub.messages)
+	sub.mu.RUnlock()
+	if n != 0 {
+		t.Errorf("after salvage: %d messages remain, want 0 (heap eviction failed)", n)
+	}
+	sub.expMu.Lock()
+	heapLen := sub.exp.Len()
+	sub.expMu.Unlock()
+	if heapLen != 0 {
+		t.Errorf("after salvage: heap len %d, want 0 (entry should be popped)", heapLen)
+	}
+}
+
+func TestSubscription_SalvageHeapTombstonesAckedMessages(t *testing.T) {
+	// Publish, ack via the message API, then run salvage. The heap entry is
+	// a tombstone (id no longer in s.messages); salvage must skip it
+	// cleanly without panicking and must still pop it once its deadline
+	// passes (#232 tombstone strategy).
+	topic := NewTopic[int]("salvage-heap-tombstone")
+	sub := topic.NewSubscriptionWithOptions("s",
+		WithSalvageInterval(5*time.Millisecond),
+		WithTTL(10*time.Millisecond),
+		WithBufferSize(16),
+	)
+	m := sub.newMessage(1)
+	sub.publish(m)
+	// Drain the id from the channel so the consumer-side test doesn't see it.
+	<-sub.ch
+	// Ack from "outside" via the public Message API.
+	m.Ack()
+
+	sub.mu.RLock()
+	if len(sub.messages) != 0 {
+		t.Fatalf("after Ack: %d messages remain, want 0", len(sub.messages))
+	}
+	sub.mu.RUnlock()
+	sub.expMu.Lock()
+	if sub.exp.Len() != 1 {
+		t.Fatalf("after Ack: heap len %d, want 1 (tombstone)", sub.exp.Len())
+	}
+	sub.expMu.Unlock()
+
+	// Past the deadline salvage must pop the tombstone.
+	time.Sleep(15 * time.Millisecond)
+	sub.salvage(sub.interval, sub.ttl)
+
+	sub.expMu.Lock()
+	if sub.exp.Len() != 0 {
+		t.Errorf("after salvage: heap len %d, want 0 (tombstone not popped)", sub.exp.Len())
+	}
+	sub.expMu.Unlock()
+}
+
+func TestSubscription_SalvageHeapPreservesLiveMessages(t *testing.T) {
+	// Salvage must not touch messages whose deadline has not passed.
+	topic := NewTopic[int]("salvage-heap-live")
+	sub := topic.NewSubscriptionWithOptions("s",
+		WithSalvageInterval(5*time.Millisecond),
+		WithTTL(time.Hour), // far in the future
+		WithBufferSize(16),
+	)
+	m := sub.newMessage(7)
+	sub.publish(m)
+
+	sub.salvage(sub.interval, sub.ttl)
+
+	sub.mu.RLock()
+	n := len(sub.messages)
+	sub.mu.RUnlock()
+	if n != 1 {
+		t.Errorf("salvage evicted a live message: %d remain, want 1", n)
+	}
+	sub.expMu.Lock()
+	heapLen := sub.exp.Len()
+	sub.expMu.Unlock()
+	if heapLen != 1 {
+		t.Errorf("salvage modified the heap unexpectedly: len %d, want 1", heapLen)
+	}
+}
+
+func TestSubscription_FullPolicyBlockIsDefault(t *testing.T) {
+	// With the default Block policy and a buffer of 1, a second publish
+	// must block until the first id is drained.
+	topic := NewTopic[int]("policy-block")
+	sub := topic.NewSubscriptionWithOptions("s", WithBufferSize(1))
+	sub.publish(sub.newMessage(1))
+
+	done := make(chan struct{})
+	go func() {
+		sub.publish(sub.newMessage(2))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatalf("second publish returned with full buffer; Block policy did not block")
+	case <-time.After(20 * time.Millisecond):
+		// expected: still blocked.
+	}
+
+	// Drain one id; the blocked publish must now complete.
+	<-sub.ch
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatalf("blocked publish did not unblock after drain")
+	}
+}
+
+func TestSubscription_FullPolicyDropNewest(t *testing.T) {
+	// With DropNewest and a buffer of 1, the second publish must be dropped
+	// (acked and pool-returned), leaving exactly one message in flight.
+	topic := NewTopic[int]("policy-drop-newest")
+	sub := topic.NewSubscriptionWithOptions("s",
+		WithBufferSize(1),
+		WithFullPolicy(FullPolicyDropNewest),
+	)
+	sub.publish(sub.newMessage(1))
+	// Channel is full; this publish must drop.
+	sub.publish(sub.newMessage(2))
+
+	sub.mu.RLock()
+	n := len(sub.messages)
+	sub.mu.RUnlock()
+	if n != 1 {
+		t.Errorf("DropNewest: %d messages in flight, want 1", n)
+	}
+	if len(sub.ch) != 1 {
+		t.Errorf("DropNewest: ch len %d, want 1", len(sub.ch))
+	}
+}
+
+func TestSubscription_FullPolicyDropOldest(t *testing.T) {
+	// With DropOldest and a buffer of 1, the second publish must evict the
+	// first id from the channel (acking it) and enqueue itself.
+	topic := NewTopic[int]("policy-drop-oldest")
+	sub := topic.NewSubscriptionWithOptions("s",
+		WithBufferSize(1),
+		WithFullPolicy(FullPolicyDropOldest),
+	)
+	first := sub.newMessage(100)
+	firstID := first.id
+	sub.publish(first)
+	second := sub.newMessage(200)
+	secondID := second.id
+	sub.publish(second)
+
+	if !waitFor(100*time.Millisecond, func() bool {
+		return len(sub.ch) == 1
+	}) {
+		t.Fatalf("DropOldest: ch len = %d, want 1", len(sub.ch))
+	}
+	queuedID := <-sub.ch
+	if queuedID != secondID {
+		t.Errorf("DropOldest: queued id = %d, want %d (newest)", queuedID, secondID)
+	}
+	sub.mu.RLock()
+	_, hasFirst := sub.messages[firstID]
+	_, hasSecond := sub.messages[secondID]
+	sub.mu.RUnlock()
+	if hasFirst {
+		t.Errorf("DropOldest: oldest message still in s.messages")
+	}
+	if !hasSecond {
+		t.Errorf("DropOldest: newest message missing from s.messages")
+	}
+}

--- a/core/concurrent/pubsub/topic.go
+++ b/core/concurrent/pubsub/topic.go
@@ -57,7 +57,30 @@ func (t *Topic[T]) Publish(body T) {
 	}
 }
 
+// NewSubscription creates (or returns the existing) Subscription with the
+// historical positional arguments. New code should prefer
+// NewSubscriptionWithOptions which exposes buffer size and full-policy knobs;
+// this wrapper keeps existing call sites compiling.
 func (t *Topic[T]) NewSubscription(name string, concurrency int, interval time.Duration, ttl time.Duration) *Subscription[T] {
+	return t.NewSubscriptionWithOptions(
+		name,
+		WithConcurrency(concurrency),
+		WithSalvageInterval(interval),
+		WithTTL(ttl),
+	)
+}
+
+// NewSubscriptionWithOptions creates (or returns the existing) Subscription
+// configured via functional options. Defaults match the positional
+// NewSubscription wrapper: concurrency 1, interval/ttl 1 minute, buffer 65536,
+// FullPolicyBlock. If a Subscription with name already exists it is returned
+// unchanged; options on a second call are ignored.
+func (t *Topic[T]) NewSubscriptionWithOptions(name string, opts ...SubscriptionOption) *Subscription[T] {
+	cfg := defaultSubscriptionConfig()
+	for _, o := range opts {
+		o(&cfg)
+	}
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -65,11 +88,13 @@ func (t *Topic[T]) NewSubscription(name string, concurrency int, interval time.D
 		t.subscriptions[name] = &Subscription[T]{
 			name:        name,
 			topic:       t,
-			ch:          make(chan uint64, 65536),
+			ch:          make(chan uint64, cfg.bufferSize),
 			messages:    make(map[uint64]*Message[T]),
-			concurrency: concurrency,
-			interval:    interval,
-			ttl:         ttl,
+			concurrency: cfg.concurrency,
+			interval:    cfg.interval,
+			ttl:         cfg.ttl,
+			bufferSize:  cfg.bufferSize,
+			fullPolicy:  cfg.fullPolicy,
 		}
 	}
 	return t.subscriptions[name]


### PR DESCRIPTION
Closes #232. Final of #228 pubsub epic.

## Salvage heap (#232)

The salvage path no longer snapshots all in-flight messages on each interval tick. A per-Subscription min-heap of `(id, deadline-unix-nano)` entries lets salvage pop only the messages whose deadline has passed: **O(K log N)** per tick instead of O(N).

- Heap entries for acked messages are left as **tombstones** — salvage looks each id up in `s.messages` and skips it if it's no longer there. Ack stays O(1).
- The heap is guarded by its own `expMu`; lock order is `expMu -> s.mu`, never the reverse.
- Heap entry uses `(uint64 id, int64 deadline)` (16 bytes) and never holds a `*Message[T]` — that would race the sync.Pool envelope recycle from #231.
- Nack does not push a new heap entry: it re-enqueues the same id, the existing heap entry's deadline (createdAt+ttl) is still authoritative.
- The remind path (re-pushing ids whose consumer has been silent) still scans `s.messages` — `lastViewedAt` changes mid-flight and would require an indexable structure to heap-ify too. The hot path that dominates when `ttl >> interval` is expiry, which this change targets.

## Functional options

`NewSubscriptionWithOptions(name, opts...)` exposes the previously-hardcoded knobs:

- `WithConcurrency(int)` — worker pool size (was positional arg).
- `WithSalvageInterval(time.Duration)` — was positional arg.
- `WithTTL(time.Duration)` — was positional arg.
- `WithBufferSize(int)` — channel capacity, was hardcoded to 65536.
- `WithFullPolicy(FullPolicy)` — see below.

The positional `NewSubscription(name, concurrency, interval, ttl)` is preserved as a thin wrapper so every existing call site (including `core/concurrent/pubsub/example`) keeps compiling. Defaults match historical behavior: concurrency 1, interval/ttl 1 minute, buffer 65536, FullPolicyBlock.

## FullPolicy

Selects Publish behavior when the delivery channel is full:

- `FullPolicyBlock` (default) — blocks Publish until a worker drains, preserving the historical contract.
- `FullPolicyDropNewest` — non-blocking send; on full, ack the incoming envelope (returns it to the pool) and emit `slog.Warn`.
- `FullPolicyDropOldest` — non-blocking send; on full, single non-blocking drain + ack the drained envelope, then retry the push once. If still full (concurrent publisher refilled), fall back to newest-drop. **No unbounded loops.**
- `remind()` under drop policies is also non-blocking, so the salvage goroutine cannot stall on a full channel; the next interval tick retries.

No prometheus metric here — pubsub is a leaf in `core/` and metrics are a server-side concern (per issue body).

## Tests (appended to `subscription_test.go` per AGENTS.md rule 9)

- `TestNewSubscriptionWithOptions_Defaults` / `_AllSetters` / `_BufferSizeClampedToOne` — options API contract.
- `TestNewSubscription_PositionalStillWorks` — source-compat for the positional wrapper.
- `TestSubscription_SalvageHeapEvictsExpired` — expired in-flight message is ack'd and popped.
- `TestSubscription_SalvageHeapTombstonesAckedMessages` — Acked-then-expired path skips cleanly + pops the tombstone.
- `TestSubscription_SalvageHeapPreservesLiveMessages` — salvage does not touch messages whose deadline has not passed.
- `TestSubscription_FullPolicyBlockIsDefault` — second Publish blocks until first id is drained.
- `TestSubscription_FullPolicyDropNewest` — second Publish is dropped, one in-flight remains.
- `TestSubscription_FullPolicyDropOldest` — second Publish evicts the oldest, newest id is the one in the channel.

## Gates

- `gofmt -l . cli core pb sdks server tests` clean.
- All 5 modules `go test ./...` pass; `server go vet` clean.
- `go test -race ./concurrent/pubsub/...` clean.

## Cross-finding hand-off

None — this is the last sub-Issue in the #228 epic.