### PR TITLE
feat(admin): containerize as lantern-admin (GHCR) + admin-publish workflow

### DIFF
--- a/.github/workflows/admin-publish.yml
+++ b/.github/workflows/admin-publish.yml
@@ -1,0 +1,189 @@
+name: Admin Release
+
+on:
+  push:
+    tags: ['admin/v*.*.*']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/lantern-admin
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Re-run the admin gates against the tagged commit. `_verify.yml` is
+  # Go-only, so we inline the bun-flavoured equivalent of `admin.yml`'s
+  # lint / typecheck / codegen-up-to-date / build steps. Playwright is
+  # intentionally omitted because tag-time signal is low (the SPA was
+  # already exercised on the PR that landed the commit) and Chromium
+  # download dominates the runtime.
+  verify:
+    name: Verify (admin)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: admin
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        # Pinned to commit SHA (v2.2.0) for supply-chain hygiene; keep in
+        # lockstep with admin.yml + sdks/node.
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Codegen (OpenAPI types)
+        run: bun run codegen
+
+      - name: Verify codegen is up to date
+        run: |
+          if ! git diff --quiet -- app/lib/client/infrastructure/api/lantern-api.gen.ts; then
+            echo "::error::Generated API types are out of date for the tagged commit. Re-run 'bun run codegen' inside admin/ and commit before re-tagging."
+            git diff -- app/lib/client/infrastructure/api/lantern-api.gen.ts
+            exit 1
+          fi
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Format check
+        run: bun run format:check
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Build
+        run: bun run build
+
+  build:
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.4.1'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute admin version
+        id: admin_version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          # github.ref_name is `admin/vX.Y.Z`; strip the `admin/` prefix so
+          # the image tag is the plain `vX.Y.Z` (and SemVer-pure `X.Y.Z`).
+          version="${TAG#admin/}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        env:
+          # docker/metadata-action's semver pattern engine needs the bare
+          # version, not the `admin/v…` Go-module-style tag form.
+          DOCKER_METADATA_PR_HEAD_SHA: ''
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.admin_version.outputs.version }}
+            type=raw,value=latest,enable=${{ !contains(steps.admin_version.outputs.version, '-') }}
+            type=sha
+          labels: |
+            org.opencontainers.image.title=lantern-admin
+            org.opencontainers.image.description=Lantern admin SPA — browser-only React Router app that talks to the Lantern gateway over HTTP/JSON, served by Caddy on :8080.
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}/tree/main/admin
+            org.opencontainers.image.licenses=Apache-2.0
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: admin/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.admin_version.outputs.version }}
+          cache-from: type=gha,scope=admin
+          cache-to: type=gha,mode=max,scope=admin
+          provenance: true
+          sbom: true
+
+      - name: Sign the published Docker image
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: |
+          echo "$TAGS" | xargs -I {} cosign sign --yes {}@${DIGEST}
+
+  release:
+    name: GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          version="${TAG#admin/}"
+          notes_file=$(mktemp)
+          {
+            echo "## Lantern admin SPA"
+            echo
+            echo "Multi-arch container (\`linux/amd64\`, \`linux/arm64\`), signed with cosign keyless. Caddy 2 Alpine serves the React Router build on :8080 with SPA fallback."
+            echo
+            echo '```sh'
+            echo "docker run --rm -p 8080:8080 ${IMAGE}:${version}"
+            echo '```'
+            echo
+            echo "Then open http://localhost:8080 and point the Gateway picker in the header at your Lantern gateway (defaults to \`http://localhost:6381\`). Make sure \`LANTERN_CORS_ALLOWED_ORIGINS\` on the gateway includes the admin origin — see [server/README.md](https://github.com/${REPO}/blob/${TAG}/server/README.md)."
+          } > "$notes_file"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --notes-file "$notes_file" --verify-tag
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes-file "$notes_file" \
+              --verify-tag
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,12 +317,24 @@ keyless). It does NOT need to follow the `pb → core → sdks/go → root` orde
 the MCP server only imports `pb/` and `sdks/go/`, so a `sdks/go/vX.Y.Z` bump
 is the only upstream pin that requires re-tagging the MCP image.
 
+The `admin/` module is cut **independently** of the root release cadence and
+the SDK cadences (it is not a Go module and not part of `go.work`): tag
+`admin/vX.Y.Z` triggers `.github/workflows/admin-publish.yml`, which re-runs
+the admin gates (lint / typecheck / codegen-up-to-date / build), then builds
+and publishes `ghcr.io/anaregdesign/lantern-admin:X.Y.Z` (multi-arch + cosign
+keyless). It does NOT need to follow the `pb → core → sdks/go → root` order;
+the admin SPA's only cross-module build-time dependency is `pb/openapiv2/`
+(consumed by `bun run codegen`), so a `pb/vX.Y.Z` bump is the one upstream
+pin that requires re-tagging the admin image. The admin container is a pure
+SPA host (Caddy on `:8080`) — it does not reverse-proxy to the gateway, so
+the gateway's `LANTERN_CORS_ALLOWED_ORIGINS` must include the admin origin.
+
 **Release title convention (locked).** Every GitHub Release title MUST equal
 its tag name verbatim — `v0.7.2`, `core/v0.2.0`, `sdks/go/v0.8.0`,
