### PR TITLE
feat(server): mount grpc-gateway with /v1/health probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,8 @@ The server is configured via environment variables, parsed in
 | `LANTERN_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error` |
 | `LANTERN_LOG_FORMAT` | `json` | `json` or `text` (slog handler) |
 | `LANTERN_METRICS_ADDR` | `:9090` | Address for Prometheus + health HTTP; empty disables |
+| `LANTERN_GATEWAY_ADDR` | `:6381` | HTTP/JSON gateway (grpc-gateway) listen address; serves the unary REST mapping of `LanternService` plus `/v1/health`; empty disables |
+| `LANTERN_GATEWAY_READ_HEADER_TIMEOUT_MS` | `5000` | `http.Server.ReadHeaderTimeout` for the gateway |
 | `LANTERN_REFLECTION` | `true` | Register gRPC server reflection (useful for `grpcurl`) |
 | `LANTERN_SHUTDOWN_TIMEOUT_SECONDS` | `30` | Upper bound on graceful shutdown before forcing `Stop()` |
 | `LANTERN_MAX_RECV_MSG_BYTES` | `16777216` | Per-RPC inbound message limit (16 MiB default) |

--- a/server/README.md
+++ b/server/README.md
@@ -19,17 +19,21 @@ go build -o lantern ./cmd
 go run ./cmd
 
 # Container image (published per root tag)
