### PR TITLE
perf(graphcache): move search analysis out of write lock + physical-presence upsert (#739)

### DIFF
--- a/core/cache/cache.go
+++ b/core/cache/cache.go
@@ -152,6 +152,26 @@ func (c *Cache[S, T]) PutWithExpiration(key S, value T, expiration time.Time) {
 	}
 }
 
+// UpsertWithExpiration stores value for key like PutWithExpiration and reports
+// whether an entry for key was PHYSICALLY present beforehand, regardless of
+// whether that entry had already expired. It exists so layered callers can
+// detect a true first insert in a single lock cycle (vs. a Has()+Put pair, two
+// cycles) AND so an expired-but-not-yet-flushed slot is correctly treated as
+// "already present" — Has() reports such a slot as absent, which would make a
+// caller re-run first-insert side effects (e.g. interning the key again) on a
+// slot that was never released, inflating bookkeeping (#739).
+func (c *Cache[S, T]) UpsertWithExpiration(key S, value T, expiration time.Time) (physicallyExisted bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	_, physicallyExisted = c.cache[key]
+	c.cache[key] = volatile[T]{
+		value:      value,
+		expiration: expiration,
+	}
+	return physicallyExisted
+}
+
 func (c *Cache[S, T]) PutWithTTL(key S, value T, ttl time.Duration) {
 	c.PutWithExpiration(key, value, time.Now().Add(ttl))
 }

--- a/core/cache/cache_test.go
+++ b/core/cache/cache_test.go
@@ -630,3 +630,41 @@ func TestCache_OnEvictMany_Batch(t *testing.T) {
 		}
 	})
 }
+
+// TestCache_UpsertWithExpiration covers the single-lock physical-presence probe
+// added for #739: it reports whether a slot for the key existed beforehand even
+// when that slot had already expired, which Has/Get (live checks) hide.
+func TestCache_UpsertWithExpiration(t *testing.T) {
+	t.Run("reports physical presence and overwrites", func(t *testing.T) {
+		c := NewCache[string, int](time.Minute)
+		if existed := c.UpsertWithExpiration("k", 1, time.Now().Add(time.Minute)); existed {
+			t.Fatal("first upsert: physicallyExisted=true, want false")
+		}
+		if existed := c.UpsertWithExpiration("k", 2, time.Now().Add(time.Minute)); !existed {
+			t.Fatal("second upsert: physicallyExisted=false, want true")
+		}
+		if got, ok := c.Get("k"); !ok || got != 2 {
+			t.Fatalf("Get after overwrite: got=%v ok=%v want=2 true", got, ok)
+		}
+	})
+
+	t.Run("expired-but-not-flushed slot counts as present", func(t *testing.T) {
+		c := NewCache[string, int](time.Minute)
+		// Store an already-expired entry and never flush it, so the physical
+		// slot lingers while the live checks report it absent.
+		c.UpsertWithExpiration("k", 1, time.Now().Add(-time.Minute))
+		if _, ok := c.Get("k"); ok {
+			t.Fatal("Get on expired slot: ok=true, want false")
+		}
+		if c.Has("k") {
+			t.Fatal("Has on expired slot: true, want false")
+		}
+		// Upsert, by contrast, must see the lingering physical slot.
+		if existed := c.UpsertWithExpiration("k", 2, time.Now().Add(time.Minute)); !existed {
+			t.Fatal("upsert over expired-not-flushed slot: physicallyExisted=false, want true")
+		}
+		if got, ok := c.Get("k"); !ok || got != 2 {
+			t.Fatalf("Get after reviving overwrite: got=%v ok=%v want=2 true", got, ok)
+		}
+	})
+}

--- a/core/graphcache/batch.go
+++ b/core/graphcache/batch.go
@@ -3,7 +3,9 @@ package graphcache
 import (
 	"time"
 
+	"github.com/anaregdesign/lantern/core/cache"
 	"github.com/anaregdesign/lantern/core/hlc"
+	"github.com/anaregdesign/lantern/core/search"
 )
 
 // VertexItem is a single (key, value, expiration) tuple supplied to
