### PR TITLE
fix(mcp): clamp resolved TTL to LANTERN_MCP_MAX_TTL

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -106,6 +106,23 @@ syntax (no `d` suffix — use `168h` for a week). The resolved durations
 must remain **strictly monotonic**; a misordered configuration is a
 fatal startup error.
 
+### Capping long buckets to a low server `LANTERN_TOMBSTONE_TTL`
+
+The upstream Lantern server **rejects** any write whose expiry exceeds its
+`LANTERN_TOMBSTONE_TTL` with `invalid_argument`. The server default
+(`8760h`, 1 year) sits above the longest bucket, so out of the box every
+bucket is accepted. But a node deliberately run with a short tombstone
+window (e.g. `LANTERN_TOMBSTONE_TTL=24h`) would make `week` and longer
+buckets fail hard.
+
+Set `LANTERN_MCP_MAX_TTL` to the same (or a smaller) value to have the MCP
+**clamp** each bucket's horizon down to that cap *before* writing, instead
+of surfacing an error. When a write is clamped, the tool result sets
+`"capped": true`, reports the shortened `expires_at`, and the text content
+reminds you to re-`remember_*` before it expires. The bucket label is
+preserved so the intent is still legible. Unset (the default) means **no
+cap** — buckets resolve to their nominal horizons.
+
 ## Environment reference
 
 | Variable | Default | Purpose |
@@ -114,6 +131,7 @@ fatal startup error.
 | `LANTERN_MCP_HTTP_ADDR` | `127.0.0.1:6390` | Address the Streamable-HTTP MCP endpoint listens on. Loopback by default; set `0.0.0.0:6390` to expose on all interfaces (the container/Helm defaults). |
 | `LANTERN_MCP_PING_TIMEOUT` | `5s` | Bounds the startup health probe. A failed probe aborts startup with a non-zero exit so MCP clients surface a clear error. |
 | `LANTERN_MCP_TTL_<BUCKET>` | see table above | Per-bucket TTL override. |
+| `LANTERN_MCP_MAX_TTL` | unset (no cap) | Clamp every resolved bucket to at most this duration, matching a low upstream `LANTERN_TOMBSTONE_TTL`. Clamped writes report `"capped": true`. `time.ParseDuration` syntax. |
 
 Logging is structured JSON via `log/slog` to stderr at `INFO` level;
 there is no log-level or format knob today.

