### PR TITLE
fix(admin): theme-aware hover label renderer (#484)

### DIFF
--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -18,6 +18,7 @@ import type {
 } from "~/lib/client/usecase/illuminate/selectors";
 import { usePreferredTheme } from "~/lib/client/usecase/theme/use-preferred-theme";
 import { HOP_FAR_THRESHOLD, colorForHop, describeHop } from "./hop-palette";
+import { makeDrawNodeHover } from "./hover-label";
 import { decideFa2Iterations } from "./layout-iterations";
 import {
   FALLBACK_PALETTE,
@@ -374,6 +375,17 @@ export function IlluminateCanvas({
       labelSize: LABEL_SIZE,
       labelWeight: LABEL_WEIGHT,
       labelFont: FALLBACK_PALETTE.labelFont,
+      // === #484 theme-aware hover label =================================
+      // Sigma's default `drawDiscNodeHover` paints a hard-coded near-white
+      // box behind the hovered label, then draws the label in
+      // `labelColor` (our `--colorNeutralForeground1`) — which is also
+      // near-white in dark theme, so the hovered label rendered
+      // white-on-white. Swap in a palette-skinned renderer: the chip is
+      // filled with `--colorNeutralBackground1` and outlined with a 1px
+      // `--colorNeutralStroke1`, guaranteeing it contrasts with the text.
+      // The palette effect re-applies this on every theme flip.
+      defaultDrawNodeHover: makeDrawNodeHover(FALLBACK_PALETTE),
+      // === end #484 =====================================================
     });
     graphRef.current = graph;
     sigmaRef.current = renderer;
@@ -783,6 +795,21 @@ export function IlluminateCanvas({
          * directed arrowheads are wired and have not regressed.
          */
         getDefaultEdgeType: () => string;
+        /**
+         * #484 test bridge: the resolved hover-label chip colours
+         * (`background` ← `--colorNeutralBackground1`, `stroke` ←
+         * `--colorNeutralStroke1`, `text` ← `--colorNeutralForeground1`).
+         * The custom hover renderer paints the chip with `background` +
+         * a 1px `stroke` and the label with `text`, so asserting
+         * `background !== text` in the live theme proves the hovered
+         * label can never collide with its own box. Reads `paletteRef`
+         * so it reflects the current theme after a flip.
+         */
+        getHoverLabelColors: () => {
+          background: string;
+          stroke: string;
+          text: string;
+        };
       };
     };
     win.__illuminateCanvas = {
@@ -894,6 +921,11 @@ export function IlluminateCanvas({
       },
       infoIconNode: () => infoIconRef.current?.key ?? null,
       getDefaultEdgeType: () => renderer.getSetting("defaultEdgeType"),
+      getHoverLabelColors: () => ({
+        background: paletteRef.current.labelBackground,
+        stroke: paletteRef.current.labelStroke,
+        text: paletteRef.current.labelText,
+      }),
     };
 
     return () => {
@@ -923,6 +955,9 @@ export function IlluminateCanvas({
     sigma.setSetting("defaultEdgeColor", palette.edge);
     sigma.setSetting("labelColor", { color: palette.labelText });
     sigma.setSetting("labelFont", palette.labelFont);
+    // #484: rebuild the hover renderer against the new palette so the
+    // hovered-label chip follows the theme alongside the label text.
+    sigma.setSetting("defaultDrawNodeHover", makeDrawNodeHover(palette));
     for (const id of graph.nodes()) {
       const attrs = graph.getNodeAttributes(id) as {
         hopDistance?: number;

--- a/admin/app/components/illuminate/IlluminateCanvas/hover-label.test.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/hover-label.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, test } from "bun:test";
+
+import { makeDrawNodeHover } from "./hover-label";
+import { FALLBACK_PALETTE, type SigmaPalette } from "./palette";
+
+/**
+ * Unit coverage for the theme-aware hover-label renderer (#484).
+ *
+ * The renderer is pure 2D-canvas drawing, so we drive it with a fake
+ * `CanvasRenderingContext2D` that records each drawing call together with
+ * the *active* style state at the moment of the call. That lets the suite
+ * assert the box was filled with `labelBackground`, stroked with
+ * `labelStroke`, and that the label text was painted in `labelText` — the
+ * collision #484 fixes is precisely "text drawn in the same colour as the
+ * box behind it".
+ */
+
+interface RecordedOp {
+  op: string;
+  fillStyle: string;
+  strokeStyle: string;
+  lineWidth: number;
+  shadowBlur: number;
+  args: unknown[];
+}
+
+function makeFakeContext(textWidth = 42) {
+  const ops: RecordedOp[] = [];
+  const state = {
+    font: "",
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 0,
+    shadowOffsetX: 0,
+    shadowOffsetY: 0,
+    shadowBlur: 0,
+    shadowColor: "",
+  };
+  const record = (op: string, args: unknown[] = []) =>
+    ops.push({
+      op,
+      fillStyle: state.fillStyle,
+      strokeStyle: state.strokeStyle,
+      lineWidth: state.lineWidth,
+      shadowBlur: state.shadowBlur,
+      args,
+    });
+
+  const ctx = {
+    get font() {
+      return state.font;
+    },
+    set font(v: string) {
+      state.font = v;
+    },
+    get fillStyle() {
+      return state.fillStyle;
+    },
+    set fillStyle(v: string) {
+      state.fillStyle = v;
+    },
+    get strokeStyle() {
+      return state.strokeStyle;
+    },
+    set strokeStyle(v: string) {
+      state.strokeStyle = v;
+    },
+    get lineWidth() {
+      return state.lineWidth;
+    },
+    set lineWidth(v: number) {
+      state.lineWidth = v;
+    },
+    get shadowOffsetX() {
+      return state.shadowOffsetX;
+    },
+    set shadowOffsetX(v: number) {
+      state.shadowOffsetX = v;
+    },
+    get shadowOffsetY() {
+      return state.shadowOffsetY;
+    },
+    set shadowOffsetY(v: number) {
+      state.shadowOffsetY = v;
+    },
+    get shadowBlur() {
+      return state.shadowBlur;
+    },
+    set shadowBlur(v: number) {
+      state.shadowBlur = v;
+    },
+    get shadowColor() {
+      return state.shadowColor;
+    },
+    set shadowColor(v: string) {
+      state.shadowColor = v;
+    },
+    measureText: (_t: string) => ({ width: textWidth }),
+    beginPath: () => record("beginPath"),
+    moveTo: (...a: number[]) => record("moveTo", a),
+    lineTo: (...a: number[]) => record("lineTo", a),
+    arc: (...a: number[]) => record("arc", a),
+    closePath: () => record("closePath"),
+    fill: () => record("fill"),
+    stroke: () => record("stroke"),
+    fillText: (...a: unknown[]) => record("fillText", a),
+  };
+
+  return { ctx, ops, state };
+}
+
+// Minimal sigma settings the renderer reads. The full Settings type is
+// large; the renderer only touches these three fields, so we cast a
+// partial through `unknown` at the call site.
+const SETTINGS = {
+  labelSize: 13,
+  labelFont: "system-ui, sans-serif",
+  labelWeight: "600",
+};
+
+// A distinctive palette so each colour assertion is unambiguous (none of
+// the four values collide).
+const PALETTE: SigmaPalette = {
+  ...FALLBACK_PALETTE,
+  labelBackground: "#101010",
+  labelStroke: "#808080",
+  labelText: "#fafafa",
+};
+
+function draw(
+  palette: SigmaPalette,
+  data: { x: number; y: number; size: number; label?: string; color?: string },
+  textWidth = 42,
+) {
+  const fake = makeFakeContext(textWidth);
+  const fn = makeDrawNodeHover(palette);
+  fn(
+    fake.ctx as unknown as CanvasRenderingContext2D,
+    data as unknown as Parameters<ReturnType<typeof makeDrawNodeHover>>[1],
+    SETTINGS as unknown as Parameters<ReturnType<typeof makeDrawNodeHover>>[2],
+  );
+  return fake;
+}
+
+describe("makeDrawNodeHover", () => {
+  test("fills the label chip with labelBackground", () => {
+    const { ops } = draw(PALETTE, {
+      x: 100,
+      y: 50,
+      size: 8,
+      label: "alpha",
+      color: "#0078d4",
+    });
+    const fill = ops.find((o) => o.op === "fill");
+    expect(fill).toBeDefined();
+    expect(fill?.fillStyle).toBe(PALETTE.labelBackground);
+  });
+
+  test("outlines the chip with a 1px labelStroke border", () => {
+    const { ops } = draw(PALETTE, {
+      x: 100,
+      y: 50,
+      size: 8,
+      label: "alpha",
+      color: "#0078d4",
+    });
+    const stroke = ops.find((o) => o.op === "stroke");
+    expect(stroke).toBeDefined();
+    expect(stroke?.strokeStyle).toBe(PALETTE.labelStroke);
+    expect(stroke?.lineWidth).toBe(1);
+  });
+
+  test("draws the label text in labelText so it contrasts with the chip", () => {
+    const { ops } = draw(PALETTE, {
+      x: 100,
+      y: 50,
+      size: 8,
+      label: "alpha",
+      color: "#0078d4",
+    });
+    const text = ops.find((o) => o.op === "fillText");
+    expect(text).toBeDefined();
+    expect(text?.fillStyle).toBe(PALETTE.labelText);
+    // The text colour must differ from the box fill — that is the exact
+    // collision #484 fixes.
+    expect(text?.fillStyle).not.toBe(PALETTE.labelBackground);
+  });
+
+  test("positions the label at sigma's canonical offset (x + size + 3, y + size/3)", () => {
+    const { ops } = draw(PALETTE, {
+      x: 100,
+      y: 50,
+      size: 8,
+      label: "alpha",
+      color: "#0078d4",
+    });
+    const text = ops.find((o) => o.op === "fillText");
+    expect(text?.args).toEqual(["alpha", 100 + 8 + 3, 50 + 13 / 3]);
+  });
+
+  test("draws no drop shadow (shadowBlur stays 0 through the fill)", () => {
+    const { ops, state } = draw(PALETTE, {
+      x: 100,
+      y: 50,
+      size: 8,
+      label: "alpha",
+      color: "#0078d4",
+    });
+    const fill = ops.find((o) => o.op === "fill");
+    expect(fill?.shadowBlur).toBe(0);
+    expect(state.shadowBlur).toBe(0);
+  });
+
+  test("sets the font from sigma's label settings", () => {
+    const { state } = draw(PALETTE, {
+      x: 0,
+      y: 0,
+      size: 6,
+      label: "x",
+      color: "#000",
+    });
+    expect(state.font).toBe("600 13px system-ui, sans-serif");
+  });
+
+  test("falls back to a plain disc halo and paints no text when the node has no label", () => {
+    const { ops } = draw(PALETTE, { x: 10, y: 20, size: 6, color: "#000" });
+    // The label-less branch draws a full-circle arc, fills + strokes it,
+    // and never calls fillText.
+    const arc = ops.find((o) => o.op === "arc");
+    expect(arc).toBeDefined();
+    expect(arc?.args).toEqual([10, 20, 6 + 2, 0, Math.PI * 2]);
+    expect(ops.some((o) => o.op === "fill")).toBe(true);
+    expect(ops.some((o) => o.op === "stroke")).toBe(true);
+    expect(ops.some((o) => o.op === "fillText")).toBe(false);
+  });
+
+  test("measures the label to size the chip width", () => {
+    // A label-bearing node must measure its text (the box width derives
+    // from it). We assert the renderer routes through measureText by
+    // giving the fake a known width and checking a rectangle vertex uses
+    // it: the right edge is at x + radius + round(textWidth + 5).
+    const textWidth = 60;
+    const { ops } = draw(
+      PALETTE,
+      { x: 100, y: 50, size: 8, label: "alpha", color: "#0078d4" },
+      textWidth,
+    );
+    const radius = Math.max(8, 13 / 2) + 2; // matches the renderer
+    const expectedRight = 100 + radius + Math.round(textWidth + 5);
+    const rightVertex = ops.find(
+      (o) => o.op === "lineTo" && (o.args as number[])[0] === expectedRight,
+    );
+    expect(rightVertex).toBeDefined();
+  });
+
+  test("the fallback palette already separates the hover box from the label text", () => {
+    // Guard the real shipped default: the light fallback chip (#ffffff)
+    // and label (#242424) must contrast even before Fluent hydrates.
+    const { ops } = draw(FALLBACK_PALETTE, {
+      x: 5,
+      y: 5,
+      size: 7,
+      label: "node",
+      color: "#000",
+    });
+    const fill = ops.find((o) => o.op === "fill");
+    const text = ops.find((o) => o.op === "fillText");
+    expect(fill?.fillStyle).toBe(FALLBACK_PALETTE.labelBackground);
+    expect(text?.fillStyle).toBe(FALLBACK_PALETTE.labelText);
+    expect(fill?.fillStyle).not.toBe(text?.fillStyle);
+  });
+});

--- a/admin/app/components/illuminate/IlluminateCanvas/hover-label.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/hover-label.ts
@@ -1,0 +1,105 @@
+/**
+ * Theme-aware hover-label renderer for the Illuminate canvas (#484).
+ *
+ * Sigma's built-in `defaultDrawNodeHover` paints a hard-coded near-white
+ * (`#FFF`) rounded box behind the hovered node's label and then draws the
+ * label text in `settings.labelColor`. The canvas wires `labelColor` to
+ * the Fluent `--colorNeutralForeground1` token, which is *also* near-white
+ * in dark theme — so the hovered label rendered as white-on-white and was
+ * unreadable exactly when the user needed it most.
+ *
+ * {@link makeDrawNodeHover} returns a drop-in `NodeHoverDrawingFunction`
+ * that keeps sigma's box geometry (a rounded rectangle fused to the node
+ * disc) but skins it from the palette: the box is filled with
+ * `labelBackground` (`--colorNeutralBackground1`) and outlined with a 1px
+ * `labelStroke` (`--colorNeutralStroke1`) so it reads as a chip, then the
+ * label is drawn in `labelText` (`--colorNeutralForeground1`). Because the
+ * box now follows the surface token and the text follows the foreground
+ * token, the two always contrast in both light and dark themes.
+ *
+ * The function is colocated with the canvas (it is pure 2D-canvas drawing
+ * math, not interaction state) and takes the palette by value so the
+ * caller can re-create it whenever the theme flips and re-apply it via
+ * `setSetting("defaultDrawNodeHover", …)`.
+ */
+
+import type { NodeHoverDrawingFunction } from "sigma/rendering";
+
+import type { SigmaPalette } from "./palette";
+
+/**
+ * Inner padding (canvas px) between the label text and the chip edge.
+ * Mirrors sigma's default `PADDING = 2` so the hover box keeps the same
+ * proportions the rest of the canvas was tuned against.
+ */
+const PADDING = 2;
+
+/**
+ * Build a `NodeHoverDrawingFunction` that paints the hovered node's label
+ * chip from the supplied {@link SigmaPalette}. The returned function reads
+ * `labelSize` / `labelFont` / `labelWeight` off sigma's live settings (so
+ * it tracks the same font metrics as the non-hover labels) but takes its
+ * colours from the palette argument, guaranteeing box/text contrast.
+ */
+export function makeDrawNodeHover(
+  palette: SigmaPalette,
+): NodeHoverDrawingFunction {
+  return (context, data, settings) => {
+    const size = settings.labelSize;
+    const font = settings.labelFont;
+    const weight = settings.labelWeight;
+    context.font = `${weight} ${size}px ${font}`;
+
+    // Skin the chip from the theme tokens and drop sigma's default drop
+    // shadow — the 1px stroke is what now separates the chip from the
+    // canvas, and a shadow would only muddy the contrast we just fixed.
+    context.fillStyle = palette.labelBackground;
+    context.strokeStyle = palette.labelStroke;
+    context.lineWidth = 1;
+    context.shadowOffsetX = 0;
+    context.shadowOffsetY = 0;
+    context.shadowBlur = 0;
+
+    if (typeof data.label === "string") {
+      // Same rounded-rectangle-fused-to-disc geometry as sigma's
+      // `drawDiscNodeHover`, so the chip hugs the node identically; only
+      // the fill/stroke styling changes.
+      const textWidth = context.measureText(data.label).width;
+      const boxWidth = Math.round(textWidth + 5);
+      const boxHeight = Math.round(size + 2 * PADDING);
+      const radius = Math.max(data.size, size / 2) + PADDING;
+      const angleRadian = Math.asin(boxHeight / 2 / radius);
+      const xDeltaCoord = Math.sqrt(
+        Math.abs(Math.pow(radius, 2) - Math.pow(boxHeight / 2, 2)),
+      );
+
+      context.beginPath();
+      context.moveTo(data.x + xDeltaCoord, data.y + boxHeight / 2);
+      context.lineTo(data.x + radius + boxWidth, data.y + boxHeight / 2);
+      context.lineTo(data.x + radius + boxWidth, data.y - boxHeight / 2);
+      context.lineTo(data.x + xDeltaCoord, data.y - boxHeight / 2);
+      context.arc(data.x, data.y, radius, angleRadian, -angleRadian);
+      context.closePath();
+      context.fill();
+      context.stroke();
+    } else {
+      // No label: sigma falls back to a plain disc halo. Keep that, just
+      // skinned from the palette.
+      context.beginPath();
+      context.arc(data.x, data.y, data.size + PADDING, 0, Math.PI * 2);
+      context.closePath();
+      context.fill();
+      context.stroke();
+    }
+
+    // Draw the label on top of the chip in the foreground token. We paint
+    // it here (rather than delegating to sigma's `drawDiscNodeLabel`) so
+    // the renderer is self-contained and the box/text contrast is proven
+    // by this function alone — the text colour can never silently diverge
+    // from the box we just filled.
+    if (typeof data.label === "string" && data.label.length > 0) {
+      context.fillStyle = palette.labelText;
+      context.fillText(data.label, data.x + data.size + 3, data.y + size / 3);
+    }
+  };
+}

--- a/admin/app/components/illuminate/IlluminateCanvas/palette.test.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/palette.test.ts
@@ -53,6 +53,51 @@ describe("resolvePaletteFromTokens", () => {
     expect(palette.labelFont).toBe("Inter, sans-serif");
   });
 
+  // ── #484 hover-label chip ───────────────────────────────────────
+  // The custom hover renderer fills the hovered node's label box with
+  // `labelBackground` and outlines it with `labelStroke`, then draws
+  // the label in `labelText`. The tokens must follow the Fluent
+  // surface ramp so a theme flip re-skins the box (and never collides
+  // with the foreground text the way sigma's near-white default did).
+
+  test("reads --colorNeutralBackground1 for the hover-label background", () => {
+    const palette = resolvePaletteFromTokens(
+      readerFrom({ "--colorNeutralBackground1": "#1b1a19" }),
+    );
+    expect(palette.labelBackground).toBe("#1b1a19");
+  });
+
+  test("reads --colorNeutralStroke1 for the hover-label border", () => {
+    const palette = resolvePaletteFromTokens(
+      readerFrom({ "--colorNeutralStroke1": "#484644" }),
+    );
+    expect(palette.labelStroke).toBe("#484644");
+  });
+
+  test("hover-label tokens fall back to light-theme literals when unset", () => {
+    const palette = resolvePaletteFromTokens(readerFrom({}));
+    expect(palette.labelBackground).toBe("#ffffff");
+    expect(palette.labelStroke).toBe("#d1d1d1");
+  });
+
+  test("hover-label background contrasts with label text in both fallback and a dark token set (#484)", () => {
+    // Light fallback: white box, near-black text.
+    const light = resolvePaletteFromTokens(readerFrom({}));
+    expect(light.labelBackground).not.toBe(light.labelText);
+
+    // Dark theme: the very collision #484 fixes — sigma's default hover
+    // box was near-white while the foreground token is also near-white.
+    // With the box now following `--colorNeutralBackground1`, the box
+    // (near-black) and the text (near-white) read as opposites.
+    const dark = resolvePaletteFromTokens(
+      readerFrom({
+        "--colorNeutralBackground1": "#292929",
+        "--colorNeutralForeground1": "#ffffff",
+      }),
+    );
+    expect(dark.labelBackground).not.toBe(dark.labelText);
+  });
+
   test("trims whitespace around the resolved CSS variable", () => {
     const palette = resolvePaletteFromTokens(
       readerFrom({ "--colorNeutralForeground1": "  #0a0a0a  " }),

--- a/admin/app/components/illuminate/IlluminateCanvas/palette.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/palette.ts
@@ -38,6 +38,22 @@ export interface SigmaPalette {
   dimEdge: string;
   /** Label color resolved from `--colorNeutralForeground1`. */
   labelText: string;
+  /**
+   * #484 hover-label chip background, resolved from
+   * `--colorNeutralBackground1`. The custom hover renderer
+   * (`makeDrawNodeHover`) fills the hovered node's label box with this
+   * so the box and the {@link labelText} on top of it always contrast,
+   * fixing the white-on-white collision sigma's default hover renderer
+   * produced in dark theme.
+   */
+  labelBackground: string;
+  /**
+   * #484 hover-label chip border, resolved from `--colorNeutralStroke1`.
+   * Drawn as a 1px stroke around the hover box so the chip reads as a
+   * distinct surface even when its background is close to the canvas
+   * background.
+   */
+  labelStroke: string;
   /** Label font stack resolved from `--fontFamilyBase`. */
   labelFont: string;
   /**
@@ -72,6 +88,12 @@ export const FALLBACK_PALETTE: SigmaPalette = {
   dimNode: "#3f3f4626",
   dimEdge: "#bdbdbd26",
   labelText: "#242424",
+  // #484 hover chip. Light-theme literals for `--colorNeutralBackground1`
+  // (#ffffff) and `--colorNeutralStroke1` (#d1d1d1); paired with the
+  // `#242424` labelText they give a legible chip before FluentProvider
+  // hydrates and in the unit suite.
+  labelBackground: "#ffffff",
+  labelStroke: "#d1d1d1",
   labelFont:
     'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
   // #460 hop ramp. Light-theme literals — these are the swatches the
@@ -123,6 +145,15 @@ export function resolvePaletteFromTokens(reader: CssTokenReader): SigmaPalette {
     dimNode: FALLBACK_PALETTE.dimNode,
     dimEdge: FALLBACK_PALETTE.dimEdge,
     labelText: readVar("--colorNeutralForeground1", FALLBACK_PALETTE.labelText),
+    // #484 hover chip. Follow the Fluent surface tokens so a theme flip
+    // re-skins the hover box alongside the label text; the canvas
+    // re-applies them via `setSetting("defaultDrawNodeHover", …)` in the
+    // palette effect.
+    labelBackground: readVar(
+      "--colorNeutralBackground1",
+      FALLBACK_PALETTE.labelBackground,
+    ),
+    labelStroke: readVar("--colorNeutralStroke1", FALLBACK_PALETTE.labelStroke),
     labelFont: readVar("--fontFamilyBase", FALLBACK_PALETTE.labelFont),
     // #460 hop ramp. Token mapping per spec: hop 0/1/2 trace the
     // Fluent brand foreground/stroke ladder so the warmest stop

--- a/admin/tests/e2e/illuminate.spec.ts
+++ b/admin/tests/e2e/illuminate.spec.ts
@@ -1261,4 +1261,46 @@ test.describe("/illuminate", () => {
     }, hubToLeftEdge);
     expect(renderedColor).not.toBeNull();
   });
+
+  test("Hovered label chip contrasts with its text in both themes (#484)", async ({
+    page,
+  }) => {
+    const seed = encodeURIComponent("e2e:illum:hub");
+    await page.goto(`/illuminate?seed=${seed}`);
+    await expect(page.getByTestId("illuminate-counter")).toContainText(
+      "5 vertices",
+    );
+
+    type Bridge = {
+      getHoverLabelColors: () => {
+        background: string;
+        stroke: string;
+        text: string;
+      };
+    };
+    await page.waitForFunction(() => {
+      const win = window as Window & { __illuminateCanvas?: Bridge };
+      return !!win.__illuminateCanvas?.getHoverLabelColors;
+    });
+
+    // #484: sigma's default hover renderer painted a near-white box and
+    // drew the label in `--colorNeutralForeground1`, which is also
+    // near-white in dark theme — an unreadable white-on-white collision.
+    // The custom renderer skins the chip from `--colorNeutralBackground1`
+    // (+ a 1px `--colorNeutralStroke1` border) so the box always
+    // contrasts with the text. Asserting the resolved tokens differ in
+    // the *live* theme proves the wiring resolves real Fluent variables
+    // (not just the fallback literals) and that they never collide.
+    const colors = await page.evaluate(() => {
+      const win = window as Window & { __illuminateCanvas?: Bridge };
+      return win.__illuminateCanvas?.getHoverLabelColors() ?? null;
+    });
+    expect(colors).not.toBeNull();
+    expect(colors?.background).toBeTruthy();
+    expect(colors?.stroke).toBeTruthy();
+    expect(colors?.text).toBeTruthy();
+    // The chip background and the label text must be different colours —
+    // the exact collision #484 fixes.
+    expect(colors?.background).not.toBe(colors?.text);
+  });
 });


### PR DESCRIPTION
## Summary

Hovered node labels on the admin `/illuminate` canvas were illegible in dark theme. Sigma's default node-hover renderer paints a hardcoded white (`#FFF`) chip and draws the label using `labelColor`, so in dark mode users saw a glaring white box with near-invisible text.

This PR adds a theme-aware hover renderer, colocated with the canvas following the established `IlluminateCanvas/` pattern (rendering helper `.ts` + sibling `.test.ts`):

- **`palette.ts`** — resolve `labelBackground` (`--colorNeutralBackground1`) and `labelStroke` (`--colorNeutralStroke1`) from Fluent tokens, with light-theme literal fallbacks.
- **`hover-label.ts`** — `makeDrawNodeHover(palette)` returns a `NodeHoverDrawingFunction` that paints the chip with the resolved surface color + a 1px border and always draws the label in the contrasting `labelText` color. Mirrors Sigma's default chip geometry.
- **`IlluminateCanvas.tsx`** — wire it via `defaultDrawNodeHover` in the Sigma constructor and re-apply on palette (theme) changes. Exposes `getHoverLabelColors()` on the test bridge.

## Behavior

The chip background uses the Fluent app surface (`--colorNeutralBackground1`), so it blends with the canvas and is delineated by its 1px border, while the label text always contrasts:

- Light: box `#ffffff`, border `#d1d1d1`, text `#242424`
- Dark: box `#292929`, border `#666666`, text `#ffffff`

## Testing

- `hover-label.test.ts` (new) — asserts the renderer fills with `labelBackground`, strokes with `labelStroke` (1px), and draws the label in `labelText` (≠ background), plus the no-label branch and geometry.
- `palette.test.ts` — new cases for token resolution + dark/light contrast.
- `illuminate.spec.ts` — e2e asserts the live hover chip background differs from its text color.
- Full local gates green: lint, format check, typecheck, build, `435` unit, `46` e2e.

Closes #484