### PR TITLE
fix(deploy): copy mcp/go.mod in Dockerfile + document bench Connect-compat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,11 @@ introduced a new sub-config, update the **Providers** bullet in this file.
   propagate `go.sum` entries.
 - If the Dockerfile was touched, confirm every workspace member's `go.mod` and
   `go.sum` are COPYed **before** `go mod download` (go.work prerequisite).
+  The current list (6 modules: root, `core/`, `mcp/`, `pb/`, `sdks/go/`,
+  `server/`) must stay in lockstep with `go.work`. PR CI does not run
+  `docker build`, so a missed `COPY` only surfaces at release-tag time —
+  see [#382](https://github.com/anaregdesign/lantern/issues/382) for the
+  `mcp/go.mod` regression caused by exactly this.
 
 ### Bumping the Go toolchain
 
@@ -301,7 +306,12 @@ Tag order matters because each downstream module pins the upstream tag:
    `testbed/bench/release-scenarios.txt`, including all illuminate
    variants, batch/scan/edge/TTL paths, and many_subscribers fan-out)
    and splices a fixed-format report into the release notes. The bench
-   job is non-blocking — if it fails, the release still ships with a
+   driver uses `ghz`; Connect-Go handlers accept gRPC frames natively
+   on the same h2c socket and `connectrpc.com/grpcreflect` exposes the
+   reflection service, so the harness works unchanged against the
+   Connect-only server (verified in
+   [#383](https://github.com/anaregdesign/lantern/issues/383)). The
+   bench job is non-blocking — if it fails, the release still ships with a
    placeholder bench section. See issues
    [#256](https://github.com/anaregdesign/lantern/issues/256) and
    [#262](https://github.com/anaregdesign/lantern/issues/262).

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,13 @@ FROM golang:1.26-alpine AS builder
 WORKDIR /src
 
 # Cache module downloads independently of source changes.
-# go.work pulls in the sdks/go module from this monorepo.
+# go.work pulls in every workspace member; `go mod download` fails with
+# `cannot load module <name> listed in go.work file` if any per-module
+# go.mod is missing from the build context. Keep this COPY block in
+# lockstep with `go.work`.
 COPY go.mod go.sum go.work go.work.sum* ./
 COPY core/go.mod core/go.sum ./core/
+COPY mcp/go.mod mcp/go.sum ./mcp/
 COPY pb/go.mod pb/go.sum ./pb/
 COPY sdks/go/go.mod sdks/go/go.sum ./sdks/go/
 COPY server/go.mod server/go.sum ./server/

--- a/testbed/bench/README.md
+++ b/testbed/bench/README.md
@@ -27,10 +27,19 @@ per-scenario leak gate, and renders a Markdown report.
 ## Prerequisites
 
 - Docker + `docker compose` v2
-- [`ghz`][ghz] ≥ 0.117
+- [`ghz`][ghz] ≥ 0.117 — drives load over gRPC wire frames. The Lantern
+  server is Connect-only (see [#335][i335]), but the Connect-Go handlers
+  accept gRPC, gRPC-Web, and Connect on the same h2c socket, and
+  `connectrpc.com/grpcreflect` exposes the standard
+  `grpc.reflection.v1*` service the harness uses for descriptor
+  discovery. ghz keeps working unchanged. See [#383][i383] for the
+  verification log.
 - [`yq`][yq] v4 (Go reimplementation)
 - `jq`, `curl`, `bash` ≥ 4
 - Go (matching `go.mod` toolchain) — used to build the report renderer
+
+[i335]: https://github.com/anaregdesign/lantern/issues/335
+[i383]: https://github.com/anaregdesign/lantern/issues/383
 
 ## Quick start
 

--- a/testbed/bench/run.sh
+++ b/testbed/bench/run.sh
@@ -63,10 +63,14 @@ steady_conc="$(yq -r '.phases.steady.concurrency' "$SCENARIO_FILE")"
 steady_rps="$(yq -r '.phases.steady.rps' "$SCENARIO_FILE")"
 cooldown="$(yq -r '.phases.cooldown' "$SCENARIO_FILE")"
 endpoints=( $(yq -r '.target.endpoints[]' "$SCENARIO_FILE") )
-# ghz uses gRPC reflection to resolve method/message descriptors. The server
-# registers reflection unconditionally (see server/provider/provider.go), so
-# we do not need to point ghz at the .proto file — which would also pull in
-# google/api/annotations.proto from grpc-gateway and other transitive deps.
+# ghz drives load over gRPC wire, which the server's Connect-Go handlers
+# accept natively on the same h2c socket (per #347 — the primary :6380
+# port serves Connect + gRPC + gRPC-Web simultaneously). ghz uses gRPC
+# reflection to resolve method/message descriptors; the server mounts
+# `connectrpc.com/grpcreflect` unconditionally (see
+# server/provider/lantern_listener.go), so no .proto file is needed and
+# the harness keeps working unchanged against the Connect-only server.
+# See #383 for the empirical verification log.
 
 # ----- compose up ------------------------------------------------------------
 if [[ "${SKIP_UP:-0}" != "1" ]]; then

--- a/testbed/docker-compose.yml
+++ b/testbed/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     image: ${LANTERN_IMAGE:-lantern:local}
     container_name: lantern-testbed
     ports:
-      - "6380:6380"   # gRPC
+      - "6380:6380"   # Connect (also accepts gRPC + gRPC-Web on the same h2c socket)
       - "9090:9090"   # /metrics, /healthz, /readyz
     environment:
       LANTERN_PORT: "6380"


### PR DESCRIPTION
Closes #382. Closes #383.

Two coupled v1.0-prep fixes that came out of the same investigation while triaging the last bullets of #342.

## #382 — Dockerfile fails because `mcp/go.mod` isn't copied

`docker build -t lantern .` has been broken on `main` since #288 added the mcp module to `go.work`. The Dockerfile builder stage copies five per-module manifests before `go mod download`, but never the new `mcp/go.mod`. PR CI doesn't run `docker build`, so the regression only surfaces at `v*.*.*` tag time via `docker-publish.yml`.

Repro before:
```
0.151 go: cannot load module mcp listed in go.work file: open mcp/go.mod: no such file or directory
ERROR: failed to build: failed to solve: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

Fix: add `COPY mcp/go.mod mcp/go.sum ./mcp/` to the builder stage with a comment noting the block must stay in lockstep with `go.work`. Verified locally:

```
$ docker build -t lantern:local .   # success
$ docker run -d -p 16380:6380 -p 19090:9090 -e LANTERN_REFLECTION=true lantern:local
$ curl http://localhost:19090/readyz                                     # ready
$ ghz --insecure --call graph.v1.LanternService.GetServerStatus ...      # 3/3 OK
```

Also updated AGENTS.md "After adding a dependency" with the explicit 6-module list and a pointer to #382, so the next contributor sees the regression trace.

## #383 — Document that the bench harness works against Connect-only

The #342 acceptance includes a bullet to "replace the ghz bench harness with a Connect-aware tool". Empirical verification (2026-06-06) against a single-replica Connect-only server:

| RPC | Calls | Result |
| --- | --- | --- |
| `PutVertex`     | 200 | 200 OK |
| `ScanVertices`  | 100 | 100 OK |
| `Illuminate`    |  50 |  50 OK |
| `Subscribe` (streaming) | 1 (-z 1s) | `Canceled` at timeout — normal end-of-stream |

ghz keeps working because:
1. Connect-Go handlers accept gRPC frames natively on the same h2c socket (per #347 the primary `:6380` listener serves Connect + gRPC + gRPC-Web).
2. `connectrpc.com/grpcreflect` mounts the standard `grpc.reflection.v1*` service that ghz uses for descriptor discovery.

The harness needs **no code changes**. This commit only updates the docs that describe ghz as "gRPC-only":

- `testbed/bench/run.sh` header comment.
- `testbed/bench/README.md` prerequisites.
- `testbed/docker-compose.yml` port comment (6380 = Connect, also accepts gRPC + gRPC-Web).
- AGENTS.md "Cutting a release" §5 — adds the wire-compat note so the next maintainer doesn't re-investigate.

## What's NOT in this PR

- Helm chart (`deploy/helm/lantern/templates/{service,statefulset}.yaml`) still names its port `grpc`. Renaming would be a breaking change for existing deployments and is unrelated to v1.0 readiness; left for a separate cleanup if/when it becomes worth the migration cost.
- Wiring `docker build` into PR CI as a smoke check (called out as follow-up in #382 itself, out of scope here).