### PR TITLE
refactor(replication): drop connect.WithGRPC() — Connect-Go end-to-end

### DIFF
--- a/server/replication/antientropy.go
+++ b/server/replication/antientropy.go
@@ -204,7 +204,7 @@ func (a *AntiEntropy) tickPeer(ctx context.Context, addr string) {
 	log := a.cfg.Logger.With(slog.String("peer", addr))
 
 	cli := graphv1connect.NewLanternReplicationServiceClient(
-		a.cfg.HTTPClient, peerBaseURL(addr), connect.WithGRPC(),
+		a.cfg.HTTPClient, peerBaseURL(addr),
 	)
 
 	resp, err := cli.PeerStatus(ctx, connect.NewRequest(&pb.PeerStatusRequest{}))

--- a/server/replication/pump.go
+++ b/server/replication/pump.go
@@ -301,14 +301,12 @@ func (p *Pump) session(ctx context.Context, addr string, fromSeq uint64) (uint64
 	// connection state of their own — the underlying http.Client
 	// pools connections internally. No defer-close needed.
 	//
-	// WithGRPC pins the wire protocol to gRPC-over-h2 instead of the
-	// Connect protocol so this client can talk to both legacy
-	// grpc.NewServer peers (the production state until #347 cuts
-	// over) and Connect handlers (which accept all three protocols
-	// natively). Streaming RPCs benefit from gRPC's binary framing
-	// over the JSON-friendly Connect framing.
+	// The default Connect-Go wire protocol is used. Both ends of the
+	// replication channel are Connect handlers in the same process
+	// family, so the gRPC binary framing pin from earlier cutover
+	// builds (§A of #393) is no longer needed.
 	cli := graphv1connect.NewLanternReplicationServiceClient(
-		p.cfg.HTTPClient, peerBaseURL(addr), connect.WithGRPC(),
+		p.cfg.HTTPClient, peerBaseURL(addr),
 	)
 
 	p.cfg.Metrics.OnPumpConnect(addr)


### PR DESCRIPTION
Closes #393 (§A is the last open part; §B–§I shipped via PR #396).

## Why

\`server/replication/pump.go\` and \`server/replication/antientropy.go\` both constructed their \`LanternReplicationServiceClient\` with \`connect.WithGRPC()\`. The justifying comment in \`pump.go\` said this pinned the wire protocol to gRPC binary framing \"to talk to both legacy \`grpc.NewServer\` peers (the production state until #347 cuts over) and Connect handlers\". 

Since #347, #364/#376, and #381 all shipped, there are no legacy \`grpc.NewServer\` peers anywhere in the Lantern fleet — peers always run our own server binary, which is Connect-only. \`connect.WithGRPC()\` therefore serves no purpose and the rationale comment is stale.

## What

- Drop \`connect.WithGRPC()\` from both call sites.
- Replace the explanatory comment with a one-paragraph note recording the cleanup.
- Net diff: +6 / −8 across 2 files.

## Behaviour change

Replication peers now speak the native Connect protocol on the same h2c socket. Lantern handlers accept all three protocols (Connect / gRPC / gRPC-Web) via Connect-Go's protocol negotiation, so this is transparent at the wire — the change is observable only in:
- Slightly smaller per-frame overhead (Connect framing < gRPC framing)
- Slightly different HTTP/2 trailers / response headers

## Verification

\`\`\`
gofmt -l . cli core mcp pb sdks server tests                  # clean
(cd server && go vet ./... && go test ./...)                   # green
go test -race ./...                                            # green (root + tests/integration)
(cd server && go test -race ./replication)                     # green
\`\`\`

\`tests/integration/antientropy_test.go\` end-to-end covers both pump and anti-entropy under \`-race\`. The bench harness (chaos_kill_replica + replication_soak) lives in docker compose infra outside this PR's scope; the per-package \`-race\` coverage exercises the same code path so the structural change is safe.

## Out of scope

The mutationlog fan-out structural fix tracked under #392 remains open — see [my analysis comment](https://github.com/anaregdesign/lantern/issues/392#issuecomment-4638595307) on that issue for the next-step plan.