### PR TITLE
test: fuzz parse/decode boundaries (proto, cursor, contribId, NDJSON, CLI grammar)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -164,3 +164,36 @@ jobs:
             (cd "$mod" && govulncheck ./...)
             echo "::endgroup::"
           done
+
+  fuzz:
+    name: Fuzz (smoke)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.4'
+          check-latest: true
+      # Active-mutation smoke run for every `func Fuzz*` target. The Build &
+      # Test job already replays the committed seed corpora under -race (Go
+      # runs FuzzXxx as ordinary tests when -fuzz is absent); this job adds a
+      # short bout of real mutation per target so malformed-input regressions
+      # surface on PRs. A crash writes a reproducer under the package's
+      # testdata/fuzz/ and fails the job. Per-module + per-target because
+      # `-fuzz` only accepts a single target in a single package. Refs #714.
+      - name: Fuzz each target (per module)
+        run: |
+          set -e
+          for mod in . core mcp pb sdks/go server; do
+            (cd "$mod"
+             dirs=$(grep -rl --include='*_test.go' --exclude-dir=node_modules -e 'func Fuzz' . 2>/dev/null \
+               | xargs -r -n1 dirname | sort -u)
+             for d in $dirs; do
+               pkg=$(go list "$d" 2>/dev/null) || continue
+               for t in $(go test -list='^Fuzz' "$pkg" 2>/dev/null | grep '^Fuzz' || true); do
+                 echo "::group::fuzz ${pkg} ${t}"
+                 go test -run='^$' -fuzz="^${t}$" -fuzztime=20s "$pkg"
+                 echo "::endgroup::"
+               done
+             done)
+          done

--- a/cli/cmd/bulk_test.go
+++ b/cli/cmd/bulk_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// FuzzBulkVertexLine fuzzes the per-line decode pipeline of `bulk vertices`:
+// json.Unmarshal into vertexLine, then parseTTL + expirationFromTTL. A
+// malformed NDJSON line must surface as an error, never a panic — the CLI
+// streams untrusted files straight into this path.
+func FuzzBulkVertexLine(f *testing.F) {
+	seeds := []string{
+		`{"key":"alice","value":42}`,
+		`{"key":"bob","value":{"name":"Bob"},"ttl":"1h"}`,
+		`{"key":"c","value":"hi","ttl":"30m"}`,
+		`{"key":"d","value":[1,2,3]}`,
+		`{"key":"e","value":true,"ttl":"0s"}`,
+		`{"key":"f","value":1.5,"ttl":"-5s"}`,
+		`{"ttl":"notaduration"}`,
+		`{`,
+		``,
+		`null`,
+		`{"value":1e999}`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, line string) {
+		var v vertexLine
+		if json.Unmarshal([]byte(line), &v) != nil {
+			return
+		}
+		ttl, err := parseTTL(v.TTL)
+		if err != nil {
+			return
+		}
+		_ = expirationFromTTL(ttl)
+	})
+}
+
+// FuzzBulkEdgeLine fuzzes the `bulk edges` per-line decode pipeline.
+func FuzzBulkEdgeLine(f *testing.F) {
+	seeds := []string{
+		`{"tail":"alice","head":"bob","weight":1.5}`,
+		`{"tail":"a","head":"b","weight":-0.0,"ttl":"1h"}`,
+		`{"tail":"a","head":"b"}`,
+		`{"weight":"notafloat"}`,
+		`{"tail":"a","head":"b","weight":1,"ttl":"bogus"}`,
+		`{`,
+		``,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, line string) {
+		var e edgeLine
+		if json.Unmarshal([]byte(line), &e) != nil {
+			return
+		}
+		ttl, err := parseTTL(e.TTL)
+		if err != nil {
+			return
+		}
+		_ = expirationFromTTL(ttl)
+	})
+}

