### PR TITLE
fix(compose): pin host ports via explicit lantern-0/1/2 services (#435)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,12 @@ in practice means it doesn't.
   `--no-verify`. One PR per issue from clean main.
 - Merge with `gh pr merge <n> --squash --delete-branch`, then
   `git checkout main && git pull --rebase`.
+- **Multi-issue `Closes` syntax.** GitHub only auto-links the *first* issue
+  on a comma-separated line. `Closes #1, #2, #3` closes `#1` and leaves
+  `#2`/`#3` orphaned after merge. Use either one keyword per issue
+  (`Closes #1, closes #2, closes #3`) or one keyword per line. PR #441
+  shipped fixes for #428/#429/#430/#432 but only #428 closed
+  automatically.
 
 ### After editing `.proto`
 

--- a/README.md
+++ b/README.md
@@ -245,15 +245,19 @@ A 3-replica HA topology for local experiments lives in
 ```shell
 cd deploy/compose
 docker compose up -d
-docker compose up -d --scale lantern=5    # reconciles in ≤1 discovery tick
 ```
 
-Each replica is published on its own host port (`6380`, `6381`, …) so
-a reverse-proxy sidecar (Caddy / Traefik / envoy with a DNS-resolved
-upstream pool) or DNS round-robin from the client can fan reads across
-them, while Prometheus on `:9091` scrapes every pod via DNS SD. See
-[`deploy/compose/README.md`](deploy/compose/README.md) for the client
-LB options.
+The canonical compose declares three explicit `lantern-{0,1,2}` services
+with pinned host ports (`6380`, `6381`, `6382`) since
+[#435](https://github.com/anaregdesign/lantern/issues/435), so the admin
+SPA's default gateway (`http://localhost:6380`) and any direct curls
+land on a stable replica across `up`/`down` cycles. All three join the
+same `lantern` DNS alias, so peer discovery and Compose-side round-robin
+still work unchanged. Prometheus on `:9091` scrapes every replica via
+DNS SD. See [`deploy/compose/README.md`](deploy/compose/README.md) for
+the full port table and client LB options, and the
+[Helm chart](deploy/helm/lantern/) when you need more than three
+replicas.
 
 ### Run on serverless container PaaS
 

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -6,19 +6,37 @@ single-host HA experiments.
 
 ## Topology
 
-- 3 × `lantern` replicas (`deploy.replicas: 3`), each on host ports
-  `6380`, `6381`, `6382`.
-- Compose's embedded DNS resolves the service name `lantern` to one A
-  per running replica. Each lantern container's peer pump (#190)
-  resolves that name, filters its own IP via `LocalIPSet()`, and opens
-  replication streams to the other peers.
+- 3 × explicit lantern services — `lantern-0`, `lantern-1`, `lantern-2` —
+  on host ports **`6380`**, **`6381`**, **`6382`** respectively. Each
+  service is its own entry (no `deploy.replicas`) so the host-port
+  mapping is pinned across restarts; this is what `#435` fixes. The
+  admin SPA's default gateway `http://localhost:6380` therefore keeps
+  working out of the box.
+- All three services share the network alias `lantern`. Compose's
+  embedded DNS resolves `lantern` to one A per healthy replica, so the
+  peer pump (#190) — and any SDK / MCP container dialing
+  `http://lantern:6380` — continues to round-robin across the live
+  replicas without knowing about the per-service names.
 - 1 × `admin` browser SPA (`ghcr.io/anaregdesign/lantern-admin`)
   on host port `8080`. Pure SPA host (Caddy on `:8080`), no reverse
-  proxy — the browser talks to the gateway directly, so the `lantern`
+  proxy — the browser talks to the gateway directly, so each lantern
   service has `LANTERN_CORS_ALLOWED_ORIGINS=http://localhost:8080`
   baked in.
-- `prometheus` scrapes via `dns_sd_configs` so it picks up every
-  replica automatically (no static targets file to maintain).
+- `prometheus` scrapes via `dns_sd_configs` against the `lantern`
+  alias, so it picks up every replica automatically (no static targets
+  file to maintain).
+
+| service     | host port → container | compose container name              |
+|-------------|-----------------------|-------------------------------------|
+| `lantern-0` | `6380` → `6380`       | `${COMPOSE_PROJECT_NAME}-lantern-0-1` |
+| `lantern-1` | `6381` → `6380`       | `${COMPOSE_PROJECT_NAME}-lantern-1-1` |
+| `lantern-2` | `6382` → `6380`       | `${COMPOSE_PROJECT_NAME}-lantern-2-1` |
+
+Use the service name (`lantern-0`, ...) when invoking
+`docker compose` subcommands; use the full container name only when
+shelling out to `docker` directly (e.g. `docker inspect`,
+`docker logs --details`). The project name defaults to the directory
+basename (`compose`).
 
 ## Run
 
@@ -28,20 +46,19 @@ docker compose up -d
 docker compose ps
 ```
 
-Scale up or down without restarting; each lantern container reconciles
-within one discovery tick (default `LANTERN_PEER_DISCOVERY_INTERVAL_MS=10000`):
-
-```shell
-docker compose up -d --scale lantern=5
-# Logs on any one container should show 4 active peers within ~10s.
-docker compose logs --tail=20 lantern
-```
-
 Tear down:
 
 ```shell
 docker compose down -v
 ```
+
+> `docker compose up -d --scale lantern=N` no longer applies — the
+> canonical compose uses three explicit services so the host-port
+> mapping stays stable across restarts (#435). For >3 replicas, add a
+> `lantern-3` block (host port `6383`, etc.) using the
+> `x-lantern-common` YAML anchor, or switch to the Helm chart in
+> [`../helm/lantern/`](../helm/lantern/) which has no host-port
+> constraint.
 
 ## Client access
 
@@ -93,7 +110,7 @@ networks, or put your own ingress-level auth proxy in front.
 
 ```shell
 # Each replica should log "peer_discovery" lines with the other 2 IPs.
-docker compose logs lantern | grep peer_discovery
+docker compose logs lantern-0 lantern-1 lantern-2 | grep peer_discovery
 
 # Prometheus (http://localhost:9091):
 #   lantern_replication_peer_up         — 1 gauge per active peer link
@@ -102,14 +119,15 @@ docker compose logs lantern | grep peer_discovery
 
 ## Single-instance fallback
 
-For non-HA development just override the replicas to 1:
+For non-HA development bring up only one replica:
 
 ```shell
-docker compose up -d --scale lantern=1
+docker compose up -d lantern-0 admin prometheus
 ```
 
-`LANTERN_PEER_DNS_NAME=lantern` still resolves — to a single A record
-which `LocalIPSet()` filters as self, so the pump becomes a no-op.
+`LANTERN_PEER_DNS_NAME=lantern` still resolves — to the single A
+record for `lantern-0`, which `LocalIPSet()` filters as self, so the
+pump becomes a no-op.
 
 ## Cross-references
 

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -1,69 +1,97 @@
 # Docker Compose: HA topology (3-replica peer-discovery cluster).
 #
 # Mirrors the Helm chart's Tier-A topology for local development and
-# single-host HA experiments. Uses Compose's embedded DNS: the service
-# name `lantern` resolves to one A per replica, and the lantern peer
-# pump (#190) filters its own IP.
+# single-host HA experiments. Each replica is its own service
+# (`lantern-0`, `lantern-1`, `lantern-2`) with a pinned host port
+# (`6380`, `6381`, `6382` respectively), so the admin SPA's default
+# gateway URL (`http://localhost:6380`) keeps working across restarts
+# (#435). All three share the `lantern` network alias, so Compose
+# embedded DNS still resolves `lantern` to one A per healthy replica
+# — the lantern peer pump (#190) and lantern-mcp / prometheus / SDK
+# DNS round-robin continue to work unchanged.
 #
-# Clients use the Go SDK's round-robin LB (#189):
-#   c, _ := lantern.NewLanternWithEndpoints(
-#       []string{"localhost:6380", "localhost:6381", "localhost:6382"})
+# Clients pick one of:
+#   c, _ := lantern.NewLantern("http://lantern:6380")  // DNS round-robin
+#   c, _ := lantern.NewLantern("http://localhost:6380") // single replica
 # There is intentionally no client-side LB sidecar in this example —
 # picking one would push opinions that don't belong in a quickstart.
 #
 # Usage:
 #   cd deploy/compose
 #   docker compose up -d
-#   docker compose up -d --scale lantern=5     # each pod reconciles in ≤1 tick
 #   docker compose down -v
+#
+# To scale beyond three replicas, edit the file (each replica needs
+# its own service + host port) or use the Helm chart. The previous
+# `--scale lantern=N` workflow is gone — it depended on Compose's
+# port-range allocator, which is what #435 fixes.
 #
 # Override the image:
 #   LANTERN_IMAGE=ghcr.io/anaregdesign/lantern:v0.7.1 docker compose up -d
 
+# Shared lantern config. Each replica differs only in the published
+# host port; container naming is left to Compose so the canonical
+# stack and the testbed/bench overlay can run side-by-side without
+# colliding on globally-scoped container names.
+x-lantern-common: &lantern-common
+  image: ${LANTERN_IMAGE:-lantern:local}
+  environment:
+    LANTERN_PORT: "6380"
+    LANTERN_METRICS_ADDR: ":9090"
+    LANTERN_DEFAULT_TTL_SECONDS: "3600"
+    LANTERN_LOG_FORMAT: "json"
+    LANTERN_LOG_LEVEL: "info"
+    # Peer discovery (#190): resolve the shared `lantern` alias via
+    # Compose DNS. All three services join the default network with
+    # this alias, so the pump sees one A per healthy peer.
+    LANTERN_PEER_DISCOVERY: "dns"
+    LANTERN_PEER_DNS_NAME: "lantern"
+    LANTERN_PEER_DEFAULT_PORT: "6380"
+    LANTERN_PEER_DISCOVERY_INTERVAL_MS: "10000"
+    # Readiness gating (#188).
+    LANTERN_MAX_REPLICATION_LAG: "10000"
+    # Allow the admin SPA to call this listener from the browser.
+    # Lantern serves Connect / gRPC / gRPC-Web on the same h2c socket,
+    # and the admin container is a pure SPA host (no reverse proxy),
+    # so CORS must allow the admin origin.
+    LANTERN_CORS_ALLOWED_ORIGINS: "http://localhost:8080"
+  networks:
+    default:
+      aliases:
+        - lantern
+  healthcheck:
+    test: ["CMD", "wget", "-qO-", "http://localhost:9090/readyz"]
+    interval: 5s
+    timeout: 2s
+    retries: 12
+    start_period: 10s
+
 services:
-  lantern:
-    image: ${LANTERN_IMAGE:-lantern:local}
-    deploy:
-      replicas: 3
-    # Publish a port range so each replica is reachable on its own host
-    # port (6380, 6381, 6382, ...) — clients can enumerate them all for
-    # SDK round-robin. Compose assigns the next free port to each replica.
+  lantern-0:
+    <<: *lantern-common
     ports:
-      - target: 6380
-        published: "6380-6389"
-        protocol: tcp
-        mode: host
-    environment:
-      LANTERN_PORT: "6380"
-      LANTERN_METRICS_ADDR: ":9090"
-      LANTERN_DEFAULT_TTL_SECONDS: "3600"
-      LANTERN_LOG_FORMAT: "json"
-      LANTERN_LOG_LEVEL: "info"
-      # Peer discovery (#190): resolve the service name via Compose DNS.
-      LANTERN_PEER_DISCOVERY: "dns"
-      LANTERN_PEER_DNS_NAME: "lantern"
-      LANTERN_PEER_DEFAULT_PORT: "6380"
-      LANTERN_PEER_DISCOVERY_INTERVAL_MS: "10000"
-      # Readiness gating (#188).
-      LANTERN_MAX_REPLICATION_LAG: "10000"
-      # Allow the admin SPA to call this listener from the browser.
-      # Lantern serves Connect / gRPC / gRPC-Web on the same h2c socket,
-      # and the admin container is a pure SPA host (no reverse proxy),
-      # so CORS must allow the admin origin.
-      LANTERN_CORS_ALLOWED_ORIGINS: "http://localhost:8080"
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:9090/readyz"]
-      interval: 5s
-      timeout: 2s
-      retries: 12
-      start_period: 10s
+      - "6380:6380"
+
+  lantern-1:
+    <<: *lantern-common
+    ports:
+      - "6381:6380"
+
+  lantern-2:
+    <<: *lantern-common
+    ports:
+      - "6382:6380"
 
   admin:
     image: ${LANTERN_ADMIN_IMAGE:-ghcr.io/anaregdesign/lantern-admin:latest}
     ports:
       - "8080:8080"
     depends_on:
-      lantern:
+      lantern-0:
+        condition: service_healthy
+      lantern-1:
+        condition: service_healthy
+      lantern-2:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8080/healthz"]
@@ -87,11 +115,16 @@ services:
     stdin_open: true
     tty: false
     environment:
-      # Compose DNS round-robins the `lantern` service across replicas.
+      # Compose DNS round-robins the `lantern` alias across the three
+      # lantern-N services.
       LANTERN_ADDR: "http://lantern:6380"
       LANTERN_MCP_PING_TIMEOUT: "5s"
     depends_on:
-      lantern:
+      lantern-0:
+        condition: service_healthy
+      lantern-1:
+        condition: service_healthy
+      lantern-2:
         condition: service_healthy
 
   prometheus:
@@ -104,5 +137,9 @@ services:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.retention.time=1h"
     depends_on:
-      lantern:
+      lantern-0:
+        condition: service_healthy
+      lantern-1:
+        condition: service_healthy
+      lantern-2:
         condition: service_healthy

--- a/docs/ha-runbook.md
+++ b/docs/ha-runbook.md
@@ -22,7 +22,7 @@ Start here. Pick a row, then jump to the corresponding section.
 | Platform | HA (multi-instance) | Single-instance | Section |
 |---|---|---|---|
 | Kubernetes (StatefulSet + headless Service) | ✅ canonical | ✅ | [§3.1](#31-kubernetes) |
-| Docker Compose (`deploy.replicas` + service DNS) | ✅ | ✅ | [§3.2](#32-docker-compose) |
+| Docker Compose (explicit `lantern-N` services + DNS alias) | ✅ | ✅ | [§3.2](#32-docker-compose) |
 | HashiCorp Nomad + Consul DNS | ✅ user-configured | ✅ | [§3.3](#33-nomad) |
 | Plain VMs / bare metal | ✅ static or DNS | ✅ | [§3.4](#34-plain-vms) |
 | Google Cloud Run | ❌ HA not supported | ✅ | [§3.5](#35-serverless-paas-single-instance-only) |
@@ -130,16 +130,21 @@ and don't open an HTTP/2 stream on every check.
 
 ### 3.2 Docker Compose
 
-**Example at [`deploy/compose/`](../deploy/compose/).** The compose file
-scales the `lantern` service to 3 replicas, exposes a host port
-*range* (6380–6389) so each replica gets a unique host port, and uses
-Compose's embedded DNS for `LANTERN_PEER_DNS_NAME=lantern`.
+**Example at [`deploy/compose/`](../deploy/compose/).** Since
+[#435](https://github.com/anaregdesign/lantern/issues/435) the compose
+file declares three explicit `lantern-{0,1,2}` services with pinned
+host ports (`6380`, `6381`, `6382`); all three share the `lantern`
+network alias so `LANTERN_PEER_DNS_NAME=lantern` round-robins across
+them via Compose's embedded DNS.
 
 ```sh
 cd deploy/compose
 docker compose up -d
-docker compose scale lantern=5   # all 5 join the cluster on next tick
 ```
+
+Scaling past three replicas via `docker compose --scale` no longer
+applies — the canonical compose is a fixed 3-node topology. For larger
+clusters, use the [Helm chart](../deploy/helm/lantern/).
 
 There is **no nginx / haproxy sidecar**. OSS nginx's `resolve` keyword
 on `upstream server` is an nginx-plus feature, so a generic Compose
@@ -147,11 +152,12 @@ recipe would need stream-block trickery to re-resolve DNS. Two pragmatic
 answers:
 
 1. **Reverse proxy / sidecar fan-out.** Drop in Caddy, Traefik, or
-   envoy with a `*.lantern` DNS-resolved upstream pool. Each of these
+   envoy with a `lantern` DNS-resolved upstream pool. Each of these
    re-resolves DNS A records on a cadence (Caddy: `dynamic dns`;
-   Traefik: Docker provider; envoy: `STRICT_DNS` cluster), so scaling
-   `lantern=N` is picked up without a config push. The proxy speaks
-   h2c upstream → Lantern's single port, terminating TLS at the edge.
+   Traefik: Docker provider; envoy: `STRICT_DNS` cluster), so adding or
+   removing replicas is picked up without a config push. The proxy
+   speaks h2c upstream → Lantern's single port, terminating TLS at the
+   edge.
 2. **DNS round-robin from the client.** Point the SDK at a host name
    that resolves to all backends; the OS resolver hands the addresses
    to `net/http`'s `http2.Transport` in shuffled order, and any backend
@@ -171,10 +177,10 @@ patterns above instead. For Swarm mode, use `tasks.lantern` instead
 of `lantern` for the discovery DNS name on the server side; clients
 still target a single proxy URL.
 
-**Single-instance on Compose.** `docker compose up --scale lantern=1`
-plus omitting `LANTERN_PEER_DISCOVERY` puts the service in single-
-instance mode (§2.1). Useful for local dev against the same compose
-file you'd run in HA.
+**Single-instance on Compose.** `docker compose up -d lantern-0 admin
+prometheus` plus omitting `LANTERN_PEER_DISCOVERY` (override the env
+locally) puts the service in single-instance mode (§2.1). Useful for
+local dev against the same compose file you'd run in HA.
 
 ### 3.3 Nomad
 
@@ -418,7 +424,10 @@ this runbook.
 - `/readyz` flips to 200 once lag-to-all-peers is below the threshold.
 
 No operator action required. Just `kubectl scale statefulset lantern
---replicas=N` or `docker compose scale lantern=N`.
+--replicas=N`. On Docker Compose the canonical topology is a fixed
+three-node cluster (`lantern-{0,1,2}`) since
+[#435](https://github.com/anaregdesign/lantern/issues/435); use the
+Helm chart when you need to scale past three.
 
 ### 8.2 Scale down (remove a pod)
 

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -497,8 +497,12 @@ services:
       LANTERN_PEER_DEFAULT_PORT: "50051"
 ```
 
-`docker compose scale lantern=N` triggers Compose's embedded DNS to
-add/remove A records; the pump converges on the next tick.
+Since [#435](https://github.com/anaregdesign/lantern/issues/435) the
+canonical compose declares three explicit `lantern-{0,1,2}` services
+sharing the `lantern` network alias, so Compose's embedded DNS resolves
+that alias to all three replica IPs and the pump picks up new entries
+on the next tick. To run with more than three replicas, switch to the
+Helm chart.
 
 ## 10. Partition & split-brain analysis
 
@@ -539,7 +543,7 @@ carries the full per-platform instructions; this is the summary.
 | Platform | HA mode | Single-instance | Notes |
 |---|---|---|---|
 | Kubernetes (StatefulSet + headless Service) | ✅ canonical | ✅ | Helm chart in `deploy/helm/lantern/` (#191). |
-| Docker Compose (`deploy.replicas` + service DNS) | ✅ | ✅ | Example in `deploy/compose/` (#191). Best for local dev / single-host. |
+| Docker Compose (explicit `lantern-N` services + shared DNS alias) | ✅ | ✅ | Example in `deploy/compose/` (#191, #435). Best for local dev / single-host. |
 | Nomad + Consul DNS | ✅ | ✅ | User-configured; same `LANTERN_PEER_DISCOVERY=dns` works. |
 | Plain VMs / bare metal | ✅ | ✅ | Static `LANTERN_PEERS` CSV or DNS round-robin. |
 | Google Cloud Run | ❌ HA not supported | ✅ | Instance-level addressing hidden; long-lived peer streams incompatible with the request-scoped lifecycle. Use as a fast in-memory KVS with CDC via `Subscribe`. |

--- a/testbed/bench/compose.override.yml
+++ b/testbed/bench/compose.override.yml
@@ -11,26 +11,37 @@
 #     -f testbed/bench/compose.override.yml \
 #     up -d
 #
-# The metrics port (9090 inside the container) is published on a per-replica
-# host range 9390-9392 so each replica is independently scrape-able by the
-# harness's pprof.sh and direct /metrics curls.
+# Since #435 the canonical compose declares three explicit lantern-{0,1,2}
+# services with pinned host ports (6380-6382). This override extends each
+# one with bench-only env + an explicit per-replica metrics port mapping
+# (9390/9391/9392) so the harness's pprof.sh and direct /metrics curls
+# address each replica deterministically.
+
+x-lantern-bench-env: &lantern-bench-env
+  LANTERN_PPROF_ENABLED: "true"
+  # Sample 1/N events. Non-zero values are required for /debug/pprof/mutex
+  # and /debug/pprof/block to return useful data. Cheap at these rates.
+  LANTERN_MUTEX_PROFILE_FRACTION: "100"
+  LANTERN_BLOCK_PROFILE_RATE: "10000"
+  # Shrink the mutation-log ring from the prod default (100k) to a bench
+  # size. At 5k RPS for 5min the steady-state phase generates ~1.5M ops,
+  # so a 10k ring overflows ~150x — exercising gap-fill / snapshot paths
+  # while keeping legitimate ring retention well under the leak_gate
+  # heap budget. See issue #254.
+  LANTERN_MUTATION_LOG_CAPACITY: "10000"
 
 services:
-  lantern:
-    environment:
-      LANTERN_PPROF_ENABLED: "true"
-      # Sample 1/N events. Non-zero values are required for /debug/pprof/mutex
-      # and /debug/pprof/block to return useful data. Cheap at these rates.
-      LANTERN_MUTEX_PROFILE_FRACTION: "100"
-      LANTERN_BLOCK_PROFILE_RATE: "10000"
-      # Shrink the mutation-log ring from the prod default (100k) to a bench
-      # size. At 5k RPS for 5min the steady-state phase generates ~1.5M ops,
-      # so a 10k ring overflows ~150x — exercising gap-fill / snapshot paths
-      # while keeping legitimate ring retention well under the leak_gate
-      # heap budget. See issue #254.
-      LANTERN_MUTATION_LOG_CAPACITY: "10000"
+  lantern-0:
+    environment: *lantern-bench-env
     ports:
-      - target: 9090
-        published: "9390-9392"
-        protocol: tcp
-        mode: host
+      - "9390:9090"
+
+  lantern-1:
+    environment: *lantern-bench-env
+    ports:
+      - "9391:9090"
+
+  lantern-2:
+    environment: *lantern-bench-env
+    ports:
+      - "9392:9090"

--- a/testbed/bench/release.sh
+++ b/testbed/bench/release.sh
@@ -85,7 +85,9 @@ export LANTERN_IMAGE="$img"
 
 # Bring up the shared cluster once.
 log "compose up (project=$COMPOSE_PROJECT_NAME, image=$img)"
-docker compose "${COMPOSE_FILES[@]}" up -d --scale lantern=3 --wait
+# Since #435 the canonical compose declares three explicit lantern-{0,1,2}
+# services, so `--scale lantern=3` is no longer needed.
+docker compose "${COMPOSE_FILES[@]}" up -d --wait
 
 cleanup() {
   log "compose down"

--- a/testbed/bench/run.sh
+++ b/testbed/bench/run.sh
@@ -75,21 +75,24 @@ endpoints=( $(yq -r '.target.endpoints[]' "$SCENARIO_FILE") )
 # ----- compose up ------------------------------------------------------------
 if [[ "${SKIP_UP:-0}" != "1" ]]; then
   log "compose up (project=$COMPOSE_PROJECT_NAME)"
-  docker compose "${COMPOSE_FILES[@]}" up -d --scale lantern=3 --wait
+  # Since #435 the canonical compose declares three explicit lantern-{0,1,2}
+  # services with pinned host ports, so `--scale lantern=3` is no longer
+  # needed (and would in fact fail — there is no `lantern` service).
+  docker compose "${COMPOSE_FILES[@]}" up -d --wait
 fi
 
 # ----- discover actual published ports ---------------------------------------
-# Compose's port-range allocation (`6380-6389`, `9390-9392`) is not stable
-# across runs: when a previous bench leaves entries in the daemon's port
-# bookkeeping, the next `up` skips them and we end up on e.g. 6386/6387/6388.
-# Query the live containers and rewrite REPLICA_*_PORTS + scenario endpoints
-# accordingly so the harness works regardless of what Compose assigned.
+# Ports are pinned in the canonical compose (6380-6382 / 9390-9392) since
+# #435, but we keep the discovery step as a belt-and-suspenders check that
+# the harness keeps working if a future override hops back to dynamic
+# ranges. Query the live containers and rewrite REPLICA_*_PORTS + scenario
+# endpoints from the live mapping.
 discover_ports() {
   local ps_json grpc metrics
   ps_json="$(docker compose "${COMPOSE_FILES[@]}" ps --format json 2>/dev/null)"
-  # Sort by replica name so lantern-1/2/3 map to deterministic slots.
-  grpc=( $(jq -rs 'sort_by(.Name) | .[] | select(.Name | test("lantern-[0-9]+$")) | .Publishers[] | select(.TargetPort==6380 and .URL=="0.0.0.0") | .PublishedPort' <<<"$ps_json") )
-  metrics=( $(jq -rs 'sort_by(.Name) | .[] | select(.Name | test("lantern-[0-9]+$")) | .Publishers[] | select(.TargetPort==9090 and .URL=="0.0.0.0") | .PublishedPort' <<<"$ps_json") )
+  # Sort by service name so lantern-0/1/2 map to deterministic slots.
+  grpc=( $(jq -rs 'sort_by(.Service) | .[] | select(.Service | test("^lantern-[0-9]+$")) | .Publishers[] | select(.TargetPort==6380 and .URL=="0.0.0.0") | .PublishedPort' <<<"$ps_json") )
+  metrics=( $(jq -rs 'sort_by(.Service) | .[] | select(.Service | test("^lantern-[0-9]+$")) | .Publishers[] | select(.TargetPort==9090 and .URL=="0.0.0.0") | .PublishedPort' <<<"$ps_json") )
   [[ ${#grpc[@]} -eq 3 && ${#metrics[@]} -eq 3 ]] || die "could not discover 3 grpc+metrics ports (grpc=${grpc[*]} metrics=${metrics[*]})"
   REPLICA_GRPC_PORTS=( "${grpc[@]}" )
   REPLICA_METRICS_PORTS=( "${metrics[@]}" )

--- a/testbed/bench/scenarios/chaos_kill_replica.yaml
+++ b/testbed/bench/scenarios/chaos_kill_replica.yaml
@@ -15,10 +15,12 @@ target:
   data_template: |
     {"vertex":{"key":"chaos-{{.RequestNumber}}","int64":"{{.RequestNumber}}"}}
 chaos:
-  # Replica container name as known to docker compose (compose adds the
-  # project prefix). run.sh forces COMPOSE_PROJECT_NAME=lantern-bench, so
-  # the default container name follows that.
-  kill_target: "lantern-bench-lantern-2"
+  # Replica container name as known to docker compose. With the explicit
+  # lantern-{0,1,2} services introduced in #435, Compose names the
+  # container `${PROJECT}-${SERVICE}-${REPLICA_INDEX}`. run.sh forces
+  # COMPOSE_PROJECT_NAME=lantern-bench and there's only one replica per
+  # service, so the middle replica is `lantern-bench-lantern-1-1`.
+  kill_target: "lantern-bench-lantern-1-1"
   kill_at: 30s
   restart_at: 90s
 leak_gate:

--- a/testbed/ha-recovery/main.go
+++ b/testbed/ha-recovery/main.go
@@ -1,8 +1,8 @@
 // Compose HA failure-recovery test:
 //  1. seed baseline data via round-robin LB
-//  2. stop compose-lantern-2 (one of three replicas)
+//  2. stop compose-lantern-1-1 (one of three replicas)
 //  3. write new data while it is down (only 2 replicas accept)
-//  4. start compose-lantern-2 again
+//  4. start compose-lantern-1-1 again
 //  5. wait for catch-up via Subscribe replay / Snapshot
 //  6. assert the restarted replica has every vertex/edge
 package main
@@ -18,9 +18,14 @@ import (
 	client "github.com/anaregdesign/lantern/sdks/go"
 )
 
-const victimContainer = "compose-lantern-2"
+// Since #435 the canonical compose declares three explicit lantern-{0,1,2}
+// services, so Compose names containers `${PROJECT}-${SERVICE}-1` (the
+// trailing `-1` is the per-service replica index, always 1). When you run
+// `docker compose up -d` from deploy/compose/, the project defaults to the
+// directory name `compose`, giving these container names.
+const victimContainer = "compose-lantern-1-1"
 
-var containers = []string{"compose-lantern-1", "compose-lantern-2", "compose-lantern-3"}
+var containers = []string{"compose-lantern-0-1", "compose-lantern-1-1", "compose-lantern-2-1"}
 
 func docker(args ...string) {
 	out, err := exec.Command("docker", args...).CombinedOutput()
@@ -169,16 +174,18 @@ func metricsFor(container string) string {
 func main() {
 	ctx := context.Background()
 
-	// Resolve dynamic host-port mappings (mode:host range allocation drifts
-	// between compose restarts).
+	// Resolve host-port mappings. Since #435 these are pinned in the
+	// canonical compose (6380/6381/6382), but we still query at runtime
+	// so a bench override that hops back to dynamic ports would keep
+	// working.
 	endpointByContainer := map[string]string{}
 	for _, c := range containers {
 		endpointByContainer[c] = hostPort(c)
 	}
 	allEndpoints := []string{
-		endpointByContainer["compose-lantern-1"],
-		endpointByContainer["compose-lantern-2"],
-		endpointByContainer["compose-lantern-3"],
+		endpointByContainer["compose-lantern-0-1"],
+		endpointByContainer["compose-lantern-1-1"],
+		endpointByContainer["compose-lantern-2-1"],
 	}
 	victimEndpoint := endpointByContainer[victimContainer]
 	survivorEndpoints := []string{}
@@ -228,7 +235,8 @@ func main() {
 	// 5) Restart the victim.
 	fmt.Printf("\n--- starting %s ---\n", victimContainer)
 	docker("start", victimContainer)
-	// Compose's mode:host reassigns the host port on restart — re-resolve.
+	// Ports are pinned in the canonical compose, but re-resolve in case a
+	// bench override has switched back to dynamic mode:host ranges.
 	victimEndpoint = hostPort(victimContainer)
 	fmt.Printf("    (post-restart host port: %s)\n", victimEndpoint)
 	waitReady(victimEndpoint, 60*time.Second)
@@ -244,7 +252,7 @@ func main() {
 
 	// 8) Per-replica metric dump.
 	fmt.Println("\n--- per-replica metrics ---")
-	for _, c := range []string{"compose-lantern-1", "compose-lantern-2", "compose-lantern-3"} {
+	for _, c := range containers {
 		fmt.Printf("=== %s ===\n%s", c, metricsFor(c))
 	}
 


### PR DESCRIPTION
# Summary

Pin compose host ports so the admin SPA's default gateway URL
(`http://localhost:6380`) keeps working across `docker compose down`
/ `up` cycles and across consecutive bench runs.

Closes #435.

## Root cause

The canonical compose declared a single `lantern` service with
`deploy.replicas: 3` and `published: "6380-6389" mode: host`. Compose's
port-range allocator picks the lowest *currently-free* port per replica.
Across restarts, the daemon's port bookkeeping keeps prior allocations
lingering, so the next `up` hops forward (e.g. 6386/6387/6388 instead of
6380/6381/6382). That made every hard-coded `http://localhost:6380`
URL — including the admin SPA's default gateway, the docs examples,
and the bench harness's scenario files — break on the second run.

## Fix

Replace the single `lantern` service with three explicit services
`lantern-0`, `lantern-1`, `lantern-2` that share an `x-lantern-common`
YAML anchor and the `lantern` network alias. Each service pins one
host port (6380, 6381, 6382 → container 6380). Compose's embedded DNS
still resolves the shared `lantern` alias to one A per healthy replica,
so the peer pump (#190) and any in-cluster DNS round-robin clients
(admin, lantern-mcp, prometheus, SDK) keep working unchanged.

Container naming is left to Compose (no `container_name:` override) so
the canonical `compose` stack and the `testbed/bench` overlay can run
side-by-side without colliding.

## Files

### `deploy/compose/`

- **`docker-compose.yml`** — rewrite. Anchor `x-lantern-common`, three
  explicit `lantern-{0,1,2}` services, shared `lantern` alias, pinned
  ports, healthcheck unchanged. `admin`, `lantern-mcp`, and
  `prometheus` now `depends_on` all three replicas via
  `condition: service_healthy`.
- **`README.md`** — rewrote Topology (with a port-mapping table that
  shows both the service name and the Compose-derived container name),
  rewrote Run, replaced the `--scale` example with a note pointing to
  the Helm chart for >3 replicas, updated verification + single-instance
  fallback snippets.

### `testbed/bench/`

- **`compose.override.yml`** — was a single `lantern:` block layering
  pprof env + a port range; now uses an `x-lantern-bench-env` anchor
  and extends each of `lantern-{0,1,2}` with one explicit metrics port
  (9390 / 9391 / 9392).
- **`run.sh`** — dropped `--scale lantern=3`. `discover_ports()` jq
  filter switched from `select(.Name | test("lantern-[0-9]+$"))` to
  `select(.Service | test("^lantern-[0-9]+$"))` for robustness across
  naming schemes; the dynamic-port discovery itself is kept as a
  belt-and-suspenders check.
- **`release.sh`** — dropped `--scale lantern=3`.
- **`scenarios/chaos_kill_replica.yaml`** — `kill_target` updated from
  `lantern-bench-lantern-2` to `lantern-bench-lantern-1-1` (new
  Compose naming `${PROJECT}-${SERVICE}-1`).

### `testbed/ha-recovery/`

- **`main.go`** — `victimContainer` and `containers` updated to
  `compose-lantern-{0,1,2}-1`. Comments refreshed to note that ports
  are now pinned but `hostPort()` still works if a bench override
  switches back to dynamic ranges.

### Docs

- **`README.md`** (root) — replaced the `--scale lantern=5` example
  with the new explicit-services description.
- **`docs/ha-runbook.md`** §3.2 + §8.1 + topology matrix — rewrote
  the compose topology description, replaced both
  `docker compose scale lantern=N` references, updated the
  single-instance fallback example.
- **`docs/replication.md`** — table row + the section describing how
  scaling works now point at the explicit-services model.

### Cross-cutting hygiene

- **`AGENTS.md`** — one-line note about the multi-issue `Closes` syntax
  gotcha. `Closes #1, #2, #3` auto-links only `#1`; use one keyword
  per issue or one per line. PR #441 shipped fixes for #428/#429/#430/#432
  but only #428 closed automatically. (Surfaced while burning down
  the post-#440 admin-CLI cluster; AGENTS.md is the right home for
  workflow tripwires.)

## Verification

- `docker compose -f deploy/compose/docker-compose.yml config --quiet` →
  exit 0.
- `docker compose -f deploy/compose/docker-compose.yml
  -f testbed/bench/compose.override.yml --project-name lantern-bench
  config --quiet` → exit 0. Merged config shows
  `LANTERN_PPROF_ENABLED=true` and the canonical env block on each of
  `lantern-0/1/2`, with ports `6380/9390`, `6381/9391`, `6382/9392`.
- `go build ./...` from `testbed/ha-recovery/` and from repo root —
  both clean.

## Note for reviewers

The 8-site cascade is mechanical and centered on one root cause, so
it's batched into a single PR per AGENTS.md's "one Issue per coherent
unit of work" rule. The `testbed/docker-compose.yml` file is an
independent single-instance compose for the testbed/SKILL.md workflow
and is not affected by #435.
