### PR TITLE
fix(service): stamp HLC watermark on local writes so multi-writer Puts converge

### DIFF
--- a/core/graphcache/batch.go
+++ b/core/graphcache/batch.go
@@ -1,6 +1,10 @@
 package graphcache
 
-import "time"
+import (
+	"time"
+
+	"github.com/anaregdesign/lantern/core/hlc"
+)
 
 // VertexItem is a single (key, value, expiration) tuple supplied to
 // PutVerticesWithExpiration.
@@ -151,4 +155,119 @@ func (c *GraphCache[S, T]) DeleteEdges(keys []EdgeKey[S]) int {
 		}
 	}
 	return n
+}
+
+// PutVerticesWithExpirationHLC is the LWW-aware, single-lock batch sibling of
+// PutVerticesWithExpiration used by the LOCAL write path when replication is
+// enabled. Every item is stamped with the SAME ts — the HLC the originating
+// mutation is logged under — so the origin's own writes participate in
+// last-writer-wins on equal footing with the values its peers apply from its
+// mutation log.
+//
+// This closes a convergence hole: when the local path used the non-HLC
+// PutVerticesWithExpiration it stored a value WITHOUT recording a vertexHLC
+// watermark, so a concurrently-written OLDER value replayed from a peer would
+// clobber the origin's newer value on the origin (the incoming write saw no
+// watermark to lose to) while every other replica kept the newer value —
+// permanent divergence for the same key. Stamping the watermark here makes
+// PutVertex an LWW-Register on every replica, exactly as docs/replication.md
+// specifies ("Higher HLC wins; same HLC ⇒ higher origin ID wins").
+//
+// Per item the usual guards apply: a write whose ts is strictly older than the
+// key's tombstone, or strictly older than the key's stored vertexHLC, is
+// skipped. Born-expired items follow the same dead-on-arrival handling as
+// PutVerticesWithExpiration (the entry is removed, not stored) so the #698
+// high-water optimisation is preserved; the watermark is still recorded so a
+// later strictly-older write cannot resurrect the key.
+func (c *GraphCache[S, T]) PutVerticesWithExpirationHLC(items []VertexItem[S, T], ts hlc.Timestamp) {
+	if len(items) == 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, it := range items {
+		if tombTs, ok := c.vertexTombstoneLocked(it.Key); ok && ts.Less(tombTs) {
+			continue
+		}
+		if existing, ok := c.vertexHLC[it.Key]; ok && ts.Less(existing) {
+			continue
+		}
+		c.putLocalVertexLocked(it.Key, it.Value, it.Expiration)
+		if c.vertexHLC == nil {
+			c.vertexHLC = make(map[S]hlc.Timestamp)
+		}
+		c.vertexHLC[it.Key] = ts
+		if c.vertexTombstones != nil {
+			delete(c.vertexTombstones, it.Key)
+		}
+	}
+}
+
+// PutEdgesWithExpirationHLC is the LWW-aware, single-lock batch sibling of
+// PutEdgesWithExpiration used by the LOCAL write path when replication is
+// enabled. Like PutVerticesWithExpirationHLC it stamps every edge with the
+// originating mutation's ts so PutEdge resolves as an LWW-Register on
+// (tail, head) across replicas rather than diverging when two origins write
+// the same edge concurrently. Endpoint vertices are auto-created regardless of
+// the per-edge LWW outcome (matching PutEdgeWithExpirationHLC) so traversal
+// always sees the endpoints.
+func (c *GraphCache[S, T]) PutEdgesWithExpirationHLC(items []EdgeItem[S], ts hlc.Timestamp) {
+	if len(items) == 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, it := range items {
+		if tombTs, ok := c.edgeTombstoneLocked(it.Tail, it.Head); ok && ts.Less(tombTs) {
+			continue
+		}
+		c.ensureVertexLocked(it.Tail, it.Expiration)
+		c.ensureVertexLocked(it.Head, it.Expiration)
+		created, tailID, headID, applied := c.edges.putWithExpirationHLC(it.Tail, it.Head, it.Weight, it.Expiration, ts)
+		if created {
+			c.onEdgeAddedLocked(created, tailID, headID, it.Head)
+		}
+		if applied && c.edgeTombstones != nil {
+			delete(c.edgeTombstones, EdgeKey[S]{Tail: it.Tail, Head: it.Head})
+		}
+	}
+}
+
+// AddEdgesWithExpirationContribHLC is the tombstone-aware, single-lock batch
+// sibling of AddEdgesWithExpirationContrib used by the LOCAL write path when
+// replication is enabled. Additive merge already converges via ContribID set
+// semantics regardless of delivery order, so the ts is NOT compared against a
+// per-edge write watermark; it is consulted ONLY against the edge tombstone so
+// a contribution whose ts is strictly older than a delete is dropped on the
+// origin exactly as it is on every peer. Items whose ts loses to the tombstone
+// are skipped and counted as deduped=false (they applied nothing); items with
+// a matching live ContribID are deduped as in the non-HLC variant. Returns the
+// number of items that added no weight (tombstone-dropped or ContribID-deduped).
+func (c *GraphCache[S, T]) AddEdgesWithExpirationContribHLC(items []EdgeItem[S], ts hlc.Timestamp) (deduped int) {
+	if len(items) == 0 {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, it := range items {
+		if tombTs, ok := c.edgeTombstoneLocked(it.Tail, it.Head); ok && ts.Less(tombTs) {
+			deduped++
+			continue
+		}
+		c.ensureVertexLocked(it.Tail, it.Expiration)
+		c.ensureVertexLocked(it.Head, it.Expiration)
+		created, tailID, headID, applied := c.edges.addWithExpirationContrib(it.Tail, it.Head, it.Weight, it.Expiration, it.ContribID)
+		if applied {
+			c.onEdgeAddedLocked(created, tailID, headID, it.Head)
+			if c.edgeTombstones != nil {
+				delete(c.edgeTombstones, EdgeKey[S]{Tail: it.Tail, Head: it.Head})
+			}
+			continue
+		}
+		deduped++
+		if created {
+			c.onEdgeAddedLocked(created, tailID, headID, it.Head)
+		}
+	}
+	return deduped
 }

--- a/core/graphcache/batch_external_test.go
+++ b/core/graphcache/batch_external_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/anaregdesign/lantern/core/graphcache"
+	"github.com/anaregdesign/lantern/core/hlc"
 )
 
 // TestAddEdgesWithExpiration_AtomicNeighborSnapshot verifies that a
