### PR TITLE
build(admin): exclude host node_modules and build artefacts from docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,15 @@ Dockerfile
 README.md
 AGENTS.md
 LICENSE
+
+# Toolchain output. The admin image (admin/Dockerfile) uses the repo root
+# as its build context, so node_modules / build artefacts must be excluded
+# here too — otherwise a host `bun install` collides with the in-image,
+# lockfile-pinned install (a directory-vs-symlink COPY conflict). CI builds
+# from a clean checkout, so this is a local-build correctness fix.
+**/node_modules
+admin/build
+admin/.vite
+admin/.react-router
+admin/test-results
+admin/playwright-report


### PR DESCRIPTION
Closes #486.

`admin/Dockerfile` builds with the repo root as its Docker context (required by the `file:../sdks/node` dependency, #409). The root `.dockerignore` did not exclude `admin/node_modules` or admin build artefacts, so a local `docker build` from a dirty tree copied the host's bun symlink trees over the in-image lockfile-pinned install — a directory-vs-symlink `COPY` conflict / non-reproducible image.

This adds the missing excludes:

```
**/node_modules
admin/build
admin/.vite
admin/.react-router
admin/test-results
admin/playwright-report
```

The admin Dockerfile already re-installs and re-builds inside the image, so excluding these is cheap and correct. Server image build is unaffected; CI builds from a clean checkout so its behaviour is unchanged.