### PR TITLE
feat(admin): add vertex prefix to /cli click-to-illuminate axis picker

### DIFF
--- a/admin/app/components/cli/CliAxisPicker/CliAxisPicker.module.css
+++ b/admin/app/components/cli/CliAxisPicker/CliAxisPicker.module.css
@@ -47,6 +47,14 @@
   width: 72px;
 }
 
+/* Free-text input for the vertex prefix (#617). Wider than the numeric
+ * inputs because namespace prefixes (`svc:`, `team:`, `users/`) need room,
+ * but still shrinks via min-width:0 on narrow canvas columns. */
+.textInput {
+  width: 140px;
+  min-width: 0;
+}
+
 /* Dropdowns for algorithm / objective. The descendant selector raises
  * specificity above Fluent UI's default 250px min-width so the controls
  * can shrink and the strip never overflows a narrow canvas column. */

--- a/admin/app/components/cli/CliAxisPicker/CliAxisPicker.tsx
+++ b/admin/app/components/cli/CliAxisPicker/CliAxisPicker.tsx
@@ -70,6 +70,16 @@ export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
     [setAxis],
   );
 
+  // Free-text axis (#617): any string is valid, including "" (= no filter).
+  // The formatter only echoes a non-empty prefix, so clearing the field
+  // restores the canonical short-form click.
+  const onPrefixChange = useCallback<NonNullable<InputProps["onChange"]>>(
+    (_, data) => {
+      setAxis("vertexPrefix", data.value);
+    },
+    [setAxis],
+  );
+
   const preview = formatIlluminateClick("<key>", axes);
 
   return (
@@ -167,6 +177,20 @@ export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
         }
         data-testid="cli-axis-tfidf"
       />
+
+      <label className={styles.field}>
+        <span className={styles.label}>prefix</span>
+        <Input
+          className={styles.textInput}
+          type="text"
+          value={axes.vertexPrefix}
+          onChange={onPrefixChange}
+          disabled={disabled}
+          placeholder="(none)"
+          data-testid="cli-axis-prefix"
+          aria-label="Vertex prefix (optional)"
+        />
+      </label>
 
       <code
         id="cli-axis-picker-preview"

--- a/admin/app/lib/cli/illuminate-axes.test.ts
+++ b/admin/app/lib/cli/illuminate-axes.test.ts
@@ -6,9 +6,9 @@
  * 1. `formatIlluminateClick` emits the short form when every axis
  *    matches {@link CLI_CLICK_AXIS_DEFAULTS} and only appends the
  *    diverging kwargs, in the fixed order
- *    `algorithm=` → `objective=` → `weighting=`. The default-short-form
- *    case is the regression guard for #439 — the byte-for-byte stable
- *    click string the canvas snapshot test depends on.
+ *    `algorithm=` → `objective=` → `weighting=` → `prefix=`. The
+ *    default-short-form case is the regression guard for #439 — the
+ *    byte-for-byte stable click string the canvas snapshot test depends on.
  *
  * 2. Every shape this formatter can produce is parseable by the
  *    shared CLI parser in `./parser`, and round-trips to the same
@@ -25,6 +25,7 @@ import {
   parseStoredAlgorithm,
   parseStoredK,
   parseStoredObjective,
+  parseStoredPrefix,
   parseStoredStep,
   parseStoredWeighting,
   type CliClickAxes,
@@ -76,7 +77,25 @@ describe("formatIlluminateClick", () => {
     ).toBe("illuminate alice 2 5 weighting=tfidf");
   });
 
