### PR TITLE
feat(server): add GetVertices/GetEdges hit/miss Prometheus counters

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -159,6 +159,10 @@ runtime, process, and `grpc_server_*` collectors):
 | `lantern_scan_results` | histogram | `op` | Result counts for prefix scans (`ScanVertices`, `ScanEdges`, `DeleteVerticesByPrefix`). |
 | `lantern_scan_duration_seconds` | histogram | `op` | Wall-clock for the same scan ops. |
 | `lantern_batch_size` | histogram | `op` | Batch size for plural RPCs (`GetVertices`, `PutVertices`, `DeleteVertices`, `GetEdges`, `AddEdges`, `PutEdges`, `DeleteEdges`). Singular forwarders are NOT instrumented to avoid double-counting. |
+| `lantern_get_vertex_hits_total` | counter | — | `GetVertices` key lookups that found a live vertex (present at read time, including a present-but-nil value). Counted once by the plural impl; the singular `GetVertex` forwards through it. Recall hit ratio = `hits / (hits + misses)`. |
+| `lantern_get_vertex_misses_total` | counter | — | `GetVertices` key lookups that found no live vertex (absent or expired). The miss side of the vertex recall ratio. |
+| `lantern_get_edge_hits_total` | counter | — | `GetEdges` (tail, head) lookups that found a live edge. Counted once by the plural impl; the singular `GetEdge` forwards through it. |
+| `lantern_get_edge_misses_total` | counter | — | `GetEdges` (tail, head) lookups that found no live edge (absent or expired). |
 | `lantern_validation_rejected_total` | counter | `reason` | Requests rejected by the validation interceptor or service-layer guards. Reasons: `empty_key`, `key_too_long`, `empty_batch`, `batch_too_large`, `nil_item`, `bad_weight`, `step_too_large`, `k_too_large`, `bad_ttl`, `bad_cursor`. Unknown reasons fold onto `unknown`. Pre-warmed at startup. |
 | `lantern_rate_limit_rejected_total` | counter | — | RPCs rejected with `ResourceExhausted` by the process-wide token-bucket rate limiter (`LANTERN_RATE_LIMIT_RPS`). |
 | `lantern_tombstone_clamp_rejected_total` | counter | — | HLC `Put*` / `Add*` mutations rejected because a newer tombstone or LWW value already covered the key/edge (only counted while `LANTERN_TOMBSTONE_TTL_SECONDS > 0`). |
@@ -196,6 +200,11 @@ standing up a metrics stack:
 - **Hot scans** — `lantern_scan_results` / `lantern_scan_duration_seconds`
   flag clients fan-paging large prefixes; expect to also see `slow rpc`
   records for the same `method`.
+- **Recall effectiveness** — `lantern_get_vertex_hits_total` /
+  `lantern_get_vertex_misses_total` (and the `_edge_` pair) give a hit
+  ratio `hits / (hits + misses)`; a falling ratio means callers are asking
+  for keys that have decayed away or were never written — the read-side
+  signal for "memory isn't sticking."
 
 ## Dependency boundaries (invariants)
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -97,6 +97,19 @@ type DomainMetrics struct {
 	scanDuration              *prometheus.HistogramVec
 	batchSize                 *prometheus.HistogramVec
 
+	// Recall hit/miss counters (#539). Bumped by the service layer's
+	// plural GetVertices / GetEdges implementations (the singular GetVertex
+	// / GetEdge forwarders delegate to the plurals, so a read counts exactly
+	// once). A "hit" is a key present at read time — including a
+	// present-but-nil vertex value; a "miss" is a key absent or already
+	// expired. Plain counters scrape as 0 from process start once
+	// registered, so recall effectiveness = hits / (hits + misses) is
+	// observable without any label pre-warming.
+	getVertexHits   prometheus.Counter
+	getVertexMisses prometheus.Counter
+	getEdgeHits     prometheus.Counter
+	getEdgeMisses   prometheus.Counter
+
 	sampleInterval time.Duration
 	sample         Sampler
 	mlogSample     MutationLogSampler
@@ -296,6 +309,22 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 			Help:    "Item count of a single plural-RPC batch (PutVertices, PutEdges, AddEdges, GetVertices, GetEdges, DeleteVertices, DeleteEdges). Singular RPC forwarders are not double-counted.",
 			Buckets: prometheus.ExponentialBuckets(1, 4, 10),
 		}, []string{"op"}),
