### PR TITLE
feat(admin)!: additive expansion model for /illuminate

### DIFF
--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -351,6 +351,7 @@ export function CliPage() {
             <IlluminateCanvas
               nodes={latestGraph.view.nodes}
               edges={latestGraph.view.edges}
+              latestExpansionOrigin={latestGraph.view.latestExpansionOrigin}
               onNodeClick={onNodeClick}
               isBusy={busy}
             />

--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -11,12 +11,21 @@ import styles from "./IlluminateCanvas.module.css";
 export interface IlluminateCanvasProps {
   nodes: GraphNode[];
   edges: GraphEdge[];
+  /**
+   * Key of the vertex that originated the most recent expansion. Used as
+   * the position hint for new nodes (#466 D7): when a node is being
+   * added for the first time, we place it near the centroid of its
+   * (already-placed) neighbours so ForceAtlas2 settles without yanking
+   * the existing layout.
+   */
+  latestExpansionOrigin: string | null;
   onNodeClick: (key: string) => void;
   /** When true, the canvas dims to communicate a stale frame. */
   isBusy: boolean;
 }
 
 const SEED_COLOR = "#0078d4"; // FluentUI brandColor (web theme accent)
+const ORIGIN_COLOR = "#5c2d91"; // Darker accent for non-seed expansion origins
 const NODE_COLOR = "#5b5b5b";
 const EDGE_COLOR = "#bdbdbd";
 
@@ -38,6 +47,7 @@ interface HoverState {
 export function IlluminateCanvas({
   nodes,
   edges,
+  latestExpansionOrigin,
   onNodeClick,
   isBusy,
 }: IlluminateCanvasProps) {
@@ -142,9 +152,17 @@ export function IlluminateCanvas({
       }
     }
 
+    // Per-node neighbour lookup for the placement hint. We build it once
+    // per reconcile so we don't rescan the edge list per node below.
+    const neighboursByKey = buildNeighbourMap(nodes, edges);
+
     for (const node of nodes) {
       const size = 4 + node.importance * 10;
-      const color = node.isSeed ? SEED_COLOR : NODE_COLOR;
+      const color = node.isInitialSeed
+        ? SEED_COLOR
+        : node.isExpansionOrigin
+          ? ORIGIN_COLOR
+          : NODE_COLOR;
       const detail = describeVertex(node);
       if (graph.hasNode(node.id)) {
         graph.mergeNodeAttributes(node.id, {
@@ -152,22 +170,25 @@ export function IlluminateCanvas({
           size,
           color,
           detail,
-          isSeed: node.isSeed,
+          isInitialSeed: node.isInitialSeed,
+          isExpansionOrigin: node.isExpansionOrigin,
         });
       } else {
-        // Seed the layout near the origin, neighbours in a wide ring so
-        // ForceAtlas2 has somewhere to push from. Random within a circle
-        // keeps the first frame stable.
-        const angle = Math.random() * Math.PI * 2;
-        const radius = node.isSeed ? 0 : 1 + Math.random() * 4;
+        const { x, y } = pickInitialPosition({
+          graph,
+          node,
+          neighbours: neighboursByKey.get(node.id) ?? [],
+          latestExpansionOrigin,
+        });
         graph.addNode(node.id, {
           label: node.label,
-          x: Math.cos(angle) * radius,
-          y: Math.sin(angle) * radius,
+          x,
+          y,
           size,
           color,
           detail,
-          isSeed: node.isSeed,
+          isInitialSeed: node.isInitialSeed,
+          isExpansionOrigin: node.isExpansionOrigin,
         });
       }
     }
@@ -201,7 +222,7 @@ export function IlluminateCanvas({
     }
 
     sigma?.refresh();
-  }, [nodes, edges]);
+  }, [nodes, edges, latestExpansionOrigin]);
 
   const empty = nodes.length === 0;
   const wrapperClass = useMemo(
@@ -236,6 +257,112 @@ export function IlluminateCanvas({
       ) : null}
     </div>
   );
+}
+
+/**
+ * Build an undirected neighbour map: for each node id, the keys of its
+ * neighbours (in either direction). Used by `pickInitialPosition` to
+ * seed a new node near its existing neighbours, per #466 D7.
+ */
+function buildNeighbourMap(
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+): Map<string, string[]> {
+  const keys = new Set(nodes.map((n) => n.id));
+  const out = new Map<string, string[]>();
+  for (const e of edges) {
+    if (!keys.has(e.source) || !keys.has(e.target)) continue;
+    appendNeighbour(out, e.source, e.target);
+    appendNeighbour(out, e.target, e.source);
+  }
+  return out;
+}
+
+function appendNeighbour(
+  map: Map<string, string[]>,
+  key: string,
+  neighbour: string,
+) {
+  const list = map.get(key);
+  if (list) {
+    list.push(neighbour);
+  } else {
+    map.set(key, [neighbour]);
+  }
+}
+
+/**
+ * Pick an (x, y) for a node that's being added to the graph for the
+ * first time.
+ *
+ * Priority order:
+ *  1. The initial seed sits at the origin.
+ *  2. If the node has neighbours that are ALREADY placed in graphology,
+ *     drop it at their centroid with small jitter — ForceAtlas2 then
+ *     only has to nudge it into place instead of yanking the whole
+ *     layout.
+ *  3. If the latest expansion origin is placed, drop the node in a ring
+ *     around it (#466 D7 explicitly calls out "near the parent click").
+ *  4. Otherwise, the original random-in-a-circle seeding.
+ */
+function pickInitialPosition({
+  graph,
+  node,
+  neighbours,
+  latestExpansionOrigin,
+}: {
+  graph: Graph;
+  node: GraphNode;
+  neighbours: string[];
+  latestExpansionOrigin: string | null;
+}): { x: number; y: number } {
+  if (node.isInitialSeed) {
+    return { x: 0, y: 0 };
+  }
+  // 2 — centroid of already-placed neighbours.
+  let sumX = 0;
+  let sumY = 0;
+  let placedCount = 0;
+  for (const neighbour of neighbours) {
+    if (!graph.hasNode(neighbour)) continue;
+    const attrs = graph.getNodeAttributes(neighbour) as {
+      x?: number;
+      y?: number;
+    };
+    if (typeof attrs.x !== "number" || typeof attrs.y !== "number") continue;
+    sumX += attrs.x;
+    sumY += attrs.y;
+    placedCount += 1;
+  }
+  if (placedCount > 0) {
+    const cx = sumX / placedCount;
+    const cy = sumY / placedCount;
+    // Small jitter so colocated nodes don't sit exactly on top of each
+    // other (would make ForceAtlas2's first iteration meaningless).
+    return {
+      x: cx + (Math.random() - 0.5) * 0.5,
+      y: cy + (Math.random() - 0.5) * 0.5,
+    };
+  }
+  // 3 — ring around the latest expansion origin if it's placed.
+  if (latestExpansionOrigin !== null && graph.hasNode(latestExpansionOrigin)) {
+    const attrs = graph.getNodeAttributes(latestExpansionOrigin) as {
+      x?: number;
+      y?: number;
+    };
+    const ox = typeof attrs.x === "number" ? attrs.x : 0;
+    const oy = typeof attrs.y === "number" ? attrs.y : 0;
+    const angle = Math.random() * Math.PI * 2;
+    const radius = 1 + Math.random() * 2;
+    return {
+      x: ox + Math.cos(angle) * radius,
+      y: oy + Math.sin(angle) * radius,
+    };
+  }
+  // 4 — fallback random-in-circle seeding.
+  const angle = Math.random() * Math.PI * 2;
+  const radius = 1 + Math.random() * 4;
+  return { x: Math.cos(angle) * radius, y: Math.sin(angle) * radius };
 }
 
 function describeVertex(node: GraphNode): string {

--- a/admin/app/components/illuminate/IlluminatePage/IlluminatePage.tsx
+++ b/admin/app/components/illuminate/IlluminatePage/IlluminatePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import { MessageBar, MessageBarBody } from "@fluentui/react-components";
 import { useNavigate, useSearchParams } from "react-router";
 import { IlluminateCanvas } from "../IlluminateCanvas/IlluminateCanvas";
@@ -6,42 +6,41 @@ import { IlluminateTable } from "../IlluminateTable/IlluminateTable";
 import { IlluminateToolbar } from "../IlluminateToolbar/IlluminateToolbar";
 import { SeedPrompt } from "../SeedPrompt/SeedPrompt";
 import { useIlluminate } from "~/lib/client/usecase/illuminate/use-illuminate";
+import { ACCUMULATOR_SOFT_CAP } from "~/lib/client/usecase/illuminate/state";
 import styles from "./IlluminatePage.module.css";
 
 /**
- * Top-level orchestrator for the Illuminate screen. The URL's `?seed=`
- * query param is the source of truth for the active seed; pushing a new
- * seed via the canvas / table updates the URL so the browser back button
- * walks the user back through the seed history naturally.
+ * Top-level orchestrator for the Illuminate screen. Per #466 the URL's
+ * `?seed=` query param is the source of truth for `initialSeed` only —
+ * subsequent clicks on canvas/table append expansions to the in-memory
+ * audit trail without changing the URL. Use the SeedPrompt or Clear
+ * button to change the URL-level seed.
  */
 export function IlluminatePage() {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const rawSeed = searchParams.get("seed") ?? "";
   const urlSeed = decodeSeed(rawSeed);
 
   const ill = useIlluminate(urlSeed);
 
-  // Mirror reducer-driven seed changes (push/pop) back into the URL so
-  // the browser history walks naturally. The URL is authoritative on the
-  // way IN (a dedicated effect inside `useIlluminate` syncs `urlSeed` →
-  // reducer); this effect is purely state → URL, and must NEVER clear
-  // the URL from a transient empty reducer state — that would race the
-  // initial SEED_CHANGED priming step and wipe the seed the user just
-  // navigated to.
-  useEffect(() => {
-    if (ill.state.seed === "" || ill.state.seed === urlSeed) return;
-    setSearchParams({ seed: ill.state.seed }, { replace: false });
-  }, [ill.state.seed, urlSeed, setSearchParams]);
-
   const handleNodeClick = useCallback(
     (key: string) => {
-      if (key && key !== ill.state.seed) {
-        ill.push(key);
-      }
+      if (!key) return;
+      // Per #466 D11 the expand is idempotent — even when the user clicks
+      // the same node twice we fire the request so they can pick up newly
+      // arrived neighbours (server-side decay).
+      ill.expand(key);
     },
     [ill],
   );
+
+  const handleClear = useCallback(() => {
+    // Clear navigates back to the bare `/illuminate` URL; the hook's
+    // INITIAL_SEED_CHANGED handler aborts in-flight expansions and resets
+    // the accumulator when it sees the empty URL.
+    navigate("/illuminate");
+  }, [navigate]);
 
   const openFromPrompt = useCallback(
     (seed: string) => {
@@ -55,8 +54,8 @@ export function IlluminatePage() {
       <header className={styles.header}>
         <h1 className={styles.title}>Illuminate</h1>
         <p className={styles.lead}>
-          Explore a vertex&rsquo;s neighbourhood. Click a node to re-seed; use{" "}
-          <em>Pop</em> to walk back through the history stack.
+          Explore a vertex&rsquo;s neighbourhood. Click any node to expand its
+          neighbourhood into the canvas; use <em>Clear</em> to start over.
         </p>
       </header>
 
@@ -65,12 +64,15 @@ export function IlluminatePage() {
       ) : (
         <>
           <IlluminateToolbar
-            seed={ill.state.seed}
+            initialSeed={ill.state.initialSeed ?? ""}
             controls={ill.state.controls}
             status={ill.state.status}
-            canPop={ill.canPop}
+            canClear={ill.canClear}
+            vertexCount={ill.view.nodes.length}
+            edgeCount={ill.view.edges.length}
+            expansionCount={ill.expansionCount}
             onControlsChange={ill.setControls}
-            onPop={ill.pop}
+            onClear={handleClear}
             onRefresh={ill.refresh}
           />
           {ill.state.error ? (
@@ -82,9 +84,23 @@ export function IlluminatePage() {
               <MessageBarBody>{ill.state.error}</MessageBarBody>
             </MessageBar>
           ) : null}
+          {ill.view.overSoftCap ? (
+            <MessageBar
+              intent="warning"
+              data-testid="illuminate-soft-cap"
+              className={styles.alert}
+            >
+              <MessageBarBody>
+                Accumulator past the soft cap of {ACCUMULATOR_SOFT_CAP} vertices
+                ({ill.view.nodes.length}). Layout may slow down; use Clear to
+                start over.
+              </MessageBarBody>
+            </MessageBar>
+          ) : null}
           <IlluminateCanvas
             nodes={ill.view.nodes}
             edges={ill.view.edges}
+            latestExpansionOrigin={ill.view.latestExpansionOrigin}
             onNodeClick={handleNodeClick}
             isBusy={ill.isBusy}
           />
@@ -93,7 +109,7 @@ export function IlluminatePage() {
               List view ({ill.view.nodes.length} vertices,&nbsp;
               {ill.view.edges.length} edges)
             </summary>
-            <IlluminateTable nodes={ill.view.nodes} onIlluminate={ill.push} />
+            <IlluminateTable nodes={ill.view.nodes} onExpand={ill.expand} />
           </details>
         </>
       )}

--- a/admin/app/components/illuminate/IlluminateTable/IlluminateTable.tsx
+++ b/admin/app/components/illuminate/IlluminateTable/IlluminateTable.tsx
@@ -15,15 +15,17 @@ import styles from "./IlluminateTable.module.css";
 
 export interface IlluminateTableProps {
   nodes: GraphNode[];
-  onIlluminate: (key: string) => void;
+  /** Fire an Illuminate expansion using this row's key as the origin. */
+  onExpand: (key: string) => void;
 }
 
 /**
  * Accessible companion view for the canvas. Keyboard and screen-reader
- * users get the same neighbourhood data as a flat table; clicking a row
- * pushes that key onto the seed history.
+ * users get the same neighbourhood data as a flat table; clicking a
+ * row's Expand button fires an additive Illuminate using that key as
+ * the origin (#466 D11: idempotent, including for the initial seed).
  */
-export function IlluminateTable({ nodes, onIlluminate }: IlluminateTableProps) {
+export function IlluminateTable({ nodes, onExpand }: IlluminateTableProps) {
   if (nodes.length === 0) {
     return null;
   }
@@ -51,7 +53,11 @@ export function IlluminateTable({ nodes, onIlluminate }: IlluminateTableProps) {
                 to={`/vertices/${encodeURIComponent(node.id)}`}
                 className={styles.keyLink}
               >
-                {node.isSeed ? <strong>{node.label}</strong> : node.label}
+                {node.isInitialSeed ? (
+                  <strong>{node.label}</strong>
+                ) : (
+                  node.label
+                )}
               </Link>
             </TableCell>
             <TableCell>
@@ -64,11 +70,10 @@ export function IlluminateTable({ nodes, onIlluminate }: IlluminateTableProps) {
               <Button
                 appearance="subtle"
                 size="small"
-                onClick={() => onIlluminate(node.id)}
-                disabled={node.isSeed}
-                aria-label={`Re-seed from ${node.id}`}
+                onClick={() => onExpand(node.id)}
+                aria-label={`Expand from ${node.id}`}
               >
-                Re-seed
+                Expand
               </Button>
             </TableCell>
           </TableRow>

--- a/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.tsx
+++ b/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.tsx
@@ -11,7 +11,7 @@ import {
 } from "@fluentui/react-components";
 import {
   ArrowClockwise20Regular,
-  ArrowUndo20Regular,
+  Delete20Regular,
 } from "@fluentui/react-icons";
 import type {
   IlluminateControls,
@@ -24,12 +24,15 @@ import type {
 import styles from "./IlluminateToolbar.module.css";
 
 export interface IlluminateToolbarProps {
-  seed: string;
+  initialSeed: string;
   controls: IlluminateControls;
   status: IlluminateStatus;
-  canPop: boolean;
+  canClear: boolean;
+  vertexCount: number;
+  edgeCount: number;
+  expansionCount: number;
   onControlsChange: (next: IlluminateControls) => void;
-  onPop: () => void;
+  onClear: () => void;
   onRefresh: () => void;
 }
 
@@ -52,14 +55,21 @@ const OBJECTIVES: Array<{ value: Objective; label: string }> = [
  * Controlled toolbar above the Illuminate canvas. Owns no async state of
  * its own — every change fans out through `onControlsChange` so the
  * usecase hook stays the single source of truth.
+ *
+ * Per #466 the additive model means there is no seed stack to pop — the
+ * old `Pop` button is replaced with `Clear` which empties the
+ * accumulator (and navigates back to the SeedPrompt).
  */
 export function IlluminateToolbar({
-  seed,
+  initialSeed,
   controls,
   status,
-  canPop,
+  canClear,
+  vertexCount,
+  edgeCount,
+  expansionCount,
   onControlsChange,
-  onPop,
+  onClear,
   onRefresh,
 }: IlluminateToolbarProps) {
   const update = <K extends keyof IlluminateControls>(
@@ -77,31 +87,51 @@ export function IlluminateToolbar({
     >
       <div className={styles.seedRow}>
         <Label className={styles.seedLabel}>Seed</Label>
-        <Tooltip content={seed} relationship="label" withArrow>
+        <Tooltip content={initialSeed} relationship="label" withArrow>
           <code className={styles.seedValue} data-testid="illuminate-seed">
-            {seed || "—"}
+            {initialSeed || "—"}
           </code>
         </Tooltip>
-        <Button
-          appearance="subtle"
-          size="small"
-          icon={<ArrowUndo20Regular />}
-          disabled={!canPop}
-          onClick={onPop}
-          data-testid="illuminate-pop"
+        <Badge
+          appearance="tint"
+          color="informative"
+          data-testid="illuminate-counter"
         >
-          Pop
-        </Button>
-        <Button
-          appearance="subtle"
-          size="small"
-          icon={<ArrowClockwise20Regular />}
-          disabled={status === "loading" || seed === ""}
-          onClick={onRefresh}
-          data-testid="illuminate-refresh"
+          {vertexCount} vertices · {edgeCount} edges · {expansionCount}{" "}
+          expansions
+        </Badge>
+        <Tooltip
+          content="Re-fire the most recent expansion with current controls"
+          relationship="label"
+          withArrow
         >
-          Refresh
-        </Button>
+          <Button
+            appearance="subtle"
+            size="small"
+            icon={<ArrowClockwise20Regular />}
+            disabled={status === "loading" || initialSeed === ""}
+            onClick={onRefresh}
+            data-testid="illuminate-refresh"
+          >
+            Refresh
+          </Button>
+        </Tooltip>
+        <Tooltip
+          content="Empty accumulator and return to seed prompt"
+          relationship="label"
+          withArrow
+        >
+          <Button
+            appearance="subtle"
+            size="small"
+            icon={<Delete20Regular />}
+            disabled={!canClear}
+            onClick={onClear}
+            data-testid="illuminate-clear"
+          >
+            Clear
+          </Button>
+        </Tooltip>
         <StatusBadge status={status} />
       </div>
 

--- a/admin/app/lib/cli/graph-view.test.ts
+++ b/admin/app/lib/cli/graph-view.test.ts
@@ -32,7 +32,7 @@ describe("commandResultToGraphView — illuminate", () => {
     };
     const view = commandResultToGraphView(cmd, response)!;
     expect(view.nodes.map((n) => n.id).sort()).toEqual(["a", "b", "c"]);
-    expect(view.nodes.find((n) => n.id === "a")!.isSeed).toBe(true);
+    expect(view.nodes.find((n) => n.id === "a")!.isInitialSeed).toBe(true);
     expect(view.nodes.find((n) => n.id === "a")!.importance).toBe(1);
     expect(view.edges.map((e) => e.id).sort()).toEqual(["a→b", "a→c"]);
   });
@@ -66,7 +66,7 @@ describe("commandResultToGraphView — get vertex", () => {
     const view = commandResultToGraphView(cmd, vertex)!;
     expect(view.nodes).toHaveLength(1);
     expect(view.nodes[0].id).toBe("alice");
-    expect(view.nodes[0].isSeed).toBe(true);
+    expect(view.nodes[0].isInitialSeed).toBe(true);
     expect(view.nodes[0].importance).toBe(1);
     expect(view.edges).toEqual([]);
   });
@@ -90,8 +90,8 @@ describe("commandResultToGraphView — get edge", () => {
     const edge: Edge = { tail: "alice", head: "bob", weight: 7 };
     const view = commandResultToGraphView(cmd, edge)!;
     expect(view.nodes.map((n) => n.id).sort()).toEqual(["alice", "bob"]);
-    expect(view.nodes.find((n) => n.id === "alice")!.isSeed).toBe(true);
-    expect(view.nodes.find((n) => n.id === "bob")!.isSeed).toBe(false);
+    expect(view.nodes.find((n) => n.id === "alice")!.isInitialSeed).toBe(true);
+    expect(view.nodes.find((n) => n.id === "bob")!.isInitialSeed).toBe(false);
     expect(view.edges).toHaveLength(1);
     expect(view.edges[0].id).toBe("alice→bob");
     expect(view.edges[0].weight).toBe(7);
@@ -127,7 +127,7 @@ describe("commandResultToGraphView — scan vertices", () => {
       "user:carol",
     ]);
     expect(view.edges).toEqual([]);
-    expect(view.nodes.every((n) => !n.isSeed)).toBe(true);
+    expect(view.nodes.every((n) => !n.isInitialSeed)).toBe(true);
   });
 
   it("marks the exact-match vertex as a seed when prefix is non-empty", () => {
@@ -141,8 +141,10 @@ describe("commandResultToGraphView — scan vertices", () => {
       vertices: [{ key: "alice" }, { key: "aliceland" }],
     };
     const view = commandResultToGraphView(cmd, response)!;
-    expect(view.nodes.find((n) => n.id === "alice")!.isSeed).toBe(true);
-    expect(view.nodes.find((n) => n.id === "aliceland")!.isSeed).toBe(false);
+    expect(view.nodes.find((n) => n.id === "alice")!.isInitialSeed).toBe(true);
+    expect(view.nodes.find((n) => n.id === "aliceland")!.isInitialSeed).toBe(
+      false,
+    );
   });
 });
 
@@ -176,8 +178,8 @@ describe("commandResultToGraphView — scan edges", () => {
       edges: [{ tail: "alice", head: "bob", weight: 1 }],
     };
     const view = commandResultToGraphView(cmd, response)!;
-    expect(view.nodes.find((n) => n.id === "alice")!.isSeed).toBe(true);
-    expect(view.nodes.find((n) => n.id === "bob")!.isSeed).toBe(false);
+    expect(view.nodes.find((n) => n.id === "alice")!.isInitialSeed).toBe(true);
+    expect(view.nodes.find((n) => n.id === "bob")!.isInitialSeed).toBe(false);
   });
 
   it("does not seed any node when the tail prefix is empty", () => {
@@ -191,7 +193,7 @@ describe("commandResultToGraphView — scan edges", () => {
       edges: [{ tail: "alice", head: "bob", weight: 1 }],
     };
     const view = commandResultToGraphView(empty, response)!;
-    expect(view.nodes.every((n) => !n.isSeed)).toBe(true);
+    expect(view.nodes.every((n) => !n.isInitialSeed)).toBe(true);
   });
 });
 

--- a/admin/app/lib/cli/graph-view.ts
+++ b/admin/app/lib/cli/graph-view.ts
@@ -11,6 +11,11 @@
  *
  * Pure: no React, no DOM, no Sigma. The CliPage component handles
  * mount lifecycle.
+ *
+ * The CLI surface is stateless from the canvas's perspective — every
+ * command produces a single "expansion" that overwrites the previous
+ * frame. So every node gets `firstSeenExpansion: 0` and `overSoftCap`
+ * is always false (no accumulation across commands).
  */
 
 import type { Command } from "./types";
@@ -55,6 +60,25 @@ export function commandResultToGraphView(
   }
 }
 
+/**
+ * Wrap a freshly built {nodes, edges} pair in the additive-model
+ * envelope the canvas expects. `seed` doubles as both the initial
+ * seed and the latest expansion origin in the CLI's stateless view.
+ */
+function wrapView(
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  seed: string | null,
+): GraphView {
+  return {
+    nodes,
+    edges,
+    latestExpansionOrigin: seed,
+    expansionOrigins: seed !== null && seed !== "" ? [seed] : [],
+    overSoftCap: false,
+  };
+}
+
 function illuminateView(seed: string, response: IlluminateResponse): GraphView {
   const graph = response.graph ?? {};
   const seedKey = seed;
@@ -96,8 +120,10 @@ function illuminateView(seed: string, response: IlluminateResponse): GraphView {
         id: v.key,
         label: v.key,
         vertex: v,
-        isSeed,
+        isInitialSeed: isSeed,
+        isExpansionOrigin: isSeed,
         importance,
+        firstSeenExpansion: 0,
       };
     });
 
@@ -114,32 +140,35 @@ function illuminateView(seed: string, response: IlluminateResponse): GraphView {
       edge: e,
     });
   }
-  return { nodes, edges };
+  return wrapView(nodes, edges, seedKey === "" ? null : seedKey);
 }
 
 function getVertexView(key: string, vertex: Vertex | null): GraphView {
   if (!vertex) {
     // The server returned NotFound. Render an empty canvas; the
     // scrollback already shows the error.
-    return { nodes: [], edges: [] };
+    return wrapView([], [], null);
   }
-  return {
-    nodes: [
+  return wrapView(
+    [
       {
         id: key,
         label: key,
         vertex: { ...vertex, key },
-        isSeed: true,
+        isInitialSeed: true,
+        isExpansionOrigin: true,
         importance: 1,
+        firstSeenExpansion: 0,
       },
     ],
-    edges: [],
-  };
+    [],
+    key,
+  );
 }
 
 function getEdgeView(tail: string, head: string, edge: Edge | null): GraphView {
   if (!edge) {
-    return { nodes: [], edges: [] };
+    return wrapView([], [], null);
   }
   const nodes: GraphNode[] = [
     {
@@ -150,15 +179,19 @@ function getEdgeView(tail: string, head: string, edge: Edge | null): GraphView {
       // canvas tooltip / a11y table render a recognisable label
       // rather than crashing on missing fields.
       vertex: { key: tail },
-      isSeed: true,
+      isInitialSeed: true,
+      isExpansionOrigin: true,
       importance: 1,
+      firstSeenExpansion: 0,
     },
     {
       id: head,
       label: head,
       vertex: { key: head },
-      isSeed: false,
+      isInitialSeed: false,
+      isExpansionOrigin: false,
       importance: 0.5,
+      firstSeenExpansion: 0,
     },
   ];
   const edges: GraphEdge[] = [
@@ -170,7 +203,7 @@ function getEdgeView(tail: string, head: string, edge: Edge | null): GraphView {
       edge,
     },
   ];
-  return { nodes, edges };
+  return wrapView(nodes, edges, tail);
 }
 
 function scanVerticesView(
@@ -184,14 +217,25 @@ function scanVerticesView(
       (v): v is Vertex & { key: string } =>
         typeof v.key === "string" && v.key !== "",
     )
-    .map((v) => ({
-      id: v.key,
-      label: v.key,
-      vertex: v,
-      isSeed: seedKey !== "" && v.key === seedKey,
-      importance: 0.5,
-    }));
-  return { nodes, edges: [] };
+    .map((v) => {
+      const isSeed = seedKey !== "" && v.key === seedKey;
+      return {
+        id: v.key,
+        label: v.key,
+        vertex: v,
+        isInitialSeed: isSeed,
+        isExpansionOrigin: isSeed,
+        importance: 0.5,
+        firstSeenExpansion: 0,
+      };
+    });
+  // For scan we treat the prefix as the latest origin only if a node
+  // matches it exactly (otherwise the canvas would render a halo
+  // around an absent vertex). Returning null is the right signal.
+  const matchedSeed = nodes.some((n) => seedKey !== "" && n.id === seedKey)
+    ? seedKey
+    : null;
+  return wrapView(nodes, [], matchedSeed);
 }
 
 function scanEdgesView(
@@ -204,14 +248,17 @@ function scanEdgesView(
   for (const e of rawEdges) {
     if (!e.tail || !e.head) continue;
     if (!nodeMap.has(e.tail)) {
+      const isSeed = tailPrefix !== "" && e.tail === tailPrefix;
       nodeMap.set(e.tail, {
         id: e.tail,
         label: e.tail,
         vertex: { key: e.tail },
         // Mark every endpoint whose key matches the scan prefix as
         // a seed. Empty prefix → no seeds (every node neutral).
-        isSeed: tailPrefix !== "" && e.tail === tailPrefix,
+        isInitialSeed: isSeed,
+        isExpansionOrigin: isSeed,
         importance: 0.5,
+        firstSeenExpansion: 0,
       });
     }
     if (!nodeMap.has(e.head)) {
@@ -219,8 +266,10 @@ function scanEdgesView(
         id: e.head,
         label: e.head,
         vertex: { key: e.head },
-        isSeed: false,
+        isInitialSeed: false,
+        isExpansionOrigin: false,
         importance: 0.5,
+        firstSeenExpansion: 0,
       });
     }
     edges.push({
@@ -231,5 +280,7 @@ function scanEdgesView(
       edge: e,
     });
   }
-  return { nodes: Array.from(nodeMap.values()), edges };
+  const matchedSeed =
+    nodeMap.has(tailPrefix) && tailPrefix !== "" ? tailPrefix : null;
+  return wrapView(Array.from(nodeMap.values()), edges, matchedSeed);
 }

--- a/admin/app/lib/client/usecase/illuminate/handlers.ts
+++ b/admin/app/lib/client/usecase/illuminate/handlers.ts
@@ -5,30 +5,41 @@ import {
 } from "~/lib/client/infrastructure/api/illuminate";
 import type { LanternClient } from "~/lib/client/infrastructure/api/lantern-client";
 import type { IlluminateAction } from "./reducer";
-import type { IlluminateControls, IlluminateFrame } from "./state";
+import type { IlluminateControls } from "./state";
 
-export interface FetchIlluminateInput {
+export interface ExpandInput {
   client: LanternClient;
-  seed: string;
+  expansionId: number;
+  origin: string;
   controls: IlluminateControls;
-  epoch: number;
+  startedAtMs: number;
   signal?: AbortSignal;
 }
 
 /**
- * Fetches one Illuminate frame and dispatches the resulting state
- * transition. Swallows `AbortError` because cancellation is a normal
- * control-flow event in this view (the user drags a slider and we move on
- * to a fresh request).
+ * Fires one Illuminate call and dispatches the resulting expansion
+ * action. Swallows `AbortError` because cancellation is a normal
+ * control-flow event in this view (the hook aborts in-flight
+ * expansions on Clear / unmount / initial-seed change).
+ *
+ * Per #466 each expansion carries its own AbortController, so a later
+ * click does NOT cancel earlier ones — they all merge into the
+ * accumulator as they return.
  */
-export async function fetchIlluminate(
-  input: FetchIlluminateInput,
+export async function runExpansion(
+  input: ExpandInput,
   dispatch: (action: IlluminateAction) => void,
 ): Promise<void> {
-  dispatch({ type: "FETCH_REQUESTED", epoch: input.epoch });
+  dispatch({
+    type: "EXPANSION_REQUESTED",
+    expansionId: input.expansionId,
+    origin: input.origin,
+    controls: input.controls,
+    startedAtMs: input.startedAtMs,
+  });
   try {
     const request: IlluminateRequest = {
-      seed: input.seed,
+      seed: input.origin,
       step: input.controls.step,
       k: input.controls.k,
       algorithm: input.controls.algorithm,
@@ -38,20 +49,32 @@ export async function fetchIlluminate(
     const response = await illuminate(input.client, request, {
       signal: input.signal,
     });
-    const frame: IlluminateFrame = {
-      seed: input.seed,
+    dispatch({
+      type: "EXPANSION_RECEIVED",
+      expansionId: input.expansionId,
+      origin: input.origin,
       controls: input.controls,
+      startedAtMs: input.startedAtMs,
       vertices: response.graph?.vertices ?? [],
       edges: response.graph?.edges ?? [],
-    };
-    dispatch({ type: "FETCH_RECEIVED", epoch: input.epoch, frame });
+      receivedAtMs:
+        typeof performance !== "undefined" ? performance.now() : Date.now(),
+    });
   } catch (err) {
     if (isAbortError(err)) {
+      // Synthesise a FAILED that the reducer treats as "discount the
+      // pending counter" without setting an error; we still need to
+      // balance the optimistic EXPANSION_REQUESTED.
+      dispatch({
+        type: "EXPANSION_FAILED",
+        expansionId: input.expansionId,
+        error: "",
+      });
       return;
     }
     dispatch({
-      type: "FETCH_FAILED",
-      epoch: input.epoch,
+      type: "EXPANSION_FAILED",
+      expansionId: input.expansionId,
       error: messageOf(err),
     });
   }

--- a/admin/app/lib/client/usecase/illuminate/reducer.test.ts
+++ b/admin/app/lib/client/usecase/illuminate/reducer.test.ts
@@ -1,217 +1,386 @@
 import { describe, expect, it } from "bun:test";
-import { illuminateReducer, type IlluminateAction } from "./reducer";
+import type { Edge, Vertex } from "~/lib/client/infrastructure/api/illuminate";
+import { illuminateReducer } from "./reducer";
 import {
+  ACCUMULATOR_HARD_CAP,
   DEFAULT_ILLUMINATE_CONTROLS,
+  edgeIdOf,
   INITIAL_ILLUMINATE_STATE,
   type IlluminateControls,
-  type IlluminateFrame,
   type IlluminateState,
 } from "./state";
 
-function withSeed(seed: string): IlluminateState {
-  // Mimic an arrival from a URL-level navigation.
+/**
+ * Helpers — keep test bodies focused on the assertion. We never reach
+ * for `as any`: the model is small enough to type honestly.
+ */
+function v(key: string): Vertex {
+  return { key };
+}
+
+function e(tail: string, head: string, weight = 1): Edge {
+  return { tail, head, weight };
+}
+
+function afterUrlSeed(seed: string | null): IlluminateState {
   return illuminateReducer(INITIAL_ILLUMINATE_STATE, {
-    type: "SEED_CHANGED",
+    type: "INITIAL_SEED_CHANGED",
     seed,
   });
 }
 
-function frame(seed: string): IlluminateFrame {
-  return {
-    seed,
-    controls: DEFAULT_ILLUMINATE_CONTROLS,
-    vertices: [{ key: seed }],
-    edges: [],
-  };
+function afterExpansion(
+  state: IlluminateState,
+  opts: {
+    expansionId: number;
+    origin: string;
+    vertices: Vertex[];
+    edges: Edge[];
+    receivedAtMs?: number;
+  },
+): IlluminateState {
+  const requested = illuminateReducer(state, {
+    type: "EXPANSION_REQUESTED",
+    expansionId: opts.expansionId,
+    origin: opts.origin,
+    controls: state.controls,
+    startedAtMs: 0,
+  });
+  return illuminateReducer(requested, {
+    type: "EXPANSION_RECEIVED",
+    expansionId: opts.expansionId,
+    origin: opts.origin,
+    controls: state.controls,
+    startedAtMs: 0,
+    vertices: opts.vertices,
+    edges: opts.edges,
+    receivedAtMs: opts.receivedAtMs ?? 100,
+  });
 }
 
 describe("illuminateReducer", () => {
-  describe("SEED_CHANGED", () => {
-    it("is identity when the seed is unchanged", () => {
+  describe("INITIAL_SEED_CHANGED", () => {
+    it("is identity when the seed is unchanged (both null)", () => {
       const next = illuminateReducer(INITIAL_ILLUMINATE_STATE, {
-        type: "SEED_CHANGED",
-        seed: "",
+        type: "INITIAL_SEED_CHANGED",
+        seed: null,
       });
       expect(next).toBe(INITIAL_ILLUMINATE_STATE);
     });
 
-    it("replaces history and bumps the epoch", () => {
-      const next = illuminateReducer(INITIAL_ILLUMINATE_STATE, {
-        type: "SEED_CHANGED",
-        seed: "user:1",
-      });
-      expect(next.seed).toBe("user:1");
-      expect(next.history).toEqual(["user:1"]);
-      expect(next.fetchEpoch).toBe(1);
-      expect(next.frame).toBeNull();
+    it("adopts a new URL seed and resets the accumulator", () => {
+      const seeded = afterUrlSeed("user:1");
+      expect(seeded.initialSeed).toBe("user:1");
+      expect(seeded.accumulator.vertices.size).toBe(0);
+      expect(seeded.expansions).toEqual([]);
+      expect(seeded.status).toBe("idle");
+      expect(seeded.error).toBeNull();
     });
 
-    it("empties history when the seed is cleared", () => {
-      const seeded = withSeed("user:1");
-      const next = illuminateReducer(seeded, {
-        type: "SEED_CHANGED",
-        seed: "",
+    it("preserves controls across an INITIAL_SEED_CHANGED", () => {
+      const custom: IlluminateControls = {
+        ...DEFAULT_ILLUMINATE_CONTROLS,
+        step: 4,
+        k: 16,
+      };
+      const withControls = illuminateReducer(afterUrlSeed("a"), {
+        type: "CONTROLS_CHANGED",
+        controls: custom,
       });
-      expect(next.seed).toBe("");
-      expect(next.history).toEqual([]);
-      expect(next.status).toBe("idle");
+      const reseeded = illuminateReducer(withControls, {
+        type: "INITIAL_SEED_CHANGED",
+        seed: "b",
+      });
+      expect(reseeded.controls).toEqual(custom);
+      expect(reseeded.initialSeed).toBe("b");
+    });
+
+    it("clears the seed back to null when the URL drops ?seed=", () => {
+      const seeded = afterUrlSeed("a");
+      const cleared = illuminateReducer(seeded, {
+        type: "INITIAL_SEED_CHANGED",
+        seed: null,
+      });
+      expect(cleared.initialSeed).toBeNull();
+      expect(cleared.accumulator.vertices.size).toBe(0);
     });
   });
 
-  describe("SEED_PUSHED / SEED_POPPED", () => {
-    it("pushes a new seed onto history", () => {
-      const a = withSeed("a");
-      const ab = illuminateReducer(a, { type: "SEED_PUSHED", seed: "b" });
-      expect(ab.seed).toBe("b");
-      expect(ab.history).toEqual(["a", "b"]);
-      expect(ab.fetchEpoch).toBe(a.fetchEpoch + 1);
+  describe("EXPANSION lifecycle", () => {
+    it("flips to loading on EXPANSION_REQUESTED", () => {
+      const seeded = afterUrlSeed("a");
+      const next = illuminateReducer(seeded, {
+        type: "EXPANSION_REQUESTED",
+        expansionId: 1,
+        origin: "a",
+        controls: seeded.controls,
+        startedAtMs: 0,
+      });
+      expect(next.status).toBe("loading");
+      expect(next.pendingCount).toBe(1);
     });
 
-    it("ignores SEED_PUSHED for an empty or duplicate seed", () => {
-      const a = withSeed("a");
-      expect(illuminateReducer(a, { type: "SEED_PUSHED", seed: "" })).toBe(a);
-      expect(illuminateReducer(a, { type: "SEED_PUSHED", seed: "a" })).toBe(a);
+    it("merges vertices and edges and appends to expansions", () => {
+      const seeded = afterUrlSeed("a");
+      const next = afterExpansion(seeded, {
+        expansionId: 1,
+        origin: "a",
+        vertices: [v("a"), v("b"), v("c")],
+        edges: [e("a", "b", 2), e("a", "c", 3)],
+      });
+      expect(next.accumulator.vertices.size).toBe(3);
+      expect(next.accumulator.edges.size).toBe(2);
+      expect(next.expansions).toHaveLength(1);
+      expect(next.expansions[0]?.origin).toBe("a");
+      expect(next.expansions[0]?.vertexKeys).toEqual(["a", "b", "c"]);
+      expect(next.expansions[0]?.edgeIds).toEqual([
+        edgeIdOf("a", "b"),
+        edgeIdOf("a", "c"),
+      ]);
+      expect(next.status).toBe("ready");
+      expect(next.pendingCount).toBe(0);
     });
 
-    it("pops back to the previous seed", () => {
-      let state = withSeed("a");
-      state = illuminateReducer(state, { type: "SEED_PUSHED", seed: "b" });
-      state = illuminateReducer(state, { type: "SEED_PUSHED", seed: "c" });
-      const popped = illuminateReducer(state, { type: "SEED_POPPED" });
-      expect(popped.seed).toBe("b");
-      expect(popped.history).toEqual(["a", "b"]);
+    it("is additive across two expansions — no node is dropped", () => {
+      const seeded = afterUrlSeed("a");
+      const after1 = afterExpansion(seeded, {
+        expansionId: 1,
+        origin: "a",
+        vertices: [v("a"), v("b")],
+        edges: [e("a", "b")],
+      });
+      const after2 = afterExpansion(after1, {
+        expansionId: 2,
+        origin: "b",
+        vertices: [v("b"), v("c")],
+        edges: [e("b", "c")],
+      });
+      expect(after2.accumulator.vertices.size).toBe(3);
+      expect([...after2.accumulator.vertices.keys()].sort()).toEqual([
+        "a",
+        "b",
+        "c",
+      ]);
+      // b appears in both expansion-index lists; latest-wins on the
+      // `vertex` payload.
+      expect(after2.accumulator.vertices.get("b")?.expansionIndexes).toEqual([
+        0, 1,
+      ]);
+      expect(after2.expansions).toHaveLength(2);
+      expect(after2.expansions[1]?.origin).toBe("b");
+      // `vertexKeys` mirrors the response payload — both `b` and `c`
+      // came back even though `b` was already in the accumulator.
+      expect(after2.expansions[1]?.vertexKeys).toEqual(["b", "c"]);
+      expect(after2.expansions[1]?.edgeIds).toEqual([edgeIdOf("b", "c")]);
     });
 
-    it("ignores SEED_POPPED at the root of history", () => {
-      const a = withSeed("a");
-      expect(illuminateReducer(a, { type: "SEED_POPPED" })).toBe(a);
+    it("is latest-wins on the vertex payload (#466 D3/D4)", () => {
+      const seeded = afterUrlSeed("a");
+      const first = afterExpansion(seeded, {
+        expansionId: 1,
+        origin: "a",
+        vertices: [{ key: "a", string: "old" }],
+        edges: [],
+        receivedAtMs: 50,
+      });
+      const second = afterExpansion(first, {
+        expansionId: 2,
+        origin: "a",
+        vertices: [{ key: "a", string: "new" }],
+        edges: [],
+        receivedAtMs: 100,
+      });
+      expect(second.accumulator.vertices.get("a")?.vertex.string).toBe("new");
+      expect(second.accumulator.vertices.get("a")?.receivedAtMs).toBe(100);
+    });
+
+    it("dedups vertex keys within a single response", () => {
+      const seeded = afterUrlSeed("a");
+      const next = afterExpansion(seeded, {
+        expansionId: 1,
+        origin: "a",
+        vertices: [v("a"), v("a"), v("b")],
+        edges: [],
+      });
+      expect(next.accumulator.vertices.size).toBe(2);
+      expect(next.expansions[0]?.vertexKeys).toEqual(["a", "b"]);
+    });
+
+    it("drops vertices without a key", () => {
+      const seeded = afterUrlSeed("a");
+      const next = afterExpansion(seeded, {
+        expansionId: 1,
+        origin: "a",
+        vertices: [v("a"), { key: "" }],
+        edges: [],
+      });
+      expect([...next.accumulator.vertices.keys()]).toEqual(["a"]);
+    });
+
+    it("drops edges missing tail or head", () => {
+      const seeded = afterUrlSeed("a");
+      const next = afterExpansion(seeded, {
+        expansionId: 1,
+        origin: "a",
+        vertices: [v("a"), v("b")],
+        edges: [e("a", "b"), { tail: "", head: "b", weight: 1 }],
+      });
+      expect(next.accumulator.edges.size).toBe(1);
+    });
+
+    it("records an EXPANSION_FAILED error and decrements pendingCount", () => {
+      const seeded = afterUrlSeed("a");
+      const requested = illuminateReducer(seeded, {
+        type: "EXPANSION_REQUESTED",
+        expansionId: 1,
+        origin: "a",
+        controls: seeded.controls,
+        startedAtMs: 0,
+      });
+      const failed = illuminateReducer(requested, {
+        type: "EXPANSION_FAILED",
+        expansionId: 1,
+        error: "boom",
+      });
+      expect(failed.status).toBe("error");
+      expect(failed.error).toBe("boom");
+      expect(failed.pendingCount).toBe(0);
+    });
+
+    it("treats EXPANSION_FAILED with empty error as a silent abort", () => {
+      const seeded = afterUrlSeed("a");
+      const requested = illuminateReducer(seeded, {
+        type: "EXPANSION_REQUESTED",
+        expansionId: 1,
+        origin: "a",
+        controls: seeded.controls,
+        startedAtMs: 0,
+      });
+      const aborted = illuminateReducer(requested, {
+        type: "EXPANSION_FAILED",
+        expansionId: 1,
+        error: "",
+      });
+      // Error is still recorded but is the empty string — the page won't
+      // render a MessageBar for an empty error.
+      expect(aborted.pendingCount).toBe(0);
+      expect(aborted.error).toBe("");
+    });
+  });
+
+  describe("hard cap (#466 D13)", () => {
+    it("rejects an EXPANSION_RECEIVED that would push past the hard cap", () => {
+      let state = afterUrlSeed("a");
+      // Pre-fill the accumulator to one below the cap.
+      const bigVertices: Vertex[] = [];
+      for (let i = 0; i < ACCUMULATOR_HARD_CAP - 1; i += 1) {
+        bigVertices.push(v(`pre:${i}`));
+      }
+      state = afterExpansion(state, {
+        expansionId: 1,
+        origin: "a",
+        vertices: bigVertices,
+        edges: [],
+      });
+      expect(state.accumulator.vertices.size).toBe(ACCUMULATOR_HARD_CAP - 1);
+
+      // Now request an expansion that adds two more vertices — over cap.
+      const requested = illuminateReducer(state, {
+        type: "EXPANSION_REQUESTED",
+        expansionId: 2,
+        origin: "a",
+        controls: state.controls,
+        startedAtMs: 0,
+      });
+      const rejected = illuminateReducer(requested, {
+        type: "EXPANSION_RECEIVED",
+        expansionId: 2,
+        origin: "a",
+        controls: state.controls,
+        startedAtMs: 0,
+        vertices: [v("over:0"), v("over:1")],
+        edges: [],
+        receivedAtMs: 1,
+      });
+      // Accumulator untouched.
+      expect(rejected.accumulator.vertices.size).toBe(ACCUMULATOR_HARD_CAP - 1);
+      // Expansions list NOT appended.
+      expect(rejected.expansions).toHaveLength(state.expansions.length);
+      expect(rejected.status).toBe("error");
+      expect(rejected.error).toMatch(/hard cap/);
     });
   });
 
   describe("CONTROLS_CHANGED", () => {
     it("is identity when the controls are unchanged by value", () => {
-      const a = withSeed("a");
-      const next = illuminateReducer(a, {
+      const seeded = afterUrlSeed("a");
+      const next = illuminateReducer(seeded, {
         type: "CONTROLS_CHANGED",
         controls: { ...DEFAULT_ILLUMINATE_CONTROLS },
       });
-      expect(next).toBe(a);
+      expect(next).toBe(seeded);
     });
 
-    it("records new controls and bumps the epoch", () => {
-      const a = withSeed("a");
-      const controls: IlluminateControls = {
-        ...DEFAULT_ILLUMINATE_CONTROLS,
-        step: 4,
-        k: 16,
-      };
-      const next = illuminateReducer(a, {
-        type: "CONTROLS_CHANGED",
-        controls,
+    it("updates controls without touching the accumulator or expansions (#466 D8)", () => {
+      let state = afterUrlSeed("a");
+      state = afterExpansion(state, {
+        expansionId: 1,
+        origin: "a",
+        vertices: [v("a"), v("b")],
+        edges: [e("a", "b")],
       });
-      expect(next.controls).toEqual(controls);
-      expect(next.fetchEpoch).toBe(a.fetchEpoch + 1);
-    });
-
-    it("keeps the existing frame on screen while reloading", () => {
-      let state = withSeed("a");
-      state = illuminateReducer(state, {
-        type: "FETCH_RECEIVED",
-        epoch: state.fetchEpoch,
-        frame: frame("a"),
-      });
+      const before = state;
       const next = illuminateReducer(state, {
         type: "CONTROLS_CHANGED",
-        controls: { ...DEFAULT_ILLUMINATE_CONTROLS, step: 3 },
+        controls: { ...DEFAULT_ILLUMINATE_CONTROLS, step: 4 },
       });
-      expect(next.frame).toBe(state.frame);
+      expect(next.controls.step).toBe(4);
+      expect(next.accumulator).toBe(before.accumulator);
+      expect(next.expansions).toBe(before.expansions);
     });
   });
 
-  describe("REFETCH_REQUESTED", () => {
-    it("bumps the epoch when there is an active seed", () => {
-      const a = withSeed("a");
-      const next = illuminateReducer(a, { type: "REFETCH_REQUESTED" });
-      expect(next.fetchEpoch).toBe(a.fetchEpoch + 1);
-    });
-
-    it("is a no-op when there is no seed", () => {
-      const next = illuminateReducer(INITIAL_ILLUMINATE_STATE, {
-        type: "REFETCH_REQUESTED",
+  describe("CLEARED", () => {
+    it("empties accumulator and expansions but preserves initialSeed + controls", () => {
+      let state = afterUrlSeed("a");
+      state = illuminateReducer(state, {
+        type: "CONTROLS_CHANGED",
+        controls: { ...DEFAULT_ILLUMINATE_CONTROLS, k: 16 },
       });
-      expect(next).toBe(INITIAL_ILLUMINATE_STATE);
-    });
-  });
-
-  describe("FETCH_REQUESTED / FETCH_RECEIVED / FETCH_FAILED", () => {
-    it("transitions to loading on a fresh epoch", () => {
-      const a = withSeed("a");
-      const next = illuminateReducer(a, {
-        type: "FETCH_REQUESTED",
-        epoch: a.fetchEpoch,
+      state = afterExpansion(state, {
+        expansionId: 1,
+        origin: "a",
+        vertices: [v("a"), v("b")],
+        edges: [e("a", "b")],
       });
-      expect(next.status).toBe("loading");
-    });
-
-    it("drops stale request markers", () => {
-      const a = withSeed("a");
-      const action: IlluminateAction = {
-        type: "FETCH_REQUESTED",
-        epoch: a.fetchEpoch - 1,
-      };
-      expect(illuminateReducer(a, action)).toBe(a);
-    });
-
-    it("records the received frame and flips to ready", () => {
-      const a = withSeed("a");
-      const next = illuminateReducer(a, {
-        type: "FETCH_RECEIVED",
-        epoch: a.fetchEpoch,
-        frame: frame("a"),
-      });
-      expect(next.status).toBe("ready");
-      expect(next.frame?.seed).toBe("a");
-    });
-
-    it("drops stale frames", () => {
-      const a = withSeed("a");
-      const next = illuminateReducer(a, {
-        type: "FETCH_RECEIVED",
-        epoch: a.fetchEpoch - 1,
-        frame: frame("stale"),
-      });
-      expect(next).toBe(a);
-    });
-
-    it("records errors at the current epoch", () => {
-      const a = withSeed("a");
-      const next = illuminateReducer(a, {
-        type: "FETCH_FAILED",
-        epoch: a.fetchEpoch,
-        error: "boom",
-      });
-      expect(next.status).toBe("error");
-      expect(next.error).toBe("boom");
-    });
-
-    it("drops stale errors", () => {
-      const a = withSeed("a");
-      const next = illuminateReducer(a, {
-        type: "FETCH_FAILED",
-        epoch: a.fetchEpoch - 1,
-        error: "old",
-      });
-      expect(next).toBe(a);
+      const cleared = illuminateReducer(state, { type: "CLEARED" });
+      expect(cleared.initialSeed).toBe("a");
+      expect(cleared.controls.k).toBe(16);
+      expect(cleared.accumulator.vertices.size).toBe(0);
+      expect(cleared.expansions).toEqual([]);
+      expect(cleared.status).toBe("idle");
+      expect(cleared.pendingCount).toBe(0);
     });
   });
 
   describe("RESET", () => {
-    it("returns to initial state and bumps the epoch", () => {
-      const a = withSeed("a");
-      const next = illuminateReducer(a, { type: "RESET" });
-      expect(next.seed).toBe("");
-      expect(next.history).toEqual([]);
-      expect(next.fetchEpoch).toBe(a.fetchEpoch + 1);
+    it("wipes everything except controls", () => {
+      let state = afterUrlSeed("a");
+      state = illuminateReducer(state, {
+        type: "CONTROLS_CHANGED",
+        controls: { ...DEFAULT_ILLUMINATE_CONTROLS, step: 3 },
+      });
+      state = afterExpansion(state, {
+        expansionId: 1,
+        origin: "a",
+        vertices: [v("a"), v("b")],
+        edges: [e("a", "b")],
+      });
+      const next = illuminateReducer(state, { type: "RESET" });
+      expect(next.initialSeed).toBeNull();
+      expect(next.accumulator.vertices.size).toBe(0);
+      expect(next.expansions).toEqual([]);
+      expect(next.controls.step).toBe(3); // preserved
     });
   });
 });

--- a/admin/app/lib/client/usecase/illuminate/reducer.ts
+++ b/admin/app/lib/client/usecase/illuminate/reducer.ts
@@ -1,136 +1,246 @@
+import type { Edge, Vertex } from "~/lib/client/infrastructure/api/illuminate";
 import {
+  ACCUMULATOR_HARD_CAP,
   INITIAL_ILLUMINATE_STATE,
+  edgeIdOf,
+  type AccumEdge,
+  type AccumVertex,
+  type Expansion,
   type IlluminateControls,
-  type IlluminateFrame,
   type IlluminateState,
 } from "./state";
 
 export type IlluminateAction =
-  | { type: "SEED_CHANGED"; seed: string }
-  | { type: "SEED_PUSHED"; seed: string }
-  | { type: "SEED_POPPED" }
+  | { type: "INITIAL_SEED_CHANGED"; seed: string | null }
+  | {
+      type: "EXPANSION_REQUESTED";
+      expansionId: number;
+      origin: string;
+      controls: IlluminateControls;
+      startedAtMs: number;
+    }
+  | {
+      type: "EXPANSION_RECEIVED";
+      expansionId: number;
+      origin: string;
+      controls: IlluminateControls;
+      startedAtMs: number;
+      vertices: Vertex[];
+      edges: Edge[];
+      /** Wall-clock-ish ms used as the merge timestamp. */
+      receivedAtMs: number;
+    }
+  | { type: "EXPANSION_FAILED"; expansionId: number; error: string }
   | { type: "CONTROLS_CHANGED"; controls: IlluminateControls }
-  | { type: "REFETCH_REQUESTED" }
-  | { type: "FETCH_REQUESTED"; epoch: number }
-  | { type: "FETCH_RECEIVED"; epoch: number; frame: IlluminateFrame }
-  | { type: "FETCH_FAILED"; epoch: number; error: string }
+  | { type: "CLEARED" }
   | { type: "RESET" };
 
 /**
  * Pure reducer for the Illuminate view. Async I/O lives in `handlers.ts`;
  * this module is the single source of truth for state transitions and is
  * therefore unit-testable without touching the network.
+ *
+ * Per #466 the model is additive: each `EXPANSION_RECEIVED` merges the
+ * server response into the accumulator (latest-response-wins per D3/D4)
+ * and appends an `Expansion` to the audit trail. `CLEARED` empties
+ * everything but preserves the `initialSeed` so the next URL render
+ * can re-run the seed expansion; `RESET` also forgets the seed.
  */
 export function illuminateReducer(
   state: IlluminateState,
   action: IlluminateAction,
 ): IlluminateState {
   switch (action.type) {
-    case "SEED_CHANGED": {
-      if (action.seed === state.seed) {
+    case "INITIAL_SEED_CHANGED": {
+      if (action.seed === state.initialSeed) {
         return state;
       }
-      // Replace history entirely — `SEED_CHANGED` represents a URL-level
-      // navigation (e.g. arriving on the page from the Browse screen), not
-      // a click inside the canvas. Use `SEED_PUSHED` for the latter.
-      const history = action.seed === "" ? [] : [action.seed];
+      // A URL-level seed change wipes everything we know — the new seed
+      // implies a fresh exploration. The hook is responsible for aborting
+      // any in-flight controllers BEFORE dispatching this so we don't end
+      // up merging a stale fetch into the cleared accumulator.
       return {
-        ...state,
-        seed: action.seed,
-        history,
-        frame: null,
-        status: action.seed === "" ? "idle" : state.status,
-        error: null,
-        fetchEpoch: state.fetchEpoch + 1,
+        ...INITIAL_ILLUMINATE_STATE,
+        controls: state.controls,
+        initialSeed: action.seed,
       };
     }
-    case "SEED_PUSHED": {
-      if (action.seed === "" || action.seed === state.seed) {
-        return state;
-      }
+    case "EXPANSION_REQUESTED": {
+      // Optimistic counter — the badge flips to "loading" immediately so
+      // the user sees feedback even though the merge hasn't landed yet.
       return {
         ...state,
-        seed: action.seed,
-        history: [...state.history, action.seed],
-        frame: null,
+        pendingCount: state.pendingCount + 1,
+        status: "loading",
         error: null,
-        fetchEpoch: state.fetchEpoch + 1,
       };
     }
-    case "SEED_POPPED": {
-      if (state.history.length <= 1) {
-        return state;
+    case "EXPANSION_RECEIVED": {
+      const merged = mergeExpansion(state, action);
+      if (merged === null) {
+        // Hard cap exceeded — surface as an error and discount the
+        // pending counter so the badge clears.
+        const pendingCount = Math.max(0, state.pendingCount - 1);
+        return {
+          ...state,
+          pendingCount,
+          status: pendingCount > 0 ? "loading" : "error",
+          error: `Accumulator hard cap of ${ACCUMULATOR_HARD_CAP} vertices reached — click Clear to start over.`,
+        };
       }
-      const history = state.history.slice(0, -1);
-      const seed = history[history.length - 1] ?? "";
+      const pendingCount = Math.max(0, state.pendingCount - 1);
+      return {
+        ...merged,
+        pendingCount,
+        status: pendingCount > 0 ? "loading" : "ready",
+        error: null,
+      };
+    }
+    case "EXPANSION_FAILED": {
+      const pendingCount = Math.max(0, state.pendingCount - 1);
       return {
         ...state,
-        seed,
-        history,
-        frame: null,
-        error: null,
-        fetchEpoch: state.fetchEpoch + 1,
+        pendingCount,
+        status: pendingCount > 0 ? "loading" : "error",
+        error: action.error,
       };
     }
     case "CONTROLS_CHANGED": {
       if (controlsEqual(action.controls, state.controls)) {
         return state;
       }
+      // Per #466 D8 a control change does NOT touch the accumulator and
+      // does NOT trigger a refetch — only the next click sees the new
+      // values. Just clear any stale error so the toolbar isn't sticky.
       return {
         ...state,
         controls: action.controls,
-        // Keep the existing frame on screen until the new one arrives so
-        // the user doesn't see a flash of empty canvas while dragging a
-        // slider; clear `error` because the old failure no longer applies.
-        error: null,
-        fetchEpoch: state.fetchEpoch + 1,
-      };
-    }
-    case "REFETCH_REQUESTED": {
-      // No-op when there's no seed to fetch — guard rail so toolbar can
-      // dispatch unconditionally.
-      if (state.seed === "") {
-        return state;
-      }
-      return {
-        ...state,
-        error: null,
-        fetchEpoch: state.fetchEpoch + 1,
-      };
-    }
-    case "FETCH_REQUESTED": {
-      if (action.epoch !== state.fetchEpoch) {
-        return state;
-      }
-      return { ...state, status: "loading", error: null };
-    }
-    case "FETCH_RECEIVED": {
-      if (action.epoch !== state.fetchEpoch) {
-        return state;
-      }
-      return {
-        ...state,
-        frame: action.frame,
-        status: "ready",
         error: null,
       };
     }
-    case "FETCH_FAILED": {
-      if (action.epoch !== state.fetchEpoch) {
-        return state;
-      }
-      return { ...state, status: "error", error: action.error };
-    }
-    case "RESET":
+    case "CLEARED": {
+      // Empty the canvas but keep the initialSeed; the hook re-runs the
+      // seed expansion afterwards so the user lands on a fresh seed frame
+      // rather than the empty SeedPrompt.
       return {
         ...INITIAL_ILLUMINATE_STATE,
-        fetchEpoch: state.fetchEpoch + 1,
+        controls: state.controls,
+        initialSeed: state.initialSeed,
       };
+    }
+    case "RESET": {
+      return { ...INITIAL_ILLUMINATE_STATE, controls: state.controls };
+    }
     default: {
       const exhaustive: never = action;
       return exhaustive;
     }
   }
+}
+
+/**
+ * Merge the response from one expansion into the accumulator. Returns
+ * `null` when the merge would push the vertex count past the hard cap
+ * (#466 D13); the caller surfaces that as an error.
+ */
+function mergeExpansion(
+  state: IlluminateState,
+  action: Extract<IlluminateAction, { type: "EXPANSION_RECEIVED" }>,
+): IlluminateState | null {
+  const vertices = new Map(state.accumulator.vertices);
+  const edges = new Map(state.accumulator.edges);
+
+  // Vertices first — collect normalised keys for dedup + audit + the
+  // hard-cap check. We treat empty/null keys as no-ops so a server
+  // response can't poison the accumulator with anonymous nodes.
+  const newVertexKeys: string[] = [];
+  const seenVertexKeys = new Set<string>();
+  for (const v of action.vertices) {
+    const key = typeof v.key === "string" ? v.key : "";
+    if (key === "" || seenVertexKeys.has(key)) continue;
+    seenVertexKeys.add(key);
+    newVertexKeys.push(key);
+  }
+
+  // Hard cap — reject merges that would exceed it. We compute the
+  // post-merge size by counting only vertices NOT already in the
+  // accumulator (the merge is idempotent on keys).
+  let projectedSize = vertices.size;
+  for (const key of newVertexKeys) {
+    if (!vertices.has(key)) projectedSize += 1;
+  }
+  if (projectedSize > ACCUMULATOR_HARD_CAP) {
+    return null;
+  }
+
+  // Append the expansion record FIRST so vertex/edge audit indexes can
+  // reference it. Append-only means the index stays stable.
+  const expansionIndex = state.expansions.length;
+  for (const key of newVertexKeys) {
+    const prev = vertices.get(key);
+    const indexes = prev
+      ? withIndex(prev.expansionIndexes, expansionIndex)
+      : [expansionIndex];
+    const vertex = findVertex(action.vertices, key) ?? prev?.vertex;
+    if (!vertex) continue;
+    const merged: AccumVertex = {
+      vertex,
+      receivedAtMs: action.receivedAtMs,
+      expansionIndexes: indexes,
+    };
+    vertices.set(key, merged);
+  }
+
+  const newEdgeIds: string[] = [];
+  const seenEdgeIds = new Set<string>();
+  for (const e of action.edges) {
+    const tail = typeof e.tail === "string" ? e.tail : "";
+    const head = typeof e.head === "string" ? e.head : "";
+    if (tail === "" || head === "") continue;
+    const id = edgeIdOf(tail, head);
+    if (seenEdgeIds.has(id)) continue;
+    seenEdgeIds.add(id);
+    newEdgeIds.push(id);
+    const prev = edges.get(id);
+    const indexes = prev
+      ? withIndex(prev.expansionIndexes, expansionIndex)
+      : [expansionIndex];
+    const merged: AccumEdge = {
+      edge: e,
+      receivedAtMs: action.receivedAtMs,
+      expansionIndexes: indexes,
+    };
+    edges.set(id, merged);
+  }
+
+  const expansion: Expansion = {
+    id: action.expansionId,
+    origin: action.origin,
+    controls: action.controls,
+    startedAtMs: action.startedAtMs,
+    vertexKeys: newVertexKeys,
+    edgeIds: newEdgeIds,
+  };
+
+  return {
+    ...state,
+    accumulator: { vertices, edges },
+    expansions: [...state.expansions, expansion],
+  };
+}
+
+function findVertex(list: Vertex[], key: string): Vertex | null {
+  for (const v of list) {
+    if (v.key === key) return v;
+  }
+  return null;
+}
+
+function withIndex(list: number[], index: number): number[] {
+  if (list.length > 0 && list[list.length - 1] === index) {
+    return list;
+  }
+  return [...list, index];
 }
 
 function controlsEqual(a: IlluminateControls, b: IlluminateControls): boolean {

--- a/admin/app/lib/client/usecase/illuminate/selectors.test.ts
+++ b/admin/app/lib/client/usecase/illuminate/selectors.test.ts
@@ -1,119 +1,270 @@
 import { describe, expect, it } from "bun:test";
-import { selectCanPop, selectGraphView, selectIsBusy } from "./selectors";
+import type { Edge, Vertex } from "~/lib/client/infrastructure/api/illuminate";
+import { illuminateReducer } from "./reducer";
 import {
-  DEFAULT_ILLUMINATE_CONTROLS,
+  selectCanClear,
+  selectExpansionCount,
+  selectGraphView,
+  selectIsBusy,
+} from "./selectors";
+import {
+  ACCUMULATOR_SOFT_CAP,
   INITIAL_ILLUMINATE_STATE,
-  type IlluminateFrame,
   type IlluminateState,
 } from "./state";
 
-function stateWith(frame: IlluminateFrame | null): IlluminateState {
-  return {
-    ...INITIAL_ILLUMINATE_STATE,
-    seed: frame?.seed ?? "",
-    history: frame ? [frame.seed] : [],
-    frame,
-    status: frame ? "ready" : "idle",
-  };
+function v(key: string): Vertex {
+  return { key };
+}
+
+function e(tail: string, head: string, weight = 1): Edge {
+  return { tail, head, weight };
+}
+
+function applyExpansion(
+  state: IlluminateState,
+  opts: {
+    expansionId: number;
+    origin: string;
+    vertices: Vertex[];
+    edges: Edge[];
+  },
+): IlluminateState {
+  const requested = illuminateReducer(state, {
+    type: "EXPANSION_REQUESTED",
+    expansionId: opts.expansionId,
+    origin: opts.origin,
+    controls: state.controls,
+    startedAtMs: 0,
+  });
+  return illuminateReducer(requested, {
+    type: "EXPANSION_RECEIVED",
+    expansionId: opts.expansionId,
+    origin: opts.origin,
+    controls: state.controls,
+    startedAtMs: 0,
+    vertices: opts.vertices,
+    edges: opts.edges,
+    receivedAtMs: 100 * opts.expansionId,
+  });
+}
+
+function stateWithInitialSeed(seed: string): IlluminateState {
+  return illuminateReducer(INITIAL_ILLUMINATE_STATE, {
+    type: "INITIAL_SEED_CHANGED",
+    seed,
+  });
 }
 
 describe("selectGraphView", () => {
-  it("returns empty arrays when no frame has been received", () => {
+  it("returns empty arrays when no expansion has been received", () => {
     const view = selectGraphView(INITIAL_ILLUMINATE_STATE);
     expect(view.nodes).toEqual([]);
     expect(view.edges).toEqual([]);
+    expect(view.latestExpansionOrigin).toBeNull();
+    expect(view.expansionOrigins).toEqual([]);
+    expect(view.overSoftCap).toBe(false);
   });
 
-  it("marks the seed node and renders all returned vertices", () => {
-    const frame: IlluminateFrame = {
-      seed: "a",
-      controls: DEFAULT_ILLUMINATE_CONTROLS,
-      vertices: [{ key: "a" }, { key: "b" }, { key: "c" }],
-      edges: [
-        { tail: "a", head: "b", weight: 1 },
-        { tail: "a", head: "c", weight: 3 },
-      ],
-    };
-    const view = selectGraphView(stateWith(frame));
-    expect(view.nodes.map((n) => n.id).sort()).toEqual(["a", "b", "c"]);
-    const seed = view.nodes.find((n) => n.id === "a");
-    expect(seed?.isSeed).toBe(true);
-    expect(seed?.importance).toBe(1);
+  it("marks the initial seed and the expansion origin", () => {
+    let state = stateWithInitialSeed("a");
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "a",
+      vertices: [v("a"), v("b"), v("c")],
+      edges: [e("a", "b", 1), e("a", "c", 3)],
+    });
+    const view = selectGraphView(state);
+    const a = view.nodes.find((n) => n.id === "a");
+    const b = view.nodes.find((n) => n.id === "b");
     const c = view.nodes.find((n) => n.id === "c");
-    expect(c?.isSeed).toBe(false);
-    // Importance is normalised against the highest weight sum (here `c`
-    // shares all 3 weight units with the seed; `b` has 1 unit). The seed
-    // is pinned to 1 regardless.
+    expect(a?.isInitialSeed).toBe(true);
+    expect(a?.isExpansionOrigin).toBe(true);
+    expect(a?.importance).toBe(1);
+    expect(b?.isInitialSeed).toBe(false);
+    expect(b?.isExpansionOrigin).toBe(false);
+    // Importance is normalised against the heaviest non-origin node.
     expect(c?.importance).toBeGreaterThan(0);
     expect(c?.importance).toBeLessThanOrEqual(1);
   });
 
-  it("drops vertices that lack a key", () => {
-    const frame: IlluminateFrame = {
-      seed: "a",
-      controls: DEFAULT_ILLUMINATE_CONTROLS,
-      vertices: [{ key: "a" }, { key: "" }, {} as { key?: string }],
-      edges: [],
-    };
-    const view = selectGraphView(stateWith(frame));
-    expect(view.nodes.map((n) => n.id)).toEqual(["a"]);
+  it("tracks every expansion origin in insertion order, latest last", () => {
+    let state = stateWithInitialSeed("a");
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "a",
+      vertices: [v("a"), v("b")],
+      edges: [e("a", "b")],
+    });
+    state = applyExpansion(state, {
+      expansionId: 2,
+      origin: "b",
+      vertices: [v("b"), v("c")],
+      edges: [e("b", "c")],
+    });
+    const view = selectGraphView(state);
+    expect(view.expansionOrigins).toEqual(["a", "b"]);
+    expect(view.latestExpansionOrigin).toBe("b");
+    // Both 'a' and 'b' are expansion origins; only 'a' is the initial seed.
+    expect(view.nodes.find((n) => n.id === "a")?.isExpansionOrigin).toBe(true);
+    expect(view.nodes.find((n) => n.id === "b")?.isExpansionOrigin).toBe(true);
+    expect(view.nodes.find((n) => n.id === "a")?.isInitialSeed).toBe(true);
+    expect(view.nodes.find((n) => n.id === "b")?.isInitialSeed).toBe(false);
   });
 
-  it("drops edges that reference unknown vertices", () => {
-    const frame: IlluminateFrame = {
-      seed: "a",
-      controls: DEFAULT_ILLUMINATE_CONTROLS,
-      vertices: [{ key: "a" }, { key: "b" }],
-      edges: [
-        { tail: "a", head: "b", weight: 1 },
-        // `c` was not returned in the response; this edge must be dropped.
-        { tail: "a", head: "c", weight: 1 },
+  it("attributes firstSeenExpansion to the earliest expansion that brought the vertex in", () => {
+    let state = stateWithInitialSeed("a");
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "a",
+      vertices: [v("a"), v("b")],
+      edges: [e("a", "b")],
+    });
+    state = applyExpansion(state, {
+      expansionId: 2,
+      origin: "b",
+      vertices: [v("b"), v("c")],
+      edges: [e("b", "c")],
+    });
+    const view = selectGraphView(state);
+    expect(view.nodes.find((n) => n.id === "a")?.firstSeenExpansion).toBe(0);
+    expect(view.nodes.find((n) => n.id === "b")?.firstSeenExpansion).toBe(0);
+    expect(view.nodes.find((n) => n.id === "c")?.firstSeenExpansion).toBe(1);
+  });
+
+  it("aggregates edge weights across expansions for importance ranking", () => {
+    let state = stateWithInitialSeed("a");
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "a",
+      vertices: [v("a"), v("b")],
+      edges: [e("a", "b", 2)],
+    });
+    state = applyExpansion(state, {
+      expansionId: 2,
+      origin: "b",
+      vertices: [v("b"), v("a")],
+      edges: [e("b", "a", 5)],
+    });
+    const view = selectGraphView(state);
+    // Two edges in opposite directions; both are kept in the view.
+    expect(view.edges).toHaveLength(2);
+    const ids = view.edges.map((edge) => edge.id).sort();
+    expect(ids).toEqual(["a→b", "b→a"]);
+  });
+
+  it("drops edges that reference unknown vertices (defensive filter)", () => {
+    // Direct-construct a state where the accumulator has a stale edge
+    // pointing at a vanished vertex — the reducer prevents this in
+    // practice, but the selector must still be defensive.
+    const state: IlluminateState = {
+      ...INITIAL_ILLUMINATE_STATE,
+      initialSeed: "a",
+      accumulator: {
+        vertices: new Map([
+          ["a", { vertex: v("a"), receivedAtMs: 1, expansionIndexes: [0] }],
+        ]),
+        edges: new Map([
+          [
+            "a→b",
+            {
+              edge: e("a", "b"),
+              receivedAtMs: 1,
+              expansionIndexes: [0],
+            },
+          ],
+        ]),
+      },
+      expansions: [
+        {
+          id: 1,
+          origin: "a",
+          controls: INITIAL_ILLUMINATE_STATE.controls,
+          startedAtMs: 0,
+          vertexKeys: ["a"],
+          edgeIds: ["a→b"],
+        },
       ],
     };
-    const view = selectGraphView(stateWith(frame));
-    expect(view.edges.map((e) => e.id)).toEqual(["a→b"]);
+    const view = selectGraphView(state);
+    expect(view.edges).toEqual([]);
   });
 
-  it("emits stable IDs for edges", () => {
-    const frame: IlluminateFrame = {
-      seed: "a",
-      controls: DEFAULT_ILLUMINATE_CONTROLS,
-      vertices: [{ key: "a" }, { key: "b" }],
-      edges: [{ tail: "a", head: "b", weight: 1 }],
-    };
-    const view = selectGraphView(stateWith(frame));
-    expect(view.edges[0]?.id).toBe("a→b");
-    expect(view.edges[0]?.source).toBe("a");
-    expect(view.edges[0]?.target).toBe("b");
+  it("flips overSoftCap when the accumulator passes ACCUMULATOR_SOFT_CAP", () => {
+    let state = stateWithInitialSeed("a");
+    const bigVertices: Vertex[] = [];
+    for (let i = 0; i < ACCUMULATOR_SOFT_CAP + 1; i += 1) {
+      bigVertices.push(v(`k:${i}`));
+    }
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "a",
+      vertices: bigVertices,
+      edges: [],
+    });
+    const view = selectGraphView(state);
+    expect(view.overSoftCap).toBe(true);
+  });
+
+  it("does NOT flip overSoftCap at exactly the soft cap", () => {
+    let state = stateWithInitialSeed("a");
+    const bigVertices: Vertex[] = [];
+    for (let i = 0; i < ACCUMULATOR_SOFT_CAP; i += 1) {
+      bigVertices.push(v(`k:${i}`));
+    }
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "a",
+      vertices: bigVertices,
+      edges: [],
+    });
+    const view = selectGraphView(state);
+    expect(view.overSoftCap).toBe(false);
   });
 });
 
-describe("selectCanPop", () => {
-  it("is false until the user pushes a second seed", () => {
-    expect(selectCanPop(INITIAL_ILLUMINATE_STATE)).toBe(false);
-    const single: IlluminateState = {
-      ...INITIAL_ILLUMINATE_STATE,
-      seed: "a",
-      history: ["a"],
-    };
-    expect(selectCanPop(single)).toBe(false);
-    const stacked: IlluminateState = {
-      ...INITIAL_ILLUMINATE_STATE,
-      seed: "b",
-      history: ["a", "b"],
-    };
-    expect(selectCanPop(stacked)).toBe(true);
+describe("selectCanClear", () => {
+  it("is false on a brand-new state", () => {
+    expect(selectCanClear(INITIAL_ILLUMINATE_STATE)).toBe(false);
+  });
+
+  it("is true once an expansion has populated the accumulator", () => {
+    let state = stateWithInitialSeed("a");
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "a",
+      vertices: [v("a")],
+      edges: [],
+    });
+    expect(selectCanClear(state)).toBe(true);
+  });
+});
+
+describe("selectExpansionCount", () => {
+  it("counts the expansions stored in state", () => {
+    let state = stateWithInitialSeed("a");
+    expect(selectExpansionCount(state)).toBe(0);
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "a",
+      vertices: [v("a")],
+      edges: [],
+    });
+    expect(selectExpansionCount(state)).toBe(1);
   });
 });
 
 describe("selectIsBusy", () => {
-  it("is true only during a loading state", () => {
+  it("is false on a brand-new state", () => {
     expect(selectIsBusy(INITIAL_ILLUMINATE_STATE)).toBe(false);
+  });
+
+  it("is true while loading or while any pending expansion remains", () => {
     expect(
       selectIsBusy({ ...INITIAL_ILLUMINATE_STATE, status: "loading" }),
     ).toBe(true);
-    expect(selectIsBusy({ ...INITIAL_ILLUMINATE_STATE, status: "ready" })).toBe(
-      false,
+    expect(selectIsBusy({ ...INITIAL_ILLUMINATE_STATE, pendingCount: 1 })).toBe(
+      true,
     );
   });
 });

--- a/admin/app/lib/client/usecase/illuminate/selectors.ts
+++ b/admin/app/lib/client/usecase/illuminate/selectors.ts
@@ -1,19 +1,27 @@
 import type { Edge, Vertex } from "~/lib/client/infrastructure/api/illuminate";
-import type { IlluminateState } from "./state";
+import { ACCUMULATOR_SOFT_CAP, type IlluminateState } from "./state";
 
 /**
  * Graph node shape consumed by `IlluminateCanvas`. We keep the full
- * Vertex around so the tooltip / a11y table can render typed values
- * without a second pass over the response.
+ * Vertex around so the tooltip / a11y table / Drawer can render typed
+ * values without a second pass over the response.
+ *
+ * `isInitialSeed` replaces the legacy `isSeed`: in the additive model
+ * (#466) the structurally privileged node is the URL-level initial seed
+ * (`expansions[0].origin`), not whichever vertex the user clicked last.
  */
 export interface GraphNode {
   id: string;
   label: string;
   vertex: Vertex;
-  /** True iff this node is the active seed. */
-  isSeed: boolean;
-  /** Edge-weight-derived score in [0, 1], 1.0 for the seed. */
+  /** True iff this node is `initialSeed` — the first expansion's origin. */
+  isInitialSeed: boolean;
+  /** True iff this node was ever the origin of an expansion (D5 chip strip). */
+  isExpansionOrigin: boolean;
+  /** Edge-weight-derived score in [0, 1], 1.0 for the seed and expansion origins. */
   importance: number;
+  /** Index into `state.expansions[]` where this vertex first appeared. */
+  firstSeenExpansion: number;
 }
 
 export interface GraphEdge {
@@ -27,75 +35,113 @@ export interface GraphEdge {
 export interface GraphView {
   nodes: GraphNode[];
   edges: GraphEdge[];
+  /**
+   * The origin of the most recent expansion, or null when the canvas is
+   * empty. `IlluminateCanvas` uses this to seed new-node positions near
+   * the parent click (#466 D7).
+   */
+  latestExpansionOrigin: string | null;
+  /** All expansion origins, in order; used by #456 chip strip and #460 hop coloring. */
+  expansionOrigins: string[];
+  /** True when the accumulator is past the soft cap; UI surfaces a MessageBar. */
+  overSoftCap: boolean;
 }
 
 /**
- * Builds the view model the canvas renders from the most recent fetched
- * frame. Pure; no React, no DOM, no graphology — those live in the
- * component layer so this stays trivial to unit-test.
+ * Builds the view model the canvas renders from the accumulator. Pure;
+ * no React, no DOM, no graphology — those live in the component layer
+ * so this stays trivial to unit-test.
  */
 export function selectGraphView(state: IlluminateState): GraphView {
-  const frame = state.frame;
-  if (!frame) {
-    return { nodes: [], edges: [] };
+  const initialSeed = state.initialSeed;
+  const expansionOrigins = state.expansions.map((e) => e.origin);
+  const latestExpansionOrigin =
+    expansionOrigins.length > 0
+      ? (expansionOrigins[expansionOrigins.length - 1] ?? null)
+      : null;
+
+  if (state.accumulator.vertices.size === 0) {
+    return {
+      nodes: [],
+      edges: [],
+      latestExpansionOrigin,
+      expansionOrigins,
+      overSoftCap: false,
+    };
   }
-  const seed = frame.seed;
+
+  const originSet = new Set(expansionOrigins);
+
+  // Edge weights drive node importance. Aggregate over the merged edges.
   const weightByKey = new Map<string, number>();
-  for (const edge of frame.edges) {
-    if (!edge.tail || !edge.head) continue;
-    weightByKey.set(
-      edge.tail,
-      (weightByKey.get(edge.tail) ?? 0) + (edge.weight ?? 0),
-    );
-    weightByKey.set(
-      edge.head,
-      (weightByKey.get(edge.head) ?? 0) + (edge.weight ?? 0),
-    );
+  for (const acc of state.accumulator.edges.values()) {
+    const e = acc.edge;
+    if (!e.tail || !e.head) continue;
+    const w = e.weight ?? 0;
+    weightByKey.set(e.tail, (weightByKey.get(e.tail) ?? 0) + w);
+    weightByKey.set(e.head, (weightByKey.get(e.head) ?? 0) + w);
   }
   const maxWeight = Math.max(0, ...weightByKey.values());
-  const nodes: GraphNode[] = frame.vertices
-    .filter(
-      (v): v is Vertex & { key: string } =>
-        typeof v.key === "string" && v.key !== "",
-    )
-    .map((v) => {
-      const isSeed = v.key === seed;
-      const raw = weightByKey.get(v.key) ?? 0;
-      const importance = isSeed
+
+  const nodes: GraphNode[] = [];
+  for (const [key, acc] of state.accumulator.vertices) {
+    if (key === "") continue;
+    const isInitialSeed = initialSeed !== null && key === initialSeed;
+    const isExpansionOrigin = originSet.has(key);
+    const raw = weightByKey.get(key) ?? 0;
+    const importance =
+      isInitialSeed || isExpansionOrigin
         ? 1
         : maxWeight > 0
           ? Math.max(0.1, raw / maxWeight)
           : 0.5;
-      return {
-        id: v.key,
-        label: v.key,
-        vertex: v,
-        isSeed,
-        importance,
-      };
+    const firstSeenExpansion = acc.expansionIndexes[0] ?? 0;
+    nodes.push({
+      id: key,
+      label: key,
+      vertex: acc.vertex,
+      isInitialSeed,
+      isExpansionOrigin,
+      importance,
+      firstSeenExpansion,
     });
+  }
+
   const knownKeys = new Set(nodes.map((n) => n.id));
   const edges: GraphEdge[] = [];
-  for (const e of frame.edges) {
+  for (const [id, acc] of state.accumulator.edges) {
+    const e = acc.edge;
     if (!e.tail || !e.head) continue;
-    // Drop edges that reference vertices the response didn't return; the
-    // canvas would otherwise throw when sigma tries to look them up.
+    // Drop edges that reference vertices we don't have; the canvas would
+    // otherwise throw when sigma tries to look them up. (Shouldn't happen
+    // with current server behaviour, but defensive.)
     if (!knownKeys.has(e.tail) || !knownKeys.has(e.head)) continue;
     edges.push({
-      id: `${e.tail}→${e.head}`,
+      id,
       source: e.tail,
       target: e.head,
       weight: e.weight ?? 0,
       edge: e,
     });
   }
-  return { nodes, edges };
-}
 
-export function selectCanPop(state: IlluminateState): boolean {
-  return state.history.length > 1;
+  return {
+    nodes,
+    edges,
+    latestExpansionOrigin,
+    expansionOrigins,
+    overSoftCap: state.accumulator.vertices.size > ACCUMULATOR_SOFT_CAP,
+  };
 }
 
 export function selectIsBusy(state: IlluminateState): boolean {
-  return state.status === "loading";
+  return state.status === "loading" || state.pendingCount > 0;
+}
+
+export function selectExpansionCount(state: IlluminateState): number {
+  return state.expansions.length;
+}
+
+export function selectCanClear(state: IlluminateState): boolean {
+  return state.expansions.length > 0 || state.accumulator.vertices.size > 0;
 }

--- a/admin/app/lib/client/usecase/illuminate/state.ts
+++ b/admin/app/lib/client/usecase/illuminate/state.ts
@@ -8,10 +8,16 @@ import type {
 
 /**
  * Knobs that the user can tweak from the toolbar. Persisted in state so
- * the reducer can decide when a control change should kick off a re-fetch.
+ * each click can snapshot the controls in effect at dispatch time.
  * Per #410 the three Illuminate axes (algorithm, objective, weighting)
  * are first-class controls; the legacy single "optimization" knob and
  * the standalone tfidf switch are gone.
+ *
+ * Per #466 D8 a `controls` change does NOT retroactively re-apply to
+ * the existing accumulator; it only affects the next click. Each
+ * `Expansion` snapshots the controls in force at its dispatch time so
+ * the audit trail records "this sub-neighbourhood was the result of
+ * k=8 SPT at 10:14".
  */
 export interface IlluminateControls {
   step: number;
@@ -37,42 +43,96 @@ export const DEFAULT_ILLUMINATE_CONTROLS: IlluminateControls = {
 export type IlluminateStatus = "idle" | "loading" | "ready" | "error";
 
 /**
- * Subgraph returned by a single Illuminate call, normalised into the shape
- * the canvas/table need. We keep the seed alongside the graph so back-nav
- * through the seed history stack can restore a frame without re-fetching.
+ * Vertex stored in the accumulator. The full payload is kept around so
+ * the canvas tooltip, the IlluminateTable, and (post-#460/#461) the
+ * hop tooltip and info Drawer can render typed values without re-fetching.
+ *
+ * Per #466 D3 a collision is resolved by latest-response-wins (we
+ * overwrite `vertex` + `receivedAtMs`) and the originating expansion
+ * is appended to `expansionIndexes` so per-vertex audit ("first seen
+ * in expansion #N") stays cheap.
  */
-export interface IlluminateFrame {
-  seed: string;
-  controls: IlluminateControls;
-  vertices: Vertex[];
-  edges: Edge[];
+export interface AccumVertex {
+  vertex: Vertex;
+  /** `performance.now()` snapshot when this vertex was last received. */
+  receivedAtMs: number;
+  /** Indexes into `IlluminateState.expansions[]` that produced or refreshed this vertex. */
+  expansionIndexes: number[];
 }
 
-export interface IlluminateState {
-  /** Active seed (already URL-decoded). Empty string ⇒ no seed prompt yet. */
-  seed: string;
-  /** Stack of seeds visited so far. The last entry is always === `seed`. */
-  history: string[];
-  /** Currently-pending knob values. */
+/**
+ * Edge stored in the accumulator. Per #466 D4 the merge rule is
+ * latest-response-wins on collision (the server already handles
+ * additive edge semantics; client-side re-summing would double-count).
+ */
+export interface AccumEdge {
+  edge: Edge;
+  receivedAtMs: number;
+  expansionIndexes: number[];
+}
+
+/**
+ * Snapshot of one Illuminate call's worth of provenance. `expansions[0]`
+ * is structurally privileged per #466 D5: it is the initial seed (mirrors
+ * `IlluminateState.initialSeed`) and cannot be dropped via "Clear last"
+ * style actions (D6 v2 — out of scope for v1).
+ */
+export interface Expansion {
+  /** Stable, monotonically increasing id for React keys + the pending map. */
+  id: number;
+  /** Vertex key the user clicked (or initial seed key). */
+  origin: string;
+  /** Controls in effect when this expansion was dispatched. */
   controls: IlluminateControls;
-  /** Most-recent successful frame for the active seed, or null. */
-  frame: IlluminateFrame | null;
+  /** `performance.now()` snapshot at dispatch. */
+  startedAtMs: number;
+  /** Vertex keys returned by THIS expansion's Illuminate call. */
+  vertexKeys: string[];
+  /** Edge IDs (`${tail}→${head}`) returned by THIS expansion's call. */
+  edgeIds: string[];
+}
+
+/**
+ * Soft / hard caps for the accumulator (#466 D13). The reducer enforces
+ * the hard cap by rejecting merges that would exceed it; the soft cap
+ * is purely advisory and surfaces a `MessageBar` in the UI.
+ */
+export const ACCUMULATOR_SOFT_CAP = 500;
+export const ACCUMULATOR_HARD_CAP = 2000;
+
+export interface IlluminateState {
+  /**
+   * First click; mirrors the URL `?seed=` (#466 D10). `null` when the
+   * canvas is empty and the SeedPrompt is showing. Changing this clears
+   * the accumulator and re-runs the seed expansion.
+   */
+  initialSeed: string | null;
+  /** All expansions in chronological order. `expansions[0]` is the seed expansion. */
+  expansions: Expansion[];
+  /** Merged vertex/edge view of every expansion received so far. */
+  accumulator: {
+    vertices: Map<string, AccumVertex>;
+    edges: Map<string, AccumEdge>;
+  };
+  /** Knob values used for the NEXT click (per #466 D8). */
+  controls: IlluminateControls;
+  /** Number of in-flight expansion requests (drives the loading badge). */
+  pendingCount: number;
   status: IlluminateStatus;
   error: string | null;
-  /**
-   * Bumped on every seed-or-controls change. Async handlers carry the
-   * value they saw at dispatch time and discard their result if it has
-   * moved on (matches the prefixEpoch pattern used by browse-vertices).
-   */
-  fetchEpoch: number;
 }
 
 export const INITIAL_ILLUMINATE_STATE: IlluminateState = {
-  seed: "",
-  history: [],
+  initialSeed: null,
+  expansions: [],
+  accumulator: { vertices: new Map(), edges: new Map() },
   controls: DEFAULT_ILLUMINATE_CONTROLS,
-  frame: null,
+  pendingCount: 0,
   status: "idle",
   error: null,
-  fetchEpoch: 0,
 };
+
+/** Stable encoding for an edge's accumulator key. Mirrors `selectGraphView`'s edge id. */
+export function edgeIdOf(tail: string, head: string): string {
+  return `${tail}→${head}`;
+}

--- a/admin/app/lib/client/usecase/illuminate/use-illuminate.ts
+++ b/admin/app/lib/client/usecase/illuminate/use-illuminate.ts
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
 import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
-import { fetchIlluminate } from "./handlers";
+import { runExpansion } from "./handlers";
 import { illuminateReducer, type IlluminateAction } from "./reducer";
 import {
-  selectCanPop,
+  selectCanClear,
+  selectExpansionCount,
   selectGraphView,
   selectIsBusy,
   type GraphView,
@@ -18,17 +19,22 @@ export interface UseIlluminateResult {
   state: IlluminateState;
   view: GraphView;
   isBusy: boolean;
-  canPop: boolean;
-  push: (seed: string) => void;
-  pop: () => void;
+  canClear: boolean;
+  expansionCount: number;
+  /** Fire an Illuminate from `origin` and merge the response into the accumulator. */
+  expand: (origin: string) => void;
+  /** Empty accumulator + expansions; preserves `initialSeed` so the seed expansion re-fires. */
+  clear: () => void;
   setControls: (next: IlluminateControls) => void;
+  /** Re-fire the most recent expansion's origin with current controls. */
   refresh: () => void;
 }
 
 /**
  * React-facing hook that wires the pure reducer + handlers into the live
- * Lantern client. Owns its own AbortController so a fresh seed or knob
- * cancels any in-flight request immediately.
+ * Lantern client. Each expansion gets its own `AbortController` so later
+ * clicks do NOT cancel earlier in-flight requests — they merge into the
+ * accumulator as they return (#466).
  *
  * `urlSeed` is the URL-decoded seed read from the `?seed=` query param.
  * Pass `""` when the route has no seed yet (the SeedPrompt UI takes over).
@@ -40,69 +46,139 @@ export function useIlluminate(urlSeed: string): UseIlluminateResult {
     INITIAL_ILLUMINATE_STATE,
   );
 
-  // Sync URL seed into reducer. `SEED_CHANGED` is a no-op when the value
-  // already matches, so this is safe to fire on every render.
+  // Map of in-flight expansion id → AbortController. Lives in a ref so
+  // re-renders don't reset it. `clear()` aborts every entry; unmount
+  // aborts every entry; per-expansion settle removes its entry.
+  const controllersRef = useRef<Map<number, AbortController>>(new Map());
+  // Monotonic id source for the expansion id used to thread
+  // request ↔ controller ↔ reducer action.
+  const nextExpansionIdRef = useRef<number>(1);
+  // Latest state for `refresh()`/`clear()` to read without re-binding.
+  const stateRef = useRef(state);
   useEffect(() => {
-    dispatch({ type: "SEED_CHANGED", seed: urlSeed });
-  }, [urlSeed]);
+    stateRef.current = state;
+  }, [state]);
+  // Latest client so the imperative helpers can use it without becoming
+  // unstable on hot-reload.
+  const clientRef = useRef(client);
+  useEffect(() => {
+    clientRef.current = client;
+  }, [client]);
 
-  // Refetch whenever the epoch advances (seed or knob change). The
-  // controller cancels any prior request to keep latency tight.
-  const lastEpochRef = useRef<number>(-1);
-  useEffect(() => {
-    if (state.seed === "") {
-      lastEpochRef.current = state.fetchEpoch;
-      return;
-    }
-    if (state.fetchEpoch === lastEpochRef.current) {
-      return;
-    }
-    lastEpochRef.current = state.fetchEpoch;
+  const launchExpansion = useCallback((origin: string) => {
+    if (origin === "") return;
+    const id = nextExpansionIdRef.current++;
     const controller = new AbortController();
-    void fetchIlluminate(
+    controllersRef.current.set(id, controller);
+    const controls = stateRef.current.controls;
+    const startedAtMs =
+      typeof performance !== "undefined" ? performance.now() : Date.now();
+    void runExpansion(
       {
-        client,
-        seed: state.seed,
-        controls: state.controls,
-        epoch: state.fetchEpoch,
+        client: clientRef.current,
+        expansionId: id,
+        origin,
+        controls,
+        startedAtMs,
         signal: controller.signal,
       },
       dispatch as (action: IlluminateAction) => void,
-    );
-    return () => controller.abort();
-  }, [client, state.seed, state.controls, state.fetchEpoch]);
-
-  const push = useCallback((seed: string) => {
-    dispatch({ type: "SEED_PUSHED", seed });
+    ).finally(() => {
+      controllersRef.current.delete(id);
+    });
   }, []);
 
-  const pop = useCallback(() => {
-    dispatch({ type: "SEED_POPPED" });
+  const abortAll = useCallback(() => {
+    for (const ctrl of controllersRef.current.values()) {
+      ctrl.abort();
+    }
+    controllersRef.current.clear();
   }, []);
+
+  // Sync URL seed into reducer. URL is the source of truth for the
+  // initial seed. When the URL changes (either user navigation or our
+  // own pushState), abort in-flight expansions, reset the accumulator,
+  // and kick off the seed expansion.
+  const lastSeedRef = useRef<string | null>(null);
+  useEffect(() => {
+    const normalised = urlSeed === "" ? null : urlSeed;
+    if (normalised === lastSeedRef.current) return;
+    lastSeedRef.current = normalised;
+    abortAll();
+    dispatch({ type: "INITIAL_SEED_CHANGED", seed: normalised });
+    if (normalised !== null) {
+      launchExpansion(normalised);
+    }
+  }, [urlSeed, abortAll, launchExpansion]);
+
+  // Abort all in-flight expansions on unmount so the responses can't
+  // race a remount.
+  useEffect(() => {
+    return () => {
+      abortAll();
+    };
+  }, [abortAll]);
+
+  const expand = useCallback(
+    (origin: string) => {
+      launchExpansion(origin);
+    },
+    [launchExpansion],
+  );
+
+  const clear = useCallback(() => {
+    abortAll();
+    dispatch({ type: "CLEARED" });
+    const seed = stateRef.current.initialSeed;
+    if (seed !== null) {
+      launchExpansion(seed);
+    }
+  }, [abortAll, launchExpansion]);
+
+  const refresh = useCallback(() => {
+    const expansions = stateRef.current.expansions;
+    const last = expansions[expansions.length - 1];
+    if (last) {
+      launchExpansion(last.origin);
+      return;
+    }
+    const seed = stateRef.current.initialSeed;
+    if (seed !== null) {
+      launchExpansion(seed);
+    }
+  }, [launchExpansion]);
 
   const setControls = useCallback((next: IlluminateControls) => {
     dispatch({ type: "CONTROLS_CHANGED", controls: next });
   }, []);
 
-  const refresh = useCallback(() => {
-    dispatch({ type: "REFETCH_REQUESTED" });
-  }, []);
-
   const view = useMemo(() => selectGraphView(state), [state]);
   const isBusy = selectIsBusy(state);
-  const canPop = selectCanPop(state);
+  const canClear = selectCanClear(state);
+  const expansionCount = selectExpansionCount(state);
 
   return useMemo<UseIlluminateResult>(
     () => ({
       state,
       view,
       isBusy,
-      canPop,
-      push,
-      pop,
+      canClear,
+      expansionCount,
+      expand,
+      clear,
       setControls,
       refresh,
     }),
-    [state, view, isBusy, canPop, push, pop, setControls, refresh],
+    [
+      state,
+      view,
+      isBusy,
+      canClear,
+      expansionCount,
+      expand,
+      clear,
+      setControls,
+      refresh,
+    ],
   );
 }

--- a/admin/tests/e2e/illuminate.spec.ts
+++ b/admin/tests/e2e/illuminate.spec.ts
@@ -3,20 +3,29 @@ import { expect, test } from "@playwright/test";
 import { CONNECT_URL, STORAGE_KEY, putEdges, putVertices } from "./helpers";
 
 /**
- * Seeds a tiny star graph centred on `e2e:illum:hub` so the Illuminate
- * screen has at least one neighbour to render. The other tests that share
- * this gateway also seed under `e2e:vertex:*`; we use a distinct prefix
- * to keep the assertions tight.
+ * Seeds a small chain so the additive expansion model has multiple
+ * neighbourhoods to walk through:
+ *
+ *    hub --(1)--> left --(1)--> leftleft
+ *    hub --(3)--> right --(2)--> rightright
+ *
+ * The first Illuminate from `hub` brings in {hub, left, right} + 2 edges.
+ * Clicking `left` then brings in `leftleft` without removing the
+ * previous nodes (#466 additive invariant).
  */
 test.beforeAll(async () => {
   await putVertices([
     { key: "e2e:illum:hub", string: "hub" },
     { key: "e2e:illum:left", int32: 1 },
     { key: "e2e:illum:right", int32: 2 },
+    { key: "e2e:illum:leftleft", string: "leftleft" },
+    { key: "e2e:illum:rightright", string: "rightright" },
   ]);
   await putEdges([
     { tail: "e2e:illum:hub", head: "e2e:illum:left", weight: 1 },
     { tail: "e2e:illum:hub", head: "e2e:illum:right", weight: 3 },
+    { tail: "e2e:illum:left", head: "e2e:illum:leftleft", weight: 1 },
+    { tail: "e2e:illum:right", head: "e2e:illum:rightright", weight: 2 },
   ]);
 });
 
@@ -52,15 +61,17 @@ test.describe("/illuminate", () => {
     );
     await expect(page.getByTestId("illuminate-canvas")).toBeVisible();
 
-    // Pop is disabled until the user pushes a second seed onto the stack.
-    await expect(page.getByTestId("illuminate-pop")).toBeDisabled();
-
     // Refresh should be enabled once the seed is set.
     await expect(page.getByTestId("illuminate-refresh")).toBeEnabled();
 
-    // The disclosure summary reflects the live frame counts. Wait for the
-    // fetch to land — the count goes from 0/0 to 3/2 — before clicking
-    // so we don't race the React re-render and end up with a stale node.
+    // Counter reflects the live accumulator: 3 vertices, 2 edges, 1
+    // expansion after the initial fetch from the hub seed.
+    const counter = page.getByTestId("illuminate-counter");
+    await expect(counter).toContainText("3 vertices");
+    await expect(counter).toContainText("2 edges");
+    await expect(counter).toContainText("1 expansion");
+
+    // The disclosure summary reflects the live accumulator counts.
     const summary = page.getByRole("group").getByText(/List view \(3 vertices/);
     await expect(summary).toBeVisible();
     await summary.click();
@@ -78,33 +89,94 @@ test.describe("/illuminate", () => {
     ).toBeVisible();
   });
 
-  test("Re-seed from the list view pushes a new seed and enables Pop", async ({
+  test("Expand from the list view ADDS new neighbours without removing existing ones", async ({
     page,
   }) => {
     const seed = encodeURIComponent("e2e:illum:hub");
     await page.goto(`/illuminate?seed=${seed}`);
     await expect(page.getByTestId("illuminate-toolbar")).toBeVisible();
 
-    // Wait for the seed's frame to land before opening the disclosure.
-    const summary = page.getByRole("group").getByText(/List view \(3 vertices/);
-    await expect(summary).toBeVisible();
-    await summary.click();
+    // Wait for the initial fetch to land.
+    const counter = page.getByTestId("illuminate-counter");
+    await expect(counter).toContainText("3 vertices");
+
+    // Open the list view to access per-row Expand buttons.
+    await page
+      .getByRole("group")
+      .getByText(/List view \(3 vertices/)
+      .click();
 
     const table = page.getByTestId("illuminate-table");
     await table
-      .getByRole("button", { name: "Re-seed from e2e:illum:left" })
+      .getByRole("button", { name: "Expand from e2e:illum:left" })
       .click();
 
-    await expect(page.getByTestId("illuminate-seed")).toHaveText(
-      "e2e:illum:left",
-    );
-    await expect(page).toHaveURL(/\?seed=e2e%3Aillum%3Aleft/);
-    await expect(page.getByTestId("illuminate-pop")).toBeEnabled();
-
-    await page.getByTestId("illuminate-pop").click();
+    // The accumulator must GROW: we should now have hub, left, right,
+    // and leftleft (4 vertices). The URL stays anchored on the initial
+    // seed so deep links remain stable.
+    await expect(counter).toContainText("4 vertices");
+    await expect(counter).toContainText("2 expansions");
+    await expect(page).toHaveURL(/\?seed=e2e%3Aillum%3Ahub/);
     await expect(page.getByTestId("illuminate-seed")).toHaveText(
       "e2e:illum:hub",
     );
-    await expect(page.getByTestId("illuminate-pop")).toBeDisabled();
+
+    // The existing nodes survive across the expansion.
+    await expect(
+      table.getByRole("link", { name: "e2e:illum:hub" }),
+    ).toBeVisible();
+    await expect(
+      table.getByRole("link", { name: "e2e:illum:right" }),
+    ).toBeVisible();
+    // And the newcomer is present too.
+    await expect(
+      table.getByRole("link", { name: "e2e:illum:leftleft" }),
+    ).toBeVisible();
+  });
+
+  test("Clear empties the accumulator and returns to the seed prompt", async ({
+    page,
+  }) => {
+    const seed = encodeURIComponent("e2e:illum:hub");
+    await page.goto(`/illuminate?seed=${seed}`);
+    await expect(page.getByTestId("illuminate-toolbar")).toBeVisible();
+    await expect(page.getByTestId("illuminate-counter")).toContainText(
+      "3 vertices",
+    );
+
+    await page.getByTestId("illuminate-clear").click();
+
+    // The URL drops the seed and the prompt comes back.
+    await expect(page).toHaveURL(/\/illuminate$/);
+    await expect(page.getByTestId("illuminate-seed-prompt")).toBeVisible();
+  });
+
+  test("Re-expanding the same node is idempotent (no crash, accumulator stable)", async ({
+    page,
+  }) => {
+    const seed = encodeURIComponent("e2e:illum:hub");
+    await page.goto(`/illuminate?seed=${seed}`);
+    await expect(page.getByTestId("illuminate-toolbar")).toBeVisible();
+
+    const counter = page.getByTestId("illuminate-counter");
+    await expect(counter).toContainText("3 vertices");
+
+    await page
+      .getByRole("group")
+      .getByText(/List view \(3 vertices/)
+      .click();
+
+    const table = page.getByTestId("illuminate-table");
+    // Click Expand on the initial seed itself (#466 D11 — even the seed
+    // is meaningful to re-expand because the server graph decays).
+    await table
+      .getByRole("button", { name: "Expand from e2e:illum:hub" })
+      .click();
+    // Wait for the expansion to register (counter ticks even if vertices
+    // stay the same).
+    await expect(counter).toContainText("2 expansion");
+    // Accumulator must still hold all three vertices; no error appears.
+    await expect(counter).toContainText("3 vertices");
+    await expect(page.getByTestId("illuminate-error")).toHaveCount(0);
   });
 });


### PR DESCRIPTION
Closes #466.

Replaces the seed-stack "re-seed navigation" model with an additive
expansion accumulator. Every click on a graph node adds that vertex's
neighbourhood to the **same** canvas instead of refetching from a fresh
seed; existing vertices and edges survive across clicks.

## What changed

**State (`state.ts` / `reducer.ts`)**
- New `AccumVertex` / `AccumEdge` / `Expansion` / `IlluminateState` shape.
- `expansions[]` is append-only; `expansions[0]` is the initial URL seed.
- Accumulator stored in `Map<string,...>` for stable Map identity (D3/D4 latest-wins merge).
- Hard cap (2000) silently drops a response that would push past it; soft cap (500) flips `overSoftCap` for a MessageBar warning.
- `CLEARED` preserves `initialSeed` + `controls`; `RESET` wipes everything except `controls`.
- `CONTROLS_CHANGED` never retro-applies to already-accumulated content.

**Handlers + hook (`handlers.ts`, `use-illuminate.ts`)**
- `runExpansion` fires per-call dispatch: `REQUESTED → RECEIVED/FAILED`.
- **Per-expansion `AbortController`**; later clicks DO NOT cancel earlier ones — all merge as they return. Abort synthesizes an empty-error `FAILED` to balance `pendingCount`.
- `expand(origin)` is idempotent (D11).
- `clear()` aborts all in-flight, dispatches `CLEARED`, re-fires initial seed if URL still has `?seed=`.
- `refresh()` re-fires the most recent expansion's origin.

**Selectors (`selectors.ts`)**
- `selectGraphView` emits `{nodes, edges, latestExpansionOrigin, expansionOrigins[], overSoftCap}`.
- `importance = max(0.1, weightSum/maxWeight)`; seeds + origins pin to `1`.
- Dangling edges defensively filtered.

**UI**
- `IlluminatePage`: URL `?seed=` only tracks `initialSeed`; node click calls `expand()`; Clear navigates to `/illuminate`.
- `IlluminateToolbar`: `Pop` replaced with `Clear`; counter shows `N vertices · M edges · K expansions`; `Refresh` re-fires last origin.
- `IlluminateTable`: `Re-seed` button → `Expand`; never disabled (D11).
- `IlluminateCanvas`: reconcile-by-id (drop missing / merge existing / add new); ForceAtlas2 80 iters per reconcile with barnesHut once `order>100`; `pickInitialPosition` seeds new nodes at parent-click centroid + small ring around `latestExpansionOrigin` (D7 — surviving nodes do not reshuffle).

**CLI surface (`graph-view.ts`)**
- Wraps every per-command `GraphView` in the new envelope; CLI is stateless from the canvas's perspective so `firstSeenExpansion=0` and `overSoftCap=false` uniformly.

## Tests
- 286 admin unit tests pass; reducer/selectors specs cover D3/D4, D8, D11, D13.
- E2E `illuminate.spec.ts` rewritten: chain graph asserts counter `3 vertices`, clicking `left` grows to 4 vertices + 2 expansions with URL still anchored on initial seed; idempotent re-expand; Clear returns to seed prompt.

## Migration impact

This is the foundation that unblocks #456 / #460 / #461 (whose bodies have already been rewritten for the additive model). It also largely subsumes #454 (ForceAtlas2 reshuffle) via D7 reconcile-by-id placement — to be re-evaluated as a separate PR.

## Required checks
Run/wait for all 4: Build & Test, Lint, Proto (buf), govulncheck.