### PR TITLE
feat(deploy): add lantern-mcp to docker-compose HA file + Helm chart

### DIFF
--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -122,19 +122,34 @@ which `LocalIPSet()` filters as self, so the pump becomes a no-op.
 
 For local LLM-agent experiments there is a smaller compose file in
 [`docker-compose.mcp.yml`](docker-compose.mcp.yml) that stands up one
-`lantern` + one `lantern-mcp`. The MCP server is stdio-only, so the
-typical workflow is:
+`lantern` + one `lantern-mcp`. The HA compose file in this directory
+also ships a `lantern-mcp` service behind a Compose profile, so the
+same MCP container can be exercised against the 3-replica cluster:
 
 ```shell
-# Bring up just Lantern in the background.
+# Single-node (small file): bring lantern up in the background, then
+# attach the MCP container interactively.
 docker compose -f docker-compose.mcp.yml up -d lantern
-
-# Sanity-check the MCP wire (note `run`, not `up` — stdio).
 docker compose -f docker-compose.mcp.yml run --rm lantern-mcp
+
+# HA cluster (this file): same lantern-mcp container, but talking to
+# the 3-replica cluster — Compose DNS round-robins `lantern:6380`
+# across the live replicas.
+docker compose --profile mcp run --rm lantern-mcp
 ```
+
+`docker compose up` is the wrong verb in both cases — the MCP server
+is **stdio-only** (`mcp/cmd/main.go` mounts `&mcp.StdioTransport{}`),
+so backgrounding the container would leave nothing consuming stdout.
 
 In production, the agent runtime (Claude Desktop, VS Code, Cursor, …)
 owns the MCP container's lifetime — see
 [`../../mcp/examples/`](../../mcp/examples/) for those configs and
 [`../../mcp/README.md`](../../mcp/README.md) for the full operator
 reference.
+
+> The standalone `docker-compose.mcp.yml` covers the single-node case
+> and stays useful as a template for embedding `lantern-mcp` in your
+> own agent-runtime compose file. The HA file's `mcp` profile covers
+> the multi-replica case without duplicating the lantern + Prometheus
+> stack.

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -72,6 +72,28 @@ services:
       retries: 6
       start_period: 5s
 
+  # Opt-in MCP server. The MCP protocol is stdio-only, so this service
+  # is only useful via `docker compose --profile mcp run --rm lantern-mcp`
+  # (NOT `up`, which would just background the container with nothing
+  # consuming stdout). Real production traffic should live inside the
+  # agent runtime's pod — see `mcp/examples/` for the configs that wire
+  # Claude Desktop / VS Code / Cursor to a local container.
+  #
+  # Usage:
+  #   docker compose --profile mcp run --rm lantern-mcp
+  lantern-mcp:
+    profiles: ["mcp"]
+    image: ${LANTERN_MCP_IMAGE:-ghcr.io/anaregdesign/lantern-mcp:latest}
+    stdin_open: true
+    tty: false
+    environment:
+      # Compose DNS round-robins the `lantern` service across replicas.
+      LANTERN_ADDR: "http://lantern:6380"
+      LANTERN_MCP_PING_TIMEOUT: "5s"
+    depends_on:
+      lantern:
+        condition: service_healthy
+
   prometheus:
     image: prom/prometheus:v3.5.0
     ports:

--- a/deploy/helm/lantern/README.md
+++ b/deploy/helm/lantern/README.md
@@ -129,6 +129,59 @@ container image's `admin/README.md`). Run it only on trusted networks
 (`admin.ingress.enabled=false` + `kubectl port-forward`) or front it
 with your own ingress-level auth proxy.
 
