### PR TITLE
ci: add commitlint workflow for PR titles (refs #295)

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,57 @@
+name: Commitlint
+
+# Validates that PR titles follow the Conventional Commits format used
+# throughout this repo (feat / fix / chore / docs / ci / refactor / perf /
+# test / build / revert). Because we squash-merge every PR, the merge
+# commit subject defaults to the PR title, so enforcing the title is
+# effectively enforcing the commit log.
+#
+# Refs #295 (dev-flow improvements backlog).
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+# The action only needs to read the PR; it does not push status or
+# comments back when the title is valid.
+permissions:
+  pull-requests: read
+
+# Cancel superseded runs on the same PR — title edits can fire repeatedly.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      # Pinned to a concrete release so a future major can't silently
+      # rewrite our type list. Dependabot's github-actions ecosystem will
+      # keep this current.
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Allowed prefixes — matches what is already in the git log.
+          types: |
+            feat
+            fix
+            chore
+            docs
+            ci
+            refactor
+            perf
+            test
+            build
+            revert
+          # Scopes are optional; many one-shot fixes use a bare `ci:` or
+          # `docs:` prefix.
+          requireScope: false
+          # Subject lowercase preferred but not enforced — release titles
+          # and version bumps occasionally need capitals.
+          subjectPattern: ^.+$
+          # Don't validate individual commits in PRs that have just one
+          # commit; squash-merge collapses them anyway.
+          validateSingleCommit: false


### PR DESCRIPTION
## What

Adds `.github/workflows/commitlint.yml` — a single-job workflow that runs on `pull_request` and validates the PR title against the Conventional Commits format already used throughout this repo.

## Why

This is item #8 from the #295 backlog ("PR title / commit lint"). Every PR here is squash-merged, so the merge commit subject defaults to the PR title. Validating the title is the cheapest way to keep the commit log on `main` machine-parseable for tooling (release-notes generators, changelog scrapers, `git log --grep`).

The repo already uses these prefixes informally — formalising stops the convention from drifting.

## Shape

- Action: `amannn/action-semantic-pull-request@v6` (current major; Dependabot github-actions ecosystem will bump it).
- Allowed types: `feat` / `fix` / `chore` / `docs` / `ci` / `refactor` / `perf` / `test` / `build` / `revert`.
- Scope is **optional** — many one-shot fixes here use a bare `ci:` or `docs:` prefix.
- Subject pattern is permissive (`^.+$`) to keep release-title-style capitals legal.
- `validateSingleCommit: false` — title is the source of truth; squash-merge collapses per-commit messages anyway.
- Permissions: `pull-requests: read` only (no comment-back on green).

## Verification

This PR's own title (`ci: add commitlint workflow for PR titles (refs #295)`) is the first input the new workflow will see; if the title shape is wrong, this PR fails its own check and we fix the title before merge.

## Out of scope

- Branch protection (making the check required). Defer until we've watched a few PRs flow through clean.
- Per-commit message linting on the PR branch — squash-merge makes it noise.
- Changelog generation / release-please — separate, larger change with its own design tradeoffs.

Refs #295.