### PR TITLE
perf(graphcache): make point reads lock-free (#740)

### DIFF
--- a/core/graphcache/bench_test.go
+++ b/core/graphcache/bench_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -166,6 +167,78 @@ func BenchmarkGraphCacheGetWeight(b *testing.B) {
 				head := keys[(i+1)%s.vertices]
 				_, _ = c.GetWeight(tail, head)
 			}
+		})
+	}
+}
+
+// BenchmarkGetVertex_Contended measures the GetVertex point read while a
+// background writer churns unrelated keys. Before #740 the read serialized
+// behind the writer on GraphCache.mu; afterwards it only contends on the inner
+// vertex-cache lock. Run before/after to capture the contention win.
+func BenchmarkGetVertex_Contended(b *testing.B) {
+	for _, s := range smallScales(testing.Short()) {
+		s := s
+		b.Run(s.name, func(b *testing.B) {
+			c := NewGraphCache[string, string](time.Hour)
+			keys := populate(b, c, s)
+			exp := time.Now().Add(time.Hour)
+			var stop atomic.Bool
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				i := 0
+				for !stop.Load() {
+					// Write churn on a disjoint key namespace so reads always hit.
+					wk := makeKey("writer", i%s.vertices, s.keyLen)
+					c.PutVertexWithExpiration(wk, "", exp)
+					c.DeleteVertex(wk)
+					i++
+				}
+			}()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = c.GetVertex(keys[i%s.vertices])
+			}
+			b.StopTimer()
+			stop.Store(true)
+			<-done
+		})
+	}
+}
+
+// BenchmarkGetEdgeDetail_Contended measures the GetEdgeDetail point read on a
+// hot existing edge while a background writer adds unrelated edges. It captures
+// the #740 win of dropping GraphCache.mu from edge point reads (pinBoth closes
+// the dictionary ABA hazard instead).
+func BenchmarkGetEdgeDetail_Contended(b *testing.B) {
+	for _, s := range smallScales(testing.Short()) {
+		s := s
+		b.Run(s.name, func(b *testing.B) {
+			c := NewGraphCache[string, string](time.Hour)
+			keys := populate(b, c, s)
+			exp := time.Now().Add(time.Hour)
+			var stop atomic.Bool
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				i := 0
+				for !stop.Load() {
+					tail := keys[i%s.vertices]
+					head := keys[(i+2)%s.vertices]
+					c.AddEdgeWithExpiration(tail, head, 1, exp)
+					i++
+				}
+			}()
+			hotTail, hotHead := keys[0], keys[1%s.vertices]
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _, _ = c.GetEdgeDetail(hotTail, hotHead)
+			}
+			b.StopTimer()
+			stop.Store(true)
+			<-done
 		})
 	}
 }

--- a/core/graphcache/cache.go
+++ b/core/graphcache/cache.go
@@ -201,27 +201,35 @@ func (c *GraphCache[S, T]) ensureVertexLocked(key S, expiration time.Time) {
 	c.onEndpointVertexCreatedLocked(key)
 }
 
+// GetVertex returns the live value stored for key. It is a point read that
+// does not take GraphCache.mu: the inner vertex cache has its own RWMutex and
+// hides expired entries, so a point lookup needs no aggregate-lock
+// consistency with the prefix/search/edge indexes. Dropping c.mu here keeps
+// hot reads from serializing behind unrelated writes, long scans, and GC
+// (#740). A read may race a concurrent Put/Delete on the same key and observe
+// either the pre- or post-write state, which is the existing point-read
+// contract.
 func (c *GraphCache[S, T]) GetVertex(key S) (T, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
 	return c.vertices.Get(key)
 }
 
+// GetWeight returns the additive weight of the (tail, head) edge. Like
+// GetVertex it is a lock-free point read: edges.get pins both endpoint ids
+// (closing the dictionary ABA hazard) and reads the edge map under the
+// edgeCache's own lock, so GraphCache.mu is not required (#740).
 func (c *GraphCache[S, T]) GetWeight(tail, head S) (float32, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
 	return c.edges.get(tail, head)
 }
 
 // GetEdgeDetail returns the current edge weight together with the latest
 // contribution expiration. The expiration is the moment after which the edge
 // is guaranteed to have decayed to zero. When no edge exists, ok is false.