+## MCP sidecar
+
+The chart **does not render a Pod / Deployment for `lantern-mcp`**.
+MCP is a stdio protocol (the binary mounts `&mcp.StdioTransport{}`
+in `mcp/cmd/main.go`), so a free-standing Service shape doesn't fit:
+there's no socket to expose and no obvious client to attach to. The
+canonical deployment shape is a **sidecar inside the agent runtime's
+pod** (Claude Desktop / VS Code Server / a custom worker).
+
+To make that easy, the chart exports a named template,
+`lantern.mcpSidecar`, that emits a container spec your own
+chart / manifest can splice in:
+
+```yaml
+# my-agent/templates/pod.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-agent
+spec:
+  containers:
+    - name: agent
+      image: my-agent:latest
+      stdin: true
+      tty: false
+    {{- include "lantern.mcpSidecar" . | nindent 4 }}
+```
+
+The sidecar reads its config from `.Values.mcp`:
+
+| Value | Default | Purpose |
+| --- | --- | --- |
+| `mcp.image.repository` | `ghcr.io/anaregdesign/lantern-mcp` | Override for private mirrors. |
+| `mcp.image.tag` | `.Chart.AppVersion` | Pin to a specific `mcp/vX.Y.Z`. |
+| `mcp.lanternAddr` | _(empty → in-cluster Service FQDN)_ | Override only for cross-namespace / cross-cluster setups. |
+| `mcp.pingTimeout` | `5s` | Startup health-check timeout. |
+| `mcp.ttl.<bucket>` | _(unset)_ | Per-bucket TTL override; rendered as `LANTERN_MCP_TTL_<UPPER>` env. |
+| `mcp.resources` | small | requests/limits for the sidecar container. |
+| `mcp.extraEnv` | `[]` | Raw env list appended to the templated ones. |
+
+Real production traffic happens over stdio inside the pod; for
+manual probes use `kubectl exec -it <pod> -c lantern-mcp` which
+hands you the same stdio channel the agent uses.
+
+If you actually want a free-standing `lantern-mcp` Deployment (e.g.
+for `kubectl attach` exploration), the agent-runtime configs in
+[`mcp/examples/`](../../../mcp/examples/) show the pattern — fork
+them into your own chart rather than complicating this one.
+
+If an HTTP/SSE transport lands in the upstream `go-sdk`, the chart
+will gain a proper `mcp-deployment.yaml` + `mcp-service.yaml`; tracked
+as a follow-up.
+
 ## Smoke test
 
 ```shell

--- a/deploy/helm/lantern/templates/_mcp-sidecar.tpl
+++ b/deploy/helm/lantern/templates/_mcp-sidecar.tpl
@@ -1,0 +1,59 @@
+{{/*
+MCP sidecar partial. lantern-mcp is stdio-only (it implements the
+Model Context Protocol over stdin/stdout, not a network listener), so
+the canonical way to run it on Kubernetes is as a **sidecar inside the
+agent runtime's pod** rather than as a free-standing Service.
+
+This file exports a single named template, `lantern.mcpSidecar`, that
+emits a container spec callers can splice into their own Pod template
+via `{{ include "lantern.mcpSidecar" . | nindent 8 }}`. The chart
+deliberately does NOT render a Pod / Deployment for lantern-mcp on its
+own — see `mcp/examples/` for the canonical agent-runtime configs and
+the issue thread on #391 for the rationale.
+
+The container is configured via `.Values.mcp`:
+
+  - mcp.image.{repository,tag,pullPolicy}
+  - mcp.lanternAddr   (defaults to in-cluster ClusterIP Service)
+  - mcp.pingTimeout
+  - mcp.ttl           (a map[bucket]duration; each non-empty entry is
+                       emitted as LANTERN_MCP_TTL_<BUCKET>)
+  - mcp.resources
+  - mcp.extraEnv      (raw env list appended after the templated ones)
+
+Example consumer (in your own chart / manifest):
+
+  containers:
+    - name: agent
+      image: my-agent:latest
+      stdin: true
+      tty: false
+    {{- include "lantern.mcpSidecar" . | nindent 4 }}
+
+The agent talks to lantern-mcp over stdio inside the pod
+(`kubectl exec -it ... -c lantern-mcp` reproduces the same channel
+for manual probes).
+*/}}
+{{- define "lantern.mcpSidecar" -}}
+- name: lantern-mcp
+  image: "{{ .Values.mcp.image.repository }}:{{ .Values.mcp.image.tag | default .Chart.AppVersion }}"
+  imagePullPolicy: {{ .Values.mcp.image.pullPolicy }}
+  stdin: true
+  tty: false
+  env:
+    - name: LANTERN_ADDR
+      value: {{ default (printf "http://%s.%s.svc.cluster.local:%v" (include "lantern.fullname" .) .Release.Namespace .Values.service.port) .Values.mcp.lanternAddr | quote }}
+    - name: LANTERN_MCP_PING_TIMEOUT
+      value: {{ .Values.mcp.pingTimeout | quote }}
+    {{- range $bucket, $ttl := .Values.mcp.ttl }}
+    {{- if $ttl }}
+    - name: {{ printf "LANTERN_MCP_TTL_%s" (upper $bucket) }}
+      value: {{ $ttl | quote }}
+    {{- end }}
+    {{- end }}
+    {{- with .Values.mcp.extraEnv }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  resources:
+    {{- toYaml .Values.mcp.resources | nindent 4 }}
+{{- end -}}

--- a/deploy/helm/lantern/values.yaml
+++ b/deploy/helm/lantern/values.yaml
@@ -202,3 +202,54 @@ admin:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+
+# Bring-your-own MCP sidecar (lantern-mcp). The chart does NOT render
+# a Pod / Deployment for lantern-mcp on its own — MCP is a stdio
+# protocol, so the canonical deployment shape is a sidecar inside the
+# agent runtime's pod (Claude Desktop / VS Code Server / a custom
+# worker). This `mcp:` block configures the named template
+# `lantern.mcpSidecar` defined in templates/_mcp-sidecar.tpl, which
+# external charts / manifests splice into their own Pod spec via:
+#
+#   containers:
+#     - name: agent
+#       ...
+#     {{- include "lantern.mcpSidecar" . | nindent 4 }}
+#
+# See deploy/helm/lantern/README.md "MCP sidecar" for the full
+# walkthrough and mcp/examples/ for the agent-runtime configs that
+# already wire lantern-mcp end-to-end.
+mcp:
+  image:
+    repository: ghcr.io/anaregdesign/lantern-mcp
+    tag: ""        # defaults to .Chart.AppVersion; pin to mcp/vX.Y.Z in prod
+    pullPolicy: IfNotPresent
+
+  # Address the MCP container dials. Empty (default) lets the sidecar
+  # template fall back to the chart's ClusterIP Service FQDN so the
+  # sidecar talks to the in-cluster lantern automatically. Override
+  # only when the sidecar runs in a different namespace / cluster.
+  lanternAddr: ""
+
+  # Startup health-check timeout for the MCP container's initial ping.
+  pingTimeout: "5s"
+
+  # Per-TTL-bucket override map. Each non-empty value is emitted as a
+  # `LANTERN_MCP_TTL_<UPPER_BUCKET>` env var on the sidecar. See
+  # mcp/internal/ttl/ for the canonical bucket list + defaults.
+  ttl: {}
+    # turn: "15m"
+    # conversation: "2h"
+
+  resources:
+    requests:
+      cpu: 5m
+      memory: 16Mi
+    limits:
+      cpu: 200m
+      memory: 64Mi
+
+  # Raw env list appended to the templated entries above. Useful for
+  # LANTERN_MCP_LOG_LEVEL or any future knob the sidecar template
+  # hasn't been updated for yet.
+  extraEnv: []


### PR DESCRIPTION
Closes #391.

## docker-compose

`deploy/compose/docker-compose.yml` ships a new `lantern-mcp` service behind a Compose **profile** so it stays opt-in:

```yaml
lantern-mcp:
  profiles: ["mcp"]
  image: ${LANTERN_MCP_IMAGE:-ghcr.io/anaregdesign/lantern-mcp:latest}
  stdin_open: true
  tty: false
  environment:
    LANTERN_ADDR: "http://lantern:6380"   # Compose DNS round-robins
    LANTERN_MCP_PING_TIMEOUT: "5s"
  depends_on:
    lantern: { condition: service_healthy }
