### PR TITLE
ci(node-sdk): grant id-token: write for npm provenance

### DIFF
--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -70,6 +70,9 @@ jobs:
     needs: test
     if: startsWith(github.ref, 'refs/tags/sdks/node/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # for npm provenance via Sigstore
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node


### PR DESCRIPTION
## What

Adds a minimal `permissions` block to the `publish` job in `.github/workflows/node-sdk.yml`:

```yaml
permissions:
  contents: read
  id-token: write  # for npm provenance via Sigstore
```

## Why

First publish attempt for `sdks/node/v0.1.1` ([run 26991053063](https://github.com/anaregdesign/lantern/actions/runs/26991053063)) failed with:

```
npm error code EUSAGE
npm error Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
```

The publish step runs `npm publish --access public --provenance`, which requests a Sigstore certificate via the GitHub OIDC token. That requires `id-token: write` on the job.

`python-sdk.yml` and `docker-publish.yml` already declare this permission; `node-sdk.yml` was the outlier.

## Scope

CI-only change, single file, three added lines. No code, proto, dependency, or SDK changes.

## Follow-up

After merge, re-tag `sdks/node/v0.1.1` (the tag exists on origin but no artifact was published to npm yet) to trigger a clean release run.