### PR TITLE
chore: pin pb v0.2.1 + core v0.2.2 in root go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.4.0
-	github.com/anaregdesign/lantern/core v0.2.1
+	github.com/anaregdesign/lantern/core v0.2.2
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
-	github.com/anaregdesign/lantern/pb v0.2.0
+	github.com/anaregdesign/lantern/pb v0.2.1
 	github.com/anaregdesign/lantern/sdks/go v0.9.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0


### PR DESCRIPTION
Prepares the root module for the v0.8.1 release tag.

- pb/v0.2.1 ships the comment regen from PR #396 (post-Connect documentation refresh).
- core/v0.2.2 ships the pubsub test fix from PR #406 (#397 race flake).

Both upstream tags are docs/test-only — no behavior change. This PR just bumps the root `require` lines so the v0.8.1 image, when cut, pins the latest tagged versions.

```
go test ./...   # green
```