-`sdks/node/v0.1.2`, `sdks/python/v0.1.1`, `mcp/v0.1.0`. No friendly aliases
-(`Node SDK v0.1.2`, `Go SDK v0.6.0`, etc). `docker-publish.yml` and
-`mcp-publish.yml` already enforce this via `gh release create --title
-"$TAG"`. The Python and Node SDK GitHub Releases are currently created
+`sdks/node/v0.1.2`, `sdks/python/v0.1.1`, `mcp/v0.1.0`, `admin/v0.1.0`. No
+friendly aliases (`Node SDK v0.1.2`, `Go SDK v0.6.0`, etc).
+`docker-publish.yml`, `mcp-publish.yml`, and `admin-publish.yml` already
+enforce this via `gh release create --title "$TAG"`. The Python and Node SDK GitHub Releases are currently created
 manually — when creating them, always pass `--title "$(git describe
 --tags)"` (or the literal tag) so the title matches. If you ever automate
 those releases inside `python-sdk.yml` / `node-sdk.yml`, use the same

--- a/admin/.dockerignore
+++ b/admin/.dockerignore
@@ -1,0 +1,20 @@
+# Local toolchain output. The Docker build runs `bun install` and
+# `bun run build` from scratch inside the build stage; copying the host
+# `node_modules/` in would (a) bloat the build context to hundreds of MB,
+# (b) risk an arch mismatch (host arm64 → linux/amd64 image), and
+# (c) defeat the lockfile-pinned reproducibility guarantee.
+node_modules
+
+# Test + tooling artefacts that are never part of the runtime image.
+tests
+playwright-report
+test-results
+.vite
+.react-router
+
+# Build output is regenerated inside the build stage, never copied in.
+build
+
+# Editor / VCS noise.
+.DS_Store
+*.log

