### PR TITLE
docs(AGENTS.md): adopt GitHub Projects for cross-track triage + findings-sharing rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,49 @@ they take a listed action, and run the matching step before pushing / merging.
 This section is the canonical maintenance contract; mirror only the most
 load-bearing items into `/memories/repo/lantern.md` for compacted-state survival.
 
+### GitHub Project triage (`Lantern roadmap`)
+
+Cross-track triage lives in a single Project named `Lantern roadmap`. Issues
+remain the source of truth — the Project is a view layer + lightweight kanban
+on top of them.
+
+**Custom fields (all four are mandatory on every Issue):**
+
+| Field | Allowed values |
+|---|---|
+| `Track` | `Admin` / `HA` / `Connect` / `SDK` / `Maintenance` / `Docs` |
+| `Module` | `pb` / `core` / `server` / `sdks-go` / `sdks-node` / `sdks-python` / `admin` / `mcp` / `tests` / `docs` / `ci` |
+| `Release target` | `next pb` / `next sdks-go` / `next root` / `next mcp` / `next admin-internal` / `unscheduled` |
+| `Priority` | `P0` / `P1` / `P2` |
+
+**Rules:**
+
+- Every new Issue must have all four fields filled **in the same session it is
+  created** (typically via the Project Web UI right after `gh issue create`).
+- The Project is **not** the source of truth. Do not infer scope, dependencies,
+  or release order from the board — those live in the Issue body and in this
+  file. The board is a view.
+- Do not create additional Projects (per-module, per-release, etc.); a single
+  Project keeps the cost of "what is everyone working on" close to zero.
+- `gh` CLI needs the `project` scope (`gh auth refresh -s project`) to mutate
+  the board.
+
+### After closing any Issue with cross-cutting findings
+
+When the work that closed Issue #A surfaced a fact useful to another open Issue
+#B (a wire-shape gotcha, a flake reproducer, a perf number, a build-order
+constraint), drop a short comment on #B in the same PR that closes #A — or
+immediately after merge if the finding only became clear at merge time:
+
+> Finding from #A (closed by #M): \<one-paragraph fact\>. Source:
+> \<code/file/log link\>.
+
+Do not put this in the closing PR description; reviewers reading #B in six
+months will not follow that link. The comment must live on #B itself. If three
+or more Issues benefit, also append a one-line entry to the relevant section of
+this file (`Architecture notes` / `Conventions and gotchas`) so future
+agents see it without having to grep Issue threads.
+
 ### Before every `git push` (local quality gate)
 
 Run from repo root — this matches what the four required CI checks enforce


### PR DESCRIPTION
Closes #333

## What

Adds two new subsections to the **Maintenance checklist** in `AGENTS.md`:

### 1. `### GitHub Project triage (\`Lantern roadmap\`)`

- Locks a **single** project named `Lantern roadmap` (no per-module / per-release boards).
- Defines four mandatory custom fields on every Issue:
  - `Track` (Admin / HA / Connect / SDK / Maintenance / Docs)
  - `Module` (pb / core / server / sdks-go / sdks-node / sdks-python / admin / mcp / tests / docs / ci)
  - `Release target` (next pb / next sdks-go / next root / next mcp / next admin-internal / unscheduled)
  - `Priority` (P0 / P1 / P2)
- Reminds future agents that the board is a **view**, not the source of truth — scope and dependencies live in Issue bodies + AGENTS.md.
- Notes the `gh` scope requirement (`gh auth refresh -s project`).

### 2. `### After closing any Issue with cross-cutting findings`

Codifies the operating rule the user asked for:

> Finding from #A (closed by #M): \<one-paragraph fact\>. Source: \<code/file/log link\>.

- Comment lives on Issue #B (not in PR description) so reviewers reading #B months later see it.
- If \u22653 open Issues benefit, also append one line to the relevant section of `AGENTS.md` so the finding survives any single Issue closing.

## Why

The project now spans Admin, HA, Connect (planned), SDKs, MCP, and ongoing maintenance — five+ concurrent tracks across six modules. Without a triage layer, decisions like "what should the next root release contain" or "which Issue does this admin work block" require manual grep across open Issues. A single Project board with four fields collapses that to one query.

The findings rule formalises what has been happening ad-hoc since the HA epic: every closed issue surfaces a fact that helps the next one, and burying that in the PR description loses it for everyone who comes to the related issue afterwards.

## Scope

Doc-only — no code or workflow changes. Required CI checks (Build & Test, Lint, Proto (buf), govulncheck) all pass trivially.