### PR TITLE
perf(graphcache): bound GC edge sweep with an incremental cursor (#744)

### DIFF
--- a/core/graphcache/bench_test.go
+++ b/core/graphcache/bench_test.go
@@ -230,7 +230,36 @@ func BenchmarkGCFlush(b *testing.B) {
 	}
 }
 
-// BenchmarkWeight_AddOnly exercises the amortized-compaction path: every add
+// BenchmarkGCFlushIncremental measures the worst per-tick pause of the bounded
+// edge sweep (#744): it times a single flush() that builds a fresh sweep plan
+// (the tailIDs snapshot) and processes one budget's worth of tails. Contrast
+// its ns/op with BenchmarkGCFlush — the unbounded O(E) sweep — to see the pause
+// the budget trades away for more ticks. The budget scales with the graph
+// (1/16 of the tail count) so the bound tracks graph size.
+func BenchmarkGCFlushIncremental(b *testing.B) {
+	for _, s := range smallScales(testing.Short()) {
+		s := s
+		budget := s.vertices / 16
+		if budget < 1 {
+			budget = 1
+		}
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				c := NewGraphCache[string, string](time.Hour)
+				keys := populate(b, c, s)
+				for j := 0; j < s.vertices; j += 4 {
+					c.DeleteVertex(keys[j])
+				}
+				c.SetGCEdgeBudget(budget)
+				b.StartTimer()
+				_, _ = c.flush() // first bounded tick: plan build + one batch
+			}
+		})
+	}
+}
+
 // targets a single weight with already-expired entries, forcing flushLocked
 // to fire at the trigger boundary. Cost must stay roughly O(1) per op rather
 // than blowing up as the slice grows.

