### PR TITLE
refactor(admin): collapse Home cards to Data / CLI / Ops

### DIFF
--- a/admin/app/components/landing/LandingPage/LandingPage.tsx
+++ b/admin/app/components/landing/LandingPage/LandingPage.tsx
@@ -3,7 +3,6 @@ import {
   ArrowRight20Regular,
   Code24Regular,
   DatabaseSearch24Regular,
-  LinkMultiple24Regular,
   PulseSquare24Regular,
 } from "@fluentui/react-icons";
 import type { ReactElement } from "react";
@@ -17,30 +16,28 @@ interface Feature {
   copy: string;
 }
 
+// The Home tiles mirror the three working surfaces in the AppShell nav
+// (#655): Data / CLI / Ops. Vertices, Edges, and content search were
+// folded into the single Data surface (#650); the standalone Illuminate
+// explorer moved into the CLI workspace (#651).
 const FEATURES: readonly Feature[] = [
   {
     to: "/vertices",
     icon: <DatabaseSearch24Regular />,
-    title: "Vertices",
-    copy: "Scan vertices by key prefix and inspect their typed values and TTLs.",
+    title: "Data",
+    copy: "Browse vertices and edges by key prefix, search vertices by content, and inspect typed values, TTLs, and relationship weights.",
   },
   {
-    to: "/edges",
-    icon: <LinkMultiple24Regular />,
-    title: "Edges",
-    copy: "Filter edges by tail and head prefix to follow relationships and weights.",
+    to: "/cli",
+    icon: <Code24Regular />,
+    title: "CLI",
+    copy: "Type-and-run REPL — same grammar as `lantern repl` (#411). Walk the graph on the canvas and do quick CRUD without leaving the SPA.",
   },
   {
     to: "/ops",
     icon: <PulseSquare24Regular />,
     title: "Ops",
     copy: "Inspect server status and replication health. Triage live before paging.",
-  },
-  {
-    to: "/cli",
-    icon: <Code24Regular />,
-    title: "CLI",
-    copy: "Type-and-run REPL — same grammar as `lantern repl` (#411). Useful for quick CRUD without leaving the SPA.",
   },
 ];
 

--- a/admin/app/components/shared/AppShell/AppShell.tsx
+++ b/admin/app/components/shared/AppShell/AppShell.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { NavLink, useLocation } from "react-router";
+import { Link, useLocation } from "react-router";
 import { ConnectionSwitcher } from "~/components/shared/ConnectionSwitcher/ConnectionSwitcher";
 import styles from "./AppShell.module.css";
 
@@ -11,10 +11,11 @@ interface NavEntry {
   to: string;
   label: string;
   /**
-   * Optional extra active-state predicate. NavLink only lights up for
-   * paths under `to`; an entry that fronts several sibling routes (e.g.
-   * the Data surface spanning /vertices and /edges) uses this to stay
-   * active across all of them.
+   * Optional extra active-state predicate. By default an entry is active
+   * only for paths under its own `to`; an entry that fronts several
+   * sibling routes (e.g. the Data surface spanning /vertices and /edges)
+   * uses this to stay active — and announce `aria-current` — across all
+   * of them. See {@link isEntryActive}.
    */
   match?: (pathname: string) => boolean;
 }
@@ -38,6 +39,25 @@ const NAV: readonly NavEntry[] = [
   { to: "/ops", label: "Ops" },
 ];
 