+		getVertexHits: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "lantern_get_vertex_hits_total",
+			Help: "Total GetVertices key lookups that found a live vertex (present at read time, including a present-but-nil value). Bumped by the plural GetVertices implementation; the singular GetVertex forwards through it so reads count exactly once. Recall hit ratio = hits / (hits + misses).",
+		}),
+		getVertexMisses: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "lantern_get_vertex_misses_total",
+			Help: "Total GetVertices key lookups that found no live vertex (absent or already expired at read time). See lantern_get_vertex_hits_total for the hit side.",
+		}),
+		getEdgeHits: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "lantern_get_edge_hits_total",
+			Help: "Total GetEdges (tail,head) lookups that found a live edge. Bumped by the plural GetEdges implementation; the singular GetEdge forwards through it so reads count exactly once.",
+		}),
+		getEdgeMisses: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "lantern_get_edge_misses_total",
+			Help: "Total GetEdges (tail,head) lookups that found no live edge (absent or already expired at read time). See lantern_get_edge_hits_total for the hit side.",
+		}),
 		peerConnected: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "lantern_peer_connected",
 			Help: "1 when the local replication pump currently holds an open Subscribe (or Subscribe+Snapshot) session to the named peer; 0 otherwise. Updated on every pump connect/disconnect lifecycle event.",
@@ -361,6 +390,7 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 		m.antiEntropyCycles, m.antiEntropyGapsFound,
 		m.illuminateVisitedVertices, m.illuminateVisitedEdges, m.illuminateDuration,
 		m.scanResults, m.scanDuration, m.batchSize,
+		m.getVertexHits, m.getVertexMisses, m.getEdgeHits, m.getEdgeMisses,
 		m.peerConnected, m.replicationApplyTotal, m.snapshotReplayedTotal,
 		m.snapshotVertices, m.snapshotEdges, m.snapshotDuration,
 		m.mutationLogFillRatio, m.mutationLogEvicted, m.originStatesCount,
@@ -712,6 +742,35 @@ func (m *DomainMetrics) OnScan(op string, results int, duration time.Duration) {
 func (m *DomainMetrics) OnBatch(op string, size int) {
 	o := sanitizeLabel(op, batchOps, op)
 	m.batchSize.WithLabelValues(o).Observe(float64(size))
+}
+
+// OnGetVertices records the hit/miss split of one GetVertices RPC (#539):
+// hits is the number of requested keys that resolved to a live vertex,
+// misses the number absent or expired. Called once by the plural
+// GetVertices implementation, so the singular GetVertex forwarder counts
+// through it exactly once. Zero-valued sides are skipped so an all-hit or
+// all-miss batch touches only the relevant counter.
+func (m *DomainMetrics) OnGetVertices(hits, misses int) {
+	if hits > 0 {
+		m.getVertexHits.Add(float64(hits))
+	}
+	if misses > 0 {
+		m.getVertexMisses.Add(float64(misses))
+	}
+}
+
+// OnGetEdges records the hit/miss split of one GetEdges RPC (#539): hits is
+// the number of requested (tail,head) pairs that resolved to a live edge,
+// misses the number absent or expired. Called once by the plural GetEdges
+// implementation, so the singular GetEdge forwarder counts through it
+// exactly once.
+func (m *DomainMetrics) OnGetEdges(hits, misses int) {
+	if hits > 0 {
+		m.getEdgeHits.Add(float64(hits))
+	}
+	if misses > 0 {
+		m.getEdgeMisses.Add(float64(misses))
+	}
 }
 
 // BindSampler stores the gauge-population callback. Must be called before

--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -66,6 +66,55 @@ func TestDomainMetrics_ExposesLanternFamilies(t *testing.T) {
 	}
 }
 
