### PR TITLE
feat(admin): type-ahead seed picker (#457)

### DIFF
--- a/admin/app/components/illuminate/IlluminatePage/IlluminatePage.tsx
+++ b/admin/app/components/illuminate/IlluminatePage/IlluminatePage.tsx
@@ -86,6 +86,7 @@ export function IlluminatePage() {
             onClear={handleClear}
             onRefresh={ill.refresh}
             onChipClick={handleChipClick}
+            onExpandFromKey={ill.expand}
           />
           {ill.state.error ? (
             <MessageBar

--- a/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.module.css
+++ b/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.module.css
@@ -44,6 +44,19 @@
   min-width: 0;
 }
 
+.expandRow {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--spacingHorizontalS, 8px);
+  flex-wrap: wrap;
+}
+
+.expandPickerSlot {
+  flex: 1 1 320px;
+  min-width: 0;
+  max-width: 480px;
+}
+
 .knobs {
   display: flex;
   align-items: center;

--- a/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.tsx
+++ b/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.tsx
@@ -10,9 +10,12 @@ import {
   Tooltip,
 } from "@fluentui/react-components";
 import {
+  Add20Regular,
   ArrowClockwise20Regular,
   Delete20Regular,
 } from "@fluentui/react-icons";
+import { useCallback, useState } from "react";
+import { VertexPicker } from "~/components/shared/VertexPicker/VertexPicker";
 import { ExpansionChipStrip } from "../ExpansionChipStrip/ExpansionChipStrip";
 import type {
   IlluminateControls,
@@ -48,6 +51,14 @@ export interface IlluminateToolbarProps {
    * vertex; no state mutation, no re-fetch.
    */
   onChipClick: (originKey: string) => void;
+  /**
+   * Fired when the user commits a key in the inline “Expand from key…”
+   * picker (#457). Under the additive model (#466) this dispatches a fresh
+   * expansion (`ill.expand`) rather than replacing the URL-level seed, so
+   * the operator can grow the accumulator from an arbitrary key without
+   * navigating back to the SeedPrompt.
+   */
+  onExpandFromKey: (key: string) => void;
 }
 
 // Per #410 the post-traversal reduction is the orthogonal triple
@@ -87,7 +98,22 @@ export function IlluminateToolbar({
   onClear,
   onRefresh,
   onChipClick,
+  onExpandFromKey,
 }: IlluminateToolbarProps) {
+  const [expandOpen, setExpandOpen] = useState(false);
+  const [expandValue, setExpandValue] = useState("");
+
+  const commitExpand = useCallback(
+    (key: string) => {
+      const next = key.trim();
+      if (next === "") return;
+      onExpandFromKey(next);
+      setExpandValue("");
+      setExpandOpen(false);
+    },
+    [onExpandFromKey],
+  );
+
   const update = <K extends keyof IlluminateControls>(
     key: K,
     value: IlluminateControls[K],
@@ -117,6 +143,16 @@ export function IlluminateToolbar({
           {vertexCount} vertices · {edgeCount} edges · {expansionCount}{" "}
           expansions
         </Badge>
+        <Button
+          appearance="subtle"
+          size="small"
+          icon={<Add20Regular />}
+          onClick={() => setExpandOpen((open) => !open)}
+          aria-expanded={expandOpen}
+          data-testid="illuminate-expand-toggle"
+        >
+          Expand from key…
+        </Button>
         <Tooltip
           content="Re-fire the most recent expansion with current controls"
           relationship="label"
@@ -151,6 +187,43 @@ export function IlluminateToolbar({
         </Tooltip>
         <StatusBadge status={status} />
       </div>
+
+      {expandOpen ? (
+        <div className={styles.expandRow} data-testid="illuminate-expand-row">
+          <div className={styles.expandPickerSlot}>
+            <VertexPicker
+              value={expandValue}
+              onValueChange={setExpandValue}
+              onSelect={commitExpand}
+              label="Expand from key"
+              placeholder="Type a vertex key…"
+              autoFocus
+              inputTestId="illuminate-expand-input"
+              captionTestId="illuminate-expand-matches"
+            />
+          </div>
+          <Button
+            appearance="primary"
+            size="small"
+            disabled={expandValue.trim() === ""}
+            onClick={() => commitExpand(expandValue)}
+            data-testid="illuminate-expand-submit"
+          >
+            Expand
+          </Button>
+          <Button
+            appearance="subtle"
+            size="small"
+            onClick={() => {
+              setExpandOpen(false);
+              setExpandValue("");
+            }}
+            data-testid="illuminate-expand-cancel"
+          >
+            Cancel
+          </Button>
+        </div>
+      ) : null}
 
       <div className={styles.knobs}>
         <Field

--- a/admin/app/components/illuminate/SeedPrompt/SeedPrompt.module.css
+++ b/admin/app/components/illuminate/SeedPrompt/SeedPrompt.module.css
@@ -8,8 +8,3 @@
   border-radius: var(--borderRadiusMedium, 6px);
   background: var(--colorNeutralBackground1, #fff);
 }
-
-.field {
-  display: flex;
-  flex-direction: column;
-}

--- a/admin/app/components/illuminate/SeedPrompt/SeedPrompt.tsx
+++ b/admin/app/components/illuminate/SeedPrompt/SeedPrompt.tsx
@@ -1,12 +1,7 @@
-import { useState, type FormEvent } from "react";
-import {
-  Button,
-  Field,
-  Input,
-  MessageBar,
-  MessageBarBody,
-} from "@fluentui/react-components";
+import { useCallback, useState, type FormEvent } from "react";
+import { Button, MessageBar, MessageBarBody } from "@fluentui/react-components";
 import { LightbulbFilament20Regular } from "@fluentui/react-icons";
+import { VertexPicker } from "~/components/shared/VertexPicker/VertexPicker";
 import styles from "./SeedPrompt.module.css";
 
 export interface SeedPromptProps {
@@ -16,16 +11,33 @@ export interface SeedPromptProps {
 /**
  * Shown when the Illuminate route has no `?seed=`. Lets the user kick off
  * an exploration from any key without first visiting the Browse screen.
+ *
+ * Per #457 the blind text input is now a type-ahead {@link VertexPicker}:
+ * keys are suggested live from ScanVertices and the total match count is
+ * surfaced beneath the field. Committing a suggestion (click / ↵ / Tab) or
+ * the explicit Open button both route through
+ * {@link SeedPromptProps.onOpen}.
  */
 export function SeedPrompt({ onOpen }: SeedPromptProps) {
   const [seed, setSeed] = useState("");
+  const trimmed = seed.trim();
 
-  const submit = (event: FormEvent) => {
-    event.preventDefault();
-    const trimmed = seed.trim();
-    if (trimmed === "") return;
-    onOpen(trimmed);
-  };
+  const open = useCallback(
+    (key: string) => {
+      const next = key.trim();
+      if (next === "") return;
+      onOpen(next);
+    },
+    [onOpen],
+  );
+
+  const submit = useCallback(
+    (event: FormEvent) => {
+      event.preventDefault();
+      open(seed);
+    },
+    [open, seed],
+  );
 
   return (
     <form
@@ -39,20 +51,21 @@ export function SeedPrompt({ onOpen }: SeedPromptProps) {
           “Illuminate” from any row on the Browse screen.
         </MessageBarBody>
       </MessageBar>
-      <Field label="Seed key" className={styles.field}>
-        <Input
-          value={seed}
-          onChange={(_, data) => setSeed(data.value)}
-          placeholder="e.g. user:42"
-          data-testid="illuminate-seed-input"
-          autoFocus
-        />
-      </Field>
+      <VertexPicker
+        value={seed}
+        onValueChange={setSeed}
+        onSelect={open}
+        label="Seed key"
+        placeholder="e.g. user:42"
+        autoFocus
+        inputTestId="illuminate-seed-input"
+        captionTestId="illuminate-seed-matches"
+      />
       <Button
         appearance="primary"
         icon={<LightbulbFilament20Regular />}
         type="submit"
-        disabled={seed.trim() === ""}
+        disabled={trimmed === ""}
         data-testid="illuminate-open"
       >
         Open

--- a/admin/app/components/shared/VertexPicker/VertexPicker.module.css
+++ b/admin/app/components/shared/VertexPicker/VertexPicker.module.css
@@ -1,0 +1,10 @@
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalXS, 4px);
+}
+
+.caption {
+  color: var(--colorNeutralForeground3, #616161);
+  min-height: var(--lineHeightBase200, 16px);
+}

--- a/admin/app/components/shared/VertexPicker/VertexPicker.tsx
+++ b/admin/app/components/shared/VertexPicker/VertexPicker.tsx
@@ -1,0 +1,116 @@
+import {
+  Combobox,
+  Field,
+  Option,
+  Text,
+  type ComboboxProps,
+} from "@fluentui/react-components";
+import { useCallback } from "react";
+import { selectCaption } from "~/lib/client/usecase/vertex-picker/selectors";
+import {
+  useVertexPicker,
+  type UseVertexPickerOptions,
+} from "~/lib/client/usecase/vertex-picker/use-vertex-picker";
+import styles from "./VertexPicker.module.css";
+
+export interface VertexPickerProps {
+  /** The current (live, un-debounced) prefix text. Fully controlled. */
+  value: string;
+  /** Called on every keystroke with the new prefix text. */
+  onValueChange: (next: string) => void;
+  /** Called when a suggestion is committed (click, ↵, or Tab). */
+  onSelect: (key: string) => void;
+  label?: string;
+  placeholder?: string;
+  autoFocus?: boolean;
+  disabled?: boolean;
+  /** Test id forwarded to the underlying `<input>`. */
+  inputTestId?: string;
+  /** Test id forwarded to the caption line. */
+  captionTestId?: string;
+  /** Tuning knobs forwarded to {@link useVertexPicker}. */
+  pickerOptions?: UseVertexPickerOptions;
+}
+
+/**
+ * Shared type-ahead picker for vertex keys (#457).
+ *
+ * Backed by ScanVertices (suggestions) + CountVerticesByPrefix
+ * ("N matches"), both debounced and cancellable via
+ * {@link useVertexPicker}. Built on a Fluent `Combobox` so ↑/↓ navigation,
+ * Esc-to-dismiss, and Tab-to-commit come for free; choosing an option
+ * (click, ↵, or Tab) calls {@link VertexPickerProps.onSelect}. The live
+ * input text is fully controlled by the parent, which decides what a
+ * commit means — open a new seed (SeedPrompt) or expand from a key
+ * (IlluminateToolbar).
+ */
+export function VertexPicker({
+  value,
+  onValueChange,
+  onSelect,
+  label = "Vertex key",
+  placeholder = "Type at least 1 character…",
+  autoFocus,
+  disabled,
+  inputTestId,
+  captionTestId,
+  pickerOptions,
+}: VertexPickerProps) {
+  const { state, suggestions } = useVertexPicker(value, pickerOptions);
+
+  const onChange = useCallback<NonNullable<ComboboxProps["onChange"]>>(
+    (event) => {
+      onValueChange(event.target.value);
+    },
+    [onValueChange],
+  );
+
+  const onOptionSelect = useCallback<
+    NonNullable<ComboboxProps["onOptionSelect"]>
+  >(
+    (_event, data) => {
+      const key = data.optionValue;
+      if (!key) {
+        return;
+      }
+      onValueChange(key);
+      onSelect(key);
+    },
+    [onSelect, onValueChange],
+  );
+
+  const caption = selectCaption(state);
+
+  return (
+    <Field label={label} className={styles.field}>
+      <Combobox
+        freeform
+        value={value}
+        placeholder={placeholder}
+        autoFocus={autoFocus}
+        disabled={disabled}
+        onChange={onChange}
+        onOptionSelect={onOptionSelect}
+        input={
+          inputTestId
+            ? ({ "data-testid": inputTestId } as ComboboxProps["input"])
+            : undefined
+        }
+      >
+        {suggestions.map((key) => (
+          <Option key={key} value={key} text={key}>
+            {key}
+          </Option>
+        ))}
+      </Combobox>
+      <Text
+        size={200}
+        aria-live="polite"
+        className={styles.caption}
+        data-testid={captionTestId}
+      >
+        {caption}
+      </Text>
+    </Field>
+  );
+}

--- a/admin/app/lib/client/usecase/vertex-picker/handlers.ts
+++ b/admin/app/lib/client/usecase/vertex-picker/handlers.ts
@@ -1,0 +1,89 @@
+import { countVerticesByPrefix } from "~/lib/client/infrastructure/api/count-vertices-by-prefix";
+import { LanternApiError } from "~/lib/client/infrastructure/api/error";
+import type { LanternClient } from "~/lib/client/infrastructure/api/lantern-client";
+import { scanVertices } from "~/lib/client/infrastructure/api/scan-vertices";
+import type { VertexPickerAction } from "./reducer";
+
+export interface FetchSuggestionsInput {
+  client: LanternClient;
+  prefix: string;
+  limit: number;
+  epoch: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Scans for the first `limit` vertex keys matching `prefix` and dispatches
+ * the resulting suggestions. As in Browse Vertices, `AbortError` is
+ * swallowed: cancelling an in-flight scan when the prefix moves on is
+ * normal control flow, not a failure.
+ */
+export async function fetchSuggestions(
+  input: FetchSuggestionsInput,
+  dispatch: (action: VertexPickerAction) => void,
+): Promise<void> {
+  dispatch({ type: "SCAN_REQUESTED", epoch: input.epoch });
+  try {
+    const response = await scanVertices(
+      input.client,
+      { prefix: input.prefix, limit: input.limit },
+      { signal: input.signal },
+    );
+    const suggestions = (response.vertices ?? [])
+      .map((vertex) => vertex.key ?? "")
+      .filter((key) => key.length > 0);
+    dispatch({ type: "SCAN_RECEIVED", epoch: input.epoch, suggestions });
+  } catch (err) {
+    if (isAbortError(err)) {
+      return;
+    }
+    dispatch({
+      type: "SCAN_FAILED",
+      epoch: input.epoch,
+      error: messageOf(err),
+    });
+  }
+}
+
+export interface FetchMatchCountInput {
+  client: LanternClient;
+  prefix: string;
+  epoch: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Counts total matches for `prefix` in parallel with the scan. The count
+ * is advisory, so a non-abort failure resolves to 0 rather than surfacing
+ * an error over the (more important) suggestion list.
+ */
+export async function fetchMatchCount(
+  input: FetchMatchCountInput,
+  dispatch: (action: VertexPickerAction) => void,
+): Promise<void> {
+  try {
+    const count = await countVerticesByPrefix(input.client, input.prefix, {
+      signal: input.signal,
+    });
+    dispatch({ type: "COUNT_RECEIVED", epoch: input.epoch, count });
+  } catch (err) {
+    if (isAbortError(err)) {
+      return;
+    }
+    dispatch({ type: "COUNT_RECEIVED", epoch: input.epoch, count: 0 });
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}
+
+function messageOf(err: unknown): string {
+  if (err instanceof LanternApiError) {
+    return err.grpcMessage ?? err.message;
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}

--- a/admin/app/lib/client/usecase/vertex-picker/reducer.test.ts
+++ b/admin/app/lib/client/usecase/vertex-picker/reducer.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "bun:test";
+import { vertexPickerReducer, type VertexPickerAction } from "./reducer";
+import { INITIAL_VERTEX_PICKER_STATE, type VertexPickerState } from "./state";
+
+function reduce(
+  state: VertexPickerState,
+  ...actions: VertexPickerAction[]
+): VertexPickerState {
+  return actions.reduce(vertexPickerReducer, state);
+}
+
+describe("vertexPickerReducer", () => {
+  it("bumps the epoch and clears prior results on a new prefix", () => {
+    const next = reduce(INITIAL_VERTEX_PICKER_STATE, {
+      type: "PREFIX_CHANGED",
+      prefix: "Distri",
+    });
+    expect(next.prefix).toBe("Distri");
+    expect(next.prefixEpoch).toBe(1);
+    expect(next.status).toBe("idle");
+    expect(next.suggestions).toEqual([]);
+    expect(next.matchCount).toBeNull();
+  });
+
+  it("ignores a PREFIX_CHANGED that does not change the prefix", () => {
+    const seeded = reduce(INITIAL_VERTEX_PICKER_STATE, {
+      type: "PREFIX_CHANGED",
+      prefix: "abc",
+    });
+    const same = vertexPickerReducer(seeded, {
+      type: "PREFIX_CHANGED",
+      prefix: "abc",
+    });
+    // Identity preserved → no epoch bump, no re-fetch.
+    expect(same).toBe(seeded);
+    expect(same.prefixEpoch).toBe(1);
+  });
+
+  it("resets to the empty state (but advances epoch) when the prefix is cleared", () => {
+    const seeded = reduce(
+      INITIAL_VERTEX_PICKER_STATE,
+      { type: "PREFIX_CHANGED", prefix: "abc" },
+      { type: "SCAN_REQUESTED", epoch: 1 },
+      { type: "SCAN_RECEIVED", epoch: 1, suggestions: ["abc"] },
+    );
+    const cleared = vertexPickerReducer(seeded, {
+      type: "PREFIX_CHANGED",
+      prefix: "",
+    });
+    expect(cleared.prefix).toBe("");
+    expect(cleared.suggestions).toEqual([]);
+    expect(cleared.matchCount).toBeNull();
+    expect(cleared.status).toBe("idle");
+    // Epoch still advances so any in-flight reply for "abc" is discarded.
+    expect(cleared.prefixEpoch).toBe(2);
+  });
+
+  it("applies scan + count results that match the live epoch", () => {
+    const next = reduce(
+      INITIAL_VERTEX_PICKER_STATE,
+      { type: "PREFIX_CHANGED", prefix: "Distri" },
+      { type: "SCAN_REQUESTED", epoch: 1 },
+      {
+        type: "SCAN_RECEIVED",
+        epoch: 1,
+        suggestions: ["Distributed_computing", "Distribution"],
+      },
+      { type: "COUNT_RECEIVED", epoch: 1, count: 42 },
+    );
+    expect(next.status).toBe("ready");
+    expect(next.suggestions).toEqual(["Distributed_computing", "Distribution"]);
+    expect(next.matchCount).toBe(42);
+  });
+
+  it("drops a stale scan response from an abandoned prefix (epoch guard)", () => {
+    // Type "ab" (epoch 1), then "abc" (epoch 2) before "ab"'s scan lands.
+    const seeded = reduce(
+      INITIAL_VERTEX_PICKER_STATE,
+      { type: "PREFIX_CHANGED", prefix: "ab" },
+      { type: "SCAN_REQUESTED", epoch: 1 },
+      { type: "PREFIX_CHANGED", prefix: "abc" },
+    );
+    expect(seeded.prefixEpoch).toBe(2);
+
+    // The slow reply for "ab" (epoch 1) arrives — it must be ignored.
+    const afterStale = vertexPickerReducer(seeded, {
+      type: "SCAN_RECEIVED",
+      epoch: 1,
+      suggestions: ["ab_stale"],
+    });
+    expect(afterStale).toBe(seeded);
+    expect(afterStale.suggestions).toEqual([]);
+
+    // The fresh reply for "abc" (epoch 2) is applied.
+    const afterFresh = vertexPickerReducer(afterStale, {
+      type: "SCAN_RECEIVED",
+      epoch: 2,
+      suggestions: ["abc_fresh"],
+    });
+    expect(afterFresh.suggestions).toEqual(["abc_fresh"]);
+  });
+
+  it("drops a stale count response (epoch guard)", () => {
+    const seeded = reduce(
+      INITIAL_VERTEX_PICKER_STATE,
+      { type: "PREFIX_CHANGED", prefix: "ab" },
+      { type: "PREFIX_CHANGED", prefix: "abc" },
+    );
+    const afterStaleCount = vertexPickerReducer(seeded, {
+      type: "COUNT_RECEIVED",
+      epoch: 1,
+      count: 999,
+    });
+    expect(afterStaleCount.matchCount).toBeNull();
+  });
+
+  it("records a scan failure and clears suggestions on the live epoch", () => {
+    const next = reduce(
+      INITIAL_VERTEX_PICKER_STATE,
+      { type: "PREFIX_CHANGED", prefix: "boom" },
+      { type: "SCAN_REQUESTED", epoch: 1 },
+      { type: "SCAN_RECEIVED", epoch: 1, suggestions: ["boom"] },
+      { type: "SCAN_FAILED", epoch: 1, error: "unavailable" },
+    );
+    expect(next.status).toBe("error");
+    expect(next.error).toBe("unavailable");
+    expect(next.suggestions).toEqual([]);
+  });
+});

--- a/admin/app/lib/client/usecase/vertex-picker/reducer.ts
+++ b/admin/app/lib/client/usecase/vertex-picker/reducer.ts
@@ -1,0 +1,76 @@
+import { INITIAL_VERTEX_PICKER_STATE, type VertexPickerState } from "./state";
+
+export type VertexPickerAction =
+  | { type: "PREFIX_CHANGED"; prefix: string }
+  | { type: "SCAN_REQUESTED"; epoch: number }
+  | { type: "SCAN_RECEIVED"; epoch: number; suggestions: string[] }
+  | { type: "SCAN_FAILED"; epoch: number; error: string }
+  | { type: "COUNT_RECEIVED"; epoch: number; count: number };
+
+/**
+ * Pure reducer for the vertex picker. The `epoch` guards make stale
+ * responses inert: any SCAN_* / COUNT_RECEIVED carrying an epoch other
+ * than the live `prefixEpoch` is dropped, so a slow reply from an
+ * abandoned prefix cannot overwrite fresher results even if its
+ * AbortController loses the race. This is the unit-testable heart of the
+ * debounce-and-cancel behaviour required by #457.
+ */
+export function vertexPickerReducer(
+  state: VertexPickerState,
+  action: VertexPickerAction,
+): VertexPickerState {
+  switch (action.type) {
+    case "PREFIX_CHANGED": {
+      if (action.prefix === state.prefix) {
+        return state;
+      }
+      const prefixEpoch = state.prefixEpoch + 1;
+      if (action.prefix.length === 0) {
+        // Empty prefix shows no suggestions and issues no request, but the
+        // epoch still advances so any in-flight reply is discarded.
+        return { ...INITIAL_VERTEX_PICKER_STATE, prefixEpoch };
+      }
+      return {
+        ...state,
+        prefix: action.prefix,
+        prefixEpoch,
+        status: "idle",
+        suggestions: [],
+        matchCount: null,
+        error: null,
+      };
+    }
+    case "SCAN_REQUESTED": {
+      if (action.epoch !== state.prefixEpoch) {
+        return state;
+      }
+      return { ...state, status: "loading", error: null };
+    }
+    case "SCAN_RECEIVED": {
+      if (action.epoch !== state.prefixEpoch) {
+        return state;
+      }
+      return { ...state, status: "ready", suggestions: action.suggestions };
+    }
+    case "SCAN_FAILED": {
+      if (action.epoch !== state.prefixEpoch) {
+        return state;
+      }
+      return {
+        ...state,
+        status: "error",
+        error: action.error,
+        suggestions: [],
+      };
+    }
+    case "COUNT_RECEIVED": {
+      if (action.epoch !== state.prefixEpoch) {
+        return state;
+      }
+      return { ...state, matchCount: action.count };
+    }
+    default: {
+      return state;
+    }
+  }
+}

--- a/admin/app/lib/client/usecase/vertex-picker/selectors.test.ts
+++ b/admin/app/lib/client/usecase/vertex-picker/selectors.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { formatMatchCount, selectCaption } from "./selectors";
+import { INITIAL_VERTEX_PICKER_STATE, type VertexPickerState } from "./state";
+
+describe("formatMatchCount", () => {
+  it("uses the singular noun for exactly one match", () => {
+    expect(formatMatchCount(1)).toBe("1 match");
+  });
+
+  it("groups digits with underscores", () => {
+    expect(formatMatchCount(0)).toBe("0 matches");
+    expect(formatMatchCount(42)).toBe("42 matches");
+    expect(formatMatchCount(1234)).toBe("1_234 matches");
+    expect(formatMatchCount(1234567)).toBe("1_234_567 matches");
+  });
+
+  it("renders the clamp ceiling with a trailing +", () => {
+    expect(formatMatchCount(Number.MAX_SAFE_INTEGER)).toBe(
+      "9_007_199_254_740_991+ matches",
+    );
+  });
+});
+
+describe("selectCaption", () => {
+  function state(partial: Partial<VertexPickerState>): VertexPickerState {
+    return { ...INITIAL_VERTEX_PICKER_STATE, ...partial };
+  }
+
+  it("prompts the user when the prefix is empty", () => {
+    expect(selectCaption(state({ prefix: "" }))).toBe(
+      "Type at least 1 character to search.",
+    );
+  });
+
+  it("surfaces the error message on a failed scan", () => {
+    expect(
+      selectCaption(
+        state({ prefix: "x", status: "error", error: "unavailable" }),
+      ),
+    ).toBe("unavailable");
+  });
+
+  it("reports the match count once known", () => {
+    expect(
+      selectCaption(state({ prefix: "x", status: "ready", matchCount: 3 })),
+    ).toBe("3 matches");
+  });
+
+  it("shows a settling label while the count is still pending", () => {
+    expect(
+      selectCaption(
+        state({ prefix: "x", status: "loading", matchCount: null }),
+      ),
+    ).toBe("Searching…");
+  });
+});

--- a/admin/app/lib/client/usecase/vertex-picker/selectors.ts
+++ b/admin/app/lib/client/usecase/vertex-picker/selectors.ts
@@ -1,0 +1,44 @@
+import type { VertexPickerState } from "./state";
+
+/**
+ * The ceiling `countVerticesByPrefix` clamps to (wire `uint64` →
+ * `Number.MAX_SAFE_INTEGER`). Rendered with a trailing `+` so the user
+ * knows the true count may be larger than what JavaScript can represent
+ * exactly.
+ */
+const MATCH_CEILING = Number.MAX_SAFE_INTEGER;
+
+/** Groups digits with underscores: 1234567 → "1_234_567". */
+function groupDigits(n: number): string {
+  return Math.trunc(n)
+    .toString()
+    .replace(/\B(?=(\d{3})+(?!\d))/g, "_");
+}
+
+/**
+ * Formats a match count as "N matches" with underscore digit grouping.
+ * The clamp ceiling renders as "9_007_199_254_740_991+ matches".
+ */
+export function formatMatchCount(count: number): string {
+  const noun = count === 1 ? "match" : "matches";
+  const suffix = count >= MATCH_CEILING ? "+" : "";
+  return `${groupDigits(count)}${suffix} ${noun}`;
+}
+
+/**
+ * Caption rendered beneath the combobox. Mirrors the picker lifecycle: an
+ * empty prefix prompts the user, a failed scan surfaces the error, a known
+ * count reports "N matches"; otherwise the search is still settling.
+ */
+export function selectCaption(state: VertexPickerState): string {
+  if (state.prefix.length === 0) {
+    return "Type at least 1 character to search.";
+  }
+  if (state.status === "error") {
+    return state.error ?? "Search failed.";
+  }
+  if (state.matchCount !== null) {
+    return formatMatchCount(state.matchCount);
+  }
+  return "Searching…";
+}

--- a/admin/app/lib/client/usecase/vertex-picker/state.ts
+++ b/admin/app/lib/client/usecase/vertex-picker/state.ts
@@ -1,0 +1,36 @@
+/**
+ * State for the type-ahead vertex picker (#457).
+ *
+ * The picker debounces the user's prefix, scans for matching vertex keys,
+ * and counts the total matches in parallel. Async I/O lives in
+ * `handlers.ts`; this module and `reducer.ts` are the pure, unit-testable
+ * core. Every server response carries the `prefixEpoch` it was issued
+ * under so a stale reply from an abandoned prefix can never clobber the
+ * current suggestions — the same cancellation invariant Browse Vertices
+ * (#409) relies on.
+ */
+export type VertexPickerStatus = "idle" | "loading" | "ready" | "error";
+
+export interface VertexPickerState {
+  /** The debounced prefix currently being searched. */
+  prefix: string;
+  /** Monotonic counter bumped on every prefix change. */
+  prefixEpoch: number;
+  /** Lifecycle of the in-flight (or last completed) scan. */
+  status: VertexPickerStatus;
+  /** Vertex keys matching `prefix`, in server order. */
+  suggestions: string[];
+  /** Total matches for `prefix`, or `null` before the count arrives. */
+  matchCount: number | null;
+  /** Human-readable error from the last failed scan, if any. */
+  error: string | null;
+}
+
+export const INITIAL_VERTEX_PICKER_STATE: VertexPickerState = {
+  prefix: "",
+  prefixEpoch: 0,
+  status: "idle",
+  suggestions: [],
+  matchCount: null,
+  error: null,
+};

--- a/admin/app/lib/client/usecase/vertex-picker/use-vertex-picker.ts
+++ b/admin/app/lib/client/usecase/vertex-picker/use-vertex-picker.ts
@@ -1,0 +1,96 @@
+import { useEffect, useMemo, useReducer, useRef } from "react";
+import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
+import { fetchMatchCount, fetchSuggestions } from "./handlers";
+import { vertexPickerReducer, type VertexPickerAction } from "./reducer";
+import { INITIAL_VERTEX_PICKER_STATE, type VertexPickerState } from "./state";
+
+/**
+ * Debounce window for prefix typing, in milliseconds. Tighter than Browse
+ * Vertices (200 ms) because the picker is a foreground type-and-pick
+ * affordance where latency is felt keenly, yet still wide enough that a
+ * fast typist never fires a request per keystroke (#457 acceptance: no
+ * request sooner than 100 ms after the previous one).
+ */
+export const SUGGEST_DEBOUNCE_MS = 150;
+
+/**
+ * Cap on the number of suggestions requested per keystroke. Kept small so
+ * the dropdown stays scannable and well under the server's scan default.
+ */
+export const DEFAULT_SUGGESTION_LIMIT = 20;
+
+export interface UseVertexPickerOptions {
+  limit?: number;
+  debounceMs?: number;
+}
+
+export interface UseVertexPickerResult {
+  state: VertexPickerState;
+  suggestions: string[];
+}
+
+/**
+ * Wires the pure picker reducer + handlers to the live Lantern client.
+ * Owns a single AbortController per prefix epoch so a fresh keystroke
+ * cancels the previous scan and count immediately; the reducer's epoch
+ * guards make any reply that still lands inert.
+ */
+export function useVertexPicker(
+  rawPrefix: string,
+  options: UseVertexPickerOptions = {},
+): UseVertexPickerResult {
+  const limit = options.limit ?? DEFAULT_SUGGESTION_LIMIT;
+  const debounceMs = options.debounceMs ?? SUGGEST_DEBOUNCE_MS;
+  const client = useLanternClient();
+  const [state, dispatch] = useReducer(
+    vertexPickerReducer,
+    INITIAL_VERTEX_PICKER_STATE,
+  );
+
+  // Debounce the live prefix into the reducer.
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      dispatch({ type: "PREFIX_CHANGED", prefix: rawPrefix });
+    }, debounceMs);
+    return () => window.clearTimeout(handle);
+  }, [rawPrefix, debounceMs]);
+
+  // On every prefix change, scan + count under a fresh AbortController.
+  const lastEpochRef = useRef<number>(-1);
+  useEffect(() => {
+    if (state.prefixEpoch === lastEpochRef.current) {
+      return;
+    }
+    lastEpochRef.current = state.prefixEpoch;
+    if (state.prefix.length === 0) {
+      // Empty prefix: nothing to fetch (the reducer already cleared state).
+      return;
+    }
+    const controller = new AbortController();
+    void fetchSuggestions(
+      {
+        client,
+        prefix: state.prefix,
+        limit,
+        epoch: state.prefixEpoch,
+        signal: controller.signal,
+      },
+      dispatch as (action: VertexPickerAction) => void,
+    );
+    void fetchMatchCount(
+      {
+        client,
+        prefix: state.prefix,
+        epoch: state.prefixEpoch,
+        signal: controller.signal,
+      },
+      dispatch as (action: VertexPickerAction) => void,
+    );
+    return () => controller.abort();
+  }, [client, state.prefix, state.prefixEpoch, limit]);
+
+  return useMemo<UseVertexPickerResult>(
+    () => ({ state, suggestions: state.suggestions }),
+    [state],
+  );
+}

--- a/admin/tests/e2e/illuminate.spec.ts
+++ b/admin/tests/e2e/illuminate.spec.ts
@@ -55,6 +55,40 @@ test.describe("/illuminate", () => {
     await expect(page.getByTestId("illuminate-open")).toBeDisabled();
   });
 
+  test("Seed prompt suggests keys as you type and opens on commit (#457)", async ({
+    page,
+  }) => {
+    await page.goto("/illuminate");
+    await expect(page.getByTestId("illuminate-seed-prompt")).toBeVisible();
+
+    // Empty prefix shows the placeholder caption, not a count.
+    await expect(page.getByTestId("illuminate-seed-matches")).toContainText(
+      /at least/i,
+    );
+
+    const input = page.getByTestId("illuminate-seed-input");
+    await input.click();
+    await input.pressSequentially("e2e:illum:left");
+
+    // CountVerticesByPrefix surfaces a match tally beneath the field.
+    await expect(page.getByTestId("illuminate-seed-matches")).toContainText(
+      /\d+ match/,
+    );
+
+    // ScanVertices feeds the Combobox listbox; the three `left*` keys all
+    // share the typed prefix, so the exact `leftleft` option is offered.
+    const option = page.getByRole("option", {
+      name: "e2e:illum:leftleft",
+      exact: true,
+    });
+    await expect(option).toBeVisible();
+    await option.click();
+
+    // Committing a suggestion opens that neighbourhood (no Browse detour).
+    await expect(page.getByTestId("illuminate-toolbar")).toBeVisible();
+    await expect(page).toHaveURL(/\?seed=e2e%3Aillum%3Aleftleft/);
+  });
+
   test("renders the canvas and neighbour table for a seed", async ({
     page,
   }) => {
@@ -158,6 +192,42 @@ test.describe("/illuminate", () => {
     await expect(
       table.getByRole("link", { name: "e2e:illum:leftleftleft", exact: true }),
     ).toBeVisible();
+  });
+
+  test("Expand from key (toolbar typeahead) ADDS a neighbourhood in place (#457)", async ({
+    page,
+  }) => {
+    const seed = encodeURIComponent("e2e:illum:hub");
+    await page.goto(`/illuminate?seed=${seed}`);
+    await expect(page.getByTestId("illuminate-toolbar")).toBeVisible();
+
+    const counter = page.getByTestId("illuminate-counter");
+    await expect(counter).toContainText("5 vertices");
+
+    // Open the inline Expand-from-key picker from the toolbar.
+    await page.getByTestId("illuminate-expand-toggle").click();
+    const input = page.getByTestId("illuminate-expand-input");
+    await expect(input).toBeVisible();
+    await input.click();
+    await input.pressSequentially("e2e:illum:leftleft");
+
+    // Commit the suggestion that bridges to a vertex outside the initial
+    // 2-hop frame (`leftleftleft` is 3 hops from hub).
+    const option = page.getByRole("option", {
+      name: "e2e:illum:leftleft",
+      exact: true,
+    });
+    await expect(option).toBeVisible();
+    await option.click();
+
+    // The accumulator grows additively (5 → 6) and the deep-link URL stays
+    // anchored on the original seed (the picker dispatches `ill.expand`,
+    // not a fresh navigation).
+    await expect(counter).toContainText("6 vertices");
+    await expect(counter).toContainText("2 expansions");
+    await expect(page).toHaveURL(/\?seed=e2e%3Aillum%3Ahub/);
+    // The picker collapses once a key is committed.
+    await expect(input).toHaveCount(0);
   });
 
   test("Clear empties the accumulator and returns to the seed prompt", async ({


### PR DESCRIPTION
## What

Replaces the blind seed `<Input>` on the Illuminate route with a debounced
type-ahead **`<VertexPicker>`** shared component, and reuses that same picker
for a toolbar **"Expand from key…"** affordance.

Closes #457.

## Why

Operators had to know an exact key (or bounce through the Browse screen) to
start an exploration. Now keys are suggested live from `ScanVertices` and the
total tally is surfaced from `CountVerticesByPrefix`, so a partial prefix is
enough to find and commit a seed in place.

## How

**`app/lib/client/usecase/vertex-picker/`** (new usecase):

- `use-vertex-picker.ts` — `SUGGEST_DEBOUNCE_MS = 150`,
  `DEFAULT_SUGGESTION_LIMIT = 20`. Debounces the raw prefix, then on each
  epoch change spins a fresh `AbortController` and fires `ScanVertices` +
  `CountVerticesByPrefix` in parallel, returning `() => controller.abort()`
  so a new keystroke cancels the in-flight pair.
- `reducer.ts` — every prefix change bumps `prefixEpoch`; scan/count actions
  carry the epoch they were issued under and are **dropped when stale**
  (`action.epoch !== state.prefixEpoch`). This is the race guard that makes
  "no response faster than the next keystroke can clobber the listbox" a
  unit-tested invariant rather than a timing hope.
- `selectors.ts` — `formatMatchCount` groups digits with `_` and appends a
  `+` sentinel at `Number.MAX_SAFE_INTEGER` (mirrors the count adapter's
  clamp); `selectCaption` drives the "type at least 1 character" / "N matches"
  / error copy.

**`app/components/shared/VertexPicker/`** (new component): a Fluent
`Combobox` in `freeform` mode. Suggestions render as `Option`s; ↵ / click /
Tab commit through `onSelect(key)`; an `aria-live="polite"` caption shows the
match tally. ↑/↓/Esc/Tab are native.

**Consumers:**

- `SeedPrompt` opens straight from a committed suggestion — no Browse detour.
  Existing test ids (`illuminate-seed-input`, `-open`, `-prompt`) preserved.
- `IlluminateToolbar` gains an inline **"Expand from key…"** disclosure. I
  used an inline row rather than a Fluent `Popover` to avoid nested-portal
  focus-trap fights between the popover's dismiss-on-outside-click and the
  Combobox's portaled listbox. Committing dispatches `ill.expand(key)`, i.e.
  an **additive** expansion under #466 (the accumulator grows; the deep-link
  URL stays anchored on the original seed) rather than a seed replacement.
  This is the home for the "change/expand seed" interaction that #466's note
  deferred.

## Tests

- **Unit** (`bun test app`): `reducer.test.ts` (epoch bump/clear, stale-scan
  and stale-count drop, failure clears suggestions) + `selectors.test.ts`
  (`formatMatchCount` grouping + MAX_SAFE_INTEGER sentinel, all caption
  branches). 360/360 pass.
- **e2e** (`illuminate.spec.ts`): (1) type a prefix → a suggestion Option
  appears + `N matches` caption → commit opens that neighbourhood; (2) toolbar
  Expand-from-key grows the accumulator 5→6 **in place** without changing the
  `?seed=` URL. 14/14 illuminate specs pass.

Hooks and handlers have no unit-test siblings by repo convention (no React
test renderer in-tree); their behaviour is covered by the e2e flows above and
the reducer-level epoch-cancel invariant.

Gates run locally from `admin/`: `typecheck`, `lint`, `format`, `bun test app`,
`build`, `playwright test`. (The full e2e run can flake under 7 local workers
on the shared listener — crud edge-delete — but passes single-worker; CI runs
`workers: 1` + 2 retries.)