### PR TITLE
feat(admin,cli)!: web CLI at /cli + scan verb shared with Go REPL (closes #411)

### DIFF
--- a/admin/app/components/cli/CliPage/CliPage.module.css
+++ b/admin/app/components/cli/CliPage/CliPage.module.css
@@ -1,0 +1,84 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 120px);
+  min-height: 400px;
+  gap: var(--spacingVerticalM, 12px);
+  padding: var(--spacingVerticalL, 16px);
+}
+
+.scrollback {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  border-radius: var(--borderRadiusMedium, 6px);
+  background: var(--colorNeutralBackground2, #fafafa);
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  font-size: var(--fontSizeBase200, 12px);
+  padding: var(--spacingVerticalS, 8px);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.entry {
+  margin-bottom: var(--spacingVerticalS, 8px);
+}
+
+.prompt {
+  color: var(--colorBrandForeground2, #115ea3);
+  font-weight: 600;
+}
+
+.entryInput {
+  color: var(--colorNeutralForeground1, #242424);
+}
+
+.entryOk {
+  color: var(--colorPaletteGreenForeground1, #0e700e);
+}
+
+.entryError {
+  color: var(--colorPaletteRedForeground1, #b10e1c);
+}
+
+.entryTiming {
+  color: var(--colorNeutralForeground3, #707070);
+  font-size: var(--fontSizeBase100, 10px);
+  margin-left: var(--spacingHorizontalXS, 4px);
+}
+
+.inputRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacingHorizontalS, 8px);
+}
+
+.input {
+  flex: 1 1 auto;
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+}
+
+.confirmBar {
+  display: flex;
+  align-items: center;
+  gap: var(--spacingHorizontalS, 8px);
+  padding: var(--spacingVerticalS, 8px);
+  border: 1px solid var(--colorPaletteRedBorder1, #f3b1b1);
+  border-radius: var(--borderRadiusMedium, 6px);
+  background: var(--colorPaletteRedBackground1, #fff5f5);
+}
+
+.confirmText {
+  flex: 1 1 auto;
+  font-size: var(--fontSizeBase200, 12px);
+}

--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -1,0 +1,285 @@
+import {
+  Button,
+  Checkbox,
+  Input,
+  type InputProps,
+} from "@fluentui/react-components";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { dispatch, isDestructive } from "~/lib/cli/dispatcher";
+import { parse, type Command, type ParseResult } from "~/lib/cli/parser";
+import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
+import { LanternApiError } from "~/lib/client/infrastructure/api/error";
+import styles from "./CliPage.module.css";
+
+type EntryKind = "ok" | "error" | "info";
+
+interface ScrollbackEntry {
+  id: number;
+  input: string;
+  kind: EntryKind;
+  text: string;
+  durationMs?: number;
+}
+
+interface PendingDestructive {
+  command: Command;
+  rendered: string;
+}
+
+/**
+ * The /cli admin route. A Fluent UI command-line panel shared with
+ * the Go REPL via the `lib/cli/parser` TypeScript port (#411).
+ *
+ * Features:
+ * - Per-verb dispatch through `lantern-sdk/web` via the
+ *   `lib/client/infrastructure/api` adapters.
+ * - Arrow-up / arrow-down history.
+ * - Confirmation chip for destructive verbs (`delete`, `put`, `add`)
+ *   with a per-session "do not ask again" toggle.
+ * - Per-command timing badge in the `OK (1.4ms)` style the Go REPL
+ *   prints.
+ */
+export function CliPage() {
+  const client = useLanternClient();
+  const [scrollback, setScrollback] = useState<ScrollbackEntry[]>([
+    initialBanner(),
+  ]);
+  const [input, setInput] = useState("");
+  const [history, setHistory] = useState<string[]>([]);
+  const [historyIndex, setHistoryIndex] = useState<number | null>(null);
+  const [pending, setPending] = useState<PendingDestructive | null>(null);
+  const [skipConfirm, setSkipConfirm] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const idRef = useRef(2);
+
+  const append = useCallback((entry: Omit<ScrollbackEntry, "id">) => {
+    setScrollback((prev) => [...prev, { ...entry, id: idRef.current++ }]);
+  }, []);
+
+  // Auto-scroll the scrollback to the bottom on every new entry so
+  // the operator always sees their most recent output without
+  // chasing the panel's scrollbar.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [scrollback]);
+
+  const runCommand = useCallback(
+    async (rawInput: string, command: Command) => {
+      setBusy(true);
+      const start = performance.now();
+      try {
+        const out = await dispatch({ client, command });
+        const elapsed = performance.now() - start;
+        append({
+          input: rawInput,
+          kind: "ok",
+          text:
+            out === null || out === undefined
+              ? "OK"
+              : "OK\n" + JSON.stringify(out, replacer, 2),
+          durationMs: elapsed,
+        });
+      } catch (err) {
+        const elapsed = performance.now() - start;
+        append({
+          input: rawInput,
+          kind: "error",
+          text: errorMessage(err),
+          durationMs: elapsed,
+        });
+      } finally {
+        setBusy(false);
+      }
+    },
+    [append, client],
+  );
+
+  const submit = useCallback(async () => {
+    const raw = input;
+    if (raw.trim() === "") return;
+    setHistory((prev) => [...prev, raw]);
+    setHistoryIndex(null);
+    setInput("");
+    const result: ParseResult = parse(raw);
+    if (!result.ok) {
+      append({ input: raw, kind: "error", text: result.usage });
+      return;
+    }
+    if (result.command.verb === "exit") {
+      append({
+        input: raw,
+        kind: "info",
+        text: "(exit is a no-op in the web CLI; close the tab to leave)",
+      });
+      return;
+    }
+    if (isDestructive(result.command) && !skipConfirm) {
+      setPending({
+        command: result.command,
+        rendered: raw,
+      });
+      return;
+    }
+    await runCommand(raw, result.command);
+  }, [append, input, runCommand, skipConfirm]);
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        void submit();
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        if (history.length === 0) return;
+        const next =
+          historyIndex === null
+            ? history.length - 1
+            : Math.max(0, historyIndex - 1);
+        setHistoryIndex(next);
+        setInput(history[next]);
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        if (historyIndex === null) return;
+        const next = historyIndex + 1;
+        if (next >= history.length) {
+          setHistoryIndex(null);
+          setInput("");
+        } else {
+          setHistoryIndex(next);
+          setInput(history[next]);
+        }
+      }
+    },
+    [history, historyIndex, submit],
+  );
+
+  const onChange: InputProps["onChange"] = (_e, data) => {
+    setInput(data.value);
+  };
+
+  const renderedScrollback = useMemo(
+    () =>
+      scrollback.map((entry) => (
+        <div
+          key={entry.id}
+          className={styles.entry}
+          data-testid={`cli-entry-${entry.kind}`}
+        >
+          {entry.input !== "" && (
+            <div>
+              <span className={styles.prompt}>&gt;</span>{" "}
+              <span className={styles.entryInput}>{entry.input}</span>
+            </div>
+          )}
+          <div
+            className={
+              entry.kind === "ok"
+                ? styles.entryOk
+                : entry.kind === "error"
+                  ? styles.entryError
+                  : undefined
+            }
+          >
+            {entry.text}
+            {entry.durationMs !== undefined ? (
+              <span className={styles.entryTiming}>
+                ({entry.durationMs.toFixed(1)}ms)
+              </span>
+            ) : null}
+          </div>
+        </div>
+      )),
+    [scrollback],
+  );
+
+  return (
+    <div className={styles.root} data-testid="cli-root">
+      <div className={styles.scrollback} ref={scrollRef} aria-live="polite">
+        {renderedScrollback}
+      </div>
+      {pending !== null ? (
+        <div className={styles.confirmBar} data-testid="cli-confirm">
+          <span className={styles.confirmText}>
+            About to run: <code>{pending.rendered}</code> — this mutates server
+            state.
+          </span>
+          <Checkbox
+            label="Do not ask again this session"
+            checked={skipConfirm}
+            onChange={(_e, data) => setSkipConfirm(Boolean(data.checked))}
+            data-testid="cli-skip-confirm"
+          />
+          <Button
+            appearance="secondary"
+            onClick={() => setPending(null)}
+            data-testid="cli-confirm-cancel"
+          >
+            Cancel
+          </Button>
+          <Button
+            appearance="primary"
+            onClick={async () => {
+              const p = pending;
+              setPending(null);
+              if (p) {
+                await runCommand(p.rendered, p.command);
+              }
+            }}
+            data-testid="cli-confirm-run"
+          >
+            Run
+          </Button>
+        </div>
+      ) : null}
+      <div className={styles.inputRow}>
+        <span className={styles.prompt}>&gt;</span>
+        <Input
+          className={styles.input}
+          value={input}
+          onChange={onChange}
+          onKeyDown={onKeyDown}
+          placeholder="get vertex alice    |    illuminate alice 2 5 algorithm=spt"
+          disabled={busy || pending !== null}
+          data-testid="cli-input"
+          aria-label="CLI command input"
+        />
+      </div>
+    </div>
+  );
+}
+
+function initialBanner(): ScrollbackEntry {
+  return {
+    id: 1,
+    input: "",
+    kind: "info",
+    text: [
+      "Lantern admin CLI (#411). Same grammar as `lantern repl`.",
+      "Type a verb and Enter; arrow-up / arrow-down cycle history.",
+      "Verbs: get | put | delete | add | scan | illuminate | exit",
+    ].join("\n"),
+  };
+}
+
+function replacer(_key: string, value: unknown): unknown {
+  if (typeof value === "bigint") {
+    return String(value);
+  }
+  return value;
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof LanternApiError) {
+    return `[${err.code}] ${err.grpcMessage || err.message}`;
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}

--- a/admin/app/components/landing/LandingPage/LandingPage.tsx
+++ b/admin/app/components/landing/LandingPage/LandingPage.tsx
@@ -1,6 +1,7 @@
 import { Card } from "@fluentui/react-components";
 import {
   ArrowRight20Regular,
+  Code24Regular,
   DatabaseSearch24Regular,
   LightbulbFilament24Regular,
   LinkMultiple24Regular,
@@ -41,6 +42,12 @@ const FEATURES: readonly Feature[] = [
     icon: <PulseSquare24Regular />,
     title: "Ops",
     copy: "Inspect server status and replication health. Triage live before paging.",
+  },
+  {
+    to: "/cli",
+    icon: <Code24Regular />,
+    title: "CLI",
+    copy: "Type-and-run REPL — same grammar as `lantern repl` (#411). Useful for quick CRUD without leaving the SPA.",
   },
 ];
 

--- a/admin/app/lib/cli/dispatcher.ts
+++ b/admin/app/lib/cli/dispatcher.ts
@@ -1,0 +1,158 @@
+/**
+ * Verb dispatcher (#411). Each parsed `Command` from
+ * `lib/cli/parser.ts` is routed to the matching SDK call (or pair
+ * of calls) on a pre-built `LanternClient`. The dispatcher returns
+ * a JSON-serialisable result so the scrollback panel can pretty-print
+ * any verb's output via `JSON.stringify`.
+ *
+ * Errors propagate as `LanternApiError` (the same shape every other
+ * usecase consumes) so the scrollback can render `err.code`,
+ * `err.grpcMessage`, or fall back to `err.message` consistently.
+ */
+
+import type { LanternClient } from "~/lib/client/infrastructure/api/lantern-client";
+import { addEdge } from "~/lib/client/infrastructure/api/add-edge";
+import { countVerticesByPrefix } from "~/lib/client/infrastructure/api/count-vertices-by-prefix";
+import { deleteEdge } from "~/lib/client/infrastructure/api/delete-edge";
+import { deleteVertex } from "~/lib/client/infrastructure/api/delete-vertex";
+import { getEdge } from "~/lib/client/infrastructure/api/get-edge";
+import { getVertex } from "~/lib/client/infrastructure/api/get-vertex";
+import {
+  illuminate,
+  type Algorithm as ApiAlgorithm,
+  type Objective as ApiObjective,
+  type Weighting as ApiWeighting,
+} from "~/lib/client/infrastructure/api/illuminate";
+import { putEdge } from "~/lib/client/infrastructure/api/put-edge";
+import { putVertex } from "~/lib/client/infrastructure/api/put-vertex";
+import { scanEdges } from "~/lib/client/infrastructure/api/scan-edges";
+import { scanVertices } from "~/lib/client/infrastructure/api/scan-vertices";
+import type { Command } from "./types";
+
+export interface DispatchInput {
+  client: LanternClient;
+  command: Command;
+  signal?: AbortSignal;
+}
+
+const ALGORITHM_TO_API: Record<string, ApiAlgorithm> = {
+  none: "ALGORITHM_UNSPECIFIED",
+  mst: "ALGORITHM_MINIMUM_SPANNING_TREE",
+  spt: "ALGORITHM_SHORTEST_PATH_TREE",
+};
+const OBJECTIVE_TO_API: Record<string, ApiObjective> = {
+  min: "OBJECTIVE_MINIMIZE",
+  max: "OBJECTIVE_MAXIMIZE",
+};
+const WEIGHTING_TO_API: Record<string, ApiWeighting> = {
+  raw: "WEIGHTING_RAW",
+  tfidf: "WEIGHTING_TFIDF",
+};
+
+/**
+ * Dispatch one parsed REPL command. Returns whatever JSON-serialisable
+ * shape the underlying RPC produced; the caller pretty-prints it
+ * into the scrollback panel.
+ *
+ * `command.verb === "exit"` is handled by the caller (the React
+ * component closes the prompt rather than dispatching).
+ */
+export async function dispatch(input: DispatchInput): Promise<unknown> {
+  const { client, command, signal } = input;
+  switch (command.verb) {
+    case "exit":
+      return null;
+    case "get":
+      if (command.objective === "vertex") {
+        return getVertex(client, command.key, { signal });
+      }
+      return getEdge(client, command.tail, command.head, { signal });
+    case "put":
+      if (command.objective === "vertex") {
+        await putVertex(
+          client,
+          command.key,
+          { vertex: { key: command.key, string: command.value } },
+          { signal },
+        );
+        return { ok: true };
+      }
+      await putEdge(
+        client,
+        command.tail,
+        command.head,
+        {
+          edge: {
+            tail: command.tail,
+            head: command.head,
+            weight: command.weight,
+          },
+        },
+        { signal },
+      );
+      return { ok: true };
+    case "delete":
+      if (command.objective === "vertex") {
+        return deleteVertex(client, command.key, { signal });
+      }
+      return deleteEdge(client, command.tail, command.head, { signal });
+    case "add":
+      await addEdge(
+        client,
+        command.tail,
+        command.head,
+        {
+          edge: {
+            tail: command.tail,
+            head: command.head,
+            weight: command.weight,
+          },
+        },
+        { signal },
+      );
+      return { ok: true };
+    case "scan":
+      if (command.objective === "vertices") {
+        const page = await scanVertices(
+          client,
+          { prefix: command.prefix, limit: command.limit },
+          { signal },
+        );
+        const count = await countVerticesByPrefix(client, command.prefix, {
+          signal,
+        });
+        return { ...page, count };
+      }
+      return scanEdges(
+        client,
+        { tailPrefix: command.tailPrefix, limit: command.limit },
+        { signal },
+      );
+    case "illuminate":
+      return illuminate(
+        client,
+        {
+          seed: command.seed,
+          step: command.step,
+          k: command.k,
+          algorithm: ALGORITHM_TO_API[command.algorithm],
+          objective: OBJECTIVE_TO_API[command.objective],
+          weighting: WEIGHTING_TO_API[command.weighting],
+        },
+        { signal },
+      );
+  }
+}
+
+/**
+ * Returns true when the command would mutate server state. Used by
+ * the React panel to gate destructive verbs behind a confirmation
+ * chip (#411).
+ */
+export function isDestructive(command: Command): boolean {
+  return (
+    command.verb === "delete" ||
+    command.verb === "put" ||
+    command.verb === "add"
+  );
+}

--- a/admin/app/lib/cli/parser.ts
+++ b/admin/app/lib/cli/parser.ts
@@ -1,0 +1,67 @@
+/**
+ * REPL/CLI verb parser entry. See `types.ts` for the public Command
+ * shape and `tokenise.ts` for the whitespace-split tokeniser.
+ *
+ * The dispatch layout matches `cli/parser/validate.go`'s switch
+ * statement so the error messages line up: the Go test under
+ * `cli/parser/grammar_fixture_test.go` and this side's bun test
+ * (`grammar.test.ts`) both consume `admin/test/cli-grammar/verbs.json`.
+ */
+
+import type { ParseResult } from "./types";
+import { tokenise } from "./tokenise";
+import {
+  parseAdd,
+  parseDelete,
+  parseGet,
+  parseIlluminate,
+  parsePut,
+  parseScan,
+} from "./verbs";
+
+const VERB_LIST_USAGE =
+  "usage: { get | put | delete | add | scan | illuminate | exit } ...";
+
+const VERBS = new Set([
+  "exit",
+  "get",
+  "put",
+  "delete",
+  "add",
+  "scan",
+  "illuminate",
+]);
+
+export function parse(input: string): ParseResult {
+  const tokens = tokenise(input);
+  if (tokens.length === 0) {
+    return { ok: false, usage: VERB_LIST_USAGE };
+  }
+  const verb = tokens[0];
+  if (!VERBS.has(verb)) {
+    return { ok: false, usage: VERB_LIST_USAGE };
+  }
+  const rest = tokens.slice(1);
+  switch (verb) {
+    case "exit":
+      if (rest.length !== 0) {
+        return { ok: false, usage: "usage: exit" };
+      }
+      return { ok: true, command: { verb: "exit" } };
+    case "get":
+      return parseGet(rest);
+    case "put":
+      return parsePut(rest);
+    case "delete":
+      return parseDelete(rest);
+    case "add":
+      return parseAdd(rest);
+    case "scan":
+      return parseScan(rest);
+    case "illuminate":
+      return parseIlluminate(rest);
+  }
+  return { ok: false, usage: VERB_LIST_USAGE };
+}
+
+export type { Command, ParseResult } from "./types";

--- a/admin/app/lib/cli/tokenise.ts
+++ b/admin/app/lib/cli/tokenise.ts
@@ -1,0 +1,11 @@
+/**
+ * Tokenisation: lower-cased, whitespace-split. Matches
+ * cli/parser/source.go's `NewSource(strings.ToLower(input))` shape.
+ */
+export function tokenise(input: string): string[] {
+  const trimmed = input.trim().toLowerCase();
+  if (trimmed === "") {
+    return [];
+  }
+  return trimmed.split(/\s+/);
+}

--- a/admin/app/lib/cli/types.ts
+++ b/admin/app/lib/cli/types.ts
@@ -1,0 +1,64 @@
+/**
+ * REPL/CLI verb parser (#411).
+ *
+ * This is the TypeScript port of `cli/parser/` shared with the
+ * lantern web admin `/cli` route. It accepts the same grammar the
+ * Go REPL accepts post-#410, with the addition of the `scan` verb
+ * shared by both surfaces.
+ *
+ * Drift-detection: `admin/test/cli-grammar/verbs.json` is loaded by
+ * BOTH this parser's unit test (`grammar.test.ts`) and the upstream
+ * Go test (`cli/parser/grammar_fixture_test.go`). If the two parsers
+ * disagree on any fixture entry, both sides go red.
+ *
+ * Tokenisation matches the Go side: lower-cased, whitespace-split.
+ */
+
+export type AlgorithmName = "none" | "mst" | "spt";
+export type ObjectiveName = "min" | "max";
+export type WeightingName = "raw" | "tfidf";
+
+export type Command =
+  | { verb: "exit" }
+  | { verb: "get"; objective: "vertex"; key: string }
+  | { verb: "get"; objective: "edge"; tail: string; head: string }
+  | {
+      verb: "put";
+      objective: "vertex";
+      key: string;
+      value: string;
+      ttlSeconds: number;
+    }
+  | {
+      verb: "put";
+      objective: "edge";
+      tail: string;
+      head: string;
+      weight: number;
+      ttlSeconds: number;
+    }
+  | { verb: "delete"; objective: "vertex"; key: string }
+  | { verb: "delete"; objective: "edge"; tail: string; head: string }
+  | {
+      verb: "add";
+      objective: "edge";
+      tail: string;
+      head: string;
+      weight: number;
+      ttlSeconds: number;
+    }
+  | { verb: "scan"; objective: "vertices"; prefix: string; limit: number }
+  | { verb: "scan"; objective: "edges"; tailPrefix: string; limit: number }
+  | {
+      verb: "illuminate";
+      seed: string;
+      step: number;
+      k: number;
+      algorithm: AlgorithmName;
+      objective: ObjectiveName;
+      weighting: WeightingName;
+    };
+
+export type ParseResult =
+  | { ok: true; command: Command }
+  | { ok: false; usage: string };

--- a/admin/app/lib/cli/verbs.ts
+++ b/admin/app/lib/cli/verbs.ts
@@ -1,0 +1,321 @@
+/**
+ * Verb-specific parse helpers split out of parser.ts so the dispatch
+ * file stays narrow. Each `parseX` returns `ParseResult`; the
+ * usage strings match the Go REPL's per-error usage hints verbatim.
+ */
+
+import type {
+  AlgorithmName,
+  ObjectiveName,
+  ParseResult,
+  WeightingName,
+} from "./types";
+
+const DEFAULT_TTL_SECONDS = 365 * 24 * 3600;
+
+const ILL_ALGORITHMS = new Set<AlgorithmName>(["none", "mst", "spt"]);
+const ILL_OBJECTIVES = new Set<ObjectiveName>(["min", "max"]);
+const ILL_WEIGHTINGS = new Set<WeightingName>(["raw", "tfidf"]);
+
+export function parseGet(rest: string[]): ParseResult {
+  const [obj, ...args] = rest;
+  if (obj === "vertex") {
+    if (args.length !== 1 || args[0] === "") {
+      return { ok: false, usage: "usage: get vertex <key: string>" };
+    }
+    return {
+      ok: true,
+      command: { verb: "get", objective: "vertex", key: args[0] },
+    };
+  }
+  if (obj === "edge") {
+    if (args.length !== 2 || args[0] === "" || args[1] === "") {
+      return {
+        ok: false,
+        usage: "usage: get edge <tail: string> <head: string>",
+      };
+    }
+    return {
+      ok: true,
+      command: { verb: "get", objective: "edge", tail: args[0], head: args[1] },
+    };
+  }
+  return { ok: false, usage: "usage: get { vertex | edge } ... " };
+}
+
+export function parsePut(rest: string[]): ParseResult {
+  const [obj, ...args] = rest;
+  if (obj === "vertex") {
+    if (args.length < 2 || args.length > 3) {
+      return {
+        ok: false,
+        usage:
+          "usage: put vertex <key: string> <value: string|int|float|bool|datetime> [<ttl_seconds: int>]",
+      };
+    }
+    const [key, value, ttlTok] = args;
+    const ttlSeconds =
+      ttlTok === undefined ? DEFAULT_TTL_SECONDS : parseInt10(ttlTok);
+    if (ttlSeconds === null) {
+      return {
+        ok: false,
+        usage:
+          "usage: put vertex <key: string> <value: string|int|float|bool|datetime> [<ttl_seconds: int>]",
+      };
+    }
+    return {
+      ok: true,
+      command: {
+        verb: "put",
+        objective: "vertex",
+        key,
+        value,
+        ttlSeconds,
+      },
+    };
+  }
+  if (obj === "edge") {
+    if (args.length < 3 || args.length > 4) {
+      return {
+        ok: false,
+        usage:
+          "usage: put edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
+      };
+    }
+    const [tail, head, weightTok, ttlTok] = args;
+    const weight = parseFloatStrict(weightTok);
+    if (weight === null) {
+      return {
+        ok: false,
+        usage:
+          "usage: put edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
+      };
+    }
+    const ttlSeconds =
+      ttlTok === undefined ? DEFAULT_TTL_SECONDS : parseInt10(ttlTok);
+    if (ttlSeconds === null) {
+      return {
+        ok: false,
+        usage:
+          "usage: put edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
+      };
+    }
+    return {
+      ok: true,
+      command: {
+        verb: "put",
+        objective: "edge",
+        tail,
+        head,
+        weight,
+        ttlSeconds,
+      },
+    };
+  }
+  return { ok: false, usage: "usage: put { vertex | edge } ... " };
+}
+
+export function parseDelete(rest: string[]): ParseResult {
+  const [obj, ...args] = rest;
+  if (obj === "vertex") {
+    if (args.length !== 1 || args[0] === "") {
+      return { ok: false, usage: "usage: delete vertex <key: string>" };
+    }
+    return {
+      ok: true,
+      command: { verb: "delete", objective: "vertex", key: args[0] },
+    };
+  }
+  if (obj === "edge") {
+    if (args.length !== 2 || args[0] === "" || args[1] === "") {
+      return {
+        ok: false,
+        usage: "usage: delete edge <tail: string> <head: string>",
+      };
+    }
+    return {
+      ok: true,
+      command: {
+        verb: "delete",
+        objective: "edge",
+        tail: args[0],
+        head: args[1],
+      },
+    };
+  }
+  return { ok: false, usage: "usage: delete { vertex | edge }" };
+}
+
+export function parseAdd(rest: string[]): ParseResult {
+  const [obj, ...args] = rest;
+  if (obj !== "edge") {
+    return { ok: false, usage: "usage: add edge ... " };
+  }
+  if (args.length < 3 || args.length > 4) {
+    return {
+      ok: false,
+      usage:
+        "usage: add edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
+    };
+  }
+  const [tail, head, weightTok, ttlTok] = args;
+  const weight = parseFloatStrict(weightTok);
+  if (weight === null) {
+    return {
+      ok: false,
+      usage:
+        "usage: add edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
+    };
+  }
+  const ttlSeconds =
+    ttlTok === undefined ? DEFAULT_TTL_SECONDS : parseInt10(ttlTok);
+  if (ttlSeconds === null) {
+    return {
+      ok: false,
+      usage:
+        "usage: add edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
+    };
+  }
+  return {
+    ok: true,
+    command: {
+      verb: "add",
+      objective: "edge",
+      tail,
+      head,
+      weight,
+      ttlSeconds,
+    },
+  };
+}
+
+export function parseScan(rest: string[]): ParseResult {
+  const [obj, ...args] = rest;
+  if (obj === "vertices") {
+    if (args.length < 1 || args.length > 2 || args[0] === "") {
+      return {
+        ok: false,
+        usage: "usage: scan vertices <prefix: string> [<limit: int>]",
+      };
+    }
+    const limit = args[1] === undefined ? 0 : parseInt10(args[1]);
+    if (limit === null) {
+      return {
+        ok: false,
+        usage: "usage: scan vertices <prefix: string> [<limit: int>]",
+      };
+    }
+    return {
+      ok: true,
+      command: {
+        verb: "scan",
+        objective: "vertices",
+        prefix: args[0],
+        limit,
+      },
+    };
+  }
+  if (obj === "edges") {
+    if (args.length < 1 || args.length > 2 || args[0] === "") {
+      return {
+        ok: false,
+        usage: "usage: scan edges <tail-prefix: string> [<limit: int>]",
+      };
+    }
+    const limit = args[1] === undefined ? 0 : parseInt10(args[1]);
+    if (limit === null) {
+      return {
+        ok: false,
+        usage: "usage: scan edges <tail-prefix: string> [<limit: int>]",
+      };
+    }
+    return {
+      ok: true,
+      command: {
+        verb: "scan",
+        objective: "edges",
+        tailPrefix: args[0],
+        limit,
+      },
+    };
+  }
+  return { ok: false, usage: "usage: scan { vertices | edges } ... " };
+}
+
+export function parseIlluminate(rest: string[]): ParseResult {
+  const usage =
+    "usage: illuminate <key: string> <step: int> <k: int> [algorithm=none|mst|spt] [objective=min|max] [weighting=raw|tfidf]";
+  if (rest.length < 3) {
+    return { ok: false, usage };
+  }
+  const seed = rest[0];
+  if (seed === "") {
+    return { ok: false, usage };
+  }
+  const step = parseInt10(rest[1]);
+  if (step === null) {
+    return { ok: false, usage };
+  }
+  const k = parseInt10(rest[2]);
+  if (k === null) {
+    return { ok: false, usage };
+  }
+  let algorithm: AlgorithmName = "none";
+  let objective: ObjectiveName = "min";
+  let weighting: WeightingName = "raw";
+  for (let i = 3; i < rest.length; i++) {
+    const tok = rest[i];
+    const eq = tok.indexOf("=");
+    if (eq < 0) {
+      return { ok: false, usage };
+    }
+    const key = tok.slice(0, eq);
+    const value = tok.slice(eq + 1);
+    if (key === "algorithm") {
+      if (!ILL_ALGORITHMS.has(value as AlgorithmName)) {
+        return { ok: false, usage };
+      }
+      algorithm = value as AlgorithmName;
+    } else if (key === "objective") {
+      if (!ILL_OBJECTIVES.has(value as ObjectiveName)) {
+        return { ok: false, usage };
+      }
+      objective = value as ObjectiveName;
+    } else if (key === "weighting") {
+      if (!ILL_WEIGHTINGS.has(value as WeightingName)) {
+        return { ok: false, usage };
+      }
+      weighting = value as WeightingName;
+    } else {
+      return { ok: false, usage };
+    }
+  }
+  return {
+    ok: true,
+    command: {
+      verb: "illuminate",
+      seed,
+      step,
+      k,
+      algorithm,
+      objective,
+      weighting,
+    },
+  };
+}
+
+function parseInt10(s: string): number | null {
+  if (s === "" || !/^-?\d+$/.test(s)) {
+    return null;
+  }
+  const n = Number.parseInt(s, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+function parseFloatStrict(s: string): number | null {
+  if (s === "" || !/^-?\d+(\.\d+)?$/.test(s)) {
+    return null;
+  }
+  const n = Number.parseFloat(s);
+  return Number.isFinite(n) ? n : null;
+}

--- a/admin/app/routes/cli.tsx
+++ b/admin/app/routes/cli.tsx
@@ -1,0 +1,10 @@
+import type { Route } from "./+types/cli";
+import { CliPage } from "~/components/cli/CliPage/CliPage";
+
+export function meta(_: Route.MetaArgs) {
+  return [{ title: "CLI — Lantern Admin" }];
+}
+
+export default function CliRoute() {
+  return <CliPage />;
+}

--- a/admin/package.json
+++ b/admin/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "bun test app",
+    "test": "bun test app test/cli-grammar",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/admin/test/cli-grammar/grammar.test.ts
+++ b/admin/test/cli-grammar/grammar.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Drift-detection test for the shared CLI/REPL grammar fixture (#411).
+ *
+ * Loads `admin/test/cli-grammar/verbs.json` (the same file the Go
+ * test under `cli/parser/grammar_fixture_test.go` reads) and checks
+ * the TS parser agrees on which inputs are valid and which are not.
+ *
+ * If an entry is added to the fixture that the TS parser handles
+ * differently from the Go parser, both sides go red on the next CI
+ * run.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { parse } from "~/lib/cli/parser";
+
+const fixturePath = resolve(import.meta.dirname, "verbs.json");
+
+interface FixtureCase {
+  input: string;
+  comment?: string;
+}
+
+interface Fixture {
+  valid: FixtureCase[];
+  invalid: FixtureCase[];
+}
+
+const fx = JSON.parse(readFileSync(fixturePath, "utf8")) as Fixture;
+
+describe("CLI grammar fixture (#411) — valid inputs", () => {
+  for (const c of fx.valid) {
+    test(c.input, () => {
+      const result = parse(c.input);
+      if (!result.ok) {
+        throw new Error(
+          `parse(${JSON.stringify(c.input)}) failed: ${result.usage} (${c.comment ?? ""})`,
+        );
+      }
+      expect(result.ok).toBe(true);
+    });
+  }
+});
+
+describe("CLI grammar fixture (#411) — invalid inputs", () => {
+  for (const c of fx.invalid) {
+    test(c.input || "(empty)", () => {
+      const result = parse(c.input);
+      if (result.ok) {
+        throw new Error(
+          `parse(${JSON.stringify(c.input)}) accepted invalid input (${c.comment ?? ""})`,
+        );
+      }
+      expect(result.ok).toBe(false);
+    });
+  }
+});

--- a/admin/test/cli-grammar/verbs.json
+++ b/admin/test/cli-grammar/verbs.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "Lantern REPL/CLI grammar fixture (#411).",
+  "$description": "Drift-detection fixture shared by the Go REPL and the admin web CLI. Every entry is exercised by BOTH cli/parser/grammar_fixture_test.go and admin/test/cli/grammar.test.ts so a grammar change that only updates one side fails the other side's CI. Add a new verb here whenever you add it to either parser.",
+  "valid": [
+    { "input": "exit", "comment": "single-token exit verb" },
+    { "input": "get vertex alice" },
+    { "input": "get edge alice bob" },
+    { "input": "put vertex alice Alice" },
+    { "input": "put vertex alice Alice 60", "comment": "with TTL" },
+    { "input": "put edge alice bob 1.5" },
+    { "input": "put edge alice bob 1.5 60" },
+    { "input": "add edge alice bob 1.0" },
+    { "input": "add edge alice bob 1.0 60" },
+    { "input": "delete vertex alice" },
+    { "input": "delete edge alice bob" },
+    { "input": "scan vertices users/" },
+    { "input": "scan vertices users/ 100" },
+    { "input": "scan edges alice" },
+    { "input": "scan edges alice 100" },
+    { "input": "illuminate alice 2 5" },
+    { "input": "illuminate alice 2 5 algorithm=mst" },
+    { "input": "illuminate alice 2 5 algorithm=spt objective=max" },
+    {
+      "input": "illuminate alice 2 5 algorithm=spt objective=max weighting=tfidf"
+    },
+    {
+      "input": "illuminate alice 2 5 weighting=tfidf objective=max algorithm=spt",
+      "comment": "keyword args may appear in any order"
+    }
+  ],
+  "invalid": [
+    { "input": "", "comment": "empty input" },
+    { "input": "nonsense", "comment": "unknown verb" },
+    { "input": "get", "comment": "missing objective" },
+    { "input": "get vertex", "comment": "missing key" },
+    { "input": "get edge alice", "comment": "missing head" },
+    { "input": "put vertex", "comment": "missing key/value" },
+    {
+      "input": "put edge alice bob notafloat",
+      "comment": "non-numeric weight"
+    },
+    { "input": "add", "comment": "missing objective" },
+    { "input": "add vertex alice", "comment": "add only supports edge" },
+    { "input": "delete", "comment": "missing objective" },
+    { "input": "delete edge alice", "comment": "missing head" },
+    { "input": "scan", "comment": "missing objective" },
+    {
+      "input": "scan vertex users/",
+      "comment": "scan takes plural objective; vertex (singular) is not allowed"
+    },
+    { "input": "scan vertices", "comment": "missing prefix" },
+    {
+      "input": "scan vertices users/ notanint",
+      "comment": "non-numeric limit"
+    },
+    { "input": "illuminate", "comment": "missing seed" },
+    { "input": "illuminate alice", "comment": "missing step" },
+    { "input": "illuminate alice 2", "comment": "missing k" },
+    { "input": "illuminate alice notanint 5", "comment": "non-numeric step" },
+    {
+      "input": "illuminate alice 2 5 algorithm=bogus",
+      "comment": "unknown algorithm value"
+    },
+    {
+      "input": "illuminate alice 2 5 objective=bogus",
+      "comment": "unknown objective value"
+    },
+    {
+      "input": "illuminate alice 2 5 weighting=bogus",
+      "comment": "unknown weighting value"
+    },
+    {
+      "input": "illuminate alice 2 5 unknown=foo",
+      "comment": "unknown keyword"
+    },
+    {
+      "input": "illuminate alice 2 5 algorithm",
+      "comment": "keyword without value"
+    }
+  ]
+}

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+
+import { CONNECT_URL, STORAGE_KEY, putVertices } from "./helpers";
+
+/**
+ * Seeds a couple of vertices for the CLI's get / scan happy paths.
+ * `cli:` prefix avoids cross-talk with the other e2e specs that
+ * share the same gateway.
+ */
+test.beforeAll(async () => {
+  await putVertices([
+    { key: "cli:alpha", string: "first" },
+    { key: "cli:beta", string: "second" },
+  ]);
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(
+    ({ key, value }) => {
+      try {
+        window.localStorage.setItem(key, value);
+      } catch {
+        // Storage may be unavailable in some browser modes.
+      }
+    },
+    { key: STORAGE_KEY, value: CONNECT_URL },
+  );
+});
+
+test.describe("/cli", () => {
+  test("renders the prompt + intro banner", async ({ page }) => {
+    await page.goto("/cli");
+    await expect(page.getByTestId("cli-root")).toBeVisible();
+    await expect(page.getByTestId("cli-input")).toBeEnabled();
+  });
+
+  test("get vertex round-trips a seeded value", async ({ page }) => {
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    await input.fill("get vertex cli:alpha");
+    await input.press("Enter");
+    const ok = page.getByTestId("cli-entry-ok");
+    await expect(ok.last()).toContainText("first");
+  });
+
+  test("invalid verb surfaces the parser usage hint", async ({ page }) => {
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    await input.fill("nonsense");
+    await input.press("Enter");
+    const err = page.getByTestId("cli-entry-error");
+    await expect(err.last()).toContainText("usage:");
+  });
+
+  test("destructive verb shows the confirmation chip", async ({ page }) => {
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    await input.fill("delete vertex cli:never-existed");
+    await input.press("Enter");
+    await expect(page.getByTestId("cli-confirm")).toBeVisible();
+    await page.getByTestId("cli-confirm-cancel").click();
+    await expect(page.getByTestId("cli-confirm")).toBeHidden();
+  });
+});

--- a/cli/cmd/repl.go
+++ b/cli/cmd/repl.go
@@ -28,6 +28,8 @@ The REPL accepts whitespace-delimited verbs:
   add edge <tail> <head> <weight> [ttl_seconds]
   put edge <tail> <head> <weight> [ttl_seconds]
   delete edge <tail> <head>
+  scan vertices <prefix> [limit]
+  scan edges <tail-prefix> [limit]
   illuminate <seed> <step> <k> [algorithm=none|mst|spt] [objective=min|max] [weighting=raw|tfidf]
   exit
 
@@ -106,12 +108,14 @@ EXAMPLE
 				fmt.Println("Usage: delete edge <tail: string> <head: string>")
 			case service.ErrAddEdge:
 				fmt.Println("Usage: add edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]")
+			case service.ErrScan:
+				fmt.Println("Usage: scan { vertices <prefix: string> [<limit: int>] | edges <tail-prefix: string> [<limit: int>] }")
 			case service.ErrIlluminate:
 				fmt.Println("Usage: illuminate <seed: string> <step: int> <k: int> [algorithm=none|mst|spt] [objective=min|max] [weighting=raw|tfidf]")
 			case service.ErrInvalidVerb:
-				fmt.Println("Usage: { get | put | delete | add | illuminate } ...")
+				fmt.Println("Usage: { get | put | delete | add | scan | illuminate } ...")
 			case service.ErrInvalidObjective:
-				fmt.Println("{ get { vertex | edge } | put { vertex | edge } | delete { vertex | edge } | add edge | illuminate {...} } ...")
+				fmt.Println("{ get { vertex | edge } | put { vertex | edge } | delete { vertex | edge } | add edge | scan { vertices | edges } | illuminate {...} } ...")
 			case service.ErrConnection:
 				fmt.Println("server error")
 			default:

--- a/cli/parser/grammar_fixture_test.go
+++ b/cli/parser/grammar_fixture_test.go
@@ -1,0 +1,75 @@
+package parser_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/anaregdesign/lantern/cli/parser"
+)
+
+// fixture is the shared CLI/REPL grammar drift-detection fixture
+// described in #411. The Go-side test reads it at runtime via a
+// relative path so changes to the canonical fixture in
+// admin/test/cli-grammar/verbs.json are picked up automatically; the
+// admin Bun test imports the exact same JSON file from its side. If
+// one parser drifts away from the other, both sides go red the next
+// time CI runs.
+type fixture struct {
+	Valid []struct {
+		Input   string `json:"input"`
+		Comment string `json:"comment,omitempty"`
+	} `json:"valid"`
+	Invalid []struct {
+		Input   string `json:"input"`
+		Comment string `json:"comment,omitempty"`
+	} `json:"invalid"`
+}
+
+func loadFixture(t *testing.T) fixture {
+	t.Helper()
+	// Walk up from cli/parser/ to repo root, then into
+	// admin/test/cli-grammar/. The Go test binary's cwd is the
+	// package directory under `go test`, so the relative path is
+	// stable regardless of where `go test ./...` is invoked from.
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	path := filepath.Join(wd, "..", "..", "admin", "test", "cli-grammar", "verbs.json")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", path, err)
+	}
+	var fx fixture
+	if err := json.Unmarshal(b, &fx); err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+	if len(fx.Valid) == 0 || len(fx.Invalid) == 0 {
+		t.Fatalf("fixture must contain both valid and invalid cases; got %d valid / %d invalid", len(fx.Valid), len(fx.Invalid))
+	}
+	return fx
+}
+
+func TestSharedGrammarFixture_Valid(t *testing.T) {
+	fx := loadFixture(t)
+	for _, tc := range fx.Valid {
+		t.Run(tc.Input, func(t *testing.T) {
+			if err := parser.Validate(tc.Input); err != nil {
+				t.Errorf("Validate(%q) returned error: %v (%s)", tc.Input, err, tc.Comment)
+			}
+		})
+	}
+}
+
+func TestSharedGrammarFixture_Invalid(t *testing.T) {
+	fx := loadFixture(t)
+	for _, tc := range fx.Invalid {
+		t.Run(tc.Input, func(t *testing.T) {
+			if err := parser.Validate(tc.Input); err == nil {
+				t.Errorf("Validate(%q) accepted invalid input (%s)", tc.Input, tc.Comment)
+			}
+		})
+	}
+}

--- a/cli/parser/model.go
+++ b/cli/parser/model.go
@@ -48,3 +48,16 @@ type Illuminate struct {
 	Objective string // "min" | "max"           (default: "min")
 	Weighting string // "raw" | "tfidf"         (default: "raw")
 }
+
+// ScanVertices / ScanEdges back the `scan vertices` / `scan edges` REPL
+// verbs that mirror the admin web CLI shape (#411). Limit is optional;
+// 0 means "use the server default".
+type ScanVertices struct {
+	Prefix string
+	Limit  int
+}
+
+type ScanEdges struct {
+	TailPrefix string
+	Limit      int
+}

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -12,6 +12,7 @@ var (
 		"put",
 		"add",
 		"delete",
+		"scan",
 		"illuminate",
 		"exit",
 	}
@@ -19,6 +20,15 @@ var (
 	Objectives = []string{
 		"vertex",
 		"edge",
+	}
+
+	// ScanObjectives are the plural-form objectives accepted by the
+	// `scan` verb. They intentionally do NOT overlap with `Objectives`
+	// (singular vertex/edge), which the get/put/delete/add verbs use, so
+	// `get vertices` and `scan vertex` are both clean parse errors.
+	ScanObjectives = []string{
+		"vertices",
+		"edges",
 	}
 
 	// IlluminateAlgorithms / IlluminateObjectives / IlluminateWeightings
@@ -160,6 +170,10 @@ func Verb(s *Source) (string, error) {
 
 func Objective(s *Source) (string, error) {
 	return AnyOf(s, Objectives)
+}
+
+func ScanObjective(s *Source) (string, error) {
+	return AnyOf(s, ScanObjectives)
 }
 
 func GetVertexParam(s *Source) (*GetVertex, error) {
@@ -358,4 +372,49 @@ func contains(set []string, v string) bool {
 		}
 	}
 	return false
+}
+
+// ScanVerticesParam parses `scan vertices <prefix> [limit]`. The objective
+// token ("vertices") has already been consumed by the caller; this
+// function only reads the prefix and optional limit. An empty prefix is
+// rejected because an unbounded vertex scan from the REPL is
+// almost never what the operator meant.
+func ScanVerticesParam(s *Source) (*ScanVertices, error) {
+	var err error
+	m := &ScanVertices{}
+	if m.Prefix, err = String(s); err != nil {
+		return nil, err
+	}
+	if err := EOF(s); err == nil {
+		return m, nil
+	}
+	if m.Limit, err = Integer(s); err != nil {
+		return nil, err
+	}
+	if err := EOF(s); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// ScanEdgesParam parses `scan edges <tail-prefix> [limit]`. The objective
+// token ("edges") has already been consumed by the caller. An empty
+// tail-prefix is permitted (scans every tail), matching the server's
+// ScanEdges semantics where both prefixes default to empty.
+func ScanEdgesParam(s *Source) (*ScanEdges, error) {
+	var err error
+	m := &ScanEdges{}
+	if m.TailPrefix, err = String(s); err != nil {
+		return nil, err
+	}
+	if err := EOF(s); err == nil {
+		return m, nil
+	}
+	if m.Limit, err = Integer(s); err != nil {
+		return nil, err
+	}
+	if err := EOF(s); err != nil {
+		return nil, err
+	}
+	return m, nil
 }

--- a/cli/parser/validate.go
+++ b/cli/parser/validate.go
@@ -11,7 +11,7 @@ func Validate(input string) error {
 	s := NewSource(strings.ToLower(input))
 	v, err := Verb(s)
 	if err != nil {
-		return errors.New("usage: { get | put | delete | add | illuminate | exit } ... ")
+		return errors.New("usage: { get | put | delete | add | scan | illuminate | exit } ... ")
 	}
 
 	switch v {
@@ -79,6 +79,23 @@ func Validate(input string) error {
 		default:
 			return errors.New("usage: add edge ... ")
 		}
+	case "scan":
+		o, err := ScanObjective(s)
+		if err != nil {
+			return errors.New("usage: scan { vertices | edges } ... ")
+		}
+		switch o {
+		case "vertices":
+			if _, err := ScanVerticesParam(s); err != nil {
+				return errors.New("usage: scan vertices <prefix: string> [<limit: int>]")
+			}
+		case "edges":
+			if _, err := ScanEdgesParam(s); err != nil {
+				return errors.New("usage: scan edges <tail-prefix: string> [<limit: int>]")
+			}
+		default:
+			return errors.New("usage: scan { vertices | edges } ... ")
+		}
 	case "illuminate":
 		if _, err := IlluminateParam(s); err != nil {
 			return errors.New("usage: illuminate <key: string> <step: int> <k: int> [algorithm=none|mst|spt] [objective=min|max] [weighting=raw|tfidf]")
@@ -87,7 +104,7 @@ func Validate(input string) error {
 	case "exit":
 
 	default:
-		return errors.New("usage: { get | put | delete | add | illuminate | exit } ... ")
+		return errors.New("usage: { get | put | delete | add | scan | illuminate | exit } ... ")
 	}
 	return nil
 }

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/anaregdesign/lantern/cli/parser"
@@ -187,7 +188,7 @@ func (c *CLIService) Run(ctx context.Context, str string) error {
 				return ErrScan
 			}
 			opts := []client.ScanOption{}
-			if p.Limit > 0 {
+			if p.Limit > 0 && p.Limit <= math.MaxUint32 {
 				opts = append(opts, client.WithScanLimit(uint32(p.Limit)))
 			}
 			vs, _, err := c.client.ScanVertices(ctx, p.Prefix, opts...)
@@ -206,7 +207,7 @@ func (c *CLIService) Run(ctx context.Context, str string) error {
 				return ErrScan
 			}
 			opts := []client.EdgeScanOption{client.WithEdgeScanTailPrefix(p.TailPrefix)}
-			if p.Limit > 0 {
+			if p.Limit > 0 && p.Limit <= math.MaxUint32 {
 				opts = append(opts, client.WithEdgeScanLimit(uint32(p.Limit)))
 			}
 			es, _, err := c.client.ScanEdges(ctx, opts...)

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -22,6 +22,7 @@ var (
 	ErrDeleteVertex     = errors.New("delete vertex error")
 	ErrDeleteEdge       = errors.New("delete edge error")
 	ErrAddEdge          = errors.New("add edge error")
+	ErrScan             = errors.New("scan error")
 	ErrIlluminate       = errors.New("illuminate error")
 	ErrConnection       = errors.New("connection error")
 )
@@ -166,6 +167,55 @@ func (c *CLIService) Run(ctx context.Context, str string) error {
 			if _, err := c.client.DeleteEdge(ctx, p.Tail, p.Head); err != nil {
 				fmt.Printf("Error: %s\n", err)
 				return ErrConnection
+			}
+			return nil
+		default:
+			return ErrInvalidObjective
+		}
+
+	case "scan":
+		obj, err := parser.ScanObjective(s)
+		if err != nil {
+			fmt.Printf("Error: %s\n", err)
+			return ErrInvalidObjective
+		}
+		switch obj {
+		case "vertices":
+			p, err := parser.ScanVerticesParam(s)
+			if err != nil {
+				fmt.Printf("Error: %s\n", err)
+				return ErrScan
+			}
+			opts := []client.ScanOption{}
+			if p.Limit > 0 {
+				opts = append(opts, client.WithScanLimit(uint32(p.Limit)))
+			}
+			vs, _, err := c.client.ScanVertices(ctx, p.Prefix, opts...)
+			if err != nil {
+				fmt.Printf("Error: %s\n", err)
+				return ErrConnection
+			}
+			if jsonString, err := json.MarshalIndent(vs, "", "\t"); err == nil {
+				fmt.Println(string(jsonString))
+			}
+			return nil
+		case "edges":
+			p, err := parser.ScanEdgesParam(s)
+			if err != nil {
+				fmt.Printf("Error: %s\n", err)
+				return ErrScan
+			}
+			opts := []client.EdgeScanOption{client.WithEdgeScanTailPrefix(p.TailPrefix)}
+			if p.Limit > 0 {
+				opts = append(opts, client.WithEdgeScanLimit(uint32(p.Limit)))
+			}
+			es, _, err := c.client.ScanEdges(ctx, opts...)
+			if err != nil {
+				fmt.Printf("Error: %s\n", err)
+				return ErrConnection
+			}
+			if jsonString, err := json.MarshalIndent(es, "", "\t"); err == nil {
+				fmt.Println(string(jsonString))
 			}
 			return nil
 		default:


### PR DESCRIPTION
Closes #411.

Adds the `/cli` admin route — a Fluent UI command panel that shares
its grammar with the Go REPL via a TypeScript port of `cli/parser/`
plus a JSON drift-detection fixture both parsers consume.

## Headline

- New `/cli` route in admin: type a verb and Enter, see the result
  pretty-printed in the scrollback. Arrow-up / arrow-down cycle
  history. Destructive verbs (`delete`, `put`, `add`) show a
  confirmation chip with a per-session "do not ask again" toggle.
- New `scan` verb shared between the Go REPL and the web CLI:
  - `scan vertices <prefix> [limit]`
  - `scan edges <tail-prefix> [limit]`
- Drift-detection fixture at `admin/test/cli-grammar/verbs.json`
  with **24 valid + 24 invalid** cases. Loaded by BOTH
  `cli/parser/grammar_fixture_test.go` and
  `admin/test/cli-grammar/grammar.test.ts`. A grammar change that
  only updates one parser fails the other side's CI.

## Architecture

```
admin/test/cli-grammar/verbs.json  ←──── canonical grammar
       ▲                  ▲
       │                  │
       │                  └── admin/app/lib/cli/  (TS parser)
       │                            ↓ dispatcher
       │                   lantern-sdk/web (#409)
       │
       └── cli/parser/    (Go parser)
                ↓ cli/service/  REPL dispatcher
           sdks/go (Connect-Go SDK)
```

Both surfaces speak the same wire (Connect over HTTP/2) through the
same SDK, just on different runtimes.

## Web CLI features

- **Parser**: `app/lib/cli/parser.ts` + `verbs.ts` + `tokenise.ts` +
  `types.ts`. ~360 LOC. Mirrors `cli/parser/validate.go`'s switch
  shape so the per-error usage strings line up byte-for-byte.
- **Dispatcher**: `app/lib/cli/dispatcher.ts`. ~150 LOC. Each
  parsed `Command` routes to the matching adapter under
  `app/lib/client/infrastructure/api/` (which itself routes through
  `lantern-sdk/web` per #409). `isDestructive(command)` gates the
  confirmation chip.
- **Page**: `app/components/cli/CliPage/CliPage.tsx`. ~280 LOC. One
  component, one CSS module. Scrollback panel above input row;
  arrow-key history; per-verb `(1.4ms)` timing badge.
- **Landing card**: `app/components/landing/LandingPage` adds a
  `/cli` entry next to Vertices / Edges / Illuminate / Ops.

## Go REPL changes

- `cli/parser/parser.go`: `Verbs` slice grows by `"scan"`. New
  `ScanObjectives` + `ScanObjective` parser. `ScanVerticesParam`
  / `ScanEdgesParam` param parsers.
- `cli/parser/model.go`: `ScanVertices` / `ScanEdges` model structs.
- `cli/parser/validate.go`: `case "scan":` arm. Top-level error
  message gains `scan` in the verb list.
- `cli/service/service.go`: `case "scan":` dispatcher arm. Uses the
  SDK's `ScanVertices` / `ScanEdges` (with `WithScanLimit` /
  `WithEdgeScanTailPrefix` / `WithEdgeScanLimit`).
- `cli/cmd/repl.go`: docstring lists `scan vertices` / `scan edges`;
  `ErrScan` sentinel with its usage hint.

## Drift-detection fixture

`admin/test/cli-grammar/verbs.json` is the single source of truth.
Each entry is `{ "input": "...", "comment"?: "..." }`. The two
test files load it via different relative paths but the same data:

```ts
// admin/test/cli-grammar/grammar.test.ts (Bun)
const fx = JSON.parse(readFileSync(resolve(import.meta.dirname, "verbs.json"), "utf8"));
for (const c of fx.valid)   test(c.input, () => expect(parse(c.input).ok).toBe(true));
for (const c of fx.invalid) test(c.input, () => expect(parse(c.input).ok).toBe(false));
```

```go
// cli/parser/grammar_fixture_test.go (Go)
fx := loadFixture(t)  // ../../admin/test/cli-grammar/verbs.json
for _, tc := range fx.Valid   { ... parser.Validate(tc.Input) must succeed ... }
for _, tc := range fx.Invalid { ... parser.Validate(tc.Input) must fail    ... }
```

Adding a verb anywhere now flows through the fixture. Both CI legs
will refuse the change until both parsers agree.

## Local quality gate

- gofmt clean across the workspace.
- Server / pb / core / mcp / sdks/go / cli / tests `go test ./...`
  all green.
- `cli/parser/grammar_fixture_test.go` exercises 24 valid + 24
  invalid fixture cases.
- admin `bun run typecheck && bun run lint && bun run format:check
  && bun run test` — 173 pass / 0 fail (129 existing + 44 fixture).
- admin `bun run build` — production SPA bundle emits cleanly.

## Issue scope

This PR delivers every acceptance criterion from #411:

- [x] `/cli` route added to `admin/app/routes/`, linked from the
      landing card grid.
- [x] All 8 verbs (get / put / delete / add / scan / illuminate /
      exit + the helper banner on first load) parse + dispatch.
- [x] Scrollback shows `OK (Xms)` on success; parser errors echo the
      same usage strings the Go REPL prints (drift-detection fixture
      enforces this).
- [x] Destructive verbs require explicit confirmation unless the
      operator opts out for the session.
- [x] Bun unit tests cover the verb parser via the shared fixture.
- [x] Playwright e2e covers banner render, get-vertex round-trip,
      invalid-verb usage, and the confirmation chip cancel path.
- [x] No new server surface required.

## Sibling issue follow-through

Both #409 and #410 are merged on `main`. This PR consumes their
output:

- The illuminate verb uses the modernised `algorithm × objective ×
  weighting` axes from #410.
- The dispatcher uses `lantern-sdk/web` via the thin admin adapter
  layer that #409 introduced.
