### PR TITLE
fix(server): restore from backup as a baseline overlaid by peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,8 +809,7 @@ The server is configured via environment variables, parsed in
 | `LANTERN_BACKUP_INTERVAL` | `5m` | Dump cadence (`time.ParseDuration`, e.g. `300s`, `5m`). |
 | `LANTERN_BACKUP_RETAIN` | `3` | Keep the newest N of this instance's own dumps; `0` keeps all. |
 | `LANTERN_BACKUP_INSTANCE_ID` | _(hostname)_ | Per-instance dump filename token, so replicas sharing a volume never collide or prune each other's dumps. |
-| `LANTERN_BACKUP_RESTORE_ON_START` | `true` | Restore the newest valid dump on boot, before serving. Single-instance-gated: skipped in multi-peer mode (peer bootstrap is the recovery path) unless `LANTERN_BACKUP_RESTORE_FORCE=true`. |
-| `LANTERN_BACKUP_RESTORE_FORCE` | `false` | Restore on boot even when peers are configured. |
+| `LANTERN_BACKUP_RESTORE_ON_START` | `true` | Replay the newest valid dump on boot, before serving, as a baseline. When peers exist, bootstrap then overlays it via HLC (newer peer state wins per key — replicas take priority); a solo instance or whole-cluster cold start keeps the dump as the recovered state. Set `false` to skip restore. |
 | `LANTERN_BACKUP_RESTORE_REQUIRED` | `false` | Fail boot if a restore errors (else warn and continue with the current/empty graph). |
 | `LANTERN_MAX_RECV_MSG_BYTES` | `16777216` | Per-RPC inbound message limit (16 MiB default) |
 | `LANTERN_MAX_SEND_MSG_BYTES` | `16777216` | Per-RPC outbound message limit |

--- a/deploy/compose/docker-compose.backup.yml
+++ b/deploy/compose/docker-compose.backup.yml
@@ -16,9 +16,10 @@
 #   docker compose -f docker-compose.backup.yml up -d   # restores on boot
 #   go run ../../cli get vertex hello               # still there
 #
-# Single instance ⇒ restore-on-start runs (no peers to bootstrap from). For
-# the 3-replica Tier-A HA stack use docker-compose.yml instead; there restore
-# is gated off because peer bootstrap is the recovery path.
+# Single instance ⇒ restore-on-start is the whole recovery path (no peers to
+# bootstrap from). The 3-replica Tier-A HA stack in docker-compose.yml also
+# restores on boot, but only as a baseline — peer bootstrap then overlays it
+# via HLC, so there replicas take priority and the dump just fills gaps.
 #
 # Override the image the same way as the HA stack:
 #   LANTERN_IMAGE=lantern:local docker compose -f docker-compose.backup.yml up -d

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -68,6 +68,22 @@ x-lantern-common: &lantern-common
     # admin container DOES optionally reverse-proxy Prometheus same-
     # origin under /api/prom — that path needs no gateway CORS.)
     LANTERN_CORS_ALLOWED_ORIGINS: "http://localhost:8080"
+    # Snapshot durability (#770, #779): each replica periodically dumps its
+    # whole graph to its own mounted volume (declared per-service below) and
+    # replays the newest dump on boot as a BASELINE. Peer bootstrap then
+    # overlays that baseline through the write path, so HLC ordering lets
+    # newer peer state win per key — replicas take priority, the dump only
+    # fills gaps, and a whole-cluster restart recovers from the dumps instead
+    # of coming up empty. Each replica's LANTERN_BACKUP_INSTANCE_ID defaults
+    # to its hostname, pinned per-service below so dumps never collide and
+    # retention prunes the right files across restarts. The default TTL
+    # (3600s) stays well above the 5m interval per the TTL-vs-interval caveat,
+    # so a restored dump is still live.
+    LANTERN_BACKUP_ENABLED: "true"
+    LANTERN_BACKUP_DIR: "/data"
+    LANTERN_BACKUP_INTERVAL: "5m"
+    LANTERN_BACKUP_RETAIN: "3"
+    LANTERN_BACKUP_RESTORE_ON_START: "true"
   networks:
     default:
       aliases:
@@ -82,18 +98,30 @@ x-lantern-common: &lantern-common
 services:
   lantern-0:
     <<: *lantern-common
