### PR TITLE
fix: pre-own the snapshot backup /data dir as the non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,16 @@ ENV LANTERN_DEFAULT_TTL_SECONDS=3600 \
 WORKDIR /app
 COPY --from=builder /out/lantern /app/lantern
 
+# Backup/snapshot mount point (#770), pre-owned by the non-root runtime user.
+# Docker copies this dir's owner+mode onto a freshly-created (empty) named
+# volume at first mount, so the periodic dump writes as uid lantern; without
+# it the volume root is root:root and every dump fails "permission denied".
+# Backups stay opt-in (LANTERN_BACKUP_ENABLED=false by default), so no VOLUME
+# is declared — this only prepares the conventional /data target as the right
+# owner (bind mounts on Linux still follow host ownership; Mac/Windows Docker
+# Desktop file sharing makes them writable regardless).
+RUN mkdir -p /data && chown lantern:lantern /data
+
 USER lantern
 # 6380 = gRPC, 9090 = Prometheus /metrics + /healthz + /readyz
 EXPOSE 6380 9090


### PR DESCRIPTION
Closes #794

## What

The image runs as non-root `lantern` (uid 100) but never created the backup
mount point. A freshly-created named volume / PVC at `LANTERN_BACKUP_DIR`
(e.g. `/data` in the Compose HA stack) was therefore `root:root`, and every
periodic snapshot dump (#770) failed with `permission denied` — no backup was
ever written.

One line fixes it: create `/data` owned by `lantern` before `USER lantern`, so a
fresh empty named volume inherits the runtime user's ownership.

## Verification

Built locally and recreated `deploy/compose/docker-compose.yml` on the fixed image:
- `/data` is now `lantern:lantern` and writable on all 3 replicas; the backup
  loop starts with no permission errors.
- Wrote a vertex → graceful-stopped `lantern-0` → `backup: wrote dump … vertices:1`.
- Restarted → `backup: restored from dump … vertices:1`; data recovered.

## Notes

- Fixes named volumes (Compose) and K8s PVCs (with `fsGroup`). Native-Linux bind
  mounts follow host ownership and are unaffected; Mac/Windows Docker Desktop
  bind mounts are writable regardless. Backups stay opt-in, so no `VOLUME` is
  declared.
