### PR TITLE
docs: vendor the react-router-app-architecture skill into .github/skills/

### DIFF
--- a/.github/skills/react-router-app-architecture/SKILL.md
+++ b/.github/skills/react-router-app-architecture/SKILL.md
@@ -1,0 +1,530 @@
+---
+name: react-router-app-architecture
+description: "Own React Router app-code architecture, route boundaries, UI structure, and verification for Vite-based web apps. Use when the request mentions React Router routes, loaders or actions, component boundaries, use cases, domain models, server-side data access through repository ports, Fluent UI, responsive UI, charts, Playwright UI verification, or app-structure refactoring. Do not use this skill for `/docs/spec` planning, Azure platform setup, app registration, end-user auth contract design, release delivery, or for choosing a specific ORM or database engine."
+---
+
+# React Router App Architecture
+
+## Overview
+
+Use this skill as the default architecture workflow for a React Router SPA that
+uses Vite. Use it from initial bootstrap through ongoing implementation. Keep
+FlatRoute modules declarative, view files thin, data access server-only, and
+dependency direction explicit before writing code.
+
+This skill owns code structure, dependency direction, UI guardrails, and
+verification for the app codebase. Do not use it to define cloud provider
+choice, identity provisioning, secret-store topology, IaC layout, or deployment
+infrastructure; let a companion hosting skill add those concerns while
+preserving these rules.
+
+This skill is also persistence-agnostic. It defines where the data access layer
+lives, how it is shaped (repository ports in `domain`, repository
+implementations and ORM/SDK code in `server/infrastructure`), and how it must
+not leak across boundaries — but it does not pick an ORM, query builder, or
+database engine. Plug in the data stack that fits the project (Drizzle, Kysely,
+Prisma, TypeORM, raw `pg`, an HTTP backend, etc.) inside
+`app/lib/server/infrastructure/` and keep the rest of the rules unchanged.
+
+This skill also does not own `/docs/spec`, `/docs/plans/plan.md`, commit-log
+workflow, branch naming workflow, or PR management; use a repository workflow
+skill for those concerns and keep this skill focused on app code.
+
+For new or unstandardized UI work, prefer Fluent UI React v9 and a quiet,
+simple visual presentation. Keep primary labels and layouts concise, and move
+only supplemental, non-essential detail into Tooltip or InfoLabel patterns.
+
+When data visualization is required, prefer the simplest accessible chart that
+matches the analytical task and keep chart interaction lightweight.
+
+For responsive behavior, prefer guidance that keeps the same feature usable on
+both desktop and mobile rather than treating `mobile-first` as a universal
+process requirement.
+
+If a companion hosting skill explicitly overrides runtime mode or config
+bootstrap, keep these architecture and boundary rules and let the companion
+override only the hosting-specific pieces.
+
+## Quick Start
+
+1. Always read
+   [`references/layout-and-module-placement.md`](references/layout-and-module-placement.md)
+   before deciding where code should live.
+2. Run a placement preflight before implementing:
+   - list every new file, moved file, and extracted file
+   - assign the exact canonical target path for each file before writing code
+   - if a file does not fit the canonical layout, stop and revise the placement
+     plan before creating a new directory
+3. Classify the requested change:
+   - route composition
+   - presentational UI
+   - client interaction flow
+   - server use case
+   - persistence or external integration
+   - domain rule
+   - cross-boundary contract or utility
+4. Place code in the canonical layout:
+   - `app/routes/`
+   - `app/components/<feature>/`
+   - `app/components/shared/`
+   - `app/lib/client/usecase/`
+   - `app/lib/client/usecase/<feature>/use-<feature>.ts`
+   - `app/lib/client/usecase/<feature>/state.ts`
+   - `app/lib/client/usecase/<feature>/reducer.ts`
+   - `app/lib/client/usecase/<feature>/selectors.ts`
+   - `app/lib/client/usecase/<feature>/handlers.ts`
+   - `app/lib/client/infrastructure/`
+   - `app/lib/client/infrastructure/api/`
+   - `app/lib/client/infrastructure/browser/`
+   - `app/lib/server/usecase/`
+   - `app/lib/server/infrastructure/`
+   - `app/lib/server/infrastructure/config/`
+   - `app/lib/server/infrastructure/repositories/`
+   - `app/lib/server/infrastructure/gateways/`
+   - `app/lib/domain/entities/`
+   - `app/lib/domain/value-objects/`
+   - `app/lib/domain/policies/`
+   - `app/lib/domain/services/`
+   - `app/lib/domain/repositories/`
+5. Read the narrowest additional reference file after the layout reference:
+   - project bootstrap and dependency install:
+     [`references/project-bootstrap.md`](references/project-bootstrap.md)
+   - architecture overview index for multi-boundary changes:
+     [`references/layout-and-dependency-rules.md`](references/layout-and-dependency-rules.md)
+   - client layer responsibilities:
+     [`references/client-layer-responsibilities.md`](references/client-layer-responsibilities.md)
+   - server and domain layer responsibilities:
+     [`references/server-and-domain-layer-responsibilities.md`](references/server-and-domain-layer-responsibilities.md)
+   - boundary, contract, and validation rules:
+     [`references/boundary-and-contract-rules.md`](references/boundary-and-contract-rules.md)
+   - domain modeling and type rules:
+     [`references/domain-modeling-and-type-rules.md`](references/domain-modeling-and-type-rules.md)
+   - dependency injection, lifetime, and side-effect rules:
+     [`references/dependency-injection-lifetime-and-side-effects.md`](references/dependency-injection-lifetime-and-side-effects.md)
+   - FlatRoute REST API rules:
+     [`references/flat-route-rest-api-guidelines.md`](references/flat-route-rest-api-guidelines.md)
+   - state and handler composition:
+     [`references/view-state-and-handler-patterns.md`](references/view-state-and-handler-patterns.md)
+   - component file, Fluent UI, and CSS Module rules:
+     [`references/component-file-and-css-module-rules.md`](references/component-file-and-css-module-rules.md)
+   - chart and data visualization guidance:
+     [`references/chart-and-data-visualization-guidance.md`](references/chart-and-data-visualization-guidance.md)
+   - responsive and mobile UI guidance:
+     [`references/responsive-and-mobile-ui-guidance.md`](references/responsive-and-mobile-ui-guidance.md)
+   - Playwright UI verification workflow:
+     [`references/playwright-ui-verification.md`](references/playwright-ui-verification.md)
+   - stateful flow compromise rules:
+     [`references/stateful-flow-compromises.md`](references/stateful-flow-compromises.md)
+   - hotspot refactor workflow:
+     [`references/hotspot-refactor-workflow.md`](references/hotspot-refactor-workflow.md)
+   - verification before push:
+     [`references/verification-gates.md`](references/verification-gates.md)
+
+## Non-Negotiable Rules
+
+- Keep dependency direction inward:
+  - `app/routes` and `app/components` depend on client-facing orchestration,
+    never on server infrastructure or ORM/data-client code
+  - `app/lib/client/usecase` depends on `domain` and client adapters
+  - `app/lib/server/usecase` depends on `domain` and repository ports
+  - `app/lib/server/infrastructure` implements repository ports and external
+    integrations
+  - `app/lib/domain/*` depends only on other domain modules
+- Lock file placement before coding. Name the exact target file paths first,
+  then implement.
+- Keep feature-local presentational components in `app/components/<feature>/`.
+  Use `app/components/shared/` only for feature-agnostic UI that is already
+  reused or clearly about to be reused across features.
+- Keep ORM clients, SDK clients, query builders, and direct database/network
+  access inside `app/lib/server/infrastructure/`. Server use cases and the
+  domain layer must talk to repository ports, not to concrete data clients.
+- Keep `app/components/` presentational. Allow only ephemeral UI state there,
+  such as local input focus or disclosure toggles.
+- Prefer Fluent UI React v9 (`@fluentui/react-components`) for new UI work
+  unless the repository already has a clear design-system standard or an
+  approved migration plan says otherwise.
+- Compose UI from documented Fluent UI primitives (`Field`, `Button`,
+  `Dialog`, `MessageBar`, `Menu`, `Toolbar`, etc.) before introducing custom
+  low-level controls, and use Fluent UI tokens through `makeStyles` for
+  theme-aware visuals layered on those primitives.
+- Do not mix two general-purpose component libraries in the same app. If a
+  design system is already established, follow that system and document the
+  deviation explicitly instead of layering Fluent UI on top.
+- Keep UI visually simple: concise labels, low-noise layouts, restrained text
+  density, and deliberate spacing over decorative complexity.
+- Use Tooltip or InfoLabel for supplemental, non-essential detail. Do not hide
+  required labels, key instructions, validation messages, or critical status
+  only inside a Tooltip.
+- When rendering charts, choose the simplest chart that matches the task: line
+  charts for continuous trends over time, and bar or column charts for
+  comparing discrete categories or ranked values.
+- Keep charts low-noise and accessible: avoid 3D or decorative chart junk,
+  avoid color-only encoding, and keep critical values or explanations
+  discoverable without hover.
+- For important charts, provide a nearby text summary and, when exact
+  inspection matters, an accessible table or equivalent non-hover path to the
+  underlying values.
+- Build responsive UI so the same feature stays capable on both desktop and
+  mobile, using fluid layout primitives and content-driven breakpoints rather
+  than device-name-specific forks or fixed desktop widths.
+- Support narrow-screen reflow and avoid ordinary horizontal scrolling for app
+  UI. Do not lock orientation unless a single orientation is genuinely
+  essential.
+- Do not rely on hover-only or fine-pointer-only interaction for primary
+  actions, labels, or critical explanation. Keep a touch and keyboard path for
+  the same task.
+- Keep touch targets and spacing mobile-usable. Meet at least WCAG 2.2 minimum
+  target size expectations or provide equivalent spacing, and use larger
+  targets when practical.
+- One React component per `.tsx` file. The file name (`PascalCase.tsx`) and
+  the primary exported component name must match exactly. Tiny private
+  presentational helpers that have no state, no effects, and no exports may
+  stay in the same file; everything else gets its own file.
+- Default to CSS Modules for component-owned styling. Each component that
+  needs custom CSS owns a sibling `<ComponentName>.module.css` colocated with
+  the component, imported as `import styles from "./<ComponentName>.module.css";`
+  and applied through the `styles` object. Do not import non-module CSS files
+  inside components.
+- Keep media queries and other responsive styles inside the component's own
+  CSS Module (or `makeStyles`) so style scope stays bounded to the component
+  that owns the layout.
+- Reserve global CSS for a small, named set of concerns (reset, font loading,
+  baseline body and root styles, one-time `FluentProvider` host wiring) and
+  place it under `app/styles/`. Global stylesheets must not contain
+  feature-specific or component-name selectors, and must not override Fluent
+  UI internal class names.
+- Avoid inline `style={{ ... }}` for static styling. Use `makeStyles` for
+  theme-aware visuals on Fluent UI primitives and a colocated CSS Module for
+  the component's structural layout; reserve inline style for genuinely
+  dynamic runtime values.
+- For UI-affecting changes, verify the actual rendered result with Playwright
+  before pushing instead of relying only on code inspection.
+- Prefer accessible locators and web-first assertions in Playwright, and check
+  the touched flow at the relevant route and viewport sizes.
+- Keep async state, mutation handlers, and derived view models in
+  `app/lib/client/usecase/`.
+- Co-locate `state`, `reducer`, `selector`, and `handler` modules inside the
+  owning feature directory under `app/lib/client/usecase/<feature>/`.
+- Do not create horizontal buckets such as `app/state/`, `app/reducers/`,
+  `app/stores/`, `app/handlers/`, or `app/lib/client/usecase/state/`.
+- Use FlatRoute (`@react-router/fs-routes` `flatRoutes()`) as the default
+  routing convention. One file per route module under `app/routes/`, with
+  dots in the file name mapping to URL slashes and `$segment` marking dynamic
+  parameters. Deviate only when the project already uses a different
+  convention, a third-party generator imposes one, or a specific framework
+  integration requires it.
+- Shape API URLs as resources, not actions: collection at `/items`, single
+  resource at `/items/$itemId`, sub-collection at `/items/$itemId/comments`.
+  Reserve verb-shaped paths (`/items/$itemId/publish`) for genuine operations
+  that do not fit CRUD, and keep them rare.
+- Keep route modules responsible for HTTP, loader/action wiring, and top-level
+  composition only.
+- Validate at the correct layer: transport shape in routes or API adapters,
+  application rules in use cases, business invariants in domain.
+- Default client-side data access to `api` adapters plus DTO mapping inside the
+  owning use case. Introduce a client-side repository abstraction only for
+  clear multi-source or local-first requirements.
+- Instantiate repositories and gateways in a composition root or dependency
+  factory, not inside domain models or use cases.
+- Prefer React Router's official Vite-powered bootstrap for new projects. Use
+  plain `create-vite` only when you intentionally choose a lower-level React
+  Router mode or must retrofit an existing starter.
+- Do not put cloud-provider provisioning, app registration, secret-store
+  policy, IaC topology, or release-infrastructure rules in this skill. Keep
+  those in a companion hosting skill while preserving these code-level
+  boundaries.
+- Do not pick the ORM, query builder, or database engine inside this skill.
+  Keep that choice in the project's data-stack decision and confine all of its
+  imports to `app/lib/server/infrastructure/`.
+- Keep authorization, serialization, migration steps, background side effects,
+  and barrel exports intentional rather than ad hoc.
+- Treat thread safety mainly as async safety and request safety: avoid
+  module-level mutable state, keep request context out of singletons, and
+  rebuild transaction-scoped dependencies per request.
+- Keep feature internals private by default and avoid circular dependencies
+  across extracted modules.
+- Use `class` only when identity, invariants, or lifecycle matter. Prefer
+  composition over inheritance, and keep DTO or transport shapes as `type` plus
+  function-based modules.
+- Use `interface` for stable object-shaped ports or contracts with multiple
+  implementations. Use `type` for DTOs, unions, mapped shapes, and local
+  view-model shapes.
+- Use `unknown` at trust boundaries when a value exists but its shape is not
+  yet proven. Narrow or parse it immediately; do not let raw `unknown` drift
+  into use cases, components, or domain models.
+- Keep one concept under one owner. Consolidate duplicate same-role modules
+  only when they represent the same concept in the same boundary.
+- Build business behavior around domain models and domain language, but do not
+  force UI state, DTOs, or infrastructure concerns into `domain`.
+- Keep constants in the narrowest owning module or feature. Extract repeated
+  stable literals into `constants.ts` only when they have one clear owner; do
+  not build a global constants dump.
+- Do not create a generic common bucket. Keep code in the narrowest owning
+  layer, and duplicate small utilities until a stable abstraction is obvious.
+- Do not create alternate top-level buckets such as `app/features/`,
+  `app/modules/`, `app/hooks/`, `app/services/`, `app/utils/`, `app/types/`, or
+  `app/store/` unless an explicit migration plan or companion skill requires
+  them.
+- If a file does not fit the canonical layout, revise the plan before
+  implementation instead of inventing a convenience directory.
+- Prefer direct replacement over compatibility aliases when renaming
+  architecture terms.
+
+## Implementation Workflow
+
+### Placement Preflight For Every Change
+
+- Read
+  [`references/layout-and-module-placement.md`](references/layout-and-module-placement.md)
+  first.
+- Write the exact target paths for every created or moved file before touching
+  code.
+- Confirm that each target path matches one canonical owner:
+  - route HTTP composition: `app/routes/`
+  - feature-local presentational UI: `app/components/<feature>/`
+  - shared presentational UI: `app/components/shared/`
+  - client orchestration and state: `app/lib/client/usecase/<feature>/`
+  - client adapters: `app/lib/client/infrastructure/`
+  - server orchestration: `app/lib/server/usecase/`
+  - server integrations, ORM/SDK clients, and persistence:
+    `app/lib/server/infrastructure/`
+  - domain concepts and ports: `app/lib/domain/`
+- If any planned file lacks a clear owner, fix the placement plan before
+  implementing.
+
+### 0. Bootstrap new projects correctly
+
+- When starting from scratch, follow
+  [`references/project-bootstrap.md`](references/project-bootstrap.md) before
+  writing features.
+- Prefer `create-react-router` for this skill's architecture because it
+  already aligns with Vite, route modules, and SPA mode.
+- Add `@react-router/fs-routes` and SPA configuration before layering domain or
+  use-case code. Use FlatRoute (`flatRoutes()`) as the routing convention from
+  the first route file so URL shape, dynamic segments, and index modules stay
+  consistent across the app.
+- Add Fluent UI React v9 early for new UI work so components, theming, and
+  accessibility patterns stay consistent from the first screen.
+- Pick the data stack (ORM, query builder, or remote backend client) once,
+  document it in the project, and keep its imports confined to
+  `app/lib/server/infrastructure/`. This skill is intentionally silent on
+  which one.
+- Before substantial feature work begins, prefer installing the baseline
+  dependencies the project already knows it will need so architecture work does
+  not drift around missing packages mid-implementation.
+- When hosting, identity, or deployment requirements appear, keep this skill on
+  code-level architecture and hand the platform-specific decisions to the
+  companion hosting skill.
+
+### 1. Model the change around a use case
+
+- Name the user intent first.
+- Put invariants in `domain/entities` or `domain/value-objects`, and put
+  cross-entity rules in `domain/policies` or `domain/services` when they do not
+  naturally belong to one model.
+- Put behavior where the state lives: entity behavior on entities, value
+  normalization on value objects, cross-entity rules on policies, and
+  orchestration on services or use cases.
+- Keep literals local until they become stable, named concepts. Extract only
+  when the name improves readability or the value is reused inside one clear
+  boundary.
+- Treat untrusted data as `unknown` first, then narrow it at the boundary with
+  a parser, schema, or type guard before promoting it to a DTO or domain shape.
+- When two modules appear to serve the same role, first ask whether they are
+  actually the same concept in the same layer. Merge duplicates inside one
+  boundary, but keep separate shapes when one is a DTO, one is a view model, or
+  one is a domain model.
+- Put repository interfaces in `domain/repositories`.
+- Keep request or response shapes next to the route, API client, or use case
+  that owns them. Promote them only after the boundary is stable and truly
+  reused.
+- Do not move transport `Request` or `Response` types into `domain` just
+  because several modules share them.
+
+### 2. Keep view logic out of components
+
+- Build a custom Hook, controller, or view-model module in
+  `app/lib/client/usecase/` for each non-trivial screen or interaction flow.
+- When the interaction has enough complexity to need submodules, create a
+  feature directory and keep the use case internals there.
+- Keep feature-specific presentational components in
+  `app/components/<feature>/` by default. Promote a component to
+  `app/components/shared/` only after it proves to be truly feature-agnostic.
+- Prefer composing views from Fluent UI primitives before introducing custom
+  low-level controls.
+- Keep on-screen copy terse. Put optional elaboration behind Tooltip,
+  InfoLabel, Popover, or a similar secondary affordance only when the extra
+  detail is not required for task completion.
+- Keep purely presentational responsive adaptation in CSS, layout primitives,
+  and presentational components. Move breakpoint-aware state into `usecase`
+  only when it changes interaction flow or data loading behavior.
+- For chart-heavy views, keep series transformation, grouping, filtering, and
+  drill state in `app/lib/client/usecase/`, and keep chart components focused
+  on rendering, theming, and accessibility wiring.
+- Let that module own:
+  - async calls
+  - reducer logic
+  - derived screen state
+  - event handlers
+  - error and pending mapping
+- Pass view-ready props into `app/components/<feature>/` or
+  `app/components/shared/` when the component is genuinely cross-feature.
+
+### 3. Use React Router primitives before inventing new state containers
+
+- Use loader data for route reads.
+- Use action or fetcher state for mutations.
+- Use navigation or fetcher pending state instead of duplicating network flags
+  in component state.
+- Add client state only for interaction state that is not already owned by the
+  router.
+
+### 4. Move DTOs through the client boundary explicitly
+
+- Return JSON DTOs from route loaders, actions, or API endpoints.
+- Let `client/infrastructure/api` fetch those DTOs.
+- Rebuild client-facing objects or value objects inside the owning use case
+  only when that adds real value.
+- Do not expect server-side `Entity` instance identity to cross the network
+  boundary.
+
+### 5. Assemble dependencies at the edge
+
+- Keep `usecase` and `domain` code constructor-injected.
+- Build repository, gateway, and service instances in route loaders, actions,
+  server entry points, or dedicated dependency factories.
+- Prefer manual DI with explicit factory functions before introducing a DI
+  container.
+- Recreate request-scoped dependencies such as transaction-bound repositories
+  from the current request or transaction context.
+
+### 6. Validate and map errors by layer
+
+- Keep request parsing and input shape validation at the HTTP or client
+  transport boundary.
+- Keep use-case rule validation in `server/usecase` or `client/usecase`.
+- Keep invariant enforcement in `domain`.
+- Map domain, application, and infrastructure errors to transport responses at
+  the edge.
+
+### 7. Keep authorization and serialization explicit
+
+- Resolve authentication at the edge, but keep authorization decisions in use
+  cases or domain policies.
+- Convert `Date`, ids, money-like values, and value objects at boundaries
+  rather than leaking transport or ORM shapes inward.
+
+### 8. Keep mutable state scoped
+
+- Do not store request-specific state in module globals or singleton services.
+- Pass auth context, user context, tenant context, and correlation metadata
+  explicitly.
+- Keep transaction handles scoped to the current transaction only.
+- Treat client-side async race conditions as correctness issues and guard
+  against stale responses.
+
+### 9. Use explicit compromises for stateful flows
+
+- For chat, streaming, session, playback, or wizard-style flows, allow a
+  feature-local controller or store when lifecycle and identity genuinely
+  matter.
+- Keep that compromise inside `app/lib/client/usecase/<feature>/` rather than
+  spreading mutable state across routes or components.
+- Split durable state, ephemeral runtime state, and infrastructure handles
+  explicitly.
+
+### 10. Push side effects and migrations into explicit workflows
+
+- Keep schema changes, background jobs, external notifications, and indexing
+  side effects visible and testable.
+- Do not hide them inside random route handlers or repositories.
+- Use barrel exports sparingly and only when they do not obscure ownership or
+  create cycles.
+
+### 11. Verify before push
+
+- Run targeted tests for the touched area.
+- Run typecheck and lint or the project quality gate.
+- Audit for boundary drift and forbidden imports.
+- For UI-affecting changes, run the touched route in Playwright and confirm the
+  rendered result, interaction states, and responsive layout.
+- Fix architecture violations before pushing even if tests pass.
+
+### 12. Refactor overloaded files in phases
+
+- When a `ts` or `tsx` file has too many responsibilities, do not rewrite it in
+  one jump.
+- Follow the hotspot workflow in
+  [`references/hotspot-refactor-workflow.md`](references/hotspot-refactor-workflow.md).
+- When several hotspots exist, start with the one that combines correctness
+  risk, change frequency, and boundary damage rather than the one that is
+  merely largest.
+- Separate analysis, planning, extraction sequencing, execution, and
+  verification.
+- Move one stable seam at a time and keep the file working after each batch.
+
+## Placement Guide
+
+- Need feature-local pure rendering and markup: `app/components/<feature>/`
+- Need reusable pure UI primitives or shared Fluent UI composition wrappers:
+  `app/components/shared/`
+- Need route composition or loader/action bridging: `app/routes/`
+- Need client-side state, handlers, reducers, selectors, or orchestration:
+  `app/lib/client/usecase/<feature>/`
+- Need browser APIs, API clients, or router adapters:
+  `app/lib/client/infrastructure/`
+- Need endpoint-specific API clients: `app/lib/client/infrastructure/api/`
+- Need browser-only adapters such as storage, clipboard, media queries, or
+  channel APIs: `app/lib/client/infrastructure/browser/`
+- Need a business invariant or behavior-rich model: `app/lib/domain/entities/`
+- Need a small immutable business concept with validation:
+  `app/lib/domain/value-objects/`
+- Need cross-entity business rules: prefer `app/lib/domain/policies/`
+- Need domain-level orchestration that is still infrastructure-free:
+  `app/lib/domain/services/`
+- Need a repository port or domain-facing persistence contract:
+  `app/lib/domain/repositories/`
+- Need server orchestration: `app/lib/server/usecase/`
+- Need ORM clients, SDK clients, file system access, or external service code:
+  `app/lib/server/infrastructure/`
+- Need platform-specific server config bootstrap or config readers:
+  `app/lib/server/infrastructure/config/`
+- Need persistence implementations: `app/lib/server/infrastructure/repositories/`
+- Need external SDK or HTTP adapters: `app/lib/server/infrastructure/gateways/`
+- Need a reusable type or utility: place it with the owning route, use case, or
+  domain module first; extract only after repeated reuse proves the boundary
+
+## References
+
+- project bootstrap and baseline dependency install:
+  [`references/project-bootstrap.md`](references/project-bootstrap.md)
+- overview index for placement and dependency rules:
+  [`references/layout-and-dependency-rules.md`](references/layout-and-dependency-rules.md)
+- layout and module placement, always read first:
+  [`references/layout-and-module-placement.md`](references/layout-and-module-placement.md)
+- client layer responsibilities:
+  [`references/client-layer-responsibilities.md`](references/client-layer-responsibilities.md)
+- server and domain layer responsibilities:
+  [`references/server-and-domain-layer-responsibilities.md`](references/server-and-domain-layer-responsibilities.md)
+- boundary and contract rules:
+  [`references/boundary-and-contract-rules.md`](references/boundary-and-contract-rules.md)
+- domain modeling and type rules:
+  [`references/domain-modeling-and-type-rules.md`](references/domain-modeling-and-type-rules.md)
+- dependency injection, lifetime, and side-effect rules:
+  [`references/dependency-injection-lifetime-and-side-effects.md`](references/dependency-injection-lifetime-and-side-effects.md)
+- FlatRoute REST API guidance:
+  [`references/flat-route-rest-api-guidelines.md`](references/flat-route-rest-api-guidelines.md)
+- view-state and handler composition:
+  [`references/view-state-and-handler-patterns.md`](references/view-state-and-handler-patterns.md)
+- chart and data visualization guidance:
+  [`references/chart-and-data-visualization-guidance.md`](references/chart-and-data-visualization-guidance.md)
+- responsive and mobile UI guidance:
+  [`references/responsive-and-mobile-ui-guidance.md`](references/responsive-and-mobile-ui-guidance.md)
+- Playwright UI verification workflow:
+  [`references/playwright-ui-verification.md`](references/playwright-ui-verification.md)
+- stateful flow compromise rules:
+  [`references/stateful-flow-compromises.md`](references/stateful-flow-compromises.md)
+- hotspot refactor workflow:
+  [`references/hotspot-refactor-workflow.md`](references/hotspot-refactor-workflow.md)
+- verification before push:
+  [`references/verification-gates.md`](references/verification-gates.md)