@@ -328,4 +329,151 @@ func itoa(i int) string {
 		i /= 10
 	}
 	return string(buf[pos:])
+}
+
+// PutVerticesWithExpirationHLC stamps every item with the supplied HLC so the
+// LOCAL batch write path participates in last-writer-wins exactly like the
+// per-item apply path. A strictly-older batch is dropped per key, a brand-new
+// key in the same batch still applies, and a key under a newer tombstone is
+// not resurrected by an older batch put.
+func TestPutVerticesWithExpirationHLC_BatchLWW(t *testing.T) {
+	exp := time.Now().Add(time.Hour)
+	older := hlc.Timestamp{WallNs: 1000}
+	newer := hlc.Timestamp{WallNs: 2000}
+
+	t.Run("LWW", func(t *testing.T) {
+		c := graphcache.NewGraphCache[string, string](time.Minute)
+		c.PutVerticesWithExpirationHLC([]graphcache.VertexItem[string, string]{
+			{Key: "a", Value: "newA", Expiration: exp},
+			{Key: "b", Value: "newB", Expiration: exp},
+		}, newer)
+		c.PutVerticesWithExpirationHLC([]graphcache.VertexItem[string, string]{
+			{Key: "a", Value: "staleA", Expiration: exp}, // dropped: strictly older
+			{Key: "b", Value: "staleB", Expiration: exp}, // dropped: strictly older
+			{Key: "c", Value: "freshC", Expiration: exp}, // applied: brand-new key
+		}, older)
+		for _, tc := range []struct{ key, want string }{
+			{"a", "newA"}, {"b", "newB"}, {"c", "freshC"},
+		} {
+			if got, ok := c.GetVertex(tc.key); !ok || got != tc.want {
+				t.Errorf("%s: got (%q,%v), want (%q,true) — newer HLC must win", tc.key, got, ok, tc.want)
+			}
+		}
+	})
+
+	t.Run("TombstoneFencesOlder", func(t *testing.T) {
+		c := graphcache.NewGraphCache[string, string](time.Minute)
+		c.PutVerticesWithExpirationHLC([]graphcache.VertexItem[string, string]{
+			{Key: "d", Value: "live", Expiration: exp},
+		}, older)
+		if n := c.DeleteVerticesHLC([]string{"d"}, newer, exp); n != 1 {
+			t.Fatalf("delete: got %d, want 1", n)
+		}
+		c.PutVerticesWithExpirationHLC([]graphcache.VertexItem[string, string]{
+			{Key: "d", Value: "resurrect", Expiration: exp}, // dropped: older than tombstone
+		}, older)
+		if _, ok := c.GetVertex("d"); ok {
+			t.Errorf("older batch put resurrected a tombstoned key")
+		}
+	})
+}
+
+// PutEdgesWithExpirationHLC is the edge LWW sibling: a strictly-older batch is
+// dropped per (tail, head), a brand-new edge in the same batch applies, and a
+// newer edge tombstone fences an older batch put.
+func TestPutEdgesWithExpirationHLC_BatchLWW(t *testing.T) {
+	exp := time.Now().Add(time.Hour)
+	older := hlc.Timestamp{WallNs: 1000}
+	newer := hlc.Timestamp{WallNs: 2000}
+
+	t.Run("LWW", func(t *testing.T) {
+		c := graphcache.NewGraphCache[string, string](time.Minute)
+		c.PutEdgesWithExpirationHLC([]graphcache.EdgeItem[string]{
+			{Tail: "a", Head: "b", Weight: 2.5, Expiration: exp},
+		}, newer)
+		c.PutEdgesWithExpirationHLC([]graphcache.EdgeItem[string]{
+			{Tail: "a", Head: "b", Weight: 9.9, Expiration: exp}, // dropped: strictly older
+			{Tail: "x", Head: "y", Weight: 1.0, Expiration: exp}, // applied: brand-new edge
+		}, older)
+		if got, ok := c.GetWeight("a", "b"); !ok || got != 2.5 {
+			t.Errorf("a->b: got (%v,%v), want (2.5,true) — newer HLC must win", got, ok)
+		}
+		if got, ok := c.GetWeight("x", "y"); !ok || got != 1.0 {
+			t.Errorf("x->y: got (%v,%v), want (1.0,true)", got, ok)
+		}
+	})
+
+	t.Run("TombstoneFencesOlder", func(t *testing.T) {
+		c := graphcache.NewGraphCache[string, string](time.Minute)
+		c.PutEdgesWithExpirationHLC([]graphcache.EdgeItem[string]{
+			{Tail: "a", Head: "b", Weight: 1.0, Expiration: exp},
+		}, older)
+		if n := c.DeleteEdgesHLC([]graphcache.EdgeKey[string]{{Tail: "a", Head: "b"}}, newer, exp); n != 1 {
+			t.Fatalf("delete: got %d, want 1", n)
+		}
+		c.PutEdgesWithExpirationHLC([]graphcache.EdgeItem[string]{
+			{Tail: "a", Head: "b", Weight: 9.0, Expiration: exp}, // dropped: older than tombstone
+		}, older)
+		if _, ok := c.GetWeight("a", "b"); ok {
+			t.Errorf("older batch put resurrected a tombstoned edge")
+		}
+	})
+}
+
+// AddEdgesWithExpirationContribHLC keeps additive ContribID-set semantics but
+// fences each contribution by the edge tombstone at the supplied HLC: an
+// older-than-tombstone contribution adds nothing (and is counted as deduped),
+// an exact ContribID replay is idempotent, and two distinct contributions sum.
+func TestAddEdgesWithExpirationContribHLC_TombstoneFenced(t *testing.T) {
+	exp := time.Now().Add(time.Hour)
+	older := hlc.Timestamp{WallNs: 1000}
+	newer := hlc.Timestamp{WallNs: 2000}
+
+	t.Run("TombstoneDropsOlderContribution", func(t *testing.T) {
+		c := graphcache.NewGraphCache[string, string](time.Minute)
+		c.AddEdgesWithExpirationContribHLC([]graphcache.EdgeItem[string]{
+			{Tail: "a", Head: "b", Weight: 1.0, Expiration: exp, ContribID: graphcache.ContribID{0: 1}},
+		}, older)
+		if n := c.DeleteEdgesHLC([]graphcache.EdgeKey[string]{{Tail: "a", Head: "b"}}, newer, exp); n != 1 {
+			t.Fatalf("delete: got %d, want 1", n)
+		}
+		deduped := c.AddEdgesWithExpirationContribHLC([]graphcache.EdgeItem[string]{
+			{Tail: "a", Head: "b", Weight: 5.0, Expiration: exp, ContribID: graphcache.ContribID{0: 2}},
+		}, older)
+		if deduped != 1 {
+			t.Errorf("deduped: got %d, want 1 (tombstone-dropped)", deduped)
+		}
+		if _, ok := c.GetWeight("a", "b"); ok {
+			t.Errorf("older contribution resurrected a tombstoned edge")
+		}
+	})
+
+	t.Run("ContribIDDedup", func(t *testing.T) {
+		c := graphcache.NewGraphCache[string, string](time.Minute)
+		items := []graphcache.EdgeItem[string]{
+			{Tail: "a", Head: "b", Weight: 1.0, Expiration: exp, ContribID: graphcache.ContribID{0: 9}},
+		}
+		if d := c.AddEdgesWithExpirationContribHLC(items, older); d != 0 {
+			t.Errorf("first apply deduped: got %d, want 0", d)
+		}
+		if d := c.AddEdgesWithExpirationContribHLC(items, newer); d != 1 {
+			t.Errorf("replay deduped: got %d, want 1 (same ContribID is idempotent)", d)
+		}
+		if got, ok := c.GetWeight("a", "b"); !ok || got != 1.0 {
+			t.Errorf("a->b weight: got (%v,%v), want (1.0,true) — replay must not double-count", got, ok)
+		}
+	})
+
+	t.Run("AdditiveMerge", func(t *testing.T) {
+		c := graphcache.NewGraphCache[string, string](time.Minute)
+		c.AddEdgesWithExpirationContribHLC([]graphcache.EdgeItem[string]{
+			{Tail: "a", Head: "b", Weight: 1.0, Expiration: exp, ContribID: graphcache.ContribID{0: 1}},
+		}, older)
+		c.AddEdgesWithExpirationContribHLC([]graphcache.EdgeItem[string]{
+			{Tail: "a", Head: "b", Weight: 2.0, Expiration: exp, ContribID: graphcache.ContribID{0: 2}},
+		}, newer)
+		if got, ok := c.GetWeight("a", "b"); !ok || got != 3.0 {
+			t.Errorf("a->b weight: got (%v,%v), want (3.0,true) — distinct contributions must sum", got, ok)
+		}
+	})
 }

