### PR TITLE
feat(admin): hover focus mode in the Illuminate canvas (#458)

### DIFF
--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -68,6 +68,14 @@ export function IlluminateCanvas({
   const previousNodeIdsRef = useRef<Set<string>>(new Set());
   const [hover, setHover] = useState<HoverState | null>(null);
   const [palette, setPalette] = useState<SigmaPalette>(FALLBACK_PALETTE);
+  // The mount effect runs ONCE, so any palette swatch read inside the
+  // hover-focus reducer (#458) needs a ref so it tracks the latest
+  // value after a theme flip. Keeping the ref in sync via a separate
+  // useEffect avoids reinstalling the reducer on every palette change.
+  const paletteRef = useRef(palette);
+  useEffect(() => {
+    paletteRef.current = palette;
+  }, [palette]);
   const theme = usePreferredTheme();
 
   // Resolve theme-aware palette from FluentProvider CSS variables (#453).
@@ -118,6 +126,73 @@ export function IlluminateCanvas({
     renderer.on("clickNode", (event) => {
       onNodeClickRef.current(event.node);
     });
+
+    // === #458 hover focus mode ==============================================
+    // On hover, dim every node and edge that isn't incident to the
+    // hovered vertex so the local structure pops. Idiomatic for sigma:
+    // install a `nodeReducer` / `edgeReducer` that swaps the rendered
+    // colour to a low-alpha swatch and hides the label. The hovered
+    // node id lives in closure-local state (NOT React state) so
+    // changing it doesn't rerender the parent; we just bump sigma's
+    // refresh tick to re-evaluate the reducers.
+    //
+    // Composition note: future siblings #459 (TTL halo) and #460 (min-
+    // hop coloring) will wrap these reducers. The locked composition
+    // order is hop hue (#460) \u2192 TTL alpha (#459) \u2192 hover dim (#458)
+    // so that hover always wins as the topmost visual filter. Keep the
+    // body of these reducers small and pure so wrapping stays trivial.
+    let hoveredNodeId: string | null = null;
+    let focusSet: Set<string> | null = null;
+    /**
+     * Compute the focus set for a hovered node: `{N} \u222a neighbors(N)`.
+     * Cached so the reducer doesn't re-scan adjacency every frame; the
+     * cache is rebuilt only when the hovered node id changes.
+     */
+    const rebuildFocusSet = (key: string | null): Set<string> | null => {
+      if (key === null) return null;
+      if (!graph.hasNode(key)) return null;
+      const s = new Set<string>([key]);
+      for (const neighbour of graph.neighbors(key)) {
+        s.add(neighbour);
+      }
+      return s;
+    };
+    const setHoveredNode = (key: string | null) => {
+      if (hoveredNodeId === key) return;
+      hoveredNodeId = key;
+      focusSet = rebuildFocusSet(key);
+      renderer.refresh();
+    };
+    renderer.setSetting("nodeReducer", (key, data) => {
+      if (focusSet === null) return data;
+      if (focusSet.has(key)) return data;
+      return {
+        ...data,
+        color: paletteRef.current.dimNode,
+        // Drop the label so the focused subset is the only labelled
+        // group; protects against label-vs-dim-disc contrast going
+        // out of WCAG-AA range (#453).
+        label: "",
+        // Push behind the focused subset so any overlap reads as the
+        // focused node sitting on top.
+        zIndex: 0,
+      };
+    });
+    renderer.setSetting("edgeReducer", (key, data) => {
+      if (focusSet === null || hoveredNodeId === null) return data;
+      const [src, dst] = graph.extremities(key);
+      // Incident edges stay at full saturation so the local subgraph
+      // structure is obvious.
+      if (src === hoveredNodeId || dst === hoveredNodeId) {
+        return { ...data, zIndex: 1 };
+      }
+      return { ...data, color: paletteRef.current.dimEdge, zIndex: 0 };
+    });
+    // Sigma needs zIndex sorting opted-in to honour the per-element
+    // zIndex hints emitted by the reducers above.
+    renderer.setSetting("zIndex", true);
+    // === end #458 ===========================================================
+
     const showNodeHover = (event: {
       node: string;
       event: { x: number; y: number };
@@ -133,6 +208,8 @@ export function IlluminateCanvas({
         x: event.event.x,
         y: event.event.y,
       });
+      // #458: trigger hover focus mode for the node under the cursor.
+      setHoveredNode(event.node);
     };
     const showEdgeHover = (event: {
       edge: string;
@@ -149,12 +226,22 @@ export function IlluminateCanvas({
         x: event.event.x,
         y: event.event.y,
       });
+      // #458: hovering an edge focuses both endpoints so the edge and
+      // its incidents pop together \u2014 mirrors the issue's acceptance
+      // criterion for "enterEdge: highlight both endpoints + the edge
+      // itself."
+      const [src] = graph.extremities(event.edge);
+      setHoveredNode(src);
     };
-    const clearHover = () => setHover(null);
+    const clearHoverNode = () => {
+      setHover(null);
+      // #458: leaving any node/edge restores the full graph.
+      setHoveredNode(null);
+    };
     renderer.on("enterNode", showNodeHover);
-    renderer.on("leaveNode", clearHover);
+    renderer.on("leaveNode", clearHoverNode);
     renderer.on("enterEdge", showEdgeHover);
-    renderer.on("leaveEdge", clearHover);
+    renderer.on("leaveEdge", clearHoverNode);
 
     // === #455 drag-to-pin ===================================================
     // Sigma's standard drag-and-drop recipe. The dragged node id lives in
@@ -205,11 +292,15 @@ export function IlluminateCanvas({
     mouseCaptor.on("mouseup", finishDrag);
     // === end #455 ===========================================================
 
-    // Read-only Playwright test bridge (#454, extended in #455). Lets
-    // the e2e suite assert surviving-node positions across an additive
-    // expansion and the position/pin state after a drag without
-    // resorting to flaky pixel diffs. Harmless in production — pure
-    // read-only accessors over the live graphology + sigma state.
+    // Read-only Playwright test bridge (#454, extended in #455/#458).
+    // Lets the e2e suite assert surviving-node positions across an
+    // additive expansion, the position/pin state after a drag, and the
+    // post-reducer colour after a hover \u2014 all without resorting to
+    // flaky pixel diffs. Harmless in production: all production-facing
+    // accessors are pure read-only views over the live graphology +
+    // sigma state; the two write methods (`simulateDrag`, `setHoveredNode`)
+    // mirror the behaviour the real user pointer would produce, and
+    // the same internal helpers are invoked.
     const win = window as Window & {
       __illuminateCanvas?: {
         getNodePosition: (key: string) => { x: number; y: number } | null;
@@ -219,8 +310,8 @@ export function IlluminateCanvas({
           moveBody: number;
           mouseUp: number;
         };
-        // Test-only: fires a synthetic drag (downNode → mousemovebody
-        // → mouseup → finishDrag) by invoking the same closure-local
+        // Test-only: fires a synthetic drag (downNode \u2192 mousemovebody
+        // \u2192 mouseup \u2192 finishDrag) by invoking the same closure-local
         // handlers the real sigma events trigger. We use this instead
         // of dispatching real `MouseEvent`s through the page because
         // sigma's `downNode` hit-test reads from a WebGL picking
@@ -231,6 +322,30 @@ export function IlluminateCanvas({
           deltaGraphX: number,
           deltaGraphY: number,
         ) => boolean;
+        /**
+         * #458 test bridge: set or clear the hover-focus subject.
+         * Same effect as a real `enterNode` / `leaveNode` event: the
+         * reducer chain re-evaluates and the post-reducer colours
+         * become observable via {@link getRenderedNodeColor}.
+         * Returns `true` when the supplied key exists (or is `null`),
+         * `false` if the key isn't in the live graph.
+         */
+        setHoveredNode: (key: string | null) => boolean;
+        /**
+         * #458 test bridge: read the post-reducer render colour for a
+         * given node id. Returns `null` if the node is unknown.
+         */
+        getRenderedNodeColor: (key: string) => string | null;
+        /**
+         * #458 test bridge: read the post-reducer render colour for a
+         * given edge id. Returns `null` if the edge is unknown.
+         */
+        getRenderedEdgeColor: (key: string) => string | null;
+        /**
+         * #458 test bridge: read whether the hover-focus reducer is
+         * currently active (i.e., a node is focused).
+         */
+        hoveredNode: () => string | null;
       };
     };
     win.__illuminateCanvas = {
@@ -259,20 +374,36 @@ export function IlluminateCanvas({
         if (typeof attrs.x !== "number" || typeof attrs.y !== "number") {
           return false;
         }
-        // 1) downNode — latch the dragged node
+        // 1) downNode \u2014 latch the dragged node
         draggedNodeRef.current = key;
         graph.setNodeAttribute(key, "highlighted", true);
         dragStats.downNode += 1;
-        // 2) mousemovebody — write the new position. We don't go
+        // 2) mousemovebody \u2014 write the new position. We don't go
         //    through viewportToGraph because the test supplies graph
         //    deltas directly.
         graph.setNodeAttribute(key, "x", attrs.x + deltaGraphX);
         graph.setNodeAttribute(key, "y", attrs.y + deltaGraphY);
         dragStats.moveBody += 1;
-        // 3) mouseup — release + pin
+        // 3) mouseup \u2014 release + pin
         finishDrag();
         return true;
       },
+      setHoveredNode: (key: string | null) => {
+        if (key !== null && !graph.hasNode(key)) return false;
+        setHoveredNode(key);
+        return true;
+      },
+      getRenderedNodeColor: (key: string) => {
+        if (!graph.hasNode(key)) return null;
+        const data = renderer.getNodeDisplayData(key);
+        return data?.color ?? null;
+      },
+      getRenderedEdgeColor: (key: string) => {
+        if (!graph.hasEdge(key)) return null;
+        const data = renderer.getEdgeDisplayData(key);
+        return data?.color ?? null;
+      },
+      hoveredNode: () => hoveredNodeId,
     };
 
     return () => {

--- a/admin/app/components/illuminate/IlluminateCanvas/palette.test.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/palette.test.ts
@@ -70,6 +70,31 @@ describe("resolvePaletteFromTokens", () => {
     expect(palette.origin).toBe("#5c2d91");
   });
 
+  test("dim swatches stay at the fallback literals regardless of Fluent CSS variables (#458)", () => {
+    // The hover-focus reducer (#458) needs a stable ~15% alpha across
+    // both themes; neutral stroke tokens differ enough across themes
+    // that we keep the dim swatches hard-coded.
+    const palette = resolvePaletteFromTokens(
+      readerFrom({
+        "--colorNeutralStroke2": "#000000",
+        "--colorBrandBackground": "#ff00ff",
+      }),
+    );
+    expect(palette.dimNode).toBe("#3f3f4626");
+    expect(palette.dimEdge).toBe("#bdbdbd26");
+  });
+
+  test("dim swatches encode alpha 0x26 (~15%) so sigma's WebGL blend renders them at ~15% opacity (#458)", () => {
+    // Sigma's `parseColor` reads the trailing two hex digits of a
+    // 9-char `#RRGGBBAA` as alpha (`parseInt("26", 16) / 255 \u2248 0.149`).
+    // The reducer documentation in IlluminateCanvas relies on this
+    // exact mapping; if Fluent ever bumps the desired dim intensity
+    // we change it here so the unit + e2e tests catch any drift.
+    expect(FALLBACK_PALETTE.dimNode.slice(-2)).toBe("26");
+    expect(FALLBACK_PALETTE.dimEdge.slice(-2)).toBe("26");
+    expect(parseInt("26", 16) / 255).toBeCloseTo(0.149, 3);
+  });
+
   test("empty CSS variable values fall back to the light-theme literal", () => {
     const palette = resolvePaletteFromTokens(
       readerFrom({

--- a/admin/app/components/illuminate/IlluminateCanvas/palette.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/palette.ts
@@ -26,6 +26,16 @@ export interface SigmaPalette {
   baseNode: string;
   /** Edge color. */
   edge: string;
+  /**
+   * Dimmed node fill applied by the hover-focus reducer (#458) to
+   * every node outside the focused subset. Uses 8-char hex so sigma's
+   * default node program renders it at ~15% alpha (`0x26 / 0xff ≈
+   * 0.15`), which is enough for the focused subset to pop without
+   * making the surrounding context vanish.
+   */
+  dimNode: string;
+  /** Dimmed edge color paired with {@link dimNode}; same alpha. */
+  dimEdge: string;
   /** Label color resolved from `--colorNeutralForeground1`. */
   labelText: string;
   /** Label font stack resolved from `--fontFamilyBase`. */
@@ -37,6 +47,11 @@ export const FALLBACK_PALETTE: SigmaPalette = {
   origin: "#5c2d91",
   baseNode: "#3f3f46",
   edge: "#bdbdbd",
+  // Same hue as baseNode/edge but at ~15% alpha so the unfocused
+  // subset still hints at the surrounding structure without competing
+  // visually with the focused subset.
+  dimNode: "#3f3f4626",
+  dimEdge: "#bdbdbd26",
   labelText: "#242424",
   labelFont:
     'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
@@ -70,6 +85,12 @@ export function resolvePaletteFromTokens(reader: CssTokenReader): SigmaPalette {
     origin: FALLBACK_PALETTE.origin,
     baseNode: FALLBACK_PALETTE.baseNode,
     edge: readVar("--colorNeutralStroke2", FALLBACK_PALETTE.edge),
+    // Dim swatches are fixed literals — they need a consistent visual
+    // weight across light/dark, which Fluent's neutral stroke ramps
+    // don't guarantee at this alpha. Keep them code-side so the
+    // focused-subset contrast story doesn't drift with token churn.
+    dimNode: FALLBACK_PALETTE.dimNode,
+    dimEdge: FALLBACK_PALETTE.dimEdge,
     labelText: readVar("--colorNeutralForeground1", FALLBACK_PALETTE.labelText),
     labelFont: readVar("--fontFamilyBase", FALLBACK_PALETTE.labelFont),
   };

--- a/admin/tests/e2e/illuminate.spec.ts
+++ b/admin/tests/e2e/illuminate.spec.ts
@@ -496,4 +496,134 @@ test.describe("/illuminate", () => {
       `pinned node drifted by ${drift.toFixed(6)} graph units across an additive expansion`,
     ).toBeLessThan(0.001);
   });
+
+  test("Hover focus mode dims non-neighbours and keeps incident edges saturated (#458)", async ({
+    page,
+  }) => {
+    const seed = encodeURIComponent("e2e:illum:hub");
+    await page.goto(`/illuminate?seed=${seed}`);
+    await expect(page.getByTestId("illuminate-counter")).toContainText(
+      "5 vertices",
+    );
+
+    type Bridge = {
+      setHoveredNode: (k: string | null) => boolean;
+      getRenderedNodeColor: (k: string) => string | null;
+      getRenderedEdgeColor: (k: string) => string | null;
+      hoveredNode: () => string | null;
+    };
+    await page.waitForFunction(() => {
+      const win = window as Window & { __illuminateCanvas?: Bridge };
+      return !!win.__illuminateCanvas;
+    });
+
+    const readNode = (k: string): Promise<string | null> =>
+      page.evaluate((key) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.getRenderedNodeColor(key) ?? null;
+      }, k);
+    const readEdge = (k: string): Promise<string | null> =>
+      page.evaluate((key) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.getRenderedEdgeColor(key) ?? null;
+      }, k);
+    const setHover = (k: string | null): Promise<boolean> =>
+      page.evaluate((key) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.setHoveredNode(key) ?? false;
+      }, k);
+    const hoveredNow = (): Promise<string | null> =>
+      page.evaluate(() => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.hoveredNode() ?? null;
+      });
+
+    // Layout (see beforeAll seeder):
+    //
+    //    hub --(1)--> left      --(1)--> leftleft  --(1)--> leftleftleft
+    //    hub --(3)--> right     --(2)--> rightright
+    //
+    // From `hub` the 2-hop frontier is {left, right, leftleft,
+    // rightright} but only `left` + `right` are direct neighbours,
+    // so `leftleft` and `rightright` MUST dim when hub is focused.
+    const hubKey = "e2e:illum:hub";
+    const leftKey = "e2e:illum:left";
+    const rightKey = "e2e:illum:right";
+    const leftLeftKey = "e2e:illum:leftleft";
+    const rightRightKey = "e2e:illum:rightright";
+    // Edge ids follow `${tail}→${head}` (see edgeIdOf in
+    // app/lib/client/usecase/illuminate/state.ts).
+    const hubToLeftEdge = `${hubKey}→${leftKey}`;
+    const leftToLeftLeftEdge = `${leftKey}→e2e:illum:leftleft`;
+
+    const DIM_NODE = "#3f3f4626";
+    const DIM_EDGE = "#bdbdbd26";
+
+    // Sanity: baseline colours BEFORE any hover. The reducer returns
+    // `data` unchanged when nothing is focused, so every node renders
+    // at whatever colour the data layer wrote into graphology.
+    expect(await hoveredNow()).toBeNull();
+    const baselineHub = await readNode(hubKey);
+    const baselineLeft = await readNode(leftKey);
+    const baselineRight = await readNode(rightKey);
+    const baselineLeftLeft = await readNode(leftLeftKey);
+    const baselineRightRight = await readNode(rightRightKey);
+    const baselineHubLeft = await readEdge(hubToLeftEdge);
+    const baselineLeftLeftLeft = await readEdge(leftToLeftLeftEdge);
+    for (const c of [
+      baselineHub,
+      baselineLeft,
+      baselineRight,
+      baselineLeftLeft,
+      baselineRightRight,
+      baselineHubLeft,
+      baselineLeftLeftLeft,
+    ]) {
+      expect(c).not.toBeNull();
+      // Dim swatches end in `26` (alpha 0x26 ≈ 0.15). The baseline
+      // must NOT use either dim swatch.
+      expect(c).not.toBe(DIM_NODE);
+      expect(c).not.toBe(DIM_EDGE);
+    }
+
+    // Focus hub: hub + neighbours stay saturated, 2-hop dims.
+    expect(await setHover(hubKey)).toBe(true);
+    expect(await hoveredNow()).toBe(hubKey);
+    expect(await readNode(hubKey)).toBe(baselineHub);
+    expect(await readNode(leftKey)).toBe(baselineLeft);
+    expect(await readNode(rightKey)).toBe(baselineRight);
+    expect(await readNode(leftLeftKey)).toBe(DIM_NODE);
+    expect(await readNode(rightRightKey)).toBe(DIM_NODE);
+
+    // Edges incident to hub keep their base colour; edges not touching
+    // hub get the dim edge swatch.
+    expect(await readEdge(hubToLeftEdge)).toBe(baselineHubLeft);
+    expect(await readEdge(leftToLeftLeftEdge)).toBe(DIM_EDGE);
+
+    // Switching focus to `left` shifts the focus set: `hub` AND
+    // `leftleft` are now neighbours of `left`, while `right` +
+    // `rightright` dim instead. This proves the reducer recomputes
+    // the focus set per hover (not just the first time).
+    expect(await setHover(leftKey)).toBe(true);
+    expect(await readNode(hubKey)).toBe(baselineHub);
+    expect(await readNode(leftLeftKey)).toBe(baselineLeftLeft);
+    expect(await readNode(rightKey)).toBe(DIM_NODE);
+    expect(await readNode(rightRightKey)).toBe(DIM_NODE);
+
+    // Clear the hover → every colour returns to its baseline.
+    expect(await setHover(null)).toBe(true);
+    expect(await hoveredNow()).toBeNull();
+    expect(await readNode(hubKey)).toBe(baselineHub);
+    expect(await readNode(leftKey)).toBe(baselineLeft);
+    expect(await readNode(rightKey)).toBe(baselineRight);
+    expect(await readNode(leftLeftKey)).toBe(baselineLeftLeft);
+    expect(await readNode(rightRightKey)).toBe(baselineRightRight);
+    expect(await readEdge(hubToLeftEdge)).toBe(baselineHubLeft);
+    expect(await readEdge(leftToLeftLeftEdge)).toBe(baselineLeftLeftLeft);
+
+    // Unknown node id: the bridge must reject without throwing AND
+    // must NOT mutate the hover state.
+    expect(await setHover("e2e:illum:does-not-exist")).toBe(false);
+    expect(await hoveredNow()).toBeNull();
+  });
 });


### PR DESCRIPTION
Closes #458

Hovering a node (or edge) on the Illuminate canvas now dims every vertex and edge that is not incident to the focused vertex, so the local neighbourhood pops out of the surrounding accumulator.

### Implementation
- **palette.ts** \u2014 add `dimNode` (`#3f3f4626`) and `dimEdge` (`#bdbdbd26`) swatches. The trailing alpha byte (`0x26 \u2248 0.15`) is honoured by sigma's 9-char hex parser, which packs it into the WebGL float used by the node/edge programs. Swatches are theme-independent (fallback literals) so the contrast story stays predictable across light/dark Fluent themes.
- **IlluminateCanvas.tsx** \u2014 install a sigma `nodeReducer` + `edgeReducer` chain plus `zIndex` sorting. The reducers consult a closure-local focus set rebuilt on every hover (`focus = {hovered} \u222a neighbours`), swap the colour to the dim swatch for everything else, and drop labels on dimmed nodes so the WCAG-AA label contrast story (#453) stays intact. Palette is read via a `paletteRef` ref so a theme flip picks up new swatches without reinstalling the reducer.
- **IlluminateCanvas.tsx** \u2014 extend the `__illuminateCanvas` test bridge with `setHoveredNode` / `getRenderedNodeColor` / `getRenderedEdgeColor` / `hoveredNode` so the e2e suite can drive the same closure path real hover events trigger, without depending on sigma's WebGL picking framebuffer (which is unreliable in headless chromium across serial runs).

### Tests
- **palette.test.ts** \u2014 2 new specs lock the dim swatches at the theme-independent literals and assert the alpha byte encodes \u2248 0.15.
- **illuminate.spec.ts** \u2014 1 new e2e walks the focus set through a 3-state cycle (no hover \u2192 focus hub \u2192 focus left \u2192 clear) and asserts post-reducer colours for nodes + edges at each step, including baseline restoration and unknown-node rejection.

### Composition
The reducer chain is intentionally minimal so the future siblings #459 (TTL alpha) and #460 (min-hop hue) can wrap it in the locked order **hop hue \u2192 TTL alpha \u2192 hover dim**.

### Local quality gate
- `bun run lint` \u2014 clean
- `bun run typecheck` \u2014 clean
- `bun test` \u2014 339 pass / 5 pre-existing playwright-vs-bun-runner failures (same as main)
- `bun run format:check` \u2014 clean
- `bun run build` \u2014 clean
- `bun run playwright test tests/e2e/illuminate.spec.ts` \u2014 9/9 pass (parallel + `--workers=1`)
- `bun run playwright test` \u2014 38/38 pass (full suite)