### PR TITLE
feat(sdks/go): add IncrementalSearch search-as-you-type driver

### DIFF
--- a/sdks/go/search_incremental.go
+++ b/sdks/go/search_incremental.go
@@ -1,0 +1,281 @@
+// Package client: search_incremental.go owns IncrementalSearch, the
+// search-as-you-type driver that wraps SearchVertices with debounce,
+// in-flight cancellation, and stale-drop so a UI can fire a fresh search on
+// every keystroke and only ever observe the result of the LATEST query.
+//
+// It is the full-text analogue of the admin SPA's vertex picker: rapid query
+// updates are coalesced and debounced, a newer query cancels the previous
+// in-flight RPC, and a late reply from a superseded query is dropped (never
+// delivered out of order). The wire surface is unchanged — IncrementalSearch
+// is pure client-side orchestration over the existing SearchVertices RPC, so
+// it needs no proto or server support.
+package client
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// defaultIncrementalDebounce is the debounce window applied between the last
+// Search call and the dispatched RPC when WithDebounce is not supplied. It
+// mirrors the admin SPA's SUGGEST_DEBOUNCE_MS so the Go and browser
+// search-as-you-type surfaces feel identical.
+const defaultIncrementalDebounce = 150 * time.Millisecond
+
+// defaultMinQueryLength is the shortest query (in runes) that triggers an RPC
+// when WithMinQueryLength is not supplied. A shorter query short-circuits to
+// an empty result without a round-trip.
+const defaultMinQueryLength = 1
+
+// SearchUpdate is one delivery on IncrementalSearch.Updates: the query that
+// produced it paired with either its ranked hits or the error the
+// SearchVertices call returned. On a non-nil Err, Hits is nil. Query is always
+// the exact string passed to Search, so a consumer rendering results can
+// confirm the delivery still matches the text currently in the input box.
+type SearchUpdate struct {
+	Query string
+	Hits  []SearchHit
+	Err   error
+}
+
+// IncrementalSearchOption configures NewIncrementalSearch.
+type IncrementalSearchOption func(*incrementalSearchOptions)
+
+type incrementalSearchOptions struct {
+	debounce       time.Duration
+	limit          uint32
+	prefix         string
+	minQueryLength int
+}
+
+// WithDebounce sets the quiet period that must elapse after the most recent
+// Search call before the driver issues the RPC. Bursts of keystrokes within
+// the window collapse to a single search of the final query. The default is
+// 150ms; pass 0 to dispatch on the next driver tick without waiting.
+func WithDebounce(d time.Duration) IncrementalSearchOption {
+	return func(o *incrementalSearchOptions) { o.debounce = d }
+}
+
+// WithIncrementalSearchLimit forwards a per-call hit cap to every
+// SearchVertices RPC the driver issues, exactly like WithSearchLimit on a
+// one-shot call. 0 (the default) lets the server apply its configured default.
+func WithIncrementalSearchLimit(n uint32) IncrementalSearchOption {
+	return func(o *incrementalSearchOptions) { o.limit = n }
+}
+
+// WithIncrementalSearchPrefix scopes every issued search to vertices whose key
+// carries the given prefix, exactly like WithSearchPrefix on a one-shot call.
+// An empty prefix (the default) searches every live vertex.
+func WithIncrementalSearchPrefix(p string) IncrementalSearchOption {
+	return func(o *incrementalSearchOptions) { o.prefix = p }
+}
+
+// WithMinQueryLength sets the shortest query, counted in runes, that triggers
+// an RPC. A shorter (e.g. empty) query is answered immediately with an
+// empty-hit SearchUpdate and no round-trip, so a cleared input box resets the
+// result list without a wasted call. The default is 1; pass 0 to search even
+// the empty query (the server returns zero hits for it).
+func WithMinQueryLength(n int) IncrementalSearchOption {
+	return func(o *incrementalSearchOptions) { o.minQueryLength = n }
+}
+
+// IncrementalSearch is a search-as-you-type driver over SearchVertices.
+// Construct one with Lantern.NewIncrementalSearch, push queries with Search as
+// the user types, and consume ranked results from Updates. It is safe to call
+// Search from one goroutine while ranging over Updates in another.
+//
+// Lifecycle: the driver runs until the context passed to NewIncrementalSearch
+// is cancelled or Close is called. After shutdown Updates is no longer written
+// (a consumer ranging over it should also select on its own done signal) and
+// further Search calls are dropped.
+type IncrementalSearch struct {
+	l    *Lantern
+	opts incrementalSearchOptions
+
+	updates chan SearchUpdate
+	wake    chan struct{}
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	mu     sync.Mutex
+	latest string
+	dirty  bool
+
+	// epoch is bumped once per dispatched search (real or short-circuit). A
+	// reply is delivered only while epoch still equals the value its dispatch
+	// recorded, so a late reply from a superseded query is dropped.
+	epoch     atomic.Uint64
+	deliverMu sync.Mutex
+
+	closeOnce sync.Once
+}
+
+// NewIncrementalSearch starts a search-as-you-type driver bound to ctx and
+// returns it. The driver owns one background goroutine that debounces Search
+// calls, issues SearchVertices, and publishes results to Updates. Cancel ctx
+// or call Close to stop it.
+func (l *Lantern) NewIncrementalSearch(ctx context.Context, opts ...IncrementalSearchOption) *IncrementalSearch {
+	o := incrementalSearchOptions{
+		debounce:       defaultIncrementalDebounce,
+		minQueryLength: defaultMinQueryLength,
+	}
+	for _, apply := range opts {
+		apply(&o)
+	}
+	if o.debounce < 0 {
+		o.debounce = 0
+	}
+	if o.minQueryLength < 0 {
+		o.minQueryLength = 0
+	}
+	dctx, cancel := context.WithCancel(ctx)
+	s := &IncrementalSearch{
+		l:       l,
+		opts:    o,
+		updates: make(chan SearchUpdate, 1),
+		wake:    make(chan struct{}, 1),
+		ctx:     dctx,
+		cancel:  cancel,
+		done:    make(chan struct{}),
+	}
+	go s.run()
+	return s
+}
+
+// Search records query as the latest pending search and wakes the driver. It
+// never blocks: repeated calls before the debounce window elapses overwrite
+// the pending query, so only the final keystroke's text is searched. A call
+// after Close (or ctx cancellation) is a no-op.
+func (s *IncrementalSearch) Search(query string) {
+	s.mu.Lock()
+	s.latest = query
+	s.dirty = true
+	s.mu.Unlock()
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+}
+
+// Updates is the stream of search results, one SearchUpdate per dispatched
+// query, most-recent-wins: the channel is buffered to one and the driver
+// replaces an unconsumed update rather than blocking, so a slow consumer
+// always reads the latest result rather than a backlog. Errors (including
+// ErrFailedPrecondition when the server's search index is disabled) arrive as
+// SearchUpdate.Err.
+func (s *IncrementalSearch) Updates() <-chan SearchUpdate {
+	return s.updates
+}
+
+// Close stops the driver and waits for its goroutine to exit, cancelling any
+// in-flight SearchVertices call. It is idempotent and safe to call from any
+// goroutine; it always returns nil (the error return mirrors io.Closer for
+// composability).
+func (s *IncrementalSearch) Close() error {
+	s.closeOnce.Do(func() { s.cancel() })
+	<-s.done
+	return nil
+}
+
+// run is the single driver goroutine. It owns the debounce timer and the
+// in-flight search's cancel func, so neither needs its own lock.
+func (s *IncrementalSearch) run() {
+	defer close(s.done)
+
+	timer := time.NewTimer(s.opts.debounce)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	armed := false
+
+	var searchCancel context.CancelFunc
+	cancelInFlight := func() {
+		if searchCancel != nil {
+			searchCancel()
+			searchCancel = nil
+		}
+	}
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			timer.Stop()
+			cancelInFlight()
+			return
+
+		case <-s.wake:
+			// (Re)arm the debounce window on every keystroke.
+			if armed && !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(s.opts.debounce)
+			armed = true
+
+		case <-timer.C:
+			armed = false
+			s.mu.Lock()
+			query := s.latest
+			had := s.dirty
+			s.dirty = false
+			s.mu.Unlock()
+			if !had {
+				continue
+			}
+			// A newer dispatch supersedes any in-flight search.
+			cancelInFlight()
+			epoch := s.epoch.Add(1)
+			if len([]rune(query)) < s.opts.minQueryLength {
+				// Too short to search: answer immediately, no round-trip.
+				s.deliver(epoch, SearchUpdate{Query: query, Hits: []SearchHit{}})
+				continue
+			}
+			sctx, c := context.WithCancel(s.ctx)
+			searchCancel = c
+			go s.doSearch(sctx, epoch, query)
+		}
+	}
+}
+
+// doSearch issues one SearchVertices call and delivers its result unless the
+// call was cancelled (superseded by a newer query) before it returned.
+func (s *IncrementalSearch) doSearch(ctx context.Context, epoch uint64, query string) {
+	opts := make([]SearchOption, 0, 2)
+	if s.opts.limit > 0 {
+		opts = append(opts, WithSearchLimit(s.opts.limit))
+	}
+	if s.opts.prefix != "" {
+		opts = append(opts, WithSearchPrefix(s.opts.prefix))
+	}
+	hits, err := s.l.SearchVertices(ctx, query, opts...)
+	if ctx.Err() != nil {
+		return // superseded or shut down: drop the stale reply
+	}
+	s.deliver(epoch, SearchUpdate{Query: query, Hits: hits, Err: err})
+}
+
+// deliver publishes u on Updates with most-recent-wins semantics, but only
+// while epoch is still current — a reply whose epoch was overtaken by a newer
+// dispatch is dropped. The deliver lock serialises the drop-then-send against
+// a concurrent short-circuit delivery from the driver goroutine.
+func (s *IncrementalSearch) deliver(epoch uint64, u SearchUpdate) {
+	s.deliverMu.Lock()
+	defer s.deliverMu.Unlock()
+	if s.epoch.Load() != epoch {
+		return
+	}
+	select {
+	case <-s.updates: // discard a still-unread update so the newest wins
+	default:
+	}
+	select {
+	case s.updates <- u:
+	default:
+	}
+}

