### PR TITLE
feat(sdk): make AddEdge idempotent via client-supplied ContribID

### DIFF
--- a/core/cache/graph/batch.go
+++ b/core/cache/graph/batch.go
@@ -17,6 +17,13 @@ type EdgeItem[S comparable] struct {
 	Head       S
 	Weight     float32
 	Expiration time.Time
+	// ContribID is an optional dedup key for additive AddEdges* writes.
+	// A non-zero id makes the contribution idempotent: re-applying an item
+	// with the same id leaves the stored weight unchanged (see
+	// AddEdgesWithExpirationContrib). The zero value disables dedup and keeps
+	// the legacy additive semantics. PutEdgesWithExpiration ignores this
+	// field — Put is already idempotent.
+	ContribID ContribID
 }
 
 // EdgeKey identifies a directed edge for batch deletion via DeleteEdges.
@@ -44,18 +51,48 @@ func (c *GraphCache[S, T]) PutVerticesWithExpiration(items []VertexItem[S, T]) {
 // single write lock, auto-creating endpoint vertices on demand (matching
 // the per-edge AddEdgeWithExpiration invariant). Concurrent readers see
 // either the pre-batch or the post-batch state.
+//
+// Each item's ContribID is honored: a non-zero id deduplicates the
+// contribution (see AddEdgesWithExpirationContrib). Leaving ContribID at its
+// zero value — the default — keeps the legacy non-idempotent additive path.
 func (c *GraphCache[S, T]) AddEdgesWithExpiration(items []EdgeItem[S]) {
+	c.AddEdgesWithExpirationContrib(items)
+}
+
+// AddEdgesWithExpirationContrib is the dedup-aware batch sibling of
+// AddEdgesWithExpiration. It applies the whole batch under a single write
+// lock and returns the number of items that were deduplicated — i.e. whose
+// non-zero ContribID matched a live contribution already stored on the
+// (tail, head) edge, so no weight was added. Items with a zero ContribID
+// always apply (legacy additive semantics) and never count as deduped.
+//
+// The dedup guarantee mirrors the per-edge AddEdgeWithExpirationContrib used
+// by the replication apply path (#182): replaying a batch with the same
+// ContribIDs leaves the stored weights unchanged. This is what lets a
+// client-supplied idempotency key make AddEdge(s) safe to retry (#588).
+func (c *GraphCache[S, T]) AddEdgesWithExpirationContrib(items []EdgeItem[S]) (deduped int) {
 	if len(items) == 0 {
-		return
+		return 0
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for _, it := range items {
 		c.ensureVertexLocked(it.Tail, it.Expiration)
 		c.ensureVertexLocked(it.Head, it.Expiration)
-		created, tailID, headID := c.edges.addWithExpiration(it.Tail, it.Head, it.Weight, it.Expiration)
-		c.onEdgeAddedLocked(created, tailID, headID, it.Head)
+		created, tailID, headID, applied := c.edges.addWithExpirationContrib(it.Tail, it.Head, it.Weight, it.Expiration, it.ContribID)
+		if applied {
+			c.onEdgeAddedLocked(created, tailID, headID, it.Head)
+			continue
+		}
+		deduped++
+		if created {
+			// Defensive: a dedup-skip cannot also create a fresh bucket
+			// (see AddEdgeWithExpirationContrib), but keep the side indexes
+			// consistent if that invariant ever changes.
+			c.onEdgeAddedLocked(created, tailID, headID, it.Head)
+		}
 	}
+	return deduped
 }
 
 // PutEdgesWithExpiration replaces every supplied edge atomically under a

--- a/core/cache/graph/batch_external_test.go
+++ b/core/cache/graph/batch_external_test.go
@@ -211,6 +211,109 @@ func TestBatchAPIs_ReturnCounts(t *testing.T) {
 	}
 }
 
+// TestAddEdgesWithExpirationContrib_Dedup verifies the #588 idempotency
+// contract: a non-zero ContribID makes an additive contribution apply at
+// most once (so a retried batch is an exact no-op), while a zero ContribID
+// preserves the legacy additive (sum-on-replay) behavior. The deduped count
+// reports exactly the items suppressed by a matching live ContribID.
+func TestAddEdgesWithExpirationContrib_Dedup(t *testing.T) {
+	exp := time.Now().Add(time.Minute)
+
+	t.Run("same id twice contributes once", func(t *testing.T) {
+		c := graph.NewGraphCache[string, int](time.Minute)
+		var id graph.ContribID
+		id[0], id[23] = 0xAB, 0x01
+
+		batch := []graph.EdgeItem[string]{
+			{Tail: "s", Head: "h", Weight: 2.5, Expiration: exp, ContribID: id},
+		}
+		if deduped := c.AddEdgesWithExpirationContrib(batch); deduped != 0 {
+			t.Fatalf("first apply: deduped = %d, want 0", deduped)
+		}
+		// Replay the identical batch: must be an exact no-op.
+		if deduped := c.AddEdgesWithExpirationContrib(batch); deduped != 1 {
+			t.Fatalf("replay: deduped = %d, want 1", deduped)
+		}
+		w, ok := c.GetWeight("s", "h")
+		if !ok {
+			t.Fatal("edge missing after contrib writes")
+		}
+		if w != 2.5 {
+			t.Fatalf("weight = %v, want 2.5 (contribution must apply exactly once)", w)
+		}
+	})
+
+	t.Run("zero id stays additive", func(t *testing.T) {
+		c := graph.NewGraphCache[string, int](time.Minute)
+		batch := []graph.EdgeItem[string]{
+			{Tail: "s", Head: "h", Weight: 2, Expiration: exp}, // ContribID zero
+		}
+		if deduped := c.AddEdgesWithExpirationContrib(batch); deduped != 0 {
+			t.Fatalf("first apply: deduped = %d, want 0", deduped)
+		}
+		if deduped := c.AddEdgesWithExpirationContrib(batch); deduped != 0 {
+			t.Fatalf("replay: deduped = %d, want 0 (zero id must not dedup)", deduped)
+		}
+		if w, _ := c.GetWeight("s", "h"); w != 4 {
+			t.Fatalf("weight = %v, want 4 (zero id must sum on replay)", w)
+		}
+	})
+
+	t.Run("distinct ids both contribute", func(t *testing.T) {
+		c := graph.NewGraphCache[string, int](time.Minute)
+		var id1, id2 graph.ContribID
+		id1[0], id1[23] = 0x01, 0x01
+		id2[0], id2[23] = 0x01, 0x02
+		c.AddEdgesWithExpirationContrib([]graph.EdgeItem[string]{
+			{Tail: "s", Head: "h", Weight: 1, Expiration: exp, ContribID: id1},
+		})
+		deduped := c.AddEdgesWithExpirationContrib([]graph.EdgeItem[string]{
+			{Tail: "s", Head: "h", Weight: 1, Expiration: exp, ContribID: id2},
+		})
+		if deduped != 0 {
+			t.Fatalf("distinct id: deduped = %d, want 0", deduped)
+		}
+		if w, _ := c.GetWeight("s", "h"); w != 2 {
+			t.Fatalf("weight = %v, want 2 (distinct ids both contribute)", w)
+		}
+	})
+
+	t.Run("mixed batch counts only deduped items", func(t *testing.T) {
+		c := graph.NewGraphCache[string, int](time.Minute)
+		var id graph.ContribID
+		id[0] = 0x7F
+		c.AddEdgesWithExpirationContrib([]graph.EdgeItem[string]{
+			{Tail: "s", Head: "a", Weight: 1, Expiration: exp, ContribID: id},
+		})
+		// Mix the already-seen id (deduped) with a fresh zero-id edge (applies).
+		deduped := c.AddEdgesWithExpirationContrib([]graph.EdgeItem[string]{
+			{Tail: "s", Head: "a", Weight: 1, Expiration: exp, ContribID: id},
+			{Tail: "s", Head: "b", Weight: 1, Expiration: exp},
+		})
+		if deduped != 1 {
+			t.Fatalf("mixed batch: deduped = %d, want 1", deduped)
+		}
+		if w, _ := c.GetWeight("s", "a"); w != 1 {
+			t.Fatalf("weight s->a = %v, want 1 (deduped)", w)
+		}
+		if w, ok := c.GetWeight("s", "b"); !ok || w != 1 {
+			t.Fatalf("weight s->b = %v ok=%v, want 1 true (applied)", w, ok)
+		}
+	})
+
+	t.Run("facade preserves additive semantics", func(t *testing.T) {
+		c := graph.NewGraphCache[string, int](time.Minute)
+		batch := []graph.EdgeItem[string]{
+			{Tail: "s", Head: "h", Weight: 3, Expiration: exp},
+		}
+		c.AddEdgesWithExpiration(batch)
+		c.AddEdgesWithExpiration(batch)
+		if w, _ := c.GetWeight("s", "h"); w != 6 {
+			t.Fatalf("facade weight = %v, want 6 (AddEdgesWithExpiration stays additive)", w)
+		}
+	})
+}
+
 // itoa avoids pulling in strconv just to label test keys.
 func itoa(i int) string {
 	if i == 0 {

--- a/pb/graph/v1/graph.pb.go
+++ b/pb/graph/v1/graph.pb.go
@@ -2225,10 +2225,20 @@ func (x *DeleteEdgesResponse) GetDeleted() int32 {
 
 // AddEdgeRequest accumulates weight onto a single (tail, head) pair: repeated
 // calls with the same endpoints sum their weights. This is the singular
-// convenience wrapper over AddEdges and shares its non-idempotent semantics.
+// convenience wrapper over AddEdges and shares its semantics.
 type AddEdgeRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Edge          *Edge                  `protobuf:"bytes,1,opt,name=edge,proto3" json:"edge,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Edge  *Edge                  `protobuf:"bytes,1,opt,name=edge,proto3" json:"edge,omitempty"`
+	// contrib_id is an optional 24-byte idempotency key for the contribution.
+	// When set (non-empty and not all-zero), the server records the weight at
+	// most once per distinct id: re-sending the same request (e.g. a
+	// transport-level retry) is an exact no-op instead of double-counting the
+	// additive weight. An empty value preserves the legacy non-idempotent
+	// additive behavior. The id is opaque to the server; the Go SDK derives it
+	// from a per-client random nonce plus a monotonic call sequence when
+	// idempotent adds are enabled. Forwarded into contrib_ids[0] of the
+	// one-element AddEdges batch this wraps.
+	ContribId     []byte `protobuf:"bytes,2,opt,name=contrib_id,json=contribId,proto3" json:"contrib_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2270,6 +2280,13 @@ func (x *AddEdgeRequest) GetEdge() *Edge {
 	return nil
 }
 
+func (x *AddEdgeRequest) GetContribId() []byte {
+	if x != nil {
+		return x.ContribId
+	}
+	return nil
+}
+
 type AddEdgeResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -2307,11 +2324,19 @@ func (*AddEdgeResponse) Descriptor() ([]byte, []int) {
 }
 
 // AddEdgesRequest accumulates weight onto each (tail, head) pair: repeated
-// calls with the same endpoints sum their weights. This operation is
-// non-idempotent.
+// calls with the same endpoints sum their weights. Additive writes are
+// non-idempotent unless an index-aligned contrib_ids entry is supplied.
 type AddEdgesRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Edges         []*Edge                `protobuf:"bytes,1,rep,name=edges,proto3" json:"edges,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Edges []*Edge                `protobuf:"bytes,1,rep,name=edges,proto3" json:"edges,omitempty"`
+	// contrib_ids is an optional index-aligned list of 24-byte idempotency
+	// keys, one per entry in edges. When contrib_ids[i] is set (non-empty and
+	// not all-zero) the server records edges[i] at most once per distinct id,
+	// making a retried batch safe to replay without double-counting weight. A
+	// shorter list, a missing entry, or an empty/zero value leaves the
+	// corresponding edge on the legacy non-idempotent additive path. Each id is
+	// opaque to the server.
+	ContribIds    [][]byte `protobuf:"bytes,2,rep,name=contrib_ids,json=contribIds,proto3" json:"contrib_ids,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2349,6 +2374,13 @@ func (*AddEdgesRequest) Descriptor() ([]byte, []int) {
 func (x *AddEdgesRequest) GetEdges() []*Edge {
 	if x != nil {
 		return x.Edges
+	}
+	return nil
+}
+
+func (x *AddEdgesRequest) GetContribIds() [][]byte {
+	if x != nil {
+		return x.ContribIds
 	}
 	return nil
 }
@@ -3106,12 +3138,16 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\x12DeleteEdgesRequest\x12'\n" +
 	"\x05edges\x18\x01 \x03(\v2\x11.graph.v1.EdgeKeyR\x05edges\"/\n" +
 	"\x13DeleteEdgesResponse\x12\x18\n" +
-	"\adeleted\x18\x01 \x01(\x05R\adeleted\"4\n" +
+	"\adeleted\x18\x01 \x01(\x05R\adeleted\"S\n" +
 	"\x0eAddEdgeRequest\x12\"\n" +
-	"\x04edge\x18\x01 \x01(\v2\x0e.graph.v1.EdgeR\x04edge\"\x11\n" +
-	"\x0fAddEdgeResponse\"7\n" +
+	"\x04edge\x18\x01 \x01(\v2\x0e.graph.v1.EdgeR\x04edge\x12\x1d\n" +
+	"\n" +
+	"contrib_id\x18\x02 \x01(\fR\tcontribId\"\x11\n" +
+	"\x0fAddEdgeResponse\"X\n" +
 	"\x0fAddEdgesRequest\x12$\n" +
-	"\x05edges\x18\x01 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\",\n" +
+	"\x05edges\x18\x01 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\x12\x1f\n" +
+	"\vcontrib_ids\x18\x02 \x03(\fR\n" +
+	"contribIds\",\n" +
 	"\x10AddEdgesResponse\x12\x18\n" +
 	"\awritten\x18\x01 \x01(\x05R\awritten\"4\n" +
 	"\x0ePutEdgeRequest\x12\"\n" +

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -308,18 +308,36 @@ message DeleteEdgesResponse {
 
 // AddEdgeRequest accumulates weight onto a single (tail, head) pair: repeated
 // calls with the same endpoints sum their weights. This is the singular
-// convenience wrapper over AddEdges and shares its non-idempotent semantics.
+// convenience wrapper over AddEdges and shares its semantics.
 message AddEdgeRequest {
   Edge edge = 1;
+  // contrib_id is an optional 24-byte idempotency key for the contribution.
+  // When set (non-empty and not all-zero), the server records the weight at
+  // most once per distinct id: re-sending the same request (e.g. a
+  // transport-level retry) is an exact no-op instead of double-counting the
+  // additive weight. An empty value preserves the legacy non-idempotent
+  // additive behavior. The id is opaque to the server; the Go SDK derives it
+  // from a per-client random nonce plus a monotonic call sequence when
+  // idempotent adds are enabled. Forwarded into contrib_ids[0] of the
+  // one-element AddEdges batch this wraps.
+  bytes contrib_id = 2;
 }
 
 message AddEdgeResponse {}
 
 // AddEdgesRequest accumulates weight onto each (tail, head) pair: repeated
-// calls with the same endpoints sum their weights. This operation is
-// non-idempotent.
+// calls with the same endpoints sum their weights. Additive writes are
+// non-idempotent unless an index-aligned contrib_ids entry is supplied.
 message AddEdgesRequest {
   repeated Edge edges = 1;
+  // contrib_ids is an optional index-aligned list of 24-byte idempotency
+  // keys, one per entry in edges. When contrib_ids[i] is set (non-empty and
+  // not all-zero) the server records edges[i] at most once per distinct id,
+  // making a retried batch safe to replay without double-counting weight. A
+  // shorter list, a missing entry, or an empty/zero value leaves the
+  // corresponding edge on the legacy non-idempotent additive path. Each id is
+  // opaque to the server.
+  repeated bytes contrib_ids = 2;
 }
 
 message AddEdgesResponse {

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -9,10 +9,13 @@ package client
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"connectrpc.com/connect"
@@ -116,6 +119,13 @@ type Lantern struct {
 	opts       options
 	httpClient *http.Client
 	baseURL    string
+
+	// nonce + callSeq generate per-call ContribID idempotency keys when
+	// WithIdempotentAdds is set (#588). nonce is a per-client 128-bit random
+	// prefix that namespaces this client's keys; callSeq is bumped once per
+	// Add* request build. See nextContribIDs.
+	nonce   [16]byte
+	callSeq atomic.Uint64
 }
 
 // NewLantern dials the Lantern server at baseURL and returns a
@@ -143,12 +153,20 @@ func NewLantern(baseURL string, opts ...Option) (*Lantern, error) {
 		o.httpClient = defaultH2CClient()
 	}
 
-	return &Lantern{
+	l := &Lantern{
 		client:     graphv1connect.NewLanternServiceClient(o.httpClient, baseURL, o.clientOptions...),
 		opts:       o,
 		httpClient: o.httpClient,
 		baseURL:    baseURL,
-	}, nil
+	}
+	// A per-client random nonce namespaces this client's ContribIDs so two
+	// processes (or two NewLantern calls) never collide their idempotency
+	// keys. Only consulted when WithIdempotentAdds is set, but seeded
+	// unconditionally so the field is always valid.
+	if _, err := rand.Read(l.nonce[:]); err != nil {
+		return nil, fmt.Errorf("client: NewLantern could not seed idempotency nonce: %w", err)
+	}
+	return l, nil
 }
 
 // Close releases any idle HTTP/2 connections the SDK is holding. The
@@ -363,6 +381,11 @@ func (l *Lantern) GetEdge(ctx context.Context, tail string, head string) (*Edge,
 // AddEdge accumulates weight onto the (tail, head) pair: repeated calls with
 // the same endpoints sum their weights. A non-positive ttl stores the edge
 // permanently (no decay); see expirationFromTTL.
+//
+// When the client was built WithIdempotentAdds, a transport-level retry of a
+// single AddEdge/AddEdgeAt call records the weight once (the SDK attaches a
+// stable per-call idempotency key); calling AddEdge twice yourself still
+// sums, as documented above.
 func (l *Lantern) AddEdge(ctx context.Context, tail string, head string, weight float32, ttl time.Duration) error {
 	return l.AddEdgeAt(ctx, tail, head, weight, expirationFromTTL(ttl))
 }
@@ -372,7 +395,8 @@ func (l *Lantern) AddEdgeAt(ctx context.Context, tail string, head string, weigh
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
 	_, err := unary(ctx, &pb.AddEdgesRequest{
-		Edges: []*pb.Edge{{Tail: tail, Head: head, Weight: weight, Expiration: timestamppb.New(expiration)}},
+		Edges:      []*pb.Edge{{Tail: tail, Head: head, Weight: weight, Expiration: timestamppb.New(expiration)}},
+		ContribIds: l.nextContribIDs(1),
 	}, l.client.AddEdges)
 	return err
 }
@@ -384,15 +408,44 @@ func (l *Lantern) AddEdgeAt(ctx context.Context, tail string, head string, weigh
 // edges already committed, so callers can resume with inputs[err.Written:].
 // Note that because AddEdge is additive (not idempotent), naively retrying
 // from index 0 will double-count weight for the already-committed prefix.
+//
+// With WithIdempotentAdds the SDK stamps each contribution with a per-call
+// idempotency key, so a transport-level retry of a chunk records its weight
+// exactly once. That key is regenerated on each AddEdges invocation, so it
+// does not make an application-level resume/retry from index 0 idempotent —
+// use err.Written to resume, as above.
 func (l *Lantern) AddEdges(ctx context.Context, inputs []EdgeInput) error {
 	if len(inputs) == 0 {
 		return nil
 	}
 	_, err := runBatchWrite(ctx, l, edgesFrom(inputs), func(ctx context.Context, chunk []*pb.Edge) (int32, error) {
-		_, err := unary(ctx, &pb.AddEdgesRequest{Edges: chunk}, l.client.AddEdges)
+		_, err := unary(ctx, &pb.AddEdgesRequest{Edges: chunk, ContribIds: l.nextContribIDs(len(chunk))}, l.client.AddEdges)
 		return 0, err
 	})
 	return err
+}
+
+// nextContribIDs returns n per-edge idempotency keys for one Add* request,
+// or nil when WithIdempotentAdds is not set (nil → the wire carries no
+// contrib_ids, i.e. the legacy additive path). It bumps callSeq exactly once
+// per call; key i packs the client nonce into bytes [0:16] and the
+// big-endian (seq<<16)|i into bytes [16:24], matching the server's ContribID
+// layout. Because the keys are baked into the request when it is built, a
+// transport retry that re-sends the same request re-sends the same keys, so
+// the contribution is recorded exactly once.
+func (l *Lantern) nextContribIDs(n int) [][]byte {
+	if !l.opts.idempotentAdds || n <= 0 {
+		return nil
+	}
+	seq := l.callSeq.Add(1)
+	ids := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		id := make([]byte, 24)
+		copy(id[:16], l.nonce[:])
+		binary.BigEndian.PutUint64(id[16:], (seq<<16)|uint64(uint16(i)))
+		ids[i] = id
+	}
+	return ids
 }
 
 // PutEdge overwrites the (tail, head) pair. A non-positive ttl stores the

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -1,8 +1,16 @@
 package client
 
 import (
+	"bytes"
+	"context"
+	"encoding/binary"
 	"testing"
 	"time"
+
+	"connectrpc.com/connect"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
 )
 
 // TestNewLantern_BaseURLValidation covers the constructor's argument-
@@ -59,6 +67,182 @@ func TestExpirationFromTTL(t *testing.T) {
 		}
 		if got.Before(before) || got.After(after) {
 			t.Fatalf("expirationFromTTL(%v) = %v, want within [%v, %v]", ttl, got, before, after)
+		}
+	})
+}
+
+// mustLantern builds a *Lantern against a never-dialed local URL. The
+// constructor performs no I/O, so this is safe for white-box tests that only
+// exercise request-construction logic.
+func mustLantern(t *testing.T, opts ...Option) *Lantern {
+	t.Helper()
+	l, err := NewLantern("http://localhost:6380", opts...)
+	if err != nil {
+		t.Fatalf("NewLantern: %v", err)
+	}
+	return l
+}
+
+// decodeContribID splits a 24-byte ContribID into its packed (seq, idx)
+// suffix, mirroring nextContribIDs' big-endian (seq<<16)|idx layout.
+func decodeContribID(t *testing.T, id []byte) (seq uint64, idx uint16) {
+	t.Helper()
+	if len(id) != 24 {
+		t.Fatalf("contrib_id must be 24 bytes, got %d", len(id))
+	}
+	packed := binary.BigEndian.Uint64(id[16:])
+	return packed >> 16, uint16(packed & 0xffff)
+}
+
+// TestNextContribIDs pins the per-call idempotency-key generator (#588): it
+// is nil unless WithIdempotentAdds opted in, packs the client nonce in the
+// high 16 bytes and an index-aligned (seq<<16)|idx in the low 8, shares one
+// seq across all keys of a single call, and advances the seq on the next
+// call while keeping the nonce stable.
+func TestNextContribIDs(t *testing.T) {
+	t.Run("nil when idempotency disabled", func(t *testing.T) {
+		l := mustLantern(t)
+		if ids := l.nextContribIDs(3); ids != nil {
+			t.Fatalf("disabled client must return nil, got %d ids", len(ids))
+		}
+	})
+	t.Run("nil for non-positive n even when enabled", func(t *testing.T) {
+		l := mustLantern(t, WithIdempotentAdds())
+		if ids := l.nextContribIDs(0); ids != nil {
+			t.Fatalf("n=0 must return nil, got %d", len(ids))
+		}
+		if ids := l.nextContribIDs(-1); ids != nil {
+			t.Fatalf("n<0 must return nil, got %d", len(ids))
+		}
+	})
+	t.Run("layout: nonce prefix + index-aligned shared seq", func(t *testing.T) {
+		l := mustLantern(t, WithIdempotentAdds())
+		ids := l.nextContribIDs(3)
+		if len(ids) != 3 {
+			t.Fatalf("want 3 ids, got %d", len(ids))
+		}
+		var seq0 uint64
+		for i, id := range ids {
+			if !bytes.Equal(id[:16], l.nonce[:]) {
+				t.Fatalf("id %d prefix must equal the client nonce", i)
+			}
+			seq, idx := decodeContribID(t, id)
+			if int(idx) != i {
+				t.Fatalf("id %d index want %d got %d", i, i, idx)
+			}
+			if i == 0 {
+				seq0 = seq
+			} else if seq != seq0 {
+				t.Fatalf("all ids in one call share a seq; id %d seq %d != %d", i, seq, seq0)
+			}
+		}
+	})
+	t.Run("callSeq advances per call; nonce stable", func(t *testing.T) {
+		l := mustLantern(t, WithIdempotentAdds())
+		first := l.nextContribIDs(1)[0]
+		second := l.nextContribIDs(1)[0]
+		seqA, _ := decodeContribID(t, first)
+		seqB, _ := decodeContribID(t, second)
+		if seqB <= seqA {
+			t.Fatalf("callSeq must increase per call: %d then %d", seqA, seqB)
+		}
+		if !bytes.Equal(first[:16], second[:16]) {
+			t.Fatalf("nonce prefix must be stable across calls")
+		}
+	})
+}
+
+// captureAddEdges is a fake LanternServiceClient that records every
+// AddEdgesRequest it receives. It embeds the interface (left nil) so it
+// satisfies the full surface while only overriding AddEdges — the single
+// method the Add* helpers route through.
+type captureAddEdges struct {
+	graphv1connect.LanternServiceClient
+	reqs []*pb.AddEdgesRequest
+}
+
+func (c *captureAddEdges) AddEdges(_ context.Context, req *connect.Request[pb.AddEdgesRequest]) (*connect.Response[pb.AddEdgesResponse], error) {
+	c.reqs = append(c.reqs, req.Msg)
+	return connect.NewResponse(&pb.AddEdgesResponse{}), nil
+}
+
+// TestAddContribIDWiring verifies the SDK attaches contrib_ids only when
+// WithIdempotentAdds is set, that AddEdge stamps exactly one key, and that
+// AddEdges stamps index-aligned keys per chunk with a fresh seq per chunk.
+func TestAddContribIDWiring(t *testing.T) {
+	newClient := func(t *testing.T, opts ...Option) (*Lantern, *captureAddEdges) {
+		t.Helper()
+		l := mustLantern(t, opts...)
+		capt := &captureAddEdges{}
+		l.client = capt
+		return l, capt
+	}
+
+	t.Run("default sends no contrib_ids (AddEdge)", func(t *testing.T) {
+		l, capt := newClient(t)
+		if err := l.AddEdge(context.Background(), "a", "b", 1, 0); err != nil {
+			t.Fatalf("AddEdge: %v", err)
+		}
+		if len(capt.reqs) != 1 {
+			t.Fatalf("want 1 request, got %d", len(capt.reqs))
+		}
+		if got := capt.reqs[0].GetContribIds(); got != nil {
+			t.Fatalf("default must send no contrib_ids, got %d", len(got))
+		}
+	})
+
+	t.Run("WithIdempotentAdds stamps one key (AddEdge)", func(t *testing.T) {
+		l, capt := newClient(t, WithIdempotentAdds())
+		if err := l.AddEdge(context.Background(), "a", "b", 1, 0); err != nil {
+			t.Fatalf("AddEdge: %v", err)
+		}
+		ids := capt.reqs[0].GetContribIds()
+		if len(ids) != 1 {
+			t.Fatalf("want 1 contrib_id, got %d", len(ids))
+		}
+		if !bytes.Equal(ids[0][:16], l.nonce[:]) {
+			t.Fatalf("contrib_id prefix must be the client nonce")
+		}
+	})
+
+	t.Run("WithIdempotentAdds stamps index-aligned keys per chunk (AddEdges)", func(t *testing.T) {
+		l, capt := newClient(t, WithIdempotentAdds(), WithBatchChunkSize(2))
+		inputs := []EdgeInput{
+			{Tail: "a", Head: "b", Weight: 1},
+			{Tail: "c", Head: "d", Weight: 1},
+			{Tail: "e", Head: "f", Weight: 1},
+		}
+		if err := l.AddEdges(context.Background(), inputs); err != nil {
+			t.Fatalf("AddEdges: %v", err)
+		}
+		if len(capt.reqs) != 2 {
+			t.Fatalf("chunk size 2 over 3 inputs want 2 requests, got %d", len(capt.reqs))
+		}
+		c0, c1 := capt.reqs[0].GetContribIds(), capt.reqs[1].GetContribIds()
+		if len(c0) != 2 || len(c1) != 1 {
+			t.Fatalf("chunk key counts want 2,1 got %d,%d", len(c0), len(c1))
+		}
+		seq0, idx00 := decodeContribID(t, c0[0])
+		_, idx01 := decodeContribID(t, c0[1])
+		if idx00 != 0 || idx01 != 1 {
+			t.Fatalf("chunk 0 indices want 0,1 got %d,%d", idx00, idx01)
+		}
+		seq1, idx10 := decodeContribID(t, c1[0])
+		if idx10 != 0 {
+			t.Fatalf("chunk 1 index want 0 got %d", idx10)
+		}
+		if seq1 == seq0 {
+			t.Fatalf("each chunk must use a distinct seq; got %d twice", seq0)
+		}
+	})
+
+	t.Run("default sends no contrib_ids (AddEdges)", func(t *testing.T) {
+		l, capt := newClient(t)
+		if err := l.AddEdges(context.Background(), []EdgeInput{{Tail: "a", Head: "b", Weight: 1}}); err != nil {
+			t.Fatalf("AddEdges: %v", err)
+		}
+		if got := capt.reqs[0].GetContribIds(); got != nil {
+			t.Fatalf("default AddEdges must send no contrib_ids, got %d", len(got))
 		}
 	})
 }

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -21,6 +21,7 @@ type options struct {
 	clientOptions  []connect.ClientOption
 	defaultTimeout time.Duration
 	batchChunkSize int
+	idempotentAdds bool
 }
 
 // Option configures a Lantern client built via NewLantern.
@@ -68,4 +69,20 @@ func WithBatchChunkSize(n int) Option {
 			o.batchChunkSize = n
 		}
 	}
+}
+
+// WithIdempotentAdds makes AddEdge / AddEdgeAt / AddEdges attach a
+// client-generated, per-call idempotency key (ContribID) to every edge
+// contribution (#588). The server records each ContribID at most once, so a
+// transport-level retry that re-sends the identical request — e.g. a Connect
+// retry interceptor reacting to a transient Unavailable — adds the edge
+// weight exactly once instead of double-counting.
+//
+// The guarantee is scoped to retries of a single logical call: the SDK bakes
+// the keys into the request when it is built, and a transport retry re-sends
+// those same bytes. Calling AddEdge twice yourself is still two distinct
+// contributions (their keys differ), preserving the additive semantics of
+// the API. Off by default; opt in per client.
+func WithIdempotentAdds() Option {
+	return func(o *options) { o.idempotentAdds = true }
 }

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -110,6 +110,13 @@ type DomainMetrics struct {
 	getEdgeHits     prometheus.Counter
 	getEdgeMisses   prometheus.Counter
 
+	// Idempotent-AddEdge dedup counter (#588). Bumped by the service
+	// layer's AddEdges implementation with the number of additive edge
+	// contributions suppressed because an incoming client-supplied
+	// ContribID matched a still-live prior contribution (a retried
+	// idempotent Add). Plain counter: scrapes as 0 from process start.
+	edgeContribDeduped prometheus.Counter
+
 	sampleInterval time.Duration
 	sample         Sampler
 	mlogSample     MutationLogSampler
@@ -325,6 +332,10 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 			Name: "lantern_get_edge_misses_total",
 			Help: "Total GetEdges (tail,head) lookups that found no live edge (absent or already expired at read time). See lantern_get_edge_hits_total for the hit side.",
 		}),
