### PR TITLE
chore: pin sdks/go v0.15.0 in root + mcp; bump sdks/node to 0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/anaregdesign/lantern/core v0.7.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.6.0
-	github.com/anaregdesign/lantern/sdks/go v0.14.0
+	github.com/anaregdesign/lantern/sdks/go v0.15.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -3,15 +3,15 @@ module github.com/anaregdesign/lantern/mcp
 go 1.26
 
 require (
-	github.com/anaregdesign/lantern/pb v0.4.0
-	github.com/anaregdesign/lantern/sdks/go v0.13.0
+	github.com/anaregdesign/lantern/pb v0.6.0
+	github.com/anaregdesign/lantern/sdks/go v0.15.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	google.golang.org/protobuf v1.36.11
 )
 
 require (
 	connectrpc.com/connect v1.20.0 // indirect
-	github.com/anaregdesign/lantern/core v0.5.0 // indirect
+	github.com/anaregdesign/lantern/core v0.7.0 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/mcp/go.sum
+++ b/mcp/go.sum
@@ -1,7 +1,7 @@
 connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=
 connectrpc.com/connect v1.20.0/go.mod h1:A2ygJrukXwWy32vkCAAHNVguZrqZ+jeZ9rGRnGR4dN4=
-github.com/anaregdesign/lantern/core v0.5.0 h1:q5r+zwFqCLHaiBl/nwtO0/42u1MUHSexa1LDSUkJwdo=
-github.com/anaregdesign/lantern/core v0.5.0/go.mod h1:HIOhpdioYbCvoT0s/g0HGC4cgdBoMMAbTyizWbM0wPE=
+github.com/anaregdesign/lantern/core v0.7.0 h1:0CGZFSMZv4EGD/Etbydt5xXBJ52ZiE6pk7M9ufnVg18=
+github.com/anaregdesign/lantern/core v0.7.0/go.mod h1:qJpBTt6AWmBIlabDQI2bWjgnx7kDiRwWGcVdcBFgALw=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lantern-sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Official TypeScript client SDK for Lantern — an in-memory graph KVS, over Connect (HTTP/2).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Release prep for the SearchVertices cascade.

- Pin `sdks/go v0.15.0` in root and mcp go.mod (was v0.14.0 / v0.13.0).
- Cascade mcp indirect deps to `pb v0.6.0` + `core v0.7.0` via `go mod tidy`.
- Bump `sdks/node` package version `0.3.0` → `0.4.0` for the npm publish.

Precedes the root `v0.14.0`, `mcp/v0.8.0`, `admin/v0.8.0`, `sdks/node/v0.4.0` tags.

Part of the SearchVertices epic (#628).