### PR TITLE
chore: improve zero-config Docker Compose / MCP quickstart defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,13 +243,15 @@ for the discovery semantics.
 
 The fastest way to get a running cluster **and** a browser console in front of
 it is the Compose stack in [`deploy/compose/`](deploy/compose/). One `up`
-brings up a 3-replica HA cluster, the [`lantern-admin`](admin/) SPA, and
-Prometheus — no local build required:
+brings up a 3-replica HA cluster, the [`lantern-admin`](admin/) SPA, the
+`lantern-mcp` server, and Prometheus — no local build required:
 
 ```shell
 cd deploy/compose
-# Pull published images for the server and the Admin SPA, then start the stack.
-LANTERN_IMAGE=ghcr.io/anaregdesign/lantern:latest docker compose up -d
+# Every service defaults to its published `:latest` image, so no local build is
+# needed. `--pull always` re-fetches the `:latest` tags so you never run a stale
+# cached image.
+docker compose up -d --pull always
 ```
 
 Then open the Admin in your browser:
@@ -266,10 +268,11 @@ other two. Each replica ships
 from the Admin origin is allowed out of the box. Tear the stack down with
 `docker compose down -v`.
 
-> **Iterating on the server itself?** The `lantern` service defaults to the
-> locally-built `lantern:local` tag, so build it once from the repo root
-> (`docker build -t lantern:local .`) and drop the `LANTERN_IMAGE` override to
-> run the cluster against your own changes.
+> **Iterating on the server itself?** The `lantern` services default to the
+> published `ghcr.io/anaregdesign/lantern:latest` image. To run the cluster
+> against your own changes, build the repo once
+> (`docker build -t lantern:local .`) and set `LANTERN_IMAGE=lantern:local`
+> before `docker compose up -d`.
 
 Under the hood the canonical compose declares three explicit
 `lantern-{0,1,2}` services with pinned host ports (`6380`, `6381`, `6382`)
@@ -742,7 +745,7 @@ The server is configured via environment variables, parsed in
 | `LANTERN_TLS_CERT_FILE` | _(unset)_ | Server certificate; enables TLS when set with key |
 | `LANTERN_TLS_KEY_FILE` | _(unset)_ | Server private key |
 | `LANTERN_TLS_CLIENT_CA_FILE` | _(unset)_ | Client CA bundle; enables mTLS (`RequireAndVerifyClientCert`) when set |
