### PR TITLE
ci: stop cancelling in-progress Commitlint runs to avoid stuck cancelled checks

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -17,10 +17,13 @@ on:
 permissions:
   pull-requests: read
 
-# Cancel superseded runs on the same PR — title edits can fire repeatedly.
+# Dedupe superseded *pending* runs on the same PR (title edits can fire
+# repeatedly), but do NOT cancel the in-progress / latest run. Cancelling it
+# leaves a `cancelled` check as the most recent "Validate PR title" result,
+# which surfaces the PR as failing even though the title is valid.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   pr-title:


### PR DESCRIPTION
## What

Set `cancel-in-progress: false` on the `Commitlint` workflow's concurrency
block (keeping the group so superseded *pending* runs are still deduped).

## Why

On #709 the same head commit ended up with two `Validate PR title` check runs —
one `success` and one `cancelled` — with the **cancelled** one most recent, so
the PR showed as `UNSTABLE`/failing even though the title was valid.

Root cause: `cancel-in-progress: true` cancels the in-progress run when rapid
`opened`/`edited`/`synchronize` events fire (e.g. the Copilot cloud agent
creating a PR + the first-run approval flow). A cancelled run leaves a
`cancelled` check as the latest result for the required-style
`Validate PR title` name.

With `cancel-in-progress: false`, GitHub still cancels superseded *pending*
runs (so we don't waste runners) but always lets the **latest** run finish, so
the most-recent `Validate PR title` result is always a real `success`/`failure`
— never a stuck `cancelled`. The job is a ~5s title check, so the extra
completions are negligible.

No issue filed — one-line CI-hygiene follow-up to the CI behaviour observed on
#709 (issue-first exemption for obvious CI fixes).
