### PR TITLE
obs(#240): pubsub queue depth / drop / dispatch metrics

### DIFF
--- a/core/concurrent/pubsub/doc.go
+++ b/core/concurrent/pubsub/doc.go
@@ -1,0 +1,18 @@
+// Package pubsub is an in-process publish/subscribe primitive for the
+// Lantern core. It owns message lifecycles (Publish → enqueue → consumer
+// → Ack/salvage) and the FullPolicy semantics that govern channel
+// saturation.
+//
+// # Observability
+//
+// Subscriptions emit telemetry through the Observer interface. core/ is
+// a leaf module and never imports server/metrics (see AGENTS.md
+// "Dependency boundaries"); the server-side Prometheus collectors are
+// plugged in per subscription via WithObserver(...). The default is a
+// no-op so library consumers pay zero overhead.
+//
+// Authors adding new drop or dispatch paths must invoke the matching
+// Observer method exactly once per event and, when a new drop policy is
+// introduced, extend the DropPolicies slice so server-side label
+// pre-warming stays exhaustive.
+package pubsub

--- a/core/concurrent/pubsub/metrics.go
+++ b/core/concurrent/pubsub/metrics.go
@@ -1,0 +1,56 @@
+package pubsub
+
+import "time"
+
+// Observer is the optional sink for pubsub subscription telemetry. core/ is
+// a leaf module and must not import server/metrics (AGENTS.md dependency
+// boundary), so the server-side Prometheus collectors are injected via this
+// interface. Implementations must be safe for concurrent use; pubsub may
+// call any method from any worker goroutine. A nil observer is treated as
+// the no-op.
+//
+// Method semantics:
+//
+//   - RecordEnqueueDepth is invoked once per successful enqueue with the
+//     channel length after the send. Sampled rather than gauged so the
+//     collector can aggregate (histogram) without per-subscription
+//     cardinality.
+//   - RecordDrop is invoked once per drop-path execution with one of the
+//     policy strings exported below. Each drop must increment exactly once,
+//     even when the drop-oldest fallback also drops the newest message
+//     (that case fires RecordDrop("drop_oldest") followed by
+//     RecordDrop("drop_newest_after_oldest")).
+//   - ObserveDispatch is invoked once per consumer return with the wall-
+//     clock duration from the originating Publish (message.createdAt) to
+//     the moment the consumer callback returned.
+type Observer interface {
+	RecordEnqueueDepth(depth int)
+	RecordDrop(policy string)
+	ObserveDispatch(d time.Duration)
+}
+
+// Drop policy labels passed to Observer.RecordDrop. Exposed as a bounded
+// set so server-side collectors can pre-warm the label rows and dashboards
+// render the full series from process start.
+const (
+	DropPolicyNewest            = "drop_newest"
+	DropPolicyOldest            = "drop_oldest"
+	DropPolicyNewestAfterOldest = "drop_newest_after_oldest"
+)
+
+// DropPolicies is the canonical ordered list of policy labels emitted by
+// RecordDrop. Useful for pre-warming Prometheus CounterVec rows.
+var DropPolicies = []string{
+	DropPolicyNewest,
+	DropPolicyOldest,
+	DropPolicyNewestAfterOldest,
+}
+
+// noopObserver is the default Observer used when none is configured. Kept
+// as a typed value rather than a nil check in every call site so the hot
+// path stays branch-free.
+type noopObserver struct{}
+
+func (noopObserver) RecordEnqueueDepth(int)        {}
+func (noopObserver) RecordDrop(string)             {}
+func (noopObserver) ObserveDispatch(time.Duration) {}

--- a/core/concurrent/pubsub/metrics_test.go
+++ b/core/concurrent/pubsub/metrics_test.go
@@ -1,0 +1,41 @@
+package pubsub
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNoopObserver_AllMethodsAreSafe(t *testing.T) {
+	// The default noop observer is used on every subscription that does
+	// not call WithObserver. It must accept any input without side
+	// effects so the hot path stays branch-free.
+	var o Observer = noopObserver{}
+	o.RecordEnqueueDepth(0)
+	o.RecordEnqueueDepth(1 << 30)
+	o.RecordDrop(DropPolicyNewest)
+	o.RecordDrop(DropPolicyOldest)
+	o.RecordDrop(DropPolicyNewestAfterOldest)
+	o.RecordDrop("unknown-policy")
+	o.ObserveDispatch(0)
+	o.ObserveDispatch(time.Hour)
+}
+
+func TestDropPolicies_CoversInterfaceContract(t *testing.T) {
+	// DropPolicies is consumed by server-side collectors for label
+	// pre-warming; it must list every policy string the pubsub package
+	// can pass to Observer.RecordDrop. Guard against silent additions
+	// to the policy set by checking length + membership here.
+	want := map[string]struct{}{
+		DropPolicyNewest:            {},
+		DropPolicyOldest:            {},
+		DropPolicyNewestAfterOldest: {},
+	}
+	if len(DropPolicies) != len(want) {
+		t.Fatalf("DropPolicies = %v (len %d), want %d entries", DropPolicies, len(DropPolicies), len(want))
+	}
+	for _, p := range DropPolicies {
+		if _, ok := want[p]; !ok {
+			t.Errorf("DropPolicies contains unexpected entry %q", p)
+		}
+	}
+}

--- a/core/concurrent/pubsub/options.go
+++ b/core/concurrent/pubsub/options.go
@@ -37,6 +37,7 @@ type subscriptionConfig struct {
 	ttl         time.Duration
 	bufferSize  int
 	fullPolicy  FullPolicy
+	observer    Observer
 }
 
 func defaultSubscriptionConfig() subscriptionConfig {
@@ -46,6 +47,7 @@ func defaultSubscriptionConfig() subscriptionConfig {
 		ttl:         time.Minute,
 		bufferSize:  defaultBufferSize,
 		fullPolicy:  FullPolicyBlock,
+		observer:    noopObserver{},
 	}
 }
 
@@ -85,4 +87,19 @@ func WithBufferSize(n int) SubscriptionOption {
 // full. See FullPolicy for the available modes.
 func WithFullPolicy(p FullPolicy) SubscriptionOption {
 	return func(c *subscriptionConfig) { c.fullPolicy = p }
+}
+
+// WithObserver installs an Observer that receives enqueue-depth samples,
+// drop counters, and dispatch-duration observations for this subscription.
+// A nil observer reverts to the no-op (no telemetry). core/ never imports
+// server/metrics directly; the server wires a Prometheus-backed Observer
+// here (#240).
+func WithObserver(o Observer) SubscriptionOption {
+	return func(c *subscriptionConfig) {
+		if o == nil {
+			c.observer = noopObserver{}
+			return
+		}
+		c.observer = o
+	}
 }

--- a/core/concurrent/pubsub/subscription.go
+++ b/core/concurrent/pubsub/subscription.go
@@ -26,6 +26,7 @@ type Subscription[T any] struct {
 	ttl         time.Duration
 	bufferSize  int
 	fullPolicy  FullPolicy
+	observer    Observer
 
 	// expMu guards exp. Kept separate from s.mu so the salvage path can
 	// peek/pop heap entries without blocking the consumer's dispatch path
@@ -82,6 +83,13 @@ func (s *Subscription[T]) Subscribe(ctx context.Context, consumer function.Consu
 						continue
 					}
 					consumer(m)
+					if obs := s.observer; obs != nil {
+						// Enqueue-to-consumer-return latency, measured from the
+						// originating Publish (#240). Reads m.createdAt without
+						// the lock: the field is stamped once in newMessage and
+						// never mutated thereafter.
+						obs.ObserveDispatch(time.Since(m.createdAt))
+					}
 				case <-ctx.Done():
 					return
 				}
@@ -166,18 +174,28 @@ func (s *Subscription[T]) publish(message *Message[T]) {
 // policies trade strict delivery for liveness and ack the dropped envelope
 // so its pool slot and map entry are released (#232).
 func (s *Subscription[T]) enqueue(message *Message[T]) {
+	obs := s.observer
 	switch s.fullPolicy {
 	case FullPolicyDropNewest:
 		select {
 		case s.ch <- message.id:
+			if obs != nil {
+				obs.RecordEnqueueDepth(len(s.ch))
+			}
 		default:
 			slog.Warn("pubsub: drop newest (channel full)",
 				"topic", s.topic.name, "subscription", s.name)
+			if obs != nil {
+				obs.RecordDrop(DropPolicyNewest)
+			}
 			s.ack(message)
 		}
 	case FullPolicyDropOldest:
 		select {
 		case s.ch <- message.id:
+			if obs != nil {
+				obs.RecordEnqueueDepth(len(s.ch))
+			}
 		default:
 			// Single non-blocking drain + retry. Looping unbounded would
 			// let a fast publisher starve the consumer indefinitely.
@@ -185,27 +203,42 @@ func (s *Subscription[T]) enqueue(message *Message[T]) {
 			case droppedID := <-s.ch:
 				slog.Warn("pubsub: drop oldest (channel full)",
 					"topic", s.topic.name, "subscription", s.name)
+				if obs != nil {
+					obs.RecordDrop(DropPolicyOldest)
+				}
 				if dropped := s.message(droppedID); dropped != nil {
 					s.ack(dropped)
 				}
 				select {
 				case s.ch <- message.id:
+					if obs != nil {
+						obs.RecordEnqueueDepth(len(s.ch))
+					}
 				default:
 					// A concurrent publisher refilled the slot; treat
 					// this publish as a newest-drop fallback rather
 					// than spinning on the channel.
 					slog.Warn("pubsub: drop newest after oldest drop (still full)",
 						"topic", s.topic.name, "subscription", s.name)
+					if obs != nil {
+						obs.RecordDrop(DropPolicyNewestAfterOldest)
+					}
 					s.ack(message)
 				}
 			default:
 				// Channel drained between the full-select and the drain
 				// attempt; just send.
 				s.ch <- message.id
+				if obs != nil {
+					obs.RecordEnqueueDepth(len(s.ch))
+				}
 			}
 		}
 	default: // FullPolicyBlock
 		s.ch <- message.id
+		if obs != nil {
+			obs.RecordEnqueueDepth(len(s.ch))
+		}
 	}
 }
 

--- a/core/concurrent/pubsub/subscription_test.go
+++ b/core/concurrent/pubsub/subscription_test.go
@@ -829,3 +829,157 @@ func TestSubscription_FullPolicyDropOldest(t *testing.T) {
 		t.Errorf("DropOldest: newest message missing from s.messages")
 	}
 }
+
+// recordingObserver captures Observer invocations for assertion in tests.
+// All fields are read after the system under test has quiesced so a plain
+// mutex (not atomic) keeps the test code readable.
+type recordingObserver struct {
+	mu         sync.Mutex
+	depths     []int
+	drops      []string
+	dispatches []time.Duration
+}
+
+func (r *recordingObserver) RecordEnqueueDepth(d int) {
+	r.mu.Lock()
+	r.depths = append(r.depths, d)
+	r.mu.Unlock()
+}
+
+func (r *recordingObserver) RecordDrop(policy string) {
+	r.mu.Lock()
+	r.drops = append(r.drops, policy)
+	r.mu.Unlock()
+}
+
+func (r *recordingObserver) ObserveDispatch(d time.Duration) {
+	r.mu.Lock()
+	r.dispatches = append(r.dispatches, d)
+	r.mu.Unlock()
+}
+
+func (r *recordingObserver) snapshot() (depths []int, drops []string, dispatches []time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	depths = append(depths, r.depths...)
+	drops = append(drops, r.drops...)
+	dispatches = append(dispatches, r.dispatches...)
+	return
+}
+
+func TestSubscription_Observer_RecordEnqueueDepthOnPublish(t *testing.T) {
+	// Each successful publish must produce exactly one depth sample equal
+	// to the channel length immediately after the send (#240).
+	obs := &recordingObserver{}
+	topic := NewTopic[int]("obs-depth")
+	sub := topic.NewSubscriptionWithOptions("s",
+		WithBufferSize(4),
+		WithObserver(obs),
+	)
+	sub.publish(sub.newMessage(1))
+	sub.publish(sub.newMessage(2))
+	sub.publish(sub.newMessage(3))
+
+	depths, drops, _ := obs.snapshot()
+	if len(drops) != 0 {
+		t.Errorf("unexpected drops on uncongested publish: %v", drops)
+	}
+	want := []int{1, 2, 3}
+	if !reflect.DeepEqual(depths, want) {
+		t.Errorf("depths = %v, want %v", depths, want)
+	}
+}
+
+func TestSubscription_Observer_RecordDropNewest(t *testing.T) {
+	obs := &recordingObserver{}
+	topic := NewTopic[int]("obs-drop-newest")
+	sub := topic.NewSubscriptionWithOptions("s",
+		WithBufferSize(1),
+		WithFullPolicy(FullPolicyDropNewest),
+		WithObserver(obs),
+	)
+	sub.publish(sub.newMessage(1)) // fills channel
+	sub.publish(sub.newMessage(2)) // dropped
+
+	_, drops, _ := obs.snapshot()
+	if !reflect.DeepEqual(drops, []string{DropPolicyNewest}) {
+		t.Errorf("drops = %v, want [%s]", drops, DropPolicyNewest)
+	}
+}
+
+func TestSubscription_Observer_RecordDropOldest(t *testing.T) {
+	obs := &recordingObserver{}
+	topic := NewTopic[int]("obs-drop-oldest")
+	sub := topic.NewSubscriptionWithOptions("s",
+		WithBufferSize(1),
+		WithFullPolicy(FullPolicyDropOldest),
+		WithObserver(obs),
+	)
+	sub.publish(sub.newMessage(1)) // fills channel
+	sub.publish(sub.newMessage(2)) // evicts id=1, enqueues id=2
+
+	_, drops, _ := obs.snapshot()
+	if !reflect.DeepEqual(drops, []string{DropPolicyOldest}) {
+		t.Errorf("drops = %v, want [%s]", drops, DropPolicyOldest)
+	}
+}
+
+func TestSubscription_Observer_ObserveDispatchOnConsumerReturn(t *testing.T) {
+	// Subscribe drains the channel and the worker must call
+	// ObserveDispatch after the consumer returns, with a duration
+	// measured from the originating Publish (#240).
+	obs := &recordingObserver{}
+	topic := NewTopic[int]("obs-dispatch")
+	sub := topic.NewSubscriptionWithOptions("s",
+		WithBufferSize(4),
+		WithObserver(obs),
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go sub.Subscribe(ctx, func(m *Message[int]) {
+		defer wg.Done()
+		m.Ack()
+	})
+
+	sub.publish(sub.newMessage(1))
+	sub.publish(sub.newMessage(2))
+	sub.publish(sub.newMessage(3))
+
+	wg.Wait()
+	// Give the worker a moment to run the post-consumer Observe call.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		_, _, dispatches := obs.snapshot()
+		if len(dispatches) >= 3 {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	_, _, dispatches := obs.snapshot()
+	if len(dispatches) != 3 {
+		t.Fatalf("dispatch observations = %d, want 3", len(dispatches))
+	}
+	for i, d := range dispatches {
+		if d < 0 {
+			t.Errorf("dispatch[%d] = %v, want >= 0", i, d)
+		}
+	}
+}
+
+func TestWithObserver_NilRestoresNoop(t *testing.T) {
+	// WithObserver(nil) must not leave the subscription with a nil
+	// observer (which would NPE in enqueue). It must restore the
+	// internal no-op sentinel.
+	topic := NewTopic[int]("obs-nil")
+	sub := topic.NewSubscriptionWithOptions("s", WithObserver(nil))
+	if sub.observer == nil {
+		t.Fatal("observer is nil; WithObserver(nil) should restore noopObserver{}")
+	}
+	if _, ok := sub.observer.(noopObserver); !ok {
+		t.Errorf("observer type = %T, want noopObserver", sub.observer)
+	}
+}

--- a/core/concurrent/pubsub/topic.go
+++ b/core/concurrent/pubsub/topic.go
@@ -95,6 +95,7 @@ func (t *Topic[T]) NewSubscriptionWithOptions(name string, opts ...SubscriptionO
 			ttl:         cfg.ttl,
 			bufferSize:  cfg.bufferSize,
 			fullPolicy:  cfg.fullPolicy,
+			observer:    cfg.observer,
 		}
 	}
 	return t.subscriptions[name]

--- a/server/README.md
+++ b/server/README.md
@@ -123,6 +123,9 @@ runtime, process, and `grpc_server_*` collectors):
 | `lantern_mutation_log_capacity` | gauge | — | Configured ring slots. |
 | `lantern_subscribe_active_streams` | gauge | — | Active `Subscribe` streams. |
 | `lantern_subscribe_dropped_total` | counter | `reason` | `Subscribe` aborts. |
+| `lantern_subscription_queue_depth` | histogram | — | In-process pubsub subscription channel depth, sampled on every successful enqueue (#240). Aggregate across subscriptions. |
+| `lantern_subscription_dropped_total` | counter | `policy` | Pubsub messages dropped at the subscription enqueue boundary, partitioned by `FullPolicy` decision (`drop_newest`, `drop_oldest`, `drop_newest_after_oldest`). Pre-warmed. |
+| `lantern_subscription_dispatch_duration_seconds` | histogram | — | Pubsub dispatch latency from `Publish` to consumer return. Aggregate across subscriptions. |
 | `lantern_replication_applied_total` | counter | `origin` | Remote mutations applied locally. |
 | `lantern_replication_dropped_total` | counter | `peer`, `reason` | Replication frames or peer interactions dropped. |
 | `lantern_replication_lag_seq` | gauge | `peer`, `origin` | Per-(peer, origin) lag in seq units. |

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -10,6 +10,7 @@ import (
 	"runtime/debug"
 	"time"
 
+	"github.com/anaregdesign/lantern/core/concurrent/pubsub"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -41,6 +42,13 @@ type DomainMetrics struct {
 	mutationLogCapacity prometheus.Gauge
 	subscribeActive     prometheus.Gauge
 	subscribeDropped    *prometheus.CounterVec
+
+	// In-process pubsub subscription telemetry (#240). Wired by the
+	// server-side pubsub.Observer adapter so the leaf core/concurrent/
+	// pubsub package never imports server/metrics.
+	pubsubQueueDepth       prometheus.Histogram
+	pubsubDropped          *prometheus.CounterVec
+	pubsubDispatchDuration prometheus.Histogram
 
 	replicationApplied   *prometheus.CounterVec
 	replicationDropped   *prometheus.CounterVec
@@ -207,6 +215,20 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 			Name: "lantern_subscribe_dropped_total",
 			Help: "Total Subscribe streams terminated abnormally, partitioned by reason (gapped, send_failed).",
 		}, []string{"reason"}),
+		pubsubQueueDepth: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "lantern_subscription_queue_depth",
+			Help:    "Distribution of in-process pubsub subscription channel depth, sampled on every successful enqueue (#240). Aggregated across all subscriptions to avoid per-subscription cardinality.",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 12), // 1 .. 2048
+		}),
+		pubsubDropped: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "lantern_subscription_dropped_total",
+			Help: "Total pubsub messages dropped at the subscription enqueue boundary, partitioned by FullPolicy decision (drop_newest | drop_oldest | drop_newest_after_oldest). Each drop path increments exactly once.",
+		}, []string{"policy"}),
+		pubsubDispatchDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "lantern_subscription_dispatch_duration_seconds",
+			Help:    "Distribution of pubsub dispatch latency measured from Publish to consumer return (#240). Aggregated across all subscriptions.",
+			Buckets: prometheus.ExponentialBuckets(0.0001, 4, 8), // 0.1ms .. ~1.6s
+		}),
 		replicationApplied: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "lantern_replication_applied_total",
 			Help: "Total remote mutations applied locally via the replication apply path, partitioned by origin (HLC NodeID, lowercase hex).",
