### PR TITLE
docs(agents): lock release-title convention to raw tag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,6 +267,17 @@ keyless). It does NOT need to follow the `pb → core → sdks/go → root` orde
 the MCP server only imports `pb/` and `sdks/go/`, so a `sdks/go/vX.Y.Z` bump
 is the only upstream pin that requires re-tagging the MCP image.
 
+**Release title convention (locked).** Every GitHub Release title MUST equal
+its tag name verbatim — `v0.7.2`, `core/v0.2.0`, `sdks/go/v0.8.0`,
+`sdks/node/v0.1.2`, `sdks/python/v0.1.1`, `mcp/v0.1.0`. No friendly aliases
+(`Node SDK v0.1.2`, `Go SDK v0.6.0`, etc). `docker-publish.yml` and
+`mcp-publish.yml` already enforce this via `gh release create --title
+"$TAG"`. The Python and Node SDK GitHub Releases are currently created
+manually — when creating them, always pass `--title "$(git describe
+--tags)"` (or the literal tag) so the title matches. If you ever automate
+those releases inside `python-sdk.yml` / `node-sdk.yml`, use the same
+`--title "$TAG"` pattern.
+
 ### Periodic doc-staleness sweep (before each release, or whenever memory and
 ### code disagree)
 


### PR DESCRIPTION
Per the user's request to make release titles consistent going forward.

## Context

`gh release list` showed two competing styles for component release titles:

| Style | Examples |
|---|---|
| Raw tag (current convention) | `sdks/go/v0.8.0`, `core/v0.2.0`, `mcp/v0.1.0`, `v0.7.2` |
| Friendly alias (drift) | `Node SDK v0.1.2`, `Python SDK v0.1.1`, `Go SDK v0.6.0` |

## Change

Adds a 'Release title convention (locked)' paragraph to AGENTS.md's 'Cutting a release' section that mandates the raw tag verbatim. `docker-publish.yml` and `mcp-publish.yml` already enforce this via `gh release create --title "\$TAG"`; the convention covers the manually-created SDK releases too.

## Out of scope

The 6 historical inconsistent titles (`sdks/{node,python,go}/v0.1.x` and `sdks/go/v0.6.0`) were renamed out-of-band via `gh release edit --title` immediately before this PR was opened, so the live release list already matches the locked convention.