--- a/admin/Caddyfile
+++ b/admin/Caddyfile
@@ -1,0 +1,56 @@
+# SPA host config for lantern-admin.
+#
+# Caddy serves the React Router (SPA mode) build from /srv with:
+#   - SPA fallback to /index.html so client-side routes (e.g. /browse,
+#     /illuminate, /ops) work on direct navigation or refresh.
+#   - Aggressive cache headers on hashed asset paths (Vite emits
+#     `/assets/<name>-<hash>.js|css`), no-cache on index.html so a new
+#     deploy is picked up on next page load.
+#   - Listens on :8080 unprivileged (image runs as `caddy` non-root user)
+#     to match the README "Container image" docs.
+#
+# This file is intentionally minimal — no reverse proxy. The admin SPA
+# talks to the Lantern gateway directly from the user's browser. CORS is
+# enforced on the gateway side via LANTERN_CORS_ALLOWED_ORIGINS; see
+# server/README.md.
+
+{
+	# Disable Caddy's admin endpoint inside the container. We never need
+	# to reload config at runtime; image tag swap is the deploy unit.
+	admin off
+	# Suppress the persistent-config write attempt that would fail on a
+	# read-only rootfs.
+	persist_config off
+}
+
+:8080 {
+	encode zstd gzip
+
+	# Health endpoint for container orchestrators. Declared FIRST and as
+	# an exclusive `handle` block so it wins over the SPA `try_files`
+	# fallback below (which would otherwise rewrite /healthz → index.html
+	# because no such file exists on disk). No upstream dependency, so it
+	# stays green even when the Lantern gateway is unreachable.
+	handle /healthz {
+		respond "ok" 200
+	}
+
+	# Everything else is the SPA: cache-headers + try_files + file_server.
+	handle {
+		root * /srv
+
+		# Long-lived immutable cache for hashed assets.
+		@hashed path /assets/* /favicon.ico
+		header @hashed Cache-Control "public, max-age=31536000, immutable"
+
+		# Never cache the SPA shell — index.html is the entry point and
+		# changes every deploy.
+		@html path / /index.html
+		header @html Cache-Control "no-cache, no-store, must-revalidate"
+
+		# SPA fallback: any path that doesn't match a file on disk serves
+		# index.html so React Router can handle the route client-side.
+		try_files {path} /index.html
+		file_server
+	}
+}

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -1,0 +1,57 @@
+# syntax=docker/dockerfile:1.7
+
+# --- build stage ---------------------------------------------------------
+# Multi-stage build for lantern-admin. The build context MUST be the repo
+# root (not admin/) because the codegen step reads pb/openapiv2/.../*.swagger.json
+# from the sibling pb/ module — see admin/scripts/codegen.mjs.
+FROM oven/bun:1.3.14-alpine AS builder
+
+WORKDIR /src
+
+# Copy bun manifest + lockfile first so dependency installs are cached
+# independently of source changes. `--frozen-lockfile` is the lockfile-
+# verifying mode in bun >= 1.3 (no `bun ci` exists).
+COPY admin/package.json admin/bun.lock ./admin/
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+    cd admin && bun install --frozen-lockfile
+
+# pb/openapiv2 holds the swagger source that admin's codegen consumes.
+# We bring it in before the rest so it stays on its own cacheable layer.
+COPY pb/openapiv2 ./pb/openapiv2
+
+# Everything the build actually needs from admin/. .dockerignore keeps
+# node_modules, tests, build artefacts, and editor noise out of the
+# context, so a plain `COPY admin ./admin` is both cheap and correct.
+COPY admin ./admin
+
+# Stamp the build with the release version so the deployed asset bundle
+# can be traced back to a tag. We expose it as a Vite env var; if the
+# SPA ever wants to render the version, it can read import.meta.env.VITE_VERSION.
+ARG VERSION=dev
+ENV VITE_VERSION=${VERSION}
+
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+    cd admin && \
+    bun run codegen && \
+    bun run build
+
+# --- final stage ---------------------------------------------------------
+# Caddy 2 Alpine — small, has zero shell-out attack surface (no package
+# manager calls at runtime), and supports SPA fallback declaratively via
+# `try_files`. The official caddy:*-alpine image already runs as a
+# non-root `caddy` user when bound to port >= 1024, which is why the
+# Caddyfile listens on :8080.
+FROM caddy:2.10-alpine
+
+# Copy in the SPA build and the Caddy config.
+COPY --from=builder /src/admin/build/client /srv
+COPY admin/Caddyfile /etc/caddy/Caddyfile
+
+# The image binds :8080 (see Caddyfile). Containers running orchestrated
+# can map that to whatever external port the platform exposes.
+EXPOSE 8080
+
+# Caddy's default entrypoint loads /etc/caddy/Caddyfile. We pass --adapter
+# caddyfile explicitly so the format is unambiguous even if a future
+# base-image change ever swaps the default.
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/admin/README.md
+++ b/admin/README.md
@@ -64,7 +64,44 @@ points:
 No `lib/server/` is present in v1 because the admin app calls the Lantern
 gateway directly from the browser (CORS is enforced by the gateway).
 
-## Releases & Docker
+## Container image
 
-The container image and GHCR publishing pipeline are tracked under
-[F-R1 (#323)](../README.md) and are not in this package yet.
+Tagged releases of `admin/vX.Y.Z` publish a multi-arch (`linux/amd64`,
+`linux/arm64`) image to
+[`ghcr.io/anaregdesign/lantern-admin`](https://github.com/anaregdesign/lantern/pkgs/container/lantern-admin),
+signed with cosign keyless. The image is Caddy 2 Alpine serving the built
+SPA from `/srv` on port `8080`, with SPA fallback to `index.html`,
+immutable cache headers on hashed `/assets/*`, and a `GET /healthz`
+endpoint that returns `200 ok`.
+
+```sh
+# Pull and run the latest tagged admin.
+docker run --rm -p 8080:8080 ghcr.io/anaregdesign/lantern-admin:latest
+# → http://localhost:8080
+```
+
+The container is a **pure SPA host** — there is no reverse proxy to the
+Lantern gateway. The user's browser talks to the gateway directly, so the
+gateway must have `LANTERN_CORS_ALLOWED_ORIGINS` set to allow the admin
+origin (see [`server/README.md`](../server/README.md)). Switch between
+gateways at runtime via the **Gateway** button in the header.
+
+### Releasing
+
+Tag from `main` with the `admin/vX.Y.Z` prefix and push:
+
+```sh
+git tag admin/v0.1.0
+git push origin admin/v0.1.0
+```
+
+This triggers
+[`.github/workflows/admin-publish.yml`](../.github/workflows/admin-publish.yml),
+which re-runs the admin gates (lint / typecheck / codegen-up-to-date /
+build), builds + pushes the multi-arch image, signs it with cosign, and
+creates a GitHub Release titled exactly `admin/vX.Y.Z` (per the AGENTS.md
+release-title convention).
+
+The admin module's only cross-module dependency at build time is
+`pb/openapiv2/` (consumed by `bun run codegen`), so a `pb/vX.Y.Z` bump is
+the one upstream pin that requires re-tagging the admin image.


### PR DESCRIPTION
Closes #323.

## What

Adds the admin SPA's container build (`admin/Dockerfile` + `admin/Caddyfile` + `admin/.dockerignore`) and the tag-driven release workflow (`.github/workflows/admin-publish.yml`), mirroring the existing `lantern-mcp` pipeline.

After this PR, pushing a tag `admin/vX.Y.Z` from `main` will:

1. Re-run the bun-flavoured admin gates against the tagged commit (lint / format:check / typecheck / codegen-up-to-date / build).
2. Build a multi-arch (`linux/amd64`, `linux/arm64`) image, push to `ghcr.io/anaregdesign/lantern-admin:X.Y.Z` (+ `latest` if non-prerelease + `sha-…`), sign with cosign keyless.
3. Create a GitHub Release titled exactly `admin/vX.Y.Z` per the LOCKED title convention (PR #307).

## Container details

- **Builder:** \`oven/bun:1.3.14-alpine\` with a \`/root/.bun/install/cache\` mount. Runs \`bun install --frozen-lockfile\` against \`admin/\`, then copies the workspace's \`pb/openapiv2\` (the only cross-module build-time dep), then \`bun run codegen && bun run build\`. \`VERSION\` build-arg flows into \`VITE_VERSION\` so the SPA can render it.
- **Build context MUST be repo root** (sibling \`pb/openapiv2\`). The workflow does this; document this in \`admin/Dockerfile\` header comments.
- **Runtime:** \`caddy:2-alpine\` serving \`/srv\` on \`:8080\`. Pure SPA host — **no reverse proxy** to the gateway. The browser talks to the gateway directly; CORS is enforced by the gateway via \`LANTERN_CORS_ALLOWED_ORIGINS\`.
- **Caddyfile:** exclusive \`handle\` blocks so \`/healthz\` (returns \`200 ok\`) wins over the SPA \`try_files\` fallback. Immutable cache on \`/assets/*\`, \`no-cache\` on \`index.html\`. \`zstd gzip\` encoding.
- **Image size:** ~58 MB (Caddy + built SPA).

## Workflow notes

- \`_verify.yml\` (PR #312) is Go-only and cannot be reused, so the bun verify is inlined as the \`verify\` job. It mirrors \`admin.yml\` minus Playwright (chromium download dominates runtime and the SPA was already exercised on the PR that landed the commit).
- \`metadata-action\` emits the bare \`X.Y.Z\` tag plus \`latest\` (non-prerelease only) plus \`sha\`. The \`admin/\` git-tag prefix is stripped because \`docker/metadata-action\`'s semver matcher only accepts \`vX.Y.Z\` style.
- \`build-push-action\` uses cache \`scope=admin\` so it doesn't fight \`docker-publish\`/\`mcp-publish\` for the same GHA cache namespace.

## Smoke test (local single-arch)

\`\`\`
$ docker build -f admin/Dockerfile -t lantern-admin:local-test --build-arg VERSION=local-test .
$ docker run -d -p 8089:8080 lantern-admin:local-test
$ curl -sI http://localhost:8089/         | grep -i cache-control
Cache-Control: no-cache, no-store, must-revalidate
$ curl -sI http://localhost:8089/ops      | grep -i content-type
Content-Type: text/html; charset=utf-8           # SPA fallback ✓
$ curl http://localhost:8089/healthz
ok                                                # status 200 ✓
$ curl -sI http://localhost:8089/assets/<hash>.js | grep -i cache-control
Cache-Control: public, max-age=31536000, immutable
\`\`\`

## Docs

- \`AGENTS.md\` "Cutting a release": appends an \`admin/\` paragraph next to the \`mcp/\` paragraph (independent cadence; only upstream pin is \`pb/openapiv2/\`); release-title-convention example list adds \`admin/v0.1.0\` and \`admin-publish.yml\`.
- \`admin/README.md\`: replaces the "Releases & Docker" placeholder with "Container image" + "Releasing" subsections documenting \`docker run\`, the CORS-on-gateway rule, the tag-and-push procedure, and the \`pb → admin\` re-tag dependency.

## Out of scope (per #323)

- Helm chart for the admin (\`deploy/helm/\`) — follow-up if needed; v1 ships only the image.
- SSO / auth proxy in front of the admin.
- Vulnerability scanning beyond GHCR's Dependabot.

## Manual verification after merge

Optional dry-run per the issue: \`git tag admin/v0.0.0-rc.1 && git push origin admin/v0.0.0-rc.1\`, watch \`admin-publish.yml\`, verify GHCR push + cosign attestation, \`docker run -p 8080:8080 ghcr.io/anaregdesign/lantern-admin:0.0.0-rc.1\`, load \`http://localhost:8080\`.