+//
+// Like GetWeight it is a lock-free point read (see edges.getDetail): it does
+// not take GraphCache.mu and may observe either the pre- or post-write state
+// under a concurrent edge mutation, but it never resolves a recycled endpoint
+// id to an unrelated edge.
 func (c *GraphCache[S, T]) GetEdgeDetail(tail, head S) (float32, time.Time, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
 	return c.edges.getDetail(tail, head)
 }
 

--- a/core/graphcache/cache_test.go
+++ b/core/graphcache/cache_test.go
@@ -620,6 +620,131 @@ func TestGraphCache_DeleteVertex(t *testing.T) {
 	}
 }
 
+func TestGraphCache_PointReadsLockFree(t *testing.T) {
+	// GetVertex / GetWeight / GetEdgeDetail are lock-free point reads as of
+	// #740: they no longer take GraphCache.mu. These stress tests must be run
+	// under -race (the package suite is) to prove the lock removal is safe.
+
+	t.Run("GetVertex under concurrent Put/Delete/Flush returns only live values", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		const keys = 32
+		key := func(i int) string { return fmt.Sprintf("k-%d", i) }
+		// Invariant under test: a vertex's value, when present, always equals
+		// its key. A reader that observes any other (e.g. torn) value would
+		// indicate a data race the race detector might miss.
+		for i := 0; i < keys; i++ {
+			c.PutVertex(key(i), key(i))
+		}
+
+		var stop atomic.Bool
+		var wg sync.WaitGroup
+
+		writer := func(seed int) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(int64(seed)))
+			for !stop.Load() {
+				i := rng.Intn(keys)
+				switch rng.Intn(3) {
+				case 0:
+					c.PutVertex(key(i), key(i))
+				case 1:
+					c.DeleteVertex(key(i))
+				default:
+					c.PutVertexWithTTL(key(i), key(i), time.Nanosecond) // born-expired churn
+				}
+			}
+		}
+		flusher := func() {
+			defer wg.Done()
+			for !stop.Load() {
+				c.vertices.Flush()
+				c.flush()
+			}
+		}
+		reader := func() {
+			defer wg.Done()
+			for !stop.Load() {
+				for i := 0; i < keys; i++ {
+					if v, ok := c.GetVertex(key(i)); ok && v != key(i) {
+						t.Errorf("GetVertex(%s) returned stale/torn value %q", key(i), v)
+						return
+					}
+				}
+			}
+		}
+
+		for w := 0; w < 4; w++ {
+			wg.Add(1)
+			go writer(w + 1)
+		}
+		wg.Add(1)
+		go flusher()
+		for r := 0; r < 4; r++ {
+			wg.Add(1)
+			go reader()
+		}
+		time.Sleep(150 * time.Millisecond)
+		stop.Store(true)
+		wg.Wait()
+	})
+
+	t.Run("edge point read never resolves a recycled endpoint id to a foreign edge", func(t *testing.T) {
+		// ABA hazard (#740): GetEdgeDetail resolves (tail,head) to dict ids,
+		// then reads the edge map. If a concurrent delete frees an endpoint id
+		// and a decoy edge recycles it, an unpinned read could surface the
+		// decoy's weight under the real edge's key. pinBoth must prevent that.
+		c := NewGraphCache[string, int](time.Minute)
+		const realWeight = 1
+		const decoyWeight = 99
+		exp := time.Now().Add(time.Hour)
+		c.AddEdgeWithExpiration("T", "H", realWeight, exp)
+
+		var stop atomic.Bool
+		var wg sync.WaitGroup
+
+		// Churner: repeatedly delete T/H and their edge (freeing their dict
+		// ids), create decoy vertices+edges (weight 99) to recycle the freed
+		// ids, then restore the real T->H edge.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			i := 0
+			for !stop.Load() {
+				c.DeleteEdge("T", "H")
+				c.DeleteVertex("T")
+				c.DeleteVertex("H")
+				d1 := fmt.Sprintf("decoy-a-%d", i)
+				d2 := fmt.Sprintf("decoy-b-%d", i)
+				c.AddEdgeWithExpiration(d1, d2, decoyWeight, exp)
+				c.DeleteEdge(d1, d2)
+				c.DeleteVertex(d1)
+				c.DeleteVertex(d2)
+				c.AddEdgeWithExpiration("T", "H", realWeight, exp)
+				i++
+			}
+		}()
+
+		// Readers: a successful read of (T,H) must never report the decoy
+		// weight. Either the real weight or not-found is acceptable.
+		for r := 0; r < 4; r++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for !stop.Load() {
+					if w, _, ok := c.GetEdgeDetail("T", "H"); ok && w == decoyWeight {
+						t.Errorf("GetEdgeDetail(T,H) returned decoy weight %v from a recycled id", w)
+						return
+					}
+				}
+			}()
+		}
+
+		time.Sleep(200 * time.Millisecond)
+		stop.Store(true)
+		wg.Wait()
+	})
+}
+
 func TestGraphCache_DeleteEdge(t *testing.T) {
 	g := NewGraphCache[string, string](time.Minute)
 	g.AddEdgeWithTTL("a", "b", 3.14, 60*time.Second)

--- a/core/graphcache/dict.go
+++ b/core/graphcache/dict.go
@@ -114,6 +114,38 @@ func (d *dictionary[S]) lookupBoth(a, b S) (idA, idB vertexID, okA, okB bool) {
 	return
 }
 
+// pinBoth resolves both keys to vertexIDs and increments their refcounts
+// under a single write-lock cycle, returning a release func that drops the
+// two references again. While the pin is held the ids cannot reach refcount
+// zero, so they can neither be freed nor recycled to a different key — which
+// is exactly the ABA guarantee a lock-free point read needs: a reader that
+// pins (tail, head) before consulting the edge map cannot have its endpoint
+// ids reused out from under it between resolution and the bucket lookup.
+//
+// Returns ok=false (with a no-op release) when either key is absent, so the
+// caller can treat "endpoint unknown" identically to lookupBoth. release is
+// always non-nil and safe to call exactly once; it is idempotent only via the
+// caller's own discipline (call it once), mirroring release's contract.
+//
+// A self-pin (a == b) bumps the single shared id twice and the release drops
+// it twice, preserving the refcount invariant.
+func (d *dictionary[S]) pinBoth(a, b S) (idA, idB vertexID, release func(), ok bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	idA, okA := d.forward[a]
+	idB, okB := d.forward[b]
+	if !okA || !okB {
+		return 0, 0, func() {}, false
+	}
+	d.refcount[idA]++
+	d.refcount[idB]++
+	return idA, idB, func() {
+		d.release(idA)
+		d.release(idB)
+	}, true
+}
+
 // resolve returns the key for id. It returns the zero value of S and
 // false if id is not currently allocated (either never minted or already
 // freed).

--- a/core/graphcache/dict_test.go
+++ b/core/graphcache/dict_test.go
@@ -193,3 +193,80 @@ func TestDictionary_GenericNonStringKey(t *testing.T) {
 		t.Fatalf("distinct struct keys mapped to same id: %d", id1)
 	}
 }
