### PR TITLE
feat(mcp): add search_facts for approximate recall over keys+values

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -73,6 +73,7 @@ from the source so the LLM and the human reader see the same contract.
 |---|---|
 | `remember_fact` | Store a fact in Lantern with a **required TTL bucket**. Writing the same key again overwrites the value and resets the TTL — that is the canonical way to refresh a fact since `recall_*` does NOT refresh. |
 | `recall_fact` | Look up a single fact by exact key. Returns `{found=false}` for missing keys (structured result, not a tool error). Does NOT refresh TTL. |
+| `search_facts` | Find facts by a case-insensitive substring matched against both keys **and** values — the approximate counterpart to `recall_fact` for when you recall a topic but not the exact key. Returns compact `{key, snippet, expires_at}` previews (same shape as `list_under` `projection=snippet`); pass a `prefix` to scope and speed the scan. Does NOT refresh TTL. |
 | `forget` | Delete a fact by exact key. Idempotent. Edges incident to the key are NOT cascade-deleted; they decay on their own TTL. |
 | `list_under` | Enumerate facts whose key starts with the given prefix, in ascending key order. Defaults to 50 entries, max 500. A `projection` (`keys` / `snippet` / `full`, default `full`) controls how much of each value is returned. |
 | `remember_relation` | Add (or reinforce) a directed relation from one fact to another. **Additive** — writing the same relation twice strengthens it; this is the Hebbian primitive. |
@@ -138,6 +139,23 @@ you only wanted to know *which* keys exist. `list_under` accepts a
 `full` remains the default for backward compatibility. Each entry always
 carries its `key`; `value` is set only for `full`, `snippet` only for
 `snippet`. The chosen mode is echoed back as `projection` on the result.
+
+### Approximate recall with `search_facts`
+
+`recall_fact` needs the **exact** key. When you remember the *topic* of a
+fact but not where you filed it, `search_facts` does a case-insensitive
+substring match over both keys and values and returns the same compact
+`{key, snippet, expires_at}` rows as `list_under` `projection=snippet`. Read
+a full value by passing a returned key back to `recall_fact`.
+
+v1 is an unindexed scan-and-filter (no server change), so:
+
+- Pass a `prefix` whenever you know the rough namespace — it scopes the scan
+  to that subtree, making the search both faster and more precise.
+- A single call scans at most `10000` vertices before stopping. If that
+  ceiling is reached (or the `limit`, default 20 / max 100, is filled),
+  `truncated` is `true` and `suggestion` tells you to narrow the prefix or
+  raise the limit. `scanned` reports how many vertices were examined.
 
 ## Environment reference
 

