### PR TITLE
fix(cli,admin): quoting + case-insensitive tokenisation (#437, #438)

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,13 @@ illuminate <seed> <step> <k> [algorithm=none|mst|spt] [objective=min|max] \
 exit
 ```
 
+Tokens are whitespace-delimited and quotable — wrap a value in
+`"double quotes"` for C-style escapes (`\"`, `\\`, `\n`, `\r`, `\t`)
+or `'single quotes'` to carry the payload verbatim (no escapes). Verb
+and objective tokens are matched case-insensitively (`Get VERTEX foo`
+works); positional arguments preserve case (`put vertex CamelKey
+CamelValue` stores `CamelKey` / `CamelValue`).
+
 For everything outside that grammar — batch writes, prefix scans, bulk
 loads, gzip/TLS, typed values — use the one-shot subcommands:
 
@@ -830,6 +837,12 @@ delete edge   <tail:string> <head:string>
 illuminate <seed:string> <step:int> <k:int> [algorithm=none|mst|spt] \
            [objective=min|max] [weighting=raw|tfidf]
 ```
+
+Verb and objective (`vertex` / `edge` / `vertices` / `edges`) tokens are
+case-insensitive; arguments preserve case verbatim. Wrap any argument
+in `"double quotes"` (with `\"`, `\\`, `\n`, `\r`, `\t` escapes) or
+`'single quotes'` (verbatim, no escapes) to carry whitespace or other
+special characters — e.g. `put vertex greeting "hello world"`.
 
 Worked examples (with diagrams) live in the walkthrough below.
 

--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -332,6 +332,7 @@ function initialBanner(): ScrollbackEntry {
       "Lantern admin CLI (#411). Same grammar as `lantern repl`.",
       "Type a verb and Enter; arrow-up / arrow-down cycle history.",
       "Verbs: get | put | delete | add | scan | illuminate | exit",
+      'Quoting: "double" with C-style escapes (\\" \\\\ \\n \\r \\t); \'single\' verbatim. Verb/objective case-insensitive; args preserve case.',
     ].join("\n"),
   };
 }

--- a/admin/app/lib/cli/parser.ts
+++ b/admin/app/lib/cli/parser.ts
@@ -1,11 +1,15 @@
 /**
  * REPL/CLI verb parser entry. See `types.ts` for the public Command
- * shape and `tokenise.ts` for the whitespace-split tokeniser.
+ * shape and `tokenise.ts` for the quoting-aware tokeniser.
  *
  * The dispatch layout matches `cli/parser/validate.go`'s switch
  * statement so the error messages line up: the Go test under
  * `cli/parser/grammar_fixture_test.go` and this side's bun test
  * (`grammar.test.ts`) both consume `admin/test/cli-grammar/verbs.json`.
+ *
+ * Verb names are matched case-insensitively (mirrors the Go REPL's
+ * `strings.ToLower(verb)` dispatch). Arguments are passed through
+ * untouched — see #437.
  */
 
 import type { ParseResult } from "./types";
