### PR TITLE
refactor(admin): unify illuminate render-set membership in one selector

### DIFF
--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -14,6 +14,7 @@ import { EdgeArrowProgram } from "sigma/rendering";
 import { Info16Regular } from "@fluentui/react-icons";
 import {
   selectHopBucketCounts,
+  selectRenderTargets,
   type GraphEdge,
   type GraphNode,
   type HopBucketKey,
@@ -1331,18 +1332,16 @@ export function IlluminateCanvas({
     if (!graph) return;
     const sigma = sigmaRef.current;
 
-    // #491: the rendered set IS the latest expansion result. Once an
-    // expansion has produced a result we reconcile graphology down to
-    // exactly those nodes/edges (dropping the rest); an empty result set
-    // (cold mount, reseed, or Clear) falls back to the full accumulator
-    // (which is itself empty in that case).
-    const hasResult = latestResultVertexKeys.size > 0;
-    const nextNodeIds = hasResult
-      ? latestResultVertexKeys
-      : new Set(nodes.map((n) => n.id));
-    const nextEdgeIds = hasResult
-      ? latestResultEdgeIds
-      : new Set(edges.map((e) => e.id));
+    // #491: the rendered set IS the latest expansion result. The
+    // membership rule (latest-result-or-full-accumulator fallback) is
+    // owned by the pure `selectRenderTargets` selector so the reconcile
+    // diff and the hop legend can never disagree about what's on screen.
+    const { nodeIds: nextNodeIds, edgeIds: nextEdgeIds } = selectRenderTargets({
+      nodes,
+      edges,
+      latestResultVertexKeys,
+      latestResultEdgeIds,
+    });
 
     // Per-reconcile diff used to choose the layout regime below (#483).
     // We compute it BEFORE mutating the graph so the counts reflect the
@@ -1531,12 +1530,13 @@ export function IlluminateCanvas({
   // legend stays compact in the common case (most graphs have no
   // unreachables, and many won't have anything past 2 hops).
   const legendBuckets = useMemo(() => {
-    // Counting — including the #491 "render only the latest expansion
-    // result" membership rule — now lives in the pure
-    // `selectHopBucketCounts` selector (it desynced from the rendered set
-    // when it was inline here). This memo only attaches presentation: a
-    // theme-derived swatch colour and the human hop label per tier, then
-    // hides empty tiers so the legend stays compact.
+    // Membership (#491 "render only the latest expansion result") comes
+    // from the shared `selectRenderTargets` selector and counting from
+    // `selectHopBucketCounts` — the same membership the reconcile uses, so
+    // the legend can't desync from the canvas the way it did inline here.
+    // This memo only attaches presentation: a theme-derived swatch colour
+    // and the human hop label per tier, then hides empty tiers so the
+    // legend stays compact.
     const presentation: Record<HopBucketKey, { label: string; color: string }> =
       {
         origin: { label: describeHop(0), color: palette.hop0 },
@@ -1548,10 +1548,16 @@ export function IlluminateCanvas({
           color: palette.hopUnreachable,
         },
       };
-    return selectHopBucketCounts(nodes, latestResultVertexKeys)
+    const { nodeIds } = selectRenderTargets({
+      nodes,
+      edges,
+      latestResultVertexKeys,
+      latestResultEdgeIds,
+    });
+    return selectHopBucketCounts(nodes, nodeIds)
       .filter((b) => b.count > 0)
       .map((b) => ({ ...b, ...presentation[b.key] }));
-  }, [nodes, palette, latestResultVertexKeys]);
+  }, [nodes, edges, palette, latestResultVertexKeys, latestResultEdgeIds]);
 
   return (
     <div className={wrapperClass} data-testid="illuminate-canvas">

--- a/admin/app/lib/client/usecase/illuminate/selectors.test.ts
+++ b/admin/app/lib/client/usecase/illuminate/selectors.test.ts
@@ -11,6 +11,8 @@ import {
   selectHopBucketCounts,
   selectInspectedDetail,
   selectIsBusy,
+  selectRenderTargets,
+  type GraphEdge,
   type GraphNode,
 } from "./selectors";
 import {
@@ -747,6 +749,13 @@ describe("selectHopBucketCounts", () => {
     };
   }
 
+  // The legend counts only nodes in the resolved render set; this mirrors
+  // the cold-start fallback (`selectRenderTargets` returns every id when
+  // there is no latest result), i.e. "count them all".
+  function renderAll(nodes: GraphNode[]): Set<string> {
+    return new Set(nodes.map((n) => n.id));
+  }
+
   it("returns all five tiers in palette-ramp order, zeros included", () => {
     const buckets = selectHopBucketCounts([], new Set());
     expect(buckets).toEqual([
@@ -759,10 +768,8 @@ describe("selectHopBucketCounts", () => {
   });
 
   it("buckets each finite hop distance into its own tier", () => {
-    const buckets = selectHopBucketCounts(
-      [node("o", 0), node("a", 1), node("b", 1), node("c", 2)],
-      new Set(),
-    );
+    const nodes = [node("o", 0), node("a", 1), node("b", 1), node("c", 2)];
+    const buckets = selectHopBucketCounts(nodes, renderAll(nodes));
     expect(buckets).toEqual([
       { key: "origin", count: 1 },
       { key: "1hop", count: 2 },
@@ -773,37 +780,24 @@ describe("selectHopBucketCounts", () => {
   });
 
   it("collapses every distance >= HOP_FAR_THRESHOLD into the far tier", () => {
-    const buckets = selectHopBucketCounts(
-      [node("a", HOP_FAR_THRESHOLD), node("b", 4), node("c", 9)],
-      new Set(),
-    );
+    const nodes = [node("a", HOP_FAR_THRESHOLD), node("b", 4), node("c", 9)];
+    const buckets = selectHopBucketCounts(nodes, renderAll(nodes));
     expect(buckets.find((b) => b.key === "far")?.count).toBe(3);
   });
 
   it("treats non-finite and negative distances as unreachable", () => {
-    const buckets = selectHopBucketCounts(
-      [
-        node("inf", Number.POSITIVE_INFINITY),
-        node("nan", Number.NaN),
-        node("neg", -1),
-      ],
-      new Set(),
-    );
+    const nodes = [
+      node("inf", Number.POSITIVE_INFINITY),
+      node("nan", Number.NaN),
+      node("neg", -1),
+    ];
+    const buckets = selectHopBucketCounts(nodes, renderAll(nodes));
     expect(buckets.find((b) => b.key === "unreachable")?.count).toBe(3);
   });
 
-  it("counts every node when latestResultVertexKeys is empty", () => {
-    const buckets = selectHopBucketCounts(
-      [node("a", 0), node("b", 1)],
-      new Set(),
-    );
-    const total = buckets.reduce((sum, b) => sum + b.count, 0);
-    expect(total).toBe(2);
-  });
-
-  it("counts only nodes in the latest result when one is present (#491)", () => {
-    // `dropped` is past the membership filter and must not be tallied,
-    // mirroring the canvas dropping it from the rendered set.
+  it("counts only the nodes whose id is in the render set (#491)", () => {
+    // `dropped` is absent from the render set and must not be tallied,
+    // mirroring the canvas dropping it from the rendered frame.
     const buckets = selectHopBucketCounts(
       [node("kept", 0), node("dropped", 1)],
       new Set(["kept"]),
@@ -819,5 +813,78 @@ describe("selectHopBucketCounts", () => {
 
   it("pins HOP_FAR_THRESHOLD at the #460 spec boundary of 3", () => {
     expect(HOP_FAR_THRESHOLD).toBe(3);
+  });
+});
+
+describe("selectRenderTargets", () => {
+  function node(id: string, hopDistance = 0): GraphNode {
+    return {
+      id,
+      label: id,
+      vertex: v(id),
+      isInitialSeed: false,
+      isExpansionOrigin: false,
+      importance: 0.5,
+      firstSeenExpansion: 0,
+      hopDistance,
+    };
+  }
+
+  function edge(id: string): GraphEdge {
+    const [source, target] = id.split("\u2192");
+    return { id, source, target, weight: 1, edge: e(source, target) };
+  }
+
+  it("renders exactly the latest result when one is present (#491)", () => {
+    const targets = selectRenderTargets({
+      nodes: [node("a"), node("b"), node("dropped")],
+      edges: [edge("a\u2192b"), edge("a\u2192dropped")],
+      latestResultVertexKeys: new Set(["a", "b"]),
+      latestResultEdgeIds: new Set(["a\u2192b"]),
+    });
+    expect([...targets.nodeIds].sort()).toEqual(["a", "b"]);
+    expect([...targets.edgeIds]).toEqual(["a\u2192b"]);
+  });
+
+  it("returns the caller's own result Set references when present", () => {
+    // Reference identity matters: the reconcile stores nodeIds straight
+    // into previousNodeIdsRef, so a fresh copy would defeat the diff.
+    const latestResultVertexKeys = new Set(["a"]);
+    const latestResultEdgeIds = new Set(["a\u2192b"]);
+    const targets = selectRenderTargets({
+      nodes: [node("a")],
+      edges: [edge("a\u2192b")],
+      latestResultVertexKeys,
+      latestResultEdgeIds,
+    });
+    expect(targets.nodeIds).toBe(latestResultVertexKeys);
+    expect(targets.edgeIds).toBe(latestResultEdgeIds);
+  });
+
+  it("falls back to the full accumulator when there is no result (cold start)", () => {
+    const targets = selectRenderTargets({
+      nodes: [node("a"), node("b")],
+      edges: [edge("a\u2192b")],
+      latestResultVertexKeys: new Set(),
+      latestResultEdgeIds: new Set(),
+    });
+    expect([...targets.nodeIds].sort()).toEqual(["a", "b"]);
+    expect([...targets.edgeIds]).toEqual(["a\u2192b"]);
+  });
+
+  it("feeds selectHopBucketCounts the same membership the canvas renders", () => {
+    // End-to-end: the legend composition counts only nodes the render
+    // target keeps, never a vertex the latest result dropped (#491).
+    const nodes = [node("kept", 0), node("dropped", 1)];
+    const { nodeIds } = selectRenderTargets({
+      nodes,
+      edges: [],
+      latestResultVertexKeys: new Set(["kept"]),
+      latestResultEdgeIds: new Set(),
+    });
+    const buckets = selectHopBucketCounts(nodes, nodeIds);
+    const total = buckets.reduce((sum, b) => sum + b.count, 0);
+    expect(total).toBe(1);
+    expect(buckets.find((b) => b.key === "origin")?.count).toBe(1);
   });
 });

--- a/admin/app/lib/client/usecase/illuminate/selectors.ts
+++ b/admin/app/lib/client/usecase/illuminate/selectors.ts
@@ -179,6 +179,52 @@ function appendAdjacency(
 }
 
 /**
+ * The set of node/edge ids graphology keeps for the current frame.
+ * {@link selectRenderTargets} resolves it; the reconcile effect and the
+ * hop legend both consume it so they agree on exactly what is rendered.
+ */
+export interface RenderTargets {
+  /** Node ids to keep this frame (everything else is dropped). */
+  nodeIds: Set<string>;
+  /** Edge ids to keep this frame (everything else is dropped). */
+  edgeIds: Set<string>;
+}
+
+/**
+ * Resolves which nodes and edges the canvas renders this frame (#491).
+ *
+ * The canvas renders ONLY the latest expansion result: once an expansion
+ * produces a result, graphology is reconciled down to exactly those
+ * nodes/edges and the rest are DROPPED (not hidden). An empty result set
+ * — cold mount, reseed, or Clear — falls back to the full accumulator
+ * (itself empty in that case), i.e. "no filter".
+ *
+ * Single membership authority: the reconcile diff (add/drop) and the hop
+ * legend ({@link selectHopBucketCounts}) both derive their rendered set
+ * from here, so the legend can never again tally vertices that have been
+ * dropped from the canvas (the #491 desync). The `hasResult` branch
+ * returns the SAME Set references the caller passed in, so reference
+ * identity (e.g. the reconcile's `previousNodeIdsRef`) is preserved.
+ */
+export function selectRenderTargets({
+  nodes,
+  edges,
+  latestResultVertexKeys,
+  latestResultEdgeIds,
+}: Pick<
+  GraphView,
+  "nodes" | "edges" | "latestResultVertexKeys" | "latestResultEdgeIds"
+>): RenderTargets {
+  const hasResult = latestResultVertexKeys.size > 0;
+  return {
+    nodeIds: hasResult
+      ? latestResultVertexKeys
+      : new Set(nodes.map((n) => n.id)),
+    edgeIds: hasResult ? latestResultEdgeIds : new Set(edges.map((e) => e.id)),
+  };
+}
+
+/**
  * The hop distance at which the per-step ramp collapses into the single
  * desaturated "far" tier (#460): every vertex `>= HOP_FAR_THRESHOLD`
  * hops from the nearest expansion origin shares one swatch, because
@@ -210,32 +256,28 @@ export interface HopBucketCount {
 /**
  * Counts the rendered nodes per hop-distance tier for the legend (#460).
  *
- * The canvas renders ONLY the latest expansion result (#491), so the
- * legend must tally exactly that set — otherwise it counts vertices that
- * have already been dropped from the canvas. This mirrors the reconcile's
- * membership predicate: when a latest result is present the rendered set
- * IS that result; otherwise (cold mount, reseed, or Clear) every
- * accumulator node renders. An empty `latestResultVertexKeys` therefore
- * counts every node in `nodes`.
+ * `renderNodeIds` is the resolved render set from
+ * {@link selectRenderTargets} — the SAME membership the reconcile uses —
+ * so the legend can only ever tally nodes that are actually on the canvas
+ * (the #491 desync came from re-deriving membership inline here). Nodes
+ * absent from the set are skipped; pass every node id (the cold-start
+ * fallback `selectRenderTargets` already returns) to count them all.
  *
  * Returns all five tiers in palette-ramp order with their counts (zeros
  * included); presentation decides whether to hide empty tiers and which
- * swatch/label to attach. Kept pure here — the previous incarnation lived
- * inline in the component `useMemo`, the exact selector-in-component seam
- * that desynced the legend from the rendered set in #491.
+ * swatch/label to attach.
  */
 export function selectHopBucketCounts(
   nodes: GraphNode[],
-  latestResultVertexKeys: Set<string>,
+  renderNodeIds: Set<string>,
 ): HopBucketCount[] {
-  const hasResult = latestResultVertexKeys.size > 0;
   let origin = 0;
   let oneHop = 0;
   let twoHop = 0;
   let far = 0;
   let unreachable = 0;
   for (const node of nodes) {
-    if (hasResult && !latestResultVertexKeys.has(node.id)) continue;
+    if (!renderNodeIds.has(node.id)) continue;
     const h = node.hopDistance;
     if (!Number.isFinite(h) || h < 0) {
       unreachable += 1;


### PR DESCRIPTION
## What

Batch 2 of the **#495** `IlluminateCanvas` hotspot decomposition. Extracts the
render-set **membership** rule into one pure selector so the reconcile effect
and the hop legend can no longer disagree about what is on the canvas.

Follows `hotspot-refactor-workflow.md` Phase 2 ordering (selectors / derived
read-models first) and the issue's own step 1, which names both `legendBuckets`
(landed in #498) **and render-set membership** as the unit to extract.

## Why

The "render **only** the latest expansion result, otherwise fall back to the
full accumulator" rule (#491) was encoded **twice**:

- inline in the `IlluminateCanvas` reconcile `useEffect`
  (`hasResult ? latestResult* : full` → `nextNodeIds` / `nextEdgeIds`), and
- again inside `selectHopBucketCounts` for the legend.

Two copies of the same predicate are precisely how the legend desynced from
the rendered set in **#491**.

## Change

- New pure selector `selectRenderTargets(view) → { nodeIds, edgeIds }` in
  `usecase/illuminate/selectors.ts` — the **single membership authority**.
  The `hasResult` branch returns the caller's own `Set` references, so the
  reconcile's `previousNodeIdsRef` identity bookkeeping is byte-for-byte
  unchanged.
- The reconcile effect and the `legendBuckets` memo both resolve their
  rendered set from `selectRenderTargets`.
- `selectHopBucketCounts(nodes, renderNodeIds)` now takes the **resolved**
  node-id set instead of re-deriving membership.

## Behavior

Behavior-preserving — the membership logic is relocated, not changed.

## Tests

- New `selectRenderTargets` unit suite (latest-result filtering, cold-start
  fallback, `Set` reference identity, and end-to-end composition with
  `selectHopBucketCounts`); `selectHopBucketCounts` tests updated for the new
  signature. **468 unit pass / 0 fail.**
- Full **47 e2e pass**, including `illuminate.spec.ts` "Deletes nodes and
  edges outside the latest result (#491)" and "Hop-distance coloring … recolors
  to the latest result after an expansion (#460, #491)" — the direct
  regression net for this membership rule.
- `format` / `lint` / `typecheck` clean.

## Scope

Not closing **#495**. Remaining batches (reconcile add/drop diff + layout-regime
decision; then the rAF tick + drag/`finishDrag` lifecycle into a feature-local
controller hook) are the correctness-sensitive orchestration work and stay
tracked on the issue.

Refs #495
