### PR TITLE
ci: enforce per-module coverage floor gate

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -86,7 +86,48 @@ jobs:
           echo "Merged coverage line count:"
           wc -l coverage/merged.out
 
+      # Ratchet coverage gate. Each per-module floor sits just below that
+      # module's current measured baseline (documented in CONTRIBUTING.md ->
+      # "Coverage floor"); a PR that drops a module below its floor fails the
+      # build. Raise the floor in the same PR whenever coverage rises durably so
+      # the ratchet only moves up. Module totals vary widely (generated pb and
+      # the CLI sit far below core/mcp), so a single workspace number would let a
+      # regression in a well-tested module hide behind the large low-coverage
+      # denominator -- hence per-module floors over the merged total. Reuses the
+      # per-module profiles from the test step; no extra dependency. Refs #717.
+      - name: Enforce coverage floors
+        run: |
+          set -euo pipefail
+          # slug:floor% -- keep in sync with CONTRIBUTING.md "Coverage floor".
+          floors="root:31 core:84 mcp:84 pb:5 sdks-go:37 server:52"
+          fail=0
+          for entry in $floors; do
+            slug=${entry%%:*}
+            floor=${entry##*:}
+            prof="coverage/${slug}.out"
+            if [ ! -f "$prof" ]; then
+              echo "::error::coverage profile $prof is missing"
+              fail=1
+              continue
+            fi
+            total=$(go tool cover -func="$prof" | awk '/^total:/ {gsub(/%/,"",$3); print $3}')
+            if awk -v t="$total" -v f="$floor" 'BEGIN { exit !(t+0 < f+0) }'; then
+              echo "::error::coverage for '$slug' is ${total}%, below floor ${floor}%"
+              fail=1
+            else
+              echo "ok: ${slug} ${total}% >= ${floor}%"
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::coverage floor gate failed; raise coverage or, if this is a deliberate baseline change, adjust the floor + CONTRIBUTING.md"
+            exit 1
+          fi
+
+      # `if: always()` so the artifact survives a failing floor gate (or a test
+      # failure that still produced partial profiles) -- it is the primary
+      # debugging aid when the gate trips.
       - name: Upload coverage artifact
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,42 @@ Per-module test runs are mandatory: the root `go test ./...` does **not** span
 submodules. `make lint` runs the same linter as the `Lint` job. The `Proto (buf)` check
 fails on any uncommitted codegen diff — regenerate locally first (below).
 
+## Coverage floor (ratchet)
+
+The `Build & Test` job measures per-module coverage (`-covermode=atomic`), merges the
+six profiles with `gocovmerge`, and then enforces a **per-module floor** in the
+`Enforce coverage floors` step. A PR that drops any module below its floor fails CI.
+
+The floors are a **ratchet, not an aspiration**: each sits just below that module's
+current measured baseline, so coverage can only hold or climb. They are per-module
+(not one workspace number) because module totals vary widely — generated `pb` and the
+CLI sit far below `core`/`mcp`, and a single merged floor would let a regression in a
+well-tested module hide behind the large low-coverage denominator.
+
+Current floors (baseline measured on `main`; **raise these in the same PR** whenever a
+module's coverage rises durably):
+
+| Module (profile slug) | Floor |
+| --- | --- |
+| `root` | 31% |
+| `core` | 84% |
+| `mcp` | 84% |
+| `pb` | 5% |
+| `sdks-go` | 37% |
+| `server` | 52% |
+
+The authoritative values live in the `floors=` line of the `Enforce coverage floors`
+step in [`.github/workflows/go.yml`](.github/workflows/go.yml); this table must be kept
+in sync with it. To reproduce a module's number locally:
+
+```bash
+(cd <module> && go test -covermode=atomic -coverprofile=/tmp/cov.out ./...)
+go tool cover -func=/tmp/cov.out | tail -1   # the `total:` line
+```
+
+If a PR legitimately lowers a floor (e.g. deleting a well-covered package), say so in
+the PR body and update both the workflow and this table together.
+
 ## Before merging a PR
 
 - Wait for **all required checks** green. Never use `--admin` or `--no-verify`. One PR


### PR DESCRIPTION
Closes #717. Part of #713.

## What

Adds an **Enforce coverage floors** step to the `Build & Test` job. It fails the build when any module's coverage drops below a **ratchet floor** set just below that module's current measured baseline, so coverage can only hold or climb.

## Why per-module (not the merged total)

Module totals vary widely — measured on `main`:

| slug | baseline | floor |
| --- | --- | --- |
| `root` | 32.1% | 31% |
| `core` | 84.8% | 84% |
| `mcp` | 84.7% | 84% |
| `pb` | 5.5% | 5% |
| `sdks-go` | 37.9% | 37% |
| `server` | 52.8% | 52% |

Generated `pb` and the CLI sit far below `core`/`mcp`, so a single merged floor (≈49%) would let a regression in a well-tested module hide behind the large low-coverage denominator. Per-module floors keep each area honest, and reuse the per-module `.out` profiles the test step already writes.

## Open questions from the issue, resolved

- **Single vs per-module floor** → per-module (variance is wide: 5.5%–84.8%).
- **Tool** → `go tool cover -func` + a tiny shell loop. No new dependency / action.
- **Total % vs per-PR delta** → total-% floor only (a delta gate needs base-branch comparison and is flakier); the ratchet covers regressions.

## Notes

- Floors are ~1% below baseline; coverage was identical across `-race -shuffle=on` and plain runs, so jitter headroom is small by design.
- The coverage-artifact upload is now `if: always()` so it survives a failing gate (primary debugging aid).
- Documented in `CONTRIBUTING.md` → **Coverage floor (ratchet)**, including how to reproduce a module's number and the rule to raise the floor in the same PR when coverage rises.

## Validation

Ran the exact gate logic under `bash` against the real per-module profiles: baseline → all six `ok`, `GATE: PASS` (rc 0); forced `server:99` → `GATE: FAIL` (rc 1). `gofmt -l .` clean; no Go code touched.