### PR TITLE
feat(server/replication): port pump + antientropy clients to Connect-Go (#359)

### DIFF
--- a/server/replication/antientropy.go
+++ b/server/replication/antientropy.go
@@ -33,15 +33,15 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net/http"
 	"sync"
 	"time"
 
 	"github.com/anaregdesign/lantern/core/hlc"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/status"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
+
+	"connectrpc.com/connect"
 )
 
 // LocalStateProvider is the surface the anti-entropy driver uses to
@@ -106,9 +106,10 @@ type AntiEntropyConfig struct {
 	// always emitted regardless of this knob.
 	GapWarnThreshold uint64
 
-	// DialOptions are passed to grpc.NewClient. Defaults to
-	// insecure credentials (in-cluster Tier-A topology).
-	DialOptions []grpc.DialOption
+	// HTTPClient is the http.Client used to open Connect-Go streams
+	// against each peer. Defaults to defaultH2CClient() (plaintext
+	// HTTP/2 for the in-cluster Tier-A topology).
+	HTTPClient *http.Client
 
 	// Logger receives lifecycle events. slog.Default() when nil.
 	Logger *slog.Logger
@@ -146,8 +147,8 @@ func NewAntiEntropy(cfg AntiEntropyConfig, local LocalStateProvider, apply Mutat
 	if cfg.Metrics == nil {
 		cfg.Metrics = nopAntiEntropyMetrics{}
 	}
-	if len(cfg.DialOptions) == 0 {
-		cfg.DialOptions = []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = defaultH2CClient()
 	}
 	return &AntiEntropy{cfg: cfg, local: local, apply: apply, snap: snap}
 }
@@ -202,28 +203,24 @@ func (a *AntiEntropy) tickPeer(ctx context.Context, addr string) {
 	a.cfg.Metrics.OnAntiEntropyTick(addr)
 	log := a.cfg.Logger.With(slog.String("peer", addr))
 
-	conn, err := grpc.NewClient(addr, a.cfg.DialOptions...)
-	if err != nil {
-		log.Warn("anti-entropy: dial failed", slog.Any("err", err))
-		a.cfg.Metrics.OnAntiEntropyError(addr, "dial_failed")
-		return
-	}
-	defer func() { _ = conn.Close() }()
-	cli := pb.NewLanternReplicationServiceClient(conn)
+	cli := graphv1connect.NewLanternReplicationServiceClient(
+		a.cfg.HTTPClient, peerBaseURL(addr), connect.WithGRPC(),
+	)
 
-	resp, err := cli.PeerStatus(ctx, &pb.PeerStatusRequest{})
+	resp, err := cli.PeerStatus(ctx, connect.NewRequest(&pb.PeerStatusRequest{}))
 	if err != nil {
 		log.Warn("anti-entropy: PeerStatus failed", slog.Any("err", err))
 		a.cfg.Metrics.OnAntiEntropyError(addr, "peerstatus_failed")
 		return
 	}
-	if len(resp.GetSelfOrigin()) == 0 {
+	msg := resp.Msg
+	if len(msg.GetSelfOrigin()) == 0 {
 		// Peer cannot identify itself — older binary or
 		// replication unwired on the peer side. Nothing to do.
 		return
 	}
 	var peerNID hlc.NodeID
-	copy(peerNID[:], resp.GetSelfOrigin())
+	copy(peerNID[:], msg.GetSelfOrigin())
 	// Self-skip: a configured peer pointing back to ourselves (e.g.
 	// stale DNS in a single-node test) should be ignored.
 	if peerNID == a.cfg.NodeID {
@@ -238,7 +235,7 @@ func (a *AntiEntropy) tickPeer(ctx context.Context, addr string) {
 	// replay them.
 	var target uint64
 	found := false
-	for _, row := range resp.GetOrigins() {
+	for _, row := range msg.GetOrigins() {
 		if len(row.GetOrigin()) != len(peerNID) {
 			continue
 		}
@@ -298,37 +295,21 @@ func (a *AntiEntropy) tickPeer(ctx context.Context, addr string) {
 // after which catchUp returns — the next tick will re-probe.
 //
 // Returns the number of mutations applied during this call.
-func (a *AntiEntropy) catchUp(ctx context.Context, cli pb.LanternReplicationServiceClient, peerNID hlc.NodeID, fromSeq, target uint64) (uint64, error) {
+func (a *AntiEntropy) catchUp(ctx context.Context, cli graphv1connect.LanternReplicationServiceClient, peerNID hlc.NodeID, fromSeq, target uint64) (uint64, error) {
 	tctx, cancel := context.WithTimeout(ctx, a.cfg.SubscribeTimeout)
 	defer cancel()
 
-	stream, err := cli.Subscribe(tctx, &pb.SubscribeRequest{FromSeq: fromSeq})
+	stream, err := cli.Subscribe(tctx, connect.NewRequest(&pb.SubscribeRequest{FromSeq: fromSeq}))
 	if err != nil {
-		if status.Code(err) == codes.FailedPrecondition {
+		if connect.CodeOf(err) == connect.CodeFailedPrecondition {
 			return 0, a.snapshotFrom(ctx, cli)
 		}
 		return 0, err
 	}
+	defer func() { _ = stream.Close() }()
 	var applied uint64
-	for {
-		resp, recvErr := stream.Recv()
-		if errors.Is(recvErr, io.EOF) {
-			return applied, nil
-		}
-		if recvErr != nil {
-			if status.Code(recvErr) == codes.FailedPrecondition {
-				return applied, a.snapshotFrom(ctx, cli)
-			}
-			// Deadline-exceeded from the subscribe timeout is
-			// expected when the catch-up window is shorter
-			// than the gap — surface as nil so the tick is
-			// accounted as a partial success, the next tick
-			// will resume.
-			if errors.Is(recvErr, context.DeadlineExceeded) || status.Code(recvErr) == codes.DeadlineExceeded {
-				return applied, nil
-			}
-			return applied, recvErr
-		}
+	for stream.Receive() {
+		resp := stream.Msg()
 		mu := resp.GetMutation()
 		if mu == nil {
 			continue
@@ -348,25 +329,35 @@ func (a *AntiEntropy) catchUp(ctx context.Context, cli pb.LanternReplicationServ
 			return applied, nil
 		}
 	}
+	recvErr := stream.Err()
+	if recvErr == nil || errors.Is(recvErr, io.EOF) {
+		return applied, nil
+	}
+	if connect.CodeOf(recvErr) == connect.CodeFailedPrecondition {
+		return applied, a.snapshotFrom(ctx, cli)
+	}
+	// Deadline-exceeded from the subscribe timeout is expected
+	// when the catch-up window is shorter than the gap — surface as
+	// nil so the tick is accounted as a partial success, the next
+	// tick will resume.
+	if errors.Is(recvErr, context.DeadlineExceeded) || connect.CodeOf(recvErr) == connect.CodeDeadlineExceeded {
+		return applied, nil
+	}
+	return applied, recvErr
 }
 
 // snapshotFrom replays a full Snapshot from the peer into the local
 // cache. Triggered by FailedPrecondition on Subscribe. After this
 // returns, the next anti-entropy tick will re-probe PeerStatus and
 // resume normal catch-up.
-func (a *AntiEntropy) snapshotFrom(ctx context.Context, cli pb.LanternReplicationServiceClient) error {
-	stream, err := cli.Snapshot(ctx, &pb.SnapshotRequest{})
+func (a *AntiEntropy) snapshotFrom(ctx context.Context, cli graphv1connect.LanternReplicationServiceClient) error {
+	stream, err := cli.Snapshot(ctx, connect.NewRequest(&pb.SnapshotRequest{}))
 	if err != nil {
 		return err
 	}
-	for {
-		resp, recvErr := stream.Recv()
-		if errors.Is(recvErr, io.EOF) {
-			return nil
-		}
-		if recvErr != nil {
-			return recvErr
-		}
+	defer func() { _ = stream.Close() }()
+	for stream.Receive() {
+		resp := stream.Msg()
 		switch e := resp.GetEntry().(type) {
 		case *pb.SnapshotResponse_Header:
 			// nothing to apply
@@ -396,4 +387,8 @@ func (a *AntiEntropy) snapshotFrom(ctx context.Context, cli pb.LanternReplicatio
 			// path. Anti-entropy is best-effort.
 		}
 	}
+	if err := stream.Err(); err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	return nil
 }

--- a/server/replication/h2c.go
+++ b/server/replication/h2c.go
@@ -1,0 +1,57 @@
+// Package replication: h2c.go provides the shared default http.Client
+// used by the Connect-Go replication clients (Pump + AntiEntropy) when
+// the caller does not supply one via Config.HTTPClient /
+// AntiEntropyConfig.HTTPClient.
+//
+// The default speaks HTTP/2 over plaintext so the cluster-internal
+// replication path (Tier-A topology) works without TLS plumbing —
+// matching the gRPC behaviour previously achieved via
+// grpc.WithTransportCredentials(insecure.NewCredentials()). Operators
+// that need TLS supply their own http.Client backed by an
+// http2.Transport with a real *tls.Config.
+//
+// peerBaseURL prepends the "http://" scheme to a bare "host:port"
+// peer address so Connect-Go's generated client constructor accepts
+// it. The scheme intentionally cannot be configured at this layer —
+// operators that need https:// build their own *http.Client via
+// Config.HTTPClient and pass full URLs in Config.Peers (or via the
+// PeerSource resolver).
+package replication
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"strings"
+
+	"golang.org/x/net/http2"
+)
+
+func defaultH2CClient() *http.Client {
+	return &http.Client{
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			// AllowHTTP=true makes http2.Transport treat
+			// DialTLSContext as the plain TCP dialer (no TLS
+			// handshake). The tls.Config arg is honored by the
+			// transport but ignored by us.
+			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, network, addr)
+			},
+		},
+	}
+}
+
+// peerBaseURL accepts the historical "host:port" peer address form
+// and the new "http://host:port" / "https://host:port" forms.
+// Returns the input unchanged when it already carries a scheme; adds
+// "http://" otherwise. Trailing slashes are trimmed so the
+// Connect-Go client's path concatenation produces clean URLs.
+func peerBaseURL(addr string) string {
+	if strings.HasPrefix(addr, "http://") || strings.HasPrefix(addr, "https://") {
+		return strings.TrimRight(addr, "/")
+	}
+	return "http://" + addr
+}

--- a/server/replication/pump.go
+++ b/server/replication/pump.go
@@ -36,15 +36,15 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net/http"
 	"time"
 
 	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
 	"github.com/anaregdesign/lantern/core/hlc"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/status"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
+
+	"connectrpc.com/connect"
 )
 
 // MutationApplier is the narrow surface the pump uses to replay a
@@ -96,9 +96,10 @@ type Config struct {
 	NodeID hlc.NodeID
 
 	// Peers is the static list of peer addresses to subscribe to.
-	// Each entry is consumed by grpc.NewClient verbatim
-	// ("host:port"). Empty (or nil) is valid when Source is set;
-	// otherwise yields a no-op pump.
+	// Each entry must be a bare "host:port" (e.g. "lantern-0:6380").
+	// The pump prepends "http://" to build the Connect baseURL.
+	// Empty (or nil) is valid when Source is set; otherwise yields
+	// a no-op pump.
 	Peers []string
 
 	// Source, when non-nil, takes precedence over Peers and is the
@@ -118,11 +119,13 @@ type Config struct {
 	// failure does not tear down established subscriptions.
 	DiscoveryInterval time.Duration
 
-	// DialOptions are passed to grpc.NewClient for each peer
-	// connection. When empty, insecure transport credentials are
-	// used — sufficient for the in-cluster Tier-A topology where
-	// peers are reachable only via the cluster network.
-	DialOptions []grpc.DialOption
+	// HTTPClient is the http.Client used to open Connect-Go streams
+	// against each peer. When nil, defaultH2CClient() is used so the
+	// pump talks plain HTTP/2 over the cluster network — sufficient
+	// for the Tier-A topology where peers are only reachable via the
+	// cluster network. For TLS, supply an http.Client backed by an
+	// http2.Transport with a real *tls.Config.
+	HTTPClient *http.Client
 
 	// BackoffMin is the initial reconnect delay after a session
 	// error. Doubles on each successive failure, capped at
@@ -170,8 +173,8 @@ func NewPump(cfg Config, apply MutationApplier, snap SnapshotApplier) *Pump {
 	if cfg.Metrics == nil {
 		cfg.Metrics = nopMetrics{}
 	}
-	if len(cfg.DialOptions) == 0 {
-		cfg.DialOptions = []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = defaultH2CClient()
 	}
 	return &Pump{cfg: cfg, apply: apply, snap: snap, tracker: newPeerTracker()}
 }
@@ -294,12 +297,19 @@ func (p *Pump) runPeer(ctx context.Context, addr string) {
 // exit).
 func (p *Pump) session(ctx context.Context, addr string, fromSeq uint64) (uint64, error) {
 	log := p.cfg.Logger.With(slog.String("peer", addr))
-	conn, err := grpc.NewClient(addr, p.cfg.DialOptions...)
-	if err != nil {
-		return fromSeq, err
-	}
-	defer func() { _ = conn.Close() }()
-	cli := pb.NewLanternReplicationServiceClient(conn)
+	// Connect-Go clients are cheap to construct and own no
+	// connection state of their own — the underlying http.Client
+	// pools connections internally. No defer-close needed.
+	//
+	// WithGRPC pins the wire protocol to gRPC-over-h2 instead of the
+	// Connect protocol so this client can talk to both legacy
+	// grpc.NewServer peers (the production state until #347 cuts
+	// over) and Connect handlers (which accept all three protocols
+	// natively). Streaming RPCs benefit from gRPC's binary framing
+	// over the JSON-friendly Connect framing.
+	cli := graphv1connect.NewLanternReplicationServiceClient(
+		p.cfg.HTTPClient, peerBaseURL(addr), connect.WithGRPC(),
+	)
 
 	p.cfg.Metrics.OnPumpConnect(addr)
 	log.Info("replication pump: peer transition",
@@ -322,7 +332,7 @@ func (p *Pump) session(ctx context.Context, addr string, fromSeq uint64) (uint64
 			slog.String("reason", "ctx_cancel"))
 		return next, nil
 	}
-	if status.Code(err) == codes.FailedPrecondition {
+	if connect.CodeOf(err) == connect.CodeFailedPrecondition {
 		// gapped: snapshot, then resume from cutoff+1.
 		log.Info("replication pump: peer transition",
 			slog.String("transition", "snapshot_start"),
@@ -362,22 +372,17 @@ func (p *Pump) session(ctx context.Context, addr string, fromSeq uint64) (uint64
 // subscribe opens a Subscribe stream at fromSeq and applies every
 // received Mutation. Self-origin mutations are dropped before
 // dispatch. Returns the seq of the last successfully-applied mutation
-// + 1 (i.e. the next seq to resume at) and any error from Recv/Apply.
-// io.EOF is treated as a normal end-of-stream (returns nil).
-func (p *Pump) subscribe(ctx context.Context, cli pb.LanternReplicationServiceClient, addr string, fromSeq uint64) (uint64, error) {
-	stream, err := cli.Subscribe(ctx, &pb.SubscribeRequest{FromSeq: fromSeq})
+// + 1 (i.e. the next seq to resume at) and any error from Receive /
+// Apply. A clean stream end returns nil.
+func (p *Pump) subscribe(ctx context.Context, cli graphv1connect.LanternReplicationServiceClient, addr string, fromSeq uint64) (uint64, error) {
+	stream, err := cli.Subscribe(ctx, connect.NewRequest(&pb.SubscribeRequest{FromSeq: fromSeq}))
 	if err != nil {
 		return fromSeq, err
 	}
+	defer func() { _ = stream.Close() }()
 	next := fromSeq
-	for {
-		resp, err := stream.Recv()
-		if errors.Is(err, io.EOF) {
-			return next, nil
-		}
-		if err != nil {
-			return next, err
-		}
+	for stream.Receive() {
+		resp := stream.Msg()
 		mu := resp.GetMutation()
 		if mu == nil {
 			continue
@@ -394,17 +399,22 @@ func (p *Pump) subscribe(ctx context.Context, cli pb.LanternReplicationServiceCl
 		next = mu.GetSeq() + 1
 		p.tracker.recordEvent(addr, mu.GetSeq(), time.Now())
 	}
+	if err := stream.Err(); err != nil && !errors.Is(err, io.EOF) {
+		return next, err
+	}
+	return next, nil
 }
 
 // snapshot opens a Snapshot stream and replays every Header / Vertex
 // / Edge frame into the local cache via the SnapshotApplier seams.
 // Returns the cutoff_seq from the Header (the value the caller
 // should pass as fromSeq-1 on the subsequent Subscribe).
-func (p *Pump) snapshot(ctx context.Context, cli pb.LanternReplicationServiceClient, addr string) (uint64, error) {
-	stream, err := cli.Snapshot(ctx, &pb.SnapshotRequest{})
+func (p *Pump) snapshot(ctx context.Context, cli graphv1connect.LanternReplicationServiceClient, addr string) (uint64, error) {
+	stream, err := cli.Snapshot(ctx, connect.NewRequest(&pb.SnapshotRequest{}))
 	if err != nil {
 		return 0, err
 	}
+	defer func() { _ = stream.Close() }()
 	start := time.Now()
 	var (
 		cutoff       uint64
@@ -414,27 +424,21 @@ func (p *Pump) snapshot(ctx context.Context, cli pb.LanternReplicationServiceCli
 		sawFooter    bool
 		footerCounts struct{ v, e uint64 }
 	)
-	for {
-		resp, err := stream.Recv()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		if err != nil {
-			return cutoff, err
-		}
+	for stream.Receive() {
+		resp := stream.Msg()
 		switch e := resp.GetEntry().(type) {
 		case *pb.SnapshotResponse_Header:
 			if gotHeader {
-				return cutoff, status.Error(codes.Internal, "snapshot: duplicate header frame")
+				return cutoff, connect.NewError(connect.CodeInternal, errors.New("snapshot: duplicate header frame"))
 			}
 			cutoff = e.Header.GetCutoffSeq()
 			gotHeader = true
 		case *pb.SnapshotResponse_Vertex:
 			if !gotHeader {
-				return cutoff, status.Error(codes.Internal, "snapshot: vertex frame before header")
+				return cutoff, connect.NewError(connect.CodeInternal, errors.New("snapshot: vertex frame before header"))
 			}
 			if sawFooter {
-				return cutoff, status.Error(codes.Internal, "snapshot: vertex frame after footer")
+				return cutoff, connect.NewError(connect.CodeInternal, errors.New("snapshot: vertex frame after footer"))
 			}
 			sv := e.Vertex
 			v := sv.GetVertex()
@@ -447,10 +451,10 @@ func (p *Pump) snapshot(ctx context.Context, cli pb.LanternReplicationServiceCli
 			}
 		case *pb.SnapshotResponse_Edge:
 			if !gotHeader {
-				return cutoff, status.Error(codes.Internal, "snapshot: edge frame before header")
+				return cutoff, connect.NewError(connect.CodeInternal, errors.New("snapshot: edge frame before header"))
 			}
 			if sawFooter {
-				return cutoff, status.Error(codes.Internal, "snapshot: edge frame after footer")
+				return cutoff, connect.NewError(connect.CodeInternal, errors.New("snapshot: edge frame after footer"))
 			}
 			se := e.Edge
 			edgeHLC := snapshotHLC(se.GetHlc())
@@ -469,11 +473,14 @@ func (p *Pump) snapshot(ctx context.Context, cli pb.LanternReplicationServiceCli
 			footerCounts.e = e.Footer.GetEdgeCount()
 		}
 	}
+	if err := stream.Err(); err != nil && !errors.Is(err, io.EOF) {
+		return cutoff, err
+	}
 	if !gotHeader {
-		return cutoff, status.Error(codes.Internal, "snapshot: stream ended before header")
+		return cutoff, connect.NewError(connect.CodeInternal, errors.New("snapshot: stream ended before header"))
 	}
 	if !sawFooter {
-		return cutoff, status.Error(codes.Internal, "snapshot: stream ended before footer")
+		return cutoff, connect.NewError(connect.CodeInternal, errors.New("snapshot: stream ended before footer"))
 	}
 	if footerCounts.v != vertexCount || footerCounts.e != edgeCount {
 		// Count mismatch is a soft warning, not a hard error — the

--- a/tests/integration/antientropy_test.go
+++ b/tests/integration/antientropy_test.go
@@ -87,12 +87,15 @@ func TestAntiEntropy_DriverConvergesWithoutPump(t *testing.T) {
 
 	// Wire C's anti-entropy driver at B with a short tick interval.
 	// 50ms cadence keeps the test fast without thrashing the loopback.
+	// HTTPClient is left zero so the driver constructs its default
+	// h2c client (plaintext HTTP/2). The Connect-Go client is
+	// configured with connect.WithGRPC() internally so it talks to
+	// b's grpc.NewServer peer.
 	ae := replication.NewAntiEntropy(replication.AntiEntropyConfig{
 		NodeID:           c.nodeID,
 		Peers:            []string{b.addr},
 		Interval:         50 * time.Millisecond,
 		SubscribeTimeout: 2 * time.Second,
-		DialOptions:      []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
 	}, c.svc, c.svc, c.cache)
 	aeCtx, cancelAE := context.WithCancel(ctx)
 	done := make(chan struct{})


### PR DESCRIPTION
Closes #359.

## What

Migrates the server-internal replication clients — the peer Subscribe/Snapshot **pump** and the **anti-entropy** convergence driver — from `google.golang.org/grpc` to `connectrpc.com/connect`, using the generated `graphv1connect` client.

This is the last "client side" gap in the Connect-Go migration. After this PR, no production code path on the server side imports `google.golang.org/grpc` for client work; the only remaining gRPC client surface is the public Go SDK (kept additive in #338), and the only remaining gRPC server is the existing primary listener on \`:6380\` (cutover tracked separately in #347, which now depends on this PR).

## Wire compatibility

The new clients are constructed with \`connect.WithGRPC()\`, so they speak the **gRPC binary wire protocol over HTTP/2**. This keeps them compatible with:

- **Today's production peers**, which listen on \`grpc.NewServer()\` at \`:6380\` (the cutover to a Connect-only listener is the next PR, #347)
- **The Connect listener** on \`:6381\` shipped in #337 (Connect handlers accept gRPC, gRPC-Web, and Connect natively)

This intentionally preserves the existing high-throughput streaming framing (gRPC binary frames) over Subscribe/Snapshot rather than the JSON-friendly Connect framing.

## Config surface change

\`Config.DialOptions []grpc.DialOption\` and \`AntiEntropyConfig.DialOptions []grpc.DialOption\` are replaced by:

\`\`\`go
HTTPClient *http.Client
\`\`\`

When left nil, a shared \`defaultH2CClient()\` is used (plaintext HTTP/2 via \`x/net/http2.Transport\` with \`AllowHTTP=true\`). This preserves the in-cluster Tier-A topology's existing behavior — no TLS, no TLS plumbing.

Operators who need TLS supply their own \`http.Client\` backed by an \`http2.Transport\` with a real \`*tls.Config\`. The shared \`peerBaseURL(addr)\` helper accepts both \`"host:port"\` (prepends \`http://\`) and full \`http(s)://host:port\` URLs.

## Error handling

| Before | After |
| --- | --- |
| \`status.Code(err) == codes.FailedPrecondition\` | \`connect.CodeOf(err) == connect.CodeFailedPrecondition\` |
| \`status.Error(codes.Internal, msg)\` | \`connect.NewError(connect.CodeInternal, errors.New(msg))\` |
| \`stream.Recv() (msg, err); io.EOF sentinel\` | \`for stream.Receive() { msg := stream.Msg() }; stream.Err()\` |

## Tests

- \`tests/integration/antientropy_test.go\` drops its \`grpc.DialOption\` literal and lets the driver use the default h2c client. The test's peer server is still \`grpc.NewServer()\`, which works because the new client speaks gRPC over h2 via \`connect.WithGRPC()\`. This is the explicit cross-protocol scenario the migration must support.
- \`server/replication\` + \`tests/integration\` both pass under \`go test -race -count=1\`.

## Follow-ups

- **#347** (rescoped earlier in this thread) — primary listener cutover from gRPC to Connect on \`:6380\`. With this PR merged, that PR is unblocked.
- The \`connect.WithGRPC()\` option can stay indefinitely (Connect server accepts gRPC natively, and gRPC framing is more efficient than Connect framing for binary streaming). No follow-up needed there.