### PR TITLE
chore(release): bump core/pb/sdks-go pins for v0.7.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/anaregdesign/lantern
 go 1.26
 
 require (
-	github.com/anaregdesign/lantern/core v0.1.0
-	github.com/anaregdesign/lantern/pb v0.1.0
-	github.com/anaregdesign/lantern/sdks/go v0.7.0
+	github.com/anaregdesign/lantern/core v0.1.1
+	github.com/anaregdesign/lantern/pb v0.1.1
+	github.com/anaregdesign/lantern/sdks/go v0.7.1
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
Release prep for root v0.7.2.

Bumps require lines to match the freshly pushed submodule tags:
- core v0.1.0 → v0.1.1
- pb v0.1.0 → v0.1.1
- sdks/go v0.7.0 → v0.7.1

Per AGENTS.md "Cutting a release" step 4. Root v0.7.2 tag will be cut after this merges.