### PR TITLE
chore(release): pin sdks/go v0.19.0 in root go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/anaregdesign/lantern/core v0.13.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.8.0
-	github.com/anaregdesign/lantern/sdks/go v0.18.0
+	github.com/anaregdesign/lantern/sdks/go v0.19.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1


### PR DESCRIPTION
## What

Bump the root module's `sdks/go` require from `v0.18.0` to `v0.19.0`.

`sdks/go/v0.19.0` was just cut to carry the `core` `v0.7.0 → v0.13.0` pin bump merged in #793. Per the CONTRIBUTING release cadence (step 4: "Bump the matching `require`/`replace` lines in the root `go.mod` to the freshly-tagged versions"), the root pin follows the SDK tag ahead of the next root release.

## Notes

- One-line `go.mod` pin bump; `replace => ./sdks/go` means no `go.sum` change.
- `go build ./...` + `go test ./...` (incl. `tests/integration`) pass locally; `gofmt -l` clean.
