### PR TITLE
feat(mcp): drive a proactive capture+recall loop via server instructions & tool descriptions

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -269,12 +269,22 @@ func newServer(lc lanternClient, resolver *ttl.Resolver, logger *slog.Logger) *m
 }
 
 // serverInstructions is the system-prompt-style guidance the MCP server
-// advertises to the LLM at session-open. The wording is deliberate:
-//   - states the core mental model (decaying graph),
-//   - calls out the single most-violated invariant (recall does NOT
-//     refresh TTL), and
-//   - gives a one-line tie-breaker for ambiguous bucket choices.
+// advertises to the LLM at session-open. The wording is deliberate and
+// does three jobs:
+//   - states the core mental model (a decaying graph) and the single
+//     most-violated invariant (recall does NOT refresh TTL);
+//   - mandates an ambient capture+recall LOOP (recall before answering,
+//     capture after a substantive exchange) so memory accrues without the
+//     user having to ask for it; and
+//   - establishes a key-namespace convention (user.* / project.* /
+//     session.*) so the captured graph stays navigable as a mind map in
+//     Admin Illuminate.
 //
 // Changing this text is an LLM-behavior-affecting change; treat it the
 // way you would a prompt update and call it out in release notes.
-const serverInstructions = "Lantern is a decaying graph memory. Vertices (facts) and edges (relations) carry TTLs and disappear when they expire. Two critical properties: (1) there is no \"forever\" — every write picks a bucket from {seconds, transient, turn, conversation, task, workday, day, week, sprint, month, quarter, durable}; (2) recall does NOT refresh TTL, so to keep a fact alive you must call remember_fact again. When in doubt about the right bucket, ask yourself \"when will this stop being true?\" and \"how bad is it if this lingers past then?\" — and pick the SHORTER bucket. Relations are additive: writing the same relation twice strengthens it."
+const serverInstructions = "Lantern is your ambient, decaying graph memory. Use it proactively — you do not need to be asked. Run this loop every turn: " +
+	"(1) RECALL FIRST: before answering anything that could depend on remembered context, call recall_fact (exact key), recall_related (walk from a seed), or list_under (enumerate a namespace) to pull in what you already know. " +
+	"(2) ANSWER using what you recalled. " +
+	"(3) CAPTURE AFTER: once the exchange settles, write any new durable facts with remember_fact and any new associations with remember_relation — preferences, decisions, identities, project facts, and how they connect. Capturing is the default, not the exception. " +
+	"Two invariants govern every write: (a) there is no \"forever\" — each write picks a TTL bucket from {seconds, transient, turn, conversation, task, workday, day, week, sprint, month, quarter, durable}; (b) recall does NOT refresh TTL, so to keep a fact alive you must re-remember it when you reference it. Choosing a bucket: ask \"when will this stop being true?\" and \"how bad is it if this lingers past then?\" and pick the SHORTER one. Relations are additive — writing the same relation twice strengthens it, so reinforce associations you keep using. " +
+	"Namespace keys so the graph reads as a mind map: user.* for stable facts about the person (user.preferences.tone, user.identity.role), project.* for the work at hand (project.lantern.stack), session.* for ephemeral working state (session.current-task). Prefer dotted, hierarchical keys; reuse a key to update its value."

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -135,3 +135,39 @@ func TestMCPHTTPHandler_ServesMCPOverStreamableHTTP(t *testing.T) {
 		t.Fatalf("ping content = %q, want pong", got)
 	}
 }