--- a/mcp/helpers_test.go
+++ b/mcp/helpers_test.go
@@ -19,8 +19,15 @@ import (
 // and inspect calls.
 func newTestHarness(t *testing.T) *testHarness {
 	t.Helper()
+	return newTestHarnessWith(t, mustDefaultResolver(t))
+}
+
+// newTestHarnessWith is newTestHarness with an explicit TTL resolver so a
+// test can exercise the LANTERN_MCP_MAX_TTL clamp without mutating process
+// environment.
+func newTestHarnessWith(t *testing.T, r *ttl.Resolver) *testHarness {
+	t.Helper()
 	fake := &fakeLantern{}
-	r := mustDefaultResolver(t)
 	srv := newServer(fake, r, slog.New(slog.NewJSONHandler(io.Discard, nil)))
 
 	serverT, clientT := mcp.NewInMemoryTransports()
@@ -62,6 +69,15 @@ func mustDefaultResolver(t *testing.T) *ttl.Resolver {
 		t.Fatalf("ttl.LoadFromEnv: %v", err)
 	}
 	return r
+}
+
+// mustCappedResolver builds a resolver whose LANTERN_MCP_MAX_TTL cap is
+// maxTTL (a time.ParseDuration string). t.Setenv restores the previous
+// value at test end, so callers must not run in parallel.
+func mustCappedResolver(t *testing.T, maxTTL string) *ttl.Resolver {
+	t.Helper()
+	t.Setenv(ttl.MaxTTLEnvVar, maxTTL)
+	return mustDefaultResolver(t)
 }
 
 type testHarness struct {

--- a/mcp/internal/ttl/ttl.go
+++ b/mcp/internal/ttl/ttl.go
@@ -161,21 +161,54 @@ func EnvVar(b Bucket) string {
 	return "LANTERN_MCP_TTL_" + strings.ToUpper(b.String())
 }
 
+// MaxTTLEnvVar is the environment variable that caps every resolved bucket
+// duration. It exists so an operator whose Lantern server runs a low
+// LANTERN_TOMBSTONE_TTL (which rejects any Expiration beyond it with
+// invalid_argument) can have the MCP clamp long buckets down to a value
+// the server will accept, instead of surfacing a hard error for week+
+// horizons. Unset or non-positive means no cap — the default server
+// LANTERN_TOMBSTONE_TTL (8760h) already exceeds the longest bucket.
+const MaxTTLEnvVar = "LANTERN_MCP_MAX_TTL"
+
 // Resolver maps each bucket to its configured duration after applying env
 // overrides. It is the single source of truth for ttl.Resolve at runtime.
 type Resolver struct {
 	values map[Bucket]time.Duration
+	// maxTTL clamps every resolved duration when positive; zero disables
+	// the cap. Configured via LANTERN_MCP_MAX_TTL.
+	maxTTL time.Duration
 }
 
 // Resolve returns the configured duration for b, or panics if b is not a
 // valid bucket — bucket values originate from ParseBucket so this should
-// be unreachable in normal flow.
+// be unreachable in normal flow. Resolve returns the bucket's nominal
+// horizon and does NOT apply the LANTERN_MCP_MAX_TTL cap; callers that
+// write to the server should use ResolveCapped.
 func (r *Resolver) Resolve(b Bucket) time.Duration {
 	d, ok := r.values[b]
 	if !ok {
 		panic(fmt.Sprintf("ttl: bucket %v not configured", b))
 	}
 	return d
+}
+
+// MaxTTL reports the configured cap, or zero when no cap is set.
+func (r *Resolver) MaxTTL() time.Duration {
+	return r.maxTTL
+}
+
+// ResolveCapped returns the duration the MCP should actually send to the
+// server for bucket b: the bucket's nominal horizon clamped to
+// LANTERN_MCP_MAX_TTL when that cap is configured and shorter. The second
+// return value reports whether the clamp fired, so handlers can tell the
+// caller their requested horizon was shortened rather than silently
+// writing a different expiry.
+func (r *Resolver) ResolveCapped(b Bucket) (time.Duration, bool) {
+	d := r.Resolve(b)
+	if r.maxTTL > 0 && d > r.maxTTL {
+		return r.maxTTL, true
+	}
+	return d, false
 }
 
 // LoadFromEnv constructs a Resolver from os.LookupEnv overrides applied on
@@ -213,7 +246,18 @@ func loadFrom(lookup func(string) (string, bool)) (*Resolver, error) {
 	if err := validateMonotonic(values); err != nil {
 		return nil, err
 	}
-	return &Resolver{values: values}, nil
+	var maxTTL time.Duration
+	if raw, ok := lookup(MaxTTLEnvVar); ok {
+		parsed, err := time.ParseDuration(raw)
+		if err != nil {
+			return nil, fmt.Errorf("ttl: %s=%q: %w", MaxTTLEnvVar, raw, err)
+		}
+		if parsed <= 0 {
+			return nil, fmt.Errorf("ttl: %s=%q: duration must be positive", MaxTTLEnvVar, raw)
+		}
+		maxTTL = parsed
+	}
+	return &Resolver{values: values, maxTTL: maxTTL}, nil
 }
 
 // errNonMonotonic indicates a configuration that would lie to the model

--- a/mcp/internal/ttl/ttl_test.go
+++ b/mcp/internal/ttl/ttl_test.go
@@ -137,3 +137,93 @@ func TestEnvVar(t *testing.T) {
 		t.Fatalf("EnvVar(Day) = %q, want LANTERN_MCP_TTL_DAY", got)
 	}
 }
+
+func TestResolveCapped_NoCapByDefault(t *testing.T) {
+	r, err := loadFrom(func(string) (string, bool) { return "", false })
+	if err != nil {
+		t.Fatalf("loadFrom(empty env) returned error: %v", err)
+	}
+	if r.MaxTTL() != 0 {
+		t.Fatalf("MaxTTL() = %v, want 0 (no cap) when %s unset", r.MaxTTL(), MaxTTLEnvVar)
+	}
+	// Every bucket resolves to its nominal horizon and never reports capped.
+	for _, b := range AllBuckets() {
+		d, capped := r.ResolveCapped(b)
+		if capped {
+			t.Fatalf("ResolveCapped(%v) reported capped with no cap configured", b)
+		}
+		if d != Defaults[b] {
+			t.Fatalf("ResolveCapped(%v) = %v, want %v", b, d, Defaults[b])
+		}
+	}
+}
+
+func TestResolveCapped_ClampsOverCapBuckets(t *testing.T) {
+	// Mirror an operator whose server runs LANTERN_TOMBSTONE_TTL=24h: the MCP
+	// cap is set to match, so day and below pass through untouched while
+	// week+ clamp down to 24h instead of producing invalid_argument.
+	env := map[string]string{MaxTTLEnvVar: "24h"}
+	r, err := loadFrom(func(k string) (string, bool) { v, ok := env[k]; return v, ok })
+	if err != nil {
+		t.Fatalf("loadFrom returned error: %v", err)
+	}
+	if r.MaxTTL() != 24*time.Hour {
+		t.Fatalf("MaxTTL() = %v, want 24h", r.MaxTTL())
+	}
+	cap := 24 * time.Hour
+	for _, b := range AllBuckets() {
+		d, capped := r.ResolveCapped(b)
+		nominal := Defaults[b]
+		if nominal > cap {
+			if !capped {
+				t.Errorf("ResolveCapped(%v): capped = false, want true (nominal %v > cap %v)", b, nominal, cap)
+			}
+			if d != cap {
+				t.Errorf("ResolveCapped(%v) = %v, want %v (clamped)", b, d, cap)
+			}
+			continue
+		}
+		if capped {
+			t.Errorf("ResolveCapped(%v): capped = true, want false (nominal %v <= cap %v)", b, nominal, cap)
+		}
+		if d != nominal {
+			t.Errorf("ResolveCapped(%v) = %v, want %v (unclamped)", b, d, nominal)
+		}
+	}
+}
+
+func TestResolveCapped_ExactCapNotReportedCapped(t *testing.T) {
+	// A bucket whose nominal horizon equals the cap is NOT clamped — the
+	// boundary is inclusive, so no misleading "capped" flag fires.
+	env := map[string]string{MaxTTLEnvVar: Defaults[Day].String()}
+	r, err := loadFrom(func(k string) (string, bool) { v, ok := env[k]; return v, ok })
+	if err != nil {
+		t.Fatalf("loadFrom returned error: %v", err)
+	}
+	d, capped := r.ResolveCapped(Day)
+	if capped {
+		t.Fatalf("ResolveCapped(Day) reported capped when nominal == cap")
+	}
+	if d != Defaults[Day] {
+		t.Fatalf("ResolveCapped(Day) = %v, want %v", d, Defaults[Day])
+	}
+}
+
+func TestLoadFromEnv_MaxTTLInvalid(t *testing.T) {
+	env := map[string]string{MaxTTLEnvVar: "1y"} // "y" unsupported by ParseDuration
+	_, err := loadFrom(func(k string) (string, bool) { v, ok := env[k]; return v, ok })
+	if err == nil {
+		t.Fatal("loadFrom with invalid max TTL returned nil error")
+	}
+	if !strings.Contains(err.Error(), MaxTTLEnvVar) {
+		t.Fatalf("error %q does not mention %s", err, MaxTTLEnvVar)
+	}
+}
+
+func TestLoadFromEnv_MaxTTLNonPositive(t *testing.T) {
+	env := map[string]string{MaxTTLEnvVar: "0s"}
+	_, err := loadFrom(func(k string) (string, bool) { v, ok := env[k]; return v, ok })
+	if err == nil {
+		t.Fatal("loadFrom with 0s max TTL returned nil error")
+	}
+}

--- a/mcp/tool_remember_fact.go
+++ b/mcp/tool_remember_fact.go
@@ -23,6 +23,10 @@ type rememberFactOutput struct {
 	Key       string `json:"key"`
 	Bucket    string `json:"bucket"`
 	ExpiresAt string `json:"expires_at"`
+	// Capped is true when the bucket's nominal horizon was clamped down to
+	// LANTERN_MCP_MAX_TTL before writing, so the caller knows the stored
+	// expiry is shorter than the bucket label implies.
+	Capped bool `json:"capped,omitempty"`
 }
 
 const rememberFactDescription = "Store a fact in Lantern with a required TTL bucket. Call this PROACTIVELY whenever the user states a durable preference, decision, identity, or project fact — you do not need to be asked. The value can be any JSON-encodable shape (string, number, bool, object, array). Use a dotted namespaced key (user.* / project.* / session.*). Writing the same key again overwrites the previous value and resets the TTL — that is the canonical way to refresh a fact since recall does NOT refresh."
@@ -43,7 +47,7 @@ func registerRememberFact(srv *mcp.Server, lc lanternClient, r *ttl.Resolver) {
 		if err != nil {
 			return nil, rememberFactOutput{}, fmt.Errorf("remember_fact: %w", err)
 		}
-		d := r.Resolve(bucket)
+		d, capped := r.ResolveCapped(bucket)
 		if err := lc.PutVertex(ctx, in.Key, sdkValue, d); err != nil {
 			return nil, rememberFactOutput{}, mapSDKError("remember_fact", err)
 		}
@@ -51,10 +55,15 @@ func registerRememberFact(srv *mcp.Server, lc lanternClient, r *ttl.Resolver) {
 			Key:       in.Key,
 			Bucket:    bucket.String(),
 			ExpiresAt: time.Now().Add(d).UTC().Format(time.RFC3339),
+			Capped:    capped,
+		}
+		text := fmt.Sprintf("Stored %q (bucket=%s, expires≈%s).", out.Key, out.Bucket, out.ExpiresAt)
+		if capped {
+			text += fmt.Sprintf(" Note: TTL clamped to the server cap (%s); re-remember before it expires to keep the fact alive.", d)
 		}
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{
-				Text: fmt.Sprintf("Stored %q (bucket=%s, expires≈%s).", out.Key, out.Bucket, out.ExpiresAt),
+				Text: text,
 			}},
 		}, out, nil
 	})

