### PR TITLE
fix(admin): keep Browse table actions reachable on mobile

### DIFF
--- a/admin/app/components/browse-edges/BrowseEdgesPage/BrowseEdgesPage.module.css
+++ b/admin/app/components/browse-edges/BrowseEdgesPage/BrowseEdgesPage.module.css
@@ -83,15 +83,49 @@
   position: relative;
   border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
   border-radius: var(--borderRadiusMedium, 6px);
-  /* Scroll horizontally on narrow screens instead of clipping the right-hand
-     Actions column. */
+  /* On narrow (phone) widths the fixed-column table is wider than the
+     viewport, so scroll it horizontally instead of clipping the right-hand
+     Actions column (#657). The layered background paints a soft shadow at
+     whichever horizontal edge still hides content — a visible "more columns
+     this way" affordance that fades out at the start/end. The `local` cover
+     gradients ride the scrolled content; the `scroll` shadows stay pinned to
+     the viewport edges. Rows are transparent at rest (TTL state lives on the
+     chip, not the row), so the shadow shows through cleanly. */
   overflow-x: auto;
+  background:
+    linear-gradient(
+        to right,
+        var(--colorNeutralBackground1, #fff) 30%,
+        rgba(255, 255, 255, 0)
+      )
+      0 0 / 32px 100% no-repeat,
+    linear-gradient(
+        to left,
+        var(--colorNeutralBackground1, #fff) 30%,
+        rgba(255, 255, 255, 0)
+      )
+      100% 0 / 32px 100% no-repeat,
+    radial-gradient(
+        farthest-side at 0 50%,
+        rgba(0, 0, 0, 0.18),
+        rgba(0, 0, 0, 0)
+      )
+      0 0 / 14px 100% no-repeat,
+    radial-gradient(
+        farthest-side at 100% 50%,
+        rgba(0, 0, 0, 0.18),
+        rgba(0, 0, 0, 0)
+      )
+      100% 0 / 14px 100% no-repeat;
+  background-attachment: local, local, scroll, scroll;
 }
 
 .table {
   /* Keep the percentage columns from collapsing/overlapping on phones; the
-     wrapper scrolls horizontally below this width. */
-  min-width: 480px;
+     wrapper scrolls horizontally below this width. Sized so the Edit +
+     Illuminate action pair and the Expires header render at full width
+     without clipping (#657). */
+  min-width: 680px;
 }
 
 .colKey {

--- a/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.module.css
+++ b/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.module.css
@@ -83,15 +83,49 @@
   position: relative;
   border: 1px solid var(--colorNeutralStroke2, #e0e0e0);
   border-radius: var(--borderRadiusMedium, 6px);
-  /* Scroll horizontally on narrow screens instead of clipping the right-hand
-     Actions column. */
+  /* On narrow (phone) widths the fixed-column table is wider than the
+     viewport, so scroll it horizontally instead of clipping the right-hand
+     Actions column (#657). The layered background paints a soft shadow at
+     whichever horizontal edge still hides content — a visible "more columns
+     this way" affordance that fades out at the start/end. The `local` cover
+     gradients ride the scrolled content; the `scroll` shadows stay pinned to
+     the viewport edges. Rows are transparent at rest (TTL state lives on the
+     chip, not the row), so the shadow shows through cleanly. */
   overflow-x: auto;
+  background:
+    linear-gradient(
+        to right,
+        var(--colorNeutralBackground1, #fff) 30%,
+        rgba(255, 255, 255, 0)
+      )
+      0 0 / 32px 100% no-repeat,
+    linear-gradient(
+        to left,
+        var(--colorNeutralBackground1, #fff) 30%,
+        rgba(255, 255, 255, 0)
+      )
+      100% 0 / 32px 100% no-repeat,
+    radial-gradient(
+        farthest-side at 0 50%,
+        rgba(0, 0, 0, 0.18),
+        rgba(0, 0, 0, 0)
+      )
+      0 0 / 14px 100% no-repeat,
+    radial-gradient(
+        farthest-side at 100% 50%,
+        rgba(0, 0, 0, 0.18),
+        rgba(0, 0, 0, 0)
+      )
+      100% 0 / 14px 100% no-repeat;
+  background-attachment: local, local, scroll, scroll;
 }
 
 .table {
   /* Keep the percentage columns from collapsing/overlapping on phones; the
-     wrapper scrolls horizontally below this width. */
-  min-width: 480px;
+     wrapper scrolls horizontally below this width. Sized so the single
+     Illuminate action and the Expires header render at full width without
+     clipping (#657). */
+  min-width: 520px;
 }
 
 .colKey {

--- a/admin/tests/e2e/browse.spec.ts
+++ b/admin/tests/e2e/browse.spec.ts
@@ -123,3 +123,58 @@ test.describe("/edges", () => {
     );
   });
 });
+
+// #657: on a phone-class viewport the fixed-column Browse tables are wider
+// than the screen. They must scroll horizontally (advertised by the wrapper's
+// scroll-shadow) so the right-hand Actions column stays reachable instead of
+// being clipped off-screen with no affordance.
+test.describe("mobile (390px) — Browse row actions stay reachable (#657)", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("/vertices Illuminate action is reachable via horizontal scroll", async ({
+    page,
+  }) => {
+    await page.goto("/vertices");
+    await page.getByTestId("vertex-prefix-input").fill("e2e:vertex:");
+
+    const table = page.getByTestId("vertices-table");
+    await expect(table).toBeVisible();
+
+    // The table is wider than its scroll container, so there IS content
+    // hidden to the right that the wrapper scrolls to reveal (and the
+    // shadow advertises) — rather than the row being clipped away.
+    const overflows = await table.evaluate((el) => {
+      const wrap = el.parentElement;
+      return wrap ? wrap.scrollWidth > wrap.clientWidth + 1 : false;
+    });
+    expect(overflows).toBe(true);
+
+    // Reachable: clicking auto-scrolls the off-screen action into view and
+    // navigates, proving it is not clipped out of reach.
+    const illuminate = table
+      .getByRole("button", { name: /Illuminate from e2e:vertex:a/i })
+      .first();
+    await illuminate.click();
+    await expect(page).toHaveURL(/\/illuminate\?seed=e2e%3Avertex%3Aa/);
+  });
+
+  test("/edges Edit action is reachable via horizontal scroll", async ({
+    page,
+  }) => {
+    await page.goto("/edges");
+    await page.getByTestId("edge-tail-prefix-input").fill("e2e:vertex:");
+
+    const table = page.getByTestId("edges-table");
+    await expect(table).toBeVisible();
+
+    const overflows = await table.evaluate((el) => {
+      const wrap = el.parentElement;
+      return wrap ? wrap.scrollWidth > wrap.clientWidth + 1 : false;
+    });
+    expect(overflows).toBe(true);
+
+    const edit = table.getByTestId("edge-row-edit").first();
+    await edit.click();
+    await expect(page).toHaveURL(/\/edges\/e2e%3Avertex%3Aa\//);
+  });
+});

--- a/admin/tests/e2e/browse.spec.ts
+++ b/admin/tests/e2e/browse.spec.ts
@@ -173,7 +173,12 @@ test.describe("mobile (390px) — Browse row actions stay reachable (#657)", () 
     });
     expect(overflows).toBe(true);
 
-    const edit = table.getByTestId("edge-row-edit").first();
+    // Click a specific tail's Edit button (auto-waits for the filtered row),
+    // not `.first()` of the testid set — the latter would race the debounced
+    // filter and hit the alphabetically-first `e2e:other:z` row instead.
+    const edit = table
+      .getByRole("button", { name: /Edit edge e2e:vertex:a/i })
+      .first();
     await edit.click();
     await expect(page).toHaveURL(/\/edges\/e2e%3Avertex%3Aa\//);
   });


### PR DESCRIPTION
## Summary

Closes #657.

On phone-class widths (~375–414px) the **Vertices** and **Edges** browse tables
were wider than the viewport, so the right-hand **Actions** column was clipped
off-screen — the Illuminate / Edit buttons were unreachable and the **Expires**
header truncated. #587 had added a partial `overflow-x: auto` (min-width 480px),
but 480px is too tight for the action cells (especially Edges' Edit+Illuminate
pair) and there was **no scroll affordance**, so users couldn't tell content was
hidden.

This adopts the reviewer-endorsed option from the issue — *"horizontally
scrollable container with a visible affordance"*:

- **Scroll-shadow affordance** on `.tableWrapper` (Lea Verou layered-background
  technique): `local` cover gradients ride the scrolled content while `scroll`
  radial shadows pin to the viewport edges, fading in only while content is
  still hidden that direction. Rows are transparent at rest (TTL state lives on
  the `ExpirationCell` chip, not the row), so the shadow shows through cleanly.
- **Adequate min-widths** so every column renders without clipping:
  Vertices `480px → 520px` (single Illuminate action + Expires header),
  Edges `480px → 680px` (Edit + Illuminate pair + Expires header).

The P2 secondary observation (header crowding / nav collapse) is intentionally
left to the #655 umbrella, as the issue notes.

## Verification

- Admin inner gate green: `format` ✓, `lint` ✓, `typecheck` ✓, `test`
  (682 pass / 0 fail) ✓, `build` ✓.
- **Two new mobile-viewport (390×844) Playwright e2e tests** in
  `browse.spec.ts` (run by CI): each asserts the table overflows its scroll
  container *and* that the off-screen row action (Vertices **Illuminate**,
  Edges **Edit**) still clicks through and navigates — proving it is reachable,
  not clipped.

## Scope

Admin-only (CSS + e2e). No Go touched → ships in the next `admin/` release.
