### PR TITLE
ci: add sdks/go tag-verify workflow (refs #295)

### DIFF
--- a/.github/workflows/sdks-go-publish.yml
+++ b/.github/workflows/sdks-go-publish.yml
@@ -1,0 +1,75 @@
+# Tag-triggered verification + release notes for the Go client SDK.
+# The Go module ecosystem pulls source directly from VCS — there is no
+# artifact to push — but a `sdks/go/vX.Y.Z` tag bypasses the regular
+# Go CI run, so without this workflow we could index a broken tag on
+# pkg.go.dev. This mirrors the verify+release-notes pattern in
+# `mcp-publish.yml` (sans the Docker push).
+#
+# Per AGENTS.md "Release title convention (locked)": title MUST equal
+# the raw tag name verbatim.
+
+name: SDKs/Go Release
+
+on:
+  push:
+    tags: ['sdks/go/v*.*.*']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify (build + test)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.4'
+          check-latest: true
+      - name: Vet
+        run: (cd sdks/go && go vet ./...)
+      - name: Build
+        run: (cd sdks/go && go build -v ./...)
+      - name: Test
+        run: (cd sdks/go && go test -race -shuffle=on ./...)
+
+  release:
+    name: Publish GitHub Release
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG#sdks/go/}"
+          notes_file=$(mktemp)
+          {
+            echo "## Lantern Go client SDK"
+            echo
+            echo "Pull with:"
+            echo
+            echo '```sh'
+            echo "go get github.com/anaregdesign/lantern/sdks/go@${version}"
+            echo '```'
+            echo
+            echo "Import as \`github.com/anaregdesign/lantern/sdks/go\` (package name remains \`client\`)."
+          } > "$notes_file"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --notes-file "$notes_file" --verify-tag
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes-file "$notes_file" \
+              --verify-tag
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,7 +242,13 @@ Tag order matters because each downstream module pins the upstream tag:
 
 1. `pb/vX.Y.Z`
 2. `core/vX.Y.Z`
-3. `sdks/go/vX.Y.Z`
+3. `sdks/go/vX.Y.Z` — triggers `.github/workflows/sdks-go-publish.yml`,
+   which runs vet/build/test against the tagged commit and creates a
+   GitHub Release with `--title "$TAG"` (raw-tag convention). The Go
+   module proxy pulls source directly from VCS, so there is no artifact
+   to push; the verify step exists because tag pushes do not trigger
+   the regular `Go` workflow and a broken `sdks/go/vX.Y.Z` would
+   otherwise land on pkg.go.dev unchecked.
 4. Bump the matching `require` (and any `replace`) lines in the root `go.mod`
    to the freshly-tagged versions.
 5. Root `vX.Y.Z` — triggers `docker-publish.yml` (amd64 + arm64 buildx +


### PR DESCRIPTION
Third quick-win from #295: close the parity gap where the Go client SDK has no tag-time CI.

## Problem

The Go module proxy pulls source straight from VCS when someone runs `go get github.com/anaregdesign/lantern/sdks/go@vX.Y.Z`, so a tag push **bypasses** the regular `Go` workflow (it only fires on `push:branches`). The mcp/server release flow has a `verify` job for exactly this reason ([`mcp-publish.yml#L14-L40`](.github/workflows/mcp-publish.yml#L14-L40)); the SDK didn't.

## Change

[`.github/workflows/sdks-go-publish.yml`](.github/workflows/sdks-go-publish.yml):

| Job | Steps |
|---|---|
| `verify` | `go vet ./...` + `go build -v ./...` + `go test -race -shuffle=on ./...` inside `sdks/go`. Go 1.26.4 pinned. |
| `release` | Creates or updates a GitHub Release with `--title "\$TAG"` (locked raw-tag convention) and a short `go get` snippet. Needs `verify`. |

No Docker image, no artifact push — pkg.go.dev indexes the tag from VCS automatically. The workflow exists to make sure the tagged commit actually builds + tests before that indexing happens.

## AGENTS.md

Updated step 3 of the 'Cutting a release' sequence so the next agent cutting an SDK release knows the workflow now fires and what it does.

## Out of scope

The reusable `_verify.yml` extraction from #295 — punting until we have a third release pipeline that would benefit. With just `mcp-publish.yml` + `sdks-go-publish.yml` the duplication is ~10 lines per file, not worth the indirection yet.

Refs #295.