### PR TITLE
fix(admin): use bunx in codegen, not npx — bun:alpine has no Node

### DIFF
--- a/admin/scripts/codegen.mjs
+++ b/admin/scripts/codegen.mjs
@@ -5,10 +5,12 @@
 //
 // Regenerate with: bun run codegen
 //
-// The bun runtime invokes `buf` via npx so the build does not need a
+// The bun runtime invokes `buf` via bunx so the build does not need a
 // global buf install — the bufbuild org publishes the CLI as
 // @bufbuild/buf. The pinned version matches the rest of the repo (see
-// root buf.gen.yaml).
+// root buf.gen.yaml). bunx is used (not npx) so the script works inside
+// the production builder image `oven/bun:alpine`, which ships only bun
+// — no Node.js / npm / npx. See #387.
 
 import { spawn } from "node:child_process";
 import { dirname, resolve } from "node:path";
@@ -28,7 +30,7 @@ async function main() {
   await rm(genDir, { recursive: true, force: true });
   await mkdir(genDir, { recursive: true });
 
-  await run("npx", [
+  await run("bunx", [
     "--yes",
     `@bufbuild/buf@${BUF_VERSION}`,
     "generate",


### PR DESCRIPTION
Closes #387.

`admin/scripts/codegen.mjs` invoked `npx --yes @bufbuild/buf@1.70.0 generate`, which works locally because the host has Node.js, but the production builder image `oven/bun:1.3.14-alpine` ships only bun — no Node, no npm, no npx. The `admin-publish.yml` run for `admin/v0.1.0` (2026-06-06) crashed during `bun run codegen` with:

```
error: Executable not found in $PATH: "npx"
error: script "codegen" exited with code 1
ERROR: process "/bin/sh -c cd admin && bun run codegen && bun run build" did not complete successfully: exit code: 1
```

[Failed run](https://github.com/anaregdesign/lantern/actions/runs/27061235792)

`bunx` is a drop-in replacement: same `--yes` flag, same `@scope/pkg@version` arg shape, same global-cache semantics. Local hosts have both, which is why the regression was masked until the first end-to-end Docker build at tag time.

## Verification

```
$ docker build -t lantern-admin:test -f admin/Dockerfile .
... ✓ built in 7.87s
$ docker run --rm -d -p 18080:8080 lantern-admin:test
$ curl -sI http://localhost:18080/healthz       # HTTP/1.1 200 OK
$ curl -sI http://localhost:18080/              # HTTP/1.1 200 OK (SPA index)
$ docker stop lantern-admin-smoke
```

## After this lands

Retag `admin/v0.1.1` (cannot move `admin/v0.1.0` — tag-trigger contract is non-idempotent past the failed run; per AGENTS.md "arm64 buildx" lesson).

## Out of scope

Wire `docker build -f admin/Dockerfile` into PR CI as a smoke check so this regression class is caught pre-tag. Same shape as the `docker build` smoke-check follow-up in #382. Tracked in #387.