-  test("all axes off-default → fixed token order", () => {
+  test("only prefix off-default → single kwarg appended last", () => {
+    expect(
+      formatIlluminateClick("alice", {
+        ...CLI_CLICK_AXIS_DEFAULTS,
+        vertexPrefix: "svc:",
+      }),
+    ).toBe("illuminate alice 2 5 prefix=svc:");
+  });
+
+  test("prefix value is emitted verbatim (case-sensitive, #604)", () => {
+    expect(
+      formatIlluminateClick("alice", {
+        ...CLI_CLICK_AXIS_DEFAULTS,
+        vertexPrefix: "Users/Alice",
+      }),
+    ).toBe("illuminate alice 2 5 prefix=Users/Alice");
+  });
+
+  test("empty prefix emits no kwarg even with other axes off-default", () => {
     expect(
       formatIlluminateClick("alice", {
         step: 3,
@@ -84,8 +103,24 @@ describe("formatIlluminateClick", () => {
         algorithm: "spt",
         objective: "min",
         weighting: "tfidf",
+        vertexPrefix: "",
       }),
     ).toBe("illuminate alice 3 10 algorithm=spt objective=min weighting=tfidf");
+  });
+
+  test("all axes off-default → fixed token order ending in prefix=", () => {
+    expect(
+      formatIlluminateClick("alice", {
+        step: 3,
+        k: 10,
+        algorithm: "spt",
+        objective: "min",
+        weighting: "tfidf",
+        vertexPrefix: "svc:",
+      }),
+    ).toBe(
+      "illuminate alice 3 10 algorithm=spt objective=min weighting=tfidf prefix=svc:",
+    );
   });
 
   test("seed containing a colon round-trips literally", () => {
@@ -123,6 +158,10 @@ describe("formatIlluminateClick ↔ parse round-trip", () => {
       axes: { ...CLI_CLICK_AXIS_DEFAULTS, weighting: "tfidf" },
     },
     {
+      name: "only prefix",
+      axes: { ...CLI_CLICK_AXIS_DEFAULTS, vertexPrefix: "team:" },
+    },
+    {
       name: "all axes off-default",
       axes: {
         step: 3,
@@ -130,6 +169,7 @@ describe("formatIlluminateClick ↔ parse round-trip", () => {
         algorithm: "spt",
         objective: "min",
         weighting: "tfidf",
+        vertexPrefix: "svc:",
       },
     },
   ];
@@ -150,6 +190,7 @@ describe("formatIlluminateClick ↔ parse round-trip", () => {
     expect(result.command.algorithm).toBe(axes.algorithm);
     expect(result.command.objective).toBe(axes.objective);
     expect(result.command.weighting).toBe(axes.weighting);
+    expect(result.command.vertexPrefix).toBe(axes.vertexPrefix);
   });
 });
 
@@ -187,5 +228,14 @@ describe("parseStored* helpers", () => {
     expect(parseStoredWeighting("raw")).toBe("raw");
     expect(parseStoredWeighting("tfidf")).toBe("tfidf");
     expect(parseStoredWeighting("WEIGHTING_TFIDF")).toBeNull();
+  });
+
+  test("prefix is free text: any non-null string is valid, null stays null", () => {
+    expect(parseStoredPrefix("svc:")).toBe("svc:");
+    expect(parseStoredPrefix("Users/Alice")).toBe("Users/Alice");
+    // Empty is a legitimate stored value (= no filter), distinct from a
+    // missing key (null), which falls back to the default.
+    expect(parseStoredPrefix("")).toBe("");
+    expect(parseStoredPrefix(null)).toBeNull();
   });
 });

--- a/admin/app/lib/cli/illuminate-axes.ts
+++ b/admin/app/lib/cli/illuminate-axes.ts
@@ -42,6 +42,14 @@ export interface CliClickAxes {
   algorithm: AlgorithmName;
   objective: ObjectiveName;
   weighting: WeightingName;
+  /**
+   * Free-text vertex-prefix filter (#604/#617). Restricts the click-driven
+   * walk frontier to keys under this prefix; the seed is always kept as the
+   * anchor even when it does not match. Empty means "no filter". Matched
+   * against vertex keys verbatim (case-SENSITIVE), unlike the closed-set
+   * axes above.
+   */
+  vertexPrefix: string;
 }
 
 /**
@@ -60,6 +68,9 @@ export const CLI_CLICK_AXIS_DEFAULTS: CliClickAxes = {
   // the weakest once the click is dispatched.
   objective: "max",
   weighting: "raw",
+  // Empty = no prefix filter, so the bare click stays byte-for-byte the
+  // canonical short form `illuminate <seed> 2 5` (the #439 regression guard).
+  vertexPrefix: "",
 };
 
 export const CLI_ALGORITHMS: ReadonlyArray<{
@@ -92,9 +103,9 @@ export const CLI_WEIGHTINGS: ReadonlyArray<{
  *
  * Emits the short form `illuminate <seed> <step> <k>` when every axis
  * matches {@link CLI_CLICK_AXIS_DEFAULTS}. Appends the optional kwargs
- * in fixed order (`algorithm=` → `objective=` → `weighting=`) only for
- * axes that diverge from the default; the fixed order keeps scrollback
- * snapshots deterministic and matches the parser's usage string.
+ * in fixed order (`algorithm=` → `objective=` → `weighting=` → `prefix=`)
+ * only for axes that diverge from the default; the fixed order keeps
+ * scrollback snapshots deterministic and matches the parser's usage string.
  *
  * The function is intentionally pure so `bun:test` can round-trip it
  * through {@link parse} without a DOM.
@@ -118,6 +129,15 @@ export function formatIlluminateClick(
   if (axes.weighting !== CLI_CLICK_AXIS_DEFAULTS.weighting) {
     tokens.push(`weighting=${axes.weighting}`);
   }
+  // #617: prefix is a FREE-TEXT axis, not a closed enum. Emit `prefix=<value>`
+  // only when non-empty — the parser (and the Go REPL) reject an explicit empty
+  // `prefix=`, and an empty prefix means "no filter" anyway, so the bare click
+  // stays the canonical short form. The value is echoed verbatim (case-
+  // SENSITIVE, #604); it carries no spaces because the CLI tokeniser splits on
+  // whitespace.
+  if (axes.vertexPrefix !== "") {
+    tokens.push(`prefix=${axes.vertexPrefix}`);
+  }
   return tokens.join(" ");
 }
 
@@ -131,6 +151,7 @@ export const AXIS_STORAGE_KEYS = {
   algorithm: "cli.click.algorithm",
   objective: "cli.click.objective",
   weighting: "cli.click.weighting",
+  vertexPrefix: "cli.click.prefix",
 } as const;
 
 /**
@@ -157,6 +178,15 @@ export function parseStoredObjective(raw: string | null): ObjectiveName | null {
 
 export function parseStoredWeighting(raw: string | null): WeightingName | null {
   return matchOption(raw, CLI_WEIGHTINGS);
+}
+
+/**
+ * Parse a stored vertex prefix. Prefix is free text, so every non-null
+ * string is valid (including ""); only a missing key returns null, letting
+ * the caller fall back to {@link CLI_CLICK_AXIS_DEFAULTS}.vertexPrefix.
+ */
+export function parseStoredPrefix(raw: string | null): string | null {
+  return raw;
 }
 
 /** Inverse of the parse helpers; numeric axes serialise as base-10 ints. */

--- a/admin/app/lib/client/usecase/cli/use-cli-axis-picker.ts
+++ b/admin/app/lib/client/usecase/cli/use-cli-axis-picker.ts
@@ -11,6 +11,7 @@ import {
   parseStoredAlgorithm,
   parseStoredK,
   parseStoredObjective,
+  parseStoredPrefix,
   parseStoredStep,
   parseStoredWeighting,
   type CliClickAxes,
@@ -65,19 +66,23 @@ export function useCliAxisPicker(
     weighting:
       parseStoredWeighting(store.get(AXIS_STORAGE_KEYS.weighting)) ??
       CLI_CLICK_AXIS_DEFAULTS.weighting,
+    vertexPrefix:
+      parseStoredPrefix(store.get(AXIS_STORAGE_KEYS.vertexPrefix)) ??
+      CLI_CLICK_AXIS_DEFAULTS.vertexPrefix,
   }));
 
-  // Re-persist whenever the axes change. We persist all five every time
+  // Re-persist whenever the axes change. We persist all six every time
   // rather than diffing because the picker fires at most once per user
-  // gesture — a Dropdown selection or a Switch toggle — so the cost is
-  // negligible and avoids subtle bugs from forgetting to persist a key
-  // after splitting setters apart.
+  // gesture — a Dropdown selection, a Switch toggle, or a keystroke in the
+  // prefix field — so the cost is negligible and avoids subtle bugs from
+  // forgetting to persist a key after splitting setters apart.
   useEffect(() => {
     store.set(AXIS_STORAGE_KEYS.step, formatStoredStep(axes.step));
     store.set(AXIS_STORAGE_KEYS.k, formatStoredK(axes.k));
     store.set(AXIS_STORAGE_KEYS.algorithm, axes.algorithm);
     store.set(AXIS_STORAGE_KEYS.objective, axes.objective);
     store.set(AXIS_STORAGE_KEYS.weighting, axes.weighting);
+    store.set(AXIS_STORAGE_KEYS.vertexPrefix, axes.vertexPrefix);
   }, [axes, store]);
 
   const setAxis = useCallback(


### PR DESCRIPTION
## What & why

The `/cli` **click-to-illuminate axis picker** (#464, restyled in #512) let
operators tune `step`, `k`, `algorithm`, `objective` and `TF-IDF` before
clicking a vertex in the inline graph — but it had **no prefix control**.
Clicking a node re-ran `illuminate <key> 2 5 …` with **no `prefix=`**, silently
dropping namespace scoping, even though the `prefix=` kwarg (#604 / #606) is
already wired end-to-end through parse → dispatch → API.

This adds a free-text **`prefix`** field to the picker strip so a click can
stay scoped to a namespace (e.g. `svc:`).

## Behaviour

- Free-text, **case-sensitive**, emitted **verbatim** (matches the `prefix=`
  contract — unlike `algorithm`/`objective`/`weighting`, prefix is not a
  case-folded closed enum).
- Emitted **only when non-empty**, appended **last** in the fixed token order
  `algorithm= → objective= → weighting= → prefix=` for deterministic
  scrollback.
- Empty (default) keeps the **byte-stable short form** `illuminate <key> 2 5`
  (the #439 regression guard) — the parser rejects an explicit empty `prefix=`,
  so we never emit one.
- Persisted to `localStorage` under `cli.click.prefix`, alongside the other
  five axes.

## Verification

- `bun run format` (clean) · `bun run lint` (clean) · `bun run typecheck`
  (clean) · `bun run test` → **642 pass / 0 fail** (incl. new formatter,
  round-trip, and `parseStoredPrefix` tests) · `bun run build` (success).
- Live-checked in the browser: typing `svc:` updates both the picker preview
  and the canvas `click a node →` hint to
  `illuminate <key> 2 5 prefix=svc:`; an empty field keeps `illuminate <key> 2 5`.

Closes #617