@@ -40,15 +42,55 @@ type EdgeKey[S comparable] struct {
 // write lock. Concurrent readers observe either the pre-batch or the
 // post-batch state — never an intermediate snapshot where some keys are
 // present and others are not.
+//
+// Search-document analysis (tokenization) for the whole batch runs BEFORE the
+// lock is taken (see prepareSearchDocs) so the expensive per-vertex work never
+// serializes other writers behind the aggregate graph lock; only the cheap
+// store + postings mutation happens under c.mu (#739).
 func (c *GraphCache[S, T]) PutVerticesWithExpiration(items []VertexItem[S, T]) {
 	if len(items) == 0 {
 		return
 	}
+	now := time.Now()
+	prepared := c.prepareSearchDocs(items, now)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	for _, it := range items {
-		c.putLocalVertexLocked(it.Key, it.Value, it.Expiration)
+	for i := range items {
+		c.putLocalVertexLockedAt(items[i].Key, items[i].Value, items[i].Expiration, now, preparedAt(prepared, i))
 	}
+}
+
+// prepareSearchDocs analyzes the search document of every live item OUTSIDE
+// c.mu so the per-vertex tokenization never runs under the aggregate graph lock
+// (#739). It returns nil when no search index is installed — the overwhelmingly
+// common case pays a single nil check and no allocation — and otherwise a slice
+// aligned 1:1 with items. Born-expired items (which putLocalVertexLockedAt
+// deletes rather than stores) are left as the zero PreparedDocument and never
+// indexed, so their analysis is skipped. Safe to call without c.mu held:
+// c.searchIndex and c.searchExtract are installed once by EnableSearchIndex
+// before any vertex is stored and never mutated afterward.
+func (c *GraphCache[S, T]) prepareSearchDocs(items []VertexItem[S, T], now time.Time) []search.PreparedDocument {
+	if c.searchIndex == nil {
+		return nil
+	}
+	prepared := make([]search.PreparedDocument, len(items))
+	for i := range items {
+		if cache.IsLiveAt(items[i].Expiration, now) {
+			prepared[i] = c.searchIndex.Prepare(c.searchExtract(items[i].Value))
+		}
+	}
+	return prepared
+}
+
+// preparedAt returns a pointer to the i-th prepared document, or nil when no
+// search index produced a batch (prepared == nil) so the callee falls back to
+// inline analysis. The pointer is safe to take because prepared is a
+// fixed-size slice that is never appended to after prepareSearchDocs returns.
+func preparedAt(prepared []search.PreparedDocument, i int) *search.PreparedDocument {
+	if prepared == nil {
+		return nil
+	}
+	return &prepared[i]
 }
 
 // AddEdgesWithExpiration additively writes every supplied edge under a
@@ -162,13 +204,16 @@ func (c *GraphCache[S, T]) PutVerticesWithExpirationHLC(items []VertexItem[S, T]
 	if len(items) == 0 {
 		return
 	}
+	now := time.Now()
+	prepared := c.prepareSearchDocs(items, now)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	for _, it := range items {
+	for i := range items {
+		it := items[i]
 		if !c.vertexWriteAllowedLocked(it.Key, ts) {
 			continue
 		}
-		c.putLocalVertexLocked(it.Key, it.Value, it.Expiration)
+		c.putLocalVertexLockedAt(it.Key, it.Value, it.Expiration, now, preparedAt(prepared, i))
 		c.recordVertexHLCLocked(it.Key, ts)
 		c.clearVertexTombstoneLocked(it.Key)
 	}

--- a/core/graphcache/bench_test.go
+++ b/core/graphcache/bench_test.go
@@ -584,3 +584,64 @@ func BenchmarkDeleteByPrefix_Indexed(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkPutVerticesIndexed measures the batch vertex-write path with the
+// search index disabled vs enabled, and under concurrency. Since #739 the
+// per-document analysis (tokenization) runs BEFORE the aggregate write lock is
+// taken, so the Indexed arms hold the lock only for the cheap store + postings
+// mutation. The Parallel arm is the headline: multiple writers batch into the
+// same cache, where shrinking the locked critical section lifts throughput.
+// Run with -benchmem.
+func BenchmarkPutVerticesIndexed(b *testing.B) {
+	const batch = 256
+	exp := time.Now().Add(time.Hour)
+
+	makeBatch := func(prefix string) []VertexItem[string, string] {
+		items := make([]VertexItem[string, string], batch)
+		for i := range items {
+			items[i] = VertexItem[string, string]{
+				Key:        makeKey(prefix, i, 32),
+				Value:      benchSearchCorpus[i%len(benchSearchCorpus)],
+				Expiration: exp,
+			}
+		}
+		return items
+	}
+
+	b.Run("SearchDisabled", func(b *testing.B) {
+		c := NewGraphCache[string, string](time.Hour)
+		items := makeBatch("k")
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			c.PutVerticesWithExpiration(items)
+		}
+	})
+
+	b.Run("SearchEnabled", func(b *testing.B) {
+		c := NewGraphCache[string, string](time.Hour)
+		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+		items := makeBatch("k")
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			c.PutVerticesWithExpiration(items)
+		}
+	})
+
+	b.Run("SearchEnabledParallel", func(b *testing.B) {
+		c := NewGraphCache[string, string](time.Hour)
+		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+		var worker atomic.Int64
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			// Each goroutine writes into its own key namespace so the run
+			// exercises concurrent inserts rather than pure last-write churn.
+			items := makeBatch(fmt.Sprintf("w%d-", worker.Add(1)))
+			for pb.Next() {
+				c.PutVerticesWithExpiration(items)
+			}
+		})
+	})
+}

--- a/core/graphcache/cache.go
+++ b/core/graphcache/cache.go
@@ -168,15 +168,39 @@ func (c *GraphCache[S, T]) EnablePrefixIndex(extract func(S) string) {
 	c.headByTail = make(map[vertexID]*headIndex)
 }
 
-// putVertexLocked inserts (or refreshes) a vertex entry, interning the key
-// in the dictionary exactly once per net live entry. Caller must hold c.mu.
+// putVertexLocked inserts (or refreshes) a vertex entry with its search
+// document analyzed inline (under c.mu). It backs the replicated apply path
+// (PutVertexWithExpirationHLC) and the inline-analysis fallback for single
+// local writes; batch writers precompute the search document outside c.mu and
+// call upsertVertexLocked with it directly. Caller must hold c.mu.
 func (c *GraphCache[S, T]) putVertexLocked(key S, value T, expiration time.Time) {
-	firstInsert := !c.vertices.Has(key)
-	if c.dict != nil && firstInsert {
-		c.dict.intern(key)
+	c.upsertVertexLocked(key, value, expiration, nil)
+}
+
+// upsertVertexLocked stores/refreshes the vertex and updates its secondary
+// indexes in a single inner-cache lock cycle. physicallyExisted (true when a
+// slot for key was present even if already expired) drives the once-per-slot
+// side effects — dictionary interning and prefix insertion — so an
+// expired-but-not-yet-flushed overwrite neither re-interns the key (which would
+// inflate its dictionary refcount past the single live slot) nor re-inserts it
+// into the prefix index. When prepared is non-nil its pre-analyzed tokens are
+// applied to the search index — analysis having run outside c.mu — otherwise
+// the document is analyzed inline. Caller must hold c.mu (#739).
+func (c *GraphCache[S, T]) upsertVertexLocked(key S, value T, expiration time.Time, prepared *search.PreparedDocument) {
+	physicallyExisted := c.vertices.UpsertWithExpiration(key, value, expiration)
+	if !physicallyExisted {
+		if c.dict != nil {
+			c.dict.intern(key)
+		}
+		c.insertVertexPrefixLocked(key)
 	}
-	c.vertices.PutWithExpiration(key, value, expiration)
-	c.onExplicitVertexStoredLocked(key, value, firstInsert)
+	if c.searchIndex != nil {
+		if prepared != nil {
+			c.searchIndex.IndexPrepared(key, *prepared)
+		} else {
+			c.searchIndex.Index(key, c.searchExtract(value))
+		}
+	}
 }
 
 // putLocalVertexLocked is the client-write entry that backs
@@ -194,7 +218,17 @@ func (c *GraphCache[S, T]) putVertexLocked(key S, value T, expiration time.Time)
 // a per-key watermark after the store, so it keeps calling putVertexLocked
 // directly. Caller must hold c.mu.
 func (c *GraphCache[S, T]) putLocalVertexLocked(key S, value T, expiration time.Time) {
-	if !cache.IsLiveAt(expiration, time.Now()) {
+	c.putLocalVertexLockedAt(key, value, expiration, time.Now(), nil)
+}
+
+// putLocalVertexLockedAt is putLocalVertexLocked with the liveness clock and an
+// optional precomputed search document supplied by the caller. A batch writer
+// samples time.Now() once for the whole batch and analyzes every search
+// document outside c.mu (see prepareSearchDocs), then calls this per item so the
+// only work under c.mu is the cheap store + postings mutation. A nil prepared
+// falls back to inline analysis. Caller must hold c.mu (#739).
+func (c *GraphCache[S, T]) putLocalVertexLockedAt(key S, value T, expiration, now time.Time, prepared *search.PreparedDocument) {
+	if !cache.IsLiveAt(expiration, now) {
 		// Dead on arrival. Delete is a cheap map-miss when the key is absent
 		// (the common churn case) and fires the eviction hook — releasing the
 		// dictionary reference and dropping prefix/search postings — when it is
@@ -202,7 +236,7 @@ func (c *GraphCache[S, T]) putLocalVertexLocked(key S, value T, expiration time.
 		c.vertices.Delete(key)
 		return
 	}
-	c.putVertexLocked(key, value, expiration)
+	c.upsertVertexLocked(key, value, expiration, prepared)
 }
 
 // ensureVertexLocked auto-creates an endpoint vertex (used by edge writes)

--- a/core/graphcache/cache_test.go
+++ b/core/graphcache/cache_test.go
@@ -1419,3 +1419,56 @@ func TestSearchIndexStats(t *testing.T) {
 // ContribID.IsZero distinguishes the zero value (no identity) from a
 // populated one with a low byte — guards against accidental "all bytes
 // must be set" implementations.
+
+// TestGraphCache_DictRefcountStableAcrossExpiredOverwrite guards the #739 fix:
+// overwriting a vertex whose slot has expired but not yet been flushed must NOT
+// re-intern the key. The old !Has() probe reported the lingering expired slot as
+// absent, so the overwrite re-interned the key and inflated its dictionary
+// refcount past the single live slot it represents — a slow leak under a churn
+// of short-TTL keys rewritten before the GC sweep runs. The physical-presence
+// upsert keeps refcount pinned at one for both the single and batch put paths.
+func TestGraphCache_DictRefcountStableAcrossExpiredOverwrite(t *testing.T) {
+	setupExpiredSlot := func(t *testing.T, c *GraphCache[string, string]) vertexID {
+		// putVertexLocked stores unconditionally (no born-expired gate), so a
+		// past expiration yields exactly the lingering "expired, interned once,
+		// not yet flushed" state a live put reaches once its TTL elapses.
+		c.mu.Lock()
+		c.putVertexLocked("k", "v1", time.Now().Add(-time.Minute))
+		c.mu.Unlock()
+		id, ok := c.dict.lookup("k")
+		if !ok {
+			t.Fatal("setup: key not interned")
+		}
+		if got := c.dict.refcount[id]; got != 1 {
+			t.Fatalf("setup: refcount=%d, want 1", got)
+		}
+		return id
+	}
+	assertStable := func(t *testing.T, c *GraphCache[string, string], id vertexID) {
+		if got := c.dict.refcount[id]; got != 1 {
+			t.Fatalf("refcount after expired overwrite = %d, want 1", got)
+		}
+		if got := c.dict.len(); got != 1 {
+			t.Fatalf("dict.len after expired overwrite = %d, want 1", got)
+		}
+		if got, ok := c.GetVertex("k"); !ok || got != "v2" {
+			t.Fatalf("GetVertex after overwrite: got=%q ok=%v want v2 true", got, ok)
+		}
+	}
+
+	t.Run("single put", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		id := setupExpiredSlot(t, c)
+		c.PutVertexWithExpiration("k", "v2", time.Now().Add(time.Minute))
+		assertStable(t, c, id)
+	})
+
+	t.Run("batch put", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		id := setupExpiredSlot(t, c)
+		c.PutVerticesWithExpiration([]VertexItem[string, string]{
+			{Key: "k", Value: "v2", Expiration: time.Now().Add(time.Minute)},
+		})
+		assertStable(t, c, id)
+	})
+}

--- a/core/graphcache/indexes.go
+++ b/core/graphcache/indexes.go
@@ -19,19 +19,6 @@ func (c *GraphCache[S, T]) onVerticesEvicted(keys []S) {
 	c.deleteVerticesIndexes(keys)
 }
 
-// onExplicitVertexStoredLocked updates vertex secondary indexes after a caller
-// has stored an explicit user value. Prefix membership changes only on first
-// insert, while search postings refresh on every put because overwrites can
-// change the indexed document. Caller must hold c.mu.
-func (c *GraphCache[S, T]) onExplicitVertexStoredLocked(key S, value T, firstInsert bool) {
-	if firstInsert {
-		c.insertVertexPrefixLocked(key)
-	}
-	if c.searchIndex != nil {
-		c.searchIndex.Index(key, c.searchExtract(value))
-	}
-}
-
 // onEndpointVertexCreatedLocked updates the vertex-side indexes for an
 // auto-created edge endpoint. Endpoint creation records key existence for
 // prefix scans but deliberately does not index search content: the zero T value

--- a/core/graphcache/prefix_test.go
+++ b/core/graphcache/prefix_test.go
@@ -358,3 +358,26 @@ func BenchmarkPrefixScan(b *testing.B) {
 		})
 	}
 }
