### PR TITLE
feat(admin): unify the row-level Edit affordance across Browse tables

### DIFF
--- a/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.module.css
+++ b/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.module.css
@@ -122,10 +122,11 @@
 
 .table {
   /* Keep the percentage columns from collapsing/overlapping on phones; the
-     wrapper scrolls horizontally below this width. Sized so the single
-     Illuminate action and the Expires header render at full width without
-     clipping (#657). */
-  min-width: 520px;
+     wrapper scrolls horizontally below this width. Sized so the Edit +
+     Illuminate action pair and the Expires header render at full width
+     without clipping (#657, #652). Matches the Edges table floor now that
+     both Browse surfaces carry the same two-button Actions cell. */
+  min-width: 680px;
 }
 
 .colKey {
@@ -137,7 +138,7 @@
 }
 
 .colActions {
-  width: 14%;
+  width: 16%;
   text-align: right;
 }
 

--- a/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.tsx
+++ b/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.tsx
@@ -17,6 +17,7 @@ import {
 } from "@fluentui/react-components";
 import {
   ArrowClockwise20Regular,
+  Edit20Regular,
   LightbulbFilament20Regular,
 } from "@fluentui/react-icons";
 import { Link, useNavigate } from "react-router";
@@ -144,6 +145,20 @@ export function BrowseVerticesPage() {
                   <ExpirationCell expiration={vertex.expiration} />
                 </TableCell>
                 <TableCell className={styles.colActions}>
+                  <Button
+                    appearance="subtle"
+                    size="small"
+                    icon={<Edit20Regular />}
+                    onClick={() =>
+                      navigate(
+                        `/vertices/${encodeURIComponent(vertex.key ?? "")}?edit=1`,
+                      )
+                    }
+                    aria-label={`Edit vertex ${vertex.key ?? "vertex"}`}
+                    data-testid="vertex-row-edit"
+                  >
+                    Edit
+                  </Button>
                   <Button
                     appearance="subtle"
                     size="small"

--- a/admin/app/components/edit-vertex/VertexDetailPage/VertexDetailPage.tsx
+++ b/admin/app/components/edit-vertex/VertexDetailPage/VertexDetailPage.tsx
@@ -12,7 +12,7 @@ import {
   Save20Regular,
 } from "@fluentui/react-icons";
 import { Link, useNavigate } from "react-router";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useEditVertex } from "~/lib/client/usecase/edit-vertex/use-edit-vertex";
 import { kindOfVertex } from "~/lib/client/usecase/edit-vertex/value-codec";
 import type { Vertex } from "~/lib/client/infrastructure/api/get-vertex";
@@ -27,12 +27,21 @@ import styles from "./VertexDetailPage.module.css";
 
 export interface VertexDetailPageProps {
   vertexKey: string;
+  /**
+   * When true (the Browse row "Edit" affordance navigates with `?edit=1`),
+   * open the editor as soon as the vertex resolves instead of pausing on the
+   * read-only confirm step — giving Vertices the same single-click edit reach
+   * as the Edges Browse table (#652).
+   */
+  initialEdit?: boolean;
 }
 
 /**
  * Read/Edit/Delete page for a single vertex. Begins in view mode so the
  * user can confirm they have the right row before mutating it, then
  * flips to an inline editor sharing reducer state with the API handlers.
+ * Arriving via the Browse row Edit button (`initialEdit`) skips straight
+ * to the editor so the edit path costs no more clicks than Edges'.
  */
 export function VertexDetailPage(props: VertexDetailPageProps) {
   const navigate = useNavigate();
@@ -44,6 +53,25 @@ export function VertexDetailPage(props: VertexDetailPageProps) {
       navigate("/vertices");
     }
   }, [editor.deleted, navigate]);
