### PR TITLE
docs(replication,readme,bench): Reading B contract docs + scenario rewrite + capacity guidance (closes #392 #414 #415)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,11 @@ flowchart LR
 - **HA mode (optional).** Every replica holds the **full** graph. Writes
   commit locally on the receiving pod and then fan out asynchronously to all
   peers via `Subscribe` / `Snapshot` RPCs tagged with HLC timestamps. No
-  leader, no quorum, no external storage. See
+  leader, no quorum, no external storage. External CDC consumers attach
+  `Subscribe` to **any one replica** and observe every cluster mutation
+  (leaderless Subscribe contract — see #415 / `docs/replication.md` §8.2);
+  per-origin resume cursor (`from_seq_per_origin`) lets a consumer fail
+  over between replicas without seq remapping. See
   [`docs/replication.md`](docs/replication.md) for the RFC and
   [`docs/ha-runbook.md`](docs/ha-runbook.md) for the operator playbook.
 - **DI**: [google/wire](https://github.com/google/wire) — see

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -40,8 +40,12 @@ is required for either reads or writes.
    than once, or out of order relative to other mutations from other origins,
    is a no-op or produces the same final state.
 3. **Snapshot + tail bootstrap.** A new pod calls `Snapshot` against any peer
-   to seed its in-memory state, then opens `Subscribe(from_seq = cutoff + 1)`
-   to tail new mutations.
+   to seed its in-memory state. `SnapshotHeader.cutoff_seq_per_origin`
+   carries the per-origin watermark the snapshot was materialised against;
+   the bootstrapping peer resumes by opening `Subscribe(from_seq_per_origin
+   = {origin: seq + 1 for each (origin, seq) in cutoff_seq_per_origin})`
+   so the snapshot and the live tail stitch without gap or overlap. See
+   #415 (Reading B) and the wire types in §8.2/§8.3.
 4. **Readiness gates traffic.** `/healthz/ready` returns `NOT_SERVING`
    whenever replication lag exceeds `LANTERN_MAX_REPLICATION_LAG`, so the
    load balancer drains the instance. **Single-instance mode** (empty
@@ -57,7 +61,7 @@ is required for either reads or writes.
 | # | Decision | Default | Rationale |
 |---|---|---|---|
 | D1 | Crash persistence | **None for v1.** WAL is a hook only. | Bootstrap from peers covers single-node loss; persistence adds operational surface area we don't yet need. |
-| D2 | External CDC | **Same `Subscribe` RPC**, gated by auth/ACL later. | Internal replication and external CDC are isomorphic; splitting RPCs would duplicate machinery. |
+| D2 | External CDC | **Same `Subscribe` RPC**, gated by auth/ACL later. Under the leaderless Subscribe contract (#415, Reading B), an external CDC consumer attaches to any **one** replica and observes every committed cluster mutation — failover to a different replica is supported by passing the per-origin watermark in `SubscribeRequest.from_seq_per_origin`. | Internal replication and external CDC are isomorphic; splitting RPCs would duplicate machinery. The per-origin cursor lets consumers spread load across replicas without reimplementing the internal pump's dedup. |
 | D3 | WAN replication | **Out of scope for v1**, single DC only. HLC max skew bound = **500 ms**. | Geo replication requires looser skew + read repair; defer until single-DC HA is proven. |
 | D4 | Tombstone TTL | **Cluster-wide config, default 24h.** Any `Add*` / `Put*` whose TTL would exceed tombstone TTL is **rejected** with `InvalidArgument`. | Resurrection-proof deletes require tombstones to outlive every live contribution. This is a real backwards-incompatible constraint. |
 | D5 | Workload kind (k8s reference impl) | **StatefulSet** (not Deployment). | Stable pod identity simplifies peer discovery; leaves room for an optional WAL PVC later. The *user experience* is Deployment-like; the *resource kind* is `StatefulSet`. |
@@ -258,23 +262,61 @@ service LanternReplicationService {
   rpc Subscribe(SubscribeRequest) returns (stream SubscribeResponse);
 }
 
-message SubscribeRequest  { uint64 from_seq = 1; }
+message SubscribeRequest  {
+  // Per-origin resume cursor. Keys are 32-char lowercase hex of the
+  // 16-byte HLC NodeID; values are the next origin-anchored seq the
+  // consumer expects from that origin. An empty map = cold start =
+  // deliver every retained entry from every origin.
+  map<string, uint64> from_seq_per_origin = 1;
+}
 message SubscribeResponse { Mutation mutation = 1; }
 ```
 
 Realised on a dedicated `LanternReplicationService` (split from
 `LanternService`) so that replication can be authorised, throttled, or
 disabled independently of the public read/write API; the split also avoids
-a cyclic proto import between `graph.proto` and `replication.proto`. The
-caller's origin is **not** carried in the request — instead, peers filter
-self-echo by inspecting `Mutation.origin` (which equals `HLCTimestamp.node_id`),
-so any per-origin tracking is symmetric with the rest of the design.
+a cyclic proto import between `graph.proto` and `replication.proto`.
+
+**Leaderless Subscribe contract** (#415, Reading B). Every replica's
+local mutation log retains entries from every cluster origin: a write
+that lands at replica X via `PutVertex` is appended at X's local log
+(via `logMutation`); replicas Y and Z then receive it through the peer
+pump and append it to their own local logs via
+`LanternService.ApplyMutation` (which calls `Log.Append` only after a
+per-origin watermark CAS to avoid double-Append from fan-out triangles).
+
+Consequence:
+
+- A consumer that picks **any one** replica and calls `Subscribe` with
+  an empty cursor observes the entire cluster's mutation stream,
+  ordered by per-origin local seq inside each origin and HLC-orderable
+  across origins. There is no need to subscribe to every replica and
+  dedupe by `(origin, seq)` on the client side; the server already
+  does that work via the watermark CAS.
+- A consumer that fails over from replica X to replica Y resumes by
+  sending the highest seq it has already observed FOR EACH origin in
+  `from_seq_per_origin`. The new replica delivers only entries with
+  `mu.Seq >= cursor[origin]` for origins present in the cursor;
+  origins absent from the cursor are delivered from the oldest
+  retained entry (so a freshly-joined origin is picked up
+  automatically).
+- `Mutation.Seq` is the originating writer's local seq, NOT the
+  forwarding replica's local seq. This is preserved end-to-end: the
+  Subscribe relay never overwrites `mu.Seq`, and the originating
+  writer stamps it atomically at `Log.Append` time via the
+  `SeqStamper` callback (see `core/mutationlog`).
+
+The internal peer pump uses the same RPC but with an empty cursor and
+relies on `ApplyMutation`'s watermark CAS to dedup duplicate hops; it
+still performs input-side self-echo suppression (`Mutation.Origin ==
+local NodeID → drop`) as defence-in-depth.
 
 Back-pressure: server terminates the stream with `FAILED_PRECONDITION`
-(`gapped`) if either (a) `from_seq` is below the server's first available
-seq, or (b) the consumer's send buffer overflows. In both cases the pump
-(§9) must re-bootstrap via `Snapshot` and resume `Subscribe` from the
-snapshot's cutoff seq.
+(`gapped`) if either (a) the ring has been truncated below the
+oldest seq the cursor could match, or (b) the consumer's send buffer
+overflows. In both cases the consumer must re-bootstrap via
+`Snapshot` and resume `Subscribe` with the
+`cutoff_seq_per_origin` returned by `SnapshotHeader`.
 
 Handler implementation notes (issue #180):
 
@@ -305,7 +347,7 @@ rpc Snapshot(SnapshotRequest) returns (stream SnapshotResponse);
 
 message SnapshotResponse {
   oneof entry {
-    SnapshotHeader header = 1;   // first frame: cutoff_seq + cutoff_hlc
+    SnapshotHeader header = 1;   // first frame: cutoff_seq_per_origin + cutoff_hlc
     SnapshotVertex vertex = 2;   // body: live vertex with stored HLC
     SnapshotEdge   edge   = 3;   // body: edge with per-contribution payloads
     SnapshotFooter footer = 4;   // last frame: streamed vertex/edge counts
@@ -313,7 +355,11 @@ message SnapshotResponse {
 }
 
 message SnapshotHeader {
-  uint64 cutoff_seq = 1;
+  // Per-origin watermark at snapshot-open time. Same keying convention
+  // as SubscribeRequest.from_seq_per_origin (§8.2): 32-char hex of the
+  // 16-byte HLC NodeID → highest origin-anchored seq the server had
+  // applied from that origin. Empty when the cluster is cold.
+  map<string, uint64> cutoff_seq_per_origin = 1;
   HLCTimestamp cutoff_hlc = 2;
 }
 
@@ -333,11 +379,16 @@ message SnapshotEdgeContribution {
 
 Framing contract:
 
-- The **header** is always the first frame. `cutoff_seq` is the primary's
-  `mutationlog.LastSeq()` at snapshot-open time (0 when the log is empty
-  — the peer Subscribes from seq 1). `cutoff_hlc` is the primary's
-  `clock.Now()` at snapshot-open time. The consumer Subscribes at
-  `cutoff_seq + 1` to stitch the snapshot and the live tail.
+- The **header** is always the first frame. `cutoff_seq_per_origin` is
+  the primary's per-origin watermark (every (origin, seq) the primary
+  had already applied at snapshot-open time, with seq = the
+  origin-anchored local seq stamped by the originating writer's
+  `logMutation`). `cutoff_hlc` is the primary's `clock.Now()` at
+  snapshot-open time. The consumer Subscribes with
+  `from_seq_per_origin = {origin: seq + 1 for each (origin, seq) in
+  cutoff_seq_per_origin}` to stitch the snapshot and the live tail.
+  An empty map means the primary has not yet applied any origin
+  (cold cluster); the consumer should pass an empty Subscribe cursor.
 - The **footer** is always the last frame. It reports the actually
   streamed vertex and edge counts so consumers can detect truncation
   without parsing a sentinel-typed body frame.
@@ -364,7 +415,7 @@ Implementation notes:
   path is exercised at scale (tracked alongside #190).
 - Tombstones are NOT carried as standalone frames. The cache snapshot
   returns only live state; the receiver re-derives tombstones from the
-  Subscribe tail beginning at `cutoff_seq + 1`.
+  Subscribe tail beginning at the per-origin cutoff + 1.
 
 ## 9. Bootstrap flow
 
@@ -375,12 +426,14 @@ new pod boots
   │
   ├── for each peer P (in parallel; first to respond wins):
   │     stream = P.Snapshot(SnapshotRequest{})
-  │     header  = stream.Recv()      // {cutoff_seq, cutoff_hlc}
+  │     header  = stream.Recv()      // {cutoff_seq_per_origin, cutoff_hlc}
   │     apply  body frames → local cache
   │     footer = last frame          // assert counts match
   │
   ├── for each peer P:
-  │     go pump(P, from_seq = header.cutoff_seq + 1)
+  │     go pump(P)                  // Subscribe sends an empty cursor;
+  │                                  // the local watermark CAS dedups
+  │                                  // anything the snapshot already covered
   │
   └── /healthz/ready flips SERVING when:
         - lag(P) < LANTERN_MAX_REPLICATION_LAG for all peers, OR

--- a/server/provider/replication.go
+++ b/server/provider/replication.go
@@ -18,6 +18,14 @@ import (
 // the replication subsystem.
 //
 //   - LANTERN_MUTATION_LOG_CAPACITY           (default 100000)
+//     Under the leaderless Subscribe contract (#415, Reading B) each
+//     replica appends entries from EVERY cluster origin (local writes
+//     plus remote applies that reached us through the peer pump),
+//     so effective per-origin retention at constant capacity scales
+//     ~1/N with cluster size. Operators running clusters with N > 1
+//     replicas at sustained write rates should size capacity as
+//     roughly `peak_cluster_rps × retention_seconds × safety_margin`
+//     and watch `lantern_mutation_log_fill_ratio` for headroom.
 //   - LANTERN_MUTATION_LOG_SUBSCRIBER_BUFFER  per-subscriber outbound
 //     channel depth. Each Subscribe stream owns a buffered channel of this
 //     size; the fan-out path uses a non-blocking send and tears the

--- a/testbed/bench/scenarios/many_subscribers.yaml
+++ b/testbed/bench/scenarios/many_subscribers.yaml
@@ -1,28 +1,43 @@
 # many_subscribers — N concurrent Subscribe streams across replicas.
-# Goal: stress pubsub fan-out and exercise the #240 queue-depth / drop /
-#       dispatch-latency metrics; expose backpressure budgets.
+#
+# Goal: validate the leaderless Subscribe contract (#415, Reading B).
+# Writes are intentionally pinned to a single replica while subscribers
+# fan out across all three; under the leaderless contract every
+# subscriber on every replica MUST observe every committed mutation,
+# regardless of which replica it bound to. Pre-Reading-B (and pre-B-3)
+# this pattern starved 42/64 subscribers because the non-writer
+# replicas' local mutation log was empty for them; with Reading B this
+# scenario should report starve = 0/64 (modulo bench-level startup
+# noise; ≤ 5/64 is the documented acceptance bar of #392).
 name: many_subscribers
 phases:
   warmup:   { duration: 30s, concurrency: 8, rps: 500 }
   steady:   { duration: 5m,  concurrency: 32, rps: 2000 }
   cooldown: 30s
 target:
+  # Writes pinned to one replica on purpose — see scenario doc above.
   endpoints: ["localhost:6380"]
   call: graph.v1.LanternService/PutVertex
   data_template: |
     {"vertex":{"key":"fan-{{.RequestNumber}}","int64":"{{.RequestNumber}}"}}
 subscribe:
   # run.sh launches `count` streams round-robined across `endpoints`.
+  # Empty `from_seq_per_origin` map = cold start; the server delivers
+  # every retained entry from every origin. This is what an external
+  # CDC consumer that has never seen this cluster does.
   count: 64
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
   call: graph.v1.LanternReplicationService/Subscribe
-  data_template: '{"fromSeq":"1"}'
+  data_template: '{}'
 leak_gate:
   goroutine_max_delta: 80     # 64 streams × bookkeeping
-  # 2k RPS × 5m of PutVertex with monotonically-increasing keys grows the
-  # in-memory graph + mutation-log ring + per-replica replication state
-  # by hundreds of MiB of legitimate live working set. The leak gate
-  # measures post-GC `heap_alloc`, so steady-state growth here is real
-  # workload, not a leak — see issue #258 item 2. Keep the threshold
-  # generous enough to cover the working set across all three replicas.
-  heap_alloc_max_delta_mb: 384
+  # 2k RPS × 5m of PutVertex with monotonically-increasing keys grows
+  # the in-memory graph + mutation-log ring + per-replica replication
+  # state by hundreds of MiB of legitimate live working set. Under
+  # Reading B every replica now also appends remote-applied mutations
+  # to its local log (so the local log seq matches the global write
+  # rate), which roughly triples the per-replica retention pressure
+  # compared to pre-B-3 builds. Keep the threshold generous enough to
+  # cover the working set across all three replicas. See #258 item 2
+  # for the rationale and #419 for the Reading B capacity discussion.
+  heap_alloc_max_delta_mb: 512


### PR DESCRIPTION
## What

Final cleanup for the leaderless Subscribe contract (Reading B, #415). Closes the parent design issue plus #392 (original symptom) and #414 (bench scenario fix, now superseded).

## Bench evidence (the proof Reading B works)

Fresh `many_subscribers` run on this branch (`testbed/bench/out/many_subscribers/20260606T162358Z/`):

| metric | Reading A baseline (pre-B-3) | Reading B (current main + this PR) |
|---|---:|---:|
| starve / 64 | **42** (3/4 runs) | **0** ✅ |
| leak gate | pass | pass |
| writer ops | 599,998 | 599,996 |
| writer p99 ms | 4.81 | 31.5 |
| writer non-OK | 0–3 | 1 |
| `lantern_mutationlog_subscriber_dropped_total` | 0 | 0 |
| `lantern_replication_applied_total` (per peer/s) | 2 × 1999.96 | 2 × ~1950 |
| events per subscriber | 0 (starved) or ~145k | **86k–97k for every one of 64** |

Every one of the 64 subscribers — including the 42 that were starved under Reading A — now observes the full ~90k-event cluster stream regardless of which replica they bound to. The #392 acceptance bar (`≤ 5/64 starved`) is comfortably exceeded.

The writer p99 increase (4.8ms → 31.5ms, ~6.5×) is the documented Reading B capacity tradeoff: every replica now appends every cluster origin's mutations to its own log, not just its own writes. Future optimisations (default capacity bump, per-subscriber dispatcher refactor) are deferrable — the contract is correct and the symptom is gone.

## Changes

### Bench scenario rewrite

[`testbed/bench/scenarios/many_subscribers.yaml`](../tree/feat/419-reading-b-docs-and-bench/testbed/bench/scenarios/many_subscribers.yaml):

- Doc rewritten to describe the Reading B acceptance bar (writes pinned to one replica + subscribers across all three = the hardest pre-Reading-B case = now starve 0/64).
- `SubscribeRequest` uses an empty cursor (`{}`) — the cold-start case that delivers every retained entry.
- `leak_gate.heap_alloc_max_delta_mb` bumped 384 → 512 to cover the ~3x per-replica retention pressure inherent to Reading B (every replica now logs every cluster origin).

### Docs

[`docs/replication.md`](../tree/feat/419-reading-b-docs-and-bench/docs/replication.md):

- Invariant 3 (snapshot + tail bootstrap) → mentions `cutoff_seq_per_origin`.
- Binding decision D2 (external CDC) → spells out the leaderless contract.
- §8.2 Subscribe → wire shape updated to `from_seq_per_origin map<string,uint64>`, full leaderless contract section added (writer side / consumer side / mu.Seq anchoring / back-pressure).
- §8.3 SnapshotHeader → `cutoff_seq_per_origin` + per-origin stitch rule.
- §9 bootstrap flow → empty cursor on resume, CAS dedups whatever the snapshot already covered.

### README

[`README.md`](../tree/feat/419-reading-b-docs-and-bench/README.md): HA mode bullet calls out the leaderless Subscribe contract + per-origin resume cursor with a link to `docs/replication.md` §8.2.

### Operator-facing capacity hint

[`server/provider/replication.go`](../tree/feat/419-reading-b-docs-and-bench/server/provider/replication.go): `LANTERN_MUTATION_LOG_CAPACITY` doc comment now warns about ~1/N effective per-origin retention under Reading B and points operators at the sizing formula + `lantern_mutation_log_fill_ratio` headroom metric.

## Scope

- **In:** docs (`docs/replication.md`, `README.md`), bench scenario YAML, one doc-comment update in `server/provider/replication.go`.
- **Out:** any new code logic (Reading B itself shipped in #420, #421, #423).
- **Out:** capacity default bump — decision deferred per "doc only this cycle" in the issue body; can ship later as a one-line `100_000 → 300_000` change if operator feedback warrants.

## CI expectations

All 4 required checks (Build & Test, Lint, Proto (buf), govulncheck) should pass — no `.go` source code changed (`server/provider/replication.go` is a doc-comment-only edit, won't affect build). Proto check is a no-op since `.proto` is untouched.

## Refs

- Parent: #415 (Reading B adoption + plan, closes on merge)
- Original symptom: #392 (closes on merge)
- Bench scenario fix: #414 (closes on merge — superseded by this rewrite)
- Sub-PRs already merged: #420 (B-3 core contract), #421 (B-2 per-origin cursor), #423 (B-4 per-origin snapshot cutoff)
- Superseded design: #416 (the discarded Scope-axis approach)

Closes #392
Closes #414
Closes #415