+
+// TestGraphCache_PutVertices_PrefixStableAcrossExpiredOverwrite confirms the
+// #739 physical-presence upsert keeps prefix membership correct (no leak, no
+// double count) when a batch overwrites a vertex whose slot expired but was not
+// yet flushed: the once-per-slot prefix insert is now keyed on physical
+// presence, so the overwrite neither re-inserts nor drops the radix entry.
+func TestGraphCache_PutVertices_PrefixStableAcrossExpiredOverwrite(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	c.EnablePrefixIndex(identityExtract)
+	// Seed an expired-but-not-flushed slot through the unconditional store path.
+	c.mu.Lock()
+	c.putVertexLocked("user:1", "v1", time.Now().Add(-time.Minute))
+	c.mu.Unlock()
+	if got := c.CountByPrefix("user:"); got != 1 {
+		t.Fatalf("CountByPrefix after seed = %d, want 1", got)
+	}
+	c.PutVerticesWithExpiration([]VertexItem[string, string]{
+		{Key: "user:1", Value: "v2", Expiration: time.Now().Add(time.Minute)},
+	})
+	if got := c.CountByPrefix("user:"); got != 1 {
+		t.Fatalf("CountByPrefix after overwrite = %d, want 1", got)
+	}
+}

--- a/core/graphcache/search_test.go
+++ b/core/graphcache/search_test.go
@@ -299,3 +299,79 @@ func sameSet(got, want []string) bool {
 	}
 	return true
 }
