### PR TITLE
feat(mcp): container image + tag-gated ghcr publish (#286)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,11 +42,13 @@ jobs:
       - name: Vet
         run: |
           go vet ./...
+          (cd mcp && go vet ./...)
           (cd sdks/go && go vet ./...)
 
       - name: Build
         run: |
           go build -v ./...
+          (cd mcp && go build -v ./...)
           (cd sdks/go && go build -v ./...)
 
       - name: Test (race + coverage)
@@ -54,6 +56,9 @@ jobs:
 
       - name: Test SDK module (race)
         run: cd sdks/go && go test -race -shuffle=on ./...
+
+      - name: Test MCP module (race)
+        run: cd mcp && go test -race -shuffle=on ./...
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
@@ -115,4 +120,6 @@ jobs:
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run govulncheck
-        run: govulncheck ./...
+        run: |
+          govulncheck ./...
+          (cd mcp && govulncheck ./...)

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -1,0 +1,166 @@
+name: MCP Release
+
+on:
+  push:
+    tags: [ 'mcp/v*.*.*' ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/lantern-mcp
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Re-run the canonical gates against the tagged commit. Tag pushes do
+  # not trigger the `Go` workflow, so without this we could ship a broken
+  # MCP image from a bad tag.
+  verify:
+    name: Verify (build + test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.4'
+          check-latest: true
+      - name: Vet
+        run: |
+          go vet ./...
+          (cd mcp && go vet ./...)
+      - name: Build
+        run: |
+          go build -v ./...
+          (cd mcp && go build -v ./...)
+      - name: Test
+        run: |
+          go test -race -shuffle=on ./...
+          (cd mcp && go test -race -shuffle=on ./...)
+
+  build:
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.4.1'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute mcp version
+        id: mcp_version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          # github.ref_name is `mcp/vX.Y.Z`; strip the `mcp/` prefix so the
+          # image tag is the plain `vX.Y.Z` (and SemVer-pure `X.Y.Z`).
+          version="${TAG#mcp/}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        env:
+          # docker/metadata-action's semver pattern engine needs the bare
+          # version, not the `mcp/v…` Go-module tag form.
+          DOCKER_METADATA_PR_HEAD_SHA: ''
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.mcp_version.outputs.version }}
+            type=raw,value=${{ steps.mcp_version.outputs.version }},enable=${{ !contains(steps.mcp_version.outputs.version, '-') }}
+            type=raw,value=latest,enable=${{ !contains(steps.mcp_version.outputs.version, '-') }}
+            type=sha
+          labels: |
+            org.opencontainers.image.title=lantern-mcp
+            org.opencontainers.image.description=Lantern MCP server — exposes a decaying-memory tool surface (remember_fact, recall_fact, forget, list_under, remember_relation, recall_related) over Model Context Protocol stdio.
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}/tree/main/mcp
+            org.opencontainers.image.licenses=Apache-2.0
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: mcp/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.mcp_version.outputs.version }}
+          cache-from: type=gha,scope=mcp
+          cache-to: type=gha,mode=max,scope=mcp
+          provenance: true
+          sbom: true
+
+      - name: Sign the published Docker image
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: |
+          echo "$TAGS" | xargs -I {} cosign sign --yes {}@${DIGEST}
+
+  release:
+    name: GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          version="${TAG#mcp/}"
+          notes_file=$(mktemp)
+          {
+            echo "## Lantern MCP server"
+            echo
+            echo "Multi-arch container (\`linux/amd64\`, \`linux/arm64\`), signed with cosign keyless."
+            echo
+            echo '```sh'
+            echo "docker pull ${IMAGE}:${version}"
+            echo '```'
+            echo
+            echo "Configure your MCP client to launch \`docker run --rm -i -e LANTERN_ADDR=<host>:6380 ${IMAGE}:${version}\` and the server will expose six tools (remember_fact, recall_fact, forget, list_under, remember_relation, recall_related) for LLM agents to interact with Lantern's decaying-memory graph."
+          } > "$notes_file"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --notes-file "$notes_file" --verify-tag
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes-file "$notes_file" \
+              --verify-tag
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Lantern is an in-memory `key-vertex-store` (graph-based KVS). It runs as a gRPC 
 
 ## Monorepo layout
 
-This project used to be split across four separate repositories (`lantern` / `lantern-proto` / `lantern-cli`, plus a shared graph/cache/NLP toolkit), but **everything is now consolidated into this repo as a 5-module Go workspace** so each piece can be consumed (`go get`) on its own:
+This project used to be split across four separate repositories (`lantern` / `lantern-proto` / `lantern-cli`, plus a shared graph/cache/NLP toolkit), but **everything is now consolidated into this repo as a 6-module Go workspace** so each piece can be consumed (`go get`) on its own:
 
 | Path | Module | Role |
 |---|---|---|
