### PR TITLE
chore(release): bump module pins for keys feature (pb v0.7.0, sdks/go v0.16.0, node 0.5.0)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	connectrpc.com/grpchealth v1.4.0
 	github.com/anaregdesign/lantern/core v0.7.1
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
-	github.com/anaregdesign/lantern/pb v0.6.0
-	github.com/anaregdesign/lantern/sdks/go v0.15.1
+	github.com/anaregdesign/lantern/pb v0.7.0
+	github.com/anaregdesign/lantern/sdks/go v0.16.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	github.com/anaregdesign/lantern/core v0.7.0
-	github.com/anaregdesign/lantern/pb v0.6.0
+	github.com/anaregdesign/lantern/pb v0.7.0
 	golang.org/x/net v0.56.0
 	google.golang.org/protobuf v1.36.11
 )

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lantern-sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Official TypeScript client SDK for Lantern — an in-memory graph KVS, over Connect (HTTP/2).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## What

Release-prep pin bumps for the `keys` / `ScanVertexKeys` feature (#674, merged in #677). No code changes — only cross-module version pins and the Node SDK package version.

| Module | From | To |
|---|---|---|
| `pb` | v0.6.0 | **v0.7.0** (new `ScanVertexKeys` RPC) |
| `sdks/go` | v0.15.1 | **v0.16.0** (new `ScanVertexKeys`/`ScanVertexKeysAll`) |
| root (server + CLI) | v0.16.0 | **v0.17.0** (`keys` command) |
| `sdks/node` | 0.4.0 | **0.5.0** (`scanVertexKeys`/`scanVertexKeysAll`) |
| `core` | — | unchanged (v0.7.1) |
| `mcp` | — | unchanged (v0.8.1) |

## Why

`sdks/go` v0.16.0 consumes the new `ScanVertexKeysRequest`/`Response` from `pb`, so its `require` must point at `pb v0.7.0` to compile for downstream `go get` consumers (the local `replace` directives keep monorepo builds working regardless). The root module then pins the freshly tagged `pb v0.7.0` + `sdks/go v0.16.0`.

## Changes

- `sdks/go/go.mod`: `require pb` v0.6.0 → v0.7.0
- `go.mod` (root): `require pb` v0.6.0 → v0.7.0, `require sdks/go` v0.15.1 → v0.16.0
- `sdks/node/package.json`: `version` 0.4.0 → 0.5.0

`go build ./...` passes in both the root and `sdks/go`; `go mod tidy` keeps the bumped pins stable (replaces resolve locally, no `go.sum` churn).

## Release cascade (after merge)

Tag in order at the merged commit: `pb/v0.7.0` → `sdks/go/v0.16.0` → `v0.17.0` → `sdks/node/v0.5.0`.
