### PR TITLE
chore(deps): bump core to v0.13.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.4.0
-	github.com/anaregdesign/lantern/core v0.12.0
+	github.com/anaregdesign/lantern/core v0.13.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.8.0
 	github.com/anaregdesign/lantern/sdks/go v0.18.0


### PR DESCRIPTION
Bumps the root module's `core` require from v0.12.0 to the freshly-tagged **core/v0.13.0**, picking up the search inverted-index memory work (epic #782: #783, #784, #785 — ~86% smaller index footprint, public API and ranked results unchanged).

Step 4 of the release flow (CONTRIBUTING "Cutting a release") ahead of the next root tag. The `replace => ./core` keeps local/workspace builds on the in-tree core; this updates the pinned version used outside the workspace.