### PR TITLE
feat(mcp): touch — extend a fact's TTL without rewriting its value

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -65,7 +65,7 @@ before exit.
 
 ## Tools
 
-Six tools, all advertised at session-open via the server-instructions
+The tool set below is advertised at session-open via the server-instructions
 string in [`server.go`](server.go). Descriptions are reproduced verbatim
 from the source so the LLM and the human reader see the same contract.
 
@@ -73,6 +73,7 @@ from the source so the LLM and the human reader see the same contract.
 |---|---|
 | `remember_fact` | Store a fact in Lantern with a **required TTL bucket**. Writing the same key again overwrites the value and resets the TTL — that is the canonical way to refresh a fact since `recall_*` does NOT refresh. |
 | `recall_fact` | Look up a single fact by exact key. Returns `{found=false}` for missing keys (structured result, not a tool error). Does NOT refresh TTL. |
+| `touch` | Extend a fact's TTL **without rewriting its value** — the cheap keep-alive. Since recall does NOT refresh TTL, touch a fact you want to keep instead of re-supplying its whole value via `remember_fact`. Reads the current value and re-stores it unchanged with a fresh expiry of now + the chosen bucket. A missing key returns `{found=false}` (structured result, not a tool error); touch never creates a fact. The vertex-side counterpart to `remember_relation` (which strengthens an edge rather than just keeping it alive). |
 | `search_facts` | Find facts by a case-insensitive substring matched against both keys **and** values — the approximate counterpart to `recall_fact` for when you recall a topic but not the exact key. Returns compact `{key, snippet, expires_at}` previews (same shape as `list_under` `projection=snippet`); pass a `prefix` to scope and speed the scan. Does NOT refresh TTL. |
 | `forget` | Delete a fact by exact key. Idempotent. Edges incident to the key are NOT cascade-deleted; they decay on their own TTL. |
 | `list_under` | Enumerate facts whose key starts with the given prefix, in ascending key order. Defaults to 50 entries, max 500. A `projection` (`keys` / `snippet` / `full`, default `full`) controls how much of each value is returned. |

--- a/mcp/internal/value/value.go
+++ b/mcp/internal/value/value.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	client "github.com/anaregdesign/lantern/sdks/go"
 )
 
@@ -120,6 +121,52 @@ func FromVertex(v *client.Vertex) any {
 		return d.String()
 	}
 	return nil
+}
+
+// Native extracts a vertex's stored value as the Go type that round-trips
+// back to the SAME oneof variant when handed to client.PutVertex (via
+// nativeVertex.asVertex). It exists for the value-preserving re-put that
+// backs the touch tool (#543): unlike FromVertex — which stringifies
+// timestamps/durations and promotes JSON strings to structured shapes for
+// MCP *output* — Native preserves the stored kind and width exactly
+// (Int32 stays Int32, Timestamp stays Timestamp), so touching a fact
+// extends its TTL without mutating the value the server holds.
+//
+// A nil vertex and the Vertex_Nil tombstone both return nil, which
+// re-puts as the same present-nil tombstone. Any unknown/unset variant
+// also returns nil rather than erroring: the caller is re-storing a value
+// the server already accepted, so there is nothing to validate.
+func Native(v *client.Vertex) any {
+	if v == nil {
+		return nil
+	}
+	switch x := v.Value.(type) {
+	case *pb.Vertex_Float32:
+		return x.Float32
+	case *pb.Vertex_Float64:
+		return x.Float64
+	case *pb.Vertex_Int32:
+		return x.Int32
+	case *pb.Vertex_Int64:
+		return x.Int64
+	case *pb.Vertex_Uint32:
+		return x.Uint32
+	case *pb.Vertex_Uint64:
+		return x.Uint64
+	case *pb.Vertex_Bool:
+		return x.Bool
+	case *pb.Vertex_String_:
+		return x.String_
+	case *pb.Vertex_Bytes:
+		return x.Bytes
+	case *pb.Vertex_Timestamp:
+		return x.Timestamp.AsTime()
+	case *pb.Vertex_Duration:
+		return x.Duration.AsDuration()
+	default:
+		// Vertex_Nil tombstone or an unset/unknown variant: re-put as nil.
+		return nil
+	}
 }
 
 // SnippetMaxRunes bounds the truncated value preview returned by Snippet.

