### PR TITLE
feat(core): add GraphCache.SnapshotGraph() whole-graph single-lock snapshot

### DIFF
--- a/core/graphcache/snapshot.go
+++ b/core/graphcache/snapshot.go
@@ -41,6 +41,15 @@ type SnapshotEdge[S comparable] struct {
 	Contributions []SnapshotContribution
 }
 
+// GraphSnapshot is the result of GraphCache.SnapshotGraph: every live
+// vertex and edge materialised under a single lock acquisition, so the two
+// slices reflect one point-in-time. The type is named GraphSnapshot (not
+// SnapshotGraph) so the SnapshotGraph name is free for the method.
+type GraphSnapshot[S comparable, T any] struct {
+	Vertices []SnapshotVertex[S, T]
+	Edges    []SnapshotEdge[S]
+}
+
 // SnapshotVertices returns a materialised snapshot of every live vertex
 // in the cache. The snapshot is taken under a single write-lock pass; the
 // returned slice is independent of the cache and safe to iterate without
@@ -53,6 +62,14 @@ type SnapshotEdge[S comparable] struct {
 func (c *GraphCache[S, T]) SnapshotVertices() []SnapshotVertex[S, T] {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	return c.snapshotVerticesLocked()
+}
+
+// snapshotVerticesLocked materialises every live vertex. The caller MUST
+// hold c.mu as a WRITE lock: it calls c.vertices.Flush(), which mutates the
+// cache, so a read lock is insufficient. Factored out so SnapshotGraph can
+// reuse it under a single lock acquisition.
+func (c *GraphCache[S, T]) snapshotVerticesLocked() []SnapshotVertex[S, T] {
 	c.vertices.Flush()
 	out := make([]SnapshotVertex[S, T], 0, c.vertices.Count())
 	c.vertices.Range(func(key S, value T, expiration time.Time) bool {
@@ -83,7 +100,13 @@ func (c *GraphCache[S, T]) SnapshotVertices() []SnapshotVertex[S, T] {
 func (c *GraphCache[S, T]) SnapshotEdges() []SnapshotEdge[S] {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	now := time.Now()
+	return c.snapshotEdgesLocked(time.Now())
+}
+
+// snapshotEdgesLocked materialises every live edge as of now. The caller
+// MUST hold c.mu (write lock — symmetric with snapshotVerticesLocked so
+// SnapshotGraph can take the lock once for both sides).
+func (c *GraphCache[S, T]) snapshotEdgesLocked(now time.Time) []SnapshotEdge[S] {
 	out := make([]SnapshotEdge[S], 0, c.edges.count())
 	c.edges.rangeBuckets(func(tail, head S, w *weight) bool {
 		contribs, ts, nonEmpty := w.snapshotEntry(now)
@@ -99,4 +122,26 @@ func (c *GraphCache[S, T]) SnapshotEdges() []SnapshotEdge[S] {
 		return true
 	})
 	return out
+}
+
+// SnapshotGraph returns a materialised whole-graph snapshot — every live
+// vertex and edge — taken under a SINGLE write-lock pass, so the vertex and
+// edge sides reflect the same instant. Calling SnapshotVertices and
+// SnapshotEdges separately locks twice and can observe a vertex/edge set
+// that never co-existed; SnapshotGraph closes that window, which is what a
+// whole-graph backup/restore needs.
+//
+// The returned slices are independent of the cache and safe to iterate
+// without further locking. Expired vertices and fully-decayed edges are
+// skipped, identical to the single-kind methods. Memory cost is O(live
+// vertices + live edges); like the single-kind snapshots it is intended for
+// bounded, infrequent operations (backup, replication bootstrap), not hot
+// read paths.
+func (c *GraphCache[S, T]) SnapshotGraph() GraphSnapshot[S, T] {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return GraphSnapshot[S, T]{
+		Vertices: c.snapshotVerticesLocked(),
+		Edges:    c.snapshotEdgesLocked(time.Now()),
+	}
 }

--- a/core/graphcache/snapshot_test.go
+++ b/core/graphcache/snapshot_test.go
@@ -1,0 +1,152 @@
+package graphcache
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+// vertexByKey indexes a vertex snapshot by key for order-independent
+// comparison (Range / rangeBuckets iteration order is unspecified).
+func vertexByKey(vs []SnapshotVertex[string, string]) map[string]SnapshotVertex[string, string] {
+	m := make(map[string]SnapshotVertex[string, string], len(vs))
+	for _, v := range vs {
+		m[v.Key] = v
+	}
+	return m
+}
+
+// edgeByEndpoints indexes an edge snapshot by (tail, head).
+func edgeByEndpoints(es []SnapshotEdge[string]) map[EdgeKey[string]]SnapshotEdge[string] {
+	m := make(map[EdgeKey[string]]SnapshotEdge[string], len(es))
+	for _, e := range es {
+		m[EdgeKey[string]{Tail: e.Tail, Head: e.Head}] = e
+	}
+	return m
+}
+
+func TestGraphCache_SnapshotGraph(t *testing.T) {
+	// SnapshotGraph must return exactly what SnapshotVertices and
+	// SnapshotEdges return — it is the same materialise logic taken under a
+	// single lock instead of two.
+	t.Run("MatchesSingleMethods", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Hour)
+		future := time.Now().Add(time.Hour)
+		c.PutVerticesWithExpiration([]VertexItem[string, string]{
+			{Key: "a", Value: "A", Expiration: future},
+			{Key: "b", Value: "B", Expiration: future},
+			{Key: "c", Value: "C", Expiration: future},
+		})
+		c.PutEdgesWithExpiration([]EdgeItem[string]{
+			{Tail: "a", Head: "b", Weight: 1.5, Expiration: future},
+			{Tail: "b", Head: "c", Weight: 2, Expiration: future},
+		})
+
+		got := c.SnapshotGraph()
+		wantV := c.SnapshotVertices()
+		wantE := c.SnapshotEdges()
+
+		if !reflect.DeepEqual(vertexByKey(got.Vertices), vertexByKey(wantV)) {
+			t.Errorf("SnapshotGraph().Vertices = %v, want (SnapshotVertices) %v", got.Vertices, wantV)
+		}
+		if !reflect.DeepEqual(edgeByEndpoints(got.Edges), edgeByEndpoints(wantE)) {
+			t.Errorf("SnapshotGraph().Edges = %v, want (SnapshotEdges) %v", got.Edges, wantE)
+		}
+		if len(got.Vertices) != 3 {
+			t.Errorf("got %d vertices, want 3", len(got.Vertices))
+		}
+		if len(got.Edges) != 2 {
+			t.Errorf("got %d edges, want 2", len(got.Edges))
+		}
+	})
+
+	t.Run("SkipsExpiredVerticesAndEdges", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Hour)
+		now := time.Now()
+		future := now.Add(time.Hour)
+		past := now.Add(-time.Hour)
+		c.PutVerticesWithExpiration([]VertexItem[string, string]{
+			{Key: "a", Value: "A", Expiration: future},
+			{Key: "b", Value: "B", Expiration: future},
+			{Key: "gone", Value: "X", Expiration: past},
+		})
+		c.PutEdgesWithExpiration([]EdgeItem[string]{
+			{Tail: "a", Head: "b", Weight: 1, Expiration: future},
+			{Tail: "b", Head: "gone", Weight: 1, Expiration: past},
+		})
+
+		got := c.SnapshotGraph()
+
+		vs := vertexByKey(got.Vertices)
+		if _, ok := vs["gone"]; ok {
+			t.Errorf("expired vertex 'gone' present in snapshot: %v", got.Vertices)
+		}
+		if _, ok := vs["a"]; !ok {
+			t.Errorf("live vertex 'a' missing from snapshot: %v", got.Vertices)
+		}
+		if len(got.Vertices) != 2 {
+			t.Errorf("got %d vertices, want 2 (a,b)", len(got.Vertices))
+		}
+
+		es := edgeByEndpoints(got.Edges)
+		if _, ok := es[EdgeKey[string]{Tail: "b", Head: "gone"}]; ok {
+			t.Errorf("expired edge b->gone present in snapshot: %v", got.Edges)
+		}
+		if _, ok := es[EdgeKey[string]{Tail: "a", Head: "b"}]; !ok {
+			t.Errorf("live edge a->b missing from snapshot: %v", got.Edges)
+		}
+		if len(got.Edges) != 1 {
+			t.Errorf("got %d edges, want 1 (a->b)", len(got.Edges))
+		}
+	})
+
+	t.Run("EmptyCache", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Hour)
+		got := c.SnapshotGraph()
+		if len(got.Vertices) != 0 {
+			t.Errorf("got %d vertices, want 0", len(got.Vertices))
+		}
+		if len(got.Edges) != 0 {
+			t.Errorf("got %d edges, want 0", len(got.Edges))
+		}
+	})
+
+	// Exercise SnapshotGraph's single-lock pass against concurrent writers.
+	// Run under -race (CI default) this catches a missing or wrong lock.
+	t.Run("ConcurrentWritesNoRace", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Hour)
+		future := time.Now().Add(time.Hour)
+		var wg sync.WaitGroup
+
+		for w := 0; w < 4; w++ {
+			wg.Add(1)
+			go func(w int) {
+				defer wg.Done()
+				key := string(rune('a' + w))
+				for i := 0; i < 200; i++ {
+					c.PutVerticesWithExpiration([]VertexItem[string, string]{
+						{Key: key, Value: "v", Expiration: future},
+					})
+					c.PutEdgesWithExpiration([]EdgeItem[string]{
+						{Tail: key, Head: "hub", Weight: 1, Expiration: future},
+					})
+				}
+			}(w)
+		}
+		for s := 0; s < 2; s++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for i := 0; i < 200; i++ {
+					_ = c.SnapshotGraph()
+				}
+			}()
+		}
+		wg.Wait()
+
+		if got := c.SnapshotGraph(); len(got.Vertices) == 0 {
+			t.Error("expected some vertices after concurrent writes")
+		}
+	})
+}


