### PR TITLE
sdks/node: bump to v0.1.2 to verify OIDC publish

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lantern-sdk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Official TypeScript client SDK for Lantern — an in-memory graph KVS over gRPC.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
First end-to-end exercise of the npm Trusted Publishing pipeline introduced in #281.

## Why

0.1.1 was published manually from a workstation because the npmjs.com trusted-publisher binding can only be registered on an **existing** package. This 0.1.2 bump is a no-op release whose sole purpose is to confirm the CI-side publish works without `NPM_TOKEN` (OIDC + Sigstore provenance via the new `Publish to npm` job).

## Changes

- `sdks/node/package.json`: `version` 0.1.1 → 0.1.2.

No code, dep, or workflow changes.

## Verification

After merge, tag `sdks/node/v0.1.2` and observe the publish job:
- No `NODE_AUTH_TOKEN` env var.
- `npm publish --access public` succeeds via OIDC.
- npmjs.com shows 0.1.2 with provenance.

Refs #280, #281.