--- a/mcp/tool_remember_fact_test.go
+++ b/mcp/tool_remember_fact_test.go
@@ -88,3 +88,56 @@ func TestRememberFactDescription_IsProactive(t *testing.T) {
 		t.Errorf("rememberFactDescription should keep the recall-does-not-refresh invariant: %q", rememberFactDescription)
 	}
 }
+
+// TestRememberFact_TTLCappedToMaxTTL proves that with LANTERN_MCP_MAX_TTL
+// set, an over-cap bucket (durable=180d) is clamped to the cap before the
+// PutVertex write and the result reports capped=true (#537). This is the
+// honesty contract: a bucket the server would reject is silently shortened
+// to a value the server accepts, with the shortening surfaced.
+func TestRememberFact_TTLCappedToMaxTTL(t *testing.T) {
+	h := newTestHarnessWith(t, mustCappedResolver(t, "24h"))
+	res := h.call(t, "remember_fact", map[string]any{
+		"key":   "user.identity.role",
+		"value": "architect",
+		"ttl":   "durable", // nominal 180d, far beyond the 24h cap
+	})
+	if res.IsError {
+		t.Fatalf("IsError = true, text=%q", contentText(res))
+	}
+	if h.fake.lastPutTTL != 24*time.Hour {
+		t.Fatalf("lastPutTTL = %v, want clamped 24h", h.fake.lastPutTTL)
+	}
+	var out rememberFactOutput
+	structuredAs(t, res, &out)
+	if !out.Capped {
+		t.Fatalf("output Capped = false, want true; out=%+v", out)
+	}
+	if out.Bucket != "durable" {
+		t.Fatalf("output Bucket = %q, want durable (label preserved)", out.Bucket)
+	}
+	if !strings.Contains(contentText(res), "clamped") {
+		t.Fatalf("result text should mention the clamp; got %q", contentText(res))
+	}
+}
+
+// TestRememberFact_UnderCapNotClamped confirms a bucket at/below the cap is
+// written verbatim with capped=false even when a cap is configured.
+func TestRememberFact_UnderCapNotClamped(t *testing.T) {
+	h := newTestHarnessWith(t, mustCappedResolver(t, "24h"))
+	res := h.call(t, "remember_fact", map[string]any{
+		"key":   "session.cursor",
+		"value": "x",
+		"ttl":   "conversation", // 1h, well under the 24h cap
+	})
+	if res.IsError {
+		t.Fatalf("IsError = true, text=%q", contentText(res))
+	}
+	if h.fake.lastPutTTL != time.Hour {
+		t.Fatalf("lastPutTTL = %v, want 1h (unclamped)", h.fake.lastPutTTL)
+	}
+	var out rememberFactOutput
+	structuredAs(t, res, &out)
+	if out.Capped {
+		t.Fatalf("output Capped = true, want false for under-cap bucket; out=%+v", out)
+	}
+}

