### PR TITLE
feat(mcp): back search_facts with server-side SearchVertices index

### DIFF
--- a/mcp/fake_lantern_test.go
+++ b/mcp/fake_lantern_test.go
@@ -23,6 +23,10 @@ type fakeLantern struct {
 	getVertexFn func(ctx context.Context, key string) (*client.Vertex, error)
 	lastGetKey  string
 
+	// GetVertices
+	getVerticesFn       func(ctx context.Context, keys []string) ([]*client.Vertex, []string, error)
+	lastGetVerticesKeys []string
+
 	// DeleteVertex
 	deleteVertexFn func(ctx context.Context, key string) (bool, error)
 	lastDeleteKey  string
@@ -31,6 +35,11 @@ type fakeLantern struct {
 	scanVerticesFn  func(ctx context.Context, prefix string, opts ...client.ScanOption) ([]*client.Vertex, []byte, error)
 	lastScanPrefix  string
 	lastScanOptions []client.ScanOption
+
+	// SearchVertices
+	searchVerticesFn  func(ctx context.Context, query string, opts ...client.SearchOption) ([]client.SearchHit, error)
+	lastSearchQuery   string
+	lastSearchOptions []client.SearchOption
 
 	// CountVerticesByPrefix
 	countByPrefixFn func(ctx context.Context, prefix string) (uint64, error)
@@ -95,6 +104,14 @@ func (f *fakeLantern) GetVertex(ctx context.Context, key string) (*client.Vertex
 	return nil, nil
 }
 
+func (f *fakeLantern) GetVertices(ctx context.Context, keys []string) ([]*client.Vertex, []string, error) {
+	f.lastGetVerticesKeys = keys
+	if f.getVerticesFn != nil {
+		return f.getVerticesFn(ctx, keys)
+	}
+	return nil, nil, nil
+}
+
 func (f *fakeLantern) DeleteVertex(ctx context.Context, key string) (bool, error) {
 	f.lastDeleteKey = key
 	if f.deleteVertexFn != nil {
@@ -110,6 +127,15 @@ func (f *fakeLantern) ScanVertices(ctx context.Context, prefix string, opts ...c
 		return f.scanVerticesFn(ctx, prefix, opts...)
 	}
 	return nil, nil, nil
+}
+
+func (f *fakeLantern) SearchVertices(ctx context.Context, query string, opts ...client.SearchOption) ([]client.SearchHit, error) {
+	f.lastSearchQuery = query
+	f.lastSearchOptions = opts
+	if f.searchVerticesFn != nil {
+		return f.searchVerticesFn(ctx, query, opts...)
+	}
+	return nil, nil
 }
 
 func (f *fakeLantern) CountVerticesByPrefix(ctx context.Context, prefix string) (uint64, error) {

--- a/mcp/lantern.go
+++ b/mcp/lantern.go
@@ -22,8 +22,10 @@ import (
 type lanternClient interface {
 	PutVertex(ctx context.Context, key string, value any, ttl time.Duration) error
 	GetVertex(ctx context.Context, key string) (*client.Vertex, error)
+	GetVertices(ctx context.Context, keys []string) (found []*client.Vertex, missing []string, err error)
 	DeleteVertex(ctx context.Context, key string) (bool, error)
 	ScanVertices(ctx context.Context, prefix string, opts ...client.ScanOption) (vertices []*client.Vertex, nextCursor []byte, err error)
+	SearchVertices(ctx context.Context, query string, opts ...client.SearchOption) (hits []client.SearchHit, err error)
 	CountVerticesByPrefix(ctx context.Context, prefix string) (uint64, error)
 	DeleteVerticesByPrefix(ctx context.Context, prefix string, opts ...client.DeleteByPrefixOption) (uint64, error)
 	PutVertices(ctx context.Context, inputs []client.VertexInput) error

--- a/mcp/tool_search_facts.go
+++ b/mcp/tool_search_facts.go
@@ -2,8 +2,8 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/anaregdesign/lantern/mcp/internal/value"
 	client "github.com/anaregdesign/lantern/sdks/go"
@@ -19,20 +19,8 @@ const searchFactsDefaultLimit uint32 = 20
 // flood the model context.
 const searchFactsMaxLimit uint32 = 100
 
-// searchFactsScanBatch is the per-page size forwarded to ScanVertices while
-// paginating. Larger pages mean fewer round trips; this is independent of how
-// many matches we ultimately return.
-const searchFactsScanBatch uint32 = 500
-
-// searchFactsMaxScan bounds how many vertices a single search may pull from
-// the server before giving up. v1 search is an unindexed scan-and-filter, so
-// without this ceiling a miss on a large keyspace would walk every vertex.
-// When the ceiling is hit before enough matches accumulate, the result is
-// marked truncated and the caller is told to narrow the prefix.
-const searchFactsMaxScan = 10_000
-
 type searchFactsInput struct {
-	Query  string `json:"query" jsonschema:"Case-insensitive substring to find. It is matched against BOTH each fact's key AND its value, so you can search by topic words you remember even when you have forgotten the exact key. Must not be empty."`
+	Query  string `json:"query" jsonschema:"Words or a phrase to search for. Matched against BOTH each fact's key AND its value through a relevance-ranked full-text index, so you can search by topic words you remember even when you have forgotten the exact key. Matches come back most-relevant-first. Must not be empty."`
 	Prefix string `json:"prefix,omitempty" jsonschema:"Optional key prefix to restrict the search to one namespace (e.g. user. or project.lantern.). Empty (the default) searches the entire keyspace. Supplying a prefix when you know the rough namespace makes the search both faster and more precise."`
 	Limit  uint32 `json:"limit,omitempty" jsonschema:"Maximum number of matching facts to return (default 20, capped at 100). Results are compact previews, not full values."`
 }
@@ -48,15 +36,12 @@ type searchFactsMatch struct {
 }
 
 type searchFactsOutput struct {
-	Query      string             `json:"query"`
-	Count      int                `json:"count"`
-	Matches    []searchFactsMatch `json:"matches"`
-	Scanned    int                `json:"scanned"`
-	Truncated  bool               `json:"truncated"`
-	Suggestion string             `json:"suggestion,omitempty"`
+	Query   string             `json:"query"`
+	Count   int                `json:"count"`
+	Matches []searchFactsMatch `json:"matches"`
 }
 
-const searchFactsDescription = "Find facts by a case-insensitive substring matched against both keys AND values. Use this when you remember the TOPIC of a stored fact but not its exact key — it is the approximate counterpart to recall_fact (exact key) and complements list_under (prefix scan). Returns compact {key, snippet, expires_at} previews, not full values; call recall_fact with a returned key to read the whole value. Pass a prefix to scope the search to a namespace and keep it fast. If truncated=true the scan hit its budget before finishing — narrow with a prefix. Does NOT refresh TTL for matched facts."
+const searchFactsDescription = "Find facts by relevance-ranked full-text search over both keys AND values. Use this when you remember the TOPIC of a stored fact but not its exact key — it is the approximate counterpart to recall_fact (exact key) and complements list_under (prefix scan). Matches come back most-relevant-first as compact {key, snippet, expires_at} previews, not full values; call recall_fact with a returned key to read the whole value. Pass a prefix to scope the search to a namespace. Requires the server's search index (LANTERN_SEARCH_ENABLED); if it is off the call returns a clear error. Does NOT refresh TTL for matched facts."
 
 func registerSearchFacts(srv *mcp.Server, lc lanternClient) {
 	mcp.AddTool(srv, &mcp.Tool{
@@ -73,75 +58,56 @@ func registerSearchFacts(srv *mcp.Server, lc lanternClient) {
 		if limit > searchFactsMaxLimit {
 			limit = searchFactsMaxLimit
 		}
-		needle := strings.ToLower(in.Query)
 
-		matches := make([]searchFactsMatch, 0, limit)
-		scanned := 0
-		truncated := false
-		var cursor []byte
-
-	scan:
-		for {
-			verts, next, err := lc.ScanVertices(ctx, in.Prefix,
-				client.WithScanLimit(searchFactsScanBatch),
-				client.WithScanCursor(cursor))
-			if err != nil {
-				return nil, searchFactsOutput{}, mapSDKError("search_facts", err)
+		hits, err := lc.SearchVertices(ctx, in.Query,
+			client.WithSearchLimit(limit),
+			client.WithSearchPrefix(in.Prefix))
+		if err != nil {
+			if errors.Is(err, client.ErrFailedPrecondition) {
+				return nil, searchFactsOutput{}, fmt.Errorf("search_facts: the server's search index is disabled; set LANTERN_SEARCH_ENABLED=true on the Lantern server to enable search_facts: %w", err)
 			}
-			for _, v := range verts {
-				if v == nil {
-					continue
+			return nil, searchFactsOutput{}, mapSDKError("search_facts", err)
+		}
+
+		matches := make([]searchFactsMatch, 0, len(hits))
+		if len(hits) > 0 {
+			keys := make([]string, len(hits))
+			for i, h := range hits {
+				keys[i] = h.Key
+			}
+			// SearchHit carries only {key, score}; hydrate each match's
+			// snippet and expiry with one batch read, then re-emit in the
+			// ranked order the index returned.
+			found, _, gerr := lc.GetVertices(ctx, keys)
+			if gerr != nil {
+				return nil, searchFactsOutput{}, mapSDKError("search_facts", gerr)
+			}
+			byKey := make(map[string]*client.Vertex, len(found))
+			for _, v := range found {
+				if v != nil {
+					byKey[v.GetKey()] = v
 				}
-				scanned++
-				if factMatchesQuery(v, needle) {
-					m := searchFactsMatch{Key: v.GetKey(), Snippet: value.Snippet(v)}
+			}
+			for _, h := range hits {
+				m := searchFactsMatch{Key: h.Key}
+				if v := byKey[h.Key]; v != nil {
+					m.Snippet = value.Snippet(v)
 					if exp := client.VertexExpiration(v); !exp.IsZero() {
 						m.ExpiresAt = exp.UTC().Format("2006-01-02T15:04:05Z07:00")
 					}
-					matches = append(matches, m)
-					if uint32(len(matches)) >= limit {
-						truncated = true
-						break scan
-					}
 				}
-				if scanned >= searchFactsMaxScan {
-					truncated = true
-					break scan
-				}
+				matches = append(matches, m)
 			}
-			if len(next) == 0 {
-				break
-			}
-			cursor = next
 		}
 
 		out := searchFactsOutput{
-			Query:     in.Query,
-			Count:     len(matches),
-			Matches:   matches,
-			Scanned:   scanned,
-			Truncated: truncated,
+			Query:   in.Query,
+			Count:   len(matches),
+			Matches: matches,
 		}
-		if truncated {
-			if uint32(len(matches)) >= limit {
-				out.Suggestion = fmt.Sprintf("Returned the first %d matches; more may exist. Raise limit (max %d) or pass a prefix to narrow the search.", limit, searchFactsMaxLimit)
-			} else {
-				out.Suggestion = fmt.Sprintf("Stopped after scanning %d facts without filling the result. Pass a prefix to scope the search to a namespace.", scanned)
-			}
-		}
-		text := fmt.Sprintf("Found %d fact(s) matching %q (scanned=%d, truncated=%t).", out.Count, in.Query, out.Scanned, out.Truncated)
+		text := fmt.Sprintf("Found %d fact(s) matching %q.", out.Count, in.Query)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: text}},
 		}, out, nil
 	})
-}
-
-// factMatchesQuery reports whether the lower-cased needle occurs in the
-// vertex key or in its full single-line value text. value.Text (not Snippet)
-// is used so a match in a long value past the preview cap is not missed.
-func factMatchesQuery(v *client.Vertex, lowerNeedle string) bool {
-	if strings.Contains(strings.ToLower(v.GetKey()), lowerNeedle) {
-		return true
-	}
-	return strings.Contains(strings.ToLower(value.Text(v)), lowerNeedle)
 }

--- a/mcp/tool_search_facts_test.go
+++ b/mcp/tool_search_facts_test.go
@@ -2,8 +2,10 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	client "github.com/anaregdesign/lantern/sdks/go"
@@ -15,64 +17,108 @@ func vstr(key, val string) *client.Vertex {
 }
 
 // singlePage makes a scanVerticesFn that returns all of verts in one page
-// (empty next cursor), regardless of prefix or options.
+// (empty next cursor), regardless of prefix or options. It is shared by the
+// scan-backed tool tests in this package.
 func singlePage(verts ...*client.Vertex) func(context.Context, string, ...client.ScanOption) ([]*client.Vertex, []byte, error) {
 	return func(_ context.Context, _ string, _ ...client.ScanOption) ([]*client.Vertex, []byte, error) {
 		return verts, nil, nil
 	}
 }
 
-func TestSearchFacts_MatchesValueAcrossUnrelatedKeyPrefixes(t *testing.T) {
+// hit builds a ranked search hit. search_facts only consumes the key; score is
+// carried for ordering realism.
+func hit(key string, score float64) client.SearchHit {
+	return client.SearchHit{Key: key, Score: score}
+}
+
+// hydrateFrom returns a getVerticesFn that resolves keys against the supplied
+// vertices (by key), mimicking a batch GetVertices read. Unknown keys are
+// reported as missing.
+func hydrateFrom(verts ...*client.Vertex) func(context.Context, []string) ([]*client.Vertex, []string, error) {
+	byKey := make(map[string]*client.Vertex, len(verts))
+	for _, v := range verts {
+		byKey[v.GetKey()] = v
+	}
+	return func(_ context.Context, keys []string) ([]*client.Vertex, []string, error) {
+		var found []*client.Vertex
+		var missing []string
+		for _, k := range keys {
+			if v, ok := byKey[k]; ok {
+				found = append(found, v)
+			} else {
+				missing = append(missing, k)
+			}
+		}
+		return found, missing, nil
+	}
+}
+
+func TestSearchFacts_ForwardsQueryAndOptions(t *testing.T) {
 	h := newTestHarness(t)
-	h.fake.scanVerticesFn = singlePage(
-		vstr("project.lantern.milestone", "ship build 2026 in June"),
-		vstr("user.identity.role", "principal engineer"),
-		vstr("session.scratch", "unrelated note"),
-	)
-	res := h.call(t, "search_facts", map[string]any{"query": "build 2026"})
+	h.fake.searchVerticesFn = func(_ context.Context, _ string, opts ...client.SearchOption) ([]client.SearchHit, error) {
+		return []client.SearchHit{hit("project.lantern.milestone", 0.9)}, nil
+	}
+	h.fake.getVerticesFn = hydrateFrom(vstr("project.lantern.milestone", "ship build 2026 in June"))
+
+	res := h.call(t, "search_facts", map[string]any{"query": "build 2026", "prefix": "project.lantern."})
 	if res.IsError {
 		t.Fatalf("IsError = true: %s", contentText(res))
 	}
+	if h.fake.lastSearchQuery != "build 2026" {
+		t.Fatalf("query forwarded = %q, want %q", h.fake.lastSearchQuery, "build 2026")
+	}
+	// The handler always forwards both WithSearchLimit and WithSearchPrefix;
+	// their values are covered by the SDK forwarder tests, which can inspect
+	// the request the options build.
+	if len(h.fake.lastSearchOptions) != 2 {
+		t.Fatalf("forwarded %d search options, want 2 (limit + prefix)", len(h.fake.lastSearchOptions))
+	}
 	var out searchFactsOutput
 	structuredAs(t, res, &out)
-	if out.Count != 1 {
-		t.Fatalf("Count = %d, want 1 (matches=%+v)", out.Count, out.Matches)
+	if out.Count != 1 || out.Matches[0].Key != "project.lantern.milestone" {
+		t.Fatalf("unexpected matches: %+v", out.Matches)
 	}
-	if out.Matches[0].Key != "project.lantern.milestone" {
-		t.Fatalf("matched wrong key: %q", out.Matches[0].Key)
+	if out.Matches[0].Snippet == "" {
+		t.Fatalf("snippet not hydrated: %+v", out.Matches[0])
 	}
 }
 
-func TestSearchFacts_MatchesKey(t *testing.T) {
+func TestSearchFacts_PreservesRankOrder(t *testing.T) {
 	h := newTestHarness(t)
-	h.fake.scanVerticesFn = singlePage(
-		vstr("user.preferences.tone", "concise"),
-		vstr("user.identity.role", "engineer"),
-	)
-	// "preferences" appears only in a key, not in any value.
-	res := h.call(t, "search_facts", map[string]any{"query": "preferences"})
+	// Index ranks b above a.
+	h.fake.searchVerticesFn = func(context.Context, string, ...client.SearchOption) ([]client.SearchHit, error) {
+		return []client.SearchHit{hit("b", 0.9), hit("a", 0.4)}, nil
+	}
+	// GetVertices answers in a different (key-sorted) order to prove the
+	// handler re-keys by rank, not by the batch-read order.
+	h.fake.getVerticesFn = func(_ context.Context, keys []string) ([]*client.Vertex, []string, error) {
+		return []*client.Vertex{vstr("a", "alpha"), vstr("b", "bravo")}, nil, nil
+	}
+
+	res := h.call(t, "search_facts", map[string]any{"query": "x"})
 	var out searchFactsOutput
 	structuredAs(t, res, &out)
-	if out.Count != 1 || out.Matches[0].Key != "user.preferences.tone" {
-		t.Fatalf("key match failed: %+v", out.Matches)
+	if out.Count != 2 {
+		t.Fatalf("Count = %d, want 2", out.Count)
+	}
+	if out.Matches[0].Key != "b" || out.Matches[1].Key != "a" {
+		t.Fatalf("rank order not preserved: %+v", out.Matches)
+	}
+	// Hydration is requested with the keys in ranked order.
+	if got := h.fake.lastGetVerticesKeys; len(got) != 2 || got[0] != "b" || got[1] != "a" {
+		t.Fatalf("GetVertices keys = %v, want [b a]", got)
 	}
 }
 
-func TestSearchFacts_IsCaseInsensitive(t *testing.T) {
+func TestSearchFacts_HydratesSnippetAndExpiry(t *testing.T) {
 	h := newTestHarness(t)
-	h.fake.scanVerticesFn = singlePage(vstr("k", "The Build 2026 Plan"))
-	res := h.call(t, "search_facts", map[string]any{"query": "build 2026"})
-	var out searchFactsOutput
-	structuredAs(t, res, &out)
-	if out.Count != 1 {
-		t.Fatalf("case-insensitive match failed: %+v", out)
-	}
-}
-
-func TestSearchFacts_ResultsAreCompactSnippets(t *testing.T) {
-	h := newTestHarness(t)
+	exp := time.Date(2031, 2, 3, 4, 5, 6, 0, time.UTC)
 	long := "match " + strings.Repeat("z", 400)
-	h.fake.scanVerticesFn = singlePage(vstr("k", long))
+	h.fake.searchVerticesFn = func(context.Context, string, ...client.SearchOption) ([]client.SearchHit, error) {
+		return []client.SearchHit{hit("k", 1)}, nil
+	}
+	h.fake.getVerticesFn = hydrateFrom(vexp("k", long, exp))
+
 	res := h.call(t, "search_facts", map[string]any{"query": "match"})
 	var out searchFactsOutput
 	structuredAs(t, res, &out)
@@ -81,16 +127,43 @@ func TestSearchFacts_ResultsAreCompactSnippets(t *testing.T) {
 	}
 	snip := out.Matches[0].Snippet
 	if !strings.HasSuffix(snip, "…") {
-		t.Fatalf("long value should be returned as a truncated snippet: %q", snip)
+		t.Fatalf("long value should be a truncated snippet: %q", snip)
 	}
 	if n := len([]rune(snip)); n > 121 {
 		t.Fatalf("snippet length = %d runes, want <= 121 (no full-value dump)", n)
+	}
+	if out.Matches[0].ExpiresAt != "2031-02-03T04:05:06Z" {
+		t.Fatalf("expires_at = %q, want the vertex's own expiry", out.Matches[0].ExpiresAt)
+	}
+}
+
+func TestSearchFacts_MissingHydrationStillEmitsKey(t *testing.T) {
+	h := newTestHarness(t)
+	// A hit whose vertex raced away (expired/deleted) between search and get.
+	h.fake.searchVerticesFn = func(context.Context, string, ...client.SearchOption) ([]client.SearchHit, error) {
+		return []client.SearchHit{hit("ghost", 0.7)}, nil
+	}
+	h.fake.getVerticesFn = hydrateFrom() // resolves nothing
+
+	res := h.call(t, "search_facts", map[string]any{"query": "x"})
+	if res.IsError {
+		t.Fatalf("IsError = true: %s", contentText(res))
+	}
+	var out searchFactsOutput
+	structuredAs(t, res, &out)
+	if out.Count != 1 || out.Matches[0].Key != "ghost" {
+		t.Fatalf("missing hydration should still surface the key: %+v", out.Matches)
+	}
+	if out.Matches[0].Snippet != "" || out.Matches[0].ExpiresAt != "" {
+		t.Fatalf("unhydrated match should carry only the key: %+v", out.Matches[0])
 	}
 }
 
 func TestSearchFacts_NoMatchesIsEmptyNotError(t *testing.T) {
 	h := newTestHarness(t)
-	h.fake.scanVerticesFn = singlePage(vstr("k", "nothing relevant here"))
+	h.fake.searchVerticesFn = func(context.Context, string, ...client.SearchOption) ([]client.SearchHit, error) {
+		return nil, nil
+	}
 	res := h.call(t, "search_facts", map[string]any{"query": "absent"})
 	if res.IsError {
 		t.Fatalf("no-match should not be an error: %s", contentText(res))
@@ -100,87 +173,52 @@ func TestSearchFacts_NoMatchesIsEmptyNotError(t *testing.T) {
 	if out.Count != 0 || len(out.Matches) != 0 {
 		t.Fatalf("expected zero matches, got %+v", out)
 	}
+	// No hits means no hydration round trip.
+	if h.fake.lastGetVerticesKeys != nil {
+		t.Fatalf("GetVertices should not be called when there are no hits: %v", h.fake.lastGetVerticesKeys)
+	}
 }
 
 func TestSearchFacts_RejectsEmptyQuery(t *testing.T) {
 	h := newTestHarness(t)
 	h.callExpectError(t, "search_facts", map[string]any{"query": ""})
-}
-
-func TestSearchFacts_ForwardsPrefixToScan(t *testing.T) {
-	h := newTestHarness(t)
-	h.fake.scanVerticesFn = singlePage(vstr("project.lantern.x", "build 2026"))
-	h.call(t, "search_facts", map[string]any{"query": "build", "prefix": "project.lantern."})
-	if h.fake.lastScanPrefix != "project.lantern." {
-		t.Fatalf("prefix not forwarded to ScanVertices: %q", h.fake.lastScanPrefix)
+	// A rejected query never reaches the server.
+	if h.fake.lastSearchQuery != "" {
+		t.Fatalf("empty query should not be forwarded, got %q", h.fake.lastSearchQuery)
 	}
 }
 
-func TestSearchFacts_TruncatesAtLimit(t *testing.T) {
+func TestSearchFacts_DisabledIndexSurfacesEnableHint(t *testing.T) {
 	h := newTestHarness(t)
-	verts := make([]*client.Vertex, 0, 5)
-	for i := 0; i < 5; i++ {
-		verts = append(verts, vstr("k", "build 2026"))
+	h.fake.searchVerticesFn = func(context.Context, string, ...client.SearchOption) ([]client.SearchHit, error) {
+		return nil, fmt.Errorf("search is off: %w", client.ErrFailedPrecondition)
 	}
-	h.fake.scanVerticesFn = singlePage(verts...)
-	res := h.call(t, "search_facts", map[string]any{"query": "build", "limit": 2})
-	var out searchFactsOutput
-	structuredAs(t, res, &out)
-	if out.Count != 2 {
-		t.Fatalf("Count = %d, want 2 (capped at limit)", out.Count)
-	}
-	if !out.Truncated {
-		t.Fatalf("Truncated = false; want true when limit is hit")
-	}
-	if out.Suggestion == "" {
-		t.Fatalf("Suggestion should be set when truncated")
+	res := h.callExpectError(t, "search_facts", map[string]any{"query": "x"})
+	if !strings.Contains(contentText(res), "LANTERN_SEARCH_ENABLED") {
+		t.Fatalf("disabled-index error should name the enable flag: %s", contentText(res))
 	}
 }
 
-func TestSearchFacts_FollowsCursorPagination(t *testing.T) {
+func TestSearchFacts_SearchErrorMapsThroughSDKError(t *testing.T) {
 	h := newTestHarness(t)
-	calls := 0
-	h.fake.scanVerticesFn = func(_ context.Context, _ string, _ ...client.ScanOption) ([]*client.Vertex, []byte, error) {
-		calls++
-		if calls == 1 {
-			return []*client.Vertex{vstr("a", "no")}, []byte("cursor-1"), nil
-		}
-		return []*client.Vertex{vstr("b", "build 2026")}, nil, nil
+	h.fake.searchVerticesFn = func(context.Context, string, ...client.SearchOption) ([]client.SearchHit, error) {
+		return nil, client.ErrResourceExhausted
 	}
-	res := h.call(t, "search_facts", map[string]any{"query": "build"})
-	var out searchFactsOutput
-	structuredAs(t, res, &out)
-	if calls != 2 {
-		t.Fatalf("expected 2 scan pages, got %d", calls)
-	}
-	if out.Count != 1 || out.Matches[0].Key != "b" {
-		t.Fatalf("match on second page not found: %+v", out)
-	}
-	if out.Scanned != 2 {
-		t.Fatalf("Scanned = %d, want 2 across both pages", out.Scanned)
+	res := h.callExpectError(t, "search_facts", map[string]any{"query": "x"})
+	if !strings.Contains(contentText(res), "rate limited") {
+		t.Fatalf("resource-exhausted should map to a backoff hint: %s", contentText(res))
 	}
 }
 
-func TestSearchFacts_StopsAtScanBudget(t *testing.T) {
+func TestSearchFacts_HydrationErrorSurfaces(t *testing.T) {
 	h := newTestHarness(t)
-	// One page larger than the scan budget, none matching, empty cursor.
-	verts := make([]*client.Vertex, 0, searchFactsMaxScan+1)
-	for i := 0; i < searchFactsMaxScan+1; i++ {
-		verts = append(verts, vstr("k", "no match here"))
+	h.fake.searchVerticesFn = func(context.Context, string, ...client.SearchOption) ([]client.SearchHit, error) {
+		return []client.SearchHit{hit("k", 1)}, nil
 	}
-	h.fake.scanVerticesFn = singlePage(verts...)
-	res := h.call(t, "search_facts", map[string]any{"query": "needle"})
-	var out searchFactsOutput
-	structuredAs(t, res, &out)
-	if !out.Truncated {
-		t.Fatalf("Truncated = false; want true when the scan budget is hit")
+	h.fake.getVerticesFn = func(context.Context, []string) ([]*client.Vertex, []string, error) {
+		return nil, nil, fmt.Errorf("boom")
 	}
-	if out.Scanned != searchFactsMaxScan {
-		t.Fatalf("Scanned = %d, want %d (budget ceiling)", out.Scanned, searchFactsMaxScan)
-	}
-	if out.Suggestion == "" {
-		t.Fatalf("Suggestion should advise narrowing when the budget is hit")
-	}
+	h.callExpectError(t, "search_facts", map[string]any{"query": "x"})
 }
 
 // TestSearchFactsDescription_IsApproximateRecall guards the framing that

--- a/sdks/go/failover.go
+++ b/sdks/go/failover.go
@@ -67,6 +67,7 @@ type failoverNode interface {
 	DeleteVertex(ctx context.Context, key string) (bool, error)
 	DeleteVertices(ctx context.Context, keys []string) (int, error)
 	ScanVertices(ctx context.Context, prefix string, opts ...ScanOption) (vertices []*Vertex, nextCursor []byte, err error)
+	SearchVertices(ctx context.Context, query string, opts ...SearchOption) (hits []SearchHit, err error)
 	CountVerticesByPrefix(ctx context.Context, prefix string) (uint64, error)
 	DeleteVerticesByPrefix(ctx context.Context, prefix string, opts ...DeleteByPrefixOption) (uint64, error)
 	AddEdge(ctx context.Context, tail, head string, weight float32, ttl time.Duration) error
@@ -218,6 +219,18 @@ func (f *Failover) ScanVertices(ctx context.Context, prefix string, opts ...Scan
 		return ie
 	})
 	return vertices, nextCursor, e
+}
+
+// SearchVertices forwards to the current endpoint's SearchVertices, failing
+// over on ErrUnavailable. Search runs over the shared replicated keyspace, so
+// a mid-call rotation simply re-runs the query against the next replica.
+func (f *Failover) SearchVertices(ctx context.Context, query string, opts ...SearchOption) (hits []SearchHit, err error) {
+	e := f.try(func(l failoverNode) error {
+		var ie error
+		hits, ie = l.SearchVertices(ctx, query, opts...)
+		return ie
+	})
+	return hits, e
 }
 
 // CountVerticesByPrefix forwards to the current endpoint's

--- a/sdks/go/failover_test.go
+++ b/sdks/go/failover_test.go
@@ -37,6 +37,9 @@ func (f *fakeNode) DeleteVertices(context.Context, []string) (int, error) { retu
 func (f *fakeNode) ScanVertices(context.Context, string, ...ScanOption) ([]*Vertex, []byte, error) {
 	return nil, nil, nil
 }
+func (f *fakeNode) SearchVertices(context.Context, string, ...SearchOption) ([]SearchHit, error) {
+	return nil, nil
+}
 func (f *fakeNode) CountVerticesByPrefix(context.Context, string) (uint64, error) { return 0, nil }
 func (f *fakeNode) DeleteVerticesByPrefix(context.Context, string, ...DeleteByPrefixOption) (uint64, error) {
 	return 0, nil


### PR DESCRIPTION
## What

Reworks the `search_facts` MCP tool to use the server's relevance-ranked
**SearchVertices** index (#623/#624) instead of the old client-side
prefix-scan-and-substring-filter.

The tool now:
1. forwards `{query, prefix, limit}` to `SearchVertices`, and
2. hydrates each ranked `SearchHit`'s `snippet` + `expires_at` with one
   batch `GetVertices` read, **preserving the index's rank order**.

## Behaviour

- **Requires the server search index.** When `LANTERN_SEARCH_ENABLED` is
  off the SDK surfaces `ErrFailedPrecondition`; the tool maps that to a
  clear *"set `LANTERN_SEARCH_ENABLED=true`"* hint rather than an opaque
  error.
- An **empty result set is a zero-hit success**, not an error.
- `limit` is clamped (default 20, max 100) as a context-size policy,
  independent of any server-side clamp.
- Dropped the old scan knobs (`scanned`/`truncated`/`suggestion`) and the
  `factMatchesQuery` substring matcher.

## Also: completes `Failover.SearchVertices` in `sdks/go`

#625 added `SearchVertices` only to `*Lantern`, but the MCP server holds a
`*client.Failover` (HA wrapper). Without the method on `Failover` the
`lanternClient` interface could not be satisfied and the build broke. This
PR adds `SearchVertices` to the `failoverNode` interface and the `Failover`
forwarder — a read op over the shared replicated keyspace, so a mid-call
rotation simply re-runs the query against the next replica. This rolls into
the same `sdks/go` release already slated for #625.

## Verification

- `gofmt -l` clean across `mcp/`, `sdks/go/`, root
- `go build`/`go vet`/`go test ./...` green in `sdks/go`, `mcp`, and the
  root module (incl. `tests/integration`)

Closes #626