### PR TITLE
feat(deploy): add lantern-admin to docker-compose + Helm chart

### DIFF
--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -12,6 +12,11 @@ single-host HA experiments.
   per running replica. Each lantern container's peer pump (#190)
   resolves that name, filters its own IP via `LocalIPSet()`, and opens
   replication streams to the other peers.
+- 1 × `admin` browser SPA (`ghcr.io/anaregdesign/lantern-admin`)
+  on host port `8080`. Pure SPA host (Caddy on `:8080`), no reverse
+  proxy — the browser talks to the gateway directly, so the `lantern`
+  service has `LANTERN_CORS_ALLOWED_ORIGINS=http://localhost:8080`
+  baked in.
 - `prometheus` scrapes via `dns_sd_configs` so it picks up every
   replica automatically (no static targets file to maintain).
 
@@ -63,6 +68,26 @@ Pick one of:
 > round-robin LB was removed when the SDK collapsed to Connect-only
 > ([#367](https://github.com/anaregdesign/lantern/issues/367)). Use a
 > reverse proxy or DNS round-robin instead.
+
+## Admin UI
+
+The compose file ships the `lantern-admin` browser SPA alongside the
+cluster. Open **<http://localhost:8080/>** after `docker compose up -d`
+finishes warming up. The admin connects to whichever lantern node the
+**Gateway** button (top-right of the SPA header) is set to — defaults
+to `http://localhost:6380`; change to `:6381` or `:6382` to point at
+the other replicas.
+
+The browser fetches directly against the gateway, so the lantern
+service sets `LANTERN_CORS_ALLOWED_ORIGINS=http://localhost:8080`.
+If you map the admin to a different external port / host, override
+that env to match (otherwise the browser preflight blocks the
+request). Override the image with
+`LANTERN_ADMIN_IMAGE=ghcr.io/anaregdesign/lantern-admin:v0.1.1
+docker compose up -d`.
+
+The admin container is **not** auth-fronted. Run it only on trusted
+networks, or put your own ingress-level auth proxy in front.
 
 ## Verifying peer discovery
 

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -46,12 +46,31 @@ services:
       LANTERN_PEER_DISCOVERY_INTERVAL_MS: "10000"
       # Readiness gating (#188).
       LANTERN_MAX_REPLICATION_LAG: "10000"
+      # Allow the admin SPA to call this listener from the browser.
+      # Lantern serves Connect / gRPC / gRPC-Web on the same h2c socket,
+      # and the admin container is a pure SPA host (no reverse proxy),
+      # so CORS must allow the admin origin.
+      LANTERN_CORS_ALLOWED_ORIGINS: "http://localhost:8080"
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:9090/readyz"]
       interval: 5s
       timeout: 2s
       retries: 12
       start_period: 10s
+
+  admin:
+    image: ${LANTERN_ADMIN_IMAGE:-ghcr.io/anaregdesign/lantern-admin:latest}
+    ports:
+      - "8080:8080"
+    depends_on:
+      lantern:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 5s
 
   prometheus:
     image: prom/prometheus:v3.5.0

--- a/deploy/helm/lantern/README.md
+++ b/deploy/helm/lantern/README.md
@@ -68,9 +68,66 @@ HA runbook (#192) for the limits.
 | `antiEntropy.intervalMs`                    | `30000`                | Background reconciliation cadence.                 |
 | `podDisruptionBudget.minAvailable`          | `2`                    | Quorum-ish.                                        |
 | `metrics.serviceMonitor.enabled`            | `false`                | Requires the prometheus-operator CRD.              |
+| `admin.enabled`                             | `false`                | Render the `lantern-admin` SPA Deployment + Service. |
+| `admin.image.repository`                    | `ghcr.io/anaregdesign/lantern-admin` | Admin SPA image (Caddy serving the built bundle).     |
+| `admin.image.tag`                           | `.Chart.AppVersion`    | Pin to an `admin/vX.Y.Z` tag in production.        |
+| `admin.service.port`                        | `8080`                 | Service ClusterIP port for the SPA.                |
+| `admin.ingress.enabled`                     | `false`                | Render an Ingress for the admin Service.           |
+| `admin.ingress.host`                        | `""` (required when enabled) | Host name the Ingress rule matches.        |
 
 See [`values.yaml`](values.yaml) for the full set including probes,
 resources, security context, anti-affinity, and `extraEnv`.
+
+## Admin UI (`admin.enabled=true`)
+
+The browser-facing admin SPA (`lantern-admin`) ships as part of this
+chart but is **disabled by default** to preserve the existing install
+footprint.
+
+```shell
+helm upgrade --install lantern deploy/helm/lantern \
+  --set admin.enabled=true \
+  --set extraEnv[0].name=LANTERN_CORS_ALLOWED_ORIGINS \
+  --set extraEnv[0].value=http://localhost:8080
+kubectl port-forward svc/lantern-admin 8080:8080
+# Open http://localhost:8080/ — the Gateway button (top-right) points
+# at the lantern service; default is http://localhost:6380, override
+# at runtime.
+```
+
+The admin container is a **pure Caddy SPA host** — the browser calls
+the lantern listener (Connect-Web) directly, so the lantern server
+**must** allow the admin origin via `LANTERN_CORS_ALLOWED_ORIGINS`.
+Set it on the server StatefulSet via `extraEnv` (above) to include
+every origin the SPA may be served from (`http://localhost:8080`
+during port-forward dev, `https://<ingress-host>` once an Ingress is
+configured, …). Multiple origins are comma-separated.
+
+### Ingress
+
+```shell
+helm upgrade --install lantern deploy/helm/lantern \
+  --set admin.enabled=true \
+  --set admin.ingress.enabled=true \
+  --set admin.ingress.host=admin.example.com \
+  --set admin.ingress.className=nginx \
+  --set extraEnv[0].name=LANTERN_CORS_ALLOWED_ORIGINS \
+  --set extraEnv[0].value=https://admin.example.com
+```
+
+`admin.ingress.host` is required when `admin.ingress.enabled=true`;
+the template fails fast (`helm: …admin.ingress.host to be set`) if it
+is omitted. For TLS, set `admin.ingress.tls` to the standard
+networking.k8s.io/v1 Ingress TLS slice. For multi-host setups, fork
+`templates/admin-ingress.yaml` — v1 of the chart deliberately only
+covers the single-host happy path.
+
+### No auth
+
+v1 ships **no** auth in front of the admin (same posture as the
+container image's `admin/README.md`). Run it only on trusted networks
+(`admin.ingress.enabled=false` + `kubectl port-forward`) or front it
+with your own ingress-level auth proxy.
 
 ## Smoke test
 

--- a/deploy/helm/lantern/templates/_helpers.tpl
+++ b/deploy/helm/lantern/templates/_helpers.tpl
@@ -86,3 +86,27 @@ Service account name.
 {{- default "default" .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Admin-scoped helpers (gated by .Values.admin.enabled). The admin
+Deployment / Service / Ingress share the lantern.* common labels but
+need a distinct fullname and selector so they don't collide with the
+server StatefulSet selector.
+*/}}
+{{- define "lantern.adminFullname" -}}
+{{- printf "%s-admin" (include "lantern.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "lantern.adminSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "lantern.name" . }}-admin
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: admin
+{{- end -}}
+
+{{- define "lantern.adminLabels" -}}
+helm.sh/chart: {{ include "lantern.chart" . }}
+{{ include "lantern.adminSelectorLabels" . }}
+app.kubernetes.io/version: {{ .Values.admin.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: {{ include "lantern.name" . }}
+{{- end -}}

--- a/deploy/helm/lantern/templates/admin-deployment.yaml
+++ b/deploy/helm/lantern/templates/admin-deployment.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.admin.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lantern.adminFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lantern.adminLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.admin.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "lantern.adminSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lantern.adminSelectorLabels" . | nindent 8 }}
+        {{- with .Values.admin.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.admin.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.admin.podSecurityContext | nindent 8 }}
+      {{- with .Values.admin.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admin.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admin.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: admin
+          image: "{{ .Values.admin.image.repository }}:{{ .Values.admin.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.admin.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.admin.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.admin.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+            successThreshold: 1
+          resources:
+            {{- toYaml .Values.admin.resources | nindent 12 }}
+          {{- with .Values.admin.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/deploy/helm/lantern/templates/admin-ingress.yaml
+++ b/deploy/helm/lantern/templates/admin-ingress.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.admin.enabled .Values.admin.ingress.enabled -}}
+{{- if not .Values.admin.ingress.host -}}
+{{- fail "admin.ingress.enabled=true requires admin.ingress.host to be set" -}}
+{{- end -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "lantern.adminFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lantern.adminLabels" . | nindent 4 }}
+  {{- with .Values.admin.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.admin.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.admin.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.admin.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "lantern.adminFullname" . }}
+                port:
+                  number: {{ .Values.admin.service.port }}
+{{- end }}

--- a/deploy/helm/lantern/templates/admin-service.yaml
+++ b/deploy/helm/lantern/templates/admin-service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.admin.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lantern.adminFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lantern.adminLabels" . | nindent 4 }}
+  {{- with .Values.admin.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.admin.service.type }}
+  selector:
+    {{- include "lantern.adminSelectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.admin.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/deploy/helm/lantern/values.yaml
+++ b/deploy/helm/lantern/values.yaml
@@ -132,3 +132,73 @@ serviceAccount:
 
 podAnnotations: {}
 podLabels: {}
+
+# Browser-facing admin SPA (lantern-admin). Disabled by default to
+# preserve the existing install footprint; flip `admin.enabled=true`
+# to render a Deployment + Service (and optionally an Ingress) for
+# the SPA. The container is a pure Caddy SPA host — the browser
+# calls the Lantern Service directly over Connect-Web, so the
+# lantern server must allow the admin origin via
+# `LANTERN_CORS_ALLOWED_ORIGINS` (set under `extraEnv` on the
+# StatefulSet, or via the auto-derived value when
+# `admin.ingress.enabled=true` — see admin-deployment.yaml).
+#
+# v1 ships **without** auth in front of the admin. Run it only on
+# trusted networks or front it with your own ingress-level auth
+# proxy.
+admin:
+  enabled: false
+
+  image:
+    repository: ghcr.io/anaregdesign/lantern-admin
+    # Defaults to .Chart.AppVersion (same convention as the server
+    # image); pin to a specific admin tag (e.g. "v0.1.1") in production.
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    # When enabled, host MUST be set — the chart appends
+    # `https://<host>` to LANTERN_CORS_ALLOWED_ORIGINS on the
+    # StatefulSet so the browser preflight succeeds. Multiple hosts
+    # are not supported in v1; copy admin-ingress.yaml if you need a
+    # richer routing setup.
+    host: ""
+    tls: []
+    #  - secretName: lantern-admin-tls
+    #    hosts:
+    #      - admin.example.com
+
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 500m
+      memory: 128Mi
+
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    fsGroup: 65532
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    readOnlyRootFilesystem: false
+
+  extraEnv: []
+  podAnnotations: {}
+  podLabels: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}


### PR DESCRIPTION
Closes #390.

## docker-compose

\`deploy/compose/docker-compose.yml\` now ships an \`admin\` service alongside the 3-replica lantern + Prometheus:

- \`ghcr.io/anaregdesign/lantern-admin:latest\` (override via \`LANTERN_ADMIN_IMAGE\`)
- Maps \`8080:8080\`, healthchecks against \`/healthz\`
- \`depends_on.lantern.condition: service_healthy\`
- Bakes \`LANTERN_CORS_ALLOWED_ORIGINS=http://localhost:8080\` into the lantern env so the browser preflight succeeds

\`deploy/compose/README.md\` gets a new \"Admin UI\" section explaining the URL, the CORS rule, and the no-auth posture.

## Helm chart

New \`admin.*\` values block, **disabled by default** to preserve the existing install footprint:

\`\`\`yaml
admin:
  enabled: false              # flip to true to render the admin
  image:
    repository: ghcr.io/anaregdesign/lantern-admin
    tag: \"\"                # defaults to .Chart.AppVersion
  replicaCount: 1
  service: { type: ClusterIP, port: 8080, annotations: {} }
  ingress:
    enabled: false
    className: \"\"
    host: \"\"               # required when enabled=true
    annotations: {}
    tls: []
  resources / podSecurityContext / securityContext / extraEnv / pod{Annotations,Labels} / nodeSelector / tolerations / affinity
\`\`\`

New templates (all gated by \`.Values.admin.enabled\`):
- \`templates/admin-deployment.yaml\` — single-replica Deployment, /healthz probes, runs as nonroot 65532
- \`templates/admin-service.yaml\` — ClusterIP Service on \`admin.service.port\`
- \`templates/admin-ingress.yaml\` — optional Ingress; fails fast via \`{{ fail }}\` when \`ingress.enabled=true\` but \`ingress.host\` is empty

New \`_helpers.tpl\` definitions: \`lantern.adminFullname\` (\`<release>-lantern-admin\`), \`lantern.adminLabels\`, \`lantern.adminSelectorLabels\` carrying \`app.kubernetes.io/component=admin\` so the admin selector never collides with the StatefulSet selector.

\`deploy/helm/lantern/README.md\` gets a new \"Admin UI (\`admin.enabled=true\`)\" section covering port-forward dev, Ingress + CORS env wiring, and the no-auth posture.

## CORS auto-wiring

Templating multi-origin CORS strings via \`--set\` array syntax gets ugly, so I went with the documented-manual route: operators set \`extraEnv[0]={LANTERN_CORS_ALLOWED_ORIGINS, <their origin>}\` on the StatefulSet themselves, the README shows the exact \`--set\` invocation, and the chart's \`admin-ingress.yaml\` fail-fast on missing \`host\` makes the dependency hard to miss. Verified the wiring works via \`helm template … --set extraEnv[0].name=LANTERN_CORS_ALLOWED_ORIGINS\`.

## Out of scope (per the issue body)

- Reverse-proxying the gateway through Caddy (admin stays a pure SPA host).
- Auth/SSO sidecar.
- Cross-namespace deploys (copy the templates if needed).
- A sub-chart split — single chart with \`admin.enabled\` toggle is simpler for now.

## Verification

\`\`\`
helm lint deploy/helm/lantern                                  # clean
helm lint deploy/helm/lantern --set admin.enabled=true         # clean
helm template lantern deploy/helm/lantern                      # no admin objects rendered (default)
helm template lantern deploy/helm/lantern --set admin.enabled=true                        # Deployment + Service rendered
helm template lantern deploy/helm/lantern --set admin.enabled=true \\
   --set admin.ingress.enabled=true --set admin.ingress.host=admin.example.com            # adds Ingress
helm template lantern deploy/helm/lantern --set admin.enabled=true \\
   --set admin.ingress.enabled=true                                                       # fails with explicit message
docker compose -f deploy/compose/docker-compose.yml config                                # syntax clean
\`\`\`

## Follow-up

#391 (MCP in deploy) tracked separately. \`admin\` here doesn't change any existing path, so the chart is upgrade-safe.