+// TestDomainMetrics_GetHitMissCounters asserts the #539 recall hit/miss
+// counters register, scrape as 0 from process start (plain counters need no
+// pre-warm), and accumulate across calls via the OnGetVertices / OnGetEdges
+// hooks.
+func TestDomainMetrics_GetHitMissCounters(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := New(reg, Options{Version: "v", Commit: "c", SampleInterval: time.Hour})
+
+	// Registered and scrape as 0 before any traffic.
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	names := map[string]bool{}
+	for _, mf := range mfs {
+		names[mf.GetName()] = true
+	}
+	for _, want := range []string{
+		"lantern_get_vertex_hits_total",
+		"lantern_get_vertex_misses_total",
+		"lantern_get_edge_hits_total",
+		"lantern_get_edge_misses_total",
+	} {
+		if !names[want] {
+			t.Errorf("metric family %q not registered (plain counters should scrape as 0 from start)", want)
+		}
+	}
+
+	// Accumulate across two batches; zero-valued sides are skipped but the
+	// counters still total correctly.
+	m.OnGetVertices(2, 1)
+	m.OnGetVertices(3, 0)
+	m.OnGetEdges(0, 4)
+	m.OnGetEdges(1, 1)
+
+	if got := testutil.ToFloat64(m.getVertexHits); got != 5 {
+		t.Errorf("get_vertex_hits_total = %v, want 5", got)
+	}
+	if got := testutil.ToFloat64(m.getVertexMisses); got != 1 {
+		t.Errorf("get_vertex_misses_total = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.getEdgeHits); got != 1 {
+		t.Errorf("get_edge_hits_total = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.getEdgeMisses); got != 5 {
+		t.Errorf("get_edge_misses_total = %v, want 5", got)
+	}
+}
+
 func TestDomainMetrics_Run_NoSampler_StopsOnContextCancel(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	m := New(reg, Options{SampleInterval: time.Millisecond})

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -79,6 +79,8 @@ type HotPathMetrics interface {
 	OnIlluminate(algorithm, objective, weighting string, visitedVertices, visitedEdges int, traversal, optimize time.Duration)
 	OnScan(op string, results int, duration time.Duration)
 	OnBatch(op string, size int)
+	OnGetVertices(hits, misses int)
+	OnGetEdges(hits, misses int)
 }
 
 type noopHotPathMetrics struct{}
@@ -87,6 +89,8 @@ func (noopHotPathMetrics) OnIlluminate(string, string, string, int, int, time.Du
 }
 func (noopHotPathMetrics) OnScan(string, int, time.Duration) {}
 func (noopHotPathMetrics) OnBatch(string, int)               {}
+func (noopHotPathMetrics) OnGetVertices(int, int)            {}
+func (noopHotPathMetrics) OnGetEdges(int, int)               {}
 
 // ScanLimits caps the per-call pagination knobs for the prefix RPCs. It is
 // a value struct rather than a pointer-to-provider type so the service
@@ -426,6 +430,7 @@ func (s *LanternService) GetVertices(ctx context.Context, request *pb.GetVertice
 			resp.Vertices = append(resp.Vertices, v)
 		}
 	}
+	s.metrics.OnGetVertices(len(resp.Vertices), len(resp.Missing))
 	return resp, nil
 }
 
@@ -522,6 +527,7 @@ func (s *LanternService) GetEdges(ctx context.Context, request *pb.GetEdgesReque
 		}
 		resp.Edges = append(resp.Edges, edge)
 	}
