### PR TITLE
feat(pb,server,sdks): per-origin SubscribeRequest cursor (Reading B B-2, closes #418)

### DIFF
--- a/admin/app/lib/api/gen/graph/v1/graph_pb.ts
+++ b/admin/app/lib/api/gen/graph/v1/graph_pb.ts
@@ -1992,8 +1992,9 @@ export class GetServerStatusResponse extends Message<GetServerStatusResponse> {
 
   /**
    * Wall-clock instant the server process started serving requests.
-   * Captured at gRPC server start, not at process start, so the value
-   * reflects "ready to serve" rather than "wire init done".
+   * Captured when the Connect listener starts accepting, not at process
+   * start, so the value reflects "ready to serve" rather than "wire
+   * init done".
    *
    * @generated from field: google.protobuf.Timestamp started_at = 3;
    */
@@ -2043,7 +2044,7 @@ export class GetServerStatusResponse extends Message<GetServerStatusResponse> {
   scanMaxLimit = 0;
 
   /**
-   * True when the gRPC server is terminating TLS
+   * True when the server is terminating TLS
    * (LANTERN_TLS_CERT_FILE + LANTERN_TLS_KEY_FILE both set).
    *
    * @generated from field: bool tls_enabled = 10;

--- a/admin/app/lib/api/gen/graph/v1/replication_connect.ts
+++ b/admin/app/lib/api/gen/graph/v1/replication_connect.ts
@@ -36,7 +36,9 @@ export const LanternReplicationService = {
      * also have the stream terminated with FAILED_PRECONDITION — the
      * remedy is the same.
      *
-     * No HTTP gateway annotation: replication is intentionally gRPC-only.
+     * No HTTP gateway annotation: replication is intentionally exposed
+     * only as Connect server-streaming (consumed by replication pumps on
+     * peer nodes, never directly from browsers).
      *
      * @generated from rpc graph.v1.LanternReplicationService.Subscribe
      */

--- a/admin/app/lib/api/gen/graph/v1/replication_pb.ts
+++ b/admin/app/lib/api/gen/graph/v1/replication_pb.ts
@@ -257,19 +257,47 @@ export class Mutation extends Message<Mutation> {
 
 /**
  * SubscribeRequest opens a stream of replicated mutations starting at
- * `from_seq` (inclusive). The server replays any in-buffer entries with
- * seq >= from_seq, then streams live mutations as they are appended.
+ * the per-origin cursor in `from_seq_per_origin`.
  *
- * If `from_seq` is below the server's first available seq the call fails
- * with FAILED_PRECONDITION and the caller must snapshot + resubscribe.
+ * Under the leaderless Subscribe contract (#415, B-3), every replica's
+ * local mutation log carries entries from every cluster origin (each
+ * stamped with its writer's HLC NodeID). A consumer can therefore pick
+ * any one replica and see every committed cluster mutation; on failover
+ * to a different replica it resumes by passing the highest `seq` it
+ * has already observed FOR EACH origin.
+ *
+ * Semantics:
+ *
+ *   - Empty map (or unset field) requests every entry the server still
+ *     retains. This is the new-consumer / cold-start case.
+ *   - For each origin key present in the map, the server delivers only
+ *     entries with `seq >= from_seq_per_origin[origin]` for that
+ *     origin. Entries for origins NOT in the map are delivered from
+ *     the oldest retained entry; this lets a consumer that has only
+ *     ever talked to a subset of replicas naturally pick up entries
+ *     from a newly-joined origin.
+ *   - If the resulting overall earliest requested seq is below the
+ *     server's first retained log seq the call fails with
+ *     FAILED_PRECONDITION and the caller must snapshot + resubscribe.
+ *
+ * Keys are 32-character lowercase hexadecimal encodings of the 16-byte
+ * HLC NodeID (matching `HLCTimestamp.node_id` and `Mutation.origin`).
+ * Hex was chosen over raw bytes because proto3 map keys forbid `bytes`
+ * and because the hex form already appears in `lantern_replication_*`
+ * Prometheus labels and in admin UI surfaces, keeping the consumer
+ * debug experience uniform across wire, metrics, and UI.
  *
  * @generated from message graph.v1.SubscribeRequest
  */
 export class SubscribeRequest extends Message<SubscribeRequest> {
   /**
-   * @generated from field: uint64 from_seq = 1;
+   * Per-origin resume cursor. Keys are 32-char lowercase hex of the
+   * 16-byte HLC NodeID; values are the next local `seq` the consumer
+   * expects from that origin.
+   *
+   * @generated from field: map<string, uint64> from_seq_per_origin = 1;
    */
-  fromSeq = protoInt64.zero;
+  fromSeqPerOrigin: { [key: string]: bigint } = {};
 
   constructor(data?: PartialMessage<SubscribeRequest>) {
     super();
@@ -279,7 +307,7 @@ export class SubscribeRequest extends Message<SubscribeRequest> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "graph.v1.SubscribeRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "from_seq", kind: "scalar", T: 4 /* ScalarType.UINT64 */ },
+    { no: 1, name: "from_seq_per_origin", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "scalar", T: 4 /* ScalarType.UINT64 */} },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): SubscribeRequest {

--- a/pb/graph/v1/replication.pb.go
+++ b/pb/graph/v1/replication.pb.go
@@ -405,16 +405,43 @@ func (x *Mutation) GetOp() *MutationOp {
 }
 
 // SubscribeRequest opens a stream of replicated mutations starting at
-// `from_seq` (inclusive). The server replays any in-buffer entries with
-// seq >= from_seq, then streams live mutations as they are appended.
+// the per-origin cursor in `from_seq_per_origin`.
 //
-// If `from_seq` is below the server's first available seq the call fails
-// with FAILED_PRECONDITION and the caller must snapshot + resubscribe.
+// Under the leaderless Subscribe contract (#415, B-3), every replica's
+// local mutation log carries entries from every cluster origin (each
+// stamped with its writer's HLC NodeID). A consumer can therefore pick
+// any one replica and see every committed cluster mutation; on failover
+// to a different replica it resumes by passing the highest `seq` it
+// has already observed FOR EACH origin.
+//
+// Semantics:
+//
+//   - Empty map (or unset field) requests every entry the server still
+//     retains. This is the new-consumer / cold-start case.
+//   - For each origin key present in the map, the server delivers only
+//     entries with `seq >= from_seq_per_origin[origin]` for that
+//     origin. Entries for origins NOT in the map are delivered from
+//     the oldest retained entry; this lets a consumer that has only
+//     ever talked to a subset of replicas naturally pick up entries
+//     from a newly-joined origin.
+//   - If the resulting overall earliest requested seq is below the
+//     server's first retained log seq the call fails with
+//     FAILED_PRECONDITION and the caller must snapshot + resubscribe.
+//
+// Keys are 32-character lowercase hexadecimal encodings of the 16-byte
+// HLC NodeID (matching `HLCTimestamp.node_id` and `Mutation.origin`).
+// Hex was chosen over raw bytes because proto3 map keys forbid `bytes`
+// and because the hex form already appears in `lantern_replication_*`
+// Prometheus labels and in admin UI surfaces, keeping the consumer
+// debug experience uniform across wire, metrics, and UI.
 type SubscribeRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	FromSeq       uint64                 `protobuf:"varint,1,opt,name=from_seq,json=fromSeq,proto3" json:"from_seq,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Per-origin resume cursor. Keys are 32-char lowercase hex of the
+	// 16-byte HLC NodeID; values are the next local `seq` the consumer
+	// expects from that origin.
+	FromSeqPerOrigin map[string]uint64 `protobuf:"bytes,1,rep,name=from_seq_per_origin,json=fromSeqPerOrigin,proto3" json:"from_seq_per_origin,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *SubscribeRequest) Reset() {
@@ -447,11 +474,11 @@ func (*SubscribeRequest) Descriptor() ([]byte, []int) {
 	return file_graph_v1_replication_proto_rawDescGZIP(), []int{3}
 }
 
-func (x *SubscribeRequest) GetFromSeq() uint64 {
+func (x *SubscribeRequest) GetFromSeqPerOrigin() map[string]uint64 {
 	if x != nil {
-		return x.FromSeq
+		return x.FromSeqPerOrigin
 	}
-	return 0
+	return nil
 }
 
 // SubscribeResponse carries one replicated mutation per message.
@@ -1163,9 +1190,12 @@ const file_graph_v1_replication_proto_rawDesc = "" +
 	"\x03seq\x18\x01 \x01(\x04R\x03seq\x12(\n" +
 	"\x03hlc\x18\x02 \x01(\v2\x16.graph.v1.HLCTimestampR\x03hlc\x12\x16\n" +
 	"\x06origin\x18\x03 \x01(\fR\x06origin\x12$\n" +
-	"\x02op\x18\x04 \x01(\v2\x14.graph.v1.MutationOpR\x02op\"-\n" +
-	"\x10SubscribeRequest\x12\x19\n" +
-	"\bfrom_seq\x18\x01 \x01(\x04R\afromSeq\"C\n" +
+	"\x02op\x18\x04 \x01(\v2\x14.graph.v1.MutationOpR\x02op\"\xb8\x01\n" +
+	"\x10SubscribeRequest\x12_\n" +
+	"\x13from_seq_per_origin\x18\x01 \x03(\v20.graph.v1.SubscribeRequest.FromSeqPerOriginEntryR\x10fromSeqPerOrigin\x1aC\n" +
+	"\x15FromSeqPerOriginEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\x04R\x05value:\x028\x01\"C\n" +
 	"\x11SubscribeResponse\x12.\n" +
 	"\bmutation\x18\x01 \x01(\v2\x12.graph.v1.MutationR\bmutation\"\x11\n" +
 	"\x0fSnapshotRequest\"f\n" +
@@ -1227,7 +1257,7 @@ func file_graph_v1_replication_proto_rawDescGZIP() []byte {
 	return file_graph_v1_replication_proto_rawDescData
 }
 
-var file_graph_v1_replication_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_graph_v1_replication_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_graph_v1_replication_proto_goTypes = []any{
 	(*HLCTimestamp)(nil),                  // 0: graph.v1.HLCTimestamp
 	(*MutationOp)(nil),                    // 1: graph.v1.MutationOp
@@ -1244,58 +1274,60 @@ var file_graph_v1_replication_proto_goTypes = []any{
 	(*PeerStatusRequest)(nil),             // 12: graph.v1.PeerStatusRequest
 	(*OriginState)(nil),                   // 13: graph.v1.OriginState
 	(*PeerStatusResponse)(nil),            // 14: graph.v1.PeerStatusResponse
-	(*PutVertexRequest)(nil),              // 15: graph.v1.PutVertexRequest
-	(*PutVerticesRequest)(nil),            // 16: graph.v1.PutVerticesRequest
-	(*DeleteVertexRequest)(nil),           // 17: graph.v1.DeleteVertexRequest
-	(*DeleteVerticesRequest)(nil),         // 18: graph.v1.DeleteVerticesRequest
-	(*DeleteVerticesByPrefixRequest)(nil), // 19: graph.v1.DeleteVerticesByPrefixRequest
-	(*AddEdgeRequest)(nil),                // 20: graph.v1.AddEdgeRequest
-	(*AddEdgesRequest)(nil),               // 21: graph.v1.AddEdgesRequest
-	(*PutEdgeRequest)(nil),                // 22: graph.v1.PutEdgeRequest
-	(*PutEdgesRequest)(nil),               // 23: graph.v1.PutEdgesRequest
-	(*DeleteEdgeRequest)(nil),             // 24: graph.v1.DeleteEdgeRequest
-	(*DeleteEdgesRequest)(nil),            // 25: graph.v1.DeleteEdgesRequest
-	(*Vertex)(nil),                        // 26: graph.v1.Vertex
-	(*timestamppb.Timestamp)(nil),         // 27: google.protobuf.Timestamp
+	nil,                                   // 15: graph.v1.SubscribeRequest.FromSeqPerOriginEntry
+	(*PutVertexRequest)(nil),              // 16: graph.v1.PutVertexRequest
+	(*PutVerticesRequest)(nil),            // 17: graph.v1.PutVerticesRequest
+	(*DeleteVertexRequest)(nil),           // 18: graph.v1.DeleteVertexRequest
+	(*DeleteVerticesRequest)(nil),         // 19: graph.v1.DeleteVerticesRequest
+	(*DeleteVerticesByPrefixRequest)(nil), // 20: graph.v1.DeleteVerticesByPrefixRequest
+	(*AddEdgeRequest)(nil),                // 21: graph.v1.AddEdgeRequest
+	(*AddEdgesRequest)(nil),               // 22: graph.v1.AddEdgesRequest
+	(*PutEdgeRequest)(nil),                // 23: graph.v1.PutEdgeRequest
+	(*PutEdgesRequest)(nil),               // 24: graph.v1.PutEdgesRequest
+	(*DeleteEdgeRequest)(nil),             // 25: graph.v1.DeleteEdgeRequest
+	(*DeleteEdgesRequest)(nil),            // 26: graph.v1.DeleteEdgesRequest
+	(*Vertex)(nil),                        // 27: graph.v1.Vertex
+	(*timestamppb.Timestamp)(nil),         // 28: google.protobuf.Timestamp
 }
 var file_graph_v1_replication_proto_depIdxs = []int32{
-	15, // 0: graph.v1.MutationOp.put_vertex:type_name -> graph.v1.PutVertexRequest
-	16, // 1: graph.v1.MutationOp.put_vertices:type_name -> graph.v1.PutVerticesRequest
-	17, // 2: graph.v1.MutationOp.delete_vertex:type_name -> graph.v1.DeleteVertexRequest
-	18, // 3: graph.v1.MutationOp.delete_vertices:type_name -> graph.v1.DeleteVerticesRequest
-	19, // 4: graph.v1.MutationOp.delete_vertices_by_prefix:type_name -> graph.v1.DeleteVerticesByPrefixRequest
-	20, // 5: graph.v1.MutationOp.add_edge:type_name -> graph.v1.AddEdgeRequest
-	21, // 6: graph.v1.MutationOp.add_edges:type_name -> graph.v1.AddEdgesRequest
-	22, // 7: graph.v1.MutationOp.put_edge:type_name -> graph.v1.PutEdgeRequest
-	23, // 8: graph.v1.MutationOp.put_edges:type_name -> graph.v1.PutEdgesRequest
-	24, // 9: graph.v1.MutationOp.delete_edge:type_name -> graph.v1.DeleteEdgeRequest
-	25, // 10: graph.v1.MutationOp.delete_edges:type_name -> graph.v1.DeleteEdgesRequest
+	16, // 0: graph.v1.MutationOp.put_vertex:type_name -> graph.v1.PutVertexRequest
+	17, // 1: graph.v1.MutationOp.put_vertices:type_name -> graph.v1.PutVerticesRequest
+	18, // 2: graph.v1.MutationOp.delete_vertex:type_name -> graph.v1.DeleteVertexRequest
+	19, // 3: graph.v1.MutationOp.delete_vertices:type_name -> graph.v1.DeleteVerticesRequest
+	20, // 4: graph.v1.MutationOp.delete_vertices_by_prefix:type_name -> graph.v1.DeleteVerticesByPrefixRequest
+	21, // 5: graph.v1.MutationOp.add_edge:type_name -> graph.v1.AddEdgeRequest
+	22, // 6: graph.v1.MutationOp.add_edges:type_name -> graph.v1.AddEdgesRequest
+	23, // 7: graph.v1.MutationOp.put_edge:type_name -> graph.v1.PutEdgeRequest
+	24, // 8: graph.v1.MutationOp.put_edges:type_name -> graph.v1.PutEdgesRequest
+	25, // 9: graph.v1.MutationOp.delete_edge:type_name -> graph.v1.DeleteEdgeRequest
+	26, // 10: graph.v1.MutationOp.delete_edges:type_name -> graph.v1.DeleteEdgesRequest
 	0,  // 11: graph.v1.Mutation.hlc:type_name -> graph.v1.HLCTimestamp
 	1,  // 12: graph.v1.Mutation.op:type_name -> graph.v1.MutationOp
-	2,  // 13: graph.v1.SubscribeResponse.mutation:type_name -> graph.v1.Mutation
-	0,  // 14: graph.v1.SnapshotHeader.cutoff_hlc:type_name -> graph.v1.HLCTimestamp
-	26, // 15: graph.v1.SnapshotVertex.vertex:type_name -> graph.v1.Vertex
-	0,  // 16: graph.v1.SnapshotVertex.hlc:type_name -> graph.v1.HLCTimestamp
-	27, // 17: graph.v1.SnapshotEdgeContribution.expiration:type_name -> google.protobuf.Timestamp
-	0,  // 18: graph.v1.SnapshotEdge.hlc:type_name -> graph.v1.HLCTimestamp
-	9,  // 19: graph.v1.SnapshotEdge.contributions:type_name -> graph.v1.SnapshotEdgeContribution
-	6,  // 20: graph.v1.SnapshotResponse.header:type_name -> graph.v1.SnapshotHeader
-	8,  // 21: graph.v1.SnapshotResponse.vertex:type_name -> graph.v1.SnapshotVertex
-	10, // 22: graph.v1.SnapshotResponse.edge:type_name -> graph.v1.SnapshotEdge
-	7,  // 23: graph.v1.SnapshotResponse.footer:type_name -> graph.v1.SnapshotFooter
-	0,  // 24: graph.v1.OriginState.last_hlc:type_name -> graph.v1.HLCTimestamp
-	13, // 25: graph.v1.PeerStatusResponse.origins:type_name -> graph.v1.OriginState
-	3,  // 26: graph.v1.LanternReplicationService.Subscribe:input_type -> graph.v1.SubscribeRequest
-	5,  // 27: graph.v1.LanternReplicationService.Snapshot:input_type -> graph.v1.SnapshotRequest
-	12, // 28: graph.v1.LanternReplicationService.PeerStatus:input_type -> graph.v1.PeerStatusRequest
-	4,  // 29: graph.v1.LanternReplicationService.Subscribe:output_type -> graph.v1.SubscribeResponse
-	11, // 30: graph.v1.LanternReplicationService.Snapshot:output_type -> graph.v1.SnapshotResponse
-	14, // 31: graph.v1.LanternReplicationService.PeerStatus:output_type -> graph.v1.PeerStatusResponse
-	29, // [29:32] is the sub-list for method output_type
-	26, // [26:29] is the sub-list for method input_type
-	26, // [26:26] is the sub-list for extension type_name
-	26, // [26:26] is the sub-list for extension extendee
-	0,  // [0:26] is the sub-list for field type_name
+	15, // 13: graph.v1.SubscribeRequest.from_seq_per_origin:type_name -> graph.v1.SubscribeRequest.FromSeqPerOriginEntry
+	2,  // 14: graph.v1.SubscribeResponse.mutation:type_name -> graph.v1.Mutation
+	0,  // 15: graph.v1.SnapshotHeader.cutoff_hlc:type_name -> graph.v1.HLCTimestamp
+	27, // 16: graph.v1.SnapshotVertex.vertex:type_name -> graph.v1.Vertex
+	0,  // 17: graph.v1.SnapshotVertex.hlc:type_name -> graph.v1.HLCTimestamp
+	28, // 18: graph.v1.SnapshotEdgeContribution.expiration:type_name -> google.protobuf.Timestamp
+	0,  // 19: graph.v1.SnapshotEdge.hlc:type_name -> graph.v1.HLCTimestamp
+	9,  // 20: graph.v1.SnapshotEdge.contributions:type_name -> graph.v1.SnapshotEdgeContribution
+	6,  // 21: graph.v1.SnapshotResponse.header:type_name -> graph.v1.SnapshotHeader
+	8,  // 22: graph.v1.SnapshotResponse.vertex:type_name -> graph.v1.SnapshotVertex
+	10, // 23: graph.v1.SnapshotResponse.edge:type_name -> graph.v1.SnapshotEdge
+	7,  // 24: graph.v1.SnapshotResponse.footer:type_name -> graph.v1.SnapshotFooter
+	0,  // 25: graph.v1.OriginState.last_hlc:type_name -> graph.v1.HLCTimestamp
+	13, // 26: graph.v1.PeerStatusResponse.origins:type_name -> graph.v1.OriginState
+	3,  // 27: graph.v1.LanternReplicationService.Subscribe:input_type -> graph.v1.SubscribeRequest
+	5,  // 28: graph.v1.LanternReplicationService.Snapshot:input_type -> graph.v1.SnapshotRequest
+	12, // 29: graph.v1.LanternReplicationService.PeerStatus:input_type -> graph.v1.PeerStatusRequest
+	4,  // 30: graph.v1.LanternReplicationService.Subscribe:output_type -> graph.v1.SubscribeResponse
+	11, // 31: graph.v1.LanternReplicationService.Snapshot:output_type -> graph.v1.SnapshotResponse
+	14, // 32: graph.v1.LanternReplicationService.PeerStatus:output_type -> graph.v1.PeerStatusResponse
+	30, // [30:33] is the sub-list for method output_type
+	27, // [27:30] is the sub-list for method input_type
+	27, // [27:27] is the sub-list for extension type_name
+	27, // [27:27] is the sub-list for extension extendee
+	0,  // [0:27] is the sub-list for field type_name
 }
 
 func init() { file_graph_v1_replication_proto_init() }
@@ -1329,7 +1361,7 @@ func file_graph_v1_replication_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_graph_v1_replication_proto_rawDesc), len(file_graph_v1_replication_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   15,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/graph/v1/replication.proto
+++ b/proto/graph/v1/replication.proto
@@ -63,13 +63,40 @@ message Mutation {
 }
 
 // SubscribeRequest opens a stream of replicated mutations starting at
-// `from_seq` (inclusive). The server replays any in-buffer entries with
-// seq >= from_seq, then streams live mutations as they are appended.
+// the per-origin cursor in `from_seq_per_origin`.
 //
-// If `from_seq` is below the server's first available seq the call fails
-// with FAILED_PRECONDITION and the caller must snapshot + resubscribe.
+// Under the leaderless Subscribe contract (#415, B-3), every replica's
+// local mutation log carries entries from every cluster origin (each
+// stamped with its writer's HLC NodeID). A consumer can therefore pick
+// any one replica and see every committed cluster mutation; on failover
+// to a different replica it resumes by passing the highest `seq` it
+// has already observed FOR EACH origin.
+//
+// Semantics:
+//
+//   - Empty map (or unset field) requests every entry the server still
+//     retains. This is the new-consumer / cold-start case.
+//   - For each origin key present in the map, the server delivers only
+//     entries with `seq >= from_seq_per_origin[origin]` for that
+//     origin. Entries for origins NOT in the map are delivered from
+//     the oldest retained entry; this lets a consumer that has only
+//     ever talked to a subset of replicas naturally pick up entries
+//     from a newly-joined origin.
+//   - If the resulting overall earliest requested seq is below the
+//     server's first retained log seq the call fails with
+//     FAILED_PRECONDITION and the caller must snapshot + resubscribe.
+//
+// Keys are 32-character lowercase hexadecimal encodings of the 16-byte
+// HLC NodeID (matching `HLCTimestamp.node_id` and `Mutation.origin`).
+// Hex was chosen over raw bytes because proto3 map keys forbid `bytes`
+// and because the hex form already appears in `lantern_replication_*`
+// Prometheus labels and in admin UI surfaces, keeping the consumer
+// debug experience uniform across wire, metrics, and UI.
 message SubscribeRequest {
-  uint64 from_seq = 1;
+  // Per-origin resume cursor. Keys are 32-char lowercase hex of the
+  // 16-byte HLC NodeID; values are the next local `seq` the consumer
+  // expects from that origin.
+  map<string, uint64> from_seq_per_origin = 1;
 }
 
 // SubscribeResponse carries one replicated mutation per message.

--- a/sdks/go/subscribe.go
+++ b/sdks/go/subscribe.go
@@ -8,28 +8,46 @@ package client
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"io"
 	"iter"
 
 	"connectrpc.com/connect"
 
+	"github.com/anaregdesign/lantern/core/hlc"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
 )
 
 // Subscribe opens a server-stream against the replication service and
 // returns an iter.Seq2 yielding successive *SubscribeResponse frames
-// until the stream closes. fromSeq passes through unchanged.
+// until the stream closes.
+//
+// Under the leaderless Subscribe contract (#415), the cluster's full
+// mutation stream is visible from every replica; cursor selects the
+// resume point per origin. An empty cursor (nil or zero-length map)
+// asks the server for every entry it still retains, suitable for a
+// new consumer.
+//
+// Keys in the cursor are HLC NodeIDs of every origin the caller has
+// already observed; values are the next seq the caller expects from
+// that origin. Origins absent from the cursor are delivered from the
+// oldest retained entry — see pb.SubscribeRequest for the full
+// semantics.
 //
 // Stop conditions: clean EOF, any server error, the supplied ctx being
 // canceled, or the consumer returning false from yield. The underlying
 // *connect.ServerStreamForClient is always closed before iteration
 // ends.
-func (l *Lantern) Subscribe(ctx context.Context, fromSeq uint64) iter.Seq2[*pb.SubscribeResponse, error] {
+func (l *Lantern) Subscribe(ctx context.Context, cursor map[hlc.NodeID]uint64) iter.Seq2[*pb.SubscribeResponse, error] {
 	return func(yield func(*pb.SubscribeResponse, error) bool) {
+		wire := make(map[string]uint64, len(cursor))
+		for id, seq := range cursor {
+			wire[hex.EncodeToString(id[:])] = seq
+		}
 		rc := graphv1connect.NewLanternReplicationServiceClient(l.httpClient, l.baseURL)
-		stream, err := rc.Subscribe(ctx, connect.NewRequest(&pb.SubscribeRequest{FromSeq: fromSeq}))
+		stream, err := rc.Subscribe(ctx, connect.NewRequest(&pb.SubscribeRequest{FromSeqPerOrigin: wire}))
 		if err != nil {
 			yield(nil, wrapConnectErr(err))
 			return

--- a/sdks/node/src/gen/graph/v1/graph_pb.ts
+++ b/sdks/node/src/gen/graph/v1/graph_pb.ts
@@ -1075,8 +1075,9 @@ export type GetServerStatusResponse = Message<"graph.v1.GetServerStatusResponse"
 
   /**
    * Wall-clock instant the server process started serving requests.
-   * Captured at gRPC server start, not at process start, so the value
-   * reflects "ready to serve" rather than "wire init done".
+   * Captured when the Connect listener starts accepting, not at process
+   * start, so the value reflects "ready to serve" rather than "wire
+   * init done".
    *
    * @generated from field: google.protobuf.Timestamp started_at = 3;
    */
@@ -1126,7 +1127,7 @@ export type GetServerStatusResponse = Message<"graph.v1.GetServerStatusResponse"
   scanMaxLimit: number;
 
   /**
-   * True when the gRPC server is terminating TLS
+   * True when the server is terminating TLS
    * (LANTERN_TLS_CERT_FILE + LANTERN_TLS_KEY_FILE both set).
    *
    * @generated from field: bool tls_enabled = 10;

--- a/sdks/node/src/gen/graph/v1/replication_pb.ts
+++ b/sdks/node/src/gen/graph/v1/replication_pb.ts
@@ -14,7 +14,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file graph/v1/replication.proto.
  */
 export const file_graph_v1_replication: GenFile = /*@__PURE__*/
-  fileDesc("ChpncmFwaC92MS9yZXBsaWNhdGlvbi5wcm90bxIIZ3JhcGgudjEiQQoMSExDVGltZXN0YW1wEg8KB3dhbGxfbnMYASABKAMSDwoHbG9naWNhbBgCIAEoDRIPCgdub2RlX2lkGAMgASgMIuIECgpNdXRhdGlvbk9wEjAKCnB1dF92ZXJ0ZXgYASABKAsyGi5ncmFwaC52MS5QdXRWZXJ0ZXhSZXF1ZXN0SAASNAoMcHV0X3ZlcnRpY2VzGAIgASgLMhwuZ3JhcGgudjEuUHV0VmVydGljZXNSZXF1ZXN0SAASNgoNZGVsZXRlX3ZlcnRleBgDIAEoCzIdLmdyYXBoLnYxLkRlbGV0ZVZlcnRleFJlcXVlc3RIABI6Cg9kZWxldGVfdmVydGljZXMYBCABKAsyHy5ncmFwaC52MS5EZWxldGVWZXJ0aWNlc1JlcXVlc3RIABJMChlkZWxldGVfdmVydGljZXNfYnlfcHJlZml4GAUgASgLMicuZ3JhcGgudjEuRGVsZXRlVmVydGljZXNCeVByZWZpeFJlcXVlc3RIABIsCghhZGRfZWRnZRgGIAEoCzIYLmdyYXBoLnYxLkFkZEVkZ2VSZXF1ZXN0SAASLgoJYWRkX2VkZ2VzGAcgASgLMhkuZ3JhcGgudjEuQWRkRWRnZXNSZXF1ZXN0SAASLAoIcHV0X2VkZ2UYCCABKAsyGC5ncmFwaC52MS5QdXRFZGdlUmVxdWVzdEgAEi4KCXB1dF9lZGdlcxgJIAEoCzIZLmdyYXBoLnYxLlB1dEVkZ2VzUmVxdWVzdEgAEjIKC2RlbGV0ZV9lZGdlGAogASgLMhsuZ3JhcGgudjEuRGVsZXRlRWRnZVJlcXVlc3RIABI0CgxkZWxldGVfZWRnZXMYCyABKAsyHC5ncmFwaC52MS5EZWxldGVFZGdlc1JlcXVlc3RIAEIECgJvcCJuCghNdXRhdGlvbhILCgNzZXEYASABKAQSIwoDaGxjGAIgASgLMhYuZ3JhcGgudjEuSExDVGltZXN0YW1wEg4KBm9yaWdpbhgDIAEoDBIgCgJvcBgEIAEoCzIULmdyYXBoLnYxLk11dGF0aW9uT3AiJAoQU3Vic2NyaWJlUmVxdWVzdBIQCghmcm9tX3NlcRgBIAEoBCI5ChFTdWJzY3JpYmVSZXNwb25zZRIkCghtdXRhdGlvbhgBIAEoCzISLmdyYXBoLnYxLk11dGF0aW9uIhEKD1NuYXBzaG90UmVxdWVzdCJQCg5TbmFwc2hvdEhlYWRlchISCgpjdXRvZmZfc2VxGAEgASgEEioKCmN1dG9mZl9obGMYAiABKAsyFi5ncmFwaC52MS5ITENUaW1lc3RhbXAiOgoOU25hcHNob3RGb290ZXISFAoMdmVydGV4X2NvdW50GAEgASgEEhIKCmVkZ2VfY291bnQYAiABKAQiVwoOU25hcHNob3RWZXJ0ZXgSIAoGdmVydGV4GAEgASgLMhAuZ3JhcGgudjEuVmVydGV4EiMKA2hsYxgCIAEoCzIWLmdyYXBoLnYxLkhMQ1RpbWVzdGFtcCJuChhTbmFwc2hvdEVkZ2VDb250cmlidXRpb24SDgoGd2VpZ2h0GAEgASgCEi4KCmV4cGlyYXRpb24YAiABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEhIKCmNvbnRyaWJfaWQYAyABKAwiigEKDFNuYXBzaG90RWRnZRIMCgR0YWlsGAEgASgJEgwKBGhlYWQYAiABKAkSIwoDaGxjGAMgASgLMhYuZ3JhcGgudjEuSExDVGltZXN0YW1wEjkKDWNvbnRyaWJ1dGlvbnMYBCADKAsyIi5ncmFwaC52MS5TbmFwc2hvdEVkZ2VDb250cmlidXRpb24ixwEKEFNuYXBzaG90UmVzcG9uc2USKgoGaGVhZGVyGAEgASgLMhguZ3JhcGgudjEuU25hcHNob3RIZWFkZXJIABIqCgZ2ZXJ0ZXgYAiABKAsyGC5ncmFwaC52MS5TbmFwc2hvdFZlcnRleEgAEiYKBGVkZ2UYAyABKAsyFi5ncmFwaC52MS5TbmFwc2hvdEVkZ2VIABIqCgZmb290ZXIYBCABKAsyGC5ncmFwaC52MS5TbmFwc2hvdEZvb3RlckgAQgcKBWVudHJ5IhMKEVBlZXJTdGF0dXNSZXF1ZXN0IlkKC09yaWdpblN0YXRlEg4KBm9yaWdpbhgBIAEoDBIQCghsYXN0X3NlcRgCIAEoBBIoCghsYXN0X2hsYxgDIAEoCzIWLmdyYXBoLnYxLkhMQ1RpbWVzdGFtcCJRChJQZWVyU3RhdHVzUmVzcG9uc2USEwoLc2VsZl9vcmlnaW4YASABKAwSJgoHb3JpZ2lucxgCIAMoCzIVLmdyYXBoLnYxLk9yaWdpblN0YXRlMvEBChlMYW50ZXJuUmVwbGljYXRpb25TZXJ2aWNlEkYKCVN1YnNjcmliZRIaLmdyYXBoLnYxLlN1YnNjcmliZVJlcXVlc3QaGy5ncmFwaC52MS5TdWJzY3JpYmVSZXNwb25zZTABEkMKCFNuYXBzaG90EhkuZ3JhcGgudjEuU25hcHNob3RSZXF1ZXN0GhouZ3JhcGgudjEuU25hcHNob3RSZXNwb25zZTABEkcKClBlZXJTdGF0dXMSGy5ncmFwaC52MS5QZWVyU3RhdHVzUmVxdWVzdBocLmdyYXBoLnYxLlBlZXJTdGF0dXNSZXNwb25zZUJhCgxjb20uZ3JhcGgudjFCEFJlcGxpY2F0aW9uUHJvdG9QAaICA0dYWKoCCEdyYXBoLlYxygIIR3JhcGhcVjHiAhRHcmFwaFxWMVxHUEJNZXRhZGF0YeoCCUdyYXBoOjpWMWIGcHJvdG8z", [file_google_protobuf_timestamp, file_graph_v1_graph]);
+  fileDesc("ChpncmFwaC92MS9yZXBsaWNhdGlvbi5wcm90bxIIZ3JhcGgudjEiQQoMSExDVGltZXN0YW1wEg8KB3dhbGxfbnMYASABKAMSDwoHbG9naWNhbBgCIAEoDRIPCgdub2RlX2lkGAMgASgMIuIECgpNdXRhdGlvbk9wEjAKCnB1dF92ZXJ0ZXgYASABKAsyGi5ncmFwaC52MS5QdXRWZXJ0ZXhSZXF1ZXN0SAASNAoMcHV0X3ZlcnRpY2VzGAIgASgLMhwuZ3JhcGgudjEuUHV0VmVydGljZXNSZXF1ZXN0SAASNgoNZGVsZXRlX3ZlcnRleBgDIAEoCzIdLmdyYXBoLnYxLkRlbGV0ZVZlcnRleFJlcXVlc3RIABI6Cg9kZWxldGVfdmVydGljZXMYBCABKAsyHy5ncmFwaC52MS5EZWxldGVWZXJ0aWNlc1JlcXVlc3RIABJMChlkZWxldGVfdmVydGljZXNfYnlfcHJlZml4GAUgASgLMicuZ3JhcGgudjEuRGVsZXRlVmVydGljZXNCeVByZWZpeFJlcXVlc3RIABIsCghhZGRfZWRnZRgGIAEoCzIYLmdyYXBoLnYxLkFkZEVkZ2VSZXF1ZXN0SAASLgoJYWRkX2VkZ2VzGAcgASgLMhkuZ3JhcGgudjEuQWRkRWRnZXNSZXF1ZXN0SAASLAoIcHV0X2VkZ2UYCCABKAsyGC5ncmFwaC52MS5QdXRFZGdlUmVxdWVzdEgAEi4KCXB1dF9lZGdlcxgJIAEoCzIZLmdyYXBoLnYxLlB1dEVkZ2VzUmVxdWVzdEgAEjIKC2RlbGV0ZV9lZGdlGAogASgLMhsuZ3JhcGgudjEuRGVsZXRlRWRnZVJlcXVlc3RIABI0CgxkZWxldGVfZWRnZXMYCyABKAsyHC5ncmFwaC52MS5EZWxldGVFZGdlc1JlcXVlc3RIAEIECgJvcCJuCghNdXRhdGlvbhILCgNzZXEYASABKAQSIwoDaGxjGAIgASgLMhYuZ3JhcGgudjEuSExDVGltZXN0YW1wEg4KBm9yaWdpbhgDIAEoDBIgCgJvcBgEIAEoCzIULmdyYXBoLnYxLk11dGF0aW9uT3AimgEKEFN1YnNjcmliZVJlcXVlc3QSTQoTZnJvbV9zZXFfcGVyX29yaWdpbhgBIAMoCzIwLmdyYXBoLnYxLlN1YnNjcmliZVJlcXVlc3QuRnJvbVNlcVBlck9yaWdpbkVudHJ5GjcKFUZyb21TZXFQZXJPcmlnaW5FbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAQ6AjgBIjkKEVN1YnNjcmliZVJlc3BvbnNlEiQKCG11dGF0aW9uGAEgASgLMhIuZ3JhcGgudjEuTXV0YXRpb24iEQoPU25hcHNob3RSZXF1ZXN0IlAKDlNuYXBzaG90SGVhZGVyEhIKCmN1dG9mZl9zZXEYASABKAQSKgoKY3V0b2ZmX2hsYxgCIAEoCzIWLmdyYXBoLnYxLkhMQ1RpbWVzdGFtcCI6Cg5TbmFwc2hvdEZvb3RlchIUCgx2ZXJ0ZXhfY291bnQYASABKAQSEgoKZWRnZV9jb3VudBgCIAEoBCJXCg5TbmFwc2hvdFZlcnRleBIgCgZ2ZXJ0ZXgYASABKAsyEC5ncmFwaC52MS5WZXJ0ZXgSIwoDaGxjGAIgASgLMhYuZ3JhcGgudjEuSExDVGltZXN0YW1wIm4KGFNuYXBzaG90RWRnZUNvbnRyaWJ1dGlvbhIOCgZ3ZWlnaHQYASABKAISLgoKZXhwaXJhdGlvbhgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASEgoKY29udHJpYl9pZBgDIAEoDCKKAQoMU25hcHNob3RFZGdlEgwKBHRhaWwYASABKAkSDAoEaGVhZBgCIAEoCRIjCgNobGMYAyABKAsyFi5ncmFwaC52MS5ITENUaW1lc3RhbXASOQoNY29udHJpYnV0aW9ucxgEIAMoCzIiLmdyYXBoLnYxLlNuYXBzaG90RWRnZUNvbnRyaWJ1dGlvbiLHAQoQU25hcHNob3RSZXNwb25zZRIqCgZoZWFkZXIYASABKAsyGC5ncmFwaC52MS5TbmFwc2hvdEhlYWRlckgAEioKBnZlcnRleBgCIAEoCzIYLmdyYXBoLnYxLlNuYXBzaG90VmVydGV4SAASJgoEZWRnZRgDIAEoCzIWLmdyYXBoLnYxLlNuYXBzaG90RWRnZUgAEioKBmZvb3RlchgEIAEoCzIYLmdyYXBoLnYxLlNuYXBzaG90Rm9vdGVySABCBwoFZW50cnkiEwoRUGVlclN0YXR1c1JlcXVlc3QiWQoLT3JpZ2luU3RhdGUSDgoGb3JpZ2luGAEgASgMEhAKCGxhc3Rfc2VxGAIgASgEEigKCGxhc3RfaGxjGAMgASgLMhYuZ3JhcGgudjEuSExDVGltZXN0YW1wIlEKElBlZXJTdGF0dXNSZXNwb25zZRITCgtzZWxmX29yaWdpbhgBIAEoDBImCgdvcmlnaW5zGAIgAygLMhUuZ3JhcGgudjEuT3JpZ2luU3RhdGUy8QEKGUxhbnRlcm5SZXBsaWNhdGlvblNlcnZpY2USRgoJU3Vic2NyaWJlEhouZ3JhcGgudjEuU3Vic2NyaWJlUmVxdWVzdBobLmdyYXBoLnYxLlN1YnNjcmliZVJlc3BvbnNlMAESQwoIU25hcHNob3QSGS5ncmFwaC52MS5TbmFwc2hvdFJlcXVlc3QaGi5ncmFwaC52MS5TbmFwc2hvdFJlc3BvbnNlMAESRwoKUGVlclN0YXR1cxIbLmdyYXBoLnYxLlBlZXJTdGF0dXNSZXF1ZXN0GhwuZ3JhcGgudjEuUGVlclN0YXR1c1Jlc3BvbnNlQmEKDGNvbS5ncmFwaC52MUIQUmVwbGljYXRpb25Qcm90b1ABogIDR1hYqgIIR3JhcGguVjHKAghHcmFwaFxWMeICFEdyYXBoXFYxXEdQQk1ldGFkYXRh6gIJR3JhcGg6OlYxYgZwcm90bzM", [file_google_protobuf_timestamp, file_graph_v1_graph]);
 
 /**
  * HLCTimestamp is the wire form of core/hlc.Timestamp. All replicated
@@ -191,19 +191,47 @@ export const MutationSchema: GenMessage<Mutation> = /*@__PURE__*/
 
 /**
  * SubscribeRequest opens a stream of replicated mutations starting at
- * `from_seq` (inclusive). The server replays any in-buffer entries with
- * seq >= from_seq, then streams live mutations as they are appended.
+ * the per-origin cursor in `from_seq_per_origin`.
  *
- * If `from_seq` is below the server's first available seq the call fails
- * with FAILED_PRECONDITION and the caller must snapshot + resubscribe.
+ * Under the leaderless Subscribe contract (#415, B-3), every replica's
+ * local mutation log carries entries from every cluster origin (each
+ * stamped with its writer's HLC NodeID). A consumer can therefore pick
+ * any one replica and see every committed cluster mutation; on failover
+ * to a different replica it resumes by passing the highest `seq` it
+ * has already observed FOR EACH origin.
+ *
+ * Semantics:
+ *
+ *   - Empty map (or unset field) requests every entry the server still
+ *     retains. This is the new-consumer / cold-start case.
+ *   - For each origin key present in the map, the server delivers only
+ *     entries with `seq >= from_seq_per_origin[origin]` for that
+ *     origin. Entries for origins NOT in the map are delivered from
+ *     the oldest retained entry; this lets a consumer that has only
+ *     ever talked to a subset of replicas naturally pick up entries
+ *     from a newly-joined origin.
+ *   - If the resulting overall earliest requested seq is below the
+ *     server's first retained log seq the call fails with
+ *     FAILED_PRECONDITION and the caller must snapshot + resubscribe.
+ *
+ * Keys are 32-character lowercase hexadecimal encodings of the 16-byte
+ * HLC NodeID (matching `HLCTimestamp.node_id` and `Mutation.origin`).
+ * Hex was chosen over raw bytes because proto3 map keys forbid `bytes`
+ * and because the hex form already appears in `lantern_replication_*`
+ * Prometheus labels and in admin UI surfaces, keeping the consumer
+ * debug experience uniform across wire, metrics, and UI.
  *
  * @generated from message graph.v1.SubscribeRequest
  */
 export type SubscribeRequest = Message<"graph.v1.SubscribeRequest"> & {
   /**
-   * @generated from field: uint64 from_seq = 1;
+   * Per-origin resume cursor. Keys are 32-char lowercase hex of the
+   * 16-byte HLC NodeID; values are the next local `seq` the consumer
+   * expects from that origin.
+   *
+   * @generated from field: map<string, uint64> from_seq_per_origin = 1;
    */
-  fromSeq: bigint;
+  fromSeqPerOrigin: { [key: string]: bigint };
 };
 
 /**
@@ -563,7 +591,9 @@ export const LanternReplicationService: GenService<{
    * also have the stream terminated with FAILED_PRECONDITION — the
    * remedy is the same.
    *
-   * No HTTP gateway annotation: replication is intentionally gRPC-only.
+   * No HTTP gateway annotation: replication is intentionally exposed
+   * only as Connect server-streaming (consumed by replication pumps on
+   * peer nodes, never directly from browsers).
    *
    * @generated from rpc graph.v1.LanternReplicationService.Subscribe
    */

--- a/server/replication/antientropy.go
+++ b/server/replication/antientropy.go
@@ -294,12 +294,20 @@ func (a *AntiEntropy) tickPeer(ctx context.Context, addr string) {
 // itself advances local watermarks via the SnapshotApplier seams)
 // after which catchUp returns — the next tick will re-probe.
 //
+// Under the leaderless Subscribe contract (#415), the peer's log
+// carries entries from every cluster origin. We narrow the request to
+// peerNID's own origin via a per-origin cursor so the server only
+// streams the entries we actually care about, avoiding wasted
+// bandwidth on cross-origin entries that this catch-up call would
+// drop anyway.
+//
 // Returns the number of mutations applied during this call.
 func (a *AntiEntropy) catchUp(ctx context.Context, cli graphv1connect.LanternReplicationServiceClient, peerNID hlc.NodeID, fromSeq, target uint64) (uint64, error) {
 	tctx, cancel := context.WithTimeout(ctx, a.cfg.SubscribeTimeout)
 	defer cancel()
 
-	stream, err := cli.Subscribe(tctx, connect.NewRequest(&pb.SubscribeRequest{FromSeq: fromSeq}))
+	cursor := map[string]uint64{hex.EncodeToString(peerNID[:]): fromSeq}
+	stream, err := cli.Subscribe(tctx, connect.NewRequest(&pb.SubscribeRequest{FromSeqPerOrigin: cursor}))
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodeFailedPrecondition {
 			return 0, a.snapshotFrom(ctx, cli)

--- a/server/replication/pump.go
+++ b/server/replication/pump.go
@@ -367,13 +367,29 @@ func (p *Pump) session(ctx context.Context, addr string, fromSeq uint64) (uint64
 	return next, err
 }
 
-// subscribe opens a Subscribe stream at fromSeq and applies every
-// received Mutation. Self-origin mutations are dropped before
-// dispatch. Returns the seq of the last successfully-applied mutation
-// + 1 (i.e. the next seq to resume at) and any error from Receive /
-// Apply. A clean stream end returns nil.
+// subscribe opens a Subscribe stream and applies every received
+// Mutation. Self-origin mutations are dropped before dispatch.
+// Returns the seq of the last successfully-applied mutation + 1 (i.e.
+// the next seq to resume at) and any error from Receive / Apply. A
+// clean stream end returns nil.
+//
+// Under the leaderless Subscribe contract (#415) the peer's local log
+// carries mutations from every cluster origin, not just the peer's
+// own writes. The pump intentionally requests the entire retained
+// range on every reconnect (empty cursor) and relies on the per-origin
+// watermark CAS inside LanternService.ApplyMutation to dedup entries
+// it has already seen via another peer hop. This keeps reconnect logic
+// simple — no need to track per-(peer, origin) state on the pump side
+// — at the price of one full-range scan per reconnect, which is
+// bounded by the mutation log ring capacity.
+//
+// The fromSeq argument is retained for reconnect bookkeeping (the
+// pump remembers it across reconnects, and the snapshot fallback path
+// resumes from cutoff_seq + 1), but it is intentionally NOT sent on
+// the wire — the cursor stays empty so the pump observes every
+// retained entry and the CAS gate filters out duplicates.
 func (p *Pump) subscribe(ctx context.Context, cli graphv1connect.LanternReplicationServiceClient, addr string, fromSeq uint64) (uint64, error) {
-	stream, err := cli.Subscribe(ctx, connect.NewRequest(&pb.SubscribeRequest{FromSeq: fromSeq}))
+	stream, err := cli.Subscribe(ctx, connect.NewRequest(&pb.SubscribeRequest{}))
 	if err != nil {
 		return fromSeq, err
 	}

--- a/server/service/replication.go
+++ b/server/service/replication.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -112,36 +113,51 @@ func (s *LanternReplicationService) WithOriginStates(p OriginStatesProvider) *La
 	return s
 }
 
-// Subscribe streams every mutation log entry at or after req.FromSeq
-// to the supplied Sender, honouring ctx cancellation throughout.
+// Subscribe streams every mutation log entry whose (origin, seq)
+// satisfies the per-origin resume cursor in req.FromSeqPerOrigin to
+// the supplied Sender, honouring ctx cancellation throughout.
+//
+// Under the leaderless Subscribe contract (#415), every replica's log
+// carries entries from every cluster origin (each stamped with its
+// writer's HLC NodeID on Entry.HLC.NodeID, which round-trips to the
+// wire as Mutation.Hlc.NodeId / Mutation.Origin). A consumer attaches
+// to any replica and resumes per-origin so failover between replicas
+// does not require deduplication or seq remapping.
 //
 // Flow:
-//  1. Open a subscription on the mutation log starting at req.FromSeq.
-//     If FromSeq is below the ring's firstSeq the log returns ErrGapped
-//     and we surface FailedPrecondition + reason "gapped" so the client
-//     knows to snapshot and resubscribe (see RFC §8.2).
-//  2. Drain the subscription channel and forward each entry as a
-//     SubscribeResponse. The Mutation stored on the entry already carries
-//     hlc/origin/op; we shallow-copy it to overwrite Seq with the
-//     authoritative value from the log entry (the stored Mutation has
-//     Seq=0 because the log assigns seq at Append time).
-//  3. If the channel is closed mid-stream the subscriber fell behind the
-//     per-subscriber buffer (Options.SubscriberBuffer). Surface this as
-//     FailedPrecondition + "gapped" — symmetric with case 1.
-//  4. Honor ctx cancellation throughout.
+//  1. Compute the minimum seq across all requested origins (cold-start
+//     callers pass an empty map, which yields min=1 = oldest retained
+//     entry). Open a log subscription at that minimum so the dispatcher
+//     hands us every entry the cursor could possibly want.
+//  2. For each entry, filter by the per-origin cursor: deliver only
+//     when entry.Seq >= cursor[origin]. Origins absent from the cursor
+//     are delivered from the oldest retained entry — this lets a
+//     consumer that has never seen origin X (e.g. X joined the cluster
+//     while the consumer was offline) catch up naturally.
+//  3. ErrGapped from the log layer (the computed minimum is below the
+//     ring's firstSeq) surfaces as FailedPrecondition + reason
+//     "gapped" so the client knows to snapshot and resubscribe (RFC
+//     §8.2).
+//  4. If the channel is closed mid-stream the subscriber fell behind
+//     the per-subscriber buffer (Options.SubscriberBuffer). Surface
+//     this as FailedPrecondition + "gapped" — symmetric with case 3.
+//  5. Honor ctx cancellation throughout.
 //
-// Send errors terminate the stream and increment dropped{reason="send_failed"}.
+// Send errors terminate the stream and increment
+// dropped{reason="send_failed"}.
 func (s *LanternReplicationService) Subscribe(ctx context.Context, req *pb.SubscribeRequest, stream Sender[pb.SubscribeResponse]) error {
 	if s.log == nil {
 		return connect.NewError(connect.CodeUnavailable, errors.New("replication is not enabled on this server"))
 	}
-	ch, cancel, err := s.log.Subscribe(req.GetFromSeq())
+	cursor := req.GetFromSeqPerOrigin()
+	minSeq := minSeqFromCursor(cursor)
+	ch, cancel, err := s.log.Subscribe(minSeq)
 	if err != nil {
 		if errors.Is(err, mutationlog.ErrGapped) {
 			s.metrics.OnSubscribeDropped("gapped")
 			return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf(
 				"gapped: from_seq=%d is older than the first available seq; snapshot and resubscribe",
-				req.GetFromSeq()))
+				minSeq))
 		}
 		return connect.NewError(connect.CodeUnavailable, fmt.Errorf("subscribe failed: %w", err))
 	}
@@ -170,6 +186,14 @@ func (s *LanternReplicationService) Subscribe(ctx context.Context, req *pb.Subsc
 				return connect.NewError(connect.CodeInternal, fmt.Errorf(
 					"replication: malformed mutation log entry at seq=%d", entry.Seq))
 			}
+			// Per-origin filter: skip entries whose origin watermark
+			// the consumer already covers. Origins absent from the
+			// cursor are NOT skipped — they are delivered from the
+			// oldest retained entry, matching the contract documented
+			// on pb.SubscribeRequest.
+			if want, present := cursor[hex.EncodeToString(mu.GetOrigin())]; present && entry.Seq < want {
+				continue
+			}
 			// Shallow copy so we can stamp Seq without mutating the
 			// shared Mutation pointer other subscribers (or the WAL) may
 			// be observing.
@@ -185,6 +209,24 @@ func (s *LanternReplicationService) Subscribe(ctx context.Context, req *pb.Subsc
 			}
 		}
 	}
+}
+
+// minSeqFromCursor returns the smallest seq present in the per-origin
+// cursor, or 1 (the first valid log seq) when the cursor is empty so a
+// cold-start subscriber receives every retained entry.
+func minSeqFromCursor(cursor map[string]uint64) uint64 {
+	if len(cursor) == 0 {
+		return 1
+	}
+	var min uint64
+	first := true
+	for _, v := range cursor {
+		if first || v < min {
+			min = v
+			first = false
+		}
+	}
+	return min
 }
 
 func (s *LanternReplicationService) loggerOrDefault() *slog.Logger {

--- a/tests/integration/subscribe_test.go
+++ b/tests/integration/subscribe_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"io"
 	"testing"
@@ -59,7 +60,7 @@ func TestSubscribe_E2E_100Writes(t *testing.T) {
 		}
 	}
 
-	stream, err := subCli.Subscribe(ctx, connect.NewRequest(&pb.SubscribeRequest{FromSeq: 1}))
+	stream, err := subCli.Subscribe(ctx, connect.NewRequest(&pb.SubscribeRequest{}))
 	if err != nil {
 		t.Fatalf("Subscribe: %v", err)
 	}
@@ -101,4 +102,99 @@ func itoa(i int) string {
 		i /= 10
 	}
 	return string(b[pos:])
+}
+
+// TestSubscribe_PerOriginCursor_Skips covers the leaderless Subscribe
+// contract's resume semantics (#415, B-2). The wire-level cursor is
+// `map<string, uint64> from_seq_per_origin` keyed by hex-encoded HLC
+// NodeID; an entry whose origin appears in the cursor is delivered
+// only when its seq is >= the cursor value, and an entry whose origin
+// is absent from the cursor is delivered from the oldest retained
+// entry.
+//
+// The test fabricates entries from two origins on a single replica's
+// log via the LanternReplicationService directly (cheaper and more
+// targeted than spinning a multi-node cluster — the per-origin filter
+// lives entirely in the Subscribe handler and is independent of the
+// peer pump).
+func TestSubscribe_PerOriginCursor_Skips(t *testing.T) {
+	originA := hlc.NodeID{0x11}
+	originB := hlc.NodeID{0x22}
+
+	log := mutationlog.New(mutationlog.Options{Capacity: 64, SubscriberBuffer: 64})
+	t.Cleanup(func() { _ = log.Close() })
+	clock := hlc.New(originA, hlc.Options{})
+
+	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	svc := service.NewLanternService(cache).
+		WithReplication(log, clock, nil)
+	rep := service.NewLanternReplicationService(log, cache, clock)
+	srv := newConnectTestServer(t, svc, rep, nil)
+	subCli := newReplicationRawClient(t, srv.url)
+
+	// Append four entries: A, B, A, B. The log assigns Seq 1..4 in
+	// that order; per-origin seqs are A=1,2 and B=1,2. The cursor
+	// {hex(A): 2} should skip seq 1 (A's first) while keeping seq 2
+	// (B's first, absent from cursor → delivered from oldest), seq 3
+	// (A's second, exactly at cursor), seq 4 (B's second, no cursor).
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	mkMu := func(originID hlc.NodeID, key string) *pb.Mutation {
+		ts := hlc.New(originID, hlc.Options{}).Now()
+		return &pb.Mutation{
+			Hlc: &pb.HLCTimestamp{
+				WallNs: ts.WallNs, Logical: ts.Logical,
+				NodeId: append([]byte(nil), originID[:]...),
+			},
+			Origin: append([]byte(nil), originID[:]...),
+			Op: &pb.MutationOp{Op: &pb.MutationOp_PutVertex{
+				PutVertex: &pb.PutVertexRequest{Vertex: &pb.Vertex{Key: key}},
+			}},
+		}
+	}
+	for _, m := range []*pb.Mutation{
+		mkMu(originA, "a1"), mkMu(originB, "b1"),
+		mkMu(originA, "a2"), mkMu(originB, "b2"),
+	} {
+		// Append directly to the log so we control origin assignment;
+		// going through PutVertex would stamp originA for every call.
+		if _, err := log.Append(m, hlc.Timestamp{NodeID: hlc.NodeID(m.GetHlc().GetNodeId()[0:16])}); err != nil {
+			t.Fatalf("log.Append: %v", err)
+		}
+	}
+
+	cursor := map[string]uint64{hex.EncodeToString(originA[:]): 2}
+	stream, err := subCli.Subscribe(ctx, connect.NewRequest(&pb.SubscribeRequest{FromSeqPerOrigin: cursor}))
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	t.Cleanup(func() { _ = stream.Close() })
+
+	type got struct {
+		seq    uint64
+		origin string
+	}
+	var seen []got
+	for i := 0; i < 3; i++ {
+		if !stream.Receive() {
+			if streamErr := stream.Err(); streamErr != nil && !errors.Is(streamErr, io.EOF) {
+				t.Fatalf("Recv[%d]: %v", i, streamErr)
+			}
+			t.Fatalf("stream ended after %d entries; want 3", len(seen))
+		}
+		m := stream.Msg().GetMutation()
+		seen = append(seen, got{seq: m.GetSeq(), origin: hex.EncodeToString(m.GetOrigin())})
+	}
+
+	want := []got{
+		{seq: 2, origin: hex.EncodeToString(originB[:])}, // B's first; not in cursor → oldest
+		{seq: 3, origin: hex.EncodeToString(originA[:])}, // A's second; exactly at cursor
+		{seq: 4, origin: hex.EncodeToString(originB[:])}, // B's second
+	}
+	for i, g := range seen {
+		if g != want[i] {
+			t.Errorf("entry[%d] got %+v want %+v", i, g, want[i])
+		}
+	}
 }


### PR DESCRIPTION
## What

Replace `pb.SubscribeRequest.from_seq` (scalar `uint64`) with a per-origin resume cursor `map<string, uint64> from_seq_per_origin` so external CDC consumers can fail over between replicas without seq remapping. Stage **B-2** of the [#415 plan](../issues/415#issuecomment-4639408249); closes #418.

## Wire

[`proto/graph/v1/replication.proto`](../tree/feat/418-subscribe-per-origin-cursor/proto/graph/v1/replication.proto):

```diff
 message SubscribeRequest {
-  uint64 from_seq = 1;
+  map<string, uint64> from_seq_per_origin = 1;
 }
```

Keys are 32-char lowercase hex of the 16-byte HLC NodeID. Hex was chosen over raw bytes because proto3 map keys forbid `bytes`, and because the hex form already appears in `lantern_replication_*` Prometheus labels and admin UI surfaces — uniform debug experience across wire, metrics, and UI.

### Semantics

- Empty map / unset field → stream every retained entry (cold start).
- For each origin key present: deliver entries with `seq >= cursor[origin]`.
- Origins absent from the cursor → delivered from the oldest retained entry (so a consumer catches up to a newly-joined origin naturally).
- If the overall earliest requested seq is below the ring's `firstSeq`, the call fails with `FAILED_PRECONDITION` and the caller snapshots + resubscribes.

## Plumbing

- `pb/graph/v1/replication.pb.go` regenerated via `go generate ./...` (no `--clean`, per AGENTS.md).
- `sdks/node/src/gen/graph/v1/*` regenerated via `bun run codegen`.
- `admin/app/lib/api/gen/graph/v1/*` regenerated via `bun run codegen`.

## Server handler

[`server/service/replication.go`](../tree/feat/418-subscribe-per-origin-cursor/server/service/replication.go): `Subscribe` reads `req.GetFromSeqPerOrigin()`, opens the log subscription at the smallest seq across cursor entries (so the dispatcher hands the handler everything the cursor could possibly want), then filters per origin during delivery. Helper `minSeqFromCursor` returns 1 for empty cursors so cold starts see every retained entry.

## SDK Go

[`sdks/go/subscribe.go`](../tree/feat/418-subscribe-per-origin-cursor/sdks/go/subscribe.go): `Subscribe` signature becomes `(ctx, cursor map[hlc.NodeID]uint64)`. The SDK converts the typed map to the hex-keyed wire map internally so callers work with strongly-typed `hlc.NodeID` and never see the hex encoding.

## Peer pump

[`server/replication/pump.go`](../tree/feat/418-subscribe-per-origin-cursor/server/replication/pump.go): `subscribe()` sends an empty cursor on every reconnect and relies on the per-origin watermark CAS in `ApplyMutation` (from B-3 / #420) to dedup. `fromSeq` is kept for the snapshot-fallback bookkeeping but is intentionally NOT sent on the wire — trading one full-range scan per reconnect for simpler reconnect logic (bounded by ring capacity). The snapshot path is unchanged.

## Anti-entropy

[`server/replication/antientropy.go`](../tree/feat/418-subscribe-per-origin-cursor/server/replication/antientropy.go): `catchUp` sends a single-key cursor `{peerNID: fromSeq}` so the server only streams the peer's own origin entries during catch-up, avoiding wasted bandwidth on cross-origin entries this call would drop anyway.

## Tests

- `TestSubscribe_E2E_100Writes` updated to send an empty cursor (cold start = all entries).
- New `TestSubscribe_PerOriginCursor_Skips` proves the filter drops only the origin/seq pairs the cursor covers and delivers everything else, including entries from origins absent from the cursor.

All Go tests green across the 6 modules: `root`, `server`, `core`, `sdks/go`, `mcp`, `pb`. Node SDK `bun run build` + admin `bun run typecheck` both clean.

## Capacity note (deferred to B-5)

Empty-cursor reconnect by the peer pump trades a touch of bandwidth for reconnect simplicity. At default ring capacity (100k) this is one ~100k-entry burst per peer per reconnect; B-5 will revisit the default in light of the Reading B fan-in factor.

## Refs

- Parent: #415 (Reading B adoption + plan)
- Sibling: #420 (B-3, merged), #419 (B-5)
- Closes #418
