### PR TITLE
fix: store writes that omit TTL/expiration permanently (#523)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,29 +14,6 @@ disk-backed graph database. It is the small, hot, online piece you put in front
 of those systems so request-path code can ask *"who is this user related to
 right now, and how strongly?"* in a single millisecond-scale RPC.
 
-**In one glance:**
-
-- **Time-decaying by design** — every vertex *and* edge carries its own TTL,
-  so the working set forgets stale data with no batch job.
-  [Why →](#why-lantern-is-different)
-- **Additive, decaying edge weights** — each event appends a contribution; the
-  live weight is the sum of what hasn't expired yet.
-  [Why →](#why-lantern-is-different)
-- **Online graph algorithms in one RPC** — `Illuminate` walks the live graph
-  from a seed and returns an MST / SPT subgraph (min/max, raw or TF-IDF)
-  already shaped for your use case.
-  [Algorithms →](#3-built-in-online-graph-algorithms-over-the-live-snapshot)
-- **Decaying memory for LLM agents** — `lantern-mcp` exposes the store over the
-  Model Context Protocol so Claude / VS Code / Cursor remember and forget on a
-  TTL ladder. [MCP →](#use-as-an-mcp-server)
-- **Browser console** — a React Router + Sigma.js admin SPA to browse,
-  `Illuminate`, and run ops against a live cluster. [Admin →](admin/)
-- **Leaderless HA, no external storage** — every replica holds the full graph;
-  writes commit locally and fan out under an HLC clock (last-writer-wins).
-  [Replication RFC →](docs/replication.md)
-- **Polyglot, one wire** — Go and Node / TypeScript SDKs, a scriptable
-  CLI + REPL, and Connect / gRPC / gRPC-Web multiplexed on a single `:6380`
-  socket. [Quick start →](#quick-start)
 
 ---
 
@@ -734,7 +711,7 @@ The server is configured via environment variables, parsed in
 | Variable | Default | Meaning |
 |---|---|---|
 | `LANTERN_PORT` | `6380` | Primary RPC listen port (Connect / gRPC / gRPC-Web multiplexed) |
-| `LANTERN_DEFAULT_TTL_SECONDS` | `60` | Default TTL when a request omits one |
+| `LANTERN_DEFAULT_TTL_SECONDS` | `60` | Surfaced in `GetServerStatus`/startup logs only; **not** applied to RPC writes — a write that omits TTL/expiration is stored permanently (decay is opt-in per write, #523). |
 | `LANTERN_GC_INTERVAL_SECONDS` | `60` | Cache GC tick interval |
 | `LANTERN_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error` |
 | `LANTERN_LOG_FORMAT` | `json` | `json` or `text` (slog handler) |

--- a/admin/app/lib/cli/types.ts
+++ b/admin/app/lib/cli/types.ts
@@ -28,7 +28,7 @@ export type Command =
       objective: "vertex";
       key: string;
       value: string;
-      ttlSeconds: number;
+      ttlSeconds: number | null;
     }
   | {
       verb: "put";
@@ -36,7 +36,7 @@ export type Command =
       tail: string;
       head: string;
       weight: number;
-      ttlSeconds: number;
+      ttlSeconds: number | null;
     }
   | { verb: "delete"; objective: "vertex"; key: string }
   | { verb: "delete"; objective: "edge"; tail: string; head: string }
@@ -46,7 +46,7 @@ export type Command =
       tail: string;
       head: string;
       weight: number;
-      ttlSeconds: number;
+      ttlSeconds: number | null;
     }
   | { verb: "scan"; objective: "vertices"; prefix: string; limit: number }
   | { verb: "scan"; objective: "edges"; tailPrefix: string; limit: number }

--- a/admin/app/lib/cli/verbs.test.ts
+++ b/admin/app/lib/cli/verbs.test.ts
@@ -70,7 +70,7 @@ describe("parseAdd / parsePut weight uses parseFloatStrict (#434)", () => {
         tail: "alice",
         head: "bob",
         weight: 1000,
-        ttlSeconds: expect.any(Number),
+        ttlSeconds: null,
       });
     }
   });

--- a/admin/app/lib/cli/verbs.ts
+++ b/admin/app/lib/cli/verbs.ts
@@ -11,8 +11,6 @@ import type {
   WeightingName,
 } from "./types";
 
-const DEFAULT_TTL_SECONDS = 365 * 24 * 3600;
-
 const ILL_ALGORITHMS = new Set<AlgorithmName>(["none", "mst", "spt"]);
 const ILL_OBJECTIVES = new Set<ObjectiveName>(["min", "max"]);
 const ILL_WEIGHTINGS = new Set<WeightingName>(["raw", "tfidf"]);
@@ -56,14 +54,18 @@ export function parsePut(rest: string[]): ParseResult {
       };
     }
     const [key, value, ttlTok] = args;
-    const ttlSeconds =
-      ttlTok === undefined ? DEFAULT_TTL_SECONDS : parseInt10(ttlTok);
-    if (ttlSeconds === null) {
-      return {
-        ok: false,
-        usage:
-          "usage: put vertex <key: string> <value: string|int|float|bool|datetime> [<ttl_seconds: int>]",
-      };
+    // Omitted ttl_seconds ⇒ permanent (no decay); only an explicit but
+    // malformed token is a usage error (#523).
+    let ttlSeconds: number | null = null;
+    if (ttlTok !== undefined) {
+      ttlSeconds = parseInt10(ttlTok);
+      if (ttlSeconds === null) {
+        return {
+          ok: false,
+          usage:
+            "usage: put vertex <key: string> <value: string|int|float|bool|datetime> [<ttl_seconds: int>]",
+        };
+      }
     }
     return {
       ok: true,
@@ -93,14 +95,18 @@ export function parsePut(rest: string[]): ParseResult {
           "usage: put edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
       };
     }
-    const ttlSeconds =
-      ttlTok === undefined ? DEFAULT_TTL_SECONDS : parseInt10(ttlTok);
-    if (ttlSeconds === null) {
-      return {
-        ok: false,
-        usage:
-          "usage: put edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
-      };
+    // Omitted ttl_seconds ⇒ permanent (no decay); only an explicit but
+    // malformed token is a usage error (#523).
+    let ttlSeconds: number | null = null;
+    if (ttlTok !== undefined) {
+      ttlSeconds = parseInt10(ttlTok);
+      if (ttlSeconds === null) {
+        return {
+          ok: false,
+          usage:
+            "usage: put edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
+        };
+      }
     }
     return {
       ok: true,
@@ -170,14 +176,18 @@ export function parseAdd(rest: string[]): ParseResult {
         "usage: add edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
     };
   }
-  const ttlSeconds =
-    ttlTok === undefined ? DEFAULT_TTL_SECONDS : parseInt10(ttlTok);
-  if (ttlSeconds === null) {
-    return {
-      ok: false,
-      usage:
-        "usage: add edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
-    };
+  // Omitted ttl_seconds ⇒ permanent (no decay); only an explicit but
+  // malformed token is a usage error (#523).
+  let ttlSeconds: number | null = null;
+  if (ttlTok !== undefined) {
+    ttlSeconds = parseInt10(ttlTok);
+    if (ttlSeconds === null) {
+      return {
+        ok: false,
+        usage:
+          "usage: add edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
+      };
+    }
   }
   return {
     ok: true,

--- a/admin/app/lib/client/usecase/cli/dispatcher.test.ts
+++ b/admin/app/lib/client/usecase/cli/dispatcher.test.ts
@@ -144,15 +144,20 @@ describe("coerceValue (#428 cascade matches Go cli/parser Value())", () => {
   });
 });
 
-describe("ttlSecondsToExpiration (#429)", () => {
-  test("returns now+ttl as ISO8601", () => {
+describe("ttlSecondsToExpiration (#429, #523)", () => {
+  test("returns now+ttl as ISO8601 for a positive ttl", () => {
     const before = Date.now();
     const iso = ttlSecondsToExpiration(60);
     const after = Date.now();
-    const t = new Date(iso).getTime();
+    expect(iso).toBeDefined();
+    const t = new Date(iso!).getTime();
     expect(t).toBeGreaterThanOrEqual(before + 60_000);
     expect(t).toBeLessThanOrEqual(after + 60_000);
-    expect(iso.endsWith("Z")).toBe(true);
+    expect(iso!.endsWith("Z")).toBe(true);
+  });
+
+  test("returns undefined for a null (omitted) ttl ⇒ permanent (#523)", () => {
+    expect(ttlSecondsToExpiration(null)).toBeUndefined();
   });
 });
 

--- a/admin/app/lib/client/usecase/cli/dispatcher.ts
+++ b/admin/app/lib/client/usecase/cli/dispatcher.ts
@@ -16,8 +16,10 @@
  *     (#428).
  *   - `put vertex` / `put edge` / `add edge` carry the parser-supplied
  *     `ttlSeconds` through as `expiration = now + ttl` so server-side
- *     decay matches what the user typed (#429). Mirrors Go REPL
- *     `cli/service/service.go` `c.client.PutVertex(ctx, key, value, ttl)`.
+ *     decay matches what the user typed (#429); an omitted `ttl_seconds`
+ *     (null) sends no expiration and is stored permanently (#523).
+ *     Mirrors Go REPL `cli/service/service.go`
+ *     `c.client.PutVertex(ctx, key, value, ttl)`.
  *   - `get vertex` / `get edge` raise `LanternApiError.notFound` when the
  *     adapter returned `null` so the scrollback renders a red `[not_found]`
  *     error chip rather than a misleading `OK` (#430).
@@ -237,13 +239,18 @@ export function coerceValue(
 }
 
 /**
- * Convert a parser-supplied TTL (in whole seconds; the verbs default
- * to one year) to the ISO-8601 absolute expiration the wire format
- * carries. Mirrors `cli/service/service.go`'s `time.Now().Add(ttl)`
- * server-side computation.
+ * Convert a parser-supplied TTL (in whole seconds) to the ISO-8601
+ * absolute expiration the wire format carries. A `null` TTL means the
+ * verb omitted `ttl_seconds`, which maps to `undefined` so no
+ * expiration is sent and the server stores the value permanently
+ * (decay is opt-in; see #523). Mirrors `cli/service/service.go`'s
+ * `time.Now().Add(ttl)` server-side computation for positive TTLs.
  *
  * Exported for unit testing.
  */
-export function ttlSecondsToExpiration(ttlSeconds: number): string {
+export function ttlSecondsToExpiration(
+  ttlSeconds: number | null,
+): string | undefined {
+  if (ttlSeconds === null) return undefined;
   return new Date(Date.now() + ttlSeconds * 1000).toISOString();
 }

--- a/cli/cmd/bulk.go
+++ b/cli/cmd/bulk.go
@@ -30,8 +30,9 @@ INPUT SCHEMAS
   bulk edges add  / bulk edges put:
     {"tail":"alice","head":"bob","weight":1.5,"ttl":"1h"}
 
-  "ttl" is a Go duration string (e.g. 30s, 5m, 1h, 24h). If omitted, 24h
-  is used. "value" may be any JSON value (object, array, scalar).
+  "ttl" is a Go duration string (e.g. 30s, 5m, 1h, 24h). If omitted, the
+  vertex/edge is stored permanently (no decay). "value" may be any JSON
+  value (object, array, scalar).
 
 ERRORS
   A malformed line aborts the stream and returns exit code 1. Already-sent
@@ -59,9 +60,23 @@ type edgeLine struct {
 
 func parseTTL(s string) (time.Duration, error) {
 	if s == "" {
-		return 24 * time.Hour, nil
+		// Omitted "ttl" ⇒ permanent (no decay). expirationFromTTL maps the
+		// resulting zero duration to the wire's permanent sentinel (#523).
+		return 0, nil
 	}
 	return time.ParseDuration(s)
+}
+
+// expirationFromTTL maps a relative TTL onto the absolute expiration the
+// batch RPCs carry. A non-positive ttl ⇒ permanent: it yields the zero
+// time.Time, which the SDK serialises as the wire's never-expiring
+// sentinel. Mirrors the SDK convenience-method contract so the bulk path
+// injects no hidden default expiration (#523).
+func expirationFromTTL(ttl time.Duration) time.Time {
+	if ttl <= 0 {
+		return time.Time{}
+	}
+	return time.Now().Add(ttl)
 }
 
 func openInput(path string) (io.ReadCloser, error) {
@@ -80,7 +95,7 @@ Each line:
   {"key":"<string>","value":<any json>,"ttl":"<duration>"}
 
 Lines are accumulated into batches of --chunk-size and sent via PutVertices.
-` + "`ttl`" + ` defaults to 24h when omitted.`,
+` + "`ttl`" + ` is stored permanently (no decay) when omitted.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r, err := openInput(args[0])
@@ -141,7 +156,7 @@ Lines are accumulated into batches of --chunk-size and sent via PutVertices.
 				value = string(b)
 			}
 			batch = append(batch, client.VertexInput{
-				Key: v.Key, Value: value, Expiration: time.Now().Add(ttl),
+				Key: v.Key, Value: value, Expiration: expirationFromTTL(ttl),
 			})
 			if len(batch) >= flagChunkSize {
 				if err := flush(); err != nil {
@@ -171,7 +186,7 @@ Each line:
 
 Lines are accumulated into batches of --chunk-size and sent via ` +
 			(map[string]string{"add": "AddEdges", "put": "PutEdges"})[verb] + `.
-` + "`ttl`" + ` defaults to 24h when omitted.
+` + "`ttl`" + ` is stored permanently (no decay) when omitted.
 
 Recall the semantic difference: ` + "`add`" + ` SUMS weight onto existing edges
 (non-idempotent), ` + "`put`" + ` REPLACES it (idempotent).`,
@@ -229,7 +244,7 @@ Recall the semantic difference: ` + "`add`" + ` SUMS weight onto existing edges
 				}
 				batch = append(batch, client.EdgeInput{
 					Tail: e.Tail, Head: e.Head, Weight: e.Weight,
-					Expiration: time.Now().Add(ttl),
+					Expiration: expirationFromTTL(ttl),
 				})
 				if len(batch) >= flagChunkSize {
 					if err := flush(); err != nil {

--- a/cli/cmd/edge.go
+++ b/cli/cmd/edge.go
@@ -111,7 +111,8 @@ SEMANTICS
 
 TTL
   --ttl bumps the edge's expiration to now+ttl on every call. There is no
-  "extend by" mode — each call sets a fresh absolute expiration. Default 24h.
+  "extend by" mode — each call sets a fresh absolute expiration. Omit --ttl
+  (or pass 0) to store the edge permanently (no decay).
 
 WEIGHT
   Parsed as float32 (the wire type). NaN and ±Inf are rejected server-side.
@@ -157,7 +158,8 @@ SEMANTICS
   it on UNAVAILABLE / RESOURCE_EXHAUSTED.
 
 TTL
-  --ttl sets the edge's expiration to now+ttl. Default 24h.
+  --ttl sets the edge's expiration to now+ttl. Omit --ttl (or pass 0) to
+  store the edge permanently (no decay).
 
 WEIGHT
   Parsed as float32. NaN and ±Inf are rejected server-side.
@@ -274,8 +276,8 @@ EXAMPLES
 }
 
 func init() {
-	edgeAddCmd.Flags().DurationVar(&edgeAddTTL, "ttl", 24*time.Hour, "TTL relative to now (e.g. 30s, 5m, 24h)")
-	edgePutCmd.Flags().DurationVar(&edgePutTTL, "ttl", 24*time.Hour, "TTL relative to now (e.g. 30s, 5m, 24h)")
+	edgeAddCmd.Flags().DurationVar(&edgeAddTTL, "ttl", 0, "TTL relative to now (e.g. 30s, 5m, 24h); omit or 0 = permanent")
+	edgePutCmd.Flags().DurationVar(&edgePutTTL, "ttl", 0, "TTL relative to now (e.g. 30s, 5m, 24h); omit or 0 = permanent")
 	edgeDeleteCmd.Flags().String("separator", ":", "delimiter inside each tail:head positional argument")
 
 	edgeCmd.AddCommand(edgeGetCmd, edgeAddCmd, edgePutCmd, edgeDeleteCmd)

--- a/cli/cmd/vertex.go
+++ b/cli/cmd/vertex.go
@@ -98,7 +98,8 @@ VALUE TYPING
 TTL SEMANTICS
   --ttl is a Go duration relative to the server's "now" at receipt
   (e.g. 30s, 5m, 1h, 24h, 168h). The vertex is reaped lazily after it
-  expires. Default 24h.
+  expires. Omit --ttl (or pass 0) to store the vertex permanently
+  (no decay).
 
 OUTPUT
   Prints "OK" on success. Errors go to stderr (exit code 2 for server
@@ -188,7 +189,7 @@ EXAMPLES
 }
 
 func init() {
-	vertexPutCmd.Flags().DurationVar(&vertexPutTTL, "ttl", 24*time.Hour, "TTL relative to now (e.g. 30s, 5m, 24h)")
+	vertexPutCmd.Flags().DurationVar(&vertexPutTTL, "ttl", 0, "TTL relative to now (e.g. 30s, 5m, 24h); omit or 0 = permanent")
 	vertexPutCmd.Flags().StringVar(&vertexPutValueType, "value-type", "auto", "type of <value>: auto|string|int|float|bool|datetime|duration|json")
 
 	vertexCmd.AddCommand(vertexGetCmd, vertexPutCmd, vertexDeleteCmd)

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -222,7 +222,10 @@ func PutVertexParam(s *Source) (*PutVertex, error) {
 		return nil, err
 	}
 	if err := EOF(s); err == nil {
-		m.TTL = 24 * 365 * time.Hour
+		// Omitted ttl_seconds ⇒ permanent (no decay). Leaving TTL at its
+		// zero value makes cli/service forward a ttl<=0 to the SDK, whose
+		// convenience methods send the wire's permanent sentinel (#523).
+		m.TTL = 0
 		return m, nil
 	}
 	if m.TTL, err = Duration(s); err != nil {
@@ -248,7 +251,8 @@ func PutEdgeParam(s *Source) (*PutEdge, error) {
 		return nil, err
 	}
 	if err := EOF(s); err == nil {
-		m.TTL = 24 * 365 * time.Hour
+		// Omitted ttl_seconds ⇒ permanent (no decay); see PutVertexParam (#523).
+		m.TTL = 0
 		return m, nil
 	}
 	if m.TTL, err = Duration(s); err != nil {
@@ -273,7 +277,8 @@ func AddEdgeParam(s *Source) (*AddEdge, error) {
 		return nil, err
 	}
 	if err := EOF(s); err == nil {
-		m.TTL = 24 * 365 * time.Hour
+		// Omitted ttl_seconds ⇒ permanent (no decay); see PutVertexParam (#523).
+		m.TTL = 0
 		return m, nil
 	}
 	if m.TTL, err = Duration(s); err != nil {

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -1,0 +1,92 @@
+package parser
+
+import (
+	"testing"
+	"time"
+)
+
+// TestParam_OmittedTTLIsPermanent pins the opt-in decay contract (#523)
+// for the REPL grammar: a write that omits ttl_seconds leaves TTL at its
+// zero value (forwarded to the SDK as "permanent"), while an explicit
+// ttl_seconds is parsed as whole seconds. The param parsers run after the
+// verb/object tokens have been consumed, so each Source carries only the
+// argument portion.
+func TestParam_OmittedTTLIsPermanent(t *testing.T) {
+	t.Run("put vertex", func(t *testing.T) {
+		cases := []struct {
+			name string
+			in   string
+			want time.Duration
+		}{
+			{name: "omitted is permanent", in: "key value", want: 0},
+			{name: "explicit seconds", in: "key value 60", want: 60 * time.Second},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				s, err := NewSource(tc.in)
+				if err != nil {
+					t.Fatalf("NewSource(%q): %v", tc.in, err)
+				}
+				m, err := PutVertexParam(s)
+				if err != nil {
+					t.Fatalf("PutVertexParam(%q): %v", tc.in, err)
+				}
+				if m.TTL != tc.want {
+					t.Fatalf("PutVertexParam(%q).TTL = %v, want %v", tc.in, m.TTL, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("put edge", func(t *testing.T) {
+		cases := []struct {
+			name string
+			in   string
+			want time.Duration
+		}{
+			{name: "omitted is permanent", in: "a b 1.5", want: 0},
+			{name: "explicit seconds", in: "a b 1.5 60", want: 60 * time.Second},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				s, err := NewSource(tc.in)
+				if err != nil {
+					t.Fatalf("NewSource(%q): %v", tc.in, err)
+				}
+				m, err := PutEdgeParam(s)
+				if err != nil {
+					t.Fatalf("PutEdgeParam(%q): %v", tc.in, err)
+				}
+				if m.TTL != tc.want {
+					t.Fatalf("PutEdgeParam(%q).TTL = %v, want %v", tc.in, m.TTL, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("add edge", func(t *testing.T) {
+		cases := []struct {
+			name string
+			in   string
+			want time.Duration
+		}{
+			{name: "omitted is permanent", in: "a b 1.5", want: 0},
+			{name: "explicit seconds", in: "a b 1.5 60", want: 60 * time.Second},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				s, err := NewSource(tc.in)
+				if err != nil {
+					t.Fatalf("NewSource(%q): %v", tc.in, err)
+				}
+				m, err := AddEdgeParam(s)
+				if err != nil {
+					t.Fatalf("AddEdgeParam(%q): %v", tc.in, err)
+				}
+				if m.TTL != tc.want {
+					t.Fatalf("AddEdgeParam(%q).TTL = %v, want %v", tc.in, m.TTL, tc.want)
+				}
+			})
+		}
+	})
+}

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -232,9 +232,24 @@ func (l *Lantern) GetVertex(ctx context.Context, key string) (*Vertex, error) {
 	return resp.Vertex, nil
 }
 
-// PutVertex upserts a single vertex with a relative TTL.
+// expirationFromTTL converts a relative TTL into the absolute expiration
+// the wire carries. A non-positive ttl means "no expiration" (permanent):
+// it yields the zero time.Time, which serialises to the wire's permanent
+// sentinel and is stored by the server as never-expiring (see #523 and
+// core/cache.IsLiveAt). Decay is therefore strictly opt-in via a positive
+// ttl. This keeps the relative-TTL convenience methods consistent with the
+// absolute *At variants, which already treat a zero expiration as permanent.
+func expirationFromTTL(ttl time.Duration) time.Time {
+	if ttl <= 0 {
+		return time.Time{}
+	}
+	return time.Now().Add(ttl)
+}
+
+// PutVertex upserts a single vertex with a relative TTL. A non-positive ttl
+// stores the vertex permanently (no decay); see expirationFromTTL.
 func (l *Lantern) PutVertex(ctx context.Context, key string, value any, ttl time.Duration) error {
-	return l.PutVertexAt(ctx, key, value, time.Now().Add(ttl))
+	return l.PutVertexAt(ctx, key, value, expirationFromTTL(ttl))
 }
 
 // PutVertexAt upserts a single vertex with an absolute expiration time.
@@ -344,9 +359,10 @@ func (l *Lantern) GetEdge(ctx context.Context, tail string, head string) (*Edge,
 }
 
 // AddEdge accumulates weight onto the (tail, head) pair: repeated calls with
-// the same endpoints sum their weights.
+// the same endpoints sum their weights. A non-positive ttl stores the edge
+// permanently (no decay); see expirationFromTTL.
 func (l *Lantern) AddEdge(ctx context.Context, tail string, head string, weight float32, ttl time.Duration) error {
-	return l.AddEdgeAt(ctx, tail, head, weight, time.Now().Add(ttl))
+	return l.AddEdgeAt(ctx, tail, head, weight, expirationFromTTL(ttl))
 }
 
 // AddEdgeAt is AddEdge with an absolute expiration.
@@ -377,9 +393,10 @@ func (l *Lantern) AddEdges(ctx context.Context, inputs []EdgeInput) error {
 	return err
 }
 
-// PutEdge overwrites the (tail, head) pair.
+// PutEdge overwrites the (tail, head) pair. A non-positive ttl stores the
+// edge permanently (no decay); see expirationFromTTL.
 func (l *Lantern) PutEdge(ctx context.Context, tail string, head string, weight float32, ttl time.Duration) error {
-	return l.PutEdgeAt(ctx, tail, head, weight, time.Now().Add(ttl))
+	return l.PutEdgeAt(ctx, tail, head, weight, expirationFromTTL(ttl))
 }
 
 // PutEdgeAt is PutEdge with an absolute expiration.

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -1,6 +1,9 @@
 package client
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 // TestNewLantern_BaseURLValidation covers the constructor's argument-
 // shape guards: empty baseURL, missing scheme, bare host:port. The SDK
@@ -27,4 +30,35 @@ func TestNewLantern_BaseURLValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestExpirationFromTTL pins the opt-in decay contract (#523): a
+// non-positive ttl yields the zero time.Time (the wire's permanent
+// sentinel), while a positive ttl materialises an absolute expiration
+// at now+ttl. The relative-TTL convenience methods (PutVertex, AddEdge,
+// PutEdge) route through this helper, so an omitted/zero TTL stores a
+// vertex/edge permanently rather than injecting a hidden default.
+func TestExpirationFromTTL(t *testing.T) {
+	t.Run("zero ttl is permanent", func(t *testing.T) {
+		if got := expirationFromTTL(0); !got.IsZero() {
+			t.Fatalf("expirationFromTTL(0) = %v, want zero time", got)
+		}
+	})
+	t.Run("negative ttl is permanent", func(t *testing.T) {
+		if got := expirationFromTTL(-time.Hour); !got.IsZero() {
+			t.Fatalf("expirationFromTTL(-1h) = %v, want zero time", got)
+		}
+	})
+	t.Run("positive ttl materialises now+ttl", func(t *testing.T) {
+		const ttl = time.Minute
+		before := time.Now().Add(ttl)
+		got := expirationFromTTL(ttl)
+		after := time.Now().Add(ttl)
+		if got.IsZero() {
+			t.Fatalf("expirationFromTTL(%v) = zero time, want absolute expiration", ttl)
+		}
+		if got.Before(before) || got.After(after) {
+			t.Fatalf("expirationFromTTL(%v) = %v, want within [%v, %v]", ttl, got, before, after)
+		}
+	})
 }

--- a/sdks/go/doc.go
+++ b/sdks/go/doc.go
@@ -26,6 +26,17 @@
 // multiple replicas use a reverse proxy or DNS round-robin in front
 // of Lantern — the SDK speaks to one URL.
 //
+// # TTL and expiration
+//
+// Decay is opt-in. The relative-TTL convenience methods (PutVertex,
+// AddEdge, PutEdge) treat a non-positive ttl as "no expiration": a ttl
+// of 0 (or any negative duration) stores the vertex/edge permanently,
+// and the value never decays. Pass a positive ttl to opt into decay,
+// or use the absolute *At variants (PutVertexAt, AddEdgeAt, PutEdgeAt)
+// with a zero time.Time for the same permanent semantics. The SDK never
+// injects a hidden default expiration — an omitted/zero TTL is honoured
+// as permanent end to end (see #523).
+//
 // # Model definition policy
 //
 // This SDK follows a strict "no parallel models" rule: wherever a

--- a/sdks/node/test/values.test.ts
+++ b/sdks/node/test/values.test.ts
@@ -12,6 +12,7 @@ import {
   Weighting,
   fromEdgeJson,
   fromVertexJson,
+  toEdgeJson,
   toVertexJson,
 } from "../src/index.js";
 
@@ -131,6 +132,25 @@ describe("toVertexJson dispatch", () => {
 
   test("ttl materialises to absolute ISO string", () => {
     const j = toVertexJson({ key: "k", value: 1, ttlSeconds: 60 });
+    expect(typeof j.expiration).toBe("string");
+    const skew = Math.abs(Date.parse(String(j.expiration)) - (Date.now() + 60_000));
+    expect(skew).toBeLessThan(1_000);
+  });
+
+  test("no opts ⇒ no expiration field (permanent) (#523)", () => {
+    const j = toVertexJson({ key: "k", value: 1 });
+    expect(j).not.toHaveProperty("expiration");
+  });
+});
+
+describe("toEdgeJson dispatch (#523)", () => {
+  test("no opts ⇒ no expiration field (permanent)", () => {
+    const j = toEdgeJson({ tail: "a", head: "b", weight: 1 });
+    expect(j).not.toHaveProperty("expiration");
+  });
+
+  test("ttl materialises to absolute ISO string", () => {
+    const j = toEdgeJson({ tail: "a", head: "b", weight: 1, ttlSeconds: 60 });
     expect(typeof j.expiration).toBe("string");
     const skew = Math.abs(Date.parse(String(j.expiration)) - (Date.now() + 60_000));
     expect(skew).toBeLessThan(1_000);

--- a/server/README.md
+++ b/server/README.md
@@ -92,7 +92,7 @@ most common knobs:
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `LANTERN_PORT` | `6380` | Primary Lantern RPC listen port (Connect / gRPC / gRPC-Web multiplexed on h2c). |
-| `LANTERN_DEFAULT_TTL_SECONDS` | `60` | Default vertex/edge TTL. |
+| `LANTERN_DEFAULT_TTL_SECONDS` | `60` | Surfaced in `GetServerStatus`/startup logs only; **not** applied to RPC writes (omitted TTL/expiration ⇒ permanent; decay is opt-in per write, #523). |
 | `LANTERN_GC_INTERVAL_SECONDS` | `60` | GraphCache GC tick. |
 | `LANTERN_MAX_RECV_MSG_BYTES` / `LANTERN_MAX_SEND_MSG_BYTES` | `16 MiB` | Per-RPC message size caps (Connect / gRPC / gRPC-Web). |
 | `LANTERN_MAX_CONCURRENT_STREAMS` | `1024` | Per-connection stream cap (0 = unlimited). |


### PR DESCRIPTION
## Summary

A write that omits its TTL/expiration is supposed to be stored **permanently** —
"unset == permanent" is the wire contract (`core/cache.IsLiveAt` treats a zero /
non-positive expiration as never-expiring). In practice every client surface
injected a **default** TTL before the write reached the wire, so "omit the TTL"
silently meant "decay after the client's default window":

| Surface | Old injected default on omit |
|---|---|
| Go REPL (`cli/parser`) | 1 year |
| Admin web CLI | 1 year |
| Go cobra CLI (`vertex`/`edge`) | 24h |
| Go bulk loader | 24h |

This PR removes all of that default injection so decay is strictly **opt-in per
write**. An omitted TTL now maps to a zero/undefined expiration end-to-end, which
the server stores permanently.

## Changes by surface

- **Go SDK (`sdks/go`)** — new `expirationFromTTL` helper (`ttl <= 0` → zero
  `time.Time` → permanent); `PutVertex` / `AddEdge` / `PutEdge` route through it.
  `doc.go` gains a *TTL and expiration* section documenting the rule.
- **Go REPL parser (`cli/parser`)** — an omitted `ttl_seconds` sets `TTL = 0`
  (permanent) for `put vertex` / `put edge` / `add edge`; new `parser_test.go`
  pins the boundary (omitted → 0, explicit `60` → 60s).
- **Go cobra CLI (`cli/cmd`)** — `vertex` / `edge` default flags and the bulk
  loader's `parseTTL("")` change from `24h`/`1y` to `0` (permanent); help text
  updated.
- **Admin web CLI (`admin`)** — `verbs.ts` / `types.ts` / `dispatcher.ts` carry
  an omitted `ttl_seconds` as `null` → `undefined` expiration → omitted on the
  wire; tests updated. Explicit `0` is intentionally left as `now+0` (out of
  scope for this issue).
- **Node SDK (`sdks/node`)** — regression tests pin "no opts ⇒ no `expiration`
  field" for both `toVertexJson` and `toEdgeJson`.
- **Docs** — `README.md` and `server/README.md` `LANTERN_DEFAULT_TTL_SECONDS`
  rows now state the value is surfaced only in `GetServerStatus`/startup logs and
  is **not** applied to RPC writes.

## Verification

- `gofmt -l` clean; `go vet` + `go test ./...` green in **every** module
  (server, root, core, mcp, pb, sdks/go).
- Admin gates green: `typecheck`, `lint`, `test` (546), `build`, `format:check`.
- Node SDK green: `typecheck`, `test` (32, incl. the new #523 regressions),
  `lint`, `format:check`.

Closes #523