### PR TITLE
test(integration): migrate unary tests to Connect-on-h2c harness (#350)

### DIFF
--- a/server/service/connect.go
+++ b/server/service/connect.go
@@ -19,13 +19,16 @@ package service
 
 import (
 	"context"
+	"errors"
 
 	"connectrpc.com/connect"
 
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
 
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // NewLanternServiceConnectHandler wraps *LanternService so it satisfies
@@ -52,12 +55,77 @@ type lanternServiceConnect struct {
 // unary is the one-line forwarding helper every adapter method uses.
 // Generics keep the per-method code to a single line while preserving
 // type safety: the call site supplies the typed underlying method.
+//
+// gRPC status errors from the underlying service are translated to
+// connect.Error so wire clients receive Connect-flavoured error codes
+// (e.g. NOT_FOUND → connect.CodeNotFound) instead of the
+// double-wrapped "rpc error: code = Unknown desc = rpc error: ..."
+// surface a plain error would produce.
 func unary[Req, Resp any](ctx context.Context, req *connect.Request[Req], fn func(context.Context, *Req) (*Resp, error)) (*connect.Response[Resp], error) {
 	out, err := fn(ctx, req.Msg)
 	if err != nil {
-		return nil, err
+		return nil, grpcErrToConnect(err)
 	}
 	return connect.NewResponse(out), nil
+}
+
+// grpcErrToConnect translates a gRPC status error (the shape every
+// service.LanternService method returns on failure) into a
+// connect.Error carrying the matching code. Non-status errors fall
+// through unchanged.
+func grpcErrToConnect(err error) error {
+	if err == nil {
+		return nil
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		return err
+	}
+	return connect.NewError(grpcCodeToConnect(st.Code()), errors.New(st.Message()))
+}
+
+// grpcCodeToConnect mirrors the 16-entry table in
+// server/provider/connect_interceptors.go (the package-private
+// translator there serves the interceptor layer; this copy serves
+// the adapter layer). Kept identical so a future refactor can hoist
+// either copy into a shared helper without behaviour changes.
+func grpcCodeToConnect(c codes.Code) connect.Code {
+	switch c {
+	case codes.Canceled:
+		return connect.CodeCanceled
+	case codes.Unknown:
+		return connect.CodeUnknown
+	case codes.InvalidArgument:
+		return connect.CodeInvalidArgument
+	case codes.DeadlineExceeded:
+		return connect.CodeDeadlineExceeded
+	case codes.NotFound:
+		return connect.CodeNotFound
+	case codes.AlreadyExists:
+		return connect.CodeAlreadyExists
+	case codes.PermissionDenied:
+		return connect.CodePermissionDenied
+	case codes.ResourceExhausted:
+		return connect.CodeResourceExhausted
+	case codes.FailedPrecondition:
+		return connect.CodeFailedPrecondition
+	case codes.Aborted:
+		return connect.CodeAborted
+	case codes.OutOfRange:
+		return connect.CodeOutOfRange
+	case codes.Unimplemented:
+		return connect.CodeUnimplemented
+	case codes.Internal:
+		return connect.CodeInternal
+	case codes.Unavailable:
+		return connect.CodeUnavailable
+	case codes.DataLoss:
+		return connect.CodeDataLoss
+	case codes.Unauthenticated:
+		return connect.CodeUnauthenticated
+	default:
+		return connect.CodeUnknown
+	}
 }
 
 func (h *lanternServiceConnect) Illuminate(ctx context.Context, req *connect.Request[pb.IlluminateRequest]) (*connect.Response[pb.IlluminateResponse], error) {

--- a/tests/integration/batch_error_test.go
+++ b/tests/integration/batch_error_test.go
@@ -3,63 +3,11 @@ package integration_test
 import (
 	"context"
 	"errors"
-	"net"
 	"testing"
 	"time"
 
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
-	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	client "github.com/anaregdesign/lantern/sdks/go"
-	"github.com/anaregdesign/lantern/server/provider"
-	"github.com/anaregdesign/lantern/server/service"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/test/bufconn"
 )
-
-// newInProcessClientChunked is like newInProcessClient but lets the test
-// force a custom batchChunkSize so partial-write scenarios can be exercised
-// with a small input.
-func newInProcessClientChunked(t *testing.T, chunkSize int) (*client.Lantern, func()) {
-	t.Helper()
-
-	lis := bufconn.Listen(1 << 16)
-	vi := provider.NewValidationInterceptor(provider.ValidationLimits{
-		MaxKeyLen:         256,
-		MaxBatchSize:      1024,
-		IlluminateMaxStep: 32,
-		IlluminateMaxK:    256,
-	})
-	srv := grpc.NewServer(grpc.UnaryInterceptor(vi.UnaryServerInterceptor()))
-	svc := service.NewLanternService(cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute))
-	pb.RegisterLanternServiceServer(srv, svc)
-
-	go func() {
-		if err := srv.Serve(lis); err != nil {
-			t.Logf("grpc Serve returned: %v", err)
-		}
-	}()
-
-	dialer := func(context.Context, string) (net.Conn, error) {
-		return lis.Dial()
-	}
-	l, err := client.NewLantern(
-		"passthrough://bufconn",
-		client.WithTransportCredentials(insecure.NewCredentials()),
-		client.WithDialOption(grpc.WithContextDialer(dialer)),
-		client.WithBatchChunkSize(chunkSize),
-	)
-	if err != nil {
-		t.Fatalf("NewLantern: %v", err)
-	}
-
-	cleanup := func() {
-		_ = l.Close()
-		srv.Stop()
-		_ = lis.Close()
-	}
-	return l, cleanup
-}
 
 // TestBatchError_PartialWrite verifies that when a later chunk fails, the
 // SDK returns a *BatchError whose Written field reflects fully-committed

--- a/tests/integration/client_test.go
+++ b/tests/integration/client_test.go
@@ -3,61 +3,11 @@ package integration_test
 import (
 	"context"
 	"errors"
-	"net"
 	"testing"
 	"time"
 
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
-	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	client "github.com/anaregdesign/lantern/sdks/go"
-	"github.com/anaregdesign/lantern/server/provider"
-	"github.com/anaregdesign/lantern/server/service"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/test/bufconn"
 )
-
-// newInProcessClient wires a Lantern client to an in-process gRPC server
-// backed by a real LanternService, so we exercise the actual wire format.
-func newInProcessClient(t *testing.T) (*client.Lantern, func()) {
-	t.Helper()
-
-	lis := bufconn.Listen(1 << 16)
-	vi := provider.NewValidationInterceptor(provider.ValidationLimits{
-		MaxKeyLen:         256,
-		MaxBatchSize:      1024,
-		IlluminateMaxStep: 32,
-		IlluminateMaxK:    256,
-	})
-	srv := grpc.NewServer(grpc.UnaryInterceptor(vi.UnaryServerInterceptor()))
-	svc := service.NewLanternService(cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute))
-	pb.RegisterLanternServiceServer(srv, svc)
-
-	go func() {
-		if err := srv.Serve(lis); err != nil {
-			t.Logf("grpc Serve returned: %v", err)
-		}
-	}()
-
-	dialer := func(context.Context, string) (net.Conn, error) {
-		return lis.Dial()
-	}
-	l, err := client.NewLantern(
-		"passthrough://bufconn",
-		client.WithTransportCredentials(insecure.NewCredentials()),
-		client.WithDialOption(grpc.WithContextDialer(dialer)),
-	)
-	if err != nil {
-		t.Fatalf("NewLantern: %v", err)
-	}
-
-	cleanup := func() {
-		_ = l.Close()
-		srv.Stop()
-		_ = lis.Close()
-	}
-	return l, cleanup
-}
 
 func TestLantern_PutGetDeleteVertex(t *testing.T) {
 	l, cleanup := newInProcessClient(t)

--- a/tests/integration/cursor_cross_rpc_test.go
+++ b/tests/integration/cursor_cross_rpc_test.go
@@ -13,8 +13,8 @@ import (
 // TestSDK_Cursor_CrossRPC_Rejected is the end-to-end pin for #168: a
 // next_cursor minted by ScanVertices, fed back into ScanEdges (and vice
 // versa), must surface as INVALID_ARGUMENT rather than silently restart
-// the scan. Exercises the full bufconn wire path so the proto comments
-// and server-side discriminator decode stay honest.
+// the scan. Exercises the full wire path so the proto comments and
+// server-side discriminator decode stay honest.
 func TestSDK_Cursor_CrossRPC_Rejected(t *testing.T) {
 	l, cleanup := newPrefixSDKClient(t)
 	defer cleanup()

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -1,0 +1,178 @@
+package integration_test
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+
+	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/anaregdesign/lantern/server/provider"
+	"github.com/anaregdesign/lantern/server/service"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers — Connect-on-h2c in-process harness (#350)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The integration suite migrated from bufconn + grpc.NewServer to
+// httptest + h2c + Connect-Go handlers in #350 (part of #335). Every
+// helper here returns a *client.Lantern wired through the Connect
+// transport so the tests exercise the production wire path the
+// server will use once #347 cuts over.
+//
+// Why httptest instead of net.Listen: httptest.Server owns the
+// listener lifecycle (auto-close on t.Cleanup), picks an ephemeral
+// port that never collides with other parallel tests, and exposes
+// `.URL` already in the http://host:port form NewLanternConnect
+// requires. h2c lets the test work without juggling TLS certs.
+
+// connectTestServer pairs the live LanternService with the
+// httptest.Server hosting its Connect handler. Tests that need to
+// inspect or mutate the service after construction (e.g. seeding
+// vertices via the service's own Backend) hold this aggregate
+// directly; tests that only need an SDK client take the *client.Lantern
+// returned by the convenience helpers.
+type connectTestServer struct {
+	svc *service.LanternService
+	rep *service.LanternReplicationService
+	srv *httptest.Server
+	url string
+}
+
+// defaultIntegrationValidationLimits matches the historical
+// ValidationLimits the legacy bufconn helper used. Keeping the limits
+// constant across the suite means tests that depend on a particular
+// "request too large" behaviour stay deterministic.
+func defaultIntegrationValidationLimits() provider.ValidationLimits {
+	return provider.ValidationLimits{
+		MaxKeyLen:         256,
+		MaxBatchSize:      1024,
+		IlluminateMaxStep: 32,
+		IlluminateMaxK:    256,
+	}
+}
+
+// newConnectTestServer stands up an h2c httptest.Server mounting the
+// supplied service + optional replication handler with the supplied
+// chain of Connect interceptors. Returns the aggregate; tests usually
+// consume the convenience wrappers (newInProcessClient,
+// newInProcessClientWithInterceptors, ...) rather than this directly.
+//
+// rep MAY be nil — the replication handler is then not mounted,
+// mirroring the gRPC path where replication can be disabled.
+func newConnectTestServer(
+	t *testing.T,
+	svc *service.LanternService,
+	rep *service.LanternReplicationService,
+	interceptors ...connect.Interceptor,
+) *connectTestServer {
+	t.Helper()
+
+	var opts []connect.HandlerOption
+	if len(interceptors) > 0 {
+		opts = []connect.HandlerOption{connect.WithInterceptors(interceptors...)}
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle(graphv1connect.NewLanternServiceHandler(
+		service.NewLanternServiceConnectHandler(svc),
+		opts...,
+	))
+	if rep != nil {
+		mux.Handle(graphv1connect.NewLanternReplicationServiceHandler(
+			service.NewLanternReplicationServiceConnectHandler(rep),
+			opts...,
+		))
+	}
+
+	srv := httptest.NewServer(h2c.NewHandler(mux, &http2.Server{}))
+	t.Cleanup(srv.Close)
+	return &connectTestServer{svc: svc, rep: rep, srv: srv, url: srv.URL}
+}
+
+// newConnectClientFor wires a *client.Lantern via NewLanternConnect at
+// the supplied URL. The constructor is forced to use an h2c-capable
+// http.Client because httptest spins up plain HTTP/2-over-cleartext.
+// Optional SDK-side options (WithConnectBatchChunkSize, ...) flow
+// through.
+func newConnectClientFor(t *testing.T, baseURL string, opts ...client.ConnectOption) *client.Lantern {
+	t.Helper()
+	all := append([]client.ConnectOption{client.WithHTTPClient(h2cClient())}, opts...)
+	l, err := client.NewLanternConnect(baseURL, all...)
+	if err != nil {
+		t.Fatalf("NewLanternConnect: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	return l
+}
+
+// h2cClient returns an h2c-flavoured http.Client that matches what
+// httptest.Server speaks. Each call returns a fresh client so a test
+// that explicitly calls Close on the *client.Lantern does not affect
+// any other in-flight client in a parallel test.
+func h2cClient() *http.Client {
+	return &http.Client{
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, network, addr)
+			},
+		},
+	}
+}
+
+// newInProcessClient is the default helper most integration tests
+// consume: a fresh GraphCache-backed LanternService, the standard
+// validation interceptor, and an h2c-backed Connect *client.Lantern.
+//
+// The returned cleanup is a no-op (kept in the signature so
+// historical call sites stay source-compatible). The httptest.Server
+// and the *client.Lantern register their own Cleanup hooks through
+// the supplied *testing.T, so the test does not have to remember to
+// tear anything down explicitly.
+func newInProcessClient(t *testing.T) (*client.Lantern, func()) {
+	t.Helper()
+	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	svc := service.NewLanternService(cache)
+	val := provider.NewValidationInterceptor(defaultIntegrationValidationLimits())
+	srv := newConnectTestServer(t, svc, nil, val.ConnectInterceptor())
+	return newConnectClientFor(t, srv.url), func() {}
+}
+
+// newInProcessClientChunked mirrors newInProcessClient but with a
+// custom batch chunk size. Used by batch_error_test.go to deliberately
+// trip mid-batch failures.
+func newInProcessClientChunked(t *testing.T, chunkSize int) (*client.Lantern, func()) {
+	t.Helper()
+	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	svc := service.NewLanternService(cache)
+	val := provider.NewValidationInterceptor(defaultIntegrationValidationLimits())
+	srv := newConnectTestServer(t, svc, nil, val.ConnectInterceptor())
+	l := newConnectClientFor(t, srv.url, client.WithConnectBatchChunkSize(chunkSize))
+	return l, func() {}
+}
+
+// newInProcessClientWithPrefix mirrors newInProcessClient but enables
+// the prefix index on the underlying GraphCache so list_under /
+// prefix-scan integration tests pass.
+func newInProcessClientWithPrefix(t *testing.T) (*client.Lantern, func()) {
+	t.Helper()
+	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache.EnablePrefixIndex(func(k string) string { return k })
+	svc := service.NewLanternService(cache)
+	val := provider.NewValidationInterceptor(defaultIntegrationValidationLimits())
+	srv := newConnectTestServer(t, svc, nil, val.ConnectInterceptor())
+	return newConnectClientFor(t, srv.url), func() {}
+}

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -11,7 +11,6 @@ import (
 
 	"connectrpc.com/connect"
 	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 
 	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
@@ -96,7 +95,15 @@ func newConnectTestServer(
 		))
 	}
 
-	srv := httptest.NewServer(h2c.NewHandler(mux, &http2.Server{}))
+	srv := httptest.NewUnstartedServer(mux)
+	// Enable unencrypted HTTP/2 via the Go 1.24+ Server.Protocols
+	// surface (the older h2c.NewHandler wrapper is deprecated by
+	// staticcheck SA1019).
+	protos := new(http.Protocols)
+	protos.SetHTTP1(true)
+	protos.SetUnencryptedHTTP2(true)
+	srv.Config.Protocols = protos
+	srv.Start()
 	t.Cleanup(srv.Close)
 	return &connectTestServer{svc: svc, rep: rep, srv: srv, url: srv.URL}
 }

--- a/tests/integration/mcp_test.go
+++ b/tests/integration/mcp_test.go
@@ -5,71 +5,18 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
-	"net"
 	"testing"
 	"time"
 
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
 	lmcp "github.com/anaregdesign/lantern/mcp"
-	pb "github.com/anaregdesign/lantern/pb/graph/v1"
-	client "github.com/anaregdesign/lantern/sdks/go"
-	"github.com/anaregdesign/lantern/server/provider"
-	"github.com/anaregdesign/lantern/server/service"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/test/bufconn"
 )
 
-// newInProcessClientWithPrefix is a variant of newInProcessClient whose
-// backing GraphCache has the prefix index enabled, so list_under (which
-// drives ScanVertices) actually returns results. The default shared
-// helper does not enable it because most integration tests don't need
-// the index and we want to keep their behaviour unchanged.
-func newInProcessClientWithPrefix(t *testing.T) (*client.Lantern, func()) {
-	t.Helper()
-	lis := bufconn.Listen(1 << 16)
-
-	gc := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
-	gc.EnablePrefixIndex(func(s string) string { return s })
-
-	vi := provider.NewValidationInterceptor(provider.ValidationLimits{
-		MaxKeyLen:         256,
-		MaxBatchSize:      1024,
-		IlluminateMaxStep: 32,
-		IlluminateMaxK:    256,
-	})
-	srv := grpc.NewServer(grpc.UnaryInterceptor(vi.UnaryServerInterceptor()))
-	pb.RegisterLanternServiceServer(srv, service.NewLanternService(gc))
-
-	go func() {
-		if err := srv.Serve(lis); err != nil {
-			t.Logf("grpc Serve returned: %v", err)
-		}
-	}()
-
-	dialer := func(context.Context, string) (net.Conn, error) { return lis.Dial() }
-	l, err := client.NewLantern(
-		"passthrough://bufconn",
-		client.WithTransportCredentials(insecure.NewCredentials()),
-		client.WithDialOption(grpc.WithContextDialer(dialer)),
-	)
-	if err != nil {
-		t.Fatalf("NewLantern: %v", err)
-	}
-	cleanup := func() {
-		_ = l.Close()
-		srv.Stop()
-		_ = lis.Close()
-	}
-	return l, cleanup
-}
-
 // TestMCP_EndToEnd exercises the 6-tool MCP surface through a real MCP
-// client session over InMemoryTransport, backed by a real Lantern gRPC
-// service (bufconn). It is the smoke test that proves the whole stack
-// — schema inference, argument validation, SDK round-trip, and result
-// shape — agrees end-to-end.
+// client session over InMemoryTransport, backed by a real Lantern
+// service (Connect-on-h2c per #350). It is the smoke test that proves
+// the whole stack — schema inference, argument validation, SDK
+// round-trip, and result shape — agrees end-to-end.
 func TestMCP_EndToEnd(t *testing.T) {
 	lan, cleanup := newInProcessClientWithPrefix(t)
 	defer cleanup()


### PR DESCRIPTION
Closes #350. Part of #335. Built on #338 / #349.

## What

Migrates the unary-RPC slice of `tests/integration/` from `bufconn` + `grpc.NewServer` to `httptest` + `h2c` + Connect handlers, mirroring the pattern proven in #339 (admin) and #340 (sdks/node).

Also fixes a long-standing bug in the Connect adapter caught by the migrated tests: gRPC `status` errors from the underlying service flowed through unchanged to wire clients, producing double-wrapped `"rpc error: code = Unknown desc = rpc error: code = NotFound desc = ..."` surfaces. The adapter now translates via a new `grpcCodeToConnect` table so the SDK's `wrapStatus` shim correctly observes `ErrNotFound` / `ErrInvalidArgument` / `ErrResourceExhausted`.

## Scope (partial — per rescoped #350)

**Migrated:**
* `tests/integration/helpers_test.go` (new) — `newInProcessClient` / `newInProcessClientChunked` / `newInProcessClientWithPrefix` all over Connect-on-h2c.
* `client_test.go` / `batch_error_test.go` / `mcp_test.go` — local server setup deleted; tests consume the shared helpers.
* `cursor_cross_rpc_test.go` — stale comment cleanup.

**Deferred to #347 / #342** because they exercise layers that still talk grpc directly:
* `antientropy` / `peer_pump` / `snapshot` / `subscribe` — exercise server replication dialer which uses `grpc.DialOption`.
* `health` — uses gRPC Health v1 surface (not yet ported to Connect).
* `prefix_scan` / `prefix_sdk` — drive the generated pb client directly, not the SDK.
* `client_options` / `middleware_chain` / `multi_endpoint` — exercise grpc dial-option plumbing.

## Verified

- `gofmt -l . cli core mcp pb sdks server tests` empty.
- All 6 server-module tests pass.
- 1 sdks/go test passes.
- Full integration suite (`go test ./tests/integration/...`) green.

All four required CI checks expected green.