### PR TITLE
chore(root,mcp): bump sdks/go pin to v0.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/anaregdesign/lantern/core v0.3.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.3.0
-	github.com/anaregdesign/lantern/sdks/go v0.9.0
+	github.com/anaregdesign/lantern/sdks/go v0.10.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/anaregdesign/lantern/pb v0.3.0
-	github.com/anaregdesign/lantern/sdks/go v0.9.0
+	github.com/anaregdesign/lantern/sdks/go v0.10.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 )
 


### PR DESCRIPTION
Closes #449.

Now that `sdks/go/v0.10.0` is tagged (#448 merge) and proxy-cached, lift the downstream pins so the next published `mcp` tag and root `v0.9.0` reference `v0.10.0` instead of `v0.9.0`.

### Pin moves
| file | before | after |
|---|---|---|
| `go.mod` (root) | `sdks/go v0.9.0` | `v0.10.0` |
| `mcp/go.mod`    | `sdks/go v0.9.0` | `v0.10.0` |

Local `replace` directives (`./sdks/go` from root, `../sdks/go` from mcp) bypass the proxy so `go.sum` gains no entries — the bump is purely declarative and matters only for downstream consumers of the published `mcp` module.

### Local verify
All 6 modules build + vet + test green under `GOWORK=off`:
- root, core, mcp, pb, sdks/go, server

### Next steps after merge
- Tag `mcp/v0.3.0` at the merge commit
- Tag root `v0.9.0` at the same merge commit (triggers docker-publish)