### PR TITLE
feat(sdks/go): add SearchVertices client forwarder

### DIFF
--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -51,6 +51,15 @@ var ErrResourceExhausted = errors.New("resource exhausted")
 // retry against a sibling replica may succeed.
 var ErrUnavailable = errors.New("unavailable")
 
+// ErrFailedPrecondition wraps connect.CodeFailedPrecondition responses — the
+// "the server is not in a state to serve this call" signal. Its canonical
+// source is SearchVertices against a server started without the search index
+// (LANTERN_SEARCH_ENABLED=false): the call cannot succeed until an operator
+// enables the index, so it is a configuration state, not a transient failure.
+// Use errors.Is to present a calm "search is turned off" state rather than
+// retrying.
+var ErrFailedPrecondition = errors.New("failed precondition")
+
 // Edge re-exports the generated protobuf Edge type so SDK callers do not
 // need to import the pb package directly. It is a true Go type alias, not a
 // parallel struct: client.Edge and pb.Edge are the same type, freely
@@ -223,10 +232,10 @@ func unary[Req, Resp any](
 
 // wrapConnectErr lifts a *connect.Error into a joined error that
 // satisfies errors.Is against the matching SDK sentinel (ErrNotFound /
-// ErrInvalidArgument / ErrResourceExhausted / ErrUnavailable) while
-// preserving the original *connect.Error for callers that need
-// connect.CodeOf or the per-error metadata. Non-Connect errors pass
-// through unchanged.
+// ErrInvalidArgument / ErrResourceExhausted / ErrUnavailable /
+// ErrFailedPrecondition) while preserving the original *connect.Error for
+// callers that need connect.CodeOf or the per-error metadata. Non-Connect
+// errors pass through unchanged.
 func wrapConnectErr(err error) error {
 	if err == nil {
 		return nil
@@ -240,6 +249,8 @@ func wrapConnectErr(err error) error {
 		return errors.Join(ErrResourceExhausted, err)
 	case connect.CodeUnavailable:
 		return errors.Join(ErrUnavailable, err)
+	case connect.CodeFailedPrecondition:
+		return errors.Join(ErrFailedPrecondition, err)
 	}
 	return err
 }

--- a/sdks/go/search.go
+++ b/sdks/go/search.go
@@ -1,0 +1,82 @@
+package client
+
+import (
+	"context"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+)
+
+// SearchHit is one ranked result from Lantern.SearchVertices: the key of a
+// matching vertex paired with its full-text relevance Score (higher is more
+// relevant). Like EdgeRef it is a flat SDK-native value, not a proto alias —
+// it carries only the key and score, so call GetVertex / GetVertices on the
+// keys to hydrate the stored value and TTL.
+type SearchHit struct {
+	Key   string
+	Score float64
+}
+
+// SearchOption configures Lantern.SearchVertices. Use WithSearchLimit /
+// WithSearchPrefix to cap the result count or scope hits to a key prefix.
+type SearchOption func(*searchOptions)
+
+type searchOptions struct {
+	limit  uint32
+	prefix string
+}
+
+// WithSearchLimit caps the number of hits the server returns from one
+// SearchVertices call. 0 (the default) lets the server apply its configured
+// default (see LANTERN_SEARCH_DEFAULT_LIMIT). Values above the server's
+// configured maximum (LANTERN_SEARCH_MAX_LIMIT) are clamped down
+// server-side, so callers never need to pre-clamp.
+func WithSearchLimit(n uint32) SearchOption {
+	return func(o *searchOptions) { o.limit = n }
+}
+
+// WithSearchPrefix scopes hits to vertices whose key carries the given
+// prefix — the content-search analogue of restricting ScanVertices to a
+// namespace. An empty prefix (the default) searches every live vertex.
+func WithSearchPrefix(p string) SearchOption {
+	return func(o *searchOptions) { o.prefix = p }
+}
+
+// SearchVertices returns vertices ranked by full-text relevance over their
+// indexed content (key + value), most relevant first. It is the content
+// counterpart to ScanVertices' lexicographic key walk: search by a
+// remembered topic word instead of an exact key prefix.
+//
+// Empty result vs. error: an empty, unanalysable, or simply non-matching
+// query is a zero-hit success — the returned slice is empty (never nil) and
+// err is nil, not a sentinel. The server clamps the limit to its configured
+// (0, MaxLimit] range (0 = server default) AFTER applying liveness and
+// prefix filters, so the returned slice never exceeds the effective limit
+// and the SDK does not pre-clamp.
+//
+// Gating: when the server was started without the search index
+// (LANTERN_SEARCH_ENABLED=false) the call returns an error matching
+// ErrFailedPrecondition — a configuration state, not a transient failure.
+// Detect it with errors.Is(err, ErrFailedPrecondition) and present a calm
+// "search is turned off" state rather than retrying.
+func (l *Lantern) SearchVertices(ctx context.Context, query string, opts ...SearchOption) ([]SearchHit, error) {
+	o := searchOptions{}
+	for _, apply := range opts {
+		apply(&o)
+	}
+	ctx, cancel := l.applyTimeout(ctx)
+	defer cancel()
+	resp, err := unary(ctx, &pb.SearchVerticesRequest{
+		Query:  query,
+		Limit:  o.limit,
+		Prefix: o.prefix,
+	}, l.client.SearchVertices)
+	if err != nil {
+		return nil, err
+	}
+	pbHits := resp.GetHits()
+	hits := make([]SearchHit, 0, len(pbHits))
+	for _, h := range pbHits {
+		hits = append(hits, SearchHit{Key: h.GetKey(), Score: h.GetScore()})
+	}
+	return hits, nil
+}

--- a/sdks/go/search_test.go
+++ b/sdks/go/search_test.go
@@ -1,0 +1,163 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
+)
+
+func TestSearchOptions_Defaults(t *testing.T) {
+	o := searchOptions{}
+	if o.limit != 0 {
+		t.Errorf("default limit = %d, want 0", o.limit)
+	}
+	if o.prefix != "" {
+		t.Errorf("default prefix = %q, want empty", o.prefix)
+	}
+}
+
+func TestSearchOptions_Apply(t *testing.T) {
+	o := searchOptions{}
+	for _, apply := range []SearchOption{
+		WithSearchLimit(42),
+		WithSearchPrefix("user."),
+	} {
+		apply(&o)
+	}
+	if o.limit != 42 {
+		t.Errorf("limit = %d, want 42", o.limit)
+	}
+	if o.prefix != "user." {
+		t.Errorf("prefix = %q, want %q", o.prefix, "user.")
+	}
+}
+
+// captureSearch is a fake LanternServiceClient that records every
+// SearchVerticesRequest it receives and replays a canned response (or error).
+// It embeds the interface (left nil) so it satisfies the full surface while
+// overriding only SearchVertices.
+type captureSearch struct {
+	graphv1connect.LanternServiceClient
+	reqs []*pb.SearchVerticesRequest
+	resp *pb.SearchVerticesResponse
+	err  error
+}
+
+func (c *captureSearch) SearchVertices(_ context.Context, req *connect.Request[pb.SearchVerticesRequest]) (*connect.Response[pb.SearchVerticesResponse], error) {
+	c.reqs = append(c.reqs, req.Msg)
+	if c.err != nil {
+		return nil, c.err
+	}
+	resp := c.resp
+	if resp == nil {
+		resp = &pb.SearchVerticesResponse{}
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// TestSearchVertices verifies the forwarder's contracts: it wires
+// query/limit/prefix onto the request, maps the ranked *pb.SearchHit slice to
+// the SDK-native []SearchHit preserving order, treats a no-match response as a
+// zero-hit success (empty, non-nil slice, nil error), and lifts a
+// FAILED_PRECONDITION reply into the ErrFailedPrecondition sentinel.
+func TestSearchVertices(t *testing.T) {
+	newClient := func(t *testing.T) (*Lantern, *captureSearch) {
+		t.Helper()
+		l := mustLantern(t)
+		capt := &captureSearch{}
+		l.client = capt
+		return l, capt
+	}
+
+	t.Run("forwards query, limit and prefix", func(t *testing.T) {
+		l, capt := newClient(t)
+		if _, err := l.SearchVertices(context.Background(), "calm tone",
+			WithSearchLimit(7), WithSearchPrefix("user.")); err != nil {
+			t.Fatalf("SearchVertices: %v", err)
+		}
+		if len(capt.reqs) != 1 {
+			t.Fatalf("want 1 request, got %d", len(capt.reqs))
+		}
+		got := capt.reqs[0]
+		if got.GetQuery() != "calm tone" {
+			t.Errorf("query = %q, want %q", got.GetQuery(), "calm tone")
+		}
+		if got.GetLimit() != 7 {
+			t.Errorf("limit = %d, want 7", got.GetLimit())
+		}
+		if got.GetPrefix() != "user." {
+			t.Errorf("prefix = %q, want %q", got.GetPrefix(), "user.")
+		}
+	})
+
+	t.Run("default omits limit and prefix", func(t *testing.T) {
+		l, capt := newClient(t)
+		if _, err := l.SearchVertices(context.Background(), "q"); err != nil {
+			t.Fatalf("SearchVertices: %v", err)
+		}
+		got := capt.reqs[0]
+		if got.GetLimit() != 0 {
+			t.Errorf("default limit = %d, want 0 (server default)", got.GetLimit())
+		}
+		if got.GetPrefix() != "" {
+			t.Errorf("default prefix = %q, want empty", got.GetPrefix())
+		}
+	})
+
+	t.Run("maps ranked hits preserving order", func(t *testing.T) {
+		l, capt := newClient(t)
+		capt.resp = &pb.SearchVerticesResponse{Hits: []*pb.SearchHit{
+			{Key: "user.preferences.tone", Score: 2.5},
+			{Key: "user.preferences.format", Score: 1.0},
+		}}
+		hits, err := l.SearchVertices(context.Background(), "calm")
+		if err != nil {
+			t.Fatalf("SearchVertices: %v", err)
+		}
+		want := []SearchHit{
+			{Key: "user.preferences.tone", Score: 2.5},
+			{Key: "user.preferences.format", Score: 1.0},
+		}
+		if len(hits) != len(want) {
+			t.Fatalf("got %d hits, want %d", len(hits), len(want))
+		}
+		for i := range want {
+			if hits[i] != want[i] {
+				t.Errorf("hit[%d] = %+v, want %+v", i, hits[i], want[i])
+			}
+		}
+	})
+
+	t.Run("no match yields empty non-nil slice and nil error", func(t *testing.T) {
+		l, capt := newClient(t)
+		capt.resp = &pb.SearchVerticesResponse{} // zero hits
+		hits, err := l.SearchVertices(context.Background(), "nothing")
+		if err != nil {
+			t.Fatalf("no-match must be a success, got err: %v", err)
+		}
+		if hits == nil {
+			t.Fatalf("no-match must return an empty non-nil slice, got nil")
+		}
+		if len(hits) != 0 {
+			t.Fatalf("want 0 hits, got %d", len(hits))
+		}
+	})
+
+	t.Run("FAILED_PRECONDITION maps to ErrFailedPrecondition", func(t *testing.T) {
+		l, capt := newClient(t)
+		capt.err = connect.NewError(connect.CodeFailedPrecondition,
+			errors.New("vertex search is disabled on this server"))
+		hits, err := l.SearchVertices(context.Background(), "q")
+		if hits != nil {
+			t.Errorf("want nil hits on error, got %v", hits)
+		}
+		if !errors.Is(err, ErrFailedPrecondition) {
+			t.Fatalf("want errors.Is(err, ErrFailedPrecondition), got %v", err)
+		}
+	})
+}

--- a/tests/integration/search_vertices_test.go
+++ b/tests/integration/search_vertices_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/anaregdesign/lantern/core/search"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
+	client "github.com/anaregdesign/lantern/sdks/go"
 	"github.com/anaregdesign/lantern/server/service"
 )
 
@@ -50,6 +52,26 @@ func newSearchRawClient(t *testing.T, enabled bool) graphv1connect.LanternServic
 	})
 	srv := newConnectTestServer(t, svc, nil)
 	return graphv1connect.NewLanternServiceClient(h2cClient(), srv.url)
