### PR TITLE
chore(sdks/go): pin pb v0.2.0 ahead of sdks/go/v0.9.0 tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	connectrpc.com/grpchealth v1.4.0
 	github.com/anaregdesign/lantern/core v0.1.1
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
-	github.com/anaregdesign/lantern/pb v0.1.1
+	github.com/anaregdesign/lantern/pb v0.2.0
 	github.com/anaregdesign/lantern/sdks/go v0.7.1
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -3,7 +3,7 @@ module github.com/anaregdesign/lantern/mcp
 go 1.26
 
 require (
-	github.com/anaregdesign/lantern/pb v0.1.1
+	github.com/anaregdesign/lantern/pb v0.2.0
 	github.com/anaregdesign/lantern/sdks/go v0.7.1
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 )

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	connectrpc.com/connect v1.20.0
-	github.com/anaregdesign/lantern/pb v0.1.1
+	github.com/anaregdesign/lantern/pb v0.2.0
 	golang.org/x/net v0.55.0
 	google.golang.org/protobuf v1.36.11
 )


### PR DESCRIPTION
Part of the #342 v0.x release sequence.

Bumps `sdks/go/go.mod` require directive from `pb v0.1.1` → `pb v0.2.0` so that the upcoming `sdks/go/v0.9.0` tag carries the correct metadata for downstream consumers (Go module proxy reads the tag from VCS).

`replace github.com/anaregdesign/lantern/pb => ../../pb` keeps local dev unchanged.

## Verification

- `(cd sdks/go && go mod tidy)` clean
- `(cd sdks/go && go test ./...)` green
- `go test ./...` from repo root green

## Tag order (for context)

1. ✅ `pb/v0.2.0` (pushed)
2. ✅ `core/v0.2.1` (pushed)
3. **This PR** → then tag `sdks/go/v0.9.0`
4. Next PR: root `go.mod` pin bumps → tag root `v0.8.0`
5. Next PR: `mcp/go.mod` pin bumps → tag `mcp/v0.2.0`
6. Tag `admin/v0.1.0` (no Go deps)

Refs #342.