### PR TITLE
chore(sdks/node): bump to v0.2.0

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lantern-sdk",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Official TypeScript client SDK for Lantern — an in-memory graph KVS, over Connect (HTTP/2).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Closes #451.

Bumps `sdks/node/package.json` `version` from `0.1.2` to `0.2.0` to mark the next minor of the TypeScript client SDK on the v0.x.x pre-release track.

### What landed since 0.1.2
- Illuminate axis enums (#410) for the typed objective/weighting surface
- `hlc.NodeID` cursor flowing through subscribe (consumed by admin /cli #433)
- Misc admin SPA polish (CLI clear/cancel actions etc.)

### Local verify
- `bun install --frozen-lockfile` — no changes
- `bun run build` — CJS + ESM + d.ts clean
- `bun test` — 37 pass, 0 fail

### Next steps after merge
- Tag `sdks/node/v0.2.0` (triggers `node-sdk.yml` OIDC publish to npm)
- Tag `admin/v0.2.0` at the same merge commit (triggers `admin-publish.yml`)