### PR TITLE
sdks/node: rename npm package to lantern-sdk, bump to v0.1.1

### DIFF
--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -1,4 +1,4 @@
-# lantern-client (Node.js / TypeScript)
+# lantern-sdk (Node.js / TypeScript)
 
 Official Node.js / TypeScript client for [Lantern](https://github.com/anaregdesign/lantern) —
 an in-memory graph KVS with prefix scan, neighborhood traversal (`Illuminate`), and TTL.
@@ -10,17 +10,17 @@ an in-memory graph KVS with prefix scan, neighborhood traversal (`Illuminate`), 
 ## Install
 
 ```bash
-npm install lantern-client
+npm install lantern-sdk
 # or
-bun add lantern-client
+bun add lantern-sdk
 # or
-pnpm add lantern-client
+pnpm add lantern-sdk
 ```
 
 ## Quick Start
 
 ```ts
-import { Lantern, Optimization } from "lantern-client";
+import { Lantern, Optimization } from "lantern-sdk";
 
 const client = Lantern.connect("localhost:6380");
 try {
@@ -70,7 +70,7 @@ oneof field:
 | `Float32(n)`                           | `float32`                          |
 | `Duration({seconds, nanos})`           | `duration`                         |
 
-Use the typed wrappers from `lantern-client` when you need a narrower numeric
+Use the typed wrappers from `lantern-sdk` when you need a narrower numeric
 type than `number` / `bigint` would infer.
 
 ## Batch APIs
@@ -82,7 +82,7 @@ chunk failure the call throws `BatchError`, which carries `.written`
 error — and the underlying `cause`.
 
 ```ts
-import { BatchError } from "lantern-client";
+import { BatchError } from "lantern-sdk";
 
 try {
   await client.putEdges(edges, { chunkSize: 500 });

--- a/sdks/node/bun.lock
+++ b/sdks/node/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "lantern-client",
+      "name": "lantern-sdk",
       "dependencies": {
         "@grpc/grpc-js": "^1.12.0",
         "long": "^5.2.3",

--- a/sdks/node/example/main.ts
+++ b/sdks/node/example/main.ts
@@ -1,4 +1,4 @@
-import { Lantern, Optimization } from "lantern-client";
+import { Lantern, Optimization } from "lantern-sdk";
 
 async function main(): Promise<void> {
   const client = Lantern.connect("localhost:6380");

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "lantern-client",
-  "version": "0.1.0",
+  "name": "lantern-sdk",
+  "version": "0.1.1",
   "description": "Official TypeScript client SDK for Lantern — an in-memory graph KVS over gRPC.",
   "license": "Apache-2.0",
   "type": "module",

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * `lantern-client` — Bun-managed TypeScript SDK for the Lantern graph KVS.
+ * `lantern-sdk` — Bun-managed TypeScript SDK for the Lantern graph KVS.
  *
  * @packageDocumentation
  */


### PR DESCRIPTION
## What

Renames the Node SDK's npm package from `lantern-client` to `lantern-sdk` and bumps the version to v0.1.1.

## Why

The first publish attempt for v0.1.0 (run [26963329956](https://github.com/anaregdesign/lantern/actions/runs/26963329956)) failed with `ENEEDAUTH` — the `NPM_TOKEN` repo secret is not set. While the release plumbing is open anyway, renaming to `lantern-sdk` for symmetry with the parallel Python SDK rename (#275 / PR #277). Both names verified free on npm as of 2026-06-05.

Unlike Python (where distribution name and import name are independent), Node uses the package name as the import specifier, so every `import { ... } from "lantern-client"` had to be updated alongside `package.json`.

## Scope

- `sdks/node/package.json` — `name` + `version`
- `sdks/node/bun.lock` — regenerated from scratch (`rm bun.lock && bun install`)
- `sdks/node/README.md` — H1, install snippets (npm/bun/pnpm), all import snippets, typed-wrappers paragraph
- `sdks/node/example/main.ts` — import path
- `sdks/node/src/index.ts` — file header comment

## Verification

- `bun install` — clean
- `bun run codegen` — no diff
- `bun run lint && bun run format:check && bun run typecheck` — clean
- `bun test` — 36 pass, 0 fail
- `bun run build` — ESM + CJS + DTS all succeed
- `gofmt -l . cli core pb sdks server tests` — empty (mandated gate)

## User-owned manual steps before tagging

1. Create an npmjs.com account (if needed) + enable 2FA.
2. On npmjs.com: *Access Tokens → Generate New Token → Granular Access Token*. Read+write; *all packages* for the first publish, scope down to `lantern-sdk` afterwards.
3. `gh secret set NPM_TOKEN` — paste the token.
4. After merge: `git tag sdks/node/v0.1.1 && git push origin sdks/node/v0.1.1`.

Optional next step after v0.1.1 is live: switch to npm trusted publishing (OIDC) so the `NPM_TOKEN` secret can be retired.

Closes #276
Refs #269