### PR TITLE
ci: release-time bench → fixed-format report in release notes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -107,6 +107,64 @@ jobs:
         run: |
           echo "$TAGS" | xargs -I {} cosign sign --yes {}@${DIGEST}
 
+  bench:
+    # Release-time benchmark sweep. Runs the smoke scenarios listed in
+    # testbed/bench/release-scenarios.txt against a freshly-built local
+    # image and uploads a fixed-format bench-report.md for the release
+    # job to splice into the release notes. Non-blocking: a leak-gate
+    # failure or harness hiccup must not prevent a release from shipping.
+    # See issue #256.
+    name: Release-time benchmark
+    needs: verify
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.4'
+          check-latest: true
+      - name: Install bench prerequisites (ghz, yq)
+        run: |
+          set -euo pipefail
+          GHZ_VERSION="0.121.0"
+          curl -fsSL -o /tmp/ghz.tgz \
+            "https://github.com/bojand/ghz/releases/download/v${GHZ_VERSION}/ghz-linux-x86_64.tar.gz"
+          sudo tar -xzf /tmp/ghz.tgz -C /usr/local/bin ghz
+          sudo chmod +x /usr/local/bin/ghz
+          ghz --version
+          YQ_VERSION="v4.45.4"
+          sudo curl -fsSL -o /usr/local/bin/yq \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+      - name: Build lantern:local image
+        run: |
+          docker build \
+            --build-arg VERSION=${{ github.ref_name }} \
+            --build-arg COMMIT=${{ github.sha }} \
+            -t lantern:local .
+      - name: Run release bench sweep
+        env:
+          TAG: ${{ github.ref_name }}
+          COMMIT: ${{ github.sha }}
+          RUNNER: linux/amd64 (ubuntu-latest)
+          LANTERN_IMAGE: lantern:local
+        run: ./testbed/bench/release.sh --out bench-report.md
+      - name: Upload bench report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-report
+          path: bench-report.md
+          if-no-files-found: warn
+          retention-days: 30
+
   binaries:
     name: Build CLI binaries
     needs: verify
@@ -142,7 +200,7 @@ jobs:
 
   release:
     name: GitHub Release
-    needs: [build, binaries]
+    needs: [build, binaries, bench]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -156,6 +214,12 @@ jobs:
         with:
           name: cli-binaries
           path: dist
+      - name: Download bench report
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: bench-report
+          path: bench
       - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -193,6 +257,18 @@ jobs:
             echo "curl -L -o lantern-cli.tar.gz https://github.com/${REPO}/releases/download/${TAG}/lantern-cli_${TAG#v}_Darwin_arm64.tar.gz"
             echo "tar -xzf lantern-cli.tar.gz && ./lantern-cli version"
             echo '```'
