### PR TITLE
sdks/python: rename PyPI distribution to lantern-sdk, bump to v0.1.1

### DIFF
--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -61,7 +61,7 @@ jobs:
       id-token: write   # for PyPI trusted publishing
     environment:
       name: pypi
-      url: https://pypi.org/p/lantern-client
+      url: https://pypi.org/p/lantern-sdk
     steps:
       - uses: actions/checkout@v4
       - name: Install uv

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,4 +1,4 @@
-# lantern-client
+# lantern-sdk (Python)
 
 Python client SDK for [Lantern](https://github.com/anaregdesign/lantern), an
 in-memory graph key-vertex-store served over gRPC. Mirrors the [Go
@@ -13,10 +13,13 @@ gRPC health check.
 
 ## Install
 
+Distributed on PyPI as [`lantern-sdk`](https://pypi.org/project/lantern-sdk/);
+the Python import package name remains `lantern_client`.
+
 ```sh
-pip install lantern-client
+pip install lantern-sdk
 # or with uv
-uv add lantern-client
+uv add lantern-sdk
 ```
 
 ## Quick start

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "lantern-client"
-version = "0.1.0"
+name = "lantern-sdk"
+version = "0.1.1"
 description = "Python client SDK for Lantern, an in-memory graph key-vertex-store served over gRPC."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -191,8 +191,8 @@ wheels = [
 ]
 
 [[package]]
-name = "lantern-client"
-version = "0.1.0"
+name = "lantern-sdk"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
## What

Renames the Python SDK's PyPI distribution from `lantern-client` to `lantern-sdk` and bumps the version to v0.1.1.

## Why

`lantern-client` on PyPI is already owned by [lanterndata/lantern-python](https://pypi.org/project/lantern-client/) (current 0.0.6). The first publish attempt for v0.1.0 (run [26962246268](https://github.com/anaregdesign/lantern/actions/runs/26962246268)) failed at the trusted-publisher step, but even after fixing that the registration would have collided. `lantern-sdk` is verified free on PyPI as of 2026-06-05.

## Scope

- `sdks/python/pyproject.toml` — `name` + `version`
- `.github/workflows/python-sdk.yml` — environment URL
- `sdks/python/README.md` — H1 + install snippets + one-line note about the import package name
- `sdks/python/uv.lock` — regenerated

**Explicitly not changing:** the Python import package name stays `lantern_client` (`from lantern_client import ...`). PyPI distribution names and Python import names are independent; renaming `src/lantern_client/` would touch every import site in tests, examples, and docstrings for zero user-visible benefit.

## Verification

- `uv sync --dev` — clean
- `uv build` — `lantern_sdk-0.1.1.{whl,tar.gz}`
- `uv run pytest -q` — 38 passed
- `uv run ruff check . && uv run ruff format --check .` — clean
- `gofmt -l . cli core pb sdks server tests` — empty (mandated gate)

## User-owned manual step before tagging

Register a 'pending publisher' on https://pypi.org/manage/account/publishing/ matching:

- PyPI project: `lantern-sdk`
- Owner: `anaregdesign`
- Repository: `lantern`
- Workflow filename: `python-sdk.yml`
- Environment name: `pypi`

Then after merge: `git tag sdks/python/v0.1.1 && git push origin sdks/python/v0.1.1`.

Closes #275
Refs #269