--- a/server/service/backend.go
+++ b/server/service/backend.go
@@ -51,6 +51,24 @@ type Backend interface {
 	PutVertexWithExpirationHLC(key string, value *pb.Vertex, expiration time.Time, ts hlc.Timestamp) bool
 	PutEdgeWithExpirationHLC(tail, head string, w float32, expiration time.Time, ts hlc.Timestamp) bool
 
+	// batch HLC siblings used by the LOCAL write path (PutVertices /
+	// PutEdges / AddEdges) when replication is enabled. They stamp every
+	// item in the batch with the SAME ts the originating mutation is logged
+	// under, so the origin's own writes participate in LWW (vertices, edges)
+	// or edge-tombstone fencing (additive contributions) on equal footing
+	// with the values its peers later apply from that log entry. Without the
+	// watermark a concurrently-written strictly-older Put replayed from a
+	// peer would clobber the origin's newer value on the origin alone while
+	// every other replica kept the newer one — permanent divergence. The
+	// local path keeps using the non-HLC PutVerticesWithExpiration /
+	// PutEdgesWithExpiration / AddEdgesWithExpirationContrib when replication
+	// is off (clock nil) so non-replicated workloads pay nothing.
+	// AddEdgesWithExpirationContribHLC returns the count of items that added
+	// no weight (tombstone-dropped or ContribID-deduped).
+	PutVerticesWithExpirationHLC(items []graphcache.VertexItem[string, *pb.Vertex], ts hlc.Timestamp)
+	PutEdgesWithExpirationHLC(items []graphcache.EdgeItem[string], ts hlc.Timestamp)
+	AddEdgesWithExpirationContribHLC(items []graphcache.EdgeItem[string], ts hlc.Timestamp) int
+
 	// tombstone-aware Delete*/Add* entry points used by ApplyMutation
 	// when LANTERN_TOMBSTONE_TTL is configured (#183). DeleteVertexHLC,
 	// DeleteVerticesHLC, DeleteEdgeHLC, DeleteEdgesHLC and

--- a/server/service/fake_backend_test.go
+++ b/server/service/fake_backend_test.go
@@ -299,6 +299,24 @@ func (f *fakeBackend) PutEdgeWithExpirationHLC(tail, head string, w float32, _ t
 	return true
 }
 
+// batch HLC siblings driven by the LOCAL write path when replication is
+// enabled. The fake collapses the HLC bookkeeping into the non-HLC batch
+// siblings so the existing call counters and captured items stay observable
+// whether or not the service takes the replicated branch; real LWW / tombstone
+// convergence is covered by the core and integration tests against the real
+// backend.
+func (f *fakeBackend) PutVerticesWithExpirationHLC(items []graphcache.VertexItem[string, *pb.Vertex], _ hlc.Timestamp) {
+	f.PutVerticesWithExpiration(items)
+}
+
+func (f *fakeBackend) PutEdgesWithExpirationHLC(items []graphcache.EdgeItem[string], _ hlc.Timestamp) {
+	f.PutEdgesWithExpiration(items)
+}
+
+func (f *fakeBackend) AddEdgesWithExpirationContribHLC(items []graphcache.EdgeItem[string], _ hlc.Timestamp) int {
+	return f.AddEdgesWithExpirationContrib(items)
+}
+
 // Tombstone-aware entry points (#183). The fake intentionally collapses
 // the tombstone bookkeeping into the underlying delete; service-level
 // tests that exercise tombstone semantics use the real backend.

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -331,7 +331,23 @@ func (s *LanternService) logMutation(op *pb.MutationOp) {
 	if s.log == nil || s.clock == nil {
 		return
 	}
-	ts := s.clock.Now()
+	s.logMutationAt(op, s.clock.Now())
+}
+
+// logMutationAt is logMutation with the commit HLC supplied by the caller
+// instead of sampled here. Local write paths that ALSO stamp the cache with
+// an HLC watermark (so the origin's own writes participate in LWW on equal
+// footing with the values its peers later apply from this same log entry)
+// sample s.clock.Now() ONCE and hand that identical ts to both the cache
+// write and this call. Sharing the instant closes the window in which the
+// cache-side watermark and the logged mutation HLC could differ — a gap that
+// let a concurrent write slip between the two and resolve LWW one way on the
+// origin and the other way on its peers. Returns immediately when the log is
+// not wired (test path); callers may pass a zero ts in that case.
+func (s *LanternService) logMutationAt(op *pb.MutationOp, ts hlc.Timestamp) {
+	if s.log == nil || s.clock == nil {
+		return
+	}
 	mu := &pb.Mutation{
 		Hlc: &pb.HLCTimestamp{
 			WallNs:  ts.WallNs,
@@ -517,7 +533,16 @@ func (s *LanternService) PutVertices(ctx context.Context, request *pb.PutVertice
 			liveCount++
 		}
 	}
-	s.cache.PutVerticesWithExpiration(items)
+	// When replication is enabled (clock wired) every local write is stamped
+	// with the SAME HLC it is logged under, via the *HLC cache method, so the
+	// origin's own PutVertex participates in last-writer-wins on equal footing
+	// with the values its peers apply from this log entry. The non-HLC method
+	// stored a value WITHOUT a vertexHLC watermark, so a concurrently-written
+	// OLDER value replayed from a peer would clobber the origin's newer value
+	// on the origin alone while every other replica kept the newer one —
+	// permanent divergence (docs/replication.md "Higher HLC wins"). The
+	// non-replicated path (clock nil) keeps the cheaper watermark-free method.
+	//
 	// A born-expired write (expiration already in the past) is dead on arrival:
 	// the cache does not store it and it is invisible to GetVertex, so it must
 	// not be logged or replicated either — otherwise peers would apply, store
@@ -525,17 +550,23 @@ func (s *LanternService) PutVertices(ctx context.Context, request *pb.PutVertice
 	// inflating their high-water for zero benefit (#698). Replicate only the
 	// live subset; the all-live fast path forwards the original request
 	// unchanged so the steady-state cost is a single liveness check per vertex.
-	switch {
-	case liveCount == len(in):
-		s.logMutation(&pb.MutationOp{Op: &pb.MutationOp_PutVertices{PutVertices: request}})
-	case liveCount > 0:
-		live := make([]*pb.Vertex, 0, liveCount)
-		for _, v := range in {
-			if cache.IsLiveAt(v.GetExpiration().AsTime(), now) {
-				live = append(live, v)
+	if s.clock != nil {
+		ts := s.clock.Now()
+		s.cache.PutVerticesWithExpirationHLC(items, ts)
+		switch {
+		case liveCount == len(in):
+			s.logMutationAt(&pb.MutationOp{Op: &pb.MutationOp_PutVertices{PutVertices: request}}, ts)
+		case liveCount > 0:
+			live := make([]*pb.Vertex, 0, liveCount)
+			for _, v := range in {
+				if cache.IsLiveAt(v.GetExpiration().AsTime(), now) {
+					live = append(live, v)
+				}
 			}
+			s.logMutationAt(&pb.MutationOp{Op: &pb.MutationOp_PutVertices{PutVertices: &pb.PutVerticesRequest{Vertices: live}}}, ts)
 		}
-		s.logMutation(&pb.MutationOp{Op: &pb.MutationOp_PutVertices{PutVertices: &pb.PutVerticesRequest{Vertices: live}}})
+	} else {
+		s.cache.PutVerticesWithExpiration(items)
 	}
 	return &pb.PutVerticesResponse{Written: int32(len(items))}, nil
 }
@@ -557,13 +588,19 @@ func (s *LanternService) DeleteVertices(ctx context.Context, in *pb.DeleteVertic
 	s.metrics.OnBatch("DeleteVertices", len(in.GetKeys()))
 	var n int
 	if s.clock != nil && s.tombstoneTTL > 0 {
-		// Replicated path: stamp tombstones at clock.Now() so peers
-		// resolve LWW deterministically; local expiration is best-effort.
-		n = s.cache.DeleteVerticesHLC(in.GetKeys(), s.clock.Now(), s.tombstoneExpiration())
+		// Replicated path: sample the commit HLC ONCE and stamp BOTH the
+		// tombstone and the logged mutation with it. Sampling clock.Now()
+		// separately for each (as the cache call and logMutation used to)
+		// left a window where a concurrent Put with an HLC between the two
+		// would lose to the delete on peers but beat the tombstone on the
+		// origin — divergence. Local expiration is best-effort wall clock.
+		ts := s.clock.Now()
+		n = s.cache.DeleteVerticesHLC(in.GetKeys(), ts, s.tombstoneExpiration())
+		s.logMutationAt(&pb.MutationOp{Op: &pb.MutationOp_DeleteVertices{DeleteVertices: in}}, ts)
 	} else {
 		n = s.cache.DeleteVertices(in.GetKeys())
+		s.logMutation(&pb.MutationOp{Op: &pb.MutationOp_DeleteVertices{DeleteVertices: in}})
 	}
-	s.logMutation(&pb.MutationOp{Op: &pb.MutationOp_DeleteVertices{DeleteVertices: in}})
 	return &pb.DeleteVerticesResponse{Deleted: int32(n)}, nil
 }
 
@@ -650,9 +687,22 @@ func (s *LanternService) AddEdges(ctx context.Context, request *pb.AddEdgesReque
 		}
 		items = append(items, item)
 	}
-	deduped := s.cache.AddEdgesWithExpirationContrib(items)
-	s.metrics.OnEdgeContribDeduped(deduped)
-	s.logMutation(&pb.MutationOp{Op: &pb.MutationOp_AddEdges{AddEdges: request}})
+	// Additive merge converges via ContribID set semantics regardless of
+	// delivery order, but when replication is enabled the contribution must
+	// still be fenced by the edge tombstone at the SAME HLC it is logged
+	// under, so a contribution older than a concurrent DeleteEdge is dropped
+	// on the origin exactly as it is on every peer. The non-replicated path
+	// (clock nil) keeps the cheaper tombstone-free method.
+	var deduped int
+	if s.clock != nil {
+		ts := s.clock.Now()
+		deduped = s.cache.AddEdgesWithExpirationContribHLC(items, ts)
+		s.metrics.OnEdgeContribDeduped(deduped)
+		s.logMutationAt(&pb.MutationOp{Op: &pb.MutationOp_AddEdges{AddEdges: request}}, ts)
+	} else {
+		deduped = s.cache.AddEdgesWithExpirationContrib(items)
+		s.metrics.OnEdgeContribDeduped(deduped)
+	}
 	return &pb.AddEdgesResponse{Written: int32(len(items))}, nil
 }
 
@@ -681,11 +731,22 @@ func (s *LanternService) PutEdges(ctx context.Context, request *pb.PutEdgesReque
 			Expiration: e.GetExpiration().AsTime(),
 		})
 	}
-	// PutEdgesWithExpiration takes the cache write lock once for the whole
-	// batch, so concurrent GetEdge readers never observe a transient
-	// NotFound between the per-edge delete and add.
-	s.cache.PutEdgesWithExpiration(items)
-	s.logMutation(&pb.MutationOp{Op: &pb.MutationOp_PutEdges{PutEdges: request}})
+	// PutEdges*WithExpiration takes the cache write lock once for the whole
+	// batch, so concurrent GetEdge readers never observe a transient NotFound
+	// between the per-edge delete and add. When replication is enabled the
+	// *HLC method stamps every edge with the SAME HLC it is logged under so
+	// PutEdge resolves as an LWW-Register on (tail, head) across replicas —
+	// without the watermark a concurrently-written OLDER edge replayed from a
+	// peer would clobber the origin's newer weight on the origin alone
+	// (docs/replication.md "Higher HLC wins"). The non-replicated path (clock
+	// nil) keeps the cheaper watermark-free method.
+	if s.clock != nil {
+		ts := s.clock.Now()
+		s.cache.PutEdgesWithExpirationHLC(items, ts)
+		s.logMutationAt(&pb.MutationOp{Op: &pb.MutationOp_PutEdges{PutEdges: request}}, ts)
+	} else {
+		s.cache.PutEdgesWithExpiration(items)
+	}
 	return &pb.PutEdgesResponse{Written: int32(len(items))}, nil
 }
 
@@ -711,11 +772,15 @@ func (s *LanternService) DeleteEdges(ctx context.Context, in *pb.DeleteEdgesRequ
 	}
 	var n int
 	if s.clock != nil && s.tombstoneTTL > 0 {
-		n = s.cache.DeleteEdgesHLC(keys, s.clock.Now(), s.tombstoneExpiration())
+		// Share one commit HLC between the tombstone and the logged
+		// mutation (see DeleteVertices for the divergence this closes).
+		ts := s.clock.Now()
+		n = s.cache.DeleteEdgesHLC(keys, ts, s.tombstoneExpiration())
+		s.logMutationAt(&pb.MutationOp{Op: &pb.MutationOp_DeleteEdges{DeleteEdges: in}}, ts)
 	} else {
 		n = s.cache.DeleteEdges(keys)
+		s.logMutation(&pb.MutationOp{Op: &pb.MutationOp_DeleteEdges{DeleteEdges: in}})
 	}
-	s.logMutation(&pb.MutationOp{Op: &pb.MutationOp_DeleteEdges{DeleteEdges: in}})
 	return &pb.DeleteEdgesResponse{Deleted: int32(n)}, nil
 }
 

