### PR TITLE
feat(admin): incremental ForceAtlas2 iterations on Illuminate reconcile

### DIFF
--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -7,6 +7,7 @@ import type {
   GraphNode,
 } from "~/lib/client/usecase/illuminate/selectors";
 import { usePreferredTheme } from "~/lib/client/usecase/theme/use-preferred-theme";
+import { decideFa2Iterations } from "./layout-iterations";
 import {
   FALLBACK_PALETTE,
   LABEL_SIZE,
@@ -57,6 +58,14 @@ export function IlluminateCanvas({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const sigmaRef = useRef<Sigma | null>(null);
   const graphRef = useRef<Graph | null>(null);
+  /**
+   * Snapshot of the node IDs the graph held at the end of the previous
+   * reconcile. Diffing against the next reconcile's IDs feeds
+   * `decideFa2Iterations` (#454) so we only burn an 80-iteration FA2
+   * pass on cold mounts; additive expansions (the common case) cost a
+   * cheap 5-iter relax and surviving vertices stay put.
+   */
+  const previousNodeIdsRef = useRef<Set<string>>(new Set());
   const [hover, setHover] = useState<HoverState | null>(null);
   const [palette, setPalette] = useState<SigmaPalette>(FALLBACK_PALETTE);
   const theme = usePreferredTheme();
@@ -147,11 +156,36 @@ export function IlluminateCanvas({
     renderer.on("enterEdge", showEdgeHover);
     renderer.on("leaveEdge", clearHover);
 
+    // Read-only Playwright test bridge (#454). Lets the e2e suite assert
+    // surviving-node positions across an additive expansion without
+    // resorting to flaky pixel diffs. Harmless in production — pure
+    // read-only accessor over the live graphology positions.
+    const win = window as Window & {
+      __illuminateCanvas?: {
+        getNodePosition: (key: string) => { x: number; y: number } | null;
+      };
+    };
+    win.__illuminateCanvas = {
+      getNodePosition: (key: string) => {
+        if (!graph.hasNode(key)) return null;
+        const attrs = graph.getNodeAttributes(key) as {
+          x?: number;
+          y?: number;
+        };
+        if (typeof attrs.x !== "number" || typeof attrs.y !== "number") {
+          return null;
+        }
+        return { x: attrs.x, y: attrs.y };
+      },
+    };
+
     return () => {
       renderer.kill();
       graph.clear();
       sigmaRef.current = null;
       graphRef.current = null;
+      previousNodeIdsRef.current = new Set();
+      delete win.__illuminateCanvas;
     };
   }, []);
 
@@ -197,6 +231,20 @@ export function IlluminateCanvas({
 
     const nextNodeIds = new Set(nodes.map((n) => n.id));
     const nextEdgeIds = new Set(edges.map((e) => e.id));
+
+    // Per-reconcile diff used by `decideFa2Iterations` (#454). We
+    // compute it BEFORE mutating the graph so the counts reflect the
+    // structural delta, not the post-merge state.
+    const previousNodeIds = previousNodeIdsRef.current;
+    const previousNodeCount = previousNodeIds.size;
+    let addedCount = 0;
+    let droppedCount = 0;
+    for (const id of nextNodeIds) {
+      if (!previousNodeIds.has(id)) addedCount += 1;
+    }
+    for (const id of previousNodeIds) {
+      if (!nextNodeIds.has(id)) droppedCount += 1;
+    }
 
     // Drop edges first to avoid orphan references when we drop nodes.
     for (const edgeId of graph.edges()) {
@@ -263,9 +311,19 @@ export function IlluminateCanvas({
       }
     }
 
-    if (graph.order > 0) {
+    // Per #454: only burn an 80-iteration FA2 pass on a cold mount or
+    // post-drop reseed; the common additive case relaxes in 5 so
+    // surviving vertices stay within roughly ±10% of their prior pixel
+    // position.
+    const iterations = decideFa2Iterations({
+      previousNodeCount,
+      addedCount,
+      droppedCount,
+      nextNodeCount: nextNodeIds.size,
+    });
+    if (iterations > 0 && graph.order > 0) {
       forceAtlas2.assign(graph, {
-        iterations: 80,
+        iterations,
         settings: {
           gravity: 1,
           scalingRatio: 8,
@@ -274,6 +332,8 @@ export function IlluminateCanvas({
         },
       });
     }
+
+    previousNodeIdsRef.current = nextNodeIds;
 
     sigma?.refresh();
   }, [nodes, edges, latestExpansionOrigin, palette, pickFill]);

--- a/admin/app/components/illuminate/IlluminateCanvas/layout-iterations.test.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/layout-iterations.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import {
+  FA2_ITERATIONS_ADDITIVE,
+  FA2_ITERATIONS_COLD,
+  FA2_ITERATIONS_DROP,
+  decideFa2Iterations,
+} from "./layout-iterations";
+
+describe("decideFa2Iterations", () => {
+  test("empty graph after reconcile → 0 iterations", () => {
+    expect(
+      decideFa2Iterations({
+        previousNodeCount: 0,
+        addedCount: 0,
+        droppedCount: 0,
+        nextNodeCount: 0,
+      }),
+    ).toBe(0);
+    // even if the prior graph held nodes that all got dropped, still 0:
+    expect(
+      decideFa2Iterations({
+        previousNodeCount: 5,
+        addedCount: 0,
+        droppedCount: 5,
+        nextNodeCount: 0,
+      }),
+    ).toBe(0);
+  });
+
+  test("cold mount (empty → populated) runs the full 80-iteration warm-up", () => {
+    expect(
+      decideFa2Iterations({
+        previousNodeCount: 0,
+        addedCount: 5,
+        droppedCount: 0,
+        nextNodeCount: 5,
+      }),
+    ).toBe(FA2_ITERATIONS_COLD);
+  });
+
+  test("post-Clear reseed (empty → populated, regardless of accounting) cold-starts", () => {
+    // After CLEAR the previous reconcile already dropped every node;
+    // the NEXT reconcile sees previousNodeCount=0 and treats it as cold.
+    expect(
+      decideFa2Iterations({
+        previousNodeCount: 0,
+        addedCount: 12,
+        droppedCount: 0,
+        nextNodeCount: 12,
+      }),
+    ).toBe(FA2_ITERATIONS_COLD);
+  });
+
+  test("pure attribute refresh (no add/drop, same node set) skips FA2", () => {
+    expect(
+      decideFa2Iterations({
+        previousNodeCount: 5,
+        addedCount: 0,
+        droppedCount: 0,
+        nextNodeCount: 5,
+      }),
+    ).toBe(0);
+  });
+
+  test("additive expansion (only new nodes added) uses the cheap 5-iter relax", () => {
+    expect(
+      decideFa2Iterations({
+        previousNodeCount: 5,
+        addedCount: 1,
+        droppedCount: 0,
+        nextNodeCount: 6,
+      }),
+    ).toBe(FA2_ITERATIONS_ADDITIVE);
+    expect(
+      decideFa2Iterations({
+        previousNodeCount: 5,
+        addedCount: 7,
+        droppedCount: 0,
+        nextNodeCount: 12,
+      }),
+    ).toBe(FA2_ITERATIONS_ADDITIVE);
+  });
+
+  test("drops (TTL expiry, soft-cap evict, etc.) get the 30-iter partial settle", () => {
+    expect(
+      decideFa2Iterations({
+        previousNodeCount: 6,
+        addedCount: 0,
+        droppedCount: 1,
+        nextNodeCount: 5,
+      }),
+    ).toBe(FA2_ITERATIONS_DROP);
+    // add + drop in the same reconcile is still treated as a drop case.
+    expect(
+      decideFa2Iterations({
+        previousNodeCount: 6,
+        addedCount: 2,
+        droppedCount: 1,
+        nextNodeCount: 7,
+      }),
+    ).toBe(FA2_ITERATIONS_DROP);
+  });
+});

--- a/admin/app/components/illuminate/IlluminateCanvas/layout-iterations.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/layout-iterations.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure helper that decides how many ForceAtlas2 iterations to run after
+ * a graph reconcile.
+ *
+ * Background (#454): the canvas previously ran 80 iterations on EVERY
+ * prop change. The iterative nature of FA2 means an 80-iteration pass
+ * from a perturbed equilibrium (one new centre-of-mass node + extra
+ * edges) redistributes every node. Surviving vertices jumped to new
+ * positions on every click, making the additive-expansion model (#466)
+ * impossible to follow visually.
+ *
+ * Rule of thumb:
+ *
+ *   - cold start (graph was empty before): full 80-iteration warm-up.
+ *   - pure attribute update (same node set, no add/drop): skip FA2.
+ *   - additive (no drops, ≥1 add): light 5-iteration relax. New nodes
+ *     were already seeded near their neighbours' centroid (#466 D7);
+ *     5 iterations is enough to nudge them out of overlap without
+ *     yanking the surrounding layout.
+ *   - drops (vertex expired, soft-cap evict, etc.): 30-iteration mid
+ *     settle. Fewer than cold start because most positions are still
+ *     usable; more than additive because edge counts changed too.
+ */
+export const FA2_ITERATIONS_COLD = 80;
+export const FA2_ITERATIONS_ADDITIVE = 5;
+export const FA2_ITERATIONS_DROP = 30;
+
+export interface Fa2IterationsInput {
+  /** Number of nodes that survived from the previous reconcile to this one. */
+  previousNodeCount: number;
+  /** Number of nodes that appeared this reconcile (in next, not in prev). */
+  addedCount: number;
+  /** Number of nodes that disappeared this reconcile (in prev, not in next). */
+  droppedCount: number;
+  /** Number of nodes the graph holds AFTER reconcile. */
+  nextNodeCount: number;
+}
+
+export function decideFa2Iterations(input: Fa2IterationsInput): number {
+  // Nothing to lay out.
+  if (input.nextNodeCount === 0) return 0;
+  // Cold start: empty → populated (initial mount, or reseed after Clear).
+  if (input.previousNodeCount === 0) return FA2_ITERATIONS_COLD;
+  // Pure attribute refresh: same node set, no structural change.
+  if (input.addedCount === 0 && input.droppedCount === 0) return 0;
+  // Additive — keep surviving nodes within tolerance of their prior
+  // position; only relax new arrivals out of overlap.
+  if (input.droppedCount === 0) return FA2_ITERATIONS_ADDITIVE;
+  // Drops happened — partial settle.
+  return FA2_ITERATIONS_DROP;
+}

--- a/admin/tests/e2e/illuminate.spec.ts
+++ b/admin/tests/e2e/illuminate.spec.ts
@@ -272,4 +272,95 @@ test.describe("/illuminate", () => {
     expect(contrastReport.error).toBeUndefined();
     expect(contrastReport.ratio).toBeGreaterThanOrEqual(4.5);
   });
+
+  test("Additive expansion keeps surviving nodes within layout tolerance (#454)", async ({
+    page,
+  }) => {
+    const seed = encodeURIComponent("e2e:illum:hub");
+    await page.goto(`/illuminate?seed=${seed}`);
+    await expect(page.getByTestId("illuminate-toolbar")).toBeVisible();
+    await expect(page.getByTestId("illuminate-counter")).toContainText(
+      "5 vertices",
+    );
+
+    // Wait for the canvas test bridge to be installed (it is set in the
+    // Sigma mount effect, after the renderer is created).
+    await page.waitForFunction(() => {
+      const win = window as Window & {
+        __illuminateCanvas?: {
+          getNodePosition: (key: string) => { x: number; y: number } | null;
+        };
+      };
+      return !!win.__illuminateCanvas;
+    });
+
+    // Capture positions of two surviving nodes (a 1-hop neighbour of
+    // the seed, and a 2-hop "leaf" on the right branch) before the
+    // additive expansion fires. Both should hold steady — only the
+    // newly-added `leftleftleft` should land at fresh coordinates.
+    type Pos = { x: number; y: number };
+    const sampleKeys = ["e2e:illum:right", "e2e:illum:rightright"] as const;
+    const readPositions = (): Promise<(Pos | null)[]> =>
+      page.evaluate(
+        (keys) => {
+          const win = window as Window & {
+            __illuminateCanvas?: {
+              getNodePosition: (k: string) => Pos | null;
+            };
+          };
+          const bridge = win.__illuminateCanvas;
+          return keys.map((k) => (bridge ? bridge.getNodePosition(k) : null));
+        },
+        sampleKeys as unknown as string[],
+      );
+
+    const before = await readPositions();
+    expect(before.every((p) => p !== null)).toBe(true);
+
+    // Trigger an additive expansion from `leftleft` (adds
+    // `leftleftleft` — one fresh node, no drops).
+    await page
+      .getByRole("group")
+      .getByText(/List view \(5 vertices/)
+      .click();
+    const table = page.getByTestId("illuminate-table");
+    await table
+      .getByRole("button", { name: "Expand from e2e:illum:leftleft" })
+      .click();
+    await expect(page.getByTestId("illuminate-counter")).toContainText(
+      "6 vertices",
+    );
+
+    const after = await readPositions();
+
+    // Tolerance: with the additive-relax path running only 5 FA2
+    // iterations from the prior equilibrium, surviving nodes must not
+    // drift by more than a couple of graphology units. The pre-#454
+    // behaviour (80 iterations) would routinely move them tens of
+    // units; this guard ensures we don't regress to that.
+    const TOLERANCE = 2.0;
+    for (let i = 0; i < sampleKeys.length; i++) {
+      const a = before[i];
+      const b = after[i];
+      expect(
+        a,
+        `expected position for ${sampleKeys[i]} before expansion`,
+      ).not.toBeNull();
+      expect(
+        b,
+        `expected position for ${sampleKeys[i]} after expansion`,
+      ).not.toBeNull();
+      if (!a || !b) continue;
+      const dx = Math.abs(b.x - a.x);
+      const dy = Math.abs(b.y - a.y);
+      expect(
+        dx,
+        `${sampleKeys[i]} drifted by Δx=${dx.toFixed(2)} (tolerance ${TOLERANCE})`,
+      ).toBeLessThanOrEqual(TOLERANCE);
+      expect(
+        dy,
+        `${sampleKeys[i]} drifted by Δy=${dy.toFixed(2)} (tolerance ${TOLERANCE})`,
+      ).toBeLessThanOrEqual(TOLERANCE);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Closes #454.

The Illuminate canvas previously called `forceAtlas2.assign(graph, { iterations: 80 })` on **every** reconcile, including after an additive click. Because FA2 is iterative, 80 iterations from a perturbed equilibrium (one new centre-of-mass node + a fresh edge) redistribute every surviving vertex by tens of graphology units. The result was visually jarring — the additive-expansion model shipped in #466 read like a layout reshuffle on each click.

This PR makes the FA2 iteration count a function of the reconcile diff:

| Diff shape | Iterations |
|---|---|
| graph empty after reconcile | 0 |
| cold mount / post-Clear reseed (`previousNodeCount === 0`) | 80 |
| pure attribute update (no add/drop) | 0 |
| additive (`droppedCount === 0`, `addedCount > 0`) | 5 |
| drops happened | 30 |

New nodes were already seeded near their neighbours' centroid (per #466 D7), so the 5-iter relax is enough to nudge them out of overlap without yanking the surrounding layout.

## Files

- `admin/app/components/illuminate/IlluminateCanvas/layout-iterations.ts` — pure helper `decideFa2Iterations(...)` with the truth table above.
- `admin/app/components/illuminate/IlluminateCanvas/layout-iterations.test.ts` — bun:test covering all five branches.
- `admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx` — diffs by `previousNodeIdsRef`, branches the FA2 call. Also installs a read-only `window.__illuminateCanvas` test bridge in the mount effect (deleted on unmount) so Playwright can assert positions without flaky pixel diffs.
- `admin/tests/e2e/illuminate.spec.ts` — adds *"Additive expansion keeps surviving nodes within layout tolerance (#454)"* which captures positions of `right` and `rightright`, fires an `Expand from leftleft` click, then re-captures and asserts `|Δx| ≤ 2 && |Δy| ≤ 2` (pre-fix the same nodes drift by tens of units).

## Local gates

```
bun run lint            # clean
bun run typecheck       # clean
bun run test            # 337 pass (+6 from layout-iterations.test.ts)
bun run build           # clean
bun run format:check    # clean
bunx playwright test tests/e2e/illuminate.spec.ts   # 7 pass
```
