### PR TITLE
obs(#239): wire LANTERN_MUTEX_PROFILE_FRACTION / LANTERN_BLOCK_PROFILE_RATE

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -89,6 +89,8 @@ most common knobs:
 | `LANTERN_ANTI_ENTROPY_GAP_WARN_THRESHOLD` | `1024` | Emit a `slog` warning per anti-entropy tick whose detected peer gap (in seq units) exceeds this value (0 disables). |
 | `LANTERN_METRICS_ADDR` | `:9090` | HTTP listen for `/metrics`, `/healthz`, `/readyz` (empty disables). |
 | `LANTERN_PPROF_ENABLED` | `false` | Mount `/debug/pprof/*` (heap, goroutine, allocs, threadcreate, block, mutex, profile, trace, cmdline, symbol) on the metrics listener. Keep off in production unless the metrics port is bound to an internal-only interface; the endpoint exposes goroutine stacks and live heap data. `block` / `mutex` profiles also require `LANTERN_BLOCK_PROFILE_RATE` / `LANTERN_MUTEX_PROFILE_FRACTION` to be non-zero. |
+| `LANTERN_MUTEX_PROFILE_FRACTION` | `0` | `runtime.SetMutexProfileFraction` — 1-in-N sampling of mutex contention. Non-zero adds per-Unlock overhead; leave `0` in production unless actively profiling. Combine with `LANTERN_PPROF_ENABLED=true` to read the samples via `/debug/pprof/mutex`. |
+| `LANTERN_BLOCK_PROFILE_RATE` | `0` | `runtime.SetBlockProfileRate` — nanoseconds between block-event samples (lower = more samples). Non-zero adds per-blocking-op overhead; same caveats as `MUTEX_PROFILE_FRACTION`. Read via `/debug/pprof/block`. |
 | `LANTERN_REFLECTION` | `true` | gRPC server reflection. |
 | `LANTERN_LOG_LEVEL` / `LANTERN_LOG_FORMAT` | `info` / `json` | slog handler. |
 | `LANTERN_TLS_CERT_FILE` / `LANTERN_TLS_KEY_FILE` / `LANTERN_TLS_CLIENT_CA_FILE` | (unset) | TLS / mTLS material (all-or-nothing). |

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -168,6 +168,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Apply runtime mutex/block profile sampling rates as early as
+	// possible so any subsequent contention is captured. Both knobs are
+	// no-ops when the env vars are unset (#239).
+	provider.ApplyRuntimeProfiling(app.cfg.Observability, app.logger)
+
 	app.logger.Info("lantern starting",
 		slog.Int("port", app.cfg.Net.Port),
 		slog.Duration("default_ttl", app.cfg.Cache.TTL),

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -82,15 +82,24 @@ type RateLimitConfig struct {
 //     goroutine, mutex, block, allocs, threadcreate, profile (CPU), trace,
 //     cmdline, and symbol. The metrics listener is intended for internal
 //     scrape traffic only — leave PPROF disabled unless that boundary holds.
+//   - LANTERN_MUTEX_PROFILE_FRACTION     int   (default 0 = disabled)
+//     passed to runtime.SetMutexProfileFraction. Sampling rate for mutex
+//     contention events; 1-in-N stacks are recorded. Has runtime cost on
+//     contended workloads — leave 0 in production unless actively profiling.
+//   - LANTERN_BLOCK_PROFILE_RATE         int   (default 0 = disabled)
+//     passed to runtime.SetBlockProfileRate. Nanoseconds between block-event
+//     samples; lower = more samples. Same runtime-cost caveat as above.
 type ObservabilityConfig struct {
-	LogLevel         slog.Level
-	LogFormat        string
-	MetricsAddr      string
-	EnableReflection bool
-	Version          string
-	Commit           string
-	SlowRPCThreshold time.Duration
-	EnablePprof      bool
+	LogLevel             slog.Level
+	LogFormat            string
+	MetricsAddr          string
+	EnableReflection     bool
+	Version              string
+	Commit               string
+	SlowRPCThreshold     time.Duration
+	EnablePprof          bool
+	MutexProfileFraction int
+	BlockProfileRate     int
 }
 
 // CacheConfig sizes the GraphCache TTL and its GC tick.
@@ -170,14 +179,16 @@ func NewConfig() *Config {
 			Burst: burst,
 		},
 		Observability: ObservabilityConfig{
-			LogLevel:         envconfig.LogLevel(os.Getenv("LANTERN_LOG_LEVEL")),
-			LogFormat:        envconfig.String("LANTERN_LOG_FORMAT", "json"),
-			MetricsAddr:      envconfig.String("LANTERN_METRICS_ADDR", ":9090"),
-			EnableReflection: envconfig.Bool("LANTERN_REFLECTION", true),
-			Version:          os.Getenv("LANTERN_VERSION"),
-			Commit:           os.Getenv("LANTERN_COMMIT"),
-			SlowRPCThreshold: time.Duration(envconfig.Int("LANTERN_SLOW_RPC_THRESHOLD_MS", 500)) * time.Millisecond,
-			EnablePprof:      envconfig.Bool("LANTERN_PPROF_ENABLED", false),
+			LogLevel:             envconfig.LogLevel(os.Getenv("LANTERN_LOG_LEVEL")),
+			LogFormat:            envconfig.String("LANTERN_LOG_FORMAT", "json"),
+			MetricsAddr:          envconfig.String("LANTERN_METRICS_ADDR", ":9090"),
+			EnableReflection:     envconfig.Bool("LANTERN_REFLECTION", true),
+			Version:              os.Getenv("LANTERN_VERSION"),
+			Commit:               os.Getenv("LANTERN_COMMIT"),
+			SlowRPCThreshold:     time.Duration(envconfig.Int("LANTERN_SLOW_RPC_THRESHOLD_MS", 500)) * time.Millisecond,
+			EnablePprof:          envconfig.Bool("LANTERN_PPROF_ENABLED", false),
+			MutexProfileFraction: envconfig.Int("LANTERN_MUTEX_PROFILE_FRACTION", 0),
+			BlockProfileRate:     envconfig.Int("LANTERN_BLOCK_PROFILE_RATE", 0),
 		},
 		Cache: CacheConfig{
 			TTL:        time.Duration(envconfig.Int("LANTERN_DEFAULT_TTL_SECONDS", 60)) * time.Second,

--- a/server/provider/runtime_profiling.go
+++ b/server/provider/runtime_profiling.go
@@ -1,0 +1,37 @@
+package provider
+
+import (
+	"log/slog"
+	"runtime"
+)
+
+// ApplyRuntimeProfiling installs the process-wide mutex- and block-profile
+// sampling rates derived from ObservabilityConfig. Both knobs are runtime
+// globals (runtime.SetMutexProfileFraction / runtime.SetBlockProfileRate)
+// and have no effect unless the matching pprof handlers are reachable —
+// typically via LANTERN_PPROF_ENABLED (#238).
+//
+// Zero leaves the runtime untouched so a process started without these env
+// vars behaves exactly as before this hook existed. Non-zero values are
+// logged at info so operators can confirm their env actually took effect
+// (a common foot-gun: setting the env on the wrong unit or in the wrong
+// shell scope).
+func ApplyRuntimeProfiling(o ObservabilityConfig, logger *slog.Logger) {
+	if o.MutexProfileFraction > 0 {
+		prev := runtime.SetMutexProfileFraction(o.MutexProfileFraction)
+		if logger != nil {
+			logger.Info("mutex profiling enabled",
+				slog.Int("fraction", o.MutexProfileFraction),
+				slog.Int("previous", prev),
+			)
+		}
+	}
+	if o.BlockProfileRate > 0 {
+		runtime.SetBlockProfileRate(o.BlockProfileRate)
+		if logger != nil {
+			logger.Info("block profiling enabled",
+				slog.Int("rate_ns", o.BlockProfileRate),
+			)
+		}
+	}
+}

--- a/server/provider/runtime_profiling_test.go
+++ b/server/provider/runtime_profiling_test.go
@@ -1,0 +1,63 @@
+package provider
+
+import (
+	"runtime"
+	"testing"
+)
+
+// resetProfilingRates returns the runtime to "off" so tests don't leak
+// global state into siblings. SetMutexProfileFraction(0) returns the
+// previous value, which is how we also assert what ApplyRuntimeProfiling
+// installed.
+func resetProfilingRates(t *testing.T) {
+	t.Helper()
+	runtime.SetMutexProfileFraction(0)
+	runtime.SetBlockProfileRate(0)
+}
+
+func TestApplyRuntimeProfiling_DefaultsAreNoOp(t *testing.T) {
+	resetProfilingRates(t)
+	t.Cleanup(func() { resetProfilingRates(t) })
+
+	// Seed a non-zero value so we can prove Apply with zeros does NOT
+	// clobber it. (Realistic foot-gun: a process that already set the
+	// rates via runtime/debug should not be silently overwritten.)
+	runtime.SetMutexProfileFraction(7)
+
+	ApplyRuntimeProfiling(ObservabilityConfig{}, nil)
+
+	got := runtime.SetMutexProfileFraction(0)
+	if got != 7 {
+		t.Fatalf("Apply with zero fraction overwrote pre-set value: got %d, want 7", got)
+	}
+}
+
+func TestApplyRuntimeProfiling_AppliesMutexFraction(t *testing.T) {
+	resetProfilingRates(t)
+	t.Cleanup(func() { resetProfilingRates(t) })
+
+	ApplyRuntimeProfiling(ObservabilityConfig{MutexProfileFraction: 23}, nil)
+
+	prev := runtime.SetMutexProfileFraction(0)
+	if prev != 23 {
+		t.Fatalf("mutex fraction not installed: got %d, want 23", prev)
+	}
+}
+
+func TestApplyRuntimeProfiling_AppliesBlockRate(t *testing.T) {
+	resetProfilingRates(t)
+	t.Cleanup(func() { resetProfilingRates(t) })
+
+	// runtime exposes no getter for the block profile rate, so we can
+	// only assert the call path does not panic and that pairing with a
+	// mutex fraction still works end-to-end.
+	ApplyRuntimeProfiling(ObservabilityConfig{
+		MutexProfileFraction: 11,
+		BlockProfileRate:     1000,
+	}, nil)
+
+	prev := runtime.SetMutexProfileFraction(0)
+	if prev != 11 {
+		t.Fatalf("mutex fraction not installed alongside block rate: got %d, want 11", prev)
+	}
+}


### PR DESCRIPTION
Closes #239
Part of #237.

## What
Two new env knobs that pair with the pprof endpoint from #238:

- `LANTERN_MUTEX_PROFILE_FRACTION` → `runtime.SetMutexProfileFraction`
- `LANTERN_BLOCK_PROFILE_RATE`     → `runtime.SetBlockProfileRate`

Applied once at startup via `provider.ApplyRuntimeProfiling`, called from `main` right after wire boot.

## Why
`/debug/pprof/mutex` and `/debug/pprof/block` are inert until these runtime globals are non-zero. Without this PR an operator who flips `LANTERN_PPROF_ENABLED=true` to debug contention sees empty profiles and assumes the harness is broken.

## Safety
- Both default to 0 (off) → no production deployment changes behaviour.
- Apply with zero leaves any pre-existing runtime state alone (test: `TestApplyRuntimeProfiling_DefaultsAreNoOp`).
- Non-zero values are logged at info so operators can confirm the env actually took effect.

## Tests
`server/provider/runtime_profiling_test.go` covers:
- defaults are a no-op and do not overwrite pre-set state
- mutex fraction is installed exactly (verified via `SetMutexProfileFraction(0)` returning the previous value)
- block rate path runs alongside mutex fraction without interfering