### PR TITLE
feat(illuminate): vertex_prefix proto field + server HasPrefix frontier filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ Examples:
 - `algorithm=spt objective=max`  — **most-relevant** path tree
 - `weighting=tfidf`              — suppress hub vertices like "popular" items
 
+**Scoping the frontier** — `vertex_prefix` (when non-empty) restricts the walk
+to vertices whose key carries that prefix; the seed is always retained as the
+anchor even if it does not match, and an empty value means no filter. The
+filter is applied during the walk — BEFORE the per-hop top-k prune and BEFORE
+the MST/SPT reduction — so the result is the prefix-*induced* subgraph. One
+consequence to keep in mind: `vertex_prefix` together with `algorithm=mst|spt`
+yields a tree over that induced subgraph, **not** a true shortest path in the
+full graph — a matching vertex reachable only through a non-matching bridge
+vertex is excluded, because the bridge is not traversable.
+
 You don't fetch a wall of edges and post-process — the server returns exactly
 the shape you asked for.
 

--- a/pb/graph/v1/graph.pb.go
+++ b/pb/graph/v1/graph.pb.go
@@ -639,13 +639,19 @@ func (x *Graph) GetEdges() []*Edge {
 }
 
 type IlluminateRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Seed          string                 `protobuf:"bytes,1,opt,name=seed,proto3" json:"seed,omitempty"`
-	Step          uint32                 `protobuf:"varint,2,opt,name=step,proto3" json:"step,omitempty"`
-	K             uint32                 `protobuf:"varint,3,opt,name=k,proto3" json:"k,omitempty"`
-	Algorithm     Algorithm              `protobuf:"varint,6,opt,name=algorithm,proto3,enum=graph.v1.Algorithm" json:"algorithm,omitempty"`
-	Objective     Objective              `protobuf:"varint,7,opt,name=objective,proto3,enum=graph.v1.Objective" json:"objective,omitempty"`
-	Weighting     Weighting              `protobuf:"varint,8,opt,name=weighting,proto3,enum=graph.v1.Weighting" json:"weighting,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Seed      string                 `protobuf:"bytes,1,opt,name=seed,proto3" json:"seed,omitempty"`
+	Step      uint32                 `protobuf:"varint,2,opt,name=step,proto3" json:"step,omitempty"`
+	K         uint32                 `protobuf:"varint,3,opt,name=k,proto3" json:"k,omitempty"`
+	Algorithm Algorithm              `protobuf:"varint,6,opt,name=algorithm,proto3,enum=graph.v1.Algorithm" json:"algorithm,omitempty"`
+	Objective Objective              `protobuf:"varint,7,opt,name=objective,proto3,enum=graph.v1.Objective" json:"objective,omitempty"`
+	Weighting Weighting              `protobuf:"varint,8,opt,name=weighting,proto3,enum=graph.v1.Weighting" json:"weighting,omitempty"`
+	// vertex_prefix, when non-empty, restricts the traversal frontier to
+	// vertices whose key has this prefix. The seed is always retained as the
+	// anchor even if it does not match. Empty = no filter. Applied BEFORE
+	// per-hop top-k and BEFORE the MST/SPT reduction (induced-subgraph
+	// semantics: non-matching vertices are not traversable bridges).
+	VertexPrefix  string `protobuf:"bytes,9,opt,name=vertex_prefix,json=vertexPrefix,proto3" json:"vertex_prefix,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -720,6 +726,13 @@ func (x *IlluminateRequest) GetWeighting() Weighting {
 		return x.Weighting
 	}
 	return Weighting_WEIGHTING_UNSPECIFIED
