### PR TITLE
fix(testbed/bench): bound keyspace + measure post-GC live heap

### DIFF
--- a/testbed/bench/README.md
+++ b/testbed/bench/README.md
@@ -57,7 +57,13 @@ artifacts are written under
 Each YAML declares the phases (`warmup`, `steady`, `cooldown`), the ghz
 target (`call` + `data_template`), optional `subscribe` and `chaos`
 blocks, and the leak-gate thresholds (`goroutine_max_delta`,
-`heap_inuse_max_delta_mb`).
+`heap_alloc_max_delta_mb`). The gate evaluates against `heap_alloc`
+(post-GC live bytes), forcing a `runtime.GC()` via
+`/debug/pprof/heap?gc=1` before each snapshot so the reading reflects
+live memory rather than span-level allocator headroom. The legacy field
+name `heap_inuse_max_delta_mb` is still accepted for backward
+compatibility but produced false-positive verdicts under sustained
+churn — see issue #248.
 
 ## Output layout
 
@@ -65,7 +71,7 @@ blocks, and the leak-gate thresholds (`goroutine_max_delta`,
 testbed/bench/out/<scenario>/<ts>/
 ├── report.md                       # rendered summary (start here)
 ├── leak_gate.json                  # verdict + per-replica deltas + thresholds
-├── runtime_pre.json                # per-replica go_goroutines + heap_inuse, after warmup
+├── runtime_pre.json                # per-replica go_goroutines + heap_alloc/heap_inuse/heap_objects, after warmup
 ├── runtime_post.json               # same, after cooldown
 ├── ghz_warmup_<endpoint>.json      # raw ghz results, one per invocation
 ├── ghz_steady_<...>.json
@@ -80,8 +86,10 @@ testbed/bench/out/<scenario>/<ts>/
 ## Drill-down workflow
 
 1. **Verdict & deltas.** Open `report.md`. The leak-gate table shows the
-   pre/post goroutines + heap_inuse per replica with the Δ vs the
-   scenario threshold. Any cell exceeding the threshold is the first
+   pre/post goroutines + heap_alloc + heap_inuse + heap_objects per
+   replica with the Δ vs the scenario threshold. The verdict is driven
+   by `heap_alloc` (post-GC live bytes); `heap_inuse` and `heap_objects`
+   are shown for context. Any cell exceeding the threshold is the first
    place to look.
 2. **Allocation source.** For a leaking replica, diff its heap profiles:
 

--- a/testbed/bench/report/render.go
+++ b/testbed/bench/report/render.go
@@ -27,10 +27,18 @@ import (
 )
 
 // LeakGate mirrors the schema written by run.sh.
+//
+// The leak gate evaluates against heap_alloc (post-GC live bytes), not
+// heap_inuse (span-level, includes free slots). See issue #248 — under
+// sustained churn, heap_inuse drifts upward as the allocator opens new
+// spans even when live memory is flat, producing false-positive verdicts.
 type LeakGate struct {
 	Thresholds struct {
 		GoroutineMaxDelta   int `json:"goroutine_max_delta"`
-		HeapInuseMaxDeltaMB int `json:"heap_inuse_max_delta_mb"`
+		HeapAllocMaxDeltaMB int `json:"heap_alloc_max_delta_mb"`
+		// HeapInuseMaxDeltaMB is the legacy field name retained for backward
+		// compatibility with older leak_gate.json artifacts.
+		HeapInuseMaxDeltaMB int `json:"heap_inuse_max_delta_mb,omitempty"`
 	} `json:"thresholds"`
 	Replicas []LeakGateReplica `json:"replicas"`
 	Verdict  string            `json:"verdict"`
@@ -45,6 +53,12 @@ type LeakGateReplica struct {
 	HeapInusePreBytes   int64  `json:"heap_inuse_pre_bytes"`
 	HeapInusePostBytes  int64  `json:"heap_inuse_post_bytes"`
 	HeapInuseDeltaBytes int64  `json:"heap_inuse_delta_bytes"`
+	HeapAllocPreBytes   int64  `json:"heap_alloc_pre_bytes"`
+	HeapAllocPostBytes  int64  `json:"heap_alloc_post_bytes"`
+	HeapAllocDeltaBytes int64  `json:"heap_alloc_delta_bytes"`
+	HeapObjectsPre      int64  `json:"heap_objects_pre"`
+	HeapObjectsPost     int64  `json:"heap_objects_post"`
+	HeapObjectsDelta    int64  `json:"heap_objects_delta"`
 }
 
 // GhzSummary captures the subset of fields ghz writes that the report uses.
@@ -169,18 +183,26 @@ func RenderReport(w io.Writer, in Input) error {
 	if in.LeakGate == nil {
 		bw.printf("_not captured_\n\n")
 	} else {
-		bw.printf("Thresholds: goroutine_max_delta=%d, heap_inuse_max_delta_mb=%d\n\n",
-			in.LeakGate.Thresholds.GoroutineMaxDelta,
-			in.LeakGate.Thresholds.HeapInuseMaxDeltaMB)
-		bw.printf("| replica | goroutines (pre → post = Δ) | heap_inuse MiB (pre → post = Δ) |\n")
-		bw.printf("| --- | --- | --- |\n")
+		hMB := in.LeakGate.Thresholds.HeapAllocMaxDeltaMB
+		if hMB == 0 {
+			hMB = in.LeakGate.Thresholds.HeapInuseMaxDeltaMB
+		}
+		bw.printf("Thresholds: goroutine_max_delta=%d, heap_alloc_max_delta_mb=%d\n\n",
+			in.LeakGate.Thresholds.GoroutineMaxDelta, hMB)
+		bw.printf("Gate evaluates against `heap_alloc` (post-GC live bytes); `heap_inuse` and `heap_objects` are shown for context only.\n\n")
+		bw.printf("| replica | goroutines (Δ) | heap_alloc MiB (pre → post = Δ) | heap_inuse MiB (pre → post = Δ) | heap_objects (Δ) |\n")
+		bw.printf("| --- | --- | --- | --- | --- |\n")
 		for _, r := range in.LeakGate.Replicas {
-			bw.printf("| `%s` | %d → %d = **%+d** | %.1f → %.1f = **%+.1f** |\n",
+			bw.printf("| `%s` | %d → %d = **%+d** | %.1f → %.1f = **%+.1f** | %.1f → %.1f = **%+.1f** | %d → %d = **%+d** |\n",
 				r.Endpoint,
 				r.GoroutinesPre, r.GoroutinesPost, r.GoroutineDelta,
+				bytesToMiB(r.HeapAllocPreBytes),
+				bytesToMiB(r.HeapAllocPostBytes),
+				bytesToMiB(r.HeapAllocDeltaBytes),
 				bytesToMiB(r.HeapInusePreBytes),
 				bytesToMiB(r.HeapInusePostBytes),
 				bytesToMiB(r.HeapInuseDeltaBytes),
+				r.HeapObjectsPre, r.HeapObjectsPost, r.HeapObjectsDelta,
 			)
 		}
 		bw.printf("\n")

--- a/testbed/bench/report/render_test.go
+++ b/testbed/bench/report/render_test.go
@@ -17,12 +17,15 @@ func TestRenderReport_AllSectionsAndVerdict(t *testing.T) {
 			Verdict: "pass",
 			Thresholds: struct {
 				GoroutineMaxDelta   int `json:"goroutine_max_delta"`
-				HeapInuseMaxDeltaMB int `json:"heap_inuse_max_delta_mb"`
-			}{GoroutineMaxDelta: 20, HeapInuseMaxDeltaMB: 32},
+				HeapAllocMaxDeltaMB int `json:"heap_alloc_max_delta_mb"`
+				HeapInuseMaxDeltaMB int `json:"heap_inuse_max_delta_mb,omitempty"`
+			}{GoroutineMaxDelta: 20, HeapAllocMaxDeltaMB: 32},
 			Replicas: []LeakGateReplica{{
 				Endpoint:      "localhost:9390",
 				GoroutinesPre: 100, GoroutinesPost: 110, GoroutineDelta: 10,
 				HeapInusePreBytes: 10 << 20, HeapInusePostBytes: 15 << 20, HeapInuseDeltaBytes: 5 << 20,
+				HeapAllocPreBytes: 8 << 20, HeapAllocPostBytes: 9 << 20, HeapAllocDeltaBytes: 1 << 20,
+				HeapObjectsPre: 1000, HeapObjectsPost: 1100, HeapObjectsDelta: 100,
 			}},
 		},
 		GhzFiles: []GhzFile{{
@@ -51,6 +54,7 @@ func TestRenderReport_AllSectionsAndVerdict(t *testing.T) {
 		"**Leak gate verdict:** `pass`",
 		"## Leak gate",
 		"goroutine_max_delta=20",
+		"heap_alloc_max_delta_mb=32",
 		"`localhost:9390`",
 		"**+10**",
 		"50.00", // p99 ms
@@ -94,8 +98,8 @@ func TestLoadInput_AssemblesFromDisk(t *testing.T) {
 
 	lg := LeakGate{Verdict: "fail"}
 	lg.Thresholds.GoroutineMaxDelta = 5
-	lg.Thresholds.HeapInuseMaxDeltaMB = 16
-	lg.Replicas = []LeakGateReplica{{Endpoint: "x", GoroutineDelta: 9, HeapInuseDeltaBytes: 1 << 20}}
+	lg.Thresholds.HeapAllocMaxDeltaMB = 16
+	lg.Replicas = []LeakGateReplica{{Endpoint: "x", GoroutineDelta: 9, HeapAllocDeltaBytes: 1 << 20}}
 	mustWriteJSON(t, filepath.Join(dir, "leak_gate.json"), lg)
 
 	gh := GhzSummary{Count: 42, Rps: 1, Average: 1_000_000,

--- a/testbed/bench/run.sh
+++ b/testbed/bench/run.sh
@@ -132,18 +132,30 @@ prom_scalar() {
 }
 
 snapshot_runtime() {
+  # Force a GC on every replica before sampling so heap_alloc_bytes reflects
+  # live (post-GC) memory rather than transient allocation between cycles.
+  # /debug/pprof/heap?gc=1 calls runtime.GC() before returning the profile —
+  # we discard the body and just use the side effect.
   local out="$1" port
+  for port in "${REPLICA_METRICS_PORTS[@]}"; do
+    curl -fsS --max-time 10 "http://localhost:${port}/debug/pprof/heap?gc=1" \
+      -o /dev/null || true
+  done
   local -a samples=()
   for port in "${REPLICA_METRICS_PORTS[@]}"; do
     local text
     text="$(curl -fsS --max-time 5 "http://localhost:${port}/metrics" || true)"
-    local g h
+    local g h_inuse h_alloc h_objs
     # Prom client formats large gauges in scientific notation (e.g. 1.949696e+07).
     # Coerce to integer so downstream JSON consumers (jq + Go int64) don't choke.
     g="$(printf '%.0f' "$(prom_scalar go_goroutines "$text")" 2>/dev/null)"; g="${g:-0}"
-    h="$(printf '%.0f' "$(prom_scalar go_memstats_heap_inuse_bytes "$text")" 2>/dev/null)"; h="${h:-0}"
-    samples+=( "$(jq -nc --arg ep "localhost:${port}" --argjson g "$g" --argjson h "$h" \
-      '{endpoint: $ep, goroutines: $g, heap_inuse_bytes: $h}')" )
+    h_inuse="$(printf '%.0f' "$(prom_scalar go_memstats_heap_inuse_bytes "$text")" 2>/dev/null)"; h_inuse="${h_inuse:-0}"
+    h_alloc="$(printf '%.0f' "$(prom_scalar go_memstats_heap_alloc_bytes "$text")" 2>/dev/null)"; h_alloc="${h_alloc:-0}"
+    h_objs="$(printf '%.0f'  "$(prom_scalar go_memstats_heap_objects     "$text")" 2>/dev/null)"; h_objs="${h_objs:-0}"
+    samples+=( "$(jq -nc --arg ep "localhost:${port}" \
+        --argjson g "$g" \
+        --argjson hi "$h_inuse" --argjson ha "$h_alloc" --argjson ho "$h_objs" \
+      '{endpoint: $ep, goroutines: $g, heap_inuse_bytes: $hi, heap_alloc_bytes: $ha, heap_objects: $ho}')" )
   done
   printf '%s\n' "${samples[@]}" | jq -s '.' > "$out"
 }
@@ -292,7 +304,11 @@ done < "$CAPTURE_DIR/prom_queries.txt"
 
 # ----- Leak gate -------------------------------------------------------------
 g_thresh="$(yq -r '.leak_gate.goroutine_max_delta' "$SCENARIO_FILE")"
-h_thresh_mb="$(yq -r '.leak_gate.heap_inuse_max_delta_mb' "$SCENARIO_FILE")"
+# Prefer the new heap_alloc-based threshold; fall back to the legacy
+# heap_inuse_max_delta_mb so scenarios that haven't been updated yet still
+# evaluate. See issue #248 — heap_inuse is span-level and includes free
+# slots, so it is unreliable as a leak signal under sustained churn.
+h_thresh_mb="$(yq -r '.leak_gate.heap_alloc_max_delta_mb // .leak_gate.heap_inuse_max_delta_mb' "$SCENARIO_FILE")"
 h_thresh_bytes=$(( h_thresh_mb * 1024 * 1024 ))
 
 leak_json="$(jq -n \
@@ -310,13 +326,19 @@ leak_json="$(jq -n \
       goroutine_delta:   ($post[$i].goroutines - $pre[$i].goroutines),
       heap_inuse_pre_bytes:  $pre[$i].heap_inuse_bytes,
       heap_inuse_post_bytes: $post[$i].heap_inuse_bytes,
-      heap_inuse_delta_bytes:($post[$i].heap_inuse_bytes - $pre[$i].heap_inuse_bytes)
+      heap_inuse_delta_bytes:($post[$i].heap_inuse_bytes - $pre[$i].heap_inuse_bytes),
+      heap_alloc_pre_bytes:  $pre[$i].heap_alloc_bytes,
+      heap_alloc_post_bytes: $post[$i].heap_alloc_bytes,
+      heap_alloc_delta_bytes:($post[$i].heap_alloc_bytes - $pre[$i].heap_alloc_bytes),
+      heap_objects_pre:      $pre[$i].heap_objects,
+      heap_objects_post:     $post[$i].heap_objects,
+      heap_objects_delta:   ($post[$i].heap_objects - $pre[$i].heap_objects)
     }
   ] as $r |
   {
-    thresholds: {goroutine_max_delta: $g_thresh, heap_inuse_max_delta_mb: $h_thresh_mb},
+    thresholds: {goroutine_max_delta: $g_thresh, heap_alloc_max_delta_mb: $h_thresh_mb},
     replicas: $r,
-    verdict: (if any($r[]; .goroutine_delta > $g_thresh or .heap_inuse_delta_bytes > $h_thresh)
+    verdict: (if any($r[]; .goroutine_delta > $g_thresh or .heap_alloc_delta_bytes > $h_thresh)
               then "fail" else "pass" end)
   }')"
 printf '%s\n' "$leak_json" > "$OUTDIR/leak_gate.json"

--- a/testbed/bench/scenarios/addedge_contention.yaml
+++ b/testbed/bench/scenarios/addedge_contention.yaml
@@ -13,4 +13,4 @@ target:
     {"edge":{"tail":"hot-tail","head":"hot-head","weight":1.0}}
 leak_gate:
   goroutine_max_delta: 15
-  heap_inuse_max_delta_mb: 16
+  heap_alloc_max_delta_mb: 16

--- a/testbed/bench/scenarios/batch_put_vertices.yaml
+++ b/testbed/bench/scenarios/batch_put_vertices.yaml
@@ -10,11 +10,11 @@ target:
   call: graph.v1.LanternService/PutVertices
   data_template: |
     {"vertices":[
-      {"key":"bk-{{.RequestNumber}}-0","int64":"{{.RequestNumber}}"},
-      {"key":"bk-{{.RequestNumber}}-1","int64":"{{.RequestNumber}}"},
-      {"key":"bk-{{.RequestNumber}}-2","int64":"{{.RequestNumber}}"},
-      {"key":"bk-{{.RequestNumber}}-3","int64":"{{.RequestNumber}}"}
+      {"key":"bk-{{mod .RequestNumber 10000}}-0","int64":"{{.RequestNumber}}"},
+      {"key":"bk-{{mod .RequestNumber 10000}}-1","int64":"{{.RequestNumber}}"},
+      {"key":"bk-{{mod .RequestNumber 10000}}-2","int64":"{{.RequestNumber}}"},
+      {"key":"bk-{{mod .RequestNumber 10000}}-3","int64":"{{.RequestNumber}}"}
     ]}
 leak_gate:
   goroutine_max_delta: 20
-  heap_inuse_max_delta_mb: 48
+  heap_alloc_max_delta_mb: 48

--- a/testbed/bench/scenarios/chaos_kill_replica.yaml
+++ b/testbed/bench/scenarios/chaos_kill_replica.yaml
@@ -24,4 +24,4 @@ chaos:
 leak_gate:
   # Replica restart legitimately adds goroutines until pumps settle; widen.
   goroutine_max_delta: 60
-  heap_inuse_max_delta_mb: 64
+  heap_alloc_max_delta_mb: 64

--- a/testbed/bench/scenarios/illuminate.yaml
+++ b/testbed/bench/scenarios/illuminate.yaml
@@ -14,4 +14,4 @@ target:
     {"seed":"k-{{mod .RequestNumber 1000}}","step":2,"k":32}
 leak_gate:
   goroutine_max_delta: 20
-  heap_inuse_max_delta_mb: 32
+  heap_alloc_max_delta_mb: 32

--- a/testbed/bench/scenarios/many_subscribers.yaml
+++ b/testbed/bench/scenarios/many_subscribers.yaml
@@ -19,4 +19,4 @@ subscribe:
   data_template: '{"fromSeq":"1"}'
 leak_gate:
   goroutine_max_delta: 80     # 64 streams × bookkeeping
-  heap_inuse_max_delta_mb: 64
+  heap_alloc_max_delta_mb: 64

--- a/testbed/bench/scenarios/mixed_rw.yaml
+++ b/testbed/bench/scenarios/mixed_rw.yaml
@@ -12,10 +12,10 @@ target:
   calls:
     - call: graph.v1.LanternService/PutVertex
       data_template: |
-        {"vertex":{"key":"k-{{.RequestNumber}}","int64":"{{.RequestNumber}}"}}
+        {"vertex":{"key":"k-{{mod .RequestNumber 10000}}","int64":"{{.RequestNumber}}"}}
     - call: graph.v1.LanternService/GetVertex
       data_template: |
         {"key":"k-{{mod .RequestNumber 10000}}"}
 leak_gate:
   goroutine_max_delta: 25
-  heap_inuse_max_delta_mb: 32
+  heap_alloc_max_delta_mb: 32

--- a/testbed/bench/scenarios/read_heavy.yaml
+++ b/testbed/bench/scenarios/read_heavy.yaml
@@ -12,4 +12,4 @@ target:
     {"key":"k-{{mod .RequestNumber 10000}}"}
 leak_gate:
   goroutine_max_delta: 20
-  heap_inuse_max_delta_mb: 24
+  heap_alloc_max_delta_mb: 24

--- a/testbed/bench/scenarios/replication_soak.yaml
+++ b/testbed/bench/scenarios/replication_soak.yaml
@@ -24,4 +24,4 @@ subscribe:
       data_template: '{"fromSeq":"1"}'
 leak_gate:
   goroutine_max_delta: 30
-  heap_inuse_max_delta_mb: 64
+  heap_alloc_max_delta_mb: 64

--- a/testbed/bench/scenarios/scan_prefix.yaml
+++ b/testbed/bench/scenarios/scan_prefix.yaml
@@ -12,4 +12,4 @@ target:
     {"prefix":"k-{{mod .RequestNumber 100}}","limit":128}
 leak_gate:
   goroutine_max_delta: 20
-  heap_inuse_max_delta_mb: 32
+  heap_alloc_max_delta_mb: 32

--- a/testbed/bench/scenarios/smoke_write_heavy.yaml
+++ b/testbed/bench/scenarios/smoke_write_heavy.yaml
@@ -10,7 +10,7 @@ target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
   call: graph.v1.LanternService/PutVertex
   data_template: |
-    {"vertex":{"key":"k-{{.RequestNumber}}","int64":"{{.RequestNumber}}"}}
+    {"vertex":{"key":"k-{{mod .RequestNumber 10000}}","int64":"{{.RequestNumber}}"}}
 leak_gate:
   goroutine_max_delta: 20
-  heap_inuse_max_delta_mb: 32
+  heap_alloc_max_delta_mb: 32

--- a/testbed/bench/scenarios/ttl_churn.yaml
+++ b/testbed/bench/scenarios/ttl_churn.yaml
@@ -18,4 +18,4 @@ target:
 leak_gate:
   # cooldown is long enough that expirations have drained; tighter bounds.
   goroutine_max_delta: 15
-  heap_inuse_max_delta_mb: 16
+  heap_alloc_max_delta_mb: 16

--- a/testbed/bench/scenarios/write_heavy.yaml
+++ b/testbed/bench/scenarios/write_heavy.yaml
@@ -11,8 +11,14 @@ target:
   # Templates are evaluated AFTER JSON parse, so every templated value must
   # sit inside a string literal. int64 is a proto3 JSON-string-encoded
   # numeric field, so `"int64":"{{.RequestNumber}}"` round-trips cleanly.
+  #
+  # Key is wrapped in `mod` to bound the working set: warmup fills the
+  # cache, steady-state writes are overwrites (mutate-in-place). Without
+  # this bound the cache grows unboundedly (no size-based eviction in
+  # core/cache) and the leak gate fires on legitimate fill, not on a
+  # real leak. See issue #248.
   data_template: |
-    {"vertex":{"key":"k-{{.RequestNumber}}","int64":"{{.RequestNumber}}"}}
+    {"vertex":{"key":"k-{{mod .RequestNumber 50000}}","int64":"{{.RequestNumber}}"}}
 leak_gate:
   goroutine_max_delta: 20
-  heap_inuse_max_delta_mb: 32
+  heap_alloc_max_delta_mb: 32


### PR DESCRIPTION
Closes #248.

Two coupled fixes for the bench harness, surfaced while deep-diving `write_heavy` stability.

## 1. Bounded keyspace in write scenarios

`core/cache` is intentionally TTL-only (no size cap). Unbounded write keyspaces fill the cache for the full 5-min TTL and look like a leak even though the cache is behaving as designed. Bounded the steady-state key cardinality:

| Scenario | Key template |
| --- | --- |
| `write_heavy` | `k-{{mod .RequestNumber 50000}}` |
| `smoke_write_heavy` | `k-{{mod .RequestNumber 10000}}` |
| `mixed_rw` (Put side) | `k-{{mod .RequestNumber 10000}}` |
| `batch_put_vertices` | `bk-{{mod .RequestNumber 10000}}-N` |

## 2. Leak gate now measures post-GC live bytes (`heap_alloc`)

While verifying fix #1 the smoke run still flagged `fail` with +132 MiB on lantern-2. `pprof` base-diff told a different story:

\`\`\`
inuse_space delta:  -881.91 kB  (essentially zero — pprof forces runtime.GC)
allocs   delta:      8.5 MB     (cumulative — i.e. allocation rate)
heap_inuse_bytes:   +132 MiB    (the false positive)
\`\`\`

Root cause: `go_memstats_heap_inuse_bytes` is a span gauge that retains capacity after high-churn workloads. It is **not** a live-memory signal and produces false-positive leak verdicts under sustained churn with GOGC=100 and heterogeneous pre-heaps.

Changes:
- `snapshot_runtime()` now calls `curl /debug/pprof/heap?gc=1` against each replica (discarding the body) to force `runtime.GC()` before scraping `/metrics`, then captures `go_memstats_heap_alloc_bytes` and `go_memstats_heap_objects` alongside `heap_inuse_bytes`.
- Verdict evaluates against `heap_alloc_max_delta_mb` (post-GC live bytes). The legacy key `heap_inuse_max_delta_mb` is still accepted as a fallback for backward compatibility.
- All 12 scenario YAMLs renamed to `heap_alloc_max_delta_mb`.
- Report renderer + tests updated. `report.md` now shows `heap_alloc` as the gate signal with `heap_inuse` and `heap_objects` displayed for context.

## Smoke validation

`SKIP_UP=1 KEEP_UP=1 ./testbed/bench/run.sh smoke_write_heavy` (60 s @ 5k rps, 3 replicas, 10k-key space):

\`\`\`
verdict: pass
heap_alloc Δ:  -1.3 MiB / -0.6 MiB / +1.5 MiB
heap_inuse Δ:  -0.9 MiB / +0.0 MiB / +2.2 MiB
heap_objects Δ: -2863 / +5665 / +6600
goroutines Δ:   -1 / 0 / 0
\`\`\`

The same run under the previous gate would have failed with +132 MiB on `heap_inuse`.