### PR TITLE
ci: merge per-module coverage into coverage/merged.out (refs #295)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -74,6 +74,18 @@ jobs:
           # coverage.out at the repo root keeps working.
           cp coverage/root.out coverage.out
 
+      # Merge the six per-module coverage profiles into a single workspace-wide
+      # profile. `go test -coverprofile` only sees one module's packages, so
+      # merging is the only way to get a unified view across the workspace.
+      # gocovmerge is the standard tool — see https://github.com/wadey/gocovmerge.
+      # Refs #295.
+      - name: Merge per-module coverage
+        run: |
+          go install github.com/wadey/gocovmerge@latest
+          gocovmerge coverage/*.out > coverage/merged.out
+          echo "Merged coverage line count:"
+          wc -l coverage/merged.out
+
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## What

Adds a `Merge per-module coverage` step to `go.yml` Build & Test that runs `gocovmerge` across the six per-module coverage profiles (`coverage/*.out`) and writes a single workspace-wide profile to `coverage/merged.out`. Uploaded alongside the existing per-module files in the same artifact.

## Why

`go test -coverprofile` only sees one module's packages, so the per-module profiles produced by the existing 6-module sweep (`#293`) can't be consumed by tools (Codecov, Coveralls, IDE coverage views) that expect a unified profile. `gocovmerge` is the standard merge tool — single shell line.

This is item #7 from the #295 backlog ("Coverage merging across modules").

## Shape

- New step right after `Test (race + coverage, all modules)`, before the existing `Upload coverage artifact` step.
- `go install github.com/wadey/gocovmerge@latest` is pulled per run (no module bloat; cached by setup-go's module cache).
- Artifact contents grow by one file (`coverage/merged.out`); the legacy root `coverage.out` symlink is unchanged.

## Verification

Pure CI workflow change. `gofmt` etc. are no-ops here. The merge step will run on this PR's own `go.yml` invocation.

## Out of scope

- Uploading to Codecov / Coveralls — both require repo-level setup (token / GH app install). Filing as a separate issue if/when wanted.
- Failing CI on coverage drops.

Refs #295.