### PR TITLE
obs(#238): mount /debug/pprof/* behind LANTERN_PPROF_ENABLED

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -88,6 +88,7 @@ most common knobs:
 | `LANTERN_SLOW_RPC_THRESHOLD_MS` | `500` | Emit a `slog` warning per unary/stream RPC whose handler exceeds this duration (0 disables). |
 | `LANTERN_ANTI_ENTROPY_GAP_WARN_THRESHOLD` | `1024` | Emit a `slog` warning per anti-entropy tick whose detected peer gap (in seq units) exceeds this value (0 disables). |
 | `LANTERN_METRICS_ADDR` | `:9090` | HTTP listen for `/metrics`, `/healthz`, `/readyz` (empty disables). |
+| `LANTERN_PPROF_ENABLED` | `false` | Mount `/debug/pprof/*` (heap, goroutine, allocs, threadcreate, block, mutex, profile, trace, cmdline, symbol) on the metrics listener. Keep off in production unless the metrics port is bound to an internal-only interface; the endpoint exposes goroutine stacks and live heap data. `block` / `mutex` profiles also require `LANTERN_BLOCK_PROFILE_RATE` / `LANTERN_MUTEX_PROFILE_FRACTION` to be non-zero. |
 | `LANTERN_REFLECTION` | `true` | gRPC server reflection. |
 | `LANTERN_LOG_LEVEL` / `LANTERN_LOG_FORMAT` | `info` / `json` | slog handler. |
 | `LANTERN_TLS_CERT_FILE` / `LANTERN_TLS_KEY_FILE` / `LANTERN_TLS_CLIENT_CA_FILE` | (unset) | TLS / mTLS material (all-or-nothing). |

--- a/server/provider/metrics_server_test.go
+++ b/server/provider/metrics_server_test.go
@@ -15,7 +15,7 @@ import (
 // returns 200 on both /readyz and /healthz/ready immediately at startup.
 func TestMetricsMux_ReadinessSingleInstance(t *testing.T) {
 	gate := readiness.NewGate(10000, false, health.NewServer())
-	ts := httptest.NewServer(newMetricsMux(prometheus.NewRegistry(), gate))
+	ts := httptest.NewServer(newMetricsMux(prometheus.NewRegistry(), gate, false))
 	defer ts.Close()
 
 	for _, path := range []string{"/readyz", "/healthz/ready"} {
@@ -36,7 +36,7 @@ func TestMetricsMux_ReadinessSingleInstance(t *testing.T) {
 // each transition on both probe endpoints.
 func TestMetricsMux_ReadinessMultiPeerFlips(t *testing.T) {
 	gate := readiness.NewGate(100, true, health.NewServer())
-	ts := httptest.NewServer(newMetricsMux(prometheus.NewRegistry(), gate))
+	ts := httptest.NewServer(newMetricsMux(prometheus.NewRegistry(), gate, false))
 	defer ts.Close()
 
 	probe := func(path string) int {

--- a/server/provider/pprof.go
+++ b/server/provider/pprof.go
@@ -1,0 +1,32 @@
+package provider
+
+import (
+	"net/http"
+	"net/http/pprof"
+)
+
+// registerPprofHandlers mounts net/http/pprof handlers on the supplied mux.
+// Gated upstream by ObservabilityConfig.EnablePprof (LANTERN_PPROF_ENABLED).
+//
+// Important: pprof exposes process-internal data (goroutine stacks, heap
+// allocations, CPU profile, mutex/block samples). The metrics listener it
+// shares is intended for internal scrape traffic only. Operators MUST keep
+// the metrics port unreachable from untrusted networks before enabling pprof.
+//
+// mutex and block profiles require runtime.SetMutexProfileFraction and
+// runtime.SetBlockProfileRate to be non-zero respectively; otherwise those
+// endpoints return empty samples. Those knobs are wired separately.
+func registerPprofHandlers(mux *http.ServeMux) {
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	// runtime profiles are served via pprof.Handler(name).ServeHTTP and the
+	// index page links to each by name; explicit registration keeps each
+	// profile reachable even without crawling the index.
+	for _, name := range []string{"goroutine", "heap", "allocs", "threadcreate", "block", "mutex"} {
+		mux.Handle("/debug/pprof/"+name, pprof.Handler(name))
+	}
+}

--- a/server/provider/pprof_test.go
+++ b/server/provider/pprof_test.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/anaregdesign/lantern/server/readiness"
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc/health"
+)
+
+// TestPprof_DisabledByDefault confirms /debug/pprof/* is not reachable when
+// EnablePprof is false. This is the on-by-default-on-prod safety guarantee.
+func TestPprof_DisabledByDefault(t *testing.T) {
+	gate := readiness.NewGate(10000, false, health.NewServer())
+	ts := httptest.NewServer(newMetricsMux(prometheus.NewRegistry(), gate, false))
+	defer ts.Close()
+
+	for _, path := range []string{
+		"/debug/pprof/",
+		"/debug/pprof/heap",
+		"/debug/pprof/goroutine",
+		"/debug/pprof/cmdline",
+		"/debug/pprof/symbol",
+	} {
+		resp, err := http.Get(ts.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("GET %s (disabled): want 404, got %d", path, resp.StatusCode)
+		}
+	}
+}
+
+// TestPprof_EnabledServesIndexAndProfiles confirms that the index page and
+// each registered runtime profile respond with 2xx when EnablePprof is true.
+// We deliberately skip /debug/pprof/profile and /debug/pprof/trace because
+// those block for a sampling window.
+func TestPprof_EnabledServesIndexAndProfiles(t *testing.T) {
+	gate := readiness.NewGate(10000, false, health.NewServer())
+	ts := httptest.NewServer(newMetricsMux(prometheus.NewRegistry(), gate, true))
+	defer ts.Close()
+
+	for _, path := range []string{
+		"/debug/pprof/",
+		"/debug/pprof/heap",
+		"/debug/pprof/goroutine",
+		"/debug/pprof/allocs",
+		"/debug/pprof/threadcreate",
+		"/debug/pprof/block",
+		"/debug/pprof/mutex",
+		"/debug/pprof/cmdline",
+	} {
+		resp, err := http.Get(ts.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			t.Fatalf("GET %s (enabled): want 2xx, got %d", path, resp.StatusCode)
+		}
+	}
+}
+
+// TestPprof_EnabledKeepsMetricsAndReadyz makes sure mounting the pprof
+// handlers does not collide with the pre-existing routes on the same mux.
+func TestPprof_EnabledKeepsMetricsAndReadyz(t *testing.T) {
+	gate := readiness.NewGate(10000, false, health.NewServer())
+	ts := httptest.NewServer(newMetricsMux(prometheus.NewRegistry(), gate, true))
+	defer ts.Close()
+
+	for _, path := range []string{"/metrics", "/healthz", "/readyz", "/healthz/ready"} {
+		resp, err := http.Get(ts.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET %s with pprof enabled: want 200, got %d", path, resp.StatusCode)
+		}
+	}
+}

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -77,6 +77,11 @@ type RateLimitConfig struct {
 //   - LANTERN_COMMIT                     overrides lantern_build_info{commit}
 //   - LANTERN_SLOW_RPC_THRESHOLD_MS      milliseconds; RPCs that take longer
 //     emit a warn-level "slow rpc" log. Default 500. Set to 0 to disable.
+//   - LANTERN_PPROF_ENABLED              true|false            (default false)
+//     when true, mounts /debug/pprof/* on the metrics listener for heap,
+//     goroutine, mutex, block, allocs, threadcreate, profile (CPU), trace,
+//     cmdline, and symbol. The metrics listener is intended for internal
+//     scrape traffic only — leave PPROF disabled unless that boundary holds.
 type ObservabilityConfig struct {
 	LogLevel         slog.Level
 	LogFormat        string
@@ -85,6 +90,7 @@ type ObservabilityConfig struct {
 	Version          string
 	Commit           string
 	SlowRPCThreshold time.Duration
+	EnablePprof      bool
 }
 
 // CacheConfig sizes the GraphCache TTL and its GC tick.
@@ -171,6 +177,7 @@ func NewConfig() *Config {
 			Version:          os.Getenv("LANTERN_VERSION"),
 			Commit:           os.Getenv("LANTERN_COMMIT"),
 			SlowRPCThreshold: time.Duration(envconfig.Int("LANTERN_SLOW_RPC_THRESHOLD_MS", 500)) * time.Millisecond,
+			EnablePprof:      envconfig.Bool("LANTERN_PPROF_ENABLED", false),
 		},
 		Cache: CacheConfig{
 			TTL:        time.Duration(envconfig.Int("LANTERN_DEFAULT_TTL_SECONDS", 60)) * time.Second,
@@ -488,7 +495,7 @@ func NewMetricsServer(o ObservabilityConfig, reg *prometheus.Registry, gate *rea
 	return &httpMetricsServer{
 		srv: &http.Server{
 			Addr:              o.MetricsAddr,
-			Handler:           newMetricsMux(reg, gate),
+			Handler:           newMetricsMux(reg, gate, o.EnablePprof),
 			ReadHeaderTimeout: 5 * time.Second,
 		},
 		logger: logger,
@@ -497,10 +504,14 @@ func NewMetricsServer(o ObservabilityConfig, reg *prometheus.Registry, gate *rea
 
 // newMetricsMux builds the /metrics + /healthz + /readyz + /healthz/ready
 // handler tree. Extracted so tests can exercise the readiness-aware HTTP
-// shim with httptest without binding a real port.
-func newMetricsMux(reg *prometheus.Registry, gate *readiness.Gate) http.Handler {
+// shim with httptest without binding a real port. When enablePprof is true,
+// /debug/pprof/* is additionally mounted; otherwise those paths 404.
+func newMetricsMux(reg *prometheus.Registry, gate *readiness.Gate, enablePprof bool) http.Handler {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg}))
+	if enablePprof {
+		registerPprofHandlers(mux)
+	}
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))


### PR DESCRIPTION
Closes #238
Part of #237 (perf observation/bench epic).

## What
Off-by-default `LANTERN_PPROF_ENABLED` flag that mounts `net/http/pprof` on the existing metrics listener:

- `/debug/pprof/` (index)
- `/debug/pprof/{cmdline,profile,symbol,trace}`
- `/debug/pprof/{goroutine,heap,allocs,threadcreate,block,mutex}`

No new listener, no extra port — reuses `LANTERN_METRICS_ADDR`.

## Why
Bench harness (#241) needs heap / goroutine / mutex / block snapshots to triage hotspots and leaks. Today only `process_resident_memory_bytes` and `go_goroutines` are exposed via Prometheus; that is not enough to find what allocates or who blocks.

## Safety
- Default off. Operator must opt in.
- The metrics port is intended for internal scrape traffic only — README is explicit that pprof MUST NOT be enabled when the port is reachable from untrusted networks (it exposes goroutine stacks, live heap data, and CPU profile).
- `block` / `mutex` profiles still need `LANTERN_BLOCK_PROFILE_RATE` / `LANTERN_MUTEX_PROFILE_FRACTION` to be non-zero (wired separately in #239).

## Tests
New `server/provider/pprof_test.go` covers:
- disabled-by-default → all `/debug/pprof/*` 404
- enabled → index + all six runtime profiles + cmdline return 2xx
- enabled → `/metrics`, `/healthz`, `/readyz`, `/healthz/ready` still 200 (no route collision)