+
+  // Drop straight into edit mode when reached via a row "Edit" affordance.
+  // Fires once per loaded vertex (after the row resolves ready/not-found); a
+  // later Cancel returns to the read view without re-triggering. The ref
+  // resets when the key changes so each vertex gets its own single shot.
+  const autoEditAppliedRef = useRef(false);
+  useEffect(() => {
+    autoEditAppliedRef.current = false;
+  }, [props.vertexKey]);
+  useEffect(() => {
+    if (!props.initialEdit || autoEditAppliedRef.current) return;
+    if (
+      editor.state.loadStatus === "ready" ||
+      editor.state.loadStatus === "not-found"
+    ) {
+      autoEditAppliedRef.current = true;
+      editor.beginEdit();
+    }
+  }, [props.initialEdit, editor.state.loadStatus, editor.beginEdit]);
 
   return (
     <div className={styles.root}>

--- a/admin/app/routes/vertices.$key.tsx
+++ b/admin/app/routes/vertices.$key.tsx
@@ -1,5 +1,5 @@
 import type { Route } from "./+types/vertices.$key";
-import { Navigate, useParams } from "react-router";
+import { Navigate, useParams, useSearchParams } from "react-router";
 import { VertexDetailPage } from "~/components/edit-vertex/VertexDetailPage/VertexDetailPage";
 
 export function meta({ params }: Route.MetaArgs) {
@@ -13,11 +13,17 @@ export function meta({ params }: Route.MetaArgs) {
  */
 export default function VertexDetailRoute() {
   const { key } = useParams<{ key: string }>();
+  const [searchParams] = useSearchParams();
   const decoded = decodeKey(key);
   if (!decoded) {
     return <Navigate to="/vertices" replace />;
   }
-  return <VertexDetailPage vertexKey={decoded} />;
+  return (
+    <VertexDetailPage
+      vertexKey={decoded}
+      initialEdit={searchParams.get("edit") === "1"}
+    />
+  );
 }
 
 function decodeKey(raw: string | undefined): string {

--- a/admin/tests/e2e/browse.spec.ts
+++ b/admin/tests/e2e/browse.spec.ts
@@ -86,6 +86,29 @@ test.describe("/vertices", () => {
     await illuminate.click();
     await expect(page).toHaveURL(/\/illuminate\?seed=e2e%3Avertex%3Aa/);
   });
+
+  test("Edit action opens the vertex editor directly (parity with Edges, #652)", async ({
+    page,
+  }) => {
+    await page.goto("/vertices");
+    await page.getByTestId("vertex-prefix-input").fill("e2e:vertex:");
+
+    const table = page.getByTestId("vertices-table");
+    // A specifically-named Edit button auto-waits for the filtered row; never
+    // `.first()` of the testid set, which would race the debounced prefix
+    // filter and hit the alphabetically-first unfiltered row.
+    const edit = table
+      .getByRole("button", { name: /Edit vertex e2e:vertex:a/i })
+      .first();
+    await expect(edit).toBeVisible();
+    await edit.click();
+
+    // One click lands directly on the editor — no intermediate read-only hop,
+    // matching the Edges row Edit affordance.
+    await expect(page).toHaveURL(/\/vertices\/e2e%3Avertex%3Aa\?edit=1/);
+    await expect(page.getByTestId("vertex-detail-edit")).toBeVisible();
+    await expect(page.getByTestId("vertex-detail-read")).toHaveCount(0);
+  });
 });
 
 test.describe("/edges", () => {


### PR DESCRIPTION
## What

Unify the row-level **Edit** affordance across the Vertices and Edges Browse tables.

Edges reach an editable edge in one click (row **Edit** → edge detail page, which is edit-ready). Vertices had **no** row Edit — the only path was the Key link into a read-only detail view, then a second **Edit value** click. The two surfaces spoke a different Actions vocabulary and the vertex edit path cost an extra hop.

## Changes

- **Vertices Actions cell** now carries the same **Edit + Illuminate** pair as Edges (`Edit20Regular`, subtle/small, `aria-label="Edit vertex <key>"`, `data-testid="vertex-row-edit"`).
- The Edit button navigates to `/vertices/<key>?edit=1`. `VertexDetailPage` reads the flag (via the route's `useSearchParams`) and opens the editor as soon as the vertex resolves — a **once-per-key** effect, so a later **Cancel** falls back to the read view without re-triggering. The Key link still opens the read-only confirm view for inspection.
- **Vertices table widened to the Edges floor** (`min-width` 520px → 680px, `colActions` 14% → 16%) so the two-button cell renders without re-clipping on phone widths — preserving the #657 scroll-shadow behaviour.
- **e2e**: a new `/vertices` test asserts the row Edit lands directly on the editor in one click (`vertex-detail-edit` visible, `vertex-detail-read` absent), giving parity with the Edges row.

## Validation

- `bun run format && bun run lint && bun run typecheck && bun run test && bun run build` all green locally.
- Playwright e2e runs in CI (the new parity test + existing mobile-reachability coverage).

Closes #652