+}
+
+func (x *IlluminateRequest) GetVertexPrefix() string {
+	if x != nil {
+		return x.VertexPrefix
+	}
+	return ""
 }
 
 type IlluminateResponse struct {
@@ -3054,14 +3067,15 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"expiration\"[\n" +
 	"\x05Graph\x12,\n" +
 	"\bvertices\x18\x01 \x03(\v2\x10.graph.v1.VertexR\bvertices\x12$\n" +
-	"\x05edges\x18\x02 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\"\x83\x02\n" +
+	"\x05edges\x18\x02 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\"\xa8\x02\n" +
 	"\x11IlluminateRequest\x12\x12\n" +
 	"\x04seed\x18\x01 \x01(\tR\x04seed\x12\x12\n" +
 	"\x04step\x18\x02 \x01(\rR\x04step\x12\f\n" +
 	"\x01k\x18\x03 \x01(\rR\x01k\x121\n" +
 	"\talgorithm\x18\x06 \x01(\x0e2\x13.graph.v1.AlgorithmR\talgorithm\x121\n" +
 	"\tobjective\x18\a \x01(\x0e2\x13.graph.v1.ObjectiveR\tobjective\x121\n" +
-	"\tweighting\x18\b \x01(\x0e2\x13.graph.v1.WeightingR\tweightingJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\x05tfidfR\foptimization\";\n" +
+	"\tweighting\x18\b \x01(\x0e2\x13.graph.v1.WeightingR\tweighting\x12#\n" +
+	"\rvertex_prefix\x18\t \x01(\tR\fvertexPrefixJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\x05tfidfR\foptimization\";\n" +
 	"\x12IlluminateResponse\x12%\n" +
 	"\x05graph\x18\x01 \x01(\v2\x0f.graph.v1.GraphR\x05graph\"$\n" +
 	"\x10GetVertexRequest\x12\x10\n" +

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -95,6 +95,12 @@ message IlluminateRequest {
   Algorithm algorithm = 6;
   Objective objective = 7;
   Weighting weighting = 8;
+  // vertex_prefix, when non-empty, restricts the traversal frontier to
+  // vertices whose key has this prefix. The seed is always retained as the
+  // anchor even if it does not match. Empty = no filter. Applied BEFORE
+  // per-hop top-k and BEFORE the MST/SPT reduction (induced-subgraph
+  // semantics: non-matching vertices are not traversable bridges).
+  string vertex_prefix = 9;
 }
 
 message IlluminateResponse {

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -349,8 +350,19 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 	// the costliest edges. UNSPECIFIED resolves to MAXIMIZE (strongest edges).
 	objective := request.GetObjective()
 	selectSmallest := objective == pb.Objective_OBJECTIVE_MINIMIZE
+	// vertex_prefix (#602) scopes the traversal frontier to vertices whose key
+	// carries the prefix. The server owns the concrete predicate (S = string
+	// here); core only ever sees keep func(string) bool (#601). An empty prefix
+	// leaves keep nil, i.e. an unfiltered walk. The closure is applied inside
+	// the BFS BEFORE per-hop top-k and BEFORE any MST/SPT reduction below, so
+	// the result is an induced subgraph (non-matching vertices are not
+	// traversable bridges) and the seed stays as the anchor.
+	var keep func(string) bool
+	if p := request.GetVertexPrefix(); p != "" {
+		keep = func(s string) bool { return strings.HasPrefix(s, p) }
+	}
 	traversalStart := time.Now()
-	g, expirations, err := s.cache.NeighborWithExpirationsContext(ctx, request.GetSeed(), int(request.GetStep()), int(request.GetK()), useTFIDF, selectSmallest, nil)
+	g, expirations, err := s.cache.NeighborWithExpirationsContext(ctx, request.GetSeed(), int(request.GetStep()), int(request.GetK()), useTFIDF, selectSmallest, keep)
 	traversalDur := time.Since(traversalStart)
 	if err != nil {
 		return nil, ctxToConnect(err)

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -667,6 +667,53 @@ func TestLanternService_FakeBackend_Illuminate_ObjectiveSteersPruning(t *testing
 	}
 }
 
+// TestLanternService_FakeBackend_Illuminate_VertexPrefixBuildsKeep pins the
+// #602 contract at the service boundary: the Illuminate handler must translate
+// a non-empty vertex_prefix into a HasPrefix keep predicate it hands the
+// backend, and leave keep nil when the prefix is empty (an unfiltered walk).
+// The concrete string predicate lives in the server (core stays generic), so
+// this is the only seam that can prove the closure shape.
+func TestLanternService_FakeBackend_Illuminate_VertexPrefixBuildsKeep(t *testing.T) {
+	t.Run("empty prefix leaves keep nil", func(t *testing.T) {
+		fb := newFakeBackend()
+		svc := NewLanternService(fb)
+		if _, err := svc.Illuminate(context.Background(), &pb.IlluminateRequest{
+			Seed: "a", Step: 1, K: 3,
+		}); err != nil {
+			t.Fatalf("Illuminate: %v", err)
+		}
+		if fb.neighborCalls != 1 {
+			t.Fatalf("neighborCalls = %d, want 1", fb.neighborCalls)
+		}
+		if fb.lastNeighborKeep != nil {
+			t.Error("lastNeighborKeep = non-nil, want nil for empty vertex_prefix")
+		}
+	})
+
+	t.Run("non-empty prefix builds HasPrefix keep", func(t *testing.T) {
+		fb := newFakeBackend()
+		svc := NewLanternService(fb)
+		if _, err := svc.Illuminate(context.Background(), &pb.IlluminateRequest{
+			Seed: "users/1", Step: 1, K: 3, VertexPrefix: "users/",
+		}); err != nil {
+			t.Fatalf("Illuminate: %v", err)
+		}
+		if fb.neighborCalls != 1 {
+			t.Fatalf("neighborCalls = %d, want 1", fb.neighborCalls)
+		}
+		keep := fb.lastNeighborKeep
+		if keep == nil {
+			t.Fatal("lastNeighborKeep = nil, want non-nil for vertex_prefix=\"users/\"")
+		}
+		if !keep("users/42") {
+			t.Error(`keep("users/42") = false, want true`)
+		}
+		if keep("orgs/42") {
+			t.Error(`keep("orgs/42") = true, want false`)
+		}
+	})
+}
+
 // seedStar builds a directed star: seed "s" fans out to h1..h5 with distinct
 // weights 1..5 (and nothing else), so a per-hop prune at k < 5 must choose
 // which heads survive. Used by the #560 min-vs-max-differ end-to-end test.

--- a/tests/integration/illuminate_prefix_test.go
+++ b/tests/integration/illuminate_prefix_test.go
@@ -1,0 +1,182 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// TestLantern_Illuminate_VertexPrefix drives the #602 vertex_prefix frontier
+// filter end-to-end through the raw Connect-Go client. The Go SDK does not yet
+// expose a WithVertexPrefix option (that is #603), so these full-stack
+// assertions speak the wire pb.IlluminateRequest directly — the same pattern
+// prefix_scan_test.go uses for RPCs the SDK has not wrapped. Fixtures carry an
+// explicit Expiration to dodge the timestamppb-nil → 1970 trap (#250 lesson).
+func TestLantern_Illuminate_VertexPrefix(t *testing.T) {
+	exp := timestamppb.New(time.Now().Add(time.Hour))
+
+	// putGraph stands up a fresh raw client, seeds the supplied string-valued
+	// vertices and directed weighted edges, and returns the client + ctx. The
+	// prefix index is irrelevant here: the keep predicate is a pure HasPrefix
+	// check applied during the BFS walk, independent of any index.
+	putGraph := func(t *testing.T, keys []string, edges []*pb.Edge) (graphv1connect.LanternServiceClient, context.Context) {
+		t.Helper()
+		c, _ := newRawConnectClient(t, false)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+		verts := make([]*pb.Vertex, len(keys))
+		for i, k := range keys {
+			verts[i] = &pb.Vertex{Key: k, Value: &pb.Vertex_String_{String_: k}, Expiration: exp}
+		}
+		if _, err := c.PutVertices(ctx, connect.NewRequest(&pb.PutVerticesRequest{Vertices: verts})); err != nil {
+			t.Fatalf("PutVertices: %v", err)
+		}
+		for _, e := range edges {
+			e.Expiration = exp
+		}
+		if _, err := c.PutEdges(ctx, connect.NewRequest(&pb.PutEdgesRequest{Edges: edges})); err != nil {
+			t.Fatalf("PutEdges: %v", err)
+		}
+		return c, ctx
+	}
+
+	keySet := func(vs []*pb.Vertex) map[string]bool {
+		m := make(map[string]bool, len(vs))
+		for _, v := range vs {
+			m[v.Key] = true
+		}
+		return m
+	}
+
+	t.Run("filters to matching and retains non-matching seed", func(t *testing.T) {
+		// Seed "root" does not carry the "p:" prefix, yet must survive as the
+		// anchor; "p:a"/"p:b" match and stay; "q:x" is filtered out.
+		c, ctx := putGraph(t,
+			[]string{"root", "p:a", "p:b", "q:x"},
+			[]*pb.Edge{
+				{Tail: "root", Head: "p:a", Weight: 1},
+				{Tail: "root", Head: "p:b", Weight: 1},
+				{Tail: "root", Head: "q:x", Weight: 1},
+			},
+		)
+		resp, err := c.Illuminate(ctx, connect.NewRequest(&pb.IlluminateRequest{
+			Seed: "root", Step: 3, K: 10, VertexPrefix: "p:",
+		}))
+		if err != nil {
+			t.Fatalf("Illuminate: %v", err)
+		}
+		got := keySet(resp.Msg.GetGraph().GetVertices())
+		for _, want := range []string{"root", "p:a", "p:b"} {
+			if !got[want] {
+				t.Errorf("missing vertex %q (got %v)", want, got)
+			}
+		}
+		if got["q:x"] {
+			t.Errorf("non-matching vertex q:x present (got %v)", got)
+		}
+	})
+
+	t.Run("filters before per-hop top-k", func(t *testing.T) {
+		// s's three strongest edges are all non-matching (100/99/98); the
+		// matching edges are weaker (10/9). With k=2, a filter applied AFTER
+		// top-k would select {q:1,q:2} and then drop them, leaving only the
+		// seed. Applying the filter BEFORE top-k must instead surface the two
+		// strongest MATCHING neighbours.
+		c, ctx := putGraph(t,
+			[]string{"s", "q:1", "q:2", "q:3", "p:1", "p:2"},
+			[]*pb.Edge{
+				{Tail: "s", Head: "q:1", Weight: 100},
+				{Tail: "s", Head: "q:2", Weight: 99},
+				{Tail: "s", Head: "q:3", Weight: 98},
+				{Tail: "s", Head: "p:1", Weight: 10},
+				{Tail: "s", Head: "p:2", Weight: 9},
+			},
+		)
+		resp, err := c.Illuminate(ctx, connect.NewRequest(&pb.IlluminateRequest{
+			Seed: "s", Step: 1, K: 2, VertexPrefix: "p:",
+		}))
+		if err != nil {
+			t.Fatalf("Illuminate: %v", err)
+		}
+		got := keySet(resp.Msg.GetGraph().GetVertices())
+		for _, want := range []string{"s", "p:1", "p:2"} {
+			if !got[want] {
+				t.Errorf("missing vertex %q (got %v) — filter likely applied AFTER top-k", want, got)
+			}
+		}
+		for _, no := range []string{"q:1", "q:2", "q:3"} {
+			if got[no] {
+				t.Errorf("non-matching vertex %q present (got %v)", no, got)
+			}
+		}
+	})
+
+	t.Run("induced subgraph under SPT and MST drops vertices reachable only via non-matching bridge", func(t *testing.T) {
+		for _, algo := range []pb.Algorithm{
+			pb.Algorithm_ALGORITHM_SHORTEST_PATH_TREE,
+			pb.Algorithm_ALGORITHM_MINIMUM_SPANNING_TREE,
+		} {
+			t.Run(algo.String(), func(t *testing.T) {
+				// p:leaf matches the prefix but is reachable ONLY through the
+				// non-matching bridge q:bridge. Filtering the bridge during the
+				// walk makes p:leaf unreachable (induced-subgraph semantics), so
+				// the tree contains only p:root and the directly-reachable
+				// p:direct — never a true shortest path through the full graph.
+				c, ctx := putGraph(t,
+					[]string{"p:root", "q:bridge", "p:leaf", "p:direct"},
+					[]*pb.Edge{
+						{Tail: "p:root", Head: "q:bridge", Weight: 5},
+						{Tail: "q:bridge", Head: "p:leaf", Weight: 5},
+						{Tail: "p:root", Head: "p:direct", Weight: 1},
+					},
+				)
+				resp, err := c.Illuminate(ctx, connect.NewRequest(&pb.IlluminateRequest{
+					Seed: "p:root", Step: 3, K: 10, VertexPrefix: "p:", Algorithm: algo,
+				}))
+				if err != nil {
+					t.Fatalf("Illuminate(%s): %v", algo, err)
+				}
+				got := keySet(resp.Msg.GetGraph().GetVertices())
+				for _, want := range []string{"p:root", "p:direct"} {
+					if !got[want] {
+						t.Errorf("%s: missing vertex %q (got %v)", algo, want, got)
+					}
+				}
+				if got["q:bridge"] {
+					t.Errorf("%s: non-matching bridge q:bridge present (got %v)", algo, got)
+				}
+				if got["p:leaf"] {
+					t.Errorf("%s: p:leaf present but only reachable via filtered bridge (got %v)", algo, got)
+				}
+			})
+		}
+	})
+
+	t.Run("empty vertex_prefix is no filter", func(t *testing.T) {
+		c, ctx := putGraph(t,
+			[]string{"root", "p:a", "p:b", "q:x"},
+			[]*pb.Edge{
+				{Tail: "root", Head: "p:a", Weight: 1},
+				{Tail: "root", Head: "p:b", Weight: 1},
+				{Tail: "root", Head: "q:x", Weight: 1},
+			},
+		)
+		resp, err := c.Illuminate(ctx, connect.NewRequest(&pb.IlluminateRequest{
+			Seed: "root", Step: 3, K: 10, VertexPrefix: "",
+		}))
+		if err != nil {
+			t.Fatalf("Illuminate: %v", err)
+		}
+		got := keySet(resp.Msg.GetGraph().GetVertices())
+		for _, want := range []string{"root", "p:a", "p:b", "q:x"} {
+			if !got[want] {
+				t.Errorf("missing vertex %q with empty prefix (got %v)", want, got)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## What

Adds `IlluminateRequest.vertex_prefix` (proto field 9) and wires it through the server. When non-empty, the walk frontier is scoped to vertices whose key carries the prefix; the server owns the concrete `strings.HasPrefix` predicate and hands it to the core BFS as the `keep func(string) bool` seam landed in #601 — **core stays generic** (no string/prefix knowledge).

This is the end-to-end MVP that makes prefix-scoped `Illuminate` work over raw Connect/gRPC. It unblocks #603 (Go SDK option) and #605 (Node SDK option), which need this proto field.

## Semantics

- Applied **during the walk**, BEFORE the per-hop top-k prune and BEFORE the MST/SPT reduction → result is the prefix-**induced** subgraph (non-matching vertices are not traversable bridges).
- The **seed is always retained** as the anchor even if it does not match.
- **Empty = no filter** (`keep` stays nil → unfiltered walk).
- No change to `optimizer.go` or `core/graph` — MST/SPT inherit the induced subgraph for free.

## Validation decision

**No** length validation was added for `vertex_prefix`. The existing prefix-scan RPCs (`CountVerticesByPrefix`/`DeleteVerticesByPrefix`) are not in the validation interceptor either, and an overlong prefix is harmless (matches nothing, returns fast). Adding a `LANTERN_MAX_KEY_LEN` check only for Illuminate would be an inconsistent special case.

## Tests

- **server/service** (`service_test.go`): unit `t.Run` proving empty prefix → nil `keep`, non-empty → `HasPrefix` closure (asserted via the fake backend's `lastNeighborKeep` capture).
- **tests/integration** (`illuminate_prefix_test.go`, raw Connect client since the SDK option is #603):
  - filters to matching + retains a non-matching seed;
  - **filters BEFORE top-k** — seed whose k strongest neighbours are non-matching returns the k strongest *matching* ones (ordering proof);
  - **SPT and MST** induced subgraph drops a matching vertex reachable only via a non-matching bridge;
  - empty `vertex_prefix` == no filter.

## Codegen

`go generate ./...` (buf, never `--clean`) — only field 9 added to `graph.pb.go`.

## Quality gate

`gofmt -l` clean; `pb`, `server` (vet+test), and root (incl. `tests/integration`) all green.

Closes #602