### PR DESCRIPTION
Closes #689. First deliverable of epic #685 (whole-graph backup/restore — core snapshot foundation).

## What

Adds `GraphCache.SnapshotGraph()` to `core/graphcache/snapshot.go`: materialises **every live vertex and edge under a single `c.mu` write-lock acquisition**, so the two sides reflect one point-in-time. `SnapshotVertices()` and `SnapshotEdges()` lock separately, so reading them in sequence can observe a vertex/edge set that never co-existed — `SnapshotGraph` closes that window (the foundation a whole-graph backup needs).

## How

- New `GraphSnapshot[S, T]{ Vertices; Edges }` result type (named `GraphSnapshot` so the method name `SnapshotGraph` stays free).
- Extracted lock-free `snapshotVerticesLocked` / `snapshotEdgesLocked` helpers; `SnapshotVertices` / `SnapshotEdges` now call them under their existing lock (no behaviour change), and `SnapshotGraph` calls both under one lock.
- **Write `Lock`, not `RLock`** — the vertex path calls `c.vertices.Flush()` (mutates), so a read lock is insufficient.

## Tests

New `core/graphcache/snapshot_test.go` (the source had no test pair): SnapshotGraph equivalence to the two single methods, expired vertex/edge skipping, empty cache, and a `-race` concurrent-writes guard. `go test -race ./graphcache/` green; full local gate (gofmt + core/server/root build+test) green.

## Scope

`core/` leaf module only. The proto `BackupRecord` / `BackupSnapshot` RPC, server handler, SDK consumer, and CLI/MCP wrappers remain **future** work tracked by epic #685.
