### PR TITLE
fix(ci): make release bench self-bounding so it always produces a report

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -97,9 +97,9 @@ jobs:
           echo "$TAGS" | xargs -I {} cosign sign --yes {}@${DIGEST}
 
   bench:
-    # Release-time benchmark sweep. Runs the smoke scenarios listed in
-    # testbed/bench/release-scenarios.txt against a freshly-built local
-    # image and uploads a fixed-format bench-report.md for the release
+    # Release-time benchmark sweep. Runs the full canonical scenario set
+    # listed in testbed/bench/release-scenarios.txt against a freshly-built
+    # local image and uploads a fixed-format bench-report.md for the release
     # job to splice into the release notes. Non-blocking: a leak-gate
     # failure or harness hiccup must not prevent a release from shipping.
     # See issue #256.
@@ -107,7 +107,14 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     continue-on-error: true
-    timeout-minutes: 30
+    # The full sweep is ~83 min of scenario execution (see release-scenarios.txt).
+    # release.sh self-bounds via RELEASE_BENCH_BUDGET_SECONDS (default 90 min) and
+    # always aggregates a report before returning, so this `timeout-minutes` is
+    # only a hard backstop — sized above the budget plus one scenario's worst-case
+    # overshoot (90 + ~6 min) plus job overhead so the script's graceful cutoff
+    # fires first and the report is never discarded by a mid-loop cancellation.
+    # See issue #571.
+    timeout-minutes: 105
     permissions:
       contents: read
     steps:

--- a/testbed/bench/release-scenarios.txt
+++ b/testbed/bench/release-scenarios.txt
@@ -5,12 +5,18 @@
 # This is the canonical release-time signal. The release bench job is
 # `continue-on-error` (non-blocking), so we run the full canonical
 # scenarios — not just the smoke variants — to surface regressions across
-# every major call path. The three `smoke_*` entries at the top of the
-# sweep remain so the rendered report is partially populated even if a
-# later full scenario times out or the runner stalls.
+# every major call path. The three `smoke_*` entries lead the sweep so the
+# rendered report is populated with useful rows first: release.sh self-bounds
+# the sweep via RELEASE_BENCH_BUDGET_SECONDS and always aggregates whatever
+# ran (appending a `## Truncated` note), so an over-budget runner still yields
+# a partial report instead of an empty one.
 #
-# Wall-time budget on a fresh ubuntu-latest runner (single shared
-# 3-replica compose, sequential execution): ~50 min total.
+# Wall-time on a fresh ubuntu-latest runner (single shared 3-replica compose,
+# sequential execution): ~83 min total — ~6 min per full scenario (warmup 30s
+# + steady 5m + cooldown 30s) plus ~1.5 min per smoke scenario. The release
+# bench job's `timeout-minutes` and release.sh's RELEASE_BENCH_BUDGET_SECONDS
+# (default 90 min) are sized against this figure; see issue #571. If you add or
+# lengthen scenarios, update those two knobs in lockstep.
 #
 # If you add a scenario here, keep it self-contained: the release driver
 # reuses ONE compose stack across all entries, so a scenario that mutates

--- a/testbed/bench/release.sh
+++ b/testbed/bench/release.sh
@@ -9,15 +9,21 @@
 #   ./testbed/bench/release.sh [--out PATH]
 #
 # Environment knobs:
-#   TAG            release tag (default: `git describe --tags --abbrev=0`)
-#   COMMIT         release commit SHA (default: `git rev-parse HEAD`)
-#   RUNNER         runner platform string (default: `uname -s/uname -m`, lowercased)
-#   LANTERN_IMAGE  image to run (default: lantern:local — must exist locally)
-#   KEEP_OUT=1     do not delete the per-scenario `out/` tree afterwards
+#   TAG                          release tag (default: `git describe --tags --abbrev=0`)
+#   COMMIT                       release commit SHA (default: `git rev-parse HEAD`)
+#   RUNNER                       runner platform string (default: `uname -s/uname -m`, lowercased)
+#   LANTERN_IMAGE                image to run (default: lantern:local — must exist locally)
+#   KEEP_OUT=1                   do not delete the per-scenario `out/` tree afterwards
+#   RELEASE_BENCH_BUDGET_SECONDS wall-clock budget for the scenario sweep (default: 5400).
+#                                Once exhausted, the remaining scenarios are skipped, the
+#                                report is aggregated from whatever ran (with a `## Truncated`
+#                                note appended), and the script still exits 0. Set to 0 to
+#                                disable the budget and always run every scenario.
 #
 # Exit codes:
