### PR TITLE
feat(admin): anchor & enlarge illuminate seed, on-edge weights, vivid hop ramp

### DIFF
--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -28,9 +28,12 @@ import {
   type ForceLink,
   type ForceNode,
 } from "./force-layout";
+import { formatEdgeWeight } from "./edge-label";
 import { HOP_FAR_THRESHOLD, colorForHop, describeHop } from "./hop-palette";
 import { makeDrawNodeHover } from "./hover-label";
 import {
+  EDGE_LABEL_SIZE,
+  EDGE_LABEL_WEIGHT,
   FALLBACK_PALETTE,
   LABEL_SIZE,
   LABEL_WEIGHT,
@@ -150,6 +153,16 @@ const INFO_ICON_OFFSET_X = 10;
 const INFO_ICON_OFFSET_Y = 18;
 
 /**
+ * #500 node sizing. The per-expansion seed (the canvas's pinned anchor)
+ * renders at {@link SEED_NODE_SIZE}; every other node renders at the
+ * single uniform {@link DEFAULT_NODE_SIZE}. Sizes feed both the sigma
+ * disc radius and the d3-force collision radius, so the larger seed also
+ * claims more space — reinforcing its role as the layout's fixed point.
+ */
+const DEFAULT_NODE_SIZE = 7;
+const SEED_NODE_SIZE = 16;
+
+/**
  * Hosts a `graphology` graph and a `sigma` renderer. The component owns
  * the lifecycle of the renderer (mount on first paint, destroy on unmount)
  * and reconciles the graph in-place when the view model changes — full
@@ -190,6 +203,14 @@ export function IlluminateCanvas({
    * structural delta (just re-apply the hide filter).
    */
   const previousNodeIdsRef = useRef<Set<string>>(new Set());
+  /**
+   * Snapshot of the edge IDs the graph held at the end of the previous
+   * reconcile (#500). Diffing against the next reconcile's edge IDs lets
+   * an expansion that only adds/removes EDGES among already-present nodes
+   * (no node delta) still trigger an animated reheat of the whole render
+   * set, so existing nodes move on every structural expansion.
+   */
+  const previousEdgeIdsRef = useRef<Set<string>>(new Set());
   /**
    * The live d3-force simulation driving the continuous layout (#483),
    * or `null` when nothing is animating. `forceNodes` is the array d3
@@ -278,6 +299,10 @@ export function IlluminateCanvas({
   }, [theme]);
 
   const pickFill = useCallback(
+    // #460/#500: every node (including the pinned seed) draws from the
+    // red→blue hop ramp. The seed is the hop-0 origin, so it naturally
+    // lands on the warm red end — it's distinguished by colour via the
+    // ramp itself, plus its larger size and pinned position (#500).
     (node: { hopDistance: number }) => colorForHop(node.hopDistance, palette),
     [palette],
   );
@@ -291,10 +316,12 @@ export function IlluminateCanvas({
   // without re-wiring sigma listeners.
 
   /**
-   * Copy the simulation's positions into graphology. No node is ever
-   * pinned (drag-to-pin was removed in #491), so this is a one-way
-   * sim → graphology flow; the simulation is always authoritative for
-   * position and is free to relax every node toward equilibrium.
+   * Copy the simulation's positions into graphology. The only pinned
+   * node is the per-expansion seed (#500), whose `fx`/`fy` hold its
+   * coordinates constant — writing those back is a harmless no-op since
+   * d3-force keeps `x === fx`. Every other node is unpinned (drag-to-pin
+   * was removed in #491), so this stays a one-way sim → graphology flow
+   * with the simulation authoritative for position.
    */
   const writeBackLayoutPositions = useCallback(() => {
     const layout = layoutRef.current;
@@ -367,20 +394,29 @@ export function IlluminateCanvas({
    * start animating so the layout re-converges. Used after a drag
    * release (#491): the dropped node is NOT pinned, so reheating lets
    * physics settle the whole graph around its new position instead of
-   * freezing it where the cursor left it. Rebuilding from the live
-   * graphology positions means no `fx`/`fy` pin survives the gesture.
+   * freezing it where the cursor left it. The one exception is the
+   * per-expansion seed (#500): its `fixed` attribute re-pins it (fx/fy)
+   * so the reheat relaxes everything else around the anchor.
    */
   const reheatLayout = useCallback(() => {
     const graph = graphRef.current;
     if (!graph) return;
     const forceNodes: ForceNode[] = [];
     for (const id of graph.nodes()) {
-      forceNodes.push({
+      const x = graph.getNodeAttribute(id, "x") as number;
+      const y = graph.getNodeAttribute(id, "y") as number;
+      const fn: ForceNode = {
         id,
         size: graph.getNodeAttribute(id, "size") as number,
-        x: graph.getNodeAttribute(id, "x") as number,
-        y: graph.getNodeAttribute(id, "y") as number,
-      });
+        x,
+        y,
+      };
+      // #500: keep the seed pinned across a reheat.
+      if (graph.getNodeAttribute(id, "fixed") === true) {
+        fn.fx = x;
+        fn.fy = y;
+      }
+      forceNodes.push(fn);
     }
     if (forceNodes.length === 0) {
       stopLayout();
@@ -595,6 +631,18 @@ export function IlluminateCanvas({
       labelSize: LABEL_SIZE,
       labelWeight: LABEL_WEIGHT,
       labelFont: FALLBACK_PALETTE.labelFont,
+      // === #500 on-edge weight labels ===================================
+      // Render each edge's accumulated weight as a label along the edge
+      // body. The per-edge text is stamped in the reconcile loop
+      // (`formatEdgeWeight(edge.weight)`); these settings govern its
+      // appearance, and the palette effect re-applies the colour/font on
+      // a theme flip, mirroring the node-label settings above.
+      renderEdgeLabels: true,
+      edgeLabelColor: { color: FALLBACK_PALETTE.labelText },
+      edgeLabelSize: EDGE_LABEL_SIZE,
+      edgeLabelWeight: EDGE_LABEL_WEIGHT,
+      edgeLabelFont: FALLBACK_PALETTE.labelFont,
+      // === end #500 =====================================================
       // === #484 theme-aware hover label =================================
       // Sigma's default `drawDiscNodeHover` paints a hard-coded near-white
       // box behind the hovered label, then draws the label in
@@ -952,6 +1000,19 @@ export function IlluminateCanvas({
          */
         getNodeHopDistance: (key: string) => number | null;
         /**
+         * #500 test bridge: read the disc size stamped on a node.
+         * Returns `null` if the node is unknown. The e2e suite uses
+         * this to assert the seed renders larger than the uniform
+         * non-seed size.
+         */
+        getNodeSize: (key: string) => number | null;
+        /**
+         * #500 test bridge: read the weight label stamped on an edge.
+         * Returns `null` if the edge is unknown. Lets the e2e assert
+         * the on-edge weight label without reading WebGL pixels.
+         */
+        getEdgeLabel: (key: string) => string | null;
+        /**
          * #458 test bridge: read whether the hover-focus reducer is
          * currently active (i.e., a node is focused).
          */
@@ -1147,6 +1208,16 @@ export function IlluminateCanvas({
           ? attrs.hopDistance
           : Number.POSITIVE_INFINITY;
       },
+      getNodeSize: (key: string) => {
+        if (!graph.hasNode(key)) return null;
+        const size = graph.getNodeAttribute(key, "size");
+        return typeof size === "number" ? size : null;
+      },
+      getEdgeLabel: (key: string) => {
+        if (!graph.hasEdge(key)) return null;
+        const label = graph.getEdgeAttribute(key, "label");
+        return typeof label === "string" ? label : null;
+      },
       hoveredNode: () => hoveredNodeId,
       tickCount: () => tickCountRef.current,
       setNow: (ms: number | null) => {
@@ -1215,6 +1286,7 @@ export function IlluminateCanvas({
       sigmaRef.current = null;
       graphRef.current = null;
       previousNodeIdsRef.current = new Set();
+      previousEdgeIdsRef.current = new Set();
       if (infoIconHideTimer !== null) {
         clearTimeout(infoIconHideTimer);
         infoIconHideTimer = null;
@@ -1236,6 +1308,9 @@ export function IlluminateCanvas({
     sigma.setSetting("defaultEdgeColor", palette.edge);
     sigma.setSetting("labelColor", { color: palette.labelText });
     sigma.setSetting("labelFont", palette.labelFont);
+    // #500: keep the on-edge weight labels in sync with the theme.
+    sigma.setSetting("edgeLabelColor", { color: palette.labelText });
+    sigma.setSetting("edgeLabelFont", palette.labelFont);
     // #484: rebuild the hover renderer against the new palette so the
     // hovered-label chip follows the theme alongside the label text.
     sigma.setSetting("defaultDrawNodeHover", makeDrawNodeHover(palette));
@@ -1355,6 +1430,20 @@ export function IlluminateCanvas({
     for (const id of previousNodeIds) {
       if (!nextNodeIds.has(id)) droppedCount += 1;
     }
+    // #500: an expansion can add/remove EDGES among nodes that are all
+    // already present (no node delta). Detect that so the whole render
+    // set still reheats and existing nodes move on every structural
+    // expansion, not only when the node set changes.
+    const previousEdgeIds = previousEdgeIdsRef.current;
+    let edgeSetChanged = previousEdgeIds.size !== nextEdgeIds.size;
+    if (!edgeSetChanged) {
+      for (const id of nextEdgeIds) {
+        if (!previousEdgeIds.has(id)) {
+          edgeSetChanged = true;
+          break;
+        }
+      }
+    }
 
     // Drop edges first to avoid orphan references when we drop nodes.
     for (const edgeId of graph.edges()) {
@@ -1377,8 +1466,17 @@ export function IlluminateCanvas({
       // neither merged nor (re)created — the drop loop above already
       // deleted it from graphology.
       if (!nextNodeIds.has(node.id)) continue;
-      const size = 4 + node.importance * 10;
-      const color = pickFill(node);
+      // #500: the per-expansion seed (origin of the most recent
+      // expansion) is the canvas's pinned anchor — render it larger and
+      // stamp `fixed` so the layout driver pins it (fx/fy) and the drag
+      // bridge reports it fixed. Its colour comes from the hop ramp like
+      // every other node: as the hop-0 origin it sits on the warm red end,
+      // which is what visually distinguishes it. Every other node renders
+      // at a single uniform size.
+      const isSeed =
+        latestExpansionOrigin != null && node.id === latestExpansionOrigin;
+      const size = isSeed ? SEED_NODE_SIZE : DEFAULT_NODE_SIZE;
+      const color = pickFill({ hopDistance: node.hopDistance });
       const detail = describeVertex(node);
       // #459: stash the protobuf-JSON expiration on the graphology
       // node so the per-tick reducer can read it without crossing back
@@ -1393,6 +1491,11 @@ export function IlluminateCanvas({
           detail,
           isInitialSeed: node.isInitialSeed,
           isExpansionOrigin: node.isExpansionOrigin,
+          // #500: mark the per-expansion seed so the layout driver pins
+          // it (fx/fy). Size (above) is what visually enlarges it; colour
+          // comes from the hop ramp (hop-0 origin = warm red end).
+          isSeed,
+          fixed: isSeed,
           expiration,
           // #460: stamp hop distance for the legend computation and
           // (post-theme-flip) for the palette repaint effect to look
@@ -1416,6 +1519,9 @@ export function IlluminateCanvas({
           detail,
           isInitialSeed: node.isInitialSeed,
           isExpansionOrigin: node.isExpansionOrigin,
+          // #500: see the merge branch above.
+          isSeed,
+          fixed: isSeed,
           expiration,
           hopDistance: node.hopDistance,
           firstSeenExpansion: node.firstSeenExpansion,
@@ -1432,7 +1538,8 @@ export function IlluminateCanvas({
       if (graph.hasEdge(edge.id)) {
         graph.mergeEdgeAttributes(edge.id, {
           size: 1 + Math.min(4, edge.weight),
-          label: edge.id,
+          // #500: render the accumulated weight on the edge itself.
+          label: formatEdgeWeight(edge.weight),
           detail: `weight = ${edge.weight}`,
           expiration,
         });
@@ -1440,7 +1547,8 @@ export function IlluminateCanvas({
         graph.addEdgeWithKey(edge.id, edge.source, edge.target, {
           size: 1 + Math.min(4, edge.weight),
           color: palette.edge,
-          label: edge.id,
+          // #500: render the accumulated weight on the edge itself.
+          label: formatEdgeWeight(edge.weight),
           detail: `weight = ${edge.weight}`,
           expiration,
         });
@@ -1450,15 +1558,20 @@ export function IlluminateCanvas({
     // === #483 continuous layout regime =================================
     // Build the simulation over every rendered node (#491: delete-not-
     // hide means graphology already holds exactly the latest result, so
-    // there is nothing to exclude). No node is pinned — drag-to-pin was
-    // removed in #491, so the sim is free to relax the whole frame toward
-    // equilibrium every reconcile.
+    // there is nothing to exclude). The per-expansion seed is pinned
+    // (#500): its `fixed` attribute fixes fx/fy so the sim relaxes every
+    // other node around the anchor instead of letting it drift.
     const forceNodes: ForceNode[] = [];
     for (const id of graph.nodes()) {
       const x = graph.getNodeAttribute(id, "x") as number;
       const y = graph.getNodeAttribute(id, "y") as number;
       const size = graph.getNodeAttribute(id, "size") as number;
-      forceNodes.push({ id, size, x, y });
+      const fn: ForceNode = { id, size, x, y };
+      if (graph.getNodeAttribute(id, "fixed") === true) {
+        fn.fx = x;
+        fn.fy = y;
+      }
+      forceNodes.push(fn);
     }
     const forceLinks: ForceLink[] = [];
     for (const edge of edges) {
@@ -1482,7 +1595,7 @@ export function IlluminateCanvas({
     const isIncremental =
       !isColdStart &&
       forceNodes.length > 0 &&
-      (addedCount > 0 || droppedCount > 0);
+      (addedCount > 0 || droppedCount > 0 || edgeSetChanged);
 
     if (isColdStart && forceNodes.length > 0) {
       beginLayout(forceNodes, forceLinks, FORCE_ALPHA_COLD);
@@ -1502,6 +1615,7 @@ export function IlluminateCanvas({
     // === end #483 ======================================================
 
     previousNodeIdsRef.current = nextNodeIds;
+    previousEdgeIdsRef.current = nextEdgeIds;
   }, [
     nodes,
     edges,

--- a/admin/app/components/illuminate/IlluminateCanvas/edge-label.test.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/edge-label.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatEdgeWeight } from "./edge-label";
+
+describe("formatEdgeWeight", () => {
+  test("renders a whole number without a decimal point", () => {
+    expect(formatEdgeWeight(3)).toBe("3");
+    expect(formatEdgeWeight(0)).toBe("0");
+    expect(formatEdgeWeight(42)).toBe("42");
+  });
+
+  test("renders a fractional value to one decimal", () => {
+    expect(formatEdgeWeight(2.5)).toBe("2.5");
+    expect(formatEdgeWeight(0.3)).toBe("0.3");
+  });
+
+  test("rounds to a single decimal place", () => {
+    expect(formatEdgeWeight(1.24)).toBe("1.2");
+    expect(formatEdgeWeight(1.26)).toBe("1.3");
+  });
+
+  test("returns an empty string for non-finite input", () => {
+    expect(formatEdgeWeight(Number.NaN)).toBe("");
+    expect(formatEdgeWeight(Number.POSITIVE_INFINITY)).toBe("");
+  });
+});

--- a/admin/app/components/illuminate/IlluminateCanvas/edge-label.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/edge-label.ts
@@ -1,0 +1,22 @@
+/**
+ * Edge-weight label formatting for the Illuminate canvas (#500).
+ *
+ * The canvas renders each edge's accumulated weight as an on-edge label
+ * (`renderEdgeLabels`). Weights are additive `float32` decay counters, so
+ * they are frequently whole numbers but can carry a fraction. We format
+ * them compactly so the label stays legible where it sits between two
+ * vertices:
+ *
+ *   - A whole number renders without a decimal point (`3`, not `3.0`).
+ *   - A fractional value renders to a single decimal (`2.5`, `0.3`).
+ *
+ * Kept as a pure helper (mirroring the folder's `force-layout` /
+ * `hop-palette` / `ttl-decay` modules) so it is unit-testable without a
+ * DOM or a live sigma instance.
+ */
+export function formatEdgeWeight(weight: number): string {
+  if (!Number.isFinite(weight)) {
+    return "";
+  }
+  return Number.isInteger(weight) ? String(weight) : weight.toFixed(1);
+}

--- a/admin/app/components/illuminate/IlluminateCanvas/palette.test.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/palette.test.ts
@@ -155,43 +155,54 @@ describe("resolvePaletteFromTokens", () => {
   // The hop-distance reducer reads `hop0/1/2/Far/Unreachable` off the
   // palette and applies them BEFORE the TTL fade so a node's hue
   // communicates structural distance and its alpha communicates
-  // remaining lifetime. The token mapping comes straight from the
-  // #460 spec; the test pins it so a Fluent token rename can't
-  // silently change the canvas reading.
+  // remaining lifetime. #500 turned the ramp into a deliberate
+  // red→blue diverging colormap of code-side literals: the original
+  // #460 mapping pulled hop 0/1/2 from the single-hue Fluent brand
+  // ladder, which flattened to three near-identical blues. The tiers
+  // are now fixed literals (like the dim swatches) so the sweep stays
+  // extreme and theme-stable — supplying brand/neutral tokens must
+  // NOT move them.
 
-  test("reads --colorBrandForeground1 for hop 0 (origin)", () => {
+  test("hop ramp ignores Fluent brand/neutral tokens and stays the red→blue literals (#500)", () => {
     const palette = resolvePaletteFromTokens(
-      readerFrom({ "--colorBrandForeground1": "#aabbcc" }),
+      readerFrom({
+        // The very tokens the original #460 ramp consumed — proving the
+        // ramp no longer tracks them.
+        "--colorBrandForeground1": "#aabbcc",
+        "--colorBrandForeground2": "#112233",
+        "--colorBrandForeground2Hover": "#445566",
+        "--colorNeutralForeground3": "#778899",
+        "--colorPaletteRedForeground1": "#992222",
+      }),
     );
-    expect(palette.hop0).toBe("#aabbcc");
+    expect(palette.hop0).toBe(FALLBACK_PALETTE.hop0);
+    expect(palette.hop1).toBe(FALLBACK_PALETTE.hop1);
+    expect(palette.hop2).toBe(FALLBACK_PALETTE.hop2);
+    expect(palette.hopFar).toBe(FALLBACK_PALETTE.hopFar);
+    expect(palette.hopUnreachable).toBe(FALLBACK_PALETTE.hopUnreachable);
   });
 
-  test("reads --colorBrandForeground2 for hop 1", () => {
-    const palette = resolvePaletteFromTokens(
-      readerFrom({ "--colorBrandForeground2": "#112233" }),
-    );
-    expect(palette.hop1).toBe("#112233");
-  });
+  test("hop ramp spans a genuinely warm→cool sweep so origin/1hop/2hop are distinguishable (#500)", () => {
+    // The user-visible acceptance: the three tiers a default expansion
+    // shows (origin, 1 hop, 2 hops) must be obviously different colours,
+    // not three shades of one blue. Assert they are mutually distinct and
+    // that the ramp ends on opposite temperature poles (red origin, blue
+    // far). Channel checks encode "warm" (red-dominant) vs "cool"
+    // (blue-dominant) without pinning exact hexes.
+    const p = FALLBACK_PALETTE;
+    const distinct = new Set([p.hop0, p.hop1, p.hop2]);
+    expect(distinct.size).toBe(3);
 
-  test("reads --colorBrandForeground2Hover for hop 2", () => {
-    const palette = resolvePaletteFromTokens(
-      readerFrom({ "--colorBrandForeground2Hover": "#445566" }),
-    );
-    expect(palette.hop2).toBe("#445566");
-  });
-
-  test("reads --colorNeutralForeground3 for hopFar (≥3 hops)", () => {
-    const palette = resolvePaletteFromTokens(
-      readerFrom({ "--colorNeutralForeground3": "#778899" }),
-    );
-    expect(palette.hopFar).toBe("#778899");
-  });
-
-  test("reads --colorPaletteRedForeground1 for unreachable", () => {
-    const palette = resolvePaletteFromTokens(
-      readerFrom({ "--colorPaletteRedForeground1": "#992222" }),
-    );
-    expect(palette.hopUnreachable).toBe("#992222");
+    const channels = (hex: string) => ({
+      r: parseInt(hex.slice(1, 3), 16),
+      b: parseInt(hex.slice(5, 7), 16),
+    });
+    // origin is warm: red channel dominates blue.
+    const origin = channels(p.hop0);
+    expect(origin.r).toBeGreaterThan(origin.b);
+    // the far end is cool: blue channel dominates red.
+    const far = channels(p.hopFar);
+    expect(far.b).toBeGreaterThan(far.r);
   });
 
   test("hop ramp falls back to the light-theme literals when no tokens are set", () => {

--- a/admin/app/components/illuminate/IlluminateCanvas/palette.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/palette.ts
@@ -63,12 +63,14 @@ export interface SigmaPalette {
    * `hopUnreachable` covers vertices with no path to any origin (the
    * `Number.POSITIVE_INFINITY` case in `selectGraphView`).
    *
-   * Fluent token mapping (per #460 spec):
-   *   hop0          → colorBrandForeground1 (origin highlight)
-   *   hop1          → colorBrandForeground2 (single-hop ring)
-   *   hop2          → colorBrandForeground2Hover (two-hop ring)
-   *   hopFar        → desaturated neutral   (everything ≥ 3 hops)
-   *   hopUnreachable → low-chroma red       (disconnected; visually distinct)
+   * #500 made this a deliberate red→blue diverging colormap (code-side
+   * literals, not Fluent brand tokens) so the tiers are obviously
+   * distinct at a glance:
+   *   hop0          → vivid red    (origin / pinned anchor — "you are here")
+   *   hop1          → violet       (single-hop ring; midpoint of the sweep)
+   *   hop2          → azure blue   (two-hop ring)
+   *   hopFar        → deep blue    (everything ≥ 3 hops — coldest/furthest)
+   *   hopUnreachable → neutral grey (disconnected; off the warm→cool ramp)
    */
   hop0: string;
   hop1: string;
@@ -96,22 +98,32 @@ export const FALLBACK_PALETTE: SigmaPalette = {
   labelStroke: "#d1d1d1",
   labelFont:
     'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-  // #460 hop ramp. Light-theme literals — these are the swatches the
-  // canvas falls back to before FluentProvider hydrates and the test
-  // suite asserts against. The ramp moves from the Fluent brand
-  // accent (hop 0, origin) outward through brand-foreground tints to
-  // a desaturated neutral for ≥3 hops, then to a low-chroma red for
-  // unreachable. Distinct enough to read at a glance, similar enough
-  // in luminance to avoid clobbering the hover dim's contrast story.
-  hop0: "#005a9e", // colorBrandForeground1 (light)
-  hop1: "#106ebe", // colorBrandForeground2 (light)
-  hop2: "#2b88d8", // colorBrandForeground2Hover (light)
-  hopFar: "#8a8886", // colorNeutralForeground3 (light, desaturated)
-  hopUnreachable: "#a4262c", // colorPaletteRedForeground1 (light, low chroma)
+  // #500 red→blue diverging hop ramp. Deliberate code-side literals (not
+  // Fluent brand tokens): the original #460 ramp pulled hop 0/1/2 from the
+  // single-hue brand foreground ladder, which rendered as three nearly
+  // identical blues and read as "no colour coding" at all. This sweep runs
+  // warm→cool so structural distance from the origin is obvious at a
+  // glance — vivid red at the pinned anchor, through a violet midpoint, to
+  // azure then deep blue as you move outward; disconnected nodes sit off
+  // the ramp in neutral grey. Hues are far enough apart to distinguish the
+  // tiers, dark enough to keep the hover-dim contrast story intact.
+  hop0: "#d13438", // origin — vivid red ("you are here")
+  hop1: "#8764b8", // 1 hop — violet midpoint
+  hop2: "#0078d4", // 2 hops — azure blue
+  hopFar: "#004e8c", // ≥3 hops — deep/cold blue (furthest)
+  hopUnreachable: "#605e5c", // disconnected — neutral grey, off the ramp
 };
 
 export const LABEL_SIZE = 13;
 export const LABEL_WEIGHT = "600";
+
+/**
+ * #500 edge-weight label sizing. Slightly smaller than {@link LABEL_SIZE}
+ * so an on-edge weight reads as secondary to the vertex labels it sits
+ * between.
+ */
+export const EDGE_LABEL_SIZE = 11;
+export const EDGE_LABEL_WEIGHT = "600";
 
 /**
  * Token reader injected into `resolvePaletteFromTokens`. Receives a
@@ -155,27 +167,18 @@ export function resolvePaletteFromTokens(reader: CssTokenReader): SigmaPalette {
     ),
     labelStroke: readVar("--colorNeutralStroke1", FALLBACK_PALETTE.labelStroke),
     labelFont: readVar("--fontFamilyBase", FALLBACK_PALETTE.labelFont),
-    // #460 hop ramp. Token mapping per spec: hop 0/1/2 trace the
-    // Fluent brand foreground/stroke ladder so the warmest stop
-    // (origin) reads as "you are here" and the cooler stops indicate
-    // distance. `hopFar` flattens to a desaturated neutral so the
-    // canvas reads as "out of focus past 2 hops" without falling all
-    // the way to the unreachable red.
-    //
-    // Token rationale: the issue spec suggested `colorBrandStroke1`
-    // for hop 2, but in Fluent v9's default brand ramp `BrandStroke1`
-    // (Shade80) and `BrandForeground1` (Shade100) collide at the
-    // same hex value — hop 0 and hop 2 would render identically.
-    // `BrandForeground2Hover` (Shade120) gives us a properly
-    // separated third stop in the same brand family.
-    hop0: readVar("--colorBrandForeground1", FALLBACK_PALETTE.hop0),
-    hop1: readVar("--colorBrandForeground2", FALLBACK_PALETTE.hop1),
-    hop2: readVar("--colorBrandForeground2Hover", FALLBACK_PALETTE.hop2),
-    hopFar: readVar("--colorNeutralForeground3", FALLBACK_PALETTE.hopFar),
-    hopUnreachable: readVar(
-      "--colorPaletteRedForeground1",
-      FALLBACK_PALETTE.hopUnreachable,
-    ),
+    // #500: the hop ramp is a controlled red→blue diverging colormap, so
+    // every stop is a code-side literal (like the dim swatches). Pulling
+    // each tier from an independent Fluent token — or worse, three shades
+    // of the single-hue brand ladder, as the original #460 ramp did —
+    // can't guarantee the "origin/1hop/2hop are obviously different"
+    // property; it flattened to three near-identical blues. Fixed literals
+    // keep the sweep extreme and stable across themes.
+    hop0: FALLBACK_PALETTE.hop0,
+    hop1: FALLBACK_PALETTE.hop1,
+    hop2: FALLBACK_PALETTE.hop2,
+    hopFar: FALLBACK_PALETTE.hopFar,
+    hopUnreachable: FALLBACK_PALETTE.hopUnreachable,
   };
 }
 

--- a/admin/tests/e2e/illuminate.spec.ts
+++ b/admin/tests/e2e/illuminate.spec.ts
@@ -767,6 +767,212 @@ test.describe("/illuminate", () => {
     ).toBeGreaterThan(1);
   });
 
+  test("Seed anchor is pinned, enlarged, and hop-coloured while other nodes relayout; edges show their weight (#500)", async ({
+    page,
+  }) => {
+    const seed = encodeURIComponent("e2e:illum:hub");
+    await page.goto(`/illuminate?seed=${seed}`);
+    await expect(page.getByTestId("illuminate-toolbar")).toBeVisible();
+    const counter = page.getByTestId("illuminate-counter");
+    await expect(counter).toContainText("5 vertices");
+
+    type Pos = { x: number; y: number };
+    type Bridge = {
+      getNodePosition: (k: string) => Pos | null;
+      getRenderedNodeColor: (k: string) => string | null;
+      getNodeSize: (k: string) => number | null;
+      getEdgeLabel: (k: string) => string | null;
+      isNodeFixed: (k: string) => boolean;
+      setLayoutPaused: (paused: boolean) => void;
+      settleLayout: (maxTicks?: number) => number;
+    };
+    // `getNodeSize` + `getEdgeLabel` are the #500 additions to the
+    // bridge; waiting on the former proves the new bridge is installed.
+    await page.waitForFunction(() => {
+      const win = window as Window & { __illuminateCanvas?: Bridge };
+      return !!win.__illuminateCanvas?.getNodeSize;
+    });
+
+    const readPos = (k: string): Promise<Pos | null> =>
+      page.evaluate((key) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.getNodePosition(key) ?? null;
+      }, k);
+    const readColor = (k: string): Promise<string | null> =>
+      page.evaluate((key) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.getRenderedNodeColor(key) ?? null;
+      }, k);
+    const readSize = (k: string): Promise<number | null> =>
+      page.evaluate((key) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.getNodeSize(key) ?? null;
+      }, k);
+    const readEdgeLabel = (k: string): Promise<string | null> =>
+      page.evaluate((key) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.getEdgeLabel(key) ?? null;
+      }, k);
+    const isFixed = (k: string): Promise<boolean> =>
+      page.evaluate((key) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.isNodeFixed(key) ?? false;
+      }, k);
+    const pause = (p: boolean): Promise<void> =>
+      page.evaluate((paused) => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        win.__illuminateCanvas?.setLayoutPaused(paused);
+      }, p);
+    const settle = (): Promise<number> =>
+      page.evaluate(() => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.settleLayout() ?? 0;
+      });
+
+    // The seed echoed by `?seed=` is the latest expansion origin, so it
+    // is THE seed anchor (都度Seed). These fixtures carry no TTL and we
+    // never hover, so the node reducer is an identity pass-through —
+    // `getRenderedNodeColor` returns the stamped colour verbatim.
+    const SEED = "e2e:illum:hub";
+
+    // Feature B: the seed is the ONLY pinned node …
+    expect(await isFixed(SEED), "seed must be pinned").toBe(true);
+    // … and, as the hop-0 origin, renders on the warm red end of the
+    // #500 red→blue hop ramp. Dropping the separate orange accent, this
+    // is now what colour-distinguishes the seed (plus its size + pin).
+    const HOP0_RED = "#d13438";
+    const HOP1_VIOLET = "#8764b8";
+    const HOP2_BLUE = "#0078d4";
+    expect(
+      await readColor(SEED),
+      "seed must render as the hop-0 red origin",
+    ).toBe(HOP0_RED);
+
+    // Feature C: the seed is strictly larger than every other node.
+    const seedSize = await readSize(SEED);
+    expect(seedSize).not.toBeNull();
+
+    const others = [
+      "e2e:illum:left",
+      "e2e:illum:right",
+      "e2e:illum:leftleft",
+      "e2e:illum:rightright",
+    ] as const;
+    const otherSizes: number[] = [];
+    for (const k of others) {
+      expect(await isFixed(k), `${k} must not be pinned`).toBe(false);
+      expect(
+        await readColor(k),
+        `${k} must not render as the hop-0 red origin`,
+      ).not.toBe(HOP0_RED);
+      const s = await readSize(k);
+      expect(s, `${k} should have a size`).not.toBeNull();
+      otherSizes.push(s!);
+    }
+    for (const s of otherSizes) {
+      expect(
+        seedSize!,
+        "seed must be larger than every other node",
+      ).toBeGreaterThan(s);
+    }
+    // Feature C (uniformity): all non-seed nodes share ONE size.
+    expect(
+      new Set(otherSizes).size,
+      "non-seed nodes must all be the same size",
+    ).toBe(1);
+
+    // The core #500 colour acceptance: origin / 1 hop / 2 hops are three
+    // obviously-different colours (red → violet → blue), not three shades
+    // of one blue. left/right are 1 hop from the hub; leftleft/rightright
+    // are 2 hops.
+    expect(await readColor("e2e:illum:left")).toBe(HOP1_VIOLET);
+    expect(await readColor("e2e:illum:right")).toBe(HOP1_VIOLET);
+    expect(await readColor("e2e:illum:leftleft")).toBe(HOP2_BLUE);
+    expect(await readColor("e2e:illum:rightright")).toBe(HOP2_BLUE);
+    expect(
+      new Set([HOP0_RED, HOP1_VIOLET, HOP2_BLUE]).size,
+      "origin/1hop/2hop must be three distinct hues",
+    ).toBe(3);
+
+    // Feature D: each edge renders its weight as the on-edge label.
+    // Edge ids follow `${tail}→${head}` (edgeIdOf); integer weights
+    // render with no decimal point (see formatEdgeWeight).
+    expect(await readEdgeLabel("e2e:illum:hub→e2e:illum:left")).toBe("1");
+    expect(await readEdgeLabel("e2e:illum:hub→e2e:illum:right")).toBe("3");
+    expect(await readEdgeLabel("e2e:illum:right→e2e:illum:rightright")).toBe(
+      "2",
+    );
+
+    // Features A + B in motion. Expanding from `left` makes `left` the
+    // new seed; its 2-hop result is {left, leftleft, leftleftleft}.
+    // `leftleft` SURVIVES the frame but is NOT the new seed, so it is
+    // free to move (Feature A — 既存ノードも動いていい); `left` is the
+    // new seed, so it is pinned and must not move (Feature B —
+    // これだけは動かない).
+    await pause(true);
+    await page
+      .getByRole("group")
+      .getByText(/List view \(5 vertices/)
+      .click();
+    const table = page.getByTestId("illuminate-table");
+    await table
+      .getByRole("button", { name: "Expand from e2e:illum:left", exact: true })
+      .click();
+    await expect(counter).toContainText("6 vertices");
+
+    const NEW_SEED = "e2e:illum:left";
+    const SURVIVOR = "e2e:illum:leftleft";
+
+    // The accent + pin + size move with the seed identity to `left`.
+    expect(await isFixed(NEW_SEED), "new seed must be pinned").toBe(true);
+    expect(await isFixed(SURVIVOR), "non-seed survivor must be free").toBe(
+      false,
+    );
+    // The red hop-0 origin colour follows the seed identity to `left`;
+    // the survivor `leftleft` is now 1 hop from the new seed, so it
+    // recolours to the violet 1-hop tier (and is NOT the red origin).
+    expect(await readColor(NEW_SEED), "new seed must be the hop-0 red").toBe(
+      HOP0_RED,
+    );
+    expect(
+      await readColor(SURVIVOR),
+      "survivor must not wear the hop-0 red origin colour",
+    ).not.toBe(HOP0_RED);
+    const newSeedSize = await readSize(NEW_SEED);
+    const survivorSize = await readSize(SURVIVOR);
+    expect(newSeedSize).not.toBeNull();
+    expect(survivorSize).not.toBeNull();
+    expect(newSeedSize!).toBeGreaterThan(survivorSize!);
+
+    // Drive the (paused) simulation to rest by hand: the pinned seed
+    // holds its EXACT coordinates while the springs relax the non-seed
+    // survivor away from where it started.
+    const seedBefore = await readPos(NEW_SEED);
+    const survivorBefore = await readPos(SURVIVOR);
+    expect(seedBefore, "new seed should have a position").not.toBeNull();
+    expect(survivorBefore, "survivor should have a position").not.toBeNull();
+    await settle();
+    const seedAfter = await readPos(NEW_SEED);
+    const survivorAfter = await readPos(SURVIVOR);
+    expect(seedAfter, "new seed vanished").not.toBeNull();
+    expect(survivorAfter, "survivor vanished").not.toBeNull();
+
+    // Feature B: pinned seed is immovable — exact equality after settle
+    // (d3-force overwrites x/y with fx/fy every tick).
+    expect(seedAfter!.x, "pinned seed x drifted").toBe(seedBefore!.x);
+    expect(seedAfter!.y, "pinned seed y drifted").toBe(seedBefore!.y);
+
+    // Feature A: the non-seed survivor is repositioned by the layout.
+    const survivorMove = Math.hypot(
+      survivorAfter!.x - survivorBefore!.x,
+      survivorAfter!.y - survivorBefore!.y,
+    );
+    expect(
+      survivorMove,
+      "non-seed survivor should be relaxed by the layout, not frozen",
+    ).toBeGreaterThan(1);
+  });
+
   test("Hover focus mode dims non-neighbours and keeps incident edges saturated (#458)", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

Implements the four acceptance criteria of #500 for the Illuminate canvas.

- **Relayout on expansion (A).** A change to the rendered **node OR edge**
  set now reheats the whole d3-force simulation, so pre-existing nodes are
  free to migrate into a better arrangement after an expansion instead of
  staying frozen.
- **Seed anchor (B).** The per-expansion seed (`latestExpansionOrigin`) is
  the **only** pinned node — it holds its exact `fx`/`fy` every tick while
  every other node relaxes around it.
- **Seed size (C).** The seed renders larger (`SEED_NODE_SIZE` 16); all
  other nodes share one uniform size (`DEFAULT_NODE_SIZE` 7).
- **On-edge weights (D).** Each edge now carries its numeric weight as an
  on-edge label via `formatEdgeWeight` (integer when whole, else one
  decimal).

## Colour rework (per user feedback)

The original #460 hop ramp drew all three near tiers from the single-hue
Fluent **brand** foreground ladder, so origin / 1 hop / 2 hops rendered as
three near-identical blues and read as "no colour coding." Per the user's
follow-up, this PR:

- **drops the separate orange seed accent** — the seed is hop-0, so it is
  now simply the red end of the ramp and stays distinct without an override
  (`isSeed` now drives only **size** and **pinning**, not colour); and
- **reworks the hop ramp into an extreme red→blue diverging colormap** made
  of code-side literals (theme-stable, like the existing dim/base literals):

  | tier | colour |
  |---|---|
  | origin (hop 0) | `#d13438` vivid red |
  | 1 hop | `#8764b8` violet |
  | 2 hops | `#0078d4` azure |
  | 3+ hops | `#004e8c` deep blue |
  | unreachable | `#605e5c` grey |

## Tests

- `bun run format && bun run lint && bun run typecheck && bun run test` —
  green (469 pass / 0 fail).
- `bunx playwright test --workers=1` — green (48 passed). The #500 e2e
  asserts the seed is pinned + enlarged + red `#d13438`, that origin / 1 hop
  / 2 hops are three distinct hues, that non-seed nodes share one size, that
  edges show their weight, and that survivors relayout while the pinned seed
  holds its exact position.

Closes #500
