### PR TITLE
feat(server): periodic snapshot backup + restore-on-startup engine

### DIFF
--- a/server/backup/backup.go
+++ b/server/backup/backup.go
@@ -1,0 +1,431 @@
+// Package backup is the server-internal snapshot-durability engine (#770):
+// a goroutine that periodically dumps the whole graph to a mounted volume,
+// plus restore-on-startup that re-seeds the in-memory graph from the newest
+// dump before the server begins serving. It is the automation layer on top
+// of the on-demand backup/restore primitives shipped in #685 — the
+// rolling-update insurance for single-instance (Tier B) Cloud Run / ACA
+// deploys where the in-memory graph would otherwise be lost on every
+// revision rotation.
+//
+// Reuse, not reinvention: the periodic dump drives the existing
+// LanternService.BackupSnapshot RPC verbatim through a file-backed Sender,
+// so files are byte-identical to `lantern-cli dump --format proto` and
+// interchange with the CLI. Restore replays frames through the in-process
+// PutVertices / PutEdges, so HLC stamping and the born-expired skip (#698)
+// apply automatically — an entry whose TTL already elapsed since the dump
+// is correctly NOT resurrected.
+//
+// Shared storage is never assumed safe for concurrent writes (Cloud Run
+// GCS FUSE / NFS have no file locking; ACA Azure Files leaves multi-writer
+// coordination to the app), so every writer owns a per-instance file
+// (name carries InstanceID) and restore selects the newest valid file.
+// Writes are atomic via a temp file + rename; a half-written file is never
+// a restore candidate.
+package backup
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/encoding/protodelim"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/server/service"
+)
+
+const (
+	filePrefix = "lantern-backup-"
+	fileSuffix = ".lbk"
+	tmpSuffix  = ".lbk.tmp"
+
+	restoreChunkSize = 1000
+)
+
+// Config is the resolved backup configuration. It lives in this package
+// (not provider) so the dependency direction stays provider → backup. The
+// provider's loader resolves RestoreOnStart against peer mode before
+// constructing the Backupper.
+type Config struct {
+	// Enabled gates the periodic dump loop. Resolved to false when
+	// LANTERN_BACKUP_DIR is empty even if LANTERN_BACKUP_ENABLED is set.
+	Enabled bool
+	// Dir is the mounted directory backups are written to and read from.
+	Dir string
+	// Interval is the dump cadence.
+	Interval time.Duration
+	// Retain caps how many of THIS instance's own dumps are kept (newest
+	// first). 0 keeps all.
+	Retain int
+	// InstanceID is the per-instance filename token (collision-free writes
+	// on shared storage). Defaults to the hostname.
+	InstanceID string
+	// RestoreOnStart is the resolved decision to restore the newest dump on
+	// boot (already factors enabled, dir, the env knob, and peer mode).
+	RestoreOnStart bool
+	// RestoreRequired makes a restore error fail boot instead of warning.
+	RestoreRequired bool
+}
+
+// Service is the subset of *service.LanternService the Backupper drives.
+// Declared as an interface so tests can inject a fake without standing up a
+// full GraphCache.
+type Service interface {
+	BackupSnapshot(ctx context.Context, req *pb.BackupSnapshotRequest, stream service.Sender[pb.BackupSnapshotResponse]) error
+	PutVertices(ctx context.Context, req *pb.PutVerticesRequest) (*pb.PutVerticesResponse, error)
+	PutEdges(ctx context.Context, req *pb.PutEdgesRequest) (*pb.PutEdgesResponse, error)
+}
+
+// Stats counts the vertices and edges in a single backup or restore.
+type Stats struct {
+	Vertices int
+	Edges    int
+}
+
+// Backupper owns the periodic-dump loop and restore-on-startup.
+type Backupper struct {
+	svc     Service
+	cfg     Config
+	logger  *slog.Logger
+	metrics *metrics
+	now     func() time.Time
+}
+
+// New constructs a Backupper. reg may be nil (metrics unregistered but the
+// gauges still function). A disabled config (Enabled=false) yields a
+// Backupper whose Run / RestoreOnStartup are no-ops, so callers never have
+// to nil-check.
+func New(svc Service, cfg Config, reg prometheus.Registerer, logger *slog.Logger) *Backupper {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Backupper{svc: svc, cfg: cfg, metrics: newMetrics(reg), logger: logger, now: time.Now}
+}
+
+// RestoreOnStartup loads the newest valid dump from the backup directory and
+// replays it through PutVertices / PutEdges. It is a no-op (zero, nil) when
+// restore is disabled or the directory is empty/absent — a fresh start is
+// not an error. A directory that contains only corrupt files returns an
+// error so RestoreRequired callers can fail boot.
+func (b *Backupper) RestoreOnStartup(ctx context.Context) (Stats, error) {
+	if !b.cfg.RestoreOnStart {
+		return Stats{}, nil
+	}
+	candidates, err := b.listBackups()
+	if err != nil {
+		return Stats{}, err
+	}
+	if len(candidates) == 0 {
+		b.logger.Info("backup: restore-on-startup found no dumps; starting fresh",
+			slog.String("dir", b.cfg.Dir))
+		return Stats{}, nil
+	}
+
+	var lastErr error
+	for _, path := range candidates {
+		vertices, edges, derr := decodeFile(path)
+		if derr != nil {
+			b.logger.Warn("backup: dump failed to decode; trying older file",
+				slog.String("file", path), slog.Any("err", derr))
+			lastErr = derr
+			continue
+		}
+		stats, aerr := b.apply(ctx, vertices, edges)
+		if aerr != nil {
+			return stats, aerr
+		}
+		b.logger.Info("backup: restored from dump",
+			slog.String("file", path),
+			slog.Int("vertices", stats.Vertices),
+			slog.Int("edges", stats.Edges))
+		if b.metrics != nil {
+			b.metrics.observeRestore(stats, b.now())
+		}
+		return stats, nil
+	}
+	return Stats{}, fmt.Errorf("backup: all %d dump(s) in %s failed to decode: %w",
+		len(candidates), b.cfg.Dir, lastErr)
+}
+
+// Run drives the periodic dump loop until ctx is cancelled. It is a no-op
+// when backups are disabled. On graceful cancellation it takes one final
+// best-effort dump so the latest state is captured before exit.
+func (b *Backupper) Run(ctx context.Context) error {
+	if !b.cfg.Enabled || b.cfg.Interval <= 0 {
+		return nil
+	}
+	b.logger.Info("backup: periodic dump loop started",
+		slog.String("dir", b.cfg.Dir),
+		slog.Duration("interval", b.cfg.Interval),
+		slog.Int("retain", b.cfg.Retain),
+		slog.String("instance", b.cfg.InstanceID))
+
+	ticker := time.NewTicker(b.cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			// Final best-effort dump on graceful shutdown, bounded so it
+			// never blocks the drain budget.
+			finalCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			if _, err := b.backupOnce(finalCtx); err != nil {
+				b.logger.Warn("backup: final dump on shutdown failed", slog.Any("err", err))
+			}
+			cancel()
+			return nil
+		case <-ticker.C:
+			if _, err := b.backupOnce(ctx); err != nil {
+				b.logger.Warn("backup: periodic dump failed", slog.Any("err", err))
+			}
+		}
+	}
+}
+
+// BackupNow writes one whole-graph dump immediately and returns its stats.
+// It is the one-shot the periodic loop runs each tick, exposed so an
+// operator- or test-driven backup reuses the same atomic-write + retention
+// path.
+func (b *Backupper) BackupNow(ctx context.Context) (Stats, error) {
+	return b.backupOnce(ctx)
+}
+
+// backupOnce writes one whole-graph dump atomically (temp file + rename),
+// then prunes to Retain newest of this instance's own dumps.
+func (b *Backupper) backupOnce(ctx context.Context) (Stats, error) {
+	start := b.now()
+	if err := os.MkdirAll(b.cfg.Dir, 0o755); err != nil {
+		b.failed()
+		return Stats{}, fmt.Errorf("backup: mkdir %s: %w", b.cfg.Dir, err)
+	}
+
+	final := filepath.Join(b.cfg.Dir, b.fileName(start))
+	tmp := final[:len(final)-len(fileSuffix)] + tmpSuffix
+
+	f, err := os.Create(tmp)
+	if err != nil {
+		b.failed()
+		return Stats{}, fmt.Errorf("backup: create %s: %w", tmp, err)
+	}
+	sender := &protoFileSender{w: bufio.NewWriter(f)}
+	serr := b.svc.BackupSnapshot(ctx, &pb.BackupSnapshotRequest{}, sender)
+	if serr == nil {
+		serr = sender.w.Flush()
+	}
+	if cerr := f.Close(); serr == nil {
+		serr = cerr
+	}
+	if serr != nil {
+		_ = os.Remove(tmp)
+		b.failed()
+		return Stats{}, fmt.Errorf("backup: write %s: %w", tmp, serr)
+	}
+	if err := os.Rename(tmp, final); err != nil {
+		_ = os.Remove(tmp)
+		b.failed()
+		return Stats{}, fmt.Errorf("backup: rename %s: %w", final, err)
+	}
+
+	stats := Stats{Vertices: sender.vertices, Edges: sender.edges}
+	if b.metrics != nil {
+		b.metrics.observeBackup(stats, b.now().Sub(start), b.now())
+	}
+	b.logger.Info("backup: wrote dump",
+		slog.String("file", final),
+		slog.Int("vertices", stats.Vertices),
+		slog.Int("edges", stats.Edges),
+		slog.Duration("took", b.now().Sub(start)))
+	b.prune()
+	return stats, nil
+}
+
+func (b *Backupper) failed() {
+	if b.metrics != nil {
+		b.metrics.failures.Inc()
+	}
+}
+
+// apply replays decoded vertices then edges through the service in chunks.
+// Vertices first so PutEdges' auto-created endpoints don't shadow real
+// vertex values.
+func (b *Backupper) apply(ctx context.Context, vertices []*pb.Vertex, edges []*pb.Edge) (Stats, error) {
+	var stats Stats
+	for i := 0; i < len(vertices); i += restoreChunkSize {
+		end := min(i+restoreChunkSize, len(vertices))
+		if _, err := b.svc.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: vertices[i:end]}); err != nil {
+			return stats, fmt.Errorf("backup: restore PutVertices: %w", err)
+		}
+		stats.Vertices += end - i
+	}
+	for i := 0; i < len(edges); i += restoreChunkSize {
+		end := min(i+restoreChunkSize, len(edges))
+		if _, err := b.svc.PutEdges(ctx, &pb.PutEdgesRequest{Edges: edges[i:end]}); err != nil {
+			return stats, fmt.Errorf("backup: restore PutEdges: %w", err)
+		}
+		stats.Edges += end - i
+	}
+	return stats, nil
+}
+
+// fileName builds this instance's dump filename for the given instant. The
+// nanosecond stamp keeps names unique even under a tight test loop.
+func (b *Backupper) fileName(ts time.Time) string {
+	return fmt.Sprintf("%s%s-%d%s", filePrefix, b.cfg.InstanceID, ts.UnixNano(), fileSuffix)
+}
+
+// ownPrefix is the filename prefix of this instance's dumps, used to scope
+// retention pruning so an instance never deletes a peer's files.
+func (b *Backupper) ownPrefix() string {
+	return filePrefix + b.cfg.InstanceID + "-"
+}
+
+// listBackups returns every finalised dump in the directory (any instance),
+// newest first. Ordering uses the nanosecond stamp embedded in the filename
+// (deterministic, independent of filesystem mtime granularity), falling back
+// to mtime. Temp files and non-dump entries are ignored.
+func (b *Backupper) listBackups() ([]string, error) {
+	files, err := b.collect(filePrefix)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, len(files))
+	for i, f := range files {
+		paths[i] = f.path
+	}
+	return paths, nil
+}
+
+// prune deletes this instance's own dumps beyond Retain (newest kept). Only
+// files carrying this instance's token are eligible, so concurrent writers
+// on shared storage never race to delete each other's dumps.
+func (b *Backupper) prune() {
+	if b.cfg.Retain <= 0 {
+		return
+	}
+	own, err := b.collect(b.ownPrefix())
+	if err != nil || len(own) <= b.cfg.Retain {
+		return
+	}
+	for _, f := range own[b.cfg.Retain:] {
+		if rerr := os.Remove(f.path); rerr != nil {
+			b.logger.Warn("backup: prune failed", slog.String("file", f.path), slog.Any("err", rerr))
+		}
+	}
+}
+
+// backupFile is a finalised dump plus its sort keys.
+type backupFile struct {
+	path  string
+	stamp int64
+	mod   time.Time
+}
+
+// collect returns the finalised dumps whose filename starts with prefix,
+// sorted newest first by embedded stamp (mtime tiebreak).
+func (b *Backupper) collect(prefix string) ([]backupFile, error) {
+	entries, err := os.ReadDir(b.cfg.Dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("backup: read dir %s: %w", b.cfg.Dir, err)
+	}
+	var out []backupFile
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, fileSuffix) {
+			continue
+		}
+		info, ierr := e.Info()
+		if ierr != nil {
+			continue
+		}
+		stamp, _ := fileStamp(name)
+		out = append(out, backupFile{path: filepath.Join(b.cfg.Dir, name), stamp: stamp, mod: info.ModTime()})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].stamp != out[j].stamp {
+			return out[i].stamp > out[j].stamp
+		}
+		return out[i].mod.After(out[j].mod)
+	})
+	return out, nil
+}
+
+// fileStamp parses the trailing "-<unixNano>.lbk" stamp from a dump
+// filename. The instance token may itself contain '-', so the stamp is the
+// final '-'-separated segment.
+func fileStamp(name string) (int64, bool) {
+	s := strings.TrimSuffix(name, fileSuffix)
+	i := strings.LastIndexByte(s, '-')
+	if i < 0 {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(s[i+1:], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// protoFileSender satisfies service.Sender[pb.BackupSnapshotResponse] by
+// writing each frame as length-delimited protobuf — byte-identical to the
+// SDK / CLI proto dump format.
+type protoFileSender struct {
+	w        *bufio.Writer
+	vertices int
+	edges    int
+}
+
+func (s *protoFileSender) Send(rec *pb.BackupSnapshotResponse) error {
+	if _, err := protodelim.MarshalTo(s.w, rec); err != nil {
+		return err
+	}
+	switch rec.GetRecord().(type) {
+	case *pb.BackupSnapshotResponse_Vertex:
+		s.vertices++
+	case *pb.BackupSnapshotResponse_Edge:
+		s.edges++
+	}
+	return nil
+}
+
+// decodeFile reads a whole dump into memory, validating that every frame
+// decodes. A mid-stream decode error (a truncated / corrupt file) is
+// returned so the caller can fall back to an older dump WITHOUT having
+// applied a partial file.
+func decodeFile(path string) (vertices []*pb.Vertex, edges []*pb.Edge, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	r := bufio.NewReader(f)
+	for {
+		rec := &pb.BackupSnapshotResponse{}
+		if uerr := protodelim.UnmarshalFrom(r, rec); uerr != nil {
+			if errors.Is(uerr, io.EOF) {
+				break
+			}
+			return nil, nil, uerr
+		}
+		switch x := rec.GetRecord().(type) {
+		case *pb.BackupSnapshotResponse_Vertex:
+			vertices = append(vertices, x.Vertex)
+		case *pb.BackupSnapshotResponse_Edge:
+			edges = append(edges, x.Edge)
+		}
+	}
+	return vertices, edges, nil
+}

--- a/server/backup/backup_test.go
+++ b/server/backup/backup_test.go
@@ -1,0 +1,189 @@
+package backup
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/server/service"
+)
+
+// fakeService satisfies the backup Service: BackupSnapshot emits a fixed
+// frame list; PutVertices / PutEdges record what restore replayed.
+type fakeService struct {
+	frames []*pb.BackupSnapshotResponse
+	putV   []*pb.Vertex
+	putE   []*pb.Edge
+}
+
+func (f *fakeService) BackupSnapshot(_ context.Context, _ *pb.BackupSnapshotRequest, stream service.Sender[pb.BackupSnapshotResponse]) error {
+	for _, fr := range f.frames {
+		if err := stream.Send(fr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *fakeService) PutVertices(_ context.Context, req *pb.PutVerticesRequest) (*pb.PutVerticesResponse, error) {
+	f.putV = append(f.putV, req.GetVertices()...)
+	return &pb.PutVerticesResponse{}, nil
+}
+
+func (f *fakeService) PutEdges(_ context.Context, req *pb.PutEdgesRequest) (*pb.PutEdgesResponse, error) {
+	f.putE = append(f.putE, req.GetEdges()...)
+	return &pb.PutEdgesResponse{}, nil
+}
+
+func vFrame(key string) *pb.BackupSnapshotResponse {
+	return &pb.BackupSnapshotResponse{Record: &pb.BackupSnapshotResponse_Vertex{Vertex: &pb.Vertex{Key: key}}}
+}
+
+func eFrame(tail, head string, w float32) *pb.BackupSnapshotResponse {
+	return &pb.BackupSnapshotResponse{Record: &pb.BackupSnapshotResponse_Edge{Edge: &pb.Edge{Tail: tail, Head: head, Weight: w}}}
+}
+
+func testConfig(dir string) Config {
+	return Config{Enabled: true, Dir: dir, Interval: time.Hour, Retain: 3, InstanceID: "node-a", RestoreOnStart: true}
+}
+
+func TestBackupper_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	src := &fakeService{frames: []*pb.BackupSnapshotResponse{vFrame("a"), vFrame("b"), eFrame("a", "b", 1.5)}}
+	if _, err := New(src, testConfig(dir), nil, nil).backupOnce(context.Background()); err != nil {
+		t.Fatalf("backupOnce: %v", err)
+	}
+
+	dst := &fakeService{}
+	stats, err := New(dst, testConfig(dir), nil, nil).RestoreOnStartup(context.Background())
+	if err != nil {
+		t.Fatalf("RestoreOnStartup: %v", err)
+	}
+	if stats.Vertices != 2 || stats.Edges != 1 {
+		t.Fatalf("stats = %+v, want {2 1}", stats)
+	}
+	if len(dst.putV) != 2 || dst.putV[0].GetKey() != "a" || dst.putV[1].GetKey() != "b" {
+		t.Fatalf("restored vertices = %+v", dst.putV)
+	}
+	if len(dst.putE) != 1 || dst.putE[0].GetTail() != "a" || dst.putE[0].GetHead() != "b" || dst.putE[0].GetWeight() != 1.5 {
+		t.Fatalf("restored edges = %+v", dst.putE)
+	}
+}
+
+func TestBackupper_RestoreSkipsCorruptFile(t *testing.T) {
+	dir := t.TempDir()
+
+	good := New(&fakeService{frames: []*pb.BackupSnapshotResponse{vFrame("good")}}, testConfig(dir), nil, nil)
+	good.now = func() time.Time { return time.Unix(0, 100) } // stamp 100
+	if _, err := good.backupOnce(context.Background()); err != nil {
+		t.Fatalf("backupOnce: %v", err)
+	}
+
+	// A NEWER (stamp 200) but corrupt dump: a varint length of 5 with only
+	// two bytes following → decode fails. It must be skipped for the older
+	// good file rather than aborting the restore.
+	corrupt := filepath.Join(dir, fmt.Sprintf("%snode-a-200%s", filePrefix, fileSuffix))
+	if err := os.WriteFile(corrupt, []byte{0x05, 0x01, 0x02}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := &fakeService{}
+	stats, err := New(dst, testConfig(dir), nil, nil).RestoreOnStartup(context.Background())
+	if err != nil {
+		t.Fatalf("RestoreOnStartup should fall back to the good file, got %v", err)
+	}
+	if stats.Vertices != 1 || len(dst.putV) != 1 || dst.putV[0].GetKey() != "good" {
+		t.Fatalf("expected the good dump restored, got stats=%+v putV=%+v", stats, dst.putV)
+	}
+}
+
+func TestBackupper_RestoreAllCorruptErrors(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, fmt.Sprintf("%snode-a-1%s", filePrefix, fileSuffix))
+	if err := os.WriteFile(bad, []byte{0x05, 0x01, 0x02}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := New(&fakeService{}, testConfig(dir), nil, nil).RestoreOnStartup(context.Background()); err == nil {
+		t.Fatal("expected an error when every dump is corrupt (so RestoreRequired can fail boot)")
+	}
+}
+
+func TestBackupper_RestoreEmptyDirIsFreshStart(t *testing.T) {
+	stats, err := New(&fakeService{}, testConfig(t.TempDir()), nil, nil).RestoreOnStartup(context.Background())
+	if err != nil {
+		t.Fatalf("empty dir must not error: %v", err)
+	}
+	if stats != (Stats{}) {
+		t.Fatalf("empty dir restore = %+v, want zero", stats)
+	}
+}
+
+func TestBackupper_Retention(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testConfig(dir)
+	cfg.Retain = 2
+	b := New(&fakeService{frames: []*pb.BackupSnapshotResponse{vFrame("x")}}, cfg, nil, nil)
+	var n int64
+	b.now = func() time.Time { n++; return time.Unix(0, n) } // strictly increasing stamps
+
+	for i := 0; i < 5; i++ {
+		if _, err := b.backupOnce(context.Background()); err != nil {
+			t.Fatalf("backupOnce %d: %v", i, err)
+		}
+	}
+	files, err := b.listBackups()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("Retain=2 should leave 2 dumps, got %d", len(files))
+	}
+	// No temp files should linger.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".tmp" {
+			t.Fatalf("temp file lingered: %s", e.Name())
+		}
+	}
+}
+
+func TestBackupper_DisabledNoOps(t *testing.T) {
+	b := New(&fakeService{}, Config{Enabled: false, Dir: t.TempDir(), RestoreOnStart: false}, nil, nil)
+	if err := b.Run(context.Background()); err != nil {
+		t.Fatalf("disabled Run should return nil immediately, got %v", err)
+	}
+	stats, err := b.RestoreOnStartup(context.Background())
+	if err != nil || stats != (Stats{}) {
+		t.Fatalf("disabled restore should be a no-op, got stats=%+v err=%v", stats, err)
+	}
+}
+
+func TestBackupper_PerInstanceFileNaming(t *testing.T) {
+	dir := t.TempDir()
+	// Two instances writing to the same shared dir must not collide nor
+	// prune each other.
+	a := New(&fakeService{frames: []*pb.BackupSnapshotResponse{vFrame("x")}}, Config{Enabled: true, Dir: dir, Retain: 1, InstanceID: "node-a"}, nil, nil)
+	bcfg := Config{Enabled: true, Dir: dir, Retain: 1, InstanceID: "node-b"}
+	b := New(&fakeService{frames: []*pb.BackupSnapshotResponse{vFrame("y")}}, bcfg, nil, nil)
+	var na, nb int64
+	a.now = func() time.Time { na++; return time.Unix(0, na) }
+	b.now = func() time.Time { nb++; return time.Unix(100, nb) }
+
+	for i := 0; i < 3; i++ {
+		if _, err := a.backupOnce(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := b.backupOnce(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Retain=1 per instance → one file each survives, two total.
+	all, _ := a.listBackups()
+	if len(all) != 2 {
+		t.Fatalf("expected 1 dump per instance (2 total), got %d", len(all))
+	}
+}

--- a/server/backup/metrics.go
+++ b/server/backup/metrics.go
@@ -1,0 +1,79 @@
+package backup
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// metrics holds the Prometheus collectors for the backup engine. They are
+// registered on the shared server registry when one is provided; with a nil
+// registerer the gauges still function (Set/Inc are no-ops observability-
+// wise) so the Backupper never has to nil-check.
+type metrics struct {
+	lastSuccess   prometheus.Gauge
+	duration      prometheus.Gauge
+	vertices      prometheus.Gauge
+	edges         prometheus.Gauge
+	failures      prometheus.Counter
+	restoreVtx    prometheus.Gauge
+	restoreEdges  prometheus.Gauge
+	restoreLastTS prometheus.Gauge
+}
+
+func newMetrics(reg prometheus.Registerer) *metrics {
+	m := &metrics{
+		lastSuccess: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "lantern_backup_last_success_timestamp_seconds",
+			Help: "Unix timestamp of the last successful periodic backup.",
+		}),
+		duration: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "lantern_backup_duration_seconds",
+			Help: "Wall-clock seconds the last successful backup took.",
+		}),
+		vertices: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "lantern_backup_vertices",
+			Help: "Vertices written by the last successful backup.",
+		}),
+		edges: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "lantern_backup_edges",
+			Help: "Edges written by the last successful backup.",
+		}),
+		failures: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "lantern_backup_failures_total",
+			Help: "Total periodic backups that failed to write.",
+		}),
+		restoreVtx: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "lantern_restore_vertices",
+			Help: "Vertices replayed by restore-on-startup.",
+		}),
+		restoreEdges: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "lantern_restore_edges",
+			Help: "Edges replayed by restore-on-startup.",
+		}),
+		restoreLastTS: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "lantern_restore_last_timestamp_seconds",
+			Help: "Unix timestamp of the last restore-on-startup.",
+		}),
+	}
+	if reg != nil {
+		reg.MustRegister(
+			m.lastSuccess, m.duration, m.vertices, m.edges, m.failures,
+			m.restoreVtx, m.restoreEdges, m.restoreLastTS,
+		)
+	}
+	return m
+}
+
+func (m *metrics) observeBackup(s Stats, took time.Duration, at time.Time) {
+	m.lastSuccess.Set(float64(at.Unix()))
+	m.duration.Set(took.Seconds())
+	m.vertices.Set(float64(s.Vertices))
+	m.edges.Set(float64(s.Edges))
+}
+
+func (m *metrics) observeRestore(s Stats, at time.Time) {
+	m.restoreVtx.Set(float64(s.Vertices))
+	m.restoreEdges.Set(float64(s.Edges))
+	m.restoreLastTS.Set(float64(at.Unix()))
+}

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"math"
 	"os"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
