### PR TITLE
feat(server): port ValidationInterceptor + RateLimitInterceptor to Connect-Go (#349)

### DIFF
--- a/server/cmd/wire.go
+++ b/server/cmd/wire.go
@@ -41,6 +41,8 @@ func initializeApp() (*App, error) {
 		provider.NewListener,
 		provider.NewPrometheusRegistry,
 		provider.NewGrpcServerMetrics,
+		provider.NewValidationInterceptorProvider,
+		provider.NewRateLimitInterceptorProvider,
 		provider.NewGrpcServerOptions,
 		provider.NewGrpcServer,
 		provider.NewHealthServer,

--- a/server/cmd/wire_gen.go
+++ b/server/cmd/wire_gen.go
@@ -31,9 +31,11 @@ func initializeApp() (*App, error) {
 	lanternService := newLanternService(graphCache, scanConfig, replicationConfig, validationLimits, tlsConfig, cacheConfig, observabilityConfig, logger, log, clock, domainMetrics)
 	lanternReplicationService := newLanternReplicationService(log, graphCache, clock, logger, domainMetrics, lanternService)
 	netConfig := provider.NewNetConfig(config)
-	rateLimitConfig := provider.NewRateLimitConfig(config)
 	serverMetrics := provider.NewGrpcServerMetrics(registry)
-	v, err := provider.NewGrpcServerOptions(netConfig, tlsConfig, rateLimitConfig, validationLimits, observabilityConfig, logger, serverMetrics, domainMetrics)
+	validationInterceptor := provider.NewValidationInterceptorProvider(validationLimits, domainMetrics, logger)
+	rateLimitConfig := provider.NewRateLimitConfig(config)
+	rateLimitInterceptor := provider.NewRateLimitInterceptorProvider(rateLimitConfig, domainMetrics)
+	v, err := provider.NewGrpcServerOptions(netConfig, tlsConfig, observabilityConfig, logger, serverMetrics, validationInterceptor, rateLimitInterceptor)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +59,7 @@ func initializeApp() (*App, error) {
 		return nil, err
 	}
 	connectListenerConfig := provider.NewConnectListenerConfig(config)
-	connectServer := provider.NewConnectServer(connectListenerConfig, lanternService, lanternReplicationService, logger)
+	connectServer := provider.NewConnectServer(connectListenerConfig, lanternService, lanternReplicationService, validationInterceptor, rateLimitInterceptor, logger)
 	tracing, err := provider.NewTracing(logger)
 	if err != nil {
 		return nil, err

--- a/server/provider/connect.go
+++ b/server/provider/connect.go
@@ -18,6 +18,8 @@ import (
 	"net/http"
 	"time"
 
+	"connectrpc.com/connect"
+
 	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
 	"github.com/anaregdesign/lantern/server/internal/envconfig"
 	"github.com/anaregdesign/lantern/server/service"
@@ -81,24 +83,37 @@ type httpConnectServer struct {
 // "/graph.v1.LanternService/" prefix), so the resulting URLs are
 // directly addressable by `curl -X POST` for Connect+JSON.
 //
+// The ValidationInterceptor and RateLimitInterceptor — already wired
+// onto the primary gRPC server via grpc.ChainUnaryInterceptor — are
+// mounted here as connect.WithInterceptors so the additive listener
+// enforces identical limits and bumps the same
+// lantern_validation_rejected_total / lantern_rate_limit_rejected_total
+// counters. Behaviour is observable as identical across both
+// transports; see #349.
+//
 // rep MAY be nil — in that case the replication handler is not mounted
 // (mirroring the gRPC path where replication can be disabled).
 func NewConnectServer(
 	cfg ConnectListenerConfig,
 	svc *service.LanternService,
 	rep *service.LanternReplicationService,
+	val *ValidationInterceptor,
+	rl *RateLimitInterceptor,
 	logger *slog.Logger,
 ) ConnectServer {
 	if cfg.Port <= 0 {
 		return NoopConnectServer{}
 	}
+	handlerOpts := connectHandlerOptions(val, rl)
 	mux := http.NewServeMux()
 	mux.Handle(graphv1connect.NewLanternServiceHandler(
 		service.NewLanternServiceConnectHandler(svc),
+		handlerOpts...,
 	))
 	if rep != nil {
 		mux.Handle(graphv1connect.NewLanternReplicationServiceHandler(
 			service.NewLanternReplicationServiceConnectHandler(rep),
+			handlerOpts...,
 		))
 	}
 	addr := fmt.Sprintf(":%d", cfg.Port)
@@ -111,6 +126,27 @@ func NewConnectServer(
 		logger: logger,
 		addr:   addr,
 	}
+}
+
+// connectHandlerOptions assembles the connect.HandlerOption chain shared
+// by every mounted Connect handler. Pulled out so adding a new
+// interceptor (auth, OTel, etc.) is a one-line edit at a single site
+// rather than two parallel handler-mount blocks.
+//
+// Skips nil interceptors so call sites with a disabled rate limiter
+// (RateLimitConfig.RPS<=0) don't have to special-case construction.
+func connectHandlerOptions(val *ValidationInterceptor, rl *RateLimitInterceptor) []connect.HandlerOption {
+	var ints []connect.Interceptor
+	if val != nil {
+		ints = append(ints, val.ConnectInterceptor())
+	}
+	if rl != nil && rl.lim != nil {
+		ints = append(ints, rl.ConnectInterceptor())
+	}
+	if len(ints) == 0 {
+		return nil
+	}
+	return []connect.HandlerOption{connect.WithInterceptors(ints...)}
 }
 
 func (c *httpConnectServer) Run(ctx context.Context) error {

--- a/server/provider/connect_interceptors.go
+++ b/server/provider/connect_interceptors.go
@@ -1,0 +1,171 @@
+// Package provider: connect_interceptors.go wires the existing
+// ValidationInterceptor and RateLimitInterceptor into Connect-Go's
+// connect.UnaryInterceptorFunc shape so the additive Connect listener
+// from #337 — and later the cutover in #347 — pick up the same
+// validation rules, token-bucket policy, reject hooks, and slog
+// channels the gRPC path uses.
+//
+// Design constraints (per #349):
+//   - Reuse the existing private validate(req any) and r.lim.Allow()
+//     logic verbatim. Behaviour MUST be observable as identical from
+//     reject-hook callbacks and slog output regardless of transport.
+//   - Translate the gRPC status errors the underlying logic returns
+//     into the matching connect.Error so wire clients see
+//     CodeInvalidArgument / CodeResourceExhausted, not a leaked
+//     gRPC-flavoured payload.
+//   - The existing UnaryServerInterceptor / StreamServerInterceptor
+//     gRPC methods are untouched (additive only — production deletion
+//     lives in #347).
+package provider
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"connectrpc.com/connect"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
+)
+
+// NewValidationInterceptorProvider wires the shared
+// *ValidationInterceptor instance both the gRPC server and the
+// additive Connect listener mount as their per-request validator.
+// Hoisting construction out of NewGrpcServerOptions (where it used to
+// live inline) lets both transports observe the same reject hook and
+// slog channel for free — the underlying validate() rules + reason set
+// stay in lockstep without duplication.
+func NewValidationInterceptorProvider(
+	limits ValidationLimits,
+	dm *domainmetrics.DomainMetrics,
+	logger *slog.Logger,
+) *ValidationInterceptor {
+	return NewValidationInterceptor(limits).
+		WithRejectHook(dm.OnValidationRejected).
+		WithLogger(logger)
+}
+
+// NewRateLimitInterceptorProvider wires the shared
+// *RateLimitInterceptor instance both the gRPC server and the
+// additive Connect listener consult before forwarding a call.
+//
+// When LANTERN_RATE_LIMIT_RPS<=0 the limiter is disabled: a
+// *RateLimitInterceptor with lim=nil is returned so the gRPC chain
+// builder can detect the disabled state (rli.lim == nil) and skip the
+// interceptor, mirroring the original RPS-gate behaviour. The Connect
+// side does the same check inside connectHandlerOptions.
+func NewRateLimitInterceptorProvider(
+	rl RateLimitConfig,
+	dm *domainmetrics.DomainMetrics,
+) *RateLimitInterceptor {
+	if rl.RPS <= 0 {
+		return &RateLimitInterceptor{}
+	}
+	return NewRateLimitInterceptor(rl.RPS, rl.Burst).
+		WithRejectHook(dm.OnRateLimitRejected)
+}
+
+// ConnectInterceptor returns a connect.UnaryInterceptorFunc that
+// validates every unary Connect call against the same ValidationLimits
+// the gRPC path uses.
+//
+// The interceptor calls the private validate(req any) shared with the
+// gRPC path so the canonical reason set, reject hook, and debug-level
+// slog channel stay identical across transports.
+//
+// Streaming RPCs (Subscribe / Snapshot) skip validation because
+// validate() only has cases for unary request types; the gRPC stream
+// interceptor (StreamServerInterceptor) is similarly a pass-through.
+// If validation is ever extended to streams, mirror the change here.
+func (v *ValidationInterceptor) ConnectInterceptor() connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			if err := v.validate(req.Any()); err != nil {
+				return nil, grpcStatusToConnect(err)
+			}
+			return next(ctx, req)
+		}
+	}
+}
+
+// ConnectInterceptor returns a connect.UnaryInterceptorFunc that
+// drains one token from the shared *rate.Limiter per unary Connect call
+// and returns connect.CodeResourceExhausted when the bucket is empty.
+//
+// The reject hook fires on the rejection path so
+// lantern_rate_limit_rejected_total keeps incrementing whether the
+// caller hit the gRPC or the Connect surface.
+func (r *RateLimitInterceptor) ConnectInterceptor() connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			if !r.lim.Allow() {
+				if r.rejectHook != nil {
+					r.rejectHook()
+				}
+				return nil, connect.NewError(connect.CodeResourceExhausted, errors.New("rate limit exceeded"))
+			}
+			return next(ctx, req)
+		}
+	}
+}
+
+// grpcStatusToConnect translates the gRPC status errors the existing
+// validate() path returns into matching connect.Errors so wire clients
+// receive Connect-flavoured codes and messages. Non-status errors fall
+// through unchanged.
+//
+// The 16-entry table mirrors connect-go's own internal table verbatim
+// (the names match by design — Connect's codes are wire-compatible with
+// gRPC's). The unknown fallback preserves CodeUnknown semantics for any
+// future gRPC code the bridge has not yet learned.
+func grpcStatusToConnect(err error) error {
+	if err == nil {
+		return nil
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		return err
+	}
+	return connect.NewError(grpcCodeToConnect(st.Code()), errors.New(st.Message()))
+}
+
+func grpcCodeToConnect(c codes.Code) connect.Code {
+	switch c {
+	case codes.Canceled:
+		return connect.CodeCanceled
+	case codes.Unknown:
+		return connect.CodeUnknown
+	case codes.InvalidArgument:
+		return connect.CodeInvalidArgument
+	case codes.DeadlineExceeded:
+		return connect.CodeDeadlineExceeded
+	case codes.NotFound:
+		return connect.CodeNotFound
+	case codes.AlreadyExists:
+		return connect.CodeAlreadyExists
+	case codes.PermissionDenied:
+		return connect.CodePermissionDenied
+	case codes.ResourceExhausted:
+		return connect.CodeResourceExhausted
+	case codes.FailedPrecondition:
+		return connect.CodeFailedPrecondition
+	case codes.Aborted:
+		return connect.CodeAborted
+	case codes.OutOfRange:
+		return connect.CodeOutOfRange
+	case codes.Unimplemented:
+		return connect.CodeUnimplemented
+	case codes.Internal:
+		return connect.CodeInternal
+	case codes.Unavailable:
+		return connect.CodeUnavailable
+	case codes.DataLoss:
+		return connect.CodeDataLoss
+	case codes.Unauthenticated:
+		return connect.CodeUnauthenticated
+	default:
+		return connect.CodeUnknown
+	}
+}

