### PR TITLE
feat(mcp): add list_under projection mode (keys/snippet/full)

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -74,7 +74,7 @@ from the source so the LLM and the human reader see the same contract.
 | `remember_fact` | Store a fact in Lantern with a **required TTL bucket**. Writing the same key again overwrites the value and resets the TTL — that is the canonical way to refresh a fact since `recall_*` does NOT refresh. |
 | `recall_fact` | Look up a single fact by exact key. Returns `{found=false}` for missing keys (structured result, not a tool error). Does NOT refresh TTL. |
 | `forget` | Delete a fact by exact key. Idempotent. Edges incident to the key are NOT cascade-deleted; they decay on their own TTL. |
-| `list_under` | Enumerate facts whose key starts with the given prefix, in ascending key order. Defaults to 50 entries, max 500. |
+| `list_under` | Enumerate facts whose key starts with the given prefix, in ascending key order. Defaults to 50 entries, max 500. A `projection` (`keys` / `snippet` / `full`, default `full`) controls how much of each value is returned. |
 | `remember_relation` | Add (or reinforce) a directed relation from one fact to another. **Additive** — writing the same relation twice strengthens it; this is the Hebbian primitive. |
 | `recall_related` | Walk the graph from a seed key with `step`, `k`, and three orthogonal axes (`algorithm` ∈ `none` / `mst` / `spt`, `objective` ∈ `min` / `max`, `weighting` ∈ `raw` / `tfidf`; see #410). Returns related facts with cumulative weights. Does NOT refresh TTL. |
 
@@ -122,6 +122,22 @@ of surfacing an error. When a write is clamped, the tool result sets
 reminds you to re-`remember_*` before it expires. The bucket label is
 preserved so the intent is still legible. Unset (the default) means **no
 cap** — buckets resolve to their nominal horizons.
+
+### Value projections for `list_under`
+
+Surveying a namespace can dump large values into the model context when
+you only wanted to know *which* keys exist. `list_under` accepts a
+`projection` argument to control that:
+
+| Projection | Returns | Use when |
+|---|---|---|
+| `keys` | `key` + `expires_at` only (no value) | Surveying which keys exist — cheapest. |
+| `snippet` | `key` + a truncated ~120-char `snippet` of the value + `expires_at` | You want a preview without full payloads. |
+| `full` | `key` + the entire `value` + `expires_at` | You need the values (the **default**, preserving prior behaviour). |
+
+`full` remains the default for backward compatibility. Each entry always
+carries its `key`; `value` is set only for `full`, `snippet` only for
+`snippet`. The chosen mode is echoed back as `projection` on the result.
 
 ## Environment reference
 

--- a/mcp/internal/value/value.go
+++ b/mcp/internal/value/value.go
@@ -15,6 +15,7 @@ package value
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	client "github.com/anaregdesign/lantern/sdks/go"
@@ -119,4 +120,44 @@ func FromVertex(v *client.Vertex) any {
 		return d.String()
 	}
 	return nil
+}
+
+// SnippetMaxRunes bounds the truncated value preview returned by Snippet.
+// It keeps namespace surveys and search results legible without spilling
+// multi-KB values into the model context.
+const SnippetMaxRunes = 120
+
+// Snippet renders a vertex value as a compact, single-line preview for
+// namespace surveys and search results: structured values are JSON-encoded,
+// embedded newlines and tabs are collapsed to spaces, and the result is
+// truncated to SnippetMaxRunes runes with a trailing "…" when shortened. It
+// returns "" for a nil vertex or a nil value. Callers that need the full
+// value should use FromVertex instead.
+func Snippet(v *client.Vertex) string {
+	return snippetN(v, SnippetMaxRunes)
+}
+
+func snippetN(v *client.Vertex, max int) string {
+	val := FromVertex(v)
+	if val == nil {
+		return ""
+	}
+	var s string
+	switch x := val.(type) {
+	case string:
+		s = x
+	default:
+		if b, err := json.Marshal(x); err == nil {
+			s = string(b)
+		} else {
+			s = fmt.Sprintf("%v", x)
+		}
+	}
+	s = strings.NewReplacer("\n", " ", "\r", " ", "\t", " ").Replace(s)
+	if max > 0 {
+		if runes := []rune(s); len(runes) > max {
+			return string(runes[:max]) + "…"
+		}
+	}
+	return s
 }

