### PR TITLE
docs(mcp): README section, mcp/README expansion, client config examples, compose snippet (#287)

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,142 @@ plain unary gRPC, no streaming required.
 
 ---
 
+## Use as an MCP server
+
+The [`mcp/`](mcp/) module ships **`lantern-mcp`**, a
+[Model Context Protocol](https://modelcontextprotocol.io) server that turns
+a running Lantern endpoint into **decaying graph memory** for LLM agents
+(Claude Desktop, VS Code / Copilot, Cursor, …).
+
+The pitch in one line: **facts decay on a TTL ladder; relations are additive
+and decay independently**. Treating Lantern as a Redis-style KV with TTLs
+misses the point — `recall_*` deliberately does NOT refresh TTL, and
+`remember_relation` is Hebbian (writing the same relation twice strengthens
+it). The agent learns which facts and relations are worth keeping by
+reinforcing them; everything else dies on schedule.
+
+`lantern-mcp` is **not** a replacement for the Go SDK, the gRPC surface, or
+the CLI — it is the LLM-facing facade. Under the hood it dials Lantern with
+the same SDK any other client uses; it never imports `server/` or `core/`.
+
+### Tools
+
+Six tools, advertised at session-open. Descriptions match those exposed via
+MCP `tools/list` (see [mcp/server.go](mcp/server.go) for the source of truth).
+
+| Tool | Purpose |
+|---|---|
+| `remember_fact` | Store a fact with a **required TTL bucket**. Re-writing the same key overwrites + resets TTL — the canonical way to refresh. |
+| `recall_fact` | Look up a single fact. Returns `{found=false}` for misses (structured, not a tool error). Does NOT refresh TTL. |
+| `forget` | Delete a fact by exact key. Idempotent. Edges incident to the key are NOT cascade-deleted; they decay on their own. |
+| `list_under` | Enumerate facts whose key starts with a prefix, ascending. Defaults to 50, max 500. |
+| `remember_relation` | Add or **reinforce** a directed relation. Additive: same write twice = stronger relation. |
+| `recall_related` | Walk the graph from a seed with `step`, `k`, and an optional `objective` (`mst` / `max-st` / `spt` / `inverse-spt`). |
+
+A `ping` tool also exists so operators can sanity-check the wire without
+touching state.
+
+### TTL buckets
+
+Every `remember_*` tool takes a **required** bucket parameter. Twelve enum
+horizons covering "next breath" through "next quarter":
+
+```
+seconds → transient → turn → conversation → task → workday → day →
+  week → sprint → month → quarter → durable
+```
+
+Defaults run from 30s to 180d and are all overridable via
+`LANTERN_MCP_TTL_<BUCKET>` environment variables (see
+[mcp/README.md](mcp/README.md#ttl-buckets-required-parameter-for-every-remember_-tool)
+for the full table). When in doubt about which bucket to pick, choose the
+shorter one — re-writing is cheap.
+
+### Run the container
+
+```shell
+# Pin to a release tag — never `:latest` for agent runtimes.
+docker run --rm -i \
+  -e LANTERN_ADDR=host.docker.internal:6380 \
+  ghcr.io/anaregdesign/lantern-mcp:v0.1.0
+```
+
+Images are published to `ghcr.io/anaregdesign/lantern-mcp` on every
+`mcp/vX.Y.Z` git tag (independent of the server's release cadence). Both
+`vX.Y.Z` and bare `X.Y.Z` tag forms are available, plus `latest` and
+`sha-<short>`; each image is multi-arch (`linux/amd64` + `linux/arm64`)
+and signed with cosign keyless.
+
+### Client configs
+
+Copy-paste snippets live in [`mcp/examples/`](mcp/examples/). The Claude
+Desktop entry:
+
+```json
+{
+  "mcpServers": {
+    "lantern": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-e", "LANTERN_ADDR=host.docker.internal:6380",
+        "ghcr.io/anaregdesign/lantern-mcp:v0.1.0"
+      ]
+    }
+  }
+}
+```
+
+VS Code (`.vscode/mcp.json`) and Cursor (`~/.cursor/mcp.json`) take the
+same shape — see [mcp/examples/README.md](mcp/examples/README.md) for
+file locations and `LANTERN_ADDR` tweaks for Linux / remote setups.
+
+### Worked example: agent memory session
+
+The interaction pattern that exercises Lantern's strengths is
+**reinforce-then-recall** — short-TTL writes that accumulate into a
+useful neighborhood:
+
+```text
+# 1. Capture facts as they arise. Bucket is required; prefer SHORTER.
+remember_fact(key="user:alice/role",      value="staff eng",     bucket="quarter")
+remember_fact(key="user:alice/team",      value="payments",      bucket="month")
+remember_fact(key="topic:payments/owner", value="alice",         bucket="month")
+
+# 2. Reinforce relations every time they show up in the conversation.
+#    Each call APPENDS a contribution — repeated co-occurrence builds weight.
+remember_relation(tail="user:alice", head="topic:payments", weight=1.0, bucket="day")
+remember_relation(tail="user:alice", head="topic:payments", weight=1.0, bucket="day")
+remember_relation(tail="user:alice", head="topic:auth",     weight=0.4, bucket="day")
+
+# 3. Later in the session, walk the live graph. SPT-inverse-weight returns
+#    a "most relevant" tree — exactly what you want for grounding context.
+recall_related(seed="user:alice", step=2, k=5, objective="inverse-spt")
+# → [{key: "topic:payments", weight: 2.0}, {key: "topic:auth", weight: 0.4}, …]
+```
+
+Two recurring traps worth memorising:
+
+- **`recall_*` does NOT refresh TTL.** A frequently-read but never-rewritten
+  fact will still decay. The canonical idiom is *"recall, then if you want
+  it to stick around, `remember_fact` again with the same key."*
+- **`remember_relation` is additive, not idempotent.** Re-writing the same
+  edge strengthens it; that is the design. Use the relation's TTL bucket as
+  a half-life knob — short buckets give you a "what's hot right now" view,
+  long buckets give you "what has this user historically cared about."
+
+### Docs and references
+
+- Operator / contributor reference: [mcp/README.md](mcp/README.md).
+- Server-instructions string the LLM sees at session-open:
+  [mcp/server.go](mcp/server.go) (`serverInstructions` constant).
+- Container build + publish pipeline:
+  [.github/workflows/mcp-publish.yml](.github/workflows/mcp-publish.yml).
+- Integration test that wires the MCP server against an in-process Lantern:
+  [tests/integration/mcp_test.go](tests/integration/mcp_test.go).
+
+---
+
 ## gRPC surface
 
 Defined in [proto/graph/v1/graph.proto](proto/graph/v1/graph.proto), served by
@@ -498,19 +634,20 @@ Lantern ships production-grade observability out of the box:
 
 ## Repository layout
 
-This is a monorepo consolidating four formerly separate repositories, now stitched together as a 5-module Go workspace so each piece can be consumed independently.
+This is a monorepo consolidating four formerly separate repositories, now stitched together as a 6-module Go workspace so each piece can be consumed independently.
 
 | Path | Module | Role |
 |---|---|---|
-| `pb/` | `github.com/anaregdesign/lantern/pb` | Generated protobuf / gRPC / grpc-gateway stubs. Shared contract — both `server/` and `sdks/go/` depend on it. |
+| `pb/` | `github.com/anaregdesign/lantern/pb` | Generated protobuf / gRPC / grpc-gateway stubs. Shared contract — `server/`, `sdks/go/`, and `mcp/` all depend on it. |
 | `core/` | `github.com/anaregdesign/lantern/core` | Shared building blocks: graph algorithms, TTL caches, collections, concurrency, NLP. |
 | `sdks/go/` | `github.com/anaregdesign/lantern/sdks/go` | Go client SDK — depends on `pb/` only. |
 | `server/` | `github.com/anaregdesign/lantern/server` | gRPC server (DI via google/wire) — depends on `pb/` + `core/`, **not** on the client SDK. |
+| `mcp/` | `github.com/anaregdesign/lantern/mcp` | MCP server binary that exposes Lantern as decaying graph memory to LLM agents. Depends on `pb/` + `sdks/go/` only; ships as the `ghcr.io/anaregdesign/lantern-mcp` container on `mcp/vX.Y.Z` tags. |
 | `.` (root) | `github.com/anaregdesign/lantern` | Umbrella module hosting `cli/` (cobra + promptui) and `tests/integration/` (cross-module bufconn tests). |
 | `proto/` | (no Go module) | `.proto` sources — formerly `lantern-proto`. |
-| `go.work` | — | Pins all 5 modules for local dev. |
+| `go.work` | — | Pins all 6 modules for local dev. |
 
-Dependency direction is a strict DAG: `pb` and `core` are leaves; `sdks/go` → `pb`; `server` → `pb`, `core`; root → all four.
+Dependency direction is a strict DAG: `pb` and `core` are leaves; `sdks/go` → `pb`; `server` → `pb`, `core`; `mcp` → `sdks/go` → `pb`; root → all five submodules.
 
 ---
 

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -83,3 +83,24 @@ which `LocalIPSet()` filters as self, so the pump becomes a no-op.
 - Peer discovery spec: [`../../docs/replication.md` §9.1](../../docs/replication.md#91-peer-discovery-190)
 - HA runbook: issue #192 (in flight).
 - Testbed (single-instance observability QA): [`../../testbed/`](../../testbed/)
+
+## Single-node + MCP server
+
+For local LLM-agent experiments there is a smaller compose file in
+[`docker-compose.mcp.yml`](docker-compose.mcp.yml) that stands up one
+`lantern` + one `lantern-mcp`. The MCP server is stdio-only, so the
+typical workflow is:
+
+```shell
+# Bring up just Lantern in the background.
+docker compose -f docker-compose.mcp.yml up -d lantern
+
+# Sanity-check the MCP wire (note `run`, not `up` — stdio).
+docker compose -f docker-compose.mcp.yml run --rm lantern-mcp
+```
+
+In production, the agent runtime (Claude Desktop, VS Code, Cursor, …)
+owns the MCP container's lifetime — see
+[`../../mcp/examples/`](../../mcp/examples/) for those configs and
+[`../../mcp/README.md`](../../mcp/README.md) for the full operator
+reference.

--- a/deploy/compose/docker-compose.mcp.yml
+++ b/deploy/compose/docker-compose.mcp.yml
@@ -1,0 +1,63 @@
+# Docker Compose: single-node lantern + lantern-mcp.
+#
+# Minimal local-dev topology for trying the MCP server against a fresh
+# Lantern. Not for HA — see `docker-compose.yml` in this directory for
+# the 3-replica peer-discovery cluster.
+#
+# Usage:
+#   cd deploy/compose
+#   docker compose -f docker-compose.mcp.yml up -d lantern
+#
+# The MCP server is a stdio server — `docker compose up lantern-mcp` is
+# rarely what you want, because the agent runtime (Claude Desktop, VS
+# Code, Cursor, …) owns the lifetime and stdio pipe. The `lantern-mcp`
+# service definition below is here so you can:
+#
+#   1. Sanity-check the wire: `docker compose -f docker-compose.mcp.yml \
+#        run --rm lantern-mcp` (note `run`, not `up`).
+#   2. Use the service spec as a template for your own compose file with
+#      a real MCP-aware client attached on stdio.
+#
+# Override the image tags:
+#   LANTERN_IMAGE=ghcr.io/anaregdesign/lantern:v0.8.0 \
+#   LANTERN_MCP_IMAGE=ghcr.io/anaregdesign/lantern-mcp:v0.1.0 \
+#       docker compose -f docker-compose.mcp.yml up -d lantern
+
+services:
+  lantern:
+    image: ${LANTERN_IMAGE:-ghcr.io/anaregdesign/lantern:latest}
+    ports:
+      - "6380:6380"
+      - "9090:9090"
+    environment:
+      LANTERN_PORT: "6380"
+      LANTERN_METRICS_ADDR: ":9090"
+      LANTERN_DEFAULT_TTL_SECONDS: "3600"
+      LANTERN_LOG_FORMAT: "json"
+      LANTERN_LOG_LEVEL: "info"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9090/readyz"]
+      interval: 5s
+      timeout: 2s
+      retries: 12
+      start_period: 5s
+
+  lantern-mcp:
+    image: ${LANTERN_MCP_IMAGE:-ghcr.io/anaregdesign/lantern-mcp:latest}
+    # MCP is a stdio protocol — `stdin_open: true` so `docker compose run
+    # --rm lantern-mcp` keeps stdin attached and the client can speak
+    # JSON-RPC. `up -d` would just exit because there's nothing to read.
+    stdin_open: true
+    tty: false
+    environment:
+      # Use the Compose service DNS name so this works on Linux without
+      # `host.docker.internal`.
+      LANTERN_ADDR: "lantern:6380"
+      LANTERN_MCP_PING_TIMEOUT: "5s"
+      # Uncomment any of the 12 TTL buckets you want to override; values
+      # must use Go time.ParseDuration syntax (no `d` suffix).
+      # LANTERN_MCP_TTL_TURN: "15m"
+      # LANTERN_MCP_TTL_CONVERSATION: "2h"
+    depends_on:
+      lantern:
+        condition: service_healthy

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -4,21 +4,96 @@ A [Model Context Protocol](https://modelcontextprotocol.io) server that
 exposes a remote [Lantern](https://github.com/anaregdesign/lantern) gRPC
 endpoint as **decaying graph memory** for LLM agents.
 
-This module is a standalone executable. Real tool surface (`remember_fact`,
-`recall_related`, …) lands in sub-issue
-[#285](https://github.com/anaregdesign/lantern/issues/285); this scaffold
-ships a single no-op `ping` tool so the end-to-end MCP round-trip can be
-validated.
+The pitch: **facts decay on a TTL ladder; relations are additive and
+decay independently**. Treating Lantern as a Redis-style KV with TTLs
+misses the point — the value lives in the graph that emerges when you
+let an agent reinforce useful relations and let weak ones die on their
+own schedule.
+
+For the end-user docs (Claude Desktop / VS Code / Cursor configs, agent
+session walkthrough), see the **"Use as an MCP server"** section in the
+[root README](../README.md#use-as-an-mcp-server). This file is the
+reference for operators and contributors.
 
 ## Run
 
-```bash
+The binary speaks MCP over **stdio**. Diagnostics go to stderr; stdout
+is owned by the JSON-RPC stream.
+
+### From a container (recommended)
+
+```shell
+# Pin to a release tag — never `:latest` for agent runtimes.
+docker run --rm -i \
+  -e LANTERN_ADDR=host.docker.internal:6380 \
+  ghcr.io/anaregdesign/lantern-mcp:v0.1.0
+```
+
+The image is published on every `mcp/vX.Y.Z` tag push (see
+[mcp-publish.yml](../.github/workflows/mcp-publish.yml)). Both `vX.Y.Z`
+and bare `X.Y.Z` tag forms are available, plus `latest` and `sha-<short>`.
+
+### From source
+
+```shell
 # from repo root
 LANTERN_ADDR=localhost:6380 go run ./mcp/cmd
 ```
 
-The binary speaks MCP over **stdio**. Diagnostics go to stderr; stdout is
-owned by the JSON-RPC stream.
+## Tools
+
+Six tools, all advertised at session-open via the server-instructions
+string in [`server.go`](server.go). Descriptions are reproduced verbatim
+from the source so the LLM and the human reader see the same contract.
+
+| Tool | Purpose |
+|---|---|
+| `remember_fact` | Store a fact in Lantern with a **required TTL bucket**. Writing the same key again overwrites the value and resets the TTL — that is the canonical way to refresh a fact since `recall_*` does NOT refresh. |
+| `recall_fact` | Look up a single fact by exact key. Returns `{found=false}` for missing keys (structured result, not a tool error). Does NOT refresh TTL. |
+| `forget` | Delete a fact by exact key. Idempotent. Edges incident to the key are NOT cascade-deleted; they decay on their own TTL. |
+| `list_under` | Enumerate facts whose key starts with the given prefix, in ascending key order. Defaults to 50 entries, max 500. |
+| `remember_relation` | Add (or reinforce) a directed relation from one fact to another. **Additive** — writing the same relation twice strengthens it; this is the Hebbian primitive. |
+| `recall_related` | Walk the graph from a seed key with `step`, `k`, and an optional `objective` (`mst` / `max-st` / `spt` / `inverse-spt`). Returns related facts with cumulative weights. Does NOT refresh TTL. |
+
+A `ping` tool also exists so operators can sanity-check the wire without
+mutating state.
+
+### TTL buckets (required parameter for every `remember_*` tool)
+
+Twelve enum horizons. Picking a shorter bucket is almost always the
+right call ("when will this stop being true?"); writing again is cheap.
+
+| Bucket | Default TTL | Env override |
+|---|---|---|
+| `seconds` | 30s | `LANTERN_MCP_TTL_SECONDS` |
+| `transient` | 2m | `LANTERN_MCP_TTL_TRANSIENT` |
+| `turn` | 10m | `LANTERN_MCP_TTL_TURN` |
+| `conversation` | 1h | `LANTERN_MCP_TTL_CONVERSATION` |
+| `task` | 4h | `LANTERN_MCP_TTL_TASK` |
+| `workday` | 12h | `LANTERN_MCP_TTL_WORKDAY` |
+| `day` | 24h | `LANTERN_MCP_TTL_DAY` |
+| `week` | 7d | `LANTERN_MCP_TTL_WEEK` |
+| `sprint` | 14d | `LANTERN_MCP_TTL_SPRINT` |
+| `month` | 30d | `LANTERN_MCP_TTL_MONTH` |
+| `quarter` | 90d | `LANTERN_MCP_TTL_QUARTER` |
+| `durable` | 180d | `LANTERN_MCP_TTL_DURABLE` |
+
+Overrides use Go [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration)
+syntax (no `d` suffix — use `168h` for a week). The resolved durations
+must remain **strictly monotonic**; a misordered configuration is a
+fatal startup error.
+
+## Environment reference
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `LANTERN_ADDR` | `localhost:6380` | Upstream Lantern gRPC target. |
+| `LANTERN_MCP_PING_TIMEOUT` | `5s` | Bounds the startup health probe. A failed probe aborts startup with a non-zero exit so MCP clients surface a clear error. |
+| `LANTERN_MCP_TTL_<BUCKET>` | see table above | Per-bucket TTL override. |
+
+Logging is structured JSON via `log/slog` to stderr at `INFO` level
+(stdout is owned by the JSON-RPC stream); there is no log-level or
+format knob today.
 
 ## Dependency boundary
 
@@ -28,37 +103,44 @@ mcp/  →  sdks/go/  →  pb/
 
 `mcp/` never imports `core/` or `server/`. The MCP server is a vanilla
 Lantern client and talks to the upstream over the wire like any external
-caller.
+caller — which is exactly why the image can be cut independently of the
+server release cadence.
 
-## Environment
+## Container image
 
-| Variable | Default | Purpose |
-|---|---|---|
-| `LANTERN_ADDR` | `localhost:6380` | Upstream Lantern gRPC target. |
-| `LANTERN_MCP_PING_TIMEOUT` | `5s` | Bounds the startup health probe. |
-| `LANTERN_MCP_TTL_<BUCKET>` | see below | Per-bucket TTL override. |
+Built by [mcp-publish.yml](../.github/workflows/mcp-publish.yml) on every
+`mcp/vX.Y.Z` tag push:
 
-### TTL buckets
+- Image: `ghcr.io/anaregdesign/lantern-mcp`
+- Tag forms: `vX.Y.Z`, `X.Y.Z`, `latest` (non-prerelease only), `sha-<short>`.
+- Multi-arch: `linux/amd64` + `linux/arm64`.
+- Base: `gcr.io/distroless/static:nonroot` (no shell, no writable FS —
+  fine for stdio MCP, but `docker exec` is not supported).
+- Signed with cosign keyless (`cosign verify --certificate-identity-regexp
+  '^https://github.com/anaregdesign/lantern' ...`).
 
-Twelve required-enum horizons that every `remember_*`-style tool will take
-as a typed parameter (wiring lands in #285). Defaults:
+The version baked at build time is reported in the startup `slog` record
+as the `version` field.
 
-| bucket | default |
-|---|---|
-| `seconds` | 30s |
-| `transient` | 2m |
-| `turn` | 10m |
-| `conversation` | 1h |
-| `task` | 4h |
-| `workday` | 12h |
-| `day` | 24h |
-| `week` | 7d |
-| `sprint` | 14d |
-| `month` | 30d |
-| `quarter` | 90d |
-| `durable` | 180d |
+## Client configuration
 
-Overrides use Go [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration)
-syntax (no `d` suffix — use `168h` for a week). The resolved durations must
-remain **strictly monotonic**; a misordered configuration is a fatal
-startup error.
+See [`examples/`](examples/) for ready-to-copy snippets:
+
+- [`examples/claude-desktop.json`](examples/claude-desktop.json) — Claude Desktop `claude_desktop_config.json`.
+- [`examples/vscode-mcp.json`](examples/vscode-mcp.json) — VS Code workspace `.vscode/mcp.json`.
+- [`examples/cursor-mcp.json`](examples/cursor-mcp.json) — Cursor `~/.cursor/mcp.json`.
+
+All three follow the same shape: `command: docker`, `args` invoke the
+container with stdio and your `LANTERN_ADDR`.
+
+## Development
+
+```shell
+(cd mcp && go test ./...)              # unit tests
+(cd mcp && go test -race -shuffle=on ./...)
+go test ./tests/integration -run MCP   # in-process integration test
+```
+
+The integration test in [`tests/integration/mcp_test.go`](../tests/integration/mcp_test.go)
+wires the server module against an in-process Lantern via `mcp.InMemoryTransport`
+— no Docker required.

--- a/mcp/examples/README.md
+++ b/mcp/examples/README.md
@@ -1,0 +1,40 @@
+# lantern-mcp client config examples
+
+Ready-to-copy MCP server entries for the major agent runtimes. All three
+files share the same shape: spawn the `ghcr.io/anaregdesign/lantern-mcp`
+container with stdio attached and point it at a Lantern gRPC endpoint
+via `LANTERN_ADDR`.
+
+| File | Drop into |
+|---|---|
+| [`claude-desktop.json`](claude-desktop.json) | `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) / `%APPDATA%\Claude\claude_desktop_config.json` (Windows) |
+| [`vscode-mcp.json`](vscode-mcp.json) | `.vscode/mcp.json` in your workspace, or `~/.config/Code/User/mcp.json` for user scope |
+| [`cursor-mcp.json`](cursor-mcp.json) | `~/.cursor/mcp.json` |
+
+## Things to change before pasting
+
+- **Pin the image tag.** The examples use `v0.1.0`; bump to whatever the
+  newest [`mcp/vX.Y.Z` release](https://github.com/anaregdesign/lantern/releases?q=mcp%2F)
+  ships. Do not use `:latest` — agent runtimes treat the tool surface as
+  contract, and a silent schema bump is hostile.
+- **Pick the right `LANTERN_ADDR`.**
+  - macOS / Windows Docker Desktop, Lantern on the host: `host.docker.internal:6380` (used in the snippets).
+  - Linux Docker, Lantern on the host: `127.0.0.1:6380` with `--network=host` (drop the `-e` and add `--network=host` to `args`).
+  - Lantern on a remote host: `lantern.example.com:6380` (consider TLS — see [#212](https://github.com/anaregdesign/lantern/issues/212)).
+- **TTL ladder overrides** (optional): append `-e LANTERN_MCP_TTL_TURN=15m`
+  etc. to `args` for any of the 12 buckets. Defaults are listed in
+  [`../README.md`](../README.md#ttl-buckets-required-parameter-for-every-remember_-tool).
+
+## Sanity check
+
+```shell
+docker run --rm -i \
+  -e LANTERN_ADDR=host.docker.internal:6380 \
+  ghcr.io/anaregdesign/lantern-mcp:v0.1.0 <<'EOF'
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"1"}}}
+EOF
+```
+
+If Lantern is reachable you will see the standard MCP `initialize`
+response on stdout. If not, the container exits non-zero with a single
+line on stderr identifying the address that failed.

--- a/mcp/examples/claude-desktop.json
+++ b/mcp/examples/claude-desktop.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "lantern": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-e", "LANTERN_ADDR=host.docker.internal:6380",
+        "ghcr.io/anaregdesign/lantern-mcp:v0.1.0"
+      ]
+    }
+  }
+}

--- a/mcp/examples/cursor-mcp.json
+++ b/mcp/examples/cursor-mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "lantern": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-e", "LANTERN_ADDR=host.docker.internal:6380",
+        "ghcr.io/anaregdesign/lantern-mcp:v0.1.0"
+      ]
+    }
+  }
+}

--- a/mcp/examples/vscode-mcp.json
+++ b/mcp/examples/vscode-mcp.json
@@ -1,0 +1,13 @@
+{
+  "servers": {
+    "lantern": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-e", "LANTERN_ADDR=host.docker.internal:6380",
+        "ghcr.io/anaregdesign/lantern-mcp:v0.1.0"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Closes #287 — final sub-issue of the MCP epic #283.

## What landed

- **`README.md`** — new top-level "Use as an MCP server" section placed between Quick start and gRPC surface. Leads with the decaying-memory pitch ("facts decay on a TTL ladder; relations are additive and decay independently"), then 6-tool table, TTL bucket ladder, docker pull pinned to a versioned tag, Claude Desktop snippet, and a worked **reinforce-then-recall** agent session showing why `recall_*` not refreshing TTL and `remember_relation` being additive are features, not bugs.
- **`README.md` Repository layout** — bumped to **6-module workspace** with `mcp/` row + DAG line update (`mcp/ → sdks/go/ → pb/`).
- **`mcp/README.md`** — full rewrite. Per-tool table sourced verbatim from `tool_*.go` descriptions; full 12-bucket TTL table with the matching `LANTERN_MCP_TTL_*` env-var names; container provenance section (multi-arch, cosign verify recipe); link out to `examples/`.
- **`mcp/examples/`** — `claude-desktop.json`, `vscode-mcp.json`, `cursor-mcp.json`, and a README documenting file locations for each runtime plus `LANTERN_ADDR` tweaks for macOS Docker Desktop vs Linux `--network=host` vs remote.
- **`deploy/compose/docker-compose.mcp.yml`** — single-node lantern + lantern-mcp compose file with `stdin_open: true` and a clear note that `docker compose run --rm lantern-mcp` (not `up`) is the right invocation for stdio. `deploy/compose/README.md` gets a cross-reference paragraph.

## Local verification

```
gofmt -l . cli core mcp pb sdks server tests  # clean
(cd mcp && go test ./...)                     # green
python3 -m json.tool < mcp/examples/*.json    # all valid JSON
docker compose -f deploy/compose/docker-compose.mcp.yml config   # validates
```

All inter-doc links manually audited; every relative path resolves.

## What ships after this PR

Epic #283 closes once this merges:
- ✅ #284 / PR #288 — mcp/ scaffold + TTL bucket plumbing.
- ✅ #285 / PR #289 — 6-tool LLM surface.
- ✅ #286 / PR #290 — container image + tag-gated ghcr publish.
- This PR — docs.

A first `mcp/v0.1.0` tag can be cut whenever.

## Out of scope (per #287)

- Standalone `docs/mcp.md` deep dive (only if the README section grows past ~300 lines — currently ~140).
- Helm chart for `lantern-mcp` — file a separate issue if there is demand.
- Marketing copy beyond the README.