--- a/.github/skills/react-router-app-architecture/agents/openai.yaml
+++ b/.github/skills/react-router-app-architecture/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "React Router App Architecture"
+  short_description: "Own app-code architecture, route boundaries, UI structure, and verification"
+  default_prompt: "Use $react-router-app-architecture when the work is primarily React Router routes, loaders or actions, component boundaries, use cases, domain models, server-side data access through repository ports, Fluent UI screens, responsive UI, charts, Playwright verification, or app-structure refactoring. Do not use it for `/docs/spec` planning, Azure platform setup, app registration, end-user auth contract design, release delivery, or for choosing a specific ORM or database engine."

--- a/.github/skills/react-router-app-architecture/references/boundary-and-contract-rules.md
+++ b/.github/skills/react-router-app-architecture/references/boundary-and-contract-rules.md
@@ -1,0 +1,135 @@
+# Boundary And Contract Rules
+
+## Dependency Direction
+
+Follow this direction strictly:
+
+```text
+routes/components
+  -> client/usecase
+  -> client/infrastructure
+  -> domain
+
+components/shared
+  -> nothing application-specific
+
+server/usecase
+  -> domain
+  -> domain/repositories
+
+server/infrastructure
+  -> domain
+  -> external systems
+```
+
+Treat `domain` as the inner policy layer and `server/infrastructure` as the
+outer integration layer.
+
+## Contract Placement Rule
+
+Do not move API `Request` or `Response` structures into `domain` just because
+they are reused.
+
+Use this decision order:
+
+1. Keep route-specific transport shapes near the owning route or server use
+   case.
+2. Keep client transport DTOs near the owning API client.
+3. Promote a type into `domain` only when it is a real business concept with
+   invariants.
+4. If transport contracts become broadly shared across many boundaries,
+   introduce a dedicated `app/lib/contracts/` directory later instead of
+   polluting `domain`.
+
+## Constant Placement Rule
+
+Do not create a global constants dump by default.
+
+Use this order:
+
+1. keep a literal local when it is obvious and used once
+2. extract to the nearest owning module when the name improves readability
+3. extract to a feature-level `constants.ts` only when several modules in the
+   same feature share it
+4. promote to a wider scope only when the constant is truly cross-feature and
+   stable
+
+Use `domain` for constants only when the value is really a domain concept.
+
+## Validation Ownership Rule
+
+Validate at the narrowest boundary that can correctly own the rule.
+
+Use this split:
+
+- routes and API adapters: request shape, query parsing, content-type,
+  required fields, basic schema validation
+- use cases: permission checks, workflow preconditions, cross-field application
+  rules
+- domain: business invariants that must always hold
+- infrastructure: persistence constraints and external service response
+  validation
+
+Do not push domain invariants outward just because the route can reject early,
+and do not pull HTTP-specific validation into `domain`.
+
+## Error Mapping Rule
+
+Keep error categories explicit:
+
+- transport errors
+- application or use-case errors
+- domain errors
+- infrastructure errors
+
+Use cases should return or throw errors that still make sense without HTTP.
+Route modules should translate those errors into status codes and response
+envelopes.
+
+## Authorization Ownership Rule
+
+Keep authentication and authorization distinct.
+
+Use this split:
+
+- route or server entry: resolve the current principal or session
+- use case: decide whether the requested operation is allowed
+- domain policy: enforce reusable business authorization rules when they are
+  part of the domain language
+
+Do not bury authorization in repositories, and do not make UI visibility checks
+the only access control.
+
+## Serialization Rule
+
+Convert between transport, persistence, and domain shapes at explicit
+boundaries.
+
+Do not let these cross boundaries unchanged without intent:
+
+- `Date`
+- database ids
+- money-like values
+- enums with transport-specific names
+- value objects
+
+Prefer DTOs with primitives over leaking runtime-rich objects across HTTP.
+
+## Import Smell Checks
+
+Treat these as architecture failures:
+
+- `components` importing server modules or ORM/SDK data clients
+- `components/shared` importing feature-specific client use cases
+- `client/usecase` importing server modules
+- `domain` importing React Router, browser APIs, ORM clients, or any
+  infrastructure SDK
+- `server/usecase` depending on concrete repository classes when a repository
+  port would do
+- transport `Request` or `Response` types being moved into `domain` without
+  real business invariants
+- `usecase` code constructing its own repositories or gateways with `new`
+- module-level mutable server state holding request or user context
+- circular imports across route, use case, or infrastructure boundaries
+- authorization enforced only in the UI with no server-side check
+- persistence or transport serialization leaking directly into domain rules