--- a/tests/integration/convergence_gate_test.go
+++ b/tests/integration/convergence_gate_test.go
@@ -1,0 +1,295 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/graphcache"
+	"github.com/anaregdesign/lantern/core/hlc"
+	"github.com/anaregdesign/lantern/core/mutationlog"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/anaregdesign/lantern/server/service"
+	"google.golang.org/protobuf/proto"
+)
+
+// convergenceNode is a tombstone-enabled sibling of pumpNode
+// (peer_pump_test.go). The only difference from newPumpNode is the
+// extra WithTombstoneTTL on the service: the partition→heal convergence
+// gate below exercises Delete vs Put races, which only converge when
+// the replication apply path stamps HLC tombstones (a delete handled
+// via the non-HLC backend leaves no fence, so a re-delivered older Put
+// can resurrect the key on some replicas but not others). Everything
+// else — the Connect/h2c httptest server, the SDK client, the
+// startPump / waitForVertex / waitForEdge helpers — is reused verbatim
+// from the pump harness, so a convergenceNode IS a *pumpNode.
+func newConvergenceNode(t *testing.T, nodeID hlc.NodeID, tombstoneTTL time.Duration) *pumpNode {
+	t.Helper()
+	log := mutationlog.New(mutationlog.Options{Capacity: 1024, SubscriberBuffer: 1024})
+	t.Cleanup(func() { _ = log.Close() })
+	clock := hlc.New(nodeID, hlc.Options{})
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+	svc := service.NewLanternService(cache).
+		WithReplication(log, clock, nil).
+		WithTombstoneTTL(tombstoneTTL)
+	rep := service.NewLanternReplicationService(log, cache, clock)
+	srv := newConnectTestServer(t, svc, rep)
+
+	return &pumpNode{
+		url:    srv.url,
+		cache:  cache,
+		clock:  clock,
+		log:    log,
+		svc:    svc,
+		sdk:    newConnectClientFor(t, srv.url),
+		nodeID: nodeID,
+	}
+}
+
+// waitForVertexAbsent polls cache.GetVertex until the key is gone or the
+// deadline elapses. It is the tombstone-aware counterpart of
+// waitForVertex: a deleted key must converge to *absent* on every
+// replica, so the assertion waits for the terminal "not present" state
+// rather than a value.
+func waitForVertexAbsent(t *testing.T, cache *graphcache.GraphCache[string, *pb.Vertex], key string, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, ok := cache.GetVertex(key); !ok {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	_, ok := cache.GetVertex(key)
+	return !ok
+}
+
+// waitForVertexValue polls cache.GetVertex until the key holds the
+// expected string value or the deadline elapses. Returns the last value
+// observed (for diagnostics) and whether it matched. Used to assert that
+// an LWW conflict converges to the higher-HLC writer's payload on every
+// replica.
+func waitForVertexValue(t *testing.T, cache *graphcache.GraphCache[string, *pb.Vertex], key, want string, timeout time.Duration) (string, bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last string
+	for time.Now().Before(deadline) {
+		if v, ok := cache.GetVertex(key); ok {
+			if s, err := client.StringValue(v); err == nil {
+				last = s
+				if s == want {
+					return s, true
+				}
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return last, false
+}
+
+// TestConvergence_PartitionHealReconverges is the HA correctness gate
+// for issue #715. It stands up a three-replica leaderless cluster, holds
+// the peer pumps DOWN to simulate a network partition, applies divergent
+// writes to individual replicas, then HEALS the partition by attaching a
+// full-mesh of pumps and asserts that every replica reconverges to one
+// byte-identical state.
+//
+// The gate covers exactly the conflict classes the replication RFC
+// (docs/replication.md §"Conflict resolution") guarantees converge under
+// arbitrary delivery order:
+//
+//   - LWW-Register (PutVertex / PutEdge): the strictly-higher HLC wins.
+//   - Additive merge (AddEdge): contributions from distinct origins carry
+//     distinct ContribIDs and SUM; re-delivery dedups.
+//   - Tombstone (Delete with a HIGHER HLC than the racing Put): the
+//     delete wins and the key converges to absent. Any Put whose HLC is
+//     strictly older than the delete is dropped on every replica
+//     (README "LANTERN_TOMBSTONE_TTL"), so the outcome is delivery-order
+//     independent.
+//
+// The reverse race — a Put whose HLC is *newer* than a delete
+// (resurrection) — is intentionally NOT asserted here: the project only
+// guarantees that an older Put is fenced, and ha-runbook.md documents
+// resurrection as a known hazard rather than a convergence guarantee. A
+// gate that asserted it would encode a property the system does not
+// claim to provide.
+//
+// The winner of each LWW race is made deterministic by sequencing: all
+// "loser" writes happen first, then a real-time gap, then the "winner"
+// writes. Because every replica reads the same wall clock, the later
+// write carries the strictly-higher HLC.
+func TestConvergence_PartitionHealReconverges(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping partition→heal convergence gate in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Tombstone retention comfortably exceeds every write TTL below so the
+	// D4 clamp never rejects a write and tombstones never expire mid-test;
+	// convergence is decided on the stored HLC, not on local expiration.
+	const (
+		tombstoneTTL = 24 * time.Hour
+		writeTTL     = time.Hour
+		converge     = 8 * time.Second
+	)
+
+	a := newConvergenceNode(t, hlc.NodeID{0xA1}, tombstoneTTL)
+	b := newConvergenceNode(t, hlc.NodeID{0xB2}, tombstoneTTL)
+	c := newConvergenceNode(t, hlc.NodeID{0xC3}, tombstoneTTL)
+	nodes := []*pumpNode{a, b, c}
+
+	// ----------------------------------------------------------------
+	// Phase 1 — PARTITION. No pumps are running, so writes stay local to
+	// the replica that received them and the cluster diverges.
+	// ----------------------------------------------------------------
+
+	// Round 1: the "loser" / uncontested writes (lower HLC).
+	if err := a.sdk.PutVertex(ctx, "ow", "ow-from-A", writeTTL); err != nil {
+		t.Fatalf("a.PutVertex(ow): %v", err)
+	}
+	if err := a.sdk.PutVertex(ctx, "del", "doomed", writeTTL); err != nil {
+		t.Fatalf("a.PutVertex(del): %v", err)
+	}
+	if err := a.sdk.PutVertex(ctx, "only-a", "only-on-A", writeTTL); err != nil {
+		t.Fatalf("a.PutVertex(only-a): %v", err)
+	}
+	if err := a.sdk.PutEdge(ctx, "pe-t", "pe-h", 5.0, writeTTL); err != nil {
+		t.Fatalf("a.PutEdge: %v", err)
+	}
+	// Additive merge: A and B each contribute 1.0 to the same edge from
+	// distinct origins, so the contributions sum to 2.0 cluster-wide.
+	if err := a.sdk.AddEdge(ctx, "m-t", "m-h", 1.0, writeTTL); err != nil {
+		t.Fatalf("a.AddEdge: %v", err)
+	}
+	if err := b.sdk.AddEdge(ctx, "m-t", "m-h", 1.0, writeTTL); err != nil {
+		t.Fatalf("b.AddEdge: %v", err)
+	}
+	if err := c.sdk.PutVertex(ctx, "only-c", "only-on-C", writeTTL); err != nil {
+		t.Fatalf("c.PutVertex(only-c): %v", err)
+	}
+
+	// Real-time gap so the Round 2 writes carry a strictly-higher HLC
+	// (every replica shares the same wall clock).
+	time.Sleep(25 * time.Millisecond)
+
+	// Round 2: the "winner" writes on B (higher HLC).
+	if err := b.sdk.PutVertex(ctx, "ow", "ow-from-B", writeTTL); err != nil {
+		t.Fatalf("b.PutVertex(ow): %v", err)
+	}
+	if _, err := b.sdk.DeleteVertex(ctx, "del"); err != nil {
+		t.Fatalf("b.DeleteVertex(del): %v", err)
+	}
+	if err := b.sdk.PutEdge(ctx, "pe-t", "pe-h", 9.0, writeTTL); err != nil {
+		t.Fatalf("b.PutEdge: %v", err)
+	}
+
+	// ----------------------------------------------------------------
+	// Phase 2 — HEAL. Attach a full mesh of pumps. Each pump subscribes
+	// to its peers from an empty cursor and replays their entire logs, so
+	// every divergent mutation reaches every replica.
+	// ----------------------------------------------------------------
+	a.startPump(ctx, t, []string{b.url, c.url})
+	b.startPump(ctx, t, []string{a.url, c.url})
+	c.startPump(ctx, t, []string{a.url, b.url})
+
+	// ----------------------------------------------------------------
+	// Phase 3 — CONVERGENCE. Every replica must reach the same terminal
+	// state for the full controlled keyspace.
+	// ----------------------------------------------------------------
+	nodeName := map[*pumpNode]string{a: "A", b: "B", c: "C"}
+
+	for _, n := range nodes {
+		name := nodeName[n]
+
+		// LWW vertex: B's higher-HLC write wins on every replica.
+		if got, ok := waitForVertexValue(t, n.cache, "ow", "ow-from-B", converge); !ok {
+			t.Errorf("node %s: vertex %q did not converge to %q (last=%q)", name, "ow", "ow-from-B", got)
+		}
+
+		// Uncontested writes from A and C propagate everywhere.
+		if got, ok := waitForVertexValue(t, n.cache, "only-a", "only-on-A", converge); !ok {
+			t.Errorf("node %s: vertex %q did not converge to %q (last=%q)", name, "only-a", "only-on-A", got)
+		}
+		if got, ok := waitForVertexValue(t, n.cache, "only-c", "only-on-C", converge); !ok {
+			t.Errorf("node %s: vertex %q did not converge to %q (last=%q)", name, "only-c", "only-on-C", got)
+		}
+
+		// Tombstone: B's delete has the higher HLC, so the key converges
+		// to absent on every replica (A's older Put is fenced).
+		if !waitForVertexAbsent(t, n.cache, "del", converge) {
+			t.Errorf("node %s: vertex %q did not converge to absent (tombstone-wins)", name, "del")
+		}
+
+		// Additive merge: two distinct-origin contributions sum to 2.0.
+		if w, ok := waitForEdge(t, n.cache, "m-t", "m-h", 2.0, converge); !ok || w != 2.0 {
+			t.Errorf("node %s: edge m-t->m-h converged to w=%v ok=%v, want 2.0/true", name, w, ok)
+		}
+
+		// LWW edge: B's higher-HLC PutEdge (9.0) replaces A's 5.0.
+		if w, ok := waitForEdge(t, n.cache, "pe-t", "pe-h", 9.0, converge); !ok || w != 9.0 {
+			t.Errorf("node %s: edge pe-t->pe-h converged to w=%v ok=%v, want 9.0/true", name, w, ok)
+		}
+	}
+
+	// Belt-and-suspenders: assert byte-identical vertex payloads and
+	// exact edge weights across all three replicas, not merely that each
+	// reached its own expected value. This is the literal "byte-for-byte
+	// identical state" the gate promises.
+	assertReplicasIdentical(t, nodes,
+		[]string{"ow", "del", "only-a", "only-c", "pe-t", "pe-h", "m-t", "m-h"},
+		[][2]string{{"m-t", "m-h"}, {"pe-t", "pe-h"}})
+}
+
+// assertReplicasIdentical fails the test if any vertex key or edge pair
+// differs across the supplied replicas. Vertex presence+payload is
+// compared by deterministic proto marshaling; edge presence+weight by
+// exact float32 equality. An absent key must be absent on every replica.
+func assertReplicasIdentical(t *testing.T, nodes []*pumpNode, vertexKeys []string, edges [][2]string) {
+	t.Helper()
+	if len(nodes) < 2 {
+		return
+	}
+	ref := nodes[0]
+	for _, key := range vertexKeys {
+		refV, refOK := ref.cache.GetVertex(key)
+		for _, n := range nodes[1:] {
+			gotV, gotOK := n.cache.GetVertex(key)
+			if refOK != gotOK {
+				t.Errorf("vertex %q presence diverged: node0=%v nodeN=%v", key, refOK, gotOK)
+				continue
+			}
+			if refOK && string(mustMarshalVertex(t, refV)) != string(mustMarshalVertex(t, gotV)) {
+				t.Errorf("vertex %q payload diverged across replicas", key)
+			}
+		}
+	}
+	for _, e := range edges {
+		refW, refOK := ref.cache.GetWeight(e[0], e[1])
+		for _, n := range nodes[1:] {
+			gotW, gotOK := n.cache.GetWeight(e[0], e[1])
+			if refOK != gotOK {
+				t.Errorf("edge %v presence diverged: node0=%v nodeN=%v", e, refOK, gotOK)
+				continue
+			}
+			if refOK && refW != gotW {
+				t.Errorf("edge %v weight diverged: node0=%g nodeN=%g", e, refW, gotW)
+			}
+		}
+	}
+}
+
+// mustMarshalVertex deterministically marshals a vertex for byte-equality
+// comparison across replicas. Kept local to the integration suite so it
+// does not depend on the service package's test-only helper of the same
+// shape.
+func mustMarshalVertex(t *testing.T, v *pb.Vertex) []byte {
+	t.Helper()
+	b, err := proto.MarshalOptions{Deterministic: true}.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal vertex: %v", err)
+	}
+	return b
+}


### PR DESCRIPTION
## What & why

The partition→heal convergence gate built for #715 **failed on first run** and exposed a real, RFC-violating divergence (#719) — so this PR is a `fix`, not just a test.

When replication is enabled, the **local write paths** (`PutVertices`/`PutVertex`, `PutEdges`/`PutEdge`) stored values through the **non-HLC** cache methods, which record no `vertexHLC` / edge HLC watermark. The replication **apply** path uses the HLC-aware methods. So an origin's *own* write left **no watermark**, and an **older** value for the same key replayed from a peer's log clobbered the origin's newer value **on the origin alone** while every other replica kept the newer value — permanent divergence, violating the LWW-Register guarantee in [docs/replication.md](docs/replication.md) (*"Higher HLC wins; same HLC ⇒ higher origin ID wins"*).

## Changes

- **`core/graphcache/batch.go`** — add LWW/tombstone-aware batch siblings used by the local write path: `PutVerticesWithExpirationHLC`, `PutEdgesWithExpirationHLC`, `AddEdgesWithExpirationContribHLC` (mirror the singular apply-path HLC methods, looped under one lock). The vertex batch keeps the dead-on-arrival `putLocalVertexLocked` path so the #698 born-expired optimisation survives while still stamping the watermark. + black-box unit tests for all three.
- **`server/service/service.go`** — `logMutation` → `logMutationAt(op, ts)`. Every replicated local write samples `clock.Now()` **once** and hands the same `ts` to both the HLC cache method and the mutation-log append. Put/AddEdge stamping gated on `s.clock != nil` (Put-vs-Put LWW needs a watermark even without tombstones); Delete on `s.clock != nil && s.tombstoneTTL > 0`. This also collapses a **latent delete race** where the tombstone and the logged mutation each sampled `clock.Now()` separately. Non-replicated workloads (clock nil) keep the cheaper watermark-free path.
- **`server/service/backend.go`** — extend the `Backend` interface with the three batch HLC methods; the test fake delegates to the non-HLC siblings so existing service call-counter assertions still hold.
- **`tests/integration/convergence_gate_test.go`** — the #715 partition→heal correctness gate: 3-node leaderless cluster, divergent writes under partition, full-mesh heal, then asserts **byte-identical** reconvergence for LWW vertex, LWW edge, additive merge, and tombstone-wins.

## Scope / non-goals

- **Resurrection** (a Put with an HLC *newer* than a competing Delete) is **intentionally not** asserted: `DeleteVertexHLC` deletes unconditionally and `docs/ha-runbook.md` documents resurrection as a known hazard, not a guarantee. The gate asserts only that a strictly-*older* Put is fenced.
- Apply-path clock-skew assimilation is a separate latent concern, out of scope here.

## Verification

- `go test ./tests/integration/ -run TestConvergence_PartitionHealReconverges -race` — **passes** (failed before the fix).
- New `core/graphcache` batch-HLC unit tests pass under `-race`.
- Full per-module suites (`core`, `server`, `mcp`, `pb`, `sdks/go`, root) + `gofmt -l` clean + golangci-lint (root) 0 issues.

Closes #715, closes #719
