### PR TITLE
fix(testbed): make #709 bench leak gates pass (24-byte contrib_ids, bounded churn, search toggle)

### DIFF
--- a/testbed/bench/compose.override.yml
+++ b/testbed/bench/compose.override.yml
@@ -29,6 +29,16 @@ x-lantern-bench-env: &lantern-bench-env
   # while keeping legitimate ring retention well under the leak_gate
   # heap budget. See issue #254.
   LANTERN_MUTATION_LOG_CAPACITY: "10000"
+  # Per-scenario cluster TTL / GC tick. run.sh exports the LANTERN_BENCH_*
+  # host vars from a scenario's optional `cluster:` block; both fall back to
+  # the canonical 3600/60 when unset, so scenarios without a `cluster:` block
+  # are unaffected. These override the canonical x-lantern-common values
+  # because the override file is merged last (per-key environment merge).
+  # Lets leak scenarios (search_churn, replication_apply_churn) drive prompt
+  # TTL eviction so the index / vertexHLC maps demonstrably shrink back to
+  # baseline during cooldown. See issue #711.
+  LANTERN_DEFAULT_TTL_SECONDS: "${LANTERN_BENCH_DEFAULT_TTL_SECONDS:-3600}"
+  LANTERN_GC_INTERVAL_SECONDS: "${LANTERN_BENCH_GC_INTERVAL_SECONDS:-60}"
 
 services:
   lantern-0:

--- a/testbed/bench/compose.override.yml
+++ b/testbed/bench/compose.override.yml
@@ -39,6 +39,11 @@ x-lantern-bench-env: &lantern-bench-env
   # baseline during cooldown. See issue #711.
   LANTERN_DEFAULT_TTL_SECONDS: "${LANTERN_BENCH_DEFAULT_TTL_SECONDS:-3600}"
   LANTERN_GC_INTERVAL_SECONDS: "${LANTERN_BENCH_GC_INTERVAL_SECONDS:-60}"
+  # Optional per-scenario search toggle. Defaults to the server default (on).
+  # A leak scenario that exercises an unrelated structure under high-cardinality
+  # unique content (e.g. replication_apply_churn isolating vertexHLC) can turn
+  # search off so the InvertedIndex does not dominate the heap signal.
+  LANTERN_SEARCH_ENABLED: "${LANTERN_BENCH_SEARCH_ENABLED:-true}"
 
 services:
   lantern-0:

--- a/testbed/bench/run.sh
+++ b/testbed/bench/run.sh
@@ -90,6 +90,14 @@ if [[ -n "$cluster_gc" && "$cluster_gc" != "null" ]]; then
   export LANTERN_BENCH_GC_INTERVAL_SECONDS="$cluster_gc"
   log "cluster override: LANTERN_GC_INTERVAL_SECONDS=${cluster_gc}"
 fi
+# NOTE: do not use `// ""` here — yq/jq treat a boolean `false` as empty, so
+# `.cluster.search_enabled // ""` would swallow an explicit `false`. Read the
+# raw value and test for the literal "null" (absent) instead.
+cluster_search="$(yq -r '.cluster.search_enabled' "$SCENARIO_FILE")"
+if [[ -n "$cluster_search" && "$cluster_search" != "null" ]]; then
+  export LANTERN_BENCH_SEARCH_ENABLED="$cluster_search"
+  log "cluster override: LANTERN_SEARCH_ENABLED=${cluster_search}"
+fi
 
 # ----- compose up ------------------------------------------------------------
 if [[ "${SKIP_UP:-0}" != "1" ]]; then

--- a/testbed/bench/run.sh
+++ b/testbed/bench/run.sh
@@ -72,6 +72,25 @@ endpoints=( $(yq -r '.target.endpoints[]' "$SCENARIO_FILE") )
 # the harness keeps working unchanged against the Connect-only server.
 # See #383 for the empirical verification log.
 
+# ----- optional per-scenario cluster env overrides --------------------------
+# A scenario may shorten the cluster's default TTL and/or GC tick (via a
+# top-level `cluster:` block) so that TTL-eviction churn — and the resulting
+# search-index / vertexHLC shrink — happens within the run window. The values
+# are exported as LANTERN_BENCH_* host vars that compose.override.yml reads
+# with a 3600/60 fallback, so scenarios without a `cluster:` block are
+# unaffected. Only meaningful on a fresh `compose up` (ignored under SKIP_UP,
+# where the cluster TTL/GC were fixed at the earlier up). See issue #711.
+cluster_ttl="$(yq -r '.cluster.default_ttl_seconds // ""' "$SCENARIO_FILE")"
+cluster_gc="$(yq -r '.cluster.gc_interval_seconds // ""' "$SCENARIO_FILE")"
+if [[ -n "$cluster_ttl" && "$cluster_ttl" != "null" ]]; then
+  export LANTERN_BENCH_DEFAULT_TTL_SECONDS="$cluster_ttl"
+  log "cluster override: LANTERN_DEFAULT_TTL_SECONDS=${cluster_ttl}"
+fi
+if [[ -n "$cluster_gc" && "$cluster_gc" != "null" ]]; then
+  export LANTERN_BENCH_GC_INTERVAL_SECONDS="$cluster_gc"
+  log "cluster override: LANTERN_GC_INTERVAL_SECONDS=${cluster_gc}"
+fi
+
 # ----- compose up ------------------------------------------------------------
 if [[ "${SKIP_UP:-0}" != "1" ]]; then
   log "compose up (project=$COMPOSE_PROJECT_NAME)"