--- a/cli/parser/validate_test.go
+++ b/cli/parser/validate_test.go
@@ -1,0 +1,53 @@
+package parser
+
+import "testing"
+
+// FuzzValidate fuzzes the CLI/REPL grammar dispatcher end-to-end: NewSource
+// tokenises arbitrary input, then Validate dispatches it. Neither may panic
+// on any byte sequence — a syntactically invalid command must surface as an
+// error, never a crash. Seeds are drawn from the shared grammar corpus
+// (admin/test/cli-grammar/verbs.json) plus adversarial quoting/escaping so
+// the fuzzer starts from realistic, structurally diverse commands.
+func FuzzValidate(f *testing.F) {
+	seeds := []string{
+		// Valid forms (mirrors the "valid" arm of the shared fixture).
+		"exit", "help", "help me",
+		"get vertex alice", "get edge alice bob",
+		"put vertex alice Alice", "put vertex alice Alice 60",
+		"put vertex price 1234 type=int", "put vertex name 007 type=string",
+		"put edge alice bob 1.5", "put edge alice bob 1.5 60",
+		"add edge alice bob 1.0",
+		"delete vertex alice", "delete vertex alice bob carol",
+		"delete edge alice bob", "delete edge alice bob carol dave",
+		"scan vertices users/", "scan vertices users/ 100 all=true",
+		"scan edges alice head=post:", "count vertices users/",
+		"delete-prefix vertices tmp/ confirm=yes",
+		"delete-prefix vertices tmp/ dry_run=true limit=500",
+		"keys users/", "keys users/ 100",
+		"illuminate alice 2 5",
+		"illuminate alice 2 5 algorithm=spt objective=max weighting=tfidf",
+		"illuminate alice 2 5 prefix=team:",
+		`put vertex greeting "hello world"`,
+		`put vertex code 'console.log("hi")'`,
+		`put vertex path "a\nb\tc"`,
+		// Invalid / adversarial forms (mirrors the "invalid" arm + quoting).
+		"", "nonsense", "get", "put vertex k v type=bogus",
+		"put edge alice bob notafloat", "scan vertex users/",
+		"illuminate alice 2 5 algorithm=bogus",
+		`put vertex greeting "hello world`,
+		`put vertex greeting "bad \q escape"`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		// Must not panic or hang. Both a nil (valid) and non-nil (rejected)
+		// result are acceptable outcomes; only a crash is a failure.
+		_ = Validate(input)
+		// Exercise the tokeniser directly too — it is the front end Validate
+		// relies on, and REPL/RPC callers may invoke it standalone.
+		if s, err := NewSource(input); err == nil {
+			_, _ = Verb(s)
+		}
+	})
+}

