### PR TITLE
chore(release): pin root to core/v0.4.0 for v0.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.4.0
-	github.com/anaregdesign/lantern/core v0.3.1
+	github.com/anaregdesign/lantern/core v0.4.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.3.0
 	github.com/anaregdesign/lantern/sdks/go v0.11.0


### PR DESCRIPTION
## Release pin for v0.11.0

Bumps the root module's `core` require **v0.3.1 → v0.4.0** (freshly tagged), matching the established release-pin pattern (cf. #534).

### Release batch (cut after this merges)
| Tag | Module | Highlights |
|---|---|---|
| `core/v0.4.0` | core | #560 — `Neighbor*` gain `selectSmallest`; new `SortableMap.Bottom(k)` |
| `v0.11.0` | server (root) | #566 GetVertices/GetEdges hit/miss Prometheus counters; #560 Objective-directional top-k pruning; CLI illuminate default flip |
| `mcp/v0.5.0` | mcp | 16-commit feature wave (#552–#568): search_facts, list_namespaces, recall_relation, touch, forget_under, batch remember, memory_stats, reinforce-on-recall, recall direction, multi-node failover, list_under projection + #560 flip |
| `admin/v0.5.0` | admin | #560 illuminate-axes default flip; #536 zero-config quickstart |

### Skipped (no meaningful change)
- `pb` (stays v0.3.0): #560 touched only Go doc-comments; compiled output identical.
- `sdks/go` (stays v0.11.0): #560 touched only a doc-comment.
- `sdks/node` (stays v0.2.0): #523/#525 fix left on its independent npm cadence.

Local `replace` directives keep the workspace build on `./core`; no go.sum change. Build + full per-module test gate green locally.
