### PR TITLE
feat(cli): add the put-vertex type= value-type override to the verb-first grammar

### DIFF
--- a/admin/app/lib/cli/types.ts
+++ b/admin/app/lib/cli/types.ts
@@ -29,6 +29,7 @@ export type Command =
       key: string;
       value: string;
       ttlSeconds: number | null;
+      valueType: string;
     }
   | {
       verb: "put";

--- a/admin/app/lib/cli/verbs.test.ts
+++ b/admin/app/lib/cli/verbs.test.ts
@@ -369,4 +369,36 @@ describe("#679 grammar — count / delete-prefix / batch delete / scan paging", 
     ).toBe(false);
     expect(parse("delete-prefix vertices tmp/ confirm=no").ok).toBe(false);
   });
+
+  test("put vertex extracts the type= override and ttl in either order", () => {
+    expect(ok("put vertex k 1234 type=int")).toEqual({
+      verb: "put",
+      objective: "vertex",
+      key: "k",
+      value: "1234",
+      ttlSeconds: null,
+      valueType: "int",
+    });
+    expect(ok("put vertex k v 60 type=string")).toEqual({
+      verb: "put",
+      objective: "vertex",
+      key: "k",
+      value: "v",
+      ttlSeconds: 60,
+      valueType: "string",
+    });
+    expect(ok("put vertex k v")).toEqual({
+      verb: "put",
+      objective: "vertex",
+      key: "k",
+      value: "v",
+      ttlSeconds: null,
+      valueType: "auto",
+    });
+  });
+
+  test("put vertex rejects an unknown type and a bare type token", () => {
+    expect(parse("put vertex k v type=bogus").ok).toBe(false);
+    expect(parse("put vertex k v type").ok).toBe(false);
+  });
 });

--- a/admin/app/lib/cli/verbs.ts
+++ b/admin/app/lib/cli/verbs.ts
@@ -15,6 +15,21 @@ const ILL_ALGORITHMS = new Set<AlgorithmName>(["none", "mst", "spt"]);
 const ILL_OBJECTIVES = new Set<ObjectiveName>(["min", "max"]);
 const ILL_WEIGHTINGS = new Set<WeightingName>(["raw", "tfidf"]);
 