--- a/mcp/internal/value/value_test.go
+++ b/mcp/internal/value/value_test.go
@@ -2,6 +2,7 @@ package value
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -144,6 +145,69 @@ func TestFromVertex_NilVariantIsNil(t *testing.T) {
 func TestFromVertex_NilPointerIsNil(t *testing.T) {
 	if got := FromVertex(nil); got != nil {
 		t.Fatalf("FromVertex(nil) = %v, want nil", got)
+	}
+}
+
+func TestSnippet_NilVertexAndNilValueAreEmpty(t *testing.T) {
+	if got := Snippet(nil); got != "" {
+		t.Fatalf("Snippet(nil) = %q, want empty", got)
+	}
+	v, err := mustVertex("k", nil)
+	if err != nil {
+		t.Fatalf("mustVertex: %v", err)
+	}
+	if got := Snippet(v); got != "" {
+		t.Fatalf("Snippet(nil-variant) = %q, want empty", got)
+	}
+}
+
+func TestSnippet_ShortStringVerbatim(t *testing.T) {
+	v, err := mustVertex("k", "concise value")
+	if err != nil {
+		t.Fatalf("mustVertex: %v", err)
+	}
+	if got := Snippet(v); got != "concise value" {
+		t.Fatalf("Snippet = %q, want %q", got, "concise value")
+	}
+}
+
+func TestSnippet_TruncatesLongStringToCap(t *testing.T) {
+	long := strings.Repeat("x", SnippetMaxRunes+50)
+	v, err := mustVertex("k", long)
+	if err != nil {
+		t.Fatalf("mustVertex: %v", err)
+	}
+	got := Snippet(v)
+	wantRunes := SnippetMaxRunes + 1 // cap runes plus the trailing ellipsis
+	if n := len([]rune(got)); n != wantRunes {
+		t.Fatalf("Snippet length = %d runes, want %d", n, wantRunes)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("truncated Snippet should end with ellipsis: %q", got)
+	}
+}
+
+func TestSnippet_StructuredValueJSONEncoded(t *testing.T) {
+	encoded, err := ToSDK(map[string]any{"name": "lantern"})
+	if err != nil {
+		t.Fatalf("ToSDK: %v", err)
+	}
+	v, err := mustVertex("k", encoded)
+	if err != nil {
+		t.Fatalf("mustVertex: %v", err)
+	}
+	if got := Snippet(v); got != `{"name":"lantern"}` {
+		t.Fatalf("Snippet = %q, want %q", got, `{"name":"lantern"}`)
+	}
+}
+
+func TestSnippet_CollapsesNewlinesToSpaces(t *testing.T) {
+	v, err := mustVertex("k", "line one\nline two\ttabbed")
+	if err != nil {
+		t.Fatalf("mustVertex: %v", err)
+	}
+	if got := Snippet(v); got != "line one line two tabbed" {
+		t.Fatalf("Snippet = %q, want collapsed single line", got)
 	}
 }
 

--- a/mcp/tool_list_under.go
+++ b/mcp/tool_list_under.go
@@ -19,26 +19,51 @@ const listUnderDefaultLimit uint32 = 50
 // further clamps this against its own configured maximum.
 const listUnderMaxLimit uint32 = 500
 
+// Projection modes select how much of each value list_under returns.
+// "full" is the default for backward compatibility with callers written
+// before the projection field existed.
+const (
+	projectionKeys    = "keys"
+	projectionSnippet = "snippet"
+	projectionFull    = "full"
+)
+
+// parseProjection validates the projection mode, defaulting empty to
+// "full" so existing callers keep their original full-value behaviour.
+func parseProjection(p string) (string, error) {
+	switch p {
+	case "":
+		return projectionFull, nil
+	case projectionKeys, projectionSnippet, projectionFull:
+		return p, nil
+	default:
+		return "", fmt.Errorf("invalid projection %q (want keys, snippet, or full)", p)
+	}
+}
+
 type listUnderInput struct {
-	Prefix string `json:"prefix" jsonschema:"Key prefix to enumerate (e.g. user.preferences. — note the trailing dot is part of the prefix). Empty string would scan the entire keyspace and is rejected; pick a meaningful namespace."`
-	Limit  uint32 `json:"limit,omitempty" jsonschema:"Maximum number of facts to return in this call (default 50, capped at 500). v1 does not expose a pagination cursor; if the response is full and you need more, narrow the prefix."`
+	Prefix     string `json:"prefix" jsonschema:"Key prefix to enumerate (e.g. user.preferences. — note the trailing dot is part of the prefix). Empty string would scan the entire keyspace and is rejected; pick a meaningful namespace."`
+	Limit      uint32 `json:"limit,omitempty" jsonschema:"Maximum number of facts to return in this call (default 50, capped at 500). v1 does not expose a pagination cursor; if the response is full and you need more, narrow the prefix."`
+	Projection string `json:"projection,omitempty" jsonschema:"How much of each fact to return: 'keys' (key + expires_at only — cheapest, use this to survey which keys exist without reading values), 'snippet' (adds a truncated ~120-char preview of each value), or 'full' (the entire value; the default). Prefer 'keys' or 'snippet' when you only need to know what exists, to avoid flooding the context with large values."`
 }
 
 type listUnderEntry struct {
 	Key       string `json:"key"`
 	Value     any    `json:"value,omitempty"`
+	Snippet   string `json:"snippet,omitempty"`
 	ExpiresAt string `json:"expires_at,omitempty"`
 }
 
 type listUnderOutput struct {
 	Prefix     string           `json:"prefix"`
+	Projection string           `json:"projection"`
 	Count      int              `json:"count"`
 	HasMore    bool             `json:"has_more"`
 	Entries    []listUnderEntry `json:"entries"`
 	Suggestion string           `json:"suggestion,omitempty"`
 }
 
-const listUnderDescription = "Enumerate facts whose key starts with the given prefix, in ascending key order. Call this PROACTIVELY to survey a namespace (e.g. user. or project.) before answering, so you recall everything you know about that topic. Defaults to 50 entries, max 500. If has_more=true the result is truncated; narrow the prefix or follow the suggestion. Does NOT refresh TTL for the listed facts."
+const listUnderDescription = "Enumerate facts whose key starts with the given prefix, in ascending key order. Call this PROACTIVELY to survey a namespace (e.g. user. or project.) before answering, so you recall everything you know about that topic. Defaults to 50 entries, max 500. Use projection=keys to list just the key names cheaply, or projection=snippet for short value previews, when you don't need full values. If has_more=true the result is truncated; narrow the prefix or follow the suggestion. Does NOT refresh TTL for the listed facts."
 
 func registerListUnder(srv *mcp.Server, lc lanternClient) {
 	mcp.AddTool(srv, &mcp.Tool{
@@ -47,6 +72,10 @@ func registerListUnder(srv *mcp.Server, lc lanternClient) {
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in listUnderInput) (*mcp.CallToolResult, listUnderOutput, error) {
 		if in.Prefix == "" {
 			return nil, listUnderOutput{}, fmt.Errorf("list_under: prefix must not be empty")
+		}
+		projection, err := parseProjection(in.Projection)
+		if err != nil {
+			return nil, listUnderOutput{}, fmt.Errorf("list_under: %w", err)
 		}
 		limit := in.Limit
 		if limit == 0 {
@@ -73,22 +102,31 @@ func registerListUnder(srv *mcp.Server, lc lanternClient) {
 			if v == nil {
 				continue
 			}
-			e := listUnderEntry{Key: v.GetKey(), Value: value.FromVertex(v)}
+			e := listUnderEntry{Key: v.GetKey()}
+			switch projection {
+			case projectionFull:
+				e.Value = value.FromVertex(v)
+			case projectionSnippet:
+				e.Snippet = value.Snippet(v)
+			case projectionKeys:
+				// key + expires_at only; no value payload.
+			}
 			if exp := client.VertexExpiration(v); !exp.IsZero() {
 				e.ExpiresAt = exp.UTC().Format("2006-01-02T15:04:05Z07:00")
 			}
 			entries = append(entries, e)
 		}
 		out := listUnderOutput{
-			Prefix:  in.Prefix,
-			Count:   len(entries),
-			HasMore: hasMore,
-			Entries: entries,
+			Prefix:     in.Prefix,
+			Projection: projection,
+			Count:      len(entries),
+			HasMore:    hasMore,
+			Entries:    entries,
 		}
 		if hasMore {
 			out.Suggestion = fmt.Sprintf("More than %d facts share this prefix. Narrow the prefix (e.g. %q + a sub-namespace) or raise limit (max %d).", limit, in.Prefix, listUnderMaxLimit)
 		}
-		text := fmt.Sprintf("Listed %d facts under %q (has_more=%t).", out.Count, in.Prefix, out.HasMore)
+		text := fmt.Sprintf("Listed %d facts under %q (projection=%s, has_more=%t).", out.Count, in.Prefix, out.Projection, out.HasMore)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: text}},
 		}, out, nil

--- a/mcp/tool_list_under_test.go
+++ b/mcp/tool_list_under_test.go
@@ -62,6 +62,93 @@ func TestListUnder_RejectsEmptyPrefix(t *testing.T) {
 	h.callExpectError(t, "list_under", map[string]any{"prefix": ""})
 }
 
+// fakeListVertices returns a fixed set of string vertices for projection
+// tests: one short value and one long value so snippet truncation is
+// observable.
+func fakeListVertices() []*client.Vertex {
+	return []*client.Vertex{
+		{Key: "topic.a", Value: &pb.Vertex_String_{String_: "short"}},
+		{Key: "topic.b", Value: &pb.Vertex_String_{String_: strings.Repeat("y", 300)}},
+	}
+}
+
+func TestListUnder_DefaultProjectionIsFull(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.scanVerticesFn = func(_ context.Context, _ string, _ ...client.ScanOption) ([]*client.Vertex, []byte, error) {
+		return fakeListVertices(), nil, nil
+	}
+	res := h.call(t, "list_under", map[string]any{"prefix": "topic."})
+	var out listUnderOutput
+	structuredAs(t, res, &out)
+	if out.Projection != "full" {
+		t.Fatalf("Projection = %q, want full (back-compat default)", out.Projection)
+	}
+	if len(out.Entries) != 2 {
+		t.Fatalf("Count = %d, want 2", len(out.Entries))
+	}
+	if out.Entries[0].Value != "short" {
+		t.Fatalf("full projection should return Value; got %+v", out.Entries[0])
+	}
+	if out.Entries[0].Snippet != "" {
+		t.Fatalf("full projection should not set Snippet; got %q", out.Entries[0].Snippet)
+	}
+}
+
+func TestListUnder_KeysProjectionOmitsValues(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.scanVerticesFn = func(_ context.Context, _ string, _ ...client.ScanOption) ([]*client.Vertex, []byte, error) {
+		return fakeListVertices(), nil, nil
+	}
+	res := h.call(t, "list_under", map[string]any{"prefix": "topic.", "projection": "keys"})
+	var out listUnderOutput
+	structuredAs(t, res, &out)
+	if out.Projection != "keys" {
+		t.Fatalf("Projection = %q, want keys", out.Projection)
+	}
+	for _, e := range out.Entries {
+		if e.Key == "" {
+			t.Fatalf("keys projection must still return Key: %+v", e)
+		}
+		if e.Value != nil || e.Snippet != "" {
+			t.Fatalf("keys projection must omit Value and Snippet: %+v", e)
+		}
+	}
+}
+
+func TestListUnder_SnippetProjectionTruncates(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.scanVerticesFn = func(_ context.Context, _ string, _ ...client.ScanOption) ([]*client.Vertex, []byte, error) {
+		return fakeListVertices(), nil, nil
+	}
+	res := h.call(t, "list_under", map[string]any{"prefix": "topic.", "projection": "snippet"})
+	var out listUnderOutput
+	structuredAs(t, res, &out)
+	if out.Projection != "snippet" {
+		t.Fatalf("Projection = %q, want snippet", out.Projection)
+	}
+	if out.Entries[0].Value != nil {
+		t.Fatalf("snippet projection must omit Value: %+v", out.Entries[0])
+	}
+	if out.Entries[0].Snippet != "short" {
+		t.Fatalf("short value should pass through: %q", out.Entries[0].Snippet)
+	}
+	long := out.Entries[1].Snippet
+	if !strings.HasSuffix(long, "…") {
+		t.Fatalf("long value should be truncated with ellipsis: %q", long)
+	}
+	if n := len([]rune(long)); n > 121 {
+		t.Fatalf("snippet length = %d runes, want <= 121", n)
+	}
+}
+
+func TestListUnder_RejectsUnknownProjection(t *testing.T) {
+	h := newTestHarness(t)
+	res := h.callExpectError(t, "list_under", map[string]any{"prefix": "topic.", "projection": "bogus"})
+	if !strings.Contains(contentText(res), "projection") {
+		t.Fatalf("error should mention projection: %q", contentText(res))
+	}
+}
+
 // TestListUnderDescription_IsProactive guards the survey-before-answering
 // framing while keeping the no-refresh invariant (#528).
 func TestListUnderDescription_IsProactive(t *testing.T) {


### PR DESCRIPTION
## Problem

`list_under` always returned the full vertex value for every entry, so
surveying a namespace just to learn *which keys exist* could dump 13–14KB
into the model context and spill to a file (#541).

## Change

Add a `projection` argument to `list_under`:

| Projection | Returns |
|---|---|
| `keys` | `key` + `expires_at` only (no value) |
| `snippet` | `key` + a truncated ~120-char `snippet` + `expires_at` |
| `full` | `key` + the entire `value` + `expires_at` (**default**) |

`full` stays the default, so existing callers are unaffected — the
back-compat default is called out per the AC. The chosen mode is echoed
back as `projection` on the result. Unknown projections are rejected with
an actionable error (same runtime-validation idiom as the TTL bucket enum).

A reusable `value.Snippet` helper does the truncation (JSON-encodes
structured values, collapses newlines/tabs to spaces, truncates to 120
runes with a trailing `…`). It is factored into `mcp/internal/value` so the
forthcoming `search_facts` (#538) and `list_namespaces` (#550) tools can
share the same snippet shape.

## Changes

- `mcp/internal/value/value.go`: `Snippet` + `SnippetMaxRunes`.
- `mcp/tool_list_under.go`: `projection` input, `Snippet` entry field,
  `Projection` output field, `parseProjection` (default `full`).
- `mcp/README.md`: documents the three projection modes.
- Tests: `value.Snippet` unit tests (nil, verbatim, truncation, structured,
  newline-collapse) + `list_under` handler tests (default full, keys omits
  values, snippet truncates, unknown projection rejected).

## Verification

- `gofmt -l` clean across all roots.
- `go vet` + `go test ./...` green in `mcp/`, `core/`, `pb/`, `sdks/go/`,
  `server/`, and root.

Closes #541
