### PR TITLE
feat(admin): live Prometheus time-series charts on Ops page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,10 +369,15 @@ keyless). It does NOT need to follow the `pb → core → sdks/go → root` orde
 the admin SPA's only cross-module build-time dependency is the `proto/`
 sources (consumed by `bun run codegen` via `@bufbuild/protoc-gen-es` +
 `@connectrpc/protoc-gen-connect-es`), so a `pb/vX.Y.Z` bump is the one
-upstream pin that requires re-tagging the admin image. The admin container is
-a pure SPA host (Caddy on `:8080`) — it does not reverse-proxy to the
-listener, so the server's `LANTERN_CORS_ALLOWED_ORIGINS` must include the
-admin origin.
+upstream pin that requires re-tagging the admin image. The admin container
+hosts the SPA on Caddy (`:8080`) and does **not** reverse-proxy the Lantern
+listener — the browser calls the gateway directly, so the server's
+`LANTERN_CORS_ALLOWED_ORIGINS` must include the admin origin. It *does*
+optionally reverse-proxy Prometheus same-origin under `/api/prom` (opt-in via
+the `LANTERN_ADMIN_PROMETHEUS_UPSTREAM` env var, materialised at container
+start by `admin/docker-entrypoint.sh` into a Caddy `handle_path` snippet the
+Caddyfile glob-imports); the SPA's Ops Metrics page uses that path to dodge
+Prometheus's missing CORS headers.
 
 **Release title convention (locked).** Every GitHub Release title MUST equal
 its tag name verbatim — `v0.7.2`, `core/v0.2.0`, `sdks/go/v0.8.0`,

--- a/admin/Caddyfile
+++ b/admin/Caddyfile
@@ -9,11 +9,15 @@
 #   - Listens on :8080 unprivileged (image runs as `caddy` non-root user)
 #     to match the README "Container image" docs.
 #
