### PR TITLE
test(bench): cover write RPCs in broad_mutate + nightly blocking leak gate

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -1,0 +1,89 @@
+name: Bench (nightly leak gate)
+
+# Nightly BLOCKING leak gate. Runs the same compact scenario sweep as the
+# release-time bench (testbed/bench/release-scenarios.txt) against a
+# freshly-built lantern:local image, but — unlike the release bench, which is
+# deliberately `continue-on-error` so a hiccup can never block shipping
+# (#256, #394) — this job has NO continue-on-error. release.sh exits non-zero
+# when any scenario's goroutine/heap leak gate trips, so a leak regression
+# fails this required check rather than merely warning in an advisory artifact.
+# This is the enforcement half of #716.
+#
+# It also runs with RELEASE_BENCH_BUDGET_SECONDS=0 (the sweep's graceful
+# wall-clock cutoff disabled), so every scenario runs to completion and no leak
+# can hide behind a budget-truncated tail. The job `timeout-minutes` is the only
+# backstop.
+
+on:
+  schedule:
+    # 18:00 UTC daily — off-peak for the maintainers and well clear of the
+    # release pipeline. Scheduled runs always use the default branch (main).
+    - cron: '0 18 * * *'
+  workflow_dispatch: {}
+
+# A new nightly supersedes an in-flight one rather than queueing a second
+# 3-replica compose stack on a fresh runner.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  leak-gate:
+    name: Nightly leak gate
+    runs-on: ubuntu-latest
+    # Unbounded budget means the loop runs ~23 min (see release-scenarios.txt),
+    # plus image build + tool install + compose up + aggregation. 60 min leaves
+    # generous headroom on an abnormally slow runner without letting a wedged
+    # scenario hang the job indefinitely.
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.4'
+          check-latest: true
+      - name: Install bench prerequisites (ghz, yq)
+        run: |
+          set -euo pipefail
+          GHZ_VERSION="0.121.0"
+          curl -fsSL -o /tmp/ghz.tgz \
+            "https://github.com/bojand/ghz/releases/download/v${GHZ_VERSION}/ghz-linux-x86_64.tar.gz"
+          sudo tar -xzf /tmp/ghz.tgz -C /usr/local/bin ghz
+          sudo chmod +x /usr/local/bin/ghz
+          ghz --version
+          YQ_VERSION="v4.45.4"
+          sudo curl -fsSL -o /usr/local/bin/yq \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+      - name: Build lantern:local image
+        run: |
+          docker build \
+            --build-arg VERSION=nightly \
+            --build-arg COMMIT=${{ github.sha }} \
+            -t lantern:local .
+      - name: Run nightly leak-gate sweep (blocking)
+        env:
+          TAG: nightly
+          COMMIT: ${{ github.sha }}
+          RUNNER: linux/amd64 (ubuntu-latest)
+          LANTERN_IMAGE: lantern:local
+          # Disable the graceful truncation budget so every scenario runs and a
+          # leak in a tail scenario cannot be silently skipped. The job
+          # timeout-minutes above is the hard backstop.
+          RELEASE_BENCH_BUDGET_SECONDS: "0"
+        # No continue-on-error: a non-zero exit (any scenario's leak gate failed,
+        # or a harness/setup error) fails this required nightly check.
+        run: ./testbed/bench/release.sh --out bench-report.md
+      - name: Upload bench report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bench-report-nightly
+          path: bench-report.md
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -101,14 +101,17 @@ jobs:
     # listed in testbed/bench/release-scenarios.txt against a freshly-built
     # local image and uploads a fixed-format bench-report.md for the release
     # job to splice into the release notes. Non-blocking: a leak-gate
-    # failure or harness hiccup must not prevent a release from shipping.
-    # See issue #256.
+    # failure or harness hiccup must not prevent a release from shipping
+    # (the deliberate design of #256, #394). Leak ENFORCEMENT instead lives in
+    # the nightly blocking run (.github/workflows/bench-nightly.yml), which
+    # runs this same sweep WITHOUT continue-on-error so a goroutine/heap-leak
+    # regression fails a required check rather than just warning here (#716).
     name: Release-time benchmark
     needs: verify
     runs-on: ubuntu-latest
     continue-on-error: true
     # The compact sweep is ~20 min of scenario loop (see release-scenarios.txt, #573, #708).
-    # release.sh self-bounds via RELEASE_BENCH_BUDGET_SECONDS (default 23 min) and
+    # release.sh self-bounds via RELEASE_BENCH_BUDGET_SECONDS (default 27 min) and
     # always aggregates a report before returning, so this `timeout-minutes` is
     # only a hard backstop — sized above the budget plus one scenario's worst-case
     # overshoot plus job overhead (checkout + Go + ghz/yq + docker build + compose)

