### PR TITLE
perf(graphcache): snapshot edge scan before invoking visitor (#742)

### DIFF
--- a/core/graphcache/bench_test.go
+++ b/core/graphcache/bench_test.go
@@ -1,6 +1,7 @@
 package graphcache
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"strings"
@@ -298,4 +299,35 @@ func BenchmarkPutVertex_Search(b *testing.B) {
 			c.PutVertexWithExpiration(makeKey("k", i, 24), benchSearchCorpus[i%len(benchSearchCorpus)], exp)
 		}
 	})
+}
+
+// BenchmarkScanEdgesByPrefix measures the edge-prefix scan after #742 moved the
+// visitor out of the read lock: matching rows are snapshotted under c.mu.RLock
+// and the visitor replays after release. The headline cost surfaced here is the
+// snapshot allocation (one row per matched edge, visible under -benchmem); the
+// win it buys — a slow visitor no longer holding the lock against writers — is
+// asserted for correctness by TestGraphCache_ScanEdgesByPrefix_CallbackReentrant
+// rather than timed here.
+func BenchmarkScanEdgesByPrefix(b *testing.B) {
+	for _, s := range smallScales(testing.Short()) {
+		s := s
+		b.Run(s.name, func(b *testing.B) {
+			c := NewGraphCache[string, string](time.Hour)
+			c.EnablePrefixIndex(func(k string) string { return k })
+			populate(b, c, s)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var n int
+				c.ScanEdgesByPrefix(context.Background(), "https://example.com", "",
+					func(_ string, _ string, _ string, _ string, _ float32, _ time.Time) bool {
+						n++
+						return true
+					})
+				if n == 0 {
+					b.Fatal("scan matched no edges")
+				}
+			}
+		})
+	}
 }

