### PR TITLE
fix(core): skip storing born-expired vertex writes (#698)

### DIFF
--- a/core/graphcache/batch.go
+++ b/core/graphcache/batch.go
@@ -43,7 +43,7 @@ func (c *GraphCache[S, T]) PutVerticesWithExpiration(items []VertexItem[S, T]) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for _, it := range items {
-		c.putVertexLocked(it.Key, it.Value, it.Expiration)
+		c.putLocalVertexLocked(it.Key, it.Value, it.Expiration)
 	}
 }
 

--- a/core/graphcache/cache.go
+++ b/core/graphcache/cache.go
@@ -182,6 +182,32 @@ func (c *GraphCache[S, T]) putVertexLocked(key S, value T, expiration time.Time)
 	}
 }
 
+// putLocalVertexLocked is the client-write entry that backs
+// PutVertexWithExpiration and the PutVerticesWithExpiration batch. It treats a
+// dead-on-arrival write — one whose expiration is already in the past — as an
+// expiry of the key rather than an insert. Storing an already-expired vertex
+// has no observable effect (GetVertex hides expired entries via
+// cache.IsLiveAt) and would only occupy a cache slot plus prefix- and
+// search-index postings until the next GC sweep, inflating the map high-water
+// under a churn of short-lived writes (#698). A born-expired write therefore
+// deletes any existing entry for the key and stores nothing.
+//
+// The replicated apply path (PutVertexWithExpirationHLC) deliberately does NOT
+// route through here: it must preserve LWW/HLC/tombstone causality and records
+// a per-key watermark after the store, so it keeps calling putVertexLocked
+// directly. Caller must hold c.mu.
+func (c *GraphCache[S, T]) putLocalVertexLocked(key S, value T, expiration time.Time) {
+	if !cache.IsLiveAt(expiration, time.Now()) {
+		// Dead on arrival. Delete is a cheap map-miss when the key is absent
+		// (the common churn case) and fires the eviction hook — releasing the
+		// dictionary reference and dropping prefix/search postings — when it is
+		// present, so an overwrite-to-expired still takes effect.
+		c.vertices.Delete(key)
+		return
+	}
+	c.putVertexLocked(key, value, expiration)
+}
+
 // ensureVertexLocked auto-creates an endpoint vertex (used by edge writes)
 // without overwriting an existing value. The dict reference is taken only
 // on the first insertion so refcount tracks the cache contents 1:1.
@@ -227,7 +253,7 @@ func (c *GraphCache[S, T]) PutVertexWithExpiration(key S, value T, expiration ti
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.putVertexLocked(key, value, expiration)
+	c.putLocalVertexLocked(key, value, expiration)
 }
 
 func (c *GraphCache[S, T]) PutVertexWithTTL(key S, value T, ttl time.Duration) {

--- a/core/graphcache/cache_test.go
+++ b/core/graphcache/cache_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/anaregdesign/lantern/core/cache"
 	"github.com/anaregdesign/lantern/core/graph"
 	"github.com/anaregdesign/lantern/core/hlc"
+	"github.com/anaregdesign/lantern/core/search"
 )
 
 func TestGraph_AddEdge(t *testing.T) {
@@ -363,6 +364,74 @@ func TestGraphCache_PutVertexWithExpiration(t *testing.T) {
 			tt.c.PutVertexWithExpiration(tt.args.key, tt.args.value, tt.args.expiration)
 		})
 	}