@@ -33,11 +37,15 @@ const VERBS = new Set([
 ]);
 
 export function parse(input: string): ParseResult {
-  const tokens = tokenise(input);
+  const r = tokenise(input);
+  if (!r.ok) {
+    return { ok: false, usage: r.error };
+  }
+  const tokens = r.tokens;
   if (tokens.length === 0) {
     return { ok: false, usage: VERB_LIST_USAGE };
   }
-  const verb = tokens[0];
+  const verb = tokens[0].toLowerCase();
   if (!VERBS.has(verb)) {
     return { ok: false, usage: VERB_LIST_USAGE };
   }

--- a/admin/app/lib/cli/tokenise.test.ts
+++ b/admin/app/lib/cli/tokenise.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Focused unit coverage for `tokenise` (#437 + #438).
+ *
+ * The shared fixture under `admin/test/cli-grammar/verbs.json` covers
+ * end-to-end parser agreement with the Go REPL. This file pins the
+ * tokeniser's own behaviour — case preservation, the quote-as-token-
+ * boundary rule, the C-style escape table, and the unterminated-
+ * literal error — without coupling to the verb-dispatch surface.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { tokenise } from "~/lib/cli/tokenise";
+
+function ok(input: string): string[] {
+  const r = tokenise(input);
+  if (!r.ok) {
+    throw new Error(`tokenise(${JSON.stringify(input)}) failed: ${r.error}`);
+  }
+  return r.tokens;
+}
+
+function err(input: string): string {
+  const r = tokenise(input);
+  if (r.ok) {
+    throw new Error(
+      `tokenise(${JSON.stringify(input)}) unexpectedly succeeded with ${JSON.stringify(
+        r.tokens,
+      )}`,
+    );
+  }
+  return r.error;
+}
+
+describe("tokenise — happy path (#437 case preservation)", () => {
+  test("empty input yields no tokens", () => {
+    expect(ok("")).toEqual([]);
+  });
+
+  test("whitespace-only input yields no tokens", () => {
+    expect(ok("   \t\n  ")).toEqual([]);
+  });
+
+  test("preserves case on every argument", () => {
+    expect(ok("Get VERTEX CamelKey")).toEqual(["Get", "VERTEX", "CamelKey"]);
+  });
+
+  test("does not lowercase illuminate keyword args", () => {
+    expect(ok("illuminate Alice 2 5 Algorithm=SPT")).toEqual([
+      "illuminate",
+      "Alice",
+      "2",
+      "5",
+      "Algorithm=SPT",
+    ]);
+  });
+
+  test("collapses any whitespace run between tokens", () => {
+    expect(ok("a   b\tc\nd")).toEqual(["a", "b", "c", "d"]);
+  });
+
+  test("trims leading and trailing whitespace", () => {
+    expect(ok("  put vertex k v  ")).toEqual(["put", "vertex", "k", "v"]);
+  });
+});
+
+describe("tokenise — bareword quoting policy (#438 boundary rule)", () => {
+  test("quotes embedded mid-bareword stay verbatim", () => {
+    expect(ok(`key=foo"bar`)).toEqual([`key=foo"bar`]);
+  });
+
+  test("single-quote mid-bareword stays verbatim", () => {
+    expect(ok("key=foo'bar")).toEqual(["key=foo'bar"]);
+  });
+
+  test("bareword may contain '=' for kwarg syntax", () => {
+    expect(ok("a=b c=d")).toEqual(["a=b", "c=d"]);
+  });
+});
+
+describe("tokenise — double-quoted strings (#438)", () => {
+  test("simple quoted string with whitespace", () => {
+    expect(ok('put vertex greeting "hello world"')).toEqual([
+      "put",
+      "vertex",
+      "greeting",
+      "hello world",
+    ]);
+  });
+
+  test("empty double-quoted string", () => {
+    expect(ok('a "" b')).toEqual(["a", "", "b"]);
+  });
+
+  test('escape: \\" → "', () => {
+    expect(ok('"say \\"hi\\""')).toEqual(['say "hi"']);
+  });
+
+  test("escape: \\\\ → \\", () => {
+    expect(ok('"a\\\\b"')).toEqual(["a\\b"]);
+  });
+
+  test("escape: \\n → newline, \\t → tab, \\r → CR", () => {
+    expect(ok('"a\\nb\\tc\\rd"')).toEqual(["a\nb\tc\rd"]);
+  });
+
+  test("multiple quoted tokens separated by whitespace", () => {
+    expect(ok('"foo" "bar baz"')).toEqual(["foo", "bar baz"]);
+  });
+
+  test("quoted token alongside bareword", () => {
+    expect(ok('cmd "with spaces" tail')).toEqual([
+      "cmd",
+      "with spaces",
+      "tail",
+    ]);
+  });
+});
+
+describe("tokenise — single-quoted strings (#438)", () => {
+  test("single-quoted carries embedded double-quote verbatim", () => {
+    expect(ok(`put vertex code 'console.log("hi")'`)).toEqual([
+      "put",
+      "vertex",
+      "code",
+      `console.log("hi")`,
+    ]);
+  });
+
+  test("single-quoted carries embedded backslash verbatim (no escapes)", () => {
+    expect(ok(`'C:\\Users\\hiroki'`)).toEqual([`C:\\Users\\hiroki`]);
+  });
+
+  test("empty single-quoted string", () => {
+    expect(ok("a '' b")).toEqual(["a", "", "b"]);
+  });
+});
+
+describe("tokenise — errors (#438)", () => {
+  test("unterminated double-quote", () => {
+    expect(err('"hello world')).toBe("error: unterminated string literal");
+  });
+
+  test("unterminated single-quote", () => {
+    expect(err("'hello world")).toBe("error: unterminated string literal");
+  });
+
+  test("trailing backslash inside double-quote is unterminated", () => {
+    expect(err('"foo\\')).toBe("error: unterminated string literal");
+  });
+
+  test("unknown backslash escape inside double-quote", () => {
+    expect(err('"bad \\q escape"')).toBe("error: invalid escape sequence \\q");
+  });
+});

--- a/admin/app/lib/cli/tokenise.ts
+++ b/admin/app/lib/cli/tokenise.ts
@@ -1,11 +1,136 @@
 /**
- * Tokenisation: lower-cased, whitespace-split. Matches
- * cli/parser/source.go's `NewSource(strings.ToLower(input))` shape.
+ * Tokenisation for the admin CLI grammar (#411).
+ *
+ * Mirrors `cli/parser/source.go` `NewSource`. The fixture under
+ * `admin/test/cli-grammar/verbs.json` is loaded by both this side
+ * and the Go side, so any drift in tokenisation surfaces on the
+ * next CI run.
+ *
+ * Grammar (#437 + #438):
+ *
+ *   token = bareword | double-quoted | single-quoted
+ *   bareword       = first char ∉ {whitespace, '"', "'"} ; consume until next whitespace.
+ *                    Quotes inside a bareword are kept verbatim (so `foo"bar` is one token).
+ *   double-quoted  = `"` … `"` with C-style escapes  `\"`, `\\`, `\n`, `\r`, `\t`.
+ *                    Any other backslash sequence is a parse error.
+ *   single-quoted  = `'` … `'`  with NO escapes (verbatim payload).
+ *
+ * Quoting is only special at the **start** of a token — once a bareword
+ * has begun, every subsequent non-whitespace character (including
+ * quotes) is part of that bareword. This keeps `key=foo"bar` working
+ * without escaping while still letting `put vertex k "hello world"`
+ * carry whitespace.
+ *
+ * The tokeniser does NOT lowercase. Case-folding for the verb and
+ * objective slots happens at the comparison site (parser.ts / verbs.ts),
+ * which matches the Go REPL: `service.Run` only ToLowers the dispatch
+ * tokens, never the arguments. This preserves user-supplied casing in
+ * vertex keys, edge endpoints, and illuminate seeds — see #437.
+ *
+ * Unterminated quotes return an error; the caller surfaces it as the
+ * parse-time usage line.
  */
-export function tokenise(input: string): string[] {
-  const trimmed = input.trim().toLowerCase();
-  if (trimmed === "") {
-    return [];
+
+export type TokeniseResult =
+  | { ok: true; tokens: string[] }
+  | { ok: false; error: string };
+
+const WHITESPACE = /\s/;
+
+export function tokenise(input: string): TokeniseResult {
+  const tokens: string[] = [];
+  let i = 0;
+  const n = input.length;
+  while (i < n) {
+    const ch = input[i];
+    if (WHITESPACE.test(ch)) {
+      i++;
+      continue;
+    }
+    if (ch === '"') {
+      const r = scanDoubleQuoted(input, i);
+      if (!r.ok) return r;
+      tokens.push(r.value);
+      i = r.next;
+      continue;
+    }
+    if (ch === "'") {
+      const r = scanSingleQuoted(input, i);
+      if (!r.ok) return r;
+      tokens.push(r.value);
+      i = r.next;
+      continue;
+    }
+    // bareword: consume up to next whitespace (quotes embedded mid-token
+    // stay verbatim, matching the issue's "only special at token
+    // boundaries" rule).
+    let j = i + 1;
+    while (j < n && !WHITESPACE.test(input[j])) j++;
+    tokens.push(input.slice(i, j));
+    i = j;
   }
-  return trimmed.split(/\s+/);
+  return { ok: true, tokens };
+}
+
+type ScanResult =
+  | { ok: true; value: string; next: number }
+  | { ok: false; error: string };
+
+function scanDoubleQuoted(input: string, start: number): ScanResult {
+  // input[start] === '"'
+  const out: string[] = [];
+  let i = start + 1;
+  const n = input.length;
+  while (i < n) {
+    const ch = input[i];
+    if (ch === '"') {
+      return { ok: true, value: out.join(""), next: i + 1 };
+    }
+    if (ch === "\\") {
+      if (i + 1 >= n) {
+        return { ok: false, error: "error: unterminated string literal" };
+      }
+      const esc = input[i + 1];
+      switch (esc) {
+        case '"':
+          out.push('"');
+          break;
+        case "\\":
+          out.push("\\");
+          break;
+        case "n":
+          out.push("\n");
+          break;
+        case "r":
+          out.push("\r");
+          break;
+        case "t":
+          out.push("\t");
+          break;
+        default:
+          return {
+            ok: false,
+            error: `error: invalid escape sequence \\${esc}`,
+          };
+      }
+      i += 2;
+      continue;
+    }
+    out.push(ch);
+    i++;
+  }
+  return { ok: false, error: "error: unterminated string literal" };
+}
+
+function scanSingleQuoted(input: string, start: number): ScanResult {
+  // input[start] === "'"
+  let i = start + 1;
+  const n = input.length;
+  while (i < n) {
+    if (input[i] === "'") {
+      return { ok: true, value: input.slice(start + 1, i), next: i + 1 };
+    }
+    i++;
+  }
+  return { ok: false, error: "error: unterminated string literal" };
 }

--- a/admin/app/lib/cli/verbs.ts
+++ b/admin/app/lib/cli/verbs.ts
@@ -19,7 +19,8 @@ const ILL_WEIGHTINGS = new Set<WeightingName>(["raw", "tfidf"]);
 
 export function parseGet(rest: string[]): ParseResult {
   const [obj, ...args] = rest;
-  if (obj === "vertex") {
+  const o = obj?.toLowerCase();
+  if (o === "vertex") {
     if (args.length !== 1 || args[0] === "") {
       return { ok: false, usage: "usage: get vertex <key: string>" };
     }
@@ -28,7 +29,7 @@ export function parseGet(rest: string[]): ParseResult {
       command: { verb: "get", objective: "vertex", key: args[0] },
     };
   }
-  if (obj === "edge") {
+  if (o === "edge") {
     if (args.length !== 2 || args[0] === "" || args[1] === "") {
       return {
         ok: false,
@@ -45,7 +46,8 @@ export function parseGet(rest: string[]): ParseResult {
 
 export function parsePut(rest: string[]): ParseResult {
   const [obj, ...args] = rest;
-  if (obj === "vertex") {
+  const o = obj?.toLowerCase();
+  if (o === "vertex") {
     if (args.length < 2 || args.length > 3) {
       return {
         ok: false,
@@ -74,7 +76,7 @@ export function parsePut(rest: string[]): ParseResult {
       },
     };
   }
-  if (obj === "edge") {
+  if (o === "edge") {
     if (args.length < 3 || args.length > 4) {
       return {
         ok: false,
@@ -117,7 +119,8 @@ export function parsePut(rest: string[]): ParseResult {
 
 export function parseDelete(rest: string[]): ParseResult {
   const [obj, ...args] = rest;
-  if (obj === "vertex") {
+  const o = obj?.toLowerCase();
+  if (o === "vertex") {
     if (args.length !== 1 || args[0] === "") {
       return { ok: false, usage: "usage: delete vertex <key: string>" };
     }
@@ -126,7 +129,7 @@ export function parseDelete(rest: string[]): ParseResult {
       command: { verb: "delete", objective: "vertex", key: args[0] },
     };
   }
-  if (obj === "edge") {
+  if (o === "edge") {
     if (args.length !== 2 || args[0] === "" || args[1] === "") {
       return {
         ok: false,
@@ -148,7 +151,7 @@ export function parseDelete(rest: string[]): ParseResult {
 
 export function parseAdd(rest: string[]): ParseResult {
   const [obj, ...args] = rest;
-  if (obj !== "edge") {
+  if (obj?.toLowerCase() !== "edge") {
     return { ok: false, usage: "usage: add edge ... " };
   }
   if (args.length < 3 || args.length > 4) {
@@ -191,7 +194,8 @@ export function parseAdd(rest: string[]): ParseResult {
 
 export function parseScan(rest: string[]): ParseResult {
   const [obj, ...args] = rest;
-  if (obj === "vertices") {
+  const o = obj?.toLowerCase();
+  if (o === "vertices") {
     if (args.length < 1 || args.length > 2 || args[0] === "") {
       return {
         ok: false,
@@ -215,7 +219,7 @@ export function parseScan(rest: string[]): ParseResult {
       },
     };
   }
-  if (obj === "edges") {
+  if (o === "edges") {
     if (args.length < 1 || args.length > 2 || args[0] === "") {
       return {
         ok: false,
@@ -269,8 +273,12 @@ export function parseIlluminate(rest: string[]): ParseResult {
     if (eq < 0) {
       return { ok: false, usage };
     }
-    const key = tok.slice(0, eq);
-    const value = tok.slice(eq + 1);
+    // The keyword KEY and the keyword VALUE for the three closed-set
+    // axes (algorithm / objective / weighting) are case-insensitive —
+    // they only ever take values from a small fixed enum the Go REPL
+    // also matches case-insensitively. See #437.
+    const key = tok.slice(0, eq).toLowerCase();
+    const value = tok.slice(eq + 1).toLowerCase();
     if (key === "algorithm") {
       if (!ILL_ALGORITHMS.has(value as AlgorithmName)) {
         return { ok: false, usage };

--- a/admin/test/cli-grammar/verbs.json
+++ b/admin/test/cli-grammar/verbs.json
@@ -26,6 +26,34 @@
     {
       "input": "illuminate alice 2 5 weighting=tfidf objective=max algorithm=spt",
       "comment": "keyword args may appear in any order"
+    },
+    {
+      "input": "Get VERTEX alice",
+      "comment": "#437: verb + objective case-insensitive"
+    },
+    {
+      "input": "PUT VERTEX CamelKey CamelValue",
+      "comment": "#437: verb + objective case-insensitive; key/value preserve case downstream"
+    },
+    {
+      "input": "illuminate alice 2 5 Algorithm=SPT Objective=Max Weighting=TFIDF",
+      "comment": "#437: illuminate keyword key + closed-set value case-insensitive"
+    },
+    {
+      "input": "put vertex greeting \"hello world\"",
+      "comment": "#438: double-quoted value carries whitespace"
+    },
+    {
+      "input": "put vertex code 'console.log(\"hi\")'",
+      "comment": "#438: single-quoted value carries embedded double-quotes verbatim"
+    },
+    {
+      "input": "put vertex path \"a\\nb\\tc\"",
+      "comment": "#438: C-style escapes inside double-quoted token"
+    },
+    {
+      "input": "get vertex \"key with spaces\"",
+      "comment": "#438: quoted key works in non-put positions too"
     }
   ],
   "invalid": [
@@ -76,6 +104,18 @@
     {
       "input": "illuminate alice 2 5 algorithm",
       "comment": "keyword without value"
+    },
+    {
+      "input": "put vertex greeting \"hello world",
+      "comment": "#438: unterminated double-quote is a parse error"
+    },
+    {
+      "input": "put vertex greeting 'hello world",
+      "comment": "#438: unterminated single-quote is a parse error"
+    },
+    {
+      "input": "put vertex greeting \"bad \\q escape\"",
+      "comment": "#438: unknown backslash escape inside double-quote is rejected"
     }
   ]
 }

--- a/cli/cmd/repl.go
+++ b/cli/cmd/repl.go
@@ -33,6 +33,20 @@ The REPL accepts whitespace-delimited verbs:
   illuminate <seed> <step> <k> [algorithm=none|mst|spt] [objective=min|max] [weighting=raw|tfidf]
   exit
 
+QUOTING (#438)
+  Any argument may be wrapped in "double quotes" — C-style escapes
+  \" \\ \n \r \t apply — or 'single quotes' (verbatim, no escapes).
+  Quotes are only special at token boundaries; embedded quotes inside
+  a bareword stay verbatim. Examples:
+    put vertex greeting "hello world"
+    put vertex code 'console.log("hi")'
+    put vertex path "C:\\Users\\hiroki"
+
+CASE (#437)
+  Verb and objective tokens are matched case-insensitively
+  ('Get VERTEX foo' works). Arguments preserve case verbatim
+  ('put vertex CamelKey CamelValue' stores CamelKey / CamelValue).
+
 The illuminate verb exposes the orthogonal axes introduced in #410:
 algorithm selects the post-traversal reduction, objective picks the
 direction (minimise/maximise), and weighting toggles RAW vs TF-IDF edge

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"errors"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -150,6 +151,13 @@ func Float32(s *Source) (float32, error) {
 	return float32(v), nil
 }
 
+// AnyOf returns the canonical lowercase choice that matches the next
+// token case-insensitively, or ErrNotFound. The returned value is
+// always one of the entries in `choices` (not the raw token), so
+// downstream switches can compare against the canonical form. This
+// mirrors the Go REPL's existing ToLower-on-dispatch convention and
+// keeps argument tokens (vertex keys, edge endpoints, illuminate
+// seeds) free of case mangling \u2014 see #437.
 func AnyOf(s *Source, choices []string) (string, error) {
 	defer s.Next()
 	str, err := s.Peek()
@@ -157,8 +165,8 @@ func AnyOf(s *Source, choices []string) (string, error) {
 		return "", err
 	}
 	for _, v := range choices {
-		if str == v {
-			return str, nil
+		if strings.EqualFold(str, v) {
+			return v, nil
 		}
 	}
 	return "", ErrNotFound
@@ -333,6 +341,11 @@ func IlluminateParam(s *Source) (*Illuminate, error) {
 		if !ok {
 			return nil, errors.New("illuminate: expected key=value token, got " + tok)
 		}
+		// Keyword KEY and the keyword VALUE for the three closed-set
+		// axes are case-insensitive — they only ever take values from
+		// a small fixed enum. See #437.
+		key = strings.ToLower(key)
+		value = strings.ToLower(value)
 		switch key {
 		case "algorithm":
 			if !contains(IlluminateAlgorithms, value) {

--- a/cli/parser/source.go
+++ b/cli/parser/source.go
@@ -2,11 +2,15 @@ package parser
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 )
 
 var (
 	ErrOutOfIndex = errors.New("out of index")
+	// ErrUnterminatedString is returned by NewSource when the input
+	// contains an unmatched single- or double-quote opener. See #438.
+	ErrUnterminatedString = errors.New("unterminated string literal")
 )
 
 type Source struct {
@@ -15,14 +19,127 @@ type Source struct {
 	length int
 }
 
-func NewSource(str string) *Source {
-	ss := strings.TrimSpace(str)
-	s := strings.Split(ss, " ")
-	return &Source{
-		s:      s,
-		pos:    0,
-		length: len(s),
+// NewSource tokenises the input into a Source. The grammar (#438):
+//
+//	token         = bareword | double-quoted | single-quoted
+//	bareword      = first char ∉ {whitespace,'"',"'"}, continues until next whitespace.
+//	                Quotes inside a bareword are kept verbatim.
+//	double-quoted = "..." with C-style escapes \", \\, \n, \r, \t.
+//	single-quoted = '...' verbatim (no escapes).
+//
+// Quoting is only special at the start of a token. Unterminated quotes
+// (or unknown backslash sequences inside a double-quoted token) return
+// ErrUnterminatedString or a parse error. On any error the returned
+// Source is still valid (empty token stream) so callers that ignore
+// the error do not deref a nil pointer.
+func NewSource(str string) (*Source, error) {
+	tokens, err := tokenise(str)
+	if err != nil {
+		return &Source{s: nil, pos: 0, length: 0}, err
 	}
+	return &Source{
+		s:      tokens,
+		pos:    0,
+		length: len(tokens),
+	}, nil
+}
+
+func tokenise(input string) ([]string, error) {
+	var out []string
+	i := 0
+	n := len(input)
+	for i < n {
+		ch := input[i]
+		if isSpace(ch) {
+			i++
+			continue
+		}
+		switch ch {
+		case '"':
+			value, next, err := scanDoubleQuoted(input, i)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, value)
+			i = next
+		case '\'':
+			value, next, err := scanSingleQuoted(input, i)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, value)
+			i = next
+		default:
+			// bareword: consume to next whitespace; quotes mid-token are
+			// part of the bareword.
+			j := i + 1
+			for j < n && !isSpace(input[j]) {
+				j++
+			}
+			out = append(out, input[i:j])
+			i = j
+		}
+	}
+	return out, nil
+}
+
+func isSpace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r', '\v', '\f':
+		return true
+	}
+	return false
+}
+
+func scanDoubleQuoted(input string, start int) (string, int, error) {
+	// input[start] == '"'
+	var sb strings.Builder
+	i := start + 1
+	n := len(input)
+	for i < n {
+		ch := input[i]
+		if ch == '"' {
+			return sb.String(), i + 1, nil
+		}
+		if ch == '\\' {
+			if i+1 >= n {
+				return "", 0, ErrUnterminatedString
+			}
+			esc := input[i+1]
+			switch esc {
+			case '"':
+				sb.WriteByte('"')
+			case '\\':
+				sb.WriteByte('\\')
+			case 'n':
+				sb.WriteByte('\n')
+			case 'r':
+				sb.WriteByte('\r')
+			case 't':
+				sb.WriteByte('\t')
+			default:
+				return "", 0, fmt.Errorf("invalid escape sequence \\%c", esc)
+			}
+			i += 2
+			continue
+		}
+		sb.WriteByte(ch)
+		i++
+	}
+	return "", 0, ErrUnterminatedString
+}
+
+func scanSingleQuoted(input string, start int) (string, int, error) {
+	// input[start] == '\''
+	i := start + 1
+	n := len(input)
+	for i < n {
+		if input[i] == '\'' {
+			return input[start+1 : i], i + 1, nil
+		}
+		i++
+	}
+	return "", 0, ErrUnterminatedString
 }
 
 func (s *Source) Next() {

--- a/cli/parser/source_test.go
+++ b/cli/parser/source_test.go
@@ -1,0 +1,103 @@
+package parser
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Focused tokeniser coverage for #437 + #438. The shared fixture under
+// admin/test/cli-grammar/verbs.json exercises the full validator
+// pipeline; this file pins the raw token stream so a future refactor
+// that subtly changes (say) case-handling or escape semantics turns
+// red here before propagating.
+
+func tokens(t *testing.T, in string) []string {
+	t.Helper()
+	s, err := NewSource(in)
+	if err != nil {
+		t.Fatalf("NewSource(%q) failed: %v", in, err)
+	}
+	return s.Slice()
+}
+
+func TestNewSource_Empty(t *testing.T) {
+	if got := tokens(t, ""); len(got) != 0 {
+		t.Errorf("empty input -> %#v, want []", got)
+	}
+	if got := tokens(t, "   \t\n  "); len(got) != 0 {
+		t.Errorf("whitespace-only -> %#v, want []", got)
+	}
+}
+
+func TestNewSource_CasePreservation(t *testing.T) {
+	got := tokens(t, "Get VERTEX CamelKey")
+	want := []string{"Get", "VERTEX", "CamelKey"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestNewSource_BarewordBoundary(t *testing.T) {
+	// Quotes embedded inside a bareword stay verbatim — they are only
+	// special at the *start* of a token.
+	got := tokens(t, `key=foo"bar a=b`)
+	want := []string{`key=foo"bar`, `a=b`}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestNewSource_DoubleQuoted(t *testing.T) {
+	cases := map[string][]string{
+		`put vertex k "hello world"`: {"put", "vertex", "k", "hello world"},
+		`"" trailing`:                {"", "trailing"},
+		`"say \"hi\""`:               {`say "hi"`},
+		`"a\\b"`:                     {`a\b`},
+		`"a\nb\tc\rd"`:               {"a\nb\tc\rd"},
+		`"foo" "bar baz"`:            {"foo", "bar baz"},
+	}
+	for in, want := range cases {
+		got := tokens(t, in)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("tokens(%q) = %#v, want %#v", in, got, want)
+		}
+	}
+}
+
+func TestNewSource_SingleQuoted(t *testing.T) {
+	cases := map[string][]string{
+		`put vertex code 'console.log("hi")'`: {"put", "vertex", "code", `console.log("hi")`},
+		`'C:\Users\hiroki'`:                   {`C:\Users\hiroki`},
+		`a '' b`:                              {"a", "", "b"},
+	}
+	for in, want := range cases {
+		got := tokens(t, in)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("tokens(%q) = %#v, want %#v", in, got, want)
+		}
+	}
+}
+
+func TestNewSource_UnterminatedQuote(t *testing.T) {
+	cases := []string{
+		`"hello world`,
+		`'hello world`,
+		`"foo\`,
+	}
+	for _, in := range cases {
+		_, err := NewSource(in)
+		if !errors.Is(err, ErrUnterminatedString) {
+			t.Errorf("NewSource(%q) err = %v, want ErrUnterminatedString", in, err)
+		}
+	}
+}
+
+func TestNewSource_InvalidEscape(t *testing.T) {
+	in := `"bad \q escape"`
+	_, err := NewSource(in)
+	if err == nil || !strings.Contains(err.Error(), "invalid escape sequence") {
+		t.Errorf("NewSource(%q) err = %v, want invalid escape error", in, err)
+	}
+}

--- a/cli/parser/validate.go
+++ b/cli/parser/validate.go
@@ -2,13 +2,16 @@ package parser
 
 import (
 	"errors"
-	"strings"
+	"fmt"
 )
 
 var ErrParse = errors.New("parse error")
 
 func Validate(input string) error {
-	s := NewSource(strings.ToLower(input))
+	s, err := NewSource(input)
+	if err != nil {
+		return fmt.Errorf("error: %w", err)
+	}
 	v, err := Verb(s)
 	if err != nil {
 		return errors.New("usage: { get | put | delete | add | scan | illuminate | exit } ... ")

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -39,7 +39,11 @@ func NewCLIService(client *client.Lantern) *CLIService {
 }
 
 func (c *CLIService) Run(ctx context.Context, str string) error {
-	s := parser.NewSource(str)
+	s, err := parser.NewSource(str)
+	if err != nil {
+		fmt.Printf("Error: %s\n", err)
+		return ErrInvalidVerb
+	}
 	verb, err := parser.Verb(s)
 	if err != nil {
 		fmt.Printf("Error: %s\n", err)


### PR DESCRIPTION
## Summary

Burn-down PR C — the paired tokeniser overhaul covering Issues #437 (case-insensitivity) and #438 (quoting). Touches both ends of the CLI surface (Go REPL + admin web CLI) and the shared grammar fixture.

## #437 — case-insensitive verbs + objectives

`get` / `put` / `delete` / `add` / `scan` / `illuminate` and the objective tokens (`vertex` / `edge` / `vertices` / `edges`) are now matched case-insensitively at both ends. The same applies to `illuminate`'s keyword **keys** (`algorithm` / `objective` / `weighting`) and their **closed-set values** (`none|mst|spt`, `min|max`, `raw|tfidf`).

Positional argument tokens (keys, edge endpoints, vertex **values**, scan prefixes, illuminate seeds) still preserve case verbatim — `put vertex CamelKey CamelValue` stores `CamelKey` / `CamelValue`, not `camelkey` / `camelvalue`.

Implementation choice: case-folding lives at the *comparison site*, not in the tokeniser. The TS verb dispatcher `.toLowerCase()`s the verb at lookup; `parseGet`/`parsePut`/etc lower the objective; `parseIlluminate` lowers the kwarg key and value. On the Go side, `AnyOf` now uses `strings.EqualFold` and returns the **canonical** lowercase choice (so downstream switches keep working), and `IlluminateParam` lowercases the kwarg key + value after `splitKeyValue`.

## #438 — quoted argument tokens

Any argument may now be wrapped in:

- **`"double quotes"`** — C-style escapes apply: `\\"` `\\\\` `\\n` `\\r` `\\t`. An unknown escape (`\\q`) is an explicit parse error.
- **`'single quotes'`** — verbatim, no escapes. Carries embedded double-quotes (`'console.log(\"hi\")'`) and backslashes (`'C:\\Users\\hiroki'`) untouched.

Quotes are only special at the **start** of a token; an embedded quote inside a bareword stays verbatim (`key=foo\"bar` is one token). Unterminated literals at EOF (`\"hello world`) are an explicit parse error instead of silent token corruption.

## Implementation

Both ends share the same scanner shape: a hand-written `tokenise` helper that returns either a token slice or a typed error. The Go signature changed from `NewSource(string) *Source` to `NewSource(string) (*Source, error)` — the two call sites (`cli/parser/validate.go`, `cli/service/service.go`) propagate the error.

```
cli/parser/source.go         - hand-written scanner; new
                               ErrUnterminatedString; NewSource
                               returns (*Source, error).
cli/parser/parser.go         - AnyOf uses strings.EqualFold and
                               returns the canonical lowercase
                               choice; IlluminateParam lowercases
                               keyword key + value.
cli/parser/validate.go       - propagate NewSource error.
cli/service/service.go       - propagate NewSource error.
cli/parser/source_test.go    - 7 focused Go tokeniser tests.
cli/cmd/repl.go              - REPL --help documents quoting + case.
admin/app/lib/cli/tokenise.ts        - same scanner; exports
                                       TokeniseResult.
admin/app/lib/cli/parser.ts          - consume TokeniseResult;
                                       lower the verb at lookup.
admin/app/lib/cli/verbs.ts           - lowercase objective + the
                                       illuminate kwarg key/value
                                       at each comparison site.
admin/app/lib/cli/tokenise.test.ts   - 23 new unit tests pinning
                                       the scanner.
admin/app/components/cli/CliPage     - banner mentions quoting +
                                       case rules.
admin/test/cli-grammar/verbs.json    - 7 new valid + 3 new invalid
                                       fixture rows exercised by
                                       BOTH Go and TS parsers.
README.md                            - CLI cheatsheet documents
                                       quoting + case rules.
```

## Verification

- `go test -count=1 ./cli/...` — all green; `TestNewSource_*` covers empty/whitespace, case preservation, bareword boundary, double-quoted (incl. all 5 escapes), single-quoted (verbatim), unterminated (3 shapes), invalid escape.
- `bun run test` — **273 pass / 0 fail** (up from 250); the new `tokenise.test.ts` adds 23 cases.
- The shared fixture `admin/test/cli-grammar/verbs.json` runs through *both* parsers, so any case/quoting drift between Go and TS fails CI immediately.
- `bun run lint` / `typecheck` / `format:check` / `build` all clean.
- `go build ./...` clean across the workspace.

## Cross-cutting findings

None new — the round-trip-surprise cluster (#429/#430/#432) from PR A is unaffected; `parseFloatStrict` from PR B is unaffected.

Closes #437
Closes #438