### PR TITLE
chore(release): bump module pins for backup/restore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.4.0
-	github.com/anaregdesign/lantern/core v0.7.1
+	github.com/anaregdesign/lantern/core v0.8.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
-	github.com/anaregdesign/lantern/pb v0.7.0
-	github.com/anaregdesign/lantern/sdks/go v0.16.0
+	github.com/anaregdesign/lantern/pb v0.8.0
+	github.com/anaregdesign/lantern/sdks/go v0.17.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	github.com/anaregdesign/lantern/core v0.7.0
-	github.com/anaregdesign/lantern/pb v0.7.0
+	github.com/anaregdesign/lantern/pb v0.8.0
 	golang.org/x/net v0.56.0
 	google.golang.org/protobuf v1.36.11
 )


### PR DESCRIPTION
Pre-tag pin bump for the backup/restore release cascade (epic #685, layers #691/#692/#693 merged).

- `sdks/go/go.mod`: require pb v0.7.0 -> **v0.8.0** (Backup uses `BackupSnapshotResponse`).
- `go.mod` (root): require pb -> **v0.8.0**, core v0.7.1 -> **v0.8.0**, sdks/go v0.16.0 -> **v0.17.0**.

All replace-backed, so local/CI builds are unaffected (`go mod tidy` leaves them stable, verified). Requires are metadata for downstream `go get`. Tags pb/v0.8.0 -> core/v0.8.0 -> sdks/go/v0.17.0 -> v0.18.0 follow this merge.