### PR TITLE
feat(admin): promote /cli to first-class panel with graph canvas + click-to-illuminate

### DIFF
--- a/admin/app/components/cli/CliPage/CliPage.module.css
+++ b/admin/app/components/cli/CliPage/CliPage.module.css
@@ -7,8 +7,60 @@
   padding: var(--spacingVerticalL, 16px);
 }
 
+/* Canvas panel rendered above the scrollback when the most recent
+   command produced graph data. The body owns ~45% of the panel and
+   shrinks gracefully on short viewports; the scrollback still has at
+   least a few lines of room thanks to min-height on `.scrollback`. */
+.canvasPanel {
+  display: flex;
+  flex-direction: column;
+  flex: 0 0 45%;
+  min-height: 240px;
+  border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  border-radius: var(--borderRadiusMedium, 6px);
+  background: var(--colorNeutralBackground1, #ffffff);
+  overflow: hidden;
+}
+
+.canvasHeader {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacingHorizontalS, 8px);
+  padding: var(--spacingVerticalXS, 4px) var(--spacingHorizontalS, 8px);
+  border-bottom: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  background: var(--colorNeutralBackground2, #fafafa);
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  font-size: var(--fontSizeBase200, 12px);
+}
+
+.canvasHeaderLabel {
+  color: var(--colorNeutralForeground3, #707070);
+}
+
+.canvasHeaderSource {
+  color: var(--colorNeutralForeground1, #242424);
+}
+
+.canvasHeaderHint {
+  margin-left: auto;
+  color: var(--colorNeutralForeground3, #707070);
+  font-size: var(--fontSizeBase100, 10px);
+}
+
+.canvasBody {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 .scrollback {
   flex: 1 1 auto;
+  min-height: 120px;
   overflow-y: auto;
   border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
   border-radius: var(--borderRadiusMedium, 6px);

--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -7,11 +7,23 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { dispatch, isDestructive } from "~/lib/cli/dispatcher";
 import { parse, type Command, type ParseResult } from "~/lib/cli/parser";
+import { commandResultToGraphView } from "~/lib/cli/graph-view";
+import { IlluminateCanvas } from "~/components/illuminate/IlluminateCanvas/IlluminateCanvas";
+import type { GraphView } from "~/lib/client/usecase/illuminate/selectors";
 import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
 import { LanternApiError } from "~/lib/client/infrastructure/api/error";
 import styles from "./CliPage.module.css";
 
 type EntryKind = "ok" | "error" | "info";
+
+/** Default step/k for click-to-illuminate. Matches the placeholder text. */
+const CLICK_TO_ILLUMINATE = { step: 2, k: 5 } as const;
+
+interface LatestGraph {
+  /** The exact CLI input that produced this graph (`get vertex alice`, …). */
+  source: string;
+  view: GraphView;
+}
 
 interface ScrollbackEntry {
   id: number;
@@ -50,6 +62,11 @@ export function CliPage() {
   const [pending, setPending] = useState<PendingDestructive | null>(null);
   const [skipConfirm, setSkipConfirm] = useState(false);
   const [busy, setBusy] = useState(false);
+  // The most recent graph-producing command's view. Mutating verbs
+  // (`put`, `add`, `delete`) leave this alone so the operator keeps
+  // their exploration context after a write. Null until the first
+  // graph-producing command lands.
+  const [latestGraph, setLatestGraph] = useState<LatestGraph | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const idRef = useRef(2);
 
@@ -81,6 +98,13 @@ export function CliPage() {
               : "OK\n" + JSON.stringify(out, replacer, 2),
           durationMs: elapsed,
         });
+        // Project graph-shaped results onto the canvas. null means
+        // the verb carries no graph payload (put/add/delete/exit) —
+        // leave the previous canvas alone in that case.
+        const view = commandResultToGraphView(command, out);
+        if (view !== null) {
+          setLatestGraph({ source: rawInput, view });
+        }
       } catch (err) {
         const elapsed = performance.now() - start;
         append({
@@ -96,34 +120,54 @@ export function CliPage() {
     [append, client],
   );
 
+  const runRaw = useCallback(
+    async (raw: string) => {
+      if (raw.trim() === "") return;
+      setHistory((prev) => [...prev, raw]);
+      setHistoryIndex(null);
+      setInput("");
+      const result: ParseResult = parse(raw);
+      if (!result.ok) {
+        append({ input: raw, kind: "error", text: result.usage });
+        return;
+      }
+      if (result.command.verb === "exit") {
+        append({
+          input: raw,
+          kind: "info",
+          text: "(exit is a no-op in the web CLI; close the tab to leave)",
+        });
+        return;
+      }
+      if (isDestructive(result.command) && !skipConfirm) {
+        setPending({
+          command: result.command,
+          rendered: raw,
+        });
+        return;
+      }
+      await runCommand(raw, result.command);
+    },
+    [append, runCommand, skipConfirm],
+  );
+
   const submit = useCallback(async () => {
-    const raw = input;
-    if (raw.trim() === "") return;
-    setHistory((prev) => [...prev, raw]);
-    setHistoryIndex(null);
-    setInput("");
-    const result: ParseResult = parse(raw);
-    if (!result.ok) {
-      append({ input: raw, kind: "error", text: result.usage });
-      return;
-    }
-    if (result.command.verb === "exit") {
-      append({
-        input: raw,
-        kind: "info",
-        text: "(exit is a no-op in the web CLI; close the tab to leave)",
-      });
-      return;
-    }
-    if (isDestructive(result.command) && !skipConfirm) {
-      setPending({
-        command: result.command,
-        rendered: raw,
-      });
-      return;
-    }
-    await runCommand(raw, result.command);
-  }, [append, input, runCommand, skipConfirm]);
+    await runRaw(input);
+  }, [input, runRaw]);
+
+  // Click-to-illuminate (#439). Writes `illuminate <key> 2 5` into
+  // the prompt and submits it through the same parser path the user
+  // would hit by typing it. Illuminate is non-destructive, so the
+  // confirmation chip never fires here.
+  const onNodeClick = useCallback(
+    (key: string) => {
+      if (busy || pending !== null) return;
+      const raw = `illuminate ${key} ${CLICK_TO_ILLUMINATE.step} ${CLICK_TO_ILLUMINATE.k}`;
+      setInput(raw);
+      void runRaw(raw);
+    },
+    [busy, pending, runRaw],
+  );
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -200,6 +244,31 @@ export function CliPage() {
 
   return (
     <div className={styles.root} data-testid="cli-root">
+      {latestGraph !== null ? (
+        <div className={styles.canvasPanel} data-testid="cli-canvas-panel">
+          <div className={styles.canvasHeader}>
+            <span className={styles.canvasHeaderLabel}>from:</span>{" "}
+            <code className={styles.canvasHeaderSource}>
+              {latestGraph.source}
+            </code>
+            <span className={styles.canvasHeaderHint}>
+              click any node to run{" "}
+              <code>
+                illuminate &lt;key&gt; {CLICK_TO_ILLUMINATE.step}{" "}
+                {CLICK_TO_ILLUMINATE.k}
+              </code>
+            </span>
+          </div>
+          <div className={styles.canvasBody}>
+            <IlluminateCanvas
+              nodes={latestGraph.view.nodes}
+              edges={latestGraph.view.edges}
+              onNodeClick={onNodeClick}
+              isBusy={busy}
+            />
+          </div>
+        </div>
+      ) : null}
       <div className={styles.scrollback} ref={scrollRef} aria-live="polite">
         {renderedScrollback}
       </div>

--- a/admin/app/components/shared/AppShell/AppShell.tsx
+++ b/admin/app/components/shared/AppShell/AppShell.tsx
@@ -17,6 +17,10 @@ const NAV: readonly NavEntry[] = [
   { to: "/vertices", label: "Vertices" },
   { to: "/edges", label: "Edges" },
   { to: "/illuminate", label: "Illuminate" },
+  // CLI is the power-user shortcut to the same RPC surface the other
+  // routes wrap; place it next to Illuminate (the other "explore"
+  // surface) and before the operator-facing Ops page (#439, #431).
+  { to: "/cli", label: "CLI" },
   { to: "/ops", label: "Ops" },
 ];
 

--- a/admin/app/lib/cli/graph-view.test.ts
+++ b/admin/app/lib/cli/graph-view.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "bun:test";
+import { commandResultToGraphView } from "./graph-view";
+import type { Command } from "./types";
+import type {
+  Edge,
+  IlluminateResponse,
+  ScanEdgesResponse,
+  ScanVerticesResponse,
+  Vertex,
+} from "~/lib/client/infrastructure/api/types";
+
+describe("commandResultToGraphView — illuminate", () => {
+  const cmd: Command = {
+    verb: "illuminate",
+    seed: "a",
+    step: 2,
+    k: 5,
+    algorithm: "none",
+    objective: "min",
+    weighting: "raw",
+  };
+
+  it("marks the seed and renders all returned vertices + edges", () => {
+    const response: IlluminateResponse = {
+      graph: {
+        vertices: [{ key: "a" }, { key: "b" }, { key: "c" }],
+        edges: [
+          { tail: "a", head: "b", weight: 1 },
+          { tail: "a", head: "c", weight: 3 },
+        ],
+      },
+    };
+    const view = commandResultToGraphView(cmd, response)!;
+    expect(view.nodes.map((n) => n.id).sort()).toEqual(["a", "b", "c"]);
+    expect(view.nodes.find((n) => n.id === "a")!.isSeed).toBe(true);
+    expect(view.nodes.find((n) => n.id === "a")!.importance).toBe(1);
+    expect(view.edges.map((e) => e.id).sort()).toEqual(["a→b", "a→c"]);
+  });
+
+  it("drops edges that reference unknown vertices", () => {
+    const response: IlluminateResponse = {
+      graph: {
+        vertices: [{ key: "a" }, { key: "b" }],
+        edges: [
+          { tail: "a", head: "b", weight: 1 },
+          { tail: "a", head: "missing", weight: 1 },
+        ],
+      },
+    };
+    const view = commandResultToGraphView(cmd, response)!;
+    expect(view.edges.map((e) => e.id)).toEqual(["a→b"]);
+  });
+
+  it("renders an empty view when the response carries no graph", () => {
+    const view = commandResultToGraphView(cmd, {} as IlluminateResponse)!;
+    expect(view.nodes).toEqual([]);
+    expect(view.edges).toEqual([]);
+  });
+});
+
+describe("commandResultToGraphView — get vertex", () => {
+  const cmd: Command = { verb: "get", objective: "vertex", key: "alice" };
+
+  it("renders a single seed node", () => {
+    const vertex: Vertex = { key: "alice", string: "wonderland" };
+    const view = commandResultToGraphView(cmd, vertex)!;
+    expect(view.nodes).toHaveLength(1);
+    expect(view.nodes[0].id).toBe("alice");
+    expect(view.nodes[0].isSeed).toBe(true);
+    expect(view.nodes[0].importance).toBe(1);
+    expect(view.edges).toEqual([]);
+  });
+
+  it("renders an empty view when the server returned NotFound", () => {
+    const view = commandResultToGraphView(cmd, null)!;
+    expect(view.nodes).toEqual([]);
+    expect(view.edges).toEqual([]);
+  });
+});
+
+describe("commandResultToGraphView — get edge", () => {
+  const cmd: Command = {
+    verb: "get",
+    objective: "edge",
+    tail: "alice",
+    head: "bob",
+  };
+
+  it("renders both endpoints plus the edge", () => {
+    const edge: Edge = { tail: "alice", head: "bob", weight: 7 };
+    const view = commandResultToGraphView(cmd, edge)!;
+    expect(view.nodes.map((n) => n.id).sort()).toEqual(["alice", "bob"]);
+    expect(view.nodes.find((n) => n.id === "alice")!.isSeed).toBe(true);
+    expect(view.nodes.find((n) => n.id === "bob")!.isSeed).toBe(false);
+    expect(view.edges).toHaveLength(1);
+    expect(view.edges[0].id).toBe("alice→bob");
+    expect(view.edges[0].weight).toBe(7);
+  });
+
+  it("renders an empty view when the server returned NotFound", () => {
+    const view = commandResultToGraphView(cmd, null)!;
+    expect(view.nodes).toEqual([]);
+    expect(view.edges).toEqual([]);
+  });
+});
+
+describe("commandResultToGraphView — scan vertices", () => {
+  it("renders each returned vertex with no edges", () => {
+    const cmd: Command = {
+      verb: "scan",
+      objective: "vertices",
+      prefix: "user:",
+      limit: 10,
+    };
+    const response: ScanVerticesResponse & { count: number } = {
+      vertices: [
+        { key: "user:alice" },
+        { key: "user:bob" },
+        { key: "user:carol" },
+      ],
+      count: 3,
+    };
+    const view = commandResultToGraphView(cmd, response)!;
+    expect(view.nodes.map((n) => n.id).sort()).toEqual([
+      "user:alice",
+      "user:bob",
+      "user:carol",
+    ]);
+    expect(view.edges).toEqual([]);
+    expect(view.nodes.every((n) => !n.isSeed)).toBe(true);
+  });
+
+  it("marks the exact-match vertex as a seed when prefix is non-empty", () => {
+    const cmd: Command = {
+      verb: "scan",
+      objective: "vertices",
+      prefix: "alice",
+      limit: 10,
+    };
+    const response: ScanVerticesResponse = {
+      vertices: [{ key: "alice" }, { key: "aliceland" }],
+    };
+    const view = commandResultToGraphView(cmd, response)!;
+    expect(view.nodes.find((n) => n.id === "alice")!.isSeed).toBe(true);
+    expect(view.nodes.find((n) => n.id === "aliceland")!.isSeed).toBe(false);
+  });
+});
+
+describe("commandResultToGraphView — scan edges", () => {
+  const cmd: Command = {
+    verb: "scan",
+    objective: "edges",
+    tailPrefix: "alice",
+    limit: 10,
+  };
+
+  it("synthesises endpoints from edges and dedupes shared vertices", () => {
+    const response: ScanEdgesResponse = {
+      edges: [
+        { tail: "alice", head: "bob", weight: 1 },
+        { tail: "alice", head: "carol", weight: 2 },
+        { tail: "alice", head: "bob", weight: 5 }, // duplicate endpoint
+      ],
+    };
+    const view = commandResultToGraphView(cmd, response)!;
+    expect(view.nodes.map((n) => n.id).sort()).toEqual([
+      "alice",
+      "bob",
+      "carol",
+    ]);
+    expect(view.edges).toHaveLength(3);
+  });
+
+  it("marks the tail-prefix match as a seed", () => {
+    const response: ScanEdgesResponse = {
+      edges: [{ tail: "alice", head: "bob", weight: 1 }],
+    };
+    const view = commandResultToGraphView(cmd, response)!;
+    expect(view.nodes.find((n) => n.id === "alice")!.isSeed).toBe(true);
+    expect(view.nodes.find((n) => n.id === "bob")!.isSeed).toBe(false);
+  });
+
+  it("does not seed any node when the tail prefix is empty", () => {
+    const empty: Command = {
+      verb: "scan",
+      objective: "edges",
+      tailPrefix: "",
+      limit: 10,
+    };
+    const response: ScanEdgesResponse = {
+      edges: [{ tail: "alice", head: "bob", weight: 1 }],
+    };
+    const view = commandResultToGraphView(empty, response)!;
+    expect(view.nodes.every((n) => !n.isSeed)).toBe(true);
+  });
+});
+
+describe("commandResultToGraphView — non-graph verbs", () => {
+  it("returns null for put vertex", () => {
+    const cmd: Command = {
+      verb: "put",
+      objective: "vertex",
+      key: "alice",
+      value: "wonderland",
+      ttlSeconds: 0,
+    };
+    expect(commandResultToGraphView(cmd, { ok: true })).toBeNull();
+  });
+
+  it("returns null for put edge", () => {
+    const cmd: Command = {
+      verb: "put",
+      objective: "edge",
+      tail: "alice",
+      head: "bob",
+      weight: 1,
+      ttlSeconds: 0,
+    };
+    expect(commandResultToGraphView(cmd, { ok: true })).toBeNull();
+  });
+
+  it("returns null for add edge", () => {
+    const cmd: Command = {
+      verb: "add",
+      objective: "edge",
+      tail: "alice",
+      head: "bob",
+      weight: 1,
+      ttlSeconds: 0,
+    };
+    expect(commandResultToGraphView(cmd, { ok: true })).toBeNull();
+  });
+
+  it("returns null for delete vertex", () => {
+    const cmd: Command = { verb: "delete", objective: "vertex", key: "alice" };
+    expect(commandResultToGraphView(cmd, { existed: true })).toBeNull();
+  });
+
+  it("returns null for delete edge", () => {
+    const cmd: Command = {
+      verb: "delete",
+      objective: "edge",
+      tail: "alice",
+      head: "bob",
+    };
+    expect(commandResultToGraphView(cmd, { existed: true })).toBeNull();
+  });
+
+  it("returns null for exit", () => {
+    const cmd: Command = { verb: "exit" };
+    expect(commandResultToGraphView(cmd, null)).toBeNull();
+  });
+});

--- a/admin/app/lib/cli/graph-view.ts
+++ b/admin/app/lib/cli/graph-view.ts
@@ -1,0 +1,238 @@
+/**
+ * Per-command graph projection (#439).
+ *
+ * Given a parsed CLI `Command` and the JSON-serialisable result the
+ * dispatcher returned, project the response into the same
+ * `GraphView` shape `IlluminateCanvas` already consumes on the
+ * `/illuminate` route. Verbs whose response carries no graph data
+ * (`put`, `add`, `delete`, `exit`) return `null` so the caller can
+ * keep the previous canvas frame visible — the user does not lose
+ * their context after a mutation.
+ *
+ * Pure: no React, no DOM, no Sigma. The CliPage component handles
+ * mount lifecycle.
+ */
+
+import type { Command } from "./types";
+import type {
+  GraphEdge,
+  GraphNode,
+  GraphView,
+} from "~/lib/client/usecase/illuminate/selectors";
+import type {
+  Edge,
+  IlluminateResponse,
+  ScanEdgesResponse,
+  ScanVerticesResponse,
+  Vertex,
+} from "~/lib/client/infrastructure/api/types";
+
+/**
+ * Project the dispatcher result for `command` into a `GraphView`.
+ * Returns `null` when the verb carries no graph payload — the
+ * caller should leave the previous canvas frame alone.
+ */
+export function commandResultToGraphView(
+  command: Command,
+  result: unknown,
+): GraphView | null {
+  switch (command.verb) {
+    case "illuminate":
+      return illuminateView(command.seed, result as IlluminateResponse);
+    case "get":
+      if (command.objective === "vertex") {
+        return getVertexView(command.key, result as Vertex | null);
+      }
+      return getEdgeView(command.tail, command.head, result as Edge | null);
+    case "scan":
+      if (command.objective === "vertices") {
+        return scanVerticesView(
+          command.prefix,
+          result as ScanVerticesResponse & { count?: number },
+        );
+      }
+      return scanEdgesView(command.tailPrefix, result as ScanEdgesResponse);
+    default:
+      // put, add, delete, exit — no graph payload.
+      return null;
+  }
+}
+
+function illuminateView(seed: string, response: IlluminateResponse): GraphView {
+  const graph = response.graph ?? {};
+  const seedKey = seed;
+
+  const rawVertices: Vertex[] = graph.vertices ?? [];
+  const rawEdges: Edge[] = graph.edges ?? [];
+
+  // Importance == sum of incident edge weights, normalised against the
+  // largest such sum. The seed is pinned to 1 regardless so it always
+  // dominates the canvas like the /illuminate route does.
+  const weightByKey = new Map<string, number>();
+  for (const edge of rawEdges) {
+    if (!edge.tail || !edge.head) continue;
+    weightByKey.set(
+      edge.tail,
+      (weightByKey.get(edge.tail) ?? 0) + (edge.weight ?? 0),
+    );
+    weightByKey.set(
+      edge.head,
+      (weightByKey.get(edge.head) ?? 0) + (edge.weight ?? 0),
+    );
+  }
+  const maxWeight = Math.max(0, ...weightByKey.values());
+
+  const nodes: GraphNode[] = rawVertices
+    .filter(
+      (v): v is Vertex & { key: string } =>
+        typeof v.key === "string" && v.key !== "",
+    )
+    .map((v) => {
+      const isSeed = v.key === seedKey;
+      const raw = weightByKey.get(v.key) ?? 0;
+      const importance = isSeed
+        ? 1
+        : maxWeight > 0
+          ? Math.max(0.1, raw / maxWeight)
+          : 0.5;
+      return {
+        id: v.key,
+        label: v.key,
+        vertex: v,
+        isSeed,
+        importance,
+      };
+    });
+
+  const knownKeys = new Set(nodes.map((n) => n.id));
+  const edges: GraphEdge[] = [];
+  for (const e of rawEdges) {
+    if (!e.tail || !e.head) continue;
+    if (!knownKeys.has(e.tail) || !knownKeys.has(e.head)) continue;
+    edges.push({
+      id: `${e.tail}→${e.head}`,
+      source: e.tail,
+      target: e.head,
+      weight: e.weight ?? 0,
+      edge: e,
+    });
+  }
+  return { nodes, edges };
+}
+
+function getVertexView(key: string, vertex: Vertex | null): GraphView {
+  if (!vertex) {
+    // The server returned NotFound. Render an empty canvas; the
+    // scrollback already shows the error.
+    return { nodes: [], edges: [] };
+  }
+  return {
+    nodes: [
+      {
+        id: key,
+        label: key,
+        vertex: { ...vertex, key },
+        isSeed: true,
+        importance: 1,
+      },
+    ],
+    edges: [],
+  };
+}
+
+function getEdgeView(tail: string, head: string, edge: Edge | null): GraphView {
+  if (!edge) {
+    return { nodes: [], edges: [] };
+  }
+  const nodes: GraphNode[] = [
+    {
+      id: tail,
+      label: tail,
+      // We do NOT have the underlying vertex value (the server only
+      // returned the edge); synthesise a key-only Vertex so the
+      // canvas tooltip / a11y table render a recognisable label
+      // rather than crashing on missing fields.
+      vertex: { key: tail },
+      isSeed: true,
+      importance: 1,
+    },
+    {
+      id: head,
+      label: head,
+      vertex: { key: head },
+      isSeed: false,
+      importance: 0.5,
+    },
+  ];
+  const edges: GraphEdge[] = [
+    {
+      id: `${tail}→${head}`,
+      source: tail,
+      target: head,
+      weight: edge.weight ?? 0,
+      edge,
+    },
+  ];
+  return { nodes, edges };
+}
+
+function scanVerticesView(
+  prefix: string,
+  response: ScanVerticesResponse,
+): GraphView {
+  const rawVertices = response.vertices ?? [];
+  const seedKey = prefix; // Empty prefix → no seed, every node neutral.
+  const nodes: GraphNode[] = rawVertices
+    .filter(
+      (v): v is Vertex & { key: string } =>
+        typeof v.key === "string" && v.key !== "",
+    )
+    .map((v) => ({
+      id: v.key,
+      label: v.key,
+      vertex: v,
+      isSeed: seedKey !== "" && v.key === seedKey,
+      importance: 0.5,
+    }));
+  return { nodes, edges: [] };
+}
+
+function scanEdgesView(
+  tailPrefix: string,
+  response: ScanEdgesResponse,
+): GraphView {
+  const rawEdges = response.edges ?? [];
+  const nodeMap = new Map<string, GraphNode>();
+  const edges: GraphEdge[] = [];
+  for (const e of rawEdges) {
+    if (!e.tail || !e.head) continue;
+    if (!nodeMap.has(e.tail)) {
+      nodeMap.set(e.tail, {
+        id: e.tail,
+        label: e.tail,
+        vertex: { key: e.tail },
+        // Mark every endpoint whose key matches the scan prefix as
+        // a seed. Empty prefix → no seeds (every node neutral).
+        isSeed: tailPrefix !== "" && e.tail === tailPrefix,
+        importance: 0.5,
+      });
+    }
+    if (!nodeMap.has(e.head)) {
+      nodeMap.set(e.head, {
+        id: e.head,
+        label: e.head,
+        vertex: { key: e.head },
+        isSeed: false,
+        importance: 0.5,
+      });
+    }
+    edges.push({
+      id: `${e.tail}→${e.head}`,
+      source: e.tail,
+      target: e.head,
+      weight: e.weight ?? 0,
+      edge: e,
+    });
+  }
+  return { nodes: Array.from(nodeMap.values()), edges };
+}

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { CONNECT_URL, STORAGE_KEY, putVertices } from "./helpers";
+import { CONNECT_URL, STORAGE_KEY, putEdges, putVertices } from "./helpers";
 
 /**
  * Seeds a couple of vertices for the CLI's get / scan happy paths.
@@ -12,6 +12,9 @@ test.beforeAll(async () => {
     { key: "cli:alpha", string: "first" },
     { key: "cli:beta", string: "second" },
   ]);
+  // Edge so illuminate / get edge happy-paths in the canvas spec
+  // below have something to render.
+  await putEdges([{ tail: "cli:alpha", head: "cli:beta", weight: 2 }]);
 });
 
 test.beforeEach(async ({ page }) => {
@@ -60,5 +63,46 @@ test.describe("/cli", () => {
     await expect(page.getByTestId("cli-confirm")).toBeVisible();
     await page.getByTestId("cli-confirm-cancel").click();
     await expect(page.getByTestId("cli-confirm")).toBeHidden();
+  });
+
+  // #439 — graph-producing verbs render the IlluminateCanvas above
+  // the scrollback so the operator can see what they just touched.
+  test("get vertex renders the canvas panel", async ({ page }) => {
+    await page.goto("/cli");
+    // Canvas is hidden until the first graph-producing command lands.
+    await expect(page.getByTestId("cli-canvas-panel")).toHaveCount(0);
+    const input = page.getByTestId("cli-input");
+    await input.fill("get vertex cli:alpha");
+    await input.press("Enter");
+    await expect(page.getByTestId("cli-entry-ok").last()).toContainText(
+      "first",
+    );
+    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
+    await expect(page.getByTestId("cli-canvas-panel")).toContainText(
+      "get vertex cli:alpha",
+    );
+  });
+
+  test("illuminate persists across non-graph commands", async ({ page }) => {
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    // Render a graph first.
+    await input.fill("illuminate cli:alpha 2 5");
+    await input.press("Enter");
+    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
+    await expect(page.getByTestId("cli-canvas-panel")).toContainText(
+      "illuminate cli:alpha 2 5",
+    );
+    // A non-graph command (parser usage hint here) must NOT clear the
+    // canvas \u2014 the operator's exploration context survives mistakes.
+    await input.fill("nonsense");
+    await input.press("Enter");
+    await expect(page.getByTestId("cli-entry-error").last()).toContainText(
+      "usage:",
+    );
+    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
+    await expect(page.getByTestId("cli-canvas-panel")).toContainText(
+      "illuminate cli:alpha 2 5",
+    );
   });
 });

--- a/admin/tests/e2e/landing.spec.ts
+++ b/admin/tests/e2e/landing.spec.ts
@@ -15,6 +15,9 @@ test("landing page renders with navigation and gateway connection", async ({
     page.getByRole("link", { name: /Open Illuminate/i }),
   ).toBeVisible();
   await expect(page.getByRole("link", { name: /Open Ops/i })).toBeVisible();
+  // #439 — landing tile + AppShell nav now expose /cli alongside the
+  // other top-level sections.
+  await expect(page.getByRole("link", { name: /Open CLI/i })).toBeVisible();
   await expect(page.getByText("http://localhost:6380")).toBeVisible();
 });
 


### PR DESCRIPTION
## What

Closes #431
Closes #439

`/cli` was reachable only by typing the URL — and its output stayed text-only even when the dispatched verb returned a full subgraph. This PR promotes the CLI to a first-class admin panel and turns its output into an interactive graph, matching the verbatim ask:

> CLIもAdminのメニューに表示させたい．CLIの結果はグラフとしてvisualize され，クリックによってIlluminateコマンドが入力・実行されるようにしたい．

So now:

1. **AppShell nav** has a `CLI` entry between `Illuminate` and `Ops`. The landing-page tile that was already shipped for `/cli` is now asserted in e2e too.
2. **CLI results render as a graph** above the scrollback for every graph-producing verb (`illuminate`, `get vertex`, `get edge`, `scan vertices`, `scan edges`). Mutating verbs (`put` / `add` / `delete`) intentionally leave the canvas alone so the operator's last exploration context is preserved.
3. **Clicking any node** drops `illuminate <key> 2 5` into the prompt and runs it through the exact same parser path the user would hit by typing it — no parallel code path, no escape hatch.

## How

| File | Change |
| --- | --- |
| `admin/app/components/shared/AppShell/AppShell.tsx` | Add `/cli` to primary nav |
| `admin/app/lib/cli/graph-view.ts` (new) | Pure selector `commandResultToGraphView(command, result) → GraphView \| null`. Five verb handlers; reuses `GraphNode`/`GraphEdge`/`GraphView` from the illuminate selector and the existing `Vertex`/`Edge` API types. Edge id `${tail}→${head}`; seed importance=1, others=normalised edge-weight sum (0.5 fallback). `get vertex` NotFound → empty view; `get edge` synthesises key-only endpoints; `scan vertices` marks the exact-match key as seed; `scan edges` marks the exact tail and dedupes via Map. |
| `admin/app/lib/cli/graph-view.test.ts` (new) | 18 unit tests covering every verb branch + the non-graph passthrough |
| `admin/app/components/cli/CliPage/CliPage.tsx` | `latestGraph` state, render `<IlluminateCanvas>` above scrollback when set, `onNodeClick` builds + runs `illuminate <key> 2 5` through the dispatcher. `submit` refactored into a thin wrapper over a new `runRaw(raw)` helper so click and Enter share one code path. |
| `admin/app/components/cli/CliPage/CliPage.module.css` | Split panel into `.canvasPanel` (45% min 240px, scrollable scrollback below) |
| `admin/tests/e2e/cli.spec.ts` | Seeds an edge alongside the vertices. Two new tests: canvas hidden → visible after `get vertex`; canvas persists after a subsequent `nonsense` parser-error so mutating/invalid verbs don't wipe context. |
| `admin/tests/e2e/landing.spec.ts` | Asserts the landing-page `Open CLI` tile |

The CSS uses `min-height: 0` on the body so Sigma.js can size itself inside the flex column — same trick as the Illuminate route.

## Verification (all green)

```text
admin/ bun test                      191 pass, 0 fail (added 18 selector tests)
admin/ bun run lint                  clean
admin/ bun run typecheck             clean
admin/ bun run format:check          All matched files use Prettier code style
admin/ bun run build                 ✓ built in 8.37s

admin/ bun run test:e2e --project=chromium tests/e2e/{landing,cli}.spec.ts
  9 passed (3.0s)
  - landing page renders with navigation and gateway connection  (Open CLI tile asserted)
  - get vertex renders the canvas panel                          (new)
  - illuminate persists across non-graph commands                (new)
  + the 6 pre-existing cli + landing tests
```

CI gates (Lint / Build & Test / Proto / govulncheck) will re-run on push.

## Notes / out of scope

- Click step/k pinned to `2 / 5` to match the placeholder text already shown in the prompt; the AppShell stays the single source of truth for that pair.
- `put` / `add` / `delete` / `exit` deliberately do **not** rebuild the canvas — they don't return graph payloads. This avoids a flicker-then-blank loop when an operator mutates state between explorations. Tests pin this behaviour.
- `.dockerignore` admin-image-fix from earlier in this thread is stashed (`wip-dockerignore-phase4` on `main`) and tracked separately; not required for this PR.