+// The value-type overrides accepted by `put vertex … type=` (migrated from
+// the noun-first `vertex put --value-type`). The grammar validates the type
+// NAME here; the value coercion itself happens in the dispatcher (the Go
+// REPL coerces at parse — a mismatch surfaces at execution on the web CLI).
+const VALUE_TYPES = new Set([
+  "auto",
+  "string",
+  "int",
+  "float",
+  "bool",
+  "datetime",
+  "duration",
+  "json",
+]);
+
 export function parseGet(rest: string[]): ParseResult {
   const [obj, ...args] = rest;
   const o = obj?.toLowerCase();
@@ -46,26 +61,38 @@ export function parsePut(rest: string[]): ParseResult {
   const [obj, ...args] = rest;
   const o = obj?.toLowerCase();
   if (o === "vertex") {
-    if (args.length < 2 || args.length > 3) {
-      return {
-        ok: false,
-        usage:
-          "usage: put vertex <key: string> <value: string|int|float|bool|datetime> [<ttl_seconds: int>]",
-      };
+    const usage =
+      "usage: put vertex <key: string> <value: string|int|float|bool|datetime> [<ttl_seconds: int>] [type=auto|string|int|float|bool|datetime|duration|json]";
+    if (args.length < 2) {
+      return { ok: false, usage };
     }
-    const [key, value, ttlTok] = args;
-    // Omitted ttl_seconds ⇒ permanent (no decay); only an explicit but
-    // malformed token is a usage error (#523).
+    const [key, value, ...tail] = args;
+    // Omitted ttl_seconds ⇒ permanent (no decay) (#523); the optional
+    // positional ttl and the type= kwarg may appear in either order.
     let ttlSeconds: number | null = null;
-    if (ttlTok !== undefined) {
-      ttlSeconds = parseInt10(ttlTok);
-      if (ttlSeconds === null) {
-        return {
-          ok: false,
-          usage:
-            "usage: put vertex <key: string> <value: string|int|float|bool|datetime> [<ttl_seconds: int>]",
-        };
+    let ttlSet = false;
+    let valueType = "auto";
+    for (const tok of tail) {
+      const eq = tok.indexOf("=");
+      if (eq >= 0) {
+        if (tok.slice(0, eq).toLowerCase() !== "type") {
+          return { ok: false, usage };
+        }
+        valueType = tok.slice(eq + 1).toLowerCase();
+        continue;
       }
+      if (ttlSet) {
+        return { ok: false, usage };
+      }
+      const n = parseInt10(tok);
+      if (n === null) {
+        return { ok: false, usage };
+      }
+      ttlSeconds = n;
+      ttlSet = true;
+    }
+    if (!VALUE_TYPES.has(valueType)) {
+      return { ok: false, usage };
     }
     return {
       ok: true,
@@ -75,6 +102,7 @@ export function parsePut(rest: string[]): ParseResult {
         key,
         value,
         ttlSeconds,
+        valueType,
       },
     };
   }
@@ -477,7 +505,7 @@ export const HELP_TEXT = [
   "",
   "  get    vertex <key: string>",
   "  get    edge   <tail: string> <head: string>",
-  "  put    vertex <key: string> <value: string|int|float|bool|datetime> [<ttl_seconds: int>]",
+  "  put    vertex <key: string> <value: string|int|float|bool|datetime> [<ttl_seconds: int>] [type=auto|string|int|float|bool|datetime|duration|json]",
   "  put    edge   <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
   "  add    edge   <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
   "  delete vertex <key: string> [<key: string> ...]",
@@ -539,9 +567,9 @@ export const CLI_COMMAND_REFERENCE: readonly CliCommandDoc[] = [
   {
     group: "Vertices",
     verb: "put",
-    signature: "put vertex <key> <value> [ttl]",
+    signature: "put vertex <key> <value> [ttl] [type=...]",
     summary:
-      "Create or replace a vertex. Value is typed (string / int / float / bool / datetime); TTL seconds optional.",
+      "Create or replace a vertex; value is auto-typed, or forced with type= (string/int/float/bool/datetime/duration/json). TTL seconds optional.",
     example: "put vertex alice Alice 3600",
   },
   {

--- a/admin/app/lib/client/usecase/cli/dispatcher.test.ts
+++ b/admin/app/lib/client/usecase/cli/dispatcher.test.ts
@@ -154,6 +154,25 @@ describe("coerceValue (#428 cascade matches Go cli/parser Value())", () => {
       string: "2024-01-02T03:04",
     });
   });
+
+  test("#679 type= forces the value field (and rejects a mismatch)", () => {
+    expect(coerceValue("123", "string")).toEqual({ string: "123" });
+    expect(coerceValue("007", "string")).toEqual({ string: "007" });
+    expect(coerceValue("42", "int")).toEqual({ int64: "42" });
+    expect(coerceValue("3.5", "float")).toEqual({ float64: 3.5 });
+    expect(coerceValue("true", "bool")).toEqual({ bool: true });
+    expect(coerceValue("2024-01-02T03:04:05Z", "datetime")).toEqual({
+      timestamp: "2024-01-02T03:04:05Z",
+    });
+    expect(coerceValue("30s", "duration")).toEqual({ duration: "30s" });
+    // json objects re-encode to a compact string; json scalars coerce naturally.
+    expect(coerceValue('{"a":1}', "json")).toEqual({ string: '{"a":1}' });
+    expect(coerceValue("true", "json")).toEqual({ bool: true });
+    // a value that does not match its forced type throws.
+    expect(() => coerceValue("abc", "int")).toThrow();
+    expect(() => coerceValue("abc", "datetime")).toThrow();
+    expect(() => coerceValue("{bad", "json")).toThrow();
+  });
 });
 
 describe("ttlSecondsToExpiration (#429, #523)", () => {
@@ -187,6 +206,7 @@ describe("dispatch put vertex (#428 + #429)", () => {
       key: "answer",
       value: "42",
       ttlSeconds: 120,
+      valueType: "auto",
     };
     const before = Date.now();
     await dispatch({ client: asClient(fake), command: cmd });
@@ -215,6 +235,7 @@ describe("dispatch put vertex (#428 + #429)", () => {
       key: "greeting",
       value: "hello",
       ttlSeconds: 60,
+      valueType: "auto",
     };
     await dispatch({ client: asClient(fake), command: cmd });
     const call = fake.calls.find((c) => c.method === "putVertex");
@@ -236,6 +257,7 @@ describe("dispatch put vertex (#428 + #429)", () => {
       key: "flag",
       value: "true",
       ttlSeconds: 60,
+      valueType: "auto",
     };
     await dispatch({ client: asClient(fake), command: cmd });
     const call = fake.calls.find((c) => c.method === "putVertex");
@@ -252,6 +274,7 @@ describe("dispatch put vertex (#428 + #429)", () => {
       key: "pi",
       value: "3.14",
       ttlSeconds: 60,
+      valueType: "auto",
     };
     await dispatch({ client: asClient(fake), command: cmd });
     const call = fake.calls.find((c) => c.method === "putVertex");
@@ -268,6 +291,7 @@ describe("dispatch put vertex (#428 + #429)", () => {
       key: "when",
       value: "2024-01-02T03:04:05Z",
       ttlSeconds: 60,
+      valueType: "auto",
     };
     await dispatch({ client: asClient(fake), command: cmd });
     const call = fake.calls.find((c) => c.method === "putVertex");
@@ -338,6 +362,7 @@ describe("dispatch write echo surfaces the applied TTL/expiry (#653)", () => {
       key: "a",
       value: "a",
       ttlSeconds: 1,
+      valueType: "auto",
     };
     const before = Date.now();
     const out = (await dispatch({ client: asClient(fake), command: cmd })) as {
@@ -363,6 +388,7 @@ describe("dispatch write echo surfaces the applied TTL/expiry (#653)", () => {
       key: "permkey",
       value: "permval",
       ttlSeconds: null,
+      valueType: "auto",
     };
     const out = await dispatch({ client: asClient(fake), command: cmd });
     expect(out).toEqual({ key: "permkey", ttlSeconds: null, expiresAt: null });

--- a/admin/app/lib/client/usecase/cli/dispatcher.ts
+++ b/admin/app/lib/client/usecase/cli/dispatcher.ts
@@ -123,7 +123,7 @@ export async function dispatch(input: DispatchInput): Promise<unknown> {
         const expiration = ttlSecondsToExpiration(command.ttlSeconds);
         const vertex: Vertex = {
           key: command.key,
-          ...coerceValue(command.value),
+          ...coerceValue(command.value, command.valueType),
           expiration,
         };
         await putVertex(client, command.key, { vertex }, { signal });
@@ -341,23 +341,73 @@ const FALSE_TOKENS = new Set(["0", "f", "F", "FALSE", "false", "False"]);
  */
 export function coerceValue(
   raw: string,
-): Pick<Vertex, "string" | "int64" | "float64" | "bool" | "timestamp"> {
-  if (INT_RE.test(raw)) {
-    return { int64: raw };
+  valueType: string = "auto",
+): Pick<
+  Vertex,
+  "string" | "int64" | "float64" | "bool" | "timestamp" | "duration"
+> {
+  switch (valueType) {
+    case "":
+    case "auto":
+      if (INT_RE.test(raw)) return { int64: raw };
+      if (FLOAT_RE.test(raw)) return { float64: Number.parseFloat(raw) };
+      if (TRUE_TOKENS.has(raw)) return { bool: true };
+      if (FALSE_TOKENS.has(raw)) return { bool: false };
+      if (RFC3339_RE.test(raw) && !Number.isNaN(Date.parse(raw)))
+        return { timestamp: raw };
+      return { string: raw };
+    case "string":
+      return { string: raw };
+    case "int":
+      if (!INT_RE.test(raw)) throw valueTypeError("int", raw);
+      return { int64: raw };
+    case "float":
+      if (!FLOAT_RE.test(raw)) throw valueTypeError("float", raw);
+      return { float64: Number.parseFloat(raw) };
+    case "bool":
+      if (TRUE_TOKENS.has(raw)) return { bool: true };
+      if (FALSE_TOKENS.has(raw)) return { bool: false };
+      throw valueTypeError("bool", raw);
+    case "datetime":
+      if (!RFC3339_RE.test(raw) || Number.isNaN(Date.parse(raw)))
+        throw valueTypeError("datetime", raw);
+      return { timestamp: raw };
+    case "duration":
+      return { duration: raw };
+    case "json":
+      return coerceJsonValue(raw);
+    default:
+      throw valueTypeError(valueType, raw);
   }
-  if (FLOAT_RE.test(raw)) {
-    return { float64: Number.parseFloat(raw) };
+}
+
+// A value that does not coerce to its forced `type=`. The Go REPL rejects
+// this at parse; on the web CLI the parser validates only the type NAME, so
+// the mismatch surfaces here at dispatch.
+function valueTypeError(typ: string, raw: string): Error {
+  return new Error(
+    `type=${typ}: cannot parse ${JSON.stringify(raw)} as ${typ}`,
+  );
+}
+
+// `type=json`: parse the token; objects / arrays / null re-encode as a
+// compact JSON string (the wire has no nested value variant), mirroring the
+// Go `parseValue`. JSON numbers are float64 (Go's encoding/json convention).
+function coerceJsonValue(
+  raw: string,
+): Pick<Vertex, "string" | "int64" | "float64" | "bool"> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`type=json: invalid JSON ${JSON.stringify(raw)}`);
   }
-  if (TRUE_TOKENS.has(raw)) {
-    return { bool: true };
+  if (parsed === null || typeof parsed === "object") {
+    return { string: JSON.stringify(parsed) };
   }
-  if (FALSE_TOKENS.has(raw)) {
-    return { bool: false };
-  }
-  if (RFC3339_RE.test(raw) && !Number.isNaN(Date.parse(raw))) {
-    return { timestamp: raw };
-  }
-  return { string: raw };
+  if (typeof parsed === "boolean") return { bool: parsed };
+  if (typeof parsed === "number") return { float64: parsed };
+  return { string: String(parsed) };
 }
 
 /**

--- a/admin/app/lib/client/usecase/cli/graph-view.test.ts
+++ b/admin/app/lib/client/usecase/cli/graph-view.test.ts
@@ -216,6 +216,7 @@ describe("commandResultToGraphView — non-graph verbs", () => {
       key: "alice",
       value: "wonderland",
       ttlSeconds: 0,
+      valueType: "auto",
     };
     expect(commandResultToGraphView(cmd, { ok: true })).toBeNull();
   });
@@ -276,6 +277,7 @@ describe("commandResultToGraphMerge", () => {
       key: "alice",
       value: "wonderland",
       ttlSeconds: 0,
+      valueType: "auto",
     };
     const merge = commandResultToGraphMerge(cmd)!;
     expect(merge.nodes).toHaveLength(1);
@@ -295,6 +297,7 @@ describe("commandResultToGraphMerge", () => {
       key: "n",
       value: "42",
       ttlSeconds: 0,
+      valueType: "auto",
     };
     const merge = commandResultToGraphMerge(cmd)!;
     expect(merge.nodes[0].vertex.int64).toBe("42");
@@ -390,6 +393,7 @@ describe("mergeGraphView", () => {
       key: "x",
       value: "1",
       ttlSeconds: 0,
+      valueType: "auto",
     })!;
     const view = mergeGraphView(null, merge);
     expect(view.nodes.map((n) => n.id)).toEqual(["x"]);
@@ -427,6 +431,7 @@ describe("mergeGraphView", () => {
       key: "c",
       value: "1",
       ttlSeconds: 0,
+      valueType: "auto",
     })!;
     const view = mergeGraphView(base, merge);
     expect(view.nodes.map((n) => n.id).sort()).toEqual(["a", "b", "c"]);
@@ -481,6 +486,7 @@ describe("mergeGraphView", () => {
         key: "a",
         value: "rich",
         ttlSeconds: 0,
+        valueType: "auto",
       })!,
     );
     const a1 = enriched.nodes.find((n) => n.id === "a")!;

--- a/admin/app/lib/client/usecase/cli/graph-view.ts
+++ b/admin/app/lib/client/usecase/cli/graph-view.ts
@@ -366,7 +366,7 @@ export function commandResultToGraphMerge(command: Command): GraphMerge | null {
   if (command.verb === "put" && command.objective === "vertex") {
     const vertex: Vertex = {
       key: command.key,
-      ...coerceValue(command.value),
+      ...coerceValue(command.value, command.valueType),
       expiration: ttlSecondsToExpiration(command.ttlSeconds),
     };
     return {

--- a/admin/app/lib/client/usecase/cli/reducer.test.ts
+++ b/admin/app/lib/client/usecase/cli/reducer.test.ts
@@ -177,6 +177,7 @@ describe("cliReducer", () => {
       key: "x",
       value: "1",
       ttlSeconds: 0,
+      valueType: "auto",
     };
     const putY: Command = {
       verb: "put",
@@ -184,6 +185,7 @@ describe("cliReducer", () => {
       key: "y",
       value: "1",
       ttlSeconds: 0,
+      valueType: "auto",
     };
 
     it("folds a put onto an empty canvas and records the source", () => {

--- a/admin/test/cli-grammar/verbs.json
+++ b/admin/test/cli-grammar/verbs.json
@@ -7,6 +7,18 @@
     { "input": "get edge alice bob" },
     { "input": "put vertex alice Alice" },
     { "input": "put vertex alice Alice 60", "comment": "with TTL" },
+    {
+      "input": "put vertex price 1234 type=int",
+      "comment": "#679: type= forces the value type"
+    },
+    {
+      "input": "put vertex name 007 type=string",
+      "comment": "#679: type=string keeps a numeric-looking value as a string"
+    },
+    {
+      "input": "put vertex alice Alice 60 type=string",
+      "comment": "#679: ttl and type= compose"
+    },
     { "input": "put edge alice bob 1.5" },
     { "input": "put edge alice bob 1.5 60" },
     { "input": "add edge alice bob 1.0" },
@@ -125,6 +137,14 @@
     { "input": "get vertex", "comment": "missing key" },
     { "input": "get edge alice", "comment": "missing head" },
     { "input": "put vertex", "comment": "missing key/value" },
+    {
+      "input": "put vertex k v type=bogus",
+      "comment": "#679: unknown value type"
+    },
+    {
+      "input": "put vertex k v type",
+      "comment": "#679: a bare type without =value is not a valid ttl token"
+    },
     {
       "input": "put edge alice bob notafloat",
       "comment": "non-numeric weight"

--- a/cli/parser/model.go
+++ b/cli/parser/model.go
@@ -11,10 +11,15 @@ type GetEdge struct {
 	Head string
 }
 
+// PutVertex backs `put vertex <key> <value> [ttl_seconds] [type=…]`. Type is
+// the optional value-type override migrated from `vertex put --value-type`:
+// "" / "auto" auto-detects (int→float→bool→RFC3339→string); otherwise one of
+// string|int|float|bool|datetime|duration|json.
 type PutVertex struct {
 	Key   string
 	Value any
 	TTL   time.Duration
+	Type  string
 }
 
 type PutEdge struct {

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -217,29 +218,123 @@ func GetEdgeParam(s *Source) (*GetEdge, error) {
 }
 
 func PutVertexParam(s *Source) (*PutVertex, error) {
-	var err error
-	m := &PutVertex{}
-	if m.Key, err = String(s); err != nil {
+	key, err := String(s)
+	if err != nil {
 		return nil, err
 	}
-	if m.Value, err = Value(s); err != nil {
+	raw, err := String(s)
+	if err != nil {
 		return nil, err
 	}
-	if err := EOF(s); err == nil {
-		// Omitted ttl_seconds ⇒ permanent (no decay). Leaving TTL at its
-		// zero value makes cli/service forward a ttl<=0 to the SDK, whose
-		// convenience methods send the wire's permanent sentinel (#523).
-		m.TTL = 0
-		return m, nil
+	m := &PutVertex{Key: key, Type: "auto"}
+	// After the positional key/value, an optional ttl_seconds (a bare
+	// integer, the REPL form) and an optional type= override may follow in
+	// either order — mirroring illuminate's positional-then-kwarg tail.
+	// Omitted ttl_seconds ⇒ permanent (no decay) (#523).
+	ttlSet := false
+	for s.HasNext() {
+		tok, err := String(s)
+		if err != nil {
+			return nil, err
+		}
+		if k, v, ok := strings.Cut(tok, "="); ok {
+			if strings.ToLower(k) != "type" {
+				return nil, fmt.Errorf("put vertex: unknown keyword %q", k)
+			}
+			m.Type = strings.ToLower(v)
+			continue
+		}
+		if ttlSet {
+			return nil, fmt.Errorf("put vertex: unexpected token %q", tok)
+		}
+		n, perr := strconv.Atoi(tok)
+		if perr != nil {
+			return nil, perr
+		}
+		m.TTL = time.Duration(n) * time.Second
+		ttlSet = true
 	}
-	if m.TTL, err = Duration(s); err != nil {
+	if m.Value, err = CoerceValue(raw, m.Type); err != nil {
 		return nil, err
 	}
-	if err := EOF(s); err != nil {
-		return nil, err
-	}
-
 	return m, nil
+}
+
+// CoerceValue converts a raw CLI value token into a Go value for PutVertex,
+// honouring the optional `type=` override (migrated from the noun-first
+// `vertex put --value-type`). "" / "auto" auto-detects
+// (int→float→bool→RFC3339→string); otherwise the named type is forced and a
+// mismatch is an error. `json` parses the token and re-encodes objects /
+// arrays as a compact JSON string (the wire has no nested value variant);
+// json scalars pass through as their natural Go type.
+func CoerceValue(raw, typ string) (any, error) {
+	switch typ {
+	case "", "auto":
+		if v, err := strconv.Atoi(raw); err == nil {
+			return v, nil
+		}
+		if v, err := strconv.ParseFloat(raw, 64); err == nil {
+			return v, nil
+		}
+		if v, err := strconv.ParseBool(raw); err == nil {
+			return v, nil
+		}
+		if v, err := time.Parse(time.RFC3339, raw); err == nil {
+			return v, nil
+		}
+		return raw, nil
+	case "string":
+		return raw, nil
+	case "int":
+		v, err := strconv.Atoi(raw)
+		if err != nil {
+			return nil, fmt.Errorf("type=int: %w", err)
+		}
+		return v, nil
+	case "float":
+		v, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return nil, fmt.Errorf("type=float: %w", err)
+		}
+		return v, nil
+	case "bool":
+		v, err := strconv.ParseBool(raw)
+		if err != nil {
+			return nil, fmt.Errorf("type=bool: %w", err)
+		}
+		return v, nil
+	case "datetime":
+		v, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			return nil, fmt.Errorf("type=datetime (RFC3339): %w", err)
+		}
+		return v, nil
+	case "duration":
+		v, err := time.ParseDuration(raw)
+		if err != nil {
+			return nil, fmt.Errorf("type=duration: %w", err)
+		}
+		return v, nil
+	case "json":
+		var v any
+		if err := json.Unmarshal([]byte(raw), &v); err != nil {
+			return nil, fmt.Errorf("type=json: %w", err)
+		}
+		// The wire format has no nested value variant; re-encode objects and
+		// arrays as a compact JSON string. Scalars forward as-is.
+		switch v.(type) {
+		case map[string]any, []any:
+			b, err := json.Marshal(v)
+			if err != nil {
+				return nil, fmt.Errorf("type=json re-encode: %w", err)
+			}
+			return string(b), nil
+		default:
+			return v, nil
+		}
+	default:
+		return nil, fmt.Errorf("unknown type %q (want auto|string|int|float|bool|datetime|duration|json)", typ)
+	}
 }
 
 func PutEdgeParam(s *Source) (*PutEdge, error) {
@@ -624,7 +719,7 @@ const HelpText = `Lantern CLI grammar:
 
   get    vertex <key: string>
   get    edge   <tail: string> <head: string>
-  put    vertex <key: string> <value: string|int|float|bool|datetime> [<ttl_seconds: int>]
+  put    vertex <key: string> <value: string|int|float|bool|datetime> [<ttl_seconds: int>] [type=auto|string|int|float|bool|datetime|duration|json]
   put    edge   <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]
   add    edge   <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]
   delete vertex <key: string> [<key: string> ...]

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -218,6 +218,65 @@ func TestDeletePrefixVerticesParam(t *testing.T) {
 	})
 }
 
+// TestPutVertexParam_Type pins the #679 type= value-type override migrated
+// from `vertex put --value-type`: auto by default, an explicit type forces
+// coercion (and rejects a mismatch), json re-encodes objects to a compact
+// string, and ttl_seconds composes with type= in either order.
+func TestPutVertexParam_Type(t *testing.T) {
+	t.Run("auto by default", func(t *testing.T) {
+		s, _ := NewSource("k 123")
+		m, err := PutVertexParam(s)
+		if err != nil {
+			t.Fatalf("PutVertexParam: %v", err)
+		}
+		if m.Value != 123 {
+			t.Errorf("Value = %v (%T), want int 123", m.Value, m.Value)
+		}
+	})
+	t.Run("type=string forces string", func(t *testing.T) {
+		s, _ := NewSource("k 123 type=string")
+		m, err := PutVertexParam(s)
+		if err != nil {
+			t.Fatalf("PutVertexParam: %v", err)
+		}
+		if m.Value != "123" {
+			t.Errorf("Value = %v (%T), want string 123", m.Value, m.Value)
+		}
+	})
+	t.Run("type=json re-encodes objects to a compact string", func(t *testing.T) {
+		s, _ := NewSource(`k '{"a":1}' type=json`)
+		m, err := PutVertexParam(s)
+		if err != nil {
+			t.Fatalf("PutVertexParam: %v", err)
+		}
+		if m.Value != `{"a":1}` {
+			t.Errorf("Value = %v, want compact json string", m.Value)
+		}
+	})
+	t.Run("ttl and type compose in either order", func(t *testing.T) {
+		s, _ := NewSource("k v 60 type=string")
+		m, err := PutVertexParam(s)
+		if err != nil {
+			t.Fatalf("PutVertexParam: %v", err)
+		}
+		if m.TTL != 60*time.Second || m.Value != "v" {
+			t.Errorf("got ttl=%v value=%v", m.TTL, m.Value)
+		}
+	})
+	t.Run("unknown type is error", func(t *testing.T) {
+		s, _ := NewSource("k v type=bogus")
+		if _, err := PutVertexParam(s); err == nil {
+			t.Errorf("type=bogus accepted, want error")
+		}
+	})
+	t.Run("unknown keyword is error", func(t *testing.T) {
+		s, _ := NewSource("k v foo=bar")
+		if _, err := PutVertexParam(s); err == nil {
+			t.Errorf("foo=bar accepted, want error")
+		}
+	})
+}
+
 // TestParam_OmittedTTLIsPermanent pins the opt-in decay contract (#523)
 // for the REPL grammar: a write that omits ttl_seconds leaves TTL at its
 // zero value (forwarded to the SDK as "permanent"), while an explicit


### PR DESCRIPTION
## What

Third increment of #679 (unify the CLI on the verb-first grammar). Migrates the
last noun-first-only capability — `vertex put --value-type` — into the
verb-first grammar as a `type=` kwarg, so forced value typing survives the
upcoming removal of the noun-first `vertex`/`edge` subcommands.

```
put vertex <key> <value> [ttl_seconds] [type=auto|string|int|float|bool|datetime|duration|json]
```

`auto` (the default) keeps the existing int→float→bool→RFC3339→string cascade;
an explicit `type=` forces the value field. `type=json` re-encodes objects /
arrays into a compact JSON string (the wire has no nested value variant).

## How

- **Go** (`cli/parser`): `PutVertex.Type`; `PutVertexParam` now reads the raw
  value + an optional `ttl_seconds` (positional) and `type=` (kwarg) in either
  order; `CoerceValue` performs the coercion (mirrors `cli/cmd/value.go`
  `parseValue`).
- **admin** (`app/lib/cli` + `usecase/cli`): `parsePut` accepts `type=` and
  validates the type NAME against `VALUE_TYPES`; the dispatcher `coerceValue`
  gains the forced types (including `duration` and `json`); the `Command` union,
  `HELP_TEXT` (byte-exact with `cli/parser/parser.go`), and
  `CLI_COMMAND_REFERENCE` are updated.
- **Fixture**: `admin/test/cli-grammar/verbs.json` gains `type=` valid/invalid
  cases, read by both the Go and Bun parser tests.

### A deliberate, fixture-safe asymmetry

The Go REPL coerces at parse, so it rejects a value/type **mismatch**
(`put vertex k abc type=int`) up front. The web CLI parser validates only the
type *name* and coerces at dispatch, so the same mismatch surfaces as a runtime
error in the scrollback. Both ultimately reject it — just at different stages.
The shared fixture therefore only exercises **type-name validity** and
**coercion-success** cases, so the two parsers never disagree on a fixture
entry.

## Testing

Go `cli/parser` tests (incl. new `type=` cases) pass; admin `bun run test` 660
pass; `typecheck` / `lint` (0 errors) / `format` / `build` clean. The Go
`grammar_fixture_test.go` and the admin `grammar.test.ts` both accept/reject the
new fixture entries (cross-language agreement verified locally).

Part of #679.