+
+// TestGraphCache_PutVertices_SearchLifecycle verifies that moving search-document
+// analysis outside the aggregate write lock (#739) keeps the batch put path in
+// perfect lockstep with the search index: hits are visible synchronously after
+// the batch returns, an overwrite drops the stale document, duplicate keys in
+// one batch keep last-write semantics, and a born-expired item is neither stored
+// nor indexed. Test words have mutually disjoint bigrams so the NGram(2)
+// analyzer cannot produce spurious cross-matches.
+func TestGraphCache_PutVertices_SearchLifecycle(t *testing.T) {
+	future := func() time.Time { return time.Now().Add(time.Minute) }
+
+	t.Run("batch puts are searchable synchronously", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract)
+		c.PutVerticesWithExpiration([]VertexItem[string, string]{
+			{Key: "a", Value: "alpha", Expiration: future()},
+			{Key: "b", Value: "bravo", Expiration: future()},
+		})
+		if got := keys(c.SearchVertices("alpha", 10, "")); !equalKeys(got, []string{"a"}) {
+			t.Fatalf(`Search("alpha") = %v, want [a]`, got)
+		}
+		if got := keys(c.SearchVertices("bravo", 10, "")); !equalKeys(got, []string{"b"}) {
+			t.Fatalf(`Search("bravo") = %v, want [b]`, got)
+		}
+	})
+
+	t.Run("overwrite drops stale document", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract)
+		c.PutVerticesWithExpiration([]VertexItem[string, string]{
+			{Key: "a", Value: "alpha", Expiration: future()},
+		})
+		c.PutVerticesWithExpiration([]VertexItem[string, string]{
+			{Key: "a", Value: "zulu", Expiration: future()},
+		})
+		if got := c.SearchVertices("alpha", 10, ""); got != nil {
+			t.Fatalf(`Search("alpha") after overwrite = %v, want nil`, keys(got))
+		}
+		if got := keys(c.SearchVertices("zulu", 10, "")); !equalKeys(got, []string{"a"}) {
+			t.Fatalf(`Search("zulu") after overwrite = %v, want [a]`, got)
+		}
+	})
+
+	t.Run("duplicate keys in one batch keep last write", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract)
+		c.PutVerticesWithExpiration([]VertexItem[string, string]{
+			{Key: "a", Value: "alpha", Expiration: future()},
+			{Key: "a", Value: "zulu", Expiration: future()},
+		})
+		if got := c.SearchVertices("alpha", 10, ""); got != nil {
+			t.Fatalf(`Search("alpha") = %v, want nil (last write wins)`, keys(got))
+		}
+		if got := keys(c.SearchVertices("zulu", 10, "")); !equalKeys(got, []string{"a"}) {
+			t.Fatalf(`Search("zulu") = %v, want [a]`, got)
+		}
+	})
+
+	t.Run("born-expired item is neither stored nor indexed", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract)
+		c.PutVerticesWithExpiration([]VertexItem[string, string]{
+			{Key: "live", Value: "alpha", Expiration: future()},
+			{Key: "dead", Value: "bravo", Expiration: time.Now().Add(-time.Minute)},
+		})
+		if _, ok := c.GetVertex("dead"); ok {
+			t.Fatal("born-expired vertex was stored")
+		}
+		if got := c.SearchVertices("bravo", 10, ""); got != nil {
+			t.Fatalf(`Search("bravo") = %v, want nil (born-expired not indexed)`, keys(got))
+		}
+		if got := keys(c.SearchVertices("alpha", 10, "")); !equalKeys(got, []string{"live"}) {
+			t.Fatalf(`Search("alpha") = %v, want [live]`, got)
+		}
+	})
+}