+		edgeContribDeduped: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "lantern_edge_contrib_deduped_total",
+			Help: "Total additive edge contributions suppressed by client-supplied ContribID dedup (#588). A retried idempotent AddEdge/AddEdges re-sending the same ContribID bumps this instead of double-counting edge weight.",
+		}),
 		peerConnected: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "lantern_peer_connected",
 			Help: "1 when the local replication pump currently holds an open Subscribe (or Subscribe+Snapshot) session to the named peer; 0 otherwise. Updated on every pump connect/disconnect lifecycle event.",
@@ -391,6 +402,7 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 		m.illuminateVisitedVertices, m.illuminateVisitedEdges, m.illuminateDuration,
 		m.scanResults, m.scanDuration, m.batchSize,
 		m.getVertexHits, m.getVertexMisses, m.getEdgeHits, m.getEdgeMisses,
+		m.edgeContribDeduped,
 		m.peerConnected, m.replicationApplyTotal, m.snapshotReplayedTotal,
 		m.snapshotVertices, m.snapshotEdges, m.snapshotDuration,
 		m.mutationLogFillRatio, m.mutationLogEvicted, m.originStatesCount,
@@ -770,6 +782,16 @@ func (m *DomainMetrics) OnGetEdges(hits, misses int) {
 	}
 	if misses > 0 {
 		m.getEdgeMisses.Add(float64(misses))
+	}
+}
+
+// OnEdgeContribDeduped records that n additive edge contributions were
+// suppressed by client-supplied ContribID dedup during one AddEdges RPC
+// (#588). Called once per plural AddEdges; the singular AddEdge forwards
+// through it. Zero is skipped so a fully-applied batch touches nothing.
+func (m *DomainMetrics) OnEdgeContribDeduped(n int) {
+	if n > 0 {
+		m.edgeContribDeduped.Add(float64(n))
 	}
 }
 

