### PR TITLE
feat(admin): per-node info-icon overlay opens NodeDetailPanel Drawer (#461)

### DIFF
--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.module.css
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.module.css
@@ -51,6 +51,39 @@
   font-size: var(--fontSizeBase200, 12px);
 }
 
+/* #461: per-node info icon. The only canvas overlay that takes pointer
+   events (pointer-events: auto) so the user can click it to open the
+   detail Drawer; sits above the tooltip/legend (z-index 3). */
+.infoIcon {
+  position: absolute;
+  left: var(--icon-x, 0px);
+  top: var(--icon-y, 0px);
+  pointer-events: auto;
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  margin: 0;
+  color: var(--colorNeutralForegroundOnBrand, #fff);
+  background: var(--colorBrandBackground, #0f6cbd);
+  border: none;
+  border-radius: var(--borderRadiusCircular, 9999px);
+  box-shadow: var(--shadow8, 0 2px 8px rgba(0, 0, 0, 0.18));
+  cursor: pointer;
+}
+
+.infoIcon:hover {
+  background: var(--colorBrandBackgroundHover, #115ea3);
+}
+
+.infoIcon:focus-visible {
+  outline: 2px solid var(--colorStrokeFocus2, #000);
+  outline-offset: 1px;
+}
+
 .tooltipKind {
   color: var(--colorNeutralForeground3, #707070);
   text-transform: lowercase;

--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -10,6 +10,7 @@ import {
 import Graph from "graphology";
 import forceAtlas2 from "graphology-layout-forceatlas2";
 import Sigma from "sigma";
+import { Info16Regular } from "@fluentui/react-icons";
 import type {
   GraphEdge,
   GraphNode,
@@ -45,6 +46,14 @@ export interface IlluminateCanvasProps {
    */
   latestExpansionOrigin: string | null;
   onNodeClick: (key: string) => void;
+  /**
+   * Fired when the user activates a node's info icon (#461). Distinct
+   * from `onNodeClick` (which drives the additive expansion on a node
+   * body click): inspecting opens the read-only detail Drawer and must
+   * NOT expand or refetch. Optional so the canvas stays reusable from
+   * contexts that don't surface a detail panel.
+   */
+  onNodeInspect?: (key: string) => void;
   /** When true, the canvas dims to communicate a stale frame. */
   isBusy: boolean;
   /**
@@ -85,6 +94,35 @@ interface HoverState {
 }
 
 /**
+ * Per-node info-icon position (#461). Viewport-pixel coordinates of the
+ * icon button that, when activated, opens the read-only detail Drawer.
+ */
+interface InfoIconState {
+  key: string;
+  x: number;
+  y: number;
+}
+
+/**
+ * #461 info-icon tuning.
+ *
+ * - `INFO_ICON_HIDE_DELAY_MS`: grace period after the cursor leaves a
+ *   node before the icon hides, so the user can travel from the node to
+ *   the icon without it disappearing (the standard hover-bridge
+ *   pattern).
+ * - `INFO_ICON_DRAG_TOLERANCE_PX`: pointer travel (viewport px) at or
+ *   below which a press → release on the icon counts as a click; beyond
+ *   it the gesture is treated as a drag and the inspect is suppressed so
+ *   #455 drag-to-pin keeps precedence.
+ * - `INFO_ICON_OFFSET_*`: where the icon sits relative to the node's
+ *   viewport centre.
+ */
+const INFO_ICON_HIDE_DELAY_MS = 160;
+const INFO_ICON_DRAG_TOLERANCE_PX = 4;
+const INFO_ICON_OFFSET_X = 10;
+const INFO_ICON_OFFSET_Y = 18;
+
+/**
  * Hosts a `graphology` graph and a `sigma` renderer. The component owns
  * the lifecycle of the renderer (mount on first paint, destroy on unmount)
  * and reconciles the graph in-place when the view model changes — full
@@ -96,6 +134,7 @@ export function IlluminateCanvas({
   edges,
   latestExpansionOrigin,
   onNodeClick,
+  onNodeInspect,
   isBusy,
   ref,
 }: IlluminateCanvasProps) {
@@ -149,6 +188,26 @@ export function IlluminateCanvas({
    */
   const tickCountRef = useRef<number>(0);
   const [hover, setHover] = useState<HoverState | null>(null);
+  /**
+   * #461 per-node info icon. `null` when no node is hovered. Held as
+   * React state (not a ref) because the icon is rendered declaratively
+   * in JSX; a ref mirror ({@link infoIconRef}) lets the mount-effect
+   * closure (test bridge) read it without re-installing handlers.
+   */
+  const [infoIcon, setInfoIcon] = useState<InfoIconState | null>(null);
+  const infoIconRef = useRef<InfoIconState | null>(null);
+  useEffect(() => {
+    infoIconRef.current = infoIcon;
+  }, [infoIcon]);
+  /**
+   * Viewport coords of the pointer-down that began the current info-icon
+   * press (#461). Compared against the click position so a press that
+   * travelled more than {@link INFO_ICON_DRAG_TOLERANCE_PX} is treated
+   * as a drag and suppresses the inspect — keeping #455 drag-to-pin the
+   * dominant gesture. `null` for keyboard activation, which always
+   * inspects.
+   */
+  const infoIconPointerDownRef = useRef<{ x: number; y: number } | null>(null);
   const [palette, setPalette] = useState<SigmaPalette>(FALLBACK_PALETTE);
   // The mount effect runs ONCE, so any palette swatch read inside the
   // hover-focus reducer (#458) needs a ref so it tracks the latest
@@ -179,6 +238,22 @@ export function IlluminateCanvas({
   useEffect(() => {
     onNodeClickRef.current = onNodeClick;
   }, [onNodeClick]);
+
+  // #461: stable ref to the inspect callback, read at event time inside
+  // the once-mounted sigma effect (and by the info-icon click handler)
+  // so we never rebind sigma listeners when the parent re-renders.
+  const onNodeInspectRef = useRef(onNodeInspect);
+  useEffect(() => {
+    onNodeInspectRef.current = onNodeInspect;
+  }, [onNodeInspect]);
+
+  // #461 hover-bridge plumbing. The pending-hide timer lives in the
+  // mount-effect closure (it owns the sigma handlers), but the
+  // JSX-rendered icon needs to cancel/re-arm that timer from its own
+  // mouse events. These refs publish the closure's cancel/schedule
+  // helpers to the render body.
+  const cancelInfoIconHideRef = useRef<(() => void) | null>(null);
+  const scheduleInfoIconHideRef = useRef<(() => void) | null>(null);
 
   // #456 imperative handle. Reads from `graphRef`/`sigmaRef` at call
   // time so the closure stays valid across re-renders without any
@@ -404,6 +479,54 @@ export function IlluminateCanvas({
     renderer.setSetting("zIndex", true);
     // === end #458 ===========================================================
 
+    // === #461 per-node info icon ===========================================
+    // On hover, surface a small info button anchored near the node's
+    // viewport position. Activating it opens the read-only detail Drawer
+    // (the parent's `onNodeInspect`) WITHOUT expanding — node-body
+    // clicks keep their #466 additive-expansion meaning. A short hide
+    // delay lets the cursor travel from the node onto the icon without
+    // it vanishing; the icon's own `onMouseEnter` cancels the pending
+    // hide (the standard hover-bridge pattern).
+    let infoIconHideTimer: ReturnType<typeof setTimeout> | null = null;
+    const computeIconViewport = (
+      key: string,
+    ): { x: number; y: number } | null => {
+      const display = renderer.getNodeDisplayData(key);
+      if (!display) return null;
+      // `getNodeDisplayData` is in sigma's framed-graph space; convert
+      // to viewport pixels so the DOM overlay lands on the node.
+      const vp = renderer.framedGraphToViewport({
+        x: display.x,
+        y: display.y,
+      });
+      return { x: vp.x + INFO_ICON_OFFSET_X, y: vp.y - INFO_ICON_OFFSET_Y };
+    };
+    const showInfoIconFor = (key: string): boolean => {
+      if (infoIconHideTimer !== null) {
+        clearTimeout(infoIconHideTimer);
+        infoIconHideTimer = null;
+      }
+      const pos = computeIconViewport(key);
+      if (!pos) return false;
+      setInfoIcon({ key, x: pos.x, y: pos.y });
+      return true;
+    };
+    const scheduleInfoIconHide = () => {
+      if (infoIconHideTimer !== null) clearTimeout(infoIconHideTimer);
+      infoIconHideTimer = setTimeout(() => {
+        infoIconHideTimer = null;
+        setInfoIcon(null);
+      }, INFO_ICON_HIDE_DELAY_MS);
+    };
+    cancelInfoIconHideRef.current = () => {
+      if (infoIconHideTimer !== null) {
+        clearTimeout(infoIconHideTimer);
+        infoIconHideTimer = null;
+      }
+    };
+    scheduleInfoIconHideRef.current = scheduleInfoIconHide;
+    // === end #461 ===========================================================
+
     const showNodeHover = (event: {
       node: string;
       event: { x: number; y: number };
@@ -421,6 +544,8 @@ export function IlluminateCanvas({
       });
       // #458: trigger hover focus mode for the node under the cursor.
       setHoveredNode(event.node);
+      // #461: surface the per-node info icon near the hovered node.
+      showInfoIconFor(event.node);
     };
     const showEdgeHover = (event: {
       edge: string;
@@ -448,6 +573,9 @@ export function IlluminateCanvas({
       setHover(null);
       // #458: leaving any node/edge restores the full graph.
       setHoveredNode(null);
+      // #461: arm the delayed hide so the cursor can bridge onto the
+      // icon before it disappears.
+      scheduleInfoIconHide();
     };
     renderer.on("enterNode", showNodeHover);
     renderer.on("leaveNode", clearHoverNode);
@@ -615,6 +743,24 @@ export function IlluminateCanvas({
          * e2e confirm the pulse fires (and later clears).
          */
         isNodeHighlighted: (key: string) => boolean;
+        /**
+         * #461 test bridge: open the detail Drawer for a node exactly as
+         * the info-icon click would, bypassing the WebGL hover + DOM
+         * click headless chromium populates only intermittently. Returns
+         * `false` when the key isn't in the live graph.
+         */
+        inspectNode: (key: string) => boolean;
+        /**
+         * #461 test bridge: surface the per-node info icon for a node as
+         * a real `enterNode` hover would. Returns `false` when the key
+         * isn't in the live graph or has no display data yet.
+         */
+        showInfoIcon: (key: string) => boolean;
+        /**
+         * #461 test bridge: the key of the node whose info icon is
+         * currently visible, or `null` when none is shown.
+         */
+        infoIconNode: () => string | null;
       };
     };
     win.__illuminateCanvas = {
@@ -715,6 +861,16 @@ export function IlluminateCanvas({
         if (!graph.hasNode(key)) return false;
         return graph.getNodeAttribute(key, "highlighted") === true;
       },
+      inspectNode: (key: string) => {
+        if (!graph.hasNode(key)) return false;
+        onNodeInspectRef.current?.(key);
+        return true;
+      },
+      showInfoIcon: (key: string) => {
+        if (!graph.hasNode(key)) return false;
+        return showInfoIconFor(key);
+      },
+      infoIconNode: () => infoIconRef.current?.key ?? null,
     };
 
     return () => {
@@ -723,6 +879,12 @@ export function IlluminateCanvas({
       sigmaRef.current = null;
       graphRef.current = null;
       previousNodeIdsRef.current = new Set();
+      if (infoIconHideTimer !== null) {
+        clearTimeout(infoIconHideTimer);
+        infoIconHideTimer = null;
+      }
+      cancelInfoIconHideRef.current = null;
+      scheduleInfoIconHideRef.current = null;
       delete win.__illuminateCanvas;
     };
   }, []);
@@ -1081,6 +1243,41 @@ export function IlluminateCanvas({
             <div className={styles.tooltipDetail}>{hover.detail}</div>
           ) : null}
         </div>
+      ) : null}
+      {infoIcon ? (
+        <button
+          type="button"
+          className={styles.infoIcon}
+          data-testid="illuminate-info-icon"
+          aria-label={`Inspect ${infoIcon.key}`}
+          ref={(el) => {
+            if (!el) return;
+            el.style.setProperty("--icon-x", `${infoIcon.x}px`);
+            el.style.setProperty("--icon-y", `${infoIcon.y}px`);
+          }}
+          onPointerDown={(e) => {
+            e.stopPropagation();
+            infoIconPointerDownRef.current = { x: e.clientX, y: e.clientY };
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            const down = infoIconPointerDownRef.current;
+            infoIconPointerDownRef.current = null;
+            // A pointer press that travelled too far is a drag, not a
+            // click — suppress so #455 drag-to-pin wins. `down === null`
+            // means keyboard activation (Enter/Space), which inspects.
+            if (down) {
+              const moved = Math.hypot(e.clientX - down.x, e.clientY - down.y);
+              if (moved > INFO_ICON_DRAG_TOLERANCE_PX) return;
+            }
+            onNodeInspectRef.current?.(infoIcon.key);
+            setInfoIcon(null);
+          }}
+          onMouseEnter={() => cancelInfoIconHideRef.current?.()}
+          onMouseLeave={() => scheduleInfoIconHideRef.current?.()}
+        >
+          <Info16Regular />
+        </button>
       ) : null}
     </div>
   );

--- a/admin/app/components/illuminate/IlluminatePage/IlluminatePage.tsx
+++ b/admin/app/components/illuminate/IlluminatePage/IlluminatePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { MessageBar, MessageBarBody } from "@fluentui/react-components";
 import { useNavigate, useSearchParams } from "react-router";
 import {
@@ -7,8 +7,10 @@ import {
 } from "../IlluminateCanvas/IlluminateCanvas";
 import { IlluminateTable } from "../IlluminateTable/IlluminateTable";
 import { IlluminateToolbar } from "../IlluminateToolbar/IlluminateToolbar";
+import { NodeDetailPanel } from "../NodeDetailPanel/NodeDetailPanel";
 import { SeedPrompt } from "../SeedPrompt/SeedPrompt";
 import { useIlluminate } from "~/lib/client/usecase/illuminate/use-illuminate";
+import { selectInspectedDetail } from "~/lib/client/usecase/illuminate/selectors";
 import { ACCUMULATOR_SOFT_CAP } from "~/lib/client/usecase/illuminate/state";
 import styles from "./IlluminatePage.module.css";
 
@@ -29,13 +31,35 @@ export function IlluminatePage() {
 
   const canvasRef = useRef<IlluminateCanvasHandle | null>(null);
 
+  // #461 node-detail Drawer. The inspected vertex is pure UI state
+  // (page-local) — opening/closing never touches the accumulator,
+  // expansions, or camera. The selector projects the live accumulator
+  // into the panel's view-model and returns null once the vertex is
+  // gone (TTL sweep), so the Drawer self-closes without extra wiring.
+  const [inspectedVertex, setInspectedVertex] = useState<string | null>(null);
+  const inspectedDetail = useMemo(
+    () => selectInspectedDetail(ill.state, inspectedVertex),
+    [ill.state, inspectedVertex],
+  );
+
   const handleNodeClick = useCallback(
     (key: string) => {
       if (!key) return;
-      // Per #466 D11 the expand is idempotent — even when the user clicks
-      // the same node twice we fire the request so they can pick up newly
-      // arrived neighbours (server-side decay).
+      // A node-body click is an additive expansion (#466 D11, idempotent).
+      // It also dismisses the inspect Drawer so a body click never leaves
+      // a stale panel open over the freshly expanded neighbourhood.
+      setInspectedVertex(null);
       ill.expand(key);
+    },
+    [ill],
+  );
+
+  // #461 "Expand from here": same additive expansion as a body click,
+  // then close the Drawer so the canvas takes focus on the new nodes.
+  const handleExpandFromHere = useCallback(
+    (key: string) => {
+      ill.expand(key);
+      setInspectedVertex(null);
     },
     [ill],
   );
@@ -116,7 +140,13 @@ export function IlluminatePage() {
             edges={ill.view.edges}
             latestExpansionOrigin={ill.view.latestExpansionOrigin}
             onNodeClick={handleNodeClick}
+            onNodeInspect={setInspectedVertex}
             isBusy={ill.isBusy}
+          />
+          <NodeDetailPanel
+            detail={inspectedDetail}
+            onClose={() => setInspectedVertex(null)}
+            onExpandFromHere={handleExpandFromHere}
           />
           <details className={styles.tableDisclosure}>
             <summary className={styles.summary}>

--- a/admin/app/components/illuminate/NodeDetailPanel/NodeDetailPanel.module.css
+++ b/admin/app/components/illuminate/NodeDetailPanel/NodeDetailPanel.module.css
@@ -1,0 +1,114 @@
+.drawer {
+  width: min(420px, 100vw);
+}
+
+.headerLabel {
+  font-weight: var(--fontWeightSemibold, 600);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: var(--fontSizeBase200, 12px);
+  font-weight: var(--fontWeightSemibold, 600);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--colorNeutralForeground3, #616161);
+}
+
+.keyRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.key {
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  font-size: var(--fontSizeBase300, 14px);
+  overflow-wrap: anywhere;
+}
+
+.copied {
+  font-size: var(--fontSizeBase200, 12px);
+  color: var(--colorPaletteGreenForeground1, #0e700e);
+}
+
+.empty {
+  margin: 0;
+  font-size: var(--fontSizeBase200, 12px);
+  color: var(--colorNeutralForeground3, #616161);
+}
+
+.edgeList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.edgeRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--fontSizeBase200, 12px);
+}
+
+.edgeArrow {
+  color: var(--colorNeutralForeground3, #616161);
+}
+
+.edgeTarget {
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  overflow-wrap: anywhere;
+}
+
+.edgeWeight {
+  margin-left: auto;
+  color: var(--colorNeutralForeground3, #616161);
+  font-variant-numeric: tabular-nums;
+}
+
+.inboundError {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.errorText {
+  margin: 0;
+  font-size: var(--fontSizeBase200, 12px);
+  color: var(--colorPaletteRedForeground1, #b10e1c);
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}

--- a/admin/app/components/illuminate/NodeDetailPanel/NodeDetailPanel.tsx
+++ b/admin/app/components/illuminate/NodeDetailPanel/NodeDetailPanel.tsx
@@ -1,0 +1,298 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Button,
+  DrawerBody,
+  DrawerHeader,
+  DrawerHeaderTitle,
+  OverlayDrawer,
+  Spinner,
+  Tooltip,
+} from "@fluentui/react-components";
+import {
+  ArrowExpand20Regular,
+  Copy16Regular,
+  Dismiss20Regular,
+  Open20Regular,
+} from "@fluentui/react-icons";
+import { useNavigate } from "react-router";
+import { ExpirationCell } from "~/components/browse-vertices/ExpirationCell/ExpirationCell";
+import { ValueCell } from "~/components/browse-vertices/ValueCell/ValueCell";
+import type { InspectedVertexDetail } from "~/lib/client/usecase/illuminate/selectors";
+import { edgeIdOf } from "~/lib/client/usecase/illuminate/state";
+import { useInboundEdges } from "~/lib/client/usecase/illuminate/use-inbound-edges";
+import styles from "./NodeDetailPanel.module.css";
+
+export interface NodeDetailPanelProps {
+  /**
+   * The inspected vertex's view-model, or `null` when the Drawer is
+   * closed. Driving `open` straight off this prop means a TTL sweep that
+   * drops the inspected vertex (selector returns `null`) auto-closes the
+   * Drawer with no extra wiring (#461).
+   */
+  detail: InspectedVertexDetail | null;
+  /** Dismiss the Drawer (Esc, close button, or backdrop) → clears selection. */
+  onClose: () => void;
+  /**
+   * "Expand from here" — fire an additive expansion from the inspected
+   * vertex (same path as a node-body click) and close the Drawer (#461).
+   */
+  onExpandFromHere: (key: string) => void;
+}
+
+const COPIED_RESET_MS = 1_200;
+
+/**
+ * Read-only inspector for a single vertex, surfaced as an end-anchored
+ * Fluent Drawer (#461). Opens from the per-node info icon on the canvas;
+ * shows the vertex key (with copy-to-clipboard), its decoded value and
+ * expiration, the outgoing edges already in the accumulator (no fetch),
+ * and an on-demand "Show inbound edges" action that scans for edges
+ * terminating at this vertex WITHOUT merging them into the canvas
+ * accumulator (the canvas stays the sole graph owner per #466).
+ *
+ * Non-modal so the canvas stays interactive while the Drawer is pinned —
+ * #458 hover focus keeps following the cursor underneath it.
+ */
+export function NodeDetailPanel({
+  detail,
+  onClose,
+  onExpandFromHere,
+}: NodeDetailPanelProps) {
+  const navigate = useNavigate();
+  const inbound = useInboundEdges(detail?.key ?? null);
+  const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear the transient "Copied" badge whenever the inspected vertex
+  // changes or the component unmounts, so it never lingers on the wrong
+  // key.
+  useEffect(() => {
+    setCopied(false);
+    return () => {
+      if (copiedTimerRef.current) {
+        clearTimeout(copiedTimerRef.current);
+        copiedTimerRef.current = null;
+      }
+    };
+  }, [detail?.key]);
+
+  const copyKey = useCallback(async (key: string) => {
+    try {
+      await navigator.clipboard?.writeText(key);
+      setCopied(true);
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+      copiedTimerRef.current = setTimeout(() => {
+        setCopied(false);
+        copiedTimerRef.current = null;
+      }, COPIED_RESET_MS);
+    } catch {
+      // Clipboard can reject in insecure contexts / when permission is
+      // denied. The key is still visible in the header, so there's
+      // nothing to recover — just skip the "Copied" affordance.
+    }
+  }, []);
+
+  const open = detail !== null;
+
+  return (
+    <OverlayDrawer
+      as="aside"
+      position="end"
+      modalType="non-modal"
+      open={open}
+      onOpenChange={(_, data) => {
+        if (!data.open) onClose();
+      }}
+      data-testid="illuminate-node-detail"
+      className={styles.drawer}
+    >
+      {detail ? (
+        <>
+          <DrawerHeader>
+            <DrawerHeaderTitle
+              action={
+                <Button
+                  appearance="subtle"
+                  aria-label="Close vertex detail"
+                  icon={<Dismiss20Regular />}
+                  data-testid="illuminate-detail-close"
+                  onClick={onClose}
+                />
+              }
+            >
+              <span className={styles.headerLabel}>Vertex</span>
+            </DrawerHeaderTitle>
+          </DrawerHeader>
+          <DrawerBody>
+            <div className={styles.body}>
+              <section className={styles.section}>
+                <div className={styles.keyRow}>
+                  <code
+                    className={styles.key}
+                    data-testid="illuminate-detail-key"
+                  >
+                    {detail.key}
+                  </code>
+                  <Tooltip
+                    content={copied ? "Copied" : "Copy key"}
+                    relationship="label"
+                    withArrow
+                  >
+                    <Button
+                      appearance="subtle"
+                      size="small"
+                      icon={<Copy16Regular />}
+                      aria-label="Copy vertex key"
+                      data-testid="illuminate-detail-copy"
+                      onClick={() => void copyKey(detail.key)}
+                    />
+                  </Tooltip>
+                  {copied ? (
+                    <span
+                      className={styles.copied}
+                      role="status"
+                      data-testid="illuminate-detail-copied"
+                    >
+                      Copied
+                    </span>
+                  ) : null}
+                </div>
+              </section>
+
+              <section className={styles.section}>
+                <h3 className={styles.sectionTitle}>Value</h3>
+                <ValueCell vertex={detail.vertex} />
+              </section>
+
+              <section className={styles.section}>
+                <h3 className={styles.sectionTitle}>Expires</h3>
+                <ExpirationCell expiration={detail.vertex.expiration} />
+              </section>
+
+              <section className={styles.section}>
+                <h3 className={styles.sectionTitle}>
+                  Outgoing edges ({detail.outgoing.length})
+                </h3>
+                {detail.outgoing.length === 0 ? (
+                  <p className={styles.empty}>No outgoing edges.</p>
+                ) : (
+                  <ul
+                    className={styles.edgeList}
+                    data-testid="illuminate-detail-outgoing"
+                  >
+                    {detail.outgoing.map((o) => (
+                      <li key={o.id} className={styles.edgeRow}>
+                        <span className={styles.edgeArrow} aria-hidden="true">
+                          &rarr;
+                        </span>
+                        <code className={styles.edgeTarget}>{o.target}</code>
+                        <span className={styles.edgeWeight}>w={o.weight}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+
+              <section className={styles.section}>
+                <h3 className={styles.sectionTitle}>Inbound edges</h3>
+                <InboundEdges
+                  status={inbound.status}
+                  edges={inbound.edges}
+                  error={inbound.error}
+                  onLoad={inbound.load}
+                />
+              </section>
+
+              <section className={styles.actions}>
+                <Button
+                  appearance="primary"
+                  icon={<ArrowExpand20Regular />}
+                  data-testid="illuminate-detail-expand"
+                  onClick={() => onExpandFromHere(detail.key)}
+                >
+                  Expand from here
+                </Button>
+                <Button
+                  appearance="secondary"
+                  icon={<Open20Regular />}
+                  data-testid="illuminate-detail-open-page"
+                  onClick={() =>
+                    navigate(`/vertices/${encodeURIComponent(detail.key)}`)
+                  }
+                >
+                  Open vertex page
+                </Button>
+              </section>
+            </div>
+          </DrawerBody>
+        </>
+      ) : null}
+    </OverlayDrawer>
+  );
+}
+
+interface InboundEdgesProps {
+  status: ReturnType<typeof useInboundEdges>["status"];
+  edges: ReturnType<typeof useInboundEdges>["edges"];
+  error: string | null;
+  onLoad: () => void;
+}
+
+/**
+ * The on-demand inbound-edge sub-view. Split out so the load/loading/
+ * loaded/error states stay readable and the parent body keeps to its
+ * declarative section layout.
+ */
+function InboundEdges({ status, edges, error, onLoad }: InboundEdgesProps) {
+  if (status === "idle") {
+    return (
+      <Button
+        appearance="subtle"
+        size="small"
+        data-testid="illuminate-detail-inbound-toggle"
+        onClick={onLoad}
+      >
+        Show inbound edges
+      </Button>
+    );
+  }
+  if (status === "loading") {
+    return <Spinner size="tiny" label={"Loading inbound edges\u2026"} />;
+  }
+  if (status === "error") {
+    return (
+      <div className={styles.inboundError}>
+        <p
+          className={styles.errorText}
+          data-testid="illuminate-detail-inbound-error"
+        >
+          {error ?? "Failed to load inbound edges."}
+        </p>
+        <Button appearance="subtle" size="small" onClick={onLoad}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+  // loaded
+  if (edges.length === 0) {
+    return <p className={styles.empty}>No inbound edges.</p>;
+  }
+  return (
+    <ul className={styles.edgeList} data-testid="illuminate-detail-inbound">
+      {edges.map((e) => {
+        const tail = e.tail ?? "";
+        const head = e.head ?? "";
+        return (
+          <li key={edgeIdOf(tail, head)} className={styles.edgeRow}>
+            <code className={styles.edgeTarget}>{tail}</code>
+            <span className={styles.edgeArrow} aria-hidden="true">
+              &rarr;
+            </span>
+            <span className={styles.edgeWeight}>w={e.weight ?? 0}</span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/admin/app/lib/client/usecase/illuminate/selectors.test.ts
+++ b/admin/app/lib/client/usecase/illuminate/selectors.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "bun:test";
 import type { Edge, Vertex } from "~/lib/client/infrastructure/api/illuminate";
 import { illuminateReducer } from "./reducer";
 import {
+  filterInboundEdges,
   selectCanClear,
   selectExpansionChips,
   selectExpansionCount,
   selectGraphView,
+  selectInspectedDetail,
   selectIsBusy,
 } from "./selectors";
 import {
@@ -599,5 +601,102 @@ describe("selectExpansionChips (#456)", () => {
     expect(new Set(chips.map((c) => c.id)).size).toBe(2);
     expect(chips[0]?.isSeed).toBe(true);
     expect(chips[1]?.isSeed).toBe(false);
+  });
+});
+
+describe("selectInspectedDetail", () => {
+  it("returns null for a null key, empty key, or unknown vertex", () => {
+    let state = stateWithInitialSeed("hub");
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "hub",
+      vertices: [v("hub"), v("left")],
+      edges: [e("hub", "left")],
+    });
+    expect(selectInspectedDetail(state, null)).toBeNull();
+    expect(selectInspectedDetail(state, "")).toBeNull();
+    expect(selectInspectedDetail(state, "not-in-accumulator")).toBeNull();
+  });
+
+  it("projects the vertex and its live outgoing edges, sorted by target", () => {
+    let state = stateWithInitialSeed("hub");
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "hub",
+      vertices: [v("hub"), v("alpha"), v("beta"), v("gamma")],
+      // Intentionally out of target order so the sort is observable.
+      edges: [
+        e("hub", "gamma", 3),
+        e("hub", "alpha", 1),
+        e("hub", "beta", 2),
+        // An edge that does NOT originate at hub must be excluded.
+        e("alpha", "beta", 9),
+      ],
+    });
+
+    const detail = selectInspectedDetail(state, "hub");
+    expect(detail).not.toBeNull();
+    expect(detail?.key).toBe("hub");
+    expect(detail?.vertex.key).toBe("hub");
+    expect(detail?.outgoing.map((o) => o.target)).toEqual([
+      "alpha",
+      "beta",
+      "gamma",
+    ]);
+    expect(detail?.outgoing.map((o) => o.weight)).toEqual([1, 2, 3]);
+    // Stable edge ids mirror `edgeIdOf(tail, head)`.
+    expect(detail?.outgoing[0]?.id).toBe("hub\u2192alpha");
+  });
+
+  it("drops the inspected vertex once it has expired", () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    let state = stateWithInitialSeed("hub");
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "hub",
+      vertices: [{ key: "hub", expiration: past }, v("left")],
+      edges: [e("hub", "left")],
+    });
+    // With a wall clock after the expiry, the vertex is gone → null so the
+    // Drawer self-closes.
+    expect(selectInspectedDetail(state, "hub", Date.now())).toBeNull();
+    // But reading it as-of a time BEFORE the expiry still resolves it.
+    expect(
+      selectInspectedDetail(state, "hub", Date.parse(past) - 1_000),
+    ).not.toBeNull();
+  });
+
+  it("filters expired outgoing edges out of the projection", () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    let state = stateWithInitialSeed("hub");
+    state = applyExpansion(state, {
+      expansionId: 1,
+      origin: "hub",
+      vertices: [v("hub"), v("live"), v("dead")],
+      edges: [
+        { tail: "hub", head: "live", weight: 1 },
+        { tail: "hub", head: "dead", weight: 1, expiration: past },
+      ],
+    });
+    const detail = selectInspectedDetail(state, "hub", Date.now());
+    expect(detail?.outgoing.map((o) => o.target)).toEqual(["live"]);
+  });
+});
+
+describe("filterInboundEdges", () => {
+  it("keeps only edges whose head exactly equals the key", () => {
+    const edges: Edge[] = [
+      e("a", "target"),
+      e("b", "target"),
+      // Prefix over-match the wire `headPrefix` scan can return.
+      e("c", "target:child"),
+      e("d", "other"),
+    ];
+    const inbound = filterInboundEdges(edges, "target");
+    expect(inbound.map((x) => x.tail)).toEqual(["a", "b"]);
+  });
+
+  it("returns an empty array for an empty key", () => {
+    expect(filterInboundEdges([e("a", "")], "")).toEqual([]);
   });
 });

--- a/admin/app/lib/client/usecase/illuminate/selectors.ts
+++ b/admin/app/lib/client/usecase/illuminate/selectors.ts
@@ -300,6 +300,92 @@ export function selectCanClear(state: IlluminateState): boolean {
 }
 
 /**
+ * One outgoing edge as surfaced by the node-detail Drawer (#461). The
+ * `id` mirrors `edgeIdOf(tail, head)` so React keys stay stable and the
+ * caller can cross-reference the accumulator if needed.
+ */
+export interface OutgoingEdge {
+  id: string;
+  /** Head vertex key (the edge's destination). */
+  target: string;
+  weight: number;
+  /** Proto-JSON expiration of the edge, if any. */
+  expiration?: string;
+}
+
+/**
+ * View-model the node-detail Drawer renders for the inspected vertex
+ * (#461). Built purely from the accumulator so opening the Drawer never
+ * issues an RPC — outgoing edges come straight from
+ * `state.accumulator.edges`. Inbound edges are NOT included here: they
+ * require a fresh `ScanEdges({ headPrefix })` and are fetched on demand
+ * by {@link useInboundEdges} into panel-local state so they never
+ * mutate the canvas accumulator (#466 keeps the canvas the sole graph
+ * owner).
+ */
+export interface InspectedVertexDetail {
+  key: string;
+  vertex: Vertex;
+  /**
+   * Live (non-expired) outgoing edges whose tail is `key`, sorted by
+   * target key for a stable render order.
+   */
+  outgoing: OutgoingEdge[];
+}
+
+/**
+ * Builds the {@link InspectedVertexDetail} for the supplied key, or
+ * `null` when the vertex is absent / expired. Returning `null` for a
+ * vanished vertex lets the page drive the Drawer's `open` state straight
+ * off this selector: if a TTL sweep drops the inspected vertex, the
+ * Drawer self-closes on the next render without any extra wiring.
+ *
+ * Pure (no React, no client) so the accumulator → panel projection is
+ * unit-testable in isolation.
+ */
+export function selectInspectedDetail(
+  state: IlluminateState,
+  key: string | null,
+  nowMs: number = Date.now(),
+): InspectedVertexDetail | null {
+  if (key === null || key === "") return null;
+  const acc = state.accumulator.vertices.get(key);
+  if (!acc) return null;
+  if (isExpired(acc.vertex.expiration, nowMs)) return null;
+
+  const outgoing: OutgoingEdge[] = [];
+  for (const [id, accEdge] of state.accumulator.edges) {
+    const e = accEdge.edge;
+    if (e.tail !== key || !e.head) continue;
+    if (isExpired(e.expiration, nowMs)) continue;
+    outgoing.push({
+      id,
+      target: e.head,
+      weight: e.weight ?? 0,
+      expiration: e.expiration,
+    });
+  }
+  outgoing.sort((a, b) =>
+    a.target < b.target ? -1 : a.target > b.target ? 1 : 0,
+  );
+
+  return { key, vertex: acc.vertex, outgoing };
+}
+
+/**
+ * Narrows a `ScanEdges({ headPrefix: key })` result to the edges that
+ * terminate at exactly `key` (#461 "Show inbound edges"). The wire
+ * `headPrefix` scan is a prefix match, so `key = "a"` would also return
+ * `a*→…` edges whose head merely starts with the prefix; the Drawer
+ * only wants true inbound edges, hence the exact `head === key` filter.
+ * Pure so it can be unit-tested without a live client.
+ */
+export function filterInboundEdges(edges: Edge[], key: string): Edge[] {
+  if (key === "") return [];
+  return edges.filter((e) => e.head === key);
+}
+
+/**
  * View-model for the per-expansion chip in the toolbar (#456). Each chip
  * is a "scroll-to-origin" affordance — clicking it pans the camera to the
  * origin vertex without mutating state or re-issuing any RPC.

--- a/admin/app/lib/client/usecase/illuminate/use-inbound-edges.ts
+++ b/admin/app/lib/client/usecase/illuminate/use-inbound-edges.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { LanternApiError } from "~/lib/client/infrastructure/api/error";
+import {
+  scanEdges,
+  type Edge,
+} from "~/lib/client/infrastructure/api/scan-edges";
+import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
+import { filterInboundEdges } from "./selectors";
+
+/**
+ * How many inbound edges the node-detail Drawer pulls in one shot
+ * (#461). The Drawer is a quick-look inspector, not a paginated browser
+ * (that's `/edges`), so a single bounded page is plenty; the user can
+ * jump to the full edge browser for exhaustive traversal.
+ */
+const INBOUND_EDGE_LIMIT = 200;
+
+export type InboundEdgesStatus = "idle" | "loading" | "loaded" | "error";
+
+export interface UseInboundEdgesResult {
+  status: InboundEdgesStatus;
+  /** Edges that terminate at the bound vertex (head === vertexKey). */
+  edges: Edge[];
+  error: string | null;
+  /** Fetch inbound edges for the bound vertex. No-op when none is bound. */
+  load: () => void;
+}
+
+/**
+ * Panel-scoped, on-demand fetch of the edges that TERMINATE at
+ * `vertexKey` (#461 "Show inbound edges").
+ *
+ * Deliberately kept OUT of the Illuminate accumulator: per #466 the
+ * canvas owns the graph and the Drawer is a read-only inspector, so
+ * inbound edges surfaced here never mutate the canvas view. Re-binding
+ * `vertexKey` (inspecting a different vertex, or closing the Drawer with
+ * `null`) resets back to `idle` and aborts any in-flight request so a
+ * late response can't bleed into the next vertex's panel.
+ *
+ * No unit-test sibling by repo convention — hooks are covered by the
+ * Illuminate Playwright suite; the testable seam (`filterInboundEdges`)
+ * lives in `selectors.ts`.
+ */
+export function useInboundEdges(
+  vertexKey: string | null,
+): UseInboundEdgesResult {
+  const client = useLanternClient();
+  const [status, setStatus] = useState<InboundEdgesStatus>("idle");
+  const [edges, setEdges] = useState<Edge[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const controllerRef = useRef<AbortController | null>(null);
+
+  // Reset whenever the inspected vertex changes (or the Drawer closes).
+  // Aborting the in-flight scan keeps a stale response from landing in
+  // the next vertex's panel.
+  useEffect(() => {
+    controllerRef.current?.abort();
+    controllerRef.current = null;
+    setStatus("idle");
+    setEdges([]);
+    setError(null);
+    return () => {
+      controllerRef.current?.abort();
+      controllerRef.current = null;
+    };
+  }, [vertexKey]);
+
+  const load = useCallback(() => {
+    if (vertexKey === null || vertexKey === "") return;
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    setStatus("loading");
+    setError(null);
+    void scanEdges(
+      client,
+      { headPrefix: vertexKey, limit: INBOUND_EDGE_LIMIT },
+      { signal: controller.signal },
+    )
+      .then((response) => {
+        if (controller.signal.aborted) return;
+        setEdges(filterInboundEdges(response.edges ?? [], vertexKey));
+        setStatus("loaded");
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return;
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setError(messageOf(err));
+        setStatus("error");
+      });
+  }, [client, vertexKey]);
+
+  return { status, edges, error, load };
+}
+
+function messageOf(err: unknown): string {
+  if (err instanceof LanternApiError) {
+    return err.grpcMessage ?? err.message;
+  }
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/admin/tests/e2e/illuminate.spec.ts
+++ b/admin/tests/e2e/illuminate.spec.ts
@@ -1138,4 +1138,85 @@ test.describe("/illuminate", () => {
       { timeout: 4000 },
     );
   });
+
+  test("Info icon opens a read-only detail Drawer; Expand from here grows the lineage (#461)", async ({
+    page,
+  }) => {
+    const seed = encodeURIComponent("e2e:illum:hub");
+    await page.goto(`/illuminate?seed=${seed}`);
+    await expect(page.getByTestId("illuminate-toolbar")).toBeVisible();
+
+    const counter = page.getByTestId("illuminate-counter");
+    await expect(counter).toContainText("5 vertices");
+    await expect(counter).toContainText("1 expansion");
+
+    // Wait for the #461 test-bridge surface, then surface the info icon
+    // for `left` exactly as a real hover would. The WebGL hover hit-test
+    // is flaky under headless chromium, so we drive the icon through the
+    // bridge — the icon it renders and the click path are the real ones.
+    type Bridge = {
+      showInfoIcon: (k: string) => boolean;
+      infoIconNode: () => string | null;
+      inspectNode: (k: string) => boolean;
+    };
+    await page.waitForFunction(() => {
+      const win = window as Window & { __illuminateCanvas?: Bridge };
+      return !!win.__illuminateCanvas?.showInfoIcon;
+    });
+    const shown = await page.evaluate(() => {
+      const win = window as Window & { __illuminateCanvas?: Bridge };
+      return win.__illuminateCanvas!.showInfoIcon("e2e:illum:left");
+    });
+    expect(shown).toBe(true);
+
+    // The icon is the one canvas overlay that takes pointer events.
+    const infoIcon = page.getByTestId("illuminate-info-icon");
+    await expect(infoIcon).toBeVisible();
+    await expect(infoIcon).toHaveAttribute("aria-label", /e2e:illum:left/);
+
+    // Clicking it opens the detail Drawer for that vertex.
+    await infoIcon.click();
+    const panel = page.getByTestId("illuminate-node-detail");
+    await expect(panel).toBeVisible();
+    await expect(page.getByTestId("illuminate-detail-key")).toHaveText(
+      "e2e:illum:left",
+    );
+
+    // Inspecting is read-only: it must NOT expand or refetch. The
+    // accumulator counts stay exactly where they were.
+    await expect(counter).toContainText("5 vertices");
+    await expect(counter).toContainText("1 expansion");
+
+    // The accumulator already holds the outgoing edge left -> leftleft,
+    // so the outgoing list renders without any RPC.
+    await expect(page.getByTestId("illuminate-detail-outgoing")).toContainText(
+      "e2e:illum:leftleft",
+    );
+
+    // "Show inbound edges" issues a fresh prefix scan. The wire scan is a
+    // prefix match, so headPrefix "e2e:illum:left" over-matches
+    // `leftleft`/`leftleftleft`; the panel must filter to the exact
+    // inbound edge hub -> left only.
+    await page.getByTestId("illuminate-detail-inbound-toggle").click();
+    const inbound = page.getByTestId("illuminate-detail-inbound");
+    await expect(inbound).toBeVisible();
+    await expect(inbound).toContainText("e2e:illum:hub");
+    await expect(inbound.getByRole("listitem")).toHaveCount(1);
+
+    // "Expand from here" fires an additive expansion from `left` and
+    // closes the Drawer. `leftleftleft` is the one vertex outside the
+    // current 2-hop frame, so the accumulator grows by exactly one.
+    await page.getByTestId("illuminate-detail-expand").click();
+    await expect(panel).toBeHidden();
+    await expect(counter).toContainText("6 vertices");
+    await expect(counter).toContainText("2 expansions");
+
+    // A new, non-seed lineage chip records the `left` expansion (#456).
+    const expansionChip = page.getByTestId("illuminate-chip-1");
+    await expect(expansionChip).toHaveAttribute(
+      "data-chip-origin",
+      "e2e:illum:left",
+    );
+    await expect(expansionChip).toHaveAttribute("data-chip-is-seed", "false");
+  });
 });


### PR DESCRIPTION
## Summary

Adds a read-only **NodeDetailPanel** to `/illuminate`, opened by a per-node **info icon** that surfaces on hover. Clicking the icon inspects the vertex (Drawer); clicking the node **body** still fires the #466 additive expansion — the two click targets are spatially separated so there is no gesture ambiguity.

The panel is read-only with respect to the canvas: opening/closing it never touches `accumulator`, `expansions`, or the Sigma camera, and no RPC fires unless the user clicks **Show inbound edges** (per #466 D2/D5 boundaries).

## What's included

- **`selectInspectedDetail`** — projects the live accumulator into the panel view-model (key, vertex, outgoing edges sorted by target); returns `null` once the vertex is TTL-swept so the Drawer self-closes.
- **`filterInboundEdges`** — trims a `headPrefix` `ScanEdges` scan to exact-head matches (the wire scan is a prefix match, so `e2e:illum:left` over-matches `leftleft`/`leftleftleft`).
- **`useInboundEdges`** — lazy `ScanEdges({ headPrefix })` hook, `AbortController`-guarded, feeds the panel without mutating the accumulator.
- **`NodeDetailPanel`** (Fluent UI `OverlayDrawer`, `position="end"`, `modalType="non-modal"`) — key + copy button, `ValueCell`, `ExpirationCell`, outgoing edges, lazy "Show inbound edges", **Expand from here**, **Open vertex page**. Non-modal so it coexists with #458 hover focus and keeps the canvas interactive.
- **`IlluminateCanvas`** — hover-driven info-icon overlay (`pointer-events: auto`, z-index above tooltip/legend) with click-vs-drag discrimination so **#455 drag-to-pin keeps precedence**; new `onNodeInspect` prop + test-bridge methods (`inspectNode` / `showInfoIcon` / `infoIconNode`).
- **`IlluminatePage`** — page-local `inspectedVertex` state; both a node-body click and "Expand from here" close the Drawer.

## Acceptance criteria

- [x] Info-icon click opens the Drawer; `accumulator`/`expansions`/camera unchanged; no RPC unless "Show inbound edges".
- [x] Node-body click dispatches the #466 additive expansion; Drawer does **not** open as a side effect.
- [x] "Expand from here" fires a new expansion (same path as a body click) and closes the Drawer.
- [x] Drag (#455) takes precedence over icon click via the click-tolerance threshold.
- [x] Playwright covers hover → icon → click → panel → "Expand from here" → panel closes + new expansion chip (#456).

> Note: "Open vertex page" navigates to `/vertices/<key>` (the route the IlluminateTable already links to), not the issue body's loose `/browse/vertex/<key>`.

## Verification

`bun run typecheck` · `bun run lint` · `bun run format` · `bun test app test/cli-grammar` (422 pass) · `bun run build` · `bunx playwright test` (44 pass, incl. new #461 test).

Closes #461