### PR TITLE
chore(sdks/go): bump pb pin v0.1.0 → v0.1.1

### DIFF
--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -3,7 +3,7 @@ module github.com/anaregdesign/lantern/sdks/go
 go 1.26
 
 require (
-	github.com/anaregdesign/lantern/pb v0.1.0
+	github.com/anaregdesign/lantern/pb v0.1.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11


### PR DESCRIPTION
## What

Bumps `sdks/go/go.mod`'s `require github.com/anaregdesign/lantern/pb v0.1.0` to `v0.1.1`.

## Why

`sdks/go` has exercised pb v0.1.1 APIs (`ScanEdges`, `Snapshot`, replication mutation/HLC types) since #196 / #203 / #205 landed, but its require directive still pinned pb v0.1.0. The workspace `replace` directive masked this locally — only consumers running `go get github.com/anaregdesign/lantern/sdks/go@latest` saw the broken pin.

This is the prerequisite for cutting `sdks/go/v0.8.0` per the canonical tag order (pb → core → sdks/go).

## Verification

- `cd sdks/go && go build ./... && go test ./...` → pass.
- `gofmt -l . cli core mcp pb sdks server tests` → clean.
- No `go.sum` churn (workspace `replace` keeps local builds identical).

Closes #292 (step 2 of 3 — step 1 `core/v0.2.0` already shipped; step 3 `sdks/go/v0.8.0` cut after this merges).