+
+// TestServerInstructions_DefinesCaptureRecallLoop asserts the
+// session-open instructions advertise the ambient loop contract: recall
+// before answering, capture after the exchange, the no-forever / recall-
+// does-not-refresh invariants, and the key-namespace convention. These
+// are string-level guards so a future edit cannot silently drop the
+// loop-shaped guidance the LLM relies on (#528).
+func TestServerInstructions_DefinesCaptureRecallLoop(t *testing.T) {
+	lower := strings.ToLower(serverInstructions)
+	for _, want := range []string{
+		"recall",   // step 1
+		"answer",   // step 2
+		"capture",  // step 3
+		"proactiv", // proactive framing (matches proactive/proactively)
+		"does not refresh",
+		"there is no \"forever\"",
+	} {
+		if !strings.Contains(lower, strings.ToLower(want)) {
+			t.Errorf("serverInstructions missing %q", want)
+		}
+	}
+	// All three namespace prefixes must be named so the captured graph is
+	// navigable as a mind map.
+	for _, ns := range []string{"user.", "project.", "session."} {
+		if !strings.Contains(serverInstructions, ns) {
+			t.Errorf("serverInstructions missing namespace %q", ns)
+		}
+	}
+	// Every memory tool should be referenced so the agent knows the full
+	// toolset participates in the loop.
+	for _, tool := range []string{"remember_fact", "recall_fact", "recall_related", "list_under", "remember_relation"} {
+		if !strings.Contains(serverInstructions, tool) {
+			t.Errorf("serverInstructions does not mention tool %q", tool)
+		}
+	}
+}

--- a/mcp/tool_forget.go
+++ b/mcp/tool_forget.go
@@ -16,7 +16,7 @@ type forgetOutput struct {
 	Existed bool   `json:"existed"`
 }
 
