### PR TITLE
fix(agents): enable cloud-agent issue filing for the User agent

### DIFF
--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -45,6 +45,36 @@ Document the agent's:
 
 **Scope:** Lantern Admin (`admin/` directory) UI/UX only. Does not cover backend behavior, performance, or architectural decisions.
 
+## Cloud-agent issue filing
+
+The **User** agent files GitHub Issues as part of its review. When it runs on the
+**Copilot cloud agent** (github.com), the built-in `github` MCP server is **read-only**
+— its token is scoped to *read* the source repository, so it cannot create Issues.
+Without extra configuration the "file Issue" step fails (the agent falls back to
+`gh issue create`, which has no write token).
+
+To enable issue filing on the cloud agent, a repository or organization admin provides a
+writable token **once**:
+
+1. Create a **fine-grained personal access token** scoped to this repository with the
+   **Issues: Read and write** permission (no other scopes needed). See
+   [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
+2. Add it as an **Agents secret** named `COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN`
+   (repository **Settings → Secrets and variables → Copilot**, or at the org level). The
+   hosted GitHub MCP server automatically consumes this specially-named secret.
+
+The wiring lives in [`User.agent.md`](User.agent.md)'s `mcp-servers` frontmatter, which
+points the cloud agent at the hosted GitHub MCP server with only the `issues` toolset
+enabled (least privilege). That block is ignored in VS Code / IDE / CLI runs, which use
+their own GitHub MCP server configuration.
+
+> If the secret is absent, the agent can still complete a review — instruct it to
+> summarize findings in its pull-request body instead of filing Issues.
+
+**References**
+- [Configure MCP servers for your repository → Customizing the built-in GitHub MCP server](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/configure-mcp-servers#customizing-the-built-in-github-mcp-server)
+- [Custom agents configuration → MCP server configuration details](https://docs.github.com/en/copilot/reference/custom-agents-configuration#mcp-server-configuration-details)
+
 ## Adding a New Agent
 
 1. Create `<AgentName>.agent.md` in this directory

--- a/.github/agents/User.agent.md
+++ b/.github/agents/User.agent.md
@@ -3,7 +3,24 @@ name: User
 description: UX/UI design review specialist for Lantern Admin interface — inspects actual browser behavior using Playwright, identifies usability friction, design opportunities, and accessibility concerns. Files actionable Issues.
 argument-hint: "Admin UI component or page to review, specific workflow to test, or UX concern to investigate (browser testing enabled)"
 model: claude-opus-4.8
-tools: ['bash', 'view', 'edit', 'grep', 'glob', 'github-issue_write', 'github-list_issues']
+# Tool names are listed in BOTH naming conventions on purpose so the agent works in
+# every host (each host silently ignores names it does not recognize):
+#   - `github-*`         → Copilot CLI / IDE GitHub MCP server tool naming
+#   - `github-issues/*`  → Copilot cloud agent, served by the `mcp-servers` entry below
+tools: ['bash', 'view', 'edit', 'grep', 'glob', 'search', 'github-issue_write', 'github-list_issues', 'github-issues/issue_write', 'github-issues/list_issues']
+# Cloud-agent ONLY (ignored by VS Code / IDE custom agents): the built-in `github` MCP
+# server is READ-ONLY (its token can only read the source repo), so it cannot create
+# Issues. This declares a writable GitHub MCP server limited to the `issues` toolset,
+# authenticated by a fine-grained PAT supplied through the
+# `COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN` Agents secret (Issues: Read and write).
+# Setup steps: see .github/agents/README.md → "Cloud-agent issue filing".
+mcp-servers:
+  github-issues:
+    type: http
+    url: https://api.githubcopilot.com/mcp/
+    tools: ['issue_write', 'list_issues']
+    headers:
+      X-MCP-Toolsets: issues
 ---
 
 # User Agent — Lantern Admin UX/UI Review Specialist


### PR DESCRIPTION
Closes #578

## What

The `User` agent couldn't file Issues on the Copilot **cloud agent**: the built-in `github` MCP server is **read-only**, so no issue-write tool is exposed, and the hyphen-namespaced `github-*` tool names aren't recognized by the cloud agent (which uses `github/<tool>`). It then fell back to `gh issue create`, which has no write token.

## Changes

- **`.github/agents/User.agent.md`** — added an `mcp-servers:` block declaring a writable hosted GitHub MCP server limited to the `issues` toolset (least privilege), and listed both cloud-agent (`github-issues/issue_write`) and CLI/IDE (`github-issue_write`) tool names so the agent works in every host.
- **`.github/agents/README.md`** — new "Cloud-agent issue filing" section documenting the required setup.

## Required manual step (not in this PR)

A repo/org admin must add an **Agents secret** `COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN` — a fine-grained PAT with **Issues: Read and write** — under **Settings → Secrets and variables → Copilot**. The config also only takes effect once merged to the branch the cloud agent runs from.

## Notes

- Docs-/config-only; no Go or Admin SPA code touched. YAML frontmatter validated as parseable.