--- a/mcp/internal/value/value.go
+++ b/mcp/internal/value/value.go
@@ -127,17 +127,13 @@ func FromVertex(v *client.Vertex) any {
 // multi-KB values into the model context.
 const SnippetMaxRunes = 120
 
-// Snippet renders a vertex value as a compact, single-line preview for
-// namespace surveys and search results: structured values are JSON-encoded,
-// embedded newlines and tabs are collapsed to spaces, and the result is
-// truncated to SnippetMaxRunes runes with a trailing "…" when shortened. It
-// returns "" for a nil vertex or a nil value. Callers that need the full
-// value should use FromVertex instead.
-func Snippet(v *client.Vertex) string {
-	return snippetN(v, SnippetMaxRunes)
-}
-
-func snippetN(v *client.Vertex, max int) string {
+// Text renders a vertex value as a single-line string with embedded
+// newlines, carriage returns, and tabs collapsed to single spaces, and with
+// NO length limit. Structured values are JSON-encoded. It returns "" for a
+// nil vertex or a nil value. Text is the full-length searchable form used by
+// substring search (search_facts); Snippet is the truncated preview built on
+// top of it.
+func Text(v *client.Vertex) string {
 	val := FromVertex(v)
 	if val == nil {
 		return ""
@@ -153,11 +149,19 @@ func snippetN(v *client.Vertex, max int) string {
 			s = fmt.Sprintf("%v", x)
 		}
 	}
-	s = strings.NewReplacer("\n", " ", "\r", " ", "\t", " ").Replace(s)
-	if max > 0 {
-		if runes := []rune(s); len(runes) > max {
-			return string(runes[:max]) + "…"
-		}
+	return strings.NewReplacer("\n", " ", "\r", " ", "\t", " ").Replace(s)
+}
+
+// Snippet renders a vertex value as a compact, single-line preview for
+// namespace surveys and search results: structured values are JSON-encoded,
+// embedded newlines and tabs are collapsed to spaces, and the result is
+// truncated to SnippetMaxRunes runes with a trailing "…" when shortened. It
+// returns "" for a nil vertex or a nil value. Callers that need the full
+// value should use FromVertex instead.
+func Snippet(v *client.Vertex) string {
+	s := Text(v)
+	if runes := []rune(s); len(runes) > SnippetMaxRunes {
+		return string(runes[:SnippetMaxRunes]) + "…"
 	}
 	return s
 }

--- a/mcp/internal/value/value_test.go
+++ b/mcp/internal/value/value_test.go
@@ -211,6 +211,58 @@ func TestSnippet_CollapsesNewlinesToSpaces(t *testing.T) {
 	}
 }
 
+func TestText_NilVertexAndNilValueAreEmpty(t *testing.T) {
+	if got := Text(nil); got != "" {
+		t.Fatalf("Text(nil) = %q, want empty", got)
+	}
+	v, err := mustVertex("k", nil)
+	if err != nil {
+		t.Fatalf("mustVertex: %v", err)
+	}
+	if got := Text(v); got != "" {
+		t.Fatalf("Text(nil-variant) = %q, want empty", got)
+	}
+}
+
+func TestText_DoesNotTruncateLongValue(t *testing.T) {
+	long := strings.Repeat("z", SnippetMaxRunes+200)
+	v, err := mustVertex("k", long)
+	if err != nil {
+		t.Fatalf("mustVertex: %v", err)
+	}
+	got := Text(v)
+	if got != long {
+		t.Fatalf("Text truncated or altered the value: len=%d want=%d", len([]rune(got)), len([]rune(long)))
+	}
+	if strings.HasSuffix(got, "…") {
+		t.Fatalf("Text must not append an ellipsis: %q", got)
+	}
+}
+
+func TestText_CollapsesNewlinesToSpaces(t *testing.T) {
+	v, err := mustVertex("k", "build\n2026\trelease")
+	if err != nil {
+		t.Fatalf("mustVertex: %v", err)
+	}
+	if got := Text(v); got != "build 2026 release" {
+		t.Fatalf("Text = %q, want collapsed single line", got)
+	}
+}
+
+func TestText_StructuredValueJSONEncoded(t *testing.T) {
+	encoded, err := ToSDK(map[string]any{"name": "lantern"})
+	if err != nil {
+		t.Fatalf("ToSDK: %v", err)
+	}
+	v, err := mustVertex("k", encoded)
+	if err != nil {
+		t.Fatalf("mustVertex: %v", err)
+	}
+	if got := Text(v); got != `{"name":"lantern"}` {
+		t.Fatalf("Text = %q, want %q", got, `{"name":"lantern"}`)
+	}
+}
+
 // mustVertex builds a *client.Vertex (= *pb.Vertex) whose oneof variant
 // matches v's concrete type. The variant matrix replicates the SDK's
 // internal nativeVertex.asVertex path; we only need enough cases to cover

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -260,6 +260,7 @@ func newServer(lc lanternClient, resolver *ttl.Resolver, logger *slog.Logger) *m
 
 	registerRememberFact(srv, lc, resolver)
 	registerRecallFact(srv, lc)
+	registerSearchFacts(srv, lc)
 	registerForget(srv, lc)
 	registerListUnder(srv, lc)
 	registerRememberRelation(srv, lc, resolver)
@@ -283,7 +284,7 @@ func newServer(lc lanternClient, resolver *ttl.Resolver, logger *slog.Logger) *m
 // Changing this text is an LLM-behavior-affecting change; treat it the
 // way you would a prompt update and call it out in release notes.
 const serverInstructions = "Lantern is your ambient, decaying graph memory. Use it proactively — you do not need to be asked. Run this loop every turn: " +
-	"(1) RECALL FIRST: before answering anything that could depend on remembered context, call recall_fact (exact key), recall_related (walk from a seed), or list_under (enumerate a namespace) to pull in what you already know. " +
+	"(1) RECALL FIRST: before answering anything that could depend on remembered context, call recall_fact (exact key), search_facts (substring over keys+values when you recall the topic but not the exact key), recall_related (walk from a seed), or list_under (enumerate a namespace) to pull in what you already know. " +
 	"(2) ANSWER using what you recalled. " +
 	"(3) CAPTURE AFTER: once the exchange settles, write any new durable facts with remember_fact and any new associations with remember_relation — preferences, decisions, identities, project facts, and how they connect. Capturing is the default, not the exception. " +
 	"Two invariants govern every write: (a) there is no \"forever\" — each write picks a TTL bucket from {seconds, transient, turn, conversation, task, workday, day, week, sprint, month, quarter, durable}; (b) recall does NOT refresh TTL, so to keep a fact alive you must re-remember it when you reference it. Choosing a bucket: ask \"when will this stop being true?\" and \"how bad is it if this lingers past then?\" and pick the SHORTER one. Relations are additive — writing the same relation twice strengthens it, so reinforce associations you keep using. " +

--- a/mcp/tool_search_facts.go
+++ b/mcp/tool_search_facts.go
@@ -1,0 +1,147 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/anaregdesign/lantern/mcp/internal/value"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// searchFactsDefaultLimit is the number of matches returned when the caller
+// omits limit. It is small on purpose: search exists to relocate a fact whose
+// exact key the agent has forgotten, not to bulk-export a namespace.
+const searchFactsDefaultLimit uint32 = 20
+
+// searchFactsMaxLimit caps the per-call match count so a broad query cannot
+// flood the model context.
+const searchFactsMaxLimit uint32 = 100
+
+// searchFactsScanBatch is the per-page size forwarded to ScanVertices while
+// paginating. Larger pages mean fewer round trips; this is independent of how
+// many matches we ultimately return.
+const searchFactsScanBatch uint32 = 500
+
+// searchFactsMaxScan bounds how many vertices a single search may pull from
+// the server before giving up. v1 search is an unindexed scan-and-filter, so
+// without this ceiling a miss on a large keyspace would walk every vertex.
+// When the ceiling is hit before enough matches accumulate, the result is
+// marked truncated and the caller is told to narrow the prefix.
+const searchFactsMaxScan = 10_000
+
+type searchFactsInput struct {
+	Query  string `json:"query" jsonschema:"Case-insensitive substring to find. It is matched against BOTH each fact's key AND its value, so you can search by topic words you remember even when you have forgotten the exact key. Must not be empty."`
+	Prefix string `json:"prefix,omitempty" jsonschema:"Optional key prefix to restrict the search to one namespace (e.g. user. or project.lantern.). Empty (the default) searches the entire keyspace. Supplying a prefix when you know the rough namespace makes the search both faster and more precise."`
+	Limit  uint32 `json:"limit,omitempty" jsonschema:"Maximum number of matching facts to return (default 20, capped at 100). Results are compact previews, not full values."`
+}
+
+// searchFactsMatch is one hit. It mirrors the {key, snippet, expires_at}
+// shape that list_under returns under projection=snippet so callers can treat
+// the two surfaces interchangeably. To read a match's full value, call
+// recall_fact with its key.
+type searchFactsMatch struct {
+	Key       string `json:"key"`
+	Snippet   string `json:"snippet,omitempty"`
+	ExpiresAt string `json:"expires_at,omitempty"`
+}
+
+type searchFactsOutput struct {
+	Query      string             `json:"query"`
+	Count      int                `json:"count"`
+	Matches    []searchFactsMatch `json:"matches"`
+	Scanned    int                `json:"scanned"`
+	Truncated  bool               `json:"truncated"`
+	Suggestion string             `json:"suggestion,omitempty"`
+}
+
+const searchFactsDescription = "Find facts by a case-insensitive substring matched against both keys AND values. Use this when you remember the TOPIC of a stored fact but not its exact key — it is the approximate counterpart to recall_fact (exact key) and complements list_under (prefix scan). Returns compact {key, snippet, expires_at} previews, not full values; call recall_fact with a returned key to read the whole value. Pass a prefix to scope the search to a namespace and keep it fast. If truncated=true the scan hit its budget before finishing — narrow with a prefix. Does NOT refresh TTL for matched facts."
+
+func registerSearchFacts(srv *mcp.Server, lc lanternClient) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "search_facts",
+		Description: searchFactsDescription,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in searchFactsInput) (*mcp.CallToolResult, searchFactsOutput, error) {
+		if in.Query == "" {
+			return nil, searchFactsOutput{}, fmt.Errorf("search_facts: query must not be empty")
+		}
+		limit := in.Limit
+		if limit == 0 {
+			limit = searchFactsDefaultLimit
+		}
+		if limit > searchFactsMaxLimit {
+			limit = searchFactsMaxLimit
+		}
+		needle := strings.ToLower(in.Query)
+
+		matches := make([]searchFactsMatch, 0, limit)
+		scanned := 0
+		truncated := false
+		var cursor []byte
+
+	scan:
+		for {
+			verts, next, err := lc.ScanVertices(ctx, in.Prefix,
+				client.WithScanLimit(searchFactsScanBatch),
+				client.WithScanCursor(cursor))
+			if err != nil {
+				return nil, searchFactsOutput{}, mapSDKError("search_facts", err)
+			}
+			for _, v := range verts {
+				if v == nil {
+					continue
+				}
+				scanned++
+				if factMatchesQuery(v, needle) {
+					m := searchFactsMatch{Key: v.GetKey(), Snippet: value.Snippet(v)}
+					if exp := client.VertexExpiration(v); !exp.IsZero() {
+						m.ExpiresAt = exp.UTC().Format("2006-01-02T15:04:05Z07:00")
+					}
+					matches = append(matches, m)
+					if uint32(len(matches)) >= limit {
+						truncated = true
+						break scan
+					}
+				}
+				if scanned >= searchFactsMaxScan {
+					truncated = true
+					break scan
+				}
+			}
+			if len(next) == 0 {
+				break
+			}
+			cursor = next
+		}
+
+		out := searchFactsOutput{
+			Query:     in.Query,
+			Count:     len(matches),
+			Matches:   matches,
+			Scanned:   scanned,
+			Truncated: truncated,
+		}
+		if truncated {
+			if uint32(len(matches)) >= limit {
+				out.Suggestion = fmt.Sprintf("Returned the first %d matches; more may exist. Raise limit (max %d) or pass a prefix to narrow the search.", limit, searchFactsMaxLimit)
+			} else {
+				out.Suggestion = fmt.Sprintf("Stopped after scanning %d facts without filling the result. Pass a prefix to scope the search to a namespace.", scanned)
+			}
+		}
+		text := fmt.Sprintf("Found %d fact(s) matching %q (scanned=%d, truncated=%t).", out.Count, in.Query, out.Scanned, out.Truncated)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: text}},
+		}, out, nil
+	})
+}
+
+// factMatchesQuery reports whether the lower-cased needle occurs in the
+// vertex key or in its full single-line value text. value.Text (not Snippet)
+// is used so a match in a long value past the preview cap is not missed.
+func factMatchesQuery(v *client.Vertex, lowerNeedle string) bool {
+	if strings.Contains(strings.ToLower(v.GetKey()), lowerNeedle) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(value.Text(v)), lowerNeedle)
+}

