### PR TITLE
docs: reorganize AI instruction files and strip stale content

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,65 @@
+# Lantern — Copilot instructions
+
+Lantern is an in-memory graph KVS (`key-vertex-store`) served over Connect/HTTP-2
+(wire-compatible with gRPC and gRPC-Web on a single h2c socket); both vertices and
+edges carry TTLs and decay over time. The repo is a monorepo: a multi-module Go
+workspace (`go.work`) plus a standalone TypeScript admin SPA (`admin/`, Bun-managed,
+**outside** `go.work`).
+
+`AGENTS.md` is the full agent guide and `CONTRIBUTING.md` is the release/CI/maintenance
+contract. This file is the short, always-on subset — when it and `AGENTS.md` overlap,
+they must not conflict.
+
+## Never hand-edit generated code
+
+- `pb/**` — protobuf messages + Connect-Go stubs. Regenerate with `go generate ./...`
+  (runs `buf generate`; **never** pass `--clean`).
+- `server/cmd/wire_gen.go` — google/wire output. Regenerate from `server/` with
+  `go tool wire ./cmd`.
+
+## Architecture invariants
+
+- **The RPC surface is plural-first.** Every read/write/delete has a singular and a
+  plural form; the plural is the canonical implementation and the singular forwards a
+  one-element batch to it. When adding write surface, implement the plural first and
+  the singular as a thin facade — never duplicate logic.
+- **Dependency direction is a DAG — no back edges.** `pb` and `core` are leaves.
+  `sdks/go` imports `pb` only (never `core`/`server`). `server` imports `pb` and `core`
+  only (**never** the client SDK). The root module (cli + tests/integration) is the only
+  place that depends on everything. Cross-module/full-stack tests live in
+  `tests/integration/`, not under the producing package.
+- **SDK value accessors are free functions, not methods**: `Kind(v)`, `IntValue(v)`,
+  `StringValue(v)`, etc. `client.Vertex`/`client.Edge` are true aliases of the `pb`
+  types (one `Vertex` type, no boundary casts). Adding a value type updates three sites
+  in `sdks/go/value.go`.
+
+## Go conventions
+
+- **1:1 source↔test pairing.** Each `xxx.go` has at most one `xxx_test.go` in the same
+  package. Do **not** add `xxx_<concern>_test.go` siblings — extend the existing
+  `xxx_test.go` with sub-tests (`t.Run(...)`). The only permitted extra is
+  `xxx_external_test.go` (black-box, package `xxx_test`). Cross-cutting suites touching
+  ≥3 sources use `_gate_test.go`; shared test helpers live in `helpers_test.go`.
+- Put a new dependency in the module that actually imports it, then run `go mod tidy`
+  in every affected module (workspace `replace`s don't propagate `go.sum`).
+- The Go toolchain version is whatever each `go.mod` and the CI workflows pin — read it
+  there, never assume or hard-code a number.
+
+## Workflow (hard rules)
+
+- **File a GitHub Issue before any non-trivial change.** Exceptions: doc-only edits,
+  in-flight PR-review follow-ups, and one-line obvious fixes. The PR closes it with
+  `Closes #N` — use one keyword per issue (`Closes #1, closes #2`), since GitHub only
+  auto-links the first issue on a comma-separated line.
+- **PR titles must be Conventional Commits** (`feat`/`fix`/`docs`/`chore`/`ci`/
+  `refactor`/`perf`/`test`/`build`/`revert`); a required check rejects others.
+- **Before every push**, run the local quality gate: `gofmt -l` must print nothing,
+  then `go test ./...` from the root **and** from each submodule (the root run does not
+  span submodules).
+- Wait for all required CI checks before merging; never use `--admin`/`--no-verify`.
+  Merge with `--squash --delete-branch`. Never push to `main` directly.
+
+## Admin SPA (`admin/`)
+
+A separate Bun + React Router + Fluent UI v9 + Sigma.js stack — see `admin/AGENTS.md`.
+When editing admin code, follow the vendored `react-router-app-architecture` skill.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Lantern is an in-memory `key-vertex-store` (graph-based KVS). It runs as a Conne
 
 ## Monorepo layout
 
-This project used to be split across four separate repositories (`lantern` / `lantern-proto` / `lantern-cli`, plus a shared graph/cache/NLP toolkit), but **everything is now consolidated into this repo as a 6-module Go workspace** so each piece can be consumed (`go get`) on its own:
+This project used to be split across four separate repositories (`lantern` / `lantern-proto` / `lantern-cli`, plus a shared graph/cache/NLP toolkit), but **everything is now consolidated into this repo as a multi-module Go workspace** so each piece can be consumed (`go get`) on its own:
 
 | Path | Module | Role |
 |---|---|---|
@@ -56,10 +56,10 @@ make wire                        # alias: go tool wire ./server/cmd (run from se
 make proto                       # alias: buf generate (system `buf` if present, else `go run`)
 go run ./server/cmd              # start the server (:6380)
 go run ./cli                     # start the CLI
-docker build -t lantern .        # container build (Go 1.26-alpine)
+docker build -t lantern .        # container build
 ```
 
-CI: [.github/workflows/go.yml](.github/workflows/go.yml) runs `go build` + `go test` on PR/push (Go 1.26, actions/checkout@v4, setup-go@v5). [.github/workflows/docker-publish.yml](.github/workflows/docker-publish.yml) publishes to ghcr.io on `v*.*.*` tag pushes with cosign keyless signing (cosign v2, `--yes`).
+CI: [.github/workflows/go.yml](.github/workflows/go.yml) runs `go build` + `go test` on PR/push. [.github/workflows/docker-publish.yml](.github/workflows/docker-publish.yml) publishes to ghcr.io on `v*.*.*` tag pushes with cosign keyless signing. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full release and CI flow.
 
 ## Conventions and gotchas
 
@@ -108,10 +108,10 @@ CI: [.github/workflows/go.yml](.github/workflows/go.yml) runs `go build` + `go t
   9. When adding a new test, **append to the existing `xxx_test.go`**
      instead of creating a new file. Reviewers must reject PRs that
      introduce a new `<existing-source>_<concern>_test.go` sibling.
-- **Go version**: every `go.mod` is on `1.26` and the Dockerfile uses `golang:1.26-alpine`; CI pins `1.26.4`. Bumping the toolchain requires updating **every** site in lockstep — see the [Maintenance checklist](#maintenance-checklist) for the full list.
+- **Go version**: the toolchain version is whatever each `go.mod` and the CI workflows pin — treat those as the single source of truth and never hard-code a number in prose or docs. Bumping it requires updating **every** site in lockstep — see [CONTRIBUTING.md](CONTRIBUTING.md) for the checklist.
 - **wire and generics**: as the `// Avoiding bug of 'wire'. Generic type is not supported.` comment in `service.go` notes, wire cannot handle generic type arguments, so the provider returns the concrete `GraphCache[string, *Vertex]`. Re-check this constraint before trying to introduce generics there.
-- **Regenerating proto**: `go_package_prefix` in `buf.gen.yaml` is `github.com/anaregdesign/lantern/pb`, so the generated files land **inside the standalone `pb/` module** at `pb/graph/v1`. `go generate ./...` (or `make proto`) runs `buf generate` and rebuilds everything under `pb/`. **Do NOT pass `--clean`** — `buf`'s output root is `pb/`, and `--clean` would delete `pb/go.mod` and `pb/doc.go` along with the stubs. `buf.yaml` (v2 workspace) and `buf.gen.yaml` live at the repo root. `buf` does not need to be installed locally — the directive in [generate.go](generate.go) falls back to `go run github.com/bufbuild/buf/cmd/buf@v1.70.0` (the pin is mirrored as `BUF_VERSION` in the Makefile — bump both together). Treat `pb/` as generated-only — never hand-edit, never add domain code there.
-- **Multi-module layout**: five modules (`.`, `core/`, `pb/`, `sdks/go/`, `server/`) are stitched together for local dev via [go.work](go.work) and via `replace` directives in each importing module's `go.mod`. When adding a dep, place it in the module that actually uses it (e.g. server-only middleware → `server/go.mod`; client transport → `sdks/go/go.mod`; cli/integration-test only → root `go.mod`). After dependency changes run `go mod tidy` in **every** affected module. The `tool github.com/google/wire/cmd/wire` directive lives in `server/go.mod` (not root), so wire regen must be run from `server/`.
+- **Regenerating proto**: `go_package_prefix` in `buf.gen.yaml` is `github.com/anaregdesign/lantern/pb`, so the generated files land **inside the standalone `pb/` module** at `pb/graph/v1`. `go generate ./...` (or `make proto`) runs `buf generate` and rebuilds everything under `pb/`. **Do NOT pass `--clean`** — `buf`'s output root is `pb/`, and `--clean` would delete `pb/go.mod` and `pb/doc.go` along with the stubs. `buf.yaml` (v2 workspace) and `buf.gen.yaml` live at the repo root. `buf` does not need to be installed locally — the directive in [generate.go](generate.go) falls back to running buf via `go run` at the version pinned there (mirrored as `BUF_VERSION` in the Makefile — bump both together). Treat `pb/` as generated-only — never hand-edit, never add domain code there.
+- **Multi-module layout**: the workspace modules are stitched together for local dev via [go.work](go.work) and via `replace` directives in each importing module's `go.mod`. When adding a dep, place it in the module that actually uses it (e.g. server-only middleware → `server/go.mod`; client transport → `sdks/go/go.mod`; cli/integration-test only → root `go.mod`). After dependency changes run `go mod tidy` in **every** affected module. The `tool github.com/google/wire/cmd/wire` directive lives in `server/go.mod` (not root), so wire regen must be run from `server/`.
 - **Test gaps**: there are no tests for the server/service layer, wire wiring, or client transport paths. For non-trivial changes, **add at least a minimal table test in the same PR**.
 
 ## Docs / Links
@@ -128,278 +128,26 @@ CI: [.github/workflows/go.yml](.github/workflows/go.yml) runs `go build` + `go t
   rolling upgrades, common gotchas). Pair with the RFC; the runbook
   defers to the RFC on any disagreement.
 
-## Maintenance checklist
+## Workflow & maintenance
 
-Each item is **trigger → action**. Coding agents must consult this list whenever
-they take a listed action, and run the matching step before pushing / merging.
-This section is the canonical maintenance contract; mirror only the most
-load-bearing items into `/memories/repo/lantern.md` for compacted-state survival.
+The full release/CI/maintenance contract — issue triage, code-generation steps, the
+release tag order, the toolchain-bump checklist, and the doc-staleness sweep — lives in
+[CONTRIBUTING.md](CONTRIBUTING.md). Consult it whenever you take one of those actions.
+The load-bearing always-on essentials:
 
-### GitHub Project triage (`Lantern roadmap`)
+- **File a GitHub Issue before any non-trivial change** (exceptions: doc-only edits,
+  in-flight PR-review follow-ups, one-line obvious fixes). The closing PR references it
+  with `Closes #N` — one keyword per issue (`Closes #1, closes #2`).
+- **Before every push**, run the local quality gate: `gofmt -l` must print nothing, then
+  `go test ./...` from the root **and** from each submodule (the root run does not span
+  submodules).
+- **Never hand-edit generated code.** Regenerate `pb/**` with `go generate ./...` (buf,
+  never `--clean`) and `server/cmd/wire_gen.go` from `server/` with `go tool wire ./cmd`.
+- **When your work surfaces a fact another open Issue needs, comment it on that Issue in
+  the same session** — never only in a PR description or chat reply, which are invisible
+  to whoever opens the Issue next. See CONTRIBUTING.md for the format.
+- Wait for all required CI checks before merging; never use `--admin`/`--no-verify`;
+  merge `--squash --delete-branch`; never push to `main` directly.
 
-Cross-track triage lives in a single Project named `Lantern roadmap`. Issues
-remain the source of truth — the Project is a view layer + lightweight kanban
-on top of them.
-
-**Custom fields (all four are mandatory on every Issue):**
-
-| Field | Allowed values |
-|---|---|
-| `Track` | `Admin` / `HA` / `Connect` / `SDK` / `Maintenance` / `Docs` |
-| `Module` | `pb` / `core` / `server` / `sdks-go` / `sdks-node` / `sdks-python` / `admin` / `mcp` / `tests` / `docs` / `ci` |
-| `Release target` | `next pb` / `next sdks-go` / `next root` / `next mcp` / `next admin-internal` / `unscheduled` |
-| `Priority` | `P0` / `P1` / `P2` |
-
-**Rules:**
-
-- Every new Issue must have all four fields filled **in the same session it is
-  created** (typically via the Project Web UI right after `gh issue create`).
-- The Project is **not** the source of truth. Do not infer scope, dependencies,
-  or release order from the board — those live in the Issue body and in this
-  file. The board is a view.
-- Do not create additional Projects (per-module, per-release, etc.); a single
-  Project keeps the cost of "what is everyone working on" close to zero.
-- `gh` CLI needs the `project` scope (`gh auth refresh -s project`) to mutate
-  the board.
-
-### When your work surfaces a finding useful to another open Issue
-
-Whether you are closing #A, filing a foundation Issue that re-frames others, or
-just reading code mid-task, the rule is the same: **the moment your current work
-produces a fact that future-you (or another agent) will need when picking up an
-unrelated open Issue, post it as a comment on that Issue, in the same session,
-before you forget.** Wire-shape gotchas, flake reproducers, perf numbers,
-build-order constraints, model-shift implications — anything that would make a
-reader of Issue #B six months from now ask "why didn't anyone mention this?".
-
-Format the comment so #B's reader gets the context without having to chase the
-link:
-
-> Finding from \<work that surfaced this — PR/Issue/exploration\>:
-> \<one-paragraph fact\>. Source: \<code/file/log link\>.
-
-Concrete triggers (non-exhaustive):
-
-- **Closing #A.** If the work on #A's PR surfaced something #B needs, comment
-  on #B in the same PR — not in the PR description (reviewers of #B won't
-  follow that link six months from now).
-- **Filing a foundation Issue #F that re-frames others.** When #F shifts the
-  assumptions #B1, #B2, … were built on, comment on each downstream Issue with
-  the impact (blocked / body needs revision / unchanged) and a pointer to the
-  relevant section of #F, in the same session you file #F. Precedent: #466
-  → comments on #456 / #460 / #461 (blocked, bodies revised) and on
-  #457 / #458 / #459 / #464 / #465 (unchanged).
-- **Mid-task exploration.** If reading the code for task #A reveals that #B's
-  reproduction steps are wrong, its proposed approach won't work, or a
-  prerequisite it assumes is already done, comment on #B before resuming #A.
-  Don't promise yourself you'll come back to it.
-
-Always post the comment **on #B itself**, never only in a PR description or a
-chat reply — those surfaces are invisible to whoever opens #B next. If three
-or more Issues benefit from the same finding, also append a one-line entry to
-the relevant section of this file (`Architecture notes` / `Conventions and
-gotchas`) so future agents see it without having to grep Issue threads.
-
-### Before every `git push` (local quality gate)
-
-Run from repo root — this matches what the four required CI checks enforce
-(`Build & Test`, `Lint`, `Proto (buf)`, `govulncheck`):
-
-```bash
-gofmt -l . cli core mcp pb sdks server tests   # must print nothing
-(cd server && go vet ./... && go test ./...)
-go test ./...
-(cd core    && go test ./...)
-(cd mcp     && go test ./...)
-(cd pb      && go test ./...)
-(cd sdks/go && go test ./...)
-```
-
-Per-module test runs are mandatory: root `go test ./...` does **not** span
-submodules. The `Lint` job runs `golangci-lint` (CI installs it); `make lint`
-is the local equivalent if you have it. `Proto (buf)` fails on any uncommitted
-codegen diff — regenerate locally first (see below).
-
-### Before starting any non-trivial fix or feature
-
-**File a GitHub Issue first, then implement.** This is a hard rule, not a
-suggestion. The Issue is what makes the change reviewable: it pins down the
-problem statement, the chosen option among alternatives, the scope, and the
-"why now / why not now" decision **before** any diff exists. Skipping straight
-to a branch means the PR description has to carry all of that context, which
-in practice means it doesn't.
-
-- One Issue per coherent problem. Use `gh issue create --title ... --body ...`.
-- The PR that closes it references the Issue (`Closes #N`) so the merge wires
-  the discussion to the diff automatically.
-- Exceptions — no Issue required:
-  - Pure doc-only edits (README typos, comment fixes, AGENTS.md tweaks).
-  - Direct follow-ups requested in an in-flight PR review.
-  - One-line obvious bug fixes where writing the Issue would take longer than
-    the fix and there is nothing to discuss.
-- When in doubt, file the Issue. The overhead is ~2 minutes; the cost of a
-  rejected/reworked PR is far higher.
-
-### Before merging a PR
-
-- Wait for **all 4 required checks** green. Never use `--admin` or
-  `--no-verify`. One PR per issue from clean main.
-- Merge with `gh pr merge <n> --squash --delete-branch`, then
-  `git checkout main && git pull --rebase`.
-- **Multi-issue `Closes` syntax.** GitHub only auto-links the *first* issue
-  on a comma-separated line. `Closes #1, #2, #3` closes `#1` and leaves
-  `#2`/`#3` orphaned after merge. Use either one keyword per issue
-  (`Closes #1, closes #2, closes #3`) or one keyword per line. PR #441
-  shipped fixes for #428/#429/#430/#432 but only #428 closed
-  automatically.
-
-### After editing `.proto`
-
-```bash
-go generate ./...   # runs buf generate (NO --clean) + wire
-```
-
-Commit the resulting `pb/graph/v1/**` (protobuf messages + Connect-Go stubs).
-Never pass `--clean` to buf — it deletes `pb/go.mod` and `pb/doc.go`.
-
-### After editing wire providers (`server/provider/*`, `server/cmd/wire.go`)
-
-```bash
-cd server && go tool wire ./cmd       # or: make wire
-```
-
-Commit the regenerated `server/cmd/wire_gen.go`. Never hand-edit it. If you
-introduced a new sub-config, update the **Providers** bullet in this file.
-
-### After renaming any public SDK / server symbol (refactor)
-
-- Grep the **entire workspace** (`cli/`, `core/`, `mcp/`, `pb/`, `sdks/go/`,
-  `server/`, `testbed/`, `tests/integration/`, `*.md`) for every old name. A
-  single-module test pass is **not** sufficient — six modules can compile in
-  isolation while the cross-module call site is broken.
-- Update the **Architecture notes** bullets in this file and the
-  **Conventions and gotchas** section of `README.md` in the **same PR**. The
-  #106 alias refactor invalidated three method names across two docs — that
-  pattern recurs.
-
-### After adding a dependency
-
-- Add the require to the module that **actually imports** it (server-only
-  middleware → `server/go.mod`; client transport → `sdks/go/go.mod`; cli or
-  integration tests only → root `go.mod`).
-- Run `go mod tidy` in **every** affected module. Workspace `replace`s do not
-  propagate `go.sum` entries.
-- If the Dockerfile was touched, confirm every workspace member's `go.mod` and
-  `go.sum` are COPYed **before** `go mod download` (go.work prerequisite).
-  The current list (6 modules: root, `core/`, `mcp/`, `pb/`, `sdks/go/`,
-  `server/`) must stay in lockstep with `go.work`. PR CI does not run
-  `docker build`, so a missed `COPY` only surfaces at release-tag time —
-  see [#382](https://github.com/anaregdesign/lantern/issues/382) for the
-  `mcp/go.mod` regression caused by exactly this.
-
-### Bumping the Go toolchain
-
-Update **all** of the following in one PR:
-
-1. Every `go.mod` (6 files): root, `core/`, `mcp/`, `pb/`, `sdks/go/`, `server/`.
-2. `Dockerfile` and `mcp/Dockerfile` — `FROM golang:X.Y-alpine`.
-3. Every `go-version:` in `.github/workflows/*.yml` (`go.yml`, `docker-publish.yml`,
-   `mcp-publish.yml`).
-4. The `Go version` mentions in this file and `README.md`.
-5. The CI version note in `/memories/repo/lantern.md`.
-
-### Bumping the `buf` pin
-
-Update **both**: the `@vX.Y.Z` suffix in [generate.go](generate.go) **and**
-`BUF_VERSION` in the [Makefile](Makefile).
-
-### Cutting a release (`vX.Y.Z`)
-
-Tag order matters because each downstream module pins the upstream tag:
-
-1. `pb/vX.Y.Z`
-2. `core/vX.Y.Z`
-3. `sdks/go/vX.Y.Z` — triggers `.github/workflows/sdks-go-publish.yml`,
-   which runs vet/build/test against the tagged commit and creates a
-   GitHub Release with `--title "$TAG"` (raw-tag convention). The Go
-   module proxy pulls source directly from VCS, so there is no artifact
-   to push; the verify step exists because tag pushes do not trigger
-   the regular `Go` workflow and a broken `sdks/go/vX.Y.Z` would
-   otherwise land on pkg.go.dev unchecked.
-4. Bump the matching `require` (and any `replace`) lines in the root `go.mod`
-   to the freshly-tagged versions.
-5. Root `vX.Y.Z` — triggers `docker-publish.yml` (amd64 + arm64 buildx +
-   cosign keyless). The same workflow also runs the release-time bench
-   sweep (`testbed/bench/release.sh` → the compact canonical sweep listed in
-   `testbed/bench/release-scenarios.txt`: two fan-out scenarios
-   (`broad_rw`, `broad_illuminate`) covering read/write/batch/scan/edge/delete
-   and the Illuminate algorithm×objective×weighting axes inside a single steady
-   window, plus `ttl_churn` and `many_subscribers` — ~14 min of scenario loop,
-   self-bounded by `RELEASE_BENCH_BUDGET_SECONDS` (default 18 min); see
-   [#573](https://github.com/anaregdesign/lantern/issues/573))
-   and splices a fixed-format report into the release notes. The bench
-   driver uses `ghz`; Connect-Go handlers accept gRPC frames natively
-   on the same h2c socket and `connectrpc.com/grpcreflect` exposes the
-   reflection service, so the harness works unchanged against the
-   Connect-only server (verified in
-   [#383](https://github.com/anaregdesign/lantern/issues/383)). The
-   bench job is non-blocking — if it fails OR is cancelled (e.g. hits the
-   35-min `timeout-minutes` cap), the release still ships with a
-   placeholder bench section. The `release` job's `needs:` deliberately
-   excludes `bench` because GitHub Actions treats `cancelled` as neither
-   success nor failure, so a `needs: [..., bench]` edge skips the release
-   on cancellation regardless of `continue-on-error`. See issues
-   [#256](https://github.com/anaregdesign/lantern/issues/256),
-   [#262](https://github.com/anaregdesign/lantern/issues/262), and
-   [#394](https://github.com/anaregdesign/lantern/issues/394).
-
-The `server/` module is **never** tagged independently — it ships under the
-root tag. arm64 buildx under QEMU is slow; if a root tag already pushed the
-amd64 image, bump the patch number rather than force-moving the tag.
-
-The `mcp/` module is cut **independently** of the root release cadence: tag
-`mcp/vX.Y.Z` triggers `.github/workflows/mcp-publish.yml`, which builds and
-publishes `ghcr.io/anaregdesign/lantern-mcp:X.Y.Z` (multi-arch + cosign
-keyless). It does NOT need to follow the `pb → core → sdks/go → root` order;
-the MCP server only imports `pb/` and `sdks/go/`, so a `sdks/go/vX.Y.Z` bump
-is the only upstream pin that requires re-tagging the MCP image.
-
-The `admin/` module is cut **independently** of the root release cadence and
-the SDK cadences (it is not a Go module and not part of `go.work`): tag
-`admin/vX.Y.Z` triggers `.github/workflows/admin-publish.yml`, which re-runs
-the admin gates (lint / typecheck / codegen-up-to-date / build), then builds
-and publishes `ghcr.io/anaregdesign/lantern-admin:X.Y.Z` (multi-arch + cosign
-keyless). It does NOT need to follow the `pb → core → sdks/go → root` order;
-the admin SPA's only cross-module build-time dependency is the `proto/`
-sources (consumed by `bun run codegen` via `@bufbuild/protoc-gen-es` +
-`@connectrpc/protoc-gen-connect-es`), so a `pb/vX.Y.Z` bump is the one
-upstream pin that requires re-tagging the admin image. The admin container
-hosts the SPA on Caddy (`:8080`) and does **not** reverse-proxy the Lantern
-listener — the browser calls the gateway directly, so the server's
-`LANTERN_CORS_ALLOWED_ORIGINS` must include the admin origin. It *does*
-optionally reverse-proxy Prometheus same-origin under `/api/prom` (opt-in via
-the `LANTERN_ADMIN_PROMETHEUS_UPSTREAM` env var, materialised at container
-start by `admin/docker-entrypoint.sh` into a Caddy `handle_path` snippet the
-Caddyfile glob-imports); the SPA's Ops Metrics page uses that path to dodge
-Prometheus's missing CORS headers.
-
-**Release title convention (locked).** Every GitHub Release title MUST equal
-its tag name verbatim — `v0.7.2`, `core/v0.2.0`, `sdks/go/v0.8.0`,
-`sdks/node/v0.1.2`, `sdks/python/v0.1.1`, `mcp/v0.1.0`, `admin/v0.1.0`. No
-friendly aliases (`Node SDK v0.1.2`, `Go SDK v0.6.0`, etc).
-`docker-publish.yml`, `mcp-publish.yml`, and `admin-publish.yml` already
-enforce this via `gh release create --title "$TAG"`. The Python and Node SDK GitHub Releases are currently created
-manually — when creating them, always pass `--title "$(git describe
---tags)"` (or the literal tag) so the title matches. If you ever automate
-those releases inside `python-sdk.yml` / `node-sdk.yml`, use the same
-`--title "$TAG"` pattern.
-
-### Periodic doc-staleness sweep (before each release, or whenever memory and
-### code disagree)
-
-- Re-read this file, `README.md` "Conventions and gotchas", and
-  `/memories/repo/lantern.md`.
-- For every cited symbol, file path, env var, and shell command, verify it
-  still exists and works. CLI command snippets in `README.md` can be checked
-  with `go run ./cli <subcommand> --help`.
-- Reconcile any drift in the same PR.
+Mirror only the most load-bearing items into `/memories/repo/lantern.md` for
+compacted-state survival.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,192 @@
+# Contributing to Lantern
+
+This file is the process and maintenance contract for the repo: triage, the local
+quality gate, the issue-first policy, PR/merge rules, code-generation steps, and the
+release/tag procedure. [AGENTS.md](AGENTS.md) covers the codebase architecture and
+per-task conventions; [.github/copilot-instructions.md](.github/copilot-instructions.md)
+is the always-on short subset.
+
+Each maintenance item below is **trigger → action**. Run the matching step before
+pushing or merging.
+
+## Issue triage — the `Lantern roadmap` project
+
+Cross-track triage lives in a single GitHub Project named `Lantern roadmap`. Issues
+remain the source of truth — the Project is only a view layer + lightweight kanban on
+top of them.
+
+Every Issue must have all four custom fields filled **in the same session it is
+created**:
+
+| Field | Allowed values |
+| --- | --- |
+| `Track` | `Admin` / `HA` / `Connect` / `SDK` / `Maintenance` / `Docs` |
+| `Module` | `pb` / `core` / `server` / `sdks-go` / `sdks-node` / `sdks-python` / `admin` / `mcp` / `tests` / `docs` / `ci` |
+| `Release target` | `next pb` / `next sdks-go` / `next root` / `next mcp` / `next admin-internal` / `unscheduled` |
+| `Priority` | `P0` / `P1` / `P2` |
+
+Rules:
+
+- The Project is **not** the source of truth — do not infer scope, dependencies, or
+  release order from the board. Those live in the Issue body and in `AGENTS.md`.
+- Do not create additional Projects (per-module, per-release, …); one Project keeps the
+  "what is everyone working on" cost near zero.
+- `gh` needs the `project` scope (`gh auth refresh -s project`) to mutate the board.
+
+## Record findings on the Issue they help, in the same session
+
+The moment your current work produces a fact that future-you (or another agent) will
+need when picking up an **unrelated** open Issue, post it as a comment on that Issue
+before you forget. Wire-shape gotchas, flake reproducers, perf numbers, build-order
+constraints, model-shift implications — anything that would make a future reader ask
+"why didn't anyone mention this?".
+
+Format so the reader gets the context without chasing the link:
+
+> Finding from \<work that surfaced this — PR/Issue/exploration\>: \<one-paragraph
+> fact\>. Source: \<code/file/log link\>.
+
+Always post on the Issue itself — never only in a PR description or a chat reply, which
+are invisible to whoever opens the Issue next. If three or more Issues benefit from the
+same finding, also add a one-line entry to the relevant section of `AGENTS.md`.
+
+## Before starting any non-trivial fix or feature
+
+**File a GitHub Issue first, then implement.** This is a hard rule. The Issue pins down
+the problem, the chosen option among alternatives, and the scope *before* a diff exists.
+
+- One Issue per coherent problem (`gh issue create`).
+- The closing PR references it (`Closes #N`) so the merge wires discussion to diff.
+- Exceptions (no Issue required): pure doc-only edits; direct follow-ups requested in an
+  in-flight PR review; one-line obvious bug fixes with nothing to discuss.
+- When in doubt, file the Issue — the overhead is tiny next to a reworked PR.
+
+## Before every `git push` — local quality gate
+
+Run from the repo root; this matches the required CI checks (Build & Test, Lint,
+Proto (buf), govulncheck):
+
+```bash
+gofmt -l .                       # must print nothing (covers every Go module)
+go test ./...                    # root module
+(cd core    && go test ./...)
+(cd mcp     && go test ./...)
+(cd pb      && go test ./...)
+(cd sdks/go && go test ./...)
+(cd server  && go vet ./... && go test ./...)
+```
+
+Per-module test runs are mandatory: the root `go test ./...` does **not** span
+submodules. `make lint` runs the same linter as the `Lint` job. The `Proto (buf)` check
+fails on any uncommitted codegen diff — regenerate locally first (below).
+
+## Before merging a PR
+
+- Wait for **all required checks** green. Never use `--admin` or `--no-verify`. One PR
+  per Issue from clean `main`.
+- Merge with `gh pr merge <n> --squash --delete-branch`, then
+  `git checkout main && git pull --rebase`.
+- **Multi-issue `Closes` syntax:** GitHub only auto-links the *first* issue on a
+  comma-separated line. Use one keyword per issue (`Closes #1, closes #2, closes #3`)
+  or one keyword per line; otherwise the later issues are left open after merge.
+
+## After editing `.proto`
+
+```bash
+go generate ./...   # runs buf generate (NO --clean) + wire
+```
+
+Commit the regenerated stubs under `pb/`. Never pass `--clean` to buf — its output root
+is `pb/`, so `--clean` would delete `pb/go.mod` and `pb/doc.go` alongside the stubs.
+
+## After editing wire providers (`server/provider/*`, `server/cmd/wire.go`)
+
+```bash
+cd server && go tool wire ./cmd       # or: make wire
+```
+
+Commit the regenerated `server/cmd/wire_gen.go`; never hand-edit it. If you introduced a
+new sub-config, update the **Providers** note in `AGENTS.md`.
+
+## After renaming any public SDK / server symbol
+
+- Grep the **entire workspace** (every Go module, the TypeScript `admin/`, and all
+  `*.md`) for the old name. Single-module compilation is not sufficient — modules can
+  build in isolation while a cross-module call site is broken.
+- Update the affected notes in `AGENTS.md` and `README.md` in the same PR.
+
+## After adding a dependency
+
+- Add the require to the module that **actually imports** it (server-only middleware →
+  `server/go.mod`; client transport → `sdks/go/go.mod`; cli or integration tests only →
+  root `go.mod`).
+- Run `go mod tidy` in **every** affected module — workspace `replace`s do not propagate
+  `go.sum` entries.
+- If the `Dockerfile` was touched, confirm every workspace member's `go.mod`/`go.sum` is
+  `COPY`ed **before** `go mod download` (a `go.work` prerequisite). The module set must
+  stay in lockstep with `go.work`. PR CI does not run `docker build`, so a missed `COPY`
+  only surfaces at release-tag time.
+
+## Bumping the Go toolchain
+
+Update **all** of these in one PR, then re-run the local quality gate:
+
+1. Every `go.mod` (all workspace modules).
+2. Every `Dockerfile` (`FROM golang:<version>-alpine`).
+3. Every `go-version:` in `.github/workflows/*.yml`.
+4. The Go-version mentions in `README.md` (no instruction file pins a version — they
+   point here / to `go.mod`).
+
+## Bumping the `buf` pin
+
+Update **both** the `@vX.Y.Z` suffix in [generate.go](generate.go) and `BUF_VERSION` in
+the [Makefile](Makefile) — keep them identical.
+
+## Cutting a release (`vX.Y.Z`)
+
+Tag order matters because each downstream module pins its upstream tag:
+
+1. `pb/vX.Y.Z`
+2. `core/vX.Y.Z`
+3. `sdks/go/vX.Y.Z` — triggers `sdks-go-publish.yml` (vet/build/test on the tagged
+   commit + a GitHub Release titled exactly the tag). The module proxy pulls source from
+   VCS, so there is no artifact to push.
+4. Bump the matching `require`/`replace` lines in the root `go.mod` to the freshly-tagged
+   versions.
+5. Root `vX.Y.Z` — triggers `docker-publish.yml` (multi-arch buildx + cosign keyless),
+   which also runs the release-time bench sweep and splices a report into the notes. The
+   bench job is **non-blocking**: if it fails or is cancelled the release still ships
+   with a placeholder bench section (the `release` job's `needs:` deliberately excludes
+   `bench`, because Actions treats `cancelled` as neither success nor failure).
+
+The `server/` module is never tagged independently — it ships under the root tag. arm64
+buildx under QEMU is slow; if a root tag already pushed the amd64 image, bump the patch
+number rather than force-moving the tag.
+
+`mcp/` and `admin/` are cut **independently** of the root cadence:
+
+- `mcp/vX.Y.Z` triggers `mcp-publish.yml` → `ghcr.io/anaregdesign/lantern-mcp` (multi-arch
+  + cosign). The MCP server only imports `pb/` and `sdks/go/`, so a `sdks/go` bump is the
+  only upstream pin that forces a re-tag.
+- `admin/vX.Y.Z` triggers `admin-publish.yml` (admin gates → multi-arch + cosign) →
+  `ghcr.io/anaregdesign/lantern-admin`. The admin SPA's only cross-module build-time
+  input is the `proto/` sources (consumed by `bun run codegen`), so a `pb/` bump is the
+  only upstream pin that forces a re-tag. The container hosts the SPA on Caddy and does
+  not reverse-proxy the Lantern listener — the browser calls the gateway directly, so the
+  server's `LANTERN_CORS_ALLOWED_ORIGINS` must include the admin origin.
+
+**Release title convention (locked).** Every GitHub Release title MUST equal its tag name
+verbatim (`v0.7.2`, `core/v0.2.0`, `sdks/go/v0.8.0`, `mcp/v0.1.0`, `admin/v0.1.0`, …) —
+no friendly aliases. The container-publishing workflows enforce this via
+`gh release create --title "$TAG"`; when creating SDK releases manually, pass the same
+`--title "$TAG"`.
+
+## Periodic doc-staleness sweep
+
+Before each release, or whenever memory and code disagree:
+
+- Re-read `AGENTS.md`, `.github/copilot-instructions.md`, `README.md` "Conventions and
+  gotchas", and `/memories/repo/lantern.md`.
+- For every cited symbol, file path, env var, and shell command, verify it still exists
+  and works (CLI snippets via `go run ./cli <subcommand> --help`).
+- Reconcile any drift in the same PR.

--- a/admin/AGENTS.md
+++ b/admin/AGENTS.md
@@ -1,0 +1,53 @@
+# Admin SPA — Agent Instructions
+
+The browser control surface for Lantern. This is a **standalone TypeScript package**,
+not a Go module, and is **not** part of `go.work`. See [README.md](README.md) for setup
+and scripts; this file is the always-on agent context for editing admin code.
+
+## Stack
+
+- **React Router (SPA mode)** + **TypeScript**, bundled by **Vite**.
+- **Fluent UI v9** (`@fluentui/react-components`) for UI; **Sigma.js** + **graphology**
+  for graph rendering.
+- **Bun** is the toolchain and package manager — the exact version is pinned in
+  `package.json` (`packageManager`); read it there, don't hard-code a number.
+- Talks to the Lantern server over **Connect-Web** via `lantern-sdk/web` (the browser
+  subpath of the Node SDK). All protobuf types, value codecs, batch helpers, and error
+  mapping live in the SDK — admin has no Connect-Web codegen of its own.
+
+## Follow the React Router app-architecture skill
+
+When editing admin code, follow the vendored `react-router-app-architecture` skill
+(`.github/skills/react-router-app-architecture/`). It owns route boundaries, component
+structure, use-case/repository-port layering, Fluent UI usage, and Playwright
+verification. The conventions below are the load-bearing subset.
+
+## Structure conventions (principle-based — do not enumerate routes here)
+
+- **One React component per `.tsx`**, filename matches the export, with a colocated CSS
+  Module. Use **CSS Modules**, not Fluent `makeStyles`, for component styling.
+- UI-facing use cases live under `app/lib/client/usecase/`; browser/HTTP adapters under
+  `app/lib/client/infrastructure/`. All per-RPC adapters route through the single client
+  builder in `app/lib/client/infrastructure/api/`.
+- There is **no `lib/server/`** — the SPA calls the server directly from the browser, so
+  CORS is enforced server-side. The server's `LANTERN_CORS_ALLOWED_ORIGINS` must include
+  the admin origin.
+- `app/styles/` is reserved for `FluentProvider` host wiring only; feature styles live
+  with their components.
+
+## Quality gate (before pushing admin changes)
+
+Run from `admin/`:
+
+```bash
+bun run format
+bun run lint
+bun run typecheck      # react-router typegen, then tsc -b
+bun run test           # unit tests (do NOT use bare `bun test`)
+bun run build
+bun run test:e2e       # Playwright; free the server ports first
+```
+
+Use the package scripts, not bare `bun test` — the `test` script scopes Bun's runner to
+the right paths. The Playwright suite needs a running server, so stop any local compose
+stack that holds the ports before starting it.

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -1,0 +1,48 @@
+# Server — Agent Instructions
+
+The Lantern Connect server module. See [README.md](README.md) for the package layout,
+env-var contract, and observability endpoints; this file is the always-on agent context
+for editing server code. Root [../AGENTS.md](../AGENTS.md) covers cross-module
+architecture.
+
+## RPC surface is plural-first
+
+[service/service.go](service/service.go) implements `LanternService`. Every
+read/write/delete has a **singular** and a **plural** form. The plural is the canonical
+implementation; the singular forwards a one-element batch to its plural counterpart
+(e.g. for `GetVertex`/`GetEdge`, `len(Missing)==1` maps to `codes.NotFound`; for
+`DeleteVertex`/`DeleteEdge`, `Existed = resp.GetDeleted() == 1`). When you add write
+surface, **always implement the plural first and the singular as the facade** — never
+duplicate logic.
+
+## Dependency boundary
+
+The server imports `pb/` and `core/` only — **never** the client SDK. If a server test
+needs the client (e.g. a full-stack bufconn round-trip), put it in `tests/integration/`
+in the root module instead of under `server/`.
+
+## Dependency injection: google/wire
+
+- [cmd/wire.go](cmd/wire.go) holds the provider list (hand-edited, build-tagged
+  `wireinject`).
+- [cmd/wire_gen.go](cmd/wire_gen.go) is generated — **never hand-edit it.** Regenerate
+  from this directory after changing providers:
+
+  ```bash
+  go tool wire ./cmd       # or: make wire (from repo root)
+  ```
+
+- **Providers take the focused sub-config slice they actually need** (e.g.
+  `NewListener(*NetConfig)`), not the aggregate `*Config`. Keep that SRP invariant when
+  adding providers; only `App`/`main` may hold `*Config` because they observe multiple
+  slices. The env-var parsing lives in `internal/envconfig/`.
+- **wire cannot handle generic type arguments**, so the cache provider returns the
+  concrete `GraphCache[string, *Vertex]`. Re-check this before trying to introduce
+  generics in the provider graph.
+
+## Tests
+
+Follow the repo-wide 1:1 source↔test pairing (one `xxx_test.go` per `xxx.go`; sub-tests
+via `t.Run`, not `xxx_<concern>_test.go` siblings). The service/wire layers are
+historically under-tested — add at least a minimal table test alongside any non-trivial
+change.


### PR DESCRIPTION
## What

Reorganize the repository's AI instruction files to follow GitHub's best-practice precedence model, and remove content that will go stale.

### New files
- **`.github/copilot-instructions.md`** (~3.7k chars) — concise, always-on, repo-wide subset. Deliberately kept under the ~4,000-char window so GitHub's **PR code-review** bot (which reads this file but **not** `AGENTS.md`, and only the first ~4k chars) and **GitHub.com Chat** still get the highest-value, review-relevant rules.
- **`CONTRIBUTING.md`** — the release/CI/maintenance contract relocated out of `AGENTS.md` (triage, the quality gate, code-gen steps, toolchain-bump checklist, release tag order, doc-staleness sweep).
- **`admin/AGENTS.md`** and **`server/AGENTS.md`** — nearest-in-tree context for those subtrees.

### Slimmed
- **`AGENTS.md`** trimmed to architecture + per-task conventions + a short always-on workflow subset; the long maintenance checklist now lives in `CONTRIBUTING.md`.

### Stale content removed (from the instruction files)
- Go version pins → point at `go.mod`/CI as the single source of truth.
- The inaccurate hardcoded module count ("five/6 modules") → "the workspace modules".
- Version-pinned `buf`/CI-action/cosign details → generalized.

## Why
The three instruction surfaces have different read scopes. VS Code Chat / the cloud coding agent / Copilot CLI read all three (with `AGENTS.md` nearest-in-tree winning); PR code review and GitHub.com Chat read only `copilot-instructions.md`. The new `copilot-instructions.md` is a non-conflicting subset that also points to `AGENTS.md`/`CONTRIBUTING.md`.

## Notes
- Doc-only change — exempt from the issue-first policy per `AGENTS.md`.
- No code touched; `gofmt`/tests unaffected.