--- a/.github/skills/react-router-app-architecture/references/chart-and-data-visualization-guidance.md
+++ b/.github/skills/react-router-app-architecture/references/chart-and-data-visualization-guidance.md
@@ -1,0 +1,69 @@
+# Chart And Data Visualization Guidance
+
+## Goal
+
+Use the simplest accessible chart that answers the product question without
+overloading the canvas.
+
+## Choose The Chart Deliberately
+
+- Use line charts for continuous trends over time.
+- Use bar or column charts to compare values across discrete categories or
+  distinct periods.
+- Use combo charts only when line and bar marks truly share the same X-axis
+  and the comparison would be weaker as separate views.
+- Add a secondary Y-axis only when measures genuinely have different scales,
+  and label both axes explicitly.
+
+## Keep The Visual Quiet
+
+- Keep data ink as the primary focus. Avoid 3D effects, heavy shadows,
+  decorative gradients, and non-informational chrome.
+- Keep axis labels readable and keep gridlines visually secondary.
+- Use theme-aware colors instead of ad hoc hardcoded palettes.
+- Keep chart titles, legends, and units short and easy to scan.
+- Match legend markers to the actual chart geometry so users do not decode
+  shapes twice.
+
+## Labels, Tooltip, And Interaction
+
+- Keep key context visible: chart title, timeframe, units, series names,
+  thresholds, and major status cues.
+- Use Tooltip for supplemental inspection, not as the only place where users
+  can discover the chart's meaning.
+- Keep interactions simple and direct. Add filtering, drilldown, or zoom only
+  when they materially improve exploration.
+- If a chart becomes crowded, reduce the number of visible series or split the
+  view instead of stacking more colors, legends, and labels into one canvas.
+
+## Motion
+
+- Animate only meaningful state changes.
+- If both axes and marks change, transition the axes first and the data
+  second.
+- Avoid independent animation of many marks at the same time.
+- Prefer subtle motion that helps users track change instead of decorative
+  animation.
+
+## Accessibility
+
+- Never rely on color alone. Add labels, shape differences, annotations, or
+  patterns when distinctions matter.
+- Keep keyboard access and focus treatment intentional for interactive chart
+  controls.
+- For important charts, provide a nearby text summary and, when exact values
+  matter, an accessible table or equivalent non-hover path to the data.
+- If the chart behaves like a complex image, connect it to a visible text
+  description with standard accessible markup.
+- Do not hide critical insight, error state, or threshold meaning only inside
+  a hover Tooltip.
+
+## Architecture Placement
+
+- Put DTO-to-series mapping, filters, grouping, sorting, and drill state in
+  `app/lib/client/usecase/<feature>/`.
+- Keep shared chart shells, wrappers, and common chart presentation primitives
+  in `app/components/shared/`.
+- Keep feature-specific chart views near the owning feature component.
+- Treat chart library adapters as client-side UI infrastructure only when they
+  need a reusable wrapper or abstraction boundary.

--- a/.github/skills/react-router-app-architecture/references/client-layer-responsibilities.md
+++ b/.github/skills/react-router-app-architecture/references/client-layer-responsibilities.md
@@ -1,0 +1,109 @@
+# Client Layer Responsibilities
+
+## `app/routes/`
+
+- Define route modules.
+- Read loader and action inputs.
+- Map route data into page composition.
+- Delegate non-trivial logic to `client/usecase` or `server/usecase`.
+
+Do not call ORM clients, SDK clients, or other server-infrastructure modules
+directly; hide business rules in route files; or let route modules become the
+main state container for reusable interactions.
+
+## `app/components/<feature>/`
+
+- Render UI from props.
+- Hold tiny UI-local state only when it is truly view-local, such as popover
+  open state, active tab index, focused element, or an uncontrolled input
+  bridge.
+
+Do not fetch data, own mutation orchestration, build DTOs for the server,
+contain business rules or persistence rules, or introduce component-local
+`state/` or `reducers/` directories.
+
+## `app/components/shared/`
+
+- Hold reusable presentational primitives.
+- Keep these components styleable and composable.
+- Treat `shared` as an extraction target, not as the default starting location
+  for new components.
+
+Promote a component to `shared` only when:
+
+1. it is used or clearly about to be used across multiple features
+2. the API can be expressed in generic UI terms rather than product vocabulary
+3. it does not need feature-specific state or handlers
+4. extraction reduces duplication without turning it into a configurable
+   monster
+
+Do not import feature use cases, own feature vocabulary, or hide data fetching
+or mutation logic in `shared`.
+
+## `app/lib/client/usecase/`
+
+- Own screen-level state and event handlers.
+- Assemble view models for components.
+- Coordinate API clients, router calls, optimistic UI, reducers, and derived
+  state.
+- Hold use-case-local DTO mapping when that mapping is part of the interaction
+  flow.
+- Expose a stable interface for the view layer.
+
+Prefer a feature directory when more than one file is needed for the same
+flow.
+
+Reserve `store.ts` for cases where shared identity and lifecycle actually
+matter across multiple sibling views. Do not default to a store when a Hook
+plus reducer is enough.
+
+## `app/lib/client/infrastructure/`
+
+- Implement browser-facing and network-facing adapters.
+- Wrap `fetch`, `localStorage`, clipboard, browser events, and router
+  integration.
+- Translate transport details into domain-friendly or usecase-friendly
+  interfaces.
+
+Keep framework adapters here, not in a generic common layer.
+
+## `app/lib/client/infrastructure/api/`
+
+- Hold feature or resource API clients.
+- Keep transport and serialization details here.
+- Return shapes that the owning use case can consume directly.
+- Default to JSON DTOs, not domain entity instances.
+- Keep client-side mapping shallow here; put use-case-specific reconstruction
+  in the owning use case.
+
+Client flow should normally be:
+
+```text
+client/usecase
+  -> client/infrastructure/api
+  -> HTTP JSON DTO
+  -> server/usecase
+```
+
+## `app/lib/client/infrastructure/browser/`
+
+- Hold browser-only integrations such as `localStorage`, `sessionStorage`,
+  clipboard, media query, `BroadcastChannel`, `IntersectionObserver`, or
+  document event adapters.
+- Keep direct DOM and browser API calls here unless the logic is tiny and
+  strictly component-local.
+
+## Optional `client/infrastructure/repositories/`
+
+Do not make this a baseline directory.
+
+Add a client-side repository layer only when the client must hide multiple
+data sources behind one abstraction, for example:
+
+- IndexedDB plus remote API
+- memory cache plus remote fetch
+- offline-first synchronization
+- local-first conflict handling
+
+If the client is only calling HTTP endpoints, prefer `api/` instead of a
+repository abstraction.

