### PR TITLE
fix(bench): shrink mutation-log ring to 10k for write_heavy leak_gate

### DIFF
--- a/testbed/bench/compose.override.yml
+++ b/testbed/bench/compose.override.yml
@@ -23,6 +23,12 @@ services:
       # and /debug/pprof/block to return useful data. Cheap at these rates.
       LANTERN_MUTEX_PROFILE_FRACTION: "100"
       LANTERN_BLOCK_PROFILE_RATE: "10000"
+      # Shrink the mutation-log ring from the prod default (100k) to a bench
+      # size. At 5k RPS for 5min the steady-state phase generates ~1.5M ops,
+      # so a 10k ring overflows ~150x — exercising gap-fill / snapshot paths
+      # while keeping legitimate ring retention well under the leak_gate
+      # heap budget. See issue #254.
+      LANTERN_MUTATION_LOG_CAPACITY: "10000"
     ports:
       - target: 9090
         published: "9390-9392"


### PR DESCRIPTION
Closes #254

## Summary

Post-#253 the primary replica legitimately retains a full mutationlog ring in steady-state (~470 B/entry × 100k default = ~36 MiB), exceeding the 32 MiB heap_alloc leak_gate budget. The gate was firing on intentional bounded retention, not a leak.

This recalibrates the bench environment by setting `LANTERN_MUTATION_LOG_CAPACITY=10000` in `testbed/bench/compose.override.yml`:

- Keeps leak_gate sensitive to actual leaks (budget stays at 32 MiB).
- Exercises gap-fill / snapshot paths more aggressively (1.5M writes against a 10k ring → ~150× overflow).
- Does **not** change production defaults.

## Validation

Clean `write_heavy` run with this change:

| replica | goroutines Δ | heap_alloc Δ | p99 |
| --- | --- | --- | --- |
| 9390 | +0 | +8.4 MiB | — |
| 9391 | +1 | +7.7 MiB | — |
| 9392 | +0 | +8.6 MiB | — |

- ghz steady: 1,499,999 ops, p99 0.89 ms, **2 non-OK**.
- Leak gate verdict: **pass**.

## Quality gate

- `gofmt -l . cli core pb sdks server tests` → clean
- `(cd server && go vet ./... && go test ./...)` → ok
- per-module `go test ./...` → ok