--- a/sdks/go/search_incremental_test.go
+++ b/sdks/go/search_incremental_test.go
@@ -1,0 +1,258 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
+)
+
+// fakeIncSearch is a LanternServiceClient stub for the incremental-search
+// driver tests. It records every query it is asked to search, optionally
+// delays a chosen query so a slower in-flight call can be overtaken, and
+// replays per-query canned hits (or a single canned error for every query).
+type fakeIncSearch struct {
+	graphv1connect.LanternServiceClient
+	mu    sync.Mutex
+	reqs  []*pb.SearchVerticesRequest
+	delay map[string]time.Duration
+	hits  map[string][]*pb.SearchHit
+	err   error
+}
+
+func (f *fakeIncSearch) SearchVertices(ctx context.Context, req *connect.Request[pb.SearchVerticesRequest]) (*connect.Response[pb.SearchVerticesResponse], error) {
+	q := req.Msg.GetQuery()
+	f.mu.Lock()
+	f.reqs = append(f.reqs, req.Msg)
+	d := f.delay[q]
+	h := f.hits[q]
+	e := f.err
+	f.mu.Unlock()
+	if e != nil {
+		return nil, e
+	}
+	if d > 0 {
+		select {
+		case <-time.After(d):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return connect.NewResponse(&pb.SearchVerticesResponse{Hits: h}), nil
+}
+
+func (f *fakeIncSearch) calls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.reqs))
+	for i, r := range f.reqs {
+		out[i] = r.GetQuery()
+	}
+	return out
+}
+
+func (f *fakeIncSearch) firstReq() *pb.SearchVerticesRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.reqs) == 0 {
+		return nil
+	}
+	return f.reqs[0]
+}
+
+// newDriver wires a fake client into a *Lantern and returns a started driver
+// that is closed on test cleanup.
+func newDriver(t *testing.T, fake *fakeIncSearch, opts ...IncrementalSearchOption) *IncrementalSearch {
+	t.Helper()
+	l := mustLantern(t)
+	l.client = fake
+	ctx, cancel := context.WithCancel(context.Background())
+	is := l.NewIncrementalSearch(ctx, opts...)
+	t.Cleanup(func() {
+		_ = is.Close()
+		cancel()
+	})
+	return is
+}
+
+// waitUpdate reads one SearchUpdate or fails the test on timeout.
+func waitUpdate(t *testing.T, is *IncrementalSearch) SearchUpdate {
+	t.Helper()
+	select {
+	case u := <-is.Updates():
+		return u
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for a SearchUpdate")
+		return SearchUpdate{}
+	}
+}
+
+func TestIncrementalSearchOptions(t *testing.T) {
+	t.Run("constants are the documented defaults", func(t *testing.T) {
+		if defaultIncrementalDebounce != 150*time.Millisecond {
+			t.Errorf("default debounce = %v, want 150ms", defaultIncrementalDebounce)
+		}
+		if defaultMinQueryLength != 1 {
+			t.Errorf("default minQueryLength = %d, want 1", defaultMinQueryLength)
+		}
+	})
+
+	t.Run("apply", func(t *testing.T) {
+		o := incrementalSearchOptions{}
+		for _, apply := range []IncrementalSearchOption{
+			WithDebounce(7 * time.Millisecond),
+			WithIncrementalSearchLimit(9),
+			WithIncrementalSearchPrefix("user."),
+			WithMinQueryLength(3),
+		} {
+			apply(&o)
+		}
+		if o.debounce != 7*time.Millisecond {
+			t.Errorf("debounce = %v, want 7ms", o.debounce)
+		}
+		if o.limit != 9 {
+			t.Errorf("limit = %d, want 9", o.limit)
+		}
+		if o.prefix != "user." {
+			t.Errorf("prefix = %q, want %q", o.prefix, "user.")
+		}
+		if o.minQueryLength != 3 {
+			t.Errorf("minQueryLength = %d, want 3", o.minQueryLength)
+		}
+	})
+}
+
+func TestIncrementalSearch_ForwardsAndDelivers(t *testing.T) {
+	fake := &fakeIncSearch{hits: map[string][]*pb.SearchHit{
+		"hello": {{Key: "user.hi", Score: 1.5}},
+	}}
+	is := newDriver(t, fake, WithDebounce(5*time.Millisecond),
+		WithIncrementalSearchLimit(7), WithIncrementalSearchPrefix("user."))
+
+	is.Search("hello")
+	u := waitUpdate(t, is)
+
+	if u.Err != nil {
+		t.Fatalf("unexpected err: %v", u.Err)
+	}
+	if u.Query != "hello" {
+		t.Errorf("query = %q, want %q", u.Query, "hello")
+	}
+	if len(u.Hits) != 1 || u.Hits[0].Key != "user.hi" || u.Hits[0].Score != 1.5 {
+		t.Errorf("hits = %+v, want one user.hi/1.5", u.Hits)
+	}
+	req := fake.firstReq()
+	if req == nil {
+		t.Fatal("no SearchVertices request recorded")
+	}
+	if req.GetLimit() != 7 {
+		t.Errorf("limit = %d, want 7", req.GetLimit())
+	}
+	if req.GetPrefix() != "user." {
+		t.Errorf("prefix = %q, want %q", req.GetPrefix(), "user.")
+	}
+}
+
+func TestIncrementalSearch_DebounceCoalesces(t *testing.T) {
+	fake := &fakeIncSearch{hits: map[string][]*pb.SearchHit{
+		"abc": {{Key: "k", Score: 1}},
+	}}
+	is := newDriver(t, fake, WithDebounce(30*time.Millisecond))
+
+	is.Search("a")
+	is.Search("ab")
+	is.Search("abc")
+
+	u := waitUpdate(t, is)
+	if u.Query != "abc" {
+		t.Errorf("query = %q, want %q", u.Query, "abc")
+	}
+	// Only the final query of the burst hit the wire.
+	if got := fake.calls(); len(got) != 1 || got[0] != "abc" {
+		t.Errorf("calls = %v, want [abc]", got)
+	}
+}
+
+func TestIncrementalSearch_CancelsInFlight(t *testing.T) {
+	fake := &fakeIncSearch{
+		delay: map[string]time.Duration{"slow": 500 * time.Millisecond},
+		hits: map[string][]*pb.SearchHit{
+			"slow": {{Key: "slow.hit", Score: 9}},
+			"fast": {{Key: "fast.hit", Score: 1}},
+		},
+	}
+	is := newDriver(t, fake, WithDebounce(5*time.Millisecond))
+
+	is.Search("slow")
+	// Let "slow" dispatch and enter its 500ms delay before superseding it.
+	time.Sleep(60 * time.Millisecond)
+	is.Search("fast")
+
+	u := waitUpdate(t, is)
+	if u.Query != "fast" {
+		t.Fatalf("query = %q, want fast (slow must be superseded)", u.Query)
+	}
+	if len(u.Hits) != 1 || u.Hits[0].Key != "fast.hit" {
+		t.Errorf("hits = %+v, want fast.hit", u.Hits)
+	}
+	// Both were dispatched; "slow" was cancelled, only "fast" delivered.
+	if calls := fake.calls(); len(calls) != 2 {
+		t.Fatalf("calls = %v, want both slow and fast dispatched", calls)
+	}
+}
+
+func TestIncrementalSearch_MinQueryLength(t *testing.T) {
+	fake := &fakeIncSearch{}
+	is := newDriver(t, fake, WithDebounce(5*time.Millisecond), WithMinQueryLength(3))
+
+	is.Search("ab") // shorter than 3 runes
+	u := waitUpdate(t, is)
+
+	if u.Query != "ab" {
+		t.Errorf("query = %q, want %q", u.Query, "ab")
+	}
+	if len(u.Hits) != 0 {
+		t.Errorf("hits = %+v, want empty", u.Hits)
+	}
+	if u.Err != nil {
+		t.Errorf("err = %v, want nil", u.Err)
+	}
+	if got := fake.calls(); len(got) != 0 {
+		t.Errorf("calls = %v, want no RPC for a too-short query", got)
+	}
+}
+
+func TestIncrementalSearch_DeliversError(t *testing.T) {
+	fake := &fakeIncSearch{err: connect.NewError(connect.CodeFailedPrecondition,
+		errors.New("vertex search is disabled on this server"))}
+	is := newDriver(t, fake, WithDebounce(5*time.Millisecond))
+
+	is.Search("anything")
+	u := waitUpdate(t, is)
+
+	if !errors.Is(u.Err, ErrFailedPrecondition) {
+		t.Fatalf("err = %v, want errors.Is ErrFailedPrecondition", u.Err)
+	}
+}
+
+func TestIncrementalSearch_CloseIsIdempotent(t *testing.T) {
+	fake := &fakeIncSearch{}
+	l := mustLantern(t)
+	l.client = fake
+	is := l.NewIncrementalSearch(context.Background(), WithDebounce(5*time.Millisecond))
+
+	if err := is.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := is.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	// A Search after Close must not panic or block.
+	is.Search("ignored")
+}


