### PR TITLE
feat(cli): add count/delete-prefix verbs, batch delete, and scan paging to the verb-first grammar

### DIFF
--- a/cli/cmd/grammar.go
+++ b/cli/cmd/grammar.go
@@ -103,34 +103,34 @@ omit it for a permanent (no-decay) edge.`,
 }
 
 var grammarDeleteCmd = &cobra.Command{
-	Use:   "delete { vertex <key> | edge <tail> <head> }",
-	Short: "Delete one vertex or edge (REPL grammar)",
-	Long: `Delete a vertex or edge using the same verb-first grammar as the REPL:
+	Use:   "delete { vertex <key> [<key>...] | edge <tail> <head> [<tail> <head>...] }",
+	Short: "Delete vertices or edges (REPL grammar)",
+	Long: `Delete vertices or edges using the same verb-first grammar as the REPL:
 
-  lantern delete vertex <key>
-  lantern delete edge <tail> <head>
+  lantern delete vertex <key> [<key> ...]
+  lantern delete edge <tail> <head> [<tail> <head> ...]
 
-This is the single-target REPL form. For batch deletes (DeleteVertices /
-DeleteEdges), prefix deletes, or piping keys from a file, use the noun-first
-"lantern vertex delete" / "lantern edge delete" commands, which accept
-multiple keys/pairs.`,
+One key/pair deletes a single target; supplying more than one routes to the
+batched DeleteVertices / DeleteEdges RPC and prints "OK <n>" with the count
+actually removed. To delete every vertex under a key prefix, use
+"delete-prefix vertices".`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGrammarLine(cmd, "delete", args)
 	},
 }
 
 var grammarScanCmd = &cobra.Command{
-	Use:   "scan { vertices <prefix> | edges <tail-prefix> } [limit]",
+	Use:   "scan { vertices <prefix> | edges <tail-prefix> } [limit] [head=<prefix>] [all=true]",
 	Short: "Enumerate vertices or edges by prefix (REPL grammar)",
 	Long: `Scan vertices or edges using the same verb-first grammar as the REPL:
 
-  lantern scan vertices <prefix> [limit]
-  lantern scan edges <tail-prefix> [limit]
+  lantern scan vertices <prefix> [limit] [all=true]
+  lantern scan edges <tail-prefix> [limit] [head=<prefix>] [all=true]
 
-The optional trailing limit is a positional integer (the REPL form). Results
-print as a JSON array. For cursor pagination, --all streaming, NDJSON output,
-or a --head-prefix on edges, use the noun-first "lantern vertex scan" /
-"lantern edge scan" commands.`,
+The optional trailing limit is a positional integer (the REPL form); results
+print as a JSON array. all=true iterates every page and renders the full
+result set; head=<prefix> narrows edges by their head endpoint. To list vertex
+keys only (no values), use "keys <prefix>".`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGrammarLine(cmd, "scan", args)
 	},
