### PR TITLE
ci: add CodeQL workflow for Go + Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,65 @@
+# CodeQL static analysis for Go and GitHub Actions workflows.
+# Filed as part of the #295 quick-win backlog. Job names ('Analyze (go)' /
+# 'Analyze (actions)') are reserved for the default-branch trend view in
+# the Security tab — do not rename without retraining branch protection.
+
+name: CodeQL
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    # Weekly Monday 06:00 UTC sweep so a stale main still gets a fresh
+    # baseline even when no PRs land.
+    - cron: "0 6 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.4"
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # 'security-extended' adds higher-precision queries beyond the
+          # default suite. 'security-and-quality' would also pull in
+          # maintainability rules — out of scope for a security baseline.
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Second quick-win from #295: add CodeQL static analysis.

## What

[`.github/workflows/codeql.yml`](.github/workflows/codeql.yml) runs CodeQL across two languages:

| Language | Build mode | Why |
|---|---|---|
| go | autobuild | Static-analysis baseline for the 6-module workspace. `go build ./...` via go.work is sufficient. |
| actions | none | Catches expression-injection / unsafe-untrusted-input patterns in the workflow YAMLs themselves. Particularly valuable now that Dependabot's `github-actions` ecosystem covers every workflow file (#294 / #297) and can silently bump action versions. |

Triggers: push to main, every PR, and a weekly Monday 06:00 UTC sweep.

Query pack: `security-extended` — higher-precision security queries beyond the default; deliberately not `security-and-quality` (the latter folds in maintainability noise that we don't need on top of golangci-lint).

## Note for future

Job names `Analyze (go)` / `Analyze (actions)` are the trend identifiers in the Security tab — don't rename without retraining branch protection if anyone makes them required.

## Out of scope

Not adding CodeQL as a required check on `main` in this PR — let it run a few times first to confirm the autobuild step works cleanly on the workspace before gating PRs on it.

Refs #295.