### PR DESCRIPTION
## Summary

Adds `IncrementalSearch`, a search-as-you-type driver to `sdks/go` that wraps the existing `SearchVertices` RPC with:

- **Debounce** — coalesces rapid `Search` calls into a single RPC of the final query (`WithDebounce`, default 150ms).
- **In-flight cancellation** — a newer query cancels the previous RPC's `context`.
- **Stale-drop** — an atomic epoch tags each dispatch; a late reply from a superseded query is dropped, so the consumer only ever observes the latest query's result.

Pure client-side orchestration over the existing RPC — **no proto / server change**. This is the full-text analogue of the admin SPA's vertex picker, lifted into the SDK.

## API

```go
is := l.NewIncrementalSearch(ctx, client.WithDebounce(150*time.Millisecond))
defer is.Close()

go func() {
    for u := range is.Updates() {
        if u.Err != nil { // e.g. errors.Is(u.Err, client.ErrFailedPrecondition)
            continue
        }
        render(u.Query, u.Hits)
    }
}()

is.Search("co")     // call on each keystroke
is.Search("cof")
is.Search("coffee") // only this one hits the wire (debounced)
```

Options: `WithDebounce`, `WithIncrementalSearchLimit`, `WithIncrementalSearchPrefix`, `WithMinQueryLength`.

## Tests

`search_incremental_test.go` (fake client, `-race` clean):

- option apply
- forward + deliver (limit/prefix wired onto the request)
- debounce coalescing (burst → one RPC of the final query)
- in-flight cancellation (a slow query is superseded; only the newer result is delivered)
- `minQueryLength` short-circuit (too-short query → empty result, no RPC)
- error delivery (`ErrFailedPrecondition`)
- idempotent `Close`

## Files (1:1 pairing rule)

- New `sdks/go/search_incremental.go` ↔ `sdks/go/search_incremental_test.go`.

Closes #764
