### PR TITLE
perf(graphcache): batch vertex delete index maintenance (#738)

### DIFF
--- a/core/cache/cache.go
+++ b/core/cache/cache.go
@@ -55,8 +55,16 @@ type Cache[S comparable, T any] struct {
 	// the lock on c.mu has been released, so the callback may safely call
 	// back into the same Cache without deadlocking — but it must not block
 	// indefinitely (it runs inline on the caller's goroutine).
-	hookMu  sync.RWMutex
-	onEvict func(S)
+	//
+	// onEvictMany is the batch counterpart installed via SetOnEvictMany. When
+	// non-nil it TAKES PRECEDENCE over onEvict: a single removal fires it with
+	// a one-element slice and a batch removal (DeleteMany, Clear, Flush) fires
+	// it once with the whole evicted set, so a layered cache can amortize its
+	// per-key index cleanup over one pass and one set of inner-lock
+	// acquisitions (#738). Install exactly one of the two hooks.
+	hookMu      sync.RWMutex
+	onEvict     func(S)
+	onEvictMany func([]S)
 }
 
 func NewCache[S comparable, T any](defaultTTL time.Duration) *Cache[S, T] {
@@ -80,10 +88,44 @@ func (c *Cache[S, T]) SetOnEvict(fn func(S)) {
 	c.onEvict = fn
 }
 
-func (c *Cache[S, T]) snapshotOnEvict() func(S) {
+// SetOnEvictMany installs (or clears, when nil) a batch eviction callback
+// invoked once with the full slice of keys removed by a Delete, DeleteMany,
+// Clear, or Flush call. When installed it takes precedence over the per-key
+// SetOnEvict hook (the per-key hook is not also called), so install exactly
+// one of the two. Like the per-key hook it fires after c.mu has been released,
+// so it may re-enter the same Cache without deadlocking, and it must not
+// block. The slice is owned by the callback for the duration of the call only.
+func (c *Cache[S, T]) SetOnEvictMany(fn func([]S)) {
+	c.hookMu.Lock()
+	defer c.hookMu.Unlock()
+	c.onEvictMany = fn
+}
+
+// snapshotHooks returns both eviction hooks under a single hookMu read so a
+// caller observes a consistent (one, many) pair.
+func (c *Cache[S, T]) snapshotHooks() (one func(S), many func([]S)) {
 	c.hookMu.RLock()
 	defer c.hookMu.RUnlock()
-	return c.onEvict
+	return c.onEvict, c.onEvictMany
+}
+
+// fireEvicted invokes the eviction hooks for evicted after c.mu has been
+// released. The batch hook takes precedence over the per-key hook; when only
+// the per-key hook is installed it is called once per key. A nil/empty evicted
+// slice is a no-op.
+func (c *Cache[S, T]) fireEvicted(one func(S), many func([]S), evicted []S) {
+	if len(evicted) == 0 {
+		return
+	}
+	if many != nil {
+		many(evicted)
+		return
+	}
+	if one != nil {
+		for _, k := range evicted {
+			one(k)
+		}
+	}
 }
 
 func (c *Cache[S, T]) Get(key S) (T, bool) {
@@ -120,8 +162,9 @@ func (c *Cache[S, T]) Put(key S, value T) {
 
 // Delete removes the entry for key. It returns true if the key was
 // present (and therefore removed by this call), false otherwise. When the
-// key was present and an OnEvict callback is installed, the callback fires
-// once after c.mu is released.
+// key was present and an eviction callback is installed, it fires once
+// after c.mu is released (the batch hook with a one-element slice, else the
+// per-key hook).
 func (c *Cache[S, T]) Delete(key S) bool {
 	c.mu.Lock()
 	if _, ok := c.cache[key]; !ok {
@@ -129,12 +172,42 @@ func (c *Cache[S, T]) Delete(key S) bool {
 		return false
 	}
 	delete(c.cache, key)
+	one, many := c.snapshotHooks()
 	c.mu.Unlock()
 
-	if cb := c.snapshotOnEvict(); cb != nil {
-		cb(key)
+	switch {
+	case many != nil:
+		many([]S{key})
+	case one != nil:
+		one(key)
 	}
 	return true
+}
+
+// DeleteMany removes every supplied key that is present, under a single c.mu
+// critical section, and returns the keys actually removed (those present at
+// call time) in unspecified order. Absent keys are skipped and not reported;
+// duplicate keys are reported at most once. The eviction callback fires once
+// after c.mu is released — the batch hook with the whole evicted slice when
+// installed, else the per-key hook once per removed key — so a layered cache
+// amortizes its index cleanup over one pass (#738).
+func (c *Cache[S, T]) DeleteMany(keys []S) []S {
+	if len(keys) == 0 {
+		return nil
+	}
+	c.mu.Lock()
+	evicted := make([]S, 0, len(keys))
+	for _, k := range keys {
+		if _, ok := c.cache[k]; ok {
+			delete(c.cache, k)
+			evicted = append(evicted, k)
+		}
+	}
+	one, many := c.snapshotHooks()
+	c.mu.Unlock()
+
+	c.fireEvicted(one, many, evicted)
+	return evicted
 }
 
 func (c *Cache[S, T]) Has(key S) bool {
@@ -143,14 +216,16 @@ func (c *Cache[S, T]) Has(key S) bool {
 	return ok
 }
 
-// Clear removes every entry. When an OnEvict callback is installed it is
-// invoked once per removed key after c.mu has been released. Keys are
-// reported in unspecified order.
+// Clear removes every entry. When an eviction callback is installed it is
+// invoked once after c.mu has been released — the batch hook with all removed
+// keys, else the per-key hook once per key. Keys are reported in unspecified
+// order.
 func (c *Cache[S, T]) Clear() {
 	c.mu.Lock()
-	cb := c.snapshotOnEvict()
+	one, many := c.snapshotHooks()
+	hook := one != nil || many != nil
 	var evicted []S
-	if cb != nil {
+	if hook {
 		evicted = make([]S, 0, len(c.cache))
 		for k := range c.cache {
 			evicted = append(evicted, k)
@@ -159,11 +234,7 @@ func (c *Cache[S, T]) Clear() {
 	c.cache = make(map[S]volatile[T])
 	c.mu.Unlock()
 
-	if cb != nil {
-		for _, k := range evicted {
-			cb(k)
-		}
-	}
+	c.fireEvicted(one, many, evicted)
 }
 
 func (c *Cache[S, T]) Count() int {
@@ -196,17 +267,18 @@ func (c *Cache[S, T]) Range(fn func(key S, value T, expiration time.Time) bool) 
 
 // Flush evicts every entry whose TTL has passed. It returns the number of
 // entries removed so callers (e.g. server-side TTL metrics) can record
-// expiration counts without scanning the cache again. When an OnEvict
-// callback is installed it is invoked once per removed key after c.mu has
-// been released.
+// expiration counts without scanning the cache again. When an eviction
+// callback is installed it is invoked once after c.mu has been released —
+// the batch hook with the whole expired set, else the per-key hook once per
+// key — so a layered cache cleans its side indexes in one pass (#738).
 func (c *Cache[S, T]) Flush() int {
 	c.mu.Lock()
-	cb := c.snapshotOnEvict()
-	var evicted []S
-	if cb != nil {
+	one, many := c.snapshotHooks()
+	if one != nil || many != nil {
 		// Two-phase: collect keys under the lock, fire callbacks after release.
 		// maps.DeleteFunc cannot collect because the predicate's S is the live
 		// key but we need to defer the callback past Unlock.
+		var evicted []S
 		for k, v := range c.cache {
 			if v.IsExpired() {
 				evicted = append(evicted, k)
@@ -216,9 +288,7 @@ func (c *Cache[S, T]) Flush() int {
 			delete(c.cache, k)
 		}
 		c.mu.Unlock()
-		for _, k := range evicted {
-			cb(k)
-		}
+		c.fireEvicted(one, many, evicted)
 		return len(evicted)
 	}
 	before := len(c.cache)

--- a/core/cache/cache_test.go
+++ b/core/cache/cache_test.go
@@ -489,3 +489,144 @@ func TestCache_PutWithExpiration_ZeroNeverExpires(t *testing.T) {
 		})
 	}
 }
+
+// TestCache_DeleteMany verifies the batch delete removes every present key,
+// skips absent keys, reports the removed set, and is a no-op for an empty
+// input.
+func TestCache_DeleteMany(t *testing.T) {
+	c := NewCache[string, int](time.Minute)
+	c.Put("a", 1)
+	c.Put("b", 2)
+	c.Put("c", 3)
+
+	if got := c.DeleteMany(nil); got != nil {
+		t.Fatalf("DeleteMany(nil) = %v, want nil", got)
+	}
+
+	evicted := c.DeleteMany([]string{"a", "missing", "c", "a"})
+	sort.Strings(evicted)
+	want := []string{"a", "c"}
+	if !reflect.DeepEqual(evicted, want) {
+		t.Fatalf("DeleteMany evicted = %v, want %v", evicted, want)
+	}
+	if c.Has("a") || c.Has("c") {
+		t.Fatalf("deleted keys still present")
+	}
+	if !c.Has("b") {
+		t.Fatalf("untouched key b was removed")
+	}
+}
+
+// TestCache_OnEvictMany_Batch verifies the batch hook fires exactly once with
+// the full set of removed keys for Delete (one-element slice), DeleteMany,
+// Clear, and Flush, and that it takes precedence over a per-key hook.
+func TestCache_OnEvictMany_Batch(t *testing.T) {
+	type batch []string
+	newWatched := func() (*[]batch, *sync.Mutex, *atomic.Int32) {
+		var batches []batch
+		var mu sync.Mutex
+		var perKey atomic.Int32
+		return &batches, &mu, &perKey
+	}
+
+	t.Run("DeleteSingleKeyArrivesAsBatch", func(t *testing.T) {
+		c := NewCache[string, int](time.Minute)
+		c.Put("a", 1)
+		batches, mu, perKey := newWatched()
+		c.SetOnEvict(func(string) { perKey.Add(1) })
+		c.SetOnEvictMany(func(keys []string) {
+			mu.Lock()
+			defer mu.Unlock()
+			*batches = append(*batches, append(batch(nil), keys...))
+		})
+		c.Delete("a")
+		mu.Lock()
+		defer mu.Unlock()
+		if len(*batches) != 1 || len((*batches)[0]) != 1 || (*batches)[0][0] != "a" {
+			t.Fatalf("batches = %v, want [[a]]", *batches)
+		}
+		if perKey.Load() != 0 {
+			t.Fatalf("per-key hook fired %d times; batch hook must take precedence", perKey.Load())
+		}
+	})
+
+	t.Run("DeleteMany", func(t *testing.T) {
+		c := NewCache[string, int](time.Minute)
+		c.Put("a", 1)
+		c.Put("b", 2)
+		c.Put("c", 3)
+		batches, mu, _ := newWatched()
+		c.SetOnEvictMany(func(keys []string) {
+			mu.Lock()
+			defer mu.Unlock()
+			*batches = append(*batches, append(batch(nil), keys...))
+		})
+		c.DeleteMany([]string{"a", "b", "missing"})
+		mu.Lock()
+		defer mu.Unlock()
+		if len(*batches) != 1 {
+			t.Fatalf("want exactly one batch, got %v", *batches)
+		}
+		got := append(batch(nil), (*batches)[0]...)
+		sort.Strings(got)
+		if !reflect.DeepEqual([]string(got), []string{"a", "b"}) {
+			t.Fatalf("batch = %v, want [a b]", got)
+		}
+	})
+
+	t.Run("Clear", func(t *testing.T) {
+		c := NewCache[string, int](time.Minute)
+		c.Put("a", 1)
+		c.Put("b", 2)
+		batches, mu, _ := newWatched()
+		c.SetOnEvictMany(func(keys []string) {
+			mu.Lock()
+			defer mu.Unlock()
+			*batches = append(*batches, append(batch(nil), keys...))
+		})
+		c.Clear()
+		mu.Lock()
+		defer mu.Unlock()
+		if len(*batches) != 1 || len((*batches)[0]) != 2 {
+			t.Fatalf("Clear batch = %v, want one batch of 2", *batches)
+		}
+	})
+
+	t.Run("Flush", func(t *testing.T) {
+		c := NewCache[string, int](time.Minute)
+		c.PutWithTTL("alive", 1, time.Hour)
+		c.PutWithExpiration("dead-1", 2, time.Now().Add(-time.Second))
+		c.PutWithExpiration("dead-2", 3, time.Now().Add(-time.Second))
+		batches, mu, _ := newWatched()
+		c.SetOnEvictMany(func(keys []string) {
+			mu.Lock()
+			defer mu.Unlock()
+			*batches = append(*batches, append(batch(nil), keys...))
+		})
+		if removed := c.Flush(); removed != 2 {
+			t.Fatalf("Flush() = %d, want 2", removed)
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		if len(*batches) != 1 {
+			t.Fatalf("want exactly one batch, got %v", *batches)
+		}
+		got := append(batch(nil), (*batches)[0]...)
+		sort.Strings(got)
+		if !reflect.DeepEqual([]string(got), []string{"dead-1", "dead-2"}) {
+			t.Fatalf("Flush batch = %v, want [dead-1 dead-2]", got)
+		}
+	})
+
+	t.Run("Clearing", func(t *testing.T) {
+		c := NewCache[string, int](time.Minute)
+		c.Put("a", 1)
+		var calls atomic.Int32
+		c.SetOnEvictMany(func([]string) { calls.Add(1) })
+		c.SetOnEvictMany(nil)
+		c.Delete("a")
+		if calls.Load() != 0 {
+			t.Fatalf("calls = %d, want 0 after SetOnEvictMany(nil)", calls.Load())
+		}
+	})
+}

--- a/core/graphcache/batch.go
+++ b/core/graphcache/batch.go
@@ -106,20 +106,16 @@ func (c *GraphCache[S, T]) PutEdgesWithExpiration(items []EdgeItem[S]) {
 // DeleteVertices removes every supplied vertex under a single write lock
 // and returns the count of keys that were actually present (and therefore
 // deleted). Concurrent readers observe either the pre-batch or the
-// post-batch state.
+// post-batch state. Vertex-owned side indexes (dict refs, prefix radix,
+// search postings) are cleaned in one pass via the batch eviction hook so a
+// large delete pays one acquisition per index instead of one per key (#738).
 func (c *GraphCache[S, T]) DeleteVertices(keys []S) int {
 	if len(keys) == 0 {
 		return 0
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	var n int
-	for _, k := range keys {
-		if c.vertices.Delete(k) {
-			n++
-		}
-	}
-	return n
+	return len(c.vertices.DeleteMany(keys))
 }
 
 // DeleteEdges removes every supplied edge under a single write lock and

--- a/core/graphcache/batch_external_test.go
+++ b/core/graphcache/batch_external_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
+	"github.com/anaregdesign/lantern/core/search"
 )
 
 // TestAddEdgesWithExpiration_AtomicNeighborSnapshot verifies that a
@@ -209,6 +210,41 @@ func TestBatchAPIs_ReturnCounts(t *testing.T) {
 	})
 	if got != 1 {
 		t.Fatalf("DeleteEdges: got %d, want 1", got)
+	}
+}
+
+// TestDeleteVertices_ClearsPrefixAndSearchIndexes verifies the batched
+// DeleteVertices (#738) removes deleted keys from the prefix radix and the
+// search index in addition to the vertex cache, while leaving untouched keys
+// fully indexed. Content words share no bigrams (NGram{N:2} analyzer) so a
+// search match is unambiguous.
+func TestDeleteVertices_ClearsPrefixAndSearchIndexes(t *testing.T) {
+	c := graphcache.NewGraphCache[string, string](time.Minute)
+	c.EnablePrefixIndex(func(k string) string { return k })
+	c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+
+	c.PutVertex("ns:a", "alpha")
+	c.PutVertex("ns:b", "bravo")
+	c.PutVertex("keep:1", "zulu")
+
+	if n := c.DeleteVertices([]string{"ns:a", "ns:b", "missing"}); n != 2 {
+		t.Fatalf("DeleteVertices = %d, want 2", n)
+	}
+
+	if got := c.CountByPrefix("ns:"); got != 0 {
+		t.Fatalf("CountByPrefix(ns:) after DeleteVertices = %d, want 0", got)
+	}
+	if got := c.CountByPrefix("keep:"); got != 1 {
+		t.Fatalf("CountByPrefix(keep:) = %d, want 1", got)
+	}
+	for _, term := range []string{"alpha", "bravo"} {
+		if got := c.SearchVertices(term, 10, ""); got != nil {
+			t.Fatalf("SearchVertices(%q) after DeleteVertices = non-nil, want nil", term)
+		}
+	}
+	results := c.SearchVertices("zulu", 10, "")
+	if len(results) != 1 || results[0].ID != "keep:1" {
+		t.Fatalf(`SearchVertices("zulu") = %v, want [keep:1]`, results)
 	}
 }
 

--- a/core/graphcache/bench_test.go
+++ b/core/graphcache/bench_test.go
@@ -518,3 +518,69 @@ func BenchmarkSearchVertices(b *testing.B) {
 		wg.Wait()
 	})
 }
+
+func BenchmarkDeleteVertices_Indexed(b *testing.B) {
+	for _, n := range []int{1000, 10000} {
+		n := n
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			exp := time.Now().Add(time.Hour)
+			keys := make([]string, n)
+			for i := range keys {
+				keys[i] = makeKey("https://example.com", i, 32)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for iter := 0; iter < b.N; iter++ {
+				b.StopTimer()
+				c := NewGraphCache[string, string](time.Hour)
+				c.EnablePrefixIndex(func(k string) string { return k })
+				c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+				vs := make([]VertexItem[string, string], n)
+				for i, k := range keys {
+					vs[i] = VertexItem[string, string]{Key: k, Value: benchSearchCorpus[i%len(benchSearchCorpus)], Expiration: exp}
+				}
+				c.PutVerticesWithExpiration(vs)
+				b.StartTimer()
+
+				if got := c.DeleteVertices(keys); got != n {
+					b.Fatalf("DeleteVertices = %d, want %d", got, n)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkDeleteByPrefix_Indexed measures the batched DeleteByPrefix path
+// (#738): it walks the prefix radix to collect victims, then removes them in a
+// single DeleteMany that fires one batched index-maintenance pass. Setup is
+// excluded from the timer.
+func BenchmarkDeleteByPrefix_Indexed(b *testing.B) {
+	for _, n := range []int{1000, 10000} {
+		n := n
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			exp := time.Now().Add(time.Hour)
+			keys := make([]string, n)
+			for i := range keys {
+				keys[i] = makeKey("doomed:", i, 32)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for iter := 0; iter < b.N; iter++ {
+				b.StopTimer()
+				c := NewGraphCache[string, string](time.Hour)
+				c.EnablePrefixIndex(func(k string) string { return k })
+				c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+				vs := make([]VertexItem[string, string], n)
+				for i, k := range keys {
+					vs[i] = VertexItem[string, string]{Key: k, Value: benchSearchCorpus[i%len(benchSearchCorpus)], Expiration: exp}
+				}
+				c.PutVerticesWithExpiration(vs)
+				b.StartTimer()
+
+				if got := c.DeleteByPrefix(context.Background(), "doomed:", 0); got != n {
+					b.Fatalf("DeleteByPrefix = %d, want %d", got, n)
+				}
+			}
+		})
+	}
+}

--- a/core/graphcache/cache.go
+++ b/core/graphcache/cache.go
@@ -23,8 +23,8 @@ type GraphCache[S comparable, T any] struct {
 	// dict is the shared vertex-id allocator. Both the vertex cache and the
 	// edge cache reference each key through this dictionary so the heavy
 	// edge maps can be keyed by uint32 instead of S. The vertex cache holds
-	// one reference per live entry (released via SetOnEvict); the edge cache
-	// holds one reference per endpoint per edge.
+	// one reference per live entry (released via the SetOnEvictMany batch
+	// eviction hook); the edge cache holds one reference per endpoint per edge.
 	dict *dictionary[S]
 
 	// GC observability hooks. Both are optional; the cache stays metrics-free
@@ -133,7 +133,7 @@ func NewGraphCache[S comparable, T any](defaultTTL time.Duration) *GraphCache[S,
 		edges:      newEdgeCache[S](defaultTTL, dict),
 		dict:       dict,
 	}
-	vertices.SetOnEvict(c.onVertexEvicted)
+	vertices.SetOnEvictMany(c.onVerticesEvicted)
 	return c
 }
 

--- a/core/graphcache/dict.go
+++ b/core/graphcache/dict.go
@@ -167,7 +167,12 @@ func (d *dictionary[S]) resolve(id vertexID) (S, bool) {
 func (d *dictionary[S]) release(id vertexID) bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	return d.releaseLocked(id)
+}
 
+// releaseLocked is release without acquiring d.mu; the caller must already
+// hold the write lock. It is shared by release and releaseKeys.
+func (d *dictionary[S]) releaseLocked(id vertexID) bool {
 	if int(id) >= len(d.refcount) || d.refcount[id] == 0 {
 		panic("dictionary: release of unallocated vertexID")
 	}
@@ -181,6 +186,26 @@ func (d *dictionary[S]) release(id vertexID) bool {
 	d.reverse[id] = zero // drop the string reference so the GC can reclaim it
 	d.free = append(d.free, id)
 	return true
+}
+
+// releaseKeys looks up each key and drops one reference to its id, all under a
+// single write-lock acquisition. Keys that are not currently interned are
+// skipped — mirroring the per-key lookup-then-release, which no-ops when
+// the key was never interned (e.g. an edge-only endpoint with no vertex ref).
+// It is the batch sibling of lookup+release used by GraphCache's batch
+// eviction path so a large delete pays one dict.mu acquisition instead of one
+// lookup plus one release per key (#738).
+func (d *dictionary[S]) releaseKeys(keys []S) {
+	if len(keys) == 0 {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, key := range keys {
+		if id, ok := d.forward[key]; ok {
+			d.releaseLocked(id)
+		}
+	}
 }
 
 // len returns the number of currently live vertexIDs (i.e. ids with a

--- a/core/graphcache/dict_test.go
+++ b/core/graphcache/dict_test.go
@@ -70,6 +70,45 @@ func TestDictionary_RefcountAndRelease(t *testing.T) {
 	}
 }
 
+// TestDictionary_ReleaseKeys verifies the batch release drops exactly one
+// reference per supplied key under a single lock, frees ids whose refcount
+// reaches zero, and silently skips keys that are not interned (#738).
+func TestDictionary_ReleaseKeys(t *testing.T) {
+	d := newDictionary[string]()
+	a := d.intern("a") // refcount = 1
+	b := d.intern("b") // refcount = 1
+	c := d.intern("c")
+	d.acquire(c) // "c" refcount = 2
+
+	// Drop one ref each from a, b, c and ignore an absent key.
+	d.releaseKeys([]string{"a", "b", "c", "missing"})
+
+	// a and b hit zero -> freed; c had 2 refs -> still resolvable.
+	if _, ok := d.lookup("a"); ok {
+		t.Fatalf("a still resolvable after releaseKeys to zero")
+	}
+	if _, ok := d.lookup("b"); ok {
+		t.Fatalf("b still resolvable after releaseKeys to zero")
+	}
+	if _, ok := d.lookup("c"); !ok {
+		t.Fatalf("c dropped while refcount > 0")
+	}
+	if got := d.len(); got != 1 {
+		t.Fatalf("len=%d after releaseKeys, want 1 (only c remains)", got)
+	}
+	// A freed id (a's or b's) must be recycled rather than growing the space.
+	reused := d.intern("z")
+	if reused != a && reused != b {
+		t.Fatalf("freed id not recycled by releaseKeys: a=%d b=%d reused=%d", a, b, reused)
+	}
+
+	// Empty / nil input is a no-op.
+	d.releaseKeys(nil)
+	if got := d.len(); got != 2 {
+		t.Fatalf("len=%d after no-op releaseKeys, want 2", got)
+	}
+}
+
 func TestDictionary_FreelistReuse(t *testing.T) {
 	d := newDictionary[string]()
 	id1 := d.intern("a")

--- a/core/graphcache/indexes.go
+++ b/core/graphcache/indexes.go
@@ -1,17 +1,22 @@
 package graphcache
 
-// onVertexEvicted keeps all vertex-owned side structures in sync with a
-// vertex cache eviction. It is installed as cache.Cache.SetOnEvict and may be
-// invoked by Delete, Clear, or Flush. Some callers hold GraphCache.mu when the
-// hook fires and some do not, so this helper must not assume the aggregate lock
-// is held.
-func (c *GraphCache[S, T]) onVertexEvicted(key S) {
-	if c.dict != nil {
-		if id, ok := c.dict.lookup(key); ok {
-			c.dict.release(id)
-		}
+// onVerticesEvicted keeps all vertex-owned side structures in sync with a batch
+// of vertex cache evictions. It is installed as cache.Cache.SetOnEvictMany and
+// may be invoked by Delete, DeleteMany, Clear, or Flush (a single-key Delete
+// arrives here as a one-element slice). Each underlying structure (dict, prefix
+// radix, search index) is updated under a single one of its own locks for the
+// whole batch, so a namespace-wide or TTL-flush delete pays one acquisition per
+// structure instead of one per key (#738). Some callers hold GraphCache.mu when
+// the hook fires and some do not, so this helper must not assume the aggregate
+// lock is held — it touches only the inner-locked structures, never c.mu.
+func (c *GraphCache[S, T]) onVerticesEvicted(keys []S) {
+	if len(keys) == 0 {
+		return
 	}
-	c.deleteVertexIndexes(key)
+	if c.dict != nil {
+		c.dict.releaseKeys(keys)
+	}
+	c.deleteVerticesIndexes(keys)
 }
 
 // onExplicitVertexStoredLocked updates vertex secondary indexes after a caller
@@ -41,12 +46,22 @@ func (c *GraphCache[S, T]) insertVertexPrefixLocked(key S) {
 	}
 }
 
-func (c *GraphCache[S, T]) deleteVertexIndexes(key S) {
+// deleteVerticesIndexes removes a batch of keys from the prefix radix and the
+// search index, each under one of its own write locks for the whole batch. It
+// is shared by onVerticesEvicted (#738).
+func (c *GraphCache[S, T]) deleteVerticesIndexes(keys []S) {
+	if len(keys) == 0 {
+		return
+	}
 	if c.prefixIndex != nil {
-		c.prefixIndex.delete(c.prefixExtract(key))
+		prefixes := make([]string, len(keys))
+		for i, key := range keys {
+			prefixes[i] = c.prefixExtract(key)
+		}
+		c.prefixIndex.deleteMany(prefixes)
 	}
 	if c.searchIndex != nil {
-		c.searchIndex.Delete(key)
+		c.searchIndex.DeleteMany(keys)
 	}
 }
 

--- a/core/graphcache/prefix.go
+++ b/core/graphcache/prefix.go
@@ -117,11 +117,11 @@ func (c *GraphCache[S, T]) CountByPrefix(prefix string) int {
 // delete the entire matching set. When the index has not been enabled,
 // DeleteByPrefix returns 0 without touching the cache.
 //
-// Deletion goes through DeleteVertex semantics for each matched key so
-// the standard OnEvict / refcount / radix-removal chain runs uniformly.
-// Edges incident to a deleted vertex are NOT removed eagerly here \u2014
-// they will be reclaimed by the next dangling-edge flush, matching the
-// existing DeleteVertex contract.
+// Deletion routes the whole matched set through a single vertices.DeleteMany,
+// so the OnEvict / refcount / radix-removal chain runs once for the batch
+// rather than once per key (#738). Edges incident to a deleted vertex are NOT
+// removed eagerly here — they will be reclaimed by the next dangling-edge
+// flush, matching the existing DeleteVertex contract.
 func (c *GraphCache[S, T]) DeleteByPrefix(ctx context.Context, prefix string, limit int) int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -130,8 +130,8 @@ func (c *GraphCache[S, T]) DeleteByPrefix(ctx context.Context, prefix string, li
 	}
 	// Collect first, then delete. We cannot mutate the radix from inside
 	// its own walk (the walk holds radix.mu.RLock; delete needs the
-	// write lock), and even if we could, the vertex-cache OnEvict
-	// callback already calls radix.delete \u2014 which would deadlock.
+	// write lock), and even if we could, the vertex-cache eviction
+	// callback already calls radix.deleteMany — which would deadlock.
 	var victims []S
 	c.prefixIndex.walkPrefix(prefix, func(projected string) bool {
 		if err := ctx.Err(); err != nil {
@@ -147,12 +147,7 @@ func (c *GraphCache[S, T]) DeleteByPrefix(ctx context.Context, prefix string, li
 		victims = append(victims, key)
 		return true
 	})
-	deleted := 0
-	for _, k := range victims {
-		if c.vertices.Delete(k) {
-			deleted++
-		}
-	}
+	deleted := len(c.vertices.DeleteMany(victims))
 	return deleted
 }
 

--- a/core/graphcache/prefix_test.go
+++ b/core/graphcache/prefix_test.go
@@ -206,6 +206,36 @@ func TestGraphCache_PrefixIndex_DroppedOnDeleteVertex(t *testing.T) {
 	}
 }
 
+// TestGraphCache_DeleteByPrefix_ClearsSearchIndex verifies the batched
+// DeleteByPrefix (#738) drops deleted vertices from the search index as well as
+// the prefix index, leaving keys outside the prefix searchable. Content words
+// are chosen to share no bigrams (the index uses an NGram{N:2} analyzer) so a
+// match is unambiguous.
+func TestGraphCache_DeleteByPrefix_ClearsSearchIndex(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	c.EnablePrefixIndex(identityExtract)
+	c.EnableSearchIndex(textExtract)
+	c.PutVertex("doc:1", "alpha")
+	c.PutVertex("doc:2", "bravo")
+	c.PutVertex("keep:1", "zulu")
+
+	if got := c.DeleteByPrefix(context.Background(), "doc:", 0); got != 2 {
+		t.Fatalf("DeleteByPrefix(doc:) = %d, want 2", got)
+	}
+
+	// Deleted docs are gone from the search index...
+	if got := c.SearchVertices("alpha", 10, ""); got != nil {
+		t.Fatalf(`SearchVertices("alpha") after DeleteByPrefix = %v, want nil`, keys(got))
+	}
+	if got := c.SearchVertices("bravo", 10, ""); got != nil {
+		t.Fatalf(`SearchVertices("bravo") after DeleteByPrefix = %v, want nil`, keys(got))
+	}
+	// ...but the surviving doc is still indexed.
+	if got := keys(c.SearchVertices("zulu", 10, "")); !equalKeys(got, []string{"keep:1"}) {
+		t.Fatalf(`SearchVertices("zulu") after DeleteByPrefix = %v, want [keep:1]`, got)
+	}
+}
+
 func TestGraphCache_PrefixIndex_NoDoubleInsertOnRefresh(t *testing.T) {
 	c := NewGraphCache[string, string](time.Minute)
 	c.EnablePrefixIndex(identityExtract)

--- a/core/graphcache/radix.go
+++ b/core/graphcache/radix.go
@@ -142,6 +142,27 @@ func (r *radix) delete(key string) bool {
 	return false
 }
 
+// deleteMany removes every supplied key under a single write-lock
+// acquisition, decrementing size once per key actually removed, and returns
+// the number removed. Keys absent from the radix are skipped. It is the batch
+// sibling of delete used by GraphCache's batch eviction path so a large delete
+// pays one radix.mu acquisition instead of one per key (#738).
+func (r *radix) deleteMany(keys []string) int {
+	if len(keys) == 0 {
+		return 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var n int
+	for _, key := range keys {
+		if r.deleteAt(r.root, key) {
+			r.size--
+			n++
+		}
+	}
+	return n
+}
+
 func (r *radix) deleteAt(n *radixNode, key string) bool {
 	if key == "" {
 		if !n.terminal {

--- a/core/graphcache/radix_test.go
+++ b/core/graphcache/radix_test.go
@@ -141,6 +141,35 @@ func TestRadix_DeleteAndCompaction(t *testing.T) {
 	}
 }
 
+// TestRadix_DeleteMany verifies the batch delete removes every present key,
+// skips absent keys, decrements size only for keys actually removed, returns
+// that count, and is a no-op for an empty input (#738).
+func TestRadix_DeleteMany(t *testing.T) {
+	r := newRadix()
+	keys := []string{"alpha", "alphabet", "alpine", "alps", "beta"}
+	for _, k := range keys {
+		r.insert(k)
+	}
+
+	if got := r.deleteMany(nil); got != 0 {
+		t.Fatalf("deleteMany(nil) = %d, want 0", got)
+	}
+
+	// "ghost" is absent and must not be counted; "alpha" appears twice and
+	// must be counted once (the second pass is an absent-key no-op).
+	n := r.deleteMany([]string{"alpha", "alpine", "ghost", "alpha"})
+	if n != 2 {
+		t.Fatalf("deleteMany removed = %d, want 2", n)
+	}
+	want := []string{"alphabet", "alps", "beta"}
+	if got := collectAll(r); !equalSlices(got, want) {
+		t.Fatalf("after deleteMany:\n  got  %v\n  want %v", got, want)
+	}
+	if got := r.len(); got != 3 {
+		t.Fatalf("len after deleteMany: got %d want 3", got)
+	}
+}
+
 func TestRadix_EmptyKey(t *testing.T) {
 	r := newRadix()
 	if !r.insert("") {

--- a/core/graphcache/search.go
+++ b/core/graphcache/search.go
@@ -41,8 +41,9 @@ func newSearchIndex[S comparable]() *search.InvertedIndex[S, search.Document] {
 //
 // Once enabled, the index is kept in perfect lockstep with the vertex
 // lifecycle: every put (including overwrites) re-indexes the value, and
-// eviction — Delete, Clear, and TTL Flush — drops the key through the shared
-// SetOnEvict hook, so entries decay together with the vertices they describe.
+// eviction — Delete, DeleteMany, Clear, and TTL Flush — drops the key through
+// the shared SetOnEvictMany hook, so entries decay together with the vertices
+// they describe.
 // The index is a third opt-in secondary structure alongside the prefix index;
 // when it is left disabled the put / evict hot paths pay only a nil check.
 func (c *GraphCache[S, T]) EnableSearchIndex(extract func(T) search.Document) {

--- a/core/graphcache/tombstone.go
+++ b/core/graphcache/tombstone.go
@@ -112,11 +112,12 @@ func (c *GraphCache[S, T]) DeleteVerticesHLC(keys []S, ts hlc.Timestamp, expirat
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	n := 0
+	// DeleteMany batches the vertex-index maintenance into one pass (#738);
+	// it returns only the keys that were present, which is exactly the count
+	// we report. Tombstones still go on EVERY key (including absent ones) so
+	// a Delete-before-Add race is resolved by LWW once the Add arrives.
+	n := len(c.vertices.DeleteMany(keys))
 	for _, k := range keys {
-		if c.vertices.Delete(k) {
-			n++
-		}
 		c.setVertexTombstoneLocked(k, ts, expiration)
 	}
 	return n
@@ -177,11 +178,11 @@ func (c *GraphCache[S, T]) DeleteByPrefixHLC(ctx context.Context, prefix string,
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
-	n := 0
+	// victims are all live (resolveProjected confirms via the vertex cache),
+	// so DeleteMany removes them all; batch it into one index-maintenance pass
+	// (#738) and tombstone each victim.
+	n := len(c.vertices.DeleteMany(victims))
 	for _, k := range victims {
-		if c.vertices.Delete(k) {
-			n++
-		}
 		c.setVertexTombstoneLocked(k, ts, expiration)
 	}
 	return n, nil

--- a/core/graphcache/tombstone_test.go
+++ b/core/graphcache/tombstone_test.go
@@ -139,3 +139,50 @@ func TestDeleteByPrefixHLC_TombstonesPerVertex(t *testing.T) {
 		t.Fatalf("older put against tombstone: want applied=false")
 	}
 }
+
+// TestDeleteVerticesHLC_BatchTombstonesAllDeletesPresent verifies the batched
+// HLC delete (#738) still counts only keys that were present while stamping a
+// tombstone on EVERY supplied key — including absent ones — so a late
+// Delete-before-Add race is resolved by LWW once the Add arrives.
+func TestDeleteVerticesHLC_BatchTombstonesAllDeletesPresent(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	c.EnablePrefixIndex(identityExtract)
+	c.EnableSearchIndex(textExtract)
+	exp := time.Now().Add(time.Hour)
+	t0 := hlc.Timestamp{WallNs: 1000}
+	t1 := hlc.Timestamp{WallNs: 2000}
+
+	for _, k := range []string{"present:1", "present:2"} {
+		if !c.PutVertexWithExpirationHLC(k, "searchable payload", exp, t0) {
+			t.Fatalf("seed %q failed", k)
+		}
+	}
+
+	// "absent:1" was never stored; it must still receive a tombstone.
+	n := c.DeleteVerticesHLC([]string{"present:1", "present:2", "absent:1"}, t1, exp)
+	if n != 2 {
+		t.Fatalf("DeleteVerticesHLC count = %d, want 2 (only present keys)", n)
+	}
+
+	// Present keys gone from point reads and both side indexes.
+	for _, k := range []string{"present:1", "present:2"} {
+		if _, ok := c.GetVertex(k); ok {
+			t.Fatalf("%q still present after batch HLC delete", k)
+		}
+	}
+	if got := c.CountByPrefix("present:"); got != 0 {
+		t.Fatalf("CountByPrefix(present:) = %d, want 0", got)
+	}
+	if got := c.SearchVertices("searchable", 10, ""); got != nil {
+		t.Fatalf("SearchVertices after batch HLC delete = %v, want nil", keys(got))
+	}
+
+	// Tombstone fences an older Put on the absent key too.
+	if c.PutVertexWithExpirationHLC("absent:1", "late", exp, t0) {
+		t.Fatalf("older put against absent-key tombstone: want applied=false")
+	}
+	// A newer Put is still accepted (tombstone is LWW, not permanent).
+	if !c.PutVertexWithExpirationHLC("present:1", "revived", exp, hlc.Timestamp{WallNs: 3000}) {
+		t.Fatalf("newer put after tombstone: want applied=true")
+	}
+}

--- a/core/search/inverted_index.go
+++ b/core/search/inverted_index.go
@@ -106,6 +106,22 @@ func (idx *InvertedIndex[S, D]) Delete(id S) {
 	idx.deleteLocked(id)
 }
 
+// DeleteMany removes every id in ids and its postings under a single write
+// lock. Ids that were never indexed are skipped. It is the batch sibling of
+// Delete used by GraphCache's batch eviction path so a namespace-wide or
+// TTL-flush delete pays one idx.mu acquisition instead of one per document
+// (#738).
+func (idx *InvertedIndex[S, D]) DeleteMany(ids []S) {
+	if len(ids) == 0 {
+		return
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	for _, id := range ids {
+		idx.deleteLocked(id)
+	}
+}
+
 // deleteLocked removes id and its postings; callers must hold idx.mu for
 // writing. It is shared by Delete and the replace step of Index, which already
 // holds the lock—sync.Mutex is not reentrant, so Index must not call Delete.

--- a/core/search/inverted_index_test.go
+++ b/core/search/inverted_index_test.go
@@ -87,6 +87,47 @@ func TestInvertedIndexDelete(t *testing.T) {
 	}
 }
 
+// TestInvertedIndexDeleteMany verifies the batch delete removes every supplied
+// id under one lock, skips unknown ids, fully reclaims postings/forward
+// entries/length, and is a no-op for an empty input. It is the batch sibling
+// of Delete (#738).
+func TestInvertedIndexDeleteMany(t *testing.T) {
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+	idx.Index("doc1", Text("alpha beta"))
+	idx.Index("doc2", Text("beta gamma"))
+	idx.Index("doc3", Text("gamma delta"))
+
+	idx.DeleteMany(nil) // no-op
+
+	idx.DeleteMany([]string{"doc1", "missing", "doc3"})
+
+	if got := idsOf(idx.Search("alpha")); len(got) != 0 {
+		t.Fatalf(`Search("alpha") after DeleteMany = %v, want none`, got)
+	}
+	if got := idsOf(idx.Search("delta")); len(got) != 0 {
+		t.Fatalf(`Search("delta") after DeleteMany = %v, want none`, got)
+	}
+	// doc2 still owns "beta" and "gamma".
+	if got := idsOf(idx.Search("beta")); !equalStrings(got, []string{"doc2"}) {
+		t.Fatalf(`Search("beta") after DeleteMany = %v, want [doc2]`, got)
+	}
+	if got := idsOf(idx.Search("gamma")); !equalStrings(got, []string{"doc2"}) {
+		t.Fatalf(`Search("gamma") after DeleteMany = %v, want [doc2]`, got)
+	}
+
+	// Removing the last remaining doc empties every internal map.
+	idx.DeleteMany([]string{"doc2"})
+	if len(idx.postings) != 0 {
+		t.Fatalf("postings not fully reclaimed: %v", idx.postings)
+	}
+	if len(idx.docs) != 0 {
+		t.Fatalf("forward docs not fully reclaimed: %v", idx.docs)
+	}
+	if idx.totalLen != 0 {
+		t.Fatalf("totalLen not reset: %d", idx.totalLen)
+	}
+}
+
 func TestInvertedIndexReindexReplaces(t *testing.T) {
 	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
 	idx.Index("doc1", Text("alpha beta"))


### PR DESCRIPTION
## What

Implements #738: batch the vertex-owned **index maintenance** on delete so a large delete pays **one lock acquisition per side index** instead of one per key.

Before, every vertex removal fired the per-key `OnEvict` hook, which took the dict lock, the prefix-radix lock, and the search-index lock **once per key**. A `DeleteByPrefix` over N keys therefore did 3·N inner-lock acquisitions. This PR collapses that to 3 acquisitions for the whole batch.

## How

- **`core/cache`**: new `SetOnEvictMany([]S)` batch eviction hook that **takes precedence** over the per-key `SetOnEvict` (install exactly one). New `DeleteMany(keys) []S`. `Delete`/`Clear`/`Flush` route through a shared `fireEvicted`, so a single `Delete` arrives at the batch hook as a one-element slice and batch removals fire it once with the whole set. Callbacks still fire **after** `c.mu` is released (re-entrant-safe).
- **`core/search`**: `InvertedIndex.DeleteMany(ids)` — one `idx.mu` write lock for the whole batch.
- **`core/graphcache`**:
  - `radix.deleteMany`, `dict.releaseLocked` + `dict.releaseKeys` (single lock, skips absent keys), and `onVerticesEvicted` / `deleteVerticesIndexes`.
  - `NewGraphCache` wires the vertex cache via `SetOnEvictMany(c.onVerticesEvicted)`.
  - `DeleteVertices`, `DeleteByPrefix`, `DeleteVerticesHLC`, `DeleteByPrefixHLC` now delegate to `vertices.DeleteMany`. HLC deletes still **tombstone every supplied key** (including absent ones, for the Delete-before-Add race) while **counting only those present**.

Scope is Phase 1 + the `DeleteByPrefix` batch. The riskier Phase-2 `popPrefix` subtree removal is intentionally **not** in this PR.

## Tests / benchmarks

- cache: `DeleteMany`, batch-hook precedence over per-key hook, `SetOnEvictMany` for Delete/DeleteMany/Clear/Flush + clearing.
- search: `DeleteMany` (skips unknown ids, fully reclaims postings/forward/length).
- radix: `deleteMany` (counts only removed, skips absent).
- dict: `releaseKeys` (one ref per key, frees at zero, skips absent, recycles ids).
- graphcache integration: `DeleteVertices` and `DeleteByPrefix` clear **both** prefix and search indexes; `DeleteVerticesHLC` tombstones-all / deletes-present.
- benchmarks: `BenchmarkDeleteVertices_Indexed`, `BenchmarkDeleteByPrefix_Indexed` (1k/10k).

`gofmt -l` clean; `go test ./...` green under `-race` in `core/`, and green in `server/`, root, and `tests/integration/`.

Closes #738
