### PR TITLE
fix(mcp): drop redundant sentinel label in mapSDKError

### DIFF
--- a/mcp/lantern.go
+++ b/mcp/lantern.go
@@ -33,14 +33,18 @@ type lanternClient interface {
 // low-cardinality form suitable for an LLM tool result. The original
 // error is wrapped so callers using errors.Is on the sentinels still
 // match; the prefix is purely additive context.
+//
+// Only ErrResourceExhausted earns a bespoke label, because "rate limited;
+// back off and retry" is actionable guidance the sentinel text ("resource
+// exhausted") does not convey. The other sentinels already stringify to a
+// clear phrase (ErrInvalidArgument → "invalid argument", ErrNotFound →
+// "not found"), so adding a matching literal label only produced doubled
+// noise like "invalid argument: invalid argument"; they fall through to the
+// generic "%s: %w" form alongside unclassified errors.
 func mapSDKError(tool string, err error) error {
 	switch {
-	case errors.Is(err, client.ErrInvalidArgument):
-		return fmt.Errorf("%s: invalid argument: %w", tool, err)
 	case errors.Is(err, client.ErrResourceExhausted):
 		return fmt.Errorf("%s: rate limited; back off and retry: %w", tool, err)
-	case errors.Is(err, client.ErrNotFound):
-		return fmt.Errorf("%s: not found: %w", tool, err)
 	default:
 		return fmt.Errorf("%s: %w", tool, err)
 	}

--- a/mcp/lantern_test.go
+++ b/mcp/lantern_test.go
@@ -13,11 +13,33 @@ func TestMapSDKError_InvalidArgument(t *testing.T) {
 	if !errors.Is(err, client.ErrInvalidArgument) {
 		t.Fatalf("errors.Is sentinel lost")
 	}
-	if !strings.Contains(err.Error(), "invalid argument") {
-		t.Fatalf("missing branch label: %v", err)
+	// The sentinel already stringifies to "invalid argument"; the wrapper must
+	// not prepend a redundant literal (regression guard for #546).
+	if got, want := err.Error(), "remember_fact: invalid argument"; got != want {
+		t.Fatalf("message shape: got %q want %q", got, want)
 	}
-	if !strings.Contains(err.Error(), "remember_fact") {
-		t.Fatalf("missing tool prefix: %v", err)
+	if strings.Contains(err.Error(), "invalid argument: invalid argument") {
+		t.Fatalf("doubled label not removed: %v", err)
+	}
+}
+
+// TestMapSDKError_InvalidArgumentJoined reproduces the real dogfooding path
+// (#546): the SDK joins ErrInvalidArgument with the underlying connect error,
+// so the message must surface the sentinel once, never doubled.
+func TestMapSDKError_InvalidArgumentJoined(t *testing.T) {
+	joined := errors.Join(
+		client.ErrInvalidArgument,
+		errors.New("invalid_argument: expiration exceeds LANTERN_TOMBSTONE_TTL=24h0m0s"),
+	)
+	err := mapSDKError("remember_fact", joined)
+	if !errors.Is(err, client.ErrInvalidArgument) {
+		t.Fatalf("errors.Is sentinel lost")
+	}
+	if strings.Contains(err.Error(), "invalid argument: invalid argument") {
+		t.Fatalf("doubled label leaked through joined error: %v", err)
+	}
+	if !strings.HasPrefix(err.Error(), "remember_fact: invalid argument") {
+		t.Fatalf("missing tool prefix / sentinel: %v", err)
 	}
 }
 
@@ -36,8 +58,13 @@ func TestMapSDKError_NotFound(t *testing.T) {
 	if !errors.Is(err, client.ErrNotFound) {
 		t.Fatalf("errors.Is sentinel lost")
 	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Fatalf("missing branch label: %v", err)
+	// "not found" comes from the sentinel itself; it must appear once, not
+	// doubled (the redundant literal label was removed in #546).
+	if got, want := err.Error(), "recall_fact: not found"; got != want {
+		t.Fatalf("message shape: got %q want %q", got, want)
+	}
+	if strings.Contains(err.Error(), "not found: not found") {
+		t.Fatalf("doubled label not removed: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
`mapSDKError` rendered `ErrInvalidArgument` as `"%s: invalid argument: %w"`, but
the SDK sentinel already stringifies to `invalid argument`, producing the doubled
`invalid argument: invalid argument` seen in the dogfooding evidence. The
`ErrNotFound` branch (`"%s: not found: %w"`) had the identical defect
(`not found: not found`).

This collapses both redundant branches into the generic `"%s: %w"` form. Only
`ErrResourceExhausted` keeps a bespoke label, because `rate limited; back off and
retry` is actionable guidance its sentinel text (`resource exhausted`) does not
convey.

## Changes
- `mcp/lantern.go`: remove the redundant `invalid argument` / `not found` literal
  labels; keep the `ErrResourceExhausted` hint; document why.
- `mcp/lantern_test.go`: assert the exact no-doubling message shape for both
  sentinels and add `TestMapSDKError_InvalidArgumentJoined`, which reproduces the
  real SDK `errors.Join(ErrInvalidArgument, connectErr)` path from the evidence.

## Acceptance criteria (#546)
- [x] No `invalid argument: invalid argument` doubling (also fixes the identical
  `not found: not found` clone).
- [x] `errors.Is(err, client.ErrInvalidArgument)` still true (verified, incl. the
  joined-error path).
- [x] Test asserts the message shape.

## Verification
`gofmt -l` clean; `go vet`, mcp/core/pb/sdks-go/server/root tests all green.

Closes #546
