### PR TITLE
fix(admin/e2e): collapse edge-detail starting-state `.or()` with `.first()`

### DIFF
--- a/admin/tests/e2e/crud.spec.ts
+++ b/admin/tests/e2e/crud.spec.ts
@@ -142,11 +142,15 @@ test.describe("edge detail", () => {
     );
 
     // Either the row is missing (first run) or already exists — both are
-    // acceptable starting states for the test.
+    // acceptable starting states for the test. After the DELETE fixture the
+    // page renders both `edge-detail-missing` (placeholder card) and
+    // `edge-form-add` (the add-weight form) as siblings, so `.or()` must be
+    // collapsed with `.first()` to relax Playwright strict-mode (#344).
     await expect(
       page
         .getByTestId("edge-form-add")
-        .or(page.getByTestId("edge-detail-missing")),
+        .or(page.getByTestId("edge-detail-missing"))
+        .first(),
     ).toBeVisible();
 
     // Add the same contribution twice. The exact accumulator math is


### PR DESCRIPTION
## Summary

Fixes the flaky `tests/e2e/crud.spec.ts:131 → edge detail › AddEdge accumulates weight and PutEdge replaces it` job that has been failing intermittently on `main`. Root cause is a Playwright strict-mode violation: after the DELETE fixture clears the edge, the page renders BOTH `edge-detail-missing` (placeholder card) and `edge-form-add` (the add-weight form) as siblings, so the `.or()` assertion matches two elements and `toBeVisible()` rejects.

```
strict mode violation: getByTestId('edge-form-add').or(getByTestId('edge-detail-missing'))
resolved to 2 elements
```

The intent is "at least one of these two starting states is visible", so collapse with `.first()`.

## Change

One-line test fix in `admin/tests/e2e/crud.spec.ts:150` + 3-line comment explaining why.

## Evidence (failure pre-exists this PR)
- Run on `main` (6b97f2f): https://github.com/anaregdesign/lantern/actions/runs/27052125033
- Run on PR #343 (21fffc1): https://github.com/anaregdesign/lantern/actions/runs/27053323472

## Local gates
- `bun run lint` ✅
- `bun run typecheck` ✅
- `bun run format:check` ✅
- `gofmt -l` ✅ (no Go diff, but mandate requires it)
- `(cd server && go vet ./... && go test ./...)` ✅
- `go test ./...` from root + `core` + `mcp` + `pb` + `sdks/go` ✅

Closes #344