-#   0  every scenario succeeded AND every leak gate verdict == "pass"
-#   1  the aggregator ran but at least one scenario failed or fail-gated
+#   0  every scenario that RAN passed its leak gate (the sweep may have been
+#      truncated by the wall-clock budget — truncation alone is not a failure)
+#   1  the aggregator ran but at least one scenario that ran failed or fail-gated
 #   2  setup error (missing tools, missing image, etc.)
 #
 # Design notes:
@@ -28,6 +34,10 @@
 #   - We DO NOT abort on a single scenario failure — the aggregator marks
 #     missing scenarios as `(failed)` rows and the workflow surfaces the
 #     overall verdict via this script's exit code.
+#   - We self-bound the sweep via RELEASE_BENCH_BUDGET_SECONDS so the report is
+#     always aggregated and uploaded *before* the CI job's hard `timeout-minutes`
+#     can cancel us mid-loop (which would discard the report entirely). The job
+#     timeout is the backstop; this budget is the graceful cutoff.
 
 set -euo pipefail
 
@@ -73,8 +83,18 @@ done < "$SCENARIO_LIST"
 
 [[ ${#scenarios[@]} -gt 0 ]] || die "no scenarios in $SCENARIO_LIST"
 
+# Wall-clock budget for the scenario sweep. The release workflow caps the whole
+# job via `timeout-minutes`; this budget is the *graceful* cutoff that lets us
+# aggregate a partial report and exit cleanly BEFORE the runner hard-kills the
+# job (which would discard the report entirely, leaving the release notes with a
+# placeholder). The default (5400s = 90 min) leaves the full canonical sweep
+# (~83 min) room to finish, so it only trips when a runner is abnormally slow or
+# the scenario set grows. Set RELEASE_BENCH_BUDGET_SECONDS=0 to disable.
+BUDGET_SECONDS="${RELEASE_BENCH_BUDGET_SECONDS:-5400}"
+
 log "release-bench: tag=$TAG commit=$COMMIT_SHORT runner=$RUNNER captured=$CAPTURED"
 log "release-bench: scenarios=${scenarios[*]}"
+log "release-bench: sweep budget=${BUDGET_SECONDS}s (0 = unbounded)"
 
 # Verify the image exists locally so we fail fast.
 img="${LANTERN_IMAGE:-lantern:local}"
@@ -97,9 +117,27 @@ trap cleanup EXIT
 
 # Track each scenario's output directory and overall verdict.
 scenario_args=()
+skipped=()
 fail_count=0
+sweep_start="$(date +%s)"
+budget_hit=0
 
 for s in "${scenarios[@]}"; do
+  # Graceful wall-clock cutoff: once the budget is spent, skip the rest of the
+  # sweep instead of letting the CI job's hard timeout cancel us mid-scenario.
+  if [[ "$budget_hit" -eq 0 && "$BUDGET_SECONDS" -gt 0 ]]; then
+    elapsed=$(( $(date +%s) - sweep_start ))
+    if [[ "$elapsed" -ge "$BUDGET_SECONDS" ]]; then
+      log "sweep budget ${BUDGET_SECONDS}s reached after ${elapsed}s — skipping remaining scenarios"
+      budget_hit=1
+    fi
+  fi
+  if [[ "$budget_hit" -eq 1 ]]; then
+    log "scenario $s: SKIPPED (sweep budget exhausted)"
+    skipped+=("$s")
+    continue
+  fi
+
   log "scenario: $s"
   before_dir="$HERE/out/$s"
   mkdir -p "$before_dir"
@@ -140,7 +178,24 @@ go run "$HERE/release" \
   -out "$OUT_PATH" \
   "${scenario_args[@]}"
 
-log "done: $OUT_PATH (failures=$fail_count)"
+# If the budget truncated the sweep, the aggregated report only covers the
+# scenarios that ran. Append an honest note listing what was skipped so readers
+# of the release notes know the sweep was partial (and why).
+if [[ ${#skipped[@]} -gt 0 ]]; then
+  log "sweep truncated: ${#skipped[@]} scenario(s) skipped: ${skipped[*]}"
+  {
+    printf '\n## Truncated\n\n'
+    printf 'The release bench wall-clock budget (%ss) was reached before the full ' "$BUDGET_SECONDS"
+    printf 'scenario sweep completed. %d of %d scenario(s) were skipped and are ' \
+      "${#skipped[@]}" "${#scenarios[@]}"
+    printf 'absent from the summary above:\n\n'
+    for s in "${skipped[@]}"; do
+      printf -- '- `%s`\n' "$s"
+    done
+  } >> "$OUT_PATH"
+fi
+
+log "done: $OUT_PATH (failures=$fail_count, skipped=${#skipped[@]})"
 if [[ "${KEEP_OUT:-0}" != "1" ]]; then
   rm -rf "$HERE/out"
 fi


### PR DESCRIPTION
## What & why

The release-time benchmark job (`Release-time benchmark` in
`.github/workflows/docker-publish.yml`) **never completes and never produces its
report**. It was hard-capped at `timeout-minutes: 30`, but the full 16-scenario
canonical sweep needs **~83 min**, so the job is cancelled mid-loop on every
release. `testbed/bench/release.sh` only aggregates results *after* the whole
loop finishes, so a mid-loop cancellation discards `bench-report.md` entirely and
the release notes fall back to the placeholder — silently defeating #256's
deliverable on every tag.

Three numbers disagreed today: the job timeout (30 min), the
`release-scenarios.txt` header comment ("~50 min"), and the real sweep (~83 min).

Verified on run [27283439332](https://github.com/anaregdesign/lantern/actions/runs/27283439332)
(`v0.11.0`): 7 of 16 scenarios ran (all PASS) before the 30-min wall hit
`scan_prefix`; the `v0.11.0` release notes contain only
`_Bench job did not produce a report for this release…_`.

Full diagnosis in #571.

## The fix

1. **`release.sh` is now self-bounding.** A new `RELEASE_BENCH_BUDGET_SECONDS`
   wall-clock budget (default `5400` = 90 min) is checked before each scenario.
   Once exhausted, the remaining scenarios are **skipped**, the report is
   aggregated from whatever ran, a `## Truncated` note listing the skipped
   scenarios is appended, and the script **exits 0**. This makes the
   already-documented "partial report on timeout" intent actually work and
   guarantees the run never hard-cancels again, regardless of how the scenario
   set grows.
2. **Job `timeout-minutes` raised 30 → 105** — now purely a hard backstop, sized
   above the budget plus one scenario's worst-case overshoot (90 + ~6 min) plus
   job overhead, so the script's graceful cutoff always fires first. The bench
   job is non-blocking (`continue-on-error`, excluded from `release.needs` per
   #394) and release-only, so the longer ceiling is acceptable.
3. **Stale comments corrected** in `docker-publish.yml` ("smoke scenarios" → full
   canonical set) and `release-scenarios.txt` (~50 min → real ~83 min + document
   the new knob, with a note to keep the two timing knobs in lockstep).

No Go/aggregator change — the truncation note is appended by `release.sh`, so
`testbed/bench/release/` and its tests are untouched.

## Behaviour after this change

- **Normal runner**: full ~83-min sweep completes under the 90-min budget →
  complete report, exit 0.
- **Slow runner / larger scenario set**: budget trips → partial report with a
  `## Truncated` section, exit 0, run is **green** (no more `cancelled`).
- The 105-min job timeout only matters if `release.sh` itself hangs.

## Validation

- `bash -n testbed/bench/release.sh` — clean.
- `gofmt -l . cli core mcp pb sdks server tests` — clean (no Go changes).
- `python3 -c "yaml.safe_load(...)"` on the workflow — parses.
- Standalone probe of the new budget/skip/truncation logic (fake instantaneous
  "runs"): budget trips → correct RAN/SKIP split, well-formed `## Truncated`
  markdown, exit 0; budget disabled (`=0`) → all run, no note, exit 0.

Closes #571
