### PR TITLE
feat(sdks/node): add incremental search driver

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lantern-sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Official TypeScript client SDK for Lantern — an in-memory graph KVS, over Connect (HTTP/2).",
   "license": "Apache-2.0",
   "type": "module",

--- a/sdks/node/src/client.ts
+++ b/sdks/node/src/client.ts
@@ -74,6 +74,11 @@ import {
   type ScanOptions,
   type SearchOptions,
 } from "./options.js";
+import {
+  createIncrementalSearch,
+  type IncrementalSearch,
+  type IncrementalSearchOptions,
+} from "./incremental-search.js";
 
 /**
  * Constructor arguments for `Lantern.connect` /
@@ -376,6 +381,26 @@ export class Lantern {
       );
       return resp.hits.map((h) => ({ key: h.key, score: h.score }));
     });
+  }
+
+  /**
+   * Opens a search-as-you-type driver over {@link searchVertices}: push a
+   * query with `search` on each keystroke, then receive ranked results via
+   * `subscribe` or by `for await`-ing the returned driver. It debounces rapid
+   * input, aborts the previous in-flight RPC when a newer query arrives, and
+   * drops a late reply from a superseded query, so a consumer only ever
+   * observes the latest query's result. Pure client-side orchestration over
+   * the existing RPC — no extra wire surface.
+   *
+   * Errors (including a `FailedPreconditionError` when the server-side index
+   * is disabled) arrive as `SearchUpdate.error` rather than rejecting. Call
+   * `close()` when done to stop the driver and abort any in-flight call.
+   */
+  incrementalSearch(opts: IncrementalSearchOptions = {}): IncrementalSearch {
+    return createIncrementalSearch(
+      (query, searchOpts, signal) => this.searchVertices(query, searchOpts, signal),
+      opts,
+    );
   }
 
   async countVerticesByPrefix(prefix: string, signal?: AbortSignal): Promise<bigint> {

--- a/sdks/node/src/incremental-search.ts
+++ b/sdks/node/src/incremental-search.ts
@@ -1,0 +1,197 @@
+/**
+ * incremental-search.ts — the search-as-you-type driver that wraps
+ * `Lantern.searchVertices` with debounce, in-flight cancellation, and
+ * stale-drop so a UI can fire a fresh search on every keystroke and only ever
+ * observe the result of the LATEST query.
+ *
+ * It is the full-text analogue of the admin SPA's vertex picker: rapid query
+ * updates are coalesced and debounced, a newer query aborts the previous
+ * in-flight RPC, and a late reply from a superseded query is dropped. The wire
+ * surface is unchanged — this is pure client-side orchestration over the
+ * existing `searchVertices` RPC, so it needs no proto or server support.
+ */
+
+import type { SearchHit } from "./values.js";
+
+/** Default debounce window (ms); mirrors the admin SPA's `SUGGEST_DEBOUNCE_MS`. */
+export const DEFAULT_DEBOUNCE_MS = 150;
+
+/** Default shortest query (in code points) that triggers an RPC. */
+export const DEFAULT_MIN_QUERY_LENGTH = 1;
+
+export interface IncrementalSearchOptions {
+  /** Quiet period after the last `search` call before the RPC fires (default 150). */
+  debounceMs?: number;
+  /** Per-call hit cap forwarded to every `searchVertices` RPC (0/omitted = server default). */
+  limit?: number;
+  /** Key-prefix namespace scope forwarded to every `searchVertices` RPC. */
+  prefix?: string;
+  /**
+   * Shortest query (code points) that triggers an RPC; a shorter one resolves
+   * immediately to an empty result with no round-trip (default 1). Pass 0 to
+   * search even the empty query.
+   */
+  minQueryLength?: number;
+}
+
+/**
+ * One delivery from an {@link IncrementalSearch}: the query that produced it
+ * paired with either its ranked hits or the error `searchVertices` rejected
+ * with. On a defined `error`, `hits` is empty. `query` is always the exact
+ * string passed to `search`, so a consumer rendering results can confirm the
+ * delivery still matches the text currently in the input box.
+ */
+export interface SearchUpdate {
+  query: string;
+  hits: SearchHit[];
+  error?: unknown;
+}
+
+/**
+ * The search primitive the driver drives. Structurally matches
+ * `Lantern.searchVertices`, so `client.incrementalSearch()` simply binds the
+ * method — but accepting the function (rather than the client) keeps this
+ * module free of a client import and trivially testable with a fake.
+ */
+export type SearchFn = (
+  query: string,
+  opts: { limit?: number; prefix?: string },
+  signal?: AbortSignal,
+) => Promise<SearchHit[]>;
+
+/**
+ * A search-as-you-type driver. Push queries with `search` as the user types;
+ * receive ranked results via `subscribe` (which returns an unsubscribe) or by
+ * `for await`-ing the driver. Call `close` (or rely on it via the async
+ * iterator's `return`) to stop it and abort any in-flight call.
+ */
+export interface IncrementalSearch {
+  search(query: string): void;
+  subscribe(listener: (update: SearchUpdate) => void): () => void;
+  close(): void;
+  [Symbol.asyncIterator](): AsyncIterator<SearchUpdate>;
+}
+
+/**
+ * Builds an {@link IncrementalSearch} around any {@link SearchFn}. Most callers
+ * use `Lantern.incrementalSearch()`, which binds `searchVertices`; this factory
+ * is exported for tests and for driving a custom search primitive.
+ */
+export function createIncrementalSearch(
+  searchFn: SearchFn,
+  options: IncrementalSearchOptions = {},
+): IncrementalSearch {
+  const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  const minQueryLength = options.minQueryLength ?? DEFAULT_MIN_QUERY_LENGTH;
+  const searchOpts = { limit: options.limit, prefix: options.prefix };
+
+  const listeners = new Set<(update: SearchUpdate) => void>();
+  let epoch = 0;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let inFlight: AbortController | undefined;
+  let closed = false;
+
+  // Async-iterator plumbing: a one-slot, newest-wins buffer plus a pending
+  // next() resolver, so a slow `for await` consumer always sees the latest
+  // update rather than a backlog.
+  let buffered: SearchUpdate | undefined;
+  let pendingNext: ((result: IteratorResult<SearchUpdate>) => void) | undefined;
+
+  function emit(update: SearchUpdate): void {
+    for (const listener of listeners) listener(update);
+    if (pendingNext) {
+      const resolve = pendingNext;
+      pendingNext = undefined;
+      resolve({ value: update, done: false });
+    } else {
+      buffered = update; // newest-wins
+    }
+  }
+
+  function dispatch(query: string): void {
+    if (closed) return;
+    // A newer dispatch supersedes any in-flight search.
+    inFlight?.abort();
+    inFlight = undefined;
+    const myEpoch = ++epoch;
+
+    if ([...query].length < minQueryLength) {
+      // Too short to search: answer immediately, no round-trip.
+      emit({ query, hits: [] });
+      return;
+    }
+
+    const controller = new AbortController();
+    inFlight = controller;
+    void searchFn(query, searchOpts, controller.signal).then(
+      (hits) => {
+        if (closed || myEpoch !== epoch) return; // superseded: drop
+        emit({ query, hits });
+      },
+      (error) => {
+        // Drop a stale or aborted rejection; surface a live one.
+        if (closed || myEpoch !== epoch || controller.signal.aborted) return;
+        emit({ query, hits: [], error });
+      },
+    );
+  }
+
+  function search(query: string): void {
+    if (closed) return;
+    if (timer !== undefined) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = undefined;
+      dispatch(query);
+    }, debounceMs);
+  }
+
+  function close(): void {
+    if (closed) return;
+    closed = true;
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+    inFlight?.abort();
+    inFlight = undefined;
+    if (pendingNext) {
+      const resolve = pendingNext;
+      pendingNext = undefined;
+      resolve({ value: undefined, done: true });
+    }
+  }
+
+  function subscribe(listener: (update: SearchUpdate) => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }
+
+  const iterator: AsyncIterator<SearchUpdate> = {
+    next(): Promise<IteratorResult<SearchUpdate>> {
+      if (buffered !== undefined) {
+        const value = buffered;
+        buffered = undefined;
+        return Promise.resolve({ value, done: false });
+      }
+      if (closed) return Promise.resolve({ value: undefined, done: true });
+      return new Promise((resolve) => {
+        pendingNext = resolve;
+      });
+    },
+    return(): Promise<IteratorResult<SearchUpdate>> {
+      close();
+      return Promise.resolve({ value: undefined, done: true });
+    },
+  };
+
+  return {
+    search,
+    subscribe,
+    close,
+    [Symbol.asyncIterator]() {
+      return iterator;
+    },
+  };
+}

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -50,6 +50,17 @@ export function connect(baseUrl: string, args: LanternArgs = {}): Lantern {
 
 export { Lantern } from "./client.js";
 export type { LanternArgs } from "./client.js";
+export {
+  createIncrementalSearch,
+  DEFAULT_DEBOUNCE_MS,
+  DEFAULT_MIN_QUERY_LENGTH,
+} from "./incremental-search.js";
+export type {
+  IncrementalSearch,
+  IncrementalSearchOptions,
+  SearchFn,
+  SearchUpdate,
+} from "./incremental-search.js";
 export { ReplicationPeer_State } from "./gen/graph/v1/graph_pb.js";
 export {
   BatchError,

--- a/sdks/node/test/incremental-search.test.ts
+++ b/sdks/node/test/incremental-search.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createIncrementalSearch,
+  DEFAULT_DEBOUNCE_MS,
+  DEFAULT_MIN_QUERY_LENGTH,
+  type IncrementalSearch,
+  type SearchFn,
+  type SearchUpdate,
+} from "../src/incremental-search.js";
+
+// nextUpdate resolves with the first update the driver emits.
+function nextUpdate(is: IncrementalSearch): Promise<SearchUpdate> {
+  return new Promise((resolve) => {
+    const unsubscribe = is.subscribe((u) => {
+      unsubscribe();
+      resolve(u);
+    });
+  });
+}
+
+const tick = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("createIncrementalSearch", () => {
+  test("exposes the documented defaults", () => {
+    expect(DEFAULT_DEBOUNCE_MS).toBe(150);
+    expect(DEFAULT_MIN_QUERY_LENGTH).toBe(1);
+  });
+
+  test("forwards limit/prefix and delivers ranked hits", async () => {
+    const calls: { query: string; opts: { limit?: number; prefix?: string } }[] = [];
+    const searchFn: SearchFn = async (query, opts) => {
+      calls.push({ query, opts });
+      return [{ key: "user.hi", score: 1.5 }];
+    };
+    const is = createIncrementalSearch(searchFn, { debounceMs: 5, limit: 7, prefix: "user." });
+
+    is.search("hello");
+    const u = await nextUpdate(is);
+    is.close();
+
+    expect(u.error).toBeUndefined();
+    expect(u.query).toBe("hello");
+    expect(u.hits).toEqual([{ key: "user.hi", score: 1.5 }]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({ query: "hello", opts: { limit: 7, prefix: "user." } });
+  });
+
+  test("debounce coalesces a burst into one search of the final query", async () => {
+    const queries: string[] = [];
+    const searchFn: SearchFn = async (query) => {
+      queries.push(query);
+      return [];
+    };
+    const is = createIncrementalSearch(searchFn, { debounceMs: 30 });
+
+    is.search("a");
+    is.search("ab");
+    is.search("abc");
+    const u = await nextUpdate(is);
+    is.close();
+
+    expect(u.query).toBe("abc");
+    expect(queries).toEqual(["abc"]);
+  });
+
+  test("a newer query aborts the in-flight search and only its result is delivered", async () => {
+    const seen: string[] = [];
+    const searchFn: SearchFn = async (query, _opts, signal) => {
+      seen.push(query);
+      if (query === "slow") {
+        await new Promise<void>((resolve, reject) => {
+          const t = setTimeout(resolve, 500);
+          signal?.addEventListener("abort", () => {
+            clearTimeout(t);
+            reject(new Error("aborted"));
+          });
+        });
+      }
+      return [{ key: `${query}.hit`, score: 1 }];
+    };
+    const is = createIncrementalSearch(searchFn, { debounceMs: 5 });
+
+    is.search("slow");
+    await tick(40); // let "slow" dispatch and enter its delay
+    is.search("fast");
+    const u = await nextUpdate(is);
+    is.close();
+
+    expect(u.query).toBe("fast");
+    expect(u.hits).toEqual([{ key: "fast.hit", score: 1 }]);
+    expect(seen).toEqual(["slow", "fast"]);
+  });
+
+  test("a too-short query resolves to an empty result with no RPC", async () => {
+    let calls = 0;
+    const searchFn: SearchFn = async () => {
+      calls++;
+      return [];
+    };
+    const is = createIncrementalSearch(searchFn, { debounceMs: 5, minQueryLength: 3 });
+
+    is.search("ab");
+    const u = await nextUpdate(is);
+    is.close();
+
+    expect(u.query).toBe("ab");
+    expect(u.hits).toEqual([]);
+    expect(u.error).toBeUndefined();
+    expect(calls).toBe(0);
+  });
+
+  test("delivers a search rejection as SearchUpdate.error", async () => {
+    const boom = new Error("vertex search is disabled on this server");
+    const searchFn: SearchFn = async () => {
+      throw boom;
+    };
+    const is = createIncrementalSearch(searchFn, { debounceMs: 5 });
+
+    is.search("anything");
+    const u = await nextUpdate(is);
+    is.close();
+
+    expect(u.error).toBe(boom);
+    expect(u.hits).toEqual([]);
+  });
+
+  test("close is idempotent and search after close is a no-op", async () => {
+    let calls = 0;
+    const searchFn: SearchFn = async () => {
+      calls++;
+      return [];
+    };
+    const is = createIncrementalSearch(searchFn, { debounceMs: 5 });
+
+    is.close();
+    is.close(); // must not throw
+    is.search("ignored");
+    await tick(20);
+
+    expect(calls).toBe(0);
+  });
+
+  test("is async-iterable, yielding the latest update", async () => {
+    const searchFn: SearchFn = async (query) => [{ key: query, score: 1 }];
+    const is = createIncrementalSearch(searchFn, { debounceMs: 5 });
+
+    is.search("hello");
+    const iterator = is[Symbol.asyncIterator]();
+    const { value, done } = await iterator.next();
+    is.close();
+
+    expect(done).toBe(false);
+    expect(value?.query).toBe("hello");
+    expect(value?.hits).toEqual([{ key: "hello", score: 1 }]);
+  });
+});


### PR DESCRIPTION
## What

Adds `createIncrementalSearch` to the Node SDK: a search-as-you-type driver that
wraps `searchVertices` with debounce, in-flight cancellation, and stale-drop, so
a UI can fire a fresh search on every keystroke and only ever observe the result
of the **latest** query. Surfaced as `Lantern.incrementalSearch(opts?)`.

This is the Node counterpart to the Go SDK's `IncrementalSearch` (#764) and the
full-text analogue of the admin SPA's vertex picker. Pure client-side
orchestration over the existing `searchVertices` RPC — **no proto or server
changes**.

## API

- `client.incrementalSearch(opts?)` → `IncrementalSearch`
- `IncrementalSearch.search(query)` — push a query (call on each keystroke)
- `IncrementalSearch.subscribe(cb)` → returns an unsubscribe; or `for await (const u of is)`
- `IncrementalSearch.close()` — stop the driver and abort any in-flight call
- `SearchUpdate { query; hits; error? }` — errors (incl. the disabled-index
  `FailedPreconditionError`) arrive as `error`, not a rejection
- Options: `debounceMs` (default 150, mirrors the admin SPA), `limit`, `prefix`,
  `minQueryLength` (default 1)

## Behaviour

1. **Coalesce + debounce** — a burst of keystrokes fires one RPC for the final query.
2. **Cancel in-flight** — a newer query aborts the previous RPC via `AbortSignal`.
3. **Stale-drop** — a late reply from a superseded query is dropped (monotonic epoch).
4. **Deliver latest** — subscribers / async-iterator see only the newest result.

## Tests

`test/incremental-search.test.ts` (bun:test) — forward+deliver, debounce
coalesce, cancel in-flight, min-query-length short-circuit, error delivery,
idempotent close, async-iterable. 8 tests, all green.

Quality gate: `bun run lint`, `bun run typecheck`, `bun test` (55/55),
`bun run build`, `prettier --check` all pass. `package.json` bumped 0.5.0 → 0.6.0.

Closes #765
