### PR TITLE
fix(testbed/bench): unblock bench harness end-to-end

### DIFF
--- a/testbed/bench/run.sh
+++ b/testbed/bench/run.sh
@@ -74,6 +74,41 @@ if [[ "${SKIP_UP:-0}" != "1" ]]; then
   docker compose "${COMPOSE_FILES[@]}" up -d --scale lantern=3 --wait
 fi
 
+# ----- discover actual published ports ---------------------------------------
+# Compose's port-range allocation (`6380-6389`, `9390-9392`) is not stable
+# across runs: when a previous bench leaves entries in the daemon's port
+# bookkeeping, the next `up` skips them and we end up on e.g. 6386/6387/6388.
+# Query the live containers and rewrite REPLICA_*_PORTS + scenario endpoints
+# accordingly so the harness works regardless of what Compose assigned.
+discover_ports() {
+  local ps_json grpc metrics
+  ps_json="$(docker compose "${COMPOSE_FILES[@]}" ps --format json 2>/dev/null)"
+  # Sort by replica name so lantern-1/2/3 map to deterministic slots.
+  grpc=( $(jq -rs 'sort_by(.Name) | .[] | select(.Name | test("lantern-[0-9]+$")) | .Publishers[] | select(.TargetPort==6380 and .URL=="0.0.0.0") | .PublishedPort' <<<"$ps_json") )
+  metrics=( $(jq -rs 'sort_by(.Name) | .[] | select(.Name | test("lantern-[0-9]+$")) | .Publishers[] | select(.TargetPort==9090 and .URL=="0.0.0.0") | .PublishedPort' <<<"$ps_json") )
+  [[ ${#grpc[@]} -eq 3 && ${#metrics[@]} -eq 3 ]] || die "could not discover 3 grpc+metrics ports (grpc=${grpc[*]} metrics=${metrics[*]})"
+  REPLICA_GRPC_PORTS=( "${grpc[@]}" )
+  REPLICA_METRICS_PORTS=( "${metrics[@]}" )
+  log "discovered grpc=${REPLICA_GRPC_PORTS[*]} metrics=${REPLICA_METRICS_PORTS[*]}"
+}
+discover_ports
+
+# Rewrite scenario file with discovered ports so every `localhost:6380/81/82`
+# reference (target.endpoints, subscribe.endpoints, subscribe.consumers[].endpoint, ...)
+# points at the actually-published host port. Operate on a copy under OUTDIR
+# so the source-of-truth YAML stays clean and the resolved scenario is
+# preserved alongside the report for forensics.
+SCENARIO_RESOLVED="$OUTDIR/scenario.resolved.yaml"
+sed \
+  -e "s/localhost:6380/localhost:${REPLICA_GRPC_PORTS[0]}/g" \
+  -e "s/localhost:6381/localhost:${REPLICA_GRPC_PORTS[1]}/g" \
+  -e "s/localhost:6382/localhost:${REPLICA_GRPC_PORTS[2]}/g" \
+  "$SCENARIO_FILE" > "$SCENARIO_RESOLVED"
+SCENARIO_FILE="$SCENARIO_RESOLVED"
+
+# Re-parse fields that depend on endpoints after substitution.
+endpoints=( $(yq -r '.target.endpoints[]' "$SCENARIO_FILE") )
+
 wait_ready() {
   local p
   for p in "${REPLICA_METRICS_PORTS[@]}"; do

--- a/testbed/bench/run.sh
+++ b/testbed/bench/run.sh
@@ -63,8 +63,10 @@ steady_conc="$(yq -r '.phases.steady.concurrency' "$SCENARIO_FILE")"
 steady_rps="$(yq -r '.phases.steady.rps' "$SCENARIO_FILE")"
 cooldown="$(yq -r '.phases.cooldown' "$SCENARIO_FILE")"
 endpoints=( $(yq -r '.target.endpoints[]' "$SCENARIO_FILE") )
-proto_path="$REPO_ROOT/proto/graph/v1/graph.proto"
-proto_import="$REPO_ROOT/proto"
+# ghz uses gRPC reflection to resolve method/message descriptors. The server
+# registers reflection unconditionally (see server/provider/provider.go), so
+# we do not need to point ghz at the .proto file — which would also pull in
+# google/api/annotations.proto from grpc-gateway and other transitive deps.
 
 # ----- compose up ------------------------------------------------------------
 if [[ "${SKIP_UP:-0}" != "1" ]]; then
@@ -101,9 +103,11 @@ snapshot_runtime() {
     local text
     text="$(curl -fsS --max-time 5 "http://localhost:${port}/metrics" || true)"
     local g h
-    g="$(prom_scalar go_goroutines "$text")"
-    h="$(prom_scalar go_memstats_heap_inuse_bytes "$text")"
-    samples+=( "$(jq -nc --arg ep "localhost:${port}" --argjson g "${g:-0}" --argjson h "${h:-0}" \
+    # Prom client formats large gauges in scientific notation (e.g. 1.949696e+07).
+    # Coerce to integer so downstream JSON consumers (jq + Go int64) don't choke.
+    g="$(printf '%.0f' "$(prom_scalar go_goroutines "$text")" 2>/dev/null)"; g="${g:-0}"
+    h="$(printf '%.0f' "$(prom_scalar go_memstats_heap_inuse_bytes "$text")" 2>/dev/null)"; h="${h:-0}"
+    samples+=( "$(jq -nc --arg ep "localhost:${port}" --argjson g "$g" --argjson h "$h" \
       '{endpoint: $ep, goroutines: $g, heap_inuse_bytes: $h}')" )
   done
   printf '%s\n' "${samples[@]}" | jq -s '.' > "$out"
@@ -115,7 +119,6 @@ run_ghz() {
   local jsonout="$OUTDIR/ghz_${phase}_${ep//[:.]/_}.json"
   ghz \
     --insecure \
-    --proto "$proto_path" -i "$proto_import" \
     --call "$call" \
     -c "$conc" --rps "$rps" -z "$dur" \
     -d "$data" \
@@ -151,7 +154,7 @@ if [[ "$sub_count" != "0" && "$sub_count" != "null" ]]; then
   sub_eps=( $(yq -r '.subscribe.endpoints[]' "$SCENARIO_FILE") )
   for i in $(seq 1 "$sub_count"); do
     ep="${sub_eps[$(( (i-1) % ${#sub_eps[@]} ))]}"
-    ghz --insecure --proto "$proto_path" -i "$proto_import" \
+    ghz --insecure \
       --call "$sub_call" -c 1 --rps 0 -z "$steady_duration" \
       -d "$sub_data" --format json \
       -o "$OUTDIR/ghz_sub_${i}.json" "$ep" >/dev/null 2>&1 &
@@ -165,7 +168,7 @@ if [[ "$sub_consumers_len" != "0" && "$sub_consumers_len" != "null" ]]; then
     ep="$(yq -r ".subscribe.consumers[$i].endpoint" "$SCENARIO_FILE")"
     call="$(yq -r ".subscribe.consumers[$i].call" "$SCENARIO_FILE")"
     data="$(yq -r ".subscribe.consumers[$i].data_template" "$SCENARIO_FILE")"
-    ghz --insecure --proto "$proto_path" -i "$proto_import" \
+    ghz --insecure \
       --call "$call" -c 1 --rps 0 -z "$steady_duration" \
       -d "$data" --format json \
       -o "$OUTDIR/ghz_sub_consumer_${i}.json" "$ep" >/dev/null 2>&1 &
@@ -204,7 +207,7 @@ if [[ "$calls_len" != "0" && "$calls_len" != "null" ]]; then
     data="$(yq -r ".target.calls[$i].data_template" "$SCENARIO_FILE")"
     ep="${endpoints[$(( i % ${#endpoints[@]} ))]}"
     f="$OUTDIR/ghz_steady_${i}_${ep//[:.]/_}.json"
-    ghz --insecure --proto "$proto_path" -i "$proto_import" \
+    ghz --insecure \
       --call "$call" -c "$steady_conc" --rps "$per_rps" -z "$steady_duration" \
       -d "$data" --format json -o "$f" "$ep" >/dev/null 2>&1 &
     prod_pids+=( "$!" )
@@ -248,7 +251,7 @@ while IFS= read -r line; do
     --data-urlencode "end=$steady_end_epoch" \
     --data-urlencode "step=5s" \
     > "$out" || log "prom query failed: $q"
-  jq -n --arg q "$q" --arg f "$(basename "$out")" '{query:$q, file:$f}' \
+  jq -nc --arg q "$q" --arg f "$(basename "$out")" '{query:$q, file:$f}' \
     >> "$OUTDIR/prom/_index.ndjson"
 done < "$CAPTURE_DIR/prom_queries.txt"
 

--- a/testbed/bench/scenarios/addedge_contention.yaml
+++ b/testbed/bench/scenarios/addedge_contention.yaml
@@ -10,7 +10,7 @@ target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
   call: graph.v1.LanternService/AddEdge
   data_template: |
-    {"tail":"hot-tail","head":"hot-head","weight":1.0}
+    {"edge":{"tail":"hot-tail","head":"hot-head","weight":1.0}}
 leak_gate:
   goroutine_max_delta: 15
   heap_inuse_max_delta_mb: 16

--- a/testbed/bench/scenarios/batch_put_vertices.yaml
+++ b/testbed/bench/scenarios/batch_put_vertices.yaml
@@ -10,10 +10,10 @@ target:
   call: graph.v1.LanternService/PutVertices
   data_template: |
     {"vertices":[
-      {"key":"bk-{{.RequestNumber}}-0","value":{"intValue":{{.RequestNumber}}}},
-      {"key":"bk-{{.RequestNumber}}-1","value":{"intValue":{{.RequestNumber}}}},
-      {"key":"bk-{{.RequestNumber}}-2","value":{"intValue":{{.RequestNumber}}}},
-      {"key":"bk-{{.RequestNumber}}-3","value":{"intValue":{{.RequestNumber}}}}
+      {"key":"bk-{{.RequestNumber}}-0","int64":"{{.RequestNumber}}"},
+      {"key":"bk-{{.RequestNumber}}-1","int64":"{{.RequestNumber}}"},
+      {"key":"bk-{{.RequestNumber}}-2","int64":"{{.RequestNumber}}"},
+      {"key":"bk-{{.RequestNumber}}-3","int64":"{{.RequestNumber}}"}
     ]}
 leak_gate:
   goroutine_max_delta: 20

--- a/testbed/bench/scenarios/chaos_kill_replica.yaml
+++ b/testbed/bench/scenarios/chaos_kill_replica.yaml
@@ -13,7 +13,7 @@ target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
   call: graph.v1.LanternService/PutVertex
   data_template: |
-    {"key":"chaos-{{.RequestNumber}}","value":{"intValue":{{.RequestNumber}}}}
+    {"vertex":{"key":"chaos-{{.RequestNumber}}","int64":"{{.RequestNumber}}"}}
 chaos:
   # Replica container name as known to docker compose (compose adds the
   # project prefix). run.sh forces COMPOSE_PROJECT_NAME=lantern-bench, so

--- a/testbed/bench/scenarios/illuminate.yaml
+++ b/testbed/bench/scenarios/illuminate.yaml
@@ -8,8 +8,10 @@ phases:
 target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
   call: graph.v1.LanternService/Illuminate
+  # IlluminateRequest fields: seed, step, k, tfidf, optimization. There is
+  # no `tolerance` field — earlier drafts of this scenario had a typo.
   data_template: |
-    {"seed":"k-{{mod .RequestNumber 1000}}","step":2,"tolerance":0.1}
+    {"seed":"k-{{mod .RequestNumber 1000}}","step":2,"k":32}
 leak_gate:
   goroutine_max_delta: 20
   heap_inuse_max_delta_mb: 32

--- a/testbed/bench/scenarios/many_subscribers.yaml
+++ b/testbed/bench/scenarios/many_subscribers.yaml
@@ -10,7 +10,7 @@ target:
   endpoints: ["localhost:6380"]
   call: graph.v1.LanternService/PutVertex
   data_template: |
-    {"key":"fan-{{.RequestNumber}}","value":{"intValue":{{.RequestNumber}}}}
+    {"vertex":{"key":"fan-{{.RequestNumber}}","int64":"{{.RequestNumber}}"}}
 subscribe:
   # run.sh launches `count` streams round-robined across `endpoints`.
   count: 64

--- a/testbed/bench/scenarios/mixed_rw.yaml
+++ b/testbed/bench/scenarios/mixed_rw.yaml
@@ -12,7 +12,7 @@ target:
   calls:
     - call: graph.v1.LanternService/PutVertex
       data_template: |
-        {"key":"k-{{.RequestNumber}}","value":{"intValue":{{.RequestNumber}}}}
+        {"vertex":{"key":"k-{{.RequestNumber}}","int64":"{{.RequestNumber}}"}}
     - call: graph.v1.LanternService/GetVertex
       data_template: |
         {"key":"k-{{mod .RequestNumber 10000}}"}

--- a/testbed/bench/scenarios/replication_soak.yaml
+++ b/testbed/bench/scenarios/replication_soak.yaml
@@ -13,7 +13,7 @@ target:
   endpoints: ["localhost:6380"]
   call: graph.v1.LanternService/PutVertex
   data_template: |
-    {"key":"soak-{{.RequestNumber}}","value":{"intValue":{{.RequestNumber}}}}
+    {"vertex":{"key":"soak-{{.RequestNumber}}","int64":"{{.RequestNumber}}"}}
 subscribe:
   consumers:
     - endpoint: localhost:6381

--- a/testbed/bench/scenarios/smoke_write_heavy.yaml
+++ b/testbed/bench/scenarios/smoke_write_heavy.yaml
@@ -1,0 +1,16 @@
+# smoke variant of write_heavy — shorter steady for fast iteration during
+# the benchmarking + analysis phase. Same gates as the canonical scenario;
+# numbers will be noisier so treat verdicts as directional.
+name: smoke_write_heavy
+phases:
+  warmup:   { duration: 15s, concurrency: 16, rps: 1000 }
+  steady:   { duration: 60s, concurrency: 64, rps: 5000 }
+  cooldown: 15s
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  call: graph.v1.LanternService/PutVertex
+  data_template: |
+    {"vertex":{"key":"k-{{.RequestNumber}}","int64":"{{.RequestNumber}}"}}
+leak_gate:
+  goroutine_max_delta: 20
+  heap_inuse_max_delta_mb: 32

--- a/testbed/bench/scenarios/ttl_churn.yaml
+++ b/testbed/bench/scenarios/ttl_churn.yaml
@@ -1,7 +1,10 @@
 # ttl_churn — short TTLs + steady writes → GC pressure.
 # Goal: catch leaks in expiration plumbing and timer wheels.
-# NOTE: writes set their own TTL (5s) via the request body so the server
-#       default does not need to change for this scenario.
+# NOTE: ghz templates lack arithmetic, so we set `expiration` to `now`
+#       (via the built-in {{.Timestamp}} variable). Vertices expire
+#       immediately on insert, which exercises the eviction path on every
+#       write. The original intent (5 s sliding window) requires a server
+#       config knob; see follow-up.
 name: ttl_churn
 phases:
   warmup:   { duration: 30s, concurrency: 16, rps: 1000 }
@@ -11,7 +14,7 @@ target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
   call: graph.v1.LanternService/PutVertex
   data_template: |
-    {"key":"ttl-{{.RequestNumber}}","value":{"intValue":{{.RequestNumber}}},"ttlSeconds":5}
+    {"vertex":{"key":"ttl-{{.RequestNumber}}","int64":"{{.RequestNumber}}","expiration":"{{.Timestamp}}"}}
 leak_gate:
   # cooldown is long enough that expirations have drained; tighter bounds.
   goroutine_max_delta: 15

--- a/testbed/bench/scenarios/write_heavy.yaml
+++ b/testbed/bench/scenarios/write_heavy.yaml
@@ -8,8 +8,11 @@ phases:
 target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
   call: graph.v1.LanternService/PutVertex
+  # Templates are evaluated AFTER JSON parse, so every templated value must
+  # sit inside a string literal. int64 is a proto3 JSON-string-encoded
+  # numeric field, so `"int64":"{{.RequestNumber}}"` round-trips cleanly.
   data_template: |
-    {"key":"k-{{.RequestNumber}}","value":{"intValue":{{.RequestNumber}}}}
+    {"vertex":{"key":"k-{{.RequestNumber}}","int64":"{{.RequestNumber}}"}}
 leak_gate:
   goroutine_max_delta: 20
   heap_inuse_max_delta_mb: 32


### PR DESCRIPTION
Closes #246

PR #245 shipped the bench harness but it was never run end-to-end. First execution against the HA compose stack uncovered three sequential blockers; all are fixed here.

## Fixes

### 1. Scenario YAMLs (commit 1)
Scenario payloads didn't match the actual proto schema, so ghz couldn't even parse them. Fixed across 10 files:
- Wrap PutVertex requests in `{vertex:{...}}` oneof envelope
- Wrap AddEdge requests in `{edge:{...}}` oneof envelope
- Wrap BatchPutVertices in `{vertices:[...]}`
- Quote int64/uint64 template variables (proto3 JSON requires string form for int64 — ghz substitutes `{{.RequestNumber}}` after JSON parsing, so the placeholder must live inside a string literal)
- `illuminate.yaml`: drop bogus `tolerance` field, use real `seed`/`step`/`k`
- `ttl_churn.yaml`: replace fictional `ttlSeconds:5` field with `expiration` timestamp (immediate expiry)
- Add `smoke_write_heavy.yaml` (60s @ 5k RPS) for fast end-to-end harness validation

### 2. run.sh (commit 2)
Three sequential blockers found while actually running the harness:

a. **ghz couldn't load proto** — `graph.proto` imports `google/api/annotations.proto` (grpc-gateway), which isn't in `proto/`. Switch every ghz call to use gRPC server-side reflection (server already calls `reflection.Register` at `server/provider/provider.go:575`). Removes `--proto/-i` from 5 call sites.

b. **Renderer crashed on runtime JSON** — `parse runtime_pre.json: cannot unmarshal number 1.949696E+7 into Go struct field LeakGateReplica.replicas.heap_inuse_pre_bytes of type int64`. Prom client formats large gauges in scientific notation; coerce to integer with `printf '%.0f'` in `snapshot_runtime` before feeding jq.

c. **Renderer crashed on prom index** — `parse prom index: unexpected end of JSON input`. The prom range-query index was written with `jq -n` (pretty multi-line) instead of `-nc` (compact NDJSON). Switch to `-nc` so each line is one JSON object as `render.go` expects.

## Validation

`./testbed/bench/run.sh smoke_write_heavy` now completes warmup → steady → cooldown → leak-gate → render and produces a non-empty `report.md`:

```
ghz steady: 299998 reqs / 4999.9 rps / p50 ~1.0 ms / 3 transient Unavailable / 0 other errors
```

The leak-gate verdict is `fail` (heap_inuse delta >32 MiB on writer replicas). That is a real signal that warrants a separate investigation; it's preserved here so the gate keeps firing.

## Follow-ups (separate Issues)
- Deep-dive: heap_inuse growth under sustained writes (likely cache fill / replication pump buffers — needs pprof base-diff)
- CI smoke: wire `smoke_write_heavy` into a CI job so harness rot doesn't recur
