### PR TITLE
feat(search): exclude JSON field names and non-string values from the vertex content index

### DIFF
--- a/core/search/normalizer.go
+++ b/core/search/normalizer.go
@@ -1,6 +1,8 @@
 package search
 
 import (
+	"encoding/json"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -99,6 +101,80 @@ type WidthNormalizer struct{}
 // Normalize folds full-width and half-width variants to their normal width.
 func (WidthNormalizer) Normalize(text string) string {
 	return width.Fold.String(text)
+}
+
+// JSONStringValueNormalizer rewrites text that is a JSON object or array into
+// just the text of its string values, dropping every object field name (key)
+// and every non-string scalar (number, boolean, null). Its purpose is to keep
+// a full-text index free of JSON structure: when a vertex stores a serialized
+// document such as {"role":"admin","score":9,"active":true}, only the human
+// content ("admin") becomes searchable — not the field names ("role", "score",
+// "active") and not the numeric or boolean scalars. String values are emitted
+// in object-key sorted order (arrays keep their order) so the output is
+// deterministic and re-indexing is idempotent.
+//
+// Text that is not a JSON object or array passes through unchanged: a fast path
+// returns the input verbatim when the first non-space byte is neither '{' nor
+// '[', and any string that starts that way but fails to parse as JSON is also
+// returned verbatim (so a value that merely looks like JSON is still indexed as
+// raw text). A JSON object/array carrying no string values normalizes to the
+// empty string.
+//
+// Unlike the other normalizers in this package, this one is meant to run on a
+// value in isolation — the document projection of a single stored value — not
+// on a composed document such as "key value", because a key concatenated with
+// a JSON blob is not itself valid JSON and the fast path would return it
+// unchanged. Place it at the projection step, not in a shared analyzer chain.
+type JSONStringValueNormalizer struct{}
+
+// Normalize returns the space-joined string values of a JSON object or array,
+// or the input unchanged when it is not such a document.
+func (JSONStringValueNormalizer) Normalize(text string) string {
+	trimmed := strings.TrimSpace(text)
+	// Only a JSON object or array is treated as structured JSON. Plain prose
+	// and bare scalars (including a quoted JSON string) are left untouched, so
+	// values like "true" or "42" stay searchable as their literal text.
+	if len(trimmed) == 0 || (trimmed[0] != '{' && trimmed[0] != '[') {
+		return text
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+		return text // looked like JSON but is not: index the raw text as-is.
+	}
+	var b strings.Builder
+	appendJSONStringValues(&b, parsed)
+	return b.String()
+}
+
+// appendJSONStringValues walks a value decoded from JSON and appends every
+// string it contains to b, separated by single spaces. Object keys and
+// non-string scalars are skipped; objects are visited in sorted-key order for
+// deterministic output.
+func appendJSONStringValues(b *strings.Builder, v any) {
+	switch val := v.(type) {
+	case string:
+		if val == "" {
+			return
+		}
+		if b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(val)
+	case []any:
+		for _, e := range val {
+			appendJSONStringValues(b, e)
+		}
+	case map[string]any:
+		keys := make([]string, 0, len(val))
+		for k := range val {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			appendJSONStringValues(b, val[k])
+		}
+	}
+	// float64 (numbers), bool, and nil carry no searchable text: skipped.
 }
 
 // dropNonspacingMark returns r unless r is a Unicode nonspacing combining mark

--- a/core/search/normalizer_test.go
+++ b/core/search/normalizer_test.go
@@ -88,3 +88,40 @@ func TestWidthNormalizer(t *testing.T) {
 		})
 	}
 }
