### PR TITLE
fix(#260): decouple mutation-log fan-out from Append critical section

### DIFF
--- a/core/mutationlog/mutationlog.go
+++ b/core/mutationlog/mutationlog.go
@@ -91,6 +91,13 @@ type Options struct {
 	// WAL receives every appended entry before it fans out to subscribers.
 	// Nil defaults to [NopWAL].
 	WAL WAL
+	// OnDrop, when non-nil, is invoked synchronously from the dispatcher
+	// goroutine each time a live fan-out drops an entry to a subscriber.
+	// The cause argument is one of the DropCause* constants in this
+	// package. Implementations must not block (they run on the hot
+	// fan-out path) and must not call back into the [Log] — the
+	// dispatcher holds the subscriber mutex at the call site (#260).
+	OnDrop func(cause string)
 }
 
 const (
@@ -98,9 +105,33 @@ const (
 	defaultSubscriberBuffer = 512
 )
 
+// Drop-cause labels passed to [Options.OnDrop]. New causes may be added
+// in future revisions; consumers should treat unknown values as opaque
+// strings rather than enumerate (#260).
+const (
+	// DropCauseBufferFull is reported when the dispatcher's non-blocking
+	// send to a subscriber's outbound channel fails because the channel
+	// is full. The subscriber is marked gapped, its channel is closed,
+	// and it is unregistered from the log.
+	DropCauseBufferFull = "buffer_full"
+)
+
 // Log is an append-only, bounded, in-memory mutation log.
 //
 // The zero value is not ready for use; construct with [New].
+//
+// Locking model (#260): two mutexes split the hot path so [Log.Append]
+// no longer iterates subscribers under its own critical section.
+//
+//   - mu  protects the ring buffer, sequence counters, and the closed flag.
+//     Held briefly by Append (WAL write + store + seq update + handoff
+//     to the dispatcher) and by Subscribe (replay + sub registration).
+//   - subsMu protects the subscribers map and per-subscriber state.
+//     Held by the dispatcher goroutine during fan-out and by cancel.
+//
+// Lock order when both are taken: mu → subsMu. The dispatcher only takes
+// subsMu, and Append only takes mu (the channel send happens under mu to
+// preserve global Seq ordering), so the two paths cannot deadlock.
 type Log struct {
 	mu       sync.Mutex
 	capacity int
@@ -109,24 +140,39 @@ type Log struct {
 	// ring is a fixed-size circular buffer allocated once at construction.
 	// Valid entries occupy positions [head, head+size) modulo capacity.
 	// Append is O(1) at all fill levels; eviction is a single head bump.
-	ring        []Entry
-	head        int    // index of the oldest entry when size > 0
-	size        int    // number of valid entries; 0 <= size <= capacity
-	firstSeq    uint64 // seq of ring[head] when size > 0; meaningless otherwise
-	lastSeq     uint64 // seq of last appended entry; 0 means none appended yet
-	evicted     uint64 // total entries dropped by ring-buffer eviction
-	hasEntries  bool
-	closed      bool
+	ring       []Entry
+	head       int    // index of the oldest entry when size > 0
+	size       int    // number of valid entries; 0 <= size <= capacity
+	firstSeq   uint64 // seq of ring[head] when size > 0; meaningless otherwise
+	lastSeq    uint64 // seq of last appended entry; 0 means none appended yet
+	evicted    uint64 // total entries dropped by ring-buffer eviction
+	hasEntries bool
+	closed     bool
+
+	// Dispatcher pipeline (#260). Append hands entries off to a single
+	// background goroutine that performs the per-subscriber fan-out, so
+	// writer latency is independent of subscriber count.
+	dispatch       chan Entry
+	dispatcherDone chan struct{}
+	onDrop         func(cause string)
+
+	subsMu      sync.Mutex
 	subscribers map[*subscription]struct{}
 }
 
 // subscription is the live state for one subscriber.
 type subscription struct {
-	ch     chan Entry
-	gapped bool // set when a fan-out drop turned into a gap
+	ch chan Entry
+	// startSeq is the first Seq the dispatcher is allowed to deliver to
+	// this subscriber. Entries with Seq < startSeq were already loaded
+	// into ch as part of the replay window during Subscribe, so the
+	// dispatcher must skip them to avoid duplicate delivery.
+	startSeq uint64
+	gapped   bool // set when a fan-out drop turned into a gap
 }
 
-// New constructs a [Log] with the given options.
+// New constructs a [Log] with the given options. It also starts a
+// background dispatcher goroutine; call [Log.Close] to stop it.
 func New(opts Options) *Log {
 	capacity := opts.Capacity
 	if capacity <= 0 {
@@ -140,13 +186,22 @@ func New(opts Options) *Log {
 	if wal == nil {
 		wal = NopWAL{}
 	}
-	return &Log{
+	l := &Log{
 		capacity:    capacity,
 		subBuf:      subBuf,
 		wal:         wal,
 		ring:        make([]Entry, capacity),
 		subscribers: make(map[*subscription]struct{}),
+		// Inbox sized to SubscriberBuffer mirrors the headroom budget
+		// documented on Options.SubscriberBuffer: a dispatcher stall of
+		// that many entries is tolerated before Append blocks waiting
+		// for the dispatcher to drain.
+		dispatch:       make(chan Entry, subBuf),
+		dispatcherDone: make(chan struct{}),
+		onDrop:         opts.OnDrop,
 	}
+	go l.dispatcher()
+	return l
 }
 
 // FirstSeq returns the lowest Seq still resident in the ring buffer. It
@@ -195,11 +250,15 @@ func (l *Log) Evicted() uint64 {
 }
 
 // Append assigns the next sequence number to op, persists the entry through
-// the WAL hook, stores it in the ring buffer, and fans it out to every live
-// subscriber. The returned [Entry] carries the assigned Seq.
+// the WAL hook, stores it in the ring buffer, and hands it off to the
+// dispatcher goroutine which performs per-subscriber fan-out. The
+// returned [Entry] carries the assigned Seq.
 //
 // Append is safe for concurrent use; calls are serialised so Seq strictly
-// increases by one for each successful return.
+// increases by one for each successful return. The hand-off to the
+// dispatcher happens under the log mutex so the dispatcher observes
+// entries in strict Seq order (#260); under sustained overload Append
+// will block briefly waiting for the dispatcher to drain its inbox.
 func (l *Log) Append(op MutationOp, ts hlc.Timestamp) (Entry, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -214,7 +273,13 @@ func (l *Log) Append(op MutationOp, ts hlc.Timestamp) (Entry, error) {
 	l.storeLocked(entry)
 	l.lastSeq = seq
 	l.hasEntries = true
-	l.fanoutLocked(entry)
+	// Hand-off to dispatcher. The send is under l.mu so concurrent
+	// Append calls cannot reorder entries on the inbox channel; the
+	// dispatcher consumes single-threaded so subscribers observe Seq
+	// in strictly increasing order. If the inbox is full Append blocks
+	// here — this is the writer-side back-pressure that protects the
+	// dispatcher from runaway producers.
+	l.dispatch <- entry
 	return entry, nil
 }
 
@@ -241,23 +306,61 @@ func (l *Log) storeLocked(entry Entry) {
 	l.evicted++
 }
 
-// fanoutLocked delivers entry to every subscriber. A subscriber that cannot
-// receive without blocking has its channel marked gapped and closed on the
-// next replay attempt. Live delivery uses a non-blocking send to preserve
-// the back-pressure semantics promised by SubscriberBuffer.
-func (l *Log) fanoutLocked(entry Entry) {
+// dispatcher consumes entries handed off by [Log.Append] and fans each
+// one out to every live subscriber. It runs on its own goroutine started
+// by [New] and exits when [Log.Close] closes the inbox channel; the
+// exit path closes any subscribers still registered so callers blocked
+// in <-ch observe channel closure (#260).
+func (l *Log) dispatcher() {
+	defer close(l.dispatcherDone)
+	for entry := range l.dispatch {
+		l.fanout(entry)
+	}
+	// Inbox closed by Close. Drain any subscribers that haven't been
+	// cancelled. Close holds l.mu before closing the inbox so no Append
+	// can race with us here.
+	l.subsMu.Lock()
+	defer l.subsMu.Unlock()
+	for sub := range l.subscribers {
+		close(sub.ch)
+		delete(l.subscribers, sub)
+	}
+}
+
+// fanout delivers entry to every live subscriber registered at the time of
+// the call. A subscriber whose outbound channel is full is marked gapped,
+// has its channel closed, and is unregistered; the optional
+// [Options.OnDrop] hook is then invoked with [DropCauseBufferFull].
+//
+// Live delivery uses a non-blocking send to preserve the back-pressure
+// semantics promised by [Options.SubscriberBuffer]: a slow subscriber
+// loses its subscription rather than stalling fan-out for everyone else.
+//
+// fanout runs exclusively on the dispatcher goroutine, so the only
+// other goroutines that contend on subsMu are Subscribe (briefly, to
+// register) and the per-subscription cancel func.
+func (l *Log) fanout(entry Entry) {
+	l.subsMu.Lock()
+	defer l.subsMu.Unlock()
 	for sub := range l.subscribers {
 		if sub.gapped {
+			continue
+		}
+		// Entries below startSeq were already delivered as part of the
+		// replay window during Subscribe; skip them to avoid duplicate
+		// delivery (#260).
+		if entry.Seq < sub.startSeq {
 			continue
 		}
 		select {
 		case sub.ch <- entry:
 		default:
-			// Subscriber is too slow: mark gapped and close to signal a
-			// reconnect-and-snapshot to the caller.
 			sub.gapped = true
 			close(sub.ch)
 			delete(l.subscribers, sub)
+			if l.onDrop != nil {
+				l.onDrop(DropCauseBufferFull)
+			}
 		}
 	}
 }
@@ -286,7 +389,14 @@ func (l *Log) Subscribe(fromSeq uint64) (<-chan Entry, func() error, error) {
 	if l.hasEntries && fromSeq < l.firstSeq {
 		return nil, nil, ErrGapped
 	}
-	sub := &subscription{ch: make(chan Entry, l.subBuf)}
+	// startSeq pins the boundary between replay (loaded synchronously
+	// into sub.ch below) and live delivery (handed in by the
+	// dispatcher). It is captured under l.mu so it cannot tear against
+	// concurrent Append calls (#260).
+	sub := &subscription{
+		ch:       make(chan Entry, l.subBuf),
+		startSeq: l.lastSeq + 1,
+	}
 	// Replay any in-buffer entries with Seq >= fromSeq. Entries are stored
 	// in the circular ring at positions [head, head+size); iterate that
 	// active window rather than ranging over the backing slice (which
@@ -306,13 +416,20 @@ func (l *Log) Subscribe(fromSeq uint64) (<-chan Entry, func() error, error) {
 			return nil, nil, ErrGapped
 		}
 	}
+	// Register the subscriber under subsMu (lock order: mu → subsMu).
+	// Holding mu here ensures the dispatcher cannot deliver an entry
+	// with Seq >= startSeq before the subscriber is visible, because the
+	// dispatcher needs subsMu and Append needs mu to enqueue further
+	// entries.
+	l.subsMu.Lock()
 	l.subscribers[sub] = struct{}{}
+	l.subsMu.Unlock()
 
 	var cancelOnce sync.Once
 	cancel := func() error {
 		cancelOnce.Do(func() {
-			l.mu.Lock()
-			defer l.mu.Unlock()
+			l.subsMu.Lock()
+			defer l.subsMu.Unlock()
 			if _, ok := l.subscribers[sub]; ok {
 				delete(l.subscribers, sub)
 				close(sub.ch)
@@ -323,18 +440,23 @@ func (l *Log) Subscribe(fromSeq uint64) (<-chan Entry, func() error, error) {
 	return sub.ch, cancel, nil
 }
 
-// Close stops accepting appends and closes every subscriber channel.
-// Calling Close more than once returns nil.
+// Close stops accepting appends, signals the dispatcher to drain, and
+// waits for it to exit. The dispatcher closes every still-live
+// subscriber channel on its way out. Calling Close more than once
+// returns nil.
 func (l *Log) Close() error {
 	l.mu.Lock()
-	defer l.mu.Unlock()
 	if l.closed {
+		l.mu.Unlock()
 		return nil
 	}
 	l.closed = true
-	for sub := range l.subscribers {
-		close(sub.ch)
-		delete(l.subscribers, sub)
-	}
+	// Close the inbox while holding l.mu: this guarantees no concurrent
+	// Append can be in the middle of `l.dispatch <- entry` (Append
+	// holds l.mu across the send), so we cannot panic on send to a
+	// closed channel.
+	close(l.dispatch)
+	l.mu.Unlock()
+	<-l.dispatcherDone
 	return nil
 }

--- a/core/mutationlog/mutationlog_test.go
+++ b/core/mutationlog/mutationlog_test.go
@@ -317,3 +317,100 @@ func TestCancelIsIdempotent(t *testing.T) {
 		t.Fatalf("second cancel = %v, want nil", err)
 	}
 }
+
+// TestOnDropFiresForBufferFullSubscriber asserts the #260 drop hook:
+// when the dispatcher's non-blocking send to a slow subscriber fails
+// because that subscriber's channel is full, OnDrop is invoked exactly
+// once with DropCauseBufferFull and the subscriber is unregistered.
+func TestOnDropFiresForBufferFullSubscriber(t *testing.T) {
+	var (
+		mu     sync.Mutex
+		causes []string
+	)
+	l := New(Options{
+		Capacity:         64,
+		SubscriberBuffer: 2,
+		OnDrop: func(cause string) {
+			mu.Lock()
+			defer mu.Unlock()
+			causes = append(causes, cause)
+		},
+	})
+	defer l.Close()
+
+	_, cancel, err := l.Subscribe(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancel()
+
+	// Append more entries than SubscriberBuffer without draining. The
+	// dispatcher's non-blocking send will eventually fail and OnDrop
+	// must fire with DropCauseBufferFull.
+	for i := 1; i <= 20; i++ {
+		if _, err := l.Append(i, ts(int64(i))); err != nil {
+			t.Fatalf("append #%d: %v", i, err)
+		}
+	}
+
+	// The dispatcher is asynchronous; poll briefly for the hook.
+	deadline := time.After(2 * time.Second)
+	for {
+		mu.Lock()
+		n := len(causes)
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("OnDrop never fired for slow subscriber")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(causes) != 1 {
+		t.Fatalf("OnDrop fired %d times, want exactly 1: %v", len(causes), causes)
+	}
+	if causes[0] != DropCauseBufferFull {
+		t.Fatalf("cause = %q, want %q", causes[0], DropCauseBufferFull)
+	}
+}
+
+// TestAppendDoesNotIterateSubscribersUnderMu is a behavioural smoke
+// test for the #260 decoupling: Append must not be blocked by a slow
+// subscriber's outbound channel because fan-out runs on the dispatcher
+// goroutine, not under l.mu. With SubscriberBuffer large enough that
+// the dispatcher inbox never fills, Append latency must remain
+// independent of subscriber count.
+func TestAppendDoesNotBlockOnSlowSubscriber(t *testing.T) {
+	l := New(Options{Capacity: 1024, SubscriberBuffer: 1024})
+	defer l.Close()
+
+	// Register a subscriber that never drains. The dispatcher will fill
+	// its channel up to SubscriberBuffer, then drop it. Either way,
+	// Append must return promptly for all 100 calls.
+	_, cancel, err := l.Subscribe(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 1; i <= 100; i++ {
+			if _, err := l.Append(i, ts(int64(i))); err != nil {
+				t.Errorf("append #%d: %v", i, err)
+				return
+			}
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Append blocked despite dispatcher fan-out being decoupled")
+	}
+}

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/anaregdesign/lantern/core/concurrent/pubsub"
+	"github.com/anaregdesign/lantern/core/mutationlog"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -76,6 +77,14 @@ type DomainMetrics struct {
 	validationRejected     *prometheus.CounterVec
 	rateLimitRejected      prometheus.Counter
 	tombstoneClampRejected prometheus.Counter
+
+	// Mutation-log subscriber drop counter (#260). Incremented when the
+	// mutationlog dispatcher's non-blocking send to a subscriber's
+	// outbound channel fails and the subscriber is unregistered. The
+	// existing lantern_subscription_dropped_total{policy} metric covers
+	// the (currently dormant) core/concurrent/pubsub package and is
+	// intentionally distinct from this one.
+	mutationLogSubscriberDropped *prometheus.CounterVec
 
 	// Hot-path RPC observability (#220). Wired by the service layer via
 	// the HotPathMetrics interface in server/service. Histograms are
@@ -330,6 +339,10 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 			Name: "lantern_tombstone_clamp_rejected_total",
 			Help: "Total ApplyMutation Put/Add operations dropped on the tombstone-aware HLC path because the incoming mutation lost the LWW comparison against an existing tombstone or a strictly-newer live HLC. A sustained rate indicates causally-late replication frames or clock skew larger than LANTERN_TOMBSTONE_TTL.",
 		}),
+		mutationLogSubscriberDropped: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "lantern_mutationlog_subscriber_dropped_total",
+			Help: "Total mutation-log subscribers terminated by the dispatcher because their outbound channel could not absorb a live entry (#260). cause=\"buffer_full\" is the only label today; new causes may be added.",
+		}, []string{"cause"}),
 		sampleInterval: opts.SampleInterval,
 	}
 
@@ -343,7 +356,8 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 		m.peerConnected, m.replicationApplyTotal, m.snapshotReplayedTotal,
 		m.snapshotVertices, m.snapshotEdges, m.snapshotDuration,
 		m.mutationLogFillRatio, m.mutationLogEvicted, m.originStatesCount,
-		m.validationRejected, m.rateLimitRejected, m.tombstoneClampRejected)
+		m.validationRejected, m.rateLimitRejected, m.tombstoneClampRejected,
+		m.mutationLogSubscriberDropped)
 
 	// Pre-create label rows so empty counters scrape as 0.
 	for _, r := range []string{"gapped", "send_failed"} {
@@ -396,6 +410,10 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 		m.validationRejected.WithLabelValues(r)
 	}
 	m.validationRejected.WithLabelValues("unknown")
+
+	// Pre-warm the single known mutation-log drop cause so dashboards
+	// render the series at 0 from process start (#260).
+	m.mutationLogSubscriberDropped.WithLabelValues(mutationlog.DropCauseBufferFull)
 
 	version, commit := opts.Version, opts.Commit
 	if version == "" || commit == "" {
@@ -616,6 +634,19 @@ func (m *DomainMetrics) OnRateLimitRejected() {
 // against a live tombstone or against a strictly-newer existing entry).
 func (m *DomainMetrics) OnTombstoneClampRejected() {
 	m.tombstoneClampRejected.Inc()
+}
+
+// OnMutationLogSubscriberDropped increments
+// lantern_mutationlog_subscriber_dropped_total{cause} when the
+// mutationlog dispatcher's non-blocking send to a subscriber's outbound
+// channel fails and the subscriber is unregistered (#260). The "cause"
+// label is sanitised against the known set
+// (currently just mutationlog.DropCauseBufferFull); unknown values fall
+// back to "unknown" so a future cause added without a metrics update
+// still shows up.
+func (m *DomainMetrics) OnMutationLogSubscriberDropped(cause string) {
+	c := sanitizeLabel(cause, []string{mutationlog.DropCauseBufferFull}, "unknown")
+	m.mutationLogSubscriberDropped.WithLabelValues(c).Inc()
 }
 
 // --- Hot-path RPC observability (#220) ---

--- a/server/provider/replication.go
+++ b/server/provider/replication.go
@@ -104,6 +104,10 @@ func NewMutationLog(mlc MutationLogConfig, m *domainmetrics.DomainMetrics) *muta
 	log := mutationlog.New(mutationlog.Options{
 		Capacity:         mlc.Capacity,
 		SubscriberBuffer: mlc.SubscriberBuffer,
+		// Forward dispatcher fan-out drops to the Prometheus counter so
+		// operators see slow-subscriber pressure (#260). The callback
+		// pattern keeps core/mutationlog free of prometheus deps.
+		OnDrop: m.OnMutationLogSubscriberDropped,
 	})
 	m.SetMutationLogCapacity(mlc.Capacity)
 	return log


### PR DESCRIPTION
Closes #260

## What

Refactor `core/mutationlog` so `Append` no longer iterates subscribers under its own mutex. A single dispatcher goroutine, started by `New()` and stopped by `Close()`, consumes a buffered `dispatch` channel that `Append` hands entries off to. Per-subscriber fan-out happens on the dispatcher under a separate `subsMu`, so writer latency is independent of subscriber count.

## Locking model

- `mu` — ring buffer, sequence counters, `closed` flag.
- `subsMu` — subscribers map, per-subscriber state.
- Lock order **mu → subsMu** (only `Subscribe` takes both).
- The hand-off send `l.dispatch <- entry` happens under `l.mu` so concurrent `Append` calls cannot reorder entries on the inbox; the dispatcher consumes single-threaded, so per-subscriber Seq remains strictly increasing.
- `Close` closes the inbox under `l.mu`, then waits on `dispatcherDone`; the dispatcher drains remaining subscribers as it exits, so there is no double-close race with in-flight fan-out.

## Replay/live boundary

Each `subscription` carries a `startSeq` captured under `l.mu` at registration time. The dispatcher skips entries with `entry.Seq < sub.startSeq` so the entries pre-loaded into the subscriber channel during replay are not re-delivered.

## Observability

New `Options.OnDrop func(cause string)` callback fires when the dispatcher's non-blocking send to a slow subscriber fails (the subscriber is marked gapped, channel closed, unregistered — same semantics as before, just async now). The server wires it to a new Prometheus counter:

```
lantern_mutationlog_subscriber_dropped_total{cause="buffer_full"}
```

Pre-warmed with `mutationlog.DropCauseBufferFull`. The existing `lantern_subscription_dropped_total{policy}` belongs to the dormant `core/concurrent/pubsub` package and is intentionally left untouched.

## Tests

- `TestOnDropFiresForBufferFullSubscriber` — registers `OnDrop`, overfills a slow subscriber, asserts the callback fires exactly once with `buffer_full`.
- `TestAppendDoesNotBlockOnSlowSubscriber` — verifies 100 `Append` calls complete promptly despite an undrained subscriber.
- All 12 pre-existing `mutationlog` tests still pass (including `TestSlowSubscriberIsDroppedNotBlocking`).
- Full server, integration, and SDK suites green locally.

## Files touched

- `core/mutationlog/mutationlog.go` — dispatcher refactor.
- `core/mutationlog/mutationlog_test.go` — two new behavioural tests.
- `server/metrics/metrics.go` — counter + pre-warm + `OnMutationLogSubscriberDropped` hook.
- `server/provider/replication.go` — pass `OnDrop` into `mutationlog.Options`.
