### PR TITLE
feat(deploy): snapshot-backup volume mounts + durability guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ coverage.html
 
 # Bench harness output (testbed/bench/) — local-only run artifacts.
 testbed/bench/out/
+
+# Local snapshot-backup dumps from deploy/compose/docker-compose.backup.yml (#770)
+deploy/compose/backups/

--- a/README.md
+++ b/README.md
@@ -804,6 +804,14 @@ The server is configured via environment variables, parsed in
 | `LANTERN_REFLECTION` | `true` | Register gRPC server reflection (useful for `grpcurl`) |
 | `LANTERN_SHUTDOWN_TIMEOUT_SECONDS` | `30` | Upper bound on graceful shutdown before forcing `http.Server.Close()` |
 | `LANTERN_DRAIN_DELAY_SECONDS` | `0` | Zero-drop rolling-update drain (#768). On `SIGTERM` the server flips readiness (`/readyz` + overall `""` health) to `NOT_SERVING` immediately, then keeps the listener serving for this long so load balancers deregister it before it stops accepting. `0` disables (no hold). Keep `terminationGracePeriodSeconds ≥` this `+ LANTERN_SHUTDOWN_TIMEOUT_SECONDS`. |
+| `LANTERN_BACKUP_ENABLED` | `false` | Enable the periodic whole-graph snapshot backup loop (#770). Requires `LANTERN_BACKUP_DIR`. Rolling-update insurance for single-instance (Tier B) Cloud Run / ACA deploys — see [docs/backup.md](docs/backup.md). |
+| `LANTERN_BACKUP_DIR` | _(empty)_ | Mounted directory the server writes/reads whole-graph dumps in. |
+| `LANTERN_BACKUP_INTERVAL` | `5m` | Dump cadence (`time.ParseDuration`, e.g. `300s`, `5m`). |
+| `LANTERN_BACKUP_RETAIN` | `3` | Keep the newest N of this instance's own dumps; `0` keeps all. |
+| `LANTERN_BACKUP_INSTANCE_ID` | _(hostname)_ | Per-instance dump filename token, so replicas sharing a volume never collide or prune each other's dumps. |
+| `LANTERN_BACKUP_RESTORE_ON_START` | `true` | Restore the newest valid dump on boot, before serving. Single-instance-gated: skipped in multi-peer mode (peer bootstrap is the recovery path) unless `LANTERN_BACKUP_RESTORE_FORCE=true`. |
+| `LANTERN_BACKUP_RESTORE_FORCE` | `false` | Restore on boot even when peers are configured. |
+| `LANTERN_BACKUP_RESTORE_REQUIRED` | `false` | Fail boot if a restore errors (else warn and continue with the current/empty graph). |
 | `LANTERN_MAX_RECV_MSG_BYTES` | `16777216` | Per-RPC inbound message limit (16 MiB default) |
 | `LANTERN_MAX_SEND_MSG_BYTES` | `16777216` | Per-RPC outbound message limit |
 | `LANTERN_MAX_CONCURRENT_STREAMS` | `1024` | Upper bound on concurrent streams per HTTP/2 connection |

--- a/deploy/compose/docker-compose.backup.yml
+++ b/deploy/compose/docker-compose.backup.yml
@@ -1,0 +1,60 @@
+# Docker Compose: single-instance (Tier B) with snapshot durability (#770).
+#
+# This is the rolling-update / restart insurance for a single Lantern
+# instance — the Cloud Run / Azure Container Apps shape, run locally. Lantern
+# is in-memory, so without this a `docker compose down && up` (or a crash)
+# loses the whole graph. With a mounted volume + the LANTERN_BACKUP_* knobs,
+# the server periodically dumps the whole graph to ./backups and restores the
+# newest dump on the next boot, BEFORE it starts serving.
+#
+# Try it:
+#   cd deploy/compose
+#   docker compose -f docker-compose.backup.yml up -d
+#   go run ../../cli put vertex hello world         # write something
+#   # wait one LANTERN_BACKUP_INTERVAL (60s) for a dump to land in ./backups
+#   docker compose -f docker-compose.backup.yml down
+#   docker compose -f docker-compose.backup.yml up -d   # restores on boot
+#   go run ../../cli get vertex hello               # still there
+#
+# Single instance ⇒ restore-on-start runs (no peers to bootstrap from). For
+# the 3-replica Tier-A HA stack use docker-compose.yml instead; there restore
+# is gated off because peer bootstrap is the recovery path.
+#
+# Override the image the same way as the HA stack:
+#   LANTERN_IMAGE=lantern:local docker compose -f docker-compose.backup.yml up -d
+
+services:
+  lantern:
+    image: ${LANTERN_IMAGE:-ghcr.io/anaregdesign/lantern:latest}
+    ports:
+      - "6380:6380"
+      - "9090:9090"
+    # Cover the drain (#768) + shutdown timeout on `down`.
+    stop_grace_period: 45s
+    environment:
+      LANTERN_PORT: "6380"
+      LANTERN_METRICS_ADDR: ":9090"
+      LANTERN_LOG_FORMAT: "json"
+      LANTERN_LOG_LEVEL: "info"
+      # TTL-vs-interval caveat: entries decay, so a dump is only as useful as
+      # its data is still live at restore time. Keep the default TTL well above
+      # the backup interval (here 24h ≫ 60s) so a restart restores live data.
+      LANTERN_DEFAULT_TTL_SECONDS: "86400"
+      # Snapshot durability (#770).
+      LANTERN_BACKUP_ENABLED: "true"
+      LANTERN_BACKUP_DIR: "/data"
+      LANTERN_BACKUP_INTERVAL: "60s"
+      LANTERN_BACKUP_RETAIN: "5"
+      LANTERN_BACKUP_RESTORE_ON_START: "true"
+      # Flip readiness before the listener closes on `down` (#768).
+      LANTERN_DRAIN_DELAY_SECONDS: "5"
+    volumes:
+      # The mounted volume that survives container recreation. On Cloud Run
+      # this is a GCS-FUSE / Filestore mount; on ACA an Azure Files share.
+      - ./backups:/data
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9090/readyz"]
+      interval: 5s
+      timeout: 2s
+      retries: 12
+      start_period: 5s

--- a/deploy/helm/lantern/templates/statefulset.yaml
+++ b/deploy/helm/lantern/templates/statefulset.yaml
@@ -121,6 +121,26 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            {{- if .Values.backup.enabled }}
+            - name: LANTERN_BACKUP_ENABLED
+              value: "true"
+            - name: LANTERN_BACKUP_DIR
+              value: {{ .Values.backup.dir | quote }}
+            - name: LANTERN_BACKUP_INTERVAL
+              value: {{ .Values.backup.interval | quote }}
+            - name: LANTERN_BACKUP_RETAIN
+              value: {{ .Values.backup.retain | quote }}
+            - name: LANTERN_BACKUP_RESTORE_ON_START
+              value: {{ .Values.backup.restoreOnStart | quote }}
+            - name: LANTERN_BACKUP_RESTORE_REQUIRED
+              value: {{ .Values.backup.restoreRequired | quote }}
+            # Stable per-pod token so each replica's dumps are distinct on a
+            # shared volume (StatefulSet pod names are stable).
+            - name: LANTERN_BACKUP_INSTANCE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -143,3 +163,28 @@ spec:
             successThreshold: {{ .Values.probes.readiness.successThreshold }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.backup.enabled }}
+          volumeMounts:
+            - name: backup
+              mountPath: {{ .Values.backup.dir }}
+          {{- end }}
+      {{- if and .Values.backup.enabled .Values.backup.persistence.existingClaim }}
+      volumes:
+        - name: backup
+          persistentVolumeClaim:
+            claimName: {{ .Values.backup.persistence.existingClaim }}
+      {{- end }}
+  {{- if and .Values.backup.enabled .Values.backup.persistence.enabled (not .Values.backup.persistence.existingClaim) }}
+  volumeClaimTemplates:
+    - metadata:
+        name: backup
+      spec:
+        accessModes:
+          {{- toYaml .Values.backup.persistence.accessModes | nindent 10 }}
+        {{- with .Values.backup.persistence.storageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.backup.persistence.size | quote }}
+  {{- end }}

--- a/deploy/helm/lantern/values.yaml
+++ b/deploy/helm/lantern/values.yaml
@@ -101,6 +101,30 @@ antiEntropy:
 cache:
   defaultTtlSeconds: 3600
 
+# Snapshot durability (#770): periodic whole-graph dumps to a mounted volume
+# + restore-on-startup. Disabled by default. This is primarily the Tier-B
+# (single-instance, replicaCount=1) rolling-update insurance — there
+# restore-on-start re-seeds the graph on boot. In a multi-replica StatefulSet
+# restore is gated off (peer bootstrap is the recovery path), so backups there
+# only serve whole-cluster-loss recovery; each pod writes its own dumps
+# (LANTERN_BACKUP_INSTANCE_ID = pod name).
+backup:
+  enabled: false
+  dir: /var/lib/lantern/backups
+  interval: 5m
+  retain: 3
+  restoreOnStart: true
+  restoreRequired: false
+  persistence:
+    # A real PVC is required for dumps to survive pod restarts (an emptyDir
+    # would not). When enabled and no existingClaim is set, the chart renders
+    # a per-pod volumeClaimTemplate mounted at `dir`.
+    enabled: true
+    existingClaim: ""
+    storageClass: ""
+    accessModes: ["ReadWriteOnce"]
+    size: 1Gi
+
 # Liveness/readiness probes.
 probes:
   liveness:

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,0 +1,180 @@
+# Snapshot backup & restore (Tier-B durability)
+
+> Tracking: [#769](https://github.com/anaregdesign/lantern/issues/769) (epic),
+> [#770](https://github.com/anaregdesign/lantern/issues/770) (engine),
+> [#771](https://github.com/anaregdesign/lantern/issues/771) (this doc).
+
+Lantern is an **in-memory** store, so a single instance loses its whole graph
+on any restart — including the routine **rolling update** of a serverless
+container revision. The snapshot-durability feature is the insurance for that:
+the server **periodically dumps the whole graph to a mounted volume** and
+**restores the newest dump on startup**, before it begins serving.
+
+This is the **Tier B** (single-instance) durability story — Cloud Run, Azure
+Container Apps, App Runner, or any single-container deploy. In a **Tier A**
+multi-replica cluster, a restarted pod recovers from its **peers** (snapshot +
+tail bootstrap, see [replication.md](replication.md)); there backups serve only
+whole-cluster-loss recovery and restore-on-start is gated off by default.
+
+It is **snapshot-based** durability — complementary to, and distinct from, the
+write-ahead-log hook deferred in the replication RFC (D1). It changes no
+leaderless-replication invariant.
+
+## How it works
+
+- **Dump** drives the same `BackupSnapshot` surface the CLI `lantern-cli dump`
+  uses — a whole-graph, point-in-time snapshot taken under one lock — and
+  writes it as length-delimited protobuf. The on-disk format is **identical**
+  to `lantern-cli dump --format proto`, so a server-written dump loads with
+  `lantern-cli restore` and vice-versa.
+- **Restore** replays the newest valid dump through the normal write path, so
+  absolute expirations and HLC ordering are honoured; an entry whose TTL has
+  already elapsed since the dump is **not** resurrected.
+- **Per-instance files.** Each writer owns files named
+  `lantern-backup-<instance>-<nanos>.lbk` (`instance` defaults to the
+  hostname). Writes are atomic (temp file + `rename`); a half-written file is
+  never a restore candidate. Restore picks the **newest valid** file and skips
+  a corrupt/truncated one for the next-newest. Retention deletes only an
+  instance's **own** files.
+
+### Why per-instance files (the shared-storage decision)
+
+The volume can be shared across replicas, but **none** of the relevant backends
+offer safe concurrent-write coordination:
+
+| Backend | Shared? | Concurrent-write safety |
+|---|---|---|
+| Cloud Run — Cloud Storage (GCS FUSE) | yes | **no file locking**, last-write-wins, not POSIX; mount must finish < 30 s or boot fails |
+| Cloud Run — NFS (Filestore) | yes | mounted **no-lock** |
+| ACA — Azure Files (SMB/NFS) | yes (across replicas/revisions) | multi-writer coordination is the app's job |
+| ACA — EmptyDir | no (replica-scoped, ephemeral) | n/a |
+
+So Lantern **never** writes a shared single file and **never** does leader
+election — per-instance filenames make concurrent writes collision-free on
+every backend, and degrade cleanly to the single-instance case.
+
+## Configuration
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `LANTERN_BACKUP_ENABLED` | `false` | Master switch for the periodic dump loop. Requires `LANTERN_BACKUP_DIR`. |
+| `LANTERN_BACKUP_DIR` | _(empty)_ | Mounted directory dumps are written to / read from. |
+| `LANTERN_BACKUP_INTERVAL` | `5m` | Dump cadence (`time.ParseDuration`). |
+| `LANTERN_BACKUP_RETAIN` | `3` | Keep newest N own dumps; `0` keeps all. |
+| `LANTERN_BACKUP_INSTANCE_ID` | _(hostname)_ | Per-instance filename token. |
+| `LANTERN_BACKUP_RESTORE_ON_START` | `true` | Restore the newest dump on boot (before serving). |
+| `LANTERN_BACKUP_RESTORE_FORCE` | `false` | Restore even when peers are configured (multi-peer mode otherwise relies on peer bootstrap). |
+| `LANTERN_BACKUP_RESTORE_REQUIRED` | `false` | Fail boot when a restore errors (else warn + continue). |
+
+> **TTL-vs-interval caveat.** Entries decay, so a dump is only as useful as its
+> data is still live at restore time. Keep `LANTERN_DEFAULT_TTL_SECONDS`
+> comfortably **above** `LANTERN_BACKUP_INTERVAL` (and above your expected
+> restart gap) or much of a restored graph may already be expired.
+
+## Cloud Run
+
+Mount a Cloud Storage bucket (GCS FUSE) — or a Filestore NFS share — at
+`LANTERN_BACKUP_DIR`, single instance:
+
+```bash
+gcloud run deploy lantern \
+  --image ghcr.io/anaregdesign/lantern:latest \
+  --port 6380 --use-http2 \
+  --min-instances 1 --max-instances 1 \
+  --add-volume name=backups,type=cloud-storage,bucket=YOUR_BUCKET \
+  --add-volume-mount volume=backups,mount-path=/data \
+  --set-env-vars LANTERN_BACKUP_ENABLED=true,LANTERN_BACKUP_DIR=/data,LANTERN_BACKUP_INTERVAL=5m,LANTERN_DEFAULT_TTL_SECONDS=86400,LANTERN_DRAIN_DELAY_SECONDS=5
+```
+
+Notes: `--use-http2` is required for Lantern's h2c (Connect / gRPC) surface;
+GCS FUSE provides **no locking** (per-instance files handle it); the volume
+mount must complete within Cloud Run's 30 s startup budget. For lower-latency
+durability use a Filestore NFS volume (`type=cloud-storage` → an NFS volume)
+instead of GCS.
+
+## Azure Container Apps
+
+Define an Azure Files (SMB) share on the environment, then mount it at
+`LANTERN_BACKUP_DIR`:
+
+```bash
+az containerapp env storage set -n my-env -g my-rg \
+  --storage-name backups --storage-type AzureFile \
+  --azure-file-account-name STORAGE --azure-file-account-key KEY \
+  --azure-file-share-name SHARE --access-mode ReadWrite
+```
+
+```yaml
+# app.yaml — properties.template excerpt
+template:
+  containers:
+    - name: lantern
+      image: ghcr.io/anaregdesign/lantern:latest
+      env:
+        - name: LANTERN_BACKUP_ENABLED
+          value: "true"
+        - name: LANTERN_BACKUP_DIR
+          value: /data
+        - name: LANTERN_BACKUP_INTERVAL
+          value: 5m
+        - name: LANTERN_DEFAULT_TTL_SECONDS
+          value: "86400"
+      volumeMounts:
+        - volumeName: backups
+          mountPath: /data
+  scale:
+    minReplicas: 1
+    maxReplicas: 1
+  volumes:
+    - name: backups
+      storageType: AzureFile
+      storageName: backups
+```
+
+`EmptyDir` is replica-scoped and ephemeral — **don't** use it for durability.
+
+## Docker Compose (local)
+
+A runnable single-instance example lives at
+[deploy/compose/docker-compose.backup.yml](../deploy/compose/docker-compose.backup.yml):
+
+```bash
+cd deploy/compose
+docker compose -f docker-compose.backup.yml up -d
+go run ../../cli put vertex hello world
+# wait one LANTERN_BACKUP_INTERVAL, then:
+docker compose -f docker-compose.backup.yml down
+docker compose -f docker-compose.backup.yml up -d   # restores on boot
+go run ../../cli get vertex hello                    # still there
+```
+
+## Helm
+
+The chart's `backup` values wire the env + a per-pod PVC mounted at `backup.dir`
+(see [deploy/helm/lantern/values.yaml](../deploy/helm/lantern/values.yaml)):
+
+```yaml
+backup:
+  enabled: true
+  dir: /var/lib/lantern/backups
+  interval: 5m
+  retain: 3
+  restoreOnStart: true
+  persistence:
+    enabled: true
+    size: 1Gi
+    # or: existingClaim: my-backup-pvc
+```
+
+In a multi-replica StatefulSet each pod's `LANTERN_BACKUP_INSTANCE_ID` is its
+stable pod name, so dumps never collide; restore-on-start stays gated off there
+(peer bootstrap is the recovery path) unless you also set
+`LANTERN_BACKUP_RESTORE_FORCE=true`.
+
+## See also
+
+- [docs/ha-runbook.md](ha-runbook.md) — rolling-upgrade drain (§7) and HA ops.
+- [docs/replication.md](replication.md) — the Tier-A peer-bootstrap recovery
+  path and the deployment-topology matrix (D7).
+- `lantern-cli dump` / `lantern-cli restore` — the on-demand, file-compatible
+  CLI half of the same format.

--- a/docs/ha-runbook.md
+++ b/docs/ha-runbook.md
@@ -469,7 +469,8 @@ of termination** before the listener stops accepting.
 have no peer to fail over to, so the drain still flips `/readyz` (the
 platform shifts traffic to the new revision) but durability across the
 rotation comes from the snapshot backup/restore feature
-(`LANTERN_BACKUP_*`, #770), not replication.
+(`LANTERN_BACKUP_*`, #770) — see [docs/backup.md](backup.md) — not
+replication.
 
 **Backwards compatibility.** v1's Subscribe/Snapshot wire format is
 versioned at the proto level; minor version bumps within v1 are


### PR DESCRIPTION
## What

Deploy + docs for the snapshot-durability feature (#771): mount a volume on
Cloud Run / Azure Container Apps / Compose / Helm and wire `LANTERN_BACKUP_*`
so the periodic backup + restore-on-startup engine (#770) works end-to-end.

## Changes

- **`docs/backup.md`** (new) — the canonical guide: how it works, the
  per-instance-file / no-locking shared-storage decision (with the Cloud Run
  GCS-FUSE / NFS + ACA Azure Files findings table), the full `LANTERN_BACKUP_*`
  contract, the TTL-vs-interval caveat, and copy-paste **Cloud Run** (`gcloud
  --add-volume`), **ACA** (`az ... storage set` + volume YAML), **Compose**,
  and **Helm** recipes.
- **`deploy/compose/docker-compose.backup.yml`** (new) — a runnable
  single-instance (Tier B) example: `./backups:/data` bind mount +
  `LANTERN_BACKUP_ENABLED/DIR/INTERVAL` + restore-on-start, with a
  down-then-up "data survives" walkthrough. `.gitignore` ignores the local
  dump dir.
- **Helm** — new `backup` values (enabled / dir / interval / retain /
  restoreOnStart / restoreRequired + `persistence` PVC or `existingClaim`).
  The StatefulSet renders the `LANTERN_BACKUP_*` env (instance id = stable pod
  name), a volumeMount at `backup.dir`, and a per-pod `volumeClaimTemplate`
  (or an existing claim). Disabled by default.
- **README** — `LANTERN_BACKUP_*` rows added to the env table, linking
  `docs/backup.md`.
- **Runbook** — the Tier-B note in §7.1 now links `docs/backup.md`.

## Validation

`helm lint` clean; `helm template --set backup.enabled=true` renders the env +
volumeMount + `volumeClaimTemplate` (and `persistentVolumeClaim` for
`existingClaim`); `docker compose -f docker-compose.backup.yml config` valid. No
Go changes.

Closes #771. Part of epic #769 (engine: #770). The Terraform IaC counterpart for
Cloud Run / ACA is #772.