+
+func TestDictionary_PinBoth(t *testing.T) {
+	t.Run("pins both refcounts and releases them", func(t *testing.T) {
+		d := newDictionary[string]()
+		tail := d.intern("tail") // refcount 1
+		head := d.intern("head") // refcount 1
+
+		idT, idH, release, ok := d.pinBoth("tail", "head")
+		if !ok {
+			t.Fatalf("pinBoth of present keys returned ok=false")
+		}
+		if idT != tail || idH != head {
+			t.Fatalf("pinBoth ids = (%d,%d), want (%d,%d)", idT, idH, tail, head)
+		}
+		// The pin added one reference to each id, so the original intern
+		// reference can be released without freeing the id.
+		if freed := d.release(tail); freed {
+			t.Fatalf("tail freed while pin still held")
+		}
+		if freed := d.release(head); freed {
+			t.Fatalf("head freed while pin still held")
+		}
+		if _, ok := d.lookup("tail"); !ok {
+			t.Fatalf("tail vanished while pinned")
+		}
+		// Dropping the pin frees both (their last reference).
+		release()
+		if _, ok := d.lookup("tail"); ok {
+			t.Fatalf("tail still resolvable after pin release + intern release")
+		}
+		if _, ok := d.lookup("head"); ok {
+			t.Fatalf("head still resolvable after pin release + intern release")
+		}
+		if got := d.len(); got != 0 {
+			t.Fatalf("len=%d after full release, want 0", got)
+		}
+	})
+
+	t.Run("missing endpoint returns ok=false and no-op release", func(t *testing.T) {
+		d := newDictionary[string]()
+		d.intern("tail")
+		idT, idH, release, ok := d.pinBoth("tail", "absent")
+		if ok {
+			t.Fatalf("pinBoth with missing head returned ok=true")
+		}
+		if idT != 0 || idH != 0 {
+			t.Fatalf("pinBoth miss returned ids (%d,%d), want (0,0)", idT, idH)
+		}
+		if release == nil {
+			t.Fatalf("pinBoth miss returned nil release")
+		}
+		release() // must not panic
+		// The present endpoint must not have been pinned.
+		if freed := d.release(idT); freed != true {
+			// tail had refcount 1; releasing it should free (proves pinBoth
+			// did not leak an extra reference on the miss path).
+			t.Fatalf("tail refcount drifted on pinBoth miss")
+		}
+	})
+
+	t.Run("self-pin balances", func(t *testing.T) {
+		d := newDictionary[string]()
+		self := d.intern("self") // refcount 1
+		idA, idB, release, ok := d.pinBoth("self", "self")
+		if !ok || idA != self || idB != self {
+			t.Fatalf("self pinBoth = (%d,%d,%v), want (%d,%d,true)", idA, idB, ok, self, self)
+		}
+		// Pin added two references (a == b bumped twice); release drops both.
+		release()
+		if freed := d.release(self); !freed {
+			t.Fatalf("self refcount unbalanced after self-pin: not freed at expected count")
+		}
+		if got := d.len(); got != 0 {
+			t.Fatalf("len=%d after self-pin balance, want 0", got)
+		}
+	})
+}