@@ -159,6 +159,43 @@ objects.`,
 	},
 }
 
+var grammarCountCmd = &cobra.Command{
+	Use:   "count vertices <prefix>",
+	Short: "Count vertices under a key prefix (REPL grammar)",
+	Long: `Count the vertices whose key starts with <prefix>, using the same
+verb-first grammar as the REPL:
+
+  lantern count vertices <prefix>
+
+Prints a single decimal integer. The count is read from the radix index and is
+not cross-checked against per-vertex liveness, so a vertex that has expired but
+not yet been reaped is still counted; pipe "scan vertices <prefix> all=true"
+through a line counter for the strictly-live count.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGrammarLine(cmd, "count", args)
+	},
+}
+
+var grammarDeletePrefixCmd = &cobra.Command{
+	Use:   "delete-prefix vertices <prefix> [limit=<int>] [confirm=yes|dry_run=true]",
+	Short: "Bulk-delete vertices under a key prefix (DESTRUCTIVE, REPL grammar)",
+	Long: `Remove every live vertex whose key starts with <prefix>, using the same
+verb-first grammar as the REPL:
+
+  lantern delete-prefix vertices <prefix> dry_run=true   # preview, mutates nothing
+  lantern delete-prefix vertices <prefix> confirm=yes    # perform the delete
+  lantern delete-prefix vertices <prefix> confirm=yes limit=500
+
+SAFETY GATE: exactly one of confirm=yes or dry_run=true is REQUIRED — a bare
+"delete-prefix vertices <prefix>" is refused, because a bulk prefix delete is
+irreversible and trivially typo-able. dry_run prints "would delete <n>";
+confirm prints "deleted <n>". The optional limit caps the deletes per call.
+Edges incident to deleted vertices are reaped lazily with their own TTL.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGrammarLine(cmd, "delete-prefix", args)
+	},
+}
+
 func init() {
 	// SetInterspersed(false): stop flag parsing at the first positional so
 	// leading-dash values (negative weights/values) pass through verbatim;
@@ -170,6 +207,8 @@ func init() {
 		grammarDeleteCmd,
 		grammarScanCmd,
 		grammarKeysCmd,
+		grammarCountCmd,
+		grammarDeletePrefixCmd,
 	} {
 		c.Flags().SetInterspersed(false)
 		rootCmd.AddCommand(c)

--- a/cli/parser/model.go
+++ b/cli/parser/model.go
@@ -31,13 +31,23 @@ type AddEdge struct {
 	TTL    time.Duration
 }
 
+// DeleteVertex backs `delete vertex <key> [<key> …]`. Keys holds one or
+// more keys; the dispatcher forwards a one-element batch to DeleteVertex
+// and a multi-element batch to DeleteVertices.
 type DeleteVertex struct {
-	Key string
+	Keys []string
 }
 
-type DeleteEdge struct {
+// EdgePair is one (tail, head) pair in a batch edge delete.
+type EdgePair struct {
 	Tail string
 	Head string
+}
+
+// DeleteEdge backs `delete edge <tail> <head> [<tail> <head> …]`. Pairs
+// holds one or more (tail, head) pairs (the token count must be even).
+type DeleteEdge struct {
+	Pairs []EdgePair
 }
 
 type Illuminate struct {
@@ -50,17 +60,23 @@ type Illuminate struct {
 	Prefix    string // vertex-key prefix filter; "" (default) = no filter (#604)
 }
 
-// ScanVertices / ScanEdges back the `scan vertices` / `scan edges` REPL
-// verbs that mirror the admin web CLI shape (#411). Limit is optional;
-// 0 means "use the server default".
+// ScanVertices backs `scan vertices <prefix> [limit] [all=true]` (#411,
+// extended in #679). Limit is optional (0 = server default); All iterates
+// every page and renders the full result.
 type ScanVertices struct {
 	Prefix string
 	Limit  int
+	All    bool
 }
 
+// ScanEdges backs `scan edges <tail-prefix> [limit] [head=<prefix>]
+// [all=true]`. HeadPrefix narrows the head dimension as a server-side index
+// lookup; All iterates every page.
 type ScanEdges struct {
 	TailPrefix string
+	HeadPrefix string
 	Limit      int
+	All        bool
 }
 
 // Keys backs the `keys <prefix> [limit]` verb — the Redis-familiar key lister
@@ -70,4 +86,21 @@ type ScanEdges struct {
 type Keys struct {
 	Prefix string
 	Limit  int
+}
+
+// CountVertices backs `count vertices <prefix>` — the prefix-cardinality
+// verb migrated from the former `vertex count` subcommand.
+type CountVertices struct {
+	Prefix string
+}
+
+// DeletePrefixVertices backs `delete-prefix vertices <prefix> [limit=<n>]
+// [confirm=yes|dry_run=true]` — the destructive prefix delete migrated from
+// `vertex delete-prefix`. Exactly one of Confirm / DryRun must be set (the
+// safety gate); a bare `delete-prefix vertices p` is a usage error.
+type DeletePrefixVertices struct {
+	Prefix  string
+	Limit   int
+	DryRun  bool
+	Confirm bool
 }

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -14,6 +15,8 @@ var (
 		"add",
 		"delete",
 		"scan",
+		"count",
+		"delete-prefix",
 		"keys",
 		"illuminate",
 		"help",
@@ -290,29 +293,49 @@ func AddEdgeParam(s *Source) (*AddEdge, error) {
 	}
 	return m, nil
 }
+
+// DeleteVertexParam parses `delete vertex <key> [<key> …]` — one or more
+// keys. A one-element batch deletes a single vertex; more than one routes
+// to DeleteVertices in the dispatcher.
 func DeleteVertexParam(s *Source) (*DeleteVertex, error) {
-	var err error
 	m := &DeleteVertex{}
-	if m.Key, err = String(s); err != nil {
-		return nil, err
+	for s.HasNext() {
+		key, err := String(s)
+		if err != nil {
+			return nil, err
+		}
+		if key == "" {
+			return nil, ErrNotFound
+		}
+		m.Keys = append(m.Keys, key)
 	}
-	if err := EOF(s); err != nil {
-		return nil, err
+	if len(m.Keys) == 0 {
+		return nil, ErrNotFound
 	}
 	return m, nil
 }
 
+// DeleteEdgeParam parses `delete edge <tail> <head> [<tail> <head> …]` —
+// one or more (tail, head) pairs (an even, non-zero token count). A single
+// pair deletes one edge; more than one routes to DeleteEdges.
 func DeleteEdgeParam(s *Source) (*DeleteEdge, error) {
-	var err error
 	m := &DeleteEdge{}
-	if m.Tail, err = String(s); err != nil {
-		return nil, err
+	for s.HasNext() {
+		tail, err := String(s)
+		if err != nil {
+			return nil, err
+		}
+		head, err := String(s)
+		if err != nil {
+			return nil, err
+		}
+		if tail == "" || head == "" {
+			return nil, ErrNotFound
+		}
+		m.Pairs = append(m.Pairs, EdgePair{Tail: tail, Head: head})
 	}
-	if m.Head, err = String(s); err != nil {
-		return nil, err
-	}
-	if err := EOF(s); err != nil {
-		return nil, err
+	if len(m.Pairs) == 0 {
+		return nil, ErrNotFound
 	}
 	return m, nil
 }
@@ -409,19 +432,40 @@ func contains(set []string, v string) bool {
 // rejected because an unbounded vertex scan from the REPL is
 // almost never what the operator meant.
 func ScanVerticesParam(s *Source) (*ScanVertices, error) {
-	var err error
-	m := &ScanVertices{}
-	if m.Prefix, err = String(s); err != nil {
+	prefix, err := String(s)
+	if err != nil {
 		return nil, err
 	}
-	if err := EOF(s); err == nil {
-		return m, nil
-	}
-	if m.Limit, err = Integer(s); err != nil {
-		return nil, err
-	}
-	if err := EOF(s); err != nil {
-		return nil, err
+	m := &ScanVertices{Prefix: prefix}
+	limitSet := false
+	for s.HasNext() {
+		tok, err := String(s)
+		if err != nil {
+			return nil, err
+		}
+		key, value, isKwarg := strings.Cut(tok, "=")
+		if !isKwarg {
+			if limitSet {
+				return nil, fmt.Errorf("scan vertices: unexpected token %q", tok)
+			}
+			n, perr := strconv.Atoi(tok)
+			if perr != nil {
+				return nil, perr
+			}
+			m.Limit = n
+			limitSet = true
+			continue
+		}
+		switch strings.ToLower(key) {
+		case "all":
+			b, perr := strconv.ParseBool(value)
+			if perr != nil {
+				return nil, fmt.Errorf("scan vertices: all must be true or false")
+			}
+			m.All = b
+		default:
+			return nil, fmt.Errorf("scan vertices: unknown keyword %q", key)
+		}
 	}
 	return m, nil
 }
@@ -431,19 +475,45 @@ func ScanVerticesParam(s *Source) (*ScanVertices, error) {
 // tail-prefix is permitted (scans every tail), matching the server's
 // ScanEdges semantics where both prefixes default to empty.
 func ScanEdgesParam(s *Source) (*ScanEdges, error) {
-	var err error
-	m := &ScanEdges{}
-	if m.TailPrefix, err = String(s); err != nil {
+	tailPrefix, err := String(s)
+	if err != nil {
 		return nil, err
 	}
-	if err := EOF(s); err == nil {
-		return m, nil
-	}
-	if m.Limit, err = Integer(s); err != nil {
-		return nil, err
-	}
-	if err := EOF(s); err != nil {
-		return nil, err
+	m := &ScanEdges{TailPrefix: tailPrefix}
+	limitSet := false
+	for s.HasNext() {
+		tok, err := String(s)
+		if err != nil {
+			return nil, err
+		}
+		key, value, isKwarg := strings.Cut(tok, "=")
+		if !isKwarg {
+			if limitSet {
+				return nil, fmt.Errorf("scan edges: unexpected token %q", tok)
+			}
+			n, perr := strconv.Atoi(tok)
+			if perr != nil {
+				return nil, perr
+			}
+			m.Limit = n
+			limitSet = true
+			continue
+		}
+		switch strings.ToLower(key) {
+		case "head":
+			if value == "" {
+				return nil, fmt.Errorf("scan edges: empty head prefix")
+			}
+			m.HeadPrefix = value
+		case "all":
+			b, perr := strconv.ParseBool(value)
+			if perr != nil {
+				return nil, fmt.Errorf("scan edges: all must be true or false")
+			}
+			m.All = b
+		default:
+			return nil, fmt.Errorf("scan edges: unknown keyword %q", key)
+		}
 	}
 	return m, nil
 }
@@ -471,6 +541,76 @@ func KeysParam(s *Source) (*Keys, error) {
 	return m, nil
 }
 
+// CountVerticesParam parses `count vertices <prefix>` — exactly one prefix
+// (migrated from the `vertex count` subcommand). The objective token
+// ("vertices") has already been consumed by the caller.
+func CountVerticesParam(s *Source) (*CountVertices, error) {
+	prefix, err := String(s)
+	if err != nil {
+		return nil, err
+	}
+	if prefix == "" {
+		return nil, ErrNotFound
+	}
+	if err := EOF(s); err != nil {
+		return nil, err
+	}
+	return &CountVertices{Prefix: prefix}, nil
+}
+
+// DeletePrefixVerticesParam parses `delete-prefix vertices <prefix>
+// [limit=<int>] [confirm=yes|dry_run=true]`. Exactly one of confirm=yes or
+// dry_run=true is REQUIRED — the destructive-op safety gate; a bare
+// `delete-prefix vertices p` is a usage error. The objective token
+// ("vertices") has already been consumed by the caller.
+func DeletePrefixVerticesParam(s *Source) (*DeletePrefixVertices, error) {
+	prefix, err := String(s)
+	if err != nil {
+		return nil, err
+	}
+	if prefix == "" {
+		return nil, ErrNotFound
+	}
+	m := &DeletePrefixVertices{Prefix: prefix}
+	for s.HasNext() {
+		tok, err := String(s)
+		if err != nil {
+			return nil, err
+		}
+		key, value, ok := strings.Cut(tok, "=")
+		if !ok {
+			return nil, fmt.Errorf("delete-prefix: expected key=value, got %q", tok)
+		}
+		switch strings.ToLower(key) {
+		case "limit":
+			n, perr := strconv.Atoi(value)
+			if perr != nil {
+				return nil, fmt.Errorf("delete-prefix: limit must be an integer")
+			}
+			m.Limit = n
+		case "confirm":
+			if !strings.EqualFold(value, "yes") {
+				return nil, fmt.Errorf("delete-prefix: confirm must be 'yes'")
+			}
+			m.Confirm = true
+		case "dry_run":
+			b, perr := strconv.ParseBool(value)
+			if perr != nil {
+				return nil, fmt.Errorf("delete-prefix: dry_run must be true or false")
+			}
+			m.DryRun = b
+		default:
+			return nil, fmt.Errorf("delete-prefix: unknown keyword %q", key)
+		}
+	}
+	// Safety gate: require EXACTLY one of confirm=yes / dry_run=true. Both
+	// unset (no gate) and both set (ambiguous) are usage errors.
+	if m.Confirm == m.DryRun {
+		return nil, fmt.Errorf("delete-prefix: requires confirm=yes or dry_run=true")
+	}
+	return m, nil
+}
+
 // HelpText is the per-verb grammar reference printed by the `help` verb
 // (#436). Single source of truth for the Go REPL; the TypeScript port
 // keeps a byte-equivalent copy at `admin/app/lib/cli/verbs.ts` `HELP_TEXT`,
@@ -487,10 +627,12 @@ const HelpText = `Lantern CLI grammar:
   put    vertex <key: string> <value: string|int|float|bool|datetime> [<ttl_seconds: int>]
   put    edge   <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]
   add    edge   <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]
-  delete vertex <key: string>
-  delete edge   <tail: string> <head: string>
-  scan   vertices <prefix: string> [<limit: int>]
-  scan   edges    <tail-prefix: string> [<limit: int>]
+  delete vertex <key: string> [<key: string> ...]
+  delete edge   <tail: string> <head: string> [<tail: string> <head: string> ...]
+  scan   vertices <prefix: string> [<limit: int>] [all=true]
+  scan   edges    <tail-prefix: string> [<limit: int>] [head=<prefix>] [all=true]
+  count  vertices <prefix: string>
+  delete-prefix vertices <prefix: string> [limit=<int>] [confirm=yes|dry_run=true]
   keys   <prefix: string> [<limit: int>]
   illuminate <seed: string> <step: int> <k: int>
              [algorithm={none|mst|spt}]  default=none

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -45,6 +45,179 @@ func TestKeysParam(t *testing.T) {
 	})
 }
 
+// TestDeleteParam_Batch pins the #679 variadic batch-delete grammar: one or
+// more keys for `delete vertex`, and one or more (tail,head) pairs for
+// `delete edge` (an even, non-zero token count). Zero targets and odd edge
+// token counts are errors.
+func TestDeleteParam_Batch(t *testing.T) {
+	t.Run("vertex single", func(t *testing.T) {
+		s, _ := NewSource("alice")
+		m, err := DeleteVertexParam(s)
+		if err != nil {
+			t.Fatalf("DeleteVertexParam: %v", err)
+		}
+		if len(m.Keys) != 1 || m.Keys[0] != "alice" {
+			t.Errorf("Keys = %v, want [alice]", m.Keys)
+		}
+	})
+	t.Run("vertex batch", func(t *testing.T) {
+		s, _ := NewSource("alice bob carol")
+		m, err := DeleteVertexParam(s)
+		if err != nil {
+			t.Fatalf("DeleteVertexParam: %v", err)
+		}
+		if len(m.Keys) != 3 {
+			t.Errorf("Keys = %v, want 3 keys", m.Keys)
+		}
+	})
+	t.Run("vertex zero is error", func(t *testing.T) {
+		s, _ := NewSource("")
+		if _, err := DeleteVertexParam(s); err == nil {
+			t.Errorf("DeleteVertexParam(empty) = nil, want error")
+		}
+	})
+	t.Run("edge single pair", func(t *testing.T) {
+		s, _ := NewSource("a b")
+		m, err := DeleteEdgeParam(s)
+		if err != nil {
+			t.Fatalf("DeleteEdgeParam: %v", err)
+		}
+		if len(m.Pairs) != 1 || m.Pairs[0].Tail != "a" || m.Pairs[0].Head != "b" {
+			t.Errorf("Pairs = %v, want [{a b}]", m.Pairs)
+		}
+	})
+	t.Run("edge batch pairs", func(t *testing.T) {
+		s, _ := NewSource("a b c d")
+		m, err := DeleteEdgeParam(s)
+		if err != nil {
+			t.Fatalf("DeleteEdgeParam: %v", err)
+		}
+		if len(m.Pairs) != 2 || m.Pairs[1].Tail != "c" || m.Pairs[1].Head != "d" {
+			t.Errorf("Pairs = %v, want 2 pairs", m.Pairs)
+		}
+	})
+	t.Run("edge odd token count is error", func(t *testing.T) {
+		s, _ := NewSource("a b c")
+		if _, err := DeleteEdgeParam(s); err == nil {
+			t.Errorf("DeleteEdgeParam(odd) = nil, want error")
+		}
+	})
+}
+
+// TestScanParam_Kwargs pins the #679 scan paging kwargs: an optional
+// positional limit followed by all=<bool> (vertices) and head=<prefix> +
+// all=<bool> (edges).
+func TestScanParam_Kwargs(t *testing.T) {
+	t.Run("vertices limit and all", func(t *testing.T) {
+		s, _ := NewSource("users/ 100 all=true")
+		m, err := ScanVerticesParam(s)
+		if err != nil {
+			t.Fatalf("ScanVerticesParam: %v", err)
+		}
+		if m.Prefix != "users/" || m.Limit != 100 || !m.All {
+			t.Errorf("got {%q, %d, %v}", m.Prefix, m.Limit, m.All)
+		}
+	})
+	t.Run("vertices unknown kwarg is error", func(t *testing.T) {
+		s, _ := NewSource("users/ bogus=1")
+		if _, err := ScanVerticesParam(s); err == nil {
+			t.Errorf("ScanVerticesParam(bogus) = nil, want error")
+		}
+	})
+	t.Run("vertices non-bool all is error", func(t *testing.T) {
+		s, _ := NewSource("users/ all=maybe")
+		if _, err := ScanVerticesParam(s); err == nil {
+			t.Errorf("ScanVerticesParam(all=maybe) = nil, want error")
+		}
+	})
+	t.Run("edges head and all", func(t *testing.T) {
+		s, _ := NewSource("alice 50 head=post: all=true")
+		m, err := ScanEdgesParam(s)
+		if err != nil {
+			t.Fatalf("ScanEdgesParam: %v", err)
+		}
+		if m.TailPrefix != "alice" || m.Limit != 50 || m.HeadPrefix != "post:" || !m.All {
+			t.Errorf("got {%q, %d, %q, %v}", m.TailPrefix, m.Limit, m.HeadPrefix, m.All)
+		}
+	})
+	t.Run("edges empty head is error", func(t *testing.T) {
+		s, _ := NewSource("alice head=")
+		if _, err := ScanEdgesParam(s); err == nil {
+			t.Errorf("ScanEdgesParam(head=) = nil, want error")
+		}
+	})
+}
+
+// TestCountVerticesParam pins `count vertices <prefix>` — exactly one prefix
+// and nothing else (#679).
+func TestCountVerticesParam(t *testing.T) {
+	t.Run("prefix", func(t *testing.T) {
+		s, _ := NewSource("users/")
+		m, err := CountVerticesParam(s)
+		if err != nil {
+			t.Fatalf("CountVerticesParam: %v", err)
+		}
+		if m.Prefix != "users/" {
+			t.Errorf("Prefix = %q, want users/", m.Prefix)
+		}
+	})
+	t.Run("missing prefix is error", func(t *testing.T) {
+		s, _ := NewSource("")
+		if _, err := CountVerticesParam(s); err == nil {
+			t.Errorf("CountVerticesParam(empty) = nil, want error")
+		}
+	})
+	t.Run("trailing token is error", func(t *testing.T) {
+		s, _ := NewSource("users/ extra")
+		if _, err := CountVerticesParam(s); err == nil {
+			t.Errorf("CountVerticesParam(extra) = nil, want error")
+		}
+	})
+}
+
+// TestDeletePrefixVerticesParam pins the #679 destructive-op safety gate:
+// exactly one of confirm=yes / dry_run=true is required.
+func TestDeletePrefixVerticesParam(t *testing.T) {
+	t.Run("confirm yes", func(t *testing.T) {
+		s, _ := NewSource("tmp/ confirm=yes")
+		m, err := DeletePrefixVerticesParam(s)
+		if err != nil {
+			t.Fatalf("DeletePrefixVerticesParam: %v", err)
+		}
+		if m.Prefix != "tmp/" || !m.Confirm || m.DryRun {
+			t.Errorf("got {%q confirm=%v dry=%v}", m.Prefix, m.Confirm, m.DryRun)
+		}
+	})
+	t.Run("dry_run with limit", func(t *testing.T) {
+		s, _ := NewSource("tmp/ dry_run=true limit=500")
+		m, err := DeletePrefixVerticesParam(s)
+		if err != nil {
+			t.Fatalf("DeletePrefixVerticesParam: %v", err)
+		}
+		if !m.DryRun || m.Limit != 500 {
+			t.Errorf("got dry=%v limit=%d", m.DryRun, m.Limit)
+		}
+	})
+	t.Run("no gate is error", func(t *testing.T) {
+		s, _ := NewSource("tmp/")
+		if _, err := DeletePrefixVerticesParam(s); err == nil {
+			t.Errorf("DeletePrefixVerticesParam(no gate) = nil, want error")
+		}
+	})
+	t.Run("both gates is error", func(t *testing.T) {
+		s, _ := NewSource("tmp/ confirm=yes dry_run=true")
+		if _, err := DeletePrefixVerticesParam(s); err == nil {
+			t.Errorf("DeletePrefixVerticesParam(both) = nil, want error")
+		}
+	})
+	t.Run("confirm not yes is error", func(t *testing.T) {
+		s, _ := NewSource("tmp/ confirm=no")
+		if _, err := DeletePrefixVerticesParam(s); err == nil {
+			t.Errorf("DeletePrefixVerticesParam(confirm=no) = nil, want error")
+		}
+	})
+}
+
 // TestParam_OmittedTTLIsPermanent pins the opt-in decay contract (#523)
 // for the REPL grammar: a write that omits ttl_seconds leaves TTL at its
 // zero value (forwarded to the SDK as "permanent"), while an explicit

--- a/cli/parser/validate.go
+++ b/cli/parser/validate.go
@@ -99,6 +99,32 @@ func Validate(input string) error {
 		default:
 			return errors.New("usage: scan { vertices | edges } ... ")
 		}
+	case "count":
+		o, err := ScanObjective(s)
+		if err != nil {
+			return errors.New("usage: count vertices <prefix: string>")
+		}
+		switch o {
+		case "vertices":
+			if _, err := CountVerticesParam(s); err != nil {
+				return errors.New("usage: count vertices <prefix: string>")
+			}
+		default:
+			return errors.New("usage: count vertices <prefix: string>")
+		}
+	case "delete-prefix":
+		o, err := ScanObjective(s)
+		if err != nil {
+			return errors.New("usage: delete-prefix vertices <prefix: string> [limit=<int>] [confirm=yes|dry_run=true]")
+		}
+		switch o {
+		case "vertices":
+			if _, err := DeletePrefixVerticesParam(s); err != nil {
+				return errors.New("usage: delete-prefix vertices <prefix: string> [limit=<int>] [confirm=yes|dry_run=true]")
+			}
+		default:
+			return errors.New("usage: delete-prefix vertices <prefix: string> [limit=<int>] [confirm=yes|dry_run=true]")
+		}
 	case "keys":
 		if _, err := KeysParam(s); err != nil {
 			return errors.New("usage: keys <prefix: string> [<limit: int>]")

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -25,6 +25,8 @@ var (
 	ErrDeleteEdge       = errors.New("delete edge error")
 	ErrAddEdge          = errors.New("add edge error")
 	ErrScan             = errors.New("scan error")
+	ErrCount            = errors.New("count error")
+	ErrDeletePrefix     = errors.New("delete-prefix error")
 	ErrKeys             = errors.New("keys error")
 	ErrIlluminate       = errors.New("illuminate error")
 	ErrConnection       = errors.New("connection error")
@@ -180,10 +182,19 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 				fmt.Printf("Error: %s\n", err)
 				return ErrDeleteVertex
 			}
-			if _, err := c.client.DeleteVertex(ctx, p.Key); err != nil {
+			if len(p.Keys) == 1 {
+				if _, err := c.client.DeleteVertex(ctx, p.Keys[0]); err != nil {
+					fmt.Printf("Error: %s\n", err)
+					return ErrConnection
+				}
+				return nil
+			}
+			n, err := c.client.DeleteVertices(ctx, p.Keys)
+			if err != nil {
 				fmt.Printf("Error: %s\n", err)
 				return ErrConnection
 			}
+			fmt.Printf("OK %d\n", n)
 			return nil
 
 		case "edge":
@@ -192,10 +203,23 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 				fmt.Printf("Error: %s\n", err)
 				return ErrDeleteEdge
 			}
-			if _, err := c.client.DeleteEdge(ctx, p.Tail, p.Head); err != nil {
+			if len(p.Pairs) == 1 {
+				if _, err := c.client.DeleteEdge(ctx, p.Pairs[0].Tail, p.Pairs[0].Head); err != nil {
+					fmt.Printf("Error: %s\n", err)
+					return ErrConnection
+				}
+				return nil
+			}
+			refs := make([]client.EdgeRef, len(p.Pairs))
+			for i, pr := range p.Pairs {
+				refs[i] = client.EdgeRef{Tail: pr.Tail, Head: pr.Head}
+			}
+			n, err := c.client.DeleteEdges(ctx, refs)
+			if err != nil {
 				fmt.Printf("Error: %s\n", err)
 				return ErrConnection
 			}
+			fmt.Printf("OK %d\n", n)
 			return nil
 		default:
 			return ErrInvalidObjective
@@ -214,9 +238,27 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 				fmt.Printf("Error: %s\n", err)
 				return ErrScan
 			}
-			opts := []client.ScanOption{}
+			var limit uint32
 			if p.Limit > 0 && p.Limit <= math.MaxUint32 {
-				opts = append(opts, client.WithScanLimit(uint32(p.Limit)))
+				limit = uint32(p.Limit)
+			}
+			if p.All {
+				var all []*client.Vertex
+				for batch, err := range c.client.ScanVerticesAll(ctx, p.Prefix, limit) {
+					if err != nil {
+						fmt.Printf("Error: %s\n", err)
+						return ErrConnection
+					}
+					all = append(all, batch...)
+				}
+				if jsonString, err := json.MarshalIndent(all, "", "\t"); err == nil {
+					fmt.Println(string(jsonString))
+				}
+				return nil
+			}
+			opts := []client.ScanOption{}
+			if limit > 0 {
+				opts = append(opts, client.WithScanLimit(limit))
 			}
 			vs, _, err := c.client.ScanVertices(ctx, p.Prefix, opts...)
 			if err != nil {
@@ -233,9 +275,31 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 				fmt.Printf("Error: %s\n", err)
 				return ErrScan
 			}
-			opts := []client.EdgeScanOption{client.WithEdgeScanTailPrefix(p.TailPrefix)}
+			var limit uint32
 			if p.Limit > 0 && p.Limit <= math.MaxUint32 {
-				opts = append(opts, client.WithEdgeScanLimit(uint32(p.Limit)))
+				limit = uint32(p.Limit)
+			}
+			baseOpts := []client.EdgeScanOption{client.WithEdgeScanTailPrefix(p.TailPrefix)}
+			if p.HeadPrefix != "" {
+				baseOpts = append(baseOpts, client.WithEdgeScanHeadPrefix(p.HeadPrefix))
+			}
+			if p.All {
+				var all []*client.Edge
+				for batch, err := range c.client.ScanEdgesAll(ctx, limit, baseOpts...) {
+					if err != nil {
+						fmt.Printf("Error: %s\n", err)
+						return ErrConnection
+					}
+					all = append(all, batch...)
+				}
+				if jsonString, err := json.MarshalIndent(all, "", "\t"); err == nil {
+					fmt.Println(string(jsonString))
+				}
+				return nil
+			}
+			opts := append([]client.EdgeScanOption{}, baseOpts...)
+			if limit > 0 {
+				opts = append(opts, client.WithEdgeScanLimit(limit))
 			}
 			es, _, err := c.client.ScanEdges(ctx, opts...)
 			if err != nil {
@@ -249,6 +313,61 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 		default:
 			return ErrInvalidObjective
 		}
+
+	case "count":
+		obj, err := parser.ScanObjective(s)
+		if err != nil {
+			fmt.Printf("Error: %s\n", err)
+			return ErrInvalidObjective
+		}
+		if obj != "vertices" {
+			return ErrInvalidObjective
+		}
+		p, err := parser.CountVerticesParam(s)
+		if err != nil {
+			fmt.Printf("Error: %s\n", err)
+			return ErrCount
+		}
+		n, err := c.client.CountVerticesByPrefix(ctx, p.Prefix)
+		if err != nil {
+			fmt.Printf("Error: %s\n", err)
+			return ErrConnection
+		}
+		fmt.Printf("%d\n", n)
+		return nil
+
+	case "delete-prefix":
+		obj, err := parser.ScanObjective(s)
+		if err != nil {
+			fmt.Printf("Error: %s\n", err)
+			return ErrInvalidObjective
+		}
+		if obj != "vertices" {
+			return ErrInvalidObjective
+		}
+		p, err := parser.DeletePrefixVerticesParam(s)
+		if err != nil {
+			fmt.Printf("Error: %s\n", err)
+			return ErrDeletePrefix
+		}
+		opts := []client.DeleteByPrefixOption{}
+		if p.Limit > 0 && p.Limit <= math.MaxUint32 {
+			opts = append(opts, client.WithDeleteByPrefixLimit(uint32(p.Limit)))
+		}
+		if p.DryRun {
+			opts = append(opts, client.WithDryRun())
+		}
+		n, err := c.client.DeleteVerticesByPrefix(ctx, p.Prefix, opts...)
+		if err != nil {
+			fmt.Printf("Error: %s\n", err)
+			return ErrConnection
+		}
+		word := "deleted"
+		if p.DryRun {
+			word = "would delete"
+		}
+		fmt.Printf("%s %d\n", word, n)
+		return nil
 
 	case "keys":
 		p, err := parser.KeysParam(s)


### PR DESCRIPTION
## What

First increment of #679 (unify the CLI on the verb-first grammar). Brings the
shared verb-first grammar — the `lantern repl` prompt and the `lantern <verb> …`
one-liners, which share one parser + dispatcher — to feature parity with the
noun-first `vertex`/`edge` subcommands, so those can be removed later without
losing functionality.

New grammar (additive — nothing removed yet):

```
delete vertex <key> [<key> ...]                  # variadic batch → DeleteVertices
delete edge   <tail> <head> [<tail> <head> ...]  # variadic pairs  → DeleteEdges
scan   vertices <prefix> [limit] [all=true]
scan   edges    <tail-prefix> [limit] [head=<prefix>] [all=true]
count  vertices <prefix>
delete-prefix vertices <prefix> [limit=<int>] [confirm=yes|dry_run=true]
```

| migrated capability | was (noun-first) | now (verb-first) |
|---|---|---|
| count by prefix | `vertex count <p>` | `count vertices <p>` |
| destructive prefix delete | `vertex delete-prefix … --dry-run/--yes` | `delete-prefix vertices <p> dry_run=true \| confirm=yes` |
| batch vertex delete | `vertex delete a b c` | `delete vertex a b c` |
| batch edge delete | `edge delete a:b c:d` | `delete edge a b c d` |
| scan all pages | `… scan --all` | `scan … all=true` |
| edge head filter | `edge scan --head-prefix` | `scan edges <tail> head=<prefix>` |

The `delete-prefix` safety gate is preserved in the grammar: exactly one of
`confirm=yes` or `dry_run=true` is **required** (a bare `delete-prefix vertices p`
is rejected, as is setting both).

## Scope

Go only — `cli/parser` (`model.go`, `parser.go`, `validate.go`, `HelpText`),
`cli/service/service.go` (dispatcher), `cli/cmd/grammar.go` (the two new
one-liner commands + updated `delete`/`scan` help). Deferred to follow-ups under
#679:

- the admin web `/cli` mirror + the shared `admin/test/cli-grammar/verbs.json`
  fixture entries (kept untouched here so admin CI stays green);
- the `put vertex … type=<...>` value-type kwarg;
- removing the now-redundant noun-first `vertex`/`edge` cobra trees.

## Testing

`gofmt -l` clean; `go build ./...`, `go vet ./cli/...`, and the full root module
`go test ./...` (incl. `tests/integration`) all pass. New table tests cover the
batch-delete, scan-kwarg, count, and delete-prefix parsers (including the
safety-gate rejections); the existing shared-grammar fixture still passes
against the unchanged `verbs.json`.

Part of #679.
