### PR TITLE
perf(graphcache): split SearchVertices read-side lock (#741)

### DIFF
--- a/core/graphcache/bench_test.go
+++ b/core/graphcache/bench_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -432,4 +433,88 @@ func BenchmarkScanEdgesByPrefix(b *testing.B) {
 			}
 		})
 	}
+}
+
+// BenchmarkSearchVertices measures the read-side search path after the #741
+// lock-splitting refactor (query analysis + BM25 ranking + liveness/prefix
+// filtering run without GraphCache.mu). It covers a narrow query (few
+// matches), a broad query (many matches), a prefix-scoped query, and a broad
+// query under concurrent writer pressure — the contended case the refactor
+// targets, where searches previously serialized against writers on
+// GraphCache.mu. Run with -benchmem.
+func BenchmarkSearchVertices(b *testing.B) {
+	const n = 5000
+	newSeeded := func() *GraphCache[string, string] {
+		c := NewGraphCache[string, string](time.Hour)
+		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+		c.EnablePrefixIndex(func(s string) string { return s })
+		exp := time.Now().Add(time.Hour)
+		for i := 0; i < n; i++ {
+			ns := "user:"
+			if i%2 == 1 {
+				ns = "session:"
+			}
+			// Every doc carries the broad term "payload"; only a few carry the
+			// rare term "unicorn" so the narrow query ranks a small candidate set.
+			val := benchSearchCorpus[i%len(benchSearchCorpus)] + " payload"
+			if i%1000 == 0 {
+				val += " unicorn"
+			}
+			c.PutVertexWithExpiration(fmt.Sprintf("%s%05d", ns, i), val, exp)
+		}
+		return c
+	}
+
+	b.Run("Narrow", func(b *testing.B) {
+		c := newSeeded()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = c.SearchVertices("unicorn", 50, "")
+		}
+	})
+
+	b.Run("Broad", func(b *testing.B) {
+		c := newSeeded()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = c.SearchVertices("payload", 50, "")
+		}
+	})
+
+	b.Run("PrefixScoped", func(b *testing.B) {
+		c := newSeeded()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = c.SearchVertices("payload", 50, "user:")
+		}
+	})
+
+	b.Run("BroadConcurrentWriters", func(b *testing.B) {
+		c := newSeeded()
+		var stop atomic.Bool
+		var wg sync.WaitGroup
+		exp := time.Now().Add(time.Hour)
+		for w := 0; w < 4; w++ {
+			wg.Add(1)
+			go func(seed int) {
+				defer wg.Done()
+				i := seed
+				for !stop.Load() {
+					c.PutVertexWithExpiration(fmt.Sprintf("user:%05d", i%n), "churn payload", exp)
+					i += 7
+				}
+			}(w)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = c.SearchVertices("payload", 50, "")
+		}
+		b.StopTimer()
+		stop.Store(true)
+		wg.Wait()
+	})
 }

