### PR TITLE
feat(mcp): add recall_relation to read a single edge's weight + TTL

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -79,6 +79,7 @@ from the source so the LLM and the human reader see the same contract.
 | `list_namespaces` | Discover the **shape** of the key space: return the distinct child namespace segments under a prefix, each with a count of facts beneath it, and **no values**. An empty prefix (allowed here, unlike `list_under`) lists top-level namespaces; `depth` controls how many dot-delimited segments deep to aggregate (default 1). Does NOT refresh TTL. |
 | `remember_relation` | Add (or reinforce) a directed relation from one fact to another. **Additive** — writing the same relation twice strengthens it; this is the Hebbian primitive. |
 | `recall_related` | Walk the graph from a seed key with `step`, `k`, and three orthogonal axes (`algorithm` ∈ `none` / `mst` / `spt`, `objective` ∈ `min` / `max`, `weighting` ∈ `raw` / `tfidf`; see #410). Returns related facts with cumulative weights. Does NOT refresh TTL. |
+| `recall_relation` | Read a **single** directed edge by its exact `(from, to)` endpoints, returning its current accumulated `weight` and `expires_at`. The per-edge counterpart to `recall_related` (which sums all incoming edges into a node-level score). Returns `{found=false}` for a missing or fully-decayed edge (structured result, not a tool error). Direction matters: `from→to` only. Does NOT refresh TTL or weight. |
 
 A `ping` tool also exists so operators can sanity-check the wire without
 mutating state.

--- a/mcp/fake_lantern_test.go
+++ b/mcp/fake_lantern_test.go
@@ -40,6 +40,11 @@ type fakeLantern struct {
 	lastEdgeTTL    time.Duration
 	addEdgeCalls   int
 
+	// GetEdge
+	getEdgeFn       func(ctx context.Context, tail, head string) (*client.Edge, error)
+	lastGetEdgeTail string
+	lastGetEdgeHead string
+
 	// Illuminate
 	illuminateFn  func(ctx context.Context, seed string, opts ...client.IlluminateOption) (*client.Graph, error)
 	lastSeed      string
@@ -91,6 +96,15 @@ func (f *fakeLantern) AddEdge(_ context.Context, tail, head string, weight float
 	f.lastEdgeWeight = weight
 	f.lastEdgeTTL = ttl
 	return f.addEdgeErr
+}
+
+func (f *fakeLantern) GetEdge(ctx context.Context, tail, head string) (*client.Edge, error) {
+	f.lastGetEdgeTail = tail
+	f.lastGetEdgeHead = head
+	if f.getEdgeFn != nil {
+		return f.getEdgeFn(ctx, tail, head)
+	}
+	return nil, nil
 }
 
 func (f *fakeLantern) Illuminate(ctx context.Context, seed string, opts ...client.IlluminateOption) (*client.Graph, error) {

--- a/mcp/lantern.go
+++ b/mcp/lantern.go
@@ -25,6 +25,7 @@ type lanternClient interface {
 	DeleteVertex(ctx context.Context, key string) (bool, error)
 	ScanVertices(ctx context.Context, prefix string, opts ...client.ScanOption) (vertices []*client.Vertex, nextCursor []byte, err error)
 	AddEdge(ctx context.Context, tail, head string, weight float32, ttl time.Duration) error
+	GetEdge(ctx context.Context, tail, head string) (*client.Edge, error)
 	Illuminate(ctx context.Context, seed string, opts ...client.IlluminateOption) (*client.Graph, error)
 	Ping(ctx context.Context) error
 }

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -266,6 +266,7 @@ func newServer(lc lanternClient, resolver *ttl.Resolver, logger *slog.Logger) *m
 	registerListNamespaces(srv, lc)
 	registerRememberRelation(srv, lc, resolver)
 	registerRecallRelated(srv, lc)
+	registerRecallRelation(srv, lc)
 
 	return srv
 }
@@ -285,7 +286,7 @@ func newServer(lc lanternClient, resolver *ttl.Resolver, logger *slog.Logger) *m
 // Changing this text is an LLM-behavior-affecting change; treat it the
 // way you would a prompt update and call it out in release notes.
 const serverInstructions = "Lantern is your ambient, decaying graph memory. Use it proactively — you do not need to be asked. Run this loop every turn: " +
-	"(1) RECALL FIRST: before answering anything that could depend on remembered context, call recall_fact (exact key), search_facts (substring over keys+values when you recall the topic but not the exact key), recall_related (walk from a seed), list_under (enumerate a namespace), or list_namespaces (discover which namespaces exist, counts only, no values) to pull in what you already know. " +
+	"(1) RECALL FIRST: before answering anything that could depend on remembered context, call recall_fact (exact key), search_facts (substring over keys+values when you recall the topic but not the exact key), recall_related (walk from a seed), recall_relation (read one specific from→to edge's weight and decay), list_under (enumerate a namespace), or list_namespaces (discover which namespaces exist, counts only, no values) to pull in what you already know. " +
 	"(2) ANSWER using what you recalled. " +
 	"(3) CAPTURE AFTER: once the exchange settles, write any new durable facts with remember_fact and any new associations with remember_relation — preferences, decisions, identities, project facts, and how they connect. Capturing is the default, not the exception. " +
 	"Two invariants govern every write: (a) there is no \"forever\" — each write picks a TTL bucket from {seconds, transient, turn, conversation, task, workday, day, week, sprint, month, quarter, durable}; (b) recall does NOT refresh TTL, so to keep a fact alive you must re-remember it when you reference it. Choosing a bucket: ask \"when will this stop being true?\" and \"how bad is it if this lingers past then?\" and pick the SHORTER one. Relations are additive — writing the same relation twice strengthens it, so reinforce associations you keep using. " +

--- a/mcp/tool_recall_relation.go
+++ b/mcp/tool_recall_relation.go
@@ -1,0 +1,80 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type recallRelationInput struct {
+	From string `json:"from" jsonschema:"Tail vertex key. The lookup is directed: this checks the edge from→to only, never the reverse. Use recall_related to walk a neighbourhood instead of probing one edge."`
+	To   string `json:"to"   jsonschema:"Head vertex key."`
+}
+
+// recallRelationOutput is the structured result. Found mirrors presence so
+// the LLM can branch without parsing the human-readable Text. Weight is the
+// current accumulated edge weight (additive writes have already been summed
+// server-side); it is omitted when the edge is missing. ExpiresAt is omitted
+// when the edge carries no expiration.
+type recallRelationOutput struct {
+	Found     bool    `json:"found"`
+	From      string  `json:"from"`
+	To        string  `json:"to"`
+	Weight    float32 `json:"weight,omitempty"`
+	ExpiresAt string  `json:"expires_at,omitempty"`
+}
+
+const recallRelationDescription = "Read a single directed relation by its exact (from, to) endpoints, returning its current accumulated weight and decay horizon. Call this PROACTIVELY when you need to know whether — and how strongly — two specific facts are connected (e.g. before relying on an association you wrote earlier). Direction matters: this checks from→to only, not the reverse. Returns {found=false} for a missing or fully-decayed edge (this is a structured result, NOT a tool error). IMPORTANT: recalling a relation does NOT refresh its TTL or weight — to strengthen it, call remember_relation again (weights are additive). To explore a whole neighbourhood instead of one edge, use recall_related."
+
+func registerRecallRelation(srv *mcp.Server, lc lanternClient) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "recall_relation",
+		Description: recallRelationDescription,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in recallRelationInput) (*mcp.CallToolResult, recallRelationOutput, error) {
+		if in.From == "" || in.To == "" {
+			return nil, recallRelationOutput{}, fmt.Errorf("recall_relation: both from and to must be non-empty")
+		}
+		e, err := lc.GetEdge(ctx, in.From, in.To)
+		if err != nil {
+			if errors.Is(err, client.ErrNotFound) {
+				return notFoundRelation(in.From, in.To), recallRelationOutput{Found: false, From: in.From, To: in.To}, nil
+			}
+			return nil, recallRelationOutput{}, mapSDKError("recall_relation", err)
+		}
+		// Defensive: a nil edge with no error is treated as missing so the
+		// tool never reports found=true with no weight.
+		if e == nil {
+			return notFoundRelation(in.From, in.To), recallRelationOutput{Found: false, From: in.From, To: in.To}, nil
+		}
+		out := recallRelationOutput{
+			Found:  true,
+			From:   in.From,
+			To:     in.To,
+			Weight: e.GetWeight(),
+		}
+		if exp := client.EdgeExpiration(e); !exp.IsZero() {
+			out.ExpiresAt = exp.UTC().Format("2006-01-02T15:04:05Z07:00")
+		}
+		text := fmt.Sprintf("Relation %q -> %q has weight %.2f", in.From, in.To, out.Weight)
+		if out.ExpiresAt != "" {
+			text += fmt.Sprintf(", expires=%s", out.ExpiresAt)
+		} else {
+			text += " (no expiration)"
+		}
+		text += ". Recall did NOT refresh TTL or weight."
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: text}},
+		}, out, nil
+	})
+}
+
+func notFoundRelation(from, to string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{
+			Text: fmt.Sprintf("No relation stored from %q to %q.", from, to),
+		}},
+	}
+}