--- a/mcp/internal/value/value_test.go
+++ b/mcp/internal/value/value_test.go
@@ -1,6 +1,7 @@
 package value
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -8,6 +9,8 @@ import (
 
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	client "github.com/anaregdesign/lantern/sdks/go"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestToSDK_PrimitivesPassThrough(t *testing.T) {
@@ -290,3 +293,75 @@ var errUnsupportedTestType = errInvalidTestType("unsupported test value type")
 type errInvalidTestType string
 
 func (e errInvalidTestType) Error() string { return string(e) }
+
+// TestNative_PreservesKindAndValue proves Native returns, for every oneof
+// variant, the concrete Go type that nativeVertex.asVertex re-encodes back
+// to the SAME variant — so a touch re-put leaves the stored kind and value
+// untouched. This is the contract that distinguishes Native from FromVertex,
+// which deliberately lossily stringifies timestamps/durations for MCP output.
+func TestNative_PreservesKindAndValue(t *testing.T) {
+	ts := time.Date(2031, 2, 3, 4, 5, 6, 0, time.UTC)
+	dur := 90 * time.Minute
+	cases := []struct {
+		name string
+		v    *pb.Vertex
+		want any
+	}{
+		{"float32", &pb.Vertex{Value: &pb.Vertex_Float32{Float32: 1.5}}, float32(1.5)},
+		{"float64", &pb.Vertex{Value: &pb.Vertex_Float64{Float64: 2.5}}, float64(2.5)},
+		{"int32", &pb.Vertex{Value: &pb.Vertex_Int32{Int32: -7}}, int32(-7)},
+		{"int64", &pb.Vertex{Value: &pb.Vertex_Int64{Int64: 42}}, int64(42)},
+		{"uint32", &pb.Vertex{Value: &pb.Vertex_Uint32{Uint32: 9}}, uint32(9)},
+		{"uint64", &pb.Vertex{Value: &pb.Vertex_Uint64{Uint64: 11}}, uint64(11)},
+		{"bool", &pb.Vertex{Value: &pb.Vertex_Bool{Bool: true}}, true},
+		{"string", &pb.Vertex{Value: &pb.Vertex_String_{String_: "warm"}}, "warm"},
+		{"bytes", &pb.Vertex{Value: &pb.Vertex_Bytes{Bytes: []byte{1, 2, 3}}}, []byte{1, 2, 3}},
+		{"timestamp", &pb.Vertex{Value: &pb.Vertex_Timestamp{Timestamp: timestamppb.New(ts)}}, ts},
+		{"duration", &pb.Vertex{Value: &pb.Vertex_Duration{Duration: durationpb.New(dur)}}, dur},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Native(c.v)
+			switch want := c.want.(type) {
+			case []byte:
+				gb, ok := got.([]byte)
+				if !ok || !bytes.Equal(gb, want) {
+					t.Fatalf("Native = %v (%T), want %v ([]byte)", got, got, want)
+				}
+			case time.Time:
+				gt, ok := got.(time.Time)
+				if !ok || !gt.Equal(want) {
+					t.Fatalf("Native = %v (%T), want %v (time.Time)", got, got, want)
+				}
+			default:
+				if got != c.want {
+					t.Fatalf("Native = %v (%T), want %v (%T)", got, got, c.want, c.want)
+				}
+			}
+		})
+	}
+}
+
+// TestNative_StringStaysVerbatim guards the one place Native must NOT behave
+// like FromVertex: a JSON-looking string is returned as a string (not
+// promoted to a map), so re-putting it stores the identical String variant
+// rather than re-encoding a structured shape.
+func TestNative_StringStaysVerbatim(t *testing.T) {
+	v := &pb.Vertex{Value: &pb.Vertex_String_{String_: `{"x":1}`}}
+	got := Native(v)
+	if s, ok := got.(string); !ok || s != `{"x":1}` {
+		t.Fatalf("Native = %v (%T), want verbatim string {\"x\":1}", got, got)
+	}
+}
+
+// TestNative_NilVariantsAreNil confirms both a nil pointer and the present
+// Vertex_Nil tombstone collapse to a Go nil, which re-puts as the same
+// present-nil tombstone.
+func TestNative_NilVariantsAreNil(t *testing.T) {
+	if got := Native(nil); got != nil {
+		t.Fatalf("Native(nil) = %v, want nil", got)
+	}
+	if got := Native(&pb.Vertex{Value: &pb.Vertex_Nil{Nil: true}}); got != nil {
+		t.Fatalf("Native(nil-variant) = %v, want nil", got)
+	}
+}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -261,6 +261,7 @@ func newServer(lc lanternClient, resolver *ttl.Resolver, logger *slog.Logger) *m
 	registerRememberFact(srv, lc, resolver)
 	registerRecallFact(srv, lc)
 	registerSearchFacts(srv, lc)