--- a/testbed/bench/release-scenarios.txt
+++ b/testbed/bench/release-scenarios.txt
@@ -3,13 +3,19 @@
 # Lines starting with `#` and blank lines are ignored.
 #
 # This is the canonical release-time signal. The release bench job is
-# `continue-on-error` (non-blocking). Rather than run ~16 single-call
-# scenarios (which paid per-scenario fixed overhead — warmup + pre/post
-# runtime+pprof snapshots + cooldown + 12 Prometheus range queries + report
-# render — for each call path), the sweep is compacted to SIX scenarios, two
-# of which fan out across many call paths inside a single steady window (see
-# the `target.calls` fan-out rule in run.sh). This keeps broad coverage while
-# cutting wall-time roughly 5x vs individual scenarios. See issue #573.
+# `continue-on-error` (non-blocking) so a leak-gate hiccup or slow runner can
+# never block a release (the deliberate design of #256, #394). The SAME sweep
+# ALSO runs nightly via `.github/workflows/bench-nightly.yml` WITHOUT
+# continue-on-error and with RELEASE_BENCH_BUDGET_SECONDS=0 (no truncation), so
+# a goroutine/heap-leak regression fails a required check there rather than
+# merely warning in an advisory artifact (#716). Rather than run ~16
+# single-call scenarios (which paid per-scenario fixed overhead — warmup +
+# pre/post runtime+pprof snapshots + cooldown + 12 Prometheus range queries +
+# report render — for each call path), the sweep is compacted to SEVEN
+# scenarios, THREE of which fan out across many call paths inside a single
+# steady window (see the `target.calls` fan-out rule in run.sh). This keeps
+# broad coverage while cutting wall-time roughly 5x vs individual scenarios.
+# See issues #573 and #716.
 #
 # Why steady = 2m (and not shorter): Lantern is purely in-memory — no LSM
 # compaction / WAL replay / page-cache warmup — so throughput stabilizes in
@@ -24,13 +30,14 @@
 # broad_illuminate. Do not reorder.
 #
 # Wall-time on a fresh ubuntu-latest runner (single shared 3-replica compose,
-# sequential execution): ~20 min of scenario loop (broad_rw ~3m +
-# broad_illuminate ~3m + ttl_churn ~4m + many_subscribers ~3.5m +
-# search_churn ~3.5m + replication_apply_churn ~4.5m), ~22 min including
-# compose up + final aggregation. release.sh's RELEASE_BENCH_BUDGET_SECONDS
-# (default 1380s = 23 min) and the bench job's `timeout-minutes` (45) are
-# sized against this figure; see issues #571, #573, and #708. If you add or
-# lengthen scenarios, update those two knobs in lockstep.
+# sequential execution): ~23 min of scenario loop (broad_rw ~3m +
+# broad_mutate ~3m + broad_illuminate ~3m + ttl_churn ~4m +
+# many_subscribers ~3.5m + search_churn ~3.5m + replication_apply_churn
+# ~4.5m), ~25 min including compose up + final aggregation. release.sh's
+# RELEASE_BENCH_BUDGET_SECONDS (default 1620s = 27 min) and the bench job's
+# `timeout-minutes` (45) are sized against this figure; see issues #571,
+# #573, #708, and #716. If you add or lengthen scenarios, update those two
+# knobs in lockstep.
 #
 # release.sh self-bounds the sweep via RELEASE_BENCH_BUDGET_SECONDS and always
 # aggregates whatever ran (appending a `## Truncated` note), so an over-budget
@@ -53,6 +60,10 @@
 #   PutVertex, GetVertex, PutVertices, GetVertices, AddEdge, GetEdges,
 #   ScanVertices, DeleteVertex, ScanVertexKeys, ScanEdges,
 #   CountVerticesByPrefix, AddEdge(idempotent/ContribID)
+#
+# broad_mutate fan-out covers the remaining write surface (9-way, see #716):
+#   PutEdge, GetEdge, PutEdges, AddEdges, DeleteEdge, DeleteEdges,
+#   DeleteVertices, DeleteVerticesByPrefix, BackupSnapshot
 
 # read / write / scan / edge / delete call surface (12-way fan-out, #708)
 broad_rw
@@ -60,6 +71,11 @@ broad_rw
 # graph traversal across the orthogonal axes (4-way fan-out) — runs AFTER
 # broad_rw so the k-* graph it traverses is populated.
 broad_illuminate