+            echo
+            # Splice in the release-time benchmark report if the bench job
+            # produced one. The bench job is non-blocking (continue-on-error)
+            # so a missing artifact is normal — fall back to a placeholder
+            # rather than aborting the release. Issue #256.
+            if [[ -s bench/bench-report.md ]]; then
+              cat bench/bench-report.md
+            else
+              echo "## Lantern benchmark — ${TAG}"
+              echo
+              echo "_Bench job did not produce a report for this release; see the workflow run for details._"
+            fi
             echo
             echo "$auto"
           } > "$notes_file"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,7 +244,11 @@ Tag order matters because each downstream module pins the upstream tag:
 4. Bump the matching `require` (and any `replace`) lines in the root `go.mod`
    to the freshly-tagged versions.
 5. Root `vX.Y.Z` — triggers `docker-publish.yml` (amd64 + arm64 buildx +
-   cosign keyless).
+   cosign keyless). The same workflow also runs the release-time bench
+   sweep (`testbed/bench/release.sh` → smoke scenarios) and splices a
+   fixed-format report into the release notes. The bench job is
+   non-blocking — if it fails, the release still ships with a placeholder
+   bench section. See issue [#256](https://github.com/anaregdesign/lantern/issues/256).
 
 The `server/` module is **never** tagged independently — it ships under the
 root tag. arm64 buildx under QEMU is slow; if a root tag already pushed the

--- a/testbed/bench/README.md
+++ b/testbed/bench/README.md
@@ -5,10 +5,21 @@ cluster (see `deploy/compose/`). Drives the cluster with [`ghz`][ghz],
 captures Prometheus range queries + Go pprof snapshots, applies a
 per-scenario leak gate, and renders a Markdown report.
 
-> **Not wired into CI.** Per the parent epic [#237], CI runs only fast
-> functional checks; this harness is a local / on-demand tool meant to be
-> used by maintainers when investigating performance or leak regressions.
-> Its outputs (under `testbed/bench/out/`) are git-ignored.
+> **PR CI does not run this harness.** Per the parent epic [#237], the
+> default PR pipeline runs only fast functional checks; this harness is a
+> local / on-demand tool meant to be used by maintainers when investigating
+> performance or leak regressions. Its outputs (under `testbed/bench/out/`)
+> are git-ignored.
+>
+> **Release CI does run a smoke subset.** On every `vX.Y.Z` tag push, the
+> `Release` workflow runs `./testbed/bench/release.sh` — a driver that
+> sweeps the scenarios listed in `release-scenarios.txt` (currently the
+> `smoke_*` variants) and produces a fixed-format `bench-report.md` that
+> is spliced into the GitHub Release notes. The bench job is
+> `continue-on-error`, so a noisy runner cannot block a release. See
+> issue [#256].
+
+[#256]: https://github.com/anaregdesign/lantern/issues/256
 
 ## Prerequisites
 

--- a/testbed/bench/release-scenarios.txt
+++ b/testbed/bench/release-scenarios.txt
@@ -1,0 +1,14 @@
+# Scenarios executed by testbed/bench/release.sh at release time.
+# One scenario stem per line (matches testbed/bench/scenarios/<stem>.yaml).
+# Lines starting with `#` and blank lines are ignored.
+#
+# Keep this list short: the release CI job runs each one sequentially on a
+# shared ubuntu-latest runner. The smoke_* variants finish in ~2 min wall
+# each (15s warmup + 60s steady + 15s cooldown + compose up/down), which
+# keeps total release time under ~10 min and avoids saturating the runner.
+#
+# Full *_heavy / mixed_rw scenarios remain the canonical signal for
+# local deep-dives; do not put them here.
+smoke_write_heavy
+smoke_read_heavy
+smoke_mixed_rw

--- a/testbed/bench/release.sh
+++ b/testbed/bench/release.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# release.sh — release-time bench driver.
+#
+# Runs every scenario listed in testbed/bench/release-scenarios.txt against
+# a single shared Compose stack and produces ONE aggregated bench-report.md
+# in the fixed format expected by the release workflow.
+#
+# Usage:
+#   ./testbed/bench/release.sh [--out PATH]
+#
+# Environment knobs:
+#   TAG            release tag (default: `git describe --tags --abbrev=0`)
+#   COMMIT         release commit SHA (default: `git rev-parse HEAD`)
+#   RUNNER         runner platform string (default: `uname -s/uname -m`, lowercased)
+#   LANTERN_IMAGE  image to run (default: lantern:local — must exist locally)
+#   KEEP_OUT=1     do not delete the per-scenario `out/` tree afterwards
+#
+# Exit codes:
+#   0  every scenario succeeded AND every leak gate verdict == "pass"
+#   1  the aggregator ran but at least one scenario failed or fail-gated
+#   2  setup error (missing tools, missing image, etc.)
+#
+# Design notes:
+#   - We DO bring up Compose ourselves once (not inside run.sh) and pass
+#     SKIP_UP=1/KEEP_UP=1 to run.sh for every scenario, so all scenarios
+#     hit the same 3-replica cluster. This keeps wall-time bounded and
+#     ensures every scenario observes the same baseline.
+#   - We DO NOT abort on a single scenario failure — the aggregator marks
+#     missing scenarios as `(failed)` rows and the workflow surfaces the
+#     overall verdict via this script's exit code.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+COMPOSE_FILES=(
+  -f "$REPO_ROOT/deploy/compose/docker-compose.yml"
+  -f "$HERE/compose.override.yml"
+)
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-lantern-bench-release}"
+
+OUT_PATH="bench-report.md"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out) OUT_PATH="$2"; shift 2 ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "release.sh: unknown arg $1" >&2; exit 2 ;;
+  esac
+done
+
+die() { echo "release.sh: $*" >&2; exit 2; }
+log() { printf '[%s] %s\n' "$(date -u +%H:%M:%SZ)" "$*"; }
+need() { command -v "$1" >/dev/null 2>&1 || die "missing required tool: $1"; }
+
+need docker; need ghz; need yq; need jq; need curl; need go; need git
+
+TAG="${TAG:-$(git -C "$REPO_ROOT" describe --tags --abbrev=0 2>/dev/null || echo unknown)}"
+COMMIT="${COMMIT:-$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)}"
+COMMIT_SHORT="${COMMIT:0:7}"
+RUNNER="${RUNNER:-$(uname -s | tr '[:upper:]' '[:lower:]')/$(uname -m)}"
+CAPTURED="$(date -u +%Y%m%dT%H%M%SZ)"
+
+SCENARIO_LIST="$HERE/release-scenarios.txt"
+[[ -f "$SCENARIO_LIST" ]] || die "missing $SCENARIO_LIST"
+
+scenarios=()
+while IFS= read -r line; do
+  line="${line%%#*}"
+  line="${line//[[:space:]]/}"
+  [[ -z "$line" ]] && continue
+  scenarios+=("$line")
+done < "$SCENARIO_LIST"
+
+[[ ${#scenarios[@]} -gt 0 ]] || die "no scenarios in $SCENARIO_LIST"
+
+log "release-bench: tag=$TAG commit=$COMMIT_SHORT runner=$RUNNER captured=$CAPTURED"
+log "release-bench: scenarios=${scenarios[*]}"
+
+# Verify the image exists locally so we fail fast.
+img="${LANTERN_IMAGE:-lantern:local}"
+if ! docker image inspect "$img" >/dev/null 2>&1; then
+  die "docker image $img not found; build it first (e.g. \`docker build -t lantern:local .\`)"
+fi
+export LANTERN_IMAGE="$img"
+
+# Bring up the shared cluster once.
+log "compose up (project=$COMPOSE_PROJECT_NAME, image=$img)"
+docker compose "${COMPOSE_FILES[@]}" up -d --scale lantern=3 --wait
+
+cleanup() {
+  log "compose down"
+  docker compose "${COMPOSE_FILES[@]}" down -v >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Track each scenario's output directory and overall verdict.
+scenario_args=()
+fail_count=0
+
+for s in "${scenarios[@]}"; do
+  log "scenario: $s"
+  before_dir="$HERE/out/$s"
+  mkdir -p "$before_dir"
+  # Snapshot existing run directories so we can identify the new one.
+  before_listing="$(ls -1 "$before_dir" 2>/dev/null | sort || true)"
+
+  # SKIP_UP=1 + KEEP_UP=1 → run.sh reuses our cluster and leaves it alone.
+  if SKIP_UP=1 KEEP_UP=1 "$HERE/run.sh" "$s"; then
+    log "scenario $s: PASS"
+  else
+    log "scenario $s: FAIL (leak gate or harness error)"
+    fail_count=$((fail_count + 1))
+  fi
+
+  after_listing="$(ls -1 "$before_dir" 2>/dev/null | sort || true)"
+  new_dir=""
+  while IFS= read -r d; do
+    if ! grep -Fxq "$d" <<<"$before_listing"; then
+      new_dir="$d"
+    fi
+  done <<<"$after_listing"
+
+  if [[ -n "$new_dir" ]]; then
+    scenario_args+=("$s=$before_dir/$new_dir")
+  else
+    log "scenario $s: no new output directory found — recording as failed"
+    scenario_args+=("$s=")
+    fail_count=$((fail_count + 1))
+  fi
+done
+
+log "aggregating into $OUT_PATH"
+go run "$HERE/release" \
+  -tag "$TAG" \
+  -commit "$COMMIT_SHORT" \
+  -runner "$RUNNER" \
+  -captured "$CAPTURED" \
+  -out "$OUT_PATH" \
+  "${scenario_args[@]}"
+
+log "done: $OUT_PATH (failures=$fail_count)"
+if [[ "${KEEP_OUT:-0}" != "1" ]]; then
+  rm -rf "$HERE/out"
+fi
+
+if [[ "$fail_count" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/testbed/bench/release/main.go
+++ b/testbed/bench/release/main.go
@@ -1,0 +1,297 @@
+// Package main is the release-time bench aggregator.
+//
+// It consumes the per-scenario artifacts produced by testbed/bench/run.sh
+// (one run directory per scenario, each containing leak_gate.json,
+// ghz_*.json, and a pre-rendered report.md) and emits a single fixed-format
+// Markdown document suitable for appending to a GitHub Release body.
+//
+// The output schema is intentionally stable across releases so that
+// readers can diff bench numbers tag-over-tag without parsing pain:
+//
+//	# Lantern benchmark — <tag>
+//	- Commit: <sha>
+//	- Runner: <runner>
+//	- Captured: <UTC timestamp>
+//
+//	## Summary
+//	| scenario | leak gate | rps | p99 (ms) | non-OK |
+//	| ... |
+//
+//	## <scenario>
+//	<per-scenario report.md, with H1 demoted to H3 so it nests cleanly>
+//
+// Invocation:
+//
+//	go run ./testbed/bench/release \
+//	    -tag v1.2.3 -commit abc1234 -runner linux/amd64 \
+//	    -captured 20260604T120000Z \
+//	    -out bench-report.md \
+//	    smoke_write_heavy=path/to/out/smoke_write_heavy/<ts> \
+//	    smoke_read_heavy=path/to/out/smoke_read_heavy/<ts> \
+//	    ...
+//
+// Missing per-scenario artifacts do NOT abort the run — the scenario is
+// rendered as a `(failed)` row in the summary so a single noisy scenario
+// does not prevent the rest of the report from shipping. The driver script
+// (release.sh) decides whether a fail row should fail the CI job.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// leakGate mirrors the subset of testbed/bench/report.LeakGate that the
+// aggregator needs. We re-declare it here (rather than importing the
+// renderer) because the renderer is package main and Go forbids importing
+// `main`. Keep the JSON tags in sync.
+type leakGate struct {
+	Verdict string `json:"verdict"`
+}
+
+// ghzSummary mirrors the subset of testbed/bench/report.GhzSummary that
+// the summary table needs.
+type ghzSummary struct {
+	Count                  uint64         `json:"count"`
+	Rps                    float64        `json:"rps"`
+	StatusCodeDistribution map[string]int `json:"statusCodeDistribution"`
+	LatencyDistribution    []struct {
+		Percentage int   `json:"percentage"`
+		Latency    int64 `json:"latency"`
+	} `json:"latencyDistribution"`
+}
+
+// scenarioInput is one row in the release report.
+type scenarioInput struct {
+	Name   string
+	Dir    string // run directory; empty if the scenario was not produced
+	Detail string // pre-rendered per-scenario report.md, with headers demoted
+	Row    summaryRow
+}
+
+// summaryRow is the rendered values for one row in the Summary table.
+type summaryRow struct {
+	Verdict string // "pass", "fail", or "(failed)" if artifacts are missing
+	Rps     string // pre-formatted, e.g. "5000.0" or "—"
+	P99ms   string // pre-formatted, e.g. "0.89" or "—"
+	NonOK   string // pre-formatted, e.g. "0" or "—"
+}
+
+// Header carries the fixed-format report header fields.
+type Header struct {
+	Tag      string
+	Commit   string
+	Runner   string
+	Captured string
+}
+
+func loadScenario(name, dir string) scenarioInput {
+	in := scenarioInput{Name: name, Dir: dir, Row: summaryRow{Verdict: "(failed)", Rps: "—", P99ms: "—", NonOK: "—"}}
+	if dir == "" {
+		return in
+	}
+
+	// Leak-gate verdict.
+	if b, err := os.ReadFile(filepath.Join(dir, "leak_gate.json")); err == nil {
+		var lg leakGate
+		if err := json.Unmarshal(b, &lg); err == nil && lg.Verdict != "" {
+			in.Row.Verdict = lg.Verdict
+		}
+	}
+
+	// Steady-phase ghz: pick the file whose basename starts with `ghz_steady_`.
+	// If multiple exist (e.g. mixed_rw forks per-call), aggregate them:
+	// rps = sum(rps), p99 = max(p99), non-OK = sum, count = sum.
+	if entries, err := os.ReadDir(dir); err == nil {
+		var sums []ghzSummary
+		for _, e := range entries {
+			n := e.Name()
+			if e.IsDir() || !strings.HasPrefix(n, "ghz_steady_") || !strings.HasSuffix(n, ".json") {
+				continue
+			}
+			b, err := os.ReadFile(filepath.Join(dir, n))
+			if err != nil {
+				continue
+			}
+			var s ghzSummary
+			if err := json.Unmarshal(b, &s); err == nil {
+				sums = append(sums, s)
+			}
+		}
+		if len(sums) > 0 {
+			var totalRps float64
+			var maxP99 int64
+			var nonOK int
+			for _, s := range sums {
+				totalRps += s.Rps
+				if p := percentileNs(s, 99); p > maxP99 {
+					maxP99 = p
+				}
+				for code, n := range s.StatusCodeDistribution {
+					if code != "OK" {
+						nonOK += n
+					}
+				}
+			}
+			in.Row.Rps = fmt.Sprintf("%.1f", totalRps)
+			in.Row.P99ms = fmt.Sprintf("%.2f", float64(maxP99)/1e6)
+			in.Row.NonOK = fmt.Sprintf("%d", nonOK)
+		}
+	}
+
+	// Detail section: re-use the renderer's output if present.
+	if b, err := os.ReadFile(filepath.Join(dir, "report.md")); err == nil {
+		in.Detail = demoteHeaders(string(b))
+	}
+
+	return in
+}
+
+func percentileNs(s ghzSummary, pct int) int64 {
+	for _, d := range s.LatencyDistribution {
+		if d.Percentage == pct {
+			return d.Latency
+		}
+	}
+	return 0
+}
+
+// demoteHeaders shifts every Markdown ATX heading down by two levels so
+// the per-scenario report nests under `## <scenario>` without colliding
+// with the top-level structure. `# X` becomes `### X`, `## X` becomes
+// `#### X`, etc. Capped at H6 so we stay within CommonMark.
+func demoteHeaders(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, ln := range lines {
+		j := 0
+		for j < len(ln) && ln[j] == '#' {
+			j++
+		}
+		if j == 0 || j >= len(ln) || ln[j] != ' ' {
+			continue
+		}
+		newLevel := j + 2
+		if newLevel > 6 {
+			newLevel = 6
+		}
+		lines[i] = strings.Repeat("#", newLevel) + ln[j:]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// Render writes the aggregated report to w. Output is stable for fixed
+// inputs (no time.Now, no os.Hostname) so it round-trips under tests.
+func Render(w io.Writer, h Header, scenarios []scenarioInput) error {
+	bw := &errWriter{w: w}
+	bw.printf("# Lantern benchmark — %s\n", h.Tag)
+	bw.printf("- Commit: `%s`\n", h.Commit)
+	bw.printf("- Runner: `%s`\n", h.Runner)
+	bw.printf("- Captured: `%s`\n\n", h.Captured)
+
+	bw.printf("## Summary\n\n")
+	bw.printf("| scenario | leak gate | rps | p99 (ms) | non-OK |\n")
+	bw.printf("| --- | --- | ---: | ---: | ---: |\n")
+	for _, s := range scenarios {
+		bw.printf("| `%s` | `%s` | %s | %s | %s |\n",
+			s.Name, s.Row.Verdict, s.Row.Rps, s.Row.P99ms, s.Row.NonOK)
+	}
+	bw.printf("\n")
+
+	for _, s := range scenarios {
+		bw.printf("## %s\n\n", s.Name)
+		if s.Detail == "" {
+			bw.printf("_no report.md produced for this scenario; see workflow logs._\n\n")
+			continue
+		}
+		bw.printf("%s\n", strings.TrimRight(s.Detail, "\n"))
+		bw.printf("\n")
+	}
+	return bw.err
+}
+
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) printf(format string, args ...any) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = fmt.Fprintf(e.w, format, args...)
+}
+
+// parseScenarioArgs accepts repeated `name=dir` arguments and returns
+// scenarios in the order given (CI cares about ordering so the table is
+// reproducible). An empty `dir` indicates the scenario did not produce
+// artifacts (CI passes `name=` for those).
+func parseScenarioArgs(args []string) ([]scenarioInput, error) {
+	out := make([]scenarioInput, 0, len(args))
+	seen := map[string]bool{}
+	for _, a := range args {
+		idx := strings.IndexByte(a, '=')
+		if idx <= 0 {
+			return nil, fmt.Errorf("scenario arg %q must be name=dir", a)
+		}
+		name, dir := a[:idx], a[idx+1:]
+		if seen[name] {
+			return nil, fmt.Errorf("duplicate scenario: %s", name)
+		}
+		seen[name] = true
+		out = append(out, loadScenario(name, dir))
+	}
+	return out, nil
+}
+
+func main() {
+	tag := flag.String("tag", "", "release tag, e.g. v1.2.3 (required)")
+	commit := flag.String("commit", "", "release commit SHA (required)")
+	runner := flag.String("runner", "", "runner platform, e.g. linux/amd64 (required)")
+	captured := flag.String("captured", "", "report capture timestamp (UTC, e.g. 20260604T120000Z) (required)")
+	out := flag.String("out", "", "output bench-report.md path (required)")
+	flag.Parse()
+
+	for k, v := range map[string]string{"tag": *tag, "commit": *commit, "runner": *runner, "captured": *captured, "out": *out} {
+		if v == "" {
+			fmt.Fprintf(os.Stderr, "release: -%s is required\n", k)
+			os.Exit(2)
+		}
+	}
+
+	scenarios, err := parseScenarioArgs(flag.Args())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "release:", err)
+		os.Exit(2)
+	}
+
+	// Stable ordering is determined by CLI arg order, but make sure the
+	// failed-scenario rows still group last when callers pass them mixed
+	// in — keeps the summary readable.
+	sort.SliceStable(scenarios, func(i, j int) bool {
+		ai := scenarios[i].Row.Verdict == "(failed)"
+		aj := scenarios[j].Row.Verdict == "(failed)"
+		if ai != aj {
+			return !ai
+		}
+		return false
+	})
+
+	f, err := os.Create(*out)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "release: create:", err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	h := Header{Tag: *tag, Commit: *commit, Runner: *runner, Captured: *captured}
+	if err := Render(f, h, scenarios); err != nil {
+		fmt.Fprintln(os.Stderr, "release: render:", err)
+		os.Exit(1)
+	}
+}

--- a/testbed/bench/release/main.go
+++ b/testbed/bench/release/main.go
@@ -287,11 +287,15 @@ func main() {
 		fmt.Fprintln(os.Stderr, "release: create:", err)
 		os.Exit(1)
 	}
-	defer f.Close()
 
 	h := Header{Tag: *tag, Commit: *commit, Runner: *runner, Captured: *captured}
 	if err := Render(f, h, scenarios); err != nil {
+		_ = f.Close()
 		fmt.Fprintln(os.Stderr, "release: render:", err)
+		os.Exit(1)
+	}
+	if err := f.Close(); err != nil {
+		fmt.Fprintln(os.Stderr, "release: close:", err)
 		os.Exit(1)
 	}
 }

--- a/testbed/bench/release/main_test.go
+++ b/testbed/bench/release/main_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDemoteHeaders(t *testing.T) {
+	in := "# Top\n## Sub\n#NotAHeading\ntext\n###### Already deep\n"
+	got := demoteHeaders(in)
+	want := "### Top\n#### Sub\n#NotAHeading\ntext\n###### Already deep\n"
+	if got != want {
+		t.Errorf("demoteHeaders mismatch\n got:%q\nwant:%q", got, want)
+	}
+}
+
+func TestLoadScenario_MissingDir(t *testing.T) {
+	s := loadScenario("smoke_write_heavy", "")
+	if s.Row.Verdict != "(failed)" {
+		t.Errorf("missing dir verdict: %q", s.Row.Verdict)
+	}
+	if s.Row.Rps != "—" || s.Row.P99ms != "—" || s.Row.NonOK != "—" {
+		t.Errorf("missing dir row: %+v", s.Row)
+	}
+}
+
+func TestLoadScenario_PopulatesRowAndDetail(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, "leak_gate.json"), map[string]any{"verdict": "pass"})
+	writeJSON(t, filepath.Join(dir, "ghz_steady_localhost_6380.json"), map[string]any{
+		"count":                  1000,
+		"rps":                    4995.5,
+		"statusCodeDistribution": map[string]int{"OK": 990, "DEADLINE_EXCEEDED": 10},
+		"latencyDistribution":    []map[string]any{{"percentage": 99, "latency": 1_230_000}},
+	})
+	if err := os.WriteFile(filepath.Join(dir, "report.md"), []byte("# Inner\n## Section\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := loadScenario("smoke_write_heavy", dir)
+	if s.Row.Verdict != "pass" {
+		t.Errorf("verdict: %q", s.Row.Verdict)
+	}
+	if s.Row.Rps != "4995.5" {
+		t.Errorf("rps: %q", s.Row.Rps)
+	}
+	if s.Row.P99ms != "1.23" {
+		t.Errorf("p99ms: %q", s.Row.P99ms)
+	}
+	if s.Row.NonOK != "10" {
+		t.Errorf("nonOK: %q", s.Row.NonOK)
+	}
+	if !strings.Contains(s.Detail, "### Inner") || !strings.Contains(s.Detail, "#### Section") {
+		t.Errorf("detail not demoted: %q", s.Detail)
+	}
+}
+
+func TestLoadScenario_AggregatesMultipleGhzFiles(t *testing.T) {
+	// mixed_rw forks two ghz invocations — verify aggregation: sum(rps),
+	// max(p99), sum(non-OK).
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, "leak_gate.json"), map[string]any{"verdict": "pass"})
+	writeJSON(t, filepath.Join(dir, "ghz_steady_put.json"), map[string]any{
+		"count":                  1000,
+		"rps":                    2000.0,
+		"statusCodeDistribution": map[string]int{"OK": 1000},
+		"latencyDistribution":    []map[string]any{{"percentage": 99, "latency": 5_000_000}},
+	})
+	writeJSON(t, filepath.Join(dir, "ghz_steady_get.json"), map[string]any{
+		"count":                  1000,
+		"rps":                    3000.0,
+		"statusCodeDistribution": map[string]int{"OK": 995, "UNAVAILABLE": 5},
+		"latencyDistribution":    []map[string]any{{"percentage": 99, "latency": 8_000_000}},
+	})
+
+	s := loadScenario("smoke_mixed_rw", dir)
+	if s.Row.Rps != "5000.0" {
+		t.Errorf("rps aggregate: %q", s.Row.Rps)
+	}
+	if s.Row.P99ms != "8.00" {
+		t.Errorf("p99 aggregate: %q", s.Row.P99ms)
+	}
+	if s.Row.NonOK != "5" {
+		t.Errorf("nonOK aggregate: %q", s.Row.NonOK)
+	}
+}
+
+func TestRender_FixedFormat(t *testing.T) {
+	scenarios := []scenarioInput{
+		{
+			Name:   "smoke_write_heavy",
+			Detail: "### Bench report — `smoke_write_heavy`\nbody\n",
+			Row:    summaryRow{Verdict: "pass", Rps: "5000.0", P99ms: "1.23", NonOK: "0"},
+		},
+		{
+			Name: "smoke_read_heavy",
+			Row:  summaryRow{Verdict: "(failed)", Rps: "—", P99ms: "—", NonOK: "—"},
+		},
+	}
+	var buf bytes.Buffer
+	if err := Render(&buf, Header{Tag: "v9.9.9", Commit: "abc1234", Runner: "linux/amd64", Captured: "20260101T000000Z"}, scenarios); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{
+		"# Lantern benchmark — v9.9.9",
+		"- Commit: `abc1234`",
+		"- Runner: `linux/amd64`",
+		"- Captured: `20260101T000000Z`",
+		"## Summary",
+		"| scenario | leak gate | rps | p99 (ms) | non-OK |",
+		"| `smoke_write_heavy` | `pass` | 5000.0 | 1.23 | 0 |",
+		"| `smoke_read_heavy` | `(failed)` | — | — | — |",
+		"## smoke_write_heavy",
+		"### Bench report — `smoke_write_heavy`",
+		"## smoke_read_heavy",
+		"_no report.md produced for this scenario; see workflow logs._",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestParseScenarioArgs(t *testing.T) {
+	tmp := t.TempDir()
+	writeJSON(t, filepath.Join(tmp, "leak_gate.json"), map[string]any{"verdict": "pass"})
+
+	got, err := parseScenarioArgs([]string{"a=" + tmp, "b="})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].Name != "a" || got[1].Name != "b" {
+		t.Errorf("got: %+v", got)
+	}
+	if got[0].Row.Verdict != "pass" {
+		t.Errorf("a verdict: %q", got[0].Row.Verdict)
+	}
+	if got[1].Row.Verdict != "(failed)" {
+		t.Errorf("b verdict: %q", got[1].Row.Verdict)
+	}
+
+	if _, err := parseScenarioArgs([]string{"no-equals"}); err == nil {
+		t.Errorf("expected error on missing =")
+	}
+	if _, err := parseScenarioArgs([]string{"x=" + tmp, "x="}); err == nil {
+		t.Errorf("expected error on duplicate name")
+	}
+}

--- a/testbed/bench/scenarios/smoke_mixed_rw.yaml
+++ b/testbed/bench/scenarios/smoke_mixed_rw.yaml
@@ -1,0 +1,20 @@
+# smoke variant of mixed_rw — shorter steady for CI release validation.
+# Same gates as the canonical scenario; numbers will be noisier so treat
+# verdicts as directional.
+name: smoke_mixed_rw
+phases:
+  warmup:   { duration: 15s, concurrency: 16, rps: 1000 }
+  steady:   { duration: 60s, concurrency: 96, rps: 6000 }
+  cooldown: 15s
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  calls:
+    - call: graph.v1.LanternService/PutVertex
+      data_template: |
+        {"vertex":{"key":"k-{{mod .RequestNumber 10000}}","int64":"{{.RequestNumber}}"}}
+    - call: graph.v1.LanternService/GetVertex
+      data_template: |
+        {"key":"k-{{mod .RequestNumber 10000}}"}
+leak_gate:
+  goroutine_max_delta: 25
+  heap_alloc_max_delta_mb: 32

--- a/testbed/bench/scenarios/smoke_read_heavy.yaml
+++ b/testbed/bench/scenarios/smoke_read_heavy.yaml
@@ -1,0 +1,16 @@
+# smoke variant of read_heavy — shorter steady for CI release validation.
+# Same gates as the canonical scenario; numbers will be noisier so treat
+# verdicts as directional.
+name: smoke_read_heavy
+phases:
+  warmup:   { duration: 15s, concurrency: 16, rps: 1000 }
+  steady:   { duration: 60s, concurrency: 128, rps: 10000 }
+  cooldown: 15s
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  call: graph.v1.LanternService/GetVertex
+  data_template: |
+    {"key":"k-{{mod .RequestNumber 10000}}"}
+leak_gate:
+  goroutine_max_delta: 20
+  heap_alloc_max_delta_mb: 24


### PR DESCRIPTION
Closes #256

## Summary

On every `vX.Y.Z` tag, the `Release` workflow now runs a smoke
benchmark sweep against a freshly-built `lantern:local` image and splices
a fixed-format Markdown report into the GitHub Release notes alongside the
existing container/CLI sections.

## What ships

| Piece | Role |
| --- | --- |
| `testbed/bench/scenarios/smoke_{read_heavy,mixed_rw}.yaml` | Short (~2 min wall) variants suitable for shared CI runners. |
| `testbed/bench/release-scenarios.txt` | Single source of truth for which scenarios the release runs. |
| `testbed/bench/release/` (+ tests) | Go aggregator that consumes each scenario's `leak_gate.json` + `ghz_steady_*.json` + `report.md` and emits one fixed-format report. |
| `testbed/bench/release.sh` | Shell driver — brings up Compose once, runs each scenario with `SKIP_UP=1 KEEP_UP=1`, invokes the aggregator. |
| `.github/workflows/docker-publish.yml` | New `bench` job (`continue-on-error`, `needs: verify`); `release` job downloads the artifact and includes it in the notes heredoc. |

## Fixed format

```
# Lantern benchmark — <tag>
- Commit: `<sha>`
- Runner: `<runner>`
- Captured: `<ts>`

## Summary
| scenario | leak gate | rps | p99 (ms) | non-OK |
| ... | ... | ... | ... | ... |

## <scenario_name>
<per-scenario report.md, H1→H3 demoted>
```

## Non-blocking by design

The bench job is `continue-on-error: true`. If a runner is noisy or the
harness hiccups, the release still ships — the bench section falls back to
a placeholder line. Per-scenario failures appear in the summary table as
`(failed)` rows.

## Local quality gate

```
gofmt -l . cli core pb sdks server tests   # empty
go test ./...                              # ok
(cd server && go vet ./... && go test ./...)  # ok
(cd core && go test ./...)                 # ok
(cd pb && go test ./...)                   # ok
(cd sdks/go && go test ./...)              # ok
```

## Verification path

Workflow path-only change → does not exercise the new release path on this
PR (only `v*` tag pushes do). End-to-end signal will land on the next
`vX.Y.Z` tag.