--- a/mcp/tool_search_facts_test.go
+++ b/mcp/tool_search_facts_test.go
@@ -1,0 +1,196 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+// vstr builds a string-valued vertex for search tests.
+func vstr(key, val string) *client.Vertex {
+	return &pb.Vertex{Key: key, Value: &pb.Vertex_String_{String_: val}}
+}
+
+// singlePage makes a scanVerticesFn that returns all of verts in one page
+// (empty next cursor), regardless of prefix or options.
+func singlePage(verts ...*client.Vertex) func(context.Context, string, ...client.ScanOption) ([]*client.Vertex, []byte, error) {
+	return func(_ context.Context, _ string, _ ...client.ScanOption) ([]*client.Vertex, []byte, error) {
+		return verts, nil, nil
+	}
+}
+
+func TestSearchFacts_MatchesValueAcrossUnrelatedKeyPrefixes(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.scanVerticesFn = singlePage(
+		vstr("project.lantern.milestone", "ship build 2026 in June"),
+		vstr("user.identity.role", "principal engineer"),
+		vstr("session.scratch", "unrelated note"),
+	)
+	res := h.call(t, "search_facts", map[string]any{"query": "build 2026"})
+	if res.IsError {
+		t.Fatalf("IsError = true: %s", contentText(res))
+	}
+	var out searchFactsOutput
+	structuredAs(t, res, &out)
+	if out.Count != 1 {
+		t.Fatalf("Count = %d, want 1 (matches=%+v)", out.Count, out.Matches)
+	}
+	if out.Matches[0].Key != "project.lantern.milestone" {
+		t.Fatalf("matched wrong key: %q", out.Matches[0].Key)
+	}
+}
+
+func TestSearchFacts_MatchesKey(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.scanVerticesFn = singlePage(
+		vstr("user.preferences.tone", "concise"),
+		vstr("user.identity.role", "engineer"),
+	)
+	// "preferences" appears only in a key, not in any value.
+	res := h.call(t, "search_facts", map[string]any{"query": "preferences"})
+	var out searchFactsOutput
+	structuredAs(t, res, &out)
+	if out.Count != 1 || out.Matches[0].Key != "user.preferences.tone" {
+		t.Fatalf("key match failed: %+v", out.Matches)
+	}
+}
+
+func TestSearchFacts_IsCaseInsensitive(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.scanVerticesFn = singlePage(vstr("k", "The Build 2026 Plan"))
+	res := h.call(t, "search_facts", map[string]any{"query": "build 2026"})
+	var out searchFactsOutput
+	structuredAs(t, res, &out)
+	if out.Count != 1 {
+		t.Fatalf("case-insensitive match failed: %+v", out)
+	}
+}
+
+func TestSearchFacts_ResultsAreCompactSnippets(t *testing.T) {
+	h := newTestHarness(t)
+	long := "match " + strings.Repeat("z", 400)
+	h.fake.scanVerticesFn = singlePage(vstr("k", long))
+	res := h.call(t, "search_facts", map[string]any{"query": "match"})
+	var out searchFactsOutput
+	structuredAs(t, res, &out)
+	if out.Count != 1 {
+		t.Fatalf("Count = %d, want 1", out.Count)
+	}
+	snip := out.Matches[0].Snippet
+	if !strings.HasSuffix(snip, "…") {
+		t.Fatalf("long value should be returned as a truncated snippet: %q", snip)
+	}
+	if n := len([]rune(snip)); n > 121 {
+		t.Fatalf("snippet length = %d runes, want <= 121 (no full-value dump)", n)
+	}
+}
+
+func TestSearchFacts_NoMatchesIsEmptyNotError(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.scanVerticesFn = singlePage(vstr("k", "nothing relevant here"))
+	res := h.call(t, "search_facts", map[string]any{"query": "absent"})
+	if res.IsError {
+		t.Fatalf("no-match should not be an error: %s", contentText(res))
+	}
+	var out searchFactsOutput
+	structuredAs(t, res, &out)
+	if out.Count != 0 || len(out.Matches) != 0 {
+		t.Fatalf("expected zero matches, got %+v", out)
+	}
+}
+
+func TestSearchFacts_RejectsEmptyQuery(t *testing.T) {
+	h := newTestHarness(t)
+	h.callExpectError(t, "search_facts", map[string]any{"query": ""})
+}
+
+func TestSearchFacts_ForwardsPrefixToScan(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.scanVerticesFn = singlePage(vstr("project.lantern.x", "build 2026"))
+	h.call(t, "search_facts", map[string]any{"query": "build", "prefix": "project.lantern."})
+	if h.fake.lastScanPrefix != "project.lantern." {
+		t.Fatalf("prefix not forwarded to ScanVertices: %q", h.fake.lastScanPrefix)
+	}
+}
+
+func TestSearchFacts_TruncatesAtLimit(t *testing.T) {
+	h := newTestHarness(t)
+	verts := make([]*client.Vertex, 0, 5)
+	for i := 0; i < 5; i++ {
+		verts = append(verts, vstr("k", "build 2026"))
+	}
+	h.fake.scanVerticesFn = singlePage(verts...)
+	res := h.call(t, "search_facts", map[string]any{"query": "build", "limit": 2})
+	var out searchFactsOutput
+	structuredAs(t, res, &out)
+	if out.Count != 2 {
+		t.Fatalf("Count = %d, want 2 (capped at limit)", out.Count)
+	}
+	if !out.Truncated {
+		t.Fatalf("Truncated = false; want true when limit is hit")
+	}
+	if out.Suggestion == "" {
+		t.Fatalf("Suggestion should be set when truncated")
+	}
+}
+
+func TestSearchFacts_FollowsCursorPagination(t *testing.T) {
+	h := newTestHarness(t)
+	calls := 0
+	h.fake.scanVerticesFn = func(_ context.Context, _ string, _ ...client.ScanOption) ([]*client.Vertex, []byte, error) {
+		calls++
+		if calls == 1 {
+			return []*client.Vertex{vstr("a", "no")}, []byte("cursor-1"), nil
+		}
+		return []*client.Vertex{vstr("b", "build 2026")}, nil, nil
+	}
+	res := h.call(t, "search_facts", map[string]any{"query": "build"})
+	var out searchFactsOutput
+	structuredAs(t, res, &out)
+	if calls != 2 {
+		t.Fatalf("expected 2 scan pages, got %d", calls)
+	}
+	if out.Count != 1 || out.Matches[0].Key != "b" {
+		t.Fatalf("match on second page not found: %+v", out)
+	}
+	if out.Scanned != 2 {
+		t.Fatalf("Scanned = %d, want 2 across both pages", out.Scanned)
+	}
+}
+
+func TestSearchFacts_StopsAtScanBudget(t *testing.T) {
+	h := newTestHarness(t)
+	// One page larger than the scan budget, none matching, empty cursor.
+	verts := make([]*client.Vertex, 0, searchFactsMaxScan+1)
+	for i := 0; i < searchFactsMaxScan+1; i++ {
+		verts = append(verts, vstr("k", "no match here"))
+	}
+	h.fake.scanVerticesFn = singlePage(verts...)
+	res := h.call(t, "search_facts", map[string]any{"query": "needle"})
+	var out searchFactsOutput
+	structuredAs(t, res, &out)
+	if !out.Truncated {
+		t.Fatalf("Truncated = false; want true when the scan budget is hit")
+	}
+	if out.Scanned != searchFactsMaxScan {
+		t.Fatalf("Scanned = %d, want %d (budget ceiling)", out.Scanned, searchFactsMaxScan)
+	}
+	if out.Suggestion == "" {
+		t.Fatalf("Suggestion should advise narrowing when the budget is hit")
+	}
+}
+
+// TestSearchFactsDescription_IsApproximateRecall guards the framing that
+// distinguishes search_facts (approximate) from recall_fact (exact) and
+// keeps the no-refresh invariant.
+func TestSearchFactsDescription_IsApproximateRecall(t *testing.T) {
+	if !strings.Contains(searchFactsDescription, "recall_fact") {
+		t.Errorf("description should relate search_facts to recall_fact: %q", searchFactsDescription)
+	}
+	if !strings.Contains(searchFactsDescription, "NOT refresh") {
+		t.Errorf("description should keep the does-not-refresh invariant: %q", searchFactsDescription)
+	}
+}


