### PR TITLE
feat(deploy): rolling-update drain manifests + runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,6 +803,7 @@ The server is configured via environment variables, parsed in
 | `LANTERN_CORS_ALLOWED_ORIGINS` | _(empty)_ | Comma-separated CORS allow-list for the primary `:6380` listener (e.g. `http://localhost:5173,https://admin.example.com`). Empty disables CORS. `*` is honoured only when sole entry. |
 | `LANTERN_REFLECTION` | `true` | Register gRPC server reflection (useful for `grpcurl`) |
 | `LANTERN_SHUTDOWN_TIMEOUT_SECONDS` | `30` | Upper bound on graceful shutdown before forcing `http.Server.Close()` |
+| `LANTERN_DRAIN_DELAY_SECONDS` | `0` | Zero-drop rolling-update drain (#768). On `SIGTERM` the server flips readiness (`/readyz` + overall `""` health) to `NOT_SERVING` immediately, then keeps the listener serving for this long so load balancers deregister it before it stops accepting. `0` disables (no hold). Keep `terminationGracePeriodSeconds ≥` this `+ LANTERN_SHUTDOWN_TIMEOUT_SECONDS`. |
 | `LANTERN_MAX_RECV_MSG_BYTES` | `16777216` | Per-RPC inbound message limit (16 MiB default) |
 | `LANTERN_MAX_SEND_MSG_BYTES` | `16777216` | Per-RPC outbound message limit |
 | `LANTERN_MAX_CONCURRENT_STREAMS` | `1024` | Upper bound on concurrent streams per HTTP/2 connection |

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -38,6 +38,10 @@
 # colliding on globally-scoped container names.
 x-lantern-common: &lantern-common
   image: ${LANTERN_IMAGE:-ghcr.io/anaregdesign/lantern:latest}
+  # Zero-drop drain on recreate (#768): Docker SIGKILLs 10s after SIGTERM by
+  # default, which is shorter than LANTERN_DRAIN_DELAY_SECONDS (5) + the
+  # server shutdown timeout (30). Give the drain + in-flight flush room.
+  stop_grace_period: 45s
   environment:
     LANTERN_PORT: "6380"
     LANTERN_METRICS_ADDR: ":9090"
@@ -53,6 +57,10 @@ x-lantern-common: &lantern-common
     LANTERN_PEER_DISCOVERY_INTERVAL_MS: "10000"
     # Readiness gating (#188).
     LANTERN_MAX_REPLICATION_LAG: "10000"
+    # Zero-drop rolling-update drain (#768): on SIGTERM the server flips
+    # readiness to NOT_SERVING then keeps serving this long so clients /
+    # DNS round-robin stop hitting the dying replica before it closes.
+    LANTERN_DRAIN_DELAY_SECONDS: "5"
     # Allow the admin SPA to call this listener from the browser.
     # Lantern serves Connect / gRPC / gRPC-Web on the same h2c socket,
     # and the admin container does not proxy the gateway (the browser

--- a/deploy/helm/lantern/templates/statefulset.yaml
+++ b/deploy/helm/lantern/templates/statefulset.yaml
@@ -9,6 +9,7 @@ spec:
   serviceName: {{ include "lantern.headlessName" . }}
   replicas: {{ .Values.replicaCount }}
   podManagementPolicy: Parallel
+  minReadySeconds: {{ .Values.minReadySeconds }}
   updateStrategy:
     type: {{ .Values.updateStrategy.type }}
   selector:
@@ -33,7 +34,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -61,6 +62,17 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.drain.preStop }}
+          # Optional k8s-native drain belt (#768): pause before SIGTERM so
+          # kubelet/mesh deregistration settles. The server ALSO drains
+          # itself for LANTERN_DRAIN_DELAY_SECONDS on SIGTERM, so this is
+          # usually unnecessary; it needs /bin/sleep (present on the
+          # alpine-based server image).
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep", "{{ .Values.drain.delaySeconds }}"]
+          {{- end }}
           ports:
             - name: grpc
               containerPort: {{ .Values.service.port }}
@@ -99,6 +111,8 @@ spec:
               value: {{ .Values.antiEntropy.intervalMs | quote }}
             - name: LANTERN_ANTI_ENTROPY_SUBSCRIBE_TIMEOUT_MS
               value: {{ .Values.antiEntropy.subscribeTimeoutMs | quote }}