--- a/core/search/inverted_index.go
+++ b/core/search/inverted_index.go
@@ -69,14 +69,68 @@ func NewInvertedIndex[S comparable, D Document](analyzer Analyzer, scorer Scorer
 // postings, so re-indexing a mutated document leaves no stale terms behind;
 // Index therefore doubles as update. A document with no analyzable terms simply
 // removes id.
+//
+// Index is the analyze-then-write convenience wrapper over Prepare +
+// IndexPrepared: analysis runs outside idx.mu and only the cheap postings
+// mutation happens under it. Callers that want to keep analysis off a hotter
+// lock of their own (e.g. a layered cache writing under its aggregate lock)
+// should call Prepare before taking that lock and IndexPrepared after.
 func (idx *InvertedIndex[S, D]) Index(id S, doc D) {
-	// Analyze outside the lock: the analyzer is immutable and stateless, and
-	// tokenization is the expensive part we do not want under the write lock.
-	tokens := idx.analyzer.Analyze(doc.String())
+	idx.IndexPrepared(id, idx.Prepare(doc))
+}
 
+// PreparedDocument carries the analyzed tokens of a document so the expensive
+// analysis (doc.String() + tokenization) can run outside the index write lock.
+// Produce one with Prepare and apply it with IndexPrepared or IndexManyPrepared.
+// The zero value is a valid empty document: applying it removes the id, matching
+// Index of a document with no analyzable terms.
+type PreparedDocument struct {
+	tokens []Token
+}
+
+// PreparedItem pairs an id with its PreparedDocument for IndexManyPrepared.
+type PreparedItem[S comparable] struct {
+	ID       S
+	Prepared PreparedDocument
+}
+
+// Prepare analyzes doc.String() WITHOUT taking the index lock and returns the
+// tokens IndexPrepared needs. The analyzer is immutable and stateless, so
+// Prepare is safe to call concurrently and from outside any of the caller's
+// locks.
+func (idx *InvertedIndex[S, D]) Prepare(doc D) PreparedDocument {
+	return PreparedDocument{tokens: idx.analyzer.Analyze(doc.String())}
+}
+
+// IndexPrepared records id's postings from a PreparedDocument produced by
+// Prepare, taking idx.mu only for the postings mutation. Replace semantics match
+// Index: any previous postings for id are dropped first, and an empty prepared
+// document simply removes id.
+func (idx *InvertedIndex[S, D]) IndexPrepared(id S, prepared PreparedDocument) {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
+	idx.indexPreparedLocked(id, prepared.tokens)
+}
 
+// IndexManyPrepared applies a batch of prepared documents under a SINGLE index
+// write lock. Items are applied in slice order, so a repeated id keeps
+// last-write semantics. It is the batch sibling of IndexPrepared for callers
+// (e.g. batch vertex writes) that have no other per-id work to interleave
+// between the postings updates (#739).
+func (idx *InvertedIndex[S, D]) IndexManyPrepared(items []PreparedItem[S]) {
+	if len(items) == 0 {
+		return
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	for _, it := range items {
+		idx.indexPreparedLocked(it.ID, it.Prepared.tokens)
+	}
+}
+
+// indexPreparedLocked is the shared postings-mutation core of IndexPrepared and
+// IndexManyPrepared; callers must hold idx.mu for writing.
+func (idx *InvertedIndex[S, D]) indexPreparedLocked(id S, tokens []Token) {
 	// Replace semantics: drop any postings from a previous Index(id, ...)
 	// before recording the new ones.
 	idx.deleteLocked(id)

--- a/core/search/inverted_index_test.go
+++ b/core/search/inverted_index_test.go
@@ -238,3 +238,69 @@ func TestInvertedIndexConcurrent(t *testing.T) {
 		t.Fatalf(`Search("beta") returned %d docs, want %d`, got, want)
 	}
 }
+
+// TestInvertedIndexPrepared covers the Prepare / IndexPrepared split that lets
+// callers analyze a document outside the index write lock (#739). The
+// analyze-then-index result must be byte-for-byte equivalent to Index, an empty
+// prepared document must remove the id like Index of an unanalyzable document,
+// and IndexManyPrepared must apply a batch under one lock with last-write
+// semantics.
+func TestInvertedIndexPrepared(t *testing.T) {
+	t.Run("IndexPrepared matches Index", func(t *testing.T) {
+		viaIndex := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+		viaIndex.Index("doc1", Text("Alpha Beta"))
+		viaIndex.Index("doc2", Text("beta gamma"))
+
+		viaPrepared := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+		viaPrepared.IndexPrepared("doc1", viaPrepared.Prepare(Text("Alpha Beta")))
+		viaPrepared.IndexPrepared("doc2", viaPrepared.Prepare(Text("beta gamma")))
+
+		for _, q := range []string{"alpha", "beta", "gamma", "alpha gamma"} {
+			a := idsOf(viaIndex.Search(q))
+			b := idsOf(viaPrepared.Search(q))
+			sort.Strings(a)
+			sort.Strings(b)
+			if !equalStrings(a, b) {
+				t.Fatalf("Search(%q): Index=%v IndexPrepared=%v", q, a, b)
+			}
+		}
+	})
+
+	t.Run("empty prepared removes id", func(t *testing.T) {
+		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+		idx.IndexPrepared("doc1", idx.Prepare(Text("alpha beta")))
+		// Re-index doc1 with a document that analyzes to no terms: its postings
+		// must be dropped, matching Index's replace-with-empty behavior.
+		idx.IndexPrepared("doc1", idx.Prepare(Text("   ")))
+		if got := idsOf(idx.Search("alpha")); len(got) != 0 {
+			t.Fatalf(`Search("alpha") after empty re-index = %v, want none`, got)
+		}
+	})
+
+	t.Run("IndexManyPrepared applies batch last-write", func(t *testing.T) {
+		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+		// doc1 appears twice; the later item must win (replace semantics in
+		// slice order). doc2's first document is later replaced by an empty one,
+		// so it must be absent at the end.
+		items := []PreparedItem[string]{
+			{ID: "doc1", Prepared: idx.Prepare(Text("alpha"))},
+			{ID: "doc2", Prepared: idx.Prepare(Text("beta"))},
+			{ID: "doc1", Prepared: idx.Prepare(Text("gamma"))},
+			{ID: "doc2", Prepared: idx.Prepare(Text("   "))},
+		}
+		idx.IndexManyPrepared(items)
+
+		if got := idsOf(idx.Search("alpha")); len(got) != 0 {
+			t.Fatalf(`Search("alpha") = %v, want none (replaced by gamma)`, got)
+		}
+		if got := idsOf(idx.Search("gamma")); !equalStrings(got, []string{"doc1"}) {
+			t.Fatalf(`Search("gamma") = %v, want [doc1]`, got)
+		}
+		if got := idsOf(idx.Search("beta")); len(got) != 0 {
+			t.Fatalf(`Search("beta") = %v, want none (doc2 emptied)`, got)
+		}
+
+		// Empty batch is a no-op and must not panic.
+		idx.IndexManyPrepared(nil)
+	})
+}


### PR DESCRIPTION
## Summary

Implements #739: move the search-document analysis off the aggregate graph write lock for batch vertex writes, and replace the live `!Has()` first-insert probe with a single-lock **physical-presence** upsert.

Before this change `PutVerticesWithExpiration` / `PutVerticesWithExpirationHLC` ran `InvertedIndex.Index` — which tokenizes the document — **while holding `c.mu`**, so the expensive analysis serialized every concurrent writer. Now the whole batch is analyzed *before* the lock is taken; only the cheap store + postings mutation happens under `c.mu`.

## Fact-check (verified against code)

- `putVertexLocked` used `firstInsert := !c.vertices.Has(key)` (a **live** check) then `PutWithExpiration` — two inner-cache lock cycles per item. ✅
- **Latent correctness bug:** overwriting a vertex whose slot had expired but not yet been flushed made `Has()` report it absent → `firstInsert=true` → `dict.intern(key)` ran again, inflating the key's refcount to 2 for a single live slot (no eviction released the old ref). ✅ Fixed here and covered by a regression test that fails on the old code.
- `InvertedIndex.Index` analyzed outside `idx.mu` but was invoked **under `GraphCache.mu`**, putting tokenization on the aggregate lock. ✅

## Changes

- **core/search**: `Prepare` / `IndexPrepared` / `IndexManyPrepared` (+ `PreparedDocument`, `PreparedItem`); `Index` refactored to `Prepare`+`IndexPrepared` (identical behavior).
- **core/cache**: `UpsertWithExpiration(key, value, expiration) (physicallyExisted bool)` — physical presence in one lock cycle; an expired-not-flushed slot reads as present.
- **core/graphcache**: `putVertexLocked` → new `upsertVertexLocked` keyed on physical presence (fixes the double-intern); batch paths sample `time.Now()` once and precompute prepared docs via `prepareSearchDocs` outside `c.mu`, applying them per stored item (per-item, not deferred, so interleaved born-expired deletes stay correct). Single-write and replicated-apply (`...HLC`) paths fall back to inline analysis through the same upsert.

## Testing

- `gofmt -l` clean; `go vet` clean.
- `cd core && go test ./... -race`, `cd server && go test ./...`, root `go test ./...`, plus `pb` / `sdks/go` / `mcp` — all green.
- New unit tests: search Prepare/IndexPrepared/IndexManyPrepared equivalence + batch last-write; cache physical-presence (incl. expired slot); graphcache dict-refcount stability across expired overwrite (single + batch), batch search lifecycle (synchronous visibility, overwrite drops stale, duplicate-key last-write, born-expired neither stored nor indexed), prefix stability across expired overwrite.
- New benchmark `BenchmarkPutVerticesIndexed` (SearchDisabled / SearchEnabled / SearchEnabledParallel).

Closes #739
