### PR TITLE
feat(core): add opt-in inverted search index to GraphCache

### DIFF
--- a/core/graphcache/bench_test.go
+++ b/core/graphcache/bench_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/anaregdesign/lantern/core/search"
 )
 
 // makeKey returns a string of length n. It mimics a normalized URL by
@@ -256,4 +258,44 @@ func BenchmarkAddEdge_Existing(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		c.AddEdgeWithExpiration("hot-tail", "hot-head", 1, exp)
 	}
+}
+
+// benchSearchCorpus is a small pool of realistic content strings the put
+// benchmark cycles through so the analyzer (normalize → bigram → filter) does
+// representative work on every indexed write rather than re-tokenizing one
+// cached string.
+var benchSearchCorpus = []string{
+	"lantern graph database memory",
+	"connect http2 grpc gateway",
+	"vertex edge ttl decay model",
+	"inverted index bm25 ranking",
+	"namespace prefix scan traversal",
+}
+
+// BenchmarkPutVertex_Search contrasts the vertex put hot path with the search
+// index disabled ("Plain") versus enabled ("Indexed"). The Plain arm proves
+// the feature stays pay-for-what-you-use — a single nil check per put — while
+// the Indexed arm captures the analyze-and-index cost a search-enabled server
+// pays. Run with -benchmem; the delta between the two arms is the headline.
+func BenchmarkPutVertex_Search(b *testing.B) {
+	exp := time.Now().Add(time.Hour)
+
+	b.Run("Plain", func(b *testing.B) {
+		c := NewGraphCache[string, string](time.Hour)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			c.PutVertexWithExpiration(makeKey("k", i, 24), benchSearchCorpus[i%len(benchSearchCorpus)], exp)
+		}
+	})
+
+	b.Run("Indexed", func(b *testing.B) {
+		c := NewGraphCache[string, string](time.Hour)
+		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			c.PutVertexWithExpiration(makeKey("k", i, 24), benchSearchCorpus[i%len(benchSearchCorpus)], exp)
+		}
+	})
 }

--- a/core/graphcache/cache.go
+++ b/core/graphcache/cache.go
@@ -11,6 +11,7 @@ import (
 	"github.com/anaregdesign/lantern/core/collection/pq"
 	"github.com/anaregdesign/lantern/core/graph"
 	"github.com/anaregdesign/lantern/core/hlc"
+	"github.com/anaregdesign/lantern/core/search"
 )
 
 // neighborParallelThreshold is the minimum frontier size that triggers
@@ -64,6 +65,19 @@ type GraphCache[S comparable, T any] struct {
 	// before/after benchmarks. Production code never disables it.
 	headByTail map[vertexID]*headIndex
 
+	// searchIndex is an optional secondary inverted index (see
+	// EnableSearchIndex) that ranks live vertices by how well their
+	// projected value matches a query (BM25). Like prefixIndex it is opt-in
+	// and maintained under c.mu, but it differs in one way: it is refreshed
+	// on EVERY put, not just the first insert, because a vertex's value —
+	// and therefore its postings — changes on overwrite. Entries are dropped
+	// from the index by the shared vertices.SetOnEvict hook, so they decay
+	// in lockstep with the vertices they describe (Delete, Clear, and TTL
+	// Flush all route through that hook). When nil the put / evict paths pay
+	// only a single nil check.
+	searchIndex   *search.InvertedIndex[S, search.Document]
+	searchExtract func(T) search.Document
+
 	// vertexHLC tracks the last HLC accepted by PutVertexWithExpirationHLC
 	// (the LWW replication apply path; #182). It is only populated when
 	// a replicated write touches a vertex; the local non-replicated path
@@ -106,6 +120,11 @@ func NewGraphCache[S comparable, T any](defaultTTL time.Duration) *GraphCache[S,
 		}
 		if idx := c.prefixIndex; idx != nil {
 			idx.delete(c.prefixExtract(key))
+		}
+		// One hook covers Delete, Clear, and the TTL Flush GC tick, so the
+		// search index decays in lockstep with the vertices it describes.
+		if idx := c.searchIndex; idx != nil {
+			idx.Delete(key)
 		}
 	})
 	return c
