### PR TITLE
feat(admin)!: split /cli canvas and scrollback left/right with draggable splitter (closes #465)

### DIFF
--- a/admin/app/components/cli/CliPage/CliPage.module.css
+++ b/admin/app/components/cli/CliPage/CliPage.module.css
@@ -1,4 +1,21 @@
+/* The /cli root.
+ *
+ * Two layout modes (#465):
+ *   data-mode="cli"   : no graph yet — full-width terminal, splitter hidden.
+ *   data-mode="split" : graph present and viewport ≥ 1024px — two-column
+ *                       grid with a draggable splitter between the canvas
+ *                       (left) and the toolbar/scrollback/input stack
+ *                       (right). Below 1024px the layout falls back to the
+ *                       legacy single-column stack regardless of mode.
+ *
+ * The grid template columns are driven by `--cli-canvas-frac` and
+ * `--cli-right-frac` written from the `useCliSplitter` hook. Defaults are
+ * declared on the host so the layout has a sensible value before the hook
+ * mounts and on first paint after SSR.
+ */
 .root {
+  --cli-canvas-frac: 0.6fr;
+  --cli-right-frac: 0.4fr;
   display: flex;
   flex-direction: column;
   height: calc(100vh - 120px);
@@ -7,15 +24,69 @@
   padding: var(--spacingVerticalL, 16px);
 }
 
-/* Canvas panel rendered above the scrollback when the most recent
-   command produced graph data. The body owns ~45% of the panel and
-   shrinks gracefully on short viewports; the scrollback still has at
-   least a few lines of room thanks to min-height on `.scrollback`. */
-.canvasPanel {
+.root[data-dragging="true"] {
+  user-select: none;
+  cursor: col-resize;
+}
+
+/* Left column wraps the canvas panel; on narrow viewports it carries the
+   45% sizing the canvasPanel used to own. */
+.leftColumn {
   display: flex;
   flex-direction: column;
   flex: 0 0 45%;
   min-height: 240px;
+  min-width: 0;
+}
+
+/* Right column wraps the toolbar / scrollback / confirm bar / input row.
+   On narrow viewports it fills the remaining vertical space. */
+.rightColumn {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalM, 12px);
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+}
+
+/* Splitter handle — hidden by default; only visible in `split` mode at
+   ≥ 1024px (see media query at the bottom of the file). The thin visible
+   strip is 4px wide; an invisible ::before extends the hit target to 12px
+   so it's easy to grab without making the visible line thick. */
+.splitter {
+  display: none;
+  position: relative;
+  background: var(--colorNeutralStroke2, #e0e0e0);
+  cursor: col-resize;
+  outline: none;
+}
+
+.splitter::before {
+  content: "";
+  position: absolute;
+  inset: 0 -4px;
+  /* Invisible hit target, 12px wide centered on the visible strip. */
+}
+
+.splitter:hover,
+.splitter:focus-visible,
+.root[data-dragging="true"] .splitter {
+  background: var(--colorBrandStroke1, #0f6cbd);
+}
+
+.splitter:focus-visible {
+  outline: 2px solid var(--colorStrokeFocus2, #115ea3);
+  outline-offset: 1px;
+}
+
+/* Canvas panel rendered inside `.leftColumn` when the most recent
+   command produced graph data. Fills the column. */
+.canvasPanel {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
   border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
   border-radius: var(--borderRadiusMedium, 6px);
   background: var(--colorNeutralBackground1, #ffffff);
@@ -144,4 +215,35 @@
 .confirmText {
   flex: 1 1 auto;
   font-size: var(--fontSizeBase200, 12px);
+}
+
+/* Wide viewports — switch to the two-column grid when a graph is present. */
+@media (min-width: 1024px) {
+  .root[data-mode="split"] {
+    display: grid;
+    grid-template-columns: var(--cli-canvas-frac, 0.6fr) 4px var(
+        --cli-right-frac,
+        0.4fr
+      );
+    grid-template-rows: 1fr;
+    gap: 0;
+  }
+
+  .root[data-mode="split"] > .leftColumn {
+    flex: 1 1 auto;
+    min-height: 0;
+    grid-column: 1;
+  }
+
+  .root[data-mode="split"] > .splitter {
+    display: block;
+    grid-column: 2;
+    height: 100%;
+  }
+
+  .root[data-mode="split"] > .rightColumn {
+    flex: 1 1 auto;
+    grid-column: 3;
+    padding-left: var(--spacingHorizontalM, 12px);
+  }
 }

--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -9,6 +9,7 @@ import { dispatch, isDestructive } from "~/lib/cli/dispatcher";
 import { parse, type Command, type ParseResult } from "~/lib/cli/parser";
 import { HELP_TEXT } from "~/lib/cli/verbs";
 import { commandResultToGraphView } from "~/lib/cli/graph-view";
+import { useCliSplitter } from "~/lib/cli/use-cli-splitter";
 import { IlluminateCanvas } from "~/components/illuminate/IlluminateCanvas/IlluminateCanvas";
 import type { GraphView } from "~/lib/client/usecase/illuminate/selectors";
 import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
@@ -76,6 +77,14 @@ export function CliPage() {
   // while busy. The dispatcher already plumbs `signal` through every
   // underlying RPC, so the abort propagates end-to-end.
   const abortRef = useRef<AbortController | null>(null);
+  // Drives the two-column grid + draggable splitter (#465). Only active
+  // when a graph is present; otherwise the right column owns the full
+  // width and the splitter handle is hidden by CSS.
+  const rootRef = useRef<HTMLDivElement>(null);
+  const splitter = useCliSplitter({
+    enabled: latestGraph !== null,
+    rootRef,
+  });
 
   const append = useCallback((entry: Omit<ScrollbackEntry, "id">) => {
     setScrollback((prev) => [...prev, { ...entry, id: idRef.current++ }]);
@@ -331,107 +340,125 @@ export function CliPage() {
   );
 
   return (
-    <div className={styles.root} data-testid="cli-root">
+    <div
+      ref={rootRef}
+      className={styles.root}
+      data-testid="cli-root"
+      data-mode={latestGraph !== null ? "split" : "cli"}
+      data-dragging={splitter.dragging ? "true" : undefined}
+    >
       {latestGraph !== null ? (
-        <div className={styles.canvasPanel} data-testid="cli-canvas-panel">
-          <div className={styles.canvasHeader}>
-            <span className={styles.canvasHeaderLabel}>from:</span>{" "}
-            <code className={styles.canvasHeaderSource}>
-              {latestGraph.source}
-            </code>
-            <span className={styles.canvasHeaderHint}>
-              click any node to run{" "}
-              <code>
-                illuminate &lt;key&gt; {CLICK_TO_ILLUMINATE.step}{" "}
-                {CLICK_TO_ILLUMINATE.k}
+        <div className={styles.leftColumn} data-testid="cli-left-column">
+          <div className={styles.canvasPanel} data-testid="cli-canvas-panel">
+            <div className={styles.canvasHeader}>
+              <span className={styles.canvasHeaderLabel}>from:</span>{" "}
+              <code className={styles.canvasHeaderSource}>
+                {latestGraph.source}
               </code>
-            </span>
-          </div>
-          <div className={styles.canvasBody}>
-            <IlluminateCanvas
-              nodes={latestGraph.view.nodes}
-              edges={latestGraph.view.edges}
-              latestExpansionOrigin={latestGraph.view.latestExpansionOrigin}
-              onNodeClick={onNodeClick}
-              isBusy={busy}
-            />
+              <span className={styles.canvasHeaderHint}>
+                click any node to run{" "}
+                <code>
+                  illuminate &lt;key&gt; {CLICK_TO_ILLUMINATE.step}{" "}
+                  {CLICK_TO_ILLUMINATE.k}
+                </code>
+              </span>
+            </div>
+            <div className={styles.canvasBody}>
+              <IlluminateCanvas
+                nodes={latestGraph.view.nodes}
+                edges={latestGraph.view.edges}
+                latestExpansionOrigin={latestGraph.view.latestExpansionOrigin}
+                onNodeClick={onNodeClick}
+                isBusy={busy}
+              />
+            </div>
           </div>
         </div>
       ) : null}
-      <div className={styles.toolbar} data-testid="cli-toolbar">
-        <Button
-          appearance="secondary"
-          size="small"
-          onClick={clearScrollback}
-          disabled={scrollback.length <= 1}
-          data-testid="cli-clear"
-          aria-label="Clear scrollback (Ctrl+L)"
-          title="Clear scrollback (Ctrl+L)"
-        >
-          Clear
-        </Button>
-        {busy ? (
+      {latestGraph !== null ? (
+        <div
+          className={styles.splitter}
+          data-testid="cli-splitter"
+          aria-label="Resize canvas vs scrollback"
+          {...splitter.handleProps}
+        />
+      ) : null}
+      <div className={styles.rightColumn} data-testid="cli-right-column">
+        <div className={styles.toolbar} data-testid="cli-toolbar">
           <Button
             appearance="secondary"
             size="small"
-            onClick={cancelInFlight}
-            data-testid="cli-cancel"
-            aria-label="Cancel in-flight command (Esc)"
-            title="Cancel in-flight command (Esc)"
+            onClick={clearScrollback}
+            disabled={scrollback.length <= 1}
+            data-testid="cli-clear"
+            aria-label="Clear scrollback (Ctrl+L)"
+            title="Clear scrollback (Ctrl+L)"
           >
-            Cancel
+            Clear
           </Button>
-        ) : null}
-      </div>
-      <div className={styles.scrollback} ref={scrollRef} aria-live="polite">
-        {renderedScrollback}
-      </div>
-      {pending !== null ? (
-        <div className={styles.confirmBar} data-testid="cli-confirm">
-          <span className={styles.confirmText}>
-            About to run: <code>{pending.rendered}</code> — this mutates server
-            state.
-          </span>
-          <Checkbox
-            label="Do not ask again this session"
-            checked={skipConfirm}
-            onChange={(_e, data) => setSkipConfirm(Boolean(data.checked))}
-            data-testid="cli-skip-confirm"
-          />
-          <Button
-            appearance="secondary"
-            onClick={() => setPending(null)}
-            data-testid="cli-confirm-cancel"
-          >
-            Cancel
-          </Button>
-          <Button
-            appearance="primary"
-            onClick={async () => {
-              const p = pending;
-              setPending(null);
-              if (p) {
-                await runCommand(p.rendered, p.command);
-              }
-            }}
-            data-testid="cli-confirm-run"
-          >
-            Run
-          </Button>
+          {busy ? (
+            <Button
+              appearance="secondary"
+              size="small"
+              onClick={cancelInFlight}
+              data-testid="cli-cancel"
+              aria-label="Cancel in-flight command (Esc)"
+              title="Cancel in-flight command (Esc)"
+            >
+              Cancel
+            </Button>
+          ) : null}
         </div>
-      ) : null}
-      <div className={styles.inputRow}>
-        <span className={styles.prompt}>&gt;</span>
-        <Input
-          className={styles.input}
-          value={input}
-          onChange={onChange}
-          onKeyDown={onKeyDown}
-          placeholder="get vertex alice    |    illuminate alice 2 5 algorithm=spt"
-          disabled={busy || pending !== null}
-          data-testid="cli-input"
-          aria-label="CLI command input"
-        />
+        <div className={styles.scrollback} ref={scrollRef} aria-live="polite">
+          {renderedScrollback}
+        </div>
+        {pending !== null ? (
+          <div className={styles.confirmBar} data-testid="cli-confirm">
+            <span className={styles.confirmText}>
+              About to run: <code>{pending.rendered}</code> — this mutates
+              server state.
+            </span>
+            <Checkbox
+              label="Do not ask again this session"
+              checked={skipConfirm}
+              onChange={(_e, data) => setSkipConfirm(Boolean(data.checked))}
+              data-testid="cli-skip-confirm"
+            />
+            <Button
+              appearance="secondary"
+              onClick={() => setPending(null)}
+              data-testid="cli-confirm-cancel"
+            >
+              Cancel
+            </Button>
+            <Button
+              appearance="primary"
+              onClick={async () => {
+                const p = pending;
+                setPending(null);
+                if (p) {
+                  await runCommand(p.rendered, p.command);
+                }
+              }}
+              data-testid="cli-confirm-run"
+            >
+              Run
+            </Button>
+          </div>
+        ) : null}
+        <div className={styles.inputRow}>
+          <span className={styles.prompt}>&gt;</span>
+          <Input
+            className={styles.input}
+            value={input}
+            onChange={onChange}
+            onKeyDown={onKeyDown}
+            placeholder="get vertex alice    |    illuminate alice 2 5 algorithm=spt"
+            disabled={busy || pending !== null}
+            data-testid="cli-input"
+            aria-label="CLI command input"
+          />
+        </div>
       </div>
     </div>
   );

--- a/admin/app/lib/cli/cli-splitter.test.ts
+++ b/admin/app/lib/cli/cli-splitter.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SPLITTER_DEFAULT_RATIO,
+  SPLITTER_MIN_PANE_PX,
+  clampRatio,
+  formatStoredRatio,
+  nudgeRatio,
+  parseStoredRatio,
+} from "./cli-splitter";
+
+describe("cli-splitter clampRatio", () => {
+  test("honours min pane size on both sides for a wide container", () => {
+    // 1600px container, 360px min → ratio bounded to [0.225, 0.775].
+    const w = 1600;
+    expect(clampRatio(0.6, w)).toBeCloseTo(0.6, 6);
+    expect(clampRatio(0.1, w)).toBeCloseTo(SPLITTER_MIN_PANE_PX / w, 6);
+    expect(clampRatio(0.95, w)).toBeCloseTo(1 - SPLITTER_MIN_PANE_PX / w, 6);
+  });
+
+  test("falls back to soft [0.1, 0.9] clamp when container cannot honour min sizes", () => {
+    // 600px container, 360px min → 2*360 >= 600, soft clamp.
+    expect(clampRatio(0.6, 600)).toBeCloseTo(0.6, 6);
+    expect(clampRatio(0.05, 600)).toBeCloseTo(0.1, 6);
+    expect(clampRatio(0.99, 600)).toBeCloseTo(0.9, 6);
+  });
+
+  test("returns default ratio for non-finite desired", () => {
+    expect(clampRatio(Number.NaN, 1600)).toBe(SPLITTER_DEFAULT_RATIO);
+    expect(clampRatio(Number.POSITIVE_INFINITY, 1600)).toBe(
+      SPLITTER_DEFAULT_RATIO,
+    );
+  });
+
+  test("returns soft clamp for a zero/negative container width", () => {
+    expect(clampRatio(0.6, 0)).toBeCloseTo(0.6, 6);
+    expect(clampRatio(0.05, -100)).toBeCloseTo(0.1, 6);
+  });
+
+  test("respects a custom min pane size", () => {
+    expect(clampRatio(0.95, 1000, 100)).toBeCloseTo(0.9, 6);
+    expect(clampRatio(0.05, 1000, 100)).toBeCloseTo(0.1, 6);
+  });
+});
+
+describe("cli-splitter parseStoredRatio", () => {
+  test("accepts numeric strings strictly inside (0, 1)", () => {
+    expect(parseStoredRatio("0.42")).toBeCloseTo(0.42, 6);
+    expect(parseStoredRatio("0.0001")).toBeCloseTo(0.0001, 6);
+  });
+
+  test("rejects null", () => {
+    expect(parseStoredRatio(null)).toBeNull();
+  });
+
+  test("rejects garbage", () => {
+    expect(parseStoredRatio("not a number")).toBeNull();
+    expect(parseStoredRatio("")).toBeNull();
+  });
+
+  test("rejects boundary values 0 and 1", () => {
+    expect(parseStoredRatio("0")).toBeNull();
+    expect(parseStoredRatio("1")).toBeNull();
+    expect(parseStoredRatio("-0.5")).toBeNull();
+    expect(parseStoredRatio("1.5")).toBeNull();
+  });
+
+  test("round-trips through formatStoredRatio", () => {
+    expect(parseStoredRatio(formatStoredRatio(0.6))).toBeCloseTo(0.6, 4);
+    expect(parseStoredRatio(formatStoredRatio(0.2375))).toBeCloseTo(0.2375, 4);
+  });
+});
+
+describe("cli-splitter nudgeRatio", () => {
+  test("ArrowLeft/ArrowRight nudge by 2% (no shift)", () => {
+    expect(nudgeRatio(0.5, "ArrowLeft", { shiftKey: false })).toBeCloseTo(
+      0.48,
+      6,
+    );
+    expect(nudgeRatio(0.5, "ArrowRight", { shiftKey: false })).toBeCloseTo(
+      0.52,
+      6,
+    );
+  });
+
+  test("ArrowLeft/ArrowRight jump by 10% with shift", () => {
+    expect(nudgeRatio(0.5, "ArrowLeft", { shiftKey: true })).toBeCloseTo(
+      0.4,
+      6,
+    );
+    expect(nudgeRatio(0.5, "ArrowRight", { shiftKey: true })).toBeCloseTo(
+      0.6,
+      6,
+    );
+  });
+
+  test("Home returns 0 (caller clamps to min)", () => {
+    expect(nudgeRatio(0.7, "Home", { shiftKey: false })).toBe(0);
+  });
+
+  test("End returns 1 (caller clamps to max)", () => {
+    expect(nudgeRatio(0.3, "End", { shiftKey: false })).toBe(1);
+  });
+
+  test("Enter resets to default", () => {
+    expect(nudgeRatio(0.2, "Enter", { shiftKey: false })).toBe(
+      SPLITTER_DEFAULT_RATIO,
+    );
+  });
+
+  test("returns null for unrelated keys", () => {
+    expect(nudgeRatio(0.5, "Escape", { shiftKey: false })).toBeNull();
+    expect(nudgeRatio(0.5, "a", { shiftKey: false })).toBeNull();
+    expect(nudgeRatio(0.5, " ", { shiftKey: false })).toBeNull();
+  });
+});

--- a/admin/app/lib/cli/cli-splitter.ts
+++ b/admin/app/lib/cli/cli-splitter.ts
@@ -1,0 +1,107 @@
+/**
+ * Pure helpers for the /cli page L/R splitter (#465).
+ *
+ * The DOM-coupled React hook lives in {@link ./use-cli-splitter}; everything
+ * here is side-effect free so it can be unit-tested under `bun:test` without
+ * a DOM. The split is intentional: clamping and key handling are easy to get
+ * subtly wrong, so they should be covered by tests, while the
+ * PointerEvent/ResizeObserver wiring is best left to Playwright.
+ */
+
+/** localStorage key used to persist the canvas's share of the row. */
+export const SPLITTER_STORAGE_KEY = "cli.splitRatio";
+
+/** Default canvas share (60% canvas / 40% right column). */
+export const SPLITTER_DEFAULT_RATIO = 0.6;
+
+/** Neither pane may collapse below this many CSS pixels. */
+export const SPLITTER_MIN_PANE_PX = 360;
+
+/** Below this viewport width the split layout is disabled. */
+export const SPLITTER_BREAKPOINT_PX = 1024;
+
+/** Per-arrow keyboard nudge, expressed as a fraction of the row. */
+export const SPLITTER_NUDGE = 0.02;
+
+/** Shift+arrow jump size. */
+export const SPLITTER_JUMP = 0.1;
+
+/**
+ * Clamp a desired canvas fraction so that neither pane shrinks below
+ * {@link SPLITTER_MIN_PANE_PX}. When the container itself is too narrow to
+ * honour the min size on both sides, falls back to a soft [0.1, 0.9] clamp so
+ * the splitter remains usable — narrow viewports are not the primary target
+ * anyway.
+ */
+export function clampRatio(
+  desired: number,
+  containerWidth: number,
+  minPanePx: number = SPLITTER_MIN_PANE_PX,
+): number {
+  if (!Number.isFinite(desired)) {
+    return SPLITTER_DEFAULT_RATIO;
+  }
+  if (containerWidth <= 0 || minPanePx * 2 >= containerWidth) {
+    return clampInRange(desired, 0.1, 0.9);
+  }
+  const minRatio = minPanePx / containerWidth;
+  const maxRatio = 1 - minPanePx / containerWidth;
+  return clampInRange(desired, minRatio, maxRatio);
+}
+
+/**
+ * Parse a value previously written by {@link saveRatio}. Returns null if the
+ * value is missing, malformed, or outside the open interval (0, 1). The caller
+ * is expected to fall back to {@link SPLITTER_DEFAULT_RATIO} in that case.
+ */
+export function parseStoredRatio(raw: string | null): number | null {
+  if (raw === null) return null;
+  const n = Number.parseFloat(raw);
+  if (!Number.isFinite(n)) return null;
+  if (n <= 0 || n >= 1) return null;
+  return n;
+}
+
+/** Inverse of {@link parseStoredRatio}; serialised to four decimals. */
+export function formatStoredRatio(ratio: number): string {
+  return ratio.toFixed(4);
+}
+
+export interface NudgeOptions {
+  shiftKey: boolean;
+}
+
+/**
+ * Map a keydown event to the desired next ratio, or null if the key is not a
+ * splitter control. The caller is responsible for clamping the result; the
+ * `Home`/`End` cases intentionally return values outside [0, 1] so the clamp
+ * snaps to the actual min/max for the current container width.
+ */
+export function nudgeRatio(
+  current: number,
+  key: string,
+  opts: NudgeOptions,
+): number | null {
+  const step = opts.shiftKey ? SPLITTER_JUMP : SPLITTER_NUDGE;
+  switch (key) {
+    case "ArrowLeft":
+      return current - step;
+    case "ArrowRight":
+      return current + step;
+    case "Home":
+      return 0;
+    case "End":
+      return 1;
+    case "Enter":
+      return SPLITTER_DEFAULT_RATIO;
+    default:
+      return null;
+  }
+}
+
+function clampInRange(value: number, lo: number, hi: number): number {
+  if (lo > hi) return (lo + hi) / 2;
+  if (value < lo) return lo;
+  if (value > hi) return hi;
+  return value;
+}

--- a/admin/app/lib/cli/use-cli-splitter.ts
+++ b/admin/app/lib/cli/use-cli-splitter.ts
@@ -1,0 +1,224 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type AriaAttributes,
+  type DOMAttributes,
+  type PointerEvent as ReactPointerEvent,
+  type RefObject,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
+import {
+  browserStorage,
+  type BrowserStorage,
+} from "~/lib/client/infrastructure/browser/storage";
+import {
+  SPLITTER_DEFAULT_RATIO,
+  SPLITTER_STORAGE_KEY,
+  clampRatio,
+  formatStoredRatio,
+  nudgeRatio,
+  parseStoredRatio,
+} from "./cli-splitter";
+
+export interface UseCliSplitterOptions {
+  /**
+   * When false, the hook does not register a ResizeObserver and the handle
+   * does nothing. Use this to keep state stable while the splitter is hidden
+   * (no graph rendered yet).
+   */
+  enabled: boolean;
+  /** Ref to the splitter's grid container; CSS vars are written here. */
+  rootRef: RefObject<HTMLDivElement | null>;
+  /** Override for tests. Defaults to {@link browserStorage}. */
+  storage?: BrowserStorage;
+}
+
+type HandleProps = AriaAttributes &
+  Pick<
+    DOMAttributes<HTMLDivElement>,
+    | "onPointerDown"
+    | "onPointerMove"
+    | "onPointerUp"
+    | "onPointerCancel"
+    | "onDoubleClick"
+    | "onKeyDown"
+  > & {
+    role: "separator";
+    tabIndex: number;
+    title: string;
+  };
+
+export interface CliSplitterApi {
+  /** The current canvas-share ratio (committed value, not the live drag). */
+  ratio: number;
+  /** True while a pointer drag is in progress. */
+  dragging: boolean;
+  /** Spread onto the splitter handle element. */
+  handleProps: HandleProps;
+}
+
+/**
+ * Drives the L/R splitter on the /cli page (#465).
+ *
+ * Writes the canvas fraction to two CSS variables on the host root —
+ * `--cli-canvas-frac` and `--cli-right-frac` — so the grid layout updates
+ * without re-rendering the React tree on every pointermove. Persists the
+ * final ratio to localStorage under {@link SPLITTER_STORAGE_KEY}.
+ *
+ * The committed `ratio` state is updated only on drag end, keyboard nudge,
+ * double-click reset, and ResizeObserver re-clamps — i.e. at most once per
+ * gesture, never per frame.
+ */
+export function useCliSplitter({
+  enabled,
+  rootRef,
+  storage,
+}: UseCliSplitterOptions): CliSplitterApi {
+  const store = useMemo(() => storage ?? browserStorage(), [storage]);
+  const [ratio, setRatio] = useState<number>(() => {
+    const stored = parseStoredRatio(store.get(SPLITTER_STORAGE_KEY));
+    return stored ?? SPLITTER_DEFAULT_RATIO;
+  });
+  const [dragging, setDragging] = useState(false);
+  const liveRatioRef = useRef(ratio);
+  const widthRef = useRef(0);
+
+  // Apply CSS vars whenever the committed ratio changes. During a drag we
+  // also write them directly from onPointerMove, but that path doesn't go
+  // through state so this effect doesn't fight with it.
+  useEffect(() => {
+    liveRatioRef.current = ratio;
+    const root = rootRef.current;
+    if (!root) return;
+    root.style.setProperty("--cli-canvas-frac", `${ratio}fr`);
+    root.style.setProperty("--cli-right-frac", `${1 - ratio}fr`);
+  }, [ratio, rootRef]);
+
+  // Observe container width so the ratio re-clamps when the window shrinks.
+  // Disabled while the splitter is hidden so we don't pay observer cost on
+  // the empty-canvas state.
+  useEffect(() => {
+    if (!enabled) return;
+    const root = rootRef.current;
+    if (!root || typeof ResizeObserver === "undefined") return;
+    const obs = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      const w = entry?.contentRect.width ?? root.getBoundingClientRect().width;
+      widthRef.current = w;
+      const clamped = clampRatio(liveRatioRef.current, w);
+      if (clamped !== liveRatioRef.current) {
+        liveRatioRef.current = clamped;
+        setRatio(clamped);
+      }
+    });
+    obs.observe(root);
+    return () => obs.disconnect();
+  }, [enabled, rootRef]);
+
+  const persist = useCallback(
+    (next: number) => {
+      liveRatioRef.current = next;
+      setRatio(next);
+      store.set(SPLITTER_STORAGE_KEY, formatStoredRatio(next));
+    },
+    [store],
+  );
+
+  const onPointerDown = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      if (!enabled) return;
+      e.preventDefault();
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId);
+      } catch {
+        // Some browsers throw if the pointer is already captured; non-fatal.
+      }
+      setDragging(true);
+      if (typeof document !== "undefined") {
+        document.body.style.cursor = "col-resize";
+      }
+    },
+    [enabled],
+  );
+
+  const onPointerMove = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      if (!dragging) return;
+      const root = rootRef.current;
+      if (!root) return;
+      const rect = root.getBoundingClientRect();
+      if (rect.width <= 0) return;
+      const desired = (e.clientX - rect.left) / rect.width;
+      const next = clampRatio(desired, rect.width);
+      liveRatioRef.current = next;
+      root.style.setProperty("--cli-canvas-frac", `${next}fr`);
+      root.style.setProperty("--cli-right-frac", `${1 - next}fr`);
+      e.currentTarget.setAttribute(
+        "aria-valuenow",
+        String(Math.round(next * 100)),
+      );
+    },
+    [dragging, rootRef],
+  );
+
+  const onPointerUp = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      if (!dragging) return;
+      setDragging(false);
+      if (typeof document !== "undefined") {
+        document.body.style.cursor = "";
+      }
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        // Safe to ignore — capture may have already been released by the browser.
+      }
+      persist(liveRatioRef.current);
+    },
+    [dragging, persist],
+  );
+
+  const onDoubleClick = useCallback(() => {
+    if (!enabled) return;
+    persist(SPLITTER_DEFAULT_RATIO);
+    store.remove(SPLITTER_STORAGE_KEY);
+  }, [enabled, persist, store]);
+
+  const onKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (!enabled) return;
+      const next = nudgeRatio(liveRatioRef.current, e.key, {
+        shiftKey: e.shiftKey,
+      });
+      if (next === null) return;
+      e.preventDefault();
+      const root = rootRef.current;
+      const w = root ? root.getBoundingClientRect().width : widthRef.current;
+      persist(clampRatio(next, w));
+    },
+    [enabled, persist, rootRef],
+  );
+
+  return {
+    ratio,
+    dragging,
+    handleProps: {
+      role: "separator",
+      "aria-orientation": "vertical",
+      "aria-valuenow": Math.round(ratio * 100),
+      "aria-valuemin": 0,
+      "aria-valuemax": 100,
+      tabIndex: 0,
+      title: "Drag to resize · double-click to reset",
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel: onPointerUp,
+      onDoubleClick,
+      onKeyDown,
+    },
+  };
+}

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -204,4 +204,126 @@ test.describe("/cli", () => {
     );
     await expect(input).toBeEnabled();
   });