--- a/core/graphcache/edge.go
+++ b/core/graphcache/edge.go
@@ -147,6 +147,27 @@ func (w *weight) isZero() bool {
 	return w.sum == 0
 }
 
+// replace atomically swaps all contributions for a single (value, expiration)
+// contribution under the weight's own lock. A concurrent lock-free reader
+// (snapshot) therefore observes either the pre-replace or the post-replace
+// value and never an empty bucket. This is what lets the local PutEdge path
+// replace an existing edge in place instead of delete+add, preserving the
+// atomic-replace contract (no transient NotFound) for point reads that no
+// longer hold GraphCache.mu (#740).
+//
+// lastHLC is reset to the zero value so the resulting state is identical to
+// the fresh newWeight()+single-add the old delete+add path produced; the
+// replicated LWW path uses putWithExpirationHLC, not this helper.
+func (w *weight) replace(value float32, expiration time.Time) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.values = w.values[:0]
+	w.values = append(w.values, weightValue{value: value, expiration: expiration})
+	w.sum = value
+	w.lastFlushLen = 1
+	w.lastHLC = hlc.Timestamp{}
+}
+
 // snapshot returns the cached sum, the furthest-future expiration among the
 // live contributions, and whether any live contributions remain — all under
 // a single lock acquisition and a single flush pass. Read-hot callers
