### PR TITLE
security(ci): supply-chain hardening on node-sdk.yml (#329)

### DIFF
--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -21,6 +21,14 @@ defaults:
   run:
     working-directory: sdks/node
 
+# Least-privilege default: the test job only needs to read repo contents
+# (checkout, codegen, lint, build, test). It does not write to PRs,
+# packages, deployments, or attestations. The publish job overrides this
+# with the additional `id-token: write` needed for npm Trusted Publishing
+# (OIDC). Mirrors the pattern PR #328 applied to admin.yml (#329).
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test (Node ${{ matrix.node-version }})
@@ -36,13 +44,13 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           # Pin so a fresh bun release can't silently break CI. Dependabot's
           # github-actions ecosystem will bump this via PR (#295).
           bun-version: 1.3.14
       - name: Setup buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
           version: '1.70.0'
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -88,12 +96,12 @@ jobs:
       - name: Upgrade npm (Trusted Publishing requires >= 11.5.1)
         run: npm install -g npm@latest
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           # See note in test job above (#295).
           bun-version: 1.3.14
       - name: Setup buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
           version: '1.70.0'
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #329. Mirrors PR #328's hardening of admin.yml.

## What

Pins third-party actions to commit SHA and adds workflow-level least-privilege `permissions` block. Both GHAS findings (`actions/unpinned-tag` CWE-829, `actions/missing-workflow-permissions` CWE-275) still apply to `node-sdk.yml` on main because the workflow had not been touched since the rule rolled out.

## Changes

- Add workflow-level `permissions: contents: read` (the publish job's existing override stays put — still needs `contents: read + id-token: write` for npm Trusted Publishing via OIDC).
- Pin `oven-sh/setup-bun@v2` → `@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0` (same SHA as admin.yml — bumps in lockstep).
- Pin `bufbuild/buf-setup-action@v1` → `@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0` (latest v1 release as of 2026-06-06).

## Out of scope (per #329)

- GitHub-owned actions (`actions/checkout`, `actions/setup-node`) — CodeQL exempts verified-creator immutable actions.
- Touching admin.yml — already done in PR #328.

All four required CI checks expected green.