+
+# edge SET / plural-add / delete / prefix-delete / backup surface (9-way
+# fan-out, #716) — the write RPCs broad_rw omits. Self-contained m-* keyspace
+# (disjoint from broad_rw), so its position in the sweep is not load-bearing.
+broad_mutate
 
 # TTL expiry / eviction plumbing under sustained write churn
 ttl_churn

--- a/testbed/bench/release.sh
+++ b/testbed/bench/release.sh
@@ -14,7 +14,7 @@
 #   RUNNER                       runner platform string (default: `uname -s/uname -m`, lowercased)
 #   LANTERN_IMAGE                image to run (default: lantern:local — must exist locally)
 #   KEEP_OUT=1                   do not delete the per-scenario `out/` tree afterwards
-#   RELEASE_BENCH_BUDGET_SECONDS wall-clock budget for the scenario sweep (default: 1080).
+#   RELEASE_BENCH_BUDGET_SECONDS wall-clock budget for the scenario sweep (default: 1620).
 #                                Once exhausted, the remaining scenarios are skipped, the
 #                                report is aggregated from whatever ran (with a `## Truncated`
 #                                note appended), and the script still exits 0. Set to 0 to
@@ -87,11 +87,13 @@ done < "$SCENARIO_LIST"
 # job via `timeout-minutes`; this budget is the *graceful* cutoff that lets us
 # aggregate a partial report and exit cleanly BEFORE the runner hard-kills the
 # job (which would discard the report entirely, leaving the release notes with a
-# placeholder). The default (1380s = 23 min) leaves the compact canonical sweep
-# (~20 min of scenario loop; see release-scenarios.txt, #573, #708) headroom to
-# finish, so it only trips when a runner is abnormally slow or the scenario set
-# grows. Set RELEASE_BENCH_BUDGET_SECONDS=0 to disable.
-BUDGET_SECONDS="${RELEASE_BENCH_BUDGET_SECONDS:-1380}"
+# placeholder). The default (1620s = 27 min) leaves the compact canonical sweep
+# (~23 min of scenario loop; see release-scenarios.txt, #573, #708, #716)
+# headroom to finish, so it only trips when a runner is abnormally slow or the
+# scenario set grows. Set RELEASE_BENCH_BUDGET_SECONDS=0 to disable (the nightly
+# blocking job in bench-nightly.yml does exactly that so no leak can hide behind
+# a truncated sweep).
+BUDGET_SECONDS="${RELEASE_BENCH_BUDGET_SECONDS:-1620}"
 
 log "release-bench: tag=$TAG commit=$COMMIT_SHORT runner=$RUNNER captured=$CAPTURED"
 log "release-bench: scenarios=${scenarios[*]}"

