### PR TITLE
docs(mcp): ship a recommended host-agent instruction profile for ambient memory

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -158,6 +158,12 @@ All three follow the same shape: a single `url` pointing at the running
 endpoint (`http://localhost:6390/mcp`). Hosts that only speak stdio can
 bridge via `mcp-remote` — see [`examples/README.md`](examples/README.md).
 
+Connecting the server only makes the tools *available*. To make the agent
+**use** them without being asked — recall before answering, capture durable
+facts after — install the ambient-memory instruction profile:
+
+- [`examples/ambient-memory.instructions.md`](examples/ambient-memory.instructions.md) — copy-paste capture+recall policy, plus VS Code / Claude Desktop wiring and an Admin Illuminate "watch your mind map" pointer in [`examples/README.md`](examples/README.md#make-the-agent-use-lantern-automatically).
+
 ## Development
 
 ```shell

--- a/mcp/examples/README.md
+++ b/mcp/examples/README.md
@@ -12,6 +12,12 @@ share the same shape — a single `url` pointing at the running endpoint.
 | [`vscode-mcp.json`](vscode-mcp.json) | `.vscode/mcp.json` in your workspace, or `~/.config/Code/User/mcp.json` for user scope |
 | [`cursor-mcp.json`](cursor-mcp.json) | `~/.cursor/mcp.json` |
 
+> These three files only **connect** the agent to Lantern. To make the agent
+> actually *use* it — recall before answering, capture durable facts after —
+> without being asked, also install the
+> [ambient-memory instruction profile](#make-the-agent-use-lantern-automatically)
+> below.
+
 ## Start the server first
 
 The agent no longer spawns the container — it connects to an
@@ -89,3 +95,55 @@ endpoint is unreachable, the server exits non-zero at startup with a
 single line on stderr identifying the address that failed — so a failing
 `curl` against a dead container means the server never came up; check
 `docker logs`.
+
+## Make the agent use Lantern automatically
+
+Connecting the server (above) only makes the tools *available*. The server
+already advertises a system-prompt-style nudge at session-open, but the host
+agent ultimately decides when to call tools — so for reliably always-on
+behaviour, also install a client-side instruction profile:
+
+**→ [`ambient-memory.instructions.md`](ambient-memory.instructions.md)**
+
+It tells the agent to run a per-turn loop — **recall** relevant context before
+answering, **capture** durable facts and relations after a substantive
+exchange — with sensible TTL buckets and the `user.*` / `project.*` /
+`session.*` key-namespace convention so the graph stays a navigable mind map.
+
+### VS Code Copilot
+
+1. Wire the server: drop [`vscode-mcp.json`](vscode-mcp.json) into
+   `.vscode/mcp.json` (note `"type": "http"` — required since the server
+   moved to Streamable HTTP).
+2. Install the policy: copy `ambient-memory.instructions.md` into your
+   workspace at `.github/instructions/ambient-memory.instructions.md`. Its
+   `applyTo: '**'` frontmatter makes Copilot apply it to every request
+   automatically. (Alternatively, paste the body — everything below the
+   frontmatter — into `.github/copilot-instructions.md`.)
+
+### Claude Desktop / other MCP hosts
+
+1. Wire the server with [`claude-desktop.json`](claude-desktop.json) (or the
+   [`mcp-remote`](#hosts-that-only-support-stdio-mcp-servers) bridge for
+   stdio-only hosts).
+2. Copy the body of `ambient-memory.instructions.md` (skip the YAML
+   frontmatter) into the host's system prompt, project instructions, or
+   custom-instructions field. The text is host-agnostic — it only references
+   the Lantern tool names.
+
+## Watch your mind map
+
+Everything the agent captures lands in the same Lantern the MCP server writes
+to, so you can watch the graph fill in live. Point the
+[**lantern-admin**](../../admin/) SPA at that Lantern and open **Illuminate**:
+
+- In the [compose stack](../../README.md#run-with-docker-compose--open-the-admin-ui)
+  the Admin is served at **<http://localhost:8080>** — open it and go to
+  **Illuminate** (`/illuminate`).
+- Seed the walk with a namespace root you have been writing under — e.g.
+  `user.identity.name` or `project.lantern` — then increase the hop count to
+  watch related facts and relations fan out.
+
+Because recall does **not** refresh TTL, stale corners of the map fade on their
+own between visits; the keys the agent keeps re-remembering stay bright. That
+visible decay *is* the feature.

--- a/mcp/examples/ambient-memory.instructions.md
+++ b/mcp/examples/ambient-memory.instructions.md
@@ -1,0 +1,90 @@
+---
+description: 'Ambient memory policy for agents connected to the Lantern MCP server — recall before answering, capture durable facts after, with TTL-bucketed, namespaced keys.'
+applyTo: '**'
+---
+
+# Ambient memory (Lantern MCP)
+
+> **What this is.** A ready-to-use instruction profile that turns the Lantern
+> MCP server's built-in nudge into an always-on capture+recall policy on the
+> *client* side — because the host agent, not the server, ultimately decides
+> when to call tools.
+>
+> **How to install it** is in [`README.md`](README.md#make-the-agent-use-lantern-automatically).
+> In short: VS Code Copilot picks this file up automatically when it lives in
+> `.github/instructions/`; for Claude Desktop or any other host, copy
+> everything below the frontmatter into your system / project instructions.
+
+You are connected to **Lantern**, an ambient graph memory exposed over MCP. It
+is yours to use **proactively — you do not need to be asked** to remember or
+recall. Treat it like your own long-term memory of this user and their work.
+
+## Run this loop every turn
+
+1. **Recall first.** Before answering anything that could depend on prior
+   context — preferences, decisions, people, project facts — pull in what you
+   already know:
+   - `recall_fact` — look up an exact key you expect to exist.
+   - `recall_related` — walk outward from a seed key to gather surrounding
+     context and associations.
+   - `list_under` — enumerate a namespace (e.g. `user.`, `project.`) when you
+     are unsure of the exact key.
+2. **Answer** using what you recalled. Prefer a remembered fact over
+   re-asking the user something you were already told.
+3. **Capture after.** Once the exchange settles, write what is newly durable:
+   - `remember_fact` — a preference, decision, identity, or project fact.
+   - `remember_relation` — how two things connect (additive: writing the same
+     relation again strengthens it).
+
+   Capturing is the **default, not the exception**.
+
+## Two invariants govern every write
+
+- **There is no "forever."** Each write picks a TTL bucket from
+  `seconds`, `transient`, `turn`, `conversation`, `task`, `workday`, `day`,
+  `week`, `sprint`, `month`, `quarter`, `durable`. Ask *"when will this stop
+  being true?"* and *"how bad is it if it lingers past then?"* and pick the
+  **shorter** bucket — writing again is cheap.
+- **Recall does not refresh TTL.** Reading a fact does not extend its life. To
+  keep a fact alive, **re-remember it when you reference it**.
+
+## Namespace keys so the graph reads as a mind map
+
+Use dotted, hierarchical keys. Reuse a key to update its value.
+
+- `user.*` — stable facts about the person
+  (`user.preferences.tone`, `user.identity.role`, `user.timezone`).
+- `project.*` — the work at hand
+  (`project.lantern.stack`, `project.lantern.deadline`).
+- `session.*` — ephemeral working state
+  (`session.current-task`, `session.open-question`).
+
+Only call `forget` when a fact is now **wrong** or the user asks you to drop it
+— routine staleness is handled by TTL decay, so you rarely need it.
+
+## Suggested TTL defaults
+
+A starting point; shorter is always safer, and the server's bucket durations
+are configurable.
+
+| Kind of fact | Bucket |
+|---|---|
+| Name, role, timezone, long-standing preferences | `durable` / `quarter` |
+| Current project's stack, conventions, owners | `month` / `sprint` |
+| What we're doing right now | `task` / `conversation` |
+| A one-off detail for the next few replies | `turn` / `transient` |
+
+## Worked example
+
+> **User:** "I'm Hiro, I lead the Lantern project and I prefer terse answers."
+
+1. `recall_related` from `user.identity` and `list_under` `user.` — nothing yet.
+2. Answer briefly (honoring the stated preference).
+3. Capture:
+   - `remember_fact` `user.identity.name` = `Hiro` — bucket `durable`.
+   - `remember_fact` `user.identity.role` = `lead, Lantern project` — `quarter`.
+   - `remember_fact` `user.preferences.tone` = `terse` — `durable`.
+   - `remember_relation` `user.identity.name` → `project.lantern` — `quarter`.
+
+Next session, a `list_under` `user.` surfaces all of it before you answer — so
+you stay terse and never re-ask who they are.


### PR DESCRIPTION
## What

Ship the **client-side** half of the ambient-memory epic (#530): a ready-to-use
instruction profile that turns the server-side nudge into an always-on
capture+recall policy on the host agent, plus wiring notes and a "watch your
mind map" pointer. Pure docs/examples — no Go.

## Why

The host agent — not the server — decides when to call tools. PR #532 (#528)
made the server *advertise* a capture+recall loop, but reliable always-on
behaviour needs a client-side instruction profile the user installs into their
host. This is the practical other half.

## Changes

- **`mcp/examples/ambient-memory.instructions.md`** (new) — a copy-paste agent
  instruction block (VS Code `*.instructions.md` shape, `applyTo: '**'`) that
  tells the connected agent to:
  - **recall** relevant context before answering (`recall_fact` /
    `recall_related` / `list_under`);
  - **capture** durable facts and relations after a substantive exchange
    (`remember_fact` / `remember_relation`), with sensible TTL buckets;
  - follow the `user.*` / `project.*` / `session.*` key-namespace convention so
    the graph reads as a mind map.

  It restates the two invariants (no `"forever"`; recall does **not** refresh
  TTL), gives a suggested TTL-default table, and ends with a worked example.
  The text is host-agnostic — non-VS-Code hosts copy the body below the
  frontmatter.

- **`mcp/examples/README.md`** — new **"Make the agent use Lantern
  automatically"** section with per-host wiring (VS Code Copilot:
  `.vscode/mcp.json` `type: http` + `.github/instructions/…`; Claude Desktop /
  other hosts: system-prompt paste), and a **"Watch your mind map"** section
  pointing at the Admin **Illuminate** view (`/illuminate`) against the same
  Lantern. Added a pointer after the config table.

- **`mcp/README.md`** — link the new instruction profile from the client-config
  list for discoverability.

## Notes

- Pure docs; no tool signatures, wire surface, or Go code change.
- The `type: http` wiring depends on the Streamable-HTTP transport (#531) and
  the namespace convention it references is the one introduced server-side in
  #532 — both already merged.

## Verification

- All internal links checked: `#make-the-agent-use-lantern-automatically`,
  `#run-with-docker-compose--open-the-admin-ui`, relative `../../admin/` /
  `../../README.md` paths.

Closes #529
