### PR TITLE
feat: install lantern and lantern-cli via Homebrew cask tap

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -162,7 +162,7 @@ jobs:
           retention-days: 30
 
   binaries:
-    name: Build CLI binaries
+    name: Build CLI + server binaries
     needs: verify
     runs-on: ubuntu-latest
     permissions:
@@ -183,11 +183,24 @@ jobs:
           distribution: goreleaser
           version: '~> v2'
           args: release --clean
-      - name: Upload CLI artifacts
+        env:
+          # GoReleaser uses this for GitHub API calls; the GitHub Release itself
+          # is created by the `release` job below (release.disable: true keeps
+          # GoReleaser from touching it).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Cross-repo token for pushing the generated casks to
+          # anaregdesign/homebrew-tap. Always exported (empty when the secret is
+          # absent) so the `skip_upload` template in .goreleaser.yaml can gate
+          # publishing without erroring on an undefined env var. Add a PAT/App
+          # token with contents:write on the tap repo as this secret to enable
+          # cask publishing.
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+      - name: Upload binary artifacts
         uses: actions/upload-artifact@v7
         with:
           name: cli-binaries
           path: |
+            dist/lantern_*.tar.gz
             dist/lantern-cli_*.tar.gz
             dist/lantern-cli_*.zip
             dist/checksums.txt
@@ -249,13 +262,24 @@ jobs:
             echo "docker pull ${IMAGE}:${TAG#v}"
             echo '```'
             echo
-            echo "## CLI binaries"
+            echo "## Binaries"
             echo
-            echo "Pre-built \`lantern-cli\` archives for macOS / Linux / Windows on x86_64 and arm64"
-            echo "are attached to this release. Verify with \`checksums.txt\`."
+            echo "Pre-built \`lantern\` (server) and \`lantern-cli\` archives are attached to this"
+            echo "release. The server covers macOS / Linux and the CLI also covers Windows, on"
+            echo "x86_64 and arm64. Verify with \`checksums.txt\`."
+            echo
+            echo "### Homebrew (macOS)"
             echo
             echo '```sh'
-            echo "# macOS arm64 example"
+            echo "brew tap anaregdesign/tap"
+            echo "brew install --cask lantern        # server"
+            echo "brew install --cask lantern-cli    # client"
+            echo '```'
+            echo
+            echo "### Direct download"
+            echo
+            echo '```sh'
+            echo "# macOS arm64 CLI example"
             echo "curl -L -o lantern-cli.tar.gz https://github.com/${REPO}/releases/download/${TAG}/lantern-cli_${TAG#v}_Darwin_arm64.tar.gz"
             echo "tar -xzf lantern-cli.tar.gz && ./lantern-cli version"
             echo '```'
@@ -276,7 +300,7 @@ jobs:
           } > "$notes_file"
 
           # Collect the artifacts to attach to the release.
-          assets=( dist/lantern-cli_*.tar.gz dist/lantern-cli_*.zip dist/checksums.txt )
+          assets=( dist/lantern_*.tar.gz dist/lantern-cli_*.tar.gz dist/lantern-cli_*.zip dist/checksums.txt )
 
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release edit "$TAG" --notes-file "$notes_file" --verify-tag

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,13 +1,14 @@
-# GoReleaser config for the Lantern CLI.
+# GoReleaser config for the Lantern server + CLI binaries and their Homebrew casks.
 #
-# Produces cross-platform `lantern-cli` archives + checksums in ./dist for the
-# release workflow to attach to the GitHub Release. The GitHub Release itself
-# is owned by .github/workflows/docker-publish.yml so the container image and
-# CLI binaries land on a single release with consistent notes.
+# Produces cross-platform `lantern` (server) and `lantern-cli` archives + checksums
+# in ./dist for the release workflow to attach to the GitHub Release, and generates
+# + pushes Homebrew casks to anaregdesign/homebrew-tap. The GitHub Release itself is
+# owned by .github/workflows/docker-publish.yml so the container image and binaries
+# land on a single release with consistent notes.
 #