--- a/core/graphcache/edge_prefix.go
+++ b/core/graphcache/edge_prefix.go
@@ -27,28 +27,88 @@ import (
 // is disabled. The two paths emit identical (tailProj, headProj) sets
 // for any given graph state.
 //
-// Locking contract is identical to ScanByPrefix: the walk holds
-// c.mu.RLock for its duration. Callers MUST NOT invoke any GraphCache
-// write method from inside fn. Long-running fn bodies starve writers;
-// callers that need to do non-trivial per-edge work should accumulate
-// into a slice and process after ScanEdgesByPrefix returns.
+// Locking contract mirrors ScanByPrefix (#742): the matching edge rows are
+// collected into a point-in-time snapshot under c.mu.RLock, the lock is
+// released, and only THEN is fn invoked per row. Because fn runs after the
+// lock is dropped, a slow visitor no longer starves writers for the whole
+// scan, and fn MAY call back into GraphCache (including write methods)
+// without risking sync.RWMutex reentrancy. The tradeoff is that fn observes
+// a consistent snapshot taken at collection time, not necessarily the latest
+// state after the lock was released, and an unbounded scan buffers one row
+// per matching edge — callers that need to bound memory should scope the
+// scan with prefixes or page at the service layer.
 //
-// Returns false when the prefix index is not enabled or fn requested an
-// early stop; true on a clean exhaustion of the matching set.
+// Returns false when the prefix index is not enabled, when ctx is cancelled,
+// or when fn requested an early stop; true on a clean exhaustion of the
+// matching set.
 func (c *GraphCache[S, T]) ScanEdgesByPrefix(
 	ctx context.Context,
 	tailPrefix, headPrefix string,
 	fn func(tailProjected string, tail S, headProjected string, head S, weight float32, expiration time.Time) bool,
 ) bool {
+	snapshot, enabled, collected := c.collectEdgeScanRows(ctx, tailPrefix, headPrefix)
+	if !enabled {
+		return false
+	}
+	// Collection was interrupted by ctx cancellation; report the walk as
+	// incomplete even if some rows were buffered.
+	if !collected {
+		return false
+	}
+	for i := range snapshot {
+		if err := ctx.Err(); err != nil {
+			return false
+		}
+		r := &snapshot[i]
+		if !fn(r.tailProj, r.tail, r.headProj, r.head, r.weight, r.expiration) {
+			return false
+		}
+	}
+	return true
+}
+
+// edgeScanRow is one matched (tail, head) edge captured during the locked
+// collection phase of ScanEdgesByPrefix so the visitor can run after the read
+// lock is released (#742).
+type edgeScanRow[S comparable] struct {
+	tailProj   string
+	tail       S
+	headProj   string
+	head       S
+	weight     float32
+	expiration time.Time
+}
+
+// collectEdgeScanRows gathers every matching edge into a snapshot under a
+// single c.mu.RLock, reusing the same fast/fallback head walk as the live
+// scan. enabled is false when the prefix index is disabled (the caller maps
+// this to a false return); collected is false when ctx was cancelled mid-walk.
+// The visitor is NOT called here — collection appends rows and always keeps
+// going, so early-stop is honoured later during replay, matching ScanByPrefix.
+func (c *GraphCache[S, T]) collectEdgeScanRows(
+	ctx context.Context,
+	tailPrefix, headPrefix string,
+) (snapshot []edgeScanRow[S], enabled, collected bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.prefixIndex == nil {
-		return false
+		return nil, false, false
 	}
-	completed := true
+	collected = true
+	collect := func(tailProj string, tail S, headProj string, head S, weight float32, expiration time.Time) bool {
+		snapshot = append(snapshot, edgeScanRow[S]{
+			tailProj:   tailProj,
+			tail:       tail,
+			headProj:   headProj,
+			head:       head,
+			weight:     weight,
+			expiration: expiration,
+		})
+		return true
+	}
 	c.prefixIndex.walkPrefix(tailPrefix, func(tailProj string) bool {
 		if err := ctx.Err(); err != nil {
-			completed = false
+			collected = false
 			return false
 		}
 		tail, ok := c.resolveProjected(tailProj)
@@ -59,19 +119,14 @@ func (c *GraphCache[S, T]) ScanEdgesByPrefix(
 		if !ok || len(heads) == 0 {
 			return true
 		}
-		var ok2 bool
 		if c.headByTail != nil {
-			ok2 = c.scanTailHeadsFast(tail, tailProj, headPrefix, heads, fn)
+			c.scanTailHeadsFast(tail, tailProj, headPrefix, heads, collect)
 		} else {
-			ok2 = c.scanTailHeadsFallback(tail, tailProj, headPrefix, heads, fn)
-		}
-		if !ok2 {
-			completed = false
-			return false
+			c.scanTailHeadsFallback(tail, tailProj, headPrefix, heads, collect)
 		}
 		return true
 	})
-	return completed
+	return snapshot, true, collected
 }
 
 // scanTailHeadsFast emits matching (tail, head) pairs for one tail using

--- a/core/graphcache/edge_prefix_test.go
+++ b/core/graphcache/edge_prefix_test.go
@@ -372,3 +372,47 @@ func TestScanEdgesByPrefix_Atomic(t *testing.T) {
 		t.Fatalf("quiesce set empty — writers never won any insert?")
 	}
 }
+
+// TestGraphCache_ScanEdgesByPrefix_CallbackReentrant proves the #742 behavior
+// change: the visitor now runs AFTER the read lock is released, so it may call
+// back into GraphCache write methods. Under the old contract (callback invoked
+// while holding c.mu.RLock) any such write would self-deadlock because
+// sync.RWMutex is not reentrant. The scan is run in a goroutine with a timeout
+// so a regression fails loudly instead of hanging the suite.
+func TestGraphCache_ScanEdgesByPrefix_CallbackReentrant(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	c.EnablePrefixIndex(identityExtract)
+	exp := time.Now().Add(time.Minute)
+	for i := 0; i < 5; i++ {
+		c.PutEdgeWithExpiration(fmt.Sprintf("t%d", i), "h", 1.0, exp)
+	}
+
+	done := make(chan bool, 1)
+	go func() {
+		var visited int
+		ok := c.ScanEdgesByPrefix(context.Background(), "t", "",
+			func(_ string, tail string, _ string, _ string, _ float32, _ time.Time) bool {
+				visited++
+				// Reentrant writes from inside the visitor: an existing-edge
+				// append (takes c.mu.Lock) and a brand-new vertex.
+				c.AddEdgeWithExpiration(tail, "h", 1, exp)
+				c.PutVertexWithExpiration("side:"+tail, "v", exp)
+				return true
+			})
+		done <- ok && visited == 5
+	}()
+
+	select {
+	case ok := <-done:
+		if !ok {
+			t.Fatal("reentrant ScanEdgesByPrefix did not complete cleanly")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("reentrant ScanEdgesByPrefix deadlocked (visitor ran under the read lock?)")
+	}
+
+	// The reentrant writes took effect after the scan released the lock.
+	if _, ok := c.GetVertex("side:t0"); !ok {
+		t.Fatal("reentrant PutVertex from visitor did not persist")
+	}
+}


### PR DESCRIPTION
## What

Make `GraphCache.ScanEdgesByPrefix` snapshot the matching edge rows under a
single `c.mu.RLock`, release the lock, and only then invoke the visitor `fn`
per row — mirroring the `ScanByPrefix` contract.

Closes #742.

## Why

The old contract held `c.mu.RLock` for the entire walk and called `fn`
inline. Two problems:

- **Writer starvation.** A slow visitor (network I/O, large per-edge work)
  kept the read lock for the whole scan, blocking every writer.
- **No reentrancy.** `fn` could not call back into any `GraphCache` method
  that takes the lock — `sync.RWMutex` is not reentrant, so a write from
  inside the visitor self-deadlocked.

## How

- New unexported `collectEdgeScanRows` gathers every matching `(tail, head)`
  edge into a `[]edgeScanRow[S]` snapshot under one `RLock`, reusing the
  existing `scanTailHeadsFast` / `scanTailHeadsFallback` head walks (their
  signatures are unchanged; collection passes a `collect` closure that always
  continues, so early-stop is honoured during replay, not collection).
- `ScanEdgesByPrefix` releases the lock, then replays `fn` per row.
- Semantics preserved: walk order unchanged; `fn` returning false still
  stops and yields `false`; prefix-index-disabled still yields `false`;
  context cancellation during collection or replay yields `false`.
- Tradeoff documented on the method: one buffered row per matching edge for
  unbounded scans. The service layer bounds result size.

## Scope

Phase 1 only. Phase 2 (bounding the long read locks in traversal / `Neighbor`)
is intentionally deferred to keep this PR focused, as the issue allows.

## Tests / benchmarks

- `TestGraphCache_ScanEdgesByPrefix_CallbackReentrant` (new): the visitor
  performs `GraphCache` writes mid-scan; run under a 5s timeout so a
  regression (callback under the read lock) fails loudly instead of hanging.
- Existing `..._EarlyExitAndCancel`, `..._ExpiredEdgeSkipped`, and the
  `TestScanEdgesByPrefix_Atomic` concurrent-writer stress test (under
  `-race`) continue to pass unchanged.
- `BenchmarkScanEdgesByPrefix` (new) documents the snapshot allocation cost
  across scales.

## Validation

- `gofmt -l` clean on touched files; `go vet ./graphcache/` clean.
- `cd core && go test ./... -race` green.
- `cd server && go vet ./... && go test ./...` green.
- root `go test ./...` green.

Do not merge — leaving CI + review for the maintainer.
