### PR TITLE
feat(mcp): opt-in reinforce-on-recall (Hebbian edge strengthening)

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -82,7 +82,7 @@ from the source so the LLM and the human reader see the same contract.
 | `list_namespaces` | Discover the **shape** of the key space: return the distinct child namespace segments under a prefix, each with a count of facts beneath it, and **no values**. An empty prefix (allowed here, unlike `list_under`) lists top-level namespaces; `depth` controls how many dot-delimited segments deep to aggregate (default 1). Does NOT refresh TTL. |
 | `remember_relation` | Add (or reinforce) a directed relation from one fact to another. **Additive** — writing the same relation twice strengthens it; this is the Hebbian primitive. Returns the resulting `accumulated_weight` (distinct from this write's `increment`) so you can observe an association getting stronger. |
 | `remember_relations` | Add (or reinforce) **several directed relations in one call** — the batch counterpart to `remember_relation`. Pass `edges[]`, each with `from`, `to`, TTL, and optional `weight`. **Additive**, so a PARTIAL failure must be resumed with only the edges that did not commit (resending a committed edge double-counts). For efficiency the batch path does NOT read back `accumulated_weight` — use `remember_relation` / `recall_relation` for that. |
-| `recall_related` | Walk the graph from a seed key with `step`, `k`, a `direction` (`out` default — forward BFS over out-edges; `in` — the seed's direct predecessors, so seeding a pure sink is no longer empty; `both` — union), and three orthogonal axes (`algorithm` ∈ `none` / `mst` / `spt`, `objective` ∈ `min` / `max`, `weighting` ∈ `raw` / `tfidf`; see #410). Returns related facts with cumulative weights. Reverse predecessors carry `key` + `weight` only (no payload — call `recall_fact`); the reverse scan is bounded and sets `truncated` when it stops early. Does NOT refresh TTL. |
+| `recall_related` | Walk the graph from a seed key with `step`, `k`, a `direction` (`out` default — forward BFS over out-edges; `in` — the seed's direct predecessors, so seeding a pure sink is no longer empty; `both` — union), and three orthogonal axes (`algorithm` ∈ `none` / `mst` / `spt`, `objective` ∈ `min` / `max`, `weighting` ∈ `raw` / `tfidf`; see #410). Returns related facts with cumulative weights. Reverse predecessors carry `key` + `weight` only (no payload — call `recall_fact`); the reverse scan is bounded and sets `truncated` when it stops early. Read-only by default; pass `reinforce=true` to add a decaying weight pulse to the edges it traverses (opt-in — see below). |
 | `recall_relation` | Read a **single** directed edge by its exact `(from, to)` endpoints, returning its current accumulated `weight` and `expires_at`. The per-edge counterpart to `recall_related` (which sums all incoming edges into a node-level score). Returns `{found=false}` for a missing or fully-decayed edge (structured result, not a tool error). Direction matters: `from→to` only. Does NOT refresh TTL or weight. |
 
 A `ping` tool also exists so operators can sanity-check the wire without
@@ -206,6 +206,37 @@ Linting is advisory by design — it never rejects a key, so it nudges toward
 the documented namespacing without the friction of a hard failure. (Hard
 validation errors — an empty key, an unknown TTL bucket, an unencodable value
 — are separate and *do* reject the write.)
+
+### Reinforce-on-recall with `recall_related`
+
+Recall is **read-only by default**: walking the graph does not refresh the
+TTL of any vertex or edge it touches (the single most-violated invariant —
+weak relations are supposed to decay). `recall_related` accepts an opt-in
+`reinforce` flag that makes a *use-strengthens-memory* exception for the
+edges the walk actually traverses — the Hebbian, edge-side analog of `touch`
+(which keeps a single vertex alive). It is **off unless you ask for it**.
+
+| Argument | Default | Effect |
+|---|---|---|
+| `reinforce` | `false` | When `true`, every edge traversed by this walk receives an additive weight pulse. `false` keeps the call purely read-only. |
+| `reinforce_weight` | `1.0` | The weight added to each traversed edge. Additive — it stacks on the edge's existing weight. |
+| `reinforce_ttl` | `conversation` | The decay horizon of the pulse, from the same 12-bucket ladder as `remember_*` (clamped by `LANTERN_MCP_MAX_TTL`, so a clamp sets `reinforce_capped`). |
+
+Because the store keeps **every contribution as an independent
+`(weight, expiration)` pulse** and an edge's life is its *latest*
+contribution's expiry, a reinforcement **never shortens** an edge — a short
+`reinforce_ttl` simply adds a pulse that itself fades on that horizon while
+leaving any longer-lived contribution untouched. Frequent use stacks pulses
+(sustained strength and a continually-extended life); sporadic use lets them
+fade back to baseline. This is exactly the "use it or lose it" loop.
+
+Reinforcement is a **best-effort side effect**: the recall result is produced
+first and is never failed by a reinforcement write that does not land. The
+result reports `reinforced` (how many traversed edges were bumped); to read an
+edge's resulting `accumulated_weight`, call `recall_relation` (the hot recall
+path deliberately skips a per-edge read-back). `reinforce` works for every
+`direction` — it bumps the forward-walk edges for `out`, the predecessor edges
+for `in`, and the union for `both`.
 
 ## Environment reference
 

--- a/mcp/fake_lantern_test.go
+++ b/mcp/fake_lantern_test.go
@@ -46,6 +46,7 @@ type fakeLantern struct {
 	lastPutVertices []client.VertexInput
 
 	// AddEdge
+	addEdgeFn      func(ctx context.Context, tail, head string, weight float32, ttl time.Duration) error
 	addEdgeErr     error
 	lastEdgeTail   string
 	lastEdgeHead   string
@@ -144,12 +145,15 @@ func (f *fakeLantern) AddEdges(ctx context.Context, inputs []client.EdgeInput) e
 	return nil
 }
 
-func (f *fakeLantern) AddEdge(_ context.Context, tail, head string, weight float32, ttl time.Duration) error {
+func (f *fakeLantern) AddEdge(ctx context.Context, tail, head string, weight float32, ttl time.Duration) error {
 	f.addEdgeCalls++
 	f.lastEdgeTail = tail
 	f.lastEdgeHead = head
 	f.lastEdgeWeight = weight
 	f.lastEdgeTTL = ttl
+	if f.addEdgeFn != nil {
+		return f.addEdgeFn(ctx, tail, head, weight, ttl)
+	}
 	return f.addEdgeErr
 }
 

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -269,7 +269,7 @@ func newServer(lc lanternClient, resolver *ttl.Resolver, logger *slog.Logger) *m
 	registerListNamespaces(srv, lc)
 	registerRememberRelation(srv, lc, resolver)
 	registerRememberRelations(srv, lc, resolver)
-	registerRecallRelated(srv, lc)
+	registerRecallRelated(srv, lc, resolver)
 	registerRecallRelation(srv, lc)
 
 	return srv
@@ -293,5 +293,5 @@ const serverInstructions = "Lantern is your ambient, decaying graph memory. Use 
 	"(1) RECALL FIRST: before answering anything that could depend on remembered context, call recall_fact (exact key), search_facts (substring over keys+values when you recall the topic but not the exact key), recall_related (walk from a seed), recall_relation (read one specific from→to edge's weight and decay), list_under (enumerate a namespace), or list_namespaces (discover which namespaces exist, counts only, no values) to pull in what you already know. " +
 	"(2) ANSWER using what you recalled. " +
 	"(3) CAPTURE AFTER: once the exchange settles, write any new durable facts with remember_fact and any new associations with remember_relation (or remember_facts / remember_relations to record several in one call) — preferences, decisions, identities, project facts, and how they connect. Capturing is the default, not the exception. " +
-	"Two invariants govern every write: (a) there is no \"forever\" — each write picks a TTL bucket from {seconds, transient, turn, conversation, task, workday, day, week, sprint, month, quarter, durable}; (b) recall does NOT refresh TTL, so to keep a fact alive you must re-remember it — or touch it to extend its TTL without resupplying the value — when you reference it. Choosing a bucket: ask \"when will this stop being true?\" and \"how bad is it if this lingers past then?\" and pick the SHORTER one. Relations are additive — writing the same relation twice strengthens it, so reinforce associations you keep using. " +
+	"Two invariants govern every write: (a) there is no \"forever\" — each write picks a TTL bucket from {seconds, transient, turn, conversation, task, workday, day, week, sprint, month, quarter, durable}; (b) recall does NOT refresh TTL, so to keep a fact alive you must re-remember it — or touch it to extend its TTL without resupplying the value — when you reference it. The edge-side keep-alive is recall_related with reinforce=true, which adds a decaying weight pulse to the edges it walks (the one opt-in exception to this no-refresh rule, and it never shortens an edge's existing life). Choosing a bucket: ask \"when will this stop being true?\" and \"how bad is it if this lingers past then?\" and pick the SHORTER one. Relations are additive — writing the same relation twice strengthens it, so reinforce associations you keep using. " +
 	"Namespace keys so the graph reads as a mind map: user.* for stable facts about the person (user.preferences.tone, user.identity.role), project.* for the work at hand (project.lantern.stack), session.* for ephemeral working state (session.current-task). Prefer dotted, hierarchical keys; reuse a key to update its value."

--- a/mcp/tool_recall_related.go
+++ b/mcp/tool_recall_related.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/anaregdesign/lantern/mcp/internal/ttl"
 	"github.com/anaregdesign/lantern/mcp/internal/value"
 	client "github.com/anaregdesign/lantern/sdks/go"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -62,14 +63,40 @@ const (
 	recallRelatedReverseScanMax   = 10000
 )
 
+// reinforce-on-recall defaults (#549). Reinforcement is opt-in (default
+// off) so recall stays read-only unless asked. When enabled, each
+// traversed edge gets an additive weight contribution via AddEdge. Because
+// the store keeps every contribution as an independent (weight, expiration)
+// pulse and an edge's life is the latest contribution's expiration, a
+// reinforcement NEVER shortens an edge's existing horizon — it adds a
+// pulse that itself decays on reinforce_ttl. Frequent use stacks pulses
+// (sustained strength); sporadic use lets them fade. This is the
+// edge-side analog of touch and the one deliberate exception to "recall
+// does NOT refresh TTL".
+const (
+	defaultReinforceWeight = float32(1)
+	defaultReinforceBucket = ttl.Conversation
+)
+
+// reinforceEdge identifies one traversed edge (tail -> head) so the
+// reinforce pass bumps exactly the edges that fed the returned neighbours,
+// and no others. See #549.
+type reinforceEdge struct {
+	tail string
+	head string
+}
+
 type recallRelatedInput struct {
-	Seed      string                 `json:"seed"                jsonschema:"Starting fact key for the walk. The seed itself is returned at depth 0."`
-	Step      uint32                 `json:"step,omitempty"      jsonschema:"BFS depth (default 2). Larger values explore further at quadratic cost. Server enforces a hard cap. Applies to the out-direction walk only."`
-	K         uint32                 `json:"k,omitempty"         jsonschema:"Per-hop fan-out: keep the top-k strongest outgoing edges at each step (default 8). Server enforces a hard cap. Applies to the out-direction walk only."`
-	Direction recallRelatedDirection `json:"direction,omitempty" jsonschema:"Which edge direction to follow from the seed: out (default - forward BFS over out-edges, the historical behaviour), in (reverse - return the seed's direct predecessors, so seeding a pure sink is no longer empty), or both (union of the two). step/k/algorithm/objective/weighting shape the out walk; the in pass is a single bounded reverse-adjacency hop."`
-	Algorithm recallRelatedAlgorithm `json:"algorithm,omitempty" jsonschema:"Post-traversal subgraph reduction: one of: none (default - raw BFS subgraph), mst (minimum/maximum spanning tree depending on objective), spt (shortest-path tree from seed)."`
-	Objective recallRelatedObjective `json:"objective,omitempty" jsonschema:"Direction of the algorithm reduction: min (default - cost-weighted, smallest tree wins) or max (relevance-weighted, largest tree wins). Ignored when algorithm=none."`
-	Weighting recallRelatedWeighting `json:"weighting,omitempty" jsonschema:"Edge-weight transform applied BEFORE the walk: raw (default - edge weights as stored) or tfidf (re-score via TF-IDF over per-vertex out-edge distribution)."`
+	Seed            string                 `json:"seed"                jsonschema:"Starting fact key for the walk. The seed itself is returned at depth 0."`
+	Step            uint32                 `json:"step,omitempty"      jsonschema:"BFS depth (default 2). Larger values explore further at quadratic cost. Server enforces a hard cap. Applies to the out-direction walk only."`
+	K               uint32                 `json:"k,omitempty"         jsonschema:"Per-hop fan-out: keep the top-k strongest outgoing edges at each step (default 8). Server enforces a hard cap. Applies to the out-direction walk only."`
+	Direction       recallRelatedDirection `json:"direction,omitempty" jsonschema:"Which edge direction to follow from the seed: out (default - forward BFS over out-edges, the historical behaviour), in (reverse - return the seed's direct predecessors, so seeding a pure sink is no longer empty), or both (union of the two). step/k/algorithm/objective/weighting shape the out walk; the in pass is a single bounded reverse-adjacency hop."`
+	Algorithm       recallRelatedAlgorithm `json:"algorithm,omitempty" jsonschema:"Post-traversal subgraph reduction: one of: none (default - raw BFS subgraph), mst (minimum/maximum spanning tree depending on objective), spt (shortest-path tree from seed)."`
+	Objective       recallRelatedObjective `json:"objective,omitempty" jsonschema:"Direction of the algorithm reduction: min (default - cost-weighted, smallest tree wins) or max (relevance-weighted, largest tree wins). Ignored when algorithm=none."`
+	Weighting       recallRelatedWeighting `json:"weighting,omitempty" jsonschema:"Edge-weight transform applied BEFORE the walk: raw (default - edge weights as stored) or tfidf (re-score via TF-IDF over per-vertex out-edge distribution)."`
+	Reinforce       bool                   `json:"reinforce,omitempty"        jsonschema:"Opt in (default false) to strengthening the edges this walk actually traverses. Each traversed edge gains an additive weight pulse via the same additive model as remember_relation; recall stays read-only when false. This is the Hebbian use-strengthens-memory loop — the edge-side analog of touch and the one deliberate exception to 'recall does NOT refresh TTL'."`
+	ReinforceWeight float32                `json:"reinforce_weight,omitempty" jsonschema:"Weight added to each traversed edge when reinforce=true (default 1.0). Additive: the pulse stacks on the edge's existing weight. Ignored when reinforce=false."`
+	ReinforceTTL    string                 `json:"reinforce_ttl,omitempty"    jsonschema:"Decay horizon of the reinforcement pulse when reinforce=true (default conversation). The store keeps each contribution independently, so a short horizon NEVER shortens the edge's existing life — it adds a pulse that itself decays on this horizon; frequent use stacks pulses. One of: seconds, transient, turn, conversation, task, workday, day, week, sprint, month, quarter, durable. Ignored when reinforce=false."`
 }
 
 type recallRelatedNeighbor struct {
@@ -79,19 +106,27 @@ type recallRelatedNeighbor struct {
 }
 
 type recallRelatedOutput struct {
-	Seed      string                  `json:"seed"`
-	Direction string                  `json:"direction"`
-	Algorithm string                  `json:"algorithm"`
-	Objective string                  `json:"objective"`
-	Weighting string                  `json:"weighting"`
-	Count     int                     `json:"count"`
-	Truncated bool                    `json:"truncated,omitempty"`
-	Neighbors []recallRelatedNeighbor `json:"neighbors"`
+	Seed      string `json:"seed"`
+	Direction string `json:"direction"`
+	Algorithm string `json:"algorithm"`
+	Objective string `json:"objective"`
+	Weighting string `json:"weighting"`
+	Count     int    `json:"count"`
+	Truncated bool   `json:"truncated,omitempty"`
+	// Reinforced is the number of traversed edges that received a weight
+	// pulse this call. Zero (and omitted) unless reinforce=true. It can be
+	// lower than the number of edges walked if some best-effort bump writes
+	// failed — the recall result itself is unaffected.
+	Reinforced int `json:"reinforced,omitempty"`
+	// ReinforceCapped is true when the reinforcement pulse's TTL was clamped
+	// down to LANTERN_MCP_MAX_TTL before writing.
+	ReinforceCapped bool                    `json:"reinforce_capped,omitempty"`
+	Neighbors       []recallRelatedNeighbor `json:"neighbors"`
 }
 
-const recallRelatedDescription = "Walk Lantern's graph from a seed key, returning the related facts with their cumulative edge weights. Call this PROACTIVELY to pull in surrounding context before answering — start from the most relevant known key. Use step + k to bound exploration. Use algorithm + objective + weighting to control how the discovered subgraph is reduced and weighted (see #410). Use direction to choose which way edges are followed: out (default, forward), in (reverse — the seed's predecessors, so seeding a pure sink is no longer empty), or both. IMPORTANT: recall does NOT refresh TTL for any vertex or edge visited; weak relations will still decay on schedule."
+const recallRelatedDescription = "Walk Lantern's graph from a seed key, returning the related facts with their cumulative edge weights. Call this PROACTIVELY to pull in surrounding context before answering — start from the most relevant known key. Use step + k to bound exploration. Use algorithm + objective + weighting to control how the discovered subgraph is reduced and weighted (see #410). Use direction to choose which way edges are followed: out (default, forward), in (reverse — the seed's predecessors, so seeding a pure sink is no longer empty), or both. By default recall does NOT refresh TTL for any vertex or edge visited; weak relations will still decay on schedule. Set reinforce=true to OPT IN to strengthening the edges you actually traverse — each gains an additive, decaying weight pulse (the Hebbian use-strengthens-memory loop and the edge-side analog of touch); this is the one deliberate exception to the no-refresh rule, and because contributions stack independently it never shortens an edge's existing life."
 
-func registerRecallRelated(srv *mcp.Server, lc lanternClient) {
+func registerRecallRelated(srv *mcp.Server, lc lanternClient, r *ttl.Resolver) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "recall_related",
 		Description: recallRelatedDescription,
@@ -130,6 +165,17 @@ func registerRecallRelated(srv *mcp.Server, lc lanternClient) {
 		if err != nil {
 			return nil, recallRelatedOutput{}, fmt.Errorf("recall_related: %w", err)
 		}
+		// Resolve the reinforcement horizon up front so a bad bucket fails
+		// fast — before any read work — consistent with the enum validations
+		// above. Only consulted when reinforce is requested.
+		reinforceBucket := defaultReinforceBucket
+		if in.Reinforce && in.ReinforceTTL != "" {
+			b, err := ttl.ParseBucket(in.ReinforceTTL)
+			if err != nil {
+				return nil, recallRelatedOutput{}, fmt.Errorf("recall_related: %w", err)
+			}
+			reinforceBucket = b
+		}
 
 		acc := newNeighborAccumulator()
 		var truncated bool
@@ -165,7 +211,7 @@ func registerRecallRelated(srv *mcp.Server, lc lanternClient) {
 			}
 			truncated = t
 			for _, e := range preds {
-				acc.addPredecessor(e.GetTail(), e.GetWeight())
+				acc.addPredecessor(e.GetTail(), e.GetHead(), e.GetWeight())
 			}
 		}
 
@@ -180,7 +226,52 @@ func registerRecallRelated(srv *mcp.Server, lc lanternClient) {
 			Truncated: truncated,
 			Neighbors: neighbors,
 		}
-		text := fmt.Sprintf("Recalled %d related facts for seed %q (direction=%s, algorithm=%s, objective=%s, weighting=%s). Recall did NOT refresh TTL.", out.Count, in.Seed, out.Direction, out.Algorithm, out.Objective, out.Weighting)
+
+		// Reinforce-on-recall (#549): opt-in, default off. Replay each
+		// traversed edge through AddEdge so it gains an additive weight pulse
+		// on the reinforce_ttl horizon. The store keeps contributions
+		// independently, so this strengthens (and at most extends) the edge
+		// without ever shortening its existing life. It is a best-effort side
+		// effect: the recall already succeeded and its neighbours are valid,
+		// so a failed bump must not fail the tool — count the bumps that
+		// landed and note any shortfall. No per-edge read-back on this hot
+		// path (see the #540/#547 findings); call recall_relation to observe
+		// an edge's accumulated weight.
+		var (
+			reinforceBump      float32
+			reinforceAttempted int
+		)
+		if in.Reinforce {
+			reinforceBump = in.ReinforceWeight
+			if reinforceBump <= 0 {
+				reinforceBump = defaultReinforceWeight
+			}
+			d, capped := r.ResolveCapped(reinforceBucket)
+			visited := acc.visitedEdges()
+			reinforceAttempted = len(visited)
+			reinforced := 0
+			for _, e := range visited {
+				if err := lc.AddEdge(ctx, e.tail, e.head, reinforceBump, d); err != nil {
+					continue // best-effort: the recall already succeeded
+				}
+				reinforced++
+			}
+			out.Reinforced = reinforced
+			out.ReinforceCapped = capped
+		}
+
+		text := fmt.Sprintf("Recalled %d related facts for seed %q (direction=%s, algorithm=%s, objective=%s, weighting=%s).", out.Count, in.Seed, out.Direction, out.Algorithm, out.Objective, out.Weighting)
+		if in.Reinforce {
+			text += fmt.Sprintf(" Reinforced %d of %d traversed edge(s) with a +%.2f weight pulse (bucket=%s); this never shortens existing edge life.", out.Reinforced, reinforceAttempted, reinforceBump, reinforceBucket.String())
+			if out.Reinforced < reinforceAttempted {
+				text += " Some reinforcement writes failed; the recall result is unaffected."
+			}
+			if out.ReinforceCapped {
+				text += " Reinforcement TTL was clamped to the server cap."
+			}
+		} else {
+			text += " Recall did NOT refresh TTL."
+		}
 		if truncated {
 			text += fmt.Sprintf(" Reverse scan truncated at %d edges; some predecessors may be missing.", recallRelatedReverseScanMax)
 		}
@@ -283,6 +374,11 @@ type neighborAccumulator struct {
 	keys    map[string]struct{}
 	weights map[string]float32
 	values  map[string]any
+	// edges records the traversed edges (deduplicated, first-seen order) so
+	// an opt-in reinforce pass can bump exactly the edges that contributed
+	// to the returned neighbours. See #549.
+	edges []reinforceEdge
+	seen  map[reinforceEdge]struct{}
 }
 
 func newNeighborAccumulator() *neighborAccumulator {
@@ -290,6 +386,7 @@ func newNeighborAccumulator() *neighborAccumulator {
 		keys:    map[string]struct{}{},
 		weights: map[string]float32{},
 		values:  map[string]any{},
+		seen:    map[reinforceEdge]struct{}{},
 	}
 }
 
@@ -309,18 +406,39 @@ func (a *neighborAccumulator) addGraph(g *client.Graph) {
 		}
 		a.values[k] = value.FromVertex(v)
 	}
-	for _, heads := range g.Edges {
+	for from, heads := range g.Edges {
 		for to, w := range heads {
 			a.weights[to] += w
+			a.recordEdge(from, to)
 		}
 	}
 }
 
-// addPredecessor folds one reverse edge (tail -> seed) in: the tail
-// becomes a neighbour weighted by the edge it points along.
-func (a *neighborAccumulator) addPredecessor(tail string, w float32) {
+// addPredecessor folds one reverse edge (tail -> head, where head is the
+// seed) in: the tail becomes a neighbour weighted by the edge it points
+// along, and the edge is recorded so an opt-in reinforce pass can bump it.
+func (a *neighborAccumulator) addPredecessor(tail, head string, w float32) {
 	a.keys[tail] = struct{}{}
 	a.weights[tail] += w
+	a.recordEdge(tail, head)
+}
+
+// recordEdge remembers a traversed edge, deduplicated, so a later reinforce
+// pass bumps each contributing edge exactly once. Dedup matters for
+// direction=both, where the same edge can surface from both the forward
+// Illuminate subgraph and the reverse predecessor scan.
+func (a *neighborAccumulator) recordEdge(tail, head string) {
+	e := reinforceEdge{tail: tail, head: head}
+	if _, ok := a.seen[e]; ok {
+		return
+	}
+	a.seen[e] = struct{}{}
+	a.edges = append(a.edges, e)
+}
+
+// visitedEdges returns the traversed edges in first-seen order.
+func (a *neighborAccumulator) visitedEdges() []reinforceEdge {
+	return a.edges
 }
 
 // finalize produces the ranked neighbour list. The seed is always present

--- a/mcp/tool_recall_related_test.go
+++ b/mcp/tool_recall_related_test.go
@@ -2,8 +2,10 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	client "github.com/anaregdesign/lantern/sdks/go"
@@ -262,5 +264,212 @@ func TestRecallRelated_ReverseScanTruncates(t *testing.T) {
 	structuredAs(t, res, &out)
 	if !out.Truncated {
 		t.Fatalf("Truncated = false; want true once the scan budget is hit")
+	}
+}
+
+// captureReinforce wires an addEdgeFn that records every reinforcement write
+// into a tail->head keyed map and returns the supplied per-call error.
+func captureReinforce(f *fakeLantern, err error) map[string]float32 {
+	got := make(map[string]float32)
+	f.addEdgeFn = func(_ context.Context, tail, head string, weight float32, _ time.Duration) error {
+		got[tail+"->"+head] = weight
+		return err
+	}
+	return got
+}
+
+// TestRecallRelated_DefaultDoesNotReinforce confirms recall stays read-only
+// unless reinforce is set: no AddEdge write happens and the reinforced count
+// is zero (#549).
+func TestRecallRelated_DefaultDoesNotReinforce(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.illuminateFn = func(_ context.Context, _ string, _ ...client.IlluminateOption) (*client.Graph, error) {
+		return &client.Graph{
+			Vertices: map[string]*client.Vertex{"seed": {Key: "seed"}, "a": {Key: "a"}},
+			Edges:    map[string]map[string]float32{"seed": {"a": 0.7}},
+		}, nil
+	}
+	res := h.call(t, "recall_related", map[string]any{"seed": "seed"})
+	if res.IsError {
+		t.Fatalf("IsError = true")
+	}
+	if h.fake.addEdgeCalls != 0 {
+		t.Fatalf("AddEdge called %d times without reinforce; want 0", h.fake.addEdgeCalls)
+	}
+	var out recallRelatedOutput
+	structuredAs(t, res, &out)
+	if out.Reinforced != 0 {
+		t.Fatalf("Reinforced = %d, want 0", out.Reinforced)
+	}
+	if !strings.Contains(contentText(res), "did NOT refresh") {
+		t.Fatalf("read-only recall should restate the no-refresh invariant: %q", contentText(res))
+	}
+}
+
+// TestRecallRelated_ReinforceBumpsTraversedEdgesOut asserts every edge the
+// forward walk traverses is reinforced exactly once with the default pulse,
+// and an edge that is NOT part of the traversed subgraph is left alone (#549).
+func TestRecallRelated_ReinforceBumpsTraversedEdgesOut(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.illuminateFn = func(_ context.Context, _ string, _ ...client.IlluminateOption) (*client.Graph, error) {
+		return &client.Graph{
+			Vertices: map[string]*client.Vertex{
+				"seed": {Key: "seed"}, "a": {Key: "a"}, "b": {Key: "b"},
+			},
+			Edges: map[string]map[string]float32{
+				"seed": {"a": 0.7, "b": 0.1},
+				"a":    {"b": 0.2},
+			},
+		}, nil
+	}
+	got := captureReinforce(h.fake, nil)
+	res := h.call(t, "recall_related", map[string]any{"seed": "seed", "reinforce": true})
+	if res.IsError {
+		t.Fatalf("IsError = true")
+	}
+	want := map[string]float32{"seed->a": 1, "seed->b": 1, "a->b": 1}
+	if len(got) != len(want) {
+		t.Fatalf("reinforced edges = %v, want %v", got, want)
+	}
+	for k, w := range want {
+		if got[k] != w {
+			t.Fatalf("edge %q reinforced with %v, want %v (all=%v)", k, got[k], w, got)
+		}
+	}
+	if _, bumped := got["seed->z"]; bumped {
+		t.Fatalf("untraversed edge seed->z must not be reinforced; got=%v", got)
+	}
+	var out recallRelatedOutput
+	structuredAs(t, res, &out)
+	if out.Reinforced != 3 {
+		t.Fatalf("Reinforced = %d, want 3", out.Reinforced)
+	}
+}
+
+// TestRecallRelated_ReinforceCustomWeight asserts reinforce_weight overrides
+// the default pulse magnitude on every traversed edge (#549).
+func TestRecallRelated_ReinforceCustomWeight(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.illuminateFn = func(_ context.Context, _ string, _ ...client.IlluminateOption) (*client.Graph, error) {
+		return &client.Graph{
+			Vertices: map[string]*client.Vertex{"seed": {Key: "seed"}, "a": {Key: "a"}},
+			Edges:    map[string]map[string]float32{"seed": {"a": 0.7}},
+		}, nil
+	}
+	got := captureReinforce(h.fake, nil)
+	res := h.call(t, "recall_related", map[string]any{
+		"seed": "seed", "reinforce": true, "reinforce_weight": 2.5,
+	})
+	if res.IsError {
+		t.Fatalf("IsError = true")
+	}
+	if got["seed->a"] != 2.5 {
+		t.Fatalf("edge seed->a reinforced with %v, want 2.5 (all=%v)", got["seed->a"], got)
+	}
+}
+
+// TestRecallRelated_ReinforceInDirectionBumpsPredecessors confirms reinforce
+// also strengthens the reverse-walk edges (predecessor -> seed) when
+// direction=in (#549).
+func TestRecallRelated_ReinforceInDirectionBumpsPredecessors(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.scanEdgesFn = func(_ context.Context, _ ...client.EdgeScanOption) ([]*client.Edge, []byte, error) {
+		return []*client.Edge{
+			{Tail: "x", Head: "seed", Weight: 0.4},
+			{Tail: "y", Head: "seed", Weight: 0.6},
+		}, nil, nil
+	}
+	got := captureReinforce(h.fake, nil)
+	res := h.call(t, "recall_related", map[string]any{
+		"seed": "seed", "direction": "in", "reinforce": true,
+	})
+	if res.IsError {
+		t.Fatalf("IsError = true")
+	}
+	want := map[string]float32{"x->seed": 1, "y->seed": 1}
+	if len(got) != len(want) {
+		t.Fatalf("reinforced edges = %v, want %v", got, want)
+	}
+	for k, w := range want {
+		if got[k] != w {
+			t.Fatalf("edge %q reinforced with %v, want %v (all=%v)", k, got[k], w, got)
+		}
+	}
+	var out recallRelatedOutput
+	structuredAs(t, res, &out)
+	if out.Reinforced != 2 {
+		t.Fatalf("Reinforced = %d, want 2", out.Reinforced)
+	}
+}
+
+// TestRecallRelated_ReinforceIsBestEffort asserts a failing reinforcement
+// write never fails the recall: the neighbours still return and Reinforced
+// reflects that nothing landed (#549).
+func TestRecallRelated_ReinforceIsBestEffort(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.illuminateFn = func(_ context.Context, _ string, _ ...client.IlluminateOption) (*client.Graph, error) {
+		return &client.Graph{
+			Vertices: map[string]*client.Vertex{
+				"seed": {Key: "seed"}, "a": {Key: "a"}, "b": {Key: "b"},
+			},
+			Edges: map[string]map[string]float32{"seed": {"a": 0.7, "b": 0.1}},
+		}, nil
+	}
+	captureReinforce(h.fake, errors.New("edge store unavailable"))
+	res := h.call(t, "recall_related", map[string]any{"seed": "seed", "reinforce": true})
+	if res.IsError {
+		t.Fatalf("IsError = true; a failed reinforcement must not fail the recall")
+	}
+	var out recallRelatedOutput
+	structuredAs(t, res, &out)
+	if out.Count != 3 {
+		t.Fatalf("Count = %d, want 3 (seed, a, b)", out.Count)
+	}
+	if out.Reinforced != 0 {
+		t.Fatalf("Reinforced = %d, want 0 (no write landed)", out.Reinforced)
+	}
+}
+
+// TestRecallRelated_RejectsUnknownReinforceTTL asserts a bad reinforce_ttl
+// bucket fails fast with a tool error and never writes (#549).
+func TestRecallRelated_RejectsUnknownReinforceTTL(t *testing.T) {
+	h := newTestHarness(t)
+	h.fake.illuminateFn = func(_ context.Context, _ string, _ ...client.IlluminateOption) (*client.Graph, error) {
+		return &client.Graph{Vertices: map[string]*client.Vertex{"seed": {Key: "seed"}}}, nil
+	}
+	h.callExpectError(t, "recall_related", map[string]any{
+		"seed": "seed", "reinforce": true, "reinforce_ttl": "not-a-bucket",
+	})
+	if h.fake.addEdgeCalls != 0 {
+		t.Fatalf("AddEdge called %d times after a bad bucket; want 0", h.fake.addEdgeCalls)
+	}
+}
+
+// TestRecallRelated_ReinforceTTLControlsHorizon asserts reinforce_ttl selects
+// the pulse's decay horizon: a short bucket yields a strictly shorter AddEdge
+// TTL than the conversation default, and neither alters the long-lived base
+// edge (the store keeps each contribution independently) (#549).
+func TestRecallRelated_ReinforceTTLControlsHorizon(t *testing.T) {
+	graph := func(_ context.Context, _ string, _ ...client.IlluminateOption) (*client.Graph, error) {
+		return &client.Graph{
+			Vertices: map[string]*client.Vertex{"seed": {Key: "seed"}, "a": {Key: "a"}},
+			Edges:    map[string]map[string]float32{"seed": {"a": 0.7}},
+		}, nil
+	}
+
+	hDefault := newTestHarness(t)
+	hDefault.fake.illuminateFn = graph
+	hDefault.call(t, "recall_related", map[string]any{"seed": "seed", "reinforce": true})
+	defaultTTL := hDefault.fake.lastEdgeTTL
+
+	hShort := newTestHarness(t)
+	hShort.fake.illuminateFn = graph
+	hShort.call(t, "recall_related", map[string]any{
+		"seed": "seed", "reinforce": true, "reinforce_ttl": "seconds",
+	})
+	shortTTL := hShort.fake.lastEdgeTTL
+
+	if !(shortTTL < defaultTTL) {
+		t.Fatalf("reinforce_ttl=seconds TTL %v should be shorter than default %v", shortTTL, defaultTTL)
 	}
 }


### PR DESCRIPTION
## Summary

Implements #549 — an opt-in **reinforce-on-recall** capability for `recall_related`. Walking the graph now optionally strengthens the edges it actually traverses: the Hebbian *use-strengthens-memory* loop and the edge-side analog of `touch` (#543). It is the single deliberate exception to the "recall does **NOT** refresh TTL" invariant, and it is **off unless asked for**.

## What changed

- **`recall_related` gains three opt-in inputs:**
  - `reinforce` (bool, default `false`) — master switch; recall stays purely read-only when false.
  - `reinforce_weight` (default `1.0`) — additive pulse magnitude stacked onto each traversed edge.
  - `reinforce_ttl` (default `conversation`) — decay horizon of the pulse, from the same 12-bucket ladder as `remember_*` (clamped by `LANTERN_MCP_MAX_TTL` → `reinforce_capped`).
- **Never shortens an edge.** The store keeps every contribution as an independent `(weight, expiration)` pulse and an edge's life is its *latest* contribution's expiry — so a short `reinforce_ttl` only adds a pulse that itself fades, leaving any longer-lived contribution untouched. Frequent use stacks pulses; sporadic use lets them decay.
- **Best-effort side effect.** The recall result is produced first and is never failed by a reinforcement write that does not land. Output reports `reinforced` (count of bumped edges) and `reinforce_capped`. The hot path deliberately skips a per-edge read-back — use `recall_relation` to observe an edge's `accumulated_weight`.
- **Every direction.** Reinforces the forward-walk edges for `out`, predecessor edges for `in`, and the union for `both` (deduped).
- **`serverInstructions` invariant (b)** now names `recall_related` with `reinforce=true` as the edge-side keep-alive (closes the loop opened by #543's touch). *LLM-behaviour-affecting — note in release.*
- README: new **Reinforce-on-recall** subsection + updated `recall_related` row.

## Tests

Appended to `mcp/tool_recall_related_test.go` (`addEdgeFn` capture hook added to the fake):

- default recall does **not** reinforce (no `AddEdge`, `reinforced=0`, restates no-refresh);
- `reinforce=true` bumps **exactly** the traversed `out` edges and leaves untraversed ones alone;
- custom `reinforce_weight` is honoured;
- `direction=in` reinforces the predecessor edges;
- best-effort: a failing write keeps the recall successful with `reinforced=0`;
- unknown `reinforce_ttl` bucket fails fast and writes nothing;
- `reinforce_ttl` selects the pulse horizon (short bucket → strictly shorter `AddEdge` TTL).

## Acceptance criteria

- [x] `recall_related(seed, reinforce=true)` strengthens (weight and/or TTL) the traversed edges; default remains read-only.
- [x] Behaviour documented; clearly opt-in.
- [x] Tests assert traversed edges are reinforced and untraversed ones are not.

Closes #549
