### PR TITLE
feat(admin): vertex content-search UI (SearchVertices)

### DIFF
--- a/admin/app/components/search/SearchPage/SearchPage.module.css
+++ b/admin/app/components/search/SearchPage/SearchPage.module.css
@@ -1,0 +1,125 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalL, 16px);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalS, 8px);
+}
+
+.title {
+  font-size: var(--fontSizeBase600, 24px);
+  font-weight: var(--fontWeightSemibold, 600);
+  margin: 0;
+}
+
+.lead {
+  color: var(--colorNeutralForeground2, #424242);
+  margin: 0;
+}
+
+.controls {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--spacingHorizontalM, 12px);
+  flex-wrap: wrap;
+}
+
+.queryField {
+  min-width: 260px;
+  flex: 1;
+}
+
+.controlsMeta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacingHorizontalM, 12px);
+}
+
+.caption {
+  color: var(--colorNeutralForeground3, #707070);
+  font-size: var(--fontSizeBase200, 12px);
+  margin: 0;
+}
+
+.alert {
+  margin: 0;
+}
+
+.tableWrapper {
+  position: relative;
+  border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  border-radius: var(--borderRadiusMedium, 6px);
+  /* Scroll horizontally on narrow screens instead of clipping the right-hand
+     Actions column. */
+  overflow-x: auto;
+}
+
+.table {
+  /* Keep the percentage columns from collapsing/overlapping on phones; the
+     wrapper scrolls horizontally below this width. */
+  min-width: 520px;
+}
+
+.colKey {
+  width: 32%;
+}
+
+.colScore {
+  width: 12%;
+}
+
+.colExp {
+  width: 16%;
+}
+
+.colActions {
+  width: 14%;
+  text-align: right;
+}
+
+.keyLink {
+  color: var(--colorBrandForegroundLink, #0078d4);
+  text-decoration: none;
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+}
+
+.keyLink:hover {
+  text-decoration: underline;
+}
+
+.score {
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  font-variant-numeric: tabular-nums;
+  color: var(--colorNeutralForeground2, #424242);
+}
+
+.expired {
+  color: var(--colorNeutralForeground3, #707070);
+  font-style: italic;
+}
+
+.placeholder {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacingVerticalS, 8px);
+  padding: var(--spacingVerticalXXL, 32px);
+  color: var(--colorNeutralForeground3, #707070);
+  text-align: center;
+}

--- a/admin/app/components/search/SearchPage/SearchPage.tsx
+++ b/admin/app/components/search/SearchPage/SearchPage.tsx
@@ -1,0 +1,215 @@
+import { useState } from "react";
+import {
+  Badge,
+  Button,
+  Field,
+  Input,
+  MessageBar,
+  MessageBarBody,
+  MessageBarTitle,
+  Spinner,
+  Table,
+  TableBody,
+  TableCell,
+  TableCellLayout,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+} from "@fluentui/react-components";
+import {
+  ArrowClockwise20Regular,
+  LightbulbFilament20Regular,
+  Search24Regular,
+} from "@fluentui/react-icons";
+import { Link, useNavigate } from "react-router";
+import { useSearchVertices } from "~/lib/client/usecase/search-vertices/use-search-vertices";
+import {
+  formatScore,
+  selectCaption,
+} from "~/lib/client/usecase/search-vertices/selectors";
+import { ValueCell } from "~/components/browse-vertices/ValueCell/ValueCell";
+import { ExpirationCell } from "~/components/browse-vertices/ExpirationCell/ExpirationCell";
+import styles from "./SearchPage.module.css";
+
+/**
+ * Vertex content-search screen (#627). Runs the server's BM25 keyword
+ * search over indexed string/bytes content, hydrates the ranked hits into
+ * full vertices, and lets the operator pivot a result into the Illuminate
+ * neighborhood — the same seed handoff Browse Vertices uses.
+ *
+ * Content search is enabled by default (opt-out). When a server has the
+ * index turned off, the screen renders a calm "not enabled" notice rather
+ * than an error.
+ */
+export function SearchPage() {
+  const [query, setQuery] = useState("");
+  const search = useSearchVertices(query);
+  const navigate = useNavigate();
+
+  const { status, results } = search.state;
+  const caption = selectCaption(search.state);
+  const showTable =
+    query.length > 0 && status !== "disabled" && status !== "error";
+  const showEmpty = status === "ready" && results.length === 0;
+  const showLoading = status === "loading" && results.length === 0;
+
+  return (
+    <div className={styles.root}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>Search</h1>
+        <p className={styles.lead}>
+          Full-text search over indexed vertex content, ranked by relevance.
+          Select a result to explore its neighborhood in Illuminate.
+        </p>
+      </header>
+
+      <section className={styles.controls}>
+        <Field label="Query" className={styles.queryField}>
+          <Input
+            value={query}
+            onChange={(_, data) => setQuery(data.value)}
+            placeholder="e.g. distributed systems"
+            contentBefore={<Search24Regular />}
+            data-testid="search-query-input"
+          />
+        </Field>
+        <div className={styles.controlsMeta}>
+          {status === "ready" && results.length > 0 ? (
+            <Badge
+              appearance="tint"
+              shape="rounded"
+              data-testid="search-count-badge"
+            >
+              {results.length} {results.length === 1 ? "result" : "results"}
+            </Badge>
+          ) : null}
+          <Button
+            appearance="subtle"
+            icon={<ArrowClockwise20Regular />}
+            onClick={search.retry}
+            disabled={query.length === 0 || status === "loading"}
+            data-testid="search-refresh"
+          >
+            Refresh
+          </Button>
+        </div>
+      </section>
+
+      <p className={styles.caption} data-testid="search-caption">
+        {caption}
+      </p>
+
+      {status === "disabled" ? (
+        <MessageBar
+          intent="info"
+          className={styles.alert}
+          data-testid="search-disabled"
+        >
+          <MessageBarBody>
+            <MessageBarTitle>Content search is not enabled</MessageBarTitle>
+            This server has the keyword index turned off. Enable it by starting
+            the server with content search on (it is on by default; the operator
+            may have set <code>LANTERN_SEARCH_ENABLED=false</code>).
+          </MessageBarBody>
+        </MessageBar>
+      ) : status === "error" ? (
+        <MessageBar intent="error" className={styles.alert}>
+          <MessageBarBody>
+            {search.state.error ?? "Search failed."}
+          </MessageBarBody>
+        </MessageBar>
+      ) : null}
+
+      {query.length === 0 ? (
+        <div className={styles.placeholder} data-testid="search-idle">
+          <Search24Regular />
+          <p>Type a query to search vertex content.</p>
+        </div>
+      ) : null}
+
+      {showTable ? (
+        <div className={styles.tableWrapper}>
+          <Table
+            aria-label="Search results"
+            sortable={false}
+            data-testid="search-results-table"
+            className={styles.table}
+          >
+            <TableHeader>
+              <TableRow>
+                <TableHeaderCell className={styles.colKey}>Key</TableHeaderCell>
+                <TableHeaderCell>Value</TableHeaderCell>
+                <TableHeaderCell className={styles.colScore}>
+                  Score
+                </TableHeaderCell>
+                <TableHeaderCell className={styles.colExp}>
+                  Expires
+                </TableHeaderCell>
+                <TableHeaderCell className={styles.colActions}>
+                  Actions
+                </TableHeaderCell>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {results.map((row) => (
+                <TableRow key={row.key}>
+                  <TableCell className={styles.colKey}>
+                    <TableCellLayout>
+                      <Link
+                        to={`/vertices/${encodeURIComponent(row.key)}`}
+                        className={styles.keyLink}
+                      >
+                        {row.key}
+                      </Link>
+                    </TableCellLayout>
+                  </TableCell>
+                  <TableCell>
+                    {row.vertex ? (
+                      <ValueCell vertex={row.vertex} />
+                    ) : (
+                      <span className={styles.expired}>expired</span>
+                    )}
+                  </TableCell>
+                  <TableCell className={styles.colScore}>
+                    <span className={styles.score} data-testid="search-score">
+                      {formatScore(row.score)}
+                    </span>
+                  </TableCell>
+                  <TableCell className={styles.colExp}>
+                    <ExpirationCell expiration={row.vertex?.expiration} />
+                  </TableCell>
+                  <TableCell className={styles.colActions}>
+                    <Button
+                      appearance="subtle"
+                      size="small"
+                      icon={<LightbulbFilament20Regular />}
+                      onClick={() =>
+                        navigate(
+                          `/illuminate?seed=${encodeURIComponent(row.key)}`,
+                        )
+                      }
+                      aria-label={`Illuminate from ${row.key}`}
+                    >
+                      Illuminate
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+
+          {showLoading ? (
+            <div className={styles.placeholder} data-testid="search-loading">
+              <Spinner size="tiny" label="Searching…" />
+            </div>
+          ) : null}
+          {showEmpty ? (
+            <div className={styles.placeholder} data-testid="search-empty">
+              <p>No vertices match this query.</p>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/admin/app/components/shared/AppShell/AppShell.tsx
+++ b/admin/app/components/shared/AppShell/AppShell.tsx
@@ -16,6 +16,10 @@ const NAV: readonly NavEntry[] = [
   { to: "/", label: "Home" },
   { to: "/vertices", label: "Vertices" },
   { to: "/edges", label: "Edges" },
+  // Content search feeds the same explore loop as Illuminate (select a
+  // ranked hit → seed the neighborhood), so it sits next to the browse
+  // surfaces and just before Illuminate (#627).
+  { to: "/search", label: "Search" },
   { to: "/illuminate", label: "Illuminate" },
   // CLI is the power-user shortcut to the same RPC surface the other
   // routes wrap; place it next to Illuminate (the other "explore"

--- a/admin/app/lib/client/infrastructure/api/error.ts
+++ b/admin/app/lib/client/infrastructure/api/error.ts
@@ -1,4 +1,5 @@
 import {
+  FailedPreconditionError,
   InvalidArgumentError,
   LanternError,
   NotFoundError,
@@ -49,6 +50,9 @@ export class LanternApiError extends Error {
     if (err instanceof ResourceExhaustedError) {
       return new LanternApiError(rpc, "resource_exhausted", err.message);
     }
+    if (err instanceof FailedPreconditionError) {
+      return new LanternApiError(rpc, "failed_precondition", err.message);
+    }
     if (err instanceof LanternError) {
       return new LanternApiError(rpc, "unknown", err.message);
     }
@@ -63,6 +67,21 @@ export class LanternApiError extends Error {
    */
   static isNotFound(err: unknown): boolean {
     return err instanceof NotFoundError;
+  }
+
+  /**
+   * Returns true when the underlying call failed because the server has
+   * the feature disabled (FAILED_PRECONDITION). Content search
+   * (`SearchVertices`) raises this when the keyword index is turned off
+   * (opt-out via `LANTERN_SEARCH_ENABLED=false`); the search usecase
+   * uses it to render a calm "not enabled" state instead of an error
+   * toast (#627).
+   */
+  static isDisabled(err: unknown): boolean {
+    return (
+      err instanceof FailedPreconditionError ||
+      (err instanceof LanternApiError && err.code === "failed_precondition")
+    );
   }
 
   /**

--- a/admin/app/lib/client/infrastructure/api/get-vertices.ts
+++ b/admin/app/lib/client/infrastructure/api/get-vertices.ts
@@ -1,0 +1,35 @@
+import type { LanternClient } from "./lantern-client";
+import { LanternApiError } from "./error";
+import { sdkVertexToFlat } from "./to-flat";
+import type { Vertex } from "./types";
+
+export type { Vertex } from "./types";
+
+/**
+ * Calls `LanternService.GetVertices` via `lantern-sdk/web` (#627).
+ *
+ * Used to hydrate content-search hits: `SearchVertices` returns only
+ * `{ key, score }`, so the search usecase resolves the ranked keys to
+ * full vertices in a single batch read. The SDK partitions the result
+ * into `found` / `missing`; missing keys are surfaced so the caller can
+ * still render the rank slot (a hit whose vertex expired between the
+ * search and the hydration is a real, expected TTL race).
+ *
+ * `found` ordering is not guaranteed by the wire, so the caller must
+ * re-order against the ranked hit list rather than trusting this array.
+ */
+export async function getVertices(
+  client: LanternClient,
+  keys: readonly string[],
+  init?: { signal?: AbortSignal },
+): Promise<{ found: Vertex[]; missing: string[] }> {
+  if (keys.length === 0) {
+    return { found: [], missing: [] };
+  }
+  try {
+    const { found, missing } = await client.getVertices(keys, init?.signal);
+    return { found: found.map(sdkVertexToFlat), missing };
+  } catch (err) {
+    throw LanternApiError.fromUnknown("GetVertices", err);
+  }
+}

--- a/admin/app/lib/client/infrastructure/api/search-vertices.ts
+++ b/admin/app/lib/client/infrastructure/api/search-vertices.ts
@@ -1,0 +1,44 @@
+import type { LanternClient } from "./lantern-client";
+import { LanternApiError } from "./error";
+import type {
+  SearchHit,
+  SearchVerticesRequest,
+  SearchVerticesResponse,
+} from "./types";
+
+export type {
+  SearchHit,
+  SearchVerticesRequest,
+  SearchVerticesResponse,
+} from "./types";
+
+/**
+ * Calls `LanternService.SearchVertices` via `lantern-sdk/web` (#627).
+ *
+ * Returns the server's BM25-ranked `{ key, score }` hits in descending
+ * relevance order. A blank query, or a query that matches nothing,
+ * resolves to an empty `hits` array — an empty success, not an error.
+ *
+ * When the server has the keyword index disabled (opt-out via
+ * `LANTERN_SEARCH_ENABLED=false`) the SDK raises
+ * `FailedPreconditionError`; this adapter re-wraps it as a
+ * `LanternApiError` with code `"failed_precondition"` so the usecase
+ * layer can discriminate it via `LanternApiError.isDisabled(err)` and
+ * render a calm "content search is not enabled" state.
+ */
+export async function searchVertices(
+  client: LanternClient,
+  request: SearchVerticesRequest,
+  init?: { signal?: AbortSignal },
+): Promise<SearchVerticesResponse> {
+  try {
+    const hits: SearchHit[] = await client.searchVertices(
+      request.query,
+      { limit: request.limit ?? 0, prefix: request.prefix ?? "" },
+      init?.signal,
+    );
+    return { hits };
+  } catch (err) {
+    throw LanternApiError.fromUnknown("SearchVertices", err);
+  }
+}

--- a/admin/app/lib/client/infrastructure/api/types.ts
+++ b/admin/app/lib/client/infrastructure/api/types.ts
@@ -97,6 +97,26 @@ export interface ScanVerticesResponse {
   nextCursor?: string;
 }
 
+// Content-search (BM25 keyword) value-object shapes (#627). The server
+// ranks vertices by indexed string/bytes content and returns lightweight
+// `{ key, score }` hits — the admin search usecase hydrates the keys back
+// into full vertices via GetVertices, preserving rank order.
+
+export interface SearchVerticesRequest {
+  query: string;
+  limit?: number;
+  prefix?: string;
+}
+
+export interface SearchHit {
+  key: string;
+  score: number;
+}
+
+export interface SearchVerticesResponse {
+  hits: SearchHit[];
+}
+
 export interface AddEdgeBody {
   edge?: Edge;
 }

--- a/admin/app/lib/client/usecase/search-vertices/handlers.ts
+++ b/admin/app/lib/client/usecase/search-vertices/handlers.ts
@@ -1,0 +1,86 @@
+import { LanternApiError } from "~/lib/client/infrastructure/api/error";
+import { getVertices } from "~/lib/client/infrastructure/api/get-vertices";
+import type { LanternClient } from "~/lib/client/infrastructure/api/lantern-client";
+import { searchVertices } from "~/lib/client/infrastructure/api/search-vertices";
+import type { SearchResultRow } from "./state";
+import type { SearchVerticesAction } from "./reducer";
+
+export interface FetchSearchResultsInput {
+  client: LanternClient;
+  query: string;
+  limit: number;
+  prefix?: string;
+  epoch: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Runs the two-step content search: BM25 keyword search for ranked
+ * `{ key, score }` hits, then a single batch `GetVertices` to hydrate the
+ * keys into full vertices. The ranked hit order is authoritative — the
+ * hydration result is partitioned into found/missing and re-projected
+ * against the hit list, so a hit whose vertex expired between the two
+ * calls still renders its rank slot (with a `null` vertex) rather than
+ * silently dropping out of the ranking.
+ *
+ * As in Browse Vertices and the vertex picker, `AbortError` is swallowed:
+ * cancelling an in-flight search when the query moves on is normal control
+ * flow, not a failure. A `FAILED_PRECONDITION` (the server has the keyword
+ * index disabled) becomes a calm `SEARCH_DISABLED`, not an error.
+ */
+export async function fetchSearchResults(
+  input: FetchSearchResultsInput,
+  dispatch: (action: SearchVerticesAction) => void,
+): Promise<void> {
+  dispatch({ type: "SEARCH_REQUESTED", epoch: input.epoch });
+  try {
+    const { hits } = await searchVertices(
+      input.client,
+      { query: input.query, limit: input.limit, prefix: input.prefix },
+      { signal: input.signal },
+    );
+    if (hits.length === 0) {
+      // Empty match set is an empty success, not an error.
+      dispatch({ type: "SEARCH_RECEIVED", epoch: input.epoch, results: [] });
+      return;
+    }
+    const keys = hits.map((hit) => hit.key);
+    const { found } = await getVertices(input.client, keys, {
+      signal: input.signal,
+    });
+    const byKey = new Map(found.map((vertex) => [vertex.key ?? "", vertex]));
+    const results: SearchResultRow[] = hits.map((hit) => ({
+      key: hit.key,
+      score: hit.score,
+      vertex: byKey.get(hit.key) ?? null,
+    }));
+    dispatch({ type: "SEARCH_RECEIVED", epoch: input.epoch, results });
+  } catch (err) {
+    if (isAbortError(err)) {
+      return;
+    }
+    if (LanternApiError.isDisabled(err)) {
+      dispatch({ type: "SEARCH_DISABLED", epoch: input.epoch });
+      return;
+    }
+    dispatch({
+      type: "SEARCH_FAILED",
+      epoch: input.epoch,
+      error: messageOf(err),
+    });
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}
+
+function messageOf(err: unknown): string {
+  if (err instanceof LanternApiError) {
+    return err.grpcMessage ?? err.message;
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}

--- a/admin/app/lib/client/usecase/search-vertices/reducer.test.ts
+++ b/admin/app/lib/client/usecase/search-vertices/reducer.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "bun:test";
+import { searchVerticesReducer, type SearchVerticesAction } from "./reducer";
+import {
+  INITIAL_SEARCH_VERTICES_STATE,
+  type SearchResultRow,
+  type SearchVerticesState,
+} from "./state";
+
+function reduce(
+  state: SearchVerticesState,
+  ...actions: SearchVerticesAction[]
+): SearchVerticesState {
+  return actions.reduce(searchVerticesReducer, state);
+}
+
+const ROW: SearchResultRow = {
+  key: "doc:alpha",
+  score: 1.5,
+  vertex: { key: "doc:alpha", string: "alpha beta" },
+};
+
+describe("searchVerticesReducer", () => {
+  it("bumps the epoch and clears prior results on a new query", () => {
+    const next = reduce(INITIAL_SEARCH_VERTICES_STATE, {
+      type: "QUERY_CHANGED",
+      query: "alpha",
+    });
+    expect(next.query).toBe("alpha");
+    expect(next.queryEpoch).toBe(1);
+    expect(next.status).toBe("idle");
+    expect(next.results).toEqual([]);
+    expect(next.error).toBeNull();
+  });
+
+  it("ignores a QUERY_CHANGED that does not change the query", () => {
+    const seeded = reduce(INITIAL_SEARCH_VERTICES_STATE, {
+      type: "QUERY_CHANGED",
+      query: "alpha",
+    });
+    const same = searchVerticesReducer(seeded, {
+      type: "QUERY_CHANGED",
+      query: "alpha",
+    });
+    // Identity preserved → no epoch bump, no re-fetch.
+    expect(same).toBe(seeded);
+    expect(same.queryEpoch).toBe(1);
+  });
+
+  it("resets to the empty state (but advances epoch) when the query is cleared", () => {
+    const seeded = reduce(
+      INITIAL_SEARCH_VERTICES_STATE,
+      { type: "QUERY_CHANGED", query: "alpha" },
+      { type: "SEARCH_REQUESTED", epoch: 1 },
+      { type: "SEARCH_RECEIVED", epoch: 1, results: [ROW] },
+    );
+    const cleared = searchVerticesReducer(seeded, {
+      type: "QUERY_CHANGED",
+      query: "",
+    });
+    expect(cleared.query).toBe("");
+    expect(cleared.results).toEqual([]);
+    expect(cleared.status).toBe("idle");
+    // Epoch still advances so any in-flight reply for "alpha" is discarded.
+    expect(cleared.queryEpoch).toBe(2);
+  });
+
+  it("applies a search result that matches the live epoch", () => {
+    const next = reduce(
+      INITIAL_SEARCH_VERTICES_STATE,
+      { type: "QUERY_CHANGED", query: "alpha" },
+      { type: "SEARCH_REQUESTED", epoch: 1 },
+      { type: "SEARCH_RECEIVED", epoch: 1, results: [ROW] },
+    );
+    expect(next.status).toBe("ready");
+    expect(next.results).toEqual([ROW]);
+  });
+
+  it("treats a zero-result response as a ready, empty success", () => {
+    const next = reduce(
+      INITIAL_SEARCH_VERTICES_STATE,
+      { type: "QUERY_CHANGED", query: "nomatch" },
+      { type: "SEARCH_REQUESTED", epoch: 1 },
+      { type: "SEARCH_RECEIVED", epoch: 1, results: [] },
+    );
+    expect(next.status).toBe("ready");
+    expect(next.results).toEqual([]);
+    expect(next.error).toBeNull();
+  });
+
+  it("drops a stale search response from an abandoned query (epoch guard)", () => {
+    // Type "ab" (epoch 1), then "abc" (epoch 2) before "ab"'s search lands.
+    const seeded = reduce(
+      INITIAL_SEARCH_VERTICES_STATE,
+      { type: "QUERY_CHANGED", query: "ab" },
+      { type: "SEARCH_REQUESTED", epoch: 1 },
+      { type: "QUERY_CHANGED", query: "abc" },
+    );
+    expect(seeded.queryEpoch).toBe(2);
+
+    // The slow reply for "ab" (epoch 1) arrives — it must be ignored.
+    const afterStale = searchVerticesReducer(seeded, {
+      type: "SEARCH_RECEIVED",
+      epoch: 1,
+      results: [ROW],
+    });
+    expect(afterStale).toBe(seeded);
+    expect(afterStale.results).toEqual([]);
+
+    // The fresh reply for "abc" (epoch 2) is applied.
+    const fresh: SearchResultRow = { key: "abc", score: 2, vertex: null };
+    const afterFresh = searchVerticesReducer(afterStale, {
+      type: "SEARCH_RECEIVED",
+      epoch: 2,
+      results: [fresh],
+    });
+    expect(afterFresh.results).toEqual([fresh]);
+  });
+
+  it("records a search failure and clears results on the live epoch", () => {
+    const next = reduce(
+      INITIAL_SEARCH_VERTICES_STATE,
+      { type: "QUERY_CHANGED", query: "boom" },
+      { type: "SEARCH_REQUESTED", epoch: 1 },
+      { type: "SEARCH_RECEIVED", epoch: 1, results: [ROW] },
+      { type: "SEARCH_FAILED", epoch: 1, error: "unavailable" },
+    );
+    expect(next.status).toBe("error");
+    expect(next.error).toBe("unavailable");
+    expect(next.results).toEqual([]);
+  });
+
+  it("enters the disabled state (no error) when the index is off", () => {
+    const next = reduce(
+      INITIAL_SEARCH_VERTICES_STATE,
+      { type: "QUERY_CHANGED", query: "alpha" },
+      { type: "SEARCH_REQUESTED", epoch: 1 },
+      { type: "SEARCH_DISABLED", epoch: 1 },
+    );
+    expect(next.status).toBe("disabled");
+    expect(next.results).toEqual([]);
+    expect(next.error).toBeNull();
+  });
+
+  it("drops a stale SEARCH_DISABLED from an abandoned query", () => {
+    const seeded = reduce(
+      INITIAL_SEARCH_VERTICES_STATE,
+      { type: "QUERY_CHANGED", query: "ab" },
+      { type: "QUERY_CHANGED", query: "abc" },
+    );
+    const afterStale = searchVerticesReducer(seeded, {
+      type: "SEARCH_DISABLED",
+      epoch: 1,
+    });
+    expect(afterStale).toBe(seeded);
+    expect(afterStale.status).toBe("idle");
+  });
+});

--- a/admin/app/lib/client/usecase/search-vertices/reducer.ts
+++ b/admin/app/lib/client/usecase/search-vertices/reducer.ts
@@ -1,0 +1,81 @@
+import {
+  INITIAL_SEARCH_VERTICES_STATE,
+  type SearchResultRow,
+  type SearchVerticesState,
+} from "./state";
+
+export type SearchVerticesAction =
+  | { type: "QUERY_CHANGED"; query: string }
+  | { type: "SEARCH_REQUESTED"; epoch: number }
+  | { type: "SEARCH_RECEIVED"; epoch: number; results: SearchResultRow[] }
+  | { type: "SEARCH_FAILED"; epoch: number; error: string }
+  | { type: "SEARCH_DISABLED"; epoch: number };
+
+/**
+ * Pure reducer for vertex content-search. The `epoch` guards make stale
+ * responses inert: any SEARCH_* carrying an epoch other than the live
+ * `queryEpoch` is dropped, so a slow reply from an abandoned query cannot
+ * overwrite fresher results even if its AbortController loses the race.
+ * This is the unit-testable heart of the debounce-and-cancel behaviour
+ * required by #627.
+ */
+export function searchVerticesReducer(
+  state: SearchVerticesState,
+  action: SearchVerticesAction,
+): SearchVerticesState {
+  switch (action.type) {
+    case "QUERY_CHANGED": {
+      if (action.query === state.query) {
+        return state;
+      }
+      const queryEpoch = state.queryEpoch + 1;
+      if (action.query.length === 0) {
+        // Empty query shows no results and issues no request, but the
+        // epoch still advances so any in-flight reply is discarded.
+        return { ...INITIAL_SEARCH_VERTICES_STATE, queryEpoch };
+      }
+      return {
+        ...state,
+        query: action.query,
+        queryEpoch,
+        status: "idle",
+        results: [],
+        error: null,
+      };
+    }
+    case "SEARCH_REQUESTED": {
+      if (action.epoch !== state.queryEpoch) {
+        return state;
+      }
+      return { ...state, status: "loading", error: null };
+    }
+    case "SEARCH_RECEIVED": {
+      if (action.epoch !== state.queryEpoch) {
+        return state;
+      }
+      return {
+        ...state,
+        status: "ready",
+        results: action.results,
+        error: null,
+      };
+    }
+    case "SEARCH_FAILED": {
+      if (action.epoch !== state.queryEpoch) {
+        return state;
+      }
+      return { ...state, status: "error", error: action.error, results: [] };
+    }
+    case "SEARCH_DISABLED": {
+      if (action.epoch !== state.queryEpoch) {
+        return state;
+      }
+      // The server has the keyword index turned off — a calm, expected
+      // outcome (opt-out), not a failure. Clear any prior error.
+      return { ...state, status: "disabled", results: [], error: null };
+    }
+    default: {
+      return state;
+    }
+  }
+}

--- a/admin/app/lib/client/usecase/search-vertices/selectors.test.ts
+++ b/admin/app/lib/client/usecase/search-vertices/selectors.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import { formatResultCount, formatScore, selectCaption } from "./selectors";
+import {
+  INITIAL_SEARCH_VERTICES_STATE,
+  type SearchResultRow,
+  type SearchVerticesState,
+} from "./state";
+
+const ROW: SearchResultRow = {
+  key: "doc:alpha",
+  score: 1.5,
+  vertex: { key: "doc:alpha", string: "alpha beta" },
+};
+
+function state(patch: Partial<SearchVerticesState>): SearchVerticesState {
+  return { ...INITIAL_SEARCH_VERTICES_STATE, ...patch };
+}
+
+describe("formatResultCount", () => {
+  it("singularises a single result", () => {
+    expect(formatResultCount(1)).toBe("1 result");
+  });
+
+  it("pluralises zero and many results", () => {
+    expect(formatResultCount(0)).toBe("0 results");
+    expect(formatResultCount(42)).toBe("42 results");
+  });
+});
+
+describe("formatScore", () => {
+  it("renders three decimal places", () => {
+    expect(formatScore(1.5)).toBe("1.500");
+    expect(formatScore(0)).toBe("0.000");
+    expect(formatScore(12.34567)).toBe("12.346");
+  });
+});
+
+describe("selectCaption", () => {
+  it("prompts the user when the query is empty", () => {
+    expect(selectCaption(INITIAL_SEARCH_VERTICES_STATE)).toBe(
+      "Type a query to search vertex content.",
+    );
+  });
+
+  it("explains a disabled index calmly", () => {
+    const caption = selectCaption(
+      state({ query: "alpha", status: "disabled" }),
+    );
+    expect(caption).toBe("Content search is not enabled on this server.");
+  });
+
+  it("surfaces the error message on failure", () => {
+    const caption = selectCaption(
+      state({ query: "alpha", status: "error", error: "unavailable" }),
+    );
+    expect(caption).toBe("unavailable");
+  });
+
+  it("falls back to a generic message when the error is missing", () => {
+    const caption = selectCaption(
+      state({ query: "alpha", status: "error", error: null }),
+    );
+    expect(caption).toBe("Search failed.");
+  });
+
+  it("reports the result count when ready", () => {
+    expect(
+      selectCaption(state({ query: "alpha", status: "ready", results: [ROW] })),
+    ).toBe("1 result");
+  });
+
+  it("reports an empty match set when ready with no results", () => {
+    expect(
+      selectCaption(state({ query: "nomatch", status: "ready", results: [] })),
+    ).toBe("No vertices match this query.");
+  });
+
+  it("shows a settling message while loading", () => {
+    expect(selectCaption(state({ query: "alpha", status: "loading" }))).toBe(
+      "Searching…",
+    );
+  });
+});

--- a/admin/app/lib/client/usecase/search-vertices/selectors.ts
+++ b/admin/app/lib/client/usecase/search-vertices/selectors.ts
@@ -1,0 +1,41 @@
+import type { SearchVerticesState } from "./state";
+
+/** Formats a result count as "N result(s)". */
+export function formatResultCount(count: number): string {
+  const noun = count === 1 ? "result" : "results";
+  return `${count} ${noun}`;
+}
+
+/**
+ * Formats a BM25 relevance score for display. Scores are unbounded
+ * positive floats whose absolute magnitude is not meaningful to the user;
+ * three decimals is enough to distinguish adjacent ranks without implying
+ * false precision.
+ */
+export function formatScore(score: number): string {
+  return score.toFixed(3);
+}
+
+/**
+ * Caption rendered beneath the search box. Mirrors the search lifecycle:
+ * an empty query prompts the user, a disabled index explains itself
+ * calmly, a failed search surfaces the error, a settled search reports the
+ * result count; otherwise the search is still in flight.
+ */
+export function selectCaption(state: SearchVerticesState): string {
+  if (state.query.length === 0) {
+    return "Type a query to search vertex content.";
+  }
+  if (state.status === "disabled") {
+    return "Content search is not enabled on this server.";
+  }
+  if (state.status === "error") {
+    return state.error ?? "Search failed.";
+  }
+  if (state.status === "ready") {
+    return state.results.length === 0
+      ? "No vertices match this query."
+      : formatResultCount(state.results.length);
+  }
+  return "Searching…";
+}

--- a/admin/app/lib/client/usecase/search-vertices/state.ts
+++ b/admin/app/lib/client/usecase/search-vertices/state.ts
@@ -1,0 +1,60 @@
+import type { Vertex } from "~/lib/client/infrastructure/api/types";
+
+/**
+ * State for the vertex content-search screen (#627).
+ *
+ * The screen debounces the user's query, runs the server's BM25 keyword
+ * search, then hydrates the ranked `{ key, score }` hits back into full
+ * vertices (preserving rank order) for display. Async I/O lives in
+ * `handlers.ts`; this module and `reducer.ts` are the pure, unit-testable
+ * core. Every server response carries the `queryEpoch` it was issued
+ * under so a stale reply from an abandoned query can never clobber the
+ * current results — the same cancellation invariant Browse Vertices
+ * (#409) and the vertex picker (#457) rely on.
+ *
+ * `disabled` is a first-class lifecycle state, not an error: when the
+ * server has the keyword index turned off (opt-out via
+ * `LANTERN_SEARCH_ENABLED=false`) the screen renders a calm "not enabled"
+ * notice rather than an error toast.
+ */
+export type SearchVerticesStatus =
+  | "idle"
+  | "loading"
+  | "ready"
+  | "error"
+  | "disabled";
+
+/** One ranked search hit, hydrated with its full vertex when available. */
+export interface SearchResultRow {
+  /** The matched vertex key. */
+  key: string;
+  /** BM25 relevance score (higher = more relevant). */
+  score: number;
+  /**
+   * The hydrated vertex, or `null` when the key no longer resolves — a hit
+   * whose vertex expired between the search and the hydration (a real,
+   * expected TTL race). The row still renders so the rank slot is honest.
+   */
+  vertex: Vertex | null;
+}
+
+export interface SearchVerticesState {
+  /** The debounced query currently being searched. */
+  query: string;
+  /** Monotonic counter bumped on every query change. */
+  queryEpoch: number;
+  /** Lifecycle of the in-flight (or last completed) search. */
+  status: SearchVerticesStatus;
+  /** Ranked, hydrated results for `query`, in descending relevance. */
+  results: SearchResultRow[];
+  /** Human-readable error from the last failed search, if any. */
+  error: string | null;
+}
+
+export const INITIAL_SEARCH_VERTICES_STATE: SearchVerticesState = {
+  query: "",
+  queryEpoch: 0,
+  status: "idle",
+  results: [],
+  error: null,
+};

--- a/admin/app/lib/client/usecase/search-vertices/use-search-vertices.ts
+++ b/admin/app/lib/client/usecase/search-vertices/use-search-vertices.ts
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
+import { fetchSearchResults } from "./handlers";
+import { searchVerticesReducer, type SearchVerticesAction } from "./reducer";
+import {
+  INITIAL_SEARCH_VERTICES_STATE,
+  type SearchVerticesState,
+} from "./state";
+
+/**
+ * Debounce window for query typing, in milliseconds. Matches Browse
+ * Vertices (200 ms): content search is a heavier server operation than a
+ * prefix scan, so a slightly wider window than the foreground picker
+ * (150 ms) keeps a fast typist from firing a request per keystroke.
+ */
+export const SEARCH_DEBOUNCE_MS = 200;
+
+/**
+ * Cap on the number of ranked hits requested per query. Kept modest so the
+ * single hydration batch stays small and the results list stays scannable.
+ */
+export const DEFAULT_SEARCH_LIMIT = 25;
+
+export interface UseSearchVerticesOptions {
+  limit?: number;
+  /** Optional key-prefix filter applied to the ranked hits server-side. */
+  prefix?: string;
+  debounceMs?: number;
+}
+
+export interface UseSearchVerticesResult {
+  state: SearchVerticesState;
+  /** Re-runs the current query (e.g. after the operator enables the index). */
+  retry: () => void;
+}
+
+/**
+ * Wires the pure search reducer + handlers to the live Lantern client.
+ * Owns a single AbortController per query epoch so a fresh keystroke
+ * cancels the previous search and hydration immediately; the reducer's
+ * epoch guards make any reply that still lands inert.
+ */
+export function useSearchVertices(
+  rawQuery: string,
+  options: UseSearchVerticesOptions = {},
+): UseSearchVerticesResult {
+  const limit = options.limit ?? DEFAULT_SEARCH_LIMIT;
+  const prefix = options.prefix;
+  const debounceMs = options.debounceMs ?? SEARCH_DEBOUNCE_MS;
+  const client = useLanternClient();
+  const [state, dispatch] = useReducer(
+    searchVerticesReducer,
+    INITIAL_SEARCH_VERTICES_STATE,
+  );
+
+  // Debounce the live query into the reducer.
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      dispatch({ type: "QUERY_CHANGED", query: rawQuery });
+    }, debounceMs);
+    return () => window.clearTimeout(handle);
+  }, [rawQuery, debounceMs]);
+
+  // On every query change, search + hydrate under a fresh AbortController.
+  const lastEpochRef = useRef<number>(-1);
+  useEffect(() => {
+    if (state.queryEpoch === lastEpochRef.current) {
+      return;
+    }
+    lastEpochRef.current = state.queryEpoch;
+    if (state.query.length === 0) {
+      // Empty query: nothing to fetch (the reducer already cleared state).
+      return;
+    }
+    const controller = new AbortController();
+    void fetchSearchResults(
+      {
+        client,
+        query: state.query,
+        limit,
+        prefix,
+        epoch: state.queryEpoch,
+        signal: controller.signal,
+      },
+      dispatch as (action: SearchVerticesAction) => void,
+    );
+    return () => controller.abort();
+  }, [client, state.query, state.queryEpoch, limit, prefix]);
+
+  const retry = useCallback(() => {
+    if (state.query.length === 0) {
+      return;
+    }
+    // Re-run under the live epoch so the reducer accepts the response; the
+    // detached controller mirrors Browse Vertices' manual refresh.
+    void fetchSearchResults(
+      {
+        client,
+        query: state.query,
+        limit,
+        prefix,
+        epoch: state.queryEpoch,
+      },
+      dispatch as (action: SearchVerticesAction) => void,
+    );
+  }, [client, state.query, state.queryEpoch, limit, prefix]);
+
+  return useMemo<UseSearchVerticesResult>(
+    () => ({ state, retry }),
+    [state, retry],
+  );
+}

--- a/admin/app/routes/search.tsx
+++ b/admin/app/routes/search.tsx
@@ -1,0 +1,10 @@
+import type { Route } from "./+types/search";
+import { SearchPage } from "~/components/search/SearchPage/SearchPage";
+
+export function meta(_: Route.MetaArgs) {
+  return [{ title: "Search — Lantern Admin" }];
+}
+
+export default function SearchRoute() {
+  return <SearchPage />;
+}

--- a/admin/playwright.config.ts
+++ b/admin/playwright.config.ts
@@ -4,12 +4,16 @@ import { defineConfig, devices } from "@playwright/test";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const PORT = 4173;
+// Ports are env-overridable (defaults match CI) so the suite can run on a
+// machine that already has a Lantern instance on :6380 — e.g. a local
+// `deploy/compose` cluster — without a bind conflict. CI sets none of these,
+// so it keeps the canonical 4173 / 6380 / 9090 trio.
+const PORT = Number(process.env.LANTERN_E2E_PREVIEW_PORT ?? 4173);
 // The Lantern primary listener (:6380 by default) serves Connect /
 // gRPC / gRPC-Web on the same h2c socket. The admin SPA talks to it
 // directly via Connect-Web.
-const LANTERN_PORT = 6380;
-const METRICS_PORT = 9090;
+const LANTERN_PORT = Number(process.env.LANTERN_PORT ?? 6380);
+const METRICS_PORT = Number(process.env.LANTERN_E2E_METRICS_PORT ?? 9090);
 const CONNECT_URL = `http://127.0.0.1:${LANTERN_PORT}`;
 
 process.env.LANTERN_E2E_GATEWAY_URL = CONNECT_URL;
@@ -46,6 +50,10 @@ export default defineConfig({
         LANTERN_METRICS_ADDR: `:${METRICS_PORT}`,
         LANTERN_CORS_ALLOWED_ORIGINS: `http://127.0.0.1:${PORT}`,
         LANTERN_LOG_LEVEL: "warn",
+        // Content search is opt-out (on by default), but pin it explicitly
+        // so the search e2e (#627) stays deterministic if the default ever
+        // changes.
+        LANTERN_SEARCH_ENABLED: "true",
       },
     },
     {

--- a/admin/tests/e2e/search.spec.ts
+++ b/admin/tests/e2e/search.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "@playwright/test";
+
+import { CONNECT_URL, STORAGE_KEY, putVertices } from "./helpers";
+
+/**
+ * Seeds a small corpus for the Search screen (#627). The string values
+ * carry deliberately rare tokens (`zorptangle`, `quibblefrost`) so a
+ * keyword query matches exactly the seeded vertices and nothing the other
+ * specs write to the shared server instance.
+ *
+ *   - 2 vertices contain `zorptangle`
+ *   - 1 vertex contains `quibblefrost`
+ *
+ * Content search is opt-out (enabled by default); the Playwright webServer
+ * pins `LANTERN_SEARCH_ENABLED=true` for determinism.
+ */
+test.beforeAll(async () => {
+  await seed();
+});
+
+async function seed() {
+  await putVertices([
+    { key: "e2e:search:doc1", string: "zorptangle distributed consensus" },
+    { key: "e2e:search:doc2", string: "zorptangle vector clocks" },
+    { key: "e2e:search:doc3", string: "quibblefrost unrelated content" },
+  ]);
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(
+    ({ key, value }) => {
+      try {
+        window.localStorage.setItem(key, value);
+      } catch {
+        // ignore — storage may be unavailable in private mode
+      }
+    },
+    { key: STORAGE_KEY, value: CONNECT_URL },
+  );
+});
+
+test.describe("/search", () => {
+  test("prompts for a query before anything is typed", async ({ page }) => {
+    await page.goto("/search");
+
+    await expect(page.getByTestId("search-idle")).toBeVisible();
+    await expect(page.getByTestId("search-results-table")).toHaveCount(0);
+  });
+
+  test("ranks the strongest content matches to the top", async ({ page }) => {
+    await page.goto("/search");
+    await page.getByTestId("search-query-input").fill("zorptangle");
+
+    const table = page.getByTestId("search-results-table");
+    await expect(table).toBeVisible();
+
+    // The index is substring/fuzzy (n-gram BM25), so a vertex can match on a
+    // stray shared n-gram. doc1 and doc2 carry the full `zorptangle` token,
+    // so they always outrank that noise and occupy the top two ranks.
+    await expect(
+      table.getByRole("link", { name: "e2e:search:doc1" }),
+    ).toBeVisible();
+    await expect(
+      table.getByRole("link", { name: "e2e:search:doc2" }),
+    ).toBeVisible();
+
+    const keyLinks = table.locator("tbody a");
+    await expect(keyLinks.nth(0)).toHaveText(/e2e:search:doc[12]/);
+    await expect(keyLinks.nth(1)).toHaveText(/e2e:search:doc[12]/);
+
+    // Each ranked hit shows a relevance score, and the caption summarises the
+    // match count.
+    await expect(page.getByTestId("search-score").first()).toContainText(
+      /\d\.\d{3}/,
+    );
+    await expect(page.getByTestId("search-caption")).toContainText(/result/);
+  });
+
+  test("Illuminate action seeds the Illuminate screen with the hit key", async ({
+    page,
+  }) => {
+    await page.goto("/search");
+    await page.getByTestId("search-query-input").fill("quibblefrost");
+
+    const table = page.getByTestId("search-results-table");
+    const illuminate = table
+      .getByRole("button", { name: /Illuminate from e2e:search:doc3/i })
+      .first();
+    await expect(illuminate).toBeVisible();
+    await illuminate.click();
+    await expect(page).toHaveURL(/\/illuminate\?seed=e2e%3Asearch%3Adoc3/);
+  });
+});


### PR DESCRIPTION
## Summary

Final sub-issue of the SearchVertices epic (#628). Adds a standalone
**/search** screen to the Admin SPA that finds vertices by **content**
(not just key prefix) over the Connect-Web `SearchVertices` RPC, and lets
a chosen hit seed the Illuminate view.

Consumes the Node SDK surface added in #639 (`searchVertices` →
`SearchHit[]`, `FailedPreconditionError`). No server/proto/Go-SDK/MCP
changes — those shipped in the earlier sub-issues.

## What's here

**infrastructure/api/** (mirrors `scan-vertices.ts`)
- `search-vertices.ts` — wraps `LanternService.SearchVertices`; returns
  BM25-ranked `{ key, score }` hits; errors re-wrapped as `LanternApiError`.
- `get-vertices.ts` — batch-hydrates ranked keys to full vertices; surfaces
  `missing` so a TTL race (vertex expired between search and hydrate) still
  renders its rank slot.
- `error.ts` — maps the SDK `FailedPreconditionError` to code
  `"failed_precondition"` and adds `LanternApiError.isDisabled(err)`.
- `types.ts` — `SearchVerticesRequest` / `SearchHit` / `SearchVerticesResponse`.

**usecase/search-vertices/** (mirrors the `vertex-picker` usecase)
- Debounced query reducer + hook with an `AbortController` epoch guard,
  ranked results, and a calm `disabled` state for the opt-out keyword index.
- `reducer.test.ts` + `selectors.test.ts` (Vitest) — 19 tests.

**UI**
- `routes/search.tsx` + `components/search/SearchPage` — Fluent UI v9,
  responsive; reuses `ValueCell` / `ExpirationCell`. A `FAILED_PRECONDITION`
  response renders a calm **info** MessageBar ("Content search is not enabled
  on this server"), not an error toast. Each hit links to its vertex and
  offers an **Illuminate** action that seeds `/illuminate?seed=…`.
- `AppShell` gains a **Search** nav entry.

**e2e**
- `tests/e2e/search.spec.ts` — pins `LANTERN_SEARCH_ENABLED=true` on the
  test server. Because the content index is **n-gram / fuzzy BM25** (a
  vertex can match on a stray shared n-gram), the spec asserts that the
  full-token matches **rank to the top**, plus the empty/idle prompt and the
  Illuminate seed handoff.
- `playwright.config.ts` ports are now env-overridable (defaults unchanged,
  so CI is identical) — lets the suite run alongside a local cluster.

## Verification

`cd admin && bun run format && bun run lint && bun run typecheck && bun run test && bun run build` — all clean (661 unit tests pass).
`bun run test:e2e` — 60 pass (3 new search specs + 57 existing, no regressions).

Closes #627