### PR TITLE
ci: pin floating tool versions (golangci-lint, uv, bun)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -95,7 +95,10 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          # Pin to a concrete release so a fresh golangci-lint can't silently
+          # break CI. Dependabot's github-actions ecosystem will bump this
+          # via PR (#295).
+          version: v2.12.2
           args: --timeout=5m
 
   proto:

--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -38,7 +38,9 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          # Pin so a fresh bun release can't silently break CI. Dependabot's
+          # github-actions ecosystem will bump this via PR (#295).
+          bun-version: 1.3.14
       - name: Setup buf
         uses: bufbuild/buf-setup-action@v1
         with:
@@ -88,7 +90,8 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          # See note in test job above (#295).
+          bun-version: 1.3.14
       - name: Setup buf
         uses: bufbuild/buf-setup-action@v1
         with:

--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -32,7 +32,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: 'latest'
+          # Pin so a fresh uv release can't silently break CI. Dependabot's
+          # github-actions ecosystem will bump this via PR (#295).
+          version: '0.11.19'
       - name: Install Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
First quick-win from #295: pin the 'latest' tool tags in three workflows.

## What

| File | Tool | Before | After |
|---|---|---|---|
| [`go.yml`](.github/workflows/go.yml) | golangci-lint | `latest` | `v2.12.2` |
| [`python-sdk.yml`](.github/workflows/python-sdk.yml) | uv | `'latest'` | `'0.11.19'` |
| [`node-sdk.yml`](.github/workflows/node-sdk.yml) | bun | `latest` ×2 | `1.3.14` ×2 |

## Why

`latest` couples CI to whatever upstream ships next. A bad cut breaks CI on the next workflow run with zero PR context — the failure mode #295 calls out. Pinning to a concrete release moves upstream churn into reviewable Dependabot PRs (the `github-actions` ecosystem covers all three).

## Out of scope

The other #295 bullets — CodeQL, reusable `_verify.yml`, `sdks/go` tag-verify workflow, release-please, coverage merging, commitlint — are tracked separately on #295 and can land as future one-line PRs.

Note: the issue's bullet about "`docker-publish.yml` lacks `sbom: true` / `provenance: true`" is already done (`docker-publish.yml` has both — will mark that item complete on the issue).

Refs #295.