### PR TITLE
feat(admin): render directed-edge arrowheads (#485)

### DIFF
--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -10,6 +10,7 @@ import {
 import Graph from "graphology";
 import forceAtlas2 from "graphology-layout-forceatlas2";
 import Sigma from "sigma";
+import { EdgeArrowProgram } from "sigma/rendering";
 import { Info16Regular } from "@fluentui/react-icons";
 import type {
   GraphEdge,
@@ -355,6 +356,20 @@ export function IlluminateCanvas({
       labelRenderedSizeThreshold: 8,
       defaultEdgeColor: FALLBACK_PALETTE.edge,
       defaultNodeColor: FALLBACK_PALETTE.baseNode,
+      // === #485 directed-edge arrowheads ================================
+      // The graphology graph is `type: "directed"`, but Sigma's default
+      // edge renderer (`EdgeRectangleProgram`) draws every edge as a
+      // plain undirected bar, so the canvas hid the direction Lantern's
+      // edges actually carry (tail → head). Render the built-in arrow
+      // program instead: `EdgeClampedProgram` body + `EdgeArrowHeadProgram`
+      // head, with the head clamped to the target node radius so it never
+      // disappears under the disc. We register the program explicitly and
+      // make it the default type for every edge (no edge sets a per-edge
+      // `type`, so this governs the whole graph) rather than relying on
+      // the default registry, keeping the wiring self-contained.
+      defaultEdgeType: "arrow",
+      edgeProgramClasses: { arrow: EdgeArrowProgram },
+      // === end #485 =====================================================
       labelColor: { color: FALLBACK_PALETTE.labelText },
       labelSize: LABEL_SIZE,
       labelWeight: LABEL_WEIGHT,
@@ -761,6 +776,13 @@ export function IlluminateCanvas({
          * currently visible, or `null` when none is shown.
          */
         infoIconNode: () => string | null;
+        /**
+         * #485 test bridge: the resolved `defaultEdgeType` sigma
+         * setting. Every edge renders with this program (none set a
+         * per-edge `type`), so asserting it is `"arrow"` proves the
+         * directed arrowheads are wired and have not regressed.
+         */
+        getDefaultEdgeType: () => string;
       };
     };
     win.__illuminateCanvas = {
@@ -871,6 +893,7 @@ export function IlluminateCanvas({
         return showInfoIconFor(key);
       },
       infoIconNode: () => infoIconRef.current?.key ?? null,
+      getDefaultEdgeType: () => renderer.getSetting("defaultEdgeType"),
     };
 
     return () => {

--- a/admin/tests/e2e/illuminate.spec.ts
+++ b/admin/tests/e2e/illuminate.spec.ts
@@ -1219,4 +1219,46 @@ test.describe("/illuminate", () => {
     );
     await expect(expansionChip).toHaveAttribute("data-chip-is-seed", "false");
   });
+
+  test("Directed edges render with the arrow program (#485)", async ({
+    page,
+  }) => {
+    const seed = encodeURIComponent("e2e:illum:hub");
+    await page.goto(`/illuminate?seed=${seed}`);
+    await expect(page.getByTestId("illuminate-counter")).toContainText(
+      "5 vertices",
+    );
+
+    type Bridge = {
+      getDefaultEdgeType: () => string;
+      getRenderedEdgeColor: (k: string) => string | null;
+    };
+    await page.waitForFunction(() => {
+      const win = window as Window & { __illuminateCanvas?: Bridge };
+      return !!win.__illuminateCanvas;
+    });
+
+    // The graphology graph is directed (tail → head). Sigma's default
+    // edge program draws plain undirected bars, so the canvas must opt
+    // into the arrow program to make direction legible. No edge sets a
+    // per-edge `type`, so the resolved `defaultEdgeType` governs the
+    // whole graph — asserting it is `"arrow"` proves every edge renders
+    // an arrowhead.
+    const defaultEdgeType = await page.evaluate(() => {
+      const win = window as Window & { __illuminateCanvas?: Bridge };
+      return win.__illuminateCanvas?.getDefaultEdgeType() ?? null;
+    });
+    expect(defaultEdgeType).toBe("arrow");
+
+    // Sanity: an actual edge from the seeded graph carries rendered
+    // display data, so the arrow program governs a live edge rather than
+    // an empty registry. Edge ids follow `${tail}→${head}` (see edgeIdOf
+    // in app/lib/client/usecase/illuminate/state.ts).
+    const hubToLeftEdge = "e2e:illum:hub→e2e:illum:left";
+    const renderedColor = await page.evaluate((edgeId) => {
+      const win = window as Window & { __illuminateCanvas?: Bridge };
+      return win.__illuminateCanvas?.getRenderedEdgeColor(edgeId) ?? null;
+    }, hubToLeftEdge);
+    expect(renderedColor).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## What

The `/illuminate` canvas drew every edge as a plain undirected bar, even
though the graphology graph is `type: "directed"` and Lantern's edges
carry a real tail → head direction. This switches the Sigma renderer to
the built-in arrow program so each edge renders an arrowhead clamped to
its target node.

## How

- Register `EdgeArrowProgram` (`sigma/rendering`) and set
  `defaultEdgeType: "arrow"` in the Sigma constructor. No edge sets a
  per-edge `type`, so the default governs the whole graph.
- Add a `getDefaultEdgeType` test bridge on `window.__illuminateCanvas`.

## Verification

- New e2e test asserts `defaultEdgeType === "arrow"` and that a live
  seeded edge carries rendered display data under the arrow program.
- Full admin gates green locally: `format:check`, `lint`, `typecheck`,
  `build`, and the full Playwright suite (45 passed).
- Visually confirmed via Playwright screenshot: arrowheads render at each
  target node (`viz:hub → viz:right`, `viz:right → viz:rightright`, …).

Closes #485
