### PR TITLE
feat(deploy): Terraform modules for Cloud Run + Azure Container Apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,11 @@ testbed/bench/out/
 
 # Local snapshot-backup dumps from deploy/compose/docker-compose.backup.yml (#770)
 deploy/compose/backups/
+
+# Terraform (deploy/terraform/) — local init artifacts + state, never committed
+deploy/terraform/**/.terraform/
+deploy/terraform/**/.terraform.lock.hcl
+deploy/terraform/**/*.tfstate
+deploy/terraform/**/*.tfstate.*
+deploy/terraform/**/*.tfvars
+deploy/terraform/**/crash.log

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -1,0 +1,59 @@
+# Lantern Terraform modules
+
+Infrastructure-as-Code for the **single-instance (Tier B)** Lantern deploys —
+Google **Cloud Run** and Azure **Container Apps** — with snapshot durability
+wired in (a mounted volume + `LANTERN_BACKUP_*`, see
+[../../docs/backup.md](../../docs/backup.md)).
+
+These are the serverless PaaS targets the replication RFC classifies as Tier B
+([../../docs/replication.md](../../docs/replication.md) D7): a single instance,
+no replicated cluster. Lantern is in-memory, so durability across a revision
+rotation comes from the periodic backup + restore-on-startup engine — the
+modules provision the volume and set the env so that works out of the box.
+
+For the multi-replica **Tier A** HA topology use the Helm chart
+([../helm/lantern](../helm/lantern)); for local experiments use
+[../compose](../compose).
+
+| Module | Platform | Volume backend |
+|---|---|---|
+| [`cloudrun/`](cloudrun) | Google Cloud Run | Cloud Storage (GCS FUSE) bucket |
+| [`aca/`](aca) | Azure Container Apps | Azure Files (SMB) share |
+
+## Usage
+
+Each module is standalone. Provide a backend / credentials for your cloud, set
+the required variables, and apply:
+
+```bash
+cd cloudrun   # or: cd aca
+terraform init
+terraform plan  -var project_id=my-proj -var backup_bucket_name=my-lantern-backups
+terraform apply -var project_id=my-proj -var backup_bucket_name=my-lantern-backups
+```
+
+```bash
+cd aca
+terraform init
+terraform apply -var storage_account_name=mylanternsa   # 3-24 lowercase alphanumeric, globally unique
+```
+
+The `backend` block is intentionally omitted — configure remote state to suit
+your org.
+
+## Notes
+
+- **Single instance.** Both modules pin `min = max = 1`. Running multiple
+  instances as a replicated cluster is unsupported on these platforms (RFC D7).
+- **Per-instance files, no locking.** GCS FUSE and Azure Files give no
+  cross-writer locking; the backup engine writes per-instance filenames, so
+  even a transient two-revision cutover window is collision-free.
+- **30 s mount budget (Cloud Run).** A slow GCS mount fails container start;
+  the module uses the second-generation execution environment automatically
+  (required for GCS volumes).
+- **HTTP/2.** Both expose the port as h2c / `transport = http2` so Lantern's
+  Connect / gRPC surface works end-to-end.
+- **Drain.** `LANTERN_DRAIN_DELAY_SECONDS` is set so revision cutover sheds
+  in-flight requests cleanly (#768).
+- **TTL vs interval.** `default_ttl_seconds` defaults to 24 h — keep it well
+  above `backup_interval` so a restored dump still carries live data.

--- a/deploy/terraform/aca/main.tf
+++ b/deploy/terraform/aca/main.tf
@@ -1,0 +1,101 @@
+# Single-instance (Tier B) Lantern on Azure Container Apps with snapshot
+# durability. An Azure Files (SMB) share is mounted at LANTERN_BACKUP_DIR and
+# the periodic backup + restore-on-startup engine (#770) re-seeds the graph on
+# every revision rotation. min=max=1 keeps it single-instance (Tier B per the
+# replication RFC D7); EmptyDir would be ephemeral, so Azure Files is required.
+
+locals {
+  env = merge({
+    LANTERN_PORT                    = tostring(var.port)
+    LANTERN_DEFAULT_TTL_SECONDS     = tostring(var.default_ttl_seconds)
+    LANTERN_DRAIN_DELAY_SECONDS     = tostring(var.drain_delay_seconds)
+    LANTERN_BACKUP_ENABLED          = "true"
+    LANTERN_BACKUP_DIR              = var.backup_dir
+    LANTERN_BACKUP_INTERVAL         = var.backup_interval
+    LANTERN_BACKUP_RETAIN           = tostring(var.backup_retain)
+    LANTERN_BACKUP_RESTORE_ON_START = "true"
+  }, var.extra_env)
+}
+
+resource "azurerm_resource_group" "this" {
+  name     = var.resource_group_name
+  location = var.location
+}
+
+resource "azurerm_storage_account" "this" {
+  name                     = var.storage_account_name
+  resource_group_name      = azurerm_resource_group.this.name
+  location                 = azurerm_resource_group.this.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_share" "backups" {
+  name                 = var.file_share_name
+  storage_account_name = azurerm_storage_account.this.name
+  quota                = var.file_share_quota_gb
+}
+
+resource "azurerm_container_app_environment" "this" {
+  name                = "${var.app_name}-env"
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+}
+
+resource "azurerm_container_app_environment_storage" "backups" {
+  name                         = "backups"
+  container_app_environment_id = azurerm_container_app_environment.this.id
+  account_name                 = azurerm_storage_account.this.name
+  share_name                   = azurerm_storage_share.backups.name
+  access_key                   = azurerm_storage_account.this.primary_access_key
+  access_mode                  = "ReadWrite"
+}
+
+resource "azurerm_container_app" "lantern" {
+  name                         = var.app_name
+  container_app_environment_id = azurerm_container_app_environment.this.id
+  resource_group_name          = azurerm_resource_group.this.name
+  revision_mode                = "Single"
+
+  template {
+    min_replicas = 1
+    max_replicas = 1
+
+    container {
+      name   = "lantern"
+      image  = var.image
+      cpu    = var.cpu
+      memory = var.memory
+
+      dynamic "env" {
+        for_each = local.env
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      volume_mounts {
+        name = "backups"
+        path = var.backup_dir
+      }
+    }
+
+    volume {
+      name         = "backups"
+      storage_type = "AzureFile"
+      storage_name = azurerm_container_app_environment_storage.backups.name
+    }
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = var.port
+    transport        = "http2"
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+}

--- a/deploy/terraform/aca/outputs.tf
+++ b/deploy/terraform/aca/outputs.tf
@@ -1,0 +1,14 @@
+output "ingress_fqdn" {
+  description = "Public FQDN of the Lantern Container App."
+  value       = azurerm_container_app.lantern.ingress[0].fqdn
+}
+
+output "resource_group" {
+  description = "Resource group the deployment lives in."
+  value       = azurerm_resource_group.this.name
+}
+
+output "backup_share" {
+  description = "Azure Files share holding the snapshot dumps."
+  value       = azurerm_storage_share.backups.name
+}

--- a/deploy/terraform/aca/variables.tf
+++ b/deploy/terraform/aca/variables.tf
@@ -1,0 +1,96 @@
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group to create for the deployment."
+  default     = "lantern-rg"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region (e.g. eastus)."
+  default     = "eastus"
+}
+
+variable "app_name" {
+  type        = string
+  description = "Container App name."
+  default     = "lantern"
+}
+
+variable "image" {
+  type        = string
+  description = "Lantern server container image."
+  default     = "ghcr.io/anaregdesign/lantern:latest"
+}
+
+variable "port" {
+  type        = number
+  description = "Container port Lantern serves on (h2c)."
+  default     = 6380
+}
+
+variable "cpu" {
+  type        = number
+  description = "vCPU per replica."
+  default     = 0.5
+}
+
+variable "memory" {
+  type        = string
+  description = "Memory per replica (must pair with cpu per ACA's allowed combos)."
+  default     = "1Gi"
+}
+
+variable "storage_account_name" {
+  type        = string
+  description = "Storage account for Azure Files (globally unique, 3-24 lowercase alphanumeric)."
+}
+
+variable "file_share_name" {
+  type        = string
+  description = "Azure Files share name for snapshot backups."
+  default     = "lantern-backups"
+}
+
+variable "file_share_quota_gb" {
+  type        = number
+  description = "Azure Files share quota in GiB."
+  default     = 1
+}
+
+# --- snapshot durability (#770) ---
+
+variable "backup_dir" {
+  type        = string
+  description = "Mount path for the backup volume (LANTERN_BACKUP_DIR)."
+  default     = "/data"
+}
+
+variable "backup_interval" {
+  type        = string
+  description = "Backup cadence (LANTERN_BACKUP_INTERVAL)."
+  default     = "5m"
+}
+
+variable "backup_retain" {
+  type        = number
+  description = "Backups to retain per instance (LANTERN_BACKUP_RETAIN)."
+  default     = 3
+}
+
+variable "default_ttl_seconds" {
+  type        = number
+  description = "Default vertex/edge TTL. Keep well above backup_interval so restores carry live data."
+  default     = 86400
+}
+
+variable "drain_delay_seconds" {
+  type        = number
+  description = "Graceful drain hold on SIGTERM (#768) for clean revision cutover."
+  default     = 5
+}
+
+variable "extra_env" {
+  type        = map(string)
+  description = "Additional LANTERN_* environment variables."
+  default     = {}
+}

--- a/deploy/terraform/aca/versions.tf
+++ b/deploy/terraform/aca/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/deploy/terraform/cloudrun/main.tf
+++ b/deploy/terraform/cloudrun/main.tf
@@ -1,0 +1,104 @@
+# Single-instance (Tier B) Lantern on Cloud Run with snapshot durability.
+#
+# Lantern is in-memory, so a rolling revision update would lose the graph.
+# This mounts a Cloud Storage bucket (GCS FUSE) at LANTERN_BACKUP_DIR and
+# enables the periodic backup + restore-on-startup engine (#770), so a new
+# revision restores the newest dump on boot. min=max=1 keeps it single-
+# instance (Tier B per the replication RFC D7); GCS FUSE has no file locking,
+# which the engine handles via per-instance filenames.
+
+locals {
+  # Merge the backup/runtime env with any caller-supplied extras. Extras win.
+  env = merge({
+    LANTERN_PORT                    = tostring(var.port)
+    LANTERN_DEFAULT_TTL_SECONDS     = tostring(var.default_ttl_seconds)
+    LANTERN_DRAIN_DELAY_SECONDS     = tostring(var.drain_delay_seconds)
+    LANTERN_BACKUP_ENABLED          = "true"
+    LANTERN_BACKUP_DIR              = var.backup_dir
+    LANTERN_BACKUP_INTERVAL         = var.backup_interval
+    LANTERN_BACKUP_RETAIN           = tostring(var.backup_retain)
+    LANTERN_BACKUP_RESTORE_ON_START = "true"
+  }, var.extra_env)
+}
+
+# Backup bucket. Uniform bucket-level access; versioning off (the engine keeps
+# its own retention of per-instance dump files).
+resource "google_storage_bucket" "backups" {
+  name                        = var.backup_bucket_name
+  project                     = var.project_id
+  location                    = var.region
+  uniform_bucket_level_access = true
+  force_destroy               = false
+}
+
+# Dedicated service identity for the Lantern revision.
+resource "google_service_account" "lantern" {
+  project      = var.project_id
+  account_id   = "${var.service_name}-sa"
+  display_name = "Lantern Cloud Run service account"
+}
+
+# Least privilege: read+write objects in the backup bucket only.
+resource "google_storage_bucket_iam_member" "backups_rw" {
+  bucket = google_storage_bucket.backups.name
+  role   = "roles/storage.objectUser"
+  member = "serviceAccount:${google_service_account.lantern.email}"
+}
+
+resource "google_cloud_run_v2_service" "lantern" {
+  name     = var.service_name
+  project  = var.project_id
+  location = var.region
+  ingress  = var.ingress
+
+  # Cloud Storage FUSE volumes require the second-generation execution env.
+  template {
+    service_account = google_service_account.lantern.email
+
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 1
+    }
+
+    containers {
+      image = var.image
+
+      # Named "h2c" so Cloud Run serves HTTP/2 end-to-end (Lantern's
+      # Connect / gRPC surface is h2c).
+      ports {
+        name           = "h2c"
+        container_port = var.port
+      }
+
+      resources {
+        limits = {
+          cpu    = var.cpu
+          memory = var.memory
+        }
+      }
+
+      dynamic "env" {
+        for_each = local.env
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      volume_mounts {
+        name       = "backups"
+        mount_path = var.backup_dir
+      }
+    }
+
+    volumes {
+      name = "backups"
+      gcs {
+        bucket    = google_storage_bucket.backups.name
+        read_only = false
+      }
+    }
+  }
+
+  depends_on = [google_storage_bucket_iam_member.backups_rw]
+}

--- a/deploy/terraform/cloudrun/outputs.tf
+++ b/deploy/terraform/cloudrun/outputs.tf
@@ -1,0 +1,14 @@
+output "service_uri" {
+  description = "Public URL of the Lantern Cloud Run service."
+  value       = google_cloud_run_v2_service.lantern.uri
+}
+
+output "service_account_email" {
+  description = "Service identity the revision runs as."
+  value       = google_service_account.lantern.email
+}
+
+output "backup_bucket" {
+  description = "Cloud Storage bucket holding the snapshot dumps."
+  value       = google_storage_bucket.backups.name
+}

--- a/deploy/terraform/cloudrun/variables.tf
+++ b/deploy/terraform/cloudrun/variables.tf
@@ -1,0 +1,89 @@
+variable "project_id" {
+  type        = string
+  description = "GCP project ID to deploy into."
+}
+
+variable "region" {
+  type        = string
+  description = "Cloud Run region (e.g. us-central1)."
+  default     = "us-central1"
+}
+
+variable "service_name" {
+  type        = string
+  description = "Cloud Run service name."
+  default     = "lantern"
+}
+
+variable "image" {
+  type        = string
+  description = "Lantern server container image."
+  default     = "ghcr.io/anaregdesign/lantern:latest"
+}
+
+variable "port" {
+  type        = number
+  description = "Container port Lantern serves on (h2c)."
+  default     = 6380
+}
+
+variable "cpu" {
+  type        = string
+  description = "CPU limit per instance."
+  default     = "1"
+}
+
+variable "memory" {
+  type        = string
+  description = "Memory limit per instance."
+  default     = "512Mi"
+}
+
+variable "ingress" {
+  type        = string
+  description = "Cloud Run ingress: INGRESS_TRAFFIC_ALL or INGRESS_TRAFFIC_INTERNAL_ONLY."
+  default     = "INGRESS_TRAFFIC_ALL"
+}
+
+# --- snapshot durability (#770) ---
+
+variable "backup_bucket_name" {
+  type        = string
+  description = "Cloud Storage bucket for snapshot backups. Created by this module."
+}
+
+variable "backup_dir" {
+  type        = string
+  description = "Mount path for the backup volume (LANTERN_BACKUP_DIR)."
+  default     = "/data"
+}
+
+variable "backup_interval" {
+  type        = string
+  description = "Backup cadence (LANTERN_BACKUP_INTERVAL)."
+  default     = "5m"
+}
+
+variable "backup_retain" {
+  type        = number
+  description = "Backups to retain per instance (LANTERN_BACKUP_RETAIN)."
+  default     = 3
+}
+
+variable "default_ttl_seconds" {
+  type        = number
+  description = "Default vertex/edge TTL. Keep well above backup_interval so restores carry live data."
+  default     = 86400
+}
+
+variable "drain_delay_seconds" {
+  type        = number
+  description = "Graceful drain hold on SIGTERM (#768) for clean revision cutover."
+  default     = 5
+}
+
+variable "extra_env" {
+  type        = map(string)
+  description = "Additional LANTERN_* environment variables."
+  default     = {}
+}

--- a/deploy/terraform/cloudrun/versions.tf
+++ b/deploy/terraform/cloudrun/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## What

Terraform modules under `deploy/terraform/` provisioning **single-instance
(Tier B)** Lantern on the two serverless PaaS targets, with snapshot durability
(#770) wired in. Closes #772.

| Module | Platform | Volume |
|---|---|---|
| `cloudrun/` | Google Cloud Run | Cloud Storage (GCS FUSE) bucket |
| `aca/` | Azure Container Apps | Azure Files (SMB) share |

## Each module

- Single instance (`min = max = 1`), h2c / `transport = http2` so Lantern's
  Connect / gRPC surface works end-to-end.
- Provisions the backup volume + storage backend, mounts it at
  `LANTERN_BACKUP_DIR`, and sets the full `LANTERN_BACKUP_*` env (+ a sane
  24 h `default_ttl_seconds` and `LANTERN_DRAIN_DELAY_SECONDS` for clean
  revision cutover, #768) so periodic backup + restore-on-startup works on
  apply.
- **Cloud Run**: `google_cloud_run_v2_service` + a GCS bucket + a dedicated
  service account with least-privilege `roles/storage.objectUser`.
- **ACA**: resource group + storage account + Azure Files share +
  `azurerm_container_app_environment{,_storage}` + `azurerm_container_app`.
- Standard layout (`versions.tf` / `variables.tf` / `main.tf` / `outputs.tf`),
  pinned providers (`google ~> 6.0`, `azurerm ~> 4.0`), outputs the service
  URL / FQDN. The `backend` block is left to the operator.

`deploy/terraform/README.md` documents usage and the Tier-B / per-instance-file
/ no-locking / 30 s-mount caveats.

## Validation

`terraform fmt -recursive -check` clean; `terraform init -backend=false` +
`terraform validate` **Success** for both modules. `.gitignore` excludes
`.terraform/`, lock files, and state. No Go changes.

Companion to the doc snippets in #771; both descend from the durability epic
#769.