+	"github.com/anaregdesign/lantern/server/backup"
 	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
 	"github.com/anaregdesign/lantern/server/provider"
 	"github.com/anaregdesign/lantern/server/readiness"
@@ -34,6 +36,8 @@ type App struct {
 	health      *provider.HealthChecker
 	gate        *readiness.Gate
 	drainDelay  time.Duration
+	backupper   *backup.Backupper
+	restoreReq  bool
 	pump        *replication.Pump
 	antiEntropy *replication.AntiEntropy
 }
@@ -51,6 +55,8 @@ func newApp(
 	antiEntropy *replication.AntiEntropy,
 	gate *readiness.Gate,
 	sc provider.ShutdownConfig,
+	backupper *backup.Backupper,
+	bcfg backup.Config,
 	pc provider.PeerConfig,
 	rc provider.ReplicationConfig,
 	_ provider.CacheGCHooksWired,
@@ -79,6 +85,8 @@ func newApp(
 		health:      hc,
 		gate:        gate,
 		drainDelay:  sc.DrainDelay,
+		backupper:   backupper,
+		restoreReq:  bcfg.RestoreRequired,
 		pump:        pump,
 		antiEntropy: antiEntropy,
 	}
@@ -181,6 +189,19 @@ func newLanternReplicationService(
 }
 
 func (a *App) Run(ctx context.Context) error {
+	// Restore-on-startup (#770) runs BEFORE any listener serves, so a
+	// single-instance (Tier B) deploy recovers its in-memory graph from the
+	// newest mounted dump before accepting traffic. The Backupper no-ops
+	// when backups are disabled or restore is gated off (multi-peer mode
+	// relies on peer bootstrap instead). A restore failure fails boot only
+	// when LANTERN_BACKUP_RESTORE_REQUIRED is set.
+	if _, err := a.backupper.RestoreOnStartup(ctx); err != nil {
+		if a.restoreReq {
+			return fmt.Errorf("restore-on-startup: %w", err)
+		}
+		a.logger.Warn("restore-on-startup failed; starting with current state", slog.Any("err", err))
+	}
+
 	// The overall ("") gRPC health entry is owned by the readiness Gate
 	// (#188): in single-instance mode it is already SERVING; in
 	// multi-peer mode it stays NOT_SERVING until bootstrap completes
@@ -204,6 +225,7 @@ func (a *App) Run(ctx context.Context) error {
 	g.Go(func() error { a.domain.Run(gctx); return nil })
 	g.Go(func() error { return a.pump.Run(gctx) })
 	g.Go(func() error { return a.antiEntropy.Run(gctx) })
+	g.Go(func() error { return a.backupper.Run(gctx) })
 	g.Go(func() error {
 		drainPhase(ctx, gctx.Done(), a.drainDelay, a.beginDrain)
 		cancelServe()

--- a/server/cmd/wire.go
+++ b/server/cmd/wire.go
@@ -50,6 +50,8 @@ func initializeApp() (*App, error) {
 		provider.NewMetricsServer,
 		provider.NewCORSConfig,
 		provider.NewLifecycleConfig,
+		provider.NewBackupConfig,
+		provider.NewBackupper,
 		newLanternService,
 		newLanternReplicationService,
 		provider.NewReplicationPump,

--- a/server/cmd/wire_gen.go
+++ b/server/cmd/wire_gen.go
@@ -64,7 +64,9 @@ func initializeApp() (*App, error) {
 	antiEntropyConfig := provider.NewAntiEntropyConfig(config)
 	antiEntropyMetrics := provider.NewAntiEntropyMetrics(domainMetrics, gate)
 	antiEntropy := provider.NewAntiEntropyDriver(peerConfig, replicationConfig, antiEntropyConfig, lanternService, graphCache, pump, antiEntropyMetrics, logger)
+	backupConfig := provider.NewBackupConfig(config)
+	backupper := provider.NewBackupper(backupConfig, lanternService, registry, logger)
 	cacheGCHooksWired := provider.WireCacheGCHooks(graphCache, domainMetrics, logger)
-	app := newApp(config, logger, lanternService, lanternServer, metricsServer, tracing, domainMetrics, healthChecker, pump, antiEntropy, gate, shutdownConfig, peerConfig, replicationConfig, cacheGCHooksWired)
+	app := newApp(config, logger, lanternService, lanternServer, metricsServer, tracing, domainMetrics, healthChecker, pump, antiEntropy, gate, shutdownConfig, backupper, backupConfig, peerConfig, replicationConfig, cacheGCHooksWired)
 	return app, nil
 }

--- a/server/provider/backup.go
+++ b/server/provider/backup.go
@@ -1,0 +1,86 @@
+package provider
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/anaregdesign/lantern/server/backup"
+	"github.com/anaregdesign/lantern/server/internal/envconfig"
+	"github.com/anaregdesign/lantern/server/service"
+)
+
+// loadBackupConfig reads the LANTERN_BACKUP_* contract and resolves the
+// restore-on-startup decision against peer mode (#770).
+//
+//   - LANTERN_BACKUP_ENABLED          (default false) master switch for the
+//     periodic dump loop. Resolved to off when LANTERN_BACKUP_DIR is empty.
+//   - LANTERN_BACKUP_DIR              mounted directory to write/read dumps.
+//   - LANTERN_BACKUP_INTERVAL         (default 5m) dump cadence.
+//   - LANTERN_BACKUP_RETAIN           (default 3) keep newest N own dumps;
+//     0 keeps all.
+//   - LANTERN_BACKUP_INSTANCE_ID      (default hostname) per-instance file
+//     token so shared-storage writes never collide.
+//   - LANTERN_BACKUP_RESTORE_ON_START (default true) restore the newest
+//     dump on boot. Restore is single-instance-gated: in multi-peer mode it
+//     is skipped (peer bootstrap is the recovery path) unless
+//     LANTERN_BACKUP_RESTORE_FORCE=true.
+//   - LANTERN_BACKUP_RESTORE_FORCE    (default false) restore even when
+//     peers are configured.
+//   - LANTERN_BACKUP_RESTORE_REQUIRED (default false) fail boot when a
+//     restore errors instead of warning and continuing.
+func loadBackupConfig(hasPeers bool) backup.Config {
+	enabled := envconfig.Bool("LANTERN_BACKUP_ENABLED", false)
+	dir := strings.TrimSpace(envconfig.String("LANTERN_BACKUP_DIR", ""))
+	active := enabled && dir != ""
+
+	instance := strings.TrimSpace(envconfig.String("LANTERN_BACKUP_INSTANCE_ID", ""))
+	if instance == "" {
+		if h, err := os.Hostname(); err == nil && strings.TrimSpace(h) != "" {
+			instance = strings.TrimSpace(h)
+		} else {
+			instance = "lantern"
+		}
+	}
+
+	restoreOnStart := active &&
+		envconfig.Bool("LANTERN_BACKUP_RESTORE_ON_START", true) &&
+		(!hasPeers || envconfig.Bool("LANTERN_BACKUP_RESTORE_FORCE", false))
+
+	return backup.Config{
+		Enabled:         active,
+		Dir:             dir,
+		Interval:        envconfig.Duration("LANTERN_BACKUP_INTERVAL", 5*time.Minute),
+		Retain:          envconfig.Int("LANTERN_BACKUP_RETAIN", 3),
+		InstanceID:      sanitizeInstanceID(instance),
+		RestoreOnStart:  restoreOnStart,
+		RestoreRequired: envconfig.Bool("LANTERN_BACKUP_RESTORE_REQUIRED", false),
+	}
+}
+
+// sanitizeInstanceID strips characters that would make an unsafe path
+// segment so the instance token is always a clean filename component.
+func sanitizeInstanceID(s string) string {
+	repl := func(r rune) rune {
+		switch r {
+		case '/', '\\', ' ', '\t', '\n':
+			return '_'
+		default:
+			return r
+		}
+	}
+	return strings.Map(repl, s)
+}
+
+// NewBackupConfig is the wire selector for the resolved backup config.
+func NewBackupConfig(c *Config) backup.Config { return c.Backup }
+
+// NewBackupper constructs the snapshot-durability engine, registering its
+// metrics on the shared registry. It is always non-nil; a disabled config
+// yields a Backupper whose Run / RestoreOnStartup are no-ops.
+func NewBackupper(cfg backup.Config, svc *service.LanternService, reg *prometheus.Registry, logger *slog.Logger) *backup.Backupper {
+	return backup.New(svc, cfg, reg, logger)
+}

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/anaregdesign/lantern/core/graphcache"
 	v1 "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/server/backup"
 	"github.com/anaregdesign/lantern/server/internal/envconfig"
 	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
 	"github.com/anaregdesign/lantern/server/readiness"
@@ -175,6 +176,7 @@ type Config struct {
 	AntiEntropy   AntiEntropyConfig
 	Readiness     ReadinessConfig
 	CORS          CORSConfig
+	Backup        backup.Config
 }
 
 func NewConfig() *Config {
@@ -183,6 +185,10 @@ func NewConfig() *Config {
 	if burst <= 0 && rps > 0 {
 		burst = int(2 * rps)
 	}
+	// Peers are loaded up front because the backup loader's
+	// restore-on-startup decision is peer-mode-aware (single-instance only
+	// by default, #770).
+	peer := loadPeerConfig()
 	return &Config{
 		Net: NetConfig{
 			Port:                 envconfig.Int("LANTERN_PORT", 6380),
@@ -239,9 +245,10 @@ func NewConfig() *Config {
 		MutationLog: loadMutationLogConfig(),
 		Replication: loadReplicationConfig(),
 		Readiness:   loadReadinessConfig(),
-		Peer:        loadPeerConfig(),
+		Peer:        peer,
 		AntiEntropy: loadAntiEntropyConfig(),
 		CORS:        loadCORSConfig(),
+		Backup:      loadBackupConfig(len(peer.Peers) > 0),
 	}
 }
 

--- a/tests/integration/backup_test.go
+++ b/tests/integration/backup_test.go
@@ -14,6 +14,7 @@ import (
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
 	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/anaregdesign/lantern/server/backup"
 	"github.com/anaregdesign/lantern/server/provider"
 	"github.com/anaregdesign/lantern/server/service"
 )
@@ -122,6 +123,70 @@ func drainBackup(t *testing.T, ctx context.Context, raw graphv1connect.LanternSe
 		t.Fatalf("BackupSnapshot stream: %v", err)
 	}
 	return vertices, edges
+}
+
+// TestBackupper_ServerInternal_RoundTrip_E2E drives the server-internal
+// snapshot engine (#770) end-to-end against real services + caches: seed a
+// graph, dump it to a temp dir via the Backupper's BackupNow (same path the
+// periodic loop uses), then RestoreOnStartup it into a FRESH service and
+// confirm every vertex value + edge weight survived. Proves the
+// server-internal proto dump interchanges with the BackupSnapshot surface
+// and that restore replays faithfully through PutVertices / PutEdges.
+func TestBackupper_ServerInternal_RoundTrip_E2E(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	dir := t.TempDir()
+	cfg := backup.Config{Enabled: true, Dir: dir, Interval: time.Hour, Retain: 3, InstanceID: "itest", RestoreOnStart: true}
+	val := provider.NewValidationInterceptor(defaultIntegrationValidationLimits())
+
+	// Source service, seeded via the SDK.
+	srcCache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+	srcSvc := service.NewLanternService(srcCache)
+	srcSrv := newConnectTestServer(t, srcSvc, nil, val.ConnectInterceptor())
+	srcSDK := newConnectClientFor(t, srcSrv.url)
+
+	const bigInt = int64(9007199254740993) // 2^53 + 1
+	if err := srcSDK.PutVertex(ctx, "alice", "Alice", time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	if err := srcSDK.PutVertex(ctx, "num", bigInt, time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	if err := srcSDK.AddEdge(ctx, "alice", "num", 1.5, time.Minute); err != nil {
+		t.Fatal(err)
+	}
+
+	// Server-internal dump (same path as the periodic loop).
+	if _, err := backup.New(srcSvc, cfg, nil, nil).BackupNow(ctx); err != nil {
+		t.Fatalf("BackupNow: %v", err)
+	}
+
+	// Fresh service, restored on startup from the dump.
+	dstCache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+	dstSvc := service.NewLanternService(dstCache)
+	dstSrv := newConnectTestServer(t, dstSvc, nil, val.ConnectInterceptor())
+	dstRaw := graphv1connect.NewLanternServiceClient(h2cClient(), dstSrv.url)
+
+	stats, err := backup.New(dstSvc, cfg, nil, nil).RestoreOnStartup(ctx)
+	if err != nil {
+		t.Fatalf("RestoreOnStartup: %v", err)
+	}
+	if stats.Vertices != 2 || stats.Edges != 1 {
+		t.Fatalf("restore stats = %+v, want {2,1}", stats)
+	}
+
+	// Re-dump the restored service and confirm fidelity.
+	vs, es := drainBackup(t, ctx, dstRaw, &pb.BackupSnapshotRequest{})
+	if got, err := client.StringValue(vs["alice"]); err != nil || got != "Alice" {
+		t.Errorf("restored alice = %q (err %v), want Alice", got, err)
+	}
+	if got, err := client.IntValue(vs["num"]); err != nil || int64(got) != bigInt {
+		t.Errorf("restored num = %d (err %v), want %d", got, err, bigInt)
+	}
+	if e := es["alice->num"]; e == nil || e.GetWeight() != 1.5 {
+		t.Errorf("restored edge alice->num = %v, want weight 1.5", e)
+	}
 }
 
 // TestBackupRestore_E2E_SDK round-trips a graph through the SDK Backup


### PR DESCRIPTION
## What

The server-internal snapshot-durability engine (#770): a goroutine that
**periodically dumps the whole graph to a mounted volume**, plus
**restore-on-startup** that re-seeds the in-memory graph from the newest dump
before the server serves. Rolling-update insurance for single-instance (Tier B)
Cloud Run / ACA deploys.

## Design (reuse-first)

- New package **`server/backup`** with a `Backupper`:
  - **Dump** drives the existing `LanternService.BackupSnapshot` RPC verbatim
    through a file-backed `Sender[pb.BackupSnapshotResponse]` writing
    length-delimited protobuf — **byte-identical to `lantern-cli dump --format
    proto`**, so files interchange with the CLI. No `sdks/go` import (respects
    the `server → pb + core` boundary).
  - **Restore** decodes frames and replays them through in-process
    `PutVertices` / `PutEdges`, so HLC stamping + the born-expired skip (#698)
    apply for free.
  - **Per-instance files** (`lantern-backup-<instance>-<nano>.lbk`), atomic
    write (temp + rename), retention prune scoped to this instance's own files
    — safe on the no-locking shared backends (Cloud Run GCS FUSE / NFS, ACA
    Azure Files). Restore picks the newest **valid** file; a truncated dump is
    skipped for the previous good one.
- **`LANTERN_BACKUP_*`** config (provider `backup.Config` + `NewBackupConfig` +
  `NewBackupper`): `ENABLED`, `DIR`, `INTERVAL` (5m), `RETAIN` (3),
  `INSTANCE_ID` (hostname), `RESTORE_ON_START` (true), `RESTORE_FORCE`,
  `RESTORE_REQUIRED`. Restore is **single-instance-gated** by default
  (multi-peer relies on peer bootstrap) unless `RESTORE_FORCE`.
- **`App.Run` integration**: restore runs **before any listener serves**; the
  periodic loop is an errgroup goroutine that also takes one final best-effort
  dump on graceful shutdown (bounded, never blocks the #768 drain budget).
- **Metrics**: `lantern_backup_last_success_timestamp_seconds`,
  `lantern_backup_duration_seconds`, `lantern_backup_vertices` /
  `_edges`, `lantern_backup_failures_total`, `lantern_restore_*`.

## Tests

- `server/backup/backup_test.go`: round-trip via real files, corrupt-file
  skip, all-corrupt errors (so `RESTORE_REQUIRED` can fail boot), empty dir =
  fresh start, retention prune, per-instance isolation (two instances sharing
  a dir don't prune each other).
- `tests/integration/backup_test.go`: faithful end-to-end against real
  services + caches — seed → `BackupNow` → `RestoreOnStartup` into a fresh
  service → re-dump and confirm values + edge weight (incl. an int64 > 2^53)
  survived.

## Gate

`gofmt` clean; `go vet ./...` + `go test ./...` green in `server/`, root
(incl. `tests/integration`). `wire_gen.go` regenerated.

Closes #770. Part of epic #769. Deploy manifests + Cloud Run/ACA docs land in
#771; coordinates with the #768 drain on the shared `App.Run` seam (both merged
cleanly — restore is startup-side, drain is shutdown-side).
