### PR TITLE
feat(cli): accept REPL grammar as verb-first one-liners

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,15 @@ The cask binaries are not Apple-notarized, so each cask clears the macOS quarant
 bit on install. The casks track the root `vX.Y.Z` release; `lantern-mcp` and
 `lantern-admin` remain container-only.
 
+The client cask installs the `lantern-cli` binary. It speaks the same grammar as
+the interactive prompt, so you can drive it as a one-liner straight away:
+
+```shell
+lantern-cli put vertex alice "Alice" 3600     # value + TTL seconds
+lantern-cli get vertex alice
+lantern-cli illuminate alice 2 5 algorithm=spt objective=max
+```
+
 ### Use the CLI
 
 On macOS the quickest path is `brew install --cask lantern-cli` (see
@@ -346,15 +355,26 @@ go build -o lantern ./cli
 ./lantern --help
 ```
 
-The CLI ships an interactive REPL (`lantern repl`) plus a scriptable
-subcommand for every RPC (`lantern vertex put`, `lantern edge add`,
-`lantern illuminate`, …). The REPL is the fastest way to poke at a running
-server; the one-shot subcommands are what you reach for when you want
-batch writes, prefix scans, NDJSON bulk loads, gzip compression, TLS
-flags, or typed values — features the REPL grammar intentionally does
-not cover. Every subcommand has long-form, LLM-friendly help text
+The CLI gives you the same grammar three ways:
+
+- **`lantern repl`** — an interactive prompt; the fastest way to poke at a
+  running server.
+- **Verb-first one-liners** — every line you can type at the prompt also works
+  as a single shell command: `lantern get vertex alice`,
+  `lantern put vertex alice "Alice" 3600`,
+  `lantern illuminate alice 2 5 algorithm=spt`. These share the exact parser
+  and dispatcher with the REPL ([#672](https://github.com/anaregdesign/lantern/issues/672)),
+  so the prompt and the shell never diverge.
+- **Noun-first subcommands** — `lantern vertex put`, `lantern edge add`,
+  `lantern vertex scan`, … — for everything the REPL grammar intentionally
+  does not cover: typed values, batch writes, cursor-paged prefix scans,
+  NDJSON bulk loads, gzip compression, and TLS flags.
+
+Every subcommand has long-form, LLM-friendly help text
 (`lantern <cmd> --help`); read commands emit JSON on stdout and write
-commands print `OK`.
+commands print `OK`. If you installed via Homebrew the client binary is
+`lantern-cli`; a from-source `go build -o lantern ./cli` names it `lantern`
+— the examples below use `lantern`, so substitute the name you have.
 
 A REPL session that exercises the full vertex/edge/illuminate surface:
 
@@ -404,22 +424,31 @@ OK (0.6ms)
 > exit
 ```
 
-REPL grammar (full reference in `lantern repl --help`, or type `help`
-inside the prompt to print it into the scrollback):
+REPL grammar — works both at the `lantern repl` prompt and as a verb-first
+one-liner (prefix any line with `lantern`). Full reference in
+`lantern repl --help`, or type `help` inside the prompt to print it into the
+scrollback:
 
 ```text
-get    vertex <key>
-put    vertex <key> <value> [ttl_seconds]
-delete vertex <key>
-get    edge   <tail> <head>
-add    edge   <tail> <head> <weight> [ttl_seconds]
-put    edge   <tail> <head> <weight> [ttl_seconds]
-delete edge   <tail> <head>
+get    vertex   <key>
+put    vertex   <key> <value> [ttl_seconds]
+delete vertex   <key>
+get    edge     <tail> <head>
+add    edge     <tail> <head> <weight> [ttl_seconds]
+put    edge     <tail> <head> <weight> [ttl_seconds]
+delete edge     <tail> <head>
+scan   vertices <prefix> [limit]
+scan   edges    <tail-prefix> [limit]
 illuminate <seed> <step> <k> [algorithm=none|mst|spt] [objective=min|max] \
-           [weighting=raw|tfidf]
+           [weighting=raw|tfidf] [prefix=<string>]
 help
 exit
 ```
+
+For example, `lantern get vertex alice` run as a shell command is identical
+to typing `get vertex alice` at the prompt; `lantern add edge a b -1.5`
+passes the negative weight through verbatim (global connection flags such
+as `--address` go before the verb).
 
 Tokens are whitespace-delimited and quotable — wrap a value in
 `"double quotes"` for C-style escapes (`\"`, `\\`, `\n`, `\r`, `\t`)

--- a/cli/cmd/grammar.go
+++ b/cli/cmd/grammar.go
@@ -1,0 +1,153 @@
+package cmd
+
+import (
+	"github.com/anaregdesign/lantern/cli/service"
+	"github.com/spf13/cobra"
+)
+
+// This file wires the REPL grammar (verb-first, whitespace-delimited) as
+// top-level one-shot commands so that everything you can type at the
+// `lantern repl` prompt also works as a single shell invocation (#672):
+//
+//	lantern get    vertex <key>
+//	lantern put    vertex <key> <value> [ttl_seconds]
+//	lantern delete vertex <key>
+//	lantern get    edge   <tail> <head>
+//	lantern add    edge   <tail> <head> <weight> [ttl_seconds]
+//	lantern put    edge   <tail> <head> <weight> [ttl_seconds]
+//	lantern delete edge   <tail> <head>
+//	lantern scan   vertices <prefix> [limit]
+//	lantern scan   edges    <tail-prefix> [limit]
+//
+// These commands intentionally share ONE grammar and ONE dispatcher with
+// the REPL: each forwards its argv to service.CLIService.RunArgs, the same
+// entry point the REPL uses per typed line. They are additive — the
+// noun-first `vertex` / `edge` subcommands remain for typed values, batch
+// writes, scan pagination, NDJSON bulk load, and the TLS/gzip flags that
+// the REPL grammar deliberately does not cover.
+//
+// Flag-parsing note: each verb sets SetInterspersed(false) so a value
+// beginning with '-' (e.g. a negative edge weight, `add edge a b -1.5`) is
+// taken verbatim as a positional token instead of being mis-parsed as a
+// flag. The trade-off is that global connection flags must come BEFORE the
+// verb, e.g. `lantern --address host:6380 get vertex alice`.
+
+// runGrammarLine dials the server and dispatches a REPL-grammar token
+// stream (the verb plus its arguments) through the same CLIService the
+// REPL uses, so the one-liner and the prompt accept byte-identical grammar.
+func runGrammarLine(cmd *cobra.Command, verb string, args []string) error {
+	if len(args) == 0 {
+		return cmd.Help()
+	}
+	cli, err := dial()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = cli.Close() }()
+	return service.NewCLIService(cli).RunArgs(cmd.Context(), append([]string{verb}, args...))
+}
+
+var grammarGetCmd = &cobra.Command{
+	Use:   "get { vertex <key> | edge <tail> <head> }",
+	Short: "Read a vertex or edge (REPL grammar)",
+	Long: `Read a vertex or edge using the same verb-first grammar as the REPL:
+
+  lantern get vertex <key>
+  lantern get edge <tail> <head>
+
+"lantern get vertex alice" is identical to typing "get vertex alice" at the
+"lantern repl" prompt. The vertex value prints as JSON; the edge weight prints
+as a float. For typed output fields and a NotFound exit code, the noun-first
+"lantern vertex get" / "lantern edge get" commands remain available.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGrammarLine(cmd, "get", args)
+	},
+}
+
+var grammarPutCmd = &cobra.Command{
+	Use:   "put { vertex <key> <value> | edge <tail> <head> <weight> } [ttl_seconds]",
+	Short: "Upsert a vertex or replace an edge weight (REPL grammar)",
+	Long: `Write a vertex or edge using the same verb-first grammar as the REPL:
+
+  lantern put vertex <key> <value> [ttl_seconds]
+  lantern put edge <tail> <head> <weight> [ttl_seconds]
+
+The optional trailing ttl_seconds is a positional integer (the REPL form),
+NOT the --ttl duration flag of "lantern vertex put". Omit it for a permanent
+(no-decay) write. The vertex value is auto-typed (int, float, bool, RFC3339
+datetime, else string), exactly as in the REPL; for forced typing (JSON,
+leading-zero strings, durations) use "lantern vertex put --value-type".
+
+put edge REPLACES the weight (idempotent); use "add edge" to accumulate.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGrammarLine(cmd, "put", args)
+	},
+}
+
+var grammarAddCmd = &cobra.Command{
+	Use:   "add edge <tail> <head> <weight> [ttl_seconds]",
+	Short: "Additive edge write: sum weight onto (tail,head) (REPL grammar)",
+	Long: `Accumulate an edge weight using the same verb-first grammar as the REPL:
+
+  lantern add edge <tail> <head> <weight> [ttl_seconds]
+
+add edge is ADDITIVE: repeated calls on the same (tail, head) pair sum their
+weights server-side ("add edge a b 1.5" then "add edge a b 0.5" leaves 2.0).
+Use "put edge" when the weight is a measured property to replace wholesale.
+
+The optional trailing ttl_seconds is a positional integer (the REPL form);
+omit it for a permanent (no-decay) edge.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGrammarLine(cmd, "add", args)
+	},
+}
+
+var grammarDeleteCmd = &cobra.Command{
+	Use:   "delete { vertex <key> | edge <tail> <head> }",
+	Short: "Delete one vertex or edge (REPL grammar)",
+	Long: `Delete a vertex or edge using the same verb-first grammar as the REPL:
+
+  lantern delete vertex <key>
+  lantern delete edge <tail> <head>
+
+This is the single-target REPL form. For batch deletes (DeleteVertices /
+DeleteEdges), prefix deletes, or piping keys from a file, use the noun-first
+"lantern vertex delete" / "lantern edge delete" commands, which accept
+multiple keys/pairs.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGrammarLine(cmd, "delete", args)
+	},
+}
+
+var grammarScanCmd = &cobra.Command{
+	Use:   "scan { vertices <prefix> | edges <tail-prefix> } [limit]",
+	Short: "Enumerate vertices or edges by prefix (REPL grammar)",
+	Long: `Scan vertices or edges using the same verb-first grammar as the REPL:
+
+  lantern scan vertices <prefix> [limit]
+  lantern scan edges <tail-prefix> [limit]
+
+The optional trailing limit is a positional integer (the REPL form). Results
+print as a JSON array. For cursor pagination, --all streaming, NDJSON output,
+or a --head-prefix on edges, use the noun-first "lantern vertex scan" /
+"lantern edge scan" commands.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGrammarLine(cmd, "scan", args)
+	},
+}
+
+func init() {
+	// SetInterspersed(false): stop flag parsing at the first positional so
+	// leading-dash values (negative weights/values) pass through verbatim;
+	// global connection flags must therefore precede the verb.
+	for _, c := range []*cobra.Command{
+		grammarGetCmd,
+		grammarPutCmd,
+		grammarAddCmd,
+		grammarDeleteCmd,
+		grammarScanCmd,
+	} {
+		c.Flags().SetInterspersed(false)
+		rootCmd.AddCommand(c)
+	}
+}

--- a/cli/cmd/grammar_test.go
+++ b/cli/cmd/grammar_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"io"
+	"testing"
+
+	"github.com/anaregdesign/lantern/cli/parser"
+	"github.com/spf13/cobra"
+)
+
+// The verb-first one-liners (#672) must stay wired to rootCmd and must keep
+// flag interspersing OFF, so a leading-dash value (a negative edge weight or
+// vertex value) passes through as a positional token rather than being
+// mis-parsed as an unknown flag.
+func TestGrammarVerbsRegistered(t *testing.T) {
+	want := map[string]bool{"get": true, "put": true, "add": true, "delete": true, "scan": true}
+	found := map[string]*cobra.Command{}
+	for _, c := range rootCmd.Commands() {
+		if want[c.Name()] {
+			found[c.Name()] = c
+		}
+	}
+	for name := range want {
+		c, ok := found[name]
+		if !ok {
+			t.Errorf("top-level verb %q is not registered on rootCmd", name)
+			continue
+		}
+		// Behavioural assertion that SetInterspersed(false) is in effect:
+		// once the first positional ("edge") is seen, a later "-0.5" must be
+		// retained as a positional, not rejected as an unknown shorthand
+		// flag. With interspersing ON this Parse would error.
+		fs := c.Flags()
+		fs.SetOutput(io.Discard)
+		if err := fs.Parse([]string{"edge", "a", "b", "-0.5"}); err != nil {
+			t.Errorf("verb %q: Parse with a negative value = %v, want nil (interspersing must be off)", name, err)
+		}
+	}
+}
+
+// Drift guard: every top-level verb exposed as a one-liner must be a verb the
+// shared REPL grammar actually accepts, so the two surfaces cannot diverge.
+func TestGrammarVerbsAcceptedByParser(t *testing.T) {
+	for _, verb := range []string{"get", "put", "add", "delete", "scan"} {
+		accepted := false
+		for _, v := range parser.Verbs {
+			if v == verb {
+				accepted = true
+				break
+			}
+		}
+		if !accepted {
+			t.Errorf("verb %q exposed as a one-liner but not in parser.Verbs", verb)
+		}
+	}
+}
+
+// runGrammarLine must print help (and not dial) when invoked with no
+// arguments, so `lantern get` with nothing is a friendly no-op rather than a
+// connection attempt.
+func TestRunGrammarLineEmptyArgsShowsHelp(t *testing.T) {
+	c := &cobra.Command{Use: "get"}
+	c.SetOut(io.Discard)
+	c.SetErr(io.Discard)
+	if err := runGrammarLine(c, "get", nil); err != nil {
+		t.Errorf("runGrammarLine(empty) = %v, want nil (help shown)", err)
+	}
+}

--- a/cli/cmd/illuminate.go
+++ b/cli/cmd/illuminate.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/anaregdesign/lantern/cli/service"
 	client "github.com/anaregdesign/lantern/sdks/go"
 	"github.com/spf13/cobra"
 )
@@ -107,9 +108,36 @@ EXAMPLES
 
   # 2-hop walk restricted to the users/ keyspace (seed always kept)
   lantern illuminate alice --step 2 --k 5 --prefix users/
+
+REPL GRAMMAR (one-liner parity, #672)
+  In addition to the flags above, illuminate accepts the REPL's positional
+  form so the prompt and the shell share one grammar:
+
+    lantern illuminate <seed> <step> <k> [algorithm=none|mst|spt] \
+            [objective=min|max] [weighting=raw|tfidf] [prefix=<string>]
+
+  e.g. "lantern illuminate alice 2 5 algorithm=spt objective=max" is
+  identical to typing it at "lantern repl". The positional form kicks in
+  whenever more than the bare <seed> is supplied; a bare "lantern
+  illuminate alice" uses the flag defaults (step=1, k=10).
 `,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// REPL positional grammar: `illuminate <seed> <step> <k> [key=value …]`.
+		// When more than the bare seed is present, forward argv to the shared
+		// REPL dispatcher so `lantern illuminate alice 2 5 algorithm=spt`
+		// behaves exactly like the prompt (#672). A bare seed keeps the
+		// flag-driven path below, which is the only form that supplies the
+		// step/k defaults.
+		if len(args) > 1 {
+			cli, err := dial()
+			if err != nil {
+				return err
+			}
+			defer func() { _ = cli.Close() }()
+			return service.NewCLIService(cli).RunArgs(cmd.Context(), append([]string{"illuminate"}, args...))
+		}
+
 		algo, ok := algorithmByName[illuminateAlgorithmStr]
 		if !ok {
 			return fmt.Errorf("unknown --algorithm %q (want none|mst|spt)", illuminateAlgorithmStr)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -64,11 +64,15 @@ WHAT LANTERN IS
   plus an interactive REPL.
 
 COMMAND LAYOUT
-  vertex      get / put / delete vertices (single or batch)
-  edge        get / add / put / delete edges (single or batch)
-  illuminate  walk the graph from a seed; optional algorithm × objective × weighting reduction
+  REPL grammar (verb-first one-liners — identical to the "lantern repl" prompt):
+    get / put / add / delete / scan   e.g. "lantern get vertex alice"
+  Noun-first subcommands (typed values, batch, paging, NDJSON bulk, TLS/gzip):
+    vertex      get / put / delete / scan / count / delete-prefix vertices
+    edge        get / add / put / delete / scan edges
+  illuminate  walk the graph from a seed; accepts flags OR the REPL
+              positional grammar (illuminate <seed> <step> <k> [key=value …])
   bulk        stream NDJSON from a file or stdin (bulk load)
-  repl        legacy interactive prompt
+  repl        interactive prompt
   version     print client version
   completion  generate shell completions (bash, zsh, fish, powershell)
 
@@ -96,7 +100,14 @@ EXIT CODES
   2  RPC error returned by the server (NotFound, InvalidArgument, …)
 
 EXAMPLES
-  # one-shot writes against a local server
+  # REPL grammar as one-liners (identical to the "lantern repl" prompt)
+  lantern get vertex alice
+  lantern put vertex alice "Alice" 3600        # value + TTL seconds
+  lantern add edge alice bob 1.5 3600          # additive edge write
+  lantern scan vertices users/ 100
+  lantern illuminate alice 2 5 algorithm=spt objective=max
+
+  # noun-first subcommands for typed values, batch, paging, TLS
   lantern vertex put alice '{"name":"Alice"}' --value-type json --ttl 1h
   lantern edge add alice bob 1.5 --ttl 30m
   lantern edge add alice bob 0.5      # weight now totals 2.0

--- a/cli/parser/source.go
+++ b/cli/parser/source.go
@@ -44,6 +44,22 @@ func NewSource(str string) (*Source, error) {
 	}, nil
 }
 
+// NewSourceFromTokens builds a Source directly from already-split tokens,
+// skipping the quote-aware tokeniser entirely. It exists so the one-shot
+// CLI verbs (`lantern get vertex <key>`, etc.) can feed cobra's
+// shell-split argv straight into the same grammar the REPL parses from a
+// raw line — the shell already performed the word/quote splitting, so a
+// second pass through tokenise() would be both redundant and lossy (a
+// value containing spaces would be re-split). The verb token is expected
+// to be the first element, mirroring `Verb(s)` on a NewSource stream.
+func NewSourceFromTokens(tokens []string) *Source {
+	return &Source{
+		s:      tokens,
+		pos:    0,
+		length: len(tokens),
+	}
+}
+
 func tokenise(input string) ([]string, error) {
 	var out []string
 	i := 0

--- a/cli/parser/source_test.go
+++ b/cli/parser/source_test.go
@@ -49,6 +49,36 @@ func TestNewSource_BarewordBoundary(t *testing.T) {
 	}
 }
 
+// TestNewSourceFromTokens pins the constructor the one-shot verbs use to
+// feed cobra's already-split argv into the REPL grammar without a second
+// tokenise pass (#672). It preserves tokens verbatim — including ones that
+// NewSource would have re-split (embedded spaces) — and the verb stream
+// reads back identically to a NewSource of the equivalent quoted line.
+func TestNewSourceFromTokens(t *testing.T) {
+	in := []string{"put", "vertex", "k", "hello world"}
+	s := NewSourceFromTokens(in)
+	if got := s.Slice(); !reflect.DeepEqual(got, in) {
+		t.Fatalf("Slice() = %#v, want %#v (no re-splitting)", got, in)
+	}
+	if s.Len() != len(in) {
+		t.Errorf("Len() = %d, want %d", s.Len(), len(in))
+	}
+	verb, err := Verb(s)
+	if err != nil {
+		t.Fatalf("Verb() error: %v", err)
+	}
+	if verb != "put" {
+		t.Errorf("Verb() = %q, want %q", verb, "put")
+	}
+	line, err := NewSource(`put vertex k "hello world"`)
+	if err != nil {
+		t.Fatalf("NewSource line failed: %v", err)
+	}
+	if !reflect.DeepEqual(line.Slice(), in) {
+		t.Errorf("NewSource line tokens = %#v, want %#v", line.Slice(), in)
+	}
+}
+
 func TestNewSource_DoubleQuoted(t *testing.T) {
 	cases := map[string][]string{
 		`put vertex k "hello world"`: {"put", "vertex", "k", "hello world"},

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -45,6 +45,21 @@ func (c *CLIService) Run(ctx context.Context, str string) error {
 		fmt.Printf("Error: %s\n", err)
 		return ErrInvalidVerb
 	}
+	return c.runSource(ctx, s)
+}
+
+// RunArgs dispatches an already-split token stream (verb + arguments)
+// through the same grammar the REPL parses from a raw line. The one-shot
+// verb-first CLI commands (`lantern get vertex <key>`, …) call this with
+// cobra's argv so the one-liner surface and the REPL share exactly one
+// grammar and one dispatcher (#672).
+func (c *CLIService) RunArgs(ctx context.Context, args []string) error {
+	return c.runSource(ctx, parser.NewSourceFromTokens(args))
+}
+
+// runSource is the shared verb dispatcher behind both Run (a raw line from
+// the REPL) and RunArgs (pre-split argv from the one-shot verbs).
+func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 	verb, err := parser.Verb(s)
 	if err != nil {
 		fmt.Printf("Error: %s\n", err)

--- a/cli/service/service_test.go
+++ b/cli/service/service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -41,6 +42,31 @@ func TestFormatWriteEcho(t *testing.T) {
 		want := `put edge "a" -> "b" (weight 1.5) (ttl 1m30s, expires 2026-06-16T12:36:26Z)`
 		if got != want {
 			t.Errorf("formatWriteEcho() = %q, want %q", got, want)
+		}
+	})
+}
+
+// TestRunArgs pins the one-liner dispatch entry point (#672). RunArgs feeds
+// pre-split argv through the same runSource dispatcher Run uses for a raw
+// REPL line. The help and invalid-verb branches never touch the client, so
+// a nil-client service exercises the shared dispatch without a live server.
+func TestRunArgs(t *testing.T) {
+	svc := NewCLIService(nil)
+	ctx := context.Background()
+
+	t.Run("HelpVerbReturnsNil", func(t *testing.T) {
+		if err := svc.RunArgs(ctx, []string{"help"}); err != nil {
+			t.Errorf("RunArgs([help]) = %v, want nil", err)
+		}
+	})
+	t.Run("UnknownVerbReturnsErrInvalidVerb", func(t *testing.T) {
+		if err := svc.RunArgs(ctx, []string{"bogus"}); err != ErrInvalidVerb {
+			t.Errorf("RunArgs([bogus]) = %v, want ErrInvalidVerb", err)
+		}
+	})
+	t.Run("EmptyArgsReturnsErrInvalidVerb", func(t *testing.T) {
+		if err := svc.RunArgs(ctx, nil); err != ErrInvalidVerb {
+			t.Errorf("RunArgs(nil) = %v, want ErrInvalidVerb", err)
 		}
 	})
 }


### PR DESCRIPTION
## What & why

`Closes #672.`

The interactive REPL and the one-shot CLI used two divergent grammars:

| op | REPL (verb-first) | one-liner before (noun-first + flags) |
|---|---|---|
| read | `get vertex alice` | `lantern-cli vertex get alice` |
| write | `put vertex alice "Alice" 30` | `lantern-cli vertex put alice "Alice" --ttl 30s` |
| edge add | `add edge a b 1.5 60` | `lantern-cli edge add a b 1.5 --ttl 60s` |
| scan | `scan vertices user: 100` | `lantern-cli vertex scan user: --limit 100` |
| illuminate | `illuminate alice 2 5 algorithm=spt` | `lantern-cli illuminate alice --step 2 --k 5 --algorithm spt` |

Now easy to reach via `brew install --cask lantern-cli` (#671), the prompt
grammar could not be typed as a one-liner. This makes the REPL grammar work
verbatim as a one-liner, sharing **one** parser + dispatcher.

## How

- New `parser.NewSourceFromTokens([]string)` feeds cobra's already-split argv
  into the grammar without a second tokenise pass.
- New `service.CLIService.RunArgs(ctx, argv)` shares `runSource` with the
  existing `Run(ctx, line)` (REPL), so both surfaces dispatch identically.
- New top-level `get` / `put` / `add` / `delete` / `scan` commands forward
  their argv through `RunArgs`. `illuminate` now also accepts the REPL
  positional `<step> <k> [key=value …]` form alongside its flags.
- Each verb sets `SetInterspersed(false)` so a leading-dash value (negative
  edge weight) passes through verbatim; global connection flags go before the
  verb.
- **Additive** — the noun-first `vertex` / `edge` subcommands are untouched
  (typed values, batch, scan paging, NDJSON bulk, TLS/gzip).

## Docs

- README "Use the CLI" reframed around the three surfaces; grammar reference
  completed (adds `scan vertices/edges` + illuminate `prefix=`).
- Homebrew section enriched now that the tap is live (#671); leads with the
  `lantern-cli` binary and a one-liner example.

## Tests / verification

- `parser`: `NewSourceFromTokens` round-trip + equivalence with the line path.
- `service`: `RunArgs` help + invalid-verb branches (nil-client).
- `cmd`: verb registration + `SetInterspersed(false)` behavioural guard +
  parser-drift guard.
- Smoke-tested every verb against the live 3-node compose stack: writes/TTL
  echo, additive **and negative** edge weight (`-0.25` → sum 1.75), scan,
  illuminate positional + flag forms, delete, global flag before verb
  (`--address localhost:6381`), `-h`, error exit codes (1 local/parse, 2 RPC).
- Local gate: `gofmt -l` clean, `go vet ./...`, `go test ./...` (incl.
  `tests/integration`) all green.