+}
+
+// TestGraphCache_PutVertexWithExpiration_BornExpired pins #698: a client write
+// whose expiration is already in the past is dead on arrival and must not be
+// stored. Storing it would only inflate the vertex / dictionary / prefix /
+// search high-water until the next GC sweep, for zero observable benefit
+// (GetVertex already hides expired entries). An overwrite-to-expired must still
+// drop the existing live entry. The full secondary-index wiring is enabled so
+// the test catches a dead key leaking into the prefix or search index too.
+func TestGraphCache_PutVertexWithExpiration_BornExpired(t *testing.T) {
+	newCache := func() *GraphCache[string, string] {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnablePrefixIndex(func(s string) string { return s })
+		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+		return c
+	}
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+
+	// assertNoTrace fails when any of the four structures still references key.
+	assertNoTrace := func(t *testing.T, c *GraphCache[string, string], key, term string) {
+		t.Helper()
+		if _, ok := c.GetVertex(key); ok {
+			t.Fatalf("GetVertex(%q) is visible, want absent", key)
+		}
+		if got := c.VertexCount(); got != 0 {
+			t.Fatalf("VertexCount() = %d, want 0", got)
+		}
+		if n := c.CountByPrefix(key); n != 0 {
+			t.Fatalf("CountByPrefix(%q) = %d, want 0 (prefix index retained dead key)", key, n)
+		}
+		if hits := c.SearchVertices(term, 10, ""); len(hits) != 0 {
+			t.Fatalf("SearchVertices(%q) = %d hits, want 0 (search index retained dead key)", term, len(hits))
+		}
+	}
+
+	t.Run("NewKeyNotStored", func(t *testing.T) {
+		c := newCache()
+		c.PutVertexWithExpiration("k", "alpha", past)
+		assertNoTrace(t, c, "k", "alpha")
+	})
+
+	t.Run("OverwriteExpiresExisting", func(t *testing.T) {
+		c := newCache()
+		c.PutVertexWithExpiration("k", "alpha", future)
+		if _, ok := c.GetVertex("k"); !ok {
+			t.Fatal("setup: live vertex was not stored")
+		}
+		c.PutVertexWithExpiration("k", "beta", past)
+		assertNoTrace(t, c, "k", "alpha")
+	})
+
+	t.Run("BatchSkipsBornExpiredOnly", func(t *testing.T) {
+		c := newCache()
+		c.PutVerticesWithExpiration([]VertexItem[string, string]{
+			{Key: "live", Value: "v", Expiration: future},
+			{Key: "dead", Value: "v", Expiration: past},
+		})
+		if got := c.VertexCount(); got != 1 {
+			t.Fatalf("VertexCount() = %d, want 1 (only the live item)", got)
+		}
+		if _, ok := c.GetVertex("dead"); ok {
+			t.Fatal("batch stored the born-expired item 'dead'")
+		}
+		if _, ok := c.GetVertex("live"); !ok {
+			t.Fatal("batch dropped the live item 'live'")
+		}
+	})
 }
 
 func TestGraphCache_PutVertexWithTTL(t *testing.T) {

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -11,6 +11,7 @@ import (
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/anaregdesign/lantern/core/cache"
 	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
@@ -498,7 +499,9 @@ func (s *LanternService) PutVertices(ctx context.Context, request *pb.PutVertice
 	}
 	in := request.GetVertices()
 	s.metrics.OnBatch("PutVertices", len(in))
+	now := time.Now()
 	items := make([]graphcache.VertexItem[string, *pb.Vertex], 0, len(in))
+	liveCount := 0
 	for _, v := range in {
 		if err := s.validateExpiration(v.GetExpiration().AsTime()); err != nil {
 			return nil, err
@@ -508,9 +511,30 @@ func (s *LanternService) PutVertices(ctx context.Context, request *pb.PutVertice
 			Value:      v,
 			Expiration: v.GetExpiration().AsTime(),
 		})
+		if cache.IsLiveAt(v.GetExpiration().AsTime(), now) {
+			liveCount++
+		}
 	}
 	s.cache.PutVerticesWithExpiration(items)
-	s.logMutation(&pb.MutationOp{Op: &pb.MutationOp_PutVertices{PutVertices: request}})
+	// A born-expired write (expiration already in the past) is dead on arrival:
+	// the cache does not store it and it is invisible to GetVertex, so it must
+	// not be logged or replicated either — otherwise peers would apply, store
+	// and index (and watermark in vertexHLC) data that is already gone,
+	// inflating their high-water for zero benefit (#698). Replicate only the
+	// live subset; the all-live fast path forwards the original request
+	// unchanged so the steady-state cost is a single liveness check per vertex.
+	switch {
+	case liveCount == len(in):
+		s.logMutation(&pb.MutationOp{Op: &pb.MutationOp_PutVertices{PutVertices: request}})
+	case liveCount > 0:
+		live := make([]*pb.Vertex, 0, liveCount)
+		for _, v := range in {
+			if cache.IsLiveAt(v.GetExpiration().AsTime(), now) {
+				live = append(live, v)
+			}
+		}
+		s.logMutation(&pb.MutationOp{Op: &pb.MutationOp_PutVertices{PutVertices: &pb.PutVerticesRequest{Vertices: live}}})
+	}
 	return &pb.PutVerticesResponse{Written: int32(len(items))}, nil
 }
 

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -912,6 +912,100 @@ func TestLanternService_MutationLog_NotWired_NoOp(t *testing.T) {
 	}
 }
 
