### PR TITLE
fix(cli): echo applied TTL/expiry on put/add success

### DIFF
--- a/admin/app/lib/client/usecase/cli/dispatcher.test.ts
+++ b/admin/app/lib/client/usecase/cli/dispatcher.test.ts
@@ -14,7 +14,12 @@ import { describe, expect, test } from "bun:test";
 import { InvalidArgumentError, NotFoundError } from "lantern-sdk/web";
 import { LanternApiError } from "~/lib/client/infrastructure/api/error";
 import type { LanternClient } from "~/lib/client/infrastructure/api/lantern-client";
-import { coerceValue, dispatch, ttlSecondsToExpiration } from "./dispatcher";
+import {
+  coerceValue,
+  dispatch,
+  ttlSecondsToExpiration,
+  writeEcho,
+} from "./dispatcher";
 import type { Command } from "~/lib/cli/types";
 
 // ----------------------------------------------------------------------------
@@ -313,6 +318,127 @@ describe("dispatch put / add edge carry expiration (#429)", () => {
     const call = fake.calls.find((c) => c.method === "addEdge");
     const input = call!.args[0] as { expiration?: Date };
     expect(input.expiration).toBeInstanceOf(Date);
+  });
+});
+
+describe("dispatch write echo surfaces the applied TTL/expiry (#653)", () => {
+  test("put vertex with a TTL echoes ttlSeconds + absolute expiresAt", async () => {
+    const fake = new FakeLanternClient();
+    fake.stub("putVertex", () => undefined);
+    const cmd: Command = {
+      verb: "put",
+      objective: "vertex",
+      key: "a",
+      value: "a",
+      ttlSeconds: 1,
+    };
+    const before = Date.now();
+    const out = (await dispatch({ client: asClient(fake), command: cmd })) as {
+      key: string;
+      ttlSeconds: number | null;
+      expiresAt: string | null;
+    };
+    const after = Date.now();
+    expect(out.key).toBe("a");
+    expect(out.ttlSeconds).toBe(1);
+    expect(out.expiresAt).not.toBeNull();
+    const ms = new Date(out.expiresAt!).getTime();
+    expect(ms).toBeGreaterThanOrEqual(before + 1_000);
+    expect(ms).toBeLessThanOrEqual(after + 1_000);
+  });
+
+  test("put vertex without a TTL echoes nulls (permanent, no decay)", async () => {
+    const fake = new FakeLanternClient();
+    fake.stub("putVertex", () => undefined);
+    const cmd: Command = {
+      verb: "put",
+      objective: "vertex",
+      key: "permkey",
+      value: "permval",
+      ttlSeconds: null,
+    };
+    const out = await dispatch({ client: asClient(fake), command: cmd });
+    expect(out).toEqual({ key: "permkey", ttlSeconds: null, expiresAt: null });
+  });
+
+  test("put edge echoes its identity + ttlSeconds + expiresAt", async () => {
+    const fake = new FakeLanternClient();
+    fake.stub("putEdge", () => undefined);
+    const cmd: Command = {
+      verb: "put",
+      objective: "edge",
+      tail: "a",
+      head: "b",
+      weight: 1.5,
+      ttlSeconds: null,
+    };
+    const out = await dispatch({ client: asClient(fake), command: cmd });
+    expect(out).toEqual({
+      tail: "a",
+      head: "b",
+      weight: 1.5,
+      ttlSeconds: null,
+      expiresAt: null,
+    });
+  });
+
+  test("add edge echoes its identity + ttlSeconds + expiresAt", async () => {
+    const fake = new FakeLanternClient();
+    fake.stub("addEdge", () => undefined);
+    const cmd: Command = {
+      verb: "add",
+      objective: "edge",
+      tail: "x",
+      head: "y",
+      weight: 0.25,
+      ttlSeconds: 30,
+    };
+    const before = Date.now();
+    const out = (await dispatch({ client: asClient(fake), command: cmd })) as {
+      tail: string;
+      head: string;
+      weight: number;
+      ttlSeconds: number | null;
+      expiresAt: string | null;
+    };
+    const after = Date.now();
+    expect(out.tail).toBe("x");
+    expect(out.head).toBe("y");
+    expect(out.weight).toBe(0.25);
+    expect(out.ttlSeconds).toBe(30);
+    const ms = new Date(out.expiresAt!).getTime();
+    expect(ms).toBeGreaterThanOrEqual(before + 30_000);
+    expect(ms).toBeLessThanOrEqual(after + 30_000);
+  });
+});
+
+describe("writeEcho (#653)", () => {
+  test("a positive TTL surfaces ttlSeconds + the absolute expiry it was given", () => {
+    expect(writeEcho({ key: "a" }, 1, "2026-06-16T12:34:57.000Z")).toEqual({
+      key: "a",
+      ttlSeconds: 1,
+      expiresAt: "2026-06-16T12:34:57.000Z",
+    });
+  });
+
+  test("an omitted TTL (null) maps undefined expiration → null (permanent)", () => {
+    expect(writeEcho({ key: "permkey" }, null, undefined)).toEqual({
+      key: "permkey",
+      ttlSeconds: null,
+      expiresAt: null,
+    });
+  });
+
+  test("carries arbitrary identity fields verbatim (edge tail/head/weight)", () => {
+    expect(
+      writeEcho({ tail: "a", head: "b", weight: 1.5 }, null, undefined),
+    ).toEqual({
+      tail: "a",
+      head: "b",
+      weight: 1.5,
+      ttlSeconds: null,
+      expiresAt: null,
+    });
   });
 });
 