-# This file is intentionally minimal — no reverse proxy. The admin SPA
-# talks to the Lantern gateway directly from the user's browser. CORS is
-# enforced on the gateway side via LANTERN_CORS_ALLOWED_ORIGINS; see
-# server/README.md.
-
+# This file serves the SPA and, optionally, reverse-proxies Prometheus.
+# The admin SPA talks to the Lantern gateway directly from the user's
+# browser (CORS enforced on the gateway via LANTERN_CORS_ALLOWED_ORIGINS;
+# see server/README.md). Prometheus, however, is proxied SAME-ORIGIN
+# through this host so the browser never makes a cross-origin call to it:
+# the `import` below pulls in /etc/caddy/conf.d/*.caddy, which
+# docker-entrypoint.sh populates with a `handle_path /api/prom/*` reverse
+# proxy ONLY when LANTERN_ADMIN_PROMETHEUS_UPSTREAM is set (otherwise the
+# snippet is empty and the import is a no-op).
 {
 	# Disable Caddy's admin endpoint inside the container. We never need
 	# to reload config at runtime; image tag swap is the deploy unit.
@@ -34,6 +38,16 @@
 	handle /healthz {
 		respond "ok" 200
 	}
+
+	# Optional same-origin Prometheus reverse proxy. No-op unless
+	# LANTERN_ADMIN_PROMETHEUS_UPSTREAM is set at container start. Declared
+	# BEFORE the catch-all SPA `handle` so /api/prom/* is proxied rather
+	# than rewritten to index.html. handle_path strips the /api/prom
+	# prefix, so /api/prom/api/v1/query_range hits Prometheus at
+	# /api/v1/query_range. The GLOB import is deliberate: a directory with
+	# no *.caddy file is a no-op (the SPA still serves), so the container
+	# stays up even if the entrypoint could not write the snippet.
+	import /etc/caddy/conf.d/*.caddy
 
 	# Everything else is the SPA: cache-headers + try_files + file_server.
 	handle {

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -54,11 +54,27 @@ FROM caddy:2.10-alpine
 COPY --from=builder /src/admin/build/client /srv
 COPY admin/Caddyfile /etc/caddy/Caddyfile
 
+# Entrypoint generates the optional Prometheus reverse-proxy snippet at
+# container start. Pre-create the conf.d dir + an empty snippet so the
+# Caddyfile glob import resolves even if the entrypoint is bypassed. The
+# dir is made group-writable and assigned to gid 0 (the k8s/OpenShift
+# arbitrary-uid pattern) so a non-root `runAsUser` can still write the
+# snippet when the Helm chart sets one. Containers that mount a writable
+# volume over /etc/caddy/conf.d (e.g. the Helm emptyDir) override this.
+COPY admin/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh \
+    && mkdir -p /etc/caddy/conf.d \
+    && : > /etc/caddy/conf.d/prom.caddy \
+    && chgrp -R 0 /etc/caddy/conf.d \
+    && chmod -R g+rwX /etc/caddy/conf.d
+
 # The image binds :8080 (see Caddyfile). Containers running orchestrated
 # can map that to whatever external port the platform exposes.
 EXPOSE 8080
 
-# Caddy's default entrypoint loads /etc/caddy/Caddyfile. We pass --adapter
-# caddyfile explicitly so the format is unambiguous even if a future
-# base-image change ever swaps the default.
+# The entrypoint wires up the optional Prometheus proxy (driven by
+# LANTERN_ADMIN_PROMETHEUS_UPSTREAM) and then execs the CMD. We pass
+# --adapter caddyfile explicitly so the format is unambiguous even if a
+# future base-image change ever swaps the default.
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/admin/README.md
+++ b/admin/README.md
@@ -71,6 +71,46 @@ No `lib/server/` is present in v1 because the admin app calls the Lantern
 server directly from the browser over Connect-Web (CORS is enforced by the
 server via `LANTERN_CORS_ALLOWED_ORIGINS`).
 
+## Metrics (Prometheus)
+
+The **Ops** page renders live Prometheus time-series charts (cache size,
+throughput, RPC latency, TTL expirations, replication lag, Go runtime, …)
+alongside the existing point-in-time status cards. The charts issue
+`query_range` calls against a Prometheus server that scrapes the Lantern
+`/metrics` endpoint.
+
+Prometheus serves no CORS headers, so the browser cannot call it
+cross-origin. The admin SPA therefore queries Prometheus **same-origin**
+under `/api/prom` (the default), and the container reverse-proxies that
+path to your Prometheus when `LANTERN_ADMIN_PROMETHEUS_UPSTREAM` is set:
+
+```sh
+docker run --rm -p 8080:8080 \
+  -e LANTERN_ADMIN_PROMETHEUS_UPSTREAM=http://prometheus:9090 \
+  ghcr.io/anaregdesign/lantern-admin:latest
+# Ops Metrics → /api/prom/api/v1/query_range → Prometheus /api/v1/query_range
+```
+
+- **Opt-in.** With `LANTERN_ADMIN_PROMETHEUS_UPSTREAM` unset, the proxy is
+  a no-op and the Metrics section degrades gracefully (it shows an
+  "unreachable" banner instead of charts). Everything else on the Ops page
+  keeps working.
+- **Runtime override.** Change the Prometheus URL at runtime via the
+  **Prometheus** button in the Metrics toolbar — a same-origin path like
+  `/api/prom`, or an absolute `http(s)://…` URL if that server sends CORS
+  headers. The choice is persisted to `localStorage`
+  (`lantern.admin.prometheusUrl`), as is the selected time range
+  (`lantern.admin.metricsRange`).
+- **Dev server.** Under `bun run dev` / `bun run start` there is no Caddy
+  proxy; point the **Prometheus** button at an absolute URL of a
+  CORS-enabled Prometheus, or run the container image to get the
+  same-origin proxy.
+
+Ready-made Prometheus + admin stacks: [`deploy/compose/`](../deploy/compose/)
+(`LANTERN_ADMIN_PROMETHEUS_UPSTREAM` pre-wired) and the Helm
+`admin.prometheus.upstream` value in
+[`deploy/helm/lantern/`](../deploy/helm/lantern/).
+
 ## Container image
 
 Tagged releases of `admin/vX.Y.Z` publish a multi-arch (`linux/amd64`,
@@ -87,11 +127,13 @@ docker run --rm -p 8080:8080 ghcr.io/anaregdesign/lantern-admin:latest
 # → http://localhost:8080
 ```
 
-The container is a **pure SPA host** — there is no reverse proxy to the
-Lantern server. The user's browser talks to the server directly, so the
-server must have `LANTERN_CORS_ALLOWED_ORIGINS` set to allow the admin
-origin (see [`server/README.md`](../server/README.md)). Switch between
-servers at runtime via the **Gateway** button in the header.
+The container does **not** reverse-proxy the Lantern gateway — the user's
+browser talks to the gateway directly, so the server must have
+`LANTERN_CORS_ALLOWED_ORIGINS` set to allow the admin origin (see
+[`server/README.md`](../server/README.md)). Switch between gateways at
+runtime via the **Gateway** button in the header. The container _does_
+optionally reverse-proxy Prometheus same-origin under `/api/prom` for the
+Ops Metrics page — see [Metrics (Prometheus)](#metrics-prometheus).
 
 ### Releasing
 

--- a/admin/app/components/ops/MetricsSection/MetricPanel.module.css
+++ b/admin/app/components/ops/MetricsSection/MetricPanel.module.css
@@ -1,0 +1,40 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem 1.25rem;
+}
+
+.head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.description {
+  margin: 0;
+  color: var(--colorNeutralForeground3);
+  font-size: 0.85rem;
+}
+
+.summary {
+  margin: 0;
+  color: var(--colorNeutralForeground2);
+  font-size: 0.85rem;
+  font-family: var(--fontFamilyMonospace, monospace);
+  word-break: break-word;
+}
+
+.empty {
+  margin: 0;
+  padding: 1.5rem 0;
+  text-align: center;
+  color: var(--colorNeutralForeground3);
+  font-style: italic;
+}

--- a/admin/app/components/ops/MetricsSection/MetricPanel.tsx
+++ b/admin/app/components/ops/MetricsSection/MetricPanel.tsx
@@ -1,0 +1,65 @@
+import {
+  Card,
+  MessageBar,
+  MessageBarBody,
+  Spinner,
+} from "@fluentui/react-components";
+
+import type { PanelSpec } from "~/lib/client/usecase/ops/metrics/catalog";
+import {
+  summariseSeries,
+  toChartSeries,
+} from "~/lib/client/usecase/ops/metrics/selectors";
+import type { PanelState } from "~/lib/client/usecase/ops/metrics/state";
+import { TimeSeriesChart } from "./TimeSeriesChart";
+import styles from "./MetricPanel.module.css";
+
+export interface MetricPanelProps {
+  panel: PanelSpec;
+  state: PanelState;
+}
+
+/**
+ * MetricPanel renders one catalog panel. It owns only presentation: the
+ * PanelState comes from the metrics reducer and the chart series are
+ * derived through the tested selector layer. One panel failing (e.g. a
+ * metric the server has not emitted yet) surfaces an inline MessageBar and
+ * never affects its siblings.
+ */
+export function MetricPanel({ panel, state }: MetricPanelProps) {
+  const testId = `ops-metric-${panel.id}`;
+  const chart = toChartSeries(panel.title, state.series);
+  const pending = state.status === "idle" || state.status === "loading";
+
+  return (
+    <Card className={styles.panel} data-testid={testId}>
+      <header className={styles.head}>
+        <h3 className={styles.title}>{panel.title}</h3>
+        <p className={styles.description}>{panel.description}</p>
+      </header>
+      {pending && <Spinner size="tiny" label="Loading…" />}
+      {state.status === "error" && state.error && (
+        <MessageBar intent="error" data-testid={`${testId}-error`}>
+          <MessageBarBody>{state.error}</MessageBarBody>
+        </MessageBar>
+      )}
+      {state.status === "ready" &&
+        (chart.length === 0 ? (
+          <p className={styles.empty} data-testid={`${testId}-empty`}>
+            No data in the selected range.
+          </p>
+        ) : (
+          <>
+            <TimeSeriesChart
+              series={chart}
+              unit={panel.unit}
+              ariaLabel={`${panel.title} — ${panel.description}`}
+            />
+            <p className={styles.summary} data-testid={`${testId}-summary`}>
+              {summariseSeries(chart, panel.unit)}
+            </p>
+          </>
+        ))}
+    </Card>
+  );
+}

--- a/admin/app/components/ops/MetricsSection/MetricsSection.module.css
+++ b/admin/app/components/ops/MetricsSection/MetricsSection.module.css
@@ -1,0 +1,59 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.lead {
+  margin: 0.25rem 0 0 0;
+  color: var(--colorNeutralForeground3);
+  font-size: 0.9rem;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.groupTitle {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--colorNeutralForeground3);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+}
+
+@media (min-width: 960px) {
+  .grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+}

--- a/admin/app/components/ops/MetricsSection/MetricsSection.tsx
+++ b/admin/app/components/ops/MetricsSection/MetricsSection.tsx
@@ -1,0 +1,134 @@
+import {
+  MessageBar,
+  MessageBarBody,
+  Tab,
+  TabList,
+} from "@fluentui/react-components";
+
+import {
+  METRIC_PANELS,
+  PANEL_GROUPS,
+  type PanelGroup,
+} from "~/lib/client/usecase/ops/metrics/catalog";
+import {
+  RANGE_OPTIONS,
+  type RangeKey,
+} from "~/lib/client/usecase/ops/metrics/range";
+import type { PanelState } from "~/lib/client/usecase/ops/metrics/state";
+import { useMetrics } from "~/lib/client/usecase/ops/metrics/use-metrics";
+import { usePrometheusUrl } from "~/lib/client/usecase/ops/metrics/use-prometheus-url";
+import { MetricPanel } from "./MetricPanel";
+import { PrometheusSwitcher } from "./PrometheusSwitcher";
+import styles from "./MetricsSection.module.css";
+
+export interface MetricsSectionProps {
+  /** Poll interval inherited from the Ops toolbar (0 disables polling). */
+  pollMs: number;
+  /** Bumped by the Ops Refresh button to force an immediate fetch round. */
+  refreshNonce: number;
+}
+
+/**
+ * MetricsSection is the Prometheus time-series half of the Ops page. It sits
+ * below the point-in-time status cards and renders the curated panel
+ * catalog grouped by concern. The Prometheus endpoint and the time range
+ * are ops-local concerns owned here (not in the global header), and polling
+ * is driven by the same cadence/refresh signal as the status cards.
+ */
+export function MetricsSection({ pollMs, refreshNonce }: MetricsSectionProps) {
+  const prometheus = usePrometheusUrl();
+  const { state, range, setRange } = useMetrics({
+    prometheusUrl: prometheus.prometheusUrl,
+    pollMs,
+    refreshNonce,
+  });
+
+  const panelStates = Object.values(state.panels);
+  const allError =
+    panelStates.length > 0 &&
+    panelStates.every((panel) => panel.status === "error");
+
+  return (
+    <section className={styles.section} data-testid="ops-metrics-section">
+      <header className={styles.header}>
+        <div>
+          <h2 className={styles.title}>Metrics</h2>
+          <p className={styles.lead}>
+            Time-series from Prometheus. Point-in-time counts above are the live
+            snapshot.
+          </p>
+        </div>
+        <div className={styles.toolbar}>
+          <TabList
+            selectedValue={range}
+            onTabSelect={(_, data) => setRange(data.value as RangeKey)}
+            size="small"
+            data-testid="ops-metrics-range"
+          >
+            {RANGE_OPTIONS.map((option) => (
+              <Tab key={option.key} value={option.key}>
+                {option.label}
+              </Tab>
+            ))}
+          </TabList>
+          <PrometheusSwitcher prometheus={prometheus} />
+        </div>
+      </header>
+
+      {allError && (
+        <MessageBar intent="warning" data-testid="ops-metrics-degraded">
+          <MessageBarBody>
+            All metric panels failed to load. Verify the Prometheus endpoint (
+            <code>{prometheus.prometheusUrl}</code>) is reachable — on a local{" "}
+            <code>vite preview</code> build there is no Prometheus behind{" "}
+            <code>/api/prom</code>.
+          </MessageBarBody>
+        </MessageBar>
+      )}
+
+      {PANEL_GROUPS.map((group) => {
+        const panels = METRIC_PANELS.filter(
+          (panel) => panel.group === group.id,
+        );
+        if (panels.length === 0) {
+          return null;
+        }
+        return (
+          <MetricGroup
+            key={group.id}
+            label={group.label}
+            groupId={group.id}
+            panels={panels}
+            state={state.panels}
+          />
+        );
+      })}
+    </section>
+  );
+}
+
+interface MetricGroupProps {
+  label: string;
+  groupId: PanelGroup;
+  panels: typeof METRIC_PANELS;
+  state: Record<string, PanelState>;
+}
+
+function MetricGroup({ label, groupId, panels, state }: MetricGroupProps) {
+  return (
+    <div className={styles.group} data-testid={`ops-metrics-group-${groupId}`}>
+      <h3 className={styles.groupTitle}>{label}</h3>
+      <div className={styles.grid}>
+        {panels.map((panel) => {
+          const panelState = state[panel.id];
+          if (!panelState) {
+            return null;
+          }
+          return (
+            <MetricPanel key={panel.id} panel={panel} state={panelState} />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/admin/app/components/ops/MetricsSection/PrometheusSwitcher.module.css
+++ b/admin/app/components/ops/MetricsSection/PrometheusSwitcher.module.css
@@ -1,0 +1,34 @@
+.root {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacingHorizontalS);
+}
+
+.label {
+  font-size: var(--fontSizeBase200);
+  color: var(--colorNeutralForeground3);
+}
+
+.value {
+  font-family: var(--fontFamilyMonospace);
+  font-size: var(--fontSizeBase200);
+  color: var(--colorNeutralForeground1);
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dialogBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalS);
+  min-width: 320px;
+}
+
+@media (max-width: 600px) {
+  .root {
+    width: 100%;
+    justify-content: space-between;
+  }
+}

--- a/admin/app/components/ops/MetricsSection/PrometheusSwitcher.tsx
+++ b/admin/app/components/ops/MetricsSection/PrometheusSwitcher.tsx
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogContent,
+  DialogSurface,
+  DialogTitle,
+  DialogTrigger,
+  Field,
+  Input,
+} from "@fluentui/react-components";
+import { DataTrending24Regular } from "@fluentui/react-icons";
+
+import { DEFAULT_PROMETHEUS_URL } from "~/lib/client/usecase/ops/metrics/prometheus-url";
+import type { UsePrometheusUrl } from "~/lib/client/usecase/ops/metrics/use-prometheus-url";
+import styles from "./PrometheusSwitcher.module.css";
+
+export interface PrometheusSwitcherProps {
+  prometheus: UsePrometheusUrl;
+}
+
+/**
+ * PrometheusSwitcher mirrors ConnectionSwitcher but targets the Prometheus
+ * query base URL used by the Ops Metrics section. It is mounted inside the
+ * Metrics toolbar (ops-local) rather than the global header because the
+ * Prometheus endpoint is only meaningful on this page.
+ */
+export function PrometheusSwitcher({ prometheus }: PrometheusSwitcherProps) {
+  const { prometheusUrl, setPrometheusUrl, reset } = prometheus;
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(prometheusUrl);
+  const [error, setError] = useState<string | null>(null);
+
+  const onOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (next) {
+      setDraft(prometheusUrl);
+      setError(null);
+    }
+  };
+
+  const onSave = () => {
+    const ok = setPrometheusUrl(draft);
+    if (!ok) {
+      setError("Enter a same-origin path like /api/prom or an http(s) URL");
+      return;
+    }
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(_, data) => onOpenChange(data.open)}>
+      <div className={styles.root}>
+        <span className={styles.label}>Prometheus</span>
+        <DialogTrigger disableButtonEnhancement>
+          <Button
+            appearance="subtle"
+            icon={<DataTrending24Regular />}
+            aria-label="Change Prometheus endpoint"
+            data-testid="ops-prometheus-switcher"
+          >
+            <span className={styles.value}>{prometheusUrl}</span>
+          </Button>
+        </DialogTrigger>
+      </div>
+      <DialogSurface>
+        <DialogBody>
+          <DialogTitle>Prometheus query endpoint</DialogTitle>
+          <DialogContent>
+            <div className={styles.dialogBody}>
+              <Field
+                label="Query base URL"
+                validationState={error ? "error" : "none"}
+                validationMessage={error ?? undefined}
+                hint={`Default: ${DEFAULT_PROMETHEUS_URL} (reverse-proxied to Prometheus). The SPA appends /api/v1/query_range.`}
+              >
+                <Input
+                  value={draft}
+                  onChange={(_, data) => {
+                    setDraft(data.value);
+                    setError(null);
+                  }}
+                  placeholder={DEFAULT_PROMETHEUS_URL}
+                  data-testid="ops-prometheus-input"
+                />
+              </Field>
+            </div>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              appearance="secondary"
+              onClick={() => {
+                reset();
+                setDraft(DEFAULT_PROMETHEUS_URL);
+                setError(null);
+              }}
+            >
+              Reset
+            </Button>
+            <DialogTrigger disableButtonEnhancement>
+              <Button appearance="secondary">Cancel</Button>
+            </DialogTrigger>
+            <Button
+              appearance="primary"
+              onClick={onSave}
+              data-testid="ops-prometheus-save"
+            >
+              Save
+            </Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+}

--- a/admin/app/components/ops/MetricsSection/TimeSeriesChart.module.css
+++ b/admin/app/components/ops/MetricsSection/TimeSeriesChart.module.css
@@ -1,0 +1,108 @@
+.figure {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.chart {
+  width: 100%;
+  height: auto;
+  display: block;
+  overflow: visible;
+}
+
+.grid {
+  stroke: var(--colorNeutralStroke2);
+  stroke-width: 1;
+}
+
+.axisLabel {
+  fill: var(--colorNeutralForeground3);
+  font-size: 11px;
+  font-family: var(--fontFamilyMonospace, monospace);
+}
+
+.line {
+  fill: none;
+  stroke-width: 2;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+/*
+ * Eight categorical series styles. Each pairs a distinct hue with a
+ * distinct dash pattern so series remain distinguishable without relying
+ * on colour alone (accessibility) and in monochrome printouts.
+ */
+.series0 {
+  stroke: #0f6cbd;
+}
+.series1 {
+  stroke: #d13438;
+  stroke-dasharray: 6 3;
+}
+.series2 {
+  stroke: #107c10;
+  stroke-dasharray: 2 3;
+}
+.series3 {
+  stroke: #8764b8;
+  stroke-dasharray: 8 3 2 3;
+}
+.series4 {
+  stroke: #c19c00;
+  stroke-dasharray: 4 2;
+}
+.series5 {
+  stroke: #00b7c3;
+  stroke-dasharray: 1 3;
+}
+.series6 {
+  stroke: #e3008c;
+  stroke-dasharray: 10 4;
+}
+.series7 {
+  stroke: #5c2e91;
+  stroke-dasharray: 3 3;
+}
+
+.legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 1rem;
+}
+
+.legendItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+}
+
+.swatch {
+  width: 24px;
+  height: 8px;
+  flex: none;
+}
+
+.legendLabel {
+  color: var(--colorNeutralForeground2);
+}
+
+.legendValue {
+  color: var(--colorNeutralForeground1);
+  font-family: var(--fontFamilyMonospace, monospace);
+  font-weight: 600;
+}
+
+.empty {
+  margin: 0;
+  padding: 1.5rem 0;
+  text-align: center;
+  color: var(--colorNeutralForeground3);
+  font-style: italic;
+}

--- a/admin/app/components/ops/MetricsSection/TimeSeriesChart.tsx
+++ b/admin/app/components/ops/MetricsSection/TimeSeriesChart.tsx
@@ -1,0 +1,241 @@
+import { useId } from "react";
+
+import type { MetricUnit } from "~/lib/client/usecase/ops/metrics/catalog";
+import {
+  formatValue,
+  type ChartSeries,
+} from "~/lib/client/usecase/ops/metrics/selectors";
+import styles from "./TimeSeriesChart.module.css";
+
+export interface TimeSeriesChartProps {
+  series: ChartSeries[];
+  unit: MetricUnit;
+  ariaLabel: string;
+}
+
+// SVG user-space geometry. The chart scales to its container via the
+// viewBox; these numbers are the coordinate system, not CSS pixels.
+const WIDTH = 760;
+const HEIGHT = 240;
+const PAD_LEFT = 56;
+const PAD_RIGHT = 16;
+const PAD_TOP = 16;
+const PAD_BOTTOM = 28;
+const PLOT_W = WIDTH - PAD_LEFT - PAD_RIGHT;
+const PLOT_H = HEIGHT - PAD_TOP - PAD_BOTTOM;
+const Y_TICKS = 4;
+// Number of distinct series styles defined in the CSS module (.series0…N).
+// Colour AND dash pattern vary per slot so the chart is never colour-only.
+const SERIES_STYLES = 8;
+
+/**
+ * TimeSeriesChart is a dependency-free multi-series line chart. The admin
+ * SPA ships no charting library, so this renders raw SVG. Accessibility is
+ * a first-class concern: every series carries both a distinct colour and a
+ * distinct dash pattern (never colour alone), the chart exposes
+ * `role="img"` + `<title>`/`<desc>`, and the consuming MetricPanel always
+ * pairs it with a text legend and a values summary.
+ */
+export function TimeSeriesChart({
+  series,
+  unit,
+  ariaLabel,
+}: TimeSeriesChartProps) {
+  const titleId = useId();
+  const descId = useId();
+  const domain = computeDomain(series);
+
+  if (!domain) {
+    return (
+      <p className={styles.empty} role="img" aria-label={ariaLabel}>
+        No data in range.
+      </p>
+    );
+  }
+
+  const { minT, spanT, minV, spanV } = domain;
+  const xScale = (t: number) => PAD_LEFT + ((t - minT) / spanT) * PLOT_W;
+  const yScale = (v: number) => PAD_TOP + (1 - (v - minV) / spanV) * PLOT_H;
+
+  const yTicks = buildYTicks(minV, spanV);
+  const xTicks = buildXTicks(minT, spanT);
+
+  return (
+    <figure className={styles.figure}>
+      <svg
+        className={styles.chart}
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        role="img"
+        aria-labelledby={`${titleId} ${descId}`}
+        preserveAspectRatio="xMidYMid meet"
+      >
+        <title id={titleId}>{ariaLabel}</title>
+        <desc id={descId}>
+          {series.length} series, latest values:{" "}
+          {series
+            .map((s) => `${s.label} ${formatValue(s.lastValue, unit)}`)
+            .join("; ")}
+          .
+        </desc>
+        {yTicks.map((tick) => {
+          const y = yScale(tick).toFixed(1);
+          return (
+            <g key={`y-${tick}`}>
+              <line
+                className={styles.grid}
+                x1={PAD_LEFT}
+                y1={y}
+                x2={PAD_LEFT + PLOT_W}
+                y2={y}
+              />
+              <text
+                className={styles.axisLabel}
+                x={PAD_LEFT - 8}
+                y={y}
+                textAnchor="end"
+                dominantBaseline="central"
+              >
+                {formatValue(tick, unit)}
+              </text>
+            </g>
+          );
+        })}
+        {xTicks.map((t, i) => {
+          const x = xScale(t);
+          const anchor =
+            i === 0 ? "start" : i === xTicks.length - 1 ? "end" : "middle";
+          return (
+            <text
+              key={`x-${t}`}
+              className={styles.axisLabel}
+              x={x.toFixed(1)}
+              y={HEIGHT - PAD_BOTTOM + 18}
+              textAnchor={anchor}
+            >
+              {formatClock(t)}
+            </text>
+          );
+        })}
+        {series.map((s) => {
+          const d = buildPath(s.points, xScale, yScale);
+          if (!d) return null;
+          return (
+            <path
+              key={s.key}
+              className={`${styles.line} ${seriesClass(s.colorIndex)}`}
+              d={d}
+            />
+          );
+        })}
+      </svg>
+      <ul className={styles.legend}>
+        {series.map((s) => (
+          <li key={s.key} className={styles.legendItem}>
+            <svg
+              className={styles.swatch}
+              viewBox="0 0 24 8"
+              aria-hidden="true"
+            >
+              <line
+                className={`${styles.line} ${seriesClass(s.colorIndex)}`}
+                x1="0"
+                y1="4"
+                x2="24"
+                y2="4"
+              />
+            </svg>
+            <span className={styles.legendLabel}>{s.label}</span>
+            <span className={styles.legendValue}>
+              {formatValue(s.lastValue, unit)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </figure>
+  );
+}
+
+function seriesClass(colorIndex: number): string {
+  const slot = ((colorIndex % SERIES_STYLES) + SERIES_STYLES) % SERIES_STYLES;
+  return styles[`series${slot}`] ?? "";
+}
+
+interface Domain {
+  minT: number;
+  spanT: number;
+  minV: number;
+  spanV: number;
+}
+
+function computeDomain(series: ChartSeries[]): Domain | null {
+  let minT = Number.POSITIVE_INFINITY;
+  let maxT = Number.NEGATIVE_INFINITY;
+  let minV = Number.POSITIVE_INFINITY;
+  let maxV = Number.NEGATIVE_INFINITY;
+  for (const s of series) {
+    for (const p of s.points) {
+      if (p.t < minT) minT = p.t;
+      if (p.t > maxT) maxT = p.t;
+      if (Number.isFinite(p.v)) {
+        if (p.v < minV) minV = p.v;
+        if (p.v > maxV) maxV = p.v;
+      }
+    }
+  }
+  if (!Number.isFinite(minT) || !Number.isFinite(minV)) {
+    return null;
+  }
+  // Expand a flat domain so a constant series renders as a centred line.
+  if (minV === maxV) {
+    const pad = minV === 0 ? 1 : Math.abs(minV) * 0.1;
+    minV -= pad;
+    maxV += pad;
+  }
+  return {
+    minT,
+    spanT: maxT - minT || 1,
+    minV,
+    spanV: maxV - minV || 1,
+  };
+}
+
+function buildPath(
+  points: ChartSeries["points"],
+  xScale: (t: number) => number,
+  yScale: (v: number) => number,
+): string {
+  let d = "";
+  let pen = false;
+  for (const p of points) {
+    if (!Number.isFinite(p.v)) {
+      // A gap (missing/NaN sample) lifts the pen so the line breaks
+      // instead of interpolating across an absent region.
+      pen = false;
+      continue;
+    }
+    const x = xScale(p.t).toFixed(1);
+    const y = yScale(p.v).toFixed(1);
+    d += `${pen ? "L" : "M"}${x},${y} `;
+    pen = true;
+  }
+  return d.trim();
+}
+
+function buildYTicks(minV: number, spanV: number): number[] {
+  const ticks: number[] = [];
+  for (let i = 0; i <= Y_TICKS; i += 1) {
+    ticks.push(minV + (spanV * i) / Y_TICKS);
+  }
+  return ticks;
+}
+
+function buildXTicks(minT: number, spanT: number): number[] {
+  return [minT, minT + spanT / 2, minT + spanT];
+}
+
+function formatClock(t: number): string {
+  return new Date(t * 1000).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/admin/app/components/ops/OpsPage/OpsPage.tsx
+++ b/admin/app/components/ops/OpsPage/OpsPage.tsx
@@ -8,6 +8,7 @@ import {
   Switch,
 } from "@fluentui/react-components";
 import { ArrowClockwise20Regular } from "@fluentui/react-icons";
+import { useCallback, useState } from "react";
 
 import {
   peerStatePillIntent,
@@ -18,6 +19,7 @@ import {
 } from "~/lib/client/usecase/ops/selectors";
 import { DEFAULT_POLL_MS } from "~/lib/client/usecase/ops/state";
 import { useOps } from "~/lib/client/usecase/ops/use-ops";
+import { MetricsSection } from "../MetricsSection/MetricsSection";
 import styles from "./OpsPage.module.css";
 
 /**
@@ -32,10 +34,18 @@ import styles from "./OpsPage.module.css";
  */
 export function OpsPage() {
   const ops = useOps();
+  const [refreshNonce, setRefreshNonce] = useState(0);
   const pollingOn = ops.state.pollMs > 0;
   const onPollToggle = (_: unknown, data: { checked: boolean }) => {
     ops.setPollMs(data.checked ? DEFAULT_POLL_MS : 0);
   };
+  // The toolbar Refresh button refreshes both halves of the page: the
+  // status cards (ops.refresh) and the metric panels (refreshNonce bump,
+  // which the MetricsSection effect observes).
+  const onRefresh = useCallback(() => {
+    ops.refresh();
+    setRefreshNonce((n) => n + 1);
+  }, [ops]);
   return (
     <div className={styles.root}>
       <header className={styles.header}>
@@ -55,7 +65,7 @@ export function OpsPage() {
           />
           <Button
             icon={<ArrowClockwise20Regular />}
-            onClick={ops.refresh}
+            onClick={onRefresh}
             data-testid="ops-refresh"
           >
             Refresh
@@ -74,6 +84,7 @@ export function OpsPage() {
           error={ops.state.replication.error}
         />
       </section>
+      <MetricsSection pollMs={ops.state.pollMs} refreshNonce={refreshNonce} />
     </div>
   );
 }

--- a/admin/app/lib/client/infrastructure/api/prometheus-query-range.test.ts
+++ b/admin/app/lib/client/infrastructure/api/prometheus-query-range.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import {
+  PrometheusError,
+  parseSampleValue,
+  queryRange,
+} from "./prometheus-query-range";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+type FetchArgs = { url: string; init?: RequestInit };
+
+/** Replaces global fetch with a stub returning `response`, capturing args. */
+function stubFetch(response: Response | (() => never)): FetchArgs {
+  const captured: FetchArgs = { url: "" };
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    captured.url = String(input);
+    captured.init = init;
+    if (typeof response === "function") {
+      response();
+    }
+    return Promise.resolve(response as Response);
+  }) as typeof fetch;
+  return captured;
+}
+
+function matrix(
+  result: Array<{
+    metric: Record<string, string>;
+    values: Array<[number, string]>;
+  }>,
+): Response {
+  return new Response(
+    JSON.stringify({
+      status: "success",
+      data: { resultType: "matrix", result },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+describe("queryRange", () => {
+  it("builds the query_range URL with start/end/step", async () => {
+    const captured = stubFetch(matrix([]));
+    await queryRange("/api/prom", {
+      query: "up",
+      start: 1000.7,
+      end: 2000.2,
+      step: 30,
+    });
+    expect(captured.url).toBe(
+      "/api/prom/api/v1/query_range?query=up&start=1000&end=2000&step=30s",
+    );
+  });
+
+  it("url-encodes the PromQL expression", async () => {
+    const captured = stubFetch(matrix([]));
+    await queryRange("http://localhost:9090", {
+      query: "sum by (grpc_method) (rate(grpc_server_handled_total[1m]))",
+      start: 0,
+      end: 60,
+      step: 15,
+    });
+    expect(captured.url).toContain("query=sum+by+%28grpc_method%29");
+    expect(
+      captured.url.startsWith("http://localhost:9090/api/v1/query_range?"),
+    ).toBe(true);
+  });
+
+  it("maps a matrix response into MetricSeries with parsed points", async () => {
+    stubFetch(
+      matrix([
+        {
+          metric: { __name__: "lantern_vertices", instance: "a" },
+          values: [
+            [1000, "12"],
+            [1030, "13.5"],
+          ],
+        },
+      ]),
+    );
+    const series = await queryRange("/api/prom", {
+      query: "lantern_vertices",
+      start: 1000,
+      end: 1030,
+      step: 30,
+    });
+    expect(series).toHaveLength(1);
+    expect(series[0].labels).toEqual({
+      __name__: "lantern_vertices",
+      instance: "a",
+    });
+    expect(series[0].points).toEqual([
+      { t: 1000, v: 12 },
+      { t: 1030, v: 13.5 },
+    ]);
+  });
+
+  it("returns multiple series for a `by`-grouped query", async () => {
+    stubFetch(
+      matrix([
+        { metric: { grpc_method: "GetVertex" }, values: [[0, "1"]] },
+        { metric: { grpc_method: "PutVertex" }, values: [[0, "2"]] },
+      ]),
+    );
+    const series = await queryRange("/api/prom", {
+      query: "x",
+      start: 0,
+      end: 0,
+      step: 1,
+    });
+    expect(series.map((s) => s.labels.grpc_method)).toEqual([
+      "GetVertex",
+      "PutVertex",
+    ]);
+  });
+
+  it("parses special float sample values", async () => {
+    stubFetch(
+      matrix([
+        {
+          metric: {},
+          values: [
+            [0, "NaN"],
+            [1, "+Inf"],
+            [2, "-Inf"],
+          ],
+        },
+      ]),
+    );
+    const series = await queryRange("/api/prom", {
+      query: "x",
+      start: 0,
+      end: 2,
+      step: 1,
+    });
+    expect(Number.isNaN(series[0].points[0].v)).toBe(true);
+    expect(series[0].points[1].v).toBe(Number.POSITIVE_INFINITY);
+    expect(series[0].points[2].v).toBe(Number.NEGATIVE_INFINITY);
+  });
+
+  it("throws a status PrometheusError when Prometheus replies status:error", async () => {
+    stubFetch(
+      new Response(
+        JSON.stringify({
+          status: "error",
+          errorType: "bad_data",
+          error: "invalid parameter",
+        }),
+        { status: 400 },
+      ),
+    );
+    await expect(
+      queryRange("/api/prom", { query: "(", start: 0, end: 1, step: 1 }),
+    ).rejects.toMatchObject({ kind: "status" });
+  });
+
+  it("throws an http PrometheusError for a non-JSON error body", async () => {
+    stubFetch(new Response("502 Bad Gateway", { status: 502 }));
+    const err = await queryRange("/api/prom", {
+      query: "x",
+      start: 0,
+      end: 1,
+      step: 1,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(PrometheusError);
+    expect((err as PrometheusError).kind).toBe("http");
+    expect((err as PrometheusError).httpStatus).toBe(502);
+  });
+
+  it("throws a parse PrometheusError for an SPA index.html fallback (HTTP 200 HTML)", async () => {
+    stubFetch(
+      new Response("<!DOCTYPE html><html><body>app</body></html>", {
+        status: 200,
+        headers: { "Content-Type": "text/html" },
+      }),
+    );
+    await expect(
+      queryRange("/api/prom", { query: "x", start: 0, end: 1, step: 1 }),
+    ).rejects.toMatchObject({ kind: "parse" });
+  });
+
+  it("throws a parse PrometheusError when resultType is not matrix", async () => {
+    stubFetch(
+      new Response(
+        JSON.stringify({
+          status: "success",
+          data: { resultType: "vector", result: [] },
+        }),
+        { status: 200 },
+      ),
+    );
+    await expect(
+      queryRange("/api/prom", { query: "x", start: 0, end: 1, step: 1 }),
+    ).rejects.toMatchObject({ kind: "parse" });
+  });
+
+  it("throws a network PrometheusError when fetch rejects", async () => {
+    stubFetch(() => {
+      throw new TypeError("Failed to fetch");
+    });
+    await expect(
+      queryRange("/api/prom", { query: "x", start: 0, end: 1, step: 1 }),
+    ).rejects.toMatchObject({ kind: "network" });
+  });
+
+  it("rethrows AbortError untouched (not wrapped in PrometheusError)", async () => {
+    stubFetch(() => {
+      const abort = new Error("aborted");
+      abort.name = "AbortError";
+      throw abort;
+    });
+    const err = await queryRange("/api/prom", {
+      query: "x",
+      start: 0,
+      end: 1,
+      step: 1,
+    }).catch((e) => e);
+    expect(err).not.toBeInstanceOf(PrometheusError);
+    expect((err as Error).name).toBe("AbortError");
+  });
+});
+
+describe("parseSampleValue", () => {
+  it("parses finite numbers", () => {
+    expect(parseSampleValue("3.14")).toBe(3.14);
+    expect(parseSampleValue("0")).toBe(0);
+    expect(parseSampleValue("-7")).toBe(-7);
+  });
+
+  it("maps the Prometheus special-float encodings", () => {
+    expect(Number.isNaN(parseSampleValue("NaN"))).toBe(true);
+    expect(parseSampleValue("+Inf")).toBe(Number.POSITIVE_INFINITY);
+    expect(parseSampleValue("-Inf")).toBe(Number.NEGATIVE_INFINITY);
+  });
+});

--- a/admin/app/lib/client/infrastructure/api/prometheus-query-range.ts
+++ b/admin/app/lib/client/infrastructure/api/prometheus-query-range.ts
@@ -1,0 +1,221 @@
+/**
+ * Prometheus HTTP query adapter for the Ops Metrics section.
+ *
+ * This is a plain `fetch` against Prometheus's `GET /api/v1/query_range`
+ * endpoint — it is NOT a Connect RPC, so it deliberately does not use
+ * `LanternApiError`. Failures surface as `PrometheusError`, a flat,
+ * snapshot-testable error carrying enough context for the UI to render a
+ * "configure / unreachable" state. The success shape is flattened into
+ * `MetricSeries[]` (one entry per returned time series), mirroring the
+ * flattening done by `get-server-status.ts`.
+ *
+ * The `promBaseUrl` may be a same-origin path (`/api/prom`, the default
+ * reverse-proxy shape) or an absolute `http(s)://…` URL; relative paths
+ * resolve against the document origin at fetch time.
+ */
+
+/** A single sample: `t` is epoch seconds, `v` is the parsed float value. */
+export interface MetricPoint {
+  t: number;
+  v: number;
+}
+
+/** One Prometheus time series: its label set plus its samples over the range. */
+export interface MetricSeries {
+  labels: Record<string, string>;
+  points: MetricPoint[];
+}
+
+export type PrometheusErrorKind = "network" | "http" | "status" | "parse";
+
+/**
+ * Error raised by {@link queryRange}. `kind` distinguishes the failure
+ * mode so the UI can phrase the degraded state appropriately:
+ *
+ * - `network` — the request never completed (DNS, connection refused, TLS).
+ * - `http` — a non-2xx response with no usable Prometheus error body.
+ * - `status` — Prometheus replied with `status: "error"` and an `error` field.
+ * - `parse` — the response was not the expected JSON matrix envelope (e.g.
+ *   an SPA `index.html` fallback when no Prometheus is wired up).
+ *
+ * `AbortError` is never wrapped in this type — {@link queryRange} rethrows
+ * the original `DOMException` so callers can detect cancellation via
+ * `err.name === "AbortError"`, consistent with `use-ops.ts`.
+ */
+export class PrometheusError extends Error {
+  readonly kind: PrometheusErrorKind;
+  readonly httpStatus?: number;
+
+  private constructor(
+    message: string,
+    kind: PrometheusErrorKind,
+    httpStatus?: number,
+  ) {
+    super(message);
+    this.name = "PrometheusError";
+    this.kind = kind;
+    this.httpStatus = httpStatus;
+  }
+
+  static network(detail: string): PrometheusError {
+    return new PrometheusError(
+      `Could not reach Prometheus: ${detail}`,
+      "network",
+    );
+  }
+
+  static http(status: number, detail?: string): PrometheusError {
+    const suffix = detail ? `: ${detail}` : "";
+    return new PrometheusError(
+      `Prometheus returned HTTP ${status}${suffix}`,
+      "http",
+      status,
+    );
+  }
+
+  static status(detail: string): PrometheusError {
+    return new PrometheusError(`Prometheus query failed: ${detail}`, "status");
+  }
+
+  static parse(detail: string): PrometheusError {
+    return new PrometheusError(
+      `Unexpected Prometheus response: ${detail}`,
+      "parse",
+    );
+  }
+}
+
+export interface QueryRangeParams {
+  /** A PromQL expression with all placeholders already resolved. */
+  query: string;
+  /** Range start, epoch seconds (inclusive). */
+  start: number;
+  /** Range end, epoch seconds (inclusive). */
+  end: number;
+  /** Resolution step, seconds. */
+  step: number;
+  signal?: AbortSignal;
+}
+
+interface PromMatrixResult {
+  metric?: Record<string, string>;
+  values?: Array<[number, string]>;
+}
+
+interface PromEnvelope {
+  status?: string;
+  error?: string;
+  errorType?: string;
+  data?: {
+    resultType?: string;
+    result?: PromMatrixResult[];
+  };
+}
+
+/**
+ * Executes a Prometheus `query_range` request and returns one
+ * {@link MetricSeries} per time series in the matrix response. Throws a
+ * {@link PrometheusError} on any non-success outcome (and rethrows
+ * `AbortError` untouched).
+ */
+export async function queryRange(
+  promBaseUrl: string,
+  params: QueryRangeParams,
+): Promise<MetricSeries[]> {
+  const search = new URLSearchParams({
+    query: params.query,
+    start: String(Math.floor(params.start)),
+    end: String(Math.floor(params.end)),
+    step: `${Math.max(1, Math.floor(params.step))}s`,
+  });
+  const url = `${promBaseUrl}/api/v1/query_range?${search.toString()}`;
+
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: params.signal,
+    });
+  } catch (err) {
+    if ((err as Error)?.name === "AbortError") {
+      throw err;
+    }
+    throw PrometheusError.network((err as Error)?.message ?? "fetch failed");
+  }
+
+  let body: string;
+  try {
+    body = await resp.text();
+  } catch (err) {
+    if ((err as Error)?.name === "AbortError") {
+      throw err;
+    }
+    throw PrometheusError.network("response body could not be read");
+  }
+
+  let envelope: PromEnvelope | undefined;
+  try {
+    envelope = JSON.parse(body) as PromEnvelope;
+  } catch {
+    if (!resp.ok) {
+      throw PrometheusError.http(resp.status, snippet(body));
+    }
+    throw PrometheusError.parse("response was not valid JSON");
+  }
+
+  if (envelope?.status === "error") {
+    throw PrometheusError.status(envelope.error ?? "unknown error");
+  }
+  if (!resp.ok) {
+    throw PrometheusError.http(resp.status, envelope?.error);
+  }
+  if (envelope?.status !== "success") {
+    throw PrometheusError.parse(
+      `expected status "success", got "${envelope?.status ?? "<missing>"}"`,
+    );
+  }
+  if (envelope.data?.resultType !== "matrix") {
+    throw PrometheusError.parse(
+      `expected a matrix result, got "${envelope.data?.resultType ?? "<missing>"}"`,
+    );
+  }
+
+  return (envelope.data.result ?? []).map(toSeries);
+}
+
+function toSeries(result: PromMatrixResult): MetricSeries {
+  return {
+    labels: result.metric ?? {},
+    points: (result.values ?? []).map(([t, raw]) => ({
+      t,
+      v: parseSampleValue(raw),
+    })),
+  };
+}
+
+/**
+ * Parses a Prometheus sample value string. Prometheus encodes special
+ * floats as `"NaN"`, `"+Inf"`, and `"-Inf"`, which `Number()` does not
+ * handle, so they are mapped explicitly.
+ */
+export function parseSampleValue(raw: string): number {
+  switch (raw) {
+    case "NaN":
+      return Number.NaN;
+    case "+Inf":
+      return Number.POSITIVE_INFINITY;
+    case "-Inf":
+      return Number.NEGATIVE_INFINITY;
+    default:
+      return Number(raw);
+  }
+}
+
+function snippet(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= 80) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, 77)}…`;
+}

--- a/admin/app/lib/client/infrastructure/browser/storage.ts
+++ b/admin/app/lib/client/infrastructure/browser/storage.ts
@@ -1,4 +1,6 @@
 const STORAGE_KEY = "lantern.admin.baseUrl";
+const PROMETHEUS_STORAGE_KEY = "lantern.admin.prometheusUrl";
+const METRICS_RANGE_STORAGE_KEY = "lantern.admin.metricsRange";
 
 export interface BrowserStorage {
   get(key: string): string | null;
@@ -36,3 +38,16 @@ function memoryStorage(): BrowserStorage {
 }
 
 export const connectionStorageKey = STORAGE_KEY;
+
+/**
+ * localStorage key the admin SPA stores the Prometheus query base URL
+ * under (used by the Ops Metrics section). Defaults to the same-origin
+ * reverse-proxy path `/api/prom` — see `usecase/ops/metrics/prometheus-url.ts`.
+ */
+export const prometheusStorageKey = PROMETHEUS_STORAGE_KEY;
+
+/**
+ * localStorage key the admin SPA stores the Ops Metrics time range
+ * selection under (e.g. `1h`). See `usecase/ops/metrics/range.ts`.
+ */
+export const metricsRangeStorageKey = METRICS_RANGE_STORAGE_KEY;

--- a/admin/app/lib/client/usecase/ops/metrics/catalog.test.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/catalog.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+
+import { METRIC_PANELS, PANEL_GROUPS, type PanelGroup } from "./catalog";
+
+const KNOWN_UNITS = new Set(["count", "rate", "ratio", "seconds", "bytes"]);
+const KNOWN_GROUPS = new Set<PanelGroup>(PANEL_GROUPS.map((g) => g.id));
+
+describe("METRIC_PANELS", () => {
+  it("is non-empty", () => {
+    expect(METRIC_PANELS.length).toBeGreaterThan(0);
+  });
+
+  it("has unique kebab-case ids", () => {
+    const ids = METRIC_PANELS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) {
+      expect(id).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+  });
+
+  it("references only known groups and units", () => {
+    for (const panel of METRIC_PANELS) {
+      expect(KNOWN_GROUPS.has(panel.group)).toBe(true);
+      expect(KNOWN_UNITS.has(panel.unit)).toBe(true);
+    }
+  });
+
+  it("gives every panel a title, description, and at least one query", () => {
+    for (const panel of METRIC_PANELS) {
+      expect(panel.title.length).toBeGreaterThan(0);
+      expect(panel.description.length).toBeGreaterThan(0);
+      expect(panel.queries.length).toBeGreaterThan(0);
+      for (const query of panel.queries) {
+        expect(query.expr.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("uses the $__rate placeholder inside every rate()/irate() window", () => {
+    for (const panel of METRIC_PANELS) {
+      for (const query of panel.queries) {
+        if (/\b(?:rate|irate)\(/.test(query.expr)) {
+          expect(query.expr).toContain("[$__rate]");
+        }
+      }
+    }
+  });
+
+  it("never hard-codes a literal range window like [5m]", () => {
+    for (const panel of METRIC_PANELS) {
+      for (const query of panel.queries) {
+        expect(query.expr).not.toMatch(/\[\d+[smhdwy]\]/);
+      }
+    }
+  });
+
+  it("balances parentheses in every expression", () => {
+    for (const panel of METRIC_PANELS) {
+      for (const query of panel.queries) {
+        const opens = (query.expr.match(/\(/g) ?? []).length;
+        const closes = (query.expr.match(/\)/g) ?? []).length;
+        expect(opens).toBe(closes);
+      }
+    }
+  });
+});
+
+describe("PANEL_GROUPS", () => {
+  it("covers every group referenced by a panel", () => {
+    const used = new Set(METRIC_PANELS.map((p) => p.group));
+    for (const group of used) {
+      expect(KNOWN_GROUPS.has(group)).toBe(true);
+    }
+  });
+
+  it("has unique group ids", () => {
+    const ids = PANEL_GROUPS.map((g) => g.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/admin/app/lib/client/usecase/ops/metrics/catalog.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/catalog.ts
@@ -1,0 +1,281 @@
+/**
+ * Declarative catalog of the curated Ops Metrics panels.
+ *
+ * Each {@link PanelSpec} maps one or more PromQL queries onto a single
+ * time-series chart. Expressions use the `$__rate` placeholder wherever a
+ * `rate()` window is required; the selector layer
+ * (`selectors.ts#resolveExpr`) substitutes a concrete window derived from
+ * the active step before the query is sent to Prometheus.
+ *
+ * Every metric name referenced here is a real series exported by the
+ * Lantern server (see `server/provider/*` and `server/metrics/*`) plus the
+ * standard `process_*` / `go_*` collectors registered in
+ * `NewPrometheusRegistry`. Do not invent metric names — add the exporter
+ * first, then a panel.
+ */
+
+/** Logical grouping used to lay panels out under section headings. */
+export type PanelGroup =
+  | "cache"
+  | "throughput"
+  | "latency"
+  | "ttl"
+  | "backpressure"
+  | "replication"
+  | "rejections"
+  | "runtime";
+
+/**
+ * How a panel's values should be formatted on axes / legends. Drives the
+ * value formatter in `selectors.ts`.
+ */
+export type MetricUnit = "count" | "rate" | "ratio" | "seconds" | "bytes";
+
+export interface PanelQuery {
+  /**
+   * A PromQL expression. May contain the literal token `$__rate`, which the
+   * selector replaces with a concrete range-vector window (e.g. `1m`).
+   */
+  expr: string;
+  /**
+   * Optional legend template. `{{label}}` tokens are filled from each
+   * returned series' label set. When omitted the legend is derived from the
+   * series labels (or the panel title for single-series queries).
+   */
+  legend?: string;
+}
+
+export interface PanelSpec {
+  /** Stable kebab-case id — React key, reducer key, and `data-testid` stem. */
+  id: string;
+  group: PanelGroup;
+  title: string;
+  description: string;
+  unit: MetricUnit;
+  queries: PanelQuery[];
+}
+
+/** Section groups in display order, with human-readable headings. */
+export const PANEL_GROUPS: ReadonlyArray<{ id: PanelGroup; label: string }> = [
+  { id: "cache", label: "Cache" },
+  { id: "throughput", label: "Throughput" },
+  { id: "latency", label: "Latency" },
+  { id: "ttl", label: "TTL reaping" },
+  { id: "backpressure", label: "Back-pressure" },
+  { id: "replication", label: "Replication" },
+  { id: "rejections", label: "Rejections" },
+  { id: "runtime", label: "Process / Go runtime" },
+];
+
+/**
+ * The curated panel set. Ordering within a group is preserved in the UI.
+ */
+export const METRIC_PANELS: readonly PanelSpec[] = [
+  {
+    id: "cache-size",
+    group: "cache",
+    title: "Cache size",
+    description: "Live vertices and edges currently held in the store.",
+    unit: "count",
+    queries: [
+      { expr: "lantern_vertices", legend: "vertices" },
+      { expr: "lantern_edges", legend: "edges" },
+    ],
+  },
+  {
+    id: "write-throughput",
+    group: "throughput",
+    title: "Write throughput",
+    description: "Mutation-log appends per second.",
+    unit: "rate",
+    queries: [
+      {
+        expr: "rate(lantern_mutation_log_entries_total[$__rate])",
+        legend: "appends/s",
+      },
+    ],
+  },
+  {
+    id: "rpc-throughput",
+    group: "throughput",
+    title: "RPC throughput",
+    description: "Completed RPCs per second, by method.",
+    unit: "rate",
+    queries: [
+      {
+        expr: "sum by (grpc_method) (rate(grpc_server_handled_total[$__rate]))",
+        legend: "{{grpc_method}}",
+      },
+    ],
+  },
+  {
+    id: "rpc-latency",
+    group: "latency",
+    title: "RPC latency (p50 / p99)",
+    description: "Server handling-time quantiles across all methods.",
+    unit: "seconds",
+    queries: [
+      {
+        expr: "histogram_quantile(0.5, sum by (le) (rate(grpc_server_handling_seconds_bucket[$__rate])))",
+        legend: "p50",
+      },
+      {
+        expr: "histogram_quantile(0.99, sum by (le) (rate(grpc_server_handling_seconds_bucket[$__rate])))",
+        legend: "p99",
+      },
+    ],
+  },
+  {
+    id: "traversal-latency",
+    group: "latency",
+    title: "Illuminate & scan latency (p99)",
+    description: "99th-percentile traversal and scan durations.",
+    unit: "seconds",
+    queries: [
+      {
+        expr: "histogram_quantile(0.99, sum by (le) (rate(lantern_illuminate_duration_seconds_bucket[$__rate])))",
+        legend: "illuminate",
+      },
+      {
+        expr: "histogram_quantile(0.99, sum by (le, op) (rate(lantern_scan_duration_seconds_bucket[$__rate])))",
+        legend: "scan {{op}}",
+      },
+    ],
+  },
+  {
+    id: "gc-duration",
+    group: "latency",
+    title: "GC duration (p99)",
+    description: "99th-percentile graph-cache GC sweep duration.",
+    unit: "seconds",
+    queries: [
+      {
+        expr: "histogram_quantile(0.99, sum by (le) (rate(lantern_gc_duration_seconds_bucket[$__rate])))",
+        legend: "p99",
+      },
+    ],
+  },
+  {
+    id: "ttl-reaping",
+    group: "ttl",
+    title: "TTL reaping",
+    description: "Expired vertices and edges reaped per second, by kind.",
+    unit: "rate",
+    queries: [
+      {
+        expr: "sum by (kind) (rate(lantern_ttl_expirations_total[$__rate]))",
+        legend: "{{kind}}",
+      },
+    ],
+  },
+  {
+    id: "mutation-log-fill",
+    group: "backpressure",
+    title: "Mutation-log fill ratio",
+    description: "Fraction of the mutation-log ring buffer in use (0–1).",
+    unit: "ratio",
+    queries: [
+      { expr: "lantern_mutation_log_fill_ratio", legend: "fill ratio" },
+    ],
+  },
+  {
+    id: "mutation-log-eviction",
+    group: "backpressure",
+    title: "Mutation-log eviction rate",
+    description: "Entries evicted from the mutation log per second.",
+    unit: "rate",
+    queries: [
+      {
+        expr: "rate(lantern_mutation_log_evicted_total[$__rate])",
+        legend: "evicted/s",
+      },
+    ],
+  },
+  {
+    id: "subscribe-streams",
+    group: "backpressure",
+    title: "Active subscribe streams",
+    description: "Open replication Subscribe streams.",
+    unit: "count",
+    queries: [{ expr: "lantern_subscribe_active_streams", legend: "streams" }],
+  },
+  {
+    id: "replication-lag",
+    group: "replication",
+    title: "Replication lag",
+    description: "Per-peer sequence lag behind each origin.",
+    unit: "count",
+    queries: [
+      {
+        expr: "lantern_replication_lag_seq",
+        legend: "{{peer}} ← {{origin}}",
+      },
+    ],
+  },
+  {
+    id: "peer-connected",
+    group: "replication",
+    title: "Peer connectivity",
+    description: "1 when a peer link is up, 0 when down.",
+    unit: "count",
+    queries: [{ expr: "lantern_peer_connected", legend: "{{peer}}" }],
+  },
+  {
+    id: "replication-apply",
+    group: "replication",
+    title: "Replication apply / drop rate",
+    description: "Mutations applied (by op) and dropped per second.",
+    unit: "rate",
+    queries: [
+      {
+        expr: "sum by (op) (rate(lantern_replication_apply_total[$__rate]))",
+        legend: "apply {{op}}",
+      },
+      {
+        expr: "sum(rate(lantern_replication_dropped_total[$__rate]))",
+        legend: "dropped",
+      },
+    ],
+  },
+  {
+    id: "rejections",
+    group: "rejections",
+    title: "Rejections",
+    description:
+      "Validation, rate-limit, and tombstone-clamp rejections per second.",
+    unit: "rate",
+    queries: [
+      {
+        expr: "sum(rate(lantern_validation_rejected_total[$__rate]))",
+        legend: "validation",
+      },
+      {
+        expr: "sum(rate(lantern_rate_limit_rejected_total[$__rate]))",
+        legend: "rate limit",
+      },
+      {
+        expr: "sum(rate(lantern_tombstone_clamp_rejected_total[$__rate]))",
+        legend: "tombstone clamp",
+      },
+    ],
+  },
+  {
+    id: "process-memory",
+    group: "runtime",
+    title: "Memory",
+    description: "Process resident set size and Go heap in-use.",
+    unit: "bytes",
+    queries: [
+      { expr: "process_resident_memory_bytes", legend: "RSS" },
+      { expr: "go_memstats_heap_inuse_bytes", legend: "heap in-use" },
+    ],
+  },
+  {
+    id: "goroutines",
+    group: "runtime",
+    title: "Goroutines",
+    description: "Live goroutine count.",
+    unit: "count",
+    queries: [{ expr: "go_goroutines", legend: "goroutines" }],
+  },
+];

--- a/admin/app/lib/client/usecase/ops/metrics/prometheus-url.test.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/prometheus-url.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  DEFAULT_PROMETHEUS_URL,
+  normalisePrometheusUrl,
+} from "./prometheus-url";
+
+describe("DEFAULT_PROMETHEUS_URL", () => {
+  it("is the same-origin reverse-proxy path", () => {
+    expect(DEFAULT_PROMETHEUS_URL).toBe("/api/prom");
+  });
+});
+
+describe("normalisePrometheusUrl", () => {
+  it("accepts a root-relative same-origin path", () => {
+    expect(normalisePrometheusUrl("/api/prom")).toBe("/api/prom");
+  });
+
+  it("strips trailing slashes from a relative path", () => {
+    expect(normalisePrometheusUrl("/api/prom/")).toBe("/api/prom");
+    expect(normalisePrometheusUrl("/api/prom///")).toBe("/api/prom");
+  });
+
+  it("keeps a bare root path as '/'", () => {
+    expect(normalisePrometheusUrl("/")).toBe("/");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalisePrometheusUrl("  /api/prom  ")).toBe("/api/prom");
+    expect(normalisePrometheusUrl(" http://localhost:9090 ")).toBe(
+      "http://localhost:9090",
+    );
+  });
+
+  it("accepts an absolute http URL and strips the trailing slash", () => {
+    expect(normalisePrometheusUrl("http://localhost:9090/")).toBe(
+      "http://localhost:9090",
+    );
+  });
+
+  it("accepts an absolute https URL with a path prefix", () => {
+    expect(normalisePrometheusUrl("https://prom.example.com/prefix/")).toBe(
+      "https://prom.example.com/prefix",
+    );
+  });
+
+  it("returns null for an empty or whitespace-only input", () => {
+    expect(normalisePrometheusUrl("")).toBeNull();
+    expect(normalisePrometheusUrl("   ")).toBeNull();
+  });
+
+  it("returns null for a non-http(s) scheme", () => {
+    expect(normalisePrometheusUrl("ftp://example.com")).toBeNull();
+    expect(normalisePrometheusUrl("ws://example.com")).toBeNull();
+  });
+
+  it("returns null for a protocol-relative URL", () => {
+    expect(normalisePrometheusUrl("//evil.example.com")).toBeNull();
+  });
+
+  it("returns null for a bare host without a scheme or leading slash", () => {
+    expect(normalisePrometheusUrl("localhost:9090")).toBeNull();
+    expect(normalisePrometheusUrl("api/prom")).toBeNull();
+  });
+});

--- a/admin/app/lib/client/usecase/ops/metrics/prometheus-url.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/prometheus-url.ts
@@ -1,0 +1,60 @@
+/**
+ * Default Prometheus query base URL for the Ops Metrics section.
+ *
+ * The bundled deployment topologies (compose / helm) reverse-proxy
+ * Prometheus through the admin's own Caddy origin at `/api/prom`, so the
+ * browser never makes a cross-origin request and CORS never applies. The
+ * SPA therefore defaults to this same-origin path; operators running
+ * Prometheus elsewhere can point the URL at an absolute `http(s)://…`
+ * endpoint via the in-app Prometheus switcher.
+ *
+ * See `admin/Caddyfile` + `admin/docker-entrypoint.sh` for the opt-in
+ * reverse-proxy route gated on `LANTERN_ADMIN_PROMETHEUS_UPSTREAM`.
+ */
+export const DEFAULT_PROMETHEUS_URL = "/api/prom";
+
+/**
+ * Normalises a user-entered Prometheus base URL.
+ *
+ * Unlike `normaliseBaseUrl` (which requires an absolute http(s) URL), the
+ * Prometheus URL may also be a **root-relative path** like `/api/prom`,
+ * because the default deployment reverse-proxies Prometheus through the
+ * admin's own origin. Both forms are accepted:
+ *
+ * - Absolute: `http://localhost:9090`, `https://prom.example.com/prefix`
+ * - Root-relative: `/api/prom`, `/metrics-proxy`
+ *
+ * In every case a trailing slash is stripped so callers can append
+ * `/api/v1/query_range` unconditionally. Returns `null` for inputs that are
+ * empty, use a non-http(s) scheme, or are relative paths that do not begin
+ * with `/`.
+ */
+export function normalisePrometheusUrl(input: string): string | null {
+  const trimmed = input.trim();
+  if (trimmed === "") {
+    return null;
+  }
+
+  // Root-relative same-origin path (the default deployment shape).
+  if (trimmed.startsWith("/")) {
+    // Reject protocol-relative `//host` — ambiguous and not what we mean.
+    if (trimmed.startsWith("//")) {
+      return null;
+    }
+    const stripped = trimmed.replace(/\/+$/, "");
+    return stripped === "" ? "/" : stripped;
+  }
+
+  // Otherwise it must be an absolute http(s) URL.
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return null;
+  }
+  const path = url.pathname.replace(/\/$/, "");
+  return `${url.protocol}//${url.host}${path}`;
+}

--- a/admin/app/lib/client/usecase/ops/metrics/range.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/range.ts
@@ -1,0 +1,22 @@
+/**
+ * Time-range selection for the Ops Metrics section.
+ *
+ * Ranges are a small fixed set so the selector can be a segmented control
+ * and the persisted value is trivially validatable. Each key maps to a
+ * concrete `(rangeSeconds, stepSeconds)` window in `selectors.ts`.
+ */
+export type RangeKey = "15m" | "1h" | "6h" | "24h";
+
+export const DEFAULT_RANGE: RangeKey = "1h";
+
+export const RANGE_OPTIONS: ReadonlyArray<{ key: RangeKey; label: string }> = [
+  { key: "15m", label: "15m" },
+  { key: "1h", label: "1h" },
+  { key: "6h", label: "6h" },
+  { key: "24h", label: "24h" },
+];
+
+/** Type guard for a persisted / user-supplied range string. */
+export function isRangeKey(value: string): value is RangeKey {
+  return RANGE_OPTIONS.some((option) => option.key === value);
+}

--- a/admin/app/lib/client/usecase/ops/metrics/reducer.test.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/reducer.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "bun:test";
+
+import { METRIC_PANELS } from "./catalog";
+import { metricsReducer, type MetricsAction } from "./reducer";
+import { initialMetricsState, type PanelSeries } from "./state";
+
+const firstPanelId = METRIC_PANELS[0].id;
+const secondPanelId = METRIC_PANELS[1].id;
+
+const sampleSeries: PanelSeries[] = [
+  { legendTemplate: "x", labels: {}, points: [{ t: 0, v: 1 }] },
+];
+
+describe("metricsReducer", () => {
+  it("flips idle panels to loading on the first fetch round", () => {
+    const next = metricsReducer(initialMetricsState(), {
+      type: "FETCH_STARTED",
+      epoch: 1,
+    });
+    expect(next.fetchEpoch).toBe(1);
+    for (const panel of Object.values(next.panels)) {
+      expect(panel.status).toBe("loading");
+    }
+  });
+
+  it("keeps ready panels in place on a subsequent fetch (no flash)", () => {
+    let state = metricsReducer(initialMetricsState(), {
+      type: "FETCH_STARTED",
+      epoch: 1,
+    });
+    state = metricsReducer(state, {
+      type: "PANEL_LOADED",
+      epoch: 1,
+      id: firstPanelId,
+      series: sampleSeries,
+    });
+    const next = metricsReducer(state, { type: "FETCH_STARTED", epoch: 2 });
+    expect(next.panels[firstPanelId].status).toBe("ready");
+    expect(next.panels[firstPanelId].series).toEqual(sampleSeries);
+  });
+
+  it("stores series on PANEL_LOADED for the matching epoch", () => {
+    let state = metricsReducer(initialMetricsState(), {
+      type: "FETCH_STARTED",
+      epoch: 3,
+    });
+    state = metricsReducer(state, {
+      type: "PANEL_LOADED",
+      epoch: 3,
+      id: firstPanelId,
+      series: sampleSeries,
+    });
+    expect(state.panels[firstPanelId]).toEqual({
+      status: "ready",
+      series: sampleSeries,
+      error: null,
+    });
+  });
+
+  it("records an error on PANEL_ERROR for the matching epoch", () => {
+    let state = metricsReducer(initialMetricsState(), {
+      type: "FETCH_STARTED",
+      epoch: 4,
+    });
+    state = metricsReducer(state, {
+      type: "PANEL_ERROR",
+      epoch: 4,
+      id: secondPanelId,
+      error: "boom",
+    });
+    expect(state.panels[secondPanelId].status).toBe("error");
+    expect(state.panels[secondPanelId].error).toBe("boom");
+  });
+
+  it("drops a stale PANEL_LOADED from an older epoch", () => {
+    let state = metricsReducer(initialMetricsState(), {
+      type: "FETCH_STARTED",
+      epoch: 5,
+    });
+    // A newer round started before the old result arrived.
+    state = metricsReducer(state, { type: "FETCH_STARTED", epoch: 6 });
+    const stale: MetricsAction = {
+      type: "PANEL_LOADED",
+      epoch: 5,
+      id: firstPanelId,
+      series: sampleSeries,
+    };
+    const next = metricsReducer(state, stale);
+    expect(next).toBe(state);
+    expect(next.panels[firstPanelId].status).not.toBe("ready");
+  });
+
+  it("ignores actions for an unknown panel id", () => {
+    const state = metricsReducer(initialMetricsState(), {
+      type: "FETCH_STARTED",
+      epoch: 1,
+    });
+    const next = metricsReducer(state, {
+      type: "PANEL_LOADED",
+      epoch: 1,
+      id: "does-not-exist",
+      series: sampleSeries,
+    });
+    expect(next).toBe(state);
+  });
+
+  it("resets panels to a fresh idle state when the range changes", () => {
+    let state = metricsReducer(initialMetricsState("1h"), {
+      type: "FETCH_STARTED",
+      epoch: 1,
+    });
+    state = metricsReducer(state, {
+      type: "PANEL_LOADED",
+      epoch: 1,
+      id: firstPanelId,
+      series: sampleSeries,
+    });
+    const next = metricsReducer(state, { type: "SET_RANGE", range: "6h" });
+    expect(next.range).toBe("6h");
+    expect(next.fetchEpoch).toBe(0);
+    expect(next.panels[firstPanelId].status).toBe("idle");
+    expect(next.panels[firstPanelId].series).toEqual([]);
+  });
+
+  it("is a no-op when SET_RANGE matches the current range", () => {
+    const state = initialMetricsState("1h");
+    const next = metricsReducer(state, { type: "SET_RANGE", range: "1h" });
+    expect(next).toBe(state);
+  });
+
+  it("RESET preserves the range but clears panels and epoch", () => {
+    let state = metricsReducer(initialMetricsState("6h"), {
+      type: "FETCH_STARTED",
+      epoch: 9,
+    });
+    state = metricsReducer(state, {
+      type: "PANEL_LOADED",
+      epoch: 9,
+      id: firstPanelId,
+      series: sampleSeries,
+    });
+    const next = metricsReducer(state, { type: "RESET" });
+    expect(next.range).toBe("6h");
+    expect(next.fetchEpoch).toBe(0);
+    expect(next.panels[firstPanelId].status).toBe("idle");
+  });
+});

--- a/admin/app/lib/client/usecase/ops/metrics/reducer.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/reducer.ts
@@ -1,0 +1,76 @@
+import {
+  type MetricsState,
+  type PanelSeries,
+  type PanelState,
+  initialMetricsState,
+} from "./state";
+import type { RangeKey } from "./range";
+
+/**
+ * MetricsAction is the union of every transition the metrics reducer
+ * understands. Per-panel LOADED/ERROR actions carry the epoch they were
+ * dispatched under so stale in-flight results are dropped.
+ */
+export type MetricsAction =
+  | { type: "FETCH_STARTED"; epoch: number }
+  | { type: "PANEL_LOADED"; epoch: number; id: string; series: PanelSeries[] }
+  | { type: "PANEL_ERROR"; epoch: number; id: string; error: string }
+  | { type: "SET_RANGE"; range: RangeKey }
+  | { type: "RESET" };
+
+/**
+ * metricsReducer applies a MetricsAction. fetchEpoch gating: panel
+ * handlers dispatch with the epoch observed when their round began. A
+ * newer epoch means a fresh round (manual refresh, range change, or
+ * Prometheus-URL change) started while the previous fetch was in flight;
+ * the stale result is discarded so a panel never reverts to old data.
+ */
+export function metricsReducer(
+  state: MetricsState,
+  action: MetricsAction,
+): MetricsState {
+  switch (action.type) {
+    case "FETCH_STARTED": {
+      // Each panel that has never loaded flips to "loading" on its first
+      // fetch; panels already showing data stay put to avoid flashing.
+      const panels: Record<string, PanelState> = {};
+      for (const [id, panel] of Object.entries(state.panels)) {
+        panels[id] =
+          panel.status === "idle" ? { ...panel, status: "loading" } : panel;
+      }
+      return { ...state, fetchEpoch: action.epoch, panels };
+    }
+    case "PANEL_LOADED": {
+      if (action.epoch !== state.fetchEpoch) return state;
+      const existing = state.panels[action.id];
+      if (!existing) return state;
+      return {
+        ...state,
+        panels: {
+          ...state.panels,
+          [action.id]: { status: "ready", series: action.series, error: null },
+        },
+      };
+    }
+    case "PANEL_ERROR": {
+      if (action.epoch !== state.fetchEpoch) return state;
+      const existing = state.panels[action.id];
+      if (!existing) return state;
+      return {
+        ...state,
+        panels: {
+          ...state.panels,
+          [action.id]: { ...existing, status: "error", error: action.error },
+        },
+      };
+    }
+    case "SET_RANGE": {
+      if (action.range === state.range) return state;
+      // Reset panels to idle so the new range shows a loading state rather
+      // than briefly charting the previous window's data on a new axis.
+      return initialMetricsState(action.range);
+    }
+    case "RESET":
+      return initialMetricsState(state.range);
+  }
+}

--- a/admin/app/lib/client/usecase/ops/metrics/selectors.test.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/selectors.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  formatValue,
+  rangeToWindow,
+  rateWindow,
+  resolveExpr,
+  seriesLegend,
+  summariseSeries,
+  toChartSeries,
+} from "./selectors";
+import type { PanelSeries } from "./state";
+
+describe("rangeToWindow", () => {
+  it("maps each range to a step that yields ~60–290 points", () => {
+    for (const range of ["15m", "1h", "6h", "24h"] as const) {
+      const { rangeSeconds, stepSeconds } = rangeToWindow(range);
+      const points = rangeSeconds / stepSeconds;
+      expect(points).toBeGreaterThanOrEqual(60);
+      expect(points).toBeLessThanOrEqual(290);
+    }
+  });
+});
+
+describe("rateWindow", () => {
+  it("uses max(4×step, 60s) formatted as the largest whole unit", () => {
+    expect(rateWindow(15)).toBe("1m"); // 60s
+    expect(rateWindow(30)).toBe("2m"); // 120s
+    expect(rateWindow(120)).toBe("8m"); // 480s
+    expect(rateWindow(300)).toBe("20m"); // 1200s
+  });
+
+  it("formats whole hours as hours", () => {
+    expect(rateWindow(900)).toBe("1h"); // 3600s
+  });
+});
+
+describe("resolveExpr", () => {
+  it("substitutes every $__rate occurrence with the window", () => {
+    expect(
+      resolveExpr("rate(lantern_mutation_log_entries_total[$__rate])", "2m"),
+    ).toBe("rate(lantern_mutation_log_entries_total[2m])");
+  });
+
+  it("treats the window as a literal, not a pattern", () => {
+    expect(resolveExpr("a[$__rate] + b[$__rate]", "1m")).toBe("a[1m] + b[1m]");
+  });
+});
+
+describe("seriesLegend", () => {
+  it("fills template placeholders from labels", () => {
+    expect(
+      seriesLegend("{{grpc_method}}", { grpc_method: "GetVertex" }, "fb"),
+    ).toBe("GetVertex");
+  });
+
+  it("collapses whitespace and falls back when a placeholder is missing", () => {
+    expect(seriesLegend("{{peer}} ← {{origin}}", {}, "fallback")).toBe(
+      "fallback",
+    );
+    expect(seriesLegend("scan {{op}}", { op: "GetVertices" }, "fb")).toBe(
+      "scan GetVertices",
+    );
+  });
+
+  it("returns a static template verbatim", () => {
+    expect(seriesLegend("dropped", { op: "x" }, "fb")).toBe("dropped");
+  });
+
+  it("derives from non-synthetic labels when no template is given", () => {
+    expect(
+      seriesLegend(
+        undefined,
+        { __name__: "m", le: "0.1", kind: "vertex" },
+        "fb",
+      ),
+    ).toBe("vertex");
+  });
+
+  it("falls back to the metric name when only synthetic labels remain", () => {
+    expect(
+      seriesLegend(undefined, { __name__: "lantern_vertices" }, "fb"),
+    ).toBe("lantern_vertices");
+  });
+});
+
+describe("formatValue", () => {
+  it("renders an em dash for non-finite values", () => {
+    expect(formatValue(Number.NaN, "count")).toBe("—");
+    expect(formatValue(Number.POSITIVE_INFINITY, "rate")).toBe("—");
+  });
+
+  it("formats counts compactly", () => {
+    expect(formatValue(12, "count")).toBe("12");
+    expect(formatValue(1500, "count")).toBe("1.5K");
+  });
+
+  it("suffixes rates with /s", () => {
+    expect(formatValue(2.5, "rate")).toBe("2.5/s");
+  });
+
+  it("formats ratios as percentages", () => {
+    expect(formatValue(0.42, "ratio")).toBe("42.0%");
+  });
+
+  it("humanises byte values in binary units", () => {
+    expect(formatValue(512, "bytes")).toBe("512 B");
+    expect(formatValue(1024, "bytes")).toBe("1.0 KiB");
+    expect(formatValue(1024 * 1024 * 3, "bytes")).toBe("3.0 MiB");
+  });
+
+  it("humanises sub-second durations", () => {
+    expect(formatValue(0.00002, "seconds")).toBe("20 µs");
+    expect(formatValue(0.0023, "seconds")).toBe("2.3 ms");
+    expect(formatValue(1.5, "seconds")).toBe("1.50 s");
+    expect(formatValue(90, "seconds")).toBe("1.5 min");
+  });
+});
+
+describe("toChartSeries", () => {
+  const series: PanelSeries[] = [
+    {
+      legendTemplate: "vertices",
+      labels: { __name__: "lantern_vertices" },
+      points: [
+        { t: 0, v: 1 },
+        { t: 1, v: 5 },
+      ],
+    },
+    {
+      legendTemplate: "{{grpc_method}}",
+      labels: { grpc_method: "GetVertex" },
+      points: [{ t: 0, v: Number.NaN }],
+    },
+  ];
+
+  it("assigns stable keys, labels, colour slots, and last finite value", () => {
+    const chart = toChartSeries("Panel", series);
+    expect(chart).toHaveLength(2);
+    expect(chart[0]).toMatchObject({
+      label: "vertices",
+      colorIndex: 0,
+      lastValue: 5,
+    });
+    expect(chart[0].key).toBe("0:vertices");
+    expect(chart[1].label).toBe("GetVertex");
+    expect(Number.isNaN(chart[1].lastValue)).toBe(true);
+  });
+});
+
+describe("summariseSeries", () => {
+  it("returns a no-data sentinel for an empty panel", () => {
+    expect(summariseSeries([], "count")).toBe("No data.");
+  });
+
+  it("joins the latest values with their labels", () => {
+    const chart = toChartSeries("Panel", [
+      { legendTemplate: "vertices", labels: {}, points: [{ t: 0, v: 1500 }] },
+      { legendTemplate: "edges", labels: {}, points: [{ t: 0, v: 3000 }] },
+    ]);
+    expect(summariseSeries(chart, "count")).toBe("vertices: 1.5K, edges: 3K");
+  });
+});

--- a/admin/app/lib/client/usecase/ops/metrics/selectors.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/selectors.ts
@@ -1,0 +1,191 @@
+import type { MetricPoint } from "~/lib/client/infrastructure/api/prometheus-query-range";
+
+import type { MetricUnit } from "./catalog";
+import type { RangeKey } from "./range";
+import type { PanelSeries } from "./state";
+
+/**
+ * Concrete `(rangeSeconds, stepSeconds)` window for each range key. Steps
+ * are chosen to keep every range at ~60–290 points — enough resolution for
+ * a compact chart without over-fetching.
+ */
+const RANGE_WINDOWS: Record<
+  RangeKey,
+  { rangeSeconds: number; stepSeconds: number }
+> = {
+  "15m": { rangeSeconds: 900, stepSeconds: 15 },
+  "1h": { rangeSeconds: 3600, stepSeconds: 30 },
+  "6h": { rangeSeconds: 21600, stepSeconds: 120 },
+  "24h": { rangeSeconds: 86400, stepSeconds: 300 },
+};
+
+export function rangeToWindow(range: RangeKey): {
+  rangeSeconds: number;
+  stepSeconds: number;
+} {
+  return RANGE_WINDOWS[range];
+}
+
+/**
+ * Derives the `rate()` range-vector window for a given step. Prometheus
+ * needs a window covering several scrape steps for `rate()` to be stable,
+ * so we use `max(4 × step, 60s)` and format it as the largest whole unit.
+ */
+export function rateWindow(stepSeconds: number): string {
+  const seconds = Math.max(4 * stepSeconds, 60);
+  return formatPromDuration(seconds);
+}
+
+function formatPromDuration(seconds: number): string {
+  if (seconds % 3600 === 0) return `${seconds / 3600}h`;
+  if (seconds % 60 === 0) return `${seconds / 60}m`;
+  return `${seconds}s`;
+}
+
+/**
+ * Substitutes the `$__rate` placeholder in a catalog expression with a
+ * concrete window. Uses split/join (not RegExp) so the window string is
+ * never interpreted as a pattern.
+ */
+export function resolveExpr(expr: string, window: string): string {
+  return expr.split("$__rate").join(window);
+}
+
+/**
+ * Computes a display label for one series. A legend template containing
+ * `{{label}}` tokens is filled from the series' label set; a static
+ * template is returned verbatim; with no template the label is derived
+ * from the non-synthetic labels, falling back to the panel title.
+ */
+export function seriesLegend(
+  template: string | undefined,
+  labels: Record<string, string>,
+  fallback: string,
+): string {
+  if (template && template.includes("{{")) {
+    let anyFilled = false;
+    const filled = template.replace(
+      /\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g,
+      (_match, key: string) => {
+        const value = labels[key];
+        if (value != null && value !== "") {
+          anyFilled = true;
+          return value;
+        }
+        return "";
+      },
+    );
+    const cleaned = filled.replace(/\s+/g, " ").trim();
+    return anyFilled && cleaned.length > 0 ? cleaned : fallback;
+  }
+  if (template) {
+    return template;
+  }
+  const entries = Object.entries(labels).filter(
+    ([key]) => key !== "__name__" && key !== "le" && key !== "quantile",
+  );
+  if (entries.length === 0) {
+    return labels.__name__ ?? fallback;
+  }
+  return entries.map(([, value]) => value).join(", ");
+}
+
+/** A chart-ready series: a stable key, display label, colour slot, points. */
+export interface ChartSeries {
+  key: string;
+  label: string;
+  colorIndex: number;
+  lastValue: number;
+  points: MetricPoint[];
+}
+
+/**
+ * Maps a panel's resolved series into chart-ready series with stable keys,
+ * display labels, colour slots, and the latest finite value.
+ */
+export function toChartSeries(
+  panelTitle: string,
+  series: PanelSeries[],
+): ChartSeries[] {
+  return series.map((entry, index) => {
+    const label = seriesLegend(entry.legendTemplate, entry.labels, panelTitle);
+    return {
+      key: `${index}:${label}`,
+      label,
+      colorIndex: index,
+      lastValue: lastFiniteValue(entry.points),
+      points: entry.points,
+    };
+  });
+}
+
+function lastFiniteValue(points: MetricPoint[]): number {
+  for (let i = points.length - 1; i >= 0; i -= 1) {
+    if (Number.isFinite(points[i].v)) {
+      return points[i].v;
+    }
+  }
+  return Number.NaN;
+}
+
+const compactNumber = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 2,
+});
+
+/** Formats a value for axes, legends, and accessibility text. */
+export function formatValue(value: number, unit: MetricUnit): string {
+  if (!Number.isFinite(value)) {
+    return "—";
+  }
+  switch (unit) {
+    case "bytes":
+      return formatBytes(value);
+    case "seconds":
+      return formatSeconds(value);
+    case "ratio":
+      return `${(value * 100).toFixed(1)}%`;
+    case "rate":
+      return `${compactNumber.format(value)}/s`;
+    case "count":
+    default:
+      return compactNumber.format(value);
+  }
+}
+
+function formatBytes(value: number): string {
+  const units = ["B", "KiB", "MiB", "GiB", "TiB"];
+  let scaled = value;
+  let unit = 0;
+  while (Math.abs(scaled) >= 1024 && unit < units.length - 1) {
+    scaled /= 1024;
+    unit += 1;
+  }
+  const digits = unit === 0 ? 0 : 1;
+  return `${scaled.toFixed(digits)} ${units[unit]}`;
+}
+
+function formatSeconds(value: number): string {
+  const abs = Math.abs(value);
+  if (abs === 0) return "0 s";
+  if (abs < 1e-3) return `${(value * 1e6).toFixed(0)} µs`;
+  if (abs < 1) return `${(value * 1e3).toFixed(1)} ms`;
+  if (abs < 60) return `${value.toFixed(2)} s`;
+  return `${(value / 60).toFixed(1)} min`;
+}
+
+/**
+ * Builds a one-line text summary of a panel's latest values, used as the
+ * accessible description alongside the chart (no color-only encoding).
+ */
+export function summariseSeries(
+  series: ChartSeries[],
+  unit: MetricUnit,
+): string {
+  if (series.length === 0) {
+    return "No data.";
+  }
+  return series
+    .map((entry) => `${entry.label}: ${formatValue(entry.lastValue, unit)}`)
+    .join(", ");
+}

--- a/admin/app/lib/client/usecase/ops/metrics/state.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/state.ts
@@ -1,0 +1,56 @@
+import type { MetricPoint } from "~/lib/client/infrastructure/api/prometheus-query-range";
+
+import { METRIC_PANELS } from "./catalog";
+import { DEFAULT_RANGE, type RangeKey } from "./range";
+
+/**
+ * MetricsStatus is the lifecycle phase of a single panel. "idle" is the
+ * pre-first-fetch state; "ready" means the panel has series to render;
+ * "error" surfaces the last PrometheusError message. "loading" is only
+ * set on a panel's first fetch — subsequent revalidates keep the prior
+ * status so charts do not flash while polling.
+ */
+export type MetricsStatus = "idle" | "loading" | "ready" | "error";
+
+/**
+ * One resolved time series belonging to a panel. The hook resolves each
+ * Prometheus series into this shape, carrying the originating query's
+ * legend template so the selector layer can compute a display label
+ * without re-reading the catalog.
+ */
+export interface PanelSeries {
+  legendTemplate?: string;
+  labels: Record<string, string>;
+  points: MetricPoint[];
+}
+
+export interface PanelState {
+  status: MetricsStatus;
+  series: PanelSeries[];
+  error: string | null;
+}
+
+/**
+ * MetricsState is the aggregate the Ops Metrics reducer manages. Panels
+ * are independent — one panel erroring (e.g. a metric not yet emitted)
+ * does not tear down the others. fetchEpoch is bumped on every refresh
+ * round so stale handlers can discard their result, mirroring the Ops
+ * cards reducer.
+ */
+export interface MetricsState {
+  panels: Record<string, PanelState>;
+  range: RangeKey;
+  fetchEpoch: number;
+}
+
+export function initialMetricsState(
+  range: RangeKey = DEFAULT_RANGE,
+): MetricsState {
+  const panels: Record<string, PanelState> = {};
+  for (const panel of METRIC_PANELS) {
+    panels[panel.id] = { status: "idle", series: [], error: null };
+  }
+  return { panels, range, fetchEpoch: 0 };
+}
+
+export const INITIAL_METRICS_STATE = initialMetricsState();

--- a/admin/app/lib/client/usecase/ops/metrics/use-metrics.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/use-metrics.ts
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+
+import {
+  queryRange,
+  type MetricSeries,
+} from "~/lib/client/infrastructure/api/prometheus-query-range";
+import {
+  browserStorage,
+  metricsRangeStorageKey,
+} from "~/lib/client/infrastructure/browser/storage";
+import { METRIC_PANELS } from "./catalog";
+import { DEFAULT_RANGE, isRangeKey, type RangeKey } from "./range";
+import { metricsReducer } from "./reducer";
+import { rangeToWindow, rateWindow, resolveExpr } from "./selectors";
+import { initialMetricsState, type PanelSeries } from "./state";
+
+export interface UseMetricsArgs {
+  /** Prometheus query base URL (same-origin proxy path or absolute URL). */
+  prometheusUrl: string;
+  /** Poll interval in ms; <= 0 disables the timer (single fetch on mount). */
+  pollMs: number;
+  /** Bumped by the Ops toolbar Refresh button to force an immediate round. */
+  refreshNonce: number;
+}
+
+export interface UseMetrics {
+  state: ReturnType<typeof metricsReducer>;
+  range: RangeKey;
+  setRange: (range: RangeKey) => void;
+}
+
+/**
+ * useMetrics owns the Prometheus time-series polling for the Ops Metrics
+ * section. It mirrors `useOps`: one AbortController per round, epoch-gated
+ * dispatches, a polling timer cleared on unmount / dependency change. Each
+ * round queries every catalog panel in parallel via `Promise.allSettled`,
+ * so a single failing panel (e.g. a metric not yet emitted) never tears
+ * down the others.
+ *
+ * The selected range is the single source of truth here (not a sibling
+ * hook): it drives both the query window and the panel reset, and is
+ * persisted to `localStorage` so it survives reloads. Changing the range
+ * recreates `fetchRound`, which the effect observes to refetch immediately.
+ */
+export function useMetrics({
+  prometheusUrl,
+  pollMs,
+  refreshNonce,
+}: UseMetricsArgs): UseMetrics {
+  const storage = useMemo(() => browserStorage(), []);
+  const [state, dispatch] = useReducer(metricsReducer, undefined, () => {
+    const stored = storage.get(metricsRangeStorageKey);
+    const range = stored && isRangeKey(stored) ? stored : DEFAULT_RANGE;
+    return initialMetricsState(range);
+  });
+
+  // epochRef carries the latest dispatched epoch so the polling closure
+  // does not depend on state.fetchEpoch (which would reset the timer).
+  const epochRef = useRef(state.fetchEpoch);
+  epochRef.current = state.fetchEpoch;
+
+  const setRange = useCallback(
+    (range: RangeKey) => {
+      storage.set(metricsRangeStorageKey, range);
+      dispatch({ type: "SET_RANGE", range });
+    },
+    [storage],
+  );
+
+  const range = state.range;
+
+  const fetchRound = useCallback(
+    async (signal: AbortSignal) => {
+      const epoch = epochRef.current + 1;
+      epochRef.current = epoch;
+      dispatch({ type: "FETCH_STARTED", epoch });
+
+      const { rangeSeconds, stepSeconds } = rangeToWindow(range);
+      const window = rateWindow(stepSeconds);
+      const end = Math.floor(Date.now() / 1000);
+      const start = end - rangeSeconds;
+
+      await Promise.allSettled(
+        METRIC_PANELS.map(async (panel) => {
+          try {
+            const resolved = await Promise.all(
+              panel.queries.map((query) =>
+                queryRange(prometheusUrl, {
+                  query: resolveExpr(query.expr, window),
+                  start,
+                  end,
+                  step: stepSeconds,
+                  signal,
+                }).then((series: MetricSeries[]) => ({ query, series })),
+              ),
+            );
+            const panelSeries: PanelSeries[] = resolved.flatMap(
+              ({ query, series }) =>
+                series.map((s) => ({
+                  legendTemplate: query.legend,
+                  labels: s.labels,
+                  points: s.points,
+                })),
+            );
+            dispatch({
+              type: "PANEL_LOADED",
+              epoch,
+              id: panel.id,
+              series: panelSeries,
+            });
+          } catch (err: unknown) {
+            if ((err as Error)?.name === "AbortError") return;
+            dispatch({
+              type: "PANEL_ERROR",
+              epoch,
+              id: panel.id,
+              error: errorMessage(err),
+            });
+          }
+        }),
+      );
+    },
+    [prometheusUrl, range],
+  );
+
+  // First-paint fetch + polling timer. refreshNonce in the dependency
+  // list lets the toolbar force a fresh round without changing pollMs.
+  useEffect(() => {
+    const ctl = new AbortController();
+    void fetchRound(ctl.signal);
+    if (pollMs <= 0) {
+      return () => ctl.abort();
+    }
+    const id = window.setInterval(() => {
+      void fetchRound(ctl.signal);
+    }, pollMs);
+    return () => {
+      window.clearInterval(id);
+      ctl.abort();
+    };
+  }, [fetchRound, pollMs, refreshNonce]);
+
+  return { state, range, setRange };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/admin/app/lib/client/usecase/ops/metrics/use-prometheus-url.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/use-prometheus-url.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  browserStorage,
+  prometheusStorageKey,
+} from "~/lib/client/infrastructure/browser/storage";
+import {
+  DEFAULT_PROMETHEUS_URL,
+  normalisePrometheusUrl,
+} from "./prometheus-url";
+
+export interface UsePrometheusUrl {
+  prometheusUrl: string;
+  /** Validates + applies a new URL. Returns false (and ignores) on invalid input. */
+  setPrometheusUrl: (input: string) => boolean;
+  /** Restores the same-origin reverse-proxy default. */
+  reset: () => void;
+}
+
+/**
+ * Owns the Prometheus query base URL for the Ops Metrics section. The value
+ * is persisted to `localStorage` so it survives reloads. Unlike the gateway
+ * connection this is a plain hook (not a context) because only the Metrics
+ * section reads it — mirroring `connection-context` would be over-scoped.
+ */
+export function usePrometheusUrl(): UsePrometheusUrl {
+  const storage = useMemo(() => browserStorage(), []);
+  const [prometheusUrl, setState] = useState<string>(() => {
+    const stored = storage.get(prometheusStorageKey);
+    if (stored) {
+      const normalised = normalisePrometheusUrl(stored);
+      if (normalised) {
+        return normalised;
+      }
+    }
+    return DEFAULT_PROMETHEUS_URL;
+  });
+
+  useEffect(() => {
+    storage.set(prometheusStorageKey, prometheusUrl);
+  }, [prometheusUrl, storage]);
+
+  const setPrometheusUrl = useCallback((input: string) => {
+    const normalised = normalisePrometheusUrl(input);
+    if (!normalised) {
+      return false;
+    }
+    setState(normalised);
+    return true;
+  }, []);
+
+  const reset = useCallback(() => {
+    setState(DEFAULT_PROMETHEUS_URL);
+  }, []);
+
+  return { prometheusUrl, setPrometheusUrl, reset };
+}

--- a/admin/docker-entrypoint.sh
+++ b/admin/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Container entrypoint for lantern-admin.
+#
+# Generates the optional Prometheus reverse-proxy snippet imported by the
+# Caddyfile, then hands off to the image's command (caddy). The proxy is
+# OPT-IN: it is only wired up when LANTERN_ADMIN_PROMETHEUS_UPSTREAM is set
+# (e.g. "http://prometheus:9090"). When unset, an EMPTY snippet is written
+# so the Caddyfile's glob `import` resolves to a no-op and the SPA host
+# behaves exactly as before.
+#
+# Proxying Prometheus same-origin (under /api/prom) is how the admin
+# Metrics page avoids a cross-origin browser call to Prometheus, which has
+# no CORS headers of its own.
+#
+# Writes are best-effort: the Caddyfile uses a glob import, so if the
+# snippet cannot be written (e.g. read-only filesystem with no writable
+# conf.d mount) the container still serves the SPA — only the Prometheus
+# proxy is skipped. We log loudly in that case rather than crash-looping.
+set -eu
+
+CONF_DIR=/etc/caddy/conf.d
+PROM_CONF="$CONF_DIR/prom.caddy"
+
+mkdir -p "$CONF_DIR" 2>/dev/null || true
+
+if [ -n "${LANTERN_ADMIN_PROMETHEUS_UPSTREAM:-}" ]; then
+	SNIPPET="handle_path /api/prom/* {
+	reverse_proxy ${LANTERN_ADMIN_PROMETHEUS_UPSTREAM}
+}"
+	if printf '%s\n' "$SNIPPET" >"$PROM_CONF" 2>/dev/null; then
+		echo "lantern-admin: Prometheus proxy enabled -> ${LANTERN_ADMIN_PROMETHEUS_UPSTREAM}" >&2
+	else
+		echo "lantern-admin: WARNING could not write ${PROM_CONF}; Prometheus proxy NOT enabled (is the filesystem read-only?)" >&2
+	fi
+else
+	# Empty snippet keeps the glob import a no-op. Tolerated if unwritable.
+	: >"$PROM_CONF" 2>/dev/null || true
+	echo "lantern-admin: Prometheus proxy disabled (set LANTERN_ADMIN_PROMETHEUS_UPSTREAM to enable)" >&2
+fi
+
+exec "$@"

--- a/admin/tests/e2e/ops-metrics.spec.ts
+++ b/admin/tests/e2e/ops-metrics.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Ops Metrics (#524) — the Prometheus time-series half of the Ops page.
+ *
+ * The Playwright `webServer` serves the SPA from a `vite preview` build with
+ * NO Prometheus behind `/api/prom`, so the default state is "degraded": every
+ * panel's `query_range` request falls through to the SPA `index.html`
+ * fallback, the adapter rejects with a `parse` error, and MetricsSection
+ * surfaces the aggregate warning banner. The second scenario installs a
+ * `page.route` mock for `/api/prom/api/v1/query_range` so the panels render
+ * real charts without needing a live Prometheus.
+ */
+
+/**
+ * Builds a Prometheus `query_range` matrix envelope with `count` samples of a
+ * single series, spaced `step` seconds apart and ending at `now`.
+ */
+function matrixEnvelope(now: number, step = 60, count = 10) {
+  const values: Array<[number, string]> = [];
+  for (let i = count - 1; i >= 0; i -= 1) {
+    values.push([now - i * step, String(100 + (count - i))]);
+  }
+  return {
+    status: "success",
+    data: {
+      resultType: "matrix",
+      result: [{ metric: { __name__: "lantern_vertices" }, values }],
+    },
+  };
+}
+
+test.describe("Ops metrics section", () => {
+  test("renders the metrics section below the status cards", async ({
+    page,
+  }) => {
+    await page.goto("/ops");
+    await expect(page.getByTestId("ops-server-card")).toBeVisible();
+    const section = page.getByTestId("ops-metrics-section");
+    await expect(section).toBeVisible();
+    await expect(
+      section.getByRole("heading", { level: 2, name: "Metrics" }),
+    ).toBeVisible();
+    // The Prometheus switcher advertises the default same-origin endpoint.
+    await expect(page.getByTestId("ops-prometheus-switcher")).toContainText(
+      "/api/prom",
+    );
+    // The range selector defaults to 1h.
+    await expect(
+      page.getByTestId("ops-metrics-range").getByRole("tab", { name: "1h" }),
+    ).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("shows the degraded banner when no Prometheus is reachable", async ({
+    page,
+  }) => {
+    // vite preview has no /api/prom upstream — every panel fails to load.
+    await page.goto("/ops");
+    await expect(page.getByTestId("ops-metrics-degraded")).toBeVisible();
+    await expect(page.getByTestId("ops-metrics-degraded")).toContainText(
+      "/api/prom",
+    );
+  });
+
+  test("renders charts when query_range is mocked", async ({ page }) => {
+    await page.route("**/api/prom/api/v1/query_range*", async (route) => {
+      const now = Math.floor(Date.now() / 1000);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(matrixEnvelope(now)),
+      });
+    });
+
+    await page.goto("/ops");
+    // The degraded banner must NOT appear once panels resolve.
+    await expect(page.getByTestId("ops-metrics-degraded")).toHaveCount(0);
+    // The cache-size panel is the first catalog entry; it renders a summary
+    // line derived from the mocked series.
+    await expect(page.getByTestId("ops-metric-cache-size")).toBeVisible();
+    await expect(
+      page.getByTestId("ops-metric-cache-size-summary"),
+    ).toBeVisible();
+  });
+
+  test("persists a runtime Prometheus URL override", async ({ page }) => {
+    await page.goto("/ops");
+    await page.getByTestId("ops-prometheus-switcher").click();
+    const input = page.getByTestId("ops-prometheus-input");
+    await expect(input).toBeVisible();
+    await input.fill("https://prom.example.com");
+    await page.getByTestId("ops-prometheus-save").click();
+    await expect(page.getByTestId("ops-prometheus-switcher")).toContainText(
+      "https://prom.example.com",
+    );
+    // The override survives a reload (localStorage persistence).
+    await page.reload();
+    await expect(page.getByTestId("ops-prometheus-switcher")).toContainText(
+      "https://prom.example.com",
+    );
+  });
+});

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -18,10 +18,13 @@ single-host HA experiments.
   `http://lantern:6380` — continues to round-robin across the live
   replicas without knowing about the per-service names.
 - 1 × `admin` browser SPA (`ghcr.io/anaregdesign/lantern-admin`)
-  on host port `8080`. Pure SPA host (Caddy on `:8080`), no reverse
-  proxy — the browser talks to the gateway directly, so each lantern
-  service has `LANTERN_CORS_ALLOWED_ORIGINS=http://localhost:8080`
-  baked in.
+  on host port `8080`. Caddy SPA host on `:8080`; the browser talks to
+  the gateway directly (not proxied), so each lantern service has
+  `LANTERN_CORS_ALLOWED_ORIGINS=http://localhost:8080` baked in. The
+  admin container *does* reverse-proxy Prometheus same-origin under
+  `/api/prom` (`LANTERN_ADMIN_PROMETHEUS_UPSTREAM=http://prometheus:9090`
+  is set on the admin service) so the Ops Metrics charts work without a
+  cross-origin call to Prometheus.
 - `prometheus` scrapes via `dns_sd_configs` against the `lantern`
   alias, so it picks up every replica automatically (no static targets
   file to maintain).
@@ -102,6 +105,13 @@ that env to match (otherwise the browser preflight blocks the
 request). Override the image with
 `LANTERN_ADMIN_IMAGE=ghcr.io/anaregdesign/lantern-admin:v0.1.1
 docker compose up -d`.
+
+The **Ops** page's Prometheus time-series charts query Prometheus
+same-origin under `/api/prom`; the admin service's
+`LANTERN_ADMIN_PROMETHEUS_UPSTREAM=http://prometheus:9090` makes the
+admin container reverse-proxy that path to the bundled `prometheus`
+service, so the charts render out of the box. Point the **Prometheus**
+button in the Metrics toolbar elsewhere to override at runtime.
 
 The admin container is **not** auth-fronted. Run it only on trusted
 networks, or put your own ingress-level auth proxy in front.

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -52,8 +52,10 @@ x-lantern-common: &lantern-common
     LANTERN_MAX_REPLICATION_LAG: "10000"
     # Allow the admin SPA to call this listener from the browser.
     # Lantern serves Connect / gRPC / gRPC-Web on the same h2c socket,
-    # and the admin container is a pure SPA host (no reverse proxy),
-    # so CORS must allow the admin origin.
+    # and the admin container does not proxy the gateway (the browser
+    # calls it directly), so CORS must allow the admin origin. (The
+    # admin container DOES optionally reverse-proxy Prometheus same-
+    # origin under /api/prom — that path needs no gateway CORS.)
     LANTERN_CORS_ALLOWED_ORIGINS: "http://localhost:8080"
   networks:
     default:
@@ -86,6 +88,13 @@ services:
     image: ${LANTERN_ADMIN_IMAGE:-ghcr.io/anaregdesign/lantern-admin:latest}
     ports:
       - "8080:8080"
+    environment:
+      # Enable the same-origin Prometheus reverse proxy. The admin
+      # entrypoint writes a `handle_path /api/prom/* { reverse_proxy ... }`
+      # Caddy snippet from this value, so the SPA's default Prometheus URL
+      # (`/api/prom`) reaches Prometheus without a cross-origin browser
+      # call. Unset this to disable the proxy.
+      LANTERN_ADMIN_PROMETHEUS_UPSTREAM: "http://prometheus:9090"
     depends_on:
       lantern-0:
         condition: service_healthy
@@ -93,6 +102,8 @@ services:
         condition: service_healthy
       lantern-2:
         condition: service_healthy
+      prometheus:
+        condition: service_started
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8080/healthz"]
       interval: 10s

--- a/deploy/helm/lantern/templates/admin-deployment.yaml
+++ b/deploy/helm/lantern/templates/admin-deployment.yaml
@@ -70,8 +70,30 @@ spec:
             successThreshold: 1
           resources:
             {{- toYaml .Values.admin.resources | nindent 12 }}
-          {{- with .Values.admin.extraEnv }}
+          {{- if or .Values.admin.prometheus.upstream .Values.admin.extraEnv }}
           env:
+            {{- if .Values.admin.prometheus.upstream }}
+            # Enables the same-origin Prometheus reverse proxy. The
+            # container entrypoint turns this into a Caddy
+            # `handle_path /api/prom/*` reverse_proxy snippet.
+            - name: LANTERN_ADMIN_PROMETHEUS_UPSTREAM
+              value: {{ .Values.admin.prometheus.upstream | quote }}
+            {{- end }}
+            {{- with .Values.admin.extraEnv }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
+          {{- if .Values.admin.prometheus.upstream }}
+          # Writable conf.d so the non-root container can drop the
+          # generated Prometheus proxy snippet even when the root
+          # filesystem is read-only.
+          volumeMounts:
+            - name: caddy-conf-d
+              mountPath: /etc/caddy/conf.d
+          {{- end }}
+      {{- if .Values.admin.prometheus.upstream }}
+      volumes:
+        - name: caddy-conf-d
+          emptyDir: {}
+      {{- end }}
 {{- end }}

--- a/deploy/helm/lantern/values.yaml
+++ b/deploy/helm/lantern/values.yaml
@@ -178,6 +178,18 @@ admin:
     #    hosts:
     #      - admin.example.com
 
+  # Optional same-origin Prometheus reverse proxy for the admin Metrics
+  # page. When `upstream` is non-empty, the admin container's entrypoint
+  # writes a Caddy `handle_path /api/prom/* { reverse_proxy <upstream> }`
+  # snippet, the SPA's default Prometheus URL (`/api/prom`) reaches
+  # Prometheus without a cross-origin browser call, and the chart mounts
+  # an emptyDir at /etc/caddy/conf.d so the non-root container can write
+  # that snippet regardless of `securityContext.readOnlyRootFilesystem`.
+  # Leave empty to disable (Metrics page degrades gracefully; operators
+  # can still point it at any reachable Prometheus from the browser).
+  prometheus:
+    upstream: ""   # e.g. "http://prometheus-server.monitoring.svc:80"
+
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
## What

Adds live Prometheus time-series charts to the admin **Ops** page, backed by
an opt-in same-origin reverse proxy so the browser never makes a cross-origin
call to Prometheus (which serves no CORS headers).

`Closes #524`

## Why

The Ops page only showed point-in-time RPC/status snapshots. #524 asks for
historical trends (cache size, throughput, latency, TTL reaping, replication
lag, runtime) so operators can see direction, not just the current value.

## How

**Frontend (react-router-app-architecture layering):**
- `infrastructure/api/prometheus-query-range.ts` — a plain `fetch` adapter for
  Prometheus `GET /api/v1/query_range`, flattening the matrix envelope to
  `MetricSeries[]` and surfacing a typed `PrometheusError` (network / http /
  status / parse) for the degraded UI.
- `usecase/ops/metrics/` — declarative PromQL panel `catalog` (every metric
  name is a real Lantern/`process_*`/`go_*` series), epoch-gated `reducer`,
  `selectors` (range→window, formatters, series→points), `use-metrics` polling
  hook (AbortController + `Promise.allSettled`, one failing panel never tears
  down siblings), and `prometheus-url` normaliser (accepts `/api/prom` or an
  absolute `http(s)` URL).
- `components/ops/MetricsSection/` — `MetricsSection`, `MetricPanel`,
  hand-rolled accessible `TimeSeriesChart` (SVG, no new deps), and
  `PrometheusSwitcher` (ops-local Fluent dialog). Wired below the status cards
  in `OpsPage`; range + URL persisted to `localStorage`.

**Deploy / infra:**
- `admin/Caddyfile` glob-imports `/etc/caddy/conf.d/*.caddy` (before the SPA
  catch-all). `admin/docker-entrypoint.sh` writes a `handle_path /api/prom/*
  { reverse_proxy <upstream> }` snippet **only** when
  `LANTERN_ADMIN_PROMETHEUS_UPSTREAM` is set; unset = empty file = graceful
  no-op. `handle_path` strips the prefix so `/api/prom/api/v1/query_range` →
  Prometheus `/api/v1/query_range`. Dockerfile makes conf.d group-writable
  (k8s arbitrary-uid pattern).
- `deploy/compose`: upstream pre-wired (`http://prometheus:9090`) + `depends_on`.
- `deploy/helm`: new `admin.prometheus.upstream` value gates the env var, a
  `volumeMount`, and an `emptyDir` volume (read-only-rootfs resilience).

## Tests

- Bun unit tests (colocated): adapter, catalog, reducer, selectors, URL
  normaliser — `bun run test` → **607 pass, 0 fail**.
- Playwright `tests/e2e/ops-metrics.spec.ts`: default degraded banner (no
  Prometheus under `vite preview`), mocked-`query_range` chart render, runtime
  URL persistence across reload — full suite **55 passed** (`--workers=1`).
- `caddy validate` green for both empty-snippet and populated-snippet states;
  `helm lint` + 3-case `helm template`; `docker compose config` valid.
- `bun run format` / `lint` / `typecheck` clean.

## Docs

`admin/README.md` (new Metrics section + reverse-proxy rationale),
`deploy/compose/README.md`, and `AGENTS.md` (admin release paragraph) updated.
