### PR TITLE
perf(mutationlog): read-lock status methods via RWMutex (#745)

### DIFF
--- a/core/mutationlog/bench_test.go
+++ b/core/mutationlog/bench_test.go
@@ -1,6 +1,10 @@
 package mutationlog
 
-import "testing"
+import (
+	"sync"
+	"testing"
+	"time"
+)
 
 // BenchmarkAppendAtCapacity exercises the eviction path that issue #252
 // turned from O(N) (shift-copy of the entire ring) into O(1) head bumping.
@@ -21,5 +25,130 @@ func BenchmarkAppendAtCapacity(b *testing.B) {
 		if _, err := l.Append(i, ts(int64(i))); err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+// sleepWAL models a durability layer with a fixed per-write latency. Append
+// holds the log write lock across WAL.Write, so this is the knob the #745
+// benchmarks use to show how WAL latency couples to append throughput.
+type sleepWAL struct{ delay time.Duration }
+
+func (w sleepWAL) Write(Entry) error {
+	if w.delay > 0 {
+		time.Sleep(w.delay)
+	}
+	return nil
+}
+
+// BenchmarkAppend measures the steady-state append hot path under the #745
+// locking model across three WAL/fan-out shapes: a no-op WAL, a slow WAL (the
+// latency that serializes under the write lock), and many live subscribers
+// (which the #260 dispatcher decouples from append latency).
+func BenchmarkAppend(b *testing.B) {
+	b.Run("NopWAL", func(b *testing.B) {
+		l := New(Options{Capacity: 4096, SubscriberBuffer: 4096})
+		defer l.Close()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := l.Append(i, ts(int64(i))); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("SlowWAL", func(b *testing.B) {
+		l := New(Options{Capacity: 4096, SubscriberBuffer: 4096, WAL: sleepWAL{delay: 5 * time.Microsecond}})
+		defer l.Close()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := l.Append(i, ts(int64(i))); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("ManySubscribers", func(b *testing.B) {
+		const subs = 64
+		l := New(Options{Capacity: 4096, SubscriberBuffer: 1 << 20})
+		defer l.Close()
+		for s := 0; s < subs; s++ {
+			ch, cancel, err := l.Subscribe(1)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer cancel()
+			go func() {
+				for range ch {
+				}
+			}()
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := l.Append(i, ts(int64(i))); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkStatusReadsDuringAppend measures the read-only status path
+// (LastSeq) under concurrent append pressure. After #745 these reads take the
+// RWMutex read lock, so this captures the contended status-poll cost a
+// replication monitor pays while writes stream in.
+func BenchmarkStatusReadsDuringAppend(b *testing.B) {
+	l := New(Options{Capacity: 4096, SubscriberBuffer: 4096})
+	defer l.Close()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_, _ = l.Append(i, ts(int64(i)))
+			i++
+		}
+	}()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = l.LastSeq()
+	}
+	b.StopTimer()
+	close(stop)
+	wg.Wait()
+}
+
+// BenchmarkSubscribeReplay measures the cost of registering a subscriber that
+// replays a full ring-buffer window, the Subscribe critical section #745
+// item 5 targets. The replay window is sized to the whole capacity so every
+// resident entry is copied into the new subscriber channel under the lock.
+func BenchmarkSubscribeReplay(b *testing.B) {
+	const capacity = 4096
+	l := New(Options{Capacity: capacity, SubscriberBuffer: capacity})
+	defer l.Close()
+	for i := 0; i < capacity; i++ {
+		if _, err := l.Append(i, ts(int64(i))); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, cancel, err := l.Subscribe(1)
+		if err != nil {
+			b.Fatal(err)
+		}
+		cancel()
 	}
 }

--- a/core/mutationlog/mutationlog.go
+++ b/core/mutationlog/mutationlog.go
@@ -120,12 +120,16 @@ const (
 //
 // The zero value is not ready for use; construct with [New].
 //
-// Locking model (#260): two mutexes split the hot path so [Log.Append]
+// Locking model (#260, #745): two mutexes split the hot path so [Log.Append]
 // no longer iterates subscribers under its own critical section.
 //
-//   - mu  protects the ring buffer, sequence counters, and the closed flag.
-//     Held briefly by Append (WAL write + store + seq update + handoff
-//     to the dispatcher) and by Subscribe (replay + sub registration).
+//   - mu  is an RWMutex protecting the ring buffer, sequence counters, and
+//     the closed flag. The mutation paths take the write lock: Append (WAL
+//     write + store + seq update + handoff to the dispatcher), Subscribe
+//     (replay + sub registration), and Close. The pure-read status methods
+//     (FirstSeq, LastSeq, Len, Evicted) take only the read lock, so a burst
+//     of status polling no longer serializes against itself and proceeds
+//     concurrently whenever no append/subscribe is mid-flight (#745).
 //   - subsMu protects the subscribers map and per-subscriber state.
 //     Held by the dispatcher goroutine during fan-out and by cancel.
 //
@@ -133,7 +137,7 @@ const (
 // subsMu, and Append only takes mu (the channel send happens under mu to
 // preserve global Seq ordering), so the two paths cannot deadlock.
 type Log struct {
-	mu       sync.Mutex
+	mu       sync.RWMutex
 	capacity int
 	subBuf   int
 	wal      WAL
@@ -207,8 +211,8 @@ func New(opts Options) *Log {
 // FirstSeq returns the lowest Seq still resident in the ring buffer. It
 // returns 0 (and false) when the log is empty.
 func (l *Log) FirstSeq() (uint64, bool) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
+	l.mu.RLock()
+	defer l.mu.RUnlock()
 	if !l.hasEntries {
 		return 0, false
 	}
@@ -218,8 +222,8 @@ func (l *Log) FirstSeq() (uint64, bool) {
 // LastSeq returns the Seq of the most recently appended entry. It returns
 // 0 (and false) when the log is empty.
 func (l *Log) LastSeq() (uint64, bool) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
+	l.mu.RLock()
+	defer l.mu.RUnlock()
 	if !l.hasEntries {
 		return 0, false
 	}
@@ -235,8 +239,8 @@ func (l *Log) Cap() int {
 // Len returns the number of entries currently resident in the ring buffer.
 // 0 <= Len() <= Cap().
 func (l *Log) Len() int {
-	l.mu.Lock()
-	defer l.mu.Unlock()
+	l.mu.RLock()
+	defer l.mu.RUnlock()
 	return l.size
 }
 
@@ -244,8 +248,8 @@ func (l *Log) Len() int {
 // buffer because Append at full capacity displaced the oldest entry. The
 // counter is monotonic for the lifetime of the Log.
 func (l *Log) Evicted() uint64 {
-	l.mu.Lock()
-	defer l.mu.Unlock()
+	l.mu.RLock()
+	defer l.mu.RUnlock()
 	return l.evicted
 }
 

--- a/core/mutationlog/mutationlog_test.go
+++ b/core/mutationlog/mutationlog_test.go
@@ -414,3 +414,128 @@ func TestAppendDoesNotBlockOnSlowSubscriber(t *testing.T) {
 		t.Fatal("Append blocked despite dispatcher fan-out being decoupled")
 	}
 }
+
+// TestStatusReadsRaceFreeDuringAppend hammers the read-only status methods
+// (FirstSeq, LastSeq, Len, Evicted, Cap) from several goroutines while a
+// writer appends. It exercises the #745 RWMutex read path: the run must be
+// race-free under -race, and from any single reader's perspective LastSeq must
+// never move backwards (Append only ever increments it).
+func TestStatusReadsRaceFreeDuringAppend(t *testing.T) {
+	l := New(Options{Capacity: 256, SubscriberBuffer: 1024})
+	defer l.Close()
+
+	const appends = 2000
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 1; i <= appends; i++ {
+			if _, err := l.Append(i, ts(int64(i))); err != nil {
+				t.Errorf("append #%d: %v", i, err)
+				return
+			}
+		}
+	}()
+
+	for r := 0; r < 6; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var prevLast uint64
+			for i := 0; i < 5000; i++ {
+				if last, ok := l.LastSeq(); ok {
+					if last < prevLast {
+						t.Errorf("LastSeq went backwards: %d < %d", last, prevLast)
+						return
+					}
+					prevLast = last
+				}
+				_, _ = l.FirstSeq()
+				_ = l.Len()
+				_ = l.Evicted()
+				_ = l.Cap()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if last, _ := l.LastSeq(); last != appends {
+		t.Fatalf("LastSeq = %d, want %d", last, appends)
+	}
+}
+
+// blockingWAL models a slow durability layer: every Write sleeps before
+// recording the entry. It records entries in call order so a test can assert
+// the WAL observed strictly increasing seqs.
+type blockingWAL struct {
+	mu      sync.Mutex
+	entries []Entry
+	delay   time.Duration
+}
+
+func (w *blockingWAL) Write(e Entry) error {
+	time.Sleep(w.delay)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.entries = append(w.entries, e)
+	return nil
+}
+
+// TestSlowWALKeepsOrderingAndStatusResponsive verifies that with a slow WAL
+// held under the Append write lock, (a) entries are persisted in strict Seq
+// order with no gaps across concurrent writers, and (b) concurrent read-only
+// status polling does not deadlock. This pins the current design choice for
+// #745: the WAL stays under the lock (the issue's lower-risk option), so a
+// slow WAL serializes appends but never corrupts ordering or wedges readers.
+func TestSlowWALKeepsOrderingAndStatusResponsive(t *testing.T) {
+	w := &blockingWAL{delay: time.Millisecond}
+	l := New(Options{Capacity: 1024, SubscriberBuffer: 1024, WAL: w})
+	defer l.Close()
+
+	const writers = 4
+	const perWriter = 25
+	var wg sync.WaitGroup
+	for x := 0; x < writers; x++ {
+		wg.Add(1)
+		go func(x int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				if _, err := l.Append(x*1000+i, ts(int64(x*1000+i))); err != nil {
+					t.Errorf("append: %v", err)
+					return
+				}
+			}
+		}(x)
+	}
+
+	stop := make(chan struct{})
+	pollDone := make(chan struct{})
+	go func() {
+		defer close(pollDone)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_, _ = l.LastSeq()
+			_ = l.Len()
+		}
+	}()
+
+	wg.Wait()
+	close(stop)
+	<-pollDone
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.entries) != writers*perWriter {
+		t.Fatalf("WAL saw %d entries, want %d", len(w.entries), writers*perWriter)
+	}
+	for i, e := range w.entries {
+		if e.Seq != uint64(i+1) {
+			t.Fatalf("WAL entry %d has Seq %d, want %d", i, e.Seq, i+1)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
`FirstSeq`, `LastSeq`, `Len` and `Evicted` are pure counter reads but took the **exclusive** log mutex, so they queued behind every `Append`/`Subscribe` and against each other. Under sustained replication load with frequent status polling that is needless contention.

## Change
Convert `Log.mu` from `sync.Mutex` to `sync.RWMutex` and have the four read-only status methods take the **read** lock. The mutation paths (`Append`, `Subscribe`, `Close`) keep the write lock.

## Invariants preserved (per #745 non-goals)
- **Seq monotonicity** — Append still serializes under the write lock.
- **Subscribe replay/live boundary** — unchanged (still under the write lock).
- **WAL-under-lock contract** — `wal.Write` still runs under the write lock.

The riskier explorations the issue lists (moving `wal.Write` out of the critical section behind a pending-commit queue, decoupling the dispatcher handoff, copying the Subscribe replay window before sending) are **deliberately deferred**: they are benchmark-driven and must not risk seq gaps or reordering. This PR takes the issue's explicitly-stated *lower-risk* option (keep WAL under the lock) and documents it.

## Tests
- `TestStatusReadsRaceFreeDuringAppend` — 6 readers hammer the status surface during appends; race-free under `-race` and `LastSeq` never regresses.
- `TestSlowWALKeepsOrderingAndStatusResponsive` — slow WAL under concurrent writers; asserts strict WAL seq ordering (no gaps) and that status polling does not deadlock.

## Benchmarks
- `BenchmarkAppend` (`NopWAL` / `SlowWAL` / `ManySubscribers`)
- `BenchmarkStatusReadsDuringAppend`
- `BenchmarkSubscribeReplay`

Full `core` module green under `-race`; `gofmt -l` clean.

Closes #745