--- a/mcp/tool_remember_relation.go
+++ b/mcp/tool_remember_relation.go
@@ -22,6 +22,10 @@ type rememberRelationOutput struct {
 	Bucket    string  `json:"bucket"`
 	Weight    float32 `json:"weight"`
 	ExpiresAt string  `json:"expires_at"`
+	// Capped is true when the bucket's nominal horizon was clamped down to
+	// LANTERN_MCP_MAX_TTL before writing, so the caller knows the stored
+	// expiry is shorter than the bucket label implies.
+	Capped bool `json:"capped,omitempty"`
 }
 
 const rememberRelationDescription = "Add (or reinforce) a directed relation from one fact to another. Call this PROACTIVELY whenever you learn how two things connect — you do not need to be asked. IMPORTANT: writes are ADDITIVE — writing the same relation twice STRENGTHENS it, it does not idempotently overwrite. This is the Hebbian-style memory primitive: frequent short-TTL writes accumulate into strong associations, while weak relations decay, so reinforce associations you keep using. Use remember_fact to ensure the endpoint keys exist."
@@ -42,7 +46,7 @@ func registerRememberRelation(srv *mcp.Server, lc lanternClient, r *ttl.Resolver
 		if weight == 0 {
 			weight = 1
 		}
-		d := r.Resolve(bucket)
+		d, capped := r.ResolveCapped(bucket)
 		if err := lc.AddEdge(ctx, in.From, in.To, weight, d); err != nil {
 			return nil, rememberRelationOutput{}, mapSDKError("remember_relation", err)
 		}
@@ -52,10 +56,15 @@ func registerRememberRelation(srv *mcp.Server, lc lanternClient, r *ttl.Resolver
 			Bucket:    bucket.String(),
 			Weight:    weight,
 			ExpiresAt: time.Now().Add(d).UTC().Format(time.RFC3339),
+			Capped:    capped,
+		}
+		text := fmt.Sprintf("Added relation %q -> %q (+%.2f, bucket=%s, expires≈%s). Repeated calls strengthen.", in.From, in.To, weight, out.Bucket, out.ExpiresAt)
+		if capped {
+			text += fmt.Sprintf(" Note: TTL clamped to the server cap (%s); re-remember before it expires to keep the relation alive.", d)
 		}
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{
-				Text: fmt.Sprintf("Added relation %q -> %q (+%.2f, bucket=%s, expires≈%s). Repeated calls strengthen.", in.From, in.To, weight, out.Bucket, out.ExpiresAt),
+				Text: text,
 			}},
 		}, out, nil
 	})

