### PR TITLE
feat(mcp): add list_namespaces for facet/schema discovery of the key space

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -76,6 +76,7 @@ from the source so the LLM and the human reader see the same contract.
 | `search_facts` | Find facts by a case-insensitive substring matched against both keys **and** values — the approximate counterpart to `recall_fact` for when you recall a topic but not the exact key. Returns compact `{key, snippet, expires_at}` previews (same shape as `list_under` `projection=snippet`); pass a `prefix` to scope and speed the scan. Does NOT refresh TTL. |
 | `forget` | Delete a fact by exact key. Idempotent. Edges incident to the key are NOT cascade-deleted; they decay on their own TTL. |
 | `list_under` | Enumerate facts whose key starts with the given prefix, in ascending key order. Defaults to 50 entries, max 500. A `projection` (`keys` / `snippet` / `full`, default `full`) controls how much of each value is returned. |
+| `list_namespaces` | Discover the **shape** of the key space: return the distinct child namespace segments under a prefix, each with a count of facts beneath it, and **no values**. An empty prefix (allowed here, unlike `list_under`) lists top-level namespaces; `depth` controls how many dot-delimited segments deep to aggregate (default 1). Does NOT refresh TTL. |
 | `remember_relation` | Add (or reinforce) a directed relation from one fact to another. **Additive** — writing the same relation twice strengthens it; this is the Hebbian primitive. |
 | `recall_related` | Walk the graph from a seed key with `step`, `k`, and three orthogonal axes (`algorithm` ∈ `none` / `mst` / `spt`, `objective` ∈ `min` / `max`, `weighting` ∈ `raw` / `tfidf`; see #410). Returns related facts with cumulative weights. Does NOT refresh TTL. |
 
@@ -156,6 +157,25 @@ v1 is an unindexed scan-and-filter (no server change), so:
   ceiling is reached (or the `limit`, default 20 / max 100, is filled),
   `truncated` is `true` and `suggestion` tells you to narrow the prefix or
   raise the limit. `scanned` reports how many vertices were examined.
+
+### Namespace discovery with `list_namespaces`
+
+Before guessing keys, ask what's there. `list_namespaces` returns the
+distinct child namespace segments under a prefix with a per-segment fact
+count and **no values** — the cheap way to learn the schema of memory.
+
+- An **empty prefix** lists the top-level namespaces of the whole keyspace
+  (`user`, `project`, `session`, …). This is allowed here (unlike
+  `list_under`) precisely because only segment names and counts are
+  returned, never values.
+- `depth` controls how many dot-delimited segments below the prefix collapse
+  into each namespace (default 1 = immediate children, max 10).
+- `has_children` on a result marks namespaces you can drill into further
+  (with a longer prefix or a larger `depth`).
+- Results are ordered most-populated first and capped at 500 namespaces. Like
+  `search_facts`, the survey scans at most `10000` vertices; when either
+  ceiling is hit, `truncated` is `true` (counts become lower bounds) and
+  `suggestion` advises narrowing.
 
 ## Environment reference
 

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -263,6 +263,7 @@ func newServer(lc lanternClient, resolver *ttl.Resolver, logger *slog.Logger) *m
 	registerSearchFacts(srv, lc)
 	registerForget(srv, lc)
 	registerListUnder(srv, lc)
+	registerListNamespaces(srv, lc)
 	registerRememberRelation(srv, lc, resolver)
 	registerRecallRelated(srv, lc)
 
@@ -284,7 +285,7 @@ func newServer(lc lanternClient, resolver *ttl.Resolver, logger *slog.Logger) *m
 // Changing this text is an LLM-behavior-affecting change; treat it the
 // way you would a prompt update and call it out in release notes.
 const serverInstructions = "Lantern is your ambient, decaying graph memory. Use it proactively — you do not need to be asked. Run this loop every turn: " +
-	"(1) RECALL FIRST: before answering anything that could depend on remembered context, call recall_fact (exact key), search_facts (substring over keys+values when you recall the topic but not the exact key), recall_related (walk from a seed), or list_under (enumerate a namespace) to pull in what you already know. " +
+	"(1) RECALL FIRST: before answering anything that could depend on remembered context, call recall_fact (exact key), search_facts (substring over keys+values when you recall the topic but not the exact key), recall_related (walk from a seed), list_under (enumerate a namespace), or list_namespaces (discover which namespaces exist, counts only, no values) to pull in what you already know. " +
 	"(2) ANSWER using what you recalled. " +
 	"(3) CAPTURE AFTER: once the exchange settles, write any new durable facts with remember_fact and any new associations with remember_relation — preferences, decisions, identities, project facts, and how they connect. Capturing is the default, not the exception. " +
 	"Two invariants govern every write: (a) there is no \"forever\" — each write picks a TTL bucket from {seconds, transient, turn, conversation, task, workday, day, week, sprint, month, quarter, durable}; (b) recall does NOT refresh TTL, so to keep a fact alive you must re-remember it when you reference it. Choosing a bucket: ask \"when will this stop being true?\" and \"how bad is it if this lingers past then?\" and pick the SHORTER one. Relations are additive — writing the same relation twice strengthens it, so reinforce associations you keep using. " +

--- a/mcp/tool_list_namespaces.go
+++ b/mcp/tool_list_namespaces.go
@@ -1,0 +1,172 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// listNamespacesDefaultDepth aggregates one dot-delimited segment below the
+// prefix when the caller omits depth — the "immediate children" view.
+const listNamespacesDefaultDepth uint32 = 1
+
+// listNamespacesMaxDepth bounds how many segments deep a single call may
+// aggregate. Deeper than this is almost always better expressed as a longer
+// prefix.
+const listNamespacesMaxDepth uint32 = 10
+
+// listNamespacesScanBatch is the per-page size forwarded to ScanVertices.
+const listNamespacesScanBatch uint32 = 500
+
+// listNamespacesMaxScan bounds how many vertices a single call pulls before
+// stopping. Facet discovery is an unindexed scan (ScanVertices returns full
+// vertices even though we only read keys), so without this ceiling a survey
+// of a huge keyspace would transfer every value. When the ceiling is hit the
+// reported counts are lower bounds and truncated is set.
+const listNamespacesMaxScan = 10_000
+
+// listNamespacesMaxFacets caps how many distinct namespaces a single result
+// returns, so a high depth over a diverse keyspace cannot flood the context.
+const listNamespacesMaxFacets = 500
+
+type listNamespacesInput struct {
+	Prefix string `json:"prefix,omitempty" jsonschema:"Key prefix to enumerate beneath (e.g. user. or project.lantern. — end it at a segment boundary with a trailing dot for clean results, since matching is a byte prefix). Empty (the default) enumerates the TOP-LEVEL namespaces of the entire keyspace — the natural starting point for discovering what exists. Unlike list_under, an empty prefix is allowed here because only segment names and counts are returned, never values."`
+	Depth  uint32 `json:"depth,omitempty" jsonschema:"How many dot-delimited segments below the prefix to aggregate into each namespace (default 1 = immediate children, max 10). depth=1 under 'topic.' groups topic.lantern.* and topic.build.* into 'lantern' and 'build'; depth=2 would distinguish their next segment too."`
+}
+
+// namespaceFacet is one distinct child namespace. Segment is the path
+// relative to the requested prefix (the joined first `depth` segments).
+// Count is how many facts fall under it. HasChildren reports whether at
+// least one of those facts has further segments below this depth — i.e.
+// whether drilling down (a longer prefix or a larger depth) would reveal
+// more structure.
+type namespaceFacet struct {
+	Segment     string `json:"segment"`
+	Count       int    `json:"count"`
+	HasChildren bool   `json:"has_children"`
+}
+
+type listNamespacesOutput struct {
+	Prefix     string           `json:"prefix"`
+	Depth      uint32           `json:"depth"`
+	Count      int              `json:"count"`
+	Namespaces []namespaceFacet `json:"namespaces"`
+	Scanned    int              `json:"scanned"`
+	Truncated  bool             `json:"truncated"`
+	Suggestion string           `json:"suggestion,omitempty"`
+}
+
+const listNamespacesDescription = "Discover the SHAPE of the key space: return the distinct child namespace segments under a prefix, each with a count of facts beneath it, WITHOUT returning any values. Call this PROACTIVELY to learn which namespaces exist — start with an empty prefix to see top-level user./project./session., then drill into the ones that look relevant — before guessing exact keys for recall_fact or running search_facts. depth controls how many dot-delimited segments deep to aggregate (default 1). has_children on a result marks namespaces you can drill into further. Cheap by design (no value payloads). Does NOT refresh TTL."
+
+func registerListNamespaces(srv *mcp.Server, lc lanternClient) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "list_namespaces",
+		Description: listNamespacesDescription,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in listNamespacesInput) (*mcp.CallToolResult, listNamespacesOutput, error) {
+		depth := in.Depth
+		if depth == 0 {
+			depth = listNamespacesDefaultDepth
+		}
+		if depth > listNamespacesMaxDepth {
+			depth = listNamespacesMaxDepth
+		}
+
+		type agg struct {
+			count       int
+			hasChildren bool
+		}
+		facets := make(map[string]*agg)
+		scanned := 0
+		scanBudgetHit := false
+		var cursor []byte
+
+	scan:
+		for {
+			verts, next, err := lc.ScanVertices(ctx, in.Prefix,
+				client.WithScanLimit(listNamespacesScanBatch),
+				client.WithScanCursor(cursor))
+			if err != nil {
+				return nil, listNamespacesOutput{}, mapSDKError("list_namespaces", err)
+			}
+			for _, v := range verts {
+				if v == nil {
+					continue
+				}
+				scanned++
+				// rest is the key tail below the prefix. A key exactly equal
+				// to the prefix has no child segment and is skipped.
+				if rest := strings.TrimPrefix(v.GetKey(), in.Prefix); rest != "" {
+					segs := strings.Split(rest, ".")
+					n := int(depth)
+					if n > len(segs) {
+						n = len(segs)
+					}
+					facet := strings.Join(segs[:n], ".")
+					a := facets[facet]
+					if a == nil {
+						a = &agg{}
+						facets[facet] = a
+					}
+					a.count++
+					if len(segs) > int(depth) {
+						a.hasChildren = true
+					}
+				}
+				if scanned >= listNamespacesMaxScan {
+					scanBudgetHit = true
+					break scan
+				}
+			}
+			if len(next) == 0 {
+				break
+			}
+			cursor = next
+		}
+
+		namespaces := make([]namespaceFacet, 0, len(facets))
+		for seg, a := range facets {
+			namespaces = append(namespaces, namespaceFacet{
+				Segment:     seg,
+				Count:       a.count,
+				HasChildren: a.hasChildren,
+			})
+		}
+		// Biggest buckets first so the most populated namespaces surface even
+		// when the facet list is capped; segment order breaks ties for stable
+		// output.
+		sort.Slice(namespaces, func(i, j int) bool {
+			if namespaces[i].Count != namespaces[j].Count {
+				return namespaces[i].Count > namespaces[j].Count
+			}
+			return namespaces[i].Segment < namespaces[j].Segment
+		})
+		facetCapHit := false
+		if len(namespaces) > listNamespacesMaxFacets {
+			namespaces = namespaces[:listNamespacesMaxFacets]
+			facetCapHit = true
+		}
+
+		out := listNamespacesOutput{
+			Prefix:     in.Prefix,
+			Depth:      depth,
+			Count:      len(namespaces),
+			Namespaces: namespaces,
+			Scanned:    scanned,
+			Truncated:  scanBudgetHit || facetCapHit,
+		}
+		switch {
+		case scanBudgetHit:
+			out.Suggestion = fmt.Sprintf("Stopped after scanning %d facts; counts are lower bounds. Pass a longer prefix to scope the survey to a sub-namespace.", scanned)
+		case facetCapHit:
+			out.Suggestion = fmt.Sprintf("More than %d distinct namespaces matched; showing the %d most populated. Pass a longer prefix or a smaller depth to narrow.", listNamespacesMaxFacets, listNamespacesMaxFacets)
+		}
+		text := fmt.Sprintf("Found %d namespace(s) under %q at depth %d (scanned=%d, truncated=%t).", out.Count, in.Prefix, out.Depth, out.Scanned, out.Truncated)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: text}},
+		}, out, nil
+	})
+}

