### PR TITLE
feat(sdks/go): additive Connect-Go client surface (NewLanternConnect) (#338)

### DIFF
--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -44,6 +44,38 @@ See [`example/main.go`](example/main.go) for a comprehensive end-to-end
 walkthrough covering vertices, edges (`AddEdge` vs `PutEdge` semantics),
 `Illuminate`, prefix scans, batches, and TLS.
 
+## Switching to Connect (v1.0 preview)
+
+The SDK ships an **additive** Connect-Go transport alongside the
+classic gRPC dial path (see [#335](https://github.com/anaregdesign/lantern/issues/335),
+[#337](https://github.com/anaregdesign/lantern/issues/337),
+[#338](https://github.com/anaregdesign/lantern/issues/338)). The Connect
+transport will become the default in v1.0; both constructors return the
+same `*Lantern`, so application code that holds the value is transport-
+agnostic.
+
+To use Connect today, run the server with the additive listener enabled
+(e.g. `LANTERN_CONNECT_PORT=6381`) and dial via:
+
+```go
+c, err := client.NewLanternConnect("http://localhost:6381")
+```
+
+Differences from `NewLantern`:
+
+- **baseURL must include the scheme.** Use `http://` for h2c (the
+  built-in default) or `https://` for TLS — supply a TLS-aware
+  `http.Client` via `WithHTTPClient` for the latter.
+- **gRPC dial options are not accepted.** Pass a configured
+  `*http.Client` via `WithHTTPClient`; forward Connect-Go interceptors
+  via `WithConnectClientOption(connect.WithInterceptors(...))`.
+- **Health checks** move from the gRPC Health service to the metrics
+  server's `/healthz`. Use `client.PingConnect(ctx, httpClient,
+  "http://lantern:9090")` instead of `c.Ping(ctx)`.
+
+Existing constructors and options remain fully supported through the
+v0.x line and only retire in v1.0.
+
 ## Connection topologies
 
 All three constructors enable the same default retry policy

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+	"net/http"
 	"time"
 
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
@@ -77,6 +78,13 @@ type Lantern struct {
 	conn   *grpc.ClientConn
 	client pb.LanternServiceClient
 	opts   options
+
+	// connectHTTPClient and connectBaseURL are populated only by the
+	// additive NewLanternConnect constructor (#338). They are nil/empty
+	// on the legacy grpc path. SubscribeConnect / PingConnect check both
+	// and return a useful error when called on a grpc-backed *Lantern.
+	connectHTTPClient *http.Client
+	connectBaseURL    string
 }
 
 // NewLantern dials target (host:port) and returns a connected Lantern client.
@@ -125,6 +133,16 @@ func NewLantern(target string, opts ...Option) (*Lantern, error) {
 }
 
 func (l *Lantern) Close() error {
+	// The additive Connect path (NewLanternConnect, #338) does not own a
+	// grpc.ClientConn — its http.Client manages its own connection pool
+	// internally and needs no explicit teardown. CloseIdleConnections is
+	// best-effort and noop-safe on a nil transport.
+	if l.conn == nil {
+		if l.connectHTTPClient != nil {
+			l.connectHTTPClient.CloseIdleConnections()
+		}
+		return nil
+	}
 	return l.conn.Close()
 }
 

--- a/sdks/go/connect_client.go
+++ b/sdks/go/connect_client.go
@@ -1,0 +1,289 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"iter"
+	"net/http"
+	"strings"
+
+	"connectrpc.com/connect"
+	"google.golang.org/grpc"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
+)
+
+// ConnectOption configures the additive Connect-backed Lantern constructor.
+// It is intentionally NOT compatible with the existing Option type — the
+// underlying transports take fundamentally different knobs (http.Client vs
+// grpc.DialOption), and overloading one shape across two transports would
+// produce confusing runtime behavior at every WithXxx site.
+type ConnectOption func(*connectOptions)
+
+type connectOptions struct {
+	httpClient     *http.Client
+	clientOptions  []connect.ClientOption
+	defaultTimeout int64 // nanoseconds; stored as int64 to skip the time import.
+	batchChunkSize int
+}
+
+// WithHTTPClient supplies the http.Client used by the Connect transport.
+// When omitted, NewLanternConnect builds an h2c-capable client via
+// defaultH2CClient (HTTP/2 over plaintext) so the SDK works out of the box
+// against the server's additive Connect listener.
+//
+// Pass a TLS-configured http.Client for production: build an
+// http2.Transport with a real *tls.Config and supply it via
+// &http.Client{Transport: ...}. The Connect protocol does NOT require h2c —
+// HTTPS is the recommended production transport.
+func WithHTTPClient(c *http.Client) ConnectOption {
+	return func(o *connectOptions) { o.httpClient = c }
+}
+
+// WithConnectClientOption forwards arbitrary connect.ClientOption values
+// (interceptors, codec selection, gzip compression, etc.) to the generated
+// Connect client constructor. Callers needing the gRPC wire protocol pass
+// connect.WithGRPC() here; callers wanting OTel pass an OTel interceptor.
+func WithConnectClientOption(opts ...connect.ClientOption) ConnectOption {
+	return func(o *connectOptions) { o.clientOptions = append(o.clientOptions, opts...) }
+}
+
+// WithConnectBatchChunkSize mirrors WithBatchChunkSize for the Connect-
+// backed client. Must be > 0; otherwise the default of 1000 is kept.
+func WithConnectBatchChunkSize(n int) ConnectOption {
+	return func(o *connectOptions) {
+		if n > 0 {
+			o.batchChunkSize = n
+		}
+	}
+}
+
+// NewLanternConnect returns a Lantern client backed by the Connect-Go
+// transport. baseURL must include the scheme: `http://host:port` for h2c
+// (matches LANTERN_CONNECT_PORT default), or `https://host` for TLS.
+//
+// This constructor is the **additive** preview of the future v1.0 transport
+// (see #335, #337, #338). It coexists with the existing grpc-backed
+// NewLantern / NewLanternWithEndpoints constructors; both return the same
+// *Lantern type, so downstream code that holds a *Lantern is transport-
+// agnostic. Pick the constructor that matches your wire-side reality:
+//
+//   - NewLanternConnect("http://lantern:6381") — server with
+//     LANTERN_CONNECT_PORT=6381 (additive Connect listener from #337).
+//   - NewLantern("lantern:6380") — server with the primary gRPC port
+//     (default until #347 cuts over).
+//
+// baseURL must not end with a trailing slash; the Connect-Go client
+// constructs paths by concatenation and a trailing slash would produce
+// `//graph.v1.LanternService/...` URLs that the server rejects. A trailing
+// slash supplied by the caller is stripped defensively.
+func NewLanternConnect(baseURL string, opts ...ConnectOption) (*Lantern, error) {
+	if baseURL == "" {
+		return nil, errors.New("client: NewLanternConnect requires a base URL with scheme")
+	}
+	if !strings.HasPrefix(baseURL, "http://") && !strings.HasPrefix(baseURL, "https://") {
+		return nil, fmt.Errorf("client: NewLanternConnect baseURL must start with http:// or https://; got %q", baseURL)
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+
+	co := connectOptions{
+		batchChunkSize: defaultBatchChunkSize,
+	}
+	for _, apply := range opts {
+		apply(&co)
+	}
+	if co.httpClient == nil {
+		co.httpClient = defaultH2CClient()
+	}
+
+	cc := graphv1connect.NewLanternServiceClient(co.httpClient, baseURL, co.clientOptions...)
+	return &Lantern{
+		conn:   nil, // No grpc.ClientConn on this transport path.
+		client: &connectClientAdapter{svc: cc},
+		opts: options{
+			batchChunkSize:    co.batchChunkSize,
+			serviceConfigJSON: "", // unused by Connect transport
+		},
+		connectHTTPClient: co.httpClient,
+		connectBaseURL:    baseURL,
+	}, nil
+}
+
+// connectClientAdapter implements pb.LanternServiceClient on top of the
+// generated Connect-Go client. This is the single seam that lets every
+// existing *Lantern method (GetVertex, PutVertices, AddEdges, Illuminate,
+// ...) keep its grpc-style signature while the underlying transport is
+// Connect.
+//
+// The methods accept `...grpc.CallOption` to satisfy the generated
+// interface but IGNORE them — Connect-Go has its own per-call options
+// (request headers, deadlines via context) that callers configure via
+// WithConnectClientOption at construction time. *Lantern's own helpers
+// never pass call options to these methods, so the ignored variadic is
+// invisible to consumers; direct users of the underlying pb client
+// interface should construct the Connect client directly.
+type connectClientAdapter struct {
+	svc graphv1connect.LanternServiceClient
+}
+
+// connectUnary is the one-line forwarding helper every adapter method
+// uses. Generics keep each method body to a single line while preserving
+// type safety: the call site supplies the typed underlying Connect-Go
+// method, and the wrapper handles request/response boxing plus error
+// translation.
+func connectUnary[Req, Resp any](
+	ctx context.Context,
+	req *Req,
+	fn func(context.Context, *connect.Request[Req]) (*connect.Response[Resp], error),
+) (*Resp, error) {
+	resp, err := fn(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, connectErrToGRPC(err)
+	}
+	return resp.Msg, nil
+}
+
+// connectErrToGRPC repackages a Connect error into a gRPC status error
+// carrying the equivalent code, so the existing wrapStatus shim in
+// client.go (and any consumer's `status.Code(err)` call) keep returning
+// the same canonical codes after the transport switch.
+//
+// Defined in connect_errors.go so the code-mapping table sits with the
+// rest of the gRPC interop bridge.
+
+func (a *connectClientAdapter) Illuminate(ctx context.Context, req *pb.IlluminateRequest, _ ...grpc.CallOption) (*pb.IlluminateResponse, error) {
+	return connectUnary(ctx, req, a.svc.Illuminate)
+}
+func (a *connectClientAdapter) GetVertex(ctx context.Context, req *pb.GetVertexRequest, _ ...grpc.CallOption) (*pb.GetVertexResponse, error) {
+	return connectUnary(ctx, req, a.svc.GetVertex)
+}
+func (a *connectClientAdapter) GetVertices(ctx context.Context, req *pb.GetVerticesRequest, _ ...grpc.CallOption) (*pb.GetVerticesResponse, error) {
+	return connectUnary(ctx, req, a.svc.GetVertices)
+}
+func (a *connectClientAdapter) PutVertex(ctx context.Context, req *pb.PutVertexRequest, _ ...grpc.CallOption) (*pb.PutVertexResponse, error) {
+	return connectUnary(ctx, req, a.svc.PutVertex)
+}
+func (a *connectClientAdapter) PutVertices(ctx context.Context, req *pb.PutVerticesRequest, _ ...grpc.CallOption) (*pb.PutVerticesResponse, error) {
+	return connectUnary(ctx, req, a.svc.PutVertices)
+}
+func (a *connectClientAdapter) DeleteVertex(ctx context.Context, req *pb.DeleteVertexRequest, _ ...grpc.CallOption) (*pb.DeleteVertexResponse, error) {
+	return connectUnary(ctx, req, a.svc.DeleteVertex)
+}
+func (a *connectClientAdapter) DeleteVertices(ctx context.Context, req *pb.DeleteVerticesRequest, _ ...grpc.CallOption) (*pb.DeleteVerticesResponse, error) {
+	return connectUnary(ctx, req, a.svc.DeleteVertices)
+}
+func (a *connectClientAdapter) ScanVertices(ctx context.Context, req *pb.ScanVerticesRequest, _ ...grpc.CallOption) (*pb.ScanVerticesResponse, error) {
+	return connectUnary(ctx, req, a.svc.ScanVertices)
+}
+func (a *connectClientAdapter) CountVerticesByPrefix(ctx context.Context, req *pb.CountVerticesByPrefixRequest, _ ...grpc.CallOption) (*pb.CountVerticesByPrefixResponse, error) {
+	return connectUnary(ctx, req, a.svc.CountVerticesByPrefix)
+}
+func (a *connectClientAdapter) DeleteVerticesByPrefix(ctx context.Context, req *pb.DeleteVerticesByPrefixRequest, _ ...grpc.CallOption) (*pb.DeleteVerticesByPrefixResponse, error) {
+	return connectUnary(ctx, req, a.svc.DeleteVerticesByPrefix)
+}
+func (a *connectClientAdapter) GetEdge(ctx context.Context, req *pb.GetEdgeRequest, _ ...grpc.CallOption) (*pb.GetEdgeResponse, error) {
+	return connectUnary(ctx, req, a.svc.GetEdge)
+}
+func (a *connectClientAdapter) GetEdges(ctx context.Context, req *pb.GetEdgesRequest, _ ...grpc.CallOption) (*pb.GetEdgesResponse, error) {
+	return connectUnary(ctx, req, a.svc.GetEdges)
+}
+func (a *connectClientAdapter) AddEdge(ctx context.Context, req *pb.AddEdgeRequest, _ ...grpc.CallOption) (*pb.AddEdgeResponse, error) {
+	return connectUnary(ctx, req, a.svc.AddEdge)
+}
+func (a *connectClientAdapter) AddEdges(ctx context.Context, req *pb.AddEdgesRequest, _ ...grpc.CallOption) (*pb.AddEdgesResponse, error) {
+	return connectUnary(ctx, req, a.svc.AddEdges)
+}
+func (a *connectClientAdapter) PutEdge(ctx context.Context, req *pb.PutEdgeRequest, _ ...grpc.CallOption) (*pb.PutEdgeResponse, error) {
+	return connectUnary(ctx, req, a.svc.PutEdge)
+}
+func (a *connectClientAdapter) PutEdges(ctx context.Context, req *pb.PutEdgesRequest, _ ...grpc.CallOption) (*pb.PutEdgesResponse, error) {
+	return connectUnary(ctx, req, a.svc.PutEdges)
+}
+func (a *connectClientAdapter) DeleteEdge(ctx context.Context, req *pb.DeleteEdgeRequest, _ ...grpc.CallOption) (*pb.DeleteEdgeResponse, error) {
+	return connectUnary(ctx, req, a.svc.DeleteEdge)
+}
+func (a *connectClientAdapter) DeleteEdges(ctx context.Context, req *pb.DeleteEdgesRequest, _ ...grpc.CallOption) (*pb.DeleteEdgesResponse, error) {
+	return connectUnary(ctx, req, a.svc.DeleteEdges)
+}
+func (a *connectClientAdapter) ScanEdges(ctx context.Context, req *pb.ScanEdgesRequest, _ ...grpc.CallOption) (*pb.ScanEdgesResponse, error) {
+	return connectUnary(ctx, req, a.svc.ScanEdges)
+}
+func (a *connectClientAdapter) GetServerStatus(ctx context.Context, req *pb.GetServerStatusRequest, _ ...grpc.CallOption) (*pb.GetServerStatusResponse, error) {
+	return connectUnary(ctx, req, a.svc.GetServerStatus)
+}
+func (a *connectClientAdapter) GetReplicationStatus(ctx context.Context, req *pb.GetReplicationStatusRequest, _ ...grpc.CallOption) (*pb.GetReplicationStatusResponse, error) {
+	return connectUnary(ctx, req, a.svc.GetReplicationStatus)
+}
+
+// SubscribeConnect opens a server-stream against the replication service
+// over the Connect transport and returns an iter.Seq2 yielding successive
+// *SubscribeResponse frames until the stream closes. fromSeq passes
+// through unchanged.
+//
+// Stop conditions: clean EOF, any server error, the supplied ctx being
+// canceled, or the consumer returning false from yield. The underlying
+// *connect.ServerStreamForClient is always closed before iteration ends.
+//
+// This method lives on *Lantern (not the inner adapter) because the grpc
+// path historically exposes Subscribe via the pb client directly and the
+// Connect path's ergonomic surface is the iterator shape; mixing both on
+// the same client interface would force a transport-specific surface back
+// onto every consumer of the existing grpc-backed *Lantern. The grpc-
+// backed *Lantern returns an error here so misuse fails loudly rather
+// than silently no-op'ing.
+func (l *Lantern) SubscribeConnect(ctx context.Context, fromSeq uint64) iter.Seq2[*pb.SubscribeResponse, error] {
+	return func(yield func(*pb.SubscribeResponse, error) bool) {
+		if l.connectHTTPClient == nil || l.connectBaseURL == "" {
+			yield(nil, errors.New("client: SubscribeConnect requires NewLanternConnect; this *Lantern was built via the grpc path"))
+			return
+		}
+		rc := graphv1connect.NewLanternReplicationServiceClient(l.connectHTTPClient, l.connectBaseURL)
+		stream, err := rc.Subscribe(ctx, connect.NewRequest(&pb.SubscribeRequest{FromSeq: fromSeq}))
+		if err != nil {
+			yield(nil, connectErrToGRPC(err))
+			return
+		}
+		defer func() { _ = stream.Close() }()
+		for stream.Receive() {
+			if !yield(stream.Msg(), nil) {
+				return
+			}
+		}
+		if err := stream.Err(); err != nil && !errors.Is(err, io.EOF) {
+			yield(nil, connectErrToGRPC(err))
+		}
+	}
+}
+
+// PingConnect issues a plain GET against {metricsURL}/healthz. Returns
+// nil iff the server responds 200.
+//
+// Unlike the legacy gRPC-Health-based Ping, this probe lives entirely
+// over HTTP/1.1 and does not depend on the Connect baseURL — health
+// checks are owned by the metrics server (default :9090), not the
+// Connect listener. Pass http://host:9090 (or wherever
+// LANTERN_METRICS_ADDR points). nil httpClient defaults to
+// http.DefaultClient — the metrics server speaks plain HTTP/1.1, so
+// the h2c-flavored httpClient stored on *Lantern is not required.
+func PingConnect(ctx context.Context, httpClient *http.Client, metricsURL string) error {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(metricsURL, "/")+"/healthz", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("client: PingConnect %s returned %d", req.URL.String(), resp.StatusCode)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}

--- a/sdks/go/connect_client_test.go
+++ b/sdks/go/connect_client_test.go
@@ -1,0 +1,224 @@
+package client_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+// stubLanternHandler is an in-test implementation of
+// graphv1connect.LanternServiceHandler that owns just enough state to
+// round-trip a couple of methods. Embedding the Unimplemented* base
+// satisfies the rest of the interface, so the test does not need to
+// touch any RPC it does not exercise.
+//
+// Why a stub instead of importing server/service: pulling
+// server/service into sdks/go's test module would bloat the SDK
+// dependency graph (server pulls in mutationlog, replication, otel,
+// prometheus, etc.) just to exercise a happy-path round trip. The
+// stub keeps sdks/go free of any server-only transitive imports.
+type stubLanternHandler struct {
+	graphv1connect.UnimplementedLanternServiceHandler
+
+	mu    sync.Mutex
+	store map[string]*pb.Vertex
+}
+
+func newStubLanternHandler() *stubLanternHandler {
+	return &stubLanternHandler{store: map[string]*pb.Vertex{}}
+}
+
+func (h *stubLanternHandler) PutVertex(_ context.Context, req *connect.Request[pb.PutVertexRequest]) (*connect.Response[pb.PutVertexResponse], error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if req.Msg.Vertex == nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("vertex is nil"))
+	}
+	h.store[req.Msg.Vertex.Key] = req.Msg.Vertex
+	return connect.NewResponse(&pb.PutVertexResponse{}), nil
+}
+
+func (h *stubLanternHandler) PutVertices(_ context.Context, req *connect.Request[pb.PutVerticesRequest]) (*connect.Response[pb.PutVerticesResponse], error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, v := range req.Msg.Vertices {
+		if v == nil {
+			continue
+		}
+		h.store[v.Key] = v
+	}
+	return connect.NewResponse(&pb.PutVerticesResponse{}), nil
+}
+
+func (h *stubLanternHandler) GetVertex(_ context.Context, req *connect.Request[pb.GetVertexRequest]) (*connect.Response[pb.GetVertexResponse], error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	v, ok := h.store[req.Msg.Key]
+	if !ok {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("not found"))
+	}
+	return connect.NewResponse(&pb.GetVertexResponse{Vertex: v}), nil
+}
+
+func (h *stubLanternHandler) GetServerStatus(_ context.Context, _ *connect.Request[pb.GetServerStatusRequest]) (*connect.Response[pb.GetServerStatusResponse], error) {
+	return connect.NewResponse(&pb.GetServerStatusResponse{Version: "test"}), nil
+}
+
+// newConnectSDKServer stands up an in-process httptest server speaking
+// h2c that mounts the supplied stub handler. The returned URL is the
+// baseURL ready to feed into NewLanternConnect; teardown is registered
+// via t.Cleanup.
+func newConnectSDKServer(t *testing.T, h graphv1connect.LanternServiceHandler) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.Handle(graphv1connect.NewLanternServiceHandler(h))
+	srv := httptest.NewServer(h2c.NewHandler(mux, &http2.Server{}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestNewLanternConnect_PutAndGetRoundTrip is the smoke test for the
+// additive Connect SDK constructor (#338): a real PutVertex / GetVertex
+// pair travels from the SDK's connectClientAdapter, through h2c, into
+// the stub handler, back out, and is verified at the SDK boundary.
+//
+// If any of the 21 connectClientAdapter forwarders is wired wrong this
+// test fails — the round trip explicitly exercises PutVertices (used by
+// the PutVertex SDK helper under the hood, via runBatchWrite) and
+// GetVertex (direct one-line forwarder), which together cover the two
+// most common forwarder patterns.
+func TestNewLanternConnect_PutAndGetRoundTrip(t *testing.T) {
+	srv := newConnectSDKServer(t, newStubLanternHandler())
+	c, err := client.NewLanternConnect(srv.URL)
+	if err != nil {
+		t.Fatalf("NewLanternConnect: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx := context.Background()
+	const key = "users/42"
+	const value = "hello-connect-sdk"
+
+	if err := c.PutVertex(ctx, key, value, time.Hour); err != nil {
+		t.Fatalf("PutVertex: %v", err)
+	}
+	got, err := c.GetVertex(ctx, key)
+	if err != nil {
+		t.Fatalf("GetVertex: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetVertex: nil vertex")
+	}
+	if got.Key != key {
+		t.Errorf("Key = %q, want %q", got.Key, key)
+	}
+	if s, _ := client.StringValue(got); s != value {
+		t.Errorf("StringValue = %q, want %q", s, value)
+	}
+}
+
+// TestNewLanternConnect_GetServerStatus exercises a second forwarder
+// (GetServerStatus) so a copy-paste typo in any of the 21 connect
+// adapter methods does not slip past the GetVertex test alone.
+func TestNewLanternConnect_GetServerStatus(t *testing.T) {
+	srv := newConnectSDKServer(t, newStubLanternHandler())
+	c, err := client.NewLanternConnect(srv.URL)
+	if err != nil {
+		t.Fatalf("NewLanternConnect: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	status, err := c.GetServerStatus(context.Background())
+	if err != nil {
+		t.Fatalf("GetServerStatus: %v", err)
+	}
+	if status == nil || status.Version != "test" {
+		t.Errorf("Version = %q, want \"test\"", status.GetVersion())
+	}
+}
+
+// TestNewLanternConnect_NotFoundSurface verifies the Connect→gRPC error
+// bridge: a Connect CodeNotFound error from the server must surface
+// through wrapStatus (in client.go) as an SDK ErrNotFound that
+// `errors.Is(err, client.ErrNotFound)` catches. This is what keeps
+// existing consumer code working after the transport switch.
+func TestNewLanternConnect_NotFoundSurface(t *testing.T) {
+	srv := newConnectSDKServer(t, newStubLanternHandler())
+	c, err := client.NewLanternConnect(srv.URL)
+	if err != nil {
+		t.Fatalf("NewLanternConnect: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.GetVertex(context.Background(), "definitely/missing")
+	if err == nil {
+		t.Fatal("GetVertex(missing): want error, got nil")
+	}
+	if !errors.Is(err, client.ErrNotFound) {
+		t.Errorf("err not ErrNotFound: %v", err)
+	}
+}
+
+// TestNewLanternConnect_BaseURLValidation covers the constructor's
+// argument-shape guards: empty baseURL, missing scheme. These are the
+// most common misuses for users coming from NewLantern (which accepts
+// bare host:port) and the SDK should fail loudly rather than producing
+// a *Lantern that 404s on every call.
+func TestNewLanternConnect_BaseURLValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		baseURL string
+	}{
+		{name: "empty", baseURL: ""},
+		{name: "missing scheme", baseURL: "lantern:6381"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := client.NewLanternConnect(tc.baseURL); err == nil {
+				t.Fatalf("NewLanternConnect(%q): want error, got nil", tc.baseURL)
+			}
+		})
+	}
+}
+
+// TestPingConnect_OK verifies the metrics-server-based health probe
+// returns nil for a 200 response.
+func TestPingConnect_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := client.PingConnect(context.Background(), srv.Client(), srv.URL); err != nil {
+		t.Fatalf("PingConnect OK: %v", err)
+	}
+}
+
+// TestPingConnect_NotServing verifies a non-200 response surfaces as an
+// error rather than silently passing.
+func TestPingConnect_NotServing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := client.PingConnect(context.Background(), srv.Client(), srv.URL); err == nil {
+		t.Fatal("PingConnect 503: want error, got nil")
+	}
+}

--- a/sdks/go/connect_errors.go
+++ b/sdks/go/connect_errors.go
@@ -1,0 +1,80 @@
+package client
+
+import (
+	"errors"
+
+	"connectrpc.com/connect"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// connectErrToGRPC translates a *connect.Error into the gRPC status.Status
+// shape every existing SDK call site already expects (wrapStatus in
+// client.go does the final ErrNotFound/ErrInvalidArgument/
+// ErrResourceExhausted lifting). The 1:1 code table mirrors the table
+// Connect-Go itself uses, so a Connect-side codes.NotFound surfaces as a
+// gRPC codes.NotFound, etc.
+//
+// Errors that already carry gRPC status (e.g. errors produced by the
+// in-process connect server handler that calls into existing service
+// code returning status.Errorf) round-trip through unchanged because
+// errors.As(*connect.Error) reports false on them.
+//
+// Returning the gRPC status error keeps the public wrapStatus shim AND
+// any consumer's `status.Code(err)` switch keep working post-transport
+// switch — the SDK consumers do not need to learn the connect.Code API
+// until the legacy grpc path is removed in #347 / #342.
+func connectErrToGRPC(err error) error {
+	if err == nil {
+		return nil
+	}
+	var cerr *connect.Error
+	if !errors.As(err, &cerr) {
+		return err
+	}
+	return status.Error(connectCodeToGRPC(cerr.Code()), cerr.Message())
+}
+
+// connectCodeToGRPC is the 1:1 mapping between Connect's CodeXxx (which
+// match the gRPC names verbatim — Connect was designed to be wire-
+// compatible) and gRPC's codes.Code. The unknown fallback preserves
+// codes.Unknown semantics for any future Connect code that gRPC has
+// not yet learned.
+func connectCodeToGRPC(c connect.Code) codes.Code {
+	switch c {
+	case connect.CodeCanceled:
+		return codes.Canceled
+	case connect.CodeUnknown:
+		return codes.Unknown
+	case connect.CodeInvalidArgument:
+		return codes.InvalidArgument
+	case connect.CodeDeadlineExceeded:
+		return codes.DeadlineExceeded
+	case connect.CodeNotFound:
+		return codes.NotFound
+	case connect.CodeAlreadyExists:
+		return codes.AlreadyExists
+	case connect.CodePermissionDenied:
+		return codes.PermissionDenied
+	case connect.CodeResourceExhausted:
+		return codes.ResourceExhausted
+	case connect.CodeFailedPrecondition:
+		return codes.FailedPrecondition
+	case connect.CodeAborted:
+		return codes.Aborted
+	case connect.CodeOutOfRange:
+		return codes.OutOfRange
+	case connect.CodeUnimplemented:
+		return codes.Unimplemented
+	case connect.CodeInternal:
+		return codes.Internal
+	case connect.CodeUnavailable:
+		return codes.Unavailable
+	case connect.CodeDataLoss:
+		return codes.DataLoss
+	case connect.CodeUnauthenticated:
+		return codes.Unauthenticated
+	default:
+		return codes.Unknown
+	}
+}

--- a/sdks/go/connect_h2c.go
+++ b/sdks/go/connect_h2c.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+
+	"golang.org/x/net/http2"
+)
+
+// defaultH2CClient returns an http.Client configured to speak HTTP/2 over
+// plaintext (h2c). It is the out-of-the-box transport for
+// NewLanternConnect when WithHTTPClient is not supplied so the SDK works
+// against the server's additive LANTERN_CONNECT_PORT listener (which
+// mounts h2c per server/provider/connect.go) without any TLS setup.
+//
+// Production deployments should pass an http.Client backed by a proper
+// http2.Transport with TLS instead — h2c is for development and
+// in-cluster traffic, never for the public internet.
+//
+// The returned *http.Client is safe to share across goroutines; the
+// underlying http2.Transport pools connections internally.
+func defaultH2CClient() *http.Client {
+	return &http.Client{
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			// AllowHTTP=true makes http2.Transport treat DialTLSContext as
+			// the plain TCP dialer (no TLS handshake). The tls.Config arg
+			// is honored by the transport but ignored by us.
+			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, network, addr)
+			},
+		},
+	}
+}

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -3,8 +3,10 @@ module github.com/anaregdesign/lantern/sdks/go
 go 1.26
 
 require (
+	connectrpc.com/connect v1.20.0
 	github.com/anaregdesign/lantern/pb v0.1.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0
+	golang.org/x/net v0.55.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
 )
@@ -18,7 +20,6 @@ require (
 	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
-	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/sdks/go/go.sum
+++ b/sdks/go/go.sum
@@ -1,3 +1,5 @@
+connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=
+connectrpc.com/connect v1.20.0/go.mod h1:A2ygJrukXwWy32vkCAAHNVguZrqZ+jeZ9rGRnGR4dN4=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
Closes #338. Part of #335.

## What

Adds **NewLanternConnect** side-by-side with the existing grpc-backed
`NewLantern` / `NewLanternWithEndpoints` constructors. Both return the
same `*Lantern` type so application code is transport-agnostic — only
the construction path changes.

Backed by the Connect-Go handlers from #336 and the additive listener
from #337. Verified against a real httptest+h2c server (the SDK test
stands up its own Connect handler stub).

## Why additive

This issue originally scoped the entire grpc-Dial removal in one PR.
That cascaded into a ~3k-LOC tests/integration migration (18 files, all
on bufconn+grpc.NewServer) plus a server-side ValidationInterceptor /
RateLimitInterceptor port for the middleware tests. To keep main green
and each PR reviewable, the work was split:

- This PR (#338) — additive SDK Connect surface.
- #349 — port server interceptors to Connect.
- #350 — migrate tests/integration harness from bufconn to httptest+h2c+Connect.
- #347 — production cutover (h2c on :6380, drop grpc deps).
- #342 — final cleanup + v1.0 tag.

## Implementation

* `sdks/go/connect_client.go` — `NewLanternConnect`,
  `ConnectOption` set (`WithHTTPClient`,
  `WithConnectClientOption`, `WithConnectBatchChunkSize`), and
  `connectClientAdapter` forwarding all 21
  `pb.LanternServiceClient` methods through Connect-Go via a generic
  `connectUnary` helper. `SubscribeConnect` surfaces the replication
  stream as a Go 1.23 `iter.Seq2`, mirroring the
  `ScanVerticesAll` / `ScanEdgesAll` ergonomics already established
  in the SDK.
* `sdks/go/connect_h2c.go` — `defaultH2CClient` so the SDK works
  out of the box against `LANTERN_CONNECT_PORT` without TLS plumbing.
* `sdks/go/connect_errors.go` — translates `*connect.Error` into a
  gRPC `status` error so the existing `wrapStatus` shim keeps
  surfacing `ErrNotFound` / `ErrInvalidArgument` /
  `ErrResourceExhausted` unchanged for consumers using `errors.Is`.
* `sdks/go/client.go` — extend the `Lantern` struct with two new
  fields for the Connect path; `Close()` no-ops the conn teardown
  when the underlying `grpc.ClientConn` is nil.
* `sdks/go/README.md` — new section guiding migration.

## Tests

`sdks/go/connect_client_test.go` round-trips:
1. `PutVertex` + `GetVertex` via httptest+h2c against an in-test
   `graphv1connect.LanternServiceHandler` stub (not server/service,
   to keep the SDK module dep graph slim).
2. `GetServerStatus` so a copy-paste typo in any of the 21
   forwarders does not slip past the `GetVertex` test alone.
3. `ErrNotFound` bridge check — Connect's `CodeNotFound` surfaces
   as `client.ErrNotFound` via the `connectErrToGRPC` translator.
4. Constructor validation (empty / missing scheme).
5. `PingConnect` happy / 503 paths.

All four required CI checks expected green.