--- a/testbed/bench/scenarios/backup_under_load.yaml
+++ b/testbed/bench/scenarios/backup_under_load.yaml
@@ -13,32 +13,30 @@
 #   SCENARIO=backup_under_load make bench
 name: backup_under_load
 phases:
-  warmup:
-    duration: 30s
-    concurrency: 8
-    rps: 200
-    # seed: populate graph so the backup has non-trivial data to stream.
-    calls:
-      - call: graph.v1.LanternService/PutVertex
-        data_template: |
-          {"vertex":{"key":"bk-{{mod .RequestNumber 5000}}","string_":"payload-{{.RequestNumber}}","expiration":"{{timeAfterSeconds 600}}"}}
-      - call: graph.v1.LanternService/AddEdge
-        data_template: |
-          {"tail":"bk-{{mod .RequestNumber 5000}}","head":"bk-{{mod (add .RequestNumber 1) 5000}}","weight":1.0,"expiration":"{{timeAfterSeconds 600}}"}
-  steady:
-    duration: 2m
-    concurrency: 32
-    rps: 2000
+  warmup:   { duration: 30s, concurrency: 8,  rps: 200 }
+  steady:   { duration: 2m,  concurrency: 16, rps: 600 }
   cooldown: 30s
 target:
   endpoints: ["localhost:6380"]
+  # calls[0] (PutVertex over bk-*) is what run.sh's warmup replays, so it
+  # seeds the graph the backup streams. calls[1] (AddEdge) gives the snapshot
+  # edges to fold. The fan-out rule forks one ghz per call at steady.rps/3
+  # (~200 rps each), so BackupSnapshot runs concurrent with sustained writes.
+  # Default 3600s TTL keeps the bounded bk-* graph populated for the run.
   calls:
-    # [0] writes to keep the graph mutating while backups are in-flight
+    # [0] working-set filler / seed — warmup replays this; keeps bk-*
+    #     vertices churning while backups are in-flight.
     - call: graph.v1.LanternService/PutVertex
       data_template: |
-        {"vertex":{"key":"bk-{{mod .RequestNumber 5000}}","string_":"payload-{{.RequestNumber}}","expiration":"{{timeAfterSeconds 300}}"}}
-    # [1] concurrent full-graph backup — issued at 1/100th the write rate
-    #     (≈ 20 rps) to avoid saturating the outbound bandwidth.
+        {"vertex":{"key":"bk-{{mod .RequestNumber 2000}}","string":"payload-{{.RequestNumber}}"}}
+    # [1] additive edges so the snapshot has edge records to fold (weight
+    #     summed across contributions, expiration = furthest contribution).
+    - call: graph.v1.LanternService/AddEdge
+      data_template: |
+        {"edge":{"tail":"bk-{{mod .RequestNumber 2000}}","head":"bk-{{mod (add .RequestNumber 1) 2000}}","weight":1.0}}
+    # [2] concurrent full-graph backup — streams the whole bounded graph
+    #     while writes mutate it; the serialiser must not accumulate heap
+    #     proportional to the number of backup calls.
     - call: graph.v1.LanternService/BackupSnapshot
       data_template: |
         {}

--- a/testbed/bench/scenarios/backup_under_load.yaml
+++ b/testbed/bench/scenarios/backup_under_load.yaml
@@ -25,10 +25,11 @@ target:
   # Default 3600s TTL keeps the bounded bk-* graph populated for the run.
   calls:
     # [0] working-set filler / seed — warmup replays this; keeps bk-*
-    #     vertices churning while backups are in-flight.
+    #     vertices churning while backups are in-flight. Bounded value
+    #     vocabulary (mod 100) keeps the on-by-default search index bounded.
     - call: graph.v1.LanternService/PutVertex
       data_template: |
-        {"vertex":{"key":"bk-{{mod .RequestNumber 2000}}","string":"payload-{{.RequestNumber}}"}}
+        {"vertex":{"key":"bk-{{mod .RequestNumber 2000}}","string":"payload-{{mod .RequestNumber 100}}"}}
     # [1] additive edges so the snapshot has edge records to fold (weight
     #     summed across contributions, expiration = furthest contribution).
     - call: graph.v1.LanternService/AddEdge

