### PR TITLE
ci: expand Dependabot to all 6 Go modules + mcp/Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # gomod — one entry per Go module in the workspace (6 total).
   - package-ecosystem: gomod
     directory: /
     schedule:
@@ -15,14 +16,96 @@ updates:
         patterns:
           - "golang.org/x/*"
 
+  - package-ecosystem: gomod
+    directory: /core
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      x-deps:
+        patterns:
+          - "golang.org/x/*"
+
+  - package-ecosystem: gomod
+    directory: /mcp
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      mcp-sdk:
+        patterns:
+          - "github.com/modelcontextprotocol/*"
+      grpc-protobuf:
+        patterns:
+          - "google.golang.org/grpc*"
+          - "google.golang.org/protobuf*"
+
+  - package-ecosystem: gomod
+    directory: /pb
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      grpc-protobuf:
+        patterns:
+          - "google.golang.org/grpc*"
+          - "google.golang.org/protobuf*"
+          - "google.golang.org/genproto*"
+      grpc-gateway:
+        patterns:
+          - "github.com/grpc-ecosystem/grpc-gateway*"
+
+  - package-ecosystem: gomod
+    directory: /sdks/go
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      grpc-protobuf:
+        patterns:
+          - "google.golang.org/grpc*"
+          - "google.golang.org/protobuf*"
+          - "google.golang.org/genproto*"
+      otel:
+        patterns:
+          - "go.opentelemetry.io/*"
+
+  - package-ecosystem: gomod
+    directory: /server
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      grpc-protobuf:
+        patterns:
+          - "google.golang.org/grpc*"
+          - "google.golang.org/protobuf*"
+          - "google.golang.org/genproto*"
+      x-deps:
+        patterns:
+          - "golang.org/x/*"
+      otel:
+        patterns:
+          - "go.opentelemetry.io/*"
+      prometheus:
+        patterns:
+          - "github.com/prometheus/*"
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
 
+  # docker — one entry per Dockerfile (2 total).
   - package-ecosystem: docker
     directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: docker
+    directory: /mcp
     schedule:
       interval: weekly
     open-pull-requests-limit: 5


### PR DESCRIPTION
## What

Expands [`.github/dependabot.yml`](.github/dependabot.yml) from 3 entries to 9:

| Ecosystem | Before | After |
|---|---|---|
| `gomod` | `/` only (1 of 6 modules) | `/`, `/core`, `/mcp`, `/pb`, `/sdks/go`, `/server` (6 of 6) |
| `docker` | `/` only (1 of 2 Dockerfiles) | `/`, `/mcp` (2 of 2) |
| `github-actions` | unchanged | unchanged |

## Why

5 of 6 `go.mod` files and the `mcp/Dockerfile` were unscanned for weekly dependency updates. `server/` in particular has the largest dependency surface (grpc, otel, prometheus, opentelemetry-collector) and was never receiving security patches via Dependabot — every transitive CVE landed only if a separate root-module bump happened to drag it in.

## Grouping

Each new entry gets tailored `groups:` rules so the weekly PR storm stays reviewable:

- `grpc-protobuf` — `google.golang.org/{grpc,protobuf,genproto}*` (root, mcp, pb, sdks/go, server)
- `x-deps` — `golang.org/x/*` (root, core, server)
- `otel` — `go.opentelemetry.io/*` (sdks/go, server)
- `prometheus` — `github.com/prometheus/*` (server)
- `grpc-gateway` — `github.com/grpc-ecosystem/grpc-gateway*` (pb)
- `mcp-sdk` — `github.com/modelcontextprotocol/*` (mcp)

## Verification

Pure YAML config; Dependabot validates on next scheduled run. Local check: `yamllint .github/dependabot.yml` parses cleanly.

Closes #294.