### PR TITLE
fix(cache): treat zero/epoch expiration as never-expires (#250)

### DIFF
--- a/core/cache/cache.go
+++ b/core/cache/cache.go
@@ -12,8 +12,36 @@ type volatile[T any] struct {
 	expiration time.Time
 }
 
+// IsLiveAt reports whether an expiration deadline is still in the future
+// relative to now. It centralises the "no expiration" sentinel handling
+// shared across the vertex cache, the edge cache, and any future expiring
+// store. Two values are treated as "never expires":
+//
+//   - Go zero time (`time.Time{}`, year 1) — the documented sentinel for
+//     "no expiration" used by service.validateExpiration and the proto
+//     contract (`Vertex.expiration` / `Edge.expiration` are optional).
+//   - Unix epoch or earlier (`expiration.Unix() <= 0`) — `(*timestamppb.
+//     Timestamp)(nil).AsTime()` returns `time.Unix(0,0).UTC()`, NOT Go zero,
+//     so the cache used to silently treat every PutVertex without an
+//     expiration as already-expired (issue #250).
+//
+// Any positive future deadline behaves as before: live until now passes it.
+func IsLiveAt(expiration, now time.Time) bool {
+	if expiration.IsZero() || expiration.Unix() <= 0 {
+		return true
+	}
+	return expiration.After(now)
+}
+
+// IsLive is the IsLiveAt shorthand that samples time.Now() once per call.
+func IsLive(expiration time.Time) bool {
+	return IsLiveAt(expiration, time.Now())
+}
+
+// IsExpired reports whether this entry has passed its expiration deadline.
+// See IsLiveAt for the "no expiration" sentinel semantics.
 func (v *volatile[T]) IsExpired() bool {
-	return v.expiration.Before(time.Now())
+	return !IsLive(v.expiration)
 }
 
 type Cache[S comparable, T any] struct {
@@ -156,9 +184,8 @@ func (c *Cache[S, T]) Count() int {
 func (c *Cache[S, T]) Range(fn func(key S, value T, expiration time.Time) bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	now := time.Now()
 	for k, v := range c.cache {
-		if v.expiration.Before(now) {
+		if v.IsExpired() {
 			continue
 		}
 		if !fn(k, v.value, v.expiration) {

--- a/core/cache/cache_test.go
+++ b/core/cache/cache_test.go
@@ -439,3 +439,53 @@ func TestCache_OnEvict_Clearing(t *testing.T) {
 		t.Fatalf("calls = %d, want 0", got)
 	}
 }
+
+// TestIsLiveAt covers the "never expires" sentinels documented in the
+// IsLiveAt godoc. Regression for issue #250: PutVertex without an
+// Expiration was silently stored as already-expired because the volatile
+// entry was constructed from `(*timestamppb.Timestamp)(nil).AsTime()`,
+// which yields Unix(0,0) — not Go zero — so the original Before(now)
+// check evicted it on the next read.
+func TestIsLiveAt(t *testing.T) {
+	now := time.Date(2026, 6, 4, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		exp  time.Time
+		want bool
+	}{
+		{"go zero is never-expires", time.Time{}, true},
+		{"unix epoch UTC is never-expires", time.Unix(0, 0).UTC(), true},
+		{"unix epoch local is never-expires", time.Unix(0, 0), true},
+		{"negative unix is never-expires", time.Unix(-1, 0), true},
+		{"future is live", now.Add(time.Hour), true},
+		{"past is expired", now.Add(-time.Hour), false},
+	}
+	for _, tt := range tests {
+		if got := IsLiveAt(tt.exp, now); got != tt.want {
+			t.Errorf("%s: IsLiveAt(%v) = %v, want %v", tt.name, tt.exp, got, tt.want)
+		}
+	}
+}
+
+// TestCache_PutWithExpiration_ZeroNeverExpires is the end-to-end regression
+// for #250: a value stored with a zero or unix-epoch expiration must remain
+// retrievable indefinitely, and must survive a Flush pass.
+func TestCache_PutWithExpiration_ZeroNeverExpires(t *testing.T) {
+	cases := map[string]time.Time{
+		"go-zero":    {},
+		"unix-epoch": time.Unix(0, 0).UTC(),
+	}
+	for name, exp := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewCache[string, int](time.Minute)
+			c.PutWithExpiration("k", 42, exp)
+			if got, ok := c.Get("k"); !ok || got != 42 {
+				t.Fatalf("Get after put: got=%v ok=%v want=42 true", got, ok)
+			}
+			c.Flush()
+			if got, ok := c.Get("k"); !ok || got != 42 {
+				t.Fatalf("Get after flush: got=%v ok=%v want=42 true", got, ok)
+			}
+		})
+	}
+}

--- a/core/cache/graph/edge.go
+++ b/core/cache/graph/edge.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/anaregdesign/lantern/core/cache"
 	"github.com/anaregdesign/lantern/core/hlc"
 )
 
@@ -87,7 +88,7 @@ func (w *weight) addWithExpirationContrib(value float32, expiration time.Time, c
 	if !contribID.IsZero() {
 		now := time.Now()
 		for _, v := range w.values {
-			if v.contribID == contribID && v.expiration.After(now) {
+			if v.contribID == contribID && cache.IsLiveAt(v.expiration, now) {
 				return false
 			}
 		}
@@ -176,7 +177,7 @@ func (w *weight) snapshotEntry(now time.Time) ([]SnapshotContribution, hlc.Times
 	defer w.mu.Unlock()
 	out := make([]SnapshotContribution, 0, len(w.values))
 	for _, v := range w.values {
-		if !v.expiration.After(now) {
+		if !cache.IsLiveAt(v.expiration, now) {
 			continue
 		}
 		out = append(out, SnapshotContribution{
@@ -198,7 +199,7 @@ func (w *weight) flushLocked() {
 	write := 0
 	var sum float32
 	for _, v := range w.values {
-		if v.expiration.After(now) {
+		if cache.IsLiveAt(v.expiration, now) {
 			w.values[write] = v
 			write++
 			sum += v.value

--- a/server/service/service_external_test.go
+++ b/server/service/service_external_test.go
@@ -280,3 +280,49 @@ func TestBufconn_GetEdges_PartialMiss(t *testing.T) {
 		t.Errorf("Missing = %v, want [{x y}]", resp.GetMissing())
 	}
 }
+
+// TestBufconn_PutVertex_NoExpiration_NeverExpires is the end-to-end
+// regression for #250. Before the fix, omitting Expiration on PutVertex
+// caused (*timestamppb.Timestamp)(nil).AsTime() == Unix(0,0) to flow into
+// the volatile cache entry. volatile.IsExpired returned Before(now)==true
+// for that timestamp, so GetVertex returned NotFound for every write —
+// exactly the silent data-loss observed in the read_heavy bench scenario.
+func TestBufconn_PutVertex_NoExpiration_NeverExpires(t *testing.T) {
+	c, ctx, cleanup := newBufconnClient(t)
+	defer cleanup()
+
+	v := &pb.Vertex{Key: "no-exp", Value: &pb.Vertex_Nil{Nil: true}} // no Expiration set
+	if _, err := c.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: []*pb.Vertex{v}}); err != nil {
+		t.Fatalf("PutVertices: %v", err)
+	}
+
+	got, err := c.GetVertex(ctx, &pb.GetVertexRequest{Key: "no-exp"})
+	if err != nil {
+		t.Fatalf("GetVertex(no-exp) returned %v, want vertex; this is the #250 regression", err)
+	}
+	if got.GetVertex().GetKey() != "no-exp" {
+		t.Errorf("key = %q, want %q", got.GetVertex().GetKey(), "no-exp")
+	}
+}
+
+// TestBufconn_AddEdge_NoExpiration_NeverExpires mirrors the vertex
+// regression for edges. The edgeCache flushLocked path also called
+// v.expiration.After(now), so an edge added without Expiration was
+// immediately swept on the next read.
+func TestBufconn_AddEdge_NoExpiration_NeverExpires(t *testing.T) {
+	c, ctx, cleanup := newBufconnClient(t)
+	defer cleanup()
+
+	e := &pb.Edge{Tail: "a", Head: "b", Weight: 1.5} // no Expiration set
+	if _, err := c.AddEdges(ctx, &pb.AddEdgesRequest{Edges: []*pb.Edge{e}}); err != nil {
+		t.Fatalf("AddEdges: %v", err)
+	}
+
+	got, err := c.GetEdge(ctx, &pb.GetEdgeRequest{Tail: "a", Head: "b"})
+	if err != nil {
+		t.Fatalf("GetEdge(a->b) returned %v, want edge; this is the #250 regression", err)
+	}
+	if got.GetEdge().GetWeight() != 1.5 {
+		t.Errorf("weight = %v, want 1.5", got.GetEdge().GetWeight())
+	}
+}


### PR DESCRIPTION
Closes #250

## Problem

`PutVertex`/`AddEdge` requests that omit the proto `Expiration` field were silently dropped:
`PutVertex` returned OK, but every subsequent `GetVertex` returned `NotFound`.
The bench's `read_heavy` scenario surfaced this as **2,999,994 / 2,999,998 NotFound** after the `PutVertex` half of the run completed cleanly. Per-replica metrics confirmed `PutVertex OK ≈ 4M` vs `GetVertex NotFound ≈ 3M` on the same backend — i.e. the writes were accepted, never retained.

## Root cause

- `(*timestamppb.Timestamp)(nil).AsTime()` returns `time.Unix(0, 0).UTC()` — **not** Go zero (`time.Time{}`, year 1).
- The service-layer contract (`validateExpiration` doc and the proto `optional` semantics) treats a missing `Expiration` as 'never expires' and accepts it silently.
- The cache layer (`core/cache.volatile.IsExpired`) checked `expiration.Before(time.Now())`. Both Go zero **and** unix-epoch satisfy that, so every entry without an explicit `Expiration` was immediately expired.
- The edge cache (`core/cache/graph/edge.go`) used the symmetric `expiration.After(now)` predicate in `flushLocked`, `snapshotEntry`, and the ContribID dedup path — same bug for edges.

## Fix

- New package-level helpers `core/cache.IsLiveAt` / `core/cache.IsLive` centralise the 'never expires' contract:
  - Go zero (`time.Time{}`) → live
  - `expiration.Unix() <= 0` (covers nil-proto `AsTime()` and pre-epoch) → live
  - any positive future deadline → live until `now` passes it
- Route `volatile.IsExpired`, `Cache.Range`, and the three edge-weight expiration checks (dedup, snapshotEntry, flushLocked) through the helper so vertex and edge caches honour the contract uniformly.

## Tests

- `core/cache`: `TestIsLiveAt` (truth table) + `TestCache_PutWithExpiration_ZeroNeverExpires` (Put → Get → Flush → Get for Go-zero and unix-epoch).
- `server/service` bufconn: `TestBufconn_PutVertex_NoExpiration_NeverExpires` and `TestBufconn_AddEdge_NoExpiration_NeverExpires` exercise the wire path that the bench scenarios use.

All module test suites pass locally (`go test ./...` from root, `core/`, `pb/`, `sdks/go/`, and `(cd server && go vet ./... && go test ./...)`).

## Bench impact (follow-up)

After this lands, the bench server image will be rebuilt and the sweep continued: write_heavy (to verify heap actually grows), read_heavy (expect 0 NotFound), then mixed_rw / addedge_contention / replication_soak / many_subscribers / chaos_kill_replica.