### PR TITLE
fix(core,server): honor Objective in Illuminate top-k pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ shape (#410):
 | Axis | Values | What it does |
 |---|---|---|
 | `algorithm` | `none` (default) — raw k-NN subgraph<br>`mst` — spanning tree<br>`spt` — shortest-path tree from seed | Picks the post-traversal subgraph reduction |
-| `objective` | `min` (default) — smallest-weight tree wins<br>`max` — largest-weight tree wins | Picks the direction of the reduction. Ignored when `algorithm=none` |
+| `objective` | `max` (default) — keeps strongest edges, largest-weight tree wins<br>`min` — keeps smallest edges, smallest-weight tree wins | Picks the direction of BOTH the per-hop top-k prune and the reduction (#560) |
 | `weighting` | `raw` (default) — edge.weight verbatim<br>`tfidf` — per-hop top-k weighted by `w / log2(1+df(head))` | Picks the edge-weight transform applied BEFORE the BFS walk |
 
 Examples:

--- a/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.tsx
+++ b/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.tsx
@@ -288,15 +288,15 @@ export function IlluminateToolbar({
         <RadioGroup
           value={
             controls.objective === "OBJECTIVE_UNSPECIFIED"
-              ? "OBJECTIVE_MINIMIZE"
+              ? "OBJECTIVE_MAXIMIZE"
               : controls.objective
           }
           onChange={(_, data) => update("objective", data.value as Objective)}
           layout="horizontal-stacked"
-          // Objective is only meaningful when an algorithm reduction is
-          // selected; disable the radio when algorithm = UNSPECIFIED so the
-          // UI reflects the server semantics.
-          disabled={controls.algorithm === "ALGORITHM_UNSPECIFIED"}
+          // Per #560 the objective governs BOTH the per-hop top-k pruning
+          // (always, even when algorithm = none) and the post-traversal
+          // reduction, so it is always meaningful — never disabled. The
+          // UNSPECIFIED fallback mirrors the server's MAXIMIZE default.
         >
           {OBJECTIVES.map((opt) => (
             <Radio

--- a/admin/app/lib/cli/illuminate-axes.test.ts
+++ b/admin/app/lib/cli/illuminate-axes.test.ts
@@ -62,9 +62,9 @@ describe("formatIlluminateClick", () => {
     expect(
       formatIlluminateClick("alice", {
         ...CLI_CLICK_AXIS_DEFAULTS,
-        objective: "max",
+        objective: "min",
       }),
-    ).toBe("illuminate alice 2 5 objective=max");
+    ).toBe("illuminate alice 2 5 objective=min");
   });
 
   test("only weighting off-default → single kwarg", () => {
@@ -82,10 +82,10 @@ describe("formatIlluminateClick", () => {
         step: 3,
         k: 10,
         algorithm: "spt",
-        objective: "max",
+        objective: "min",
         weighting: "tfidf",
       }),
-    ).toBe("illuminate alice 3 10 algorithm=spt objective=max weighting=tfidf");
+    ).toBe("illuminate alice 3 10 algorithm=spt objective=min weighting=tfidf");
   });
 
   test("seed containing a colon round-trips literally", () => {
@@ -115,8 +115,8 @@ describe("formatIlluminateClick ↔ parse round-trip", () => {
       axes: { ...CLI_CLICK_AXIS_DEFAULTS, algorithm: "spt" },
     },
     {
-      name: "only objective=max",
-      axes: { ...CLI_CLICK_AXIS_DEFAULTS, objective: "max" },
+      name: "only objective=min",
+      axes: { ...CLI_CLICK_AXIS_DEFAULTS, objective: "min" },
     },
     {
       name: "only weighting=tfidf",
@@ -128,7 +128,7 @@ describe("formatIlluminateClick ↔ parse round-trip", () => {
         step: 3,
         k: 10,
         algorithm: "spt",
-        objective: "max",
+        objective: "min",
         weighting: "tfidf",
       },
     },

--- a/admin/app/lib/cli/illuminate-axes.ts
+++ b/admin/app/lib/cli/illuminate-axes.ts
@@ -53,7 +53,12 @@ export const CLI_CLICK_AXIS_DEFAULTS: CliClickAxes = {
   step: 2,
   k: 5,
   algorithm: "none",
-  objective: "min",
+  // #560: the server resolves an unspecified objective to MAXIMIZE, and the
+  // objective now also steers the per-hop top-k pruning. Defaulting the
+  // picker to `max` keeps the bare click on the strongest neighbours
+  // (the pre-#560 de-facto behaviour) instead of silently inverting to
+  // the weakest once the click is dispatched.
+  objective: "max",
   weighting: "raw",
 };
 

--- a/admin/app/lib/cli/verbs.test.ts
+++ b/admin/app/lib/cli/verbs.test.ts
@@ -131,7 +131,7 @@ describe("HELP_TEXT (#436 — grammar contract)", () => {
 
   test("documents illuminate kwarg defaults", () => {
     expect(HELP_TEXT).toContain("default=none");
-    expect(HELP_TEXT).toContain("default=min");
+    expect(HELP_TEXT).toContain("default=max");
     expect(HELP_TEXT).toContain("default=raw");
   });
 

--- a/admin/app/lib/cli/verbs.ts
+++ b/admin/app/lib/cli/verbs.ts
@@ -275,7 +275,10 @@ export function parseIlluminate(rest: string[]): ParseResult {
     return { ok: false, usage };
   }
   let algorithm: AlgorithmName = "none";
-  let objective: ObjectiveName = "min";
+  // #560: defaults to `max` so a long-form command that omits the objective
+  // kwarg matches the server's MAXIMIZE default and the click picker's
+  // default — keeping the strongest-neighbour behaviour byte-for-byte.
+  let objective: ObjectiveName = "max";
   let weighting: WeightingName = "raw";
   for (let i = 3; i < rest.length; i++) {
     const tok = rest[i];
@@ -347,7 +350,7 @@ export const HELP_TEXT = [
   "  scan   edges    <tail-prefix: string> [<limit: int>]",
   "  illuminate <seed: string> <step: int> <k: int>",
   "             [algorithm={none|mst|spt}]  default=none",
-  "             [objective={min|max}]       default=min",
+  "             [objective={min|max}]       default=max",
   "             [weighting={raw|tfidf}]     default=raw",
   "  help",
   "  exit",

--- a/admin/app/lib/client/usecase/illuminate/state.ts
+++ b/admin/app/lib/client/usecase/illuminate/state.ts
@@ -30,7 +30,10 @@ export interface IlluminateControls {
 /**
  * Defaults that match the server's behaviour when knobs are omitted, and
  * give a sensible first frame for the user. UNSPECIFIED on every axis
- * lets the server pick (raw subgraph, minimise direction, raw weighting).
+ * lets the server pick (raw subgraph, maximise direction, raw weighting).
+ * Per #560 the server resolves an unspecified objective to MAXIMIZE and
+ * the objective steers the per-hop top-k pruning as well as the
+ * post-traversal reduction.
  */
 export const DEFAULT_ILLUMINATE_CONTROLS: IlluminateControls = {
   step: 2,

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -361,7 +361,7 @@ test.describe("/cli", () => {
     await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
     const picker = page.getByTestId("cli-axis-picker");
     await expect(picker).toBeVisible();
-    // Defaults: step=2, k=5, algorithm=none, objective=min, weighting=raw
+    // Defaults: step=2, k=5, algorithm=none, objective=max, weighting=raw
     // → short form `illuminate <key> 2 5`.
     await expect(page.getByTestId("cli-axis-preview")).toHaveText(
       "illuminate <key> 2 5",
@@ -401,22 +401,22 @@ test.describe("/cli", () => {
     await page.getByRole("option", { name: "Shortest-path tree" }).click();
     await expect(preview).toHaveText("illuminate <key> 3 10 algorithm=spt");
 
-    // Pick objective=max.
+    // Pick objective=min (max is the default, so it would be omitted).
     await page.getByTestId("cli-axis-objective").click();
-    await page.getByRole("option", { name: /Maximize/ }).click();
+    await page.getByRole("option", { name: /Minimize/ }).click();
     await expect(preview).toHaveText(
-      "illuminate <key> 3 10 algorithm=spt objective=max",
+      "illuminate <key> 3 10 algorithm=spt objective=min",
     );
 
     // Flip TF-IDF on. Token order must be algorithm → objective → weighting.
     await page.getByTestId("cli-axis-tfidf").click();
     await expect(preview).toHaveText(
-      "illuminate <key> 3 10 algorithm=spt objective=max weighting=tfidf",
+      "illuminate <key> 3 10 algorithm=spt objective=min weighting=tfidf",
     );
 
     // The header hint tracks the picker.
     await expect(page.getByTestId("cli-click-hint")).toHaveText(
-      "illuminate <key> 3 10 algorithm=spt objective=max weighting=tfidf",
+      "illuminate <key> 3 10 algorithm=spt objective=min weighting=tfidf",
     );
   });
 

--- a/cli/cmd/illuminate.go
+++ b/cli/cmd/illuminate.go
@@ -55,10 +55,13 @@ ORTHOGONAL ILLUMINATE AXES (#410)
                           none  (default) return the raw discovered subgraph
                           mst   minimum or maximum spanning tree
                           spt   shortest-path tree rooted at the seed
-  --objective <dir>     direction of the algorithm-driven reduction:
-                          min   (default) smallest-weight tree wins
-                          max   largest-weight tree wins (use when weight
-                                encodes RELEVANCE, not cost)
+  --objective <dir>     direction of the weight-sensitive optimisation;
+                        governs BOTH the per-hop top-k pruning and the
+                        algorithm-driven reduction (#560):
+                          max   (default) largest-weight edges win (use when
+                                weight encodes RELEVANCE)
+                          min   smallest-weight edges win (use when weight
+                                encodes COST)
   --weighting <mode>    edge-weight transform applied BEFORE the walk:
                           raw   (default) edge.weight as stored
                           tfidf re-score using TF-IDF over the per-vertex
@@ -86,7 +89,7 @@ EXAMPLES
   lantern illuminate alice --step 2 --k 5 --weighting tfidf
 
   # 3-hop MST rooted at alice (smallest-weight connecting tree)
-  lantern illuminate alice --step 3 --k 20 --algorithm mst
+  lantern illuminate alice --step 3 --k 20 --algorithm mst --objective min
 
   # 3-hop relevance-weighted SPT (formerly the "inverse-SPT" enum value)
   lantern illuminate alice --step 3 --k 20 --algorithm spt --objective max
@@ -132,7 +135,7 @@ func init() {
 	illuminateCmd.Flags().Uint32Var(&illuminateStep, "step", 1, "maximum walk depth from the seed")
 	illuminateCmd.Flags().Uint32Var(&illuminateK, "k", 10, "max neighbours visited per node")
 	illuminateCmd.Flags().StringVar(&illuminateAlgorithmStr, "algorithm", "none", "post-traversal reduction: none|mst|spt (#410)")
-	illuminateCmd.Flags().StringVar(&illuminateObjectiveStr, "objective", "min", "reduction direction: min|max (ignored when --algorithm none) (#410)")
+	illuminateCmd.Flags().StringVar(&illuminateObjectiveStr, "objective", "max", "optimisation direction: min|max; governs per-hop top-k pruning AND reduction (#560)")
 	illuminateCmd.Flags().StringVar(&illuminateWeightingStr, "weighting", "raw", "edge-weight transform before walk: raw|tfidf (#410)")
 	rootCmd.AddCommand(illuminateCmd)
 }

--- a/cli/cmd/repl.go
+++ b/cli/cmd/repl.go
@@ -53,10 +53,11 @@ CASE (#437)
 
 The illuminate verb exposes the orthogonal axes introduced in #410:
 algorithm selects the post-traversal reduction, objective picks the
-direction (minimise/maximise), and weighting toggles RAW vs TF-IDF edge
-weights. The three keyword arguments may appear in any order; each
-defaults to the server's UNSPECIFIED resolution (algorithm=none,
-objective=min, weighting=raw).
+direction (minimise/maximise) for BOTH the per-hop top-k pruning and the
+reduction, and weighting toggles RAW vs TF-IDF edge weights. The three
+keyword arguments may appear in any order; each defaults to the
+strongest-edge behaviour (algorithm=none, objective=max, weighting=raw),
+so a bare illuminate keeps the top-k strongest neighbours (#560).
 
 EXAMPLE
   $ lantern repl

--- a/cli/parser/help_test.go
+++ b/cli/parser/help_test.go
@@ -29,7 +29,7 @@ func TestHelpText_EnumeratesIlluminateKwargValues(t *testing.T) {
 }
 
 func TestHelpText_DocumentsIlluminateDefaults(t *testing.T) {
-	for _, d := range []string{"default=none", "default=min", "default=raw"} {
+	for _, d := range []string{"default=none", "default=max", "default=raw"} {
 		if !strings.Contains(HelpText, d) {
 			t.Errorf("HelpText missing illuminate default %q", d)
 		}

--- a/cli/parser/model.go
+++ b/cli/parser/model.go
@@ -45,7 +45,7 @@ type Illuminate struct {
 	Step      int
 	K         int
 	Algorithm string // "none" | "mst" | "spt" (default: "none")
-	Objective string // "min" | "max"           (default: "min")
+	Objective string // "min" | "max"           (default: "max")
 	Weighting string // "raw" | "tfidf"         (default: "raw")
 }
 

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -321,14 +321,16 @@ func DeleteEdgeParam(s *Source) (*DeleteEdge, error) {
 //	illuminate <seed> <step> <k> [algorithm=none|mst|spt] [objective=min|max] [weighting=raw|tfidf]
 //
 // The three keyword arguments may appear in any order and any subset.
-// Each defaults to its UNSPECIFIED enum value, which the server
-// resolves to (algorithm=none, objective=minimize, weighting=raw).
+// Each defaults to the strongest-edge behaviour (algorithm=none,
+// objective=max, weighting=raw); objective defaults to max so a bare
+// illuminate keeps the top-k strongest neighbours and the per-hop
+// pruning matches the reduction direction (#560).
 // Unknown keyword names, malformed `key=value` tokens, or values
 // outside the canonical set above are rejected with a descriptive
 // error so the REPL can surface a usage hint.
 func IlluminateParam(s *Source) (*Illuminate, error) {
 	var err error
-	m := &Illuminate{Algorithm: "none", Objective: "min", Weighting: "raw"}
+	m := &Illuminate{Algorithm: "none", Objective: "max", Weighting: "raw"}
 	if m.Seed, err = String(s); err != nil {
 		return nil, err
 	}
@@ -460,7 +462,7 @@ const HelpText = `Lantern CLI grammar:
   scan   edges    <tail-prefix: string> [<limit: int>]
   illuminate <seed: string> <step: int> <k: int>
              [algorithm={none|mst|spt}]  default=none
-             [objective={min|max}]       default=min
+             [objective={min|max}]       default=max
              [weighting={raw|tfidf}]     default=raw
   help
   exit

--- a/core/cache/graph/batch_external_test.go
+++ b/core/cache/graph/batch_external_test.go
@@ -41,7 +41,7 @@ func TestAddEdgesWithExpiration_AtomicNeighborSnapshot(t *testing.T) {
 		go func() {
 			defer readerWG.Done()
 			for !stop.Load() {
-				g := c.Neighbor("s", 1, fanOut+1, false)
+				g := c.Neighbor("s", 1, fanOut+1, false, false)
 				reads.Add(1)
 				if g == nil {
 					continue
@@ -102,7 +102,7 @@ func TestDeleteEdges_AtomicNeighborSnapshot(t *testing.T) {
 		go func() {
 			defer readerWG.Done()
 			for !stop.Load() {
-				g := c.Neighbor("s", 1, fanOut+1, false)
+				g := c.Neighbor("s", 1, fanOut+1, false, false)
 				reads.Add(1)
 				if g == nil {
 					continue

--- a/core/cache/graph/bench_test.go
+++ b/core/cache/graph/bench_test.go
@@ -181,7 +181,7 @@ func BenchmarkNeighbor_Small(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_ = c.Neighbor(keys[i%s.vertices], 1, 10, false)
+				_ = c.Neighbor(keys[i%s.vertices], 1, 10, false, false)
 			}
 		})
 	}
@@ -199,7 +199,7 @@ func BenchmarkNeighbor_Large(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_ = c.Neighbor(keys[i%s.vertices], 3, 10, false)
+				_ = c.Neighbor(keys[i%s.vertices], 3, 10, false, false)
 			}
 		})
 	}

--- a/core/cache/graph/cache.go
+++ b/core/cache/graph/cache.go
@@ -436,8 +436,14 @@ func (c *GraphCache[S, T]) snapshotHooks() (func(string, int), func(time.Duratio
 	return c.onExpire, c.onGCDuration
 }
 
-func (c *GraphCache[S, T]) Neighbor(seed S, step int, k int, tfidf bool) *graph.Graph[S, T] {
-	g, _ := c.NeighborContext(context.Background(), seed, step, k, tfidf)
+// Neighbor walks the graph from seed and returns the visited subgraph. The
+// per-hop top-k pruning keeps the k largest-weight edges when selectSmallest
+// is false and the k smallest-weight edges when it is true (#560) — the
+// caller picks the direction that matches its Objective so a cost-minimiser
+// is not handed the costliest edges. tfidf re-scores edge weights BEFORE the
+// directional top/bottom-k selection.
+func (c *GraphCache[S, T]) Neighbor(seed S, step int, k int, tfidf bool, selectSmallest bool) *graph.Graph[S, T] {
+	g, _ := c.NeighborContext(context.Background(), seed, step, k, tfidf, selectSmallest)
 	return g
 }
 
@@ -445,8 +451,8 @@ func (c *GraphCache[S, T]) Neighbor(seed S, step int, k int, tfidf bool) *graph.
 // ctx.Err() as soon as the context is cancelled or its deadline has expired
 // — checked between BFS expansion steps — so handlers can short-circuit
 // large traversals when the caller has given up.
-func (c *GraphCache[S, T]) NeighborContext(ctx context.Context, seed S, step int, k int, tfidf bool) (*graph.Graph[S, T], error) {
-	g, _, err := c.neighborContext(ctx, seed, step, k, tfidf, false)
+func (c *GraphCache[S, T]) NeighborContext(ctx context.Context, seed S, step int, k int, tfidf bool, selectSmallest bool) (*graph.Graph[S, T], error) {
+	g, _, err := c.neighborContext(ctx, seed, step, k, tfidf, selectSmallest, false)
 	return g, err
 }
 
@@ -458,11 +464,11 @@ func (c *GraphCache[S, T]) NeighborContext(ctx context.Context, seed S, step int
 // The expirations map only contains entries for edges that ended up in
 // the returned graph; a missing or zero value means the edge has no
 // known expiration.
-func (c *GraphCache[S, T]) NeighborWithExpirationsContext(ctx context.Context, seed S, step int, k int, tfidf bool) (*graph.Graph[S, T], map[S]map[S]time.Time, error) {
-	return c.neighborContext(ctx, seed, step, k, tfidf, true)
+func (c *GraphCache[S, T]) NeighborWithExpirationsContext(ctx context.Context, seed S, step int, k int, tfidf bool, selectSmallest bool) (*graph.Graph[S, T], map[S]map[S]time.Time, error) {
+	return c.neighborContext(ctx, seed, step, k, tfidf, selectSmallest, true)
 }
 
-func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int, k int, tfidf bool, collectExpirations bool) (*graph.Graph[S, T], map[S]map[S]time.Time, error) {
+func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int, k int, tfidf bool, selectSmallest bool, collectExpirations bool) (*graph.Graph[S, T], map[S]map[S]time.Time, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	g := graph.NewGraph[S, T]()
@@ -528,8 +534,14 @@ func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int
 			}
 		}
 
-		// Filter light edges; trim expirations to the survivors.
-		edges = edges.Top(k)
+		// Prune to the k edges at the Objective-selected extreme — the k
+		// smallest weights when selectSmallest (MINIMIZE), the k largest
+		// otherwise (#560) — then trim expirations to the survivors.
+		if selectSmallest {
+			edges = edges.Bottom(k)
+		} else {
+			edges = edges.Top(k)
+		}
 		if expRow != nil {
 			filtered := make(map[S]time.Time, len(edges))
 			for head := range edges {

--- a/core/cache/graph/cache_test.go
+++ b/core/cache/graph/cache_test.go
@@ -428,10 +428,11 @@ func TestGraphCache_GetVertex(t *testing.T) {
 
 func TestGraphCache_Neighbor(t *testing.T) {
 	type args[S comparable] struct {
-		seed  S
-		step  int
-		k     int
-		tfidf bool
+		seed           S
+		step           int
+		k              int
+		tfidf          bool
+		selectSmallest bool
 	}
 	type testCase[S comparable, T any] struct {
 		name string
@@ -445,8 +446,77 @@ func TestGraphCache_Neighbor(t *testing.T) {
 	for i := range tests {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.c.Neighbor(tt.args.seed, tt.args.step, tt.args.k, tt.args.tfidf); !reflect.DeepEqual(got, tt.want) {
+			if got := tt.c.Neighbor(tt.args.seed, tt.args.step, tt.args.k, tt.args.tfidf, tt.args.selectSmallest); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Neighbor() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGraphCache_Neighbor_ObjectiveDirection pins the #560 fix at the cache
+// layer. When a vertex's out-degree exceeds k, the selectSmallest flag chooses
+// WHICH k edges survive the per-hop prune: false keeps the k largest-weight
+// heads (Top — the maximise/strongest direction), true keeps the k smallest
+// (Bottom — the minimise/cheapest direction). Before the fix the prune always
+// kept the largest k regardless of objective, starving a cost minimiser of the
+// cheap edges it cares about. When k does not bind, the flag is a no-op.
+func TestGraphCache_Neighbor_ObjectiveDirection(t *testing.T) {
+	const seed = "seed"
+	mk := func() *GraphCache[string, string] {
+		c := NewGraphCache[string, string](time.Minute)
+		// Five heads with distinct weights 1..5 so k=2 binds and the two
+		// directions select disjoint survivors.
+		c.AddEdge(seed, "h1", 1)
+		c.AddEdge(seed, "h2", 2)
+		c.AddEdge(seed, "h3", 3)
+		c.AddEdge(seed, "h4", 4)
+		c.AddEdge(seed, "h5", 5)
+		return c
+	}
+
+	headSet := func(g *graph.Graph[string, string]) map[string]bool {
+		got := map[string]bool{}
+		if g != nil {
+			for head := range g.Edges[seed] {
+				got[head] = true
+			}
+		}
+		return got
+	}
+
+	tests := []struct {
+		name           string
+		k              int
+		selectSmallest bool
+		want           map[string]bool
+	}{
+		{
+			name:           "selectSmallest=false keeps the k largest",
+			k:              2,
+			selectSmallest: false,
+			want:           map[string]bool{"h4": true, "h5": true},
+		},
+		{
+			name:           "selectSmallest=true keeps the k smallest",
+			k:              2,
+			selectSmallest: true,
+			want:           map[string]bool{"h1": true, "h2": true},
+		},
+		{
+			name:           "k does not bind: direction is a no-op",
+			k:              5,
+			selectSmallest: true,
+			want: map[string]bool{
+				"h1": true, "h2": true, "h3": true, "h4": true, "h5": true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := headSet(mk().Neighbor(seed, 1, tt.k, false, tt.selectSmallest))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Neighbor(k=%d, selectSmallest=%v) heads = %v, want %v",
+					tt.k, tt.selectSmallest, got, tt.want)
 			}
 		})
 	}
@@ -614,7 +684,7 @@ func TestGraphCache_NeighborContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if _, err := c.NeighborContext(ctx, "a", 5, 10, false); !errors.Is(err, context.Canceled) {
+	if _, err := c.NeighborContext(ctx, "a", 5, 10, false, false); !errors.Is(err, context.Canceled) {
 		t.Fatalf("want context.Canceled, got %v", err)
 	}
 }
@@ -633,7 +703,7 @@ func TestGraphCache_NeighborWithExpirationsContext_ReturnsAlignedMap(t *testing.
 	c.AddEdgeWithExpiration("a", "b", 1.0, expAB)
 	c.AddEdgeWithExpiration("a", "c", 2.0, expAC)
 
-	g, exps, err := c.NeighborWithExpirationsContext(context.Background(), "a", 2, 10, false)
+	g, exps, err := c.NeighborWithExpirationsContext(context.Background(), "a", 2, 10, false, false)
 	if err != nil {
 		t.Fatalf("NeighborWithExpirationsContext: %v", err)
 	}
@@ -674,7 +744,7 @@ func TestGraphCache_NeighborContext_StillWorksAfterRefactor(t *testing.T) {
 	c.PutVertex("b", 2)
 	c.AddEdge("a", "b", 1.0)
 
-	g, err := c.NeighborContext(context.Background(), "a", 2, 10, false)
+	g, err := c.NeighborContext(context.Background(), "a", 2, 10, false, false)
 	if err != nil {
 		t.Fatalf("NeighborContext: %v", err)
 	}

--- a/core/cache/graph/example/main.go
+++ b/core/cache/graph/example/main.go
@@ -21,7 +21,7 @@ func main() {
 	c.AddEdge("a", "e", 1)
 
 	start := time.Now()
-	g := c.Neighbor("a", 3, 3, true)
+	g := c.Neighbor("a", 3, 3, true, false)
 	end := time.Now()
 
 	if jsonText, err := json.MarshalIndent(g, "", "\t"); err == nil {

--- a/core/cache/graph/production_gate_test.go
+++ b/core/cache/graph/production_gate_test.go
@@ -89,7 +89,7 @@ func testLivenessHeavyMix(t *testing.T) {
 					c.AddEdgeWithExpiration(tail, head, 1, exp)
 					c.PutEdgeWithExpiration(tail, head, 2, exp)
 					c.GetEdgeDetail(tail, head)
-					c.Neighbor(tail, 1, 4, false)
+					c.Neighbor(tail, 1, 4, false, false)
 					c.DeleteEdge(tail, head)
 					c.DeleteVertex(k)
 				}
@@ -294,8 +294,8 @@ func testInputNaNInf(t *testing.T) {
 	_, _, _ = c.GetEdgeDetail("a", "b")
 	_, _, _ = c.GetEdgeDetail("c", "d")
 	_, _, _ = c.GetEdgeDetail("e", "f")
-	_ = c.Neighbor("a", 1, 4, false)
-	_ = c.Neighbor("c", 1, 4, true) // also exercise the TF-IDF path
+	_ = c.Neighbor("a", 1, 4, false, false)
+	_ = c.Neighbor("c", 1, 4, true, false) // also exercise the TF-IDF path
 }
 
 // testInputDeleteMissing verifies idempotent delete: deleting an absent
@@ -351,7 +351,7 @@ func testReadConsistencyAfterExpiry(t *testing.T) {
 	if _, _, ok := c.GetEdgeDetail("a", "b"); ok {
 		t.Fatalf("C1: GetEdgeDetail still surfaces expired edge")
 	}
-	g := c.Neighbor("a", 2, 8, false)
+	g := c.Neighbor("a", 2, 8, false, false)
 	if len(g.Vertices) != 0 || len(g.Edges) != 0 {
 		t.Fatalf("C1: Neighbor returned %d vertices and %d edges from an all-expired seed",
 			len(g.Vertices), len(g.Edges))
@@ -406,7 +406,7 @@ func testReadConsistencyNeighborChurn(t *testing.T) {
 					return
 				default:
 				}
-				_ = c.Neighbor(keyFromInt(i%8), 2, 4, i%2 == 0)
+				_ = c.Neighbor(keyFromInt(i%8), 2, 4, i%2 == 0, false)
 			}
 		}()
 	}
@@ -463,7 +463,7 @@ func testTopologySelfLoop(t *testing.T) {
 	if !ok || w != 2.5 {
 		t.Fatalf("T1: self-loop weight wrong (got %v, ok=%v, want 2.5)", w, ok)
 	}
-	g := c.Neighbor("x", 1, 4, false)
+	g := c.Neighbor("x", 1, 4, false, false)
 	if _, ok := g.Edges["x"]["x"]; !ok {
 		t.Fatalf("T1: Neighbor lost the self-loop edge: %#v", g.Edges)
 	}

--- a/core/collection/pq/map.go
+++ b/core/collection/pq/map.go
@@ -13,13 +13,31 @@ func NewSortableMap[S comparable, T Number]() SortableMap[S, T] {
 // Top returns the k entries with the largest values. When the map already
 // holds k or fewer entries the receiver is returned as-is (no copy). For
 // k <= 0 an empty map is returned.
-//
-// Implementation: maintain a size-k min-heap (root = smallest of the current
-// top-k). Each map entry is either pushed (heap not yet full) or, if it
-// exceeds the root, replaces the root via heap.Fix. Time complexity is
-// O(N log k) versus O(N + k log N) for the prior "build a full heap, pop k
-// times" approach, and peak memory is O(k) instead of O(N).
 func (m SortableMap[S, T]) Top(k int) SortableMap[S, T] {
+	return m.selectK(k, false)
+}
+
+// Bottom returns the k entries with the smallest values. It mirrors Top —
+// same passthrough (len <= k returns the receiver) and same k <= 0 empty
+// result — but keeps the lower tail of the value distribution. Illuminate
+// uses it for per-hop pruning when the Objective is MINIMIZE so the cheapest
+// edges a cost-minimiser cares about survive instead of the costliest (#560).
+func (m SortableMap[S, T]) Bottom(k int) SortableMap[S, T] {
+	return m.selectK(k, true)
+}
+
+// selectK returns the k entries at one extreme of the value distribution: the
+// largest k when smallest is false (Top), the smallest k when smallest is true
+// (Bottom).
+//
+// Implementation: maintain a size-k bounded heap whose root is the first entry
+// to be evicted — the smallest of the current top-k (a min-heap) when selecting
+// the largest k, or the largest of the current bottom-k (a max-heap) when
+// selecting the smallest k. Each map entry is either pushed (heap not yet full)
+// or, when it belongs deeper in the retained set than the root, replaces the
+// root via heap.Fix. Time complexity is O(N log k) versus O(N + k log N) for a
+// "build a full heap, pop k times" approach, and peak memory is O(k) not O(N).
+func (m SortableMap[S, T]) selectK(k int, smallest bool) SortableMap[S, T] {
 	if k <= 0 {
 		return NewSortableMap[S, T]()
 	}
@@ -27,50 +45,84 @@ func (m SortableMap[S, T]) Top(k int) SortableMap[S, T] {
 		return m
 	}
 
-	h := make(topKHeap[S, T], 0, k)
+	h := boundedKHeap[S, T]{entries: make([]kEntry[S, T], 0, k), smallest: smallest}
 	for key, val := range m {
-		if len(h) < k {
-			heap.Push(&h, topKEntry[S, T]{value: key, priority: val})
+		if len(h.entries) < k {
+			heap.Push(&h, kEntry[S, T]{value: key, priority: val})
 			continue
 		}
-		// h[0] is the smallest priority currently in the top-k; replace it
-		// only when the candidate is strictly larger. Strict inequality
-		// keeps the operation cheap when many entries tie at the boundary.
-		if val > h[0].priority {
-			h[0] = topKEntry[S, T]{value: key, priority: val}
+		// h.entries[0] is the root: the boundary entry first to be evicted.
+		// Replace it only when the candidate belongs deeper in the retained
+		// set. Strict inequality keeps the operation cheap when many entries
+		// tie at the boundary.
+		if h.replaces(val, h.entries[0].priority) {
+			h.entries[0] = kEntry[S, T]{value: key, priority: val}
 			heap.Fix(&h, 0)
 		}
 	}
 
-	filtered := make(SortableMap[S, T], len(h))
-	for _, e := range h {
+	filtered := make(SortableMap[S, T], len(h.entries))
+	for _, e := range h.entries {
 		filtered[e.value] = e.priority
 	}
 	return filtered
 }
 
-// topKEntry / topKHeap is an internal, value-type min-heap used only by Top.
-// It is deliberately independent of PriorityQueue so this hot path avoids
-// per-item pointer allocations and the unused Index field.
-type topKEntry[S comparable, T Number] struct {
+// kEntry / boundedKHeap is an internal, value-type bounded heap used only by
+// selectK (Top / Bottom). It is deliberately independent of PriorityQueue so
+// this hot path avoids per-item pointer allocations and the unused Index field.
+//
+// The smallest flag flips the heap orientation so a single implementation
+// serves both extremes:
+//   - smallest == false: a min-heap whose root is the smallest of the current
+//     top-k, so larger candidates evict it → the k LARGEST survive (Top).
+//   - smallest == true: a max-heap whose root is the largest of the current
+//     bottom-k, so smaller candidates evict it → the k SMALLEST survive (Bottom).
+type kEntry[S comparable, T Number] struct {
 	value    S
 	priority T
 }
 
-type topKHeap[S comparable, T Number] []topKEntry[S, T]
-
-func (h topKHeap[S, T]) Len() int           { return len(h) }
-func (h topKHeap[S, T]) Less(i, j int) bool { return h[i].priority < h[j].priority }
-func (h topKHeap[S, T]) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
-
-func (h *topKHeap[S, T]) Push(x any) {
-	*h = append(*h, x.(topKEntry[S, T]))
+type boundedKHeap[S comparable, T Number] struct {
+	entries  []kEntry[S, T]
+	smallest bool
 }
 
-func (h *topKHeap[S, T]) Pop() any {
-	old := *h
+func (h boundedKHeap[S, T]) Len() int { return len(h.entries) }
+
+func (h boundedKHeap[S, T]) Less(i, j int) bool {
+	// Order the root toward the first entry to evict: the smallest priority
+	// for Top (min-heap), the largest priority for Bottom (max-heap).
+	if h.smallest {
+		return h.entries[i].priority > h.entries[j].priority
+	}
+	return h.entries[i].priority < h.entries[j].priority
+}
+
+func (h boundedKHeap[S, T]) Swap(i, j int) {
+	h.entries[i], h.entries[j] = h.entries[j], h.entries[i]
+}
+
+func (h *boundedKHeap[S, T]) Push(x any) {
+	h.entries = append(h.entries, x.(kEntry[S, T]))
+}
+
+func (h *boundedKHeap[S, T]) Pop() any {
+	old := h.entries
 	n := len(old)
 	x := old[n-1]
-	*h = old[:n-1]
+	h.entries = old[:n-1]
 	return x
+}
+
+// replaces reports whether a candidate priority should evict the current heap
+// root. For Top the candidate must be strictly larger than the smallest
+// retained entry; for Bottom it must be strictly smaller than the largest
+// retained. Strict inequality keeps boundary ties cheap (no churn when many
+// entries tie at the boundary).
+func (h boundedKHeap[S, T]) replaces(candidate, root T) bool {
+	if h.smallest {
+		return candidate < root
+	}
+	return candidate > root
 }

--- a/core/collection/pq/map_test.go
+++ b/core/collection/pq/map_test.go
@@ -141,6 +141,144 @@ func TestSortableMap_Top_LargeRandom(t *testing.T) {
 	}
 }
 
+// TestSortableMap_Bottom is the directional counterpart of
+// TestSortableMap_Top: it pins that Bottom keeps the SMALLEST k while sharing
+// Top's passthrough (len <= k returns the receiver) and k <= 0 empty
+// semantics. Illuminate relies on this lower-tail selection for per-hop
+// pruning when the Objective is MINIMIZE (#560).
+func TestSortableMap_Bottom(t *testing.T) {
+	type args struct {
+		k int
+	}
+	type testCase[S comparable, T Number] struct {
+		name string
+		m    SortableMap[S, T]
+		args args
+		want SortableMap[S, T]
+	}
+	tests := []testCase[string, float64]{
+		{
+			name: "k_greater_than_len_returns_all",
+			m: SortableMap[string, float64]{
+				"one":   1,
+				"two":   2,
+				"three": 3,
+				"four":  4,
+				"five":  5,
+			},
+			args: args{k: 10},
+			want: SortableMap[string, float64]{
+				"five": 5, "four": 4, "three": 3, "two": 2, "one": 1,
+			},
+		},
+		{
+			name: "k_equal_to_len_returns_all",
+			m: SortableMap[string, float64]{
+				"a": 1, "b": 2, "c": 3,
+			},
+			args: args{k: 3},
+			want: SortableMap[string, float64]{
+				"a": 1, "b": 2, "c": 3,
+			},
+		},
+		{
+			name: "k_smaller_picks_smallest",
+			m: SortableMap[string, float64]{
+				"a": 1, "b": 5, "c": 3, "d": 4, "e": 2,
+			},
+			args: args{k: 2},
+			want: SortableMap[string, float64]{"a": 1, "e": 2},
+		},
+		{
+			name: "k_one_picks_min",
+			m:    SortableMap[string, float64]{"a": 7, "b": 9, "c": 3},
+			args: args{k: 1},
+			want: SortableMap[string, float64]{"c": 3},
+		},
+		{
+			name: "k_zero_returns_empty",
+			m:    SortableMap[string, float64]{"a": 1, "b": 2},
+			args: args{k: 0},
+			want: SortableMap[string, float64]{},
+		},
+		{
+			name: "k_negative_returns_empty",
+			m:    SortableMap[string, float64]{"a": 1, "b": 2},
+			args: args{k: -1},
+			want: SortableMap[string, float64]{},
+		},
+		{
+			name: "empty_map",
+			m:    SortableMap[string, float64]{},
+			args: args{k: 3},
+			want: SortableMap[string, float64]{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.m.Bottom(tt.args.k); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Bottom() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSortableMap_Bottom_TieBoundary mirrors the Top tie test: when many
+// entries share the boundary priority the bottom-k still contains exactly k
+// entries and every kept entry sits at the low tail.
+func TestSortableMap_Bottom_TieBoundary(t *testing.T) {
+	m := SortableMap[int, int]{
+		1: 1, 2: 1, 3: 1, 4: 1, 5: 1,
+		6: 5, 7: 5, 8: 5,
+	}
+	got := m.Bottom(3)
+	if len(got) != 3 {
+		t.Fatalf("len(got) = %d, want 3", len(got))
+	}
+	for k, v := range got {
+		if v != 1 {
+			t.Errorf("entry %d has priority %d, want 1", k, v)
+		}
+	}
+}
+
+// TestSortableMap_Bottom_LargeRandom cross-checks Bottom against a sort-based
+// reference on randomized input: every kept value must be <= the k-th smallest.
+func TestSortableMap_Bottom_LargeRandom(t *testing.T) {
+	const (
+		n = 2000
+		k = 17
+	)
+	r := rand.New(rand.NewSource(42))
+	m := make(SortableMap[int, float64], n)
+	values := make([]float64, 0, n)
+	for i := 0; i < n; i++ {
+		v := r.Float64()
+		m[i] = v
+		values = append(values, v)
+	}
+
+	got := m.Bottom(k)
+	if len(got) != k {
+		t.Fatalf("len(got) = %d, want %d", len(got), k)
+	}
+
+	// Sort values ascending and take the k-th smallest as the threshold.
+	for i := 0; i < len(values); i++ {
+		for j := i + 1; j < len(values); j++ {
+			if values[j] < values[i] {
+				values[i], values[j] = values[j], values[i]
+			}
+		}
+	}
+	threshold := values[k-1]
+	for key, v := range got {
+		if v > threshold {
+			t.Errorf("entry %d has priority %v, above threshold %v", key, v, threshold)
+		}
+	}
+}
+
 func BenchmarkSortableMap_Top(b *testing.B) {
 	const n = 10_000
 	r := rand.New(rand.NewSource(1))

--- a/mcp/tool_recall_related.go
+++ b/mcp/tool_recall_related.go
@@ -92,7 +92,7 @@ type recallRelatedInput struct {
 	K               uint32                 `json:"k,omitempty"         jsonschema:"Per-hop fan-out: keep the top-k strongest outgoing edges at each step (default 8). Server enforces a hard cap. Applies to the out-direction walk only."`
 	Direction       recallRelatedDirection `json:"direction,omitempty" jsonschema:"Which edge direction to follow from the seed: out (default - forward BFS over out-edges, the historical behaviour), in (reverse - return the seed's direct predecessors, so seeding a pure sink is no longer empty), or both (union of the two). step/k/algorithm/objective/weighting shape the out walk; the in pass is a single bounded reverse-adjacency hop."`
 	Algorithm       recallRelatedAlgorithm `json:"algorithm,omitempty" jsonschema:"Post-traversal subgraph reduction: one of: none (default - raw BFS subgraph), mst (minimum/maximum spanning tree depending on objective), spt (shortest-path tree from seed)."`
-	Objective       recallRelatedObjective `json:"objective,omitempty" jsonschema:"Direction of the algorithm reduction: min (default - cost-weighted, smallest tree wins) or max (relevance-weighted, largest tree wins). Ignored when algorithm=none."`
+	Objective       recallRelatedObjective `json:"objective,omitempty" jsonschema:"Direction of edge selection AND any algorithm reduction: max (default - relevance-weighted, keeps the strongest edges per hop and the largest tree) or min (cost-weighted, keeps the smallest edges per hop and the smallest tree). Governs the per-hop top-k prune even when algorithm=none (see #560)."`
 	Weighting       recallRelatedWeighting `json:"weighting,omitempty" jsonschema:"Edge-weight transform applied BEFORE the walk: raw (default - edge weights as stored) or tfidf (re-score via TF-IDF over per-vertex out-edge distribution)."`
 	Reinforce       bool                   `json:"reinforce,omitempty"        jsonschema:"Opt in (default false) to strengthening the edges this walk actually traverses. Each traversed edge gains an additive weight pulse via the same additive model as remember_relation; recall stays read-only when false. This is the Hebbian use-strengthens-memory loop — the edge-side analog of touch and the one deliberate exception to 'recall does NOT refresh TTL'."`
 	ReinforceWeight float32                `json:"reinforce_weight,omitempty" jsonschema:"Weight added to each traversed edge when reinforce=true (default 1.0). Additive: the pulse stacks on the edge's existing weight. Ignored when reinforce=false."`
@@ -147,7 +147,12 @@ func registerRecallRelated(srv *mcp.Server, lc lanternClient, r *ttl.Resolver) {
 		}
 		objective := in.Objective
 		if objective == "" {
-			objective = objectiveMin
+			// #560: default to max so the per-hop top-k prune keeps the
+			// STRONGEST edges (the historical de-facto behaviour). Objective
+			// now steers the pruning direction, not just the algorithm
+			// reduction, so an unspecified objective must resolve to max to
+			// keep recall_related returning the strongest neighbours.
+			objective = objectiveMax
 		}
 		weighting := in.Weighting
 		if weighting == "" {

--- a/pb/graph/v1/graph.pb.go
+++ b/pb/graph/v1/graph.pb.go
@@ -78,12 +78,17 @@ func (Algorithm) EnumDescriptor() ([]byte, []int) {
 	return file_graph_v1_graph_proto_rawDescGZIP(), []int{0}
 }
 
-// Objective is the direction of the Algorithm-driven optimisation.
+// Objective is the direction of the weight-sensitive optimisation. It
+// governs BOTH the per-hop top-k pruning during the BFS walk AND the
+// post-traversal Algorithm reduction (#560), so a cost-minimiser is never
+// handed a candidate set already pruned to the costliest edges.
 //
-// UNSPECIFIED defaults to MINIMIZE server-side. MINIMIZE treats edge
-// weights as costs (smallest tree wins); MAXIMIZE treats them as
-// relevance (largest tree wins, equivalent to the historical
-// "inverse-SPT" / "max-MST" variants).
+// UNSPECIFIED defaults to MAXIMIZE server-side. MINIMIZE treats edge
+// weights as costs (keeps the k smallest-weight edges per hop; smallest
+// tree wins); MAXIMIZE treats them as relevance (keeps the k largest-weight
+// edges per hop; largest tree wins, equivalent to the historical
+// "inverse-SPT" / "max-MST" variants and the default strongest-neighbour
+// behaviour of a bare illuminate).
 type Objective int32
 
 const (

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -52,12 +52,17 @@ enum Algorithm {
   ALGORITHM_SHORTEST_PATH_TREE = 2;
 }
 
-// Objective is the direction of the Algorithm-driven optimisation.
+// Objective is the direction of the weight-sensitive optimisation. It
+// governs BOTH the per-hop top-k pruning during the BFS walk AND the
+// post-traversal Algorithm reduction (#560), so a cost-minimiser is never
+// handed a candidate set already pruned to the costliest edges.
 //
-// UNSPECIFIED defaults to MINIMIZE server-side. MINIMIZE treats edge
-// weights as costs (smallest tree wins); MAXIMIZE treats them as
-// relevance (largest tree wins, equivalent to the historical
-// "inverse-SPT" / "max-MST" variants).
+// UNSPECIFIED defaults to MAXIMIZE server-side. MINIMIZE treats edge
+// weights as costs (keeps the k smallest-weight edges per hop; smallest
+// tree wins); MAXIMIZE treats them as relevance (keeps the k largest-weight
+// edges per hop; largest tree wins, equivalent to the historical
+// "inverse-SPT" / "max-MST" variants and the default strongest-neighbour
+// behaviour of a bare illuminate).
 enum Objective {
   OBJECTIVE_UNSPECIFIED = 0;
   OBJECTIVE_MINIMIZE = 1;

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -68,10 +68,12 @@ const (
 	AlgorithmShortestPathTree    = pb.Algorithm_ALGORITHM_SHORTEST_PATH_TREE
 )
 
-// Objective is the direction of the Algorithm-driven optimisation:
-// MINIMIZE treats edge weights as costs (smallest tree wins), MAXIMIZE
-// treats them as relevance (largest tree wins). Server resolves
-// ObjectiveUnspecified to ObjectiveMinimize.
+// Objective is the direction of the weight-sensitive optimisation. It
+// governs both the per-hop top-k pruning and the post-traversal reduction
+// (#560): MINIMIZE treats edge weights as costs (keeps the k smallest-weight
+// edges per hop, smallest tree wins), MAXIMIZE treats them as relevance
+// (keeps the k largest-weight edges per hop, largest tree wins). Server
+// resolves ObjectiveUnspecified to ObjectiveMaximize.
 type Objective = pb.Objective
 
 const (

--- a/server/service/backend.go
+++ b/server/service/backend.go
@@ -59,12 +59,16 @@ type Backend interface {
 	DeleteEdgesHLC(keys []graph.EdgeKey[string], ts hlc.Timestamp, expiration time.Time) int
 	DeleteByPrefixHLC(ctx context.Context, prefix string, limit uint32, ts hlc.Timestamp, expiration time.Time) (int, error)
 
-	// neighborhood traversal
+	// neighborhood traversal. selectSmallest steers the per-hop top-k
+	// pruning: the k smallest-weight edges are kept when true, the k
+	// largest when false (#560), so the caller's Objective governs which
+	// edges survive both pruning and any later reduction.
 	NeighborWithExpirationsContext(
 		ctx context.Context,
 		seed string,
 		step, k int,
 		tfidf bool,
+		selectSmallest bool,
 	) (*coregraph.Graph[string, *pb.Vertex], map[string]map[string]time.Time, error)
 
 	// prefix scan / count / delete. ScanByPrefix invokes fn for each live

--- a/server/service/fake_backend_test.go
+++ b/server/service/fake_backend_test.go
@@ -18,6 +18,13 @@ type fakeBackend struct {
 	edges       map[string]map[string]float32
 	neighborErr error
 
+	// captured args from the most recent NeighborWithExpirationsContext
+	// call, so tests can assert how the Illuminate handler maps Objective
+	// onto the per-hop pruning direction (#560).
+	neighborCalls           int
+	lastNeighborTFIDF       bool
+	lastNeighborSelectSmall bool
+
 	putVerticesCalls int
 	deleteVertices   int
 	addEdgesCalls    int
@@ -104,7 +111,11 @@ func (f *fakeBackend) NeighborWithExpirationsContext(
 	seed string,
 	step, k int,
 	tfidf bool,
+	selectSmallest bool,
 ) (*coregraph.Graph[string, *pb.Vertex], map[string]map[string]time.Time, error) {
+	f.neighborCalls++
+	f.lastNeighborTFIDF = tfidf
+	f.lastNeighborSelectSmall = selectSmallest
 	if f.neighborErr != nil {
 		return nil, nil, f.neighborErr
 	}

--- a/server/service/optimizer.go
+++ b/server/service/optimizer.go
@@ -23,26 +23,28 @@ type optimizer func(ctx context.Context, g *coregraph.Graph[string, *pb.Vertex],
 // and the historical flat Optimization enum is gone.
 //
 // Note: objective ALGORITHM_UNSPECIFIED → nil (no reduction). Objective
-// OBJECTIVE_UNSPECIFIED resolves to MINIMIZE per the proto-level default.
+// OBJECTIVE_UNSPECIFIED resolves to MAXIMIZE per the proto-level default
+// (#560): a bare illuminate keeps the strongest edges both when pruning the
+// per-hop top-k and when reducing the discovered subgraph.
 func resolveOptimizer(algo pb.Algorithm, obj pb.Objective) optimizer {
 	switch algo {
 	case pb.Algorithm_ALGORITHM_MINIMUM_SPANNING_TREE:
-		if obj == pb.Objective_OBJECTIVE_MAXIMIZE {
+		if obj == pb.Objective_OBJECTIVE_MINIMIZE {
 			return func(ctx context.Context, g *coregraph.Graph[string, *pb.Vertex], seed string) (*coregraph.Graph[string, *pb.Vertex], error) {
-				return g.MaximumSpanningTreeContext(ctx, seed)
+				return g.MinimumSpanningTreeContext(ctx, seed)
 			}
 		}
 		return func(ctx context.Context, g *coregraph.Graph[string, *pb.Vertex], seed string) (*coregraph.Graph[string, *pb.Vertex], error) {
-			return g.MinimumSpanningTreeContext(ctx, seed)
+			return g.MaximumSpanningTreeContext(ctx, seed)
 		}
 	case pb.Algorithm_ALGORITHM_SHORTEST_PATH_TREE:
-		if obj == pb.Objective_OBJECTIVE_MAXIMIZE {
+		if obj == pb.Objective_OBJECTIVE_MINIMIZE {
 			return func(ctx context.Context, g *coregraph.Graph[string, *pb.Vertex], seed string) (*coregraph.Graph[string, *pb.Vertex], error) {
-				return g.ShortestPathTreeContext(ctx, seed, inverseCost)
+				return g.ShortestPathTreeContext(ctx, seed, identityCost)
 			}
 		}
 		return func(ctx context.Context, g *coregraph.Graph[string, *pb.Vertex], seed string) (*coregraph.Graph[string, *pb.Vertex], error) {
-			return g.ShortestPathTreeContext(ctx, seed, identityCost)
+			return g.ShortestPathTreeContext(ctx, seed, inverseCost)
 		}
 	}
 	return nil
@@ -61,7 +63,7 @@ func inverseCost(weight float32) float32 {
 // metric label string for each axis. UNSPECIFIED resolves to the same
 // label the server would resolve it to at execution time:
 //   - Algorithm UNSPECIFIED → "none"  (no reduction)
-//   - Objective UNSPECIFIED → "minimize"
+//   - Objective UNSPECIFIED → "maximize"
 //   - Weighting UNSPECIFIED → "raw"
 //
 // Unknown enum values (a future axis added in proto without a metrics
@@ -81,9 +83,9 @@ func algorithmLabel(a pb.Algorithm) string {
 
 func objectiveLabel(o pb.Objective) string {
 	switch o {
-	case pb.Objective_OBJECTIVE_UNSPECIFIED, pb.Objective_OBJECTIVE_MINIMIZE:
+	case pb.Objective_OBJECTIVE_MINIMIZE:
 		return "minimize"
-	case pb.Objective_OBJECTIVE_MAXIMIZE:
+	case pb.Objective_OBJECTIVE_UNSPECIFIED, pb.Objective_OBJECTIVE_MAXIMIZE:
 		return "maximize"
 	}
 	return "unknown"

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -341,15 +341,20 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 
 	weighting := request.GetWeighting()
 	useTFIDF := weighting == pb.Weighting_WEIGHTING_TFIDF
+	// Objective steers the per-hop top-k pruning as well as the post-traversal
+	// reduction (#560): a MINIMIZE caller keeps the k smallest-weight edges at
+	// each hop so the cost-minimiser is not handed a candidate set pruned to
+	// the costliest edges. UNSPECIFIED resolves to MAXIMIZE (strongest edges).
+	objective := request.GetObjective()
+	selectSmallest := objective == pb.Objective_OBJECTIVE_MINIMIZE
 	traversalStart := time.Now()
-	g, expirations, err := s.cache.NeighborWithExpirationsContext(ctx, request.GetSeed(), int(request.GetStep()), int(request.GetK()), useTFIDF)
+	g, expirations, err := s.cache.NeighborWithExpirationsContext(ctx, request.GetSeed(), int(request.GetStep()), int(request.GetK()), useTFIDF, selectSmallest)
 	traversalDur := time.Since(traversalStart)
 	if err != nil {
 		return nil, ctxToConnect(err)
 	}
 
 	algorithm := request.GetAlgorithm()
-	objective := request.GetObjective()
 	var optimizeDur time.Duration
 	if opt := resolveOptimizer(algorithm, objective); opt != nil {
 		optStart := time.Now()

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -517,6 +517,146 @@ func TestLanternService_FakeBackend_Illuminate_PropagatesError(t *testing.T) {
 	}
 }
 
+// TestLanternService_FakeBackend_Illuminate_ObjectiveSteersPruning pins the
+// #560 contract at the service boundary: the Illuminate handler must translate
+// the request Objective into the per-hop pruning direction it hands the
+// backend. MINIMIZE asks for the cheapest edges (selectSmallest=true); MAXIMIZE
+// and the UNSPECIFIED default both ask for the strongest (selectSmallest=false),
+// preserving the historical strongest-neighbour behaviour.
+func TestLanternService_FakeBackend_Illuminate_ObjectiveSteersPruning(t *testing.T) {
+	tests := []struct {
+		name            string
+		objective       pb.Objective
+		wantSelectSmall bool
+	}{
+		{
+			name:            "MINIMIZE prunes to smallest",
+			objective:       pb.Objective_OBJECTIVE_MINIMIZE,
+			wantSelectSmall: true,
+		},
+		{
+			name:            "MAXIMIZE prunes to largest",
+			objective:       pb.Objective_OBJECTIVE_MAXIMIZE,
+			wantSelectSmall: false,
+		},
+		{
+			name:            "UNSPECIFIED defaults to largest (#560)",
+			objective:       pb.Objective_OBJECTIVE_UNSPECIFIED,
+			wantSelectSmall: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fb := newFakeBackend()
+			svc := NewLanternService(fb)
+			if _, err := svc.Illuminate(context.Background(), &pb.IlluminateRequest{
+				Seed:      "a",
+				Step:      1,
+				K:         3,
+				Objective: tt.objective,
+			}); err != nil {
+				t.Fatalf("Illuminate: %v", err)
+			}
+			if fb.neighborCalls != 1 {
+				t.Fatalf("neighborCalls = %d, want 1", fb.neighborCalls)
+			}
+			if fb.lastNeighborSelectSmall != tt.wantSelectSmall {
+				t.Errorf("lastNeighborSelectSmall = %v, want %v",
+					fb.lastNeighborSelectSmall, tt.wantSelectSmall)
+			}
+		})
+	}
+}
+
+// seedStar builds a directed star: seed "s" fans out to h1..h5 with distinct
+// weights 1..5 (and nothing else), so a per-hop prune at k < 5 must choose
+// which heads survive. Used by the #560 min-vs-max-differ end-to-end test.
+func seedStar(t *testing.T, s *LanternService) {
+	t.Helper()
+	ctx := context.Background()
+	exp := futureTs(time.Minute)
+	verts := []*pb.Vertex{
+		{Key: "s", Value: &pb.Vertex_String_{String_: "S"}, Expiration: exp},
+		{Key: "h1", Value: &pb.Vertex_String_{String_: "H1"}, Expiration: exp},
+		{Key: "h2", Value: &pb.Vertex_String_{String_: "H2"}, Expiration: exp},
+		{Key: "h3", Value: &pb.Vertex_String_{String_: "H3"}, Expiration: exp},
+		{Key: "h4", Value: &pb.Vertex_String_{String_: "H4"}, Expiration: exp},
+		{Key: "h5", Value: &pb.Vertex_String_{String_: "H5"}, Expiration: exp},
+	}
+	if _, err := s.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: verts}); err != nil {
+		t.Fatalf("PutVertices: %v", err)
+	}
+	edges := []*pb.Edge{
+		{Tail: "s", Head: "h1", Weight: 1, Expiration: exp},
+		{Tail: "s", Head: "h2", Weight: 2, Expiration: exp},
+		{Tail: "s", Head: "h3", Weight: 3, Expiration: exp},
+		{Tail: "s", Head: "h4", Weight: 4, Expiration: exp},
+		{Tail: "s", Head: "h5", Weight: 5, Expiration: exp},
+	}
+	if _, err := s.PutEdges(ctx, &pb.PutEdgesRequest{Edges: edges}); err != nil {
+		t.Fatalf("PutEdges: %v", err)
+	}
+}
+
+// TestLanternService_Illuminate_ObjectiveSelectsPrunedNeighbors is the #560
+// end-to-end regression through the real GraphCache: against a star where k
+// binds (out-degree 5, k=2), the surviving per-hop neighbours must differ by
+// Objective. MAXIMIZE (and the UNSPECIFIED default) keep the two STRONGEST
+// heads; MINIMIZE keeps the two weakest. Before #560 the prune always kept the
+// strongest two regardless of Objective, so the MINIMIZE row would have
+// (wrongly) returned {h4, h5}.
+func TestLanternService_Illuminate_ObjectiveSelectsPrunedNeighbors(t *testing.T) {
+	tests := []struct {
+		name      string
+		objective pb.Objective
+		wantHeads []string
+	}{
+		{
+			name:      "MAXIMIZE keeps the strongest k",
+			objective: pb.Objective_OBJECTIVE_MAXIMIZE,
+			wantHeads: []string{"h4", "h5"},
+		},
+		{
+			name:      "UNSPECIFIED defaults to strongest k (#560)",
+			objective: pb.Objective_OBJECTIVE_UNSPECIFIED,
+			wantHeads: []string{"h4", "h5"},
+		},
+		{
+			name:      "MINIMIZE keeps the weakest k",
+			objective: pb.Objective_OBJECTIVE_MINIMIZE,
+			wantHeads: []string{"h1", "h2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestService(t)
+			seedStar(t, s)
+			resp, err := s.Illuminate(context.Background(), &pb.IlluminateRequest{
+				Seed:      "s",
+				Step:      1,
+				K:         2,
+				Objective: tt.objective,
+			})
+			if err != nil {
+				t.Fatalf("Illuminate: %v", err)
+			}
+			got := map[string]struct{}{}
+			for _, v := range resp.Graph.Vertices {
+				got[v.GetKey()] = struct{}{}
+			}
+			want := append([]string{"s"}, tt.wantHeads...)
+			if len(got) != len(want) {
+				t.Fatalf("vertex count = %d (%v), want %d (%v)", len(got), got, len(want), want)
+			}
+			for _, k := range want {
+				if _, ok := got[k]; !ok {
+					t.Errorf("missing vertex %q; got %v, want %v", k, got, want)
+				}
+			}
+		})
+	}
+}
+
 func TestLanternService_FakeBackend_PutAndDeleteEdge(t *testing.T) {
 	fb := newFakeBackend()
 	svc := NewLanternService(fb)
@@ -724,11 +864,15 @@ func TestLanternService_HotPathMetrics_EmitsOnceForBatchAndIlluminate(t *testing
 	}
 
 	// Illuminate → exactly one illuminate observation with the right labels.
+	// Objective is pinned to MINIMIZE so the asserted "minimize" label is
+	// explicit and independent of the UNSPECIFIED default (which is MAXIMIZE
+	// since #560).
 	if _, err := s.Illuminate(ctx, &pb.IlluminateRequest{
 		Seed:      "a",
 		Step:      2,
 		K:         10,
 		Algorithm: pb.Algorithm_ALGORITHM_MINIMUM_SPANNING_TREE,
+		Objective: pb.Objective_OBJECTIVE_MINIMIZE,
 	}); err != nil {
 		t.Fatalf("Illuminate: %v", err)
 	}


### PR DESCRIPTION
## What & why

`Illuminate`'s per-hop top-`k` neighbour prune always kept the `k`
**largest**-weight edges regardless of `Objective`. When `k < out-degree`,
`objective=min` was handed a candidate set already pruned to the *costliest*
edges, so `MST`-min / `SPT`-min reduced over the wrong neighbours. Fixes #560.

Per the maintainer directive ("no backward-compatibility constraint... a clean
cut in the spirit of #410"), the prune direction now follows `Objective` and
the `UNSPECIFIED` default flips **MINIMIZE → MAXIMIZE** so the de-facto
strongest-neighbour behaviour of a bare `illuminate seed` is preserved while
explicit `objective=min` is finally honoured.

## Core fix

- **`core/collection/pq`** — add `Bottom(k)` (smallest-`k`) next to `Top(k)`
  (largest-`k`), sharing one bounded-heap `selectK(k, smallest)`.
- **`core/cache/graph`** — `Neighbor*` gain a `selectSmallest` flag;
  `processTail` prunes with `Bottom(k)` when true, `Top(k)` when false. `core`
  stays `pb`-free (binary flag, no proto import).
- **`server/service`** — `Illuminate` maps `Objective==MINIMIZE →
  selectSmallest=true`; the optimizer's `UNSPECIFIED` arm now resolves to
  `MAXIMIZE` for both pruning and the reduction.

## Surfaces flipped to MAXIMIZE-default (behaviour-preserving)

Because `UNSPECIFIED` now means `MAXIMIZE`, every surface that used to send an
explicit `MINIMIZE` default is flipped to `MAXIMIZE` so the strongest-neighbour
default is unchanged for callers who don't pass an objective:

- **CLI** cobra `--objective` default (`min → max`) + REPL parser default.
- **MCP** `recall_related` default objective (`min → max`) + jsonschema.
- **admin SPA** — `/cli` click-to-illuminate axis default and the
  `/illuminate` wire toolbar: the objective control is no longer
  `disabled` for `algorithm=none` (it now governs pruning even with no
  reduction) and its fallback display reads `maximize`.

## Docs

`proto` `Objective` enum, README axis table, and the SDK comment now state that
`Objective` governs **both** the per-hop pruning and the reduction; the
"Ignored when `algorithm=none`" caveat is removed. `pb` regenerated via
`go generate`.

## Tests

- `pq`: `Bottom` table (both directions + boundary ties + `k>=len`
  passthrough + `k<=0` empty) + large-random cross-check.
- `core/cache/graph`: `TestGraphCache_Neighbor_ObjectiveDirection` —
  `selectSmallest` chooses which heads survive when `k` binds.
- `server`: `..._ObjectiveSteersPruning` (fakeBackend wiring: Objective →
  `selectSmallest`) **and** `..._ObjectiveSelectsPrunedNeighbors` — an
  end-to-end star (`k=2`, out-degree 5) where `max` keeps `{h4,h5}` and `min`
  keeps `{h1,h2}`; this fails under the old prune.

## Local gate

`gofmt -l` clean; root + `core` / `pb` / `sdks/go` / `mcp` / `server` test
suites green. admin `format:check` / `lint` / `typecheck` / `build` + bun unit
tests green (the admin e2e runs in CI — `proto/**` triggers the Admin
workflow).

Closes #560
