### PR TITLE
feat(admin): expansion lineage chip strip with scroll-to-origin (#456)

### DIFF
--- a/admin/app/components/illuminate/ExpansionChipStrip/ExpansionChipStrip.module.css
+++ b/admin/app/components/illuminate/ExpansionChipStrip/ExpansionChipStrip.module.css
@@ -1,0 +1,27 @@
+.strip {
+  display: flex;
+  align-items: center;
+  gap: var(--spacingHorizontalXS, 4px);
+  min-width: 0;
+  width: 100%;
+}
+
+.overflowContainer {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: var(--spacingHorizontalXS, 4px);
+  min-width: 0;
+  width: 100%;
+  overflow: hidden;
+}
+
+.chip {
+  /* Keep chip labels on one line; Fluent's overflow plumbing measures
+   * full button width to decide visibility, so we lean on truncation
+   * only as a safety net for pathological key lengths. */
+  max-width: 240px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/admin/app/components/illuminate/ExpansionChipStrip/ExpansionChipStrip.tsx
+++ b/admin/app/components/illuminate/ExpansionChipStrip/ExpansionChipStrip.tsx
@@ -1,0 +1,170 @@
+import {
+  Button,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  Overflow,
+  OverflowItem,
+  Tooltip,
+  useIsOverflowItemVisible,
+  useOverflowMenu,
+} from "@fluentui/react-components";
+import { MoreHorizontal20Regular, Star20Filled } from "@fluentui/react-icons";
+import type { ExpansionChip } from "~/lib/client/usecase/illuminate/selectors";
+import styles from "./ExpansionChipStrip.module.css";
+
+export interface ExpansionChipStripProps {
+  chips: ExpansionChip[];
+  /**
+   * Pure-UI scroll-to-origin handler. Should pan the canvas to centre
+   * the supplied vertex and highlight it for ~600 ms. The chip strip
+   * never mutates `IlluminateState` itself — by contract this callback
+   * must not re-fetch or push a new expansion (per #456 acceptance
+   * criteria "does not mutate state, does not re-trigger any RPC").
+   */
+  onChipClick: (originKey: string) => void;
+}
+
+/**
+ * Horizontal lineage strip showing one chip per recorded expansion
+ * (#456). Click a chip to scroll the Sigma camera back to that
+ * expansion's origin vertex. Renders nothing when there are no
+ * expansions yet — the `SeedPrompt` covers that case at the page level.
+ *
+ * Overflow handling: Fluent UI's `<Overflow>` watches the container
+ * width and hides chips that don't fit, surfacing the hidden tail
+ * through an overflow menu (`<MenuButton>` with `<MoreHorizontal20Regular>`).
+ * The seed chip (`chips[0]`) is given `priority={1}` so it stays visible
+ * even on narrow viewports — losing the seed marker would erase the
+ * #466 D5 "structurally privileged" entry point from the picture.
+ */
+export function ExpansionChipStrip({
+  chips,
+  onChipClick,
+}: ExpansionChipStripProps) {
+  if (chips.length === 0) return null;
+
+  return (
+    <div
+      className={styles.strip}
+      role="toolbar"
+      aria-label="Expansion lineage"
+      data-testid="illuminate-expansion-chips"
+    >
+      <Overflow minimumVisible={1}>
+        <div className={styles.overflowContainer}>
+          {chips.map((chip) => (
+            <OverflowItem
+              key={chip.id}
+              id={`expansion-chip-${chip.id}`}
+              priority={chip.isSeed ? 1 : 0}
+            >
+              <ChipButton chip={chip} onChipClick={onChipClick} />
+            </OverflowItem>
+          ))}
+          <OverflowMenu chips={chips} onChipClick={onChipClick} />
+        </div>
+      </Overflow>
+    </div>
+  );
+}
+
+interface ChipButtonProps {
+  chip: ExpansionChip;
+  onChipClick: (originKey: string) => void;
+}
+
+function ChipButton({ chip, onChipClick }: ChipButtonProps) {
+  const tooltipContent = chip.isSeed
+    ? `Seed: ${chip.originKey} — pan camera to the initial seed`
+    : `Expansion #${chip.index + 1}: ${chip.originKey} — pan camera to this expansion`;
+
+  return (
+    <Tooltip content={tooltipContent} relationship="label" withArrow>
+      <Button
+        appearance="subtle"
+        size="small"
+        icon={chip.isSeed ? <Star20Filled /> : undefined}
+        onClick={() => onChipClick(chip.originKey)}
+        data-testid={`illuminate-chip-${chip.index}`}
+        data-chip-origin={chip.originKey}
+        data-chip-is-seed={chip.isSeed ? "true" : "false"}
+        className={styles.chip}
+      >
+        {chip.originKey}
+      </Button>
+    </Tooltip>
+  );
+}
+
+interface OverflowMenuProps {
+  chips: ExpansionChip[];
+  onChipClick: (originKey: string) => void;
+}
+
+/**
+ * Renders an overflow `<MenuButton>` populated with the chips that the
+ * `<Overflow>` container hid. We can't put `useIsOverflowItemVisible`
+ * inside the parent's `chips.map` callback — it would call the hook in
+ * a loop and break React's rules-of-hooks. Instead the menu maps over
+ * `chips` itself and asks per-id whether the item is hidden.
+ */
+function OverflowMenu({ chips, onChipClick }: OverflowMenuProps) {
+  const { ref, isOverflowing, overflowCount } =
+    useOverflowMenu<HTMLButtonElement>();
+
+  if (!isOverflowing) return null;
+
+  return (
+    <Menu>
+      <MenuTrigger disableButtonEnhancement>
+        <Tooltip
+          content={`Show ${overflowCount} more expansion${overflowCount === 1 ? "" : "s"}`}
+          relationship="label"
+          withArrow
+        >
+          <Button
+            ref={ref}
+            appearance="subtle"
+            size="small"
+            icon={<MoreHorizontal20Regular />}
+            data-testid="illuminate-chip-overflow"
+            aria-label={`Show ${overflowCount} more expansions`}
+          />
+        </Tooltip>
+      </MenuTrigger>
+      <MenuPopover>
+        <MenuList>
+          {chips.map((chip) => (
+            <OverflowMenuItem
+              key={chip.id}
+              chip={chip}
+              onChipClick={onChipClick}
+            />
+          ))}
+        </MenuList>
+      </MenuPopover>
+    </Menu>
+  );
+}
+
+interface OverflowMenuItemProps {
+  chip: ExpansionChip;
+  onChipClick: (originKey: string) => void;
+}
+
+function OverflowMenuItem({ chip, onChipClick }: OverflowMenuItemProps) {
+  const isVisible = useIsOverflowItemVisible(`expansion-chip-${chip.id}`);
+  if (isVisible) return null;
+  return (
+    <MenuItem
+      icon={chip.isSeed ? <Star20Filled /> : undefined}
+      onClick={() => onChipClick(chip.originKey)}
+      data-testid={`illuminate-chip-overflow-${chip.index}`}
+    >
+      {chip.isSeed ? `Seed · ${chip.originKey}` : chip.originKey}
+    </MenuItem>
+  );
+}

--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type Ref,
+} from "react";
 import Graph from "graphology";
 import forceAtlas2 from "graphology-layout-forceatlas2";
 import Sigma from "sigma";
@@ -39,6 +47,33 @@ export interface IlluminateCanvasProps {
   onNodeClick: (key: string) => void;
   /** When true, the canvas dims to communicate a stale frame. */
   isBusy: boolean;
+  /**
+   * Imperative handle (#456). The expansion chip strip calls
+   * `panToNode(originKey)` to scroll the camera to a previous click
+   * point without mutating state or refetching. Optional — keeps the
+   * canvas reusable from contexts that don't need camera control.
+   */
+  ref?: Ref<IlluminateCanvasHandle>;
+}
+
+/**
+ * Imperative API exposed to parent components via `ref` (#456). Only
+ * pan-to-node is published today; the rest of the canvas's surface
+ * remains declarative (props) so test-bridge methods stay isolated to
+ * `window.__illuminateCanvas`.
+ */
+export interface IlluminateCanvasHandle {
+  /**
+   * Animate the sigma camera so the supplied vertex is centred, then
+   * briefly highlight it (~600 ms). Returns `false` when the key is
+   * not currently in the graph (e.g., the user cleared the
+   * accumulator). Repeated calls cancel the previous highlight so
+   * rapidly clicked chips don't stack pulse timers on each other.
+   */
+  panToNode: (
+    key: string,
+    options?: { duration?: number; highlightMs?: number; ratio?: number },
+  ) => boolean;
 }
 
 interface HoverState {
@@ -62,10 +97,23 @@ export function IlluminateCanvas({
   latestExpansionOrigin,
   onNodeClick,
   isBusy,
+  ref,
 }: IlluminateCanvasProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const sigmaRef = useRef<Sigma | null>(null);
   const graphRef = useRef<Graph | null>(null);
+  /**
+   * #456 highlight-cancellation handle. `panToNode` schedules a
+   * setTimeout to revert the `highlighted` attribute it sets on the
+   * pulsing node; if the user clicks another chip before the pulse
+   * expires, the prior timeout must be cancelled (and its node
+   * un-highlighted) so the new pulse doesn't get cleared early.
+   */
+  const highlightTimeoutRef = useRef<{
+    handle: ReturnType<typeof setTimeout>;
+    nodeKey: string;
+    previousHighlighted: boolean;
+  } | null>(null);
   /**
    * Snapshot of the node IDs the graph held at the end of the previous
    * reconcile. Diffing against the next reconcile's IDs feeds
@@ -131,6 +179,94 @@ export function IlluminateCanvas({
   useEffect(() => {
     onNodeClickRef.current = onNodeClick;
   }, [onNodeClick]);
+
+  // #456 imperative handle. Reads from `graphRef`/`sigmaRef` at call
+  // time so the closure stays valid across re-renders without any
+  // dependency wiring; mount/unmount of sigma is handled by the
+  // dedicated effect below.
+  useImperativeHandle(
+    ref,
+    () => ({
+      panToNode: (key, options) => {
+        const sigma = sigmaRef.current;
+        const graph = graphRef.current;
+        if (!sigma || !graph || !graph.hasNode(key)) return false;
+
+        // `getNodeDisplayData` returns coordinates in the sigma camera's
+        // coordinate frame, which is exactly what `camera.animate`
+        // accepts as a target state. The graph-space coordinates from
+        // `graph.getNodeAttributes` are NOT directly compatible (they
+        // pre-date sigma's normalization pass), so always go through
+        // the renderer's display data.
+        const display = sigma.getNodeDisplayData(key);
+        if (!display) return false;
+
+        const duration = options?.duration ?? 600;
+        const ratio = options?.ratio ?? 0.5;
+        const highlightMs = options?.highlightMs ?? duration;
+
+        const camera = sigma.getCamera();
+        camera.animate({ x: display.x, y: display.y, ratio }, { duration });
+
+        // Cancel any prior highlight pulse — restore its node first so
+        // a rapid sequence of chip clicks doesn't leave stranded
+        // `highlighted=true` attrs around.
+        const prior = highlightTimeoutRef.current;
+        if (prior) {
+          clearTimeout(prior.handle);
+          if (graph.hasNode(prior.nodeKey)) {
+            graph.setNodeAttribute(
+              prior.nodeKey,
+              "highlighted",
+              prior.previousHighlighted,
+            );
+          }
+          highlightTimeoutRef.current = null;
+        }
+
+        const previousHighlighted =
+          graph.getNodeAttribute(key, "highlighted") === true;
+        graph.setNodeAttribute(key, "highlighted", true);
+        sigma.refresh();
+
+        const handle = setTimeout(() => {
+          highlightTimeoutRef.current = null;
+          if (!graphRef.current?.hasNode(key)) return;
+          graphRef.current.setNodeAttribute(
+            key,
+            "highlighted",
+            previousHighlighted,
+          );
+          sigmaRef.current?.refresh();
+        }, highlightMs);
+
+        highlightTimeoutRef.current = {
+          handle,
+          nodeKey: key,
+          previousHighlighted,
+        };
+        return true;
+      },
+    }),
+    // The handle reads `sigmaRef`/`graphRef`/`highlightTimeoutRef` at
+    // call time, so it has no reactive dependencies; an empty array
+    // keeps the imperative handle identity stable for the lifetime of
+    // the component.
+    [],
+  );
+
+  // Cancel any in-flight #456 highlight pulse on unmount so a stale
+  // setTimeout doesn't fire against a discarded sigma instance.
+  useEffect(
+    () => () => {
+      const pending = highlightTimeoutRef.current;
+      if (pending) {
+        clearTimeout(pending.handle);
+        highlightTimeoutRef.current = null;
+      }
+    },
+    [],
+  );
 
   // Mount sigma once. The graph and renderer survive across data updates;
   // see the reconcile effect below.
@@ -452,6 +588,33 @@ export function IlluminateCanvas({
          * waiting on `setInterval`.
          */
         forceTick: () => void;
+        /**
+         * #456 test bridge: read the current sigma camera state
+         * (`x`/`y`/`ratio`/`angle`). The e2e suite snapshots this
+         * before and after a chip click to assert the camera animated
+         * toward the clicked origin without relying on pixel diffs.
+         */
+        cameraState: () => {
+          x: number;
+          y: number;
+          ratio: number;
+          angle: number;
+        };
+        /**
+         * #456 test bridge: read the post-reducer display coordinates
+         * of a node (the same frame `panToNode` animates the camera
+         * to). Returns `null` when the node is unknown. Lets the e2e
+         * assert the camera converged on the chip's origin vertex.
+         */
+        getNodeDisplayPosition: (
+          key: string,
+        ) => { x: number; y: number } | null;
+        /**
+         * #456 test bridge: whether a node currently carries the
+         * transient highlight `panToNode` applies for ~600 ms. Lets the
+         * e2e confirm the pulse fires (and later clears).
+         */
+        isNodeHighlighted: (key: string) => boolean;
       };
     };
     win.__illuminateCanvas = {
@@ -533,6 +696,24 @@ export function IlluminateCanvas({
         nowRef.current = nowOverrideRef.current ?? Date.now();
         tickCountRef.current += 1;
         renderer.refresh();
+      },
+      cameraState: () => {
+        const state = renderer.getCamera().getState();
+        return {
+          x: state.x,
+          y: state.y,
+          ratio: state.ratio,
+          angle: state.angle,
+        };
+      },
+      getNodeDisplayPosition: (key: string) => {
+        if (!graph.hasNode(key)) return null;
+        const data = renderer.getNodeDisplayData(key);
+        return data ? { x: data.x, y: data.y } : null;
+      },
+      isNodeHighlighted: (key: string) => {
+        if (!graph.hasNode(key)) return false;
+        return graph.getNodeAttribute(key, "highlighted") === true;
       },
     };
 

--- a/admin/app/components/illuminate/IlluminatePage/IlluminatePage.tsx
+++ b/admin/app/components/illuminate/IlluminatePage/IlluminatePage.tsx
@@ -1,7 +1,10 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { MessageBar, MessageBarBody } from "@fluentui/react-components";
 import { useNavigate, useSearchParams } from "react-router";
-import { IlluminateCanvas } from "../IlluminateCanvas/IlluminateCanvas";
+import {
+  IlluminateCanvas,
+  type IlluminateCanvasHandle,
+} from "../IlluminateCanvas/IlluminateCanvas";
 import { IlluminateTable } from "../IlluminateTable/IlluminateTable";
 import { IlluminateToolbar } from "../IlluminateToolbar/IlluminateToolbar";
 import { SeedPrompt } from "../SeedPrompt/SeedPrompt";
@@ -24,6 +27,8 @@ export function IlluminatePage() {
 
   const ill = useIlluminate(urlSeed);
 
+  const canvasRef = useRef<IlluminateCanvasHandle | null>(null);
+
   const handleNodeClick = useCallback(
     (key: string) => {
       if (!key) return;
@@ -34,6 +39,11 @@ export function IlluminatePage() {
     },
     [ill],
   );
+
+  // #456 scroll-to-origin: pure camera move, no state mutation, no RPC.
+  const handleChipClick = useCallback((originKey: string) => {
+    canvasRef.current?.panToNode(originKey);
+  }, []);
 
   const handleClear = useCallback(() => {
     // Clear navigates back to the bare `/illuminate` URL; the hook's
@@ -71,9 +81,11 @@ export function IlluminatePage() {
             vertexCount={ill.view.nodes.length}
             edgeCount={ill.view.edges.length}
             expansionCount={ill.expansionCount}
+            expansionChips={ill.expansionChips}
             onControlsChange={ill.setControls}
             onClear={handleClear}
             onRefresh={ill.refresh}
+            onChipClick={handleChipClick}
           />
           {ill.state.error ? (
             <MessageBar
@@ -98,6 +110,7 @@ export function IlluminatePage() {
             </MessageBar>
           ) : null}
           <IlluminateCanvas
+            ref={canvasRef}
             nodes={ill.view.nodes}
             edges={ill.view.edges}
             latestExpansionOrigin={ill.view.latestExpansionOrigin}

--- a/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.module.css
+++ b/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.module.css
@@ -39,6 +39,11 @@
   text-overflow: ellipsis;
 }
 
+.chipStripSlot {
+  flex: 1 1 240px;
+  min-width: 0;
+}
+
 .knobs {
   display: flex;
   align-items: center;

--- a/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.tsx
+++ b/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.tsx
@@ -13,6 +13,7 @@ import {
   ArrowClockwise20Regular,
   Delete20Regular,
 } from "@fluentui/react-icons";
+import { ExpansionChipStrip } from "../ExpansionChipStrip/ExpansionChipStrip";
 import type {
   IlluminateControls,
   IlluminateStatus,
@@ -21,6 +22,7 @@ import type {
   Algorithm,
   Objective,
 } from "~/lib/client/infrastructure/api/illuminate";
+import type { ExpansionChip } from "~/lib/client/usecase/illuminate/selectors";
 import styles from "./IlluminateToolbar.module.css";
 
 export interface IlluminateToolbarProps {
@@ -31,9 +33,21 @@ export interface IlluminateToolbarProps {
   vertexCount: number;
   edgeCount: number;
   expansionCount: number;
+  /**
+   * Per-expansion lineage chips (#456). The strip replaces the legacy
+   * `<code>` seed echo: the first chip carries the seed marker so the
+   * URL-level seed is still surfaced at a glance.
+   */
+  expansionChips: ExpansionChip[];
   onControlsChange: (next: IlluminateControls) => void;
   onClear: () => void;
   onRefresh: () => void;
+  /**
+   * Fired when the user clicks one of the lineage chips (#456). The
+   * handler is pure UI — pan the canvas camera to the chip's origin
+   * vertex; no state mutation, no re-fetch.
+   */
+  onChipClick: (originKey: string) => void;
 }
 
 // Per #410 the post-traversal reduction is the orthogonal triple
@@ -68,9 +82,11 @@ export function IlluminateToolbar({
   vertexCount,
   edgeCount,
   expansionCount,
+  expansionChips,
   onControlsChange,
   onClear,
   onRefresh,
+  onChipClick,
 }: IlluminateToolbarProps) {
   const update = <K extends keyof IlluminateControls>(
     key: K,
@@ -86,12 +102,13 @@ export function IlluminateToolbar({
       data-testid="illuminate-toolbar"
     >
       <div className={styles.seedRow}>
-        <Label className={styles.seedLabel}>Seed</Label>
-        <Tooltip content={initialSeed} relationship="label" withArrow>
-          <code className={styles.seedValue} data-testid="illuminate-seed">
-            {initialSeed || "—"}
-          </code>
-        </Tooltip>
+        <Label className={styles.seedLabel}>Lineage</Label>
+        <div className={styles.chipStripSlot}>
+          <ExpansionChipStrip
+            chips={expansionChips}
+            onChipClick={onChipClick}
+          />
+        </div>
         <Badge
           appearance="tint"
           color="informative"

--- a/admin/app/lib/client/usecase/illuminate/selectors.test.ts
+++ b/admin/app/lib/client/usecase/illuminate/selectors.test.ts
@@ -3,6 +3,7 @@ import type { Edge, Vertex } from "~/lib/client/infrastructure/api/illuminate";
 import { illuminateReducer } from "./reducer";
 import {
   selectCanClear,
+  selectExpansionChips,
   selectExpansionCount,
   selectGraphView,
   selectIsBusy,
@@ -537,5 +538,66 @@ describe("selectIsBusy", () => {
     expect(selectIsBusy({ ...INITIAL_ILLUMINATE_STATE, pendingCount: 1 })).toBe(
       true,
     );
+  });
+});
+
+describe("selectExpansionChips (#456)", () => {
+  it("is empty when no expansion has happened yet", () => {
+    expect(selectExpansionChips(INITIAL_ILLUMINATE_STATE)).toEqual([]);
+  });
+
+  it("emits one chip per expansion in chronological order, with the seed flag on chip 0", () => {
+    let state = stateWithInitialSeed("Distributed_computing");
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "Distributed_computing",
+      vertices: [v("Distributed_computing"), v("CAP_theorem")],
+      edges: [e("Distributed_computing", "CAP_theorem")],
+    });
+    state = applyExpansion(state, {
+      expansionId: 2,
+      origin: "CAP_theorem",
+      vertices: [v("CAP_theorem"), v("Eric_Brewer_(scientist)")],
+      edges: [e("CAP_theorem", "Eric_Brewer_(scientist)")],
+    });
+    state = applyExpansion(state, {
+      expansionId: 3,
+      origin: "Eric_Brewer_(scientist)",
+      vertices: [v("Eric_Brewer_(scientist)"), v("Larry_Page")],
+      edges: [e("Eric_Brewer_(scientist)", "Larry_Page")],
+    });
+
+    const chips = selectExpansionChips(state);
+    expect(chips).toHaveLength(3);
+    expect(chips.map((c) => c.originKey)).toEqual([
+      "Distributed_computing",
+      "CAP_theorem",
+      "Eric_Brewer_(scientist)",
+    ]);
+    expect(chips[0]).toMatchObject({ isSeed: true, index: 0 });
+    expect(chips[1]).toMatchObject({ isSeed: false, index: 1 });
+    expect(chips[2]).toMatchObject({ isSeed: false, index: 2 });
+  });
+
+  it("preserves duplicate origin keys when the user re-clicks the same vertex", () => {
+    let state = stateWithInitialSeed("a");
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "a",
+      vertices: [v("a")],
+      edges: [],
+    });
+    state = applyExpansion(state, {
+      expansionId: 2,
+      origin: "a",
+      vertices: [v("a")],
+      edges: [],
+    });
+    const chips = selectExpansionChips(state);
+    expect(chips.map((c) => c.originKey)).toEqual(["a", "a"]);
+    // Both chips keep their distinct React keys (Expansion.id).
+    expect(new Set(chips.map((c) => c.id)).size).toBe(2);
+    expect(chips[0]?.isSeed).toBe(true);
+    expect(chips[1]?.isSeed).toBe(false);
   });
 });

--- a/admin/app/lib/client/usecase/illuminate/selectors.ts
+++ b/admin/app/lib/client/usecase/illuminate/selectors.ts
@@ -298,3 +298,35 @@ export function selectExpansionCount(state: IlluminateState): number {
 export function selectCanClear(state: IlluminateState): boolean {
   return state.expansions.length > 0 || state.accumulator.vertices.size > 0;
 }
+
+/**
+ * View-model for the per-expansion chip in the toolbar (#456). Each chip
+ * is a "scroll-to-origin" affordance — clicking it pans the camera to the
+ * origin vertex without mutating state or re-issuing any RPC.
+ *
+ * Order matches `state.expansions` (chronological); `chips[0]` is the
+ * seed expansion (#466 D5) and carries `isSeed: true` so the toolbar
+ * can render a star/badge marker. Duplicates by `originKey` are
+ * preserved on purpose: clicking the same vertex twice produces two
+ * chips with the same label because the user genuinely performed two
+ * exploration actions and may want to revisit either point in time.
+ */
+export interface ExpansionChip {
+  /** Stable React key — mirrors `Expansion.id`. */
+  id: number;
+  /** Display label + camera target. */
+  originKey: string;
+  /** True only for `expansions[0]` (the URL-level seed). */
+  isSeed: boolean;
+  /** Zero-based position in `state.expansions` for tooltips. */
+  index: number;
+}
+
+export function selectExpansionChips(state: IlluminateState): ExpansionChip[] {
+  return state.expansions.map((exp, index) => ({
+    id: exp.id,
+    originKey: exp.origin,
+    isSeed: index === 0,
+    index,
+  }));
+}

--- a/admin/app/lib/client/usecase/illuminate/use-illuminate.ts
+++ b/admin/app/lib/client/usecase/illuminate/use-illuminate.ts
@@ -4,9 +4,11 @@ import { runExpansion } from "./handlers";
 import { illuminateReducer, type IlluminateAction } from "./reducer";
 import {
   selectCanClear,
+  selectExpansionChips,
   selectExpansionCount,
   selectGraphView,
   selectIsBusy,
+  type ExpansionChip,
   type GraphView,
 } from "./selectors";
 import {
@@ -21,6 +23,8 @@ export interface UseIlluminateResult {
   isBusy: boolean;
   canClear: boolean;
   expansionCount: number;
+  /** Per-expansion lineage chips for the toolbar strip (#456). */
+  expansionChips: ExpansionChip[];
   /** Fire an Illuminate from `origin` and merge the response into the accumulator. */
   expand: (origin: string) => void;
   /** Empty accumulator + expansions; preserves `initialSeed` so the seed expansion re-fires. */
@@ -156,6 +160,7 @@ export function useIlluminate(urlSeed: string): UseIlluminateResult {
   const isBusy = selectIsBusy(state);
   const canClear = selectCanClear(state);
   const expansionCount = selectExpansionCount(state);
+  const expansionChips = useMemo(() => selectExpansionChips(state), [state]);
 
   return useMemo<UseIlluminateResult>(
     () => ({
@@ -164,6 +169,7 @@ export function useIlluminate(urlSeed: string): UseIlluminateResult {
       isBusy,
       canClear,
       expansionCount,
+      expansionChips,
       expand,
       clear,
       setControls,
@@ -175,6 +181,7 @@ export function useIlluminate(urlSeed: string): UseIlluminateResult {
       isBusy,
       canClear,
       expansionCount,
+      expansionChips,
       expand,
       clear,
       setControls,

--- a/admin/tests/e2e/illuminate.spec.ts
+++ b/admin/tests/e2e/illuminate.spec.ts
@@ -62,8 +62,14 @@ test.describe("/illuminate", () => {
     await page.goto(`/illuminate?seed=${seed}`);
 
     await expect(page.getByTestId("illuminate-toolbar")).toBeVisible();
-    await expect(page.getByTestId("illuminate-seed")).toHaveText(
+    // #456: the seed echo is now the leading lineage chip (chip 0).
+    await expect(page.getByTestId("illuminate-chip-0")).toHaveAttribute(
+      "data-chip-origin",
       "e2e:illum:hub",
+    );
+    await expect(page.getByTestId("illuminate-chip-0")).toHaveAttribute(
+      "data-chip-is-seed",
+      "true",
     );
     await expect(page.getByTestId("illuminate-canvas")).toBeVisible();
 
@@ -132,7 +138,9 @@ test.describe("/illuminate", () => {
     await expect(counter).toContainText("6 vertices");
     await expect(counter).toContainText("2 expansions");
     await expect(page).toHaveURL(/\?seed=e2e%3Aillum%3Ahub/);
-    await expect(page.getByTestId("illuminate-seed")).toHaveText(
+    // #456: the seed remains the leading lineage chip across an expansion.
+    await expect(page.getByTestId("illuminate-chip-0")).toHaveAttribute(
+      "data-chip-origin",
       "e2e:illum:hub",
     );
 
@@ -939,5 +947,125 @@ test.describe("/illuminate", () => {
     // now a brand colour, not a far colour.
     expect(newHubHop).toBe(0);
     expect(await readNode(leftLeftKey)).toBe(hubColor);
+  });
+
+  test("Lineage chip strip scrolls the camera back to an expansion origin without mutating state (#456)", async ({
+    page,
+  }) => {
+    const seed = encodeURIComponent("e2e:illum:hub");
+    await page.goto(`/illuminate?seed=${seed}`);
+    await expect(page.getByTestId("illuminate-toolbar")).toBeVisible();
+
+    const counter = page.getByTestId("illuminate-counter");
+    await expect(counter).toContainText("5 vertices");
+    await expect(counter).toContainText("1 expansion");
+
+    // The strip starts with a single seed chip carrying the seed marker.
+    await expect(page.getByTestId("illuminate-expansion-chips")).toBeVisible();
+    const seedChip = page.getByTestId("illuminate-chip-0");
+    await expect(seedChip).toHaveAttribute("data-chip-origin", "e2e:illum:hub");
+    await expect(seedChip).toHaveAttribute("data-chip-is-seed", "true");
+
+    // Grow the lineage with an additive expansion from `leftleft` so a
+    // SECOND, non-seed chip appears.
+    await page
+      .getByRole("group")
+      .getByText(/List view \(5 vertices/)
+      .click();
+    const table = page.getByTestId("illuminate-table");
+    await table
+      .getByRole("button", { name: "Expand from e2e:illum:leftleft" })
+      .click();
+    await expect(counter).toContainText("6 vertices");
+    await expect(counter).toContainText("2 expansions");
+
+    // Now there are two chips: the seed (chip 0) and the leftleft
+    // expansion (chip 1). The second is NOT marked as the seed.
+    const expansionChip = page.getByTestId("illuminate-chip-1");
+    await expect(expansionChip).toHaveAttribute(
+      "data-chip-origin",
+      "e2e:illum:leftleft",
+    );
+    await expect(expansionChip).toHaveAttribute("data-chip-is-seed", "false");
+
+    // Wait for the camera test bridge.
+    type Camera = { x: number; y: number; ratio: number; angle: number };
+    type Pos = { x: number; y: number };
+    type Bridge = {
+      cameraState: () => Camera;
+      getNodeDisplayPosition: (k: string) => Pos | null;
+      isNodeHighlighted: (k: string) => boolean;
+    };
+    await page.waitForFunction(() => {
+      const win = window as Window & { __illuminateCanvas?: Bridge };
+      return !!win.__illuminateCanvas?.cameraState;
+    });
+
+    const readCamera = (): Promise<Camera> =>
+      page.evaluate(() => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas!.cameraState();
+      });
+    const readDisplay = (k: string): Promise<Pos | null> =>
+      page.evaluate((key) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.getNodeDisplayPosition(key) ?? null;
+      }, k);
+    const isHighlighted = (k: string): Promise<boolean> =>
+      page.evaluate((key) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.isNodeHighlighted(key) ?? false;
+      }, k);
+
+    // Snapshot the camera, then click the leftleft chip. Its display
+    // position is off-centre from the seed-anchored view, so the camera
+    // must move toward it.
+    const before = await readCamera();
+    const target = await readDisplay("e2e:illum:leftleft");
+    expect(target).not.toBeNull();
+
+    await expansionChip.click();
+
+    // The pan animates over ~600 ms — wait until the camera arrives at
+    // the leftleft display coordinates (within a small tolerance).
+    await page.waitForFunction(
+      ({ key }) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        const b = win.__illuminateCanvas;
+        if (!b) return false;
+        const cam = b.cameraState();
+        const dp = b.getNodeDisplayPosition(key);
+        if (!dp) return false;
+        return Math.abs(cam.x - dp.x) < 0.02 && Math.abs(cam.y - dp.y) < 0.02;
+      },
+      { key: "e2e:illum:leftleft" },
+      { timeout: 4000 },
+    );
+
+    const after = await readCamera();
+    // The camera genuinely moved (the click was not a no-op).
+    const moved =
+      Math.abs(after.x - before.x) > 1e-6 ||
+      Math.abs(after.y - before.y) > 1e-6;
+    expect(moved).toBe(true);
+
+    // The transient highlight pulse fired on the target.
+    expect(await isHighlighted("e2e:illum:leftleft")).toBe(true);
+
+    // Crucially the click is UI-only: it does NOT re-fetch, push a new
+    // expansion, or change the accumulator. Counts are unchanged.
+    await expect(counter).toContainText("6 vertices");
+    await expect(counter).toContainText("2 expansions");
+    await expect(page).toHaveURL(/\?seed=e2e%3Aillum%3Ahub/);
+
+    // The highlight reverts after the pulse window (~600 ms) elapses.
+    await page.waitForFunction(
+      ({ key }) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.isNodeHighlighted(key) === false;
+      },
+      { key: "e2e:illum:leftleft" },
+      { timeout: 4000 },
+    );
   });
 });


### PR DESCRIPTION
## Summary

Adds an **expansion lineage chip strip** to the admin `/illuminate` toolbar. Each
recorded expansion (`state.expansions[]`) becomes a clickable Fluent chip; clicking
a chip pans/zooms the Sigma camera to centre that expansion's origin vertex and
pulses a transient highlight (~600 ms). This is a **pure UI camera operation** — it
never mutates `IlluminateState`, re-fires an RPC, or perturbs the force layout.

Closes #456

## What changed

- **`selectors.ts`** — new `ExpansionChip` view-model + `selectExpansionChips`
  (one chip per expansion, chronological, `isSeed` only on `expansions[0]`;
  duplicate origins preserved as distinct chips by design).
- **`ExpansionChipStrip/`** (new) — `<Overflow minimumVisible={1}>`-based strip.
  Seed chip carries a ⭐ marker and `priority={1}` so it survives narrow viewports;
  overflow tail collapses into a `MenuButton`. Returns `null` when there are no
  expansions.
- **`IlluminateCanvas`** — new `IlluminateCanvasHandle` exposing
  `panToNode(key, { duration?, highlightMs?, ratio? })` via `useImperativeHandle`
  (React 19 `ref`-in-props idiom). Animates the camera to the node's
  `getNodeDisplayData` coords and applies a self-clearing highlight pulse; unmount
  cleanup cancels any pending pulse.
- **`IlluminateToolbar`** — replaces the static `<code data-testid="illuminate-seed">`
  seed echo with the lineage strip (labelled "Lineage").
- **`use-illuminate.ts`** — surfaces `expansionChips` (memoised).
- **`IlluminatePage`** — holds the canvas ref and routes chip clicks to
  `panToNode`.

## Tests

- **Unit** (`selectors.test.ts`): 3 new cases for `selectExpansionChips`
  (empty → no chips; chronological order + seed flag; duplicate origins keep
  distinct ids). `bun test app/` → 346 pass.
- **E2E** (`illuminate.spec.ts:952`): seeds `hub`, grows lineage via an additive
  Expand, clicks the non-seed chip, and asserts the camera converges on that
  vertex's display coords + the highlight pulse fires/clears, while the
  accumulator counts and `?seed=` URL stay unchanged (no RPC, no mutation).
  Added a read-only camera test bridge (`cameraState`, `getNodeDisplayPosition`,
  `isNodeHighlighted`). Updated the two existing tests that asserted on the
  removed `illuminate-seed` element to target the new seed chip.
  `bunx playwright test illuminate` → 12 pass.

## Verification

`bun run typecheck` ✓ · `bun run lint` ✓ (0 warnings) · `bun run format` ✓ ·
`bun test app/` ✓ (346) · `bun run build` ✓ · `bunx playwright test illuminate` ✓ (12) ·
`go build ./...` ✓
