### PR TITLE
chore(ci): pin govulncheck to v1.3.0 (x/tools v0.46.0 generics panic)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -149,7 +149,13 @@ jobs:
           go-version: '1.26.4'
           check-latest: true
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        # Pinned to v1.3.0: govulncheck@latest (v1.4.0) builds against
+        # golang.org/x/tools v0.46.0, which panics with
+        # "ForEachElement called on type containing *types.TypeParam" while
+        # analysing the generics in core/ and server/ (verified locally:
+        # v1.4.0 panics, v1.3.0 is clean on all six modules). Re-float to
+        # @latest once a fixed x/tools ships.
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
       - name: Run govulncheck (all modules)
         run: |
           set -e


### PR DESCRIPTION
## Problem

The required **govulncheck** check is failing on every open PR (and would fail
on `main` if its run were retried). The failure is an upstream toolchain
regression, **not** a vulnerability in this repo:

```
panic: ForEachElement called on type containing *types.TypeParam
```

`go install golang.org/x/vuln/cmd/govulncheck@latest` now resolves to
**v1.4.0**, which builds against **golang.org/x/tools v0.46.0**. That x/tools
release panics while analysing the generics in `core/` and `server/`. (A PR
run earlier today passed because `@latest` still resolved to the pre-v0.46.0
x/tools; the regression landed between then and now.)

## Verification (local, go 1.26.4)

Reproduced the exact CI loop `for mod in . core mcp pb sdks/go server`:

| govulncheck | result |
|---|---|
| `@latest` (v1.4.0, x/tools v0.46.0) | **panics** on `core` and `server` |
| `@v1.3.0` | `No vulnerabilities found.` on **all six** modules |

## Fix

Pin the install to `govulncheck@v1.3.0` (one line in
`.github/workflows/go.yml`), with a comment to re-float to `@latest` once a
fixed x/tools ships. This unblocks govulncheck for all PRs.

No code or dependency changes; CI-only.