--- a/mcp/tool_remember_relation_test.go
+++ b/mcp/tool_remember_relation_test.go
@@ -65,3 +65,28 @@ func TestRememberRelationDescription_IsProactive(t *testing.T) {
 		t.Errorf("rememberRelationDescription should keep the ADDITIVE-write contract: %q", rememberRelationDescription)
 	}
 }
+
+// TestRememberRelation_TTLCappedToMaxTTL mirrors the fact-side clamp (#537):
+// with LANTERN_MCP_MAX_TTL=24h, a durable relation is written with the
+// clamped TTL and reports capped=true instead of letting the server reject
+// the over-cap Expiration.
+func TestRememberRelation_TTLCappedToMaxTTL(t *testing.T) {
+	h := newTestHarnessWith(t, mustCappedResolver(t, "24h"))
+	res := h.call(t, "remember_relation", map[string]any{
+		"from": "user.identity.role", "to": "project.lantern", "ttl": "durable",
+	})
+	if res.IsError {
+		t.Fatalf("IsError = true, text=%q", contentText(res))
+	}
+	if h.fake.lastEdgeTTL != 24*time.Hour {
+		t.Fatalf("lastEdgeTTL = %v, want clamped 24h", h.fake.lastEdgeTTL)
+	}
+	var out rememberRelationOutput
+	structuredAs(t, res, &out)
+	if !out.Capped {
+		t.Fatalf("output Capped = false, want true; out=%+v", out)
+	}
+	if !strings.Contains(contentText(res), "clamped") {
+		t.Fatalf("result text should mention the clamp; got %q", contentText(res))
+	}
+}