--- a/core/graphcache/cache.go
+++ b/core/graphcache/cache.go
@@ -103,6 +103,25 @@ type GraphCache[S comparable, T any] struct {
 	// for non-replicated workloads is one nil check per write.
 	vertexTombstones map[S]tombstoneEntry
 	edgeTombstones   map[EdgeKey[S]]tombstoneEntry
+
+	// gcEdgeBudget bounds the incremental GC edge sweep (#744). When it is
+	// <= 0 (the default) flush() performs a full O(E) sweep every tick — the
+	// historical behavior and the safety net. When set to a positive N via
+	// SetGCEdgeBudget, flush() walks at most N tail buckets per tick, carrying
+	// gcSweepPlan / gcSweepPos across ticks so every tail present when a cycle
+	// began is visited exactly once before the plan is rebuilt. All three are
+	// guarded by c.mu: flush mutates them under Lock; GCSweepBacklog reads them
+	// under RLock.
+	//
+	// Deferring physical edge reclamation never surfaces dead data through
+	// point reads: fully-decayed (zero-weight) edges are already hidden by the
+	// edge read path regardless of sweep timing, and dangling-edge logical
+	// visibility is tracked separately (see #744). The plan holds vertexIDs,
+	// not edges, so a delayed sweep re-resolves liveness at sweep time — an ID
+	// reused between plan build and visit is evaluated against current state.
+	gcEdgeBudget int
+	gcSweepPlan  []vertexID
+	gcSweepPos   int
 }
 
 func NewGraphCache[S comparable, T any](defaultTTL time.Duration) *GraphCache[S, T] {

--- a/core/graphcache/edge.go
+++ b/core/graphcache/edge.go
@@ -642,22 +642,69 @@ func (c *edgeCache[S]) flushFunc(keep func(tail, head vertexID) bool, onDelete f
 	defer c.mu.Unlock()
 
 	for tailID, heads := range c.tf {
-		for headID, w := range heads {
-			switch {
-			case w.isZero():
-				if onDelete != nil {
-					onDelete(tailID, headID)
-				}
-				if c.deleteLocked(tailID, headID) {
-					zero++
-				}
-			case keep != nil && !keep(tailID, headID):
-				if onDelete != nil {
-					onDelete(tailID, headID)
-				}
-				if c.deleteLocked(tailID, headID) {
-					dangling++
-				}
+		z, d := c.sweepHeadsLocked(tailID, heads, keep, onDelete)
+		zero += z
+		dangling += d
+	}
+	return
+}
+
+// tailIDs snapshots the current set of tail vertexIDs present in tf. It is the
+// plan source for the incremental GC sweep (#744): GraphCache walks the
+// returned IDs in bounded batches across ticks. Stale IDs (tails deleted before
+// they are visited) are tolerated by flushTails, and tails created after the
+// snapshot are swept in the next cycle.
+func (c *edgeCache[S]) tailIDs() []vertexID {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	ids := make([]vertexID, 0, len(c.tf))
+	for tailID := range c.tf {
+		ids = append(ids, tailID)
+	}
+	return ids
+}
+
+// flushTails is the bounded counterpart to flushFunc (#744): it applies the
+// same zero-weight + keep-predicate sweep, but only to the supplied tail
+// buckets. Tails absent from tf (deleted since the plan was built) are skipped.
+// Counts and onDelete semantics match flushFunc exactly.
+func (c *edgeCache[S]) flushTails(tailIDs []vertexID, keep func(tail, head vertexID) bool, onDelete func(tail, head vertexID)) (zero, dangling int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, tailID := range tailIDs {
+		heads, ok := c.tf[tailID]
+		if !ok {
+			continue
+		}
+		z, d := c.sweepHeadsLocked(tailID, heads, keep, onDelete)
+		zero += z
+		dangling += d
+	}
+	return
+}
+
+// sweepHeadsLocked removes zero-weight edges (counted in `zero`) and edges for
+// which keep returns false (counted in `dangling`) from one tail's head bucket.
+// onDelete, if non-nil, fires once per removal before the underlying delete.
+// Caller must hold c.mu write-locked. Shared by flushFunc (full walk) and
+// flushTails (bounded incremental walk).
+func (c *edgeCache[S]) sweepHeadsLocked(tailID vertexID, heads map[vertexID]*weight, keep func(tail, head vertexID) bool, onDelete func(tail, head vertexID)) (zero, dangling int) {
+	for headID, w := range heads {
+		switch {
+		case w.isZero():
+			if onDelete != nil {
+				onDelete(tailID, headID)
+			}
+			if c.deleteLocked(tailID, headID) {
+				zero++
+			}
+		case keep != nil && !keep(tailID, headID):
+			if onDelete != nil {
+				onDelete(tailID, headID)
+			}
+			if c.deleteLocked(tailID, headID) {
+				dangling++
 			}
 		}
 	}

--- a/core/graphcache/gc.go
+++ b/core/graphcache/gc.go
@@ -22,7 +22,7 @@ func (c *GraphCache[S, T]) flush() (zero, dangling int) {
 	c.sweepExpiredTombstonesLocked(time.Now())
 	c.sweepStaleVertexHLCLocked()
 
-	return c.edges.flushFunc(func(tailID, headID vertexID) bool {
+	keep := func(tailID, headID vertexID) bool {
 		tail, ok := c.edges.resolveID(tailID)
 		if !ok {
 			return false
@@ -32,7 +32,49 @@ func (c *GraphCache[S, T]) flush() (zero, dangling int) {
 			return false
 		}
 		return c.vertices.Has(tail) && c.vertices.Has(head)
-	}, c.headIndexOnFlushDeleteLocked())
+	}
+	onDelete := c.headIndexOnFlushDeleteLocked()
+
+	if c.gcEdgeBudget <= 0 {
+		// Full sweep (default): unchanged O(E) behavior and the safety net
+		// that guarantees every expired/dangling edge is reclaimed each tick.
+		c.gcSweepPlan = nil
+		c.gcSweepPos = 0
+		return c.edges.flushFunc(keep, onDelete)
+	}
+	return c.flushIncrementalLocked(keep, onDelete)
+}
+
+// flushIncrementalLocked sweeps at most c.gcEdgeBudget tail buckets per call,
+// advancing c.gcSweepPos across ticks (#744). When the cursor reaches the end
+// of the current plan (or no plan exists) it snapshots the live tail set and
+// starts a fresh cycle, so every tail present at cycle start is visited exactly
+// once before the plan is rebuilt; tails created mid-cycle are picked up by the
+// next cycle. This bounds the per-tick c.mu.Lock pause to O(budget × fan-out)
+// while preserving eventual cleanup: any expired/dangling edge is reclaimed
+// within at most two cycles. Caller must hold c.mu.Lock.
+func (c *GraphCache[S, T]) flushIncrementalLocked(
+	keep func(tailID, headID vertexID) bool,
+	onDelete func(tailID, headID vertexID),
+) (zero, dangling int) {
+	if c.gcSweepPos >= len(c.gcSweepPlan) {
+		c.gcSweepPlan = c.edges.tailIDs()
+		c.gcSweepPos = 0
+	}
+	end := c.gcSweepPos + c.gcEdgeBudget
+	if end > len(c.gcSweepPlan) {
+		end = len(c.gcSweepPlan)
+	}
+	batch := c.gcSweepPlan[c.gcSweepPos:end]
+	c.gcSweepPos = end
+	zero, dangling = c.edges.flushTails(batch, keep, onDelete)
+	if c.gcSweepPos >= len(c.gcSweepPlan) {
+		// Cycle consumed: drop the plan so its backing array can be GC'd and
+		// the next tick rebuilds the cursor against the current tail set.
+		c.gcSweepPlan = nil
+		c.gcSweepPos = 0
+	}
+	return zero, dangling
 }
 
 // vertexHLCShrinkFloor and vertexHLCShrinkDivisor govern when
@@ -96,6 +138,35 @@ func (c *GraphCache[S, T]) SetGCHooks(onExpire func(kind string, n int), onGCDur
 	defer c.hookMu.Unlock()
 	c.onExpire = onExpire
 	c.onGCDuration = onGCDuration
+}
+
+// SetGCEdgeBudget bounds how many tail buckets the GC edge sweep walks per
+// Watch tick (#744). A positive n caps each tick at n tails, spreading a large
+// O(E) sweep across multiple ticks to bound the c.mu.Lock pause; the sweep
+// carries a cursor across ticks so every tail is still reclaimed within bounded
+// time. n <= 0 (the default) restores the full single-tick sweep and clears any
+// in-flight cursor. Safe for concurrent use; takes effect on the next tick.
+func (c *GraphCache[S, T]) SetGCEdgeBudget(n int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if n < 0 {
+		n = 0
+	}
+	c.gcEdgeBudget = n
+	if n == 0 {
+		c.gcSweepPlan = nil
+		c.gcSweepPos = 0
+	}
+}
+
+// GCSweepBacklog reports how many tail buckets remain in the current
+// incremental sweep cycle (#744) — those not yet visited by flush(). It is 0
+// when the incremental sweep is disabled or a cycle has just completed, and
+// lets operators see when bounded cleanup is falling behind the write rate.
+func (c *GraphCache[S, T]) GCSweepBacklog() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.gcSweepPlan) - c.gcSweepPos
 }
 
 func (c *GraphCache[S, T]) snapshotHooks() (func(string, int), func(time.Duration)) {

--- a/core/graphcache/gc_test.go
+++ b/core/graphcache/gc_test.go
@@ -2,6 +2,7 @@ package graphcache
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -74,4 +75,172 @@ func TestGraphCache_GCFlushMaintainsIndexesWatermarksAndDanglingEdges(t *testing
 	}); !completed {
 		t.Fatal("ScanByPrefix after flush returned completed=false")
 	}
+}
+
+// TestGraphCache_GCIncrementalEdgeSweep exercises the bounded per-tick edge
+// sweep (#744): convergence under a budget, deferral that never surfaces dead
+// data, dangling reclamation, the tombstone/vertexHLC sweeps running every
+// tick regardless of the edge budget, and disabling the budget mid-cycle.
+func TestGraphCache_GCIncrementalEdgeSweep(t *testing.T) {
+	const tails = 6
+
+	// setupDecayed builds `tails` live tails each with one already-decayed
+	// (zero-weight) edge to a single live head. The endpoints stay live so the
+	// edges are reclaimed via the zero-weight path, not the dangling path.
+	setupDecayed := func() *GraphCache[string, string] {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnablePrefixIndex(identityExtract)
+		live := time.Now().Add(time.Minute)
+		past := time.Now().Add(-time.Second)
+		c.PutVertexWithExpiration("h", "head", live)
+		for i := 0; i < tails; i++ {
+			tk := fmt.Sprintf("t%02d", i)
+			c.PutVertexWithExpiration(tk, "tail", live)
+			c.AddEdgeWithExpiration(tk, "h", 1, past) // born decayed
+		}
+		return c
+	}
+
+	t.Run("EventuallyRemovesWithBoundedTicks", func(t *testing.T) {
+		c := setupDecayed()
+		c.SetGCEdgeBudget(2)
+		if got := c.edges.count(); got != tails {
+			t.Fatalf("edge count before sweep = %d, want %d", got, tails)
+		}
+
+		var totalZero, ticks int
+		for c.edges.count() > 0 {
+			ticks++
+			if ticks > tails+2 {
+				t.Fatalf("incremental sweep did not converge; remaining=%d", c.edges.count())
+			}
+			z, d := c.flush()
+			if d != 0 {
+				t.Fatalf("tick %d removed dangling=%d, want 0 (endpoints live)", ticks, d)
+			}
+			if z > 2 {
+				t.Fatalf("tick %d removed zero=%d edges, exceeds budget of 2 tails", ticks, z)
+			}
+			totalZero += z
+		}
+		if totalZero != tails {
+			t.Fatalf("cumulative zero-weight removals = %d, want %d", totalZero, tails)
+		}
+		// 6 tails at budget 2 must take >= 3 ticks — proves the pause was spread
+		// across ticks rather than done in one O(E) pass.
+		if ticks < 3 {
+			t.Fatalf("converged in %d ticks; expected the budget to spread it over >= 3", ticks)
+		}
+		if got := c.GCSweepBacklog(); got != 0 {
+			t.Fatalf("backlog after convergence = %d, want 0", got)
+		}
+	})
+
+	t.Run("BoundedTickDefersWorkWithoutSurfacingDeadData", func(t *testing.T) {
+		c := setupDecayed()
+		c.SetGCEdgeBudget(2)
+
+		z, _ := c.flush() // one bounded tick
+		if z == 0 || z >= tails {
+			t.Fatalf("one bounded tick removed %d edges; want a partial 0 < n < %d", z, tails)
+		}
+		if c.edges.count() == 0 {
+			t.Fatal("one bounded tick reclaimed everything; budget not enforced")
+		}
+		if c.GCSweepBacklog() == 0 {
+			t.Fatal("backlog = 0 after a partial tick; want pending work")
+		}
+		// Despite deferred physical cleanup, no decayed edge is visible through
+		// point reads or scans.
+		for i := 0; i < tails; i++ {
+			tk := fmt.Sprintf("t%02d", i)
+			if _, _, ok := c.GetEdgeDetail(tk, "h"); ok {
+				t.Fatalf("GetEdgeDetail(%s,h) surfaced a decayed edge before its sweep", tk)
+			}
+		}
+		if got := collectScan(c, "t", ""); len(got) != 0 {
+			t.Fatalf("ScanEdgesByPrefix surfaced decayed edges before sweep: %v", got)
+		}
+	})
+
+	t.Run("DanglingEdgesReclaimedIncrementally", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnablePrefixIndex(identityExtract)
+		live := time.Now().Add(time.Minute)
+		c.PutVertexWithExpiration("h", "head", live)
+		for i := 0; i < tails; i++ {
+			tk := fmt.Sprintf("t%02d", i)
+			c.PutVertexWithExpiration(tk, "tail", live)
+			c.AddEdgeWithExpiration(tk, "h", 1, live) // live edge
+		}
+		if !c.DeleteVertex("h") {
+			t.Fatal("DeleteVertex(h) reported false")
+		}
+		c.SetGCEdgeBudget(2)
+
+		var totalDangling, ticks int
+		for c.edges.count() > 0 {
+			ticks++
+			if ticks > tails+2 {
+				t.Fatalf("dangling sweep did not converge; remaining=%d", c.edges.count())
+			}
+			_, d := c.flush()
+			if d > 2 {
+				t.Fatalf("tick %d removed dangling=%d, exceeds budget of 2 tails", ticks, d)
+			}
+			totalDangling += d
+		}
+		if totalDangling != tails {
+			t.Fatalf("cumulative dangling removals = %d, want %d", totalDangling, tails)
+		}
+		if ticks < 3 {
+			t.Fatalf("dangling sweep converged in %d ticks; expected >= 3 under budget 2", ticks)
+		}
+	})
+
+	t.Run("TombstoneAndVertexHLCSweptEachTickRegardlessOfBudget", func(t *testing.T) {
+		c := setupDecayed() // many tails => edge sweep is bounded at budget 1
+		c.SetGCEdgeBudget(1)
+		past := time.Now().Add(-time.Millisecond)
+
+		if !c.PutVertexWithExpirationHLC("hlc:expired", "x", past, hlc.Timestamp{WallNs: 1}) {
+			t.Fatal("PutVertexWithExpirationHLC reported false")
+		}
+		c.DeleteVertexHLC("tomb:old", hlc.Timestamp{WallNs: 2}, past)
+		if c.VertexHLCCount() != 1 || len(c.vertexTombstones) != 1 {
+			t.Fatalf("precondition: hlc=%d tombstones=%d, want 1/1", c.VertexHLCCount(), len(c.vertexTombstones))
+		}
+		// Drop the expired HLC vertex so the stale-HLC sweep has a dead key to
+		// reconcile against the vertex cache.
+		c.vertices.Flush()
+
+		// A single budget-1 tick cannot sweep all edges (proves it is bounded)...
+		c.flush()
+		if c.edges.count() == 0 {
+			t.Fatal("budget-1 tick reclaimed all edges; not bounded")
+		}
+		// ...yet the tombstone and vertexHLC sweeps ran in full on that tick.
+		if got := c.VertexHLCCount(); got != 0 {
+			t.Fatalf("stale vertexHLC after one bounded tick = %d, want 0", got)
+		}
+		if got := len(c.vertexTombstones); got != 0 {
+			t.Fatalf("expired tombstones after one bounded tick = %d, want 0", got)
+		}
+	})
+
+	t.Run("DisablingBudgetRestoresFullSweepAndClearsCursor", func(t *testing.T) {
+		c := setupDecayed()
+		c.SetGCEdgeBudget(2)
+		c.flush() // partial — leaves a cursor + backlog
+		if c.GCSweepBacklog() == 0 {
+			t.Fatal("expected pending backlog after a partial tick")
+		}
+		c.SetGCEdgeBudget(0) // disable mid-cycle
+		if got := c.GCSweepBacklog(); got != 0 {
+			t.Fatalf("backlog after disabling budget = %d, want 0 (cursor cleared)", got)
+		}
+		if z, _ := c.flush(); c.edges.count() != 0 {
+			t.Fatalf("full sweep left %d edges (removed %d this tick)", c.edges.count(), z)
+		}
+	})
 }


### PR DESCRIPTION
## What

Make `GraphCache.flush()`'s edge sweep incremental: an opt-in per-tick
budget caps how many tail buckets are walked under `c.mu.Lock`, spreading a
large `O(E)` sweep across multiple GC ticks.

Closes #744.

## Why

`flush()` walked the whole edge map under the aggregate write lock on every
tick, so the GC pause scaled with total edge count. On large or
delete-heavy graphs a single tick became a multi-hundred-millisecond write
stall (benchmark: ~686 ms at v100k / d32).

## How

- `SetGCEdgeBudget(n)` sets a per-tick bound. `n > 0` caps each tick at `n`
  tail buckets; `n <= 0` (the **default**) keeps the full single-tick sweep
  as the safety net, so behavior is unchanged unless a budget is set.
- The bounded sweep carries a plan + cursor (`gcSweepPlan` / `gcSweepPos`,
  guarded by `c.mu`): when the cursor is exhausted it snapshots the live
  tail set (`edgeCache.tailIDs`) and starts a fresh cycle, so every tail
  present at cycle start is visited exactly once before the plan rebuilds.
  Tails created mid-cycle are reclaimed next cycle — eventual cleanup within
  bounded time.
- New `edgeCache.flushTails` sweeps only the batch's tails; the zero-weight
  + keep-predicate removal body is factored into a shared `sweepHeadsLocked`
  used by both `flushFunc` (full) and `flushTails` (bounded), so the two
  walks can never diverge.
- `GCSweepBacklog()` exposes remaining cycle work for operators (item 5).

## Safety

- **No dead data surfaced by deferral.** Decayed (zero-weight) edges are
  already hidden by the edge read path regardless of sweep timing; the plan
  holds vertexIDs and liveness is re-resolved at sweep time, so a reused ID
  is evaluated against current state. Dangling-edge *logical* visibility is
  tracked separately (the endpoint-liveness filter noted on the issue) and
  is explicitly out of scope here.
- **Tombstone + stale-vertexHLC sweeps still run every tick**, independent
  of the edge budget (asserted by a test).
- The full sweep remains the default safety net — not removed.

## Scope

Focused first PR: the incremental edge cursor (issue items 1, 2, 5).
Deferred as future work: dirty-queue prioritization of recently-deleted
vertices (item 3) and per-phase budgeting of the tombstone / vertexHLC
sweeps (item 4).

## Tests

`core/graphcache/gc_test.go` — new `TestGraphCache_GCIncrementalEdgeSweep`
with sub-tests: bounded convergence; deferral that hides decayed edges from
`GetEdgeDetail` + `ScanEdgesByPrefix`; incremental dangling reclamation;
tombstone/vertexHLC swept every tick regardless of budget; disabling the
budget mid-cycle clears the cursor and restores the full sweep. Existing
`TestGraphCache_GCFlushMaintainsIndexesWatermarksAndDanglingEdges` covers
the unchanged default path.

## Benchmarks

`core/graphcache/bench_test.go` — new `BenchmarkGCFlushIncremental`
(worst per-tick pause under a 1/16 budget), contrast with the existing
`BenchmarkGCFlush` (full sweep):

```
BenchmarkGCFlush/v100k_d32_k80              685992938 ns/op
BenchmarkGCFlushIncremental/v100k_d32_k80    43642188 ns/op
```

```bash
(cd core && go test ./graphcache -bench 'GC|Flush|Dangling' -benchmem -count=10)
```

## Validation

- `gofmt -l` clean; `go vet ./graphcache/` clean.
- `cd core && go test ./... -race` green.
- `cd server && go vet ./... && go test ./...` green.
- root `go test ./...` green.

Do not merge — leaving CI + review for the maintainer.