--- a/mcp/tool_list_namespaces_test.go
+++ b/mcp/tool_list_namespaces_test.go
@@ -1,0 +1,230 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+// keysOf extracts the segment->facet map from a result for terse assertions.
+func facetsBySegment(out listNamespacesOutput) map[string]namespaceFacet {
+	m := make(map[string]namespaceFacet, len(out.Namespaces))
+	for _, f := range out.Namespaces {
+		m[f.Segment] = f
+	}
+	return m
+}
+
+func TestListNamespaces_AggregatesChildSegments(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.scanVerticesFn = singlePage(
+		vstr("topic.lantern.a", "x"),
+		vstr("topic.lantern.b", "y"),
+		vstr("topic.build-2026.x", "z"),
+	)
+	res := h.call(t, "list_namespaces", map[string]any{"prefix": "topic."})
+	if res.IsError {
+		t.Fatalf("IsError = true: %s", contentText(res))
+	}
+	var out listNamespacesOutput
+	structuredAs(t, res, &out)
+	if out.Count != 2 {
+		t.Fatalf("Count = %d, want 2 (namespaces=%+v)", out.Count, out.Namespaces)
+	}
+	// Biggest bucket first: lantern (2) before build-2026 (1).
+	if out.Namespaces[0].Segment != "lantern" {
+		t.Fatalf("expected lantern first (count desc), got %+v", out.Namespaces)
+	}
+	by := facetsBySegment(out)
+	if by["lantern"].Count != 2 || !by["lantern"].HasChildren {
+		t.Fatalf("lantern facet wrong: %+v", by["lantern"])
+	}
+	if by["build-2026"].Count != 1 || !by["build-2026"].HasChildren {
+		t.Fatalf("build-2026 facet wrong: %+v", by["build-2026"])
+	}
+}
+
+func TestListNamespaces_DepthControlsAggregation(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.scanVerticesFn = singlePage(
+		vstr("topic.lantern.a", "x"),
+		vstr("topic.lantern.b", "y"),
+		vstr("topic.build-2026.x", "z"),
+	)
+	res := h.call(t, "list_namespaces", map[string]any{"prefix": "topic.", "depth": 2})
+	var out listNamespacesOutput
+	structuredAs(t, res, &out)
+	if out.Depth != 2 {
+		t.Fatalf("Depth echoed = %d, want 2", out.Depth)
+	}
+	// Two segments deep distinguishes the leaf keys.
+	if out.Count != 3 {
+		t.Fatalf("Count = %d, want 3 (namespaces=%+v)", out.Count, out.Namespaces)
+	}
+	by := facetsBySegment(out)
+	for _, seg := range []string{"lantern.a", "lantern.b", "build-2026.x"} {
+		f, ok := by[seg]
+		if !ok {
+			t.Fatalf("missing facet %q: %+v", seg, out.Namespaces)
+		}
+		if f.HasChildren {
+			t.Fatalf("facet %q should have no children at depth 2: %+v", seg, f)
+		}
+	}
+}
+
+// TestListNamespaces_ReturnsNoValues guards that facet discovery never leaks
+// stored values into the result — only segment names and counts.
+func TestListNamespaces_ReturnsNoValues(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.scanVerticesFn = singlePage(
+		vstr("topic.secret.k", "TOPSECRETVALUE"),
+	)
+	res := h.call(t, "list_namespaces", map[string]any{"prefix": "topic."})
+	raw, err := json.Marshal(res.StructuredContent)
+	if err != nil {
+		t.Fatalf("marshal structured content: %v", err)
+	}
+	if strings.Contains(string(raw), "TOPSECRETVALUE") {
+		t.Fatalf("result leaked a stored value: %s", raw)
+	}
+}
+
+// TestListNamespaces_EmptyPrefixEnumeratesTopLevel verifies the key
+// difference from list_under: an empty prefix is allowed and returns the
+// top-level namespaces of the whole keyspace.
+func TestListNamespaces_EmptyPrefixEnumeratesTopLevel(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.scanVerticesFn = singlePage(
+		vstr("user.identity.role", "engineer"),
+		vstr("project.lantern.stack", "go"),
+		vstr("session.current-task", "issue-550"),
+	)
+	res := h.call(t, "list_namespaces", map[string]any{})
+	if res.IsError {
+		t.Fatalf("empty prefix should be allowed: %s", contentText(res))
+	}
+	var out listNamespacesOutput
+	structuredAs(t, res, &out)
+	if out.Depth != 1 {
+		t.Fatalf("Depth defaulted = %d, want 1", out.Depth)
+	}
+	if out.Count != 3 {
+		t.Fatalf("Count = %d, want 3 top-level namespaces: %+v", out.Count, out.Namespaces)
+	}
+	by := facetsBySegment(out)
+	for _, seg := range []string{"user", "project", "session"} {
+		if _, ok := by[seg]; !ok {
+			t.Fatalf("missing top-level namespace %q: %+v", seg, out.Namespaces)
+		}
+	}
+}
+
+// TestListNamespaces_HasChildrenFlag checks the drill-down signal: a key with
+// deeper segments sets has_children; a flat key does not.
+func TestListNamespaces_HasChildrenFlag(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.scanVerticesFn = singlePage(
+		vstr("a.b.c", "deep"),
+		vstr("x", "flat"),
+	)
+	res := h.call(t, "list_namespaces", map[string]any{})
+	var out listNamespacesOutput
+	structuredAs(t, res, &out)
+	by := facetsBySegment(out)
+	if !by["a"].HasChildren {
+		t.Fatalf("facet a should have children: %+v", by["a"])
+	}
+	if by["x"].HasChildren {
+		t.Fatalf("facet x should not have children: %+v", by["x"])
+	}
+}
+
+func TestListNamespaces_ForwardsPrefixToScan(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.scanVerticesFn = singlePage(vstr("user.a.b", "x"))
+	_ = h.call(t, "list_namespaces", map[string]any{"prefix": "user."})
+	if h.fake.lastScanPrefix != "user." {
+		t.Fatalf("prefix forwarded to scan = %q, want %q", h.fake.lastScanPrefix, "user.")
+	}
+}
+
+func TestListNamespaces_FollowsCursorPagination(t *testing.T) {
+	h := newTestHarness(t)
+	calls := 0
+	h.fake.scanVerticesFn = func(_ context.Context, _ string, _ ...client.ScanOption) ([]*client.Vertex, []byte, error) {
+		calls++
+		if calls == 1 {
+			return []*client.Vertex{vstr("topic.lantern.a", "x")}, []byte("cursor-1"), nil
+		}
+		return []*client.Vertex{vstr("topic.lantern.b", "y")}, nil, nil
+	}
+	res := h.call(t, "list_namespaces", map[string]any{"prefix": "topic."})
+	var out listNamespacesOutput
+	structuredAs(t, res, &out)
+	if calls != 2 {
+		t.Fatalf("expected 2 scan pages, got %d", calls)
+	}
+	if out.Scanned != 2 {
+		t.Fatalf("Scanned = %d, want 2 across both pages", out.Scanned)
+	}
+	by := facetsBySegment(out)
+	if by["lantern"].Count != 2 {
+		t.Fatalf("counts should aggregate across pages: %+v", out.Namespaces)
+	}
+}
+
+func TestListNamespaces_DepthDefaultedAndCapped(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.scanVerticesFn = singlePage(vstr("a.b", "x"))
+
+	// depth omitted -> default 1.
+	var def listNamespacesOutput
+	structuredAs(t, h.call(t, "list_namespaces", map[string]any{}), &def)
+	if def.Depth != listNamespacesDefaultDepth {
+		t.Fatalf("default depth = %d, want %d", def.Depth, listNamespacesDefaultDepth)
+	}
+
+	// depth above the ceiling -> clamped to max.
+	var capped listNamespacesOutput
+	structuredAs(t, h.call(t, "list_namespaces", map[string]any{"depth": listNamespacesMaxDepth + 5}), &capped)
+	if capped.Depth != listNamespacesMaxDepth {
+		t.Fatalf("capped depth = %d, want %d", capped.Depth, listNamespacesMaxDepth)
+	}
+}
+
+func TestListNamespaces_StopsAtScanBudget(t *testing.T) {
+	h := newTestHarness(t)
+	verts := make([]*client.Vertex, 0, listNamespacesMaxScan+1)
+	for i := 0; i < listNamespacesMaxScan+1; i++ {
+		verts = append(verts, vstr("topic.lantern.k", "v"))
+	}
+	h.fake.scanVerticesFn = singlePage(verts...)
+	res := h.call(t, "list_namespaces", map[string]any{"prefix": "topic."})
+	var out listNamespacesOutput
+	structuredAs(t, res, &out)
+	if !out.Truncated {
+		t.Fatalf("Truncated = false; want true when the scan budget is hit")
+	}
+	if out.Scanned != listNamespacesMaxScan {
+		t.Fatalf("Scanned = %d, want %d (budget ceiling)", out.Scanned, listNamespacesMaxScan)
+	}
+	if out.Suggestion == "" {
+		t.Fatalf("Suggestion should advise narrowing when the budget is hit")
+	}
+}
+
+// TestListNamespacesDescription_IsProactiveDiscovery guards the framing that
+// markets list_namespaces as a proactive discovery surface and keeps the
+// no-refresh invariant.
+func TestListNamespacesDescription_IsProactiveDiscovery(t *testing.T) {
+	if !strings.Contains(listNamespacesDescription, "PROACTIVELY") {
+		t.Errorf("description should encourage proactive discovery: %q", listNamespacesDescription)
+	}
+	if !strings.Contains(listNamespacesDescription, "NOT refresh") {
+		t.Errorf("description should keep the does-not-refresh invariant: %q", listNamespacesDescription)
+	}
+}