--- a/core/graphcache/search.go
+++ b/core/graphcache/search.go
@@ -78,24 +78,41 @@ func (c *GraphCache[S, T]) SearchVertices(query string, limit int, keyPrefix str
 	if limit <= 0 {
 		return nil
 	}
+	// Phase 1 — capture the immutable references the search path needs under a
+	// short RLock, then release c.mu before the expensive work. searchIndex and
+	// prefixExtract are both set once at Enable*Index time (before any vertex is
+	// stored) and never reassigned, so copying the pointers under the lock is
+	// sufficient; we do not need to hold c.mu while they are used.
 	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if c.searchIndex == nil {
+	index := c.searchIndex
+	prefixExtract := c.prefixExtract
+	c.mu.RUnlock()
+
+	if index == nil {
 		return nil
 	}
-	ranked := c.searchIndex.Search(query)
+	// Phase 2 — query analysis, BM25 ranking, and liveness/prefix filtering all
+	// run WITHOUT GraphCache.mu. The inverted index has its own RWMutex (Search
+	// takes RLock) and the vertex cache's Has is guarded by the inner cache
+	// lock, so writers and GC that need GraphCache.mu.Lock() are no longer
+	// blocked by a broad or expensive search (#741). Liveness is still checked
+	// at filter time via vertices.Has, so an expired-but-not-yet-flushed vertex
+	// is skipped exactly as before; the read may now race a concurrent
+	// Put/Delete on a given key and observe either side of it, which is the same
+	// racy point-read contract GetVertex provides (#740).
+	ranked := index.Search(query)
 	if len(ranked) == 0 {
 		return nil
 	}
 	out := make([]search.Result[S], 0, min(limit, len(ranked)))
 	for _, r := range ranked {
 		if !c.vertices.Has(r.ID) {
-			// Expired between the index write and this snapshot but the
-			// async Flush has not run yet; consistent with point-read
-			// semantics, treat as absent.
+			// Expired between the index write and this read but the async
+			// Flush has not run yet; consistent with point-read semantics,
+			// treat as absent.
 			continue
 		}
-		if keyPrefix != "" && !c.keyHasPrefix(r.ID, keyPrefix) {
+		if keyPrefix != "" && !keyHasPrefix(prefixExtract, r.ID, keyPrefix) {
 			continue
 		}
 		out = append(out, r)
@@ -110,14 +127,17 @@ func (c *GraphCache[S, T]) SearchVertices(query string, limit int, keyPrefix str
 }
 
 // keyHasPrefix reports whether key's string projection starts with prefix,
-// using the same projection the prefix index uses when it is enabled. When the
-// prefix index is disabled it falls back to the identity projection for the
-// string-keyed instantiation (Lantern's only production case); a non-string S
-// without a prefix projection cannot be scoped, so it never matches a
-// non-empty prefix. Callers must hold c.mu.
-func (c *GraphCache[S, T]) keyHasPrefix(key S, prefix string) bool {
-	if c.prefixExtract != nil {
-		return strings.HasPrefix(c.prefixExtract(key), prefix)
+// using the same projection the prefix index uses when it is enabled
+// (prefixExtract, which the caller captures under c.mu before releasing it).
+// When the prefix index is disabled (prefixExtract == nil) it falls back to the
+// identity projection for the string-keyed instantiation (Lantern's only
+// production case); a non-string S without a prefix projection cannot be
+// scoped, so it never matches a non-empty prefix. prefixExtract is set once at
+// EnablePrefixIndex time and never reassigned, so it is safe to read without
+// holding c.mu.
+func keyHasPrefix[S comparable](prefixExtract func(S) string, key S, prefix string) bool {
+	if prefixExtract != nil {
+		return strings.HasPrefix(prefixExtract(key), prefix)
 	}
 	if s, ok := any(key).(string); ok {
 		return strings.HasPrefix(s, prefix)

--- a/core/graphcache/search_test.go
+++ b/core/graphcache/search_test.go
@@ -1,6 +1,10 @@
 package graphcache
 
 import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -192,6 +196,76 @@ func TestGraphCache_SearchVertices(t *testing.T) {
 			t.Fatalf("SearchVertices(no-match) = %v, want nil", keys(got))
 		}
 	})
+}
+
+// TestGraphCache_SearchVertices_Concurrent exercises the #741 lock-splitting
+// refactor: SearchVertices runs query analysis, BM25 ranking, and
+// liveness/prefix filtering without holding GraphCache.mu. Concurrent
+// PutVertex / DeleteVertex / SearchVertices must therefore be free of data
+// races (run under -race) and every returned hit must be in scope at filter
+// time.
+func TestGraphCache_SearchVertices_Concurrent(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	c.EnableSearchIndex(textExtract)
+	c.EnablePrefixIndex(func(s string) string { return s })
+
+	const keysN = 200
+	// Seed so searches have something to match from the very first iteration.
+	for i := 0; i < keysN; i++ {
+		c.PutVertex(fmt.Sprintf("user:%03d", i), "common shared payload")
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writers churn the same key space with puts and deletes.
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			r := rand.New(rand.NewSource(int64(seed)))
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				k := fmt.Sprintf("user:%03d", r.Intn(keysN))
+				if r.Intn(2) == 0 {
+					c.PutVertex(k, "common shared payload")
+				} else {
+					c.DeleteVertex(k)
+				}
+			}
+		}(w)
+	}
+
+	// Searchers run a broad query, both unscoped and prefix-scoped. Every hit
+	// from the scoped search must be within the prefix at filter time.
+	for s := 0; s < 4; s++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				for _, r := range c.SearchVertices("payload", 50, "user:") {
+					if !strings.HasPrefix(r.ID, "user:") {
+						t.Errorf("scoped search returned out-of-prefix key %q", r.ID)
+						return
+					}
+				}
+				_ = c.SearchVertices("payload", 50, "")
+			}
+		}()
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }
 
 // equalKeys reports whether got equals want in the same order.


### PR DESCRIPTION
## Summary
`SearchVertices` held `GraphCache.mu.RLock()` across the entire operation — query analysis, BM25 ranking (`searchIndex.Search`), liveness filtering, prefix filtering, and limit collection. For broad queries, large indexes, or expensive Unicode normalization/bigram analysis, a read-only search blocked graph writers and GC that need `GraphCache.mu.Lock()`.

This splits the method into two phases so the heavy work runs without the aggregate lock.

## Changes
- **Phase 1 (short RLock):** capture the immutable `searchIndex` and `prefixExtract` references, then release `c.mu`. Both are set once at `Enable*Index` time (before any vertex is stored) and never reassigned, so copying the pointers is sufficient.
- **Phase 2 (no aggregate lock):** query analysis, BM25 ranking, and liveness/prefix filtering. `InvertedIndex.Search` has its own `RWMutex` and `vertices.Has` is guarded by the inner cache lock, so neither needs `GraphCache.mu`.
- `keyHasPrefix` becomes a free function taking the captured `prefixExtract`.

## Semantics preserved
- A hit is still returned only if the vertex is live at filter time (`vertices.Has`) — expired-but-not-yet-flushed vertices are skipped.
- Disabled-index, empty-query, non-positive-limit, and no-match behavior unchanged.
- Prefix filtering remains consistent with the configured prefix projection.
- The read may now race a concurrent `Put`/`Delete` on a given key and observe either side of it — the same racy point-read contract as `GetVertex` (#740).

## Tests / Benchmarks
- New concurrent `PutVertex`/`DeleteVertex`/`SearchVertices` race test (`-race`) asserting scoped hits stay in-prefix; existing liveness + prefix-scope tests still pass.
- `BenchmarkSearchVertices` covering narrow, broad, prefix-scoped, and broad-under-concurrent-writers cases.
- Full `core` module green under `-race`; `gofmt -l` clean.

Independent of #739 (write-side tokenization).

Closes #741
