### PR TITLE
feat(mcp): multi-node failover for the Lantern client

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -243,7 +243,7 @@ for `in`, and the union for `both`.
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `LANTERN_ADDR` | `http://localhost:6380` | Upstream Lantern endpoint URL (Connect-on-h2c by default; use `https://` for TLS). |
+| `LANTERN_ADDR` | `http://localhost:6380` | Upstream Lantern endpoint URL (Connect-on-h2c by default; use `https://` for TLS). Accepts a **comma-separated list** of endpoints for multi-node failover — see [Multi-node failover](#multi-node-failover). |
 | `LANTERN_MCP_HTTP_ADDR` | `127.0.0.1:6390` | Address the Streamable-HTTP MCP endpoint listens on. Loopback by default; set `0.0.0.0:6390` to expose on all interfaces (the container/Helm defaults). |
 | `LANTERN_MCP_PING_TIMEOUT` | `5s` | Bounds the startup health probe. A failed probe aborts startup with a non-zero exit so MCP clients surface a clear error. |
 | `LANTERN_MCP_TTL_<BUCKET>` | see table above | Per-bucket TTL override. |
@@ -251,6 +251,41 @@ for `in`, and the union for `both`.
 
 Logging is structured JSON via `log/slog` to stderr at `INFO` level;
 there is no log-level or format knob today.
+
+## Multi-node failover
+
+In a high-availability Lantern deployment the cluster runs several
+full-mesh-replicated nodes that hold identical state. Point the MCP at all
+of them by passing a **comma-separated** `LANTERN_ADDR` so the loss of any
+single node does not cut the agent off from its memory:
+
+```sh
+LANTERN_ADDR=http://lantern-0:6380,http://lantern-1:6380,http://lantern-2:6380 \
+  go run ./mcp/cmd
+```
+
+Behaviour:
+
+- **Startup probe.** The health check passes as long as **at least one**
+  endpoint reports `SERVING`; the MCP sticks to that endpoint.
+- **Per-call failover.** Each tool call is sent to the current endpoint.
+  If — and only if — that endpoint is **unreachable** (a connection
+  refused / `Unavailable` transport error), the client rotates to the next
+  endpoint and retries, walking the ring once. Application errors
+  (`not found`, `invalid argument`, rate limiting) are returned as-is and
+  never trigger failover, because a consistent replica answers them
+  identically.
+- **Stickiness.** After a rotation the client stays on the endpoint that
+  answered, so a downed node is not retried on every subsequent call.
+- **Writes.** Failover for the additive edge writes only fires on a
+  pre-delivery `Unavailable` (nothing was committed on the dead node), so a
+  rotation does not double-apply a write in the common node-down case. The
+  residual at-least-once window (a write that commits but whose response is
+  lost) is inherent to any failover and is harmless here — edge weights are
+  additive and `reinforce` is best-effort.
+
+A single (non-comma) `LANTERN_ADDR` keeps the original single-endpoint
+behaviour exactly.
 
 ## Dependency boundary
 

--- a/mcp/failover.go
+++ b/mcp/failover.go
@@ -1,0 +1,283 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"connectrpc.com/connect"
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+// parseLanternAddrs splits a comma-separated LANTERN_ADDR value into a
+// clean list of endpoint URLs. Whitespace around each entry is trimmed and
+// empty entries are dropped, so " a , ,b ," yields ["a","b"]. A single
+// address (the common case) returns a one-element slice, preserving the
+// original single-endpoint behaviour.
+func parseLanternAddrs(raw string) []string {
+	parts := strings.Split(raw, ",")
+	addrs := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if s := strings.TrimSpace(p); s != "" {
+			addrs = append(addrs, s)
+		}
+	}
+	return addrs
+}
+
+// isUnavailable reports whether err is the "this node is unreachable / not
+// serving" signal that should trigger failover to another replica.
+//
+// connect-go surfaces connection-refused dial failures and server-side
+// CodeUnavailable responses as connect.CodeUnavailable (verified
+// empirically: dialling a dead port yields "unavailable: … connection
+// refused"). Application-level errors carry other codes — ErrNotFound
+// (CodeNotFound), ErrInvalidArgument (CodeInvalidArgument),
+// ErrResourceExhausted (CodeResourceExhausted) — and must NOT trigger
+// failover, because a consistent replica would answer them identically. A
+// nil error and any non-Connect error (connect.CodeOf → CodeUnknown) are
+// treated as non-failover.
+func isUnavailable(err error) bool {
+	return err != nil && connect.CodeOf(err) == connect.CodeUnavailable
+}
+
+// failoverClient wraps an ordered set of Lantern endpoints (one per HA
+// replica) and transparently fails over between them. It implements the
+// lanternClient interface, so the MCP tool handlers consume it exactly
+// like a single *client.Lantern.
+//
+// Selection policy: calls are sticky to the last endpoint that answered
+// (cur). On a per-call basis, the wrapper tries the current endpoint
+// first; if and only if that endpoint returns an "unavailable" error
+// (isUnavailable) it advances to the next endpoint and retries, walking
+// the whole ring once. The first endpoint that either succeeds or returns
+// an application-level error wins, becomes the new sticky current, and its
+// result is returned. If every endpoint is unavailable the last
+// unavailable error is returned.
+//
+// Correctness notes (the Lantern cluster the MCP targets is full-mesh
+// replicated and consistent — see #544 — so reads against any replica are
+// equivalent):
+//   - Failover for the additive writes (AddEdge, AddEdges) only ever
+//     triggers on connect.CodeUnavailable, which connect-go returns when
+//     the request could not be delivered (e.g. connection refused) — i.e.
+//     nothing was committed on the dead node — so rotating to a healthy
+//     replica and retrying does not double-apply the write in the common
+//     node-down case. The residual at-least-once window (a write that
+//     commits on node A but whose response is lost as Unavailable) is
+//     inherent to any failover and acceptable here: edge weights are
+//     additive contributions and reinforce (#549) is best-effort.
+//   - Scan cursors (ScanVertices/ScanEdges) are radix positions over the
+//     shared, replicated keyspace, so replaying a cursor on a sibling
+//     replica is well-defined while the cluster is consistent. Callers
+//     that drive bounded scan loops (memory_stats, recall_related)
+//     tolerate a fresh restart if a rotation ever invalidates a cursor.
+type failoverClient struct {
+	nodes []lanternClient
+	cur   atomic.Uint64
+}
+
+// newFailoverClient dials every address in addrs and returns a
+// failoverClient over the resulting endpoints. addrs must be non-empty.
+// If any dial fails, every endpoint already dialled is closed and the
+// error is returned, so the caller never leaks half-open clients.
+func newFailoverClient(addrs []string, opts ...client.Option) (*failoverClient, error) {
+	if len(addrs) == 0 {
+		return nil, errors.New("mcp: newFailoverClient requires at least one address")
+	}
+	nodes := make([]lanternClient, 0, len(addrs))
+	for _, a := range addrs {
+		l, err := client.NewLantern(a, opts...)
+		if err != nil {
+			for _, n := range nodes {
+				if c, ok := n.(interface{ Close() error }); ok {
+					_ = c.Close()
+				}
+			}
+			return nil, fmt.Errorf("dial %s: %w", a, err)
+		}
+		nodes = append(nodes, l)
+	}
+	return &failoverClient{nodes: nodes}, nil
+}
+
+// try runs fn against the endpoints in sticky order, failing over to the
+// next endpoint only when the current one reports isUnavailable. It
+// returns the first non-unavailable outcome (success or application error)
+// and records the winning endpoint as the new sticky current; if all
+// endpoints are unavailable it returns the last error.
+func (f *failoverClient) try(fn func(lanternClient) error) error {
+	n := len(f.nodes)
+	if n == 0 {
+		return errors.New("mcp: failover client has no nodes")
+	}
+	start := int(f.cur.Load() % uint64(n))
+	var lastErr error
+	for i := 0; i < n; i++ {
+		idx := (start + i) % n
+		err := fn(f.nodes[idx])
+		if !isUnavailable(err) {
+			f.cur.Store(uint64(idx))
+			return err
+		}
+		lastErr = err
+	}
+	return lastErr
+}
+
+func (f *failoverClient) PutVertex(ctx context.Context, key string, value any, ttl time.Duration) error {
+	return f.try(func(lc lanternClient) error {
+		return lc.PutVertex(ctx, key, value, ttl)
+	})
+}
+
+func (f *failoverClient) GetVertex(ctx context.Context, key string) (*client.Vertex, error) {
+	var out *client.Vertex
+	err := f.try(func(lc lanternClient) error {
+		v, e := lc.GetVertex(ctx, key)
+		out = v
+		return e
+	})
+	return out, err
+}
+
+func (f *failoverClient) DeleteVertex(ctx context.Context, key string) (bool, error) {
+	var out bool
+	err := f.try(func(lc lanternClient) error {
+		v, e := lc.DeleteVertex(ctx, key)
+		out = v
+		return e
+	})
+	return out, err
+}
+
+func (f *failoverClient) ScanVertices(ctx context.Context, prefix string, opts ...client.ScanOption) ([]*client.Vertex, []byte, error) {
+	var (
+		verts  []*client.Vertex
+		cursor []byte
+	)
+	err := f.try(func(lc lanternClient) error {
+		v, c, e := lc.ScanVertices(ctx, prefix, opts...)
+		verts, cursor = v, c
+		return e
+	})
+	return verts, cursor, err
+}
+
+func (f *failoverClient) CountVerticesByPrefix(ctx context.Context, prefix string) (uint64, error) {
+	var out uint64
+	err := f.try(func(lc lanternClient) error {
+		v, e := lc.CountVerticesByPrefix(ctx, prefix)
+		out = v
+		return e
+	})
+	return out, err
+}
+
+func (f *failoverClient) DeleteVerticesByPrefix(ctx context.Context, prefix string, opts ...client.DeleteByPrefixOption) (uint64, error) {
+	var out uint64
+	err := f.try(func(lc lanternClient) error {
+		v, e := lc.DeleteVerticesByPrefix(ctx, prefix, opts...)
+		out = v
+		return e
+	})
+	return out, err
+}
+
+func (f *failoverClient) PutVertices(ctx context.Context, inputs []client.VertexInput) error {
+	return f.try(func(lc lanternClient) error {
+		return lc.PutVertices(ctx, inputs)
+	})
+}
+
+func (f *failoverClient) AddEdge(ctx context.Context, tail, head string, weight float32, ttl time.Duration) error {
+	return f.try(func(lc lanternClient) error {
+		return lc.AddEdge(ctx, tail, head, weight, ttl)
+	})
+}
+
+func (f *failoverClient) AddEdges(ctx context.Context, inputs []client.EdgeInput) error {
+	return f.try(func(lc lanternClient) error {
+		return lc.AddEdges(ctx, inputs)
+	})
+}
+
+func (f *failoverClient) GetEdge(ctx context.Context, tail, head string) (*client.Edge, error) {
+	var out *client.Edge
+	err := f.try(func(lc lanternClient) error {
+		v, e := lc.GetEdge(ctx, tail, head)
+		out = v
+		return e
+	})
+	return out, err
+}
+
+func (f *failoverClient) ScanEdges(ctx context.Context, opts ...client.EdgeScanOption) ([]*client.Edge, []byte, error) {
+	var (
+		edges  []*client.Edge
+		cursor []byte
+	)
+	err := f.try(func(lc lanternClient) error {
+		es, c, e := lc.ScanEdges(ctx, opts...)
+		edges, cursor = es, c
+		return e
+	})
+	return edges, cursor, err
+}
+
+func (f *failoverClient) Illuminate(ctx context.Context, seed string, opts ...client.IlluminateOption) (*client.Graph, error) {
+	var out *client.Graph
+	err := f.try(func(lc lanternClient) error {
+		g, e := lc.Illuminate(ctx, seed, opts...)
+		out = g
+		return e
+	})
+	return out, err
+}
+
+// Ping reports the cluster healthy if ANY endpoint reports SERVING. Unlike
+// the data methods it does not classify the error: the SDK's Ping uses a
+// raw HTTP health probe whose transport failure is not a connect code, so
+// Ping simply walks every endpoint in sticky order and returns nil on the
+// first success, sticking to that endpoint. If every endpoint fails it
+// returns the last error. This makes the MCP startup health gate pass as
+// long as one replica is reachable.
+func (f *failoverClient) Ping(ctx context.Context) error {
+	n := len(f.nodes)
+	if n == 0 {
+		return errors.New("mcp: failover client has no nodes")
+	}
+	start := int(f.cur.Load() % uint64(n))
+	var lastErr error
+	for i := 0; i < n; i++ {
+		idx := (start + i) % n
+		if err := f.nodes[idx].Ping(ctx); err != nil {
+			lastErr = err
+			continue
+		}
+		f.cur.Store(uint64(idx))
+		return nil
+	}
+	return lastErr
+}
+
+// Close releases every underlying endpoint's idle connections. It attempts
+// to close all endpoints and returns the first close error, if any.
+// Endpoints that do not expose Close (test fakes) are skipped.
+func (f *failoverClient) Close() error {
+	var firstErr error
+	for _, n := range f.nodes {
+		if c, ok := n.(interface{ Close() error }); ok {
+			if err := c.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}
+
+// Compile-time assertion: *failoverClient satisfies lanternClient.
+var _ lanternClient = (*failoverClient)(nil)

--- a/mcp/failover_test.go
+++ b/mcp/failover_test.go
@@ -1,0 +1,246 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+// unavailableErr builds the connect error the SDK surfaces when a Lantern
+// node is unreachable (connection refused) or returns CodeUnavailable.
+func unavailableErr() error {
+	return connect.NewError(connect.CodeUnavailable, errors.New("node down"))
+}
+
+func TestParseLanternAddrs(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"single", "http://a:6380", []string{"http://a:6380"}},
+		{"two", "http://a:6380,http://b:6380", []string{"http://a:6380", "http://b:6380"}},
+		{"trim-and-drop-empties", " http://a:6380 , , http://b:6380 ,", []string{"http://a:6380", "http://b:6380"}},
+		{"empty", "", nil},
+		{"only-separators", " , ", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseLanternAddrs(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("parseLanternAddrs(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("parseLanternAddrs(%q)[%d] = %q, want %q", tc.in, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestIsUnavailable(t *testing.T) {
+	if isUnavailable(nil) {
+		t.Fatal("nil must not be classified unavailable")
+	}
+	if !isUnavailable(unavailableErr()) {
+		t.Fatal("CodeUnavailable must be classified unavailable")
+	}
+	if isUnavailable(connect.NewError(connect.CodeNotFound, errors.New("nf"))) {
+		t.Fatal("CodeNotFound must not be classified unavailable")
+	}
+	if isUnavailable(client.ErrNotFound) {
+		t.Fatal("sentinel ErrNotFound must not be classified unavailable")
+	}
+	if isUnavailable(errors.New("plain")) {
+		t.Fatal("plain (non-connect) error must not be classified unavailable")
+	}
+}
+
+func TestNewFailoverClient_RejectsEmpty(t *testing.T) {
+	if _, err := newFailoverClient(nil); err == nil {
+		t.Fatal("newFailoverClient(nil) returned nil error")
+	}
+}
+
+func TestNewFailoverClient_DialsAllAddrs(t *testing.T) {
+	// NewLantern is lazy (no connection established until first RPC), so
+	// this constructs two endpoints without a live server.
+	f, err := newFailoverClient([]string{"http://127.0.0.1:6380", "http://127.0.0.1:6381"})
+	if err != nil {
+		t.Fatalf("newFailoverClient err = %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	if len(f.nodes) != 2 {
+		t.Fatalf("nodes = %d, want 2", len(f.nodes))
+	}
+}
+
+func TestNewFailoverClient_RejectsBadAddr(t *testing.T) {
+	if _, err := newFailoverClient([]string{"http://ok:6380", "no-scheme"}); err == nil {
+		t.Fatal("expected error for schemeless address")
+	}
+}
+
+func TestFailover_RotatesOnUnavailableReadAndSticks(t *testing.T) {
+	var n0, n1 int
+	node0 := &fakeLantern{getVertexFn: func(_ context.Context, _ string) (*client.Vertex, error) {
+		n0++
+		return nil, unavailableErr()
+	}}
+	node1 := &fakeLantern{getVertexFn: func(_ context.Context, key string) (*client.Vertex, error) {
+		n1++
+		return &client.Vertex{Key: key}, nil
+	}}
+	f := &failoverClient{nodes: []lanternClient{node0, node1}}
+
+	v, err := f.GetVertex(context.Background(), "k")
+	if err != nil {
+		t.Fatalf("GetVertex err = %v", err)
+	}
+	if v == nil || v.Key != "k" {
+		t.Fatalf("GetVertex returned %+v, want vertex with key k", v)
+	}
+	if n0 != 1 || n1 != 1 {
+		t.Fatalf("call counts n0=%d n1=%d, want 1 and 1", n0, n1)
+	}
+
+	// After rotating to node1 the wrapper is sticky: a second call starts
+	// at node1 and never touches the known-dead node0.
+	if _, err := f.GetVertex(context.Background(), "k2"); err != nil {
+		t.Fatalf("second GetVertex err = %v", err)
+	}
+	if n0 != 1 {
+		t.Fatalf("node0 retried after rotation: n0=%d, want 1", n0)
+	}
+	if n1 != 2 {
+		t.Fatalf("node1 not sticky: n1=%d, want 2", n1)
+	}
+}
+
+func TestFailover_DoesNotRotateOnAppError(t *testing.T) {
+	var n0, n1 int
+	node0 := &fakeLantern{getVertexFn: func(_ context.Context, _ string) (*client.Vertex, error) {
+		n0++
+		return nil, client.ErrNotFound
+	}}
+	node1 := &fakeLantern{getVertexFn: func(_ context.Context, _ string) (*client.Vertex, error) {
+		n1++
+		return nil, nil
+	}}
+	f := &failoverClient{nodes: []lanternClient{node0, node1}}
+
+	_, err := f.GetVertex(context.Background(), "k")
+	if !errors.Is(err, client.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+	if n0 != 1 || n1 != 0 {
+		t.Fatalf("call counts n0=%d n1=%d, want 1 and 0 (no rotation on app error)", n0, n1)
+	}
+}
+
+func TestFailover_AllNodesUnavailableReturnsError(t *testing.T) {
+	mk := func(c *int) *fakeLantern {
+		return &fakeLantern{getVertexFn: func(_ context.Context, _ string) (*client.Vertex, error) {
+			*c++
+			return nil, unavailableErr()
+		}}
+	}
+	var a, b, c int
+	f := &failoverClient{nodes: []lanternClient{mk(&a), mk(&b), mk(&c)}}
+
+	_, err := f.GetVertex(context.Background(), "k")
+	if !isUnavailable(err) {
+		t.Fatalf("err = %v, want unavailable", err)
+	}
+	if a != 1 || b != 1 || c != 1 {
+		t.Fatalf("each node should be tried exactly once: a=%d b=%d c=%d", a, b, c)
+	}
+}
+
+func TestFailover_PingTriesAllNodesUntilHealthy(t *testing.T) {
+	node0 := &fakeLantern{pingErr: errors.New("connection refused")}
+	node1 := &fakeLantern{pingErr: nil}
+	f := &failoverClient{nodes: []lanternClient{node0, node1}}
+
+	if err := f.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping err = %v, want nil (node1 healthy)", err)
+	}
+
+	// Ping should leave the wrapper sticky to the healthy node1, so a
+	// subsequent data call starts there.
+	var n0, n1 int
+	node0.getVertexFn = func(_ context.Context, _ string) (*client.Vertex, error) { n0++; return nil, nil }
+	node1.getVertexFn = func(_ context.Context, _ string) (*client.Vertex, error) { n1++; return nil, nil }
+	if _, err := f.GetVertex(context.Background(), "k"); err != nil {
+		t.Fatalf("GetVertex err = %v", err)
+	}
+	if n0 != 0 || n1 != 1 {
+		t.Fatalf("after Ping stickiness n0=%d n1=%d, want 0 and 1", n0, n1)
+	}
+}
+
+func TestFailover_PingAllNodesFailReturnsError(t *testing.T) {
+	f := &failoverClient{nodes: []lanternClient{
+		&fakeLantern{pingErr: errors.New("down0")},
+		&fakeLantern{pingErr: errors.New("down1")},
+	}}
+	if err := f.Ping(context.Background()); err == nil {
+		t.Fatal("Ping returned nil, want error when all nodes are down")
+	}
+}
+
+func TestFailover_AdditiveWriteRotatesOnUnavailable(t *testing.T) {
+	var n0, n1 int
+	node0 := &fakeLantern{addEdgeFn: func(_ context.Context, _, _ string, _ float32, _ time.Duration) error {
+		n0++
+		return unavailableErr()
+	}}
+	node1 := &fakeLantern{addEdgeFn: func(_ context.Context, _, _ string, _ float32, _ time.Duration) error {
+		n1++
+		return nil
+	}}
+	f := &failoverClient{nodes: []lanternClient{node0, node1}}
+
+	if err := f.AddEdge(context.Background(), "a", "b", 1, time.Hour); err != nil {
+		t.Fatalf("AddEdge err = %v", err)
+	}
+	if n0 != 1 || n1 != 1 {
+		t.Fatalf("call counts n0=%d n1=%d, want 1 and 1 (rotated to healthy replica)", n0, n1)
+	}
+}
+
+func TestFailover_SingleNodePropagatesUnavailable(t *testing.T) {
+	node := &fakeLantern{getVertexFn: func(_ context.Context, _ string) (*client.Vertex, error) {
+		return nil, unavailableErr()
+	}}
+	f := &failoverClient{nodes: []lanternClient{node}}
+	if _, err := f.GetVertex(context.Background(), "k"); !isUnavailable(err) {
+		t.Fatalf("single-node unavailable err = %v, want unavailable", err)
+	}
+}
+
+func TestFailover_ScanVerticesRotatesAndReturnsCursor(t *testing.T) {
+	node0 := &fakeLantern{scanVerticesFn: func(_ context.Context, _ string, _ ...client.ScanOption) ([]*client.Vertex, []byte, error) {
+		return nil, nil, unavailableErr()
+	}}
+	node1 := &fakeLantern{scanVerticesFn: func(_ context.Context, prefix string, _ ...client.ScanOption) ([]*client.Vertex, []byte, error) {
+		return []*client.Vertex{{Key: prefix + "x"}}, []byte("cursor"), nil
+	}}
+	f := &failoverClient{nodes: []lanternClient{node0, node1}}
+
+	vs, cur, err := f.ScanVertices(context.Background(), "p.", client.WithScanLimit(10))
+	if err != nil {
+		t.Fatalf("ScanVertices err = %v", err)
+	}
+	if len(vs) != 1 || vs[0].Key != "p.x" {
+		t.Fatalf("vertices = %+v, want [p.x]", vs)
+	}
+	if string(cur) != "cursor" {
+		t.Fatalf("cursor = %q, want \"cursor\"", cur)
+	}
+}

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -3,13 +3,14 @@ module github.com/anaregdesign/lantern/mcp
 go 1.26
 
 require (
+	connectrpc.com/connect v1.20.0
 	github.com/anaregdesign/lantern/pb v0.3.0
 	github.com/anaregdesign/lantern/sdks/go v0.11.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
+	google.golang.org/protobuf v1.36.11
 )
 
 require (
-	connectrpc.com/connect v1.20.0 // indirect
 	github.com/anaregdesign/lantern/core v0.3.0 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
@@ -19,7 +20,6 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 )
 
 replace (

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -38,9 +38,13 @@ const (
 // here is read from environment variables in main; tests construct Config
 // directly to skip env wiring.
 type Config struct {
-	// LanternAddr is the target passed to client.NewLantern. Default
-	// "http://localhost:6380" matches the Lantern server's default
-	// port and the SDK's plaintext-h2c scheme requirement.
+	// LanternAddr is the target — or comma-separated list of targets —
+	// the Lantern client dials. A single value dials one endpoint; a
+	// comma-separated list (e.g. "http://a:6380,http://b:6380") enables
+	// multi-node failover across HA replicas (see #544 and the failover
+	// notes in mcp/README.md). Default "http://localhost:6380" matches the
+	// Lantern server's default port and the SDK's plaintext-h2c scheme
+	// requirement.
 	LanternAddr string
 	// PingTimeout bounds the startup health check. The MCP server will
 	// refuse to register tools if the Lantern endpoint is unreachable
@@ -128,13 +132,18 @@ func Run(ctx context.Context, cfg Config) error {
 		httpAddr = defaultHTTPAddr
 	}
 
+	addrs := parseLanternAddrs(cfg.LanternAddr)
+	if len(addrs) == 0 {
+		return fmt.Errorf("mcp: no lantern address configured (set LANTERN_ADDR)")
+	}
 	logger.Info("mcp: dialing lantern",
-		slog.String("addr", cfg.LanternAddr),
+		slog.Any("addrs", addrs),
+		slog.Int("nodes", len(addrs)),
 		slog.String("version", Version),
 	)
-	lantern, err := client.NewLantern(cfg.LanternAddr)
+	lantern, err := newFailoverClient(addrs)
 	if err != nil {
-		return fmt.Errorf("mcp: dial %s: %w", cfg.LanternAddr, err)
+		return fmt.Errorf("mcp: dial lantern: %w", err)
 	}
 	defer func() {
 		if cerr := lantern.Close(); cerr != nil {
@@ -145,7 +154,7 @@ func Run(ctx context.Context, cfg Config) error {
 	pingCtx, cancel := context.WithTimeout(ctx, cfg.PingTimeout)
 	defer cancel()
 	if err := lantern.Ping(pingCtx); err != nil {
-		return fmt.Errorf("mcp: lantern health check at %s failed: %w", cfg.LanternAddr, err)
+		return fmt.Errorf("mcp: lantern health check failed (tried %d node(s)): %w", len(addrs), err)
 	}
 	logger.Info("mcp: lantern reachable, registering tools")
 


### PR DESCRIPTION
## What

Adds **multi-node failover** to the MCP's upstream Lantern client so the
server can target every node of a full-mesh-replicated HA cluster and keep
serving an agent's memory when any single node goes down.

`LANTERN_ADDR` now accepts a **comma-separated** list of endpoints. A
single (non-comma) value preserves the original single-endpoint behaviour
exactly. The public `NewServer` API is unchanged.

## How

- **`failover.go` (new).** `failoverClient` wraps an ordered set of
  `*client.Lantern` endpoints (one per replica) and implements the
  internal `lanternClient` interface, so every tool handler consumes it
  exactly like a single client.
  - **Sticky selection.** Calls go to the last endpoint that answered.
  - **Rotate on Unavailable only.** A call fails over to the next endpoint
    **iff** the current one returns `connect.CodeUnavailable` (connection
    refused / node down — verified empirically that connect-go maps a dead
    port to this code). Application errors (`not found`, `invalid
    argument`, `resource exhausted`) return as-is and never trigger
    failover, because a consistent replica answers them identically.
  - **Ping.** Tries every endpoint and reports healthy if **any** one is
    `SERVING`, so the startup health gate passes while at least one replica
    is reachable. (The SDK `Ping` uses a raw HTTP health probe whose
    failure isn't a connect code, so it's walked unconditionally rather
    than classified.)
- **`server.go`.** `Run` parses `LANTERN_ADDR` into a node list and dials
  it via `newFailoverClient`, with an errcheck-safe deferred `Close`.
- **`README.md`.** New *Multi-node failover* section + updated
  `LANTERN_ADDR` env row.
- **`go.mod`.** `go mod tidy` promotes `connectrpc.com/connect` (now
  imported directly by `failover.go`) and `google.golang.org/protobuf` to
  direct requirements.

## Additive-write safety

Failover for the additive edge writes (`AddEdge`/`AddEdges`) only fires on
a **pre-delivery** `Unavailable` — the request never reached the dead node,
so nothing was committed and rotating + retrying does not double-apply in
the common node-down case. The residual at-least-once window (commit on
node A, response lost as `Unavailable`) is inherent to any failover and is
harmless here: edge weights are additive contributions and `reinforce`
(#549) is best-effort. Documented in the `failoverClient` doc comment.

## Scope

`mcp`-only change (no `sdks/go` change) → ships in the next `mcp` release.
Classification is done in `mcp` via `connect.CodeOf`, keeping this a
single-module change rather than forcing an SDK sentinel + release.

## Testing

`mcp/failover_test.go` (new) — 14 tests, all green:
`TestParseLanternAddrs` (table), `TestIsUnavailable`,
`TestNewFailoverClient_{RejectsEmpty,DialsAllAddrs,RejectsBadAddr}`,
`TestFailover_{RotatesOnUnavailableReadAndSticks,DoesNotRotateOnAppError,AllNodesUnavailableReturnsError,PingTriesAllNodesUntilHealthy,PingAllNodesFailReturnsError,AdditiveWriteRotatesOnUnavailable,SingleNodePropagatesUnavailable,ScanVerticesRotatesAndReturnsCursor}`.

Full local gate green: `gofmt -l`, `go vet ./...` (mcp), root `go test
./...`, and per-module `go test ./...` for core / pb / sdks/go / mcp.

Closes #544
