### PR TITLE
chore(sdks/go): bump pb pin to v0.3.0 for v0.10.0 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.4.0
-	github.com/anaregdesign/lantern/core v0.2.2
+	github.com/anaregdesign/lantern/core v0.3.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
-	github.com/anaregdesign/lantern/pb v0.2.1
+	github.com/anaregdesign/lantern/pb v0.3.0
 	github.com/anaregdesign/lantern/sdks/go v0.9.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -3,13 +3,14 @@ module github.com/anaregdesign/lantern/mcp
 go 1.26
 
 require (
-	github.com/anaregdesign/lantern/pb v0.2.0
+	github.com/anaregdesign/lantern/pb v0.3.0
 	github.com/anaregdesign/lantern/sdks/go v0.9.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 )
 
 require (
 	connectrpc.com/connect v1.20.0 // indirect
+	github.com/anaregdesign/lantern/core v0.3.0 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/mcp/go.sum
+++ b/mcp/go.sum
@@ -1,5 +1,7 @@
 connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=
 connectrpc.com/connect v1.20.0/go.mod h1:A2ygJrukXwWy32vkCAAHNVguZrqZ+jeZ9rGRnGR4dN4=
+github.com/anaregdesign/lantern/core v0.3.0 h1:88TJNa/Xlc/reFV/RHQ1ashC2sxQsxOHjPmVYBxpxBY=
+github.com/anaregdesign/lantern/core v0.3.0/go.mod h1:cNpmz/PoUYyBUEJkbQTtqS0sgDJGQNJKnFZhAXKLufc=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -4,7 +4,8 @@ go 1.26
 
 require (
 	connectrpc.com/connect v1.20.0
-	github.com/anaregdesign/lantern/pb v0.2.0
+	github.com/anaregdesign/lantern/core v0.3.0
+	github.com/anaregdesign/lantern/pb v0.3.0
 	golang.org/x/net v0.55.0
 	google.golang.org/protobuf v1.36.11
 )

--- a/sdks/go/go.sum
+++ b/sdks/go/go.sum
@@ -1,5 +1,7 @@
 connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=
 connectrpc.com/connect v1.20.0/go.mod h1:A2ygJrukXwWy32vkCAAHNVguZrqZ+jeZ9rGRnGR4dN4=
+github.com/anaregdesign/lantern/core v0.3.0 h1:88TJNa/Xlc/reFV/RHQ1ashC2sxQsxOHjPmVYBxpxBY=
+github.com/anaregdesign/lantern/core v0.3.0/go.mod h1:cNpmz/PoUYyBUEJkbQTtqS0sgDJGQNJKnFZhAXKLufc=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=


### PR DESCRIPTION
Closes #447.

The SDK's `subscribe.go` consumes the per-origin Subscribe cursor introduced in `pb/v0.3.0` (typed as `map[hlc.NodeID]uint64` via the `core/hlc` import added in #421). Before this bump, the standalone `sdks/go` module pinned `pb v0.2.0`, which lacked `SubscribeRequest.FromSeqPerOrigin` — so pkg.go.dev's view of the SDK disagreed with HEAD source.

`go mod tidy` also surfaced `core v0.3.0` as a direct require, since the typed cursor leaks into the public Subscribe signature. No source edits needed.

Verified locally:
```sh
cd sdks/go && go mod tidy && go build ./... && go test ./...
```

After merge: tag `sdks/go/v0.10.0` at the merge commit. The tag triggers `.github/workflows/sdks-go-publish.yml` (verify + GH release w/ raw-tag title).