### PR TITLE
chore(agents): pin User agent model to Claude Opus 4.8

### DIFF
--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -13,6 +13,7 @@ Each agent is defined as `<AgentName>.agent.md` (kebab-case agent name for code 
 name: AgentName                    # Display name
 description: One-line summary of what this agent does and when to use it
 argument-hint: "Expected input(s), e.g., 'a component to review' or 'a task to implement'"
+model: claude-opus-4.8            # Optional: pin the agent to a specific model (omit to use the session default)
 tools: [tool1, tool2, ...]        # Optional: explicit tool list (if omitted, all enabled tools allowed)
 ---
 ```

--- a/.github/agents/User.agent.md
+++ b/.github/agents/User.agent.md
@@ -2,6 +2,7 @@
 name: User
 description: UX/UI design review specialist for Lantern Admin interface — inspects actual browser behavior using Playwright, identifies usability friction, design opportunities, and accessibility concerns. Files actionable Issues.
 argument-hint: "Admin UI component or page to review, specific workflow to test, or UX concern to investigate (browser testing enabled)"
+model: claude-opus-4.8
 tools: ['bash', 'view', 'edit', 'grep', 'glob', 'github-issue_write', 'github-list_issues']
 ---
 


### PR DESCRIPTION
Pins the `User` UX/UI review agent to `claude-opus-4.8` via a new `model` field in its frontmatter, and documents the optional `model` field in the agents README.

## Changes
- `.github/agents/User.agent.md` — add `model: claude-opus-4.8` to frontmatter
- `.github/agents/README.md` — document the optional `model` field in the frontmatter format

Doc/config-only change (agent definition); no Issue required per the AGENTS.md maintenance checklist carveout.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>