### PR TITLE
chore(release): pin root + mcp to core/v0.3.1 and sdks/go/v0.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.4.0
-	github.com/anaregdesign/lantern/core v0.3.0
+	github.com/anaregdesign/lantern/core v0.3.1
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.3.0
-	github.com/anaregdesign/lantern/sdks/go v0.10.0
+	github.com/anaregdesign/lantern/sdks/go v0.11.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/anaregdesign/lantern/pb v0.3.0
-	github.com/anaregdesign/lantern/sdks/go v0.10.0
+	github.com/anaregdesign/lantern/sdks/go v0.11.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 )
 


### PR DESCRIPTION
## What

Bump the `require` pins in the root and `mcp` `go.mod` files to the freshly-tagged upstreams ahead of the `v0.10.0` (root) and `mcp/v0.4.0` releases:

- root: `core v0.3.0 → v0.3.1`, `sdks/go v0.10.0 → v0.11.0`
- mcp: `sdks/go v0.10.0 → v0.11.0`

## Why

Per the AGENTS.md **Cutting a release** order: tag `core`/`sdks/go` first, then bump the downstream `require` lines, then tag the downstream modules. `core/v0.3.1` (x/sync dep bump, #508) and `sdks/go/v0.11.0` (permanent-TTL write semantics, #523/#525) are already tagged; this commit re-pins root + mcp so the `v0.10.0` and `mcp/v0.4.0` tags carry the correct metadata.

All lantern deps remain locally `replace`d (`=> ./core`, `=> ../sdks/go`, …), so this is metadata-only — both modules build clean against local source.

Release-mechanics change; no issue per the AGENTS.md release exception.
