### PR TITLE
feat(admin): Illuminate graph explorer with Sigma.js (F4 #321)

### DIFF
--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.module.css
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.module.css
@@ -1,0 +1,72 @@
+.wrapper {
+  position: relative;
+  width: 100%;
+  height: 70vh;
+  min-height: 480px;
+  border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  border-radius: var(--borderRadiusMedium, 6px);
+  background: var(--colorNeutralBackground2, #fafafa);
+  overflow: hidden;
+}
+
+.busy {
+  opacity: 0.65;
+  transition: opacity 120ms ease-out;
+}
+
+.canvas {
+  position: absolute;
+  inset: 0;
+}
+
+.emptyOverlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--colorNeutralForeground3, #707070);
+  font-size: var(--fontSizeBase300, 14px);
+  pointer-events: none;
+}
+
+.tooltip {
+  position: absolute;
+  left: var(--tooltip-x, 0px);
+  top: var(--tooltip-y, 0px);
+  pointer-events: none;
+  z-index: 2;
+  max-width: 280px;
+  padding: 6px 10px;
+  background: var(--colorNeutralBackground1, #fff);
+  border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  border-radius: var(--borderRadiusMedium, 6px);
+  box-shadow: var(--shadow8, 0 2px 8px rgba(0, 0, 0, 0.12));
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  font-size: var(--fontSizeBase200, 12px);
+}
+
+.tooltipKind {
+  color: var(--colorNeutralForeground3, #707070);
+  text-transform: lowercase;
+  font-family: var(--fontFamilyBase, system-ui, sans-serif);
+  font-size: var(--fontSizeBase100, 10px);
+  letter-spacing: 0.04em;
+}
+
+.tooltipLabel {
+  color: var(--colorNeutralForeground1, #242424);
+  font-weight: var(--fontWeightSemibold, 600);
+  word-break: break-all;
+}
+
+.tooltipDetail {
+  color: var(--colorNeutralForeground2, #424242);
+  margin-top: 2px;
+  word-break: break-all;
+}

--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import Graph from "graphology";
+import forceAtlas2 from "graphology-layout-forceatlas2";
+import Sigma from "sigma";
+import type {
+  GraphEdge,
+  GraphNode,
+} from "~/lib/client/usecase/illuminate/selectors";
+import styles from "./IlluminateCanvas.module.css";
+
+export interface IlluminateCanvasProps {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  onNodeClick: (key: string) => void;
+  /** When true, the canvas dims to communicate a stale frame. */
+  isBusy: boolean;
+}
+
+const SEED_COLOR = "#0078d4"; // FluentUI brandColor (web theme accent)
+const NODE_COLOR = "#5b5b5b";
+const EDGE_COLOR = "#bdbdbd";
+
+interface HoverState {
+  kind: "node" | "edge";
+  label: string;
+  detail: string;
+  x: number;
+  y: number;
+}
+
+/**
+ * Hosts a `graphology` graph and a `sigma` renderer. The component owns
+ * the lifecycle of the renderer (mount on first paint, destroy on unmount)
+ * and reconciles the graph in-place when the view model changes — full
+ * teardown on every prop change would cost the user any in-flight layout
+ * iterations.
+ */
+export function IlluminateCanvas({
+  nodes,
+  edges,
+  onNodeClick,
+  isBusy,
+}: IlluminateCanvasProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const sigmaRef = useRef<Sigma | null>(null);
+  const graphRef = useRef<Graph | null>(null);
+  const [hover, setHover] = useState<HoverState | null>(null);
+
+  // Stable callback ref so the click listener doesn't have to be rebound
+  // every render (would otherwise drop hover state).
+  const onNodeClickRef = useRef(onNodeClick);
+  useEffect(() => {
+    onNodeClickRef.current = onNodeClick;
+  }, [onNodeClick]);
+
+  // Mount sigma once. The graph and renderer survive across data updates;
+  // see the reconcile effect below.
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const graph = new Graph({ multi: false, type: "directed" });
+    const renderer = new Sigma(graph, containerRef.current, {
+      renderLabels: true,
+      labelDensity: 0.5,
+      labelGridCellSize: 80,
+      labelRenderedSizeThreshold: 8,
+      defaultEdgeColor: EDGE_COLOR,
+      defaultNodeColor: NODE_COLOR,
+    });
+    graphRef.current = graph;
+    sigmaRef.current = renderer;
+
+    renderer.on("clickNode", (event) => {
+      onNodeClickRef.current(event.node);
+    });
+    const showNodeHover = (event: {
+      node: string;
+      event: { x: number; y: number };
+    }) => {
+      const attrs = graph.getNodeAttributes(event.node) as {
+        label?: string;
+        detail?: string;
+      };
+      setHover({
+        kind: "node",
+        label: attrs.label ?? event.node,
+        detail: attrs.detail ?? "",
+        x: event.event.x,
+        y: event.event.y,
+      });
+    };
+    const showEdgeHover = (event: {
+      edge: string;
+      event: { x: number; y: number };
+    }) => {
+      const attrs = graph.getEdgeAttributes(event.edge) as {
+        label?: string;
+        detail?: string;
+      };
+      setHover({
+        kind: "edge",
+        label: attrs.label ?? event.edge,
+        detail: attrs.detail ?? "",
+        x: event.event.x,
+        y: event.event.y,
+      });
+    };
+    const clearHover = () => setHover(null);
+    renderer.on("enterNode", showNodeHover);
+    renderer.on("leaveNode", clearHover);
+    renderer.on("enterEdge", showEdgeHover);
+    renderer.on("leaveEdge", clearHover);
+
+    return () => {
+      renderer.kill();
+      graph.clear();
+      sigmaRef.current = null;
+      graphRef.current = null;
+    };
+  }, []);
+
+  // Reconcile the graph with the latest view model. We diff by ID rather
+  // than clearing so ForceAtlas2 can keep the positions of nodes that
+  // survived from the previous frame — the canvas reads as a smooth
+  // expansion instead of a layout reshuffle on every refetch.
+  useEffect(() => {
+    const graph = graphRef.current;
+    if (!graph) return;
+    const sigma = sigmaRef.current;
+
+    const nextNodeIds = new Set(nodes.map((n) => n.id));
+    const nextEdgeIds = new Set(edges.map((e) => e.id));
+
+    // Drop edges first to avoid orphan references when we drop nodes.
+    for (const edgeId of graph.edges()) {
+      if (!nextEdgeIds.has(edgeId)) {
+        graph.dropEdge(edgeId);
+      }
+    }
+    for (const nodeId of graph.nodes()) {
+      if (!nextNodeIds.has(nodeId)) {
+        graph.dropNode(nodeId);
+      }
+    }
+
+    for (const node of nodes) {
+      const size = 4 + node.importance * 10;
+      const color = node.isSeed ? SEED_COLOR : NODE_COLOR;
+      const detail = describeVertex(node);
+      if (graph.hasNode(node.id)) {
+        graph.mergeNodeAttributes(node.id, {
+          label: node.label,
+          size,
+          color,
+          detail,
+          isSeed: node.isSeed,
+        });
+      } else {
+        // Seed the layout near the origin, neighbours in a wide ring so
+        // ForceAtlas2 has somewhere to push from. Random within a circle
+        // keeps the first frame stable.
+        const angle = Math.random() * Math.PI * 2;
+        const radius = node.isSeed ? 0 : 1 + Math.random() * 4;
+        graph.addNode(node.id, {
+          label: node.label,
+          x: Math.cos(angle) * radius,
+          y: Math.sin(angle) * radius,
+          size,
+          color,
+          detail,
+          isSeed: node.isSeed,
+        });
+      }
+    }
+    for (const edge of edges) {
+      if (graph.hasEdge(edge.id)) {
+        graph.mergeEdgeAttributes(edge.id, {
+          size: 1 + Math.min(4, edge.weight),
+          label: edge.id,
+          detail: `weight = ${edge.weight}`,
+        });
+      } else {
+        graph.addEdgeWithKey(edge.id, edge.source, edge.target, {
+          size: 1 + Math.min(4, edge.weight),
+          color: EDGE_COLOR,
+          label: edge.id,
+          detail: `weight = ${edge.weight}`,
+        });
+      }
+    }
+
+    if (graph.order > 0) {
+      forceAtlas2.assign(graph, {
+        iterations: 80,
+        settings: {
+          gravity: 1,
+          scalingRatio: 8,
+          slowDown: 4,
+          barnesHutOptimize: graph.order > 100,
+        },
+      });
+    }
+
+    sigma?.refresh();
+  }, [nodes, edges]);
+
+  const empty = nodes.length === 0;
+  const wrapperClass = useMemo(
+    () => [styles.wrapper, isBusy ? styles.busy : ""].filter(Boolean).join(" "),
+    [isBusy],
+  );
+
+  return (
+    <div className={wrapperClass} data-testid="illuminate-canvas">
+      <div ref={containerRef} className={styles.canvas} aria-hidden="true" />
+      {empty ? (
+        <div className={styles.emptyOverlay}>
+          <span>No vertices to display.</span>
+        </div>
+      ) : null}
+      {hover ? (
+        <div
+          className={styles.tooltip}
+          role="tooltip"
+          ref={(el) => {
+            if (!el) return;
+            el.style.setProperty("--tooltip-x", `${hover.x + 12}px`);
+            el.style.setProperty("--tooltip-y", `${hover.y + 12}px`);
+          }}
+        >
+          <div className={styles.tooltipKind}>{hover.kind}</div>
+          <div className={styles.tooltipLabel}>{hover.label}</div>
+          {hover.detail ? (
+            <div className={styles.tooltipDetail}>{hover.detail}</div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function describeVertex(node: GraphNode): string {
+  const v = node.vertex;
+  if (v.bool !== undefined) return `bool = ${v.bool}`;
+  if (v.int32 !== undefined) return `int32 = ${v.int32}`;
+  if (v.int64 !== undefined) return `int64 = ${v.int64}`;
+  if (v.uint32 !== undefined) return `uint32 = ${v.uint32}`;
+  if (v.uint64 !== undefined) return `uint64 = ${v.uint64}`;
+  if (v.float32 !== undefined) return `float32 = ${v.float32}`;
+  if (v.float64 !== undefined) return `float64 = ${v.float64}`;
+  if (v.string !== undefined) return `string = ${truncate(v.string)}`;
+  if (v.timestamp !== undefined) return `timestamp = ${v.timestamp}`;
+  if (v.duration !== undefined) return `duration = ${v.duration}`;
+  if (v.bytes !== undefined) return "bytes = …";
+  if (v.nil) return "nil";
+  return "";
+}
+
+function truncate(s: string): string {
+  return s.length > 64 ? `${s.slice(0, 63)}…` : s;
+}

--- a/admin/app/components/illuminate/IlluminatePage/IlluminatePage.module.css
+++ b/admin/app/components/illuminate/IlluminatePage/IlluminatePage.module.css
@@ -1,0 +1,40 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalL, 16px);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalS, 8px);
+}
+
+.title {
+  font-size: var(--fontSizeBase600, 24px);
+  font-weight: var(--fontWeightSemibold, 600);
+  margin: 0;
+}
+
+.lead {
+  color: var(--colorNeutralForeground2, #424242);
+  margin: 0;
+}
+
+.alert {
+  margin: 0;
+}
+
+.tableDisclosure {
+  border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  border-radius: var(--borderRadiusMedium, 6px);
+  background: var(--colorNeutralBackground1, #fff);
+  padding: var(--spacingVerticalS, 8px) var(--spacingHorizontalM, 12px);
+}
+
+.summary {
+  cursor: pointer;
+  color: var(--colorNeutralForeground2, #424242);
+  font-size: var(--fontSizeBase200, 12px);
+  padding: 4px 0;
+}

--- a/admin/app/components/illuminate/IlluminatePage/IlluminatePage.tsx
+++ b/admin/app/components/illuminate/IlluminatePage/IlluminatePage.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useEffect } from "react";
+import { MessageBar, MessageBarBody } from "@fluentui/react-components";
+import { useNavigate, useSearchParams } from "react-router";
+import { IlluminateCanvas } from "../IlluminateCanvas/IlluminateCanvas";
+import { IlluminateTable } from "../IlluminateTable/IlluminateTable";
+import { IlluminateToolbar } from "../IlluminateToolbar/IlluminateToolbar";
+import { SeedPrompt } from "../SeedPrompt/SeedPrompt";
+import { useIlluminate } from "~/lib/client/usecase/illuminate/use-illuminate";
+import styles from "./IlluminatePage.module.css";
+
+/**
+ * Top-level orchestrator for the Illuminate screen. The URL's `?seed=`
+ * query param is the source of truth for the active seed; pushing a new
+ * seed via the canvas / table updates the URL so the browser back button
+ * walks the user back through the seed history naturally.
+ */
+export function IlluminatePage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const rawSeed = searchParams.get("seed") ?? "";
+  const urlSeed = decodeSeed(rawSeed);
+
+  const ill = useIlluminate(urlSeed);
+
+  // Mirror reducer-driven seed changes (push/pop) back into the URL so
+  // the browser history walks naturally. The URL is authoritative on the
+  // way IN (a dedicated effect inside `useIlluminate` syncs `urlSeed` →
+  // reducer); this effect is purely state → URL, and must NEVER clear
+  // the URL from a transient empty reducer state — that would race the
+  // initial SEED_CHANGED priming step and wipe the seed the user just
+  // navigated to.
+  useEffect(() => {
+    if (ill.state.seed === "" || ill.state.seed === urlSeed) return;
+    setSearchParams({ seed: ill.state.seed }, { replace: false });
+  }, [ill.state.seed, urlSeed, setSearchParams]);
+
+  const handleNodeClick = useCallback(
+    (key: string) => {
+      if (key && key !== ill.state.seed) {
+        ill.push(key);
+      }
+    },
+    [ill],
+  );
+
+  const openFromPrompt = useCallback(
+    (seed: string) => {
+      navigate(`/illuminate?seed=${encodeURIComponent(seed)}`);
+    },
+    [navigate],
+  );
+
+  return (
+    <div className={styles.root}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>Illuminate</h1>
+        <p className={styles.lead}>
+          Explore a vertex&rsquo;s neighbourhood. Click a node to re-seed; use{" "}
+          <em>Pop</em> to walk back through the history stack.
+        </p>
+      </header>
+
+      {urlSeed === "" ? (
+        <SeedPrompt onOpen={openFromPrompt} />
+      ) : (
+        <>
+          <IlluminateToolbar
+            seed={ill.state.seed}
+            controls={ill.state.controls}
+            status={ill.state.status}
+            canPop={ill.canPop}
+            onControlsChange={ill.setControls}
+            onPop={ill.pop}
+            onRefresh={ill.refresh}
+          />
+          {ill.state.error ? (
+            <MessageBar
+              intent="error"
+              data-testid="illuminate-error"
+              className={styles.alert}
+            >
+              <MessageBarBody>{ill.state.error}</MessageBarBody>
+            </MessageBar>
+          ) : null}
+          <IlluminateCanvas
+            nodes={ill.view.nodes}
+            edges={ill.view.edges}
+            onNodeClick={handleNodeClick}
+            isBusy={ill.isBusy}
+          />
+          <details className={styles.tableDisclosure}>
+            <summary className={styles.summary}>
+              List view ({ill.view.nodes.length} vertices,&nbsp;
+              {ill.view.edges.length} edges)
+            </summary>
+            <IlluminateTable nodes={ill.view.nodes} onIlluminate={ill.push} />
+          </details>
+        </>
+      )}
+    </div>
+  );
+}
+
+function decodeSeed(raw: string): string {
+  if (raw === "") return "";
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    // Browser already decoded once; pass through unmodified.
+    return raw;
+  }
+}

--- a/admin/app/components/illuminate/IlluminateTable/IlluminateTable.module.css
+++ b/admin/app/components/illuminate/IlluminateTable/IlluminateTable.module.css
@@ -1,0 +1,27 @@
+.colKey {
+  width: 32%;
+}
+
+.colExp {
+  width: 18%;
+}
+
+.colActions {
+  width: 14%;
+  text-align: right;
+}
+
+.keyLink {
+  color: var(--colorBrandForegroundLink, #0078d4);
+  text-decoration: none;
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+}
+
+.keyLink:hover {
+  text-decoration: underline;
+}

--- a/admin/app/components/illuminate/IlluminateTable/IlluminateTable.tsx
+++ b/admin/app/components/illuminate/IlluminateTable/IlluminateTable.tsx
@@ -1,0 +1,79 @@
+import {
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+} from "@fluentui/react-components";
+import { Link } from "react-router";
+import { ValueCell } from "~/components/browse-vertices/ValueCell/ValueCell";
+import { ExpirationCell } from "~/components/browse-vertices/ExpirationCell/ExpirationCell";
+import type { GraphNode } from "~/lib/client/usecase/illuminate/selectors";
+import styles from "./IlluminateTable.module.css";
+
+export interface IlluminateTableProps {
+  nodes: GraphNode[];
+  onIlluminate: (key: string) => void;
+}
+
+/**
+ * Accessible companion view for the canvas. Keyboard and screen-reader
+ * users get the same neighbourhood data as a flat table; clicking a row
+ * pushes that key onto the seed history.
+ */
+export function IlluminateTable({ nodes, onIlluminate }: IlluminateTableProps) {
+  if (nodes.length === 0) {
+    return null;
+  }
+  return (
+    <Table
+      aria-label="Illuminate neighbourhood"
+      data-testid="illuminate-table"
+      sortable={false}
+    >
+      <TableHeader>
+        <TableRow>
+          <TableHeaderCell className={styles.colKey}>Key</TableHeaderCell>
+          <TableHeaderCell>Value</TableHeaderCell>
+          <TableHeaderCell className={styles.colExp}>Expires</TableHeaderCell>
+          <TableHeaderCell className={styles.colActions}>
+            Actions
+          </TableHeaderCell>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {nodes.map((node) => (
+          <TableRow key={node.id}>
+            <TableCell className={styles.colKey}>
+              <Link
+                to={`/vertices/${encodeURIComponent(node.id)}`}
+                className={styles.keyLink}
+              >
+                {node.isSeed ? <strong>{node.label}</strong> : node.label}
+              </Link>
+            </TableCell>
+            <TableCell>
+              <ValueCell vertex={node.vertex} />
+            </TableCell>
+            <TableCell className={styles.colExp}>
+              <ExpirationCell expiration={node.vertex.expiration} />
+            </TableCell>
+            <TableCell className={styles.colActions}>
+              <Button
+                appearance="subtle"
+                size="small"
+                onClick={() => onIlluminate(node.id)}
+                disabled={node.isSeed}
+                aria-label={`Re-seed from ${node.id}`}
+              >
+                Re-seed
+              </Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.module.css
+++ b/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.module.css
@@ -1,0 +1,61 @@
+.toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalM, 12px);
+  padding: var(--spacingVerticalM, 12px) var(--spacingHorizontalM, 12px);
+  border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  border-radius: var(--borderRadiusMedium, 6px);
+  background: var(--colorNeutralBackground1, #fff);
+}
+
+.seedRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacingHorizontalS, 8px);
+  flex-wrap: wrap;
+}
+
+.seedLabel {
+  color: var(--colorNeutralForeground2, #424242);
+  font-size: var(--fontSizeBase200, 12px);
+}
+
+.seedValue {
+  flex: 1 1 240px;
+  min-width: 0;
+  padding: 4px 8px;
+  background: var(--colorNeutralBackground3, #f5f5f5);
+  border-radius: var(--borderRadiusMedium, 6px);
+  color: var(--colorNeutralForeground1, #242424);
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  font-size: var(--fontSizeBase200, 12px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.knobs {
+  display: flex;
+  align-items: center;
+  gap: var(--spacingHorizontalL, 16px);
+  flex-wrap: wrap;
+}
+
+.knobField {
+  display: flex;
+  align-items: center;
+  gap: var(--spacingHorizontalS, 8px);
+  min-width: 220px;
+  flex: 1 1 220px;
+}
+
+.optimization {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalXS, 4px);
+}

--- a/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.tsx
+++ b/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.tsx
@@ -1,0 +1,197 @@
+import {
+  Badge,
+  Button,
+  Field,
+  Label,
+  Radio,
+  RadioGroup,
+  Slider,
+  Switch,
+  Tooltip,
+} from "@fluentui/react-components";
+import {
+  ArrowClockwise20Regular,
+  ArrowUndo20Regular,
+} from "@fluentui/react-icons";
+import type {
+  IlluminateControls,
+  IlluminateStatus,
+} from "~/lib/client/usecase/illuminate/state";
+import type { Optimization } from "~/lib/client/infrastructure/api/illuminate";
+import styles from "./IlluminateToolbar.module.css";
+
+export interface IlluminateToolbarProps {
+  seed: string;
+  controls: IlluminateControls;
+  status: IlluminateStatus;
+  canPop: boolean;
+  onControlsChange: (next: IlluminateControls) => void;
+  onPop: () => void;
+  onRefresh: () => void;
+}
+
+const OPTIMIZATIONS: Array<{ value: Optimization; label: string }> = [
+  { value: "OPTIMIZATION_UNSPECIFIED", label: "All edges" },
+  { value: "OPTIMIZATION_SHORTEST_PATH_TREE", label: "Shortest path tree" },
+  {
+    value: "OPTIMIZATION_SHORTEST_PATH_TREE_INVERSE",
+    label: "Inverse SPT",
+  },
+  {
+    value: "OPTIMIZATION_MINIMUM_SPANNING_TREE",
+    label: "Minimum spanning tree",
+  },
+  {
+    value: "OPTIMIZATION_MAXIMUM_SPANNING_TREE",
+    label: "Maximum spanning tree",
+  },
+];
+
+/**
+ * Controlled toolbar above the Illuminate canvas. Owns no async state of
+ * its own — every change fans out through `onControlsChange` so the
+ * usecase hook stays the single source of truth.
+ */
+export function IlluminateToolbar({
+  seed,
+  controls,
+  status,
+  canPop,
+  onControlsChange,
+  onPop,
+  onRefresh,
+}: IlluminateToolbarProps) {
+  const update = <K extends keyof IlluminateControls>(
+    key: K,
+    value: IlluminateControls[K],
+  ) => {
+    onControlsChange({ ...controls, [key]: value });
+  };
+
+  return (
+    <section
+      className={styles.toolbar}
+      aria-label="Illuminate controls"
+      data-testid="illuminate-toolbar"
+    >
+      <div className={styles.seedRow}>
+        <Label className={styles.seedLabel}>Seed</Label>
+        <Tooltip content={seed} relationship="label" withArrow>
+          <code className={styles.seedValue} data-testid="illuminate-seed">
+            {seed || "—"}
+          </code>
+        </Tooltip>
+        <Button
+          appearance="subtle"
+          size="small"
+          icon={<ArrowUndo20Regular />}
+          disabled={!canPop}
+          onClick={onPop}
+          data-testid="illuminate-pop"
+        >
+          Pop
+        </Button>
+        <Button
+          appearance="subtle"
+          size="small"
+          icon={<ArrowClockwise20Regular />}
+          disabled={status === "loading" || seed === ""}
+          onClick={onRefresh}
+          data-testid="illuminate-refresh"
+        >
+          Refresh
+        </Button>
+        <StatusBadge status={status} />
+      </div>
+
+      <div className={styles.knobs}>
+        <Field
+          label={`Step (${controls.step})`}
+          className={styles.knobField}
+          orientation="horizontal"
+        >
+          <Slider
+            min={1}
+            max={5}
+            step={1}
+            value={controls.step}
+            onChange={(_, data) => update("step", data.value)}
+            data-testid="illuminate-step"
+          />
+        </Field>
+        <Field
+          label={`K (${controls.k})`}
+          className={styles.knobField}
+          orientation="horizontal"
+        >
+          <Slider
+            min={1}
+            max={32}
+            step={1}
+            value={controls.k}
+            onChange={(_, data) => update("k", data.value)}
+            data-testid="illuminate-k"
+          />
+        </Field>
+        <Switch
+          label="TF-IDF reweight"
+          checked={controls.tfidf}
+          onChange={(_, data) => update("tfidf", data.checked)}
+          data-testid="illuminate-tfidf"
+        />
+      </div>
+
+      <Field label="Tree selection" className={styles.optimization}>
+        <RadioGroup
+          value={controls.optimization}
+          onChange={(_, data) =>
+            update("optimization", data.value as Optimization)
+          }
+          layout="horizontal-stacked"
+        >
+          {OPTIMIZATIONS.map((opt) => (
+            <Radio
+              key={opt.value}
+              value={opt.value}
+              label={opt.label}
+              data-testid={`illuminate-opt-${opt.value}`}
+            />
+          ))}
+        </RadioGroup>
+      </Field>
+    </section>
+  );
+}
+
+function StatusBadge({ status }: { status: IlluminateStatus }) {
+  if (status === "loading") {
+    return (
+      <Badge
+        appearance="tint"
+        color="informative"
+        data-testid="illuminate-status"
+      >
+        Loading…
+      </Badge>
+    );
+  }
+  if (status === "error") {
+    return (
+      <Badge appearance="tint" color="danger" data-testid="illuminate-status">
+        Error
+      </Badge>
+    );
+  }
+  if (status === "ready") {
+    return (
+      <Badge appearance="tint" color="success" data-testid="illuminate-status">
+        Ready
+      </Badge>
+    );
+  }
+  return (
+    <Badge appearance="tint" color="subtle" data-testid="illuminate-status">
+      Idle
+    </Badge>
+  );
+}

--- a/admin/app/components/illuminate/SeedPrompt/SeedPrompt.module.css
+++ b/admin/app/components/illuminate/SeedPrompt/SeedPrompt.module.css
@@ -1,0 +1,15 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalM, 12px);
+  max-width: 520px;
+  padding: var(--spacingVerticalL, 16px);
+  border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  border-radius: var(--borderRadiusMedium, 6px);
+  background: var(--colorNeutralBackground1, #fff);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+}

--- a/admin/app/components/illuminate/SeedPrompt/SeedPrompt.tsx
+++ b/admin/app/components/illuminate/SeedPrompt/SeedPrompt.tsx
@@ -1,0 +1,62 @@
+import { useState, type FormEvent } from "react";
+import {
+  Button,
+  Field,
+  Input,
+  MessageBar,
+  MessageBarBody,
+} from "@fluentui/react-components";
+import { LightbulbFilament20Regular } from "@fluentui/react-icons";
+import styles from "./SeedPrompt.module.css";
+
+export interface SeedPromptProps {
+  onOpen: (seed: string) => void;
+}
+
+/**
+ * Shown when the Illuminate route has no `?seed=`. Lets the user kick off
+ * an exploration from any key without first visiting the Browse screen.
+ */
+export function SeedPrompt({ onOpen }: SeedPromptProps) {
+  const [seed, setSeed] = useState("");
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    const trimmed = seed.trim();
+    if (trimmed === "") return;
+    onOpen(trimmed);
+  };
+
+  return (
+    <form
+      className={styles.form}
+      onSubmit={submit}
+      data-testid="illuminate-seed-prompt"
+    >
+      <MessageBar intent="info">
+        <MessageBarBody>
+          Enter a vertex key to illuminate its neighbourhood, or click
+          “Illuminate” from any row on the Browse screen.
+        </MessageBarBody>
+      </MessageBar>
+      <Field label="Seed key" className={styles.field}>
+        <Input
+          value={seed}
+          onChange={(_, data) => setSeed(data.value)}
+          placeholder="e.g. user:42"
+          data-testid="illuminate-seed-input"
+          autoFocus
+        />
+      </Field>
+      <Button
+        appearance="primary"
+        icon={<LightbulbFilament20Regular />}
+        type="submit"
+        disabled={seed.trim() === ""}
+        data-testid="illuminate-open"
+      >
+        Open
+      </Button>
+    </form>
+  );
+}

--- a/admin/app/lib/client/infrastructure/api/illuminate.ts
+++ b/admin/app/lib/client/infrastructure/api/illuminate.ts
@@ -1,0 +1,74 @@
+import type { components, operations } from "./lantern-api.gen";
+import type { LanternClient } from "./lantern-client";
+import { LanternApiError } from "./error";
+
+export type Vertex = components["schemas"]["v1Vertex"];
+export type Edge = components["schemas"]["v1Edge"];
+export type Graph = components["schemas"]["v1Graph"];
+export type IlluminateResponse = components["schemas"]["v1IlluminateResponse"];
+
+/**
+ * Query knobs accepted by `LanternService_Illuminate`. Mirrors the
+ * generated `operations[…].parameters.query` shape but is the contract the
+ * usecase layer talks to (no nested `?` chains).
+ */
+export type Optimization = NonNullable<
+  NonNullable<
+    operations["LanternService_Illuminate"]["parameters"]["query"]
+  >["optimization"]
+>;
+
+export interface IlluminateRequest {
+  /** Seed vertex key. Required; must be non-empty (caller decodes URL first). */
+  seed: string;
+  /** Max hops from the seed (server-side default if omitted). */
+  step?: number;
+  /** Max neighbours expanded per hop. */
+  k?: number;
+  /** Reweight edges using TF-IDF before tree selection. */
+  tfidf?: boolean;
+  /** Tree-selection strategy applied to the returned subgraph. */
+  optimization?: Optimization;
+}
+
+/**
+ * Calls `LanternService_Illuminate` (GET `/v1/illuminate/{seed}`).
+ *
+ * The seed segment is URL-encoded here so callers can pass raw keys
+ * (including `:`, `/`, spaces, …). Empty optional knobs are omitted from
+ * the query string so the server's defaults apply.
+ */
+export async function illuminate(
+  client: LanternClient,
+  request: IlluminateRequest,
+  init?: { signal?: AbortSignal },
+): Promise<IlluminateResponse> {
+  if (request.seed === "") {
+    throw new Error("illuminate: seed must be non-empty");
+  }
+  const params = new URLSearchParams();
+  if (request.step !== undefined) {
+    params.set("step", String(request.step));
+  }
+  if (request.k !== undefined) {
+    params.set("k", String(request.k));
+  }
+  if (request.tfidf !== undefined) {
+    params.set("tfidf", String(request.tfidf));
+  }
+  if (request.optimization !== undefined) {
+    params.set("optimization", request.optimization);
+  }
+  const query = params.toString();
+  const path =
+    `/v1/illuminate/${encodeURIComponent(request.seed)}` +
+    (query === "" ? "" : `?${query}`);
+  const response = await client.request(path, {
+    method: "GET",
+    signal: init?.signal,
+  });
+  if (!response.ok) {
+    throw await LanternApiError.fromResponse(response, "Illuminate");
+  }
+  return (await response.json()) as IlluminateResponse;
+}

--- a/admin/app/lib/client/usecase/illuminate/handlers.ts
+++ b/admin/app/lib/client/usecase/illuminate/handlers.ts
@@ -1,0 +1,71 @@
+import { LanternApiError } from "~/lib/client/infrastructure/api/error";
+import {
+  illuminate,
+  type IlluminateRequest,
+} from "~/lib/client/infrastructure/api/illuminate";
+import type { LanternClient } from "~/lib/client/infrastructure/api/lantern-client";
+import type { IlluminateAction } from "./reducer";
+import type { IlluminateControls, IlluminateFrame } from "./state";
+
+export interface FetchIlluminateInput {
+  client: LanternClient;
+  seed: string;
+  controls: IlluminateControls;
+  epoch: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Fetches one Illuminate frame and dispatches the resulting state
+ * transition. Swallows `AbortError` because cancellation is a normal
+ * control-flow event in this view (the user drags a slider and we move on
+ * to a fresh request).
+ */
+export async function fetchIlluminate(
+  input: FetchIlluminateInput,
+  dispatch: (action: IlluminateAction) => void,
+): Promise<void> {
+  dispatch({ type: "FETCH_REQUESTED", epoch: input.epoch });
+  try {
+    const request: IlluminateRequest = {
+      seed: input.seed,
+      step: input.controls.step,
+      k: input.controls.k,
+      tfidf: input.controls.tfidf,
+      optimization: input.controls.optimization,
+    };
+    const response = await illuminate(input.client, request, {
+      signal: input.signal,
+    });
+    const frame: IlluminateFrame = {
+      seed: input.seed,
+      controls: input.controls,
+      vertices: response.graph?.vertices ?? [],
+      edges: response.graph?.edges ?? [],
+    };
+    dispatch({ type: "FETCH_RECEIVED", epoch: input.epoch, frame });
+  } catch (err) {
+    if (isAbortError(err)) {
+      return;
+    }
+    dispatch({
+      type: "FETCH_FAILED",
+      epoch: input.epoch,
+      error: messageOf(err),
+    });
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}
+
+function messageOf(err: unknown): string {
+  if (err instanceof LanternApiError) {
+    return err.grpcMessage ?? err.message;
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}

--- a/admin/app/lib/client/usecase/illuminate/reducer.test.ts
+++ b/admin/app/lib/client/usecase/illuminate/reducer.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "bun:test";
+import { illuminateReducer, type IlluminateAction } from "./reducer";
+import {
+  DEFAULT_ILLUMINATE_CONTROLS,
+  INITIAL_ILLUMINATE_STATE,
+  type IlluminateControls,
+  type IlluminateFrame,
+  type IlluminateState,
+} from "./state";
+
+function withSeed(seed: string): IlluminateState {
+  // Mimic an arrival from a URL-level navigation.
+  return illuminateReducer(INITIAL_ILLUMINATE_STATE, {
+    type: "SEED_CHANGED",
+    seed,
+  });
+}
+
+function frame(seed: string): IlluminateFrame {
+  return {
+    seed,
+    controls: DEFAULT_ILLUMINATE_CONTROLS,
+    vertices: [{ key: seed }],
+    edges: [],
+  };
+}
+
+describe("illuminateReducer", () => {
+  describe("SEED_CHANGED", () => {
+    it("is identity when the seed is unchanged", () => {
+      const next = illuminateReducer(INITIAL_ILLUMINATE_STATE, {
+        type: "SEED_CHANGED",
+        seed: "",
+      });
+      expect(next).toBe(INITIAL_ILLUMINATE_STATE);
+    });
+
+    it("replaces history and bumps the epoch", () => {
+      const next = illuminateReducer(INITIAL_ILLUMINATE_STATE, {
+        type: "SEED_CHANGED",
+        seed: "user:1",
+      });
+      expect(next.seed).toBe("user:1");
+      expect(next.history).toEqual(["user:1"]);
+      expect(next.fetchEpoch).toBe(1);
+      expect(next.frame).toBeNull();
+    });
+
+    it("empties history when the seed is cleared", () => {
+      const seeded = withSeed("user:1");
+      const next = illuminateReducer(seeded, {
+        type: "SEED_CHANGED",
+        seed: "",
+      });
+      expect(next.seed).toBe("");
+      expect(next.history).toEqual([]);
+      expect(next.status).toBe("idle");
+    });
+  });
+
+  describe("SEED_PUSHED / SEED_POPPED", () => {
+    it("pushes a new seed onto history", () => {
+      const a = withSeed("a");
+      const ab = illuminateReducer(a, { type: "SEED_PUSHED", seed: "b" });
+      expect(ab.seed).toBe("b");
+      expect(ab.history).toEqual(["a", "b"]);
+      expect(ab.fetchEpoch).toBe(a.fetchEpoch + 1);
+    });
+
+    it("ignores SEED_PUSHED for an empty or duplicate seed", () => {
+      const a = withSeed("a");
+      expect(illuminateReducer(a, { type: "SEED_PUSHED", seed: "" })).toBe(a);
+      expect(illuminateReducer(a, { type: "SEED_PUSHED", seed: "a" })).toBe(a);
+    });
+
+    it("pops back to the previous seed", () => {
+      let state = withSeed("a");
+      state = illuminateReducer(state, { type: "SEED_PUSHED", seed: "b" });
+      state = illuminateReducer(state, { type: "SEED_PUSHED", seed: "c" });
+      const popped = illuminateReducer(state, { type: "SEED_POPPED" });
+      expect(popped.seed).toBe("b");
+      expect(popped.history).toEqual(["a", "b"]);
+    });
+
+    it("ignores SEED_POPPED at the root of history", () => {
+      const a = withSeed("a");
+      expect(illuminateReducer(a, { type: "SEED_POPPED" })).toBe(a);
+    });
+  });
+
+  describe("CONTROLS_CHANGED", () => {
+    it("is identity when the controls are unchanged by value", () => {
+      const a = withSeed("a");
+      const next = illuminateReducer(a, {
+        type: "CONTROLS_CHANGED",
+        controls: { ...DEFAULT_ILLUMINATE_CONTROLS },
+      });
+      expect(next).toBe(a);
+    });
+
+    it("records new controls and bumps the epoch", () => {
+      const a = withSeed("a");
+      const controls: IlluminateControls = {
+        ...DEFAULT_ILLUMINATE_CONTROLS,
+        step: 4,
+        k: 16,
+      };
+      const next = illuminateReducer(a, {
+        type: "CONTROLS_CHANGED",
+        controls,
+      });
+      expect(next.controls).toEqual(controls);
+      expect(next.fetchEpoch).toBe(a.fetchEpoch + 1);
+    });
+
+    it("keeps the existing frame on screen while reloading", () => {
+      let state = withSeed("a");
+      state = illuminateReducer(state, {
+        type: "FETCH_RECEIVED",
+        epoch: state.fetchEpoch,
+        frame: frame("a"),
+      });
+      const next = illuminateReducer(state, {
+        type: "CONTROLS_CHANGED",
+        controls: { ...DEFAULT_ILLUMINATE_CONTROLS, step: 3 },
+      });
+      expect(next.frame).toBe(state.frame);
+    });
+  });
+
+  describe("REFETCH_REQUESTED", () => {
+    it("bumps the epoch when there is an active seed", () => {
+      const a = withSeed("a");
+      const next = illuminateReducer(a, { type: "REFETCH_REQUESTED" });
+      expect(next.fetchEpoch).toBe(a.fetchEpoch + 1);
+    });
+
+    it("is a no-op when there is no seed", () => {
+      const next = illuminateReducer(INITIAL_ILLUMINATE_STATE, {
+        type: "REFETCH_REQUESTED",
+      });
+      expect(next).toBe(INITIAL_ILLUMINATE_STATE);
+    });
+  });
+
+  describe("FETCH_REQUESTED / FETCH_RECEIVED / FETCH_FAILED", () => {
+    it("transitions to loading on a fresh epoch", () => {
+      const a = withSeed("a");
+      const next = illuminateReducer(a, {
+        type: "FETCH_REQUESTED",
+        epoch: a.fetchEpoch,
+      });
+      expect(next.status).toBe("loading");
+    });
+
+    it("drops stale request markers", () => {
+      const a = withSeed("a");
+      const action: IlluminateAction = {
+        type: "FETCH_REQUESTED",
+        epoch: a.fetchEpoch - 1,
+      };
+      expect(illuminateReducer(a, action)).toBe(a);
+    });
+
+    it("records the received frame and flips to ready", () => {
+      const a = withSeed("a");
+      const next = illuminateReducer(a, {
+        type: "FETCH_RECEIVED",
+        epoch: a.fetchEpoch,
+        frame: frame("a"),
+      });
+      expect(next.status).toBe("ready");
+      expect(next.frame?.seed).toBe("a");
+    });
+
+    it("drops stale frames", () => {
+      const a = withSeed("a");
+      const next = illuminateReducer(a, {
+        type: "FETCH_RECEIVED",
+        epoch: a.fetchEpoch - 1,
+        frame: frame("stale"),
+      });
+      expect(next).toBe(a);
+    });
+
+    it("records errors at the current epoch", () => {
+      const a = withSeed("a");
+      const next = illuminateReducer(a, {
+        type: "FETCH_FAILED",
+        epoch: a.fetchEpoch,
+        error: "boom",
+      });
+      expect(next.status).toBe("error");
+      expect(next.error).toBe("boom");
+    });
+
+    it("drops stale errors", () => {
+      const a = withSeed("a");
+      const next = illuminateReducer(a, {
+        type: "FETCH_FAILED",
+        epoch: a.fetchEpoch - 1,
+        error: "old",
+      });
+      expect(next).toBe(a);
+    });
+  });
+
+  describe("RESET", () => {
+    it("returns to initial state and bumps the epoch", () => {
+      const a = withSeed("a");
+      const next = illuminateReducer(a, { type: "RESET" });
+      expect(next.seed).toBe("");
+      expect(next.history).toEqual([]);
+      expect(next.fetchEpoch).toBe(a.fetchEpoch + 1);
+    });
+  });
+});

--- a/admin/app/lib/client/usecase/illuminate/reducer.ts
+++ b/admin/app/lib/client/usecase/illuminate/reducer.ts
@@ -1,0 +1,143 @@
+import {
+  INITIAL_ILLUMINATE_STATE,
+  type IlluminateControls,
+  type IlluminateFrame,
+  type IlluminateState,
+} from "./state";
+
+export type IlluminateAction =
+  | { type: "SEED_CHANGED"; seed: string }
+  | { type: "SEED_PUSHED"; seed: string }
+  | { type: "SEED_POPPED" }
+  | { type: "CONTROLS_CHANGED"; controls: IlluminateControls }
+  | { type: "REFETCH_REQUESTED" }
+  | { type: "FETCH_REQUESTED"; epoch: number }
+  | { type: "FETCH_RECEIVED"; epoch: number; frame: IlluminateFrame }
+  | { type: "FETCH_FAILED"; epoch: number; error: string }
+  | { type: "RESET" };
+
+/**
+ * Pure reducer for the Illuminate view. Async I/O lives in `handlers.ts`;
+ * this module is the single source of truth for state transitions and is
+ * therefore unit-testable without touching the network.
+ */
+export function illuminateReducer(
+  state: IlluminateState,
+  action: IlluminateAction,
+): IlluminateState {
+  switch (action.type) {
+    case "SEED_CHANGED": {
+      if (action.seed === state.seed) {
+        return state;
+      }
+      // Replace history entirely — `SEED_CHANGED` represents a URL-level
+      // navigation (e.g. arriving on the page from the Browse screen), not
+      // a click inside the canvas. Use `SEED_PUSHED` for the latter.
+      const history = action.seed === "" ? [] : [action.seed];
+      return {
+        ...state,
+        seed: action.seed,
+        history,
+        frame: null,
+        status: action.seed === "" ? "idle" : state.status,
+        error: null,
+        fetchEpoch: state.fetchEpoch + 1,
+      };
+    }
+    case "SEED_PUSHED": {
+      if (action.seed === "" || action.seed === state.seed) {
+        return state;
+      }
+      return {
+        ...state,
+        seed: action.seed,
+        history: [...state.history, action.seed],
+        frame: null,
+        error: null,
+        fetchEpoch: state.fetchEpoch + 1,
+      };
+    }
+    case "SEED_POPPED": {
+      if (state.history.length <= 1) {
+        return state;
+      }
+      const history = state.history.slice(0, -1);
+      const seed = history[history.length - 1] ?? "";
+      return {
+        ...state,
+        seed,
+        history,
+        frame: null,
+        error: null,
+        fetchEpoch: state.fetchEpoch + 1,
+      };
+    }
+    case "CONTROLS_CHANGED": {
+      if (controlsEqual(action.controls, state.controls)) {
+        return state;
+      }
+      return {
+        ...state,
+        controls: action.controls,
+        // Keep the existing frame on screen until the new one arrives so
+        // the user doesn't see a flash of empty canvas while dragging a
+        // slider; clear `error` because the old failure no longer applies.
+        error: null,
+        fetchEpoch: state.fetchEpoch + 1,
+      };
+    }
+    case "REFETCH_REQUESTED": {
+      // No-op when there's no seed to fetch — guard rail so toolbar can
+      // dispatch unconditionally.
+      if (state.seed === "") {
+        return state;
+      }
+      return {
+        ...state,
+        error: null,
+        fetchEpoch: state.fetchEpoch + 1,
+      };
+    }
+    case "FETCH_REQUESTED": {
+      if (action.epoch !== state.fetchEpoch) {
+        return state;
+      }
+      return { ...state, status: "loading", error: null };
+    }
+    case "FETCH_RECEIVED": {
+      if (action.epoch !== state.fetchEpoch) {
+        return state;
+      }
+      return {
+        ...state,
+        frame: action.frame,
+        status: "ready",
+        error: null,
+      };
+    }
+    case "FETCH_FAILED": {
+      if (action.epoch !== state.fetchEpoch) {
+        return state;
+      }
+      return { ...state, status: "error", error: action.error };
+    }
+    case "RESET":
+      return {
+        ...INITIAL_ILLUMINATE_STATE,
+        fetchEpoch: state.fetchEpoch + 1,
+      };
+    default: {
+      const exhaustive: never = action;
+      return exhaustive;
+    }
+  }
+}
+
+function controlsEqual(a: IlluminateControls, b: IlluminateControls): boolean {
+  return (
+    a.step === b.step &&
+    a.k === b.k &&
+    a.tfidf === b.tfidf &&
+    a.optimization === b.optimization
+  );
+}

--- a/admin/app/lib/client/usecase/illuminate/selectors.test.ts
+++ b/admin/app/lib/client/usecase/illuminate/selectors.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "bun:test";
+import { selectCanPop, selectGraphView, selectIsBusy } from "./selectors";
+import {
+  DEFAULT_ILLUMINATE_CONTROLS,
+  INITIAL_ILLUMINATE_STATE,
+  type IlluminateFrame,
+  type IlluminateState,
+} from "./state";
+
+function stateWith(frame: IlluminateFrame | null): IlluminateState {
+  return {
+    ...INITIAL_ILLUMINATE_STATE,
+    seed: frame?.seed ?? "",
+    history: frame ? [frame.seed] : [],
+    frame,
+    status: frame ? "ready" : "idle",
+  };
+}
+
+describe("selectGraphView", () => {
+  it("returns empty arrays when no frame has been received", () => {
+    const view = selectGraphView(INITIAL_ILLUMINATE_STATE);
+    expect(view.nodes).toEqual([]);
+    expect(view.edges).toEqual([]);
+  });
+
+  it("marks the seed node and renders all returned vertices", () => {
+    const frame: IlluminateFrame = {
+      seed: "a",
+      controls: DEFAULT_ILLUMINATE_CONTROLS,
+      vertices: [{ key: "a" }, { key: "b" }, { key: "c" }],
+      edges: [
+        { tail: "a", head: "b", weight: 1 },
+        { tail: "a", head: "c", weight: 3 },
+      ],
+    };
+    const view = selectGraphView(stateWith(frame));
+    expect(view.nodes.map((n) => n.id).sort()).toEqual(["a", "b", "c"]);
+    const seed = view.nodes.find((n) => n.id === "a");
+    expect(seed?.isSeed).toBe(true);
+    expect(seed?.importance).toBe(1);
+    const c = view.nodes.find((n) => n.id === "c");
+    expect(c?.isSeed).toBe(false);
+    // Importance is normalised against the highest weight sum (here `c`
+    // shares all 3 weight units with the seed; `b` has 1 unit). The seed
+    // is pinned to 1 regardless.
+    expect(c?.importance).toBeGreaterThan(0);
+    expect(c?.importance).toBeLessThanOrEqual(1);
+  });
+
+  it("drops vertices that lack a key", () => {
+    const frame: IlluminateFrame = {
+      seed: "a",
+      controls: DEFAULT_ILLUMINATE_CONTROLS,
+      vertices: [{ key: "a" }, { key: "" }, {} as { key?: string }],
+      edges: [],
+    };
+    const view = selectGraphView(stateWith(frame));
+    expect(view.nodes.map((n) => n.id)).toEqual(["a"]);
+  });
+
+  it("drops edges that reference unknown vertices", () => {
+    const frame: IlluminateFrame = {
+      seed: "a",
+      controls: DEFAULT_ILLUMINATE_CONTROLS,
+      vertices: [{ key: "a" }, { key: "b" }],
+      edges: [
+        { tail: "a", head: "b", weight: 1 },
+        // `c` was not returned in the response; this edge must be dropped.
+        { tail: "a", head: "c", weight: 1 },
+      ],
+    };
+    const view = selectGraphView(stateWith(frame));
+    expect(view.edges.map((e) => e.id)).toEqual(["a→b"]);
+  });
+
+  it("emits stable IDs for edges", () => {
+    const frame: IlluminateFrame = {
+      seed: "a",
+      controls: DEFAULT_ILLUMINATE_CONTROLS,
+      vertices: [{ key: "a" }, { key: "b" }],
+      edges: [{ tail: "a", head: "b", weight: 1 }],
+    };
+    const view = selectGraphView(stateWith(frame));
+    expect(view.edges[0]?.id).toBe("a→b");
+    expect(view.edges[0]?.source).toBe("a");
+    expect(view.edges[0]?.target).toBe("b");
+  });
+});
+
+describe("selectCanPop", () => {
+  it("is false until the user pushes a second seed", () => {
+    expect(selectCanPop(INITIAL_ILLUMINATE_STATE)).toBe(false);
+    const single: IlluminateState = {
+      ...INITIAL_ILLUMINATE_STATE,
+      seed: "a",
+      history: ["a"],
+    };
+    expect(selectCanPop(single)).toBe(false);
+    const stacked: IlluminateState = {
+      ...INITIAL_ILLUMINATE_STATE,
+      seed: "b",
+      history: ["a", "b"],
+    };
+    expect(selectCanPop(stacked)).toBe(true);
+  });
+});
+
+describe("selectIsBusy", () => {
+  it("is true only during a loading state", () => {
+    expect(selectIsBusy(INITIAL_ILLUMINATE_STATE)).toBe(false);
+    expect(
+      selectIsBusy({ ...INITIAL_ILLUMINATE_STATE, status: "loading" }),
+    ).toBe(true);
+    expect(selectIsBusy({ ...INITIAL_ILLUMINATE_STATE, status: "ready" })).toBe(
+      false,
+    );
+  });
+});

--- a/admin/app/lib/client/usecase/illuminate/selectors.ts
+++ b/admin/app/lib/client/usecase/illuminate/selectors.ts
@@ -1,0 +1,101 @@
+import type { Edge, Vertex } from "~/lib/client/infrastructure/api/illuminate";
+import type { IlluminateState } from "./state";
+
+/**
+ * Graph node shape consumed by `IlluminateCanvas`. We keep the full
+ * Vertex around so the tooltip / a11y table can render typed values
+ * without a second pass over the response.
+ */
+export interface GraphNode {
+  id: string;
+  label: string;
+  vertex: Vertex;
+  /** True iff this node is the active seed. */
+  isSeed: boolean;
+  /** Edge-weight-derived score in [0, 1], 1.0 for the seed. */
+  importance: number;
+}
+
+export interface GraphEdge {
+  id: string;
+  source: string;
+  target: string;
+  weight: number;
+  edge: Edge;
+}
+
+export interface GraphView {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+/**
+ * Builds the view model the canvas renders from the most recent fetched
+ * frame. Pure; no React, no DOM, no graphology — those live in the
+ * component layer so this stays trivial to unit-test.
+ */
+export function selectGraphView(state: IlluminateState): GraphView {
+  const frame = state.frame;
+  if (!frame) {
+    return { nodes: [], edges: [] };
+  }
+  const seed = frame.seed;
+  const weightByKey = new Map<string, number>();
+  for (const edge of frame.edges) {
+    if (!edge.tail || !edge.head) continue;
+    weightByKey.set(
+      edge.tail,
+      (weightByKey.get(edge.tail) ?? 0) + (edge.weight ?? 0),
+    );
+    weightByKey.set(
+      edge.head,
+      (weightByKey.get(edge.head) ?? 0) + (edge.weight ?? 0),
+    );
+  }
+  const maxWeight = Math.max(0, ...weightByKey.values());
+  const nodes: GraphNode[] = frame.vertices
+    .filter(
+      (v): v is Vertex & { key: string } =>
+        typeof v.key === "string" && v.key !== "",
+    )
+    .map((v) => {
+      const isSeed = v.key === seed;
+      const raw = weightByKey.get(v.key) ?? 0;
+      const importance = isSeed
+        ? 1
+        : maxWeight > 0
+          ? Math.max(0.1, raw / maxWeight)
+          : 0.5;
+      return {
+        id: v.key,
+        label: v.key,
+        vertex: v,
+        isSeed,
+        importance,
+      };
+    });
+  const knownKeys = new Set(nodes.map((n) => n.id));
+  const edges: GraphEdge[] = [];
+  for (const e of frame.edges) {
+    if (!e.tail || !e.head) continue;
+    // Drop edges that reference vertices the response didn't return; the
+    // canvas would otherwise throw when sigma tries to look them up.
+    if (!knownKeys.has(e.tail) || !knownKeys.has(e.head)) continue;
+    edges.push({
+      id: `${e.tail}→${e.head}`,
+      source: e.tail,
+      target: e.head,
+      weight: e.weight ?? 0,
+      edge: e,
+    });
+  }
+  return { nodes, edges };
+}
+
+export function selectCanPop(state: IlluminateState): boolean {
+  return state.history.length > 1;
+}
+
+export function selectIsBusy(state: IlluminateState): boolean {
+  return state.status === "loading";
+}

--- a/admin/app/lib/client/usecase/illuminate/state.ts
+++ b/admin/app/lib/client/usecase/illuminate/state.ts
@@ -1,0 +1,72 @@
+import type {
+  Edge,
+  Optimization,
+  Vertex,
+} from "~/lib/client/infrastructure/api/illuminate";
+
+/**
+ * Knobs that the user can tweak from the toolbar. Persisted in state so
+ * the reducer can decide when a control change should kick off a re-fetch.
+ */
+export interface IlluminateControls {
+  step: number;
+  k: number;
+  tfidf: boolean;
+  optimization: Optimization;
+}
+
+/**
+ * Defaults that match the server's behaviour when knobs are omitted, and
+ * give a sensible first frame for the user. The radio defaults to
+ * "unspecified" so the server's natural ordering is preserved until the
+ * user explicitly switches to an SPT / MST view.
+ */
+export const DEFAULT_ILLUMINATE_CONTROLS: IlluminateControls = {
+  step: 2,
+  k: 8,
+  tfidf: false,
+  optimization: "OPTIMIZATION_UNSPECIFIED",
+};
+
+export type IlluminateStatus = "idle" | "loading" | "ready" | "error";
+
+/**
+ * Subgraph returned by a single Illuminate call, normalised into the shape
+ * the canvas/table need. We keep the seed alongside the graph so back-nav
+ * through the seed history stack can restore a frame without re-fetching.
+ */
+export interface IlluminateFrame {
+  seed: string;
+  controls: IlluminateControls;
+  vertices: Vertex[];
+  edges: Edge[];
+}
+
+export interface IlluminateState {
+  /** Active seed (already URL-decoded). Empty string ⇒ no seed prompt yet. */
+  seed: string;
+  /** Stack of seeds visited so far. The last entry is always === `seed`. */
+  history: string[];
+  /** Currently-pending knob values. */
+  controls: IlluminateControls;
+  /** Most-recent successful frame for the active seed, or null. */
+  frame: IlluminateFrame | null;
+  status: IlluminateStatus;
+  error: string | null;
+  /**
+   * Bumped on every seed-or-controls change. Async handlers carry the
+   * value they saw at dispatch time and discard their result if it has
+   * moved on (matches the prefixEpoch pattern used by browse-vertices).
+   */
+  fetchEpoch: number;
+}
+
+export const INITIAL_ILLUMINATE_STATE: IlluminateState = {
+  seed: "",
+  history: [],
+  controls: DEFAULT_ILLUMINATE_CONTROLS,
+  frame: null,
+  status: "idle",
+  error: null,
+  fetchEpoch: 0,
+};

--- a/admin/app/lib/client/usecase/illuminate/use-illuminate.ts
+++ b/admin/app/lib/client/usecase/illuminate/use-illuminate.ts
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
+import { fetchIlluminate } from "./handlers";
+import { illuminateReducer, type IlluminateAction } from "./reducer";
+import {
+  selectCanPop,
+  selectGraphView,
+  selectIsBusy,
+  type GraphView,
+} from "./selectors";
+import {
+  INITIAL_ILLUMINATE_STATE,
+  type IlluminateControls,
+  type IlluminateState,
+} from "./state";
+
+export interface UseIlluminateResult {
+  state: IlluminateState;
+  view: GraphView;
+  isBusy: boolean;
+  canPop: boolean;
+  push: (seed: string) => void;
+  pop: () => void;
+  setControls: (next: IlluminateControls) => void;
+  refresh: () => void;
+}
+
+/**
+ * React-facing hook that wires the pure reducer + handlers into the live
+ * Lantern client. Owns its own AbortController so a fresh seed or knob
+ * cancels any in-flight request immediately.
+ *
+ * `urlSeed` is the URL-decoded seed read from the `?seed=` query param.
+ * Pass `""` when the route has no seed yet (the SeedPrompt UI takes over).
+ */
+export function useIlluminate(urlSeed: string): UseIlluminateResult {
+  const client = useLanternClient();
+  const [state, dispatch] = useReducer(
+    illuminateReducer,
+    INITIAL_ILLUMINATE_STATE,
+  );
+
+  // Sync URL seed into reducer. `SEED_CHANGED` is a no-op when the value
+  // already matches, so this is safe to fire on every render.
+  useEffect(() => {
+    dispatch({ type: "SEED_CHANGED", seed: urlSeed });
+  }, [urlSeed]);
+
+  // Refetch whenever the epoch advances (seed or knob change). The
+  // controller cancels any prior request to keep latency tight.
+  const lastEpochRef = useRef<number>(-1);
+  useEffect(() => {
+    if (state.seed === "") {
+      lastEpochRef.current = state.fetchEpoch;
+      return;
+    }
+    if (state.fetchEpoch === lastEpochRef.current) {
+      return;
+    }
+    lastEpochRef.current = state.fetchEpoch;
+    const controller = new AbortController();
+    void fetchIlluminate(
+      {
+        client,
+        seed: state.seed,
+        controls: state.controls,
+        epoch: state.fetchEpoch,
+        signal: controller.signal,
+      },
+      dispatch as (action: IlluminateAction) => void,
+    );
+    return () => controller.abort();
+  }, [client, state.seed, state.controls, state.fetchEpoch]);
+
+  const push = useCallback((seed: string) => {
+    dispatch({ type: "SEED_PUSHED", seed });
+  }, []);
+
+  const pop = useCallback(() => {
+    dispatch({ type: "SEED_POPPED" });
+  }, []);
+
+  const setControls = useCallback((next: IlluminateControls) => {
+    dispatch({ type: "CONTROLS_CHANGED", controls: next });
+  }, []);
+
+  const refresh = useCallback(() => {
+    dispatch({ type: "REFETCH_REQUESTED" });
+  }, []);
+
+  const view = useMemo(() => selectGraphView(state), [state]);
+  const isBusy = selectIsBusy(state);
+  const canPop = selectCanPop(state);
+
+  return useMemo<UseIlluminateResult>(
+    () => ({
+      state,
+      view,
+      isBusy,
+      canPop,
+      push,
+      pop,
+      setControls,
+      refresh,
+    }),
+    [state, view, isBusy, canPop, push, pop, setControls, refresh],
+  );
+}

--- a/admin/app/routes/illuminate.tsx
+++ b/admin/app/routes/illuminate.tsx
@@ -1,16 +1,10 @@
 import type { Route } from "./+types/illuminate";
-import { PlaceholderPage } from "~/components/shared/PlaceholderPage/PlaceholderPage";
+import { IlluminatePage } from "~/components/illuminate/IlluminatePage/IlluminatePage";
 
 export function meta(_: Route.MetaArgs) {
   return [{ title: "Illuminate — Lantern Admin" }];
 }
 
 export default function IlluminateRoute() {
-  return (
-    <PlaceholderPage
-      title="Illuminate"
-      trackingIssue="#F4"
-      description="Sigma.js neighborhood explorer with SPT / MST switching will land here."
-    />
-  );
+  return <IlluminatePage />;
 }

--- a/admin/tests/e2e/illuminate.spec.ts
+++ b/admin/tests/e2e/illuminate.spec.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "@playwright/test";
+
+const GATEWAY_URL =
+  process.env.LANTERN_E2E_GATEWAY_URL ?? "http://127.0.0.1:6381";
+const STORAGE_KEY = "lantern.admin.baseUrl";
+
+/**
+ * Seeds a tiny star graph centred on `e2e:illum:hub` so the Illuminate
+ * screen has at least one neighbour to render. The other tests that share
+ * this gateway also seed under `e2e:vertex:*`; we use a distinct prefix
+ * to keep the assertions tight.
+ */
+test.beforeAll(async () => {
+  const put = await fetch(`${GATEWAY_URL}/v1/vertices`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      vertices: [
+        { key: "e2e:illum:hub", value: { string: "hub" } },
+        { key: "e2e:illum:left", value: { int32: 1 } },
+        { key: "e2e:illum:right", value: { int32: 2 } },
+      ],
+    }),
+  });
+  if (!put.ok) {
+    throw new Error(`seed vertices failed: ${put.status} ${await put.text()}`);
+  }
+  const putEdges = await fetch(`${GATEWAY_URL}/v1/edges/put`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      edges: [
+        { tail: "e2e:illum:hub", head: "e2e:illum:left", weight: 1 },
+        { tail: "e2e:illum:hub", head: "e2e:illum:right", weight: 3 },
+      ],
+    }),
+  });
+  if (!putEdges.ok) {
+    throw new Error(
+      `seed edges failed: ${putEdges.status} ${await putEdges.text()}`,
+    );
+  }
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(
+    ({ key, value }) => {
+      try {
+        window.localStorage.setItem(key, value);
+      } catch {
+        // Storage may be unavailable in some browser modes.
+      }
+    },
+    { key: STORAGE_KEY, value: GATEWAY_URL },
+  );
+});
+
+test.describe("/illuminate", () => {
+  test("shows the seed prompt when no ?seed= is present", async ({ page }) => {
+    await page.goto("/illuminate");
+    await expect(page.getByTestId("illuminate-seed-prompt")).toBeVisible();
+    await expect(page.getByTestId("illuminate-open")).toBeDisabled();
+  });
+
+  test("renders the canvas and neighbour table for a seed", async ({
+    page,
+  }) => {
+    const seed = encodeURIComponent("e2e:illum:hub");
+    await page.goto(`/illuminate?seed=${seed}`);
+
+    await expect(page.getByTestId("illuminate-toolbar")).toBeVisible();
+    await expect(page.getByTestId("illuminate-seed")).toHaveText(
+      "e2e:illum:hub",
+    );
+    await expect(page.getByTestId("illuminate-canvas")).toBeVisible();
+
+    // Pop is disabled until the user pushes a second seed onto the stack.
+    await expect(page.getByTestId("illuminate-pop")).toBeDisabled();
+
+    // Refresh should be enabled once the seed is set.
+    await expect(page.getByTestId("illuminate-refresh")).toBeEnabled();
+
+    // The disclosure summary reflects the live frame counts. Wait for the
+    // fetch to land — the count goes from 0/0 to 3/2 — before clicking
+    // so we don't race the React re-render and end up with a stale node.
+    const summary = page.getByRole("group").getByText(/List view \(3 vertices/);
+    await expect(summary).toBeVisible();
+    await summary.click();
+
+    const table = page.getByTestId("illuminate-table");
+    await expect(table).toBeVisible();
+    await expect(
+      table.getByRole("link", { name: "e2e:illum:hub" }),
+    ).toBeVisible();
+    await expect(
+      table.getByRole("link", { name: "e2e:illum:left" }),
+    ).toBeVisible();
+    await expect(
+      table.getByRole("link", { name: "e2e:illum:right" }),
+    ).toBeVisible();
+  });
+
+  test("Re-seed from the list view pushes a new seed and enables Pop", async ({
+    page,
+  }) => {
+    const seed = encodeURIComponent("e2e:illum:hub");
+    await page.goto(`/illuminate?seed=${seed}`);
+    await expect(page.getByTestId("illuminate-toolbar")).toBeVisible();
+
+    // Wait for the seed's frame to land before opening the disclosure.
+    const summary = page.getByRole("group").getByText(/List view \(3 vertices/);
+    await expect(summary).toBeVisible();
+    await summary.click();
+
+    const table = page.getByTestId("illuminate-table");
+    await table
+      .getByRole("button", { name: "Re-seed from e2e:illum:left" })
+      .click();
+
+    await expect(page.getByTestId("illuminate-seed")).toHaveText(
+      "e2e:illum:left",
+    );
+    await expect(page).toHaveURL(/\?seed=e2e%3Aillum%3Aleft/);
+    await expect(page.getByTestId("illuminate-pop")).toBeEnabled();
+
+    await page.getByTestId("illuminate-pop").click();
+    await expect(page.getByTestId("illuminate-seed")).toHaveText(
+      "e2e:illum:hub",
+    );
+    await expect(page.getByTestId("illuminate-pop")).toBeDisabled();
+  });
+});

--- a/admin/tests/e2e/landing.spec.ts
+++ b/admin/tests/e2e/landing.spec.ts
@@ -19,12 +19,14 @@ test("landing page renders with navigation and gateway connection", async ({
 });
 
 test.describe("placeholder routes", () => {
-  test("Illuminate route renders its placeholder", async ({ page }) => {
+  test("Illuminate route renders the seed prompt when no ?seed= is set", async ({
+    page,
+  }) => {
     await page.goto("/illuminate");
     await expect(
       page.getByRole("heading", { level: 1, name: "Illuminate" }),
     ).toBeVisible();
-    await expect(page.getByText(/Coming in #F4/)).toBeVisible();
+    await expect(page.getByTestId("illuminate-seed-prompt")).toBeVisible();
   });
 
   test("Ops route renders its placeholder", async ({ page }) => {


### PR DESCRIPTION
Implements F4 — the admin Illuminate screen — a Sigma.js neighborhood
graph explorer with SPT / MST optimization toggles and TF-IDF edge
weighting.

## What's in this PR

### Components (`admin/app/components/illuminate/`)

| Component | Role |
|---|---|
| `IlluminatePage` | Top-level orchestrator. Wires URL `?seed=` ↔ reducer, owns the history stack, and arranges toolbar / canvas / list-view disclosure. |
| `IlluminateToolbar` | Seed entry, Refresh / Pop buttons, step / k / optimization (`UNSPECIFIED` / `SPT` / `MST`) / TF-IDF controls. |
| `IlluminateCanvas` | Sigma.js render with `graphology` + `forceatlas2`. Click-to-reseed. |
| `IlluminateTable` | Accessible list-view companion inside a `<details>` disclosure — same data, screen-reader friendly. |
| `SeedPrompt` | Empty-state when no `?seed=` is present. |

### Use case (`admin/app/lib/client/usecase/illuminate/`)

- `state.ts` — `IlluminateState` / `IlluminateAction` / `IlluminateControls`.
- `reducer.ts` — pure transitions: `SEED_CHANGED`, `SEED_PUSHED`, `SEED_POPPED`, `FETCH_REQUESTED` / `FETCH_RECEIVED` / `FETCH_FAILED`, `REFETCH_REQUESTED`, `CONTROLS_CHANGED`, `RESET`. Epoch-based stale-response guard keeps the UI from flickering when a slow response races a newer fetch.
- `handlers.ts` — `fetchIlluminate` async wrapper that dispatches into the reducer.
- `selectors.ts` — `selectGraphView`, `selectIsBusy`, `selectCanPop`.
- `use-illuminate.ts` — React hook that glues the reducer to the SDK client.

### Infrastructure

- `admin/app/lib/client/infrastructure/api/illuminate.ts` — typed wrapper over the generated \`/v1/illuminate/{seed}\` endpoint.

### Routing

- `admin/app/routes/illuminate.tsx` now mounts \`IlluminatePage\` instead of the previous \`PlaceholderPage\`.

## Test coverage

- **103 unit tests** — exhaustive reducer table tests + selector tests.
- **4 Playwright e2e tests** — seed prompt empty state, canvas + neighbour table render, list-view disclosure, and re-seed/pop history flow.

## Quality gate (all green locally)

\`\`\`
bun run typecheck   ✓
bun run lint        ✓  (0 errors, 0 warnings)
bun run format:check ✓
bun run build       ✓
bun test app        ✓  103 pass / 0 fail
bun run test:e2e    ✓  15 pass / 0 fail
\`\`\`

Closes #321