### PR TITLE
fix(server): stamp contribIDs on local edge writes so snapshot re-apply is idempotent

### DIFF
--- a/server/service/service.go
+++ b/server/service/service.go
@@ -344,9 +344,9 @@ func (s *LanternService) logMutation(op *pb.MutationOp) {
 // let a concurrent write slip between the two and resolve LWW one way on the
 // origin and the other way on its peers. Returns immediately when the log is
 // not wired (test path); callers may pass a zero ts in that case.
-func (s *LanternService) logMutationAt(op *pb.MutationOp, ts hlc.Timestamp) {
+func (s *LanternService) logMutationAt(op *pb.MutationOp, ts hlc.Timestamp) uint64 {
 	if s.log == nil || s.clock == nil {
-		return
+		return 0
 	}
 	mu := &pb.Mutation{
 		Hlc: &pb.HLCTimestamp{
@@ -374,7 +374,7 @@ func (s *LanternService) logMutationAt(op *pb.MutationOp, ts hlc.Timestamp) {
 			l = slog.Default()
 		}
 		l.Warn("mutation log append failed", slog.Any("err", err))
-		return
+		return 0
 	}
 	if s.origins != nil {
 		s.origins.Record(ts.NodeID, entry.Seq, ts)
@@ -382,6 +382,7 @@ func (s *LanternService) logMutationAt(op *pb.MutationOp, ts hlc.Timestamp) {
 	if s.onAppend != nil {
 		s.onAppend()
 	}
+	return entry.Seq
 }
 
 // Illuminate returns a subgraph rooted at the seed, optionally reduced via
@@ -696,9 +697,24 @@ func (s *LanternService) AddEdges(ctx context.Context, request *pb.AddEdgesReque
 	var deduped int
 	if s.clock != nil {
 		ts := s.clock.Now()
+		// Log FIRST so the per-origin seq this mutation commits under is
+		// known, then synthesize a (origin, seq, idx) ContribID for every
+		// edge the client left unkeyed BEFORE applying it locally. This
+		// makes the origin's own graphcache carry the SAME ContribID a peer
+		// synthesizes in ApplyMutation (contribIDFor), so the contribution
+		// is a G-Set element (§4/§6 of docs/replication.md) on every
+		// replica. Without it the origin stores a zero ContribID, Snapshot
+		// emits it verbatim, and a re-pulled snapshot re-adds it additively
+		// — doubling edge weight without bound on a gapped follower (#733).
+		// Mirrors the once-sampled HLC discipline PutVertices uses for LWW.
+		seq := s.logMutationAt(&pb.MutationOp{Op: &pb.MutationOp_AddEdges{AddEdges: request}}, ts)
+		for i := range items {
+			if items[i].ContribID.IsZero() {
+				items[i].ContribID = contribIDFor(s.origin, seq, uint16(i))
+			}
+		}
 		deduped = s.cache.AddEdgesWithExpirationContribHLC(items, ts)
 		s.metrics.OnEdgeContribDeduped(deduped)
-		s.logMutationAt(&pb.MutationOp{Op: &pb.MutationOp_AddEdges{AddEdges: request}}, ts)
 	} else {
 		deduped = s.cache.AddEdgesWithExpirationContrib(items)
 		s.metrics.OnEdgeContribDeduped(deduped)

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -232,6 +232,61 @@ func TestLanternService_AddEdges_ContribIDWiring(t *testing.T) {
 	})
 }
 
+// TestLanternService_LocalAddEdges_StampsSnapshotContribID is the #733
+// regression. A locally-originated AddEdges that carries no wire
+// contrib_ids (the ghz bench, and any client predating the optional #588
+// plumbing) must stamp the SAME synthesized (origin, seq, idx) ContribID
+// into the backend that a peer derives in ApplyMutation, so a re-pulled
+// snapshot frame is a G-Set no-op (docs/replication.md §4/§6) instead of
+// doubling edge weight without bound. Before the fix the origin stored a
+// zero ContribID, Snapshot emitted it verbatim, and a gapped follower
+// re-applying the snapshot double-counted every edge on each reconnect.
+func TestLanternService_LocalAddEdges_StampsSnapshotContribID(t *testing.T) {
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+	log := mutationlog.New(mutationlog.Options{Capacity: 128, SubscriberBuffer: 128})
+	t.Cleanup(func() { _ = log.Close() })
+	origin := bytes16("origin-A")
+	clock := hlc.New(origin, hlc.Options{})
+	s := NewLanternService(cache).WithReplication(log, clock, nil)
+	ctx := context.Background()
+
+	if _, err := s.AddEdges(ctx, &pb.AddEdgesRequest{
+		Edges: []*pb.Edge{{Tail: "a", Head: "b", Weight: 2, Expiration: futureTs(time.Minute)}},
+		// no contrib_ids on the wire (ghz bench / optional #588 path)
+	}); err != nil {
+		t.Fatalf("AddEdges: %v", err)
+	}
+
+	// The single logged mutation commits under seq 1 on a fresh log, so the
+	// origin's own graphcache must carry contribIDFor(origin, 1, 0): the
+	// exact id ApplyMutation synthesizes for the same frame on a peer.
+	want := contribIDFor(origin[:], 1, 0)
+	edges := cache.SnapshotEdges()
+	if len(edges) != 1 {
+		t.Fatalf("snapshot edges = %d, want 1", len(edges))
+	}
+	contribs := edges[0].Contributions
+	if len(contribs) != 1 {
+		t.Fatalf("snapshot contributions = %d, want 1", len(contribs))
+	}
+	if got := contribs[0].ContribID; got.IsZero() || got != want {
+		t.Fatalf("snapshot contribID = %x, want %x (synthesized, non-zero)", got, want)
+	}
+
+	// Re-applying that snapshot contribution — the pump / anti-entropy
+	// bootstrap path — must dedup on the matching non-zero ContribID, so
+	// AddEdgeWithExpirationContribHLC reports applied=false and the stored
+	// weight stays at 2 instead of doubling (the exact #733 leak).
+	re := edges[0]
+	c := contribs[0]
+	if cache.AddEdgeWithExpirationContribHLC(re.Tail, re.Head, c.Weight, c.Expiration, c.ContribID, re.HLC) {
+		t.Errorf("re-apply of snapshot contribution was additive; want dedup no-op (#733)")
+	}
+	if w, ok := cache.GetWeight("a", "b"); !ok || w != 2 {
+		t.Fatalf("weight after snapshot re-apply = %v ok=%v, want 2 true (dedup, not double)", w, ok)
+	}
+}
+
 func TestLanternService_PutEdge_Replaces(t *testing.T) {
 	// PutEdge deletes-then-adds: repeated calls with the same weight stay at that weight.
 	s := newTestService(t)


### PR DESCRIPTION
## Problem

The `ttl_churn` release-time benchmark leaks ~1.3 GiB of heap on linux/amd64 (the leak gate fails CI; arm64 local runs pass, so it is platform-bound). A pprof diff across all three replicas pinned the growth flat in `core/graphcache.(*weight).addWithExpirationContrib` — a few giant `w.values` slices, `inuse_objects` negative.

### Mechanism

`ttl_churn` floods the origin with `PutVertex` at rps4000, overrunning the mutation-log ring. Followers' `Subscribe` then returns `CodeFailedPrecondition` ("gapped"), so the peer loop falls back to a **full snapshot** and re-applies every edge frame. The live `broad_*` edges (shared Compose stack) are the fuel; `ttl_churn` is the trigger.

### Root cause

`ApplyMutation` (remote apply) already synthesizes `contribIDFor(origin, seq, idx)` for a zero-`contrib_id` `AddEdges`. The **local** `AddEdges` handler did not — it stored a zero `ContribID` (client `contrib_ids` are optional, #588; the ghz bench sends none). So:

1. Origin's graphcache holds a zero `ContribID`.
2. `Snapshot` emits it verbatim (nil bytes on the wire).
3. A gapped follower re-applies the snapshot edge **additively** — `weight.addWithExpirationContrib` only dedups on a **non-zero** `ContribID`.
4. Every reconnect doubles the edge weight without bound.

This violates docs/replication.md section 6: *"Every locally-originated mutation gets a contribution ID."*

## Fix

Bring the local `AddEdges` path to parity with `ApplyMutation`, mirroring the once-sampled HLC discipline `PutVertices` already uses for LWW:

1. **Log first** so the per-origin `seq` this mutation commits under is known (`logMutationAt` now returns the seq).
2. **Synthesize** `contribIDFor(s.origin, seq, idx)` for every edge the client left unkeyed.
3. **Apply** locally.

The origin now carries the **same** `ContribID` a peer derives in `ApplyMutation`, so the contribution is a G-Set element (docs/replication.md sections 4 and 6) on every replica and re-snapshot is an idempotent set-insert no-op. The snapshot apply path (pump / anti-entropy) is unchanged.

## Regression test

`TestLanternService_LocalAddEdges_StampsSnapshotContribID` asserts that a local `AddEdges` with no wire `contrib_ids`:

- stamps `contribIDFor(origin, 1, 0)` into the backend snapshot (non-zero, matching the peer-synthesized id), and
- re-applying that snapshot contribution dedups (`applied=false`) instead of doubling the weight.

Verified it **fails without the fix** (stored `contribID` is all-zero) and passes with it.

## Out of scope

`PutEdge`/`PutEdges` go through `weight.putWithExpirationHLC`, which also stores a zero `ContribID`, so they share the same snapshot double-count vulnerability. The `broad_*` bench scenarios use `AddEdge`, not `PutEdge`, so it does not manifest in this benchmark; tracked as a follow-up.

Closes #733