-const forgetDescription = "Delete a fact by exact key. Idempotent: deleting a missing key returns existed=false rather than erroring. Edges incident to the key are NOT cascade-deleted — they will decay naturally on their own TTL."
+const forgetDescription = "Delete a fact by exact key. Use this only when a fact is now wrong or the user asks you to forget it — normal staleness is handled by TTL decay, so you rarely need to call this. Idempotent: deleting a missing key returns existed=false rather than erroring. Edges incident to the key are NOT cascade-deleted — they will decay naturally on their own TTL."
 
 func registerForget(srv *mcp.Server, lc lanternClient) {
 	mcp.AddTool(srv, &mcp.Tool{

--- a/mcp/tool_forget_test.go
+++ b/mcp/tool_forget_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -43,4 +44,13 @@ func TestForget_MissingKeyIsNotError(t *testing.T) {
 func TestForget_RejectsEmptyKey(t *testing.T) {
 	h := newTestHarness(t)
 	h.callExpectError(t, "forget", map[string]any{"key": ""})
+}
+
+// TestForgetDescription_DiscouragesRoutineUse guards the framing that
+// forget is for wrong/unwanted facts, not routine staleness (TTL handles
+// that), so the agent does not over-delete (#528).
+func TestForgetDescription_DiscouragesRoutineUse(t *testing.T) {
+	if !strings.Contains(forgetDescription, "TTL decay") {
+		t.Errorf("forgetDescription should point routine staleness at TTL decay: %q", forgetDescription)
+	}
 }

--- a/mcp/tool_list_under.go
+++ b/mcp/tool_list_under.go
@@ -38,7 +38,7 @@ type listUnderOutput struct {
 	Suggestion string           `json:"suggestion,omitempty"`
 }
 
-const listUnderDescription = "Enumerate facts whose key starts with the given prefix, in ascending key order. Defaults to 50 entries, max 500. If has_more=true the result is truncated; narrow the prefix or follow the suggestion. Does NOT refresh TTL for the listed facts."
+const listUnderDescription = "Enumerate facts whose key starts with the given prefix, in ascending key order. Call this PROACTIVELY to survey a namespace (e.g. user. or project.) before answering, so you recall everything you know about that topic. Defaults to 50 entries, max 500. If has_more=true the result is truncated; narrow the prefix or follow the suggestion. Does NOT refresh TTL for the listed facts."
 
 func registerListUnder(srv *mcp.Server, lc lanternClient) {
 	mcp.AddTool(srv, &mcp.Tool{

--- a/mcp/tool_list_under_test.go
+++ b/mcp/tool_list_under_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
@@ -59,4 +60,15 @@ func TestListUnder_RespectsExplicitLimit(t *testing.T) {
 func TestListUnder_RejectsEmptyPrefix(t *testing.T) {
 	h := newTestHarness(t)
 	h.callExpectError(t, "list_under", map[string]any{"prefix": ""})
+}
+
+// TestListUnderDescription_IsProactive guards the survey-before-answering
+// framing while keeping the no-refresh invariant (#528).
+func TestListUnderDescription_IsProactive(t *testing.T) {
+	if !strings.Contains(strings.ToUpper(listUnderDescription), "PROACTIVELY") {
+		t.Errorf("listUnderDescription should tell the agent to survey PROACTIVELY: %q", listUnderDescription)
+	}
+	if !strings.Contains(listUnderDescription, "NOT refresh") {
+		t.Errorf("listUnderDescription should keep the does-not-refresh invariant: %q", listUnderDescription)
+	}
 }

--- a/mcp/tool_recall_fact.go
+++ b/mcp/tool_recall_fact.go
@@ -25,7 +25,7 @@ type recallFactOutput struct {
 	ExpiresAt string `json:"expires_at,omitempty"`
 }
 
-const recallFactDescription = "Look up a single fact by exact key. Returns {found=false} for missing keys (this is a structured result, NOT a tool error). IMPORTANT: recalling a fact does NOT refresh its TTL — the fact will still decay on schedule. To extend a fact's lifetime, call remember_fact again."
+const recallFactDescription = "Look up a single fact by exact key. Call this PROACTIVELY at the start of a turn — before answering anything that might depend on what you already know about the user or project. Returns {found=false} for missing keys (this is a structured result, NOT a tool error). IMPORTANT: recalling a fact does NOT refresh its TTL — the fact will still decay on schedule. To extend a fact's lifetime, call remember_fact again."
 
 func registerRecallFact(srv *mcp.Server, lc lanternClient) {
 	mcp.AddTool(srv, &mcp.Tool{

--- a/mcp/tool_recall_fact_test.go
+++ b/mcp/tool_recall_fact_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
@@ -49,4 +50,15 @@ func TestRecallFact_NotFoundIsStructured(t *testing.T) {
 func TestRecallFact_RejectsEmptyKey(t *testing.T) {
 	h := newTestHarness(t)
 	h.callExpectError(t, "recall_fact", map[string]any{"key": ""})
+}
+
+// TestRecallFactDescription_IsProactive guards the recall-before-answering
+// framing while keeping the no-refresh invariant (#528).
+func TestRecallFactDescription_IsProactive(t *testing.T) {
+	if !strings.Contains(strings.ToUpper(recallFactDescription), "PROACTIVELY") {
+		t.Errorf("recallFactDescription should tell the agent to recall PROACTIVELY: %q", recallFactDescription)
+	}
+	if !strings.Contains(recallFactDescription, "does NOT refresh") {
+		t.Errorf("recallFactDescription should keep the recall-does-not-refresh invariant: %q", recallFactDescription)
+	}
 }

--- a/mcp/tool_recall_related.go
+++ b/mcp/tool_recall_related.go
@@ -63,7 +63,7 @@ type recallRelatedOutput struct {
 	Neighbors []recallRelatedNeighbor `json:"neighbors"`
 }
 
-const recallRelatedDescription = "Walk Lantern's graph from a seed key, returning the related facts with their cumulative edge weights. Use step + k to bound exploration. Use algorithm + objective + weighting to control how the discovered subgraph is reduced and weighted (see #410). IMPORTANT: recall does NOT refresh TTL for any vertex or edge visited; weak relations will still decay on schedule."
+const recallRelatedDescription = "Walk Lantern's graph from a seed key, returning the related facts with their cumulative edge weights. Call this PROACTIVELY to pull in surrounding context before answering — start from the most relevant known key. Use step + k to bound exploration. Use algorithm + objective + weighting to control how the discovered subgraph is reduced and weighted (see #410). IMPORTANT: recall does NOT refresh TTL for any vertex or edge visited; weak relations will still decay on schedule."
 
 func registerRecallRelated(srv *mcp.Server, lc lanternClient) {
 	mcp.AddTool(srv, &mcp.Tool{

--- a/mcp/tool_recall_related_test.go
+++ b/mcp/tool_recall_related_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
@@ -82,4 +83,15 @@ func TestRecallRelated_PropagatesIlluminateOptions(t *testing.T) {
 func TestRecallRelated_RejectsEmptySeed(t *testing.T) {
 	h := newTestHarness(t)
 	h.callExpectError(t, "recall_related", map[string]any{"seed": ""})
+}
+
+// TestRecallRelatedDescription_IsProactive guards the recall-before-
+// answering framing while keeping the no-refresh invariant (#528).
+func TestRecallRelatedDescription_IsProactive(t *testing.T) {
+	if !strings.Contains(strings.ToUpper(recallRelatedDescription), "PROACTIVELY") {
+		t.Errorf("recallRelatedDescription should tell the agent to recall PROACTIVELY: %q", recallRelatedDescription)
+	}
+	if !strings.Contains(recallRelatedDescription, "does NOT refresh") {
+		t.Errorf("recallRelatedDescription should keep the recall-does-not-refresh invariant: %q", recallRelatedDescription)
+	}
 }

--- a/mcp/tool_remember_fact.go
+++ b/mcp/tool_remember_fact.go
@@ -25,7 +25,7 @@ type rememberFactOutput struct {
 	ExpiresAt string `json:"expires_at"`
 }
 
-const rememberFactDescription = "Store a fact in Lantern with a required TTL bucket. The value can be any JSON-encodable shape (string, number, bool, object, array). Writing the same key again overwrites the previous value and resets the TTL — that is the canonical way to refresh a fact since recall does NOT refresh."
+const rememberFactDescription = "Store a fact in Lantern with a required TTL bucket. Call this PROACTIVELY whenever the user states a durable preference, decision, identity, or project fact — you do not need to be asked. The value can be any JSON-encodable shape (string, number, bool, object, array). Use a dotted namespaced key (user.* / project.* / session.*). Writing the same key again overwrites the previous value and resets the TTL — that is the canonical way to refresh a fact since recall does NOT refresh."
 
 func registerRememberFact(srv *mcp.Server, lc lanternClient, r *ttl.Resolver) {
 	mcp.AddTool(srv, &mcp.Tool{

--- a/mcp/tool_remember_fact_test.go
+++ b/mcp/tool_remember_fact_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -75,4 +76,15 @@ func TestRememberFact_RejectsUnknownBucket(t *testing.T) {
 		t.Fatalf("PutVertex should not have been called; calls=%d", h.fake.putVertexCalls)
 	}
 	_ = res
+}
+
+// TestRememberFactDescription_IsProactive guards the proactive framing
+// that nudges the agent to capture facts without being asked (#528).
+func TestRememberFactDescription_IsProactive(t *testing.T) {
+	if !strings.Contains(strings.ToUpper(rememberFactDescription), "PROACTIVELY") {
+		t.Errorf("rememberFactDescription should tell the agent to act PROACTIVELY: %q", rememberFactDescription)
+	}
+	if !strings.Contains(rememberFactDescription, "does NOT refresh") {
+		t.Errorf("rememberFactDescription should keep the recall-does-not-refresh invariant: %q", rememberFactDescription)
+	}
 }

--- a/mcp/tool_remember_relation.go
+++ b/mcp/tool_remember_relation.go
@@ -24,7 +24,7 @@ type rememberRelationOutput struct {
 	ExpiresAt string  `json:"expires_at"`
 }
 
-const rememberRelationDescription = "Add (or reinforce) a directed relation from one fact to another. IMPORTANT: writes are ADDITIVE — writing the same relation twice STRENGTHENS it, it does not idempotently overwrite. This is the Hebbian-style memory primitive: frequent short-TTL writes accumulate into strong associations, while weak relations decay. Use remember_fact to ensure the endpoint keys exist."
+const rememberRelationDescription = "Add (or reinforce) a directed relation from one fact to another. Call this PROACTIVELY whenever you learn how two things connect — you do not need to be asked. IMPORTANT: writes are ADDITIVE — writing the same relation twice STRENGTHENS it, it does not idempotently overwrite. This is the Hebbian-style memory primitive: frequent short-TTL writes accumulate into strong associations, while weak relations decay, so reinforce associations you keep using. Use remember_fact to ensure the endpoint keys exist."
 
 func registerRememberRelation(srv *mcp.Server, lc lanternClient, r *ttl.Resolver) {
 	mcp.AddTool(srv, &mcp.Tool{

--- a/mcp/tool_remember_relation_test.go
+++ b/mcp/tool_remember_relation_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -52,4 +53,15 @@ func TestRememberRelation_RejectsEmptyEndpoints(t *testing.T) {
 	h.callExpectError(t, "remember_relation", map[string]any{
 		"from": "a", "to": "", "ttl": "turn",
 	})
+}
+
+// TestRememberRelationDescription_IsProactive guards the proactive framing
+// for capturing associations, plus the additive-write contract (#528).
+func TestRememberRelationDescription_IsProactive(t *testing.T) {
+	if !strings.Contains(strings.ToUpper(rememberRelationDescription), "PROACTIVELY") {
+		t.Errorf("rememberRelationDescription should tell the agent to act PROACTIVELY: %q", rememberRelationDescription)
+	}
+	if !strings.Contains(rememberRelationDescription, "ADDITIVE") {
+		t.Errorf("rememberRelationDescription should keep the ADDITIVE-write contract: %q", rememberRelationDescription)
+	}
 }


### PR DESCRIPTION
## What

Make the **server side** of `lantern-mcp` actively drive an ambient capture+recall loop, using only the two levers the server controls: the `serverInstructions` advertised at session-open, and each tool's `Description`. Part of the ambient-memory epic #530.

## Why

The agent — not the server — decides when to call tools. The server's only influence is the quality of the guidance it advertises. The previous instructions explained the *mental model* (decaying graph, recall-doesn't-refresh) but never told the agent to **use memory proactively**, so capture only happened when a user explicitly asked.

## Changes

**`serverInstructions` (mcp/server.go)** now mandates a per-turn loop:
1. **RECALL FIRST** — before answering anything that could depend on remembered context, call `recall_fact` / `recall_related` / `list_under`.
2. **ANSWER** using what was recalled.
3. **CAPTURE AFTER** — once the exchange settles, write new durable facts (`remember_fact`) and associations (`remember_relation`); capturing is the default, not the exception.

It keeps the two invariants (no `"forever"` bucket; recall does **not** refresh TTL → re-remember on reference) and adds a **key-namespace convention** — `user.*` (stable facts about the person), `project.*` (the work at hand), `session.*` (ephemeral state) — so the captured graph reads as a mind map in Admin Illuminate.

**Tool `Description`s** are tightened so an agent scanning the tool list infers the loop without reading the instructions:
- `remember_fact` / `recall_fact` / `remember_relation` / `recall_related` / `list_under` — "Call this **PROACTIVELY** … you do not need to be asked."
- `forget` — reframed as for **wrong/unwanted** facts only; routine staleness is handled by TTL decay, so the agent should rarely call it.

## Tests

String-level guards (no wire/signature changes, so behaviour is asserted on the registered text), matching the 1:1 source↔test rule:
- `server_test.go`: `TestServerInstructions_DefinesCaptureRecallLoop` — asserts the recall→answer→capture steps, proactive framing, both invariants, all three namespaces, and that every memory tool is referenced.
- each `tool_*_test.go`: a `Test…Description_*` that asserts the proactive framing (or, for `forget`, the TTL-decay deferral) and that the tool's key invariant survives.

## Notes / constraints

- **LLM-behaviour-affecting** — treat like a prompt update; called out for the next `mcp/vX.Y.Z` release notes (the `serverInstructions` doc-comment already says so).
- Pure `mcp`-module change; does **not** alter tool signatures or the wire surface.

## Verification

- `gofmt -l mcp` clean; `cd mcp && go build ./... && go vet ./... && go test ./...` green.
- Root `go test ./tests/...` (cross-module MCP harness) green.

Closes #528
