### PR TITLE
refactor(server/provider): make validation errors Connect-native

### DIFF
--- a/server/provider/connect_interceptors.go
+++ b/server/provider/connect_interceptors.go
@@ -1,21 +1,8 @@
 // Package provider: connect_interceptors.go wires the existing
 // ValidationInterceptor and RateLimitInterceptor into Connect-Go's
-// connect.UnaryInterceptorFunc shape so the additive Connect listener
-// from #337 — and later the cutover in #347 — pick up the same
-// validation rules, token-bucket policy, reject hooks, and slog
-// channels the gRPC path uses.
-//
-// Design constraints (per #349):
-//   - Reuse the existing private validate(req any) and r.lim.Allow()
-//     logic verbatim. Behaviour MUST be observable as identical from
-//     reject-hook callbacks and slog output regardless of transport.
-//   - Translate the gRPC status errors the underlying logic returns
-//     into the matching connect.Error so wire clients see
-//     CodeInvalidArgument / CodeResourceExhausted, not a leaked
-//     gRPC-flavoured payload.
-//   - The existing UnaryServerInterceptor / StreamServerInterceptor
-//     gRPC methods are untouched (additive only — production deletion
-//     lives in #347).
+// connect.UnaryInterceptorFunc shape so the listener picks up the
+// same validation rules, token-bucket policy, reject hooks, and
+// slog channels.
 package provider
 
 import (
@@ -24,8 +11,6 @@ import (
 	"log/slog"
 
 	"connectrpc.com/connect"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
 )
@@ -69,21 +54,16 @@ func NewRateLimitInterceptorProvider(
 
 // ConnectInterceptor returns a connect.UnaryInterceptorFunc that
 // validates every unary Connect call against the same ValidationLimits
-// the gRPC path uses.
-//
-// The interceptor calls the private validate(req any) shared with the
-// gRPC path so the canonical reason set, reject hook, and debug-level
-// slog channel stay identical across transports.
+// configured on the interceptor.
 //
 // Streaming RPCs (Subscribe / Snapshot) skip validation because
-// validate() only has cases for unary request types; the gRPC stream
-// interceptor (StreamServerInterceptor) is similarly a pass-through.
-// If validation is ever extended to streams, mirror the change here.
+// validate() only has cases for unary request types. If validation is
+// ever extended to streams, mirror the change here.
 func (v *ValidationInterceptor) ConnectInterceptor() connect.UnaryInterceptorFunc {
 	return func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 			if err := v.validate(req.Any()); err != nil {
-				return nil, grpcStatusToConnect(err)
+				return nil, err
 			}
 			return next(ctx, req)
 		}
@@ -95,8 +75,7 @@ func (v *ValidationInterceptor) ConnectInterceptor() connect.UnaryInterceptorFun
 // and returns connect.CodeResourceExhausted when the bucket is empty.
 //
 // The reject hook fires on the rejection path so
-// lantern_rate_limit_rejected_total keeps incrementing whether the
-// caller hit the gRPC or the Connect surface.
+// lantern_rate_limit_rejected_total keeps incrementing.
 func (r *RateLimitInterceptor) ConnectInterceptor() connect.UnaryInterceptorFunc {
 	return func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
@@ -108,64 +87,5 @@ func (r *RateLimitInterceptor) ConnectInterceptor() connect.UnaryInterceptorFunc
 			}
 			return next(ctx, req)
 		}
-	}
-}
-
-// grpcStatusToConnect translates the gRPC status errors the existing
-// validate() path returns into matching connect.Errors so wire clients
-// receive Connect-flavoured codes and messages. Non-status errors fall
-// through unchanged.
-//
-// The 16-entry table mirrors connect-go's own internal table verbatim
-// (the names match by design — Connect's codes are wire-compatible with
-// gRPC's). The unknown fallback preserves CodeUnknown semantics for any
-// future gRPC code the bridge has not yet learned.
-func grpcStatusToConnect(err error) error {
-	if err == nil {
-		return nil
-	}
-	st, ok := status.FromError(err)
-	if !ok {
-		return err
-	}
-	return connect.NewError(grpcCodeToConnect(st.Code()), errors.New(st.Message()))
-}
-
-func grpcCodeToConnect(c codes.Code) connect.Code {
-	switch c {
-	case codes.Canceled:
-		return connect.CodeCanceled
-	case codes.Unknown:
-		return connect.CodeUnknown
-	case codes.InvalidArgument:
-		return connect.CodeInvalidArgument
-	case codes.DeadlineExceeded:
-		return connect.CodeDeadlineExceeded
-	case codes.NotFound:
-		return connect.CodeNotFound
-	case codes.AlreadyExists:
-		return connect.CodeAlreadyExists
-	case codes.PermissionDenied:
-		return connect.CodePermissionDenied
-	case codes.ResourceExhausted:
-		return connect.CodeResourceExhausted
-	case codes.FailedPrecondition:
-		return connect.CodeFailedPrecondition
-	case codes.Aborted:
-		return connect.CodeAborted
-	case codes.OutOfRange:
-		return connect.CodeOutOfRange
-	case codes.Unimplemented:
-		return connect.CodeUnimplemented
-	case codes.Internal:
-		return connect.CodeInternal
-	case codes.Unavailable:
-		return connect.CodeUnavailable
-	case codes.DataLoss:
-		return connect.CodeDataLoss
-	case codes.Unauthenticated:
-		return connect.CodeUnauthenticated
-	default:
-		return connect.CodeUnknown
 	}
 }

