### PR TITLE
refactor(admin): extract /cli dispatch loop into usecase/cli controller

### DIFF
--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -4,316 +4,94 @@ import {
   Input,
   type InputProps,
 } from "@fluentui/react-components";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { dispatch, isDestructive } from "~/lib/client/usecase/cli/dispatcher";
-import { parse, type Command, type ParseResult } from "~/lib/cli/parser";
-import { HELP_TEXT } from "~/lib/cli/verbs";
-import { commandResultToGraphView } from "~/lib/client/usecase/cli/graph-view";
-import { useCliSplitter } from "~/lib/client/usecase/cli/use-cli-splitter";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { formatIlluminateClick } from "~/lib/cli/illuminate-axes";
+import { useCli } from "~/lib/client/usecase/cli/use-cli";
+import { useCliSplitter } from "~/lib/client/usecase/cli/use-cli-splitter";
 import { useCliAxisPicker } from "~/lib/client/usecase/cli/use-cli-axis-picker";
 import { CliAxisPicker } from "~/components/cli/CliAxisPicker/CliAxisPicker";
 import { IlluminateCanvas } from "~/components/illuminate/IlluminateCanvas/IlluminateCanvas";
-import type { GraphView } from "~/lib/client/usecase/illuminate/selectors";
-import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
-import { LanternApiError } from "~/lib/client/infrastructure/api/error";
 import styles from "./CliPage.module.css";
 
-type EntryKind = "ok" | "error" | "info";
-
-interface LatestGraph {
-  /** The exact CLI input that produced this graph (`get vertex alice`, …). */
-  source: string;
-  view: GraphView;
-}
-
-interface ScrollbackEntry {
-  id: number;
-  input: string;
-  kind: EntryKind;
-  text: string;
-  durationMs?: number;
-}
-
-interface PendingDestructive {
-  command: Command;
-  rendered: string;
-}
-
 /**
- * The /cli admin route. A Fluent UI command-line panel shared with
- * the Go REPL via the `lib/cli/parser` TypeScript port (#411).
+ * The /cli admin route. A Fluent UI command-line panel shared with the
+ * Go REPL via the `lib/cli/parser` TypeScript port (#411).
  *
- * Features:
- * - Per-verb dispatch through `lantern-sdk/web` via the
- *   `lib/client/infrastructure/api` adapters.
- * - Arrow-up / arrow-down history.
- * - Confirmation chip for destructive verbs (`delete`, `put`, `add`)
- *   with a per-session "do not ask again" toggle.
- * - Per-command timing badge in the `OK (1.4ms)` style the Go REPL
- *   prints.
+ * This component is render-only: the stateful dispatch loop (parsing,
+ * per-verb dispatch, history, destructive confirmation, cancellation,
+ * graph projection) lives in the `useCli` controller hook (#494). The
+ * splitter and axis-picker keep their own feature-local hooks.
  */
 export function CliPage() {
-  const client = useLanternClient();
-  const [scrollback, setScrollback] = useState<ScrollbackEntry[]>([
-    initialBanner(),
-  ]);
-  const [input, setInput] = useState("");
-  const [history, setHistory] = useState<string[]>([]);
-  const [historyIndex, setHistoryIndex] = useState<number | null>(null);
-  const [pending, setPending] = useState<PendingDestructive | null>(null);
-  const [skipConfirm, setSkipConfirm] = useState(false);
-  const [busy, setBusy] = useState(false);
-  // The most recent graph-producing command's view. Mutating verbs
-  // (`put`, `add`, `delete`) leave this alone so the operator keeps
-  // their exploration context after a write. Null until the first
-  // graph-producing command lands.
-  const [latestGraph, setLatestGraph] = useState<LatestGraph | null>(null);
+  const cli = useCli();
   const scrollRef = useRef<HTMLDivElement>(null);
-  const idRef = useRef(2);
-  // Backs the `Cancel` action (#433). `runCommand` populates this
-  // with a fresh controller before each dispatch and clears it on
-  // settle; the toolbar's `Cancel` button calls `.abort()` on it
-  // while busy. The dispatcher already plumbs `signal` through every
-  // underlying RPC, so the abort propagates end-to-end.
-  const abortRef = useRef<AbortController | null>(null);
   // Drives the two-column grid + draggable splitter (#465). Only active
   // when a graph is present; otherwise the right column owns the full
   // width and the splitter handle is hidden by CSS.
   const rootRef = useRef<HTMLDivElement>(null);
   const splitter = useCliSplitter({
-    enabled: latestGraph !== null,
+    enabled: cli.latestGraph !== null,
     rootRef,
   });
   // Owns the click-to-illuminate axis picker strip state (#464). The
   // hook hydrates from localStorage so a refresh preserves a tuned
-  // exploration session, and persists each axis change so the next
-  // page load picks up where the operator left off.
+  // exploration session, and persists each axis change so the next page
+  // load picks up where the operator left off.
   const axisPicker = useCliAxisPicker();
 
-  const append = useCallback((entry: Omit<ScrollbackEntry, "id">) => {
-    setScrollback((prev) => [...prev, { ...entry, id: idRef.current++ }]);
-  }, []);
-
-  // Auto-scroll the scrollback to the bottom on every new entry so
-  // the operator always sees their most recent output without
-  // chasing the panel's scrollbar.
+  // Auto-scroll the scrollback to the bottom on every new entry so the
+  // operator always sees their most recent output without chasing the
+  // panel's scrollbar.
   useEffect(() => {
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [scrollback]);
-  const runCommand = useCallback(
-    async (rawInput: string, command: Command) => {
-      setBusy(true);
-      const controller = new AbortController();
-      abortRef.current = controller;
-      const start = performance.now();
-      try {
-        const out = await dispatch({
-          client,
-          command,
-          signal: controller.signal,
-        });
-        const elapsed = performance.now() - start;
-        append({
-          input: rawInput,
-          kind: "ok",
-          text:
-            out === null || out === undefined
-              ? "OK"
-              : "OK\n" + JSON.stringify(out, replacer, 2),
-          durationMs: elapsed,
-        });
-        // Project graph-shaped results onto the canvas. null means
-        // the verb carries no graph payload (put/add/delete/exit) —
-        // leave the previous canvas alone in that case.
-        const view = commandResultToGraphView(command, out);
-        if (view !== null) {
-          setLatestGraph({ source: rawInput, view });
-        }
-      } catch (err) {
-        const elapsed = performance.now() - start;
-        // Cancellation via the Cancel button / Esc — render an
-        // `info` line ("aborted") rather than the red error chip so
-        // the operator can tell the difference between a failed RPC
-        // and a deliberate stop (#433).
-        if (isAbortError(err) || controller.signal.aborted) {
-          append({
-            input: rawInput,
-            kind: "info",
-            text: "aborted",
-            durationMs: elapsed,
-          });
-        } else {
-          append({
-            input: rawInput,
-            kind: "error",
-            text: errorMessage(err),
-            durationMs: elapsed,
-          });
-        }
-      } finally {
-        abortRef.current = null;
-        setBusy(false);
-      }
-    },
-    [append, client],
-  );
-
-  /**
-   * Resets the scrollback to just the banner line. Wired to the
-   * toolbar `Clear` button and `Ctrl+L` / `Cmd+L` (#433). Gateway
-   * override, skipConfirm, and history are deliberately preserved
-   * so a clear behaves like an editor's "clear screen", not a hard
-   * reset of the session.
-   */
-  const clearScrollback = useCallback(() => {
-    idRef.current = 2;
-    setScrollback([initialBanner()]);
-  }, []);
-
-  /**
-   * Aborts the in-flight dispatch, if any. Wired to the toolbar
-   * `Cancel` button and `Esc` (#433). The `runCommand` catch handler
-   * is responsible for rendering the `aborted` scrollback line.
-   */
-  const cancelInFlight = useCallback(() => {
-    abortRef.current?.abort();
-  }, []);
-
-  const runRaw = useCallback(
-    async (raw: string) => {
-      if (raw.trim() === "") return;
-      setHistory((prev) => [...prev, raw]);
-      setHistoryIndex(null);
-      setInput("");
-      const result: ParseResult = parse(raw);
-      if (!result.ok) {
-        append({ input: raw, kind: "error", text: result.usage });
-        return;
-      }
-      if (result.command.verb === "exit") {
-        append({
-          input: raw,
-          kind: "info",
-          text: "(exit is a no-op in the web CLI; close the tab to leave)",
-        });
-        return;
-      }
-      if (result.command.verb === "help") {
-        append({
-          input: raw,
-          kind: "info",
-          text: HELP_TEXT,
-        });
-        return;
-      }
-      if (isDestructive(result.command) && !skipConfirm) {
-        setPending({
-          command: result.command,
-          rendered: raw,
-        });
-        return;
-      }
-      await runCommand(raw, result.command);
-    },
-    [append, runCommand, skipConfirm],
-  );
-
-  const submit = useCallback(async () => {
-    await runRaw(input);
-  }, [input, runRaw]);
-
-  // Window-level keyboard shortcuts (#433):
-  //   - Esc while a command is in flight aborts the dispatch. The
-  //     prompt `<Input>` is `disabled` while busy and so cannot
-  //     receive its own keydown events; binding at window scope
-  //     is the only way to make Esc reach `cancelInFlight`.
-  //   - Ctrl+L / Cmd+L clears the scrollback. Bound globally so it
-  //     works whether the prompt has focus or not (matches xterm /
-  //     bash behaviour).
-  // The handler ignores events from text inputs, contenteditables,
-  // and textareas the user might be typing in elsewhere on the
-  // panel, except the prompt itself (which still calls the same
-  // handlers via its onKeyDown — duplication is harmless because
-  // both call sites land in idempotent setters).
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "l") {
-        e.preventDefault();
-        clearScrollback();
-        return;
-      }
-      if (e.key === "Escape" && busy) {
-        e.preventDefault();
-        cancelInFlight();
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [busy, cancelInFlight, clearScrollback]);
+  }, [cli.scrollback]);
 
   // Click-to-illuminate (#439, #464). Writes the picker-formatted
