### PR TITLE
fix(admin): parseFloatStrict accepts Go-style float literals (#434)

### DIFF
--- a/admin/app/lib/cli/verbs.test.ts
+++ b/admin/app/lib/cli/verbs.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for the verb parsers in `verbs.ts`.
+ *
+ * Scoped today to `parseFloatStrict` (#434) — the regression where the
+ * admin CLI rejected literal float forms (`1e3`, `.5`, `-.5`, `5.`,
+ * `1.5e-3`) that the Go REPL happily parses via `strconv.ParseFloat`.
+ *
+ * Also asserts that the `add edge` / `put edge` happy paths now accept
+ * those forms (since `weight` is the only place `parseFloatStrict` is
+ * invoked in production).
+ */
+import { describe, expect, test } from "bun:test";
+
+import { parseAdd, parsePut, parseFloatStrict } from "./verbs";
+
+describe("parseFloatStrict (#434 — Go strconv.ParseFloat parity)", () => {
+  test.each([
+    ["1e3", 1000],
+    ["1.5e-3", 0.0015],
+    ["0.5", 0.5],
+    [".5", 0.5],
+    ["-.5", -0.5],
+    ["5.", 5],
+    ["+2.5", 2.5],
+    ["-1.25", -1.25],
+    ["0", 0],
+    ["1E+2", 100],
+  ])("accepts %p → %p", (input, expected) => {
+    expect(parseFloatStrict(input)).toBe(expected);
+  });
+
+  test.each([
+    [""],
+    ["abc"],
+    ["abc1"],
+    ["1abc"],
+    ["nan"],
+    ["NaN"],
+    ["+nan"],
+    ["inf"],
+    ["+Inf"],
+    ["-Inf"],
+    ["infinity"],
+    ["-Infinity"],
+    [".."],
+    ["."],
+    ["1e"],
+    ["1.5e"],
+    ["e3"],
+    ["1.5.5"],
+  ])("rejects %p → null", (input) => {
+    expect(parseFloatStrict(input)).toBeNull();
+  });
+});
+
+describe("parseAdd / parsePut weight uses parseFloatStrict (#434)", () => {
+  test("add edge accepts 1e3 as weight", () => {
+    const r = parseAdd(["edge", "alice", "bob", "1e3"]);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.command).toEqual({
+        verb: "add",
+        objective: "edge",
+        tail: "alice",
+        head: "bob",
+        weight: 1000,
+        ttlSeconds: expect.any(Number),
+      });
+    }
+  });
+
+  test("put edge accepts .5 as weight", () => {
+    const r = parsePut(["edge", "alice", "bob", ".5"]);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect((r.command as { weight: number }).weight).toBe(0.5);
+    }
+  });
+
+  test("add edge rejects NaN as weight", () => {
+    const r = parseAdd(["edge", "alice", "bob", "NaN"]);
+    expect(r.ok).toBe(false);
+  });
+
+  test("add edge rejects garbled token", () => {
+    const r = parseAdd(["edge", "alice", "bob", "1abc"]);
+    expect(r.ok).toBe(false);
+  });
+});

--- a/admin/app/lib/cli/verbs.ts
+++ b/admin/app/lib/cli/verbs.ts
@@ -312,10 +312,31 @@ function parseInt10(s: string): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-function parseFloatStrict(s: string): number | null {
-  if (s === "" || !/^-?\d+(\.\d+)?$/.test(s)) {
-    return null;
-  }
+/**
+ * Parses a Go-style float literal — exposed for unit tests (#434).
+ *
+ * Mirrors `strconv.ParseFloat` as it's invoked from
+ * `cli/parser/parser.go` (used for edge weight + the put-vertex
+ * coercion cascade), with one deliberate divergence:
+ *
+ * - Go's ParseFloat accepts the IEEE special tokens
+ *   `NaN`, `Inf`, `+Inf`, `-Inf`, `Infinity`, `-Infinity` (any case).
+ *   We reject them up-front: an edge weight of NaN is a bug magnet and
+ *   nothing in lantern actually wants one.
+ *
+ * Otherwise we accept anything `Number.parseFloat` can finitely parse:
+ *   1e3, 1.5e-3, .5, -.5, 5., 0, -1.25, +2.5
+ *
+ * Returns null on parse failure (so the call site can surface its own
+ * "usage:" line).
+ */
+export function parseFloatStrict(s: string): number | null {
+  if (s === "") return null;
+  // Reject IEEE special tokens that ParseFloat would otherwise accept.
+  if (/^[+-]?(nan|inf|infinity)$/i.test(s)) return null;
+  // Structural guard so a stray "abc1" does not slip through
+  // Number.parseFloat's prefix-only parse.
+  if (!/^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(s)) return null;
   const n = Number.parseFloat(s);
   return Number.isFinite(n) ? n : null;
 }


### PR DESCRIPTION
## Summary

`admin/app/lib/cli/verbs.ts` `parseFloatStrict` used `/^-?\d+(\.\d+)?$/`, which rejected literal forms that the Go REPL accepts via `strconv.ParseFloat`. This affected the `weight` argument of `add edge` / `put edge` — power users copying weights from a notebook or log line got a usage error.

| Token | Go REPL | Admin (before) | Admin (after) |
|---|---|---|---|
| `1e3` | ✅ 1000 | ❌ rejected | ✅ 1000 |
| `1.5e-3` | ✅ 0.0015 | ❌ rejected | ✅ 0.0015 |
| `.5` | ✅ 0.5 | ❌ rejected | ✅ 0.5 |
| `-.5` | ✅ -0.5 | ❌ rejected | ✅ -0.5 |
| `5.` | ✅ 5 | ❌ rejected | ✅ 5 |

## Fix

New regex covers the same surface as Go's grammar (sign, digits, dot, exponent), then defers the final cast to `Number.parseFloat` + `Number.isFinite`:

```ts
if (s === "") return null;
if (/^[+-]?(nan|inf|infinity)$/i.test(s)) return null;
if (!/^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(s)) return null;
const n = Number.parseFloat(s);
return Number.isFinite(n) ? n : null;
```

## Deliberate divergence: IEEE special tokens

`strconv.ParseFloat` accepts `NaN`, `+Inf`, `-Inf`, `Infinity` (any case). We **reject** them up front — an edge weight of NaN is a bug magnet and nothing in lantern actually wants one. If a user ever needs the IEEE special set we can revisit; flagging it explicitly in the helper's JSDoc.

## What's new

- `admin/app/lib/cli/verbs.ts` — new `parseFloatStrict` (exported for testing). Behaviour-only change; signature unchanged.
- `admin/app/lib/cli/verbs.test.ts` (NEW, 32 cases) — full happy-path / sad-path table for `parseFloatStrict` + `add edge` / `put edge` weight integration.

## Verification

- `bun run test` — **240 pass / 0 fail** (was 208; +32 new cases).
- `bun run lint` — clean.
- `bun run typecheck` — clean.
- `bun run format:check` — clean.
- `bun run build` — clean.

Closes #434.