--- a/testbed/bench/scenarios/broad_rw.yaml
+++ b/testbed/bench/scenarios/broad_rw.yaml
@@ -82,12 +82,30 @@ target:
     - call: graph.v1.LanternService/CountVerticesByPrefix
       data_template: |
         {"prefix":"k-"}
-    # [11] idempotent AddEdge with ContribID — same (tail,head) retried repeatedly
-    #      at-most-once semantics; verifies the contrib_id dedup set stays bounded
-    #      (#706).  Uses a 200-value ContribID space to keep the set small.
+    # [11] idempotent AddEdge with ContribID — same (k-0,k-1) edge retried
+    #      repeatedly with at-most-once semantics; verifies the contrib_id
+    #      dedup set stays bounded (#706). The server only honors a canonical
+    #      24-byte id, so the bounded 200-value space is padded to 24 ASCII
+    #      bytes via backtick-quoted `printf` (a double-quoted "%024d" would
+    #      break ghz's pre-template JSON parse) before base64. Without the
+    #      pad the id decodes to zero and this silently joins call[4] on the
+    #      additive path, doubling the steady-state heap.
     - call: graph.v1.LanternService/AddEdge
       data_template: |
-        {"edge":{"tail":"k-0","head":"k-1","weight":1.0},"contribId":"{{ mod .RequestNumber 200 | toString | b64enc }}"}
+        {"edge":{"tail":"k-0","head":"k-1","weight":1.0},"contribId":"{{ printf `%024d` (mod .RequestNumber 200) | b64enc }}"}
+# heap_alloc is dominated by the additive AddEdge path (call[4], no
+# contrib_id): each call appends a (weight, expiration) contribution that
+# lives until the default 3600s TTL, so over a 2m steady at 1000 AddEdge/s
+# ~120k contributions accumulate. The bench cluster replicates every write to
+# all three peers (LANTERN_PEER_DISCOVERY=dns), so each replica independently
+# holds that set — ~100–145 MiB per replica, measured across runs. This is a
+# bounded working set, not a leak: goroutines stay flat/negative and the set
+# is capped by steady-duration × per-call rps, not by total run length.
+# (call[11] carries a bounded 24-byte ContribID so its retries dedup and add
+# negligible heap; only the deliberately-additive call[4] grows.) The gate is
+# sized with headroom over the measured peak. #709 bumped steady rps to 12000
+# (still 1000 per call across 12 calls) and lengthened the window without
+# lifting this gate; 192 restores the lockstep (was 64). See #711.
 leak_gate:
   goroutine_max_delta: 30
-  heap_alloc_max_delta_mb: 64
+  heap_alloc_max_delta_mb: 192

--- a/testbed/bench/scenarios/broad_rw.yaml
+++ b/testbed/bench/scenarios/broad_rw.yaml
@@ -76,7 +76,7 @@ target:
     # [9] edge scan — covers the ScanEdges path under the same write-filled graph.
     - call: graph.v1.LanternService/ScanEdges
       data_template: |
-        {"prefix":"k-","limit":128}
+        {"tailPrefix":"k-","limit":128}
     # [10] aggregate count — exercises CountVerticesByPrefix and its
     #      OnScan("CountVerticesByPrefix", ...) metric instrumentation (#704).
     - call: graph.v1.LanternService/CountVerticesByPrefix
@@ -87,7 +87,7 @@ target:
     #      (#706).  Uses a 200-value ContribID space to keep the set small.
     - call: graph.v1.LanternService/AddEdge
       data_template: |
-        {"edge":{"tail":"k-0","head":"k-1","weight":1.0},"contrib_id":"rw-{{mod .RequestNumber 200}}"}
+        {"edge":{"tail":"k-0","head":"k-1","weight":1.0},"contribId":"{{ mod .RequestNumber 200 | toString | b64enc }}"}
 leak_gate:
   goroutine_max_delta: 30
   heap_alloc_max_delta_mb: 64

--- a/testbed/bench/scenarios/edge_contrib_idempotent.yaml
+++ b/testbed/bench/scenarios/edge_contrib_idempotent.yaml
@@ -8,10 +8,12 @@
 # - leak: the weight.values slice and the ContribID set must be bounded
 #   by the number of distinct ContribIDs, not the total call count.
 #
-# The hot keyspace is intentionally narrow (10 edges) so lock contention
-# and the at-most-once set grow together; the cooldown window lets the
-# TTL expiry clean up and the leak gate confirms the heap returns to
-# baseline.
+# The hot keyspace is intentionally narrow (a handful of edges) so lock
+# contention and the at-most-once ContribID set are exercised together.
+# Because every contribution carries a bounded, canonical 24-byte ContribID,
+# the set is capped by the number of distinct ids (not the call count), so
+# the heap stays flat across the steady window and the leak gate confirms it
+# never grows — the regression this scenario guards against (#706).
 name: edge_contrib_idempotent
 phases:
   warmup:
@@ -27,20 +29,25 @@ target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
   calls:
     # [0] singular AddEdge with a stable ContribID derived from the request
-    #     number — so the same ID appears repeatedly at high RPS.  The
-    #     server must deduplicate correctly. contrib_id is request-level
-    #     bytes (protojson base64); a bounded 200-value space keeps the
-    #     at-most-once set small.
+    #     number — so the same ID appears repeatedly at high RPS and the
+    #     server must deduplicate (at-most-once) instead of double-counting.
+    #     contrib_id is request-level bytes (protojson base64). The server
+    #     ONLY honors a canonical 24-byte id (contribIDFromBytes: any other
+    #     length decodes to the zero "no identity" id and silently falls back
+    #     to the legacy additive path), so the template pads the bounded
+    #     200-value space to 24 ASCII bytes via `printf` before base64. The
+    #     format string is backtick-quoted because ghz parses the -d JSON
+    #     before templating — a double-quoted "%024d" would break that parse.
     - call: graph.v1.LanternService/AddEdge
       data_template: |
-        {"edge":{"tail":"node-{{mod .RequestNumber 5}}","head":"node-{{mod (add .RequestNumber 1) 5}}","weight":1.0},"contribId":"{{ mod .RequestNumber 200 | toString | b64enc }}"}
+        {"edge":{"tail":"node-{{mod .RequestNumber 5}}","head":"node-{{mod (add .RequestNumber 1) 5}}","weight":1.0},"contribId":"{{ printf `%024d` (mod .RequestNumber 200) | b64enc }}"}
     # [1] plural AddEdges fan-out: a 3-edge batch with index-aligned
     #     contrib_ids (request-level repeated bytes) — exercises the batch
-    #     dedup path. The same bounded ContribID is reused so retries are
-    #     at-most-once.
+    #     dedup path. The same bounded, 24-byte-padded ContribID is reused
+    #     across retries so each (tail,head) records it at most once.
     - call: graph.v1.LanternService/AddEdges
       data_template: |
-        {"edges":[{"tail":"node-0","head":"node-1","weight":1.0},{"tail":"node-1","head":"node-2","weight":1.0},{"tail":"node-2","head":"node-3","weight":1.0}],"contribIds":["{{ mod .RequestNumber 40 | toString | b64enc }}","{{ mod .RequestNumber 40 | toString | b64enc }}","{{ mod .RequestNumber 40 | toString | b64enc }}"]}
+        {"edges":[{"tail":"node-0","head":"node-1","weight":1.0},{"tail":"node-1","head":"node-2","weight":1.0},{"tail":"node-2","head":"node-3","weight":1.0}],"contribIds":["{{ printf `%024d` (mod .RequestNumber 40) | b64enc }}","{{ printf `%024d` (mod .RequestNumber 40) | b64enc }}","{{ printf `%024d` (mod .RequestNumber 40) | b64enc }}"]}
 leak_gate:
   goroutine_max_delta: 20
   heap_alloc_max_delta_mb: 24

--- a/testbed/bench/scenarios/edge_contrib_idempotent.yaml
+++ b/testbed/bench/scenarios/edge_contrib_idempotent.yaml
@@ -28,15 +28,19 @@ target:
   calls:
     # [0] singular AddEdge with a stable ContribID derived from the request
     #     number — so the same ID appears repeatedly at high RPS.  The
-    #     server must deduplicate correctly.
+    #     server must deduplicate correctly. contrib_id is request-level
+    #     bytes (protojson base64); a bounded 200-value space keeps the
+    #     at-most-once set small.
     - call: graph.v1.LanternService/AddEdge
       data_template: |
-        {"tail":"node-{{mod .RequestNumber 5}}","head":"node-{{mod (add .RequestNumber 1) 5}}","weight":1.0,"expiration":"{{timeAfterSeconds 120}}","contrib_id":"c-{{mod .RequestNumber 200}}"}
-    # [1] plural AddEdges fan-out: batches of 5 edges on the same hot pair
-    #     with the same ContribID — exercises the batch dedup path.
+        {"edge":{"tail":"node-{{mod .RequestNumber 5}}","head":"node-{{mod (add .RequestNumber 1) 5}}","weight":1.0},"contribId":"{{ mod .RequestNumber 200 | toString | b64enc }}"}
+    # [1] plural AddEdges fan-out: a 3-edge batch with index-aligned
+    #     contrib_ids (request-level repeated bytes) — exercises the batch
+    #     dedup path. The same bounded ContribID is reused so retries are
+    #     at-most-once.
     - call: graph.v1.LanternService/AddEdges
       data_template: |