--- a/pb/graph/v1/fuzz_test.go
+++ b/pb/graph/v1/fuzz_test.go
@@ -1,0 +1,110 @@
+package graphv1_test
+
+// This is one of the few hand-written files under pb/ — the package is
+// otherwise buf-generated. It lives here, rather than in a consumer module,
+// because the boundary it guards (proto.Unmarshal into the generated message
+// types) is the wire-decode surface owned by pb: every read/write RPC crosses
+// it with attacker-influenced bytes. buf never touches *_test.go, so the
+// "generated code is up to date" CI gate (go generate ./... + git diff) leaves
+// it untouched. Precedent: graphv1connect/graphv1connect_test.go is likewise a
+// hand-written test inside pb/.
+
+import (
+	"testing"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+// addProtoSeeds seeds a fuzz target with a baseline of pathological byte
+// inputs (empty, truncated tag, overlong varint) plus the canonical wire
+// encoding of each supplied message. Every decoder must survive all of them.
+func addProtoSeeds(f *testing.F, msgs ...proto.Message) {
+	f.Helper()
+	f.Add([]byte(nil))
+	f.Add([]byte{})
+	f.Add([]byte{0x08})                                                       // field 1, varint tag with no value (truncated)
+	f.Add([]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}) // overlong/garbage varint
+	for _, m := range msgs {
+		b, err := proto.Marshal(m)
+		if err != nil {
+			f.Fatalf("seed marshal: %v", err)
+		}
+		f.Add(b)
+	}
+}
+
+// roundTripProto asserts that a message which decoded cleanly survives a
+// Marshal→Unmarshal cycle unchanged. dst must be a fresh zero message of the
+// same concrete type as src. proto.Equal treats NaN floats as equal, so
+// fuzzed non-finite values do not produce spurious mismatches.
+func roundTripProto(t *testing.T, src, dst proto.Message) {
+	t.Helper()
+	b, err := proto.Marshal(src)
+	if err != nil {
+		t.Fatalf("re-marshal decoded message: %v", err)
+	}
+	if err := proto.Unmarshal(b, dst); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if !proto.Equal(src, dst) {
+		t.Fatalf("round-trip mismatch:\n before=%v\n after =%v", src, dst)
+	}
+}
+
+// FuzzVertexUnmarshal fuzzes the Vertex wire-decode boundary every read RPC
+// crosses. Decoding arbitrary bytes must never panic, and any input that
+// decodes cleanly must survive a Marshal/Unmarshal round-trip.
+func FuzzVertexUnmarshal(f *testing.F) {
+	addProtoSeeds(f,
+		&pb.Vertex{Key: "alice"},
+		&pb.Vertex{Key: "n", Value: &pb.Vertex_Int64{Int64: 42}},
+		&pb.Vertex{Key: "s", Value: &pb.Vertex_String_{String_: "hello"}},
+		&pb.Vertex{Key: "nil", Value: &pb.Vertex_Nil{Nil: true}},
+	)
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var v pb.Vertex
+		if proto.Unmarshal(data, &v) != nil {
+			return
+		}
+		roundTripProto(t, &v, &pb.Vertex{})
+	})
+}
+
+// FuzzEdgeUnmarshal fuzzes the Edge wire-decode boundary.
+func FuzzEdgeUnmarshal(f *testing.F) {
+	addProtoSeeds(f,
+		&pb.Edge{Tail: "alice", Head: "bob", Weight: 1.5},
+		&pb.Edge{Tail: "a", Head: "b"},
+	)
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var e pb.Edge
+		if proto.Unmarshal(data, &e) != nil {
+			return
+		}
+		roundTripProto(t, &e, &pb.Edge{})
+	})
+}
+
+// FuzzIlluminateRequestUnmarshal fuzzes a representative request message: it
+// carries scalar, enum, and reserved-field-number surface, making it the
+// richest decode in the RPC set.
+func FuzzIlluminateRequestUnmarshal(f *testing.F) {
+	addProtoSeeds(f,
+		&pb.IlluminateRequest{Seed: "alice", Step: 2, K: 5},
+		&pb.IlluminateRequest{
+			Seed: "alice", Step: 2, K: 5,
+			Algorithm:    pb.Algorithm_ALGORITHM_SHORTEST_PATH_TREE,
+			Objective:    pb.Objective_OBJECTIVE_MAXIMIZE,
+			Weighting:    pb.Weighting_WEIGHTING_TFIDF,
+			VertexPrefix: "users/",
+		},
+	)
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var r pb.IlluminateRequest
+		if proto.Unmarshal(data, &r) != nil {
+			return
+		}
+		roundTripProto(t, &r, &pb.IlluminateRequest{})
+	})
+}

--- a/sdks/go/value_test.go
+++ b/sdks/go/value_test.go
@@ -574,3 +574,58 @@ func TestEdgeJSON_RoundTrip(t *testing.T) {
 		}
 	}
 }
