### PR TITLE
feat(mcp): non-blocking key linting on remember_fact / remember_facts

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -182,6 +182,31 @@ count and **no values** — the cheap way to learn the schema of memory.
   ceiling is hit, `truncated` is `true` (counts become lower bounds) and
   `suggestion` advises narrowing.
 
+### Non-blocking key linting on `remember_fact` / `remember_facts`
+
+Key quality decides whether a fact can later be recalled: a well-shaped key
+round-trips through all three recall surfaces (exact `recall_fact`, prefix
+`list_under`, substring `search_facts`), while a sloppy one is silently
+accepted and only hurts later. To teach the conventions without ever breaking
+a write, both `remember_fact` and every item of `remember_facts` run a shared
+**non-blocking** key linter (`lintKey`). The fact is **always stored**; when
+the key violates a convention the result simply carries a `warnings[]` field
+(per item, on the batch path) with actionable hints. A clean key yields no
+`warnings`.
+
+| Rule | Fires when | Why it hurts recall |
+|---|---|---|
+| Whitespace | the key contains any space/tab | Awkward to reproduce verbatim for exact `recall_fact`; reads oddly in scans. |
+| Unrecognized scope head | the first segment isn't `session` / `task` / `project` / `user` | A scope head keeps memory organized and predictable to address. |
+| High-cardinality token mid-key | a date, UUID, or 6+ digit run sits in any segment **except the leaf** | Per-write tokens in the middle fragment the prefix tree that `list_under` / `search_facts` walk. A date/UUID is fine **as the leaf** (a unique event id). |
+| Free-text leaf | the final segment has more than 3 alphabetic words | A descriptive phrase is hard to reconstruct exactly; prefer a concise canonical leaf. Pure-numeric tokens (a trailing date) don't count. |
+| Excessive depth | the key has more than 5 dot-delimited segments | Deep nesting is hard to recall and address. |
+
+Linting is advisory by design — it never rejects a key, so it nudges toward
+the documented namespacing without the friction of a hard failure. (Hard
+validation errors — an empty key, an unknown TTL bucket, an unencodable value
+— are separate and *do* reject the write.)
+
 ## Environment reference
 
 | Variable | Default | Purpose |

