### PR TITLE
feat(core): generic frontier predicate in Neighbor* for Illuminate

### DIFF
--- a/core/cache/graph/batch_external_test.go
+++ b/core/cache/graph/batch_external_test.go
@@ -41,7 +41,7 @@ func TestAddEdgesWithExpiration_AtomicNeighborSnapshot(t *testing.T) {
 		go func() {
 			defer readerWG.Done()
 			for !stop.Load() {
-				g := c.Neighbor("s", 1, fanOut+1, false, false)
+				g := c.Neighbor("s", 1, fanOut+1, false, false, nil)
 				reads.Add(1)
 				if g == nil {
 					continue
@@ -102,7 +102,7 @@ func TestDeleteEdges_AtomicNeighborSnapshot(t *testing.T) {
 		go func() {
 			defer readerWG.Done()
 			for !stop.Load() {
-				g := c.Neighbor("s", 1, fanOut+1, false, false)
+				g := c.Neighbor("s", 1, fanOut+1, false, false, nil)
 				reads.Add(1)
 				if g == nil {
 					continue

--- a/core/cache/graph/bench_test.go
+++ b/core/cache/graph/bench_test.go
@@ -181,7 +181,7 @@ func BenchmarkNeighbor_Small(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_ = c.Neighbor(keys[i%s.vertices], 1, 10, false, false)
+				_ = c.Neighbor(keys[i%s.vertices], 1, 10, false, false, nil)
 			}
 		})
 	}
@@ -199,7 +199,7 @@ func BenchmarkNeighbor_Large(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_ = c.Neighbor(keys[i%s.vertices], 3, 10, false, false)
+				_ = c.Neighbor(keys[i%s.vertices], 3, 10, false, false, nil)
 			}
 		})
 	}

--- a/core/cache/graph/cache.go
+++ b/core/cache/graph/cache.go
@@ -442,17 +442,28 @@ func (c *GraphCache[S, T]) snapshotHooks() (func(string, int), func(time.Duratio
 // caller picks the direction that matches its Objective so a cost-minimiser
 // is not handed the costliest edges. tfidf re-scores edge weights BEFORE the
 // directional top/bottom-k selection.
-func (c *GraphCache[S, T]) Neighbor(seed S, step int, k int, tfidf bool, selectSmallest bool) *graph.Graph[S, T] {
-	g, _ := c.NeighborContext(context.Background(), seed, step, k, tfidf, selectSmallest)
+//
+// keep is an optional frontier predicate (nil = accept all): a candidate head
+// is expanded into the result only when keep(head) is true. It is applied at
+// frontier materialisation, BEFORE scoring and the directional top/bottom-k
+// prune, so top-k selects the k best *accepted* neighbours per hop. The seed
+// is the anchor exemption — it is always retained and never passed through
+// keep. Because the next-hop frontier is derived from the surviving edges, a
+// matching vertex reachable only through a rejected "bridge" is not reached
+// (induced-subgraph semantics). core stays generic: keep is just a predicate
+// over S; the concrete prefix/string logic lives in the caller.
+func (c *GraphCache[S, T]) Neighbor(seed S, step int, k int, tfidf bool, selectSmallest bool, keep func(S) bool) *graph.Graph[S, T] {
+	g, _ := c.NeighborContext(context.Background(), seed, step, k, tfidf, selectSmallest, keep)
 	return g
 }
 
 // NeighborContext is the context-aware variant of Neighbor. It returns
 // ctx.Err() as soon as the context is cancelled or its deadline has expired
 // — checked between BFS expansion steps — so handlers can short-circuit
-// large traversals when the caller has given up.
-func (c *GraphCache[S, T]) NeighborContext(ctx context.Context, seed S, step int, k int, tfidf bool, selectSmallest bool) (*graph.Graph[S, T], error) {
-	g, _, err := c.neighborContext(ctx, seed, step, k, tfidf, selectSmallest, false)
+// large traversals when the caller has given up. keep is the optional frontier
+// predicate documented on Neighbor (nil = accept all).
+func (c *GraphCache[S, T]) NeighborContext(ctx context.Context, seed S, step int, k int, tfidf bool, selectSmallest bool, keep func(S) bool) (*graph.Graph[S, T], error) {
+	g, _, err := c.neighborContext(ctx, seed, step, k, tfidf, selectSmallest, keep, false)
 	return g, err
 }
 
@@ -463,12 +474,13 @@ func (c *GraphCache[S, T]) NeighborContext(ctx context.Context, seed S, step int
 //
 // The expirations map only contains entries for edges that ended up in
 // the returned graph; a missing or zero value means the edge has no
-// known expiration.
-func (c *GraphCache[S, T]) NeighborWithExpirationsContext(ctx context.Context, seed S, step int, k int, tfidf bool, selectSmallest bool) (*graph.Graph[S, T], map[S]map[S]time.Time, error) {
-	return c.neighborContext(ctx, seed, step, k, tfidf, selectSmallest, true)
+// known expiration. keep is the optional frontier predicate documented on
+// Neighbor (nil = accept all).
+func (c *GraphCache[S, T]) NeighborWithExpirationsContext(ctx context.Context, seed S, step int, k int, tfidf bool, selectSmallest bool, keep func(S) bool) (*graph.Graph[S, T], map[S]map[S]time.Time, error) {
+	return c.neighborContext(ctx, seed, step, k, tfidf, selectSmallest, keep, true)
 }
 
-func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int, k int, tfidf bool, selectSmallest bool, collectExpirations bool) (*graph.Graph[S, T], map[S]map[S]time.Time, error) {
+func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int, k int, tfidf bool, selectSmallest bool, keep func(S) bool, collectExpirations bool) (*graph.Graph[S, T], map[S]map[S]time.Time, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	g := graph.NewGraph[S, T]()
@@ -518,6 +530,13 @@ func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int
 		for headID, w := range heads {
 			head, ok := c.edges.resolveID(headID)
 			if !ok {
+				continue
+			}
+			// Frontier predicate: reject non-matching heads here, BEFORE
+			// scoring and the Top(k)/Bottom(k) prune below, so top-k selects
+			// the k best *accepted* neighbours. The seed is set on g.Vertices
+			// before the walk and never reaches this loop, so it is exempt.
+			if keep != nil && !keep(head) {
 				continue
 			}
 			sum, latest, nonZero := w.snapshot()

--- a/core/cache/graph/cache_test.go
+++ b/core/cache/graph/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -446,7 +447,7 @@ func TestGraphCache_Neighbor(t *testing.T) {
 	for i := range tests {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.c.Neighbor(tt.args.seed, tt.args.step, tt.args.k, tt.args.tfidf, tt.args.selectSmallest); !reflect.DeepEqual(got, tt.want) {
+			if got := tt.c.Neighbor(tt.args.seed, tt.args.step, tt.args.k, tt.args.tfidf, tt.args.selectSmallest, nil); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Neighbor() = %v, want %v", got, tt.want)
 			}
 		})
@@ -513,13 +514,142 @@ func TestGraphCache_Neighbor_ObjectiveDirection(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := headSet(mk().Neighbor(seed, 1, tt.k, false, tt.selectSmallest))
+			got := headSet(mk().Neighbor(seed, 1, tt.k, false, tt.selectSmallest, nil))
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Neighbor(k=%d, selectSmallest=%v) heads = %v, want %v",
 					tt.k, tt.selectSmallest, got, tt.want)
 			}
 		})
 	}
+}
+
+// TestGraphCache_NeighborKeep pins the #601 frontier predicate: keep func(S) bool
+// is applied at frontier materialisation, BEFORE scoring and the per-hop top-k
+// prune, and the seed is always exempt. The prefix-style closures here stand in
+// for the strings.HasPrefix closure the server builds in #602 — core itself stays
+// generic (it only ever sees a predicate over S).
+func TestGraphCache_NeighborKeep(t *testing.T) {
+	// KeepNil_Unchanged: a nil predicate is identical to an accept-all predicate
+	// (the pre-#601 behaviour).
+	t.Run("KeepNil_Unchanged", func(t *testing.T) {
+		mk := func() *GraphCache[string, int] {
+			c := NewGraphCache[string, int](time.Minute)
+			c.PutVertex("a", 0)
+			c.PutVertex("b", 0)
+			c.PutVertex("c", 0)
+			c.AddEdge("a", "b", 2)
+			c.AddEdge("a", "c", 1)
+			return c
+		}
+		gNil := mk().Neighbor("a", 2, 10, false, false, nil)
+		gAll := mk().Neighbor("a", 2, 10, false, false, func(string) bool { return true })
+		if !reflect.DeepEqual(gNil, gAll) {
+			t.Errorf("nil predicate graph = %v, want identical to accept-all %v", gNil, gAll)
+		}
+	})
+
+	// KeepExcludesNonMatching: a predicate that rejects some heads drops exactly
+	// those heads (and their vertices) from the result.
+	t.Run("KeepExcludesNonMatching", func(t *testing.T) {
+		c := NewGraphCache[string, int](time.Minute)
+		for _, k := range []string{"a", "keep1", "keep2", "drop1"} {
+			c.PutVertex(k, 0)
+		}
+		c.AddEdge("a", "keep1", 1)
+		c.AddEdge("a", "keep2", 1)
+		c.AddEdge("a", "drop1", 1)
+		g := c.Neighbor("a", 1, 10, false, false, func(s string) bool {
+			return strings.HasPrefix(s, "keep")
+		})
+		if _, ok := g.Edges["a"]["drop1"]; ok {
+			t.Errorf("non-matching head drop1 survived: %v", g.Edges["a"])
+		}
+		for _, want := range []string{"keep1", "keep2"} {
+			if _, ok := g.Edges["a"][want]; !ok {
+				t.Errorf("matching head %q missing: %v", want, g.Edges["a"])
+			}
+		}
+		if _, ok := g.Vertices["drop1"]; ok {
+			t.Errorf("non-matching vertex drop1 present in g.Vertices")
+		}
+	})
+
+	// SeedRetainedWhenItFails: the seed is the anchor exemption — present even
+	// when keep(seed) is false.
+	t.Run("SeedRetainedWhenItFails", func(t *testing.T) {
+		c := NewGraphCache[string, int](time.Minute)
+		c.PutVertex("seed", 0)
+		c.PutVertex("keep1", 0)
+		c.AddEdge("seed", "keep1", 1)
+		keep := func(s string) bool { return strings.HasPrefix(s, "keep") }
+		if keep("seed") {
+			t.Fatal("test setup: seed must NOT match the predicate")
+		}
+		g := c.Neighbor("seed", 1, 10, false, false, keep)
+		if _, ok := g.Vertices["seed"]; !ok {
+			t.Errorf("seed dropped despite anchor exemption: %v", g.Vertices)
+		}
+		if _, ok := g.Edges["seed"]["keep1"]; !ok {
+			t.Errorf("matching head keep1 missing from seed edges: %v", g.Edges["seed"])
+		}
+	})
+
+	// KeepBeforeTopK is the load-bearing ordering proof: the k strongest heads
+	// overall are all non-matching, so if the filter ran AFTER top-k the result
+	// would be empty. Filtering BEFORE top-k yields the k strongest *matching*
+	// heads instead.
+	t.Run("KeepBeforeTopK", func(t *testing.T) {
+		c := NewGraphCache[string, int](time.Minute)
+		for _, k := range []string{"a", "x1", "x2", "y1", "y2", "y3"} {
+			c.PutVertex(k, 0)
+		}
+		// Non-matching heads carry the largest weights; matching heads are weaker.
+		c.AddEdge("a", "x1", 100)
+		c.AddEdge("a", "x2", 90)
+		c.AddEdge("a", "y1", 10)
+		c.AddEdge("a", "y2", 9)
+		c.AddEdge("a", "y3", 8)
+		// k=2, Top (selectSmallest=false): without the before-top-k ordering this
+		// would select x1,x2 then filter to empty.
+		g := c.Neighbor("a", 1, 2, false, false, func(s string) bool {
+			return strings.HasPrefix(s, "y")
+		})
+		got := map[string]bool{}
+		for head := range g.Edges["a"] {
+			got[head] = true
+		}
+		want := map[string]bool{"y1": true, "y2": true}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("KeepBeforeTopK heads = %v, want %v (filter must run before top-k)", got, want)
+		}
+	})
+
+	// NonMatchingBridgeBlocks: induced-subgraph semantics — a matching vertex
+	// reachable only through a rejected bridge is never reached.
+	t.Run("NonMatchingBridgeBlocks", func(t *testing.T) {
+		c := NewGraphCache[string, int](time.Minute)
+		for _, k := range []string{"m_seed", "bridge", "m_target", "m_direct"} {
+			c.PutVertex(k, 0)
+		}
+		c.AddEdge("m_seed", "bridge", 5)   // non-matching bridge
+		c.AddEdge("bridge", "m_target", 5) // matching, but only reachable via bridge
+		c.AddEdge("m_seed", "m_direct", 1) // matching, directly reachable
+		g := c.Neighbor("m_seed", 2, 10, false, false, func(s string) bool {
+			return strings.HasPrefix(s, "m")
+		})
+		if _, ok := g.Vertices["bridge"]; ok {
+			t.Errorf("rejected bridge present in g.Vertices")
+		}
+		if _, ok := g.Vertices["m_target"]; ok {
+			t.Errorf("m_target reached through a rejected bridge (induced-subgraph violated)")
+		}
+		if _, ok := g.Vertices["m_direct"]; !ok {
+			t.Errorf("directly-reachable matching vertex m_direct missing")
+		}
+		if _, ok := g.Edges["bridge"]; ok {
+			t.Errorf("rejected bridge was expanded: %v", g.Edges["bridge"])
+		}
+	})
 }
 
 func TestGraphCache_flush(t *testing.T) {
@@ -684,7 +814,7 @@ func TestGraphCache_NeighborContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if _, err := c.NeighborContext(ctx, "a", 5, 10, false, false); !errors.Is(err, context.Canceled) {
+	if _, err := c.NeighborContext(ctx, "a", 5, 10, false, false, nil); !errors.Is(err, context.Canceled) {
 		t.Fatalf("want context.Canceled, got %v", err)
 	}
 }
@@ -703,7 +833,7 @@ func TestGraphCache_NeighborWithExpirationsContext_ReturnsAlignedMap(t *testing.
 	c.AddEdgeWithExpiration("a", "b", 1.0, expAB)
 	c.AddEdgeWithExpiration("a", "c", 2.0, expAC)
 
-	g, exps, err := c.NeighborWithExpirationsContext(context.Background(), "a", 2, 10, false, false)
+	g, exps, err := c.NeighborWithExpirationsContext(context.Background(), "a", 2, 10, false, false, nil)
 	if err != nil {
 		t.Fatalf("NeighborWithExpirationsContext: %v", err)
 	}
@@ -744,7 +874,7 @@ func TestGraphCache_NeighborContext_StillWorksAfterRefactor(t *testing.T) {
 	c.PutVertex("b", 2)
 	c.AddEdge("a", "b", 1.0)
 
-	g, err := c.NeighborContext(context.Background(), "a", 2, 10, false, false)
+	g, err := c.NeighborContext(context.Background(), "a", 2, 10, false, false, nil)
 	if err != nil {
 		t.Fatalf("NeighborContext: %v", err)
 	}

--- a/core/cache/graph/example/main.go
+++ b/core/cache/graph/example/main.go
@@ -21,7 +21,7 @@ func main() {
 	c.AddEdge("a", "e", 1)
 
 	start := time.Now()
-	g := c.Neighbor("a", 3, 3, true, false)
+	g := c.Neighbor("a", 3, 3, true, false, nil)
 	end := time.Now()
 
 	if jsonText, err := json.MarshalIndent(g, "", "\t"); err == nil {

--- a/core/cache/graph/production_gate_test.go
+++ b/core/cache/graph/production_gate_test.go
@@ -89,7 +89,7 @@ func testLivenessHeavyMix(t *testing.T) {
 					c.AddEdgeWithExpiration(tail, head, 1, exp)
 					c.PutEdgeWithExpiration(tail, head, 2, exp)
 					c.GetEdgeDetail(tail, head)
-					c.Neighbor(tail, 1, 4, false, false)
+					c.Neighbor(tail, 1, 4, false, false, nil)
 					c.DeleteEdge(tail, head)
 					c.DeleteVertex(k)
 				}
@@ -294,8 +294,8 @@ func testInputNaNInf(t *testing.T) {
 	_, _, _ = c.GetEdgeDetail("a", "b")
 	_, _, _ = c.GetEdgeDetail("c", "d")
 	_, _, _ = c.GetEdgeDetail("e", "f")
-	_ = c.Neighbor("a", 1, 4, false, false)
-	_ = c.Neighbor("c", 1, 4, true, false) // also exercise the TF-IDF path
+	_ = c.Neighbor("a", 1, 4, false, false, nil)
+	_ = c.Neighbor("c", 1, 4, true, false, nil) // also exercise the TF-IDF path
 }
 
 // testInputDeleteMissing verifies idempotent delete: deleting an absent
@@ -351,7 +351,7 @@ func testReadConsistencyAfterExpiry(t *testing.T) {
 	if _, _, ok := c.GetEdgeDetail("a", "b"); ok {
 		t.Fatalf("C1: GetEdgeDetail still surfaces expired edge")
 	}
-	g := c.Neighbor("a", 2, 8, false, false)
+	g := c.Neighbor("a", 2, 8, false, false, nil)
 	if len(g.Vertices) != 0 || len(g.Edges) != 0 {
 		t.Fatalf("C1: Neighbor returned %d vertices and %d edges from an all-expired seed",
 			len(g.Vertices), len(g.Edges))
@@ -406,7 +406,7 @@ func testReadConsistencyNeighborChurn(t *testing.T) {
 					return
 				default:
 				}
-				_ = c.Neighbor(keyFromInt(i%8), 2, 4, i%2 == 0, false)
+				_ = c.Neighbor(keyFromInt(i%8), 2, 4, i%2 == 0, false, nil)
 			}
 		}()
 	}
@@ -463,7 +463,7 @@ func testTopologySelfLoop(t *testing.T) {
 	if !ok || w != 2.5 {
 		t.Fatalf("T1: self-loop weight wrong (got %v, ok=%v, want 2.5)", w, ok)
 	}
-	g := c.Neighbor("x", 1, 4, false, false)
+	g := c.Neighbor("x", 1, 4, false, false, nil)
 	if _, ok := g.Edges["x"]["x"]; !ok {
 		t.Fatalf("T1: Neighbor lost the self-loop edge: %#v", g.Edges)
 	}

--- a/server/service/backend.go
+++ b/server/service/backend.go
@@ -68,13 +68,19 @@ type Backend interface {
 	// neighborhood traversal. selectSmallest steers the per-hop top-k
 	// pruning: the k smallest-weight edges are kept when true, the k
 	// largest when false (#560), so the caller's Objective governs which
-	// edges survive both pruning and any later reduction.
+	// edges survive both pruning and any later reduction. keep is an
+	// optional frontier predicate (#601): when non-nil, a head is admitted
+	// to the frontier only if keep(head) is true, evaluated BEFORE scoring
+	// and the per-hop top-k prune so the surviving edges are the k strongest
+	// *matching* neighbours. The seed is exempt. A nil keep accepts every
+	// head (unfiltered traversal).
 	NeighborWithExpirationsContext(
 		ctx context.Context,
 		seed string,
 		step, k int,
 		tfidf bool,
 		selectSmallest bool,
+		keep func(string) bool,
 	) (*coregraph.Graph[string, *pb.Vertex], map[string]map[string]time.Time, error)
 
 	// prefix scan / count / delete. ScanByPrefix invokes fn for each live

--- a/server/service/fake_backend_test.go
+++ b/server/service/fake_backend_test.go
@@ -20,10 +20,12 @@ type fakeBackend struct {
 
 	// captured args from the most recent NeighborWithExpirationsContext
 	// call, so tests can assert how the Illuminate handler maps Objective
-	// onto the per-hop pruning direction (#560).
+	// onto the per-hop pruning direction (#560) and threads the optional
+	// frontier predicate (#601).
 	neighborCalls           int
 	lastNeighborTFIDF       bool
 	lastNeighborSelectSmall bool
+	lastNeighborKeep        func(string) bool
 
 	putVerticesCalls int
 	deleteVertices   int
@@ -138,10 +140,12 @@ func (f *fakeBackend) NeighborWithExpirationsContext(
 	step, k int,
 	tfidf bool,
 	selectSmallest bool,
+	keep func(string) bool,
 ) (*coregraph.Graph[string, *pb.Vertex], map[string]map[string]time.Time, error) {
 	f.neighborCalls++
 	f.lastNeighborTFIDF = tfidf
 	f.lastNeighborSelectSmall = selectSmallest
+	f.lastNeighborKeep = keep
 	if f.neighborErr != nil {
 		return nil, nil, f.neighborErr
 	}

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -350,7 +350,7 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 	objective := request.GetObjective()
 	selectSmallest := objective == pb.Objective_OBJECTIVE_MINIMIZE
 	traversalStart := time.Now()
-	g, expirations, err := s.cache.NeighborWithExpirationsContext(ctx, request.GetSeed(), int(request.GetStep()), int(request.GetK()), useTFIDF, selectSmallest)
+	g, expirations, err := s.cache.NeighborWithExpirationsContext(ctx, request.GetSeed(), int(request.GetStep()), int(request.GetK()), useTFIDF, selectSmallest, nil)
 	traversalDur := time.Since(traversalStart)
 	if err != nil {
 		return nil, ctxToConnect(err)


### PR DESCRIPTION
## What

Thread an optional `keep func(S) bool` frontier predicate through the
`Neighbor*` family that powers Illuminate:

- `Neighbor`, `NeighborContext`, `NeighborWithExpirationsContext`, and the
  private `neighborContext` all gain a trailing `keep func(S) bool` arg.
- The predicate is applied inside `processTail` **right after**
  `c.edges.resolveID(headID)` and **before** weight scoring and the per-hop
  `Top(k)`/`Bottom(k)` prune, so top-k selects the *k strongest accepted*
  neighbours per hop (not "top-k then filter to maybe-empty").
- The **seed is exempt** (anchor) — it is placed on `g.Vertices` before the
  walk and never passed through `keep`.
- A `nil` predicate preserves the exact pre-change unfiltered traversal.
- Because the next-hop frontier derives from the surviving edges, a matching
  vertex reachable **only** through a rejected bridge is dropped
  (induced-subgraph semantics).

## Why this layer

`core` stays generic — `keep` is just a predicate over `S`, with **no**
string/prefix/pb knowledge. The server will build the concrete
`strings.HasPrefix` closure from `IlluminateRequest` in #602. This PR is the
foundational, behaviour-preserving step of Epic #600.

## Call sites

All existing callers pass `nil` (no behaviour change): core tests, the
`example/main.go`, bench/production-gate suites, and the server's Illuminate
handler. The server `Backend` interface + its test fake gained the matching
parameter (the fake captures it as `lastNeighborKeep` for #602 to assert).

## Tests

New `TestGraphCache_NeighborKeep` in `cache_test.go` with 5 sub-tests:
`KeepNil_Unchanged`, `KeepExcludesNonMatching`, `SeedRetainedWhenItFails`,
`KeepBeforeTopK` (the load-bearing ordering proof), and
`NonMatchingBridgeBlocks` (induced-subgraph).

Quality gate: `gofmt -l` clean; `core`, `server` (vet + test), and root
(cli + tests/integration) all green.

Closes #601