+
+// FuzzUnmarshalVertexJSON fuzzes the JSON→Vertex decode path used by the NDJSON
+// backup/restore codec. A clean decode must (a) survive every value accessor
+// without panicking, and (b) re-marshal via MarshalVertexJSON to bytes that
+// themselves decode again — the marshal/unmarshal pair must stay stable.
+// Inputs MarshalVertexJSON legitimately cannot re-encode are tolerated (it must
+// fail cleanly, not panic), keeping the fuzz focused on real defects.
+func FuzzUnmarshalVertexJSON(f *testing.F) {
+	seeds := []string{
+		`{"key":"a","type":"int64","value":42}`,
+		`{"key":"u","type":"uint64","value":18446744073709551615}`,
+		`{"key":"f","type":"float64","value":3.14}`,
+		`{"key":"s","type":"string","value":"hi"}`,
+		`{"key":"b","type":"bool","value":true}`,
+		`{"key":"by","type":"bytes","value":"aGVsbG8="}`,
+		`{"key":"t","type":"timestamp","value":"2020-01-01T00:00:00Z"}`,
+		`{"key":"d","type":"duration","value":"1h30m"}`,
+		`{"key":"n","type":"nil","value":null}`,
+		`{"key":"x","type":"int64","value":42,"expiration":"2030-01-01T00:00:00Z"}`,
+		`{`,
+		``,
+		`{"type":"bogus"}`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, data string) {
+		v, err := UnmarshalVertexJSON([]byte(data))
+		if err != nil {
+			return
+		}
+		// No accessor may panic on a successfully decoded vertex.
+		_ = Kind(v)
+		_, _ = IntValue(v)
+		_, _ = UIntValue(v)
+		_, _ = FloatValue(v)
+		_, _ = StringValue(v)
+		_, _ = BoolValue(v)
+		_, _ = BytesValue(v)
+		_, _ = TimeValue(v)
+		_, _ = DurationValue(v)
+		_ = IsNil(v)
+		_ = VertexExpiration(v)
+		// The marshal/unmarshal pair must stay stable: bytes produced by
+		// MarshalVertexJSON must decode again. Values it cannot re-encode are
+		// out of scope (it must error cleanly rather than panic).
+		b, err := MarshalVertexJSON(v)
+		if err != nil {
+			return
+		}
+		if _, err := UnmarshalVertexJSON(b); err != nil {
+			t.Fatalf("re-decode of MarshalVertexJSON output: %v", err)
+		}
+	})
+}

--- a/server/service/apply_test.go
+++ b/server/service/apply_test.go
@@ -790,3 +790,41 @@ func TestApplyMutation_TombstoneClampRejectHook(t *testing.T) {
 		}
 	})
 }
+
+// FuzzContribIDFromBytes fuzzes the wire→ContribID decode. Only the canonical
+// 24-byte length may yield a non-zero id; every other length must collapse to
+// the zero sentinel (the "no identity" marker that makes receivers skip
+// dedup). A non-zero decode must round-trip back through contribIDBytes
+// unchanged, and the decode must never panic. Guards the dedup-id boundary the
+// broad_rw bench comment flags as a silent zero-decode hazard.
+func FuzzContribIDFromBytes(f *testing.F) {
+	var full graphcache.ContribID
+	for i := range full {
+		full[i] = byte(i + 1)
+	}
+	f.Add([]byte(nil))
+	f.Add(make([]byte, 24)) // canonical length, all-zero -> zero sentinel
+	f.Add(full[:])          // canonical length, non-zero
+	f.Add([]byte{1, 2, 3})  // too short
+	f.Add(make([]byte, 25)) // too long
+	f.Fuzz(func(t *testing.T, b []byte) {
+		var zero graphcache.ContribID
+		got := contribIDFromBytes(b)
+		if len(b) != len(zero) {
+			if got != zero {
+				t.Fatalf("non-canonical %d-byte input decoded to a non-zero ContribID", len(b))
+			}
+			return
+		}
+		// Canonical length: the bytes must be copied verbatim.
+		if got != graphcache.ContribID(b) {
+			t.Fatalf("24-byte decode altered bytes: got %x, want %x", got, b)
+		}
+		// Non-zero ids must survive the encode→decode round-trip.
+		if got != zero {
+			if rt := contribIDFromBytes(contribIDBytes(got)); rt != got {
+				t.Fatalf("round-trip mismatch: %x -> %x", got, rt)
+			}
+		}
+	})
+}