@@ -313,6 +335,7 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 
 	reg.MustRegister(m.vertices, m.edges, m.expirations, m.gcDuration, m.buildInfo,
 		m.mutationLogEntries, m.mutationLogCapacity, m.subscribeActive, m.subscribeDropped,
+		m.pubsubQueueDepth, m.pubsubDropped, m.pubsubDispatchDuration,
 		m.replicationApplied, m.replicationDropped, m.replicationLag,
 		m.antiEntropyCycles, m.antiEntropyGapsFound,
 		m.illuminateVisitedVertices, m.illuminateVisitedEdges, m.illuminateDuration,
@@ -325,6 +348,14 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 	// Pre-create label rows so empty counters scrape as 0.
 	for _, r := range []string{"gapped", "send_failed"} {
 		m.subscribeDropped.WithLabelValues(r)
+	}
+
+	// Pre-warm the pubsub drop counter (#240) so every FullPolicy label
+	// row scrapes as 0 from process start. Sourced from
+	// pubsub.DropPolicies so adding a new policy in core/ surfaces here
+	// at compile time without a metrics edit.
+	for _, p := range pubsub.DropPolicies {
+		m.pubsubDropped.WithLabelValues(p)
 	}
 
 	// Pre-create label rows so empty counters are still scraped as 0.
@@ -423,6 +454,40 @@ func (m *DomainMetrics) OnSubscribeEnded() {
 func (m *DomainMetrics) OnSubscribeDropped(reason string) {
 	m.subscribeDropped.WithLabelValues(reason).Inc()
 }
+
+// OnPubsubQueueDepth records a single in-process pubsub subscription
+// channel-depth sample. Called once per successful enqueue by the
+// pubsub.Observer adapter installed via WithObserver (#240).
+func (m *DomainMetrics) OnPubsubQueueDepth(depth int) {
+	m.pubsubQueueDepth.Observe(float64(depth))
+}
+
+// OnPubsubDrop increments the pubsub drop counter for the given
+// FullPolicy decision. policy must be one of pubsub.DropPolicies; unknown
+// labels will register lazily but are not pre-warmed.
+func (m *DomainMetrics) OnPubsubDrop(policy string) {
+	m.pubsubDropped.WithLabelValues(policy).Inc()
+}
+
+// OnPubsubDispatchDuration records a single Publish→consumer-return
+// latency sample.
+func (m *DomainMetrics) OnPubsubDispatchDuration(d time.Duration) {
+	m.pubsubDispatchDuration.Observe(d.Seconds())
+}
+
+// PubsubObserver returns a pubsub.Observer adapter that fans out to the
+// three pubsub collectors. Server code installs it with pubsub.WithObserver
+// when constructing in-process subscriptions; the adapter keeps
+// core/concurrent/pubsub free of any server/metrics import (#240).
+func (m *DomainMetrics) PubsubObserver() pubsub.Observer {
+	return pubsubObserver{m: m}
+}
+
+type pubsubObserver struct{ m *DomainMetrics }
+
+func (o pubsubObserver) RecordEnqueueDepth(depth int)    { o.m.OnPubsubQueueDepth(depth) }
+func (o pubsubObserver) RecordDrop(policy string)        { o.m.OnPubsubDrop(policy) }
+func (o pubsubObserver) ObserveDispatch(d time.Duration) { o.m.OnPubsubDispatchDuration(d) }
 
 // OnReplicationApplied increments lantern_replication_applied_total for
 // a mutation accepted by the apply path. origin is the HLC NodeID of the

--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/anaregdesign/lantern/core/concurrent/pubsub"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
@@ -432,4 +433,71 @@ func TestDomainMetrics_RejectionFamilies(t *testing.T) {
 	if got := testutil.ToFloat64(m.tombstoneClampRejected); got != 1 {
 		t.Errorf("tombstone_clamp_rejected_total = %v, want 1", got)
 	}
+}
+
+func TestDomainMetrics_PubsubFamiliesAndPreWarm(t *testing.T) {
+	// Acceptance for #240: the three pubsub collectors must register and
+	// every DropPolicies label row must scrape as 0 from process start
+	// (pre-warmed in New). Methods must increment / observe correctly.
+	reg := prometheus.NewRegistry()
+	m := New(reg, Options{Version: "v0.7.0", Commit: "deadbeef", SampleInterval: time.Hour})
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	names := make(map[string]bool, len(mfs))
+	for _, mf := range mfs {
+		names[mf.GetName()] = true
+	}
+	for _, want := range []string{
+		"lantern_subscription_queue_depth",
+		"lantern_subscription_dropped_total",
+		"lantern_subscription_dispatch_duration_seconds",
+	} {
+		if !names[want] {
+			t.Errorf("metric family %q not registered", want)
+		}
+	}
+
+	// Every DropPolicy label row must be pre-warmed at 0.
+	for _, p := range pubsub.DropPolicies {
+		if got := testutil.ToFloat64(m.pubsubDropped.WithLabelValues(p)); got != 0 {
+			t.Errorf("pubsub_dropped_total{policy=%q} pre-warm = %v, want 0", p, got)
+		}
+	}
+
+	// Methods bump the right collectors.
+	m.OnPubsubQueueDepth(7)
+	m.OnPubsubDrop(pubsub.DropPolicyNewest)
+	m.OnPubsubDrop(pubsub.DropPolicyNewest)
+	m.OnPubsubDrop(pubsub.DropPolicyOldest)
+	m.OnPubsubDispatchDuration(3 * time.Millisecond)
+
+	if got := testutil.ToFloat64(m.pubsubDropped.WithLabelValues(pubsub.DropPolicyNewest)); got != 2 {
+		t.Errorf("pubsub_dropped_total{policy=drop_newest} = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(m.pubsubDropped.WithLabelValues(pubsub.DropPolicyOldest)); got != 1 {
+		t.Errorf("pubsub_dropped_total{policy=drop_oldest} = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.pubsubDropped.WithLabelValues(pubsub.DropPolicyNewestAfterOldest)); got != 0 {
+		t.Errorf("pubsub_dropped_total{policy=drop_newest_after_oldest} = %v, want 0 (not called)", got)
+	}
+
+	// Histograms expose count via the dto.Metric; assert sample_count.
+	if got := collectHistogramCount(t, m.pubsubQueueDepth); got != 1 {
+		t.Errorf("pubsub_queue_depth count = %d, want 1", got)
+	}
+	if got := collectHistogramCount(t, m.pubsubDispatchDuration); got != 1 {
+		t.Errorf("pubsub_dispatch_duration count = %d, want 1", got)
+	}
+}
+
+func collectHistogramCount(t *testing.T, h prometheus.Histogram) uint64 {
+	t.Helper()
+	var dtoM dto.Metric
+	if err := h.Write(&dtoM); err != nil {
+		t.Fatalf("histogram write: %v", err)
+	}
+	return dtoM.GetHistogram().GetSampleCount()
 }


### PR DESCRIPTION
Closes #240
Part of #237.

Adds an `Observer` surface to `core/concurrent/pubsub` and three new `lantern_subscription_*` Prometheus collectors so dashboards can see in-process pubsub back-pressure.

### core/concurrent/pubsub (leaf module — no server/metrics import)
- New `Observer` interface: `RecordEnqueueDepth` / `RecordDrop` / `ObserveDispatch` with a `noopObserver` default.
- Drop policy label constants exported as `pubsub.DropPolicies` so the server side can pre-warm the counter and a future policy surfaces at compile time.
- `WithObserver` `SubscriptionOption`; nil restores the noop.
- `Subscription.enqueue` reports depth on every successful send and fires `RecordDrop` on each of the three drop branches (`DropNewest`, `DropOldest` happy-path drop, `DropOldest` fallback). Subscribe worker wraps consumer return with `ObserveDispatch(time.Since(createdAt))`.

### server/metrics
- New collectors: `lantern_subscription_queue_depth` (histogram), `lantern_subscription_dropped_total{policy}` (counter, label pre-warmed from `pubsub.DropPolicies`), `lantern_subscription_dispatch_duration_seconds` (histogram). Aggregate, no per-subscription label, per issue spec.
- `DomainMetrics.PubsubObserver()` returns a `pubsub.Observer` adapter so callers can pass it straight to `pubsub.WithObserver`. The server does not currently construct pubsub topics, so the new series stay at zero until that wire-up lands — the metric contract is what #240 calls for.

### Tests
- pubsub: noop safety + `DropPolicies` contract, observer fakes covering enqueue depth, both DropNewest/DropOldest counters, dispatch wrapper, nil-restores-noop.
- server/metrics: family registration, `DropPolicies` pre-warm at 0, method fan-out, and the `PubsubObserver` adapter satisfies `pubsub.Observer`.

Local gate green: gofmt clean across all modules; `go vet` + `go test` pass for ., cli, core, pb, sdks/go, server, tests/integration.