### PR TITLE
refactor(admin): extract illuminate legend buckets into usecase selector

### DIFF
--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -12,9 +12,11 @@ import type { Simulation } from "d3-force";
 import Sigma from "sigma";
 import { EdgeArrowProgram } from "sigma/rendering";
 import { Info16Regular } from "@fluentui/react-icons";
-import type {
-  GraphEdge,
-  GraphNode,
+import {
+  selectHopBucketCounts,
+  type GraphEdge,
+  type GraphNode,
+  type HopBucketKey,
 } from "~/lib/client/usecase/illuminate/selectors";
 import { usePreferredTheme } from "~/lib/client/usecase/theme/use-preferred-theme";
 import {
@@ -1529,65 +1531,26 @@ export function IlluminateCanvas({
   // legend stays compact in the common case (most graphs have no
   // unreachables, and many won't have anything past 2 hops).
   const legendBuckets = useMemo(() => {
-    // #491: the canvas renders ONLY the latest expansion result, so the
-    // legend must count only those nodes — otherwise it would tally
-    // vertices that have been dropped from the canvas. Mirror the
-    // reconcile's membership predicate: when a result is present the
-    // rendered set IS that result; otherwise (cold/reseed/Clear) every
-    // accumulator node renders.
-    const hasResult = latestResultVertexKeys.size > 0;
-    let origin = 0;
-    let oneHop = 0;
-    let twoHop = 0;
-    let far = 0;
-    let unreachable = 0;
-    for (const node of nodes) {
-      if (hasResult && !latestResultVertexKeys.has(node.id)) continue;
-      const h = node.hopDistance;
-      if (!Number.isFinite(h) || h < 0) {
-        unreachable += 1;
-      } else if (h === 0) {
-        origin += 1;
-      } else if (h === 1) {
-        oneHop += 1;
-      } else if (h === 2) {
-        twoHop += 1;
-      } else if (h >= HOP_FAR_THRESHOLD) {
-        far += 1;
-      }
-    }
-    return [
+    // Counting — including the #491 "render only the latest expansion
+    // result" membership rule — now lives in the pure
+    // `selectHopBucketCounts` selector (it desynced from the rendered set
+    // when it was inline here). This memo only attaches presentation: a
+    // theme-derived swatch colour and the human hop label per tier, then
+    // hides empty tiers so the legend stays compact.
+    const presentation: Record<HopBucketKey, { label: string; color: string }> =
       {
-        key: "origin" as const,
-        label: describeHop(0),
-        count: origin,
-        color: palette.hop0,
-      },
-      {
-        key: "1hop" as const,
-        label: describeHop(1),
-        count: oneHop,
-        color: palette.hop1,
-      },
-      {
-        key: "2hop" as const,
-        label: describeHop(2),
-        count: twoHop,
-        color: palette.hop2,
-      },
-      {
-        key: "far" as const,
-        label: describeHop(HOP_FAR_THRESHOLD),
-        count: far,
-        color: palette.hopFar,
-      },
-      {
-        key: "unreachable" as const,
-        label: describeHop(Number.POSITIVE_INFINITY),
-        count: unreachable,
-        color: palette.hopUnreachable,
-      },
-    ].filter((b) => b.count > 0);
+        origin: { label: describeHop(0), color: palette.hop0 },
+        "1hop": { label: describeHop(1), color: palette.hop1 },
+        "2hop": { label: describeHop(2), color: palette.hop2 },
+        far: { label: describeHop(HOP_FAR_THRESHOLD), color: palette.hopFar },
+        unreachable: {
+          label: describeHop(Number.POSITIVE_INFINITY),
+          color: palette.hopUnreachable,
+        },
+      };
+    return selectHopBucketCounts(nodes, latestResultVertexKeys)
+      .filter((b) => b.count > 0)
+      .map((b) => ({ ...b, ...presentation[b.key] }));
   }, [nodes, palette, latestResultVertexKeys]);
 
   return (

--- a/admin/app/components/illuminate/IlluminateCanvas/hop-palette.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/hop-palette.ts
@@ -27,15 +27,17 @@
  * the test bridge and a stale-accumulator scenario have a stable
  * colour to render.
  */
+import { HOP_FAR_THRESHOLD } from "~/lib/client/usecase/illuminate/selectors";
 import type { SigmaPalette } from "./palette";
 
 /**
- * The hop distance at which the per-step ramp collapses to the
- * desaturated `hopFar` swatch. Pinned here (not inlined into the
- * `if/else` ladder) so the unit test can assert the boundary
- * unambiguously.
+ * Re-exported from the use-case layer so existing `./hop-palette` import
+ * sites keep resolving the same constant. {@link HOP_FAR_THRESHOLD} is
+ * now canonically owned by `usecase/illuminate/selectors` (shared with the
+ * legend read-model); `colorForHop` / `describeHop` below still use it to
+ * pin the `>= 3` boundary unambiguously for the unit suite.
  */
-export const HOP_FAR_THRESHOLD = 3;
+export { HOP_FAR_THRESHOLD };
 
 export function colorForHop(
   hopDistance: number,

--- a/admin/app/lib/client/usecase/illuminate/selectors.test.ts
+++ b/admin/app/lib/client/usecase/illuminate/selectors.test.ts
@@ -2,13 +2,16 @@ import { describe, expect, it } from "bun:test";
 import type { Edge, Vertex } from "~/lib/client/infrastructure/api/illuminate";
 import { illuminateReducer } from "./reducer";
 import {
+  HOP_FAR_THRESHOLD,
   filterInboundEdges,
   selectCanClear,
   selectExpansionChips,
   selectExpansionCount,
   selectGraphView,
+  selectHopBucketCounts,
   selectInspectedDetail,
   selectIsBusy,
+  type GraphNode,
 } from "./selectors";
 import {
   ACCUMULATOR_SOFT_CAP,
@@ -727,5 +730,94 @@ describe("filterInboundEdges", () => {
 
   it("returns an empty array for an empty key", () => {
     expect(filterInboundEdges([e("a", "")], "")).toEqual([]);
+  });
+});
+
+describe("selectHopBucketCounts", () => {
+  function node(id: string, hopDistance: number): GraphNode {
+    return {
+      id,
+      label: id,
+      vertex: v(id),
+      isInitialSeed: false,
+      isExpansionOrigin: false,
+      importance: 0.5,
+      firstSeenExpansion: 0,
+      hopDistance,
+    };
+  }
+
+  it("returns all five tiers in palette-ramp order, zeros included", () => {
+    const buckets = selectHopBucketCounts([], new Set());
+    expect(buckets).toEqual([
+      { key: "origin", count: 0 },
+      { key: "1hop", count: 0 },
+      { key: "2hop", count: 0 },
+      { key: "far", count: 0 },
+      { key: "unreachable", count: 0 },
+    ]);
+  });
+
+  it("buckets each finite hop distance into its own tier", () => {
+    const buckets = selectHopBucketCounts(
+      [node("o", 0), node("a", 1), node("b", 1), node("c", 2)],
+      new Set(),
+    );
+    expect(buckets).toEqual([
+      { key: "origin", count: 1 },
+      { key: "1hop", count: 2 },
+      { key: "2hop", count: 1 },
+      { key: "far", count: 0 },
+      { key: "unreachable", count: 0 },
+    ]);
+  });
+
+  it("collapses every distance >= HOP_FAR_THRESHOLD into the far tier", () => {
+    const buckets = selectHopBucketCounts(
+      [node("a", HOP_FAR_THRESHOLD), node("b", 4), node("c", 9)],
+      new Set(),
+    );
+    expect(buckets.find((b) => b.key === "far")?.count).toBe(3);
+  });
+
+  it("treats non-finite and negative distances as unreachable", () => {
+    const buckets = selectHopBucketCounts(
+      [
+        node("inf", Number.POSITIVE_INFINITY),
+        node("nan", Number.NaN),
+        node("neg", -1),
+      ],
+      new Set(),
+    );
+    expect(buckets.find((b) => b.key === "unreachable")?.count).toBe(3);
+  });
+
+  it("counts every node when latestResultVertexKeys is empty", () => {
+    const buckets = selectHopBucketCounts(
+      [node("a", 0), node("b", 1)],
+      new Set(),
+    );
+    const total = buckets.reduce((sum, b) => sum + b.count, 0);
+    expect(total).toBe(2);
+  });
+
+  it("counts only nodes in the latest result when one is present (#491)", () => {
+    // `dropped` is past the membership filter and must not be tallied,
+    // mirroring the canvas dropping it from the rendered set.
+    const buckets = selectHopBucketCounts(
+      [node("kept", 0), node("dropped", 1)],
+      new Set(["kept"]),
+    );
+    expect(buckets).toEqual([
+      { key: "origin", count: 1 },
+      { key: "1hop", count: 0 },
+      { key: "2hop", count: 0 },
+      { key: "far", count: 0 },
+      { key: "unreachable", count: 0 },
+    ]);
+  });
+
+  it("pins HOP_FAR_THRESHOLD at the #460 spec boundary of 3", () => {
+    expect(HOP_FAR_THRESHOLD).toBe(3);
   });
 });

--- a/admin/app/lib/client/usecase/illuminate/selectors.ts
+++ b/admin/app/lib/client/usecase/illuminate/selectors.ts
@@ -179,6 +179,86 @@ function appendAdjacency(
 }
 
 /**
+ * The hop distance at which the per-step ramp collapses into the single
+ * desaturated "far" tier (#460): every vertex `>= HOP_FAR_THRESHOLD`
+ * hops from the nearest expansion origin shares one swatch, because
+ * distinguishing 3-hop from 5-hop adds visual noise without
+ * informational value when the canvas already encodes TTL alpha and
+ * hover focus on the same pixel.
+ *
+ * Canonical home is the use-case layer so the legend read-model
+ * ({@link selectHopBucketCounts}) and the canvas palette
+ * (`IlluminateCanvas/hop-palette.ts`, which re-exports this constant)
+ * agree on the boundary without duplicating the literal across the
+ * component/use-case line.
+ */
+export const HOP_FAR_THRESHOLD = 3;
+
+/**
+ * Hop-distance legend tiers, in palette-ramp order (#460):
+ * `origin` (0) → `1hop` → `2hop` → `far` (>= {@link HOP_FAR_THRESHOLD})
+ * → `unreachable` (∞ / disconnected from every origin).
+ */
+export type HopBucketKey = "origin" | "1hop" | "2hop" | "far" | "unreachable";
+
+/** One legend tier and how many rendered nodes fall into it. */
+export interface HopBucketCount {
+  key: HopBucketKey;
+  count: number;
+}
+
+/**
+ * Counts the rendered nodes per hop-distance tier for the legend (#460).
+ *
+ * The canvas renders ONLY the latest expansion result (#491), so the
+ * legend must tally exactly that set — otherwise it counts vertices that
+ * have already been dropped from the canvas. This mirrors the reconcile's
+ * membership predicate: when a latest result is present the rendered set
+ * IS that result; otherwise (cold mount, reseed, or Clear) every
+ * accumulator node renders. An empty `latestResultVertexKeys` therefore
+ * counts every node in `nodes`.
+ *
+ * Returns all five tiers in palette-ramp order with their counts (zeros
+ * included); presentation decides whether to hide empty tiers and which
+ * swatch/label to attach. Kept pure here — the previous incarnation lived
+ * inline in the component `useMemo`, the exact selector-in-component seam
+ * that desynced the legend from the rendered set in #491.
+ */
+export function selectHopBucketCounts(
+  nodes: GraphNode[],
+  latestResultVertexKeys: Set<string>,
+): HopBucketCount[] {
+  const hasResult = latestResultVertexKeys.size > 0;
+  let origin = 0;
+  let oneHop = 0;
+  let twoHop = 0;
+  let far = 0;
+  let unreachable = 0;
+  for (const node of nodes) {
+    if (hasResult && !latestResultVertexKeys.has(node.id)) continue;
+    const h = node.hopDistance;
+    if (!Number.isFinite(h) || h < 0) {
+      unreachable += 1;
+    } else if (h === 0) {
+      origin += 1;
+    } else if (h === 1) {
+      oneHop += 1;
+    } else if (h === 2) {
+      twoHop += 1;
+    } else if (h >= HOP_FAR_THRESHOLD) {
+      far += 1;
+    }
+  }
+  return [
+    { key: "origin", count: origin },
+    { key: "1hop", count: oneHop },
+    { key: "2hop", count: twoHop },
+    { key: "far", count: far },
+    { key: "unreachable", count: unreachable },
+  ];
+}
+
+/**
  * Builds the view model the canvas renders from the accumulator. Pure;
  * no React, no DOM, no graphology — those live in the component layer
  * so this stays trivial to unit-test.


### PR DESCRIPTION
## Summary

First behavior-preserving batch of the #495 `IlluminateCanvas` hotspot
decomposition, following `references/hotspot-refactor-workflow.md` Phase 2
("selectors / derived read-models first, smallest-first batches").

The hop-distance legend (#460) computed its bucket counts inline in an
`IlluminateCanvas` `useMemo` — a selector living in the component, the exact
seam that desynced the legend from the rendered set in #491.

## What changed

- **Extract** the legend counting into a pure `selectHopBucketCounts(nodes,
  latestResultVertexKeys)` selector in
  `app/lib/client/usecase/illuminate/selectors.ts`. It carries the #491
  "render only the latest expansion result" membership rule and returns all
  five tiers in palette-ramp order (zeros included).
- **Slim** the component `useMemo` down to presentation only: it attaches a
  theme-derived swatch colour and the human hop label per tier, then hides
  empty tiers. The rendered output shape (`{ key, count, label, color }`) and
  order are unchanged.
- **Promote** `HOP_FAR_THRESHOLD` to the use-case layer as its canonical home
  (shared by the legend read-model) and re-export it from
  `IlluminateCanvas/hop-palette.ts`, so the bucketing boundary is shared with
  the palette without crossing the component→use-case line. No existing import
  site changes.
- **Add** `selectHopBucketCounts` unit coverage in `selectors.test.ts`
  (tier bucketing, `>= HOP_FAR_THRESHOLD` collapse, non-finite/negative →
  unreachable, the #491 membership filter, and the boundary pin).

This is the only behavioral seam touched. The correctness-sensitive reconcile
diff, the Sigma reducer chain, and the rAF/drag lifecycle are **deliberately
left for later batches** — this PR does not touch the reconcile `useEffect`.

## Verification

- `bun run format` / `bun run lint` / `bun run typecheck` — clean.
- `bun run test` — **465 unit pass** (7 new `selectHopBucketCounts` cases).
- `bunx playwright test --workers=1` — **47 e2e pass**, including
  `illuminate.spec.ts` "Hop-distance coloring separates each ring, then
  recolors to the latest result after an expansion (#460, #491)" — the direct
  regression net for the legend.

## Scope

Part of #495 (batch 1 of N). The issue stays open; a follow-up comment tracks
the remaining batches (reconcile membership unification, then the rAF/drag
controller hook). Not closing #495.

Refs #495