+    # Pin the hostname so LANTERN_BACKUP_INSTANCE_ID (defaults to the
+    # hostname) is stable + distinct per replica across recreations; each
+    # replica owns one named volume mounted at LANTERN_BACKUP_DIR (/data).
+    hostname: lantern-0
     ports:
       - "6380:6380"
+    volumes:
+      - lantern-backup-0:/data
 
   lantern-1:
     <<: *lantern-common
+    hostname: lantern-1
     ports:
       - "6381:6380"
+    volumes:
+      - lantern-backup-1:/data
 
   lantern-2:
     <<: *lantern-common
+    hostname: lantern-2
     ports:
       - "6382:6380"
+    volumes:
+      - lantern-backup-2:/data
 
   admin:
     image: ${LANTERN_ADMIN_IMAGE:-ghcr.io/anaregdesign/lantern-admin:latest}
@@ -163,3 +191,12 @@ services:
         condition: service_healthy
       lantern-2:
         condition: service_healthy
+
+# Per-replica backup volumes (#770). Each lantern-N owns one named volume so
+# its snapshot dumps survive `docker compose down` (but are removed by
+# `down -v`, matching the experiment-stack teardown). Mirrors the Helm
+# StatefulSet's per-pod backup PVC (volumeClaimTemplate).
+volumes:
+  lantern-backup-0:
+  lantern-backup-1:
+  lantern-backup-2:

--- a/deploy/helm/lantern/README.md
+++ b/deploy/helm/lantern/README.md
@@ -67,6 +67,9 @@ HA runbook (#192) for the limits.
 | `replication.maxLag`                        | `10000`                | Per-(peer,origin) lag cap before readiness flips.  |
 | `antiEntropy.intervalMs`                    | `30000`                | Background reconciliation cadence.                 |
 | `podDisruptionBudget.minAvailable`          | `2`                    | Quorum-ish.                                        |
+| `backup.enabled`                            | `true`                 | Snapshot durability (#770/#779): per-pod dump PVC + restore-on-start baseline (peers overlay it via HLC). Needs a default StorageClass or `backup.persistence.storageClass`. |
+| `backup.interval`                           | `5m`                   | Dump cadence; keep `cache.defaultTtlSeconds` above it.             |
+| `backup.persistence.size`                   | `1Gi`                  | Per-pod PVC size for dumps.                        |
 | `metrics.serviceMonitor.enabled`            | `false`                | Requires the prometheus-operator CRD.              |
 | `admin.enabled`                             | `false`                | Render the `lantern-admin` SPA Deployment + Service. |
 | `admin.image.repository`                    | `ghcr.io/anaregdesign/lantern-admin` | Admin SPA image (Caddy serving the built bundle).     |

--- a/deploy/helm/lantern/values.yaml
+++ b/deploy/helm/lantern/values.yaml
@@ -101,13 +101,14 @@ antiEntropy:
 cache:
   defaultTtlSeconds: 3600
 
-# Snapshot durability (#770): periodic whole-graph dumps to a mounted volume
-# + restore-on-startup. Disabled by default. This is primarily the Tier-B
+# Snapshot durability (#770, #779): periodic whole-graph dumps to a mounted
+# volume + restore-on-startup. Disabled by default. Primarily the Tier-B
 # (single-instance, replicaCount=1) rolling-update insurance — there
 # restore-on-start re-seeds the graph on boot. In a multi-replica StatefulSet
-# restore is gated off (peer bootstrap is the recovery path), so backups there
-# only serve whole-cluster-loss recovery; each pod writes its own dumps
-# (LANTERN_BACKUP_INSTANCE_ID = pod name).
+# restore still runs on each pod as a BASELINE: peer bootstrap then overlays
+# it via HLC (newer peer state wins per key, so replicas take priority), while
+# a whole-cluster cold start recovers from the dumps instead of coming up
+# empty. Each pod writes its own dumps (LANTERN_BACKUP_INSTANCE_ID = pod name).
 backup:
   enabled: false
   dir: /var/lib/lantern/backups

--- a/deploy/helm/lantern/values.yaml
+++ b/deploy/helm/lantern/values.yaml
@@ -102,15 +102,19 @@ cache:
   defaultTtlSeconds: 3600
 
 # Snapshot durability (#770, #779): periodic whole-graph dumps to a mounted
-# volume + restore-on-startup. Disabled by default. Primarily the Tier-B
-# (single-instance, replicaCount=1) rolling-update insurance — there
-# restore-on-start re-seeds the graph on boot. In a multi-replica StatefulSet
-# restore still runs on each pod as a BASELINE: peer bootstrap then overlays
-# it via HLC (newer peer state wins per key, so replicas take priority), while
-# a whole-cluster cold start recovers from the dumps instead of coming up
-# empty. Each pod writes its own dumps (LANTERN_BACKUP_INSTANCE_ID = pod name).
+# volume + restore-on-startup. ENABLED by default — the stable durability
+# baseline. Primarily the Tier-B (single-instance, replicaCount=1)
+# rolling-update insurance, where restore-on-start re-seeds the graph on boot.
+# In a multi-replica StatefulSet restore still runs on each pod as a BASELINE:
+# peer bootstrap then overlays it via HLC (newer peer state wins per key, so
+# replicas take priority), while a whole-cluster cold start recovers from the
+# dumps instead of coming up empty. Each pod writes its own dumps
+# (LANTERN_BACKUP_INSTANCE_ID = pod name). persistence below renders a per-pod
+# PVC, so the cluster needs a default StorageClass (or set
+# persistence.storageClass / persistence.existingClaim); set enabled: false to
+# opt out.
 backup:
-  enabled: false
+  enabled: true
   dir: /var/lib/lantern/backups
   interval: 5m
   retain: 3

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -10,11 +10,14 @@ container revision. The snapshot-durability feature is the insurance for that:
 the server **periodically dumps the whole graph to a mounted volume** and
 **restores the newest dump on startup**, before it begins serving.
 
-This is the **Tier B** (single-instance) durability story — Cloud Run, Azure
-Container Apps, App Runner, or any single-container deploy. In a **Tier A**
-multi-replica cluster, a restarted pod recovers from its **peers** (snapshot +
-tail bootstrap, see [replication.md](replication.md)); there backups serve only
-whole-cluster-loss recovery and restore-on-start is gated off by default.
+This is primarily the **Tier B** (single-instance) durability story — Cloud
+Run, Azure Container Apps, App Runner, or any single-container deploy. In a
+**Tier A** multi-replica cluster restore still runs on boot as a **baseline**:
+the restarted pod replays its newest dump, then peer **bootstrap** (snapshot +
+tail, see [replication.md](replication.md)) overlays it through the write path,
+so HLC ordering lets newer peer state win per key — replicas take priority, the
+dump only fills gaps, and a whole-cluster cold start recovers from the dumps
+instead of coming up empty.
 
 It is **snapshot-based** durability — complementary to, and distinct from, the
 write-ahead-log hook deferred in the replication RFC (D1). It changes no
@@ -62,8 +65,7 @@ every backend, and degrade cleanly to the single-instance case.
 | `LANTERN_BACKUP_INTERVAL` | `5m` | Dump cadence (`time.ParseDuration`). |
 | `LANTERN_BACKUP_RETAIN` | `3` | Keep newest N own dumps; `0` keeps all. |
 | `LANTERN_BACKUP_INSTANCE_ID` | _(hostname)_ | Per-instance filename token. |
-| `LANTERN_BACKUP_RESTORE_ON_START` | `true` | Restore the newest dump on boot (before serving). |
-| `LANTERN_BACKUP_RESTORE_FORCE` | `false` | Restore even when peers are configured (multi-peer mode otherwise relies on peer bootstrap). |
+| `LANTERN_BACKUP_RESTORE_ON_START` | `true` | Replay the newest dump on boot, before serving, as a baseline (peers then overlay it via HLC). Set `false` to skip restore — pure peer bootstrap / start empty. |
 | `LANTERN_BACKUP_RESTORE_REQUIRED` | `false` | Fail boot when a restore errors (else warn + continue). |
 
 > **TTL-vs-interval caveat.** Entries decay, so a dump is only as useful as its
@@ -167,9 +169,9 @@ backup:
 ```
 
 In a multi-replica StatefulSet each pod's `LANTERN_BACKUP_INSTANCE_ID` is its
-stable pod name, so dumps never collide; restore-on-start stays gated off there
-(peer bootstrap is the recovery path) unless you also set
-`LANTERN_BACKUP_RESTORE_FORCE=true`.
+stable pod name, so dumps never collide. Restore-on-start still runs on each
+pod as a baseline; peer bootstrap then overlays newer cluster state via HLC, so
+replicas take priority while a whole-cluster cold start recovers from the dumps.
 
 ## See also
 

--- a/docs/ha-runbook.md
+++ b/docs/ha-runbook.md
@@ -56,8 +56,10 @@ is unset (or `static`). In this mode:
   gRPC listener is up.
 - `Subscribe` still works — external CDC consumers see every mutation
   in real time.
-- Cold start = empty cache. There is no persistence in v1
-  ([RFC D1](replication.md#3-binding-decisions-d1d7)).
+- Cold start = empty cache **unless snapshot backups are configured**
+  (`LANTERN_BACKUP_*`, see [backup.md](backup.md)): the replication layer
+  itself has no persistence ([RFC D1](replication.md#3-binding-decisions-d1d7)),
+  but the backup engine restores the newest dump on boot.
 
 This is the supported mode for every "❌ HA not supported" row in §1.
 
@@ -262,7 +264,8 @@ peer set.
 - Do **not** set `LANTERN_PEER_DISCOVERY` or `LANTERN_PEERS`.
 - Allocate enough memory for your working set (§5).
 - Treat the service as a fast in-memory KVS. Cold start = empty
-  cache.
+  cache unless snapshot backups are configured (`LANTERN_BACKUP_*`,
+  see [backup.md](backup.md)).
 - For CDC: open `Subscribe` from a long-lived consumer outside the
   PaaS (e.g., a worker on k8s or a VM) and persist downstream.
 
@@ -509,7 +512,8 @@ Helm chart when you need to scale past three.
 PDB still applies: on k8s, `kubectl scale` will block if going below
 `minAvailable`. Lower the PDB before scaling down hard. Going to
 zero = total-cluster loss = accepted data loss
-([RFC D1](replication.md#3-binding-decisions-d1d7)).
+([RFC D1](replication.md#3-binding-decisions-d1d7)) unless snapshot
+backups are configured ([§9.4](#94-total-cluster-loss)).
 
 ---
 
@@ -565,12 +569,19 @@ Walk the bootstrap flow:
 
 ### 9.4 Total-cluster loss
 
-Accepted ([RFC D1](replication.md#3-binding-decisions-d1d7)): v1 has
-no persistence. Re-deploy from your image; rehydrate from upstream
-sources via a fresh ingestion pass.
+Accepted ([RFC D1](replication.md#3-binding-decisions-d1d7)) by the
+**replication** layer — it has no persistence. Re-deploy from your image
+and rehydrate from upstream sources via a fresh ingestion pass.
 
-If you need crash-survival, the WAL hook exists in the apply path
-but is not wired to a writer in v1; that's a v2 conversation.
+**Unless you run snapshot backups** (`LANTERN_BACKUP_*`, see
+[backup.md](backup.md)): with a mounted dump volume each node restores its
+newest dump on boot, so the cluster comes back at roughly its last
+`LANTERN_BACKUP_INTERVAL` instead of empty. Peer bootstrap then reconciles
+any per-node differences via HLC.
+
+If you need finer-grained crash-survival than the snapshot interval, the
+WAL hook exists in the apply path but is not wired to a writer in v1;
+that's a v2 conversation.
 
 ---
 
@@ -619,7 +630,7 @@ operator actions.
 | Single pod crash | k8s probe / Compose healthcheck flips | Auto-restarts. Pod bootstraps from peers. No action unless it crashloops. |
 | Pod falls behind buffer | `subscribe_dropped_total{reason="out_of_range"}` increments | Pump auto re-snapshots. Chronic = bump capacity. |
 | All peers unreachable on boot | Pod `NOT_SERVING`, no `replication_applied` increments | Check discovery env (§9.3). |
-| Total-cluster loss | Every pod down | Accepted data loss. Rehydrate. |
+| Total-cluster loss | Every pod down | Accepted data loss; rehydrate — or restore from snapshot backups if configured ([§9.4](#94-total-cluster-loss)). |
 | NTP skew > 500 ms | `hlc_skew_clamped_total > 0` | Fix NTP. Convergence preserved, but the drifted peer's stamps land behind real wall time. |
 | Network partition < tombstone TTL | `replication_lag_seq` spike; `anti_entropy_gaps_found_total` non-zero after heal | Auto-converges. No action. |
 | Network partition > tombstone TTL | Same signals + possible resurrection | Force re-snapshot from the side you trust ([§9.1](#91-force-a-re-snapshot)). Consider extending tombstone TTL. |

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -51,8 +51,10 @@ is required for either reads or writes.
    load balancer drains the instance. **Single-instance mode** (empty
    `LANTERN_PEERS`) bypasses this gate.
 5. **No leader, no Raft, no external storage.** v1 is intentionally
-   ephemeral. Single-pod loss recovers from peers. Total-cluster loss is
-   accepted data loss.
+   ephemeral. Single-pod loss recovers from peers; total-cluster loss is
+   accepted data loss **unless snapshot backups are configured**
+   (`LANTERN_BACKUP_*`, see [backup.md](backup.md)), in which case each
+   node restores its newest dump on boot.
 6. **Rolling update safe.** One pod down → remaining pods serve → new pod
    bootstraps → ready → next. This invariant is about **cluster
    availability** (the cluster keeps accepting requests throughout). **Zero
@@ -536,7 +538,7 @@ The [HA runbook](ha-runbook.md) describes detection (`lantern_replication_lag_se
 | Single pod crash | k8s probe / Compose healthcheck | k8s/Compose restarts pod → bootstraps from peers. |
 | Pod falls behind > buffer | `Subscribe` returns `OutOfRange` | Pump auto re-snapshots and resumes. |
 | All peers unreachable on boot | `Snapshot` fails on every peer | Pod stays `NOT_SERVING`; operator alert on readiness. |
-| Total-cluster loss | every replica down | **Accepted data loss** (D1). Bring the cluster back empty. |
+| Total-cluster loss | every replica down | **Accepted data loss** (D1) — bring the cluster back empty, *or* run snapshot backups (`LANTERN_BACKUP_*`, [backup.md](backup.md)) so each node restores its newest dump on boot. |
 | NTP skew > 500ms | `lantern_hlc_skew_clamped_total > 0` | Fix NTP. Mutations from the drifted peer keep applying (their HLC wall is clamped, §5.3); convergence is preserved but the drifted peer's stamps land behind real wall time until it heals. |
 | Network partition < tombstone TTL | `lantern_replication_lag_seq` spike | Auto-converges via anti-entropy (#186) when partition heals. |
 | Network partition > tombstone TTL | same | Resurrection possible (§10). Manual reconciliation or operator-driven re-snapshot of the winning side. |
@@ -560,7 +562,8 @@ For every "not supported" platform, the **single-instance** deploy is fully
 supported: leave `LANTERN_PEERS` empty, the server runs without a pump, the
 readiness gate is bypassed, and `Subscribe` still works as a CDC stream for
 downstream consumers. Cold-start data loss is expected on these platforms
-unless an external WAL consumer is in place.
+unless snapshot backups (`LANTERN_BACKUP_*`, [backup.md](backup.md)) or an
+external WAL consumer are in place.
 
 ## 13. Out of scope (v1)
 

--- a/server/backup/backup.go
+++ b/server/backup/backup.go
@@ -55,8 +55,8 @@ const (
 
 // Config is the resolved backup configuration. It lives in this package
 // (not provider) so the dependency direction stays provider → backup. The
-// provider's loader resolves RestoreOnStart against peer mode before
-// constructing the Backupper.
+// provider's loader resolves RestoreOnStart from the LANTERN_BACKUP_* env
+// before constructing the Backupper.
 type Config struct {
 	// Enabled gates the periodic dump loop. Resolved to false when
 	// LANTERN_BACKUP_DIR is empty even if LANTERN_BACKUP_ENABLED is set.
@@ -72,7 +72,8 @@ type Config struct {
 	// on shared storage). Defaults to the hostname.
 	InstanceID string
 	// RestoreOnStart is the resolved decision to restore the newest dump on
-	// boot (already factors enabled, dir, the env knob, and peer mode).
+	// boot as a baseline (already factors enabled, dir, and the env knob);
+	// peer bootstrap later overlays that baseline via HLC.
 	RestoreOnStart bool
 	// RestoreRequired makes a restore error fail boot instead of warning.
 	RestoreRequired bool

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -189,12 +189,15 @@ func newLanternReplicationService(
 }
 
 func (a *App) Run(ctx context.Context) error {
-	// Restore-on-startup (#770) runs BEFORE any listener serves, so a
-	// single-instance (Tier B) deploy recovers its in-memory graph from the
-	// newest mounted dump before accepting traffic. The Backupper no-ops
-	// when backups are disabled or restore is gated off (multi-peer mode
-	// relies on peer bootstrap instead). A restore failure fails boot only
-	// when LANTERN_BACKUP_RESTORE_REQUIRED is set.
+	// Restore-on-startup (#770, #779) runs BEFORE any listener serves: the
+	// newest mounted dump is replayed as a baseline so the node never begins
+	// serving an empty graph. When peers exist the subsequent bootstrap
+	// overlays this baseline via HLC ordering (newer peer state wins per key,
+	// so replicas take priority); a solo instance or a whole-cluster cold
+	// start keeps the restored baseline as the recovered state. The Backupper
+	// no-ops when backups are disabled or LANTERN_BACKUP_RESTORE_ON_START is
+	// false. A restore failure fails boot only when
+	// LANTERN_BACKUP_RESTORE_REQUIRED is set.
 	if _, err := a.backupper.RestoreOnStartup(ctx); err != nil {
 		if a.restoreReq {
 			return fmt.Errorf("restore-on-startup: %w", err)

--- a/server/provider/backup.go
+++ b/server/provider/backup.go
@@ -13,8 +13,16 @@ import (
 	"github.com/anaregdesign/lantern/server/service"
 )
 
-// loadBackupConfig reads the LANTERN_BACKUP_* contract and resolves the
-// restore-on-startup decision against peer mode (#770).
+// loadBackupConfig reads the LANTERN_BACKUP_* contract (#770, #779).
+//
+// Restore-on-start is unconditional: the newest valid dump is replayed on
+// boot as a baseline, independent of replication topology. When peers exist
+// the subsequent peer bootstrap overlays that baseline through the normal
+// write path, so HLC ordering lets newer peer state win per key (replica
+// priority); when no peer is reachable — a solo instance or a whole-cluster
+// cold start — the restored baseline IS the recovered state. This is the
+// most-stable arrangement: a restart never comes up with less than its own
+// last dump, and never serves an empty graph while it waits for peers.
 //
 //   - LANTERN_BACKUP_ENABLED          (default false) master switch for the
 //     periodic dump loop. Resolved to off when LANTERN_BACKUP_DIR is empty.
@@ -24,15 +32,12 @@ import (
 //     0 keeps all.
 //   - LANTERN_BACKUP_INSTANCE_ID      (default hostname) per-instance file
 //     token so shared-storage writes never collide.
-//   - LANTERN_BACKUP_RESTORE_ON_START (default true) restore the newest
-//     dump on boot. Restore is single-instance-gated: in multi-peer mode it
-//     is skipped (peer bootstrap is the recovery path) unless
-//     LANTERN_BACKUP_RESTORE_FORCE=true.
-//   - LANTERN_BACKUP_RESTORE_FORCE    (default false) restore even when
-//     peers are configured.
+//   - LANTERN_BACKUP_RESTORE_ON_START (default true) replay the newest dump
+//     on boot, before serving. Set false to skip restore (pure peer
+//     bootstrap / start empty).
 //   - LANTERN_BACKUP_RESTORE_REQUIRED (default false) fail boot when a
 //     restore errors instead of warning and continuing.
-func loadBackupConfig(hasPeers bool) backup.Config {
+func loadBackupConfig() backup.Config {
 	enabled := envconfig.Bool("LANTERN_BACKUP_ENABLED", false)
 	dir := strings.TrimSpace(envconfig.String("LANTERN_BACKUP_DIR", ""))
 	active := enabled && dir != ""
@@ -46,17 +51,13 @@ func loadBackupConfig(hasPeers bool) backup.Config {
 		}
 	}
 
-	restoreOnStart := active &&
-		envconfig.Bool("LANTERN_BACKUP_RESTORE_ON_START", true) &&
-		(!hasPeers || envconfig.Bool("LANTERN_BACKUP_RESTORE_FORCE", false))
-
 	return backup.Config{
 		Enabled:         active,
 		Dir:             dir,
 		Interval:        envconfig.Duration("LANTERN_BACKUP_INTERVAL", 5*time.Minute),
 		Retain:          envconfig.Int("LANTERN_BACKUP_RETAIN", 3),
 		InstanceID:      sanitizeInstanceID(instance),
-		RestoreOnStart:  restoreOnStart,
+		RestoreOnStart:  active && envconfig.Bool("LANTERN_BACKUP_RESTORE_ON_START", true),
 		RestoreRequired: envconfig.Bool("LANTERN_BACKUP_RESTORE_REQUIRED", false),
 	}
 }

--- a/server/provider/backup_test.go
+++ b/server/provider/backup_test.go
@@ -1,0 +1,101 @@
+package provider
+
+import (
+	"testing"
+	"time"
+)
+
+// TestLoadBackupConfig covers the LANTERN_BACKUP_* resolution. The headline
+// invariant (#779) is that restore-on-start is UNCONDITIONAL — a baseline
+// independent of replication topology — so a restart never comes up empty
+// while it waits for peers, and a whole-cluster cold start recovers from the
+// dump instead of staying empty. Replica priority is achieved later, at
+// bootstrap time, via HLC ordering — not by suppressing restore here.
+func TestLoadBackupConfig(t *testing.T) {
+	t.Run("DisabledByDefault", func(t *testing.T) {
+		cfg := loadBackupConfig()
+		if cfg.Enabled {
+			t.Errorf("Enabled = true, want false with no LANTERN_BACKUP_ENABLED")
+		}
+		if cfg.RestoreOnStart {
+			t.Errorf("RestoreOnStart = true, want false when inactive")
+		}
+	})
+
+	t.Run("EnabledRequiresDir", func(t *testing.T) {
+		t.Setenv("LANTERN_BACKUP_ENABLED", "true")
+		// No LANTERN_BACKUP_DIR ⇒ not active ⇒ restore off.
+		cfg := loadBackupConfig()
+		if cfg.Enabled {
+			t.Errorf("Enabled = true, want false without LANTERN_BACKUP_DIR")
+		}
+		if cfg.RestoreOnStart {
+			t.Errorf("RestoreOnStart = true, want false without a dir")
+		}
+	})
+
+	t.Run("ActiveRestoresByDefault", func(t *testing.T) {
+		t.Setenv("LANTERN_BACKUP_ENABLED", "true")
+		t.Setenv("LANTERN_BACKUP_DIR", t.TempDir())
+		cfg := loadBackupConfig()
+		if !cfg.Enabled {
+			t.Fatalf("Enabled = false, want true")
+		}
+		if !cfg.RestoreOnStart {
+			t.Errorf("RestoreOnStart = false, want true by default")
+		}
+	})
+
+	t.Run("RestoreOnStartOptOut", func(t *testing.T) {
+		t.Setenv("LANTERN_BACKUP_ENABLED", "true")
+		t.Setenv("LANTERN_BACKUP_DIR", t.TempDir())
+		t.Setenv("LANTERN_BACKUP_RESTORE_ON_START", "false")
+		cfg := loadBackupConfig()
+		if cfg.RestoreOnStart {
+			t.Errorf("RestoreOnStart = true, want false when opted out")
+		}
+	})
+
+	t.Run("RestoreIndependentOfPeers", func(t *testing.T) {
+		// Regression for #779: neither a static peer list nor DNS discovery
+		// may suppress restore. Restore is the baseline; peers overlay it via
+		// HLC at bootstrap. Before the fix a static list suppressed restore
+		// while DNS discovery slipped through ungated — both are wrong.
+		t.Setenv("LANTERN_BACKUP_ENABLED", "true")
+		t.Setenv("LANTERN_BACKUP_DIR", t.TempDir())
+		t.Setenv("LANTERN_PEERS", "peer-a:6380,peer-b:6380")
+		t.Setenv("LANTERN_PEER_DISCOVERY", "dns")
+		t.Setenv("LANTERN_PEER_DNS_NAME", "lantern")
+		cfg := loadBackupConfig()
+		if !cfg.RestoreOnStart {
+			t.Errorf("RestoreOnStart = false, want true regardless of peer config")
+		}
+	})
+
+	t.Run("InstanceIDDefaultsToHostname", func(t *testing.T) {
+		t.Setenv("LANTERN_BACKUP_ENABLED", "true")
+		t.Setenv("LANTERN_BACKUP_DIR", t.TempDir())
+		cfg := loadBackupConfig()
+		if cfg.InstanceID == "" {
+			t.Errorf("InstanceID empty, want a hostname fallback")
+		}
+	})
+
+	t.Run("Overrides", func(t *testing.T) {
+		t.Setenv("LANTERN_BACKUP_ENABLED", "true")
+		t.Setenv("LANTERN_BACKUP_DIR", t.TempDir())
+		t.Setenv("LANTERN_BACKUP_INTERVAL", "90s")
+		t.Setenv("LANTERN_BACKUP_RETAIN", "7")
+		t.Setenv("LANTERN_BACKUP_INSTANCE_ID", "node-x")
+		cfg := loadBackupConfig()
+		if cfg.Interval != 90*time.Second {
+			t.Errorf("Interval = %v, want 90s", cfg.Interval)
+		}
+		if cfg.Retain != 7 {
+			t.Errorf("Retain = %d, want 7", cfg.Retain)
+		}
+		if cfg.InstanceID != "node-x" {
+			t.Errorf("InstanceID = %q, want node-x", cfg.InstanceID)
+		}
+	})
+}

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -185,9 +185,6 @@ func NewConfig() *Config {
 	if burst <= 0 && rps > 0 {
 		burst = int(2 * rps)
 	}
-	// Peers are loaded up front because the backup loader's
-	// restore-on-startup decision is peer-mode-aware (single-instance only
-	// by default, #770).
 	peer := loadPeerConfig()
 	return &Config{
 		Net: NetConfig{
@@ -248,7 +245,7 @@ func NewConfig() *Config {
 		Peer:        peer,
 		AntiEntropy: loadAntiEntropyConfig(),
 		CORS:        loadCORSConfig(),
-		Backup:      loadBackupConfig(len(peer.Peers) > 0),
+		Backup:      loadBackupConfig(),
 	}
 }
 


### PR DESCRIPTION
## Problem

The snapshot-backup restore-on-start gate keyed off the **static** peer slice
only (`loadBackupConfig(len(peer.Peers) > 0)`). Since `loadPeerConfig()` fills
`peer.Peers` only from `LANTERN_PEERS`, **DNS discovery** left it empty, so the
intended "peers take priority over restore" behaviour held for neither topology
(static suppressed restore; DNS slipped through ungated). Gating restore off
whenever peers are merely *configured* also means a **whole-cluster cold start
comes up empty** — the opposite of stable.

## Change

Restore-on-start is now **unconditional**: the newest dump is always replayed as
a **baseline** before serving, and peer bootstrap **overlays** it through the
normal write path. HLC ordering then resolves precedence per key.

| Boot scenario | Result |
|---|---|
| Replica restart, peers reachable | dump replayed, then peer snapshot overlays it — **newer peer state wins per key (replica priority)** |
| Solo instance (no peers) | dump is the recovered state |
| Whole-cluster cold start | each node recovers from its own dump (no longer empty) |

A restart never comes up with less than its own last dump, and never serves an
empty graph while it waits for peers.

- Removes the now-redundant `LANTERN_BACKUP_RESTORE_FORCE` knob and the
  `hasPeers` argument to `loadBackupConfig`.
- Configures backup on the HA `deploy/compose` stack (per-replica volumes +
  stable instance IDs) and aligns the Helm/docs prose with the baseline model.

## Out of scope

`NewReadinessGate` keeps the same static-only peer-mode flag **on purpose**: the
headless Service runs `publishNotReadyAddresses: false`, so gating readiness on
peer bootstrap in DNS mode would deadlock a cold start. Tracked separately.

## Test plan

- `server/provider/backup_test.go` (new): restore-on-start defaults on, opt-out
  honoured, and **independent of peer config** (regression for the gate bug).
- `gofmt -l .` clean; `go vet` + `go test ./...` green in `server/` and root.
- `docker compose -f deploy/compose/docker-compose.yml config -q` passes.

Closes #779