+	registerTouch(srv, lc, resolver)
 	registerForget(srv, lc)
 	registerListUnder(srv, lc)
 	registerListNamespaces(srv, lc)
@@ -289,5 +290,5 @@ const serverInstructions = "Lantern is your ambient, decaying graph memory. Use 
 	"(1) RECALL FIRST: before answering anything that could depend on remembered context, call recall_fact (exact key), search_facts (substring over keys+values when you recall the topic but not the exact key), recall_related (walk from a seed), recall_relation (read one specific from→to edge's weight and decay), list_under (enumerate a namespace), or list_namespaces (discover which namespaces exist, counts only, no values) to pull in what you already know. " +
 	"(2) ANSWER using what you recalled. " +
 	"(3) CAPTURE AFTER: once the exchange settles, write any new durable facts with remember_fact and any new associations with remember_relation — preferences, decisions, identities, project facts, and how they connect. Capturing is the default, not the exception. " +
-	"Two invariants govern every write: (a) there is no \"forever\" — each write picks a TTL bucket from {seconds, transient, turn, conversation, task, workday, day, week, sprint, month, quarter, durable}; (b) recall does NOT refresh TTL, so to keep a fact alive you must re-remember it when you reference it. Choosing a bucket: ask \"when will this stop being true?\" and \"how bad is it if this lingers past then?\" and pick the SHORTER one. Relations are additive — writing the same relation twice strengthens it, so reinforce associations you keep using. " +
+	"Two invariants govern every write: (a) there is no \"forever\" — each write picks a TTL bucket from {seconds, transient, turn, conversation, task, workday, day, week, sprint, month, quarter, durable}; (b) recall does NOT refresh TTL, so to keep a fact alive you must re-remember it — or touch it to extend its TTL without resupplying the value — when you reference it. Choosing a bucket: ask \"when will this stop being true?\" and \"how bad is it if this lingers past then?\" and pick the SHORTER one. Relations are additive — writing the same relation twice strengthens it, so reinforce associations you keep using. " +
 	"Namespace keys so the graph reads as a mind map: user.* for stable facts about the person (user.preferences.tone, user.identity.role), project.* for the work at hand (project.lantern.stack), session.* for ephemeral working state (session.current-task). Prefer dotted, hierarchical keys; reuse a key to update its value."