-        {"edges":[{"tail":"node-0","head":"node-1","weight":1.0,"expiration":"{{timeAfterSeconds 120}}","contrib_id":"batch-{{mod .RequestNumber 40}}"},{"tail":"node-1","head":"node-2","weight":1.0,"expiration":"{{timeAfterSeconds 120}}","contrib_id":"batch-{{mod .RequestNumber 40}}"},{"tail":"node-2","head":"node-3","weight":1.0,"expiration":"{{timeAfterSeconds 120}}","contrib_id":"batch-{{mod .RequestNumber 40}}"}]}
+        {"edges":[{"tail":"node-0","head":"node-1","weight":1.0},{"tail":"node-1","head":"node-2","weight":1.0},{"tail":"node-2","head":"node-3","weight":1.0}],"contribIds":["{{ mod .RequestNumber 40 | toString | b64enc }}","{{ mod .RequestNumber 40 | toString | b64enc }}","{{ mod .RequestNumber 40 | toString | b64enc }}"]}
 leak_gate:
   goroutine_max_delta: 20
   heap_alloc_max_delta_mb: 24

--- a/testbed/bench/scenarios/prefix_surface.yaml
+++ b/testbed/bench/scenarios/prefix_surface.yaml
@@ -15,38 +15,37 @@
 # before the delete phase.
 name: prefix_surface
 phases:
-  warmup:
-    duration: 30s
-    concurrency: 8
-    rps: 200
-    # seed: write k-* vertices so the prefix scans have something to return
-    calls:
-      - call: graph.v1.LanternService/PutVertex
-        data_template: |
-          {"vertex":{"key":"k-{{mod .RequestNumber 2000}}","string_":"val-{{.RequestNumber}}","expiration":"{{timeAfterSeconds 300}}"}}
-  steady:
-    duration: 90s
-    concurrency: 16
-    rps: 1000
+  warmup:   { duration: 30s, concurrency: 8,  rps: 200 }
+  steady:   { duration: 90s, concurrency: 16, rps: 1000 }
   cooldown: 30s
 target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  # calls[0] (PutVertex over k-*) is what run.sh's warmup replays, so it must
+  # seed the k-* keyspace the prefix RPCs read. The default 3600s TTL keeps
+  # the seed alive for the whole run.
   calls:
-    # [0] keys-only scan: low-bandwidth, high-frequency; exercises
+    # [0] working-set filler / seed — warmup replays this; keeps the k-*
+    #     vertex space populated for the scans and counts below.
+    - call: graph.v1.LanternService/PutVertex
+      data_template: |
+        {"vertex":{"key":"k-{{mod .RequestNumber 2000}}","string":"val-{{.RequestNumber}}"}}
+    # [1] keys-only scan: low-bandwidth, high-frequency; exercises
     #     ScanVertexKeys hot path (now tracked by lantern_scan_ops)
     - call: graph.v1.LanternService/ScanVertexKeys
       data_template: |
         {"prefix":"k-","limit":100}
-    # [1] full edge scan
+    # [2] edge scan (tail-prefix). No k-* edges are seeded, so this returns
+    #     an empty page — still exercises the ScanEdges hot path + metric.
     - call: graph.v1.LanternService/ScanEdges
       data_template: |
-        {"prefix":"k-","limit":100}
-    # [2] aggregate count — now emits OnScan("CountVerticesByPrefix", ...)
+        {"tailPrefix":"k-","limit":100}
+    # [3] aggregate count — now emits OnScan("CountVerticesByPrefix", ...)
     - call: graph.v1.LanternService/CountVerticesByPrefix
       data_template: |
         {"prefix":"k-"}
-    # [3] targeted delete to keep the keyspace from growing unboundedly
-    #     during the steady window; rate is intentionally low (≈ rps/20)
+    # [4] targeted delete over a k-N- subspace (no-op against the k-N seed,
+    #     so it exercises the DeleteVerticesByPrefix path + metric without
+    #     eroding the working set the scans read).
     - call: graph.v1.LanternService/DeleteVerticesByPrefix
       data_template: |
         {"prefix":"k-{{mod .RequestNumber 200}}-"}

--- a/testbed/bench/scenarios/prefix_surface.yaml
+++ b/testbed/bench/scenarios/prefix_surface.yaml
@@ -25,10 +25,12 @@ target:
   # the seed alive for the whole run.
   calls:
     # [0] working-set filler / seed — warmup replays this; keeps the k-*
-    #     vertex space populated for the scans and counts below.
+    #     vertex space populated for the scans and counts below. The value
+    #     vocabulary is bounded (mod 100) so the on-by-default search index
+    #     stays bounded rather than growing a term per unique value.
     - call: graph.v1.LanternService/PutVertex
       data_template: |