--- a/.github/skills/react-router-app-architecture/references/component-file-and-css-module-rules.md
+++ b/.github/skills/react-router-app-architecture/references/component-file-and-css-module-rules.md
@@ -1,0 +1,215 @@
+# Component File And CSS Module Rules
+
+Use these rules whenever you create or modify a React component, its styling,
+or its file layout. They sit alongside
+[`layout-and-module-placement.md`](layout-and-module-placement.md) and
+[`view-state-and-handler-patterns.md`](view-state-and-handler-patterns.md) and
+take precedence on file-shape and styling questions.
+
+## Goal
+
+- Keep each component independently readable, movable, and testable.
+- Keep style impact local to the component that owns it.
+- Keep Fluent UI as the default UI vocabulary and let CSS Modules cover the
+  remaining structural and presentational gaps.
+
+## One Component Per File
+
+- A `.tsx` file exports exactly one React component as its primary, file-named
+  export.
+- File name and component name match exactly. `UserMenu.tsx` exports
+  `UserMenu`; `ProfileEditorForm.tsx` exports `ProfileEditorForm`.
+- Do not co-define a second top-level component in the same file just because
+  the two are used together. Each gets its own file.
+- Tiny presentational helpers that are clearly private to the component
+  (e.g. a one-screen-use sub-row that never renders elsewhere) may stay in the
+  same file when all of the following hold:
+  - it is not exported
+  - it does not hold its own state or effects
+  - extracting it would not improve readability
+  When in doubt, give it its own file.
+- Pure utility helpers, hooks, types, and constants used by the component
+  belong in sibling files, not appended to the component file.
+
+## Filename And Export Conventions
+
+- Component files: `PascalCase.tsx` matching the exported component name.
+- Use `.tsx` only when the file renders JSX. Plain logic stays in `.ts`.
+- Prefer named exports for components. Use a `default` export only when an
+  external tool (e.g. a route module convention) requires it.
+- Do not introduce barrel `index.ts` files inside `app/components/<feature>/`
+  by default. Import components directly from their file. Add an `index.ts`
+  only when the feature directory is intentionally a public boundary.
+- The component's prop type is co-defined in the component file as
+  `type <ComponentName>Props = { ... }`. Move it to a sibling
+  `<ComponentName>.types.ts` only when the type is shared with another module
+  in the same feature.
+
+## Component File Layout
+
+Preferred sibling layout for a feature-local component:
+
+```text
+app/components/profile-editor/
+  ProfileEditorForm.tsx
+  ProfileEditorForm.module.css
+  ProfileSummaryCard.tsx
+  ProfileSummaryCard.module.css
+```
+
+Inside `ProfileEditorForm.tsx`, keep this order:
+
+1. imports (Fluent UI, React, sibling modules, then CSS Module)
+2. local types (`type ProfileEditorFormProps = { ... }`)
+3. the component function declaration
+4. small private sub-components or helpers, if any, that satisfy the
+   one-file-helper exception above
+
+Do not let a component file own:
+
+- async orchestration → put it in
+  `app/lib/client/usecase/<feature>/`
+- reducer logic → same
+- API calls → put them in `app/lib/client/infrastructure/api/`
+- server modules, ORM clients, or SDK clients
+
+## Fluent UI Usage
+
+- Default to `@fluentui/react-components` primitives (`Button`, `Field`,
+  `Input`, `Dropdown`, `Dialog`, `Toolbar`, `MessageBar`, etc.) before
+  introducing custom low-level controls.
+- Use `@fluentui/react-icons` for iconography.
+- Wrap the app root in `FluentProvider` with `webLightTheme` (or the project's
+  documented theme) once, at the highest sensible boundary.
+- Prefer Fluent UI's documented composition patterns:
+  - `Field` for form rows with label, hint, and validation
+  - `MessageBar` for inline status, not custom toasts
+  - `Dialog`, `Drawer`, `Popover`, `Menu` from Fluent UI rather than custom
+    overlays
+  - `Tooltip` and `InfoLabel` only for supplemental, non-essential detail
+- Keep primary labels, required-field markers, validation messages, and
+  critical status visible without depending on hover.
+- Respect Fluent UI tokens (`tokens.spacingHorizontalM`, etc.) instead of
+  hand-typed pixel values when the surrounding style is theme-aware.
+- Do not mix two general-purpose component libraries in the same app. If the
+  repository already has an established design system, follow that system
+  instead of layering Fluent UI on top.
+
+### When To Use `makeStyles` Versus A CSS Module
+
+Fluent UI ships its own atomic styling layer (`makeStyles` from
+`@fluentui/react-components`, backed by Griffel). Use it for component styles
+that need to be **theme-aware** or that override Fluent UI primitives:
+
+- token-driven colors, spacing, typography (`tokens.colorNeutralForeground1`,
+  `tokens.spacingVerticalS`)
+- hover, focus, pressed, and disabled visuals layered on a Fluent UI element
+- RTL-aware logical properties (`marginInlineStart`, `paddingBlock`)
+- style variants computed from props at render time
+
+Use a colocated CSS Module (`<ComponentName>.module.css`) for component-level
+**structural** styling that is not theme-token sensitive:
+
+- grid and flex layout for the component shell
+- responsive breakpoints for the component's own layout
+- positional concerns (sticky headers, side rails, page templates)
+- decorative wrappers around charts or media
+
+Both can coexist inside one component: Fluent UI tokens via `makeStyles` for
+visuals on top of Fluent primitives, CSS Module for the surrounding layout
+scaffolding the component owns.
+
+Do **not** reach for inline `style` props for anything beyond one-off
+runtime-computed values (e.g. a dynamic width derived from measurement).
+Inline style is not a substitute for either pathway above.
+
+## CSS Modules Are The Default
+
+- Every component that needs custom CSS owns a sibling
+  `<ComponentName>.module.css`.
+- Import it as `import styles from "./<ComponentName>.module.css";` and apply
+  classes through the `styles` object. Never use string class names that
+  bypass the module scope.
+- Class names inside `.module.css` are written in `camelCase` (or
+  `kebab-case` consistently across the project) and describe the role of the
+  element inside the component (`root`, `header`, `actions`, `emptyState`)
+  rather than restating presentation (`redBold`, `marginTop20`).
+- Keep selectors as flat as possible:
+  - one-level class selectors are preferred
+  - nested selectors are allowed only inside `:global(...)` escape hatches or
+    for short structural relationships (`.row > .actions`)
+  - avoid element-name selectors that match across the document (`div`,
+    `span`, `button`) inside a CSS Module
+- Compose shared visual fragments with `composes:` inside the same module or
+  from another CSS Module rather than copy-pasting selector bodies.
+- Do not use Tailwind-style utility classes or other untyped global class
+  names in app components. If a project intentionally adopts a utility
+  framework, document the deviation explicitly and confine it to that
+  decision.
+
+## Global CSS Is The Exception
+
+Global CSS is allowed only for a small, named set of concerns and lives in a
+clearly labeled location such as `app/styles/`:
+
+- CSS reset or normalize
+- web-font loading and `@font-face` declarations
+- baseline body and root styles (background, default text rendering)
+- one-time `FluentProvider` host element wiring
+
+Anything beyond this list should be a CSS Module owned by a specific
+component or layout, not a new global rule.
+
+Forbidden in global stylesheets:
+
+- feature-specific selectors
+- component-name selectors (e.g. `.user-menu`, `.profile-card`)
+- overrides targeting Fluent UI internal class names
+
+## Responsive Styles Are Component-Scoped
+
+- Media queries for a component's own layout live in that component's CSS
+  Module, not in a global stylesheet.
+- Use content-driven breakpoints chosen from the component's actual layout
+  pressure, not device-named breakpoints copy-pasted across the app.
+- When responsive behavior changes interaction flow or data loading (not just
+  presentation), move that decision into `app/lib/client/usecase/<feature>/`
+  and keep the CSS Module focused on visual reflow only.
+
+## Forbidden Patterns
+
+- Two exported components in one `.tsx` file.
+- Component filename and exported component name disagreeing.
+- Importing a CSS file globally (`import "./styles.css"`) inside a component
+  module. Component-owned styles must go through `.module.css`.
+- Inline `style={{ ... }}` for static styling that belongs in a CSS Module or
+  `makeStyles`.
+- A `.module.css` file that is not colocated with the component it styles.
+- Hidden helper components growing their own state, effects, or async logic
+  while still living inside another component's file.
+- Generic shared CSS files such as `common.css`, `helpers.css`, or
+  `utils.css` introduced as a styling dumping ground.
+
+## Verification
+
+Use these checks alongside [`verification-gates.md`](verification-gates.md):
+
+```bash
+# One component per file: every .tsx in app/components exports exactly one
+# top-level React component whose name matches the file.
+rg -n "^export (default |const |function )" app/components
+
+# CSS Modules colocated with components: every styled component has a sibling
+# .module.css.
+find app/components -name "*.tsx" -print
+find app/components -name "*.module.css" -print
+
+# No global CSS imports inside components.
+rg -n "import .*\.css['\"]" app/components | rg -v "\.module\.css"
+
+# No inline style props except for clearly dynamic values.
+rg -n "style=\{\{" app/components
+```
+
+Treat the results as signals, not hard failures. Investigate any match, and
+either fix it or document why this component is the deliberate exception.

--- a/.github/skills/react-router-app-architecture/references/dependency-injection-lifetime-and-side-effects.md
+++ b/.github/skills/react-router-app-architecture/references/dependency-injection-lifetime-and-side-effects.md
@@ -1,0 +1,88 @@
+# Dependency Injection, Lifetime, And Side Effects
+
+## Dependency Injection Rule
+
+Keep dependencies explicit and easy to substitute.
+
+Prefer:
+
+- constructor injection for classes
+- explicit function parameters for stateless helpers
+- factory functions for assembly at routes, server entry points, or dedicated
+  composition modules
+
+Avoid:
+
+- service locators that hide what a use case depends on
+- module-level mutable singletons that carry domain state
+- random direct imports of concrete repositories or gateways inside
+  `usecase` or `domain`
+
+Introduce a DI container only when the wiring complexity justifies it.
+
+## Runtime Safety Rule
+
+Treat thread safety in this codebase mainly as async safety and request
+safety.
+
+Use these rules:
+
+- avoid module-level mutable state that is read or written by multiple
+  requests
+- keep request context, user context, auth context, and correlation metadata
+  passed explicitly per call
+- recreate transaction-scoped dependencies such as transaction-bound
+  repositories per request or per transaction
+- guard client-side concurrent flows against stale responses, such as
+  multiple in-flight searches or rapid form retries
+
+## Side Effect And Migration Rule
+
+Make schema changes and runtime side effects explicit and reviewable.
+
+Keep these workflows owned by `server/infrastructure` and the deployment
+process:
+
+- schema migrations
+- seed data scripts
+- background job triggers
+- external notifications
+- async fan-out
+
+Do not bury migrations or side effects inside random route handlers, ad hoc
+scripts, or unannotated repository methods.
+
+## Lifetime Rule
+
+Choose lifetimes deliberately for server-side dependencies.
+
+Use this default:
+
+- prefer per-request lifetime for use cases and repositories that interact
+  with request-bound data, especially when they share a transaction or auth
+  context
+- prefer singleton lifetime for expensive stateless ORM/SDK clients such as
+  database connection pools or HTTP SDK clients
+- prefer transient lifetime for cheap stateless helpers and pure adapters
+
+Avoid hidden global state that leaks across requests, and never share a single
+mutable use-case instance across concurrent requests just to save allocation.
+
+## Migration Workflow Rule
+
+When changing architecture terms or boundaries, prefer the lowest-friction
+migration path.
+
+Use this order:
+
+1. choose the canonical new name or shape
+2. perform a direct replacement across the codebase in one focused change
+3. update tests, types, and documentation in the same change
+4. retain a compatibility alias only when a real consumer cannot migrate in
+   the same change set
+5. remove the alias as soon as the blocking consumer migrates
+
+Avoid:
+
+- introducing parallel old and new names that drift in scope
+- keeping deprecated names alive past their stated removal point

--- a/.github/skills/react-router-app-architecture/references/domain-modeling-and-type-rules.md
+++ b/.github/skills/react-router-app-architecture/references/domain-modeling-and-type-rules.md
@@ -1,0 +1,107 @@
+# Domain Modeling And Type Rules
+
+## Concept Ownership And Consolidation Rule
+
+Do not keep parallel classes, variables, or functions that perform the same
+job in the same boundary without a clear reason.
+
+Prefer this rule:
+
+- one concept
+- one name
+- one owner
+
+Consolidate only when the modules represent the same concept in the same
+boundary and differ only because of historical drift or accidental duplication.
+
+Do not consolidate merely because names or fields look similar across
+boundaries.
+
+## Domain-Centered Application Rule
+
+Build business behavior around domain language and domain models, but do not
+build the entire application as if everything were a domain object.
+
+Use the domain as the semantic center for:
+
+- invariants
+- value semantics
+- lifecycle transitions
+- business rule names
+
+Keep HTTP DTOs, route parsing, view models, browser runtime state, and
+persistence adapters outside `domain`.
+
+## Object-Oriented Modeling Rule
+
+Use object-oriented modeling selectively, not by default.
+
+Prefer `class` when at least one of these is true:
+
+- identity matters over time
+- invariants must be protected together with state
+- lifecycle transitions are part of the business language
+- behavior belongs naturally on the model instead of in a detached helper
+
+Prefer `type` plus pure functions when the module is mainly a DTO, parser,
+mapper, stateless transform, or lightweight contract.
+
+## Composition Over Inheritance Rule
+
+Prefer composition over inheritance.
+
+Use inheritance only when:
+
+- the subtype relationship is stable
+- substitutability is real
+- shared behavior cannot be expressed more clearly through composition
+
+Avoid deep class hierarchies for UI components, repositories, API clients, or
+use cases.
+
+## Anemic Model Boundary
+
+Do not force every rule into classes, but also do not let domain models become
+empty bags of fields.
+
+Healthy split:
+
+- entities and value objects protect their own invariants
+- policies decide cross-entity rules
+- domain services coordinate domain behavior that belongs to no single model
+- use cases orchestrate application flow, permissions, persistence, and side
+  effects
+
+## Interface And Type Rule
+
+Choose `interface` and `type` by role, not by habit.
+
+Prefer `interface` when:
+
+- the shape is an object-like port or contract
+- multiple implementations are expected
+- the contract is part of DI or architecture boundaries
+
+Prefer `type` when:
+
+- the shape is a DTO or response envelope
+- the shape is local to one feature or one module
+- unions, intersections, mapped types, tuples, or primitives are involved
+
+Avoid `I*`-prefixed port names and one-off interfaces for local object
+literals.
+
+## Unknown Type Rule
+
+Use `unknown` for data that has crossed a trust boundary but has not yet been
+proven safe.
+
+Best practice:
+
+1. receive untrusted data as `unknown`
+2. validate or narrow it immediately
+3. convert it into a DTO, value object, or domain model
+4. keep the validated shape flowing inward instead of the raw `unknown`
+
+Treat `unknown` as a boundary quarantine type, not as a long-lived application
+type.

