### PR TITLE
chore(release): bump root go.mod to core/v0.6.0 + sdks/go/v0.14.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.4.0
-	github.com/anaregdesign/lantern/core v0.5.0
+	github.com/anaregdesign/lantern/core v0.6.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.5.0
-	github.com/anaregdesign/lantern/sdks/go v0.12.0
+	github.com/anaregdesign/lantern/sdks/go v0.14.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1


### PR DESCRIPTION
Closes #613.

Release-mechanics for Epic #600 (vertex-key prefix filter). Pins the root `go.mod` to the freshly-tagged upstreams before the `v0.13.0` cut:

- `core` v0.5.0 → **v0.6.0** (#607 keep-predicate)
- `sdks/go` v0.12.0 → **v0.14.0** (#609 `WithVertexPrefix`)

External `go install github.com/anaregdesign/lantern/cli@v0.13.0` ignores the module's `replace` directives, so these `require` versions are what consumers actually resolve. `cli/cmd/illuminate.go` (#610) calls `WithVertexPrefix`, which only exists in `sdks/go/v0.14.0`.

`go.sum` untouched (both deps are locally `replace`d). Local gate green: `gofmt -l .` clean, `go build/vet/test ./...` pass.