-  // illuminate command into the prompt and submits it through the
-  // same parser path the user would hit by typing it. Illuminate is
-  // non-destructive, so the confirmation chip never fires here. With
-  // the picker at its defaults the formatter emits the canonical
-  // short form `illuminate <key> 2 5` (regression guard).
+  // illuminate command into the prompt and submits it through the same
+  // parser path the user would hit by typing it. Illuminate is
+  // non-destructive, so the confirmation chip never fires here. With the
+  // picker at its defaults the formatter emits the canonical short form
+  // `illuminate <key> 2 5` (regression guard).
   const onNodeClick = useCallback(
     (key: string) => {
-      if (busy || pending !== null) return;
-      const raw = formatIlluminateClick(key, axisPicker.axes);
-      setInput(raw);
-      void runRaw(raw);
+      if (cli.busy || cli.pending !== null) return;
+      cli.runRaw(formatIlluminateClick(key, axisPicker.axes));
     },
-    [busy, pending, runRaw, axisPicker.axes],
+    [cli, axisPicker.axes],
   );
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      // Esc / Ctrl+L are owned by the window-level handler above so
-      // they work even while the input is `disabled` (busy state) or
-      // without focus. Enter / ArrowUp / ArrowDown stay local
-      // because they read and write input state.
+      // Esc / Ctrl+L are owned by the window-level handler in `useCli`
+      // so they work even while the input is `disabled` (busy state) or
+      // without focus. Enter / ArrowUp / ArrowDown stay local because
+      // they read and write input state.
       if (e.key === "Enter") {
         e.preventDefault();
-        void submit();
+        cli.submit();
         return;
       }
       if (e.key === "ArrowUp") {
         e.preventDefault();
-        if (history.length === 0) return;
-        const next =
-          historyIndex === null
-            ? history.length - 1
-            : Math.max(0, historyIndex - 1);
-        setHistoryIndex(next);
-        setInput(history[next]);
+        cli.historyPrev();
         return;
       }
       if (e.key === "ArrowDown") {
         e.preventDefault();
-        if (historyIndex === null) return;
-        const next = historyIndex + 1;
-        if (next >= history.length) {
-          setHistoryIndex(null);
-          setInput("");
-        } else {
-          setHistoryIndex(next);
-          setInput(history[next]);
-        }
+        cli.historyNext();
       }
     },
