### PR TITLE
chore(release): pin sdks/go v0.18.0 ahead of root v0.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/anaregdesign/lantern/core v0.12.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.8.0
-	github.com/anaregdesign/lantern/sdks/go v0.17.0
+	github.com/anaregdesign/lantern/sdks/go v0.18.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1


### PR DESCRIPTION
Bumps the root module's `sdks/go` require v0.17.0 → v0.18.0 (the latest released SDK, #767) so external `go install ./cli` source-installs resolve a consistent SDK with the next root tag. Metadata-only — the workspace `replace` wins for local/CI/image builds, so `go mod tidy` leaves go.sum unchanged and the build stays green. Prep for the root v0.23.0 release (server drain #768 + backup engine #770).