### PR DESCRIPTION
## Summary

Adds **`search_facts`** — approximate recall over keys **and** values — to remove the #1 chat friction: `recall_fact` needs the *exact* key, which an agent rarely remembers, so the only fallback today is guessing a `list_under` prefix.

`search_facts(query, prefix?, limit?)` does a **case-insensitive substring** match against both each fact's key and its value, returning compact `{key, snippet, expires_at}` rows — the same shape `list_under` returns under `projection=snippet` (#541). To read a full value, pass a returned key back to `recall_fact`.

### Design (v1 — no server change)
- Unindexed **scan-and-filter**: paginates `lanternClient.ScanVertices` (cursor-driven), so no new SDK/interface surface.
- Bounded cost: stops after **10 000** scanned vertices or once the match **limit** (default 20, max 100) is filled, setting `truncated=true` and a `suggestion` to narrow the `prefix` / raise the limit. `scanned` is reported.
- Optional `prefix` scopes the scan to one namespace (faster + more precise).
- Factored `value.Text` (full single-line render) out of `value.Snippet`, so matching sees the **whole** value while previews stay truncated at ~120 runes.
- Registered in `newServer`; added to the server **RECALL-FIRST** instructions alongside `recall_fact` / `recall_related` / `list_under`.

## Acceptance criteria
- [x] `search_facts("build 2026")` finds facts stored under unrelated key prefixes (matches in the value).
- [x] Results are compact (snippet previews, no full-value dump by default).
- [x] Tests for substring match over **both** keys and values (plus case-insensitivity, prefix forwarding, cursor pagination, limit truncation, scan-budget ceiling, empty-query rejection).

## Testing
- `gofmt -l` clean across all modules.
- `cd mcp && go vet ./... && go test ./...` — pass (incl. new `value` and `search_facts` tests).
- Root `go test ./...` + `core` / `pb` / `sdks/go` / `server` — all pass.

Closes #538
