### PR TITLE
feat(graphcache): enforce live-endpoint visibility across read, scan, traversal, and snapshot surfaces

### DIFF
--- a/core/graphcache/cache.go
+++ b/core/graphcache/cache.go
@@ -266,12 +266,41 @@ func (c *GraphCache[S, T]) GetVertex(key S) (T, bool) {
 	return c.vertices.Get(key)
 }
 
+// edgeEndpointsLive reports whether BOTH endpoint vertices of an edge are
+// currently live — present in the vertex cache and not past their TTL. It is
+// the single enforcement point for the read/snapshot referential-closure
+// contract (#750): an edge may physically outlive a deleted or expired endpoint
+// vertex until the dangling-edge GC sweep reclaims it, but no public read,
+// scan, traversal, or snapshot surface may expose such an edge. vertices.Has
+// hides expired-but-not-yet-flushed entries (it routes through Get), so the
+// check is correct even before GC runs.
+//
+// The vertex cache carries its own mutex, independent of GraphCache.mu, so this
+// is safe to call both from the lock-free point reads (GetWeight/GetEdgeDetail,
+// which hold no GraphCache.mu) and from the scan/traversal/snapshot paths that
+// hold GraphCache.mu (R or W). It is the same liveness primitive the additive
+// write fast path already uses to gate an in-place contribution (see
+// tryAddExistingEdgeContrib).
+func (c *GraphCache[S, T]) edgeEndpointsLive(tail, head S) bool {
+	return c.vertices.Has(tail) && c.vertices.Has(head)
+}
+
 // GetWeight returns the additive weight of the (tail, head) edge. Like
 // GetVertex it is a lock-free point read: edges.get pins both endpoint ids
 // (closing the dictionary ABA hazard) and reads the edge map under the
 // edgeCache's own lock, so GraphCache.mu is not required (#740).
+//
+// The edge is hidden (ok=false) unless both endpoint vertices are still live,
+// so a dangling edge whose tail or head was deleted or expired but not yet
+// swept is reported as absent (#750). The endpoint check reads the vertex
+// cache under its own lock, after the edge read, so GetWeight stays free of
+// GraphCache.mu.
 func (c *GraphCache[S, T]) GetWeight(tail, head S) (float32, bool) {
-	return c.edges.get(tail, head)
+	w, ok := c.edges.get(tail, head)
+	if !ok || !c.edgeEndpointsLive(tail, head) {
+		return 0, false
+	}
+	return w, true
 }
 
 // GetEdgeDetail returns the current edge weight together with the latest
@@ -281,9 +310,15 @@ func (c *GraphCache[S, T]) GetWeight(tail, head S) (float32, bool) {
 // Like GetWeight it is a lock-free point read (see edges.getDetail): it does
 // not take GraphCache.mu and may observe either the pre- or post-write state
 // under a concurrent edge mutation, but it never resolves a recycled endpoint
-// id to an unrelated edge.
+// id to an unrelated edge. The edge is hidden unless both endpoint vertices are
+// still live, so a dangling edge to a deleted or expired-but-not-flushed vertex
+// is reported as absent (#750).
 func (c *GraphCache[S, T]) GetEdgeDetail(tail, head S) (float32, time.Time, bool) {
-	return c.edges.getDetail(tail, head)
+	w, exp, ok := c.edges.getDetail(tail, head)
+	if !ok || !c.edgeEndpointsLive(tail, head) {
+		return 0, time.Time{}, false
+	}
+	return w, exp, true
 }
 
 func (c *GraphCache[S, T]) PutVertexWithExpiration(key S, value T, expiration time.Time) {

--- a/core/graphcache/cache_test.go
+++ b/core/graphcache/cache_test.go
@@ -1591,3 +1591,69 @@ func TestGraphCache_DictRefcountStableAcrossExpiredOverwrite(t *testing.T) {
 		assertStable(t, c, id)
 	})
 }
+
+// TestGraph_EdgeReadsHideDeadEndpoints pins the point-read half of the
+// referential-closure contract (#750): GetWeight and GetEdgeDetail report an
+// edge as absent the instant either endpoint vertex stops being live — whether
+// it was deleted or merely expired-but-not-yet-swept — even though the edge
+// bucket physically survives until the dangling-edge GC sweep.
+func TestGraph_EdgeReadsHideDeadEndpoints(t *testing.T) {
+	live := time.Now().Add(time.Hour)
+	newGraph := func() *GraphCache[string, string] {
+		c := NewGraphCache[string, string](time.Hour)
+		c.PutVertexWithExpiration("tail", "t", live)
+		c.PutVertexWithExpiration("head", "h", live)
+		c.AddEdgeWithExpiration("tail", "head", 3, live)
+		return c
+	}
+
+	// Baseline: both endpoints live, so the edge is visible everywhere.
+	base := newGraph()
+	if w, ok := base.GetWeight("tail", "head"); !ok || w != 3 {
+		t.Fatalf("baseline GetWeight = (%v, %v), want (3, true)", w, ok)
+	}
+	if _, _, ok := base.GetEdgeDetail("tail", "head"); !ok {
+		t.Fatal("baseline GetEdgeDetail ok=false, want true")
+	}
+
+	assertHidden := func(t *testing.T, c *GraphCache[string, string]) {
+		t.Helper()
+		if w, ok := c.GetWeight("tail", "head"); ok {
+			t.Fatalf("GetWeight surfaced a dangling edge: weight=%v ok=%v", w, ok)
+		}
+		if _, _, ok := c.GetEdgeDetail("tail", "head"); ok {
+			t.Fatal("GetEdgeDetail surfaced a dangling edge")
+		}
+		// The edge bucket is still physically present — no GC sweep has run, so
+		// this proves the read paths filter on logical liveness rather than on
+		// physical retention.
+		if got := c.edges.count(); got != 1 {
+			t.Fatalf("edge bucket count = %d, want 1 (edge still physical before sweep)", got)
+		}
+	}
+
+	t.Run("HeadDeleted", func(t *testing.T) {
+		c := newGraph()
+		if !c.DeleteVertex("head") {
+			t.Fatal("DeleteVertex(head) reported false")
+		}
+		assertHidden(t, c)
+	})
+	t.Run("TailDeleted", func(t *testing.T) {
+		c := newGraph()
+		if !c.DeleteVertex("tail") {
+			t.Fatal("DeleteVertex(tail) reported false")
+		}
+		assertHidden(t, c)
+	})
+	t.Run("HeadExpiredNotFlushed", func(t *testing.T) {
+		c := newGraph()
+		// Overwrite head's slot with an already-past expiration through the
+		// unconditional store path so it is expired but still physically
+		// present (no flush), leaving the edge bucket untouched.
+		c.mu.Lock()
+		c.putVertexLocked("head", "h", time.Now().Add(-time.Minute))
+		c.mu.Unlock()
+		assertHidden(t, c)
+	})
+}