-    [history, historyIndex, submit],
+    [cli],
   );
 
   const onChange: InputProps["onChange"] = (_e, data) => {
-    setInput(data.value);
+    cli.setInput(data.value);
   };
 
   const renderedScrollback = useMemo(
     () =>
-      scrollback.map((entry) => (
+      cli.scrollback.map((entry) => (
         <div
           key={entry.id}
           className={styles.entry}
@@ -343,7 +121,7 @@ export function CliPage() {
           </div>
         </div>
       )),
-    [scrollback],
+    [cli.scrollback],
   );
 
   return (
@@ -351,16 +129,16 @@ export function CliPage() {
       ref={rootRef}
       className={styles.root}
       data-testid="cli-root"
-      data-mode={latestGraph !== null ? "split" : "cli"}
+      data-mode={cli.latestGraph !== null ? "split" : "cli"}
       data-dragging={splitter.dragging ? "true" : undefined}
     >
-      {latestGraph !== null ? (
+      {cli.latestGraph !== null ? (
         <div className={styles.leftColumn} data-testid="cli-left-column">
           <div className={styles.canvasPanel} data-testid="cli-canvas-panel">
             <div className={styles.canvasHeader}>
               <span className={styles.canvasHeaderLabel}>from:</span>{" "}
               <code className={styles.canvasHeaderSource}>
-                {latestGraph.source}
+                {cli.latestGraph.source}
               </code>
               <span className={styles.canvasHeaderHint}>
                 click any node to run{" "}
@@ -371,19 +149,23 @@ export function CliPage() {
             </div>
             <div className={styles.canvasBody}>
               <IlluminateCanvas
-                nodes={latestGraph.view.nodes}
-                edges={latestGraph.view.edges}
-                latestExpansionOrigin={latestGraph.view.latestExpansionOrigin}
-                latestResultVertexKeys={latestGraph.view.latestResultVertexKeys}
-                latestResultEdgeIds={latestGraph.view.latestResultEdgeIds}
+                nodes={cli.latestGraph.view.nodes}
+                edges={cli.latestGraph.view.edges}
+                latestExpansionOrigin={
+                  cli.latestGraph.view.latestExpansionOrigin
+                }
+                latestResultVertexKeys={
+                  cli.latestGraph.view.latestResultVertexKeys
+                }
+                latestResultEdgeIds={cli.latestGraph.view.latestResultEdgeIds}
                 onNodeClick={onNodeClick}
-                isBusy={busy}
+                isBusy={cli.busy}
               />
             </div>
           </div>
         </div>
       ) : null}
-      {latestGraph !== null ? (
+      {cli.latestGraph !== null ? (
         <div
           className={styles.splitter}
           data-testid="cli-splitter"
@@ -396,19 +178,19 @@ export function CliPage() {
           <Button
             appearance="secondary"
             size="small"
-            onClick={clearScrollback}
-            disabled={scrollback.length <= 1}
+            onClick={cli.clearScrollback}
+            disabled={cli.scrollback.length <= 1}
             data-testid="cli-clear"
             aria-label="Clear scrollback (Ctrl+L)"
             title="Clear scrollback (Ctrl+L)"
           >
             Clear
           </Button>
-          {busy ? (
+          {cli.busy ? (
             <Button
               appearance="secondary"
               size="small"
-              onClick={cancelInFlight}
+              onClick={cli.cancelInFlight}
               data-testid="cli-cancel"
               aria-label="Cancel in-flight command (Esc)"
               title="Cancel in-flight command (Esc)"
@@ -419,40 +201,34 @@ export function CliPage() {
           <CliAxisPicker
             axes={axisPicker.axes}
             setAxis={axisPicker.setAxis}
-            disabled={busy || pending !== null}
+            disabled={cli.busy || cli.pending !== null}
           />
         </div>
         <div className={styles.scrollback} ref={scrollRef} aria-live="polite">
           {renderedScrollback}
         </div>
-        {pending !== null ? (
+        {cli.pending !== null ? (
           <div className={styles.confirmBar} data-testid="cli-confirm">
             <span className={styles.confirmText}>
-              About to run: <code>{pending.rendered}</code> — this mutates
+              About to run: <code>{cli.pending.rendered}</code> — this mutates
               server state.
             </span>
             <Checkbox
               label="Do not ask again this session"
-              checked={skipConfirm}
-              onChange={(_e, data) => setSkipConfirm(Boolean(data.checked))}
+              checked={cli.skipConfirm}
+              onChange={(_e, data) => cli.setSkipConfirm(Boolean(data.checked))}
               data-testid="cli-skip-confirm"
             />
             <Button
               appearance="secondary"
-              onClick={() => setPending(null)}
+              onClick={cli.confirmCancel}
               data-testid="cli-confirm-cancel"
             >
               Cancel
             </Button>
             <Button
               appearance="primary"
-              onClick={async () => {
-                const p = pending;
-                setPending(null);
-                if (p) {
-                  await runCommand(p.rendered, p.command);
-                }
-              }}
+              onClick={cli.confirmRun}
               data-testid="cli-confirm-run"
             >
               Run
@@ -463,62 +239,16 @@ export function CliPage() {
           <span className={styles.prompt}>&gt;</span>
           <Input
             className={styles.input}
-            value={input}
+            value={cli.input}
             onChange={onChange}
             onKeyDown={onKeyDown}
             placeholder="get vertex alice    |    illuminate alice 2 5 algorithm=spt"
-            disabled={busy || pending !== null}
+            disabled={cli.busy || cli.pending !== null}
             data-testid="cli-input"
             aria-label="CLI command input"
           />
         </div>
       </div>
     </div>
-  );
-}
-
-function initialBanner(): ScrollbackEntry {
-  return {
-    id: 1,
-    input: "",
-    kind: "info",
-    text: [
-      "Lantern admin CLI (#411). Same grammar as `lantern repl`.",
-      "Type a verb and Enter; arrow-up / arrow-down cycle history.",
-      'Type "help" for verb signatures.',
-    ].join("\n"),
-  };
-}
-
-function replacer(_key: string, value: unknown): unknown {
-  if (typeof value === "bigint") {
-    return String(value);
-  }
-  return value;
-}
-
-function errorMessage(err: unknown): string {
-  if (err instanceof LanternApiError) {
-    return `[${err.code}] ${err.grpcMessage || err.message}`;
-  }
-  if (err instanceof Error) {
-    return err.message;
-  }
-  return String(err);
-}
-
-/**
- * Distinguishes a deliberate cancellation (from `AbortController.abort`)
- * from a genuine RPC failure. The Connect SDK and `fetch` both raise
- * `DOMException`/`Error` instances whose `name` is `"AbortError"` —
- * `error.ts` deliberately lets these through unwrapped so this check
- * works without needing a `LanternApiError` adapter.
- */
-function isAbortError(err: unknown): boolean {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    "name" in err &&
-    (err as { name?: string }).name === "AbortError"
   );
 }

--- a/admin/app/lib/client/usecase/cli/reducer.test.ts
+++ b/admin/app/lib/client/usecase/cli/reducer.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "bun:test";
+import { cliReducer } from "./reducer";
+import {
+  INITIAL_CLI_STATE,
+  initialBanner,
+  type CliState,
+  type LatestGraph,
+} from "./state";
+
+function withHistory(history: string[], historyIndex: number | null): CliState {
+  return { ...INITIAL_CLI_STATE, history, historyIndex };
+}
+
+const GRAPH: LatestGraph = {
+  source: "get vertex alice",
+  view: {
+    nodes: [],
+    edges: [],
+    latestExpansionOrigin: null,
+    expansionOrigins: [],
+    overSoftCap: false,
+    latestResultVertexKeys: new Set<string>(),
+    latestResultEdgeIds: new Set<string>(),
+  },
+};
+
+describe("cliReducer", () => {
+  describe("INPUT_CHANGED", () => {
+    it("updates the prompt text", () => {
+      const next = cliReducer(INITIAL_CLI_STATE, {
+        type: "INPUT_CHANGED",
+        value: "get vertex a",
+      });
+      expect(next.input).toBe("get vertex a");
+    });
+
+    it("is identity when the value is unchanged", () => {
+      const next = cliReducer(INITIAL_CLI_STATE, {
+        type: "INPUT_CHANGED",
+        value: "",
+      });
+      expect(next).toBe(INITIAL_CLI_STATE);
+    });
+  });
+
+  describe("HISTORY_PREV", () => {
+    it("is a no-op when history is empty", () => {
+      const next = cliReducer(INITIAL_CLI_STATE, { type: "HISTORY_PREV" });
+      expect(next).toBe(INITIAL_CLI_STATE);
+    });
+
+    it("recalls the newest entry when not yet navigating", () => {
+      const base = withHistory(["a", "b", "c"], null);
+      const next = cliReducer(base, { type: "HISTORY_PREV" });
+      expect(next.historyIndex).toBe(2);
+      expect(next.input).toBe("c");
+    });
+
+    it("steps toward older entries and clamps at zero", () => {
+      let state = withHistory(["a", "b", "c"], 1);
+      state = cliReducer(state, { type: "HISTORY_PREV" });
+      expect(state.historyIndex).toBe(0);
+      expect(state.input).toBe("a");
+      // Already at the oldest entry — stays put.
+      state = cliReducer(state, { type: "HISTORY_PREV" });
+      expect(state.historyIndex).toBe(0);
+      expect(state.input).toBe("a");
+    });
+  });
+
+  describe("HISTORY_NEXT", () => {
+    it("is a no-op when not navigating history", () => {
+      const base = withHistory(["a", "b"], null);
+      const next = cliReducer(base, { type: "HISTORY_NEXT" });
+      expect(next).toBe(base);
+    });
+
+    it("advances toward the newest entry", () => {
+      const base = withHistory(["a", "b", "c"], 0);
+      const next = cliReducer(base, { type: "HISTORY_NEXT" });
+      expect(next.historyIndex).toBe(1);
+      expect(next.input).toBe("b");
+    });
+
+    it("clears the prompt when stepping past the newest entry", () => {
+      const base = withHistory(["a", "b"], 1);
+      const next = cliReducer(base, { type: "HISTORY_NEXT" });
+      expect(next.historyIndex).toBeNull();
+      expect(next.input).toBe("");
+    });
+  });
+
+  describe("COMMAND_SUBMITTED", () => {
+    it("pushes to history, resets the cursor, and clears the prompt", () => {
+      const base = withHistory(["a"], 0);
+      const next = cliReducer(
+        { ...base, input: "get vertex bob" },
+        { type: "COMMAND_SUBMITTED", raw: "get vertex bob" },
+      );
+      expect(next.history).toEqual(["a", "get vertex bob"]);
+      expect(next.historyIndex).toBeNull();
+      expect(next.input).toBe("");
+    });
+  });
+
+  describe("ENTRY_APPENDED", () => {
+    it("appends with the next id and bumps the counter", () => {
+      const next = cliReducer(INITIAL_CLI_STATE, {
+        type: "ENTRY_APPENDED",
+        entry: { input: "help", kind: "info", text: "..." },
+      });
+      expect(next.scrollback).toHaveLength(2);
+      expect(next.scrollback[1].id).toBe(2);
+      expect(next.nextEntryId).toBe(3);
+    });
+
+    it("assigns monotonic ids across multiple appends", () => {
+      let state = cliReducer(INITIAL_CLI_STATE, {
+        type: "ENTRY_APPENDED",
+        entry: { input: "a", kind: "ok", text: "OK" },
+      });
+      state = cliReducer(state, {
+        type: "ENTRY_APPENDED",
+        entry: { input: "b", kind: "ok", text: "OK" },
+      });
+      expect(state.scrollback.map((e) => e.id)).toEqual([1, 2, 3]);
+      expect(state.nextEntryId).toBe(4);
+    });
+  });
+
+  describe("SCROLLBACK_CLEARED", () => {
+    it("resets to just the banner and rewinds the id counter", () => {
+      let state = cliReducer(INITIAL_CLI_STATE, {
+        type: "ENTRY_APPENDED",
+        entry: { input: "a", kind: "ok", text: "OK" },
+      });
+      state = cliReducer(state, { type: "SCROLLBACK_CLEARED" });
+      expect(state.scrollback).toEqual([initialBanner()]);
+      expect(state.nextEntryId).toBe(2);
+    });
+
+    it("preserves history and skipConfirm (clear-screen, not reset)", () => {
+      const base: CliState = {
+        ...INITIAL_CLI_STATE,
+        history: ["a", "b"],
+        skipConfirm: true,
+      };
+      const next = cliReducer(base, { type: "SCROLLBACK_CLEARED" });
+      expect(next.history).toEqual(["a", "b"]);
+      expect(next.skipConfirm).toBe(true);
+    });
+  });
+
+  describe("phase transitions", () => {
+    it("enters running on RUN_STARTED and idle on RUN_SETTLED", () => {
+      const running = cliReducer(INITIAL_CLI_STATE, { type: "RUN_STARTED" });
+      expect(running.phase).toBe("running");
+      const idle = cliReducer(running, { type: "RUN_SETTLED" });
+      expect(idle.phase).toBe("idle");
+    });
+  });
+
+  describe("GRAPH_UPDATED", () => {
+    it("replaces the latest graph view", () => {
+      const next = cliReducer(INITIAL_CLI_STATE, {
+        type: "GRAPH_UPDATED",
+        graph: GRAPH,
+      });
+      expect(next.latestGraph).toBe(GRAPH);
+    });
+  });
+
+  describe("pending destructive confirmation", () => {
+    it("sets and clears the pending command", () => {
+      const pending = {
+        rendered: "delete vertex alice",
+        command: { verb: "delete", objective: "vertex", key: "alice" },
+      } as const;
+      const set = cliReducer(INITIAL_CLI_STATE, {
+        type: "PENDING_SET",
+        pending,
+      });
+      expect(set.pending).toBe(pending);
+      const cleared = cliReducer(set, { type: "PENDING_CLEARED" });
+      expect(cleared.pending).toBeNull();
+    });
+
+    it("is identity when clearing an already-empty pending", () => {
+      const next = cliReducer(INITIAL_CLI_STATE, { type: "PENDING_CLEARED" });
+      expect(next).toBe(INITIAL_CLI_STATE);
+    });
+  });
+
+  describe("SKIP_CONFIRM_CHANGED", () => {
+    it("toggles the per-session flag", () => {
+      const next = cliReducer(INITIAL_CLI_STATE, {
+        type: "SKIP_CONFIRM_CHANGED",
+        value: true,
+      });
+      expect(next.skipConfirm).toBe(true);
+    });
+
+    it("is identity when the value is unchanged", () => {
+      const next = cliReducer(INITIAL_CLI_STATE, {
+        type: "SKIP_CONFIRM_CHANGED",
+        value: false,
+      });
+      expect(next).toBe(INITIAL_CLI_STATE);
+    });
+  });
+});

--- a/admin/app/lib/client/usecase/cli/reducer.ts
+++ b/admin/app/lib/client/usecase/cli/reducer.ts
@@ -1,0 +1,113 @@
+import {
+  initialBanner,
+  type CliState,
+  type LatestGraph,
+  type PendingDestructive,
+  type ScrollbackEntry,
+} from "./state";
+
+export type CliAction =
+  /** Prompt text changed (typing into the `<Input>`). */
+  | { type: "INPUT_CHANGED"; value: string }
+  /** Arrow-up: recall an older history entry into the prompt. */
+  | { type: "HISTORY_PREV" }
+  /** Arrow-down: move toward the newest history entry / empty prompt. */
+  | { type: "HISTORY_NEXT" }
+  /** A raw line was submitted: push to history and clear the prompt. */
+  | { type: "COMMAND_SUBMITTED"; raw: string }
+  /** Append a scrollback line (auto-assigns the next id). */
+  | { type: "ENTRY_APPENDED"; entry: Omit<ScrollbackEntry, "id"> }
+  /** Reset the scrollback to just the banner (Clear / Ctrl+L). */
+  | { type: "SCROLLBACK_CLEARED" }
+  /** A dispatch started: enter the `running` phase. */
+  | { type: "RUN_STARTED" }
+  /** A dispatch settled (ok, error, or abort): return to `idle`. */
+  | { type: "RUN_SETTLED" }
+  /** A graph-producing verb landed: replace the canvas view. */
+  | { type: "GRAPH_UPDATED"; graph: LatestGraph }
+  /** A destructive verb needs confirmation. */
+  | { type: "PENDING_SET"; pending: PendingDestructive }
+  /** Confirmation resolved (Run or Cancel) — clear the prompt chip. */
+  | { type: "PENDING_CLEARED" }
+  /** Toggle the per-session "do not ask again" flag. */
+  | { type: "SKIP_CONFIRM_CHANGED"; value: boolean };
+
+export function cliReducer(state: CliState, action: CliAction): CliState {
+  switch (action.type) {
+    case "INPUT_CHANGED": {
+      if (action.value === state.input) {
+        return state;
+      }
+      return { ...state, input: action.value };
+    }
+    case "HISTORY_PREV": {
+      if (state.history.length === 0) {
+        return state;
+      }
+      const next =
+        state.historyIndex === null
+          ? state.history.length - 1
+          : Math.max(0, state.historyIndex - 1);
+      return { ...state, historyIndex: next, input: state.history[next] };
+    }
+    case "HISTORY_NEXT": {
+      if (state.historyIndex === null) {
+        return state;
+      }
+      const next = state.historyIndex + 1;
+      if (next >= state.history.length) {
+        return { ...state, historyIndex: null, input: "" };
+      }
+      return { ...state, historyIndex: next, input: state.history[next] };
+    }
+    case "COMMAND_SUBMITTED": {
+      return {
+        ...state,
+        history: [...state.history, action.raw],
+        historyIndex: null,
+        input: "",
+      };
+    }
+    case "ENTRY_APPENDED": {
+      return {
+        ...state,
+        scrollback: [
+          ...state.scrollback,
+          { ...action.entry, id: state.nextEntryId },
+        ],
+        nextEntryId: state.nextEntryId + 1,
+      };
+    }
+    case "SCROLLBACK_CLEARED": {
+      return { ...state, scrollback: [initialBanner()], nextEntryId: 2 };
+    }
+    case "RUN_STARTED": {
+      return { ...state, phase: "running" };
+    }
+    case "RUN_SETTLED": {
+      return { ...state, phase: "idle" };
+    }
+    case "GRAPH_UPDATED": {
+      return { ...state, latestGraph: action.graph };
+    }
+    case "PENDING_SET": {
+      return { ...state, pending: action.pending };
+    }
+    case "PENDING_CLEARED": {
+      if (state.pending === null) {
+        return state;
+      }
+      return { ...state, pending: null };
+    }
+    case "SKIP_CONFIRM_CHANGED": {
+      if (action.value === state.skipConfirm) {
+        return state;
+      }
+      return { ...state, skipConfirm: action.value };
+    }
+    default: {
+      const exhaustive: never = action;
+      return exhaustive;
+    }
+  }
+}

--- a/admin/app/lib/client/usecase/cli/state.ts
+++ b/admin/app/lib/client/usecase/cli/state.ts
@@ -1,0 +1,86 @@
+import type { Command } from "~/lib/cli/types";
+import type { GraphView } from "~/lib/client/usecase/illuminate/selectors";
+
+export type EntryKind = "ok" | "error" | "info";
+
+export interface ScrollbackEntry {
+  id: number;
+  input: string;
+  kind: EntryKind;
+  text: string;
+  durationMs?: number;
+}
+
+export interface LatestGraph {
+  /** The exact CLI input that produced this graph (`get vertex alice`, …). */
+  source: string;
+  view: GraphView;
+}
+
+export interface PendingDestructive {
+  command: Command;
+  rendered: string;
+}
+
+/**
+ * Lifecycle phase of the dispatch loop. `idle` is the resting state;
+ * `running` covers an in-flight RPC that the `Cancel` action can abort.
+ * Kept as an explicit phase (rather than a bare `busy` boolean) per the
+ * skill's stateful-flow rules — the controller still exposes a derived
+ * `busy` for the view.
+ */
+export type CliPhase = "idle" | "running";
+
+export interface CliState {
+  /** Durable scrollback log; seeded with the banner entry (id 1). */
+  scrollback: ScrollbackEntry[];
+  /** Current prompt text (bound to the `<Input>`). */
+  input: string;
+  /** Durable command history for arrow-up / arrow-down recall. */
+  history: string[];
+  /** Cursor into `history`; null means "not navigating history". */
+  historyIndex: number | null;
+  /** Set while a destructive verb awaits confirmation. */
+  pending: PendingDestructive | null;
+  /** Per-session "do not ask again" for destructive verbs. */
+  skipConfirm: boolean;
+  /** Dispatch lifecycle phase. */
+  phase: CliPhase;
+  /**
+   * Most recent graph-producing command's view. Mutating verbs leave
+   * this alone so the operator keeps their exploration context after a
+   * write. Null until the first graph-producing command lands.
+   */
+  latestGraph: LatestGraph | null;
+  /** Monotonic id source for scrollback entries. */
+  nextEntryId: number;
+}
+
+/**
+ * The banner printed at the top of a fresh session and after `Clear`.
+ * Always carries id 1, so `nextEntryId` resets to 2 alongside it.
+ */
+export function initialBanner(): ScrollbackEntry {
+  return {
+    id: 1,
+    input: "",
+    kind: "info",
+    text: [
+      "Lantern admin CLI (#411). Same grammar as `lantern repl`.",
+      "Type a verb and Enter; arrow-up / arrow-down cycle history.",
+      'Type "help" for verb signatures.',
+    ].join("\n"),
+  };
+}
+
+export const INITIAL_CLI_STATE: CliState = {
+  scrollback: [initialBanner()],
+  input: "",
+  history: [],
+  historyIndex: null,
+  pending: null,
+  skipConfirm: false,
+  phase: "idle",
+  latestGraph: null,
+  nextEntryId: 2,
+};

--- a/admin/app/lib/client/usecase/cli/use-cli.ts
+++ b/admin/app/lib/client/usecase/cli/use-cli.ts
@@ -1,0 +1,336 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
+import { LanternApiError } from "~/lib/client/infrastructure/api/error";
+import {
+  dispatch as dispatchCommand,
+  isDestructive,
+} from "~/lib/client/usecase/cli/dispatcher";
+import { commandResultToGraphView } from "~/lib/client/usecase/cli/graph-view";
+import { parse, type Command, type ParseResult } from "~/lib/cli/parser";
+import { HELP_TEXT } from "~/lib/cli/verbs";
+import { cliReducer } from "./reducer";
+import {
+  INITIAL_CLI_STATE,
+  type LatestGraph,
+  type PendingDestructive,
+  type ScrollbackEntry,
+} from "./state";
+
+export interface UseCliResult {
+  /** Durable scrollback log, ready to render. */
+  scrollback: ScrollbackEntry[];
+  /** Current prompt text. */
+  input: string;
+  /** Destructive verb awaiting confirmation, if any. */
+  pending: PendingDestructive | null;
+  /** Per-session "do not ask again" flag. */
+  skipConfirm: boolean;
+  /** True while a dispatch is in flight (drives `Cancel` + disabled prompt). */
+  busy: boolean;
+  /** Most recent graph-producing command's view, or null. */
+  latestGraph: LatestGraph | null;
+  /** Update the prompt text. */
+  setInput: (value: string) => void;
+  /** Run the current prompt text (Enter). */
+  submit: () => void;
+  /** Run an arbitrary raw line (click-to-illuminate). */
+  runRaw: (raw: string) => void;
+  /** Recall an older history entry (ArrowUp). */
+  historyPrev: () => void;
+  /** Move toward the newest history entry (ArrowDown). */
+  historyNext: () => void;
+  /** Reset the scrollback to the banner (Clear / Ctrl+L). */
+  clearScrollback: () => void;
+  /** Abort the in-flight dispatch (Cancel / Esc). */
+  cancelInFlight: () => void;
+  /** Toggle the per-session confirmation skip. */
+  setSkipConfirm: (value: boolean) => void;
+  /** Confirm and run the pending destructive command. */
+  confirmRun: () => void;
+  /** Dismiss the pending destructive command. */
+  confirmCancel: () => void;
+}
+
+/**
+ * Owns the /cli route's stateful dispatch loop: command parsing,
+ * per-verb dispatch through `lantern-sdk/web`, arrow-key history,
+ * destructive-verb confirmation, cancellation via `AbortController`,
+ * and the graph projection that feeds the canvas.
+ *
+ * Per the skill's stateful-flow compromise, the lifecycle-heavy
+ * orchestration (async dispatch + abort handle) lives here in the
+ * controller hook while `CliPage` stays render-only. The reducer
+ * (`./reducer`) keeps every state transition pure and unit-testable;
+ * the `AbortController` is the one runtime handle and is held in a ref,
+ * never in reducer state.
+ */
+export function useCli(): UseCliResult {
+  const client = useLanternClient();
+  const [state, dispatch] = useReducer(cliReducer, INITIAL_CLI_STATE);
+  // Backs the `Cancel` action (#433). `runCommand` populates this with
+  // a fresh controller before each dispatch and clears it on settle;
+  // `cancelInFlight` calls `.abort()` on it while busy. The dispatcher
+  // plumbs `signal` through every underlying RPC, so the abort
+  // propagates end-to-end.
+  const abortRef = useRef<AbortController | null>(null);
+
+  const busy = state.phase === "running";
+
+  const runCommand = useCallback(
+    async (rawInput: string, command: Command) => {
+      dispatch({ type: "RUN_STARTED" });
+      const controller = new AbortController();
+      abortRef.current = controller;
+      const start = performance.now();
+      try {
+        const out = await dispatchCommand({
+          client,
+          command,
+          signal: controller.signal,
+        });
+        const elapsed = performance.now() - start;
+        dispatch({
+          type: "ENTRY_APPENDED",
+          entry: {
+            input: rawInput,
+            kind: "ok",
+            text:
+              out === null || out === undefined
+                ? "OK"
+                : "OK\n" + JSON.stringify(out, replacer, 2),
+            durationMs: elapsed,
+          },
+        });
+        // Project graph-shaped results onto the canvas. null means the
+        // verb carries no graph payload (put/add/delete/exit) — leave
+        // the previous canvas alone in that case.
+        const view = commandResultToGraphView(command, out);
+        if (view !== null) {
+          dispatch({
+            type: "GRAPH_UPDATED",
+            graph: { source: rawInput, view },
+          });
+        }
+      } catch (err) {
+        const elapsed = performance.now() - start;
+        // Cancellation via the Cancel button / Esc — render an `info`
+        // line ("aborted") rather than the red error chip so the
+        // operator can tell the difference between a failed RPC and a
+        // deliberate stop (#433).
+        if (isAbortError(err) || controller.signal.aborted) {
+          dispatch({
+            type: "ENTRY_APPENDED",
+            entry: {
+              input: rawInput,
+              kind: "info",
+              text: "aborted",
+              durationMs: elapsed,
+            },
+          });
+        } else {
+          dispatch({
+            type: "ENTRY_APPENDED",
+            entry: {
+              input: rawInput,
+              kind: "error",
+              text: errorMessage(err),
+              durationMs: elapsed,
+            },
+          });
+        }
+      } finally {
+        abortRef.current = null;
+        dispatch({ type: "RUN_SETTLED" });
+      }
+    },
+    [client],
+  );
+
+  const runRaw = useCallback(
+    async (raw: string) => {
+      if (raw.trim() === "") return;
+      dispatch({ type: "COMMAND_SUBMITTED", raw });
+      const result: ParseResult = parse(raw);
+      if (!result.ok) {
+        dispatch({
+          type: "ENTRY_APPENDED",
+          entry: { input: raw, kind: "error", text: result.usage },
+        });
+        return;
+      }
+      if (result.command.verb === "exit") {
+        dispatch({
+          type: "ENTRY_APPENDED",
+          entry: {
+            input: raw,
+            kind: "info",
+            text: "(exit is a no-op in the web CLI; close the tab to leave)",
+          },
+        });
+        return;
+      }
+      if (result.command.verb === "help") {
+        dispatch({
+          type: "ENTRY_APPENDED",
+          entry: { input: raw, kind: "info", text: HELP_TEXT },
+        });
+        return;
+      }
+      if (isDestructive(result.command) && !state.skipConfirm) {
+        dispatch({
+          type: "PENDING_SET",
+          pending: { command: result.command, rendered: raw },
+        });
+        return;
+      }
+      await runCommand(raw, result.command);
+    },
+    [runCommand, state.skipConfirm],
+  );
+
+  const submit = useCallback(() => {
+    void runRaw(state.input);
+  }, [runRaw, state.input]);
+
+  const setInput = useCallback((value: string) => {
+    dispatch({ type: "INPUT_CHANGED", value });
+  }, []);
+
+  const historyPrev = useCallback(() => {
+    dispatch({ type: "HISTORY_PREV" });
+  }, []);
+
+  const historyNext = useCallback(() => {
+    dispatch({ type: "HISTORY_NEXT" });
+  }, []);
+
+  /**
+   * Resets the scrollback to just the banner line. Wired to the toolbar
+   * `Clear` button and `Ctrl+L` / `Cmd+L` (#433). Gateway override,
+   * skipConfirm, and history are deliberately preserved so a clear
+   * behaves like an editor's "clear screen", not a hard reset.
+   */
+  const clearScrollback = useCallback(() => {
+    dispatch({ type: "SCROLLBACK_CLEARED" });
+  }, []);
+
+  /**
+   * Aborts the in-flight dispatch, if any. Wired to the toolbar
+   * `Cancel` button and `Esc` (#433). The `runCommand` catch handler
+   * renders the `aborted` scrollback line.
+   */
+  const cancelInFlight = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  const setSkipConfirm = useCallback((value: boolean) => {
+    dispatch({ type: "SKIP_CONFIRM_CHANGED", value });
+  }, []);
+
+  const confirmRun = useCallback(() => {
+    const p = state.pending;
+    dispatch({ type: "PENDING_CLEARED" });
+    if (p) {
+      void runCommand(p.rendered, p.command);
+    }
+  }, [runCommand, state.pending]);
+
+  const confirmCancel = useCallback(() => {
+    dispatch({ type: "PENDING_CLEARED" });
+  }, []);
+
+  // Window-level keyboard shortcuts (#433):
+  //   - Esc while a command is in flight aborts the dispatch. The prompt
+  //     `<Input>` is `disabled` while busy and so cannot receive its own
+  //     keydown events; binding at window scope is the only way to make
+  //     Esc reach `cancelInFlight`.
+  //   - Ctrl+L / Cmd+L clears the scrollback. Bound globally so it works
+  //     whether the prompt has focus or not (matches xterm / bash).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "l") {
+        e.preventDefault();
+        clearScrollback();
+        return;
+      }
+      if (e.key === "Escape" && busy) {
+        e.preventDefault();
+        cancelInFlight();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [busy, cancelInFlight, clearScrollback]);
+
+  return useMemo<UseCliResult>(
+    () => ({
+      scrollback: state.scrollback,
+      input: state.input,
+      pending: state.pending,
+      skipConfirm: state.skipConfirm,
+      busy,
+      latestGraph: state.latestGraph,
+      setInput,
+      submit,
+      runRaw: (raw: string) => void runRaw(raw),
+      historyPrev,
+      historyNext,
+      clearScrollback,
+      cancelInFlight,
+      setSkipConfirm,
+      confirmRun,
+      confirmCancel,
+    }),
+    [
+      state.scrollback,
+      state.input,
+      state.pending,
+      state.skipConfirm,
+      busy,
+      state.latestGraph,
+      setInput,
+      submit,
+      runRaw,
+      historyPrev,
+      historyNext,
+      clearScrollback,
+      cancelInFlight,
+      setSkipConfirm,
+      confirmRun,
+      confirmCancel,
+    ],
+  );
+}
+
+function replacer(_key: string, value: unknown): unknown {
+  if (typeof value === "bigint") {
+    return String(value);
+  }
+  return value;
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof LanternApiError) {
+    return `[${err.code}] ${err.grpcMessage || err.message}`;
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}
+
+/**
+ * Distinguishes a deliberate cancellation (from `AbortController.abort`)
+ * from a genuine RPC failure. The Connect SDK and `fetch` both raise
+ * `DOMException`/`Error` instances whose `name` is `"AbortError"` —
+ * `error.ts` deliberately lets these through unwrapped so this check
+ * works without needing a `LanternApiError` adapter.
+ */
+function isAbortError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "name" in err &&
+    (err as { name?: string }).name === "AbortError"
+  );
+}


### PR DESCRIPTION
## What

Extracts the `/cli` route's stateful dispatch loop out of `CliPage.tsx`
into a dedicated `app/lib/client/usecase/cli/` module, leaving the
component render-only. `CliPage.tsx` drops from **524 → 254 LOC**.

This is the skill-compliance fix tracked in #494 (react-router-app-architecture
audit). `CliPage` previously owned parsing, per-verb dispatch,
scrollback/history, destructive-command confirmation, in-flight
cancellation, and graph projection inline — exactly the "stateful flow in
a component" shape the skill's stateful-flow guidance says to hoist into a
`usecase/` controller + reducer.

## How

New `usecase/cli/` files:

- **`state.ts`** — `CliState`, scrollback/pending entry types,
  `INITIAL_CLI_STATE`, and the intro-banner factory.
- **`reducer.ts`** — pure `cliReducer` over the CLI action union
  (input, history navigation, scrollback append/clear, run phase, graph
  update, pending destructive, skip-confirm) with exhaustive `never`
  defaulting. Semantics are a 1:1 port of the previous inline state
  updates (history-cursor clamping, monotonic entry ids, clear-to-banner).
- **`reducer.test.ts`** — `bun:test` coverage for every action, including
  the history edge cases (empty / null-cursor / clamp-at-zero /
  past-newest-clears) and id auto-increment.
- **`use-cli.ts`** — `useCli()` controller hook owning the Lantern client,
  the reducer, the `AbortController` ref, the run/confirm/cancel handlers,
  and the window-level `Ctrl+L` / `Esc` shortcuts. Returns a memoized
  view-model.

`CliPage.tsx` now just consumes `useCli()` (plus the existing
`useCliSplitter` / `useCliAxisPicker` feature hooks) and renders.

## Why this shape (not a store)

Only one screen observes this state, so per the skill this stays a
hook + `useReducer` controller rather than a `useSyncExternalStore`
store. The `AbortController` lives in a ref (infrastructure handle), not
in reducer state.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run format:check` — clean
- `bun run test` — **458 pass** (439 prior + 19 new reducer tests)
- `bunx playwright test` — **47 pass**, including all **17** `cli.spec.ts`
  scenarios (prompt/banner, round-trip, parser hint, destructive chip,
  canvas panel, illuminate persistence, Clear/Ctrl+L, Cancel/Esc abort,
  splitter, axis picker). Fully behaviour-preserving.

Closes #494