--- a/server/provider/connect_interceptors_test.go
+++ b/server/provider/connect_interceptors_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
-	"google.golang.org/grpc/codes"
 
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 )
@@ -132,7 +131,7 @@ func TestRateLimitInterceptor_ConnectInterceptor_AllowsThenRejects(t *testing.T)
 // verifies the constructor's safety net: burst<=0 becomes 1 so the
 // interceptor never collapses into a permanent reject. Bursts of 0
 // would deadlock callers that expect at least one allowed request per
-// second of warm-up. Keep this in lockstep with the gRPC equivalent.
+// second of warm-up.
 func TestRateLimitInterceptor_ConnectInterceptor_ZeroBurstDefaults_To_One(t *testing.T) {
 	r := NewRateLimitInterceptor(1, 0)
 	allow := connect.UnaryFunc(func(ctx context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
@@ -144,44 +143,5 @@ func TestRateLimitInterceptor_ConnectInterceptor_ZeroBurstDefaults_To_One(t *tes
 	// limiter immediately.
 	if _, err := wrapped(context.Background(), connect.NewRequest(&pb.GetVertexRequest{Key: "k"})); err != nil {
 		t.Fatalf("first call: %v", err)
-	}
-}
-
-// TestGRPCCodeToConnect verifies the 16-entry mapping is exhaustive
-// and unambiguous. If a future grpc release adds a new code, gofmt
-// won't catch it — this table will.
-func TestGRPCCodeToConnect(t *testing.T) {
-	cases := []struct {
-		name string
-		in   codes.Code
-		want connect.Code
-	}{
-		{name: "Canceled", in: codes.Canceled, want: connect.CodeCanceled},
-		{name: "Unknown", in: codes.Unknown, want: connect.CodeUnknown},
-		{name: "InvalidArgument", in: codes.InvalidArgument, want: connect.CodeInvalidArgument},
-		{name: "DeadlineExceeded", in: codes.DeadlineExceeded, want: connect.CodeDeadlineExceeded},
-		{name: "NotFound", in: codes.NotFound, want: connect.CodeNotFound},
-		{name: "AlreadyExists", in: codes.AlreadyExists, want: connect.CodeAlreadyExists},
-		{name: "PermissionDenied", in: codes.PermissionDenied, want: connect.CodePermissionDenied},
-		{name: "ResourceExhausted", in: codes.ResourceExhausted, want: connect.CodeResourceExhausted},
-		{name: "FailedPrecondition", in: codes.FailedPrecondition, want: connect.CodeFailedPrecondition},
-		{name: "Aborted", in: codes.Aborted, want: connect.CodeAborted},
-		{name: "OutOfRange", in: codes.OutOfRange, want: connect.CodeOutOfRange},
-		{name: "Unimplemented", in: codes.Unimplemented, want: connect.CodeUnimplemented},
-		{name: "Internal", in: codes.Internal, want: connect.CodeInternal},
-		{name: "Unavailable", in: codes.Unavailable, want: connect.CodeUnavailable},
-		{name: "DataLoss", in: codes.DataLoss, want: connect.CodeDataLoss},
-		{name: "Unauthenticated", in: codes.Unauthenticated, want: connect.CodeUnauthenticated},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			if got := grpcCodeToConnect(c.in); got != c.want {
-				t.Errorf("grpcCodeToConnect(%v) = %v, want %v", c.in, got, c.want)
-			}
-		})
-	}
-	// Sanity: an unknown code maps to CodeUnknown rather than panicking.
-	if got := grpcCodeToConnect(codes.Code(9999)); got != connect.CodeUnknown {
-		t.Errorf("unknown code = %v, want CodeUnknown", got)
 	}
 }

--- a/server/provider/extra.go
+++ b/server/provider/extra.go
@@ -9,11 +9,11 @@ import (
 	"math"
 	"os"
 
+	"connectrpc.com/connect"
+	"golang.org/x/time/rate"
+
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/server/service"
-	"golang.org/x/time/rate"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // NewLifecycleConfig forwards Config knobs into the service-layer lifecycle
@@ -71,17 +71,17 @@ func (v *ValidationInterceptor) WithLogger(l *slog.Logger) *ValidationIntercepto
 }
 
 // reject fires the registered hook (if any) and returns the constructed
-// gRPC status error. Centralised so every validation rejection path is
+// Connect error. Centralised so every validation rejection path is
 // counted exactly once.
 func (v *ValidationInterceptor) reject(reason string, format string, args ...any) error {
 	if v.rejectHook != nil {
 		v.rejectHook(reason)
 	}
-	err := status.Errorf(codes.InvalidArgument, format, args...)
+	err := connect.NewError(connect.CodeInvalidArgument, fmt.Errorf(format, args...))
 	if v.logger != nil && v.logger.Enabled(context.Background(), slog.LevelDebug) {
 		v.logger.LogAttrs(context.Background(), slog.LevelDebug, "validation rejected",
 			slog.String("reason", reason),
-			slog.String("error", status.Convert(err).Message()),
+			slog.String("error", err.Error()),
 		)
 	}
 	return err


### PR DESCRIPTION
Partial **#375** (PR 1 of 3).

## What

Drop the gRPC-flavoured error idiom from the provider package — the easy first step in the multi-PR effort to remove `google.golang.org/grpc` from `server/go.mod`.

### Changes

- **`server/provider/extra.go`**: `ValidationInterceptor.reject()` now returns `connect.NewError(connect.CodeInvalidArgument, ...)` directly instead of routing through `status.Errorf` → `grpcStatusToConnect`.
- **`server/provider/connect_interceptors.go`**: drop the `grpcStatusToConnect` / `grpcCodeToConnect` helpers (no longer needed now that `validate()` returns a Connect-native error); strip the `google.golang.org/grpc/{codes,status}` imports; tighten the package doc-comment now that the gRPC dual-mount story is history.
- **`server/provider/connect_interceptors_test.go`**: delete the `TestGRPCCodeToConnect` 16-entry table that was guarding the dropped helper; drop the `grpc/codes` import.

### Why ship as 3 PRs

The full #375 scope (drop `google.golang.org/grpc` from `server/go.mod`) decomposes into three roughly equal chunks; merging them as one PR would be 800+ LOC across 20 files, very hard to review. Split:

| PR | Scope | Net effect |
| --- | --- | --- |
| **1 (this one)** | provider package | Drops 80-line dead translation helper. Provider stops importing `grpc/codes`/`status`. |
| 2 (next) | `server/service/{service,prefix,apply,replication}.go` error idiom | 40+ `status.Errorf` → `connect.NewError` mechanical sites. |
| 3 (final) | `pb.UnimplementedLanternServiceServer` embed removal + `Subscribe`/`Snapshot` signature flip + bufconn test rewrite + healthpb → grpchealth.Status migration | `google.golang.org/grpc` exits `server/go.mod`. Unblocks #362. |

## Verification

- `go build ./...` clean.
- `go test -race -count=1` green for every `server/*` package.
- `go vet` clean.