### PR TITLE
bench(#241): ghz scenario harness + leak gate for HA compose cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ dist/
 *.out
 coverage.out
 coverage.html
+
+# Bench harness output (testbed/bench/) — local-only run artifacts.
+testbed/bench/out/

--- a/testbed/bench/README.md
+++ b/testbed/bench/README.md
@@ -1,0 +1,117 @@
+# lantern bench harness (`testbed/bench/`)
+
+Reusable performance + memory-leak harness for the HA `docker compose`
+cluster (see `deploy/compose/`). Drives the cluster with [`ghz`][ghz],
+captures Prometheus range queries + Go pprof snapshots, applies a
+per-scenario leak gate, and renders a Markdown report.
+
+> **Not wired into CI.** Per the parent epic [#237], CI runs only fast
+> functional checks; this harness is a local / on-demand tool meant to be
+> used by maintainers when investigating performance or leak regressions.
+> Its outputs (under `testbed/bench/out/`) are git-ignored.
+
+## Prerequisites
+
+- Docker + `docker compose` v2
+- [`ghz`][ghz] ≥ 0.117
+- [`yq`][yq] v4 (Go reimplementation)
+- `jq`, `curl`, `bash` ≥ 4
+- Go (matching `go.mod` toolchain) — used to build the report renderer
+
+## Quick start
+
+```bash
+# Run any scenario:
+./testbed/bench/run.sh write_heavy
+
+# Keep the cluster up after the run (useful for ad-hoc poking):
+KEEP_UP=1 ./testbed/bench/run.sh read_heavy
+
+# Reuse an already-running cluster (skip compose up / down):
+SKIP_UP=1 KEEP_UP=1 ./testbed/bench/run.sh mixed_rw
+
+# Also capture a 30s CPU profile per replica after the steady phase:
+PPROF_CPU=1 ./testbed/bench/run.sh addedge_contention
+```
+
+The exit code mirrors the leak-gate verdict (`0`=pass, `1`=fail). Run
+artifacts are written under
+`testbed/bench/out/<scenario>/<UTC-timestamp>/`.
+
+## Scenarios
+
+| File | What it stresses |
+| --- | --- |
+| `write_heavy.yaml` | sustained `PutVertex` from many clients |
+| `read_heavy.yaml`  | sustained `GetVertex` on pre-warmed keys |
+| `mixed_rw.yaml`    | 50/50 `PutVertex`/`GetVertex` (two parallel ghz runs) |
+| `batch_put_vertices.yaml` | bulk write path via `PutVertices` |
+| `addedge_contention.yaml` | repeated `AddEdge` on the same (tail, head) — block/mutex hotspot probe |
+| `illuminate.yaml`  | graph traversal under moderate RPS |
+| `scan_prefix.yaml` | paginated prefix scans |
+| `ttl_churn.yaml`   | short TTLs + steady writes (expirer + timer wheel) |
+| `replication_soak.yaml`   | producer on r0, `Subscribe` consumers on r1/r2 for 10m |
+| `chaos_kill_replica.yaml` | mid-load `docker kill` + restart of one replica |
+| `many_subscribers.yaml`   | N concurrent `Subscribe` streams across replicas (#240 pubsub probe) |
+
+Each YAML declares the phases (`warmup`, `steady`, `cooldown`), the ghz
+target (`call` + `data_template`), optional `subscribe` and `chaos`
+blocks, and the leak-gate thresholds (`goroutine_max_delta`,
+`heap_inuse_max_delta_mb`).
+
+## Output layout
+
+```
+testbed/bench/out/<scenario>/<ts>/
+├── report.md                       # rendered summary (start here)
+├── leak_gate.json                  # verdict + per-replica deltas + thresholds
+├── runtime_pre.json                # per-replica go_goroutines + heap_inuse, after warmup
+├── runtime_post.json               # same, after cooldown
+├── ghz_warmup_<endpoint>.json      # raw ghz results, one per invocation
+├── ghz_steady_<...>.json
+├── ghz_sub*_<n>.json               # if subscribers were launched
+├── prom/
+│   ├── _index.ndjson               # {query, file} pairs
+│   └── q_NN.json                   # raw Prom /api/v1/query_range output
+└── pprof/
+    └── <endpoint>__{pre,post}__{heap,goroutine,allocs,mutex,block[,profile]}.pb.gz
+```
+
+## Drill-down workflow
+
+1. **Verdict & deltas.** Open `report.md`. The leak-gate table shows the
+   pre/post goroutines + heap_inuse per replica with the Δ vs the
+   scenario threshold. Any cell exceeding the threshold is the first
+   place to look.
+2. **Allocation source.** For a leaking replica, diff its heap profiles:
+
+   ```bash
+   go tool pprof -http=:0 \
+     -base testbed/bench/out/<sc>/<ts>/pprof/<ep>__pre__heap.pb.gz \
+            testbed/bench/out/<sc>/<ts>/pprof/<ep>__post__heap.pb.gz
+   ```
+
+3. **Stuck goroutines.** Open `<ep>__post__goroutine.pb.gz` and look for
+   blocked stacks (e.g. on channel send/recv, on a sync.Mutex). For
+   `addedge_contention` the mutex and block profiles (`<ep>__post__mutex.pb.gz`,
+   `<ep>__post__block.pb.gz`) are the primary signal.
+4. **Tail latency.** Cross-reference the ghz p99 column in `report.md`
+   with the matching Prom histogram queries listed under
+   "Prometheus range queries" (raw data in `prom/q_NN.json`).
+5. **Pubsub (#240).** `many_subscribers` and `replication_soak` exercise
+   the subscription queue. Inspect the per-policy
+   `lantern_subscription_dropped_total` and
+   `lantern_subscription_queue_depth_bucket` queries in `prom/`.
+
+## Why not in CI?
+
+This harness needs real wall-clock time (multi-minute steady phases, a
+10-minute soak), a healthy Docker daemon, and stable host conditions to
+produce trustworthy numbers. Running it in CI would be both slow and
+flaky. The parent epic ([#237]) explicitly carves out this harness as a
+maintainer-driven tool; functional regressions are covered by the
+existing unit + integration suites that CI already runs.
+
+[ghz]: https://ghz.sh/
+[yq]: https://github.com/mikefarah/yq
+[#237]: https://github.com/anaregdesign/lantern/issues/237

--- a/testbed/bench/capture/pprof.sh
+++ b/testbed/bench/capture/pprof.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# pprof.sh — snapshot pprof profiles from every replica.
+#
+# Args:
+#   $1  output directory                (e.g. out/write_heavy/20250101T000000Z/pprof)
+#   $2  phase tag                       ("pre" | "post")
+#   $@  remaining: replica host:port    (default: localhost:9390 9391 9392)
+#
+# Per replica + per phase we capture:
+#   - heap        (always, cheap)
+#   - goroutine   (always, cheap)
+#   - allocs      (always, cheap)
+#
+# Per replica + post-phase only we additionally capture:
+#   - mutex       (requires LANTERN_MUTEX_PROFILE_FRACTION != 0)
+#   - block       (requires LANTERN_BLOCK_PROFILE_RATE != 0)
+#   - profile?seconds=30   (CPU, 30s — opt in via PPROF_CPU=1)
+#
+# All profiles are .pb.gz files named:
+#   <replica>__<phase>__<profile>.pb.gz
+#
+# Quiet on success; loud on failure. Returns non-zero if any required
+# profile fetch fails — but missing mutex/block from a misconfigured run
+# is reported as a warning, not a hard error, so the bench can still
+# proceed and emit a partial report.
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: pprof.sh <outdir> <pre|post> [host:port ...]" >&2
+  exit 2
+fi
+
+outdir="$1"; shift
+phase="$1"; shift
+if [[ $# -eq 0 ]]; then
+  set -- localhost:9390 localhost:9391 localhost:9392
+fi
+
+mkdir -p "$outdir"
+
+fetch() {
+  local replica="$1" name="$2" url="$3" required="$4"
+  local safe="${replica//[:\/]/_}"
+  local out="$outdir/${safe}__${phase}__${name}.pb.gz"
+  if curl -fsS --max-time 60 "$url" -o "$out"; then
+    return 0
+  fi
+  if [[ "$required" == "true" ]]; then
+    echo "pprof.sh: required profile $name from $replica failed: $url" >&2
+    return 1
+  fi
+  echo "pprof.sh: optional profile $name from $replica unavailable ($url) — skipping" >&2
+  rm -f "$out"
+  return 0
+}
+
+for replica in "$@"; do
+  base="http://${replica}/debug/pprof"
+  fetch "$replica" heap      "$base/heap"      true
+  fetch "$replica" goroutine "$base/goroutine" true
+  fetch "$replica" allocs    "$base/allocs"    true
+  if [[ "$phase" == "post" ]]; then
+    fetch "$replica" mutex "$base/mutex" false
+    fetch "$replica" block "$base/block" false
+    if [[ "${PPROF_CPU:-0}" == "1" ]]; then
+      fetch "$replica" cpu "$base/profile?seconds=30" false
+    fi
+  fi
+done

--- a/testbed/bench/capture/prom_queries.txt
+++ b/testbed/bench/capture/prom_queries.txt
@@ -1,0 +1,29 @@
+# PromQL range queries captured at the end of every bench run.
+#
+# Format: one query per line.  "#" lines and blank lines are ignored.
+# Each line is run as a /api/v1/query_range against the bench's Prometheus
+# (http://localhost:9091 by default) with the run's [start, end] window.
+# Results land under out/<scenario>/<ts>/prom/<sanitized-query>.json.
+#
+# These intentionally lean on the metrics introduced in #238 (pprof handles
+# nothing here directly), #239 (mutex/block — visible via pprof, not Prom),
+# and #240 (pubsub queue depth / drops / dispatch latency).
+
+# --- service-level throughput / errors ---------------------------------
+sum by (grpc_method) (rate(grpc_server_handled_total[30s]))
+sum by (grpc_method, grpc_code) (rate(grpc_server_handled_total{grpc_code!="OK"}[30s]))
+histogram_quantile(0.99, sum by (le, grpc_method) (rate(grpc_server_handling_seconds_bucket[30s])))
+
+# --- runtime + GC pressure (#238 pprof complements these) --------------
+avg by (instance) (go_goroutines)
+avg by (instance) (go_memstats_heap_inuse_bytes)
+rate(go_memstats_gc_cpu_fraction[1m])
+
+# --- replication health (HA topology) ----------------------------------
+sum by (instance) (rate(lantern_replication_events_total[30s]))
+max by (instance) (lantern_replication_lag_seconds)
+
+# --- pubsub fan-out (#240) --------------------------------------------
+histogram_quantile(0.99, sum by (le) (rate(lantern_subscription_queue_depth_bucket[30s])))
+sum by (policy) (rate(lantern_subscription_dropped_total[30s]))
+histogram_quantile(0.99, sum by (le) (rate(lantern_subscription_dispatch_duration_seconds_bucket[30s])))

--- a/testbed/bench/compose.override.yml
+++ b/testbed/bench/compose.override.yml
@@ -1,0 +1,30 @@
+# Compose override for the bench harness.
+#
+# Layered on top of deploy/compose/docker-compose.yml so the bench can:
+#   1. reach each replica's /debug/pprof/* endpoint from the host, and
+#   2. capture mutex + block profiles (rates are server defaults of 0 in
+#      production; the harness opts in for contention scenarios).
+#
+# Apply via:
+#   docker compose \
+#     -f deploy/compose/docker-compose.yml \
+#     -f testbed/bench/compose.override.yml \
+#     up -d
+#
+# The metrics port (9090 inside the container) is published on a per-replica
+# host range 9390-9392 so each replica is independently scrape-able by the
+# harness's pprof.sh and direct /metrics curls.
+
+services:
+  lantern:
+    environment:
+      LANTERN_PPROF_ENABLED: "true"
+      # Sample 1/N events. Non-zero values are required for /debug/pprof/mutex
+      # and /debug/pprof/block to return useful data. Cheap at these rates.
+      LANTERN_MUTEX_PROFILE_FRACTION: "100"
+      LANTERN_BLOCK_PROFILE_RATE: "10000"
+    ports:
+      - target: 9090
+        published: "9390-9392"
+        protocol: tcp
+        mode: host

--- a/testbed/bench/report/render.go
+++ b/testbed/bench/report/render.go
@@ -1,0 +1,284 @@
+// Package main is the bench-harness report renderer.
+//
+// It consumes the JSON artifacts emitted by testbed/bench/run.sh under
+// out/<scenario>/<timestamp>/ and writes a Markdown summary to stdout:
+//
+//   - leak_gate.json            -> Leak Gate section + verdict header
+//   - ghz_*.json                -> Per-phase / per-call latency tables
+//   - prom/_index.ndjson        -> Indexed list of Prom range queries
+//   - pprof/                    -> Inventory of captured pprof profiles
+//
+// The renderer is intentionally side-effect free aside from reading the
+// run directory and writing Markdown to its writer, so it round-trips
+// cleanly under unit tests with synthetic fixtures.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// LeakGate mirrors the schema written by run.sh.
+type LeakGate struct {
+	Thresholds struct {
+		GoroutineMaxDelta   int `json:"goroutine_max_delta"`
+		HeapInuseMaxDeltaMB int `json:"heap_inuse_max_delta_mb"`
+	} `json:"thresholds"`
+	Replicas []LeakGateReplica `json:"replicas"`
+	Verdict  string            `json:"verdict"`
+}
+
+// LeakGateReplica is one row of the per-replica delta table.
+type LeakGateReplica struct {
+	Endpoint            string `json:"endpoint"`
+	GoroutinesPre       int    `json:"goroutines_pre"`
+	GoroutinesPost      int    `json:"goroutines_post"`
+	GoroutineDelta      int    `json:"goroutine_delta"`
+	HeapInusePreBytes   int64  `json:"heap_inuse_pre_bytes"`
+	HeapInusePostBytes  int64  `json:"heap_inuse_post_bytes"`
+	HeapInuseDeltaBytes int64  `json:"heap_inuse_delta_bytes"`
+}
+
+// GhzSummary captures the subset of fields ghz writes that the report uses.
+// All durations are nanoseconds as serialised by ghz --format json.
+type GhzSummary struct {
+	Name    string  `json:"name"`
+	Count   uint64  `json:"count"`
+	Average int64   `json:"average"`
+	Fastest int64   `json:"fastest"`
+	Slowest int64   `json:"slowest"`
+	Rps     float64 `json:"rps"`
+
+	StatusCodeDistribution map[string]int `json:"statusCodeDistribution"`
+	LatencyDistribution    []struct {
+		Percentage int   `json:"percentage"`
+		Latency    int64 `json:"latency"`
+	} `json:"latencyDistribution"`
+}
+
+// PromIndexEntry is one row of prom/_index.ndjson.
+type PromIndexEntry struct {
+	Query string `json:"query"`
+	File  string `json:"file"`
+}
+
+// Input is the rendered report's input model. All fields are optional —
+// missing artifacts produce "(not captured)" sections rather than errors.
+type Input struct {
+	Scenario  string
+	Timestamp string
+	LeakGate  *LeakGate
+	GhzFiles  []GhzFile
+	PromIndex []PromIndexEntry
+	PprofList []string
+}
+
+// GhzFile is one ghz JSON output paired with its source filename so the
+// report can show readers which on-disk artifact each row came from.
+type GhzFile struct {
+	Name    string
+	Summary GhzSummary
+}
+
+// LoadInput walks `dir` and assembles an Input from whatever artifacts the
+// run produced. Missing files are tolerated.
+func LoadInput(dir, scenario, ts string) (Input, error) {
+	in := Input{Scenario: scenario, Timestamp: ts}
+
+	if b, err := os.ReadFile(filepath.Join(dir, "leak_gate.json")); err == nil {
+		var lg LeakGate
+		if err := json.Unmarshal(b, &lg); err != nil {
+			return in, fmt.Errorf("parse leak_gate.json: %w", err)
+		}
+		in.LeakGate = &lg
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return in, err
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return in, err
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasPrefix(name, "ghz_") || !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return in, err
+		}
+		var s GhzSummary
+		if err := json.Unmarshal(b, &s); err != nil {
+			return in, fmt.Errorf("parse %s: %w", name, err)
+		}
+		in.GhzFiles = append(in.GhzFiles, GhzFile{Name: name, Summary: s})
+	}
+	sort.Slice(in.GhzFiles, func(i, j int) bool { return in.GhzFiles[i].Name < in.GhzFiles[j].Name })
+
+	if b, err := os.ReadFile(filepath.Join(dir, "prom", "_index.ndjson")); err == nil {
+		for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+			if line == "" {
+				continue
+			}
+			var p PromIndexEntry
+			if err := json.Unmarshal([]byte(line), &p); err != nil {
+				return in, fmt.Errorf("parse prom index: %w", err)
+			}
+			in.PromIndex = append(in.PromIndex, p)
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return in, err
+	}
+
+	if pprofs, err := os.ReadDir(filepath.Join(dir, "pprof")); err == nil {
+		for _, p := range pprofs {
+			if !p.IsDir() {
+				in.PprofList = append(in.PprofList, p.Name())
+			}
+		}
+		sort.Strings(in.PprofList)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return in, err
+	}
+
+	return in, nil
+}
+
+// RenderReport writes a Markdown report for `in` to `w`. Output is stable
+// for fixed inputs (no timestamps from time.Now, etc.).
+func RenderReport(w io.Writer, in Input) error {
+	bw := &errWriter{w: w}
+
+	verdict := "(no leak gate captured)"
+	if in.LeakGate != nil {
+		verdict = in.LeakGate.Verdict
+	}
+	bw.printf("# Bench report — `%s` @ `%s`\n\n", in.Scenario, in.Timestamp)
+	bw.printf("**Leak gate verdict:** `%s`\n\n", verdict)
+
+	bw.printf("## Leak gate\n\n")
+	if in.LeakGate == nil {
+		bw.printf("_not captured_\n\n")
+	} else {
+		bw.printf("Thresholds: goroutine_max_delta=%d, heap_inuse_max_delta_mb=%d\n\n",
+			in.LeakGate.Thresholds.GoroutineMaxDelta,
+			in.LeakGate.Thresholds.HeapInuseMaxDeltaMB)
+		bw.printf("| replica | goroutines (pre → post = Δ) | heap_inuse MiB (pre → post = Δ) |\n")
+		bw.printf("| --- | --- | --- |\n")
+		for _, r := range in.LeakGate.Replicas {
+			bw.printf("| `%s` | %d → %d = **%+d** | %.1f → %.1f = **%+.1f** |\n",
+				r.Endpoint,
+				r.GoroutinesPre, r.GoroutinesPost, r.GoroutineDelta,
+				bytesToMiB(r.HeapInusePreBytes),
+				bytesToMiB(r.HeapInusePostBytes),
+				bytesToMiB(r.HeapInuseDeltaBytes),
+			)
+		}
+		bw.printf("\n")
+	}
+
+	bw.printf("## ghz runs\n\n")
+	if len(in.GhzFiles) == 0 {
+		bw.printf("_no ghz artifacts found_\n\n")
+	} else {
+		bw.printf("| file | count | rps | avg ms | p99 ms | non-OK |\n")
+		bw.printf("| --- | ---: | ---: | ---: | ---: | ---: |\n")
+		for _, g := range in.GhzFiles {
+			nonOK := 0
+			for code, n := range g.Summary.StatusCodeDistribution {
+				if code != "OK" {
+					nonOK += n
+				}
+			}
+			bw.printf("| `%s` | %d | %.1f | %.2f | %.2f | %d |\n",
+				g.Name,
+				g.Summary.Count,
+				g.Summary.Rps,
+				nsToMs(g.Summary.Average),
+				nsToMs(percentileNs(g.Summary, 99)),
+				nonOK,
+			)
+		}
+		bw.printf("\n")
+	}
+
+	bw.printf("## Prometheus range queries\n\n")
+	if len(in.PromIndex) == 0 {
+		bw.printf("_no prom queries captured_\n\n")
+	} else {
+		for _, p := range in.PromIndex {
+			bw.printf("- `%s` → `prom/%s`\n", p.Query, p.File)
+		}
+		bw.printf("\n")
+	}
+
+	bw.printf("## pprof profiles\n\n")
+	if len(in.PprofList) == 0 {
+		bw.printf("_no pprof profiles captured_\n\n")
+	} else {
+		for _, p := range in.PprofList {
+			bw.printf("- `pprof/%s`\n", p)
+		}
+		bw.printf("\n")
+	}
+
+	bw.printf("## Drill-down\n\n")
+	bw.printf("1. Compare `Δ` cells in the leak gate. Any cell exceeding its threshold is the first place to look.\n")
+	bw.printf("2. For a suspect replica, diff `pprof/<replica>__pre__heap.pb.gz` against `pprof/<replica>__post__heap.pb.gz`:\n")
+	bw.printf("   `go tool pprof -http=:0 -base <pre> <post>`\n")
+	bw.printf("3. For elevated tail latency, cross-reference the matching Prom histogram query with `<replica>__post__goroutine.pb.gz` (look for blocked stacks).\n")
+	return bw.err
+}
+
+func percentileNs(s GhzSummary, pct int) int64 {
+	for _, d := range s.LatencyDistribution {
+		if d.Percentage == pct {
+			return d.Latency
+		}
+	}
+	return 0
+}
+
+func nsToMs(ns int64) float64    { return float64(ns) / 1e6 }
+func bytesToMiB(b int64) float64 { return float64(b) / (1024 * 1024) }
+
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) printf(format string, args ...any) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = fmt.Fprintf(e.w, format, args...)
+}
+
+func main() {
+	dir := flag.String("dir", "", "run output directory (required)")
+	scenario := flag.String("scenario", "", "scenario name")
+	ts := flag.String("timestamp", "", "run timestamp")
+	flag.Parse()
+	if *dir == "" {
+		fmt.Fprintln(os.Stderr, "render: -dir is required")
+		os.Exit(2)
+	}
+	in, err := LoadInput(*dir, *scenario, *ts)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "render: load:", err)
+		os.Exit(1)
+	}
+	if err := RenderReport(os.Stdout, in); err != nil {
+		fmt.Fprintln(os.Stderr, "render: write:", err)
+		os.Exit(1)
+	}
+}

--- a/testbed/bench/report/render_test.go
+++ b/testbed/bench/report/render_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRenderReport_AllSectionsAndVerdict(t *testing.T) {
+	in := Input{
+		Scenario:  "write_heavy",
+		Timestamp: "20250101T000000Z",
+		LeakGate: &LeakGate{
+			Verdict: "pass",
+			Thresholds: struct {
+				GoroutineMaxDelta   int `json:"goroutine_max_delta"`
+				HeapInuseMaxDeltaMB int `json:"heap_inuse_max_delta_mb"`
+			}{GoroutineMaxDelta: 20, HeapInuseMaxDeltaMB: 32},
+			Replicas: []LeakGateReplica{{
+				Endpoint:      "localhost:9390",
+				GoroutinesPre: 100, GoroutinesPost: 110, GoroutineDelta: 10,
+				HeapInusePreBytes: 10 << 20, HeapInusePostBytes: 15 << 20, HeapInuseDeltaBytes: 5 << 20,
+			}},
+		},
+		GhzFiles: []GhzFile{{
+			Name: "ghz_steady_localhost_6380.json",
+			Summary: GhzSummary{
+				Count: 1000, Rps: 100.5, Average: 5_000_000,
+				StatusCodeDistribution: map[string]int{"OK": 990, "DEADLINE_EXCEEDED": 10},
+				LatencyDistribution: []struct {
+					Percentage int   `json:"percentage"`
+					Latency    int64 `json:"latency"`
+				}{{Percentage: 99, Latency: 50_000_000}},
+			},
+		}},
+		PromIndex: []PromIndexEntry{{Query: "go_goroutines", File: "q_01.json"}},
+		PprofList: []string{"localhost_9390__post__heap.pb.gz"},
+	}
+
+	var buf bytes.Buffer
+	if err := RenderReport(&buf, in); err != nil {
+		t.Fatalf("RenderReport: %v", err)
+	}
+	out := buf.String()
+
+	mustContain := []string{
+		"# Bench report — `write_heavy` @ `20250101T000000Z`",
+		"**Leak gate verdict:** `pass`",
+		"## Leak gate",
+		"goroutine_max_delta=20",
+		"`localhost:9390`",
+		"**+10**",
+		"50.00", // p99 ms
+		"`ghz_steady_localhost_6380.json`",
+		"| 10 |", // non-OK column
+		"`go_goroutines` → `prom/q_01.json`",
+		"`pprof/localhost_9390__post__heap.pb.gz`",
+		"## Drill-down",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q\n---\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "DEADLINE_EXCEEDED") {
+		t.Errorf("report should not name individual non-OK codes:\n%s", out)
+	}
+}
+
+func TestRenderReport_HandlesMissingArtifactsGracefully(t *testing.T) {
+	var buf bytes.Buffer
+	if err := RenderReport(&buf, Input{Scenario: "x", Timestamp: "t"}); err != nil {
+		t.Fatalf("RenderReport: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"**Leak gate verdict:** `(no leak gate captured)`",
+		"_not captured_",
+		"_no ghz artifacts found_",
+		"_no prom queries captured_",
+		"_no pprof profiles captured_",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in: %s", want, out)
+		}
+	}
+}
+
+func TestLoadInput_AssemblesFromDisk(t *testing.T) {
+	dir := t.TempDir()
+
+	lg := LeakGate{Verdict: "fail"}
+	lg.Thresholds.GoroutineMaxDelta = 5
+	lg.Thresholds.HeapInuseMaxDeltaMB = 16
+	lg.Replicas = []LeakGateReplica{{Endpoint: "x", GoroutineDelta: 9, HeapInuseDeltaBytes: 1 << 20}}
+	mustWriteJSON(t, filepath.Join(dir, "leak_gate.json"), lg)
+
+	gh := GhzSummary{Count: 42, Rps: 1, Average: 1_000_000,
+		StatusCodeDistribution: map[string]int{"OK": 42},
+		LatencyDistribution: []struct {
+			Percentage int   `json:"percentage"`
+			Latency    int64 `json:"latency"`
+		}{{Percentage: 99, Latency: 2_000_000}}}
+	mustWriteJSON(t, filepath.Join(dir, "ghz_steady_localhost_6380.json"), gh)
+
+	if err := os.MkdirAll(filepath.Join(dir, "prom"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pi, _ := json.Marshal(PromIndexEntry{Query: "up", File: "q_01.json"})
+	if err := os.WriteFile(filepath.Join(dir, "prom", "_index.ndjson"), append(pi, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(dir, "pprof"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pprof", "x__post__heap.pb.gz"), []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	in, err := LoadInput(dir, "sc", "ts")
+	if err != nil {
+		t.Fatalf("LoadInput: %v", err)
+	}
+	if in.LeakGate == nil || in.LeakGate.Verdict != "fail" {
+		t.Errorf("leak gate not loaded: %+v", in.LeakGate)
+	}
+	if len(in.GhzFiles) != 1 || in.GhzFiles[0].Summary.Count != 42 {
+		t.Errorf("ghz files: %+v", in.GhzFiles)
+	}
+	if len(in.PromIndex) != 1 || in.PromIndex[0].Query != "up" {
+		t.Errorf("prom index: %+v", in.PromIndex)
+	}
+	if len(in.PprofList) != 1 || in.PprofList[0] != "x__post__heap.pb.gz" {
+		t.Errorf("pprof list: %+v", in.PprofList)
+	}
+}
+
+func mustWriteJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/testbed/bench/run.sh
+++ b/testbed/bench/run.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# run.sh — entrypoint for the lantern bench harness.
+#
+# Usage:
+#   ./testbed/bench/run.sh <scenario>
+#
+# Argument is the scenario stem under testbed/bench/scenarios/, without the
+# .yaml extension (e.g. `write_heavy`).
+#
+# Environment knobs:
+#   KEEP_UP=1         do not `compose down` at end (handy for debugging)
+#   SKIP_UP=1         assume the cluster is already running; skip compose up
+#   PPROF_CPU=1       also capture a 30s CPU profile per replica post-steady
+#   PROM_URL          override Prometheus URL (default http://localhost:9091)
+#
+# Exits 0 if leak gate verdict == "pass", 1 otherwise. Exits 2 on misuse.
+#
+# Prerequisites: bash 4+, docker, docker compose v2, ghz, yq (v4+), jq, curl,
+#                go (for the report renderer).
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+SCENARIO_DIR="$HERE/scenarios"
+CAPTURE_DIR="$HERE/capture"
+COMPOSE_FILES=(
+  -f "$REPO_ROOT/deploy/compose/docker-compose.yml"
+  -f "$HERE/compose.override.yml"
+)
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-lantern-bench}"
+PROM_URL="${PROM_URL:-http://localhost:9091}"
+
+REPLICA_METRICS_PORTS=(9390 9391 9392)
+REPLICA_GRPC_PORTS=(6380 6381 6382)
+
+die() { echo "run.sh: $*" >&2; exit 1; }
+log() { printf '[%s] %s\n' "$(date -u +%H:%M:%SZ)" "$*"; }
+
+need() { command -v "$1" >/dev/null 2>&1 || die "missing required tool: $1"; }
+need docker
+need ghz
+need yq
+need jq
+need curl
+need go
+
+[[ $# -eq 1 ]] || { echo "usage: $0 <scenario>" >&2; exit 2; }
+SCENARIO_NAME="$1"
+SCENARIO_FILE="$SCENARIO_DIR/${SCENARIO_NAME}.yaml"
+[[ -f "$SCENARIO_FILE" ]] || die "no such scenario: $SCENARIO_FILE"
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUTDIR="$HERE/out/${SCENARIO_NAME}/${TS}"
+mkdir -p "$OUTDIR/prom" "$OUTDIR/pprof"
+
+# Parse common scenario fields up-front.
+warmup_duration="$(yq -r '.phases.warmup.duration' "$SCENARIO_FILE")"
+warmup_conc="$(yq -r '.phases.warmup.concurrency' "$SCENARIO_FILE")"
+warmup_rps="$(yq -r '.phases.warmup.rps' "$SCENARIO_FILE")"
+steady_duration="$(yq -r '.phases.steady.duration' "$SCENARIO_FILE")"
+steady_conc="$(yq -r '.phases.steady.concurrency' "$SCENARIO_FILE")"
+steady_rps="$(yq -r '.phases.steady.rps' "$SCENARIO_FILE")"
+cooldown="$(yq -r '.phases.cooldown' "$SCENARIO_FILE")"
+endpoints=( $(yq -r '.target.endpoints[]' "$SCENARIO_FILE") )
+proto_path="$REPO_ROOT/proto/graph/v1/graph.proto"
+proto_import="$REPO_ROOT/proto"
+
+# ----- compose up ------------------------------------------------------------
+if [[ "${SKIP_UP:-0}" != "1" ]]; then
+  log "compose up (project=$COMPOSE_PROJECT_NAME)"
+  docker compose "${COMPOSE_FILES[@]}" up -d --scale lantern=3 --wait
+fi
+
+wait_ready() {
+  local p
+  for p in "${REPLICA_METRICS_PORTS[@]}"; do
+    for _ in $(seq 1 60); do
+      if curl -fsS --max-time 2 "http://localhost:${p}/readyz" >/dev/null 2>&1; then
+        break
+      fi
+      sleep 1
+    done
+  done
+}
+wait_ready
+
+# ----- helpers ---------------------------------------------------------------
+
+# Extract a single Prom metric value from a /metrics text exposition.
+# $1 metric name, $2 raw text -> echoes numeric value or "0".
+prom_scalar() {
+  local name="$1" text="$2"
+  awk -v n="$name" '$1 == n { print $2; exit }' <<<"$text"
+}
+
+snapshot_runtime() {
+  local out="$1" port
+  local -a samples=()
+  for port in "${REPLICA_METRICS_PORTS[@]}"; do
+    local text
+    text="$(curl -fsS --max-time 5 "http://localhost:${port}/metrics" || true)"
+    local g h
+    g="$(prom_scalar go_goroutines "$text")"
+    h="$(prom_scalar go_memstats_heap_inuse_bytes "$text")"
+    samples+=( "$(jq -nc --arg ep "localhost:${port}" --argjson g "${g:-0}" --argjson h "${h:-0}" \
+      '{endpoint: $ep, goroutines: $g, heap_inuse_bytes: $h}')" )
+  done
+  printf '%s\n' "${samples[@]}" | jq -s '.' > "$out"
+}
+
+run_ghz() {
+  # $1 phase tag, $2 endpoint, $3 call, $4 data_template literal, $5 conc, $6 rps, $7 duration
+  local phase="$1" ep="$2" call="$3" data="$4" conc="$5" rps="$6" dur="$7"
+  local jsonout="$OUTDIR/ghz_${phase}_${ep//[:.]/_}.json"
+  ghz \
+    --insecure \
+    --proto "$proto_path" -i "$proto_import" \
+    --call "$call" \
+    -c "$conc" --rps "$rps" -z "$dur" \
+    -d "$data" \
+    --format json \
+    -o "$jsonout" \
+    "$ep" \
+    >/dev/null
+  echo "$jsonout"
+}
+
+# ----- WARMUP ----------------------------------------------------------------
+log "warmup: ${warmup_duration} @ c=${warmup_conc} rps=${warmup_rps}"
+warm_call="$(yq -r '.target.call // .target.calls[0].call' "$SCENARIO_FILE")"
+warm_data="$(yq -r '.target.data_template // .target.calls[0].data_template' "$SCENARIO_FILE")"
+run_ghz warmup "${endpoints[0]}" "$warm_call" "$warm_data" "$warmup_conc" "$warmup_rps" "$warmup_duration" >/dev/null
+
+# ----- PRE snapshot (after warmup) -------------------------------------------
+snapshot_runtime "$OUTDIR/runtime_pre.json"
+"$CAPTURE_DIR/pprof.sh" "$OUTDIR/pprof" pre || log "pprof pre snapshot reported warnings"
+
+# ----- STEADY ----------------------------------------------------------------
+steady_start_epoch="$(date -u +%s)"
+log "steady: ${steady_duration} @ c=${steady_conc} rps=${steady_rps}"
+
+# Subscribe consumers (run in background for the duration of the steady phase).
+sub_pids=()
+sub_count="$(yq -r '.subscribe.count // 0' "$SCENARIO_FILE")"
+sub_consumers_len="$(yq -r '.subscribe.consumers | length // 0' "$SCENARIO_FILE")"
+
+if [[ "$sub_count" != "0" && "$sub_count" != "null" ]]; then
+  sub_call="$(yq -r '.subscribe.call' "$SCENARIO_FILE")"
+  sub_data="$(yq -r '.subscribe.data_template' "$SCENARIO_FILE")"
+  sub_eps=( $(yq -r '.subscribe.endpoints[]' "$SCENARIO_FILE") )
+  for i in $(seq 1 "$sub_count"); do
+    ep="${sub_eps[$(( (i-1) % ${#sub_eps[@]} ))]}"
+    ghz --insecure --proto "$proto_path" -i "$proto_import" \
+      --call "$sub_call" -c 1 --rps 0 -z "$steady_duration" \
+      -d "$sub_data" --format json \
+      -o "$OUTDIR/ghz_sub_${i}.json" "$ep" >/dev/null 2>&1 &
+    sub_pids+=( "$!" )
+  done
+  log "launched $sub_count subscribe streams"
+fi
+
+if [[ "$sub_consumers_len" != "0" && "$sub_consumers_len" != "null" ]]; then
+  for i in $(seq 0 $(( sub_consumers_len - 1 ))); do
+    ep="$(yq -r ".subscribe.consumers[$i].endpoint" "$SCENARIO_FILE")"
+    call="$(yq -r ".subscribe.consumers[$i].call" "$SCENARIO_FILE")"
+    data="$(yq -r ".subscribe.consumers[$i].data_template" "$SCENARIO_FILE")"
+    ghz --insecure --proto "$proto_path" -i "$proto_import" \
+      --call "$call" -c 1 --rps 0 -z "$steady_duration" \
+      -d "$data" --format json \
+      -o "$OUTDIR/ghz_sub_consumer_${i}.json" "$ep" >/dev/null 2>&1 &
+    sub_pids+=( "$!" )
+  done
+  log "launched $sub_consumers_len explicit subscribe consumers"
+fi
+
+# Chaos schedule (background).
+chaos_pid=""
+chaos_target="$(yq -r '.chaos.kill_target // ""' "$SCENARIO_FILE")"
+if [[ -n "$chaos_target" ]]; then
+  kill_at="$(yq -r '.chaos.kill_at' "$SCENARIO_FILE")"
+  restart_at="$(yq -r '.chaos.restart_at' "$SCENARIO_FILE")"
+  (
+    sleep_secs() { local v="$1"; sleep "${v%s}"; }
+    sleep_secs "$kill_at"
+    log "chaos: docker kill $chaos_target"
+    docker kill "$chaos_target" >/dev/null || true
+    sleep_secs "$restart_at"
+    log "chaos: docker start $chaos_target"
+    docker start "$chaos_target" >/dev/null || true
+  ) &
+  chaos_pid="$!"
+fi
+
+# Steady producer(s). If `.target.calls` is a list, fork one ghz per call
+# at floor(rps / N); otherwise run a single ghz against the primary endpoint.
+calls_len="$(yq -r '.target.calls | length // 0' "$SCENARIO_FILE")"
+prod_pids=()
+prod_files=()
+if [[ "$calls_len" != "0" && "$calls_len" != "null" ]]; then
+  per_rps=$(( steady_rps / calls_len ))
+  for i in $(seq 0 $(( calls_len - 1 ))); do
+    call="$(yq -r ".target.calls[$i].call" "$SCENARIO_FILE")"
+    data="$(yq -r ".target.calls[$i].data_template" "$SCENARIO_FILE")"
+    ep="${endpoints[$(( i % ${#endpoints[@]} ))]}"
+    f="$OUTDIR/ghz_steady_${i}_${ep//[:.]/_}.json"
+    ghz --insecure --proto "$proto_path" -i "$proto_import" \
+      --call "$call" -c "$steady_conc" --rps "$per_rps" -z "$steady_duration" \
+      -d "$data" --format json -o "$f" "$ep" >/dev/null 2>&1 &
+    prod_pids+=( "$!" )
+    prod_files+=( "$f" )
+  done
+  wait "${prod_pids[@]}"
+else
+  call="$(yq -r '.target.call' "$SCENARIO_FILE")"
+  data="$(yq -r '.target.data_template' "$SCENARIO_FILE")"
+  ep="${endpoints[0]}"
+  f="$(run_ghz steady "$ep" "$call" "$data" "$steady_conc" "$steady_rps" "$steady_duration")"
+  prod_files+=( "$f" )
+fi
+
+# Reap background helpers (subscribers run for steady_duration; they exit on
+# their own). Chaos restart also self-completes.
+if [[ ${#sub_pids[@]} -gt 0 ]]; then wait "${sub_pids[@]}" 2>/dev/null || true; fi
+if [[ -n "$chaos_pid" ]]; then wait "$chaos_pid" 2>/dev/null || true; fi
+
+steady_end_epoch="$(date -u +%s)"
+
+# ----- COOLDOWN --------------------------------------------------------------
+log "cooldown: ${cooldown}"
+sleep "${cooldown%s}"
+
+# ----- POST snapshot ---------------------------------------------------------
+snapshot_runtime "$OUTDIR/runtime_post.json"
+"$CAPTURE_DIR/pprof.sh" "$OUTDIR/pprof" post || log "pprof post snapshot reported warnings"
+
+# ----- Prom range queries ----------------------------------------------------
+log "capturing Prometheus range queries from $PROM_URL"
+i=0
+while IFS= read -r line; do
+  q="${line%%#*}"; q="${q#"${q%%[![:space:]]*}"}"; q="${q%"${q##*[![:space:]]}"}"
+  [[ -z "$q" ]] && continue
+  i=$(( i + 1 ))
+  out="$OUTDIR/prom/q_$(printf '%02d' "$i").json"
+  curl -fsS --max-time 30 -G "$PROM_URL/api/v1/query_range" \
+    --data-urlencode "query=$q" \
+    --data-urlencode "start=$steady_start_epoch" \
+    --data-urlencode "end=$steady_end_epoch" \
+    --data-urlencode "step=5s" \
+    > "$out" || log "prom query failed: $q"
+  jq -n --arg q "$q" --arg f "$(basename "$out")" '{query:$q, file:$f}' \
+    >> "$OUTDIR/prom/_index.ndjson"
+done < "$CAPTURE_DIR/prom_queries.txt"
+
+# ----- Leak gate -------------------------------------------------------------
+g_thresh="$(yq -r '.leak_gate.goroutine_max_delta' "$SCENARIO_FILE")"
+h_thresh_mb="$(yq -r '.leak_gate.heap_inuse_max_delta_mb' "$SCENARIO_FILE")"
+h_thresh_bytes=$(( h_thresh_mb * 1024 * 1024 ))
+
+leak_json="$(jq -n \
+  --slurpfile pre  "$OUTDIR/runtime_pre.json" \
+  --slurpfile post "$OUTDIR/runtime_post.json" \
+  --argjson g_thresh "$g_thresh" \
+  --argjson h_thresh "$h_thresh_bytes" \
+  --argjson h_thresh_mb "$h_thresh_mb" '
+  ($pre[0])  as $pre  | ($post[0]) as $post |
+  [range(0; ($pre|length)) as $i |
+    {
+      endpoint:           $pre[$i].endpoint,
+      goroutines_pre:     $pre[$i].goroutines,
+      goroutines_post:    $post[$i].goroutines,
+      goroutine_delta:   ($post[$i].goroutines - $pre[$i].goroutines),
+      heap_inuse_pre_bytes:  $pre[$i].heap_inuse_bytes,
+      heap_inuse_post_bytes: $post[$i].heap_inuse_bytes,
+      heap_inuse_delta_bytes:($post[$i].heap_inuse_bytes - $pre[$i].heap_inuse_bytes)
+    }
+  ] as $r |
+  {
+    thresholds: {goroutine_max_delta: $g_thresh, heap_inuse_max_delta_mb: $h_thresh_mb},
+    replicas: $r,
+    verdict: (if any($r[]; .goroutine_delta > $g_thresh or .heap_inuse_delta_bytes > $h_thresh)
+              then "fail" else "pass" end)
+  }')"
+printf '%s\n' "$leak_json" > "$OUTDIR/leak_gate.json"
+verdict="$(jq -r '.verdict' "$OUTDIR/leak_gate.json")"
+log "leak gate verdict: $verdict"
+
+# ----- Render report ---------------------------------------------------------
+(
+  cd "$REPO_ROOT"
+  go run ./testbed/bench/report -dir "$OUTDIR" -scenario "$SCENARIO_NAME" -timestamp "$TS"
+) > "$OUTDIR/report.md"
+log "report: $OUTDIR/report.md"
+
+# ----- Teardown --------------------------------------------------------------
+if [[ "${KEEP_UP:-0}" != "1" ]]; then
+  log "compose down -v"
+  docker compose "${COMPOSE_FILES[@]}" down -v >/dev/null
+fi
+
+if [[ "$verdict" == "pass" ]]; then exit 0; else exit 1; fi

--- a/testbed/bench/scenarios/addedge_contention.yaml
+++ b/testbed/bench/scenarios/addedge_contention.yaml
@@ -1,0 +1,16 @@
+# addedge_contention — repeated AddEdge against the same (tail, head).
+# Goal: hammer the per-edge lock to surface block/mutex hotspots.
+#       Read mutex + block profiles from the post-phase pprof capture.
+name: addedge_contention
+phases:
+  warmup:   { duration: 15s, concurrency: 16, rps: 500 }
+  steady:   { duration: 3m,  concurrency: 64, rps: 4000 }
+  cooldown: 15s
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  call: graph.v1.LanternService/AddEdge
+  data_template: |
+    {"tail":"hot-tail","head":"hot-head","weight":1.0}
+leak_gate:
+  goroutine_max_delta: 15
+  heap_inuse_max_delta_mb: 16

--- a/testbed/bench/scenarios/batch_put_vertices.yaml
+++ b/testbed/bench/scenarios/batch_put_vertices.yaml
@@ -1,0 +1,20 @@
+# batch_put_vertices — exercises the plural write path under bulk traffic.
+# Goal: amortized batch latency + per-batch allocation envelope.
+name: batch_put_vertices
+phases:
+  warmup:   { duration: 30s, concurrency: 8,  rps: 200 }
+  steady:   { duration: 5m,  concurrency: 32, rps: 1000 }
+  cooldown: 30s
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  call: graph.v1.LanternService/PutVertices
+  data_template: |
+    {"vertices":[
+      {"key":"bk-{{.RequestNumber}}-0","value":{"intValue":{{.RequestNumber}}}},
+      {"key":"bk-{{.RequestNumber}}-1","value":{"intValue":{{.RequestNumber}}}},
+      {"key":"bk-{{.RequestNumber}}-2","value":{"intValue":{{.RequestNumber}}}},
+      {"key":"bk-{{.RequestNumber}}-3","value":{"intValue":{{.RequestNumber}}}}
+    ]}
+leak_gate:
+  goroutine_max_delta: 20
+  heap_inuse_max_delta_mb: 48

--- a/testbed/bench/scenarios/chaos_kill_replica.yaml
+++ b/testbed/bench/scenarios/chaos_kill_replica.yaml
@@ -1,0 +1,27 @@
+# chaos_kill_replica — mid-load `docker kill` of one replica.
+# Goal: observe Snapshot resync + readiness gate recovery.
+# run.sh interprets the `chaos` block: at +30s into steady, it kills the
+# named replica; at +90s, it restarts it. Leak gate is measured AFTER the
+# replica is back and the cluster is healthy again, so the comparison
+# baseline is the original post-warmup snapshot.
+name: chaos_kill_replica
+phases:
+  warmup:   { duration: 30s, concurrency: 16, rps: 1000 }
+  steady:   { duration: 5m,  concurrency: 64, rps: 4000 }
+  cooldown: 60s
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  call: graph.v1.LanternService/PutVertex
+  data_template: |
+    {"key":"chaos-{{.RequestNumber}}","value":{"intValue":{{.RequestNumber}}}}
+chaos:
+  # Replica container name as known to docker compose (compose adds the
+  # project prefix). run.sh forces COMPOSE_PROJECT_NAME=lantern-bench, so
+  # the default container name follows that.
+  kill_target: "lantern-bench-lantern-2"
+  kill_at: 30s
+  restart_at: 90s
+leak_gate:
+  # Replica restart legitimately adds goroutines until pumps settle; widen.
+  goroutine_max_delta: 60
+  heap_inuse_max_delta_mb: 64

--- a/testbed/bench/scenarios/illuminate.yaml
+++ b/testbed/bench/scenarios/illuminate.yaml
@@ -1,0 +1,15 @@
+# illuminate — graph traversal at moderate RPS.
+# Goal: stress graph view + adjacency walk + per-RPC working set.
+name: illuminate
+phases:
+  warmup:   { duration: 30s, concurrency: 8,  rps: 200 }
+  steady:   { duration: 3m,  concurrency: 32, rps: 1000 }
+  cooldown: 30s
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  call: graph.v1.LanternService/Illuminate
+  data_template: |
+    {"seed":"k-{{mod .RequestNumber 1000}}","step":2,"tolerance":0.1}
+leak_gate:
+  goroutine_max_delta: 20
+  heap_inuse_max_delta_mb: 32

--- a/testbed/bench/scenarios/many_subscribers.yaml
+++ b/testbed/bench/scenarios/many_subscribers.yaml
@@ -1,0 +1,22 @@
+# many_subscribers — N concurrent Subscribe streams across replicas.
+# Goal: stress pubsub fan-out and exercise the #240 queue-depth / drop /
+#       dispatch-latency metrics; expose backpressure budgets.
+name: many_subscribers
+phases:
+  warmup:   { duration: 30s, concurrency: 8, rps: 500 }
+  steady:   { duration: 5m,  concurrency: 32, rps: 2000 }
+  cooldown: 30s
+target:
+  endpoints: ["localhost:6380"]
+  call: graph.v1.LanternService/PutVertex
+  data_template: |
+    {"key":"fan-{{.RequestNumber}}","value":{"intValue":{{.RequestNumber}}}}
+subscribe:
+  # run.sh launches `count` streams round-robined across `endpoints`.
+  count: 64
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  call: graph.v1.LanternReplicationService/Subscribe
+  data_template: '{"fromSeq":"1"}'
+leak_gate:
+  goroutine_max_delta: 80     # 64 streams × bookkeeping
+  heap_inuse_max_delta_mb: 64

--- a/testbed/bench/scenarios/mixed_rw.yaml
+++ b/testbed/bench/scenarios/mixed_rw.yaml
@@ -1,0 +1,21 @@
+# mixed_rw — 50/50 PutVertex/GetVertex from concurrent clients.
+# Goal: realistic hot/cold split; exercises both replication & cache GC.
+name: mixed_rw
+phases:
+  warmup:   { duration: 30s, concurrency: 16, rps: 1000 }
+  steady:   { duration: 5m,  concurrency: 96, rps: 6000 }
+  cooldown: 30s
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  # Two parallel ghz invocations are launched by run.sh — one per call,
+  # each at half the total RPS. See run.sh for the split rule.
+  calls:
+    - call: graph.v1.LanternService/PutVertex
+      data_template: |
+        {"key":"k-{{.RequestNumber}}","value":{"intValue":{{.RequestNumber}}}}
+    - call: graph.v1.LanternService/GetVertex
+      data_template: |
+        {"key":"k-{{mod .RequestNumber 10000}}"}
+leak_gate:
+  goroutine_max_delta: 25
+  heap_inuse_max_delta_mb: 32

--- a/testbed/bench/scenarios/read_heavy.yaml
+++ b/testbed/bench/scenarios/read_heavy.yaml
@@ -1,0 +1,15 @@
+# read_heavy — sustained GetVertex against a pre-warmed keyspace.
+# Goal: read-path hot-loop + cache-hit allocations under steady load.
+name: read_heavy
+phases:
+  warmup:   { duration: 30s, concurrency: 16, rps: 1000 }
+  steady:   { duration: 5m,  concurrency: 128, rps: 10000 }
+  cooldown: 30s
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  call: graph.v1.LanternService/GetVertex
+  data_template: |
+    {"key":"k-{{mod .RequestNumber 10000}}"}
+leak_gate:
+  goroutine_max_delta: 20
+  heap_inuse_max_delta_mb: 24

--- a/testbed/bench/scenarios/replication_soak.yaml
+++ b/testbed/bench/scenarios/replication_soak.yaml
@@ -1,0 +1,27 @@
+# replication_soak — writes on r0, Subscribe consumers on r1/r2.
+# Goal: long-running fan-out across replicas; surfaces pubsub queue depth
+#       (#240) and replication pump backlog.
+# NOTE: run.sh detects `subscribe.consumers` and launches them as separate
+#       long-lived ghz invocations against the listed endpoints; the
+#       `target` block below describes only the producer.
+name: replication_soak
+phases:
+  warmup:   { duration: 30s, concurrency: 8,  rps: 500 }
+  steady:   { duration: 10m, concurrency: 32, rps: 2000 }
+  cooldown: 60s
+target:
+  endpoints: ["localhost:6380"]
+  call: graph.v1.LanternService/PutVertex
+  data_template: |
+    {"key":"soak-{{.RequestNumber}}","value":{"intValue":{{.RequestNumber}}}}
+subscribe:
+  consumers:
+    - endpoint: localhost:6381
+      call: graph.v1.LanternReplicationService/Subscribe
+      data_template: '{"fromSeq":"1"}'
+    - endpoint: localhost:6382
+      call: graph.v1.LanternReplicationService/Subscribe
+      data_template: '{"fromSeq":"1"}'
+leak_gate:
+  goroutine_max_delta: 30
+  heap_inuse_max_delta_mb: 64

--- a/testbed/bench/scenarios/scan_prefix.yaml
+++ b/testbed/bench/scenarios/scan_prefix.yaml
@@ -1,0 +1,15 @@
+# scan_prefix — paginated prefix scans of varying width.
+# Goal: cursor allocation + per-page response sizing.
+name: scan_prefix
+phases:
+  warmup:   { duration: 30s, concurrency: 8,  rps: 200 }
+  steady:   { duration: 3m,  concurrency: 32, rps: 800 }
+  cooldown: 30s
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  call: graph.v1.LanternService/ScanVertices
+  data_template: |
+    {"prefix":"k-{{mod .RequestNumber 100}}","limit":128}
+leak_gate:
+  goroutine_max_delta: 20
+  heap_inuse_max_delta_mb: 32

--- a/testbed/bench/scenarios/ttl_churn.yaml
+++ b/testbed/bench/scenarios/ttl_churn.yaml
@@ -1,0 +1,18 @@
+# ttl_churn — short TTLs + steady writes → GC pressure.
+# Goal: catch leaks in expiration plumbing and timer wheels.
+# NOTE: writes set their own TTL (5s) via the request body so the server
+#       default does not need to change for this scenario.
+name: ttl_churn
+phases:
+  warmup:   { duration: 30s, concurrency: 16, rps: 1000 }
+  steady:   { duration: 5m,  concurrency: 64, rps: 4000 }
+  cooldown: 60s
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  call: graph.v1.LanternService/PutVertex
+  data_template: |
+    {"key":"ttl-{{.RequestNumber}}","value":{"intValue":{{.RequestNumber}}},"ttlSeconds":5}
+leak_gate:
+  # cooldown is long enough that expirations have drained; tighter bounds.
+  goroutine_max_delta: 15
+  heap_inuse_max_delta_mb: 16

--- a/testbed/bench/scenarios/write_heavy.yaml
+++ b/testbed/bench/scenarios/write_heavy.yaml
@@ -1,0 +1,15 @@
+# write_heavy — sustained PutVertex from many clients.
+# Goal: catch leaks in the write path + cache eviction + replication pump.
+name: write_heavy
+phases:
+  warmup:   { duration: 30s, concurrency: 16, rps: 1000 }
+  steady:   { duration: 5m,  concurrency: 64, rps: 5000 }
+  cooldown: 30s
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  call: graph.v1.LanternService/PutVertex
+  data_template: |
+    {"key":"k-{{.RequestNumber}}","value":{"intValue":{{.RequestNumber}}}}
+leak_gate:
+  goroutine_max_delta: 20
+  heap_inuse_max_delta_mb: 32


### PR DESCRIPTION
Closes #241

Part of #237

Adds a reusable, local-only performance + memory-leak harness that drives the `deploy/compose/` HA cluster with `ghz`, captures Prometheus range queries and Go pprof snapshots, applies a per-scenario leak gate, and renders a Markdown report.

**Not wired into CI** — per #237 this is a maintainer-driven tool. The output directory (`testbed/bench/out/`) is git-ignored.

## What's in the harness

- `testbed/bench/run.sh` — orchestrator: compose up (overlay) → warmup → pre snapshot (runtime + pprof) → steady ghz (with mixed_rw / subscribe / chaos fork variants) → cooldown → post snapshot → Prom range capture → leak gate → report render → teardown.
- `testbed/bench/compose.override.yml` — layered overlay that enables pprof + mutex/block sampling on every replica and publishes per-replica metrics ports `9390-9392`.
- `testbed/bench/capture/pprof.sh` — fetches `heap`, `goroutine`, `allocs` (always) and `mutex`, `block`, optional `profile` (post phase) per replica.
- `testbed/bench/capture/prom_queries.txt` — curated query set: gRPC throughput / latency / errors, Go runtime, replication, and the #240 pubsub metrics.
- `testbed/bench/scenarios/*.yaml` (11): `write_heavy`, `read_heavy`, `mixed_rw`, `batch_put_vertices`, `addedge_contention`, `illuminate`, `scan_prefix`, `ttl_churn`, `replication_soak`, `chaos_kill_replica`, `many_subscribers`.
- `testbed/bench/report/{render.go,render_test.go}` — pure Markdown renderer with a 1:1 unit test (per AGENTS.md).
- `testbed/bench/README.md` — prereqs, quick-start, per-scenario summary, output layout, drill-down workflow, and the why-not-in-CI rationale.

## How to use

```bash
./testbed/bench/run.sh write_heavy
# → testbed/bench/out/write_heavy/<UTC-ts>/report.md
```

Exit code mirrors the leak-gate verdict (`0`=pass, `1`=fail). `KEEP_UP=1`, `SKIP_UP=1`, `PPROF_CPU=1` are supported as documented in the README.

## Gates run locally

- `gofmt -l . cli core pb sdks server tests testbed` → clean
- per-module `go vet ./... && go test ./...` across `.`, `cli`, `core`, `pb`, `sdks/go`, `server`, `tests/integration` → all green
