### PR TITLE
chore: pin sdks/go v0.9.0 + core v0.2.1 across root + mcp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.4.0
-	github.com/anaregdesign/lantern/core v0.1.1
+	github.com/anaregdesign/lantern/core v0.2.1
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.2.0
-	github.com/anaregdesign/lantern/sdks/go v0.7.1
+	github.com/anaregdesign/lantern/sdks/go v0.9.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/anaregdesign/lantern/pb v0.2.0
-	github.com/anaregdesign/lantern/sdks/go v0.7.1
+	github.com/anaregdesign/lantern/sdks/go v0.9.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 )
 


### PR DESCRIPTION
Part of the #342 v0.x release sequence. Bumps:

- root `go.mod`: `core v0.1.1` → `core v0.2.1`, `sdks/go v0.7.1` → `sdks/go v0.9.0`
- `mcp/go.mod`: `sdks/go v0.7.1` → `sdks/go v0.9.0`

`pb v0.2.0` was pinned in the previous PR (#385). Local `replace` directives keep dev unchanged.

## Verification

- `go test ./...` from root green
- `(cd mcp && go test ./...)` green
- `GOWORK=off go mod tidy` clean for both modules

## Tag order

1. ✅ `pb/v0.2.0` pushed
2. ✅ `core/v0.2.1` pushed
3. ✅ `sdks/go/v0.9.0` pushed
4. **This PR** → then tag root `v0.8.0` → then `mcp/v0.2.0` → then `admin/v0.1.0`

Refs #342.