### PR TITLE
fix(admin): replace inline style with CSS Module in edit-vertex and remove dead editor.module.css

### DIFF
--- a/admin/app/components/edit-vertex/TtlField/TtlField.module.css
+++ b/admin/app/components/edit-vertex/TtlField/TtlField.module.css
@@ -1,0 +1,3 @@
+.customInput {
+  margin-top: var(--spacingVerticalS, 8px);
+}

--- a/admin/app/components/edit-vertex/TtlField/TtlField.tsx
+++ b/admin/app/components/edit-vertex/TtlField/TtlField.tsx
@@ -3,6 +3,7 @@ import type {
   TtlInput,
   TtlMode,
 } from "~/lib/client/usecase/edit-vertex/value-codec";
+import styles from "./TtlField.module.css";
 
 export interface TtlFieldProps {
   value: TtlInput;
@@ -45,7 +46,7 @@ export function TtlField(props: TtlFieldProps) {
             onChange={(_, data) => onChange({ ...value, custom: data.value })}
             placeholder="e.g. 15m, 2h30m, 7d (use Go syntax)"
             data-testid="vertex-ttl-custom"
-            style={{ marginTop: "8px" }}
+            className={styles.customInput}
           />
         ) : null}
       </div>

--- a/admin/app/components/edit-vertex/editors/editor.module.css
+++ b/admin/app/components/edit-vertex/editors/editor.module.css
@@ -1,5 +1,0 @@
-.root {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacingVerticalS, 8px);
-}


### PR DESCRIPTION
## What

Resolve the two CSS-Module rule violations in `admin/app/components/edit-vertex/`
flagged by the `react-router-app-architecture` skill audit:

1. **`TtlField`** carried an inline static `style={{ marginTop: "8px" }}` on the
   custom-duration `<Input>` — the only inline `style={{ … }}` left in the app.
   Replaced with a sibling CSS Module (`TtlField.module.css` → `.customInput`,
   `margin-top: var(--spacingVerticalS, 8px)`), matching the house idiom used
   everywhere else (e.g. `ExpansionChipStrip.module.css`). The `8px` value is
   preserved verbatim (now via the spacing token), so there is no visual change.
2. **`editors/editor.module.css`** was orphaned dead CSS — `grep -rn
   "editor.module" app/` returns zero importers; the 13 editor components render
   through Fluent `<Field>`/`<Input>` directly. Deleted.

## Why

The skill's `component-file-and-css-module-rules.md` lists inline static styles
as a forbidden pattern and CSS Modules as the default; it also calls for removing
unreferenced module files. `data-testid="vertex-ttl-custom"` is unchanged, so the
existing e2e selectors are unaffected.

## Validation

- `bun run format:check` — clean
- `bun run lint` — clean
- `bun run typecheck` — clean
- `bun run test` — 439 pass / 0 fail

Closes #493