--- a/mcp/tool_touch.go
+++ b/mcp/tool_touch.go
@@ -1,0 +1,90 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/anaregdesign/lantern/mcp/internal/ttl"
+	"github.com/anaregdesign/lantern/mcp/internal/value"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// touchInput is the JSON-schema-bearing input for touch. It mirrors the
+// remember_fact TTL bucket enum so the keep-alive horizon is chosen the
+// same way a fresh write would choose one — but there is deliberately no
+// value field: touch never changes what is stored.
+type touchInput struct {
+	Key string `json:"key" jsonschema:"Key of an existing fact to keep alive. Lookup is exact (not prefix); use list_under or search_facts to find the key first if unsure."`
+	TTL string `json:"ttl" jsonschema:"Required new decay horizon (string), applied as now + bucket. Use the SAME 12-bucket ladder as remember_fact; when in doubt pick the SHORTER bucket. Buckets (monotonic): seconds (~30s) | transient (~2m) | turn (~10m) | conversation (~1h) | task (~4h) | workday (~12h) | day (~24h) | week (~7d) | sprint (~14d) | month (~30d) | quarter (~90d) | durable (~180d). There is no 'forever'."`
+}
+
+// touchOutput is the structured result. Found mirrors presence so the LLM
+// can branch without parsing the human-readable Text: a missing key yields
+// {found:false} (a structured result, NOT a tool error), and the TTL
+// fields are populated only when a vertex was actually kept alive.
+type touchOutput struct {
+	Found     bool   `json:"found"`
+	Key       string `json:"key"`
+	Bucket    string `json:"bucket,omitempty"`
+	ExpiresAt string `json:"expires_at,omitempty"`
+	// Capped is true when the bucket's nominal horizon was clamped down to
+	// LANTERN_MCP_MAX_TTL before writing, so the caller knows the new
+	// expiry is shorter than the bucket label implies.
+	Capped bool `json:"capped,omitempty"`
+}
+
+const touchDescription = "Extend a fact's TTL WITHOUT rewriting its value — the cheap keep-alive. Recall does NOT refresh TTL, so when you reference a fact you want to keep, touch it instead of re-supplying its whole value via remember_fact. Touch reads the current value and re-stores it unchanged with a fresh expiry of now + the given bucket. A missing key returns {found=false} (a structured result, NOT a tool error) — touch never creates a fact, so use remember_fact for that. This is the vertex-side keep-alive; the edge-side counterpart is remember_relation, which strengthens an association rather than just keeping it alive."
+
+func registerTouch(srv *mcp.Server, lc lanternClient, r *ttl.Resolver) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "touch",
+		Description: touchDescription,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in touchInput) (*mcp.CallToolResult, touchOutput, error) {
+		if in.Key == "" {
+			return nil, touchOutput{}, fmt.Errorf("touch: key must not be empty")
+		}
+		bucket, err := ttl.ParseBucket(in.TTL)
+		if err != nil {
+			return nil, touchOutput{}, fmt.Errorf("touch: %w", err)
+		}
+
+		v, err := lc.GetVertex(ctx, in.Key)
+		if err != nil {
+			if errors.Is(err, client.ErrNotFound) {
+				out := touchOutput{Found: false, Key: in.Key}
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{&mcp.TextContent{
+						Text: fmt.Sprintf("No fact stored for %q; nothing to touch. Use remember_fact to create it.", in.Key),
+					}},
+				}, out, nil
+			}
+			return nil, touchOutput{}, mapSDKError("touch", err)
+		}
+
+		// Re-store the existing value verbatim with a fresh expiry. value.Native
+		// preserves the stored kind exactly, so the value the server holds is
+		// unchanged — only the TTL advances.
+		d, capped := r.ResolveCapped(bucket)
+		if err := lc.PutVertex(ctx, in.Key, value.Native(v), d); err != nil {
+			return nil, touchOutput{}, mapSDKError("touch", err)
+		}
+
+		out := touchOutput{
+			Found:     true,
+			Key:       in.Key,
+			Bucket:    bucket.String(),
+			ExpiresAt: time.Now().Add(d).UTC().Format(time.RFC3339),
+			Capped:    capped,
+		}
+		text := fmt.Sprintf("Touched %q (bucket=%s, expires≈%s); value unchanged.", out.Key, out.Bucket, out.ExpiresAt)
+		if capped {
+			text += fmt.Sprintf(" Note: TTL clamped to the server cap (%s); touch again before it expires to keep the fact alive.", d)
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: text}},
+		}, out, nil
+	})
+}

