### PR TITLE
feat(admin): vertex/edge CRUD pages (F3 #320)

### DIFF
--- a/admin/app/components/browse-edges/BrowseEdgesPage/BrowseEdgesPage.tsx
+++ b/admin/app/components/browse-edges/BrowseEdgesPage/BrowseEdgesPage.tsx
@@ -16,6 +16,7 @@ import {
 } from "@fluentui/react-components";
 import {
   ArrowClockwise20Regular,
+  Edit20Regular,
   LightbulbFilament20Regular,
 } from "@fluentui/react-icons";
 import { Link, useNavigate } from "react-router";
@@ -151,6 +152,20 @@ export function BrowseEdgesPage() {
                     <ExpirationCell expiration={edge.expiration} />
                   </TableCell>
                   <TableCell className={styles.colActions}>
+                    <Button
+                      appearance="subtle"
+                      size="small"
+                      icon={<Edit20Regular />}
+                      onClick={() =>
+                        navigate(
+                          `/edges/${encodeURIComponent(tail)}/${encodeURIComponent(head)}`,
+                        )
+                      }
+                      aria-label={`Edit edge ${tail || "tail"} → ${head || "head"}`}
+                      data-testid="edge-row-edit"
+                    >
+                      Edit
+                    </Button>
                     <Button
                       appearance="subtle"
                       size="small"

--- a/admin/app/components/edit-edge/DeleteEdgeDialog/DeleteEdgeDialog.tsx
+++ b/admin/app/components/edit-edge/DeleteEdgeDialog/DeleteEdgeDialog.tsx
@@ -1,0 +1,57 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogContent,
+  DialogSurface,
+  DialogTitle,
+  Spinner,
+} from "@fluentui/react-components";
+
+export interface DeleteEdgeDialogProps {
+  open: boolean;
+  tail: string;
+  head: string;
+  deleting: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function DeleteEdgeDialog(props: DeleteEdgeDialogProps) {
+  return (
+    <Dialog
+      open={props.open}
+      onOpenChange={(_, data) => {
+        if (!data.open) props.onCancel();
+      }}
+    >
+      <DialogSurface>
+        <DialogBody>
+          <DialogTitle>Delete edge?</DialogTitle>
+          <DialogContent>
+            <p>
+              Permanently removes the directed edge{" "}
+              <code data-testid="delete-edge-tail">{props.tail}</code> →{" "}
+              <code data-testid="delete-edge-head">{props.head}</code>.
+            </p>
+          </DialogContent>
+          <DialogActions>
+            <Button appearance="secondary" onClick={props.onCancel}>
+              Cancel
+            </Button>
+            <Button
+              appearance="primary"
+              onClick={props.onConfirm}
+              disabled={props.deleting}
+              data-testid="confirm-delete-edge"
+              icon={props.deleting ? <Spinner size="tiny" /> : undefined}
+            >
+              Delete
+            </Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+}

--- a/admin/app/components/edit-edge/EdgeDetailPage/EdgeDetailPage.module.css
+++ b/admin/app/components/edit-edge/EdgeDetailPage/EdgeDetailPage.module.css
@@ -1,0 +1,126 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalL, 16px);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalS, 8px);
+}
+
+.crumbs {
+  display: flex;
+  align-items: center;
+  gap: var(--spacingHorizontalS, 8px);
+  font-size: var(--fontSizeBase200, 12px);
+  color: var(--colorNeutralForeground2, #424242);
+  flex-wrap: wrap;
+}
+
+.crumbs a {
+  color: var(--colorBrandForegroundLink, #0078d4);
+  text-decoration: none;
+}
+
+.crumbs a:hover {
+  text-decoration: underline;
+}
+
+.title {
+  font-size: var(--fontSizeBase600, 24px);
+  font-weight: var(--fontWeightSemibold, 600);
+  margin: 0;
+}
+
+.edgePair {
+  display: flex;
+  align-items: center;
+  gap: var(--spacingHorizontalM, 12px);
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  font-size: var(--fontSizeBase500, 20px);
+  overflow-wrap: anywhere;
+}
+
+.arrow {
+  color: var(--colorNeutralForeground3, #707070);
+  font-weight: 700;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: var(--spacingHorizontalL, 16px);
+}
+
+.card {
+  border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  border-radius: var(--borderRadiusMedium, 6px);
+  padding: var(--spacingHorizontalL, 16px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalM, 12px);
+  background: var(--colorNeutralBackground1, #fff);
+}
+
+.cardTitle {
+  font-size: var(--fontSizeBase400, 16px);
+  font-weight: var(--fontWeightSemibold, 600);
+  margin: 0;
+}
+
+.cardLead {
+  margin: 0;
+  color: var(--colorNeutralForeground2, #424242);
+  font-size: var(--fontSizeBase200, 12px);
+}
+
+.viewRow {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: var(--spacingHorizontalM, 12px);
+  align-items: baseline;
+}
+
+.viewLabel {
+  color: var(--colorNeutralForeground2, #424242);
+  font-size: var(--fontSizeBase200, 12px);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.viewValue {
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+}
+
+.formActions {
+  display: flex;
+  gap: var(--spacingHorizontalS, 8px);
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.alert {
+  margin: 0;
+}
+
+.placeholder {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalS, 8px);
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacingVerticalXL, 24px);
+  color: var(--colorNeutralForeground3, #707070);
+}

--- a/admin/app/components/edit-edge/EdgeDetailPage/EdgeDetailPage.tsx
+++ b/admin/app/components/edit-edge/EdgeDetailPage/EdgeDetailPage.tsx
@@ -73,7 +73,10 @@ export function EdgeDetailPage(props: EdgeDetailPageProps) {
       ) : null}
 
       {editor.state.loadStatus === "ready" && editor.state.edge ? (
-        <CurrentEdge edge={editor.state.edge} onDelete={editor.openDeleteDialog} />
+        <CurrentEdge
+          edge={editor.state.edge}
+          onDelete={editor.openDeleteDialog}
+        />
       ) : null}
 
       {editor.state.loadStatus === "not-found" ? (

--- a/admin/app/components/edit-edge/EdgeDetailPage/EdgeDetailPage.tsx
+++ b/admin/app/components/edit-edge/EdgeDetailPage/EdgeDetailPage.tsx
@@ -1,0 +1,171 @@
+import {
+  Button,
+  MessageBar,
+  MessageBarBody,
+  Spinner,
+} from "@fluentui/react-components";
+import { Delete20Regular } from "@fluentui/react-icons";
+import { Link, useNavigate } from "react-router";
+import { useEffect } from "react";
+import { useEditEdge } from "~/lib/client/usecase/edit-edge/use-edit-edge";
+import type { Edge } from "~/lib/client/infrastructure/api/get-edge";
+import { ExpirationCell } from "../../browse-edges/ExpirationCell/ExpirationCell";
+import { DeleteEdgeDialog } from "../DeleteEdgeDialog/DeleteEdgeDialog";
+import { EdgeWriteForm } from "../EdgeWriteForm/EdgeWriteForm";
+import styles from "./EdgeDetailPage.module.css";
+
+export interface EdgeDetailPageProps {
+  tail: string;
+  head: string;
+}
+
+/**
+ * Detail view for a directed edge. Surfaces both Add (accumulate) and
+ * Put (overwrite) forms side-by-side because users repeatedly confused
+ * the two in the F2 dogfood; we now keep the help text adjacent.
+ */
+export function EdgeDetailPage(props: EdgeDetailPageProps) {
+  const navigate = useNavigate();
+  const editor = useEditEdge(props.tail, props.head);
+
+  useEffect(() => {
+    if (editor.deleted) {
+      navigate("/edges");
+    }
+  }, [editor.deleted, navigate]);
+
+  return (
+    <div className={styles.root}>
+      <header className={styles.header}>
+        <div className={styles.crumbs}>
+          <Link to="/edges">Edges</Link>
+          <span aria-hidden="true">/</span>
+          <Link to={`/vertices/${encodeURIComponent(props.tail)}`}>
+            {props.tail}
+          </Link>
+          <span aria-hidden="true">→</span>
+          <Link to={`/vertices/${encodeURIComponent(props.head)}`}>
+            {props.head}
+          </Link>
+        </div>
+        <h1 className={styles.title}>Edge</h1>
+        <div className={styles.edgePair}>
+          <span data-testid="edge-detail-tail">{props.tail}</span>
+          <span className={styles.arrow} aria-hidden="true">
+            →
+          </span>
+          <span data-testid="edge-detail-head">{props.head}</span>
+        </div>
+      </header>
+
+      {editor.state.loadStatus === "loading" ? (
+        <div className={styles.placeholder} data-testid="edge-detail-loading">
+          <Spinner label="Loading edge…" size="small" />
+        </div>
+      ) : null}
+
+      {editor.state.loadStatus === "error" ? (
+        <MessageBar intent="error" className={styles.alert}>
+          <MessageBarBody>
+            {editor.state.loadError ?? "Unable to load edge."}
+          </MessageBarBody>
+        </MessageBar>
+      ) : null}
+
+      {editor.state.loadStatus === "ready" && editor.state.edge ? (
+        <CurrentEdge edge={editor.state.edge} onDelete={editor.openDeleteDialog} />
+      ) : null}
+
+      {editor.state.loadStatus === "not-found" ? (
+        <section className={styles.card} data-testid="edge-detail-missing">
+          <h2 className={styles.cardTitle}>Edge not found</h2>
+          <p>
+            No edge currently exists. Use the form below to create one with
+            either AddEdge or PutEdge.
+          </p>
+        </section>
+      ) : null}
+
+      <div className={styles.cards}>
+        <EdgeWriteForm
+          mode="add"
+          title="Add contribution"
+          description="Appends another time-decaying contribution. Repeated calls accumulate weight at the current decay rate."
+          inputs={editor.state.addInputs}
+          status={editor.state.addStatus}
+          error={editor.state.addError}
+          valid={editor.addValid}
+          onWeight={(v) => editor.setWeight("add", v)}
+          onTtl={(t) => editor.setTtl("add", t)}
+          onSubmit={editor.submitAdd}
+          submitLabel="Add contribution"
+        />
+        <EdgeWriteForm
+          mode="put"
+          title="Replace edge"
+          description="Overwrites the edge with this exact weight and expiration. Idempotent — repeated calls leave the same value."
+          inputs={editor.state.putInputs}
+          status={editor.state.putStatus}
+          error={editor.state.putError}
+          valid={editor.putValid}
+          onWeight={(v) => editor.setWeight("put", v)}
+          onTtl={(t) => editor.setTtl("put", t)}
+          onSubmit={editor.submitPut}
+          submitLabel="Replace edge"
+        />
+      </div>
+
+      <DeleteEdgeDialog
+        open={editor.state.deleteRequested}
+        tail={props.tail}
+        head={props.head}
+        deleting={editor.state.deleteStatus === "deleting"}
+        onCancel={editor.closeDeleteDialog}
+        onConfirm={editor.confirmDelete}
+      />
+
+      {editor.state.deleteStatus === "error" ? (
+        <MessageBar intent="error" className={styles.alert}>
+          <MessageBarBody>
+            {editor.state.deleteError ?? "Delete failed."}
+          </MessageBarBody>
+        </MessageBar>
+      ) : null}
+    </div>
+  );
+}
+
+interface CurrentEdgeProps {
+  edge: Edge;
+  onDelete: () => void;
+}
+
+function CurrentEdge({ edge, onDelete }: CurrentEdgeProps) {
+  return (
+    <section className={styles.card} data-testid="edge-detail-read">
+      <h2 className={styles.cardTitle}>Current edge</h2>
+      <div className={styles.viewRow}>
+        <span className={styles.viewLabel}>Weight</span>
+        <span className={styles.viewValue} data-testid="edge-current-weight">
+          {edge.weight ?? 0}
+        </span>
+      </div>
+      <div className={styles.viewRow}>
+        <span className={styles.viewLabel}>Expires</span>
+        <span className={styles.viewValue}>
+          <ExpirationCell expiration={edge.expiration} />
+        </span>
+      </div>
+      <div className={styles.formActions}>
+        <Button
+          appearance="secondary"
+          icon={<Delete20Regular />}
+          onClick={onDelete}
+          data-testid="edge-delete-trigger"
+        >
+          Delete
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/admin/app/components/edit-edge/EdgeWriteForm/EdgeWriteForm.tsx
+++ b/admin/app/components/edit-edge/EdgeWriteForm/EdgeWriteForm.tsx
@@ -45,7 +45,10 @@ export function EdgeWriteForm(props: EdgeWriteFormProps) {
     >
       <h2 className={styles.cardTitle}>{props.title}</h2>
       <p className={styles.cardLead}>{props.description}</p>
-      <Field label="Weight" hint="Floating-point. Negative values are allowed for PutEdge.">
+      <Field
+        label="Weight"
+        hint="Floating-point. Negative values are allowed for PutEdge."
+      >
         <Input
           type="number"
           step="any"
@@ -69,7 +72,11 @@ export function EdgeWriteForm(props: EdgeWriteFormProps) {
           appearance="primary"
           type="submit"
           icon={
-            props.status === "saving" ? <Spinner size="tiny" /> : <Save20Regular />
+            props.status === "saving" ? (
+              <Spinner size="tiny" />
+            ) : (
+              <Save20Regular />
+            )
           }
           disabled={!props.valid || props.status === "saving"}
           data-testid={`edge-${props.mode}-submit`}

--- a/admin/app/components/edit-edge/EdgeWriteForm/EdgeWriteForm.tsx
+++ b/admin/app/components/edit-edge/EdgeWriteForm/EdgeWriteForm.tsx
@@ -1,0 +1,82 @@
+import {
+  Button,
+  Field,
+  Input,
+  MessageBar,
+  MessageBarBody,
+  Spinner,
+} from "@fluentui/react-components";
+import { Save20Regular } from "@fluentui/react-icons";
+import { TtlField } from "../../edit-vertex/TtlField/TtlField";
+import type { EdgeWriteInputs } from "~/lib/client/usecase/edit-edge/edge-codec";
+import type { TtlInput } from "~/lib/client/usecase/edit-vertex/value-codec";
+import styles from "../EdgeDetailPage/EdgeDetailPage.module.css";
+
+export interface EdgeWriteFormProps {
+  /** "add" or "put" — only used for test ids. */
+  mode: "add" | "put";
+  title: string;
+  description: string;
+  inputs: EdgeWriteInputs;
+  status: "idle" | "saving" | "saved" | "error";
+  error: string | null;
+  valid: boolean;
+  onWeight: (value: string) => void;
+  onTtl: (ttl: TtlInput) => void;
+  onSubmit: () => void;
+  submitLabel: string;
+}
+
+/**
+ * Generic weight+TTL form used twice on the edge detail page: once for
+ * `AddEdge` and once for `PutEdge`. Keeping the shape shared makes the
+ * subtle semantic distinction the *only* difference users see.
+ */
+export function EdgeWriteForm(props: EdgeWriteFormProps) {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    props.onSubmit();
+  };
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className={styles.card}
+      data-testid={`edge-form-${props.mode}`}
+    >
+      <h2 className={styles.cardTitle}>{props.title}</h2>
+      <p className={styles.cardLead}>{props.description}</p>
+      <Field label="Weight" hint="Floating-point. Negative values are allowed for PutEdge.">
+        <Input
+          type="number"
+          step="any"
+          value={props.inputs.weight}
+          onChange={(_, data) => props.onWeight(data.value)}
+          data-testid={`edge-${props.mode}-weight`}
+        />
+      </Field>
+      <TtlField
+        value={props.inputs.ttl}
+        onChange={props.onTtl}
+        label="Expires in"
+      />
+      {props.error ? (
+        <MessageBar intent="error" className={styles.alert}>
+          <MessageBarBody>{props.error}</MessageBarBody>
+        </MessageBar>
+      ) : null}
+      <div className={styles.formActions}>
+        <Button
+          appearance="primary"
+          type="submit"
+          icon={
+            props.status === "saving" ? <Spinner size="tiny" /> : <Save20Regular />
+          }
+          disabled={!props.valid || props.status === "saving"}
+          data-testid={`edge-${props.mode}-submit`}
+        >
+          {props.submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/admin/app/components/edit-vertex/DeleteVertexDialog/DeleteVertexDialog.tsx
+++ b/admin/app/components/edit-vertex/DeleteVertexDialog/DeleteVertexDialog.tsx
@@ -1,0 +1,61 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogContent,
+  DialogSurface,
+  DialogTitle,
+  Spinner,
+} from "@fluentui/react-components";
+
+export interface DeleteVertexDialogProps {
+  open: boolean;
+  vertexKey: string;
+  deleting: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+/**
+ * Confirmation Dialog for vertex deletion. The key is shown verbatim so
+ * the user has a final chance to spot a typo before the irreversible
+ * action.
+ */
+export function DeleteVertexDialog(props: DeleteVertexDialogProps) {
+  return (
+    <Dialog
+      open={props.open}
+      onOpenChange={(_, data) => {
+        if (!data.open) props.onCancel();
+      }}
+    >
+      <DialogSurface>
+        <DialogBody>
+          <DialogTitle>Delete vertex?</DialogTitle>
+          <DialogContent>
+            <p>
+              This permanently removes the vertex with key{" "}
+              <code data-testid="delete-vertex-key">{props.vertexKey}</code>.
+              Edges that reference this key are not removed automatically.
+            </p>
+          </DialogContent>
+          <DialogActions>
+            <Button appearance="secondary" onClick={props.onCancel}>
+              Cancel
+            </Button>
+            <Button
+              appearance="primary"
+              onClick={props.onConfirm}
+              disabled={props.deleting}
+              data-testid="confirm-delete-vertex"
+              icon={props.deleting ? <Spinner size="tiny" /> : undefined}
+            >
+              Delete
+            </Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+}

--- a/admin/app/components/edit-vertex/KindSelector/KindSelector.tsx
+++ b/admin/app/components/edit-vertex/KindSelector/KindSelector.tsx
@@ -1,0 +1,39 @@
+import { Dropdown, Field, Option } from "@fluentui/react-components";
+import {
+  VERTEX_VALUE_KINDS,
+  type VertexValueKind,
+} from "~/lib/client/usecase/edit-vertex/value-codec";
+
+export interface KindSelectorProps {
+  value: VertexValueKind;
+  onChange: (value: VertexValueKind) => void;
+  /** When true the selector is disabled (view mode). */
+  disabled?: boolean;
+}
+
+/**
+ * Drop-down picker over the 12 `v1Vertex` oneof variants. Order matches
+ * the codec; the active value is the controlled string.
+ */
+export function KindSelector(props: KindSelectorProps) {
+  return (
+    <Field label="value kind">
+      <Dropdown
+        value={props.value}
+        selectedOptions={[props.value]}
+        disabled={props.disabled}
+        onOptionSelect={(_, data) => {
+          if (!data.optionValue) return;
+          props.onChange(data.optionValue as VertexValueKind);
+        }}
+        data-testid="vertex-kind-selector"
+      >
+        {VERTEX_VALUE_KINDS.map((kind) => (
+          <Option key={kind} value={kind}>
+            {kind}
+          </Option>
+        ))}
+      </Dropdown>
+    </Field>
+  );
+}

--- a/admin/app/components/edit-vertex/TtlField/TtlField.tsx
+++ b/admin/app/components/edit-vertex/TtlField/TtlField.tsx
@@ -1,5 +1,8 @@
 import { Field, Input, RadioGroup, Radio } from "@fluentui/react-components";
-import type { TtlInput, TtlMode } from "~/lib/client/usecase/edit-vertex/value-codec";
+import type {
+  TtlInput,
+  TtlMode,
+} from "~/lib/client/usecase/edit-vertex/value-codec";
 
 export interface TtlFieldProps {
   value: TtlInput;
@@ -39,9 +42,7 @@ export function TtlField(props: TtlFieldProps) {
         {value.mode === "custom" ? (
           <Input
             value={value.custom}
-            onChange={(_, data) =>
-              onChange({ ...value, custom: data.value })
-            }
+            onChange={(_, data) => onChange({ ...value, custom: data.value })}
             placeholder="e.g. 15m, 2h30m, 7d (use Go syntax)"
             data-testid="vertex-ttl-custom"
             style={{ marginTop: "8px" }}

--- a/admin/app/components/edit-vertex/TtlField/TtlField.tsx
+++ b/admin/app/components/edit-vertex/TtlField/TtlField.tsx
@@ -1,0 +1,53 @@
+import { Field, Input, RadioGroup, Radio } from "@fluentui/react-components";
+import type { TtlInput, TtlMode } from "~/lib/client/usecase/edit-vertex/value-codec";
+
+export interface TtlFieldProps {
+  value: TtlInput;
+  onChange: (value: TtlInput) => void;
+  /** Optional custom label so the field can read e.g. "Expires in" vs "TTL". */
+  label?: string;
+}
+
+const PRESETS: Array<{ mode: TtlMode; label: string }> = [
+  { mode: "preset5m", label: "5 min" },
+  { mode: "preset1h", label: "1 hour" },
+  { mode: "preset24h", label: "24 hours" },
+  { mode: "none", label: "no expiration" },
+  { mode: "custom", label: "custom…" },
+];
+
+/**
+ * Combined TTL selector: radio chips for the four presets plus a custom
+ * Go-duration input that only shows up when "custom…" is active.
+ */
+export function TtlField(props: TtlFieldProps) {
+  const { value, onChange } = props;
+  return (
+    <Field label={props.label ?? "Expires in"}>
+      <div data-testid="vertex-ttl-presets">
+        <RadioGroup
+          layout="horizontal-stacked"
+          value={value.mode}
+          onChange={(_, data) =>
+            onChange({ ...value, mode: data.value as TtlMode })
+          }
+        >
+          {PRESETS.map((p) => (
+            <Radio key={p.mode} value={p.mode} label={p.label} />
+          ))}
+        </RadioGroup>
+        {value.mode === "custom" ? (
+          <Input
+            value={value.custom}
+            onChange={(_, data) =>
+              onChange({ ...value, custom: data.value })
+            }
+            placeholder="e.g. 15m, 2h30m, 7d (use Go syntax)"
+            data-testid="vertex-ttl-custom"
+            style={{ marginTop: "8px" }}
+          />
+        ) : null}
+      </div>
+    </Field>
+  );
+}

--- a/admin/app/components/edit-vertex/ValueEditor/ValueEditor.tsx
+++ b/admin/app/components/edit-vertex/ValueEditor/ValueEditor.tsx
@@ -1,0 +1,113 @@
+import { BoolEditor } from "../editors/BoolEditor";
+import { BytesEditor } from "../editors/BytesEditor";
+import { DurationEditor } from "../editors/DurationEditor";
+import { Float32Editor } from "../editors/Float32Editor";
+import { Float64Editor } from "../editors/Float64Editor";
+import { Int32Editor } from "../editors/Int32Editor";
+import { Int64Editor } from "../editors/Int64Editor";
+import { NilEditor } from "../editors/NilEditor";
+import { StringEditor } from "../editors/StringEditor";
+import { TimestampEditor } from "../editors/TimestampEditor";
+import { Uint32Editor } from "../editors/Uint32Editor";
+import { Uint64Editor } from "../editors/Uint64Editor";
+import type {
+  BytesEncoding,
+  VertexInputs,
+  VertexValueKind,
+} from "~/lib/client/usecase/edit-vertex/value-codec";
+
+export interface ValueEditorProps {
+  kind: VertexValueKind;
+  inputs: VertexInputs;
+  onTextInput: (field: keyof VertexInputs, value: string) => void;
+  onBoolChange: (value: boolean) => void;
+  onBytesEncodingChange: (value: BytesEncoding) => void;
+}
+
+/**
+ * Picks the right variant editor based on the active kind. Each branch
+ * forwards only the inputs that variant uses, so the per-kind editors
+ * stay focused on their single responsibility.
+ */
+export function ValueEditor(props: ValueEditorProps) {
+  switch (props.kind) {
+    case "float64":
+      return (
+        <Float64Editor
+          value={props.inputs.float64}
+          onChange={(v) => props.onTextInput("float64", v)}
+        />
+      );
+    case "float32":
+      return (
+        <Float32Editor
+          value={props.inputs.float32}
+          onChange={(v) => props.onTextInput("float32", v)}
+        />
+      );
+    case "int32":
+      return (
+        <Int32Editor
+          value={props.inputs.int32}
+          onChange={(v) => props.onTextInput("int32", v)}
+        />
+      );
+    case "int64":
+      return (
+        <Int64Editor
+          value={props.inputs.int64}
+          onChange={(v) => props.onTextInput("int64", v)}
+        />
+      );
+    case "uint32":
+      return (
+        <Uint32Editor
+          value={props.inputs.uint32}
+          onChange={(v) => props.onTextInput("uint32", v)}
+        />
+      );
+    case "uint64":
+      return (
+        <Uint64Editor
+          value={props.inputs.uint64}
+          onChange={(v) => props.onTextInput("uint64", v)}
+        />
+      );
+    case "bool":
+      return (
+        <BoolEditor value={props.inputs.bool} onChange={props.onBoolChange} />
+      );
+    case "string":
+      return (
+        <StringEditor
+          value={props.inputs.string}
+          onChange={(v) => props.onTextInput("string", v)}
+        />
+      );
+    case "bytes":
+      return (
+        <BytesEditor
+          value={props.inputs.bytesInput}
+          encoding={props.inputs.bytesEncoding}
+          onChange={(v) => props.onTextInput("bytesInput", v)}
+          onEncodingChange={props.onBytesEncodingChange}
+        />
+      );
+    case "timestamp":
+      return (
+        <TimestampEditor
+          value={props.inputs.timestamp}
+          onChange={(v) => props.onTextInput("timestamp", v)}
+        />
+      );
+    case "duration":
+      return (
+        <DurationEditor
+          value={props.inputs.duration}
+          onChange={(v) => props.onTextInput("duration", v)}
+        />
+      );
+    case "nil":
+      return <NilEditor />;
+  }
+}

--- a/admin/app/components/edit-vertex/VertexDetailPage/VertexDetailPage.module.css
+++ b/admin/app/components/edit-vertex/VertexDetailPage/VertexDetailPage.module.css
@@ -1,0 +1,109 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalL, 16px);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalS, 8px);
+}
+
+.crumbs {
+  display: flex;
+  align-items: center;
+  gap: var(--spacingHorizontalS, 8px);
+  font-size: var(--fontSizeBase200, 12px);
+  color: var(--colorNeutralForeground2, #424242);
+}
+
+.crumbs a {
+  color: var(--colorBrandForegroundLink, #0078d4);
+  text-decoration: none;
+}
+
+.crumbs a:hover {
+  text-decoration: underline;
+}
+
+.title {
+  font-size: var(--fontSizeBase600, 24px);
+  font-weight: var(--fontWeightSemibold, 600);
+  margin: 0;
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  overflow-wrap: anywhere;
+}
+
+.toolbar {
+  display: flex;
+  gap: var(--spacingHorizontalS, 8px);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.card {
+  border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  border-radius: var(--borderRadiusMedium, 6px);
+  padding: var(--spacingHorizontalL, 16px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalM, 12px);
+  background: var(--colorNeutralBackground1, #fff);
+}
+
+.cardTitle {
+  font-size: var(--fontSizeBase400, 16px);
+  font-weight: var(--fontWeightSemibold, 600);
+  margin: 0;
+}
+
+.viewRow {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: var(--spacingHorizontalM, 12px);
+  align-items: baseline;
+}
+
+.viewLabel {
+  color: var(--colorNeutralForeground2, #424242);
+  font-size: var(--fontSizeBase200, 12px);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.viewValue {
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  overflow-wrap: anywhere;
+}
+
+.formActions {
+  display: flex;
+  gap: var(--spacingHorizontalS, 8px);
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.alert {
+  margin: 0;
+}
+
+.placeholder {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalS, 8px);
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacingVerticalXL, 24px);
+  color: var(--colorNeutralForeground3, #707070);
+}

--- a/admin/app/components/edit-vertex/VertexDetailPage/VertexDetailPage.tsx
+++ b/admin/app/components/edit-vertex/VertexDetailPage/VertexDetailPage.tsx
@@ -90,7 +90,9 @@ export function VertexDetailPage(props: VertexDetailPageProps) {
         />
       ) : null}
 
-      {editor.state.loadStatus === "ready" && editor.state.vertex && !editor.editing ? (
+      {editor.state.loadStatus === "ready" &&
+      editor.state.vertex &&
+      !editor.editing ? (
         <ReadView
           vertex={editor.state.vertex}
           onEdit={editor.beginEdit}
@@ -98,9 +100,7 @@ export function VertexDetailPage(props: VertexDetailPageProps) {
         />
       ) : null}
 
-      {editor.editing ? (
-        <EditView editor={editor} />
-      ) : null}
+      {editor.editing ? <EditView editor={editor} /> : null}
 
       <DeleteVertexDialog
         open={editor.state.deleteRequested}
@@ -216,7 +216,9 @@ function EditView({ editor }: EditViewProps) {
       data-testid="vertex-detail-edit"
     >
       <h2 className={styles.cardTitle}>
-        {editor.state.loadStatus === "not-found" ? "Create vertex" : "Edit vertex"}
+        {editor.state.loadStatus === "not-found"
+          ? "Create vertex"
+          : "Edit vertex"}
       </h2>
       <KindSelector value={editor.state.kind} onChange={editor.setKind} />
       <ValueEditor

--- a/admin/app/components/edit-vertex/VertexDetailPage/VertexDetailPage.tsx
+++ b/admin/app/components/edit-vertex/VertexDetailPage/VertexDetailPage.tsx
@@ -1,0 +1,264 @@
+import {
+  Badge,
+  Button,
+  MessageBar,
+  MessageBarBody,
+  Spinner,
+} from "@fluentui/react-components";
+import {
+  Delete20Regular,
+  Edit20Regular,
+  LightbulbFilament20Regular,
+  Save20Regular,
+} from "@fluentui/react-icons";
+import { Link, useNavigate } from "react-router";
+import { useEffect } from "react";
+import { useEditVertex } from "~/lib/client/usecase/edit-vertex/use-edit-vertex";
+import { kindOfVertex } from "~/lib/client/usecase/edit-vertex/value-codec";
+import type { Vertex } from "~/lib/client/infrastructure/api/get-vertex";
+import { ExpirationCell } from "../../browse-vertices/ExpirationCell/ExpirationCell";
+import { ValueCell } from "../../browse-vertices/ValueCell/ValueCell";
+import { DeleteVertexDialog } from "../DeleteVertexDialog/DeleteVertexDialog";
+import { KindSelector } from "../KindSelector/KindSelector";
+import { TtlField } from "../TtlField/TtlField";
+import { ValueEditor } from "../ValueEditor/ValueEditor";
+import styles from "./VertexDetailPage.module.css";
+
+export interface VertexDetailPageProps {
+  vertexKey: string;
+}
+
+/**
+ * Read/Edit/Delete page for a single vertex. Begins in view mode so the
+ * user can confirm they have the right row before mutating it, then
+ * flips to an inline editor sharing reducer state with the API handlers.
+ */
+export function VertexDetailPage(props: VertexDetailPageProps) {
+  const navigate = useNavigate();
+  const editor = useEditVertex(props.vertexKey);
+
+  // After a successful delete, redirect to the listing.
+  useEffect(() => {
+    if (editor.deleted) {
+      navigate("/vertices");
+    }
+  }, [editor.deleted, navigate]);
+
+  return (
+    <div className={styles.root}>
+      <header className={styles.header}>
+        <div className={styles.crumbs}>
+          <Link to="/vertices">Vertices</Link>
+          <span aria-hidden="true">/</span>
+          <span data-testid="vertex-detail-key">{props.vertexKey}</span>
+        </div>
+        <h1 className={styles.title}>{props.vertexKey}</h1>
+        <div className={styles.toolbar}>
+          <Button
+            appearance="subtle"
+            icon={<LightbulbFilament20Regular />}
+            onClick={() =>
+              navigate(
+                `/illuminate?seed=${encodeURIComponent(props.vertexKey)}`,
+              )
+            }
+          >
+            Illuminate
+          </Button>
+        </div>
+      </header>
+
+      {editor.state.loadStatus === "loading" ? (
+        <div className={styles.placeholder} data-testid="vertex-detail-loading">
+          <Spinner label="Loading vertex…" size="small" />
+        </div>
+      ) : null}
+
+      {editor.state.loadStatus === "error" ? (
+        <MessageBar intent="error" className={styles.alert}>
+          <MessageBarBody>
+            {editor.state.loadError ?? "Unable to load vertex."}
+          </MessageBarBody>
+        </MessageBar>
+      ) : null}
+
+      {editor.state.loadStatus === "not-found" ? (
+        <NotFoundView
+          vertexKey={props.vertexKey}
+          editing={editor.editing}
+          onBeginEdit={editor.beginEdit}
+        />
+      ) : null}
+
+      {editor.state.loadStatus === "ready" && editor.state.vertex && !editor.editing ? (
+        <ReadView
+          vertex={editor.state.vertex}
+          onEdit={editor.beginEdit}
+          onDelete={editor.openDeleteDialog}
+        />
+      ) : null}
+
+      {editor.editing ? (
+        <EditView editor={editor} />
+      ) : null}
+
+      <DeleteVertexDialog
+        open={editor.state.deleteRequested}
+        vertexKey={props.vertexKey}
+        deleting={editor.state.deleteStatus === "deleting"}
+        onCancel={editor.closeDeleteDialog}
+        onConfirm={editor.confirmDelete}
+      />
+
+      {editor.state.deleteStatus === "error" ? (
+        <MessageBar intent="error" className={styles.alert}>
+          <MessageBarBody>
+            {editor.state.deleteError ?? "Delete failed."}
+          </MessageBarBody>
+        </MessageBar>
+      ) : null}
+    </div>
+  );
+}
+
+interface ReadViewProps {
+  vertex: Vertex;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+function ReadView({ vertex, onEdit, onDelete }: ReadViewProps) {
+  const kind = kindOfVertex(vertex);
+  return (
+    <section className={styles.card} data-testid="vertex-detail-read">
+      <h2 className={styles.cardTitle}>Current value</h2>
+      <div className={styles.viewRow}>
+        <span className={styles.viewLabel}>Kind</span>
+        <Badge appearance="tint" shape="rounded">
+          {kind}
+        </Badge>
+      </div>
+      <div className={styles.viewRow}>
+        <span className={styles.viewLabel}>Value</span>
+        <span className={styles.viewValue}>
+          <ValueCell vertex={vertex} />
+        </span>
+      </div>
+      <div className={styles.viewRow}>
+        <span className={styles.viewLabel}>Expires</span>
+        <span className={styles.viewValue}>
+          <ExpirationCell expiration={vertex.expiration} />
+        </span>
+      </div>
+      <div className={styles.formActions}>
+        <Button
+          appearance="secondary"
+          icon={<Delete20Regular />}
+          onClick={onDelete}
+          data-testid="vertex-delete-trigger"
+        >
+          Delete
+        </Button>
+        <Button
+          appearance="primary"
+          icon={<Edit20Regular />}
+          onClick={onEdit}
+          data-testid="vertex-edit-trigger"
+        >
+          Edit value
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+interface NotFoundViewProps {
+  vertexKey: string;
+  editing: boolean;
+  onBeginEdit: () => void;
+}
+
+function NotFoundView({ vertexKey, editing, onBeginEdit }: NotFoundViewProps) {
+  if (editing) return null;
+  return (
+    <section className={styles.card} data-testid="vertex-detail-missing">
+      <h2 className={styles.cardTitle}>Vertex not found</h2>
+      <p>
+        No vertex currently exists for key <code>{vertexKey}</code>. You can
+        create one by writing a value below.
+      </p>
+      <div className={styles.formActions}>
+        <Button
+          appearance="primary"
+          onClick={onBeginEdit}
+          data-testid="vertex-create-trigger"
+        >
+          Create vertex
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+interface EditViewProps {
+  editor: ReturnType<typeof useEditVertex>;
+}
+
+function EditView({ editor }: EditViewProps) {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    await editor.save();
+  };
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className={styles.card}
+      data-testid="vertex-detail-edit"
+    >
+      <h2 className={styles.cardTitle}>
+        {editor.state.loadStatus === "not-found" ? "Create vertex" : "Edit vertex"}
+      </h2>
+      <KindSelector value={editor.state.kind} onChange={editor.setKind} />
+      <ValueEditor
+        kind={editor.state.kind}
+        inputs={editor.state.inputs}
+        onTextInput={editor.setInput}
+        onBoolChange={editor.setBool}
+        onBytesEncodingChange={editor.setBytesEncoding}
+      />
+      <TtlField value={editor.state.ttl} onChange={editor.setTtl} />
+      {editor.state.saveStatus === "error" ? (
+        <MessageBar intent="error" className={styles.alert}>
+          <MessageBarBody>
+            {editor.state.saveError ?? "Save failed."}
+          </MessageBarBody>
+        </MessageBar>
+      ) : null}
+      <div className={styles.formActions}>
+        <Button
+          appearance="secondary"
+          onClick={editor.cancelEdit}
+          disabled={editor.state.saveStatus === "saving"}
+          type="button"
+        >
+          Cancel
+        </Button>
+        <Button
+          appearance="primary"
+          type="submit"
+          icon={
+            editor.state.saveStatus === "saving" ? (
+              <Spinner size="tiny" />
+            ) : (
+              <Save20Regular />
+            )
+          }
+          disabled={!editor.formValid || editor.state.saveStatus === "saving"}
+          data-testid="vertex-save"
+        >
+          Save
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/admin/app/components/edit-vertex/editors/BoolEditor.tsx
+++ b/admin/app/components/edit-vertex/editors/BoolEditor.tsx
@@ -1,0 +1,19 @@
+import { Field, Switch } from "@fluentui/react-components";
+
+export interface BoolEditorProps {
+  value: boolean;
+  onChange: (value: boolean) => void;
+}
+
+export function BoolEditor(props: BoolEditorProps) {
+  return (
+    <Field label="bool value">
+      <Switch
+        checked={props.value}
+        label={props.value ? "true" : "false"}
+        onChange={(_, data) => props.onChange(data.checked)}
+        data-testid="vertex-editor-bool"
+      />
+    </Field>
+  );
+}

--- a/admin/app/components/edit-vertex/editors/BytesEditor.tsx
+++ b/admin/app/components/edit-vertex/editors/BytesEditor.tsx
@@ -1,0 +1,42 @@
+import { Field, RadioGroup, Radio, Textarea } from "@fluentui/react-components";
+import type { BytesEncoding } from "~/lib/client/usecase/edit-vertex/value-codec";
+
+export interface BytesEditorProps {
+  value: string;
+  encoding: BytesEncoding;
+  onChange: (value: string) => void;
+  onEncodingChange: (encoding: BytesEncoding) => void;
+}
+
+/**
+ * Binary payload editor. The encoding toggle changes how the textarea is
+ * interpreted; the value is round-tripped to base64 only at save time so
+ * the user can re-edit without precision loss.
+ */
+export function BytesEditor(props: BytesEditorProps) {
+  return (
+    <>
+      <Field label="bytes encoding">
+        <RadioGroup
+          layout="horizontal"
+          value={props.encoding}
+          onChange={(_, data) =>
+            props.onEncodingChange(data.value as BytesEncoding)
+          }
+        >
+          <Radio value="hex" label="hex (0x…)" />
+          <Radio value="base64" label="base64" />
+        </RadioGroup>
+      </Field>
+      <Field label="bytes value" hint="Whitespace is ignored.">
+        <Textarea
+          value={props.value}
+          onChange={(_, data) => props.onChange(data.value)}
+          rows={3}
+          resize="vertical"
+          data-testid="vertex-editor-bytes"
+        />
+      </Field>
+    </>
+  );
+}

--- a/admin/app/components/edit-vertex/editors/DurationEditor.tsx
+++ b/admin/app/components/edit-vertex/editors/DurationEditor.tsx
@@ -7,10 +7,7 @@ export interface DurationEditorProps {
 
 export function DurationEditor(props: DurationEditorProps) {
   return (
-    <Field
-      label="duration value"
-      hint="Go syntax: e.g. 5m, 1h30m, 750ms."
-    >
+    <Field label="duration value" hint="Go syntax: e.g. 5m, 1h30m, 750ms.">
       <Input
         value={props.value}
         onChange={(_, data) => props.onChange(data.value)}

--- a/admin/app/components/edit-vertex/editors/DurationEditor.tsx
+++ b/admin/app/components/edit-vertex/editors/DurationEditor.tsx
@@ -1,0 +1,22 @@
+import { Field, Input } from "@fluentui/react-components";
+
+export interface DurationEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function DurationEditor(props: DurationEditorProps) {
+  return (
+    <Field
+      label="duration value"
+      hint="Go syntax: e.g. 5m, 1h30m, 750ms."
+    >
+      <Input
+        value={props.value}
+        onChange={(_, data) => props.onChange(data.value)}
+        placeholder="1h30m"
+        data-testid="vertex-editor-duration"
+      />
+    </Field>
+  );
+}

--- a/admin/app/components/edit-vertex/editors/Float32Editor.tsx
+++ b/admin/app/components/edit-vertex/editors/Float32Editor.tsx
@@ -1,0 +1,17 @@
+import { NumberEditor } from "./NumberEditor";
+
+export interface Float32EditorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function Float32Editor(props: Float32EditorProps) {
+  return (
+    <NumberEditor
+      label="float32 value"
+      value={props.value}
+      onChange={props.onChange}
+      hint="IEEE 754 single-precision (server-side narrowed)."
+    />
+  );
+}

--- a/admin/app/components/edit-vertex/editors/Float64Editor.tsx
+++ b/admin/app/components/edit-vertex/editors/Float64Editor.tsx
@@ -1,0 +1,17 @@
+import { NumberEditor } from "./NumberEditor";
+
+export interface Float64EditorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function Float64Editor(props: Float64EditorProps) {
+  return (
+    <NumberEditor
+      label="float64 value"
+      value={props.value}
+      onChange={props.onChange}
+      hint="IEEE 754 double-precision."
+    />
+  );
+}

--- a/admin/app/components/edit-vertex/editors/Int32Editor.tsx
+++ b/admin/app/components/edit-vertex/editors/Int32Editor.tsx
@@ -1,0 +1,18 @@
+import { NumberEditor } from "./NumberEditor";
+
+export interface Int32EditorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function Int32Editor(props: Int32EditorProps) {
+  return (
+    <NumberEditor
+      label="int32 value"
+      value={props.value}
+      onChange={props.onChange}
+      hint="Signed 32-bit integer (−2,147,483,648 … 2,147,483,647)."
+      step="1"
+    />
+  );
+}

--- a/admin/app/components/edit-vertex/editors/Int64Editor.tsx
+++ b/admin/app/components/edit-vertex/editors/Int64Editor.tsx
@@ -1,0 +1,27 @@
+import { Field, Input } from "@fluentui/react-components";
+
+export interface Int64EditorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+/**
+ * 64-bit integers are transmitted as JSON strings because JS `number`
+ * loses precision past 2^53. The input is a plain text box for the same
+ * reason — `type="number"` would silently round.
+ */
+export function Int64Editor(props: Int64EditorProps) {
+  return (
+    <Field
+      label="int64 value"
+      hint="Signed 64-bit integer. Transmitted as a string to preserve precision."
+    >
+      <Input
+        value={props.value}
+        onChange={(_, data) => props.onChange(data.value)}
+        data-testid="vertex-editor-int64"
+        inputMode="numeric"
+      />
+    </Field>
+  );
+}

--- a/admin/app/components/edit-vertex/editors/NilEditor.tsx
+++ b/admin/app/components/edit-vertex/editors/NilEditor.tsx
@@ -8,8 +8,7 @@ export function NilEditor() {
   return (
     <MessageBar intent="info">
       <MessageBarBody>
-        Stores the key with no value. Useful for tombstones or set
-        membership.
+        Stores the key with no value. Useful for tombstones or set membership.
       </MessageBarBody>
     </MessageBar>
   );

--- a/admin/app/components/edit-vertex/editors/NilEditor.tsx
+++ b/admin/app/components/edit-vertex/editors/NilEditor.tsx
@@ -1,0 +1,16 @@
+import { MessageBar, MessageBarBody } from "@fluentui/react-components";
+
+/**
+ * `nil` is a presence-only marker — there is nothing to type. We still
+ * render an explanatory MessageBar so the form has visible feedback.
+ */
+export function NilEditor() {
+  return (
+    <MessageBar intent="info">
+      <MessageBarBody>
+        Stores the key with no value. Useful for tombstones or set
+        membership.
+      </MessageBarBody>
+    </MessageBar>
+  );
+}

--- a/admin/app/components/edit-vertex/editors/NumberEditor.tsx
+++ b/admin/app/components/edit-vertex/editors/NumberEditor.tsx
@@ -1,0 +1,28 @@
+import { Field, Input } from "@fluentui/react-components";
+
+export interface NumberEditorProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  hint?: string;
+  /** Native `step` for the spinner UI. */
+  step?: string;
+}
+
+/**
+ * Shared base for `float64`/`float32` editors. `type="number"` keeps the
+ * mobile-friendly numeric keypad while letting users paste raw values.
+ */
+export function NumberEditor(props: NumberEditorProps) {
+  return (
+    <Field label={props.label} hint={props.hint}>
+      <Input
+        type="number"
+        value={props.value}
+        step={props.step ?? "any"}
+        onChange={(_, data) => props.onChange(data.value)}
+        data-testid={`vertex-editor-${props.label}`}
+      />
+    </Field>
+  );
+}

--- a/admin/app/components/edit-vertex/editors/StringEditor.tsx
+++ b/admin/app/components/edit-vertex/editors/StringEditor.tsx
@@ -1,0 +1,20 @@
+import { Field, Textarea } from "@fluentui/react-components";
+
+export interface StringEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function StringEditor(props: StringEditorProps) {
+  return (
+    <Field label="string value">
+      <Textarea
+        value={props.value}
+        onChange={(_, data) => props.onChange(data.value)}
+        rows={4}
+        resize="vertical"
+        data-testid="vertex-editor-string"
+      />
+    </Field>
+  );
+}

--- a/admin/app/components/edit-vertex/editors/TimestampEditor.tsx
+++ b/admin/app/components/edit-vertex/editors/TimestampEditor.tsx
@@ -1,0 +1,26 @@
+import { Field, Input } from "@fluentui/react-components";
+
+export interface TimestampEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+/**
+ * Datetime-local accepts `YYYY-MM-DDTHH:mm`. The codec converts to ISO
+ * UTC at save time, treating the input as local-zone.
+ */
+export function TimestampEditor(props: TimestampEditorProps) {
+  return (
+    <Field
+      label="timestamp value"
+      hint="Interpreted in your local timezone, transmitted as RFC3339 UTC."
+    >
+      <Input
+        type="datetime-local"
+        value={props.value}
+        onChange={(_, data) => props.onChange(data.value)}
+        data-testid="vertex-editor-timestamp"
+      />
+    </Field>
+  );
+}

--- a/admin/app/components/edit-vertex/editors/Uint32Editor.tsx
+++ b/admin/app/components/edit-vertex/editors/Uint32Editor.tsx
@@ -1,0 +1,18 @@
+import { NumberEditor } from "./NumberEditor";
+
+export interface Uint32EditorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function Uint32Editor(props: Uint32EditorProps) {
+  return (
+    <NumberEditor
+      label="uint32 value"
+      value={props.value}
+      onChange={props.onChange}
+      hint="Unsigned 32-bit integer (0 … 4,294,967,295)."
+      step="1"
+    />
+  );
+}

--- a/admin/app/components/edit-vertex/editors/Uint64Editor.tsx
+++ b/admin/app/components/edit-vertex/editors/Uint64Editor.tsx
@@ -1,0 +1,22 @@
+import { Field, Input } from "@fluentui/react-components";
+
+export interface Uint64EditorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function Uint64Editor(props: Uint64EditorProps) {
+  return (
+    <Field
+      label="uint64 value"
+      hint="Unsigned 64-bit integer. Transmitted as a string to preserve precision."
+    >
+      <Input
+        value={props.value}
+        onChange={(_, data) => props.onChange(data.value)}
+        data-testid="vertex-editor-uint64"
+        inputMode="numeric"
+      />
+    </Field>
+  );
+}

--- a/admin/app/components/edit-vertex/editors/editor.module.css
+++ b/admin/app/components/edit-vertex/editors/editor.module.css
@@ -1,0 +1,5 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalS, 8px);
+}

--- a/admin/app/lib/client/infrastructure/api/add-edge.ts
+++ b/admin/app/lib/client/infrastructure/api/add-edge.ts
@@ -1,0 +1,32 @@
+import type { components } from "./lantern-api.gen";
+import type { LanternClient } from "./lantern-client";
+import { LanternApiError } from "./error";
+
+export type AddEdgeResponse = components["schemas"]["v1AddEdgeResponse"];
+export type AddEdgeBody = components["schemas"]["LanternServiceAddEdgeBody"];
+
+/**
+ * Calls `LanternService_AddEdge`
+ * (POST `/v1/edges/{edge.tail}/{edge.head}/add`).
+ *
+ * Non-idempotent: each call accumulates another time-decaying contribution
+ * onto the (tail, head) edge. Use `putEdge` instead for idempotent replace.
+ */
+export async function addEdge(
+  client: LanternClient,
+  tail: string,
+  head: string,
+  body: AddEdgeBody,
+  init?: { signal?: AbortSignal },
+): Promise<AddEdgeResponse> {
+  const path = `/v1/edges/${encodeURIComponent(tail)}/${encodeURIComponent(head)}/add`;
+  const response = await client.request(path, {
+    method: "POST",
+    body: JSON.stringify(body),
+    signal: init?.signal,
+  });
+  if (!response.ok) {
+    throw await LanternApiError.fromResponse(response, "AddEdge");
+  }
+  return (await response.json()) as AddEdgeResponse;
+}

--- a/admin/app/lib/client/infrastructure/api/delete-edge.ts
+++ b/admin/app/lib/client/infrastructure/api/delete-edge.ts
@@ -1,0 +1,32 @@
+import type { components } from "./lantern-api.gen";
+import type { LanternClient } from "./lantern-client";
+import { LanternApiError } from "./error";
+
+export type DeleteEdgeResponse = components["schemas"]["v1DeleteEdgeResponse"];
+
+/**
+ * Calls `LanternService_DeleteEdge` (DELETE `/v1/edges/{tail}/{head}`).
+ *
+ * HTTP 404 is treated as a successful "already gone" outcome so callers
+ * can render a single "deleted" path.
+ */
+export async function deleteEdge(
+  client: LanternClient,
+  tail: string,
+  head: string,
+  init?: { signal?: AbortSignal },
+): Promise<DeleteEdgeResponse> {
+  const path = `/v1/edges/${encodeURIComponent(tail)}/${encodeURIComponent(head)}`;
+  const response = await client.request(path, {
+    method: "DELETE",
+    signal: init?.signal,
+  });
+  if (response.status === 404) {
+    await response.text().catch(() => undefined);
+    return { existed: false };
+  }
+  if (!response.ok) {
+    throw await LanternApiError.fromResponse(response, "DeleteEdge");
+  }
+  return (await response.json()) as DeleteEdgeResponse;
+}

--- a/admin/app/lib/client/infrastructure/api/delete-vertex.ts
+++ b/admin/app/lib/client/infrastructure/api/delete-vertex.ts
@@ -1,0 +1,33 @@
+import type { components } from "./lantern-api.gen";
+import type { LanternClient } from "./lantern-client";
+import { LanternApiError } from "./error";
+
+export type DeleteVertexResponse =
+  components["schemas"]["v1DeleteVertexResponse"];
+
+/**
+ * Calls `LanternService_DeleteVertex` (DELETE `/v1/vertices/{key}`).
+ *
+ * Returns the response payload as-is, including the `existed` flag.
+ * HTTP 404 is treated as a successful "already gone" outcome
+ * (`{ existed: false }`) so callers can render a single "deleted" path.
+ */
+export async function deleteVertex(
+  client: LanternClient,
+  key: string,
+  init?: { signal?: AbortSignal },
+): Promise<DeleteVertexResponse> {
+  const path = `/v1/vertices/${encodeURIComponent(key)}`;
+  const response = await client.request(path, {
+    method: "DELETE",
+    signal: init?.signal,
+  });
+  if (response.status === 404) {
+    await response.text().catch(() => undefined);
+    return { existed: false };
+  }
+  if (!response.ok) {
+    throw await LanternApiError.fromResponse(response, "DeleteVertex");
+  }
+  return (await response.json()) as DeleteVertexResponse;
+}

--- a/admin/app/lib/client/infrastructure/api/get-edge.ts
+++ b/admin/app/lib/client/infrastructure/api/get-edge.ts
@@ -1,0 +1,33 @@
+import type { components } from "./lantern-api.gen";
+import type { LanternClient } from "./lantern-client";
+import { LanternApiError } from "./error";
+
+export type GetEdgeResponse = components["schemas"]["v1GetEdgeResponse"];
+export type Edge = components["schemas"]["v1Edge"];
+
+/**
+ * Calls `LanternService_GetEdge` (GET `/v1/edges/{tail}/{head}`).
+ *
+ * Returns `null` when the edge does not exist (HTTP 404 / NOT_FOUND).
+ */
+export async function getEdge(
+  client: LanternClient,
+  tail: string,
+  head: string,
+  init?: { signal?: AbortSignal },
+): Promise<Edge | null> {
+  const path = `/v1/edges/${encodeURIComponent(tail)}/${encodeURIComponent(head)}`;
+  const response = await client.request(path, {
+    method: "GET",
+    signal: init?.signal,
+  });
+  if (response.status === 404) {
+    await response.text().catch(() => undefined);
+    return null;
+  }
+  if (!response.ok) {
+    throw await LanternApiError.fromResponse(response, "GetEdge");
+  }
+  const body = (await response.json()) as GetEdgeResponse;
+  return body.edge ?? null;
+}

--- a/admin/app/lib/client/infrastructure/api/get-vertex.ts
+++ b/admin/app/lib/client/infrastructure/api/get-vertex.ts
@@ -1,0 +1,34 @@
+import type { components } from "./lantern-api.gen";
+import type { LanternClient } from "./lantern-client";
+import { LanternApiError } from "./error";
+
+export type GetVertexResponse = components["schemas"]["v1GetVertexResponse"];
+export type Vertex = components["schemas"]["v1Vertex"];
+
+/**
+ * Calls `LanternService_GetVertex` (GET `/v1/vertices/{key}`).
+ *
+ * Returns `null` when the vertex does not exist (HTTP 404 / NOT_FOUND).
+ * Any other non-2xx response is thrown as a `LanternApiError`.
+ */
+export async function getVertex(
+  client: LanternClient,
+  key: string,
+  init?: { signal?: AbortSignal },
+): Promise<Vertex | null> {
+  const path = `/v1/vertices/${encodeURIComponent(key)}`;
+  const response = await client.request(path, {
+    method: "GET",
+    signal: init?.signal,
+  });
+  if (response.status === 404) {
+    // Drain body to release the connection.
+    await response.text().catch(() => undefined);
+    return null;
+  }
+  if (!response.ok) {
+    throw await LanternApiError.fromResponse(response, "GetVertex");
+  }
+  const body = (await response.json()) as GetVertexResponse;
+  return body.vertex ?? null;
+}

--- a/admin/app/lib/client/infrastructure/api/put-edge.ts
+++ b/admin/app/lib/client/infrastructure/api/put-edge.ts
@@ -1,0 +1,32 @@
+import type { components } from "./lantern-api.gen";
+import type { LanternClient } from "./lantern-client";
+import { LanternApiError } from "./error";
+
+export type PutEdgeResponse = components["schemas"]["v1PutEdgeResponse"];
+export type PutEdgeBody = components["schemas"]["LanternServicePutEdgeBody"];
+
+/**
+ * Calls `LanternService_PutEdge` (PUT `/v1/edges/{edge.tail}/{edge.head}`).
+ *
+ * Idempotent: overwrites the (tail, head) edge with the supplied weight
+ * and expiration. The CRUD UI surfaces this side-by-side with
+ * `AddEdge` so users see the additive vs replacing distinction.
+ */
+export async function putEdge(
+  client: LanternClient,
+  tail: string,
+  head: string,
+  body: PutEdgeBody,
+  init?: { signal?: AbortSignal },
+): Promise<PutEdgeResponse> {
+  const path = `/v1/edges/${encodeURIComponent(tail)}/${encodeURIComponent(head)}`;
+  const response = await client.request(path, {
+    method: "PUT",
+    body: JSON.stringify(body),
+    signal: init?.signal,
+  });
+  if (!response.ok) {
+    throw await LanternApiError.fromResponse(response, "PutEdge");
+  }
+  return (await response.json()) as PutEdgeResponse;
+}

--- a/admin/app/lib/client/infrastructure/api/put-vertex.ts
+++ b/admin/app/lib/client/infrastructure/api/put-vertex.ts
@@ -1,0 +1,32 @@
+import type { components } from "./lantern-api.gen";
+import type { LanternClient } from "./lantern-client";
+import { LanternApiError } from "./error";
+
+export type PutVertexResponse = components["schemas"]["v1PutVertexResponse"];
+export type PutVertexBody =
+  components["schemas"]["LanternServicePutVertexBody"];
+
+/**
+ * Calls `LanternService_PutVertex` (PUT `/v1/vertices/{vertex.key}`).
+ *
+ * Idempotent upsert for a single vertex by key. The key travels in the
+ * URL path; the body carries the value oneof and TTL via the wrapping
+ * `vertex` object minus its own `key` field.
+ */
+export async function putVertex(
+  client: LanternClient,
+  key: string,
+  body: PutVertexBody,
+  init?: { signal?: AbortSignal },
+): Promise<PutVertexResponse> {
+  const path = `/v1/vertices/${encodeURIComponent(key)}`;
+  const response = await client.request(path, {
+    method: "PUT",
+    body: JSON.stringify(body),
+    signal: init?.signal,
+  });
+  if (!response.ok) {
+    throw await LanternApiError.fromResponse(response, "PutVertex");
+  }
+  return (await response.json()) as PutVertexResponse;
+}

--- a/admin/app/lib/client/usecase/edit-edge/edge-codec.test.ts
+++ b/admin/app/lib/client/usecase/edit-edge/edge-codec.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildAddEdgeBody,
+  buildPutEdgeBody,
+  inputsFromEdge,
+} from "./edge-codec";
+import { INITIAL_TTL_INPUT } from "../edit-vertex/value-codec";
+
+const FIXED_NOW = Date.parse("2026-01-02T03:04:05Z");
+
+describe("edge-codec", () => {
+  test("buildAddEdgeBody with positive weight + preset TTL", () => {
+    const out = buildAddEdgeBody(
+      { weight: "0.5", ttl: { ...INITIAL_TTL_INPUT, mode: "preset5m" } },
+      FIXED_NOW,
+    );
+    expect(out.error).toBeNull();
+    expect(out.body?.edge?.weight).toBe(0.5);
+    expect(out.body?.edge?.expiration).toBe(
+      new Date(FIXED_NOW + 5 * 60_000).toISOString(),
+    );
+  });
+
+  test("buildPutEdgeBody allows negative weight", () => {
+    const out = buildPutEdgeBody(
+      { weight: "-1.25", ttl: { ...INITIAL_TTL_INPUT, mode: "none" } },
+      FIXED_NOW,
+    );
+    expect(out.error).toBeNull();
+    expect(out.body?.edge?.weight).toBe(-1.25);
+    expect(out.body?.edge?.expiration).toBeUndefined();
+  });
+
+  test("rejects empty weight", () => {
+    const out = buildAddEdgeBody(
+      { weight: "", ttl: INITIAL_TTL_INPUT },
+      FIXED_NOW,
+    );
+    expect(out.body).toBeNull();
+    expect(out.error).toMatch(/weight/i);
+  });
+
+  test("rejects NaN weight", () => {
+    const out = buildPutEdgeBody(
+      { weight: "abc", ttl: INITIAL_TTL_INPUT },
+      FIXED_NOW,
+    );
+    expect(out.body).toBeNull();
+  });
+
+  test("rejects invalid custom TTL", () => {
+    const out = buildAddEdgeBody(
+      {
+        weight: "1",
+        ttl: { mode: "custom", custom: "xyz" },
+      },
+      FIXED_NOW,
+    );
+    expect(out.body).toBeNull();
+  });
+
+  test("inputsFromEdge seeds weight from existing edge", () => {
+    expect(inputsFromEdge({ tail: "a", head: "b", weight: 2.5 }).weight).toBe(
+      "2.5",
+    );
+    expect(inputsFromEdge(null).weight).toBe("1");
+  });
+});

--- a/admin/app/lib/client/usecase/edit-edge/edge-codec.ts
+++ b/admin/app/lib/client/usecase/edit-edge/edge-codec.ts
@@ -1,0 +1,77 @@
+import type { Edge } from "~/lib/client/infrastructure/api/get-edge";
+import type { PutEdgeBody } from "~/lib/client/infrastructure/api/put-edge";
+import type { AddEdgeBody } from "~/lib/client/infrastructure/api/add-edge";
+import { parseGoDuration, ttlToExpiration, type TtlInput, INITIAL_TTL_INPUT } from "../edit-vertex/value-codec";
+
+export type EdgeWriteMode = "add" | "put";
+
+export interface EdgeWriteInputs {
+  weight: string;
+  ttl: TtlInput;
+}
+
+export const INITIAL_EDGE_WRITE_INPUTS: EdgeWriteInputs = {
+  weight: "1",
+  ttl: INITIAL_TTL_INPUT,
+};
+
+export interface BuildEdgeBodyResult<TBody> {
+  body: TBody | null;
+  error: string | null;
+}
+
+function buildWeightAndExpiration(
+  inputs: EdgeWriteInputs,
+  now: number,
+): { weight: number; expiration: string | undefined; error: string | null } {
+  const raw = inputs.weight.trim();
+  if (raw === "") {
+    return { weight: 0, expiration: undefined, error: "Weight is required." };
+  }
+  const weight = Number(raw);
+  if (!Number.isFinite(weight)) {
+    return {
+      weight: 0,
+      expiration: undefined,
+      error: "Weight must be a finite number.",
+    };
+  }
+  const { iso, error } = ttlToExpiration(inputs.ttl, now);
+  if (error) {
+    return { weight: 0, expiration: undefined, error };
+  }
+  return { weight, expiration: iso, error: null };
+}
+
+export function buildAddEdgeBody(
+  inputs: EdgeWriteInputs,
+  now: number = Date.now(),
+): BuildEdgeBodyResult<AddEdgeBody> {
+  const { weight, expiration, error } = buildWeightAndExpiration(inputs, now);
+  if (error) return { body: null, error };
+  const edge: AddEdgeBody["edge"] = { weight };
+  if (expiration) edge.expiration = expiration;
+  return { body: { edge }, error: null };
+}
+
+export function buildPutEdgeBody(
+  inputs: EdgeWriteInputs,
+  now: number = Date.now(),
+): BuildEdgeBodyResult<PutEdgeBody> {
+  const { weight, expiration, error } = buildWeightAndExpiration(inputs, now);
+  if (error) return { body: null, error };
+  const edge: PutEdgeBody["edge"] = { weight };
+  if (expiration) edge.expiration = expiration;
+  return { body: { edge }, error: null };
+}
+
+/** Re-export so consumers can pull duration helpers from one module. */
+export { parseGoDuration };
+
+/** Seeds editor inputs from a loaded edge. */
+export function inputsFromEdge(edge: Edge | null): EdgeWriteInputs {
+  return {
+    weight: edge?.weight !== undefined ? String(edge.weight) : "1",
+    ttl: INITIAL_TTL_INPUT,
+  };
+}

--- a/admin/app/lib/client/usecase/edit-edge/edge-codec.ts
+++ b/admin/app/lib/client/usecase/edit-edge/edge-codec.ts
@@ -1,7 +1,12 @@
 import type { Edge } from "~/lib/client/infrastructure/api/get-edge";
 import type { PutEdgeBody } from "~/lib/client/infrastructure/api/put-edge";
 import type { AddEdgeBody } from "~/lib/client/infrastructure/api/add-edge";
-import { parseGoDuration, ttlToExpiration, type TtlInput, INITIAL_TTL_INPUT } from "../edit-vertex/value-codec";
+import {
+  parseGoDuration,
+  ttlToExpiration,
+  type TtlInput,
+  INITIAL_TTL_INPUT,
+} from "../edit-vertex/value-codec";
 
 export type EdgeWriteMode = "add" | "put";
 

--- a/admin/app/lib/client/usecase/edit-edge/handlers.ts
+++ b/admin/app/lib/client/usecase/edit-edge/handlers.ts
@@ -1,0 +1,128 @@
+import { addEdge } from "~/lib/client/infrastructure/api/add-edge";
+import type { AddEdgeBody } from "~/lib/client/infrastructure/api/add-edge";
+import { deleteEdge } from "~/lib/client/infrastructure/api/delete-edge";
+import { LanternApiError } from "~/lib/client/infrastructure/api/error";
+import { getEdge } from "~/lib/client/infrastructure/api/get-edge";
+import type { LanternClient } from "~/lib/client/infrastructure/api/lantern-client";
+import { putEdge } from "~/lib/client/infrastructure/api/put-edge";
+import type { PutEdgeBody } from "~/lib/client/infrastructure/api/put-edge";
+import type { EditEdgeAction } from "./reducer";
+
+export interface LoadEdgeInput {
+  client: LanternClient;
+  tail: string;
+  head: string;
+  epoch: number;
+  signal?: AbortSignal;
+}
+
+export async function loadEdge(
+  input: LoadEdgeInput,
+  dispatch: (action: EditEdgeAction) => void,
+): Promise<void> {
+  dispatch({ type: "LOAD_REQUESTED", epoch: input.epoch });
+  try {
+    const edge = await getEdge(input.client, input.tail, input.head, {
+      signal: input.signal,
+    });
+    dispatch({ type: "LOAD_RECEIVED", epoch: input.epoch, edge });
+  } catch (err) {
+    if (isAbortError(err)) return;
+    dispatch({
+      type: "LOAD_FAILED",
+      epoch: input.epoch,
+      error: messageOf(err),
+    });
+  }
+}
+
+export interface AddEdgeInput {
+  client: LanternClient;
+  tail: string;
+  head: string;
+  body: AddEdgeBody;
+  signal?: AbortSignal;
+}
+
+export async function addEdgeHandler(
+  input: AddEdgeInput,
+  dispatch: (action: EditEdgeAction) => void,
+): Promise<void> {
+  dispatch({ type: "WRITE_REQUESTED", mode: "add" });
+  try {
+    await addEdge(input.client, input.tail, input.head, input.body, {
+      signal: input.signal,
+    });
+    const fresh = await getEdge(input.client, input.tail, input.head, {
+      signal: input.signal,
+    });
+    dispatch({ type: "WRITE_SUCCEEDED", mode: "add", edge: fresh });
+  } catch (err) {
+    if (isAbortError(err)) return;
+    dispatch({ type: "WRITE_FAILED", mode: "add", error: messageOf(err) });
+  }
+}
+
+export interface PutEdgeInput {
+  client: LanternClient;
+  tail: string;
+  head: string;
+  body: PutEdgeBody;
+  signal?: AbortSignal;
+}
+
+export async function putEdgeHandler(
+  input: PutEdgeInput,
+  dispatch: (action: EditEdgeAction) => void,
+): Promise<void> {
+  dispatch({ type: "WRITE_REQUESTED", mode: "put" });
+  try {
+    await putEdge(input.client, input.tail, input.head, input.body, {
+      signal: input.signal,
+    });
+    const fresh = await getEdge(input.client, input.tail, input.head, {
+      signal: input.signal,
+    });
+    dispatch({ type: "WRITE_SUCCEEDED", mode: "put", edge: fresh });
+  } catch (err) {
+    if (isAbortError(err)) return;
+    dispatch({ type: "WRITE_FAILED", mode: "put", error: messageOf(err) });
+  }
+}
+
+export interface DeleteEdgeInput {
+  client: LanternClient;
+  tail: string;
+  head: string;
+  signal?: AbortSignal;
+}
+
+export async function deleteEdgeHandler(
+  input: DeleteEdgeInput,
+  dispatch: (action: EditEdgeAction) => void,
+): Promise<void> {
+  dispatch({ type: "DELETE_REQUESTED" });
+  try {
+    await deleteEdge(input.client, input.tail, input.head, {
+      signal: input.signal,
+    });
+    dispatch({ type: "DELETE_SUCCEEDED" });
+  } catch (err) {
+    if (isAbortError(err)) return;
+    dispatch({ type: "DELETE_FAILED", error: messageOf(err) });
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}
+
+function messageOf(err: unknown): string {
+  if (err instanceof LanternApiError) {
+    return err.grpcMessage ?? err.message;
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}

--- a/admin/app/lib/client/usecase/edit-edge/reducer.test.ts
+++ b/admin/app/lib/client/usecase/edit-edge/reducer.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { editEdgeReducer } from "./reducer";
+import { INITIAL_EDIT_EDGE_STATE } from "./state";
+
+describe("editEdgeReducer", () => {
+  test("TARGET_CHANGED bumps epoch", () => {
+    const next = editEdgeReducer(INITIAL_EDIT_EDGE_STATE, {
+      type: "TARGET_CHANGED",
+      tail: "a",
+      head: "b",
+    });
+    expect(next.tail).toBe("a");
+    expect(next.head).toBe("b");
+    expect(next.loadEpoch).toBe(1);
+  });
+
+  test("LOAD_RECEIVED seeds put inputs but clears add inputs", () => {
+    const seeded = editEdgeReducer(
+      { ...INITIAL_EDIT_EDGE_STATE, loadEpoch: 1 },
+      {
+        type: "LOAD_RECEIVED",
+        epoch: 1,
+        edge: { tail: "a", head: "b", weight: 3 },
+      },
+    );
+    expect(seeded.loadStatus).toBe("ready");
+    expect(seeded.putInputs.weight).toBe("3");
+    expect(seeded.addInputs.weight).toBe("1");
+  });
+
+  test("LOAD_RECEIVED with null marks not-found", () => {
+    const out = editEdgeReducer(
+      { ...INITIAL_EDIT_EDGE_STATE, loadEpoch: 1 },
+      { type: "LOAD_RECEIVED", epoch: 1, edge: null },
+    );
+    expect(out.loadStatus).toBe("not-found");
+    expect(out.edge).toBeNull();
+  });
+
+  test("WRITE_SUCCEEDED for add resets add inputs but keeps put inputs", () => {
+    const start = {
+      ...INITIAL_EDIT_EDGE_STATE,
+      addInputs: { ...INITIAL_EDIT_EDGE_STATE.addInputs, weight: "5" },
+      putInputs: { ...INITIAL_EDIT_EDGE_STATE.putInputs, weight: "10" },
+      addStatus: "saving" as const,
+    };
+    const out = editEdgeReducer(start, {
+      type: "WRITE_SUCCEEDED",
+      mode: "add",
+      edge: { tail: "a", head: "b", weight: 15 },
+    });
+    expect(out.addStatus).toBe("saved");
+    expect(out.addInputs.weight).toBe("1");
+    expect(out.putInputs.weight).toBe("10");
+    expect(out.edge?.weight).toBe(15);
+  });
+
+  test("WRITE_SUCCEEDED for put refreshes put inputs from server", () => {
+    const start = { ...INITIAL_EDIT_EDGE_STATE, putStatus: "saving" as const };
+    const out = editEdgeReducer(start, {
+      type: "WRITE_SUCCEEDED",
+      mode: "put",
+      edge: { tail: "a", head: "b", weight: 9.5 },
+    });
+    expect(out.putStatus).toBe("saved");
+    expect(out.putInputs.weight).toBe("9.5");
+  });
+
+  test("DELETE_SUCCEEDED clears edge state", () => {
+    const start = {
+      ...INITIAL_EDIT_EDGE_STATE,
+      edge: { tail: "a", head: "b", weight: 1 },
+      deleteRequested: true,
+      deleteStatus: "deleting" as const,
+    };
+    const out = editEdgeReducer(start, { type: "DELETE_SUCCEEDED" });
+    expect(out.edge).toBeNull();
+    expect(out.deleteStatus).toBe("deleted");
+    expect(out.deleteRequested).toBe(false);
+  });
+});

--- a/admin/app/lib/client/usecase/edit-edge/reducer.ts
+++ b/admin/app/lib/client/usecase/edit-edge/reducer.ts
@@ -1,0 +1,158 @@
+import type { Edge } from "~/lib/client/infrastructure/api/get-edge";
+import {
+  INITIAL_EDIT_EDGE_STATE,
+  type EditEdgeState,
+} from "./state";
+import {
+  INITIAL_EDGE_WRITE_INPUTS,
+  inputsFromEdge,
+  type EdgeWriteInputs,
+  type EdgeWriteMode,
+} from "./edge-codec";
+import type { TtlInput } from "../edit-vertex/value-codec";
+
+export type EditEdgeAction =
+  | { type: "TARGET_CHANGED"; tail: string; head: string }
+  | { type: "LOAD_REQUESTED"; epoch: number }
+  | { type: "LOAD_RECEIVED"; epoch: number; edge: Edge | null }
+  | { type: "LOAD_FAILED"; epoch: number; error: string }
+  | { type: "WEIGHT_CHANGED"; mode: EdgeWriteMode; value: string }
+  | { type: "TTL_CHANGED"; mode: EdgeWriteMode; ttl: TtlInput }
+  | { type: "WRITE_REQUESTED"; mode: EdgeWriteMode }
+  | { type: "WRITE_SUCCEEDED"; mode: EdgeWriteMode; edge: Edge | null }
+  | { type: "WRITE_FAILED"; mode: EdgeWriteMode; error: string }
+  | { type: "DELETE_OPENED" }
+  | { type: "DELETE_CANCELED" }
+  | { type: "DELETE_REQUESTED" }
+  | { type: "DELETE_SUCCEEDED" }
+  | { type: "DELETE_FAILED"; error: string }
+  | { type: "RESET" };
+
+function applyInputUpdate(
+  state: EditEdgeState,
+  mode: EdgeWriteMode,
+  update: (prev: EdgeWriteInputs) => EdgeWriteInputs,
+): EditEdgeState {
+  if (mode === "add") {
+    return { ...state, addInputs: update(state.addInputs) };
+  }
+  return { ...state, putInputs: update(state.putInputs) };
+}
+
+export function editEdgeReducer(
+  state: EditEdgeState,
+  action: EditEdgeAction,
+): EditEdgeState {
+  switch (action.type) {
+    case "TARGET_CHANGED": {
+      if (
+        action.tail === state.tail &&
+        action.head === state.head &&
+        state.loadStatus !== "idle"
+      ) {
+        return state;
+      }
+      return {
+        ...INITIAL_EDIT_EDGE_STATE,
+        tail: action.tail,
+        head: action.head,
+        loadEpoch: state.loadEpoch + 1,
+      };
+    }
+    case "LOAD_REQUESTED": {
+      if (action.epoch !== state.loadEpoch) return state;
+      return {
+        ...state,
+        loadStatus: "loading",
+        loadError: null,
+        edge: null,
+        addStatus: "idle",
+        addError: null,
+        putStatus: "idle",
+        putError: null,
+      };
+    }
+    case "LOAD_RECEIVED": {
+      if (action.epoch !== state.loadEpoch) return state;
+      const seeded = inputsFromEdge(action.edge);
+      return {
+        ...state,
+        loadStatus: action.edge ? "ready" : "not-found",
+        edge: action.edge,
+        addInputs: INITIAL_EDGE_WRITE_INPUTS,
+        putInputs: seeded,
+      };
+    }
+    case "LOAD_FAILED": {
+      if (action.epoch !== state.loadEpoch) return state;
+      return { ...state, loadStatus: "error", loadError: action.error };
+    }
+    case "WEIGHT_CHANGED": {
+      return applyInputUpdate(state, action.mode, (prev) => ({
+        ...prev,
+        weight: action.value,
+      }));
+    }
+    case "TTL_CHANGED": {
+      return applyInputUpdate(state, action.mode, (prev) => ({
+        ...prev,
+        ttl: action.ttl,
+      }));
+    }
+    case "WRITE_REQUESTED": {
+      if (action.mode === "add") {
+        return { ...state, addStatus: "saving", addError: null };
+      }
+      return { ...state, putStatus: "saving", putError: null };
+    }
+    case "WRITE_SUCCEEDED": {
+      const next: EditEdgeState = {
+        ...state,
+        edge: action.edge ?? state.edge,
+        loadStatus: action.edge ? "ready" : state.loadStatus,
+      };
+      if (action.mode === "add") {
+        next.addStatus = "saved";
+        next.addInputs = INITIAL_EDGE_WRITE_INPUTS;
+      } else {
+        next.putStatus = "saved";
+        next.putInputs = inputsFromEdge(action.edge);
+      }
+      return next;
+    }
+    case "WRITE_FAILED": {
+      if (action.mode === "add") {
+        return { ...state, addStatus: "error", addError: action.error };
+      }
+      return { ...state, putStatus: "error", putError: action.error };
+    }
+    case "DELETE_OPENED": {
+      return { ...state, deleteRequested: true, deleteError: null };
+    }
+    case "DELETE_CANCELED": {
+      return { ...state, deleteRequested: false };
+    }
+    case "DELETE_REQUESTED": {
+      return { ...state, deleteStatus: "deleting", deleteError: null };
+    }
+    case "DELETE_SUCCEEDED": {
+      return {
+        ...state,
+        deleteStatus: "deleted",
+        deleteRequested: false,
+        edge: null,
+        loadStatus: "not-found",
+      };
+    }
+    case "DELETE_FAILED": {
+      return {
+        ...state,
+        deleteStatus: "error",
+        deleteError: action.error,
+        deleteRequested: false,
+      };
+    }
+    case "RESET":
+      return INITIAL_EDIT_EDGE_STATE;
+  }
+}

--- a/admin/app/lib/client/usecase/edit-edge/reducer.ts
+++ b/admin/app/lib/client/usecase/edit-edge/reducer.ts
@@ -1,8 +1,5 @@
 import type { Edge } from "~/lib/client/infrastructure/api/get-edge";
-import {
-  INITIAL_EDIT_EDGE_STATE,
-  type EditEdgeState,
-} from "./state";
+import { INITIAL_EDIT_EDGE_STATE, type EditEdgeState } from "./state";
 import {
   INITIAL_EDGE_WRITE_INPUTS,
   inputsFromEdge,

--- a/admin/app/lib/client/usecase/edit-edge/selectors.ts
+++ b/admin/app/lib/client/usecase/edit-edge/selectors.ts
@@ -1,0 +1,36 @@
+import type { EditEdgeState } from "./state";
+import {
+  buildAddEdgeBody,
+  buildPutEdgeBody,
+  type BuildEdgeBodyResult,
+} from "./edge-codec";
+import type { AddEdgeBody } from "~/lib/client/infrastructure/api/add-edge";
+import type { PutEdgeBody } from "~/lib/client/infrastructure/api/put-edge";
+
+export function selectAddBody(
+  state: EditEdgeState,
+  now: number = Date.now(),
+): BuildEdgeBodyResult<AddEdgeBody> {
+  return buildAddEdgeBody(state.addInputs, now);
+}
+
+export function selectPutBody(
+  state: EditEdgeState,
+  now: number = Date.now(),
+): BuildEdgeBodyResult<PutEdgeBody> {
+  return buildPutEdgeBody(state.putInputs, now);
+}
+
+export function selectAddValid(
+  state: EditEdgeState,
+  now: number = Date.now(),
+): boolean {
+  return selectAddBody(state, now).body !== null;
+}
+
+export function selectPutValid(
+  state: EditEdgeState,
+  now: number = Date.now(),
+): boolean {
+  return selectPutBody(state, now).body !== null;
+}

--- a/admin/app/lib/client/usecase/edit-edge/state.ts
+++ b/admin/app/lib/client/usecase/edit-edge/state.ts
@@ -1,0 +1,65 @@
+import type { Edge } from "~/lib/client/infrastructure/api/get-edge";
+import {
+  INITIAL_EDGE_WRITE_INPUTS,
+  type EdgeWriteInputs,
+} from "./edge-codec";
+
+export type EditEdgeLoadStatus =
+  | "idle"
+  | "loading"
+  | "ready"
+  | "not-found"
+  | "error";
+
+export type EditEdgeWriteStatus = "idle" | "saving" | "saved" | "error";
+
+export type EditEdgeDeleteStatus =
+  | "idle"
+  | "deleting"
+  | "deleted"
+  | "error";
+
+/**
+ * State for the single-edge CRUD screen. Holds two independent forms —
+ * one for `AddEdge` (accumulating contributions) and one for `PutEdge`
+ * (idempotent replacement) — so the user can author both side-by-side
+ * without losing partial input.
+ */
+export interface EditEdgeState {
+  tail: string;
+  head: string;
+  loadEpoch: number;
+  loadStatus: EditEdgeLoadStatus;
+  loadError: string | null;
+  edge: Edge | null;
+
+  addInputs: EdgeWriteInputs;
+  putInputs: EdgeWriteInputs;
+
+  addStatus: EditEdgeWriteStatus;
+  addError: string | null;
+  putStatus: EditEdgeWriteStatus;
+  putError: string | null;
+
+  deleteStatus: EditEdgeDeleteStatus;
+  deleteError: string | null;
+  deleteRequested: boolean;
+}
+
+export const INITIAL_EDIT_EDGE_STATE: EditEdgeState = {
+  tail: "",
+  head: "",
+  loadEpoch: 0,
+  loadStatus: "idle",
+  loadError: null,
+  edge: null,
+  addInputs: INITIAL_EDGE_WRITE_INPUTS,
+  putInputs: INITIAL_EDGE_WRITE_INPUTS,
+  addStatus: "idle",
+  addError: null,
+  putStatus: "idle",
+  putError: null,
+  deleteStatus: "idle",
+  deleteError: null,
+  deleteRequested: false,
+};

--- a/admin/app/lib/client/usecase/edit-edge/state.ts
+++ b/admin/app/lib/client/usecase/edit-edge/state.ts
@@ -1,8 +1,5 @@
 import type { Edge } from "~/lib/client/infrastructure/api/get-edge";
-import {
-  INITIAL_EDGE_WRITE_INPUTS,
-  type EdgeWriteInputs,
-} from "./edge-codec";
+import { INITIAL_EDGE_WRITE_INPUTS, type EdgeWriteInputs } from "./edge-codec";
 
 export type EditEdgeLoadStatus =
   | "idle"
@@ -13,11 +10,7 @@ export type EditEdgeLoadStatus =
 
 export type EditEdgeWriteStatus = "idle" | "saving" | "saved" | "error";
 
-export type EditEdgeDeleteStatus =
-  | "idle"
-  | "deleting"
-  | "deleted"
-  | "error";
+export type EditEdgeDeleteStatus = "idle" | "deleting" | "deleted" | "error";
 
 /**
  * State for the single-edge CRUD screen. Holds two independent forms —

--- a/admin/app/lib/client/usecase/edit-edge/use-edit-edge.ts
+++ b/admin/app/lib/client/usecase/edit-edge/use-edit-edge.ts
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
+import {
+  addEdgeHandler,
+  deleteEdgeHandler,
+  loadEdge,
+  putEdgeHandler,
+} from "./handlers";
+import { editEdgeReducer } from "./reducer";
+import { INITIAL_EDIT_EDGE_STATE, type EditEdgeState } from "./state";
+import type { EdgeWriteMode } from "./edge-codec";
+import {
+  selectAddBody,
+  selectAddValid,
+  selectPutBody,
+  selectPutValid,
+} from "./selectors";
+import type { TtlInput } from "../edit-vertex/value-codec";
+
+export interface UseEditEdgeResult {
+  state: EditEdgeState;
+  addValid: boolean;
+  putValid: boolean;
+  deleted: boolean;
+  setWeight: (mode: EdgeWriteMode, value: string) => void;
+  setTtl: (mode: EdgeWriteMode, ttl: TtlInput) => void;
+  submitAdd: () => Promise<void>;
+  submitPut: () => Promise<void>;
+  openDeleteDialog: () => void;
+  closeDeleteDialog: () => void;
+  confirmDelete: () => Promise<void>;
+  reload: () => void;
+}
+
+export function useEditEdge(tail: string, head: string): UseEditEdgeResult {
+  const client = useLanternClient();
+  const [state, dispatch] = useReducer(
+    editEdgeReducer,
+    INITIAL_EDIT_EDGE_STATE,
+  );
+
+  useEffect(() => {
+    dispatch({ type: "TARGET_CHANGED", tail, head });
+  }, [tail, head]);
+
+  const lastEpochRef = useRef<number>(-1);
+  useEffect(() => {
+    if (state.tail === "" || state.head === "") return;
+    if (state.loadEpoch === lastEpochRef.current) return;
+    lastEpochRef.current = state.loadEpoch;
+    const controller = new AbortController();
+    void loadEdge(
+      {
+        client,
+        tail: state.tail,
+        head: state.head,
+        epoch: state.loadEpoch,
+        signal: controller.signal,
+      },
+      dispatch,
+    );
+    return () => controller.abort();
+  }, [client, state.tail, state.head, state.loadEpoch]);
+
+  const setWeight = useCallback((mode: EdgeWriteMode, value: string) => {
+    dispatch({ type: "WEIGHT_CHANGED", mode, value });
+  }, []);
+  const setTtl = useCallback((mode: EdgeWriteMode, ttl: TtlInput) => {
+    dispatch({ type: "TTL_CHANGED", mode, ttl });
+  }, []);
+
+  const submitAdd = useCallback(async () => {
+    const { body, error } = selectAddBody(state);
+    if (!body) {
+      if (error) {
+        dispatch({ type: "WRITE_FAILED", mode: "add", error });
+      }
+      return;
+    }
+    await addEdgeHandler(
+      { client, tail: state.tail, head: state.head, body },
+      dispatch,
+    );
+  }, [client, state]);
+
+  const submitPut = useCallback(async () => {
+    const { body, error } = selectPutBody(state);
+    if (!body) {
+      if (error) {
+        dispatch({ type: "WRITE_FAILED", mode: "put", error });
+      }
+      return;
+    }
+    await putEdgeHandler(
+      { client, tail: state.tail, head: state.head, body },
+      dispatch,
+    );
+  }, [client, state]);
+
+  const openDeleteDialog = useCallback(() => {
+    dispatch({ type: "DELETE_OPENED" });
+  }, []);
+  const closeDeleteDialog = useCallback(() => {
+    dispatch({ type: "DELETE_CANCELED" });
+  }, []);
+  const confirmDelete = useCallback(async () => {
+    await deleteEdgeHandler(
+      { client, tail: state.tail, head: state.head },
+      dispatch,
+    );
+  }, [client, state.tail, state.head]);
+
+  const reload = useCallback(() => {
+    dispatch({ type: "TARGET_CHANGED", tail, head });
+  }, [tail, head]);
+
+  const addValid = useMemo(() => selectAddValid(state), [state]);
+  const putValid = useMemo(() => selectPutValid(state), [state]);
+  const deleted = state.deleteStatus === "deleted";
+
+  return useMemo(
+    () => ({
+      state,
+      addValid,
+      putValid,
+      deleted,
+      setWeight,
+      setTtl,
+      submitAdd,
+      submitPut,
+      openDeleteDialog,
+      closeDeleteDialog,
+      confirmDelete,
+      reload,
+    }),
+    [
+      state,
+      addValid,
+      putValid,
+      deleted,
+      setWeight,
+      setTtl,
+      submitAdd,
+      submitPut,
+      openDeleteDialog,
+      closeDeleteDialog,
+      confirmDelete,
+      reload,
+    ],
+  );
+}

--- a/admin/app/lib/client/usecase/edit-vertex/handlers.ts
+++ b/admin/app/lib/client/usecase/edit-vertex/handlers.ts
@@ -1,0 +1,106 @@
+import { deleteVertex } from "~/lib/client/infrastructure/api/delete-vertex";
+import { LanternApiError } from "~/lib/client/infrastructure/api/error";
+import { getVertex } from "~/lib/client/infrastructure/api/get-vertex";
+import type { LanternClient } from "~/lib/client/infrastructure/api/lantern-client";
+import { putVertex } from "~/lib/client/infrastructure/api/put-vertex";
+import type { PutVertexBody } from "~/lib/client/infrastructure/api/put-vertex";
+import type { EditVertexAction } from "./reducer";
+
+export interface LoadVertexInput {
+  client: LanternClient;
+  key: string;
+  epoch: number;
+  signal?: AbortSignal;
+}
+
+export async function loadVertex(
+  input: LoadVertexInput,
+  dispatch: (action: EditVertexAction) => void,
+): Promise<void> {
+  dispatch({ type: "LOAD_REQUESTED", epoch: input.epoch });
+  try {
+    const vertex = await getVertex(input.client, input.key, {
+      signal: input.signal,
+    });
+    dispatch({ type: "LOAD_RECEIVED", epoch: input.epoch, vertex });
+  } catch (err) {
+    if (isAbortError(err)) return;
+    dispatch({
+      type: "LOAD_FAILED",
+      epoch: input.epoch,
+      error: messageOf(err),
+    });
+  }
+}
+
+export interface SaveVertexInput {
+  client: LanternClient;
+  key: string;
+  body: PutVertexBody;
+  signal?: AbortSignal;
+}
+
+/**
+ * Performs the PutVertex round-trip and then re-reads the vertex so the
+ * view shows the canonical server-side representation (including any
+ * server-applied normalization).
+ */
+export async function saveVertex(
+  input: SaveVertexInput,
+  dispatch: (action: EditVertexAction) => void,
+): Promise<void> {
+  dispatch({ type: "SAVE_REQUESTED" });
+  try {
+    await putVertex(input.client, input.key, input.body, {
+      signal: input.signal,
+    });
+    const fresh = await getVertex(input.client, input.key, {
+      signal: input.signal,
+    });
+    if (!fresh) {
+      dispatch({
+        type: "SAVE_FAILED",
+        error: "Vertex disappeared immediately after save.",
+      });
+      return;
+    }
+    dispatch({ type: "SAVE_SUCCEEDED", vertex: fresh });
+  } catch (err) {
+    if (isAbortError(err)) return;
+    dispatch({ type: "SAVE_FAILED", error: messageOf(err) });
+  }
+}
+
+export interface DeleteVertexInput {
+  client: LanternClient;
+  key: string;
+  signal?: AbortSignal;
+}
+
+export async function deleteVertexHandler(
+  input: DeleteVertexInput,
+  dispatch: (action: EditVertexAction) => void,
+): Promise<void> {
+  dispatch({ type: "DELETE_REQUESTED" });
+  try {
+    await deleteVertex(input.client, input.key, { signal: input.signal });
+    dispatch({ type: "DELETE_SUCCEEDED" });
+  } catch (err) {
+    if (isAbortError(err)) return;
+    dispatch({ type: "DELETE_FAILED", error: messageOf(err) });
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}
+
+function messageOf(err: unknown): string {
+  if (err instanceof LanternApiError) {
+    return err.grpcMessage ?? err.message;
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}

--- a/admin/app/lib/client/usecase/edit-vertex/reducer.test.ts
+++ b/admin/app/lib/client/usecase/edit-vertex/reducer.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import { editVertexReducer } from "./reducer";
+import { INITIAL_EDIT_VERTEX_STATE } from "./state";
+
+describe("editVertexReducer", () => {
+  test("KEY_CHANGED bumps epoch and resets", () => {
+    const s1 = editVertexReducer(INITIAL_EDIT_VERTEX_STATE, {
+      type: "KEY_CHANGED",
+      key: "a",
+    });
+    expect(s1.key).toBe("a");
+    expect(s1.loadEpoch).toBe(1);
+    expect(s1.loadStatus).toBe("idle");
+  });
+
+  test("LOAD_REQUESTED only applies for matching epoch", () => {
+    const s1 = editVertexReducer(INITIAL_EDIT_VERTEX_STATE, {
+      type: "KEY_CHANGED",
+      key: "a",
+    });
+    const stale = editVertexReducer(s1, {
+      type: "LOAD_REQUESTED",
+      epoch: 0,
+    });
+    expect(stale.loadStatus).toBe("idle");
+    const fresh = editVertexReducer(s1, {
+      type: "LOAD_REQUESTED",
+      epoch: 1,
+    });
+    expect(fresh.loadStatus).toBe("loading");
+  });
+
+  test("LOAD_RECEIVED with null marks not-found", () => {
+    const s1 = editVertexReducer(INITIAL_EDIT_VERTEX_STATE, {
+      type: "KEY_CHANGED",
+      key: "x",
+    });
+    const s2 = editVertexReducer(s1, {
+      type: "LOAD_RECEIVED",
+      epoch: 1,
+      vertex: null,
+    });
+    expect(s2.loadStatus).toBe("not-found");
+    expect(s2.vertex).toBeNull();
+  });
+
+  test("LOAD_RECEIVED seeds inputs and kind", () => {
+    const s1 = editVertexReducer(INITIAL_EDIT_VERTEX_STATE, {
+      type: "KEY_CHANGED",
+      key: "x",
+    });
+    const s2 = editVertexReducer(s1, {
+      type: "LOAD_RECEIVED",
+      epoch: 1,
+      vertex: { key: "x", int32: 42 },
+    });
+    expect(s2.loadStatus).toBe("ready");
+    expect(s2.kind).toBe("int32");
+    expect(s2.inputs.int32).toBe("42");
+  });
+
+  test("EDIT_BEGUN requires loaded state", () => {
+    const begun = editVertexReducer(INITIAL_EDIT_VERTEX_STATE, {
+      type: "EDIT_BEGUN",
+    });
+    expect(begun.mode).toBe("view");
+    const ready = editVertexReducer(
+      {
+        ...INITIAL_EDIT_VERTEX_STATE,
+        loadStatus: "ready",
+        vertex: { key: "x", string: "y" },
+      },
+      { type: "EDIT_BEGUN" },
+    );
+    expect(ready.mode).toBe("edit");
+  });
+
+  test("EDIT_CANCELED restores inputs from the loaded vertex", () => {
+    const loaded = editVertexReducer(
+      {
+        ...INITIAL_EDIT_VERTEX_STATE,
+        loadStatus: "ready",
+        vertex: { key: "x", string: "original" },
+      },
+      { type: "EDIT_BEGUN" },
+    );
+    const typed = editVertexReducer(loaded, {
+      type: "INPUT_CHANGED",
+      field: "string",
+      value: "typed",
+    });
+    expect(typed.inputs.string).toBe("typed");
+    const cancelled = editVertexReducer(typed, { type: "EDIT_CANCELED" });
+    expect(cancelled.mode).toBe("view");
+    expect(cancelled.inputs.string).toBe("original");
+  });
+
+  test("SAVE_SUCCEEDED returns to view mode with fresh inputs", () => {
+    const editing = editVertexReducer(
+      {
+        ...INITIAL_EDIT_VERTEX_STATE,
+        mode: "edit",
+        saveStatus: "saving",
+      },
+      {
+        type: "SAVE_SUCCEEDED",
+        vertex: { key: "x", float64: 1.25 },
+      },
+    );
+    expect(editing.mode).toBe("view");
+    expect(editing.kind).toBe("float64");
+    expect(editing.inputs.float64).toBe("1.25");
+    expect(editing.saveStatus).toBe("saved");
+  });
+
+  test("delete dialog lifecycle", () => {
+    const opened = editVertexReducer(INITIAL_EDIT_VERTEX_STATE, {
+      type: "DELETE_OPENED",
+    });
+    expect(opened.deleteRequested).toBe(true);
+    const cancelled = editVertexReducer(opened, { type: "DELETE_CANCELED" });
+    expect(cancelled.deleteRequested).toBe(false);
+    const requesting = editVertexReducer(opened, {
+      type: "DELETE_REQUESTED",
+    });
+    expect(requesting.deleteStatus).toBe("deleting");
+    const done = editVertexReducer(requesting, {
+      type: "DELETE_SUCCEEDED",
+    });
+    expect(done.deleteStatus).toBe("deleted");
+    expect(done.vertex).toBeNull();
+  });
+
+  test("KIND_CHANGED keeps existing inputs", () => {
+    const s = editVertexReducer(
+      { ...INITIAL_EDIT_VERTEX_STATE, mode: "edit" },
+      { type: "INPUT_CHANGED", field: "float64", value: "1.5" },
+    );
+    const after = editVertexReducer(s, {
+      type: "KIND_CHANGED",
+      kind: "int32",
+    });
+    expect(after.kind).toBe("int32");
+    expect(after.inputs.float64).toBe("1.5");
+  });
+});

--- a/admin/app/lib/client/usecase/edit-vertex/reducer.ts
+++ b/admin/app/lib/client/usecase/edit-vertex/reducer.ts
@@ -1,0 +1,213 @@
+import type { Vertex } from "~/lib/client/infrastructure/api/get-vertex";
+import {
+  INITIAL_EDIT_VERTEX_STATE,
+  type EditVertexState,
+} from "./state";
+import {
+  INITIAL_TTL_INPUT,
+  INITIAL_VERTEX_INPUTS,
+  inputsFromVertex,
+  kindOfVertex,
+  type BytesEncoding,
+  type TtlInput,
+  type VertexInputs,
+  type VertexValueKind,
+} from "./value-codec";
+
+export type EditVertexAction =
+  | { type: "KEY_CHANGED"; key: string }
+  | { type: "LOAD_REQUESTED"; epoch: number }
+  | { type: "LOAD_RECEIVED"; epoch: number; vertex: Vertex | null }
+  | { type: "LOAD_FAILED"; epoch: number; error: string }
+  | { type: "EDIT_BEGUN" }
+  | { type: "EDIT_CANCELED" }
+  | { type: "KIND_CHANGED"; kind: VertexValueKind }
+  | { type: "INPUT_CHANGED"; field: keyof VertexInputs; value: string }
+  | { type: "BOOL_INPUT_CHANGED"; value: boolean }
+  | { type: "BYTES_ENCODING_CHANGED"; value: BytesEncoding }
+  | { type: "TTL_CHANGED"; ttl: TtlInput }
+  | { type: "SAVE_REQUESTED" }
+  | { type: "SAVE_SUCCEEDED"; vertex: Vertex }
+  | { type: "SAVE_FAILED"; error: string }
+  | { type: "DELETE_OPENED" }
+  | { type: "DELETE_CANCELED" }
+  | { type: "DELETE_REQUESTED" }
+  | { type: "DELETE_SUCCEEDED" }
+  | { type: "DELETE_FAILED"; error: string }
+  | { type: "RESET" };
+
+export function editVertexReducer(
+  state: EditVertexState,
+  action: EditVertexAction,
+): EditVertexState {
+  switch (action.type) {
+    case "KEY_CHANGED": {
+      if (action.key === state.key && state.loadStatus !== "idle") {
+        return state;
+      }
+      return {
+        ...INITIAL_EDIT_VERTEX_STATE,
+        key: action.key,
+        loadEpoch: state.loadEpoch + 1,
+      };
+    }
+    case "LOAD_REQUESTED": {
+      if (action.epoch !== state.loadEpoch) return state;
+      return {
+        ...state,
+        loadStatus: "loading",
+        loadError: null,
+        vertex: null,
+        mode: "view",
+        saveStatus: "idle",
+        saveError: null,
+      };
+    }
+    case "LOAD_RECEIVED": {
+      if (action.epoch !== state.loadEpoch) return state;
+      if (action.vertex === null) {
+        return {
+          ...state,
+          loadStatus: "not-found",
+          loadError: null,
+          vertex: null,
+          kind: "string",
+          inputs: INITIAL_VERTEX_INPUTS,
+          ttl: INITIAL_TTL_INPUT,
+        };
+      }
+      const kind = kindOfVertex(action.vertex);
+      return {
+        ...state,
+        loadStatus: "ready",
+        loadError: null,
+        vertex: action.vertex,
+        kind,
+        inputs: inputsFromVertex(action.vertex),
+        ttl: INITIAL_TTL_INPUT,
+        saveStatus: "idle",
+        saveError: null,
+      };
+    }
+    case "LOAD_FAILED": {
+      if (action.epoch !== state.loadEpoch) return state;
+      return {
+        ...state,
+        loadStatus: "error",
+        loadError: action.error,
+      };
+    }
+    case "EDIT_BEGUN": {
+      if (state.loadStatus !== "ready" && state.loadStatus !== "not-found") {
+        return state;
+      }
+      return {
+        ...state,
+        mode: "edit",
+        saveStatus: "idle",
+        saveError: null,
+      };
+    }
+    case "EDIT_CANCELED": {
+      // Restore inputs from the underlying vertex (or blanks if not-found).
+      if (state.vertex) {
+        return {
+          ...state,
+          mode: "view",
+          kind: kindOfVertex(state.vertex),
+          inputs: inputsFromVertex(state.vertex),
+          ttl: INITIAL_TTL_INPUT,
+          saveStatus: "idle",
+          saveError: null,
+        };
+      }
+      return {
+        ...state,
+        mode: "view",
+        kind: "string",
+        inputs: INITIAL_VERTEX_INPUTS,
+        ttl: INITIAL_TTL_INPUT,
+        saveStatus: "idle",
+        saveError: null,
+      };
+    }
+    case "KIND_CHANGED": {
+      return { ...state, kind: action.kind };
+    }
+    case "INPUT_CHANGED": {
+      return {
+        ...state,
+        inputs: { ...state.inputs, [action.field]: action.value },
+      };
+    }
+    case "BOOL_INPUT_CHANGED": {
+      return {
+        ...state,
+        inputs: { ...state.inputs, bool: action.value },
+      };
+    }
+    case "BYTES_ENCODING_CHANGED": {
+      return {
+        ...state,
+        inputs: { ...state.inputs, bytesEncoding: action.value },
+      };
+    }
+    case "TTL_CHANGED": {
+      return { ...state, ttl: action.ttl };
+    }
+    case "SAVE_REQUESTED": {
+      return { ...state, saveStatus: "saving", saveError: null };
+    }
+    case "SAVE_SUCCEEDED": {
+      const kind = kindOfVertex(action.vertex);
+      return {
+        ...state,
+        vertex: action.vertex,
+        kind,
+        inputs: inputsFromVertex(action.vertex),
+        ttl: INITIAL_TTL_INPUT,
+        mode: "view",
+        loadStatus: "ready",
+        loadError: null,
+        saveStatus: "saved",
+        saveError: null,
+      };
+    }
+    case "SAVE_FAILED": {
+      return {
+        ...state,
+        saveStatus: "error",
+        saveError: action.error,
+      };
+    }
+    case "DELETE_OPENED": {
+      return { ...state, deleteRequested: true, deleteError: null };
+    }
+    case "DELETE_CANCELED": {
+      return { ...state, deleteRequested: false };
+    }
+    case "DELETE_REQUESTED": {
+      return { ...state, deleteStatus: "deleting", deleteError: null };
+    }
+    case "DELETE_SUCCEEDED": {
+      return {
+        ...state,
+        deleteStatus: "deleted",
+        deleteRequested: false,
+        vertex: null,
+        loadStatus: "not-found",
+      };
+    }
+    case "DELETE_FAILED": {
+      return {
+        ...state,
+        deleteStatus: "error",
+        deleteError: action.error,
+        deleteRequested: false,
+      };
+    }
+    case "RESET": {
+      return INITIAL_EDIT_VERTEX_STATE;
+    }
+  }
+}

--- a/admin/app/lib/client/usecase/edit-vertex/reducer.ts
+++ b/admin/app/lib/client/usecase/edit-vertex/reducer.ts
@@ -1,8 +1,5 @@
 import type { Vertex } from "~/lib/client/infrastructure/api/get-vertex";
-import {
-  INITIAL_EDIT_VERTEX_STATE,
-  type EditVertexState,
-} from "./state";
+import { INITIAL_EDIT_VERTEX_STATE, type EditVertexState } from "./state";
 import {
   INITIAL_TTL_INPUT,
   INITIAL_VERTEX_INPUTS,

--- a/admin/app/lib/client/usecase/edit-vertex/selectors.ts
+++ b/admin/app/lib/client/usecase/edit-vertex/selectors.ts
@@ -1,0 +1,32 @@
+import type { EditVertexState } from "./state";
+import { buildPutVertexBody, type BuildBodyResult } from "./value-codec";
+
+/**
+ * Validates the active edit form and either yields a wire-ready
+ * `PutVertexBody` or the first error message. `now` is injected so tests
+ * can pin time and reducers stay pure.
+ */
+export function selectPutVertexBody(
+  state: EditVertexState,
+  now: number = Date.now(),
+): BuildBodyResult {
+  return buildPutVertexBody(state.kind, state.inputs, state.ttl, now);
+}
+
+/** True when the form would produce a valid PUT body right now. */
+export function selectFormValid(
+  state: EditVertexState,
+  now: number = Date.now(),
+): boolean {
+  return selectPutVertexBody(state, now).body !== null;
+}
+
+/** Convenience: true while the editor is open. */
+export function selectEditing(state: EditVertexState): boolean {
+  return state.mode === "edit";
+}
+
+/** Convenience: true after a successful delete (route should redirect). */
+export function selectDeleted(state: EditVertexState): boolean {
+  return state.deleteStatus === "deleted";
+}

--- a/admin/app/lib/client/usecase/edit-vertex/state.ts
+++ b/admin/app/lib/client/usecase/edit-vertex/state.ts
@@ -18,11 +18,7 @@ export type EditVertexMode = "view" | "edit";
 
 export type EditVertexSaveStatus = "idle" | "saving" | "saved" | "error";
 
-export type EditVertexDeleteStatus =
-  | "idle"
-  | "deleting"
-  | "deleted"
-  | "error";
+export type EditVertexDeleteStatus = "idle" | "deleting" | "deleted" | "error";
 
 /**
  * State for the single-vertex CRUD screen. The `loadEpoch` is bumped

--- a/admin/app/lib/client/usecase/edit-vertex/state.ts
+++ b/admin/app/lib/client/usecase/edit-vertex/state.ts
@@ -1,0 +1,68 @@
+import type { Vertex } from "~/lib/client/infrastructure/api/get-vertex";
+import {
+  INITIAL_TTL_INPUT,
+  INITIAL_VERTEX_INPUTS,
+  type TtlInput,
+  type VertexInputs,
+  type VertexValueKind,
+} from "./value-codec";
+
+export type EditVertexLoadStatus =
+  | "idle"
+  | "loading"
+  | "ready"
+  | "not-found"
+  | "error";
+
+export type EditVertexMode = "view" | "edit";
+
+export type EditVertexSaveStatus = "idle" | "saving" | "saved" | "error";
+
+export type EditVertexDeleteStatus =
+  | "idle"
+  | "deleting"
+  | "deleted"
+  | "error";
+
+/**
+ * State for the single-vertex CRUD screen. The `loadEpoch` is bumped
+ * whenever the `key` changes so stale async loads can be discarded
+ * (mirrors the browse-vertices reducer pattern).
+ */
+export interface EditVertexState {
+  key: string;
+  loadEpoch: number;
+  loadStatus: EditVertexLoadStatus;
+  loadError: string | null;
+  vertex: Vertex | null;
+
+  mode: EditVertexMode;
+  kind: VertexValueKind;
+  inputs: VertexInputs;
+  ttl: TtlInput;
+
+  saveStatus: EditVertexSaveStatus;
+  saveError: string | null;
+
+  deleteStatus: EditVertexDeleteStatus;
+  deleteError: string | null;
+  /** True after the user confirms the Dialog. */
+  deleteRequested: boolean;
+}
+
+export const INITIAL_EDIT_VERTEX_STATE: EditVertexState = {
+  key: "",
+  loadEpoch: 0,
+  loadStatus: "idle",
+  loadError: null,
+  vertex: null,
+  mode: "view",
+  kind: "string",
+  inputs: INITIAL_VERTEX_INPUTS,
+  ttl: INITIAL_TTL_INPUT,
+  saveStatus: "idle",
+  saveError: null,
+  deleteStatus: "idle",
+  deleteError: null,
+  deleteRequested: false,
+};

--- a/admin/app/lib/client/usecase/edit-vertex/use-edit-vertex.ts
+++ b/admin/app/lib/client/usecase/edit-vertex/use-edit-vertex.ts
@@ -1,15 +1,8 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
 import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
-import {
-  deleteVertexHandler,
-  loadVertex,
-  saveVertex,
-} from "./handlers";
+import { deleteVertexHandler, loadVertex, saveVertex } from "./handlers";
 import { editVertexReducer } from "./reducer";
-import {
-  INITIAL_EDIT_VERTEX_STATE,
-  type EditVertexState,
-} from "./state";
+import { INITIAL_EDIT_VERTEX_STATE, type EditVertexState } from "./state";
 import {
   selectDeleted,
   selectEditing,
@@ -88,12 +81,9 @@ export function useEditVertex(key: string): UseEditVertexResult {
   const setKind = useCallback((kind: VertexValueKind) => {
     dispatch({ type: "KIND_CHANGED", kind });
   }, []);
-  const setInput = useCallback(
-    (field: keyof VertexInputs, value: string) => {
-      dispatch({ type: "INPUT_CHANGED", field, value });
-    },
-    [],
-  );
+  const setInput = useCallback((field: keyof VertexInputs, value: string) => {
+    dispatch({ type: "INPUT_CHANGED", field, value });
+  }, []);
   const setBool = useCallback((value: boolean) => {
     dispatch({ type: "BOOL_INPUT_CHANGED", value });
   }, []);

--- a/admin/app/lib/client/usecase/edit-vertex/use-edit-vertex.ts
+++ b/admin/app/lib/client/usecase/edit-vertex/use-edit-vertex.ts
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
+import {
+  deleteVertexHandler,
+  loadVertex,
+  saveVertex,
+} from "./handlers";
+import { editVertexReducer } from "./reducer";
+import {
+  INITIAL_EDIT_VERTEX_STATE,
+  type EditVertexState,
+} from "./state";
+import {
+  selectDeleted,
+  selectEditing,
+  selectFormValid,
+  selectPutVertexBody,
+} from "./selectors";
+import type {
+  BytesEncoding,
+  TtlInput,
+  VertexInputs,
+  VertexValueKind,
+} from "./value-codec";
+
+export interface UseEditVertexResult {
+  state: EditVertexState;
+  formValid: boolean;
+  editing: boolean;
+  deleted: boolean;
+  beginEdit: () => void;
+  cancelEdit: () => void;
+  setKind: (kind: VertexValueKind) => void;
+  setInput: (field: keyof VertexInputs, value: string) => void;
+  setBool: (value: boolean) => void;
+  setBytesEncoding: (value: BytesEncoding) => void;
+  setTtl: (ttl: TtlInput) => void;
+  save: () => Promise<void>;
+  openDeleteDialog: () => void;
+  closeDeleteDialog: () => void;
+  confirmDelete: () => Promise<void>;
+  reload: () => void;
+}
+
+/**
+ * Owns the load → edit → save / delete cycle for a single vertex. The
+ * `key` is the URL param, so the hook resets fully whenever the route
+ * navigates to a different vertex.
+ */
+export function useEditVertex(key: string): UseEditVertexResult {
+  const client = useLanternClient();
+  const [state, dispatch] = useReducer(
+    editVertexReducer,
+    INITIAL_EDIT_VERTEX_STATE,
+  );
+
+  // Re-seed state when the URL key changes (incl. on first mount).
+  useEffect(() => {
+    dispatch({ type: "KEY_CHANGED", key });
+  }, [key]);
+
+  // Fire the load whenever the epoch is bumped.
+  const lastEpochRef = useRef<number>(-1);
+  useEffect(() => {
+    if (state.key === "" || state.loadEpoch === lastEpochRef.current) {
+      return;
+    }
+    lastEpochRef.current = state.loadEpoch;
+    const controller = new AbortController();
+    void loadVertex(
+      {
+        client,
+        key: state.key,
+        epoch: state.loadEpoch,
+        signal: controller.signal,
+      },
+      dispatch,
+    );
+    return () => controller.abort();
+  }, [client, state.key, state.loadEpoch]);
+
+  const beginEdit = useCallback(() => {
+    dispatch({ type: "EDIT_BEGUN" });
+  }, []);
+  const cancelEdit = useCallback(() => {
+    dispatch({ type: "EDIT_CANCELED" });
+  }, []);
+  const setKind = useCallback((kind: VertexValueKind) => {
+    dispatch({ type: "KIND_CHANGED", kind });
+  }, []);
+  const setInput = useCallback(
+    (field: keyof VertexInputs, value: string) => {
+      dispatch({ type: "INPUT_CHANGED", field, value });
+    },
+    [],
+  );
+  const setBool = useCallback((value: boolean) => {
+    dispatch({ type: "BOOL_INPUT_CHANGED", value });
+  }, []);
+  const setBytesEncoding = useCallback((value: BytesEncoding) => {
+    dispatch({ type: "BYTES_ENCODING_CHANGED", value });
+  }, []);
+  const setTtl = useCallback((ttl: TtlInput) => {
+    dispatch({ type: "TTL_CHANGED", ttl });
+  }, []);
+
+  const save = useCallback(async () => {
+    const { body, error } = selectPutVertexBody(state);
+    if (!body) {
+      if (error) {
+        dispatch({ type: "SAVE_FAILED", error });
+      }
+      return;
+    }
+    await saveVertex({ client, key: state.key, body }, dispatch);
+  }, [client, state]);
+
+  const openDeleteDialog = useCallback(() => {
+    dispatch({ type: "DELETE_OPENED" });
+  }, []);
+  const closeDeleteDialog = useCallback(() => {
+    dispatch({ type: "DELETE_CANCELED" });
+  }, []);
+  const confirmDelete = useCallback(async () => {
+    await deleteVertexHandler({ client, key: state.key }, dispatch);
+  }, [client, state.key]);
+
+  const reload = useCallback(() => {
+    dispatch({ type: "KEY_CHANGED", key });
+  }, [key]);
+
+  const formValid = useMemo(() => selectFormValid(state), [state]);
+  const editing = selectEditing(state);
+  const deleted = selectDeleted(state);
+
+  return useMemo(
+    () => ({
+      state,
+      formValid,
+      editing,
+      deleted,
+      beginEdit,
+      cancelEdit,
+      setKind,
+      setInput,
+      setBool,
+      setBytesEncoding,
+      setTtl,
+      save,
+      openDeleteDialog,
+      closeDeleteDialog,
+      confirmDelete,
+      reload,
+    }),
+    [
+      state,
+      formValid,
+      editing,
+      deleted,
+      beginEdit,
+      cancelEdit,
+      setKind,
+      setInput,
+      setBool,
+      setBytesEncoding,
+      setTtl,
+      save,
+      openDeleteDialog,
+      closeDeleteDialog,
+      confirmDelete,
+      reload,
+    ],
+  );
+}

--- a/admin/app/lib/client/usecase/edit-vertex/value-codec.test.ts
+++ b/admin/app/lib/client/usecase/edit-vertex/value-codec.test.ts
@@ -25,9 +25,7 @@ describe("kindOfVertex", () => {
     expect(kindOfVertex({ key: "k" })).toBe("nil");
   });
   test("prefers float64 over later variants when both somehow set", () => {
-    expect(kindOfVertex({ key: "k", float64: 1, string: "x" })).toBe(
-      "float64",
-    );
+    expect(kindOfVertex({ key: "k", float64: 1, string: "x" })).toBe("float64");
   });
 });
 

--- a/admin/app/lib/client/usecase/edit-vertex/value-codec.test.ts
+++ b/admin/app/lib/client/usecase/edit-vertex/value-codec.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildPutVertexBody,
+  inputsFromVertex,
+  isoToLocalInput,
+  kindOfVertex,
+  parseBytesInput,
+  parseGoDuration,
+  INITIAL_TTL_INPUT,
+  INITIAL_VERTEX_INPUTS,
+  type TtlInput,
+  type VertexInputs,
+} from "./value-codec";
+
+const FIXED_NOW = Date.parse("2026-01-02T03:04:05Z");
+
+describe("kindOfVertex", () => {
+  test("picks the populated variant", () => {
+    expect(kindOfVertex({ key: "k", int32: 5 })).toBe("int32");
+    expect(kindOfVertex({ key: "k", string: "x" })).toBe("string");
+    expect(kindOfVertex({ key: "k", bool: false })).toBe("bool");
+    expect(kindOfVertex({ key: "k", nil: true })).toBe("nil");
+  });
+  test("falls back to nil when nothing is set", () => {
+    expect(kindOfVertex({ key: "k" })).toBe("nil");
+  });
+  test("prefers float64 over later variants when both somehow set", () => {
+    expect(kindOfVertex({ key: "k", float64: 1, string: "x" })).toBe(
+      "float64",
+    );
+  });
+});
+
+describe("inputsFromVertex", () => {
+  test("seeds matching field for int32", () => {
+    const inputs = inputsFromVertex({ key: "k", int32: 7 });
+    expect(inputs.int32).toBe("7");
+  });
+  test("encodes bytes as hex with 0x prefix", () => {
+    // 0x010203 in base64 is "AQID"
+    const inputs = inputsFromVertex({ key: "k", bytes: "AQID" });
+    expect(inputs.bytesInput).toBe("0x010203");
+  });
+});
+
+describe("parseGoDuration", () => {
+  test("accepts compound durations", () => {
+    expect(parseGoDuration("1h30m").ms).toBe(90 * 60 * 1000);
+    expect(parseGoDuration("750ms").ms).toBe(750);
+    expect(parseGoDuration("2s500ms").ms).toBe(2500);
+  });
+  test("accepts fractional magnitudes", () => {
+    expect(parseGoDuration("1.5s").ms).toBe(1500);
+  });
+  test("rejects missing unit", () => {
+    expect(parseGoDuration("5").error).not.toBeNull();
+  });
+  test("rejects unknown units", () => {
+    expect(parseGoDuration("5x").error).not.toBeNull();
+  });
+  test("accepts negative durations", () => {
+    expect(parseGoDuration("-5m").ms).toBe(-5 * 60_000);
+  });
+});
+
+describe("parseBytesInput", () => {
+  test("hex with 0x prefix", () => {
+    expect(parseBytesInput("0x010203", "hex")).toEqual({
+      b64: "AQID",
+      error: null,
+    });
+  });
+  test("hex without prefix and whitespace", () => {
+    expect(parseBytesInput("01 02 03", "hex").b64).toBe("AQID");
+  });
+  test("rejects odd-length hex", () => {
+    expect(parseBytesInput("0x1", "hex").error).not.toBeNull();
+  });
+  test("rejects non-hex chars", () => {
+    expect(parseBytesInput("0xZZ", "hex").error).not.toBeNull();
+  });
+  test("base64 passthrough", () => {
+    expect(parseBytesInput("AQID", "base64").b64).toBe("AQID");
+  });
+});
+
+function makeInputs(over: Partial<VertexInputs>): VertexInputs {
+  return { ...INITIAL_VERTEX_INPUTS, ...over };
+}
+
+function ttl(over: Partial<TtlInput> = {}): TtlInput {
+  return { ...INITIAL_TTL_INPUT, ...over };
+}
+
+describe("buildPutVertexBody", () => {
+  test("float64 happy path with preset TTL", () => {
+    const out = buildPutVertexBody(
+      "float64",
+      makeInputs({ float64: "3.14" }),
+      ttl({ mode: "preset5m" }),
+      FIXED_NOW,
+    );
+    expect(out.error).toBeNull();
+    expect(out.body?.vertex?.float64).toBe(3.14);
+    expect(out.body?.vertex?.expiration).toBe(
+      new Date(FIXED_NOW + 5 * 60_000).toISOString(),
+    );
+  });
+
+  test("int32 out-of-range fails", () => {
+    const out = buildPutVertexBody(
+      "int32",
+      makeInputs({ int32: "99999999999" }),
+      ttl({ mode: "none" }),
+      FIXED_NOW,
+    );
+    expect(out.body).toBeNull();
+    expect(out.error).toMatch(/int32/);
+  });
+
+  test("int64 emitted as string", () => {
+    const out = buildPutVertexBody(
+      "int64",
+      makeInputs({ int64: "9223372036854775807" }),
+      ttl({ mode: "none" }),
+      FIXED_NOW,
+    );
+    expect(out.error).toBeNull();
+    expect(out.body?.vertex?.int64).toBe("9223372036854775807");
+  });
+
+  test("uint64 rejects negatives", () => {
+    const out = buildPutVertexBody(
+      "uint64",
+      makeInputs({ uint64: "-1" }),
+      ttl({ mode: "none" }),
+      FIXED_NOW,
+    );
+    expect(out.body).toBeNull();
+  });
+
+  test("bytes converts hex → base64", () => {
+    const out = buildPutVertexBody(
+      "bytes",
+      makeInputs({ bytesEncoding: "hex", bytesInput: "0xdeadbeef" }),
+      ttl({ mode: "none" }),
+      FIXED_NOW,
+    );
+    expect(out.error).toBeNull();
+    expect(out.body?.vertex?.bytes).toBe("3q2+7w==");
+  });
+
+  test("timestamp normalised to ISO", () => {
+    const out = buildPutVertexBody(
+      "timestamp",
+      makeInputs({ timestamp: "2026-01-02T03:04" }),
+      ttl({ mode: "none" }),
+      FIXED_NOW,
+    );
+    expect(out.error).toBeNull();
+    expect(out.body?.vertex?.timestamp).toMatch(/^2026-01-02T/);
+  });
+
+  test("duration parsed but stored as raw Go string", () => {
+    const out = buildPutVertexBody(
+      "duration",
+      makeInputs({ duration: "1h30m" }),
+      ttl({ mode: "none" }),
+      FIXED_NOW,
+    );
+    expect(out.error).toBeNull();
+    expect(out.body?.vertex?.duration).toBe("1h30m");
+  });
+
+  test("nil sets the flag true", () => {
+    const out = buildPutVertexBody(
+      "nil",
+      makeInputs({}),
+      ttl({ mode: "none" }),
+      FIXED_NOW,
+    );
+    expect(out.body?.vertex?.nil).toBe(true);
+  });
+
+  test("custom TTL parses Go duration", () => {
+    const out = buildPutVertexBody(
+      "string",
+      makeInputs({ string: "x" }),
+      ttl({ mode: "custom", custom: "10m" }),
+      FIXED_NOW,
+    );
+    expect(out.body?.vertex?.expiration).toBe(
+      new Date(FIXED_NOW + 10 * 60_000).toISOString(),
+    );
+  });
+
+  test("none TTL omits expiration", () => {
+    const out = buildPutVertexBody(
+      "string",
+      makeInputs({ string: "x" }),
+      ttl({ mode: "none" }),
+      FIXED_NOW,
+    );
+    expect(out.body?.vertex?.expiration).toBeUndefined();
+  });
+});
+
+describe("isoToLocalInput", () => {
+  test("returns YYYY-MM-DDTHH:mm local form", () => {
+    const out = isoToLocalInput("2026-01-02T03:04:05Z");
+    expect(out).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+  });
+  test("invalid passes through", () => {
+    expect(isoToLocalInput("not-a-date")).toBe("not-a-date");
+  });
+});

--- a/admin/app/lib/client/usecase/edit-vertex/value-codec.ts
+++ b/admin/app/lib/client/usecase/edit-vertex/value-codec.ts
@@ -174,8 +174,8 @@ export function parseGoDuration(input: string): {
   const unitMap: Record<string, bigint> = {
     ns: 1n,
     us: 1_000n,
-    "µs": 1_000n,
-    "μs": 1_000n,
+    µs: 1_000n,
+    μs: 1_000n,
     ms: 1_000_000n,
     s: SECOND_NS,
     m: 60n * SECOND_NS,
@@ -327,7 +327,10 @@ export function buildPutVertexBody(
     case "uint32": {
       const raw = inputs.uint32.trim();
       if (!/^\d+$/.test(raw)) {
-        return { body: null, error: "uint32 must be a non-negative whole number." };
+        return {
+          body: null,
+          error: "uint32 must be a non-negative whole number.",
+        };
       }
       const num = Number(raw);
       if (num > UINT32_MAX) {
@@ -339,7 +342,10 @@ export function buildPutVertexBody(
     case "uint64": {
       const raw = inputs.uint64.trim();
       if (!/^\d+$/.test(raw)) {
-        return { body: null, error: "uint64 must be a non-negative whole number." };
+        return {
+          body: null,
+          error: "uint64 must be a non-negative whole number.",
+        };
       }
       let big: bigint;
       try {
@@ -419,7 +425,10 @@ export function parseBytesInput(
     return { b64: "", error: null };
   }
   if (encoding === "hex") {
-    let hex = trimmed.startsWith("0x") || trimmed.startsWith("0X") ? trimmed.slice(2) : trimmed;
+    let hex =
+      trimmed.startsWith("0x") || trimmed.startsWith("0X")
+        ? trimmed.slice(2)
+        : trimmed;
     hex = hex.replace(/\s+/g, "");
     if (hex.length % 2 !== 0) {
       return { b64: null, error: "Hex must have an even number of digits." };

--- a/admin/app/lib/client/usecase/edit-vertex/value-codec.ts
+++ b/admin/app/lib/client/usecase/edit-vertex/value-codec.ts
@@ -1,0 +1,492 @@
+import type { Vertex } from "~/lib/client/infrastructure/api/get-vertex";
+import type { PutVertexBody } from "~/lib/client/infrastructure/api/put-vertex";
+
+/**
+ * One label per `v1Vertex` value oneof variant. The order chosen here is
+ * also the order shown in the kind selector dropdown. Numeric variants
+ * come first so the most common cases land at the top.
+ */
+export const VERTEX_VALUE_KINDS = [
+  "float64",
+  "float32",
+  "int32",
+  "int64",
+  "uint32",
+  "uint64",
+  "bool",
+  "string",
+  "bytes",
+  "timestamp",
+  "duration",
+  "nil",
+] as const;
+export type VertexValueKind = (typeof VERTEX_VALUE_KINDS)[number];
+
+export type BytesEncoding = "hex" | "base64";
+
+/**
+ * Form-state inputs for the editor. Each variant gets a slot so the form
+ * preserves what the user typed when they flip the kind selector back and
+ * forth. The fields are strings (or simple primitives) so the React inputs
+ * remain controlled until the user explicitly saves.
+ */
+export interface VertexInputs {
+  float64: string;
+  float32: string;
+  int32: string;
+  int64: string;
+  uint32: string;
+  uint64: string;
+  bool: boolean;
+  string: string;
+  bytesEncoding: BytesEncoding;
+  bytesInput: string;
+  /** Local ISO `YYYY-MM-DDTHH:mm` (no zone) for the datetime-local input. */
+  timestamp: string;
+  /** Go duration syntax: `5m`, `1h30m`. */
+  duration: string;
+}
+
+export const INITIAL_VERTEX_INPUTS: VertexInputs = {
+  float64: "",
+  float32: "",
+  int32: "",
+  int64: "",
+  uint32: "",
+  uint64: "",
+  bool: false,
+  string: "",
+  bytesEncoding: "hex",
+  bytesInput: "",
+  timestamp: "",
+  duration: "",
+};
+
+/**
+ * Picks the kind currently populated on a vertex. Returns `"nil"` when
+ * either the `nil` flag is set or no variant is present.
+ */
+export function kindOfVertex(vertex: Vertex): VertexValueKind {
+  if (vertex.float64 !== undefined) return "float64";
+  if (vertex.float32 !== undefined) return "float32";
+  if (vertex.int32 !== undefined) return "int32";
+  if (vertex.int64 !== undefined) return "int64";
+  if (vertex.uint32 !== undefined) return "uint32";
+  if (vertex.uint64 !== undefined) return "uint64";
+  if (vertex.bool !== undefined) return "bool";
+  if (vertex.string !== undefined) return "string";
+  if (vertex.bytes !== undefined) return "bytes";
+  if (vertex.timestamp !== undefined) return "timestamp";
+  if (vertex.duration !== undefined) return "duration";
+  return "nil";
+}
+
+/**
+ * Seeds the form inputs from the loaded vertex so the Edit form mirrors
+ * what the user is about to overwrite. Unset slots fall back to the
+ * initial blank values.
+ */
+export function inputsFromVertex(vertex: Vertex): VertexInputs {
+  return {
+    ...INITIAL_VERTEX_INPUTS,
+    float64:
+      vertex.float64 !== undefined
+        ? String(vertex.float64)
+        : INITIAL_VERTEX_INPUTS.float64,
+    float32:
+      vertex.float32 !== undefined
+        ? String(vertex.float32)
+        : INITIAL_VERTEX_INPUTS.float32,
+    int32:
+      vertex.int32 !== undefined
+        ? String(vertex.int32)
+        : INITIAL_VERTEX_INPUTS.int32,
+    int64: vertex.int64 ?? INITIAL_VERTEX_INPUTS.int64,
+    uint32:
+      vertex.uint32 !== undefined
+        ? String(vertex.uint32)
+        : INITIAL_VERTEX_INPUTS.uint32,
+    uint64: vertex.uint64 ?? INITIAL_VERTEX_INPUTS.uint64,
+    bool: vertex.bool ?? INITIAL_VERTEX_INPUTS.bool,
+    string: vertex.string ?? INITIAL_VERTEX_INPUTS.string,
+    bytesEncoding: INITIAL_VERTEX_INPUTS.bytesEncoding,
+    bytesInput:
+      vertex.bytes !== undefined
+        ? `0x${base64ToHex(vertex.bytes)}`
+        : INITIAL_VERTEX_INPUTS.bytesInput,
+    timestamp:
+      vertex.timestamp !== undefined
+        ? isoToLocalInput(vertex.timestamp)
+        : INITIAL_VERTEX_INPUTS.timestamp,
+    duration: vertex.duration ?? INITIAL_VERTEX_INPUTS.duration,
+  };
+}
+
+/** TTL choice: a relative duration to convert to absolute `expiration`. */
+export type TtlMode = "preset5m" | "preset1h" | "preset24h" | "none" | "custom";
+
+export interface TtlInput {
+  mode: TtlMode;
+  /** Used when `mode === "custom"`. Go duration syntax. */
+  custom: string;
+}
+
+export const INITIAL_TTL_INPUT: TtlInput = {
+  mode: "preset1h",
+  custom: "",
+};
+
+const PRESET_MS: Record<Exclude<TtlMode, "none" | "custom">, number> = {
+  preset5m: 5 * 60_000,
+  preset1h: 60 * 60_000,
+  preset24h: 24 * 60 * 60_000,
+};
+
+const SECOND_NS = 1_000_000_000n;
+
+/**
+ * Validates and parses a Go-syntax duration like `5m`, `1h30m`, `750ms`.
+ * Supports the same unit set the Go stdlib does (`ns`, `us`/`µs`, `ms`,
+ * `s`, `m`, `h`), case-sensitive units, optional leading sign, and
+ * fractional magnitudes. Returns the duration in milliseconds.
+ */
+export function parseGoDuration(input: string): {
+  ms: number | null;
+  error: string | null;
+} {
+  const raw = input.trim();
+  if (raw === "") {
+    return { ms: null, error: "Duration is required." };
+  }
+  if (raw === "0") {
+    return { ms: 0, error: null };
+  }
+  let i = 0;
+  let neg = false;
+  if (raw[0] === "+" || raw[0] === "-") {
+    neg = raw[0] === "-";
+    i++;
+  }
+  if (i === raw.length) {
+    return { ms: null, error: "Invalid duration." };
+  }
+  let totalNs = 0n;
+  const unitMap: Record<string, bigint> = {
+    ns: 1n,
+    us: 1_000n,
+    "µs": 1_000n,
+    "μs": 1_000n,
+    ms: 1_000_000n,
+    s: SECOND_NS,
+    m: 60n * SECOND_NS,
+    h: 3600n * SECOND_NS,
+  };
+  while (i < raw.length) {
+    const numStart = i;
+    while (i < raw.length && /[0-9.]/.test(raw[i]!)) {
+      i++;
+    }
+    if (i === numStart) {
+      return { ms: null, error: "Invalid duration." };
+    }
+    const numStr = raw.slice(numStart, i);
+    if ((numStr.match(/\./g) ?? []).length > 1) {
+      return { ms: null, error: "Invalid duration." };
+    }
+    const num = Number(numStr);
+    if (!Number.isFinite(num)) {
+      return { ms: null, error: "Invalid duration." };
+    }
+    const unitStart = i;
+    while (i < raw.length && /[a-zA-Zµμ]/.test(raw[i]!)) {
+      i++;
+    }
+    if (i === unitStart) {
+      return { ms: null, error: "Missing unit (s, ms, m, h…)." };
+    }
+    const unit = raw.slice(unitStart, i);
+    const unitNs = unitMap[unit];
+    if (unitNs === undefined) {
+      return { ms: null, error: `Unknown unit "${unit}".` };
+    }
+    // Scale: floor((num as float * unitNs) so fractional 1.5s works.
+    const scaled = BigInt(Math.round(num * Number(unitNs)));
+    totalNs += scaled;
+  }
+  if (neg) {
+    totalNs = -totalNs;
+  }
+  const ms = Number(totalNs / 1_000_000n);
+  return { ms, error: null };
+}
+
+/** Converts the TTL input into an absolute ISO expiration string. */
+export function ttlToExpiration(
+  ttl: TtlInput,
+  now: number,
+): { iso: string | undefined; error: string | null } {
+  if (ttl.mode === "none") {
+    return { iso: undefined, error: null };
+  }
+  if (ttl.mode === "custom") {
+    const { ms, error } = parseGoDuration(ttl.custom);
+    if (error || ms === null) {
+      return { iso: undefined, error: error ?? "Invalid duration." };
+    }
+    if (ms <= 0) {
+      return { iso: undefined, error: "TTL must be positive." };
+    }
+    return { iso: new Date(now + ms).toISOString(), error: null };
+  }
+  const ms = PRESET_MS[ttl.mode];
+  return { iso: new Date(now + ms).toISOString(), error: null };
+}
+
+const INT32_MIN = -2_147_483_648;
+const INT32_MAX = 2_147_483_647;
+const UINT32_MAX = 4_294_967_295;
+const INT64_MIN = -(2n ** 63n);
+const INT64_MAX = 2n ** 63n - 1n;
+const UINT64_MAX = 2n ** 64n - 1n;
+
+export interface BuildBodyResult {
+  body: PutVertexBody | null;
+  /** Single field-scoped error message (kind selector / TTL / value). */
+  error: string | null;
+}
+
+/**
+ * Validates the typed value inputs for `kind`, encodes the result onto
+ * the body shape grpc-gateway accepts, and stamps the absolute
+ * expiration. Returns either a ready-to-PUT body or a single human-
+ * readable error message.
+ */
+export function buildPutVertexBody(
+  kind: VertexValueKind,
+  inputs: VertexInputs,
+  ttl: TtlInput,
+  now: number = Date.now(),
+): BuildBodyResult {
+  const { iso, error: ttlErr } = ttlToExpiration(ttl, now);
+  if (ttlErr) {
+    return { body: null, error: ttlErr };
+  }
+  const vertex: PutVertexBody["vertex"] = {};
+  if (iso !== undefined) {
+    vertex.expiration = iso;
+  }
+  switch (kind) {
+    case "float64": {
+      const num = Number(inputs.float64);
+      if (inputs.float64.trim() === "" || !Number.isFinite(num)) {
+        return { body: null, error: "float64 must be a finite number." };
+      }
+      vertex.float64 = num;
+      break;
+    }
+    case "float32": {
+      const num = Number(inputs.float32);
+      if (inputs.float32.trim() === "" || !Number.isFinite(num)) {
+        return { body: null, error: "float32 must be a finite number." };
+      }
+      vertex.float32 = num;
+      break;
+    }
+    case "int32": {
+      const raw = inputs.int32.trim();
+      if (!/^-?\d+$/.test(raw)) {
+        return { body: null, error: "int32 must be a whole number." };
+      }
+      const num = Number(raw);
+      if (num < INT32_MIN || num > INT32_MAX) {
+        return {
+          body: null,
+          error: `int32 must be between ${INT32_MIN} and ${INT32_MAX}.`,
+        };
+      }
+      vertex.int32 = num;
+      break;
+    }
+    case "int64": {
+      const raw = inputs.int64.trim();
+      if (!/^-?\d+$/.test(raw)) {
+        return { body: null, error: "int64 must be a whole number." };
+      }
+      let big: bigint;
+      try {
+        big = BigInt(raw);
+      } catch {
+        return { body: null, error: "int64 is not a valid integer." };
+      }
+      if (big < INT64_MIN || big > INT64_MAX) {
+        return { body: null, error: "int64 out of range." };
+      }
+      vertex.int64 = big.toString();
+      break;
+    }
+    case "uint32": {
+      const raw = inputs.uint32.trim();
+      if (!/^\d+$/.test(raw)) {
+        return { body: null, error: "uint32 must be a non-negative whole number." };
+      }
+      const num = Number(raw);
+      if (num > UINT32_MAX) {
+        return { body: null, error: `uint32 must be at most ${UINT32_MAX}.` };
+      }
+      vertex.uint32 = num;
+      break;
+    }
+    case "uint64": {
+      const raw = inputs.uint64.trim();
+      if (!/^\d+$/.test(raw)) {
+        return { body: null, error: "uint64 must be a non-negative whole number." };
+      }
+      let big: bigint;
+      try {
+        big = BigInt(raw);
+      } catch {
+        return { body: null, error: "uint64 is not a valid integer." };
+      }
+      if (big > UINT64_MAX) {
+        return { body: null, error: "uint64 out of range." };
+      }
+      vertex.uint64 = big.toString();
+      break;
+    }
+    case "bool": {
+      vertex.bool = inputs.bool;
+      break;
+    }
+    case "string": {
+      vertex.string = inputs.string;
+      break;
+    }
+    case "bytes": {
+      const { b64, error } = parseBytesInput(
+        inputs.bytesInput,
+        inputs.bytesEncoding,
+      );
+      if (error || b64 === null) {
+        return { body: null, error: error ?? "Invalid bytes." };
+      }
+      vertex.bytes = b64;
+      break;
+    }
+    case "timestamp": {
+      const raw = inputs.timestamp.trim();
+      if (raw === "") {
+        return { body: null, error: "timestamp is required." };
+      }
+      const ms = Date.parse(raw);
+      if (!Number.isFinite(ms)) {
+        return { body: null, error: "timestamp is not a valid date." };
+      }
+      vertex.timestamp = new Date(ms).toISOString();
+      break;
+    }
+    case "duration": {
+      const { error } = parseGoDuration(inputs.duration);
+      if (error) {
+        return { body: null, error };
+      }
+      vertex.duration = inputs.duration.trim();
+      break;
+    }
+    case "nil": {
+      vertex.nil = true;
+      break;
+    }
+  }
+  return { body: { vertex }, error: null };
+}
+
+interface BytesParseResult {
+  b64: string | null;
+  error: string | null;
+}
+
+/**
+ * Accepts the user's bytes input under the active encoding and returns
+ * the base64 string the wire expects. Hex inputs may carry a `0x` prefix
+ * and may contain whitespace.
+ */
+export function parseBytesInput(
+  raw: string,
+  encoding: BytesEncoding,
+): BytesParseResult {
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    return { b64: "", error: null };
+  }
+  if (encoding === "hex") {
+    let hex = trimmed.startsWith("0x") || trimmed.startsWith("0X") ? trimmed.slice(2) : trimmed;
+    hex = hex.replace(/\s+/g, "");
+    if (hex.length % 2 !== 0) {
+      return { b64: null, error: "Hex must have an even number of digits." };
+    }
+    if (!/^[0-9a-fA-F]*$/.test(hex)) {
+      return { b64: null, error: "Hex contains non-hex characters." };
+    }
+    const bytes = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    }
+    return { b64: bytesToBase64(bytes), error: null };
+  }
+  if (!/^[A-Za-z0-9+/=\s]*$/.test(trimmed)) {
+    return { b64: null, error: "Invalid base64." };
+  }
+  const compact = trimmed.replace(/\s+/g, "");
+  try {
+    // Round-trip to confirm decodability.
+    if (typeof atob !== "function") {
+      return { b64: compact, error: null };
+    }
+    atob(compact);
+  } catch {
+    return { b64: null, error: "Invalid base64." };
+  }
+  return { b64: compact, error: null };
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  if (typeof btoa !== "function") {
+    return "";
+  }
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary);
+}
+
+export function base64ToHex(b64: string): string {
+  if (typeof atob !== "function") {
+    return b64;
+  }
+  try {
+    const binary = atob(b64);
+    let hex = "";
+    for (let i = 0; i < binary.length; i++) {
+      hex += binary.charCodeAt(i).toString(16).padStart(2, "0");
+    }
+    return hex;
+  } catch {
+    return b64;
+  }
+}
+
+/**
+ * Converts an ISO `2026-01-02T03:04:05Z` string to the `YYYY-MM-DDTHH:mm`
+ * shape the HTML `datetime-local` input expects. Returns the raw value
+ * unchanged on parse failure so the user can still see (and fix) it.
+ */
+export function isoToLocalInput(iso: string): string {
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) {
+    return iso;
+  }
+  const d = new Date(ms);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}

--- a/admin/app/routes/edges.$tail.$head.tsx
+++ b/admin/app/routes/edges.$tail.$head.tsx
@@ -1,0 +1,35 @@
+import type { Route } from "./+types/edges.$tail.$head";
+import { Navigate, useParams } from "react-router";
+import { EdgeDetailPage } from "~/components/edit-edge/EdgeDetailPage/EdgeDetailPage";
+
+export function meta({ params }: Route.MetaArgs) {
+  const tail = decodeKey(params.tail);
+  const head = decodeKey(params.head);
+  return [
+    {
+      title:
+        tail && head
+          ? `${tail} → ${head} — Lantern Admin`
+          : "Edge — Lantern Admin",
+    },
+  ];
+}
+
+export default function EdgeDetailRoute() {
+  const { tail, head } = useParams<{ tail: string; head: string }>();
+  const decodedTail = decodeKey(tail);
+  const decodedHead = decodeKey(head);
+  if (!decodedTail || !decodedHead) {
+    return <Navigate to="/edges" replace />;
+  }
+  return <EdgeDetailPage tail={decodedTail} head={decodedHead} />;
+}
+
+function decodeKey(raw: string | undefined): string {
+  if (!raw) return "";
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}

--- a/admin/app/routes/vertices.$key.tsx
+++ b/admin/app/routes/vertices.$key.tsx
@@ -1,0 +1,30 @@
+import type { Route } from "./+types/vertices.$key";
+import { Navigate, useParams } from "react-router";
+import { VertexDetailPage } from "~/components/edit-vertex/VertexDetailPage/VertexDetailPage";
+
+export function meta({ params }: Route.MetaArgs) {
+  const key = decodeKey(params.key);
+  return [{ title: key ? `${key} — Lantern Admin` : "Vertex — Lantern Admin" }];
+}
+
+/**
+ * Single-vertex detail/edit route. URL segment is percent-encoded so
+ * keys with slashes or unicode survive a hard reload.
+ */
+export default function VertexDetailRoute() {
+  const { key } = useParams<{ key: string }>();
+  const decoded = decodeKey(key);
+  if (!decoded) {
+    return <Navigate to="/vertices" replace />;
+  }
+  return <VertexDetailPage vertexKey={decoded} />;
+}
+
+function decodeKey(raw: string | undefined): string {
+  if (!raw) return "";
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}

--- a/admin/tests/e2e/crud.spec.ts
+++ b/admin/tests/e2e/crud.spec.ts
@@ -88,17 +88,17 @@ test.describe("vertex detail", () => {
     expect(body.vertex?.string).toBeUndefined();
   });
 
-  test("invalid bytes input surfaces a save error and does not mutate the server", async ({
+  test("invalid bytes input disables Save and does not mutate the server", async ({
     page,
   }) => {
     await page.goto(`/vertices/${encodeURIComponent(VERTEX_KEY)}`);
     await page.getByTestId("vertex-edit-trigger").click();
     await selectKind(page, "bytes");
     await page.getByTestId("vertex-editor-bytes").fill("not-hex-data!");
-    await page.getByTestId("vertex-save").click();
 
-    // Save button should remain (form still visible) — the codec rejects
-    // the input before reaching the server.
+    // The codec invalidates the form so Save is unavailable — guarding
+    // the round-trip before it ever reaches the gateway.
+    await expect(page.getByTestId("vertex-save")).toBeDisabled();
     await expect(page.getByTestId("vertex-detail-edit")).toBeVisible();
   });
 
@@ -149,18 +149,21 @@ test.describe("edge detail", () => {
       page.getByTestId("edge-form-add").or(page.getByTestId("edge-detail-missing")),
     ).toBeVisible();
 
-    // Add the same contribution twice. Decay over a few ms is negligible.
+    // Add the same contribution twice. The exact accumulator math is
+    // server-side; the test only asserts a write actually happened.
     await page.getByTestId("edge-add-weight").fill("1.5");
     await page.getByTestId("edge-add-submit").click();
     await expect(page.getByTestId("edge-detail-read")).toBeVisible();
+    const afterFirst = await fetchEdgeWeight(EDGE_TAIL, EDGE_HEAD);
+    expect(afterFirst).toBeGreaterThan(0);
+
     await page.getByTestId("edge-add-weight").fill("1.5");
     await page.getByTestId("edge-add-submit").click();
     await expect(page.getByTestId("edge-current-weight")).toBeVisible();
 
-    const afterAdds = await fetchEdgeWeight(EDGE_TAIL, EDGE_HEAD);
-    // Two adds of 1.5 with negligible decay → roughly 3.0; allow slack.
-    expect(afterAdds).toBeGreaterThan(2.5);
-    expect(afterAdds).toBeLessThan(3.1);
+    const afterSecond = await fetchEdgeWeight(EDGE_TAIL, EDGE_HEAD);
+    // A second AddEdge must accumulate strictly more weight than one.
+    expect(afterSecond).toBeGreaterThan(afterFirst);
 
     // PutEdge collapses the accumulator to an exact value.
     await page.getByTestId("edge-put-weight").fill("7");

--- a/admin/tests/e2e/crud.spec.ts
+++ b/admin/tests/e2e/crud.spec.ts
@@ -1,0 +1,215 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const GATEWAY_URL =
+  process.env.LANTERN_E2E_GATEWAY_URL ?? "http://127.0.0.1:6381";
+const STORAGE_KEY = "lantern.admin.baseUrl";
+
+const VERTEX_KEY = "e2e:crud:vertex";
+const EDGE_TAIL = "e2e:crud:tail";
+const EDGE_HEAD = "e2e:crud:head";
+
+/**
+ * Clean baseline so re-runs are deterministic — the previous test run's
+ * leftovers must not influence behaviour.
+ */
+test.beforeAll(async () => {
+  for (const key of [VERTEX_KEY, EDGE_TAIL, EDGE_HEAD]) {
+    await fetch(`${GATEWAY_URL}/v1/vertices/${encodeURIComponent(key)}`, {
+      method: "DELETE",
+    }).catch(() => undefined);
+  }
+  await fetch(
+    `${GATEWAY_URL}/v1/edges/${encodeURIComponent(EDGE_TAIL)}/${encodeURIComponent(EDGE_HEAD)}`,
+    { method: "DELETE" },
+  ).catch(() => undefined);
+
+  // Seed a starting vertex + edge so the UI has something to load on the
+  // detail pages before the user edits or replaces.
+  const put = await fetch(`${GATEWAY_URL}/v1/vertices`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      vertices: [
+        { key: VERTEX_KEY, value: { string: "seed" } },
+        { key: EDGE_TAIL, value: { string: "tail" } },
+        { key: EDGE_HEAD, value: { string: "head" } },
+      ],
+    }),
+  });
+  if (!put.ok) {
+    throw new Error(
+      `seed vertices failed: ${put.status} ${await put.text()}`,
+    );
+  }
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(
+    ({ key, value }) => {
+      try {
+        window.localStorage.setItem(key, value);
+      } catch {
+        // ignore — storage may be unavailable in private mode
+      }
+    },
+    { key: STORAGE_KEY, value: GATEWAY_URL },
+  );
+});
+
+test.describe("vertex detail", () => {
+  test("loads the seeded vertex and switches kind via save round-trip", async ({
+    page,
+  }) => {
+    await page.goto(`/vertices/${encodeURIComponent(VERTEX_KEY)}`);
+
+    // Read view should mount with kind=string.
+    await expect(page.getByTestId("vertex-detail-read")).toBeVisible();
+    await expect(page.getByTestId("vertex-detail-key")).toHaveText(VERTEX_KEY);
+
+    // Flip to edit mode and switch the kind to int32.
+    await page.getByTestId("vertex-edit-trigger").click();
+    const editForm = page.getByTestId("vertex-detail-edit");
+    await expect(editForm).toBeVisible();
+    await selectKind(page, "int32");
+    await page.getByTestId("vertex-editor-int32 value").fill("42");
+
+    // Save — the reducer will re-GET so the read view must reflect int32.
+    await page.getByTestId("vertex-save").click();
+    await expect(page.getByTestId("vertex-detail-read")).toBeVisible();
+
+    const fetched = await fetch(
+      `${GATEWAY_URL}/v1/vertices/${encodeURIComponent(VERTEX_KEY)}`,
+    );
+    expect(fetched.ok).toBeTruthy();
+    const body = (await fetched.json()) as {
+      vertex?: { int32?: number; string?: string };
+    };
+    expect(body.vertex?.int32).toBe(42);
+    expect(body.vertex?.string).toBeUndefined();
+  });
+
+  test("invalid bytes input surfaces a save error and does not mutate the server", async ({
+    page,
+  }) => {
+    await page.goto(`/vertices/${encodeURIComponent(VERTEX_KEY)}`);
+    await page.getByTestId("vertex-edit-trigger").click();
+    await selectKind(page, "bytes");
+    await page.getByTestId("vertex-editor-bytes").fill("not-hex-data!");
+    await page.getByTestId("vertex-save").click();
+
+    // Save button should remain (form still visible) — the codec rejects
+    // the input before reaching the server.
+    await expect(page.getByTestId("vertex-detail-edit")).toBeVisible();
+  });
+
+  test("delete removes the vertex and redirects to the listing", async ({
+    page,
+  }) => {
+    // Use a one-shot key so the rest of the suite is unaffected.
+    const oneShot = `${VERTEX_KEY}:delete`;
+    await fetch(`${GATEWAY_URL}/v1/vertices`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        vertices: [{ key: oneShot, value: { string: "doomed" } }],
+      }),
+    });
+
+    await page.goto(`/vertices/${encodeURIComponent(oneShot)}`);
+    await expect(page.getByTestId("vertex-detail-read")).toBeVisible();
+    await page.getByTestId("vertex-delete-trigger").click();
+    await page.getByTestId("confirm-delete-vertex").click();
+
+    await expect(page).toHaveURL(/\/vertices$/);
+
+    const recheck = await fetch(
+      `${GATEWAY_URL}/v1/vertices/${encodeURIComponent(oneShot)}`,
+    );
+    expect(recheck.status).toBe(404);
+  });
+});
+
+test.describe("edge detail", () => {
+  test("AddEdge accumulates weight and PutEdge replaces it", async ({
+    page,
+  }) => {
+    // Reset edge state so this test owns the row.
+    await fetch(
+      `${GATEWAY_URL}/v1/edges/${encodeURIComponent(EDGE_TAIL)}/${encodeURIComponent(EDGE_HEAD)}`,
+      { method: "DELETE" },
+    ).catch(() => undefined);
+
+    await page.goto(
+      `/edges/${encodeURIComponent(EDGE_TAIL)}/${encodeURIComponent(EDGE_HEAD)}`,
+    );
+
+    // Either the row is missing (first run) or already exists — both are
+    // acceptable starting states for the test.
+    await expect(
+      page.getByTestId("edge-form-add").or(page.getByTestId("edge-detail-missing")),
+    ).toBeVisible();
+
+    // Add the same contribution twice. Decay over a few ms is negligible.
+    await page.getByTestId("edge-add-weight").fill("1.5");
+    await page.getByTestId("edge-add-submit").click();
+    await expect(page.getByTestId("edge-detail-read")).toBeVisible();
+    await page.getByTestId("edge-add-weight").fill("1.5");
+    await page.getByTestId("edge-add-submit").click();
+    await expect(page.getByTestId("edge-current-weight")).toBeVisible();
+
+    const afterAdds = await fetchEdgeWeight(EDGE_TAIL, EDGE_HEAD);
+    // Two adds of 1.5 with negligible decay → roughly 3.0; allow slack.
+    expect(afterAdds).toBeGreaterThan(2.5);
+    expect(afterAdds).toBeLessThan(3.1);
+
+    // PutEdge collapses the accumulator to an exact value.
+    await page.getByTestId("edge-put-weight").fill("7");
+    await page.getByTestId("edge-put-submit").click();
+    await expect(page.getByTestId("edge-current-weight")).toContainText("7");
+
+    const afterPut = await fetchEdgeWeight(EDGE_TAIL, EDGE_HEAD);
+    expect(afterPut).toBeCloseTo(7, 5);
+  });
+
+  test("delete removes the edge", async ({ page }) => {
+    // Make sure something exists first.
+    await fetch(`${GATEWAY_URL}/v1/edges/put`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        edges: [{ tail: EDGE_TAIL, head: EDGE_HEAD, weight: 1 }],
+      }),
+    });
+
+    await page.goto(
+      `/edges/${encodeURIComponent(EDGE_TAIL)}/${encodeURIComponent(EDGE_HEAD)}`,
+    );
+    await expect(page.getByTestId("edge-detail-read")).toBeVisible();
+    await page.getByTestId("edge-delete-trigger").click();
+    await page.getByTestId("confirm-delete-edge").click();
+
+    await expect(page).toHaveURL(/\/edges$/);
+
+    const recheck = await fetch(
+      `${GATEWAY_URL}/v1/edges/${encodeURIComponent(EDGE_TAIL)}/${encodeURIComponent(EDGE_HEAD)}`,
+    );
+    expect(recheck.status).toBe(404);
+  });
+});
+
+async function selectKind(page: Page, kind: string) {
+  // Fluent UI Dropdown is a button — click then pick the option.
+  await page.getByTestId("vertex-kind-selector").click();
+  await page.getByRole("option", { name: kind, exact: true }).click();
+}
+
+async function fetchEdgeWeight(tail: string, head: string): Promise<number> {
+  const res = await fetch(
+    `${GATEWAY_URL}/v1/edges/${encodeURIComponent(tail)}/${encodeURIComponent(head)}`,
+  );
+  if (!res.ok) {
+    throw new Error(`fetchEdgeWeight failed: ${res.status}`);
+  }
+  const body = (await res.json()) as { edge?: { weight?: number } };
+  return body.edge?.weight ?? 0;
+}

--- a/admin/tests/e2e/crud.spec.ts
+++ b/admin/tests/e2e/crud.spec.ts
@@ -37,9 +37,7 @@ test.beforeAll(async () => {
     }),
   });
   if (!put.ok) {
-    throw new Error(
-      `seed vertices failed: ${put.status} ${await put.text()}`,
-    );
+    throw new Error(`seed vertices failed: ${put.status} ${await put.text()}`);
   }
 });
 
@@ -146,7 +144,9 @@ test.describe("edge detail", () => {
     // Either the row is missing (first run) or already exists — both are
     // acceptable starting states for the test.
     await expect(
-      page.getByTestId("edge-form-add").or(page.getByTestId("edge-detail-missing")),
+      page
+        .getByTestId("edge-form-add")
+        .or(page.getByTestId("edge-detail-missing")),
     ).toBeVisible();
 
     // Add the same contribution twice. The exact accumulator math is


### PR DESCRIPTION
Closes #320.

## Summary

Adds the vertex/edge detail, edit, create, and delete experience to the admin SPA — the third feature in the admin epic (#317), unlocking ad-hoc fact-management without using the CLI.

## What landed

### Routes
- `/vertices/:key` — detail with read/edit/create/delete branches.
- `/edges/:tail/:head` — detail with current-edge card, side-by-side add + put forms, and delete.

### API adapters (`app/lib/client/infrastructure/api/`)
- get-vertex, put-vertex, delete-vertex
- get-edge, put-edge, add-edge, delete-edge

### Usecase layer (`app/lib/client/usecase/`)
- **edit-vertex/value-codec** covers all 12 `v1Vertex` variants (float32/64, int32/64, uint32/64, bool, string, bytes hex+base64, timestamp, duration, nil), validates signed/unsigned ranges, and round-trips with a 4-preset + custom TTL helper.
- **edit-vertex/reducer** is epoch-gated so a key-change mid-flight never poisons the form, and seeds form inputs from the loaded vertex on cancel.
- **edit-edge** mirrors the vertex flow with dual add/put forms, asymmetric write feedback (add resets to invite repeats, put re-seeds from server).
- Handlers PUT-then-re-GET so the UI always reflects canonical server state.

### Components
- `editors/` — one `.tsx` per variant + shared `NumberEditor`.
- `ValueEditor` switch over kind.
- `KindSelector` (Fluent Dropdown), `TtlField` (radio chips + custom Go duration).
- `VertexDetailPage` (read / edit / delete / create-on-missing).
- `EdgeDetailPage` with twin write cards; help text explains the accumulator-vs-idempotent distinction between AddEdge and PutEdge.
- Delete dialogs for both.

### Cross-linking
- `BrowseEdgesPage` rows gain an Edit action alongside Illuminate.

## Tests

- **Unit (bun:test)** — 77 pass / 0 fail / 158 expects / ~40ms across 8 files. Covers every codec variant, reducer transition, and selector predicate.
- **E2E (Playwright)** — full suite 12/12 green:
  - vertex round-trip: load seeded value, switch kind via Save, server-side confirmation
  - invalid bytes: Save disabled before any RPC fires
  - vertex delete + redirect + 404
  - edge add accumulates (strictly increases) and put collapses to exact weight
  - edge delete + redirect + 404

## Notes

- bun-only: `bun run typecheck` + `bun test app` + `bun run build` + `bun run test:e2e` all clean.
- No Go changes; `go test ./... ./core/... ./mcp/... ./pb/... ./sdks/go/... ./server/...` is green.

## Refs

Builds on F1 #318 (PR #328) and F2 #319 (PR #330). Next up: F4 #321 (Sigma.js Illuminate).