-| `LANTERN_TOMBSTONE_TTL` | `24h` | Replication tombstone retention window. While the tombstone is live, any incoming `AddEdge`/`PutEdge`/`PutVertex` (including peer-replayed mutations via `ApplyMutation`) with an HLC strictly older than the delete is dropped, so deletes converge across nodes even under reorder. Mutations whose `Expiration` exceeds this TTL are rejected with `InvalidArgument`. Set to `0` to disable tombstones entirely (legacy behaviour; delete-then-re-add reorders may resurrect data). |
+| `LANTERN_TOMBSTONE_TTL` | `8760h` (1 year) | Replication tombstone retention window. While the tombstone is live, any incoming `AddEdge`/`PutEdge`/`PutVertex` (including peer-replayed mutations via `ApplyMutation`) with an HLC strictly older than the delete is dropped, so deletes converge across nodes even under reorder. Mutations whose `Expiration` exceeds this TTL are rejected with `InvalidArgument`. Set to `0` to disable tombstones entirely (legacy behaviour; delete-then-re-add reorders may resurrect data). |
 
 ## Observability
 

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -112,8 +112,8 @@ test.describe("/cli", () => {
   // canvas so the operator sees what they just wrote, instead of the
   // canvas staying blank. The verb dispatches straight through with no
   // confirmation chip (#521). An explicit TTL keeps the expiration inside
-  // the server's tombstone window (24h in the e2e harness); the grammar
-  // is `put vertex <key> <value> [ttl_seconds]`.
+  // the server's tombstone window (the default 1 year in the e2e harness); the
+  // grammar is `put vertex <key> <value> [ttl_seconds]`.
   test("put vertex adds the new node to the canvas (#518)", async ({
     page,
   }) => {

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -25,6 +25,12 @@ single-host HA experiments.
   `/api/prom` (`LANTERN_ADMIN_PROMETHEUS_UPSTREAM=http://prometheus:9090`
   is set on the admin service) so the Ops Metrics charts work without a
   cross-origin call to Prometheus.
+- 1 × `lantern-mcp` MCP server (`ghcr.io/anaregdesign/lantern-mcp`) on
+  host port `6390`, serving the Model Context Protocol over Streamable
+  HTTP at `/mcp`. It dials the `lantern` alias, so Compose DNS
+  round-robins its calls across the three replicas. It now comes up with
+  the rest of the stack on `docker compose up -d` — see
+  [Single-node + MCP server](#single-node--mcp-server) below.
 - `prometheus` scrapes via `dns_sd_configs` against the `lantern`
   alias, so it picks up every replica automatically (no static targets
   file to maintain).
@@ -45,7 +51,9 @@ basename (`compose`).
 
 ```shell
 cd deploy/compose
-docker compose up -d
+# Images default to the published `:latest` tags (no local build needed);
+# `--pull always` re-fetches them so you never run a stale cached image.
+docker compose up -d --pull always
 docker compose ps
 ```
 
@@ -132,7 +140,7 @@ docker compose logs lantern-0 lantern-1 lantern-2 | grep peer_discovery
 For non-HA development bring up only one replica:
 
 ```shell
-docker compose up -d lantern-0 admin prometheus
+docker compose up -d --pull always lantern-0 admin prometheus
 ```
 
 `LANTERN_PEER_DNS_NAME=lantern` still resolves — to the single A
@@ -148,20 +156,20 @@ pump becomes a no-op.
 
 ## Single-node + MCP server
 
-For local LLM-agent experiments there is a smaller compose file in
+The HA compose file in this directory ships a `lantern-mcp` service that
+comes up with the rest of the stack on `docker compose up -d`, talking to
+the 3-replica cluster — Compose DNS round-robins `lantern:6380` across the
+live replicas. For a smaller single-`lantern` topology there is also
 [`docker-compose.mcp.yml`](docker-compose.mcp.yml) that stands up one
-`lantern` + one `lantern-mcp`. The HA compose file in this directory
-also ships a `lantern-mcp` service behind a Compose profile, so the
-same MCP container can be exercised against the 3-replica cluster:
+`lantern` + one `lantern-mcp`:
 
 ```shell
-# Single-node (small file): bring lantern + the MCP server up together.
-docker compose -f docker-compose.mcp.yml up -d
+# HA cluster (this file): lantern-mcp starts with the rest of the stack.
+docker compose up -d
 
-# HA cluster (this file): same lantern-mcp container, but talking to
-# the 3-replica cluster — Compose DNS round-robins `lantern:6380`
-# across the live replicas.
-docker compose --profile mcp up -d lantern-mcp
+# Single-node (small file): one lantern + the MCP server. `--pull always`
+# re-fetches the `:latest` tags so you never run a stale cached image.
+docker compose -f docker-compose.mcp.yml up -d --pull always
 ```
 
 `lantern-mcp` serves the Model Context Protocol over **Streamable
@@ -177,6 +185,5 @@ reference.
 
 > The standalone `docker-compose.mcp.yml` covers the single-node case
 > and stays useful as a template for embedding `lantern-mcp` in your
-> own agent-runtime compose file. The HA file's `mcp` profile covers
-> the multi-replica case without duplicating the lantern + Prometheus
-> stack.
+> own agent-runtime compose file. The HA file brings `lantern-mcp` up
+> by default alongside the multi-replica cluster.

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -18,7 +18,7 @@
 #
 # Usage:
 #   cd deploy/compose
-#   docker compose up -d
+#   docker compose up -d --pull always   # --pull always re-fetches the :latest images
 #   docker compose down -v
 #
 # To scale beyond three replicas, edit the file (each replica needs
@@ -26,15 +26,18 @@
 # `--scale lantern=N` workflow is gone — it depended on Compose's
 # port-range allocator, which is what #435 fixes.
 #
-# Override the image:
+# The lantern services default to ghcr.io/anaregdesign/lantern:latest, so a
+# bare `docker compose up -d` runs the published image with no local build.
+# Override to pin a release or run a local build instead:
 #   LANTERN_IMAGE=ghcr.io/anaregdesign/lantern:v0.7.1 docker compose up -d
+#   LANTERN_IMAGE=lantern:local docker compose up -d   # after `docker build -t lantern:local .`
 
 # Shared lantern config. Each replica differs only in the published
 # host port; container naming is left to Compose so the canonical
 # stack and the testbed/bench overlay can run side-by-side without
 # colliding on globally-scoped container names.
 x-lantern-common: &lantern-common
-  image: ${LANTERN_IMAGE:-lantern:local}
+  image: ${LANTERN_IMAGE:-ghcr.io/anaregdesign/lantern:latest}
   environment:
     LANTERN_PORT: "6380"
     LANTERN_METRICS_ADDR: ":9090"
@@ -111,16 +114,12 @@ services:
       retries: 6
       start_period: 5s
 
-  # Opt-in MCP server. lantern-mcp serves the Model Context Protocol over
-  # Streamable HTTP, so it's a long-lived service — bring it up with the
-  # `mcp` profile and point your agent at http://localhost:6390/mcp. See
-  # `mcp/examples/` for the configs that wire Claude Desktop / VS Code /
-  # Cursor to it.
-  #
-  # Usage:
-  #   docker compose --profile mcp up -d lantern-mcp
+  # MCP server. lantern-mcp serves the Model Context Protocol over
+  # Streamable HTTP, so it's a long-lived service — it comes up with the
+  # rest of the stack on `docker compose up -d`. Point your agent at
+  # http://localhost:6390/mcp. See `mcp/examples/` for the configs that
+  # wire Claude Desktop / VS Code / Cursor to it.
   lantern-mcp:
-    profiles: ["mcp"]
     image: ${LANTERN_MCP_IMAGE:-ghcr.io/anaregdesign/lantern-mcp:latest}
     ports:
       - "6390:6390"

--- a/docs/ha-runbook.md
+++ b/docs/ha-runbook.md
@@ -356,7 +356,7 @@ for the full analysis. The operational summary:
 |---|---|---|
 | `AddEdge*` | Both sides accumulate contributions. | G-Set union: every contribution survives. Weight = sum. |
 | `PutVertex*` / `PutEdge*` | Both sides accept. | Higher-HLC wins (LWW); same HLC → higher origin ID wins. Losing side's value silently dropped. |
-| `DeleteVertex*` / `DeleteEdge*` | Both sides accept. | Higher-HLC tombstone wins. **Resurrection hazard if partition > `tombstone_ttl`** (D4, default 24h). |
+| `DeleteVertex*` / `DeleteEdge*` | Both sides accept. | Higher-HLC tombstone wins. **Resurrection hazard if partition > `tombstone_ttl`** (D4, default 1 year / 8760h). |
 
 **The one real failure case** is a partition that exceeds tombstone
 TTL: a `Delete` on side A may be GC'd from the mutation log before

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -63,7 +63,7 @@ is required for either reads or writes.
 | D1 | Crash persistence | **None for v1.** WAL is a hook only. | Bootstrap from peers covers single-node loss; persistence adds operational surface area we don't yet need. |
 | D2 | External CDC | **Same `Subscribe` RPC**, gated by auth/ACL later. Under the leaderless Subscribe contract (#415, Reading B), an external CDC consumer attaches to any **one** replica and observes every committed cluster mutation — failover to a different replica is supported by passing the per-origin watermark in `SubscribeRequest.from_seq_per_origin`. | Internal replication and external CDC are isomorphic; splitting RPCs would duplicate machinery. The per-origin cursor lets consumers spread load across replicas without reimplementing the internal pump's dedup. |
 | D3 | WAN replication | **Out of scope for v1**, single DC only. HLC max skew bound = **500 ms**. | Geo replication requires looser skew + read repair; defer until single-DC HA is proven. |
-| D4 | Tombstone TTL | **Cluster-wide config, default 24h.** Any `Add*` / `Put*` whose TTL would exceed tombstone TTL is **rejected** with `InvalidArgument`. | Resurrection-proof deletes require tombstones to outlive every live contribution. This is a real backwards-incompatible constraint. |
+| D4 | Tombstone TTL | **Cluster-wide config, default 1 year (8760h).** Any `Add*` / `Put*` whose TTL would exceed tombstone TTL is **rejected** with `InvalidArgument`. | Resurrection-proof deletes require tombstones to outlive every live contribution. This is a real backwards-incompatible constraint. |
 | D5 | Workload kind (k8s reference impl) | **StatefulSet** (not Deployment). | Stable pod identity simplifies peer discovery; leaves room for an optional WAL PVC later. The *user experience* is Deployment-like; the *resource kind* is `StatefulSet`. |
 | D6 | Cluster membership v1 | **Static `LANTERN_PEERS` env var.** v2 adds DNS-based discovery (#190). | Smallest surface that ships. Any DNS-routable platform (k8s headless Service, Compose service name, Nomad, plain DNS A-records) can populate it trivially. |
 | D7 | Supported deployment topologies | **Tier A (full HA):** k8s StatefulSet, Nomad, plain VMs, Docker Compose with stable peer hostnames. **Tier B (single-instance, no HA):** any container PaaS — Docker Compose single service, Cloud Run, Azure Container Apps, App Runner. **Not supported:** running multiple Cloud Run / ACA *instances* as a replicated cluster. | Leaderless P2P needs **stable inter-instance addressing** and **long-lived inbound gRPC streams between peers**. Serverless container platforms intentionally hide instance addresses and recycle instances; they fit single-instance deploys (still useful as a fast in-memory KVS) but not the replicated topology. |
@@ -516,7 +516,7 @@ Lantern is **AP** in CAP terms. During a partition:
 - `Delete*` followed by `Put*` on the **other** side of the partition is the
   only true hazard. If `Delete` HLC > later `Put` HLC on the other side, the
   `Put` will be dropped after heal. If the partition lasts **longer than
-  `tombstone_ttl` (D4, default 24h)**, the tombstone may GC before the other
+  `tombstone_ttl` (D4, default 1 year / 8760h)**, the tombstone may GC before the other
   side learns about it, resurrecting the deleted entry. Operators must keep
   partition duration < tombstone TTL or extend D4.
 

--- a/server/README.md
+++ b/server/README.md
@@ -113,7 +113,7 @@ most common knobs:
 | `LANTERN_DELETE_BY_PREFIX_DEFAULT_LIMIT` / `LANTERN_DELETE_BY_PREFIX_MAX_LIMIT` | `10000` / `100000` | Delete-by-prefix caps. |
 | `LANTERN_MAX_KEY_LEN` / `LANTERN_MAX_BATCH_SIZE` | `1024` / `10000` | Validation limits. |
 | `LANTERN_ILLUMINATE_MAX_STEP` / `LANTERN_ILLUMINATE_MAX_K` | `16` / `1024` | Validation limits. |
-| `LANTERN_TOMBSTONE_TTL` | (unset = disabled) | Tombstone retention + clamp on caller-supplied `Expiration` (see HA RFC). |
+| `LANTERN_TOMBSTONE_TTL` | `8760h` (1 year) | Tombstone retention + clamp on caller-supplied `Expiration`; set to `0` to disable (see HA RFC). |
 
 Replication-specific variables (`LANTERN_PEERS`, `LANTERN_MAX_REPLICATION_LAG`,
 anti-entropy intervals, etc.) are documented in

--- a/server/provider/replication.go
+++ b/server/provider/replication.go
@@ -46,9 +46,9 @@ type MutationLogConfig struct {
 //     identity across restarts must set this explicitly.
 //   - LANTERN_TOMBSTONE_TTL              max retention window for delete
 //     tombstones and the upper bound on caller-supplied Expiration on
-//     Add*/Put* RPCs. Default 24h. Set to a value larger than the longest
-//     plausible cross-cluster delivery delay to avoid late writes
-//     resurrecting deleted entries.
+//     Add*/Put* RPCs. Default 1 year (8760h). Set to a value larger than
+//     the longest plausible cross-cluster delivery delay to avoid late
+//     writes resurrecting deleted entries.
 type ReplicationConfig struct {
 	NodeID       hlc.NodeID
 	TombstoneTTL time.Duration
@@ -72,7 +72,7 @@ func loadMutationLogConfig() MutationLogConfig {
 // loadReplicationConfig reads ReplicationConfig from the environment. Called
 // from NewConfig so all env reads remain colocated.
 func loadReplicationConfig() ReplicationConfig {
-	ttl := envconfig.Duration("LANTERN_TOMBSTONE_TTL", 24*time.Hour)
+	ttl := envconfig.Duration("LANTERN_TOMBSTONE_TTL", 365*24*time.Hour) // 1 year
 	var id hlc.NodeID
 	raw := strings.TrimSpace(os.Getenv("LANTERN_NODE_ID"))
 	raw = strings.TrimPrefix(raw, "0x")


### PR DESCRIPTION
Closes #535

## What

Smooths the first-run Docker Compose / MCP experience and sets a saner tombstone default.

- **Tombstone TTL default `24h` → `1 year` (8760h)** in `server/provider/replication.go`. `validateExpiration` clamps any `Put*`/`Add*` whose `Expiration` exceeds `now + tombstoneTTL`; the MCP server's TTL buckets reach `durable` = 180 days, so the old 24h default rejected most `remember_*` writes out of the box. Amended in lockstep: `docs/replication.md` (D4 RFC), `docs/ha-runbook.md`, `server/README.md`, `README.md`, and a stale comment in the admin e2e spec.
- **`lantern-mcp` always starts** — dropped the opt-in `mcp` Compose profile in `deploy/compose/docker-compose.yml`. It's a long-lived Streamable-HTTP service, so it comes up with `docker compose up -d`.
- **HA compose default image → `ghcr.io/anaregdesign/lantern:latest`** (was `lantern:local`), so the quickstart runs with no local build. `LANTERN_IMAGE=lantern:local` stays documented as the opt-in for iterating on the server.
- **`--pull always`** in the quickstart examples (`README.md`, `deploy/compose/README.md`) so a cached `:latest` never masks a newer published image.

## Out of scope (intentionally unchanged)

`testbed/` and `.github/workflows/docker-publish.yml` keep `lantern:local` — that local tag is load-bearing for pre-release benchmarking (the bench driver `die`s if the local image is absent).

## Validation

- `gofmt -l . cli core mcp pb sdks server tests` → empty.
- `cd server && go vet ./... && go test ./...` → all pass.
- `docker compose -f deploy/compose/docker-compose.yml config` with no `LANTERN_IMAGE` set → all `lantern-{0,1,2}` services resolve to `ghcr.io/anaregdesign/lantern:latest`; `--services` lists `lantern-mcp` (no profile needed).