--- a/server/service/apply.go
+++ b/server/service/apply.go
@@ -158,7 +158,13 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 		if e == nil {
 			return nil
 		}
-		cID := contribIDFor(origin, seq, 0)
+		// Prefer a client-supplied ContribID carried on the wire (#588) so a
+		// retried idempotent Add dedups identically on every replica; fall
+		// back to the synthesized per-entry id for legacy writes.
+		cID := contribIDFromBytes(op.AddEdge.GetContribId())
+		if cID.IsZero() {
+			cID = contribIDFor(origin, seq, 0)
+		}
 		if useTomb {
 			applied := s.cache.AddEdgeWithExpirationContribHLC(e.GetTail(), e.GetHead(), e.GetWeight(),
 				e.GetExpiration().AsTime(), cID, ts)
@@ -173,11 +179,21 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 
 	case *pb.MutationOp_AddEdges:
 		edges := op.AddEdges.GetEdges()
+		contribIDs := op.AddEdges.GetContribIds()
 		for i, e := range edges {
 			if e == nil {
 				continue
 			}
-			cID := contribIDFor(origin, seq, uint16(i))
+			// Prefer the index-aligned client ContribID (#588); fall back to
+			// the synthesized (origin, seq, idx) id when the wire slot is
+			// absent or empty so legacy mutations keep their replay-dedup id.
+			var cID graph.ContribID
+			if i < len(contribIDs) {
+				cID = contribIDFromBytes(contribIDs[i])
+			}
+			if cID.IsZero() {
+				cID = contribIDFor(origin, seq, uint16(i))
+			}
 			if useTomb {
 				applied := s.cache.AddEdgeWithExpirationContribHLC(e.GetTail(), e.GetHead(), e.GetWeight(),
 					e.GetExpiration().AsTime(), cID, ts)
@@ -320,6 +336,19 @@ func contribIDBytes(c graph.ContribID) []byte {
 		return nil
 	}
 	return append([]byte(nil), c[:]...)
+}
+
+// contribIDFromBytes decodes a wire-encoded ContribID. Only the canonical
+// 24-byte length is accepted; a shorter, longer, or empty slice yields the
+// zero ContribID (the "no identity" sentinel), letting callers fall back to
+// a synthesized id and skip dedup. The inverse of contribIDBytes.
+func contribIDFromBytes(b []byte) graph.ContribID {
+	var c graph.ContribID
+	if len(b) != len(c) {
+		return c
+	}
+	copy(c[:], b)
+	return c
 }
 
 // contribIDFor builds the dedup identifier for an additive contribution.

--- a/server/service/apply_test.go
+++ b/server/service/apply_test.go
@@ -414,6 +414,64 @@ func TestApplyMutation_Idempotence(t *testing.T) {
 	}
 }
 
+// TestApplyMutation_WireContribIDDedupsAcrossSeq covers the #588 cross-replica
+// path: a client-supplied ContribID carried on the wire dedups a retried
+// additive contribution even when it arrives as two distinct mutation-log
+// entries (different Seq). Without the wire id the synthesized
+// (origin, seq, idx) id differs per entry, so legacy additive contributions
+// correctly sum.
+func TestApplyMutation_WireContribIDDedupsAcrossSeq(t *testing.T) {
+	origin := bytes16("origin-A")
+	exp := timestamppb.New(time.Now().Add(time.Hour))
+
+	var cid graph.ContribID
+	cid[0], cid[23] = 0xAB, 0x07
+
+	mkAddEdges := func(seq uint64, contribIDs [][]byte) *pb.Mutation {
+		return &pb.Mutation{
+			Seq:    seq,
+			Hlc:    newHLC(int64(seq), origin),
+			Origin: origin[:],
+			Op: &pb.MutationOp{Op: &pb.MutationOp_AddEdges{
+				AddEdges: &pb.AddEdgesRequest{
+					Edges:      []*pb.Edge{{Tail: "a", Head: "b", Weight: 2, Expiration: exp}},
+					ContribIds: contribIDs,
+				},
+			}},
+		}
+	}
+
+	t.Run("same wire ContribID dedups across distinct Seq", func(t *testing.T) {
+		cache := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
+		svc := NewLanternService(cache)
+		ctx := context.Background()
+		if err := svc.ApplyMutation(ctx, mkAddEdges(1, [][]byte{cid[:]})); err != nil {
+			t.Fatalf("first apply: %v", err)
+		}
+		if err := svc.ApplyMutation(ctx, mkAddEdges(2, [][]byte{cid[:]})); err != nil {
+			t.Fatalf("second apply: %v", err)
+		}
+		if w, ok := cache.GetWeight("a", "b"); !ok || w != 2 {
+			t.Fatalf("weight = %v ok=%v, want 2 true (wire ContribID must dedup the retry)", w, ok)
+		}
+	})
+
+	t.Run("legacy AddEdges without wire ContribID sums across Seq", func(t *testing.T) {
+		cache := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
+		svc := NewLanternService(cache)
+		ctx := context.Background()
+		if err := svc.ApplyMutation(ctx, mkAddEdges(1, nil)); err != nil {
+			t.Fatalf("first apply: %v", err)
+		}
+		if err := svc.ApplyMutation(ctx, mkAddEdges(2, nil)); err != nil {
+			t.Fatalf("second apply: %v", err)
+		}
+		if w, ok := cache.GetWeight("a", "b"); !ok || w != 4 {
+			t.Fatalf("weight = %v ok=%v, want 4 true (distinct synthesized ids must sum)", w, ok)
+		}
+	})
+}
+
 // ---------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------

--- a/server/service/backend.go
+++ b/server/service/backend.go
@@ -26,6 +26,12 @@ type Backend interface {
 	// edge reads/writes
 	GetEdgeDetail(tail, head string) (float32, time.Time, bool)
 	AddEdgesWithExpiration(items []graph.EdgeItem[string])
+	// AddEdgesWithExpirationContrib is the dedup-aware batch sibling of
+	// AddEdgesWithExpiration: a per-item non-zero ContribID makes that
+	// contribution idempotent (a retried batch is an exact no-op). Returns
+	// the count of items suppressed by a matching live ContribID. Items
+	// with a zero ContribID keep legacy additive semantics.
+	AddEdgesWithExpirationContrib(items []graph.EdgeItem[string]) int
 	PutEdgesWithExpiration(items []graph.EdgeItem[string])
 	DeleteEdges(keys []graph.EdgeKey[string]) int
 

--- a/server/service/fake_backend_test.go
+++ b/server/service/fake_backend_test.go
@@ -30,6 +30,14 @@ type fakeBackend struct {
 	addEdgesCalls    int
 	putEdgesCalls    int
 	deleteEdges      int
+
+	// #588 idempotent-AddEdge wiring capture. The canonical AddEdges path
+	// now calls AddEdgesWithExpirationContrib; tests assert contrib_ids are
+	// mapped index-aligned onto EdgeItem.ContribID and that the returned
+	// dedup count is forwarded to HotPathMetrics.OnEdgeContribDeduped.
+	addEdgesContribCalls int
+	lastAddEdgesItems    []graph.EdgeItem[string]
+	dedupReturn          int
 }
 
 func newFakeBackend() *fakeBackend {
@@ -80,6 +88,24 @@ func (f *fakeBackend) AddEdgesWithExpiration(items []graph.EdgeItem[string]) {
 		}
 		f.edges[it.Tail][it.Head] += it.Weight
 	}
+}
+
+// AddEdgesWithExpirationContrib is the path the production AddEdges handler
+// now drives (#588). The fake applies weight additively (mirroring the
+// zero-ContribID legacy path), captures the items so tests can assert the
+// contrib_id mapping, and returns the configurable dedupReturn so the
+// OnEdgeContribDeduped metric wiring is observable. Real dedup convergence
+// is covered by the core tests and tests/integration.
+func (f *fakeBackend) AddEdgesWithExpirationContrib(items []graph.EdgeItem[string]) int {
+	f.addEdgesContribCalls++
+	f.lastAddEdgesItems = items
+	for _, it := range items {
+		if f.edges[it.Tail] == nil {
+			f.edges[it.Tail] = map[string]float32{}
+		}
+		f.edges[it.Tail][it.Head] += it.Weight
+	}
+	return f.dedupReturn
 }
 
 func (f *fakeBackend) PutEdgesWithExpiration(items []graph.EdgeItem[string]) {

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -81,6 +81,7 @@ type HotPathMetrics interface {
 	OnBatch(op string, size int)
 	OnGetVertices(hits, misses int)
 	OnGetEdges(hits, misses int)
+	OnEdgeContribDeduped(n int)
 }
 
 type noopHotPathMetrics struct{}
@@ -91,6 +92,7 @@ func (noopHotPathMetrics) OnScan(string, int, time.Duration) {}
 func (noopHotPathMetrics) OnBatch(string, int)               {}
 func (noopHotPathMetrics) OnGetVertices(int, int)            {}
 func (noopHotPathMetrics) OnGetEdges(int, int)               {}
+func (noopHotPathMetrics) OnEdgeContribDeduped(int)          {}
 
 // ScanLimits caps the per-call pagination knobs for the prefix RPCs. It is
 // a value struct rather than a pointer-to-provider type so the service
@@ -537,7 +539,14 @@ func (s *LanternService) GetEdges(ctx context.Context, request *pb.GetEdgesReque
 }
 
 func (s *LanternService) AddEdge(ctx context.Context, request *pb.AddEdgeRequest) (*pb.AddEdgeResponse, error) {
-	if _, err := s.AddEdges(ctx, &pb.AddEdgesRequest{Edges: []*pb.Edge{request.GetEdge()}}); err != nil {
+	batch := &pb.AddEdgesRequest{Edges: []*pb.Edge{request.GetEdge()}}
+	// Forward the optional idempotency key into the plural request's
+	// index-aligned contrib_ids so the canonical AddEdges path applies the
+	// same dedup (#588). An empty key stays absent (legacy additive path).
+	if cid := request.GetContribId(); len(cid) > 0 {
+		batch.ContribIds = [][]byte{cid}
+	}
+	if _, err := s.AddEdges(ctx, batch); err != nil {
 		return nil, err
 	}
 	return &pb.AddEdgeResponse{}, nil
@@ -549,19 +558,30 @@ func (s *LanternService) AddEdges(ctx context.Context, request *pb.AddEdgesReque
 	}
 	in := request.GetEdges()
 	s.metrics.OnBatch("AddEdges", len(in))
+	contribIDs := request.GetContribIds()
 	items := make([]graph.EdgeItem[string], 0, len(in))
-	for _, e := range in {
+	for i, e := range in {
 		if err := s.validateExpiration(e.GetExpiration().AsTime()); err != nil {
 			return nil, err
 		}
-		items = append(items, graph.EdgeItem[string]{
+		item := graph.EdgeItem[string]{
 			Tail:       e.GetTail(),
 			Head:       e.GetHead(),
 			Weight:     e.GetWeight(),
 			Expiration: e.GetExpiration().AsTime(),
-		})
+		}
+		// contrib_ids is index-aligned and optional (#588): a shorter or
+		// missing slot, or an empty/zero key, leaves ContribID zero — the
+		// legacy additive path. A non-zero key makes the contribution
+		// idempotent so a transport retry re-sending the same bytes is a
+		// no-op instead of double-counting edge weight.
+		if i < len(contribIDs) {
+			item.ContribID = contribIDFromBytes(contribIDs[i])
+		}
+		items = append(items, item)
 	}
-	s.cache.AddEdgesWithExpiration(items)
+	deduped := s.cache.AddEdgesWithExpirationContrib(items)
+	s.metrics.OnEdgeContribDeduped(deduped)
 	s.logMutation(&pb.MutationOp{Op: &pb.MutationOp_AddEdges{AddEdges: request}})
 	return &pb.AddEdgesResponse{Written: int32(len(items))}, nil
 }

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -132,6 +132,105 @@ func TestLanternService_AddEdge_Additive(t *testing.T) {
 	}
 }
 
+// TestLanternService_AddEdges_ContribIDWiring asserts the #588 plumbing:
+// AddEdges maps the optional, index-aligned contrib_ids onto
+// EdgeItem.ContribID (short or empty slots stay zero), AddEdge forwards its
+// singular contrib_id into contrib_ids[0], and the backend's reported dedup
+// count is surfaced via HotPathMetrics.OnEdgeContribDeduped. Dedup
+// convergence itself is covered by the core tests and tests/integration.
+func TestLanternService_AddEdges_ContribIDWiring(t *testing.T) {
+	var id0, id1 graph.ContribID
+	id0[0], id0[23] = 0x11, 0x22
+	id1[0], id1[23] = 0x33, 0x44
+
+	t.Run("AddEdges maps index-aligned contrib_ids", func(t *testing.T) {
+		fb := newFakeBackend()
+		fm := &fakeHotPathMetrics{}
+		fb.dedupReturn = 2
+		s := NewLanternService(fb).WithHotPathMetrics(fm)
+
+		_, err := s.AddEdges(context.Background(), &pb.AddEdgesRequest{
+			Edges: []*pb.Edge{
+				{Tail: "a", Head: "b", Weight: 1, Expiration: futureTs(time.Minute)},
+				{Tail: "a", Head: "c", Weight: 1, Expiration: futureTs(time.Minute)},
+				{Tail: "a", Head: "d", Weight: 1, Expiration: futureTs(time.Minute)},
+			},
+			// id0 for edge 0; empty slot for edge 1; edge 2 has no slot.
+			ContribIds: [][]byte{id0[:], {}},
+		})
+		if err != nil {
+			t.Fatalf("AddEdges: %v", err)
+		}
+		if fb.addEdgesContribCalls != 1 {
+			t.Fatalf("AddEdgesWithExpirationContrib calls = %d, want 1", fb.addEdgesContribCalls)
+		}
+		if len(fb.lastAddEdgesItems) != 3 {
+			t.Fatalf("captured items = %d, want 3", len(fb.lastAddEdgesItems))
+		}
+		if got := fb.lastAddEdgesItems[0].ContribID; got != id0 {
+			t.Errorf("item[0].ContribID = %x, want %x", got, id0)
+		}
+		if got := fb.lastAddEdgesItems[1].ContribID; !got.IsZero() {
+			t.Errorf("item[1].ContribID = %x, want zero (empty slot)", got)
+		}
+		if got := fb.lastAddEdgesItems[2].ContribID; !got.IsZero() {
+			t.Errorf("item[2].ContribID = %x, want zero (missing slot)", got)
+		}
+		if len(fm.contribDed) != 1 || fm.contribDed[0] != 2 {
+			t.Errorf("OnEdgeContribDeduped = %v, want [2]", fm.contribDed)
+		}
+	})
+
+	t.Run("legacy AddEdges without contrib_ids stays zero", func(t *testing.T) {
+		fb := newFakeBackend()
+		fm := &fakeHotPathMetrics{}
+		s := NewLanternService(fb).WithHotPathMetrics(fm)
+		if _, err := s.AddEdges(context.Background(), &pb.AddEdgesRequest{
+			Edges: []*pb.Edge{{Tail: "a", Head: "b", Weight: 1, Expiration: futureTs(time.Minute)}},
+		}); err != nil {
+			t.Fatalf("AddEdges: %v", err)
+		}
+		if got := fb.lastAddEdgesItems[0].ContribID; !got.IsZero() {
+			t.Errorf("item[0].ContribID = %x, want zero (no contrib_ids on wire)", got)
+		}
+		// The service calls OnEdgeContribDeduped unconditionally; with the
+		// fake's default dedupReturn of 0 it fires once with 0.
+		if len(fm.contribDed) != 1 || fm.contribDed[0] != 0 {
+			t.Errorf("OnEdgeContribDeduped = %v, want [0]", fm.contribDed)
+		}
+	})
+
+	t.Run("AddEdge forwards contrib_id into contrib_ids[0]", func(t *testing.T) {
+		fb := newFakeBackend()
+		s := NewLanternService(fb)
+		if _, err := s.AddEdge(context.Background(), &pb.AddEdgeRequest{
+			Edge:      &pb.Edge{Tail: "a", Head: "b", Weight: 1, Expiration: futureTs(time.Minute)},
+			ContribId: id1[:],
+		}); err != nil {
+			t.Fatalf("AddEdge: %v", err)
+		}
+		if len(fb.lastAddEdgesItems) != 1 {
+			t.Fatalf("captured items = %d, want 1", len(fb.lastAddEdgesItems))
+		}
+		if got := fb.lastAddEdgesItems[0].ContribID; got != id1 {
+			t.Errorf("forwarded ContribID = %x, want %x", got, id1)
+		}
+	})
+
+	t.Run("AddEdge without contrib_id stays zero", func(t *testing.T) {
+		fb := newFakeBackend()
+		s := NewLanternService(fb)
+		if _, err := s.AddEdge(context.Background(), &pb.AddEdgeRequest{
+			Edge: &pb.Edge{Tail: "a", Head: "b", Weight: 1, Expiration: futureTs(time.Minute)},
+		}); err != nil {
+			t.Fatalf("AddEdge: %v", err)
+		}
+		if got := fb.lastAddEdgesItems[0].ContribID; !got.IsZero() {
+			t.Errorf("ContribID = %x, want zero (no contrib_id on wire)", got)
+		}
+	})
+}
+
 func TestLanternService_PutEdge_Replaces(t *testing.T) {
 	// PutEdge deletes-then-adds: repeated calls with the same weight stay at that weight.
 	s := newTestService(t)
@@ -792,6 +891,7 @@ type fakeHotPathMetrics struct {
 	batch      []batchObs
 	getVertex  []hitMissObs
 	getEdge    []hitMissObs
+	contribDed []int
 }
 
 type illuminateObs struct {
@@ -830,6 +930,9 @@ func (f *fakeHotPathMetrics) OnGetVertices(hits, misses int) {
 }
 func (f *fakeHotPathMetrics) OnGetEdges(hits, misses int) {
 	f.getEdge = append(f.getEdge, hitMissObs{hits, misses})
+}
+func (f *fakeHotPathMetrics) OnEdgeContribDeduped(n int) {
+	f.contribDed = append(f.contribDed, n)
 }
 
 func TestLanternService_HotPathMetrics_EmitsOnceForBatchAndIlluminate(t *testing.T) {

--- a/tests/integration/idempotent_add_test.go
+++ b/tests/integration/idempotent_add_test.go
@@ -1,0 +1,109 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+
+	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/anaregdesign/lantern/server/provider"
+	"github.com/anaregdesign/lantern/server/service"
+)
+
+// doubleSendInterceptor invokes the next unary func twice with the same
+// request and returns the second result. It models an at-least-once transport
+// retry that re-delivers identical request bytes after the server has already
+// applied the first attempt — the exact hazard WithIdempotentAdds guards
+// against (#588). Streaming RPCs pass through untouched.
+type doubleSendInterceptor struct{}
+
+func (doubleSendInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		if _, err := next(ctx, req); err != nil {
+			return nil, err
+		}
+		return next(ctx, req)
+	}
+}
+
+func (doubleSendInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return next
+}
+
+func (doubleSendInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return next
+}
+
+// newIdempotencyHarness stands up a fresh GraphCache-backed service over the
+// real Connect/h2c transport and returns an SDK client built with the
+// supplied options. Each call owns its own cache so the three subtests below
+// stay isolated.
+func newIdempotencyHarness(t *testing.T, opts ...client.Option) *client.Lantern {
+	t.Helper()
+	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	svc := service.NewLanternService(cache)
+	val := provider.NewValidationInterceptor(defaultIntegrationValidationLimits())
+	srv := newConnectTestServer(t, svc, nil, val.ConnectInterceptor())
+	return newConnectClientFor(t, srv.url, opts...)
+}
+
+// TestAddEdge_IdempotentRetry_SingleContribution is the end-to-end #588
+// acceptance check: with WithIdempotentAdds, a duplicate delivery of one
+// AddEdge call contributes its weight exactly once, while the legacy additive
+// path double-counts it, and distinct user-level calls still sum.
+func TestAddEdge_IdempotentRetry_SingleContribution(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("WithIdempotentAdds dedups a re-delivered request", func(t *testing.T) {
+		l := newIdempotencyHarness(t,
+			client.WithIdempotentAdds(),
+			client.WithConnectClientOption(connect.WithInterceptors(doubleSendInterceptor{})),
+		)
+		if err := l.AddEdge(ctx, "a", "b", 2, time.Minute); err != nil {
+			t.Fatalf("AddEdge: %v", err)
+		}
+		e, err := l.GetEdge(ctx, "a", "b")
+		if err != nil {
+			t.Fatalf("GetEdge: %v", err)
+		}
+		if e.Weight != 2 {
+			t.Fatalf("idempotent retry must contribute once: weight = %v, want 2", e.Weight)
+		}
+	})
+
+	t.Run("legacy additive path double-counts a re-delivered request", func(t *testing.T) {
+		l := newIdempotencyHarness(t,
+			client.WithConnectClientOption(connect.WithInterceptors(doubleSendInterceptor{})),
+		)
+		if err := l.AddEdge(ctx, "a", "b", 2, time.Minute); err != nil {
+			t.Fatalf("AddEdge: %v", err)
+		}
+		e, err := l.GetEdge(ctx, "a", "b")
+		if err != nil {
+			t.Fatalf("GetEdge: %v", err)
+		}
+		if e.Weight != 4 {
+			t.Fatalf("default path is additive on re-delivery: weight = %v, want 4", e.Weight)
+		}
+	})
+
+	t.Run("distinct calls still sum under WithIdempotentAdds", func(t *testing.T) {
+		l := newIdempotencyHarness(t, client.WithIdempotentAdds())
+		for i := 0; i < 2; i++ {
+			if err := l.AddEdge(ctx, "a", "b", 2, time.Minute); err != nil {
+				t.Fatalf("AddEdge #%d: %v", i, err)
+			}
+		}
+		e, err := l.GetEdge(ctx, "a", "b")
+		if err != nil {
+			t.Fatalf("GetEdge: %v", err)
+		}
+		if e.Weight != 4 {
+			t.Fatalf("distinct AddEdge calls get distinct keys and must sum: weight = %v, want 4", e.Weight)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Makes `AddEdge` / `AddEdges` safely retryable by threading a client-supplied,
index-aligned **ContribID** through the proto → core → server → SDK stack. The
edge model stays additive by default; only *duplicates of the same logical
contribution* dedup. This extends the proven contribution-identity machinery
from leaderless replication (#181/#182) to the client write path — not net-new
design.

`Closes #588`

## What changed (4 layers, bottom-up)

**proto** (`proto/graph/v1/graph.proto`, regenerated `pb/**`)
- `AddEdgeRequest.contrib_id` (`bytes`) and `AddEdgesRequest.contrib_ids`
  (`repeated bytes`, index-aligned with `edges`). Empty / short / zero ⇒ legacy
  additive for that edge, so it is naturally backward-compatible.

**core** (`core/cache/graph`)
- `EdgeItem[S].ContribID` field.
- New `AddEdgesWithExpirationContrib(items) (deduped int)`; the existing
  `AddEdgesWithExpiration` is now a thin facade over it (zero ContribID ⇒
  unchanged additive behavior). Reuses the shipped `addWithExpirationContrib`
  no-op semantics — a non-zero ContribID that matches a still-live
  contribution is an exact no-op. No new dedup-window knob was added: the
  per-edge contribution set already prunes decayed/expired entries, so the
  scan is bounded by live contributions.

**server** (`server/service`, `server/metrics`)
- `AddEdges` maps index-aligned `contrib_ids` → `EdgeItem.ContribID` and drives
  the dedup-aware backend method; `AddEdge` stays the one-element-batch facade
  (forwards its singular `contrib_id` into `contrib_ids[0]`).
- ApplyMutation prefers the wire ContribID over the synthesized
  `(origin, seq, idx)` id, so a retried idempotent add dedups across distinct
  mutation-log entries on every replica.
- New `lantern_edge_contrib_deduped_total` counter.

**sdks/go**
- Opt-in `WithIdempotentAdds()`. When set, each Add* call stamps every
  contribution with a ContribID using the same 24-byte layout as the server
  (`nonce[16] || BigEndian((seq<<16)|idx)[8]`): a per-client 128-bit random
  nonce + a per-call `atomic.Uint64` sequence. The keys are baked into the
  request when it is built, so a transport retry that re-sends the same bytes
  records the weight exactly once. Off by default; the legacy path sends no
  `contrib_ids`. Docs updated to reflect that transport retries are now safe.

## Tests

- **core**: `TestAddEdgesWithExpirationContrib_Dedup` — same ContribID twice ⇒
  one contribution + `deduped==1`; zero ID ⇒ additive; distinct IDs both
  contribute; mixed batch counts only the dups; facade preserves additive.
- **server**: `TestLanternService_AddEdges_ContribIDWiring` (index-aligned
  mapping incl. short/empty slots → zero, dedup metric) and
  `TestApplyMutation_WireContribIDDedupsAcrossSeq` (wire ContribID dedups
  across distinct `Seq`; legacy sums).
- **sdks/go**: `TestNextContribIDs` (layout/seq/nonce) + `TestAddContribIDWiring`
  (opt-in only, one key per AddEdge, index-aligned per chunk, default sends
  none).
- **tests/integration**: `TestAddEdge_IdempotentRetry_SingleContribution` —
  end-to-end over the real Connect/h2c transport, a duplicate-delivery
  interceptor proves WithIdempotentAdds contributes once, the legacy path
  double-counts, and distinct calls still sum.

## Acceptance criteria (#588)

- [x] Proto regenerated via `go generate ./...` (no hand edits under `pb/**`).
- [x] core table test: same ContribID ⇒ one contribution; zero ⇒ additive.
- [x] server `AddEdges` maps index-aligned `contrib_ids`; `AddEdge` stays the facade.
- [x] sdks/go: same logical write retried ⇒ single contribution; opt-in only; default unchanged.
- [x] Dedup metric increments on a recognized duplicate.
- [x] Local quality gate green: `gofmt -l` empty; `go test ./...` from root and each submodule.
- [x] 1:1 source↔test pairing preserved (extended existing `*_test.go`).

## Notes / deviations

- SDK surface landed as `WithIdempotentAdds()` (no args, auto-generates a stable
  per-call key) rather than the sketch `WithIdempotencyKey(...)` — it needs no
  caller-managed key and is safe for transparent transport retries by
  construction.
- No separate bounded dedup-window knob (issue listed it as optional cost
  mitigation): the existing live-contribution set already prunes expired
  entries.
- CLI retry re-enablement remains a follow-up, as scoped in the issue.

## Backward compatibility

v0.x, additive-by-default. Absent/empty/zero `contrib_id` ⇒ exactly today's
behavior; the field is purely opt-in. No migration required.