--- a/testbed/bench/scenarios/broad_mutate.yaml
+++ b/testbed/bench/scenarios/broad_mutate.yaml
@@ -1,0 +1,122 @@
+# broad_mutate — sibling of broad_rw that fans out across the EDGE-mutation,
+# bulk-delete, prefix-delete, and backup call surface that broad_rw omits.
+# Together the two scenarios give the release sweep a leak gate over every
+# write RPC the server exposes (see issue #716).
+#
+# Why a separate scenario instead of more calls in broad_rw: broad_rw's
+# per-call rps (steady.rps / len(calls)) and its 192 MiB heap gate are tuned
+# in lockstep against a deliberately-additive AddEdge path (#709, #711). Adding
+# nine more calls there would re-split every call's rps and invalidate that
+# tuning. Keeping the new surface in its own scenario preserves broad_rw's
+# math and gives the edge/delete/backup paths their own, independently-sized
+# gate. The release driver reuses ONE compose stack across scenarios, so this
+# file is deliberately self-contained: it owns the `m-*` keyspace exclusively
+# (disjoint from broad_rw's `k-*`/`kb-*`/`del-*` and backup_under_load's
+# `bk-*`), every Delete* path targets a monotonic no-op space, and
+# DeleteVerticesByPrefix uses a per-request unique prefix so it can never wipe
+# another scenario's working set. See release-scenarios.txt's self-contained
+# rule.
+#
+# Coverage (9-way fan-out) — the RPCs broad_rw does NOT exercise:
+#   PutEdge, GetEdge, PutEdges, AddEdges, DeleteEdge, DeleteEdges,
+#   DeleteVertices, DeleteVerticesByPrefix, BackupSnapshot
+#
+# Ordering: calls[0] (PutEdge over m-*) is what run.sh's warmup replays — run.sh
+#           warms ONLY calls[0] — so it must seed the working set the reads and
+#           backup touch. PutEdge populates the m-{0..1999} -> m-h edge space
+#           that GetEdge reads back (keeping GetEdge's status codes OK rather
+#           than NotFound) and that BackupSnapshot streams. Keep it first.
+name: broad_mutate
+phases:
+  warmup:   { duration: 15s, concurrency: 16, rps: 1000 }
+  steady:   { duration: 2m,  concurrency: 16, rps: 3600 }
+  # 30s (vs broad_rw's 15s) gives the 16 concurrent BackupSnapshot streams time
+  # to fully unwind server-side before the post snapshot, so the goroutine gate
+  # measures steady state rather than in-flight streams — the same cooldown the
+  # backup_under_load streaming scenario uses.
+  cooldown: 30s
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  # 9 parallel ghz invocations (one per call), each at steady.rps/9 = 400 rps
+  # and the full steady.concurrency (16). BackupSnapshot is server-streaming;
+  # 400 rps over the bounded m-* subgraph keeps its per-call rate near the
+  # proven backup_under_load profile while the cheap SET/delete paths supply
+  # sustained churn that brackets the 60s GC sweep twice across the 2m window.
+  calls:
+    # [0] working-set seed / filler — also what warmup replays. Idempotent edge
+    #     SET over the bounded m-{0..1999} -> m-h space; keeps the edges GetEdge
+    #     reads and BackupSnapshot streams continuously refreshed. Both
+    #     endpoints carry the `m-` prefix so the prefix-scoped backup folds them.
+    - call: graph.v1.LanternService/PutEdge
+      data_template: |
+        {"edge":{"tail":"m-{{mod .RequestNumber 2000}}","head":"m-h","weight":1.0}}
+    # [1] singular edge read over the seeded space — returns OK (the edge exists
+    #     because warmup + call[0] keep m-{0..1999} -> m-h populated). The only
+    #     read path here without plural OK+missing semantics, so it is pointed at
+    #     the live working set on purpose.
+    - call: graph.v1.LanternService/GetEdge
+      data_template: |
+        {"tail":"m-{{mod .RequestNumber 2000}}","head":"m-h"}
+    # [2] plural idempotent edge SET — overwrites the m-* edge and a sibling
+    #     mb-* edge. No accumulation: SET replaces weight, so the working set
+    #     stays bounded at ~2000 + ~2000 edges.
+    - call: graph.v1.LanternService/PutEdges
+      data_template: |
+        {"edges":[
+          {"tail":"m-{{mod .RequestNumber 2000}}","head":"m-h","weight":1.0},
+          {"tail":"mb-{{mod .RequestNumber 2000}}","head":"m-h","weight":1.0}
+        ]}
+    # [3] plural ADDITIVE edge write with a bounded, index-aligned contrib id so
+    #     retries dedup at-most-once. The id space (mod 200) is padded to 24
+    #     ASCII bytes via backtick-quoted printf (a double-quoted "%024d" would
+    #     break ghz's pre-template JSON parse) before base64; without the pad it
+    #     decodes to all-zero and the contribution rejoins the legacy additive
+    #     path, growing the heap unboundedly. With the pad the dedup set stays
+    #     capped at 200 entries — the same guard broad_rw call[11] verifies for
+    #     the singular AddEdge.
+    - call: graph.v1.LanternService/AddEdges
+      data_template: |
+        {"edges":[{"tail":"m-0","head":"m-h","weight":1.0}],"contribIds":["{{ printf `%024d` (mod .RequestNumber 200) | b64enc }}"]}
+    # [4] singular edge delete over a monotonic mdel-* space — every (tail, head)
+    #     is unique, so the removal is a bounded no-op (existed=false is still
+    #     codes.OK) that exercises the DeleteEdge -> DeleteEdges facade without
+    #     churning the seeded m-* graph.
+    - call: graph.v1.LanternService/DeleteEdge
+      data_template: |
+        {"tail":"mdel-{{.RequestNumber}}","head":"m-h"}
+    # [5] plural edge delete over the same monotonic no-op space.
+    - call: graph.v1.LanternService/DeleteEdges
+      data_template: |
+        {"edges":[{"tail":"mdel-{{.RequestNumber}}","head":"m-h"}]}
+    # [6] plural vertex delete over a monotonic no-op space — exercises the
+    #     DeleteVertices batch path; bounded (each key unique, deleted count 0).
+    - call: graph.v1.LanternService/DeleteVertices
+      data_template: |
+        {"keys":["mdel-{{.RequestNumber}}"]}
+    # [7] prefix delete. The prefix is unique per request (mdpfx-<n>-), so it
+    #     matches zero keys and deletes nothing — a bounded no-op that still
+    #     drives the prefix scan + delete plumbing and its scan instrumentation
+    #     without ever touching another scenario's keyspace.
+    - call: graph.v1.LanternService/DeleteVerticesByPrefix
+      data_template: |
+        {"prefix":"mdpfx-{{.RequestNumber}}-","limit":128}
+    # [8] prefix-scoped whole-subgraph backup. vertexPrefix "m-" bounds the
+    #     stream to the m-* edges call[0] seeds (an edge is folded only when BOTH
+    #     endpoints match the prefix — hence head "m-h"). The streaming
+    #     serialiser must not accumulate heap proportional to the number of
+    #     backup calls; the leak gate below is the regression guard.
+    - call: graph.v1.LanternService/BackupSnapshot
+      data_template: |
+        {"vertexPrefix":"m-"}
+# Heap profile: every write path here is bounded. The edge SET paths (call[0],
+# [2]) overwrite a fixed ~4000-edge working set; the additive AddEdges (call[3])
+# carries a bounded contrib id so its retries dedup; the Delete* paths (call[4-7])
+# operate on monotonic no-op spaces that never materialise state; BackupSnapshot
+# (call[8]) streams a bounded subgraph and must release per-call buffers. With no
+# deliberately-additive path the steady-state heap is far smaller than broad_rw's
+# — a positive delta beyond the gate means a real leak (e.g. an un-released
+# snapshot buffer or a leaked stream goroutine). The 128 MiB / 40-goroutine gate
+# mirrors backup_under_load, the existing streaming-backup scenario.
+leak_gate:
+  goroutine_max_delta: 40
+  heap_alloc_max_delta_mb: 128