-# Run locally with:
-#   go tool github.com/goreleaser/goreleaser/v2 release --snapshot --clean
-# (or `goreleaser release --snapshot --clean` if you have the CLI installed).
+# Run locally with (a dummy tap token lets the cask templates render under snapshot):
+#   HOMEBREW_TAP_GITHUB_TOKEN=dummy \
+#     go run github.com/goreleaser/goreleaser/v2@latest release --snapshot --clean
 
 version: 2
 project_name: lantern
@@ -36,6 +37,26 @@ builds:
       - amd64
       - arm64
 
+  # Server daemon. Built from ./server/cmd in workspace mode, exactly like the
+  # Dockerfile (static, CGO-free). No Windows target — the daemon ships to
+  # linux/macOS and the cask is macOS-only. Version is surfaced at runtime via
+  # LANTERN_VERSION / debug.BuildInfo, so there is no -X ldflag to inject here.
+  - id: lantern
+    main: ./server/cmd
+    binary: lantern
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
 archives:
   - id: lantern-cli
     ids:
@@ -56,6 +77,21 @@ archives:
       - LICENSE
       - README.md
 
+  - id: lantern
+    ids:
+      - lantern
+    name_template: >-
+      lantern_{{ .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+    formats:
+      - tar.gz
+    files:
+      - LICENSE
+      - README.md
+
 checksum:
   name_template: checksums.txt
 
@@ -64,6 +100,59 @@ snapshot:
   # git tag is a prefixed monorepo tag (e.g. sdks/go/vX.Y.Z) that GoReleaser
   # can't parse as semver. Real releases are driven by v*.*.* tags.
   version_template: "0.0.0-snapshot-{{ .ShortCommit }}"
+
+# Homebrew casks pushed to anaregdesign/homebrew-tap (brew tap anaregdesign/tap).
+# Cross-repo push needs a PAT/App token with contents:write on the tap repo,
+# supplied as HOMEBREW_TAP_GITHUB_TOKEN. Publishing is gated on that secret being
+# present, so a release still succeeds before the secret is configured (the cask
+# simply is not pushed). The binaries are unsigned, so a post-install hook clears
+# the macOS quarantine bit; full notarization would need an Apple Developer cert.
+homebrew_casks:
+  - name: lantern
+    ids:
+      - lantern
+    binaries:
+      - lantern
+    directory: Casks
+    homepage: "https://github.com/anaregdesign/lantern"
+    description: "Lantern — in-memory graph key-vertex-store server (Connect/HTTP-2)"
+    skip_upload: '{{ if .Env.HOMEBREW_TAP_GITHUB_TOKEN }}false{{ else }}true{{ end }}'
+    url:
+      template: "https://github.com/anaregdesign/lantern/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/lantern"]
+          end
+    repository:
+      owner: anaregdesign
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+
+  - name: lantern-cli
+    ids:
+      - lantern-cli
+    binaries:
+      - lantern-cli
+    directory: Casks
+    homepage: "https://github.com/anaregdesign/lantern"
+    description: "Lantern CLI — REPL and scriptable client for a Lantern server"
+    skip_upload: '{{ if .Env.HOMEBREW_TAP_GITHUB_TOKEN }}false{{ else }}true{{ end }}'
+    url:
+      template: "https://github.com/anaregdesign/lantern/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/lantern-cli"]
+          end
+    repository:
+      owner: anaregdesign
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
 
 # The GitHub Release is created/edited by the release job in
 # .github/workflows/docker-publish.yml. GoReleaser just produces the artifacts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,14 @@ Tag order matters because each downstream module pins its upstream tag:
    with a placeholder bench section (the `release` job's `needs:` deliberately excludes
    `bench`, because Actions treats `cancelled` as neither success nor failure).
 
