### PR TITLE
feat(admin): render only the latest Illuminate result, deleting the rest (#491)

### DIFF
--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -55,18 +55,18 @@ export interface IlluminateCanvasProps {
    */
   latestExpansionOrigin: string | null;
   /**
-   * Vertex keys belonging to the most recent expansion's result (#483).
-   * Every node whose id is absent from this set is hidden (graphology
-   * `hidden: true`) so the canvas collapses to just the latest
-   * Illuminate result. Hidden nodes are retained (not dropped) so they
-   * reappear at their remembered position when a later result includes
-   * them. An empty set means "no filter" (cold start / no expansion yet)
-   * — the canvas shows everything.
+   * Vertex keys belonging to the most recent expansion's result (#483,
+   * delete-not-hide per #491). The canvas renders ONLY this set: every
+   * node whose id is absent from it is dropped from graphology, so each
+   * graph switch deletes the previous frame's nodes and lets d3-force
+   * re-converge the new frame from scratch (no retained/frozen
+   * positions). An empty set means "no result yet" (cold start / Clear)
+   * — the canvas falls back to the full accumulator (itself empty then).
    */
   latestResultVertexKeys: Set<string>;
   /**
    * Edge ids belonging to the most recent expansion's result (#483).
-   * Same hide-but-retain semantics as {@link latestResultVertexKeys}.
+   * Same delete-only semantics as {@link latestResultVertexKeys}.
    */
   latestResultEdgeIds: Set<string>;
   onNodeClick: (key: string) => void;
@@ -202,9 +202,9 @@ export function IlluminateCanvas({
   } | null>(null);
   /**
    * When true, the rAF tick loop is suspended (#483 test bridge): the
-   * simulation is built and applied (hidden filter + survivor positions)
-   * but does not advance until `stepLayout`/`settleLayout` is called or
-   * the pause is released. Lets the e2e assert EXACT survivor positions
+   * simulation is built and applied (survivor positions retained) but
+   * does not advance until `stepLayout`/`settleLayout` is called or the
+   * pause is released. Lets the e2e assert EXACT survivor positions
    * immediately after a click, before any easing has occurred.
    */
   const layoutPausedRef = useRef<boolean>(false);
@@ -288,12 +288,10 @@ export function IlluminateCanvas({
   // without re-wiring sigma listeners.
 
   /**
-   * Copy the simulation's positions into graphology. Pinned nodes (#455
-   * `fixed`) flow the OTHER way — graphology is authoritative, so we feed
-   * the user-placed coordinate back into the sim (`fx`/`fy`) and never
-   * overwrite it. This keeps a drag performed mid-animation authoritative
-   * and guarantees pinned nodes never drift (#483 acceptance: drag-pinned
-   * remain fixed).
+   * Copy the simulation's positions into graphology. No node is ever
+   * pinned (drag-to-pin was removed in #491), so this is a one-way
+   * sim → graphology flow; the simulation is always authoritative for
+   * position and is free to relax every node toward equilibrium.
    */
   const writeBackLayoutPositions = useCallback(() => {
     const layout = layoutRef.current;
@@ -301,13 +299,6 @@ export function IlluminateCanvas({
     if (!layout || !graph) return;
     for (const fn of layout.forceNodes) {
       if (!graph.hasNode(fn.id)) continue;
-      if (graph.getNodeAttribute(fn.id, "fixed") === true) {
-        const x = graph.getNodeAttribute(fn.id, "x");
-        const y = graph.getNodeAttribute(fn.id, "y");
-        if (typeof x === "number") fn.fx = x;
-        if (typeof y === "number") fn.fy = y;
-        continue;
-      }
       if (typeof fn.x === "number") graph.setNodeAttribute(fn.id, "x", fn.x);
       if (typeof fn.y === "number") graph.setNodeAttribute(fn.id, "y", fn.y);
     }
@@ -367,6 +358,44 @@ export function IlluminateCanvas({
     },
     [],
   );
+
+  /**
+   * Rebuild the simulation over the currently-rendered nodes/edges and
+   * start animating so the layout re-converges. Used after a drag
+   * release (#491): the dropped node is NOT pinned, so reheating lets
+   * physics settle the whole graph around its new position instead of
+   * freezing it where the cursor left it. Rebuilding from the live
+   * graphology positions means no `fx`/`fy` pin survives the gesture.
+   */
+  const reheatLayout = useCallback(() => {
+    const graph = graphRef.current;
+    if (!graph) return;
+    const forceNodes: ForceNode[] = [];
+    for (const id of graph.nodes()) {
+      forceNodes.push({
+        id,
+        size: graph.getNodeAttribute(id, "size") as number,
+        x: graph.getNodeAttribute(id, "x") as number,
+        y: graph.getNodeAttribute(id, "y") as number,
+      });
+    }
+    if (forceNodes.length === 0) {
+      stopLayout();
+      return;
+    }
+    const forceLinks: ForceLink[] = graph.edges().map((id) => {
+      const [source, target] = graph.extremities(id);
+      return { source, target, weight: 1 };
+    });
+    beginLayout(forceNodes, forceLinks, FORCE_ALPHA);
+    startLayoutLoop();
+  }, [beginLayout, startLayoutLoop, stopLayout]);
+  // Ref mirror so the mount-effect drag handlers can reheat without the
+  // sigma setup effect (which runs once) needing to re-bind.
+  const reheatLayoutRef = useRef(reheatLayout);
+  useEffect(() => {
+    reheatLayoutRef.current = reheatLayout;
+  }, [reheatLayout]);
 
   /**
    * Advance the simulation `ticks` steps synchronously (no rAF) and write
@@ -619,15 +648,6 @@ export function IlluminateCanvas({
       renderer.refresh();
     };
     renderer.setSetting("nodeReducer", (key, data) => {
-      // === #483 hide non-result nodes ==================================
-      // Nodes outside the latest expansion result carry `hidden: true`
-      // (set in the reconcile effect). Return early so sigma skips them
-      // entirely and we don't waste TTL/hover math on invisible nodes.
-      // They are retained in graphology (not dropped) so they reappear
-      // at their remembered position when a later result includes them.
-      const baseAttrs = data as { hidden?: boolean };
-      if (baseAttrs.hidden === true) return data;
-      // === end #483 ===================================================
       // === #459 TTL alpha (composition note) ============================
       // Composition order is hop hue (#460) \u2192 TTL alpha (#459) \u2192 hover
       // dim (#458). TTL fade applies first so the hover dim's solid
@@ -674,12 +694,6 @@ export function IlluminateCanvas({
       };
     });
     renderer.setSetting("edgeReducer", (key, data) => {
-      // === #483 hide non-result edges =================================
-      // Edges outside the latest expansion result carry `hidden: true`.
-      // Skip them so they neither render nor incur TTL/hover compute.
-      const baseAttrs = data as { hidden?: boolean };
-      if (baseAttrs.hidden === true) return data;
-      // === end #483 ===================================================
       // === #459 TTL alpha (composition note same as nodeReducer) ========
       const attrs = data as { color: string; expiration?: string | null };
       const nowMs = nowRef.current;
@@ -812,16 +826,16 @@ export function IlluminateCanvas({
     renderer.on("enterEdge", showEdgeHover);
     renderer.on("leaveEdge", clearHoverNode);
 
-    // === #455 drag-to-pin ===================================================
+    // === #455 drag (no pin, per #491) =======================================
     // Sigma's standard drag-and-drop recipe. The dragged node id lives in
     // a closure-local ref (not React state) so a mid-drag rerender can't
     // wipe it. On mouse-down we suspend sigma's default camera-pan via
     // `preventSigmaDefault()` and mark the node highlighted so the user
     // gets a visual lock-on. On `mousemovebody` we project the cursor
     // into graph space and rewrite the node's x/y; sigma re-renders on
-    // the next frame. On mouse-up we set `fixed: true` so the continuous
-    // d3-force layout (#483) holds the user-placed node at its fx/fy on
-    // every subsequent expansion and never relaxes it.
+    // the next frame. On mouse-up we release the node back to the
+    // simulation (NO pin) and reheat the layout so physics re-converges
+    // the graph around its new position — the drag never freezes a node.
     const draggedNodeRef: { current: string | null } = { current: null };
     // Diagnostic counters exposed via the test bridge so #455's e2e can
     // disambiguate "drag fired but didn't move the node" from "drag
@@ -841,9 +855,9 @@ export function IlluminateCanvas({
       const pos = renderer.viewportToGraph({ x: coords.x, y: coords.y });
       graph.setNodeAttribute(node, "x", pos.x);
       graph.setNodeAttribute(node, "y", pos.y);
-      // #483: if a layout animation is in flight, pin this node in the
-      // sim to the cursor so the simulation respects the drag instead of
-      // fighting it (finishDrag then marks it `fixed` for good).
+      // #483: if a layout animation is in flight, hold this node at the
+      // cursor (temporary fx/fy) so the simulation respects the drag
+      // instead of fighting it; finishDrag clears the hold and reheats.
       const draggingForceNode = layoutRef.current?.nodeById.get(node);
       if (draggingForceNode) {
         draggingForceNode.fx = pos.x;
@@ -861,10 +875,12 @@ export function IlluminateCanvas({
       const node = draggedNodeRef.current;
       if (!node) return;
       graph.setNodeAttribute(node, "highlighted", false);
-      // Pin: the continuous d3-force layout (#483) holds this node at its
-      // fx/fy on every subsequent expansion so it never drifts.
-      graph.setNodeAttribute(node, "fixed", true);
       draggedNodeRef.current = null;
+      // No pin (#491): release the node back to physics and reheat the
+      // layout so it re-converges around the dropped position instead of
+      // freezing there. reheatLayout rebuilds the sim from the live
+      // graphology positions (including this drag), so no fx/fy survives.
+      reheatLayoutRef.current();
     };
     mouseCaptor.on("mouseup", finishDrag);
     // === end #455 ===========================================================
@@ -882,6 +898,12 @@ export function IlluminateCanvas({
       __illuminateCanvas?: {
         getNodePosition: (key: string) => { x: number; y: number } | null;
         isNodeFixed: (key: string) => boolean;
+        /**
+         * #491 test bridge: whether an edge currently exists in
+         * graphology. Lets the e2e assert delete-not-hide — a non-result
+         * edge is dropped (false), a result edge is present (true).
+         */
+        hasEdge: (key: string) => boolean;
         dragStats: () => {
           downNode: number;
           moveBody: number;
@@ -1022,21 +1044,6 @@ export function IlluminateCanvas({
           text: string;
         };
         /**
-         * #483 test bridge: whether a node currently carries the
-         * `hidden: true` attribute (i.e., it falls outside the latest
-         * expansion result). Hidden nodes are retained in graphology so
-         * they reappear at their remembered position; `false` when the
-         * key is unknown.
-         */
-        isNodeHidden: (key: string) => boolean;
-        /**
-         * #483 test bridge: whether an edge currently carries the
-         * `hidden: true` attribute (i.e., it falls outside the latest
-         * expansion result). Mirrors {@link isNodeHidden}; `false` when
-         * the edge id is unknown.
-         */
-        isEdgeHidden: (key: string) => boolean;
-        /**
          * #483 test bridge: pause or resume the continuous d3-force
          * layout. While paused the animation loop suspends (no ticks)
          * so the e2e can assert exact survivor positions immediately
@@ -1082,6 +1089,7 @@ export function IlluminateCanvas({
         if (!graph.hasNode(key)) return false;
         return graph.getNodeAttribute(key, "fixed") === true;
       },
+      hasEdge: (key: string) => graph.hasEdge(key),
       dragStats: () => ({ ...dragStats }),
       simulateDrag: (key: string, deltaGraphX: number, deltaGraphY: number) => {
         if (!graph.hasNode(key)) return false;
@@ -1108,7 +1116,7 @@ export function IlluminateCanvas({
           forceNode.fy = attrs.y + deltaGraphY;
         }
         dragStats.moveBody += 1;
-        // 3) mouseup \u2014 release + pin
+        // 3) mouseup \u2014 release (no pin, #491); finishDrag reheats the layout
         finishDrag();
         return true;
       },
@@ -1186,14 +1194,6 @@ export function IlluminateCanvas({
         stroke: paletteRef.current.labelStroke,
         text: paletteRef.current.labelText,
       }),
-      isNodeHidden: (key: string) => {
-        if (!graph.hasNode(key)) return false;
-        return graph.getNodeAttribute(key, "hidden") === true;
-      },
-      isEdgeHidden: (key: string) => {
-        if (!graph.hasEdge(key)) return false;
-        return graph.getEdgeAttribute(key, "hidden") === true;
-      },
       setLayoutPaused: (paused: boolean) => setLayoutPaused(paused),
       stepLayout: (ticks: number) => stepLayout(ticks),
       settleLayout: (maxTicks?: number) => settleLayout(maxTicks),
@@ -1318,23 +1318,29 @@ export function IlluminateCanvas({
   }, []);
   // === end #459 ==========================================================
 
-  // Reconcile the graph with the latest view model. We diff by ID rather
-  // than clearing so the continuous d3-force layout (#483) can keep the
-  // positions of nodes that survived from the previous frame — the canvas
-  // reads as a smooth, gradual expansion instead of a layout reshuffle on
-  // every refetch, and surviving nodes never snap on click.
+  // Reconcile the graph with the latest view model. The canvas renders
+  // ONLY the latest expansion result (#491): nodes/edges outside it are
+  // DROPPED (not hidden), and a survivor that carries over keeps its exact
+  // position so the d3-force layout (#483) eases the new frame in smoothly
+  // instead of reshuffling — surviving nodes never snap on click, while
+  // everything else is deleted and re-converges from scratch on return.
   useEffect(() => {
     const graph = graphRef.current;
     if (!graph) return;
     const sigma = sigmaRef.current;
 
-    const nextNodeIds = new Set(nodes.map((n) => n.id));
-    const nextEdgeIds = new Set(edges.map((e) => e.id));
-
-    // #483: once an expansion has produced a result, hide everything
-    // outside the latest result. An empty result set (cold mount, reseed,
-    // or Clear) hides nothing, so the full graph stays visible.
-    const hideNonResult = latestResultVertexKeys.size > 0;
+    // #491: the rendered set IS the latest expansion result. Once an
+    // expansion has produced a result we reconcile graphology down to
+    // exactly those nodes/edges (dropping the rest); an empty result set
+    // (cold mount, reseed, or Clear) falls back to the full accumulator
+    // (which is itself empty in that case).
+    const hasResult = latestResultVertexKeys.size > 0;
+    const nextNodeIds = hasResult
+      ? latestResultVertexKeys
+      : new Set(nodes.map((n) => n.id));
+    const nextEdgeIds = hasResult
+      ? latestResultEdgeIds
+      : new Set(edges.map((e) => e.id));
 
     // Per-reconcile diff used to choose the layout regime below (#483).
     // We compute it BEFORE mutating the graph so the counts reflect the
@@ -1366,6 +1372,10 @@ export function IlluminateCanvas({
     const neighboursByKey = buildNeighbourMap(nodes, edges);
 
     for (const node of nodes) {
+      // #491: render only the latest result; skip everything else so it is
+      // neither merged nor (re)created — the drop loop above already
+      // deleted it from graphology.
+      if (!nextNodeIds.has(node.id)) continue;
       const size = 4 + node.importance * 10;
       const color = pickFill(node);
       const detail = describeVertex(node);
@@ -1388,10 +1398,6 @@ export function IlluminateCanvas({
           // up against the new palette.
           hopDistance: node.hopDistance,
           firstSeenExpansion: node.firstSeenExpansion,
-          // #483: hide nodes outside the latest expansion result. We do
-          // NOT touch x/y here, so a survivor keeps its exact position
-          // (no snap); only its visibility flips.
-          hidden: hideNonResult && !latestResultVertexKeys.has(node.id),
         });
       } else {
         const { x, y } = pickInitialPosition({
@@ -1412,25 +1418,22 @@ export function IlluminateCanvas({
           expiration,
           hopDistance: node.hopDistance,
           firstSeenExpansion: node.firstSeenExpansion,
-          // #483: a freshly added node outside the latest result starts
-          // hidden but retains its seed position for when it returns.
-          hidden: hideNonResult && !latestResultVertexKeys.has(node.id),
         });
       }
     }
     for (const edge of edges) {
+      // #491: render only the latest result's edges, and never create an
+      // edge whose endpoints were dropped above (graphology would throw).
+      if (!nextEdgeIds.has(edge.id)) continue;
+      if (!graph.hasNode(edge.source) || !graph.hasNode(edge.target)) continue;
       // #459: edges have their own expiration; mirror the node treatment.
       const expiration = edge.edge.expiration ?? null;
-      // #483: hide edges that aren't part of the latest expansion result
-      // so the canvas shows only the clicked vertex's subgraph.
-      const edgeHidden = hideNonResult && !latestResultEdgeIds.has(edge.id);
       if (graph.hasEdge(edge.id)) {
         graph.mergeEdgeAttributes(edge.id, {
           size: 1 + Math.min(4, edge.weight),
           label: edge.id,
           detail: `weight = ${edge.weight}`,
           expiration,
-          hidden: edgeHidden,
         });
       } else {
         graph.addEdgeWithKey(edge.id, edge.source, edge.target, {
@@ -1439,33 +1442,27 @@ export function IlluminateCanvas({
           label: edge.id,
           detail: `weight = ${edge.weight}`,
           expiration,
-          hidden: edgeHidden,
         });
       }
     }
 
     // === #483 continuous layout regime =================================
-    // Build the simulation over only the VISIBLE nodes (hidden nodes are
-    // frozen — excluded from the sim, retaining their x/y so they reappear
-    // in place). Pinned nodes (#455 `fixed`) seed their fx/fy so the very
-    // first tick already respects the pin.
-    const visibleNodeIds = new Set<string>();
+    // Build the simulation over every rendered node (#491: delete-not-
+    // hide means graphology already holds exactly the latest result, so
+    // there is nothing to exclude). No node is pinned — drag-to-pin was
+    // removed in #491, so the sim is free to relax the whole frame toward
+    // equilibrium every reconcile.
     const forceNodes: ForceNode[] = [];
     for (const id of graph.nodes()) {
-      if (graph.getNodeAttribute(id, "hidden") === true) continue;
-      visibleNodeIds.add(id);
       const x = graph.getNodeAttribute(id, "x") as number;
       const y = graph.getNodeAttribute(id, "y") as number;
       const size = graph.getNodeAttribute(id, "size") as number;
-      const pinned = graph.getNodeAttribute(id, "fixed") === true;
-      forceNodes.push(
-        pinned ? { id, size, x, y, fx: x, fy: y } : { id, size, x, y },
-      );
+      forceNodes.push({ id, size, x, y });
     }
     const forceLinks: ForceLink[] = [];
     for (const edge of edges) {
-      if (!visibleNodeIds.has(edge.source)) continue;
-      if (!visibleNodeIds.has(edge.target)) continue;
+      if (!nextEdgeIds.has(edge.id)) continue;
+      if (!graph.hasNode(edge.source) || !graph.hasNode(edge.target)) continue;
       forceLinks.push({
         source: edge.source,
         target: edge.target,
@@ -1477,7 +1474,7 @@ export function IlluminateCanvas({
     // first paint is already a sensible layout. An incremental expansion
     // refreshes ONCE at t=0 (survivors render at their EXACT prior
     // position — no snap) and then eases on rAF. A pure attribute or
-    // visibility change just refreshes and leaves any running animation
+    // weight change just refreshes and leaves any running animation
     // alone.
     const survivorCount = nextNodeIds.size - addedCount;
     const isColdStart = nextNodeIds.size > 0 && survivorCount === 0;

--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -1529,12 +1529,20 @@ export function IlluminateCanvas({
   // legend stays compact in the common case (most graphs have no
   // unreachables, and many won't have anything past 2 hops).
   const legendBuckets = useMemo(() => {
+    // #491: the canvas renders ONLY the latest expansion result, so the
+    // legend must count only those nodes — otherwise it would tally
+    // vertices that have been dropped from the canvas. Mirror the
+    // reconcile's membership predicate: when a result is present the
+    // rendered set IS that result; otherwise (cold/reseed/Clear) every
+    // accumulator node renders.
+    const hasResult = latestResultVertexKeys.size > 0;
     let origin = 0;
     let oneHop = 0;
     let twoHop = 0;
     let far = 0;
     let unreachable = 0;
     for (const node of nodes) {
+      if (hasResult && !latestResultVertexKeys.has(node.id)) continue;
       const h = node.hopDistance;
       if (!Number.isFinite(h) || h < 0) {
         unreachable += 1;
@@ -1580,7 +1588,7 @@ export function IlluminateCanvas({
         color: palette.hopUnreachable,
       },
     ].filter((b) => b.count > 0);
-  }, [nodes, palette]);
+  }, [nodes, palette, latestResultVertexKeys]);
 
   return (
     <div className={wrapperClass} data-testid="illuminate-canvas">

--- a/admin/app/components/illuminate/IlluminateCanvas/force-layout.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/force-layout.ts
@@ -40,23 +40,34 @@ import {
  * springs pulling their endpoints toward this separation. Sigma
  * auto-rescales the whole layout to the viewport, so the absolute value
  * only matters *relative* to {@link FORCE_CHARGE_STRENGTH} and
- * {@link collideRadius}.
+ * {@link collideRadius}. Deliberately short: paired with a strong charge,
+ * short stiff edges reel each connected cluster into a tight, cohesive
+ * blob while repulsion drives the blobs apart — the classic readable
+ * force-layout look of tight edges + wide inter-cluster gaps.
  */
-export const FORCE_LINK_DISTANCE = 60;
+export const FORCE_LINK_DISTANCE = 40;
 /**
- * Spring stiffness in [0, 1]. Kept gentle so edges nudge rather than
- * yank — the charge + collide forces do most of the spacing work and a
- * stiff spring would make survivors lurch on the first tick.
+ * Spring stiffness in [0, 1]. Stiff enough that edges genuinely stay
+ * short — so a connected cluster reads as one tight group rather than a
+ * loose web — yet still below 1 so survivors ease into place after an
+ * expansion instead of snapping (#483 acceptance A; the gradual-motion
+ * invariant only requires that a node not reach its settled spot in a
+ * single tick, which velocity damping still guarantees at this
+ * stiffness).
  */
-export const FORCE_LINK_STRENGTH = 0.25;
+export const FORCE_LINK_STRENGTH = 0.5;
 /**
- * Many-body charge. Negative = mutual repulsion, so disconnected nodes
- * push apart and the graph fills open space instead of collapsing onto
- * its edges. Magnitude is balanced against the link distance to give a
- * readable, non-overlapping spread for the small-to-medium
- * neighbourhoods Illuminate returns.
+ * Many-body charge. Negative = mutual repulsion, so nodes push apart and
+ * the graph fills open space instead of collapsing onto its edges. Kept
+ * strong relative to {@link FORCE_LINK_DISTANCE}: the short, stiff edges
+ * hold each cluster together locally while this repulsion spreads the
+ * nodes — and drives whole clusters apart — opening the wide
+ * inter-cluster gaps that keep cross-cluster edges from overlapping.
+ * Because sigma rescales the layout to the viewport, it is this
+ * charge:link-distance *ratio* (not the absolute edge length) that sets
+ * how far things fan.
  */
-export const FORCE_CHARGE_STRENGTH = -180;
+export const FORCE_CHARGE_STRENGTH = -360;
 /**
  * Extra gap (graph units) added beyond a node's size-derived radius in
  * {@link collideRadius}. Guarantees a visible channel between two nodes

--- a/admin/tests/e2e/illuminate.spec.ts
+++ b/admin/tests/e2e/illuminate.spec.ts
@@ -438,10 +438,11 @@ test.describe("/illuminate", () => {
 
     // Requirement A (no snap): pause the continuous layout BEFORE the
     // click so the post-click reconcile builds the simulation but never
-    // ticks it. Every node that existed before the click must therefore
-    // hold its EXACT pre-click coordinates at t=0 (the first rendered
-    // frame) — whether it stays visible or gets hidden by the result
-    // filter — and only the brand-new node lands at fresh coordinates.
+    // ticks it. The node that SURVIVES into the latest result (leftleft,
+    // the expansion origin) must hold its EXACT pre-click coordinates at
+    // t=0 (the first rendered frame); the brand-new node lands at fresh
+    // coordinates, and every node outside the latest result is DELETED
+    // (#491) — readPos returns null for it.
     await pause(true);
 
     await page
@@ -456,13 +457,23 @@ test.describe("/illuminate", () => {
       "6 vertices",
     );
 
-    // t=0: exact equality for every pre-existing node — no jump.
+    // t=0: the surviving node (leftleft) holds its exact pre-click
+    // coordinates — no snap. Every other seed node falls outside the
+    // latest result and is therefore DELETED (#491), so readPos is null.
+    const survivorKey = "e2e:illum:leftleft";
     for (const k of seedKeys) {
       const now = await readPos(k);
-      const was = cold.get(k)!;
-      expect(now, `node ${k} vanished after the click`).not.toBeNull();
-      expect(now!.x, `${k} x snapped at t=0`).toBe(was.x);
-      expect(now!.y, `${k} y snapped at t=0`).toBe(was.y);
+      if (k === survivorKey) {
+        const was = cold.get(k)!;
+        expect(now, `survivor ${k} vanished after the click`).not.toBeNull();
+        expect(now!.x, `${k} x snapped at t=0`).toBe(was.x);
+        expect(now!.y, `${k} y snapped at t=0`).toBe(was.y);
+      } else {
+        expect(
+          now,
+          `${k} should be deleted (outside the latest result)`,
+        ).toBeNull();
+      }
     }
     // The newcomer is seeded a position near its parent's neighbourhood.
     const newcomer = await readPos("e2e:illum:leftleftleft");
@@ -528,7 +539,7 @@ test.describe("/illuminate", () => {
     expect(await layoutRunning()).toBe(false);
   });
 
-  test("Hides nodes and edges outside the latest result, retaining their positions (#483)", async ({
+  test("Deletes nodes and edges outside the latest result (#491)", async ({
     page,
   }) => {
     const seed = encodeURIComponent("e2e:illum:hub");
@@ -540,32 +551,26 @@ test.describe("/illuminate", () => {
     type Pos = { x: number; y: number };
     type Bridge = {
       getNodePosition: (k: string) => Pos | null;
-      isNodeHidden: (k: string) => boolean;
-      isEdgeHidden: (k: string) => boolean;
+      hasEdge: (k: string) => boolean;
     };
     await page.waitForFunction(() => {
       const win = window as Window & { __illuminateCanvas?: Bridge };
-      return !!win.__illuminateCanvas?.isEdgeHidden;
+      return !!win.__illuminateCanvas?.hasEdge;
     });
 
-    const nodeHidden = (k: string): Promise<boolean> =>
-      page.evaluate((key) => {
-        const win = window as Window & { __illuminateCanvas?: Bridge };
-        return win.__illuminateCanvas?.isNodeHidden(key) ?? false;
-      }, k);
-    const edgeHidden = (k: string): Promise<boolean> =>
-      page.evaluate((key) => {
-        const win = window as Window & { __illuminateCanvas?: Bridge };
-        return win.__illuminateCanvas?.isEdgeHidden(key) ?? false;
-      }, k);
     const readPos = (k: string): Promise<Pos | null> =>
       page.evaluate((key) => {
         const win = window as Window & { __illuminateCanvas?: Bridge };
         return win.__illuminateCanvas?.getNodePosition(key) ?? null;
       }, k);
+    const hasEdge = (k: string): Promise<boolean> =>
+      page.evaluate((key) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.hasEdge(key) ?? false;
+      }, k);
 
     // After the seed load (the only expansion so far) its result IS the
-    // whole frame, so nothing is hidden — all five seed nodes are shown.
+    // whole frame, so every seed node is rendered.
     for (const k of [
       "e2e:illum:hub",
       "e2e:illum:left",
@@ -573,20 +578,16 @@ test.describe("/illuminate", () => {
       "e2e:illum:leftleft",
       "e2e:illum:rightright",
     ]) {
-      expect(await nodeHidden(k), `${k} should be visible after seed`).toBe(
-        false,
-      );
+      expect(
+        await readPos(k),
+        `${k} should be rendered after seed`,
+      ).not.toBeNull();
     }
 
-    // Remember the far-right leaf's coordinates; it must be retained
-    // (hidden, not deleted) once it falls outside the next result.
-    const rightRightBefore = await readPos("e2e:illum:rightright");
-    expect(rightRightBefore).not.toBeNull();
-
     // Expand from `leftleft`. The latest result is now the leftleft
-    // neighbourhood, so the right-hand branch — four hops away and not in
-    // that result — must be hidden, while the freshly illuminated
-    // leftleftleft (and its origin) are shown.
+    // neighbourhood {leftleft, leftleftleft}, so every node outside it —
+    // hub, left, right, rightright — is DELETED (#491), while the freshly
+    // illuminated leftleftleft and its origin leftleft are rendered.
     await page
       .getByRole("group")
       .getByText(/List view \(5 vertices/)
@@ -597,29 +598,33 @@ test.describe("/illuminate", () => {
       .click();
     await expect(counter).toContainText("6 vertices");
 
-    // In the latest result → visible.
-    expect(await nodeHidden("e2e:illum:leftleftleft")).toBe(false);
-    expect(await nodeHidden("e2e:illum:leftleft")).toBe(false);
-    // Outside the latest result → hidden.
-    expect(await nodeHidden("e2e:illum:rightright")).toBe(true);
+    // In the latest result → rendered.
+    expect(await readPos("e2e:illum:leftleftleft")).not.toBeNull();
+    expect(await readPos("e2e:illum:leftleft")).not.toBeNull();
+    // Outside the latest result → deleted (not hidden).
+    for (const k of [
+      "e2e:illum:hub",
+      "e2e:illum:left",
+      "e2e:illum:right",
+      "e2e:illum:rightright",
+    ]) {
+      expect(
+        await readPos(k),
+        `${k} should be deleted (outside the latest result)`,
+      ).toBeNull();
+    }
 
-    // ...yet retained at its remembered coordinates so it reappears in
-    // place if a later result includes it.
-    const rightRightAfter = await readPos("e2e:illum:rightright");
-    expect(rightRightAfter).not.toBeNull();
-    expect(rightRightAfter!.x).toBe(rightRightBefore!.x);
-    expect(rightRightAfter!.y).toBe(rightRightBefore!.y);
-
-    // Edge filter: the edge inside the latest result is shown; an edge on
-    // the hidden right branch is hidden. Edge ids are `${tail}→${head}`
-    // (see edgeIdOf in app/lib/client/usecase/illuminate/state.ts).
-    expect(await edgeHidden("e2e:illum:leftleft→e2e:illum:leftleftleft")).toBe(
-      false,
+    // Edge delete-not-hide: the edge inside the latest result is present;
+    // an edge on the deleted right branch is gone (graphology drops the
+    // edges of any dropped node). Edge ids are `${tail}→${head}` (see
+    // edgeIdOf in app/lib/client/usecase/illuminate/state.ts).
+    expect(await hasEdge("e2e:illum:leftleft→e2e:illum:leftleftleft")).toBe(
+      true,
     );
-    expect(await edgeHidden("e2e:illum:right→e2e:illum:rightright")).toBe(true);
+    expect(await hasEdge("e2e:illum:right→e2e:illum:rightright")).toBe(false);
   });
 
-  test("Drag-to-pin: drag moves the node, releases pinned, and survives a subsequent expansion (#455)", async ({
+  test("Drag releases the node without pinning it; physics reclaims it (#491)", async ({
     page,
   }) => {
     const seed = encodeURIComponent("e2e:illum:hub");
@@ -634,10 +639,12 @@ test.describe("/illuminate", () => {
       isNodeFixed: (k: string) => boolean;
       dragStats: () => { downNode: number; moveBody: number; mouseUp: number };
       simulateDrag: (k: string, dx: number, dy: number) => boolean;
+      setLayoutPaused: (paused: boolean) => void;
+      stepLayout: (ticks: number) => number;
     };
     await page.waitForFunction(() => {
       const win = window as Window & { __illuminateCanvas?: Bridge };
-      return !!win.__illuminateCanvas;
+      return !!win.__illuminateCanvas?.setLayoutPaused;
     });
 
     const targetKey = "e2e:illum:left";
@@ -652,6 +659,23 @@ test.describe("/illuminate", () => {
         const win = window as Window & { __illuminateCanvas?: Bridge };
         return win.__illuminateCanvas?.isNodeFixed(key) ?? false;
       }, k);
+    const pause = (p: boolean): Promise<void> =>
+      page.evaluate((paused) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        win.__illuminateCanvas?.setLayoutPaused(paused);
+      }, p);
+    const step = (n: number): Promise<number> =>
+      page.evaluate((ticks) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.stepLayout(ticks) ?? 0;
+      }, n);
+
+    // Pause the continuous layout BEFORE the gesture so the reheat that
+    // finishDrag triggers (#491) builds a fresh simulation but does NOT
+    // tick it. That makes the immediate post-drag position deterministic
+    // (no rAF race), so we can assert the exact drag delta, then step the
+    // simulation by hand to prove the node is NOT pinned.
+    await pause(true);
 
     // Sanity: before the gesture, the node exists, has a graph position,
     // and is not pinned.
@@ -671,7 +695,7 @@ test.describe("/illuminate", () => {
     // serial test runs, making real-mouse synthesis unreliable. The
     // bridge invokes the SAME closure-local handlers the real sigma
     // events fire (downNode → mousemovebody → mouseup → finishDrag),
-    // so we cover the position-write + pin + dragStats accounting
+    // so we cover the position-write + release + dragStats accounting
     // without re-testing sigma's WebGL plumbing.
     const dragResult = await page.evaluate(
       ({ key, dx, dy }) => {
@@ -703,12 +727,13 @@ test.describe("/illuminate", () => {
       "drag bridge never registered mouseup",
     ).toBeGreaterThan(0);
 
+    // Immediately after release (layout paused, sim not ticked): the node
+    // sits at exactly before+delta and is NOT pinned (#491 — drag-to-pin
+    // was removed). simulateDrag bypasses sigma's viewport↔graph
+    // projection so the graph-space delta is what we put in.
     const afterDrag = await readGraphPos(targetKey);
     expect(afterDrag).not.toBeNull();
-    expect(await isFixed(targetKey)).toBe(true);
-    // The position must have moved by exactly the requested delta —
-    // simulateDrag bypasses sigma's viewport↔graph projection so the
-    // graph-space delta is what we put in.
+    expect(await isFixed(targetKey)).toBe(false);
     expect(afterDrag!.x - before!.x).toBeCloseTo(deltaX, 6);
     expect(afterDrag!.y - before!.y).toBeCloseTo(deltaY, 6);
 
@@ -722,34 +747,24 @@ test.describe("/illuminate", () => {
       "1 expansion",
     );
 
-    // Trigger an additive expansion. The continuous d3-force layout
-    // (#483) pins `left` via the simulation's fx/fy, and the write-back
-    // never overwrites a node flagged `fixed: true`, so the dropped node
-    // must stay exactly where the user left it.
-    await page
-      .getByRole("group")
-      .getByText(/List view \(5 vertices/)
-      .click();
-    const table = page.getByTestId("illuminate-table");
-    await table
-      .getByRole("button", { name: "Expand from e2e:illum:leftleft" })
-      .click();
-    await expect(page.getByTestId("illuminate-counter")).toContainText(
-      "6 vertices",
+    // No pin: the reheated simulation is free to relax the dropped node.
+    // Stepping the sim by hand must MOVE `left` away from where the drag
+    // left it — proving physics reclaims it instead of freezing it at the
+    // cursor (the old drag-to-pin behaviour held it exactly in place).
+    const ticked = await step(40);
+    expect(ticked, "stepLayout should advance the simulation").toBeGreaterThan(
+      0,
     );
-
-    const afterExpansion = await readGraphPos(targetKey);
-    expect(afterExpansion).not.toBeNull();
-    // A pinned node (fx/fy held) sees zero displacement from the force
-    // simulation — allow only floating-point noise.
-    const drift = Math.hypot(
-      afterExpansion!.x - afterDrag!.x,
-      afterExpansion!.y - afterDrag!.y,
+    const afterTicks = await readGraphPos(targetKey);
+    expect(afterTicks).not.toBeNull();
+    const reclaimed = Math.hypot(
+      afterTicks!.x - afterDrag!.x,
+      afterTicks!.y - afterDrag!.y,
     );
     expect(
-      drift,
-      `pinned node drifted by ${drift.toFixed(6)} graph units across an additive expansion`,
-    ).toBeLessThan(0.001);
+      reclaimed,
+      `unpinned node should be moved by the simulation, but only drifted ${reclaimed.toFixed(4)} units`,
+    ).toBeGreaterThan(1);
   });
 
   test("Hover focus mode dims non-neighbours and keeps incident edges saturated (#458)", async ({

--- a/admin/tests/e2e/illuminate.spec.ts
+++ b/admin/tests/e2e/illuminate.spec.ts
@@ -1079,7 +1079,7 @@ test.describe("/illuminate", () => {
     ).toBeGreaterThan(tickAfterHidden);
   });
 
-  test("Hop-distance coloring separates each ring and never grows existing distances across an additive expansion (#460)", async ({
+  test("Hop-distance coloring separates each ring, then recolors to the latest result after an expansion (#460, #491)", async ({
     page,
   }) => {
     const seed = encodeURIComponent("e2e:illum:hub");
@@ -1154,21 +1154,20 @@ test.describe("/illuminate", () => {
       0,
     );
 
-    // === Phase 2: additive expansion from leftleft =======================
-    // Adds leftleftleft (a fresh vertex) AND a second expansion origin
-    // (leftleft). After this:
-    //   - hub stays at hop 0 (still the original seed AND still an
-    //     expansion origin via the URL anchor; multi-source BFS keeps
-    //     it at 0).
-    //   - leftleft drops from hop 2 → hop 0 (it's now an expansion
-    //     origin itself).
-    //   - left drops from hop 1 → hop 1 (already at 1 from hub; can't
-    //     get lower since the chain hub→left→leftleft is 1 hop apart).
-    //   - leftleftleft enters at hop 1 (one edge from the new origin).
+    // === Phase 2: expand from leftleft — render only the latest result ===
+    // Per #491 the canvas renders ONLY the most recent expansion's
+    // result and DELETES everything else. Expanding from leftleft
+    // (step=2) yields the result {leftleft, leftleftleft}; the previous
+    // frame's hub/left/right/rightright are dropped from graphology even
+    // though they stay in the accumulator (the counter still totals 6).
     //
-    // The monotonic-shrink invariant is the key thing this test
-    // protects: every existing vertex's hop distance must stay the
-    // same or shrink, NEVER grow.
+    // Hop distances are computed over the full accumulator with both
+    // origins (hub via the URL anchor + leftleft as the new expansion),
+    // but only the rendered survivors expose a distance through the
+    // bridge:
+    //   - leftleft is now an expansion origin → hop 0.
+    //   - leftleftleft is one edge from it → hop 1.
+    //   - hub/left/right/rightright are deleted → no hop (null).
     await page
       .getByRole("group")
       .getByText(/List view \(5 vertices/)
@@ -1181,34 +1180,31 @@ test.describe("/illuminate", () => {
       "6 vertices",
     );
 
-    const newHubHop = await readHop(hubKey);
-    const newLeftHop = await readHop(leftKey);
-    const newRightHop = await readHop(rightKey);
-    const newLeftLeftHop = await readHop(leftLeftKey);
-    const newRightRightHop = await readHop(rightRightKey);
-    const newLeftLeftLeftHop = await readHop(leftLeftLeftKey);
+    // The latest result renders with its own ring colours.
+    expect(await readHop(leftLeftKey)).toBe(0);
+    expect(await readHop(leftLeftLeftKey)).toBe(1);
 
-    // The new origin and the vertex one edge from it.
-    expect(newLeftLeftHop).toBe(0);
-    expect(newLeftLeftLeftHop).toBe(1);
+    // Everything outside the latest result is gone from the canvas.
+    expect(await readHop(hubKey)).toBeNull();
+    expect(await readHop(leftKey)).toBeNull();
+    expect(await readHop(rightKey)).toBeNull();
+    expect(await readHop(rightRightKey)).toBeNull();
 
-    // Monotonic shrink: every previous distance MUST be ≤ what it was
-    // in phase 1.
-    expect(newHubHop).not.toBeNull();
-    expect(newLeftHop).not.toBeNull();
-    expect(newRightHop).not.toBeNull();
-    expect(newRightRightHop).not.toBeNull();
-    expect(newHubHop).toBeLessThanOrEqual(0);
-    expect(newLeftHop).toBeLessThanOrEqual(1);
-    expect(newRightHop).toBeLessThanOrEqual(1);
-    expect(newLeftLeftHop).toBeLessThanOrEqual(2);
-    expect(newRightRightHop).toBeLessThanOrEqual(2);
-
-    // Concretely: hub stays at 0 (still an origin), leftleft is now
-    // also at 0 (new origin), and the previously-2-hop leftleft is
-    // now a brand colour, not a far colour.
-    expect(newHubHop).toBe(0);
+    // The new origin paints with the origin colour and its single
+    // neighbour with the 1-hop colour — the same buckets phase 1 used.
     expect(await readNode(leftLeftKey)).toBe(hubColor);
+    expect(await readNode(leftLeftLeftKey)).toBe(leftColor);
+
+    // The legend recomputes to the rendered set: origin + 1-hop only.
+    // The earlier 2-hop row disappears because its only member
+    // (rightright) was deleted from the canvas.
+    await expect(page.getByTestId("illuminate-legend-origin")).toBeVisible();
+    await expect(page.getByTestId("illuminate-legend-1hop")).toBeVisible();
+    await expect(page.getByTestId("illuminate-legend-2hop")).toHaveCount(0);
+    await expect(page.getByTestId("illuminate-legend-far")).toHaveCount(0);
+    await expect(page.getByTestId("illuminate-legend-unreachable")).toHaveCount(
+      0,
+    );
   });
 
   test("Lineage chip strip scrolls the camera back to an expansion origin without mutating state (#456)", async ({


### PR DESCRIPTION
## What

Make the Illuminate canvas render **only the latest expansion result**. Each
time you seed or expand, the previous frame's nodes/edges are **deleted** from
graphology (not hidden), and the new result is added — so the layout
re-converges freely from the live physics every time. Dragging a node no longer
pins it.

Closes #491.

This reverses two behaviours that #483 / #455 had deliberately introduced:

- **#483** hid (kept, `hidden: true`) every vertex outside the latest result so
  the accumulator stayed on-canvas. #491 deletes them instead.
- **#455** pinned a node (`fixed: true`) where the user dropped it. #491 removes
  the pin so nothing blocks the d3-force convergence.

The three user directives this implements:

1. ドラッグしても固定しなくていい — a drag must not pin the node.
2. 新しいグラフに含まれない点は Hidden じゃなくて削除でいい — drop non-result
   nodes/edges, don't hide them.
3. 物理的な収束を妨げる固定はしないで欲しい。グラフを切り替えるたびに古い要素を
   消して新しい要素を追加するだけ — no convergence-blocking pins; each switch
   just deletes the old set and adds the new one.

## How

- **Reconcile** (`IlluminateCanvas.tsx`): the render set is
  `latestResultVertexKeys` when the latest expansion produced a result, else the
  full accumulator (the empty-set fallback preserves `/cli`, which passes empty
  result sets and must keep rendering everything). Nodes/edges outside the set
  are `graph.dropEdge` / `graph.dropNode`-ed (edges first) rather than marked
  hidden. The **counter still reports accumulator totals** (e.g. "6 vertices"),
  while the canvas draws only the latest result.
- **Drag**: `mousemovebody` still sets a *temporary* `fx`/`fy` on the
  in-flight simulation node while you hold it, but `finishDrag` clears the drag
  ref and calls `reheatLayout`, which rebuilds a fresh simulation from the live
  graphology positions — so no pin survives the release. The old
  `setNodeAttribute(node, "fixed", true)` is gone, and both Sigma reducers'
  `hidden` early-returns are removed.
- **Hop legend** (`fix(admin)` commit): the legend's bucket tally iterated the
  full `nodes` prop, so under #491 it claimed hop buckets for deleted vertices
  (e.g. a "2 hops" row whose only member was no longer drawn). It now filters to
  the same latest-result membership the reconcile uses, so the legend always
  matches what's on screen.
- **Force constants** (supporting tuning, requested inline in the same thread):
  shorter links + stronger charge so the from-scratch re-convergence reads
  cleanly — `FORCE_LINK_DISTANCE=40`, `FORCE_CHARGE_STRENGTH=-360`,
  `FORCE_ALPHA_DECAY=0.045`, etc. Covered by the existing `force-layout` unit
  tests.

## Tests

- **e2e** (`illuminate.spec.ts`):
  - New: *Deletes nodes and edges outside the latest result (#491)*.
  - New: *Drag releases the node without pinning it; physics reclaims it
    (#491)*.
  - Rewrote the #460 hop-colouring test: its phase-2 "additive expansion retains
    all prior nodes + monotonic hop-shrink" invariant described the pre-#491
    accumulator-render model. It now asserts the delete model — after expanding
    from `leftleft` the canvas shows only `{leftleft (hop 0), leftleftleft
    (hop 1)}`, the dropped `hub/left/right/rightright` report a null hop, and the
    legend collapses to origin + 1-hop.
  - The #483 "no positional snap at t=0" test keeps its title but now asserts
    delete semantics for the survivors.
- Full local validation: **47/47 e2e pass** (serial, CI-faithful `--workers=1`),
  **439/439 admin unit tests pass**, `typecheck` / `lint` / `format:check` all
  clean.

## Docs

No user-facing doc change needed: README.md / AGENTS.md / admin/README.md
describe only the `Illuminate` RPC + CLI surface, not the admin canvas's
internal hide/pin rendering details (verified by grep). The behaviour reversal
is captured by the new and rewritten e2e/unit tests.
