### PR TITLE
chore(release): bump core module pin to v0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.4.0
-	github.com/anaregdesign/lantern/core v0.11.0
+	github.com/anaregdesign/lantern/core v0.12.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.8.0
 	github.com/anaregdesign/lantern/sdks/go v0.17.0


### PR DESCRIPTION
Bumps the root `go.mod` `require github.com/anaregdesign/lantern/core` from v0.11.0 to v0.12.0 ahead of the next root release. core/v0.12.0 ships the new `JSONStringValueNormalizer` (#758) that the server's search projection consumes. Replace-backed, so no go.sum churn and local/CI builds are unaffected — the require is metadata for downstream `go install` consumers.