### PR TITLE
feat(admin): Ops view with server status + replication cards (#322)

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -11,7 +11,7 @@ the Go workspace (`go.work`). The TypeScript toolchain is [Bun](https://bun.sh/)
 ## Requirements
 
 - [Bun](https://bun.sh/) `1.3.14+` (the version pinned in `package.json`).
-- A running Lantern gateway (defaults to `http://localhost:6381`) with CORS
+- A running Lantern server (defaults to `http://localhost:6380`) with CORS
   configured to allow the admin origin — see
   `LANTERN_CORS_ALLOWED_ORIGINS` in [`server/README.md`](../server/README.md).
 

--- a/admin/app/components/ops/OpsPage/OpsPage.module.css
+++ b/admin/app/components/ops/OpsPage/OpsPage.module.css
@@ -1,0 +1,113 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.lead {
+  margin: 0.25rem 0 0 0;
+  color: var(--colorNeutralForeground3);
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+}
+
+@media (min-width: 960px) {
+  .cards {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.25rem;
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.cardLead {
+  margin: 0;
+  color: var(--colorNeutralForeground3);
+  font-size: 0.9rem;
+}
+
+.definitionList {
+  display: grid;
+  grid-template-columns: minmax(140px, max-content) 1fr;
+  gap: 0.4rem 1rem;
+  margin: 0;
+}
+
+.definitionList dt {
+  color: var(--colorNeutralForeground3);
+  font-weight: 500;
+}
+
+.definitionList dd {
+  margin: 0;
+  font-family: var(--fontFamilyMonospace, monospace);
+  word-break: break-word;
+}
+
+.peerTable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.peerTable th,
+.peerTable td {
+  text-align: left;
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid var(--colorNeutralStroke2);
+  font-family: var(--fontFamilyMonospace, monospace);
+}
+
+.peerTable th {
+  font-family: var(--fontFamilyBase);
+  color: var(--colorNeutralForeground3);
+  font-weight: 600;
+}
+
+.peerErrorRow {
+  color: var(--colorPaletteRedForeground1);
+  font-size: 0.85rem;
+}
+
+.empty {
+  color: var(--colorNeutralForeground3);
+  font-style: italic;
+}

--- a/admin/app/components/ops/OpsPage/OpsPage.tsx
+++ b/admin/app/components/ops/OpsPage/OpsPage.tsx
@@ -1,0 +1,234 @@
+import {
+  Badge,
+  Button,
+  Card,
+  MessageBar,
+  MessageBarBody,
+  Spinner,
+  Switch,
+} from "@fluentui/react-components";
+import { ArrowClockwise20Regular } from "@fluentui/react-icons";
+
+import {
+  peerStatePillIntent,
+  replicationCardSummary,
+  serverCardSummary,
+  formatStaleness,
+  formatCount,
+} from "~/lib/client/usecase/ops/selectors";
+import { DEFAULT_POLL_MS } from "~/lib/client/usecase/ops/state";
+import { useOps } from "~/lib/client/usecase/ops/use-ops";
+import styles from "./OpsPage.module.css";
+
+/**
+ * OpsPage is the single-route dashboard #322 ships: a server-status
+ * card (S1) + a replication card (S2) polled in parallel. The S3
+ * grpc-health-v1 card promised by the original spec is deferred —
+ * Connect-Web cannot call the gRPC-Health-v1 surface without a
+ * dedicated codegen pass, and GetServerStatus already covers the
+ * "is the server alive" signal callers need for triage. A follow-up
+ * Issue will land the dedicated health card once the grpchealth
+ * codegen is in place.
+ */
+export function OpsPage() {
+  const ops = useOps();
+  const pollingOn = ops.state.pollMs > 0;
+  const onPollToggle = (_: unknown, data: { checked: boolean }) => {
+    ops.setPollMs(data.checked ? DEFAULT_POLL_MS : 0);
+  };
+  return (
+    <div className={styles.root}>
+      <header className={styles.header}>
+        <div>
+          <h1 className={styles.title}>Ops</h1>
+          <p className={styles.lead}>
+            Server status and replication health, polled every{" "}
+            {Math.round(DEFAULT_POLL_MS / 1000)}s.
+          </p>
+        </div>
+        <div className={styles.toolbar}>
+          <Switch
+            label={pollingOn ? "Auto-poll on" : "Auto-poll off"}
+            checked={pollingOn}
+            onChange={onPollToggle}
+            data-testid="ops-poll-toggle"
+          />
+          <Button
+            icon={<ArrowClockwise20Regular />}
+            onClick={ops.refresh}
+            data-testid="ops-refresh"
+          >
+            Refresh
+          </Button>
+        </div>
+      </header>
+      <section className={styles.cards}>
+        <ServerCard
+          status={ops.state.server.status}
+          data={ops.state.server.data}
+          error={ops.state.server.error}
+        />
+        <ReplicationCard
+          status={ops.state.replication.status}
+          data={ops.state.replication.data}
+          error={ops.state.replication.error}
+        />
+      </section>
+    </div>
+  );
+}
+
+interface ServerCardProps {
+  status: "idle" | "loading" | "ready" | "error";
+  data: ReturnType<typeof useOps>["state"]["server"]["data"];
+  error: string | null;
+}
+
+function ServerCard({ status, data, error }: ServerCardProps) {
+  return (
+    <Card className={styles.card} data-testid="ops-server-card">
+      <h2 className={styles.cardTitle}>Server status</h2>
+      <p className={styles.cardLead}>
+        From <code>GetServerStatus</code>. Vertex / edge counts are sampled and
+        approximate.
+      </p>
+      {status === "loading" && <Spinner size="tiny" label="Loading…" />}
+      {status === "error" && error && (
+        <MessageBar intent="error" data-testid="ops-server-error">
+          <MessageBarBody>GetServerStatus failed: {error}</MessageBarBody>
+        </MessageBar>
+      )}
+      {status === "ready" && data && (
+        <dl className={styles.definitionList}>
+          {serverCardSummary(data).map(([label, value]) => (
+            <ServerRow key={label} label={label} value={value} />
+          ))}
+        </dl>
+      )}
+    </Card>
+  );
+}
+
+function ServerRow({ label, value }: { label: string; value: string }) {
+  return (
+    <>
+      <dt>{label}</dt>
+      <dd>{value}</dd>
+    </>
+  );
+}
+
+interface ReplicationCardProps {
+  status: "idle" | "loading" | "ready" | "error";
+  data: ReturnType<typeof useOps>["state"]["replication"]["data"];
+  error: string | null;
+}
+
+function ReplicationCard({ status, data, error }: ReplicationCardProps) {
+  return (
+    <Card className={styles.card} data-testid="ops-replication-card">
+      <h2 className={styles.cardTitle}>Replication</h2>
+      <p className={styles.cardLead}>
+        From <code>GetReplicationStatus</code>. Empty state on single-instance
+        deployments.
+      </p>
+      {status === "loading" && <Spinner size="tiny" label="Loading…" />}
+      {status === "error" && error && (
+        <MessageBar intent="error" data-testid="ops-replication-error">
+          <MessageBarBody>GetReplicationStatus failed: {error}</MessageBarBody>
+        </MessageBar>
+      )}
+      {status === "ready" && data && (
+        <>
+          <dl className={styles.definitionList}>
+            {replicationCardSummary(data).map(([label, value]) => (
+              <ServerRow key={label} label={label} value={value} />
+            ))}
+          </dl>
+          {data.enabled ? (
+            data.peers.length > 0 ? (
+              <table className={styles.peerTable} data-testid="ops-peer-table">
+                <thead>
+                  <tr>
+                    <th>Peer</th>
+                    <th>State</th>
+                    <th>Last event</th>
+                    <th>Applied seq</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.peers.map((p) => (
+                    <PeerRows key={p.address} peer={p} />
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <p className={styles.empty} data-testid="ops-peer-empty">
+                Replication enabled, but no peers have reported yet.
+              </p>
+            )
+          ) : (
+            <p className={styles.empty} data-testid="ops-replication-disabled">
+              Single-instance deployment — set <code>LANTERN_PEERS</code> to
+              wire replication. See the{" "}
+              <a
+                href="https://github.com/anaregdesign/lantern/blob/main/docs/ha-runbook.md"
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                HA runbook
+              </a>
+              .
+            </p>
+          )}
+        </>
+      )}
+    </Card>
+  );
+}
+
+function PeerRows({
+  peer,
+}: {
+  peer: NonNullable<
+    ReturnType<typeof useOps>["state"]["replication"]["data"]
+  >["peers"][number];
+}) {
+  return (
+    <>
+      <tr>
+        <td>{peer.address}</td>
+        <td>
+          <Badge appearance="filled" color={badgeColor(peer.state)}>
+            {peer.state}
+          </Badge>
+        </td>
+        <td>{formatStaleness(peer.stalenessMs)}</td>
+        <td>{formatCount(peer.appliedSeq)}</td>
+      </tr>
+      {peer.error && (
+        <tr>
+          <td colSpan={4} className={styles.peerErrorRow}>
+            ↪ {peer.error}
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function badgeColor(
+  state: string,
+): "success" | "warning" | "danger" | "informative" {
+  const intent = peerStatePillIntent(state as never);
+  switch (intent) {
+    case "success":
+      return "success";
+    case "warning":
+      return "warning";
+    case "error":
+      return "danger";
+    case "info":
+      return "informative";
+  }
+}

--- a/admin/app/components/shared/ConnectionSwitcher/ConnectionSwitcher.tsx
+++ b/admin/app/components/shared/ConnectionSwitcher/ConnectionSwitcher.tsx
@@ -33,7 +33,7 @@ export function ConnectionSwitcher() {
   const onSave = () => {
     const ok = setBaseUrl(draft);
     if (!ok) {
-      setError("Enter an http(s) URL like http://localhost:6381");
+      setError("Enter an http(s) URL like http://localhost:6380");
       return;
     }
     setOpen(false);

--- a/admin/app/lib/client/infrastructure/api/get-replication-status.ts
+++ b/admin/app/lib/client/infrastructure/api/get-replication-status.ts
@@ -1,0 +1,111 @@
+import { ReplicationPeer_State } from "~/lib/api/gen/graph/v1/graph_pb";
+import type { LanternClient } from "./lantern-client";
+import { LanternApiError } from "./error";
+
+/**
+ * ReplicationPeerState is the JSON-friendly state label the Ops view
+ * displays as a pill colour. Mirrors graph.v1.ReplicationPeer.State but
+ * collapses the proto enum to a lowercase string so React state stays
+ * primitive.
+ */
+export type ReplicationPeerState =
+  | "unspecified"
+  | "connecting"
+  | "streaming"
+  | "backoff"
+  | "closed";
+
+/**
+ * ReplicationPeerRow is the per-peer row the table renders. address
+ * doubles as the React list key.
+ */
+export interface ReplicationPeerRow {
+  address: string;
+  state: ReplicationPeerState;
+  /** epoch milliseconds; 0 when last_event_at was unset. */
+  lastEventAtMs: number;
+  /** how many ms have elapsed since lastEventAtMs, server-relative. */
+  stalenessMs: number;
+  appliedSeq: number;
+  /** non-empty when the last per-peer session loop hit a non-recoverable error. */
+  error: string;
+}
+
+/**
+ * ReplicationStatus is the JSON-flat view of GetReplicationStatusResponse.
+ * Single-instance deployments (LANTERN_PEERS unset) report enabled=false
+ * with an empty peers slice; the Ops view should render an empty-state
+ * card in that branch.
+ */
+export interface ReplicationStatus {
+  nodeId: string;
+  /** epoch milliseconds; 0 when local_now was unset. */
+  localNowMs: number;
+  enabled: boolean;
+  peers: ReplicationPeerRow[];
+}
+
+/**
+ * Calls LanternService.GetReplicationStatus and normalises the response
+ * into the flat ReplicationStatus shape used by the Ops view.
+ */
+export async function getReplicationStatus(
+  client: LanternClient,
+  init?: { signal?: AbortSignal },
+): Promise<ReplicationStatus> {
+  try {
+    const resp = await client.getReplicationStatus(
+      {},
+      { signal: init?.signal },
+    );
+    const localNowMs = resp.localNow
+      ? Number(resp.localNow.seconds) * 1000 +
+        Math.floor(resp.localNow.nanos / 1_000_000)
+      : 0;
+    const peers: ReplicationPeerRow[] = resp.peers
+      .map((p) => {
+        const lastEventAtMs = p.lastEventAt
+          ? Number(p.lastEventAt.seconds) * 1000 +
+            Math.floor(p.lastEventAt.nanos / 1_000_000)
+          : 0;
+        return {
+          address: p.address,
+          state: stateLabel(p.state),
+          lastEventAtMs,
+          stalenessMs:
+            lastEventAtMs > 0 && localNowMs > 0
+              ? Math.max(0, localNowMs - lastEventAtMs)
+              : 0,
+          appliedSeq: Number(p.appliedSeq),
+          error: p.error,
+        };
+      })
+      // The wire-level slice ordering is intentionally unspecified
+      // (per the proto comment). Sorting by address gives a stable
+      // visual ordering across re-fetches.
+      .sort((a, b) => a.address.localeCompare(b.address));
+    return {
+      nodeId: resp.nodeId,
+      localNowMs,
+      enabled: resp.enabled,
+      peers,
+    };
+  } catch (err) {
+    throw LanternApiError.fromUnknown("GetReplicationStatus", err);
+  }
+}
+
+function stateLabel(s: ReplicationPeer_State): ReplicationPeerState {
+  switch (s) {
+    case ReplicationPeer_State.CONNECTING:
+      return "connecting";
+    case ReplicationPeer_State.STREAMING:
+      return "streaming";
+    case ReplicationPeer_State.BACKOFF:
+      return "backoff";
+    case ReplicationPeer_State.CLOSED:
+      return "closed";
+    default:
+      return "unspecified";
+  }
+}

--- a/admin/app/lib/client/infrastructure/api/get-server-status.ts
+++ b/admin/app/lib/client/infrastructure/api/get-server-status.ts
@@ -1,0 +1,69 @@
+import type { LanternClient } from "./lantern-client";
+import { LanternApiError } from "./error";
+
+/**
+ * ServerStatus is the JSON-flat view of GetServerStatusResponse the Ops
+ * view consumes. Durations are surfaced as both the raw seconds value
+ * (for tooling) and a human-readable label (for the card).
+ *
+ * Mirrors the field set of pb.GetServerStatusResponse but flattens
+ * google.protobuf.Timestamp / Duration into plain numbers so the
+ * downstream selectors stay JSON-clean and serialisable for
+ * snapshot-test fixtures.
+ */
+export interface ServerStatus {
+  version: string;
+  goVersion: string;
+  /** epoch milliseconds; 0 when started_at was unset on the wire. */
+  startedAtMs: number;
+  /** seconds since start (server-computed); 0 when unset. */
+  uptimeSeconds: number;
+  /** seconds (server-side default TTL); 0 when unset. */
+  defaultTtlSeconds: number;
+  maxBatchSize: number;
+  maxKeyBytes: number;
+  scanDefaultLimit: number;
+  scanMaxLimit: number;
+  tlsEnabled: boolean;
+  replicationEnabled: boolean;
+  vertexCount: number;
+  edgeCount: number;
+}
+
+/**
+ * Calls LanternService.GetServerStatus and normalises the response into
+ * the flat ServerStatus shape. Connect errors are rethrown as
+ * LanternApiError so existing usecase error toasts keep working.
+ */
+export async function getServerStatus(
+  client: LanternClient,
+  init?: { signal?: AbortSignal },
+): Promise<ServerStatus> {
+  try {
+    const resp = await client.getServerStatus({}, { signal: init?.signal });
+    return {
+      version: resp.version,
+      goVersion: resp.goVersion,
+      startedAtMs: resp.startedAt
+        ? Number(resp.startedAt.seconds) * 1000 +
+          Math.floor(resp.startedAt.nanos / 1_000_000)
+        : 0,
+      uptimeSeconds: resp.uptime ? Number(resp.uptime.seconds) : 0,
+      defaultTtlSeconds: resp.defaultTtl ? Number(resp.defaultTtl.seconds) : 0,
+      maxBatchSize: resp.maxBatchSize,
+      maxKeyBytes: resp.maxKeyBytes,
+      scanDefaultLimit: resp.scanDefaultLimit,
+      scanMaxLimit: resp.scanMaxLimit,
+      tlsEnabled: resp.tlsEnabled,
+      replicationEnabled: resp.replicationEnabled,
+      // protobuf-es returns BigInt for uint64 fields; the admin UI
+      // works in plain numbers (count <= 2^53 is fine for any
+      // realistic cache size). Coerce here so the use case layer
+      // stays BigInt-free.
+      vertexCount: Number(resp.vertexCount),
+      edgeCount: Number(resp.edgeCount),
+    };
+  } catch (err) {
+    throw LanternApiError.fromUnknown("GetServerStatus", err);
+  }
+}

--- a/admin/app/lib/client/usecase/connection/base-url.ts
+++ b/admin/app/lib/client/usecase/connection/base-url.ts
@@ -1,8 +1,10 @@
 /**
- * Default Lantern gateway base URL. Matches the gateway's default listener
- * (`:6381`) documented in `server/README.md`.
+ * Default Lantern primary listener URL. Matches the production
+ * default (`:6380`) documented in `server/README.md`. Since the #347
+ * cutover the primary listener multiplexes Connect / gRPC / gRPC-Web
+ * on the same h2c socket, so no separate gateway port is required.
  */
-export const DEFAULT_BASE_URL = "http://localhost:6381";
+export const DEFAULT_BASE_URL = "http://localhost:6380";
 
 /**
  * Normalises a user-entered base URL by trimming whitespace and stripping a

--- a/admin/app/lib/client/usecase/ops/reducer.test.ts
+++ b/admin/app/lib/client/usecase/ops/reducer.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "bun:test";
+
+import { opsReducer, type OpsAction } from "./reducer";
+import { INITIAL_OPS_STATE, type OpsState } from "./state";
+import type { ServerStatus } from "~/lib/client/infrastructure/api/get-server-status";
+import type { ReplicationStatus } from "~/lib/client/infrastructure/api/get-replication-status";
+
+const sampleServer: ServerStatus = {
+  version: "v1.0.0",
+  goVersion: "go1.26.4",
+  startedAtMs: 1_700_000_000_000,
+  uptimeSeconds: 3700,
+  defaultTtlSeconds: 60,
+  maxBatchSize: 10_000,
+  maxKeyBytes: 1024,
+  scanDefaultLimit: 1000,
+  scanMaxLimit: 10_000,
+  tlsEnabled: false,
+  replicationEnabled: true,
+  vertexCount: 42,
+  edgeCount: 17,
+};
+
+const sampleReplication: ReplicationStatus = {
+  nodeId: "abc123",
+  localNowMs: 1_700_000_003_700,
+  enabled: true,
+  peers: [
+    {
+      address: "10.0.0.1:6380",
+      state: "streaming",
+      lastEventAtMs: 1_700_000_003_500,
+      stalenessMs: 200,
+      appliedSeq: 99,
+      error: "",
+    },
+  ],
+};
+
+function apply(actions: OpsAction[]): OpsState {
+  return actions.reduce(opsReducer, INITIAL_OPS_STATE);
+}
+
+describe("opsReducer", () => {
+  describe("FETCH_STARTED", () => {
+    it("flips both cards to loading on the first fetch", () => {
+      const next = opsReducer(INITIAL_OPS_STATE, {
+        type: "FETCH_STARTED",
+        epoch: 1,
+      });
+      expect(next.server.status).toBe("loading");
+      expect(next.replication.status).toBe("loading");
+      expect(next.fetchEpoch).toBe(1);
+    });
+
+    it("preserves card status on subsequent fetches (no flash)", () => {
+      const after = apply([
+        { type: "FETCH_STARTED", epoch: 1 },
+        { type: "SERVER_LOADED", epoch: 1, data: sampleServer },
+        { type: "REPLICATION_LOADED", epoch: 1, data: sampleReplication },
+        { type: "FETCH_STARTED", epoch: 2 },
+      ]);
+      // Both cards must stay in 'ready' so the UI does not flash a
+      // loading skeleton on every poll tick.
+      expect(after.server.status).toBe("ready");
+      expect(after.server.data).toBe(sampleServer);
+      expect(after.replication.status).toBe("ready");
+      expect(after.fetchEpoch).toBe(2);
+    });
+  });
+
+  describe("epoch gating", () => {
+    it("ignores stale SERVER_LOADED dispatches", () => {
+      const after = apply([
+        { type: "FETCH_STARTED", epoch: 1 },
+        { type: "FETCH_STARTED", epoch: 2 },
+        // Stale: epoch=1 result arrives after a newer fetch was started.
+        { type: "SERVER_LOADED", epoch: 1, data: sampleServer },
+      ]);
+      expect(after.server.data).toBeNull();
+      expect(after.server.status).toBe("loading");
+    });
+
+    it("applies the matching epoch", () => {
+      const after = apply([
+        { type: "FETCH_STARTED", epoch: 1 },
+        { type: "SERVER_LOADED", epoch: 1, data: sampleServer },
+      ]);
+      expect(after.server.data).toBe(sampleServer);
+      expect(after.server.status).toBe("ready");
+    });
+
+    it("ignores stale error dispatches", () => {
+      const after = apply([
+        { type: "FETCH_STARTED", epoch: 1 },
+        { type: "FETCH_STARTED", epoch: 2 },
+        { type: "SERVER_ERROR", epoch: 1, error: "old" },
+      ]);
+      expect(after.server.error).toBeNull();
+    });
+  });
+
+  describe("independent card failure", () => {
+    it("a server error does not clear replication state", () => {
+      const after = apply([
+        { type: "FETCH_STARTED", epoch: 1 },
+        { type: "REPLICATION_LOADED", epoch: 1, data: sampleReplication },
+        { type: "SERVER_ERROR", epoch: 1, error: "boom" },
+      ]);
+      expect(after.server.status).toBe("error");
+      expect(after.server.error).toBe("boom");
+      expect(after.replication.status).toBe("ready");
+      expect(after.replication.data).toBe(sampleReplication);
+    });
+
+    it("a replication error does not clear server state", () => {
+      const after = apply([
+        { type: "FETCH_STARTED", epoch: 1 },
+        { type: "SERVER_LOADED", epoch: 1, data: sampleServer },
+        { type: "REPLICATION_ERROR", epoch: 1, error: "boom" },
+      ]);
+      expect(after.server.status).toBe("ready");
+      expect(after.replication.status).toBe("error");
+      expect(after.replication.error).toBe("boom");
+    });
+  });
+
+  describe("SET_POLL_MS", () => {
+    it("clamps negative values to 0 (polling disabled)", () => {
+      const after = opsReducer(INITIAL_OPS_STATE, {
+        type: "SET_POLL_MS",
+        pollMs: -1,
+      });
+      expect(after.pollMs).toBe(0);
+    });
+
+    it("accepts a positive value verbatim", () => {
+      const after = opsReducer(INITIAL_OPS_STATE, {
+        type: "SET_POLL_MS",
+        pollMs: 10_000,
+      });
+      expect(after.pollMs).toBe(10_000);
+    });
+  });
+});

--- a/admin/app/lib/client/usecase/ops/reducer.ts
+++ b/admin/app/lib/client/usecase/ops/reducer.ts
@@ -1,0 +1,76 @@
+import type { ServerStatus } from "~/lib/client/infrastructure/api/get-server-status";
+import type { ReplicationStatus } from "~/lib/client/infrastructure/api/get-replication-status";
+import { type OpsState, INITIAL_OPS_STATE } from "./state";
+
+/**
+ * OpsAction is the union of every state transition the Ops reducer
+ * understands. Each transition is one-way so undo/redo is not
+ * required; the reducer is therefore a flat switch with no extra
+ * machinery.
+ */
+export type OpsAction =
+  | { type: "FETCH_STARTED"; epoch: number }
+  | { type: "SERVER_LOADED"; epoch: number; data: ServerStatus }
+  | { type: "SERVER_ERROR"; epoch: number; error: string }
+  | { type: "REPLICATION_LOADED"; epoch: number; data: ReplicationStatus }
+  | { type: "REPLICATION_ERROR"; epoch: number; error: string }
+  | { type: "SET_POLL_MS"; pollMs: number }
+  | { type: "RESET" };
+
+/**
+ * opsReducer applies an OpsAction. fetchEpoch gating: handlers
+ * dispatch with the epoch they observed when they fired. Any newer
+ * epoch means the user kicked off a fresh refresh while the previous
+ * fetch was in flight; the stale result is discarded so the card
+ * never reverts to old data.
+ */
+export function opsReducer(state: OpsState, action: OpsAction): OpsState {
+  switch (action.type) {
+    case "FETCH_STARTED": {
+      const isFirstFetch =
+        state.server.status === "idle" && state.replication.status === "idle";
+      return {
+        ...state,
+        fetchEpoch: action.epoch,
+        server: isFirstFetch
+          ? { ...state.server, status: "loading" }
+          : state.server,
+        replication: isFirstFetch
+          ? { ...state.replication, status: "loading" }
+          : state.replication,
+      };
+    }
+    case "SERVER_LOADED":
+      if (action.epoch !== state.fetchEpoch) return state;
+      return {
+        ...state,
+        server: { status: "ready", data: action.data, error: null },
+      };
+    case "SERVER_ERROR":
+      if (action.epoch !== state.fetchEpoch) return state;
+      return {
+        ...state,
+        server: { ...state.server, status: "error", error: action.error },
+      };
+    case "REPLICATION_LOADED":
+      if (action.epoch !== state.fetchEpoch) return state;
+      return {
+        ...state,
+        replication: { status: "ready", data: action.data, error: null },
+      };
+    case "REPLICATION_ERROR":
+      if (action.epoch !== state.fetchEpoch) return state;
+      return {
+        ...state,
+        replication: {
+          ...state.replication,
+          status: "error",
+          error: action.error,
+        },
+      };
+    case "SET_POLL_MS":
+      return { ...state, pollMs: Math.max(0, action.pollMs) };
+    case "RESET":
+      return INITIAL_OPS_STATE;
+  }
+}

--- a/admin/app/lib/client/usecase/ops/selectors.test.ts
+++ b/admin/app/lib/client/usecase/ops/selectors.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  formatCount,
+  formatDuration,
+  formatStaleness,
+  formatUptime,
+  peerStatePillIntent,
+  replicationCardSummary,
+  serverCardSummary,
+} from "./selectors";
+
+describe("formatUptime", () => {
+  it("returns 0s for zero or negative input", () => {
+    expect(formatUptime(0)).toBe("0s");
+    expect(formatUptime(-1)).toBe("0s");
+  });
+  it("renders sub-minute seconds verbatim", () => {
+    expect(formatUptime(5)).toBe("5s");
+    expect(formatUptime(59)).toBe("59s");
+  });
+  it("falls back to minutes + seconds under an hour", () => {
+    expect(formatUptime(90)).toBe("1m 30s");
+  });
+  it("falls back to hours + minutes under a day", () => {
+    expect(formatUptime(3700)).toBe("1h 1m");
+  });
+  it("falls back to days + hours past a day", () => {
+    expect(formatUptime(86_400 + 3600)).toBe("1d 1h");
+  });
+});
+
+describe("formatDuration", () => {
+  it("returns - for non-positive input", () => {
+    expect(formatDuration(0)).toBe("-");
+    expect(formatDuration(-1)).toBe("-");
+  });
+  it("renders sub-minute seconds verbatim", () => {
+    expect(formatDuration(30)).toBe("30s");
+  });
+  it("collapses minute/hour/day boundaries", () => {
+    expect(formatDuration(60)).toBe("1m");
+    expect(formatDuration(3600)).toBe("1h");
+    expect(formatDuration(86_400)).toBe("1d");
+  });
+});
+
+describe("formatStaleness", () => {
+  it("returns - for non-positive input", () => {
+    expect(formatStaleness(0)).toBe("-");
+  });
+  it("rounds down to whole seconds for sub-minute lag", () => {
+    expect(formatStaleness(2_500)).toBe("2s ago");
+  });
+  it("steps through minute/hour/day boundaries", () => {
+    expect(formatStaleness(90_000)).toBe("1m ago");
+    expect(formatStaleness(3_600_000)).toBe("1h ago");
+    expect(formatStaleness(86_400_000)).toBe("1d ago");
+  });
+});
+
+describe("formatCount", () => {
+  it("returns - for NaN", () => {
+    expect(formatCount(NaN)).toBe("-");
+  });
+  it("applies thousands separators", () => {
+    expect(formatCount(1_234_567)).toMatch(/1[,.]234[,.]567/);
+  });
+});
+
+describe("peerStatePillIntent", () => {
+  it("maps every documented state to a Fluent intent", () => {
+    expect(peerStatePillIntent("streaming")).toBe("success");
+    expect(peerStatePillIntent("connecting")).toBe("info");
+    expect(peerStatePillIntent("backoff")).toBe("warning");
+    expect(peerStatePillIntent("closed")).toBe("error");
+    expect(peerStatePillIntent("unspecified")).toBe("warning");
+  });
+});
+
+describe("serverCardSummary", () => {
+  it("emits a stable ordered list of (label, value) pairs", () => {
+    const rows = serverCardSummary({
+      version: "v1.0.0",
+      goVersion: "go1.26.4",
+      startedAtMs: 0,
+      uptimeSeconds: 3600,
+      defaultTtlSeconds: 60,
+      maxBatchSize: 10_000,
+      maxKeyBytes: 1024,
+      scanDefaultLimit: 1000,
+      scanMaxLimit: 10_000,
+      tlsEnabled: true,
+      replicationEnabled: false,
+      vertexCount: 42,
+      edgeCount: 17,
+    });
+    // First row is always Version.
+    expect(rows[0]).toEqual(["Version", "v1.0.0"]);
+    // Replication label flips based on the bool input.
+    expect(rows.find(([label]) => label === "Replication")?.[1]).toBe(
+      "disabled",
+    );
+    expect(rows.find(([label]) => label === "TLS")?.[1]).toBe("enabled");
+  });
+
+  it("substitutes (dev) when version is empty", () => {
+    const rows = serverCardSummary({
+      version: "",
+      goVersion: "",
+      startedAtMs: 0,
+      uptimeSeconds: 0,
+      defaultTtlSeconds: 0,
+      maxBatchSize: 0,
+      maxKeyBytes: 0,
+      scanDefaultLimit: 0,
+      scanMaxLimit: 0,
+      tlsEnabled: false,
+      replicationEnabled: false,
+      vertexCount: 0,
+      edgeCount: 0,
+    });
+    expect(rows[0][1]).toBe("(dev)");
+  });
+});
+
+describe("replicationCardSummary", () => {
+  it("collapses single-instance state to the documented label", () => {
+    const rows = replicationCardSummary({
+      nodeId: "abc",
+      localNowMs: 0,
+      enabled: false,
+      peers: [],
+    });
+    expect(rows.find(([label]) => label === "Replication")?.[1]).toBe(
+      "disabled (single instance)",
+    );
+    expect(rows.find(([label]) => label === "Peers tracked")?.[1]).toBe("0");
+  });
+});

--- a/admin/app/lib/client/usecase/ops/selectors.ts
+++ b/admin/app/lib/client/usecase/ops/selectors.ts
@@ -1,0 +1,131 @@
+import type { ServerStatus } from "~/lib/client/infrastructure/api/get-server-status";
+import type {
+  ReplicationPeerState,
+  ReplicationStatus,
+} from "~/lib/client/infrastructure/api/get-replication-status";
+
+/**
+ * Pure view-model selectors for the Ops cards. Kept separate from the
+ * components so the formatters stay unit-testable without spinning up
+ * a React renderer.
+ */
+
+/**
+ * formatUptime renders an uptime in seconds as a compact human label:
+ *   90 → "1m 30s", 3700 → "1h 1m", 86_700 → "1d 0h", 0 → "0s".
+ * Days/hours/minutes are truncated rather than rounded so the label
+ * never overstates how long the server has been up.
+ */
+export function formatUptime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "0s";
+  const sec = Math.floor(seconds);
+  const days = Math.floor(sec / 86_400);
+  const hours = Math.floor((sec % 86_400) / 3600);
+  const mins = Math.floor((sec % 3600) / 60);
+  const s = sec % 60;
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  if (mins > 0) return `${mins}m ${s}s`;
+  return `${s}s`;
+}
+
+/**
+ * formatDuration renders a TTL in seconds as a short string. Used for
+ * the "default TTL" line in the server card.
+ */
+export function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "-";
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86_400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86_400)}d`;
+}
+
+/**
+ * formatStaleness renders a millisecond delta as the same short
+ * "<n>(s|m|h|d) ago" the table column displays. A negative or zero
+ * delta returns "-" so the cell never shows nonsense.
+ */
+export function formatStaleness(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "-";
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  if (sec < 3600) return `${Math.floor(sec / 60)}m ago`;
+  if (sec < 86_400) return `${Math.floor(sec / 3600)}h ago`;
+  return `${Math.floor(sec / 86_400)}d ago`;
+}
+
+/**
+ * formatCount renders a count with thousands separators so the
+ * vertex/edge totals on the server card read cleanly at any scale.
+ */
+export function formatCount(n: number): string {
+  if (!Number.isFinite(n)) return "-";
+  return n.toLocaleString();
+}
+
+/**
+ * peerStatePillIntent maps a ReplicationPeerState onto the Fluent UI
+ * "intent" label the table cell uses for the colour pill.
+ */
+export function peerStatePillIntent(
+  s: ReplicationPeerState,
+): "success" | "warning" | "error" | "info" {
+  switch (s) {
+    case "streaming":
+      return "success";
+    case "connecting":
+      return "info";
+    case "backoff":
+    case "unspecified":
+      return "warning";
+    case "closed":
+      return "error";
+  }
+}
+
+/**
+ * serverCardSummary collapses the wire-level ServerStatus into a
+ * compact label set the card renders as a definition list. Returned
+ * tuple form (label, value) so the renderer can map directly without
+ * worrying about ordering.
+ */
+export function serverCardSummary(s: ServerStatus): Array<[string, string]> {
+  return [
+    ["Version", s.version || "(dev)"],
+    ["Go runtime", s.goVersion || "(unknown)"],
+    ["Uptime", formatUptime(s.uptimeSeconds)],
+    ["Default TTL", formatDuration(s.defaultTtlSeconds)],
+    ["Max batch size", formatCount(s.maxBatchSize)],
+    ["Max key bytes", formatCount(s.maxKeyBytes)],
+    [
+      "Scan limits",
+      `${formatCount(s.scanDefaultLimit)} default / ${formatCount(s.scanMaxLimit)} max`,
+    ],
+    ["TLS", s.tlsEnabled ? "enabled" : "disabled"],
+    ["Replication", s.replicationEnabled ? "enabled" : "disabled"],
+    ["Vertices (approx.)", formatCount(s.vertexCount)],
+    ["Edges (approx.)", formatCount(s.edgeCount)],
+  ];
+}
+
+/**
+ * replicationCardSummary returns the header rows for the replication
+ * card (local node id + local now). The per-peer rows are rendered by
+ * the table component directly off ReplicationStatus.peers; that
+ * slice stays in domain form because the table needs the typed
+ * fields for sorting / pill colour.
+ */
+export function replicationCardSummary(
+  r: ReplicationStatus,
+): Array<[string, string]> {
+  return [
+    ["Local node ID", r.nodeId || "(unknown)"],
+    [
+      "Local clock",
+      r.localNowMs > 0 ? new Date(r.localNowMs).toISOString() : "-",
+    ],
+    ["Replication", r.enabled ? "enabled" : "disabled (single instance)"],
+    ["Peers tracked", formatCount(r.peers.length)],
+  ];
+}

--- a/admin/app/lib/client/usecase/ops/state.ts
+++ b/admin/app/lib/client/usecase/ops/state.ts
@@ -1,0 +1,46 @@
+import type { ServerStatus } from "~/lib/client/infrastructure/api/get-server-status";
+import type { ReplicationStatus } from "~/lib/client/infrastructure/api/get-replication-status";
+
+/**
+ * OpsStatus is the lifecycle phase of a polling card. "idle" is the
+ * pre-first-fetch state; "ready" means we have a payload to display;
+ * "error" surfaces the last LanternApiError message. "loading" is
+ * only set on the first fetch — subsequent revalidates stay in
+ * "ready" so the card UI does not flash while polling.
+ */
+export type OpsStatus = "idle" | "loading" | "ready" | "error";
+
+/**
+ * OpsState is the aggregate the Ops page reducer manages. Both cards
+ * (server + replication) are independent — one card erroring does not
+ * tear down the other. fetchEpoch is bumped on every manual refresh so
+ * stale handlers can discard their result (mirrors the
+ * browse-vertices / illuminate pattern).
+ */
+export interface OpsState {
+  server: {
+    status: OpsStatus;
+    data: ServerStatus | null;
+    error: string | null;
+  };
+  replication: {
+    status: OpsStatus;
+    data: ReplicationStatus | null;
+    error: string | null;
+  };
+  /**
+   * Auto-poll cadence in milliseconds. 0 disables polling (manual
+   * refresh only). Default 5000 ms matches the Ops issue spec.
+   */
+  pollMs: number;
+  fetchEpoch: number;
+}
+
+export const DEFAULT_POLL_MS = 5_000;
+
+export const INITIAL_OPS_STATE: OpsState = {
+  server: { status: "idle", data: null, error: null },
+  replication: { status: "idle", data: null, error: null },
+  pollMs: DEFAULT_POLL_MS,
+  fetchEpoch: 0,
+};

--- a/admin/app/lib/client/usecase/ops/use-ops.ts
+++ b/admin/app/lib/client/usecase/ops/use-ops.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useReducer, useRef } from "react";
+
+import { getServerStatus } from "~/lib/client/infrastructure/api/get-server-status";
+import { getReplicationStatus } from "~/lib/client/infrastructure/api/get-replication-status";
+import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
+import { opsReducer } from "./reducer";
+import { INITIAL_OPS_STATE } from "./state";
+
+/**
+ * useOps is the hook the OpsPage consumes. It owns:
+ *   1. the polling timer (cleared on unmount + on pollMs change)
+ *   2. the AbortController per fetch round (one round = one
+ *      GetServerStatus + one GetReplicationStatus in parallel)
+ *   3. the manual-refresh handler exposed to the toolbar
+ *   4. the pollMs setter exposed to the toolbar
+ *
+ * Errors from either RPC are stored on their card; one failing card
+ * does NOT cancel the other.
+ */
+export function useOps() {
+  const client = useLanternClient();
+  const [state, dispatch] = useReducer(opsReducer, INITIAL_OPS_STATE);
+  // epochRef carries the latest dispatched epoch so the polling
+  // closure does not depend on state (which would re-create the
+  // setInterval handler every render and reset the timer).
+  const epochRef = useRef(state.fetchEpoch);
+  epochRef.current = state.fetchEpoch;
+
+  const fetchRound = useCallback(
+    async (signal: AbortSignal) => {
+      const epoch = epochRef.current + 1;
+      epochRef.current = epoch;
+      dispatch({ type: "FETCH_STARTED", epoch });
+      // Run both RPCs in parallel — neither blocks the other on
+      // failure. The reducer stamps both results with the same
+      // epoch so a stale round can be discarded atomically.
+      await Promise.allSettled([
+        getServerStatus(client, { signal })
+          .then((data) => dispatch({ type: "SERVER_LOADED", epoch, data }))
+          .catch((err: unknown) => {
+            if ((err as Error)?.name === "AbortError") return;
+            dispatch({
+              type: "SERVER_ERROR",
+              epoch,
+              error: errorMessage(err),
+            });
+          }),
+        getReplicationStatus(client, { signal })
+          .then((data) => dispatch({ type: "REPLICATION_LOADED", epoch, data }))
+          .catch((err: unknown) => {
+            if ((err as Error)?.name === "AbortError") return;
+            dispatch({
+              type: "REPLICATION_ERROR",
+              epoch,
+              error: errorMessage(err),
+            });
+          }),
+      ]);
+    },
+    [client],
+  );
+
+  const refresh = useCallback(() => {
+    const ctl = new AbortController();
+    void fetchRound(ctl.signal);
+    return () => ctl.abort();
+  }, [fetchRound]);
+
+  const setPollMs = useCallback((ms: number) => {
+    dispatch({ type: "SET_POLL_MS", pollMs: ms });
+  }, []);
+
+  // First-paint fetch + polling timer. The cleanup aborts any
+  // in-flight requests on unmount or before a re-fetch fires.
+  useEffect(() => {
+    const ctl = new AbortController();
+    void fetchRound(ctl.signal);
+    if (state.pollMs <= 0) {
+      return () => ctl.abort();
+    }
+    const id = window.setInterval(() => {
+      void fetchRound(ctl.signal);
+    }, state.pollMs);
+    return () => {
+      window.clearInterval(id);
+      ctl.abort();
+    };
+  }, [fetchRound, state.pollMs]);
+
+  return {
+    state,
+    refresh,
+    setPollMs,
+  };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/admin/app/routes/ops.tsx
+++ b/admin/app/routes/ops.tsx
@@ -1,16 +1,10 @@
 import type { Route } from "./+types/ops";
-import { PlaceholderPage } from "~/components/shared/PlaceholderPage/PlaceholderPage";
+import { OpsPage } from "~/components/ops/OpsPage/OpsPage";
 
 export function meta(_: Route.MetaArgs) {
   return [{ title: "Ops — Lantern Admin" }];
 }
 
 export default function OpsRoute() {
-  return (
-    <PlaceholderPage
-      title="Ops"
-      trackingIssue="#F5"
-      description="Server status and replication panels will land here."
-    />
-  );
+  return <OpsPage />;
 }

--- a/admin/playwright.config.ts
+++ b/admin/playwright.config.ts
@@ -5,15 +5,14 @@ import { defineConfig, devices } from "@playwright/test";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const PORT = 4173;
-// Admin uses LANTERN_CONNECT_PORT (the additive Connect-Go listener from
-// #337) on port 6381 — the same slot the grpc-gateway REST surface used
-// to occupy. The gateway listener is disabled in the e2e config to keep
-// the port set contention-free; production e2e (#347) will swap to the
-// primary 6380 port once the server cuts over.
-const CONNECT_PORT = 6381;
-const GRPC_PORT = 6380;
+// Since #347 the primary :6380 listener serves Connect / gRPC /
+// gRPC-Web on the same h2c socket. The legacy LANTERN_CONNECT_PORT
+// (additive listener from #337) and LANTERN_GATEWAY_ADDR
+// (grpc-gateway) env vars were both retired; the admin SPA talks to
+// the primary port directly.
+const LANTERN_PORT = 6380;
 const METRICS_PORT = 9090;
-const CONNECT_URL = `http://127.0.0.1:${CONNECT_PORT}`;
+const CONNECT_URL = `http://127.0.0.1:${LANTERN_PORT}`;
 
 process.env.LANTERN_E2E_GATEWAY_URL = CONNECT_URL;
 
@@ -37,7 +36,7 @@ export default defineConfig({
   webServer: [
     {
       command: `go run ../server/cmd`,
-      // Health probe lives on the metrics server, not the Connect
+      // Health probe lives on the metrics server, not the primary
       // listener — readyz is the canonical Lantern liveness probe per
       // docs/ha-runbook.md. Wait for it before starting the SPA.
       url: `http://127.0.0.1:${METRICS_PORT}/healthz`,
@@ -45,11 +44,7 @@ export default defineConfig({
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
       env: {
-        LANTERN_PORT: String(GRPC_PORT),
-        LANTERN_CONNECT_PORT: String(CONNECT_PORT),
-        // Disable the legacy grpc-gateway listener so it does not race
-        // with the Connect listener for the same port.
-        LANTERN_GATEWAY_ADDR: "",
+        LANTERN_PORT: String(LANTERN_PORT),
         LANTERN_METRICS_ADDR: `:${METRICS_PORT}`,
         LANTERN_CORS_ALLOWED_ORIGINS: `http://127.0.0.1:${PORT}`,
         LANTERN_LOG_LEVEL: "warn",

--- a/admin/tests/e2e/helpers.ts
+++ b/admin/tests/e2e/helpers.ts
@@ -1,14 +1,15 @@
 import { Buffer } from "node:buffer";
 
 /**
- * The Lantern Connect listener URL the Playwright webServer starts on
+ * The Lantern primary listener URL the Playwright webServer starts on
  * (see playwright.config.ts). Tests seed data through this URL using
- * Connect+JSON's `POST /graph.v1.LanternService/<Method>` shape rather
- * than the legacy grpc-gateway REST URLs — the gateway is no longer
- * started in the e2e profile (#339).
+ * Connect+JSON's `POST /graph.v1.LanternService/<Method>` shape. Since
+ * #347 the primary :6380 port multiplexes Connect / gRPC / gRPC-Web on
+ * the same h2c socket, so the additive listener (#337) and the
+ * grpc-gateway shim (#339) are both gone.
  */
 export const CONNECT_URL =
-  process.env.LANTERN_E2E_GATEWAY_URL ?? "http://127.0.0.1:6381";
+  process.env.LANTERN_E2E_GATEWAY_URL ?? "http://127.0.0.1:6380";
 
 /**
  * The localStorage key the admin SPA stores the active gateway URL

--- a/admin/tests/e2e/landing.spec.ts
+++ b/admin/tests/e2e/landing.spec.ts
@@ -15,7 +15,7 @@ test("landing page renders with navigation and gateway connection", async ({
     page.getByRole("link", { name: /Open Illuminate/i }),
   ).toBeVisible();
   await expect(page.getByRole("link", { name: /Open Ops/i })).toBeVisible();
-  await expect(page.getByText("http://localhost:6381")).toBeVisible();
+  await expect(page.getByText("http://localhost:6380")).toBeVisible();
 });
 
 test.describe("placeholder routes", () => {
@@ -29,11 +29,15 @@ test.describe("placeholder routes", () => {
     await expect(page.getByTestId("illuminate-seed-prompt")).toBeVisible();
   });
 
-  test("Ops route renders its placeholder", async ({ page }) => {
+  test("Ops route renders the server status card", async ({ page }) => {
     await page.goto("/ops");
     await expect(
       page.getByRole("heading", { level: 1, name: "Ops" }),
     ).toBeVisible();
-    await expect(page.getByText(/Coming in #F5/)).toBeVisible();
+    // Both cards mount; the server-status card is the canonical
+    // "did the page wire up" probe because GetServerStatus does not
+    // require replication to be configured.
+    await expect(page.getByTestId("ops-server-card")).toBeVisible();
+    await expect(page.getByTestId("ops-replication-card")).toBeVisible();
   });
 });


### PR DESCRIPTION
Closes #322. Part of epic #313.

## What

Implements the \`/ops\` route promised by the landing page: a single dashboard polling \`GetServerStatus\` + \`GetReplicationStatus\` every 5 seconds in parallel, with auto-poll toggle + manual refresh + per-card error handling.

## Layer placement

Follows the standard admin pattern (mirrors illuminate / browse-vertices):

- \`infrastructure/api/get-server-status.ts\` + \`get-replication-status.ts\` — Connect-Web adapters returning JSON-flat value objects (BigInt → number, Timestamp → epoch ms, Duration → seconds)
- \`usecase/ops/{state,reducer,reducer.test,selectors,selectors.test,use-ops}.ts\` — useReducer state with epoch-gated dispatches; both RPCs run in \`Promise.allSettled\` so one failing card never tears down the other
- \`components/ops/OpsPage/{OpsPage.tsx,OpsPage.module.css}\` — Fluent UI \`Card\` + \`Badge\` + \`Spinner\` + \`MessageBar\`; responsive 1-col → 2-col layout at 960px
- \`routes/ops.tsx\` — replaces the \`PlaceholderPage\` stub

## Polling design

- Default cadence **5000 ms** (\`DEFAULT_POLL_MS\`, exported for the toggle); **0 disables** polling (manual refresh only)
- First fetch flips both cards to \`loading\`; subsequent polls keep cards in \`ready\` so the UI does not flash a skeleton every tick
- Each fetch round carries a monotonically increasing **epoch**; results stamped with a stale epoch are discarded by the reducer
- \`useEffect\` cleanup aborts in-flight requests on unmount or \`pollMs\` change

## Tests

**26 unit tests** across reducer + selectors. Verifies:

- First-fetch transition flips both cards to \`loading\`
- No-flash on subsequent polls (cards stay \`ready\`)
- Epoch gating (stale dispatches dropped)
- Independent card failure (server error does not clear replication state, and vice versa)
- \`SET_POLL_MS\` clamps negative values to 0
- Every selector format: uptime / duration / staleness / counts / state pill / both summary builders

## Out of scope (deferred)

- **S3 grpc.health.v1 health card** — Connect-Web cannot call the gRPC-Health-v1 surface without a dedicated codegen pass. \`GetServerStatus\` already covers the "is the server alive" triage signal; a dedicated health card is a follow-up Issue once \`grpchealth\` codegen exists.
- **Playwright e2e against a live lantern-server container** — the unit tests + \`bun run build\` are the v1 gate. The e2e can land alongside the v1.0 cut in #342 when \`admin.yml\` gets a Lantern container fixture.

## Verification

- \`bun run typecheck\` clean
- \`bun run lint\` clean
- \`bun run build\` succeeds
- \`bun test app/lib/client/usecase/ops\` — 26 pass / 0 fail