### PR TITLE
feat(server): graceful drain window for zero-drop rolling updates

### DIFF
--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/anaregdesign/lantern/core/mutationlog"
 	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
 	"github.com/anaregdesign/lantern/server/provider"
+	"github.com/anaregdesign/lantern/server/readiness"
 	"github.com/anaregdesign/lantern/server/replication"
 	"github.com/anaregdesign/lantern/server/service"
 
@@ -31,6 +32,8 @@ type App struct {
 	tracing     *provider.Tracing
 	domain      *domainmetrics.DomainMetrics
 	health      *provider.HealthChecker
+	gate        *readiness.Gate
+	drainDelay  time.Duration
 	pump        *replication.Pump
 	antiEntropy *replication.AntiEntropy
 }
@@ -46,6 +49,8 @@ func newApp(
 	hc *provider.HealthChecker,
 	pump *replication.Pump,
 	antiEntropy *replication.AntiEntropy,
+	gate *readiness.Gate,
+	sc provider.ShutdownConfig,
 	pc provider.PeerConfig,
 	rc provider.ReplicationConfig,
 	_ provider.CacheGCHooksWired,
@@ -72,6 +77,8 @@ func newApp(
 		tracing:     tracing,
 		domain:      domain,
 		health:      hc,
+		gate:        gate,
+		drainDelay:  sc.DrainDelay,
 		pump:        pump,
 		antiEntropy: antiEntropy,
 	}
@@ -178,13 +185,30 @@ func (a *App) Run(ctx context.Context) error {
 	// (#188): in single-instance mode it is already SERVING; in
 	// multi-peer mode it stays NOT_SERVING until bootstrap completes
 	// and replication lag is within LANTERN_MAX_REPLICATION_LAG.
+	//
+	// Two-phase shutdown for zero-drop rolling updates (#768): the long-
+	// running servers serve on serveCtx, NOT the parent ctx. On SIGTERM the
+	// drain coordinator first flips readiness to NOT_SERVING (overall ""
+	// health + /readyz return 503 so load balancers deregister this
+	// instance), holds every listener up for LANTERN_DRAIN_DELAY_SECONDS so
+	// in-flight and endpoint-propagation-window requests still complete, and
+	// only then cancels serveCtx to begin the real graceful shutdown. With
+	// DrainDelay=0 the behaviour matches the historical path bar an
+	// immediate, harmless BeginDrain.
+	serveCtx, cancelServe := context.WithCancel(context.Background())
+	defer cancelServe()
 
-	g, gctx := errgroup.WithContext(ctx)
+	g, gctx := errgroup.WithContext(serveCtx)
 	g.Go(func() error { return a.server.Run(gctx) })
 	g.Go(func() error { return a.metrics.Run(gctx) })
 	g.Go(func() error { a.domain.Run(gctx); return nil })
 	g.Go(func() error { return a.pump.Run(gctx) })
 	g.Go(func() error { return a.antiEntropy.Run(gctx) })
+	g.Go(func() error {
+		drainPhase(ctx, gctx.Done(), a.drainDelay, a.beginDrain)
+		cancelServe()
+		return nil
+	})
 	g.Go(func() error {
 		<-gctx.Done()
 		a.health.SetServingStatus("", grpchealth.StatusNotServing)
@@ -197,6 +221,46 @@ func (a *App) Run(ctx context.Context) error {
 		return nil
 	})
 	return g.Wait()
+}
+
+// beginDrain latches the readiness Gate into NOT_SERVING (#768) so the
+// overall ("") gRPC health entry and /readyz report draining immediately.
+// nil-safe so an App constructed without a Gate (tests) is a no-op.
+func (a *App) beginDrain() {
+	if a.gate == nil {
+		return
+	}
+	a.logger.Info("draining: readiness NOT_SERVING, holding listeners for drain window",
+		slog.Duration("drain_delay", a.drainDelay))
+	a.gate.BeginDrain()
+}
+
+// drainPhase implements the graceful-drain window (#768). It blocks until
+// the parent context is cancelled (operator SIGTERM) or serveDone fires (a
+// server goroutine failed first). On parent cancellation it calls begin
+// once — the caller flips readiness to NOT_SERVING — then holds for
+// drainDelay (cut short if serveDone fires meanwhile) so the listeners keep
+// serving while load balancers deregister the endpoint. When serveDone
+// fires first it returns immediately without draining: an already-failing
+// server should shut down without an artificial delay.
+func drainPhase(parent context.Context, serveDone <-chan struct{}, drainDelay time.Duration, begin func()) {
+	select {
+	case <-parent.Done():
+	case <-serveDone:
+		return
+	}
+	if begin != nil {
+		begin()
+	}
+	if drainDelay <= 0 {
+		return
+	}
+	timer := time.NewTimer(drainDelay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-serveDone:
+	}
 }
 
 func main() {

--- a/server/cmd/server_test.go
+++ b/server/cmd/server_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestDrainPhase_SigtermDrainsThenReturns verifies that when the parent
+// context is cancelled (SIGTERM), drainPhase invokes begin exactly once and
+// then holds for the drain delay before returning — i.e. readiness flips
+// before the caller cancels serveCtx, and the listeners stay up for the
+// window.
+func TestDrainPhase_SigtermDrainsThenReturns(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan struct{}) // never fires
+	var begun atomic.Int32
+
+	cancel() // simulate SIGTERM already delivered
+	start := time.Now()
+	drainPhase(parent, serveDone, 40*time.Millisecond, func() { begun.Add(1) })
+	elapsed := time.Since(start)
+
+	if got := begun.Load(); got != 1 {
+		t.Fatalf("begin must be called exactly once on drain, got %d", got)
+	}
+	if elapsed < 40*time.Millisecond {
+		t.Fatalf("drainPhase must hold for the drain delay, returned after %s", elapsed)
+	}
+}
+
+// TestDrainPhase_ServerFailureSkipsDrain verifies that when a server
+// goroutine fails first (serveDone fires before SIGTERM), drainPhase returns
+// immediately WITHOUT calling begin — a failing server should not be held in
+// an artificial drain window.
+func TestDrainPhase_ServerFailureSkipsDrain(t *testing.T) {
+	parent := context.Background() // never cancelled
+	serveDone := make(chan struct{})
+	close(serveDone) // a server already failed
+	var begun atomic.Int32
+
+	start := time.Now()
+	drainPhase(parent, serveDone, time.Hour, func() { begun.Add(1) })
+	elapsed := time.Since(start)
+
+	if got := begun.Load(); got != 0 {
+		t.Fatalf("begin must NOT be called when a server fails first, got %d", got)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("drainPhase must return promptly on server failure, took %s", elapsed)
+	}
+}
+
+// TestDrainPhase_ZeroDelayDrainsImmediately verifies that with DrainDelay=0
+// drainPhase still flips readiness (calls begin) but returns without waiting.
+func TestDrainPhase_ZeroDelayDrainsImmediately(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	cancel()
+	serveDone := make(chan struct{})
+	var begun atomic.Int32
+
+	start := time.Now()
+	drainPhase(parent, serveDone, 0, func() { begun.Add(1) })
+	elapsed := time.Since(start)
+
+	if got := begun.Load(); got != 1 {
+		t.Fatalf("begin must be called once even with zero delay, got %d", got)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("zero-delay drain must return promptly, took %s", elapsed)
+	}
+}
+
+// TestDrainPhase_ServerFailureDuringDrainCutsWindow verifies that if a server
+// dies *during* the drain window, drainPhase stops waiting early.
+func TestDrainPhase_ServerFailureDuringDrainCutsWindow(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	cancel()
+	serveDone := make(chan struct{})
+	var begun atomic.Int32
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		close(serveDone)
+	}()
+
+	start := time.Now()
+	drainPhase(parent, serveDone, time.Hour, func() { begun.Add(1) })
+	elapsed := time.Since(start)
+
+	if got := begun.Load(); got != 1 {
+		t.Fatalf("begin must be called once, got %d", got)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("drain window must be cut short when a server dies, took %s", elapsed)
+	}
+}

--- a/server/cmd/wire_gen.go
+++ b/server/cmd/wire_gen.go
@@ -65,6 +65,6 @@ func initializeApp() (*App, error) {
 	antiEntropyMetrics := provider.NewAntiEntropyMetrics(domainMetrics, gate)
 	antiEntropy := provider.NewAntiEntropyDriver(peerConfig, replicationConfig, antiEntropyConfig, lanternService, graphCache, pump, antiEntropyMetrics, logger)
 	cacheGCHooksWired := provider.WireCacheGCHooks(graphCache, domainMetrics, logger)
-	app := newApp(config, logger, lanternService, lanternServer, metricsServer, tracing, domainMetrics, healthChecker, pump, antiEntropy, peerConfig, replicationConfig, cacheGCHooksWired)
+	app := newApp(config, logger, lanternService, lanternServer, metricsServer, tracing, domainMetrics, healthChecker, pump, antiEntropy, gate, shutdownConfig, peerConfig, replicationConfig, cacheGCHooksWired)
 	return app, nil
 }

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -101,11 +101,22 @@ type CacheConfig struct {
 	GCInterval time.Duration
 }
 
-// ShutdownConfig is the GracefulStop deadline.
+// ShutdownConfig is the graceful-shutdown timing.
 //
-//   - LANTERN_SHUTDOWN_TIMEOUT_SECONDS   (default 30)
+//   - LANTERN_SHUTDOWN_TIMEOUT_SECONDS   (default 30) — how long
+//     http.Server.Shutdown may take to drain in-flight requests before a
+//     hard Close.
+//   - LANTERN_DRAIN_DELAY_SECONDS         (default 0 = disabled) — the
+//     zero-drop rolling-update drain window (#768). On SIGTERM the server
+//     flips readiness to NOT_SERVING (overall "" gRPC health + /readyz)
+//     immediately, then keeps the listeners serving for this long so load
+//     balancers and kube-proxy observe the drain and stop routing new
+//     requests before the listener actually stops accepting. Opt-in
+//     because it lengthens shutdown; set it slightly above the platform's
+//     endpoint-propagation lag (typically 1-5s).
 type ShutdownConfig struct {
-	Timeout time.Duration
+	Timeout    time.Duration
+	DrainDelay time.Duration
 }
 
 // ScanConfig caps the per-call pagination knobs for the prefix RPCs.
@@ -205,7 +216,8 @@ func NewConfig() *Config {
 			GCInterval: time.Duration(envconfig.Int("LANTERN_GC_INTERVAL_SECONDS", 60)) * time.Second,
 		},
 		Shutdown: ShutdownConfig{
-			Timeout: time.Duration(envconfig.Int("LANTERN_SHUTDOWN_TIMEOUT_SECONDS", 30)) * time.Second,
+			Timeout:    time.Duration(envconfig.Int("LANTERN_SHUTDOWN_TIMEOUT_SECONDS", 30)) * time.Second,
+			DrainDelay: time.Duration(envconfig.Int("LANTERN_DRAIN_DELAY_SECONDS", 0)) * time.Second,
 		},
 		Validation: ValidationLimits{
 			MaxKeyLen:         envconfig.Int("LANTERN_MAX_KEY_LEN", 1024),

--- a/server/readiness/gate.go
+++ b/server/readiness/gate.go
@@ -41,6 +41,10 @@ type HealthSetter interface {
 //     after MarkBootstrapped() has fired AND no observed (peer, origin)
 //     lag exceeds MaxLag. It flips back to NOT_SERVING whenever the lag
 //     constraint is violated again.
+//   - BeginDrain() forces NOT_SERVING permanently regardless of mode, lag,
+//     or bootstrap state (the graceful-shutdown drain signal, #768). It is
+//     one-way: once draining, no later SetLag / MarkBootstrapped can flip
+//     the Gate back to SERVING.
 type Gate struct {
 	maxLag   uint64
 	hasPeers bool
@@ -48,6 +52,7 @@ type Gate struct {
 
 	mu           sync.Mutex
 	bootstrapped bool
+	draining     bool
 	lags         map[string]uint64 // key = peer + "\x00" + origin
 	current      grpchealth.Status
 
@@ -98,6 +103,24 @@ func (g *Gate) MarkBootstrapped() {
 	g.evaluateLocked()
 }
 
+// BeginDrain flips the Gate to NOT_SERVING and latches it there for the
+// rest of the process lifetime (#768). It is the graceful-shutdown drain
+// signal: on SIGTERM the server calls BeginDrain so the overall ("")
+// gRPC health entry and the /readyz HTTP probe report NOT_SERVING
+// immediately — load balancers deregister the instance and stop routing
+// new requests — while the listener keeps serving for the drain window.
+// It applies in single-instance mode too (that node still has a /readyz)
+// and is idempotent.
+func (g *Gate) BeginDrain() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.draining {
+		return
+	}
+	g.draining = true
+	g.evaluateLocked()
+}
+
 // SetLag records the latest observed lag for a (peer, origin) row in
 // mutation-seq units. A value of 0 clears the row (caught up). In
 // single-instance mode this is a no-op.
@@ -127,6 +150,11 @@ func (g *Gate) SetLag(peer, origin string, gap uint64) {
 func (g *Gate) Ready() bool { return g.ready.Load() }
 
 func (g *Gate) readyLocked() bool {
+	// Draining wins over every other consideration, including
+	// single-instance mode's always-ready shortcut.
+	if g.draining {
+		return false
+	}
 	if !g.hasPeers {
 		return true
 	}

--- a/server/readiness/gate_test.go
+++ b/server/readiness/gate_test.go
@@ -149,3 +149,55 @@ func TestGate_MultiplePeersOriginsTracked(t *testing.T) {
 		t.Fatalf("expected SERVING after bad row clears")
 	}
 }
+
+func TestGate_BeginDrain_SingleInstance(t *testing.T) {
+	hs := &fakeHealth{}
+	g := NewGate(100, false, hs)
+	if !g.Ready() {
+		t.Fatalf("single-instance gate must start Ready")
+	}
+
+	g.BeginDrain()
+	if g.Ready() {
+		t.Fatalf("BeginDrain must flip a single-instance gate to NOT_SERVING")
+	}
+	latest, _ := hs.snapshot()
+	if latest != grpchealth.StatusNotServing {
+		t.Fatalf("expected NOT_SERVING health transition after BeginDrain, got %v", latest)
+	}
+
+	// Idempotent: a second BeginDrain emits nothing new.
+	_, before := hs.snapshot()
+	g.BeginDrain()
+	_, after := hs.snapshot()
+	if after != before {
+		t.Fatalf("BeginDrain must be idempotent, got %d → %d health calls", before, after)
+	}
+}
+
+func TestGate_BeginDrain_LatchesOverRecovery(t *testing.T) {
+	hs := &fakeHealth{}
+	g := NewGate(10, true, hs)
+	g.MarkBootstrapped()
+	if !g.Ready() {
+		t.Fatalf("expected SERVING after bootstrap")
+	}
+
+	g.BeginDrain()
+	if g.Ready() {
+		t.Fatalf("expected NOT_SERVING after BeginDrain")
+	}
+
+	// Once draining, no later signal may resurrect readiness.
+	g.MarkBootstrapped()
+	g.SetLag("peer-a", "o1", 0)
+	g.OnPumpConnect("peer-a")
+	g.OnAntiEntropyCaughtUp("peer-a", "o1", 1)
+	if g.Ready() {
+		t.Fatalf("draining gate must stay NOT_SERVING despite recovery signals")
+	}
+	latest, _ := hs.snapshot()
+	if latest != grpchealth.StatusNotServing {
+		t.Fatalf("expected latest health NOT_SERVING, got %v", latest)
+	}
+}


### PR DESCRIPTION
## What

Server-code half of #768 (zero-drop client connection draining for HA rolling
updates). Adds a graceful **drain window** so a rolling restart drops zero
in-flight client requests.

## Changes

- **`readiness.Gate.BeginDrain()`** — latches the Gate to `NOT_SERVING`
  permanently (overall `""` gRPC health + `/readyz`), regardless of mode, lag,
  or bootstrap state. One-way: no later `SetLag`/`MarkBootstrapped` resurrects
  it. Works in single-instance mode too.
- **`LANTERN_DRAIN_DELAY_SECONDS`** (provider `ShutdownConfig.DrainDelay`,
  default `0` = today's behaviour, opt-in).
- **Two-phase `App.Run` shutdown.** The long-running servers now serve on an
  internal `serveCtx`, not the parent ctx. On `SIGTERM` the new drain
  coordinator: (1) calls `BeginDrain()` so readiness flips to `NOT_SERVING`
  **immediately**, (2) holds every listener — the data listener **and** the
  metrics server that serves `/readyz` — up for `DrainDelay` so load balancers /
  kube-proxy observe the drain and stop routing new requests, (3) then cancels
  `serveCtx` to begin the existing graceful `http.Server.Shutdown`. This fixes
  **Gap A** (no drain window) and **Gap B** (`/readyz` went away instead of
  reporting 503) from the epic in one change.

A failing server short-circuits the drain (no artificial delay), and
`DrainDelay=0` keeps the historical path bar a harmless immediate `BeginDrain`.

## Tests

- `gate_test.go`: `BeginDrain` flips single-instance + multi-peer gates to
  `NOT_SERVING`, is idempotent, and latches over later recovery signals.
- `server_test.go` (new): `drainPhase` ordering — drains-then-returns on SIGTERM,
  skips the window when a server fails first, zero-delay returns promptly, and a
  mid-window server death cuts the wait short.

## Gate

`gofmt` clean; `go vet ./...` + `go test ./...` green in `server/`, root
(incl. `tests/integration`), and all submodules. `wire_gen.go` regenerated
(`go tool wire ./cmd`).

Part of #768. Helm/Compose drain knobs + runbook §7 land in a follow-up PR.