@@ -12,14 +12,15 @@ This project used to be split across four separate repositories (`lantern` / `la
 | `core/` | `github.com/anaregdesign/lantern/core` | **Leaf.** Reusable building blocks: graph, cache, collections, concurrency, NLP. |
 | `sdks/go/` | `github.com/anaregdesign/lantern/sdks/go` | Go client SDK. Depends on `pb/` only. |
 | `server/` | `github.com/anaregdesign/lantern/server` | gRPC server (DI via google/wire). Depends on `pb/` and `core/`. **Does not depend on the client SDK.** |
-| `.` (root) | `github.com/anaregdesign/lantern` | Umbrella module — hosts the CLI (`cli/`) and cross-module integration tests (`tests/integration/`). Depends on all four submodules. |
+| `mcp/` | `github.com/anaregdesign/lantern/mcp` | MCP server binary that exposes Lantern as a decaying-memory tool to LLM agents. Depends on `pb/` and `sdks/go/` only. Ships as the `lantern-mcp` container. |
+| `.` (root) | `github.com/anaregdesign/lantern` | Umbrella module — hosts the CLI (`cli/`) and cross-module integration tests (`tests/integration/`). Depends on all five submodules. |
 | `proto/` | (no Go module) | `.proto` sources, regenerated with buf. |
-| `go.work` | — | Pins all 5 modules for local dev. |
+| `go.work` | — | Pins all 6 modules for local dev. |
 
 Dependency direction (must remain a DAG, no back edges):
 
 ```
-         pb ◀─── sdks/go ◀──┐
+         pb ◀─── sdks/go ◀──┬─── mcp
           ▲                  │
           │                  ├── . (root: cli + tests/integration)
          server ◀───────────┘
@@ -28,7 +29,7 @@ Dependency direction (must remain a DAG, no back edges):
          core ◀──────────────┘
 ```
 
-Tag scheme: `vX.Y.Z` for server+CLI (root module), `sdks/go/vX.Y.Z` for the SDK, `core/vX.Y.Z` for core, `pb/vX.Y.Z` for the proto stubs.
+Tag scheme: `vX.Y.Z` for server+CLI (root module), `sdks/go/vX.Y.Z` for the SDK, `core/vX.Y.Z` for core, `pb/vX.Y.Z` for the proto stubs, `mcp/vX.Y.Z` for the MCP server image (cut independently of the root release cadence).
 
 ## Architecture notes
 
@@ -139,10 +140,11 @@ Run from repo root — this matches what the four required CI checks enforce
 (`Build & Test`, `Lint`, `Proto (buf)`, `govulncheck`):
 
 ```bash
-gofmt -l . cli core pb sdks server tests   # must print nothing
+gofmt -l . cli core mcp pb sdks server tests   # must print nothing
 (cd server && go vet ./... && go test ./...)
 go test ./...
 (cd core    && go test ./...)
+(cd mcp     && go test ./...)
 (cd pb      && go test ./...)
 (cd sdks/go && go test ./...)
 ```
@@ -199,10 +201,10 @@ introduced a new sub-config, update the **Providers** bullet in this file.
 
 ### After renaming any public SDK / server symbol (refactor)
 
-- Grep the **entire workspace** (`cli/`, `core/`, `pb/`, `sdks/go/`, `server/`,
-  `testbed/`, `tests/integration/`, `*.md`) for every old name. A single-module
-  test pass is **not** sufficient — five modules can compile in isolation while
-  the cross-module call site is broken.
+- Grep the **entire workspace** (`cli/`, `core/`, `mcp/`, `pb/`, `sdks/go/`,
+  `server/`, `testbed/`, `tests/integration/`, `*.md`) for every old name. A
+  single-module test pass is **not** sufficient — six modules can compile in
+  isolation while the cross-module call site is broken.
 - Update the **Architecture notes** bullets in this file and the
   **Conventions and gotchas** section of `README.md` in the **same PR**. The
   #106 alias refactor invalidated three method names across two docs — that
@@ -222,10 +224,10 @@ introduced a new sub-config, update the **Providers** bullet in this file.
 
 Update **all** of the following in one PR:
 
-1. Every `go.mod` (5 files): root, `core/`, `pb/`, `sdks/go/`, `server/`.
-2. `Dockerfile` — `FROM golang:X.Y-alpine`.
-3. Every `go-version:` in `.github/workflows/*.yml` (currently 6 occurrences
-   across `go.yml` and `docker-publish.yml`).
+1. Every `go.mod` (6 files): root, `core/`, `mcp/`, `pb/`, `sdks/go/`, `server/`.
+2. `Dockerfile` and `mcp/Dockerfile` — `FROM golang:X.Y-alpine`.
+3. Every `go-version:` in `.github/workflows/*.yml` (`go.yml`, `docker-publish.yml`,
+   `mcp-publish.yml`).
 4. The `Go version` mentions in this file and `README.md`.
 5. The CI version note in `/memories/repo/lantern.md`.
 
@@ -257,6 +259,13 @@ Tag order matters because each downstream module pins the upstream tag:
 The `server/` module is **never** tagged independently — it ships under the
 root tag. arm64 buildx under QEMU is slow; if a root tag already pushed the
 amd64 image, bump the patch number rather than force-moving the tag.
+
+The `mcp/` module is cut **independently** of the root release cadence: tag
+`mcp/vX.Y.Z` triggers `.github/workflows/mcp-publish.yml`, which builds and
+publishes `ghcr.io/anaregdesign/lantern-mcp:X.Y.Z` (multi-arch + cosign
+keyless). It does NOT need to follow the `pb → core → sdks/go → root` order;
+the MCP server only imports `pb/` and `sdks/go/`, so a `sdks/go/vX.Y.Z` bump
+is the only upstream pin that requires re-tagging the MCP image.
 
 ### Periodic doc-staleness sweep (before each release, or whenever memory and
 ### code disagree)

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,0 +1,56 @@
+# syntax=docker/dockerfile:1.7
+
+# --- build stage ---------------------------------------------------------
+# Multi-stage build for the lantern-mcp server. The build context MUST be
+# the repo root (not mcp/) because mcp/go.mod has replace directives that
+# point at sibling modules (../pb, ../sdks/go) and go.work pins all six
+# workspace members.
+FROM golang:1.26-alpine AS builder
+
+WORKDIR /src
+
+# Cache module downloads independently of source changes. Every workspace
+# member's go.mod + go.sum must be present BEFORE `go mod download` because
+# go.work loads them eagerly.
+COPY go.mod go.sum go.work go.work.sum* ./
+COPY core/go.mod core/go.sum ./core/
+COPY mcp/go.mod mcp/go.sum ./mcp/
+COPY pb/go.mod pb/go.sum ./pb/
+COPY sdks/go/go.mod sdks/go/go.sum ./sdks/go/
+COPY server/go.mod server/go.sum ./server/
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY . .
+
+ARG TARGETOS
+ARG TARGETARCH
+# VERSION is stamped into `mcp.Version` via -ldflags so the MCP server can
+# self-report its release in handshake responses. CI sets it from the tag.
+ARG VERSION=dev
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    cd mcp && \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go build -trimpath \
+      -ldflags="-s -w -X github.com/anaregdesign/lantern/mcp.Version=${VERSION}" \
+      -o /out/lantern-mcp ./cmd
+
+# --- final stage ---------------------------------------------------------
+# Distroless static + nonroot. The MCP server speaks stdio only; it needs
+# no shell, no package manager, and no writable filesystem.
+FROM gcr.io/distroless/static:nonroot
+
+# Default Lantern endpoint and ping timeout. Override at runtime via -e.
+# The TTL ladder is loaded from LANTERN_MCP_TTL_<BUCKET>=<duration> env
+# overrides; see mcp/internal/ttl for the 12 bucket names.
+ENV LANTERN_ADDR=localhost:6380 \
+    LANTERN_MCP_PING_TIMEOUT=3s
+
+COPY --from=builder /out/lantern-mcp /lantern-mcp
+
+# The MCP transport owns stdin/stdout; MCP clients invoke the binary
+# directly and tear it down when the session ends. There are no ports
+# to expose and no signal-handling quirks (the SDK reads to EOF).
+USER nonroot:nonroot
+ENTRYPOINT ["/lantern-mcp"]


### PR DESCRIPTION
Closes #286.

Adds the release pipeline for the lantern-mcp container so MCP server releases can be cut independently of the Lantern server's cadence.

## What's in this PR

- `mcp/Dockerfile`: multi-stage `golang:1.26-alpine` builder + `gcr.io/distroless/static:nonroot` runtime. Build context is repo root because `mcp/go.mod`'s `replace` directives point at sibling modules. The build stamps the Go-module tag into `mcp.Version` via `-ldflags "-X github.com/anaregdesign/lantern/mcp.Version=…"`.
- `.github/workflows/mcp-publish.yml`: triggers on `mcp/v*.*.*` tag pushes, re-runs vet+build+test (including the new mcp module), builds linux/amd64+linux/arm64 via docker buildx, publishes to `ghcr.io/anaregdesign/lantern-mcp` with cosign keyless signing, and drafts a GitHub Release whose notes include the pull command + a one-line description of the 6-tool surface.
- `.github/workflows/go.yml`: extends `Build & Test` (vet, build, test) and `govulncheck` to cover the mcp module — root `go test ./...` does not span submodules.
- `AGENTS.md`: brings the **Monorepo layout** table / DAG / tag scheme / pre-push checklist / Go-toolchain checklist / release-cut section up to 6 modules.

## Local verification

```
gofmt -l . cli core mcp pb sdks server tests   # clean
(cd server && go vet ./... && go test ./...)   # green
go test ./...                                  # green
(cd core    && go test ./...)                  # green
(cd mcp     && go test ./...)                  # green
(cd pb      && go test ./...)                  # green
(cd sdks/go && go test ./...)                  # green
docker build --build-arg VERSION=v0.0.1-test -t lantern-mcp:test -f mcp/Dockerfile .
# image runs and reports version=v0.0.1-test in slog; exits with clear error
# when LANTERN_ADDR is unreachable.
```

## Out of scope (deferred per #283 plan)

- README "MCP server" section + example client configs (Claude Desktop / VS Code / Cursor) — owned by #287.