### PR TITLE
ci: extract shared verify gate into reusable _verify.yml (refs #295)

### DIFF
--- a/.github/workflows/_verify.yml
+++ b/.github/workflows/_verify.yml
@@ -1,0 +1,57 @@
+# Reusable verify gate — gofmt + vet + build + test across every Go
+# module in the workspace. Called from publish workflows so a bad tag
+# can't ship a broken release.
+#
+# Previously docker-publish.yml, mcp-publish.yml, and sdks-go-publish.yml
+# each maintained their own ad-hoc `verify` job; the bodies drifted over
+# time and only mcp-publish actually covered more than one module. This
+# workflow is now the single source of truth for the publish-side gate.
+#
+# Refs #295 (dev-flow improvements backlog).
+#
+# `go.yml` Build & Test intentionally still owns its own loop because it
+# also runs coverage + artifact upload and the job name is a branch-
+# protection required check — folding it in would risk renaming the
+# required check.
+
+name: Verify (reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.4'
+          check-latest: true
+
+      - name: Verify formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "::error::These files are not gofmt'd:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      # Per-module loop. Each module is a separate go.mod; the root
+      # `./...` does NOT recurse into core/, mcp/, pb/, sdks/go/,
+      # server/. Mirrored from go.yml.
+      - name: Vet / build / test (all modules)
+        run: |
+          set -e
+          for mod in . core mcp pb sdks/go server; do
+            echo "::group::$mod"
+            (cd "$mod" && go vet ./... && go build -v ./... && go test -race -shuffle=on ./...)
+            echo "::endgroup::"
+          done

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,22 +15,11 @@ concurrency:
 jobs:
   # Re-run the canonical CI gates on the tagged commit. Tag pushes do not
   # trigger the `Go` workflow (which is gated on branch pushes / PRs), so
-  # without this we could ship a broken image from a bad tag.
+  # without this we could ship a broken image from a bad tag. The verify
+  # job is shared with mcp-publish.yml / sdks-go-publish.yml via the
+  # reusable `_verify.yml` workflow — see #295.
   verify:
-    name: Verify (build + test)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version: '1.26.4'
-          check-latest: true
-      - name: Vet
-        run: go vet ./...
-      - name: Build
-        run: go build -v ./...
-      - name: Test
-        run: go test -race -shuffle=on ./...
+    uses: ./.github/workflows/_verify.yml
 
   build:
     needs: verify

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -15,28 +15,11 @@ concurrency:
 jobs:
   # Re-run the canonical gates against the tagged commit. Tag pushes do
   # not trigger the `Go` workflow, so without this we could ship a broken
-  # MCP image from a bad tag.
+  # MCP image from a bad tag. The verify job is shared with
+  # docker-publish.yml / sdks-go-publish.yml via the reusable
+  # `_verify.yml` workflow — see #295.
   verify:
-    name: Verify (build + test)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version: '1.26.4'
-          check-latest: true
-      - name: Vet
-        run: |
-          go vet ./...
-          (cd mcp && go vet ./...)
-      - name: Build
-        run: |
-          go build -v ./...
-          (cd mcp && go build -v ./...)
-      - name: Test
-        run: |
-          go test -race -shuffle=on ./...
-          (cd mcp && go test -race -shuffle=on ./...)
+    uses: ./.github/workflows/_verify.yml
 
   build:
     needs: verify

--- a/.github/workflows/sdks-go-publish.yml
+++ b/.github/workflows/sdks-go-publish.yml
@@ -19,22 +19,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Shared verify gate — see _verify.yml and #295. Covers all six Go
+  # modules so a bad `sdks/go/vX.Y.Z` tag can't land on pkg.go.dev even
+  # if the breakage is in an upstream module the SDK depends on.
   verify:
-    name: Verify (build + test)
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version: '1.26.4'
-          check-latest: true
-      - name: Vet
-        run: (cd sdks/go && go vet ./...)
-      - name: Build
-        run: (cd sdks/go && go build -v ./...)
-      - name: Test
-        run: (cd sdks/go && go test -race -shuffle=on ./...)
+    uses: ./.github/workflows/_verify.yml
 
   release:
     name: Publish GitHub Release


### PR DESCRIPTION
## What

Adds `.github/workflows/_verify.yml` (reusable, `workflow_call`-only) and replaces the inline `verify` jobs in `docker-publish.yml`, `mcp-publish.yml`, and `sdks-go-publish.yml` with one-line `uses:` calls. Net diff: +69 / -51.

## Why

Each publish workflow had its own hand-rolled `verify` job that ran a different subset of the canonical CI gate:

| Workflow | Modules verified before this PR |
|---|---|
| `docker-publish.yml` | root only |
| `mcp-publish.yml` | root + `mcp/` |
| `sdks-go-publish.yml` | `sdks/go/` only |

That drift defeated the purpose of the gate — a bad tag in any of the other modules (e.g. `core/` failing to compile when you push `v0.7.3`) would slip through. Item #3 of the #295 backlog.

## Shape

- New `.github/workflows/_verify.yml`: gofmt + per-module `go vet` / `go build -v` / `go test -race -shuffle=on` loop over `. core mcp pb sdks/go server` (the same loop `go.yml` Build & Test runs).
- Each publish workflow's `verify` job is now `uses: ./.github/workflows/_verify.yml` — a single line. Downstream `needs: verify` on `build` / `release` / `bench` jobs continues to work because the caller-side job ID is unchanged.

## Why not also fold go.yml's Build & Test into the reusable

`go.yml` Build & Test does additional work (coverage collection + artifact upload) on top of vet/build/test, and its job name (`Build & Test`) is a branch-protection required check. Refactoring it via `uses:` would risk renaming the required check to something like `Build & Test / Verify`. Punted: see the comment at the top of `_verify.yml`.

## Verification

Pure YAML refactor; no Go code touched. Cannot fully validate until a tag push fires, but `workflow_call` syntax is well-established and the called workflow runs the same loop already shipping in production via `go.yml`.

Refs #295.