### PR TITLE
feat(server): BackupSnapshot whole-graph backup streaming RPC

### DIFF
--- a/pb/graph/v1/graph.pb.go
+++ b/pb/graph/v1/graph.pb.go
@@ -3343,6 +3343,140 @@ func (x *GetReplicationStatusResponse) GetPeers() []*ReplicationPeer {
 	return nil
 }
 
+// BackupSnapshotRequest parameterises a whole-graph backup stream.
+// vertex_prefix, when non-empty, restricts the backup to the induced
+// subgraph over vertices whose key has this prefix (an edge is included
+// only when BOTH endpoints match). Empty = the whole graph.
+type BackupSnapshotRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	VertexPrefix  string                 `protobuf:"bytes,1,opt,name=vertex_prefix,json=vertexPrefix,proto3" json:"vertex_prefix,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BackupSnapshotRequest) Reset() {
+	*x = BackupSnapshotRequest{}
+	mi := &file_graph_v1_graph_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BackupSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BackupSnapshotRequest) ProtoMessage() {}
+
+func (x *BackupSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BackupSnapshotRequest.ProtoReflect.Descriptor instead.
+func (*BackupSnapshotRequest) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{52}
+}
+
+func (x *BackupSnapshotRequest) GetVertexPrefix() string {
+	if x != nil {
+		return x.VertexPrefix
+	}
+	return ""
+}
+
+// BackupSnapshotResponse is one frame of the BackupSnapshot stream:
+// either a live vertex or a folded live edge (weight summed across
+// contributions, expiration = the furthest-future contribution). The two
+// kinds are interleaved; consumers route on the oneof.
+type BackupSnapshotResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Record:
+	//
+	//	*BackupSnapshotResponse_Vertex
+	//	*BackupSnapshotResponse_Edge
+	Record        isBackupSnapshotResponse_Record `protobuf_oneof:"record"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BackupSnapshotResponse) Reset() {
+	*x = BackupSnapshotResponse{}
+	mi := &file_graph_v1_graph_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BackupSnapshotResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BackupSnapshotResponse) ProtoMessage() {}
+
+func (x *BackupSnapshotResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BackupSnapshotResponse.ProtoReflect.Descriptor instead.
+func (*BackupSnapshotResponse) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *BackupSnapshotResponse) GetRecord() isBackupSnapshotResponse_Record {
+	if x != nil {
+		return x.Record
+	}
+	return nil
+}
+
+func (x *BackupSnapshotResponse) GetVertex() *Vertex {
+	if x != nil {
+		if x, ok := x.Record.(*BackupSnapshotResponse_Vertex); ok {
+			return x.Vertex
+		}
+	}
+	return nil
+}
+
+func (x *BackupSnapshotResponse) GetEdge() *Edge {
+	if x != nil {
+		if x, ok := x.Record.(*BackupSnapshotResponse_Edge); ok {
+			return x.Edge
+		}
+	}
+	return nil
+}
+
+type isBackupSnapshotResponse_Record interface {
+	isBackupSnapshotResponse_Record()
+}
+
+type BackupSnapshotResponse_Vertex struct {
+	Vertex *Vertex `protobuf:"bytes,1,opt,name=vertex,proto3,oneof"`
+}
+
+type BackupSnapshotResponse_Edge struct {
+	Edge *Edge `protobuf:"bytes,2,opt,name=edge,proto3,oneof"`
+}
+
+func (*BackupSnapshotResponse_Vertex) isBackupSnapshotResponse_Record() {}
+
+func (*BackupSnapshotResponse_Edge) isBackupSnapshotResponse_Record() {}
+
 var File_graph_v1_graph_proto protoreflect.FileDescriptor
 
 const file_graph_v1_graph_proto_rawDesc = "" +
@@ -3537,7 +3671,13 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\tlocal_now\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\blocalNow\x12\x18\n" +
 	"\aenabled\x18\x03 \x01(\bR\aenabled\x12/\n" +
 	"\x05peers\x18\n" +
-	" \x03(\v2\x19.graph.v1.ReplicationPeerR\x05peers*m\n" +
+	" \x03(\v2\x19.graph.v1.ReplicationPeerR\x05peers\"<\n" +
+	"\x15BackupSnapshotRequest\x12#\n" +
+	"\rvertex_prefix\x18\x01 \x01(\tR\fvertexPrefix\"t\n" +
+	"\x16BackupSnapshotResponse\x12*\n" +
+	"\x06vertex\x18\x01 \x01(\v2\x10.graph.v1.VertexH\x00R\x06vertex\x12$\n" +
+	"\x04edge\x18\x02 \x01(\v2\x0e.graph.v1.EdgeH\x00R\x04edgeB\b\n" +
+	"\x06record*m\n" +
 	"\tAlgorithm\x12\x19\n" +
 	"\x15ALGORITHM_UNSPECIFIED\x10\x00\x12#\n" +
 	"\x1fALGORITHM_MINIMUM_SPANNING_TREE\x10\x01\x12 \n" +
@@ -3549,7 +3689,7 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\tWeighting\x12\x19\n" +
 	"\x15WEIGHTING_UNSPECIFIED\x10\x00\x12\x11\n" +
 	"\rWEIGHTING_RAW\x10\x01\x12\x13\n" +
-	"\x0fWEIGHTING_TFIDF\x10\x022\x94\x0e\n" +
+	"\x0fWEIGHTING_TFIDF\x10\x022\xeb\x0e\n" +
 	"\x0eLanternService\x12G\n" +
 	"\n" +
 	"Illuminate\x12\x1b.graph.v1.IlluminateRequest\x1a\x1c.graph.v1.IlluminateResponse\x12D\n" +
@@ -3575,7 +3715,8 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"\vDeleteEdges\x12\x1c.graph.v1.DeleteEdgesRequest\x1a\x1d.graph.v1.DeleteEdgesResponse\x12D\n" +
 	"\tScanEdges\x12\x1a.graph.v1.ScanEdgesRequest\x1a\x1b.graph.v1.ScanEdgesResponse\x12V\n" +
 	"\x0fGetServerStatus\x12 .graph.v1.GetServerStatusRequest\x1a!.graph.v1.GetServerStatusResponse\x12e\n" +
