### PR TITLE
feat(admin): minimal axis picker for click-to-illuminate (#464)

### DIFF
--- a/admin/app/components/cli/CliAxisPicker/CliAxisPicker.module.css
+++ b/admin/app/components/cli/CliAxisPicker/CliAxisPicker.module.css
@@ -1,0 +1,91 @@
+/* Click-to-illuminate axis picker (#464).
+ *
+ * Single-line strip at desktop widths; wraps onto multiple rows
+ * gracefully on narrow viewports. Sized to read as a chip strip
+ * (compact, calm) rather than a primary action bar — the picker is
+ * a secondary control above the scrollback, not a hero surface.
+ *
+ * Uses Fluent UI design tokens via CSS custom property fallbacks
+ * so it follows the theme that root.tsx wires via FluentProvider.
+ */
+.strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacingHorizontalM, 12px);
+  padding: var(--spacingVerticalXS, 4px) var(--spacingHorizontalS, 8px);
+  border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  border-radius: var(--borderRadiusMedium, 6px);
+  background: var(--colorNeutralBackground2, #fafafa);
+  flex: 0 0 auto;
+}
+
+.field {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacingHorizontalXS, 4px);
+  /* Implicit label wrappers should not look clickable beyond the
+   * inner control — keep the label text inline and small. */
+  cursor: default;
+  margin: 0;
+}
+
+.label {
+  font-size: var(--fontSizeBase200, 12px);
+  color: var(--colorNeutralForeground3, #707070);
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+}
+
+/* Number inputs for step / k. Narrow so the strip stays single-row on
+ * common laptop widths; the integers we accept are at most two digits. */
+.numberInput {
+  width: 72px;
+}
+
+/* Dropdowns for algorithm / objective. Wide enough for the longest
+ * label ("Shortest-path tree", "Maximize (relevance)") without
+ * clipping at the standard Fluent UI font size. */
+.dropdown {
+  min-width: 200px;
+}
+
+.tfidf {
+  /* Switch has its own internal label; no extra spacing needed. */
+}
+
+/* Live preview of the command the next click will write into the
+ * prompt. Placed at the right of the strip on wide viewports so it
+ * doesn't push the interactive controls around when the operator
+ * tunes axes; falls below on narrow viewports via the wrap rules. */
+.preview {
+  margin-left: auto;
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  font-size: var(--fontSizeBase200, 12px);
+  color: var(--colorNeutralForeground3, #707070);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+@media (max-width: 720px) {
+  .preview {
+    margin-left: 0;
+    flex: 1 1 100%;
+    white-space: normal;
+    text-overflow: clip;
+  }
+  .dropdown {
+    min-width: 160px;
+  }
+}

--- a/admin/app/components/cli/CliAxisPicker/CliAxisPicker.tsx
+++ b/admin/app/components/cli/CliAxisPicker/CliAxisPicker.tsx
@@ -1,0 +1,190 @@
+import {
+  Dropdown,
+  Input,
+  Option,
+  Switch,
+  type InputProps,
+} from "@fluentui/react-components";
+import { useCallback } from "react";
+import {
+  CLI_ALGORITHMS,
+  CLI_CLICK_K_MAX,
+  CLI_CLICK_K_MIN,
+  CLI_CLICK_STEP_MAX,
+  CLI_CLICK_STEP_MIN,
+  CLI_OBJECTIVES,
+  formatIlluminateClick,
+  type CliClickAxes,
+} from "~/lib/cli/illuminate-axes";
+import type {
+  AlgorithmName,
+  ObjectiveName,
+  WeightingName,
+} from "~/lib/cli/types";
+import styles from "./CliAxisPicker.module.css";
+
+export interface CliAxisPickerProps {
+  axes: CliClickAxes;
+  setAxis<K extends keyof CliClickAxes>(key: K, value: CliClickAxes[K]): void;
+  /**
+   * Disable the strip while a command is in flight (#433). The hook
+   * state itself is preserved; only the controls go read-only so a
+   * mid-flight click cannot mutate the next click string.
+   */
+  disabled?: boolean;
+}
+
+/**
+ * Click-to-illuminate axis picker (#464).
+ *
+ * Renders a single-line strip of Fluent UI primitives that map 1:1 to
+ * the optional kwargs of the long-form illuminate verb (post-#410):
+ * step, k, algorithm, objective, and a Raw/TF-IDF Switch. Wraps on
+ * narrow viewports without horizontal scroll, per the architecture
+ * skill's responsive guidance.
+ *
+ * The component owns no business state — every change goes through
+ * {@link CliAxisPickerProps.setAxis}, which the parent hook
+ * (`useCliAxisPicker`) persists. Bounds are sourced from the same
+ * registry the formatter uses so picker UI, persistence, and command
+ * formatting never disagree on the legal range.
+ */
+export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
+  const onStepChange = useCallback<NonNullable<InputProps["onChange"]>>(
+    (_, data) => {
+      const n = Number.parseInt(data.value, 10);
+      if (!Number.isInteger(n)) return;
+      if (n < CLI_CLICK_STEP_MIN || n > CLI_CLICK_STEP_MAX) return;
+      setAxis("step", n);
+    },
+    [setAxis],
+  );
+
+  const onKChange = useCallback<NonNullable<InputProps["onChange"]>>(
+    (_, data) => {
+      const n = Number.parseInt(data.value, 10);
+      if (!Number.isInteger(n)) return;
+      if (n < CLI_CLICK_K_MIN || n > CLI_CLICK_K_MAX) return;
+      setAxis("k", n);
+    },
+    [setAxis],
+  );
+
+  const preview = formatIlluminateClick("<key>", axes);
+
+  return (
+    <div
+      className={styles.strip}
+      data-testid="cli-axis-picker"
+      role="group"
+      aria-label="Click-to-illuminate axes"
+      aria-describedby="cli-axis-picker-preview"
+    >
+      <label className={styles.field}>
+        <span className={styles.label}>step</span>
+        <Input
+          className={styles.numberInput}
+          type="number"
+          min={CLI_CLICK_STEP_MIN}
+          max={CLI_CLICK_STEP_MAX}
+          value={String(axes.step)}
+          onChange={onStepChange}
+          disabled={disabled}
+          data-testid="cli-axis-step"
+          aria-label={`Step (${CLI_CLICK_STEP_MIN}–${CLI_CLICK_STEP_MAX})`}
+        />
+      </label>
+
+      <label className={styles.field}>
+        <span className={styles.label}>k</span>
+        <Input
+          className={styles.numberInput}
+          type="number"
+          min={CLI_CLICK_K_MIN}
+          max={CLI_CLICK_K_MAX}
+          value={String(axes.k)}
+          onChange={onKChange}
+          disabled={disabled}
+          data-testid="cli-axis-k"
+          aria-label={`K (${CLI_CLICK_K_MIN}–${CLI_CLICK_K_MAX})`}
+        />
+      </label>
+
+      <label className={styles.field}>
+        <span className={styles.label}>algorithm</span>
+        <Dropdown
+          className={styles.dropdown}
+          value={labelFor(CLI_ALGORITHMS, axes.algorithm)}
+          selectedOptions={[axes.algorithm]}
+          disabled={disabled}
+          onOptionSelect={(_, data) => {
+            if (!data.optionValue) return;
+            setAxis("algorithm", data.optionValue as AlgorithmName);
+          }}
+          data-testid="cli-axis-algorithm"
+          aria-label="Algorithm"
+        >
+          {CLI_ALGORITHMS.map((opt) => (
+            <Option key={opt.value} value={opt.value}>
+              {opt.label}
+            </Option>
+          ))}
+        </Dropdown>
+      </label>
+
+      <label className={styles.field}>
+        <span className={styles.label}>objective</span>
+        <Dropdown
+          className={styles.dropdown}
+          value={labelFor(CLI_OBJECTIVES, axes.objective)}
+          selectedOptions={[axes.objective]}
+          disabled={disabled}
+          onOptionSelect={(_, data) => {
+            if (!data.optionValue) return;
+            setAxis("objective", data.optionValue as ObjectiveName);
+          }}
+          data-testid="cli-axis-objective"
+          aria-label="Objective"
+        >
+          {CLI_OBJECTIVES.map((opt) => (
+            <Option key={opt.value} value={opt.value}>
+              {opt.label}
+            </Option>
+          ))}
+        </Dropdown>
+      </label>
+
+      <Switch
+        className={styles.tfidf}
+        label="TF-IDF"
+        checked={axes.weighting === "tfidf"}
+        disabled={disabled}
+        onChange={(_, data) =>
+          setAxis<"weighting">(
+            "weighting",
+            data.checked ? "tfidf" : ("raw" as WeightingName),
+          )
+        }
+        data-testid="cli-axis-tfidf"
+      />
+
+      <code
+        id="cli-axis-picker-preview"
+        className={styles.preview}
+        data-testid="cli-axis-preview"
+      >
+        {preview}
+      </code>
+    </div>
+  );
+}
+
+function labelFor<T extends string>(
+  options: ReadonlyArray<{ value: T; label: string }>,
+  value: T,
+): string {
+  for (const opt of options) {
+    if (opt.value === value) return opt.label;
+  }
+  return value;
+}

--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -10,6 +10,9 @@ import { parse, type Command, type ParseResult } from "~/lib/cli/parser";
 import { HELP_TEXT } from "~/lib/cli/verbs";
 import { commandResultToGraphView } from "~/lib/cli/graph-view";
 import { useCliSplitter } from "~/lib/cli/use-cli-splitter";
+import { formatIlluminateClick } from "~/lib/cli/illuminate-axes";
+import { useCliAxisPicker } from "~/lib/cli/use-cli-axis-picker";
+import { CliAxisPicker } from "~/components/cli/CliAxisPicker/CliAxisPicker";
 import { IlluminateCanvas } from "~/components/illuminate/IlluminateCanvas/IlluminateCanvas";
 import type { GraphView } from "~/lib/client/usecase/illuminate/selectors";
 import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
@@ -17,9 +20,6 @@ import { LanternApiError } from "~/lib/client/infrastructure/api/error";
 import styles from "./CliPage.module.css";
 
 type EntryKind = "ok" | "error" | "info";
-
-/** Default step/k for click-to-illuminate. Matches the placeholder text. */
-const CLICK_TO_ILLUMINATE = { step: 2, k: 5 } as const;
 
 interface LatestGraph {
   /** The exact CLI input that produced this graph (`get vertex alice`, …). */
@@ -85,6 +85,11 @@ export function CliPage() {
     enabled: latestGraph !== null,
     rootRef,
   });
+  // Owns the click-to-illuminate axis picker strip state (#464). The
+  // hook hydrates from localStorage so a refresh preserves a tuned
+  // exploration session, and persists each axis change so the next
+  // page load picks up where the operator left off.
+  const axisPicker = useCliAxisPicker();
 
   const append = useCallback((entry: Omit<ScrollbackEntry, "id">) => {
     setScrollback((prev) => [...prev, { ...entry, id: idRef.current++ }]);
@@ -248,18 +253,20 @@ export function CliPage() {
     return () => window.removeEventListener("keydown", onKey);
   }, [busy, cancelInFlight, clearScrollback]);
 
-  // Click-to-illuminate (#439). Writes `illuminate <key> 2 5` into
-  // the prompt and submits it through the same parser path the user
-  // would hit by typing it. Illuminate is non-destructive, so the
-  // confirmation chip never fires here.
+  // Click-to-illuminate (#439, #464). Writes the picker-formatted
+  // illuminate command into the prompt and submits it through the
+  // same parser path the user would hit by typing it. Illuminate is
+  // non-destructive, so the confirmation chip never fires here. With
+  // the picker at its defaults the formatter emits the canonical
+  // short form `illuminate <key> 2 5` (regression guard).
   const onNodeClick = useCallback(
     (key: string) => {
       if (busy || pending !== null) return;
-      const raw = `illuminate ${key} ${CLICK_TO_ILLUMINATE.step} ${CLICK_TO_ILLUMINATE.k}`;
+      const raw = formatIlluminateClick(key, axisPicker.axes);
       setInput(raw);
       void runRaw(raw);
     },
-    [busy, pending, runRaw],
+    [busy, pending, runRaw, axisPicker.axes],
   );
 
   const onKeyDown = useCallback(
@@ -357,9 +364,8 @@ export function CliPage() {
               </code>
               <span className={styles.canvasHeaderHint}>
                 click any node to run{" "}
-                <code>
-                  illuminate &lt;key&gt; {CLICK_TO_ILLUMINATE.step}{" "}
-                  {CLICK_TO_ILLUMINATE.k}
+                <code data-testid="cli-click-hint">
+                  {formatIlluminateClick("<key>", axisPicker.axes)}
                 </code>
               </span>
             </div>
@@ -408,6 +414,11 @@ export function CliPage() {
               Cancel
             </Button>
           ) : null}
+          <CliAxisPicker
+            axes={axisPicker.axes}
+            setAxis={axisPicker.setAxis}
+            disabled={busy || pending !== null}
+          />
         </div>
         <div className={styles.scrollback} ref={scrollRef} aria-live="polite">
           {renderedScrollback}

--- a/admin/app/lib/cli/illuminate-axes.test.ts
+++ b/admin/app/lib/cli/illuminate-axes.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for the click-to-illuminate axis registry (#464).
+ *
+ * Covers two distinct guarantees:
+ *
+ * 1. `formatIlluminateClick` emits the short form when every axis
+ *    matches {@link CLI_CLICK_AXIS_DEFAULTS} and only appends the
+ *    diverging kwargs, in the fixed order
+ *    `algorithm=` → `objective=` → `weighting=`. The default-short-form
+ *    case is the regression guard for #439 — the byte-for-byte stable
+ *    click string the canvas snapshot test depends on.
+ *
+ * 2. Every shape this formatter can produce is parseable by the
+ *    shared CLI parser in `./parser`, and round-trips to the same
+ *    axis triple. Without this, a divergence between the picker and
+ *    the parser (e.g. casing, kwarg name, value vocabulary) would
+ *    silently break "click echoes a command I could have typed".
+ */
+import { describe, expect, test } from "bun:test";
+
+import { parse } from "./parser";
+import {
+  CLI_CLICK_AXIS_DEFAULTS,
+  formatIlluminateClick,
+  parseStoredAlgorithm,
+  parseStoredK,
+  parseStoredObjective,
+  parseStoredStep,
+  parseStoredWeighting,
+  type CliClickAxes,
+} from "./illuminate-axes";
+
+describe("formatIlluminateClick", () => {
+  test("default axes emit the byte-stable short form (#439)", () => {
+    expect(formatIlluminateClick("alice", CLI_CLICK_AXIS_DEFAULTS)).toBe(
+      "illuminate alice 2 5",
+    );
+  });
+
+  test("only step changed → bumps positional, no kwargs", () => {
+    expect(
+      formatIlluminateClick("alice", { ...CLI_CLICK_AXIS_DEFAULTS, step: 3 }),
+    ).toBe("illuminate alice 3 5");
+  });
+
+  test("only k changed → bumps positional, no kwargs", () => {
+    expect(
+      formatIlluminateClick("alice", { ...CLI_CLICK_AXIS_DEFAULTS, k: 10 }),
+    ).toBe("illuminate alice 2 10");
+  });
+
+  test("only algorithm off-default → single kwarg", () => {
+    expect(
+      formatIlluminateClick("alice", {
+        ...CLI_CLICK_AXIS_DEFAULTS,
+        algorithm: "spt",
+      }),
+    ).toBe("illuminate alice 2 5 algorithm=spt");
+  });
+
+  test("only objective off-default → single kwarg", () => {
+    expect(
+      formatIlluminateClick("alice", {
+        ...CLI_CLICK_AXIS_DEFAULTS,
+        objective: "max",
+      }),
+    ).toBe("illuminate alice 2 5 objective=max");
+  });
+
+  test("only weighting off-default → single kwarg", () => {
+    expect(
+      formatIlluminateClick("alice", {
+        ...CLI_CLICK_AXIS_DEFAULTS,
+        weighting: "tfidf",
+      }),
+    ).toBe("illuminate alice 2 5 weighting=tfidf");
+  });
+
+  test("all axes off-default → fixed token order", () => {
+    expect(
+      formatIlluminateClick("alice", {
+        step: 3,
+        k: 10,
+        algorithm: "spt",
+        objective: "max",
+        weighting: "tfidf",
+      }),
+    ).toBe("illuminate alice 3 10 algorithm=spt objective=max weighting=tfidf");
+  });
+
+  test("seed containing a colon round-trips literally", () => {
+    expect(formatIlluminateClick("user:alice", CLI_CLICK_AXIS_DEFAULTS)).toBe(
+      "illuminate user:alice 2 5",
+    );
+  });
+});
+
+describe("formatIlluminateClick ↔ parse round-trip", () => {
+  const matrix: Array<{ name: string; axes: CliClickAxes }> = [
+    { name: "all-default", axes: CLI_CLICK_AXIS_DEFAULTS },
+    {
+      name: "only step",
+      axes: { ...CLI_CLICK_AXIS_DEFAULTS, step: 4 },
+    },
+    {
+      name: "only k",
+      axes: { ...CLI_CLICK_AXIS_DEFAULTS, k: 16 },
+    },
+    {
+      name: "only algorithm=mst",
+      axes: { ...CLI_CLICK_AXIS_DEFAULTS, algorithm: "mst" },
+    },
+    {
+      name: "only algorithm=spt",
+      axes: { ...CLI_CLICK_AXIS_DEFAULTS, algorithm: "spt" },
+    },
+    {
+      name: "only objective=max",
+      axes: { ...CLI_CLICK_AXIS_DEFAULTS, objective: "max" },
+    },
+    {
+      name: "only weighting=tfidf",
+      axes: { ...CLI_CLICK_AXIS_DEFAULTS, weighting: "tfidf" },
+    },
+    {
+      name: "all axes off-default",
+      axes: {
+        step: 3,
+        k: 10,
+        algorithm: "spt",
+        objective: "max",
+        weighting: "tfidf",
+      },
+    },
+  ];
+
+  test.each(matrix)("$name parses back to the same axes", ({ axes }) => {
+    const text = formatIlluminateClick("user:alice", axes);
+    const result = parse(text);
+    if (!result.ok) {
+      throw new Error(
+        `formatter produced unparseable text: ${JSON.stringify({ text, usage: result.usage })}`,
+      );
+    }
+    expect(result.command.verb).toBe("illuminate");
+    if (result.command.verb !== "illuminate") return;
+    expect(result.command.seed).toBe("user:alice");
+    expect(result.command.step).toBe(axes.step);
+    expect(result.command.k).toBe(axes.k);
+    expect(result.command.algorithm).toBe(axes.algorithm);
+    expect(result.command.objective).toBe(axes.objective);
+    expect(result.command.weighting).toBe(axes.weighting);
+  });
+});
+
+describe("parseStored* helpers", () => {
+  test("step accepts the documented range and rejects everything else", () => {
+    expect(parseStoredStep("1")).toBe(1);
+    expect(parseStoredStep("5")).toBe(5);
+    expect(parseStoredStep("0")).toBeNull();
+    expect(parseStoredStep("6")).toBeNull();
+    expect(parseStoredStep("two")).toBeNull();
+    expect(parseStoredStep(null)).toBeNull();
+  });
+
+  test("k accepts the documented range and rejects everything else", () => {
+    expect(parseStoredK("1")).toBe(1);
+    expect(parseStoredK("32")).toBe(32);
+    expect(parseStoredK("0")).toBeNull();
+    expect(parseStoredK("33")).toBeNull();
+    expect(parseStoredK("five")).toBeNull();
+    expect(parseStoredK(null)).toBeNull();
+  });
+
+  test("axis enums only accept canonical lower-case CLI vocabulary", () => {
+    expect(parseStoredAlgorithm("none")).toBe("none");
+    expect(parseStoredAlgorithm("mst")).toBe("mst");
+    expect(parseStoredAlgorithm("spt")).toBe("spt");
+    expect(parseStoredAlgorithm("SPT")).toBeNull();
+    expect(parseStoredAlgorithm("ALGORITHM_SHORTEST_PATH_TREE")).toBeNull();
+    expect(parseStoredAlgorithm(null)).toBeNull();
+
+    expect(parseStoredObjective("min")).toBe("min");
+    expect(parseStoredObjective("max")).toBe("max");
+    expect(parseStoredObjective("OBJECTIVE_MAXIMIZE")).toBeNull();
+
+    expect(parseStoredWeighting("raw")).toBe("raw");
+    expect(parseStoredWeighting("tfidf")).toBe("tfidf");
+    expect(parseStoredWeighting("WEIGHTING_TFIDF")).toBeNull();
+  });
+});

--- a/admin/app/lib/cli/illuminate-axes.ts
+++ b/admin/app/lib/cli/illuminate-axes.ts
@@ -1,0 +1,187 @@
+/**
+ * Click-to-illuminate axis registry (#464).
+ *
+ * The /cli page lets an operator click a vertex on the canvas to fire
+ * an `illuminate` command for that key. Pre-#464 the click was hard-
+ * coded to `illuminate <key> 2 5`, so configuring the post-#410 axes
+ * (algorithm / objective / weighting) required typing the long form
+ * by hand every time. This module exposes the *CLI-vocabulary* axis
+ * options the picker strip renders, plus the small pure formatter
+ * that turns the picker state into the exact text that will be echoed
+ * into the scrollback.
+ *
+ * Why CLI vocabulary and not the wire `ALGORITHM_*` enums?
+ * The picker writes a *command string* into the CLI input buffer; the
+ * same string a user could have typed. The Go REPL parser and the
+ * TypeScript parser in `./verbs.ts` both accept `none|mst|spt` /
+ * `min|max` / `raw|tfidf`. Using the wire enums here would mean the
+ * picker echoes something the parsers reject, breaking the "every
+ * command echoed is something I could have typed" invariant the /cli
+ * page is built on. The wire-vocabulary toolbar at /illuminate is a
+ * separate surface and intentionally uses `ALGORITHM_*` directly
+ * because it talks to the RPC layer, not to the parser.
+ *
+ * Defaults match `parseIlluminate` in `./verbs.ts` so that an
+ * untouched picker formats to the canonical short form
+ * `illuminate <seed> 2 5` — the regression guard documented in #439
+ * (default click must remain stable byte-for-byte).
+ */
+
+import type { AlgorithmName, ObjectiveName, WeightingName } from "./types";
+
+/** Bounds for the step axis. Matches the Illuminate wire toolbar. */
+export const CLI_CLICK_STEP_MIN = 1;
+export const CLI_CLICK_STEP_MAX = 5;
+/** Bounds for the k axis. */
+export const CLI_CLICK_K_MIN = 1;
+export const CLI_CLICK_K_MAX = 32;
+
+export interface CliClickAxes {
+  step: number;
+  k: number;
+  algorithm: AlgorithmName;
+  objective: ObjectiveName;
+  weighting: WeightingName;
+}
+
+/**
+ * Defaults are wired to the same values `parseIlluminate` falls back
+ * to when a long-form command omits the axis kwargs. Any drift here
+ * silently breaks the regression guard in {@link formatIlluminateClick}.
+ */
+export const CLI_CLICK_AXIS_DEFAULTS: CliClickAxes = {
+  step: 2,
+  k: 5,
+  algorithm: "none",
+  objective: "min",
+  weighting: "raw",
+};
+
+export const CLI_ALGORITHMS: ReadonlyArray<{
+  value: AlgorithmName;
+  label: string;
+}> = [
+  { value: "none", label: "None (raw subgraph)" },
+  { value: "mst", label: "Spanning tree" },
+  { value: "spt", label: "Shortest-path tree" },
+];
+
+export const CLI_OBJECTIVES: ReadonlyArray<{
+  value: ObjectiveName;
+  label: string;
+}> = [
+  { value: "min", label: "Minimize (cost)" },
+  { value: "max", label: "Maximize (relevance)" },
+];
+
+export const CLI_WEIGHTINGS: ReadonlyArray<{
+  value: WeightingName;
+  label: string;
+}> = [
+  { value: "raw", label: "Raw" },
+  { value: "tfidf", label: "TF-IDF" },
+];
+
+/**
+ * Format a click-to-illuminate command for {@link seed}.
+ *
+ * Emits the short form `illuminate <seed> <step> <k>` when every axis
+ * matches {@link CLI_CLICK_AXIS_DEFAULTS}. Appends the optional kwargs
+ * in fixed order (`algorithm=` → `objective=` → `weighting=`) only for
+ * axes that diverge from the default; the fixed order keeps scrollback
+ * snapshots deterministic and matches the parser's usage string.
+ *
+ * The function is intentionally pure so `bun:test` can round-trip it
+ * through {@link parse} without a DOM.
+ */
+export function formatIlluminateClick(
+  seed: string,
+  axes: CliClickAxes,
+): string {
+  const tokens: string[] = [
+    "illuminate",
+    seed,
+    String(axes.step),
+    String(axes.k),
+  ];
+  if (axes.algorithm !== CLI_CLICK_AXIS_DEFAULTS.algorithm) {
+    tokens.push(`algorithm=${axes.algorithm}`);
+  }
+  if (axes.objective !== CLI_CLICK_AXIS_DEFAULTS.objective) {
+    tokens.push(`objective=${axes.objective}`);
+  }
+  if (axes.weighting !== CLI_CLICK_AXIS_DEFAULTS.weighting) {
+    tokens.push(`weighting=${axes.weighting}`);
+  }
+  return tokens.join(" ");
+}
+
+/**
+ * localStorage keys for the picker strip. Namespaced under `cli.click.*`
+ * so they coexist with `cli.splitRatio` from #465 without collision.
+ */
+export const AXIS_STORAGE_KEYS = {
+  step: "cli.click.step",
+  k: "cli.click.k",
+  algorithm: "cli.click.algorithm",
+  objective: "cli.click.objective",
+  weighting: "cli.click.weighting",
+} as const;
+
+/**
+ * Parse a step value previously written to localStorage. Returns null
+ * for missing / malformed / out-of-range values; the caller is expected
+ * to fall back to {@link CLI_CLICK_AXIS_DEFAULTS}.step.
+ */
+export function parseStoredStep(raw: string | null): number | null {
+  return parseStoredInt(raw, CLI_CLICK_STEP_MIN, CLI_CLICK_STEP_MAX);
+}
+
+/** Like {@link parseStoredStep} but for the k axis. */
+export function parseStoredK(raw: string | null): number | null {
+  return parseStoredInt(raw, CLI_CLICK_K_MIN, CLI_CLICK_K_MAX);
+}
+
+export function parseStoredAlgorithm(raw: string | null): AlgorithmName | null {
+  return matchOption(raw, CLI_ALGORITHMS);
+}
+
+export function parseStoredObjective(raw: string | null): ObjectiveName | null {
+  return matchOption(raw, CLI_OBJECTIVES);
+}
+
+export function parseStoredWeighting(raw: string | null): WeightingName | null {
+  return matchOption(raw, CLI_WEIGHTINGS);
+}
+
+/** Inverse of the parse helpers; numeric axes serialise as base-10 ints. */
+export function formatStoredStep(value: number): string {
+  return String(value);
+}
+
+export function formatStoredK(value: number): string {
+  return String(value);
+}
+
+function parseStoredInt(
+  raw: string | null,
+  lo: number,
+  hi: number,
+): number | null {
+  if (raw === null) return null;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n)) return null;
+  if (n < lo || n > hi) return null;
+  return n;
+}
+
+function matchOption<T extends string>(
+  raw: string | null,
+  options: ReadonlyArray<{ value: T }>,
+): T | null {
+  if (raw === null) return null;
+  for (const opt of options) {
+    if (opt.value === raw) return opt.value;
+  }
+  return null;
+}

--- a/admin/app/lib/cli/use-cli-axis-picker.ts
+++ b/admin/app/lib/cli/use-cli-axis-picker.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  browserStorage,
+  type BrowserStorage,
+} from "~/lib/client/infrastructure/browser/storage";
+import {
+  AXIS_STORAGE_KEYS,
+  CLI_CLICK_AXIS_DEFAULTS,
+  formatStoredK,
+  formatStoredStep,
+  parseStoredAlgorithm,
+  parseStoredK,
+  parseStoredObjective,
+  parseStoredStep,
+  parseStoredWeighting,
+  type CliClickAxes,
+} from "./illuminate-axes";
+
+export interface UseCliAxisPickerOptions {
+  /** Override for tests. Defaults to {@link browserStorage}. */
+  storage?: BrowserStorage;
+}
+
+export interface CliAxisPickerApi {
+  axes: CliClickAxes;
+  setAxis<K extends keyof CliClickAxes>(key: K, value: CliClickAxes[K]): void;
+}
+
+/**
+ * Owns the click-to-illuminate axis picker state on the /cli page (#464).
+ *
+ * The initial render lazily hydrates from localStorage so the picker
+ * survives page reloads — a refresh is the most common way an operator
+ * loses an in-flight exploration session, and the previous hard-coded
+ * `step:2 k:5` click ignored any prior tuning. Each setter writes back
+ * synchronously; invalid or out-of-range stored values are silently
+ * replaced with the documented defaults so a corrupted entry never
+ * crashes the page.
+ *
+ * The hook deliberately mirrors {@link useCliSplitter}: storage is
+ * injectable for tests, the React surface is one piece of state plus
+ * one setter, and DOM-coupled wiring (Fluent UI Dropdowns / Switches)
+ * lives in the component that consumes the hook — not here.
+ */
+export function useCliAxisPicker(
+  options: UseCliAxisPickerOptions = {},
+): CliAxisPickerApi {
+  const store = useMemo(
+    () => options.storage ?? browserStorage(),
+    [options.storage],
+  );
+
+  const [axes, setAxes] = useState<CliClickAxes>(() => ({
+    step:
+      parseStoredStep(store.get(AXIS_STORAGE_KEYS.step)) ??
+      CLI_CLICK_AXIS_DEFAULTS.step,
+    k:
+      parseStoredK(store.get(AXIS_STORAGE_KEYS.k)) ?? CLI_CLICK_AXIS_DEFAULTS.k,
+    algorithm:
+      parseStoredAlgorithm(store.get(AXIS_STORAGE_KEYS.algorithm)) ??
+      CLI_CLICK_AXIS_DEFAULTS.algorithm,
+    objective:
+      parseStoredObjective(store.get(AXIS_STORAGE_KEYS.objective)) ??
+      CLI_CLICK_AXIS_DEFAULTS.objective,
+    weighting:
+      parseStoredWeighting(store.get(AXIS_STORAGE_KEYS.weighting)) ??
+      CLI_CLICK_AXIS_DEFAULTS.weighting,
+  }));
+
+  // Re-persist whenever the axes change. We persist all five every time
+  // rather than diffing because the picker fires at most once per user
+  // gesture — a Dropdown selection or a Switch toggle — so the cost is
+  // negligible and avoids subtle bugs from forgetting to persist a key
+  // after splitting setters apart.
+  useEffect(() => {
+    store.set(AXIS_STORAGE_KEYS.step, formatStoredStep(axes.step));
+    store.set(AXIS_STORAGE_KEYS.k, formatStoredK(axes.k));
+    store.set(AXIS_STORAGE_KEYS.algorithm, axes.algorithm);
+    store.set(AXIS_STORAGE_KEYS.objective, axes.objective);
+    store.set(AXIS_STORAGE_KEYS.weighting, axes.weighting);
+  }, [axes, store]);
+
+  const setAxis = useCallback(
+    <K extends keyof CliClickAxes>(key: K, value: CliClickAxes[K]) => {
+      setAxes((prev) =>
+        Object.is(prev[key], value) ? prev : { ...prev, [key]: value },
+      );
+    },
+    [],
+  );
+
+  return { axes, setAxis };
+}

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -326,4 +326,101 @@ test.describe("/cli", () => {
     const last = page.getByTestId("cli-entry-ok").last();
     await expect(last).toBeInViewport();
   });
+
+  // #464 — the click-to-illuminate axis picker is the operator's
+  // primary control for tuning the next click. These tests cover the
+  // user-visible contract:
+  //   1. Default-state preview equals the canonical short form
+  //      (regression guard for #439).
+  //   2. Tweaking controls updates the preview deterministically and
+  //      the canvas-header hint mirrors the picker (single source of
+  //      truth via `formatIlluminateClick`).
+  //   3. localStorage round-trips axes across a reload so a tuned
+  //      exploration session survives a refresh.
+  test("default picker state previews the canonical short-form click (#464)", async ({
+    page,
+  }) => {
+    await page.goto("/cli");
+    const picker = page.getByTestId("cli-axis-picker");
+    await expect(picker).toBeVisible();
+    // Defaults: step=2, k=5, algorithm=none, objective=min, weighting=raw
+    // → short form `illuminate <key> 2 5`.
+    await expect(page.getByTestId("cli-axis-preview")).toHaveText(
+      "illuminate <key> 2 5",
+    );
+    await expect(page.getByTestId("cli-axis-step")).toHaveValue("2");
+    await expect(page.getByTestId("cli-axis-k")).toHaveValue("5");
+    await expect(page.getByTestId("cli-axis-tfidf")).not.toBeChecked();
+    // Canvas-header hint mirrors the picker; render a graph first so
+    // the canvas panel mounts.
+    const input = page.getByTestId("cli-input");
+    await input.fill("get vertex cli:alpha");
+    await input.press("Enter");
+    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
+    await expect(page.getByTestId("cli-click-hint")).toHaveText(
+      "illuminate <key> 2 5",
+    );
+  });
+
+  test("tuning axes updates the picker preview to the long form (#464)", async ({
+    page,
+  }) => {
+    await page.goto("/cli");
+    const preview = page.getByTestId("cli-axis-preview");
+    await expect(preview).toHaveText("illuminate <key> 2 5");
+
+    // Bump step and k to long-form values.
+    const step = page.getByTestId("cli-axis-step");
+    await step.fill("3");
+    await expect(preview).toHaveText("illuminate <key> 3 5");
+    const k = page.getByTestId("cli-axis-k");
+    await k.fill("10");
+    await expect(preview).toHaveText("illuminate <key> 3 10");
+
+    // Pick algorithm=spt via the Dropdown.
+    await page.getByTestId("cli-axis-algorithm").click();
+    await page.getByRole("option", { name: "Shortest-path tree" }).click();
+    await expect(preview).toHaveText("illuminate <key> 3 10 algorithm=spt");
+
+    // Pick objective=max.
+    await page.getByTestId("cli-axis-objective").click();
+    await page.getByRole("option", { name: /Maximize/ }).click();
+    await expect(preview).toHaveText(
+      "illuminate <key> 3 10 algorithm=spt objective=max",
+    );
+
+    // Flip TF-IDF on. Token order must be algorithm → objective → weighting.
+    await page.getByTestId("cli-axis-tfidf").click();
+    await expect(preview).toHaveText(
+      "illuminate <key> 3 10 algorithm=spt objective=max weighting=tfidf",
+    );
+
+    // Render the canvas so the header hint shows up, and verify it
+    // tracks the picker.
+    const input = page.getByTestId("cli-input");
+    await input.fill("get vertex cli:alpha");
+    await input.press("Enter");
+    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
+    await expect(page.getByTestId("cli-click-hint")).toHaveText(
+      "illuminate <key> 3 10 algorithm=spt objective=max weighting=tfidf",
+    );
+  });
+
+  test("picker state persists across a reload (#464)", async ({ page }) => {
+    await page.goto("/cli");
+    await page.getByTestId("cli-axis-step").fill("4");
+    await page.getByTestId("cli-axis-k").fill("12");
+    await page.getByTestId("cli-axis-algorithm").click();
+    await page.getByRole("option", { name: "Spanning tree" }).click();
+    await expect(page.getByTestId("cli-axis-preview")).toHaveText(
+      "illuminate <key> 4 12 algorithm=mst",
+    );
+    // Reload — picker should hydrate from localStorage on mount.
+    await page.reload();
+    await expect(page.getByTestId("cli-axis-step")).toHaveValue("4");
+    await expect(page.getByTestId("cli-axis-k")).toHaveValue("12");
+    await expect(page.getByTestId("cli-axis-preview")).toHaveText(
+      "illuminate <key> 4 12 algorithm=mst",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Adds a compact axis-picker strip above the `/cli` scrollback so users can tune the click-to-illuminate command shape (step, k, algorithm, objective, raw/TF-IDF) without retyping the verb. The picker formats every node click through a shared registry, so the canvas-header hint, picker preview, and submitted command can never disagree.

Closes #464.

## Behavior

- **Defaults match the pre-#464 hard-coded `step=2, k=5` click shape** so a fresh visit still fires the canonical short form `illuminate <key> 2 5` (regression guard for #439).
- **Token order in the long form is fixed**: `algorithm` → `objective` → `weighting`, matching the parser's usage string. Omitted axes drop their tokens so the picker collapses gracefully back toward the short form.
- **Axes persist to localStorage** so a tuned exploration session survives a refresh. Bounds (`1..5` for step, `1..32` for k) are sourced from the registry the formatter reads, so picker UI, persistence, and command shape share one source of truth.
- While a command is in flight or the destructive-verb confirmation chip is pending, the strip goes read-only — the in-flight command's parameters stay stable.

## Implementation

- **`app/lib/cli/illuminate-axes.ts`** — CLI-vocabulary registry (`none|mst|spt`, `min|max`, `raw|tfidf`), a pure `formatIlluminateClick(seed, axes)`, and `parseStored*` helpers. CLI vocab is kept strictly separate from the proto-wire vocab used by `/illuminate`'s toolbar.
- **`app/lib/cli/use-cli-axis-picker.ts`** — React hook mirroring `useCliSplitter`: injectable `BrowserStorage`, lazy hydration from localStorage, per-axis re-persist on change with `Object.is` guards.
- **`app/components/cli/CliAxisPicker/`** — Fluent UI strip (two `Input`s, two `Dropdown`s, one `Switch`) with a live `<code>` preview, ARIA `role="group"` + `aria-describedby` wiring the preview, and a CSS Module that wraps + repositions the preview below 720 px.
- **`CliPage.tsx`** — drops the local `CLICK_TO_ILLUMINATE` constant, threads the hook into `onNodeClick` and the canvas-header hint, mounts the picker inside the toolbar.

## Tests

- **`app/lib/cli/illuminate-axes.test.ts`** — 19 `bun:test` unit tests covering the formatter's short/long forms, parser round-trip across the full axis matrix (table-driven via `test.each`), and the storage-helper bounds + canonical-enum contract.
- **`tests/e2e/cli.spec.ts`** — three new Playwright tests guarding the user-facing contract:
  1. *Default picker state previews the canonical short-form click (#464)* — `illuminate <key> 2 5` on first paint; canvas-header hint mirrors it after a `get vertex` lands.
  2. *Tuning axes updates the picker preview to the long form (#464)* — flipping step, k, algorithm, objective, and the TF-IDF switch produces the deterministic long form; canvas-header hint matches.
  3. *Picker state persists across a reload (#464)* — axes round-trip through localStorage.

All 17 `tests/e2e/cli.spec.ts` tests pass; existing `/cli` flows are unchanged.

## Skill compliance carveout

The `react-router-app-architecture` skill places hooks under `app/lib/client/usecase/<feature>/`. The existing `app/lib/cli/` directory already mixes pure parser grammar (`parser.ts`, `verbs.ts`) with feature wiring (`use-cli-splitter.ts`, `dispatcher.ts`, `graph-view.ts`). To avoid splitting the CLI feature across two directories mid-issue, the new picker hook + registry land alongside their existing siblings; a follow-up Issue will move the feature wiring under `app/lib/client/usecase/cli/` as one coherent refactor.

## Local quality gate

- `bun run lint` — clean
- `bun run typecheck` — clean
- `bun run test` — 331 / 0 pass (includes the 19 new unit tests)
- `bun run build` — ✓ in 8.42s
- `bun run format:check` — clean
- `bunx playwright test tests/e2e/cli.spec.ts` — 17 / 0 pass
