### PR TITLE
fix(admin): render permanent vertices/edges as "never" not born-expired

### DIFF
--- a/admin/app/components/browse-edges/ExpirationCell/ExpirationCell.tsx
+++ b/admin/app/components/browse-edges/ExpirationCell/ExpirationCell.tsx
@@ -23,6 +23,13 @@ export function ExpirationCell({
   if (!Number.isFinite(expiresAt)) {
     return <span className={styles.empty}>{expiration}</span>;
   }
+  if (expiresAt <= 0) {
+    // Permanent sentinel: a no-TTL vertex/edge carries the server's zero
+    // `Timestamp` (`0001-01-01T00:00:00Z`, or the Unix epoch), i.e. a
+    // non-positive instant. Render "never" like an absent field rather
+    // than a long-expired chip (mirrors the server's `IsLiveAt` rule).
+    return <span className={styles.empty}>never</span>;
+  }
   const now = Date.now();
   const deltaMs = expiresAt - now;
   const expired = deltaMs <= 0;

--- a/admin/app/components/browse-vertices/ExpirationCell/ExpirationCell.tsx
+++ b/admin/app/components/browse-vertices/ExpirationCell/ExpirationCell.tsx
@@ -26,6 +26,13 @@ export function ExpirationCell({
   if (!Number.isFinite(expiresAt)) {
     return <span className={styles.empty}>{expiration}</span>;
   }
+  if (expiresAt <= 0) {
+    // Permanent sentinel: a no-TTL vertex/edge carries the server's zero
+    // `Timestamp` (`0001-01-01T00:00:00Z`, or the Unix epoch), i.e. a
+    // non-positive instant. Render "never" like an absent field rather
+    // than a long-expired chip (mirrors the server's `IsLiveAt` rule).
+    return <span className={styles.empty}>never</span>;
+  }
   const now = Date.now();
   const deltaMs = expiresAt - now;
   const expired = deltaMs <= 0;

--- a/admin/app/lib/client/infrastructure/api/to-flat.test.ts
+++ b/admin/app/lib/client/infrastructure/api/to-flat.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for the SDK rich-shape → flat-JSON conversion (#409),
+ * focused on the permanent-vertex / permanent-edge expiration sentinel
+ * (#654).
+ *
+ * A vertex or edge written with no TTL is permanent. The server encodes
+ * that as the Go zero `time.Time` (`0001-01-01T00:00:00Z`), which the
+ * Node SDK surfaces as a `Date` with a non-positive epoch value rather
+ * than `null`. `sdkVertexToFlat` / `sdkEdgeToFlat` are the single
+ * chokepoint every browse / search / detail / CLI surface reads through,
+ * so dropping the sentinel here makes every downstream cell render
+ * "never" instead of a long-expired chip ("739783d ago").
+ */
+import { describe, expect, test } from "bun:test";
+
+import type { Edge as SdkEdge, Vertex as SdkVertex } from "lantern-sdk/web";
+
+import { sdkEdgeToFlat, sdkVertexToFlat } from "./to-flat";
+
+// The Go zero `time.Time` (`0001-01-01T00:00:00Z`) in epoch milliseconds.
+const PROTO_ZERO_TIME = new Date("0001-01-01T00:00:00Z");
+// The Unix epoch (`1970-01-01T00:00:00Z`) — the other non-positive sentinel.
+const UNIX_EPOCH = new Date(0);
+// A genuine, future expiration.
+const FUTURE = new Date("2999-01-01T00:00:00Z");
+
+function vertex(expiration: Date | null): SdkVertex {
+  return { key: "k", value: "v", kind: "string", expiration };
+}
+
+function edge(expiration: Date | null): SdkEdge {
+  return { tail: "a", head: "b", weight: 1, expiration };
+}
+
+describe("sdkVertexToFlat expiration", () => {
+  test("drops the proto zero-time sentinel (permanent vertex)", () => {
+    expect(sdkVertexToFlat(vertex(PROTO_ZERO_TIME)).expiration).toBeUndefined();
+  });
+
+  test("drops the Unix-epoch sentinel", () => {
+    expect(sdkVertexToFlat(vertex(UNIX_EPOCH)).expiration).toBeUndefined();
+  });
+
+  test("omits expiration when the SDK reports null", () => {
+    expect(sdkVertexToFlat(vertex(null)).expiration).toBeUndefined();
+  });
+
+  test("keeps a genuine future expiration as an ISO string", () => {
+    expect(sdkVertexToFlat(vertex(FUTURE)).expiration).toBe(
+      FUTURE.toISOString(),
+    );
+  });
+});
+
+describe("sdkEdgeToFlat expiration", () => {
+  test("drops the proto zero-time sentinel (permanent edge)", () => {
+    expect(sdkEdgeToFlat(edge(PROTO_ZERO_TIME)).expiration).toBeUndefined();
+  });
+
+  test("drops the Unix-epoch sentinel", () => {
+    expect(sdkEdgeToFlat(edge(UNIX_EPOCH)).expiration).toBeUndefined();
+  });
+
+  test("omits expiration when the SDK reports null", () => {
+    expect(sdkEdgeToFlat(edge(null)).expiration).toBeUndefined();
+  });
+
+  test("keeps a genuine future expiration as an ISO string", () => {
+    expect(sdkEdgeToFlat(edge(FUTURE)).expiration).toBe(FUTURE.toISOString());
+  });
+});

--- a/admin/app/lib/client/infrastructure/api/to-flat.ts
+++ b/admin/app/lib/client/infrastructure/api/to-flat.ts
@@ -32,7 +32,7 @@ import type { Edge, Vertex } from "./types";
  */
 export function sdkVertexToFlat(v: SdkVertex): Vertex {
   const out: Vertex = { key: v.key };
-  if (v.expiration) {
+  if (isRealExpiration(v.expiration)) {
     out.expiration = v.expiration.toISOString();
   }
   switch (v.kind) {
@@ -87,7 +87,7 @@ export function sdkEdgeToFlat(e: SdkEdge): Edge {
     head: e.head,
     weight: e.weight,
   };
-  if (e.expiration) {
+  if (isRealExpiration(e.expiration)) {
     out.expiration = e.expiration.toISOString();
   }
   return out;
@@ -154,6 +154,19 @@ export function flatEdgeToSdkInput(e: Edge): SdkEdgeInput {
 // ----------------------------------------------------------------------------
 // Internals
 // ----------------------------------------------------------------------------
+
+/**
+ * A vertex/edge written with no TTL is permanent. The server encodes that
+ * as the Go zero `time.Time` (`0001-01-01T00:00:00Z`), which the SDK
+ * surfaces as a `Date` with a non-positive epoch value rather than `null`.
+ * Treat any such sentinel (proto zero-time or the Unix epoch) as "no
+ * expiration" so the flat shape never carries a born-expired timestamp —
+ * mirrors the server's `IsLiveAt` rule (Unix seconds <= 0 means live
+ * forever). A genuinely-set expiration is always a positive future time.
+ */
+function isRealExpiration(d: Date | null | undefined): d is Date {
+  return d != null && d.getTime() > 0;
+}
 
 function bytesToBase64(bytes: Uint8Array): string {
   let s = "";


### PR DESCRIPTION
## Summary

A vertex or edge written with **no TTL** is permanent. The server encodes that as the Go zero `time.Time` (`0001-01-01T00:00:00Z`), which the Node SDK surfaces as a `Date` with a **non-positive epoch value** rather than `null`. The flat-JSON conversion (`sdkVertexToFlat` / `sdkEdgeToFlat`) then emitted that sentinel as an ISO string, so every browse / search / detail surface rendered a long-expired red chip (e.g. `739783d ago`) for a row that **never** expires.

## Fix

- **`to-flat.ts` (the single conversion chokepoint)**: add an `isRealExpiration` guard that drops any non-positive instant (proto zero-time **or** the Unix epoch) before projecting `expiration` onto the flat shape. This mirrors the server's `IsLiveAt` rule (*Unix seconds ≤ 0 means live forever*), so the flat shape can never carry a born-expired timestamp.
- **Both `ExpirationCell` copies** (vertices + edges): add a matching defensive `expiresAt <= 0 → "never"` guard so a non-positive timestamp from any source still renders correctly.
- **`to-flat.test.ts`** (new): covers proto zero-time / Unix-epoch / `null` / genuine-future cases for both `sdkVertexToFlat` and `sdkEdgeToFlat`.

## Verification

- `bun run format && bun run lint && bun run typecheck` — clean.
- `bun run test` — **675 pass / 0 fail** (8 new).
- `bun run build` — clean.
- Playwright e2e deferred to CI (`admin.yml` Build job) — Go is not installed on the local workstation, so the e2e `webServer` (`go run ../server/cmd`) cannot start locally.

## Root cause note (SDK)

The deeper cause is `sdks/node/src/values.ts` `parseExpiration`, which only maps `ms === 0` to `null` — the proto zero-time (`-62135596800000`) is finite and non-zero, so it slips through as a `Date(year 1)`. Fixing it there would widen the release blast radius to the Node SDK, so this PR fixes it at the admin boundary and leaves the SDK note for a follow-up.

Closes #654
