### PR TITLE
refactor(core/search): intern terms to uint32 ids

### DIFF
--- a/core/search/inverted_index.go
+++ b/core/search/inverted_index.go
@@ -26,10 +26,14 @@ type InvertedIndex[S comparable, D Document] struct {
 	scorer   Scorer
 
 	mu sync.RWMutex
-	// postings is the inverted index proper: term -> (document -> term
+	// dict assigns each distinct term a compact uint32 id so postings and the
+	// per-document forward lists key on the id instead of repeating the term
+	// string; the term itself is stored exactly once, in the dictionary.
+	dict *termDict
+	// postings is the inverted index proper: term id -> (document -> term
 	// frequency in that document). Search reads it, and the per-document count
 	// is what the Scorer needs to weight a match.
-	postings map[string]map[S]int
+	postings map[uint32]map[S]int
 	// docs is a forward index: document -> the stats needed to drop it in
 	// O(terms-in-doc) on delete or re-index and to length-normalize its score.
 	docs map[S]docStats
@@ -43,12 +47,12 @@ type docStats struct {
 	// length is the document's size in tokens, repeats included — the |d| that
 	// length normalization compares against the corpus average.
 	length int
-	// terms is the sorted, de-duplicated list of distinct terms the document was
-	// indexed under, used to find and drop its postings on delete or re-index. A
-	// slice rather than a map[string]struct{} keeps the per-document forward
-	// index compact: it is only ever range-iterated on delete, never probed by
-	// key, so it trades a map's bucket + per-entry overhead for a packed array.
-	terms []string
+	// terms is the de-duplicated list of distinct term ids the document was
+	// indexed under (see termDict), used to find and drop its postings on delete
+	// or re-index. A []uint32 rather than a map keeps the per-document forward
+	// index compact — it is only ever range-iterated on delete — and costs a
+	// 4-byte id rather than a string header per term.
+	terms []uint32
 }
 
 // NewInvertedIndex returns an empty index that analyzes both documents and
@@ -62,7 +66,8 @@ func NewInvertedIndex[S comparable, D Document](analyzer Analyzer, scorer Scorer
 	return &InvertedIndex[S, D]{
 		analyzer: analyzer,
 		scorer:   scorer,
-		postings: make(map[string]map[S]int),
+		dict:     newTermDict(),
+		postings: make(map[uint32]map[S]int),
 		docs:     make(map[S]docStats),
 	}
 }
@@ -158,20 +163,20 @@ func (idx *InvertedIndex[S, D]) indexPreparedLocked(id S, tokens []Token) {
 			distinct++
 		}
 	}
-	terms := make([]string, 0, distinct)
+	terms := make([]uint32, 0, distinct)
 	for i := 0; i < len(sorted); {
 		j := i + 1
 		for j < len(sorted) && sorted[j] == sorted[i] {
 			j++
 		}
-		term := sorted[i]
-		posting, ok := idx.postings[term]
+		tid := idx.dict.intern(sorted[i])
+		posting, ok := idx.postings[tid]
 		if !ok {
 			posting = make(map[S]int)
-			idx.postings[term] = posting
+			idx.postings[tid] = posting
 		}
 		posting[id] = j - i // term frequency = run length of this term
-		terms = append(terms, term)
+		terms = append(terms, tid)
 		i = j
 	}
 	idx.docs[id] = docStats{length: len(tokens), terms: terms}
