### PR TITLE
feat(cli): --prefix flag + REPL prefix= kwarg for illuminate

### DIFF
--- a/cli/cmd/illuminate.go
+++ b/cli/cmd/illuminate.go
@@ -14,6 +14,7 @@ var (
 	illuminateAlgorithmStr string
 	illuminateObjectiveStr string
 	illuminateWeightingStr string
+	illuminatePrefixStr    string
 )
 
 // algorithmByName, objectiveByName, weightingByName map human-friendly
@@ -67,6 +68,16 @@ ORTHOGONAL ILLUMINATE AXES (#410)
                           tfidf re-score using TF-IDF over the per-vertex
                                 out-edge distribution
 
+FRONTIER FILTER (#604)
+  --prefix <string>     restrict the walk frontier to vertices whose key
+                        has this prefix. The seed is always kept as the
+                        anchor even if it does not match. Empty (default)
+                        = no filter. The value is case-sensitive. Applied
+                        server-side BEFORE per-hop top-k and any --algorithm
+                        reduction, so --prefix with --algorithm mst|spt
+                        yields a tree over the prefix-induced subgraph, NOT
+                        a shortest path in the full graph.
+
 OUTPUT
   JSON object on stdout:
     {
@@ -93,6 +104,9 @@ EXAMPLES
 
   # 3-hop relevance-weighted SPT (formerly the "inverse-SPT" enum value)
   lantern illuminate alice --step 3 --k 20 --algorithm spt --objective max
+
+  # 2-hop walk restricted to the users/ keyspace (seed always kept)
+  lantern illuminate alice --step 2 --k 5 --prefix users/
 `,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -114,14 +128,17 @@ EXAMPLES
 		}
 		defer func() { _ = cli.Close() }()
 
-		g, err := cli.Illuminate(
-			cmd.Context(), args[0],
+		opts := []client.IlluminateOption{
 			client.WithStep(illuminateStep),
 			client.WithK(illuminateK),
 			client.WithAlgorithm(algo),
 			client.WithObjective(obj),
 			client.WithWeighting(w),
-		)
+		}
+		if illuminatePrefixStr != "" {
+			opts = append(opts, client.WithVertexPrefix(illuminatePrefixStr))
+		}
+		g, err := cli.Illuminate(cmd.Context(), args[0], opts...)
 		if err != nil {
 			return err
 		}
@@ -137,5 +154,6 @@ func init() {
 	illuminateCmd.Flags().StringVar(&illuminateAlgorithmStr, "algorithm", "none", "post-traversal reduction: none|mst|spt (#410)")
 	illuminateCmd.Flags().StringVar(&illuminateObjectiveStr, "objective", "max", "optimisation direction: min|max; governs per-hop top-k pruning AND reduction (#560)")
 	illuminateCmd.Flags().StringVar(&illuminateWeightingStr, "weighting", "raw", "edge-weight transform before walk: raw|tfidf (#410)")
+	illuminateCmd.Flags().StringVar(&illuminatePrefixStr, "prefix", "", "restrict walk frontier to vertices with this key prefix; seed always kept, empty = no filter (#604)")
 	rootCmd.AddCommand(illuminateCmd)
 }

--- a/cli/parser/help_test.go
+++ b/cli/parser/help_test.go
@@ -13,7 +13,7 @@ import (
 // every verb in the dispatch table must appear in the text.
 
 func TestHelpText_EnumeratesIlluminateKwargs(t *testing.T) {
-	for _, kw := range []string{"algorithm=", "objective=", "weighting="} {
+	for _, kw := range []string{"algorithm=", "objective=", "weighting=", "prefix="} {
 		if !strings.Contains(HelpText, kw) {
 			t.Errorf("HelpText missing illuminate kwarg %q", kw)
 		}

--- a/cli/parser/model.go
+++ b/cli/parser/model.go
@@ -47,6 +47,7 @@ type Illuminate struct {
 	Algorithm string // "none" | "mst" | "spt" (default: "none")
 	Objective string // "min" | "max"           (default: "max")
 	Weighting string // "raw" | "tfidf"         (default: "raw")
+	Prefix    string // vertex-key prefix filter; "" (default) = no filter (#604)
 }
 
 // ScanVertices / ScanEdges back the `scan vertices` / `scan edges` REPL

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -316,18 +316,19 @@ func DeleteEdgeParam(s *Source) (*DeleteEdge, error) {
 	return m, nil
 }
 
-// IlluminateParam parses the modernised illuminate grammar (#410):
+// IlluminateParam parses the modernised illuminate grammar (#410, #604):
 //
-//	illuminate <seed> <step> <k> [algorithm=none|mst|spt] [objective=min|max] [weighting=raw|tfidf]
+//	illuminate <seed> <step> <k> [algorithm=none|mst|spt] [objective=min|max] [weighting=raw|tfidf] [prefix=<string>]
 //
-// The three keyword arguments may appear in any order and any subset.
-// Each defaults to the strongest-edge behaviour (algorithm=none,
+// The keyword arguments may appear in any order and any subset. The three
+// closed-set axes default to the strongest-edge behaviour (algorithm=none,
 // objective=max, weighting=raw); objective defaults to max so a bare
 // illuminate keeps the top-k strongest neighbours and the per-hop
-// pruning matches the reduction direction (#560).
-// Unknown keyword names, malformed `key=value` tokens, or values
-// outside the canonical set above are rejected with a descriptive
-// error so the REPL can surface a usage hint.
+// pruning matches the reduction direction (#560). prefix is free-text and
+// defaults to empty (no frontier filter; #604).
+// Unknown keyword names, malformed `key=value` tokens, closed-set values
+// outside the canonical set above, or an empty prefix= value are rejected
+// with a descriptive error so the REPL can surface a usage hint.
 func IlluminateParam(s *Source) (*Illuminate, error) {
 	var err error
 	m := &Illuminate{Algorithm: "none", Objective: "max", Weighting: "raw"}
@@ -349,29 +350,35 @@ func IlluminateParam(s *Source) (*Illuminate, error) {
 		if !ok {
 			return nil, errors.New("illuminate: expected key=value token, got " + tok)
 		}
-		// Keyword KEY and the keyword VALUE for the three closed-set
-		// axes are case-insensitive — they only ever take values from
-		// a small fixed enum. See #437.
+		// The keyword KEY is always case-insensitive. The three closed-set
+		// axes also fold their VALUE because they only ever take a small
+		// fixed enum (#437); the free-text prefix VALUE is matched against
+		// vertex keys verbatim, so it stays case-SENSITIVE (#604).
 		key = strings.ToLower(key)
-		value = strings.ToLower(value)
+		lvalue := strings.ToLower(value)
 		switch key {
 		case "algorithm":
-			if !contains(IlluminateAlgorithms, value) {
+			if !contains(IlluminateAlgorithms, lvalue) {
 				return nil, errors.New("illuminate: algorithm=" + value + " (want none|mst|spt)")
 			}
-			m.Algorithm = value
+			m.Algorithm = lvalue
 		case "objective":
-			if !contains(IlluminateObjectives, value) {
+			if !contains(IlluminateObjectives, lvalue) {
 				return nil, errors.New("illuminate: objective=" + value + " (want min|max)")
 			}
-			m.Objective = value
+			m.Objective = lvalue
 		case "weighting":
-			if !contains(IlluminateWeightings, value) {
+			if !contains(IlluminateWeightings, lvalue) {
 				return nil, errors.New("illuminate: weighting=" + value + " (want raw|tfidf)")
 			}
-			m.Weighting = value
+			m.Weighting = lvalue
+		case "prefix":
+			if value == "" {
+				return nil, errors.New("illuminate: prefix= requires a non-empty value")
+			}
+			m.Prefix = value
 		default:
-			return nil, errors.New("illuminate: unknown key " + key + " (want algorithm|objective|weighting)")
+			return nil, errors.New("illuminate: unknown key " + key + " (want algorithm|objective|weighting|prefix)")
 		}
 	}
 	return m, nil
@@ -464,6 +471,7 @@ const HelpText = `Lantern CLI grammar:
              [algorithm={none|mst|spt}]  default=none
              [objective={min|max}]       default=max
              [weighting={raw|tfidf}]     default=raw
+             [prefix=<string>]           default=all keys
   help
   exit
 

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -90,3 +90,76 @@ func TestParam_OmittedTTLIsPermanent(t *testing.T) {
 		}
 	})
 }
