### PR TITLE
fix(core/pubsub): snapshot createdAt before consumer to avoid pool-recycle race

### DIFF
--- a/core/concurrent/pubsub/subscription.go
+++ b/core/concurrent/pubsub/subscription.go
@@ -82,13 +82,17 @@ func (s *Subscription[T]) Subscribe(ctx context.Context, consumer function.Consu
 						// Already acked (e.g. salvaged past TTL) between publish and lookup.
 						continue
 					}
+					// Snapshot createdAt BEFORE handing m to consumer. If consumer
+					// acks synchronously, ack() returns the envelope to s.pool;
+					// a concurrent Publish may then recycle it via newMessage,
+					// which re-stamps createdAt. Reading m.createdAt after
+					// consumer returns is a use-after-pool-recycle race (#303).
+					createdAt := m.createdAt
 					consumer(m)
 					if obs := s.observer; obs != nil {
 						// Enqueue-to-consumer-return latency, measured from the
-						// originating Publish (#240). Reads m.createdAt without
-						// the lock: the field is stamped once in newMessage and
-						// never mutated thereafter.
-						obs.ObserveDispatch(time.Since(m.createdAt))
+						// originating Publish (#240).
+						obs.ObserveDispatch(time.Since(createdAt))
 					}
 				case <-ctx.Done():
 					return


### PR DESCRIPTION
## Summary

Fixes the use-after-pool-recycle race documented in #303, surfaced by the expanded `-race` CI coverage from #293 (which runs `go test -race` against the `core/` module — root `go test ./...` does not recurse into `core/`, so this race was invisible to CI until now).

## Root cause

`Subscription.Subscribe` workers used to do:

```go
consumer(m)                                       // may Ack() -> s.pool.Put(m)
obs.ObserveDispatch(time.Since(m.createdAt))      // race: m may have been recycled
```

If the consumer acks synchronously, `ack()` returns the envelope to `s.pool`. A concurrent `Publish` then `pool.Get`s the same envelope and `newMessage` rewrites `m.createdAt` (along with `m.id`, `m.body`, `m.subscription`, …). The trailing `time.Since(m.createdAt)` read raced the recycler's write.

The companion comment claimed `createdAt` is "stamped once in newMessage and never mutated thereafter" — pool reuse falsifies that.

## Fix

Snapshot `createdAt` onto a local **before** calling consumer:

```go
createdAt := m.createdAt
consumer(m)
if obs := s.observer; obs != nil {
    obs.ObserveDispatch(time.Since(createdAt))
}
```

One-line semantic change. No API change. Observer behavior preserved.

## Verification

```
$ cd core && go test -race -count=5 -run TestTopic_PublishConcurrentSafe ./concurrent/pubsub/
ok      github.com/anaregdesign/lantern/core/concurrent/pubsub  1.452s
$ cd core && go test -race -shuffle=on -count=1 ./...
ok  (all packages)
```

(Pre-fix: `FAIL TestTopic_PublishConcurrentSafe — race detected`.)

Closes #303.