+}
+
+// newSearchSDKClient mirrors newSearchRawClient but returns the high-level
+// *client.Lantern so the SDK SearchVertices forwarder (#625) is exercised
+// against the real service handler — the SDK package itself keeps only
+// white-box request/response tests.
+func newSearchSDKClient(t *testing.T, enabled bool) *client.Lantern {
+	t.Helper()
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache.EnablePrefixIndex(func(k string) string { return k })
+	if enabled {
+		cache.EnableSearchIndex(searchVertexDocument)
+	}
+	svc := service.NewLanternService(cache).WithSearchLimits(service.SearchLimits{
+		Enabled:      enabled,
+		DefaultLimit: 100,
+		MaxLimit:     1000,
+	})
+	srv := newConnectTestServer(t, svc, nil)
+	return newConnectClientFor(t, srv.url)
 }
 
 func TestSearchVertices_EndToEnd(t *testing.T) {
@@ -119,4 +141,71 @@ func TestSearchVertices_DisabledReturnsFailedPrecondition(t *testing.T) {
 	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
 		t.Fatalf("code = %v, want FailedPrecondition", got)
 	}
+}
+
+// TestSearchVertices_SDKForwarder drives the SDK's high-level SearchVertices
+// against the live handler: ranked SearchHit mapping, WithSearchPrefix
+// scoping, the empty-query zero-hit success, and the disabled-server path
+// surfacing as the client.ErrFailedPrecondition sentinel (#625).
+func TestSearchVertices_SDKForwarder(t *testing.T) {
+	t.Run("ranked hits, prefix scope and empty query", func(t *testing.T) {
+		l := newSearchSDKClient(t, true)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		seed := []client.VertexInput{
+			{Key: "user.preferences.tone", Value: "calm and concise", Expiration: time.Now().Add(time.Hour)},
+			{Key: "user.preferences.format", Value: "calm bullet points", Expiration: time.Now().Add(time.Hour)},
+			{Key: "project.lantern.stack", Value: "go and react", Expiration: time.Now().Add(time.Hour)},
+		}
+		if err := l.PutVertices(ctx, seed); err != nil {
+			t.Fatalf("PutVertices: %v", err)
+		}
+
+		hits, err := l.SearchVertices(ctx, "calm")
+		if err != nil {
+			t.Fatalf("SearchVertices: %v", err)
+		}
+		if len(hits) != 2 {
+			t.Fatalf("hits = %d, want 2 (%+v)", len(hits), hits)
+		}
+		for _, h := range hits {
+			if !strings.HasPrefix(h.Key, "user.preferences.") {
+				t.Errorf("unexpected hit key %q", h.Key)
+			}
+			if h.Score <= 0 {
+				t.Errorf("hit %q score = %v, want > 0", h.Key, h.Score)
+			}
+		}
+
+		scoped, err := l.SearchVertices(ctx, "calm", client.WithSearchPrefix("user.preferences.tone"))
+		if err != nil {
+			t.Fatalf("SearchVertices scoped: %v", err)
+		}
+		if len(scoped) != 1 || scoped[0].Key != "user.preferences.tone" {
+			t.Fatalf("scoped hits = %+v, want only user.preferences.tone", scoped)
+		}
+
+		empty, err := l.SearchVertices(ctx, "")
+		if err != nil {
+			t.Fatalf("empty query must be a zero-hit success: %v", err)
+		}
+		if len(empty) != 0 {
+			t.Fatalf("empty-query hits = %d, want 0", len(empty))
+		}
+	})
+
+	t.Run("disabled server surfaces ErrFailedPrecondition", func(t *testing.T) {
+		l := newSearchSDKClient(t, false)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		hits, err := l.SearchVertices(ctx, "calm")
+		if hits != nil {
+			t.Errorf("want nil hits when disabled, got %+v", hits)
+		}
+		if !errors.Is(err, client.ErrFailedPrecondition) {
+			t.Fatalf("want errors.Is(err, client.ErrFailedPrecondition), got %v", err)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Forwards the plural `SearchVertices` RPC through the high-level Go SDK as
`Lantern.SearchVertices(ctx, query, ...SearchOption)` — the content-search
counterpart to `ScanVertices`' lexicographic key walk. Third issue of the
SearchVertices epic (#628), building on the server RPC (#624).

## What changed

- **`sdks/go/search.go`** (new)
  - `Lantern.SearchVertices(ctx, query, ...SearchOption) ([]SearchHit, error)` — a thin forwarder over the generated client; the server owns ranking, liveness/prefix filtering and limit clamping.
  - `SearchHit{Key string; Score float64}` — a flat SDK-native value struct (the `EdgeRef` precedent), carrying only key + relevance score; hydrate the stored value/TTL via `GetVertices`.
  - `WithSearchLimit(uint32)` / `WithSearchPrefix(string)` options. `0` limit = server default; the server clamps to its configured max, so the SDK passes the value straight through.
- **`sdks/go/client.go`**
  - New `ErrFailedPrecondition` sentinel + a `connect.CodeFailedPrecondition` arm in `wrapConnectErr`, so a search-disabled server (`LANTERN_SEARCH_ENABLED=false`) surfaces as a configuration state callers detect with `errors.Is` rather than a transient failure to retry.

## Contracts

- Empty / unanalysable / non-matching query → **zero-hit success**: empty (never nil) slice, nil error.
- Disabled server → error matching `ErrFailedPrecondition`.
- Hit order preserved from the server's ranking.

## Tests

- `sdks/go/search_test.go` — white-box option wiring + request/response capture, including the `FAILED_PRECONDITION → ErrFailedPrecondition` mapping (consistent with the SDK's existing white-box test strategy).
- `tests/integration/search_vertices_test.go` — SDK round-trip against the live handler: ranked hits, `WithSearchPrefix` scoping, empty-query success, and the disabled-server `ErrFailedPrecondition` path.

Closes #625