--- a/admin/app/lib/client/usecase/cli/dispatcher.ts
+++ b/admin/app/lib/client/usecase/cli/dispatcher.ts
@@ -112,35 +112,47 @@ export async function dispatch(input: DispatchInput): Promise<unknown> {
       }
     case "put":
       if (command.objective === "vertex") {
+        // Compute the expiration ONCE so the echo reports exactly the
+        // instant sent to the server (a second `ttlSecondsToExpiration`
+        // call would drift by the elapsed `Date.now()` delta).
+        const expiration = ttlSecondsToExpiration(command.ttlSeconds);
         const vertex: Vertex = {
           key: command.key,
           ...coerceValue(command.value),
-          expiration: ttlSecondsToExpiration(command.ttlSeconds),
+          expiration,
         };
         await putVertex(client, command.key, { vertex }, { signal });
-        return { ok: true };
+        return writeEcho({ key: command.key }, command.ttlSeconds, expiration);
       }
-      await putEdge(
-        client,
-        command.tail,
-        command.head,
-        {
-          edge: {
-            tail: command.tail,
-            head: command.head,
-            weight: command.weight,
-            expiration: ttlSecondsToExpiration(command.ttlSeconds),
+      {
+        const expiration = ttlSecondsToExpiration(command.ttlSeconds);
+        await putEdge(
+          client,
+          command.tail,
+          command.head,
+          {
+            edge: {
+              tail: command.tail,
+              head: command.head,
+              weight: command.weight,
+              expiration,
+            },
           },
-        },
-        { signal },
-      );
-      return { ok: true };
+          { signal },
+        );
+        return writeEcho(
+          { tail: command.tail, head: command.head, weight: command.weight },
+          command.ttlSeconds,
+          expiration,
+        );
+      }
     case "delete":
       if (command.objective === "vertex") {
         return deleteVertex(client, command.key, { signal });
       }
       return deleteEdge(client, command.tail, command.head, { signal });
-    case "add":
+    case "add": {
+      const expiration = ttlSecondsToExpiration(command.ttlSeconds);
       await addEdge(
         client,
         command.tail,
@@ -150,12 +162,17 @@ export async function dispatch(input: DispatchInput): Promise<unknown> {
             tail: command.tail,
             head: command.head,
             weight: command.weight,
-            expiration: ttlSecondsToExpiration(command.ttlSeconds),
+            expiration,
           },
         },
         { signal },
       );
-      return { ok: true };
+      return writeEcho(
+        { tail: command.tail, head: command.head, weight: command.weight },
+        command.ttlSeconds,
+        expiration,
+      );
+    }
     case "scan":
       if (command.objective === "vertices") {
         return scanVertices(
@@ -254,4 +271,26 @@ export function ttlSecondsToExpiration(
 ): string | undefined {
   if (ttlSeconds === null) return undefined;
   return new Date(Date.now() + ttlSeconds * 1000).toISOString();
+}
+
+/**
+ * Build the success echo for a mutating write (#653).
+ *
+ * The dispatcher used to return a bare `{ ok: true }`, which hid the
+ * applied TTL: `put vertex a a 1` looked permanent in the scrollback
+ * yet silently decayed in one second, so a follow-up `get` returned
+ * nothing and read as data loss. Surfacing the applied TTL and the
+ * absolute expiry the server decays against makes the write
+ * self-explanatory. `ttlSeconds === null` (the verb omitted
+ * `ttl_seconds`) renders as `ttlSeconds: null, expiresAt: null` —
+ * i.e. permanent, no decay (#523).
+ *
+ * Exported for unit testing.
+ */
+export function writeEcho(
+  identity: Record<string, string | number>,
+  ttlSeconds: number | null,
+  expiration: string | undefined,
+): Record<string, unknown> {
+  return { ...identity, ttlSeconds, expiresAt: expiration ?? null };
 }

--- a/cli/cmd/repl.go
+++ b/cli/cmd/repl.go
@@ -71,7 +71,11 @@ so a bare illuminate keeps the top-k strongest neighbours (#560).
 EXAMPLE
   $ lantern repl
   > put vertex alice "Alice"
+  put vertex "alice" (no ttl)
   OK (1.4ms)
+  > put vertex temp "soon" 1
+  put vertex "temp" (ttl 1s, expires 2026-06-16T12:34:57Z)
+  OK (0.6ms)
   > get vertex alice
   "Alice"
   OK (0.8ms)

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	"github.com/anaregdesign/lantern/cli/parser"
 	client "github.com/anaregdesign/lantern/sdks/go"
@@ -109,6 +110,7 @@ func (c *CLIService) Run(ctx context.Context, str string) error {
 				fmt.Printf("Error: %s\n", err)
 				return ErrConnection
 			}
+			fmt.Println(formatWriteEcho(fmt.Sprintf("add edge %q -> %q (weight %g)", p.Tail, p.Head, p.Weight), p.TTL, time.Now()))
 			return nil
 		default:
 			return ErrInvalidObjective
@@ -130,6 +132,10 @@ func (c *CLIService) Run(ctx context.Context, str string) error {
 				fmt.Printf("Error: %s\n", err)
 				return ErrConnection
 			}
+			// Echo the applied TTL/expiry so a decaying write is never
+			// silent (#653) — the REPL's "OK (<elapsed>)" status alone
+			// hid that e.g. `put vertex a a 1` expires in one second.
+			fmt.Println(formatWriteEcho(fmt.Sprintf("put vertex %q", p.Key), p.TTL, time.Now()))
 			return nil
 		case "edge":
 			p, err := parser.PutEdgeParam(s)
@@ -141,6 +147,7 @@ func (c *CLIService) Run(ctx context.Context, str string) error {
 				fmt.Printf("Error: %s\n", err)
 				return ErrConnection
 			}
+			fmt.Println(formatWriteEcho(fmt.Sprintf("put edge %q -> %q (weight %g)", p.Tail, p.Head, p.Weight), p.TTL, time.Now()))
 			return nil
 		}
 
@@ -303,3 +310,17 @@ var (
 		"tfidf": client.WeightingTFIDF,
 	}
 )
+
+// formatWriteEcho builds the one-line success summary the REPL prints
+// after a mutating write so the applied TTL/expiry is never silent
+// (#653). The "OK (<elapsed>)" status line alone hid the TTL, so
+// `put vertex a a 1` looked permanent yet silently decayed in one
+// second. A zero/negative TTL is the permanent (no-decay) sentinel
+// (#523); a positive TTL echoes the absolute expiration the server
+// decays against (now + ttl), rendered in RFC3339.
+func formatWriteEcho(subject string, ttl time.Duration, now time.Time) string {
+	if ttl <= 0 {
+		return fmt.Sprintf("%s (no ttl)", subject)
+	}
+	return fmt.Sprintf("%s (ttl %s, expires %s)", subject, ttl, now.Add(ttl).Format(time.RFC3339))
+}

--- a/cli/service/service_test.go
+++ b/cli/service/service_test.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+// TestFormatWriteEcho pins the REPL success-echo formatting (#653): a
+// mutating write must surface its applied TTL and absolute expiry so a
+// decaying write is never silent. A fixed clock keeps the expiry
+// deterministic.
+func TestFormatWriteEcho(t *testing.T) {
+	now := time.Date(2026, 6, 16, 12, 34, 56, 0, time.UTC)
+
+	t.Run("PositiveTTLEchoesDurationAndAbsoluteExpiry", func(t *testing.T) {
+		got := formatWriteEcho(`put vertex "a"`, 1*time.Second, now)
+		want := `put vertex "a" (ttl 1s, expires 2026-06-16T12:34:57Z)`
+		if got != want {
+			t.Errorf("formatWriteEcho() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("ZeroTTLIsPermanentSentinel", func(t *testing.T) {
+		got := formatWriteEcho(`put vertex "permkey"`, 0, now)
+		want := `put vertex "permkey" (no ttl)`
+		if got != want {
+			t.Errorf("formatWriteEcho() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("NegativeTTLIsAlsoPermanent", func(t *testing.T) {
+		got := formatWriteEcho("add edge", -5*time.Second, now)
+		want := "add edge (no ttl)"
+		if got != want {
+			t.Errorf("formatWriteEcho() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("MultiUnitTTLRendersViaDurationString", func(t *testing.T) {
+		got := formatWriteEcho(`put edge "a" -> "b" (weight 1.5)`, 90*time.Second, now)
+		want := `put edge "a" -> "b" (weight 1.5) (ttl 1m30s, expires 2026-06-16T12:36:26Z)`
+		if got != want {
+			t.Errorf("formatWriteEcho() = %q, want %q", got, want)
+		}
+	})
+}


### PR DESCRIPTION
## What

`put vertex <k> <v> <n>` parses `<n>` as **TTL seconds**, but the success
echo never said so:

- **admin CLI** returned a bare `{ ok: true }` → rendered as `OK\n{ "ok": true }`.
- **`lantern repl`** printed only its `OK (<elapsed>)` status line.

So `put vertex a a 1` looked permanent in the scrollback yet silently
decayed in one second; a follow-up `get` returned nothing and read as
data loss.

## How

Both surfaces now report the applied TTL **and** the absolute expiry the
server decays against, so a decaying write is never silent:

- **admin CLI** (`dispatcher.ts`): `put`/`add` return a structured
  `{ <identity>, ttlSeconds, expiresAt }` echo instead of `{ ok: true }`.
  The expiration is computed **once** and reused for both the RPC and the
  echo, so the reported instant matches exactly what was sent. A verb that
  omits `ttl_seconds` echoes `ttlSeconds: null, expiresAt: null` (permanent,
  no decay — #523). The canvas projection is unaffected: `commandResultToGraphView`/
  `…Merge` ignore the `put`/`add` result shape.
- **Go REPL** (`cli/service/service.go`): each successful `put`/`add` prints a
  one-line `<subject> (ttl <d>, expires <rfc3339>)` summary, or
  `<subject> (no ttl)` for a zero/negative (permanent) TTL. The REPL help
  `EXAMPLE` is refreshed to show the new echo.

## Tests

- `dispatcher.test.ts`: 4 dispatch-level cases (put vertex w/ TTL, put vertex
  permanent, put edge permanent, add edge w/ TTL) asserting the echo shape and
  the `expiresAt` instant, plus 3 pure `writeEcho` helper cases.
- `cli/service/service_test.go`: `TestFormatWriteEcho` pins the REPL line for
  positive / zero / negative / multi-unit TTLs against a fixed clock.

Admin inner gate (format, lint, typecheck, **682 tests**, build) is green
locally; the Go gate runs in CI.

Closes #653
