### PR TITLE
feat(admin): redesign /cli into a unified shell-style terminal

### DIFF
--- a/admin/app/components/cli/CliAxisPicker/CliAxisPicker.module.css
+++ b/admin/app/components/cli/CliAxisPicker/CliAxisPicker.module.css
@@ -1,23 +1,22 @@
-/* Click-to-illuminate axis picker (#464).
+/* Click-to-illuminate axis picker (#464, restyled for #512).
  *
- * Single-line strip at desktop widths; wraps onto multiple rows
- * gracefully on narrow viewports. Sized to read as a chip strip
- * (compact, calm) rather than a primary action bar — the picker is
- * a secondary control above the scrollback, not a hero surface.
+ * Rendered as the control header inside the canvas panel, so it carries
+ * NO frame of its own — the surrounding `.canvasControls` provides the
+ * background and bottom border, letting the picker read as part of the
+ * panel chrome. Wraps gracefully: the controls flow onto multiple rows
+ * and every control may shrink, so the strip never overflows even in a
+ * narrow canvas column.
  *
- * Uses Fluent UI design tokens via CSS custom property fallbacks
- * so it follows the theme that root.tsx wires via FluentProvider.
+ * Uses Fluent UI design tokens via CSS custom property fallbacks so it
+ * follows the theme that root.tsx wires via FluentProvider.
  */
 .strip {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: var(--spacingHorizontalM, 12px);
-  padding: var(--spacingVerticalXS, 4px) var(--spacingHorizontalS, 8px);
-  border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
-  border-radius: var(--borderRadiusMedium, 6px);
-  background: var(--colorNeutralBackground2, #fafafa);
-  flex: 0 0 auto;
+  gap: var(--spacingHorizontalS, 8px);
+  padding: var(--spacingVerticalXS, 4px) var(--spacingHorizontalM, 12px);
+  min-width: 0;
 }
 
 .field {
@@ -26,6 +25,7 @@
   gap: var(--spacingHorizontalXS, 4px);
   /* Implicit label wrappers should not look clickable beyond the
    * inner control — keep the label text inline and small. */
+  min-width: 0;
   cursor: default;
   margin: 0;
 }
@@ -41,29 +41,31 @@
   );
 }
 
-/* Number inputs for step / k. Narrow so the strip stays single-row on
- * common laptop widths; the integers we accept are at most two digits. */
+/* Number inputs for step / k. Narrow — the integers we accept are at most
+ * two digits. */
 .numberInput {
   width: 72px;
 }
 