+
+// TestIlluminateParam_Prefix pins the #604 vertex-prefix kwarg. Unlike the
+// closed-set axes, prefix= is free-text: the key is case-insensitive but the
+// value is preserved verbatim (it matches vertex keys), it composes with the
+// axis kwargs in any order, an omitted prefix leaves the field empty (no
+// filter), and an explicit prefix= with no value is rejected.
+func TestIlluminateParam_Prefix(t *testing.T) {
+	t.Run("parses value verbatim", func(t *testing.T) {
+		s, err := NewSource("alice 2 5 prefix=team:")
+		if err != nil {
+			t.Fatalf("NewSource: %v", err)
+		}
+		m, err := IlluminateParam(s)
+		if err != nil {
+			t.Fatalf("IlluminateParam: %v", err)
+		}
+		if m.Prefix != "team:" {
+			t.Fatalf("Prefix = %q, want %q", m.Prefix, "team:")
+		}
+	})
+
+	t.Run("omitted leaves prefix empty", func(t *testing.T) {
+		s, err := NewSource("alice 2 5 algorithm=mst")
+		if err != nil {
+			t.Fatalf("NewSource: %v", err)
+		}
+		m, err := IlluminateParam(s)
+		if err != nil {
+			t.Fatalf("IlluminateParam: %v", err)
+		}
+		if m.Prefix != "" {
+			t.Fatalf("Prefix = %q, want empty", m.Prefix)
+		}
+	})
+
+	t.Run("key case-insensitive, value case-sensitive", func(t *testing.T) {
+		s, err := NewSource("alice 2 5 PREFIX=Users/Alice")
+		if err != nil {
+			t.Fatalf("NewSource: %v", err)
+		}
+		m, err := IlluminateParam(s)
+		if err != nil {
+			t.Fatalf("IlluminateParam: %v", err)
+		}
+		if m.Prefix != "Users/Alice" {
+			t.Fatalf("Prefix = %q, want %q", m.Prefix, "Users/Alice")
+		}
+	})
+
+	t.Run("composes with axis kwargs in any order", func(t *testing.T) {
+		s, err := NewSource("alice 2 5 prefix=users/ algorithm=spt objective=min")
+		if err != nil {
+			t.Fatalf("NewSource: %v", err)
+		}
+		m, err := IlluminateParam(s)
+		if err != nil {
+			t.Fatalf("IlluminateParam: %v", err)
+		}
+		if m.Prefix != "users/" || m.Algorithm != "spt" || m.Objective != "min" {
+			t.Fatalf("got prefix=%q algorithm=%q objective=%q", m.Prefix, m.Algorithm, m.Objective)
+		}
+	})
+
+	t.Run("empty value rejected", func(t *testing.T) {
+		s, err := NewSource("alice 2 5 prefix=")
+		if err != nil {
+			t.Fatalf("NewSource: %v", err)
+		}
+		if _, err := IlluminateParam(s); err == nil {
+			t.Fatal("IlluminateParam accepted empty prefix=; want error")
+		}
+	})
+}

