### PR TITLE
test(core/pubsub): wait for Subscribe goroutine to avoid -race flake

### DIFF
--- a/core/concurrent/pubsub/subscription_test.go
+++ b/core/concurrent/pubsub/subscription_test.go
@@ -36,7 +36,14 @@ func TestSubscription_Name(t *testing.T) {
 }
 
 func TestSubscription_Subscribe(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	// Use a short, test-scoped context so Subscribe returns promptly,
+	// and a WaitGroup so the test waits for the goroutine to exit
+	// before t.Run returns. The previous fire-and-forget pattern
+	// (`go tt.s.Subscribe(...)` with no synchronisation) leaked the
+	// Subscribe goroutine past the test boundary, where its internal
+	// worker pool's accesses raced with the testing framework's
+	// teardown reads under -race (#397).
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 	topic := NewTopic[int]("test")
 	sub := topic.NewSubscription("test", 1, time.Minute, time.Minute)
@@ -54,15 +61,25 @@ func TestSubscription_Subscribe(t *testing.T) {
 			name: "TestSubscription_Subscribe",
 			s:    sub,
 			args: args[int]{
-				ctx:      ctx,
-				consumer: func(x *Message[int]) { t.Log(x) },
+				ctx: ctx,
+				// Consumer must not call t.Log: the test goroutine
+				// may have ticked past tt.s.Subscribe(...) and the
+				// testing.T may be in the middle of teardown when a
+				// late message arrives.
+				consumer: func(*Message[int]) {},
 			},
 		},
 	}
 	for i := range tests {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			go tt.s.Subscribe(tt.args.ctx, tt.args.consumer)
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				tt.s.Subscribe(tt.args.ctx, tt.args.consumer)
+			}()
+			wg.Wait()
 		})
 	}
 }


### PR DESCRIPTION
Closes #397.

## Diagnosis

The test launched `Subscribe` as a bare `go ...` and returned immediately, leaving the worker pool spawned inside `Subscribe` alive past the `t.Run` boundary. Under `-race + coverage` instrumentation on slower CI runners, the leaked goroutine's accesses to the `*Subscription`'s internal fields raced with the testing framework's teardown reads — exactly the flake observed on PR #396.

Two issues in the original test:
1. **Fire-and-forget goroutine** — no `sync.WaitGroup`, so the test exited while `Subscribe`'s worker pool + `watch` goroutine were still running.
2. **`consumer: func(x) { t.Log(x) }`** — `t.Log` on a *testing.T that's already been torn down is a known Go race-detector trap.

The race didn't reproduce on Apple M3 locally because the scheduler is fast enough that the workers exit before the goroutine leak matters; on the GHA Linux runner with `-race -cover` overhead, the window is wide enough that the race detector catches it.

## Fix

- Use a short test-scoped context (`50ms`) so the workers' `<-ctx.Done()` fires before `t.Run` returns.
- Wait for the `Subscribe` goroutine with `sync.WaitGroup` before `t.Run`'s closure exits.
- Drop the `t.Log` consumer in favour of a no-op (the test only asserts Subscribe doesn't deadlock / panic).

## Verification

```text
cd core && go test -race -count=20 -run TestSubscription_Subscribe \
  ./concurrent/pubsub/
→ ok 5.012s
```

Full pubsub suite also green under `-race`:

```text
cd core && go test -race ./concurrent/pubsub/
→ ok 1.467s
```

The wire/runtime behaviour of `Subscription.Subscribe` is unchanged — this is purely test-side synchronisation.