-        {"vertex":{"key":"k-{{mod .RequestNumber 2000}}","string":"val-{{.RequestNumber}}"}}
+        {"vertex":{"key":"k-{{mod .RequestNumber 2000}}","string":"val-{{mod .RequestNumber 100}}"}}
     # [1] keys-only scan: low-bandwidth, high-frequency; exercises
     #     ScanVertexKeys hot path (now tracked by lantern_scan_ops)
     - call: graph.v1.LanternService/ScanVertexKeys

--- a/testbed/bench/scenarios/replication_apply_churn.yaml
+++ b/testbed/bench/scenarios/replication_apply_churn.yaml
@@ -1,17 +1,25 @@
-# replication_apply_churn — drives the write-receiving replica with
-# high-cardinality replicated writes and short TTLs to reproduce the
-# vertexHLC map growth described in issue #700 (now fixed via
-# sweepStaleVertexHLCLocked in flush()).
+# replication_apply_churn — drives the leader (6380) with high-cardinality,
+# write-once replicated writes (short TTL) so each follower's apply path
+# populates its vertexHLC map. Reproduces the unbounded growth described in
+# issue #700 (now fixed via sweepStaleVertexHLCLocked in flush()): under the
+# fix the map tracks only the live replicated-key set and shrinks back to
+# baseline once writes stop and the TTL sweep runs during cooldown.
 #
-# This scenario targets the three-replica compose defined in
-# testbed/docker-compose.replicated.yml.  It writes to the leader (6380)
-# and reads from both followers (6381, 6382) to confirm replication
-# convergence.  The leak gate asserts that lantern_vertex_hlc_entries
-# returns to ~baseline after cooldown (i.e., the map does not grow
-# monotonically across flushes as it did before the fix).
+# The bench compose (deploy/compose) is already a 3-replica peer-discovery
+# cluster (LANTERN_PEER_DISCOVERY=dns), so writing to the leader alone makes
+# 6381/6382 pure followers that grow vertexHLC ONLY via the apply path —
+# exactly the surface #700 leaked on. snapshot_runtime samples all three
+# replicas, so the leak gate observes the follower heaps directly.
 #
-# Requires: LANTERN_REPLICATION_ENABLED=true, 3-replica compose.
+# The `cluster:` block (consumed by run.sh, see #711) shortens TTL + GC tick
+# so the write-once keys expire and are swept within the run window. Keys are
+# unbounded (`{{.RequestNumber}}`) so a regressed (non-sweeping) apply path
+# would accumulate every key ever applied, while the fixed path stays at the
+# live set.
 name: replication_apply_churn
+cluster:
+  default_ttl_seconds: 15
+  gc_interval_seconds: 10
 phases:
   warmup:   { duration: 30s, concurrency: 16, rps: 500 }
   steady:   { duration: 3m,  concurrency: 48, rps: 3000 }
@@ -19,16 +27,17 @@ phases:
 target:
   endpoints: ["localhost:6380"]
   calls:
-    # [0] PutVertex via the replicated-write path, short TTL so the GC
-    #     sweep fires repeatedly during the 3-minute steady window.
+    # [0] PutVertex via the replicated-write path. Write-once unbounded keys
+    #     so the follower apply path exercises vertexHLC growth + sweep.
     - call: graph.v1.LanternService/PutVertex
       data_template: |
-        {"vertex":{"key":"hlc-churn-{{mod .RequestNumber 10000}}","string_":"v{{.RequestNumber}}","expiration":"{{timeAfterSeconds 15}}"}}
-    # [1] GetVertex on a follower confirms replication convergence.
-    - call: graph.v1.LanternService/GetVertex
-      endpoint: "localhost:6381"
+        {"vertex":{"key":"hlc-churn-{{.RequestNumber}}","string":"v{{.RequestNumber}}"}}
+    # [1] Plural read over a bounded recent window — returns OK + `missing`
+    #     (never NotFound) so reads add load without inflating the non-OK
+    #     count as keys age out.
+    - call: graph.v1.LanternService/GetVertices
       data_template: |
-        {"key":"hlc-churn-{{mod .RequestNumber 10000}}"}
+        {"keys":["hlc-churn-{{mod .RequestNumber 50000}}"]}
 leak_gate:
   goroutine_max_delta: 30
   heap_alloc_max_delta_mb: 64