--- a/mcp/lint.go
+++ b/mcp/lint.go
@@ -1,0 +1,122 @@
+package mcp
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// maxKeyDepth is the advisory ceiling on dot-delimited key segments. Keys
+// deeper than this still store, but lintKey nudges toward flatter namespaces
+// that are easier to recall and scan.
+const maxKeyDepth = 5
+
+// maxLeafWords is the advisory ceiling on alphabetic words in the final key
+// segment. A leaf with more words than this reads like free text, which is
+// hard to reconstruct verbatim for an exact recall_fact.
+const maxLeafWords = 3
+
+// recognizedScopes are the namespace heads the memory instructions teach
+// (session.* / task.* / project.* / user.*). A key whose first segment is not
+// one of these gets an advisory nudge toward a scope head.
+var recognizedScopes = map[string]struct{}{
+	"session": {},
+	"task":    {},
+	"project": {},
+	"user":    {},
+}
+
+var (
+	// isoDateRe matches an ISO calendar date embedded anywhere in a segment.
+	isoDateRe = regexp.MustCompile(`\d{4}-\d{2}-\d{2}`)
+	// longDigitRe matches a run of 6+ digits (YYYYMMDD, epochs, counters).
+	longDigitRe = regexp.MustCompile(`\d{6,}`)
+	// uuidRe matches a canonical UUID embedded anywhere in a segment.
+	uuidRe = regexp.MustCompile(`(?i)[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+)
+
+// lintKey returns advisory, non-blocking warnings about a memory key's shape.
+// It NEVER rejects a key: the caller always stores the fact and surfaces these
+// hints alongside the result, so the model learns the conventions for the
+// three recall surfaces (exact recall_fact, prefix list_under, substring
+// search_facts) without ever breaking a write.
+//
+// The same helper backs both remember_fact (singular) and each item of
+// remember_facts (batch) so the guidance is identical across both surfaces.
+func lintKey(key string) []string {
+	var warnings []string
+
+	// Rule: no whitespace. Spaces make a key awkward to type back verbatim
+	// for exact recall and read oddly in prefix scans.
+	if strings.ContainsFunc(key, unicode.IsSpace) {
+		warnings = append(warnings,
+			`key contains whitespace; use dot-delimited segments without spaces (e.g. "user.preferences.tone")`)
+	}
+
+	// strings.Split always returns at least one element, so segments[0] and
+	// the leaf access below are safe even for a degenerate key.
+	segments := strings.Split(key, ".")
+
+	// Rule: recognized scope head.
+	if _, ok := recognizedScopes[segments[0]]; !ok {
+		warnings = append(warnings, fmt.Sprintf(
+			`first segment %q is not a recognized scope (session, task, project, user); a scope head keeps memory organized`,
+			segments[0]))
+	}
+
+	// Rule: high-cardinality token (date / UUID / long digit run) outside the
+	// leaf. Such a token in a non-final segment fragments the prefix tree that
+	// list_under and search_facts walk; it belongs in the leaf if anywhere.
+	if len(segments) > 1 {
+		for _, seg := range segments[:len(segments)-1] {
+			if isHighCardinality(seg) {
+				warnings = append(warnings, fmt.Sprintf(
+					`high-cardinality token %q is not the final segment; dates/UUIDs mid-key fragment prefix scans — move them to the leaf`,
+					seg))
+				break
+			}
+		}
+	}
+
+	// Rule: free-text / multi-word leaf.
+	leaf := segments[len(segments)-1]
+	if leafWordCount(leaf) > maxLeafWords {
+		warnings = append(warnings, fmt.Sprintf(
+			`leaf %q reads like free text (%d+ words); a concise canonical leaf is easier to reconstruct for exact recall`,
+			leaf, maxLeafWords+1))
+	}
+
+	// Rule: excessive depth.
+	if len(segments) > maxKeyDepth {
+		warnings = append(warnings, fmt.Sprintf(
+			"key has %d segments; deep nesting is hard to recall — prefer %d or fewer",
+			len(segments), maxKeyDepth))
+	}
+
+	return warnings
+}
+
+// isHighCardinality reports whether a single key segment contains a date,
+// UUID, or long digit run — tokens that vary per write and so bloat a prefix
+// tree if they sit anywhere but the leaf.
+func isHighCardinality(seg string) bool {
+	return uuidRe.MatchString(seg) || isoDateRe.MatchString(seg) || longDigitRe.MatchString(seg)
+}
+
+// leafWordCount counts alphabetic words in a leaf, splitting on hyphen,
+// underscore, and whitespace. Pure-numeric tokens (e.g. a trailing date's
+// 2026 / 06 / 10) are NOT counted, so an immutable-event leaf that ends in a
+// date is not mistaken for free text.
+func leafWordCount(leaf string) int {
+	tokens := strings.FieldsFunc(leaf, func(r rune) bool {
+		return r == '-' || r == '_' || unicode.IsSpace(r)
+	})
+	n := 0
+	for _, tok := range tokens {
+		if strings.ContainsFunc(tok, unicode.IsLetter) {
+			n++
+		}
+	}
+	return n
+}

--- a/mcp/lint_test.go
+++ b/mcp/lint_test.go
@@ -1,0 +1,111 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLintKey_GoodKeysReturnNoWarnings is the back-stop for the acceptance
+// criterion "good keys return no warnings": the canonical namespace shapes the
+// memory instructions teach must lint clean.
+func TestLintKey_GoodKeysReturnNoWarnings(t *testing.T) {
+	good := []string{
+		"user.preferences.tone",
+		"user.identity.role",
+		"project.lantern.stack",
+		"session.current-task",
+		"task.today.focus",
+		"user.tone",
+		"session.cursor",
+		// An immutable-event leaf may legitimately end in a date.
+		"session.filed-issues-2026-06-10",
+	}
+	for _, key := range good {
+		if w := lintKey(key); len(w) != 0 {
+			t.Errorf("lintKey(%q) = %v, want no warnings", key, w)
+		}
+	}
+}
+
+func TestLintKey_FlagsWhitespace(t *testing.T) {
+	w := lintKey("user.full name")
+	if !hasWarningContaining(w, "whitespace") {
+		t.Fatalf("lintKey should flag whitespace; got %v", w)
+	}
+	if len(w) != 1 {
+		t.Errorf("expected exactly the whitespace warning, got %v", w)
+	}
+}
+
+func TestLintKey_FlagsMidKeyDate(t *testing.T) {
+	w := lintKey("user.2026-06-10.note")
+	if !hasWarningContaining(w, "high-cardinality") {
+		t.Fatalf("lintKey should flag a mid-key date; got %v", w)
+	}
+	if len(w) != 1 {
+		t.Errorf("expected only the high-cardinality warning, got %v", w)
+	}
+}
+
+func TestLintKey_FlagsMidKeyUUID(t *testing.T) {
+	w := lintKey("user.550e8400-e29b-41d4-a716-446655440000.note")
+	if !hasWarningContaining(w, "high-cardinality") {
+		t.Fatalf("lintKey should flag a mid-key UUID; got %v", w)
+	}
+}
+
+func TestLintKey_FlagsMidKeyLongDigitRun(t *testing.T) {
+	w := lintKey("user.20260610.note")
+	if !hasWarningContaining(w, "high-cardinality") {
+		t.Fatalf("lintKey should flag a mid-key digit run; got %v", w)
+	}
+}
+
+func TestLintKey_AllowsDateInLeaf(t *testing.T) {
+	// A high-cardinality token IS allowed as the final segment (unique event).
+	w := lintKey("session.run-2026-06-10")
+	if hasWarningContaining(w, "high-cardinality") {
+		t.Fatalf("a date in the leaf must NOT be flagged; got %v", w)
+	}
+}
+
+func TestLintKey_FlagsFreeTextLeaf(t *testing.T) {
+	w := lintKey("user.notes.this-is-a-long-free-text-leaf")
+	if !hasWarningContaining(w, "free text") {
+		t.Fatalf("lintKey should flag a multi-word leaf; got %v", w)
+	}
+}
+
+func TestLintKey_FlagsExcessiveDepth(t *testing.T) {
+	w := lintKey("user.a.b.c.d.e.f")
+	if !hasWarningContaining(w, "segments") {
+		t.Fatalf("lintKey should flag excessive depth; got %v", w)
+	}
+}
+
+func TestLintKey_FlagsUnrecognizedScope(t *testing.T) {
+	w := lintKey("topic.lantern.note")
+	if !hasWarningContaining(w, "recognized scope") {
+		t.Fatalf("lintKey should flag a missing scope head; got %v", w)
+	}
+	if len(w) != 1 {
+		t.Errorf("expected only the scope warning, got %v", w)
+	}
+}
+
+func TestLintKey_AccumulatesMultipleWarnings(t *testing.T) {
+	// Unrecognized scope + mid-key date + whitespace + free-text leaf, at once.
+	w := lintKey("topic.2026-06-10.free text leaf here")
+	if len(w) < 4 {
+		t.Fatalf("expected several warnings for a key that breaks multiple rules; got %v", w)
+	}
+}
+
+func hasWarningContaining(warnings []string, substr string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/mcp/tool_remember_fact.go
+++ b/mcp/tool_remember_fact.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/anaregdesign/lantern/mcp/internal/ttl"
@@ -27,6 +28,9 @@ type rememberFactOutput struct {
 	// LANTERN_MCP_MAX_TTL before writing, so the caller knows the stored
 	// expiry is shorter than the bucket label implies.
 	Capped bool `json:"capped,omitempty"`
+	// Warnings carries advisory, non-blocking key-quality hints from lintKey.
+	// The fact is always stored; these only teach better key conventions.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 const rememberFactDescription = "Store a fact in Lantern with a required TTL bucket. Call this PROACTIVELY whenever the user states a durable preference, decision, identity, or project fact — you do not need to be asked. The value can be any JSON-encodable shape (string, number, bool, object, array). Use a dotted namespaced key (user.* / project.* / session.*). Writing the same key again overwrites the previous value and resets the TTL — that is the canonical way to refresh a fact since recall does NOT refresh."
@@ -56,10 +60,14 @@ func registerRememberFact(srv *mcp.Server, lc lanternClient, r *ttl.Resolver) {
 			Bucket:    bucket.String(),
 			ExpiresAt: time.Now().Add(d).UTC().Format(time.RFC3339),
 			Capped:    capped,
+			Warnings:  lintKey(in.Key),
 		}
 		text := fmt.Sprintf("Stored %q (bucket=%s, expires≈%s).", out.Key, out.Bucket, out.ExpiresAt)
 		if capped {
 			text += fmt.Sprintf(" Note: TTL clamped to the server cap (%s); re-remember before it expires to keep the fact alive.", d)
+		}
+		if len(out.Warnings) > 0 {
+			text += fmt.Sprintf(" Key hint(s): %s", strings.Join(out.Warnings, " "))
 		}
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{

--- a/mcp/tool_remember_fact_test.go
+++ b/mcp/tool_remember_fact_test.go
@@ -141,3 +141,48 @@ func TestRememberFact_UnderCapNotClamped(t *testing.T) {
 		t.Fatalf("output Capped = true, want false for under-cap bucket; out=%+v", out)
 	}
 }
+
+// TestRememberFact_LintsBadKeyButStillStores proves the non-blocking key lint
+// (#551): a key that violates conventions is STILL written (PutVertex called)
+// and the advisory warnings ride along in the structured output and the text.
+func TestRememberFact_LintsBadKeyButStillStores(t *testing.T) {
+	h := newTestHarness(t)
+	res := h.call(t, "remember_fact", map[string]any{
+		"key":   "topic.2026-06-10.note", // unrecognized scope + mid-key date
+		"value": "v",
+		"ttl":   "day",
+	})
+	if res.IsError {
+		t.Fatalf("a lint warning must NOT block the write; text=%q", contentText(res))
+	}
+	if h.fake.putVertexCalls != 1 {
+		t.Fatalf("PutVertex calls = %d, want 1 (lint is non-blocking)", h.fake.putVertexCalls)
+	}
+	var out rememberFactOutput
+	structuredAs(t, res, &out)
+	if len(out.Warnings) == 0 {
+		t.Fatalf("expected key warnings in output; got none: %+v", out)
+	}
+	if !strings.Contains(contentText(res), "hint") {
+		t.Errorf("result text should surface the key hint(s); got %q", contentText(res))
+	}
+}
+
+// TestRememberFact_GoodKeyHasNoWarnings is the output-level back-stop for the
+// "good keys return no warnings" criterion.
+func TestRememberFact_GoodKeyHasNoWarnings(t *testing.T) {
+	h := newTestHarness(t)
+	res := h.call(t, "remember_fact", map[string]any{
+		"key":   "user.preferences.tone",
+		"value": "warm",
+		"ttl":   "conversation",
+	})
+	if res.IsError {
+		t.Fatalf("IsError = true, text=%q", contentText(res))
+	}
+	var out rememberFactOutput
+	structuredAs(t, res, &out)
+	if len(out.Warnings) != 0 {
+		t.Fatalf("canonical key should lint clean; got warnings %v", out.Warnings)
+	}
+}

--- a/mcp/tool_remember_facts.go
+++ b/mcp/tool_remember_facts.go
@@ -38,6 +38,9 @@ type rememberFactsResult struct {
 	// Capped is true when this item's bucket horizon was clamped down to
 	// LANTERN_MCP_MAX_TTL before writing.
 	Capped bool `json:"capped,omitempty"`
+	// Warnings carries advisory, non-blocking key-quality hints from lintKey
+	// for THIS item's key. Independent of the storage outcome.
+	Warnings []string `json:"warnings,omitempty"`
 	// Error carries the failure cause on the first non-committed item.
 	Error string `json:"error,omitempty"`
 }
@@ -91,6 +94,7 @@ func registerRememberFacts(srv *mcp.Server, lc lanternClient, r *ttl.Resolver) {
 				Bucket:    bucket.String(),
 				ExpiresAt: exp.UTC().Format(time.RFC3339),
 				Capped:    capped,
+				Warnings:  lintKey(it.Key),
 			}
 		}
 		if len(verrs) > 0 {

--- a/mcp/tool_remember_facts_test.go
+++ b/mcp/tool_remember_facts_test.go
@@ -187,3 +187,30 @@ func TestRememberFactsDescription_FramesBatch(t *testing.T) {
 		t.Errorf("description should promise per-item partial-failure reporting: %q", rememberFactsDescription)
 	}
 }
+
+// TestRememberFacts_LintsPerItemKey proves the non-blocking key lint (#551)
+// runs per batch item: a bad key is still stored but its result row carries
+// warnings, while a good key in the same call stays clean.
+func TestRememberFacts_LintsPerItemKey(t *testing.T) {
+	h := newTestHarness(t)
+	res := h.call(t, "remember_facts", map[string]any{
+		"items": []map[string]any{
+			{"key": "user.preferences.tone", "value": "warm", "ttl": "day"}, // clean
+			{"key": "topic.2026-06-10.note", "value": "v", "ttl": "day"},    // bad scope + mid-key date
+		},
+	})
+	if res.IsError {
+		t.Fatalf("a lint warning must NOT block the batch; content=%s", contentText(res))
+	}
+	var out rememberFactsOutput
+	structuredAs(t, res, &out)
+	if out.Stored != 2 {
+		t.Fatalf("both items should still store; stored=%d", out.Stored)
+	}
+	if len(out.Results[0].Warnings) != 0 {
+		t.Errorf("clean key should have no warnings; got %v", out.Results[0].Warnings)
+	}
+	if len(out.Results[1].Warnings) == 0 {
+		t.Errorf("bad key should carry warnings; got none in %+v", out.Results[1])
+	}
+}


### PR DESCRIPTION
## What

Adds **non-blocking key linting** to `remember_fact` and the batch
`remember_facts`. A shared `lintKey` helper inspects the key shape and returns
advisory `warnings[]`; the fact is **always stored**. Good keys lint clean.

Closes #551.

## Why

Key quality decides whether a fact can later be recalled across the three
recall surfaces (exact `recall_fact`, prefix `list_under`, substring
`search_facts`). Poor keys were silently accepted and only hurt later. Linting
teaches the conventions without the friction of a hard failure.

## Rules (all advisory — never reject the write)

| Rule | Fires when |
|---|---|
| Whitespace | the key contains any space/tab |
| Unrecognized scope head | first segment ∉ {`session`,`task`,`project`,`user`} |
| High-cardinality token mid-key | a date / UUID / 6+ digit run sits in any segment **except the leaf** |
| Free-text leaf | the final segment has > 3 alphabetic words (pure-numeric tokens like a trailing date don't count) |
| Excessive depth | > 5 dot-delimited segments |

A date/UUID **as the leaf** is allowed (unique event id). Hard validation
errors (empty key, unknown bucket, unencodable value) are unchanged and still
reject the write.

## Surfaces

- `lintKey(key string) []string` in new [mcp/lint.go](mcp/lint.go) — the single
  helper both paths call, per the #540 finding (lint must cover singular **and**
  each batch item).
- `rememberFactOutput.Warnings` (+ appended to the text content).
- `rememberFactsResult.Warnings` (per-item, independent of storage outcome).
- README: new "Non-blocking key linting" subsection with the rule table +
  rationale.

## Tests

- `mcp/lint_test.go`: one test per rule, plus canonical good keys lint clean,
  a date-in-leaf is allowed, and a multi-rule key accumulates warnings.
- `tool_remember_fact_test.go`: bad key still stores + surfaces warnings; good
  key has none.
- `tool_remember_facts_test.go`: per-item lint (clean + bad in one batch).

## Acceptance criteria

- [x] Bad keys are stored but return `warnings[]`.
- [x] Good keys return no warnings.
- [x] Rules + rationale documented in `mcp/README.md`.
- [x] Tests per rule.

## Local gate

`gofmt` clean · `mcp` vet + tests green · root `go test ./...` green ·
core / pb / sdks-go / server all green.