+
+  // #465 — splitter L/R layout. The splitter is hidden while no graph
+  // has been rendered yet; once a graph-producing command lands, the
+  // page switches to a two-column grid with the canvas on the left,
+  // the toolbar/scrollback/input on the right, and a draggable splitter
+  // between them.
+  test("splitter is hidden until a graph-producing command lands (#465)", async ({
+    page,
+  }) => {
+    await page.goto("/cli");
+    await expect(page.getByTestId("cli-splitter")).toHaveCount(0);
+    // data-mode reads "cli" while no graph is present.
+    await expect(page.getByTestId("cli-root")).toHaveAttribute(
+      "data-mode",
+      "cli",
+    );
+    const input = page.getByTestId("cli-input");
+    await input.fill("get vertex cli:alpha");
+    await input.press("Enter");
+    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
+    await expect(page.getByTestId("cli-root")).toHaveAttribute(
+      "data-mode",
+      "split",
+    );
+    await expect(page.getByTestId("cli-splitter")).toBeVisible();
+  });
+
+  test("dragging the splitter changes the column ratio and persists it (#465)", async ({
+    page,
+  }) => {
+    // Playwright's `fullyParallel` runs each test in a fresh browser
+    // context, so localStorage starts empty and the splitter takes
+    // the default 0.6 ratio without any explicit cleanup.
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    await input.fill("get vertex cli:alpha");
+    await input.press("Enter");
+    const splitter = page.getByTestId("cli-splitter");
+    await expect(splitter).toBeVisible();
+    // Initial aria-valuenow reflects the 60% default.
+    await expect(splitter).toHaveAttribute("aria-valuenow", "60");
+    // Drag the handle ~150px to the left and verify the ratio shrank.
+    // 150px against the ~1100px-wide root is well inside the 360px
+    // min-pane clamp on both sides.
+    const box = await splitter.boundingBox();
+    if (!box) throw new Error("splitter has no bounding box");
+    const startX = box.x + box.width / 2;
+    const startY = box.y + box.height / 2;
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX - 150, startY, { steps: 12 });
+    await page.mouse.up();
+    // aria-valuenow should now be noticeably below 60 and well above
+    // the min-pane clamp.
+    const afterDrag = Number(await splitter.getAttribute("aria-valuenow"));
+    expect(afterDrag).toBeLessThan(55);
+    expect(afterDrag).toBeGreaterThan(35);
+    // localStorage holds the persisted value.
+    const stored = await page.evaluate(() =>
+      window.localStorage.getItem("cli.splitRatio"),
+    );
+    expect(stored).not.toBeNull();
+    const storedNum = Number.parseFloat(stored ?? "");
+    expect(storedNum).toBeGreaterThan(0);
+    expect(storedNum).toBeLessThan(1);
+    // Reload and verify the splitter starts at the persisted ratio.
+    await page.reload();
+    await page.getByTestId("cli-input").fill("get vertex cli:alpha");
+    await page.getByTestId("cli-input").press("Enter");
+    const splitter2 = page.getByTestId("cli-splitter");
+    await expect(splitter2).toBeVisible();
+    const persisted = Number(await splitter2.getAttribute("aria-valuenow"));
+    // Should be within 1pp of the post-drag value (rounded to integer pct).
+    expect(Math.abs(persisted - afterDrag)).toBeLessThanOrEqual(1);
+  });
+
+  test("double-clicking the splitter resets to the default ratio (#465)", async ({
+    page,
+  }) => {
+    // Pre-seed a non-default ratio so the reset is observable. 0.45
+    // sits safely inside the 360px-min clamp at desktop widths.
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem("cli.splitRatio", "0.4500");
+      } catch {
+        // intentionally empty
+      }
+    });
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    await input.fill("get vertex cli:alpha");
+    await input.press("Enter");
+    const splitter = page.getByTestId("cli-splitter");
+    await expect(splitter).toBeVisible();
+    await expect(splitter).toHaveAttribute("aria-valuenow", "45");
+    await splitter.dblclick();
+    await expect(splitter).toHaveAttribute("aria-valuenow", "60");
+    const stored = await page.evaluate(() =>
+      window.localStorage.getItem("cli.splitRatio"),
+    );
+    expect(stored).toBeNull();
+  });
+
+  test("auto-scroll keeps the latest scrollback entry visible after a graph command (#465)", async ({
+    page,
+  }) => {
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    // Pile up enough entries that the scrollback would naturally need
+    // to scroll for the latest one to be visible.
+    for (let i = 0; i < 6; i++) {
+      await input.fill("get vertex cli:alpha");
+      await input.press("Enter");
+      await expect(page.getByTestId("cli-entry-ok").last()).toContainText(
+        "first",
+      );
+    }
+    // The most recent ok entry must be in the viewport AND scrolled
+    // into view inside the scrollback container.
+    const last = page.getByTestId("cli-entry-ok").last();
+    await expect(last).toBeInViewport();
+  });
 });


