### PR TITLE
chore(release): bump core module pin to v0.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.4.0
-	github.com/anaregdesign/lantern/core v0.10.0
+	github.com/anaregdesign/lantern/core v0.11.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.8.0
 	github.com/anaregdesign/lantern/sdks/go v0.17.0


### PR DESCRIPTION
Bumps the root module's `require` pin for `github.com/anaregdesign/lantern/core` from `v0.10.0` to the freshly-tagged **core/v0.11.0**.

That release carries the live-endpoint visibility / logical-consistency work (#750, #752, via #756) plus the #737–#745 graphcache/mutationlog performance series.

One-line `go.mod` change. The `replace github.com/anaregdesign/lantern/core => ./core` directive means no `go.sum` entry is needed (mirrors the prior pin bump #731).

Release step 4/5 — root `v0.21.0` tag follows once this merges.