### PR DESCRIPTION
## Summary

Closes #537.

The MCP advertises TTL buckets up to `durable` (180d). A Lantern server run
with a low `LANTERN_TOMBSTONE_TTL` (e.g. the HA-cluster compose uses `24h`)
**rejects** any write whose expiry exceeds that window with
`invalid_argument`, so `week`+ buckets fail hard on such nodes. The schema
promised horizons the server would refuse.

This adds an optional **`LANTERN_MCP_MAX_TTL`** cap:

- **Unset (default)** → no cap. The default server `LANTERN_TOMBSTONE_TTL`
  (`8760h`, 1 year) already exceeds the longest bucket, so every bucket is
  accepted unchanged. Fully back-compatible.
- **Set** (operator matches their server cap) → `ttl.Resolver.ResolveCapped`
  clamps each bucket's nominal horizon down to the cap **before** the write.
  When clamped, the tool result sets `"capped": true`, reports the shortened
  `expires_at`, and the text content reminds the caller to re-`remember_*`
  before expiry. The bucket label is preserved so intent stays legible.

Applied in both `remember_fact` and `remember_relation`. `Resolve` still
returns the nominal horizon (monotonic validation unchanged); only the new
`ResolveCapped` applies the cap.

## Changes

- `mcp/internal/ttl/ttl.go`: `maxTTL` field, `MaxTTLEnvVar`, `MaxTTL()`,
  `ResolveCapped()`, env parsing in `loadFrom`.
- `mcp/tool_remember_fact.go` / `mcp/tool_remember_relation.go`: use
  `ResolveCapped`, add `capped` output field + clamp note.
- `mcp/README.md`: documents the cap and the `capped` contract.
- Tests: `ttl` unit tests (no-cap default, over-cap clamp, exact-cap
  boundary, invalid/non-positive env) + handler tests (clamped + under-cap).

## Verification

- `gofmt -l` clean across all roots.
- `go vet` + `go test ./...` green in `mcp/`, `core/`, `pb/`, `sdks/go/`,
  `server/`, and root.