### PR TITLE
feat(cli): dump/restore whole-graph backup commands

### DIFF
--- a/.github/skills/lantern-ops/SKILL.md
+++ b/.github/skills/lantern-ops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lantern-ops
-description: "Operate Lantern data through the `lantern-cli` CLI — read, write, delete, scan, count, bulk-load, and graph-walk vertices and edges from the command line. Use whenever the request involves manipulating data in a running Lantern server (get/put/delete a vertex or edge, prefix scan or count, bulk NDJSON load, prefix delete, or an illuminate graph walk), or driving Lantern from an interactive/agentic system. Do NOT use this skill for editing Lantern's own Go source, regenerating protobuf/wire code, server deployment/IaC, or the MCP decaying-memory tools."
+description: "Operate Lantern data through the `lantern-cli` CLI — read, write, delete, scan, count, bulk-load, back up/restore, and graph-walk vertices and edges from the command line. Use whenever the request involves manipulating data in a running Lantern server (get/put/delete a vertex or edge, prefix scan or count, bulk NDJSON load, whole-graph dump/restore backup, prefix delete, or an illuminate graph walk), or driving Lantern from an interactive/agentic system. Do NOT use this skill for editing Lantern's own Go source, regenerating protobuf/wire code, server deployment/IaC, or the MCP decaying-memory tools."
 ---
 
 # Lantern Ops — CLI command reference
@@ -297,6 +297,34 @@ cat edges.ndjson | lantern-cli bulk edges add -
 
 # edges put (idempotent)
 lantern-cli bulk edges put edges.ndjson --chunk-size 5000