+            - name: LANTERN_DRAIN_DELAY_SECONDS
+              value: {{ .Values.drain.delaySeconds | quote }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/helm/lantern/values.yaml
+++ b/deploy/helm/lantern/values.yaml
@@ -30,6 +30,34 @@ podDisruptionBudget:
   enabled: true
   minAvailable: 2
 
+# Zero-drop rolling-update drain (#768). On SIGTERM the server flips
+# readiness to NOT_SERVING immediately (overall "" gRPC health + /readyz
+# return 503 so kube-proxy / load balancers deregister the pod) and then
+# keeps the listener serving for `drain.delaySeconds` so in-flight and
+# endpoint-propagation-window requests still complete — this is the primary
+# mechanism and needs no shell in the image (it is server-side, via
+# LANTERN_DRAIN_DELAY_SECONDS).
+#
+# `drain.preStop` is an OPTIONAL k8s-native belt: a `sleep delaySeconds`
+# preStop hook for operators who also want kubelet to pause before SIGTERM
+# (e.g. behind a mesh that drains on container lifecycle rather than
+# readiness). It is OFF by default because the server-side hold already
+# covers the propagation window, and it requires `/bin/sleep` in the image
+# (present on the alpine-based server image, absent on distroless).
+drain:
+  delaySeconds: 5
+  preStop: false
+
+# Pod termination grace. Must exceed drain.delaySeconds + the server
+# shutdown timeout (LANTERN_SHUTDOWN_TIMEOUT_SECONDS, default 30) so the
+# drain window and the in-flight flush both fit before SIGKILL.
+terminationGracePeriodSeconds: 45
+
+# minReadySeconds gates the rollout: a freshly-restarted pod must stay
+# Ready this long before the StatefulSet controller disrupts the next one,
+# so a pod whose readiness flaps right after restart doesn't cascade.
+minReadySeconds: 10
+
 service:
   # ClusterIP service exposes the Lantern wire port to clients
   # (Connect / gRPC / gRPC-Web multiplexed on h2c).

--- a/docs/ha-runbook.md
+++ b/docs/ha-runbook.md
@@ -430,6 +430,47 @@ in the protocol that *strictly* requires sequencing — but the PDB and
 the readiness gate are what make this safe; bypass them and you've
 created an unnecessary availability dip.
 
+### 7.1 Zero-drop drain (no client-visible request errors) (#768)
+
+The procedure above keeps the *cluster* available, but a rotating pod
+can still drop **in-flight / freshly-routed** client requests in the
+window between `SIGTERM` and the moment kube-proxy / the load balancer
+removes the pod's endpoint. The graceful-drain knobs close that window:
+
+- **`LANTERN_DRAIN_DELAY_SECONDS`** (server-side, the primary mechanism;
+  Helm `drain.delaySeconds`, Compose env, default 5). On `SIGTERM` the
+  server flips the overall `""` gRPC health entry and `/readyz` to
+  `NOT_SERVING` **immediately** (so probes/LBs deregister it) but keeps
+  the listener **serving** for this long, so requests routed during the
+  propagation window still succeed. It needs no shell in the image — the
+  drain is internal. Set it slightly above your platform's
+  endpoint-propagation lag (k8s: typically 1–5 s).
+- **`terminationGracePeriodSeconds`** (Helm `terminationGracePeriodSeconds`,
+  default 45; Compose `stop_grace_period: 45s`). Must be **≥
+  `drain.delaySeconds` + `LANTERN_SHUTDOWN_TIMEOUT_SECONDS`** (default 30)
+  so the drain window *and* the in-flight flush both finish before
+  `SIGKILL`. The old hard-coded 30 s left no headroom.
+- **`minReadySeconds`** (Helm, default 10). A freshly-restarted pod must
+  stay Ready this long before the controller disrupts the next one, so a
+  pod whose readiness flaps right after restart doesn't cascade.
+- **`drain.preStop`** (Helm, default **off**). An optional `sleep`
+  preStop hook for meshes that drain on container lifecycle rather than
+  readiness. Usually unnecessary because the server-side hold already
+  covers the propagation window; it requires `/bin/sleep` (present on the
+  alpine server image, absent on distroless).
+
+**Verify** a zero-drop rollout by driving steady SDK load across a
+`kubectl rollout restart statefulset/<release>` (or a Compose
+recreate-one-at-a-time loop) and confirming no `Unavailable` /
+connection-reset errors, and that `/readyz` returns **503 at the start
+of termination** before the listener stops accepting.
+
+**Single-instance (Tier B)** deploys (Cloud Run / ACA, `replicaCount: 1`)
+have no peer to fail over to, so the drain still flips `/readyz` (the
+platform shifts traffic to the new revision) but durability across the
+rotation comes from the snapshot backup/restore feature
+(`LANTERN_BACKUP_*`, #770), not replication.
+
 **Backwards compatibility.** v1's Subscribe/Snapshot wire format is
 versioned at the proto level; minor version bumps within v1 are
 wire-compatible. Cross-major upgrades (v1 → v2) are out of scope for

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -54,7 +54,13 @@ is required for either reads or writes.
    ephemeral. Single-pod loss recovers from peers. Total-cluster loss is
    accepted data loss.
 6. **Rolling update safe.** One pod down → remaining pods serve → new pod
-   bootstraps → ready → next.
+   bootstraps → ready → next. This invariant is about **cluster
+   availability** (the cluster keeps accepting requests throughout). **Zero
+   client-visible request drops** additionally require the graceful-drain
+   window (#768): on `SIGTERM` the rotating pod flips readiness to
+   `NOT_SERVING` immediately, then keeps its listener serving for
+   `LANTERN_DRAIN_DELAY_SECONDS` so kube-proxy / load balancers deregister
+   it before it stops accepting. See the runbook §7.
 
 ## 3. Binding decisions (D1–D7)
 


### PR DESCRIPTION
## What

Deploy manifests + docs half of #768 (zero-drop connection draining for HA
rolling updates). Builds on the server-side drain shipped in #773 (`PR-A`):
exposes the `LANTERN_DRAIN_DELAY_SECONDS` mechanism through Helm + Compose and
documents the zero-drop procedure.

## Changes

- **Helm** (`deploy/helm/lantern`):
  - StatefulSet gains `minReadySeconds` (default 10), a configurable
    `terminationGracePeriodSeconds` (default **45**, was a hard-coded 30 that
    left no headroom), the `LANTERN_DRAIN_DELAY_SECONDS` env (default 5), and an
    **opt-in** `drain.preStop` `sleep` hook (default off).
  - New `drain.{delaySeconds,preStop}`, `terminationGracePeriodSeconds`,
    `minReadySeconds` values, all documented inline.
- **Compose** (`deploy/compose/docker-compose.yml`): `stop_grace_period: 45s`
  (Docker's 10 s default would `SIGKILL` mid-drain) + `LANTERN_DRAIN_DELAY_SECONDS=5`
  on the shared lantern anchor.
- **Docs**: new runbook **§7.1 "Zero-drop drain"** (the knobs, the
  grace-period coherence rule `grace ≥ drainDelay + shutdownTimeout`, how to
  verify a zero-drop rollout, and the Tier-B note pointing at the
  `LANTERN_BACKUP_*` durability path); `docs/replication.md` invariant 6
  nuanced (cluster-availability-safe vs zero client-visible drops); README env
  table gains `LANTERN_DRAIN_DELAY_SECONDS`.

## Why no `preStop` by default

The server-side hold (`LANTERN_DRAIN_DELAY_SECONDS`, #773) already keeps the
listener serving through the kube-proxy / LB endpoint-propagation window on
`SIGTERM`, so a `preStop: sleep` is redundant for the common case — and it
would need `/bin/sleep` (absent on distroless). It's offered as an opt-in belt
for meshes that drain on container lifecycle rather than readiness.

## Validation

`helm lint` clean; `helm template` renders `minReadySeconds: 10`,
`terminationGracePeriodSeconds: 45`, the drain env, and the preStop hook (when
enabled); `docker compose config` valid with `stop_grace_period` + the env on
all three replicas. No Go changes.

Closes #768. Part of the rolling-update family (durability counterpart:
#769/#770). The **optional** testbed zero-drop smoke (epic item E, marked
optional) is deferred — the drain mechanism, manifests, and docs fully deliver
the guarantee; the smoke is verification infra and can follow up.