--- a/server/service/cursor_test.go
+++ b/server/service/cursor_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestCursor_RoundTrip(t *testing.T) {
@@ -79,4 +80,47 @@ func TestCursor_RejectCrossRPC(t *testing.T) {
 	} else if !strings.Contains(err.Error(), "different Scan RPC") {
 		t.Errorf("decodeEdgesCursor(vertex cursor) error = %q, want 'different Scan RPC'", err)
 	}
+}
+
+// FuzzDecodeCursor feeds arbitrary bytes to all three Scan* cursor decoders.
+// None may panic on any input, and a cursor minted by one Scan RPC must never
+// be silently accepted by another (the #168 / #674 cross-RPC-reuse guard).
+// Only panic-freedom is asserted here; the precise cross-RPC rejection is
+// pinned by the unit tests above.
+func FuzzDecodeCursor(f *testing.F) {
+	f.Add(encodeCursor(scanCursor{LastKey: "alice"}))
+	f.Add(encodeEdgesCursor(scanEdgesCursor{LastTail: "a", LastHead: "b"}))
+	f.Add(encodeKeysCursor(scanKeysCursor{LastKey: "k"}))
+	f.Add([]byte(nil))
+	f.Add([]byte("!!!not base64!!!"))
+	f.Add([]byte("////"))
+	f.Fuzz(func(t *testing.T, b []byte) {
+		_, _ = decodeCursor(b)
+		_, _ = decodeEdgesCursor(b)
+		_, _ = decodeKeysCursor(b)
+	})
+}
+
+// FuzzCursorRoundTrip asserts the encode→decode identity for ScanVertices
+// cursors over arbitrary keys. JSON cannot carry invalid UTF-8 (it is replaced
+// with U+FFFD on the way through json.Marshal), and vertex keys are always
+// valid UTF-8 proto strings, so non-UTF-8 inputs are out of contract and
+// skipped rather than treated as failures.
+func FuzzCursorRoundTrip(f *testing.F) {
+	f.Add("")
+	f.Add("alice")
+	f.Add("users/42")
+	f.Add("emoji-✓-tab\tnewline\n")
+	f.Fuzz(func(t *testing.T, key string) {
+		if !utf8.ValidString(key) {
+			return
+		}
+		got, err := decodeCursor(encodeCursor(scanCursor{LastKey: key}))
+		if err != nil {
+			t.Fatalf("decode(encode(%q)): %v", key, err)
+		}
+		if got.LastKey != key {
+			t.Fatalf("round-trip key = %q, want %q", got.LastKey, key)
+		}
+	})
 }


### PR DESCRIPTION
Closes #714. Part of #713.

## What

Adds Go native `func Fuzz*` targets with committed seed corpora at every
untrusted-input boundary, plus a CI job that exercises them. Pure test + CI — no
shippable code changes.

Fuzz targets (each lives in the owning package's existing `xxx_test.go`, per the
1:1 pairing rule; new files only where the source had none):

| Boundary | Package | Targets |
|---|---|---|
| Wire / proto decode | `pb/graph/v1` | `FuzzVertexUnmarshal`, `FuzzEdgeUnmarshal`, `FuzzIlluminateRequestUnmarshal` |
| Cursor / prefix | `server/service` | `FuzzDecodeCursor`, `FuzzCursorRoundTrip` |
| base64 `contribId` | `server/service` | `FuzzContribIDFromBytes` |
| NDJSON bulk-load | `cli/cmd` | `FuzzBulkVertexLine`, `FuzzBulkEdgeLine` |
| CLI / REPL grammar | `cli/parser` | `FuzzValidate` |
| Value conversion | `sdks/go` | `FuzzUnmarshalVertexJSON` |

The acceptance set (proto-decode, cursor/prefix, contribId, CLI-grammar) is
covered; NDJSON and value round-trips are added as the issue's bonus surfaces.

## Properties checked

- **proto**: clean decode → `proto.Marshal` → `proto.Unmarshal` → `proto.Equal`
  (NaN-safe); malformed bytes must never panic.
- **cursor**: the three decoders are panic-free on arbitrary bytes; encode→decode
  is identity over UTF-8-valid keys.
- **contribId**: `len != 24` → zero id; `len == 24` → byte round-trip.
- **NDJSON / value**: the parse → TTL → expiration and JSON → accessors → re-encode
  pipelines are panic-free.

## CI

New **Fuzz (smoke)** job discovers every `func Fuzz*` per module and runs a short
`-fuzztime` mutation bout per target (a crash writes a reproducer under the
package's `testdata/fuzz/` and fails the job). The existing **Build & Test** job
already replays the seed corpora under `-race`.

## Verification

- `gofmt -l` (tracked) clean; root + all five submodules `go vet` + `go test` green.
- Root `golangci-lint` (v2.12.2): 0 issues.
- All 10 targets ran active fuzzing locally (~8s each) with no crashes.