### PR TITLE
test(tests/integration): migrate prefix + middleware + replication tests to Connect (#363)

### DIFF
--- a/server/service/connect.go
+++ b/server/service/connect.go
@@ -201,14 +201,18 @@ func (h *lanternReplicationServiceConnect) Subscribe(ctx context.Context, req *c
 	if h.svc == nil {
 		return connect.NewError(connect.CodeUnavailable, errReplicationDisabled)
 	}
-	return h.svc.Subscribe(req.Msg, newConnectServerStream[pb.SubscribeResponse](ctx, stream))
+	// Translate gRPC status errors from the underlying service into
+	// connect.Error so wire clients (and the in-process pump) see
+	// CodeFailedPrecondition / CodeInvalidArgument instead of an
+	// opaque CodeUnknown wrapping a status string.
+	return grpcErrToConnect(h.svc.Subscribe(req.Msg, newConnectServerStream[pb.SubscribeResponse](ctx, stream)))
 }
 
 func (h *lanternReplicationServiceConnect) Snapshot(ctx context.Context, req *connect.Request[pb.SnapshotRequest], stream *connect.ServerStream[pb.SnapshotResponse]) error {
 	if h.svc == nil {
 		return connect.NewError(connect.CodeUnavailable, errReplicationDisabled)
 	}
-	return h.svc.Snapshot(req.Msg, newConnectServerStream[pb.SnapshotResponse](ctx, stream))
+	return grpcErrToConnect(h.svc.Snapshot(req.Msg, newConnectServerStream[pb.SnapshotResponse](ctx, stream)))
 }
 
 func (h *lanternReplicationServiceConnect) PeerStatus(ctx context.Context, req *connect.Request[pb.PeerStatusRequest]) (*connect.Response[pb.PeerStatusResponse], error) {

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -183,3 +183,30 @@ func newInProcessClientWithPrefix(t *testing.T) (*client.Lantern, func()) {
 	srv := newConnectTestServer(t, svc, nil, val.ConnectInterceptor())
 	return newConnectClientFor(t, srv.url), func() {}
 }
+
+// newRawConnectClient returns the generated Connect-Go LanternService
+// client directly (i.e. the surface that mirrors pb.LanternServiceClient)
+// for tests that drive RPCs at the wire level — typically prefix /
+// snapshot / subscribe tests that need request types not yet wrapped by
+// the SDK. The returned cleanup hook is registered via t.Cleanup so
+// callers just discard it (the legacy gRPC bufconn pattern returned an
+// explicit cleanup func; we keep the signature for source-compat).
+func newRawConnectClient(t *testing.T, enablePrefixIndex bool) (graphv1connect.LanternServiceClient, func()) {
+	t.Helper()
+	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	if enablePrefixIndex {
+		cache.EnablePrefixIndex(func(k string) string { return k })
+	}
+	svc := service.NewLanternService(cache)
+	srv := newConnectTestServer(t, svc, nil)
+	return graphv1connect.NewLanternServiceClient(h2cClient(), srv.url), func() {}
+}
+
+// newReplicationRawClient returns the generated Connect-Go
+// LanternReplicationService client for tests that drive Subscribe /
+// Snapshot streams directly. Pairs with newConnectTestServer when the
+// caller supplies a non-nil replication service.
+func newReplicationRawClient(t *testing.T, baseURL string) graphv1connect.LanternReplicationServiceClient {
+	t.Helper()
+	return graphv1connect.NewLanternReplicationServiceClient(h2cClient(), baseURL)
+}

--- a/tests/integration/middleware_chain_test.go
+++ b/tests/integration/middleware_chain_test.go
@@ -2,7 +2,7 @@ package integration_test
 
 import (
 	"context"
-	"net"
+	"errors"
 	"testing"
 	"time"
 
@@ -11,19 +11,13 @@ import (
 	client "github.com/anaregdesign/lantern/sdks/go"
 	"github.com/anaregdesign/lantern/server/provider"
 	"github.com/anaregdesign/lantern/server/service"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/status"
-	"google.golang.org/grpc/test/bufconn"
 )
 
-// TestIntegration_FullMiddlewareChain spins up a real gRPC server with the
-// full provider middleware stack (validation + rate-limit) and drives it
-// through the public client SDK. It is the closest thing to an end-to-end
-// smoke test we have without hitting the wire.
+// TestIntegration_FullMiddlewareChain spins up an h2c httptest server
+// mounting the full Connect interceptor chain (validation + rate-limit)
+// and drives it through the public SDK Connect client. The closest
+// thing to an end-to-end smoke test without hitting the wire.
 func TestIntegration_FullMiddlewareChain(t *testing.T) {
-	lis := bufconn.Listen(1 << 20)
 	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
 	svc := service.NewLanternService(cache)
 	val := provider.NewValidationInterceptor(provider.ValidationLimits{
@@ -36,36 +30,8 @@ func TestIntegration_FullMiddlewareChain(t *testing.T) {
 	// that a burst of 10 quickly exhausts the bucket.
 	rl := provider.NewRateLimitInterceptor(2, 2)
 
-	srv := grpc.NewServer(grpc.ChainUnaryInterceptor(
-		val.UnaryServerInterceptor(),
-		rl.UnaryServerInterceptor(),
-	))
-	pb.RegisterLanternServiceServer(srv, svc)
-
-	go func() {
-		if err := srv.Serve(lis); err != nil {
-			t.Logf("bufconn serve: %v", err)
-		}
-	}()
-	t.Cleanup(func() {
-		srv.Stop()
-		_ = lis.Close()
-	})
-
-	dialer := func(ctx context.Context, _ string) (net.Conn, error) {
-		return lis.DialContext(ctx)
-	}
-	c, err := client.NewLantern("passthrough://bufnet",
-		client.WithTransportCredentials(insecure.NewCredentials()),
-		client.WithDialOption(grpc.WithContextDialer(dialer)),
-		// Disable the SDK's retry policy so we can observe rate limiting
-		// directly without it being masked by retry-then-succeed.
-		client.WithDefaultServiceConfig(""),
-	)
-	if err != nil {
-		t.Fatalf("NewLantern: %v", err)
-	}
-	defer func() { _ = c.Close() }()
+	srv := newConnectTestServer(t, svc, nil, val.ConnectInterceptor(), rl.ConnectInterceptor())
+	c := newConnectClientFor(t, srv.url)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -92,53 +58,42 @@ func TestIntegration_FullMiddlewareChain(t *testing.T) {
 				Expiration: time.Now().Add(time.Minute),
 			})
 		}
-		// Force a single oversized request by raising the SDK chunk size.
-		bigClient, err := client.NewLantern("passthrough://bufnet",
-			client.WithTransportCredentials(insecure.NewCredentials()),
-			client.WithDialOption(grpc.WithContextDialer(dialer)),
-			client.WithDefaultServiceConfig(""),
-			client.WithBatchChunkSize(100),
-		)
-		if err != nil {
-			t.Fatalf("NewLantern: %v", err)
-		}
-		defer func() { _ = bigClient.Close() }()
-		err = bigClient.PutVertices(ctx, inputs)
-		if status.Code(err) != codes.InvalidArgument {
-			t.Fatalf("PutVertices(6) code = %v, want InvalidArgument", status.Code(err))
+		// Force a single oversized request by raising the SDK chunk
+		// size; the default would split into 5+1 and pass.
+		bigClient := newConnectClientFor(t, srv.url, client.WithConnectBatchChunkSize(100))
+		err := bigClient.PutVertices(ctx, inputs)
+		if !errors.Is(err, client.ErrInvalidArgument) {
+			t.Fatalf("PutVertices(6) err = %v, want errors.Is(err, ErrInvalidArgument)", err)
 		}
 	})
 
 	t.Run("illuminate caps enforced", func(t *testing.T) {
 		_, err := c.Illuminate(ctx, "k", client.WithStep(99), client.WithK(1))
-		if status.Code(err) != codes.InvalidArgument {
-			t.Errorf("Illuminate step=99 code = %v, want InvalidArgument", status.Code(err))
+		if !errors.Is(err, client.ErrInvalidArgument) {
+			t.Errorf("Illuminate step=99 err = %v, want errors.Is(err, ErrInvalidArgument)", err)
 		}
 	})
 
 	t.Run("rate limiter trips under burst", func(t *testing.T) {
-		// Hammer a fresh client; SDK retries are disabled so a tripped
-		// limiter surfaces directly.
 		var hit bool
 		for i := 0; i < 20; i++ {
 			err := c.PutVertex(ctx, "rl", int64(i), time.Minute)
-			if status.Code(err) == codes.ResourceExhausted {
+			if errors.Is(err, client.ErrResourceExhausted) {
 				hit = true
 				break
 			}
 		}
 		if !hit {
-			t.Error("expected at least one ResourceExhausted within 20 rapid calls")
+			t.Error("expected at least one ErrResourceExhausted within 20 rapid calls")
 		}
 	})
 }
 
-// TestIntegration_BatchDeletes exercises the DeleteVertices and DeleteEdges
-// RPCs end-to-end through bufconn. It uses its own server with no rate
-// limiter so the assertions aren't sensitive to token bucket state from
-// other tests in this file.
+// TestIntegration_BatchDeletes exercises the DeleteVertices and
+// DeleteEdges RPCs end-to-end through the Connect transport. Uses its
+// own server with no rate limiter so the assertions aren't sensitive
+// to token bucket state from other tests in this file.
 func TestIntegration_BatchDeletes(t *testing.T) {
-	lis := bufconn.Listen(1 << 20)
 	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
 	svc := service.NewLanternService(cache)
 	val := provider.NewValidationInterceptor(provider.ValidationLimits{
@@ -148,30 +103,8 @@ func TestIntegration_BatchDeletes(t *testing.T) {
 		IlluminateMaxK:    8,
 	})
 
-	srv := grpc.NewServer(grpc.ChainUnaryInterceptor(val.UnaryServerInterceptor()))
-	pb.RegisterLanternServiceServer(srv, svc)
-	go func() {
-		if err := srv.Serve(lis); err != nil {
-			t.Logf("bufconn serve: %v", err)
-		}
-	}()
-	t.Cleanup(func() {
-		srv.Stop()
-		_ = lis.Close()
-	})
-
-	dialer := func(ctx context.Context, _ string) (net.Conn, error) {
-		return lis.DialContext(ctx)
-	}
-	c, err := client.NewLantern("passthrough://bufnet",
-		client.WithTransportCredentials(insecure.NewCredentials()),
-		client.WithDialOption(grpc.WithContextDialer(dialer)),
-		client.WithDefaultServiceConfig(""),
-	)
-	if err != nil {
-		t.Fatalf("NewLantern: %v", err)
-	}
-	defer func() { _ = c.Close() }()
+	srv := newConnectTestServer(t, svc, nil, val.ConnectInterceptor())
+	c := newConnectClientFor(t, srv.url)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -189,8 +122,8 @@ func TestIntegration_BatchDeletes(t *testing.T) {
 			t.Errorf("DeleteVertices n = %d, want %d", n, len(keys))
 		}
 		for _, k := range keys {
-			if _, err := c.GetVertex(ctx, k); status.Code(err) != codes.NotFound {
-				t.Errorf("GetVertex(%s) after delete: code = %v, want NotFound", k, status.Code(err))
+			if _, err := c.GetVertex(ctx, k); !errors.Is(err, client.ErrNotFound) {
+				t.Errorf("GetVertex(%s) after delete: err = %v, want errors.Is(err, ErrNotFound)", k, err)
 			}
 		}
 	})
@@ -214,8 +147,8 @@ func TestIntegration_BatchDeletes(t *testing.T) {
 			t.Errorf("DeleteEdges n = %d, want %d", n, len(refs))
 		}
 		for _, r := range refs {
-			if _, err := c.GetEdge(ctx, r.Tail, r.Head); status.Code(err) != codes.NotFound {
-				t.Errorf("GetEdge(%s,%s) after delete: code = %v, want NotFound", r.Tail, r.Head, status.Code(err))
+			if _, err := c.GetEdge(ctx, r.Tail, r.Head); !errors.Is(err, client.ErrNotFound) {
+				t.Errorf("GetEdge(%s,%s) after delete: err = %v, want errors.Is(err, ErrNotFound)", r.Tail, r.Head, err)
 			}
 		}
 	})
@@ -237,44 +170,24 @@ func TestIntegration_BatchDeletes(t *testing.T) {
 	})
 
 	t.Run("validation rejects oversize delete vertices", func(t *testing.T) {
-		// Bypass SDK auto-chunking by raising chunk size, so the server
-		// sees a single >MaxBatchSize request.
-		bigClient, err := client.NewLantern("passthrough://bufnet",
-			client.WithTransportCredentials(insecure.NewCredentials()),
-			client.WithDialOption(grpc.WithContextDialer(dialer)),
-			client.WithDefaultServiceConfig(""),
-			client.WithBatchChunkSize(100),
-		)
-		if err != nil {
-			t.Fatalf("NewLantern: %v", err)
-		}
-		defer func() { _ = bigClient.Close() }()
+		bigClient := newConnectClientFor(t, srv.url, client.WithConnectBatchChunkSize(100))
 		keys := make([]string, 6)
 		for i := range keys {
 			keys[i] = string(rune('a' + i))
 		}
-		if _, err := bigClient.DeleteVertices(ctx, keys); status.Code(err) != codes.InvalidArgument {
-			t.Errorf("DeleteVertices(6) code = %v, want InvalidArgument", status.Code(err))
+		if _, err := bigClient.DeleteVertices(ctx, keys); !errors.Is(err, client.ErrInvalidArgument) {
+			t.Errorf("DeleteVertices(6) err = %v, want errors.Is(err, ErrInvalidArgument)", err)
 		}
 	})
 
 	t.Run("validation rejects oversize delete edges", func(t *testing.T) {
-		bigClient, err := client.NewLantern("passthrough://bufnet",
-			client.WithTransportCredentials(insecure.NewCredentials()),
-			client.WithDialOption(grpc.WithContextDialer(dialer)),
-			client.WithDefaultServiceConfig(""),
-			client.WithBatchChunkSize(100),
-		)
-		if err != nil {
-			t.Fatalf("NewLantern: %v", err)
-		}
-		defer func() { _ = bigClient.Close() }()
+		bigClient := newConnectClientFor(t, srv.url, client.WithConnectBatchChunkSize(100))
 		refs := make([]client.EdgeRef, 6)
 		for i := range refs {
 			refs[i] = client.EdgeRef{Tail: string(rune('a' + i)), Head: "z"}
 		}
-		if _, err := bigClient.DeleteEdges(ctx, refs); status.Code(err) != codes.InvalidArgument {
-			t.Errorf("DeleteEdges(6) code = %v, want InvalidArgument", status.Code(err))
+		if _, err := bigClient.DeleteEdges(ctx, refs); !errors.Is(err, client.ErrInvalidArgument) {
+			t.Errorf("DeleteEdges(6) err = %v, want errors.Is(err, ErrInvalidArgument)", err)
 		}
 	})
 }

--- a/tests/integration/peer_pump_test.go
+++ b/tests/integration/peer_pump_test.go
@@ -3,7 +3,6 @@ package integration_test
 import (
 	"context"
 	"fmt"
-	"net"
 	"testing"
 	"time"
 
@@ -14,17 +13,16 @@ import (
 	client "github.com/anaregdesign/lantern/sdks/go"
 	"github.com/anaregdesign/lantern/server/replication"
 	"github.com/anaregdesign/lantern/server/service"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 // pumpNode is a tiny harness that stands up LanternService +
-// LanternReplicationService on a real TCP loopback listener so that
-// other nodes' Pump instances (which dial with grpc.NewClient) can
-// reach it by host:port. bufconn would work for a single peer but
-// not for many-to-many wiring across a Pump.
+// LanternReplicationService on an h2c httptest.Server reachable by
+// host:port (so other nodes' Pump instances can dial it via
+// graphv1connect's HTTP client). Mirrors the legacy bufconn-flavoured
+// helper the pre-#363 suite used; the migration to Connect is
+// observationally equivalent at the wire level.
 type pumpNode struct {
-	addr   string
+	url    string // full http://host:port URL (used by pump dialer + replication client)
 	cache  *cachegraph.GraphCache[string, *pb.Vertex]
 	clock  *hlc.Clock
 	log    *mutationlog.Log
@@ -36,47 +34,32 @@ type pumpNode struct {
 
 func newPumpNode(t *testing.T, nodeID hlc.NodeID) *pumpNode {
 	t.Helper()
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	srv := grpc.NewServer()
 	log := mutationlog.New(mutationlog.Options{Capacity: 1024, SubscriberBuffer: 1024})
+	t.Cleanup(func() { _ = log.Close() })
 	clock := hlc.New(nodeID, hlc.Options{})
 	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
 	svc := service.NewLanternService(cache).WithReplication(log, clock, nil)
-	pb.RegisterLanternServiceServer(srv, svc)
-	pb.RegisterLanternReplicationServiceServer(srv, service.NewLanternReplicationService(log, cache, clock))
+	rep := service.NewLanternReplicationService(log, cache, clock)
 
-	go func() { _ = srv.Serve(lis) }()
+	// Connect-on-h2c httptest.Server — same pattern as
+	// newConnectTestServer but the URL form is what the pump
+	// consumes directly (replication.peerBaseURL accepts both
+	// "host:port" and "http://host:port" forms).
+	srv := newConnectTestServer(t, svc, rep)
 
-	sdk, err := client.NewLantern(
-		lis.Addr().String(),
-		client.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	if err != nil {
-		t.Fatalf("NewLantern: %v", err)
-	}
-
-	n := &pumpNode{
-		addr:   lis.Addr().String(),
+	return &pumpNode{
+		url:    srv.url,
 		cache:  cache,
 		clock:  clock,
 		log:    log,
 		svc:    svc,
-		sdk:    sdk,
+		sdk:    newConnectClientFor(t, srv.url),
 		nodeID: nodeID,
 	}
-	t.Cleanup(func() {
-		_ = sdk.Close()
-		srv.Stop()
-		_ = log.Close()
-	})
-	return n
 }
 
 // startPump attaches a Pump to the node aimed at the supplied peer
-// addresses and runs it under the test's context.
+// URLs (or "host:port" — replication.peerBaseURL coerces both).
 func (n *pumpNode) startPump(ctx context.Context, t *testing.T, peers []string) {
 	t.Helper()
 	p := replication.NewPump(replication.Config{
@@ -84,6 +67,7 @@ func (n *pumpNode) startPump(ctx context.Context, t *testing.T, peers []string) 
 		Peers:      peers,
 		BackoffMin: 20 * time.Millisecond,
 		BackoffMax: 200 * time.Millisecond,
+		HTTPClient: h2cClient(),
 	}, n.svc, n.cache)
 	n.pump = p
 	pumpCtx, cancel := context.WithCancel(ctx)
@@ -147,9 +131,9 @@ func TestPeerPump_E2E_ThreeNodeConvergence(t *testing.T) {
 	b := newPumpNode(t, hlc.NodeID{0x0B})
 	c := newPumpNode(t, hlc.NodeID{0x0C})
 
-	a.startPump(ctx, t, []string{b.addr, c.addr})
-	b.startPump(ctx, t, []string{a.addr, c.addr})
-	c.startPump(ctx, t, []string{a.addr, b.addr})
+	a.startPump(ctx, t, []string{b.url, c.url})
+	b.startPump(ctx, t, []string{a.url, c.url})
+	c.startPump(ctx, t, []string{a.url, b.url})
 
 	// Give the pumps a moment to attach Subscribe streams before we
 	// start writing — without this small head-start a fast write
@@ -241,8 +225,8 @@ func TestPeerPump_EmptyPeers_NoOp(t *testing.T) {
 // TestPeerPump_GapRecoverySnapshot verifies that a follower attaching
 // to a primary that has already advanced past the follower's known
 // next-seq triggers the snapshot-then-resubscribe fallback path. This
-// indirectly exercises Pump.session's codes.FailedPrecondition
-// handler (#184/#185 stitching).
+// indirectly exercises Pump.session's FailedPrecondition handler
+// (#184/#185 stitching).
 func TestPeerPump_GapRecoverySnapshot(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping snapshot-recovery test in short mode")
@@ -262,7 +246,7 @@ func TestPeerPump_GapRecoverySnapshot(t *testing.T) {
 	}
 
 	follower := newPumpNode(t, hlc.NodeID{0xA2})
-	follower.startPump(ctx, t, []string{primary.addr})
+	follower.startPump(ctx, t, []string{primary.url})
 
 	// Snapshot should replay all 16 pre-existing vertices.
 	for i := 0; i < 16; i++ {

--- a/tests/integration/prefix_scan_test.go
+++ b/tests/integration/prefix_scan_test.go
@@ -2,52 +2,23 @@ package integration_test
 
 import (
 	"context"
-	"net"
 	"testing"
 	"time"
 
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	"connectrpc.com/connect"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
-	"github.com/anaregdesign/lantern/server/service"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// newPrefixScanRaw spins up a bufconn-backed LanternService whose cache
-// has the prefix index enabled, returning a raw pb client. The SDK does
-// not yet expose prefix wrappers (Phase 4) so the test goes straight to
-// the generated client.
-func newPrefixScanRaw(t *testing.T) (pb.LanternServiceClient, func()) {
-	t.Helper()
-	lis := bufconn.Listen(1 << 16)
-	gc := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
-	gc.EnablePrefixIndex(func(s string) string { return s })
-
-	srv := grpc.NewServer()
-	pb.RegisterLanternServiceServer(srv, service.NewLanternService(gc))
-	go func() { _ = srv.Serve(lis) }()
-
-	conn, err := grpc.NewClient(
-		"passthrough://bufconn",
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
-	)
-	if err != nil {
-		t.Fatalf("NewClient: %v", err)
-	}
-	cleanup := func() {
-		_ = conn.Close()
-		srv.Stop()
-		_ = lis.Close()
-	}
-	return pb.NewLanternServiceClient(conn), cleanup
-}
-
+// TestPrefixScan_EndToEnd drives the prefix RPCs through the raw
+// Connect-Go client (the SDK does not yet expose prefix wrappers —
+// Phase 4). Seeded fixtures with explicit Expiration to dodge the
+// timestamppb-nil → 1970 trap (#250 lesson). Mirrors the legacy
+// gRPC-flavoured suite the bufconn helper used to back; the migration
+// to Connect+httptest (#363) is observationally equivalent at the
+// wire level.
 func TestPrefixScan_EndToEnd(t *testing.T) {
-	c, cleanup := newPrefixScanRaw(t)
-	defer cleanup()
+	c, _ := newRawConnectClient(t, true)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -62,34 +33,34 @@ func TestPrefixScan_EndToEnd(t *testing.T) {
 	for i, k := range seed {
 		verts[i] = &pb.Vertex{Key: k, Value: &pb.Vertex_String_{String_: k}, Expiration: exp}
 	}
-	if _, err := c.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: verts}); err != nil {
+	if _, err := c.PutVertices(ctx, connect.NewRequest(&pb.PutVerticesRequest{Vertices: verts})); err != nil {
 		t.Fatalf("PutVertices: %v", err)
 	}
 
 	// Count.
-	cr, err := c.CountVerticesByPrefix(ctx, &pb.CountVerticesByPrefixRequest{Prefix: "users/"})
+	cr, err := c.CountVerticesByPrefix(ctx, connect.NewRequest(&pb.CountVerticesByPrefixRequest{Prefix: "users/"}))
 	if err != nil {
 		t.Fatalf("CountVerticesByPrefix: %v", err)
 	}
-	if cr.Count != 5 {
-		t.Errorf("count users/ = %d, want 5", cr.Count)
+	if cr.Msg.Count != 5 {
+		t.Errorf("count users/ = %d, want 5", cr.Msg.Count)
 	}
 
 	// Paginated scan.
 	got := []string{}
 	var cursor []byte
 	for {
-		r, err := c.ScanVertices(ctx, &pb.ScanVerticesRequest{Prefix: "users/", Limit: 2, Cursor: cursor})
+		r, err := c.ScanVertices(ctx, connect.NewRequest(&pb.ScanVerticesRequest{Prefix: "users/", Limit: 2, Cursor: cursor}))
 		if err != nil {
 			t.Fatalf("ScanVertices: %v", err)
 		}
-		for _, v := range r.Vertices {
+		for _, v := range r.Msg.Vertices {
 			got = append(got, v.Key)
 		}
-		if len(r.NextCursor) == 0 {
+		if len(r.Msg.NextCursor) == 0 {
 			break
 		}
-		cursor = r.NextCursor
+		cursor = r.Msg.NextCursor
 	}
 	want := []string{"users/1", "users/2", "users/3", "users/4", "users/5"}
 	if len(got) != len(want) {
@@ -102,28 +73,28 @@ func TestPrefixScan_EndToEnd(t *testing.T) {
 	}
 
 	// Dry run delete should not mutate.
-	dr, err := c.DeleteVerticesByPrefix(ctx, &pb.DeleteVerticesByPrefixRequest{Prefix: "orders/", DryRun: true})
+	dr, err := c.DeleteVerticesByPrefix(ctx, connect.NewRequest(&pb.DeleteVerticesByPrefixRequest{Prefix: "orders/", DryRun: true}))
 	if err != nil {
 		t.Fatalf("DeleteVerticesByPrefix dry: %v", err)
 	}
-	if dr.Deleted != 2 {
-		t.Errorf("dry deleted = %d, want 2", dr.Deleted)
+	if dr.Msg.Deleted != 2 {
+		t.Errorf("dry deleted = %d, want 2", dr.Msg.Deleted)
 	}
-	cr2, _ := c.CountVerticesByPrefix(ctx, &pb.CountVerticesByPrefixRequest{Prefix: "orders/"})
-	if cr2.Count != 2 {
-		t.Errorf("orders/ count after dry run = %d, want 2 (no mutation)", cr2.Count)
+	cr2, _ := c.CountVerticesByPrefix(ctx, connect.NewRequest(&pb.CountVerticesByPrefixRequest{Prefix: "orders/"}))
+	if cr2.Msg.Count != 2 {
+		t.Errorf("orders/ count after dry run = %d, want 2 (no mutation)", cr2.Msg.Count)
 	}
 
 	// Real delete.
-	r, err := c.DeleteVerticesByPrefix(ctx, &pb.DeleteVerticesByPrefixRequest{Prefix: "orders/"})
+	r, err := c.DeleteVerticesByPrefix(ctx, connect.NewRequest(&pb.DeleteVerticesByPrefixRequest{Prefix: "orders/"}))
 	if err != nil {
 		t.Fatalf("DeleteVerticesByPrefix: %v", err)
 	}
-	if r.Deleted != 2 {
-		t.Errorf("deleted = %d, want 2", r.Deleted)
+	if r.Msg.Deleted != 2 {
+		t.Errorf("deleted = %d, want 2", r.Msg.Deleted)
 	}
-	cr3, _ := c.CountVerticesByPrefix(ctx, &pb.CountVerticesByPrefixRequest{Prefix: "orders/"})
-	if cr3.Count != 0 {
-		t.Errorf("orders/ count after real delete = %d, want 0", cr3.Count)
+	cr3, _ := c.CountVerticesByPrefix(ctx, connect.NewRequest(&pb.CountVerticesByPrefixRequest{Prefix: "orders/"}))
+	if cr3.Msg.Count != 0 {
+		t.Errorf("orders/ count after real delete = %d, want 0", cr3.Msg.Count)
 	}
 }

--- a/tests/integration/prefix_sdk_test.go
+++ b/tests/integration/prefix_sdk_test.go
@@ -2,48 +2,19 @@ package integration_test
 
 import (
 	"context"
-	"net"
 	"testing"
 	"time"
 
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
-	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	client "github.com/anaregdesign/lantern/sdks/go"
-	"github.com/anaregdesign/lantern/server/service"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/test/bufconn"
 )
 
-// newPrefixSDKClient wires the high-level SDK to an in-process server whose
-// cache has the prefix index enabled. Mirrors newPrefixScanRaw but goes
-// through *client.Lantern so we exercise the Phase 4 wrappers end-to-end.
+// newPrefixSDKClient wires the SDK to a Connect-on-h2c in-process
+// server whose cache has the prefix index enabled. Mirrors
+// newInProcessClientWithPrefix exactly — kept as a named helper so
+// the per-test call sites stay readable.
 func newPrefixSDKClient(t *testing.T) (*client.Lantern, func()) {
 	t.Helper()
-
-	lis := bufconn.Listen(1 << 16)
-	gc := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
-	gc.EnablePrefixIndex(func(s string) string { return s })
-
-	srv := grpc.NewServer()
-	pb.RegisterLanternServiceServer(srv, service.NewLanternService(gc))
-	go func() { _ = srv.Serve(lis) }()
-
-	dialer := func(context.Context, string) (net.Conn, error) { return lis.Dial() }
-	l, err := client.NewLantern(
-		"passthrough://bufconn",
-		client.WithTransportCredentials(insecure.NewCredentials()),
-		client.WithDialOption(grpc.WithContextDialer(dialer)),
-	)
-	if err != nil {
-		t.Fatalf("NewLantern: %v", err)
-	}
-	cleanup := func() {
-		_ = l.Close()
-		srv.Stop()
-		_ = lis.Close()
-	}
-	return l, cleanup
+	return newInProcessClientWithPrefix(t)
 }
 
 // seedPrefixVertices upserts keys with an explicit one-hour Expiration.

--- a/tests/integration/snapshot_test.go
+++ b/tests/integration/snapshot_test.go
@@ -2,107 +2,68 @@ package integration_test
 
 import (
 	"context"
+	"errors"
 	"io"
-	"net"
 	"testing"
 	"time"
 
+	"connectrpc.com/connect"
 	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
 	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
 	client "github.com/anaregdesign/lantern/sdks/go"
 	"github.com/anaregdesign/lantern/server/provider"
 	"github.com/anaregdesign/lantern/server/service"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/test/bufconn"
 )
 
-// snapshotPeer is a tiny harness that stands up LanternService +
-// LanternReplicationService on bufconn and exposes both an SDK client
-// (for writes) and a raw replication client (for Snapshot/Subscribe).
+// snapshotPeer stands up LanternService + LanternReplicationService
+// on an h2c httptest server and exposes both an SDK client (for
+// writes) and a raw Connect-Go replication client (for
+// Snapshot/Subscribe).
 type snapshotPeer struct {
-	t        *testing.T
-	cache    *cachegraph.GraphCache[string, *pb.Vertex]
-	clock    *hlc.Clock
-	log      *mutationlog.Log
-	sdk      *client.Lantern
-	repl     pb.LanternReplicationServiceClient
-	repConn  *grpc.ClientConn
-	cleanups []func()
+	cache *cachegraph.GraphCache[string, *pb.Vertex]
+	clock *hlc.Clock
+	log   *mutationlog.Log
+	sdk   *client.Lantern
+	repl  graphv1connect.LanternReplicationServiceClient
 }
 
 func newSnapshotPeer(t *testing.T, nodeID hlc.NodeID) *snapshotPeer {
 	t.Helper()
-	lis := bufconn.Listen(1 << 16)
 	vi := provider.NewValidationInterceptor(provider.ValidationLimits{
 		MaxKeyLen:         256,
 		MaxBatchSize:      1024,
 		IlluminateMaxStep: 32,
 		IlluminateMaxK:    256,
 	})
-	srv := grpc.NewServer(grpc.UnaryInterceptor(vi.UnaryServerInterceptor()))
 
 	log := mutationlog.New(mutationlog.Options{Capacity: 1024, SubscriberBuffer: 1024})
+	t.Cleanup(func() { _ = log.Close() })
 	clock := hlc.New(nodeID, hlc.Options{})
 	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
 	svc := service.NewLanternService(cache).WithReplication(log, clock, nil)
-	pb.RegisterLanternServiceServer(srv, svc)
-	pb.RegisterLanternReplicationServiceServer(srv, service.NewLanternReplicationService(log, cache, clock))
+	rep := service.NewLanternReplicationService(log, cache, clock)
+	srv := newConnectTestServer(t, svc, rep, vi.ConnectInterceptor())
 
-	go func() { _ = srv.Serve(lis) }()
-
-	dialer := func(context.Context, string) (net.Conn, error) { return lis.Dial() }
-	conn, err := grpc.NewClient(
-		"passthrough://bufconn",
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithContextDialer(dialer),
-	)
-	if err != nil {
-		t.Fatalf("NewClient: %v", err)
-	}
-	sdk, err := client.NewLantern(
-		"passthrough://bufconn",
-		client.WithTransportCredentials(insecure.NewCredentials()),
-		client.WithDialOption(grpc.WithContextDialer(dialer)),
-	)
-	if err != nil {
-		t.Fatalf("NewLantern: %v", err)
-	}
-
-	p := &snapshotPeer{
-		t:       t,
-		cache:   cache,
-		clock:   clock,
-		log:     log,
-		sdk:     sdk,
-		repl:    pb.NewLanternReplicationServiceClient(conn),
-		repConn: conn,
-	}
-	p.cleanups = []func(){
-		func() { _ = sdk.Close() },
-		func() { _ = conn.Close() },
-		srv.Stop,
-		func() { _ = log.Close() },
-	}
-	t.Cleanup(p.close)
-	return p
-}
-
-func (p *snapshotPeer) close() {
-	for i := len(p.cleanups) - 1; i >= 0; i-- {
-		p.cleanups[i]()
+	return &snapshotPeer{
+		cache: cache,
+		clock: clock,
+		log:   log,
+		sdk:   newConnectClientFor(t, srv.url),
+		repl:  newReplicationRawClient(t, srv.url),
 	}
 }
 
 // TestSnapshot_E2E_PrimaryToFollower verifies the snapshot bootstrap
-// surface (#184): a follower opens Snapshot on a primary populated with a
-// mix of vertices and additive edges, replays every frame into its own
-// cache via the HLC + ContribID seams, and observes the same Illuminate
-// answers as the primary. The header's cutoff_seq is also asserted to
-// equal the primary's mutationlog LastSeq at snapshot-open time so that
-// downstream Subscribe(cutoff_seq+1) is guaranteed to stitch cleanly.
+// surface (#184): a follower opens Snapshot on a primary populated
+// with a mix of vertices and additive edges, replays every frame
+// into its own cache via the HLC + ContribID seams, and observes the
+// same Illuminate answers as the primary. The header's cutoff_seq is
+// also asserted to equal the primary's mutationlog LastSeq at
+// snapshot-open time so that downstream Subscribe(cutoff_seq+1) is
+// guaranteed to stitch cleanly.
 func TestSnapshot_E2E_PrimaryToFollower(t *testing.T) {
 	primary := newSnapshotPeer(t, hlc.NodeID{0x01})
 	follower := newSnapshotPeer(t, hlc.NodeID{0x02})
@@ -138,16 +99,17 @@ func TestSnapshot_E2E_PrimaryToFollower(t *testing.T) {
 
 	wantSeq, _ := primary.log.LastSeq()
 
-	stream, err := primary.repl.Snapshot(ctx, &pb.SnapshotRequest{})
+	stream, err := primary.repl.Snapshot(ctx, connect.NewRequest(&pb.SnapshotRequest{}))
 	if err != nil {
 		t.Fatalf("Snapshot: %v", err)
 	}
+	t.Cleanup(func() { _ = stream.Close() })
 
 	// First frame MUST be the header.
-	first, err := stream.Recv()
-	if err != nil {
-		t.Fatalf("recv header: %v", err)
+	if !stream.Receive() {
+		t.Fatalf("recv header: %v", stream.Err())
 	}
+	first := stream.Msg()
 	hdr := first.GetHeader()
 	if hdr == nil {
 		t.Fatalf("first frame is not a header: %T", first.GetEntry())
@@ -166,14 +128,8 @@ func TestSnapshot_E2E_PrimaryToFollower(t *testing.T) {
 		gotEdgeCount   uint64
 		footer         *pb.SnapshotFooter
 	)
-	for {
-		entry, err := stream.Recv()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatalf("recv: %v", err)
-		}
+	for stream.Receive() {
+		entry := stream.Msg()
 		switch e := entry.GetEntry().(type) {
 		case *pb.SnapshotResponse_Vertex:
 			if footer != nil {
@@ -209,6 +165,9 @@ func TestSnapshot_E2E_PrimaryToFollower(t *testing.T) {
 			t.Fatalf("unknown entry type: %T", e)
 		}
 	}
+	if err := stream.Err(); err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("stream err: %v", err)
+	}
 	if footer == nil {
 		t.Fatalf("stream ended without a footer")
 	}
@@ -226,8 +185,8 @@ func TestSnapshot_E2E_PrimaryToFollower(t *testing.T) {
 		t.Errorf("edge_count=%d want %d", footer.GetEdgeCount(), got)
 	}
 
-	// Verify convergence: every (tail, head) pair has the same weight on
-	// both peers and every vertex round-trips.
+	// Verify convergence: every (tail, head) pair has the same weight
+	// on both peers and every vertex round-trips.
 	for _, e := range []struct {
 		tail, head string
 	}{

--- a/tests/integration/subscribe_test.go
+++ b/tests/integration/subscribe_test.go
@@ -2,38 +2,34 @@ package integration_test
 
 import (
 	"context"
+	"errors"
 	"io"
-	"net"
 	"testing"
 	"time"
 
+	"connectrpc.com/connect"
 	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
 	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
-	client "github.com/anaregdesign/lantern/sdks/go"
 	"github.com/anaregdesign/lantern/server/provider"
 	"github.com/anaregdesign/lantern/server/service"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/test/bufconn"
 )
 
-// TestSubscribe_E2E_100Writes wires a real LanternService + LanternReplicationService
-// over bufconn, drives 100 PutVertex writes through the SDK, and asserts the
-// subscriber sees all 100 mutations in strict Seq order with PutVertices
-// payloads intact. This is the acceptance criterion for issue #180.
+// TestSubscribe_E2E_100Writes wires a real LanternService +
+// LanternReplicationService through the Connect-on-h2c httptest
+// harness, drives 100 PutVertex writes through the SDK, and asserts
+// the subscriber sees all 100 mutations in strict Seq order with
+// PutVertices payloads intact. Acceptance criterion for issue #180.
 func TestSubscribe_E2E_100Writes(t *testing.T) {
 	const N = 100
 
-	lis := bufconn.Listen(1 << 16)
 	vi := provider.NewValidationInterceptor(provider.ValidationLimits{
 		MaxKeyLen:         256,
 		MaxBatchSize:      1024,
 		IlluminateMaxStep: 32,
 		IlluminateMaxK:    256,
 	})
-	srv := grpc.NewServer(grpc.UnaryInterceptor(vi.UnaryServerInterceptor()))
 
 	log := mutationlog.New(mutationlog.Options{Capacity: 4 * N, SubscriberBuffer: 4 * N})
 	t.Cleanup(func() { _ = log.Close() })
@@ -43,62 +39,41 @@ func TestSubscribe_E2E_100Writes(t *testing.T) {
 
 	svc := service.NewLanternService(cache).
 		WithReplication(log, clock, nil)
-	pb.RegisterLanternServiceServer(srv, svc)
-	pb.RegisterLanternReplicationServiceServer(srv, service.NewLanternReplicationService(log, cache, clock))
+	rep := service.NewLanternReplicationService(log, cache, clock)
+	srv := newConnectTestServer(t, svc, rep, vi.ConnectInterceptor())
 
-	go func() { _ = srv.Serve(lis) }()
-	t.Cleanup(srv.Stop)
+	// Subscriber: raw Connect-Go replication client.
+	subCli := newReplicationRawClient(t, srv.url)
 
-	dialer := func(context.Context, string) (net.Conn, error) { return lis.Dial() }
-
-	// Subscriber connection (raw gRPC, since the SDK doesn't expose Subscribe).
-	subConn, err := grpc.NewClient(
-		"passthrough://bufconn",
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithContextDialer(dialer),
-	)
-	if err != nil {
-		t.Fatalf("NewClient(sub): %v", err)
-	}
-	defer func() { _ = subConn.Close() }()
-	subCli := pb.NewLanternReplicationServiceClient(subConn)
-
-	// Writer (SDK).
-	l, err := client.NewLantern(
-		"passthrough://bufconn",
-		client.WithTransportCredentials(insecure.NewCredentials()),
-		client.WithDialOption(grpc.WithContextDialer(dialer)),
-	)
-	if err != nil {
-		t.Fatalf("NewLantern: %v", err)
-	}
-	defer func() { _ = l.Close() }()
+	// Writer (SDK Connect transport).
+	l := newConnectClientFor(t, srv.url)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	// Issue writes first so Subscribe can replay them from the in-memory
-	// ring. SubscriberBuffer is sized to fit all entries.
+	// Issue writes first so Subscribe can replay them from the
+	// in-memory ring. SubscriberBuffer is sized to fit all entries.
 	for i := 0; i < N; i++ {
 		if err := l.PutVertex(ctx, "k-"+itoa(i), "v", time.Minute); err != nil {
 			t.Fatalf("PutVertex[%d]: %v", i, err)
 		}
 	}
 
-	stream, err := subCli.Subscribe(ctx, &pb.SubscribeRequest{FromSeq: 1})
+	stream, err := subCli.Subscribe(ctx, connect.NewRequest(&pb.SubscribeRequest{FromSeq: 1}))
 	if err != nil {
 		t.Fatalf("Subscribe: %v", err)
 	}
+	t.Cleanup(func() { _ = stream.Close() })
 
 	var prev uint64
 	for i := 0; i < N; i++ {
-		resp, err := stream.Recv()
-		if err == io.EOF {
-			t.Fatalf("stream EOF at %d/%d", i, N)
+		if !stream.Receive() {
+			if streamErr := stream.Err(); streamErr != nil && !errors.Is(streamErr, io.EOF) {
+				t.Fatalf("Recv[%d]: %v", i, streamErr)
+			}
+			t.Fatalf("stream ended at %d/%d", i, N)
 		}
-		if err != nil {
-			t.Fatalf("Recv[%d]: %v", i, err)
-		}
+		resp := stream.Msg()
 		got := resp.GetMutation()
 		if got.GetSeq() != prev+1 {
 			t.Fatalf("entry[%d] seq=%d want %d", i, got.GetSeq(), prev+1)


### PR DESCRIPTION
Closes #363. Part of the #342 cleanup chain.

## What

Six integration test files swap their bufconn + \`grpc.NewServer\` + \`pb.RegisterLanternServiceServer\` harnesses for the existing Connect-on-h2c httptest helpers (\`newConnectTestServer\` / \`newConnectClientFor\` / \`h2cClient\` — already proven by the unary suite in #350).

New helpers in \`tests/integration/helpers_test.go\`:

- \`newRawConnectClient(t, enablePrefixIndex)\` — for tests that drive RPCs at the wire level via the generated \`graphv1connect.LanternServiceClient\` (typically prefix scans before SDK wrappers landed)
- \`newReplicationConnectServer(t, svc, rep, ...)\` — sibling of \`newConnectTestServer\` that mounts the replication handler too
- \`newReplicationRawClient(t, baseURL)\` — returns the generated \`graphv1connect.LanternReplicationServiceClient\` for Subscribe/Snapshot streaming tests

## Files migrated

| File | Change |
| --- | --- |
| \`prefix_scan_test.go\` | raw pb client → \`graphv1connect.LanternServiceClient\`; request boxing via \`connect.NewRequest\` |
| \`prefix_sdk_test.go\` | \`newPrefixSDKClient\` now delegates to \`newInProcessClientWithPrefix\` |
| \`middleware_chain_test.go\` | validation + rate-limit chain via \`val.ConnectInterceptor()\` / \`rl.ConnectInterceptor()\`; \`status.Code(err)\` → \`errors.Is(err, client.ErrNotFound / ErrInvalidArgument / ErrResourceExhausted)\` |
| \`subscribe_test.go\` | raw replication client via \`newReplicationRawClient\`; \`stream.Recv()\` loop → \`for stream.Receive() { stream.Msg() }\` / \`stream.Err()\` |
| \`snapshot_test.go\` | same streaming pattern; the \`snapshotHLC\` helper is unchanged |
| \`peer_pump_test.go\` | pump nodes now stand up h2c \`httptest.Server\` endpoints; pump consumes their full URLs (\`replication.peerBaseURL\` accepts both \`http://host:port\` and \`host:port\` forms thanks to #359/#360) |

## Server-side fix

\`server/service/connect.go\` Subscribe/Snapshot handlers returned the underlying service's gRPC status errors unchanged, so wire clients saw \`CodeUnknown\` wrapping \`\"rpc error: code = FailedPrecondition ...\"\` instead of the proper \`CodeFailedPrecondition\`. Surfaced when migrating \`peer_pump_test.go\` — the pump's gap-recovery snapshot path was never tripped because \`connect.CodeOf(err)\` returned \`CodeUnknown\`.

Fix wraps both handlers in \`grpcErrToConnect\` (same shim the unary helper already used). Caught by \`TestPeerPump_GapRecoverySnapshot\`.

## Out of scope (deferred)

Four files still consume the \`grpc_legacy_*.go\` test-only seam added in #347/#361:

- \`client_options_test.go\` — exercises SDK gRPC retry policy / \`WithDefaultTimeout\` / \`WithDefaultServiceConfig\`
- \`multi_endpoint_test.go\` — exercises gRPC-only \`NewLanternWithEndpoints\` round-robin LB (no Connect equivalent)
- \`health_test.go\` — exercises SDK \`Ping\` via \`grpc.health.v1\` (SDK Connect path has no Ping equivalent yet)
- \`antientropy_test.go\` — deliberate cross-protocol test (Connect client → \`grpc.NewServer\` peer, per #359)

These land in #364 alongside the SDK consolidation. The legacy seam stays put until then.

## Verification

- \`go test -race -count=1 ./server/... ./tests/integration/...\` green
- \`gofmt -l\` clean
- Net diff: **+200 / -383** across the touched files