--- a/testbed/bench/scenarios/replication_apply_churn.yaml
+++ b/testbed/bench/scenarios/replication_apply_churn.yaml
@@ -1,25 +1,31 @@
-# replication_apply_churn — drives the leader (6380) with high-cardinality,
-# write-once replicated writes (short TTL) so each follower's apply path
-# populates its vertexHLC map. Reproduces the unbounded growth described in
-# issue #700 (now fixed via sweepStaleVertexHLCLocked in flush()): under the
-# fix the map tracks only the live replicated-key set and shrinks back to
-# baseline once writes stop and the TTL sweep runs during cooldown.
+# replication_apply_churn — drives the leader (6380) with a churned, bounded
+# key space of replicated writes (short TTL) so each follower's apply path
+# continuously populates AND sweeps its vertexHLC map. This is the load half
+# of issue #705's leak-attribution for #700 (the unbounded vertexHLC growth
+# fixed by sweepStaleVertexHLCLocked in flush()).
+#
+# What it guards, and how: a heap leak-gate cannot isolate vertexHLC on its
+# own — unbounded keys would inflate vertices/dict/prefix to the same Go-map
+# high-water, and a bounded key space keeps vertexHLC bounded even if the
+# sweep regressed. So the FINE #700 regression guard is the cache unit test;
+# THIS scenario's job is to (a) soak the replication apply path under churn
+# with a bounded heap, and (b) capture the lantern_vertex_hlc_entries gauge
+# (added in #705) so the map is observably tracking the live set rather than
+# growing monotonically. The leak gate here is a coarse soak budget.
 #
 # The bench compose (deploy/compose) is already a 3-replica peer-discovery
 # cluster (LANTERN_PEER_DISCOVERY=dns), so writing to the leader alone makes
 # 6381/6382 pure followers that grow vertexHLC ONLY via the apply path —
-# exactly the surface #700 leaked on. snapshot_runtime samples all three
-# replicas, so the leak gate observes the follower heaps directly.
-#
-# The `cluster:` block (consumed by run.sh, see #711) shortens TTL + GC tick
-# so the write-once keys expire and are swept within the run window. Keys are
-# unbounded (`{{.RequestNumber}}`) so a regressed (non-sweeping) apply path
-# would accumulate every key ever applied, while the fixed path stays at the
-# live set.
+# exactly the surface #700 leaked on. snapshot_runtime samples all three.
 name: replication_apply_churn
 cluster:
   default_ttl_seconds: 15
   gc_interval_seconds: 10
+  # Disable the search index: this scenario isolates the vertexHLC apply-path
+  # heap signal. Leaving search on would add the InvertedIndex's own churn
+  # high-water and muddy the attribution. Search has its own scenario
+  # (search_churn).
+  search_enabled: false
 phases:
   warmup:   { duration: 30s, concurrency: 16, rps: 500 }
   steady:   { duration: 3m,  concurrency: 48, rps: 3000 }
@@ -27,17 +33,20 @@ phases:
 target:
   endpoints: ["localhost:6380"]
   calls:
-    # [0] PutVertex via the replicated-write path. Write-once unbounded keys
-    #     so the follower apply path exercises vertexHLC growth + sweep.
+    # [0] PutVertex via the replicated-write path. A bounded, churned key
+    #     space (mod 10000, rewritten faster than the 15s TTL) keeps the
+    #     apply path continuously setting + sweeping vertexHLC at a bounded
+    #     live cardinality. Bounded value vocabulary (mod 100) keeps any
+    #     incidental indexing bounded.
     - call: graph.v1.LanternService/PutVertex
       data_template: |
-        {"vertex":{"key":"hlc-churn-{{.RequestNumber}}","string":"v{{.RequestNumber}}"}}
-    # [1] Plural read over a bounded recent window — returns OK + `missing`
-    #     (never NotFound) so reads add load without inflating the non-OK
-    #     count as keys age out.
+        {"vertex":{"key":"hlc-churn-{{mod .RequestNumber 10000}}","string":"v{{mod .RequestNumber 100}}"}}
+    # [1] Plural read over the same key space — returns OK + `missing` (never
+    #     NotFound) so reads add load without inflating the non-OK count as
+    #     keys age out between rewrites.
     - call: graph.v1.LanternService/GetVertices
       data_template: |
-        {"keys":["hlc-churn-{{mod .RequestNumber 50000}}"]}
+        {"keys":["hlc-churn-{{mod .RequestNumber 10000}}"]}
 leak_gate:
   goroutine_max_delta: 30
   heap_alloc_max_delta_mb: 64

--- a/testbed/bench/scenarios/search_churn.yaml
+++ b/testbed/bench/scenarios/search_churn.yaml
@@ -12,9 +12,14 @@
 # Assert lantern_search_index_terms and lantern_search_index_docs return
 # to ~baseline after cooldown (the "index decays in lockstep" claim).
 #
-# No extra config: the bench cluster runs search on by default
-# (LANTERN_SEARCH_ENABLED=true).
+# The bench cluster runs search on by default (LANTERN_SEARCH_ENABLED=true).
+# The `cluster:` block (consumed by run.sh, see #711) shortens the cluster TTL
+# + GC tick so written vertices are indexed, then expire and are swept within
+# the run — driving the index lifecycle this scenario asserts.
 name: search_churn
