### PR TITLE
fix(admin): meet WCAG AA contrast on expiration chips

### DIFF
--- a/admin/app/components/browse-edges/ExpirationCell/ExpirationCell.module.css
+++ b/admin/app/components/browse-edges/ExpirationCell/ExpirationCell.module.css
@@ -9,14 +9,20 @@
   font-variant-numeric: tabular-nums;
 }
 
+/*
+ * Pair the Background2 status tint with the *Foreground2* token, not
+ * Foreground1: Foreground1 on Background2 only reaches ~3.5-3.9:1 and fails
+ * WCAG 2.1 AA (>=4.5:1) in both themes, whereas Foreground2 on Background2
+ * clears it comfortably (~5.6-6.6:1) in light and dark alike.
+ */
 .warning {
-  background: var(--colorStatusWarningBackground2, #fff4ce);
-  color: var(--colorStatusWarningForeground1, #8a6300);
+  background: var(--colorStatusWarningBackground2, #fdcfb4);
+  color: var(--colorStatusWarningForeground2, #8a3707);
 }
 
 .expired {
-  background: var(--colorStatusDangerBackground2, #fde7e9);
-  color: var(--colorStatusDangerForeground1, #b10e1c);
+  background: var(--colorStatusDangerBackground2, #eeacb2);
+  color: var(--colorStatusDangerForeground2, #6e0811);
 }
 
 .empty {

--- a/admin/app/components/browse-vertices/ExpirationCell/ExpirationCell.module.css
+++ b/admin/app/components/browse-vertices/ExpirationCell/ExpirationCell.module.css
@@ -9,14 +9,20 @@
   font-variant-numeric: tabular-nums;
 }
 
+/*
+ * Pair the Background2 status tint with the *Foreground2* token, not
+ * Foreground1: Foreground1 on Background2 only reaches ~3.5-3.9:1 and fails
+ * WCAG 2.1 AA (>=4.5:1) in both themes, whereas Foreground2 on Background2
+ * clears it comfortably (~5.6-6.6:1) in light and dark alike.
+ */
 .warning {
-  background: var(--colorStatusWarningBackground2, #fff4ce);
-  color: var(--colorStatusWarningForeground1, #8a6300);
+  background: var(--colorStatusWarningBackground2, #fdcfb4);
+  color: var(--colorStatusWarningForeground2, #8a3707);
 }
 
 .expired {
-  background: var(--colorStatusDangerBackground2, #fde7e9);
-  color: var(--colorStatusDangerForeground1, #b10e1c);
+  background: var(--colorStatusDangerBackground2, #eeacb2);
+  color: var(--colorStatusDangerForeground2, #6e0811);
 }
 
 .empty {


### PR DESCRIPTION
## Summary

The expiration chip paired the **Background2** status tint with the **Foreground1** status token. That combination only reaches ~3.5–3.9:1 and fails WCAG 2.1 AA (≥4.5:1 for normal text):

| chip | theme | before (Fg1/Bg2) | after (Fg2/Bg2) |
|---|---|---|---|
| expired | dark | **3.52** ❌ (reported) | **6.55** ✅ |
| expired | light | 3.79 ❌ | 6.55 ✅ |
| warning | dark | 3.92 ❌ | 5.61 ✅ |
| warning | light | 3.56 ❌ | 5.61 ✅ |

(Ratios computed against the real `@fluentui/react-theme` token values for both `webLightTheme` and `webDarkTheme`.)

## Fix

- Switch both `.expired` and `.warning` from the `*Foreground1` to the stronger `*Foreground2` status token, keeping the same `*Background2` tint. Stays on Fluent v9 status tokens, so light/dark palettes remain in sync — no hand-picked theme-specific hex.
- Update the CSS-var fallback hexes to the real Fluent **light-theme** values so the no-theme fallback path also clears AA.
- Applied to **both** `ExpirationCell.module.css` copies (Vertices + Edges) — they were byte-identical and must stay in sync (see finding posted on this issue from #654).

## Scope note

The original report only flagged the dark-theme expired chip, but auditing the warning chip (as the issue requested) showed `Foreground1/Background2` fails in **all four** theme×severity combinations. `Foreground2/Background2` fixes all of them in one symmetric change.

## Verification

- `bun run format && bun run lint && bun run typecheck` — clean.
- `bun run test` — 675 pass / 0 fail.
- `bun run build` — clean.
- Contrast ratios computed directly from the installed Fluent theme tokens (table above). No axe-core e2e harness exists in the repo (the original findings were from a manual live review), so verification is the computed proof plus the standard gate; Playwright smoke runs in CI.

Closes #656