--- a/.github/skills/react-router-app-architecture/references/flat-route-rest-api-guidelines.md
+++ b/.github/skills/react-router-app-architecture/references/flat-route-rest-api-guidelines.md
@@ -1,0 +1,134 @@
+# FlatRoute REST API Guidelines
+
+## What is FlatRoute
+
+FlatRoute is the file routing convention enabled by
+`@react-router/fs-routes`'s `flatRoutes()` helper.
+
+Use this convention:
+
+- one file per route module under `app/routes/`
+- dots in the file name map to URL slashes
+- `$segment` marks a dynamic URL parameter
+- the file `_index.tsx` represents the index route for its parent
+
+Examples:
+
+- `app/routes/_index.tsx` -> `GET /`
+- `app/routes/items.tsx` -> any HTTP method to `/items`
+- `app/routes/items.$itemId.tsx` -> any HTTP method to `/items/:itemId`
+
+## Default Routing Choice
+
+Use FlatRoute by default for new SPA projects.
+
+Prefer the alternative folder-based or convention-based routing only when:
+
+- the project already uses it
+- a third-party generator imposes it
+- a specific framework integration requires it
+
+## REST URL Mapping
+
+Prefer URLs that read like resources, not actions.
+
+Use this URL pattern by default:
+
+- collection: `/items`
+- single resource: `/items/$itemId`
+- sub-collection: `/items/$itemId/comments`
+- single sub-resource: `/items/$itemId/comments/$commentId`
+
+Reserve verb-shaped paths for genuine operations that do not fit CRUD, such as
+`/items/$itemId/publish` or `/imports/$importId/run`. Keep them rare.
+
+## Route Module Responsibility
+
+A route module should be responsible for:
+
+- accepting HTTP input
+- selecting the correct use case
+- mapping use-case results into a response
+- returning typed loader data when applicable
+
+A route module should not contain:
+
+- business invariants
+- direct data-client queries
+- multi-step orchestration that belongs to a use case
+- shared transport DTOs for other features
+
+## Method And Handler Mapping
+
+Use this default mapping inside a single route file:
+
+- `GET`: `loader` returns the read model
+- `POST`: `action` handles creation
+- `PUT` or `PATCH`: `action` handles update
+- `DELETE`: `action` handles deletion
+- read methods other than `GET` are usually a smell; prefer `GET` for reads
+
+For `action`, branch on `request.method` to keep mutation logic together for
+the same resource.
+
+## Single-Resource Route Rule
+
+Co-locate single-resource and sub-resource routes by URL shape, not by HTTP
+method.
+
+Prefer:
+
+- `app/routes/items.tsx` for the collection
+- `app/routes/items.$itemId.tsx` for the single item
+- `app/routes/items.$itemId.comments.tsx` for the comment sub-collection
+- `app/routes/items.$itemId.comments.$commentId.tsx` for a single comment
+
+Avoid separate files such as `items.get.tsx`, `items.post.tsx`, or
+`items.delete.tsx`. Method dispatch belongs inside the route module.
+
+## Internal API Path Rule
+
+When the same resource needs an internal JSON API for the SPA client, prefer
+prefixing it with `api`.
+
+Use this convention:
+
+- UI page: `app/routes/items.tsx` for `/items`
+- internal JSON: `app/routes/api.items.tsx` for `/api/items`
+
+Keep both routes thin and let them share the same use case from
+`app/lib/server/usecase/`.
+
+## Action And Loader Body Rule
+
+Prefer narrow handlers.
+
+A route handler should:
+
+- parse and validate input
+- call a use case
+- map the result into a `Response` or loader data
+
+It should not:
+
+- contain business decisions
+- compose multiple unrelated use cases
+- share local helpers across unrelated routes
+
+Promote shared logic into a use case rather than into a sibling route module.
+
+## Status Code Defaults
+
+Use these defaults:
+
+- `200 OK` for successful reads and updates returning data
+- `201 Created` for resource creation, with the new resource id or location
+- `204 No Content` for delete success without a body
+- `400 Bad Request` for malformed transport input
+- `401 Unauthorized` for missing or invalid authentication
+- `403 Forbidden` for authenticated but disallowed actions
+- `404 Not Found` for unknown resource ids
+- `409 Conflict` for state conflicts such as version mismatches
+
+Map domain or use-case errors to these codes at the route boundary, not inside
+the use case itself.

--- a/.github/skills/react-router-app-architecture/references/hotspot-refactor-workflow.md
+++ b/.github/skills/react-router-app-architecture/references/hotspot-refactor-workflow.md
@@ -1,0 +1,255 @@
+# Hotspot Refactor Workflow
+
+Use this workflow when a `ts` or `tsx` file has accumulated too many
+responsibilities and must be split without breaking behavior.
+
+## Goal
+
+Reduce one hotspot file into explicit modules with clearer boundaries, smaller
+review batches, and preserved behavior.
+
+Do not treat this as a rewrite. Treat it as controlled extraction.
+
+## Priority Rule
+
+When several refactor candidates exist, do not start with the largest file by
+default.
+
+Prioritize by this order:
+
+1. correctness risk
+2. change frequency
+3. architecture damage
+4. extraction leverage
+5. file size
+
+Interpret the order like this:
+
+- correctness risk: the file is likely to cause bugs, regressions, race
+  conditions, authorization mistakes, or persistence mistakes
+- change frequency: the file is touched often and slows normal feature
+  delivery
+- architecture damage: the file currently breaks boundaries such as
+  route-to-infrastructure coupling, server-to-client leakage, or
+  DTO-to-domain leakage
+- extraction leverage: refactoring this file will make several nearby files
+  easier to clean up afterward
+- file size: use size as a signal, but not as the deciding factor by itself
+
+Good first targets usually have both high risk and high churn.
+
+Examples of high-priority hotspots:
+
+- a route file that mixes HTTP handling, data-client queries, and business
+  rules
+- a component that owns async orchestration, retries, and reducer-worthy state
+- a use case module with module-level mutable state or stale async race bugs
+- a repository or gateway that leaks persistence or SDK errors across
+  boundaries
+
+Deprioritize hotspots when they are:
+
+- large but stable
+- mostly ugly rather than risky
+- isolated from active feature work
+- likely to force a broad rename or move with little behavioral payoff
+
+Within one hotspot, prioritize seams in this order:
+
+1. hidden side effects and mutable state
+2. boundary violations
+3. duplicated validation or error mapping
+4. reducer, selector, and handler extraction
+5. naming cleanup and cosmetic reshaping
+
+Stabilize behavior first. Improve elegance second.
+
+## Phase 1: Analyze
+
+Read the hotspot file and classify each responsibility before moving code.
+
+Identify:
+
+- UI rendering
+- route or HTTP wiring
+- state transitions
+- event handlers
+- async orchestration
+- DTO parsing or mapping
+- domain rules
+- infrastructure access
+- cross-cutting utilities
+
+Mark what is:
+
+- pure and easy to extract
+- boundary-sensitive and should stay near the entry point
+- currently coupled because of naming or hidden shared state
+- risky because it changes behavior, ordering, or async lifecycle
+
+Useful checks:
+
+- count imports and note which layer each import belongs to
+- find mutable module state
+- find `useEffect`, `fetch`, `new`, data-client calls, and large inline
+  condition blocks
+- find repeated parameter groups and repeated derived expressions
+
+Do not edit yet. First understand why the file grew.
+
+## Phase 2: Plan
+
+Write a refactor plan around seams, not around lines.
+
+Prefer this extraction order:
+
+1. pure constants and small utilities
+2. local types and DTO mappers
+3. selectors and derived read models
+4. reducer and state definitions
+5. event handlers and async command helpers
+6. API adapters or infrastructure adapters
+7. domain rules or policies
+8. entry-point cleanup
+
+Choose target files based on responsibility:
+
+- render-only code -> `components`
+- reducer, selectors, handlers -> `client/usecase/<feature>/`
+- API calls or browser integrations -> `client/infrastructure/*`
+- server orchestration -> `server/usecase`
+- persistence or SDK logic -> `server/infrastructure/*`
+- business invariants -> `domain/*`
+
+Define the smallest safe batch. A good batch:
+
+- removes one responsibility
+- keeps the old file compiling
+- is reviewable without reading the whole system
+
+Do not combine naming migrations, behavior changes, and large structural
+movement in the same batch unless they are inseparable.
+
+Also plan:
+
+- which validation rules stay at the boundary and which move inward
+- which error categories need explicit mapping after extraction
+- what the public entry point of the feature will be after the split
+- how to avoid introducing circular imports
+
+## Phase 3: Consider Risks
+
+Before moving code, check the failure modes.
+
+Common risks:
+
+- hidden module-level mutable state
+- stale closures after extraction
+- accidental dependency inversion
+- transport DTOs leaking into `domain`
+- request context leaking into singletons
+- circular imports caused by rushed extraction
+- tests asserting file-local implementation details
+- over-extraction into vague common modules
+
+If the file is both a hotspot and a behavior hotspot, add or update
+characterization tests first.
+
+Good characterization targets:
+
+- reducer transitions
+- selector outputs
+- request parsing
+- response mapping
+- route status code behavior
+- pending and error states
+- validation failures and their mapped transport responses
+
+## Phase 4: Execute In Small Batches
+
+Extract one seam at a time.
+
+Recommended batch sequence:
+
+1. Move pure helpers and constants
+2. Move types and DTO mapping helpers
+3. Move selectors
+4. Move reducer and state
+5. Move async handlers
+6. Move adapters
+7. Shrink the original file to composition only
+
+After each batch:
+
+- fix imports
+- rerun targeted tests
+- rerun typecheck if the boundary changed
+- confirm no new circular dependency appeared
+- confirm the extracted module did not accidentally become another feature's
+  private dependency
+
+When a batch is too big, split it further. Favor many small extractions over
+one heroic refactor.
+
+## Phase 5: Verify
+
+After the refactor, verify both behavior and architecture.
+
+Behavior checks:
+
+- existing tests still pass
+- changed flows still work manually
+- no stale async result overwrites newer state
+- no status code or response-shape regression
+
+Architecture checks:
+
+- the hotspot file now has one clear role
+- extracted modules live in the correct layer
+- no new `server -> client` or boundary-breaking imports exist
+- no generic catch-all module was introduced
+- the remaining entry file mostly wires modules together
+- validation and error mapping still live at intentional boundaries
+
+## Phase 6: Report
+
+Summarize the refactor in terms of responsibilities moved, not just files
+changed.
+
+State:
+
+- what responsibilities were extracted
+- what stayed and why
+- what risks were reduced
+- what follow-up seams still remain
+
+If the file is still too large, leave a concrete next seam instead of
+pretending the refactor is complete.
+
+## Heuristics
+
+Use these heuristics while deciding whether to extract.
+
+Extract when:
+
+- a block can be named clearly
+- a block belongs to another layer
+- a block can be tested in isolation
+- a block is reused or will clearly stabilize
+- a block hides state transitions or mapping logic
+
+Do not extract when:
+
+- the only outcome is more files with no boundary improvement
+- the new module name would be vague, such as `helpers` or `utils`
+- the code is tightly coupled and should first be simplified in place
+
+## Target End State
+
+A successful hotspot refactor usually ends like this:
+
+- entry file: composition and top-level flow only
+- use case files: state, reducer, selectors, handlers
+- infrastructure files: transport or persistence details
+- domain files: invariants and business rules
+- presentational files: rendering only

--- a/.github/skills/react-router-app-architecture/references/layout-and-dependency-rules.md
+++ b/.github/skills/react-router-app-architecture/references/layout-and-dependency-rules.md
@@ -1,0 +1,23 @@
+# Layout And Dependency Rules Overview
+
+This topic outgrew a single reference. Use the split references below instead
+of reading one oversized file.
+
+- [`layout-and-module-placement.md`](layout-and-module-placement.md): canonical
+  directory layout, feature public API boundaries, naming, and typical flow
+- [`client-layer-responsibilities.md`](client-layer-responsibilities.md): what
+  belongs in routes, components, shared UI, and client infrastructure
+- [`server-and-domain-layer-responsibilities.md`](server-and-domain-layer-responsibilities.md):
+  what belongs in domain modules and server layers
+- [`boundary-and-contract-rules.md`](boundary-and-contract-rules.md): dependency
+  direction, contract placement, validation, authorization, serialization, and
+  import smells
+- [`domain-modeling-and-type-rules.md`](domain-modeling-and-type-rules.md):
+  concept ownership, domain-centered modeling, `class` vs `type`, `interface`,
+  and `unknown`
+- [`dependency-injection-lifetime-and-side-effects.md`](dependency-injection-lifetime-and-side-effects.md):
+  DI, runtime safety, side effects, lifetime, and migration workflow
+
+Always read `layout-and-module-placement.md` first, then read the narrowest
+additional matching reference for the task instead of loading the whole
+architecture catalog.

