### PR TITLE
feat(admin): prefix= illuminate CLI grammar + toolbar form field

### DIFF
--- a/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.tsx
+++ b/admin/app/components/illuminate/IlluminateToolbar/IlluminateToolbar.tsx
@@ -2,6 +2,7 @@ import {
   Badge,
   Button,
   Field,
+  Input,
   Label,
   Radio,
   RadioGroup,
@@ -307,6 +308,22 @@ export function IlluminateToolbar({
             />
           ))}
         </RadioGroup>
+      </Field>
+
+      <Field
+        label="Vertex prefix"
+        className={styles.optimization}
+        // Per #606 the prefix restricts the traversal frontier to keys with
+        // this prefix; the seed is always kept as the anchor. Empty = no
+        // filter. The value is matched verbatim (case-sensitive).
+        hint="Restrict the frontier to keys with this prefix. Empty = all keys; the seed is always kept."
+      >
+        <Input
+          value={controls.vertexPrefix}
+          onChange={(_, data) => update("vertexPrefix", data.value)}
+          placeholder="all keys (e.g. users/)"
+          data-testid="illuminate-prefix"
+        />
       </Field>
     </section>
   );

--- a/admin/app/lib/cli/complete.test.ts
+++ b/admin/app/lib/cli/complete.test.ts
@@ -134,10 +134,10 @@ describe("completeCommandLine — key slots", () => {
 });
 
 describe("completeCommandLine — illuminate option kwargs (slot ≥ 4)", () => {
-  test("offers the three option keys with a trailing =", () => {
+  test("offers the four option keys with a trailing =", () => {
     expect(
       completeCommandLine("illuminate alice 2 5 ", KEYS).candidates,
-    ).toEqual(["algorithm=", "objective=", "weighting="]);
+    ).toEqual(["algorithm=", "objective=", "weighting=", "prefix="]);
   });
 
   test("filters option keys by prefix", () => {
@@ -150,7 +150,7 @@ describe("completeCommandLine — illuminate option kwargs (slot ≥ 4)", () => 
     expect(
       completeCommandLine("illuminate alice 2 5 algorithm=spt ", KEYS)
         .candidates,
-    ).toEqual(["objective=", "weighting="]);
+    ).toEqual(["objective=", "weighting=", "prefix="]);
   });
 
   test("completes enum values once = is typed", () => {
@@ -171,6 +171,12 @@ describe("completeCommandLine — illuminate option kwargs (slot ≥ 4)", () => 
   test("unknown option keyword yields no value candidates", () => {
     expect(
       completeCommandLine("illuminate alice 2 5 bogus=", KEYS).candidates,
+    ).toEqual([]);
+  });
+
+  test("free-text prefix= yields no value candidates (#606)", () => {
+    expect(
+      completeCommandLine("illuminate alice 2 5 prefix=", KEYS).candidates,
     ).toEqual([]);
   });
 

--- a/admin/app/lib/cli/complete.ts
+++ b/admin/app/lib/cli/complete.ts
@@ -45,6 +45,9 @@ const ILLUMINATE_OPTION_KEYS: readonly string[] = [
   "algorithm",
   "objective",
   "weighting",
+  // #606: free-text vertex-prefix filter. Surfaced as a completion key so
+  // operators discover it, but it has no enum values to complete after `=`.
+  "prefix",
 ];
 
 /** Cap on how many key candidates we surface, so the hint stays compact. */

--- a/admin/app/lib/cli/types.ts
+++ b/admin/app/lib/cli/types.ts
@@ -58,6 +58,7 @@ export type Command =
       algorithm: AlgorithmName;
       objective: ObjectiveName;
       weighting: WeightingName;
+      vertexPrefix: string;
     };
 
 export type ParseResult =

--- a/admin/app/lib/cli/verbs.test.ts
+++ b/admin/app/lib/cli/verbs.test.ts
@@ -15,6 +15,7 @@ import {
   HELP_TEXT,
   parseAdd,
   parseHelp,
+  parseIlluminate,
   parsePut,
   parseFloatStrict,
 } from "./verbs";
@@ -117,6 +118,7 @@ describe("HELP_TEXT (#436 — grammar contract)", () => {
     expect(HELP_TEXT).toContain("algorithm=");
     expect(HELP_TEXT).toContain("objective=");
     expect(HELP_TEXT).toContain("weighting=");
+    expect(HELP_TEXT).toContain("prefix=");
   });
 
   test("enumerates illuminate kwarg valid values", () => {
@@ -133,6 +135,7 @@ describe("HELP_TEXT (#436 — grammar contract)", () => {
     expect(HELP_TEXT).toContain("default=none");
     expect(HELP_TEXT).toContain("default=max");
     expect(HELP_TEXT).toContain("default=raw");
+    expect(HELP_TEXT).toContain("default=all keys");
   });
 
   test("lists every verb (including help and exit)", () => {
@@ -148,5 +151,52 @@ describe("HELP_TEXT (#436 — grammar contract)", () => {
     ]) {
       expect(HELP_TEXT).toContain(verb);
     }
+  });
+});
+
+describe("parseIlluminate prefix= kwarg (#606)", () => {
+  function illuminate(rest: string[]) {
+    const r = parseIlluminate(rest);
+    if (!r.ok) {
+      throw new Error(`parse failed: ${r.usage}`);
+    }
+    if (r.command.verb !== "illuminate") {
+      throw new Error(`not an illuminate command: ${r.command.verb}`);
+    }
+    return r.command;
+  }
+
+  test("captures a free-text prefix value verbatim", () => {
+    expect(illuminate(["alice", "2", "5", "prefix=team:"]).vertexPrefix).toBe(
+      "team:",
+    );
+  });
+
+  test("keeps the prefix value case (key folds, value is case-sensitive)", () => {
+    expect(
+      illuminate(["alice", "2", "5", "PREFIX=Users/Alice"]).vertexPrefix,
+    ).toBe("Users/Alice");
+  });
+
+  test("omitting prefix leaves it empty (no filter)", () => {
+    expect(illuminate(["alice", "2", "5"]).vertexPrefix).toBe("");
+  });
+
+  test("parses prefix= alongside the closed-set axes in any order", () => {
+    const cmd = illuminate([
+      "alice",
+      "2",
+      "5",
+      "prefix=users/",
+      "algorithm=spt",
+      "objective=min",
+    ]);
+    expect(cmd.vertexPrefix).toBe("users/");
+    expect(cmd.algorithm).toBe("spt");
+    expect(cmd.objective).toBe("min");
+  });
+
+  test("rejects an explicit empty prefix= value", () => {
+    expect(parseIlluminate(["alice", "2", "5", "prefix="]).ok).toBe(false);
   });
 });

--- a/admin/app/lib/cli/verbs.ts
+++ b/admin/app/lib/cli/verbs.ts
@@ -258,7 +258,7 @@ export function parseScan(rest: string[]): ParseResult {
 
 export function parseIlluminate(rest: string[]): ParseResult {
   const usage =
-    "usage: illuminate <key: string> <step: int> <k: int> [algorithm=none|mst|spt] [objective=min|max] [weighting=raw|tfidf]";
+    "usage: illuminate <key: string> <step: int> <k: int> [algorithm=none|mst|spt] [objective=min|max] [weighting=raw|tfidf] [prefix=<string>]";
   if (rest.length < 3) {
     return { ok: false, usage };
   }
@@ -280,33 +280,44 @@ export function parseIlluminate(rest: string[]): ParseResult {
   // default — keeping the strongest-neighbour behaviour byte-for-byte.
   let objective: ObjectiveName = "max";
   let weighting: WeightingName = "raw";
+  // #606: prefix is a FREE-TEXT kwarg (not a closed-set axis). Empty means
+  // "no filter"; an explicit empty `prefix=` is rejected, mirroring the Go
+  // REPL. The value is matched against vertex keys verbatim (case-SENSITIVE).
+  let vertexPrefix = "";
   for (let i = 3; i < rest.length; i++) {
     const tok = rest[i];
     const eq = tok.indexOf("=");
     if (eq < 0) {
       return { ok: false, usage };
     }
-    // The keyword KEY and the keyword VALUE for the three closed-set
-    // axes (algorithm / objective / weighting) are case-insensitive —
-    // they only ever take values from a small fixed enum the Go REPL
-    // also matches case-insensitively. See #437.
+    // The keyword KEY is always case-insensitive. The three closed-set
+    // axes (algorithm / objective / weighting) also fold their VALUE
+    // because they only ever take a small fixed enum the Go REPL matches
+    // case-insensitively (#437). The free-text `prefix` VALUE is matched
+    // against vertex keys verbatim, so it stays case-SENSITIVE (#604).
     const key = tok.slice(0, eq).toLowerCase();
-    const value = tok.slice(eq + 1).toLowerCase();
+    const value = tok.slice(eq + 1);
+    const lvalue = value.toLowerCase();
     if (key === "algorithm") {
-      if (!ILL_ALGORITHMS.has(value as AlgorithmName)) {
+      if (!ILL_ALGORITHMS.has(lvalue as AlgorithmName)) {
         return { ok: false, usage };
       }
-      algorithm = value as AlgorithmName;
+      algorithm = lvalue as AlgorithmName;
     } else if (key === "objective") {
-      if (!ILL_OBJECTIVES.has(value as ObjectiveName)) {
+      if (!ILL_OBJECTIVES.has(lvalue as ObjectiveName)) {
         return { ok: false, usage };
       }
-      objective = value as ObjectiveName;
+      objective = lvalue as ObjectiveName;
     } else if (key === "weighting") {
-      if (!ILL_WEIGHTINGS.has(value as WeightingName)) {
+      if (!ILL_WEIGHTINGS.has(lvalue as WeightingName)) {
         return { ok: false, usage };
       }
-      weighting = value as WeightingName;
+      weighting = lvalue as WeightingName;
+    } else if (key === "prefix") {
+      if (value === "") {
+        return { ok: false, usage };
+      }
+      vertexPrefix = value;
     } else {
       return { ok: false, usage };
     }
@@ -321,6 +332,7 @@ export function parseIlluminate(rest: string[]): ParseResult {
       algorithm,
       objective,
       weighting,
+      vertexPrefix,
     },
   };
 }
@@ -352,6 +364,7 @@ export const HELP_TEXT = [
   "             [algorithm={none|mst|spt}]  default=none",
   "             [objective={min|max}]       default=max",
   "             [weighting={raw|tfidf}]     default=raw",
+  "             [prefix=<string>]           default=all keys",
   "  help",
   "  exit",
   "",

--- a/admin/app/lib/client/infrastructure/api/illuminate.ts
+++ b/admin/app/lib/client/infrastructure/api/illuminate.ts
@@ -36,6 +36,13 @@ export interface IlluminateRequest {
   algorithm?: Algorithm;
   objective?: Objective;
   weighting?: Weighting;
+  /**
+   * Restrict the traversal frontier to vertices whose key has this prefix
+   * (#606). The seed is always retained as the anchor even if it does not
+   * match. Empty/omitted = no filter. Applied server-side BEFORE per-hop
+   * top-k and before any MST/SPT reduction (induced-subgraph semantics).
+   */
+  vertexPrefix?: string;
 }
 
 const ALGORITHM_TO_SDK: Record<Algorithm, SdkAlgorithm> = {
@@ -90,6 +97,7 @@ export async function illuminate(
           request.weighting !== undefined
             ? WEIGHTING_TO_SDK[request.weighting]
             : undefined,
+        vertexPrefix: request.vertexPrefix ?? "",
       },
       init?.signal,
     );

--- a/admin/app/lib/client/usecase/cli/dispatcher.ts
+++ b/admin/app/lib/client/usecase/cli/dispatcher.ts
@@ -179,6 +179,7 @@ export async function dispatch(input: DispatchInput): Promise<unknown> {
           algorithm: ALGORITHM_TO_API[command.algorithm],
           objective: OBJECTIVE_TO_API[command.objective],
           weighting: WEIGHTING_TO_API[command.weighting],
+          vertexPrefix: command.vertexPrefix,
         },
         { signal },
       );

--- a/admin/app/lib/client/usecase/cli/graph-view.test.ts
+++ b/admin/app/lib/client/usecase/cli/graph-view.test.ts
@@ -22,6 +22,7 @@ describe("commandResultToGraphView — illuminate", () => {
     algorithm: "none",
     objective: "min",
     weighting: "raw",
+    vertexPrefix: "",
   };
 
   it("marks the seed and renders all returned vertices + edges", () => {
@@ -363,6 +364,7 @@ describe("mergeGraphView", () => {
       algorithm: "none",
       objective: "min",
       weighting: "raw",
+      vertexPrefix: "",
     };
     const response: IlluminateResponse = {
       graph: {

--- a/admin/app/lib/client/usecase/illuminate/handlers.ts
+++ b/admin/app/lib/client/usecase/illuminate/handlers.ts
@@ -45,6 +45,7 @@ export async function runExpansion(
       algorithm: input.controls.algorithm,
       objective: input.controls.objective,
       weighting: input.controls.weighting,
+      vertexPrefix: input.controls.vertexPrefix,
     };
     const response = await illuminate(input.client, request, {
       signal: input.signal,

--- a/admin/app/lib/client/usecase/illuminate/reducer.ts
+++ b/admin/app/lib/client/usecase/illuminate/reducer.ts
@@ -249,6 +249,7 @@ function controlsEqual(a: IlluminateControls, b: IlluminateControls): boolean {
     a.k === b.k &&
     a.algorithm === b.algorithm &&
     a.objective === b.objective &&
-    a.weighting === b.weighting
+    a.weighting === b.weighting &&
+    a.vertexPrefix === b.vertexPrefix
   );
 }

--- a/admin/app/lib/client/usecase/illuminate/state.ts
+++ b/admin/app/lib/client/usecase/illuminate/state.ts
@@ -25,6 +25,12 @@ export interface IlluminateControls {
   algorithm: Algorithm;
   objective: Objective;
   weighting: Weighting;
+  /**
+   * Free-text vertex-key prefix filter (#606). Empty = no filter. The value
+   * is matched against vertex keys verbatim (case-sensitive); the seed is
+   * always retained as the traversal anchor.
+   */
+  vertexPrefix: string;
 }
 
 /**
@@ -41,6 +47,7 @@ export const DEFAULT_ILLUMINATE_CONTROLS: IlluminateControls = {
   algorithm: "ALGORITHM_UNSPECIFIED",
   objective: "OBJECTIVE_UNSPECIFIED",
   weighting: "WEIGHTING_UNSPECIFIED",
+  vertexPrefix: "",
 };
 
 export type IlluminateStatus = "idle" | "loading" | "ready" | "error";

--- a/admin/test/cli-grammar/verbs.json
+++ b/admin/test/cli-grammar/verbs.json
@@ -40,6 +40,18 @@
       "comment": "#437: illuminate keyword key + closed-set value case-insensitive"
     },
     {
+      "input": "illuminate alice 2 5 prefix=team:",
+      "comment": "#606: free-text vertex-prefix kwarg"
+    },
+    {
+      "input": "illuminate alice 2 5 prefix=users/ algorithm=spt objective=min",
+      "comment": "#606: prefix mixes with the closed-set axes in any order"
+    },
+    {
+      "input": "illuminate alice 2 5 PREFIX=Users/Alice",
+      "comment": "#606: prefix key case-insensitive, value case-sensitive (verbatim)"
+    },
+    {
       "input": "put vertex greeting \"hello world\"",
       "comment": "#438: double-quoted value carries whitespace"
     },
@@ -105,6 +117,10 @@
     {
       "input": "illuminate alice 2 5 unknown=foo",
       "comment": "unknown keyword"
+    },
+    {
+      "input": "illuminate alice 2 5 prefix=",
+      "comment": "#606: explicit empty prefix= value is rejected"
     },
     {
       "input": "illuminate alice 2 5 algorithm",


### PR DESCRIPTION
## What

Final piece of Epic #600: surface the vertex-key **prefix filter** on the
admin Illuminate view. Both the REPL grammar and the visual toolbar can now
restrict an `illuminate` expansion to vertices whose key carries a given
prefix, matching the server filter (#602), the Go SDK option (#603), and the
CLI/REPL grammar (#604).

## Changes

**Grammar (`app/lib/cli/`)**
- `types.ts` — add `vertexPrefix: string` to the `illuminate` command.
- `verbs.ts` — `parseIlluminate` accepts an optional `prefix=<string>` kwarg,
  updates the usage string and `HELP_TEXT`. Mirrors the Go parser exactly: the
  kwarg **key** is case-insensitive while the **value** is matched verbatim
  (case-sensitive); an explicit empty `prefix=` is rejected.
- `complete.ts` — `prefix` joins the illuminate option-key completions (no
  enum value completions, since it is free text).

**Client wiring (`app/lib/client/`)**
- `infrastructure/api/illuminate.ts` — `IlluminateRequest.vertexPrefix` flows
  into the SDK `illuminate()` option (defaults to `""`).
- `usecase/cli/dispatcher.ts` — forwards `command.vertexPrefix`.
- `usecase/illuminate/{state,handlers,reducer}.ts` — new `vertexPrefix`
  control (default `""`), threaded into the expansion request and the
  controls-equality check.

**UI**
- `IlluminateToolbar.tsx` — a free-text **Vertex prefix** `Input`
  (`data-testid="illuminate-prefix"`). Empty = no filter; the seed is always
  retained as the traversal anchor (induced-subgraph semantics).

## Tests

- `test/cli-grammar/verbs.json` — new `prefix=` valid cases (verbatim value,
  case-insensitive key, mixes with the closed-set axes in any order) and one
  invalid case (empty `prefix=`). This shared fixture is consumed by **both**
  the Go `parser.Validate` test and the admin `grammar.test.ts`, so the two
  parsers stay in lock-step.
- `verbs.test.ts` — `parseIlluminate` prefix suite + `HELP_TEXT` assertions.
- `complete.test.ts` — keyword enumeration now includes `prefix=`.

## Verification

- Admin gate green: `format`, `lint`, `typecheck`, `test` (637 pass), `build`.
- Go side green: `go test ./cli/parser/` and root `go test ./...`; `gofmt -l`
  clean.

Closes #606