--- a/mcp/tool_recall_relation_test.go
+++ b/mcp/tool_recall_relation_test.go
@@ -1,0 +1,129 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestRecallRelation_Found(t *testing.T) {
+	h := newTestHarness(t)
+	exp, err := time.Parse(time.RFC3339, "2031-01-02T03:04:05Z")
+	if err != nil {
+		t.Fatalf("parse time: %v", err)
+	}
+	h.fake.getEdgeFn = func(_ context.Context, tail, head string) (*client.Edge, error) {
+		return &pb.Edge{Tail: tail, Head: head, Weight: 2.5, Expiration: timestamppb.New(exp)}, nil
+	}
+	res := h.call(t, "recall_relation", map[string]any{"from": "a", "to": "b"})
+	if res.IsError {
+		t.Fatalf("IsError = true; content=%+v", res.Content)
+	}
+	var out recallRelationOutput
+	structuredAs(t, res, &out)
+	if !out.Found {
+		t.Fatalf("Found = false; want true")
+	}
+	if out.From != "a" || out.To != "b" {
+		t.Fatalf("unexpected endpoints: %+v", out)
+	}
+	if out.Weight != 2.5 {
+		t.Fatalf("Weight = %v; want 2.5", out.Weight)
+	}
+	if out.ExpiresAt != "2031-01-02T03:04:05Z" {
+		t.Fatalf("ExpiresAt = %q; want 2031-01-02T03:04:05Z", out.ExpiresAt)
+	}
+	// The handler must read the edge by the exact (from, to) endpoints.
+	if h.fake.lastGetEdgeTail != "a" || h.fake.lastGetEdgeHead != "b" {
+		t.Fatalf("GetEdge called with (%q,%q); want (a,b)", h.fake.lastGetEdgeTail, h.fake.lastGetEdgeHead)
+	}
+}
+
+func TestRecallRelation_FoundWithoutExpiration(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.getEdgeFn = func(_ context.Context, tail, head string) (*client.Edge, error) {
+		return &pb.Edge{Tail: tail, Head: head, Weight: 1}, nil
+	}
+	res := h.call(t, "recall_relation", map[string]any{"from": "a", "to": "b"})
+	if res.IsError {
+		t.Fatalf("IsError = true; content=%+v", res.Content)
+	}
+	var out recallRelationOutput
+	structuredAs(t, res, &out)
+	if !out.Found || out.Weight != 1 {
+		t.Fatalf("unexpected output: %+v", out)
+	}
+	if out.ExpiresAt != "" {
+		t.Fatalf("ExpiresAt = %q; want empty for a permanent edge", out.ExpiresAt)
+	}
+}
+
+func TestRecallRelation_NotFoundIsStructured(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.getEdgeFn = func(_ context.Context, _, _ string) (*client.Edge, error) {
+		return nil, client.ErrNotFound
+	}
+	res := h.call(t, "recall_relation", map[string]any{"from": "a", "to": "missing"})
+	if res.IsError {
+		t.Fatalf("not_found should be a structured result, not a tool error: %+v", res.Content)
+	}
+	var out recallRelationOutput
+	structuredAs(t, res, &out)
+	if out.Found {
+		t.Fatalf("Found = true; want false")
+	}
+	if out.From != "a" || out.To != "missing" {
+		t.Fatalf("unexpected endpoints on miss: %+v", out)
+	}
+}
+
+// TestRecallRelation_NilEdgeIsNotFound guards the defensive branch: a nil
+// edge with no error must not surface as found=true with a zero weight.
+func TestRecallRelation_NilEdgeIsNotFound(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.getEdgeFn = func(_ context.Context, _, _ string) (*client.Edge, error) {
+		return nil, nil
+	}
+	res := h.call(t, "recall_relation", map[string]any{"from": "a", "to": "b"})
+	if res.IsError {
+		t.Fatalf("nil edge should be a structured miss, not a tool error: %+v", res.Content)
+	}
+	var out recallRelationOutput
+	structuredAs(t, res, &out)
+	if out.Found {
+		t.Fatalf("Found = true; want false for a nil edge")
+	}
+}
+
+func TestRecallRelation_RejectsEmptyEndpoints(t *testing.T) {
+	h := newTestHarness(t)
+	h.callExpectError(t, "recall_relation", map[string]any{"from": "", "to": "b"})
+	h.callExpectError(t, "recall_relation", map[string]any{"from": "a", "to": ""})
+}
+
+func TestRecallRelation_RateLimitMapsToError(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.getEdgeFn = func(_ context.Context, _, _ string) (*client.Edge, error) {
+		return nil, client.ErrResourceExhausted
+	}
+	res := h.callExpectError(t, "recall_relation", map[string]any{"from": "a", "to": "b"})
+	if !strings.Contains(contentText(res), "rate limited") {
+		t.Fatalf("expected rate-limit guidance; got %q", contentText(res))
+	}
+}
+
+// TestRecallRelationDescription_IsProactive guards the recall-before-relying
+// framing and the no-refresh invariant (#528 alignment).
+func TestRecallRelationDescription_IsProactive(t *testing.T) {
+	if !strings.Contains(strings.ToUpper(recallRelationDescription), "PROACTIVELY") {
+		t.Errorf("recallRelationDescription should tell the agent to recall PROACTIVELY: %q", recallRelationDescription)
+	}
+	if !strings.Contains(recallRelationDescription, "does NOT refresh") {
+		t.Errorf("recallRelationDescription should keep the recall-does-not-refresh invariant: %q", recallRelationDescription)
+	}
+}