+	s.metrics.OnGetEdges(len(resp.Edges), len(resp.Missing))
 	return resp, nil
 }
 

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -650,6 +650,8 @@ type fakeHotPathMetrics struct {
 	illuminate []illuminateObs
 	scan       []scanObs
 	batch      []batchObs
+	getVertex  []hitMissObs
+	getEdge    []hitMissObs
 }
 
 type illuminateObs struct {
@@ -669,6 +671,11 @@ type batchObs struct {
 	size int
 }
 
+type hitMissObs struct {
+	hits   int
+	misses int
+}
+
 func (f *fakeHotPathMetrics) OnIlluminate(algorithm, objective, weighting string, vV, vE int, traversal, optimize time.Duration) {
 	f.illuminate = append(f.illuminate, illuminateObs{algorithm, objective, weighting, vV, vE, traversal, optimize})
 }
@@ -677,6 +684,12 @@ func (f *fakeHotPathMetrics) OnScan(op string, results int, d time.Duration) {
 }
 func (f *fakeHotPathMetrics) OnBatch(op string, size int) {
 	f.batch = append(f.batch, batchObs{op, size})
+}
+func (f *fakeHotPathMetrics) OnGetVertices(hits, misses int) {
+	f.getVertex = append(f.getVertex, hitMissObs{hits, misses})
+}
+func (f *fakeHotPathMetrics) OnGetEdges(hits, misses int) {
+	f.getEdge = append(f.getEdge, hitMissObs{hits, misses})
 }
 
 func TestLanternService_HotPathMetrics_EmitsOnceForBatchAndIlluminate(t *testing.T) {
@@ -767,6 +780,97 @@ func TestLanternService_HotPathMetrics_EmitsOnScan(t *testing.T) {
 	}
 	if fm.scan[2].results != 2 {
 		t.Errorf("DeleteVerticesByPrefix results = %d, want 2", fm.scan[2].results)
+	}
+}
+
+// TestLanternService_HotPathMetrics_EmitsGetVertexHitMiss asserts the #539
+// hit/miss split fires once per GetVertices with the right counts, that the
+// singular GetVertex forwards through the plural (so it counts exactly
+// once), and that a present-but-nil vertex value still scores as a hit.
+func TestLanternService_HotPathMetrics_EmitsGetVertexHitMiss(t *testing.T) {
+	fm := &fakeHotPathMetrics{}
+	s := NewLanternService(graph.NewGraphCache[string, *pb.Vertex](time.Minute)).
+		WithHotPathMetrics(fm)
+	ctx := context.Background()
+
+	// Two live vertices: one with a concrete value, one explicitly nil.
+	if _, err := s.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: []*pb.Vertex{
+		{Key: "a", Value: &pb.Vertex_Int64{Int64: 1}, Expiration: futureTs(time.Minute)},
+		{Key: "n", Value: &pb.Vertex_Nil{Nil: true}, Expiration: futureTs(time.Minute)},
+	}}); err != nil {
+		t.Fatalf("PutVertices: %v", err)
+	}
+
+	// Mixed batch: 2 hits (a, n incl. present-but-nil) + 1 miss (gone).
+	if _, err := s.GetVertices(ctx, &pb.GetVerticesRequest{Keys: []string{"a", "n", "gone"}}); err != nil {
+		t.Fatalf("GetVertices: %v", err)
+	}
+	if len(fm.getVertex) != 1 {
+		t.Fatalf("getVertex observations = %d, want 1", len(fm.getVertex))
+	}
+	if got := fm.getVertex[0]; got.hits != 2 || got.misses != 1 {
+		t.Errorf("getVertex[0] = %+v, want {hits:2 misses:1}", got)
+	}
+
+	// Singular GetVertex must forward through the plural: exactly one more
+	// observation, counted as a single hit.
+	if _, err := s.GetVertex(ctx, &pb.GetVertexRequest{Key: "a"}); err != nil {
+		t.Fatalf("GetVertex: %v", err)
+	}
+	if len(fm.getVertex) != 2 {
+		t.Fatalf("getVertex observations after singular = %d, want 2", len(fm.getVertex))
+	}
+	if got := fm.getVertex[1]; got.hits != 1 || got.misses != 0 {
+		t.Errorf("getVertex[1] = %+v, want {hits:1 misses:0}", got)
+	}
+
+	// A pure miss scores only on the miss side.
+	if _, err := s.GetVertex(ctx, &pb.GetVertexRequest{Key: "absent"}); err == nil {
+		t.Fatal("GetVertex(absent): expected NotFound error, got nil")
+	}
+	if got := fm.getVertex[2]; got.hits != 0 || got.misses != 1 {
+		t.Errorf("getVertex[2] = %+v, want {hits:0 misses:1}", got)
+	}
+}
+
+// TestLanternService_HotPathMetrics_EmitsGetEdgeHitMiss asserts the #539
+// edge-side hit/miss split fires once per GetEdges and that the singular
+// GetEdge forwards through the plural.
+func TestLanternService_HotPathMetrics_EmitsGetEdgeHitMiss(t *testing.T) {
+	fm := &fakeHotPathMetrics{}
+	s := NewLanternService(graph.NewGraphCache[string, *pb.Vertex](time.Minute)).
+		WithHotPathMetrics(fm)
+	ctx := context.Background()
+
+	if _, err := s.AddEdges(ctx, &pb.AddEdgesRequest{Edges: []*pb.Edge{
+		{Tail: "a", Head: "b", Weight: 1, Expiration: futureTs(time.Minute)},
+	}}); err != nil {
+		t.Fatalf("AddEdges: %v", err)
+	}
+
+	// 1 hit (a->b) + 1 miss (a->z).
+	if _, err := s.GetEdges(ctx, &pb.GetEdgesRequest{Edges: []*pb.EdgeKey{
+		{Tail: "a", Head: "b"},
+		{Tail: "a", Head: "z"},
+	}}); err != nil {
+		t.Fatalf("GetEdges: %v", err)
+	}
+	if len(fm.getEdge) != 1 {
+		t.Fatalf("getEdge observations = %d, want 1", len(fm.getEdge))
+	}
+	if got := fm.getEdge[0]; got.hits != 1 || got.misses != 1 {
+		t.Errorf("getEdge[0] = %+v, want {hits:1 misses:1}", got)
+	}
+
+	// Singular GetEdge forwards through the plural: one more observation.
+	if _, err := s.GetEdge(ctx, &pb.GetEdgeRequest{Tail: "a", Head: "b"}); err != nil {
+		t.Fatalf("GetEdge: %v", err)
+	}
+	if len(fm.getEdge) != 2 {
+		t.Fatalf("getEdge observations after singular = %d, want 2", len(fm.getEdge))
+	}
+	if got := fm.getEdge[1]; got.hits != 1 || got.misses != 0 {
+		t.Errorf("getEdge[1] = %+v, want {hits:1 misses:0}", got)
 	}
 }
 