@@ -152,6 +171,14 @@ func (c *GraphCache[S, T]) putVertexLocked(key S, value T, expiration time.Time)
 	c.vertices.PutWithExpiration(key, value, expiration)
 	if firstInsert && c.prefixIndex != nil {
 		c.prefixIndex.insert(c.prefixExtract(key))
+	}
+	// Unlike the prefix index, the search index is refreshed on EVERY put:
+	// an overwrite changes the value and therefore the postings, so the
+	// index must re-extract even when the key already existed. Index doubles
+	// as update (it drops stale postings first), and projecting a valueless
+	// entry to an empty Document is a no-op, so this is safe for every value.
+	if c.searchIndex != nil {
+		c.searchIndex.Index(key, c.searchExtract(value))
 	}
 }
 

--- a/core/graphcache/search.go
+++ b/core/graphcache/search.go
@@ -1,0 +1,126 @@
+package graphcache
+
+import (
+	"strings"
+
+	"github.com/anaregdesign/lantern/core/search"
+)
+
+// newSearchIndex builds the inverted index used by the optional content-search
+// feature. It installs the multilingual bigram pipeline documented in
+// core/search/example as the best general-purpose setup: width / diacritic /
+// lowercase / punctuation / space normalizers feed an NGramTokenizer{N: 2}
+// whose grams keep two-character (e.g. CJK) words indexable while still
+// matching infixes, and a single WhitespaceFilter drops the grams that straddle
+// a word boundary. Matches are ranked by Okapi BM25 with the standard
+// parameters. The same analyzer runs over both stored values and queries, so
+// index-time and query-time terms stay symmetric.
+func newSearchIndex[S comparable]() *search.InvertedIndex[S, search.Document] {
+	normalizers := []search.Normalizer{
+		search.WidthNormalizer{},
+		search.DiacriticNormalizer{},
+		search.LowercaseNormalizer{},
+		search.PunctuationNormalizer{},
+		search.SpaceNormalizer{},
+	}
+	analyzer := search.NewAnalyzer(
+		normalizers,
+		search.NGramTokenizer{N: 2},
+		[]search.TokenFilter{search.WhitespaceFilter{}},
+	)
+	scorer := search.BM25{K1: 1.2, B: 0.75}
+	return search.NewInvertedIndex[S, search.Document](analyzer, scorer)
+}
+
+// EnableSearchIndex turns on the optional content-search index, projecting each
+// stored value T into the search.Document that gets indexed (for example the
+// vertex's string value). Like EnablePrefixIndex it must be called before any
+// vertex is stored, is idempotent, and panics on a non-empty cache so the
+// caller cannot silently observe an index that disagrees with point reads.
+// extract must not be nil.
+//
+// Once enabled, the index is kept in perfect lockstep with the vertex
+// lifecycle: every put (including overwrites) re-indexes the value, and
+// eviction — Delete, Clear, and TTL Flush — drops the key through the shared
+// SetOnEvict hook, so entries decay together with the vertices they describe.
+// The index is a third opt-in secondary structure alongside the prefix index;
+// when it is left disabled the put / evict hot paths pay only a nil check.
+func (c *GraphCache[S, T]) EnableSearchIndex(extract func(T) search.Document) {
+	if extract == nil {
+		panic("graphcache: EnableSearchIndex extract must not be nil")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.searchIndex != nil {
+		return // idempotent: re-enabling with the same intent is fine
+	}
+	if c.vertices.Count() != 0 {
+		panic("graphcache: EnableSearchIndex must be called before any vertex is stored")
+	}
+	c.searchExtract = extract
+	c.searchIndex = newSearchIndex[S]()
+}
+
+// SearchVertices returns up to limit keys whose indexed content matches query,
+// ranked most-relevant first by BM25. An empty or unanalyzable query, a
+// disabled index, or limit <= 0 returns nil. A non-empty keyPrefix scopes the
+// results to a namespace, keeping only keys whose projection (the same one the
+// prefix index uses) starts with keyPrefix.
+//
+// Consistency mirrors ScanByPrefix: a hit is returned only when the vertex is
+// still live, so a vertex whose TTL has expired but which has not yet been
+// flushed is skipped — the returned set matches what a matching sequence of
+// GetVertex calls under the snapshot lock would surface. Because matching is
+// the index's boolean OR over the query terms, limit is applied after the
+// liveness and prefix filters so a full page of live, in-scope hits is
+// returned whenever one exists.
+func (c *GraphCache[S, T]) SearchVertices(query string, limit int, keyPrefix string) []search.Result[S] {
+	if limit <= 0 {
+		return nil
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.searchIndex == nil {
+		return nil
+	}
+	ranked := c.searchIndex.Search(query)
+	if len(ranked) == 0 {
+		return nil
+	}
+	out := make([]search.Result[S], 0, min(limit, len(ranked)))
+	for _, r := range ranked {
+		if !c.vertices.Has(r.ID) {
+			// Expired between the index write and this snapshot but the
+			// async Flush has not run yet; consistent with point-read
+			// semantics, treat as absent.
+			continue
+		}
+		if keyPrefix != "" && !c.keyHasPrefix(r.ID, keyPrefix) {
+			continue
+		}
+		out = append(out, r)
+		if len(out) == limit {
+			break
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// keyHasPrefix reports whether key's string projection starts with prefix,
+// using the same projection the prefix index uses when it is enabled. When the
+// prefix index is disabled it falls back to the identity projection for the
+// string-keyed instantiation (Lantern's only production case); a non-string S
+// without a prefix projection cannot be scoped, so it never matches a
+// non-empty prefix. Callers must hold c.mu.
+func (c *GraphCache[S, T]) keyHasPrefix(key S, prefix string) bool {
+	if c.prefixExtract != nil {
+		return strings.HasPrefix(c.prefixExtract(key), prefix)
+	}
+	if s, ok := any(key).(string); ok {
+		return strings.HasPrefix(s, prefix)
+	}
+	return false
+}

--- a/core/graphcache/search_test.go
+++ b/core/graphcache/search_test.go
@@ -1,0 +1,227 @@
+package graphcache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/search"
+)
+
+// textExtract is the value projection used by the string-keyed tests: it makes
+// the stored string value itself the searchable document.
+func textExtract(s string) search.Document { return search.Text(s) }
+
+// keys returns just the IDs of a ranked result set, in rank order, for terse
+// assertions.
+func keys(results []search.Result[string]) []string {
+	out := make([]string, len(results))
+	for i, r := range results {
+		out[i] = r.ID
+	}
+	return out
+}
+
+func TestGraphCache_SearchDisabledByDefault(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	c.PutVertex("k", "lantern graph database")
+	// Without EnableSearchIndex the search path is inert: no index work on
+	// put, and SearchVertices returns nil.
+	if got := c.SearchVertices("database", 10, ""); got != nil {
+		t.Fatalf("SearchVertices without enable: got %v want nil", got)
+	}
+}
+
+func TestGraphCache_EnableSearchIndex_AfterPutPanics(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	c.PutVertex("k", "v")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when enabling search index on non-empty cache")
+		}
+	}()
+	c.EnableSearchIndex(textExtract)
+}
+
+func TestGraphCache_EnableSearchIndex_NilExtractPanics(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when extract is nil")
+		}
+	}()
+	c.EnableSearchIndex(nil)
+}
+
+func TestGraphCache_EnableSearchIndex_Idempotent(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	c.EnableSearchIndex(textExtract)
+	c.EnableSearchIndex(textExtract) // must not panic
+}
+
+func TestGraphCache_SearchVertices(t *testing.T) {
+	t.Run("Ranking", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract)
+		c.PutVertex("exact", "arch")
+		c.PutVertex("infix", "research laboratory")
+		c.PutVertex("other", "a giant panda")
+
+		got := c.SearchVertices("arch", 10, "")
+		// "panda" never shares a gram with "arch"; the exact short doc must
+		// outrank the longer infix match (BM25 length normalization).
+		if want := []string{"exact", "infix"}; !equalKeys(keys(got), want) {
+			t.Fatalf("SearchVertices(arch) = %v, want %v", keys(got), want)
+		}
+	})
+
+	t.Run("Overwrite drops stale postings", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract)
+		c.PutVertex("k", "alpha")
+		if got := keys(c.SearchVertices("alpha", 10, "")); !equalKeys(got, []string{"k"}) {
+			t.Fatalf("before overwrite: SearchVertices(alpha) = %v, want [k]", got)
+		}
+		// Re-index on overwrite is the key difference from the prefix index:
+		// the old value's postings must disappear, the new value's appear.
+		c.PutVertex("k", "omega zulu")
+		if got := c.SearchVertices("alpha", 10, ""); got != nil {
+			t.Fatalf("after overwrite: SearchVertices(alpha) = %v, want nil", keys(got))
+		}
+		if got := keys(c.SearchVertices("omega", 10, "")); !equalKeys(got, []string{"k"}) {
+			t.Fatalf("after overwrite: SearchVertices(omega) = %v, want [k]", got)
+		}
+	})
+
+	t.Run("Delete stops matching", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract)
+		c.PutVertex("k", "gamma unique")
+		if got := keys(c.SearchVertices("gamma", 10, "")); !equalKeys(got, []string{"k"}) {
+			t.Fatalf("before delete: got %v, want [k]", got)
+		}
+		// DeleteVertex routes through the vertices.SetOnEvict hook, which must
+		// physically drop the posting from the search index.
+		if !c.DeleteVertex("k") {
+			t.Fatal("DeleteVertex(k) reported not-present")
+		}
+		if got := c.SearchVertices("gamma", 10, ""); got != nil {
+			t.Fatalf("after delete: got %v, want nil", keys(got))
+		}
+	})
+
+	t.Run("Clear stops matching", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract)
+		c.PutVertex("a", "shared term")
+		c.PutVertex("b", "shared word")
+		// The inner cache's Clear fires SetOnEvict for every key, so the
+		// search index must end up empty too.
+		c.vertices.Clear()
+		if got := c.SearchVertices("shared", 10, ""); got != nil {
+			t.Fatalf("after clear: got %v, want nil", keys(got))
+		}
+	})
+
+	t.Run("TTL expiry stops matching", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract)
+		// Live and already-expired vertices share the term; only the live one
+		// must surface, even before the GC Flush runs (liveness filter).
+		c.PutVertex("live", "delta payload")
+		c.PutVertexWithExpiration("dead", "delta payload", time.Now().Add(-time.Minute))
+		if got := keys(c.SearchVertices("delta", 10, "")); !equalKeys(got, []string{"live"}) {
+			t.Fatalf("before flush: got %v, want [live]", got)
+		}
+		// After the Flush physically evicts the expired vertex, the index drops
+		// its posting via SetOnEvict and the result is unchanged.
+		c.vertices.Flush()
+		if got := keys(c.SearchVertices("delta", 10, "")); !equalKeys(got, []string{"live"}) {
+			t.Fatalf("after flush: got %v, want [live]", got)
+		}
+	})
+
+	t.Run("KeyPrefix scopes results", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract)
+		c.PutVertex("user:1", "common keyword")
+		c.PutVertex("user:2", "common keyword")
+		c.PutVertex("session:a", "common keyword")
+		got := c.SearchVertices("keyword", 10, "user:")
+		if want := []string{"user:1", "user:2"}; !sameSet(keys(got), want) {
+			t.Fatalf("SearchVertices(keyword, prefix user:) = %v, want %v", keys(got), want)
+		}
+	})
+
+	t.Run("Limit caps results", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract)
+		for _, k := range []string{"k1", "k2", "k3", "k4"} {
+			c.PutVertex(k, "common keyword")
+		}
+		if got := c.SearchVertices("keyword", 2, ""); len(got) != 2 {
+			t.Fatalf("SearchVertices(keyword, limit 2) returned %d hits, want 2", len(got))
+		}
+	})
+
+	t.Run("Empty query returns nil", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract)
+		c.PutVertex("k", "anything")
+		if got := c.SearchVertices("", 10, ""); got != nil {
+			t.Fatalf("SearchVertices(empty) = %v, want nil", keys(got))
+		}
+	})
+
+	t.Run("Non-positive limit returns nil", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract)
+		c.PutVertex("k", "anything")
+		if got := c.SearchVertices("anything", 0, ""); got != nil {
+			t.Fatalf("SearchVertices(limit 0) = %v, want nil", keys(got))
+		}
+		if got := c.SearchVertices("anything", -1, ""); got != nil {
+			t.Fatalf("SearchVertices(limit -1) = %v, want nil", keys(got))
+		}
+	})
+
+	t.Run("No match returns nil", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract)
+		c.PutVertex("k", "alpha beta")
+		if got := c.SearchVertices("zzzzz", 10, ""); got != nil {
+			t.Fatalf("SearchVertices(no-match) = %v, want nil", keys(got))
+		}
+	})
+}
+
+// equalKeys reports whether got equals want in the same order.
+func equalKeys(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// sameSet reports whether got and want contain the same keys regardless of
+// order — used where rank order between equally-scored docs is unspecified.
+func sameSet(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	seen := make(map[string]int, len(got))
+	for _, k := range got {
+		seen[k]++
+	}
+	for _, k := range want {
+		if seen[k] == 0 {
+			return false
+		}
+		seen[k]--
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Foundation for the content-addressed vertex search epic (#628): an optional
**inverted search index** on `GraphCache`, kept in perfect lockstep with the
vertex lifecycle. No RPC surface here — that lands in the dependent sub-issues.

`GraphCache` already hosts two opt-in secondary indexes under `c.mu`
(`prefixIndex`, `headByTail`); the search index is the third, following the same
established pattern so its entries decay together with the vertices they describe.

## What changed

- **`EnableSearchIndex(extract func(T) search.Document)`** — mirrors
  `EnablePrefixIndex`: must be called before any vertex is stored, idempotent,
  panics on a non-empty cache and on a nil `extract`. Installs the multilingual
  bigram pipeline from `core/search/example` (width / diacritic / lowercase /
  punctuation / space normalizers → `NGramTokenizer{N:2}` → `WhitespaceFilter`,
  scored by `BM25{K1:1.2, B:0.75}`).
- **`SearchVertices(query, limit, keyPrefix) []search.Result[S]`** — returns up
  to `limit` keys ranked by BM25. Empty/unanalyzable query, disabled index, or
  `limit <= 0` returns nil. Hits are filtered to **live** vertices (mirrors
  `ScanByPrefix` liveness via `c.vertices.Has`), and an optional `keyPrefix`
  scopes results using the same projection the prefix index uses. `limit` is
  applied **after** filtering so a full page of live, in-scope hits is returned
  whenever one exists.
- **Lifecycle wiring** — `putVertexLocked` re-indexes on **every** put
  (overwrites drop stale postings, the key difference from `prefixIndex`); the
  existing `vertices.SetOnEvict` closure now also calls `searchIndex.Delete`,
  which already covers Delete, Clear, and TTL `Flush`. When the index is left
  disabled, the put / evict hot paths pay only a nil check.

## Tests & benchmark

- `search_test.go` (white-box, sub-tests only): ranking sanity, overwrite drops
  stale postings, delete / Clear / TTL-expiry (GC Flush) stop matching,
  `keyPrefix` scoping, limit cap, empty / non-positive-limit / no-match → nil,
  `EnableSearchIndex` panics on non-empty cache + nil extract + idempotent.
- `BenchmarkPutVertex_Search` in `bench_test.go` quantifies the opt-in cost
  (Plain ~341 ns/op, 2 allocs vs Indexed ~3.8 µs/op, 40 allocs on M3 Max).

Quality gate: `gofmt -l` clean, `go vet` clean, `go test ./...` green in `core/`
and at the root.

Closes #623