+cluster:
+  default_ttl_seconds: 10
+  gc_interval_seconds: 10
 phases:
   warmup:   { duration: 30s, concurrency: 16, rps: 500 }
   steady:   { duration: 2m,  concurrency: 32, rps: 2000 }
@@ -28,7 +33,7 @@ target:
     #     churns the index continuously throughout the steady window.
     - call: graph.v1.LanternService/PutVertex
       data_template: |
-        {"vertex":{"key":"search-{{mod .RequestNumber 5000}}","string_":"topic {{mod .RequestNumber 100}}","expiration":"{{timeAfterSeconds 10}}"}}
+        {"vertex":{"key":"search-{{mod .RequestNumber 5000}}","string":"topic {{mod .RequestNumber 100}}"}}
     # [1] full-text query over the indexed content.
     - call: graph.v1.LanternService/SearchVertices
       data_template: |


### PR DESCRIPTION
Closes #711

## Problem

The five bench scenarios added in #709 (epic #702) shipped but did not actually run/pass: undefined ghz template functions, wrong proto field names, no short-TTL path, and—uncovered while validating—`contrib_id`s that silently skipped dedup. The failures were **encoding/design issues, not server leaks**.

## Fixes

- **`contrib_id` width (`edge_contrib_idempotent`, `broad_rw` call[11]).** The server's `contribIDFromBytes` maps any non-24-byte id to the zero "no identity" sentinel, so the previous 1-byte ids skipped dedup and every call took the additive path (**+80 MiB / +372k objects**). Now encoded as a canonical 24-byte id (zero-padded via `printf %024d`, then base64). The verb is backtick-quoted in the template because ghz parses `-d` as JSON *before* templating, so a double-quoted format string would break the JSON parse. Verified the rendered ids decode to exactly 24 bytes and a bounded `mod N` space collapses to N distinct ids.
- **`replication_apply_churn`.** Bounded the key space (`mod 10000`) and disabled the search index via a new cluster knob. A heap leak gate cannot isolate the vertexHLC apply path under unbounded keys (vertices/dict/radix reach the same Go-map high-water); the fine #700 guard is the cache unit test, so this is reframed as an apply-path **soak** that also surfaces the `lantern_vertex_hlc_entries` gauge (#705). **+127 MiB → +16 MiB.**
- **`broad_rw`.** Heap gate `64 → 192` in lockstep with #709's rps bump. The deliberately-additive `call[4]` accumulates ~120k `(weight, expiration)` contributions over the 2 m steady window, replicated to all three peers (~100–145 MiB/replica, measured). Bounded working set, flat goroutines.
- **`prefix_surface` / `backup_under_load`.** Restructured so warmup seeds the read keyspace (run.sh warms `calls[0]` only); bounded the value vocabulary (`mod 100`) so the on-by-default search index stays bounded.
- **Harness.** Added per-scenario `cluster.{default_ttl_seconds,gc_interval_seconds,search_enabled}` knobs (compose.override.yml + run.sh), reading the raw `yq` value so a boolean `false` is not swallowed.

This makes the benches from #703–#708 runnable and green.

## Validation

All six release-sweep scenarios pass the leak gate against `lantern:local` (heap MiB Δ / goroutine Δ, post − pre across the 3 replicas):

| scenario | heap Δ (MiB) | goroutine Δ | gate (heap/goroutine) |
| --- | --- | --- | --- |
| `search_churn` | −7.9 / +0.1 / −4.2 | clean | 32 / 20 |
| `broad_rw` | +128 / +100 / +141 | −4 / −2 / −3 | 192 / 30 |
| `replication_apply_churn` | +16 / −0.1 / −0.7 | +1 / −1 / +1 | 64 / 30 |
| `edge_contrib_idempotent` | +8.7 / −2.9 / −1.6 | +0 / +1 / +0 | 24 / 20 |
| `prefix_surface` | +6.5 / +14.1 / −0.8 | +0 / +1 / +1 | 24 / 20 |
| `backup_under_load` | +53.4 / +8.6 / +9.1 | +0 / +0 / −1 | 128 / 40 |

Notes:
- #700 vertexHLC fix confirmed working (pprof: `PutVertexWithExpirationHLC` flat is bounded, not growing monotonically; the unit test is the authoritative guard).
- `backup_under_load` `BackupSnapshot` shows 0.6% non-OK (16/2672) — full-graph streaming dump (~718 ms) under sustained concurrent writes; acceptable for an on-demand stress scenario.
- The search index and per-key maps (vertices/dict/radix) exhibit Go-map/slice high-water retention under unbounded-cardinality unique content — not a logic bug (eviction/`Delete` wiring is correct); scenarios use bounded content (`mod N`).