--- a/.github/skills/react-router-app-architecture/references/layout-and-module-placement.md
+++ b/.github/skills/react-router-app-architecture/references/layout-and-module-placement.md
@@ -1,0 +1,198 @@
+# Layout And Module Placement
+
+## Canonical Layout
+
+```text
+app/
+  routes/
+  components/
+    <feature>/
+    shared/
+  lib/
+    client/
+      usecase/
+        <feature>/
+          use-<feature>.ts
+          state.ts
+          reducer.ts
+          selectors.ts
+          handlers.ts
+      infrastructure/
+        api/
+        browser/
+    server/
+      usecase/
+      infrastructure/
+        config/
+        repositories/
+        gateways/
+    domain/
+      entities/
+      value-objects/
+      policies/
+      services/
+      repositories/
+```
+
+Use these directories by responsibility, not by team preference or historical
+drift.
+
+## Mandatory Placement Preflight
+
+Before implementing, list every file you expect to create, move, or extract and
+assign its exact target path.
+
+Use this rule:
+
+1. every file must have one canonical owner before code is written
+2. if a file has no clear owner, revise the placement plan first
+3. do not create a new directory just because the first idea does not fit the
+   layout
+
+Treat convenience directories such as `app/features/`, `app/modules/`,
+`app/hooks/`, `app/services/`, `app/utils/`, `app/types/`, or `app/store/` as
+layout drift unless an explicit migration plan says otherwise.
+
+## Feature Presentational Component Placement
+
+Keep feature-specific presentational components in `app/components/<feature>/`.
+
+Preferred shape:
+
+```text
+app/components/profile-editor/
+  ProfileEditorForm.tsx
+  ProfileEditorForm.module.css
+  ProfileSummaryCard.tsx
+  ProfileSummaryCard.module.css
+```
+
+One component per `.tsx` file, and the file name matches the exported
+component name. Each component that needs custom CSS owns a sibling
+`<ComponentName>.module.css` colocated with the component. See
+[`component-file-and-css-module-rules.md`](component-file-and-css-module-rules.md)
+for the full set of component, Fluent UI, and CSS Module rules.
+
+Use `app/components/shared/` only when the component is feature-agnostic,
+reusable across features, and expressed in generic UI language instead of
+product vocabulary.
+
+## State Module Placement
+
+For non-trivial client interaction flows, create a feature directory under
+`app/lib/client/usecase/` and colocate the state modules there.
+
+Preferred shape:
+
+```text
+app/lib/client/usecase/thread-composer/
+  use-thread-composer.ts
+  state.ts
+  reducer.ts
+  selectors.ts
+  handlers.ts
+  types.ts
+```
+
+Use these files by responsibility:
+
+- `state.ts`: state shape and initial state
+- `reducer.ts`: reducer function and action definitions
+- `selectors.ts`: derived read models and computed flags
+- `handlers.ts`: event-to-dispatch mapping or async command helpers
+- `use-<feature>.ts`: public Hook or controller entry point
+
+Do not create horizontal buckets such as `app/state/`, `app/reducers/`,
+`app/stores/`, `app/handlers/`, or `app/lib/client/usecase/state/`.
+
+## No Generic Common Bucket
+
+Do not add a catch-all common directory.
+
+Prefer this order instead:
+
+1. Keep code with the route, use case, or domain module that owns it.
+2. Duplicate a tiny utility once if the reuse pattern is still uncertain.
+3. Extract only after the abstraction is clearly stable.
+
+## Feature Public API Rule
+
+Treat each feature directory as having a public entry point and private
+internals.
+
+Prefer:
+
+- `client/usecase/<feature>/use-<feature>.ts` as the public client entry
+- `server/usecase/<feature>/index.ts` or one primary use-case module as the
+  public server entry
+
+Avoid importing another feature's private files such as `reducer.ts`,
+`selectors.ts`, `handlers.ts`, or `state.ts`.
+
+## Circular Dependency Rule
+
+Treat import cycles as architecture violations, especially inside feature
+internals.
+
+Common bad cycles:
+
+- `selectors -> handlers -> reducer -> selectors`
+- `route -> usecase -> route`
+- `infrastructure -> usecase -> infrastructure`
+
+When a cycle appears:
+
+1. move shared pure logic to a lower-level leaf module
+2. invert the dependency through an interface or parameter
+3. merge modules back together if the split was artificial
+
+## TS And TSX Naming Rule
+
+Keep file names explicit enough that responsibility is visible before opening
+the file.
+
+Use these defaults:
+
+- route modules: follow FlatRoute naming, such as `api.orders.ts`,
+  `api.orders.$orderId.ts`, or `settings.profile.tsx`
+- React component files: `PascalCase.tsx`
+- non-component modules: responsibility-based `kebab-case.ts`
+
+For component files:
+
+- one React component per `.tsx` file
+- the primary exported component name matches the file name exactly
+  (`UserMenu.tsx` exports `UserMenu`)
+- use `.tsx` only when the file renders JSX
+- the component's CSS lives in a sibling `<ComponentName>.module.css` when it
+  needs custom CSS
+- keep feature-specific views under `app/components/<feature>/` until they
+  prove to be generic enough for `app/components/shared/`
+
+See [`component-file-and-css-module-rules.md`](component-file-and-css-module-rules.md)
+for the full component, Fluent UI, and CSS Module conventions.
+
+Inside a feature directory, short file names such as `state.ts`, `reducer.ts`,
+`selectors.ts`, `handlers.ts`, and `types.ts` are acceptable because the
+directory already provides the feature context.
+
+Avoid vague file names such as `helpers.ts`, `utils.ts`, `common.ts`,
+`misc.ts`, `temp.ts`, or `new.ts`.
+
+Use `index.ts` only when it is a deliberate public entry point.
+
+## Typical Flow
+
+For a form submission:
+
+1. A route module renders a container page.
+2. A client use case Hook owns the draft state and handlers.
+3. A presentational component renders fields and calls passed handlers.
+4. A client infrastructure API client sends the request or a route action
+   handles it.
+5. A server use case applies the business rule.
+6. A server infrastructure repository persists through the project's chosen
+   ORM, query builder, or storage client.
+
+Each step should only depend on the next layer inward or on an adapter
+explicitly created for that boundary.

--- a/.github/skills/react-router-app-architecture/references/playwright-ui-verification.md
+++ b/.github/skills/react-router-app-architecture/references/playwright-ui-verification.md
@@ -1,0 +1,83 @@
+# Playwright UI Verification
+
+## Goal
+
+Check the real rendered UI before pushing when a change affects presentation,
+interaction, or responsive behavior.
+
+## When To Use It
+
+Run this workflow when the change touches any of the following:
+
+- route UI or page layout
+- component markup or styling
+- interactive flows such as forms, dialogs, popovers, or steppers
+- Tooltip or InfoLabel behavior
+- charts, tables, empty states, error states, or loading states
+- responsive layout, spacing, or typography
+
+## Verification Workflow
+
+1. Start the local app and confirm the route you need to inspect.
+2. Open the route in Playwright instead of relying on static code reading.
+3. Check the default happy path first, then the states most likely to
+   regress:
+   - loading
+   - empty
+   - error
+   - success
+   - disabled or permission-limited states when relevant
+4. Resize to the viewports that matter for the change, usually at least one
+   desktop width and one narrow mobile width when layout is affected. If
+   orientation matters, check both portrait and landscape.
+5. Exercise the interaction with realistic user input:
+   - click
+   - keyboard navigation
+   - hover and focus
+   - form entry and submission
+6. Confirm that labels, focus treatment, validation, and critical status
+   remain visible without depending only on hover Tooltip behavior.
+7. Capture screenshots or snapshots when the visual result matters or when
+   you need evidence for a follow-up fix.
+8. Re-run the touched flow after the fix, not just the unit or type-level
+   checks.
+
+## Playwright Usage Rules
+
+- Prefer accessible locators such as role, label, placeholder, and text-based
+  intent over brittle CSS selectors.
+- Prefer web-first assertions and visible UI state over fixed sleeps or
+  arbitrary timeouts.
+- Navigate through the real route and interaction flow rather than jumping
+  straight to internal DOM details.
+- When the UI includes charts or dense data displays, verify readability,
+  legends, labels, and non-hover access to the key insight.
+- When the UI includes Tooltip, Popover, or InfoLabel patterns, verify both
+  hover and keyboard focus behavior.
+- When the UI is mobile-sensitive, verify there is no accidental horizontal
+  scrolling, clipped call to action, or hidden validation at narrow widths.
+
+## What To Inspect
+
+- route title and primary heading
+- primary call to action and destructive action states
+- keyboard tab order and focus visibility
+- validation messages and disabled states
+- empty, error, and loading states
+- responsive stacking, overflow, and truncation
+- touch-sized layouts, bottom bars, and dialog or drawer behavior on narrow
+  screens
+- chart labels, legend clarity, summary text, and table fallback when
+  applicable
+
+## Tooling Notes
+
+When Playwright browser tooling is available in the agent runtime:
+
+- use browser navigation to open the local route
+- use resize before judging responsive layout
+- use accessibility snapshots to confirm structure and visible names
+- use screenshots when the visual presentation itself is under review
+
+Do not treat DOM inspection alone as sufficient UI verification for a
+user-facing change.