### PR DESCRIPTION
## What

Closes #716. Part of #713.

Two gaps from the quality-gate epic:

1. **Write RPCs had no leak coverage.** `broad_rw` exercises only a slice of
   the mutation surface; the edge-mutation, bulk-delete and backup RPCs were
   never driven under sustained churn.
2. **The release bench is advisory by design** (#256, #394) so it never blocks
   a release — which also means a leak regression never failed a required check.

## Changes

- **`testbed/bench/scenarios/broad_mutate.yaml`** — a sibling release scenario
  driving the nine write RPCs `broad_rw` omits: `PutEdge`, `GetEdge`,
  `PutEdges`, `AddEdges`, `DeleteEdge`, `DeleteEdges`, `DeleteVertices`,
  `DeleteVerticesByPrefix`, `BackupSnapshot`. Self-contained `m-*` keyspace,
  warmup seeds the edge space so singular `GetEdge` stays OK, all `Delete*`
  target monotonic no-op spaces, `AddEdges` carries a bounded `contribIds` set
  so retries dedup. Own goroutine/heap leak gate (`{40, 128MB}`), 30s cooldown
  so backup streams unwind before the post snapshot.
- **`.github/workflows/bench-nightly.yml`** — scheduled (+ `workflow_dispatch`)
  blocking run of the full sweep with `RELEASE_BENCH_BUDGET_SECONDS=0` (no
  truncation) and **no** `continue-on-error`, so a leak regression on `main`
  fails a required check.
- Budget default `1380 -> 1620s` for the longer sweep; comments refreshed in
  `release.sh`, `release-scenarios.txt`, `docker-publish.yml`.

## Design notes

- **Sibling, not extend `broad_rw`** — `broad_rw`'s per-call rps
  (`steady.rps / N`) and 192MB gate are tuned in lockstep with its deliberately
  additive `AddEdge` (#709, #711). Adding nine calls would re-split every
  call's rps and invalidate that tuning. A sibling isolates the new surface
  with its own gate. (#716 explicitly allows a sibling.)
- **Nightly blocking, not release-blocking** — reversing the #256/#394
  "release bench never blocks shipping" design is risky; a nightly required
  run gives a failing signal for leak regressions on `main` without coupling
  shipping to a slow runner. (#716 allows "at minimum a nightly blocking run".)

## Verification

- All nine calls smoke-tested with `ghz` against a local server: status `OK`,
  zero errors — every method name, JSON field, the `AddEdges` b64 `contribIds`
  template, and the streaming `BackupSnapshot` are accepted.
- `release.sh` syntax-checked; sweep parses to 7 scenarios in order; budget
  default `1620`; `gofmt` clean (no Go changed).