### PR TITLE
feat(sdks/go): whole-graph Backup/Restore with protobuf + NDJSON codecs

### DIFF
--- a/sdks/go/backup.go
+++ b/sdks/go/backup.go
@@ -1,0 +1,329 @@
+// Package client: backup.go owns the SDK's whole-graph backup/restore
+// surface (#685). Backup streams the LanternService BackupSnapshot RPC and
+// serialises each frame to an io.Writer; Restore reads frames back and
+// replays them through the batch Put RPCs. Two wire formats are supported:
+// length-delimited protobuf (default, lossless) and newline-delimited JSON
+// (human-readable). Restore reuses the existing PutVertices/PutEdges
+// surface, so there is no dedicated restore RPC.
+package client
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/encoding/protodelim"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+)
+
+// Format selects the on-disk encoding of a backup stream.
+type Format int
+
+const (
+	// FormatProto is the default: a stream of length-delimited protobuf
+	// BackupSnapshotResponse frames. Lossless and compact; not human
+	// readable.
+	FormatProto Format = iota
+	// FormatNDJSON is one JSON object per line, discriminated by a "kind"
+	// field ("vertex" | "edge"). Human-readable and greppable; values
+	// round-trip via MarshalVertexJSON / MarshalEdgeJSON (int64/uint64
+	// magnitudes survive through json.Number).
+	FormatNDJSON
+)
+
+// defaultRestoreChunkSize is the batch size Restore sends per PutVertices /
+// PutEdges call when WithRestoreChunkSize is not supplied.
+const defaultRestoreChunkSize = 1000
+
+// BackupStats / RestoreStats report how many vertices and edges were
+// dumped or loaded.
+type BackupStats struct {
+	Vertices int
+	Edges    int
+}
+
+type RestoreStats struct {
+	Vertices int
+	Edges    int
+}
+
+type backupConfig struct {
+	format Format
+	prefix string
+}
+
+// BackupOption customises Backup.
+type BackupOption func(*backupConfig)
+
+// WithBackupFormat selects the output format (default FormatProto).
+func WithBackupFormat(f Format) BackupOption { return func(c *backupConfig) { c.format = f } }
+
+// WithBackupPrefix restricts the backup to the induced subgraph over
+// vertices whose key has this prefix (empty = the whole graph).
+func WithBackupPrefix(p string) BackupOption { return func(c *backupConfig) { c.prefix = p } }
+
+type restoreConfig struct {
+	format    Format
+	chunkSize int
+}
+
+// RestoreOption customises Restore.
+type RestoreOption func(*restoreConfig)
+
+// WithRestoreFormat selects the input format (default FormatProto). It must
+// match the format the dump was written with.
+func WithRestoreFormat(f Format) RestoreOption { return func(c *restoreConfig) { c.format = f } }
+
+// WithRestoreChunkSize sets the batch size for the PutVertices / PutEdges
+// calls Restore issues (non-positive values are ignored).
+func WithRestoreChunkSize(n int) RestoreOption {
+	return func(c *restoreConfig) {
+		if n > 0 {
+			c.chunkSize = n
+		}
+	}
+}
+
+// Backup streams a whole-graph, point-in-time dump to w. The server
+// materialises the graph once via SnapshotGraph, so vertices and edges
+// share one instant. Backup has no replication gate — it works against a
+// single node. The returned stats count the vertices and edges written.
+func (l *Lantern) Backup(ctx context.Context, w io.Writer, opts ...BackupOption) (BackupStats, error) {
+	cfg := backupConfig{format: FormatProto}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	stream, err := l.client.BackupSnapshot(ctx, connect.NewRequest(&pb.BackupSnapshotRequest{VertexPrefix: cfg.prefix}))
+	if err != nil {
+		return BackupStats{}, wrapConnectErr(err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	bw := bufio.NewWriter(w)
+	var stats BackupStats
+	for stream.Receive() {
+		rec := stream.Msg()
+		if err := encodeBackupRecord(bw, cfg.format, rec); err != nil {
+			return stats, err
+		}
+		switch rec.GetRecord().(type) {
+		case *pb.BackupSnapshotResponse_Vertex:
+			stats.Vertices++
+		case *pb.BackupSnapshotResponse_Edge:
+			stats.Edges++
+		}
+	}
+	if err := stream.Err(); err != nil && !errors.Is(err, io.EOF) {
+		return stats, wrapConnectErr(err)
+	}
+	if err := bw.Flush(); err != nil {
+		return stats, err
+	}
+	return stats, nil
+}
+
+// Restore reads a dump from r and replays it into the graph: vertices via
+// PutVertices and edges via PutEdges (Put is idempotent, so re-running a
+// restore is a no-op on unchanged data). Records are decoded verbatim into
+// *Vertex / *Edge and put as-is, so value types and absolute expirations
+// round-trip exactly. There is no rollback on a mid-restore failure
+// (Lantern has no transactions). The returned stats count what was loaded.
+func (l *Lantern) Restore(ctx context.Context, r io.Reader, opts ...RestoreOption) (RestoreStats, error) {
+	cfg := restoreConfig{format: FormatProto, chunkSize: defaultRestoreChunkSize}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	dec := newBackupDecoder(r, cfg.format)
+	var stats RestoreStats
+	vbatch := make([]*pb.Vertex, 0, cfg.chunkSize)
+	ebatch := make([]*pb.Edge, 0, cfg.chunkSize)
+
+	flushVertices := func() error {
+		if len(vbatch) == 0 {
+			return nil
+		}
+		if _, err := l.client.PutVertices(ctx, connect.NewRequest(&pb.PutVerticesRequest{Vertices: vbatch})); err != nil {
+			return wrapConnectErr(err)
+		}
+		stats.Vertices += len(vbatch)
+		vbatch = vbatch[:0]
+		return nil
+	}
+	flushEdges := func() error {
+		if len(ebatch) == 0 {
+			return nil
+		}
+		if _, err := l.client.PutEdges(ctx, connect.NewRequest(&pb.PutEdgesRequest{Edges: ebatch})); err != nil {
+			return wrapConnectErr(err)
+		}
+		stats.Edges += len(ebatch)
+		ebatch = ebatch[:0]
+		return nil
+	}
+
+	for {
+		rec, err := dec.next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return stats, err
+		}
+		switch x := rec.GetRecord().(type) {
+		case *pb.BackupSnapshotResponse_Vertex:
+			vbatch = append(vbatch, x.Vertex)
+			if len(vbatch) >= cfg.chunkSize {
+				if err := flushVertices(); err != nil {
+					return stats, err
+				}
+			}
+		case *pb.BackupSnapshotResponse_Edge:
+			ebatch = append(ebatch, x.Edge)
+			if len(ebatch) >= cfg.chunkSize {
+				if err := flushEdges(); err != nil {
+					return stats, err
+				}
+			}
+		}
+	}
+	// Vertices before edges: PutEdges auto-creates endpoints, but flushing
+	// real vertex values first keeps endpoint values authoritative.
+	if err := flushVertices(); err != nil {
+		return stats, err
+	}
+	if err := flushEdges(); err != nil {
+		return stats, err
+	}
+	return stats, nil
+}
+
+// encodeBackupRecord writes one frame in the selected format.
+func encodeBackupRecord(w *bufio.Writer, f Format, rec *pb.BackupSnapshotResponse) error {
+	if f == FormatNDJSON {
+		line, err := marshalNDJSONRecord(rec)
+		if err != nil {
+			return err
+		}
+		if _, err := w.Write(line); err != nil {
+			return err
+		}
+		return w.WriteByte('\n')
+	}
+	_, err := protodelim.MarshalTo(w, rec)
+	return err
+}
+
+// marshalNDJSONRecord renders a backup frame as a single JSON object,
+// splicing a "kind" discriminator onto MarshalVertexJSON / MarshalEdgeJSON
+// output so the line is self-describing.
+func marshalNDJSONRecord(rec *pb.BackupSnapshotResponse) ([]byte, error) {
+	switch x := rec.GetRecord().(type) {
+	case *pb.BackupSnapshotResponse_Vertex:
+		b, err := MarshalVertexJSON(x.Vertex)
+		if err != nil {
+			return nil, err
+		}
+		return spliceKind("vertex", b), nil
+	case *pb.BackupSnapshotResponse_Edge:
+		b, err := MarshalEdgeJSON(x.Edge)
+		if err != nil {
+			return nil, err
+		}
+		return spliceKind("edge", b), nil
+	default:
+		return nil, errors.New("backup: record has no vertex or edge")
+	}
+}
+
+// spliceKind inserts {"kind":"<kind>", ...} as the first member of a JSON
+// object produced by Marshal*JSON.
+func spliceKind(kind string, obj []byte) []byte {
+	if len(obj) <= 2 { // "{}" — no other members
+		return []byte(`{"kind":"` + kind + `"}`)
+	}
+	prefix := []byte(`{"kind":"` + kind + `",`)
+	return append(prefix, obj[1:]...)
+}
+
+// backupDecoder yields successive frames from a dump, hiding the
+// format-specific framing behind next().
+type backupDecoder struct {
+	format Format
+	br     *bufio.Reader
+	sc     *bufio.Scanner
+	lineNo int
+}
+
+func newBackupDecoder(r io.Reader, f Format) *backupDecoder {
+	d := &backupDecoder{format: f}
+	if f == FormatNDJSON {
+		d.sc = bufio.NewScanner(r)
+		// Match the bulk loader's generous line cap so large base64/string
+		// values don't trip bufio.Scanner's default 64 KiB token limit.
+		d.sc.Buffer(make([]byte, 64*1024), 8*1024*1024)
+	} else {
+		d.br = bufio.NewReader(r)
+	}
+	return d
+}
+
+// next returns the next frame, or io.EOF at a clean end of stream.
+func (d *backupDecoder) next() (*pb.BackupSnapshotResponse, error) {
+	if d.format == FormatNDJSON {
+		for d.sc.Scan() {
+			d.lineNo++
+			if len(d.sc.Bytes()) == 0 {
+				continue
+			}
+			rec, err := parseNDJSONRecord(d.sc.Bytes())
+			if err != nil {
+				return nil, fmt.Errorf("line %d: %w", d.lineNo, err)
+			}
+			return rec, nil
+		}
+		if err := d.sc.Err(); err != nil {
+			return nil, err
+		}
+		return nil, io.EOF
+	}
+	var rec pb.BackupSnapshotResponse
+	if err := protodelim.UnmarshalFrom(d.br, &rec); err != nil {
+		return nil, err // io.EOF at a clean end
+	}
+	return &rec, nil
+}
+
+// parseNDJSONRecord routes one JSON line by its "kind" discriminator,
+// reusing UnmarshalVertexJSON / UnmarshalEdgeJSON (both ignore the extra
+// "kind" field).
+func parseNDJSONRecord(line []byte) (*pb.BackupSnapshotResponse, error) {
+	var disc struct {
+		Kind string `json:"kind"`
+	}
+	if err := json.Unmarshal(line, &disc); err != nil {
+		return nil, err
+	}
+	switch disc.Kind {
+	case "vertex":
+		v, err := UnmarshalVertexJSON(line)
+		if err != nil {
+			return nil, err
+		}
+		return &pb.BackupSnapshotResponse{Record: &pb.BackupSnapshotResponse_Vertex{Vertex: v}}, nil
+	case "edge":
+		e, err := UnmarshalEdgeJSON(line)
+		if err != nil {
+			return nil, err
+		}
+		return &pb.BackupSnapshotResponse{Record: &pb.BackupSnapshotResponse_Edge{Edge: e}}, nil
+	default:
+		return nil, fmt.Errorf("unknown or missing kind %q", disc.Kind)
+	}
+}

--- a/sdks/go/backup_test.go
+++ b/sdks/go/backup_test.go
@@ -1,0 +1,119 @@
+package client
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func mkVertexRec(v *pb.Vertex) *pb.BackupSnapshotResponse {
+	return &pb.BackupSnapshotResponse{Record: &pb.BackupSnapshotResponse_Vertex{Vertex: v}}
+}
+
+func mkEdgeRec(e *pb.Edge) *pb.BackupSnapshotResponse {
+	return &pb.BackupSnapshotResponse{Record: &pb.BackupSnapshotResponse_Edge{Edge: e}}
+}
+
+func sampleBackupRecords() []*pb.BackupSnapshotResponse {
+	exp := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	return []*pb.BackupSnapshotResponse{
+		mkVertexRec(&pb.Vertex{Key: "alice", Value: &pb.Vertex_String_{String_: "Alice"}}),
+		mkVertexRec(&pb.Vertex{Key: "big", Value: &pb.Vertex_Int64{Int64: math.MaxInt64}}),
+		mkVertexRec(&pb.Vertex{Key: "ubig", Value: &pb.Vertex_Uint64{Uint64: math.MaxUint64}}),
+		mkVertexRec(&pb.Vertex{Key: "raw", Value: &pb.Vertex_Bytes{Bytes: []byte{0x00, 0xff, 0x10}}}),
+		mkVertexRec(&pb.Vertex{Key: "ttl", Expiration: timestamppb.New(exp), Value: &pb.Vertex_Float64{Float64: 2.5}}),
+		mkEdgeRec(&pb.Edge{Tail: "alice", Head: "big", Weight: 1.5}),
+		mkEdgeRec(&pb.Edge{Tail: "big", Head: "ubig", Weight: 2, Expiration: timestamppb.New(exp)}),
+	}
+}
+
+// TestBackupCodec_RoundTrip encodes a mixed vertex/edge stream and decodes
+// it back in both formats, asserting exact equality (the format-orchestration
+// half of #692, exercised without a server).
+func TestBackupCodec_RoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		format Format
+	}{
+		{"proto", FormatProto},
+		{"ndjson", FormatNDJSON},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			recs := sampleBackupRecords()
+
+			var buf bytes.Buffer
+			bw := bufio.NewWriter(&buf)
+			for _, r := range recs {
+				if err := encodeBackupRecord(bw, tc.format, r); err != nil {
+					t.Fatalf("encode: %v", err)
+				}
+			}
+			if err := bw.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+
+			dec := newBackupDecoder(&buf, tc.format)
+			var got []*pb.BackupSnapshotResponse
+			for {
+				rec, err := dec.next()
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				if err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				got = append(got, rec)
+			}
+
+			if len(got) != len(recs) {
+				t.Fatalf("decoded %d records, want %d", len(got), len(recs))
+			}
+			for i := range recs {
+				if !proto.Equal(got[i], recs[i]) {
+					t.Errorf("[%d] round-trip mismatch:\n got=%v\nwant=%v", i, got[i], recs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBackupCodec_NDJSONUnknownKind(t *testing.T) {
+	dec := newBackupDecoder(strings.NewReader(`{"kind":"bogus","key":"x"}`+"\n"), FormatNDJSON)
+	if _, err := dec.next(); err == nil {
+		t.Fatal("want error for unknown kind, got nil")
+	}
+}
+
+// TestBackupCodec_NDJSONShape locks the on-disk NDJSON line shape: a "kind"
+// discriminator spliced ahead of the MarshalVertexJSON / MarshalEdgeJSON
+// fields.
+func TestBackupCodec_NDJSONShape(t *testing.T) {
+	var buf bytes.Buffer
+	bw := bufio.NewWriter(&buf)
+	if err := encodeBackupRecord(bw, FormatNDJSON, mkVertexRec(&pb.Vertex{Key: "k", Value: &pb.Vertex_String_{String_: "v"}})); err != nil {
+		t.Fatal(err)
+	}
+	if err := encodeBackupRecord(bw, FormatNDJSON, mkEdgeRec(&pb.Edge{Tail: "a", Head: "b", Weight: 1})); err != nil {
+		t.Fatal(err)
+	}
+	_ = bw.Flush()
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2: %q", len(lines), buf.String())
+	}
+	if !strings.HasPrefix(lines[0], `{"kind":"vertex",`) {
+		t.Errorf("vertex line = %s", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], `{"kind":"edge",`) {
+		t.Errorf("edge line = %s", lines[1])
+	}
+}

--- a/sdks/go/value.go
+++ b/sdks/go/value.go
@@ -1,9 +1,12 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math"
+	"strconv"
 	"time"
 
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
@@ -363,4 +366,195 @@ func MarshalVertexJSON(v *Vertex) ([]byte, error) {
 		out.Type, out.Value = "unset", nil
 	}
 	return json.Marshal(out)
+}
+
+// UnmarshalVertexJSON is the inverse of MarshalVertexJSON: it reconstructs
+// a *Vertex from the {key,type,value,expiration} shape. Numbers are decoded
+// via json.Number so int64/uint64 magnitudes above 2^53 survive without a
+// float64 intermediate. Any extra fields (e.g. the "kind" discriminator the
+// NDJSON backup codec adds) are ignored.
+//
+// Keep the type switch here in lockstep with MarshalVertexJSON's — the two
+// are a marshal/unmarshal pair.
+func UnmarshalVertexJSON(data []byte) (*Vertex, error) {
+	var raw struct {
+		Key        string          `json:"key"`
+		Type       string          `json:"type"`
+		Value      json.RawMessage `json:"value"`
+		Expiration string          `json:"expiration"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	v := &pb.Vertex{Key: raw.Key}
+	if raw.Expiration != "" {
+		t, err := time.Parse(time.RFC3339Nano, raw.Expiration)
+		if err != nil {
+			return nil, fmt.Errorf("vertex expiration: %w", err)
+		}
+		v.Expiration = timestamppb.New(t)
+	}
+	switch raw.Type {
+	case "float32":
+		f, err := jsonFloat(raw.Value)
+		if err != nil {
+			return nil, err
+		}
+		v.Value = &pb.Vertex_Float32{Float32: float32(f)}
+	case "float64":
+		f, err := jsonFloat(raw.Value)
+		if err != nil {
+			return nil, err
+		}
+		v.Value = &pb.Vertex_Float64{Float64: f}
+	case "int32":
+		n, err := jsonInt(raw.Value, 32)
+		if err != nil {
+			return nil, err
+		}
+		v.Value = &pb.Vertex_Int32{Int32: int32(n)}
+	case "int64":
+		n, err := jsonInt(raw.Value, 64)
+		if err != nil {
+			return nil, err
+		}
+		v.Value = &pb.Vertex_Int64{Int64: n}
+	case "uint32":
+		u, err := jsonUint(raw.Value, 32)
+		if err != nil {
+			return nil, err
+		}
+		v.Value = &pb.Vertex_Uint32{Uint32: uint32(u)}
+	case "uint64":
+		u, err := jsonUint(raw.Value, 64)
+		if err != nil {
+			return nil, err
+		}
+		v.Value = &pb.Vertex_Uint64{Uint64: u}
+	case "bool":
+		var b bool
+		if err := json.Unmarshal(raw.Value, &b); err != nil {
+			return nil, err
+		}
+		v.Value = &pb.Vertex_Bool{Bool: b}
+	case "string":
+		var s string
+		if err := json.Unmarshal(raw.Value, &s); err != nil {
+			return nil, err
+		}
+		v.Value = &pb.Vertex_String_{String_: s}
+	case "bytes":
+		var b []byte
+		if err := json.Unmarshal(raw.Value, &b); err != nil {
+			return nil, err
+		}
+		v.Value = &pb.Vertex_Bytes{Bytes: b}
+	case "timestamp":
+		var s string
+		if err := json.Unmarshal(raw.Value, &s); err != nil {
+			return nil, err
+		}
+		t, err := time.Parse(time.RFC3339Nano, s)
+		if err != nil {
+			return nil, fmt.Errorf("timestamp value: %w", err)
+		}
+		v.Value = &pb.Vertex_Timestamp{Timestamp: timestamppb.New(t)}
+	case "duration":
+		var s string
+		if err := json.Unmarshal(raw.Value, &s); err != nil {
+			return nil, err
+		}
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return nil, fmt.Errorf("duration value: %w", err)
+		}
+		v.Value = &pb.Vertex_Duration{Duration: durationpb.New(d)}
+	case "nil":
+		v.Value = &pb.Vertex_Nil{Nil: true}
+	case "unset", "":
+		// no value variant
+	default:
+		return nil, fmt.Errorf("unknown vertex type %q", raw.Type)
+	}
+	return v, nil
+}
+
+// MarshalEdgeJSON renders an Edge as {tail,head,weight,expiration}, the
+// edge sibling of MarshalVertexJSON used by the NDJSON backup codec.
+// Expiration is RFC3339Nano and omitted when the edge is permanent.
+func MarshalEdgeJSON(e *Edge) ([]byte, error) {
+	out := struct {
+		Tail       string  `json:"tail"`
+		Head       string  `json:"head"`
+		Weight     float32 `json:"weight"`
+		Expiration string  `json:"expiration,omitempty"`
+	}{Tail: e.GetTail(), Head: e.GetHead(), Weight: e.GetWeight()}
+	if e.GetExpiration() != nil {
+		if t := e.GetExpiration().AsTime(); !t.IsZero() {
+			out.Expiration = t.Format(time.RFC3339Nano)
+		}
+	}
+	return json.Marshal(out)
+}
+
+// UnmarshalEdgeJSON is the inverse of MarshalEdgeJSON. Extra fields (e.g. a
+// "kind" discriminator) are ignored.
+func UnmarshalEdgeJSON(data []byte) (*Edge, error) {
+	var raw struct {
+		Tail       string  `json:"tail"`
+		Head       string  `json:"head"`
+		Weight     float32 `json:"weight"`
+		Expiration string  `json:"expiration"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	e := &pb.Edge{Tail: raw.Tail, Head: raw.Head, Weight: raw.Weight}
+	if raw.Expiration != "" {
+		t, err := time.Parse(time.RFC3339Nano, raw.Expiration)
+		if err != nil {
+			return nil, fmt.Errorf("edge expiration: %w", err)
+		}
+		e.Expiration = timestamppb.New(t)
+	}
+	return e, nil
+}
+
+// jsonInt / jsonUint / jsonFloat decode a JSON number through json.Number so
+// 64-bit integer magnitudes above 2^53 are not corrupted by a float64
+// intermediate (#685 backup/restore fidelity).
+func jsonInt(raw json.RawMessage, bits int) (int64, error) {
+	n, err := jsonNumber(raw)
+	if err != nil {
+		return 0, err
+	}
+	// ParseInt with an explicit bit size bounds-checks the value, so the
+	// int32 narrowing in UnmarshalVertexJSON cannot silently overflow.
+	return strconv.ParseInt(n.String(), 10, bits)
+}
+
+func jsonUint(raw json.RawMessage, bits int) (uint64, error) {
+	n, err := jsonNumber(raw)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(n.String(), 10, bits)
+}
+
+func jsonFloat(raw json.RawMessage) (float64, error) {
+	n, err := jsonNumber(raw)
+	if err != nil {
+		return 0, err
+	}
+	return n.Float64()
+}
+
+func jsonNumber(raw json.RawMessage) (json.Number, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var n json.Number
+	if err := dec.Decode(&n); err != nil {
+		return "", err
+	}
+	return n, nil
 }

--- a/sdks/go/value_test.go
+++ b/sdks/go/value_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -511,5 +512,65 @@ func TestVertexExpiration(t *testing.T) {
 	}
 	if got := VertexExpiration(&Vertex{}); !got.IsZero() {
 		t.Errorf("empty expiration = %v, want zero", got)
+	}
+}
+
+// TestVertexJSON_RoundTrip exercises MarshalVertexJSON ↔ UnmarshalVertexJSON
+// across every value type, including int64/uint64 magnitudes above 2^53
+// (which would corrupt through a float64 intermediate) and a value-bearing
+// expiration.
+func TestVertexJSON_RoundTrip(t *testing.T) {
+	exp := time.Date(2026, 6, 18, 12, 30, 45, 123456789, time.UTC)
+	cases := []*Vertex{
+		{Key: "f32", Value: &pb.Vertex_Float32{Float32: 1.5}},
+		{Key: "f64", Value: &pb.Vertex_Float64{Float64: 3.141592653589793}},
+		{Key: "i32", Value: &pb.Vertex_Int32{Int32: -42}},
+		{Key: "i64max", Value: &pb.Vertex_Int64{Int64: math.MaxInt64}},
+		{Key: "i64min", Value: &pb.Vertex_Int64{Int64: math.MinInt64}},
+		{Key: "u32", Value: &pb.Vertex_Uint32{Uint32: 42}},
+		{Key: "u64max", Value: &pb.Vertex_Uint64{Uint64: math.MaxUint64}},
+		{Key: "bool", Value: &pb.Vertex_Bool{Bool: true}},
+		{Key: "str", Value: &pb.Vertex_String_{String_: "héllo \"world\"\n"}},
+		{Key: "bytes", Value: &pb.Vertex_Bytes{Bytes: []byte{0x00, 0x01, 0xff, 0x7f}}},
+		{Key: "ts", Value: &pb.Vertex_Timestamp{Timestamp: timestamppb.New(exp)}},
+		{Key: "dur", Value: &pb.Vertex_Duration{Duration: durationpb.New(90*time.Minute + 500*time.Millisecond)}},
+		{Key: "nilval", Value: &pb.Vertex_Nil{Nil: true}},
+		{Key: "noval"},
+		{Key: "withexp", Expiration: timestamppb.New(exp), Value: &pb.Vertex_String_{String_: "x"}},
+	}
+	for _, want := range cases {
+		b, err := MarshalVertexJSON(want)
+		if err != nil {
+			t.Fatalf("%s: marshal: %v", want.Key, err)
+		}
+		got, err := UnmarshalVertexJSON(b)
+		if err != nil {
+			t.Fatalf("%s: unmarshal: %v (json=%s)", want.Key, err, b)
+		}
+		if !proto.Equal(got, want) {
+			t.Errorf("%s round-trip mismatch:\n got=%v\nwant=%v\njson=%s", want.Key, got, want, b)
+		}
+	}
+}
+
+func TestEdgeJSON_RoundTrip(t *testing.T) {
+	exp := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	cases := []*Edge{
+		{Tail: "a", Head: "b", Weight: 1.5},
+		{Tail: "a", Head: "b", Weight: -2.25, Expiration: timestamppb.New(exp)},
+		{Tail: "x:1", Head: "x:2", Weight: 0},
+	}
+	for i, want := range cases {
+		b, err := MarshalEdgeJSON(want)
+		if err != nil {
+			t.Fatalf("[%d] marshal: %v", i, err)
+		}
+		got, err := UnmarshalEdgeJSON(b)
+		if err != nil {
+			t.Fatalf("[%d] unmarshal: %v", i, err)
+		}
+		if !proto.Equal(got, want) {
+			t.Errorf("[%d] round-trip mismatch: got=%v want=%v json=%s", i, got, want, b)
+		}
 	}
 }

--- a/tests/integration/backup_test.go
+++ b/tests/integration/backup_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -121,4 +122,80 @@ func drainBackup(t *testing.T, ctx context.Context, raw graphv1connect.LanternSe
 		t.Fatalf("BackupSnapshot stream: %v", err)
 	}
 	return vertices, edges
+}
+
+// TestBackupRestore_E2E_SDK round-trips a graph through the SDK Backup
+// (dump) and Restore (load) helpers across both wire formats, into a fresh
+// server, and verifies values + an int64 above 2^53 survive (json.Number).
+func TestBackupRestore_E2E_SDK(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		format client.Format
+	}{
+		{"proto", client.FormatProto},
+		{"ndjson", client.FormatNDJSON},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src, _ := newInProcessClient(t)
+			dst, _ := newInProcessClient(t)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			const bigInt = int64(9007199254740993) // 2^53 + 1
+			if err := src.PutVertex(ctx, "alice", "Alice", time.Minute); err != nil {
+				t.Fatal(err)
+			}
+			if err := src.PutVertex(ctx, "num", bigInt, time.Minute); err != nil {
+				t.Fatal(err)
+			}
+			if err := src.PutVertex(ctx, "carol", "Carol", time.Minute); err != nil {
+				t.Fatal(err)
+			}
+			if err := src.AddEdge(ctx, "alice", "num", 1.5, time.Minute); err != nil {
+				t.Fatal(err)
+			}
+			if err := src.AddEdge(ctx, "num", "carol", 2.0, time.Minute); err != nil {
+				t.Fatal(err)
+			}
+
+			var buf bytes.Buffer
+			bstats, err := src.Backup(ctx, &buf, client.WithBackupFormat(tc.format))
+			if err != nil {
+				t.Fatalf("Backup: %v", err)
+			}
+			if bstats.Vertices != 3 || bstats.Edges != 2 {
+				t.Fatalf("backup stats = %+v, want {3,2}", bstats)
+			}
+
+			rstats, err := dst.Restore(ctx, &buf, client.WithRestoreFormat(tc.format))
+			if err != nil {
+				t.Fatalf("Restore: %v", err)
+			}
+			if rstats.Vertices != 3 || rstats.Edges != 2 {
+				t.Fatalf("restore stats = %+v, want {3,2}", rstats)
+			}
+
+			alice, err := dst.GetVertex(ctx, "alice")
+			if err != nil {
+				t.Fatalf("GetVertex alice: %v", err)
+			}
+			if got, err := client.StringValue(alice); err != nil || got != "Alice" {
+				t.Errorf("alice = %q (err %v), want Alice", got, err)
+			}
+			num, err := dst.GetVertex(ctx, "num")
+			if err != nil {
+				t.Fatalf("GetVertex num: %v", err)
+			}
+			if got, err := client.IntValue(num); err != nil || int64(got) != bigInt {
+				t.Errorf("num = %d (err %v), want %d (2^53+1 must survive)", got, err, bigInt)
+			}
+			edge, err := dst.GetEdge(ctx, "alice", "num")
+			if err != nil {
+				t.Fatalf("GetEdge alice->num: %v", err)
+			}
+			if edge.GetWeight() != 1.5 {
+				t.Errorf("edge alice->num weight = %v, want 1.5", edge.GetWeight())
+			}
+		})
+	}
 }


