### PR TITLE
feat(server): leaderless Subscribe contract (Reading B) — apply.go appends + per-origin dedup gate (closes #417)

### DIFF
--- a/server/service/apply.go
+++ b/server/service/apply.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"log/slog"
 	"time"
 
 	"github.com/anaregdesign/lantern/core/cache/graph"
@@ -15,8 +16,15 @@ import (
 // and the snapshot bootstrap (#183) to replay a Mutation produced on a
 // remote node against the local cache. It is intentionally NOT exposed
 // as an RPC: external clients use the regular write RPCs which append to
-// the local log; ApplyMutation deliberately bypasses logMutation so a
-// replayed mutation is not re-broadcast.
+// the local log via logMutation.
+//
+// Under the Reading B contract (#415), a successfully-applied remote
+// mutation is ALSO appended to the local mutation log so external
+// Subscribe consumers on any replica observe every committed cluster
+// mutation. Replication loops are prevented by an atomic per-origin
+// watermark check at the top of the function: a (origin, seq) pair
+// that another peer hop already covered is short-circuited before any
+// cache or log mutation happens.
 //
 // Idempotence rules per oneof case:
 //
@@ -50,6 +58,31 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 	ts := hlcFromProto(m.GetHlc())
 	origin := m.GetOrigin()
 	seq := m.GetSeq()
+
+	// Reading B watermark check (#415, B-3). Record CAS-advances the
+	// per-origin (last_seq, last_hlc) watermark when seq is strictly
+	// greater than what we have already seen for this origin. The
+	// bool return drives two later decisions:
+	//
+	//   - log Append: only on advance, so external Subscribe streams
+	//     do not see the same (origin, seq) replayed when the same
+	//     mutation arrived through two different peer hops in a
+	//     fan-out triangle.
+	//   - onApplied hook: only on advance, so peer-status counters
+	//     reflect distinct cluster mutations rather than redelivery
+	//     volume.
+	//
+	// The cache apply itself runs unconditionally: it is HLC LWW
+	// (Put*) or ContribID-deduped (Add*), so out-of-order or
+	// duplicate deliveries are absorbed without divergence. This is
+	// the convergence invariant that
+	// TestApplyMutation_Convergence stresses.
+	var nid hlc.NodeID
+	advanced := false
+	if s.origins != nil && len(origin) > 0 && seq > 0 {
+		copy(nid[:], origin)
+		advanced = s.origins.Record(nid, seq, ts)
+	}
 
 	// Tombstone expiration is computed once per apply so a batch of
 	// per-edge contributions inside a single MutationOp_AddEdges shares
@@ -210,16 +243,36 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 		s.onReplicationApply(opName)
 	}
 
-	// Update the per-origin watermark used by PeerStatus (#186). We
-	// only record after a successful apply so a malformed mutation
-	// that returned early above does not advance the watermark.
-	if s.origins != nil && len(origin) > 0 && seq > 0 {
-		var nid hlc.NodeID
-		copy(nid[:], origin)
-		s.origins.Record(nid, seq, ts)
-		if s.onApplied != nil {
-			s.onApplied(hex.EncodeToString(nid[:]))
+	// Reading B (#415, B-3). After a successful apply of an entry we
+	// have not seen before, also append the mutation to the local log
+	// so external Subscribe consumers on this replica observe it. The
+	// advanced check above ensures the same (origin, seq) is appended
+	// at most once even when it reaches us through multiple peer hops.
+	//
+	// The append uses the remote HLC unchanged so Entry.HLC.NodeID
+	// equals the originating writer's NodeID — that is the field
+	// downstream actors (the peer pump, external CDC consumers) read
+	// to attribute each entry to its origin.
+	//
+	// Append errors after a successful apply are logged but not
+	// surfaced: the apply already committed and reverting it would
+	// leak inconsistency. The next remote receipt of the same
+	// mutation will short-circuit at the watermark check.
+	if advanced && s.log != nil {
+		if _, err := s.log.Append(m, ts); err != nil {
+			l := s.logger
+			if l == nil {
+				l = slog.Default()
+			}
+			l.Warn("mutation log append on remote apply failed",
+				slog.Any("err", err),
+				slog.String("origin", hex.EncodeToString(nid[:])),
+				slog.Uint64("seq", seq))
 		}
+	}
+
+	if advanced && s.onApplied != nil {
+		s.onApplied(hex.EncodeToString(nid[:]))
 	}
 	return nil
 }

--- a/server/service/apply_test.go
+++ b/server/service/apply_test.go
@@ -150,10 +150,15 @@ func TestApplyMutation_ReplicationApplyHook(t *testing.T) {
 	}
 }
 
-// TestApplyMutation_DoesNotLog asserts the cardinal rule: replayed
-// mutations MUST NOT re-append to the local log. Otherwise the peer-pump
-// in #184 would echo every mutation back to its origin and loop forever.
-func TestApplyMutation_DoesNotLog(t *testing.T) {
+// TestApplyMutation_AppendsToLocalLog is the Reading B contract test
+// (#415, B-3): a remote-applied mutation MUST land in the local
+// mutation log so external Subscribe consumers on this replica observe
+// every cluster-wide mutation, not just writes that this replica
+// directly received. Replication loops are prevented by the per-origin
+// watermark dedup in ApplyMutation itself (covered separately by
+// TestApplyMutation_DoesNotReAppendDuplicate), not by bypassing the
+// log on apply.
+func TestApplyMutation_AppendsToLocalLog(t *testing.T) {
 	cache := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
 	log := mutationlog.New(mutationlog.Options{Capacity: 128, SubscriberBuffer: 128})
 	t.Cleanup(func() { _ = log.Close() })
@@ -173,8 +178,49 @@ func TestApplyMutation_DoesNotLog(t *testing.T) {
 	if err := svc.ApplyMutation(context.Background(), m); err != nil {
 		t.Fatalf("ApplyMutation: %v", err)
 	}
-	if _, ok := log.LastSeq(); ok {
-		t.Errorf("log has entries after ApplyMutation; want none (replay must not re-append)")
+	gotSeq, ok := log.LastSeq()
+	if !ok {
+		t.Fatalf("log empty after ApplyMutation; want one entry under Reading B")
+	}
+	if gotSeq != 1 {
+		t.Errorf("log.LastSeq = %d, want 1 (first entry on a fresh log)", gotSeq)
+	}
+}
+
+// TestApplyMutation_DoesNotReAppendDuplicate asserts the per-origin
+// watermark dedup gate in ApplyMutation: the same (origin, seq) tuple
+// arriving twice (e.g. through two different peer hops in a fan-out
+// triangle) appends to the local log exactly once. Without this, the
+// peer-pump in #184 would amplify every mutation by the fan-out
+// factor on external Subscribe streams.
+func TestApplyMutation_DoesNotReAppendDuplicate(t *testing.T) {
+	cache := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	log := mutationlog.New(mutationlog.Options{Capacity: 128, SubscriberBuffer: 128})
+	t.Cleanup(func() { _ = log.Close() })
+	origin := bytes16("origin-A")
+	clock := hlc.New(origin, hlc.Options{})
+	svc := NewLanternService(cache).
+		WithReplication(log, clock, nil)
+
+	ts := newHLC(1, origin)
+	exp := timestamppb.New(time.Now().Add(time.Hour))
+	m := &pb.Mutation{
+		Seq: 1, Hlc: ts, Origin: origin[:],
+		Op: &pb.MutationOp{Op: &pb.MutationOp_PutVertex{
+			PutVertex: &pb.PutVertexRequest{Vertex: &pb.Vertex{Key: "v1", Expiration: exp}},
+		}},
+	}
+	for i := 0; i < 3; i++ {
+		if err := svc.ApplyMutation(context.Background(), m); err != nil {
+			t.Fatalf("ApplyMutation iter=%d: %v", i, err)
+		}
+	}
+	gotSeq, ok := log.LastSeq()
+	if !ok {
+		t.Fatalf("log empty after three ApplyMutation calls; want one entry")
+	}
+	if gotSeq != 1 {
+		t.Errorf("log.LastSeq = %d after dedup; want 1 (single append)", gotSeq)
 	}
 }
 

--- a/server/service/origin_state.go
+++ b/server/service/origin_state.go
@@ -9,15 +9,20 @@ import (
 
 // originStateTracker records the (last_seq, last_hlc) the local node
 // has applied for each known origin NodeID. It is the in-memory
-// backing store for the PeerStatus RPC (#186).
+// backing store for the PeerStatus RPC (#186) and the dedup gate for
+// remote-applied mutations under the Reading B contract (#415).
 //
 // Update sites:
 //
-//   - ApplyMutation, after a successful remote-origin apply, calls
-//     Record(origin, seq, hlc).
+//   - ApplyMutation, at the TOP of the function, calls Record(origin,
+//     seq, hlc) as an atomic claim. The bool return tells the caller
+//     whether the watermark advanced — if it did not, the (origin, seq)
+//     pair was already applied via another peer hop, so the apply is
+//     skipped to avoid duplicate cache writes and a duplicate log entry.
 //   - logMutation, after a successful local append, calls Record with
 //     the local origin so PeerStatus always reflects the local node's
-//     own progress too.
+//     own progress too. The bool return is ignored: local seqs are
+//     strictly monotone by construction, so the call always advances.
 //
 // Concurrency: a single RWMutex protects the map. Updates are O(1);
 // the snapshot returned by States() is a copy so callers can iterate
@@ -36,25 +41,31 @@ func newOriginStateTracker() *originStateTracker {
 	return &originStateTracker{m: make(map[hlc.NodeID]originRow)}
 }
 
-// Record updates the per-origin watermark with the strictly-greatest
-// (seq, hlc) ever seen. Lower seqs are ignored — replays and
-// out-of-order delivery must not regress the watermark.
+// Record advances the per-origin watermark to (seq, ts) iff seq is
+// strictly greater than the previously-recorded seq for origin. It
+// returns true when the watermark advanced (the caller may proceed to
+// apply and log the mutation) and false when this (origin, seq) was
+// already recorded (the caller MUST treat the mutation as a duplicate
+// and skip it). The check-and-set is performed under a single Lock so
+// concurrent ApplyMutation invocations cannot both observe a stale
+// watermark and double-apply.
 //
-// A zero origin (all-zero NodeID) is silently dropped: the wire
-// protocol forbids zero NodeIDs and accepting them would conflate
-// "unset" with "node-zero" in the PeerStatus map.
-func (t *originStateTracker) Record(origin hlc.NodeID, seq uint64, ts hlc.Timestamp) {
+// A zero origin (all-zero NodeID) is silently dropped and returns
+// false: the wire protocol forbids zero NodeIDs and accepting them
+// would conflate "unset" with "node-zero" in the PeerStatus map.
+func (t *originStateTracker) Record(origin hlc.NodeID, seq uint64, ts hlc.Timestamp) bool {
 	var zero hlc.NodeID
 	if origin == zero {
-		return
+		return false
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	prev, ok := t.m[origin]
 	if ok && seq <= prev.seq {
-		return
+		return false
 	}
 	t.m[origin] = originRow{seq: seq, hlc: ts}
+	return true
 }
 
 // OriginState is a snapshot row returned by States().

--- a/tests/integration/peer_pump_test.go
+++ b/tests/integration/peer_pump_test.go
@@ -184,20 +184,22 @@ func TestPeerPump_E2E_ThreeNodeConvergence(t *testing.T) {
 		t.Errorf("c edge from-a->target: got w=%v ok=%v want 1.5/true", w, ok)
 	}
 
-	// Self-echo defence: A's mutation seq for "from-a" must NOT be
-	// re-applied on A. The mutationlog's monotonic last-seq is the
-	// canonical witness — if a peer had bounced our own mutation
-	// back, ApplyMutation would have appended a new entry and the
-	// lastSeq would exceed the count of local writes. A produced
-	// exactly 2 local writes (PutVertex + AddEdge).
-	if last, ok := a.log.LastSeq(); !ok || last != 2 {
-		t.Errorf("a.log.LastSeq=%d ok=%v want 2 (self-echo suppression broken?)", last, ok)
+	// Reading B (#415): every node's mutation log retains all four
+	// cluster-wide writes (A's PutVertex + AddEdge, B's PutVertex,
+	// C's PutVertex). The peer-pump still suppresses self-echo and
+	// the ApplyMutation watermark gate still dedups duplicate hops,
+	// so each (origin, seq) lands at most once on every replica.
+	// The canonical witness is the monotonic last-seq: it equals
+	// the count of distinct cluster mutations seen by each replica.
+	const wantClusterWrites = 4
+	if last, ok := a.log.LastSeq(); !ok || last != wantClusterWrites {
+		t.Errorf("a.log.LastSeq=%d ok=%v want %d (leaderless Subscribe contract)", last, ok, wantClusterWrites)
 	}
-	if last, ok := b.log.LastSeq(); !ok || last != 1 {
-		t.Errorf("b.log.LastSeq=%d ok=%v want 1", last, ok)
+	if last, ok := b.log.LastSeq(); !ok || last != wantClusterWrites {
+		t.Errorf("b.log.LastSeq=%d ok=%v want %d", last, ok, wantClusterWrites)
 	}
-	if last, ok := c.log.LastSeq(); !ok || last != 1 {
-		t.Errorf("c.log.LastSeq=%d ok=%v want 1", last, ok)
+	if last, ok := c.log.LastSeq(); !ok || last != wantClusterWrites {
+		t.Errorf("c.log.LastSeq=%d ok=%v want %d", last, ok, wantClusterWrites)
 	}
 }
 


### PR DESCRIPTION
## What

Reading B (leaderless Subscribe) contract, delivered via two surgical edits with no new types, no new public API, and no wire change. Closes #417 (B-3 of the [#415 plan](../issues/415#issuecomment-4639408249)).

### Mechanism

1. [`server/service/origin_state.go`](../tree/feat/417-leaderless-subscribe/server/service/origin_state.go) — `originStateTracker.Record` becomes a CAS that returns whether the watermark advanced. The bool is the single source of truth for "is this (origin, seq) new?"
2. [`server/service/apply.go`](../tree/feat/417-leaderless-subscribe/server/service/apply.go) — `ApplyMutation` uses that bool to drive two decisions:
   - **log Append**: only on advance. Remote mutations land in the local mutationlog so external Subscribe streams on this replica observe them. `Entry.HLC.NodeID` equals the remote origin (already carried through `hlcFromProto`), which is what the peer pump reads to recognise self-echoes.
   - **onApplied hook**: only on advance, so peer-status counters reflect distinct cluster mutations rather than redelivery volume.

   The cache apply itself stays unconditional — HLC LWW for `Put*`, ContribID-deduped for `Add*` — so out-of-order or duplicate deliveries are absorbed without divergence (the `TestApplyMutation_Convergence` invariant).

Replication loops are prevented by the watermark CAS: a (origin, seq) tuple that already reached us through one peer hop short-circuits the second hop before any log Append. Combined with the pump's existing input-side `isSelfEcho` suppression, this is defence-in-depth.

## Bench evidence

`testbed/bench/out/many_subscribers/20260606T153314Z/` vs the four Reading A baselines from 2026-06-06:

| metric | Reading A (median across 4 runs) | Reading B (B-3) |
|---|---:|---:|
| starve / 64 | **42** | **0** |
| leak gate | pass | pass |
| writer ops | 599,998 | 599,768 |
| writer p99 ms | 4.81 | 15.33 |
| `lantern_mutationlog_subscriber_dropped_total` | 0 | 0 |
| `lantern_replication_applied_total` (per peer rate) | 2 × 1999.96/s | 2 × 2000.0/s |

`starve` drops to zero — every one of the 64 subscribers on every replica observes all 600k cluster writes. The p99 increase (~3×) is the documented Reading B capacity cost from #415: each replica now appends all-cluster traffic to its own log (its own writes plus two replicas' applied entries). Capacity sizing review is the topic of B-5 (#419).

## Tests

- `server/service/apply_test.go`: rewrites `TestApplyMutation_DoesNotLog` (which encoded the old Reading A contract) into two Reading B tests:
  - `TestApplyMutation_AppendsToLocalLog` — single apply lands one entry in the local log.
  - `TestApplyMutation_DoesNotReAppendDuplicate` — three applies of the same `(origin, seq)` land exactly one entry.
- `tests/integration/peer_pump_test.go`: `TestPeerPump_E2E_ThreeNodeConvergence` updates its log-witness assertion: under Reading B every replica's `log.LastSeq` equals the total count of cluster mutations (4), not just this replica's direct writes.

## Scope

- **In:** `server/service/apply.go`, `server/service/origin_state.go`, `server/service/apply_test.go`, `tests/integration/peer_pump_test.go`. ~150 LOC, all tests green: `go test ./...` passes in `core/`, `server/`, `mcp/`, and root.
- **Out:** `pb/*` (no wire change). `SubscribeRequest.from_seq` stays scalar; the per-origin resume cursor lands in B-2 (#418).
- **Out:** `core/mutationlog/*` (no API change). The abandoned B-1 `Scope` axis (see #416, closed superseded) is unnecessary — `Entry.HLC.NodeID` already carries the originating writer's NodeID.
- **Out:** `server/replication/pump.go` (no edits). The pump's input-side `isSelfEcho` remains as defence-in-depth.
- **Out:** SDKs — Go / Node / CLI subscribers see a richer entry stream from any replica with **zero code change**.
- **Out:** Docs / scenario / README updates — those land in B-5 (#419).

## CI expectations

All 4 required checks (Build & Test, Lint, Proto (buf), govulncheck) should pass. No `.proto` files touched so the Proto check is a no-op confirmation. govulncheck is unaffected.

## Refs

- Parent: #415 (Reading B adoption + plan)
- Original symptom: #392 (closes via B-5)
- Bench scenario: #414 (closes via B-5)
- Sibling: #418 (B-2 wire change), #419 (B-5 docs + scenario + capacity)
- Superseded: #416 (B-1 Scope axis approach)

Closes #417