```

Usage: `docker compose --profile mcp run --rm lantern-mcp`. **Not** `up` — the MCP server is stdio-only (`mcp/cmd/main.go` mounts `&mcp.StdioTransport{}`), so backgrounding it leaves nothing consuming stdout.

`deploy/compose/README.md` cross-links this HA-profile invocation with the existing standalone `docker-compose.mcp.yml`, keeping both files alive (the standalone one is a clean template for embedding `lantern-mcp` in your own agent-runtime compose file; the HA-file profile covers the multi-replica case without duplicating the lantern + Prometheus stack).

## Helm chart

The chart **does not render a Pod / Deployment / Service for `lantern-mcp` on its own** — the stdio transport makes a server-style Deployment ill-fitting on K8s. Instead, ship a documented sidecar partial that operators splice into **their own** agent-runtime pod.

- New `mcp:` values block: `image.{repository,tag,pullPolicy}`, `lanternAddr`, `pingTimeout`, `ttl.<bucket>` (rendered as `LANTERN_MCP_TTL_<UPPER>` env per non-empty entry), `resources`, `extraEnv`.
- New `templates/_mcp-sidecar.tpl` defines the named template `lantern.mcpSidecar`. Consumers do:

  ```yaml
  containers:
    - name: agent
      image: my-agent:latest
      stdin: true
      tty: false
    {{- include "lantern.mcpSidecar" . | nindent 4 }}
  ```

- `LANTERN_ADDR` defaults to the chart's in-cluster ClusterIP Service FQDN (`http://<release>-lantern.<ns>.svc.cluster.local:6380`) so the sidecar auto-resolves without operator config. `mcp.lanternAddr` overrides for cross-namespace / cross-cluster setups.

`deploy/helm/lantern/README.md` gets a new "MCP sidecar" section covering the consumer Pod template, values reference, rationale for the bring-your-own pattern, the `kubectl exec -it <pod> -c lantern-mcp` probe pattern, and the follow-up if upstream MCP gains an HTTP/SSE transport.

## Out of scope (per the issue body)

- Implementing an HTTP / SSE / streamable transport for `lantern-mcp` (separate epic).
- Auto-discovery of the lantern Service from inside the MCP container beyond `LANTERN_ADDR`.
- Auth on the MCP wire — MCP itself is unauthenticated stdio.

## Verification

```text
docker compose -f deploy/compose/docker-compose.yml config --services
  → [lantern, prometheus]              # mcp absent, profile gating works

docker compose --profile mcp config --services
  → [lantern, lantern-mcp, prometheus] # mcp added

helm lint deploy/helm/lantern          # clean
```

A stub consumer chart with `{{- include "lantern.mcpSidecar" . | nindent 4 }}` renders the expected container spec: `LANTERN_ADDR` auto-derived to the in-cluster Service FQDN, `LANTERN_MCP_TTL_TURN` + `LANTERN_MCP_TTL_CONVERSATION` emitted (empty bucket skipped), `mcp.extraEnv` entries appended.

## Follow-up

If an HTTP/SSE transport lands in the upstream `go-sdk`, the chart will gain a proper `mcp-deployment.yaml` + `mcp-service.yaml`. Until then, the bring-your-own pattern matches the actual deployment shape every existing example in `mcp/examples/` already uses.
