### PR TITLE
fix(replication): re-apply LWW (zero-cid) snapshot edges via Put to keep snapshots idempotent

### DIFF
--- a/server/replication/antientropy.go
+++ b/server/replication/antientropy.go
@@ -37,6 +37,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
@@ -383,10 +384,10 @@ func (a *AntiEntropy) snapshotFrom(ctx context.Context, cli graphv1connect.Lante
 			se := e.Edge
 			edgeHLC := snapshotHLC(se.GetHlc())
 			for _, c := range se.GetContributions() {
-				var cid [24]byte
+				var cid graphcache.ContribID
 				copy(cid[:], c.GetContribId())
-				a.snap.AddEdgeWithExpirationContribHLC(
-					se.GetTail(), se.GetHead(), c.GetWeight(),
+				applySnapshotEdge(
+					a.snap, se.GetTail(), se.GetHead(), c.GetWeight(),
 					c.GetExpiration().AsTime(), cid, edgeHLC,
 				)
 			}

--- a/server/replication/pump.go
+++ b/server/replication/pump.go
@@ -62,6 +62,25 @@ type MutationApplier interface {
 type SnapshotApplier interface {
 	PutVertexWithExpirationHLC(key string, value *pb.Vertex, exp time.Time, ts hlc.Timestamp) bool
 	AddEdgeWithExpirationContribHLC(tail, head string, w float32, exp time.Time, cid graphcache.ContribID, ts hlc.Timestamp) bool
+	PutEdgeWithExpirationHLC(tail, head string, w float32, exp time.Time, ts hlc.Timestamp) bool
+}
+
+// applySnapshotEdge re-applies one snapshot edge contribution into the local
+// cache via snap. A Put-origin (LWW-Register) contribution carries a zero
+// ContribID: re-applying it through AddEdgeWithExpirationContribHLC hits the
+// dedup-disabled branch of addWithExpirationContrib (a zero cid disables dedup)
+// and G-Set-APPENDs a fresh weight value on every snapshot pass, so a node that
+// keeps re-snapshotting — e.g. anti-entropy re-syncs under sustained write load
+// — accumulates unbounded duplicate contributions and leaks heap (#735). Routing
+// zero-cid contributions through the LWW PutEdgeWithExpirationHLC makes the
+// re-apply an idempotent overwrite; non-zero (AddEdge-origin) contributions keep
+// their ContribID and the dedup-aware AddEdge path.
+func applySnapshotEdge(snap SnapshotApplier, tail, head string, weight float32, exp time.Time, cid graphcache.ContribID, ts hlc.Timestamp) {
+	if cid.IsZero() {
+		snap.PutEdgeWithExpirationHLC(tail, head, weight, exp, ts)
+		return
+	}
+	snap.AddEdgeWithExpirationContribHLC(tail, head, weight, exp, cid, ts)
 }
 
 // Metrics is the narrow surface the pump uses to publish per-peer
@@ -468,8 +487,8 @@ func (p *Pump) snapshot(ctx context.Context, cli graphv1connect.LanternReplicati
 			for _, c := range se.GetContributions() {
 				var cid graphcache.ContribID
 				copy(cid[:], c.GetContribId())
-				p.snap.AddEdgeWithExpirationContribHLC(
-					se.GetTail(), se.GetHead(), c.GetWeight(),
+				applySnapshotEdge(
+					p.snap, se.GetTail(), se.GetHead(), c.GetWeight(),
 					c.GetExpiration().AsTime(), cid, edgeHLC,
 				)
 			}

--- a/server/replication/pump_test.go
+++ b/server/replication/pump_test.go
@@ -1,0 +1,121 @@
+package replication
+
+import (
+	"testing"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/graphcache"
+	"github.com/anaregdesign/lantern/core/hlc"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+)
+
+// recordingApplier records which SnapshotApplier seam each snapshot edge
+// re-apply routed to, so applySnapshotEdge's LWW-vs-G-Set routing can be
+// asserted in isolation.
+type recordingApplier struct {
+	putEdges []recordedEdge
+	addEdges []recordedEdge
+}
+
+type recordedEdge struct {
+	tail, head string
+	cid        graphcache.ContribID
+}
+
+func (r *recordingApplier) PutVertexWithExpirationHLC(string, *pb.Vertex, time.Time, hlc.Timestamp) bool {
+	return true
+}
+
+func (r *recordingApplier) AddEdgeWithExpirationContribHLC(tail, head string, _ float32, _ time.Time, cid graphcache.ContribID, _ hlc.Timestamp) bool {
+	r.addEdges = append(r.addEdges, recordedEdge{tail: tail, head: head, cid: cid})
+	return true
+}
+
+func (r *recordingApplier) PutEdgeWithExpirationHLC(tail, head string, _ float32, _ time.Time, _ hlc.Timestamp) bool {
+	r.putEdges = append(r.putEdges, recordedEdge{tail: tail, head: head})
+	return true
+}
+
+// TestApplySnapshotEdge pins the #735 fix: a Put-origin (LWW, zero ContribID)
+// snapshot edge must be re-applied via PutEdgeWithExpirationHLC (idempotent
+// overwrite), NOT AddEdgeWithExpirationContribHLC (which G-Set-appends and, for
+// a zero cid, skips dedup — accumulating a fresh contribution on every repeated
+// snapshot / anti-entropy re-sync and leaking heap). AddEdge-origin edges
+// (non-zero ContribID) must keep the dedup-aware AddEdge path.
+func TestApplySnapshotEdge(t *testing.T) {
+	now := time.Now().Add(time.Hour)
+	var ts hlc.Timestamp
+
+	t.Run("zero contribID routes to Put across repeated re-applies", func(t *testing.T) {
+		r := &recordingApplier{}
+		var zero graphcache.ContribID
+		// Re-apply the SAME zero-cid edge three times, simulating repeated
+		// full snapshots (the anti-entropy storm in #735). Every pass must
+		// route to PutEdge so the edge is overwritten, never appended.
+		for i := 0; i < 3; i++ {
+			applySnapshotEdge(r, "a", "b", 1.5, now, zero, ts)
+		}
+		if len(r.addEdges) != 0 {
+			t.Fatalf("zero-cid edge routed to AddEdge %d time(s); want 0 (must use Put to stay idempotent)", len(r.addEdges))
+		}
+		if len(r.putEdges) != 3 {
+			t.Fatalf("zero-cid edge routed to Put %d time(s); want 3", len(r.putEdges))
+		}
+	})
+
+	t.Run("non-zero contribID routes to AddEdge", func(t *testing.T) {
+		r := &recordingApplier{}
+		var cid graphcache.ContribID
+		cid[0] = 0x01 // non-zero origin byte => G-Set (AddEdge) contribution
+		applySnapshotEdge(r, "a", "b", 1.5, now, cid, ts)
+		if len(r.putEdges) != 0 {
+			t.Fatalf("non-zero-cid edge routed to Put %d time(s); want 0", len(r.putEdges))
+		}
+		if len(r.addEdges) != 1 {
+			t.Fatalf("non-zero-cid edge routed to AddEdge %d time(s); want 1", len(r.addEdges))
+		}
+		if r.addEdges[0].cid != cid {
+			t.Fatalf("AddEdge got cid %v; want %v", r.addEdges[0].cid, cid)
+		}
+	})
+}
+
+// TestApplySnapshotEdgeIdempotent is the end-to-end #735 regression against a
+// real GraphCache: replaying the SAME zero-cid (LWW/Put-origin) snapshot edge
+// many times must NOT accumulate weight. Before the fix, applySnapshotEdge
+// routed through AddEdgeWithExpirationContribHLC, whose zero-cid path skips
+// dedup and G-Set-appends a fresh contribution on every pass, so the edge
+// weight grew without bound on each repeated snapshot / anti-entropy re-sync.
+func TestApplySnapshotEdgeIdempotent(t *testing.T) {
+	c := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+	exp := time.Now().Add(time.Minute)
+
+	t.Run("zero-cid edge does not accumulate across repeated snapshots", func(t *testing.T) {
+		var zero graphcache.ContribID
+		for i := 0; i < 5; i++ {
+			applySnapshotEdge(c, "a", "b", 2.5, exp, zero, hlc.Timestamp{})
+		}
+		got, ok := c.GetWeight("a", "b")
+		if !ok {
+			t.Fatalf("edge a->b missing after re-applies")
+		}
+		if got != 2.5 {
+			t.Fatalf("edge weight = %v after 5 zero-cid re-applies; want 2.5 (LWW overwrite, no accumulation)", got)
+		}
+	})
+
+	t.Run("non-zero-cid edge dedups on ContribID", func(t *testing.T) {
+		var cid graphcache.ContribID
+		cid[0] = 0x07
+		for i := 0; i < 5; i++ {
+			applySnapshotEdge(c, "x", "y", 3.0, exp, cid, hlc.Timestamp{})
+		}
+		got, ok := c.GetWeight("x", "y")
+		if !ok {
+			t.Fatalf("edge x->y missing after re-applies")
+		}
+		if got != 3.0 {
+			t.Fatalf("edge weight = %v after 5 same-cid re-applies; want 3.0 (G-Set dedup)", got)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

The amd64 `bench-nightly` leak gate FAILS on `ttl_churn` even after #734
(`cec0115`). Per the fix-after pprof (run `27833771394`, diffed against the
fix-before run `27827916084`), `weight.addWithExpirationContrib` reached via
`Pump.snapshot → AddEdgeWithExpirationContribHLC` is STILL the dominant retained
allocation across all three replicas (892 MiB / 1.06 GiB / 636 MiB, ~97-98% of
the post-snapshot heap). This refutes #735 Hypothesis 1 (a different, smaller
structure): the edge-weight leak persists.

## Root cause

#734 stamped contribIDs on **AddEdge** local writes, but `PutEdge` / `PutEdges`
are **LWW-Register** writes that never carry a ContribID — they go through
`putWithExpirationHLC`, which records a single overwriting contribution with a
**zero** ContribID.

Both snapshot re-apply sites — `Pump.snapshot` and `AntiEntropy.snapshotFrom` —
replayed EVERY snapshot edge contribution through
`AddEdgeWithExpirationContribHLC`. For a zero-cid (LWW) contribution,
`addWithExpirationContrib` takes its `if !contribID.IsZero()` == false branch,
**skips dedup and unconditionally G-Set-appends** a fresh `weightValue`. A node
that keeps re-snapshotting (the anti-entropy storm that `ttl_churn`'s
born-expired PutVertex flood induces by gapping followers) re-appends the same
`broad_mutate` PutEdge edges on every pass → unbounded heap growth.

`ttl_churn` itself makes no edges; the leaking edges are `broad_mutate` residue
re-applied during its snapshot churn, which is why its tight 16 MiB gate trips
where `broad_*`'s looser gates hide it.

## Fix

Route zero-cid (LWW / Put-origin) snapshot contributions through
`PutEdgeWithExpirationHLC` (idempotent LWW overwrite via `putWithExpirationHLC`,
which clears `values` and appends a single contribution) instead of
`AddEdgeWithExpirationContribHLC`. Non-zero-cid (G-Set / AddEdge-origin)
contributions keep the dedup-aware AddEdge path. A shared `applySnapshotEdge`
helper is called from both `Pump.snapshot` and `AntiEntropy.snapshotFrom`, and
`PutEdgeWithExpirationHLC` is added to the `SnapshotApplier` interface
(`GraphCache` already implements it; the normal `apply.go` PutEdge mutation path
already used it, so only snapshot re-apply was leaking).

## Tests

`server/replication/pump_test.go`:

- `TestApplySnapshotEdge` — routing: zero-cid → Put (across repeated re-applies),
  non-zero-cid → AddEdge.
- `TestApplySnapshotEdgeIdempotent` — end-to-end against a real `GraphCache`:
  re-applying the same zero-cid edge 5× keeps its weight at `2.5` (no
  accumulation); a same-cid edge dedups to `3.0`.

Mutation-checked: with the fix reverted, `TestApplySnapshotEdgeIdempotent`
reports `edge weight = 12.5 after 5 zero-cid re-applies` (2.5 × 5), reproducing
the leak exactly.

Local gate: `gofmt -l` clean; `go test ./...` passes from root and every
submodule.

Closes #735
