### PR TITLE
chore: pin pb v0.6.0 + core v0.7.0 in sdks/go + root

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.4.0
-	github.com/anaregdesign/lantern/core v0.6.0
+	github.com/anaregdesign/lantern/core v0.7.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
-	github.com/anaregdesign/lantern/pb v0.5.0
+	github.com/anaregdesign/lantern/pb v0.6.0
 	github.com/anaregdesign/lantern/sdks/go v0.14.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -4,8 +4,8 @@ go 1.26
 
 require (
 	connectrpc.com/connect v1.20.0
-	github.com/anaregdesign/lantern/core v0.5.0
-	github.com/anaregdesign/lantern/pb v0.5.0
+	github.com/anaregdesign/lantern/core v0.7.0
+	github.com/anaregdesign/lantern/pb v0.6.0
 	golang.org/x/net v0.55.0
 	google.golang.org/protobuf v1.36.11
 )

--- a/sdks/go/go.sum
+++ b/sdks/go/go.sum
@@ -1,7 +1,7 @@
 connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=
 connectrpc.com/connect v1.20.0/go.mod h1:A2ygJrukXwWy32vkCAAHNVguZrqZ+jeZ9rGRnGR4dN4=
-github.com/anaregdesign/lantern/core v0.5.0 h1:q5r+zwFqCLHaiBl/nwtO0/42u1MUHSexa1LDSUkJwdo=
-github.com/anaregdesign/lantern/core v0.5.0/go.mod h1:HIOhpdioYbCvoT0s/g0HGC4cgdBoMMAbTyizWbM0wPE=
+github.com/anaregdesign/lantern/core v0.7.0 h1:0CGZFSMZv4EGD/Etbydt5xXBJ52ZiE6pk7M9ufnVg18=
+github.com/anaregdesign/lantern/core v0.7.0/go.mod h1:qJpBTt6AWmBIlabDQI2bWjgnx7kDiRwWGcVdcBFgALw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=


### PR DESCRIPTION
Bumps the `sdks/go` module pins to the freshly-tagged upstreams ahead of the `sdks/go/v0.15.0` release that ships the `SearchVertices` client forwarder (epic #628).

- `pb` v0.5.0 → **v0.6.0** (SearchVertices messages/stubs)
- `core` v0.5.0 → **v0.7.0** (inverted search index)

`go mod tidy` run in `sdks/go`; build + test green locally. No code changes — pin/go.sum only.