--- a/mcp/tool_touch_test.go
+++ b/mcp/tool_touch_test.go
@@ -1,0 +1,180 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+// TestTouch_ExtendsTTLValueUnchanged is the core acceptance case (#543): an
+// existing fact is re-stored with a fresh expiry and the SAME value, and the
+// result reports found=true with the new bucket/expiry.
+func TestTouch_ExtendsTTLValueUnchanged(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.getVertexFn = func(_ context.Context, _ string) (*client.Vertex, error) {
+		return &pb.Vertex{Key: "session.mode", Value: &pb.Vertex_String_{String_: "record-while-chatting"}}, nil
+	}
+	res := h.call(t, "touch", map[string]any{"key": "session.mode", "ttl": "day"})
+	if res.IsError {
+		t.Fatalf("IsError = true, text=%q", contentText(res))
+	}
+	if h.fake.lastGetKey != "session.mode" {
+		t.Fatalf("GetVertex key = %q, want session.mode", h.fake.lastGetKey)
+	}
+	if h.fake.putVertexCalls != 1 {
+		t.Fatalf("PutVertex calls = %d, want 1", h.fake.putVertexCalls)
+	}
+	if h.fake.lastPutKey != "session.mode" {
+		t.Fatalf("lastPutKey = %q, want session.mode", h.fake.lastPutKey)
+	}
+	if h.fake.lastPutValue != "record-while-chatting" {
+		t.Fatalf("lastPutValue = %v (%T), want value preserved verbatim", h.fake.lastPutValue, h.fake.lastPutValue)
+	}
+	if h.fake.lastPutTTL != 24*time.Hour {
+		t.Fatalf("lastPutTTL = %v, want day=24h", h.fake.lastPutTTL)
+	}
+	var out touchOutput
+	structuredAs(t, res, &out)
+	if !out.Found {
+		t.Fatalf("Found = false, want true; out=%+v", out)
+	}
+	if out.Key != "session.mode" || out.Bucket != "day" {
+		t.Fatalf("output mismatch: %+v", out)
+	}
+	if out.ExpiresAt == "" {
+		t.Fatalf("ExpiresAt should be populated; out=%+v", out)
+	}
+	if !strings.Contains(contentText(res), "value unchanged") {
+		t.Fatalf("result text should state the value is unchanged; got %q", contentText(res))
+	}
+}
+
+// TestTouch_PreservesNonStringKind proves value.Native keeps the stored kind
+// exactly: touching an Int32 fact re-puts an int32 (not a widened int64 or a
+// stringified form), so the server's value is byte-for-byte unchanged.
+func TestTouch_PreservesNonStringKind(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.getVertexFn = func(_ context.Context, _ string) (*client.Vertex, error) {
+		return &pb.Vertex{Key: "k", Value: &pb.Vertex_Int32{Int32: -7}}, nil
+	}
+	res := h.call(t, "touch", map[string]any{"key": "k", "ttl": "week"})
+	if res.IsError {
+		t.Fatalf("IsError = true, text=%q", contentText(res))
+	}
+	got, ok := h.fake.lastPutValue.(int32)
+	if !ok || got != -7 {
+		t.Fatalf("lastPutValue = %v (%T), want int32(-7) preserved", h.fake.lastPutValue, h.fake.lastPutValue)
+	}
+}
+
+// TestTouch_PreservesNilTombstone confirms touching a present-nil tombstone
+// keeps it alive: GetVertex returns the Vertex_Nil variant (found, not
+// missing), and touch re-puts a nil value rather than treating it as absent.
+func TestTouch_PreservesNilTombstone(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.getVertexFn = func(_ context.Context, _ string) (*client.Vertex, error) {
+		return &pb.Vertex{Key: "k", Value: &pb.Vertex_Nil{Nil: true}}, nil
+	}
+	res := h.call(t, "touch", map[string]any{"key": "k", "ttl": "turn"})
+	if res.IsError {
+		t.Fatalf("IsError = true, text=%q", contentText(res))
+	}
+	if h.fake.putVertexCalls != 1 {
+		t.Fatalf("PutVertex calls = %d, want 1 (tombstone kept alive)", h.fake.putVertexCalls)
+	}
+	if h.fake.lastPutValue != nil {
+		t.Fatalf("lastPutValue = %v (%T), want nil", h.fake.lastPutValue, h.fake.lastPutValue)
+	}
+	var out touchOutput
+	structuredAs(t, res, &out)
+	if !out.Found {
+		t.Fatalf("Found = false, want true for a present tombstone; out=%+v", out)
+	}
+}
+
+// TestTouch_MissingKeyIsStructured proves a missing key is a structured
+// {found:false} result, NOT a tool error, and that no write is attempted.
+func TestTouch_MissingKeyIsStructured(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.getVertexFn = func(_ context.Context, _ string) (*client.Vertex, error) {
+		return nil, client.ErrNotFound
+	}
+	res := h.call(t, "touch", map[string]any{"key": "nope", "ttl": "day"})
+	if res.IsError {
+		t.Fatalf("missing key should be a structured result, not a tool error: %q", contentText(res))
+	}
+	if h.fake.putVertexCalls != 0 {
+		t.Fatalf("PutVertex should NOT be called for a missing key; calls=%d", h.fake.putVertexCalls)
+	}
+	var out touchOutput
+	structuredAs(t, res, &out)
+	if out.Found {
+		t.Fatalf("Found = true, want false; out=%+v", out)
+	}
+	if out.Key != "nope" {
+		t.Fatalf("Key = %q, want nope", out.Key)
+	}
+}
+
+func TestTouch_RejectsEmptyKey(t *testing.T) {
+	h := newTestHarness(t)
+	h.callExpectError(t, "touch", map[string]any{"key": "", "ttl": "day"})
+	if h.fake.putVertexCalls != 0 {
+		t.Fatalf("PutVertex should not be called; calls=%d", h.fake.putVertexCalls)
+	}
+}
+
+func TestTouch_RejectsUnknownBucket(t *testing.T) {
+	h := newTestHarness(t)
+	h.callExpectError(t, "touch", map[string]any{"key": "k", "ttl": "forever"})
+	if h.fake.putVertexCalls != 0 {
+		t.Fatalf("PutVertex should not be called; calls=%d", h.fake.putVertexCalls)
+	}
+}
+
+// TestTouch_TTLCappedToMaxTTL proves the keep-alive horizon honours the same
+// LANTERN_MCP_MAX_TTL clamp as remember_fact (#537): an over-cap bucket is
+// shortened before the write and the result reports capped=true.
+func TestTouch_TTLCappedToMaxTTL(t *testing.T) {
+	h := newTestHarnessWith(t, mustCappedResolver(t, "24h"))
+	h.fake.getVertexFn = func(_ context.Context, _ string) (*client.Vertex, error) {
+		return &pb.Vertex{Key: "user.identity.role", Value: &pb.Vertex_String_{String_: "architect"}}, nil
+	}
+	res := h.call(t, "touch", map[string]any{"key": "user.identity.role", "ttl": "durable"})
+	if res.IsError {
+		t.Fatalf("IsError = true, text=%q", contentText(res))
+	}
+	if h.fake.lastPutTTL != 24*time.Hour {
+		t.Fatalf("lastPutTTL = %v, want clamped 24h", h.fake.lastPutTTL)
+	}
+	var out touchOutput
+	structuredAs(t, res, &out)
+	if !out.Capped {
+		t.Fatalf("output Capped = false, want true; out=%+v", out)
+	}
+	if out.Bucket != "durable" {
+		t.Fatalf("output Bucket = %q, want durable (label preserved)", out.Bucket)
+	}
+	if !strings.Contains(contentText(res), "clamped") {
+		t.Fatalf("result text should mention the clamp; got %q", contentText(res))
+	}
+}
+
+// TestTouchDescription_FramesKeepAlive guards the description's job: it must
+// teach that touch extends TTL without rewriting the value and that recall
+// does not refresh TTL (the motivation), and that it never creates a fact.
+func TestTouchDescription_FramesKeepAlive(t *testing.T) {
+	if !strings.Contains(touchDescription, "does NOT refresh") {
+		t.Errorf("touchDescription should cite the recall-does-not-refresh motivation: %q", touchDescription)
+	}
+	if !strings.Contains(touchDescription, "without rewriting") && !strings.Contains(touchDescription, "keep-alive") {
+		t.Errorf("touchDescription should frame touch as the value-preserving keep-alive: %q", touchDescription)
+	}
+	if !strings.Contains(touchDescription, "found=false") {
+		t.Errorf("touchDescription should document the missing-key {found=false} contract: %q", touchDescription)
+	}
+}


