### PR TITLE
feat(admin): add discoverable CLI command reference drawer

### DIFF
--- a/admin/app/components/cli/CliCommandReference/CliCommandReference.module.css
+++ b/admin/app/components/cli/CliCommandReference/CliCommandReference.module.css
@@ -1,0 +1,136 @@
+/* CLI commands reference drawer (#646).
+ *
+ * A slide-in cheat sheet listing every CLI verb with its signature and a
+ * runnable example, grouped by category. Pure presentation — the open/close
+ * state lives in CliPage. Uses Fluent UI design tokens via CSS custom
+ * property fallbacks so it follows the theme that root.tsx wires through
+ * FluentProvider.
+ */
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalL, 16px);
+}
+
+.intro {
+  margin: 0;
+  font-size: var(--fontSizeBase300, 14px);
+  color: var(--colorNeutralForeground2, #424242);
+  line-height: var(--lineHeightBase300, 20px);
+}
+
+.intro code {
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalS, 8px);
+}
+
+.groupTitle {
+  margin: 0;
+  font-size: var(--fontSizeBase200, 12px);
+  font-weight: var(--fontWeightSemibold, 600);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--colorNeutralForeground3, #707070);
+}
+
+.list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalS, 8px);
+}
+
+.item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalXXS, 2px);
+  padding: var(--spacingVerticalS, 8px) var(--spacingHorizontalM, 12px);
+  border-radius: var(--borderRadiusMedium, 4px);
+  background-color: var(--colorNeutralBackground2, #fafafa);
+  border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+}
+
+.signature {
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  font-size: var(--fontSizeBase300, 14px);
+  font-weight: var(--fontWeightSemibold, 600);
+  color: var(--colorNeutralForeground1, #242424);
+  overflow-wrap: anywhere;
+}
+
+.summary {
+  margin: 0;
+  font-size: var(--fontSizeBase200, 12px);
+  color: var(--colorNeutralForeground2, #424242);
+  line-height: var(--lineHeightBase200, 16px);
+}
+
+.example {
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  font-size: var(--fontSizeBase200, 12px);
+  color: var(--colorNeutralForeground3, #707070);
+  overflow-wrap: anywhere;
+}
+
+.examplePrompt {
+  color: var(--colorBrandForeground1, #0f6cbd);
+}
+
+.tips {
+  margin: 0;
+  padding-left: var(--spacingHorizontalL, 16px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalXS, 4px);
+  font-size: var(--fontSizeBase200, 12px);
+  color: var(--colorNeutralForeground2, #424242);
+  line-height: var(--lineHeightBase200, 16px);
+}
+
+.tips code {
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  font-size: var(--fontSizeBase200, 12px);
+}
+
+.kbd {
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  font-size: var(--fontSizeBase100, 10px);
+  padding: 1px 4px;
+  border-radius: var(--borderRadiusSmall, 2px);
+  border: 1px solid var(--colorNeutralStroke1, #d1d1d1);
+  background-color: var(--colorNeutralBackground3, #f5f5f5);
+  color: var(--colorNeutralForeground2, #424242);
+}

--- a/admin/app/components/cli/CliCommandReference/CliCommandReference.tsx
+++ b/admin/app/components/cli/CliCommandReference/CliCommandReference.tsx
@@ -1,0 +1,144 @@
+import {
+  Button,
+  DrawerBody,
+  DrawerHeader,
+  DrawerHeaderTitle,
+  OverlayDrawer,
+} from "@fluentui/react-components";
+import { Dismiss24Regular } from "@fluentui/react-icons";
+import { CLI_COMMAND_REFERENCE, type CliCommandDoc } from "~/lib/cli/verbs";
+import styles from "./CliCommandReference.module.css";
+
+export interface CliCommandReferenceProps {
+  /** Whether the reference drawer is open. */
+  open: boolean;
+  /** Close the drawer (Esc, the dismiss button, or the scrim). */
+  onClose: () => void;
+}
+
+interface CommandGroup {
+  readonly name: string;
+  readonly docs: readonly CliCommandDoc[];
+}
+
+/**
+ * Groups the flat reference by its `group` field, preserving first-seen
+ * order. Computed once at module load — the reference is static.
+ */
+function groupReference(
+  docs: readonly CliCommandDoc[],
+): readonly CommandGroup[] {
+  const order: string[] = [];
+  const byGroup = new Map<string, CliCommandDoc[]>();
+  for (const doc of docs) {
+    let bucket = byGroup.get(doc.group);
+    if (bucket === undefined) {
+      bucket = [];
+      byGroup.set(doc.group, bucket);
+      order.push(doc.group);
+    }
+    bucket.push(doc);
+  }
+  return order.map((name) => ({ name, docs: byGroup.get(name) ?? [] }));
+}
+
+const GROUPED = groupReference(CLI_COMMAND_REFERENCE);
+
+/**
+ * Slide-in "Commands" cheat sheet for the /cli page (#646).
+ *
+ * Surfaces the same grammar the `help` verb prints, but as a scannable,
+ * grouped reference so a first-time operator can discover every verb, its
+ * signature, and a runnable example without already knowing to type
+ * `help`. The data comes from {@link CLI_COMMAND_REFERENCE}, which a unit
+ * test binds to the real parser so the examples can never drift.
+ *
+ * Render-only: open/close state is owned by the parent CliPage. The modal
+ * `OverlayDrawer` manages its own focus trap and Esc-to-close; the
+ * window-level Esc handler in `useCli` only fires while a command is in
+ * flight and does not stop propagation, so the two never conflict.
+ */
+export function CliCommandReference({
+  open,
+  onClose,
+}: CliCommandReferenceProps) {
+  return (
+    <OverlayDrawer
+      open={open}
+      position="end"
+      size="medium"
+      onOpenChange={(_, data) => {
+        if (!data.open) onClose();
+      }}
+      data-testid="cli-command-reference-drawer"
+    >
+      <DrawerHeader>
+        <DrawerHeaderTitle
+          action={
+            <Button
+              appearance="subtle"
+              aria-label="Close commands"
+              icon={<Dismiss24Regular />}
+              onClick={onClose}
+              data-testid="cli-command-reference-close"
+            />
+          }
+        >
+          CLI commands
+        </DrawerHeaderTitle>
+      </DrawerHeader>
+      <DrawerBody>
+        <div className={styles.body} data-testid="cli-command-reference">
+          <p className={styles.intro}>
+            The same grammar as <code>lantern repl</code>. Type a command and
+            press <kbd className={styles.kbd}>Enter</kbd>; press{" "}
+            <kbd className={styles.kbd}>Tab</kbd> to autocomplete.
+          </p>
+
+          {GROUPED.map((group) => (
+            <section key={group.name} className={styles.group}>
+              <h3 className={styles.groupTitle}>{group.name}</h3>
+              <ul className={styles.list}>
+                {group.docs.map((doc) => (
+                  <li
+                    key={doc.signature}
+                    className={styles.item}
+                    data-testid="cli-command-row"
+                  >
+                    <code className={styles.signature}>{doc.signature}</code>
+                    <p className={styles.summary}>{doc.summary}</p>
+                    <code className={styles.example}>
+                      <span className={styles.examplePrompt} aria-hidden="true">
+                        {"❯ "}
+                      </span>
+                      {doc.example}
+                    </code>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+
+          <section className={styles.group}>
+            <h3 className={styles.groupTitle}>Tips</h3>
+            <ul className={styles.tips}>
+              <li>
+                Press <kbd className={styles.kbd}>Tab</kbd> to autocomplete
+                verbs, keys, and option names.
+              </li>
+              <li>
+                Quoting: <code>{'"double"'}</code> allows C-style escapes (
+                <code>{'\\" \\\\ \\n \\r \\t'}</code>);{" "}
+                <code>{"'single'"}</code> is verbatim.
+              </li>
+              <li>
+                Verbs and objectives are case-insensitive; argument values keep
+                their case.
+              </li>
+            </ul>
+          </section>
+        </div>
+      </DrawerBody>
+    </OverlayDrawer>
+  );
+}

--- a/admin/app/components/cli/CliPage/CliPage.module.css
+++ b/admin/app/components/cli/CliPage/CliPage.module.css
@@ -98,12 +98,22 @@
   letter-spacing: 0.02em;
 }
 
-/* Spinner + Cancel, pushed to the right edge while a command is in flight. */
-.chromeBusy {
+/* Right-aligned chrome controls: the persistent "Commands" toggle (#646)
+ * plus the transient busy spinner / Cancel cluster. `margin-left: auto`
+ * pushes the whole group to the right edge of the chrome bar. */
+.chromeActions {
   display: inline-flex;
   align-items: center;
   gap: var(--spacingHorizontalS, 8px);
   margin-left: auto;
+}
+
+/* Spinner + Cancel, shown while a command is in flight. Lives inside
+ * `.chromeActions`, which already owns the right-alignment. */
+.chromeBusy {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacingHorizontalS, 8px);
 }
 
 /* Scrollback body — transparent because the terminal box owns the frame. */

--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -1,4 +1,5 @@
 import { Button, Spinner } from "@fluentui/react-components";
+import { BookQuestionMark20Regular } from "@fluentui/react-icons";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { formatIlluminateClick } from "~/lib/cli/illuminate-axes";
 import { completeCommandLine, longestCommonPrefix } from "~/lib/cli/complete";
@@ -7,6 +8,7 @@ import { useCliSplitter } from "~/lib/client/usecase/cli/use-cli-splitter";
 import { useCliAxisPicker } from "~/lib/client/usecase/cli/use-cli-axis-picker";
 import type { ScrollbackEntry } from "~/lib/client/usecase/cli/state";
 import { CliAxisPicker } from "~/components/cli/CliAxisPicker/CliAxisPicker";
+import { CliCommandReference } from "~/components/cli/CliCommandReference/CliCommandReference";
 import { JsonView } from "~/components/cli/JsonView/JsonView";
 import { IlluminateCanvas } from "~/components/illuminate/IlluminateCanvas/IlluminateCanvas";
 import styles from "./CliPage.module.css";
@@ -28,6 +30,9 @@ export function CliPage() {
   // token is ambiguous (#515). Local UI state only — never written to the
   // scrollback log, so it behaves like a shell's transient completion row.
   const [hints, setHints] = useState<string[]>([]);
+  // Whether the slide-in "Commands" reference drawer is open (#646). Local
+  // UI state — it neither touches the dispatch loop nor the scrollback.
+  const [helpOpen, setHelpOpen] = useState(false);
   // Drives the two-column grid + draggable splitter (#465). Only active
   // when a graph is present; otherwise the right column owns the full
   // width and the splitter handle is hidden by CSS.
@@ -200,25 +205,38 @@ export function CliPage() {
             <span className={`${styles.dot} ${styles.dotGreen}`} />
           </span>
           <span className={styles.chromeTitle}>lantern · cli</span>
-          {cli.busy ? (
-            <span className={styles.chromeBusy}>
-              <Spinner
-                size="extra-tiny"
-                label="running"
-                labelPosition="before"
-              />
-              <Button
-                appearance="subtle"
-                size="small"
-                onClick={cli.cancelInFlight}
-                data-testid="cli-cancel"
-                aria-label="Cancel in-flight command (Esc)"
-                title="Cancel in-flight command (Esc)"
-              >
-                Cancel
-              </Button>
-            </span>
-          ) : null}
+          <span className={styles.chromeActions}>
+            <Button
+              appearance="subtle"
+              size="small"
+              icon={<BookQuestionMark20Regular />}
+              onClick={() => setHelpOpen(true)}
+              data-testid="cli-help-toggle"
+              aria-label="Show CLI commands"
+              title="Show CLI commands"
+            >
+              Commands
+            </Button>
+            {cli.busy ? (
+              <span className={styles.chromeBusy}>
+                <Spinner
+                  size="extra-tiny"
+                  label="running"
+                  labelPosition="before"
+                />
+                <Button
+                  appearance="subtle"
+                  size="small"
+                  onClick={cli.cancelInFlight}
+                  data-testid="cli-cancel"
+                  aria-label="Cancel in-flight command (Esc)"
+                  title="Cancel in-flight command (Esc)"
+                >
+                  Cancel
+                </Button>
+              </span>
+            ) : null}
+          </span>
         </div>
 
         <div
@@ -330,6 +348,12 @@ export function CliPage() {
           </div>
         </section>
       ) : null}
+
+      {/* Slide-in command reference (#646), toggled from the chrome
+          "Commands" button. Portals over the viewport, so its position in
+          the tree does not matter — it lives here to keep the toggle and
+          panel state co-located. */}
+      <CliCommandReference open={helpOpen} onClose={() => setHelpOpen(false)} />
     </div>
   );
 }

--- a/admin/app/lib/cli/verbs.test.ts
+++ b/admin/app/lib/cli/verbs.test.ts
@@ -11,7 +11,9 @@
  */
 import { describe, expect, test } from "bun:test";
 
+import { parse } from "./parser";
 import {
+  CLI_COMMAND_REFERENCE,
   HELP_TEXT,
   parseAdd,
   parseHelp,
@@ -19,6 +21,23 @@ import {
   parsePut,
   parseFloatStrict,
 } from "./verbs";
+
+/**
+ * The canonical verb set, duplicated here (not imported) on purpose so the
+ * test fails loudly if a verb is ever added to the parser without being
+ * surfaced in the reference and `HELP_TEXT`. Mirrors `parser.ts`'s `VERBS`
+ * and the Go `parser.Verbs`.
+ */
+const CANONICAL_VERBS = [
+  "get",
+  "put",
+  "delete",
+  "add",
+  "scan",
+  "illuminate",
+  "help",
+  "exit",
+] as const;
 
 describe("parseFloatStrict (#434 — Go strconv.ParseFloat parity)", () => {
   test.each([
@@ -198,5 +217,49 @@ describe("parseIlluminate prefix= kwarg (#606)", () => {
 
   test("rejects an explicit empty prefix= value", () => {
     expect(parseIlluminate(["alice", "2", "5", "prefix="]).ok).toBe(false);
+  });
+});
+
+describe("CLI_COMMAND_REFERENCE (#646 — structured reference ⇄ parser binding)", () => {
+  test("is non-empty", () => {
+    expect(CLI_COMMAND_REFERENCE.length).toBeGreaterThan(0);
+  });
+
+  test("every entry's verb is the first token of its signature", () => {
+    for (const doc of CLI_COMMAND_REFERENCE) {
+      expect(doc.signature.split(/\s+/)[0]).toBe(doc.verb);
+    }
+  });
+
+  test("every example parses successfully via the real parser", () => {
+    for (const doc of CLI_COMMAND_REFERENCE) {
+      const r = parse(doc.example);
+      if (!r.ok) {
+        throw new Error(`example did not parse: "${doc.example}" → ${r.usage}`);
+      }
+      // The parsed verb must match the documented verb so an example can
+      // never silently document the wrong command. The parser narrows
+      // `verb` to a literal union, so widen to string for the comparison.
+      expect(r.command.verb as string).toBe(doc.verb);
+    }
+  });
+
+  test("covers exactly the canonical verb set — no missing, no invented", () => {
+    const referenced = new Set(CLI_COMMAND_REFERENCE.map((d) => d.verb));
+    expect([...referenced].sort()).toEqual([...CANONICAL_VERBS].sort());
+  });
+
+  test("every referenced verb also appears in HELP_TEXT (cross-view parity)", () => {
+    for (const verb of new Set(CLI_COMMAND_REFERENCE.map((d) => d.verb))) {
+      expect(HELP_TEXT).toContain(verb);
+    }
+  });
+
+  test("entries carry a non-empty group, summary, and example", () => {
+    for (const doc of CLI_COMMAND_REFERENCE) {
+      expect(doc.group.length).toBeGreaterThan(0);
+      expect(doc.summary.length).toBeGreaterThan(0);
+      expect(doc.example.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/admin/app/lib/cli/verbs.ts
+++ b/admin/app/lib/cli/verbs.ts
@@ -373,6 +373,129 @@ export const HELP_TEXT = [
 ].join("\n");
 
 /**
+ * A single row of the structured CLI command reference rendered by the
+ * `/cli` "Commands" panel (`CliCommandReference`).
+ *
+ * This is a **separate, human-facing view** of the grammar — deliberately
+ * NOT derived from {@link HELP_TEXT}. `HELP_TEXT` is byte-locked to the Go
+ * `HelpText` (the `verbs.json` fixture compares both parsers against it) and
+ * its multi-line `illuminate` alignment must not be regenerated. The two are
+ * instead kept honest by `verbs.test.ts`, which asserts that every `example`
+ * parses and that the set of `verb`s equals the canonical verb list.
+ */
+export interface CliCommandDoc {
+  /** The group shown as a section header in the panel. */
+  readonly group: string;
+  /** The verb keyword as typed (`get`, `put`, `illuminate`, …). */
+  readonly verb: string;
+  /** Compact signature, e.g. `get vertex <key>`. */
+  readonly signature: string;
+  /** One-line, plain-English description. */
+  readonly summary: string;
+  /** A concrete, runnable example (must parse — bound by `verbs.test.ts`). */
+  readonly example: string;
+}
+
+/**
+ * Structured command reference for the `/cli` "Commands" panel, ordered by
+ * group (Vertices → Edges → Browse → Explore → Session). See
+ * {@link CliCommandDoc} for why this is not generated from `HELP_TEXT`.
+ */
+export const CLI_COMMAND_REFERENCE: readonly CliCommandDoc[] = [
+  {
+    group: "Vertices",
+    verb: "get",
+    signature: "get vertex <key>",
+    summary: "Read a vertex's value by key.",
+    example: "get vertex alice",
+  },
+  {
+    group: "Vertices",
+    verb: "put",
+    signature: "put vertex <key> <value> [ttl]",
+    summary:
+      "Create or replace a vertex. Value is typed (string / int / float / bool / datetime); TTL seconds optional.",
+    example: "put vertex alice Alice 3600",
+  },
+  {
+    group: "Vertices",
+    verb: "delete",
+    signature: "delete vertex <key>",
+    summary: "Remove a vertex by key.",
+    example: "delete vertex alice",
+  },
+  {
+    group: "Edges",
+    verb: "get",
+    signature: "get edge <tail> <head>",
+    summary: "Read the weight of the edge between two vertices.",
+    example: "get edge alice bob",
+  },
+  {
+    group: "Edges",
+    verb: "put",
+    signature: "put edge <tail> <head> <weight> [ttl]",
+    summary:
+      "Create or replace an edge, setting its weight. TTL seconds optional.",
+    example: "put edge alice bob 1.5",
+  },
+  {
+    group: "Edges",
+    verb: "add",
+    signature: "add edge <tail> <head> <weight> [ttl]",
+    summary:
+      "Add weight onto an edge (additive); creates it if absent. TTL seconds optional.",
+    example: "add edge alice bob 0.5",
+  },
+  {
+    group: "Edges",
+    verb: "delete",
+    signature: "delete edge <tail> <head>",
+    summary: "Remove the edge between two vertices.",
+    example: "delete edge alice bob",
+  },
+  {
+    group: "Browse",
+    verb: "scan",
+    signature: "scan vertices <prefix> [limit]",
+    summary:
+      "List vertices whose key starts with a prefix (optional max count).",
+    example: "scan vertices user: 20",
+  },
+  {
+    group: "Browse",
+    verb: "scan",
+    signature: "scan edges <tail-prefix> [limit]",
+    summary: "List edges whose tail starts with a prefix (optional max count).",
+    example: "scan edges alice 20",
+  },
+  {
+    group: "Explore",
+    verb: "illuminate",
+    signature:
+      "illuminate <seed> <step> <k> [algorithm=none|mst|spt] [objective=min|max] [weighting=raw|tfidf] [prefix=<string>]",
+    summary:
+      "Walk the graph from a seed (step hops, top-k per hop) and render the subgraph. Optional reduction axes.",
+    example: "illuminate alice 2 5 algorithm=spt",
+  },
+  {
+    group: "Session",
+    verb: "help",
+    signature: "help",
+    summary: "Print the grammar reference into the terminal.",
+    example: "help",
+  },
+  {
+    group: "Session",
+    verb: "exit",
+    signature: "exit",
+    summary:
+      "No-op in the web CLI (close the tab to leave); ends the prompt in `lantern repl`.",
+    example: "exit",
+  },
+];
+
+/**
  * Parses the `help` verb. Extra arguments are accepted silently so
  * the verb behaves like `exit` — discoverability beats strictness
  * here, since the operator typing `help` is by definition asking for

--- a/admin/app/lib/client/usecase/cli/state.ts
+++ b/admin/app/lib/client/usecase/cli/state.ts
@@ -58,8 +58,8 @@ export function initialBanner(): ScrollbackEntry {
     kind: "info",
     text: [
       "Lantern admin CLI (#411). Same grammar as `lantern repl`.",
-      "Type a verb and Enter; arrow-up / arrow-down cycle history.",
-      'Type "help" for verb signatures.',
+      "Type a verb and Enter; press Tab to autocomplete; arrow-up / arrow-down cycle history.",
+      'Click "Commands" (top-right) or type "help" for the full command reference.',
     ].join("\n"),
   };
 }

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -504,4 +504,32 @@ test.describe("/cli", () => {
     await expect(input).toBeEnabled();
     await expect(input).toBeFocused();
   });
+
+  // #646 — the chrome "Commands" button opens a slide-in reference drawer
+  // listing every verb with a signature and a runnable example, so a
+  // first-time operator can discover the grammar without already knowing
+  // to type `help`. Unlike the intro banner, the toggle never scrolls
+  // away, so the reference stays one click away for the whole session.
+  test("Commands button opens the CLI reference drawer (#646)", async ({
+    page,
+  }) => {
+    await page.goto("/cli");
+    // The toggle is part of the persistent chrome — visible from load.
+    const toggle = page.getByTestId("cli-help-toggle");
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toContainText("Commands");
+    // The drawer is closed until the toggle is clicked (modal drawer
+    // keeps its content out of the DOM while closed).
+    await expect(page.getByTestId("cli-command-reference")).toHaveCount(0);
+    await toggle.click();
+    // It opens with the grouped reference, including the illuminate verb
+    // and at least one runnable example row.
+    const drawer = page.getByTestId("cli-command-reference");
+    await expect(drawer).toBeVisible();
+    await expect(drawer).toContainText("illuminate");
+    await expect(page.getByTestId("cli-command-row").first()).toBeVisible();
+    // The dismiss button closes it again.
+    await page.getByTestId("cli-command-reference-close").click();
+    await expect(page.getByTestId("cli-command-reference")).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
## What

Make the admin `/cli` grammar discoverable. Previously the verb/flag
vocabulary was only shared through the intro banner, which scrolls out
of view once a session gets going — so a first-time user had no
persistent way to learn the grammar I defined.

## Changes

- **Always-visible "Commands" button** in the CLI chrome (top-right,
  next to the busy/cancel cluster) that opens a slide-in Fluent
  `OverlayDrawer` cheat-sheet.
- **Structured command reference** (`CLI_COMMAND_REFERENCE` in
  `app/lib/cli/verbs.ts`): every verb grouped into Vertices → Edges →
  Browse → Explore → Session, each with a signature, one-line summary,
  and a runnable example, plus a quoting/escaping **Tips** section.
- **Enhanced intro banner** advertising Tab autocomplete, history
  cycling, and the new Commands button (and `help`).

## Grammar parity is preserved

The cheat-sheet is a **separate, human-facing view**. It is **not**
derived from `HELP_TEXT`, which stays byte-locked to the Go repl's
`HelpText` (guarded by the existing grammar fixture). A new test in
`verbs.test.ts` binds every reference entry's verb back to the parser,
so the structured reference and the parser cannot silently drift.

## Verification

- `bun run format` / `bun run lint` / `bun run typecheck` — clean
- `bun run test` — 667 pass / 0 fail
- `bunx playwright test --workers=1` — 62 pass (incl. the new drawer
  open/close e2e)
- `bun run build` — clean

Closes #646