### PR DESCRIPTION
## Why
`recall_fact` needs an exact key and `search_facts` needs you to know a
topic, but agents often don't even know **what namespaces exist** — so they
guess prefixes for `list_under` and miss. There's no way to ask for the
*shape* of memory.

## What
Add `list_namespaces(prefix?, depth?)`:

- Returns the distinct child namespace **segments** under a prefix, each with
  a `count` of facts beneath it and a `has_children` drill-down flag.
- Returns **no values** — only segment names and counts.
- An **empty prefix** is allowed (unlike `list_under`) and lists the
  top-level namespaces of the whole keyspace (`user`, `project`, `session`,
  …) — the natural entry point for discovery.
- `depth` controls how many dot-delimited segments below the prefix collapse
  into each namespace (default 1 = immediate children, max 10).

## How
- Unindexed **scan-and-aggregate** over `ScanVertices`, reusing the bounded
  cursor-pagination shape from `search_facts` (#538): a 10 000-vertex scan
  budget and a 500-facet cap, both surfaced via `truncated` + `suggestion`
  so partial counts read as honest lower bounds. `scanned` is reported.
- Facets ordered **most-populated first** so the cap keeps the biggest
  namespaces; segment order breaks ties for stable output.
- Registered in `newServer`; added to the server **RECALL-FIRST**
  instructions alongside `recall_fact` / `search_facts` / `recall_related` /
  `list_under`.

## Acceptance criteria
- [x] Returns distinct child segments with counts and **no values**.
- [x] `depth` controls how many segments deep aggregation happens.
- [x] Tests for nested namespaces (depth 1 vs 2, `has_children`, empty-prefix
  top-level, cross-page aggregation, depth defaulting/capping, scan budget).

## Testing
- `gofmt -l` clean across all modules.
- `cd mcp && go vet ./... && go test ./...` — pass (incl. new `list_namespaces` suite).
- Root `go test ./...` + `core` / `pb` / `sdks/go` / `server` — all pass.

Closes #550
