### PR TITLE
feat(admin): Web CLI inline terminal, canvas folding, label visibility, and focus/confirm polish

### DIFF
--- a/admin/app/components/cli/CliPage/CliPage.module.css
+++ b/admin/app/components/cli/CliPage/CliPage.module.css
@@ -170,16 +170,17 @@
   margin-left: var(--spacingHorizontalXS, 4px);
 }
 
-/* Destructive-command confirmation, rendered inside the box above the
-   prompt row. */
+/* Destructive-command confirmation, rendered inline inside the scroll
+   region just above the live prompt (#515) as a self-contained callout. */
 .confirmBar {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: var(--spacingHorizontalS, 8px);
-  flex: 0 0 auto;
+  margin: var(--spacingVerticalS, 8px) 0;
   padding: var(--spacingVerticalS, 8px) var(--spacingHorizontalM, 12px);
-  border-top: 1px solid var(--colorPaletteRedBorder2, #f1bbbb);
+  border: 1px solid var(--colorPaletteRedBorder2, #f1bbbb);
+  border-radius: var(--borderRadiusMedium, 4px);
   background: var(--colorPaletteRedBackground1, #fff5f5);
 }
 
@@ -189,16 +190,15 @@
   font-size: var(--fontSizeBase200, 12px);
 }
 
-/* The pinned prompt row — always the last line of the terminal. Hosts a
-   native <input> styled as a bare shell line for an authentic feel. */
+/* The live prompt row — an inline terminal line that flows directly after
+   the last output inside the scroll region, not a detached form (#515).
+   No frame of its own: the surrounding scrollback owns the padding. */
 .promptRow {
   display: flex;
   align-items: center;
   gap: var(--spacingHorizontalS, 8px);
-  flex: 0 0 auto;
-  padding: var(--spacingVerticalS, 8px) var(--spacingHorizontalM, 12px);
-  border-top: 1px solid var(--colorNeutralStroke2, #e0e0e0);
-  background: var(--colorNeutralBackground1, #ffffff);
+  padding: 0;
+  margin: 0;
 }
 
 .input {
@@ -216,7 +216,7 @@
     SFMono-Regular,
     monospace
   );
-  font-size: var(--fontSizeBase300, 14px);
+  font-size: var(--fontSizeBase200, 12px);
   line-height: 1.5;
 }
 
@@ -227,6 +227,22 @@
 .input:disabled {
   color: var(--colorNeutralForeground3, #707070);
   cursor: not-allowed;
+}
+
+/* Transient Tab-completion candidates, shown under the prompt when the
+   active token is ambiguous (#515). Local UI affordance only — never
+   written to the scrollback log, cleared on the next keystroke. */
+.hints {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacingVerticalXXS, 2px) var(--spacingHorizontalM, 12px);
+  padding-top: var(--spacingVerticalXS, 4px);
+  color: var(--colorNeutralForeground3, #707070);
+}
+
+.hint {
+  color: var(--colorNeutralForeground2, #424242);
+  white-space: nowrap;
 }
 
 /* ── Splitter handle ────────────────────────────────────────────────────

--- a/admin/app/components/cli/CliPage/CliPage.module.css
+++ b/admin/app/components/cli/CliPage/CliPage.module.css
@@ -170,26 +170,6 @@
   margin-left: var(--spacingHorizontalXS, 4px);
 }
 
-/* Destructive-command confirmation, rendered inline inside the scroll
-   region just above the live prompt (#515) as a self-contained callout. */
-.confirmBar {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: var(--spacingHorizontalS, 8px);
-  margin: var(--spacingVerticalS, 8px) 0;
-  padding: var(--spacingVerticalS, 8px) var(--spacingHorizontalM, 12px);
-  border: 1px solid var(--colorPaletteRedBorder2, #f1bbbb);
-  border-radius: var(--borderRadiusMedium, 4px);
-  background: var(--colorPaletteRedBackground1, #fff5f5);
-}
-
-.confirmText {
-  flex: 1 1 auto;
-  min-width: 0;
-  font-size: var(--fontSizeBase200, 12px);
-}
-
 /* The live prompt row — an inline terminal line that flows directly after
    the last output inside the scroll region, not a detached form (#515).
    No frame of its own: the surrounding scrollback owns the padding. */

--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -316,6 +316,7 @@ export function CliPage() {
                 latestResultEdgeIds={cli.latestGraph.view.latestResultEdgeIds}
                 onNodeClick={onNodeClick}
                 isBusy={cli.busy}
+                fill
               />
             </div>
           </div>

--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -76,14 +76,11 @@ export function CliPage() {
         // then either apply the sole candidate, advance to the longest
         // common prefix, or surface the ambiguous set as a hint row.
         e.preventDefault();
+        e.stopPropagation();
         const { candidates, start } = completeCommandLine(
           cli.input,
           cli.knownKeys,
         );
-        if (candidates.length === 0) {
-          setHints([]);
-          return;
-        }
         if (candidates.length === 1) {
           const value = candidates[0];
           // Option keys (`algorithm=`) keep the cursor on the value, so
@@ -91,14 +88,31 @@ export function CliPage() {
           const suffix = value.endsWith("=") ? "" : " ";
           cli.setInput(cli.input.slice(0, start) + value + suffix);
           setHints([]);
-          return;
+        } else if (candidates.length > 1) {
+          const lcp = longestCommonPrefix(candidates);
+          const active = cli.input.slice(start);
+          if (lcp.length > active.length) {
+            cli.setInput(cli.input.slice(0, start) + lcp);
+          }
+          setHints(candidates);
+        } else {
+          setHints([]);
         }
-        const lcp = longestCommonPrefix(candidates);
-        const active = cli.input.slice(start);
-        if (lcp.length > active.length) {
-          cli.setInput(cli.input.slice(0, start) + lcp);
-        }
-        setHints(candidates);
+        // Fluent's focus manager (Tabster) installs invisible
+        // `<i tabindex="0" data-tabster-dummy>` sentinels at the
+        // FluentProvider boundary and moves focus to one of them on Tab
+        // from a window/document *capture-phase* handler — which runs
+        // before this bubble-phase onKeyDown, so e.preventDefault() alone
+        // cannot keep the caret in the prompt (#519). Restore focus and
+        // the caret to the end of the input on the next frame, after
+        // Tabster has settled.
+        requestAnimationFrame(() => {
+          const node = inputRef.current;
+          if (!node) return;
+          node.focus();
+          const end = node.value.length;
+          node.setSelectionRange(end, end);
+        });
         return;
       }
       // Any other key dismisses a stale completion hint.

--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, Spinner } from "@fluentui/react-components";
+import { Button, Spinner } from "@fluentui/react-components";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { formatIlluminateClick } from "~/lib/cli/illuminate-axes";
 import { completeCommandLine, longestCommonPrefix } from "~/lib/cli/complete";
@@ -16,9 +16,9 @@ import styles from "./CliPage.module.css";
  * Go REPL via the `lib/cli/parser` TypeScript port (#411).
  *
  * This component is render-only: the stateful dispatch loop (parsing,
- * per-verb dispatch, history, destructive confirmation, cancellation,
- * graph projection) lives in the `useCli` controller hook (#494). The
- * splitter and axis-picker keep their own feature-local hooks.
+ * per-verb dispatch, history, cancellation, graph projection) lives in
+ * the `useCli` controller hook (#494). The splitter and axis-picker keep
+ * their own feature-local hooks.
  */
 export function CliPage() {
   const cli = useCli();
@@ -45,17 +45,16 @@ export function CliPage() {
   // Auto-scroll the scrollback to the bottom on every new entry so the
   // operator always sees their most recent output without chasing the
   // panel's scrollbar. The live prompt lives inside the scroll region
-  // now (#515), so a pending-confirmation change is tracked too.
+  // now (#515), so it follows the latest output.
   useEffect(() => {
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [cli.scrollback, cli.pending]);
+  }, [cli.scrollback]);
 
-  // The prompt is `disabled` while a dispatch is in flight (busy) or a
-  // destructive confirmation chip is up (pending) — that preserves the
-  // `Cancel`/busy semantics and lets the window-level Esc handler own
-  // cancellation. But the browser blurs a disabled element and never
-  // restores focus when it re-enables, so after every Enter-submitted
+  // The prompt is `disabled` while a dispatch is in flight (busy) — that
+  // preserves the `Cancel`/busy semantics and lets the window-level Esc
+  // handler own cancellation. But the browser blurs a disabled element and
+  // never restores focus when it re-enables, so after every Enter-submitted
   // command the caret would be ejected to <body> and the operator would
   // have to click back in (#520). Refocus the prompt + park the caret at
   // the end on the disabled→enabled edge. This is the Enter counterpart
@@ -63,7 +62,7 @@ export function CliPage() {
   // disabled→blur edge (not Tabster), so no rAF deferral is needed. Only
   // reclaim focus if the disable left it on <body> — respect a deliberate
   // focus move (e.g. into the axis picker) the operator made mid-command.
-  const promptDisabled = cli.busy || cli.pending !== null;
+  const promptDisabled = cli.busy;
   const wasPromptDisabled = useRef(promptDisabled);
   useEffect(() => {
     const justEnabled = wasPromptDisabled.current && !promptDisabled;
@@ -80,13 +79,12 @@ export function CliPage() {
 
   // Click-to-illuminate (#439, #464). Writes the picker-formatted
   // illuminate command into the prompt and submits it through the same
-  // parser path the user would hit by typing it. Illuminate is
-  // non-destructive, so the confirmation chip never fires here. With the
-  // picker at its defaults the formatter emits the canonical short form
+  // parser path the user would hit by typing it. With the picker at its
+  // defaults the formatter emits the canonical short form
   // `illuminate <key> 2 5` (regression guard).
   const onNodeClick = useCallback(
     (key: string) => {
-      if (cli.busy || cli.pending !== null) return;
+      if (cli.busy) return;
       cli.runRaw(formatIlluminateClick(key, axisPicker.axes));
     },
     [cli, axisPicker.axes],
@@ -237,37 +235,6 @@ export function CliPage() {
         >
           {renderedScrollback}
 
-          {cli.pending !== null ? (
-            <div className={styles.confirmBar} data-testid="cli-confirm">
-              <span className={styles.confirmText}>
-                About to run: <code>{cli.pending.rendered}</code> — this mutates
-                server state.
-              </span>
-              <Checkbox
-                label="Do not ask again this session"
-                checked={cli.skipConfirm}
-                onChange={(_e, data) =>
-                  cli.setSkipConfirm(Boolean(data.checked))
-                }
-                data-testid="cli-skip-confirm"
-              />
-              <Button
-                appearance="secondary"
-                onClick={cli.confirmCancel}
-                data-testid="cli-confirm-cancel"
-              >
-                Cancel
-              </Button>
-              <Button
-                appearance="primary"
-                onClick={cli.confirmRun}
-                data-testid="cli-confirm-run"
-              >
-                Run
-              </Button>
-            </div>
-          ) : null}
-
           {/* Live prompt — an inline terminal line that scrolls with the
               output, not a detached form (#515). Always rendered so the
               `cli-input` testid and disabled-while-busy semantics hold. */}
@@ -329,7 +296,7 @@ export function CliPage() {
               <CliAxisPicker
                 axes={axisPicker.axes}
                 setAxis={axisPicker.setAxis}
-                disabled={cli.busy || cli.pending !== null}
+                disabled={cli.busy}
               />
             </div>
             <div className={styles.canvasMeta}>

--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -1,6 +1,7 @@
 import { Button, Checkbox, Spinner } from "@fluentui/react-components";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { formatIlluminateClick } from "~/lib/cli/illuminate-axes";
+import { completeCommandLine, longestCommonPrefix } from "~/lib/cli/complete";
 import { useCli } from "~/lib/client/usecase/cli/use-cli";
 import { useCliSplitter } from "~/lib/client/usecase/cli/use-cli-splitter";
 import { useCliAxisPicker } from "~/lib/client/usecase/cli/use-cli-axis-picker";
@@ -22,6 +23,11 @@ import styles from "./CliPage.module.css";
 export function CliPage() {
   const cli = useCli();
   const scrollRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  // Tab-completion candidates surfaced under the prompt when the active
+  // token is ambiguous (#515). Local UI state only — never written to the
+  // scrollback log, so it behaves like a shell's transient completion row.
+  const [hints, setHints] = useState<string[]>([]);
   // Drives the two-column grid + draggable splitter (#465). Only active
   // when a graph is present; otherwise the right column owns the full
   // width and the splitter handle is hidden by CSS.
@@ -38,11 +44,12 @@ export function CliPage() {
 
   // Auto-scroll the scrollback to the bottom on every new entry so the
   // operator always sees their most recent output without chasing the
-  // panel's scrollbar.
+  // panel's scrollbar. The live prompt lives inside the scroll region
+  // now (#515), so a pending-confirmation change is tracked too.
   useEffect(() => {
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [cli.scrollback]);
+  }, [cli.scrollback, cli.pending]);
 
   // Click-to-illuminate (#439, #464). Writes the picker-formatted
   // illuminate command into the prompt and submits it through the same
@@ -64,6 +71,38 @@ export function CliPage() {
       // so they work even while the input is `disabled` (busy state) or
       // without focus. Enter / ArrowUp / ArrowDown stay local because
       // they read and write input state.
+      if (e.key === "Tab") {
+        // Terminal-style completion (#515). Resolve the active token,
+        // then either apply the sole candidate, advance to the longest
+        // common prefix, or surface the ambiguous set as a hint row.
+        e.preventDefault();
+        const { candidates, start } = completeCommandLine(
+          cli.input,
+          cli.knownKeys,
+        );
+        if (candidates.length === 0) {
+          setHints([]);
+          return;
+        }
+        if (candidates.length === 1) {
+          const value = candidates[0];
+          // Option keys (`algorithm=`) keep the cursor on the value, so
+          // no trailing space; completed words advance to the next slot.
+          const suffix = value.endsWith("=") ? "" : " ";
+          cli.setInput(cli.input.slice(0, start) + value + suffix);
+          setHints([]);
+          return;
+        }
+        const lcp = longestCommonPrefix(candidates);
+        const active = cli.input.slice(start);
+        if (lcp.length > active.length) {
+          cli.setInput(cli.input.slice(0, start) + lcp);
+        }
+        setHints(candidates);
+        return;
+      }
+      // Any other key dismisses a stale completion hint.
+      setHints([]);
       if (e.key === "Enter") {
         e.preventDefault();
         cli.submit();
@@ -148,57 +187,82 @@ export function CliPage() {
           ref={scrollRef}
           aria-live="polite"
           data-testid="cli-scrollback"
+          onClick={(e) => {
+            // Click empty terminal space to focus the prompt (like a real
+            // terminal). Guarded so clicking/selecting output text or a
+            // control inside the scroll region never steals the caret.
+            if (e.target === e.currentTarget) inputRef.current?.focus();
+          }}
         >
           {renderedScrollback}
-        </div>
 
-        {cli.pending !== null ? (
-          <div className={styles.confirmBar} data-testid="cli-confirm">
-            <span className={styles.confirmText}>
-              About to run: <code>{cli.pending.rendered}</code> — this mutates
-              server state.
+          {cli.pending !== null ? (
+            <div className={styles.confirmBar} data-testid="cli-confirm">
+              <span className={styles.confirmText}>
+                About to run: <code>{cli.pending.rendered}</code> — this mutates
+                server state.
+              </span>
+              <Checkbox
+                label="Do not ask again this session"
+                checked={cli.skipConfirm}
+                onChange={(_e, data) =>
+                  cli.setSkipConfirm(Boolean(data.checked))
+                }
+                data-testid="cli-skip-confirm"
+              />
+              <Button
+                appearance="secondary"
+                onClick={cli.confirmCancel}
+                data-testid="cli-confirm-cancel"
+              >
+                Cancel
+              </Button>
+              <Button
+                appearance="primary"
+                onClick={cli.confirmRun}
+                data-testid="cli-confirm-run"
+              >
+                Run
+              </Button>
+            </div>
+          ) : null}
+
+          {/* Live prompt — an inline terminal line that scrolls with the
+              output, not a detached form (#515). Always rendered so the
+              `cli-input` testid and disabled-while-busy semantics hold. */}
+          <div className={styles.promptRow}>
+            <span className={styles.prompt} aria-hidden="true">
+              ❯
             </span>
-            <Checkbox
-              label="Do not ask again this session"
-              checked={cli.skipConfirm}
-              onChange={(_e, data) => cli.setSkipConfirm(Boolean(data.checked))}
-              data-testid="cli-skip-confirm"
+            <input
+              ref={inputRef}
+              className={styles.input}
+              value={cli.input}
+              onChange={(e) => {
+                setHints([]);
+                cli.setInput(e.target.value);
+              }}
+              onKeyDown={onKeyDown}
+              placeholder="get vertex alice    |    illuminate alice 2 5 algorithm=spt"
+              disabled={cli.busy || cli.pending !== null}
+              data-testid="cli-input"
+              aria-label="CLI command input"
+              autoComplete="off"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
             />
-            <Button
-              appearance="secondary"
-              onClick={cli.confirmCancel}
-              data-testid="cli-confirm-cancel"
-            >
-              Cancel
-            </Button>
-            <Button
-              appearance="primary"
-              onClick={cli.confirmRun}
-              data-testid="cli-confirm-run"
-            >
-              Run
-            </Button>
           </div>
-        ) : null}
 
-        <div className={styles.promptRow}>
-          <span className={styles.prompt} aria-hidden="true">
-            ❯
-          </span>
-          <input
-            className={styles.input}
-            value={cli.input}
-            onChange={(e) => cli.setInput(e.target.value)}
-            onKeyDown={onKeyDown}
-            placeholder="get vertex alice    |    illuminate alice 2 5 algorithm=spt"
-            disabled={cli.busy || cli.pending !== null}
-            data-testid="cli-input"
-            aria-label="CLI command input"
-            autoComplete="off"
-            autoCapitalize="off"
-            autoCorrect="off"
-            spellCheck={false}
-          />
+          {hints.length > 0 ? (
+            <div className={styles.hints} data-testid="cli-hints">
+              {hints.map((hint) => (
+                <span key={hint} className={styles.hint}>
+                  {hint}
+                </span>
+              ))}
+            </div>
+          ) : null}
         </div>
       </section>
 

--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -51,6 +51,33 @@ export function CliPage() {
     if (el) el.scrollTop = el.scrollHeight;
   }, [cli.scrollback, cli.pending]);
 
+  // The prompt is `disabled` while a dispatch is in flight (busy) or a
+  // destructive confirmation chip is up (pending) — that preserves the
+  // `Cancel`/busy semantics and lets the window-level Esc handler own
+  // cancellation. But the browser blurs a disabled element and never
+  // restores focus when it re-enables, so after every Enter-submitted
+  // command the caret would be ejected to <body> and the operator would
+  // have to click back in (#520). Refocus the prompt + park the caret at
+  // the end on the disabled→enabled edge. This is the Enter counterpart
+  // to the Tab refocus in `onKeyDown` (#519); here the cause is the
+  // disabled→blur edge (not Tabster), so no rAF deferral is needed. Only
+  // reclaim focus if the disable left it on <body> — respect a deliberate
+  // focus move (e.g. into the axis picker) the operator made mid-command.
+  const promptDisabled = cli.busy || cli.pending !== null;
+  const wasPromptDisabled = useRef(promptDisabled);
+  useEffect(() => {
+    const justEnabled = wasPromptDisabled.current && !promptDisabled;
+    wasPromptDisabled.current = promptDisabled;
+    if (!justEnabled) return;
+    const active = document.activeElement;
+    if (active !== null && active !== document.body) return;
+    const node = inputRef.current;
+    if (!node) return;
+    node.focus();
+    const end = node.value.length;
+    node.setSelectionRange(end, end);
+  }, [promptDisabled]);
+
   // Click-to-illuminate (#439, #464). Writes the picker-formatted
   // illuminate command into the prompt and submits it through the same
   // parser path the user would hit by typing it. Illuminate is
@@ -258,7 +285,7 @@ export function CliPage() {
               }}
               onKeyDown={onKeyDown}
               placeholder="get vertex alice    |    illuminate alice 2 5 algorithm=spt"
-              disabled={cli.busy || cli.pending !== null}
+              disabled={promptDisabled}
               data-testid="cli-input"
               aria-label="CLI command input"
               autoComplete="off"

--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.module.css
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.module.css
@@ -9,6 +9,19 @@
   overflow: hidden;
 }
 
+/* #516: when embedded in a height-constrained, overflow:hidden panel
+   (the /cli split view), fill the parent exactly instead of imposing the
+   standalone 70vh/min-height sizing — otherwise the fixed-height wrapper
+   overflows its container and clips the bottom-left hop-distance legend
+   on short viewports. */
+.fill {
+  position: absolute;
+  inset: 0;
+  width: auto;
+  height: auto;
+  min-height: 0;
+}
+
 .busy {
   opacity: 0.65;
   transition: opacity 120ms ease-out;
@@ -175,4 +188,71 @@
   margin-left: auto;
   color: var(--colorNeutralForeground3, #707070);
   font-variant-numeric: tabular-nums;
+}
+
+/* #517: on-canvas label-visibility toggles. Top-right corner so they
+   don't collide with the bottom-left legend, the centred empty-state
+   overlay, or the pointer-tracked tooltip. The cluster ignores pointer
+   events; only the buttons capture them. */
+.labelControls {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 3;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-end;
+}
+
+.labelToggle {
+  pointer-events: auto;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 9px;
+  border-radius: var(--borderRadiusCircular, 9999px);
+  border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  background: var(--colorNeutralBackground1, #fff);
+  color: var(--colorNeutralForeground2, #424242);
+  font-family: var(--fontFamilyBase, system-ui, sans-serif);
+  font-size: var(--fontSizeBase200, 12px);
+  box-shadow: var(--shadow4, 0 1px 4px rgba(0, 0, 0, 0.08));
+}
+
+/* A leading dot conveys on/off state at a glance, redundant with the
+   active styling and the aria-pressed state exposed to assistive tech. */
+.labelToggle::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--colorNeutralForeground4, #bdbdbd);
+}
+
+.labelToggle[aria-pressed="true"] {
+  background: var(--colorBrandBackground, #0f6cbd);
+  border-color: var(--colorBrandBackground, #0f6cbd);
+  color: var(--colorNeutralForegroundOnBrand, #fff);
+}
+
+.labelToggle[aria-pressed="true"]::before {
+  background: var(--colorNeutralForegroundOnBrand, #fff);
+}
+
+.labelToggle:hover {
+  border-color: var(--colorNeutralStroke1, #d1d1d1);
+}
+
+.labelToggle[aria-pressed="true"]:hover {
+  background: var(--colorBrandBackgroundHover, #115ea3);
+  border-color: var(--colorBrandBackgroundHover, #115ea3);
+}
+
+.labelToggle:focus-visible {
+  outline: 2px solid var(--colorStrokeFocus2, #000);
+  outline-offset: 1px;
 }

--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -30,9 +30,10 @@ import {
 } from "~/lib/client/usecase/illuminate/force-layout";
 import { useIlluminateCanvas } from "~/lib/client/usecase/illuminate/use-illuminate-canvas";
 import { usePreferredTheme } from "~/lib/client/usecase/theme/use-preferred-theme";
-import { formatEdgeWeight } from "./edge-label";
+import { formatEdgeWeight, makeDrawEdgeLabel } from "./edge-label";
 import { HOP_FAR_THRESHOLD, colorForHop, describeHop } from "./hop-palette";
 import { makeDrawNodeHover } from "./hover-label";
+import { makeDrawNodeLabel } from "./node-label";
 import {
   EDGE_LABEL_SIZE,
   EDGE_LABEL_WEIGHT,
@@ -163,6 +164,15 @@ const INFO_ICON_OFFSET_Y = 18;
  */
 const DEFAULT_NODE_SIZE = 7;
 const SEED_NODE_SIZE = 16;
+
+/**
+ * #514 camera re-frame duration (ms). After a click-to-expand or a fresh
+ * seed reshapes the rendered subgraph, the reconcile effect animates the
+ * camera back to its default framing over this window so the new result
+ * is centred and zoomed to fit. Long enough to read as a smooth glide,
+ * short enough not to lag the layout ease that runs alongside it.
+ */
+const CAMERA_FIT_MS = 500;
 
 /**
  * Hosts a `graphology` graph and a `sigma` renderer. The component owns
@@ -429,7 +439,11 @@ export function IlluminateCanvas({
       renderLabels: true,
       labelDensity: 0.5,
       labelGridCellSize: 80,
-      labelRenderedSizeThreshold: 8,
+      // #514: every node carries `forceLabel: true` (set in the reconcile
+      // loop) so the key is always drawn; drop the size threshold to 0 so
+      // the default-sized discs (size 7 < the old 8px gate) are never
+      // culled even on the rare frame before `forceLabel` is applied.
+      labelRenderedSizeThreshold: 0,
       defaultEdgeColor: FALLBACK_PALETTE.edge,
       defaultNodeColor: FALLBACK_PALETTE.baseNode,
       // === #485 directed-edge arrowheads ================================
@@ -450,6 +464,16 @@ export function IlluminateCanvas({
       labelSize: LABEL_SIZE,
       labelWeight: LABEL_WEIGHT,
       labelFont: FALLBACK_PALETTE.labelFont,
+      // === #514 always-on, readable node-key labels =====================
+      // Sigma's built-in `drawDiscNodeLabel` paints the key as bare text
+      // with no background, so a key over a same-luminance disc or a busy
+      // patch of canvas was hard to read. Swap in a palette-skinned
+      // renderer that draws an opaque chip behind every key (same contrast
+      // story as the hover chip). Combined with per-node `forceLabel` in
+      // the reconcile loop, every vertex key is now always visible and
+      // legible. The palette effect re-applies this on a theme flip.
+      defaultDrawNodeLabel: makeDrawNodeLabel(FALLBACK_PALETTE),
+      // === end #514 =====================================================
       // === #500 on-edge weight labels ===================================
       // Render each edge's accumulated weight as a label along the edge
       // body. The per-edge text is stamped in the reconcile loop
@@ -461,6 +485,11 @@ export function IlluminateCanvas({
       edgeLabelSize: EDGE_LABEL_SIZE,
       edgeLabelWeight: EDGE_LABEL_WEIGHT,
       edgeLabelFont: FALLBACK_PALETTE.labelFont,
+      // #514: skin the weight label the same way as the node key — an
+      // opaque chip behind the text, drawn for every edge (sigma's default
+      // skips short edges), so the weight never collides with the edge
+      // line or the discs underneath. Re-applied on a theme flip below.
+      defaultDrawEdgeLabel: makeDrawEdgeLabel(FALLBACK_PALETTE),
       // === end #500 =====================================================
       // === #484 theme-aware hover label =================================
       // Sigma's default `drawDiscNodeHover` paints a hard-coded near-white
@@ -1144,6 +1173,11 @@ export function IlluminateCanvas({
     // #484: rebuild the hover renderer against the new palette so the
     // hovered-label chip follows the theme alongside the label text.
     sigma.setSetting("defaultDrawNodeHover", makeDrawNodeHover(palette));
+    // #514: rebuild the always-on node-key and edge-weight renderers
+    // against the new palette so their chips follow the theme too,
+    // mirroring the hover renderer above.
+    sigma.setSetting("defaultDrawNodeLabel", makeDrawNodeLabel(palette));
+    sigma.setSetting("defaultDrawEdgeLabel", makeDrawEdgeLabel(palette));
     for (const id of graph.nodes()) {
       const attrs = graph.getNodeAttributes(id) as {
         hopDistance?: number;
@@ -1303,6 +1337,9 @@ export function IlluminateCanvas({
       if (graph.hasNode(node.id)) {
         graph.mergeNodeAttributes(node.id, {
           label: node.label,
+          // #514: force the key label so it is never culled by label
+          // density/grid selection — every vertex key is always visible.
+          forceLabel: true,
           size,
           color,
           detail,
@@ -1329,6 +1366,8 @@ export function IlluminateCanvas({
         });
         graph.addNode(node.id, {
           label: node.label,
+          // #514: force the key label (see the merge branch above).
+          forceLabel: true,
           x,
           y,
           size,
@@ -1357,6 +1396,8 @@ export function IlluminateCanvas({
           size: 1 + Math.min(4, edge.weight),
           // #500: render the accumulated weight on the edge itself.
           label: formatEdgeWeight(edge.weight),
+          // #514: force the weight label so it is always drawn.
+          forceLabel: true,
           detail: `weight = ${edge.weight}`,
           expiration,
         });
@@ -1366,6 +1407,8 @@ export function IlluminateCanvas({
           color: palette.edge,
           // #500: render the accumulated weight on the edge itself.
           label: formatEdgeWeight(edge.weight),
+          // #514: force the weight label (see the merge branch above).
+          forceLabel: true,
           detail: `weight = ${edge.weight}`,
           expiration,
         });
@@ -1432,6 +1475,25 @@ export function IlluminateCanvas({
       sigma?.refresh();
     }
     // === end #483 ======================================================
+
+    // === #514 re-frame the camera on the latest subgraph ===============
+    // After a structural change (click-to-expand or a fresh seed) glide
+    // the camera back to its default framing so the new result is centred
+    // and zoomed to fit. `animatedReset` returns the camera to its default
+    // (x:0.5, y:0.5, ratio:1); with sigma's autoRescale + autoCenter that
+    // frames the whole rendered graph. Gated on the structural regimes +
+    // a non-empty result so a TTL tick, theme flip, or hover ("static",
+    // or an empty Clear) never yanks the viewport. For `cold` the layout
+    // has already settled synchronously; for `incremental` autoRescale
+    // re-normalises every eased frame, so resetting to the default still
+    // frames the whole graph as it relaxes.
+    if (
+      (regime === "cold" || regime === "incremental") &&
+      forceNodes.length > 0
+    ) {
+      void sigma?.getCamera().animatedReset({ duration: CAMERA_FIT_MS });
+    }
+    // === end #514 ======================================================
 
     previousNodeIdsRef.current = nextNodeIds;
     previousEdgeIdsRef.current = nextEdgeIds;

--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -90,6 +90,15 @@ export interface IlluminateCanvasProps {
   /** When true, the canvas dims to communicate a stale frame. */
   isBusy: boolean;
   /**
+   * #516: fill the parent container (absolute `inset: 0`) instead of
+   * imposing the standalone `70vh`/`min-height` sizing. The `/cli` split
+   * view embeds the canvas in a height-constrained, `overflow: hidden`
+   * panel; without this the fixed-height wrapper overflows the panel and
+   * clips the bottom-left hop-distance legend on short viewports.
+   * `/illuminate` leaves it unset and keeps the `70vh` sizing.
+   */
+  fill?: boolean;
+  /**
    * Imperative handle (#456). The expansion chip strip calls
    * `panToNode(originKey)` to scroll the camera to a previous click
    * point without mutating state or refetching. Optional — keeps the
@@ -190,6 +199,7 @@ export function IlluminateCanvas({
   onNodeClick,
   onNodeInspect,
   isBusy,
+  fill = false,
   ref,
 }: IlluminateCanvasProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -270,6 +280,15 @@ export function IlluminateCanvas({
    * inspects.
    */
   const infoIconPointerDownRef = useRef<{ x: number; y: number } | null>(null);
+  /**
+   * #517: label-visibility toggles. Both default on. These drive sigma's
+   * `renderLabels` / `renderEdgeLabels` settings, which gate ALL node /
+   * edge labels regardless of any per-element `forceLabel`, so flipping
+   * them is the clean way to hide one label class without touching the
+   * graphology label attributes (which the test bridge still reads).
+   */
+  const [showNodeLabels, setShowNodeLabels] = useState(true);
+  const [showEdgeLabels, setShowEdgeLabels] = useState(true);
   const [palette, setPalette] = useState<SigmaPalette>(FALLBACK_PALETTE);
   // The mount effect runs ONCE, so any palette swatch read inside the
   // hover-focus reducer (#458) needs a ref so it tracks the latest
@@ -288,6 +307,23 @@ export function IlluminateCanvas({
     if (!containerRef.current) return;
     setPalette(resolvePalette(containerRef.current));
   }, [theme]);
+
+  // #517: keep sigma's label-visibility settings in lockstep with the
+  // toggles. The canvas mounts once and survives data updates, so these
+  // small effects are the single writers of these two settings (the
+  // palette effect never touches them). `refresh()` repaints immediately.
+  useEffect(() => {
+    const sigma = sigmaRef.current;
+    if (!sigma) return;
+    sigma.setSetting("renderLabels", showNodeLabels);
+    sigma.refresh();
+  }, [showNodeLabels]);
+  useEffect(() => {
+    const sigma = sigmaRef.current;
+    if (!sigma) return;
+    sigma.setSetting("renderEdgeLabels", showEdgeLabels);
+    sigma.refresh();
+  }, [showEdgeLabels]);
 
   const pickFill = useCallback(
     // #460/#500: every node (including the pinned seed) draws from the
@@ -983,6 +1019,12 @@ export function IlluminateCanvas({
          * auto-run animation to converge.
          */
         layoutRunning: () => boolean;
+        /**
+         * #517 test bridge: the live label-visibility settings the two
+         * on-canvas toggles drive. Reads `renderer.getSetting(...)` so it
+         * reflects the current sigma state, not the mount-time closure.
+         */
+        getLabelVisibility: () => { vertex: boolean; edge: boolean };
       };
     };
     win.__illuminateCanvas = {
@@ -1120,6 +1162,10 @@ export function IlluminateCanvas({
       stepLayout: (ticks: number) => stepLayout(ticks),
       settleLayout: (maxTicks?: number) => settleLayout(maxTicks),
       layoutRunning: () => layoutRef.current?.raf != null,
+      getLabelVisibility: () => ({
+        vertex: renderer.getSetting("renderLabels"),
+        edge: renderer.getSetting("renderEdgeLabels"),
+      }),
     };
 
     return () => {
@@ -1513,8 +1559,11 @@ export function IlluminateCanvas({
 
   const empty = nodes.length === 0;
   const wrapperClass = useMemo(
-    () => [styles.wrapper, isBusy ? styles.busy : ""].filter(Boolean).join(" "),
-    [isBusy],
+    () =>
+      [styles.wrapper, fill ? styles.fill : "", isBusy ? styles.busy : ""]
+        .filter(Boolean)
+        .join(" "),
+    [fill, isBusy],
   );
 
   // #460: hop-distance legend buckets. Recomputed whenever the
@@ -1594,6 +1643,33 @@ export function IlluminateCanvas({
               <span className={styles.legendCount}>{b.count}</span>
             </div>
           ))}
+        </div>
+      ) : null}
+      {!empty ? (
+        <div
+          className={styles.labelControls}
+          data-testid="illuminate-label-controls"
+        >
+          <button
+            type="button"
+            className={styles.labelToggle}
+            data-testid="illuminate-toggle-node-labels"
+            aria-pressed={showNodeLabels}
+            title={showNodeLabels ? "Hide vertex labels" : "Show vertex labels"}
+            onClick={() => setShowNodeLabels((v) => !v)}
+          >
+            vertex labels
+          </button>
+          <button
+            type="button"
+            className={styles.labelToggle}
+            data-testid="illuminate-toggle-edge-labels"
+            aria-pressed={showEdgeLabels}
+            title={showEdgeLabels ? "Hide edge labels" : "Show edge labels"}
+            onClick={() => setShowEdgeLabels((v) => !v)}
+          >
+            edge labels
+          </button>
         </div>
       ) : null}
       {hover ? (

--- a/admin/app/components/illuminate/IlluminateCanvas/edge-label.test.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/edge-label.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
-import { formatEdgeWeight } from "./edge-label";
+import { formatEdgeWeight, makeDrawEdgeLabel } from "./edge-label";
+import { FALLBACK_PALETTE, type SigmaPalette } from "./palette";
 
 describe("formatEdgeWeight", () => {
   test("renders a whole number without a decimal point", () => {
@@ -22,5 +23,184 @@ describe("formatEdgeWeight", () => {
   test("returns an empty string for non-finite input", () => {
     expect(formatEdgeWeight(Number.NaN)).toBe("");
     expect(formatEdgeWeight(Number.POSITIVE_INFINITY)).toBe("");
+  });
+});
+
+/**
+ * Unit coverage for the always-on edge-label renderer (#514). Like the
+ * node renderer it is pure 2D-canvas drawing, so we drive it with a fake
+ * `CanvasRenderingContext2D` that records each drawing call together with
+ * the active style at the moment of the call — plus `save`/`restore`/
+ * `translate`/`rotate`, which the edge renderer uses to draw the weight
+ * rotated along the edge.
+ */
+interface RecordedOp {
+  op: string;
+  fillStyle: string;
+  strokeStyle: string;
+  lineWidth: number;
+  args: unknown[];
+}
+
+function makeFakeContext(textWidth = 20) {
+  const ops: RecordedOp[] = [];
+  const state = {
+    font: "",
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 0,
+    shadowOffsetX: 0,
+    shadowOffsetY: 0,
+    shadowBlur: 0,
+  };
+  const record = (op: string, args: unknown[] = []) =>
+    ops.push({
+      op,
+      fillStyle: state.fillStyle,
+      strokeStyle: state.strokeStyle,
+      lineWidth: state.lineWidth,
+      args,
+    });
+
+  const ctx = {
+    get font() {
+      return state.font;
+    },
+    set font(v: string) {
+      state.font = v;
+    },
+    get fillStyle() {
+      return state.fillStyle;
+    },
+    set fillStyle(v: string) {
+      state.fillStyle = v;
+    },
+    get strokeStyle() {
+      return state.strokeStyle;
+    },
+    set strokeStyle(v: string) {
+      state.strokeStyle = v;
+    },
+    get lineWidth() {
+      return state.lineWidth;
+    },
+    set lineWidth(v: number) {
+      state.lineWidth = v;
+    },
+    get shadowOffsetX() {
+      return state.shadowOffsetX;
+    },
+    set shadowOffsetX(v: number) {
+      state.shadowOffsetX = v;
+    },
+    get shadowOffsetY() {
+      return state.shadowOffsetY;
+    },
+    set shadowOffsetY(v: number) {
+      state.shadowOffsetY = v;
+    },
+    get shadowBlur() {
+      return state.shadowBlur;
+    },
+    set shadowBlur(v: number) {
+      state.shadowBlur = v;
+    },
+    measureText: (_t: string) => ({ width: textWidth }),
+    save: () => record("save"),
+    restore: () => record("restore"),
+    translate: (...a: number[]) => record("translate", a),
+    rotate: (...a: number[]) => record("rotate", a),
+    beginPath: () => record("beginPath"),
+    moveTo: (...a: number[]) => record("moveTo", a),
+    lineTo: (...a: number[]) => record("lineTo", a),
+    closePath: () => record("closePath"),
+    fill: () => record("fill"),
+    stroke: () => record("stroke"),
+    fillText: (...a: unknown[]) => record("fillText", a),
+  };
+
+  return { ctx, ops, state };
+}
+
+const EDGE_SETTINGS = {
+  edgeLabelSize: 11,
+  edgeLabelFont: "system-ui, sans-serif",
+  edgeLabelWeight: "600",
+};
+
+const PALETTE: SigmaPalette = {
+  ...FALLBACK_PALETTE,
+  labelBackground: "#101010",
+  labelStroke: "#808080",
+  labelText: "#fafafa",
+};
+
+function drawEdge(
+  data: { label?: string },
+  sourceData: { x: number; y: number; size: number },
+  targetData: { x: number; y: number; size: number },
+  textWidth = 20,
+) {
+  const fake = makeFakeContext(textWidth);
+  const fn = makeDrawEdgeLabel(PALETTE);
+  type Args = Parameters<ReturnType<typeof makeDrawEdgeLabel>>;
+  fn(
+    fake.ctx as unknown as CanvasRenderingContext2D,
+    data as unknown as Args[1],
+    sourceData as unknown as Args[2],
+    targetData as unknown as Args[3],
+    EDGE_SETTINGS as unknown as Args[4],
+  );
+  return fake;
+}
+
+describe("makeDrawEdgeLabel", () => {
+  const SRC = { x: 0, y: 0, size: 7 };
+  const TGT = { x: 100, y: 0, size: 7 };
+
+  test("fills the weight chip with labelBackground", () => {
+    const { ops } = drawEdge({ label: "3" }, SRC, TGT);
+    const fill = ops.find((o) => o.op === "fill");
+    expect(fill?.fillStyle).toBe(PALETTE.labelBackground);
+  });
+
+  test("outlines the chip with a 1px labelStroke border", () => {
+    const { ops } = drawEdge({ label: "3" }, SRC, TGT);
+    const stroke = ops.find((o) => o.op === "stroke");
+    expect(stroke?.strokeStyle).toBe(PALETTE.labelStroke);
+    expect(stroke?.lineWidth).toBe(1);
+  });
+
+  test("draws the weight in labelText so it contrasts with the chip", () => {
+    const { ops } = drawEdge({ label: "3" }, SRC, TGT);
+    const text = ops.find((o) => o.op === "fillText");
+    expect(text?.fillStyle).toBe(PALETTE.labelText);
+    expect(text?.fillStyle).not.toBe(PALETTE.labelBackground);
+    expect((text?.args ?? [])[0]).toBe("3");
+  });
+
+  test("centres on the edge midpoint and rotates within a hairpin frame", () => {
+    const { ops } = drawEdge({ label: "3" }, SRC, TGT);
+    const translate = ops.find((o) => o.op === "translate");
+    // Midpoint of (0,0)→(100,0) is (50,0).
+    expect(translate?.args).toEqual([50, 0]);
+    const rotate = ops.find((o) => o.op === "rotate");
+    const a = (rotate?.args ?? [])[0] as number;
+    expect(Math.abs(a)).toBeLessThanOrEqual(Math.PI / 2 + 1e-9);
+    // Save/restore must bracket the draw so the rotation never leaks.
+    expect(ops[0]?.op).toBe("save");
+    expect(ops[ops.length - 1]?.op).toBe("restore");
+  });
+
+  test("draws short edges too (no length-based skip)", () => {
+    // Source and target almost coincident — sigma's default renderer
+    // would skip this; #514's renderer must still show the weight.
+    const { ops } = drawEdge({ label: "9" }, SRC, { x: 1, y: 0, size: 7 });
+    expect(ops.some((o) => o.op === "fillText")).toBe(true);
+  });
+
+  test("draws nothing when the edge has no label", () => {
+    const { ops } = drawEdge({}, SRC, TGT);
+    expect(ops).toHaveLength(0);
   });
 });

--- a/admin/app/components/illuminate/IlluminateCanvas/edge-label.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/edge-label.ts
@@ -1,5 +1,6 @@
 /**
- * Edge-weight label formatting for the Illuminate canvas (#500).
+ * Edge-weight label formatting + the always-on edge-label renderer for
+ * the Illuminate canvas (#500, #514).
  *
  * The canvas renders each edge's accumulated weight as an on-edge label
  * (`renderEdgeLabels`). Weights are additive `float32` decay counters, so
@@ -14,9 +15,95 @@
  * `hop-palette` / `ttl-decay` modules) so it is unit-testable without a
  * DOM or a live sigma instance.
  */
+
+import type { EdgeLabelDrawingFunction } from "sigma/rendering";
+
+import type { SigmaPalette } from "./palette";
+
 export function formatEdgeWeight(weight: number): string {
   if (!Number.isFinite(weight)) {
     return "";
   }
   return Number.isInteger(weight) ? String(weight) : weight.toFixed(1);
+}
+
+/** Horizontal inner padding (canvas px) between the text and the chip edge. */
+const PADDING_X = 4;
+/** Vertical inner padding (canvas px) between the text and the chip edge. */
+const PADDING_Y = 2;
+
+/**
+ * Build an `EdgeLabelDrawingFunction` that paints every edge's weight as a
+ * palette-skinned chip centred on the edge (#514).
+ *
+ * Sigma's built-in `drawStraightEdgeLabel` draws the weight as bare text
+ * with NO background and *skips short edges entirely* (`d < sSize + size`),
+ * so on a dense illuminate subgraph many weights either vanished or
+ * collided with the edge line and the node discs underneath — the "Weight
+ * が背景色とかぶって見えにくい" half of #514. This renderer instead:
+ *
+ *   - draws an opaque chip (filled `labelBackground`, 1px `labelStroke`)
+ *     behind the weight so it always contrasts with whatever sits under
+ *     the edge, then the weight text on top in `labelText`; and
+ *   - draws EVERY edge's weight (no short-edge skip), rotated to sit along
+ *     the edge, so the weight is always present and readable.
+ *
+ * Takes the palette by value so the caller can re-create it on a theme
+ * flip and re-apply it via `setSetting("defaultDrawEdgeLabel", …)`.
+ */
+export function makeDrawEdgeLabel(
+  palette: SigmaPalette,
+): EdgeLabelDrawingFunction {
+  return (context, data, sourceData, targetData, settings) => {
+    if (typeof data.label !== "string" || data.label.length === 0) return;
+
+    const size = settings.edgeLabelSize;
+    const font = settings.edgeLabelFont;
+    const weight = settings.edgeLabelWeight;
+    context.font = `${weight} ${size}px ${font}`;
+
+    const label = data.label;
+    const textWidth = context.measureText(label).width;
+
+    // Midpoint of the edge in viewport pixels, and the edge's angle —
+    // clamped to ±90° so the weight is never drawn upside-down.
+    const cx = (sourceData.x + targetData.x) / 2;
+    const cy = (sourceData.y + targetData.y) / 2;
+    const dx = targetData.x - sourceData.x;
+    const dy = targetData.y - sourceData.y;
+    let angle = Math.atan2(dy, dx);
+    if (angle < -Math.PI / 2) angle += Math.PI;
+    if (angle > Math.PI / 2) angle -= Math.PI;
+
+    const boxWidth = textWidth + PADDING_X * 2;
+    const boxHeight = size + PADDING_Y * 2;
+
+    context.save();
+    context.translate(cx, cy);
+    context.rotate(angle);
+
+    // Opaque chip centred on the midpoint. Drop any inherited shadow so
+    // the 1px stroke is what separates the chip from the edge/canvas.
+    context.fillStyle = palette.labelBackground;
+    context.strokeStyle = palette.labelStroke;
+    context.lineWidth = 1;
+    context.shadowOffsetX = 0;
+    context.shadowOffsetY = 0;
+    context.shadowBlur = 0;
+    context.beginPath();
+    context.moveTo(-boxWidth / 2, -boxHeight / 2);
+    context.lineTo(boxWidth / 2, -boxHeight / 2);
+    context.lineTo(boxWidth / 2, boxHeight / 2);
+    context.lineTo(-boxWidth / 2, boxHeight / 2);
+    context.closePath();
+    context.fill();
+    context.stroke();
+
+    // Weight on top of the chip in the foreground token, horizontally
+    // centred and vertically nudged onto the text baseline.
+    context.fillStyle = palette.labelText;
+    context.fillText(label, -textWidth / 2, size / 3);
+
+    context.restore();
+  };
 }

--- a/admin/app/components/illuminate/IlluminateCanvas/node-label.test.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/node-label.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+
+import { makeDrawNodeLabel } from "./node-label";
+import { FALLBACK_PALETTE, type SigmaPalette } from "./palette";
+
+/**
+ * Unit coverage for the always-on node-label renderer (#514).
+ *
+ * Like the hover renderer it is pure 2D-canvas drawing, so we drive it
+ * with a fake `CanvasRenderingContext2D` that records each drawing call
+ * together with the *active* style state at the moment of the call. The
+ * suite asserts the chip is filled with `labelBackground`, stroked with a
+ * 1px `labelStroke`, and the key text is painted in `labelText` — the
+ * "Key が背景色とかぶって見えにくい" collision #514 fixes.
+ */
+
+interface RecordedOp {
+  op: string;
+  fillStyle: string;
+  strokeStyle: string;
+  lineWidth: number;
+  args: unknown[];
+}
+
+function makeFakeContext(textWidth = 42) {
+  const ops: RecordedOp[] = [];
+  const state = {
+    font: "",
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 0,
+    shadowOffsetX: 0,
+    shadowOffsetY: 0,
+    shadowBlur: 0,
+  };
+  const record = (op: string, args: unknown[] = []) =>
+    ops.push({
+      op,
+      fillStyle: state.fillStyle,
+      strokeStyle: state.strokeStyle,
+      lineWidth: state.lineWidth,
+      args,
+    });
+
+  const ctx = {
+    get font() {
+      return state.font;
+    },
+    set font(v: string) {
+      state.font = v;
+    },
+    get fillStyle() {
+      return state.fillStyle;
+    },
+    set fillStyle(v: string) {
+      state.fillStyle = v;
+    },
+    get strokeStyle() {
+      return state.strokeStyle;
+    },
+    set strokeStyle(v: string) {
+      state.strokeStyle = v;
+    },
+    get lineWidth() {
+      return state.lineWidth;
+    },
+    set lineWidth(v: number) {
+      state.lineWidth = v;
+    },
+    get shadowOffsetX() {
+      return state.shadowOffsetX;
+    },
+    set shadowOffsetX(v: number) {
+      state.shadowOffsetX = v;
+    },
+    get shadowOffsetY() {
+      return state.shadowOffsetY;
+    },
+    set shadowOffsetY(v: number) {
+      state.shadowOffsetY = v;
+    },
+    get shadowBlur() {
+      return state.shadowBlur;
+    },
+    set shadowBlur(v: number) {
+      state.shadowBlur = v;
+    },
+    measureText: (_t: string) => ({ width: textWidth }),
+    beginPath: () => record("beginPath"),
+    moveTo: (...a: number[]) => record("moveTo", a),
+    lineTo: (...a: number[]) => record("lineTo", a),
+    closePath: () => record("closePath"),
+    fill: () => record("fill"),
+    stroke: () => record("stroke"),
+    fillText: (...a: unknown[]) => record("fillText", a),
+  };
+
+  return { ctx, ops, state };
+}
+
+const SETTINGS = {
+  labelSize: 13,
+  labelFont: "system-ui, sans-serif",
+  labelWeight: "600",
+};
+
+// A distinctive palette so each colour assertion is unambiguous (none of
+// the three values collide).
+const PALETTE: SigmaPalette = {
+  ...FALLBACK_PALETTE,
+  labelBackground: "#101010",
+  labelStroke: "#808080",
+  labelText: "#fafafa",
+};
+
+function draw(
+  palette: SigmaPalette,
+  data: { x: number; y: number; size: number; label?: string; color?: string },
+  textWidth = 42,
+) {
+  const fake = makeFakeContext(textWidth);
+  const fn = makeDrawNodeLabel(palette);
+  fn(
+    fake.ctx as unknown as CanvasRenderingContext2D,
+    data as unknown as Parameters<ReturnType<typeof makeDrawNodeLabel>>[1],
+    SETTINGS as unknown as Parameters<ReturnType<typeof makeDrawNodeLabel>>[2],
+  );
+  return fake;
+}
+
+describe("makeDrawNodeLabel", () => {
+  test("fills the label chip with labelBackground", () => {
+    const { ops } = draw(PALETTE, {
+      x: 100,
+      y: 50,
+      size: 8,
+      label: "alpha",
+      color: "#0078d4",
+    });
+    const fill = ops.find((o) => o.op === "fill");
+    expect(fill).toBeDefined();
+    expect(fill?.fillStyle).toBe(PALETTE.labelBackground);
+  });
+
+  test("outlines the chip with a 1px labelStroke border", () => {
+    const { ops } = draw(PALETTE, {
+      x: 100,
+      y: 50,
+      size: 8,
+      label: "alpha",
+      color: "#0078d4",
+    });
+    const stroke = ops.find((o) => o.op === "stroke");
+    expect(stroke).toBeDefined();
+    expect(stroke?.strokeStyle).toBe(PALETTE.labelStroke);
+    expect(stroke?.lineWidth).toBe(1);
+  });
+
+  test("draws the key text in labelText so it contrasts with the chip", () => {
+    const { ops } = draw(PALETTE, {
+      x: 100,
+      y: 50,
+      size: 8,
+      label: "alpha",
+      color: "#0078d4",
+    });
+    const text = ops.find((o) => o.op === "fillText");
+    expect(text).toBeDefined();
+    expect(text?.fillStyle).toBe(PALETTE.labelText);
+    // The text colour must differ from the box fill — that is the exact
+    // collision #514 fixes.
+    expect(text?.fillStyle).not.toBe(PALETTE.labelBackground);
+  });
+
+  test("positions the label at sigma's canonical offset (x + size + 3, y + size/3)", () => {
+    const { ops } = draw(PALETTE, {
+      x: 100,
+      y: 50,
+      size: 8,
+      label: "alpha",
+      color: "#0078d4",
+    });
+    const text = ops.find((o) => o.op === "fillText");
+    expect(text?.args).toEqual(["alpha", 100 + 8 + 3, 50 + 13 / 3]);
+  });
+
+  test("paints the chip before the text so the text lands on top", () => {
+    const { ops } = draw(PALETTE, {
+      x: 100,
+      y: 50,
+      size: 8,
+      label: "alpha",
+      color: "#0078d4",
+    });
+    const fillIdx = ops.findIndex((o) => o.op === "fill");
+    const textIdx = ops.findIndex((o) => o.op === "fillText");
+    expect(fillIdx).toBeGreaterThanOrEqual(0);
+    expect(textIdx).toBeGreaterThan(fillIdx);
+  });
+
+  test("draws nothing when the reduced label is empty (hover-dim path)", () => {
+    const { ops } = draw(PALETTE, {
+      x: 100,
+      y: 50,
+      size: 8,
+      label: "",
+      color: "#0078d4",
+    });
+    expect(ops).toHaveLength(0);
+  });
+
+  test("draws nothing when the label is missing", () => {
+    const { ops } = draw(PALETTE, {
+      x: 100,
+      y: 50,
+      size: 8,
+      color: "#0078d4",
+    });
+    expect(ops).toHaveLength(0);
+  });
+});

--- a/admin/app/components/illuminate/IlluminateCanvas/node-label.ts
+++ b/admin/app/components/illuminate/IlluminateCanvas/node-label.ts
@@ -1,0 +1,94 @@
+/**
+ * Theme-aware always-on node-label renderer for the Illuminate canvas
+ * (#514).
+ *
+ * Sigma's built-in `drawDiscNodeLabel` paints the label text with NO
+ * background, so a vertex key drawn over a same-luminance node disc or a
+ * busy patch of canvas blends into it and is hard to read — exactly the
+ * "Key が背景色とかぶって見えにくい" complaint #514 fixes. The hover
+ * renderer (`makeDrawNodeHover`) already solved this for the single
+ * hovered node by drawing a palette-skinned chip behind the text; this
+ * module brings the same contrast guarantee to EVERY node label so keys
+ * stay legible without having to hover.
+ *
+ * {@link makeDrawNodeLabel} returns a drop-in `NodeLabelDrawingFunction`
+ * that keeps sigma's text placement (to the right of the disc) but first
+ * fills a rectangular chip behind the text from `labelBackground`,
+ * outlines it with a 1px `labelStroke`, then draws the label in
+ * `labelText`. Because the chip follows the surface token and the text
+ * follows the foreground token, the two always contrast in both light and
+ * dark themes.
+ *
+ * Colocated with the canvas (pure 2D-canvas drawing math, not interaction
+ * state) and takes the palette by value so the caller can re-create it on
+ * a theme flip and re-apply it via `setSetting("defaultDrawNodeLabel", …)`.
+ */
+
+import type { NodeLabelDrawingFunction } from "sigma/rendering";
+
+import type { SigmaPalette } from "./palette";
+
+/** Horizontal inner padding (canvas px) between the text and the chip edge. */
+const PADDING_X = 4;
+/** Vertical inner padding (canvas px) between the text and the chip edge. */
+const PADDING_Y = 2;
+
+/**
+ * Build a `NodeLabelDrawingFunction` that paints every node's label as a
+ * palette-skinned chip from the supplied {@link SigmaPalette}. Reads the
+ * live font metrics off sigma's settings (so it tracks the non-hover
+ * label sizing) but takes its colours from the palette argument,
+ * guaranteeing box/text contrast.
+ *
+ * A node whose reduced label is empty (the hover-focus reducer clears the
+ * label string of every out-of-focus node, #458) draws nothing, so the
+ * focused-subset dimming keeps working unchanged.
+ */
+export function makeDrawNodeLabel(
+  palette: SigmaPalette,
+): NodeLabelDrawingFunction {
+  return (context, data, settings) => {
+    if (typeof data.label !== "string" || data.label.length === 0) return;
+
+    const size = settings.labelSize;
+    const font = settings.labelFont;
+    const weight = settings.labelWeight;
+    context.font = `${weight} ${size}px ${font}`;
+
+    const label = data.label;
+    const textWidth = context.measureText(label).width;
+    // Same anchor sigma's `drawDiscNodeLabel` uses: text sits to the
+    // right of the disc, vertically centred on the node.
+    const tx = data.x + data.size + 3;
+    const ty = data.y + size / 3;
+
+    const boxX = tx - PADDING_X;
+    const boxY = data.y - size / 2 - PADDING_Y;
+    const boxWidth = textWidth + PADDING_X * 2;
+    const boxHeight = size + PADDING_Y * 2;
+
+    // Chip behind the text. Drop any inherited shadow so the 1px stroke
+    // is what separates the chip from the canvas (mirrors the hover
+    // renderer's contrast story).
+    context.fillStyle = palette.labelBackground;
+    context.strokeStyle = palette.labelStroke;
+    context.lineWidth = 1;
+    context.shadowOffsetX = 0;
+    context.shadowOffsetY = 0;
+    context.shadowBlur = 0;
+    context.beginPath();
+    context.moveTo(boxX, boxY);
+    context.lineTo(boxX + boxWidth, boxY);
+    context.lineTo(boxX + boxWidth, boxY + boxHeight);
+    context.lineTo(boxX, boxY + boxHeight);
+    context.closePath();
+    context.fill();
+    context.stroke();
+
+    // Label on top of the chip in the foreground token — painted here
+    // (not delegated to sigma) so the box/text contrast is proven by this
+    // function alone and can never silently diverge.
+    context.fillStyle = palette.labelText;
+    context.fillText(label, tx, ty);
+  };
+}

--- a/admin/app/lib/cli/complete.test.ts
+++ b/admin/app/lib/cli/complete.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for the Web CLI Tab-completion engine (#515).
+ *
+ * `completeCommandLine` is the pure grammar core; these tests pin the
+ * slot classification and candidate vocabularies so a parser/grammar
+ * drift surfaces here rather than as a dead Tab key in the browser.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { completeCommandLine, longestCommonPrefix } from "./complete";
+
+const KEYS = ["alice", "alaska", "bob", "Bobby", "carol"];
+
+describe("completeCommandLine — verbs (slot 0)", () => {
+  test("lists every verb for an empty buffer", () => {
+    const { candidates } = completeCommandLine("", KEYS);
+    expect(candidates).toEqual([
+      "get",
+      "put",
+      "delete",
+      "add",
+      "scan",
+      "illuminate",
+      "help",
+      "exit",
+    ]);
+  });
+
+  test("filters verbs by prefix", () => {
+    expect(completeCommandLine("ge", KEYS).candidates).toEqual(["get"]);
+    expect(completeCommandLine("i", KEYS).candidates).toEqual(["illuminate"]);
+  });
+
+  test("is case-insensitive on the verb", () => {
+    expect(completeCommandLine("GE", KEYS).candidates).toEqual(["get"]);
+  });
+
+  test("reports the active token span", () => {
+    const res = completeCommandLine("ge", KEYS);
+    expect(res.token).toBe("ge");
+    expect(res.start).toBe(0);
+  });
+});
+
+describe("completeCommandLine — objectives (slot 1)", () => {
+  test("get offers vertex/edge", () => {
+    expect(completeCommandLine("get ", KEYS).candidates).toEqual([
+      "vertex",
+      "edge",
+    ]);
+  });
+
+  test("add offers only edge", () => {
+    expect(completeCommandLine("add ", KEYS).candidates).toEqual(["edge"]);
+  });
+
+  test("scan offers the plural objectives", () => {
+    expect(completeCommandLine("scan ", KEYS).candidates).toEqual([
+      "vertices",
+      "edges",
+    ]);
+  });
+
+  test("filters the objective by prefix", () => {
+    expect(completeCommandLine("get v", KEYS).candidates).toEqual(["vertex"]);
+    expect(completeCommandLine("scan e", KEYS).candidates).toEqual(["edges"]);
+  });
+
+  test("active token span points at the objective", () => {
+    const res = completeCommandLine("get v", KEYS);
+    expect(res.token).toBe("v");
+    expect(res.start).toBe("get ".length);
+  });
+});
+
+describe("completeCommandLine — key slots", () => {
+  test("get vertex completes the key from knownKeys", () => {
+    expect(completeCommandLine("get vertex al", KEYS).candidates).toEqual([
+      "alice",
+      "alaska",
+    ]);
+  });
+
+  test("key matching is case-insensitive but preserves stored casing", () => {
+    expect(completeCommandLine("get vertex bob", KEYS).candidates).toEqual([
+      "bob",
+      "Bobby",
+    ]);
+  });
+
+  test("edge verbs complete both endpoints", () => {
+    expect(completeCommandLine("add edge al", KEYS).candidates).toEqual([
+      "alice",
+      "alaska",
+    ]);
+    expect(completeCommandLine("add edge alice b", KEYS).candidates).toEqual([
+      "bob",
+      "Bobby",
+    ]);
+  });
+
+  test("delete edge completes both endpoints", () => {
+    expect(
+      completeCommandLine("delete edge alice ca", KEYS).candidates,
+    ).toEqual(["carol"]);
+  });
+
+  test("scan completes its prefix slot from known keys", () => {
+    expect(completeCommandLine("scan vertices al", KEYS).candidates).toEqual([
+      "alice",
+      "alaska",
+    ]);
+  });
+
+  test("put vertex value slot offers nothing", () => {
+    expect(completeCommandLine("put vertex alice ", KEYS).candidates).toEqual(
+      [],
+    );
+  });
+
+  test("illuminate seed (slot 1) completes from known keys", () => {
+    expect(completeCommandLine("illuminate al", KEYS).candidates).toEqual([
+      "alice",
+      "alaska",
+    ]);
+  });
+
+  test("caps key candidates at fifty", () => {
+    const many = Array.from({ length: 80 }, (_, i) => `node${i}`);
+    const { candidates } = completeCommandLine("get vertex node", many);
+    expect(candidates).toHaveLength(50);
+  });
+});
+
+describe("completeCommandLine — illuminate option kwargs (slot ≥ 4)", () => {
+  test("offers the three option keys with a trailing =", () => {
+    expect(
+      completeCommandLine("illuminate alice 2 5 ", KEYS).candidates,
+    ).toEqual(["algorithm=", "objective=", "weighting="]);
+  });
+
+  test("filters option keys by prefix", () => {
+    expect(
+      completeCommandLine("illuminate alice 2 5 a", KEYS).candidates,
+    ).toEqual(["algorithm="]);
+  });
+
+  test("drops option keys already present on the line", () => {
+    expect(
+      completeCommandLine("illuminate alice 2 5 algorithm=spt ", KEYS)
+        .candidates,
+    ).toEqual(["objective=", "weighting="]);
+  });
+
+  test("completes enum values once = is typed", () => {
+    expect(
+      completeCommandLine("illuminate alice 2 5 algorithm=", KEYS).candidates,
+    ).toEqual(["algorithm=none", "algorithm=mst", "algorithm=spt"]);
+  });
+
+  test("filters enum values by their prefix", () => {
+    expect(
+      completeCommandLine("illuminate alice 2 5 objective=m", KEYS).candidates,
+    ).toEqual(["objective=min", "objective=max"]);
+    expect(
+      completeCommandLine("illuminate alice 2 5 weighting=tf", KEYS).candidates,
+    ).toEqual(["weighting=tfidf"]);
+  });
+
+  test("unknown option keyword yields no value candidates", () => {
+    expect(
+      completeCommandLine("illuminate alice 2 5 bogus=", KEYS).candidates,
+    ).toEqual([]);
+  });
+
+  test("illuminate step/k slots offer nothing", () => {
+    expect(completeCommandLine("illuminate alice ", KEYS).candidates).toEqual(
+      [],
+    );
+    expect(completeCommandLine("illuminate alice 2 ", KEYS).candidates).toEqual(
+      [],
+    );
+  });
+});
+
+describe("longestCommonPrefix", () => {
+  test("returns the shared lead of the candidates", () => {
+    expect(longestCommonPrefix(["alice", "alaska"])).toBe("al");
+    expect(longestCommonPrefix(["algorithm=", "objective="])).toBe("");
+  });
+
+  test("returns the single value unchanged", () => {
+    expect(longestCommonPrefix(["alice"])).toBe("alice");
+  });
+
+  test("returns empty for no candidates", () => {
+    expect(longestCommonPrefix([])).toBe("");
+  });
+});

--- a/admin/app/lib/cli/complete.ts
+++ b/admin/app/lib/cli/complete.ts
@@ -1,0 +1,248 @@
+/**
+ * Tab-completion engine for the admin Web CLI (#515).
+ *
+ * The /cli prompt is a real inline terminal line, and a terminal without
+ * Tab completion feels broken. `completeCommandLine` is the pure core
+ * that powers it: given the current input buffer and a best-effort set of
+ * known vertex keys, it returns the candidates for the *active token*
+ * (the token the cursor is sitting in — i.e. the last whitespace-
+ * delimited chunk, or an empty token when the buffer ends in whitespace).
+ *
+ * It is deliberately decoupled from React: `CliPage` owns the keyboard
+ * wiring (preventDefault, applying the single/longest-common-prefix
+ * completion, rendering the candidate hint), while this module owns the
+ * grammar knowledge so it can be unit-tested without a DOM. The verb /
+ * objective / illuminate-axis vocabularies are the same ones the parser
+ * (`./verbs.ts`, `./types.ts`) and the click-to-illuminate picker
+ * (`./illuminate-axes.ts`) accept, so a completed line is always a line
+ * the parser would also accept.
+ */
+
+import {
+  CLI_ALGORITHMS,
+  CLI_OBJECTIVES,
+  CLI_WEIGHTINGS,
+} from "./illuminate-axes";
+
+/**
+ * Every verb the parser dispatches (see the `Command` union in
+ * `./types.ts`). `help` / `exit` are completion targets too — they are
+ * valid lines a user can type at the prompt.
+ */
+const VERBS: readonly string[] = [
+  "get",
+  "put",
+  "delete",
+  "add",
+  "scan",
+  "illuminate",
+  "help",
+  "exit",
+];
+
+/** The illuminate option kwargs, in the parser's fixed order. */
+const ILLUMINATE_OPTION_KEYS: readonly string[] = [
+  "algorithm",
+  "objective",
+  "weighting",
+];
+
+/** Cap on how many key candidates we surface, so the hint stays compact. */
+const MAX_KEY_CANDIDATES = 50;
+
+/**
+ * The result of a completion request. `candidates` are the full
+ * replacement tokens for the active token; `start` is the index in the
+ * input where the active token begins (so the caller replaces
+ * `input.slice(start)`); `token` is the active token's current text.
+ */
+export interface Completion {
+  candidates: string[];
+  start: number;
+  token: string;
+}
+
+/**
+ * Compute completion candidates for the active token of {@link input}.
+ *
+ * Slot semantics (0-based, whitespace-delimited):
+ *   - slot 0 → verb
+ *   - slot 1 → the verb's objective (`vertex`/`edge`/`vertices`/`edges`)
+ *     for verbs that take one, or the seed key for `illuminate`
+ *   - key slots → completed from {@link knownKeys}
+ *   - `illuminate` slots ≥ 4 → option kwargs (`algorithm=` / `objective=`
+ *     / `weighting=`, then their enum values once `=` is typed)
+ */
+export function completeCommandLine(
+  input: string,
+  knownKeys: readonly string[],
+): Completion {
+  const trailingWs = /\s$/.test(input);
+  const tokens = input.split(/\s+/).filter((t) => t.length > 0);
+  const slotIndex = trailingWs ? tokens.length : Math.max(0, tokens.length - 1);
+  const token = trailingWs ? "" : (tokens[tokens.length - 1] ?? "");
+  const start = input.length - token.length;
+  const verb = (tokens[0] ?? "").toLowerCase();
+  const objective = (tokens[1] ?? "").toLowerCase();
+
+  const none: Completion = { candidates: [], start, token };
+
+  // slot 0 — the verb.
+  if (slotIndex === 0) {
+    return { candidates: filterByPrefix(VERBS, token), start, token };
+  }
+
+  // illuminate option kwargs come before the generic slot handling so a
+  // long illuminate line (slot ≥ 4) is routed to the axis vocabulary.
+  if (verb === "illuminate" && slotIndex >= 4) {
+    return {
+      candidates: completeIlluminateOption(tokens, token),
+      start,
+      token,
+    };
+  }
+
+  // slot 1 — objective for verbs that take one, else the illuminate seed.
+  if (slotIndex === 1) {
+    const objectives = objectivesFor(verb);
+    if (objectives) {
+      return { candidates: filterByPrefix(objectives, token), start, token };
+    }
+    if (verb === "illuminate") {
+      return { candidates: completeKeys(knownKeys, token), start, token };
+    }
+    return none;
+  }
+
+  // Remaining key-bearing slots (tail/head endpoints, scan prefixes).
+  if (isKeySlot(verb, objective, slotIndex)) {
+    return { candidates: completeKeys(knownKeys, token), start, token };
+  }
+
+  return none;
+}
+
+/**
+ * The longest common prefix of {@link values}, char-for-char. Used by the
+ * caller to advance the buffer as far as it unambiguously can when more
+ * than one candidate matches (bash-style partial completion).
+ */
+export function longestCommonPrefix(values: readonly string[]): string {
+  if (values.length === 0) return "";
+  let prefix = values[0];
+  for (let i = 1; i < values.length; i++) {
+    const s = values[i];
+    let j = 0;
+    while (j < prefix.length && j < s.length && prefix[j] === s[j]) j++;
+    prefix = prefix.slice(0, j);
+    if (prefix === "") break;
+  }
+  return prefix;
+}
+
+/** The objective words a verb accepts, or null if it takes none. */
+function objectivesFor(verb: string): readonly string[] | null {
+  switch (verb) {
+    case "get":
+    case "put":
+    case "delete":
+      return ["vertex", "edge"];
+    case "add":
+      return ["edge"];
+    case "scan":
+      return ["vertices", "edges"];
+    default:
+      return null;
+  }
+}
+
+/**
+ * Whether the given slot holds a vertex key (so it should complete from
+ * `knownKeys`). Covers both endpoints of edge verbs and the prefix slot
+ * of `scan` (completing a prefix to a full known key is a useful jump).
+ */
+function isKeySlot(
+  verb: string,
+  objective: string,
+  slotIndex: number,
+): boolean {
+  switch (verb) {
+    case "get":
+    case "delete":
+    case "put":
+      if (objective === "vertex") return slotIndex === 2;
+      if (objective === "edge") return slotIndex === 2 || slotIndex === 3;
+      return false;
+    case "add": // add edge <tail> <head> ...
+      return slotIndex === 2 || slotIndex === 3;
+    case "scan": // scan { vertices | edges } <prefix> ...
+      return slotIndex === 2;
+    default:
+      return false;
+  }
+}
+
+/** Candidate vertex keys whose name starts with {@link token} (case-insensitive). */
+function completeKeys(knownKeys: readonly string[], token: string): string[] {
+  const lower = token.toLowerCase();
+  const out: string[] = [];
+  for (const key of knownKeys) {
+    if (key.toLowerCase().startsWith(lower)) {
+      out.push(key);
+      if (out.length >= MAX_KEY_CANDIDATES) break;
+    }
+  }
+  return out;
+}
+
+/**
+ * Complete an illuminate option token. With no `=` yet, suggests the
+ * option keys not already present on the line (`algorithm=` etc., which
+ * keep the trailing `=` so the caller knows not to append a space). Once
+ * `=` is typed, suggests the matching enum values as full `key=value`
+ * tokens.
+ */
+function completeIlluminateOption(
+  tokens: readonly string[],
+  token: string,
+): string[] {
+  const eq = token.indexOf("=");
+  if (eq === -1) {
+    const used = new Set(
+      tokens.slice(4).map((t) => t.split("=")[0].toLowerCase()),
+    );
+    const keys = ILLUMINATE_OPTION_KEYS.filter((k) => !used.has(k)).map(
+      (k) => `${k}=`,
+    );
+    return filterByPrefix(keys, token);
+  }
+  const kw = token.slice(0, eq).toLowerCase();
+  const valuePrefix = token.slice(eq + 1).toLowerCase();
+  const values = optionValues(kw);
+  if (!values) return [];
+  return values
+    .filter((v) => v.startsWith(valuePrefix))
+    .map((v) => `${kw}=${v}`);
+}
+
+/** The enum values for an illuminate option keyword, or null if unknown. */
+function optionValues(keyword: string): readonly string[] | null {
+  switch (keyword) {
+    case "algorithm":
+      return CLI_ALGORITHMS.map((a) => a.value);
+    case "objective":
+      return CLI_OBJECTIVES.map((o) => o.value);
+    case "weighting":
+      return CLI_WEIGHTINGS.map((w) => w.value);
+    default:
+      return null;
+  }
+}
+
+function filterByPrefix(
+  candidates: readonly string[],
+  token: string,
+): string[] {
+  const lower = token.toLowerCase();
+  return candidates.filter((c) => c.toLowerCase().startsWith(lower));
+}

--- a/admin/app/lib/client/usecase/cli/dispatcher.ts
+++ b/admin/app/lib/client/usecase/cli/dispatcher.ts
@@ -183,19 +183,6 @@ export async function dispatch(input: DispatchInput): Promise<unknown> {
   }
 }
 
-/**
- * Returns true when the command would mutate server state. Used by
- * the React panel to gate destructive verbs behind a confirmation
- * chip (#411).
- */
-export function isDestructive(command: Command): boolean {
-  return (
-    command.verb === "delete" ||
-    command.verb === "put" ||
-    command.verb === "add"
-  );
-}
-
 // ----------------------------------------------------------------------------
 // Internals
 // ----------------------------------------------------------------------------

--- a/admin/app/lib/client/usecase/cli/graph-view.test.ts
+++ b/admin/app/lib/client/usecase/cli/graph-view.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { commandResultToGraphView } from "./graph-view";
+import {
+  commandResultToGraphMerge,
+  commandResultToGraphView,
+  mergeGraphView,
+} from "./graph-view";
 import type { Command } from "~/lib/cli/types";
 import type {
   Edge,
@@ -251,5 +255,243 @@ describe("commandResultToGraphView — non-graph verbs", () => {
   it("returns null for exit", () => {
     const cmd: Command = { verb: "exit" };
     expect(commandResultToGraphView(cmd, null)).toBeNull();
+  });
+});
+
+describe("commandResultToGraphMerge", () => {
+  it("projects a put vertex into a single focus node carrying its value", () => {
+    const cmd: Command = {
+      verb: "put",
+      objective: "vertex",
+      key: "alice",
+      value: "wonderland",
+      ttlSeconds: 0,
+    };
+    const merge = commandResultToGraphMerge(cmd)!;
+    expect(merge.nodes).toHaveLength(1);
+    expect(merge.nodes[0].id).toBe("alice");
+    expect(merge.nodes[0].vertex.key).toBe("alice");
+    expect(merge.nodes[0].vertex.string).toBe("wonderland");
+    expect(typeof merge.nodes[0].vertex.expiration).toBe("string");
+    expect(merge.edges).toEqual([]);
+    expect(merge.additive).toBe(false);
+    expect(merge.focus).toBe("alice");
+  });
+
+  it("coerces a numeric put vertex value onto int64", () => {
+    const cmd: Command = {
+      verb: "put",
+      objective: "vertex",
+      key: "n",
+      value: "42",
+      ttlSeconds: 0,
+    };
+    const merge = commandResultToGraphMerge(cmd)!;
+    expect(merge.nodes[0].vertex.int64).toBe("42");
+  });
+
+  it("projects a put edge into two key-only endpoints plus the edge", () => {
+    const cmd: Command = {
+      verb: "put",
+      objective: "edge",
+      tail: "alice",
+      head: "bob",
+      weight: 2,
+      ttlSeconds: 0,
+    };
+    const merge = commandResultToGraphMerge(cmd)!;
+    expect(merge.nodes.map((n) => n.id).sort()).toEqual(["alice", "bob"]);
+    // endpoints are placeholders — identity only, no value fields.
+    expect(
+      merge.nodes.every(
+        (n) => Object.keys(n.vertex).filter((k) => k !== "key").length === 0,
+      ),
+    ).toBe(true);
+    expect(merge.edges).toHaveLength(1);
+    expect(merge.edges[0].id).toBe("alice→bob");
+    expect(merge.edges[0].weight).toBe(2);
+    expect(merge.edges[0].edge.weight).toBe(2);
+    expect(merge.additive).toBe(false);
+    expect(merge.focus).toBe("alice");
+  });
+
+  it("marks an add edge as additive", () => {
+    const cmd: Command = {
+      verb: "add",
+      objective: "edge",
+      tail: "alice",
+      head: "bob",
+      weight: 1,
+      ttlSeconds: 0,
+    };
+    const merge = commandResultToGraphMerge(cmd)!;
+    expect(merge.additive).toBe(true);
+    expect(merge.focus).toBe("alice");
+  });
+
+  it("returns null for verbs that carry no mergeable element", () => {
+    expect(
+      commandResultToGraphMerge({
+        verb: "delete",
+        objective: "vertex",
+        key: "x",
+      }),
+    ).toBeNull();
+    expect(
+      commandResultToGraphMerge({
+        verb: "delete",
+        objective: "edge",
+        tail: "a",
+        head: "b",
+      }),
+    ).toBeNull();
+    expect(commandResultToGraphMerge({ verb: "exit" })).toBeNull();
+    expect(
+      commandResultToGraphMerge({ verb: "get", objective: "vertex", key: "a" }),
+    ).toBeNull();
+  });
+});
+
+describe("mergeGraphView", () => {
+  /** A two-node illuminate frame (seed `a` → `b`, origin `a`). */
+  function illuminateBase() {
+    const cmd: Command = {
+      verb: "illuminate",
+      seed: "a",
+      step: 2,
+      k: 5,
+      algorithm: "none",
+      objective: "min",
+      weighting: "raw",
+    };
+    const response: IlluminateResponse = {
+      graph: {
+        vertices: [{ key: "a" }, { key: "b" }],
+        edges: [{ tail: "a", head: "b", weight: 1 }],
+      },
+    };
+    return commandResultToGraphView(cmd, response)!;
+  }
+
+  it("opens a fresh frame anchored on the put vertex when the canvas is empty", () => {
+    const merge = commandResultToGraphMerge({
+      verb: "put",
+      objective: "vertex",
+      key: "x",
+      value: "1",
+      ttlSeconds: 0,
+    })!;
+    const view = mergeGraphView(null, merge);
+    expect(view.nodes.map((n) => n.id)).toEqual(["x"]);
+    const x = view.nodes[0];
+    expect(x.isInitialSeed).toBe(true);
+    expect(x.isExpansionOrigin).toBe(true);
+    expect(x.hopDistance).toBe(0);
+    expect(view.expansionOrigins).toEqual(["x"]);
+    expect(view.latestExpansionOrigin).toBe("x");
+  });
+
+  it("opens a fresh frame anchored on the tail when the first command is a put edge", () => {
+    const merge = commandResultToGraphMerge({
+      verb: "put",
+      objective: "edge",
+      tail: "a",
+      head: "b",
+      weight: 2,
+      ttlSeconds: 0,
+    })!;
+    const view = mergeGraphView(null, merge);
+    expect(view.nodes.map((n) => n.id).sort()).toEqual(["a", "b"]);
+    expect(view.edges.map((e) => e.id)).toEqual(["a→b"]);
+    expect(view.nodes.find((n) => n.id === "a")!.isExpansionOrigin).toBe(true);
+    expect(view.nodes.find((n) => n.id === "a")!.hopDistance).toBe(0);
+    expect(view.nodes.find((n) => n.id === "b")!.hopDistance).toBe(1);
+    expect(view.expansionOrigins).toEqual(["a"]);
+  });
+
+  it("folds a new node onto an existing frame without disturbing its origins", () => {
+    const base = illuminateBase();
+    const merge = commandResultToGraphMerge({
+      verb: "put",
+      objective: "vertex",
+      key: "c",
+      value: "1",
+      ttlSeconds: 0,
+    })!;
+    const view = mergeGraphView(base, merge);
+    expect(view.nodes.map((n) => n.id).sort()).toEqual(["a", "b", "c"]);
+    // origins + seed survive the write.
+    expect(view.expansionOrigins).toEqual(["a"]);
+    expect(view.latestExpansionOrigin).toBe("a");
+    expect(view.nodes.find((n) => n.id === "a")!.isInitialSeed).toBe(true);
+    // the new node is NOT promoted to a seed/origin in a non-empty frame.
+    const c = view.nodes.find((n) => n.id === "c")!;
+    expect(c.isInitialSeed).toBe(false);
+    expect(c.isExpansionOrigin).toBe(false);
+    expect(c.hopDistance).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("sums an additive edge's weight onto an existing edge", () => {
+    const base = illuminateBase();
+    const merge = commandResultToGraphMerge({
+      verb: "add",
+      objective: "edge",
+      tail: "a",
+      head: "b",
+      weight: 3,
+      ttlSeconds: 0,
+    })!;
+    const view = mergeGraphView(base, merge);
+    const edge = view.edges.find((e) => e.id === "a→b")!;
+    expect(edge.weight).toBe(4);
+    expect(edge.edge.weight).toBe(4);
+  });
+
+  it("replaces an existing edge's weight on a non-additive put", () => {
+    const base = illuminateBase();
+    const merge = commandResultToGraphMerge({
+      verb: "put",
+      objective: "edge",
+      tail: "a",
+      head: "b",
+      weight: 9,
+      ttlSeconds: 0,
+    })!;
+    const view = mergeGraphView(base, merge);
+    expect(view.edges.find((e) => e.id === "a→b")!.weight).toBe(9);
+  });
+
+  it("refreshes a node's value on put but keeps its role, and a later edge placeholder never clobbers it", () => {
+    const base = illuminateBase();
+    const enriched = mergeGraphView(
+      base,
+      commandResultToGraphMerge({
+        verb: "put",
+        objective: "vertex",
+        key: "a",
+        value: "rich",
+        ttlSeconds: 0,
+      })!,
+    );
+    const a1 = enriched.nodes.find((n) => n.id === "a")!;
+    expect(a1.vertex.string).toBe("rich");
+    expect(a1.isInitialSeed).toBe(true);
+
+    const withEdge = mergeGraphView(
+      enriched,
+      commandResultToGraphMerge({
+        verb: "put",
+        objective: "edge",
+        tail: "a",
+        head: "z",
+        weight: 1,
+        ttlSeconds: 0,
+      })!,
+    );
+    const a2 = withEdge.nodes.find((n) => n.id === "a")!;
+    // the key-only "a" placeholder from the edge must not wipe the value.
+    expect(a2.vertex.string).toBe("rich");
+    expect(a2.isInitialSeed).toBe(true);
+    expect(withEdge.nodes.find((n) => n.id === "z")).toBeDefined();
   });
 });

--- a/admin/app/lib/client/usecase/cli/graph-view.ts
+++ b/admin/app/lib/client/usecase/cli/graph-view.ts
@@ -32,6 +32,7 @@ import type {
   ScanVerticesResponse,
   Vertex,
 } from "~/lib/client/infrastructure/api/types";
+import { coerceValue, ttlSecondsToExpiration } from "./dispatcher";
 
 /**
  * Project the dispatcher result for `command` into a `GraphView`.
@@ -320,4 +321,218 @@ function scanEdgesView(
   const matchedSeed =
     nodeMap.has(tailPrefix) && tailPrefix !== "" ? tailPrefix : null;
   return wrapView(Array.from(nodeMap.values()), edges, matchedSeed);
+}
+
+/**
+ * The graph elements a mutating verb (`put`/`add`) contributes to the
+ * canvas (#518). Unlike {@link commandResultToGraphView} — which REPLACES
+ * the frame for read verbs — a merge is folded additively onto the live
+ * frame (see {@link mergeGraphView}) so a `put`/`add` shows up immediately
+ * without discarding the operator's current exploration context.
+ */
+export interface GraphMerge {
+  /** Nodes to upsert. A node carrying a value replaces an existing one;
+   *  a key-only edge-endpoint placeholder never clobbers a richer node. */
+  nodes: GraphNode[];
+  /** Edges to upsert. */
+  edges: GraphEdge[];
+  /** True for `add edge` (the server sums weights additively); false for
+   *  `put`, which overwrites. Decides merge-vs-replace for an existing
+   *  edge of the same id. */
+  additive: boolean;
+  /** The key the mutation is "about" (put-vertex key / edge tail). Used as
+   *  the hop origin when the canvas is otherwise empty, so a put into a
+   *  cold canvas opens focused on the new element. */
+  focus: string | null;
+}
+
+/**
+ * Project a mutating `put`/`add` command into the {@link GraphMerge} the
+ * reducer folds onto the live canvas frame (#518). Returns `null` for
+ * every verb that already produces a full {@link GraphView} (via
+ * {@link commandResultToGraphView}) or carries nothing to show
+ * (`delete`, `exit`) — those keep their existing behaviour.
+ *
+ * Pure: derives entirely from the parsed command (the dispatcher's write
+ * responses carry no echo we need). Reuses the dispatcher's `coerceValue`
+ * / `ttlSecondsToExpiration` so the rendered vertex matches exactly what
+ * the dispatcher sent over the wire.
+ */
+export function commandResultToGraphMerge(command: Command): GraphMerge | null {
+  if (command.verb === "put" && command.objective === "vertex") {
+    const vertex: Vertex = {
+      key: command.key,
+      ...coerceValue(command.value),
+      expiration: ttlSecondsToExpiration(command.ttlSeconds),
+    };
+    return {
+      nodes: [mergeNode(command.key, vertex)],
+      edges: [],
+      additive: false,
+      focus: command.key,
+    };
+  }
+  if (
+    (command.verb === "put" || command.verb === "add") &&
+    command.objective === "edge"
+  ) {
+    const edge: Edge = {
+      tail: command.tail,
+      head: command.head,
+      weight: command.weight,
+      expiration: ttlSecondsToExpiration(command.ttlSeconds),
+    };
+    return {
+      // Key-only endpoint placeholders: if either vertex already lives on
+      // the canvas (with a value), the merge keeps the richer copy.
+      nodes: [
+        mergeNode(command.tail, { key: command.tail }),
+        mergeNode(command.head, { key: command.head }),
+      ],
+      edges: [
+        {
+          id: `${command.tail}→${command.head}`,
+          source: command.tail,
+          target: command.head,
+          weight: command.weight,
+          edge,
+        },
+      ],
+      additive: command.verb === "add",
+      focus: command.tail,
+    };
+  }
+  return null;
+}
+
+/** Build a neutral merge node. Hop distance / origin flags are finalised
+ *  by {@link mergeGraphView} once the full post-merge node + edge set is
+ *  known. */
+function mergeNode(key: string, vertex: Vertex): GraphNode {
+  return {
+    id: key,
+    label: key,
+    vertex,
+    isInitialSeed: false,
+    isExpansionOrigin: false,
+    importance: 0.5,
+    firstSeenExpansion: 0,
+    hopDistance: Number.POSITIVE_INFINITY,
+  };
+}
+
+/**
+ * Fold a {@link GraphMerge} onto the current canvas frame (#518),
+ * returning a fresh {@link GraphView}. Additive by construction so the
+ * operator's exploration context survives a write:
+ *
+ *  - **nodes** upsert — an incoming node refreshes an existing one's
+ *    payload only when it carries a value ({@link vertexHasValue}), while
+ *    preserving that node's role (seed / importance) in the current frame;
+ *    a bare edge-endpoint placeholder never overwrites a vertex already on
+ *    the canvas.
+ *  - **edges** upsert — for `add edge` an existing edge's weight is summed
+ *    (mirroring the server's additive semantics); `put edge` replaces.
+ *  - **hop distances** are recomputed from the surviving origins (or the
+ *    merge `focus` when the canvas was empty) so ramp colours stay
+ *    consistent.
+ *
+ * When `current` is `null` (cold canvas) the merge becomes the whole
+ * frame, anchored on the new element.
+ */
+export function mergeGraphView(
+  current: GraphView | null,
+  merge: GraphMerge,
+): GraphView {
+  const base = current ?? emptyView();
+  const wasEmpty = base.nodes.length === 0;
+
+  const nodeById = new Map(base.nodes.map((n) => [n.id, n]));
+  for (const incoming of merge.nodes) {
+    const existing = nodeById.get(incoming.id);
+    if (!existing) {
+      nodeById.set(incoming.id, { ...incoming });
+    } else if (vertexHasValue(incoming.vertex)) {
+      // Refresh the payload (value + expiration) but keep the node's
+      // existing role/importance in the current frame — a put must not
+      // demote the seed the operator is exploring around.
+      nodeById.set(incoming.id, { ...existing, vertex: incoming.vertex });
+    }
+    // else: key-only placeholder for a node already present → keep it.
+  }
+
+  const edgeById = new Map(base.edges.map((e) => [e.id, e]));
+  for (const incoming of merge.edges) {
+    const existing = edgeById.get(incoming.id);
+    if (existing && merge.additive) {
+      const weight = existing.weight + incoming.weight;
+      edgeById.set(incoming.id, {
+        ...incoming,
+        weight,
+        edge: { ...incoming.edge, weight },
+      });
+    } else {
+      edgeById.set(incoming.id, incoming);
+    }
+  }
+
+  const nodes = Array.from(nodeById.values());
+  const edges = Array.from(edgeById.values());
+
+  // Keep the established origins when the canvas already had a frame;
+  // otherwise anchor hop colouring on the merge focus.
+  const origins =
+    base.expansionOrigins.length > 0
+      ? base.expansionOrigins
+      : merge.focus !== null && merge.focus !== ""
+        ? [merge.focus]
+        : [];
+  const knownKeys = new Set(nodes.map((n) => n.id));
+  const hopByKey = computeHopDistances(knownKeys, edges, origins);
+  const originSet = new Set(origins);
+  const rehopped = nodes.map((n) => ({
+    ...n,
+    hopDistance: hopByKey.get(n.id) ?? Number.POSITIVE_INFINITY,
+    // Only promote a node to origin/seed when the canvas started empty —
+    // a put into an existing frame must not steal the seed halo from the
+    // node the operator is already exploring around.
+    isExpansionOrigin: n.isExpansionOrigin || (wasEmpty && originSet.has(n.id)),
+    isInitialSeed: n.isInitialSeed || (wasEmpty && originSet.has(n.id)),
+  }));
+
+  return {
+    nodes: rehopped,
+    edges,
+    latestExpansionOrigin: wasEmpty
+      ? (merge.focus ?? base.latestExpansionOrigin)
+      : base.latestExpansionOrigin,
+    expansionOrigins: origins,
+    overSoftCap: base.overSoftCap,
+    latestResultVertexKeys: new Set<string>(),
+    latestResultEdgeIds: new Set<string>(),
+  };
+}
+
+/** Empty additive-model frame — the base a merge folds onto when the
+ *  canvas has no prior view. */
+function emptyView(): GraphView {
+  return {
+    nodes: [],
+    edges: [],
+    latestExpansionOrigin: null,
+    expansionOrigins: [],
+    overSoftCap: false,
+    latestResultVertexKeys: new Set<string>(),
+    latestResultEdgeIds: new Set<string>(),
+  };
+}
+
+/** True when a vertex carries any value field beyond its identity
+ *  (`key`) and lifetime (`expiration`). Field-name-agnostic so it
+ *  survives additions to the value oneof. */
+function vertexHasValue(vertex: Vertex): boolean {
+  for (const k of Object.keys(vertex)) {
+    if (k !== "key" && k !== "expiration") return true;
+  }
+  return false;
 }

--- a/admin/app/lib/client/usecase/cli/reducer.test.ts
+++ b/admin/app/lib/client/usecase/cli/reducer.test.ts
@@ -141,15 +141,13 @@ describe("cliReducer", () => {
       expect(state.nextEntryId).toBe(2);
     });
 
-    it("preserves history and skipConfirm (clear-screen, not reset)", () => {
+    it("preserves history (clear-screen, not reset)", () => {
       const base: CliState = {
         ...INITIAL_CLI_STATE,
         history: ["a", "b"],
-        skipConfirm: true,
       };
       const next = cliReducer(base, { type: "SCROLLBACK_CLEARED" });
       expect(next.history).toEqual(["a", "b"]);
-      expect(next.skipConfirm).toBe(true);
     });
   });
 
@@ -214,45 +212,6 @@ describe("cliReducer", () => {
         "y",
       ]);
       expect(second.latestGraph?.source).toBe("put vertex y 1");
-    });
-  });
-
-  describe("pending destructive confirmation", () => {
-    it("sets and clears the pending command", () => {
-      const pending = {
-        rendered: "delete vertex alice",
-        command: { verb: "delete", objective: "vertex", key: "alice" },
-      } as const;
-      const set = cliReducer(INITIAL_CLI_STATE, {
-        type: "PENDING_SET",
-        pending,
-      });
-      expect(set.pending).toBe(pending);
-      const cleared = cliReducer(set, { type: "PENDING_CLEARED" });
-      expect(cleared.pending).toBeNull();
-    });
-
-    it("is identity when clearing an already-empty pending", () => {
-      const next = cliReducer(INITIAL_CLI_STATE, { type: "PENDING_CLEARED" });
-      expect(next).toBe(INITIAL_CLI_STATE);
-    });
-  });
-
-  describe("SKIP_CONFIRM_CHANGED", () => {
-    it("toggles the per-session flag", () => {
-      const next = cliReducer(INITIAL_CLI_STATE, {
-        type: "SKIP_CONFIRM_CHANGED",
-        value: true,
-      });
-      expect(next.skipConfirm).toBe(true);
-    });
-
-    it("is identity when the value is unchanged", () => {
-      const next = cliReducer(INITIAL_CLI_STATE, {
-        type: "SKIP_CONFIRM_CHANGED",
-        value: false,
-      });
-      expect(next).toBe(INITIAL_CLI_STATE);
     });
   });
 });

--- a/admin/app/lib/client/usecase/cli/reducer.test.ts
+++ b/admin/app/lib/client/usecase/cli/reducer.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { cliReducer } from "./reducer";
+import { commandResultToGraphMerge } from "./graph-view";
+import type { Command } from "~/lib/cli/types";
 import {
   INITIAL_CLI_STATE,
   initialBanner,
@@ -167,6 +169,51 @@ describe("cliReducer", () => {
         graph: GRAPH,
       });
       expect(next.latestGraph).toBe(GRAPH);
+    });
+  });
+
+  describe("GRAPH_MERGED", () => {
+    const putX: Command = {
+      verb: "put",
+      objective: "vertex",
+      key: "x",
+      value: "1",
+      ttlSeconds: 0,
+    };
+    const putY: Command = {
+      verb: "put",
+      objective: "vertex",
+      key: "y",
+      value: "1",
+      ttlSeconds: 0,
+    };
+
+    it("folds a put onto an empty canvas and records the source", () => {
+      const next = cliReducer(INITIAL_CLI_STATE, {
+        type: "GRAPH_MERGED",
+        source: "put vertex x 1",
+        merge: commandResultToGraphMerge(putX)!,
+      });
+      expect(next.latestGraph?.source).toBe("put vertex x 1");
+      expect(next.latestGraph?.view.nodes.map((n) => n.id)).toEqual(["x"]);
+    });
+
+    it("merges onto the existing frame instead of replacing it", () => {
+      const first = cliReducer(INITIAL_CLI_STATE, {
+        type: "GRAPH_MERGED",
+        source: "put vertex x 1",
+        merge: commandResultToGraphMerge(putX)!,
+      });
+      const second = cliReducer(first, {
+        type: "GRAPH_MERGED",
+        source: "put vertex y 1",
+        merge: commandResultToGraphMerge(putY)!,
+      });
+      expect(second.latestGraph?.view.nodes.map((n) => n.id).sort()).toEqual([
+        "x",
+        "y",
+      ]);
+      expect(second.latestGraph?.source).toBe("put vertex y 1");
     });
   });
 

--- a/admin/app/lib/client/usecase/cli/reducer.ts
+++ b/admin/app/lib/client/usecase/cli/reducer.ts
@@ -2,7 +2,6 @@ import {
   initialBanner,
   type CliState,
   type LatestGraph,
-  type PendingDestructive,
   type ScrollbackEntry,
 } from "./state";
 import { mergeGraphView, type GraphMerge } from "./graph-view";
@@ -31,13 +30,7 @@ export type CliAction =
    * live frame instead of replacing it (#518), so the operator's context
    * survives the write. Opens a fresh frame when the canvas was empty.
    */
-  | { type: "GRAPH_MERGED"; source: string; merge: GraphMerge }
-  /** A destructive verb needs confirmation. */
-  | { type: "PENDING_SET"; pending: PendingDestructive }
-  /** Confirmation resolved (Run or Cancel) — clear the prompt chip. */
-  | { type: "PENDING_CLEARED" }
-  /** Toggle the per-session "do not ask again" flag. */
-  | { type: "SKIP_CONFIRM_CHANGED"; value: boolean };
+  | { type: "GRAPH_MERGED"; source: string; merge: GraphMerge };
 
 export function cliReducer(state: CliState, action: CliAction): CliState {
   switch (action.type) {
@@ -105,21 +98,6 @@ export function cliReducer(state: CliState, action: CliAction): CliState {
           view: mergeGraphView(state.latestGraph?.view ?? null, action.merge),
         },
       };
-    }
-    case "PENDING_SET": {
-      return { ...state, pending: action.pending };
-    }
-    case "PENDING_CLEARED": {
-      if (state.pending === null) {
-        return state;
-      }
-      return { ...state, pending: null };
-    }
-    case "SKIP_CONFIRM_CHANGED": {
-      if (action.value === state.skipConfirm) {
-        return state;
-      }
-      return { ...state, skipConfirm: action.value };
     }
     default: {
       const exhaustive: never = action;

--- a/admin/app/lib/client/usecase/cli/reducer.ts
+++ b/admin/app/lib/client/usecase/cli/reducer.ts
@@ -5,6 +5,7 @@ import {
   type PendingDestructive,
   type ScrollbackEntry,
 } from "./state";
+import { mergeGraphView, type GraphMerge } from "./graph-view";
 
 export type CliAction =
   /** Prompt text changed (typing into the `<Input>`). */
@@ -25,6 +26,12 @@ export type CliAction =
   | { type: "RUN_SETTLED" }
   /** A graph-producing verb landed: replace the canvas view. */
   | { type: "GRAPH_UPDATED"; graph: LatestGraph }
+  /**
+   * A mutating verb (`put`/`add`) landed: fold the new element onto the
+   * live frame instead of replacing it (#518), so the operator's context
+   * survives the write. Opens a fresh frame when the canvas was empty.
+   */
+  | { type: "GRAPH_MERGED"; source: string; merge: GraphMerge }
   /** A destructive verb needs confirmation. */
   | { type: "PENDING_SET"; pending: PendingDestructive }
   /** Confirmation resolved (Run or Cancel) — clear the prompt chip. */
@@ -89,6 +96,15 @@ export function cliReducer(state: CliState, action: CliAction): CliState {
     }
     case "GRAPH_UPDATED": {
       return { ...state, latestGraph: action.graph };
+    }
+    case "GRAPH_MERGED": {
+      return {
+        ...state,
+        latestGraph: {
+          source: action.source,
+          view: mergeGraphView(state.latestGraph?.view ?? null, action.merge),
+        },
+      };
     }
     case "PENDING_SET": {
       return { ...state, pending: action.pending };

--- a/admin/app/lib/client/usecase/cli/state.ts
+++ b/admin/app/lib/client/usecase/cli/state.ts
@@ -47,9 +47,10 @@ export interface CliState {
   /** Dispatch lifecycle phase. */
   phase: CliPhase;
   /**
-   * Most recent graph-producing command's view. Mutating verbs leave
-   * this alone so the operator keeps their exploration context after a
-   * write. Null until the first graph-producing command lands.
+   * Most recent canvas frame. Read verbs replace it; mutating verbs
+   * (`put`/`add`) fold the new element onto it (#518) so the operator
+   * keeps their exploration context after a write. Null until the first
+   * graph-producing or mutating command lands.
    */
   latestGraph: LatestGraph | null;
   /** Monotonic id source for scrollback entries. */

--- a/admin/app/lib/client/usecase/cli/state.ts
+++ b/admin/app/lib/client/usecase/cli/state.ts
@@ -1,4 +1,3 @@
-import type { Command } from "~/lib/cli/types";
 import type { GraphView } from "~/lib/client/usecase/illuminate/selectors";
 
 export type EntryKind = "ok" | "error" | "info";
@@ -15,11 +14,6 @@ export interface LatestGraph {
   /** The exact CLI input that produced this graph (`get vertex alice`, …). */
   source: string;
   view: GraphView;
-}
-
-export interface PendingDestructive {
-  command: Command;
-  rendered: string;
 }
 
 /**
@@ -40,10 +34,6 @@ export interface CliState {
   history: string[];
   /** Cursor into `history`; null means "not navigating history". */
   historyIndex: number | null;
-  /** Set while a destructive verb awaits confirmation. */
-  pending: PendingDestructive | null;
-  /** Per-session "do not ask again" for destructive verbs. */
-  skipConfirm: boolean;
   /** Dispatch lifecycle phase. */
   phase: CliPhase;
   /**
@@ -79,8 +69,6 @@ export const INITIAL_CLI_STATE: CliState = {
   input: "",
   history: [],
   historyIndex: null,
-  pending: null,
-  skipConfirm: false,
   phase: "idle",
   latestGraph: null,
   nextEntryId: 2,

--- a/admin/app/lib/client/usecase/cli/use-cli.ts
+++ b/admin/app/lib/client/usecase/cli/use-cli.ts
@@ -1,5 +1,13 @@
-import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
+import { scanVertices } from "~/lib/client/infrastructure/api/scan-vertices";
 import { LanternApiError } from "~/lib/client/infrastructure/api/error";
 import {
   dispatch as dispatchCommand,
@@ -29,6 +37,11 @@ export interface UseCliResult {
   busy: boolean;
   /** Most recent graph-producing command's view, or null. */
   latestGraph: LatestGraph | null;
+  /**
+   * Vertex keys available for Tab completion (#515): the union of a
+   * best-effort mount scan and every key currently on the canvas.
+   */
+  knownKeys: string[];
   /** Update the prompt text. */
   setInput: (value: string) => void;
   /** Run the current prompt text (Enter). */
@@ -73,6 +86,34 @@ export function useCli(): UseCliResult {
   // plumbs `signal` through every underlying RPC, so the abort
   // propagates end-to-end.
   const abortRef = useRef<AbortController | null>(null);
+
+  // Best-effort completion vocabulary (#515). One page of vertex keys is
+  // pulled on mount so Tab can complete real keys, not just the ones the
+  // canvas already shows. This is a convenience, never a correctness
+  // dependency: a failed/aborted scan simply degrades completion to the
+  // canvas-derived keys merged in by `knownKeys` below.
+  const [scannedKeys, setScannedKeys] = useState<string[]>([]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void (async () => {
+      try {
+        const page = await scanVertices(
+          client,
+          { prefix: "", limit: 1000 },
+          { signal: controller.signal },
+        );
+        setScannedKeys(
+          (page.vertices ?? [])
+            .map((v) => v.key)
+            .filter((k): k is string => typeof k === "string"),
+        );
+      } catch {
+        // Swallow — Tab completion falls back to canvas-only keys.
+      }
+    })();
+    return () => controller.abort();
+  }, [client]);
 
   const busy = state.phase === "running";
 
@@ -262,6 +303,17 @@ export function useCli(): UseCliResult {
     return () => window.removeEventListener("keydown", onKey);
   }, [busy, cancelInFlight, clearScrollback]);
 
+  // Completion vocabulary = mount scan ∪ keys currently on the canvas.
+  // The canvas keys keep completion fresh after writes the mount scan
+  // never saw (e.g. a `put vertex` issued this session).
+  const knownKeys = useMemo<string[]>(() => {
+    const keys = new Set<string>(scannedKeys);
+    for (const node of state.latestGraph?.view.nodes ?? []) {
+      keys.add(node.id);
+    }
+    return Array.from(keys).sort((a, b) => a.localeCompare(b));
+  }, [scannedKeys, state.latestGraph]);
+
   return useMemo<UseCliResult>(
     () => ({
       scrollback: state.scrollback,
@@ -270,6 +322,7 @@ export function useCli(): UseCliResult {
       skipConfirm: state.skipConfirm,
       busy,
       latestGraph: state.latestGraph,
+      knownKeys,
       setInput,
       submit,
       runRaw: (raw: string) => void runRaw(raw),
@@ -288,6 +341,7 @@ export function useCli(): UseCliResult {
       state.skipConfirm,
       busy,
       state.latestGraph,
+      knownKeys,
       setInput,
       submit,
       runRaw,

--- a/admin/app/lib/client/usecase/cli/use-cli.ts
+++ b/admin/app/lib/client/usecase/cli/use-cli.ts
@@ -13,7 +13,10 @@ import {
   dispatch as dispatchCommand,
   isDestructive,
 } from "~/lib/client/usecase/cli/dispatcher";
-import { commandResultToGraphView } from "~/lib/client/usecase/cli/graph-view";
+import {
+  commandResultToGraphView,
+  commandResultToGraphMerge,
+} from "~/lib/client/usecase/cli/graph-view";
 import { parse, type Command, type ParseResult } from "~/lib/cli/parser";
 import { HELP_TEXT } from "~/lib/cli/verbs";
 import { cliReducer } from "./reducer";
@@ -142,15 +145,23 @@ export function useCli(): UseCliResult {
             durationMs: elapsed,
           },
         });
-        // Project graph-shaped results onto the canvas. null means the
-        // verb carries no graph payload (put/add/delete/exit) — leave
-        // the previous canvas alone in that case.
+        // Project graph-shaped results onto the canvas. A read verb
+        // returns a full view that REPLACES the frame; a mutating verb
+        // (put/add) returns null here but yields a GraphMerge that is
+        // folded onto the live frame (#518) so the new element shows up
+        // without discarding the operator's exploration context. delete /
+        // exit yield neither and leave the canvas untouched.
         const view = commandResultToGraphView(command, out);
         if (view !== null) {
           dispatch({
             type: "GRAPH_UPDATED",
             graph: { source: rawInput, view },
           });
+        } else {
+          const merge = commandResultToGraphMerge(command);
+          if (merge !== null) {
+            dispatch({ type: "GRAPH_MERGED", source: rawInput, merge });
+          }
         }
       } catch (err) {
         const elapsed = performance.now() - start;

--- a/admin/app/lib/client/usecase/cli/use-cli.ts
+++ b/admin/app/lib/client/usecase/cli/use-cli.ts
@@ -9,10 +9,7 @@ import {
 import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
 import { scanVertices } from "~/lib/client/infrastructure/api/scan-vertices";
 import { LanternApiError } from "~/lib/client/infrastructure/api/error";
-import {
-  dispatch as dispatchCommand,
-  isDestructive,
-} from "~/lib/client/usecase/cli/dispatcher";
+import { dispatch as dispatchCommand } from "~/lib/client/usecase/cli/dispatcher";
 import {
   commandResultToGraphView,
   commandResultToGraphMerge,
@@ -23,7 +20,6 @@ import { cliReducer } from "./reducer";
 import {
   INITIAL_CLI_STATE,
   type LatestGraph,
-  type PendingDestructive,
   type ScrollbackEntry,
 } from "./state";
 
@@ -32,10 +28,6 @@ export interface UseCliResult {
   scrollback: ScrollbackEntry[];
   /** Current prompt text. */
   input: string;
-  /** Destructive verb awaiting confirmation, if any. */
-  pending: PendingDestructive | null;
-  /** Per-session "do not ask again" flag. */
-  skipConfirm: boolean;
   /** True while a dispatch is in flight (drives `Cancel` + disabled prompt). */
   busy: boolean;
   /** Most recent graph-producing command's view, or null. */
@@ -59,19 +51,13 @@ export interface UseCliResult {
   clearScrollback: () => void;
   /** Abort the in-flight dispatch (Cancel / Esc). */
   cancelInFlight: () => void;
-  /** Toggle the per-session confirmation skip. */
-  setSkipConfirm: (value: boolean) => void;
-  /** Confirm and run the pending destructive command. */
-  confirmRun: () => void;
-  /** Dismiss the pending destructive command. */
-  confirmCancel: () => void;
 }
 
 /**
  * Owns the /cli route's stateful dispatch loop: command parsing,
  * per-verb dispatch through `lantern-sdk/web`, arrow-key history,
- * destructive-verb confirmation, cancellation via `AbortController`,
- * and the graph projection that feeds the canvas.
+ * cancellation via `AbortController`, and the graph projection that
+ * feeds the canvas.
  *
  * Per the skill's stateful-flow compromise, the lifecycle-heavy
  * orchestration (async dispatch + abort handle) lives here in the
@@ -228,16 +214,9 @@ export function useCli(): UseCliResult {
         });
         return;
       }
-      if (isDestructive(result.command) && !state.skipConfirm) {
-        dispatch({
-          type: "PENDING_SET",
-          pending: { command: result.command, rendered: raw },
-        });
-        return;
-      }
       await runCommand(raw, result.command);
     },
-    [runCommand, state.skipConfirm],
+    [runCommand],
   );
 
   const submit = useCallback(() => {
@@ -258,9 +237,9 @@ export function useCli(): UseCliResult {
 
   /**
    * Resets the scrollback to just the banner line. Wired to the toolbar
-   * `Clear` button and `Ctrl+L` / `Cmd+L` (#433). Gateway override,
-   * skipConfirm, and history are deliberately preserved so a clear
-   * behaves like an editor's "clear screen", not a hard reset.
+   * `Clear` button and `Ctrl+L` / `Cmd+L` (#433). Gateway override and
+   * history are deliberately preserved so a clear behaves like an
+   * editor's "clear screen", not a hard reset.
    */
   const clearScrollback = useCallback(() => {
     dispatch({ type: "SCROLLBACK_CLEARED" });
@@ -273,22 +252,6 @@ export function useCli(): UseCliResult {
    */
   const cancelInFlight = useCallback(() => {
     abortRef.current?.abort();
-  }, []);
-
-  const setSkipConfirm = useCallback((value: boolean) => {
-    dispatch({ type: "SKIP_CONFIRM_CHANGED", value });
-  }, []);
-
-  const confirmRun = useCallback(() => {
-    const p = state.pending;
-    dispatch({ type: "PENDING_CLEARED" });
-    if (p) {
-      void runCommand(p.rendered, p.command);
-    }
-  }, [runCommand, state.pending]);
-
-  const confirmCancel = useCallback(() => {
-    dispatch({ type: "PENDING_CLEARED" });
   }, []);
 
   // Window-level keyboard shortcuts (#433):
@@ -329,8 +292,6 @@ export function useCli(): UseCliResult {
     () => ({
       scrollback: state.scrollback,
       input: state.input,
-      pending: state.pending,
-      skipConfirm: state.skipConfirm,
       busy,
       latestGraph: state.latestGraph,
       knownKeys,
@@ -341,15 +302,10 @@ export function useCli(): UseCliResult {
       historyNext,
       clearScrollback,
       cancelInFlight,
-      setSkipConfirm,
-      confirmRun,
-      confirmCancel,
     }),
     [
       state.scrollback,
       state.input,
-      state.pending,
-      state.skipConfirm,
       busy,
       state.latestGraph,
       knownKeys,
@@ -360,9 +316,6 @@ export function useCli(): UseCliResult {
       historyNext,
       clearScrollback,
       cancelInFlight,
-      setSkipConfirm,
-      confirmRun,
-      confirmCancel,
     ],
   );
 }

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -106,6 +106,33 @@ test.describe("/cli", () => {
     );
   });
 
+  // #518 — a mutating verb (put/add) folds the new element onto the
+  // canvas so the operator sees what they just wrote, instead of the
+  // canvas staying blank. put is destructive-gated, so the write lands
+  // only after the confirm chip is accepted. An explicit TTL keeps the
+  // expiration inside the server's tombstone window (24h in the e2e
+  // harness); the grammar is `put vertex <key> <value> [ttl_seconds]`.
+  test("put vertex adds the new node to the canvas (#518)", async ({
+    page,
+  }) => {
+    await page.goto("/cli");
+    // Canvas starts hidden — no graph rendered yet.
+    await expect(page.getByTestId("cli-canvas-panel")).toHaveCount(0);
+    const input = page.getByTestId("cli-input");
+    await input.fill("put vertex cli:gamma fresh 3600");
+    await input.press("Enter");
+    // Destructive verb gates behind the confirm chip.
+    await expect(page.getByTestId("cli-confirm")).toBeVisible();
+    await page.getByTestId("cli-confirm-run").click();
+    await expect(page.getByTestId("cli-entry-ok").last()).toBeVisible();
+    // The canvas opens with the put as its source label and the node
+    // now lives on it.
+    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
+    await expect(page.getByTestId("cli-canvas-panel")).toContainText(
+      "put vertex cli:gamma fresh 3600",
+    );
+  });
+
   // #433 — Ctrl+L is the editor-conventional clear-screen binding and
   // the only way to clear the scrollback now that the Clear button has
   // been removed (#512). It empties the scrollback in place, leaving the

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -473,4 +473,35 @@ test.describe("/cli", () => {
     await expect(page.getByTestId("cli-hints")).toBeVisible();
     await expect(input).toBeFocused();
   });
+
+  // #520 — Enter submits a command, which disables the prompt while the
+  // dispatch is in flight. The browser blurs a disabled element, so the
+  // component must restore focus when the input re-enables; otherwise the
+  // operator is ejected to <body> after every command and has to click
+  // back in. Slow-route the RPC so the disabled→blurred window is
+  // observable, then assert focus returns to the prompt once it settles.
+  test("prompt regains focus after an Enter-submitted command settles (#520)", async ({
+    page,
+  }) => {
+    await page.route("**/graph.v1.LanternService/**", async (route) => {
+      await new Promise((r) => setTimeout(r, 250));
+      await route.continue();
+    });
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    await input.click();
+    await input.fill("get vertex cli:alpha");
+    await input.press("Enter");
+    // While in flight the prompt is disabled and the browser has moved
+    // focus off it (to <body>) — this is the regression's trigger.
+    await expect(input).toBeDisabled();
+    await expect(input).not.toBeFocused();
+    // Once the command settles the component restores focus to the prompt
+    // so the next command can be typed without a click.
+    await expect(page.getByTestId("cli-entry-ok").last()).toContainText(
+      "first",
+    );
+    await expect(input).toBeEnabled();
+    await expect(input).toBeFocused();
+  });
 });

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -55,14 +55,16 @@ test.describe("/cli", () => {
     await expect(err.last()).toContainText("usage:");
   });
 
-  test("destructive verb shows the confirmation chip", async ({ page }) => {
+  test("destructive verb runs immediately with no confirmation chip", async ({
+    page,
+  }) => {
     await page.goto("/cli");
     const input = page.getByTestId("cli-input");
     await input.fill("delete vertex cli:never-existed");
     await input.press("Enter");
-    await expect(page.getByTestId("cli-confirm")).toBeVisible();
-    await page.getByTestId("cli-confirm-cancel").click();
-    await expect(page.getByTestId("cli-confirm")).toBeHidden();
+    // No confirmation chip — the verb dispatches straight through (#521).
+    await expect(page.getByTestId("cli-confirm")).toHaveCount(0);
+    await expect(page.getByTestId("cli-entry-ok").last()).toBeVisible();
   });
 
   // #439 — graph-producing verbs render the IlluminateCanvas above
@@ -108,10 +110,10 @@ test.describe("/cli", () => {
 
   // #518 — a mutating verb (put/add) folds the new element onto the
   // canvas so the operator sees what they just wrote, instead of the
-  // canvas staying blank. put is destructive-gated, so the write lands
-  // only after the confirm chip is accepted. An explicit TTL keeps the
-  // expiration inside the server's tombstone window (24h in the e2e
-  // harness); the grammar is `put vertex <key> <value> [ttl_seconds]`.
+  // canvas staying blank. The verb dispatches straight through with no
+  // confirmation chip (#521). An explicit TTL keeps the expiration inside
+  // the server's tombstone window (24h in the e2e harness); the grammar
+  // is `put vertex <key> <value> [ttl_seconds]`.
   test("put vertex adds the new node to the canvas (#518)", async ({
     page,
   }) => {
@@ -121,9 +123,7 @@ test.describe("/cli", () => {
     const input = page.getByTestId("cli-input");
     await input.fill("put vertex cli:gamma fresh 3600");
     await input.press("Enter");
-    // Destructive verb gates behind the confirm chip.
-    await expect(page.getByTestId("cli-confirm")).toBeVisible();
-    await page.getByTestId("cli-confirm-run").click();
+    // Destructive verb dispatches straight through — no confirm chip (#521).
     await expect(page.getByTestId("cli-entry-ok").last()).toBeVisible();
     // The canvas opens with the put as its source label and the node
     // now lives on it.
@@ -136,7 +136,7 @@ test.describe("/cli", () => {
   // #433 — Ctrl+L is the editor-conventional clear-screen binding and
   // the only way to clear the scrollback now that the Clear button has
   // been removed (#512). It empties the scrollback in place, leaving the
-  // banner, while gateway override, skipConfirm, and history survive.
+  // banner, while gateway override and history survive.
   test("Ctrl+L clears the scrollback but keeps history", async ({ page }) => {
     await page.goto("/cli");
     const input = page.getByTestId("cli-input");

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -446,4 +446,31 @@ test.describe("/cli", () => {
       "illuminate <key> 4 12 algorithm=mst",
     );
   });
+
+  // #519 — Tab completion must keep the caret in the prompt. Fluent's
+  // focus manager (Tabster) moves focus to an invisible boundary
+  // sentinel on Tab from a window/document capture-phase handler, so the
+  // component restores focus + caret on the next frame. Without the fix
+  // the operator is ejected from the input after every completion and has
+  // to click back in to keep typing.
+  test("Tab completion keeps focus in the prompt (#519)", async ({ page }) => {
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    // Single-candidate completion: `illumi` → `illuminate `.
+    await input.click();
+    await input.fill("illumi");
+    await input.press("Tab");
+    await expect(input).toHaveValue("illuminate ");
+    await expect(input).toBeFocused();
+    // Caret sits at the end of the completed token, ready for the key.
+    expect(
+      await input.evaluate((el: HTMLInputElement) => el.selectionStart),
+    ).toBe("illuminate ".length);
+
+    // Ambiguous completion keeps focus while surfacing the hint row.
+    await input.fill("get ");
+    await input.press("Tab");
+    await expect(page.getByTestId("cli-hints")).toBeVisible();
+    await expect(input).toBeFocused();
+  });
 });

--- a/admin/tests/e2e/illuminate.spec.ts
+++ b/admin/tests/e2e/illuminate.spec.ts
@@ -351,6 +351,55 @@ test.describe("/illuminate", () => {
     expect(contrastReport.ratio).toBeGreaterThanOrEqual(4.5);
   });
 
+  // #517 — the operator can independently hide vertex and edge labels.
+  // The toggles drive Sigma's renderLabels / renderEdgeLabels settings,
+  // surfaced for assertion through the canvas bridge.
+  test("label toggles hide and restore vertex and edge labels (#517)", async ({
+    page,
+  }) => {
+    const seed = encodeURIComponent("e2e:illum:hub");
+    await page.goto(`/illuminate?seed=${seed}`);
+    await expect(page.getByTestId("illuminate-counter")).toContainText(
+      "5 vertices",
+    );
+
+    type LabelBridge = {
+      getLabelVisibility?: () => { vertex: boolean; edge: boolean };
+    };
+    // The label-visibility bridge is installed in the sigma mount effect.
+    await page.waitForFunction(() => {
+      const win = window as Window & { __illuminateCanvas?: LabelBridge };
+      return !!win.__illuminateCanvas?.getLabelVisibility;
+    });
+    const vis = (): Promise<{ vertex: boolean; edge: boolean }> =>
+      page.evaluate(() => {
+        const win = window as Window & { __illuminateCanvas?: LabelBridge };
+        return (
+          win.__illuminateCanvas?.getLabelVisibility?.() ?? {
+            vertex: false,
+            edge: false,
+          }
+        );
+      });
+
+    // Both kinds of labels are on by default.
+    expect(await vis()).toEqual({ vertex: true, edge: true });
+
+    // Toggling vertex labels off hides only the vertex labels.
+    await page.getByTestId("illuminate-toggle-node-labels").click();
+    await expect.poll(async () => (await vis()).vertex).toBe(false);
+    expect((await vis()).edge).toBe(true);
+
+    // Toggling edge labels off hides them too, independently.
+    await page.getByTestId("illuminate-toggle-edge-labels").click();
+    await expect.poll(async () => (await vis()).edge).toBe(false);
+
+    // Toggling vertex labels back on restores only them.
+    await page.getByTestId("illuminate-toggle-node-labels").click();
+    await expect.poll(async () => (await vis()).vertex).toBe(true);
+    expect((await vis()).edge).toBe(false);
+  });
+
   test("No positional snap at t=0 after a click, then gradual non-overlapping easing (#483)", async ({
     page,
   }) => {


### PR DESCRIPTION
Integration PR for the stacked admin-SPA CLI/canvas work that accumulated on
`main` as seven clean per-issue conventional commits. Merged with a **merge
commit** (not squash) to preserve the per-issue history; each commit already
carries its own `Closes #N` trailer.

## Commits

- `7592ca6` always-show readable vertex/edge labels + re-frame camera on expansion — #514
- `708c9cb` make Web CLI an inline terminal with key/command tab completion — #515
- `e09ea74` fill embedded canvas + label-visibility toggles — #516, #517
- `1f364b5` fold put/add results onto the CLI canvas — #518
- `9f81192` keep the caret in the CLI prompt after Tab completion — #519
- `343df49` keep the caret in the CLI prompt after Enter submits — #520
- `5989bb3` drop the destructive-command confirmation popup from the web CLI — #521

## Verification

- Static gates (in `admin/`): `format:check`, `typecheck`, `lint` all green.
- Unit: 545/545 (bun:test, 32 files).
- e2e: 51/51 (Playwright, single worker).
- Live-verified on the deployed `:8080` admin against the demo stack
  (542 vertices / 2190 edges).

Closes #514
Closes #515
Closes #516
Closes #517
Closes #518
Closes #519
Closes #520
Closes #521