### PR TITLE
feat(sdks/go): add WithVertexPrefix IlluminateOption

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	connectrpc.com/grpchealth v1.4.0
 	github.com/anaregdesign/lantern/core v0.5.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
-	github.com/anaregdesign/lantern/pb v0.4.0
+	github.com/anaregdesign/lantern/pb v0.5.0
 	github.com/anaregdesign/lantern/sdks/go v0.12.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -587,16 +587,17 @@ func NewGraph() *Graph {
 }
 
 // IlluminateOption configures a single Illuminate call. Pass any combination
-// of WithStep, WithK, WithAlgorithm, WithObjective, and WithWeighting to
-// Illuminate. See #410 for the orthogonal-axes design.
+// of WithStep, WithK, WithAlgorithm, WithObjective, WithWeighting, and
+// WithVertexPrefix to Illuminate. See #410 for the orthogonal-axes design.
 type IlluminateOption func(*illuminateConfig)
 
 type illuminateConfig struct {
-	step      uint32
-	k         uint32
-	algorithm Algorithm
-	objective Objective
-	weighting Weighting
+	step         uint32
+	k            uint32
+	algorithm    Algorithm
+	objective    Objective
+	weighting    Weighting
+	vertexPrefix string
 }
 
 // WithStep sets the BFS depth for an Illuminate call.
@@ -631,10 +632,23 @@ func WithWeighting(w Weighting) IlluminateOption {
 	return func(c *illuminateConfig) { c.weighting = w }
 }
 
+// WithVertexPrefix restricts the Illuminate traversal frontier to vertices
+// whose key has the given prefix. The seed is always retained as the anchor
+// even if it does not match. Empty (the default) = no filter. The filter is
+// applied server-side BEFORE per-hop top-k and before any Algorithm-driven
+// MST/SPT reduction: the result is the prefix-induced subgraph. Note that
+// WithVertexPrefix together with WithAlgorithm(MST|SPT) yields a tree over
+// that induced subgraph, NOT a true shortest path in the full graph — a
+// matching vertex reachable only via a non-matching bridge vertex is excluded.
+func WithVertexPrefix(prefix string) IlluminateOption {
+	return func(c *illuminateConfig) { c.vertexPrefix = prefix }
+}
+
 // Illuminate runs a k-bounded BFS from seed, returning the resulting subgraph.
