### PR TITLE
refactor(admin): extract illuminate reconcile diff + layout regime decider (#495 batch 3)

### DIFF
--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -19,6 +19,10 @@ import {
   type GraphNode,
   type HopBucketKey,
 } from "~/lib/client/usecase/illuminate/selectors";
+import {
+  decideLayoutRegime,
+  diffRenderSets,
+} from "~/lib/client/usecase/illuminate/reconcile";
 import { usePreferredTheme } from "~/lib/client/usecase/theme/use-preferred-theme";
 import {
   FORCE_ALPHA,
@@ -1420,30 +1424,17 @@ export function IlluminateCanvas({
 
     // Per-reconcile diff used to choose the layout regime below (#483).
     // We compute it BEFORE mutating the graph so the counts reflect the
-    // structural delta, not the post-merge state.
-    const previousNodeIds = previousNodeIdsRef.current;
-    let addedCount = 0;
-    let droppedCount = 0;
-    for (const id of nextNodeIds) {
-      if (!previousNodeIds.has(id)) addedCount += 1;
-    }
-    for (const id of previousNodeIds) {
-      if (!nextNodeIds.has(id)) droppedCount += 1;
-    }
-    // #500: an expansion can add/remove EDGES among nodes that are all
-    // already present (no node delta). Detect that so the whole render
-    // set still reheats and existing nodes move on every structural
-    // expansion, not only when the node set changes.
-    const previousEdgeIds = previousEdgeIdsRef.current;
-    let edgeSetChanged = previousEdgeIds.size !== nextEdgeIds.size;
-    if (!edgeSetChanged) {
-      for (const id of nextEdgeIds) {
-        if (!previousEdgeIds.has(id)) {
-          edgeSetChanged = true;
-          break;
-        }
-      }
-    }
+    // structural delta, not the post-merge state. The add/drop + edge-set
+    // arithmetic is pure, so it lives in the use-case layer (#495 batch 3)
+    // where it is unit-tested in isolation; #500's edge-only-change rule
+    // (an expansion that adds/removes EDGES among already-present nodes
+    // still reheats the whole render set) is folded into `edgeSetChanged`.
+    const { addedCount, droppedCount, edgeSetChanged } = diffRenderSets(
+      previousNodeIdsRef.current,
+      nextNodeIds,
+      previousEdgeIdsRef.current,
+      nextEdgeIds,
+    );
 
     // Drop edges first to avoid orphan references when we drop nodes.
     for (const edgeId of graph.edges()) {
@@ -1589,18 +1580,20 @@ export function IlluminateCanvas({
     // refreshes ONCE at t=0 (survivors render at their EXACT prior
     // position — no snap) and then eases on rAF. A pure attribute or
     // weight change just refreshes and leaves any running animation
-    // alone.
-    const survivorCount = nextNodeIds.size - addedCount;
-    const isColdStart = nextNodeIds.size > 0 && survivorCount === 0;
-    const isIncremental =
-      !isColdStart &&
-      forceNodes.length > 0 &&
-      (addedCount > 0 || droppedCount > 0 || edgeSetChanged);
-
-    if (isColdStart && forceNodes.length > 0) {
+    // alone. The decision is pure (#495 batch 3): `decideLayoutRegime`
+    // owns the cold/incremental/static branch; the component maps the
+    // chosen regime to the heat constant + the imperative sim calls.
+    const regime = decideLayoutRegime({
+      nextNodeCount: nextNodeIds.size,
+      forceNodeCount: forceNodes.length,
+      addedCount,
+      droppedCount,
+      edgeSetChanged,
+    });
+    if (regime === "cold") {
       beginLayout(forceNodes, forceLinks, FORCE_ALPHA_COLD);
       settleLayout();
-    } else if (isIncremental) {
+    } else if (regime === "incremental") {
       beginLayout(forceNodes, forceLinks, FORCE_ALPHA);
       // Paint survivors at their exact prior position before the first
       // tick so the click never snaps; the animation then eases on rAF.

--- a/admin/app/lib/client/usecase/illuminate/reconcile.test.ts
+++ b/admin/app/lib/client/usecase/illuminate/reconcile.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "bun:test";
+import {
+  decideLayoutRegime,
+  diffRenderSets,
+  type LayoutRegime,
+} from "./reconcile";
+
+const s = (...ids: string[]): Set<string> => new Set(ids);
+
+describe("diffRenderSets", () => {
+  it("counts a cold mount (empty → populated) as all added", () => {
+    const diff = diffRenderSets(s(), s("a", "b"), s(), s("a→b"));
+    expect(diff.addedCount).toBe(2);
+    expect(diff.droppedCount).toBe(0);
+    expect(diff.edgeSetChanged).toBe(true);
+  });
+
+  it("reports no delta when both sets are identical", () => {
+    const diff = diffRenderSets(s("a", "b"), s("a", "b"), s("a→b"), s("a→b"));
+    expect(diff.addedCount).toBe(0);
+    expect(diff.droppedCount).toBe(0);
+    expect(diff.edgeSetChanged).toBe(false);
+  });
+
+  it("counts a single added node", () => {
+    const diff = diffRenderSets(s("a"), s("a", "b"), s(), s());
+    expect(diff.addedCount).toBe(1);
+    expect(diff.droppedCount).toBe(0);
+  });
+
+  it("counts a single dropped node", () => {
+    const diff = diffRenderSets(s("a", "b"), s("a"), s(), s());
+    expect(diff.addedCount).toBe(0);
+    expect(diff.droppedCount).toBe(1);
+  });
+
+  it("counts a swap (one added, one dropped) independently", () => {
+    const diff = diffRenderSets(s("a", "b"), s("a", "c"), s(), s());
+    expect(diff.addedCount).toBe(1);
+    expect(diff.droppedCount).toBe(1);
+  });
+
+  it("flags an edge-only change among unchanged nodes (#500)", () => {
+    const diff = diffRenderSets(
+      s("a", "b"),
+      s("a", "b"),
+      s("a→b"),
+      s("a→b", "b→a"),
+    );
+    expect(diff.addedCount).toBe(0);
+    expect(diff.droppedCount).toBe(0);
+    expect(diff.edgeSetChanged).toBe(true);
+  });
+
+  it("detects an equal-size edge set with different membership", () => {
+    // Same size (1) but different id: the size short-circuit must NOT
+    // mask the membership change.
+    const diff = diffRenderSets(s("a"), s("a"), s("a→b"), s("a→c"));
+    expect(diff.edgeSetChanged).toBe(true);
+  });
+
+  it("reports edgeSetChanged=false for an equal, identical edge set", () => {
+    const diff = diffRenderSets(
+      s("a"),
+      s("a"),
+      s("a→b", "b→c"),
+      s("b→c", "a→b"),
+    );
+    expect(diff.edgeSetChanged).toBe(false);
+  });
+});
+
+describe("decideLayoutRegime", () => {
+  const regime = (
+    over: Partial<Parameters<typeof decideLayoutRegime>[0]>,
+  ): LayoutRegime =>
+    decideLayoutRegime({
+      nextNodeCount: 0,
+      forceNodeCount: 0,
+      addedCount: 0,
+      droppedCount: 0,
+      edgeSetChanged: false,
+      ...over,
+    });
+
+  it("returns 'cold' for a from-scratch mount (no survivors)", () => {
+    expect(regime({ nextNodeCount: 3, forceNodeCount: 3, addedCount: 3 })).toBe(
+      "cold",
+    );
+  });
+
+  it("returns 'cold' for a full swap that retains no survivors", () => {
+    // prev {a,b} → next {c,d}: added 2, dropped 2, survivorCount 0.
+    expect(
+      regime({
+        nextNodeCount: 2,
+        forceNodeCount: 2,
+        addedCount: 2,
+        droppedCount: 2,
+      }),
+    ).toBe("cold");
+  });
+
+  it("falls through to 'static' when a cold start rendered no nodes", () => {
+    // All-new render set but every vertex filtered out (forceNodeCount 0):
+    // the original guard `isColdStart && forceNodes.length > 0` excludes it.
+    expect(regime({ nextNodeCount: 2, forceNodeCount: 0, addedCount: 2 })).toBe(
+      "static",
+    );
+  });
+
+  it("returns 'incremental' when a node is added alongside survivors", () => {
+    expect(regime({ nextNodeCount: 4, forceNodeCount: 4, addedCount: 1 })).toBe(
+      "incremental",
+    );
+  });
+
+  it("returns 'incremental' on a drop-only delta with survivors", () => {
+    expect(
+      regime({ nextNodeCount: 2, forceNodeCount: 2, droppedCount: 1 }),
+    ).toBe("incremental");
+  });
+
+  it("returns 'incremental' on an edge-only change with survivors (#500)", () => {
+    expect(
+      regime({ nextNodeCount: 3, forceNodeCount: 3, edgeSetChanged: true }),
+    ).toBe("incremental");
+  });
+
+  it("returns 'static' for a pure attribute/weight refresh", () => {
+    expect(regime({ nextNodeCount: 3, forceNodeCount: 3 })).toBe("static");
+  });
+
+  it("returns 'static' for an empty graph (Clear)", () => {
+    expect(regime({ nextNodeCount: 0, forceNodeCount: 0 })).toBe("static");
+  });
+});

--- a/admin/app/lib/client/usecase/illuminate/reconcile.ts
+++ b/admin/app/lib/client/usecase/illuminate/reconcile.ts
@@ -1,0 +1,129 @@
+/**
+ * Pure reconcile-time decisions for the Illuminate canvas (#495 batch 3).
+ *
+ * The canvas's reconcile `useEffect`
+ * (`components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx`) must, on
+ * every render-set change, (1) measure the structural delta between the
+ * frame it last drew and the frame it is about to draw, and (2) pick which
+ * d3-force layout regime that delta warrants (#483). Both are pure
+ * set/scalar arithmetic with no React, sigma, or graphology in sight, so
+ * they live here where they can be unit-tested in isolation — the
+ * component keeps only the imperative "apply the chosen regime to the live
+ * simulation" glue.
+ *
+ * Behaviour is identical to the inline logic this replaces; the move is a
+ * relocation, not a change (#495). The regime enum is deliberately
+ * alpha-free: the cold/incremental heat constants (`FORCE_ALPHA_COLD` /
+ * `FORCE_ALPHA`) live in the component-layer `force-layout.ts`, and the
+ * use-case layer must not import upward from the component layer, so the
+ * component owns the trivial regime → alpha mapping.
+ */
+
+/**
+ * Structural delta between the previously-rendered set and the next one.
+ * `addedCount` / `droppedCount` count node-id membership changes;
+ * `edgeSetChanged` is a boolean because the layout regime only cares
+ * *whether* the edge set changed, not by how much — an edge-only
+ * expansion still reheats the whole render set (#500).
+ */
+export interface RenderSetDiff {
+  /** Count of ids in `nextNodeIds` that were absent from `previousNodeIds`. */
+  addedCount: number;
+  /** Count of ids in `previousNodeIds` that are absent from `nextNodeIds`. */
+  droppedCount: number;
+  /** True iff the edge-id set differs (size or membership) between frames. */
+  edgeSetChanged: boolean;
+}
+
+/**
+ * Measures the node add/drop counts and whether the edge set changed
+ * between the previously-rendered frame and the next one. Pure; mirrors
+ * the diff the reconcile effect computed inline BEFORE mutating
+ * graphology, so the counts reflect the structural delta rather than the
+ * post-merge state.
+ *
+ * The edge comparison short-circuits on a size mismatch and otherwise
+ * scans `nextEdgeIds` for a previously-absent id: for two equal-size sets,
+ * membership is symmetric, so a one-directional scan is sufficient to
+ * decide whether they differ.
+ */
+export function diffRenderSets(
+  previousNodeIds: ReadonlySet<string>,
+  nextNodeIds: ReadonlySet<string>,
+  previousEdgeIds: ReadonlySet<string>,
+  nextEdgeIds: ReadonlySet<string>,
+): RenderSetDiff {
+  let addedCount = 0;
+  let droppedCount = 0;
+  for (const id of nextNodeIds) {
+    if (!previousNodeIds.has(id)) addedCount += 1;
+  }
+  for (const id of previousNodeIds) {
+    if (!nextNodeIds.has(id)) droppedCount += 1;
+  }
+  let edgeSetChanged = previousEdgeIds.size !== nextEdgeIds.size;
+  if (!edgeSetChanged) {
+    for (const id of nextEdgeIds) {
+      if (!previousEdgeIds.has(id)) {
+        edgeSetChanged = true;
+        break;
+      }
+    }
+  }
+  return { addedCount, droppedCount, edgeSetChanged };
+}
+
+/**
+ * Which d3-force layout regime a reconcile should run (#483):
+ *
+ * - `"cold"`: empty → populated, or a full reseed with NO survivors. The
+ *   component settles the simulation synchronously so the first paint is
+ *   already a clean layout (full heat, `FORCE_ALPHA_COLD`).
+ * - `"incremental"`: at least one survivor carried over AND something
+ *   structural changed (a node was added/dropped, or the edge set changed
+ *   — #500). The component eases the new frame in on rAF (`FORCE_ALPHA`),
+ *   painting survivors at their exact prior position first so the click
+ *   never snaps.
+ * - `"static"`: nothing structural changed (a pure attribute/weight
+ *   refresh), or there is nothing to lay out. The component just refreshes
+ *   sigma and leaves any in-flight animation undisturbed (dropping a
+ *   now-empty simulation on Clear).
+ */
+export type LayoutRegime = "cold" | "incremental" | "static";
+
+/**
+ * Picks the {@link LayoutRegime} for a reconcile from its structural delta.
+ *
+ * `nextNodeCount` is the size of the resolved render set (`nextNodeIds`),
+ * while `forceNodeCount` is how many nodes actually made it into
+ * graphology this frame. They can differ: a latest-result key whose vertex
+ * was filtered out (e.g. expired, #459) counts toward the render set but
+ * is never added to the graph, leaving the simulation empty. Keeping them
+ * separate preserves the original guard (`isColdStart && forceNodes.length
+ * > 0`) exactly — an "all-new but nothing actually rendered" reconcile
+ * falls through to `"static"`, which the component handles by stopping any
+ * empty simulation.
+ */
+export function decideLayoutRegime({
+  nextNodeCount,
+  forceNodeCount,
+  addedCount,
+  droppedCount,
+  edgeSetChanged,
+}: {
+  nextNodeCount: number;
+  forceNodeCount: number;
+  addedCount: number;
+  droppedCount: number;
+  edgeSetChanged: boolean;
+}): LayoutRegime {
+  const survivorCount = nextNodeCount - addedCount;
+  const isColdStart = nextNodeCount > 0 && survivorCount === 0;
+  if (isColdStart && forceNodeCount > 0) return "cold";
+  const isIncremental =
+    !isColdStart &&
+    forceNodeCount > 0 &&
+    (addedCount > 0 || droppedCount > 0 || edgeSetChanged);
+  if (isIncremental) return "incremental";
+  return "static";
+}


### PR DESCRIPTION
## What

Batch 3 of the `IlluminateCanvas` decomposition (#495). Extracts the
**reconcile-time render-set diff** and the **d3-force layout-regime
decision** out of the 1.8 KLOC component and into a pure, unit-tested
use-case module.

- New `app/lib/client/usecase/illuminate/reconcile.ts`:
  - `diffRenderSets(prevNodes, nextNodes, prevEdges, nextEdges)` →
    `{ addedCount, droppedCount, edgeSetChanged }`. Mirrors the inline
    diff the reconcile effect computed *before* mutating graphology,
    including #500's "edge-only change among unchanged nodes still
    reheats" rule.
  - `decideLayoutRegime({ nextNodeCount, forceNodeCount, addedCount,
    droppedCount, edgeSetChanged })` → `"cold" | "incremental" |
    "static"` (#483). `nextNodeCount` (render set) and `forceNodeCount`
    (nodes actually in graphology) are kept separate so the original
    `isColdStart && forceNodes.length > 0` guard — an all-new set whose
    vertices were all filtered out (e.g. expired, #459) — is preserved
    exactly.
- `IlluminateCanvas.tsx` now calls those two helpers and maps the
  returned regime to the heat constant (`FORCE_ALPHA_COLD` /
  `FORCE_ALPHA`) + the imperative `beginLayout`/`settleLayout`/
  `startLayoutLoop`/`stopLayout` glue. Net −7 lines in the component.

The regime enum is deliberately **alpha-free**: the force-heat constants
live in the component-layer `force-layout.ts`, and the use-case layer
must not import upward from the component layer, so the component keeps
the trivial regime → alpha mapping.

## Why

`IlluminateCanvas.tsx` is the largest, highest-churn admin file. The
reconcile diff + regime decision are the most correctness-sensitive,
decider-worthy state transitions in it, but were buried inline in a
~200-line `useEffect`. Moving them to a pure module makes them
unit-testable in isolation and shrinks the component toward the
"Sigma/graphology rendering shell" target.

## Behaviour

Pure relocation — no behaviour change. Verified:

- `bun run format && bun run lint && bun run typecheck` — clean.
- `bun test app test/cli-grammar` — **485 pass** (16 new
  `reconcile.test.ts` cases covering cold/incremental/static, the
  full-swap-with-no-survivors cold case, the filtered-to-empty
  fall-through to static, and the #500 edge-only path).
- `bun run build` — clean.
- `bunx playwright test --workers=1` — **48 pass** (full illuminate
  suite: #483 ease-in, #491, #500, #458, #459, #460, #456, #461).

## Scope

Refs #495 — does **not** close it. Batch 4 (rAF tick loop + drag /
`finishDrag` / reheat lifecycle → feature-local controller hook) is the
final batch and will `Closes #495`.