+/**
+ * Active-state for a nav entry. Mirrors NavLink's default matching
+ * (exact for "/", prefix-with-boundary otherwise) but also honours the
+ * entry's `match` predicate. Computing this ourselves — rather than
+ * leaning on NavLink — lets the Data surface set `aria-current` on every
+ * /vertices AND /edges path: NavLink derives `aria-current` solely from
+ * its own `to`, so an /edges visit would render styled-active yet
+ * announce no current page to assistive tech (#655).
+ */
+function isEntryActive(entry: NavEntry, pathname: string): boolean {
+  if (entry.match?.(pathname)) {
+    return true;
+  }
+  if (entry.to === "/") {
+    return pathname === "/";
+  }
+  return pathname === entry.to || pathname.startsWith(`${entry.to}/`);
+}
+
 export function AppShell({ children }: AppShellProps) {
   // The /cli route is a full-bleed shell terminal + canvas workspace, so
   // it opts out of the centered max-width column the other routes use and
@@ -51,20 +71,23 @@ export function AppShell({ children }: AppShellProps) {
       <header className={styles.header}>
         <span className={styles.brand}>Lantern Admin</span>
         <nav className={styles.nav} aria-label="Primary">
-          {NAV.map((entry) => (
-            <NavLink
-              key={entry.to}
-              to={entry.to}
-              end={entry.to === "/"}
-              className={({ isActive }) =>
-                isActive || (entry.match?.(pathname) ?? false)
-                  ? `${styles.navLink} ${styles.navLinkActive}`
-                  : styles.navLink
-              }
-            >
-              {entry.label}
-            </NavLink>
-          ))}
+          {NAV.map((entry) => {
+            const active = isEntryActive(entry, pathname);
+            return (
+              <Link
+                key={entry.to}
+                to={entry.to}
+                aria-current={active ? "page" : undefined}
+                className={
+                  active
+                    ? `${styles.navLink} ${styles.navLinkActive}`
+                    : styles.navLink
+                }
+              >
+                {entry.label}
+              </Link>
+            );
+          })}
         </nav>
         <div className={styles.connection}>
           <ConnectionSwitcher />

--- a/admin/tests/e2e/landing.spec.ts
+++ b/admin/tests/e2e/landing.spec.ts
@@ -7,14 +7,14 @@ test("landing page renders with navigation and gateway connection", async ({
   await expect(
     page.getByRole("heading", { level: 1, name: "Lantern Admin" }),
   ).toBeVisible();
-  await expect(
-    page.getByRole("link", { name: /Open Vertices/i }),
-  ).toBeVisible();
-  await expect(page.getByRole("link", { name: /Open Edges/i })).toBeVisible();
-  await expect(page.getByRole("link", { name: /Open Ops/i })).toBeVisible();
-  // #439 — landing tile + AppShell nav now expose /cli alongside the
-  // other top-level sections.
+  // The Home tiles mirror the three nav surfaces (#655): Data / CLI / Ops.
+  // Vertices + Edges collapsed into the single Data tile (#650); the
+  // Illuminate explorer folded into CLI (#651).
+  await expect(page.getByRole("link", { name: /Open Data/i })).toBeVisible();
+  // #439 — landing tile + AppShell nav expose /cli alongside the other
+  // top-level sections.
   await expect(page.getByRole("link", { name: /Open CLI/i })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Open Ops/i })).toBeVisible();
   await expect(page.getByText("http://localhost:6380")).toBeVisible();
 });
 


### PR DESCRIPTION
## What

Closes #655 — the final issue of the admin UX-review sweep (#650–#657). With the nav merges already landed (#650 folded Vertices/Edges/Search into **Data**; #651 moved Illuminate into **CLI**), this brings the **Home landing tiles** in line and tidies one a11y loose end.

### Home landing cards → Data / CLI / Ops
- Fold the separate **Vertices** and **Edges** tiles into a single **Data** tile (`/vertices`, `DatabaseSearch24Regular`), copy now covering vertices, edges, and content search.
- Reorder the tiles **Data / CLI / Ops** to mirror the AppShell nav.
- CLI copy now notes it also hosts the canvas graph walk absorbed from the retired Illuminate surface (#651).
- Drop the now-unused `LinkMultiple24Regular` import.

### a11y fix — Data nav `aria-current`
The Data tab fronts two routes (`/vertices` **and** `/edges`) via a custom `match` predicate. It previously rendered through React Router's `NavLink`, which derives `aria-current` **solely from its own `to`** — so on `/edges` the tab was styled active but announced *no current page* to assistive tech.

Fix: compute active state ourselves in a small `isEntryActive(entry, pathname)` helper (exact match for `/`, prefix-with-boundary otherwise, **plus** the entry's `match`), and render a plain `<Link>` that sets both the active class and `aria-current="page"` from the same value. No behavior loss — the old code only consumed `isActive`.

## Why
The nav already showed **Home / Data / CLI / Ops**; the Home tiles still advertised four surfaces (Vertices, Edges, Ops, CLI) in the old order, contradicting the nav. This is the last sub-task on the #655 umbrella.

## Test
- `admin/tests/e2e/landing.spec.ts`: the `Open Vertices` + `Open Edges` assertions become a single `Open Data`; `Open CLI` / `Open Ops` / gateway text retained.
- Inner gate green: `bun run format && lint && typecheck && test && build` — **615 tests pass / 0 fail**, production build OK.
- Full Playwright e2e runs in the Admin CI workflow (Go is required for the gateway, not available locally).

## Scope
Presentation-only consolidation + an a11y component swap; no RPC/data-layer changes.