### PR DESCRIPTION
Closes #692. **Layer B** of epic #685 (depends on the merged #691 `BackupSnapshot` RPC).

## What

The Go SDK whole-graph backup/restore feature:

- **`Backup(ctx, w, opts...) (BackupStats, error)`** — streams the `BackupSnapshot` RPC and serialises each frame to `w`. `WithBackupPrefix` → induced-subgraph filter; `WithBackupFormat`.
- **`Restore(ctx, r, opts...) (RestoreStats, error)`** — decodes frames and replays them through the **raw** `PutVertices`/`PutEdges` (so `*Vertex`/`*Edge` are put **verbatim** — value types + absolute expirations round-trip exactly, no lossy Go-native conversion). `WithRestoreFormat`, `WithRestoreChunkSize` (default 1000). Idempotent (Put); no rollback on partial restore.
- **Two formats** (`Format`): `FormatProto` (default, length-delimited protobuf via `protodelim` — lossless) and `FormatNDJSON` (one JSON object per line, `kind` discriminator).
- **NDJSON codec** in `value.go`: `UnmarshalVertexJSON` (inverse of `MarshalVertexJSON`, **`json.Number`** so int64/uint64 > 2^53 survive), `MarshalEdgeJSON`/`UnmarshalEdgeJSON`. The NDJSON line splices `"kind"` ahead of the existing `Marshal*JSON` output and decodes by reusing `Unmarshal*JSON` (which ignore the extra field).

## Tests

- `value_test.go` — `MarshalVertexJSON`↔`UnmarshalVertexJSON` across all 11 value types incl. `MaxInt64`/`MinInt64`/`MaxUint64`, bytes, timestamp, duration, nil, expiration; edge JSON round-trip.
- `backup_test.go` — codec round-trip for **both** formats (server-free), unknown-`kind` error, NDJSON line shape.
- `tests/integration/backup_test.go` — full-stack `Backup`→`Restore` into a fresh server in **both** formats, asserting values + an int64 above 2^53 survive.

Full local gate green: gofmt + sdks/go vet+test + root build+test (incl. integration).

## Scope

`sdks/go` only (imports `pb`). Restore reuses existing Put RPCs — no new server surface. The CLI `dump`/`restore` (#693) wraps these.
