### PR TITLE
refactor(server): drop grpc.ServerStreamingServer + healthpb; close #375

### DIFF
--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -15,8 +15,9 @@ import (
 	"github.com/anaregdesign/lantern/server/provider"
 	"github.com/anaregdesign/lantern/server/replication"
 	"github.com/anaregdesign/lantern/server/service"
+
+	"connectrpc.com/grpchealth"
 	"golang.org/x/sync/errgroup"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 // App is the composition root produced by wire. It owns every long-running
@@ -180,7 +181,7 @@ func (a *App) Run(ctx context.Context) error {
 	g.Go(func() error { return a.antiEntropy.Run(gctx) })
 	g.Go(func() error {
 		<-gctx.Done()
-		a.health.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
+		a.health.SetServingStatus("", grpchealth.StatusNotServing)
 		a.health.Shutdown()
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/server/go.mod
+++ b/server/go.mod
@@ -20,7 +20,6 @@ require (
 	golang.org/x/net v0.55.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
-	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
 )
 
@@ -50,6 +49,7 @@ require (
 	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
+	google.golang.org/grpc v1.81.1 // indirect
 )
 
 tool github.com/google/wire/cmd/wire

--- a/server/provider/health.go
+++ b/server/provider/health.go
@@ -1,17 +1,15 @@
 // Package provider: health.go owns the gRPC-Health-v1 surface that the
-// new primary listener exposes (#347). The legacy *health.Server from
-// google.golang.org/grpc/health is replaced by a thin adapter over
-// connectrpc.com/grpchealth.StaticChecker so the same SetServingStatus
-// API the readiness Gate and LanternServer drive continues to work, but
-// the underlying handler is mounted on the Connect mux instead of a
-// grpc.Server.
+// primary listener exposes. The underlying handler is mounted on the
+// Connect mux via connectrpc.com/grpchealth in lantern_listener.go;
+// HealthChecker wraps a *grpchealth.StaticChecker so the readiness
+// Gate and LanternServer can drive per-service status transitions
+// through a single typed API.
 //
-// The wrapper preserves the historical surface:
-//   - SetServingStatus(service, healthpb.HealthCheckResponse_ServingStatus)
-//     mirrors *grpc/health/v1.Server.SetServingStatus exactly so neither
-//     readiness.Gate nor service.LanternServer notice the swap.
-//   - Shutdown() flips every known service to NOT_SERVING — the same end
-//     state *health.Server.Shutdown() leaves the table in.
+//   - SetServingStatus(service, grpchealth.Status) mirrors
+//     *grpc/health/v1.Server.SetServingStatus so the call shape stays
+//     boring at every call site.
+//   - Shutdown() flips every known service to StatusNotServing — the
+//     drain signal infra probes look for during teardown.
 //
 // The Checker is mounted by lantern_listener.go via
 // grpchealth.NewHandler(checker), so existing infra clients
@@ -20,17 +18,12 @@
 package provider
 
 import (
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
-
 	"connectrpc.com/grpchealth"
 )
 
 // HealthChecker is the gRPC-Health-v1 implementation exposed on the
 // primary listener. It wraps a *grpchealth.StaticChecker so the
-// per-service status table is owned by the Connect adapter, but the
-// SetServingStatus / Shutdown API is shaped like the legacy
-// google.golang.org/grpc/health.Server so existing wiring continues to
-// work unmodified.
+// per-service status table is owned by the Connect adapter.
 type HealthChecker struct {
 	inner    *grpchealth.StaticChecker
 	services []string
@@ -39,9 +32,9 @@ type HealthChecker struct {
 // NewHealthChecker constructs the checker pre-populated with the
 // LanternService and LanternReplicationService entries. Both start
 // Unknown; callers (LanternServer.Run + readiness.Gate) flip them to
-// SERVING / NOT_SERVING via SetServingStatus as the lifecycle
-// progresses. The overall ("") status is handled by StaticChecker's
-// built-in process-level status.
+// StatusServing / StatusNotServing via SetServingStatus as the
+// lifecycle progresses. The overall ("") status is handled by
+// StaticChecker's built-in process-level status.
 func NewHealthChecker() *HealthChecker {
 	// Registering the per-service names up front is what makes
 	// grpc-health-probe with --service= work (StaticChecker only
@@ -49,12 +42,11 @@ func NewHealthChecker() *HealthChecker {
 	// unknown service maps to NotFound). Both Lantern services
 	// start Unknown; LanternServer.Run flips them as it starts and
 	// stops.
+	//
+	// We declare the service names inline (rather than importing
+	// graphv1connect) to avoid the import cycle the wire layer can
+	// hit when both files exist in the same package.
 	services := []string{
-		// Mirror the gRPC service names: graph.v1.LanternService /
-		// graph.v1.LanternReplicationService. The constants live in
-		// the generated graphv1connect package; declaring them
-		// inline here avoids the import cycle the wire layer can
-		// hit when both files exist in the same package.
 		"graph.v1.LanternService",
 		"graph.v1.LanternReplicationService",
 	}
@@ -65,24 +57,21 @@ func NewHealthChecker() *HealthChecker {
 // Inner exposes the underlying *grpchealth.StaticChecker so
 // lantern_listener.go can mount it via grpchealth.NewHandler. Hiding
 // the field forces callers to go through SetServingStatus for state
-// transitions, which is the contract HealthSetter promises.
+// transitions.
 func (h *HealthChecker) Inner() *grpchealth.StaticChecker { return h.inner }
 
-// SetServingStatus mirrors *grpc/health/v1.Server.SetServingStatus so
-// callers don't notice the Connect swap. UNKNOWN maps to
-// grpchealth.StatusUnknown; SERVING to StatusServing; NOT_SERVING to
-// StatusNotServing; SERVICE_UNKNOWN is collapsed to StatusUnknown
-// because StaticChecker has no equivalent (it returns NotFound for
-// services not registered at construction, which is the same
-// observable behaviour for a probe).
-func (h *HealthChecker) SetServingStatus(service string, status healthpb.HealthCheckResponse_ServingStatus) {
-	h.inner.SetStatus(service, mapServingStatus(status))
+// SetServingStatus flips the service entry to the supplied status.
+// Mirrors the historical *grpc/health/v1.Server.SetServingStatus call
+// shape so readiness.Gate and service.LanternServer don't need to
+// know about the Connect-side type.
+func (h *HealthChecker) SetServingStatus(service string, status grpchealth.Status) {
+	h.inner.SetStatus(service, status)
 }
 
 // Shutdown flips every registered service entry — and the overall
-// process status — to NOT_SERVING. Called from App teardown to
-// mirror *health.Server.Shutdown() so probes see the drain signal
-// before the listener stops accepting connections.
+// process status — to StatusNotServing. Called from App teardown so
+// probes see the drain signal before the listener stops accepting
+// connections.
 func (h *HealthChecker) Shutdown() {
 	for _, s := range h.services {
 		h.inner.SetStatus(s, grpchealth.StatusNotServing)
@@ -91,15 +80,4 @@ func (h *HealthChecker) Shutdown() {
 	// Flipping it to NotServing is what tells overall ("") health
 	// probes to drain.
 	h.inner.SetStatus("", grpchealth.StatusNotServing)
-}
-
-func mapServingStatus(s healthpb.HealthCheckResponse_ServingStatus) grpchealth.Status {
-	switch s {
-	case healthpb.HealthCheckResponse_SERVING:
-		return grpchealth.StatusServing
-	case healthpb.HealthCheckResponse_NOT_SERVING:
-		return grpchealth.StatusNotServing
-	default:
-		return grpchealth.StatusUnknown
-	}
 }

--- a/server/provider/pprof_test.go
+++ b/server/provider/pprof_test.go
@@ -7,13 +7,12 @@ import (
 
 	"github.com/anaregdesign/lantern/server/readiness"
 	"github.com/prometheus/client_golang/prometheus"
-	"google.golang.org/grpc/health"
 )
 
 // TestPprof_DisabledByDefault confirms /debug/pprof/* is not reachable when
 // EnablePprof is false. This is the on-by-default-on-prod safety guarantee.
 func TestPprof_DisabledByDefault(t *testing.T) {
-	gate := readiness.NewGate(10000, false, health.NewServer())
+	gate := readiness.NewGate(10000, false, NewHealthChecker())
 	ts := httptest.NewServer(newMetricsMux(prometheus.NewRegistry(), gate, false))
 	defer ts.Close()
 
@@ -40,7 +39,7 @@ func TestPprof_DisabledByDefault(t *testing.T) {
 // We deliberately skip /debug/pprof/profile and /debug/pprof/trace because
 // those block for a sampling window.
 func TestPprof_EnabledServesIndexAndProfiles(t *testing.T) {
-	gate := readiness.NewGate(10000, false, health.NewServer())
+	gate := readiness.NewGate(10000, false, NewHealthChecker())
 	ts := httptest.NewServer(newMetricsMux(prometheus.NewRegistry(), gate, true))
 	defer ts.Close()
 
@@ -68,7 +67,7 @@ func TestPprof_EnabledServesIndexAndProfiles(t *testing.T) {
 // TestPprof_EnabledKeepsMetricsAndReadyz makes sure mounting the pprof
 // handlers does not collide with the pre-existing routes on the same mux.
 func TestPprof_EnabledKeepsMetricsAndReadyz(t *testing.T) {
-	gate := readiness.NewGate(10000, false, health.NewServer())
+	gate := readiness.NewGate(10000, false, NewHealthChecker())
 	ts := httptest.NewServer(newMetricsMux(prometheus.NewRegistry(), gate, true))
 	defer ts.Close()
 

--- a/server/provider/provider_test.go
+++ b/server/provider/provider_test.go
@@ -15,7 +15,6 @@ import (
 	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
 	"github.com/anaregdesign/lantern/server/readiness"
 	"github.com/prometheus/client_golang/prometheus"
-	"google.golang.org/grpc/health"
 )
 
 // TestWireCacheGCHooks_EmitsTickSummary asserts that a single
@@ -72,7 +71,7 @@ func TestMetricsMux(t *testing.T) {
 	t.Run("ReadinessSingleInstance", func(t *testing.T) {
 		// Single-instance mode (peerMode=false) returns 200 on
 		// /readyz + /healthz/ready immediately at startup.
-		gate := readiness.NewGate(10000, false, health.NewServer())
+		gate := readiness.NewGate(10000, false, NewHealthChecker())
 		ts := httptest.NewServer(newMetricsMux(prometheus.NewRegistry(), gate, false))
 		defer ts.Close()
 
@@ -93,7 +92,7 @@ func TestMetricsMux(t *testing.T) {
 		// Multi-peer mode drives the gate through bootstrap and
 		// per-peer lag transitions; both probe endpoints must
 		// reflect each transition.
-		gate := readiness.NewGate(100, true, health.NewServer())
+		gate := readiness.NewGate(100, true, NewHealthChecker())
 		ts := httptest.NewServer(newMetricsMux(prometheus.NewRegistry(), gate, false))
 		defer ts.Close()
 

--- a/server/readiness/gate.go
+++ b/server/readiness/gate.go
@@ -19,14 +19,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"connectrpc.com/grpchealth"
 )
 
-// HealthSetter is the narrow surface of *health.Server consumed by Gate.
-// Matches the same shape as service.HealthSetter so wire bindings reuse
-// the existing *health.Server registration.
+// HealthSetter is the narrow surface of *grpchealth.StaticChecker (wrapped
+// by *provider.HealthChecker) consumed by Gate. Defined here so the
+// readiness package stays free of any concrete health-server dependency.
 type HealthSetter interface {
-	SetServingStatus(service string, status healthpb.HealthCheckResponse_ServingStatus)
+	SetServingStatus(service string, status grpchealth.Status)
 }
 
 // Gate tracks readiness state for the overall ("") gRPC health entry.
@@ -49,7 +49,7 @@ type Gate struct {
 	mu           sync.Mutex
 	bootstrapped bool
 	lags         map[string]uint64 // key = peer + "\x00" + origin
-	current      healthpb.HealthCheckResponse_ServingStatus
+	current      grpchealth.Status
 
 	// ready is a lock-free mirror of the current status so HTTP probes
 	// can answer without contending with metric updates.
@@ -66,16 +66,16 @@ func NewGate(maxLag uint64, hasPeers bool, hs HealthSetter) *Gate {
 		hasPeers: hasPeers,
 		health:   hs,
 		lags:     make(map[string]uint64),
-		current:  healthpb.HealthCheckResponse_NOT_SERVING,
+		current:  grpchealth.StatusNotServing,
 	}
 	if !hasPeers {
 		// Single-instance: ready immediately. Surface SERVING via the
 		// health setter so probes see green from t=0.
 		g.bootstrapped = true
-		g.current = healthpb.HealthCheckResponse_SERVING
+		g.current = grpchealth.StatusServing
 		g.ready.Store(true)
 		if hs != nil {
-			hs.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+			hs.SetServingStatus("", grpchealth.StatusServing)
 		}
 	}
 	return g
@@ -142,15 +142,15 @@ func (g *Gate) readyLocked() bool {
 }
 
 func (g *Gate) evaluateLocked() {
-	want := healthpb.HealthCheckResponse_NOT_SERVING
+	want := grpchealth.StatusNotServing
 	if g.readyLocked() {
-		want = healthpb.HealthCheckResponse_SERVING
+		want = grpchealth.StatusServing
 	}
 	if want == g.current {
 		return
 	}
 	g.current = want
-	g.ready.Store(want == healthpb.HealthCheckResponse_SERVING)
+	g.ready.Store(want == grpchealth.StatusServing)
 	if g.health != nil {
 		g.health.SetServingStatus("", want)
 	}

--- a/server/readiness/gate_test.go
+++ b/server/readiness/gate_test.go
@@ -4,23 +4,23 @@ import (
 	"sync"
 	"testing"
 
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"connectrpc.com/grpchealth"
 )
 
 type fakeHealth struct {
 	mu     sync.Mutex
-	calls  []healthpb.HealthCheckResponse_ServingStatus
-	latest healthpb.HealthCheckResponse_ServingStatus
+	calls  []grpchealth.Status
+	latest grpchealth.Status
 }
 
-func (f *fakeHealth) SetServingStatus(_ string, s healthpb.HealthCheckResponse_ServingStatus) {
+func (f *fakeHealth) SetServingStatus(_ string, s grpchealth.Status) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.calls = append(f.calls, s)
 	f.latest = s
 }
 
-func (f *fakeHealth) snapshot() (latest healthpb.HealthCheckResponse_ServingStatus, n int) {
+func (f *fakeHealth) snapshot() (latest grpchealth.Status, n int) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.latest, len(f.calls)
@@ -34,7 +34,7 @@ func TestGate_SingleInstanceBypass(t *testing.T) {
 		t.Fatalf("single-instance gate must be Ready at construction")
 	}
 	latest, n := hs.snapshot()
-	if n != 1 || latest != healthpb.HealthCheckResponse_SERVING {
+	if n != 1 || latest != grpchealth.StatusServing {
 		t.Fatalf("expected 1 SERVING transition, got %d calls latest=%v", n, latest)
 	}
 
@@ -73,7 +73,7 @@ func TestGate_MultiPeer_BootstrapAndLag(t *testing.T) {
 		t.Fatalf("expected SERVING after bootstrap with lag below threshold")
 	}
 	latest, _ := hs.snapshot()
-	if latest != healthpb.HealthCheckResponse_SERVING {
+	if latest != grpchealth.StatusServing {
 		t.Fatalf("expected SERVING transition, got %v", latest)
 	}
 
@@ -83,7 +83,7 @@ func TestGate_MultiPeer_BootstrapAndLag(t *testing.T) {
 		t.Fatalf("expected NOT_SERVING when lag > maxLag")
 	}
 	latest, _ = hs.snapshot()
-	if latest != healthpb.HealthCheckResponse_NOT_SERVING {
+	if latest != grpchealth.StatusNotServing {
 		t.Fatalf("expected NOT_SERVING transition, got %v", latest)
 	}
 

--- a/server/service/connect.go
+++ b/server/service/connect.go
@@ -1,27 +1,24 @@
-// Package service: connect.go adapts the existing *LanternService and
-// *LanternReplicationService structs to the Connect-Go handler interfaces
-// generated under pb/graph/v1/graphv1connect (#336). The adapters forward
-// every Connect call to the unchanged underlying method, so all existing
-// gRPC tests keep covering the business logic by reference.
+// Package service: connect.go adapts *LanternService and
+// *LanternReplicationService to the Connect-Go handler interfaces
+// generated under pb/graph/v1/graphv1connect. The adapters forward
+// every Connect call to the unchanged underlying method.
 //
-// Why an adapter (rather than rewriting the service struct's method set):
-//   - Until #347 cuts the primary :6380 listener over to h2c+Connect, both
-//     the gRPC and Connect surfaces are live concurrently. Keeping the two
-//     handler shapes in separate structs lets each surface evolve without
-//     either becoming an "almost-Connect" or "almost-gRPC" Frankenstein.
-//   - The grpc.ServerStreamingServer[T] interface that the existing
-//     Subscribe/Snapshot methods take has seven methods; only Send and
-//     Context are actually called inside replication.go. We satisfy the
-//     full interface here with a tiny shim (connectServerStream) so the
-//     unchanged Subscribe/Snapshot implementations work over Connect with
-//     zero modification.
+// Why an adapter (rather than implementing the Connect interfaces
+// directly on the service structs):
+//   - The service structs predate Connect codegen and have signatures
+//     shaped by the original gRPC contract (req/resp values, no
+//     connect.Request[T] wrapper). Adapting them here keeps each side
+//     idiomatic for its consumers.
+//   - The Connect server-stream method signature takes ctx + req +
+//     *connect.ServerStream[T]. *connect.ServerStream[T] satisfies the
+//     local service.Sender[T] interface directly (both expose
+//     Send(*T) error), so streaming methods forward without a bridge.
 package service
 
 import (
 	"context"
 
 	"connectrpc.com/connect"
-	"google.golang.org/grpc/metadata"
 
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
@@ -136,16 +133,17 @@ func (h *lanternReplicationServiceConnect) Subscribe(ctx context.Context, req *c
 	if h.svc == nil {
 		return connect.NewError(connect.CodeUnavailable, errReplicationDisabled)
 	}
-	// Subscribe returns *connect.Error directly (see replication.go),
-	// so no extra translation is needed at this seam.
-	return h.svc.Subscribe(req.Msg, newConnectServerStream[pb.SubscribeResponse](ctx, stream))
+	// *connect.ServerStream[T] satisfies service.Sender[T] directly
+	// (both expose Send(*T) error). The service method returns a
+	// *connect.Error already, so no translation layer is needed.
+	return h.svc.Subscribe(ctx, req.Msg, stream)
 }
 
 func (h *lanternReplicationServiceConnect) Snapshot(ctx context.Context, req *connect.Request[pb.SnapshotRequest], stream *connect.ServerStream[pb.SnapshotResponse]) error {
 	if h.svc == nil {
 		return connect.NewError(connect.CodeUnavailable, errReplicationDisabled)
 	}
-	return h.svc.Snapshot(req.Msg, newConnectServerStream[pb.SnapshotResponse](ctx, stream))
+	return h.svc.Snapshot(ctx, req.Msg, stream)
 }
 
 func (h *lanternReplicationServiceConnect) PeerStatus(ctx context.Context, req *connect.Request[pb.PeerStatusRequest]) (*connect.Response[pb.PeerStatusResponse], error) {
@@ -163,38 +161,4 @@ type replicationDisabledError struct{}
 
 func (*replicationDisabledError) Error() string {
 	return "replication is not enabled on this server"
-}
-
-// connectServerStream adapts *connect.ServerStream[T] to the
-// grpc.ServerStreamingServer[T] interface that the existing
-// Subscribe/Snapshot methods take. The Subscribe/Snapshot implementations
-// in replication.go only call Send and Context — the remaining
-// grpc.ServerStream methods (SetHeader/SendHeader/SetTrailer/SendMsg/
-// RecvMsg) are no-ops or panic, which is safe because the production
-// callers never invoke them.
-type connectServerStream[T any] struct {
-	ctx    context.Context
-	stream *connect.ServerStream[T]
-}
-
-func newConnectServerStream[T any](ctx context.Context, stream *connect.ServerStream[T]) *connectServerStream[T] {
-	return &connectServerStream[T]{ctx: ctx, stream: stream}
-}
-
-func (s *connectServerStream[T]) Send(m *T) error          { return s.stream.Send(m) }
-func (s *connectServerStream[T]) Context() context.Context { return s.ctx }
-
-// SetHeader / SendHeader / SetTrailer / SendMsg / RecvMsg satisfy the
-// remaining grpc.ServerStream surface. They are unused by the underlying
-// Subscribe/Snapshot implementations.
-func (s *connectServerStream[T]) SetHeader(md metadata.MD) error  { return nil }
-func (s *connectServerStream[T]) SendHeader(md metadata.MD) error { return nil }
-func (s *connectServerStream[T]) SetTrailer(md metadata.MD)       {}
-
-func (s *connectServerStream[T]) SendMsg(any) error {
-	panic("connectServerStream.SendMsg: unsupported on the Connect adapter; production callers use Send")
-}
-
-func (s *connectServerStream[T]) RecvMsg(any) error {
-	panic("connectServerStream.RecvMsg: unsupported on the Connect adapter; server-streaming has no client→server frames")
 }

--- a/server/service/replication.go
+++ b/server/service/replication.go
@@ -7,13 +7,21 @@ import (
 	"log/slog"
 
 	"connectrpc.com/connect"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 )
+
+// Sender is the slim, transport-agnostic surface Subscribe and
+// Snapshot need from a server-streaming client connection: a single
+// typed Send method. *connect.ServerStream[T] satisfies it directly.
+// Tests that need to observe the streamed messages provide their own
+// implementation (see replication_test.go).
+type Sender[T any] interface {
+	Send(*T) error
+}
 
 // ReplicationServiceName is the fully-qualified gRPC service name for the
 // replication surface. Used for per-service health reporting.
@@ -44,15 +52,15 @@ type OriginStatesProvider interface {
 	OriginStates() []OriginState
 }
 
-// LanternReplicationService implements pb.LanternReplicationServiceServer.
-// It exposes the mutation log as a resumable, back-pressured server-streaming
-// RPC for peer replication and CDC consumers.
+// LanternReplicationService is the in-process implementation of the
+// graph.v1.LanternReplicationService surface. It exposes the
+// mutation log as a resumable, back-pressured server-streaming RPC
+// for peer replication and CDC consumers.
 //
 // The service holds a reference to the same *mutationlog.Log that
-// LanternService.WithReplication wired into the write path, so subscribers
-// see every successfully appended mutation in seq order.
+// LanternService.WithReplication wired into the write path, so
+// subscribers see every successfully appended mutation in seq order.
 type LanternReplicationService struct {
-	pb.UnimplementedLanternReplicationServiceServer
 	log     *mutationlog.Log
 	backend Backend
 	clock   *hlc.Clock
@@ -103,7 +111,8 @@ func (s *LanternReplicationService) WithOriginStates(p OriginStatesProvider) *La
 	return s
 }
 
-// Subscribe implements pb.LanternReplicationServiceServer.
+// Subscribe streams every mutation log entry at or after req.FromSeq
+// to the supplied Sender, honouring ctx cancellation throughout.
 //
 // Flow:
 //  1. Open a subscription on the mutation log starting at req.FromSeq.
@@ -118,10 +127,10 @@ func (s *LanternReplicationService) WithOriginStates(p OriginStatesProvider) *La
 //  3. If the channel is closed mid-stream the subscriber fell behind the
 //     per-subscriber buffer (Options.SubscriberBuffer). Surface this as
 //     FailedPrecondition + "gapped" — symmetric with case 1.
-//  4. Honor stream.Context() cancellation throughout.
+//  4. Honor ctx cancellation throughout.
 //
 // Send errors terminate the stream and increment dropped{reason="send_failed"}.
-func (s *LanternReplicationService) Subscribe(req *pb.SubscribeRequest, stream grpc.ServerStreamingServer[pb.SubscribeResponse]) error {
+func (s *LanternReplicationService) Subscribe(ctx context.Context, req *pb.SubscribeRequest, stream Sender[pb.SubscribeResponse]) error {
 	if s.log == nil {
 		return connect.NewError(connect.CodeUnavailable, errors.New("replication is not enabled on this server"))
 	}
@@ -140,7 +149,6 @@ func (s *LanternReplicationService) Subscribe(req *pb.SubscribeRequest, stream g
 	s.metrics.OnSubscribeStarted()
 	defer s.metrics.OnSubscribeEnded()
 
-	ctx := stream.Context()
 	for {
 		select {
 		case <-ctx.Done():
@@ -205,11 +213,10 @@ func (s *LanternReplicationService) loggerOrDefault() *slog.Logger {
 // Replication bootstrap is bounded (one peer per call, infrequent), so
 // the O(N+E) memory overhead is acceptable. True streaming is a follow-up
 // once the snapshot path is wired end-to-end.
-func (s *LanternReplicationService) Snapshot(_ *pb.SnapshotRequest, stream grpc.ServerStreamingServer[pb.SnapshotResponse]) error {
+func (s *LanternReplicationService) Snapshot(ctx context.Context, _ *pb.SnapshotRequest, stream Sender[pb.SnapshotResponse]) error {
 	if s.backend == nil {
 		return connect.NewError(connect.CodeUnavailable, errors.New("snapshot is not enabled on this server"))
 	}
-	ctx := stream.Context()
 
 	var cutoffSeq uint64
 	if s.log != nil {

--- a/server/service/server.go
+++ b/server/service/server.go
@@ -17,7 +17,7 @@ import (
 	"net/http"
 	"time"
 
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"connectrpc.com/grpchealth"
 )
 
 // LanternServer owns the lifecycle of the primary listener: starts the
@@ -48,7 +48,7 @@ type Watcher interface {
 // (the connectrpc.com/grpchealth-backed implementation) so the wire
 // binding is one line.
 type HealthSetter interface {
-	SetServingStatus(service string, status healthpb.HealthCheckResponse_ServingStatus)
+	SetServingStatus(service string, status grpchealth.Status)
 }
 
 // Listener is the narrow surface of provider.LanternListener that
@@ -104,8 +104,8 @@ func NewLanternServer(
 // a hard tear-down so the process can exit.
 func (s *LanternServer) Run(ctx context.Context) error {
 	if s.health != nil {
-		s.health.SetServingStatus(ServiceName, healthpb.HealthCheckResponse_SERVING)
-		s.health.SetServingStatus(ReplicationServiceName, healthpb.HealthCheckResponse_SERVING)
+		s.health.SetServingStatus(ServiceName, grpchealth.StatusServing)
+		s.health.SetServingStatus(ReplicationServiceName, grpchealth.StatusServing)
 	}
 
 	go s.gracefulShutdown(ctx)
@@ -134,8 +134,8 @@ func (s *LanternServer) Run(ctx context.Context) error {
 	}
 
 	if s.health != nil {
-		s.health.SetServingStatus(ServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
-		s.health.SetServingStatus(ReplicationServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
+		s.health.SetServingStatus(ServiceName, grpchealth.StatusNotServing)
+		s.health.SetServingStatus(ReplicationServiceName, grpchealth.StatusNotServing)
 	}
 	return err
 }
@@ -150,8 +150,8 @@ func (s *LanternServer) gracefulShutdown(ctx context.Context) {
 	s.logger.Info("shutting down lantern server",
 		slog.Duration("timeout", s.shutdownTimeout))
 	if s.health != nil {
-		s.health.SetServingStatus(ServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
-		s.health.SetServingStatus(ReplicationServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
+		s.health.SetServingStatus(ServiceName, grpchealth.StatusNotServing)
+		s.health.SetServingStatus(ReplicationServiceName, grpchealth.StatusNotServing)
 	}
 	shutdownCtx := context.Background()
 	if s.shutdownTimeout > 0 {

--- a/server/service/server_external_test.go
+++ b/server/service/server_external_test.go
@@ -10,30 +10,31 @@ import (
 	"testing"
 	"time"
 
+	"connectrpc.com/grpchealth"
+
 	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/server/service"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 // recordingHealth captures every SetServingStatus call so we can assert
 // that Run flips NOT_SERVING after Serve returns, regardless of cause.
 type recordingHealth struct {
 	mu     sync.Mutex
-	events []healthpb.HealthCheckResponse_ServingStatus
+	events []grpchealth.Status
 }
 
-func (r *recordingHealth) SetServingStatus(_ string, s healthpb.HealthCheckResponse_ServingStatus) {
+func (r *recordingHealth) SetServingStatus(_ string, s grpchealth.Status) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.events = append(r.events, s)
 }
 
-func (r *recordingHealth) last() healthpb.HealthCheckResponse_ServingStatus {
+func (r *recordingHealth) last() grpchealth.Status {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if len(r.events) == 0 {
-		return healthpb.HealthCheckResponse_UNKNOWN
+		return grpchealth.StatusUnknown
 	}
 	return r.events[len(r.events)-1]
 }
@@ -97,13 +98,13 @@ func TestLanternServer_Run_FlipsHealthOnServeReturn(t *testing.T) {
 		t.Fatal("Run returned nil error; want listener error")
 	}
 
-	if got := hs.last(); got != healthpb.HealthCheckResponse_NOT_SERVING {
+	if got := hs.last(); got != grpchealth.StatusNotServing {
 		t.Errorf("last health status = %v, want NOT_SERVING", got)
 	}
 	// Must have transitioned through SERVING first.
 	hs.mu.Lock()
 	defer hs.mu.Unlock()
-	if len(hs.events) < 2 || hs.events[0] != healthpb.HealthCheckResponse_SERVING {
+	if len(hs.events) < 2 || hs.events[0] != grpchealth.StatusServing {
 		t.Errorf("expected SERVING then NOT_SERVING, got %v", hs.events)
 	}
 }

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -16,23 +16,26 @@ import (
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 )
 
-// ServiceName is the fully-qualified gRPC service name used for per-service
+// ServiceName is the fully-qualified service name used for per-service
 // health reporting (grpc.health.v1) and as a logical metric label.
 const ServiceName = "graph.v1.LanternService"
 
-// LanternService implements pb.LanternServiceServer.
+// LanternService is the in-process implementation of the
+// graph.v1.LanternService surface. The Connect handler adapter in
+// connect.go wraps it; tests exercise it directly.
 //
-// Per-call logging, metrics, recovery, tracing and validation are wired up
-// via interceptors in server/provider so handlers stay focused on business
-// logic. Handlers honor the incoming context — short paths rely on gRPC to
-// propagate cancellation; the early ctx.Err() checks let us return a clean
-// Canceled / DeadlineExceeded status when a client already gave up.
+// Per-call logging, metrics, recovery, tracing and validation are
+// wired up via Connect interceptors in server/provider so handlers
+// stay focused on business logic. Handlers honor the incoming
+// context — short paths rely on the transport to propagate
+// cancellation; the early ctx.Err() checks let us return a clean
+// Canceled / DeadlineExceeded *connect.Error when a client already
+// gave up.
 //
 // The service depends on the narrow Backend interface (see backend.go); a
 // wire binding maps it to *graph.GraphCache in production. Tests can supply
 // a fake without standing up the real cache.
 type LanternService struct {
-	pb.UnimplementedLanternServiceServer
 	cache                  Backend
 	scan                   ScanLimits
 	log                    *mutationlog.Log


### PR DESCRIPTION
Closes #375. PR 3 of 3.

## What

Final step in the 3-PR effort (#377 #378 #this) to remove `google.golang.org/grpc` as a direct dep from `server/go.mod`. The dep persists as **indirect** only because the OTLP/gRPC trace exporter (`otlptracegrpc`) legitimately uses gRPC as its telemetry transport — that use case is independent of the service surface and was treated as out of scope in the #375 acceptance criteria.

## Changes

### 1. `Subscribe` / `Snapshot` signature flip (`server/service/replication.go`)

New local interface:

```go
type Sender[T any] interface { Send(*T) error }
```

`*connect.ServerStream[T]` satisfies it directly. `Subscribe` and `Snapshot` now take `(ctx, req, Sender[T])` instead of `(req, grpc.ServerStreamingServer[T])`. The `pb.UnimplementedLanternReplicationServiceServer` embed is gone.

### 2. Connect adapter simplification (`server/service/connect.go`)

The `connectServerStream` bridge that wrapped `*connect.ServerStream` in a fake `grpc.ServerStream` is deleted (was 7 methods, 5 of them no-ops or panics). `Subscribe`/`Snapshot` in the adapter now forward `(ctx, req.Msg, stream)` directly to the service. Drop the `metadata` import.

### 3. Health enum migration (`server/{provider,readiness,service,cmd}`)

Every `healthpb.HealthCheckResponse_ServingStatus` call site becomes `grpchealth.Status`; `SERVING` / `NOT_SERVING` / `UNKNOWN` constants become `grpchealth.StatusServing` / `StatusNotServing` / `StatusUnknown`. `mapServingStatus` in `provider/health.go` becomes identity (deleted; `SetServingStatus` calls `inner.SetStatus` directly). Test fakes in `readiness/gate_test.go` + `server/service/server_external_test.go` switch the import too.

### 4. Test fakes (`provider/provider_test.go` + `provider/pprof_test.go`)

Replace the legacy `*health.Server` fakes (the only consumer of `google.golang.org/grpc/health` in tests) with `NewHealthChecker()` — the actual production health surface.

### 5. `pb.Unimplemented*Server` embeds removed

Both `LanternService` and `LanternReplicationService` drop the gRPC unimplemented-base embeds. The Connect adapter satisfies the Connect-Go handler interface; the struct itself no longer pretends to satisfy a gRPC interface.

### 6. `server/go.mod`

`google.golang.org/grpc` drops out of direct requires (now indirect under `otlptracegrpc`). `google.golang.org/grpc/health` transitive dep gone entirely.

## Verification

- `go build ./...` clean across the workspace.
- `go test -race -count=1 ./...` green across every per-module `go.mod`.
- `gofmt -l` clean; `go vet` clean per module.
- No `google.golang.org/grpc` or `healthpb` imports in any non-OTLP server source file.