### PR TITLE
chore: pin sdks/go v0.12.0 in root + mcp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/anaregdesign/lantern/core v0.5.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.4.0
-	github.com/anaregdesign/lantern/sdks/go v0.11.0
+	github.com/anaregdesign/lantern/sdks/go v0.12.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	github.com/anaregdesign/lantern/pb v0.4.0
-	github.com/anaregdesign/lantern/sdks/go v0.11.0
+	github.com/anaregdesign/lantern/sdks/go v0.12.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	google.golang.org/protobuf v1.36.11
 )


### PR DESCRIPTION
Final pin bump of the #588 release cascade: pin the root (server + CLI) and `mcp` modules to the released `sdks/go/v0.12.0` so the published binaries/images resolve the idempotent-AddEdge SDK. Pin bump only — no code change.