+
+func TestJSONStringValueNormalizer(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Non-JSON text passes through untouched.
+		{"PlainProse", "calm and concise", "calm and concise"},
+		{"BareScalarWord", "true", "true"},
+		{"BareNumberWord", "42", "42"},
+		{"QuotedScalarLeftAsLiteral", `"hello"`, `"hello"`},
+		{"Empty", "", ""},
+		{"NotJSONButBrace", "{not valid json", "{not valid json"},
+		// Objects drop field names, keep string values in sorted-key order.
+		{"ObjectDropsKeys", `{"role":"admin","name":"Alice"}`, "Alice admin"},
+		// Non-string scalars are filtered out.
+		{"FiltersNonStrings", `{"role":"admin","score":9,"active":true,"note":null}`, "admin"},
+		{"OnlyNonStrings", `{"a":1,"b":false,"c":null}`, ""},
+		{"EmptyObject", "{}", ""},
+		{"EmptyStringValuesSkipped", `{"a":"","b":"x"}`, "x"},
+		// Arrays keep order; nested structures recurse.
+		{"ArrayOfStringsFiltersScalars", `["red","green",2,true]`, "red green"},
+		{"NestedObjectAndArray", `{"user":{"name":"Alice"},"tags":["go","db"],"n":5}`, "go db Alice"},
+		// Surrounding whitespace is tolerated before parsing.
+		{"LeadingWhitespace", `  {"x":"y"}  `, "y"},
+		// A top-level array of objects.
+		{"ArrayOfObjects", `[{"t":"hi"},{"t":"bye","skip":1}]`, "hi bye"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := (JSONStringValueNormalizer{}).Normalize(tc.in); got != tc.want {
+				t.Fatalf("Normalize(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/provider/search.go
+++ b/server/provider/search.go
@@ -9,6 +9,11 @@ import (
 	v1 "github.com/anaregdesign/lantern/pb/graph/v1"
 )
 
+// jsonStringValueNormalizer extracts only the string values from a JSON
+// object/array value, dropping field names and non-string scalars, and passes
+// non-JSON text through unchanged (#758). It is stateless and safe to share.
+var jsonStringValueNormalizer search.JSONStringValueNormalizer
+
 // vertexSearchDocument projects a vertex into the text that the full-text
 // index analyses (#624). It folds the key together with the value so a query
 // matches either the namespace path or the stored content — this mirrors the
@@ -20,6 +25,12 @@ import (
 // pass through, scalars are formatted decimally, timestamps use RFC3339 and
 // durations their Go form. The nil/unset variant contributes nothing, so an
 // existence-only vertex is still discoverable by its key alone.
+//
+// String values that hold a JSON object or array are projected to just their
+// string values (#758): JSONStringValueNormalizer drops the field names and
+// non-string scalars so a serialized document is searchable by its content,
+// not by its structure. A JSON document carrying no string content therefore
+// folds in nothing and the vertex is indexed by its key alone.
 func vertexSearchDocument(v *v1.Vertex) search.Document {
 	if v == nil {
 		return search.Text("")
@@ -39,7 +50,11 @@ func vertexSearchDocument(v *v1.Vertex) search.Document {
 func vertexValueText(v *v1.Vertex) (string, bool) {
 	switch val := v.GetValue().(type) {
 	case *v1.Vertex_String_:
-		return val.String_, true
+		// A string value is often a serialized JSON document; index only its
+		// string values, never the JSON field names or non-string scalars
+		// (#758). Non-JSON text passes through unchanged. An all-structure or
+		// empty result folds in nothing (the caller drops empty value text).
+		return jsonStringValueNormalizer.Normalize(val.String_), true
 	case *v1.Vertex_Bytes:
 		return string(val.Bytes), true
 	case *v1.Vertex_Float64:

--- a/server/provider/search_test.go
+++ b/server/provider/search_test.go
@@ -49,6 +49,26 @@ func TestVertexSearchDocument(t *testing.T) {
 			want:   "flag true",
 		},
 		{
+			name:   "json object string value drops field names and non-strings",
+			vertex: &v1.Vertex{Key: "profile", Value: &v1.Vertex_String_{String_: `{"role":"admin","name":"Alice","score":9,"active":true}`}},
+			want:   "profile Alice admin",
+		},
+		{
+			name:   "json array string value keeps only strings",
+			vertex: &v1.Vertex{Key: "tags", Value: &v1.Vertex_String_{String_: `["go","db",2,true]`}},
+			want:   "tags go db",
+		},
+		{
+			name:   "json object with no string content indexes key only",
+			vertex: &v1.Vertex{Key: "counters", Value: &v1.Vertex_String_{String_: `{"a":1,"b":false,"c":null}`}},
+			want:   "counters",
+		},
+		{
+			name:   "plain string value is not treated as json",
+			vertex: &v1.Vertex{Key: "note", Value: &v1.Vertex_String_{String_: "calm and concise"}},
+			want:   "note calm and concise",
+		},
+		{
 			name:   "empty string value yields key only (no trailing space)",
 			vertex: &v1.Vertex{Key: "k", Value: &v1.Vertex_String_{String_: ""}},
 			want:   "k",
@@ -77,6 +97,38 @@ func TestNewGraphCache_SearchEnabledIndexesKeyAndValue(t *testing.T) {
 	// Match by key content (MCP search_facts parity: key words are searchable).
 	if hits := gc.SearchVertices("preferences", 10, ""); len(hits) == 0 {
 		t.Errorf("expected a hit searching key text 'preferences', got none")
+	}
+}
+
+func TestNewGraphCache_SearchJSONStringValueFiltersStructure(t *testing.T) {
+	gc := NewGraphCache(CacheConfig{TTL: time.Minute}, SearchConfig{Enabled: true})
+	gc.PutVertex("user.profile", &v1.Vertex{
+		Key:   "user.profile",
+		Value: &v1.Vertex_String_{String_: `{"role":"administrator","city":"Tokyo","score":9000,"active":true}`},
+	})
+
+	// String values are searchable.
+	if hits := gc.SearchVertices("administrator", 10, ""); len(hits) == 0 {
+		t.Errorf("expected a hit searching JSON string value 'administrator', got none")
+	}
+	if hits := gc.SearchVertices("Tokyo", 10, ""); len(hits) == 0 {
+		t.Errorf("expected a hit searching JSON string value 'Tokyo', got none")
+	}
+
+	// Field names and non-string scalars are excluded from the index. The
+	// exact projected text is asserted deterministically by
+	// TestVertexSearchDocument; an end-to-end negative is verified here with
+	// bigram-disjoint tokens so the n-gram analyzer cannot produce an
+	// incidental partial-overlap hit through the key or the string values.
+	gc.PutVertex("zzzz", &v1.Vertex{
+		Key:   "zzzz",
+		Value: &v1.Vertex_String_{String_: `{"qqqq":"hello","wwww":4242}`},
+	})
+	if hits := gc.SearchVertices("qqqq", 10, ""); len(hits) != 0 {
+		t.Errorf("expected no hit searching JSON field name 'qqqq', got %d", len(hits))
+	}
+	if hits := gc.SearchVertices("4242", 10, ""); len(hits) != 0 {
+		t.Errorf("expected no hit searching JSON numeric value '4242', got %d", len(hits))
 	}
 }
 


### PR DESCRIPTION
## What

`string` vertex values frequently hold a serialized JSON document. The content index (`SearchVertices`, #624) previously indexed the whole value text, so JSON **field names** (object keys) and **non-string scalars** (numbers, booleans, `null`) became searchable terms — structure leaking into the search surface.

This adds a reusable `core/search` Normalizer and wires it into the server's vertex value projection so a JSON string value contributes **only its string values** to the index.

## Changes

- **`core/search/normalizer.go`** — new `JSONStringValueNormalizer` (implements `Normalizer`):
  - Fast path: text not starting with `{` / `[` (after trim) is returned unchanged — plain prose and bare scalars are never reinterpreted as JSON.
  - Parses a JSON object/array and emits only its string values, dropping object keys and skipping numbers / booleans / `null`. Objects are visited in sorted-key order for deterministic, idempotent output. Invalid JSON falls back to the raw text.
- **`server/provider/search.go`** — `vertexValueText` runs the `*Vertex_String_` case through the normalizer. The vertex **key** stays fully searchable (MCP `search_facts` parity); only the JSON **value** is filtered. A JSON document with no string content folds in nothing (key-only indexing).
- Tests appended to `core/search/normalizer_test.go` and `server/provider/search_test.go` (1:1 pairing). Exact field-name/scalar exclusion is asserted deterministically at the projection level; the end-to-end search test asserts positives plus a bigram-disjoint negative.

## Verification

- `gofmt -l` clean; `go vet ./...` (server) clean.
- `go test ./...` green from root and every submodule (`core`, `server`, `pb`, `sdks/go`, `mcp`), including `tests/integration`.

Closes #758
