### PR TITLE
bench(release): enrich release sweep with full canonical scenarios

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,10 +245,14 @@ Tag order matters because each downstream module pins the upstream tag:
    to the freshly-tagged versions.
 5. Root `vX.Y.Z` — triggers `docker-publish.yml` (amd64 + arm64 buildx +
    cosign keyless). The same workflow also runs the release-time bench
-   sweep (`testbed/bench/release.sh` → smoke scenarios) and splices a
-   fixed-format report into the release notes. The bench job is
-   non-blocking — if it fails, the release still ships with a placeholder
-   bench section. See issue [#256](https://github.com/anaregdesign/lantern/issues/256).
+   sweep (`testbed/bench/release.sh` → full canonical scenarios listed in
+   `testbed/bench/release-scenarios.txt`, including all illuminate
+   variants, batch/scan/edge/TTL paths, and many_subscribers fan-out)
+   and splices a fixed-format report into the release notes. The bench
+   job is non-blocking — if it fails, the release still ships with a
+   placeholder bench section. See issues
+   [#256](https://github.com/anaregdesign/lantern/issues/256) and
+   [#262](https://github.com/anaregdesign/lantern/issues/262).
 
 The `server/` module is **never** tagged independently — it ships under the
 root tag. arm64 buildx under QEMU is slow; if a root tag already pushed the

--- a/testbed/bench/README.md
+++ b/testbed/bench/README.md
@@ -11,15 +11,18 @@ per-scenario leak gate, and renders a Markdown report.
 > performance or leak regressions. Its outputs (under `testbed/bench/out/`)
 > are git-ignored.
 >
-> **Release CI does run a smoke subset.** On every `vX.Y.Z` tag push, the
-> `Release` workflow runs `./testbed/bench/release.sh` — a driver that
-> sweeps the scenarios listed in `release-scenarios.txt` (currently the
-> `smoke_*` variants) and produces a fixed-format `bench-report.md` that
+> **Release CI runs the full canonical sweep.** On every `vX.Y.Z` tag
+> push, the `Release` workflow runs `./testbed/bench/release.sh` — a
+> driver that sweeps the scenarios listed in `release-scenarios.txt` (the
+> three `smoke_*` variants as a fast head-of-sweep signal, then the full
+> canonical scenarios across read/write/batch/scan/edge/TTL/illuminate
+> variants/fan-out) and produces a fixed-format `bench-report.md` that
 > is spliced into the GitHub Release notes. The bench job is
 > `continue-on-error`, so a noisy runner cannot block a release. See
-> issue [#256].
+> issues [#256], [#262].
 
 [#256]: https://github.com/anaregdesign/lantern/issues/256
+[#262]: https://github.com/anaregdesign/lantern/issues/262
 
 ## Prerequisites
 

--- a/testbed/bench/release-scenarios.txt
+++ b/testbed/bench/release-scenarios.txt
@@ -2,13 +2,41 @@
 # One scenario stem per line (matches testbed/bench/scenarios/<stem>.yaml).
 # Lines starting with `#` and blank lines are ignored.
 #
-# Keep this list short: the release CI job runs each one sequentially on a
-# shared ubuntu-latest runner. The smoke_* variants finish in ~2 min wall
-# each (15s warmup + 60s steady + 15s cooldown + compose up/down), which
-# keeps total release time under ~10 min and avoids saturating the runner.
+# This is the canonical release-time signal. The release bench job is
+# `continue-on-error` (non-blocking), so we run the full canonical
+# scenarios — not just the smoke variants — to surface regressions across
+# every major call path. The three `smoke_*` entries at the top of the
+# sweep remain so the rendered report is partially populated even if a
+# later full scenario times out or the runner stalls.
 #
-# Full *_heavy / mixed_rw scenarios remain the canonical signal for
-# local deep-dives; do not put them here.
+# Wall-time budget on a fresh ubuntu-latest runner (single shared
+# 3-replica compose, sequential execution): ~50 min total.
+#
+# If you add a scenario here, keep it self-contained: the release driver
+# reuses ONE compose stack across all entries, so a scenario that mutates
+# global server config or leaves a wedged stream behind will pollute every
+# subsequent scenario's leak gate. Prefer adding a new `*.yaml` over
+# reusing an existing one with side effects.
+
+# --- fast head-of-sweep signal (~2 min each) -------------------------------
 smoke_write_heavy
 smoke_read_heavy
 smoke_mixed_rw
+
+# --- full canonical sweep --------------------------------------------------
+# read / write paths
+write_heavy
+read_heavy
+mixed_rw
+batch_put_vertices
+scan_prefix
+addedge_contention
+ttl_churn
+
+# graph traversal — three variants isolate per-traversal cost vs RPS tail
+illuminate
+illuminate_heavy
+illuminate_hot
+
+# replication / pubsub fan-out
+many_subscribers

--- a/testbed/bench/scenarios/illuminate_heavy.yaml
+++ b/testbed/bench/scenarios/illuminate_heavy.yaml
@@ -1,0 +1,16 @@
+# illuminate_heavy — deeper graph traversal at the baseline RPS.
+# Goal: isolate per-traversal cost. Same RPS profile as `illuminate` so
+# tail latency deltas reflect step/k cost only, not throughput pressure.
+name: illuminate_heavy
+phases:
+  warmup:   { duration: 30s, concurrency: 8,  rps: 200 }
+  steady:   { duration: 3m,  concurrency: 32, rps: 1000 }
+  cooldown: 30s
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  call: graph.v1.LanternService/Illuminate
+  data_template: |
+    {"seed":"k-{{mod .RequestNumber 1000}}","step":3,"k":64}
+leak_gate:
+  goroutine_max_delta: 20
+  heap_alloc_max_delta_mb: 32

--- a/testbed/bench/scenarios/illuminate_hot.yaml
+++ b/testbed/bench/scenarios/illuminate_hot.yaml
@@ -1,0 +1,17 @@
+# illuminate_hot — baseline traversal shape at 2.5x steady RPS.
+# Goal: stress saturation / tail behaviour of the read-side serving loop;
+# pair with `illuminate` (1000 rps) and `illuminate_heavy` (deeper k/step)
+# to separate throughput-driven tail from per-traversal cost.
+name: illuminate_hot
+phases:
+  warmup:   { duration: 30s, concurrency: 16, rps: 500 }
+  steady:   { duration: 3m,  concurrency: 64, rps: 2500 }
+  cooldown: 30s
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  call: graph.v1.LanternService/Illuminate
+  data_template: |
+    {"seed":"k-{{mod .RequestNumber 1000}}","step":2,"k":32}
+leak_gate:
+  goroutine_max_delta: 20
+  heap_alloc_max_delta_mb: 32


### PR DESCRIPTION
Closes #262.

## Summary

Promotes the release-time bench sweep from smoke-only (3 scenarios, ~10 min) to the full canonical sweep (14 scenarios, ~50 min). The release bench job is already `continue-on-error`, so the longer run does not gate releases.

## Changes

- **New Illuminate variants** ([testbed/bench/scenarios/illuminate_heavy.yaml](testbed/bench/scenarios/illuminate_heavy.yaml), [testbed/bench/scenarios/illuminate_hot.yaml](testbed/bench/scenarios/illuminate_hot.yaml)):
  - `illuminate_heavy` — k=64, step=3, same 1000 rps profile → isolates per-traversal cost.
  - `illuminate_hot` — k=32, step=2, 2500 rps → isolates throughput-driven tail.
- **[testbed/bench/release-scenarios.txt](testbed/bench/release-scenarios.txt)** — full sweep ordered: 3 smoke (fast head-of-sweep signal) → 7 full canonical (write/read/mixed/batch/scan/edge/TTL) → 3 illuminate variants → many_subscribers fan-out.
- Policy notes in [testbed/bench/README.md](testbed/bench/README.md) and [AGENTS.md](AGENTS.md) updated to reflect 'release sweep is the canonical signal'.

## Local verification (v0.7.2, 3-replica compose)

| scenario | k | step | rps | p99 | leak gate |
|---|---:|---:|---:|---:|---|
| illuminate | 32 | 2 | 1000 | 0.92 ms | pass |
| illuminate_heavy | 64 | 3 | 1000 | 1.09 ms | pass |
| illuminate_hot | 32 | 2 | 2500 | 0.67 ms | pass |

The other promoted scenarios were already in the canonical local-run inventory; this PR simply opts them into the release sweep.

## Risk

Bench job is `continue-on-error` ([#256](https://github.com/anaregdesign/lantern/issues/256)). Worst case: a flaky scenario adds noise to the release notes; it cannot block the release.