+```
+
+## `dump` / `restore` — whole-graph backup
+
+Back up the whole graph and reload it. Unlike `bulk` (per-type NDJSON load),
+`dump` writes a **single consistent snapshot** of every live vertex **and**
+edge — taken under one server-side lock — and `restore` replays it. Like
+`bulk`, these are file-based commands (not part of the shared grammar).
+
+- **`dump <file|->`** — `-`/omitted = stdout. `--format proto` (default,
+  length-delimited protobuf, lossless) or `--format ndjson` (human-readable,
+  one `{"kind":"vertex|edge",…}` object per line). `--prefix <p>` restricts to
+  the induced subgraph over vertices with that key prefix (an edge is kept only
+  when both endpoints match). The summary (`dumped <V> vertices, <E> edges`)
+  prints to **stderr** so stdout can carry binary protobuf.
+- **`restore <file|->`** — `-`/omitted = stdin. `--format` must match the
+  dump. Records replay via `PutVertices`/`PutEdges` in `--chunk-size` batches;
+  Put is idempotent, so re-running a restore is safe. A malformed record aborts
+  (exit 1); **already-sent batches are not rolled back**. `OK <total>` prints to
+  stdout. Absolute expirations round-trip; an expiration beyond the target
+  server's `LANTERN_TOMBSTONE_TTL` cap is rejected (whole batch).
+
+```shell
+lantern-cli dump graph.lbk                  # whole graph -> file (protobuf)
+lantern-cli dump - --format ndjson > g.ndjson
+lantern-cli dump users.lbk --prefix user:   # partial backup
+lantern-cli restore graph.lbk               # reload
+cat g.ndjson | lantern-cli restore - --format ndjson
 ```
 
 ## Other commands

--- a/README.md
+++ b/README.md
@@ -373,9 +373,11 @@ The CLI gives you the same grammar two ways:
   surfaces never diverge.
 
 The grammar covers typed values (`type=`), variadic batch writes, prefix
-scans (`all=true`), `count`, `delete-prefix`, and `keys`. Two things sit
+scans (`all=true`), `count`, `delete-prefix`, and `keys`. Three things sit
 outside it: `lantern-cli bulk vertices|edges` streams NDJSON from a file or
-stdin, and the global `--tls*` / `--compression` flags configure transport.
+stdin; `lantern-cli dump` / `restore` back up and reload the whole graph
+(a single consistent snapshot — protobuf, or `--format ndjson`); and the
+global `--tls*` / `--compression` flags configure transport.
 
 Every subcommand has long-form, LLM-friendly help text
 (`lantern-cli <cmd> --help`); read commands emit JSON on stdout and write

--- a/cli/cmd/backup.go
+++ b/cli/cmd/backup.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/spf13/cobra"
+)
+
+var (
+	dumpFormat    string
+	dumpPrefix    string
+	restoreFormat string
+)
+
+// parseBackupFormat maps the --format flag onto a client.Format.
+func parseBackupFormat(s string) (client.Format, error) {
+	switch s {
+	case "proto", "":
+		return client.FormatProto, nil
+	case "ndjson":
+		return client.FormatNDJSON, nil
+	default:
+		return 0, fmt.Errorf("unknown --format %q (want proto|ndjson)", s)
+	}
+}
+
+// nopWriteCloser adapts an io.Writer (os.Stdout) to io.WriteCloser so dump
+// can treat a file and stdout uniformly without closing stdout.
+type nopWriteCloser struct{ io.Writer }
+
+func (nopWriteCloser) Close() error { return nil }
+
+// openOutput returns the destination for dump: stdout for "-"/"" else a file.
+func openOutput(path string) (io.WriteCloser, error) {
+	if path == "-" || path == "" {
+		return nopWriteCloser{os.Stdout}, nil
+	}
+	return os.Create(path)
+}
+
+var dumpCmd = &cobra.Command{
+	Use:   "dump <file|->",
+	Short: "Dump the whole graph to a file (backup)",
+	Long: `Stream a whole-graph, point-in-time backup to a file or stdout.
+
+The dump is a single consistent snapshot — every live vertex and edge taken
+under one server-side lock. Reload it with ` + "`lantern-cli restore`" + `.
+
+The destination is "-" or omitted for stdout, else a filesystem path. The
+default --format is length-delimited protobuf ("proto"); --format ndjson
+writes one human-readable JSON object per line. --prefix restricts the dump
+to the induced subgraph over vertices whose key has that prefix (an edge is
+kept only when both endpoints match).
+
+A summary ("dumped <V> vertices, <E> edges") is printed to stderr, so stdout
+can carry the binary protobuf stream.
+
+EXAMPLES
+  lantern-cli dump graph.lbk
+  lantern-cli dump - > graph.lbk
+  lantern-cli dump graph.ndjson --format ndjson
+  lantern-cli dump users.lbk --prefix user:
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format, err := parseBackupFormat(dumpFormat)
+		if err != nil {
+			return err
+		}
+		w, err := openOutput(args[0])
+		if err != nil {
+			return err
+		}
+
+		cli, err := dial()
+		if err != nil {
+			_ = w.Close()
+			return err
+		}
+		defer func() { _ = cli.Close() }()
+
+		stats, err := cli.Backup(cmd.Context(), w, client.WithBackupFormat(format), client.WithBackupPrefix(dumpPrefix))
+		// Close the destination before reporting so a write/flush error on
+		// the final Close surfaces instead of a spurious success.
+		if cerr := w.Close(); err == nil {
+			err = cerr
+		}
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "dumped %d vertices, %d edges\n", stats.Vertices, stats.Edges)
+		return nil
+	},
+}
+
+var restoreCmd = &cobra.Command{
+	Use:   "restore <file|->",
+	Short: "Restore a graph from a dump file (load)",
+	Long: `Load a backup produced by ` + "`lantern-cli dump`" + ` back into Lantern.
+
+The source is "-" or omitted for stdin, else a filesystem path. --format must
+match the dump's format (default "proto"). Records are replayed via
+PutVertices / PutEdges in batches of --chunk-size; Put is idempotent, so
+re-running a restore is safe.
+
+A malformed record aborts with exit code 1; already-sent batches are NOT
+rolled back (Lantern has no transactions). "OK <total>" is printed to stdout
+when the load finishes.
+
+EXAMPLES
+  lantern-cli restore graph.lbk
+  cat graph.lbk | lantern-cli restore -
+  lantern-cli restore graph.ndjson --format ndjson
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format, err := parseBackupFormat(restoreFormat)
+		if err != nil {
+			return err
+		}
+		r, err := openInput(args[0])
+		if err != nil {
+			return err
+		}
+		defer func() { _ = r.Close() }()
+
+		cli, err := dial()
+		if err != nil {
+			return err
+		}
+		defer func() { _ = cli.Close() }()
+
+		stats, err := cli.Restore(cmd.Context(), r, client.WithRestoreFormat(format), client.WithRestoreChunkSize(flagChunkSize))
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK %d\n", stats.Vertices+stats.Edges)
+		return nil
+	},
+}
+
+func init() {
+	dumpCmd.Flags().StringVar(&dumpFormat, "format", "proto", `output format: "proto" or "ndjson"`)
+	dumpCmd.Flags().StringVar(&dumpPrefix, "prefix", "", "restrict to vertices with this key prefix (empty = whole graph)")
+	restoreCmd.Flags().StringVar(&restoreFormat, "format", "proto", `input format: "proto" or "ndjson"`)
+	rootCmd.AddCommand(dumpCmd, restoreCmd)
+}

--- a/cli/cmd/backup_test.go
+++ b/cli/cmd/backup_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+func TestParseBackupFormat(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    client.Format
+		wantErr bool
+	}{
+		{"proto", client.FormatProto, false},
+		{"", client.FormatProto, false},
+		{"ndjson", client.FormatNDJSON, false},
+		{"yaml", 0, true},
+	}
+	for _, c := range cases {
+		got, err := parseBackupFormat(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("parseBackupFormat(%q): want error, got nil", c.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseBackupFormat(%q): %v", c.in, err)
+		}
+		if got != c.want {
+			t.Errorf("parseBackupFormat(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestOpenOutput_Stdout(t *testing.T) {
+	for _, p := range []string{"-", ""} {
+		w, err := openOutput(p)
+		if err != nil {
+			t.Fatalf("openOutput(%q): %v", p, err)
+		}
+		if _, ok := w.(nopWriteCloser); !ok {
+			t.Errorf("openOutput(%q): want nopWriteCloser (stdout), got %T", p, w)
+		}
+		if err := w.Close(); err != nil {
+			t.Errorf("Close stdout wrapper: %v", err)
+		}
+	}
+}
+
+func TestOpenOutput_File(t *testing.T) {
+	path := t.TempDir() + "/dump.lbk"
+	w, err := openOutput(path)
+	if err != nil {
+		t.Fatalf("openOutput(file): %v", err)
+	}
+	if _, err := w.Write([]byte("x")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("dump file not created: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #693. **Layer C** of epic #685 (depends on merged #691 RPC + #692 SDK). The user-facing CLI — completes the whole-graph backup/restore surface.

## What

`cli/cmd/backup.go` adds two **cobra-only, file-based** commands (like `bulk` — NOT in the shared REPL / admin `/cli` grammar, since they touch the local filesystem):

- **`dump <file|->`** → `client.Backup`. `-`/omitted = stdout. `--format proto` (default, lossless length-delimited protobuf) | `ndjson`. `--prefix` restricts to the induced subgraph. Summary `dumped <V> vertices, <E> edges` → **stderr** (stdout may carry binary).
- **`restore <file|->`** → `client.Restore`. `-`/omitted = stdin. `--format` must match the dump. Records replay via `PutVertices`/`PutEdges` in `--chunk-size` batches (idempotent; no rollback on partial). `OK <total>` → stdout.

Naming mirrors `pg_dump`/`pg_restore`.

## Tests / docs

- `cli/cmd/backup_test.go` — `parseBackupFormat` (proto/ndjson/unknown) + `openOutput` (stdout vs file). `grammar_test.go` unaffected (dump/restore are not REPL verbs, same as `bulk`).
- README "Use the CLI" + `.github/skills/lantern-ops` SKILL document `dump`/`restore` (both formats, `--prefix`, the `LANTERN_TOMBSTONE_TTL` restore caveat).

The full Backup→Restore round-trip (both formats, int64>2^53) is covered end-to-end by `tests/integration/backup_test.go` (added in #692). Local gate green: gofmt + cli + integration.

## Note

A live CLI smoke against the running compose stack returns 404 for `dump` because that container is the **old published image** without the `BackupSnapshot` RPC; the new server image ships in the release cascade that follows this merge.