-// Configure step, k, algorithm, objective, and weighting via IlluminateOption
-// values; any option omitted defaults to its zero value, which the server
-// resolves to (step=0, k=0, no reduction, RAW weighting). See #410.
+// Configure step, k, algorithm, objective, weighting, and vertex prefix via
+// IlluminateOption values; any option omitted defaults to its zero value, which
+// the server resolves to (step=0, k=0, no reduction, RAW weighting, no prefix
+// filter). See #410.
 func (l *Lantern) Illuminate(ctx context.Context, seed string, opts ...IlluminateOption) (*Graph, error) {
 	var cfg illuminateConfig
 	for _, opt := range opts {
@@ -643,12 +657,13 @@ func (l *Lantern) Illuminate(ctx context.Context, seed string, opts ...Illuminat
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
 	resp, err := unary(ctx, &pb.IlluminateRequest{
-		Seed:      seed,
-		Step:      cfg.step,
-		K:         cfg.k,
-		Algorithm: cfg.algorithm,
-		Objective: cfg.objective,
-		Weighting: cfg.weighting,
+		Seed:         seed,
+		Step:         cfg.step,
+		K:            cfg.k,
+		Algorithm:    cfg.algorithm,
+		Objective:    cfg.objective,
+		Weighting:    cfg.weighting,
+		VertexPrefix: cfg.vertexPrefix,
 	}, l.client.Illuminate)
 	if err != nil {
 		return nil, err

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -246,3 +246,52 @@ func TestAddContribIDWiring(t *testing.T) {
 		}
 	})
 }
+
+// captureIlluminate is a fake LanternServiceClient that records every
+// IlluminateRequest it receives. It embeds the interface (left nil) so it
+// satisfies the full surface while only overriding Illuminate.
+type captureIlluminate struct {
+	graphv1connect.LanternServiceClient
+	reqs []*pb.IlluminateRequest
+}
+
+func (c *captureIlluminate) Illuminate(_ context.Context, req *connect.Request[pb.IlluminateRequest]) (*connect.Response[pb.IlluminateResponse], error) {
+	c.reqs = append(c.reqs, req.Msg)
+	return connect.NewResponse(&pb.IlluminateResponse{Graph: &pb.Graph{}}), nil
+}
+
+// TestWithVertexPrefixWiring verifies WithVertexPrefix round-trips onto the
+// emitted IlluminateRequest and that omitting it leaves the field empty (the
+// server's no-filter default).
+func TestWithVertexPrefixWiring(t *testing.T) {
+	newClient := func(t *testing.T) (*Lantern, *captureIlluminate) {
+		t.Helper()
+		l := mustLantern(t)
+		capt := &captureIlluminate{}
+		l.client = capt
+		return l, capt
+	}
+
+	t.Run("default leaves vertex_prefix empty", func(t *testing.T) {
+		l, capt := newClient(t)
+		if _, err := l.Illuminate(context.Background(), "seed"); err != nil {
+			t.Fatalf("Illuminate: %v", err)
+		}
+		if len(capt.reqs) != 1 {
+			t.Fatalf("want 1 request, got %d", len(capt.reqs))
+		}
+		if got := capt.reqs[0].GetVertexPrefix(); got != "" {
+			t.Fatalf("default must send empty vertex_prefix, got %q", got)
+		}
+	})
+
+	t.Run("WithVertexPrefix sets the field", func(t *testing.T) {
+		l, capt := newClient(t)
+		if _, err := l.Illuminate(context.Background(), "users/1", WithVertexPrefix("users/")); err != nil {
+			t.Fatalf("Illuminate: %v", err)
+		}
+		if got := capt.reqs[0].GetVertexPrefix(); got != "users/" {
+			t.Fatalf("vertex_prefix want %q got %q", "users/", got)
+		}
+	})
+}

--- a/sdks/go/example/main.go
+++ b/sdks/go/example/main.go
@@ -234,6 +234,14 @@ func main() {
 			+--> h
 			+--> i
 
+			A fourth, orthogonal axis scopes the traversal frontier:
+
+				- WithVertexPrefix: restrict the walk to vertices whose key
+				  shares the given prefix (the seed is always kept as the
+				  anchor; empty = no filter). The filter is applied before
+				  per-hop top-k and before any MST/SPT reduction, so the
+				  result is the prefix-induced subgraph.
+
 	*/
 	// Add edges
 	if err := cli.AddEdge(ctx, "a", "b", 1, 1*time.Minute); err != nil {

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	github.com/anaregdesign/lantern/core v0.5.0
-	github.com/anaregdesign/lantern/pb v0.4.0
+	github.com/anaregdesign/lantern/pb v0.5.0
 	golang.org/x/net v0.55.0
 	google.golang.org/protobuf v1.36.11
 )


### PR DESCRIPTION
## Summary

Wires the `vertex_prefix` Illuminate axis (added to the proto + server in #602,
released as `pb/v0.5.0`) into the Go SDK as a `WithVertexPrefix(string)`
functional option, following the orthogonal-axes pattern from #410.

Closes #603.

## Changes

- **`sdks/go/client.go`**
  - Add `vertexPrefix string` to `illuminateConfig`.
  - Add `WithVertexPrefix(prefix string) IlluminateOption`. Empty default = no
    filter; non-empty scopes the traversal frontier to keys with that prefix.
  - Set `VertexPrefix: cfg.vertexPrefix` on the emitted `pb.IlluminateRequest`.
  - Refresh the `IlluminateOption` / `Illuminate` doc comments to list the new
    option and its no-prefix-filter default.
- **`sdks/go/client_test.go`** — extend the fake-client suite with a
  `captureIlluminate` seam and `TestWithVertexPrefixWiring` (two sub-tests:
  default leaves `vertex_prefix` empty; `WithVertexPrefix("users/")` round-trips
  onto the request). No new `*_test.go` sibling files.
- **`sdks/go/go.mod`** — bump `github.com/anaregdesign/lantern/pb` `v0.4.0 → v0.5.0`
  (the release that carries the `VertexPrefix` field). Local `replace` to `../../pb`
  is unchanged, so `go.sum` is untouched.
- **`sdks/go/example/main.go`** — document the prefix axis in the Illuminate
  example comment.

## Behaviour notes

The filter is applied **server-side**, BEFORE per-hop top-k and BEFORE any
`WithAlgorithm(MST|SPT)` reduction — the result is the **prefix-induced
subgraph**. The seed is always retained as the anchor even if it does not match.
Consequently `WithVertexPrefix` + `WithAlgorithm(MST|SPT)` yields a tree over the
induced subgraph, **not** a true shortest path in the full graph: a matching
vertex reachable only via a non-matching bridge vertex is excluded. This caveat
is documented on the option and in the example.

## Verification

- `gofmt -l sdks/go` → clean
- `(cd sdks/go && go vet ./... && go test ./...)` → green
- root `go build ./...` + `go test ./...` → green (incl. `tests/integration`)

## Naming (locked, per #600 epic)

proto `vertex_prefix` · Go `WithVertexPrefix` · Node `vertexPrefix` ·
CLI `--prefix` · REPL/admin grammar `prefix=`.
