### PR TITLE
ci: stop double-fuzzing nested-module targets

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -227,10 +227,22 @@ jobs:
           set -e
           for mod in . core mcp pb sdks/go server; do
             (cd "$mod"
+             # `go list ./...` is module-scoped: it never descends into a nested
+             # module (core/, mcp/, pb/, sdks/go/, server/ each carry their own
+             # go.mod), so it is the authority on which packages belong to THIS
+             # module. The filesystem grep below happily recurses into sibling
+             # modules; without filtering through `own`, the root (.) iteration
+             # would resolve their fuzz targets via the active workspace and fuzz
+             # pb/graph/v1, sdks/go and server/service a SECOND time -- ~2x runner
+             # load that flaked the 20s-per-target budget (#725).
+             own=$(go list ./... 2>/dev/null)
              dirs=$(grep -rl --include='*_test.go' --exclude-dir=node_modules -e 'func Fuzz' . 2>/dev/null \
                | xargs -r -n1 dirname | sort -u)
              for d in $dirs; do
                pkg=$(go list "$d" 2>/dev/null) || continue
+               # Skip targets owned by a nested module; they fuzz in their own
+               # iteration. Keeps every target to exactly one run (#725).
+               printf '%s\n' "$own" | grep -qxF "$pkg" || continue
                for t in $(go test -list='^Fuzz' "$pkg" 2>/dev/null | grep '^Fuzz' || true); do
                  echo "::group::fuzz ${pkg} ${t}"
                  go test -run='^$' -fuzz="^${t}$" -fuzztime=20s "$pkg"


### PR DESCRIPTION
## Summary

The `Fuzz (smoke)` job (added in #714) fuzzes three targets twice per run,
doubling the heaviest part of the job and intermittently tripping the
20s-per-target budget with `context deadline exceeded` (seen on #724;
`--failed` re-runs go green — an engine-level timeout flake, not a crash).

## Root cause

The per-module loop runs over `. core mcp pb sdks/go server`. For the `mod="."`
iteration, target discovery uses a filesystem-recursive grep:

```
grep -rl --include='*_test.go' --exclude-dir=node_modules -e 'func Fuzz' .
```

`grep -rl` crosses Go module boundaries, so from the repo root it also finds
`./pb/graph/v1`, `./sdks/go`, and `./server/service` (separate modules). With
the workspace active, `go list` resolves those dirs to real package paths, so
the `.` iteration fuzzes them — and the dedicated `pb` / `sdks/go` / `server`
iterations fuzz them again.

## Fix

Filter grep-discovered packages through the module-scoped `go list ./...` set
(which never descends into nested modules), so each target runs exactly once in
its owning module. `cli/cmd` and `cli/parser` are genuinely root-module and
keep fuzzing in the `.` iteration.

## Verification (local, under bash — the CI `run:` shell)

```
FUZZ [.] .../cli/cmd FuzzBulkVertexLine
FUZZ [.] .../cli/cmd FuzzBulkEdgeLine
FUZZ [.] .../cli/parser FuzzValidate
SKIP(nested) [.] .../pb/graph/v1
SKIP(nested) [.] .../sdks/go
SKIP(nested) [.] .../server/service
FUZZ [pb] .../pb/graph/v1 FuzzVertexUnmarshal
FUZZ [pb] .../pb/graph/v1 FuzzEdgeUnmarshal
FUZZ [pb] .../pb/graph/v1 FuzzIlluminateRequestUnmarshal
FUZZ [sdks/go] .../sdks/go FuzzUnmarshalVertexJSON
FUZZ [server] .../server/service FuzzContribIDFromBytes
FUZZ [server] .../server/service FuzzDecodeCursor
FUZZ [server] .../server/service FuzzCursorRoundTrip
```

Each target runs exactly once; the three nested packages are now `SKIP(nested)`
at root. This removes the 7 duplicate target runs (was 17, now 10).

Closes #725
