### PR TITLE
chore(release): bump core module pin to v0.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.4.0
-	github.com/anaregdesign/lantern/core v0.9.0
+	github.com/anaregdesign/lantern/core v0.10.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.8.0
 	github.com/anaregdesign/lantern/sdks/go v0.17.0


### PR DESCRIPTION
Points the root module's `require` at the freshly tagged `core/v0.10.0` (the `vertexHLC` bucket-array reallocation fix for #727 + the `VertexHLCHighWater()` accessor for #729).

The local `replace => ./core` keeps workspace builds on the in-tree copy; this updates the recorded require so the upcoming `v0.20.0` root release pins the right core version. Mechanical bump, no code change.

Follows the established release cadence (cf. #726, #697).