--- a/.github/skills/react-router-app-architecture/references/project-bootstrap.md
+++ b/.github/skills/react-router-app-architecture/references/project-bootstrap.md
@@ -1,0 +1,230 @@
+# Project Bootstrap
+
+Use this guide when starting a new project from scratch.
+
+## Baseline Assumptions
+
+Assume this stack unless the user explicitly says otherwise:
+
+- TypeScript
+- React Router framework mode
+- SPA mode with `ssr: false`
+- Fluent UI React v9 for the UI layer unless the repository already has an
+  established design-system standard
+- Node.js 20.19+ or 22.x
+
+This skill does not pick the data stack. Whichever ORM, query builder, SQL
+client, or remote backend you choose, confine its imports to
+`app/lib/server/infrastructure/` and keep the rest of the layer rules
+unchanged.
+
+If a companion hosting skill explicitly requires a server runtime or a
+secretless platform-config bootstrap, let that companion override the `ssr:
+false` and local config-loading defaults in this file while keeping the rest
+of the layer rules.
+
+## Preferred Bootstrap Path
+
+For this skill's architecture, prefer React Router's official Vite-powered
+bootstrap over retrofitting a plain Vite template.
+
+Reason:
+
+- it matches `app/` and route-module conventions
+- it keeps React Router configuration aligned with current framework mode
+- it reduces manual setup drift before architecture work even starts
+
+In practice, it is usually cleaner to install the baseline routing and UI
+dependencies the project already knows it will need before feature
+implementation starts, rather than adding them piecemeal in the middle of the
+first feature. Install the chosen data stack at the same time using whatever
+its own install instructions require.
+
+## Baseline Dependencies To Have Ready
+
+For the default stack in this skill, the baseline dependency set to line up
+early is:
+
+- Route-file support: `@react-router/fs-routes`
+- Default UI layer when no existing design system overrides it:
+  `@fluentui/react-components`, `@fluentui/react-icons`
+
+In practice, that usually means these commands soon after scaffold:
+
+```bash
+npm install @react-router/fs-routes @fluentui/react-components @fluentui/react-icons
+```
+
+If the repository already has an established design system, do not add Fluent
+UI casually just because it appears in the default list.
+
+Install the data stack of your choice (ORM, query builder, SDK, or HTTP
+backend client) separately, following that stack's own documentation. Keep
+every import of that stack inside `app/lib/server/infrastructure/`.
+
+## Recommended Flow
+
+### 1. Scaffold the app
+
+```bash
+npx create-react-router@latest my-app
+cd my-app
+```
+
+Use the TypeScript option when prompted.
+
+Keep the standard mobile viewport tag in the document head:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+```
+
+Add `viewport-fit=cover` only when the layout intentionally handles safe-area
+insets.
+
+### 2. Switch the app to SPA mode by default
+
+Create or update `react-router.config.ts`:
+
+```ts
+import type { Config } from "@react-router/dev/config";
+
+export default {
+  ssr: false,
+} satisfies Config;
+```
+
+This keeps React Router in SPA mode while still using framework conventions.
+If a companion hosting skill explicitly requires server runtime features such
+as OAuth callbacks, server-owned secrets, or platform-managed config
+bootstrap, do not force `ssr: false`.
+
+### 3. Enable FlatRoute file routing
+
+Install the file-route helper:
+
+```bash
+npm install @react-router/fs-routes
+```
+
+Create or update `app/routes.ts`:
+
+```ts
+import { flatRoutes } from "@react-router/fs-routes";
+import type { RouteConfig } from "@react-router/dev/routes";
+
+export default flatRoutes() satisfies RouteConfig;
+```
+
+This is the cleanest match for the route-file conventions used by this skill.
+
+### 4. Install Fluent UI React v9
+
+For the default UI baseline:
+
+```bash
+npm install @fluentui/react-components @fluentui/react-icons
+```
+
+Wrap the app root with `FluentProvider` and the appropriate theme, typically
+`webLightTheme`, before building feature screens:
+
+```tsx
+import {
+  FluentProvider,
+  webLightTheme,
+} from "@fluentui/react-components";
+
+export function AppShell({ children }: { children: React.ReactNode }) {
+  return <FluentProvider theme={webLightTheme}>{children}</FluentProvider>;
+}
+```
+
+If the repository already has a clearly established design system, follow that
+system instead of mixing component libraries casually.
+
+### 5. Pick and install the data stack
+
+This skill is intentionally silent on which ORM, query builder, or database
+engine to use. Decide once at bootstrap time, document the choice in the
+project, and install it following its own documentation.
+
+When integrating it, keep these rules:
+
+- every import of the chosen ORM, query builder, database driver, or remote
+  backend SDK must live under `app/lib/server/infrastructure/`
+- repository interfaces stay in `app/lib/domain/repositories/`
+- repository implementations stay in
+  `app/lib/server/infrastructure/repositories/`
+- a long-lived client (connection pool, ORM client, SDK client) is
+  constructed once in a server-only bootstrap module under
+  `app/lib/server/infrastructure/` and shared by injection, not by import
+  side effects
+- environment-driven configuration (database URL, API base URL, secrets) is
+  read inside `app/lib/server/infrastructure/config/`, not inside route or
+  use-case modules
+
+If the chosen stack ships its own scaffold, migration, or codegen tooling,
+keep those commands documented in the project (`README.md`, `package.json`
+scripts), but do not let their generated client leak out of
+`app/lib/server/infrastructure/`.
+
+### 6. Create the first architecture-aligned directories
+
+Do not create every possible directory up front.
+
+Create only the ones needed for the first feature or integration, usually:
+
+```text
+app/routes/
+app/components/
+app/lib/client/usecase/
+app/lib/server/usecase/
+app/lib/server/infrastructure/
+app/lib/domain/
+```
+
+Add deeper directories such as `entities/`, `value-objects/`, `repositories/`,
+or `gateways/` when the first real owner appears.
+
+## Plain Vite Fallback
+
+Use plain Vite bootstrap only when one of these is true:
+
+- the user explicitly requires `create-vite`
+- the project intentionally uses React Router data mode or declarative mode
+  instead of framework mode
+- an existing starter must be retrofitted
+
+Fallback start:
+
+```bash
+npm create vite@latest my-app -- --template react-ts
+cd my-app
+```
+
+Then:
+
+1. install the React Router packages required by the chosen mode
+2. if you need this skill's framework conventions such as `app/routes/`,
+   route modules, and FlatRoute naming, prefer re-bootstrapping with
+   `create-react-router` instead of manually recreating the framework stack
+3. install and wire the chosen data stack exactly as above
+
+Do not treat plain `create-vite` as the default when the target architecture
+is React Router framework mode.
+
+## Bootstrap Verification
+
+Before starting feature work, confirm all of the following:
+
+- `npm run dev` starts successfully
+- SPA mode is enabled
+- the standard mobile viewport meta tag is present
+- FlatRoute routing is wired through `app/routes.ts`
+- Fluent UI React v9 is installed and the app root is wrapped with
+  `FluentProvider`, unless an existing design system overrides it
+- the chosen data stack is installed
+- no import of the chosen ORM, query builder, or SDK exists outside
+  `app/lib/server/infrastructure/`
+- route modules and domain folders are present, even if still minimal

--- a/.github/skills/react-router-app-architecture/references/responsive-and-mobile-ui-guidance.md
+++ b/.github/skills/react-router-app-architecture/references/responsive-and-mobile-ui-guidance.md
@@ -1,0 +1,72 @@
+# Responsive And Mobile UI Guidance
+
+## Goal
+
+Keep the UI usable, readable, and touch-friendly from narrow mobile screens up
+through desktop without forking the product into separate architectures.
+
+## Core Approach
+
+- Design responsive layouts that stay capable on both mobile and desktop.
+  Start from the most constrained layout when it helps, but do not treat a
+  rigid mobile-first process as mandatory.
+- Use fluid layout primitives such as CSS Grid, Flexbox, intrinsic sizing, and
+  percentage or `clamp()`-based sizing before adding hard breakpoints.
+- Choose breakpoints from content pressure, not from device marketing names.
+- Keep media, cards, panels, and data containers able to shrink or wrap
+  instead of assuming desktop width.
+
+## Document And Viewport Basics
+
+- Keep the standard mobile viewport meta tag in the document head:
+  `width=device-width, initial-scale=1`.
+- Add `viewport-fit=cover` only when the layout intentionally handles
+  safe-area insets.
+- Treat ordinary app content as needing reflow at narrow widths rather than
+  requiring two-dimensional scrolling.
+- Do not lock orientation unless one orientation is genuinely essential to the
+  task.
+
+## Interaction On Touch Devices
+
+- Do not make hover the only way to discover required actions or meaning.
+- Keep a touch path and keyboard path for the same important task.
+- Meet at least WCAG 2.2 minimum target size expectations or provide
+  equivalent spacing between targets.
+- Prefer larger touch targets when practical, especially for primary actions,
+  icon-only buttons, and dismiss controls.
+- Be careful with sticky headers, sticky footers, and bottom action bars so
+  they do not hide inputs or validation on small screens.
+
+## Data-Dense UI On Small Screens
+
+- If a table, chart, or filter bar becomes unreadable on mobile, adapt the
+  presentation instead of shrinking everything uniformly.
+- Prefer stacked summaries, progressive disclosure, card views, or drill-in
+  patterns before forcing dense desktop layouts onto mobile.
+- Use horizontal scrolling for dense data only when the structure truly
+  requires it, and keep labels or context understandable when scrolling.
+- Keep chart labels, legends, and summaries readable on small screens, and
+  provide a non-hover path to key values.
+
+## Architecture Placement
+
+- Keep responsive layout behavior in component-scoped styles — the
+  component's own CSS Module or `makeStyles` block — and in presentational
+  components by default. Do not introduce global media queries for
+  feature-specific layout.
+- Move viewport-aware state into `app/lib/client/usecase/<feature>/` only when
+  it affects interaction flow, data loading, or feature behavior rather than
+  pure presentation.
+- Keep device detection and browser capability checks in client infrastructure
+  when they are truly required.
+
+## Verification
+
+- Check at least one desktop viewport and one narrow mobile viewport for
+  UI-affecting changes.
+- If orientation matters, verify both portrait and landscape.
+- Confirm there is no accidental horizontal scrolling, clipped primary action,
+  unreadable text, or hidden validation on the touched flow.
+- Re-check Tooltip, Popover, chart, table, and dialog behavior on touch-sized
+  layouts, not just desktop.

--- a/.github/skills/react-router-app-architecture/references/server-and-domain-layer-responsibilities.md
+++ b/.github/skills/react-router-app-architecture/references/server-and-domain-layer-responsibilities.md
@@ -1,0 +1,85 @@
+# Server And Domain Layer Responsibilities
+
+## `app/lib/domain/entities/`
+
+- Hold business concepts that enforce invariants or domain behavior.
+- Use `class` when identity or invariants matter.
+- Prefer named methods that express business operations over generic setters.
+- Keep entities free from React, ORM clients, browser APIs, and HTTP concerns.
+
+Do not place `CreateXRequest`, `UpdateXPayload`, or `ListXResponse` types here
+unless they are genuinely domain concepts, which is rare.
+
+## `app/lib/domain/value-objects/`
+
+- Hold small immutable domain concepts with validation and equality semantics.
+- Prefer validated factory functions or constructors over raw object literals.
+- Keep them free from transport, framework, and persistence details.
+
+Do not use value objects as a disguised home for endpoint DTOs.
+
+## `app/lib/domain/policies/`
+
+- Hold business rules that span multiple entities or require explicit decision
+  logic.
+- Prefer this directory when the code reads like a rule or policy statement.
+
+## `app/lib/domain/services/`
+
+- Hold domain-level orchestration that is still infrastructure-free and not
+  naturally owned by a single entity or value object.
+- Use this directory sparingly.
+- Prefer `policies/` when the code is fundamentally a rule, and prefer
+  `services/` only when it is true domain orchestration.
+
+## `app/lib/domain/repositories/`
+
+- Define repository ports as interfaces or types.
+- Describe what the domain or use case needs from persistence.
+- Keep these contracts independent from any specific ORM, query builder, or
+  storage schema.
+- Treat these as domain-facing persistence ports first.
+
+Do not turn repository ports into generic request or response contract
+storage.
+
+## `app/lib/server/usecase/`
+
+- Implement server-side application services.
+- Orchestrate repositories and domain rules.
+- Map between route inputs and domain operations.
+- Accept repositories and gateways through constructors or explicit function
+  parameters.
+- Keep HTTP response formatting and status selection out of this layer.
+- Keep authorization checks and side-effect decisions visible in this layer.
+
+Do not leak ORM types into domain or client layers, or instantiate concrete
+infrastructure-backed repositories inline with `new`.
+
+## `app/lib/server/infrastructure/`
+
+- Hold ORM clients, query builders, SDK clients, repository implementations,
+  external API gateways, filesystem access, and environment-aware wiring.
+- Map storage or service details into repository ports.
+- Hold explicit job or side-effect adapters when a use case must trigger
+  background work.
+
+This is the only layer that should know about the project's chosen ORM, SQL
+client, or backend SDKs.
+
+## `app/lib/server/infrastructure/repositories/`
+
+- Hold repository implementations backed by the project's chosen data stack
+  (ORM, query builder, raw SQL client, filesystem persistence, or remote
+  backend).
+- Accept long-lived clients such as a connection pool, ORM client, or SDK
+  client through constructors so lifetime stays explicit.
+- Keep repositories stateless with respect to request identity, auth state,
+  and current transaction.
+
+## `app/lib/server/infrastructure/gateways/`
+
+- Hold integrations with external SDKs and remote services.
+- Accept SDK clients or configuration through constructors or explicit factory
+  helpers.
+- Keep outbound adapter logic here rather than inside use cases.

--- a/.github/skills/react-router-app-architecture/references/stateful-flow-compromises.md
+++ b/.github/skills/react-router-app-architecture/references/stateful-flow-compromises.md
@@ -1,0 +1,185 @@
+# Stateful Flow Compromises
+
+Use these rules for flows such as chat, streaming generation, multi-step
+wizards, live playback, or long-lived session handling.
+
+## Principle
+
+Do not pretend every highly stateful flow can stay as a simple stateless Hook
+plus presentational view split.
+
+When identity, long-lived runtime handles, streaming state, or cancellation
+semantics matter, allow a controlled compromise:
+
+- a feature-local controller
+- a feature-local store
+- a reducer-backed state machine
+
+Keep the compromise contained to the owning feature directory.
+
+## Where To Put It
+
+Use a feature directory under `app/lib/client/usecase/`.
+
+Preferred shape:
+
+```text
+app/lib/client/usecase/chat-session/
+  use-chat-session.ts
+  controller.ts
+  store.ts
+  state.ts
+  reducer.ts
+  selectors.ts
+  handlers.ts
+```
+
+Do not promote these modules to top-level `app/stores` or global client state
+by default.
+
+## When A Store Is Justified
+
+Allow `store.ts` when at least one of these is true:
+
+- multiple sibling views must observe the same live session
+- the feature owns long-lived identity beyond a single form submit
+- streaming or incremental updates arrive over time
+- cancellation, replay, resume, or reconnect logic exists
+- runtime handles such as `AbortController`, stream readers, or subscriptions
+  must be coordinated
+
+If none of these are true, prefer a Hook plus reducer without a dedicated
+store.
+
+## State Split Rule
+
+Separate the state into three categories.
+
+### Durable state
+
+State that should survive rerenders and often persistence boundaries.
+
+Examples:
+
+- message list
+- session metadata
+- wizard step data
+- playback bookmark
+
+### Ephemeral runtime state
+
+State that exists only while a live operation is running.
+
+Examples:
+
+- active request id
+- abort controller
+- current stream chunk buffer
+- retry backoff state
+- current pending phase
+
+### Infrastructure handles
+
+Objects that talk to the outside world.
+
+Examples:
+
+- SSE reader
+- WebSocket handle
+- audio context
+- timer registration
+- session pool handle
+
+Do not mix these categories into one anonymous state blob.
+
+## Controlled Architecture Compromise
+
+For a stateful feature, this is an acceptable compromise:
+
+- components remain mostly render-only
+- route modules remain shell and HTTP wiring
+- a feature-local controller or store owns lifecycle-heavy orchestration
+- infrastructure adapters remain separate from the controller
+
+This is better than forcing streaming logic into:
+
+- route modules
+- presentational components
+- generic global stores
+- ad-hoc module-level mutable variables
+
+## Event And Effect Rule
+
+- Keep user intent as explicit actions or handler calls.
+- Keep stream events as separate actions from user events.
+- Use Effects only to attach or detach external systems.
+- Keep reducer transitions pure even when the controller is stateful.
+
+Prefer explicit phases such as:
+
+```text
+idle -> submitting -> streaming -> succeeded
+idle -> submitting -> failed
+idle -> submitting -> cancelled
+```
+
+## Async Safety Rule
+
+Stateful flows must guard against stale completion.
+
+Use one or more of these:
+
+- `AbortController`
+- request ids
+- session ids
+- stream token comparison
+- current-phase guards
+
+Never let an old response or stream continue mutating state after a newer
+intent has replaced it.
+
+## External Store Rule
+
+Use `useSyncExternalStore` only when multiple components must subscribe to the
+same live feature state and a Hook-local reducer is no longer enough.
+
+Do not introduce an external store merely to avoid prop drilling if the state
+still belongs to a single screen.
+
+## React Router Compromise Rule
+
+Use React Router state first for ordinary request lifecycle:
+
+- loaders for reads
+- actions for route-owned writes
+- fetchers for non-navigation writes
+
+But for chat-like streaming or session-oriented flows, allow a feature-local
+runtime store for the parts React Router does not model well:
+
+- token streaming
+- incremental partial updates
+- reconnect
+- abort and resume
+- live session coordination
+
+## General Examples
+
+- `chat-session/store.ts`: keep streaming messages, request ids, and
+  cancellation state
+- `wizard-session/reducer.ts`: keep multi-step transition logic explicit
+- `media-playback/controller.ts`: coordinate playback state, timers, and
+  external player events
+- `generation-session/handlers.ts`: submit prompt, receive stream chunks,
+  handle cancel and retry
+
+## Smells
+
+Refactor when you see:
+
+- chat state spread across several unrelated components
+- stream readers or abort controllers inside presentational components
+- route files managing incremental streaming state directly
+- generic global store introduced for only one screen
+- reducer state mixed with live infrastructure handles in untyped bags
+- runtime handles persisted as if they were durable domain data

--- a/.github/skills/react-router-app-architecture/references/verification-gates.md
+++ b/.github/skills/react-router-app-architecture/references/verification-gates.md
@@ -1,0 +1,173 @@
+# Verification Gates
+
+## Use This Before Push
+
+Run verification in this order:
+
+1. Targeted tests for the changed behavior
+2. Typecheck
+3. Lint or project quality gate
+4. Architecture drift checks
+5. Playwright check of the touched route when UI is affected, including mobile
+   viewport verification when layout or interaction is responsive
+6. Manual spot check of the touched flow
+7. Commit history sanity check when preparing shared commits
+
+Do not push code that passes tests but breaks layer direction.
+Do not push UI-affecting changes that were never checked in a real rendered
+browser flow.
+
+## Architecture Drift Checklist
+
+Confirm all of the following:
+
+- no ORM, query builder, or data-client imports outside
+  `app/lib/server/infrastructure/`
+- no server imports inside `app/components/` or `app/lib/client/*`
+- no React or browser imports inside `app/lib/domain/*`
+- no generic catch-all common directory reintroduced
+- no convenience top-level buckets such as `app/features/`, `app/modules/`,
+  `app/hooks/`, `app/services/`, `app/utils/`, `app/types/`, or `app/store/`
+  introduced without an explicit migration plan
+- no horizontal `state`, `reducers`, `stores`, or `handlers` directories
+  introduced under `app/`
+- no feature-specific presentational component placed outside
+  `app/components/<feature>/` without a deliberate reason
+- no feature-specific logic imported into `app/components/shared/`
+- no component moved into `shared` only for convenience while still carrying
+  feature vocabulary
+- no client adapter pretending to return server-side live instances across the
+  network
+- no transport `Request` or `Response` DTOs promoted into `domain` without
+  domain meaning
+- no `usecase` or `domain` module instantiating repositories or gateways
+  directly
+- no module-level mutable server state carrying request or user context
+- no circular imports introduced across feature internals or layers
+- no authorization rule enforced only in the UI
+- no boundary object such as `Date`, ORM record, or raw persistence shape
+  leaking where a mapped shape should exist
+- no business logic buried in route modules
+- no non-trivial async orchestration left inside presentational components
+- no new vague file names such as `helpers.ts`, `utils.ts`, or `common.ts`
+- no DTO or response-envelope classes introduced where `type` plus functions
+  would be clearer
+- no entity reduced to public mutable fields plus generic setters
+- no `interface` used for one-off DTOs or `I*`-prefixed port names without a
+  strong reason
+- no parallel same-role modules left in one boundary without a clear
+  ownership distinction
+- no forced merge that collapses DTOs, view models, persistence records, and
+  domain models into one shape
+- no catch-all `constants` dump created without a clear ownership boundary
+- no business rule encoded only as scattered magic numbers or strings
+- no raw `unknown` value flowing past its trust boundary without narrowing or
+  parsing
+- no `.tsx` file under `app/components/` exporting more than one top-level
+  React component, and no file whose primary exported component name disagrees
+  with the file name
+- no component-owned CSS imported as a non-module stylesheet inside a
+  component module; per-component styling lives in a sibling
+  `<ComponentName>.module.css` (or `makeStyles`)
+- no feature-specific selectors or component-name selectors added to global
+  stylesheets under `app/styles/`
+- no inline `style={{ ... }}` used for static styling that belongs in a CSS
+  Module or `makeStyles`
+- no second general-purpose component library introduced alongside Fluent UI
+  without a documented deviation
+
+## Useful Search Patterns
+
+Use `rg` for quick audits. Adjust the data-client name (`prisma`, `drizzle`,
+`kysely`, `pg`, etc.) to whatever the project actually picked:
+
+```bash
+rg -n "lib/server" app/routes app/components app/lib/client
+rg -n "from ['\"][^'\"]*react" app/lib/domain
+find app/lib -maxdepth 2 -type d | sort
+find app -type d \( -name features -o -name modules -o -name hooks -o -name services -o -name utils -o -name types -o -name store \) | sort
+find app -type d \( -name state -o -name states -o -name reducer -o -name reducers -o -name store -o -name stores -o -name handler -o -name handlers \) | sort
+rg -n "lib/client/usecase|lib/server|routes/" app/components/shared
+rg -n "Thread|Chat|Billing|Project|Profile|Order|Invoice|Session" app/components/shared
+rg -n "new [A-Z][A-Za-z0-9_]+\(|instanceof " app/lib/client
+rg -n "Request|Response|Payload|Dto|DTO" app/lib/domain
+rg -n "new .*Repository|new .*Gateway" app/lib/domain app/lib/server/usecase
+rg -n "let current|let active|let request|let user|let tenant|globalThis\.|module\.exports\." app/lib/server
+madge --circular app 2>/dev/null || true
+rg -n "index\.ts$" app
+rg --files app | rg "/(helpers|utils|common|misc|temp|new)\.(ts|tsx)$"
+rg -n "useEffect\(" app/components
+
+# One component per file: scan exports under app/components and confirm each
+# file exposes exactly one top-level React component whose name matches the
+# file. Investigate any file with multiple `export` lines at the top level.
+rg -n "^export (default |const |function )" app/components
+
+# CSS Modules colocated with components: every styled component should have a
+# sibling .module.css. Investigate any orphan stylesheet or component that
+# imports styles through a different path.
+find app/components -name "*.tsx" -print
+find app/components -name "*.module.css" -print
+
+# No global CSS imports inside components.
+rg -n "import .*\.css['\"]" app/components | rg -v "\.module\.css"
+
+# Inline style usage. Inspect each match and confirm it is a genuinely dynamic
+# runtime value, not static styling that belongs in a CSS Module.
+rg -n "style=\{\{" app/components
+```
+
+When the project's data stack is an ORM or SDK with a clear import root, add
+one focused audit for it, for example:
+
+```bash
+rg -n "@prisma/client" app   # adapt the package name to the chosen stack
+```
+
+Interpret results, do not blindly fail on matches. The point is to surface
+suspicious files quickly.
+
+## Push Gate Heuristic
+
+Before `git push`, be able to state all of the following:
+
+- the use case layer owns the interaction logic
+- the view layer is mostly props plus rendering
+- feature-local presentational components live under `app/components/<feature>/`
+- `components/shared` stays presentational and feature-agnostic
+- components started life under `app/components/<feature>/` unless they proved
+  to be generic
+- reducer and state modules live with their owning feature use case
+- client data access returns DTOs unless a real local-first repository
+  abstraction is justified
+- transport contracts still live near their boundary unless they have become
+  true domain concepts
+- dependencies are wired at the edge rather than instantiated inside use cases
+- mutable request context does not leak through singleton or module-level
+  state
+- validation rules live at the correct layer rather than collapsing into one
+  layer
+- errors are mapped intentionally rather than leaking raw infrastructure
+  failures
+- authorization has a server-side home and is not only a UI concern
+- serialization boundaries remain explicit
+- server persistence goes through server infrastructure
+- file names reveal module responsibility without fallback names like
+  `helpers` or `utils`
+- classes are used for identity and invariants, not as generic containers or
+  static utility bags
+- `interface` is used for ports and stable object contracts, while `type` owns
+  DTOs and unions
+- the app is domain-centered for business behavior without pushing UI, HTTP,
+  or persistence details into `domain`
+- constants live with their owner instead of drifting into a global junk
+  drawer
+- `unknown` is used as a boundary quarantine type rather than a long-lived
+  internal type
+- reusable helpers still live in a specific owning layer unless the
+  abstraction is clearly stable
+- the changed area has tests or a clear reason why tests were not added
+- UI-affecting changes were checked in Playwright at the relevant route,
+  viewport sizes, and orientation when needed
+
+If any statement is false, fix the architecture before pushing.

--- a/.github/skills/react-router-app-architecture/references/view-state-and-handler-patterns.md
+++ b/.github/skills/react-router-app-architecture/references/view-state-and-handler-patterns.md
@@ -1,0 +1,134 @@
+# View State And Handler Patterns
+
+## When To Add A View State Module
+
+Add a use-case module when at least one is true:
+
+- the view has more than one piece of related state
+- multiple handlers mutate that state
+- async fetching, optimistic updates, or retries are involved
+- derived values are non-trivial
+- the same screen needs to be reused or tested with different data
+
+For a single boolean toggle, keep state in the component.
+
+## Suggested Structure
+
+For a feature `thread-composer`:
+
+```text
+app/lib/client/usecase/thread-composer/
+  use-thread-composer.ts
+  state.ts
+  reducer.ts
+  selectors.ts
+  handlers.ts
+  types.ts
+```
+
+Use this responsibility split:
+
+- `types.ts`: state-only types used by reducer, selectors, and handlers
+- `state.ts`: initial state factory and state shape definition
+- `reducer.ts`: reducer plus action types
+- `selectors.ts`: derived values such as visible items, computed flags, view
+  models
+- `handlers.ts`: event-to-dispatch mapping, async command helpers, error
+  mapping
+- `use-thread-composer.ts`: the public Hook or controller entry point
+
+For very small features, two files such as `use-feature.ts` and `state.ts`
+are enough.
+
+## Component Contract
+
+Components should:
+
+- accept props from the use case
+- call passed handlers
+- render JSX
+- hold ephemeral UI state only when it is genuinely view-local
+
+Components should not:
+
+- import server modules or ORM/data clients
+- call API clients directly
+- own reducer logic
+- own async orchestration
+- own derived business view models
+
+## Component File And Styling Rules
+
+Apply these rules to every component file, in addition to the contract above:
+
+- One React component per `.tsx` file. The file name (`PascalCase.tsx`) and
+  the primary exported component name match exactly.
+- Co-define the component's `Props` type in the same file as
+  `type <ComponentName>Props = { ... }`.
+- Default to Fluent UI React v9 primitives; use `makeStyles` with Fluent UI
+  tokens for theme-aware visuals layered on those primitives.
+- Default to a sibling `<ComponentName>.module.css` for component-owned
+  structural styling, imported as
+  `import styles from "./<ComponentName>.module.css";`. Do not import
+  non-module CSS files inside a component.
+- Reserve global CSS for resets, font loading, baseline body styles, and the
+  one-time `FluentProvider` host wiring under `app/styles/`.
+
+See
+[`component-file-and-css-module-rules.md`](component-file-and-css-module-rules.md)
+for the full set of file-shape, Fluent UI, and CSS Module conventions,
+including the narrow exception for tiny private sub-components.
+
+## Action Granularity
+
+Prefer descriptive action names that match user intent:
+
+- `composerOpened`
+- `messageDraftEdited`
+- `attachmentRemoved`
+- `submitFailed`
+
+Avoid generic action names such as `SET_STATE`, `UPDATE_FIELD`, or `RESET`
+when they hide what the user actually did.
+
+## Selector Rule
+
+Keep selectors pure and dependency-free.
+
+Selectors should:
+
+- take the state shape as input
+- return derived values
+- not call APIs
+- not trigger side effects
+- not mutate state
+
+When a derived value needs request data, move that work into the use case
+Hook, not into a selector.
+
+## Handler Rule
+
+Handlers can:
+
+- read current state through a passed selector or snapshot
+- call async dependencies through the use case
+- dispatch reducer actions
+
+Handlers should not:
+
+- own UI rendering
+- import React components
+- write directly to module-level mutable state
+
+## Hook Contract
+
+A `use-<feature>.ts` Hook should:
+
+- accept its dependencies through its argument list or React Context
+- expose a small interface to the view layer
+- combine state, selectors, and handlers into a single object suitable for the
+  view
+- own subscription cleanup
+
+A view should be able to swap one Hook implementation for another in tests
+without changing the component tree.


### PR DESCRIPTION
## What

Vendors the `react-router-app-architecture` skill into the repo at
`.github/skills/react-router-app-architecture/` (1 `SKILL.md`, 17
`references/*.md`, 1 `agents/openai.yaml` — copied verbatim from the local
Copilot plugin, byte-identical).

## Why

The `admin/` React Router SPA is actively governed by this skill, but it lived
only in a contributor's local Copilot plugin dir — unversioned, unreviewable,
and not shared across contributors/agents. Tracking it in-repo prevents drift
between the skill and the admin conventions it enforces. Mirrors the existing
`testbed/SKILL.md` co-location precedent.

## Scope

Doc-only: no Go, no `admin/` app source, no CI behavior changes.

Closes #502