+// TestLanternService_PutVertices_BornExpiredNotReplicated pins #698: a
+// born-expired vertex (expiration already in the past) is dead on arrival —
+// the cache does not store it, and it must not be appended to the mutation
+// log either, so peers never apply (store + index + watermark) data that is
+// already gone. A mixed batch logs only its live subset; an all-live batch is
+// forwarded unchanged.
+func TestLanternService_PutVertices_BornExpiredNotReplicated(t *testing.T) {
+	newSvc := func(t *testing.T) (*LanternService, *mutationlog.Log, *int) {
+		t.Helper()
+		log := mutationlog.New(mutationlog.Options{Capacity: 64, SubscriberBuffer: 64})
+		t.Cleanup(func() { _ = log.Close() })
+		clock := hlc.New(hlc.NodeID{0x01}, hlc.Options{})
+		appendCount := 0
+		s := NewLanternService(graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)).
+			WithReplication(log, clock, func() { appendCount++ })
+		return s, log, &appendCount
+	}
+	past := timestamppb.New(time.Now().Add(-time.Hour))
+	future := timestamppb.New(time.Now().Add(time.Hour))
+
+	t.Run("AllBornExpired_NotLogged", func(t *testing.T) {
+		s, log, appendCount := newSvc(t)
+		if _, err := s.PutVertices(context.Background(), &pb.PutVerticesRequest{
+			Vertices: []*pb.Vertex{{Key: "a", Expiration: past}, {Key: "b", Expiration: past}},
+		}); err != nil {
+			t.Fatalf("PutVertices: %v", err)
+		}
+		if *appendCount != 0 {
+			t.Fatalf("appendCount = %d, want 0 (born-expired must not replicate)", *appendCount)
+		}
+		if _, ok := log.LastSeq(); ok {
+			t.Fatal("mutation log has entries, want empty")
+		}
+	})
+
+	t.Run("Mixed_LogsOnlyLive", func(t *testing.T) {
+		s, log, appendCount := newSvc(t)
+		ch, cancel, err := log.Subscribe(0)
+		if err != nil {
+			t.Fatalf("Subscribe: %v", err)
+		}
+		t.Cleanup(func() { _ = cancel() })
+		if _, err := s.PutVertices(context.Background(), &pb.PutVerticesRequest{
+			Vertices: []*pb.Vertex{
+				{Key: "dead1", Expiration: past},
+				{Key: "live", Expiration: future},
+				{Key: "dead2", Expiration: past},
+			},
+		}); err != nil {
+			t.Fatalf("PutVertices: %v", err)
+		}
+		if *appendCount != 1 {
+			t.Fatalf("appendCount = %d, want 1 (one mutation for the live subset)", *appendCount)
+		}
+		select {
+		case e := <-ch:
+			mu := e.Op.(*pb.Mutation)
+			got := mu.GetOp().GetPutVertices().GetVertices()
+			if len(got) != 1 || got[0].GetKey() != "live" {
+				t.Fatalf("logged vertices = %v, want exactly [live]", got)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for the live mutation")
+		}
+	})
+
+	t.Run("AllLive_ForwardsRequestUnchanged", func(t *testing.T) {
+		s, log, appendCount := newSvc(t)
+		ch, cancel, err := log.Subscribe(0)
+		if err != nil {
+			t.Fatalf("Subscribe: %v", err)
+		}
+		t.Cleanup(func() { _ = cancel() })
+		// "y" has no expiration (zero = never expires = live).
+		if _, err := s.PutVertices(context.Background(), &pb.PutVerticesRequest{
+			Vertices: []*pb.Vertex{{Key: "x", Expiration: future}, {Key: "y"}},
+		}); err != nil {
+			t.Fatalf("PutVertices: %v", err)
+		}
+		if *appendCount != 1 {
+			t.Fatalf("appendCount = %d, want 1", *appendCount)
+		}
+		select {
+		case e := <-ch:
+			mu := e.Op.(*pb.Mutation)
+			if got := mu.GetOp().GetPutVertices().GetVertices(); len(got) != 2 {
+				t.Fatalf("logged %d vertices, want 2 (request forwarded unchanged)", len(got))
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out")
+		}
+	})
+}
+
 func keyFor(i int) string {
 	return "k-" + itoa(i)
 }

--- a/testbed/bench/scenarios/ttl_churn.yaml
+++ b/testbed/bench/scenarios/ttl_churn.yaml
@@ -1,10 +1,16 @@
-# ttl_churn — short TTLs + steady writes → GC pressure.
-# Goal: catch leaks in expiration plumbing and timer wheels.
-# NOTE: ghz templates lack arithmetic, so we set `expiration` to `now`
-#       (via the built-in {{.Timestamp}} variable). Vertices expire
-#       immediately on insert, which exercises the eviction path on every
-#       write. The original intent (5 s sliding window) requires a server
-#       config knob; see follow-up.
+# ttl_churn — a flood of born-expired (dead-on-arrival) writes must not
+# accumulate memory.
+#
+# ghz templates lack arithmetic, so `expiration` is set to `now` (the
+# built-in {{.Timestamp}} variable); every PutVertex therefore arrives
+# already expired. Since #698 the server treats a write whose expiration is
+# already in the past as a no-op store (it is invisible to GetVertex the
+# instant it lands anyway), so a sustained born-expired write flood must
+# leave the vertex, dictionary, prefix-index and search-index high-water
+# flat. Before #698 those maps grew to the inter-sweep high-water
+# (~rps × GC interval ≈ 240k entries here) and never released that backing
+# capacity after the sweep drained them, tripping the leak gate with
+# tens of MiB retained against zero live vertices.
 name: ttl_churn
 phases:
   # steady is 2m so the post-warmup→post-cooldown leak window brackets the


### PR DESCRIPTION
## What

The `Release-time benchmark` job's `ttl_churn` scenario has been failing its
leak gate since ~v0.15.0. Because the bench is non-blocking (excluded from
`release.needs`, #395) it shipped red for many releases unnoticed.

**The failure is `heap_alloc` high-water retention, not a goroutine leak.**
(goroutine Δ = +0 on every replica in the failing run.)

## Root cause (two write paths)

`ttl_churn` writes vertices with `expiration = now` — born-expired, dead on
arrival. They leaked through **both** write paths:

1. **Local write** (the direct-write replica): each born-expired vertex was
   stored, interned in the dictionary, and inserted into the prefix + content
   search indexes, only for the 60 s GC sweep to evict it. ~240k dead entries
   piled up between sweeps, growing those maps to that high-water; Go maps never
   release backing capacity after `delete`.
2. **Replication apply** (the peers): the origin logged the born-expired
   `PutVertices` to the mutation log and replicated it; peers applied it via
   `PutVertexWithExpirationHLC`, which stores + indexes the vertex **and**
   records a per-key `vertexHLC` watermark. On a replica this was the larger
   leak (heap diff: 48 MB `vertexHLC` + 35 MB dict + 24 MB vertices + 2.5 MB
   search).

## Fix

A vertex written with a past `expiration` is invisible to `GetVertex` the
instant it lands (`cache.IsLiveAt`), so it has zero observable benefit — don't
store it, and don't propagate it:

- **core** ([`graphcache`](core/graphcache/cache.go)): `PutVertexWithExpiration`
  and `PutVerticesWithExpiration` skip storing a born-expired write (deleting any
  existing entry for the key so an overwrite-to-expired still takes effect). The
  replicated apply path `PutVertexWithExpirationHLC` is **untouched** so
  LWW/HLC/tombstone causality is unaffected.
- **server** ([`service`](server/service/service.go)): `PutVertices` appends only
  the **live** subset to the mutation log, so a born-expired write never reaches
  peers. The all-live fast path forwards the request unchanged (one liveness
  check per vertex in steady state).

## Validation (3-replica bench)

`LANTERN_IMAGE=lantern:local ./testbed/bench/run.sh ttl_churn` (after
`docker build -t lantern:local .`):

| replica | heap_alloc Δ before | heap_alloc Δ after |
|---|---|---|
| `:9390` (direct writes) | +46 MiB | **-1.4 MiB** |
| `:9391` (replica) | +122 MiB | **+1.0 MiB** |
| `:9392` (replica) | +121 MiB | **+7.9 MiB** |

Gate threshold 16 MiB → **leak gate `pass`**.

- New regression tests:
  `TestGraphCache_PutVertexWithExpiration_BornExpired` (core: born-expired stores
  nothing, leaves prefix + search empty, expires an existing entry) and
  `TestLanternService_PutVertices_BornExpiredNotReplicated` (server: all-dead
  batch logs nothing, mixed batch logs only the live subset, all-live forwards
  unchanged).
- Local quality gate green: `gofmt -l` clean; `go test ./...` passes in core,
  server (+`go vet`), and root (incl. `tests/integration`).
- `ttl_churn.yaml` header comment updated to describe the corrected behavior.

## Follow-up (separate issue)

The investigation surfaced an **unbounded leak in `vertexHLC`** — the per-key
LWW watermark map is written by the apply path but never deleted, so it grows
forever on a replica under high key cardinality. Filed as #700 (it needs a
locking design: the eviction hook fires without `c.mu` held, and `vertexHLC` has
no internal lock). Not exercised once born-expired writes stop replicating, so
it is out of scope here.

Closes #698
