### PR TITLE
ci(release-bench): compact the release sweep to ~14 min via fan-out scenarios

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -97,7 +97,7 @@ jobs:
           echo "$TAGS" | xargs -I {} cosign sign --yes {}@${DIGEST}
 
   bench:
-    # Release-time benchmark sweep. Runs the full canonical scenario set
+    # Release-time benchmark sweep. Runs the compact scenario set
     # listed in testbed/bench/release-scenarios.txt against a freshly-built
     # local image and uploads a fixed-format bench-report.md for the release
     # job to splice into the release notes. Non-blocking: a leak-gate
@@ -107,14 +107,14 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     continue-on-error: true
-    # The full sweep is ~83 min of scenario execution (see release-scenarios.txt).
-    # release.sh self-bounds via RELEASE_BENCH_BUDGET_SECONDS (default 90 min) and
+    # The compact sweep is ~14 min of scenario loop (see release-scenarios.txt, #573).
+    # release.sh self-bounds via RELEASE_BENCH_BUDGET_SECONDS (default 18 min) and
     # always aggregates a report before returning, so this `timeout-minutes` is
     # only a hard backstop — sized above the budget plus one scenario's worst-case
-    # overshoot (90 + ~6 min) plus job overhead so the script's graceful cutoff
-    # fires first and the report is never discarded by a mid-loop cancellation.
-    # See issue #571.
-    timeout-minutes: 105
+    # overshoot plus job overhead (checkout + Go + ghz/yq + docker build + compose)
+    # so the script's graceful cutoff fires first and the report is never discarded
+    # by a mid-loop cancellation. See issues #571 and #573.
+    timeout-minutes: 35
     permissions:
       contents: read
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,9 +330,13 @@ Tag order matters because each downstream module pins the upstream tag:
    to the freshly-tagged versions.
 5. Root `vX.Y.Z` — triggers `docker-publish.yml` (amd64 + arm64 buildx +
    cosign keyless). The same workflow also runs the release-time bench