--- a/core/graphcache/edge_prefix.go
+++ b/core/graphcache/edge_prefix.go
@@ -168,6 +168,12 @@ func (c *GraphCache[S, T]) scanTailHeadsFast(
 		if !nonZero {
 			return true
 		}
+		// Referential closure (#750): hide an edge whose tail or head vertex
+		// is no longer live, even if the dangling-edge GC sweep has not yet
+		// reclaimed it.
+		if !c.edgeEndpointsLive(tail, head) {
+			return true
+		}
 		if !fn(tailProj, tail, headProj, head, sum, latest) {
 			keepGoing = false
 			return false
@@ -212,6 +218,12 @@ func (c *GraphCache[S, T]) scanTailHeadsFallback(
 	for _, e := range entries {
 		sum, latest, nonZero := e.w.snapshot()
 		if !nonZero {
+			continue
+		}
+		// Referential closure (#750): hide an edge whose tail or head vertex
+		// is no longer live, even if the dangling-edge GC sweep has not yet
+		// reclaimed it.
+		if !c.edgeEndpointsLive(tail, e.head) {
 			continue
 		}
 		if !fn(tailProj, tail, e.proj, e.head, sum, latest) {

--- a/core/graphcache/edge_prefix_test.go
+++ b/core/graphcache/edge_prefix_test.go
@@ -416,3 +416,70 @@ func TestGraphCache_ScanEdgesByPrefix_CallbackReentrant(t *testing.T) {
 		t.Fatal("reentrant PutVertex from visitor did not persist")
 	}
 }
+
+// TestGraphCache_ScanEdgesByPrefix_HidesDeadEndpoints pins the prefix-scan half
+// of the referential-closure contract (#750): a live edge whose head or tail
+// vertex has been deleted must not be emitted, on BOTH the head-index fast path
+// and the materialise-and-sort fallback. The edge stays physically present
+// (no GC sweep), so this proves the emit-site liveness filter, not GC timing.
+func TestGraphCache_ScanEdgesByPrefix_HidesDeadEndpoints(t *testing.T) {
+	live := time.Now().Add(time.Hour)
+	build := func() *GraphCache[string, string] {
+		c := NewGraphCache[string, string](time.Hour)
+		c.EnablePrefixIndex(identityExtract)
+		c.PutVertexWithExpiration("t:1", "t", live)
+		c.PutVertexWithExpiration("h:1", "h", live)
+		c.PutVertexWithExpiration("h:2", "h", live)
+		c.AddEdgeWithExpiration("t:1", "h:1", 1, live)
+		c.AddEdgeWithExpiration("t:1", "h:2", 1, live)
+		return c
+	}
+	asSet := func(rows []string) map[string]bool {
+		m := make(map[string]bool, len(rows))
+		for _, r := range rows {
+			m[r] = true
+		}
+		return m
+	}
+
+	for _, tc := range []struct {
+		name        string
+		disableHead bool
+	}{
+		{"FastPath", false},
+		{"FallbackPath", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := build()
+			if tc.disableHead {
+				c.disableHeadIndexForTesting()
+			}
+			if got := scanEdgesCollect(t, c, "t:", ""); len(got) != 2 {
+				t.Fatalf("baseline scan = %v, want 2 edges", got)
+			}
+
+			// Delete one head: only the edge to the surviving head remains.
+			if !c.DeleteVertex("h:1") {
+				t.Fatal("DeleteVertex(h:1) reported false")
+			}
+			got := asSet(scanEdgesCollect(t, c, "t:", ""))
+			if got["t:1->h:1=1"] {
+				t.Errorf("scan surfaced dangling edge t:1->h:1: %v", got)
+			}
+			if !got["t:1->h:2=1"] {
+				t.Errorf("scan dropped the live edge t:1->h:2: %v", got)
+			}
+			if c.edges.count() != 2 {
+				t.Fatalf("edge bucket count = %d, want 2 (both edges still physical)", c.edges.count())
+			}
+
+			// Delete the shared tail: every edge from it disappears.
+			if !c.DeleteVertex("t:1") {
+				t.Fatal("DeleteVertex(t:1) reported false")
+			}
+			if got := scanEdgesCollect(t, c, "t:", ""); len(got) != 0 {
+				t.Fatalf("scan after deleting tail = %v, want empty", got)
+			}
+		})
+	}
+}

--- a/core/graphcache/gc_test.go
+++ b/core/graphcache/gc_test.go
@@ -24,8 +24,8 @@ func TestGraphCache_GCFlushMaintainsIndexesWatermarksAndDanglingEdges(t *testing
 	if got := c.VertexHLCCount(); got != 1 {
 		t.Fatalf("VertexHLCCount before flush = %d, want 1", got)
 	}
-	if got := c.CountByPrefix("expired:"); got != 1 {
-		t.Fatalf("CountByPrefix(expired:) before vertex flush = %d, want 1", got)
+	if got := c.CountByPrefix("expired:"); got != 0 {
+		t.Fatalf("CountByPrefix(expired:) before vertex flush = %d, want 0 because the liveness filter hides expired-but-not-flushed entries", got)
 	}
 	if got := c.SearchVertices("expired", 10, ""); got != nil {
 		t.Fatalf("SearchVertices(expired) before vertex flush = %v, want nil because liveness filter hides expired entries", keys(got))
@@ -37,8 +37,11 @@ func TestGraphCache_GCFlushMaintainsIndexesWatermarksAndDanglingEdges(t *testing
 	if !c.DeleteVertex("head") {
 		t.Fatal("DeleteVertex(head) reported false")
 	}
-	if got := collectScan(c, "tail", "head"); len(got) != 1 {
-		t.Fatalf("ScanEdgesByPrefix before dangling sweep = %v, want one dangling edge still present", got)
+	// The edge survives physically until the dangling sweep, but the public
+	// scan surface must hide it immediately because its head vertex is gone
+	// (#750).
+	if got := collectScan(c, "tail", "head"); len(got) != 0 {
+		t.Fatalf("ScanEdgesByPrefix before dangling sweep = %v, want empty because the head vertex was deleted", got)
 	}
 
 	c.DeleteVertexHLC("tombstone:old", hlc.Timestamp{WallNs: 2}, expired)

--- a/core/graphcache/prefix.go
+++ b/core/graphcache/prefix.go
@@ -97,18 +97,30 @@ func (c *GraphCache[S, T]) ScanByPrefix(ctx context.Context, prefix string, fn f
 	return true
 }
 
-// CountByPrefix returns the number of indexed keys whose projection
-// starts with prefix. The count is taken from the prefix index, so it
-// reflects entries that may have expired but not yet been flushed; for
-// most workloads the skew is bounded by the Watch tick interval. Returns
-// 0 when the index has not been enabled.
+// CountByPrefix returns the number of LIVE vertices whose projected key starts
+// with prefix. It walks the prefix index and counts only keys the vertex cache
+// still resolves as live, so an entry that has expired but not yet been flushed
+// is excluded — the count therefore equals len(ScanByPrefix(prefix)) and the
+// number of live primary vertices matching prefix, independent of GC timing
+// (#752). Returns 0 when the index has not been enabled.
 func (c *GraphCache[S, T]) CountByPrefix(prefix string) int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.prefixIndex == nil {
 		return 0
 	}
-	return c.prefixIndex.countPrefix(prefix)
+	count := 0
+	c.prefixIndex.walkPrefix(prefix, func(projected string) bool {
+		// resolveProjected confirms the key against the live vertex cache
+		// (vertices.Has for the string instantiation), so a stale radix
+		// posting for an expired-but-not-flushed or already-deleted vertex is
+		// not counted — mirroring ScanByPrefix.
+		if _, ok := c.resolveProjected(projected); ok {
+			count++
+		}
+		return true
+	})
+	return count
 }
 
 // DeleteByPrefix removes every vertex whose projected key starts with

--- a/core/graphcache/prefix_test.go
+++ b/core/graphcache/prefix_test.go
@@ -371,13 +371,55 @@ func TestGraphCache_PutVertices_PrefixStableAcrossExpiredOverwrite(t *testing.T)
 	c.mu.Lock()
 	c.putVertexLocked("user:1", "v1", time.Now().Add(-time.Minute))
 	c.mu.Unlock()
-	if got := c.CountByPrefix("user:"); got != 1 {
-		t.Fatalf("CountByPrefix after seed = %d, want 1", got)
+	// The slot is physically present in the radix but logically dead, so the
+	// liveness-filtered count hides it (#752).
+	if got := c.CountByPrefix("user:"); got != 0 {
+		t.Fatalf("CountByPrefix after seeding an expired slot = %d, want 0", got)
 	}
 	c.PutVerticesWithExpiration([]VertexItem[string, string]{
 		{Key: "user:1", Value: "v2", Expiration: time.Now().Add(time.Minute)},
 	})
+	// The live overwrite makes the single key visible again — exactly once, with
+	// no stale double-count from the expired posting.
 	if got := c.CountByPrefix("user:"); got != 1 {
 		t.Fatalf("CountByPrefix after overwrite = %d, want 1", got)
+	}
+}
+
+// TestGraphCache_CountByPrefix_EqualsLiveScan pins the #752 count/scan
+// agreement invariant: for every prefix, CountByPrefix returns exactly the
+// number of keys ScanByPrefix yields, after a mix of overwrite, delete,
+// prefix-delete, and expired-but-not-flushed mutations. Both surfaces must
+// observe the live logical set, not stale radix postings.
+func TestGraphCache_CountByPrefix_EqualsLiveScan(t *testing.T) {
+	c := NewGraphCache[string, string](time.Hour)
+	c.EnablePrefixIndex(identityExtract)
+	live := time.Now().Add(time.Hour)
+
+	for _, k := range []string{"u:1", "u:2", "u:3", "u:4", "other:1"} {
+		c.PutVertexWithExpiration(k, "v", live)
+	}
+	c.PutVertexWithExpiration("u:2", "v2", live)     // overwrite stays live
+	c.DeleteVertex("u:3")                            // delete
+	c.DeleteByPrefix(context.Background(), "u:4", 0) // prefix delete removes u:4
+	// u:5 is expired-but-not-flushed: a stale radix posting that neither
+	// surface may observe.
+	c.mu.Lock()
+	c.putVertexLocked("u:5", "v", time.Now().Add(-time.Minute))
+	c.mu.Unlock()
+
+	for _, prefix := range []string{"", "u:", "u:1", "other:", "zzz"} {
+		var scanned []string
+		c.ScanByPrefix(context.Background(), prefix, func(_, key string, _ string) bool {
+			scanned = append(scanned, key)
+			return true
+		})
+		if got := c.CountByPrefix(prefix); got != len(scanned) {
+			t.Errorf("CountByPrefix(%q) = %d, ScanByPrefix len = %d (%v)", prefix, got, len(scanned), scanned)
+		}
+	}
+	// Concrete check: the live u: set is exactly {u:1, u:2}.
+	if got := c.CountByPrefix("u:"); got != 2 {
+		t.Errorf("CountByPrefix(u:) = %d, want 2 (u:1, u:2)", got)
 	}
 }

--- a/core/graphcache/production_gate_test.go
+++ b/core/graphcache/production_gate_test.go
@@ -2,8 +2,12 @@ package graphcache
 
 import (
 	"context"
+	"fmt"
 	"math"
+	"reflect"
 	"runtime"
+	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -36,6 +40,11 @@ import (
 //	C2  ReadConsistency/NeighborStableUnderConcurrentWrites
 //	D1  Idempotence/PutVertexAndPutEdgeConverge
 //	T1  Topology/SelfLoopRoundTrips
+//	G1  LogicalConsistency/VertexVisibilityAgreesAcrossSurfaces  (#752)
+//	G2  LogicalConsistency/GCNonObservableForReads               (#752)
+//	G3  LogicalConsistency/NoResurrectionFromStaleIndexes        (#752)
+//	G4  LogicalConsistency/DerivedEdgeValueAgreesAcrossSurfaces  (#752)
+//	G5  LogicalConsistency/SnapshotSetConsistency                (#752)
 func TestProductionQualityGate(t *testing.T) {
 	t.Parallel()
 
@@ -55,6 +64,14 @@ func TestProductionQualityGate(t *testing.T) {
 	t.Run("Idempotence/PutVertexAndPutEdgeConverge", testIdempotenceConverge)
 
 	t.Run("Topology/SelfLoopRoundTrips", testTopologySelfLoop)
+
+	// Logical-vs-physical consistency (#752): public surfaces observe the live
+	// graph, never physical retention or GC timing.
+	t.Run("LogicalConsistency/VertexVisibilityAgreesAcrossSurfaces", testLogicalVertexVisibility)
+	t.Run("LogicalConsistency/GCNonObservableForReads", testLogicalGCNonObservable)
+	t.Run("LogicalConsistency/NoResurrectionFromStaleIndexes", testLogicalNoResurrection)
+	t.Run("LogicalConsistency/DerivedEdgeValueAgreesAcrossSurfaces", testLogicalDerivedEdgeValue)
+	t.Run("LogicalConsistency/SnapshotSetConsistency", testLogicalSnapshotSetConsistency)
 }
 
 // ---------------------------------------------------------------------------
@@ -466,5 +483,325 @@ func testTopologySelfLoop(t *testing.T) {
 	g := c.Neighbor("x", 1, 4, false, false, nil)
 	if _, ok := g.Edges["x"]["x"]; !ok {
 		t.Fatalf("T1: Neighbor lost the self-loop edge: %#v", g.Edges)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// G1–G5  Logical-vs-physical consistency (#752)
+//
+// These properties assert that every PUBLIC surface observes the live logical
+// graph. Physical retention (an expired-but-not-flushed vertex, a dangling edge
+// awaiting the GC sweep) and the timing of GC must be invisible to reads,
+// scans, search, traversal, and snapshots.
+// ---------------------------------------------------------------------------
+
+// searchSet runs SearchVertices and returns the matched keys as a set.
+func searchSet(c *GraphCache[string, string], query string, limit int) map[string]bool {
+	m := map[string]bool{}
+	for _, r := range c.SearchVertices(query, limit, "") {
+		m[r.ID] = true
+	}
+	return m
+}
+
+// sumContribs folds a snapshot edge's live contributions into a single weight,
+// matching the additive semantics GetWeight reports.
+func sumContribs(e SnapshotEdge[string]) float32 {
+	var s float32
+	for _, contrib := range e.Contributions {
+		s += contrib.Weight
+	}
+	return s
+}
+
+// floatNear is a tolerant float32 comparison for derived edge weights.
+func floatNear(a, b float32) bool {
+	return math.Abs(float64(a-b)) < 1e-4
+}
+
+// testLogicalVertexVisibility (G1): a vertex's visibility is identical across
+// GetVertex, ScanByPrefix, CountByPrefix, SearchVertices, SnapshotVertices, and
+// SnapshotGraph, through delete / overwrite / prefix-delete / expire-not-flush.
+func testLogicalVertexVisibility(t *testing.T) {
+	c := NewGraphCache[string, string](time.Hour)
+	c.EnablePrefixIndex(identityExtract)
+	c.EnableSearchIndex(textExtract)
+	live := time.Now().Add(time.Hour)
+
+	c.PutVertexWithExpiration("live:1", "rivers", live)
+	c.PutVertexWithExpiration("del:1", "deserts", live)
+	c.PutVertexWithExpiration("ow:1", "mountains", live)
+	c.PutVertexWithExpiration("pdel:1", "canyons", live)
+
+	c.DeleteVertex("del:1")
+	c.PutVertexWithExpiration("ow:1", "harbors", live) // overwrite, still live
+	c.DeleteByPrefix(context.Background(), "pdel:", 0)
+	c.mu.Lock()
+	c.putVertexLocked("exp:1", "glaciers", time.Now().Add(-time.Minute))
+	c.mu.Unlock()
+
+	wantLive := map[string]bool{"live:1": true, "ow:1": true}
+	wantDead := []string{"del:1", "exp:1", "pdel:1"}
+
+	for k := range wantLive {
+		if _, ok := c.GetVertex(k); !ok {
+			t.Errorf("G1 GetVertex(%q) = absent, want live", k)
+		}
+	}
+	for _, k := range wantDead {
+		if _, ok := c.GetVertex(k); ok {
+			t.Errorf("G1 GetVertex(%q) = live, want dead", k)
+		}
+	}
+
+	scanned := map[string]bool{}
+	c.ScanByPrefix(context.Background(), "", func(_, key string, _ string) bool {
+		scanned[key] = true
+		return true
+	})
+	if !reflect.DeepEqual(scanned, wantLive) {
+		t.Errorf("G1 ScanByPrefix live set = %v, want %v", scanned, wantLive)
+	}
+	if got := c.CountByPrefix(""); got != len(wantLive) {
+		t.Errorf("G1 CountByPrefix() = %d, want %d", got, len(wantLive))
+	}
+
+	snapV := map[string]bool{}
+	for _, v := range c.SnapshotVertices() {
+		snapV[v.Key] = true
+	}
+	if !reflect.DeepEqual(snapV, wantLive) {
+		t.Errorf("G1 SnapshotVertices live set = %v, want %v", snapV, wantLive)
+	}
+	graphV := map[string]bool{}
+	for _, v := range c.SnapshotGraph().Vertices {
+		graphV[v.Key] = true
+	}
+	if !reflect.DeepEqual(graphV, wantLive) {
+		t.Errorf("G1 SnapshotGraph vertices = %v, want %v", graphV, wantLive)
+	}
+
+	// Search agrees: live keys match their current term; dead and
+	// overwritten-away docs never surface.
+	if got := searchSet(c, "rivers", 50); !got["live:1"] {
+		t.Errorf("G1 Search(rivers) = %v, want to include live:1", got)
+	}
+	if got := searchSet(c, "harbors", 50); !got["ow:1"] {
+		t.Errorf("G1 Search(harbors) = %v, want to include ow:1", got)
+	}
+	if got := searchSet(c, "mountains", 50); got["ow:1"] {
+		t.Errorf("G1 Search(mountains) surfaced overwritten-away ow:1: %v", got)
+	}
+	for term, dead := range map[string]string{"deserts": "del:1", "glaciers": "exp:1", "canyons": "pdel:1"} {
+		if got := searchSet(c, term, 50); got[dead] {
+			t.Errorf("G1 Search(%q) surfaced dead key %q: %v", term, dead, got)
+		}
+	}
+}
+
+// testLogicalGCNonObservable (G2): running every GC path (vertices.Flush,
+// edges.flush, c.flush) does not change any public read result. The dangling
+// edge is physically present before the sweep and gone after; the expired
+// vertex likewise — yet reads, scans, search, and snapshots are identical.
+func testLogicalGCNonObservable(t *testing.T) {
+	c := NewGraphCache[string, string](time.Hour)
+	c.EnablePrefixIndex(identityExtract)
+	c.EnableSearchIndex(textExtract)
+	live := time.Now().Add(time.Hour)
+
+	c.PutVertexWithExpiration("k:live", "rivers", live)
+	c.PutVertexWithExpiration("k:tail", "tail", live)
+	c.PutVertexWithExpiration("k:head", "head", live)
+	c.AddEdgeWithExpiration("k:tail", "k:head", 4, live)
+	c.DeleteVertex("k:head") // makes k:tail->k:head dangling but physical
+	c.mu.Lock()
+	c.putVertexLocked("k:exp", "glaciers", time.Now().Add(-time.Minute))
+	c.mu.Unlock()
+
+	snapshot := func() string {
+		var b strings.Builder
+		var vs []string
+		c.ScanByPrefix(context.Background(), "", func(_, key string, _ string) bool {
+			vs = append(vs, key)
+			return true
+		})
+		sort.Strings(vs)
+		fmt.Fprintf(&b, "scan=%v;count=%d;", vs, c.CountByPrefix(""))
+		_, _, edgeOK := c.GetEdgeDetail("k:tail", "k:head")
+		fmt.Fprintf(&b, "edge=%v;scanedge=%v;", edgeOK, collectScan(c, "k:tail", "k:head"))
+		fmt.Fprintf(&b, "search=%v;", keys(c.SearchVertices("glaciers", 10, "")))
+		g := c.SnapshotGraph()
+		fmt.Fprintf(&b, "snapV=%d;snapE=%d", len(g.Vertices), len(g.Edges))
+		return b.String()
+	}
+
+	before := snapshot()
+	c.vertices.Flush()
+	c.edges.flush()
+	c.flush()
+	after := snapshot()
+
+	if before != after {
+		t.Errorf("G2 public reads changed across GC:\n before=%s\n after =%s", before, after)
+	}
+}
+
+// testLogicalNoResurrection (G3): a deleted / prefix-deleted / expired+flushed
+// key never reappears via a stale index posting, even when a different live key
+// later reuses the same search term or prefix.
+func testLogicalNoResurrection(t *testing.T) {
+	c := NewGraphCache[string, string](time.Hour)
+	c.EnablePrefixIndex(identityExtract)
+	c.EnableSearchIndex(textExtract)
+	live := time.Now().Add(time.Hour)
+
+	c.PutVertexWithExpiration("old:1", "phoenix", live)
+	c.DeleteVertex("old:1")
+	c.PutVertexWithExpiration("new:1", "phoenix", live)
+	if hits := searchSet(c, "phoenix", 50); hits["old:1"] || !hits["new:1"] {
+		t.Errorf("G3 deleted key resurrected via shared term: %v", hits)
+	}
+
+	c.PutVertexWithExpiration("tmp:1", "comet", live)
+	c.DeleteByPrefix(context.Background(), "tmp:", 0)
+	c.PutVertexWithExpiration("keep:1", "comet", live)
+	if got := c.CountByPrefix("tmp:"); got != 0 {
+		t.Errorf("G3 CountByPrefix(tmp:) = %d after prefix delete, want 0", got)
+	}
+	if hits := searchSet(c, "comet", 50); hits["tmp:1"] || !hits["keep:1"] {
+		t.Errorf("G3 prefix-deleted key resurrected: %v", hits)
+	}
+
+	c.PutVertexWithExpiration("gone:1", "tundra", live)
+	c.mu.Lock()
+	c.putVertexLocked("gone:1", "tundra", time.Now().Add(-time.Minute))
+	c.mu.Unlock()
+	c.vertices.Flush()
+	c.PutVertexWithExpiration("fresh:1", "tundra", live)
+	if hits := searchSet(c, "tundra", 50); hits["gone:1"] || !hits["fresh:1"] {
+		t.Errorf("G3 expired+flushed key resurrected: %v", hits)
+	}
+}
+
+// testLogicalDerivedEdgeValue (G4): for a live-endpoint edge, the effective
+// weight and existence agree across GetWeight, GetEdgeDetail, ScanEdgesByPrefix,
+// Neighbor, SnapshotEdges, and SnapshotGraph — through additive Add, replacing
+// Put, and Delete.
+func testLogicalDerivedEdgeValue(t *testing.T) {
+	c := NewGraphCache[string, string](time.Hour)
+	c.EnablePrefixIndex(identityExtract)
+	live := time.Now().Add(time.Hour)
+	c.PutVertexWithExpiration("t", "t", live)
+	c.PutVertexWithExpiration("h", "h", live)
+
+	assertAgree := func(t *testing.T, wantPresent bool, wantWeight float32) {
+		t.Helper()
+		type verdict struct {
+			name    string
+			weight  float32
+			present bool
+		}
+		var vs []verdict
+
+		w, ok := c.GetWeight("t", "h")
+		vs = append(vs, verdict{"GetWeight", w, ok})
+		wd, _, okd := c.GetEdgeDetail("t", "h")
+		vs = append(vs, verdict{"GetEdgeDetail", wd, okd})
+
+		var sw float32
+		spresent := false
+		c.ScanEdgesByPrefix(context.Background(), "t", "h", func(_ string, _ string, _ string, _ string, weight float32, _ time.Time) bool {
+			sw, spresent = weight, true
+			return true
+		})
+		vs = append(vs, verdict{"ScanEdgesByPrefix", sw, spresent})
+
+		g := c.Neighbor("t", 1, 8, false, false, nil)
+		nw, npresent := g.Edges["t"]["h"]
+		vs = append(vs, verdict{"Neighbor", nw, npresent})
+
+		var ew float32
+		epresent := false
+		for _, e := range c.SnapshotEdges() {
+			if e.Tail == "t" && e.Head == "h" {
+				ew, epresent = sumContribs(e), true
+			}
+		}
+		vs = append(vs, verdict{"SnapshotEdges", ew, epresent})
+
+		var gw float32
+		gpresent := false
+		for _, e := range c.SnapshotGraph().Edges {
+			if e.Tail == "t" && e.Head == "h" {
+				gw, gpresent = sumContribs(e), true
+			}
+		}
+		vs = append(vs, verdict{"SnapshotGraph", gw, gpresent})
+
+		for _, v := range vs {
+			if v.present != wantPresent {
+				t.Errorf("G4 %s present=%v, want %v", v.name, v.present, wantPresent)
+			}
+			if wantPresent && !floatNear(v.weight, wantWeight) {
+				t.Errorf("G4 %s weight=%v, want %v", v.name, v.weight, wantWeight)
+			}
+		}
+	}
+
+	c.AddEdgeWithExpiration("t", "h", 2, live)
+	c.AddEdgeWithExpiration("t", "h", 3, live) // additive => 5
+	assertAgree(t, true, 5)
+
+	c.PutEdgeWithExpiration("t", "h", 1.5, live) // replace => 1.5
+	assertAgree(t, true, 1.5)
+
+	c.DeleteEdge("t", "h")
+	assertAgree(t, false, 0)
+}
+
+// testLogicalSnapshotSetConsistency (G5): SnapshotVertices, SnapshotEdges, and
+// SnapshotGraph agree with each other and with GetVertex, and every snapshot
+// edge references a snapshot vertex (referential closure), after an endpoint is
+// deleted.
+func testLogicalSnapshotSetConsistency(t *testing.T) {
+	c := NewGraphCache[string, string](time.Hour)
+	live := time.Now().Add(time.Hour)
+	c.PutVerticesWithExpiration([]VertexItem[string, string]{
+		{Key: "a", Value: "A", Expiration: live},
+		{Key: "b", Value: "B", Expiration: live},
+		{Key: "c", Value: "C", Expiration: live},
+	})
+	c.PutEdgesWithExpiration([]EdgeItem[string]{
+		{Tail: "a", Head: "b", Weight: 1, Expiration: live},
+		{Tail: "b", Head: "c", Weight: 1, Expiration: live},
+	})
+	c.DeleteVertex("c") // makes b->c dangling
+
+	snapV := c.SnapshotVertices()
+	for _, v := range snapV {
+		if _, ok := c.GetVertex(v.Key); !ok {
+			t.Errorf("G5 SnapshotVertices key %q not visible via GetVertex", v.Key)
+		}
+	}
+
+	g := c.SnapshotGraph()
+	if !reflect.DeepEqual(vertexByKey(g.Vertices), vertexByKey(snapV)) {
+		t.Errorf("G5 SnapshotGraph vertices != SnapshotVertices")
+	}
+	if !reflect.DeepEqual(edgeByEndpoints(g.Edges), edgeByEndpoints(c.SnapshotEdges())) {
+		t.Errorf("G5 SnapshotGraph edges != SnapshotEdges")
+	}
+
+	liveKeys := map[string]bool{}
+	for _, v := range snapV {
+		liveKeys[v.Key] = true
+	}
+	for _, e := range g.Edges {
+		if !liveKeys[e.Tail] || !liveKeys[e.Head] {
+			t.Errorf("G5 snapshot edge %s->%s references a non-snapshot vertex", e.Tail, e.Head)
+		}
+	}
+	if _, ok := edgeByEndpoints(g.Edges)[EdgeKey[string]{Tail: "b", Head: "c"}]; ok {
+		t.Error("G5 dangling edge b->c present in snapshot")
 	}
 }

--- a/core/graphcache/search_test.go
+++ b/core/graphcache/search_test.go
@@ -3,6 +3,7 @@ package graphcache
 import (
 	"fmt"
 	"math/rand"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -374,4 +375,47 @@ func TestGraphCache_PutVertices_SearchLifecycle(t *testing.T) {
 			t.Fatalf(`Search("alpha") = %v, want [live]`, got)
 		}
 	})
+}
+
+// TestGraphCache_SearchVertices_LifecycleIntersection pins the #752 search
+// agreement invariant: SearchVertices returns only keys that are simultaneously
+// (a) live in the vertex cache, (b) still carry the queried term after any
+// overwrite, and (c) inside the requested key prefix. Deleted, overwritten-away,
+// and expired-but-not-flushed documents never surface.
+func TestGraphCache_SearchVertices_LifecycleIntersection(t *testing.T) {
+	c := NewGraphCache[string, string](time.Hour)
+	c.EnablePrefixIndex(identityExtract)
+	c.EnableSearchIndex(textExtract)
+	live := time.Now().Add(time.Hour)
+
+	c.PutVertexWithExpiration("eu:1", "harbor", live)
+	c.PutVertexWithExpiration("us:1", "harbor", live)
+	c.PutVertexWithExpiration("eu:2", "harbor", live)
+	c.PutVertexWithExpiration("eu:2", "summit", live) // overwrite drops "harbor"
+	c.DeleteVertex("us:1")                            // delete removes the doc
+	// eu:3 is expired-but-not-flushed: a stale search posting.
+	c.mu.Lock()
+	c.putVertexLocked("eu:3", "harbor", time.Now().Add(-time.Minute))
+	c.mu.Unlock()
+
+	set := func(rs []search.Result[string]) map[string]bool {
+		m := make(map[string]bool, len(rs))
+		for _, r := range rs {
+			m[r.ID] = true
+		}
+		return m
+	}
+
+	// Only eu:1 is live AND still tagged "harbor".
+	if got := set(c.SearchVertices("harbor", 50, "")); !reflect.DeepEqual(got, map[string]bool{"eu:1": true}) {
+		t.Errorf("Search(harbor) = %v, want {eu:1} (us:1 deleted, eu:2 overwritten, eu:3 expired)", got)
+	}
+	// Prefix scoping intersects with liveness: us: has no live harbor doc.
+	if got := set(c.SearchVertices("harbor", 50, "us:")); len(got) != 0 {
+		t.Errorf("Search(harbor, us:) = %v, want empty (us:1 deleted)", got)
+	}
+	// The overwrite term is searchable on the surviving key only.
+	if got := set(c.SearchVertices("summit", 50, "")); !got["eu:2"] {
+		t.Errorf("Search(summit) = %v, want eu:2", got)
+	}
 }

--- a/core/graphcache/snapshot.go
+++ b/core/graphcache/snapshot.go
@@ -113,6 +113,15 @@ func (c *GraphCache[S, T]) snapshotEdgesLocked(now time.Time) []SnapshotEdge[S] 
 		if !nonEmpty {
 			return true
 		}
+		// Referential closure (#750): a snapshot must not stream an edge whose
+		// tail or head vertex is not live. SnapshotGraph flushes expired
+		// vertices before this runs; standalone SnapshotEdges relies on
+		// vertices.Has to hide expired-but-not-flushed endpoints without a
+		// prior flush, so neither path leaks a dangling edge to a deleted or
+		// expired vertex ahead of the GC sweep.
+		if !c.edgeEndpointsLive(tail, head) {
+			return true
+		}
 		out = append(out, SnapshotEdge[S]{
 			Tail:          tail,
 			Head:          head,

--- a/core/graphcache/snapshot_test.go
+++ b/core/graphcache/snapshot_test.go
@@ -150,3 +150,65 @@ func TestGraphCache_SnapshotGraph(t *testing.T) {
 		}
 	})
 }
+
+// TestGraphCache_Snapshot_ReferentialClosure pins the snapshot half of the
+// referential-closure contract (#750): a LIVE edge whose endpoint vertex has
+// been deleted (or has expired but not yet been flushed) must not appear in
+// SnapshotGraph or SnapshotEdges, even before the dangling-edge GC sweep, so a
+// restored backup is always referentially closed.
+func TestGraphCache_Snapshot_ReferentialClosure(t *testing.T) {
+	live := time.Now().Add(time.Hour)
+	build := func() *GraphCache[string, string] {
+		c := NewGraphCache[string, string](time.Hour)
+		c.PutVerticesWithExpiration([]VertexItem[string, string]{
+			{Key: "a", Value: "A", Expiration: live},
+			{Key: "b", Value: "B", Expiration: live},
+		})
+		c.PutEdgesWithExpiration([]EdgeItem[string]{
+			{Tail: "a", Head: "b", Weight: 2, Expiration: live},
+		})
+		return c
+	}
+	danglingKey := EdgeKey[string]{Tail: "a", Head: "b"}
+
+	t.Run("SnapshotGraphHidesDanglingEdge", func(t *testing.T) {
+		c := build()
+		if !c.DeleteVertex("b") {
+			t.Fatal("DeleteVertex(b) reported false")
+		}
+		got := c.SnapshotGraph()
+		if _, ok := vertexByKey(got.Vertices)["b"]; ok {
+			t.Errorf("deleted vertex b present in SnapshotGraph: %v", got.Vertices)
+		}
+		if _, ok := edgeByEndpoints(got.Edges)[danglingKey]; ok {
+			t.Errorf("dangling edge a->b present in SnapshotGraph: %v", got.Edges)
+		}
+		if c.edges.count() != 1 {
+			t.Fatalf("edge bucket count = %d, want 1 (edge still physical before sweep)", c.edges.count())
+		}
+	})
+
+	t.Run("SnapshotEdgesHidesDanglingEdge", func(t *testing.T) {
+		c := build()
+		if !c.DeleteVertex("b") {
+			t.Fatal("DeleteVertex(b) reported false")
+		}
+		for _, e := range c.SnapshotEdges() {
+			if e.Tail == "a" && e.Head == "b" {
+				t.Fatalf("SnapshotEdges streamed dangling edge a->b: %+v", e)
+			}
+		}
+	})
+
+	t.Run("ExpiredNotFlushedEndpointHidden", func(t *testing.T) {
+		c := build()
+		// Make b expired-but-not-flushed without touching the edge bucket.
+		c.mu.Lock()
+		c.putVertexLocked("b", "B", time.Now().Add(-time.Minute))
+		c.mu.Unlock()
+		got := c.SnapshotGraph()
+		if _, ok := edgeByEndpoints(got.Edges)[danglingKey]; ok {
+			t.Errorf("snapshot kept edge to expired-not-flushed endpoint: %v", got.Edges)
+		}
+	})
+}

--- a/core/graphcache/traversal.go
+++ b/core/graphcache/traversal.go
@@ -93,6 +93,12 @@ func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int
 	// them to g.Edges (and expirations, if requested) under mu. It is the
 	// shared body used by both the sequential and worker-pool paths.
 	processTail := func(t S) {
+		// Referential closure (#750): a tail whose vertex is no longer live
+		// contributes no edges, even if its buckets survive until the next
+		// dangling-edge sweep.
+		if !c.vertices.Has(t) {
+			return
+		}
 		heads, ok := c.edges.headsOf(t)
 		if !ok || len(heads) == 0 {
 			return
@@ -105,6 +111,12 @@ func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int
 		for headID, w := range heads {
 			head, ok := c.edges.resolveID(headID)
 			if !ok {
+				continue
+			}
+			// Hide an edge to a head whose vertex is not live (deleted or
+			// expired-but-not-flushed) before it can be scored or selected by
+			// the top-k prune below (#750).
+			if !c.vertices.Has(head) {
 				continue
 			}
 			// Frontier predicate: reject non-matching heads here, BEFORE
@@ -216,11 +228,18 @@ func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int
 		}
 	}
 
-	// Add vertices to the graph
+	// Add vertices to the graph. Every endpoint reached here was gated on
+	// vertices.Has in processTail, so under the held RLock Get returns ok; the
+	// ok check is a defensive guard that keeps a dead endpoint out of the
+	// result rather than inserting a zero value (#750).
 	for tail, heads := range g.Edges {
-		g.Vertices[tail], _ = c.vertices.Get(tail)
+		if v, ok := c.vertices.Get(tail); ok {
+			g.Vertices[tail] = v
+		}
 		for head := range heads {
-			g.Vertices[head], _ = c.vertices.Get(head)
+			if v, ok := c.vertices.Get(head); ok {
+				g.Vertices[head] = v
+			}
 		}
 	}
 

--- a/core/graphcache/traversal_test.go
+++ b/core/graphcache/traversal_test.go
@@ -1,6 +1,7 @@
 package graphcache
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"testing"
@@ -230,6 +231,70 @@ func TestGraphCache_NeighborKeep(t *testing.T) {
 		}
 		if _, ok := g.Edges["bridge"]; ok {
 			t.Errorf("rejected bridge was expanded: %v", g.Edges["bridge"])
+		}
+	})
+}
+
+// TestGraphCache_Neighbor_HidesDeadEndpoints pins the traversal half of the
+// referential-closure contract (#750): neither Neighbor nor
+// NeighborWithExpirationsContext may surface an edge to (or a vertex that is) a
+// deleted/expired endpoint, and a dead intermediary must not be a path to
+// vertices beyond it.
+func TestGraphCache_Neighbor_HidesDeadEndpoints(t *testing.T) {
+	live := time.Now().Add(time.Hour)
+	build := func() *GraphCache[string, string] {
+		c := NewGraphCache[string, string](time.Hour)
+		c.PutVertexWithExpiration("a", "a", live)
+		c.PutVertexWithExpiration("b", "b", live)
+		c.PutVertexWithExpiration("c", "c", live)
+		c.AddEdgeWithExpiration("a", "b", 1, live)
+		c.AddEdgeWithExpiration("b", "c", 1, live)
+		return c
+	}
+
+	t.Run("DeletedHeadDropsEdgeAndVertex", func(t *testing.T) {
+		c := build()
+		if !c.DeleteVertex("b") {
+			t.Fatal("DeleteVertex(b) reported false")
+		}
+		g := c.Neighbor("a", 3, 8, false, false, nil)
+		if _, ok := g.Vertices["b"]; ok {
+			t.Errorf("Neighbor surfaced deleted vertex b: %v", g.Vertices)
+		}
+		if heads, ok := g.Edges["a"]; ok {
+			if _, ok := heads["b"]; ok {
+				t.Errorf("Neighbor surfaced dangling edge a->b: %v", g.Edges)
+			}
+		}
+		if _, ok := g.Edges["b"]; ok {
+			t.Errorf("Neighbor surfaced edges from deleted tail b: %v", g.Edges["b"])
+		}
+		if _, ok := g.Vertices["c"]; ok {
+			t.Errorf("Neighbor reached c through dead intermediary b: %v", g.Vertices)
+		}
+		if _, ok := g.Vertices["a"]; !ok {
+			t.Errorf("Neighbor dropped the live seed a: %v", g.Vertices)
+		}
+	})
+
+	t.Run("ExpirationsMapExcludesDeadEndpoints", func(t *testing.T) {
+		c := build()
+		if !c.DeleteVertex("b") {
+			t.Fatal("DeleteVertex(b) reported false")
+		}
+		g, exps, err := c.NeighborWithExpirationsContext(context.Background(), "a", 3, 8, false, false, nil)
+		if err != nil {
+			t.Fatalf("NeighborWithExpirationsContext: %v", err)
+		}
+		if heads, ok := exps["a"]; ok {
+			if _, ok := heads["b"]; ok {
+				t.Errorf("expirations map surfaced dangling edge a->b: %v", exps)
+			}
+		}
+		if heads, ok := g.Edges["a"]; ok {
+			if _, ok := heads["b"]; ok {
+				t.Errorf("graph surfaced dangling edge a->b: %v", g.Edges)
+			}
 		}
 	})
 }

--- a/tests/integration/backup_test.go
+++ b/tests/integration/backup_test.go
@@ -199,3 +199,51 @@ func TestBackupRestore_E2E_SDK(t *testing.T) {
 		})
 	}
 }
+
+// TestBackupSnapshot_ReferentialClosure_E2E proves the read/snapshot
+// referential-closure contract (#750) end-to-end: after a vertex is deleted via
+// the SDK, BackupSnapshot must not stream that vertex nor any edge incident to
+// it, even though the edge physically survives until the dangling-edge GC sweep.
+func TestBackupSnapshot_ReferentialClosure_E2E(t *testing.T) {
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+	val := provider.NewValidationInterceptor(defaultIntegrationValidationLimits())
+	svc := service.NewLanternService(cache)
+	srv := newConnectTestServer(t, svc, nil, val.ConnectInterceptor())
+	sdk := newConnectClientFor(t, srv.url)
+	raw := graphv1connect.NewLanternServiceClient(h2cClient(), srv.url)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for _, k := range []string{"alice", "bob", "carol"} {
+		if err := sdk.PutVertex(ctx, k, k, time.Minute); err != nil {
+			t.Fatalf("PutVertex %s: %v", k, err)
+		}
+	}
+	if err := sdk.AddEdge(ctx, "alice", "bob", 1.5, time.Minute); err != nil {
+		t.Fatalf("AddEdge alice->bob: %v", err)
+	}
+	if err := sdk.AddEdge(ctx, "bob", "carol", 2.0, time.Minute); err != nil {
+		t.Fatalf("AddEdge bob->carol: %v", err)
+	}
+	if _, err := sdk.DeleteVertex(ctx, "bob"); err != nil {
+		t.Fatalf("DeleteVertex bob: %v", err)
+	}
+
+	vertices, edges := drainBackup(t, ctx, raw, &pb.BackupSnapshotRequest{})
+	if _, ok := vertices["bob"]; ok {
+		t.Errorf("backup streamed deleted vertex bob: %v", vertices)
+	}
+	if _, ok := edges["alice->bob"]; ok {
+		t.Errorf("backup streamed dangling edge alice->bob: %v", edges)
+	}
+	if _, ok := edges["bob->carol"]; ok {
+		t.Errorf("backup streamed dangling edge bob->carol: %v", edges)
+	}
+	// The surviving vertices are still streamed.
+	for _, k := range []string{"alice", "carol"} {
+		if _, ok := vertices[k]; !ok {
+			t.Errorf("backup dropped live vertex %q: %v", k, vertices)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements **#750** and **#752** together (they share one theme: every public surface must observe the **live logical graph**, independent of physical retention and dangling-edge GC timing).

Before this change, an edge could physically outlive a deleted/expired endpoint vertex until the dangling-edge sweep, and during that window the edge was still visible via point reads, prefix scans, traversal, and snapshots — and `CountByPrefix` counted stale radix postings. After this change those surfaces hide such edges/keys immediately.

## Behavior changes (`core/graphcache`)

- **New `edgeEndpointsLive(tail, head)` helper** (`cache.go`) — `vertices.Has(tail) && vertices.Has(head)`; `Has` routes through `Get`, so it also hides expired-but-not-yet-flushed vertices. This is the single enforcement point and reuses the same liveness primitive the additive write fast path (`tryAddExistingEdgeContrib`) already relies on.
- Gated on `edgeEndpointsLive`:
  - `GetWeight`, `GetEdgeDetail` (`cache.go`) — checked after the lock-free edge read, so they stay free of `GraphCache.mu`.
  - `ScanEdgesByPrefix` — both the head-index **fast path** and the materialise-and-sort **fallback** (`edge_prefix.go`).
  - `snapshotEdgesLocked` (`snapshot.go`) — keeps `SnapshotGraph` / `SnapshotEdges` / `BackupSnapshot` referentially closed.
- `Neighbor` / `NeighborWithExpirationsContext` (`traversal.go`) — skip a dead tail, skip a dead head **before** scoring / top-k pruning, and guard final vertex materialization.
- `CountByPrefix` (`prefix.go`) — counts only keys that `resolveProjected` confirms live, so it equals `len(ScanByPrefix)` and the live primary set.

Lock-order safety: the vertex cache carries its own mutex, independent of `GraphCache.mu`. The new check is therefore safe both from the lock-free point reads and from the scan/traversal/snapshot paths that hold `GraphCache.mu` (R or W); vertex evict hooks never nest back onto `GraphCache.mu`/`edges.mu`.

## Tests

**#750 referential closure** — point reads (`cache_test.go`), prefix scan on both index paths (`edge_prefix_test.go`), traversal + expirations map (`traversal_test.go`), `SnapshotGraph`/`SnapshotEdges` with a live edge to a deleted/expired endpoint (`snapshot_test.go`), and a full-stack `BackupSnapshot` E2E (`tests/integration/backup_test.go`). Each asserts the edge is still *physically* present (no sweep) yet logically hidden. Two pre-existing `gc_test.go` assertions that encoded the old physical-count semantics were flipped.

**#752 logical-consistency invariants** (`production_gate_test.go`, new `LogicalConsistency/*` group): vertex visibility agrees across GetVertex/ScanByPrefix/CountByPrefix/SearchVertices/SnapshotVertices/SnapshotGraph; GC is non-observable for reads; no resurrection from stale prefix/search postings; derived edge value agrees across GetWeight/GetEdgeDetail/ScanEdgesByPrefix/Neighbor/SnapshotEdges/SnapshotGraph; snapshot set consistency + referential closure. Plus `CountByPrefix == len(ScanByPrefix) == live set` (`prefix_test.go`) and a combined search lifecycle test (`search_test.go`).

All new tests were verified to **fail** when the enforcement is neutered (point reads/scan/snapshot, traversal head check, and the count filter each independently), confirming they are non-vacuous.

## Verification

- `gofmt -l` clean across touched modules.
- `go test ./...` green in `core/`, `server/` (+`go vet`), root (cli + `tests/integration`), and `mcp/`/`pb/`/`sdks/go/`.
- `go test -race -shuffle=on ./graphcache/` green.

## Fact-check note (#750)

The issue text was written against a pre-#740 tree: its line numbers are stale (`GetWeight`/`GetEdgeDetail` drifted ~+62 lines) and it describes those methods as delegating "under `c.mu.RLock()`", but #740 made them lock-free. The implementation here follows the **current** lock-free shape — the endpoint check runs sequentially after the edge read, not under `GraphCache.mu`. The substance of the issue (no endpoint-liveness check on these surfaces) was accurate and is what this PR fixes.

Closes #750, closes #752

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>