### PR TITLE
chore: pin core v0.7.1 + sdks/go v0.15.1 in root + mcp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.4.0
-	github.com/anaregdesign/lantern/core v0.7.0
+	github.com/anaregdesign/lantern/core v0.7.1
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.6.0
-	github.com/anaregdesign/lantern/sdks/go v0.15.0
+	github.com/anaregdesign/lantern/sdks/go v0.15.1
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/anaregdesign/lantern/pb v0.6.0
-	github.com/anaregdesign/lantern/sdks/go v0.15.0
+	github.com/anaregdesign/lantern/sdks/go v0.15.1
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	google.golang.org/protobuf v1.36.11
 )


### PR DESCRIPTION
## What

Bump the intra-repo module pins ahead of the `v0.15.1` / `mcp/v0.8.1` release tags:

- root `go.mod`: `core` v0.7.0 → **v0.7.1**, `sdks/go` v0.15.0 → **v0.15.1**
- `mcp/go.mod`: `sdks/go` v0.15.0 → **v0.15.1**

## Why

`core/v0.7.1` and `sdks/go/v0.15.1` were just cut to ship the `golang.org/x/net` +
`golang.org/x/text` security bump from #635 to standalone consumers. This pins root and
mcp to those freshly-released versions before their own tags (`v0.15.1`, `mcp/v0.8.1`)
are cut — mirroring prior release pins (#642, #643).

All three modules carry `replace => ./…` directives for these deps, so this is a pure
metadata edit with no `go.sum` churn.

No issue: routine release mechanics (consistent with prior standalone `chore:` pin PRs).
