### PR TITLE
feat(admin): render JSON string vertex values as linted, syntax-highlighted code

### DIFF
--- a/admin/app/components/shared/StringValueView/JsonCodeBlock.tsx
+++ b/admin/app/components/shared/StringValueView/JsonCodeBlock.tsx
@@ -1,0 +1,49 @@
+import { Fragment, useMemo } from "react";
+
+import { tokenizeJson, type JsonTokenKind } from "./json";
+import styles from "./StringValueView.module.css";
+
+export interface JsonCodeBlockProps {
+  /** Pretty-printed JSON to render with syntax highlighting. */
+  code: string;
+  "data-testid"?: string;
+}
+
+const TOKEN_CLASS: Record<JsonTokenKind, string | undefined> = {
+  key: styles.jsonKey,
+  string: styles.jsonString,
+  number: styles.jsonNumber,
+  boolean: styles.jsonKeyword,
+  null: styles.jsonKeyword,
+  punctuation: styles.jsonPunct,
+  whitespace: undefined,
+};
+
+/**
+ * Renders linted JSON as a syntax-highlighted code block. The hand-rolled
+ * {@link tokenizeJson} classifies each run of source text and we wrap it in a
+ * theme-aware coloured span; whitespace passes through untouched so the
+ * two-space indentation is preserved exactly inside the `<pre>`.
+ */
+export function JsonCodeBlock({
+  code,
+  "data-testid": testId,
+}: JsonCodeBlockProps) {
+  const tokens = useMemo(() => tokenizeJson(code), [code]);
+  return (
+    <pre className={styles.json} data-testid={testId}>
+      <code>
+        {tokens.map((token, index) => {
+          const className = TOKEN_CLASS[token.kind];
+          return className ? (
+            <span key={index} className={className}>
+              {token.text}
+            </span>
+          ) : (
+            <Fragment key={index}>{token.text}</Fragment>
+          );
+        })}
+      </code>
+    </pre>
+  );
+}

--- a/admin/app/components/shared/StringValueView/StringValueView.module.css
+++ b/admin/app/components/shared/StringValueView/StringValueView.module.css
@@ -19,12 +19,13 @@
   font-style: italic;
 }
 
-/* Shared box around both Raw and Markdown bodies: bounded height with
+/* Shared box around the Raw, Markdown, and JSON bodies: bounded height with
    vertical scroll so an oversized value scrolls inside the card instead of
    pushing the page. `min-width: 0` lets it shrink below intrinsic content
    width inside a grid/flex track. */
 .raw,
