### PR TITLE
ci(node-sdk): switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -70,16 +70,21 @@ jobs:
     needs: test
     if: startsWith(github.ref, 'refs/tags/sdks/node/v')
     runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/lantern-sdk
     permissions:
       contents: read
-      id-token: write  # for npm provenance via Sigstore
+      id-token: write  # for npm Trusted Publishing (OIDC) + Sigstore provenance
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+      - name: Upgrade npm (Trusted Publishing requires >= 11.5.1)
+        run: npm install -g npm@latest
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -95,7 +100,9 @@ jobs:
         run: bun run codegen
       - name: Build
         run: bun run build
-      - name: Publish to npm
-        run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm (Trusted Publishing / OIDC)
+        run: npm publish --access public
+        # No NODE_AUTH_TOKEN: npm CLI exchanges the GitHub OIDC token for a
+        # short-lived publish token via the trusted-publisher binding on
+        # npmjs.com. Provenance is attached automatically when publishing
+        # via OIDC.


### PR DESCRIPTION
Closes #280.

## What

Replaces the long-lived `NPM_TOKEN` + `--provenance` flow with **npm Trusted Publishing**. The npm CLI exchanges the GitHub OIDC token for a short-lived publish token via a trusted-publisher binding configured on npmjs.com.

## Why

The current flow is blocked by npm's `Authorization and writes` 2FA mode — even with a valid Granular Access Token, `npm publish` from CI fails with `EOTP` because there is no interactive OTP available. Run [26991182276](https://github.com/anaregdesign/lantern/actions/runs/26991182276) for tag `sdks/node/v0.1.1` is the live failure.

Trusted Publishing removes the token entirely, removes the 2FA dependency, and is the npm-recommended path for CI/CD.

## Workflow changes (publish job only)

- Add `environment: { name: npm, url: ... }` so the trusted-publisher binding can scope to (repo, workflow, environment).
- Bump Node to 22 (matches the high end of the test matrix; npm 11.x ships with Node 22+).
- Add an explicit `npm install -g npm@latest` step — Trusted Publishing requires npm >= 11.5.1, and the bundled npm in setup-node can lag.
- Drop `NODE_AUTH_TOKEN` and `--provenance` (OIDC publish attaches provenance automatically).

## Operator-side prerequisites (one-time, manual — listed in #280)

1. Create a `npm` Environment on the GitHub repo.
2. Register Trusted Publisher on https://www.npmjs.com/package/lantern-sdk/access (Publisher=GitHub Actions, Org=`anaregdesign`, Repo=`lantern`, Workflow=`node-sdk.yml`, Environment=`npm`). This requires the package to exist on npm — a one-time manual `npm publish` of 0.1.1 from a workstation creates it.
3. Revoke the existing `NPM_TOKEN` repo secret.

## Verification

- Test matrix unaffected (publish job runs only on tag push).
- After the operator steps above, retag (or push a new patch tag) to verify end-to-end OIDC publish.

## Out of scope

- Bumping the SDK version (still 0.1.1).
- Test job changes.