### PR TITLE
chore(release): bump core pin to v0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.4.0
-	github.com/anaregdesign/lantern/core v0.8.0
+	github.com/anaregdesign/lantern/core v0.9.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.8.0
 	github.com/anaregdesign/lantern/sdks/go v0.17.0


### PR DESCRIPTION
Release step 4 for cutting the next root release: bump the root module's `core`
pin from `v0.8.0` to the freshly-tagged [`core/v0.9.0`](https://github.com/anaregdesign/lantern/releases/tag/core/v0.9.0)
before the root `vX.Y.Z` tag.

`core/v0.9.0` bundles the search/prefix + HLC work (#709), the multi-writer Put
convergence fix (#720, fixes #719), and the born-expired vertex fix (#699).

One-line `go.mod` change; the `replace => ./core` directive is unchanged, so the
in-tree build is unaffected. Follows the `chore(release): bump module pins`
precedent (#697, #668). Part of the release wrap-up for epic #713.