-   sweep (`testbed/bench/release.sh` → full canonical scenarios listed in
-   `testbed/bench/release-scenarios.txt`, including all illuminate
-   variants, batch/scan/edge/TTL paths, and many_subscribers fan-out)
+   sweep (`testbed/bench/release.sh` → the compact canonical sweep listed in
+   `testbed/bench/release-scenarios.txt`: two fan-out scenarios
+   (`broad_rw`, `broad_illuminate`) covering read/write/batch/scan/edge/delete
+   and the Illuminate algorithm×objective×weighting axes inside a single steady
+   window, plus `ttl_churn` and `many_subscribers` — ~14 min of scenario loop,
+   self-bounded by `RELEASE_BENCH_BUDGET_SECONDS` (default 18 min); see
+   [#573](https://github.com/anaregdesign/lantern/issues/573))
    and splices a fixed-format report into the release notes. The bench
    driver uses `ghz`; Connect-Go handlers accept gRPC frames natively
    on the same h2c socket and `connectrpc.com/grpcreflect` exposes the
@@ -340,7 +344,7 @@ Tag order matters because each downstream module pins the upstream tag:
    Connect-only server (verified in
    [#383](https://github.com/anaregdesign/lantern/issues/383)). The
    bench job is non-blocking — if it fails OR is cancelled (e.g. hits the
-   30-min `timeout-minutes` cap), the release still ships with a
+   35-min `timeout-minutes` cap), the release still ships with a
    placeholder bench section. The `release` job's `needs:` deliberately
    excludes `bench` because GitHub Actions treats `cancelled` as neither
    success nor failure, so a `needs: [..., bench]` edge skips the release

--- a/testbed/bench/README.md
+++ b/testbed/bench/README.md
@@ -11,18 +11,21 @@ per-scenario leak gate, and renders a Markdown report.
 > performance or leak regressions. Its outputs (under `testbed/bench/out/`)
 > are git-ignored.
 >
-> **Release CI runs the full canonical sweep.** On every `vX.Y.Z` tag
+> **Release CI runs a compact canonical sweep.** On every `vX.Y.Z` tag
 > push, the `Release` workflow runs `./testbed/bench/release.sh` — a
-> driver that sweeps the scenarios listed in `release-scenarios.txt` (the
-> three `smoke_*` variants as a fast head-of-sweep signal, then the full
-> canonical scenarios across read/write/batch/scan/edge/TTL/illuminate
-> variants/fan-out) and produces a fixed-format `bench-report.md` that
-> is spliced into the GitHub Release notes. The bench job is
-> `continue-on-error`, so a noisy runner cannot block a release. See
-> issues [#256], [#262].
+> driver that sweeps the scenarios listed in `release-scenarios.txt`. To
+> keep wall-time bounded without losing coverage, the sweep is four
+> scenarios: two fan-out scenarios (`broad_rw`, `broad_illuminate`) that
+> exercise many call paths inside a single steady window (read / write /
+> batch / scan / edge / delete, and the Illuminate algorithm × objective ×
+> weighting axes) plus `ttl_churn` and `many_subscribers`. It produces a
+> fixed-format `bench-report.md` that is spliced into the GitHub Release
+> notes. The bench job is `continue-on-error`, so a noisy runner cannot
+> block a release. See issues [#256], [#262], [#573].
 
 [#256]: https://github.com/anaregdesign/lantern/issues/256
 [#262]: https://github.com/anaregdesign/lantern/issues/262
+[#573]: https://github.com/anaregdesign/lantern/issues/573
 
 ## Prerequisites
 

--- a/testbed/bench/release-scenarios.txt
+++ b/testbed/bench/release-scenarios.txt
@@ -3,50 +3,59 @@
 # Lines starting with `#` and blank lines are ignored.
 #
 # This is the canonical release-time signal. The release bench job is
-# `continue-on-error` (non-blocking), so we run the full canonical
-# scenarios — not just the smoke variants — to surface regressions across
-# every major call path. The three `smoke_*` entries lead the sweep so the
-# rendered report is populated with useful rows first: release.sh self-bounds
-# the sweep via RELEASE_BENCH_BUDGET_SECONDS and always aggregates whatever
-# ran (appending a `## Truncated` note), so an over-budget runner still yields
-# a partial report instead of an empty one.
+# `continue-on-error` (non-blocking). Rather than run ~16 single-call
+# scenarios (which paid per-scenario fixed overhead — warmup + pre/post
+# runtime+pprof snapshots + cooldown + 12 Prometheus range queries + report
+# render — for each call path), the sweep is compacted to FOUR scenarios, two
+# of which fan out across many call paths inside a single steady window (see
+# the `target.calls` fan-out rule in run.sh). This keeps broad coverage while
+# cutting wall-time roughly 5x. See issue #573.
+#
+# Why steady = 2m (and not shorter): Lantern is purely in-memory — no LSM
+# compaction / WAL replay / page-cache warmup — so throughput stabilizes in
+# seconds. The ONLY slow scheduled background process is the 60s TTL/GC sweep
+# (LANTERN_GC_INTERVAL_SECONDS). The leak gate compares a post-warmup runtime
+# snapshot against a post-cooldown one, so the steady window must bracket that
+# 60s sweep at least twice to measure steady state rather than transients —
+# hence 2m is the spec-correct floor, not an arbitrary truncation.
+#
+# ORDER MATTERS: broad_rw populates the k-* vertices AND the k-*->k-* edges
+# that broad_illuminate then traverses, so broad_rw MUST precede
+# broad_illuminate. Do not reorder.
 #
 # Wall-time on a fresh ubuntu-latest runner (single shared 3-replica compose,
-# sequential execution): ~83 min total — ~6 min per full scenario (warmup 30s
-# + steady 5m + cooldown 30s) plus ~1.5 min per smoke scenario. The release
-# bench job's `timeout-minutes` and release.sh's RELEASE_BENCH_BUDGET_SECONDS
-# (default 90 min) are sized against this figure; see issue #571. If you add or
-# lengthen scenarios, update those two knobs in lockstep.
+# sequential execution): ~14 min of scenario loop (broad_rw ~3m +
+# broad_illuminate ~3m + ttl_churn ~4m + many_subscribers ~3.5m), ~15 min
+# including compose up + final aggregation. release.sh's
+# RELEASE_BENCH_BUDGET_SECONDS (default 1080s = 18 min) and the bench job's
+# `timeout-minutes` (35) are sized against this figure; see issues #571 and
+# #573. If you add or lengthen scenarios, update those two knobs in lockstep.
+#
+# release.sh self-bounds the sweep via RELEASE_BENCH_BUDGET_SECONDS and always
+# aggregates whatever ran (appending a `## Truncated` note), so an over-budget
+# runner still yields a partial report instead of an empty one.
 #
 # If you add a scenario here, keep it self-contained: the release driver
 # reuses ONE compose stack across all entries, so a scenario that mutates
 # global server config or leaves a wedged stream behind will pollute every
 # subsequent scenario's leak gate. Prefer adding a new `*.yaml` over
 # reusing an existing one with side effects.
+#
+# The heavier single-call scenarios (write_heavy, read_heavy, mixed_rw,
+# batch_put_vertices, scan_prefix, addedge_contention, illuminate*,
+# replication_soak, chaos_kill_replica, smoke_*) remain in scenarios/ and stay
+# runnable on demand via `run.sh <stem>` for deep dives — they are simply not
+# part of the compact release gate.
 
-# --- fast head-of-sweep signal (~2 min each) -------------------------------
-smoke_write_heavy
-smoke_read_heavy
-smoke_mixed_rw
+# read / write / scan / edge / delete call surface (8-way fan-out)
+broad_rw
 
-# --- full canonical sweep --------------------------------------------------
-# read / write paths
-write_heavy
-read_heavy
-mixed_rw
-batch_put_vertices
-scan_prefix
-addedge_contention
+# graph traversal across the orthogonal axes (4-way fan-out) — runs AFTER
+# broad_rw so the k-* graph it traverses is populated.
+broad_illuminate
+
+# TTL expiry / eviction plumbing under sustained write churn
 ttl_churn
 
-# graph traversal — three variants isolate per-traversal cost vs RPS tail
-illuminate
-illuminate_heavy
-illuminate_hot
-# orthogonal-axes Illuminate variants (#410): MST/MAX and SPT/TF-IDF cover
-# the two most expensive (algorithm, objective, weighting) combinations.
-illuminate_mst_max
-illuminate_spt_tfidf
-
-# replication / pubsub fan-out
+# leaderless Subscribe fan-out across replicas
 many_subscribers

--- a/testbed/bench/release.sh
+++ b/testbed/bench/release.sh
@@ -14,7 +14,7 @@
 #   RUNNER                       runner platform string (default: `uname -s/uname -m`, lowercased)
 #   LANTERN_IMAGE                image to run (default: lantern:local — must exist locally)
 #   KEEP_OUT=1                   do not delete the per-scenario `out/` tree afterwards
-#   RELEASE_BENCH_BUDGET_SECONDS wall-clock budget for the scenario sweep (default: 5400).
+#   RELEASE_BENCH_BUDGET_SECONDS wall-clock budget for the scenario sweep (default: 1080).
 #                                Once exhausted, the remaining scenarios are skipped, the
 #                                report is aggregated from whatever ran (with a `## Truncated`
 #                                note appended), and the script still exits 0. Set to 0 to
@@ -87,10 +87,11 @@ done < "$SCENARIO_LIST"
 # job via `timeout-minutes`; this budget is the *graceful* cutoff that lets us
 # aggregate a partial report and exit cleanly BEFORE the runner hard-kills the
 # job (which would discard the report entirely, leaving the release notes with a
-# placeholder). The default (5400s = 90 min) leaves the full canonical sweep
-# (~83 min) room to finish, so it only trips when a runner is abnormally slow or
-# the scenario set grows. Set RELEASE_BENCH_BUDGET_SECONDS=0 to disable.
-BUDGET_SECONDS="${RELEASE_BENCH_BUDGET_SECONDS:-5400}"
+# placeholder). The default (1080s = 18 min) leaves the compact canonical sweep
+# (~14 min of scenario loop; see release-scenarios.txt, #573) headroom to finish,
+# so it only trips when a runner is abnormally slow or the scenario set grows.
+# Set RELEASE_BENCH_BUDGET_SECONDS=0 to disable.
+BUDGET_SECONDS="${RELEASE_BENCH_BUDGET_SECONDS:-1080}"
 
 log "release-bench: tag=$TAG commit=$COMMIT_SHORT runner=$RUNNER captured=$CAPTURED"
 log "release-bench: scenarios=${scenarios[*]}"

--- a/testbed/bench/scenarios/broad_illuminate.yaml
+++ b/testbed/bench/scenarios/broad_illuminate.yaml
@@ -1,0 +1,47 @@
+# broad_illuminate — single steady window that fans out across the Illuminate
+# orthogonal axes (Algorithm × Objective × Weighting) plus a deep/wide variant.
+# Replaces the separate illuminate / illuminate_mst_max / illuminate_spt_tfidf /
+# illuminate_hot scenarios in the release sweep: run.sh forks one ghz per entry
+# in `target.calls` and runs them all in parallel for the same steady window.
+#
+# Goal: cover both reduction algorithms (MST, SPT) + the no-reduction path, both
+#       objectives (MINIMIZE, MAXIMIZE), both weightings (RAW, TFIDF), and a
+#       deeper/wider traversal — in one 2m steady window (brackets the 60s GC
+#       sweep twice for the leak gate).
+#
+# Dependency: every variant seeds k-* (uint enums per proto/graph/v1/graph.proto:
+#   Algorithm 1=MST 2=SPT, Objective 1=MINIMIZE 2=MAXIMIZE, Weighting 2=TFIDF).
+#   The k-* vertices AND the k-*→k-* edges are populated by broad_rw, so this
+#   scenario MUST run AFTER broad_rw in the release sweep (release-scenarios.txt).
+#   Run standalone against an empty graph, Illuminate still returns codes.OK with
+#   an empty subgraph — there is just no traversal work to measure.
+name: broad_illuminate
+phases:
+  warmup:   { duration: 15s, concurrency: 8,  rps: 200 }
+  steady:   { duration: 2m,  concurrency: 16, rps: 4000 }
+  cooldown: 15s
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  # 4 parallel ghz invocations (one per variant), each at steady.rps/4 = 1000
+  # rps and the full steady.concurrency (16) → 64 concurrent traversals total.
+  calls:
+    # [0] raw discovered subgraph (no reduction, default MAXIMIZE + RAW) — also
+    #     what warmup replays. Keep this first.
+    - call: graph.v1.LanternService/Illuminate
+      data_template: |
+        {"seed":"k-{{mod .RequestNumber 1000}}","step":2,"k":32}
+    # [1] minimum spanning tree, cost-minimizing direction, raw weights.
+    - call: graph.v1.LanternService/Illuminate
+      data_template: |
+        {"seed":"k-{{mod .RequestNumber 1000}}","step":2,"k":32,"algorithm":1,"objective":1}
+    # [2] shortest-path tree, relevance-maximizing, TF-IDF re-scored weights.
+    - call: graph.v1.LanternService/Illuminate
+      data_template: |
+        {"seed":"k-{{mod .RequestNumber 1000}}","step":2,"k":32,"algorithm":2,"objective":2,"weighting":2}
+    # [3] deeper + wider traversal (heaviest fan-out) over the raw subgraph.
+    - call: graph.v1.LanternService/Illuminate
+      data_template: |
+        {"seed":"k-{{mod .RequestNumber 1000}}","step":3,"k":64}
+leak_gate:
+  goroutine_max_delta: 25
+  heap_alloc_max_delta_mb: 64

--- a/testbed/bench/scenarios/broad_rw.yaml
+++ b/testbed/bench/scenarios/broad_rw.yaml
@@ -1,0 +1,69 @@
+# broad_rw — single steady window that fans out across the whole read/write/
+# scan/edge/delete call surface. Replaces a handful of single-call scenarios
+# in the release sweep: instead of paying per-scenario fixed overhead (warmup +
+# pre/post snapshots + cooldown + Prometheus range queries + report render) for
+# each call path, run.sh forks one ghz per entry in `target.calls` and runs them
+# all in parallel for the same steady window (see the fan-out rule in run.sh:
+# per_rps = steady.rps / len(calls), each fork gets the full steady.concurrency,
+# endpoints are round-robined).
+#
+# Goal: broad call-path coverage + a leak gate that brackets the 60s GC sweep
+#       twice (steady 2m). Key spaces are chosen so every call returns codes.OK
+#       (non-OK ~ 0): plural reads return OK + a `missing` list rather than
+#       NotFound; AddEdge is additive; DeleteVertex targets a monotonic space.
+#
+# Ordering: calls[0] (PutVertex over k-*) is what warmup replays — run.sh warms
+#           ONLY calls[0] — so it must be the working-set filler. The AddEdge
+#           path also seeds the k-* graph that the broad_illuminate scenario
+#           traverses next, so broad_rw MUST run before broad_illuminate in the
+#           release sweep (see release-scenarios.txt).
+name: broad_rw
+phases:
+  warmup:   { duration: 15s, concurrency: 16, rps: 1000 }
+  steady:   { duration: 2m,  concurrency: 16, rps: 8000 }
+  cooldown: 15s
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  # 8 parallel ghz invocations (one per call), each at steady.rps/8 = 1000 rps
+  # and the full steady.concurrency (16) → 128 concurrent streams total.
+  calls:
+    # [0] working-set filler — also what warmup replays. Keep this first.
+    - call: graph.v1.LanternService/PutVertex
+      data_template: |
+        {"vertex":{"key":"k-{{mod .RequestNumber 2000}}","int64":"{{.RequestNumber}}"}}
+    # [1] hot single-key read (k-* kept warm by warmup + call[0]).
+    - call: graph.v1.LanternService/GetVertex
+      data_template: |
+        {"key":"k-{{mod .RequestNumber 2000}}"}
+    # [2] plural write path (batch upsert into k-* and a sibling kb-* space).
+    - call: graph.v1.LanternService/PutVertices
+      data_template: |
+        {"vertices":[
+          {"key":"k-{{mod .RequestNumber 2000}}","int64":"{{.RequestNumber}}"},
+          {"key":"kb-{{mod .RequestNumber 2000}}","int64":"{{.RequestNumber}}"}
+        ]}
+    # [3] plural read path — returns OK + `missing` even on a cold key, so this
+    #     never contributes NotFound to the non-OK count.
+    - call: graph.v1.LanternService/GetVertices
+      data_template: |
+        {"keys":["k-{{mod .RequestNumber 2000}}","kb-{{mod .RequestNumber 2000}}"]}
+    # [4] additive edge write — builds the k-* graph broad_illuminate traverses.
+    - call: graph.v1.LanternService/AddEdge
+      data_template: |
+        {"edge":{"tail":"k-{{mod .RequestNumber 2000}}","head":"k-{{mod .RequestNumber 1000}}","weight":1.0}}
+    # [5] plural edge read — OK + `missing` semantics, like GetVertices.
+    - call: graph.v1.LanternService/GetEdges
+      data_template: |
+        {"edges":[{"tail":"k-{{mod .RequestNumber 2000}}","head":"k-{{mod .RequestNumber 1000}}"}]}
+    # [6] paginated prefix scan over the populated k-* space.
+    - call: graph.v1.LanternService/ScanVertices
+      data_template: |
+        {"prefix":"k-","limit":128}
+    # [7] delete path over a monotonic del-* space (no-op removals — exercises
+    #     the DeleteVertex→DeleteVertices facade without churning the k-* graph).
+    - call: graph.v1.LanternService/DeleteVertex
+      data_template: |
+        {"key":"del-{{.RequestNumber}}"}
+leak_gate:
+  goroutine_max_delta: 30
+  heap_alloc_max_delta_mb: 64

--- a/testbed/bench/scenarios/many_subscribers.yaml
+++ b/testbed/bench/scenarios/many_subscribers.yaml
@@ -11,8 +11,11 @@
 # noise; ≤ 5/64 is the documented acceptance bar of #392).
 name: many_subscribers
 phases:
+  # steady compacted from 5m to 2m for the release sweep (#573); still long
+  # enough for the Subscribe fan-out to reach steady state and to bracket the
+  # 60s GC sweep twice for the leak gate.
   warmup:   { duration: 30s, concurrency: 8, rps: 500 }
-  steady:   { duration: 5m,  concurrency: 32, rps: 2000 }
+  steady:   { duration: 2m,  concurrency: 32, rps: 2000 }
   cooldown: 30s
 target:
   # Writes pinned to one replica on purpose — see scenario doc above.
@@ -31,7 +34,7 @@ subscribe:
   data_template: '{}'
 leak_gate:
   goroutine_max_delta: 80     # 64 streams × bookkeeping
-  # 2k RPS × 5m of PutVertex with monotonically-increasing keys grows
+  # 2k RPS × 2m of PutVertex with monotonically-increasing keys grows
   # the in-memory graph + mutation-log ring + per-replica replication
   # state by hundreds of MiB of legitimate live working set. Under
   # Reading B every replica now also appends remote-applied mutations

--- a/testbed/bench/scenarios/ttl_churn.yaml
+++ b/testbed/bench/scenarios/ttl_churn.yaml
@@ -7,8 +7,10 @@
 #       config knob; see follow-up.
 name: ttl_churn
 phases:
+  # steady is 2m so the post-warmup→post-cooldown leak window brackets the
+  # 60s GC/TTL sweep twice (compacted from 5m for the release sweep, #573).
   warmup:   { duration: 30s, concurrency: 16, rps: 1000 }
-  steady:   { duration: 5m,  concurrency: 64, rps: 4000 }
+  steady:   { duration: 2m,  concurrency: 64, rps: 4000 }
   cooldown: 60s
 target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]


### PR DESCRIPTION
## What

Compact the release-time benchmark sweep from ~16 single-call scenarios
(~83 min) to **four** scenarios (~14 min of scenario loop, ~15 min with
compose + aggregation), two of which fan out across many call paths inside a
single steady window.

Closes #573.

## Why

The release bench job is `continue-on-error` (non-blocking), but it still
forced a 105-min `timeout-minutes` and a 90-min graceful budget because each
single-call scenario paid the full fixed overhead (warmup + pre/post
runtime+pprof snapshots + cooldown + 12 Prometheus range queries + report
render).

Lantern is purely **in-memory** — no LSM compaction, WAL replay, or
page-cache warmup — so throughput stabilizes in seconds. The only slow
scheduled background process is the **60s TTL/GC sweep**
(`LANTERN_GC_INTERVAL_SECONDS`). The leak gate compares a post-warmup runtime
snapshot against a post-cooldown one, so the steady window only needs to
bracket that 60s sweep **twice** → `steady = 2m` is the spec-correct floor,
not an arbitrary truncation.

## How

Fan-out via run.sh's existing `target.calls` support (one ghz fork per call,
`steady.rps / len(calls)` each, full `steady.concurrency` per fork,
endpoints round-robined):

- **`broad_rw`** (8-way): `PutVertex`/`GetVertex`, `PutVertices`/`GetVertices`,
  `AddEdge`/`GetEdges`, `ScanVertices`, `DeleteVertex`. Plural reads return
  `OK` + `missing` (never `NotFound`), `AddEdge` is additive, and
  `DeleteVertex` targets a monotonic `del-*` space → non-OK ≈ 0. `calls[0]`
  (PutVertex over `k-*`) is the warmup filler and seeds the `k-*` graph.
- **`broad_illuminate`** (4-way): raw / MST+MINIMIZE / SPT+MAXIMIZE+TFIDF /
  deep+wide — covers the Illuminate algorithm × objective × weighting axes.
  Runs **after** `broad_rw` so the `k-*` graph it traverses is populated.
- **`ttl_churn`**, **`many_subscribers`**: steady trimmed `5m → 2m` (still
  brackets the 60s sweep twice).

Knobs lowered in lockstep:

- `RELEASE_BENCH_BUDGET_SECONDS` default `5400 → 1080` (18 min)
- bench job `timeout-minutes` `105 → 35`

The #571 invariant holds — the graceful budget still trips before the hard
timeout, so a partial report is always aggregated rather than discarded by a
mid-loop cancellation.

The heavier single-call scenarios (`write_heavy`, `illuminate_*`,
`replication_soak`, etc.) remain in `scenarios/` and stay runnable on demand
via `run.sh <stem>` — they are simply no longer part of the compact release
gate.

## Validation

- `bash -n release.sh run.sh` — OK
- `gofmt -l . cli core mcp pb sdks server tests` — clean (no Go changed)
- All scenario YAMLs parse; fan-out `data_template` bodies are valid JSON
  with ghz templates stripped
- `yq` parity probe (mirrors run.sh extraction): `broad_rw` calls=8,
  `broad_illuminate` calls=4, all four steady=2m, `calls[0]` warmup target
  resolves
- `release/main_test.go` unaffected (uses scenario name only as a fixture
  string; the `smoke_*` YAMLs still exist)

Docs synced: `AGENTS.md` release-cutting step + `testbed/bench/README.md`.