@@ -261,11 +282,24 @@ func (c *edgeCache[S]) get(tail, head S) (float32, bool) {
 
 // getDetail returns the current weight and the latest contribution
 // expiration, so callers can surface the edge's effective deadline.
+//
+// getDetail is a point read that does NOT require the caller to hold
+// GraphCache.mu: it pins both endpoint ids (pinBoth) so a concurrent
+// delete/recreate cannot recycle an endpoint id to a different key between
+// resolution and the bucket lookup (the ABA hazard), and it reads the edge
+// map under the edgeCache's own RLock. The returned *weight pointer stays
+// valid even if a concurrent delete detaches it from c.tf — snapshot() takes
+// the weight's own mutex — so the read observes a consistent pre- or
+// post-delete value, matching the existing racy point-read contract.
 func (c *edgeCache[S]) getDetail(tail, head S) (float32, time.Time, bool) {
-	tailID, headID, ok := c.lookupIDs(tail, head)
+	if c.dict == nil {
+		return 0, time.Time{}, false
+	}
+	tailID, headID, release, ok := c.dict.pinBoth(tail, head)
 	if !ok {
 		return 0, time.Time{}, false
 	}
+	defer release()
 
 	c.mu.RLock()
 	heads, ok := c.tf[tailID]
@@ -502,6 +536,53 @@ func (c *edgeCache[S]) internEndpoints(tail, head S) (vertexID, vertexID) {
 		return 0, 0
 	}
 	return c.dict.intern(tail), c.dict.intern(head)
+}
+
+// putWithExpiration atomically replaces the (tail, head) edge weight with a
+// single contribution. When the bucket already exists the replacement happens
+// in place under the weight's own lock (edge.replace), so a lock-free reader
+// never observes a transient missing edge — this is the local PutEdge
+// atomic-replace contract, previously enforced by holding GraphCache.mu across
+// a delete+add. When the bucket is absent it is created exactly like
+// addWithExpiration. Returns created plus the endpoint ids so the caller can
+// maintain side indexes without re-entering the dict.
+func (c *edgeCache[S]) putWithExpiration(tail, head S, w float32, expiration time.Time) (created bool, tailID, headID vertexID) {
+	if c.dict != nil {
+		if tID, hID, okT, okH := c.dict.lookupBoth(tail, head); okT && okH {
+			c.mu.RLock()
+			if heads, ok := c.tf[tID]; ok {
+				if edge, ok := heads[hID]; ok {
+					c.mu.RUnlock()
+					edge.replace(w, expiration)
+					return false, tID, hID
+				}
+			}
+			c.mu.RUnlock()
+		}
+	}
+
+	tailID, headID = c.internEndpoints(tail, head)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	heads, ok := c.tf[tailID]
+	if !ok {
+		heads = make(map[vertexID]*weight)
+		c.tf[tailID] = heads
+	}
+	edge, existed := heads[headID]
+	if !existed {
+		edge = newWeight()
+		heads[headID] = edge
+		c.df[headID]++
+		created = true
+	} else if c.dict != nil {
+		c.dict.release(tailID)
+		c.dict.release(headID)
+	}
+	edge.replace(w, expiration)
+	return created, tailID, headID
 }
 
 // putWithExpirationHLC is the LWW-aware sibling of addWithExpiration used

--- a/core/graphcache/edge_test.go
+++ b/core/graphcache/edge_test.go
@@ -5,6 +5,8 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/anaregdesign/lantern/core/hlc"
 )
 
 func Test_newWeight(t *testing.T) {
@@ -446,6 +448,58 @@ func Test_edgeCache_getDetail_noGoroutineForExpired(t *testing.T) {
 	c.flush()
 	if got := c.count(); got != 0 {
 		t.Fatalf("flush should reclaim expired edge, count=%d", got)
+	}
+}
+
+// Test_edgeCache_putWithExpiration_inPlaceReplace verifies the local PutEdge
+// path replaces an existing edge in place (weight.replace) instead of
+// delete+add, so the dict refcounts and df stay stable across a replace and a
+// concurrent lock-free reader never sees the bucket vanish (#740).
+func Test_edgeCache_putWithExpiration_inPlaceReplace(t *testing.T) {
+	d := newDictionary[string]()
+	c := newEdgeCache[string](time.Minute, d)
+	exp := time.Now().Add(time.Hour)
+
+	created, tailID, headID := c.putWithExpiration("a", "b", 1, exp)
+	if !created {
+		t.Fatalf("first putWithExpiration created=false, want true")
+	}
+	// Replace the same edge: must reuse the bucket (created=false), the same
+	// ids, leave a single contribution, and not churn dict refcounts.
+	refTail := d.refcount[tailID]
+	refHead := d.refcount[headID]
+	created2, tailID2, headID2 := c.putWithExpiration("a", "b", 5, exp)
+	if created2 {
+		t.Fatalf("replace reported created=true, want false")
+	}
+	if tailID2 != tailID || headID2 != headID {
+		t.Fatalf("replace returned different ids: (%d,%d) vs (%d,%d)", tailID2, headID2, tailID, headID)
+	}
+	if d.refcount[tailID] != refTail || d.refcount[headID] != refHead {
+		t.Fatalf("replace churned dict refcounts: tail %d->%d head %d->%d",
+			refTail, d.refcount[tailID], refHead, d.refcount[headID])
+	}
+	if got, _, ok := c.getDetail("a", "b"); !ok || got != 5 {
+		t.Fatalf("after replace getDetail = (%v,%v), want (5,true)", got, ok)
+	}
+}
+
+// Test_weight_replace verifies replace swaps all contributions for a single
+// one, recomputes the cached sum, and resets lastHLC (matching fresh-weight
+// semantics).
+func Test_weight_replace(t *testing.T) {
+	w := newWeight()
+	w.addWithExpiration(1, time.Now().Add(time.Hour))
+	w.addWithExpiration(2, time.Now().Add(time.Hour))
+	w.replace(7, time.Now().Add(time.Hour))
+	if got := w.value(); got != 7 {
+		t.Fatalf("value after replace = %v, want 7", got)
+	}
+	if len(w.values) != 1 {
+		t.Fatalf("replace left %d contributions, want 1", len(w.values))
+	}
+	if !w.lastHLC.Equal(hlc.Timestamp{}) {
+		t.Fatalf("replace did not reset lastHLC")
 	}
 }
 

--- a/core/graphcache/write.go
+++ b/core/graphcache/write.go
@@ -30,14 +30,16 @@ func (c *GraphCache[S, T]) addEdgeContribLocked(tail, head S, w float32, expirat
 }
 
 // putEdgeLocked atomically replaces one edge under the caller's aggregate
-// write lock. It intentionally does not call onEdgeDeletedLocked for the
-// temporary delete: the edge is immediately re-added with the same head key, so
-// the head-side prefix index is unchanged and its insert path is idempotent.
+// write lock. It replaces an existing edge's weight in place (edgeCache.
+// putWithExpiration → weight.replace) rather than delete+add, so a lock-free
+// point reader (GetWeight / GetEdgeDetail, which dropped GraphCache.mu in #740)
+// never observes a transient missing edge. It intentionally does not call
+// onEdgeDeletedLocked: the head key is unchanged, so the head-side prefix index
+// is untouched and its insert path is idempotent.
 func (c *GraphCache[S, T]) putEdgeLocked(tail, head S, w float32, expiration time.Time) {
 	c.ensureVertexLocked(tail, expiration)
 	c.ensureVertexLocked(head, expiration)
-	c.edges.delete(tail, head)
-	created, tailID, headID := c.edges.addWithExpiration(tail, head, w, expiration)
+	created, tailID, headID := c.edges.putWithExpiration(tail, head, w, expiration)
 	c.onEdgeAddedLocked(created, tailID, headID, head)
 }
 


### PR DESCRIPTION
## Summary
`GetVertex`, `GetWeight` and `GetEdgeDetail` took `GraphCache.mu.RLock()` only to read inner structures (`vertices`, `edges`, `dict`) that already carry their own locks. Hot point reads therefore serialized behind unrelated writes, long scans and GC. This drops the aggregate lock from all three.

## Changes
- **`dict.pinBoth`** — resolves both endpoint keys and bumps their refcounts under one write-lock cycle, returning a `release` func. While pinned the ids cannot reach refcount zero, so they can neither be freed nor recycled to a different key. This closes the dictionary **ABA hazard** a lock-free edge read would otherwise have.
- **`GetVertex` / `GetWeight` / `GetEdgeDetail`** — no longer take `GraphCache.mu`. `getDetail` now pins endpoints via `pinBoth`.
- **In-place atomic edge replace** — removing the aggregate lock exposed that the local `PutEdge` path relied on `GraphCache.mu` for its atomic-replace guarantee: `putEdgeLocked` did `delete`+`add`, so a lock-free reader could observe a transient missing edge. New `weight.replace` + `edgeCache.putWithExpiration` replace an existing edge in place under the weight's own lock, preserving the no-transient-NotFound contract for both `PutEdge` and `PutEdges`.

## Consistency contract
Point reads remain racy with respect to a concurrent write on the *same* key (observe pre- or post-write state) — unchanged from before. The new guarantee is only that a read never resolves a recycled endpoint id to an unrelated edge, and never sees an edge momentarily vanish during a local replace.

## Tests
- `dict.pinBoth` unit tests (pin/release, missing endpoint no-op, self-pin balance).
- Lock-free point-read concurrency tests under `-race`.
- In-place replace unit tests (`weight.replace`, `edgeCache.putWithExpiration` refcount/df stability).
- Two contended point-read benchmarks.
- Full `core` module green under `-race`; `gofmt -l` clean.

Closes #740