### PR DESCRIPTION
## Summary
Adds `touch(key, ttl)` — the cheap **vertex-side keep-alive**: it extends a fact's TTL to `now + bucket` **without rewriting the value**. Recall does not refresh TTL, so keeping a fact alive previously required re-`remember_fact`-ing it with the entire value resupplied. `touch` reads the current value and re-stores it verbatim with a fresh expiry.

Closes #543.

## What changed
- **New tool `touch`** (`mcp/tool_touch.go`): `GetVertex` → re-`PutVertex` same value + `now + bucket`. Missing key → `{found:false}` structured result (NOT a tool error); `touch` never creates a fact. Honours the `LANTERN_MCP_MAX_TTL` clamp (reuses `ResolveCapped` from #537) and reports `capped=true` when shortened.
- **New `value.Native` extractor** (`mcp/internal/value/value.go`): returns, per proto oneof variant, the Go type that `nativeVertex.asVertex` re-encodes back to the **same** variant — so kind and width are preserved exactly (`Int32` stays `Int32`, `Timestamp` stays `Timestamp`, a JSON-looking string stays a string). This is the deliberate counterpart to `FromVertex`, which lossily stringifies timestamps/durations for MCP *output*.
- **Registration + prompt**: registered in `newServer`; the `serverInstructions` keep-alive invariant now names `touch` as the value-preserving alternative to re-remember.
- **Docs**: README tool table gains a `touch` row; replaced the brittle hard-coded "Six tools" intro.

## Acceptance criteria (#543)
- [x] `touch(key, "day")` extends expiry; value unchanged; missing key → `{found:false}` (not an error).
- [x] Tests assert value preserved (incl. non-string kind + nil tombstone) and expiry advanced.

## Tests
- `mcp/tool_touch_test.go`: extends-TTL-value-unchanged, preserves-non-string-kind (`Int32`), preserves-nil-tombstone, missing-key-structured, rejects-empty-key, rejects-unknown-bucket, TTL-capped-to-max, description framing.
- `mcp/internal/value/value_test.go`: `Native` kind/value matrix across all oneof variants, JSON-string-stays-verbatim, nil-variants.

## Local gate
`gofmt` clean · `mcp` vet+test · root `go test ./...` · `core` / `pb` / `sdks/go` / `server` all green.