### PR DESCRIPTION
## What

Adds four plain Prometheus counters so **recall effectiveness** is observable from the server's `/metrics` endpoint:

| Metric | Meaning |
| --- | --- |
| `lantern_get_vertex_hits_total` | `GetVertices` lookups that found a live vertex (incl. present-but-nil value) |
| `lantern_get_vertex_misses_total` | `GetVertices` lookups with no live vertex (absent or expired) |
| `lantern_get_edge_hits_total` | `GetEdges` (tail,head) lookups that found a live edge |
| `lantern_get_edge_misses_total` | `GetEdges` lookups with no live edge |

Hit ratio = `hits / (hits + misses)` — a falling ratio is the read-side signal that "memory isn't sticking" (keys decayed away or were never written).

## How

- The plural `GetVertices` / `GetEdges` service impls already split found (`resp.Vertices`/`Edges`) from absent (`resp.Missing`), so this is a **pure read-path increment — no proto change**.
- Counting lives in the plural impl, so the singular `GetVertex` / `GetEdge` forwarders count **exactly once** (same invariant as `lantern_batch_size`).
- Wired through the existing `HotPathMetrics` interface (new `OnGetVertices` / `OnGetEdges`, mirrored on the no-op + test fake).
- Plain counters scrape as `0` from process start — no label pre-warm needed.

## Tests

- `server/metrics`: families register and accumulate across calls (zero-sides skipped, totals correct).
- `server/service`: hit/miss split fires once per call; singular forwards through plural; present-but-nil scores as a hit; pure miss scores only the miss side; edge equivalents.

## Docs

`server/README.md` metrics table gains the four rows + a "recall effectiveness" watch note.

## Scope

Part of #539 — this is the **server-side split** (ships under the next root tag). The MCP `memory_stats` tool follows in a separate PR and will close #539.