-.markdown {
+.markdown,
+.json {
   margin: 0;
   min-width: 0;
   max-height: 480px;
@@ -48,6 +49,48 @@
   font-size: var(--fontSizeBase300, 14px);
   line-height: 1.5;
   color: var(--colorNeutralForeground1, #242424);
+}
+
+/* JSON view — preserve the linted indentation exactly; scroll long lines
+   horizontally rather than wrapping so structure stays aligned. */
+.json {
+  white-space: pre;
+  font-family: var(
+    --fontFamilyMonospace,
+    ui-monospace,
+    SFMono-Regular,
+    monospace
+  );
+  font-size: var(--fontSizeBase300, 14px);
+  line-height: 1.5;
+  color: var(--colorNeutralForeground1, #242424);
+}
+
+.json code {
+  font: inherit;
+}
+
+/* Syntax-highlight token colours — Fluent palette tokens resolve to readable
+   values in both light and dark themes; the hex fallbacks track the light
+   theme for environments that have not injected the theme variables. */
+.jsonKey {
+  color: var(--colorPaletteBlueForeground2, #0f6cbd);
+}
+
+.jsonString {
+  color: var(--colorPaletteGreenForeground2, #0e700e);
+}
+
+.jsonNumber {
+  color: var(--colorPaletteBerryForeground2, #ad1457);
+}
+
+.jsonKeyword {
+  color: var(--colorPaletteDarkOrangeForeground2, #bc4b09);
+}
+
+.jsonPunct {
+  color: var(--colorNeutralForeground3, #616161);
 }
 
 /* Markdown view — readable prose, theme-aware. */

--- a/admin/app/components/shared/StringValueView/StringValueView.tsx
+++ b/admin/app/components/shared/StringValueView/StringValueView.tsx
@@ -1,8 +1,16 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { Button, Switch, Tooltip } from "@fluentui/react-components";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Button,
+  Switch,
+  Tab,
+  TabList,
+  Tooltip,
+} from "@fluentui/react-components";
 import { Copy16Regular } from "@fluentui/react-icons";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { formatJson } from "./json";
+import { JsonCodeBlock } from "./JsonCodeBlock";
 import styles from "./StringValueView.module.css";
 
 export interface StringValueViewProps {
@@ -12,22 +20,31 @@ export interface StringValueViewProps {
 
 const COPIED_RESET_MS = 1_200;
 
+/** Which body the JSON renderer shows: the highlighted view or the raw text. */
+type JsonView = "formatted" | "raw";
+
 /**
- * Detail-surface renderer for `string` vertex values (#644). Unlike the
- * compact, single-line {@link ValueCell} used in tables, this shows the
- * full payload multi-line (`pre-wrap`) inside a bounded, scrollable box so
- * large blobs (e.g. agent-memory notes) stay readable without blowing out
- * the layout. A Raw ⇄ Markdown `Switch` (default Raw) renders the value as
- * GitHub-flavored Markdown on demand.
+ * Detail-surface renderer for `string` vertex values (#644, #759). Unlike the
+ * compact, single-line {@link ValueCell} used in tables, this shows the full
+ * payload inside a bounded, scrollable box so large blobs (e.g. agent-memory
+ * notes) stay readable without blowing out the layout.
+ *
+ * When the value parses as a JSON object or array the renderer leads with a
+ * linted (pretty-printed), syntax-highlighted code view and a JSON ⇄ Raw
+ * `TabList`. Otherwise it keeps the prose-oriented Raw ⇄ Markdown `Switch`
+ * (default Raw) that renders the value as GitHub-flavored Markdown on demand.
  *
  * Security: Markdown renders an arbitrary stored string, so this is an
  * XSS-sensitive path. We rely on `react-markdown`'s safe defaults — raw
  * HTML is NOT passed through (no `rehype-raw`/`allowDangerousHtml`) and the
  * built-in `urlTransform` neutralizes `javascript:` URLs. Rendered links
- * additionally open in a new tab with `rel="noopener noreferrer"`.
+ * additionally open in a new tab with `rel="noopener noreferrer"`. The JSON
+ * highlighter renders only plain text spans, never HTML.
  */
 export function StringValueView({ value }: StringValueViewProps) {
+  const json = useMemo(() => formatJson(value), [value]);
   const [markdown, setMarkdown] = useState(false);
+  const [jsonView, setJsonView] = useState<JsonView>("formatted");
   const [copied, setCopied] = useState(false);
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -61,6 +78,56 @@ export function StringValueView({ value }: StringValueViewProps) {
     );
   }
 
+  const copyButton = (
+    <Tooltip
+      content={copied ? "Copied" : "Copy value"}
+      relationship="label"
+      withArrow
+    >
+      <Button
+        appearance="subtle"
+        size="small"
+        icon={<Copy16Regular />}
+        aria-label="Copy string value"
+        data-testid="vertex-string-copy"
+        onClick={() => void copy()}
+      />
+    </Tooltip>
+  );
+
+  if (json) {
+    return (
+      <div className={styles.root} data-testid="vertex-string-view">
+        <div className={styles.toolbar}>
+          <TabList
+            selectedValue={jsonView}
+            onTabSelect={(_, data) => setJsonView(data.value as JsonView)}
+            size="small"
+            data-testid="vertex-string-json-tabs"
+          >
+            <Tab value="formatted" data-testid="vertex-string-json-tab">
+              JSON
+            </Tab>
+            <Tab value="raw" data-testid="vertex-string-raw-tab">
+              Raw
+            </Tab>
+          </TabList>
+          {copyButton}
+        </div>
+        {jsonView === "formatted" ? (
+          <JsonCodeBlock
+            code={json.formatted}
+            data-testid="vertex-string-json"
+          />
+        ) : (
+          <pre className={styles.raw} data-testid="vertex-string-raw">
+            {value}
+          </pre>
+        )}
+      </div>
+    );
+  }
+
   return (
     <div className={styles.root} data-testid="vertex-string-view">
       <div className={styles.toolbar}>
@@ -70,20 +137,7 @@ export function StringValueView({ value }: StringValueViewProps) {
           label="Markdown"
           data-testid="vertex-string-markdown-toggle"
         />
-        <Tooltip
-          content={copied ? "Copied" : "Copy value"}
-          relationship="label"
-          withArrow
-        >
-          <Button
-            appearance="subtle"
-            size="small"
-            icon={<Copy16Regular />}
-            aria-label="Copy string value"
-            data-testid="vertex-string-copy"
-            onClick={() => void copy()}
-          />
-        </Tooltip>
+        {copyButton}
       </div>
       {markdown ? (
         <div className={styles.markdown} data-testid="vertex-string-markdown">

--- a/admin/app/components/shared/StringValueView/json.test.ts
+++ b/admin/app/components/shared/StringValueView/json.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "bun:test";
+
+import { formatJson, tokenizeJson, type JsonToken } from "./json";
+
+describe("formatJson", () => {
+  it("pretty-prints a JSON object with two-space indent", () => {
+    const out = formatJson('{"b":2,"a":"x"}');
+    expect(out).not.toBeNull();
+    expect(out?.formatted).toBe('{\n  "b": 2,\n  "a": "x"\n}');
+  });
+
+  it("pretty-prints a JSON array", () => {
+    expect(formatJson('["a",1]')?.formatted).toBe('[\n  "a",\n  1\n]');
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(formatJson('  {"a":1}  ')?.formatted).toBe('{\n  "a": 1\n}');
+  });
+
+  it("returns null for plain prose", () => {
+    expect(formatJson("calm and concise")).toBeNull();
+  });
+
+  it("returns null for bare scalars even if valid JSON", () => {
+    expect(formatJson("42")).toBeNull();
+    expect(formatJson("true")).toBeNull();
+    expect(formatJson('"quoted"')).toBeNull();
+  });
+
+  it("returns null for the empty string", () => {
+    expect(formatJson("")).toBeNull();
+  });
+
+  it("returns null for malformed JSON that looks like an object", () => {
+    expect(formatJson("{not valid")).toBeNull();
+  });
+});
+
+function kinds(tokens: JsonToken[]): string[] {
+  return tokens.filter((t) => t.kind !== "whitespace").map((t) => t.kind);
+}
+
+function roundTrip(tokens: JsonToken[]): string {
+  return tokens.map((t) => t.text).join("");
+}
+
+describe("tokenizeJson", () => {
+  it("reproduces the input exactly when concatenated", () => {
+    const src = '{\n  "name": "Alice",\n  "score": 9,\n  "active": true\n}';
+    expect(roundTrip(tokenizeJson(src))).toBe(src);
+  });
+
+  it("classifies object keys distinctly from string values", () => {
+    const tokens = tokenizeJson('{"name":"Alice"}');
+    expect(kinds(tokens)).toEqual([
+      "punctuation",
+      "key",
+      "punctuation",
+      "string",
+      "punctuation",
+    ]);
+  });
+
+  it("classifies numbers, booleans, and null", () => {
+    expect(kinds(tokenizeJson('{"a":9}'))).toEqual([
+      "punctuation",
+      "key",
+      "punctuation",
+      "number",
+      "punctuation",
+    ]);
+    expect(kinds(tokenizeJson('{"a":true}')).at(-2)).toBe("boolean");
+    expect(kinds(tokenizeJson('{"a":null}')).at(-2)).toBe("null");
+  });
+
+  it("handles negative and exponent numbers", () => {
+    const tokens = tokenizeJson("[-1.5e10]");
+    const num = tokens.find((t) => t.kind === "number");
+    expect(num?.text).toBe("-1.5e10");
+  });
+
+  it("does not end a string early on an escaped quote", () => {
+    const tokens = tokenizeJson('{"a":"he said \\"hi\\""}');
+    const value = tokens.filter((t) => t.kind === "string");
+    expect(value).toHaveLength(1);
+    expect(value[0]?.text).toBe('"he said \\"hi\\""');
+  });
+
+  it("treats a key literally named like a keyword as a key", () => {
+    const tokens = tokenizeJson('{"null":1}');
+    expect(tokens.find((t) => t.text === '"null"')?.kind).toBe("key");
+  });
+});

--- a/admin/app/components/shared/StringValueView/json.ts
+++ b/admin/app/components/shared/StringValueView/json.ts
@@ -1,0 +1,140 @@
+// Pure helpers for the JSON-aware rendering of `string` vertex values (#759).
+// No React, no dependencies — the tokenizer is hand-rolled so syntax
+// highlighting costs the bundle nothing.
+
+/** The linted (pretty-printed) form of a JSON value. */
+export interface FormattedJson {
+  /** The value re-serialized with two-space indentation. */
+  formatted: string;
+}
+
+/**
+ * Returns the linted (pretty-printed) form of `value` when it parses as a JSON
+ * object or array, otherwise `null`. Only `{`/`[` documents qualify, so plain
+ * prose and bare scalars (a lone number, `true`, a quoted word) are never
+ * reinterpreted as JSON. The pretty-print doubles as validation: malformed
+ * JSON throws and yields `null`, falling back to the raw text view.
+ */
+export function formatJson(value: string): FormattedJson | null {
+  const trimmed = value.trim();
+  if (trimmed === "" || (trimmed[0] !== "{" && trimmed[0] !== "[")) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  // A leading `{`/`[` guarantees an object or array, but guard anyway so a
+  // non-object can never slip through to the highlighter.
+  if (parsed === null || typeof parsed !== "object") {
+    return null;
+  }
+  return { formatted: JSON.stringify(parsed, null, 2) };
+}
+
+/** The lexical class of a JSON token, used to pick a highlight colour. */
+export type JsonTokenKind =
+  | "key"
+  | "string"
+  | "number"
+  | "boolean"
+  | "null"
+  | "punctuation"
+  | "whitespace";
+
+/** A contiguous run of source text classified for syntax highlighting. */
+export interface JsonToken {
+  kind: JsonTokenKind;
+  text: string;
+}
+
+function isWhitespace(c: string): boolean {
+  return c === " " || c === "\n" || c === "\t" || c === "\r";
+}
+
+function isDigit(c: string): boolean {
+  return c >= "0" && c <= "9";
+}
+
+// readString returns the index just past the closing quote of the JSON string
+// that starts at `start` (where source[start] === '"'). Escaped characters are
+// skipped so an embedded \" does not end the string early.
+function readString(source: string, start: number): number {
+  let i = start + 1;
+  while (i < source.length) {
+    const c = source[i];
+    if (c === "\\") {
+      i += 2;
+      continue;
+    }
+    if (c === '"') {
+      return i + 1;
+    }
+    i++;
+  }
+  return i; // unterminated — only reachable on malformed input
+}
+
+// readNumber returns the index just past the JSON number starting at `start`.
+function readNumber(source: string, start: number): number {
+  let i = start;
+  if (source[i] === "-") i++;
+  while (i < source.length && isDigit(source[i])) i++;
+  if (source[i] === ".") {
+    i++;
+    while (i < source.length && isDigit(source[i])) i++;
+  }
+  if (source[i] === "e" || source[i] === "E") {
+    i++;
+    if (source[i] === "+" || source[i] === "-") i++;
+    while (i < source.length && isDigit(source[i])) i++;
+  }
+  return i;
+}
+
+/**
+ * Splits pretty-printed JSON into a flat list of highlight tokens that, when
+ * concatenated, reproduce the input exactly (whitespace included), so a caller
+ * can wrap each token in a coloured span inside a `<pre>`. A quoted string is
+ * classified as a `key` when the next non-whitespace character is `:`, else as
+ * a `string`. The tokenizer never throws; on unexpected input it falls back to
+ * single-character punctuation tokens.
+ */
+export function tokenizeJson(source: string): JsonToken[] {
+  const tokens: JsonToken[] = [];
+  const n = source.length;
+  let i = 0;
+  while (i < n) {
+    const c = source[i];
+    if (isWhitespace(c)) {
+      let end = i + 1;
+      while (end < n && isWhitespace(source[end])) end++;
+      tokens.push({ kind: "whitespace", text: source.slice(i, end) });
+      i = end;
+    } else if (c === '"') {
+      const end = readString(source, i);
+      let j = end;
+      while (j < n && isWhitespace(source[j])) j++;
+      const kind: JsonTokenKind = source[j] === ":" ? "key" : "string";
+      tokens.push({ kind, text: source.slice(i, end) });
+      i = end;
+    } else if (c === "-" || isDigit(c)) {
+      const end = readNumber(source, i);
+      tokens.push({ kind: "number", text: source.slice(i, end) });
+      i = end;
+    } else if (source.startsWith("true", i) || source.startsWith("false", i)) {
+      const word = source.startsWith("true", i) ? "true" : "false";
+      tokens.push({ kind: "boolean", text: word });
+      i += word.length;
+    } else if (source.startsWith("null", i)) {
+      tokens.push({ kind: "null", text: "null" });
+      i += 4;
+    } else {
+      tokens.push({ kind: "punctuation", text: c });
+      i++;
+    }
+  }
+  return tokens;
+}

--- a/admin/tests/e2e/crud.spec.ts
+++ b/admin/tests/e2e/crud.spec.ts
@@ -91,6 +91,49 @@ test.describe("vertex detail", () => {
     await expect(page.getByTestId("vertex-string-raw")).toHaveCount(0);
   });
 
+  test("JSON string values render linted and syntax-highlighted with a Raw tab (#759)", async ({
+    page,
+  }) => {
+    const key = `${VERTEX_KEY}:json`;
+    await putVertices([
+      {
+        key,
+        string: '{"role":"admin","name":"Alice","score":9,"active":true}',
+      },
+    ]);
+
+    await page.goto(`/vertices/${encodeURIComponent(key)}`);
+    await expect(page.getByTestId("vertex-detail-read")).toBeVisible();
+
+    const view = page.getByTestId("vertex-string-view");
+    await expect(view).toBeVisible();
+
+    // JSON is detected, so the prose Markdown Switch is replaced by a
+    // JSON ⇄ Raw TabList and the highlighted view leads by default.
+    await expect(page.getByTestId("vertex-string-markdown-toggle")).toHaveCount(
+      0,
+    );
+    const json = page.getByTestId("vertex-string-json");
+    await expect(json).toBeVisible();
+
+    // Linted: the compact input is pretty-printed with indentation.
+    await expect(json).toContainText('"role": "admin"');
+    await expect(json).toContainText('"score": 9');
+    // Syntax-highlighted: tokens are wrapped in coloured spans.
+    await expect(
+      json.locator("span").filter({ hasText: "admin" }).first(),
+    ).toBeVisible();
+
+    // The Raw tab reveals the original, unformatted string.
+    await page.getByTestId("vertex-string-raw-tab").click();
+    const raw = page.getByTestId("vertex-string-raw");
+    await expect(raw).toBeVisible();
+    await expect(raw).toContainText(
+      '{"role":"admin","name":"Alice","score":9,"active":true}',
+    );
+    await expect(page.getByTestId("vertex-string-json")).toHaveCount(0);
+  });
+
   test("loads the seeded vertex and switches kind via save round-trip", async ({
     page,
   }) => {


### PR DESCRIPTION
## What

On the Vertex detail screen, `string` values that hold a JSON document now render as a **linted (pretty-printed), syntax-highlighted** code view instead of a raw blob. JSON is the common agent-memory shape and was previously shown as an unformatted single run of text.

## Changes

`admin/app/components/shared/StringValueView/`:

- **`json.ts`** (new, pure, zero deps):
  - `formatJson(value)` → pretty-printed JSON (`JSON.stringify(parse, null, 2)`, which also validates) only when the value parses as a JSON object/array; `null` otherwise so plain prose and bare scalars are left alone.
  - `tokenizeJson(source)` → a hand-rolled tokenizer that classifies keys / strings / numbers / booleans / null / punctuation / whitespace and reproduces the input exactly when concatenated.
- **`JsonCodeBlock.tsx`** (new): renders the tokens as theme-aware coloured `<span>`s inside `<pre><code>`; whitespace passes through untouched to preserve the indentation. Renders only text spans — no HTML.
- **`StringValueView.tsx`**: when the value is JSON, leads with the highlighted view behind a **JSON ⇄ Raw** `TabList`; otherwise keeps the existing prose **Raw ⇄ Markdown** `Switch` unchanged (no regression to #644).
- **`StringValueView.module.css`**: JSON code-block box + Fluent-palette token colours (light/dark aware, hex fallbacks).

## Verification

- `bun run format` / `lint` (0 errors) / `typecheck` / `test` (673 pass, incl. new `json.test.ts`) / `build` all green locally.
- Added an e2e (`crud.spec.ts`): seeds a JSON string vertex, asserts the linted + highlighted view leads by default (spans present, `"role": "admin"` pretty-printed) and the Raw tab reveals the original string. The existing markdown test value is not JSON, so it stays on the Switch path.
- The full Playwright suite runs in CI (`admin.yml` Build job); it was not run locally because a pre-existing benchmark docker stack on this machine holds the e2e ports.

## Scope / non-goals

- No new runtime dependency (hand-rolled highlighter).
- Search-side JSON filtering ships separately (#758).

Closes #759