-/* Dropdowns for algorithm / objective. Wide enough for the longest
- * label ("Shortest-path tree", "Maximize (relevance)") without
- * clipping at the standard Fluent UI font size. */
-.dropdown {
-  min-width: 200px;
+/* Dropdowns for algorithm / objective. The descendant selector raises
+ * specificity above Fluent UI's default 250px min-width so the controls
+ * can shrink and the strip never overflows a narrow canvas column. */
+.strip .dropdown {
+  min-width: 0;
+  max-width: 100%;
 }
 
 .tfidf {
   /* Switch has its own internal label; no extra spacing needed. */
 }
 
-/* Live preview of the command the next click will write into the
- * prompt. Placed at the right of the strip on wide viewports so it
- * doesn't push the interactive controls around when the operator
- * tunes axes; falls below on narrow viewports via the wrap rules. */
+/* Live preview of the command the next click will write into the prompt.
+ * Always sits on its own full-width row beneath the controls (flex-basis
+ * 100%) so it reads like a status line and never collides with the
+ * interactive controls, regardless of the canvas column's width. */
 .preview {
-  margin-left: auto;
+  flex: 1 1 100%;
+  margin-top: var(--spacingVerticalXXS, 2px);
   font-family: var(
     --fontFamilyMonospace,
     ui-monospace,
@@ -75,17 +77,4 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 100%;
-}
-
-@media (max-width: 720px) {
-  .preview {
-    margin-left: 0;
-    flex: 1 1 100%;
-    white-space: normal;
-    text-overflow: clip;
-  }
-  .dropdown {
-    min-width: 160px;
-  }
 }

--- a/admin/app/components/cli/CliPage/CliPage.module.css
+++ b/admin/app/components/cli/CliPage/CliPage.module.css
@@ -1,27 +1,30 @@
-/* The /cli root.
+/* The /cli root (#512).
  *
- * Two layout modes (#465):
- *   data-mode="cli"   : no graph yet — full-width terminal, splitter hidden.
- *   data-mode="split" : graph present and viewport ≥ 1024px — two-column
- *                       grid with a draggable splitter between the canvas
- *                       (left) and the toolbar/scrollback/input stack
- *                       (right). Below 1024px the layout falls back to the
- *                       legacy single-column stack regardless of mode.
+ * Two layout modes:
+ *   data-mode="cli"   : no graph yet — the shell terminal owns the full
+ *                       width; splitter and canvas are absent.
+ *   data-mode="split" : graph present and viewport ≥ 1024px — a two-column
+ *                       grid with the terminal on the LEFT, a draggable
+ *                       splitter, and the canvas (with its integrated axis
+ *                       picker) on the RIGHT. Below 1024px the layout falls
+ *                       back to a single-column stack (terminal above the
+ *                       canvas) regardless of mode.
  *
- * The grid template columns are driven by `--cli-canvas-frac` and
- * `--cli-right-frac` written from the `useCliSplitter` hook. Defaults are
- * declared on the host so the layout has a sensible value before the hook
- * mounts and on first paint after SSR.
+ * The grid template columns are driven by `--cli-left-frac` (terminal) and
+ * `--cli-right-frac` (canvas) written from the `useCliSplitter` hook.
+ * Defaults are declared on the host so the layout has a sensible value
+ * before the hook mounts and on first paint after SSR.
  */
 .root {
-  --cli-canvas-frac: 0.6fr;
-  --cli-right-frac: 0.4fr;
+  --cli-left-frac: 0.4fr;
+  --cli-right-frac: 0.6fr;
   display: flex;
   flex-direction: column;
   height: calc(100vh - 120px);
   min-height: 400px;
   gap: var(--spacingVerticalM, 12px);
-  padding: var(--spacingVerticalL, 16px);
+  /* No padding here — AppShell's <main> provides the page gutter, and on
+     /cli it runs full-bleed so the terminal can use the screen width. */
 }
 
 .root[data-dragging="true"] {
@@ -29,31 +32,207 @@
   cursor: col-resize;
 }
 
-/* Left column wraps the canvas panel; on narrow viewports it carries the
-   45% sizing the canvasPanel used to own. */
-.leftColumn {
+/* ── The unified shell terminal ─────────────────────────────────────────
+   A single bordered, elevated box that fuses the faux title chrome, the
+   scrollback, an optional confirm bar, and the pinned prompt row into one
+   surface — like a real shell, output and input are never separated. */
+.terminal {
   display: flex;
   flex-direction: column;
-  flex: 0 0 45%;
-  min-height: 240px;
-  min-width: 0;
-}
-
-/* Right column wraps the toolbar / scrollback / confirm bar / input row.
-   On narrow viewports it fills the remaining vertical space. */
-.rightColumn {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacingVerticalM, 12px);
   flex: 1 1 auto;
   min-height: 0;
   min-width: 0;
+  border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  border-radius: var(--borderRadiusLarge, 8px);
+  background: var(--colorNeutralBackground1, #ffffff);
+  box-shadow: var(--shadow4, 0 2px 4px rgba(0, 0, 0, 0.14));
+  overflow: hidden;
 }
 
-/* Splitter handle — hidden by default; only visible in `split` mode at
-   ≥ 1024px (see media query at the bottom of the file). The thin visible
-   strip is 4px wide; an invisible ::before extends the hit target to 12px
-   so it's easy to grab without making the visible line thick. */
+/* Faux terminal title bar with decorative traffic-light dots. */
+.chrome {
+  display: flex;
+  align-items: center;
+  gap: var(--spacingHorizontalS, 8px);
+  flex: 0 0 auto;
+  min-height: 32px;
+  padding: var(--spacingVerticalXS, 4px) var(--spacingHorizontalM, 12px);
+  border-bottom: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  background: var(--colorNeutralBackground2, #fafafa);
+}
+
+.dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: var(--borderRadiusCircular, 999px);
+}
+
+/* Decorative only (aria-hidden); classic terminal traffic lights. */
+.dotRed {
+  background: #ff5f56;
+}
+
+.dotAmber {
+  background: #ffbd2e;
+}
+
+.dotGreen {
+  background: #27c93f;
+}
+
+.chromeTitle {
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  font-size: var(--fontSizeBase200, 12px);
+  color: var(--colorNeutralForeground3, #707070);
+  letter-spacing: 0.02em;
+}
+
+/* Spinner + Cancel, pushed to the right edge while a command is in flight. */
+.chromeBusy {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacingHorizontalS, 8px);
+  margin-left: auto;
+}
+
+/* Scrollback body — transparent because the terminal box owns the frame. */
+.scrollback {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--spacingVerticalS, 8px) var(--spacingHorizontalM, 12px);
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  font-size: var(--fontSizeBase200, 12px);
+  line-height: 1.5;
+  color: var(--colorNeutralForeground1, #242424);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.entry {
+  margin-bottom: var(--spacingVerticalS, 8px);
+}
+
+/* Echoed command line (`❯ get vertex alice`). */
+.entryEcho {
+  color: var(--colorNeutralForeground1, #242424);
+}
+
+.prompt {
+  color: var(--colorBrandForeground2, #115ea3);
+  font-weight: 600;
+  user-select: none;
+}
+
+.entryInput {
+  color: var(--colorNeutralForeground1, #242424);
+}
+
+.entryBody {
+  display: block;
+}
+
+/* The `OK (1.2ms)` header line above a highlighted JSON payload. */
+.entryOkLine {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacingHorizontalXS, 4px);
+}
+
+.entryOk {
+  color: var(--colorPaletteGreenForeground1, #0e700e);
+  font-weight: 600;
+}
+
+.entryError {
+  color: var(--colorPaletteRedForeground1, #b10e1c);
+}
+
+.entryTiming {
+  color: var(--colorNeutralForeground3, #707070);
+  font-size: var(--fontSizeBase100, 10px);
+  margin-left: var(--spacingHorizontalXS, 4px);
+}
+
+/* Destructive-command confirmation, rendered inside the box above the
+   prompt row. */
+.confirmBar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--spacingHorizontalS, 8px);
+  flex: 0 0 auto;
+  padding: var(--spacingVerticalS, 8px) var(--spacingHorizontalM, 12px);
+  border-top: 1px solid var(--colorPaletteRedBorder2, #f1bbbb);
+  background: var(--colorPaletteRedBackground1, #fff5f5);
+}
+
+.confirmText {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: var(--fontSizeBase200, 12px);
+}
+
+/* The pinned prompt row — always the last line of the terminal. Hosts a
+   native <input> styled as a bare shell line for an authentic feel. */
+.promptRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacingHorizontalS, 8px);
+  flex: 0 0 auto;
+  padding: var(--spacingVerticalS, 8px) var(--spacingHorizontalM, 12px);
+  border-top: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  background: var(--colorNeutralBackground1, #ffffff);
+}
+
+.input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  color: var(--colorNeutralForeground1, #242424);
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  font-size: var(--fontSizeBase300, 14px);
+  line-height: 1.5;
+}
+
+.input::placeholder {
+  color: var(--colorNeutralForeground4, #919191);
+}
+
+.input:disabled {
+  color: var(--colorNeutralForeground3, #707070);
+  cursor: not-allowed;
+}
+
+/* ── Splitter handle ────────────────────────────────────────────────────
+   Hidden by default; only visible in `split` mode at ≥ 1024px (see media
+   query below). The thin visible strip is 4px wide; an invisible ::before
+   widens the hit target so it's easy to grab. */
 .splitter {
   display: none;
   position: relative;
@@ -65,8 +244,7 @@
 .splitter::before {
   content: "";
   position: absolute;
-  inset: 0 -4px;
-  /* Invisible hit target, 12px wide centered on the visible strip. */
+  inset: 0 -6px;
 }
 
 .splitter:hover,
@@ -80,24 +258,46 @@
   outline-offset: 1px;
 }
 
-/* Canvas panel rendered inside `.leftColumn` when the most recent
-   command produced graph data. Fills the column. */
+/* ── Canvas column ──────────────────────────────────────────────────────
+   Mounts only when the latest command produced a graph. Wraps the canvas
+   panel; on narrow viewports it carries an explicit share of the stack. */
+.canvasColumn {
+  display: flex;
+  flex-direction: column;
+  flex: 0 0 50%;
+  min-height: 240px;
+  min-width: 0;
+}
+
+/* The canvas panel: integrated axis-picker control header, a meta line,
+   and the graph body. Mirrors the terminal's frame for visual symmetry. */
 .canvasPanel {
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
   min-height: 0;
   border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
-  border-radius: var(--borderRadiusMedium, 6px);
+  border-radius: var(--borderRadiusLarge, 8px);
   background: var(--colorNeutralBackground1, #ffffff);
+  box-shadow: var(--shadow4, 0 2px 4px rgba(0, 0, 0, 0.14));
   overflow: hidden;
 }
 
-.canvasHeader {
+/* Wraps the CliAxisPicker as the panel's control header; the picker itself
+   renders seamlessly (no frame of its own) so it reads as part of the
+   panel chrome. */
+.canvasControls {
+  flex: 0 0 auto;
+  border-bottom: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  background: var(--colorNeutralBackground2, #fafafa);
+}
+
+.canvasMeta {
   display: flex;
   align-items: baseline;
+  flex-wrap: wrap;
   gap: var(--spacingHorizontalS, 8px);
-  padding: var(--spacingVerticalXS, 4px) var(--spacingHorizontalS, 8px);
+  padding: var(--spacingVerticalXS, 4px) var(--spacingHorizontalM, 12px);
   border-bottom: 1px solid var(--colorNeutralStroke2, #e0e0e0);
   background: var(--colorNeutralBackground2, #fafafa);
   font-family: var(
@@ -109,15 +309,16 @@
   font-size: var(--fontSizeBase200, 12px);
 }
 
-.canvasHeaderLabel {
+.canvasMetaLabel {
   color: var(--colorNeutralForeground3, #707070);
 }
 
-.canvasHeaderSource {
+.canvasMetaSource {
   color: var(--colorNeutralForeground1, #242424);
+  font-weight: 600;
 }
 
-.canvasHeaderHint {
+.canvasMetaHint {
   margin-left: auto;
   color: var(--colorNeutralForeground3, #707070);
   font-size: var(--fontSizeBase100, 10px);
@@ -129,110 +330,23 @@
   min-height: 0;
 }
 
-/* Slim toolbar above the scrollback. Hosts the Clear button and a
-   conditional Cancel button that appears only while a command is in
-   flight (#433). Sized to look like a chip strip, not a primary
-   action bar. */
-.toolbar {
-  display: flex;
-  align-items: center;
-  gap: var(--spacingHorizontalS, 8px);
-  flex: 0 0 auto;
-}
-
-.scrollback {
-  flex: 1 1 auto;
-  min-height: 120px;
-  overflow-y: auto;
-  border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
-  border-radius: var(--borderRadiusMedium, 6px);
-  background: var(--colorNeutralBackground2, #fafafa);
-  font-family: var(
-    --fontFamilyMonospace,
-    ui-monospace,
-    SFMono-Regular,
-    monospace
-  );
-  font-size: var(--fontSizeBase200, 12px);
-  padding: var(--spacingVerticalS, 8px);
-  white-space: pre-wrap;
-  word-break: break-all;
-}
-
-.entry {
-  margin-bottom: var(--spacingVerticalS, 8px);
-}
-
-.prompt {
-  color: var(--colorBrandForeground2, #115ea3);
-  font-weight: 600;
-}
-
-.entryInput {
-  color: var(--colorNeutralForeground1, #242424);
-}
-
-.entryOk {
-  color: var(--colorPaletteGreenForeground1, #0e700e);
-}
-
-.entryError {
-  color: var(--colorPaletteRedForeground1, #b10e1c);
-}
-
-.entryTiming {
-  color: var(--colorNeutralForeground3, #707070);
-  font-size: var(--fontSizeBase100, 10px);
-  margin-left: var(--spacingHorizontalXS, 4px);
-}
-
-.inputRow {
-  display: flex;
-  align-items: center;
-  gap: var(--spacingHorizontalS, 8px);
-}
-
-.input {
-  flex: 1 1 auto;
-  font-family: var(
-    --fontFamilyMonospace,
-    ui-monospace,
-    SFMono-Regular,
-    monospace
-  );
-}
-
-.confirmBar {
-  display: flex;
-  align-items: center;
-  gap: var(--spacingHorizontalS, 8px);
-  padding: var(--spacingVerticalS, 8px);
-  border: 1px solid var(--colorPaletteRedBorder1, #f3b1b1);
-  border-radius: var(--borderRadiusMedium, 6px);
-  background: var(--colorPaletteRedBackground1, #fff5f5);
-}
-
-.confirmText {
-  flex: 1 1 auto;
-  font-size: var(--fontSizeBase200, 12px);
-}
-
-/* Wide viewports — switch to the two-column grid when a graph is present. */
+/* ── Wide viewports — two-column grid when a graph is present ─────────────
+   Terminal (col 1) · splitter (col 2) · canvas (col 3). */
 @media (min-width: 1024px) {
   .root[data-mode="split"] {
     display: grid;
-    grid-template-columns: var(--cli-canvas-frac, 0.6fr) 4px var(
+    grid-template-columns: var(--cli-left-frac, 0.4fr) 4px var(
         --cli-right-frac,
-        0.4fr
+        0.6fr
       );
     grid-template-rows: 1fr;
     gap: 0;
   }
 
-  .root[data-mode="split"] > .leftColumn {
-    flex: 1 1 auto;
-    min-height: 0;
+  .root[data-mode="split"] > .terminal {
     grid-column: 1;
+    min-height: 0;
+    margin-right: var(--spacingHorizontalS, 8px);
   }
 
   .root[data-mode="split"] > .splitter {
@@ -241,9 +355,10 @@
     height: 100%;
   }
 
-  .root[data-mode="split"] > .rightColumn {
+  .root[data-mode="split"] > .canvasColumn {
     flex: 1 1 auto;
     grid-column: 3;
-    padding-left: var(--spacingHorizontalM, 12px);
+    min-height: 0;
+    margin-left: var(--spacingHorizontalS, 8px);
   }
 }

--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -1,15 +1,12 @@
-import {
-  Button,
-  Checkbox,
-  Input,
-  type InputProps,
-} from "@fluentui/react-components";
+import { Button, Checkbox, Spinner } from "@fluentui/react-components";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { formatIlluminateClick } from "~/lib/cli/illuminate-axes";
 import { useCli } from "~/lib/client/usecase/cli/use-cli";
 import { useCliSplitter } from "~/lib/client/usecase/cli/use-cli-splitter";
 import { useCliAxisPicker } from "~/lib/client/usecase/cli/use-cli-axis-picker";
+import type { ScrollbackEntry } from "~/lib/client/usecase/cli/state";
 import { CliAxisPicker } from "~/components/cli/CliAxisPicker/CliAxisPicker";
+import { JsonView } from "~/components/cli/JsonView/JsonView";
 import { IlluminateCanvas } from "~/components/illuminate/IlluminateCanvas/IlluminateCanvas";
 import styles from "./CliPage.module.css";
 
@@ -85,10 +82,6 @@ export function CliPage() {
     [cli],
   );
 
-  const onChange: InputProps["onChange"] = (_e, data) => {
-    cli.setInput(data.value);
-  };
-
   const renderedScrollback = useMemo(
     () =>
       cli.scrollback.map((entry) => (
@@ -97,28 +90,15 @@ export function CliPage() {
           className={styles.entry}
           data-testid={`cli-entry-${entry.kind}`}
         >
-          {entry.input !== "" && (
-            <div>
-              <span className={styles.prompt}>&gt;</span>{" "}
+          {entry.input !== "" ? (
+            <div className={styles.entryEcho}>
+              <span className={styles.prompt} aria-hidden="true">
+                ❯
+              </span>{" "}
               <span className={styles.entryInput}>{entry.input}</span>
             </div>
-          )}
-          <div
-            className={
-              entry.kind === "ok"
-                ? styles.entryOk
-                : entry.kind === "error"
-                  ? styles.entryError
-                  : undefined
-            }
-          >
-            {entry.text}
-            {entry.durationMs !== undefined ? (
-              <span className={styles.entryTiming}>
-                ({entry.durationMs.toFixed(1)}ms)
-              </span>
-            ) : null}
-          </div>
+          ) : null}
+          <EntryBody entry={entry} />
         </div>
       )),
     [cli.scrollback],
@@ -132,81 +112,46 @@ export function CliPage() {
       data-mode={cli.latestGraph !== null ? "split" : "cli"}
       data-dragging={splitter.dragging ? "true" : undefined}
     >
-      {cli.latestGraph !== null ? (
-        <div className={styles.leftColumn} data-testid="cli-left-column">
-          <div className={styles.canvasPanel} data-testid="cli-canvas-panel">
-            <div className={styles.canvasHeader}>
-              <span className={styles.canvasHeaderLabel}>from:</span>{" "}
-              <code className={styles.canvasHeaderSource}>
-                {cli.latestGraph.source}
-              </code>
-              <span className={styles.canvasHeaderHint}>
-                click any node to run{" "}
-                <code data-testid="cli-click-hint">
-                  {formatIlluminateClick("<key>", axisPicker.axes)}
-                </code>
-              </span>
-            </div>
-            <div className={styles.canvasBody}>
-              <IlluminateCanvas
-                nodes={cli.latestGraph.view.nodes}
-                edges={cli.latestGraph.view.edges}
-                latestExpansionOrigin={
-                  cli.latestGraph.view.latestExpansionOrigin
-                }
-                latestResultVertexKeys={
-                  cli.latestGraph.view.latestResultVertexKeys
-                }
-                latestResultEdgeIds={cli.latestGraph.view.latestResultEdgeIds}
-                onNodeClick={onNodeClick}
-                isBusy={cli.busy}
-              />
-            </div>
-          </div>
-        </div>
-      ) : null}
-      {cli.latestGraph !== null ? (
-        <div
-          className={styles.splitter}
-          data-testid="cli-splitter"
-          aria-label="Resize canvas vs scrollback"
-          {...splitter.handleProps}
-        />
-      ) : null}
-      <div className={styles.rightColumn} data-testid="cli-right-column">
-        <div className={styles.toolbar} data-testid="cli-toolbar">
-          <Button
-            appearance="secondary"
-            size="small"
-            onClick={cli.clearScrollback}
-            disabled={cli.scrollback.length <= 1}
-            data-testid="cli-clear"
-            aria-label="Clear scrollback (Ctrl+L)"
-            title="Clear scrollback (Ctrl+L)"
-          >
-            Clear
-          </Button>
+      {/* Left column — the unified shell terminal. Always present; owns
+          the full width until a graph-producing command opens the canvas. */}
+      <section className={styles.terminal} data-testid="cli-terminal">
+        <div className={styles.chrome}>
+          <span className={styles.dots} aria-hidden="true">
+            <span className={`${styles.dot} ${styles.dotRed}`} />
+            <span className={`${styles.dot} ${styles.dotAmber}`} />
+            <span className={`${styles.dot} ${styles.dotGreen}`} />
+          </span>
+          <span className={styles.chromeTitle}>lantern · cli</span>
           {cli.busy ? (
-            <Button
-              appearance="secondary"
-              size="small"
-              onClick={cli.cancelInFlight}
-              data-testid="cli-cancel"
-              aria-label="Cancel in-flight command (Esc)"
-              title="Cancel in-flight command (Esc)"
-            >
-              Cancel
-            </Button>
+            <span className={styles.chromeBusy}>
+              <Spinner
+                size="extra-tiny"
+                label="running"
+                labelPosition="before"
+              />
+              <Button
+                appearance="subtle"
+                size="small"
+                onClick={cli.cancelInFlight}
+                data-testid="cli-cancel"
+                aria-label="Cancel in-flight command (Esc)"
+                title="Cancel in-flight command (Esc)"
+              >
+                Cancel
+              </Button>
+            </span>
           ) : null}
-          <CliAxisPicker
-            axes={axisPicker.axes}
-            setAxis={axisPicker.setAxis}
-            disabled={cli.busy || cli.pending !== null}
-          />
         </div>
-        <div className={styles.scrollback} ref={scrollRef} aria-live="polite">
+
+        <div
+          className={styles.scrollback}
+          ref={scrollRef}
+          aria-live="polite"
+          data-testid="cli-scrollback"
+        >
           {renderedScrollback}
         </div>
+
         {cli.pending !== null ? (
           <div className={styles.confirmBar} data-testid="cli-confirm">
             <span className={styles.confirmText}>
@@ -235,20 +180,124 @@ export function CliPage() {
             </Button>
           </div>
         ) : null}
-        <div className={styles.inputRow}>
-          <span className={styles.prompt}>&gt;</span>
-          <Input
+
+        <div className={styles.promptRow}>
+          <span className={styles.prompt} aria-hidden="true">
+            ❯
+          </span>
+          <input
             className={styles.input}
             value={cli.input}
-            onChange={onChange}
+            onChange={(e) => cli.setInput(e.target.value)}
             onKeyDown={onKeyDown}
             placeholder="get vertex alice    |    illuminate alice 2 5 algorithm=spt"
             disabled={cli.busy || cli.pending !== null}
             data-testid="cli-input"
             aria-label="CLI command input"
+            autoComplete="off"
+            autoCapitalize="off"
+            autoCorrect="off"
+            spellCheck={false}
           />
         </div>
+      </section>
+
+      {/* Draggable splitter — only in split mode (graph present, ≥1024px). */}
+      {cli.latestGraph !== null ? (
+        <div
+          className={styles.splitter}
+          data-testid="cli-splitter"
+          aria-label="Resize terminal vs canvas"
+          {...splitter.handleProps}
+        />
+      ) : null}
+
+      {/* Right column — the canvas with the axis picker fused into its
+          control header (#512). Mounts only when a graph is available. */}
+      {cli.latestGraph !== null ? (
+        <section
+          className={styles.canvasColumn}
+          data-testid="cli-canvas-column"
+        >
+          <div className={styles.canvasPanel} data-testid="cli-canvas-panel">
+            <div className={styles.canvasControls}>
+              <CliAxisPicker
+                axes={axisPicker.axes}
+                setAxis={axisPicker.setAxis}
+                disabled={cli.busy || cli.pending !== null}
+              />
+            </div>
+            <div className={styles.canvasMeta}>
+              <span className={styles.canvasMetaLabel}>from</span>
+              <code className={styles.canvasMetaSource}>
+                {cli.latestGraph.source}
+              </code>
+              <span className={styles.canvasMetaHint}>
+                click a node →{" "}
+                <code data-testid="cli-click-hint">
+                  {formatIlluminateClick("<key>", axisPicker.axes)}
+                </code>
+              </span>
+            </div>
+            <div className={styles.canvasBody}>
+              <IlluminateCanvas
+                nodes={cli.latestGraph.view.nodes}
+                edges={cli.latestGraph.view.edges}
+                latestExpansionOrigin={
+                  cli.latestGraph.view.latestExpansionOrigin
+                }
+                latestResultVertexKeys={
+                  cli.latestGraph.view.latestResultVertexKeys
+                }
+                latestResultEdgeIds={cli.latestGraph.view.latestResultEdgeIds}
+                onNodeClick={onNodeClick}
+                isBusy={cli.busy}
+              />
+            </div>
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Render one scrollback entry's body. Successful command output is
+ * formatted by `useCli` as `OK\n<json>`; that JSON gets lightweight,
+ * theme-aware colouring via {@link JsonView}. Plain "OK", errors, info
+ * lines, and the banner render as plain monospace text. Kept as a tiny
+ * render-only subcomponent so the memoised scrollback map stays flat.
+ */
+function EntryBody({ entry }: { entry: ScrollbackEntry }) {
+  const timing =
+    entry.durationMs !== undefined ? (
+      <span className={styles.entryTiming}>
+        ({entry.durationMs.toFixed(1)}ms)
+      </span>
+    ) : null;
+
+  if (entry.kind === "ok" && entry.text.startsWith("OK\n")) {
+    return (
+      <div className={styles.entryBody}>
+        <div className={styles.entryOkLine}>
+          <span className={styles.entryOk}>OK</span>
+          {timing}
+        </div>
+        <JsonView source={entry.text.slice(3)} />
       </div>
+    );
+  }
+
+  const cls =
+    entry.kind === "ok"
+      ? styles.entryOk
+      : entry.kind === "error"
+        ? styles.entryError
+        : undefined;
+  return (
+    <div className={cls}>
+      {entry.text}
+      {timing}
     </div>
   );
 }

--- a/admin/app/components/cli/JsonView/JsonView.module.css
+++ b/admin/app/components/cli/JsonView/JsonView.module.css
@@ -1,0 +1,46 @@
+/* Syntax colouring for the /cli JSON payloads (#512).
+ *
+ * Colours come from Fluent UI palette foreground tokens so the scheme
+ * follows the light/dark theme wired by `root.tsx`'s FluentProvider; the
+ * hex fallbacks only apply if a token is ever missing. The palette is
+ * chosen for contrast against the neutral scrollback background and to
+ * keep keys, strings, and numbers visually distinct at a glance.
+ */
+.json {
+  display: block;
+  margin-top: var(--spacingVerticalXXS, 2px);
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.key {
+  color: var(--colorBrandForeground1, #0f6cbd);
+}
+
+.string {
+  color: var(--colorPaletteGreenForeground1, #0e700e);
+}
+
+.number {
+  color: var(--colorPaletteBerryForeground1, #ad1457);
+}
+
+.boolean {
+  color: var(--colorPaletteMarigoldForeground1, #835b00);
+  font-weight: var(--fontWeightSemibold, 600);
+}
+
+.null {
+  color: var(--colorNeutralForeground3, #707070);
+  font-style: italic;
+}
+
+.punctuation {
+  color: var(--colorNeutralForeground4, #919191);
+}

--- a/admin/app/components/cli/JsonView/JsonView.tsx
+++ b/admin/app/components/cli/JsonView/JsonView.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from "react";
+import {
+  tokenizeJson,
+  type JsonTokenKind,
+} from "~/lib/client/usecase/cli/json-syntax";
+import styles from "./JsonView.module.css";
+
+export interface JsonViewProps {
+  /** A JSON document (typically `JSON.stringify(value, replacer, 2)`). */
+  source: string;
+}
+
+const KIND_CLASS: Record<JsonTokenKind, string | undefined> = {
+  key: styles.key,
+  string: styles.string,
+  number: styles.number,
+  boolean: styles.boolean,
+  null: styles.null,
+  punctuation: styles.punctuation,
+  whitespace: undefined,
+};
+
+/**
+ * Render a JSON string with lightweight, theme-aware syntax colouring
+ * (#512). Pairs with the in-house {@link tokenizeJson} lexer so the
+ * admin bundle stays free of a highlighting dependency.
+ *
+ * Render-only: all lexing lives in the pure `json-syntax` module. The
+ * visible text is identical to the raw JSON — only per-token colour is
+ * added — so the `pre-wrap` scrollback keeps the pretty-printed
+ * indentation and `toContainText` assertions keep matching.
+ */
+export function JsonView({ source }: JsonViewProps) {
+  const spans = useMemo(() => {
+    let offset = 0;
+    return tokenizeJson(source).map((token) => {
+      const key = offset;
+      offset += token.text.length;
+      return (
+        <span key={key} className={KIND_CLASS[token.kind]}>
+          {token.text}
+        </span>
+      );
+    });
+  }, [source]);
+
+  return (
+    <code className={styles.json} data-testid="cli-json">
+      {spans}
+    </code>
+  );
+}

--- a/admin/app/components/shared/AppShell/AppShell.module.css
+++ b/admin/app/components/shared/AppShell/AppShell.module.css
@@ -54,6 +54,13 @@
   margin: 0 auto;
 }
 
+/* Full-bleed variant for /cli — keeps the comfortable page gutter but
+   drops the centered max-width column so the terminal and canvas can use
+   the full screen width (#512). */
+.mainFull {
+  max-width: none;
+}
+
 @media (max-width: 600px) {
   .header {
     flex-wrap: wrap;

--- a/admin/app/components/shared/AppShell/AppShell.tsx
+++ b/admin/app/components/shared/AppShell/AppShell.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { NavLink } from "react-router";
+import { NavLink, useLocation } from "react-router";
 import { ConnectionSwitcher } from "~/components/shared/ConnectionSwitcher/ConnectionSwitcher";
 import styles from "./AppShell.module.css";
 
@@ -25,6 +25,13 @@ const NAV: readonly NavEntry[] = [
 ];
 
 export function AppShell({ children }: AppShellProps) {
+  // The /cli route is a full-bleed shell terminal + canvas workspace, so
+  // it opts out of the centered max-width column the other routes use and
+  // spans the screen width instead (#512).
+  const { pathname } = useLocation();
+  const mainClassName =
+    pathname === "/cli" ? `${styles.main} ${styles.mainFull}` : styles.main;
+
   return (
     <div className={styles.shell}>
       <header className={styles.header}>
@@ -49,7 +56,7 @@ export function AppShell({ children }: AppShellProps) {
           <ConnectionSwitcher />
         </div>
       </header>
-      <main className={styles.main}>{children}</main>
+      <main className={mainClassName}>{children}</main>
     </div>
   );
 }

--- a/admin/app/lib/client/usecase/cli/cli-splitter.ts
+++ b/admin/app/lib/client/usecase/cli/cli-splitter.ts
@@ -8,11 +8,15 @@
  * PointerEvent/ResizeObserver wiring is best left to Playwright.
  */
 
-/** localStorage key used to persist the canvas's share of the row. */
+/** localStorage key used to persist the left (terminal) share of the row. */
 export const SPLITTER_STORAGE_KEY = "cli.splitRatio";
 
-/** Default canvas share (60% canvas / 40% right column). */
-export const SPLITTER_DEFAULT_RATIO = 0.6;
+/**
+ * Default left-column (terminal) share: 40% terminal / 60% canvas (#512).
+ * The canvas is the larger surface so a fresh graph has room to breathe;
+ * the terminal still gets a comfortable 40% for typing and scrollback.
+ */
+export const SPLITTER_DEFAULT_RATIO = 0.4;
 
 /** Neither pane may collapse below this many CSS pixels. */
 export const SPLITTER_MIN_PANE_PX = 360;
@@ -27,11 +31,11 @@ export const SPLITTER_NUDGE = 0.02;
 export const SPLITTER_JUMP = 0.1;
 
 /**
- * Clamp a desired canvas fraction so that neither pane shrinks below
- * {@link SPLITTER_MIN_PANE_PX}. When the container itself is too narrow to
- * honour the min size on both sides, falls back to a soft [0.1, 0.9] clamp so
- * the splitter remains usable — narrow viewports are not the primary target
- * anyway.
+ * Clamp a desired left-column (terminal) fraction so that neither pane
+ * shrinks below {@link SPLITTER_MIN_PANE_PX}. When the container itself is too
+ * narrow to honour the min size on both sides, falls back to a soft [0.1, 0.9]
+ * clamp so the splitter remains usable — narrow viewports are not the primary
+ * target anyway.
  */
 export function clampRatio(
   desired: number,

--- a/admin/app/lib/client/usecase/cli/json-syntax.test.ts
+++ b/admin/app/lib/client/usecase/cli/json-syntax.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { tokenizeJson, type JsonToken } from "./json-syntax";
+
+/** Re-join tokens; the renderer + e2e suite rely on this being lossless. */
+function rejoin(tokens: JsonToken[]): string {
+  return tokens.map((t) => t.text).join("");
+}
+
+/** Collect the text of every token of a given kind, in order. */
+function textsOf(tokens: JsonToken[], kind: JsonToken["kind"]): string[] {
+  return tokens.filter((t) => t.kind === kind).map((t) => t.text);
+}
+
+describe("tokenizeJson concatenation invariant", () => {
+  test("round-trips a pretty-printed object byte-for-byte", () => {
+    const src = JSON.stringify(
+      { key: "cli:alpha", string: "first", weight: -2.5, live: true },
+      null,
+      2,
+    );
+    expect(rejoin(tokenizeJson(src))).toBe(src);
+  });
+
+  test("round-trips nested arrays and objects", () => {
+    const src = JSON.stringify(
+      { nodes: [{ id: 1 }, { id: 2 }], edges: [], meta: null },
+      null,
+      2,
+    );
+    expect(rejoin(tokenizeJson(src))).toBe(src);
+  });
+
+  test("round-trips an empty string and whitespace-only input", () => {
+    expect(rejoin(tokenizeJson(""))).toBe("");
+    expect(rejoin(tokenizeJson("   \n\t "))).toBe("   \n\t ");
+  });
+
+  test("round-trips non-JSON input without dropping characters", () => {
+    const src = "not json @#$ <key>";
+    expect(rejoin(tokenizeJson(src))).toBe(src);
+  });
+});
+
+describe("tokenizeJson classification", () => {
+  test("distinguishes keys from string values", () => {
+    const src = '{\n  "name": "lantern"\n}';
+    const tokens = tokenizeJson(src);
+    expect(textsOf(tokens, "key")).toEqual(['"name"']);
+    expect(textsOf(tokens, "string")).toEqual(['"lantern"']);
+  });
+
+  test("a string used as an array element is not a key", () => {
+    const tokens = tokenizeJson('["a", "b"]');
+    expect(textsOf(tokens, "key")).toEqual([]);
+    expect(textsOf(tokens, "string")).toEqual(['"a"', '"b"']);
+  });
+
+  test("handles escaped quotes inside strings", () => {
+    const src = '{ "msg": "say \\"hi\\"" }';
+    const tokens = tokenizeJson(src);
+    expect(rejoin(tokens)).toBe(src);
+    expect(textsOf(tokens, "string")).toEqual(['"say \\"hi\\""']);
+    expect(textsOf(tokens, "key")).toEqual(['"msg"']);
+  });
+
+  test("classifies numbers including negative, decimal, and exponent", () => {
+    const tokens = tokenizeJson("[-2.5, 1e10, 0, 42]");
+    expect(textsOf(tokens, "number")).toEqual(["-2.5", "1e10", "0", "42"]);
+  });
+
+  test("classifies booleans and null", () => {
+    const tokens = tokenizeJson("[true, false, null]");
+    expect(textsOf(tokens, "boolean")).toEqual(["true", "false"]);
+    expect(textsOf(tokens, "null")).toEqual(["null"]);
+  });
+
+  test("emits structural punctuation tokens", () => {
+    const tokens = tokenizeJson('{"a":[1]}');
+    expect(textsOf(tokens, "punctuation")).toEqual(["{", ":", "[", "]", "}"]);
+  });
+
+  test("preserves indentation as whitespace tokens", () => {
+    const src = '{\n  "a": 1\n}';
+    const tokens = tokenizeJson(src);
+    // Two-space indent before the key is a whitespace token.
+    expect(textsOf(tokens, "whitespace")).toContain("\n  ");
+  });
+});

--- a/admin/app/lib/client/usecase/cli/json-syntax.ts
+++ b/admin/app/lib/client/usecase/cli/json-syntax.ts
@@ -1,0 +1,158 @@
+/**
+ * Tiny, dependency-free JSON tokenizer for the /cli scrollback (#512).
+ *
+ * The admin bundle deliberately carries no syntax-highlighting library,
+ * so the CLI highlights its `OK` JSON payloads with this in-house pass
+ * instead of pulling in Prism/Shiki/highlight.js. The tokenizer is total
+ * — it never throws — and is split out from its presentational component
+ * ({@link ../../../../components/cli/JsonView/JsonView}) so the lexing
+ * rules can be unit-tested under `bun:test` without a DOM.
+ *
+ * Invariant relied upon by the renderer and the e2e suite: the
+ * concatenation of every token's `text`, in order, reproduces the input
+ * byte-for-byte. That keeps Playwright `toContainText` assertions green
+ * (the visible text is unchanged; only per-token colouring is added) and
+ * means a tokenizer bug can never silently drop characters.
+ */
+
+export type JsonTokenKind =
+  | "key"
+  | "string"
+  | "number"
+  | "boolean"
+  | "null"
+  | "punctuation"
+  | "whitespace";
+
+export interface JsonToken {
+  kind: JsonTokenKind;
+  text: string;
+}
+
+function isWhitespace(ch: string): boolean {
+  return ch === " " || ch === "\n" || ch === "\t" || ch === "\r";
+}
+
+function isDigit(ch: string): boolean {
+  return ch >= "0" && ch <= "9";
+}
+
+/** Characters that may legally appear in a JSON number body after the first. */
+function isNumberPart(ch: string): boolean {
+  return (
+    isDigit(ch) ||
+    ch === "." ||
+    ch === "e" ||
+    ch === "E" ||
+    ch === "+" ||
+    ch === "-"
+  );
+}
+
+/**
+ * Lex a JSON document (typically the pretty-printed output of
+ * `JSON.stringify(value, replacer, 2)`) into colourable tokens.
+ *
+ * Object keys are distinguished from ordinary string values in a second
+ * pass: a `string` token is reclassified as a `key` when the next
+ * non-whitespace token is a `:` punctuation token. Malformed input
+ * degrades gracefully — any character that does not start a recognised
+ * token is emitted as a single-character `punctuation` token so the
+ * concatenation invariant always holds.
+ */
+export function tokenizeJson(src: string): JsonToken[] {
+  const tokens: JsonToken[] = [];
+  const n = src.length;
+  let i = 0;
+
+  while (i < n) {
+    const ch = src[i];
+
+    if (isWhitespace(ch)) {
+      let j = i + 1;
+      while (j < n && isWhitespace(src[j])) j++;
+      tokens.push({ kind: "whitespace", text: src.slice(i, j) });
+      i = j;
+      continue;
+    }
+
+    if (ch === '"') {
+      let j = i + 1;
+      while (j < n) {
+        if (src[j] === "\\") {
+          j += 2; // skip the escaped character
+          continue;
+        }
+        if (src[j] === '"') {
+          j += 1; // include the closing quote
+          break;
+        }
+        j += 1;
+      }
+      tokens.push({ kind: "string", text: src.slice(i, Math.min(j, n)) });
+      i = Math.min(j, n);
+      continue;
+    }
+
+    if (
+      ch === "{" ||
+      ch === "}" ||
+      ch === "[" ||
+      ch === "]" ||
+      ch === ":" ||
+      ch === ","
+    ) {
+      tokens.push({ kind: "punctuation", text: ch });
+      i += 1;
+      continue;
+    }
+
+    if (ch === "-" || isDigit(ch)) {
+      let j = i + 1;
+      while (j < n && isNumberPart(src[j])) j++;
+      tokens.push({ kind: "number", text: src.slice(i, j) });
+      i = j;
+      continue;
+    }
+
+    if (src.startsWith("true", i)) {
+      tokens.push({ kind: "boolean", text: "true" });
+      i += 4;
+      continue;
+    }
+    if (src.startsWith("false", i)) {
+      tokens.push({ kind: "boolean", text: "false" });
+      i += 5;
+      continue;
+    }
+    if (src.startsWith("null", i)) {
+      tokens.push({ kind: "null", text: "null" });
+      i += 4;
+      continue;
+    }
+
+    // Unrecognised character — emit it verbatim so the concatenation
+    // invariant holds even for non-JSON input.
+    tokens.push({ kind: "punctuation", text: ch });
+    i += 1;
+  }
+
+  markKeys(tokens);
+  return tokens;
+}
+
+/**
+ * Reclassify string tokens that name object members. A `string` becomes a
+ * `key` when, skipping any whitespace, the following token is `:`.
+ */
+function markKeys(tokens: JsonToken[]): void {
+  for (let k = 0; k < tokens.length; k++) {
+    if (tokens[k].kind !== "string") continue;
+    let m = k + 1;
+    while (m < tokens.length && tokens[m].kind === "whitespace") m++;
+    const next = tokens[m];
+    if (next && next.kind === "punctuation" && next.text === ":") {
+      tokens[k] = { kind: "key", text: tokens[k].text };
+    }
+  }
+}

--- a/admin/app/lib/client/usecase/cli/use-cli-splitter.ts
+++ b/admin/app/lib/client/usecase/cli/use-cli-splitter.ts
@@ -52,7 +52,7 @@ type HandleProps = AriaAttributes &
   };
 
 export interface CliSplitterApi {
-  /** The current canvas-share ratio (committed value, not the live drag). */
+  /** The current terminal-share ratio (committed value, not the live drag). */
   ratio: number;
   /** True while a pointer drag is in progress. */
   dragging: boolean;
@@ -63,8 +63,8 @@ export interface CliSplitterApi {
 /**
  * Drives the L/R splitter on the /cli page (#465).
  *
- * Writes the canvas fraction to two CSS variables on the host root —
- * `--cli-canvas-frac` and `--cli-right-frac` — so the grid layout updates
+ * Writes the terminal fraction to two CSS variables on the host root —
+ * `--cli-left-frac` and `--cli-right-frac` — so the grid layout updates
  * without re-rendering the React tree on every pointermove. Persists the
  * final ratio to localStorage under {@link SPLITTER_STORAGE_KEY}.
  *
@@ -93,7 +93,7 @@ export function useCliSplitter({
     liveRatioRef.current = ratio;
     const root = rootRef.current;
     if (!root) return;
-    root.style.setProperty("--cli-canvas-frac", `${ratio}fr`);
+    root.style.setProperty("--cli-left-frac", `${ratio}fr`);
     root.style.setProperty("--cli-right-frac", `${1 - ratio}fr`);
   }, [ratio, rootRef]);
 
@@ -154,7 +154,7 @@ export function useCliSplitter({
       const desired = (e.clientX - rect.left) / rect.width;
       const next = clampRatio(desired, rect.width);
       liveRatioRef.current = next;
-      root.style.setProperty("--cli-canvas-frac", `${next}fr`);
+      root.style.setProperty("--cli-left-frac", `${next}fr`);
       root.style.setProperty("--cli-right-frac", `${1 - next}fr`);
       e.currentTarget.setAttribute(
         "aria-valuenow",

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -106,16 +106,15 @@ test.describe("/cli", () => {
     );
   });
 
-  // #433 — Clear button empties the scrollback in place, leaving the
-  // banner. Gateway override, skipConfirm, and history are preserved.
-  test("Clear button empties the scrollback to just the banner", async ({
-    page,
-  }) => {
+  // #433 — Ctrl+L is the editor-conventional clear-screen binding and
+  // the only way to clear the scrollback now that the Clear button has
+  // been removed (#512). It empties the scrollback in place, leaving the
+  // banner, while gateway override, skipConfirm, and history survive.
+  test("Ctrl+L clears the scrollback but keeps history", async ({ page }) => {
     await page.goto("/cli");
     const input = page.getByTestId("cli-input");
-    // Initial state: only the banner entry. Clear button starts disabled.
+    // Initial state: only the banner entry.
     await expect(page.getByTestId("cli-entry-info")).toHaveCount(1);
-    await expect(page.getByTestId("cli-clear")).toBeDisabled();
     // Run a couple of commands to grow the scrollback.
     await input.fill("get vertex cli:alpha");
     await input.press("Enter");
@@ -127,32 +126,16 @@ test.describe("/cli", () => {
     await expect(page.getByTestId("cli-entry-error").last()).toContainText(
       "usage:",
     );
-    // Clear is now enabled. Click it; only the banner survives.
-    await expect(page.getByTestId("cli-clear")).toBeEnabled();
-    await page.getByTestId("cli-clear").click();
+    // Ctrl+L empties the scrollback; only the banner survives.
+    await input.focus();
+    await input.press("Control+l");
     await expect(page.getByTestId("cli-entry-ok")).toHaveCount(0);
     await expect(page.getByTestId("cli-entry-error")).toHaveCount(0);
     await expect(page.getByTestId("cli-entry-info")).toHaveCount(1);
-    await expect(page.getByTestId("cli-clear")).toBeDisabled();
     // History survives clear: arrow-up restores the last command.
     await input.focus();
     await input.press("ArrowUp");
     await expect(input).toHaveValue("nonsense");
-  });
-
-  // #433 — Ctrl+L is the editor-conventional clear-screen binding.
-  test("Ctrl+L clears the scrollback", async ({ page }) => {
-    await page.goto("/cli");
-    const input = page.getByTestId("cli-input");
-    await input.fill("get vertex cli:alpha");
-    await input.press("Enter");
-    await expect(page.getByTestId("cli-entry-ok").last()).toContainText(
-      "first",
-    );
-    await input.focus();
-    await input.press("Control+l");
-    await expect(page.getByTestId("cli-entry-ok")).toHaveCount(0);
-    await expect(page.getByTestId("cli-entry-info")).toHaveCount(1);
   });
 
   // #433 — Cancel aborts the in-flight RPC. We slow-route the Connect
@@ -205,11 +188,11 @@ test.describe("/cli", () => {
     await expect(input).toBeEnabled();
   });
 
-  // #465 — splitter L/R layout. The splitter is hidden while no graph
-  // has been rendered yet; once a graph-producing command lands, the
-  // page switches to a two-column grid with the canvas on the left,
-  // the toolbar/scrollback/input on the right, and a draggable splitter
-  // between them.
+  // #465 / #512 — splitter L/R layout. The splitter is hidden while no
+  // graph has been rendered yet; once a graph-producing command lands,
+  // the page switches to a two-column grid with the shell terminal on
+  // the left, the axis picker + canvas on the right, and a draggable
+  // splitter between them.
   test("splitter is hidden until a graph-producing command lands (#465)", async ({
     page,
   }) => {
@@ -236,18 +219,20 @@ test.describe("/cli", () => {
   }) => {
     // Playwright's `fullyParallel` runs each test in a fresh browser
     // context, so localStorage starts empty and the splitter takes
-    // the default 0.6 ratio without any explicit cleanup.
+    // the default 0.4 ratio (terminal share) without any explicit
+    // cleanup.
     await page.goto("/cli");
     const input = page.getByTestId("cli-input");
     await input.fill("get vertex cli:alpha");
     await input.press("Enter");
     const splitter = page.getByTestId("cli-splitter");
     await expect(splitter).toBeVisible();
-    // Initial aria-valuenow reflects the 60% default.
-    await expect(splitter).toHaveAttribute("aria-valuenow", "60");
-    // Drag the handle ~150px to the left and verify the ratio shrank.
-    // 150px against the ~1100px-wide root is well inside the 360px
-    // min-pane clamp on both sides.
+    // Initial aria-valuenow reflects the 40% terminal default.
+    await expect(splitter).toHaveAttribute("aria-valuenow", "40");
+    // `aria-valuenow` is the LEFT (terminal) column's share, so dragging
+    // the handle left SHRINKS the terminal. Drag ~150px left and verify
+    // the ratio dropped. 150px against the ~1100px-wide root keeps both
+    // panes inside the 360px min-pane clamp.
     const box = await splitter.boundingBox();
     if (!box) throw new Error("splitter has no bounding box");
     const startX = box.x + box.width / 2;
@@ -256,11 +241,11 @@ test.describe("/cli", () => {
     await page.mouse.down();
     await page.mouse.move(startX - 150, startY, { steps: 12 });
     await page.mouse.up();
-    // aria-valuenow should now be noticeably below 60 and well above
+    // aria-valuenow should now be noticeably below 40 and still above
     // the min-pane clamp.
     const afterDrag = Number(await splitter.getAttribute("aria-valuenow"));
-    expect(afterDrag).toBeLessThan(55);
-    expect(afterDrag).toBeGreaterThan(35);
+    expect(afterDrag).toBeLessThan(40);
+    expect(afterDrag).toBeGreaterThan(15);
     // localStorage holds the persisted value.
     const stored = await page.evaluate(() =>
       window.localStorage.getItem("cli.splitRatio"),
@@ -300,7 +285,7 @@ test.describe("/cli", () => {
     await expect(splitter).toBeVisible();
     await expect(splitter).toHaveAttribute("aria-valuenow", "45");
     await splitter.dblclick();
-    await expect(splitter).toHaveAttribute("aria-valuenow", "60");
+    await expect(splitter).toHaveAttribute("aria-valuenow", "40");
     const stored = await page.evaluate(() =>
       window.localStorage.getItem("cli.splitRatio"),
     );
@@ -341,6 +326,12 @@ test.describe("/cli", () => {
     page,
   }) => {
     await page.goto("/cli");
+    // The picker lives inside the canvas panel, so render a graph first
+    // to mount it (#512).
+    const input = page.getByTestId("cli-input");
+    await input.fill("get vertex cli:alpha");
+    await input.press("Enter");
+    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
     const picker = page.getByTestId("cli-axis-picker");
     await expect(picker).toBeVisible();
     // Defaults: step=2, k=5, algorithm=none, objective=min, weighting=raw
@@ -351,12 +342,7 @@ test.describe("/cli", () => {
     await expect(page.getByTestId("cli-axis-step")).toHaveValue("2");
     await expect(page.getByTestId("cli-axis-k")).toHaveValue("5");
     await expect(page.getByTestId("cli-axis-tfidf")).not.toBeChecked();
-    // Canvas-header hint mirrors the picker; render a graph first so
-    // the canvas panel mounts.
-    const input = page.getByTestId("cli-input");
-    await input.fill("get vertex cli:alpha");
-    await input.press("Enter");
-    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
+    // Canvas-header hint mirrors the picker.
     await expect(page.getByTestId("cli-click-hint")).toHaveText(
       "illuminate <key> 2 5",
     );
@@ -366,6 +352,12 @@ test.describe("/cli", () => {
     page,
   }) => {
     await page.goto("/cli");
+    // Render a graph first so the canvas panel — and the picker inside
+    // it — mounts (#512).
+    const input = page.getByTestId("cli-input");
+    await input.fill("get vertex cli:alpha");
+    await input.press("Enter");
+    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
     const preview = page.getByTestId("cli-axis-preview");
     await expect(preview).toHaveText("illuminate <key> 2 5");
 
@@ -395,12 +387,7 @@ test.describe("/cli", () => {
       "illuminate <key> 3 10 algorithm=spt objective=max weighting=tfidf",
     );
 
-    // Render the canvas so the header hint shows up, and verify it
-    // tracks the picker.
-    const input = page.getByTestId("cli-input");
-    await input.fill("get vertex cli:alpha");
-    await input.press("Enter");
-    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
+    // The header hint tracks the picker.
     await expect(page.getByTestId("cli-click-hint")).toHaveText(
       "illuminate <key> 3 10 algorithm=spt objective=max weighting=tfidf",
     );
@@ -408,6 +395,11 @@ test.describe("/cli", () => {
 
   test("picker state persists across a reload (#464)", async ({ page }) => {
     await page.goto("/cli");
+    // Render a graph so the picker mounts (#512).
+    const input = page.getByTestId("cli-input");
+    await input.fill("get vertex cli:alpha");
+    await input.press("Enter");
+    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
     await page.getByTestId("cli-axis-step").fill("4");
     await page.getByTestId("cli-axis-k").fill("12");
     await page.getByTestId("cli-axis-algorithm").click();
@@ -415,8 +407,12 @@ test.describe("/cli", () => {
     await expect(page.getByTestId("cli-axis-preview")).toHaveText(
       "illuminate <key> 4 12 algorithm=mst",
     );
-    // Reload — picker should hydrate from localStorage on mount.
+    // Reload — picker should hydrate from localStorage on mount. Re-run
+    // a graph command so the canvas panel (and picker) mount again.
     await page.reload();
+    await page.getByTestId("cli-input").fill("get vertex cli:alpha");
+    await page.getByTestId("cli-input").press("Enter");
+    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
     await expect(page.getByTestId("cli-axis-step")).toHaveValue("4");
     await expect(page.getByTestId("cli-axis-k")).toHaveValue("12");
     await expect(page.getByTestId("cli-axis-preview")).toHaveText(


### PR DESCRIPTION
## Summary

Redesigns the Admin SPA's `/cli` page into a single shell-style terminal
with an integrated canvas, addressing the five UX gaps raised in #512.

| # | Issue | Fix |
|---|-------|-----|
| 1 | Canvas and terminal were on the wrong sides | Terminal now on the **left**, axis picker + canvas on the **right** |
| 2 | Toolbar overflowed off-screen | Axis picker is responsive; its dropdowns shrink instead of overflowing |
| 3 | Wasted left/right whitespace | `/cli` is full-bleed (AppShell drops `max-width` via `useLocation`) |
| 4 | Form and output were separate panes | Unified into **one terminal** with a pinned bottom prompt row |
| 5 | JSON output was plain text | Syntax-highlighted via an in-house tokenizer + render-only `JsonView` |

Per the freeform direction on #512, the redesign also leans into a
"beautiful" shell aesthetic and a tighter canvas integration:

- **Faux window chrome** — traffic-light dots, a `lantern · cli` title,
  and an inline busy `Spinner` + `Cancel` while an RPC is in flight.
- **Pinned prompt** — a `❯` glyph + a native `<input>` reset to feel like
  a real shell; Enter submits, ArrowUp/ArrowDown walk history, Esc/Ctrl+L
  abort/clear via the existing window-scoped handlers.
- **Axis picker integrated into the canvas panel** — it now lives inside
  the canvas frame and only mounts once a graph is present, matching the
  "integrated with the canvas" request. The standalone **Clear button is
  removed** (Ctrl+L still clears the scrollback).

## Layout / splitter changes

- The splitter `ratio` now tracks the **terminal (left)** share. Default
  flips `0.6 → 0.4` (terminal 40% / canvas 60%), and the CSS var
  `--cli-canvas-frac` is renamed to `--cli-left-frac`. Grid columns are
  `terminal | splitter | canvas`.

## Tests

- New unit tests for the JSON tokenizer (`json-syntax.test.ts`).
- `cli.spec.ts` updated for the new layout: splitter ratios (40% default,
  drag-left shrinks the terminal), the axis picker mounting inside the
  canvas panel (graph rendered first), and Ctrl+L-driven clear (the old
  Clear-button test folded in).
- `bun run format` / `lint` / `typecheck` clean; **496** unit tests pass;
  **47** Playwright e2e specs pass (16 of them `/cli`).

Closes #512
