### PR TITLE
feat(server): additive Connect-Go listener on LANTERN_CONNECT_PORT (#337)

### DIFF
--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -29,6 +29,7 @@ type App struct {
 	grpc        *service.LanternServer
 	metrics     provider.MetricsServer
 	gateway     provider.GatewayServer
+	connect     provider.ConnectServer
 	tracing     *provider.Tracing
 	domain      *domainmetrics.DomainMetrics
 	health      *health.Server
@@ -43,6 +44,7 @@ func newApp(
 	grpcServer *service.LanternServer,
 	metricsServer provider.MetricsServer,
 	gatewayServer provider.GatewayServer,
+	connectServer provider.ConnectServer,
 	tracing *provider.Tracing,
 	domain *domainmetrics.DomainMetrics,
 	hs *health.Server,
@@ -73,6 +75,7 @@ func newApp(
 		grpc:        grpcServer,
 		metrics:     metricsServer,
 		gateway:     gatewayServer,
+		connect:     connectServer,
 		tracing:     tracing,
 		domain:      domain,
 		health:      hs,
@@ -192,6 +195,7 @@ func (a *App) Run(ctx context.Context) error {
 	g.Go(func() error { return a.grpc.Run(gctx) })
 	g.Go(func() error { return a.metrics.Run(gctx) })
 	g.Go(func() error { return a.gateway.Run(gctx) })
+	g.Go(func() error { return a.connect.Run(gctx) })
 	g.Go(func() error { a.domain.Run(gctx); return nil })
 	g.Go(func() error { return a.pump.Run(gctx) })
 	g.Go(func() error { return a.antiEntropy.Run(gctx) })
@@ -229,6 +233,7 @@ func main() {
 		slog.Duration("default_ttl", app.cfg.Cache.TTL),
 		slog.String("metrics_addr", app.cfg.Observability.MetricsAddr),
 		slog.String("gateway_addr", app.cfg.Gateway.Addr),
+		slog.Int("connect_port", app.cfg.ConnectListener.Port),
 		slog.Bool("reflection", app.cfg.Observability.EnableReflection),
 	)
 

--- a/server/cmd/wire.go
+++ b/server/cmd/wire.go
@@ -48,6 +48,8 @@ func initializeApp() (*App, error) {
 		provider.NewGatewayConfig,
 		provider.NewCORSConfig,
 		provider.NewGatewayServer,
+		provider.NewConnectListenerConfig,
+		provider.NewConnectServer,
 		provider.NewLifecycleConfig,
 		newLanternService,
 		newLanternReplicationService,

--- a/server/cmd/wire_gen.go
+++ b/server/cmd/wire_gen.go
@@ -56,6 +56,8 @@ func initializeApp() (*App, error) {
 	if err != nil {
 		return nil, err
 	}
+	connectListenerConfig := provider.NewConnectListenerConfig(config)
+	connectServer := provider.NewConnectServer(connectListenerConfig, lanternService, lanternReplicationService, logger)
 	tracing, err := provider.NewTracing(logger)
 	if err != nil {
 		return nil, err
@@ -67,6 +69,6 @@ func initializeApp() (*App, error) {
 	antiEntropy := provider.NewAntiEntropyDriver(peerConfig, replicationConfig, antiEntropyConfig, lanternService, graphCache, pump, antiEntropyMetrics, logger)
 	mainRegisteredHealth := registerHealthAndReflection(observabilityConfig, server, healthServer)
 	cacheGCHooksWired := provider.WireCacheGCHooks(graphCache, domainMetrics, logger)
-	app := newApp(config, logger, lanternService, lanternServer, metricsServer, gatewayServer, tracing, domainMetrics, healthServer, pump, antiEntropy, peerConfig, replicationConfig, mainRegisteredHealth, cacheGCHooksWired)
+	app := newApp(config, logger, lanternService, lanternServer, metricsServer, gatewayServer, connectServer, tracing, domainMetrics, healthServer, pump, antiEntropy, peerConfig, replicationConfig, mainRegisteredHealth, cacheGCHooksWired)
 	return app, nil
 }

--- a/server/go.mod
+++ b/server/go.mod
@@ -3,18 +3,22 @@ module github.com/anaregdesign/lantern/server
 go 1.26
 
 require (
+	connectrpc.com/connect v1.20.0
 	github.com/anaregdesign/lantern/core v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.0.0-00010101000000-000000000000
 	github.com/google/wire v0.7.0
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
+	golang.org/x/net v0.55.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
 	google.golang.org/grpc v1.81.1
@@ -29,11 +33,9 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/subcommands v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
@@ -42,7 +44,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,3 +1,5 @@
+connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=
+connectrpc.com/connect v1.20.0/go.mod h1:A2ygJrukXwWy32vkCAAHNVguZrqZ+jeZ9rGRnGR4dN4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/server/provider/connect.go
+++ b/server/provider/connect.go
@@ -1,0 +1,128 @@
+// Package provider: connect.go boots the additive Connect-Go listener
+// introduced by #337. It mirrors the GatewayServer / MetricsServer pattern
+// (interface + NoopConnectServer + real httpConnectServer) so the App
+// errgroup can always call Run without nil-checks.
+//
+// The endpoint is **disabled by default** (port 0). It exists purely so
+// downstream Connect-Web (#339), sdks/go Connect transport (#338), and
+// sdks/node (#340) can develop against a real Connect+JSON surface during
+// the migration window. The cutover that retires this parallel listener
+// and moves Connect onto the primary :6380 port is owned by #347.
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
+	"github.com/anaregdesign/lantern/server/internal/envconfig"
+	"github.com/anaregdesign/lantern/server/service"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+)
+
+// ConnectListenerConfig governs the additive Connect endpoint.
+//
+//   - LANTERN_CONNECT_PORT                       host port for the Connect
+//     listener (h2c). Default 0 = disabled. Set non-zero to enable.
+//   - LANTERN_CONNECT_READ_HEADER_TIMEOUT_MS     slowloris guard. Default
+//     5000 (5s). Mirrors LANTERN_GATEWAY_READ_HEADER_TIMEOUT_MS.
+type ConnectListenerConfig struct {
+	Port              int
+	ReadHeaderTimeout time.Duration
+}
+
+// NewConnectListenerConfig selects the ConnectListener slice of Config.
+func NewConnectListenerConfig(c *Config) ConnectListenerConfig { return c.ConnectListener }
+
+// loadConnectListenerConfig reads ConnectListenerConfig from the environment.
+// Called once at startup from NewConfig.
+func loadConnectListenerConfig() ConnectListenerConfig {
+	return ConnectListenerConfig{
+		Port: envconfig.Int("LANTERN_CONNECT_PORT", 0),
+		ReadHeaderTimeout: time.Duration(envconfig.Int(
+			"LANTERN_CONNECT_READ_HEADER_TIMEOUT_MS", 5000,
+		)) * time.Millisecond,
+	}
+}
+
+// ConnectServer is the long-running goroutine that exposes the additive
+// Connect-Go RPC surface. NewConnectServer returns a real http.Server when
+// ConnectListenerConfig.Port > 0 and a NoopConnectServer otherwise.
+type ConnectServer interface {
+	Run(ctx context.Context) error
+}
+
+// NoopConnectServer is the disabled-listener implementation. Its Run waits
+// for ctx to be canceled and returns nil, so the App errgroup behaves
+// identically whether or not the additive listener is enabled.
+type NoopConnectServer struct{}
+
+func (NoopConnectServer) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+type httpConnectServer struct {
+	srv    *http.Server
+	logger *slog.Logger
+	addr   string
+}
+
+// NewConnectServer mounts both the LanternService and (when wired) the
+// LanternReplicationService Connect handlers onto an h2c-wrapped
+// http.Server. The mount uses the path returned by
+// NewLanternServiceHandler / NewLanternReplicationServiceHandler (a stable
+// "/graph.v1.LanternService/" prefix), so the resulting URLs are
+// directly addressable by `curl -X POST` for Connect+JSON.
+//
+// rep MAY be nil — in that case the replication handler is not mounted
+// (mirroring the gRPC path where replication can be disabled).
+func NewConnectServer(
+	cfg ConnectListenerConfig,
+	svc *service.LanternService,
+	rep *service.LanternReplicationService,
+	logger *slog.Logger,
+) ConnectServer {
+	if cfg.Port <= 0 {
+		return NoopConnectServer{}
+	}
+	mux := http.NewServeMux()
+	mux.Handle(graphv1connect.NewLanternServiceHandler(
+		service.NewLanternServiceConnectHandler(svc),
+	))
+	if rep != nil {
+		mux.Handle(graphv1connect.NewLanternReplicationServiceHandler(
+			service.NewLanternReplicationServiceConnectHandler(rep),
+		))
+	}
+	addr := fmt.Sprintf(":%d", cfg.Port)
+	return &httpConnectServer{
+		srv: &http.Server{
+			Addr:              addr,
+			Handler:           h2c.NewHandler(mux, &http2.Server{}),
+			ReadHeaderTimeout: cfg.ReadHeaderTimeout,
+		},
+		logger: logger,
+		addr:   addr,
+	}
+}
+
+func (c *httpConnectServer) Run(ctx context.Context) error {
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = c.srv.Shutdown(shutdownCtx)
+	}()
+	c.logger.Info("connect server starting", slog.String("addr", c.addr))
+	if err := c.srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -141,21 +141,22 @@ type ScanConfig struct {
 // it (SRP). main / App may keep *Config because they observe several aspects
 // for startup logging.
 type Config struct {
-	Net           NetConfig
-	TLS           TLSConfig
-	RateLimit     RateLimitConfig
-	Observability ObservabilityConfig
-	Cache         CacheConfig
-	Shutdown      ShutdownConfig
-	Validation    ValidationLimits
-	Scan          ScanConfig
-	MutationLog   MutationLogConfig
-	Replication   ReplicationConfig
-	Peer          PeerConfig
-	AntiEntropy   AntiEntropyConfig
-	Readiness     ReadinessConfig
-	Gateway       GatewayConfig
-	CORS          CORSConfig
+	Net             NetConfig
+	TLS             TLSConfig
+	RateLimit       RateLimitConfig
+	Observability   ObservabilityConfig
+	Cache           CacheConfig
+	Shutdown        ShutdownConfig
+	Validation      ValidationLimits
+	Scan            ScanConfig
+	MutationLog     MutationLogConfig
+	Replication     ReplicationConfig
+	Peer            PeerConfig
+	AntiEntropy     AntiEntropyConfig
+	Readiness       ReadinessConfig
+	Gateway         GatewayConfig
+	CORS            CORSConfig
+	ConnectListener ConnectListenerConfig
 }
 
 func NewConfig() *Config {
@@ -211,13 +212,14 @@ func NewConfig() *Config {
 			DeleteByPrefixDefaultLimit: uint32(envconfig.Int("LANTERN_DELETE_BY_PREFIX_DEFAULT_LIMIT", 10000)),
 			DeleteByPrefixMaxLimit:     uint32(envconfig.Int("LANTERN_DELETE_BY_PREFIX_MAX_LIMIT", 100000)),
 		},
-		MutationLog: loadMutationLogConfig(),
-		Replication: loadReplicationConfig(),
-		Readiness:   loadReadinessConfig(),
-		Peer:        loadPeerConfig(),
-		AntiEntropy: loadAntiEntropyConfig(),
-		Gateway:     loadGatewayConfig(),
-		CORS:        loadCORSConfig(),
+		MutationLog:     loadMutationLogConfig(),
+		Replication:     loadReplicationConfig(),
+		Readiness:       loadReadinessConfig(),
+		Peer:            loadPeerConfig(),
+		AntiEntropy:     loadAntiEntropyConfig(),
+		Gateway:         loadGatewayConfig(),
+		CORS:            loadCORSConfig(),
+		ConnectListener: loadConnectListenerConfig(),
 	}
 }
 

--- a/server/service/connect.go
+++ b/server/service/connect.go
@@ -1,0 +1,195 @@
+// Package service: connect.go adapts the existing *LanternService and
+// *LanternReplicationService structs to the Connect-Go handler interfaces
+// generated under pb/graph/v1/graphv1connect (#336). The adapters forward
+// every Connect call to the unchanged underlying method, so all existing
+// gRPC tests keep covering the business logic by reference.
+//
+// Why an adapter (rather than rewriting the service struct's method set):
+//   - Until #347 cuts the primary :6380 listener over to h2c+Connect, both
+//     the gRPC and Connect surfaces are live concurrently. Keeping the two
+//     handler shapes in separate structs lets each surface evolve without
+//     either becoming an "almost-Connect" or "almost-gRPC" Frankenstein.
+//   - The grpc.ServerStreamingServer[T] interface that the existing
+//     Subscribe/Snapshot methods take has seven methods; only Send and
+//     Context are actually called inside replication.go. We satisfy the
+//     full interface here with a tiny shim (connectServerStream) so the
+//     unchanged Subscribe/Snapshot implementations work over Connect with
+//     zero modification.
+package service
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// NewLanternServiceConnectHandler wraps *LanternService so it satisfies
+// graphv1connect.LanternServiceHandler. The returned value carries no
+// extra state; it is safe to construct on demand at wire time.
+func NewLanternServiceConnectHandler(svc *LanternService) graphv1connect.LanternServiceHandler {
+	return &lanternServiceConnect{svc: svc}
+}
+
+// NewLanternReplicationServiceConnectHandler wraps
+// *LanternReplicationService so it satisfies
+// graphv1connect.LanternReplicationServiceHandler. Nil is permitted (mirrors
+// the gRPC path where replication can be disabled); in that case all three
+// RPCs return Unavailable.
+func NewLanternReplicationServiceConnectHandler(svc *LanternReplicationService) graphv1connect.LanternReplicationServiceHandler {
+	return &lanternReplicationServiceConnect{svc: svc}
+}
+
+type lanternServiceConnect struct {
+	graphv1connect.UnimplementedLanternServiceHandler
+	svc *LanternService
+}
+
+// unary is the one-line forwarding helper every adapter method uses.
+// Generics keep the per-method code to a single line while preserving
+// type safety: the call site supplies the typed underlying method.
+func unary[Req, Resp any](ctx context.Context, req *connect.Request[Req], fn func(context.Context, *Req) (*Resp, error)) (*connect.Response[Resp], error) {
+	out, err := fn(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(out), nil
+}
+
+func (h *lanternServiceConnect) Illuminate(ctx context.Context, req *connect.Request[pb.IlluminateRequest]) (*connect.Response[pb.IlluminateResponse], error) {
+	return unary(ctx, req, h.svc.Illuminate)
+}
+func (h *lanternServiceConnect) GetVertex(ctx context.Context, req *connect.Request[pb.GetVertexRequest]) (*connect.Response[pb.GetVertexResponse], error) {
+	return unary(ctx, req, h.svc.GetVertex)
+}
+func (h *lanternServiceConnect) GetVertices(ctx context.Context, req *connect.Request[pb.GetVerticesRequest]) (*connect.Response[pb.GetVerticesResponse], error) {
+	return unary(ctx, req, h.svc.GetVertices)
+}
+func (h *lanternServiceConnect) PutVertex(ctx context.Context, req *connect.Request[pb.PutVertexRequest]) (*connect.Response[pb.PutVertexResponse], error) {
+	return unary(ctx, req, h.svc.PutVertex)
+}
+func (h *lanternServiceConnect) PutVertices(ctx context.Context, req *connect.Request[pb.PutVerticesRequest]) (*connect.Response[pb.PutVerticesResponse], error) {
+	return unary(ctx, req, h.svc.PutVertices)
+}
+func (h *lanternServiceConnect) DeleteVertex(ctx context.Context, req *connect.Request[pb.DeleteVertexRequest]) (*connect.Response[pb.DeleteVertexResponse], error) {
+	return unary(ctx, req, h.svc.DeleteVertex)
+}
+func (h *lanternServiceConnect) DeleteVertices(ctx context.Context, req *connect.Request[pb.DeleteVerticesRequest]) (*connect.Response[pb.DeleteVerticesResponse], error) {
+	return unary(ctx, req, h.svc.DeleteVertices)
+}
+func (h *lanternServiceConnect) ScanVertices(ctx context.Context, req *connect.Request[pb.ScanVerticesRequest]) (*connect.Response[pb.ScanVerticesResponse], error) {
+	return unary(ctx, req, h.svc.ScanVertices)
+}
+func (h *lanternServiceConnect) CountVerticesByPrefix(ctx context.Context, req *connect.Request[pb.CountVerticesByPrefixRequest]) (*connect.Response[pb.CountVerticesByPrefixResponse], error) {
+	return unary(ctx, req, h.svc.CountVerticesByPrefix)
+}
+func (h *lanternServiceConnect) DeleteVerticesByPrefix(ctx context.Context, req *connect.Request[pb.DeleteVerticesByPrefixRequest]) (*connect.Response[pb.DeleteVerticesByPrefixResponse], error) {
+	return unary(ctx, req, h.svc.DeleteVerticesByPrefix)
+}
+func (h *lanternServiceConnect) GetEdge(ctx context.Context, req *connect.Request[pb.GetEdgeRequest]) (*connect.Response[pb.GetEdgeResponse], error) {
+	return unary(ctx, req, h.svc.GetEdge)
+}
+func (h *lanternServiceConnect) GetEdges(ctx context.Context, req *connect.Request[pb.GetEdgesRequest]) (*connect.Response[pb.GetEdgesResponse], error) {
+	return unary(ctx, req, h.svc.GetEdges)
+}
+func (h *lanternServiceConnect) AddEdge(ctx context.Context, req *connect.Request[pb.AddEdgeRequest]) (*connect.Response[pb.AddEdgeResponse], error) {
+	return unary(ctx, req, h.svc.AddEdge)
+}
+func (h *lanternServiceConnect) AddEdges(ctx context.Context, req *connect.Request[pb.AddEdgesRequest]) (*connect.Response[pb.AddEdgesResponse], error) {
+	return unary(ctx, req, h.svc.AddEdges)
+}
+func (h *lanternServiceConnect) PutEdge(ctx context.Context, req *connect.Request[pb.PutEdgeRequest]) (*connect.Response[pb.PutEdgeResponse], error) {
+	return unary(ctx, req, h.svc.PutEdge)
+}
+func (h *lanternServiceConnect) PutEdges(ctx context.Context, req *connect.Request[pb.PutEdgesRequest]) (*connect.Response[pb.PutEdgesResponse], error) {
+	return unary(ctx, req, h.svc.PutEdges)
+}
+func (h *lanternServiceConnect) DeleteEdge(ctx context.Context, req *connect.Request[pb.DeleteEdgeRequest]) (*connect.Response[pb.DeleteEdgeResponse], error) {
+	return unary(ctx, req, h.svc.DeleteEdge)
+}
+func (h *lanternServiceConnect) DeleteEdges(ctx context.Context, req *connect.Request[pb.DeleteEdgesRequest]) (*connect.Response[pb.DeleteEdgesResponse], error) {
+	return unary(ctx, req, h.svc.DeleteEdges)
+}
+func (h *lanternServiceConnect) ScanEdges(ctx context.Context, req *connect.Request[pb.ScanEdgesRequest]) (*connect.Response[pb.ScanEdgesResponse], error) {
+	return unary(ctx, req, h.svc.ScanEdges)
+}
+func (h *lanternServiceConnect) GetServerStatus(ctx context.Context, req *connect.Request[pb.GetServerStatusRequest]) (*connect.Response[pb.GetServerStatusResponse], error) {
+	return unary(ctx, req, h.svc.GetServerStatus)
+}
+func (h *lanternServiceConnect) GetReplicationStatus(ctx context.Context, req *connect.Request[pb.GetReplicationStatusRequest]) (*connect.Response[pb.GetReplicationStatusResponse], error) {
+	return unary(ctx, req, h.svc.GetReplicationStatus)
+}
+
+type lanternReplicationServiceConnect struct {
+	graphv1connect.UnimplementedLanternReplicationServiceHandler
+	svc *LanternReplicationService
+}
+
+func (h *lanternReplicationServiceConnect) Subscribe(ctx context.Context, req *connect.Request[pb.SubscribeRequest], stream *connect.ServerStream[pb.SubscribeResponse]) error {
+	if h.svc == nil {
+		return connect.NewError(connect.CodeUnavailable, errReplicationDisabled)
+	}
+	return h.svc.Subscribe(req.Msg, newConnectServerStream[pb.SubscribeResponse](ctx, stream))
+}
+
+func (h *lanternReplicationServiceConnect) Snapshot(ctx context.Context, req *connect.Request[pb.SnapshotRequest], stream *connect.ServerStream[pb.SnapshotResponse]) error {
+	if h.svc == nil {
+		return connect.NewError(connect.CodeUnavailable, errReplicationDisabled)
+	}
+	return h.svc.Snapshot(req.Msg, newConnectServerStream[pb.SnapshotResponse](ctx, stream))
+}
+
+func (h *lanternReplicationServiceConnect) PeerStatus(ctx context.Context, req *connect.Request[pb.PeerStatusRequest]) (*connect.Response[pb.PeerStatusResponse], error) {
+	if h.svc == nil {
+		return nil, connect.NewError(connect.CodeUnavailable, errReplicationDisabled)
+	}
+	return unary(ctx, req, h.svc.PeerStatus)
+}
+
+// errReplicationDisabled is the sentinel surfaced when the Connect adapter
+// is wired but the underlying *LanternReplicationService is nil.
+var errReplicationDisabled = &replicationDisabledError{}
+
+type replicationDisabledError struct{}
+
+func (*replicationDisabledError) Error() string {
+	return "replication is not enabled on this server"
+}
+
+// connectServerStream adapts *connect.ServerStream[T] to the
+// grpc.ServerStreamingServer[T] interface that the existing
+// Subscribe/Snapshot methods take. The Subscribe/Snapshot implementations
+// in replication.go only call Send and Context — the remaining
+// grpc.ServerStream methods (SetHeader/SendHeader/SetTrailer/SendMsg/
+// RecvMsg) are no-ops or panic, which is safe because the production
+// callers never invoke them.
+type connectServerStream[T any] struct {
+	ctx    context.Context
+	stream *connect.ServerStream[T]
+}
+
+func newConnectServerStream[T any](ctx context.Context, stream *connect.ServerStream[T]) *connectServerStream[T] {
+	return &connectServerStream[T]{ctx: ctx, stream: stream}
+}
+
+func (s *connectServerStream[T]) Send(m *T) error          { return s.stream.Send(m) }
+func (s *connectServerStream[T]) Context() context.Context { return s.ctx }
+
+// SetHeader / SendHeader / SetTrailer / SendMsg / RecvMsg satisfy the
+// remaining grpc.ServerStream surface. They are unused by the underlying
+// Subscribe/Snapshot implementations.
+func (s *connectServerStream[T]) SetHeader(md metadata.MD) error  { return nil }
+func (s *connectServerStream[T]) SendHeader(md metadata.MD) error { return nil }
+func (s *connectServerStream[T]) SetTrailer(md metadata.MD)       {}
+
+func (s *connectServerStream[T]) SendMsg(any) error {
+	panic("connectServerStream.SendMsg: unsupported on the Connect adapter; production callers use Send")
+}
+
+func (s *connectServerStream[T]) RecvMsg(any) error {
+	panic("connectServerStream.RecvMsg: unsupported on the Connect adapter; server-streaming has no client→server frames")
+}

--- a/server/service/connect_test.go
+++ b/server/service/connect_test.go
@@ -1,0 +1,125 @@
+package service
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
+)
+
+// newConnectTestClient starts an h2c httptest server in front of the
+// supplied adapters and returns a Connect client wired to it. The cleanup
+// closes the listener.
+//
+// Why h2c (rather than TLS): NewConnectServer in production mounts h2c on
+// the additive listener, so the test exercises the exact same handler
+// stack. h2c also lets server-streaming RPCs work over HTTP/2 without
+// the test having to juggle self-signed certificates.
+func newConnectTestClient(
+	t *testing.T,
+	svc *LanternService,
+	rep *LanternReplicationService,
+) graphv1connect.LanternServiceClient {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.Handle(graphv1connect.NewLanternServiceHandler(
+		NewLanternServiceConnectHandler(svc),
+	))
+	if rep != nil {
+		mux.Handle(graphv1connect.NewLanternReplicationServiceHandler(
+			NewLanternReplicationServiceConnectHandler(rep),
+		))
+	}
+	srv := httptest.NewServer(h2c.NewHandler(mux, &http2.Server{}))
+	t.Cleanup(srv.Close)
+
+	httpClient := &http.Client{
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, network, addr)
+			},
+		},
+	}
+	return graphv1connect.NewLanternServiceClient(httpClient, srv.URL)
+}
+
+// TestConnectAdapter_PutAndGetVertexRoundTrip is the smoke test for the
+// entire additive Connect path (#337): a real PutVertex / GetVertex pair
+// travels through the Connect-Go client, over h2c, into the adapter, into
+// the underlying *LanternService, back out, and is verified at the client.
+// If any of the 22 unary adapter forwarders are wired wrong this test
+// fails — the round trip explicitly exercises Put and Get.
+func TestConnectAdapter_PutAndGetVertexRoundTrip(t *testing.T) {
+	svc := NewLanternService(newFakeBackend())
+	client := newConnectTestClient(t, svc, nil)
+	ctx := context.Background()
+
+	const key = "users/42"
+	const value = "hello-connect"
+
+	if _, err := client.PutVertex(ctx, connect.NewRequest(&pb.PutVertexRequest{
+		Vertex: &pb.Vertex{Key: key, Value: &pb.Vertex_String_{String_: value}},
+	})); err != nil {
+		t.Fatalf("PutVertex: %v", err)
+	}
+
+	getResp, err := client.GetVertex(ctx, connect.NewRequest(&pb.GetVertexRequest{Key: key}))
+	if err != nil {
+		t.Fatalf("GetVertex: %v", err)
+	}
+	got := getResp.Msg.GetVertex()
+	if got == nil {
+		t.Fatal("GetVertex: nil vertex")
+	}
+	if got.Key != key {
+		t.Errorf("key = %q, want %q", got.Key, key)
+	}
+	if s := got.GetString_(); s != value {
+		t.Errorf("value = %q, want %q", s, value)
+	}
+}
+
+// TestConnectAdapter_GetServerStatus exercises a second unary path so a
+// copy-paste typo in any one of the 22 wrappers (e.g. GetServerStatus
+// accidentally forwarding to GetReplicationStatus) does not slip past
+// the GetVertex test alone.
+func TestConnectAdapter_GetServerStatus(t *testing.T) {
+	svc := NewLanternService(newFakeBackend())
+	client := newConnectTestClient(t, svc, nil)
+	ctx := context.Background()
+
+	resp, err := client.GetServerStatus(ctx, connect.NewRequest(&pb.GetServerStatusRequest{}))
+	if err != nil {
+		t.Fatalf("GetServerStatus: %v", err)
+	}
+	if resp == nil || resp.Msg == nil {
+		t.Fatal("GetServerStatus: nil response")
+	}
+}
+
+// TestConnectAdapter_ReplicationDisabled verifies the
+// nil-LanternReplicationService guard: the adapter is wired but no
+// replication is available, so every replication RPC must return
+// Unavailable rather than panicking.
+func TestConnectAdapter_ReplicationDisabled(t *testing.T) {
+	h := NewLanternReplicationServiceConnectHandler(nil)
+	_, err := h.PeerStatus(context.Background(), connect.NewRequest(&pb.PeerStatusRequest{}))
+	if err == nil {
+		t.Fatal("PeerStatus on nil replication: want error, got nil")
+	}
+	if got := connect.CodeOf(err); got != connect.CodeUnavailable {
+		t.Errorf("PeerStatus code = %v, want Unavailable", got)
+	}
+}


### PR DESCRIPTION
Closes #337. Part of #335.

## What

Wires the Connect-Go handlers generated in #336 (PR #346) onto an
**additive h2c listener** separate from the primary :6380 gRPC port.
Disabled by default (`LANTERN_CONNECT_PORT=0`); set non-zero to enable.

## Why this is additive, not a cutover

This PR is intentionally narrow. The cutover that moves Connect onto
:6380 (replacing the gRPC server, dropping grpc-go middleware, deleting
grpc-gateway, retiring grpc deps from `server/go.mod`) is owned by
**#347**. That work touches 75+ grpc references across the server
module and is too large to land in one PR with the additive listener.

The additive listener exists so the downstream client migrations
(#338 sdks/go, #339 admin, #340 sdks/node) can develop against a real
Connect+JSON surface during the migration window without touching the
production gRPC port — they can iterate independently and in parallel.

## Implementation

* `server/service/connect.go` — adapter structs forwarding all 22
  `LanternService` unary methods and the 3 `LanternReplicationService`
  methods to the unchanged underlying implementations. The
  Subscribe/Snapshot streaming path uses a tiny `connectServerStream`
  shim implementing `grpc.ServerStreamingServer[T]` over
  `*connect.ServerStream[T]`, so `replication.go` needs **zero** changes.
* `server/provider/connect.go` — `ConnectListenerConfig` +
  `NewConnectServer` following the existing GatewayServer /
  MetricsServer Null Object pattern (`NoopConnectServer` when port<=0).
* `server/cmd/{server,wire,wire_gen}.go` — `App.connect` field +
  errgroup goroutine + wire wiring. `LANTERN_CONNECT_PORT` and
  `LANTERN_CONNECT_READ_HEADER_TIMEOUT_MS` are loaded via the standard
  `provider.NewConfig` → `ConnectListenerConfig` sub-config selector
  pattern.

## Tests

`server/service/connect_test.go` rounds-trip:
1. `PutVertex` + `GetVertex` over h2c through the real Connect-Go
   client — exercises the full handler stack end-to-end.
2. `GetServerStatus` — second unary path so a copy-paste typo in any
   one of the 22 wrappers does not slip past the GetVertex test alone.
3. `PeerStatus` against a nil-replication adapter — verifies the
   `CodeUnavailable` guard rather than panicking.

All four required CI checks expected green (Build & Test / Lint /
Proto (buf) / govulncheck).