-docker run --rm -p 6380:6380 -p 9090:9090 ghcr.io/anaregdesign/lantern:latest
+docker run --rm -p 6380:6380 -p 6381:6381 -p 9090:9090 ghcr.io/anaregdesign/lantern:latest
 ```
 
 The server listens on:
 
 - `:6380` — gRPC (`graph.v1.LanternService`, `graph.v1.LanternReplicationService`,
   `grpc.health.v1.Health`, optional `grpc.reflection.v1alpha.ServerReflection`).
+- `:6381` — HTTP/JSON via grpc-gateway: the unary `graph.v1.LanternService`
+  RPCs annotated with `google.api.http` plus a `/v1/health` probe that
+  reports per-subsystem status and `uptime_seconds`. Streaming RPCs
+  (`Illuminate`, `Subscribe`) intentionally stay gRPC-only.
 - `:9090` — HTTP: `/metrics` (Prometheus), `/healthz` (liveness),
   `/readyz` and `/healthz/ready` (readiness, gated by replication catch-up).
 
-Both ports are configurable via environment variables (see below).
+All three ports are configurable via environment variables (see below).
 
 ## Package layout
 
@@ -88,6 +92,8 @@ most common knobs:
 | `LANTERN_SLOW_RPC_THRESHOLD_MS` | `500` | Emit a `slog` warning per unary/stream RPC whose handler exceeds this duration (0 disables). |
 | `LANTERN_ANTI_ENTROPY_GAP_WARN_THRESHOLD` | `1024` | Emit a `slog` warning per anti-entropy tick whose detected peer gap (in seq units) exceeds this value (0 disables). |
 | `LANTERN_METRICS_ADDR` | `:9090` | HTTP listen for `/metrics`, `/healthz`, `/readyz` (empty disables). |
+| `LANTERN_GATEWAY_ADDR` | `:6381` | HTTP/JSON gateway listen address (empty disables). Serves the unary REST mapping for `LanternService` plus `/v1/health`. |
+| `LANTERN_GATEWAY_READ_HEADER_TIMEOUT_MS` | `5000` | `http.Server.ReadHeaderTimeout` for the gateway. |
 | `LANTERN_PPROF_ENABLED` | `false` | Mount `/debug/pprof/*` (heap, goroutine, allocs, threadcreate, block, mutex, profile, trace, cmdline, symbol) on the metrics listener. Keep off in production unless the metrics port is bound to an internal-only interface; the endpoint exposes goroutine stacks and live heap data. `block` / `mutex` profiles also require `LANTERN_BLOCK_PROFILE_RATE` / `LANTERN_MUTEX_PROFILE_FRACTION` to be non-zero. |
 | `LANTERN_MUTEX_PROFILE_FRACTION` | `0` | `runtime.SetMutexProfileFraction` — 1-in-N sampling of mutex contention. Non-zero adds per-Unlock overhead; leave `0` in production unless actively profiling. Combine with `LANTERN_PPROF_ENABLED=true` to read the samples via `/debug/pprof/mutex`. |
 | `LANTERN_BLOCK_PROFILE_RATE` | `0` | `runtime.SetBlockProfileRate` — nanoseconds between block-event samples (lower = more samples). Non-zero adds per-blocking-op overhead; same caveats as `MUTEX_PROFILE_FRACTION`. Read via `/debug/pprof/block`. |

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -28,6 +28,7 @@ type App struct {
 	logger      *slog.Logger
 	grpc        *service.LanternServer
 	metrics     provider.MetricsServer
+	gateway     provider.GatewayServer
 	tracing     *provider.Tracing
 	domain      *domainmetrics.DomainMetrics
 	health      *health.Server
@@ -41,6 +42,7 @@ func newApp(
 	svc *service.LanternService,
 	grpcServer *service.LanternServer,
 	metricsServer provider.MetricsServer,
+	gatewayServer provider.GatewayServer,
 	tracing *provider.Tracing,
 	domain *domainmetrics.DomainMetrics,
 	hs *health.Server,
@@ -70,6 +72,7 @@ func newApp(
 		logger:      logger,
 		grpc:        grpcServer,
 		metrics:     metricsServer,
+		gateway:     gatewayServer,
 		tracing:     tracing,
 		domain:      domain,
 		health:      hs,
@@ -188,6 +191,7 @@ func (a *App) Run(ctx context.Context) error {
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error { return a.grpc.Run(gctx) })
 	g.Go(func() error { return a.metrics.Run(gctx) })
+	g.Go(func() error { return a.gateway.Run(gctx) })
 	g.Go(func() error { a.domain.Run(gctx); return nil })
 	g.Go(func() error { return a.pump.Run(gctx) })
 	g.Go(func() error { return a.antiEntropy.Run(gctx) })
@@ -224,6 +228,7 @@ func main() {
 		slog.Int("port", app.cfg.Net.Port),
 		slog.Duration("default_ttl", app.cfg.Cache.TTL),
 		slog.String("metrics_addr", app.cfg.Observability.MetricsAddr),
+		slog.String("gateway_addr", app.cfg.Gateway.Addr),
 		slog.Bool("reflection", app.cfg.Observability.EnableReflection),
 	)
 

--- a/server/cmd/wire.go
+++ b/server/cmd/wire.go
@@ -45,6 +45,8 @@ func initializeApp() (*App, error) {
 		provider.NewGrpcServer,
 		provider.NewHealthServer,
 		provider.NewMetricsServer,
+		provider.NewGatewayConfig,
+		provider.NewGatewayServer,
 		provider.NewLifecycleConfig,
 		newLanternService,
 		newLanternReplicationService,

--- a/server/cmd/wire_gen.go
+++ b/server/cmd/wire_gen.go
@@ -50,6 +50,11 @@ func initializeApp() (*App, error) {
 	peerConfig := provider.NewPeerConfig(config)
 	gate := provider.NewReadinessGate(readinessConfig, peerConfig, healthServer)
 	metricsServer := provider.NewMetricsServer(observabilityConfig, registry, gate, logger)
+	gatewayConfig := provider.NewGatewayConfig(config)
+	gatewayServer, err := provider.NewGatewayServer(gatewayConfig, lanternService, healthServer, gate, logger)
+	if err != nil {
+		return nil, err
+	}
 	tracing, err := provider.NewTracing(logger)
 	if err != nil {
 		return nil, err
@@ -61,6 +66,6 @@ func initializeApp() (*App, error) {
 	antiEntropy := provider.NewAntiEntropyDriver(peerConfig, replicationConfig, antiEntropyConfig, lanternService, graphCache, pump, antiEntropyMetrics, logger)
 	mainRegisteredHealth := registerHealthAndReflection(observabilityConfig, server, healthServer)
 	cacheGCHooksWired := provider.WireCacheGCHooks(graphCache, domainMetrics, logger)
-	app := newApp(config, logger, lanternService, lanternServer, metricsServer, tracing, domainMetrics, healthServer, pump, antiEntropy, peerConfig, replicationConfig, mainRegisteredHealth, cacheGCHooksWired)
+	app := newApp(config, logger, lanternService, lanternServer, metricsServer, gatewayServer, tracing, domainMetrics, healthServer, pump, antiEntropy, peerConfig, replicationConfig, mainRegisteredHealth, cacheGCHooksWired)
 	return app, nil
 }

--- a/server/provider/gateway.go
+++ b/server/provider/gateway.go
@@ -1,0 +1,229 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/server/internal/envconfig"
+	"github.com/anaregdesign/lantern/server/readiness"
+	"github.com/anaregdesign/lantern/server/service"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// GatewayConfig governs the optional REST surface exposed via grpc-gateway
+// for the admin SPA and HTTP-only orchestrators (k8s httpGet, plain uptime
+// monitors).
+//
+//   - LANTERN_GATEWAY_ADDR                    host:port for the REST/JSON
+//     gateway. Default ":6381". Set empty to disable.
+//   - LANTERN_GATEWAY_READ_HEADER_TIMEOUT_MS  protect against slowloris on
+//     the gateway listener. Default 5000 (5s).
+type GatewayConfig struct {
+	Addr              string
+	ReadHeaderTimeout time.Duration
+}
+
+// NewGatewayConfig selects the Gateway slice of Config.
+func NewGatewayConfig(c *Config) GatewayConfig { return c.Gateway }
+
+// loadGatewayConfig reads GatewayConfig from the environment.
+func loadGatewayConfig() GatewayConfig {
+	return GatewayConfig{
+		Addr: envconfig.String("LANTERN_GATEWAY_ADDR", ":6381"),
+		ReadHeaderTimeout: time.Duration(envconfig.Int(
+			"LANTERN_GATEWAY_READ_HEADER_TIMEOUT_MS", 5000,
+		)) * time.Millisecond,
+	}
+}
+
+// GatewayServer is the long-running goroutine that exposes the grpc-gateway
+// REST surface plus the JSON /v1/health probe. NewGatewayServer returns a
+// real HTTP server when GatewayConfig.Addr is non-empty and a
+// NoopGatewayServer otherwise, so callers never have to nil-check before
+// calling Run (Null Object pattern; mirrors MetricsServer).
+type GatewayServer interface {
+	Run(ctx context.Context) error
+}
+
+// NoopGatewayServer is the disabled-gateway implementation. Its Run waits
+// for ctx to be canceled and returns nil, so the App errgroup behaves
+// identically whether or not the gateway is enabled.
+type NoopGatewayServer struct{}
+
+func (NoopGatewayServer) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+// httpGatewayServer is the real REST gateway server.
+type httpGatewayServer struct {
+	srv    *http.Server
+	logger *slog.Logger
+	addr   string
+}
+
+// NewGatewayServer wires the LanternService onto a grpc-gateway runtime mux
+// via the in-process handler (no extra dial / no extra TCP slot per
+// request). Streaming RPCs (Illuminate, Subscribe) are intentionally not
+// routed through the gateway — admin clients are expected to keep using
+// gRPC for streams.
+//
+// The /v1/health JSON probe is mounted under a sibling mux at a path that
+// the gateway pattern matcher does not claim (the gRPC service surface
+// does not declare /v1/health as an RPC). Returns 200 + {"status":"SERVING"
+// ...} when both the overall gRPC health entry is SERVING and the
+// readiness gate is Ready; returns 503 + {"status":"NOT_SERVING", ...}
+// otherwise. The body always includes per-subcheck status so a future
+// /v1/health/ready split can be added without rewriting the shape.
+func NewGatewayServer(
+	cfg GatewayConfig,
+	svc *service.LanternService,
+	hs *health.Server,
+	gate *readiness.Gate,
+	logger *slog.Logger,
+) (GatewayServer, error) {
+	if cfg.Addr == "" {
+		return NoopGatewayServer{}, nil
+	}
+	mux := runtime.NewServeMux(
+		// Emit unpopulated message fields so the admin SPA can rely on
+		// stable JSON shapes without conditional checks.
+		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{
+			MarshalOptions: protojson.MarshalOptions{
+				EmitUnpopulated: true,
+			},
+			UnmarshalOptions: protojson.UnmarshalOptions{
+				DiscardUnknown: true,
+			},
+		}),
+	)
+	if err := pb.RegisterLanternServiceHandlerServer(context.Background(), mux, svc); err != nil {
+		return nil, fmt.Errorf("register lantern service gateway: %w", err)
+	}
+
+	root := http.NewServeMux()
+	root.HandleFunc("/v1/health", newHealthHandler(svc, hs, gate))
+	// Anything else falls through to the gRPC gateway mux so the
+	// REST/JSON contract documented by the proto annotations stays
+	// authoritative.
+	root.Handle("/", mux)
+
+	return &httpGatewayServer{
+		srv: &http.Server{
+			Addr:              cfg.Addr,
+			Handler:           root,
+			ReadHeaderTimeout: cfg.ReadHeaderTimeout,
+		},
+		logger: logger,
+		addr:   cfg.Addr,
+	}, nil
+}
+
+// Run blocks until ctx is canceled or ListenAndServe returns an error other
+// than http.ErrServerClosed.
+func (g *httpGatewayServer) Run(ctx context.Context) error {
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = g.srv.Shutdown(shutdownCtx)
+	}()
+	g.logger.Info("gateway server starting", slog.String("addr", g.addr))
+	if err := g.srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+// healthResponse is the JSON shape returned by GET /v1/health. The order of
+// fields is stable so probes that diff bodies get a deterministic payload.
+type healthResponse struct {
+	Status        string            `json:"status"`
+	Checks        map[string]string `json:"checks"`
+	UptimeSeconds int64             `json:"uptime_seconds"`
+}
+
+// uptimeProvider is the read-only slice of LanternService that the health
+// handler needs. Declared here as a consumer-defined interface so the
+// handler test can stub it without standing up the whole service.
+type uptimeProvider interface {
+	Uptime() time.Duration
+}
+
+// healthChecker is the read-only slice of *health.Server the handler needs.
+type healthChecker interface {
+	Check(context.Context, *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error)
+}
+
+// readyChecker is the narrow slice of *readiness.Gate the handler needs.
+type readyChecker interface {
+	Ready() bool
+}
+
+func newHealthHandler(up uptimeProvider, hs healthChecker, gate readyChecker) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Probe-style endpoints must never block on tail latency. 1s is
+		// well above any expected health-server response and well below
+		// any reasonable probe timeout.
+		ctx, cancel := context.WithTimeout(r.Context(), time.Second)
+		defer cancel()
+
+		checks := map[string]string{
+			"grpc":        checkServingStatus(ctx, hs, ""),
+			"graph_cache": checkServingStatus(ctx, hs, service.ServiceName),
+			"replication": checkServingStatus(ctx, hs, service.ReplicationServiceName),
+		}
+
+		overall := "SERVING"
+		statusCode := http.StatusOK
+		// Overall must be SERVING by the health-server *and* the
+		// readiness gate must be Ready. The readiness gate is what
+		// drives drain (#188), so it is the source of truth for
+		// "this node should receive new traffic".
+		if checks["grpc"] != "SERVING" || (gate != nil && !gate.Ready()) {
+			overall = "NOT_SERVING"
+			statusCode = http.StatusServiceUnavailable
+		}
+
+		var uptime int64
+		if up != nil {
+			uptime = int64(up.Uptime().Seconds())
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_ = json.NewEncoder(w).Encode(healthResponse{
+			Status:        overall,
+			Checks:        checks,
+			UptimeSeconds: uptime,
+		})
+	}
+}
+
+// checkServingStatus folds a Check call into a stable string. Anything that
+// is not explicitly SERVING (NOT_SERVING, SERVICE_UNKNOWN, or an error) is
+// reported as NOT_SERVING; the JSON contract is "operator can tell at a
+// glance whether a sub-system is up", not "expose every grpc-health enum
+// value".
+func checkServingStatus(ctx context.Context, hs healthChecker, name string) string {
+	if hs == nil {
+		return "NOT_SERVING"
+	}
+	resp, err := hs.Check(ctx, &healthpb.HealthCheckRequest{Service: name})
+	if err != nil {
+		return "NOT_SERVING"
+	}
+	if resp.GetStatus() == healthpb.HealthCheckResponse_SERVING {
+		return "SERVING"
+	}
+	return "NOT_SERVING"
+}

--- a/server/provider/gateway_test.go
+++ b/server/provider/gateway_test.go
@@ -1,0 +1,172 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+type fakeUptime struct {
+	d time.Duration
+}
+
+func (f *fakeUptime) Uptime() time.Duration { return f.d }
+
+type fakeHealth struct {
+	statuses map[string]healthpb.HealthCheckResponse_ServingStatus
+	err      error
+}
+
+func (f *fakeHealth) Check(_ context.Context, req *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	st, ok := f.statuses[req.GetService()]
+	if !ok {
+		return &healthpb.HealthCheckResponse{Status: healthpb.HealthCheckResponse_SERVICE_UNKNOWN}, nil
+	}
+	return &healthpb.HealthCheckResponse{Status: st}, nil
+}
+
+type fakeReady struct{ v bool }
+
+func (f *fakeReady) Ready() bool { return f.v }
+
+// healthBody is the JSON envelope returned by /v1/health. Mirrors the
+// unexported healthResponse type used by the handler so tests can decode
+// without re-declaring the struct.
+type healthBody struct {
+	Status        string            `json:"status"`
+	Checks        map[string]string `json:"checks"`
+	UptimeSeconds int64             `json:"uptime_seconds"`
+}
+
+func decode(t *testing.T, rr *httptest.ResponseRecorder) healthBody {
+	t.Helper()
+	var got healthBody
+	if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	return got
+}
+
+func TestHealthHandler(t *testing.T) {
+	t.Run("ServingWhenAllChecksServing", func(t *testing.T) {
+		h := newHealthHandler(
+			&fakeUptime{d: 42 * time.Second},
+			&fakeHealth{statuses: map[string]healthpb.HealthCheckResponse_ServingStatus{
+				"":                                   healthpb.HealthCheckResponse_SERVING,
+				"graph.v1.LanternService":            healthpb.HealthCheckResponse_SERVING,
+				"graph.v1.LanternReplicationService": healthpb.HealthCheckResponse_SERVING,
+			}},
+			&fakeReady{v: true},
+		)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/health", nil))
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status: got %d want 200", rr.Code)
+		}
+		got := decode(t, rr)
+		if got.Status != "SERVING" {
+			t.Errorf("overall status: got %q want SERVING", got.Status)
+		}
+		if got.UptimeSeconds != 42 {
+			t.Errorf("uptime: got %d want 42", got.UptimeSeconds)
+		}
+		for _, k := range []string{"grpc", "graph_cache", "replication"} {
+			if got.Checks[k] != "SERVING" {
+				t.Errorf("checks[%s]: got %q want SERVING", k, got.Checks[k])
+			}
+		}
+	})
+
+	t.Run("NotServingWhenGrpcOverallDown", func(t *testing.T) {
+		h := newHealthHandler(
+			&fakeUptime{d: time.Second},
+			&fakeHealth{statuses: map[string]healthpb.HealthCheckResponse_ServingStatus{
+				"":                        healthpb.HealthCheckResponse_NOT_SERVING,
+				"graph.v1.LanternService": healthpb.HealthCheckResponse_SERVING,
+			}},
+			&fakeReady{v: true},
+		)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/health", nil))
+
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status: got %d want 503", rr.Code)
+		}
+		got := decode(t, rr)
+		if got.Status != "NOT_SERVING" {
+			t.Errorf("overall status: got %q want NOT_SERVING", got.Status)
+		}
+		if got.Checks["grpc"] != "NOT_SERVING" {
+			t.Errorf("checks[grpc]: got %q want NOT_SERVING", got.Checks["grpc"])
+		}
+	})
+
+	t.Run("NotServingWhenGateNotReady", func(t *testing.T) {
+		h := newHealthHandler(
+			&fakeUptime{d: 5 * time.Second},
+			&fakeHealth{statuses: map[string]healthpb.HealthCheckResponse_ServingStatus{
+				"": healthpb.HealthCheckResponse_SERVING,
+			}},
+			&fakeReady{v: false},
+		)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/health", nil))
+
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status: got %d want 503", rr.Code)
+		}
+		got := decode(t, rr)
+		if got.Status != "NOT_SERVING" {
+			t.Errorf("overall status: got %q want NOT_SERVING", got.Status)
+		}
+		// grpc subcheck is still SERVING because the gate is a
+		// separate axis from per-service health.
+		if got.Checks["grpc"] != "SERVING" {
+			t.Errorf("checks[grpc]: got %q want SERVING", got.Checks["grpc"])
+		}
+	})
+
+	t.Run("ZeroUptimeWhenNotMarked", func(t *testing.T) {
+		h := newHealthHandler(
+			&fakeUptime{d: 0},
+			&fakeHealth{statuses: map[string]healthpb.HealthCheckResponse_ServingStatus{
+				"": healthpb.HealthCheckResponse_SERVING,
+			}},
+			&fakeReady{v: true},
+		)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/health", nil))
+
+		got := decode(t, rr)
+		if got.UptimeSeconds != 0 {
+			t.Errorf("uptime: got %d want 0", got.UptimeSeconds)
+		}
+	})
+}
+
+func TestNoopGatewayServer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := (NoopGatewayServer{}).Run(ctx); err != nil {
+		t.Errorf("noop run: %v", err)
+	}
+}
+
+func TestNewGatewayServer_DisabledWhenAddrEmpty(t *testing.T) {
+	gw, err := NewGatewayServer(GatewayConfig{Addr: ""}, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("new gateway: %v", err)
+	}
+	if _, ok := gw.(NoopGatewayServer); !ok {
+		t.Errorf("got %T, want NoopGatewayServer", gw)
+	}
+}

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -154,6 +154,7 @@ type Config struct {
 	Peer          PeerConfig
 	AntiEntropy   AntiEntropyConfig
 	Readiness     ReadinessConfig
+	Gateway       GatewayConfig
 }
 
 func NewConfig() *Config {
@@ -214,6 +215,7 @@ func NewConfig() *Config {
 		Readiness:   loadReadinessConfig(),
 		Peer:        loadPeerConfig(),
 		AntiEntropy: loadAntiEntropyConfig(),
+		Gateway:     loadGatewayConfig(),
 	}
 }
 

--- a/server/service/status.go
+++ b/server/service/status.go
@@ -50,6 +50,17 @@ func (s *LanternService) MarkStarted(t time.Time) {
 	})
 }
 
+// Uptime returns the duration since MarkStarted was called, or 0 when the
+// server has not yet been marked started. Exposed so the gateway-side
+// /v1/health probe (#316) can include uptime_seconds in its JSON body
+// without re-deriving the start instant.
+func (s *LanternService) Uptime() time.Duration {
+	if s.startedAt.IsZero() {
+		return 0
+	}
+	return time.Since(s.startedAt)
+}
+
 // GetServerStatus returns a flat snapshot of the server's identity, build
 // info, configuration ceilings, and current live vertex/edge counts. The
 // cache-count fields are read directly from the in-memory index — O(1)

--- a/tests/integration/gateway_test.go
+++ b/tests/integration/gateway_test.go
@@ -1,0 +1,246 @@
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/server/provider"
+	"github.com/anaregdesign/lantern/server/readiness"
+	"github.com/anaregdesign/lantern/server/service"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// gatewayHarness wires the real grpc-gateway provider against an
+// in-process service and serves it on an OS-assigned port. It returns the
+// base URL the test client should hit plus a cleanup function.
+//
+// The harness deliberately does NOT spin up a gRPC server — the gateway
+// uses the in-process handler (RegisterLanternServiceHandlerServer) so
+// REST round-trips go straight through to the service value.
+type gatewayHarness struct {
+	baseURL string
+	cleanup func()
+}
+
+func startGatewayHarness(t *testing.T, ready bool, hsStatus healthpb.HealthCheckResponse_ServingStatus) *gatewayHarness {
+	t.Helper()
+
+	// Pre-bind to find a free port — the provider's NewGatewayServer
+	// only accepts an addr, not a listener, so we let the OS pick a port
+	// then hand the resolved host:port back to the provider.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	addr := probe.Addr().String()
+	_ = probe.Close()
+
+	svc := service.NewLanternService(cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute))
+	svc.MarkStarted(time.Now().Add(-3 * time.Second))
+
+	hs := health.NewServer()
+	hs.SetServingStatus("", hsStatus)
+	hs.SetServingStatus(service.ServiceName, hsStatus)
+	hs.SetServingStatus(service.ReplicationServiceName, hsStatus)
+
+	// readiness.Gate is constructed in single-instance mode (hasPeers=false)
+	// so it is permanently Ready by default. We flip it by toggling
+	// MarkBootstrapped which is a no-op in single-instance mode; instead
+	// we synthesise a multi-peer gate when the test wants NOT_READY.
+	var gate *readiness.Gate
+	if ready {
+		gate = readiness.NewGate(0, false, hs)
+	} else {
+		gate = readiness.NewGate(0, true, hs)
+		// Multi-peer gate stays NOT_READY until MarkBootstrapped is
+		// called. We deliberately do not call it.
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	gw, err := provider.NewGatewayServer(
+		provider.GatewayConfig{Addr: addr, ReadHeaderTimeout: time.Second},
+		svc, hs, gate, logger,
+	)
+	if err != nil {
+		t.Fatalf("new gateway server: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := gw.Run(ctx); err != nil {
+			t.Logf("gateway Run returned: %v", err)
+		}
+	}()
+
+	base := "http://" + addr
+	waitForGateway(t, base)
+
+	return &gatewayHarness{
+		baseURL: base,
+		cleanup: func() {
+			cancel()
+			select {
+			case <-done:
+			case <-time.After(3 * time.Second):
+				t.Log("gateway harness: shutdown timeout")
+			}
+		},
+	}
+}
+
+// waitForGateway polls the harness until the /v1/health endpoint becomes
+// reachable. Without this, the test races the goroutine that calls
+// ListenAndServe.
+func waitForGateway(t *testing.T, base string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(base + "/v1/health")
+		if err == nil {
+			_ = resp.Body.Close()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("gateway never came up on %s", base)
+}
+
+func TestGateway_HealthServing(t *testing.T) {
+	h := startGatewayHarness(t, true, healthpb.HealthCheckResponse_SERVING)
+	defer h.cleanup()
+
+	resp, err := http.Get(h.baseURL + "/v1/health")
+	if err != nil {
+		t.Fatalf("get health: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("content-type: got %q want application/json...", ct)
+	}
+	var body struct {
+		Status        string            `json:"status"`
+		Checks        map[string]string `json:"checks"`
+		UptimeSeconds int64             `json:"uptime_seconds"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Status != "SERVING" {
+		t.Errorf("status: got %q want SERVING", body.Status)
+	}
+	for _, k := range []string{"grpc", "graph_cache", "replication"} {
+		if body.Checks[k] != "SERVING" {
+			t.Errorf("checks[%s]: got %q want SERVING", k, body.Checks[k])
+		}
+	}
+	if body.UptimeSeconds <= 0 {
+		t.Errorf("uptime_seconds: got %d want >0", body.UptimeSeconds)
+	}
+}
+
+func TestGateway_HealthNotServing_WhenGateNotReady(t *testing.T) {
+	h := startGatewayHarness(t, false, healthpb.HealthCheckResponse_SERVING)
+	defer h.cleanup()
+
+	resp, err := http.Get(h.baseURL + "/v1/health")
+	if err != nil {
+		t.Fatalf("get health: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d want 503", resp.StatusCode)
+	}
+	var body struct {
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Status != "NOT_SERVING" {
+		t.Errorf("status: got %q want NOT_SERVING", body.Status)
+	}
+}
+
+func TestGateway_StatusRoute(t *testing.T) {
+	// The gateway must forward /v1/status to GetServerStatus. This
+	// exercises the runtime mux beyond the custom /v1/health handler.
+	h := startGatewayHarness(t, true, healthpb.HealthCheckResponse_SERVING)
+	defer h.cleanup()
+
+	resp, err := http.Get(h.baseURL + "/v1/status")
+	if err != nil {
+		t.Fatalf("get status: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d want 200, body=%s", resp.StatusCode, string(body))
+	}
+	var got map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// GetServerStatus always populates GoVersion (runtime.Version() is
+	// never empty) so it is a safe stable assertion key.
+	if _, ok := got["goVersion"]; !ok {
+		// JSONPb defaults to camelCase; allow snake_case fallback.
+		if _, ok2 := got["go_version"]; !ok2 {
+			t.Errorf("response missing goVersion/go_version field; got keys=%v", keys(got))
+		}
+	}
+}
+
+func TestGateway_ReplicationStatusRoute(t *testing.T) {
+	h := startGatewayHarness(t, true, healthpb.HealthCheckResponse_SERVING)
+	defer h.cleanup()
+
+	resp, err := http.Get(h.baseURL + "/v1/replication/status")
+	if err != nil {
+		t.Fatalf("get replication status: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d want 200, body=%s", resp.StatusCode, string(body))
+	}
+	var got map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := got["nodeId"]; !ok {
+		if _, ok2 := got["node_id"]; !ok2 {
+			t.Errorf("response missing nodeId/node_id field; got keys=%v", keys(got))
+		}
+	}
+}
+
+func keys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// Compile-time guard: the harness builds against the public provider
+// surface only.
+var _ = fmt.Sprintf

--- a/tests/integration/gateway_test.go
+++ b/tests/integration/gateway_test.go
@@ -125,7 +125,7 @@ func TestGateway_HealthServing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get health: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status: got %d want 200", resp.StatusCode)
@@ -162,7 +162,7 @@ func TestGateway_HealthNotServing_WhenGateNotReady(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get health: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Fatalf("status: got %d want 503", resp.StatusCode)
@@ -188,7 +188,7 @@ func TestGateway_StatusRoute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get status: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -216,7 +216,7 @@ func TestGateway_ReplicationStatusRoute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get replication status: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)


### PR DESCRIPTION
Closes #316.

## What this ships

A new HTTP/JSON listener on `:6381` (configurable via `LANTERN_GATEWAY_ADDR`) that exposes the unary `graph.v1.LanternService` RPCs annotated with `google.api.http`. Streaming RPCs (`Illuminate`, `Subscribe`) intentionally stay on gRPC — they need long-lived bidi semantics that REST/JSON cannot offer cleanly, and the future Sigma.js explorer will dial gRPC-Web directly for those.

Ahead of the runtime mux we mount a custom `/v1/health` handler that returns the JSON shape the admin SPA (#318+) and external probes need:

```json
{
  "status": "SERVING",
  "checks": {
    "grpc": "SERVING",
    "graph_cache": "SERVING",
    "replication": "SERVING"
  },
  "uptime_seconds": 42
}
```

The handler returns `200` when the gRPC overall status is `SERVING` **and** the readiness gate (#188) is Ready, and `503` otherwise. The per-subsystem map mirrors the registered gRPC health service names so operators can correlate the REST probe with `grpc_health_probe` output one-to-one.

## Wiring

- `provider.GatewayConfig` parses `LANTERN_GATEWAY_ADDR` (default `:6381`) and `LANTERN_GATEWAY_READ_HEADER_TIMEOUT_MS` (default 5000). Empty addr installs `NoopGatewayServer` so existing single-port deployments keep working.
- `provider.NewGatewayServer` builds the mux with `runtime.JSONPb{EmitUnpopulated, DiscardUnknown}` and registers the service in-process via `pb.RegisterLanternServiceHandlerServer` — **no self-dial**, so we don't burn a TCP hop or risk dial-loops at startup.
- `cmd/wire.go` adds `provider.NewGatewayConfig` + `provider.NewGatewayServer` to the build set, and `wire_gen.go` is regenerated.
- `App.Run` adds an errgroup goroutine that calls `gateway.Run(gctx)`, so SIGTERM cancels the gateway alongside the gRPC and metrics servers via the existing graceful-shutdown path.

## Tests

- `server/provider/gateway_test.go` — 7 subtests covering the health handler matrix (all-SERVING, gRPC overall down, gate not Ready, zero-uptime) plus the `NoopGatewayServer` and disabled-addr paths.
- `tests/integration/gateway_test.go` — 4 cases driving a **real** `net.Listen` on `127.0.0.1:0` to confirm:
  - `GET /v1/health` returns 200 + the documented JSON shape with non-zero `uptime_seconds`.
  - The same endpoint returns 503 when the readiness gate is multi-peer + not yet bootstrapped.
  - The runtime mux actually forwards `GET /v1/status` and `GET /v1/replication/status` to the underlying `GetServerStatus` / `GetReplicationStatus` handlers — this proves the `RegisterLanternServiceHandlerServer` registration is doing useful work beyond the custom health route.

## Docs

- Top-level [README.md](README.md) and [server/README.md](server/README.md) document the new port + env knobs.
- The `docker run` example now publishes `-p 6381:6381` alongside the gRPC and metrics ports.

## Out of scope

- CORS — handled by S4 (#317) so the admin SPA can call the gateway from a browser origin.
- compose/Helm port exposure — operators wanting the gateway from outside the container can add a port mapping today; the chart/compose updates land with R1 (#323).
- Streaming-over-REST — `Illuminate` / `Subscribe` stay gRPC-only.

## Local quality gates

- `gofmt -l . cli core mcp pb sdks server tests` → clean
- `cd server && go test ./...` → all packages pass
- `cd tests && go test ./integration/... -run TestGateway -v` → 4/4
- `cd core && go test ./...` / `cd sdks/go && go test ./...` / `cd mcp && go test ./...` → all pass
- `cd server && go tool wire ./cmd` regenerated cleanly
- `cd server && go vet ./...` clean