### PR TITLE
chore(sdks/node): bump to v0.3.0

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lantern-sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Official TypeScript client SDK for Lantern — an in-memory graph KVS, over Connect (HTTP/2).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Bumps `sdks/node/package.json` `version` `0.2.0` → `0.3.0` so `node-sdk.yml` publishes `lantern-sdk@0.3.0` for the `vertexPrefix` illuminate option (#605, shipped in #611).

The `sdks/node/v0.3.0` tag was pushed but the publish job failed with `npm error You cannot publish over the previously published versions: 0.2.0` — the publish job reads the version from `package.json`, and the git tag only gates *whether* to publish. After this merges, the `sdks/node/v0.3.0` tag will be re-pointed at the bump commit to publish 0.3.0.

`bun install --frozen-lockfile` reports no lockfile changes; `format:check` passes.

Closes #615