### PR TITLE
feat(admin): hop-distance vertex coloring in the Illuminate canvas (#460)

### DIFF
--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.module.css
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.module.css
@@ -70,3 +70,76 @@
   margin-top: 2px;
   word-break: break-all;
 }
+
+/* #460: hop-distance legend in the canvas wrapper. Floats over the
+   bottom-left corner so it doesn't collide with the empty-state
+   overlay (centred) or the tooltip (pointer-tracked, top-anchored). */
+.legend {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  z-index: 2;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px 10px;
+  background: var(--colorNeutralBackground1, #fff);
+  border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  border-radius: var(--borderRadiusMedium, 6px);
+  box-shadow: var(--shadow4, 0 1px 4px rgba(0, 0, 0, 0.08));
+  font-family: var(--fontFamilyBase, system-ui, sans-serif);
+  font-size: var(--fontSizeBase200, 12px);
+  color: var(--colorNeutralForeground2, #424242);
+  max-width: 220px;
+}
+
+.legendTitle {
+  color: var(--colorNeutralForeground3, #707070);
+  text-transform: uppercase;
+  font-size: var(--fontSizeBase100, 10px);
+  letter-spacing: 0.04em;
+  margin-bottom: 2px;
+}
+
+.legendRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.legendSwatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* Per-bucket swatch classes. Each reads the matching custom property
+   the legend wrapper writes via its ref callback (see
+   IlluminateCanvas.tsx). Keeping the fallback as transparent makes a
+   theme-init race visible rather than silently rendering a misleading
+   colour. */
+.swatch_origin {
+  background: var(--hop-swatch-origin, transparent);
+}
+.swatch_1hop {
+  background: var(--hop-swatch-1hop, transparent);
+}
+.swatch_2hop {
+  background: var(--hop-swatch-2hop, transparent);
+}
+.swatch_far {
+  background: var(--hop-swatch-far, transparent);
+}
+.swatch_unreachable {
+  background: var(--hop-swatch-unreachable, transparent);
+}
+
+.legendCount {
+  margin-left: auto;
+  color: var(--colorNeutralForeground3, #707070);
+  font-variant-numeric: tabular-nums;
+}

--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -7,6 +7,7 @@ import type {
   GraphNode,
 } from "~/lib/client/usecase/illuminate/selectors";
 import { usePreferredTheme } from "~/lib/client/usecase/theme/use-preferred-theme";
+import { HOP_FAR_THRESHOLD, colorForHop, describeHop } from "./hop-palette";
 import { decideFa2Iterations } from "./layout-iterations";
 import {
   FALLBACK_PALETTE,
@@ -120,12 +121,7 @@ export function IlluminateCanvas({
   }, [theme]);
 
   const pickFill = useCallback(
-    (node: { isInitialSeed: boolean; isExpansionOrigin: boolean }) =>
-      node.isInitialSeed
-        ? palette.seed
-        : node.isExpansionOrigin
-          ? palette.origin
-          : palette.baseNode,
+    (node: { hopDistance: number }) => colorForHop(node.hopDistance, palette),
     [palette],
   );
 
@@ -421,6 +417,14 @@ export function IlluminateCanvas({
          */
         getRenderedEdgeColor: (key: string) => string | null;
         /**
+         * #460 test bridge: read the hop distance stamped on a node
+         * by the selector. Returns `null` if the node is unknown,
+         * `Number.POSITIVE_INFINITY` for unreachable. The e2e suite
+         * uses this to assert the multi-source BFS result without
+         * having to reverse-engineer it from rendered colours.
+         */
+        getNodeHopDistance: (key: string) => number | null;
+        /**
          * #458 test bridge: read whether the hover-focus reducer is
          * currently active (i.e., a node is focused).
          */
@@ -505,6 +509,15 @@ export function IlluminateCanvas({
         const data = renderer.getEdgeDisplayData(key);
         return data?.color ?? null;
       },
+      getNodeHopDistance: (key: string) => {
+        if (!graph.hasNode(key)) return null;
+        const attrs = graph.getNodeAttributes(key) as {
+          hopDistance?: number;
+        };
+        return typeof attrs.hopDistance === "number"
+          ? attrs.hopDistance
+          : Number.POSITIVE_INFINITY;
+      },
       hoveredNode: () => hoveredNodeId,
       tickCount: () => tickCountRef.current,
       setNow: (ms: number | null) => {
@@ -546,15 +559,20 @@ export function IlluminateCanvas({
     sigma.setSetting("labelFont", palette.labelFont);
     for (const id of graph.nodes()) {
       const attrs = graph.getNodeAttributes(id) as {
-        isInitialSeed?: boolean;
-        isExpansionOrigin?: boolean;
+        hopDistance?: number;
       };
+      // #460: re-derive the hop hue against the new palette so a theme
+      // flip recolours every node without re-running the reconcile
+      // effect. Missing/invalid `hopDistance` falls through to the
+      // unreachable tone via `colorForHop`'s defensive branch.
       graph.setNodeAttribute(
         id,
         "color",
         pickFill({
-          isInitialSeed: !!attrs.isInitialSeed,
-          isExpansionOrigin: !!attrs.isExpansionOrigin,
+          hopDistance:
+            typeof attrs.hopDistance === "number"
+              ? attrs.hopDistance
+              : Number.POSITIVE_INFINITY,
         }),
       );
     }
@@ -681,6 +699,11 @@ export function IlluminateCanvas({
           isInitialSeed: node.isInitialSeed,
           isExpansionOrigin: node.isExpansionOrigin,
           expiration,
+          // #460: stamp hop distance for the legend computation and
+          // (post-theme-flip) for the palette repaint effect to look
+          // up against the new palette.
+          hopDistance: node.hopDistance,
+          firstSeenExpansion: node.firstSeenExpansion,
         });
       } else {
         const { x, y } = pickInitialPosition({
@@ -699,6 +722,8 @@ export function IlluminateCanvas({
           isInitialSeed: node.isInitialSeed,
           isExpansionOrigin: node.isExpansionOrigin,
           expiration,
+          hopDistance: node.hopDistance,
+          firstSeenExpansion: node.firstSeenExpansion,
         });
       }
     }
@@ -756,12 +781,107 @@ export function IlluminateCanvas({
     [isBusy],
   );
 
+  // #460: hop-distance legend buckets. Recomputed whenever the
+  // accumulator changes (i.e. on the same trigger as the reconcile
+  // effect), so the counts stay in lockstep with what's rendered.
+  // Bucket order matches the palette ramp: origin (0) → 1 → 2 → far
+  // (≥3) → unreachable (∞). Buckets with zero count are hidden so the
+  // legend stays compact in the common case (most graphs have no
+  // unreachables, and many won't have anything past 2 hops).
+  const legendBuckets = useMemo(() => {
+    let origin = 0;
+    let oneHop = 0;
+    let twoHop = 0;
+    let far = 0;
+    let unreachable = 0;
+    for (const node of nodes) {
+      const h = node.hopDistance;
+      if (!Number.isFinite(h) || h < 0) {
+        unreachable += 1;
+      } else if (h === 0) {
+        origin += 1;
+      } else if (h === 1) {
+        oneHop += 1;
+      } else if (h === 2) {
+        twoHop += 1;
+      } else if (h >= HOP_FAR_THRESHOLD) {
+        far += 1;
+      }
+    }
+    return [
+      {
+        key: "origin" as const,
+        label: describeHop(0),
+        count: origin,
+        color: palette.hop0,
+      },
+      {
+        key: "1hop" as const,
+        label: describeHop(1),
+        count: oneHop,
+        color: palette.hop1,
+      },
+      {
+        key: "2hop" as const,
+        label: describeHop(2),
+        count: twoHop,
+        color: palette.hop2,
+      },
+      {
+        key: "far" as const,
+        label: describeHop(HOP_FAR_THRESHOLD),
+        count: far,
+        color: palette.hopFar,
+      },
+      {
+        key: "unreachable" as const,
+        label: describeHop(Number.POSITIVE_INFINITY),
+        count: unreachable,
+        color: palette.hopUnreachable,
+      },
+    ].filter((b) => b.count > 0);
+  }, [nodes, palette]);
+
   return (
     <div className={wrapperClass} data-testid="illuminate-canvas">
       <div ref={containerRef} className={styles.canvas} aria-hidden="true" />
       {empty ? (
         <div className={styles.emptyOverlay}>
           <span>No vertices to display.</span>
+        </div>
+      ) : null}
+      {!empty && legendBuckets.length > 0 ? (
+        <div
+          className={styles.legend}
+          role="img"
+          aria-label="Hop distance legend"
+          data-testid="illuminate-legend"
+          ref={(el) => {
+            if (!el) return;
+            // Pipe each bucket's resolved colour to the swatch via a
+            // CSS custom property. Avoids per-element inline styles
+            // (lint forbids them) while keeping the colours fully
+            // theme-derived.
+            for (const b of legendBuckets) {
+              el.style.setProperty(`--hop-swatch-${b.key}`, b.color);
+            }
+          }}
+        >
+          <div className={styles.legendTitle}>hop distance</div>
+          {legendBuckets.map((b) => (
+            <div
+              key={b.key}
+              className={styles.legendRow}
+              data-testid={`illuminate-legend-${b.key}`}
+            >
+              <span
+                className={`${styles.legendSwatch} ${styles[`swatch_${b.key}`]}`}
+                aria-hidden="true"
+              />
+              <span>{b.label}</span>
+              <span className={styles.legendCount}>{b.count}</span>
+            </div>
+          ))}
         </div>
       ) : null}
       {hover ? (
@@ -892,7 +1012,16 @@ function pickInitialPosition({
 }
 
 function describeVertex(node: GraphNode): string {
-  const v = node.vertex;
+  const valueText = formatVertexValue(node.vertex);
+  // #460: append the per-vertex audit trail the hop-distance encoding
+  // implies — "hop = N · first seen in expansion #M" — so the user can
+  // disambiguate "1 hop from origin A" vs "1 hop from origin B" via
+  // the same tooltip the hover focus reducer (#458) surfaces.
+  const auditText = `hop = ${describeHop(node.hopDistance)} · first seen in expansion #${node.firstSeenExpansion + 1}`;
+  return valueText ? `${valueText}\n${auditText}` : auditText;
+}
+
+function formatVertexValue(v: GraphNode["vertex"]): string {
   if (v.bool !== undefined) return `bool = ${v.bool}`;
   if (v.int32 !== undefined) return `int32 = ${v.int32}`;
   if (v.int64 !== undefined) return `int64 = ${v.int64}`;

--- a/admin/app/components/illuminate/IlluminateCanvas/hop-palette.test.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/hop-palette.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+
+import { HOP_FAR_THRESHOLD, colorForHop, describeHop } from "./hop-palette";
+import { FALLBACK_PALETTE } from "./palette";
+
+describe("colorForHop", () => {
+  test("returns hop0 for the origin (distance 0)", () => {
+    expect(colorForHop(0, FALLBACK_PALETTE)).toBe(FALLBACK_PALETTE.hop0);
+  });
+
+  test("returns hop1 for the single-hop ring", () => {
+    expect(colorForHop(1, FALLBACK_PALETTE)).toBe(FALLBACK_PALETTE.hop1);
+  });
+
+  test("returns hop2 for the two-hop ring", () => {
+    expect(colorForHop(2, FALLBACK_PALETTE)).toBe(FALLBACK_PALETTE.hop2);
+  });
+
+  test("collapses every distance ≥ HOP_FAR_THRESHOLD to hopFar", () => {
+    expect(colorForHop(HOP_FAR_THRESHOLD, FALLBACK_PALETTE)).toBe(
+      FALLBACK_PALETTE.hopFar,
+    );
+    expect(colorForHop(4, FALLBACK_PALETTE)).toBe(FALLBACK_PALETTE.hopFar);
+    expect(colorForHop(42, FALLBACK_PALETTE)).toBe(FALLBACK_PALETTE.hopFar);
+  });
+
+  test("returns hopUnreachable for +Infinity", () => {
+    expect(colorForHop(Number.POSITIVE_INFINITY, FALLBACK_PALETTE)).toBe(
+      FALLBACK_PALETTE.hopUnreachable,
+    );
+  });
+
+  test("defensively returns hopUnreachable for NaN and negative inputs", () => {
+    expect(colorForHop(Number.NaN, FALLBACK_PALETTE)).toBe(
+      FALLBACK_PALETTE.hopUnreachable,
+    );
+    expect(colorForHop(-1, FALLBACK_PALETTE)).toBe(
+      FALLBACK_PALETTE.hopUnreachable,
+    );
+  });
+
+  test("HOP_FAR_THRESHOLD pins the spec boundary at 3", () => {
+    // The spec calls for hop 0/1/2 to be distinct and everything from
+    // 3 onward to collapse. Pin the constant so changing it requires
+    // touching this test.
+    expect(HOP_FAR_THRESHOLD).toBe(3);
+  });
+});
+
+describe("describeHop", () => {
+  test("renders 'origin' at distance 0", () => {
+    expect(describeHop(0)).toBe("origin");
+  });
+
+  test("renders the single/two-hop labels", () => {
+    expect(describeHop(1)).toBe("1 hop");
+    expect(describeHop(2)).toBe("2 hops");
+  });
+
+  test("collapses ≥3 to '3+ hops'", () => {
+    expect(describeHop(3)).toBe("3+ hops");
+    expect(describeHop(7)).toBe("3+ hops");
+  });
+
+  test("renders 'unreachable' for Infinity and bad inputs", () => {
+    expect(describeHop(Number.POSITIVE_INFINITY)).toBe("unreachable");
+    expect(describeHop(Number.NaN)).toBe("unreachable");
+    expect(describeHop(-1)).toBe("unreachable");
+  });
+});

--- a/admin/app/components/illuminate/IlluminateCanvas/hop-palette.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/hop-palette.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure mapping from a node's hop distance (#460) to its base canvas
+ * fill. Lives next to {@link SigmaPalette} so the swatch source of
+ * truth stays in one place; the canvas reducer composes the result of
+ * this function with the TTL fade (#459) and hover dim (#458) in the
+ * locked order `hop hue → TTL alpha → hover dim`.
+ *
+ * Kept pure (no React, no DOM, no sigma) so the unit suite can pin
+ * the boundary behaviour at every stop without booting a renderer,
+ * and so swapping the palette source (Fluent token resolution vs
+ * test-injected literal) doesn't change the colour decision.
+ *
+ * Boundary semantics:
+ *   hopDistance === 0       → `palette.hop0` (the expansion origin itself)
+ *   hopDistance === 1       → `palette.hop1`
+ *   hopDistance === 2       → `palette.hop2`
+ *   hopDistance >= 3        → `palette.hopFar`
+ *   hopDistance is +Infinity → `palette.hopUnreachable`
+ *   hopDistance is NaN/-1   → defensive: treated as unreachable
+ *
+ * The "≥3 collapses to `hopFar`" rule is deliberate: distinguishing
+ * 3-hop from 5-hop visually adds noise without informational value
+ * when the canvas is also encoding TTL alpha and hover focus on the
+ * same pixel. The unreachable swatch is reserved for vertices truly
+ * disconnected from every origin — the canvas never gets there via
+ * normal Illuminate calls, but the selector emits it defensively so
+ * the test bridge and a stale-accumulator scenario have a stable
+ * colour to render.
+ */
+import type { SigmaPalette } from "./palette";
+
+/**
+ * The hop distance at which the per-step ramp collapses to the
+ * desaturated `hopFar` swatch. Pinned here (not inlined into the
+ * `if/else` ladder) so the unit test can assert the boundary
+ * unambiguously.
+ */
+export const HOP_FAR_THRESHOLD = 3;
+
+export function colorForHop(
+  hopDistance: number,
+  palette: SigmaPalette,
+): string {
+  // `NaN` and negative-finite values are nonsense from the selector's
+  // point of view, but the runtime contract here is "always return a
+  // renderable colour" — fall through to the unreachable tone so the
+  // canvas paints something instead of an empty string.
+  if (!Number.isFinite(hopDistance) || hopDistance < 0) {
+    return palette.hopUnreachable;
+  }
+  if (hopDistance === 0) return palette.hop0;
+  if (hopDistance === 1) return palette.hop1;
+  if (hopDistance === 2) return palette.hop2;
+  // hopDistance >= HOP_FAR_THRESHOLD (3+)
+  return palette.hopFar;
+}
+
+/**
+ * Stable, human-readable label for a hop distance. Powers the canvas
+ * legend (#460) and the node tooltip's "hop = N" line. Kept pure so
+ * the legend doesn't need to duplicate the bucketing logic.
+ */
+export function describeHop(hopDistance: number): string {
+  if (!Number.isFinite(hopDistance) || hopDistance < 0) {
+    return "unreachable";
+  }
+  if (hopDistance === 0) return "origin";
+  if (hopDistance === 1) return "1 hop";
+  if (hopDistance === 2) return "2 hops";
+  return `${HOP_FAR_THRESHOLD}+ hops`;
+}

--- a/admin/app/components/illuminate/IlluminateCanvas/palette.test.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/palette.test.ts
@@ -105,6 +105,58 @@ describe("resolvePaletteFromTokens", () => {
     expect(palette.labelText).toBe(FALLBACK_PALETTE.labelText);
     expect(palette.seed).toBe(FALLBACK_PALETTE.seed);
   });
+
+  // ── #460 hop ramp ───────────────────────────────────────────────
+  // The hop-distance reducer reads `hop0/1/2/Far/Unreachable` off the
+  // palette and applies them BEFORE the TTL fade so a node's hue
+  // communicates structural distance and its alpha communicates
+  // remaining lifetime. The token mapping comes straight from the
+  // #460 spec; the test pins it so a Fluent token rename can't
+  // silently change the canvas reading.
+
+  test("reads --colorBrandForeground1 for hop 0 (origin)", () => {
+    const palette = resolvePaletteFromTokens(
+      readerFrom({ "--colorBrandForeground1": "#aabbcc" }),
+    );
+    expect(palette.hop0).toBe("#aabbcc");
+  });
+
+  test("reads --colorBrandForeground2 for hop 1", () => {
+    const palette = resolvePaletteFromTokens(
+      readerFrom({ "--colorBrandForeground2": "#112233" }),
+    );
+    expect(palette.hop1).toBe("#112233");
+  });
+
+  test("reads --colorBrandForeground2Hover for hop 2", () => {
+    const palette = resolvePaletteFromTokens(
+      readerFrom({ "--colorBrandForeground2Hover": "#445566" }),
+    );
+    expect(palette.hop2).toBe("#445566");
+  });
+
+  test("reads --colorNeutralForeground3 for hopFar (≥3 hops)", () => {
+    const palette = resolvePaletteFromTokens(
+      readerFrom({ "--colorNeutralForeground3": "#778899" }),
+    );
+    expect(palette.hopFar).toBe("#778899");
+  });
+
+  test("reads --colorPaletteRedForeground1 for unreachable", () => {
+    const palette = resolvePaletteFromTokens(
+      readerFrom({ "--colorPaletteRedForeground1": "#992222" }),
+    );
+    expect(palette.hopUnreachable).toBe("#992222");
+  });
+
+  test("hop ramp falls back to the light-theme literals when no tokens are set", () => {
+    const palette = resolvePaletteFromTokens(readerFrom({}));
+    expect(palette.hop0).toBe(FALLBACK_PALETTE.hop0);
+    expect(palette.hop1).toBe(FALLBACK_PALETTE.hop1);
+    expect(palette.hop2).toBe(FALLBACK_PALETTE.hop2);
+    expect(palette.hopFar).toBe(FALLBACK_PALETTE.hopFar);
+    expect(palette.hopUnreachable).toBe(FALLBACK_PALETTE.hopUnreachable);
+  });
 });
 
 describe("label constants", () => {

--- a/admin/app/components/illuminate/IlluminateCanvas/palette.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/palette.ts
@@ -40,6 +40,25 @@ export interface SigmaPalette {
   labelText: string;
   /** Label font stack resolved from `--fontFamilyBase`. */
   labelFont: string;
+  /**
+   * #460 hop-distance ramp. Each `hopN` is the canvas fill applied to
+   * a node whose minimum-hop distance from any expansion origin is
+   * exactly `N`; `hopFar` is everything ≥ `HOP_FAR_THRESHOLD` and
+   * `hopUnreachable` covers vertices with no path to any origin (the
+   * `Number.POSITIVE_INFINITY` case in `selectGraphView`).
+   *
+   * Fluent token mapping (per #460 spec):
+   *   hop0          → colorBrandForeground1 (origin highlight)
+   *   hop1          → colorBrandForeground2 (single-hop ring)
+   *   hop2          → colorBrandForeground2Hover (two-hop ring)
+   *   hopFar        → desaturated neutral   (everything ≥ 3 hops)
+   *   hopUnreachable → low-chroma red       (disconnected; visually distinct)
+   */
+  hop0: string;
+  hop1: string;
+  hop2: string;
+  hopFar: string;
+  hopUnreachable: string;
 }
 
 export const FALLBACK_PALETTE: SigmaPalette = {
@@ -55,6 +74,18 @@ export const FALLBACK_PALETTE: SigmaPalette = {
   labelText: "#242424",
   labelFont:
     'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+  // #460 hop ramp. Light-theme literals — these are the swatches the
+  // canvas falls back to before FluentProvider hydrates and the test
+  // suite asserts against. The ramp moves from the Fluent brand
+  // accent (hop 0, origin) outward through brand-foreground tints to
+  // a desaturated neutral for ≥3 hops, then to a low-chroma red for
+  // unreachable. Distinct enough to read at a glance, similar enough
+  // in luminance to avoid clobbering the hover dim's contrast story.
+  hop0: "#005a9e", // colorBrandForeground1 (light)
+  hop1: "#106ebe", // colorBrandForeground2 (light)
+  hop2: "#2b88d8", // colorBrandForeground2Hover (light)
+  hopFar: "#8a8886", // colorNeutralForeground3 (light, desaturated)
+  hopUnreachable: "#a4262c", // colorPaletteRedForeground1 (light, low chroma)
 };
 
 export const LABEL_SIZE = 13;
@@ -93,6 +124,27 @@ export function resolvePaletteFromTokens(reader: CssTokenReader): SigmaPalette {
     dimEdge: FALLBACK_PALETTE.dimEdge,
     labelText: readVar("--colorNeutralForeground1", FALLBACK_PALETTE.labelText),
     labelFont: readVar("--fontFamilyBase", FALLBACK_PALETTE.labelFont),
+    // #460 hop ramp. Token mapping per spec: hop 0/1/2 trace the
+    // Fluent brand foreground/stroke ladder so the warmest stop
+    // (origin) reads as "you are here" and the cooler stops indicate
+    // distance. `hopFar` flattens to a desaturated neutral so the
+    // canvas reads as "out of focus past 2 hops" without falling all
+    // the way to the unreachable red.
+    //
+    // Token rationale: the issue spec suggested `colorBrandStroke1`
+    // for hop 2, but in Fluent v9's default brand ramp `BrandStroke1`
+    // (Shade80) and `BrandForeground1` (Shade100) collide at the
+    // same hex value — hop 0 and hop 2 would render identically.
+    // `BrandForeground2Hover` (Shade120) gives us a properly
+    // separated third stop in the same brand family.
+    hop0: readVar("--colorBrandForeground1", FALLBACK_PALETTE.hop0),
+    hop1: readVar("--colorBrandForeground2", FALLBACK_PALETTE.hop1),
+    hop2: readVar("--colorBrandForeground2Hover", FALLBACK_PALETTE.hop2),
+    hopFar: readVar("--colorNeutralForeground3", FALLBACK_PALETTE.hopFar),
+    hopUnreachable: readVar(
+      "--colorPaletteRedForeground1",
+      FALLBACK_PALETTE.hopUnreachable,
+    ),
   };
 }
 

--- a/admin/app/lib/cli/graph-view.ts
+++ b/admin/app/lib/cli/graph-view.ts
@@ -24,6 +24,7 @@ import type {
   GraphNode,
   GraphView,
 } from "~/lib/client/usecase/illuminate/selectors";
+import { computeHopDistances } from "~/lib/client/usecase/illuminate/selectors";
 import type {
   Edge,
   IlluminateResponse,
@@ -124,6 +125,11 @@ function illuminateView(seed: string, response: IlluminateResponse): GraphView {
         isExpansionOrigin: isSeed,
         importance,
         firstSeenExpansion: 0,
+        // Placeholder; filled in by the BFS below now that we know the
+        // full node set + edge filter. The CLI uses single-source BFS
+        // from THE seed (#460 issue body explicitly carves out the CLI
+        // path as not affected by the multi-source semantics).
+        hopDistance: Number.POSITIVE_INFINITY,
       };
     });
 
@@ -139,6 +145,13 @@ function illuminateView(seed: string, response: IlluminateResponse): GraphView {
       weight: e.weight ?? 0,
       edge: e,
     });
+  }
+  // Single-source BFS from the seed so the cli's per-call frame
+  // gets the same hop encoding as the /illuminate route (just with
+  // one origin instead of N).
+  const hopByKey = computeHopDistances(knownKeys, edges, [seedKey]);
+  for (const node of nodes) {
+    node.hopDistance = hopByKey.get(node.id) ?? Number.POSITIVE_INFINITY;
   }
   return wrapView(nodes, edges, seedKey === "" ? null : seedKey);
 }
@@ -159,6 +172,8 @@ function getVertexView(key: string, vertex: Vertex | null): GraphView {
         isExpansionOrigin: true,
         importance: 1,
         firstSeenExpansion: 0,
+        // Sole node IS the seed/origin, so hop 0 by definition.
+        hopDistance: 0,
       },
     ],
     [],
@@ -183,6 +198,8 @@ function getEdgeView(tail: string, head: string, edge: Edge | null): GraphView {
       isExpansionOrigin: true,
       importance: 1,
       firstSeenExpansion: 0,
+      // `get edge` is rooted at the tail; head is exactly one hop away.
+      hopDistance: 0,
     },
     {
       id: head,
@@ -192,6 +209,7 @@ function getEdgeView(tail: string, head: string, edge: Edge | null): GraphView {
       isExpansionOrigin: false,
       importance: 0.5,
       firstSeenExpansion: 0,
+      hopDistance: 1,
     },
   ];
   const edges: GraphEdge[] = [
@@ -227,6 +245,11 @@ function scanVerticesView(
         isExpansionOrigin: isSeed,
         importance: 0.5,
         firstSeenExpansion: 0,
+        // Scan results have NO edges so BFS isn't meaningful. The
+        // matched seed gets hop 0 (origin); everyone else gets hop 1
+        // so the legend reads as "origin + 1 neighbour bucket"
+        // instead of degenerating into an unreachable-red sea.
+        hopDistance: isSeed ? 0 : 1,
       };
     });
   // For scan we treat the prefix as the latest origin only if a node
@@ -259,6 +282,11 @@ function scanEdgesView(
         isExpansionOrigin: isSeed,
         importance: 0.5,
         firstSeenExpansion: 0,
+        // The tail endpoint is the "starting" side of the edge from
+        // the prefix scan's perspective. Same 0/1 ramp as
+        // scanVerticesView: matched prefix → origin, else first
+        // neighbour ring.
+        hopDistance: isSeed ? 0 : 1,
       });
     }
     if (!nodeMap.has(e.head)) {
@@ -270,6 +298,9 @@ function scanEdgesView(
         isExpansionOrigin: false,
         importance: 0.5,
         firstSeenExpansion: 0,
+        // Heads are always one step beyond their tails. Keep them
+        // visually distinct from the matched-prefix origins.
+        hopDistance: 1,
       });
     }
     edges.push({

--- a/admin/app/lib/client/usecase/illuminate/selectors.test.ts
+++ b/admin/app/lib/client/usecase/illuminate/selectors.test.ts
@@ -313,6 +313,185 @@ describe("selectGraphView", () => {
     // falls to the default importance for non-seed/non-origin vertices.
     expect(b?.importance).toBeGreaterThan(c?.importance ?? Infinity);
   });
+
+  // ── #460 multi-source BFS hop distances ───────────────────────────
+  // The selector annotates each node with its shortest hop to ANY
+  // expansion origin, computed over the undirected projection of the
+  // live (post-TTL) edge set. The canvas uses this for hop-distance
+  // colouring (#460); the test bridge reads it through the rendered
+  // node colour in the e2e suite.
+
+  it("attaches hopDistance 0 to expansion origins and Infinity to an empty graph", () => {
+    const view = selectGraphView(INITIAL_ILLUMINATE_STATE);
+    expect(view.nodes).toEqual([]);
+    expect(view.expansionOrigins).toEqual([]);
+  });
+
+  it("assigns hopDistance 0 to the only origin and BFS hops to its reachable neighbours", () => {
+    let state = stateWithInitialSeed("a");
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "a",
+      vertices: [v("a"), v("b"), v("c"), v("d")],
+      edges: [e("a", "b"), e("b", "c"), e("c", "d")],
+    });
+    const view = selectGraphView(state);
+    const byId = new Map(view.nodes.map((n) => [n.id, n.hopDistance]));
+    expect(byId.get("a")).toBe(0);
+    expect(byId.get("b")).toBe(1);
+    expect(byId.get("c")).toBe(2);
+    expect(byId.get("d")).toBe(3);
+  });
+
+  it("treats edges as undirected for hop distance (matches Illuminate's symmetric step semantics)", () => {
+    let state = stateWithInitialSeed("a");
+    // All edges point AWAY from 'a' — a strictly directed BFS would
+    // never reach 'a' from 'c'. Hop distance must be 0 at 'a' and 1
+    // at 'b', 2 at 'c' under the undirected projection.
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "a",
+      vertices: [v("a"), v("b"), v("c")],
+      edges: [e("a", "b"), e("b", "c")],
+    });
+    // Now run a second expansion from 'c' so 'c' itself becomes hop 0,
+    // and assert the previously-1 vertex 'b' becomes hop 1 to whichever
+    // origin is closer (still 1: 'a' is hop 0 from 'a', 'b' is hop 1
+    // from BOTH origins; 'c' is hop 0 from 'c').
+    state = applyExpansion(state, {
+      expansionId: 2,
+      origin: "c",
+      vertices: [v("c")],
+      edges: [],
+    });
+    const view = selectGraphView(state);
+    const byId = new Map(view.nodes.map((n) => [n.id, n.hopDistance]));
+    expect(byId.get("a")).toBe(0);
+    expect(byId.get("b")).toBe(1);
+    expect(byId.get("c")).toBe(0);
+  });
+
+  it("picks the minimum hop across multiple origins (multi-source BFS)", () => {
+    let state = stateWithInitialSeed("a");
+    // Topology:  a — b — c — d — e — f
+    // Origins: 'a' and 'f'. Expected hops: a=0, b=1, c=2, d=2, e=1, f=0.
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "a",
+      vertices: [v("a"), v("b"), v("c"), v("d"), v("e"), v("f")],
+      edges: [e("a", "b"), e("b", "c"), e("c", "d"), e("d", "e"), e("e", "f")],
+    });
+    state = applyExpansion(state, {
+      expansionId: 2,
+      origin: "f",
+      vertices: [v("f")],
+      edges: [],
+    });
+    const view = selectGraphView(state);
+    const byId = new Map(view.nodes.map((n) => [n.id, n.hopDistance]));
+    expect(byId.get("a")).toBe(0);
+    expect(byId.get("b")).toBe(1);
+    expect(byId.get("c")).toBe(2);
+    expect(byId.get("d")).toBe(2);
+    expect(byId.get("e")).toBe(1);
+    expect(byId.get("f")).toBe(0);
+  });
+
+  it("assigns Infinity to vertices disconnected from every origin", () => {
+    // Two components: {a, b} reachable from 'a'; {x, y} an orphan
+    // subgraph that was somehow merged in (defensive — shouldn't
+    // happen with current server behaviour but the selector must not
+    // throw).
+    const state: IlluminateState = {
+      ...INITIAL_ILLUMINATE_STATE,
+      initialSeed: "a",
+      accumulator: {
+        vertices: new Map([
+          ["a", { vertex: v("a"), receivedAtMs: 1, expansionIndexes: [0] }],
+          ["b", { vertex: v("b"), receivedAtMs: 1, expansionIndexes: [0] }],
+          ["x", { vertex: v("x"), receivedAtMs: 1, expansionIndexes: [0] }],
+          ["y", { vertex: v("y"), receivedAtMs: 1, expansionIndexes: [0] }],
+        ]),
+        edges: new Map([
+          [
+            "a→b",
+            { edge: e("a", "b"), receivedAtMs: 1, expansionIndexes: [0] },
+          ],
+          [
+            "x→y",
+            { edge: e("x", "y"), receivedAtMs: 1, expansionIndexes: [0] },
+          ],
+        ]),
+      },
+      expansions: [
+        {
+          id: 1,
+          origin: "a",
+          controls: INITIAL_ILLUMINATE_STATE.controls,
+          startedAtMs: 0,
+          vertexKeys: ["a", "b", "x", "y"],
+          edgeIds: ["a→b", "x→y"],
+        },
+      ],
+    };
+    const view = selectGraphView(state);
+    const byId = new Map(view.nodes.map((n) => [n.id, n.hopDistance]));
+    expect(byId.get("a")).toBe(0);
+    expect(byId.get("b")).toBe(1);
+    expect(byId.get("x")).toBe(Number.POSITIVE_INFINITY);
+    expect(byId.get("y")).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("never grows an existing vertex's hopDistance after a new expansion (#460 monotonic shrink invariant)", () => {
+    let state = stateWithInitialSeed("a");
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "a",
+      vertices: [v("a"), v("b"), v("c"), v("d")],
+      edges: [e("a", "b"), e("b", "c"), e("c", "d")],
+    });
+    const firstByKey = new Map(
+      selectGraphView(state).nodes.map((n) => [n.id, n.hopDistance]),
+    );
+    // Pull in 'd' as an additional expansion origin — every other
+    // vertex's distance can only stay the same or shrink.
+    state = applyExpansion(state, {
+      expansionId: 2,
+      origin: "d",
+      vertices: [v("d")],
+      edges: [],
+    });
+    const secondByKey = new Map(
+      selectGraphView(state).nodes.map((n) => [n.id, n.hopDistance]),
+    );
+    for (const [key, before] of firstByKey) {
+      const after = secondByKey.get(key);
+      expect(after).toBeDefined();
+      expect(after!).toBeLessThanOrEqual(before);
+    }
+    // And the newly-promoted origin really did drop to 0.
+    expect(secondByKey.get("d")).toBe(0);
+  });
+
+  it("does not let an expired edge bridge a BFS gap (#459/#460 interaction)", () => {
+    let state = stateWithInitialSeed("a");
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "a",
+      vertices: [v("a"), v("b"), v("c")],
+      edges: [
+        // a→b is live; b→c is expired. Without filtering, 'c' would
+        // be hop 2; with filtering it must be Infinity.
+        e("a", "b", 1),
+        eWithExpiration("b", "c", isoAt(-1_000)),
+      ],
+    });
+    const view = selectGraphView(state, T_NOW);
+    const byId = new Map(view.nodes.map((n) => [n.id, n.hopDistance]));
+    expect(byId.get("a")).toBe(0);
+    expect(byId.get("b")).toBe(1);
+    expect(byId.get("c")).toBe(Number.POSITIVE_INFINITY);
+  });
 });
 
 describe("selectCanClear", () => {

--- a/admin/app/lib/client/usecase/illuminate/selectors.ts
+++ b/admin/app/lib/client/usecase/illuminate/selectors.ts
@@ -41,6 +41,27 @@ export interface GraphNode {
   importance: number;
   /** Index into `state.expansions[]` where this vertex first appeared. */
   firstSeenExpansion: number;
+  /**
+   * Minimum hop distance from this vertex to ANY expansion origin
+   * (#460). Computed via multi-source BFS over the undirected
+   * projection of the accumulator's edge set: every origin starts at 0
+   * and a single BFS relaxation gives every reachable vertex its
+   * shortest hop. Vertices that are disconnected from every origin
+   * receive `Number.POSITIVE_INFINITY` so the canvas reducer can pick
+   * the "unreachable" tone.
+   *
+   * The undirected projection is deliberate: from the user's point of
+   * view, an `Illuminate(origin=A, step=2)` call returns a 2-hop
+   * neighbourhood regardless of edge direction, so a hop-distance
+   * encoding that distinguished `A → B` from `B → A` would render
+   * visually inconsistent with how the data arrived.
+   *
+   * Invariant (#460 acceptance criterion 2): adding a new expansion
+   * can only ever shrink an existing vertex's hop distance, never
+   * grow it — the multi-source frontier strictly widens as origins
+   * are added.
+   */
+  hopDistance: number;
 }
 
 export interface GraphEdge {
@@ -64,6 +85,77 @@ export interface GraphView {
   expansionOrigins: string[];
   /** True when the accumulator is past the soft cap; UI surfaces a MessageBar. */
   overSoftCap: boolean;
+}
+
+/**
+ * Multi-source BFS over the undirected projection of `edges`, seeded
+ * by every key in `origins` that exists in `knownKeys`. Returns a map
+ * of vertex id → minimum hop distance to ANY origin (#460). Vertices
+ * unreachable from every origin are simply absent from the result —
+ * callers should treat absence as `Number.POSITIVE_INFINITY`.
+ *
+ * Complexity is O(V + E) over the post-filter accumulator. With the
+ * #466 D13 hard cap of 2000 vertices the BFS is comfortably under a
+ * millisecond, well within the per-selector budget.
+ *
+ * The undirected projection is the intentional choice: each
+ * `Illuminate(origin, step=2)` call returns a 2-hop neighbourhood
+ * regardless of edge direction, so a directional hop encoding would
+ * disagree with how the data arrived.
+ */
+export function computeHopDistances(
+  knownKeys: Set<string>,
+  edges: GraphEdge[],
+  origins: string[],
+): Map<string, number> {
+  // Adjacency list over the undirected projection. Only includes
+  // endpoints we actually have nodes for so the BFS can't dereference
+  // an unknown id.
+  const adjacency = new Map<string, string[]>();
+  for (const e of edges) {
+    if (!knownKeys.has(e.source) || !knownKeys.has(e.target)) continue;
+    appendAdjacency(adjacency, e.source, e.target);
+    appendAdjacency(adjacency, e.target, e.source);
+  }
+
+  const distance = new Map<string, number>();
+  const frontier: string[] = [];
+  for (const origin of origins) {
+    if (!knownKeys.has(origin)) continue;
+    if (distance.has(origin)) continue;
+    distance.set(origin, 0);
+    frontier.push(origin);
+  }
+  // Multi-source BFS: every origin starts at hop 0 in the same
+  // queue, so the first time we visit a vertex we have its global
+  // shortest hop. Using an index instead of `Array.shift()` keeps the
+  // walk O(V + E) — `shift` is O(n).
+  let head = 0;
+  while (head < frontier.length) {
+    const node = frontier[head++]!;
+    const nextHop = (distance.get(node) ?? 0) + 1;
+    const neighbours = adjacency.get(node);
+    if (!neighbours) continue;
+    for (const neighbour of neighbours) {
+      if (distance.has(neighbour)) continue;
+      distance.set(neighbour, nextHop);
+      frontier.push(neighbour);
+    }
+  }
+  return distance;
+}
+
+function appendAdjacency(
+  map: Map<string, string[]>,
+  key: string,
+  neighbour: string,
+) {
+  const list = map.get(key);
+  if (list) {
+    list.push(neighbour);
+  } else {
+    map.set(key, [neighbour]);
+  }
 }
 
 /**
@@ -148,6 +240,9 @@ export function selectGraphView(
       isExpansionOrigin,
       importance,
       firstSeenExpansion,
+      // Placeholder; filled in below after edges are filtered so the
+      // BFS adjacency mirrors the live (non-expired) graph.
+      hopDistance: Number.POSITIVE_INFINITY,
     });
   }
 
@@ -171,6 +266,16 @@ export function selectGraphView(
       weight: e.weight ?? 0,
       edge: e,
     });
+  }
+
+  // #460: multi-source BFS over the undirected projection of the live
+  // (post-filter) edge set, seeded by every expansion origin that is
+  // still in the accumulator. Vertices unreachable from every origin
+  // keep the `Number.POSITIVE_INFINITY` placeholder so the canvas
+  // reducer can render them with the "unreachable" tone.
+  const hopByKey = computeHopDistances(knownKeys, edges, expansionOrigins);
+  for (const node of nodes) {
+    node.hopDistance = hopByKey.get(node.id) ?? Number.POSITIVE_INFINITY;
   }
 
   return {

--- a/admin/tests/e2e/illuminate.spec.ts
+++ b/admin/tests/e2e/illuminate.spec.ts
@@ -808,4 +808,136 @@ test.describe("/illuminate", () => {
       "expected the immediate baseline tick on visibilitychange to advance the counter",
     ).toBeGreaterThan(tickAfterHidden);
   });
+
+  test("Hop-distance coloring separates each ring and never grows existing distances across an additive expansion (#460)", async ({
+    page,
+  }) => {
+    const seed = encodeURIComponent("e2e:illum:hub");
+    await page.goto(`/illuminate?seed=${seed}`);
+    await expect(page.getByTestId("illuminate-counter")).toContainText(
+      "5 vertices",
+    );
+
+    type Bridge = {
+      getRenderedNodeColor: (k: string) => string | null;
+      getNodeHopDistance: (k: string) => number | null;
+    };
+    await page.waitForFunction(() => {
+      const win = window as Window & { __illuminateCanvas?: Bridge };
+      return !!win.__illuminateCanvas;
+    });
+
+    const readNode = (k: string): Promise<string | null> =>
+      page.evaluate((key) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.getRenderedNodeColor(key) ?? null;
+      }, k);
+    const readHop = (k: string): Promise<number | null> =>
+      page.evaluate((key) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.getNodeHopDistance(key) ?? null;
+      }, k);
+
+    const hubKey = "e2e:illum:hub";
+    const leftKey = "e2e:illum:left";
+    const rightKey = "e2e:illum:right";
+    const leftLeftKey = "e2e:illum:leftleft";
+    const rightRightKey = "e2e:illum:rightright";
+    const leftLeftLeftKey = "e2e:illum:leftleftleft";
+
+    // === Phase 1: initial seed from hub ==================================
+    // The default step=2 brings the full 2-hop frontier in one shot, so
+    // the selector sees one expansion with origin=hub. Hop distances:
+    //   hub=0, left=1, right=1, leftleft=2, rightright=2.
+    expect(await readHop(hubKey)).toBe(0);
+    expect(await readHop(leftKey)).toBe(1);
+    expect(await readHop(rightKey)).toBe(1);
+    expect(await readHop(leftLeftKey)).toBe(2);
+    expect(await readHop(rightRightKey)).toBe(2);
+
+    // Rendered colours must be distinct across hop buckets: that's the
+    // whole point of the encoding. Nodes WITHIN a bucket share the
+    // same colour (left vs right, leftleft vs rightright).
+    const hubColor = await readNode(hubKey);
+    const leftColor = await readNode(leftKey);
+    const leftLeftColor = await readNode(leftLeftKey);
+    expect(hubColor).not.toBeNull();
+    expect(leftColor).not.toBeNull();
+    expect(leftLeftColor).not.toBeNull();
+    expect(hubColor).not.toBe(leftColor);
+    expect(leftColor).not.toBe(leftLeftColor);
+    expect(hubColor).not.toBe(leftLeftColor);
+    // Same-bucket nodes match.
+    expect(await readNode(rightKey)).toBe(leftColor);
+    expect(await readNode(rightRightKey)).toBe(leftLeftColor);
+
+    // Legend is visible and surfaces the three populated buckets.
+    const legend = page.getByTestId("illuminate-legend");
+    await expect(legend).toBeVisible();
+    await expect(page.getByTestId("illuminate-legend-origin")).toBeVisible();
+    await expect(page.getByTestId("illuminate-legend-1hop")).toBeVisible();
+    await expect(page.getByTestId("illuminate-legend-2hop")).toBeVisible();
+    // No 3+ or unreachable bucket yet — those rows are hidden when
+    // empty so the legend stays compact.
+    await expect(page.getByTestId("illuminate-legend-far")).toHaveCount(0);
+    await expect(page.getByTestId("illuminate-legend-unreachable")).toHaveCount(
+      0,
+    );
+
+    // === Phase 2: additive expansion from leftleft =======================
+    // Adds leftleftleft (a fresh vertex) AND a second expansion origin
+    // (leftleft). After this:
+    //   - hub stays at hop 0 (still the original seed AND still an
+    //     expansion origin via the URL anchor; multi-source BFS keeps
+    //     it at 0).
+    //   - leftleft drops from hop 2 → hop 0 (it's now an expansion
+    //     origin itself).
+    //   - left drops from hop 1 → hop 1 (already at 1 from hub; can't
+    //     get lower since the chain hub→left→leftleft is 1 hop apart).
+    //   - leftleftleft enters at hop 1 (one edge from the new origin).
+    //
+    // The monotonic-shrink invariant is the key thing this test
+    // protects: every existing vertex's hop distance must stay the
+    // same or shrink, NEVER grow.
+    await page
+      .getByRole("group")
+      .getByText(/List view \(5 vertices/)
+      .click();
+    const table = page.getByTestId("illuminate-table");
+    await table
+      .getByRole("button", { name: "Expand from e2e:illum:leftleft" })
+      .click();
+    await expect(page.getByTestId("illuminate-counter")).toContainText(
+      "6 vertices",
+    );
+
+    const newHubHop = await readHop(hubKey);
+    const newLeftHop = await readHop(leftKey);
+    const newRightHop = await readHop(rightKey);
+    const newLeftLeftHop = await readHop(leftLeftKey);
+    const newRightRightHop = await readHop(rightRightKey);
+    const newLeftLeftLeftHop = await readHop(leftLeftLeftKey);
+
+    // The new origin and the vertex one edge from it.
+    expect(newLeftLeftHop).toBe(0);
+    expect(newLeftLeftLeftHop).toBe(1);
+
+    // Monotonic shrink: every previous distance MUST be ≤ what it was
+    // in phase 1.
+    expect(newHubHop).not.toBeNull();
+    expect(newLeftHop).not.toBeNull();
+    expect(newRightHop).not.toBeNull();
+    expect(newRightRightHop).not.toBeNull();
+    expect(newHubHop).toBeLessThanOrEqual(0);
+    expect(newLeftHop).toBeLessThanOrEqual(1);
+    expect(newRightHop).toBeLessThanOrEqual(1);
+    expect(newLeftLeftHop).toBeLessThanOrEqual(2);
+    expect(newRightRightHop).toBeLessThanOrEqual(2);
+
+    // Concretely: hub stays at 0 (still an origin), leftleft is now
+    // also at 0 (new origin), and the previously-2-hop leftleft is
+    // now a brand colour, not a far colour.
+    expect(newHubHop).toBe(0);
+    expect(await readNode(leftLeftKey)).toBe(hubColor);
+  });
 });


### PR DESCRIPTION
Closes #460.

Wave 4 of the Illuminate UX backlog: tints every vertex by its **minimum graph
distance to the nearest origin** so a glance at the canvas tells you
"origin / one hop / two hops / far / unreachable". The hop hue composes with
the existing #459 TTL alpha and #458 hover dim, in that lock-step order
(`hop hue → TTL α → hover dim`).

## What

- **Multi-source BFS in the selector.** `selectors.ts` now runs a
  multi-source BFS from every accumulated expansion origin and stamps the
  resulting `hopDistance` on each `GraphNode`. Pure data; no DOM. Origins
  that haven't fired yet (only the initial seed exists) still resolve to
  `hop = 0` for the seed.
- **5-stop hop palette.** `SigmaPalette` gains `hop0` / `hop1` / `hop2` /
  `hopFar` / `hopUnreachable`. `hop0` / `hop1` ride the Fluent brand
  foreground ramp (`colorBrandForeground1`, `colorBrandForeground2`). `hop2`
  switches to `colorBrandForeground2Hover` — the spec originally proposed
  `colorBrandStroke1`, but in Fluent v9's default brand `BrandStroke1` and
  `BrandForeground1` both resolve to `brand[80]` = `#0f6cbd`, so hop 0 and
  hop 2 would render identically. `BrandForeground2Hover` (`brand[60]`) gives
  us a properly separated third stop in the same family. `hopFar` flattens to
  `colorNeutralForeground3`; `hopUnreachable` falls back to a low-chroma red
  so disconnected vertices read as "out of bounds" rather than just stale.
- **Canvas wiring.** A new `colorForHop(hopDistance, palette)` helper drives
  `pickFill`; the reconcile pass stamps `hopDistance` + `firstSeenExpansion`
  alongside the existing `expiration` so the per-tick reducer can read them
  without re-running the selector. The hover tooltip now appends
  `hop = <bucket> · first seen in expansion #<n>`.
- **Live hop legend.** New absolute-positioned legend in the bottom-left
  corner. Per-bucket rows show swatch + label + live count; buckets with zero
  members are hidden so the legend tracks the canvas. Per-bucket CSS classes
  read CSS custom properties (`--hop-swatch-<bucket>`) the ref-callback
  stamps on the container, sidestepping the inline-style lint rule.
- **CLI graph-view stamps hop distance per verb.** `app/lib/cli/graph-view.ts`
  was missing the new required `GraphNode.hopDistance` field on every
  construction site. `illuminateView` now runs the same `computeHopDistances`
  BFS off the prefix-derived seed. The single-vertex (`get vertex`),
  single-edge (`get edge`), and prefix-scan (`scan vertices`, `scan edges`)
  views stamp a 0/1 ramp so the legend renders a meaningful two-bucket
  origin/neighbour view instead of the "unreachable red sea" you'd get from
  the `Infinity` placeholder.

## Tests

- **Selectors (`selectors.test.ts`):** 25 cases covering the BFS — single
  origin, multi-origin, isolated vertices, mid-BFS additions, cycles,
  disconnected components, the `firstSeenExpansion` index. 343/343 admin unit
  tests pass.
- **Hop palette (`hop-palette.test.ts`):** 7 cases for `colorForHop` and
  `describeHop` — origin, 1/2 hops, far threshold, infinity.
- **Palette (`palette.test.ts`):** +5 cases for the new tokens (one per hop
  bucket) and the fallback path.
- **e2e (`tests/e2e/illuminate.spec.ts`):** new `#460` test exercises a
  two-phase additive expansion: phase 1 seeds at the hub, confirms each ring
  renders with a distinct fill, same-bucket vertices match, and the legend
  shows exactly the three relevant buckets (origin / 1hop / 2hop). Phase 2
  expands from a leaf node and verifies *(a)* the leaf is now hop 0, *(b)*
  hop distances on every previously-seen vertex are **monotonically
  non-increasing** (additive expansion never lengthens an existing path),
  and *(c)* the leaf now renders with the origin swatch.

## Validation

- `bun run typecheck` clean
- `bun run lint` clean
- `bun run format:check` clean
- `bun test app/` → 343 pass / 0 fail
- `bun run build` clean (8.45s)
- `bunx playwright test` → 40 pass / 0 fail
- `go build ./...` clean

## Composition (locked)

```
Sigma reducer chain:
  hop hue (#460)  → TTL α (#459)  → hover dim (#458)
```

Hover dim must always be the topmost visual filter so out-of-focus vertices
collapse to the dim swatch regardless of their hop bucket or TTL state.
