### PR TITLE
refactor(core): consolidate cache/graph into graphcache

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -8,10 +8,11 @@ specific to the gRPC/transport layer.
 
 | Path | Description |
 | --- | --- |
-| `cache/` | Generic in-memory cache with TTL, and a graph-specialized cache (`cache/graph`). |
+| `cache/` | Generic in-memory cache with TTL. |
 | `collection/` | Generic collections: priority queue (`pq`), set, slice helpers. |
 | `concurrent/` | Concurrency primitives, including a typed pub/sub (`concurrent/pubsub`). |
 | `graph/` | In-memory graph model and traversal/scoring helpers. |
+| `graphcache/` | Graph-specialized cache: TTL'd vertices and additive decaying edges, with an optional prefix index. The server's primary store. |
 | `model/function/` | Functional-style type aliases used across the other packages. |
 | `nlp/` | Lightweight NLP helpers. |
 

--- a/core/graphcache/acid_gate_test.go
+++ b/core/graphcache/acid_gate_test.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import (
 	"sync"

--- a/core/graphcache/batch.go
+++ b/core/graphcache/batch.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import "time"
 

--- a/core/graphcache/batch_external_test.go
+++ b/core/graphcache/batch_external_test.go
@@ -1,4 +1,4 @@
-package graph_test
+package graphcache_test
 
 import (
 	"sync"
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 )
 
 // TestAddEdgesWithExpiration_AtomicNeighborSnapshot verifies that a
@@ -16,17 +16,17 @@ import (
 // fan-in.
 func TestAddEdgesWithExpiration_AtomicNeighborSnapshot(t *testing.T) {
 	const fanOut = 128
-	c := graph.NewGraphCache[string, int](time.Minute)
+	c := graphcache.NewGraphCache[string, int](time.Minute)
 
 	exp := time.Now().Add(time.Minute)
 	c.PutVertexWithExpiration("s", 0, exp)
 
-	addBatch := make([]graph.EdgeItem[string], fanOut)
-	delBatch := make([]graph.EdgeKey[string], fanOut)
+	addBatch := make([]graphcache.EdgeItem[string], fanOut)
+	delBatch := make([]graphcache.EdgeKey[string], fanOut)
 	for i := 0; i < fanOut; i++ {
 		head := "h" + itoa(i)
-		addBatch[i] = graph.EdgeItem[string]{Tail: "s", Head: head, Weight: 1, Expiration: exp}
-		delBatch[i] = graph.EdgeKey[string]{Tail: "s", Head: head}
+		addBatch[i] = graphcache.EdgeItem[string]{Tail: "s", Head: head, Weight: 1, Expiration: exp}
+		delBatch[i] = graphcache.EdgeKey[string]{Tail: "s", Head: head}
 	}
 
 	var (
@@ -77,17 +77,17 @@ func TestAddEdgesWithExpiration_AtomicNeighborSnapshot(t *testing.T) {
 // Neighbor call sees either all batched edges or none.
 func TestDeleteEdges_AtomicNeighborSnapshot(t *testing.T) {
 	const fanOut = 128
-	c := graph.NewGraphCache[string, int](time.Minute)
+	c := graphcache.NewGraphCache[string, int](time.Minute)
 
 	exp := time.Now().Add(time.Minute)
 	c.PutVertexWithExpiration("s", 0, exp)
 
-	addBatch := make([]graph.EdgeItem[string], fanOut)
-	delBatch := make([]graph.EdgeKey[string], fanOut)
+	addBatch := make([]graphcache.EdgeItem[string], fanOut)
+	delBatch := make([]graphcache.EdgeKey[string], fanOut)
 	for i := 0; i < fanOut; i++ {
 		head := "h" + itoa(i)
-		addBatch[i] = graph.EdgeItem[string]{Tail: "s", Head: head, Weight: 1, Expiration: exp}
-		delBatch[i] = graph.EdgeKey[string]{Tail: "s", Head: head}
+		addBatch[i] = graphcache.EdgeItem[string]{Tail: "s", Head: head, Weight: 1, Expiration: exp}
+		delBatch[i] = graphcache.EdgeKey[string]{Tail: "s", Head: head}
 	}
 
 	var (
@@ -140,14 +140,14 @@ func TestDeleteEdges_AtomicNeighborSnapshot(t *testing.T) {
 // between the per-item delete and re-add.
 func TestPutEdgesWithExpiration_NoTransientNotFound(t *testing.T) {
 	const batchSize = 128
-	c := graph.NewGraphCache[string, int](time.Minute)
+	c := graphcache.NewGraphCache[string, int](time.Minute)
 
-	items := make([]graph.EdgeItem[string], batchSize)
-	keys := make([]graph.EdgeKey[string], batchSize)
+	items := make([]graphcache.EdgeItem[string], batchSize)
+	keys := make([]graphcache.EdgeKey[string], batchSize)
 	for i := 0; i < batchSize; i++ {
 		tail, head := "t"+itoa(i), "h"+itoa(i)
-		items[i] = graph.EdgeItem[string]{Tail: tail, Head: head, Weight: 1, Expiration: time.Now().Add(time.Minute)}
-		keys[i] = graph.EdgeKey[string]{Tail: tail, Head: head}
+		items[i] = graphcache.EdgeItem[string]{Tail: tail, Head: head, Weight: 1, Expiration: time.Now().Add(time.Minute)}
+		keys[i] = graphcache.EdgeKey[string]{Tail: tail, Head: head}
 	}
 	c.AddEdgesWithExpiration(items)
 
@@ -186,10 +186,10 @@ func TestPutEdgesWithExpiration_NoTransientNotFound(t *testing.T) {
 // TestBatchAPIs_ReturnCounts spot-checks the bookkeeping returned by
 // DeleteVertices / DeleteEdges (count of entries actually removed).
 func TestBatchAPIs_ReturnCounts(t *testing.T) {
-	c := graph.NewGraphCache[string, int](time.Minute)
+	c := graphcache.NewGraphCache[string, int](time.Minute)
 	exp := time.Now().Add(time.Minute)
 
-	c.PutVerticesWithExpiration([]graph.VertexItem[string, int]{
+	c.PutVerticesWithExpiration([]graphcache.VertexItem[string, int]{
 		{Key: "a", Value: 1, Expiration: exp},
 		{Key: "b", Value: 2, Expiration: exp},
 		{Key: "c", Value: 3, Expiration: exp},
@@ -198,11 +198,11 @@ func TestBatchAPIs_ReturnCounts(t *testing.T) {
 		t.Fatalf("DeleteVertices: got %d, want 2", n)
 	}
 
-	c.AddEdgesWithExpiration([]graph.EdgeItem[string]{
+	c.AddEdgesWithExpiration([]graphcache.EdgeItem[string]{
 		{Tail: "x", Head: "y", Weight: 1, Expiration: exp},
 		{Tail: "y", Head: "z", Weight: 1, Expiration: exp},
 	})
-	got := c.DeleteEdges([]graph.EdgeKey[string]{
+	got := c.DeleteEdges([]graphcache.EdgeKey[string]{
 		{Tail: "x", Head: "y"},
 		{Tail: "nope", Head: "nope"},
 	})
@@ -220,11 +220,11 @@ func TestAddEdgesWithExpirationContrib_Dedup(t *testing.T) {
 	exp := time.Now().Add(time.Minute)
 
 	t.Run("same id twice contributes once", func(t *testing.T) {
-		c := graph.NewGraphCache[string, int](time.Minute)
-		var id graph.ContribID
+		c := graphcache.NewGraphCache[string, int](time.Minute)
+		var id graphcache.ContribID
 		id[0], id[23] = 0xAB, 0x01
 
-		batch := []graph.EdgeItem[string]{
+		batch := []graphcache.EdgeItem[string]{
 			{Tail: "s", Head: "h", Weight: 2.5, Expiration: exp, ContribID: id},
 		}
 		if deduped := c.AddEdgesWithExpirationContrib(batch); deduped != 0 {
@@ -244,8 +244,8 @@ func TestAddEdgesWithExpirationContrib_Dedup(t *testing.T) {
 	})
 
 	t.Run("zero id stays additive", func(t *testing.T) {
-		c := graph.NewGraphCache[string, int](time.Minute)
-		batch := []graph.EdgeItem[string]{
+		c := graphcache.NewGraphCache[string, int](time.Minute)
+		batch := []graphcache.EdgeItem[string]{
 			{Tail: "s", Head: "h", Weight: 2, Expiration: exp}, // ContribID zero
 		}
 		if deduped := c.AddEdgesWithExpirationContrib(batch); deduped != 0 {
@@ -260,14 +260,14 @@ func TestAddEdgesWithExpirationContrib_Dedup(t *testing.T) {
 	})
 
 	t.Run("distinct ids both contribute", func(t *testing.T) {
-		c := graph.NewGraphCache[string, int](time.Minute)
-		var id1, id2 graph.ContribID
+		c := graphcache.NewGraphCache[string, int](time.Minute)
+		var id1, id2 graphcache.ContribID
 		id1[0], id1[23] = 0x01, 0x01
 		id2[0], id2[23] = 0x01, 0x02
-		c.AddEdgesWithExpirationContrib([]graph.EdgeItem[string]{
+		c.AddEdgesWithExpirationContrib([]graphcache.EdgeItem[string]{
 			{Tail: "s", Head: "h", Weight: 1, Expiration: exp, ContribID: id1},
 		})
-		deduped := c.AddEdgesWithExpirationContrib([]graph.EdgeItem[string]{
+		deduped := c.AddEdgesWithExpirationContrib([]graphcache.EdgeItem[string]{
 			{Tail: "s", Head: "h", Weight: 1, Expiration: exp, ContribID: id2},
 		})
 		if deduped != 0 {
@@ -279,14 +279,14 @@ func TestAddEdgesWithExpirationContrib_Dedup(t *testing.T) {
 	})
 
 	t.Run("mixed batch counts only deduped items", func(t *testing.T) {
-		c := graph.NewGraphCache[string, int](time.Minute)
-		var id graph.ContribID
+		c := graphcache.NewGraphCache[string, int](time.Minute)
+		var id graphcache.ContribID
 		id[0] = 0x7F
-		c.AddEdgesWithExpirationContrib([]graph.EdgeItem[string]{
+		c.AddEdgesWithExpirationContrib([]graphcache.EdgeItem[string]{
 			{Tail: "s", Head: "a", Weight: 1, Expiration: exp, ContribID: id},
 		})
 		// Mix the already-seen id (deduped) with a fresh zero-id edge (applies).
-		deduped := c.AddEdgesWithExpirationContrib([]graph.EdgeItem[string]{
+		deduped := c.AddEdgesWithExpirationContrib([]graphcache.EdgeItem[string]{
 			{Tail: "s", Head: "a", Weight: 1, Expiration: exp, ContribID: id},
 			{Tail: "s", Head: "b", Weight: 1, Expiration: exp},
 		})
@@ -302,8 +302,8 @@ func TestAddEdgesWithExpirationContrib_Dedup(t *testing.T) {
 	})
 
 	t.Run("facade preserves additive semantics", func(t *testing.T) {
-		c := graph.NewGraphCache[string, int](time.Minute)
-		batch := []graph.EdgeItem[string]{
+		c := graphcache.NewGraphCache[string, int](time.Minute)
+		batch := []graphcache.EdgeItem[string]{
 			{Tail: "s", Head: "h", Weight: 3, Expiration: exp},
 		}
 		c.AddEdgesWithExpiration(batch)

--- a/core/graphcache/bench_test.go
+++ b/core/graphcache/bench_test.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import (
 	"fmt"
@@ -102,7 +102,7 @@ func reportHeap(b *testing.B, before, after runtime.MemStats, scale benchScale) 
 // BenchmarkGraphCacheMemory reports heap-in-use after populating a cache at
 // several scales. Run with:
 //
-//	go test -bench=BenchmarkGraphCacheMemory -benchmem -benchtime=1x ./core/cache/graph
+//	go test -bench=BenchmarkGraphCacheMemory -benchmem -benchtime=1x ./core/graphcache
 //
 // The b.N loop iteration count is forced to 1 by -benchtime=1x so the heap
 // snapshot reflects exactly one populated cache. Without -benchtime=1x the

--- a/core/graphcache/cache.go
+++ b/core/graphcache/cache.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import (
 	"context"

--- a/core/graphcache/cache_test.go
+++ b/core/graphcache/cache_test.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import (
 	"context"

--- a/core/graphcache/contrib.go
+++ b/core/graphcache/contrib.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 // ContribID is a globally-unique identifier for an additive edge
 // contribution. It packs the 16-byte HLC NodeID of the originating writer

--- a/core/graphcache/contrib_test.go
+++ b/core/graphcache/contrib_test.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import "testing"
 

--- a/core/graphcache/dict.go
+++ b/core/graphcache/dict.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import "sync"
 

--- a/core/graphcache/dict_test.go
+++ b/core/graphcache/dict_test.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import (
 	"fmt"

--- a/core/graphcache/edge.go
+++ b/core/graphcache/edge.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import (
 	"sync"

--- a/core/graphcache/edge_prefix.go
+++ b/core/graphcache/edge_prefix.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import (
 	"context"

--- a/core/graphcache/edge_prefix_test.go
+++ b/core/graphcache/edge_prefix_test.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import (
 	"context"

--- a/core/graphcache/edge_test.go
+++ b/core/graphcache/edge_test.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import (
 	"reflect"

--- a/core/graphcache/example/main.go
+++ b/core/graphcache/example/main.go
@@ -3,13 +3,13 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	"time"
 )
 
 func main() {
 	ctx := context.Background()
-	c := graph.NewGraphCache[string, string](1 * time.Minute)
+	c := graphcache.NewGraphCache[string, string](1 * time.Minute)
 	go c.Watch(ctx, 1*time.Second)
 
 	c.AddEdge("a", "b", 1)

--- a/core/graphcache/head_index.go
+++ b/core/graphcache/head_index.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 // headIndex is the per-tail head-side prefix index that backs the head
 // dimension of ScanEdgesByPrefix. For one tail vertex it carries:

--- a/core/graphcache/head_index_test.go
+++ b/core/graphcache/head_index_test.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import (
 	"context"
@@ -109,7 +109,7 @@ func collectScan(c *GraphCache[string, string], tailP, headP string) []string {
 //
 // Run with:
 //
-//	go test -bench BenchmarkScanEdgesByPrefix_StarHead -run ^$ ./cache/graph/...
+//	go test -bench BenchmarkScanEdgesByPrefix_StarHead -run ^$ ./graphcache/...
 //
 // On a 1-tail / 1M-head graph with a ~0.1% match the fast path should
 // be at least an order of magnitude faster than the fallback.

--- a/core/graphcache/prefix.go
+++ b/core/graphcache/prefix.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import "context"
 

--- a/core/graphcache/prefix_test.go
+++ b/core/graphcache/prefix_test.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import (
 	"context"

--- a/core/graphcache/production_gate_test.go
+++ b/core/graphcache/production_gate_test.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import (
 	"context"

--- a/core/graphcache/radix.go
+++ b/core/graphcache/radix.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import "sync"
 

--- a/core/graphcache/radix_test.go
+++ b/core/graphcache/radix_test.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import (
 	"sort"

--- a/core/graphcache/snapshot.go
+++ b/core/graphcache/snapshot.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import (
 	"time"

--- a/core/graphcache/tombstone.go
+++ b/core/graphcache/tombstone.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import (
 	"context"

--- a/core/graphcache/tombstone_test.go
+++ b/core/graphcache/tombstone_test.go
@@ -1,4 +1,4 @@
-package graph
+package graphcache
 
 import (
 	"context"

--- a/server/cmd/wire.go
+++ b/server/cmd/wire.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	"github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/server/provider"
 	"github.com/anaregdesign/lantern/server/service"
@@ -56,8 +56,8 @@ func initializeApp() (*App, error) {
 		service.NewLanternServer,
 		wire.Bind(new(service.Listener), new(*provider.LanternListener)),
 		wire.Bind(new(service.HealthSetter), new(*provider.HealthChecker)),
-		wire.Bind(new(service.Backend), new(*graph.GraphCache[string, *pb.Vertex])),
-		wire.Bind(new(service.Watcher), new(*graph.GraphCache[string, *pb.Vertex])),
+		wire.Bind(new(service.Backend), new(*graphcache.GraphCache[string, *pb.Vertex])),
+		wire.Bind(new(service.Watcher), new(*graphcache.GraphCache[string, *pb.Vertex])),
 		newApp,
 	)
 	return nil, nil

--- a/server/provider/antientropy.go
+++ b/server/provider/antientropy.go
@@ -4,7 +4,7 @@ import (
 	"log/slog"
 	"time"
 
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	v1 "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/server/internal/envconfig"
 	"github.com/anaregdesign/lantern/server/replication"
@@ -56,7 +56,7 @@ func NewAntiEntropyDriver(
 	rc ReplicationConfig,
 	ac AntiEntropyConfig,
 	svc *service.LanternService,
-	cache *cachegraph.GraphCache[string, *v1.Vertex],
+	cache *graphcache.GraphCache[string, *v1.Vertex],
 	pump *replication.Pump,
 	m replication.AntiEntropyMetrics,
 	logger *slog.Logger,

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	v1 "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/server/internal/envconfig"
 	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
@@ -237,8 +237,8 @@ func NewLogger(o ObservabilityConfig) *slog.Logger {
 	return l
 }
 
-func NewGraphCache(c CacheConfig) *graph.GraphCache[string, *v1.Vertex] {
-	gc := graph.NewGraphCache[string, *v1.Vertex](c.TTL)
+func NewGraphCache(c CacheConfig) *graphcache.GraphCache[string, *v1.Vertex] {
+	gc := graphcache.NewGraphCache[string, *v1.Vertex](c.TTL)
 	// Identity projection: vertex keys are themselves the indexed string.
 	// Enabling the prefix index up-front (before any insert) is required
 	// by the cache contract — EnablePrefixIndex panics on a non-empty
@@ -256,7 +256,7 @@ func NewGraphCache(c CacheConfig) *graph.GraphCache[string, *v1.Vertex] {
 func NewDomainMetrics(
 	reg *prometheus.Registry,
 	o ObservabilityConfig,
-	cache *graph.GraphCache[string, *v1.Vertex],
+	cache *graphcache.GraphCache[string, *v1.Vertex],
 ) *domainmetrics.DomainMetrics {
 	m := domainmetrics.New(reg, domainmetrics.Options{
 		Version: o.Version,
@@ -282,7 +282,7 @@ type CacheGCHooksWired struct{}
 // single goroutine, so the per-tick accumulator inside the closure is
 // safe without locking.
 func WireCacheGCHooks(
-	cache *graph.GraphCache[string, *v1.Vertex],
+	cache *graphcache.GraphCache[string, *v1.Vertex],
 	m *domainmetrics.DomainMetrics,
 	logger *slog.Logger,
 ) CacheGCHooksWired {

--- a/server/provider/provider_test.go
+++ b/server/provider/provider_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	v1 "github.com/anaregdesign/lantern/pb/graph/v1"
 	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
 	"github.com/anaregdesign/lantern/server/readiness"
@@ -21,7 +21,7 @@ import (
 // "graph cache: gc tick" info log record is emitted per cache tick
 // after WireCacheGCHooks installs the multiplexed hooks (#223).
 func TestWireCacheGCHooks_EmitsTickSummary(t *testing.T) {
-	cache := graph.NewGraphCache[string, *v1.Vertex](time.Second)
+	cache := graphcache.NewGraphCache[string, *v1.Vertex](time.Second)
 	reg := prometheus.NewRegistry()
 	dm := domainmetrics.New(reg, domainmetrics.Options{})
 

--- a/server/provider/pump.go
+++ b/server/provider/pump.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	v1 "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/server/internal/envconfig"
 	"github.com/anaregdesign/lantern/server/replication"
@@ -86,7 +86,7 @@ func NewReplicationPump(
 	pc PeerConfig,
 	rc ReplicationConfig,
 	svc *service.LanternService,
-	cache *cachegraph.GraphCache[string, *v1.Vertex],
+	cache *graphcache.GraphCache[string, *v1.Vertex],
 	m replication.Metrics,
 	logger *slog.Logger,
 ) *replication.Pump {

--- a/server/replication/pump.go
+++ b/server/replication/pump.go
@@ -39,7 +39,7 @@ import (
 	"net/http"
 	"time"
 
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
@@ -56,12 +56,12 @@ type MutationApplier interface {
 }
 
 // SnapshotApplier is the surface the pump uses to replay snapshot
-// frames into the local graph cache. *cachegraph.GraphCache[string,
+// frames into the local graph cache. *graphcache.GraphCache[string,
 // *pb.Vertex] satisfies it directly via its HLC + ContribID seams added
 // in #181.
 type SnapshotApplier interface {
 	PutVertexWithExpirationHLC(key string, value *pb.Vertex, exp time.Time, ts hlc.Timestamp) bool
-	AddEdgeWithExpirationContribHLC(tail, head string, w float32, exp time.Time, cid cachegraph.ContribID, ts hlc.Timestamp) bool
+	AddEdgeWithExpirationContribHLC(tail, head string, w float32, exp time.Time, cid graphcache.ContribID, ts hlc.Timestamp) bool
 }
 
 // Metrics is the narrow surface the pump uses to publish per-peer
@@ -466,7 +466,7 @@ func (p *Pump) snapshot(ctx context.Context, cli graphv1connect.LanternReplicati
 			se := e.Edge
 			edgeHLC := snapshotHLC(se.GetHlc())
 			for _, c := range se.GetContributions() {
-				var cid cachegraph.ContribID
+				var cid graphcache.ContribID
 				copy(cid[:], c.GetContribId())
 				p.snap.AddEdgeWithExpirationContribHLC(
 					se.GetTail(), se.GetHead(), c.GetWeight(),

--- a/server/service/apply.go
+++ b/server/service/apply.go
@@ -7,7 +7,7 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 )
@@ -187,7 +187,7 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 			// Prefer the index-aligned client ContribID (#588); fall back to
 			// the synthesized (origin, seq, idx) id when the wire slot is
 			// absent or empty so legacy mutations keep their replay-dedup id.
-			var cID graph.ContribID
+			var cID graphcache.ContribID
 			if i < len(contribIDs) {
 				cID = contribIDFromBytes(contribIDs[i])
 			}
@@ -237,15 +237,15 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 		if useTomb {
 			s.cache.DeleteEdgeHLC(k.GetTail(), k.GetHead(), ts, tombExp)
 		} else {
-			s.cache.DeleteEdges([]graph.EdgeKey[string]{{Tail: k.GetTail(), Head: k.GetHead()}})
+			s.cache.DeleteEdges([]graphcache.EdgeKey[string]{{Tail: k.GetTail(), Head: k.GetHead()}})
 		}
 		opName = "DeleteEdge"
 
 	case *pb.MutationOp_DeleteEdges:
 		in := op.DeleteEdges.GetEdges()
-		keys := make([]graph.EdgeKey[string], 0, len(in))
+		keys := make([]graphcache.EdgeKey[string], 0, len(in))
 		for _, e := range in {
-			keys = append(keys, graph.EdgeKey[string]{Tail: e.GetTail(), Head: e.GetHead()})
+			keys = append(keys, graphcache.EdgeKey[string]{Tail: e.GetTail(), Head: e.GetHead()})
 		}
 		if useTomb {
 			s.cache.DeleteEdgesHLC(keys, ts, tombExp)
@@ -330,8 +330,8 @@ func hlcToProto(ts hlc.Timestamp) *pb.HLCTimestamp {
 // contribIDBytes returns the wire encoding of a ContribID. A zero ContribID
 // (the local-only / non-replicated sentinel) is encoded as a nil slice so
 // receivers can recognise it explicitly and skip dedup.
-func contribIDBytes(c graph.ContribID) []byte {
-	var zero graph.ContribID
+func contribIDBytes(c graphcache.ContribID) []byte {
+	var zero graphcache.ContribID
 	if c == zero {
 		return nil
 	}
@@ -342,8 +342,8 @@ func contribIDBytes(c graph.ContribID) []byte {
 // 24-byte length is accepted; a shorter, longer, or empty slice yields the
 // zero ContribID (the "no identity" sentinel), letting callers fall back to
 // a synthesized id and skip dedup. The inverse of contribIDBytes.
-func contribIDFromBytes(b []byte) graph.ContribID {
-	var c graph.ContribID
+func contribIDFromBytes(b []byte) graphcache.ContribID {
+	var c graphcache.ContribID
 	if len(b) != len(c) {
 		return c
 	}
@@ -352,7 +352,7 @@ func contribIDFromBytes(b []byte) graph.ContribID {
 }
 
 // contribIDFor builds the dedup identifier for an additive contribution.
-// The 24-byte ContribID layout is documented on graph.ContribID:
+// The 24-byte ContribID layout is documented on graphcache.ContribID:
 //
 //	bytes [0:16] = origin NodeID (replicating node)
 //	bytes [16:24] = uint64 BE = (mutation seq << 16) | edge index
@@ -362,8 +362,8 @@ func contribIDFromBytes(b []byte) graph.ContribID {
 // guaranteeing a globally unique ContribID per (origin, seq, idx) triple.
 // Practical batch sizes are bounded by the Connect/gRPC message size cap
 // long before this limit; the assertion is defensive.
-func contribIDFor(origin []byte, seq uint64, idx uint16) graph.ContribID {
-	var c graph.ContribID
+func contribIDFor(origin []byte, seq uint64, idx uint16) graphcache.ContribID {
+	var c graphcache.ContribID
 	copy(c[:16], origin)
 	combined := (seq << 16) | uint64(idx)
 	binary.BigEndian.PutUint64(c[16:], combined)

--- a/server/service/apply_test.go
+++ b/server/service/apply_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
@@ -159,7 +159,7 @@ func TestApplyMutation_ReplicationApplyHook(t *testing.T) {
 // TestApplyMutation_DoesNotReAppendDuplicate), not by bypassing the
 // log on apply.
 func TestApplyMutation_AppendsToLocalLog(t *testing.T) {
-	cache := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	log := mutationlog.New(mutationlog.Options{Capacity: 128, SubscriberBuffer: 128})
 	t.Cleanup(func() { _ = log.Close() })
 	origin := bytes16("origin-A")
@@ -194,7 +194,7 @@ func TestApplyMutation_AppendsToLocalLog(t *testing.T) {
 // peer-pump in #184 would amplify every mutation by the fan-out
 // factor on external Subscribe streams.
 func TestApplyMutation_DoesNotReAppendDuplicate(t *testing.T) {
-	cache := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	log := mutationlog.New(mutationlog.Options{Capacity: 128, SubscriberBuffer: 128})
 	t.Cleanup(func() { _ = log.Close() })
 	origin := bytes16("origin-A")
@@ -320,7 +320,7 @@ func TestApplyMutation_Convergence(t *testing.T) {
 			// distinct shuffled order with random duplicates.
 			states := make([]nodeSnapshot, numNodes)
 			for n := 0; n < numNodes; n++ {
-				cache := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
+				cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 				svc := NewLanternService(cache)
 
 				delivery := make([]*pb.Mutation, 0, len(tape)*2)
@@ -385,8 +385,8 @@ func TestApplyMutation_Idempotence(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cacheA := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
-			cacheB := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
+			cacheA := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+			cacheB := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 			svcA := NewLanternService(cacheA)
 			svcB := NewLanternService(cacheB)
 
@@ -424,7 +424,7 @@ func TestApplyMutation_WireContribIDDedupsAcrossSeq(t *testing.T) {
 	origin := bytes16("origin-A")
 	exp := timestamppb.New(time.Now().Add(time.Hour))
 
-	var cid graph.ContribID
+	var cid graphcache.ContribID
 	cid[0], cid[23] = 0xAB, 0x07
 
 	mkAddEdges := func(seq uint64, contribIDs [][]byte) *pb.Mutation {
@@ -442,7 +442,7 @@ func TestApplyMutation_WireContribIDDedupsAcrossSeq(t *testing.T) {
 	}
 
 	t.Run("same wire ContribID dedups across distinct Seq", func(t *testing.T) {
-		cache := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
+		cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 		svc := NewLanternService(cache)
 		ctx := context.Background()
 		if err := svc.ApplyMutation(ctx, mkAddEdges(1, [][]byte{cid[:]})); err != nil {
@@ -457,7 +457,7 @@ func TestApplyMutation_WireContribIDDedupsAcrossSeq(t *testing.T) {
 	})
 
 	t.Run("legacy AddEdges without wire ContribID sums across Seq", func(t *testing.T) {
-		cache := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
+		cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 		svc := NewLanternService(cache)
 		ctx := context.Background()
 		if err := svc.ApplyMutation(ctx, mkAddEdges(1, nil)); err != nil {
@@ -577,7 +577,7 @@ type nodeSnapshot struct {
 	weights  map[[2]string]float32
 }
 
-func snapshotCache(c *graph.GraphCache[string, *pb.Vertex], vp int, edges [][2]string) nodeSnapshot {
+func snapshotCache(c *graphcache.GraphCache[string, *pb.Vertex], vp int, edges [][2]string) nodeSnapshot {
 	s := nodeSnapshot{
 		vertices: map[string][]byte{},
 		weights:  map[[2]string]float32{},
@@ -598,7 +598,7 @@ func snapshotCache(c *graph.GraphCache[string, *pb.Vertex], vp int, edges [][2]s
 
 // includeKeys extends a snapshot with explicit (vertex, edge) keys.
 // Used by the idempotence test where the universe is hand-picked.
-func (s *nodeSnapshot) includeKeys(c *graph.GraphCache[string, *pb.Vertex], vs []string, es [][2]string) {
+func (s *nodeSnapshot) includeKeys(c *graphcache.GraphCache[string, *pb.Vertex], vs []string, es [][2]string) {
 	for _, k := range vs {
 		if v, ok := c.GetVertex(k); ok {
 			s.vertices[k] = mustMarshal(v)
@@ -699,7 +699,7 @@ func TestApplyMutation_TombstoneClampRejectHook(t *testing.T) {
 	origin := bytes16("origin-A")
 
 	newSvc := func(tsCount *int) *LanternService {
-		cache := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
+		cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 		return NewLanternService(cache).
 			WithTombstoneTTL(time.Hour).
 			WithTombstoneClampRejectHook(func() { *tsCount++ })
@@ -774,7 +774,7 @@ func TestApplyMutation_TombstoneClampRejectHook(t *testing.T) {
 
 	t.Run("ClampDisabledNeverFires", func(t *testing.T) {
 		var n int
-		cache := graph.NewGraphCache[string, *pb.Vertex](time.Minute)
+		cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 		svc := NewLanternService(cache).
 			WithTombstoneClampRejectHook(func() { n++ })
 		// useTomb=false: the non-HLC backend path is taken, hook stays at 0.

--- a/server/service/backend.go
+++ b/server/service/backend.go
@@ -4,36 +4,36 @@ import (
 	"context"
 	"time"
 
-	"github.com/anaregdesign/lantern/core/cache/graph"
 	coregraph "github.com/anaregdesign/lantern/core/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 )
 
 // Backend is the narrow seam the service depends on instead of the concrete
-// *graph.GraphCache. The interface is consumer-defined here so adding new
+// *graphcache.GraphCache. The interface is consumer-defined here so adding new
 // service-layer RPCs widens it deliberately, and tests can supply a fake.
 //
-// The batch types (graph.VertexItem, graph.EdgeItem, graph.EdgeKey) remain
+// The batch types (graphcache.VertexItem, graphcache.EdgeItem, graphcache.EdgeKey) remain
 // imported as plain value structs — they describe data, not behavior, so
 // re-declaring them would just shuffle conversions without buying anything.
 type Backend interface {
 	// vertex reads/writes
 	GetVertex(key string) (*pb.Vertex, bool)
-	PutVerticesWithExpiration(items []graph.VertexItem[string, *pb.Vertex])
+	PutVerticesWithExpiration(items []graphcache.VertexItem[string, *pb.Vertex])
 	DeleteVertices(keys []string) int
 
 	// edge reads/writes
 	GetEdgeDetail(tail, head string) (float32, time.Time, bool)
-	AddEdgesWithExpiration(items []graph.EdgeItem[string])
+	AddEdgesWithExpiration(items []graphcache.EdgeItem[string])
 	// AddEdgesWithExpirationContrib is the dedup-aware batch sibling of
 	// AddEdgesWithExpiration: a per-item non-zero ContribID makes that
 	// contribution idempotent (a retried batch is an exact no-op). Returns
 	// the count of items suppressed by a matching live ContribID. Items
 	// with a zero ContribID keep legacy additive semantics.
-	AddEdgesWithExpirationContrib(items []graph.EdgeItem[string]) int
-	PutEdgesWithExpiration(items []graph.EdgeItem[string])
-	DeleteEdges(keys []graph.EdgeKey[string]) int
+	AddEdgesWithExpirationContrib(items []graphcache.EdgeItem[string]) int
+	PutEdgesWithExpiration(items []graphcache.EdgeItem[string])
+	DeleteEdges(keys []graphcache.EdgeKey[string]) int
 
 	// replicated-write entry points used by ApplyMutation (#182).
 	//
@@ -46,7 +46,7 @@ type Backend interface {
 	// against the stored last-write HLC and silently drop strictly-older
 	// writes (LWW). Equal-ts writes apply (idempotent for value-equal
 	// payloads).
-	AddEdgeWithExpirationContrib(tail, head string, w float32, expiration time.Time, contribID graph.ContribID) bool
+	AddEdgeWithExpirationContrib(tail, head string, w float32, expiration time.Time, contribID graphcache.ContribID) bool
 	PutVertexWithExpirationHLC(key string, value *pb.Vertex, expiration time.Time, ts hlc.Timestamp) bool
 	PutEdgeWithExpirationHLC(tail, head string, w float32, expiration time.Time, ts hlc.Timestamp) bool
 
@@ -58,11 +58,11 @@ type Backend interface {
 	// the tombstone window. AddEdgeWithExpirationContribHLC is the HLC
 	// sibling of AddEdgeWithExpirationContrib that consults the edge
 	// tombstone store before applying.
-	AddEdgeWithExpirationContribHLC(tail, head string, w float32, expiration time.Time, contribID graph.ContribID, ts hlc.Timestamp) bool
+	AddEdgeWithExpirationContribHLC(tail, head string, w float32, expiration time.Time, contribID graphcache.ContribID, ts hlc.Timestamp) bool
 	DeleteVertexHLC(key string, ts hlc.Timestamp, expiration time.Time) bool
 	DeleteVerticesHLC(keys []string, ts hlc.Timestamp, expiration time.Time) int
 	DeleteEdgeHLC(tail, head string, ts hlc.Timestamp, expiration time.Time) bool
-	DeleteEdgesHLC(keys []graph.EdgeKey[string], ts hlc.Timestamp, expiration time.Time) int
+	DeleteEdgesHLC(keys []graphcache.EdgeKey[string], ts hlc.Timestamp, expiration time.Time) int
 	DeleteByPrefixHLC(ctx context.Context, prefix string, limit uint32, ts hlc.Timestamp, expiration time.Time) (int, error)
 
 	// neighborhood traversal. selectSmallest steers the per-hop top-k
@@ -110,8 +110,8 @@ type Backend interface {
 	// bootstrapping peer (not on the hot path). The returned slices own
 	// their backing storage and are safe to iterate without further
 	// locking.
-	SnapshotVertices() []graph.SnapshotVertex[string, *pb.Vertex]
-	SnapshotEdges() []graph.SnapshotEdge[string]
+	SnapshotVertices() []graphcache.SnapshotVertex[string, *pb.Vertex]
+	SnapshotEdges() []graphcache.SnapshotEdge[string]
 
 	// VertexCount and EdgeCount return the current number of live entries
 	// in the underlying graph cache. Backed by index sizes — O(1) and

--- a/server/service/fake_backend_test.go
+++ b/server/service/fake_backend_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/anaregdesign/lantern/core/cache/graph"
 	coregraph "github.com/anaregdesign/lantern/core/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 )
@@ -38,7 +38,7 @@ type fakeBackend struct {
 	// mapped index-aligned onto EdgeItem.ContribID and that the returned
 	// dedup count is forwarded to HotPathMetrics.OnEdgeContribDeduped.
 	addEdgesContribCalls int
-	lastAddEdgesItems    []graph.EdgeItem[string]
+	lastAddEdgesItems    []graphcache.EdgeItem[string]
 	dedupReturn          int
 }
 
@@ -54,7 +54,7 @@ func (f *fakeBackend) GetVertex(key string) (*pb.Vertex, bool) {
 	return v, ok
 }
 
-func (f *fakeBackend) PutVerticesWithExpiration(items []graph.VertexItem[string, *pb.Vertex]) {
+func (f *fakeBackend) PutVerticesWithExpiration(items []graphcache.VertexItem[string, *pb.Vertex]) {
 	f.putVerticesCalls++
 	for _, it := range items {
 		f.vertices[it.Key] = it.Value
@@ -82,7 +82,7 @@ func (f *fakeBackend) GetEdgeDetail(tail, head string) (float32, time.Time, bool
 	return 0, time.Time{}, false
 }
 
-func (f *fakeBackend) AddEdgesWithExpiration(items []graph.EdgeItem[string]) {
+func (f *fakeBackend) AddEdgesWithExpiration(items []graphcache.EdgeItem[string]) {
 	f.addEdgesCalls++
 	for _, it := range items {
 		if f.edges[it.Tail] == nil {
@@ -98,7 +98,7 @@ func (f *fakeBackend) AddEdgesWithExpiration(items []graph.EdgeItem[string]) {
 // contrib_id mapping, and returns the configurable dedupReturn so the
 // OnEdgeContribDeduped metric wiring is observable. Real dedup convergence
 // is covered by the core tests and tests/integration.
-func (f *fakeBackend) AddEdgesWithExpirationContrib(items []graph.EdgeItem[string]) int {
+func (f *fakeBackend) AddEdgesWithExpirationContrib(items []graphcache.EdgeItem[string]) int {
 	f.addEdgesContribCalls++
 	f.lastAddEdgesItems = items
 	for _, it := range items {
@@ -110,7 +110,7 @@ func (f *fakeBackend) AddEdgesWithExpirationContrib(items []graph.EdgeItem[strin
 	return f.dedupReturn
 }
 
-func (f *fakeBackend) PutEdgesWithExpiration(items []graph.EdgeItem[string]) {
+func (f *fakeBackend) PutEdgesWithExpiration(items []graphcache.EdgeItem[string]) {
 	f.putEdgesCalls++
 	for _, it := range items {
 		if f.edges[it.Tail] == nil {
@@ -120,7 +120,7 @@ func (f *fakeBackend) PutEdgesWithExpiration(items []graph.EdgeItem[string]) {
 	}
 }
 
-func (f *fakeBackend) DeleteEdges(keys []graph.EdgeKey[string]) int {
+func (f *fakeBackend) DeleteEdges(keys []graphcache.EdgeKey[string]) int {
 	n := 0
 	for _, k := range keys {
 		if row, ok := f.edges[k.Tail]; ok {
@@ -256,7 +256,7 @@ var _ Backend = (*fakeBackend)(nil)
 // touch ApplyMutation can run against the fake without spinning up a
 // real GraphCache. It does not enforce HLC/ContribID dedup — tests that
 // care about convergence use the real backend.
-func (f *fakeBackend) AddEdgeWithExpirationContrib(tail, head string, w float32, _ time.Time, _ graph.ContribID) bool {
+func (f *fakeBackend) AddEdgeWithExpirationContrib(tail, head string, w float32, _ time.Time, _ graphcache.ContribID) bool {
 	if f.edges[tail] == nil {
 		f.edges[tail] = map[string]float32{}
 	}
@@ -280,7 +280,7 @@ func (f *fakeBackend) PutEdgeWithExpirationHLC(tail, head string, w float32, _ t
 // Tombstone-aware entry points (#183). The fake intentionally collapses
 // the tombstone bookkeeping into the underlying delete; service-level
 // tests that exercise tombstone semantics use the real backend.
-func (f *fakeBackend) AddEdgeWithExpirationContribHLC(tail, head string, w float32, exp time.Time, c graph.ContribID, _ hlc.Timestamp) bool {
+func (f *fakeBackend) AddEdgeWithExpirationContribHLC(tail, head string, w float32, exp time.Time, c graphcache.ContribID, _ hlc.Timestamp) bool {
 	return f.AddEdgeWithExpirationContrib(tail, head, w, exp, c)
 }
 
@@ -293,10 +293,10 @@ func (f *fakeBackend) DeleteVerticesHLC(keys []string, _ hlc.Timestamp, _ time.T
 }
 
 func (f *fakeBackend) DeleteEdgeHLC(tail, head string, _ hlc.Timestamp, _ time.Time) bool {
-	return f.DeleteEdges([]graph.EdgeKey[string]{{Tail: tail, Head: head}}) > 0
+	return f.DeleteEdges([]graphcache.EdgeKey[string]{{Tail: tail, Head: head}}) > 0
 }
 
-func (f *fakeBackend) DeleteEdgesHLC(keys []graph.EdgeKey[string], _ hlc.Timestamp, _ time.Time) int {
+func (f *fakeBackend) DeleteEdgesHLC(keys []graphcache.EdgeKey[string], _ hlc.Timestamp, _ time.Time) int {
 	return f.DeleteEdges(keys)
 }
 
@@ -312,22 +312,22 @@ func (f *fakeBackend) DeleteByPrefixHLC(ctx context.Context, prefix string, limi
 // returns the in-memory vertex/edge maps as flat slices with zero HLC
 // stamps and a single zero-ContribID contribution per edge — enough for
 // service-level wiring tests; convergence tests use the real backend.
-func (f *fakeBackend) SnapshotVertices() []graph.SnapshotVertex[string, *pb.Vertex] {
-	out := make([]graph.SnapshotVertex[string, *pb.Vertex], 0, len(f.vertices))
+func (f *fakeBackend) SnapshotVertices() []graphcache.SnapshotVertex[string, *pb.Vertex] {
+	out := make([]graphcache.SnapshotVertex[string, *pb.Vertex], 0, len(f.vertices))
 	for k, v := range f.vertices {
-		out = append(out, graph.SnapshotVertex[string, *pb.Vertex]{Key: k, Value: v})
+		out = append(out, graphcache.SnapshotVertex[string, *pb.Vertex]{Key: k, Value: v})
 	}
 	return out
 }
 
-func (f *fakeBackend) SnapshotEdges() []graph.SnapshotEdge[string] {
-	var out []graph.SnapshotEdge[string]
+func (f *fakeBackend) SnapshotEdges() []graphcache.SnapshotEdge[string] {
+	var out []graphcache.SnapshotEdge[string]
 	for tail, heads := range f.edges {
 		for head, w := range heads {
-			out = append(out, graph.SnapshotEdge[string]{
+			out = append(out, graphcache.SnapshotEdge[string]{
 				Tail: tail,
 				Head: head,
-				Contributions: []graph.SnapshotContribution{{
+				Contributions: []graphcache.SnapshotContribution{{
 					Weight: w,
 				}},
 			})

--- a/server/service/server.go
+++ b/server/service/server.go
@@ -34,7 +34,7 @@ type LanternServer struct {
 }
 
 // Watcher is the lifecycle hook LanternServer uses to drive the cache GC
-// loop. *graph.GraphCache satisfies it; tests can stub it.
+// loop. *graphcache.GraphCache satisfies it; tests can stub it.
 type Watcher interface {
 	Watch(ctx context.Context, interval time.Duration)
 }

--- a/server/service/server_external_test.go
+++ b/server/service/server_external_test.go
@@ -12,7 +12,7 @@ import (
 
 	"connectrpc.com/grpchealth"
 
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/server/service"
 )
@@ -74,7 +74,7 @@ type noopWatcher struct{}
 func (noopWatcher) Watch(ctx context.Context, _ time.Duration) { <-ctx.Done() }
 
 func TestLanternServer_Run_FlipsHealthOnServeReturn(t *testing.T) {
-	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	svc := service.NewLanternService(cache)
 	httpSrv := &http.Server{Handler: http.NewServeMux()}
 	lis := &brokenListener{addr: fakeAddr{}}

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -11,7 +11,7 @@ import (
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
@@ -35,7 +35,7 @@ const ServiceName = "graph.v1.LanternService"
 // gave up.
 //
 // The service depends on the narrow Backend interface (see backend.go); a
-// wire binding maps it to *graph.GraphCache in production. Tests can supply
+// wire binding maps it to *graphcache.GraphCache in production. Tests can supply
 // a fake without standing up the real cache.
 type LanternService struct {
 	cache                  Backend
@@ -466,12 +466,12 @@ func (s *LanternService) PutVertices(ctx context.Context, request *pb.PutVertice
 	}
 	in := request.GetVertices()
 	s.metrics.OnBatch("PutVertices", len(in))
-	items := make([]graph.VertexItem[string, *pb.Vertex], 0, len(in))
+	items := make([]graphcache.VertexItem[string, *pb.Vertex], 0, len(in))
 	for _, v := range in {
 		if err := s.validateExpiration(v.GetExpiration().AsTime()); err != nil {
 			return nil, err
 		}
-		items = append(items, graph.VertexItem[string, *pb.Vertex]{
+		items = append(items, graphcache.VertexItem[string, *pb.Vertex]{
 			Key:        v.GetKey(),
 			Value:      v,
 			Expiration: v.GetExpiration().AsTime(),
@@ -571,12 +571,12 @@ func (s *LanternService) AddEdges(ctx context.Context, request *pb.AddEdgesReque
 	in := request.GetEdges()
 	s.metrics.OnBatch("AddEdges", len(in))
 	contribIDs := request.GetContribIds()
-	items := make([]graph.EdgeItem[string], 0, len(in))
+	items := make([]graphcache.EdgeItem[string], 0, len(in))
 	for i, e := range in {
 		if err := s.validateExpiration(e.GetExpiration().AsTime()); err != nil {
 			return nil, err
 		}
-		item := graph.EdgeItem[string]{
+		item := graphcache.EdgeItem[string]{
 			Tail:       e.GetTail(),
 			Head:       e.GetHead(),
 			Weight:     e.GetWeight(),
@@ -611,12 +611,12 @@ func (s *LanternService) PutEdges(ctx context.Context, request *pb.PutEdgesReque
 	}
 	in := request.GetEdges()
 	s.metrics.OnBatch("PutEdges", len(in))
-	items := make([]graph.EdgeItem[string], 0, len(in))
+	items := make([]graphcache.EdgeItem[string], 0, len(in))
 	for _, e := range in {
 		if err := s.validateExpiration(e.GetExpiration().AsTime()); err != nil {
 			return nil, err
 		}
-		items = append(items, graph.EdgeItem[string]{
+		items = append(items, graphcache.EdgeItem[string]{
 			Tail:       e.GetTail(),
 			Head:       e.GetHead(),
 			Weight:     e.GetWeight(),
@@ -647,9 +647,9 @@ func (s *LanternService) DeleteEdges(ctx context.Context, in *pb.DeleteEdgesRequ
 	}
 	inEdges := in.GetEdges()
 	s.metrics.OnBatch("DeleteEdges", len(inEdges))
-	keys := make([]graph.EdgeKey[string], 0, len(inEdges))
+	keys := make([]graphcache.EdgeKey[string], 0, len(inEdges))
 	for _, e := range inEdges {
-		keys = append(keys, graph.EdgeKey[string]{Tail: e.GetTail(), Head: e.GetHead()})
+		keys = append(keys, graphcache.EdgeKey[string]{Tail: e.GetTail(), Head: e.GetHead()})
 	}
 	var n int
 	if s.clock != nil && s.tombstoneTTL > 0 {

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -10,7 +10,7 @@ import (
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
@@ -18,7 +18,7 @@ import (
 
 func newTestService(t *testing.T) *LanternService {
 	t.Helper()
-	return NewLanternService(graph.NewGraphCache[string, *pb.Vertex](time.Minute))
+	return NewLanternService(graphcache.NewGraphCache[string, *pb.Vertex](time.Minute))
 }
 
 func futureTs(d time.Duration) *timestamppb.Timestamp {
@@ -139,7 +139,7 @@ func TestLanternService_AddEdge_Additive(t *testing.T) {
 // count is surfaced via HotPathMetrics.OnEdgeContribDeduped. Dedup
 // convergence itself is covered by the core tests and tests/integration.
 func TestLanternService_AddEdges_ContribIDWiring(t *testing.T) {
-	var id0, id1 graph.ContribID
+	var id0, id1 graphcache.ContribID
 	id0[0], id0[23] = 0x11, 0x22
 	id1[0], id1[23] = 0x33, 0x44
 
@@ -493,7 +493,7 @@ func TestLanternService_SingularWriteFacades(t *testing.T) {
 // trace it back to the env knob).
 func TestExpirationClamp_RejectsBeyondTTL(t *testing.T) {
 	const ttl = time.Hour
-	s := NewLanternService(graph.NewGraphCache[string, *pb.Vertex](time.Minute)).
+	s := NewLanternService(graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)).
 		WithTombstoneTTL(ttl)
 	ctx := context.Background()
 
@@ -541,7 +541,7 @@ func TestExpirationClamp_RejectsBeyondTTL(t *testing.T) {
 // Within the clamp, the same RPCs succeed.
 func TestExpirationClamp_AcceptsWithinTTL(t *testing.T) {
 	const ttl = time.Hour
-	s := NewLanternService(graph.NewGraphCache[string, *pb.Vertex](time.Minute)).
+	s := NewLanternService(graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)).
 		WithTombstoneTTL(ttl)
 	ctx := context.Background()
 
@@ -561,7 +561,7 @@ func TestExpirationClamp_AcceptsWithinTTL(t *testing.T) {
 
 // Zero expiration (= no expiration) is always accepted regardless of TTL.
 func TestExpirationClamp_ZeroAlwaysAllowed(t *testing.T) {
-	s := NewLanternService(graph.NewGraphCache[string, *pb.Vertex](time.Minute)).
+	s := NewLanternService(graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)).
 		WithTombstoneTTL(time.Minute)
 	ctx := context.Background()
 	if _, err := s.PutVertices(ctx, &pb.PutVerticesRequest{
@@ -845,7 +845,7 @@ func TestLanternService_MutationLog_BurstAppendsMonotone(t *testing.T) {
 	clock := hlc.New(hlc.NodeID{0x11, 0x22, 0x33, 0x44}, hlc.Options{})
 
 	var appendCount int
-	s := NewLanternService(graph.NewGraphCache[string, *pb.Vertex](time.Minute)).
+	s := NewLanternService(graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)).
 		WithReplication(log, clock, func() { appendCount++ })
 
 	ch, cancel, err := log.Subscribe(0)
@@ -904,7 +904,7 @@ func TestLanternService_MutationLog_BurstAppendsMonotone(t *testing.T) {
 // the service is built without WithReplication: write RPCs must still
 // succeed and not panic on the nil log/clock.
 func TestLanternService_MutationLog_NotWired_NoOp(t *testing.T) {
-	s := NewLanternService(graph.NewGraphCache[string, *pb.Vertex](time.Minute))
+	s := NewLanternService(graphcache.NewGraphCache[string, *pb.Vertex](time.Minute))
 	if _, err := s.PutVertices(context.Background(), &pb.PutVerticesRequest{
 		Vertices: []*pb.Vertex{{Key: "k"}},
 	}); err != nil {
@@ -984,7 +984,7 @@ func (f *fakeHotPathMetrics) OnEdgeContribDeduped(n int) {
 
 func TestLanternService_HotPathMetrics_EmitsOnceForBatchAndIlluminate(t *testing.T) {
 	fm := &fakeHotPathMetrics{}
-	s := NewLanternService(graph.NewGraphCache[string, *pb.Vertex](time.Minute)).
+	s := NewLanternService(graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)).
 		WithHotPathMetrics(fm)
 
 	ctx := context.Background()
@@ -1083,7 +1083,7 @@ func TestLanternService_HotPathMetrics_EmitsOnScan(t *testing.T) {
 // once), and that a present-but-nil vertex value still scores as a hit.
 func TestLanternService_HotPathMetrics_EmitsGetVertexHitMiss(t *testing.T) {
 	fm := &fakeHotPathMetrics{}
-	s := NewLanternService(graph.NewGraphCache[string, *pb.Vertex](time.Minute)).
+	s := NewLanternService(graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)).
 		WithHotPathMetrics(fm)
 	ctx := context.Background()
 
@@ -1132,7 +1132,7 @@ func TestLanternService_HotPathMetrics_EmitsGetVertexHitMiss(t *testing.T) {
 // GetEdge forwards through the plural.
 func TestLanternService_HotPathMetrics_EmitsGetEdgeHitMiss(t *testing.T) {
 	fm := &fakeHotPathMetrics{}
-	s := NewLanternService(graph.NewGraphCache[string, *pb.Vertex](time.Minute)).
+	s := NewLanternService(graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)).
 		WithHotPathMetrics(fm)
 	ctx := context.Background()
 
@@ -1175,7 +1175,7 @@ func TestLanternService_HotPathMetrics_EmitsGetEdgeHitMiss(t *testing.T) {
 func TestExpirationClamp_FiresValidationRejectHook(t *testing.T) {
 	const ttl = time.Hour
 	var got []string
-	s := NewLanternService(graph.NewGraphCache[string, *pb.Vertex](time.Minute)).
+	s := NewLanternService(graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)).
 		WithTombstoneTTL(ttl).
 		WithValidationRejectHook(func(reason string) { got = append(got, reason) })
 

--- a/tests/integration/antientropy_test.go
+++ b/tests/integration/antientropy_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
@@ -23,7 +23,7 @@ import (
 type antiEntropyNode struct {
 	addr   string // host:port form, for replication.AntiEntropy peer config
 	url    string // full http:// URL, for SDK + raw Connect clients
-	cache  *cachegraph.GraphCache[string, *pb.Vertex]
+	cache  *graphcache.GraphCache[string, *pb.Vertex]
 	clock  *hlc.Clock
 	log    *mutationlog.Log
 	svc    *service.LanternService
@@ -36,7 +36,7 @@ func newAntiEntropyNode(t *testing.T, nodeID hlc.NodeID) *antiEntropyNode {
 	mlog := mutationlog.New(mutationlog.Options{Capacity: 1024, SubscriberBuffer: 1024})
 	t.Cleanup(func() { _ = mlog.Close() })
 	clock := hlc.New(nodeID, hlc.Options{})
-	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	svc := service.NewLanternService(cache).WithReplication(mlog, clock, nil)
 	rep := service.NewLanternReplicationService(mlog, cache, clock).WithOriginStates(svc)
 	srv := newConnectTestServer(t, svc, rep)

--- a/tests/integration/client_options_test.go
+++ b/tests/integration/client_options_test.go
@@ -11,7 +11,7 @@ import (
 
 	"connectrpc.com/connect"
 
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
 	client "github.com/anaregdesign/lantern/sdks/go"
@@ -32,7 +32,7 @@ func newOptsClient(
 	extra ...connect.Interceptor,
 ) *client.Lantern {
 	t.Helper()
-	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	svc := service.NewLanternService(cache)
 	val := provider.NewValidationInterceptor(lim)
 	interceptors := append([]connect.Interceptor{val.ConnectInterceptor()}, extra...)
@@ -49,7 +49,7 @@ func newOptsClientWithCustomOptions(
 	extra ...connect.Interceptor,
 ) *client.Lantern {
 	t.Helper()
-	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	svc := service.NewLanternService(cache)
 	val := provider.NewValidationInterceptor(lim)
 	interceptors := append([]connect.Interceptor{val.ConnectInterceptor()}, extra...)

--- a/tests/integration/edge_prefix_test.go
+++ b/tests/integration/edge_prefix_test.go
@@ -12,7 +12,7 @@ import (
 // seedPrefixEdges creates both endpoints as live vertices and then puts the
 // edges with an explicit non-zero expiration. Edges without an explicit
 // expiration are born-expired (1970-01-01) — see the AGENTS.md note in
-// core/cache/graph for the same trap.
+// core/graphcache for the same trap.
 func seedPrefixEdges(t *testing.T, ctx context.Context, l *client.Lantern, pairs [][2]string) {
 	t.Helper()
 	keySet := map[string]struct{}{}

--- a/tests/integration/health_test.go
+++ b/tests/integration/health_test.go
@@ -10,7 +10,7 @@ import (
 	"connectrpc.com/connect"
 	"connectrpc.com/grpchealth"
 
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
 	client "github.com/anaregdesign/lantern/sdks/go"
@@ -24,7 +24,7 @@ import (
 // server/provider/health.go + lantern_listener.go wire production.
 func newInProcessClientWithHealth(t *testing.T, serving bool) (*client.Lantern, func()) {
 	t.Helper()
-	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	svc := service.NewLanternService(cache)
 
 	// Pre-register the canonical empty service name so the static

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -12,7 +12,7 @@ import (
 	"connectrpc.com/connect"
 	"golang.org/x/net/http2"
 
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
 	client "github.com/anaregdesign/lantern/sdks/go"
@@ -148,7 +148,7 @@ func h2cClient() *http.Client {
 // tear anything down explicitly.
 func newInProcessClient(t *testing.T) (*client.Lantern, func()) {
 	t.Helper()
-	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	svc := service.NewLanternService(cache)
 	val := provider.NewValidationInterceptor(defaultIntegrationValidationLimits())
 	srv := newConnectTestServer(t, svc, nil, val.ConnectInterceptor())
@@ -160,7 +160,7 @@ func newInProcessClient(t *testing.T) (*client.Lantern, func()) {
 // trip mid-batch failures.
 func newInProcessClientChunked(t *testing.T, chunkSize int) (*client.Lantern, func()) {
 	t.Helper()
-	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	svc := service.NewLanternService(cache)
 	val := provider.NewValidationInterceptor(defaultIntegrationValidationLimits())
 	srv := newConnectTestServer(t, svc, nil, val.ConnectInterceptor())
@@ -173,7 +173,7 @@ func newInProcessClientChunked(t *testing.T, chunkSize int) (*client.Lantern, fu
 // prefix-scan integration tests pass.
 func newInProcessClientWithPrefix(t *testing.T) (*client.Lantern, func()) {
 	t.Helper()
-	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	cache.EnablePrefixIndex(func(k string) string { return k })
 	svc := service.NewLanternService(cache)
 	val := provider.NewValidationInterceptor(defaultIntegrationValidationLimits())
@@ -189,7 +189,7 @@ func newInProcessClientWithPrefix(t *testing.T) (*client.Lantern, func()) {
 // so callers may discard it.
 func newRawConnectClient(t *testing.T, enablePrefixIndex bool) (graphv1connect.LanternServiceClient, func()) {
 	t.Helper()
-	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	if enablePrefixIndex {
 		cache.EnablePrefixIndex(func(k string) string { return k })
 	}

--- a/tests/integration/idempotent_add_test.go
+++ b/tests/integration/idempotent_add_test.go
@@ -7,7 +7,7 @@ import (
 
 	"connectrpc.com/connect"
 
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	client "github.com/anaregdesign/lantern/sdks/go"
 	"github.com/anaregdesign/lantern/server/provider"
@@ -44,7 +44,7 @@ func (doubleSendInterceptor) WrapStreamingHandler(next connect.StreamingHandlerF
 // stay isolated.
 func newIdempotencyHarness(t *testing.T, opts ...client.Option) *client.Lantern {
 	t.Helper()
-	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	svc := service.NewLanternService(cache)
 	val := provider.NewValidationInterceptor(defaultIntegrationValidationLimits())
 	srv := newConnectTestServer(t, svc, nil, val.ConnectInterceptor())

--- a/tests/integration/middleware_chain_test.go
+++ b/tests/integration/middleware_chain_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	client "github.com/anaregdesign/lantern/sdks/go"
 	"github.com/anaregdesign/lantern/server/provider"
@@ -18,7 +18,7 @@ import (
 // and drives it through the public SDK Connect client. The closest
 // thing to an end-to-end smoke test without hitting the wire.
 func TestIntegration_FullMiddlewareChain(t *testing.T) {
-	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	svc := service.NewLanternService(cache)
 	val := provider.NewValidationInterceptor(provider.ValidationLimits{
 		MaxKeyLen:         32,
@@ -94,7 +94,7 @@ func TestIntegration_FullMiddlewareChain(t *testing.T) {
 // own server with no rate limiter so the assertions aren't sensitive
 // to token bucket state from other tests in this file.
 func TestIntegration_BatchDeletes(t *testing.T) {
-	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	svc := service.NewLanternService(cache)
 	val := provider.NewValidationInterceptor(provider.ValidationLimits{
 		MaxKeyLen:         32,

--- a/tests/integration/peer_pump_test.go
+++ b/tests/integration/peer_pump_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
@@ -23,7 +23,7 @@ import (
 // observationally equivalent at the wire level.
 type pumpNode struct {
 	url    string // full http://host:port URL (used by pump dialer + replication client)
-	cache  *cachegraph.GraphCache[string, *pb.Vertex]
+	cache  *graphcache.GraphCache[string, *pb.Vertex]
 	clock  *hlc.Clock
 	log    *mutationlog.Log
 	svc    *service.LanternService
@@ -37,7 +37,7 @@ func newPumpNode(t *testing.T, nodeID hlc.NodeID) *pumpNode {
 	log := mutationlog.New(mutationlog.Options{Capacity: 1024, SubscriberBuffer: 1024})
 	t.Cleanup(func() { _ = log.Close() })
 	clock := hlc.New(nodeID, hlc.Options{})
-	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	svc := service.NewLanternService(cache).WithReplication(log, clock, nil)
 	rep := service.NewLanternReplicationService(log, cache, clock)
 
@@ -88,7 +88,7 @@ func (n *pumpNode) startPump(ctx context.Context, t *testing.T, peers []string) 
 
 // waitForVertex polls cache.GetVertex until the key appears or the
 // deadline elapses.
-func waitForVertex(t *testing.T, cache *cachegraph.GraphCache[string, *pb.Vertex], key string, timeout time.Duration) bool {
+func waitForVertex(t *testing.T, cache *graphcache.GraphCache[string, *pb.Vertex], key string, timeout time.Duration) bool {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
@@ -102,7 +102,7 @@ func waitForVertex(t *testing.T, cache *cachegraph.GraphCache[string, *pb.Vertex
 
 // waitForEdge polls cache.GetWeight until the (tail,head) appears with
 // at least the expected weight, or the deadline elapses.
-func waitForEdge(t *testing.T, cache *cachegraph.GraphCache[string, *pb.Vertex], tail, head string, want float32, timeout time.Duration) (float32, bool) {
+func waitForEdge(t *testing.T, cache *graphcache.GraphCache[string, *pb.Vertex], tail, head string, want float32, timeout time.Duration) (float32, bool) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
@@ -162,7 +162,7 @@ func TestPeerPump_E2E_ThreeNodeConvergence(t *testing.T) {
 
 	for _, tc := range []struct {
 		name, key string
-		cache     *cachegraph.GraphCache[string, *pb.Vertex]
+		cache     *graphcache.GraphCache[string, *pb.Vertex]
 	}{
 		{"b sees from-a", "from-a", b.cache},
 		{"c sees from-a", "from-a", c.cache},

--- a/tests/integration/snapshot_test.go
+++ b/tests/integration/snapshot_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
@@ -24,7 +24,7 @@ import (
 // writes) and a raw Connect-Go replication client (for
 // Snapshot/Subscribe).
 type snapshotPeer struct {
-	cache *cachegraph.GraphCache[string, *pb.Vertex]
+	cache *graphcache.GraphCache[string, *pb.Vertex]
 	clock *hlc.Clock
 	log   *mutationlog.Log
 	sdk   *client.Lantern
@@ -43,7 +43,7 @@ func newSnapshotPeer(t *testing.T, nodeID hlc.NodeID) *snapshotPeer {
 	log := mutationlog.New(mutationlog.Options{Capacity: 1024, SubscriberBuffer: 1024})
 	t.Cleanup(func() { _ = log.Close() })
 	clock := hlc.New(nodeID, hlc.Options{})
-	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	svc := service.NewLanternService(cache).WithReplication(log, clock, nil)
 	rep := service.NewLanternReplicationService(log, cache, clock).
 		WithOriginStates(svc)
@@ -161,7 +161,7 @@ func TestSnapshot_E2E_PrimaryToFollower(t *testing.T) {
 			se := e.Edge
 			edgeHLC := snapshotHLC(se.GetHlc())
 			for _, c := range se.GetContributions() {
-				var cid cachegraph.ContribID
+				var cid graphcache.ContribID
 				copy(cid[:], c.GetContribId())
 				follower.cache.AddEdgeWithExpirationContribHLC(
 					se.GetTail(), se.GetHead(), c.GetWeight(),

--- a/tests/integration/subscribe_test.go
+++ b/tests/integration/subscribe_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	cachegraph "github.com/anaregdesign/lantern/core/cache/graph"
+	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
@@ -36,7 +36,7 @@ func TestSubscribe_E2E_100Writes(t *testing.T) {
 	t.Cleanup(func() { _ = log.Close() })
 	clock := hlc.New(hlc.NodeID{0xAA, 0xBB}, hlc.Options{})
 
-	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 
 	svc := service.NewLanternService(cache).
 		WithReplication(log, clock, nil)
@@ -125,7 +125,7 @@ func TestSubscribe_PerOriginCursor_Skips(t *testing.T) {
 	t.Cleanup(func() { _ = log.Close() })
 	clock := hlc.New(originA, hlc.Options{})
 
-	cache := cachegraph.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	svc := service.NewLanternService(cache).
 		WithReplication(log, clock, nil)
 	rep := service.NewLanternReplicationService(log, cache, clock)


### PR DESCRIPTION
## What

Moves `core/cache/graph/` → `core/graphcache/` and renames the package
`graph` → `graphcache`, flattening the unnaturally deep nesting of the
graph-specialised cache (which is `core`'s largest unit and includes the
radix prefix-index cluster).

Type and constructor names are **unchanged** (`GraphCache` / `NewGraphCache`),
so this is a pure move + package rename. The mild stutter `graphcache.GraphCache`
is accepted for now; the `GraphCache` → `Cache` rename is deferred to a
follow-up issue.

## How

- `git mv` all 24 files (renames detected at ≥78% similarity).
- Update package decls: `package graph` → `package graphcache`, and the
  black-box `package graph_test` → `package graphcache_test`.
- Update import paths and qualifiers across `server/`, `tests/integration/`,
  and the moved `example/`.
- Preserve the `core/graph` model package (still imported as the `coregraph`
  alias) and the proto FQN `graph.v1.LanternService` — neither is affected.
- Regenerate `server/cmd/wire_gen.go` (no diff — it receives the concrete type
  via inference from `provider.NewGraphCache`).
- Refresh `core/README.md`.

## Verification

- `gofmt -l` clean; `go vet ./...` (server) clean.
- `go build ./...` + `go test ./...` pass in **every** module
  (core, pb, sdks/go, mcp, server, root incl. `tests/integration`).
- No residual `cache/graph` references in any tracked file.

Closes #621