--- a/server/provider/connect_interceptors_test.go
+++ b/server/provider/connect_interceptors_test.go
@@ -1,0 +1,187 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	"google.golang.org/grpc/codes"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+)
+
+// TestValidationInterceptor_ConnectInterceptor_RejectsAndFiresHook
+// covers the Connect-Go path of the validation interceptor: the same
+// underlying validate() rules apply, the registered reject hook fires
+// exactly once with the canonical reason, and the returned error
+// surfaces as connect.CodeInvalidArgument (translated from gRPC's
+// codes.InvalidArgument via grpcCodeToConnect).
+//
+// One reason per request type is enough — the dispatch through
+// validate() is shared with the gRPC path, which TestValidationInterceptor_
+// RejectHookFiresPerReason already exercises across every reason.
+func TestValidationInterceptor_ConnectInterceptor_RejectsAndFiresHook(t *testing.T) {
+	limits := ValidationLimits{MaxKeyLen: 4, MaxBatchSize: 2}
+
+	var got string
+	v := NewValidationInterceptor(limits).
+		WithRejectHook(func(reason string) { got = reason })
+
+	interceptor := v.ConnectInterceptor()
+	called := false
+	next := connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		called = true
+		return connect.NewResponse(&pb.GetVertexResponse{}), nil
+	})
+	wrapped := interceptor(next)
+
+	_, err := wrapped(context.Background(), connect.NewRequest(&pb.GetVertexRequest{Key: ""}))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if called {
+		t.Error("next handler should NOT have been called on a rejected request")
+	}
+	if got != "empty_key" {
+		t.Errorf("hook reason = %q, want empty_key", got)
+	}
+	var cerr *connect.Error
+	if !errors.As(err, &cerr) {
+		t.Fatalf("err is not *connect.Error: %T (%v)", err, err)
+	}
+	if cerr.Code() != connect.CodeInvalidArgument {
+		t.Errorf("connect code = %v, want CodeInvalidArgument", cerr.Code())
+	}
+}
+
+// TestValidationInterceptor_ConnectInterceptor_PassesValidRequest
+// verifies the happy path: a request that survives validate() reaches
+// the next handler with its body intact and the response flows back
+// out unchanged.
+func TestValidationInterceptor_ConnectInterceptor_PassesValidRequest(t *testing.T) {
+	v := NewValidationInterceptor(ValidationLimits{MaxKeyLen: 32, MaxBatchSize: 100})
+	interceptor := v.ConnectInterceptor()
+
+	wantKey := "users/42"
+	next := connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		r, ok := req.Any().(*pb.GetVertexRequest)
+		if !ok {
+			t.Fatalf("next: unexpected req type %T", req.Any())
+		}
+		if r.Key != wantKey {
+			t.Errorf("next: key = %q, want %q", r.Key, wantKey)
+		}
+		return connect.NewResponse(&pb.GetVertexResponse{Vertex: &pb.Vertex{Key: wantKey}}), nil
+	})
+	wrapped := interceptor(next)
+
+	resp, err := wrapped(context.Background(), connect.NewRequest(&pb.GetVertexRequest{Key: wantKey}))
+	if err != nil {
+		t.Fatalf("wrapped: %v", err)
+	}
+	gv, ok := resp.Any().(*pb.GetVertexResponse)
+	if !ok {
+		t.Fatalf("resp.Any() unexpected type %T", resp.Any())
+	}
+	if got := gv.GetVertex().GetKey(); got != wantKey {
+		t.Errorf("resp.Vertex.Key = %q, want %q", got, wantKey)
+	}
+}
+
+// TestRateLimitInterceptor_ConnectInterceptor_AllowsThenRejects drains
+// the bucket to zero with a burst of allowed calls, then asserts the
+// next call is rejected with connect.CodeResourceExhausted and that
+// the reject hook fired exactly once for the rejection. Uses
+// rps=1/burst=2 so the bucket is small enough to exhaust deterministically
+// inside one test without time.Sleep.
+func TestRateLimitInterceptor_ConnectInterceptor_AllowsThenRejects(t *testing.T) {
+	r := NewRateLimitInterceptor(1, 2)
+	rejects := 0
+	r.WithRejectHook(func() { rejects++ })
+
+	allow := connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		return connect.NewResponse(&pb.GetVertexResponse{}), nil
+	})
+	wrapped := r.ConnectInterceptor()(allow)
+
+	ctx := context.Background()
+	for i := 0; i < 2; i++ {
+		if _, err := wrapped(ctx, connect.NewRequest(&pb.GetVertexRequest{Key: "k"})); err != nil {
+			t.Fatalf("burst call %d: %v", i, err)
+		}
+	}
+	// The bucket is empty; the next call must trip the limiter.
+	_, err := wrapped(ctx, connect.NewRequest(&pb.GetVertexRequest{Key: "k"}))
+	if err == nil {
+		t.Fatal("third call: want error, got nil")
+	}
+	var cerr *connect.Error
+	if !errors.As(err, &cerr) {
+		t.Fatalf("err is not *connect.Error: %T (%v)", err, err)
+	}
+	if cerr.Code() != connect.CodeResourceExhausted {
+		t.Errorf("connect code = %v, want CodeResourceExhausted", cerr.Code())
+	}
+	if rejects != 1 {
+		t.Errorf("reject hook fired %d times, want 1", rejects)
+	}
+}
+
+// TestRateLimitInterceptor_ConnectInterceptor_ZeroBurstDefaults_To_One
+// verifies the constructor's safety net: burst<=0 becomes 1 so the
+// interceptor never collapses into a permanent reject. Bursts of 0
+// would deadlock callers that expect at least one allowed request per
+// second of warm-up. Keep this in lockstep with the gRPC equivalent.
+func TestRateLimitInterceptor_ConnectInterceptor_ZeroBurstDefaults_To_One(t *testing.T) {
+	r := NewRateLimitInterceptor(1, 0)
+	allow := connect.UnaryFunc(func(ctx context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+		return connect.NewResponse(&pb.GetVertexResponse{}), nil
+	})
+	wrapped := r.ConnectInterceptor()(allow)
+
+	// At least one call must succeed; otherwise burst=0 saturated the
+	// limiter immediately.
+	if _, err := wrapped(context.Background(), connect.NewRequest(&pb.GetVertexRequest{Key: "k"})); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+}
+
+// TestGRPCCodeToConnect verifies the 16-entry mapping is exhaustive
+// and unambiguous. If a future grpc release adds a new code, gofmt
+// won't catch it — this table will.
+func TestGRPCCodeToConnect(t *testing.T) {
+	cases := []struct {
+		name string
+		in   codes.Code
+		want connect.Code
+	}{
+		{name: "Canceled", in: codes.Canceled, want: connect.CodeCanceled},
+		{name: "Unknown", in: codes.Unknown, want: connect.CodeUnknown},
+		{name: "InvalidArgument", in: codes.InvalidArgument, want: connect.CodeInvalidArgument},
+		{name: "DeadlineExceeded", in: codes.DeadlineExceeded, want: connect.CodeDeadlineExceeded},
+		{name: "NotFound", in: codes.NotFound, want: connect.CodeNotFound},
+		{name: "AlreadyExists", in: codes.AlreadyExists, want: connect.CodeAlreadyExists},
+		{name: "PermissionDenied", in: codes.PermissionDenied, want: connect.CodePermissionDenied},
+		{name: "ResourceExhausted", in: codes.ResourceExhausted, want: connect.CodeResourceExhausted},
+		{name: "FailedPrecondition", in: codes.FailedPrecondition, want: connect.CodeFailedPrecondition},
+		{name: "Aborted", in: codes.Aborted, want: connect.CodeAborted},
+		{name: "OutOfRange", in: codes.OutOfRange, want: connect.CodeOutOfRange},
+		{name: "Unimplemented", in: codes.Unimplemented, want: connect.CodeUnimplemented},
+		{name: "Internal", in: codes.Internal, want: connect.CodeInternal},
+		{name: "Unavailable", in: codes.Unavailable, want: connect.CodeUnavailable},
+		{name: "DataLoss", in: codes.DataLoss, want: connect.CodeDataLoss},
+		{name: "Unauthenticated", in: codes.Unauthenticated, want: connect.CodeUnauthenticated},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := grpcCodeToConnect(c.in); got != c.want {
+				t.Errorf("grpcCodeToConnect(%v) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+	// Sanity: an unknown code maps to CodeUnknown rather than panicking.
+	if got := grpcCodeToConnect(codes.Code(9999)); got != connect.CodeUnknown {
+		t.Errorf("unknown code = %v, want CodeUnknown", got)
+	}
+}

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -378,12 +378,11 @@ func NewGrpcServerMetrics(reg *prometheus.Registry) *grpcprom.ServerMetrics {
 func NewGrpcServerOptions(
 	net NetConfig,
 	tlsCfg TLSConfig,
-	rl RateLimitConfig,
-	limits ValidationLimits,
 	obs ObservabilityConfig,
 	logger *slog.Logger,
 	metrics *grpcprom.ServerMetrics,
-	dm *domainmetrics.DomainMetrics,
+	validator *ValidationInterceptor,
+	rli *RateLimitInterceptor,
 ) ([]grpc.ServerOption, error) {
 	logOpts := []logging.Option{
 		logging.WithLogOnEvents(logging.StartCall, logging.FinishCall),
@@ -394,10 +393,6 @@ func NewGrpcServerOptions(
 			return fmt.Errorf("internal server error")
 		}),
 	}
-
-	validator := NewValidationInterceptor(limits).
-		WithRejectHook(dm.OnValidationRejected).
-		WithLogger(logger)
 
 	unary := []grpc.UnaryServerInterceptor{
 		recovery.UnaryServerInterceptor(recoveryOpts...),
@@ -410,9 +405,14 @@ func NewGrpcServerOptions(
 		metrics.StreamServerInterceptor(),
 	}
 
-	if rl.RPS > 0 {
-		rli := NewRateLimitInterceptor(rl.RPS, rl.Burst).
-			WithRejectHook(dm.OnRateLimitRejected)
+	// validator and rli are wire providers (lifted out of this function
+	// in #349) so the additive Connect listener (#337) and the legacy
+	// gRPC server share the SAME *rate.Limiter token bucket. Sharing
+	// the limiter — rather than constructing a parallel one per
+	// transport — means a client that hammers the Connect surface
+	// cannot bypass the protection the operator configured for the
+	// gRPC surface (and vice versa).
+	if rli != nil && rli.lim != nil {
 		unary = append(unary, validator.UnaryServerInterceptor(), rli.UnaryServerInterceptor())
 		stream = append(stream, validator.StreamServerInterceptor(), rli.StreamServerInterceptor())
 	} else {


### PR DESCRIPTION
Closes #349. Part of #335. Prerequisite for #350 (tests/integration migration) and #347 (production cutover).

## What

Adds `ConnectInterceptor()` methods on both interceptors so the
additive Connect listener from #337 enforces the same
`ValidationLimits` and token-bucket policy the legacy gRPC path
enforces. Both transports now share a single `*ValidationInterceptor`
and `*RateLimitInterceptor` instance, wired via two new providers
(`NewValidationInterceptorProvider` / `NewRateLimitInterceptorProvider`)
hoisted out of `NewGrpcServerOptions` where they used to be constructed
inline.

Sharing the underlying `*rate.Limiter` — rather than building a parallel
bucket per transport — closes the loophole where a client hammering the
Connect port could bypass the operator-configured rate limit on the gRPC
port.

## Implementation

* `server/provider/connect_interceptors.go` (new) — two
  `ConnectInterceptor()` methods + a `grpcCodeToConnect` bridge
  translating the gRPC status errors the existing `validate()` and
  rate-limit paths return into Connect's matching error codes
  (16-entry table mirroring connect-go's own table). The two wire
  providers also live here so all new code sits in one file.
* `server/provider/connect.go` — `NewConnectServer` mounts both
  interceptors via `connect.WithInterceptors` on the Connect
  handlers; a tiny `connectHandlerOptions` helper centralises the
  chain assembly so adding a new interceptor (auth, OTel, etc.) is a
  one-line edit at a single site.
* `server/provider/provider.go` — `NewGrpcServerOptions` signature
  swap: takes injected interceptors instead of building them inline.
* `server/cmd/wire.go` + `wire_gen.go` — register the two new
  providers.

## Tests

`server/provider/connect_interceptors_test.go`:
1. Connect path validates + fires the reject hook with canonical
   reason; next handler NOT called; surface error is
   `connect.CodeInvalidArgument`.
2. Valid request passes through with body intact in both directions.
3. `RateLimitInterceptor` drains its bucket then trips
   `connect.CodeResourceExhausted`; reject hook fires once.
4. Zero-burst safety net (burst<=0 → 1) holds on the Connect path.
5. The 16-entry `grpcCodeToConnect` mapping is exhaustive; unknown
   codes fall back to `CodeUnknown`.

All four required CI checks expected green.