### PR TITLE
feat(admin): make per-replica Ops metrics legible

### DIFF
--- a/admin/app/components/ops/MetricsSection/MetricPanel.tsx
+++ b/admin/app/components/ops/MetricsSection/MetricPanel.tsx
@@ -9,6 +9,7 @@ import type { PanelSpec } from "~/lib/client/usecase/ops/metrics/catalog";
 import {
   summariseSeries,
   toChartSeries,
+  type ReplicaAliasMap,
 } from "~/lib/client/usecase/ops/metrics/selectors";
 import type { PanelState } from "~/lib/client/usecase/ops/metrics/state";
 import { TimeSeriesChart } from "./TimeSeriesChart";
@@ -17,6 +18,7 @@ import styles from "./MetricPanel.module.css";
 export interface MetricPanelProps {
   panel: PanelSpec;
   state: PanelState;
+  aliases?: ReplicaAliasMap;
 }
 
 /**
@@ -26,9 +28,9 @@ export interface MetricPanelProps {
  * metric the server has not emitted yet) surfaces an inline MessageBar and
  * never affects its siblings.
  */
-export function MetricPanel({ panel, state }: MetricPanelProps) {
+export function MetricPanel({ panel, state, aliases }: MetricPanelProps) {
   const testId = `ops-metric-${panel.id}`;
-  const chart = toChartSeries(panel.title, state.series);
+  const chart = toChartSeries(panel.title, state.series, aliases);
   const pending = state.status === "idle" || state.status === "loading";
 
   return (

--- a/admin/app/components/ops/MetricsSection/MetricsSection.tsx
+++ b/admin/app/components/ops/MetricsSection/MetricsSection.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import {
   MessageBar,
   MessageBarBody,
@@ -11,14 +12,23 @@ import {
   type PanelGroup,
 } from "~/lib/client/usecase/ops/metrics/catalog";
 import {
+  AGG_MODE_OPTIONS,
+  type AggMode,
+} from "~/lib/client/usecase/ops/metrics/mode";
+import {
   RANGE_OPTIONS,
   type RangeKey,
 } from "~/lib/client/usecase/ops/metrics/range";
+import {
+  buildReplicaAliases,
+  type ReplicaAliasMap,
+} from "~/lib/client/usecase/ops/metrics/selectors";
 import type { PanelState } from "~/lib/client/usecase/ops/metrics/state";
 import { useMetrics } from "~/lib/client/usecase/ops/metrics/use-metrics";
 import { usePrometheusUrl } from "~/lib/client/usecase/ops/metrics/use-prometheus-url";
 import { MetricPanel } from "./MetricPanel";
 import { PrometheusSwitcher } from "./PrometheusSwitcher";
+import { ReplicaKey } from "./ReplicaKey";
 import styles from "./MetricsSection.module.css";
 
 export interface MetricsSectionProps {
@@ -37,11 +47,19 @@ export interface MetricsSectionProps {
  */
 export function MetricsSection({ pollMs, refreshNonce }: MetricsSectionProps) {
   const prometheus = usePrometheusUrl();
-  const { state, range, setRange } = useMetrics({
+  const { state, range, setRange, aggMode, setAggMode } = useMetrics({
     prometheusUrl: prometheus.prometheusUrl,
     pollMs,
     refreshNonce,
   });
+
+  // One replica identity map for the whole section, recomputed only when the
+  // panel series change. Threading a single map down keeps each replica's
+  // alias and colour consistent across every panel.
+  const aliases = useMemo(
+    () => buildReplicaAliases(state.panels),
+    [state.panels],
+  );
 
   const panelStates = Object.values(state.panels);
   const allError =
@@ -59,6 +77,18 @@ export function MetricsSection({ pollMs, refreshNonce }: MetricsSectionProps) {
           </p>
         </div>
         <div className={styles.toolbar}>
+          <TabList
+            selectedValue={aggMode}
+            onTabSelect={(_, data) => setAggMode(data.value as AggMode)}
+            size="small"
+            data-testid="ops-metrics-agg-mode"
+          >
+            {AGG_MODE_OPTIONS.map((option) => (
+              <Tab key={option.key} value={option.key}>
+                {option.label}
+              </Tab>
+            ))}
+          </TabList>
           <TabList
             selectedValue={range}
             onTabSelect={(_, data) => setRange(data.value as RangeKey)}
@@ -86,6 +116,8 @@ export function MetricsSection({ pollMs, refreshNonce }: MetricsSectionProps) {
         </MessageBar>
       )}
 
+      <ReplicaKey aliases={aliases} />
+
       {PANEL_GROUPS.map((group) => {
         const panels = METRIC_PANELS.filter(
           (panel) => panel.group === group.id,
@@ -100,6 +132,7 @@ export function MetricsSection({ pollMs, refreshNonce }: MetricsSectionProps) {
             groupId={group.id}
             panels={panels}
             state={state.panels}
+            aliases={aliases}
           />
         );
       })}
@@ -112,9 +145,16 @@ interface MetricGroupProps {
   groupId: PanelGroup;
   panels: typeof METRIC_PANELS;
   state: Record<string, PanelState>;
+  aliases: ReplicaAliasMap;
 }
 
-function MetricGroup({ label, groupId, panels, state }: MetricGroupProps) {
+function MetricGroup({
+  label,
+  groupId,
+  panels,
+  state,
+  aliases,
+}: MetricGroupProps) {
   return (
     <div className={styles.group} data-testid={`ops-metrics-group-${groupId}`}>
       <h3 className={styles.groupTitle}>{label}</h3>
@@ -125,7 +165,12 @@ function MetricGroup({ label, groupId, panels, state }: MetricGroupProps) {
             return null;
           }
           return (
-            <MetricPanel key={panel.id} panel={panel} state={panelState} />
+            <MetricPanel
+              key={panel.id}
+              panel={panel}
+              state={panelState}
+              aliases={aliases}
+            />
           );
         })}
       </div>

--- a/admin/app/components/ops/MetricsSection/ReplicaKey.module.css
+++ b/admin/app/components/ops/MetricsSection/ReplicaKey.module.css
@@ -1,0 +1,42 @@
+.key {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem 1.25rem;
+  border: 1px solid var(--colorNeutralStroke2);
+  border-radius: var(--borderRadiusMedium);
+  background: var(--colorNeutralBackground2);
+}
+
+.caption {
+  color: var(--colorNeutralForeground3);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+}
+
+.alias {
+  color: var(--colorNeutralForeground1);
+  font-weight: 600;
+  font-family: var(--fontFamilyMonospace, monospace);
+}
+
+.separator {
+  color: var(--colorNeutralForeground4);
+}
+
+.instance {
+  color: var(--colorNeutralForeground3);
+  font-family: var(--fontFamilyMonospace, monospace);
+}

--- a/admin/app/components/ops/MetricsSection/ReplicaKey.tsx
+++ b/admin/app/components/ops/MetricsSection/ReplicaKey.tsx
@@ -1,0 +1,76 @@
+import type { ReplicaAliasMap } from "~/lib/client/usecase/ops/metrics/selectors";
+
+import chartStyles from "./TimeSeriesChart.module.css";
+import styles from "./ReplicaKey.module.css";
+
+// Mirror of the categorical hue count in TimeSeriesChart.module.css
+// (.color0…N). The swatch reuses those exact classes so a replica's key
+// colour is identical to its line colour in every panel.
+const COLOR_SLOTS = 8;
+
+export interface ReplicaKeyProps {
+  aliases: ReplicaAliasMap;
+}
+
+/**
+ * ReplicaKey is the always-visible map from each short replica alias
+ * (`r0`, `r1`, …) to its full Prometheus `instance` (`IP:port`), with the
+ * replica's stable colour swatch. Per-replica panels prefix series with the
+ * short alias only — to keep legends legible — so this strip is the single
+ * at-a-glance place the operator reads the full identity, complementing the
+ * per-series hover `<title>` and the accessible `<desc>`.
+ *
+ * It renders only when replica aliases exist, i.e. in per-replica mode where
+ * panel series carry an `instance` label. In cluster-sum mode the series have
+ * no `instance`, the alias map is empty, and the strip is omitted.
+ */
+export function ReplicaKey({ aliases }: ReplicaKeyProps) {
+  const replicas = Object.values(aliases).sort((a, b) =>
+    a.alias.localeCompare(b.alias),
+  );
+  if (replicas.length === 0) {
+    return null;
+  }
+  return (
+    <ul
+      className={styles.key}
+      data-testid="ops-metrics-replica-key"
+      aria-label="Replica colour key"
+    >
+      <li className={styles.caption} aria-hidden="true">
+        Replicas
+      </li>
+      {replicas.map((replica) => (
+        <li
+          key={replica.instance}
+          className={styles.item}
+          title={replica.instance}
+        >
+          <svg
+            className={chartStyles.swatch}
+            viewBox="0 0 24 8"
+            aria-hidden="true"
+          >
+            <line
+              className={`${chartStyles.line} ${colorClass(replica.colorSlot)}`}
+              x1="0"
+              y1="4"
+              x2="24"
+              y2="4"
+            />
+          </svg>
+          <span className={styles.alias}>{replica.alias}</span>
+          <span className={styles.separator} aria-hidden="true">
+            =
+          </span>
+          <span className={styles.instance}>{replica.instance}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function colorClass(colorSlot: number): string {
+  const slot = ((colorSlot % COLOR_SLOTS) + COLOR_SLOTS) % COLOR_SLOTS;
+  return chartStyles[`color${slot}`] ?? "";
+}

--- a/admin/app/components/ops/MetricsSection/TimeSeriesChart.module.css
+++ b/admin/app/components/ops/MetricsSection/TimeSeriesChart.module.css
@@ -31,39 +31,64 @@
 }
 
 /*
- * Eight categorical series styles. Each pairs a distinct hue with a
- * distinct dash pattern so series remain distinguishable without relying
- * on colour alone (accessibility) and in monochrome printouts.
+ * Eight categorical hues. Colour encodes identity: in per-replica mode a
+ * replica keeps the same hue across every panel; otherwise it indexes the
+ * series. Pairing with a dash pattern (below) keeps the chart legible
+ * without relying on colour alone (accessibility) and in monochrome.
  */
-.series0 {
+.color0 {
   stroke: #0f6cbd;
 }
-.series1 {
+.color1 {
   stroke: #d13438;
+}
+.color2 {
+  stroke: #107c10;
+}
+.color3 {
+  stroke: #8764b8;
+}
+.color4 {
+  stroke: #c19c00;
+}
+.color5 {
+  stroke: #00b7c3;
+}
+.color6 {
+  stroke: #e3008c;
+}
+.color7 {
+  stroke: #5c2e91;
+}
+
+/*
+ * Eight dash patterns. Dash encodes the secondary dimension within a panel
+ * (e.g. vertices vs edges, p50 vs p99), so lines that share a colour
+ * (same replica) stay distinguishable. Slot i pairs with colour i to
+ * reproduce the previous single-axis styling for non-replica panels.
+ */
+.dash0 {
+  stroke-dasharray: none;
+}
+.dash1 {
   stroke-dasharray: 6 3;
 }
-.series2 {
-  stroke: #107c10;
+.dash2 {
   stroke-dasharray: 2 3;
 }
-.series3 {
-  stroke: #8764b8;
+.dash3 {
   stroke-dasharray: 8 3 2 3;
 }
-.series4 {
-  stroke: #c19c00;
+.dash4 {
   stroke-dasharray: 4 2;
 }
-.series5 {
-  stroke: #00b7c3;
+.dash5 {
   stroke-dasharray: 1 3;
 }
-.series6 {
-  stroke: #e3008c;
+.dash6 {
   stroke-dasharray: 10 4;
 }
-.series7 {
-  stroke: #5c2e91;
+.dash7 {
   stroke-dasharray: 3 3;
 }
 

--- a/admin/app/components/ops/MetricsSection/TimeSeriesChart.tsx
+++ b/admin/app/components/ops/MetricsSection/TimeSeriesChart.tsx
@@ -24,9 +24,11 @@ const PAD_BOTTOM = 28;
 const PLOT_W = WIDTH - PAD_LEFT - PAD_RIGHT;
 const PLOT_H = HEIGHT - PAD_TOP - PAD_BOTTOM;
 const Y_TICKS = 4;
-// Number of distinct series styles defined in the CSS module (.series0…N).
-// Colour AND dash pattern vary per slot so the chart is never colour-only.
-const SERIES_STYLES = 8;
+// Number of distinct hue / dash slots defined in the CSS module
+// (.color0…N / .dash0…N). Colour encodes identity (replica, or series) and
+// dash encodes the secondary dimension, so a chart is never colour-only.
+const COLOR_SLOTS = 8;
+const DASH_SLOTS = 8;
 
 /**
  * TimeSeriesChart is a dependency-free multi-series line chart. The admin
@@ -73,7 +75,11 @@ export function TimeSeriesChart({
         <desc id={descId}>
           {series.length} series, latest values:{" "}
           {series
-            .map((s) => `${s.label} ${formatValue(s.lastValue, unit)}`)
+            .map(
+              (s) =>
+                `${s.label} ${formatValue(s.lastValue, unit)}` +
+                (s.instance ? ` (${s.instance})` : ""),
+            )
             .join("; ")}
           .
         </desc>
@@ -122,22 +128,31 @@ export function TimeSeriesChart({
           return (
             <path
               key={s.key}
-              className={`${styles.line} ${seriesClass(s.colorIndex)}`}
+              className={`${styles.line} ${colorClass(s.colorIndex)} ${dashClass(s.dashIndex)}`}
               d={d}
-            />
+            >
+              <title>
+                {s.label} {formatValue(s.lastValue, unit)}
+                {s.instance ? ` — ${s.instance}` : ""}
+              </title>
+            </path>
           );
         })}
       </svg>
       <ul className={styles.legend}>
         {series.map((s) => (
-          <li key={s.key} className={styles.legendItem}>
+          <li
+            key={s.key}
+            className={styles.legendItem}
+            title={s.instance ?? undefined}
+          >
             <svg
               className={styles.swatch}
               viewBox="0 0 24 8"
               aria-hidden="true"
             >
               <line
-                className={`${styles.line} ${seriesClass(s.colorIndex)}`}
+                className={`${styles.line} ${colorClass(s.colorIndex)} ${dashClass(s.dashIndex)}`}
                 x1="0"
                 y1="4"
                 x2="24"
@@ -155,9 +170,14 @@ export function TimeSeriesChart({
   );
 }
 
-function seriesClass(colorIndex: number): string {
-  const slot = ((colorIndex % SERIES_STYLES) + SERIES_STYLES) % SERIES_STYLES;
-  return styles[`series${slot}`] ?? "";
+function colorClass(colorIndex: number): string {
+  const slot = ((colorIndex % COLOR_SLOTS) + COLOR_SLOTS) % COLOR_SLOTS;
+  return styles[`color${slot}`] ?? "";
+}
+
+function dashClass(dashIndex: number): string {
+  const slot = ((dashIndex % DASH_SLOTS) + DASH_SLOTS) % DASH_SLOTS;
+  return styles[`dash${slot}`] ?? "";
 }
 
 interface Domain {

--- a/admin/app/lib/client/infrastructure/browser/storage.ts
+++ b/admin/app/lib/client/infrastructure/browser/storage.ts
@@ -1,6 +1,7 @@
 const STORAGE_KEY = "lantern.admin.baseUrl";
 const PROMETHEUS_STORAGE_KEY = "lantern.admin.prometheusUrl";
 const METRICS_RANGE_STORAGE_KEY = "lantern.admin.metricsRange";
+const METRICS_AGG_MODE_STORAGE_KEY = "lantern.admin.metricsAggMode";
 
 export interface BrowserStorage {
   get(key: string): string | null;
@@ -51,3 +52,9 @@ export const prometheusStorageKey = PROMETHEUS_STORAGE_KEY;
  * selection under (e.g. `1h`). See `usecase/ops/metrics/range.ts`.
  */
 export const metricsRangeStorageKey = METRICS_RANGE_STORAGE_KEY;
+
+/**
+ * localStorage key the admin SPA stores the Ops Metrics aggregation mode
+ * under (`per-replica` or `sum`). See `usecase/ops/metrics/mode.ts`.
+ */
+export const metricsAggModeStorageKey = METRICS_AGG_MODE_STORAGE_KEY;

--- a/admin/app/lib/client/usecase/ops/metrics/catalog.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/catalog.ts
@@ -33,16 +33,36 @@ export type MetricUnit = "count" | "rate" | "ratio" | "seconds" | "bytes";
 
 export interface PanelQuery {
   /**
-   * A PromQL expression. May contain the literal token `$__rate`, which the
-   * selector replaces with a concrete range-vector window (e.g. `1m`).
+   * The **inner** PromQL expression — a raw gauge or a `rate()` series,
+   * with **no** outer replica/cluster aggregation. May contain the literal
+   * token `$__rate`, which the selector replaces with a concrete
+   * range-vector window (e.g. `1m`). The selector layer
+   * (`selectors.ts#composeQuery`) wraps this in `sum by (…)` so the same
+   * query renders per-replica or as a cluster total depending on the active
+   * aggregation mode — keep the aggregation OUT of the catalog.
    */
   expr: string;
   /**
    * Optional legend template. `{{label}}` tokens are filled from each
    * returned series' label set. When omitted the legend is derived from the
-   * series labels (or the panel title for single-series queries).
+   * series labels (or the panel title for single-series queries). In
+   * per-replica mode the selector prefixes the resolved label with the
+   * series' short replica alias (`r0 · …`).
    */
   legend?: string;
+  /**
+   * Secondary grouping labels preserved in **both** aggregation modes
+   * (e.g. `["grpc_method"]`). The selector adds `instance` to this set in
+   * per-replica mode and drops it in cluster-sum mode. Omit (or `[]`) for a
+   * single undifferentiated series per replica.
+   */
+  by?: readonly string[];
+  /**
+   * How the inner expression is aggregated. `"sum"` (the default) wraps it
+   * in `sum by (…)`. `{ quantile }` wraps it in
+   * `histogram_quantile(q, sum by (le, …) (…))` for `_bucket` series.
+   */
+  agg?: "sum" | { quantile: number };
 }
 
 export interface PanelSpec {
@@ -103,7 +123,8 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
     unit: "rate",
     queries: [
       {
-        expr: "sum by (grpc_method) (rate(grpc_server_handled_total[$__rate]))",
+        expr: "rate(grpc_server_handled_total[$__rate])",
+        by: ["grpc_method"],
         legend: "{{grpc_method}}",
       },
     ],
@@ -116,11 +137,13 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
     unit: "seconds",
     queries: [
       {
-        expr: "histogram_quantile(0.5, sum by (le) (rate(grpc_server_handling_seconds_bucket[$__rate])))",
+        expr: "rate(grpc_server_handling_seconds_bucket[$__rate])",
+        agg: { quantile: 0.5 },
         legend: "p50",
       },
       {
-        expr: "histogram_quantile(0.99, sum by (le) (rate(grpc_server_handling_seconds_bucket[$__rate])))",
+        expr: "rate(grpc_server_handling_seconds_bucket[$__rate])",
+        agg: { quantile: 0.99 },
         legend: "p99",
       },
     ],
@@ -133,11 +156,14 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
     unit: "seconds",
     queries: [
       {
-        expr: "histogram_quantile(0.99, sum by (le) (rate(lantern_illuminate_duration_seconds_bucket[$__rate])))",
+        expr: "rate(lantern_illuminate_duration_seconds_bucket[$__rate])",
+        agg: { quantile: 0.99 },
         legend: "illuminate",
       },
       {
-        expr: "histogram_quantile(0.99, sum by (le, op) (rate(lantern_scan_duration_seconds_bucket[$__rate])))",
+        expr: "rate(lantern_scan_duration_seconds_bucket[$__rate])",
+        by: ["op"],
+        agg: { quantile: 0.99 },
         legend: "scan {{op}}",
       },
     ],
@@ -150,7 +176,8 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
     unit: "seconds",
     queries: [
       {
-        expr: "histogram_quantile(0.99, sum by (le) (rate(lantern_gc_duration_seconds_bucket[$__rate])))",
+        expr: "rate(lantern_gc_duration_seconds_bucket[$__rate])",
+        agg: { quantile: 0.99 },
         legend: "p99",
       },
     ],
@@ -163,7 +190,8 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
     unit: "rate",
     queries: [
       {
-        expr: "sum by (kind) (rate(lantern_ttl_expirations_total[$__rate]))",
+        expr: "rate(lantern_ttl_expirations_total[$__rate])",
+        by: ["kind"],
         legend: "{{kind}}",
       },
     ],
@@ -208,6 +236,7 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
     queries: [
       {
         expr: "lantern_replication_lag_seq",
+        by: ["peer", "origin"],
         legend: "{{peer}} ← {{origin}}",
       },
     ],
@@ -218,22 +247,31 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
     title: "Peer connectivity",
     description: "1 when a peer link is up, 0 when down.",
     unit: "count",
-    queries: [{ expr: "lantern_peer_connected", legend: "{{peer}}" }],
+    queries: [
+      { expr: "lantern_peer_connected", by: ["peer"], legend: "{{peer}}" },
+    ],
   },
   {
     id: "replication-apply",
     group: "replication",
     title: "Replication apply / drop rate",
-    description: "Mutations applied (by op) and dropped per second.",
+    // The apply counter also carries an `op` label (11 RPC kinds). Breaking
+    // the panel down by `op` multiplies by replica count (33+ lines here) and
+    // is illegible as a legend; per-op apply rates belong in an ad-hoc query,
+    // not an at-a-glance health panel. We sum over `op` to show one applied
+    // line per replica, and keep the low-cardinality `reason` split on drops
+    // (where "why" is the actionable signal — e.g. self_echo suppression).
+    description: "Remote mutations applied per replica, and drops by reason.",
     unit: "rate",
     queries: [
       {
-        expr: "sum by (op) (rate(lantern_replication_apply_total[$__rate]))",
-        legend: "apply {{op}}",
+        expr: "rate(lantern_replication_apply_total[$__rate])",
+        legend: "applied",
       },
       {
-        expr: "sum(rate(lantern_replication_dropped_total[$__rate]))",
-        legend: "dropped",
+        expr: "rate(lantern_replication_dropped_total[$__rate])",
+        by: ["reason"],
+        legend: "dropped {{reason}}",
       },
     ],
   },
@@ -246,15 +284,15 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
     unit: "rate",
     queries: [
       {
-        expr: "sum(rate(lantern_validation_rejected_total[$__rate]))",
+        expr: "rate(lantern_validation_rejected_total[$__rate])",
         legend: "validation",
       },
       {
-        expr: "sum(rate(lantern_rate_limit_rejected_total[$__rate]))",
+        expr: "rate(lantern_rate_limit_rejected_total[$__rate])",
         legend: "rate limit",
       },
       {
-        expr: "sum(rate(lantern_tombstone_clamp_rejected_total[$__rate]))",
+        expr: "rate(lantern_tombstone_clamp_rejected_total[$__rate])",
         legend: "tombstone clamp",
       },
     ],

--- a/admin/app/lib/client/usecase/ops/metrics/mode.test.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/mode.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+
+import { AGG_MODE_OPTIONS, DEFAULT_MODE, isAggMode } from "./mode";
+
+describe("AGG_MODE_OPTIONS", () => {
+  it("offers exactly the per-replica and sum modes", () => {
+    expect(AGG_MODE_OPTIONS.map((o) => o.key)).toEqual(["per-replica", "sum"]);
+  });
+
+  it("has a human label for each mode", () => {
+    for (const option of AGG_MODE_OPTIONS) {
+      expect(option.label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("DEFAULT_MODE", () => {
+  it("defaults to per-replica visibility", () => {
+    expect(DEFAULT_MODE).toBe("per-replica");
+    expect(isAggMode(DEFAULT_MODE)).toBe(true);
+  });
+});
+
+describe("isAggMode", () => {
+  it("accepts known modes and rejects anything else", () => {
+    expect(isAggMode("per-replica")).toBe(true);
+    expect(isAggMode("sum")).toBe(true);
+    expect(isAggMode("cluster")).toBe(false);
+    expect(isAggMode("")).toBe(false);
+  });
+});

--- a/admin/app/lib/client/usecase/ops/metrics/mode.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/mode.ts
@@ -1,0 +1,28 @@
+/**
+ * Aggregation-mode selection for the Ops Metrics section.
+ *
+ * A panel's series can be rendered either **per-replica** (one line per
+ * server instance, identified by a short stable alias) or collapsed to a
+ * single **cluster sum**. The mode is a small fixed set so the selector can
+ * be a segmented control and the persisted value is trivially validatable;
+ * `selectors.ts#composeQuery` turns it into the concrete `sum by (…)`
+ * wrapping for each catalog query.
+ */
+export type AggMode = "per-replica" | "sum";
+
+/**
+ * Default to per-replica: the whole point of the section is per-box
+ * visibility, and the cluster sum is one click away.
+ */
+export const DEFAULT_MODE: AggMode = "per-replica";
+
+export const AGG_MODE_OPTIONS: ReadonlyArray<{ key: AggMode; label: string }> =
+  [
+    { key: "per-replica", label: "Per-replica" },
+    { key: "sum", label: "Sum" },
+  ];
+
+/** Type guard for a persisted / user-supplied aggregation-mode string. */
+export function isAggMode(value: string): value is AggMode {
+  return AGG_MODE_OPTIONS.some((option) => option.key === value);
+}

--- a/admin/app/lib/client/usecase/ops/metrics/reducer.test.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/reducer.test.ts
@@ -144,4 +144,35 @@ describe("metricsReducer", () => {
     expect(next.fetchEpoch).toBe(0);
     expect(next.panels[firstPanelId].status).toBe("idle");
   });
+
+  it("resets panels but keeps the range when the agg mode changes", () => {
+    let state = metricsReducer(initialMetricsState("6h", "per-replica"), {
+      type: "FETCH_STARTED",
+      epoch: 1,
+    });
+    state = metricsReducer(state, {
+      type: "PANEL_LOADED",
+      epoch: 1,
+      id: firstPanelId,
+      series: sampleSeries,
+    });
+    const next = metricsReducer(state, { type: "SET_MODE", mode: "sum" });
+    expect(next.aggMode).toBe("sum");
+    expect(next.range).toBe("6h");
+    expect(next.fetchEpoch).toBe(0);
+    expect(next.panels[firstPanelId].status).toBe("idle");
+    expect(next.panels[firstPanelId].series).toEqual([]);
+  });
+
+  it("is a no-op when SET_MODE matches the current agg mode", () => {
+    const state = initialMetricsState("1h", "sum");
+    const next = metricsReducer(state, { type: "SET_MODE", mode: "sum" });
+    expect(next).toBe(state);
+  });
+
+  it("preserves the agg mode across a range change", () => {
+    const state = initialMetricsState("1h", "sum");
+    const next = metricsReducer(state, { type: "SET_RANGE", range: "6h" });
+    expect(next.aggMode).toBe("sum");
+  });
 });

--- a/admin/app/lib/client/usecase/ops/metrics/reducer.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/reducer.ts
@@ -4,6 +4,7 @@ import {
   type PanelState,
   initialMetricsState,
 } from "./state";
+import type { AggMode } from "./mode";
 import type { RangeKey } from "./range";
 
 /**
@@ -16,6 +17,7 @@ export type MetricsAction =
   | { type: "PANEL_LOADED"; epoch: number; id: string; series: PanelSeries[] }
   | { type: "PANEL_ERROR"; epoch: number; id: string; error: string }
   | { type: "SET_RANGE"; range: RangeKey }
+  | { type: "SET_MODE"; mode: AggMode }
   | { type: "RESET" };
 
 /**
@@ -68,9 +70,16 @@ export function metricsReducer(
       if (action.range === state.range) return state;
       // Reset panels to idle so the new range shows a loading state rather
       // than briefly charting the previous window's data on a new axis.
-      return initialMetricsState(action.range);
+      return initialMetricsState(action.range, state.aggMode);
+    }
+    case "SET_MODE": {
+      if (action.mode === state.aggMode) return state;
+      // The aggregation mode changes the query shape (per-replica vs
+      // cluster-sum), so reset panels to idle and let the next round fetch
+      // the new series rather than charting incompatible data.
+      return initialMetricsState(state.range, action.mode);
     }
     case "RESET":
-      return initialMetricsState(state.range);
+      return initialMetricsState(state.range, state.aggMode);
   }
 }

--- a/admin/app/lib/client/usecase/ops/metrics/selectors.test.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/selectors.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+  buildReplicaAliases,
+  composeQuery,
   formatValue,
   rangeToWindow,
   rateWindow,
@@ -9,7 +11,8 @@ import {
   summariseSeries,
   toChartSeries,
 } from "./selectors";
-import type { PanelSeries } from "./state";
+import type { PanelQuery } from "./catalog";
+import type { PanelSeries, PanelState } from "./state";
 
 describe("rangeToWindow", () => {
   it("maps each range to a step that yields ~60–290 points", () => {
@@ -145,6 +148,152 @@ describe("toChartSeries", () => {
     expect(chart[0].key).toBe("0:vertices");
     expect(chart[1].label).toBe("GetVertex");
     expect(Number.isNaN(chart[1].lastValue)).toBe(true);
+  });
+});
+
+describe("composeQuery", () => {
+  const raw: PanelQuery = { expr: "lantern_vertices", legend: "vertices" };
+  const grouped: PanelQuery = {
+    expr: "rate(grpc_server_handled_total[$__rate])",
+    by: ["grpc_method"],
+    legend: "{{grpc_method}}",
+  };
+  const quantile: PanelQuery = {
+    expr: "rate(grpc_server_handling_seconds_bucket[$__rate])",
+    agg: { quantile: 0.99 },
+    legend: "p99",
+  };
+
+  it("adds instance to the grouping in per-replica mode", () => {
+    expect(composeQuery(raw, "per-replica")).toBe(
+      "sum by (instance) (lantern_vertices)",
+    );
+    expect(composeQuery(grouped, "per-replica")).toBe(
+      "sum by (grpc_method, instance) (rate(grpc_server_handled_total[$__rate]))",
+    );
+  });
+
+  it("drops instance and keeps secondary grouping in sum mode", () => {
+    expect(composeQuery(raw, "sum")).toBe("sum(lantern_vertices)");
+    expect(composeQuery(grouped, "sum")).toBe(
+      "sum by (grpc_method) (rate(grpc_server_handled_total[$__rate]))",
+    );
+  });
+
+  it("wraps bucket series in histogram_quantile with le grouped", () => {
+    expect(composeQuery(quantile, "per-replica")).toBe(
+      "histogram_quantile(0.99, sum by (le, instance) (rate(grpc_server_handling_seconds_bucket[$__rate])))",
+    );
+    expect(composeQuery(quantile, "sum")).toBe(
+      "histogram_quantile(0.99, sum by (le) (rate(grpc_server_handling_seconds_bucket[$__rate])))",
+    );
+  });
+
+  it("preserves the $__rate placeholder for resolveExpr", () => {
+    expect(composeQuery(grouped, "per-replica")).toContain("$__rate");
+  });
+});
+
+describe("buildReplicaAliases", () => {
+  function panel(instances: (string | undefined)[]): PanelState {
+    return {
+      status: "ready",
+      error: null,
+      series: instances.map((instance) => {
+        const labels: Record<string, string> =
+          instance == null ? {} : { instance };
+        return { legendTemplate: "x", labels, points: [] };
+      }),
+    };
+  }
+
+  it("assigns stable aliases deterministically by sorted instance", () => {
+    const aliases = buildReplicaAliases({
+      b: panel(["10.0.0.3:6380", "10.0.0.1:6380"]),
+      a: panel(["10.0.0.2:6380"]),
+    });
+    expect(aliases["10.0.0.1:6380"]).toEqual({
+      alias: "r0",
+      colorSlot: 0,
+      instance: "10.0.0.1:6380",
+    });
+    expect(aliases["10.0.0.2:6380"].alias).toBe("r1");
+    expect(aliases["10.0.0.3:6380"].alias).toBe("r2");
+  });
+
+  it("keeps a replica's colour slot stable across panels", () => {
+    const aliases = buildReplicaAliases({
+      throughput: panel(["10.0.0.1:6380", "10.0.0.2:6380"]),
+      latency: panel(["10.0.0.2:6380", "10.0.0.1:6380"]),
+    });
+    expect(aliases["10.0.0.1:6380"].colorSlot).toBe(0);
+    expect(aliases["10.0.0.2:6380"].colorSlot).toBe(1);
+  });
+
+  it("ignores series without an instance label", () => {
+    const aliases = buildReplicaAliases({ p: panel([undefined, ""]) });
+    expect(Object.keys(aliases)).toHaveLength(0);
+  });
+});
+
+describe("toChartSeries replica awareness", () => {
+  const aliases = buildReplicaAliases({
+    cache: {
+      status: "ready",
+      error: null,
+      series: [
+        {
+          legendTemplate: "x",
+          labels: { instance: "10.0.0.1:6380" },
+          points: [],
+        },
+        {
+          legendTemplate: "x",
+          labels: { instance: "10.0.0.2:6380" },
+          points: [],
+        },
+      ],
+    },
+  });
+
+  const series: PanelSeries[] = [
+    {
+      legendTemplate: "vertices",
+      labels: { instance: "10.0.0.1:6380" },
+      points: [{ t: 0, v: 3 }],
+    },
+    {
+      legendTemplate: "vertices",
+      labels: { instance: "10.0.0.2:6380" },
+      points: [{ t: 0, v: 4 }],
+    },
+    {
+      legendTemplate: "edges",
+      labels: { instance: "10.0.0.1:6380" },
+      points: [{ t: 0, v: 5 }],
+    },
+  ];
+
+  it("prefixes labels with the replica alias and tracks its colour", () => {
+    const chart = toChartSeries("Cache", series, aliases);
+    expect(chart[0]).toMatchObject({
+      label: "r0 · vertices",
+      colorIndex: 0,
+      dashIndex: 0,
+      instance: "10.0.0.1:6380",
+      key: "r0:vertices",
+    });
+    expect(chart[1]).toMatchObject({ label: "r1 · vertices", colorIndex: 1 });
+  });
+
+  it("uses dash for the secondary dimension within a replica colour", () => {
+    const chart = toChartSeries("Cache", series, aliases);
+    // Same replica (10.0.0.1) keeps colour 0; vertices vs edges differ by dash.
+    expect(chart[0].colorIndex).toBe(0);
+    expect(chart[2].colorIndex).toBe(0);
+    expect(chart[0].dashIndex).toBe(0);
+    expect(chart[2].dashIndex).toBe(1);
+    expect(chart[2].key).toBe("r0:edges");
   });
 });
 

--- a/admin/app/lib/client/usecase/ops/metrics/selectors.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/selectors.ts
@@ -1,8 +1,9 @@
 import type { MetricPoint } from "~/lib/client/infrastructure/api/prometheus-query-range";
 
-import type { MetricUnit } from "./catalog";
+import type { MetricUnit, PanelQuery } from "./catalog";
+import type { AggMode } from "./mode";
 import type { RangeKey } from "./range";
-import type { PanelSeries } from "./state";
+import type { PanelSeries, PanelState } from "./state";
 
 /**
  * Concrete `(rangeSeconds, stepSeconds)` window for each range key. Steps
@@ -52,6 +53,76 @@ export function resolveExpr(expr: string, window: string): string {
 }
 
 /**
+ * Composes a catalog {@link PanelQuery} into a full PromQL expression for
+ * the active aggregation {@link AggMode}. The catalog stores only the
+ * **inner** series; the outer aggregation is added here so the same query
+ * renders per-replica (one line per `instance`) or as a cluster total.
+ *
+ * - `"sum"` (default) → `sum by (<by…>[, instance]) (<expr>)`, or `sum(<expr>)`
+ *   when nothing is grouped.
+ * - `{ quantile }` → `histogram_quantile(q, sum by (le, <by…>[, instance]) (<expr>))`
+ *   for `_bucket` series.
+ *
+ * In per-replica mode `instance` is appended to the grouping set; in sum
+ * mode it is dropped, collapsing every replica into one cluster line. The
+ * `$__rate` placeholder (if any) is preserved for {@link resolveExpr}.
+ */
+export function composeQuery(query: PanelQuery, mode: AggMode): string {
+  const by = query.by ?? [];
+  const groupBy = mode === "per-replica" ? [...by, "instance"] : [...by];
+  const agg = query.agg ?? "sum";
+  if (typeof agg === "object") {
+    const labels = ["le", ...groupBy].join(", ");
+    return `histogram_quantile(${agg.quantile}, sum by (${labels}) (${query.expr}))`;
+  }
+  if (groupBy.length === 0) {
+    return `sum(${query.expr})`;
+  }
+  return `sum by (${groupBy.join(", ")}) (${query.expr})`;
+}
+
+/**
+ * A resolved replica identity: a short stable alias (`r0`, `r1`, …), the
+ * colour slot driving its line hue across every panel, and the full
+ * Prometheus `instance` value (`IP:port`) surfaced on hover.
+ */
+export interface ReplicaAlias {
+  alias: string;
+  colorSlot: number;
+  instance: string;
+}
+
+/** Maps a full `instance` label to its resolved {@link ReplicaAlias}. */
+export type ReplicaAliasMap = Record<string, ReplicaAlias>;
+
+/**
+ * Builds one `instance → alias` map for the whole Metrics section. The
+ * distinct `instance` labels are collected across **all** panels in a
+ * round and stable-sorted, so a given replica is assigned the same alias
+ * and colour slot in every panel (consistent cross-panel identity) and the
+ * assignment is deterministic regardless of Prometheus' series order.
+ */
+export function buildReplicaAliases(
+  panels: Record<string, PanelState>,
+): ReplicaAliasMap {
+  const instances = new Set<string>();
+  for (const panel of Object.values(panels)) {
+    for (const entry of panel.series) {
+      const instance = entry.labels.instance;
+      if (instance != null && instance !== "") {
+        instances.add(instance);
+      }
+    }
+  }
+  const sorted = [...instances].sort((a, b) => a.localeCompare(b));
+  const map: ReplicaAliasMap = {};
+  sorted.forEach((instance, index) => {
+    map[instance] = { alias: `r${index}`, colorSlot: index, instance };
+  });
+  return map;
+}
+
+/**
  * Computes a display label for one series. A legend template containing
  * `{{label}}` tokens is filled from the series' label set; a static
  * template is returned verbatim; with no template the label is derived
@@ -90,29 +161,65 @@ export function seriesLegend(
   return entries.map(([, value]) => value).join(", ");
 }
 
-/** A chart-ready series: a stable key, display label, colour slot, points. */
+/** A chart-ready series: a stable key, display label, colour/dash slots, points. */
 export interface ChartSeries {
   key: string;
   label: string;
+  /**
+   * Drives the line hue. For a per-replica series this is the replica's
+   * stable colour slot, so the **same replica keeps the same colour across
+   * every panel**. For a series with no `instance` (cluster-sum mode, or an
+   * inherently single-cluster metric) it falls back to the per-series
+   * secondary slot.
+   */
   colorIndex: number;
+  /**
+   * Drives the line dash pattern, keyed off the **secondary** label
+   * (e.g. `vertices` vs `edges`, `p50` vs `p99`). Within one replica's
+   * colour, the dash disambiguates the second dimension so lines stay
+   * distinguishable without relying on colour alone.
+   */
+  dashIndex: number;
+  /** Full Prometheus `instance` (`IP:port`), surfaced on hover when present. */
+  instance?: string;
   lastValue: number;
   points: MetricPoint[];
 }
 
 /**
  * Maps a panel's resolved series into chart-ready series with stable keys,
- * display labels, colour slots, and the latest finite value.
+ * replica-aware display labels, colour/dash slots, and the latest finite
+ * value. When a series carries an `instance` label present in `aliases`,
+ * its label is prefixed with the short replica alias (`r0 · …`), its colour
+ * tracks the replica, and its dash tracks the secondary label; otherwise it
+ * falls back to a per-series slot (cluster-sum and single-cluster panels).
  */
 export function toChartSeries(
   panelTitle: string,
   series: PanelSeries[],
+  aliases: ReplicaAliasMap = {},
 ): ChartSeries[] {
+  const dashSlots = new Map<string, number>();
   return series.map((entry, index) => {
-    const label = seriesLegend(entry.legendTemplate, entry.labels, panelTitle);
+    const baseLabel = seriesLegend(
+      entry.legendTemplate,
+      entry.labels,
+      panelTitle,
+    );
+    if (!dashSlots.has(baseLabel)) {
+      dashSlots.set(baseLabel, dashSlots.size);
+    }
+    const dashIndex = dashSlots.get(baseLabel) ?? 0;
+    const instance = entry.labels.instance;
+    const replica =
+      instance != null && instance !== "" ? aliases[instance] : undefined;
+    const label = replica ? `${replica.alias} · ${baseLabel}` : baseLabel;
     return {
-      key: `${index}:${label}`,
+      key: replica ? `${replica.alias}:${baseLabel}` : `${index}:${baseLabel}`,
       label,
-      colorIndex: index,
+      colorIndex: replica ? replica.colorSlot : dashIndex,
+      dashIndex,
+      instance: replica?.instance ?? instance,
       lastValue: lastFiniteValue(entry.points),
       points: entry.points,
     };

--- a/admin/app/lib/client/usecase/ops/metrics/state.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/state.ts
@@ -1,6 +1,7 @@
 import type { MetricPoint } from "~/lib/client/infrastructure/api/prometheus-query-range";
 
 import { METRIC_PANELS } from "./catalog";
+import { DEFAULT_MODE, type AggMode } from "./mode";
 import { DEFAULT_RANGE, type RangeKey } from "./range";
 
 /**
@@ -40,17 +41,19 @@ export interface PanelState {
 export interface MetricsState {
   panels: Record<string, PanelState>;
   range: RangeKey;
+  aggMode: AggMode;
   fetchEpoch: number;
 }
 
 export function initialMetricsState(
   range: RangeKey = DEFAULT_RANGE,
+  aggMode: AggMode = DEFAULT_MODE,
 ): MetricsState {
   const panels: Record<string, PanelState> = {};
   for (const panel of METRIC_PANELS) {
     panels[panel.id] = { status: "idle", series: [], error: null };
   }
-  return { panels, range, fetchEpoch: 0 };
+  return { panels, range, aggMode, fetchEpoch: 0 };
 }
 
 export const INITIAL_METRICS_STATE = initialMetricsState();

--- a/admin/app/lib/client/usecase/ops/metrics/use-metrics.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/use-metrics.ts
@@ -6,12 +6,19 @@ import {
 } from "~/lib/client/infrastructure/api/prometheus-query-range";
 import {
   browserStorage,
+  metricsAggModeStorageKey,
   metricsRangeStorageKey,
 } from "~/lib/client/infrastructure/browser/storage";
 import { METRIC_PANELS } from "./catalog";
+import { DEFAULT_MODE, isAggMode, type AggMode } from "./mode";
 import { DEFAULT_RANGE, isRangeKey, type RangeKey } from "./range";
 import { metricsReducer } from "./reducer";
-import { rangeToWindow, rateWindow, resolveExpr } from "./selectors";
+import {
+  composeQuery,
+  rangeToWindow,
+  rateWindow,
+  resolveExpr,
+} from "./selectors";
 import { initialMetricsState, type PanelSeries } from "./state";
 
 export interface UseMetricsArgs {
@@ -27,6 +34,8 @@ export interface UseMetrics {
   state: ReturnType<typeof metricsReducer>;
   range: RangeKey;
   setRange: (range: RangeKey) => void;
+  aggMode: AggMode;
+  setAggMode: (mode: AggMode) => void;
 }
 
 /**
@@ -49,9 +58,13 @@ export function useMetrics({
 }: UseMetricsArgs): UseMetrics {
   const storage = useMemo(() => browserStorage(), []);
   const [state, dispatch] = useReducer(metricsReducer, undefined, () => {
-    const stored = storage.get(metricsRangeStorageKey);
-    const range = stored && isRangeKey(stored) ? stored : DEFAULT_RANGE;
-    return initialMetricsState(range);
+    const storedRange = storage.get(metricsRangeStorageKey);
+    const range =
+      storedRange && isRangeKey(storedRange) ? storedRange : DEFAULT_RANGE;
+    const storedMode = storage.get(metricsAggModeStorageKey);
+    const aggMode =
+      storedMode && isAggMode(storedMode) ? storedMode : DEFAULT_MODE;
+    return initialMetricsState(range, aggMode);
   });
 
   // epochRef carries the latest dispatched epoch so the polling closure
@@ -67,7 +80,16 @@ export function useMetrics({
     [storage],
   );
 
+  const setAggMode = useCallback(
+    (mode: AggMode) => {
+      storage.set(metricsAggModeStorageKey, mode);
+      dispatch({ type: "SET_MODE", mode });
+    },
+    [storage],
+  );
+
   const range = state.range;
+  const aggMode = state.aggMode;
 
   const fetchRound = useCallback(
     async (signal: AbortSignal) => {
@@ -86,7 +108,7 @@ export function useMetrics({
             const resolved = await Promise.all(
               panel.queries.map((query) =>
                 queryRange(prometheusUrl, {
-                  query: resolveExpr(query.expr, window),
+                  query: resolveExpr(composeQuery(query, aggMode), window),
                   start,
                   end,
                   step: stepSeconds,
@@ -120,7 +142,7 @@ export function useMetrics({
         }),
       );
     },
-    [prometheusUrl, range],
+    [prometheusUrl, range, aggMode],
   );
 
   // First-paint fetch + polling timer. refreshNonce in the dependency
@@ -140,7 +162,7 @@ export function useMetrics({
     };
   }, [fetchRound, pollMs, refreshNonce]);
 
-  return { state, range, setRange };
+  return { state, range, setRange, aggMode, setAggMode };
 }
 
 function errorMessage(err: unknown): string {

--- a/admin/tests/e2e/ops-metrics.spec.ts
+++ b/admin/tests/e2e/ops-metrics.spec.ts
@@ -30,6 +30,28 @@ function matrixEnvelope(now: number, step = 60, count = 10) {
   };
 }
 
+/**
+ * Builds a `query_range` matrix envelope with one series per `instance`, each
+ * offset so the lines are distinct. Mirrors what Prometheus returns for a
+ * per-replica query (`sum by (instance) (…)`): every series carries an
+ * `instance` label, which is what drives the replica alias map and key.
+ */
+function multiInstanceEnvelope(
+  now: number,
+  instances: string[],
+  step = 60,
+  count = 10,
+) {
+  const result = instances.map((instance, idx) => {
+    const values: Array<[number, string]> = [];
+    for (let i = count - 1; i >= 0; i -= 1) {
+      values.push([now - i * step, String(100 + idx * 10 + (count - i))]);
+    }
+    return { metric: { __name__: "lantern_vertices", instance }, values };
+  });
+  return { status: "success", data: { resultType: "matrix", result } };
+}
+
 test.describe("Ops metrics section", () => {
   test("renders the metrics section below the status cards", async ({
     page,
@@ -49,6 +71,27 @@ test.describe("Ops metrics section", () => {
     await expect(
       page.getByTestId("ops-metrics-range").getByRole("tab", { name: "1h" }),
     ).toHaveAttribute("aria-selected", "true");
+    // The aggregation toggle defaults to per-replica.
+    await expect(
+      page
+        .getByTestId("ops-metrics-agg-mode")
+        .getByRole("tab", { name: "Per-replica" }),
+    ).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("persists the aggregation mode across reloads", async ({ page }) => {
+    await page.goto("/ops");
+    const toggle = page.getByTestId("ops-metrics-agg-mode");
+    await toggle.getByRole("tab", { name: "Sum" }).click();
+    await expect(toggle.getByRole("tab", { name: "Sum" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await page.reload();
+    await expect(toggle.getByRole("tab", { name: "Sum" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
   });
 
   test("shows the degraded banner when no Prometheus is reachable", async ({
@@ -81,6 +124,47 @@ test.describe("Ops metrics section", () => {
     await expect(
       page.getByTestId("ops-metric-cache-size-summary"),
     ).toBeVisible();
+  });
+
+  test("shows the replica key in per-replica mode and hides it in sum mode", async ({
+    page,
+  }) => {
+    // The mock branches on the composed query: per-replica queries group by
+    // `instance` (so series carry an instance label and the replica key
+    // appears); cluster-sum queries do not (so the key self-hides).
+    await page.route("**/api/prom/api/v1/query_range*", async (route) => {
+      const now = Math.floor(Date.now() / 1000);
+      const query = new URL(route.request().url()).searchParams.get("query");
+      const body = (query ?? "").includes("instance")
+        ? multiInstanceEnvelope(now, [
+            "10.0.0.1:9090",
+            "10.0.0.2:9090",
+            "10.0.0.3:9090",
+          ])
+        : matrixEnvelope(now);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      });
+    });
+
+    await page.goto("/ops");
+    // Per-replica is the default: the key maps each alias to its instance.
+    const key = page.getByTestId("ops-metrics-replica-key");
+    await expect(key).toBeVisible();
+    await expect(key).toContainText("r0");
+    await expect(key).toContainText("10.0.0.1:9090");
+    await expect(key).toContainText("r2");
+    await expect(key).toContainText("10.0.0.3:9090");
+
+    // Switching to cluster-sum drops the instance grouping; series lose their
+    // instance label and the key disappears.
+    await page
+      .getByTestId("ops-metrics-agg-mode")
+      .getByRole("tab", { name: "Sum" })
+      .click();
+    await expect(key).toHaveCount(0);
   });
 
   test("persists a runtime Prometheus URL override", async ({ page }) => {


### PR DESCRIPTION
## Summary

Makes the `/ops` metrics panels legible on a multi-instance HA deployment by giving each replica a **stable identity** — a short alias, a consistent colour across every panel, and a per-replica/sum aggregation toggle.

Admin-only change (no server / Prometheus / Go-module impact).

## What changed

- **Stable replica alias** — `r0`, `r1`, … derived from the sorted `instance` labels (`buildReplicaAliases`). The full instance is shown on hover (legend `<li title>`) and inside the chart's `<desc>` for screen readers.
- **Consistent colour per replica** — deterministic `instance → colour-slot` mapping so a replica keeps the same hue across all panels; secondary labels (e.g. `reason`, `op`) map to dash styles.
- **Per-replica vs Sum toggle** — `composeQuery(query, mode)` wraps PromQL in `sum by(...)` for *Sum* mode and appends `instance` for *Per-replica*; quantile panels switch to `histogram_quantile`. The mode is persisted to `localStorage`.
- **Always-visible replica colour-key strip** (`ReplicaKey`) — maps each alias to its full instance, reusing the chart palette as the single source of truth. Self-hides in *Sum* mode.
- **Replication apply/drop legend fix** — the applied series now reads `applied` and drops read `dropped {{reason}}`, instead of duplicated/ambiguous labels.

A declarative `PanelSpec` / `PanelQuery` catalog drives the composable aggregation.

## Testing

- `bun run format:check`, `bun run lint`, `bun run typecheck` — clean
- `bun run test` — 627 pass (adds `mode` / `selectors` / `reducer` unit tests)
- `bun run build` — clean
- `bunx playwright test --workers=1` — 57 pass (adds an e2e test covering the replica key in per-replica vs sum mode)
- Live-verified against the local 3-replica HA compose stack (`r0`/`r1`/`r2` aliases, stable cross-panel colours, persisted toggle).

Closes #595
