### PR TITLE
feat(cli): print a startup banner in the interactive REPL

### DIFF
--- a/cli/cmd/repl.go
+++ b/cli/cmd/repl.go
@@ -11,6 +11,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// replBanner is the terminal counterpart to the admin /cli intro banner
+// (#647). promptui renders only a bare ">" prompt, so a first-time user
+// has no cue that the shell is self-describing. Printing this once at
+// startup points them at the two verbs that make the REPL discoverable —
+// `help` (full per-verb grammar) and `exit` (quit) — mirroring the wording
+// of the web banner so both surfaces feel like one tool.
+const replBanner = `Lantern interactive REPL — same grammar as the admin /cli page.
+Type a verb and press Enter. Type "help" for the full command reference, "exit" to quit.`
+
 // replCmd preserves the legacy promptui-based interactive shell, now scoped
 // behind an explicit subcommand. New scripted use should prefer the
 // dedicated subcommands (vertex, edge, illuminate, bulk).
@@ -82,6 +91,8 @@ EXAMPLE
 			}
 		}()
 		srv := service.NewCLIService(cli)
+
+		fmt.Println(replBanner)
 
 		tpl := &promptui.PromptTemplates{
 			Prompt:  "{{ . }} ",

--- a/cli/cmd/repl_test.go
+++ b/cli/cmd/repl_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/anaregdesign/lantern/cli/parser"
+)
+
+// TestReplBanner guards the startup banner the REPL prints before entering
+// its prompt loop (#647). promptui renders only a bare ">" prompt, so this
+// banner is the sole cue that tells a first-time user the shell is
+// self-describing.
+func TestReplBanner(t *testing.T) {
+	t.Run("advertises help and exit", func(t *testing.T) {
+		for _, want := range []string{"help", "exit"} {
+			if !strings.Contains(replBanner, want) {
+				t.Errorf("replBanner must mention %q so users can discover it; got:\n%s", want, replBanner)
+			}
+		}
+	})
+
+	t.Run("references the shared grammar", func(t *testing.T) {
+		if !strings.Contains(replBanner, "grammar") {
+			t.Errorf("replBanner should point at the shared grammar; got:\n%s", replBanner)
+		}
+	})
+
+	// Bind the banner to reality: a verb is only worth advertising if the
+	// parser actually accepts it. This fails loudly if the banner ever
+	// drifts to suggest a verb the grammar rejects.
+	t.Run("advertised verbs are accepted by the parser", func(t *testing.T) {
+		for _, verb := range []string{"help", "exit"} {
+			if err := parser.Validate(verb); err != nil {
+				t.Errorf("parser.Validate(%q) = %v, want nil (banner advertises it)", verb, err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## What

Make the terminal REPL's grammar discoverable, the terminal counterpart
to #646. `lantern repl` dropped straight into a bare promptui `>`
prompt, so a first-time user had no cue that the shell understands
`help` (which prints the full per-verb grammar) or `exit`.

## Changes

- Print a concise **startup banner** once, before the prompt loop, that
  points at `help` and `exit` and notes the grammar is shared with the
  admin `/cli` page — mirroring the web intro banner so both surfaces
  read as one tool.
- Add the paired `cli/cmd/repl_test.go` (1:1 source↔test). Beyond
  asserting the banner mentions `help`, `exit`, and the shared grammar,
  it **binds the advertised verbs back to `parser.Validate`**, so the
  banner can never advertise a verb the grammar rejects.

## Grammar parity

This touches only the runtime banner. `HelpText` (and its byte-locked TS
twin `HELP_TEXT`) is unchanged, so the existing grammar fixture stays
green.

## Verification

- `gofmt -l cli/` — clean
- `go build ./...` — ok
- `go test ./...` (root) — pass, incl. the new `TestReplBanner`

Closes #647