@@ -211,11 +216,12 @@ func (idx *InvertedIndex[S, D]) deleteLocked(id S) {
 	if !ok {
 		return
 	}
-	for _, term := range stats.terms {
-		posting := idx.postings[term]
+	for _, tid := range stats.terms {
+		posting := idx.postings[tid]
 		delete(posting, id)
 		if len(posting) == 0 {
-			delete(idx.postings, term)
+			delete(idx.postings, tid)
+			idx.dict.release(tid)
 		}
 	}
 	idx.totalLen -= stats.length
@@ -253,7 +259,11 @@ func (idx *InvertedIndex[S, D]) Search(query string) []Result[S] {
 
 	scores := make(map[S]float64)
 	for term := range queryTerms {
-		posting, ok := idx.postings[term]
+		tid, ok := idx.dict.lookup(term)
+		if !ok {
+			continue
+		}
+		posting, ok := idx.postings[tid]
 		if !ok {
 			continue
 		}

--- a/core/search/term_dict.go
+++ b/core/search/term_dict.go
@@ -1,0 +1,68 @@
+package search
+
+// termDict assigns a compact, reusable uint32 id to each distinct term so the
+// inverted index can key its postings and per-document forward lists by id
+// instead of repeating the term string everywhere. Storing each term string
+// exactly once here is what collapses the ~(docs × terms-per-doc) term-string
+// objects a string-keyed index would otherwise hold down to one per distinct
+// term — the dominant object-count and a large byte-count saving for an
+// n-gram index, where the same short grams recur across most documents.
+//
+// termDict is not safe for concurrent use; InvertedIndex guards it with idx.mu,
+// the same lock that protects the postings it stays in lockstep with.
+type termDict struct {
+	// ids maps a term to its assigned id. Its size is the number of live terms.
+	ids map[string]uint32
+	// terms is the reverse map id -> term, indexed by id. A released id keeps a
+	// "" slot until it is handed back out, so terms never shrinks but its
+	// high-water mark is the distinct-term count (small for an n-gram corpus).
+	terms []string
+	// free holds released ids, reused before the id space grows so ids stay
+	// dense under a delete-heavy (decaying) workload.
+	free []uint32
+}
+
+// newTermDict returns an empty dictionary ready to intern terms.
+func newTermDict() *termDict {
+	return &termDict{ids: make(map[string]uint32)}
+}
+
+// intern returns the id for term, assigning and recording a fresh one the first
+// time term is seen. A released id is reused before the id space grows.
+func (d *termDict) intern(term string) uint32 {
+	if id, ok := d.ids[term]; ok {
+		return id
+	}
+	var id uint32
+	if n := len(d.free); n > 0 {
+		id = d.free[n-1]
+		d.free = d.free[:n-1]
+		d.terms[id] = term
+	} else {
+		id = uint32(len(d.terms))
+		d.terms = append(d.terms, term)
+	}
+	d.ids[term] = id
+	return id
+}
+
+// lookup returns the id for term and whether it is currently interned, without
+// assigning one. Search uses it so a query term absent from the corpus simply
+// misses instead of growing the dictionary.
+func (d *termDict) lookup(term string) (uint32, bool) {
+	id, ok := d.ids[term]
+	return id, ok
+}
+
+// release forgets id and its term, returning the id to the free list for reuse.
+// The index calls it when a term's last posting is removed, so the dictionary
+// decays in lockstep with the postings and leaks nothing under churn. Dropping
+// the reverse slot to "" lets the term's string backing be reclaimed.
+func (d *termDict) release(id uint32) {
+	delete(d.ids, d.terms[id])
+	d.terms[id] = ""
+	d.free = append(d.free, id)
+}
+
+// len reports the number of live (interned) terms.
+func (d *termDict) len() int { return len(d.ids) }

--- a/core/search/term_dict_test.go
+++ b/core/search/term_dict_test.go
@@ -1,0 +1,56 @@
+package search
+
+import "testing"
+
+func TestTermDict(t *testing.T) {
+	d := newTermDict()
+
+	t.Run("intern assigns stable, distinct ids", func(t *testing.T) {
+		a1 := d.intern("alpha")
+		b := d.intern("beta")
+		a2 := d.intern("alpha")
+		if a1 != a2 {
+			t.Fatalf("intern not stable: alpha got %d then %d", a1, a2)
+		}
+		if a1 == b {
+			t.Fatalf("distinct terms share id %d", a1)
+		}
+		if got := d.len(); got != 2 {
+			t.Fatalf("len = %d, want 2", got)
+		}
+	})
+
+	t.Run("lookup hits interned and misses unknown without growing", func(t *testing.T) {
+		id, ok := d.lookup("alpha")
+		if !ok {
+			t.Fatal("lookup(alpha) missed an interned term")
+		}
+		if id != d.intern("alpha") {
+			t.Fatalf("lookup id %d disagrees with intern", id)
+		}
+		if _, ok := d.lookup("missing"); ok {
+			t.Fatal("lookup(missing) reported a hit")
+		}
+		if d.len() != 2 {
+			t.Fatalf("lookup must not assign an id; len grew to %d", d.len())
+		}
+	})
+
+	t.Run("release frees the id and hands it back out", func(t *testing.T) {
+		alpha, _ := d.lookup("alpha")
+		d.release(alpha)
+		if _, ok := d.lookup("alpha"); ok {
+			t.Fatal("released term still looks up")
+		}
+		if d.len() != 1 {
+			t.Fatalf("len after release = %d, want 1", d.len())
+		}
+		// The next fresh term reuses the freed id rather than growing the space.
+		if got := d.intern("gamma"); got != alpha {
+			t.Fatalf("intern after release = %d, want reused %d", got, alpha)
+		}
+		if d.len() != 2 {
+			t.Fatalf("len after reuse = %d, want 2", d.len())
+		}
+	})
+}


### PR DESCRIPTION
## What & why

Part of #782, builds on #786 (Step 1).

Adds a `termDict` that assigns each distinct term a compact, reusable `uint32`
id, so the inverted index keys its **postings** (`map[uint32]map[S]int`) and each
document's **forward list** (`[]uint32`) by id instead of repeating the term
string. The term string is stored **exactly once** in the dictionary, and its id
is released to a free list when the term's last posting drops — so the
dictionary decays in lockstep with the postings (no leak under churn). `Search`
resolves each query term to its id (or misses) before scoring.

For an n-gram, string-keyed index the same short grams recur across most
documents, so this collapses the ~(docs × terms-per-doc) recurring term-string
objects down to one per distinct term.

Public API (`Index`/`Delete`/`Search`/`Stats`) and ranked results are unchanged.
**Decay-safe:** the index stays fully mutable; no segments.

## Benchmark (4000-doc bigram corpus) — cumulative from the epic baseline

| metric | baseline | Step 1 | **Step 2** |
|---|--:|--:|--:|
| HeapInuse / index | 21.89 MiB | 13.98 MiB | **9.77 MiB** |
| B / doc | 5,738 | 3,666 | **2,562** |
| **live objects** | 104,812 | 99,992 | **4,937** |
| Build B/op (1k docs) | 9.96 MB | 8.96 MB | 8.40 MB |

Step 2 alone: footprint **−30 %** (−55 % vs baseline), and the **object count
drops −95 %** — this is the term-string interning removing the allocation
explosion the original heap profile flagged (`NGramTokenizer.Tokenize` was 72 %
of all heap objects).

> Single-machine `go test -bench … -benchtime=3x` (Apple silicon); relative
> compression, not an absolute target.

## Test

- New `term_dict_test.go` covers intern (stable/distinct ids), lookup
  (hit/miss, no growth), release (frees + reuses the id).
- `go test ./...` green in `core/` (incl. `graphcache`); search integration
  tests green in the root module; `go vet` / `gofmt -l` clean.
- Existing white-box tests assert on `len(postings)`/`len(docs)`/`totalLen`,
  which keep their shape, so they pass unchanged.

Closes #784.