--- a/cli/parser/validate.go
+++ b/cli/parser/validate.go
@@ -101,7 +101,7 @@ func Validate(input string) error {
 		}
 	case "illuminate":
 		if _, err := IlluminateParam(s); err != nil {
-			return errors.New("usage: illuminate <key: string> <step: int> <k: int> [algorithm=none|mst|spt] [objective=min|max] [weighting=raw|tfidf]")
+			return errors.New("usage: illuminate <key: string> <step: int> <k: int> [algorithm=none|mst|spt] [objective=min|max] [weighting=raw|tfidf] [prefix=<string>]")
 		}
 
 	case "help":

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -248,13 +248,17 @@ func (c *CLIService) Run(ctx context.Context, str string) error {
 			fmt.Printf("Error: illuminate: unknown weighting %q\n", p.Weighting)
 			return ErrIlluminate
 		}
-		g, err := c.client.Illuminate(ctx, p.Seed,
+		opts := []client.IlluminateOption{
 			client.WithStep(uint32(p.Step)),
 			client.WithK(uint32(p.K)),
 			client.WithAlgorithm(algo),
 			client.WithObjective(obj),
 			client.WithWeighting(w),
-		)
+		}
+		if p.Prefix != "" {
+			opts = append(opts, client.WithVertexPrefix(p.Prefix))
+		}
+		g, err := c.client.Illuminate(ctx, p.Seed, opts...)
 		if err != nil {
 			fmt.Printf("Error: %s\n", err)
 			return ErrConnection


### PR DESCRIPTION
## Summary

Surfaces the Illuminate vertex-prefix filter (#600) on both CLI front-ends,
forwarding to `client.WithVertexPrefix` (#603):

- **cobra** ([cli/cmd/illuminate.go](cli/cmd/illuminate.go)): new `--prefix`
  string flag (default `""`), forwarded only when non-empty via an
  `IlluminateOption` slice. Documented under a new `FRONTIER FILTER (#604)`
  help section with an example.
- **REPL grammar** (`cli/parser/{model,parser,validate}.go`): `parser.Illuminate`
  gains a `Prefix` field; `IlluminateParam` parses `prefix=<string>` as a
  **free-text** kwarg. Unlike the closed-set axes (`algorithm`/`objective`/
  `weighting`), the key is case-insensitive but the **value is preserved
  verbatim** (it matches vertex keys); an empty `prefix=` value is rejected.
- **REPL dispatch** ([cli/service/service.go](cli/service/service.go)):
  forwards `p.Prefix` to `WithVertexPrefix` when non-empty.
- help/usage text and `help_test.go` enumerate `prefix=`.

## Tests

- [cli/parser/parser_test.go](cli/parser/parser_test.go): new
  `TestIlluminateParam_Prefix` — `prefix=team:` → `Prefix == "team:"`; bare form
  leaves `Prefix == ""`; key case-insensitive / value case-sensitive; composes
  with axis kwargs in any order; empty `prefix=` rejected.
- [cli/parser/help_test.go](cli/parser/help_test.go): golden expectation updated
  in place to require `prefix=` (no new sibling file).

## Notes

- The shared grammar fixture `admin/test/cli-grammar/verbs.json` is intentionally
  **not** touched here: it is exercised by both the Go and admin parsers, so
  `prefix=` cases land in #606 once the admin parser also accepts them.
- `gofmt -l` clean; `go test ./...` green from the repo root.

Closes #604