### PR TITLE
fix(testbed/bench): refresh prom_queries.txt for actual metric names (closes #412)

### DIFF
--- a/testbed/bench/capture/prom_queries.txt
+++ b/testbed/bench/capture/prom_queries.txt
@@ -20,10 +20,25 @@ avg by (instance) (go_memstats_heap_inuse_bytes)
 rate(go_memstats_gc_cpu_fraction[1m])
 
 # --- replication health (HA topology) ----------------------------------
-sum by (instance) (rate(lantern_replication_events_total[30s]))
-max by (instance) (lantern_replication_lag_seconds)
+# Metric names follow server/metrics/metrics.go:
+#   lantern_replication_applied_total{origin}  — counter, per-origin apply count
+#   lantern_replication_lag_seq{peer,origin}   — gauge,  peer.last_seq - local.last_applied_seq
+sum by (instance, origin) (rate(lantern_replication_applied_total[30s]))
+max by (instance, peer, origin) (lantern_replication_lag_seq)
 
 # --- pubsub fan-out (#240) --------------------------------------------
+# Note: lantern_subscription_dropped_total{policy} is the pubsub-package
+# counter (core/concurrent/pubsub) and is intentionally distinct from the
+# mutationlog drop counter below. The pubsub package is currently dormant
+# in the server, so this series is expected to be all-zero during runs.
 histogram_quantile(0.99, sum by (le) (rate(lantern_subscription_queue_depth_bucket[30s])))
 sum by (policy) (rate(lantern_subscription_dropped_total[30s]))
 histogram_quantile(0.99, sum by (le) (rate(lantern_subscription_dispatch_duration_seconds_bucket[30s])))
+
+# --- mutationlog fan-out (#260) --------------------------------------
+# Counter incremented when the mutationlog dispatcher's non-blocking send
+# to a subscriber's outbound channel fails and the subscriber is
+# unregistered. Pre-warmed with cause="buffer_full" so the series renders
+# from process start. Per-instance breakdown is what the many_subscribers
+# scenario specifically needs (see #260 acceptance + #392).
+sum by (instance, cause) (rate(lantern_mutationlog_subscriber_dropped_total[30s]))


### PR DESCRIPTION
## What

Refresh the three stale Prometheus query lines in [`testbed/bench/capture/prom_queries.txt`](../tree/fix/412-prom-queries-stale-metric-names/testbed/bench/capture/prom_queries.txt) to the actual metric names exported by [`server/metrics/metrics.go`](../tree/fix/412-prom-queries-stale-metric-names/server/metrics/metrics.go), and add a fourth query against `lantern_mutationlog_subscriber_dropped_total{cause}` so the `many_subscribers` scenario can finally exercise the #260 counter the way #260's own acceptance criterion expected.

### Drift table (per current main, 7f2ff2b)

| `prom_queries.txt` query (before) | actual metric in `server/metrics/metrics.go` |
| --- | --- |
| `lantern_replication_events_total` | `lantern_replication_applied_total{origin}` |
| `lantern_replication_lag_seconds` | `lantern_replication_lag_seq{peer,origin}` |
| _(missing)_ | `lantern_mutationlog_subscriber_dropped_total{cause}` |

The pubsub-side `lantern_subscription_dropped_total{policy}` family is intentionally untouched: it is correctly named, just dormant per the comment at `server/metrics/metrics.go:84`. The existing queue-depth / dispatch-duration queries are also untouched (they already match).

## Why now

[#392 comment 4639182797](https://github.com/anaregdesign/lantern/issues/392#issuecomment-4639182797) re-ran `many_subscribers` against current main and observed **21/64 starved subscribers all bound to one specific replica**, but the bench harness could not tell whether those drops crossed the mutationlog OnDrop hook (= back-pressure exceeded `SubscriberBuffer`) or wedged upstream (= Connect HTTP/2 stream stall). The reason was simple: the query that would have answered that question did not exist in `prom_queries.txt`. This PR makes the next `many_subscribers` run actually informative.

## Scope

- **One file**, `.txt` only. No Go code, no `.go` build, no `.proto`, no Bicep / Helm / Compose changes.
- `run.sh`'s existing parser at `testbed/bench/run.sh:294` (`q="${line%%#*}"; ... [[ -z "$q" ]] && continue`) strips `#` and blank lines before issuing the query, so the surrounding comment block I added is a no-op at runtime.
- CI: the 4 required checks (Build & Test, Lint, Proto (buf), govulncheck) should all pass trivially — nothing under `pb/`, `core/`, `server/`, `sdks/`, `mcp/`, `cli/`, or `tests/` is touched. The bench itself is not in the required check set (was removed from `release.needs` in 86ec16b), so this is a doc-class change for the harness.

## Verification

The new metric names were cross-checked against the live registrations in `server/metrics/metrics.go`:

```
server/metrics/metrics.go:343:    Name: "lantern_mutationlog_subscriber_dropped_total"
server/metrics/metrics.go:245:    Name: "lantern_replication_applied_total"
server/metrics/metrics.go:253:    Name: "lantern_replication_lag_seq"
```

The next `many_subscribers` run on top of this branch will produce non-empty `prom/q_07.json` (replication_applied) and `prom/q_08.json` (replication_lag_seq) per replica, and a new `prom/q_11.json` (mutationlog dropped per instance/cause) — that bench run is the in-place validation and will be attached to the follow-up comment on #392.

## Out of scope

- No server-side metric changes. The drift is one-way: the harness query strings drifted away from the canonical Prometheus names; the server is the source of truth and is correct.
- No bench-runner / scenario YAML changes; only the captured-queries file.
- No dashboard updates.

Closes #412
Refs #260, #392, #240, #221