-	"\x14GetReplicationStatus\x12%.graph.v1.GetReplicationStatusRequest\x1a&.graph.v1.GetReplicationStatusResponseB\x90\x01\n" +
+	"\x14GetReplicationStatus\x12%.graph.v1.GetReplicationStatusRequest\x1a&.graph.v1.GetReplicationStatusResponse\x12U\n" +
+	"\x0eBackupSnapshot\x12\x1f.graph.v1.BackupSnapshotRequest\x1a .graph.v1.BackupSnapshotResponse0\x01B\x90\x01\n" +
 	"\fcom.graph.v1B\n" +
 	"GraphProtoP\x01Z3github.com/anaregdesign/lantern/pb/graph/v1;graphv1\xa2\x02\x03GXX\xaa\x02\bGraph.V1\xca\x02\bGraph\\V1\xe2\x02\x14Graph\\V1\\GPBMetadata\xea\x02\tGraph::V1b\x06proto3"
 
@@ -3592,7 +3733,7 @@ func file_graph_v1_graph_proto_rawDescGZIP() []byte {
 }
 
 var file_graph_v1_graph_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_graph_v1_graph_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
+var file_graph_v1_graph_proto_msgTypes = make([]protoimpl.MessageInfo, 54)
 var file_graph_v1_graph_proto_goTypes = []any{
 	(Algorithm)(0),                         // 0: graph.v1.Algorithm
 	(Objective)(0),                         // 1: graph.v1.Objective
@@ -3650,14 +3791,16 @@ var file_graph_v1_graph_proto_goTypes = []any{
 	(*ReplicationPeer)(nil),                // 53: graph.v1.ReplicationPeer
 	(*GetReplicationStatusRequest)(nil),    // 54: graph.v1.GetReplicationStatusRequest
 	(*GetReplicationStatusResponse)(nil),   // 55: graph.v1.GetReplicationStatusResponse
-	(*timestamppb.Timestamp)(nil),          // 56: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),            // 57: google.protobuf.Duration
+	(*BackupSnapshotRequest)(nil),          // 56: graph.v1.BackupSnapshotRequest
+	(*BackupSnapshotResponse)(nil),         // 57: graph.v1.BackupSnapshotResponse
+	(*timestamppb.Timestamp)(nil),          // 58: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),            // 59: google.protobuf.Duration
 }
 var file_graph_v1_graph_proto_depIdxs = []int32{
-	56, // 0: graph.v1.Vertex.expiration:type_name -> google.protobuf.Timestamp
-	56, // 1: graph.v1.Vertex.timestamp:type_name -> google.protobuf.Timestamp
-	57, // 2: graph.v1.Vertex.duration:type_name -> google.protobuf.Duration
-	56, // 3: graph.v1.Edge.expiration:type_name -> google.protobuf.Timestamp
+	58, // 0: graph.v1.Vertex.expiration:type_name -> google.protobuf.Timestamp
+	58, // 1: graph.v1.Vertex.timestamp:type_name -> google.protobuf.Timestamp
+	59, // 2: graph.v1.Vertex.duration:type_name -> google.protobuf.Duration
+	58, // 3: graph.v1.Edge.expiration:type_name -> google.protobuf.Timestamp
 	4,  // 4: graph.v1.Graph.vertices:type_name -> graph.v1.Vertex
 	5,  // 5: graph.v1.Graph.edges:type_name -> graph.v1.Edge
 	0,  // 6: graph.v1.IlluminateRequest.algorithm:type_name -> graph.v1.Algorithm
@@ -3680,64 +3823,68 @@ var file_graph_v1_graph_proto_depIdxs = []int32{
 	5,  // 23: graph.v1.AddEdgesRequest.edges:type_name -> graph.v1.Edge
 	5,  // 24: graph.v1.PutEdgeRequest.edge:type_name -> graph.v1.Edge
 	5,  // 25: graph.v1.PutEdgesRequest.edges:type_name -> graph.v1.Edge
-	56, // 26: graph.v1.GetServerStatusResponse.started_at:type_name -> google.protobuf.Timestamp
-	57, // 27: graph.v1.GetServerStatusResponse.uptime:type_name -> google.protobuf.Duration
-	57, // 28: graph.v1.GetServerStatusResponse.default_ttl:type_name -> google.protobuf.Duration
+	58, // 26: graph.v1.GetServerStatusResponse.started_at:type_name -> google.protobuf.Timestamp
+	59, // 27: graph.v1.GetServerStatusResponse.uptime:type_name -> google.protobuf.Duration
+	59, // 28: graph.v1.GetServerStatusResponse.default_ttl:type_name -> google.protobuf.Duration
 	3,  // 29: graph.v1.ReplicationPeer.state:type_name -> graph.v1.ReplicationPeer.State
-	56, // 30: graph.v1.ReplicationPeer.last_event_at:type_name -> google.protobuf.Timestamp
-	56, // 31: graph.v1.GetReplicationStatusResponse.local_now:type_name -> google.protobuf.Timestamp
+	58, // 30: graph.v1.ReplicationPeer.last_event_at:type_name -> google.protobuf.Timestamp
+	58, // 31: graph.v1.GetReplicationStatusResponse.local_now:type_name -> google.protobuf.Timestamp
 	53, // 32: graph.v1.GetReplicationStatusResponse.peers:type_name -> graph.v1.ReplicationPeer
-	7,  // 33: graph.v1.LanternService.Illuminate:input_type -> graph.v1.IlluminateRequest
-	9,  // 34: graph.v1.LanternService.GetVertex:input_type -> graph.v1.GetVertexRequest
-	11, // 35: graph.v1.LanternService.GetVertices:input_type -> graph.v1.GetVerticesRequest
-	13, // 36: graph.v1.LanternService.PutVertex:input_type -> graph.v1.PutVertexRequest
-	15, // 37: graph.v1.LanternService.PutVertices:input_type -> graph.v1.PutVerticesRequest
-	17, // 38: graph.v1.LanternService.DeleteVertex:input_type -> graph.v1.DeleteVertexRequest
-	19, // 39: graph.v1.LanternService.DeleteVertices:input_type -> graph.v1.DeleteVerticesRequest
-	21, // 40: graph.v1.LanternService.ScanVertices:input_type -> graph.v1.ScanVerticesRequest
-	23, // 41: graph.v1.LanternService.ScanVertexKeys:input_type -> graph.v1.ScanVertexKeysRequest
-	25, // 42: graph.v1.LanternService.SearchVertices:input_type -> graph.v1.SearchVerticesRequest
-	28, // 43: graph.v1.LanternService.CountVerticesByPrefix:input_type -> graph.v1.CountVerticesByPrefixRequest
-	30, // 44: graph.v1.LanternService.DeleteVerticesByPrefix:input_type -> graph.v1.DeleteVerticesByPrefixRequest
-	32, // 45: graph.v1.LanternService.GetEdge:input_type -> graph.v1.GetEdgeRequest
-	34, // 46: graph.v1.LanternService.GetEdges:input_type -> graph.v1.GetEdgesRequest
-	43, // 47: graph.v1.LanternService.AddEdge:input_type -> graph.v1.AddEdgeRequest
-	45, // 48: graph.v1.LanternService.AddEdges:input_type -> graph.v1.AddEdgesRequest
-	47, // 49: graph.v1.LanternService.PutEdge:input_type -> graph.v1.PutEdgeRequest
-	49, // 50: graph.v1.LanternService.PutEdges:input_type -> graph.v1.PutEdgesRequest
-	36, // 51: graph.v1.LanternService.DeleteEdge:input_type -> graph.v1.DeleteEdgeRequest
-	41, // 52: graph.v1.LanternService.DeleteEdges:input_type -> graph.v1.DeleteEdgesRequest
-	39, // 53: graph.v1.LanternService.ScanEdges:input_type -> graph.v1.ScanEdgesRequest
-	51, // 54: graph.v1.LanternService.GetServerStatus:input_type -> graph.v1.GetServerStatusRequest
-	54, // 55: graph.v1.LanternService.GetReplicationStatus:input_type -> graph.v1.GetReplicationStatusRequest
-	8,  // 56: graph.v1.LanternService.Illuminate:output_type -> graph.v1.IlluminateResponse
-	10, // 57: graph.v1.LanternService.GetVertex:output_type -> graph.v1.GetVertexResponse
-	12, // 58: graph.v1.LanternService.GetVertices:output_type -> graph.v1.GetVerticesResponse
-	14, // 59: graph.v1.LanternService.PutVertex:output_type -> graph.v1.PutVertexResponse
-	16, // 60: graph.v1.LanternService.PutVertices:output_type -> graph.v1.PutVerticesResponse
-	18, // 61: graph.v1.LanternService.DeleteVertex:output_type -> graph.v1.DeleteVertexResponse
-	20, // 62: graph.v1.LanternService.DeleteVertices:output_type -> graph.v1.DeleteVerticesResponse
-	22, // 63: graph.v1.LanternService.ScanVertices:output_type -> graph.v1.ScanVerticesResponse
-	24, // 64: graph.v1.LanternService.ScanVertexKeys:output_type -> graph.v1.ScanVertexKeysResponse
-	26, // 65: graph.v1.LanternService.SearchVertices:output_type -> graph.v1.SearchVerticesResponse
-	29, // 66: graph.v1.LanternService.CountVerticesByPrefix:output_type -> graph.v1.CountVerticesByPrefixResponse
-	31, // 67: graph.v1.LanternService.DeleteVerticesByPrefix:output_type -> graph.v1.DeleteVerticesByPrefixResponse
-	33, // 68: graph.v1.LanternService.GetEdge:output_type -> graph.v1.GetEdgeResponse
-	35, // 69: graph.v1.LanternService.GetEdges:output_type -> graph.v1.GetEdgesResponse
-	44, // 70: graph.v1.LanternService.AddEdge:output_type -> graph.v1.AddEdgeResponse
-	46, // 71: graph.v1.LanternService.AddEdges:output_type -> graph.v1.AddEdgesResponse
-	48, // 72: graph.v1.LanternService.PutEdge:output_type -> graph.v1.PutEdgeResponse
-	50, // 73: graph.v1.LanternService.PutEdges:output_type -> graph.v1.PutEdgesResponse
-	37, // 74: graph.v1.LanternService.DeleteEdge:output_type -> graph.v1.DeleteEdgeResponse
-	42, // 75: graph.v1.LanternService.DeleteEdges:output_type -> graph.v1.DeleteEdgesResponse
-	40, // 76: graph.v1.LanternService.ScanEdges:output_type -> graph.v1.ScanEdgesResponse
-	52, // 77: graph.v1.LanternService.GetServerStatus:output_type -> graph.v1.GetServerStatusResponse
-	55, // 78: graph.v1.LanternService.GetReplicationStatus:output_type -> graph.v1.GetReplicationStatusResponse
-	56, // [56:79] is the sub-list for method output_type
-	33, // [33:56] is the sub-list for method input_type
-	33, // [33:33] is the sub-list for extension type_name
-	33, // [33:33] is the sub-list for extension extendee
-	0,  // [0:33] is the sub-list for field type_name
+	4,  // 33: graph.v1.BackupSnapshotResponse.vertex:type_name -> graph.v1.Vertex
+	5,  // 34: graph.v1.BackupSnapshotResponse.edge:type_name -> graph.v1.Edge
+	7,  // 35: graph.v1.LanternService.Illuminate:input_type -> graph.v1.IlluminateRequest
+	9,  // 36: graph.v1.LanternService.GetVertex:input_type -> graph.v1.GetVertexRequest
+	11, // 37: graph.v1.LanternService.GetVertices:input_type -> graph.v1.GetVerticesRequest
+	13, // 38: graph.v1.LanternService.PutVertex:input_type -> graph.v1.PutVertexRequest
+	15, // 39: graph.v1.LanternService.PutVertices:input_type -> graph.v1.PutVerticesRequest
+	17, // 40: graph.v1.LanternService.DeleteVertex:input_type -> graph.v1.DeleteVertexRequest
+	19, // 41: graph.v1.LanternService.DeleteVertices:input_type -> graph.v1.DeleteVerticesRequest
+	21, // 42: graph.v1.LanternService.ScanVertices:input_type -> graph.v1.ScanVerticesRequest
+	23, // 43: graph.v1.LanternService.ScanVertexKeys:input_type -> graph.v1.ScanVertexKeysRequest
+	25, // 44: graph.v1.LanternService.SearchVertices:input_type -> graph.v1.SearchVerticesRequest
+	28, // 45: graph.v1.LanternService.CountVerticesByPrefix:input_type -> graph.v1.CountVerticesByPrefixRequest
+	30, // 46: graph.v1.LanternService.DeleteVerticesByPrefix:input_type -> graph.v1.DeleteVerticesByPrefixRequest
+	32, // 47: graph.v1.LanternService.GetEdge:input_type -> graph.v1.GetEdgeRequest
+	34, // 48: graph.v1.LanternService.GetEdges:input_type -> graph.v1.GetEdgesRequest
+	43, // 49: graph.v1.LanternService.AddEdge:input_type -> graph.v1.AddEdgeRequest
+	45, // 50: graph.v1.LanternService.AddEdges:input_type -> graph.v1.AddEdgesRequest
+	47, // 51: graph.v1.LanternService.PutEdge:input_type -> graph.v1.PutEdgeRequest
+	49, // 52: graph.v1.LanternService.PutEdges:input_type -> graph.v1.PutEdgesRequest
+	36, // 53: graph.v1.LanternService.DeleteEdge:input_type -> graph.v1.DeleteEdgeRequest
+	41, // 54: graph.v1.LanternService.DeleteEdges:input_type -> graph.v1.DeleteEdgesRequest
+	39, // 55: graph.v1.LanternService.ScanEdges:input_type -> graph.v1.ScanEdgesRequest
+	51, // 56: graph.v1.LanternService.GetServerStatus:input_type -> graph.v1.GetServerStatusRequest
+	54, // 57: graph.v1.LanternService.GetReplicationStatus:input_type -> graph.v1.GetReplicationStatusRequest
+	56, // 58: graph.v1.LanternService.BackupSnapshot:input_type -> graph.v1.BackupSnapshotRequest
+	8,  // 59: graph.v1.LanternService.Illuminate:output_type -> graph.v1.IlluminateResponse
+	10, // 60: graph.v1.LanternService.GetVertex:output_type -> graph.v1.GetVertexResponse
+	12, // 61: graph.v1.LanternService.GetVertices:output_type -> graph.v1.GetVerticesResponse
+	14, // 62: graph.v1.LanternService.PutVertex:output_type -> graph.v1.PutVertexResponse
+	16, // 63: graph.v1.LanternService.PutVertices:output_type -> graph.v1.PutVerticesResponse
+	18, // 64: graph.v1.LanternService.DeleteVertex:output_type -> graph.v1.DeleteVertexResponse
+	20, // 65: graph.v1.LanternService.DeleteVertices:output_type -> graph.v1.DeleteVerticesResponse
+	22, // 66: graph.v1.LanternService.ScanVertices:output_type -> graph.v1.ScanVerticesResponse
+	24, // 67: graph.v1.LanternService.ScanVertexKeys:output_type -> graph.v1.ScanVertexKeysResponse
+	26, // 68: graph.v1.LanternService.SearchVertices:output_type -> graph.v1.SearchVerticesResponse
+	29, // 69: graph.v1.LanternService.CountVerticesByPrefix:output_type -> graph.v1.CountVerticesByPrefixResponse
+	31, // 70: graph.v1.LanternService.DeleteVerticesByPrefix:output_type -> graph.v1.DeleteVerticesByPrefixResponse
+	33, // 71: graph.v1.LanternService.GetEdge:output_type -> graph.v1.GetEdgeResponse
+	35, // 72: graph.v1.LanternService.GetEdges:output_type -> graph.v1.GetEdgesResponse
+	44, // 73: graph.v1.LanternService.AddEdge:output_type -> graph.v1.AddEdgeResponse
+	46, // 74: graph.v1.LanternService.AddEdges:output_type -> graph.v1.AddEdgesResponse
+	48, // 75: graph.v1.LanternService.PutEdge:output_type -> graph.v1.PutEdgeResponse
+	50, // 76: graph.v1.LanternService.PutEdges:output_type -> graph.v1.PutEdgesResponse
+	37, // 77: graph.v1.LanternService.DeleteEdge:output_type -> graph.v1.DeleteEdgeResponse
+	42, // 78: graph.v1.LanternService.DeleteEdges:output_type -> graph.v1.DeleteEdgesResponse
+	40, // 79: graph.v1.LanternService.ScanEdges:output_type -> graph.v1.ScanEdgesResponse
+	52, // 80: graph.v1.LanternService.GetServerStatus:output_type -> graph.v1.GetServerStatusResponse
+	55, // 81: graph.v1.LanternService.GetReplicationStatus:output_type -> graph.v1.GetReplicationStatusResponse
+	57, // 82: graph.v1.LanternService.BackupSnapshot:output_type -> graph.v1.BackupSnapshotResponse
+	59, // [59:83] is the sub-list for method output_type
+	35, // [35:59] is the sub-list for method input_type
+	35, // [35:35] is the sub-list for extension type_name
+	35, // [35:35] is the sub-list for extension extendee
+	0,  // [0:35] is the sub-list for field type_name
 }
 
 func init() { file_graph_v1_graph_proto_init() }
@@ -3759,13 +3906,17 @@ func file_graph_v1_graph_proto_init() {
 		(*Vertex_Duration)(nil),
 		(*Vertex_Nil)(nil),
 	}
+	file_graph_v1_graph_proto_msgTypes[53].OneofWrappers = []any{
+		(*BackupSnapshotResponse_Vertex)(nil),
+		(*BackupSnapshotResponse_Edge)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_graph_v1_graph_proto_rawDesc), len(file_graph_v1_graph_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   52,
+			NumMessages:   54,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pb/graph/v1/graphv1connect/graph.connect.go
+++ b/pb/graph/v1/graphv1connect/graph.connect.go
@@ -96,6 +96,9 @@ const (
 	// LanternServiceGetReplicationStatusProcedure is the fully-qualified name of the LanternService's
 	// GetReplicationStatus RPC.
 	LanternServiceGetReplicationStatusProcedure = "/graph.v1.LanternService/GetReplicationStatus"
+	// LanternServiceBackupSnapshotProcedure is the fully-qualified name of the LanternService's
+	// BackupSnapshot RPC.
+	LanternServiceBackupSnapshotProcedure = "/graph.v1.LanternService/BackupSnapshot"
 )
 
 // LanternServiceClient is a client for the graph.v1.LanternService service.
@@ -161,6 +164,14 @@ type LanternServiceClient interface {
 	// dashboard at any cadence the operator finds useful. On
 	// single-instance deployments enabled=false and peers is empty.
 	GetReplicationStatus(context.Context, *connect.Request[v1.GetReplicationStatusRequest]) (*connect.Response[v1.GetReplicationStatusResponse], error)
+	// BackupSnapshot streams a whole-graph, point-in-time backup: every
+	// live vertex and folded edge as a BackupRecord, materialised under a
+	// single GraphCache lock (SnapshotGraph). Unlike the replication
+	// Snapshot RPC it has NO replication gate — it works on a single node.
+	// vertex_prefix optionally scopes the backup to an induced subgraph.
+	// The restore side replays records through PutVertices / PutEdges, so
+	// there is no dedicated restore RPC.
+	BackupSnapshot(context.Context, *connect.Request[v1.BackupSnapshotRequest]) (*connect.ServerStreamForClient[v1.BackupSnapshotResponse], error)
 }
 
 // NewLanternServiceClient constructs a client for the graph.v1.LanternService service. By default,
@@ -312,6 +323,12 @@ func NewLanternServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 			connect.WithSchema(lanternServiceMethods.ByName("GetReplicationStatus")),
 			connect.WithClientOptions(opts...),
 		),
+		backupSnapshot: connect.NewClient[v1.BackupSnapshotRequest, v1.BackupSnapshotResponse](
+			httpClient,
+			baseURL+LanternServiceBackupSnapshotProcedure,
+			connect.WithSchema(lanternServiceMethods.ByName("BackupSnapshot")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -340,6 +357,7 @@ type lanternServiceClient struct {
 	scanEdges              *connect.Client[v1.ScanEdgesRequest, v1.ScanEdgesResponse]
 	getServerStatus        *connect.Client[v1.GetServerStatusRequest, v1.GetServerStatusResponse]
 	getReplicationStatus   *connect.Client[v1.GetReplicationStatusRequest, v1.GetReplicationStatusResponse]
+	backupSnapshot         *connect.Client[v1.BackupSnapshotRequest, v1.BackupSnapshotResponse]
 }
 
 // Illuminate calls graph.v1.LanternService.Illuminate.
@@ -457,6 +475,11 @@ func (c *lanternServiceClient) GetReplicationStatus(ctx context.Context, req *co
 	return c.getReplicationStatus.CallUnary(ctx, req)
 }
 
+// BackupSnapshot calls graph.v1.LanternService.BackupSnapshot.
+func (c *lanternServiceClient) BackupSnapshot(ctx context.Context, req *connect.Request[v1.BackupSnapshotRequest]) (*connect.ServerStreamForClient[v1.BackupSnapshotResponse], error) {
+	return c.backupSnapshot.CallServerStream(ctx, req)
+}
+
 // LanternServiceHandler is an implementation of the graph.v1.LanternService service.
 type LanternServiceHandler interface {
 	Illuminate(context.Context, *connect.Request[v1.IlluminateRequest]) (*connect.Response[v1.IlluminateResponse], error)
@@ -520,6 +543,14 @@ type LanternServiceHandler interface {
 	// dashboard at any cadence the operator finds useful. On
 	// single-instance deployments enabled=false and peers is empty.
 	GetReplicationStatus(context.Context, *connect.Request[v1.GetReplicationStatusRequest]) (*connect.Response[v1.GetReplicationStatusResponse], error)
+	// BackupSnapshot streams a whole-graph, point-in-time backup: every
+	// live vertex and folded edge as a BackupRecord, materialised under a
+	// single GraphCache lock (SnapshotGraph). Unlike the replication
+	// Snapshot RPC it has NO replication gate — it works on a single node.
+	// vertex_prefix optionally scopes the backup to an induced subgraph.
+	// The restore side replays records through PutVertices / PutEdges, so
+	// there is no dedicated restore RPC.
+	BackupSnapshot(context.Context, *connect.Request[v1.BackupSnapshotRequest], *connect.ServerStream[v1.BackupSnapshotResponse]) error
 }
 
 // NewLanternServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -667,6 +698,12 @@ func NewLanternServiceHandler(svc LanternServiceHandler, opts ...connect.Handler
 		connect.WithSchema(lanternServiceMethods.ByName("GetReplicationStatus")),
 		connect.WithHandlerOptions(opts...),
 	)
+	lanternServiceBackupSnapshotHandler := connect.NewServerStreamHandler(
+		LanternServiceBackupSnapshotProcedure,
+		svc.BackupSnapshot,
+		connect.WithSchema(lanternServiceMethods.ByName("BackupSnapshot")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/graph.v1.LanternService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case LanternServiceIlluminateProcedure:
@@ -715,6 +752,8 @@ func NewLanternServiceHandler(svc LanternServiceHandler, opts ...connect.Handler
 			lanternServiceGetServerStatusHandler.ServeHTTP(w, r)
 		case LanternServiceGetReplicationStatusProcedure:
 			lanternServiceGetReplicationStatusHandler.ServeHTTP(w, r)
+		case LanternServiceBackupSnapshotProcedure:
+			lanternServiceBackupSnapshotHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -814,4 +853,8 @@ func (UnimplementedLanternServiceHandler) GetServerStatus(context.Context, *conn
 
 func (UnimplementedLanternServiceHandler) GetReplicationStatus(context.Context, *connect.Request[v1.GetReplicationStatusRequest]) (*connect.Response[v1.GetReplicationStatusResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("graph.v1.LanternService.GetReplicationStatus is not implemented"))
+}
+
+func (UnimplementedLanternServiceHandler) BackupSnapshot(context.Context, *connect.Request[v1.BackupSnapshotRequest], *connect.ServerStream[v1.BackupSnapshotResponse]) error {
+	return connect.NewError(connect.CodeUnimplemented, errors.New("graph.v1.LanternService.BackupSnapshot is not implemented"))
 }

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -566,6 +566,25 @@ message GetReplicationStatusResponse {
   repeated ReplicationPeer peers = 10;
 }
 
+// BackupSnapshotRequest parameterises a whole-graph backup stream.
+// vertex_prefix, when non-empty, restricts the backup to the induced
+// subgraph over vertices whose key has this prefix (an edge is included
+// only when BOTH endpoints match). Empty = the whole graph.
+message BackupSnapshotRequest {
+  string vertex_prefix = 1;
+}
+
+// BackupSnapshotResponse is one frame of the BackupSnapshot stream:
+// either a live vertex or a folded live edge (weight summed across
+// contributions, expiration = the furthest-future contribution). The two
+// kinds are interleaved; consumers route on the oneof.
+message BackupSnapshotResponse {
+  oneof record {
+    Vertex vertex = 1;
+    Edge edge = 2;
+  }
+}
+
 service LanternService {
   rpc Illuminate(IlluminateRequest) returns (IlluminateResponse);
 
@@ -650,4 +669,13 @@ service LanternService {
   // dashboard at any cadence the operator finds useful. On
   // single-instance deployments enabled=false and peers is empty.
   rpc GetReplicationStatus(GetReplicationStatusRequest) returns (GetReplicationStatusResponse);
+
+  // BackupSnapshot streams a whole-graph, point-in-time backup: every
+  // live vertex and folded edge as a BackupRecord, materialised under a
+  // single GraphCache lock (SnapshotGraph). Unlike the replication
+  // Snapshot RPC it has NO replication gate — it works on a single node.
+  // vertex_prefix optionally scopes the backup to an induced subgraph.
+  // The restore side replays records through PutVertices / PutEdges, so
+  // there is no dedicated restore RPC.
+  rpc BackupSnapshot(BackupSnapshotRequest) returns (stream BackupSnapshotResponse);
 }

--- a/server/service/backend.go
+++ b/server/service/backend.go
@@ -123,6 +123,11 @@ type Backend interface {
 	SnapshotVertices() []graphcache.SnapshotVertex[string, *pb.Vertex]
 	SnapshotEdges() []graphcache.SnapshotEdge[string]
 
+	// SnapshotGraph materialises both vertices and edges under a SINGLE
+	// GraphCache lock (#689), so a whole-graph backup observes one
+	// point-in-time. Used by BackupSnapshot.
+	SnapshotGraph() graphcache.GraphSnapshot[string, *pb.Vertex]
+
 	// VertexCount and EdgeCount return the current number of live entries
 	// in the underlying graph cache. Backed by index sizes — O(1) and
 	// safe to call from any RPC. Returned values are eventually-consistent

--- a/server/service/backup.go
+++ b/server/service/backup.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/anaregdesign/lantern/core/graphcache"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+)
+
+// BackupSnapshot streams a whole-graph, point-in-time backup: every live
+// vertex and a folded live edge as a BackupSnapshotResponse. It is the dump half of
+// the backup/restore pair (#685); the restore half replays the records
+// through PutVertices / PutEdges, so there is no dedicated restore RPC.
+//
+// Unlike the replication Snapshot RPC, BackupSnapshot has NO replication
+// gate — it works on a single node. The whole graph is materialised once
+// under the GraphCache lock via SnapshotGraph (#689), so vertices and
+// edges share one instant; records are then sent off-lock.
+//
+// vertex_prefix, when non-empty, scopes the backup to the induced subgraph
+// over vertices whose key has the prefix: a vertex is emitted only if it
+// matches, and an edge only if BOTH endpoints match, so a restore of the
+// partial dump stays referentially closed.
+func (s *LanternService) BackupSnapshot(ctx context.Context, request *pb.BackupSnapshotRequest, stream Sender[pb.BackupSnapshotResponse]) error {
+	if err := ctx.Err(); err != nil {
+		return ctxToConnect(err)
+	}
+	snap := s.cache.SnapshotGraph()
+
+	var keep map[string]bool
+	if prefix := request.GetVertexPrefix(); prefix != "" {
+		keep = make(map[string]bool, len(snap.Vertices))
+		for _, v := range snap.Vertices {
+			if strings.HasPrefix(v.Key, prefix) {
+				keep[v.Key] = true
+			}
+		}
+	}
+
+	for _, v := range snap.Vertices {
+		if err := ctx.Err(); err != nil {
+			return ctxToConnect(err)
+		}
+		if keep != nil && !keep[v.Key] {
+			continue
+		}
+		if err := stream.Send(&pb.BackupSnapshotResponse{
+			Record: &pb.BackupSnapshotResponse_Vertex{Vertex: v.Value},
+		}); err != nil {
+			return err
+		}
+	}
+
+	for _, e := range snap.Edges {
+		if err := ctx.Err(); err != nil {
+			return ctxToConnect(err)
+		}
+		if keep != nil && (!keep[e.Tail] || !keep[e.Head]) {
+			continue
+		}
+		if err := stream.Send(&pb.BackupSnapshotResponse{
+			Record: &pb.BackupSnapshotResponse_Edge{Edge: foldBackupEdge(e)},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// foldBackupEdge collapses a snapshot edge's per-contribution
+// decomposition into the single wire Edge a backup carries: weight summed
+// across live contributions, expiration = the furthest-future contribution
+// (zero ⇒ permanent). This mirrors the fold in GraphCache.GetEdgeDetail
+// (core/graphcache weight.snapshot), so a dump→restore round-trip
+// reproduces the same GetEdge result.
+func foldBackupEdge(e graphcache.SnapshotEdge[string]) *pb.Edge {
+	var weight float32
+	var latest time.Time
+	for _, c := range e.Contributions {
+		weight += c.Weight
+		if c.Expiration.After(latest) {
+			latest = c.Expiration
+		}
+	}
+	edge := &pb.Edge{Tail: e.Tail, Head: e.Head, Weight: weight}
+	if !latest.IsZero() {
+		edge.Expiration = timestamppb.New(latest)
+	}
+	return edge
+}

--- a/server/service/backup_test.go
+++ b/server/service/backup_test.go
@@ -1,0 +1,95 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+)
+
+// recordingSender captures the BackupSnapshotResponse frames a handler streams.
+type recordingSender struct{ records []*pb.BackupSnapshotResponse }
+
+func (s *recordingSender) Send(r *pb.BackupSnapshotResponse) error {
+	s.records = append(s.records, r)
+	return nil
+}
+
+func splitBackupSnapshotResponses(recs []*pb.BackupSnapshotResponse) (map[string]*pb.Vertex, map[string]*pb.Edge) {
+	vs := map[string]*pb.Vertex{}
+	es := map[string]*pb.Edge{}
+	for _, r := range recs {
+		switch x := r.GetRecord().(type) {
+		case *pb.BackupSnapshotResponse_Vertex:
+			vs[x.Vertex.GetKey()] = x.Vertex
+		case *pb.BackupSnapshotResponse_Edge:
+			es[x.Edge.GetTail()+"->"+x.Edge.GetHead()] = x.Edge
+		}
+	}
+	return vs, es
+}
+
+func TestLanternService_BackupSnapshot(t *testing.T) {
+	t.Run("WholeGraph", func(t *testing.T) {
+		fb := newFakeBackend()
+		fb.vertices["alice"] = &pb.Vertex{Key: "alice"}
+		fb.vertices["bob"] = &pb.Vertex{Key: "bob"}
+		fb.edges["alice"] = map[string]float32{"bob": 1.5}
+		svc := NewLanternService(fb)
+
+		sender := &recordingSender{}
+		if err := svc.BackupSnapshot(context.Background(), &pb.BackupSnapshotRequest{}, sender); err != nil {
+			t.Fatalf("BackupSnapshot: %v", err)
+		}
+		vs, es := splitBackupSnapshotResponses(sender.records)
+		if len(vs) != 2 {
+			t.Errorf("got %d vertices, want 2: %v", len(vs), vs)
+		}
+		if _, ok := vs["alice"]; !ok {
+			t.Errorf("missing vertex alice")
+		}
+		e, ok := es["alice->bob"]
+		if !ok {
+			t.Fatalf("missing edge alice->bob: %v", es)
+		}
+		if e.GetWeight() != 1.5 {
+			t.Errorf("edge weight = %v, want 1.5", e.GetWeight())
+		}
+		if e.Expiration != nil {
+			t.Errorf("permanent edge should have nil expiration, got %v", e.Expiration)
+		}
+	})
+
+	// vertex_prefix scopes the dump to the induced subgraph: only matching
+	// vertices, and only edges whose BOTH endpoints match.
+	t.Run("PrefixInducedSubgraph", func(t *testing.T) {
+		fb := newFakeBackend()
+		fb.vertices["user:a"] = &pb.Vertex{Key: "user:a"}
+		fb.vertices["user:b"] = &pb.Vertex{Key: "user:b"}
+		fb.vertices["other:c"] = &pb.Vertex{Key: "other:c"}
+		fb.edges["user:a"] = map[string]float32{"user:b": 1, "other:c": 2}
+		svc := NewLanternService(fb)
+
+		sender := &recordingSender{}
+		err := svc.BackupSnapshot(context.Background(), &pb.BackupSnapshotRequest{VertexPrefix: "user:"}, sender)
+		if err != nil {
+			t.Fatalf("BackupSnapshot: %v", err)
+		}
+		vs, es := splitBackupSnapshotResponses(sender.records)
+		if len(vs) != 2 {
+			t.Errorf("got %d vertices, want 2 (user:a,user:b): %v", len(vs), vs)
+		}
+		if _, ok := vs["other:c"]; ok {
+			t.Errorf("non-matching vertex other:c leaked into prefix backup")
+		}
+		if len(es) != 1 {
+			t.Errorf("got %d edges, want 1 (user:a->user:b): %v", len(es), es)
+		}
+		if _, ok := es["user:a->user:b"]; !ok {
+			t.Errorf("missing intra-prefix edge user:a->user:b")
+		}
+		if _, ok := es["user:a->other:c"]; ok {
+			t.Errorf("edge to non-matching endpoint other:c leaked into prefix backup")
+		}
+	})
+}

--- a/server/service/connect.go
+++ b/server/service/connect.go
@@ -128,6 +128,10 @@ func (h *lanternServiceConnect) GetServerStatus(ctx context.Context, req *connec
 func (h *lanternServiceConnect) GetReplicationStatus(ctx context.Context, req *connect.Request[pb.GetReplicationStatusRequest]) (*connect.Response[pb.GetReplicationStatusResponse], error) {
 	return unary(ctx, req, h.svc.GetReplicationStatus)
 }
+func (h *lanternServiceConnect) BackupSnapshot(ctx context.Context, req *connect.Request[pb.BackupSnapshotRequest], stream *connect.ServerStream[pb.BackupSnapshotResponse]) error {
+	// *connect.ServerStream[T] satisfies service.Sender[T] directly.
+	return h.svc.BackupSnapshot(ctx, req.Msg, stream)
+}
 
 type lanternReplicationServiceConnect struct {
 	graphv1connect.UnimplementedLanternReplicationServiceHandler

--- a/server/service/fake_backend_test.go
+++ b/server/service/fake_backend_test.go
@@ -342,6 +342,13 @@ func (f *fakeBackend) SnapshotVertices() []graphcache.SnapshotVertex[string, *pb
 	return out
 }
 
+func (f *fakeBackend) SnapshotGraph() graphcache.GraphSnapshot[string, *pb.Vertex] {
+	return graphcache.GraphSnapshot[string, *pb.Vertex]{
+		Vertices: f.SnapshotVertices(),
+		Edges:    f.SnapshotEdges(),
+	}
+}
+
 func (f *fakeBackend) SnapshotEdges() []graphcache.SnapshotEdge[string] {
 	var out []graphcache.SnapshotEdge[string]
 	for tail, heads := range f.edges {

--- a/tests/integration/backup_test.go
+++ b/tests/integration/backup_test.go
@@ -1,0 +1,124 @@
+package integration_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/anaregdesign/lantern/core/graphcache"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/anaregdesign/lantern/server/provider"
+	"github.com/anaregdesign/lantern/server/service"
+)
+
+// TestBackupSnapshot_E2E drives the BackupSnapshot streaming RPC (#691)
+// full-stack: seed a graph via the SDK, then dump it through the raw
+// Connect client and assert every live vertex + folded edge is streamed.
+// BackupSnapshot has no replication gate, so the server is single-node
+// (rep = nil).
+func TestBackupSnapshot_E2E(t *testing.T) {
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+	val := provider.NewValidationInterceptor(defaultIntegrationValidationLimits())
+	svc := service.NewLanternService(cache)
+	srv := newConnectTestServer(t, svc, nil, val.ConnectInterceptor())
+	sdk := newConnectClientFor(t, srv.url)
+	raw := graphv1connect.NewLanternServiceClient(h2cClient(), srv.url)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := sdk.PutVertex(ctx, "alice", "Alice", time.Minute); err != nil {
+		t.Fatalf("PutVertex alice: %v", err)
+	}
+	if err := sdk.PutVertex(ctx, "bob", int64(42), time.Minute); err != nil {
+		t.Fatalf("PutVertex bob: %v", err)
+	}
+	if err := sdk.PutVertex(ctx, "carol", "Carol", time.Minute); err != nil {
+		t.Fatalf("PutVertex carol: %v", err)
+	}
+	if err := sdk.AddEdge(ctx, "alice", "bob", 1.5, time.Minute); err != nil {
+		t.Fatalf("AddEdge alice->bob: %v", err)
+	}
+	if err := sdk.AddEdge(ctx, "bob", "carol", 2.0, time.Minute); err != nil {
+		t.Fatalf("AddEdge bob->carol: %v", err)
+	}
+
+	vertices, edges := drainBackup(t, ctx, raw, &pb.BackupSnapshotRequest{})
+
+	if len(vertices) != 3 {
+		t.Fatalf("got %d vertices, want 3: %v", len(vertices), vertices)
+	}
+	for _, k := range []string{"alice", "bob", "carol"} {
+		if _, ok := vertices[k]; !ok {
+			t.Errorf("missing vertex %q", k)
+		}
+	}
+	// The BackupSnapshotResponse carries the live *pb.Vertex, so values survive.
+	if got, err := client.StringValue(vertices["alice"]); err != nil || got != "Alice" {
+		t.Errorf("alice value = %q (err %v), want Alice", got, err)
+	}
+	if len(edges) != 2 {
+		t.Fatalf("got %d edges, want 2: %v", len(edges), edges)
+	}
+	if e := edges["alice->bob"]; e == nil || e.GetWeight() != 1.5 {
+		t.Errorf("edge alice->bob = %v, want weight 1.5", e)
+	}
+	if e := edges["bob->carol"]; e == nil || e.GetWeight() != 2.0 {
+		t.Errorf("edge bob->carol = %v, want weight 2.0", e)
+	}
+
+	// vertex_prefix scopes the dump to the induced subgraph.
+	t.Run("Prefix", func(t *testing.T) {
+		if err := sdk.PutVertex(ctx, "x:1", "one", time.Minute); err != nil {
+			t.Fatalf("PutVertex x:1: %v", err)
+		}
+		if err := sdk.PutVertex(ctx, "x:2", "two", time.Minute); err != nil {
+			t.Fatalf("PutVertex x:2: %v", err)
+		}
+		if err := sdk.AddEdge(ctx, "x:1", "x:2", 1.0, time.Minute); err != nil {
+			t.Fatalf("AddEdge x:1->x:2: %v", err)
+		}
+		vs, es := drainBackup(t, ctx, raw, &pb.BackupSnapshotRequest{VertexPrefix: "x:"})
+		for k := range vs {
+			if !strings.HasPrefix(k, "x:") {
+				t.Errorf("prefix backup leaked vertex %q", k)
+			}
+		}
+		if len(vs) != 2 {
+			t.Errorf("prefix backup got %d vertices, want 2: %v", len(vs), vs)
+		}
+		if len(es) != 1 {
+			t.Errorf("prefix backup got %d edges, want 1: %v", len(es), es)
+		}
+	})
+}
+
+// drainBackup runs BackupSnapshot to completion and returns the streamed
+// vertices (by key) and folded edges (by "tail->head").
+func drainBackup(t *testing.T, ctx context.Context, raw graphv1connect.LanternServiceClient, req *pb.BackupSnapshotRequest) (map[string]*pb.Vertex, map[string]*pb.Edge) {
+	t.Helper()
+	stream, err := raw.BackupSnapshot(ctx, connect.NewRequest(req))
+	if err != nil {
+		t.Fatalf("BackupSnapshot: %v", err)
+	}
+	vertices := map[string]*pb.Vertex{}
+	edges := map[string]*pb.Edge{}
+	for stream.Receive() {
+		switch x := stream.Msg().GetRecord().(type) {
+		case *pb.BackupSnapshotResponse_Vertex:
+			vertices[x.Vertex.GetKey()] = x.Vertex
+		case *pb.BackupSnapshotResponse_Edge:
+			edges[x.Edge.GetTail()+"->"+x.Edge.GetHead()] = x.Edge
+		}
+	}
+	if err := stream.Err(); err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("BackupSnapshot stream: %v", err)
+	}
+	return vertices, edges
+}


### PR DESCRIPTION
Closes #691. **Layer A** of epic #685 (whole-graph backup/restore).

## What

Adds the **dump** half of backup/restore as a streaming RPC:

- **proto** (`graph.proto`): `message BackupRecord { oneof record { Vertex vertex = 1; Edge edge = 2; } }`, `message BackupSnapshotRequest { string vertex_prefix = 1; }`, and `rpc BackupSnapshot(BackupSnapshotRequest) returns (stream BackupRecord);` on `LanternService`. pb regenerated via `go generate` (buf).
- **server** (`server/service/backup.go`): the handler materialises the whole graph once via `GraphCache.SnapshotGraph()` (#689) and streams every live vertex + a **folded** edge (weight summed across contributions, expiration = furthest-future contribution — mirrors `GetEdgeDetail`, so dump→restore→GetEdge is consistent), sent off-lock. **No replication gate** — works single-node. `vertex_prefix` scopes to the induced subgraph (an edge is emitted only when both endpoints match).
- Widens the service `Backend` interface with `SnapshotGraph` (the concrete `*GraphCache` already satisfies it; fake updated).

## Tests

- `server/service/backup_test.go` — handler unit test (whole-graph + prefix induced-subgraph + permanent-edge fold) via a fake `Sender`.
- `tests/integration/backup_test.go` — full-stack: seed via SDK → dump via the raw Connect `BackupSnapshot` stream → assert vertices/values/edges + prefix scoping.

Full local gate green: gofmt + `pb`/`server`/root build+test (incl. integration).

## Scope

pb + server only. The SDK `Backup`/`Restore` (#692) and CLI `dump`/`restore` (#693) build on this.