+The root release also builds the `lantern` (server) and `lantern-cli` binaries via
+GoReleaser and pushes Homebrew casks to
+[`anaregdesign/homebrew-tap`](https://github.com/anaregdesign/homebrew-tap)
+(`brew install --cask lantern` / `lantern-cli`). Cask publishing needs the
+`HOMEBREW_TAP_GITHUB_TOKEN` secret — a fine-grained PAT or App token with
+`contents:write` on the tap repo. It is gated on that secret, so a release without it
+still succeeds but skips the cask push.
+
 The `server/` module is never tagged independently — it ships under the root tag. arm64
 buildx under QEMU is slow; if a root tag already pushed the amd64 image, bump the patch
 number rather than force-moving the tag.

--- a/README.md
+++ b/README.md
@@ -305,10 +305,27 @@ per-pod IPs, which these platforms do not provide. See the
 [HA runbook](docs/ha-runbook.md) for the per-platform topology matrix,
 signals to watch, partition behaviour, and recovery procedures.
 
+### Install via Homebrew (macOS)
+
+On macOS, install the server and/or CLI from the
+[`anaregdesign/homebrew-tap`](https://github.com/anaregdesign/homebrew-tap) cask tap:
+
+```shell
+brew tap anaregdesign/tap
+brew install --cask lantern        # server (binary: lantern)
+brew install --cask lantern-cli    # client (binary: lantern-cli)
+```
+
+The cask binaries are not Apple-notarized, so each cask clears the macOS quarantine
+bit on install. The casks track the root `vX.Y.Z` release; `lantern-mcp` and
+`lantern-admin` remain container-only.
+
 ### Use the CLI
 
-Pre-built binaries for Linux, macOS, and Windows (amd64 + arm64) are
-attached to every [GitHub Release](https://github.com/anaregdesign/lantern/releases).
+On macOS the quickest path is `brew install --cask lantern-cli` (see
+[Install via Homebrew](#install-via-homebrew-macos)). Pre-built binaries for Linux,
+macOS, and Windows (amd64 + arm64) are also attached to every
+[GitHub Release](https://github.com/anaregdesign/lantern/releases).
 
 ```shell
 # macOS (Apple Silicon) — replace VERSION with the release tag, e.g. v0.6.0


### PR DESCRIPTION
## What

Distribute the Lantern **server** and **CLI** as Homebrew casks via a new tap:

```sh
brew tap anaregdesign/tap
brew install --cask lantern        # server (binary: lantern)
brew install --cask lantern-cli    # client (binary: lantern-cli)
```

## Changes

- **`.goreleaser.yaml`**: new `lantern` server build (`./server/cmd`, linux+darwin ×
  amd64/arm64, static/CGO-free like the Dockerfile) + archive; a `homebrew_casks`
  section that generates `lantern` and `lantern-cli` casks and pushes them to
  `anaregdesign/homebrew-tap`, with a quarantine-clearing `postflight` (binaries are
  unsigned).
- **`.github/workflows/docker-publish.yml`**: the GoReleaser step now receives
  `HOMEBREW_TAP_GITHUB_TOKEN` (+ `GITHUB_TOKEN`); the server archives are uploaded and
  attached to the GitHub Release; release notes gain a Homebrew section.
- **New repo `anaregdesign/homebrew-tap`** (already created) holds the generated casks
  under `Casks/`.
- **README + CONTRIBUTING** document the install path and the release-time cask push.

## ⚠️ Required manual step (owner)

The cross-repo cask push can't use the default `GITHUB_TOKEN`. Add an org/repo secret
**`HOMEBREW_TAP_GITHUB_TOKEN`** = a fine-grained PAT (or GitHub App token) with
**`contents: write`** on `anaregdesign/homebrew-tap`. Cask publishing is gated on this
secret, so releases keep working before it's set — the casks just aren't pushed until
then.

## Validation

- `goreleaser check` passes; `goreleaser release --snapshot --clean` builds every
  server+CLI target and generates `dist/homebrew/Casks/{lantern,lantern-cli}.rb` with
  correct per-arch `url` + `sha256`, the `binary` stanza, and the quarantine
  `postflight`.
- `go build ./server/cmd ./cli` from the repo root (workspace mode) — the server builds
  exactly like the Dockerfile does.

## Notes / scope

- Scope is **server + CLI only**. `lantern-mcp` and `lantern-admin` stay container-only
  (admin is a browser SPA with no native binary).
- Ordering: within one release run, GoReleaser pushes the cask during the `binaries`
  job and the `release` job uploads the matching archives moments later (same run), so
  the cask `url` resolves once the release assets are attached.

Closes #670