### PR DESCRIPTION
Closes #465.

## What changes

The admin `/cli` page now uses a two-column grid layout above 1024 px:

- **Left**: `IlluminateCanvas` at full panel height (was capped at 45 %).
- **4 px draggable splitter** in the middle column.
- **Right**: toolbar + scrollback + input stack (was below the canvas).

Below 1024 px the page falls back to the existing single-column flex stack — narrow viewports keep the old ergonomics.

While no graph-producing command has run yet (`latestGraph === null`), the right column expands to fill the row and the splitter is hidden — the page looks like a plain terminal until you ask for graph output.

## Splitter behavior

- **Drag**: \`onPointerDown\` captures the pointer, \`onPointerMove\` mutates the \`--cli-canvas-frac\` / \`--cli-right-frac\` CSS variables on \`.root\` directly via \`setAttribute\` — **no React re-render per frame**. \`onPointerUp\` commits the final ratio to state + localStorage.
- **Persistence**: localStorage key \`cli.splitRatio\` (number in [0, 1]); read on mount, falls back to 0.6 default.
- **Min/max**: clamped to \`[360 px / containerWidth, 1 - 360 px / containerWidth]\` so neither pane collapses; ResizeObserver re-clamps on container resize.
- **Double-click**: resets to 0.6 + removes the localStorage entry.
- **Keyboard**: \`role=\"separator\"\` + \`aria-orientation=\"vertical\"\` + \`aria-valuenow/min/max\`; ←/→ nudges 2 %, Shift+←/→ jumps 10 %, Home/End extremes, Enter resets.

## Architecture

Following the same pattern as #453 (\`palette.ts\`):

- \`admin/app/lib/cli/cli-splitter.ts\` — pure helpers (\`clampRatio\`, \`parseStoredRatio\`, \`formatStoredRatio\`, \`nudgeRatio\`). No DOM, no React.
- \`admin/app/lib/cli/cli-splitter.test.ts\` — 16 bun:test cases.
- \`admin/app/lib/cli/use-cli-splitter.ts\` — DOM-coupled React hook that wires the helpers up to pointer events, ResizeObserver, and \`BrowserStorage\`.
- \`admin/app/components/cli/CliPage/CliPage.{tsx,module.css}\` — integration.

## Validation

| Check | Result |
| --- | --- |
| \`bun run typecheck\` | clean |
| \`bun run test\` | 312 pass / 0 fail / 587 expect (16 new from \`cli-splitter.test.ts\`) |
| \`bun run lint\` | clean |
| \`bun run format:check\` | clean |
| \`bun run build\` | OK |
| \`bun run test:e2e --workers=1\` | 32/32 pass (includes 4 new \`#465\` cases) |

The four new Playwright cases assert: (1) splitter hidden until a graph-producing command lands, (2) drag changes the ratio + persists across reload, (3) double-click resets to 0.6, (4) scrollback auto-scroll keeps the latest entry in view after a graph command.

## Breaking change

The \`/cli\` DOM shape changed. External automation that relied on the canvas being the second child of \`.root\` must now look inside \`.leftColumn\` (\`cli-left-column\` test-id). All public test-ids (\`cli-canvas-panel\`, \`cli-input\`, \`cli-entry-ok/error/info\`, …) are stable.