### PR DESCRIPTION
## What

Adds `recall_relation(from, to)` to the MCP — the per-edge read primitive that was missing.

Until now the MCP had no way to read a single edge. `recall_related` sums all incoming edges in `flattenNeighbors` (`weights[to] += w`), collapsing each edge's individual strength into a node-level score. So an agent using the additive Hebbian model (`remember_relation`) could **write** an A→B association but never **read back** its accumulated weight or decay horizon.

`recall_relation` maps to the server's existing `GetEdge` and returns `{found, from, to, weight, expires_at}`.

## Behavior

- Returns the current **accumulated** weight (additive writes already summed server-side) and `expires_at` for an existing edge.
- A missing or fully-decayed edge → `{found:false}` as a **structured result**, not a tool error — matching `recall_fact` ergonomics. (Server reports missing/expired edges via `CodeNotFound`, which the SDK maps to `client.ErrNotFound`.)
- Directed: `from→to` only, never the reverse.
- Like the other `recall_*` tools, does **NOT** refresh TTL or weight; the description and human-readable text say so explicitly.

## Changes

- `mcp/tool_recall_relation.go` — new tool + proactive description.
- `mcp/tool_recall_relation_test.go` — found (with/without expiry), not-found-is-structured, nil-edge-is-not-found, empty-endpoint rejection, rate-limit mapping, proactive-description guard.
- `mcp/lantern.go` — extend `lanternClient` with `GetEdge`; the existing compile-time assertion against `*client.Lantern` verifies the real client satisfies it.
- `mcp/fake_lantern_test.go` — `GetEdge` double.
- `mcp/server.go` — register after `recall_related`; add to the RECALL FIRST instruction list.
- `mcp/README.md` — document the tool.

## Test plan

- [x] `gofmt -l` clean across the tree
- [x] `cd mcp && go vet ./... && go test ./...`
- [x] root `go test ./...`
- [x] `core`, `pb`, `sdks/go`, `server` `go test ./...`

Closes #548
