### PR TITLE
feat(helm): minimal GKE Autopilot chart with opt-in GMP scraping + HA doc accuracy pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ go run ./server/cmd          # listens on :6380
 
 ### Run on Kubernetes (HA mode)
 
-For Tier-A HA (3 replicas with DNS-based peer discovery, anti-entropy
+For HA (3 replicas with DNS-based peer discovery, anti-entropy
 reconciliation, and a `PodDisruptionBudget`) install the bundled Helm
 chart:
 
@@ -299,15 +299,16 @@ discovery and Compose-side round-robin still work unchanged. Prometheus on
 table and client LB options, and the [Helm chart](deploy/helm/lantern/) when
 you need more than three replicas.
 
-### Run on serverless container PaaS
+### Run as a single instance
 
-For Cloud Run / Azure Container Apps / AWS App Runner / Fly Machines /
-any platform without stable pod identities, deploy a **single
-instance** (or independent shards) without setting any `LANTERN_PEER_*`
-env. Peer discovery requires a stable in-cluster DNS that resolves to
-per-pod IPs, which these platforms do not provide. See the
-[HA runbook](docs/ha-runbook.md) for the per-platform topology matrix,
-signals to watch, partition behaviour, and recovery procedures.
+To run Lantern without peer replication — as a fast in-memory KVS on a
+single pod / container — deploy one instance and leave every
+`LANTERN_PEER_*` env unset. The peer pump becomes a no-op, the readiness
+gate is bypassed, and `Subscribe` still works as a CDC stream. Pair it
+with the snapshot-backup feature ([docs/backup.md](docs/backup.md)) so a
+restart re-seeds the graph. See the [HA runbook](docs/ha-runbook.md) for
+the deployment-topology matrix, signals to watch, partition behaviour,
+and recovery procedures.
 
 ### Install via Homebrew (macOS)
 
@@ -804,7 +805,7 @@ The server is configured via environment variables, parsed in
 | `LANTERN_REFLECTION` | `true` | Register gRPC server reflection (useful for `grpcurl`) |
 | `LANTERN_SHUTDOWN_TIMEOUT_SECONDS` | `30` | Upper bound on graceful shutdown before forcing `http.Server.Close()` |
 | `LANTERN_DRAIN_DELAY_SECONDS` | `0` | Zero-drop rolling-update drain (#768). On `SIGTERM` the server flips readiness (`/readyz` + overall `""` health) to `NOT_SERVING` immediately, then keeps the listener serving for this long so load balancers deregister it before it stops accepting. `0` disables (no hold). Keep `terminationGracePeriodSeconds ≥` this `+ LANTERN_SHUTDOWN_TIMEOUT_SECONDS`. |
-| `LANTERN_BACKUP_ENABLED` | `false` | Enable the periodic whole-graph snapshot backup loop (#770). Requires `LANTERN_BACKUP_DIR`. Rolling-update insurance for single-instance (Tier B) Cloud Run / ACA deploys — see [docs/backup.md](docs/backup.md). |
+| `LANTERN_BACKUP_ENABLED` | `false` | Enable the periodic whole-graph snapshot backup loop (#770). Requires `LANTERN_BACKUP_DIR`. Rolling-update insurance for single-instance deploys — see [docs/backup.md](docs/backup.md). |
 | `LANTERN_BACKUP_DIR` | _(empty)_ | Mounted directory the server writes/reads whole-graph dumps in. |
 | `LANTERN_BACKUP_INTERVAL` | `5m` | Dump cadence (`time.ParseDuration`, e.g. `300s`, `5m`). |
 | `LANTERN_BACKUP_RETAIN` | `3` | Keep the newest N of this instance's own dumps; `0` keeps all. |

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -145,12 +145,13 @@ networks, or put your own ingress-level auth proxy in front.
 ## Verifying peer discovery
 
 ```shell
-# Each replica should log "peer_discovery" lines with the other 2 IPs.
-docker compose logs lantern-0 lantern-1 lantern-2 | grep peer_discovery
+# Each replica logs a "replication pump: peer transition" line
+# (transition=connect, peer=<addr>) for each of the other 2 peers.
+docker compose logs lantern-0 lantern-1 lantern-2 | grep "peer transition"
 
 # Prometheus (http://localhost:9091):
-#   lantern_replication_peer_up         — 1 gauge per active peer link
-#   lantern_replication_lag             — per (peer, origin) lag
+#   lantern_peer_connected              — 1 gauge per active peer link
+#   lantern_replication_lag_seq         — per (peer, origin) lag
 ```
 
 ## Single-instance fallback

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -1,6 +1,6 @@
 # Docker Compose: HA lantern cluster
 
-3-replica peer-discovery cluster (Tier-A) on a single Docker host. Mirrors
+3-replica peer-discovery cluster on a single Docker host. Mirrors
 the Helm chart in [`../helm/lantern/`](../helm/lantern/) for local dev and
 single-host HA experiments.
 

--- a/deploy/compose/docker-compose.backup.yml
+++ b/deploy/compose/docker-compose.backup.yml
@@ -1,7 +1,7 @@
-# Docker Compose: single-instance (Tier B) with snapshot durability (#770).
+# Docker Compose: single-instance with snapshot durability (#770).
 #
 # This is the rolling-update / restart insurance for a single Lantern
-# instance — the Cloud Run / Azure Container Apps shape, run locally. Lantern
+# instance, run locally. Lantern
 # is in-memory, so without this a `docker compose down && up` (or a crash)
 # loses the whole graph. With a mounted volume + the LANTERN_BACKUP_* knobs,
 # the server periodically dumps the whole graph to ./backups and restores the
@@ -17,7 +17,7 @@
 #   go run ../../cli get vertex hello               # still there
 #
 # Single instance ⇒ restore-on-start is the whole recovery path (no peers to
-# bootstrap from). The 3-replica Tier-A HA stack in docker-compose.yml also
+# bootstrap from). The 3-replica HA stack in docker-compose.yml also
 # restores on boot, but only as a baseline — peer bootstrap then overlays it
 # via HLC, so there replicas take priority and the dump just fills gaps.
 #
@@ -50,8 +50,8 @@ services:
       # Flip readiness before the listener closes on `down` (#768).
       LANTERN_DRAIN_DELAY_SECONDS: "5"
     volumes:
-      # The mounted volume that survives container recreation. On Cloud Run
-      # this is a GCS-FUSE / Filestore mount; on ACA an Azure Files share.
+      # The mounted volume that survives container recreation. In production
+      # this is a network or persistent block-volume mount.
       - ./backups:/data
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:9090/readyz"]

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -1,6 +1,6 @@
 # Docker Compose: HA topology (3-replica peer-discovery cluster).
 #
-# Mirrors the Helm chart's Tier-A topology for local development and
+# Mirrors the Helm chart's HA topology for local development and
 # single-host HA experiments. Each replica is its own service
 # (`lantern-0`, `lantern-1`, `lantern-2`) with a pinned host port
 # (`6380`, `6381`, `6382` respectively), so the admin SPA's default

--- a/deploy/helm/lantern/Chart.yaml
+++ b/deploy/helm/lantern/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   ClusterIP Service for client traffic, with a PodDisruptionBudget
   guarding rolling updates.
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "latest"
 home: https://github.com/anaregdesign/lantern
 sources:

--- a/deploy/helm/lantern/README.md
+++ b/deploy/helm/lantern/README.md
@@ -1,9 +1,16 @@
 # lantern (Helm chart)
 
-Tier-A HA deployment of [lantern](https://github.com/anaregdesign/lantern)
-on Kubernetes: a `StatefulSet` of 3 pods behind a headless `Service` for
+Minimal, cost-optimised deployment of
+[lantern](https://github.com/anaregdesign/lantern) on Kubernetes — tuned for
+**GKE Autopilot**: a `StatefulSet` of 2 pods behind a headless `Service` for
 DNS-based peer discovery (see [docs/replication.md §9.1](../../../docs/replication.md))
-plus a `ClusterIP` `Service` for clients, guarded by a `PodDisruptionBudget`.
+plus a `ClusterIP` `Service` for in-cluster clients, guarded by a
+`PodDisruptionBudget`. Lantern is a full-replica store, so 2 replicas give
+rolling-update / single-node-drain survival at the lowest footprint. The
+Service is ClusterIP-only — Lantern is never exposed outside the cluster;
+reach it from other pods via its Service FQDN, or from a laptop with
+`kubectl port-forward` for verification. Admin, MCP and Prometheus are
+expected to run locally and are **not** deployed by this profile.
 
 ## Quick install
 
@@ -27,10 +34,10 @@ helm lint deploy/helm/lantern
 
 | Object                                | Purpose                                                |
 | ------------------------------------- | ------------------------------------------------------ |
-| `StatefulSet/<release>-lantern`       | 3 lantern pods (default), `RollingUpdate` strategy.    |
+| `StatefulSet/<release>-lantern`       | 2 lantern pods (default), `RollingUpdate` strategy.    |
 | `Service/<release>-lantern`           | `ClusterIP` — client gRPC + scrapeable `/metrics`.     |
 | `Service/<release>-lantern-headless`  | `clusterIP: None` — peer discovery DNS.                |
-| `PodDisruptionBudget/<release>-lantern` | `minAvailable: 2` to keep quorum during drains.      |
+| `PodDisruptionBudget/<release>-lantern` | `minAvailable: 1` keeps one replica up during a drain. |
 | `ServiceAccount/<release>-lantern`    | Workload identity (token-only by default).             |
 | `ServiceMonitor/<release>-lantern`    | Optional, when `metrics.serviceMonitor.enabled=true`.  |
 
@@ -46,16 +53,11 @@ just the local pod and filter it out — pump becomes a no-op) or set
 `replication.discovery.mode=static` with `replication.peers=[]`. PDB
 can be disabled via `podDisruptionBudget.enabled=false`.
 
-For serverless container PaaS (Cloud Run / Azure Container Apps /
-App Runner) there is no peer topology — do **not** use this chart;
-deploy the container directly without `LANTERN_PEER_*` env. See the
-HA runbook (#192) for the limits.
-
 ## Tuning
 
 | Value                                       | Default                | Notes                                              |
 | ------------------------------------------- | ---------------------- | -------------------------------------------------- |
-| `replicaCount`                              | `3`                    | Tier-A HA default.                                 |
+| `replicaCount`                              | `2`                    | Minimal HA default (full-replica store).           |
 | `image.repository`                          | `ghcr.io/anaregdesign/lantern` | Override for private mirrors.              |
 | `image.tag`                                 | `.Chart.AppVersion`    | Pin to a specific release tag in production.       |
 | `service.port`                              | `6380`                 | gRPC.                                              |
@@ -66,10 +68,12 @@ HA runbook (#192) for the limits.
 | `replication.discovery.intervalMs`          | `10000`                | `0` = resolve once at startup.                     |
 | `replication.maxLag`                        | `10000`                | Per-(peer,origin) lag cap before readiness flips.  |
 | `antiEntropy.intervalMs`                    | `30000`                | Background reconciliation cadence.                 |
-| `podDisruptionBudget.minAvailable`          | `2`                    | Quorum-ish.                                        |
+| `podDisruptionBudget.minAvailable`          | `1`                    | Keep one replica up while the other drains (correct for 2 replicas). |
 | `backup.enabled`                            | `true`                 | Snapshot durability (#770/#779): per-pod dump PVC + restore-on-start baseline (peers overlay it via HLC). Needs a default StorageClass or `backup.persistence.storageClass`. |
 | `backup.interval`                           | `5m`                   | Dump cadence; keep `cache.defaultTtlSeconds` above it.             |
 | `backup.persistence.size`                   | `1Gi`                  | Per-pod PVC size for dumps.                        |
+| `backup.persistence.existingClaim`          | `""`                   | Set to a pre-provisioned RWX claim for a shared dump volume. |
+| `resources.requests` / `.limits`            | `250m` CPU / `512Mi`   | requests == limits (Autopilot Guaranteed QoS). 250m is the Autopilot min; 512Mi the server floor. |
 | `metrics.serviceMonitor.enabled`            | `false`                | Requires the prometheus-operator CRD.              |
 | `admin.enabled`                             | `false`                | Render the `lantern-admin` SPA Deployment + Service. |
 | `admin.image.repository`                    | `ghcr.io/anaregdesign/lantern-admin` | Admin SPA image (Caddy serving the built bundle).     |

--- a/deploy/helm/lantern/README.md
+++ b/deploy/helm/lantern/README.md
@@ -39,7 +39,8 @@ helm lint deploy/helm/lantern
 | `Service/<release>-lantern-headless`  | `clusterIP: None` — peer discovery DNS.                |
 | `PodDisruptionBudget/<release>-lantern` | `minAvailable: 1` keeps one replica up during a drain. |
 | `ServiceAccount/<release>-lantern`    | Workload identity (token-only by default).             |
-| `ServiceMonitor/<release>-lantern`    | Optional, when `metrics.serviceMonitor.enabled=true`.  |
+| `ServiceMonitor/<release>-lantern`    | Optional, when `metrics.serviceMonitor.enabled=true` (Prometheus Operator). |
+| `PodMonitoring/<release>-lantern`     | Optional, when `metrics.podMonitoring.enabled=true` (GKE Managed Prometheus). |
 
 The pump reads `LANTERN_PEER_DISCOVERY=dns` and resolves the headless
 `Service` FQDN to obtain peer IPs. `LocalIPSet()` in the server filters
@@ -75,6 +76,8 @@ can be disabled via `podDisruptionBudget.enabled=false`.
 | `backup.persistence.existingClaim`          | `""`                   | Set to a pre-provisioned RWX claim for a shared dump volume. |
 | `resources.requests` / `.limits`            | `250m` CPU / `512Mi`   | requests == limits (Autopilot Guaranteed QoS). 250m is the Autopilot min; 512Mi the server floor. |
 | `metrics.serviceMonitor.enabled`            | `false`                | Requires the prometheus-operator CRD.              |
+| `metrics.podMonitoring.enabled`             | `false`                | GKE Managed Service for Prometheus (GMP). Requires the `monitoring.googleapis.com/v1` PodMonitoring CRD (default on GKE). |
+| `metrics.podMonitoring.interval`            | `60s`                  | GMP scrape interval.                               |
 | `admin.enabled`                             | `false`                | Render the `lantern-admin` SPA Deployment + Service. |
 | `admin.image.repository`                    | `ghcr.io/anaregdesign/lantern-admin` | Admin SPA image (Caddy serving the built bundle).     |
 | `admin.image.tag`                           | `.Chart.AppVersion`    | Pin to an `admin/vX.Y.Z` tag in production.        |

--- a/deploy/helm/lantern/README.md
+++ b/deploy/helm/lantern/README.md
@@ -207,10 +207,11 @@ kubectl -n default scale statefulset <release>-lantern --replicas=5
 ## Verifying peer discovery
 
 ```shell
-# All pods should see N-1 peer addresses in their logs.
-kubectl -n default logs <release>-lantern-0 | grep peer_discovery
+# Each pod logs a "replication pump: peer transition" line (transition=connect,
+# peer=<addr>) for each of the other N-1 peers as streams open.
+kubectl -n default logs <release>-lantern-0 | grep "peer transition"
 
-# Prometheus: lantern_replication_peer_up{peer="..."} gauge series
+# Prometheus: lantern_peer_connected{peer="..."} gauge series
 # should show one per resolved peer, transitioning 0→1 on stream open.
 ```
 
@@ -219,4 +220,4 @@ kubectl -n default logs <release>-lantern-0 | grep peer_discovery
 - RFC: [docs/replication.md](../../../docs/replication.md)
 - Discovery spec: [docs/replication.md §9.1](../../../docs/replication.md#91-peer-discovery-190)
 - Docker Compose alternative: [`deploy/compose/`](../../compose/)
-- HA runbook: see issue #192 (in flight).
+- HA runbook: [docs/ha-runbook.md](../../../docs/ha-runbook.md)

--- a/deploy/helm/lantern/templates/podmonitoring.yaml
+++ b/deploy/helm/lantern/templates/podmonitoring.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.metrics.podMonitoring.enabled -}}
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: {{ include "lantern.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lantern.labels" . | nindent 4 }}
+    {{- with .Values.metrics.podMonitoring.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "lantern.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.metrics.podMonitoring.interval }}
+{{- end }}

--- a/deploy/helm/lantern/templates/podmonitoring.yaml
+++ b/deploy/helm/lantern/templates/podmonitoring.yaml
@@ -17,4 +17,8 @@ spec:
     - port: metrics
       path: /metrics
       interval: {{ .Values.metrics.podMonitoring.interval }}
+      {{- with .Values.metrics.podMonitoring.metricRelabeling }}
+      metricRelabeling:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/deploy/helm/lantern/values.yaml
+++ b/deploy/helm/lantern/values.yaml
@@ -87,6 +87,18 @@ metrics:
     interval: 30s
     scrapeTimeout: 10s
     labels: {}
+  # Google Cloud Managed Service for Prometheus (GMP) PodMonitoring. On GKE
+  # (Autopilot has managed collection on by default) a PodMonitoring is the
+  # supported way to ingest a pod's /metrics — the serviceMonitor above is
+  # Prometheus-Operator-only and is IGNORED by GMP. Disabled by default; set
+  # podMonitoring.enabled=true on a GKE/GMP cluster. Requires the
+  # PodMonitoring CRD (monitoring.googleapis.com/v1), present by default on
+  # GKE. Mutually independent from serviceMonitor — enable whichever your
+  # monitoring backend consumes (or neither).
+  podMonitoring:
+    enabled: false
+    interval: 60s
+    labels: {}
 
 # Replication / peer discovery. See docs/replication.md §9.1.
 replication:

--- a/deploy/helm/lantern/values.yaml
+++ b/deploy/helm/lantern/values.yaml
@@ -99,6 +99,20 @@ metrics:
     enabled: false
     interval: 60s
     labels: {}
+    # GMP metricRelabeling applied to scraped samples (Prometheus
+    # metric_relabel_configs semantics). The default keeps the signals this
+    # deployment actually consumes — every lantern_* family, the grpc_server_*
+    # RPC RED metrics (rate/errors/latency; emitted lazily on the first unary
+    # call), and a minimal runtime set (scrape up, goroutines, heap-in-use,
+    # RSS, CPU) — and drops the generic go_*/process_*/promhttp_* collectors
+    # that carry no Lantern-specific signal. This is signal curation, not a
+    # major cost lever: lantern_* (its illuminate/scan histograms) is ~95% of
+    # the live series count, so the dropped collectors are only a small slice.
+    # Set to [] to ingest every scraped series.
+    metricRelabeling:
+      - action: keep
+        sourceLabels: [__name__]
+        regex: lantern_.*|grpc_server_.*|up|go_goroutines|go_memstats_heap_inuse_bytes|process_resident_memory_bytes|process_cpu_seconds_total
 
 # Replication / peer discovery. See docs/replication.md §9.1.
 replication:

--- a/deploy/helm/lantern/values.yaml
+++ b/deploy/helm/lantern/values.yaml
@@ -1,7 +1,14 @@
 # Default values for lantern.
-# Tier-A HA topology: 3-replica StatefulSet + headless Service + PDB.
-# Per RFC #175 D7. Set replicaCount=1 to fall back to single-instance
-# mode (no peer pump, no readiness gating).
+# Minimal, cost-optimised profile for GKE Autopilot: a 2-replica
+# StatefulSet + headless Service (peer DNS) + ClusterIP Service (in-cluster
+# clients) + PDB. Lantern is a full-replica store, so 2 replicas give
+# rolling-update / single-node-drain survival at the lowest footprint.
+# The Service is ClusterIP-only — Lantern is never exposed outside the
+# cluster; reach it from other pods via its Service FQDN, or from a laptop
+# with `kubectl port-forward` for verification. Admin, MCP and Prometheus
+# are expected to run locally and are NOT deployed by this profile. Set
+# replicaCount=1 to fall back to single-instance mode (no peer pump, no
+# readiness gating).
 
 image:
   repository: ghcr.io/anaregdesign/lantern
@@ -13,10 +20,12 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-# Number of lantern pods. 3 is the recommended Tier-A default.
-# Use 1 for single-instance / dev (peer pump becomes a no-op when only
-# the local pod resolves).
-replicaCount: 3
+# Number of lantern pods. 2 is the minimal HA default for this profile:
+# a full-replica store means each pod holds the whole graph, so 2 replicas
+# survive a rolling update / single-node drain at the lowest cost. Use 1
+# for single-instance / dev (peer pump becomes a no-op when only the local
+# pod resolves).
+replicaCount: 2
 
 # StatefulSet update strategy. RollingUpdate is required for the PDB
 # minAvailable guarantee to hold during upgrades.
@@ -24,11 +33,12 @@ updateStrategy:
   type: RollingUpdate
 
 # PodDisruptionBudget for voluntary disruption (node drains, upgrades).
-# minAvailable: 2 keeps quorum-style availability with 3 replicas.
-# Set enabled: false for single-instance deployments.
+# minAvailable: 1 keeps one replica serving while the other is drained —
+# the correct setting for 2 replicas (minAvailable: 2 would deadlock every
+# voluntary disruption). Set enabled: false for single-instance deployments.
 podDisruptionBudget:
   enabled: true
-  minAvailable: 2
+  minAvailable: 1
 
 # Zero-drop rolling-update drain (#768). On SIGTERM the server flips
 # readiness to NOT_SERVING immediately (overall "" gRPC health + /readyz
@@ -103,16 +113,17 @@ cache:
 
 # Snapshot durability (#770, #779): periodic whole-graph dumps to a mounted
 # volume + restore-on-startup. ENABLED by default — the stable durability
-# baseline. Primarily the Tier-B (single-instance, replicaCount=1)
-# rolling-update insurance, where restore-on-start re-seeds the graph on boot.
-# In a multi-replica StatefulSet restore still runs on each pod as a BASELINE:
+# baseline. In this 2-replica profile restore runs on each pod as a BASELINE:
 # peer bootstrap then overlays it via HLC (newer peer state wins per key, so
 # replicas take priority), while a whole-cluster cold start recovers from the
-# dumps instead of coming up empty. Each pod writes its own dumps
-# (LANTERN_BACKUP_INSTANCE_ID = pod name). persistence below renders a per-pod
-# PVC, so the cluster needs a default StorageClass (or set
-# persistence.storageClass / persistence.existingClaim); set enabled: false to
-# opt out.
+# dumps instead of coming up empty. It is also the single-instance
+# (replicaCount=1) rolling-update insurance, where restore-on-start re-seeds
+# the graph on boot. Each pod writes its own dumps (LANTERN_BACKUP_INSTANCE_ID
+# = pod name). persistence below renders a per-pod ReadWriteOnce PVC, which on
+# GKE Autopilot binds the default `standard-rwo` StorageClass — cost-minimal
+# and the recommended default. For a shared dump volume instead, point
+# persistence.existingClaim at a pre-provisioned RWX claim; set enabled: false
+# to opt out.
 backup:
   enabled: true
   dir: /var/lib/lantern/backups
@@ -144,14 +155,19 @@ probes:
     failureThreshold: 3
     successThreshold: 1
 
-# Resource requests/limits.
+# Resource requests/limits. On GKE Autopilot you pay for requests and an
+# unset limit is clamped to the request, so requests == limits here for
+# Guaranteed QoS and predictable cost. 250m CPU is the Autopilot per-pod
+# minimum; 512Mi memory is the server's working-set floor (the 250m:512Mi
+# CPU:memory ratio sits inside Autopilot's allowed 1:1–1:6.5 band). Raise
+# both together for larger graphs.
 resources:
   requests:
-    cpu: 100m
-    memory: 256Mi
+    cpu: 250m
+    memory: 512Mi
   limits:
-    cpu: "2"
-    memory: 2Gi
+    cpu: 250m
+    memory: 512Mi
 
 # Extra environment variables (raw env list, appended after the
 # templated ones). Useful for TLS_* / RATE_LIMIT_* / LOG_* tweaks.

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,18 +1,18 @@
-# Snapshot backup & restore (Tier-B durability)
+# Snapshot backup & restore
 
 > Tracking: [#769](https://github.com/anaregdesign/lantern/issues/769) (epic),
 > [#770](https://github.com/anaregdesign/lantern/issues/770) (engine),
 > [#771](https://github.com/anaregdesign/lantern/issues/771) (this doc).
 
 Lantern is an **in-memory** store, so a single instance loses its whole graph
-on any restart — including the routine **rolling update** of a serverless
-container revision. The snapshot-durability feature is the insurance for that:
+on any restart — including a routine **rolling update** or pod restart. The
+snapshot-durability feature is the insurance for that:
 the server **periodically dumps the whole graph to a mounted volume** and
 **restores the newest dump on startup**, before it begins serving.
 
-This is primarily the **Tier B** (single-instance) durability story — Cloud
-Run, Azure Container Apps, App Runner, or any single-container deploy. In a
-**Tier A** multi-replica cluster restore still runs on boot as a **baseline**:
+This is primarily the **single-instance** durability story — any single-pod
+or single-container deploy. In a **multi-replica** cluster restore still runs
+on boot as a **baseline**:
 the restarted pod replays its newest dump, then peer **bootstrap** (snapshot +
 tail, see [replication.md](replication.md)) overlays it through the write path,
 so HLC ordering lets newer peer state win per key — replicas take priority, the
@@ -47,10 +47,10 @@ offer safe concurrent-write coordination:
 
 | Backend | Shared? | Concurrent-write safety |
 |---|---|---|
-| Cloud Run — Cloud Storage (GCS FUSE) | yes | **no file locking**, last-write-wins, not POSIX; mount must finish < 30 s or boot fails |
-| Cloud Run — NFS (Filestore) | yes | mounted **no-lock** |
-| ACA — Azure Files (SMB/NFS) | yes (across replicas/revisions) | multi-writer coordination is the app's job |
-| ACA — EmptyDir | no (replica-scoped, ephemeral) | n/a |
+| Object storage via FUSE (e.g. GCS, S3) | yes | **no file locking**, last-write-wins, not POSIX; mount latency can stall boot |
+| Network file share (NFS / SMB) | yes | mounted **no-lock**; multi-writer coordination is the app's job |
+| Per-pod block volume (RWO) | no (pod-scoped) | not shared — safe by construction |
+| EmptyDir / tmpfs | no (pod-scoped, ephemeral) | n/a |
 
 So Lantern **never** writes a shared single file and **never** does leader
 election — per-instance filenames make concurrent writes collision-free on
@@ -73,67 +73,35 @@ every backend, and degrade cleanly to the single-instance case.
 > comfortably **above** `LANTERN_BACKUP_INTERVAL` (and above your expected
 > restart gap) or much of a restored graph may already be expired.
 
-## Cloud Run
+## Durability via a mounted volume
 
-Mount a Cloud Storage bucket (GCS FUSE) — or a Filestore NFS share — at
-`LANTERN_BACKUP_DIR`, single instance:
-
-```bash
-gcloud run deploy lantern \
-  --image ghcr.io/anaregdesign/lantern:latest \
-  --port 6380 --use-http2 \
-  --min-instances 1 --max-instances 1 \
-  --add-volume name=backups,type=cloud-storage,bucket=YOUR_BUCKET \
-  --add-volume-mount volume=backups,mount-path=/data \
-  --set-env-vars LANTERN_BACKUP_ENABLED=true,LANTERN_BACKUP_DIR=/data,LANTERN_BACKUP_INTERVAL=5m,LANTERN_DEFAULT_TTL_SECONDS=86400,LANTERN_DRAIN_DELAY_SECONDS=5
-```
-
-Notes: `--use-http2` is required for Lantern's h2c (Connect / gRPC) surface;
-GCS FUSE provides **no locking** (per-instance files handle it); the volume
-mount must complete within Cloud Run's 30 s startup budget. For lower-latency
-durability use a Filestore NFS volume (`type=cloud-storage` → an NFS volume)
-instead of GCS.
-
-## Azure Container Apps
-
-Define an Azure Files (SMB) share on the environment, then mount it at
-`LANTERN_BACKUP_DIR`:
+The feature works on any platform that can mount a directory which survives
+container/pod restarts at `LANTERN_BACKUP_DIR`. Point the env vars above at
+that path — the server then dumps periodically and restores the newest dump
+on boot:
 
 ```bash
-az containerapp env storage set -n my-env -g my-rg \
-  --storage-name backups --storage-type AzureFile \
-  --azure-file-account-name STORAGE --azure-file-account-key KEY \
-  --azure-file-share-name SHARE --access-mode ReadWrite
+LANTERN_BACKUP_ENABLED=true
+LANTERN_BACKUP_DIR=/data
+LANTERN_BACKUP_INTERVAL=5m
+LANTERN_DEFAULT_TTL_SECONDS=86400
 ```
 
-```yaml
-# app.yaml — properties.template excerpt
-template:
-  containers:
-    - name: lantern
-      image: ghcr.io/anaregdesign/lantern:latest
-      env:
-        - name: LANTERN_BACKUP_ENABLED
-          value: "true"
-        - name: LANTERN_BACKUP_DIR
-          value: /data
-        - name: LANTERN_BACKUP_INTERVAL
-          value: 5m
-        - name: LANTERN_DEFAULT_TTL_SECONDS
-          value: "86400"
-      volumeMounts:
-        - volumeName: backups
-          mountPath: /data
-  scale:
-    minReplicas: 1
-    maxReplicas: 1
-  volumes:
-    - name: backups
-      storageType: AzureFile
-      storageName: backups
-```
+- **Kubernetes** — the [Helm chart](../deploy/helm/lantern/) renders a per-pod
+  `ReadWriteOnce` PVC mounted at `LANTERN_BACKUP_DIR` (`backup.persistence`, on
+  by default). On GKE Autopilot this binds the default `standard-rwo`
+  StorageClass. Each pod keeps its own dumps; for a single shared dump volume
+  point `backup.persistence.existingClaim` at a pre-provisioned RWX claim.
+- **Docker Compose / single host** — bind-mount a host directory (see the
+  runnable example below).
+- **Shared / networked volumes** (NFS, SMB, object-storage FUSE) also work:
+  per-instance filenames keep concurrent writers collision-free, but such
+  backends offer **no file locking**, so never rely on cross-writer
+  coordination, and high mount latency can stall boot — prefer a local/block
+  volume when restore time matters.
 
-`EmptyDir` is replica-scoped and ephemeral — **don't** use it for durability.
+`EmptyDir` / `tmpfs` are pod-scoped and ephemeral — **don't** use them for
+durability.
 
 ## Docker Compose (local)
 
@@ -176,7 +144,7 @@ replicas take priority while a whole-cluster cold start recovers from the dumps.
 ## See also
 
 - [docs/ha-runbook.md](ha-runbook.md) — rolling-upgrade drain (§7) and HA ops.
-- [docs/replication.md](replication.md) — the Tier-A peer-bootstrap recovery
+- [docs/replication.md](replication.md) — the multi-replica peer-bootstrap recovery
   path and the deployment-topology matrix (D7).
 - `lantern-cli dump` / `lantern-cli restore` — the on-demand, file-compatible
   CLI half of the same format.

--- a/docs/ha-runbook.md
+++ b/docs/ha-runbook.md
@@ -25,19 +25,15 @@ Start here. Pick a row, then jump to the corresponding section.
 | Docker Compose (explicit `lantern-N` services + DNS alias) | ✅ | ✅ | [§3.2](#32-docker-compose) |
 | HashiCorp Nomad + Consul DNS | ✅ user-configured | ✅ | [§3.3](#33-nomad) |
 | Plain VMs / bare metal | ✅ static or DNS | ✅ | [§3.4](#34-plain-vms) |
-| Google Cloud Run | ❌ HA not supported | ✅ | [§3.5](#35-serverless-paas-single-instance-only) |
-| Azure Container Apps | ❌ HA not supported | ✅ | [§3.5](#35-serverless-paas-single-instance-only) |
-| AWS App Runner / Fly Machines (autoscale) | ❌ HA not supported | ✅ | [§3.5](#35-serverless-paas-single-instance-only) |
 
-**Why some PaaS platforms can't do HA.** Lantern's leaderless P2P
-needs (a) stable per-instance addressing for peer discovery and
-(b) long-lived inbound gRPC streams between every pair of instances.
-Cloud Run / ACA / App Runner deliberately hide instance addresses,
-route every request through a load balancer, and recycle instances
-on the request lifecycle. Single instance always works — and is
-genuinely useful as a fast in-memory KVS with CDC via `Subscribe` —
-but multiple instances cannot form a cluster on those platforms.
-See RFC [D7](replication.md#3-binding-decisions-d1d7).
+**Why some platforms can't do HA.** Lantern's leaderless P2P needs
+(a) stable per-instance addressing for peer discovery and (b)
+long-lived inbound gRPC streams between every pair of instances.
+Platforms that hide instance addresses behind a load balancer and
+recycle instances on the request lifecycle cannot satisfy these, so
+only single-instance mode works there — still genuinely useful as a
+fast in-memory KVS with CDC via `Subscribe`. See RFC
+[D7](replication.md#3-binding-decisions-d1d7).
 
 ---
 
@@ -256,29 +252,6 @@ export LANTERN_PEER_DISCOVERY_INTERVAL_MS=10000
 The pump re-resolves the DNS name every interval and reconciles its
 peer set.
 
-### 3.5 Serverless PaaS (single-instance only)
-
-**Cloud Run / Azure Container Apps / AWS App Runner / Fly Machines:**
-
-- Set instance count / max replicas / scale = 1.
-- Do **not** set `LANTERN_PEER_DISCOVERY` or `LANTERN_PEERS`.
-- Allocate enough memory for your working set (§5).
-- Treat the service as a fast in-memory KVS. Cold start = empty
-  cache unless snapshot backups are configured (`LANTERN_BACKUP_*`,
-  see [backup.md](backup.md)).
-- For CDC: open `Subscribe` from a long-lived consumer outside the
-  PaaS (e.g., a worker on k8s or a VM) and persist downstream.
-
-The single-instance gating ([§2.1](#21-single-instance-mode-no-ha))
-keeps `/readyz` returning `SERVING` immediately after the gRPC port
-opens, so the platform's health-check happy-path works unchanged.
-
-Why not just run more instances? Because the platforms (deliberately)
-won't let those instances see each other on stable per-instance
-addresses, and the request lifecycle is request-scoped — long-lived
-peer streams are torn down. Set scale=1 and stop fighting the
-platform.
-
 ---
 
 ## 4. What to watch (signals)
@@ -468,10 +441,10 @@ recreate-one-at-a-time loop) and confirming no `Unavailable` /
 connection-reset errors, and that `/readyz` returns **503 at the start
 of termination** before the listener stops accepting.
 
-**Single-instance (Tier B)** deploys (Cloud Run / ACA, `replicaCount: 1`)
-have no peer to fail over to, so the drain still flips `/readyz` (the
-platform shifts traffic to the new revision) but durability across the
-rotation comes from the snapshot backup/restore feature
+**Single-instance** deploys (`replicaCount: 1`) have no peer to fail over
+to, so the drain still flips `/readyz` (the platform shifts traffic to the
+new instance) but durability across the rotation comes from the snapshot
+backup/restore feature
 (`LANTERN_BACKUP_*`, #770) — see [docs/backup.md](backup.md) — not
 replication.
 
@@ -612,8 +585,9 @@ A short checklist to walk before opening an incident:
       single-instance mode, not "no readiness gating please". If you
       want HA, set discovery to `dns` (or put hosts in
       `LANTERN_PEERS`).
-- [ ] **Scaling a serverless PaaS to > 1 replica.** It won't work
-      and there's no warning. See [§3.5](#35-serverless-paas-single-instance-only).
+- [ ] **Scaling a single-instance deploy to > 1 replica expecting HA.**
+      On a platform that hides per-instance addresses it won't form a
+      cluster, and there's no warning. See [§2.1](#21-single-instance-mode-no-ha).
 - [ ] **NTP drift > 500 ms.** RFC D3. Watch
       `lantern_hlc_skew_clamped_total` if/when present, or just keep
       NTP healthy.

--- a/docs/ha-runbook.md
+++ b/docs/ha-runbook.md
@@ -264,15 +264,15 @@ exact Prometheus series.
 
 | Metric | Type | What it tells you |
 |---|---|---|
-| `lantern_replication_lag_seq{peer}` | gauge | How many mutation log entries this pod is behind `peer`. **The single most important HA signal.** |
-| `lantern_replication_applied_total{peer,origin}` | counter | Mutations from `peer` that landed in the local cache. `rate()` ≈ steady-state replication throughput per peer. |
-| `lantern_replication_dropped_total{peer,reason}` | counter | Mutations rejected at apply. `reason` is `tombstone` / `older_hlc` / `self_echo` etc. Persistent non-zero rate signals real conflict or a stuck peer. |
+| `lantern_replication_lag_seq{peer,origin}` | gauge | How many mutation log entries this pod is behind `peer` for that `origin`. **The single most important HA signal.** |
+| `lantern_replication_applied_total{origin}` | counter | Remote mutations from `origin` (the originating writer node) that landed in the local cache. `rate()` ≈ steady-state replication throughput per origin. |
+| `lantern_replication_dropped_total{peer,reason}` | counter | Replication frames or peer interactions dropped. `reason` is `self_echo` / `subscribe_failed` / `snapshot_failed` / `dial_failed` / `peerstatus_failed` / `catchup_failed` / `clean` / `ctx_cancel`. A persistent non-zero rate (excluding `self_echo` / `clean`) signals an unreachable or stuck peer. |
 | `lantern_anti_entropy_cycles_total` | counter | Anti-entropy ticks. Should advance at `LANTERN_ANTI_ENTROPY_INTERVAL_MS` cadence. |
 | `lantern_anti_entropy_gaps_found_total{peer,origin}` | counter | Non-zero = real divergence detected and being repaired. Spiking after a partition heal = expected. Persistently incrementing in steady state = open a bug. |
 | `lantern_mutation_log_entries_total` | counter | Total mutations ever logged on this pod. |
 | `lantern_mutation_log_capacity` | gauge | Ring buffer capacity. If sustained `rate(mutation_log_entries) × subscribe_lag_seconds > capacity`, slow peers will fall off and re-snapshot. |
 | `lantern_subscribe_active_streams` | gauge | Inbound subscribers (peers + external CDC). Drop = peer disconnect or CDC consumer crash. |
-| `lantern_subscribe_dropped_total{reason}` | counter | `reason=out_of_range` ≥ 1 means a peer's `from_seq` fell off the ring buffer; the pump will re-snapshot automatically. |
+| `lantern_subscribe_dropped_total{reason}` | counter | `reason=gapped` means a peer's `from_seq` fell off the ring buffer (the pump re-snapshots automatically); `reason=send_failed` is a broken outbound stream. |
 
 ### 4.2 Resource / cache health
 
@@ -281,13 +281,13 @@ exact Prometheus series.
 | `lantern_vertices`, `lantern_edges` | Current working-set size. Must agree (within `lantern_replication_lag_seq`) across peers. |
 | `lantern_ttl_expirations_total{kind}` | TTL-driven evictions. |
 | `lantern_gc_duration_seconds` | GC sweep latency histogram. |
-| `lantern_build_info{version,commit}` | Version pinning for cross-checks during upgrade. |
+| `lantern_build_info{version,commit,go_version}` | Version pinning for cross-checks during upgrade. |
 
 ### 4.3 RPC layer
 
 The in-house Connect interceptor in
 `server/provider/connect_middleware.go` exposes the canonical
-`grpc_server_*` metric names (handled / handling time / received / sent).
+`grpc_server_*` metric names (started / handled / handling time).
 The names are intentionally retained for operator-dashboard continuity
 after the gRPC middleware was deleted in #337/#352; the wire protocol is
 Connect. Use them for per-RPC latency SLOs.
@@ -508,14 +508,15 @@ The new pod starts in `NOT_SERVING` until snapshot+tail completes.
 
 ### 9.2 Subscribe ring buffer overflow
 
-Symptom: `lantern_subscribe_dropped_total{reason="out_of_range"}`
-increments; the affected peer logs `OutOfRange` and re-snapshots on
-its own. No manual action needed.
+Symptom: `lantern_subscribe_dropped_total{reason="gapped"}`
+increments; the server replies `FailedPrecondition` (reason
+`gapped`) and the affected peer logs a `replication pump: peer
+transition` line with `transition="snapshot_start" reason="gapped"`,
+then re-snapshots on its own. No manual action needed.
 
 If overflow is **chronic**, write rate has outgrown
 `mutation_log_capacity`. Bump
-`LANTERN_MUTATION_LOG_CAPACITY` (if/when the env knob exists) or
-add cluster capacity.
+`LANTERN_MUTATION_LOG_CAPACITY` or add cluster capacity.
 
 ### 9.3 Pod stuck `NOT_SERVING` after restart
 
@@ -602,10 +603,10 @@ operator actions.
 | Failure | Signal | What to do |
 |---|---|---|
 | Single pod crash | k8s probe / Compose healthcheck flips | Auto-restarts. Pod bootstraps from peers. No action unless it crashloops. |
-| Pod falls behind buffer | `subscribe_dropped_total{reason="out_of_range"}` increments | Pump auto re-snapshots. Chronic = bump capacity. |
+| Pod falls behind buffer | `subscribe_dropped_total{reason="gapped"}` increments | Pump auto re-snapshots. Chronic = bump capacity. |
 | All peers unreachable on boot | Pod `NOT_SERVING`, no `replication_applied` increments | Check discovery env (§9.3). |
 | Total-cluster loss | Every pod down | Accepted data loss; rehydrate — or restore from snapshot backups if configured ([§9.4](#94-total-cluster-loss)). |
-| NTP skew > 500 ms | `hlc_skew_clamped_total > 0` | Fix NTP. Convergence preserved, but the drifted peer's stamps land behind real wall time. |
+| NTP skew > 500 ms | `lantern_hlc_skew_clamped_total` (planned — #180/#182; until then watch NTP) | Fix NTP. Convergence preserved, but the drifted peer's stamps land behind real wall time. |
 | Network partition < tombstone TTL | `replication_lag_seq` spike; `anti_entropy_gaps_found_total` non-zero after heal | Auto-converges. No action. |
 | Network partition > tombstone TTL | Same signals + possible resurrection | Force re-snapshot from the side you trust ([§9.1](#91-force-a-re-snapshot)). Consider extending tombstone TTL. |
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,456 @@
+# Observability design — metrics, logs & traces
+
+> Status: **Draft** — owner-authored design note.
+> Companions: [`replication.md`](replication.md) (the HA model the signals
+> describe) and [`ha-runbook.md`](ha-runbook.md) (the operator runbook).
+> The runbook's "what to watch" is the operational quick-reference; this
+> document is the *why* behind it — who needs to answer what, and which
+> signals earn their keep.
+> Pre-v1.0.0: signal names (metric names, log keys, span names) are **not**
+> stable. Prefer the cleanest design over backward compatibility, with one
+> deliberate exception — the `grpc_server_*` RPC metric names are frozen for
+> operator continuity (see §5.2).
+
+---
+
+## 1. Purpose & scope
+
+Lantern is an in-memory graph KVS: a **leaderless, full-replica** cluster
+(any pod accepts any read/write; writes fan out asynchronously to every peer),
+holding vertices **and** edges that carry TTLs and **decay** over time, served
+over Connect/HTTP-2. That shape dictates what is worth observing — there is no
+leader to watch, no quorum to count, no disk to fsync; instead the interesting
+questions are *"are the replicas converging?"*, *"is anything decaying that
+shouldn't?"*, and *"is any single node falling behind?"*.
+
+This document organises observability from the **application owner's seat**.
+It deliberately starts from *who needs to answer what* (§2–§3), then derives
+the signal catalogue (§5–§7), and only then judges which signals are worth
+carrying (§8) and which are deliberately *not* built (§9). Current
+implementation is cited throughout as the **baseline, not the boundary** —
+where a useful signal is missing it is named in §8 rather than omitted.
+
+**In scope:** the three pillars (metrics, logs, traces) plus health, framed
+conceptually and mapped onto Lantern's subsystems.
+
+**Out of scope:** concrete dashboards and alert thresholds (they live in the
+runbook), the choice of metrics backend / exporter, SLO target numbers, and
+any code or chart change — this is a design note, not an implementation.
+
+---
+
+## 2. Personas
+
+Who consumes Lantern's signals, and the lens each one brings:
+
+| # | Persona | Core question | Horizon | Primary pillar |
+|---|---|---|---|---|
+| P1 | **Cluster operator / SRE** | Is the cluster healthy, and is it safe to roll / scale? | now → hours | metrics + health |
+| P2 | **On-call responder** | What broke, where, and what is the blast radius? | minutes | logs + traces |
+| P3 | **Application developer** (SDK / CLI / MCP) | Are my reads/writes correct and fast; is my data still there? | now → days | metrics + traces |
+| P4 | **Capacity / cost owner** | How is load growing, and what does the telemetry itself cost? | days → weeks | metrics (trends) |
+| P5 | **Maintainer / perf engineer** | Are there leaks, regressions, or pathological internals? | release → release | metrics + traces |
+
+These personas overlap in a small deployment (one person wears all five hats),
+but separating the *questions* keeps the signal catalogue honest: every signal
+should trace back to at least one persona's question.
+
+---
+
+## 3. User stories
+
+The catalogue in §5–§7 exists to answer these. Each story is tagged with the
+signal that answers it primarily; corroborating signals are noted in §5.
+
+**P1 — Cluster operator / SRE**
+
+- As an operator, I want to know **every pod is up and serving** so I can trust
+  the cluster. → liveness (`up`, the `grpc.health.v1.Health` / `/healthz` /
+  `/readyz` probes, `lantern_build_info`, and uptime derived from
+  `process_start_time_seconds`).
+- As an operator, I want to know **a rolling update recovered** — the new pod
+  rejoined and re-synced — before I proceed to the next pod. →
+  `lantern_peer_connected`, `lantern_snapshot_replayed_total`,
+  `lantern_vertices` / `lantern_edges` re-converging.
+- As an operator, I want to know **a pod death healed** (peer lost, then
+  re-applied the backlog) without my intervention. → `lantern_peer_connected`
+  (1→0→1), `lantern_replication_apply_total`.
+- As an operator, I want **early warning that a replica is falling behind**
+  before clients see stale reads. → `lantern_replication_lag_seq`,
+  `lantern_anti_entropy_gaps_found_total`, `lantern_mutation_log_fill_ratio`.
+
+**P2 — On-call responder**
+
+- As a responder, I want to know **which RPC is erroring and with what code**
+  so I can localise a fault. → `grpc_server_handled_total{grpc_code}`.
+- As a responder, I want to know **why a write was rejected** (bad input, rate
+  limit, tombstone clamp) so I can tell client bug from server back-pressure. →
+  `lantern_validation_rejected_total{reason}`, `lantern_rate_limit_rejected_total`,
+  `lantern_tombstone_clamp_rejected_total` + the matching slog lines.
+- As a responder, I want to know **whether replicas diverged** and against which
+  peer/origin. → `lantern_anti_entropy_gaps_found_total{peer,origin}` + the
+  `anti-entropy: gap exceeds warn threshold` log.
+- As a responder, I want a **per-request causal latency breakdown** for a slow
+  call. → traces (§7).
+
+**P3 — Application developer**
+
+- As a developer, I want to know my **read recall** — how often a key I ask for
+  is actually present (vs expired/absent). → `lantern_get_vertex_hits_total` /
+  `_misses_total`, `lantern_get_edge_hits_total` / `_misses_total`.
+- As a developer, I want to know **how aggressively my data is decaying** so I
+  can tune TTLs. → `lantern_ttl_expirations_total{kind}`, `lantern_vertices` /
+  `lantern_edges` trend.
+- As a developer, I want **p50/p99 latency for the method I call** so I can size
+  timeouts. → `grpc_server_handling_seconds{grpc_method}`.
+- As a developer, I want to know **my `Subscribe`/CDC consumer isn't dropping
+  events**. → `lantern_subscribe_dropped_total`,
+  `lantern_subscription_dropped_total{policy}`, `lantern_mutation_log_evicted_total`.
+
+**P4 — Capacity / cost owner**
+
+- As a cost owner, I want **graph-size and throughput trends** to plan memory. →
+  `lantern_vertices` / `lantern_edges`, `process_resident_memory_bytes`,
+  `grpc_server_started_total` rate.
+- As a cost owner, I want to know **what the telemetry itself costs** (series
+  count) so I can prune. → cardinality of the scrape (see §10).
+
+**P5 — Maintainer / perf engineer**
+
+- As a maintainer, I want to catch **memory / map leaks** across releases. →
+  `lantern_vertex_hlc_entries` / `_high_water`, `go_memstats_heap_inuse_bytes`,
+  `go_goroutines`.
+- As a maintainer, I want to know **GC and hot-path cost** under load. →
+  `lantern_gc_duration_seconds`, `lantern_illuminate_duration_seconds`,
+  `lantern_scan_duration_seconds`.
+
+---
+
+## 4. The three pillars — division of labour
+
+| Pillar | Shape | Answers | Cost driver | Don't use it for |
+|---|---|---|---|---|
+| **Metrics** | aggregated time series, bounded labels | "how much / how often / how fast / how full" — alerting & trends | series cardinality | per-event detail, anything keyed by a value |
+| **Logs** | discrete, timestamped, context-rich events | "what exactly happened, with which inputs" — the triage grep target | volume × retention | counting (use a metric), high-frequency hot paths |
+| **Traces** | causal spans across a request / propagation path | "where did the latency go, across which hop" | span volume × sampling | steady-state rates, sub-µs internal hops |
+| **Health** | binary liveness / readiness | "should the orchestrator route to / restart this pod" | — | anything graded or historical |
+
+**Guiding rule.** Every user story in §3 should have **one** primary pillar;
+the others corroborate. The runbook already leans on this — e.g. replication
+divergence *alerts* on a metric (`anti_entropy_gaps_found_total`) but is
+*triaged* on a log (`anti-entropy: gap exceeds warn threshold`). Resist
+re-implementing a log's job as a high-cardinality metric label, or a metric's
+job as a log you have to count.
+
+**Method lenses.** Two standard frames map cleanly onto Lantern:
+
+- **RED** (Rate, Errors, Duration) for the request-driven data plane → §5.2.
+- **USE** (Utilization, Saturation, Errors) for bounded resources — the
+  mutation-log ring buffer, the subscribe fan-out, the heap → §5.4, §5.9.
+
+The **four golden signals** (latency, traffic, errors, saturation) are the
+operator-facing subset; §10 distils the catalogue down to them for alerting.
+
+---
+
+## 5. Metrics taxonomy
+
+Organised by subsystem. Each group states the **question it answers**, the
+**persona**, and its **role** (liveness = page on it; RCA = reach for it during
+triage; capacity = trend it). Metric names below are the *current* ground truth
+(`server/metrics/metrics.go` and `server/provider/connect_middleware.go`);
+proposed gaps are deferred to §8. The exhaustive per-metric reference table
+lives in [`../server/README.md`](../server/README.md) — this section is the
+conceptual map, not a duplicate of it.
+
+### 5.1 Identity & liveness — "is this the build I think it is, and is it up?"
+
+*Persona P1 · role: liveness.* `lantern_build_info{version,commit,go_version}`
+(always 1; the labels carry the truth), `process_start_time_seconds` (→ uptime),
+the scrape's own `up`, and the `grpc.health.v1.Health` / `/healthz` / `/readyz`
+endpoints (§ health). These are the cheapest, highest-value signals: a missing
+`up` or a flapping `/readyz` is the first thing a pager should fire on.
+
+### 5.2 Data plane / RPC — RED for every call
+
+*Persona P2, P3 · role: liveness (errors) + RCA + capacity.* The Connect
+interceptor reproduces the canonical **`grpc_server_*`** family — names
+**frozen** for operator continuity even though the wire protocol is Connect, not
+gRPC (the historical `grpc-ecosystem` middleware was removed in #337/#352 but
+its vocabulary is an operator contract):
+
+- `grpc_server_started_total{grpc_type,grpc_service,grpc_method}` — **traffic**.
+- `grpc_server_handled_total{grpc_type,grpc_service,grpc_method,grpc_code}` —
+  **traffic + errors** (the `grpc_code` label is the error signal:
+  `not_found`, `resource_exhausted`, `invalid_argument`, …).
+- `grpc_server_handling_seconds{…}` (histogram) — **duration** (p50/p99).
+
+`grpc_type` is hard-coded `unary`; the streaming RPCs (`Subscribe`, `Snapshot`)
+are **not** metered here — they are visible only as listener-level spans (§7)
+and via the subscribe/snapshot domain metrics (§5.4). That asymmetry is a known
+gap (§8).
+
+### 5.3 Graph state & TTL decay — "what's in memory, and what's leaving?"
+
+*Persona P3, P4 · role: capacity + RCA.* `lantern_vertices`, `lantern_edges`
+(live counts — the headline gauges; **divergence between pods is the cluster's
+drift signal**), `lantern_ttl_expirations_total{kind=vertex|edge|dangling_edge}`
+(the decay rate — a sudden spike means a TTL cliff), and
+`lantern_gc_duration_seconds` (the cost of reaping). Together they answer "is
+the working set growing, decaying, or churning, and is GC keeping up?".
+
+### 5.4 Replication & HA — the heart of a leaderless cluster
+
+*Persona P1, P2 · role: liveness + RCA.* This is where Lantern's signals matter
+most, because correctness is *emergent* from convergence rather than enforced by
+a leader. Grouped by concern:
+
+- **Peering (liveness).** `lantern_peer_connected{peer}` — 1 while the local
+  pump holds a `Subscribe` to `peer`, 0 after disconnect, back to 1 on
+  reconnect. The single clearest "a peer died / healed" edge.
+  `lantern_subscribe_active_streams` is the inbound counterpart.
+- **Apply throughput (RCA).** `lantern_replication_apply_total{op}` (per
+  `MutationOp` — both remote and local applies) and
+  `lantern_replication_applied_total{origin}` (per originating node). After a
+  pod restart, watching every `op` row refill is how you *prove* the backlog
+  re-applied.
+- **Lag & convergence (liveness).** `lantern_replication_lag_seq{peer,origin}`
+  (in mutation-**seq** units, not seconds — set from `PeerStatus` probes) and
+  `lantern_anti_entropy_cycles_total` / `lantern_anti_entropy_gaps_found_total{peer,origin}`.
+  A rising gap is *the* divergence alert.
+- **Mutation-log back-pressure (saturation — USE).** `lantern_mutation_log_capacity`,
+  `lantern_mutation_log_fill_ratio` (≥ 0.8 sustained ⇒ slow subscribers risk
+  `ErrGapped` and a forced `Snapshot` reseed), `lantern_mutation_log_entries_total`,
+  `lantern_mutation_log_evicted_total`, and the subscriber-drop counters
+  `lantern_subscribe_dropped_total{reason}` /
+  `lantern_mutationlog_subscriber_dropped_total{cause}`.
+- **Bootstrap / reseed (RCA).** `lantern_snapshot_replayed_total{peer}` and the
+  `lantern_snapshot_{vertices,edges,duration_seconds}{peer}` histograms — how a
+  fresh or gapped pod re-seeded, and how expensive it was.
+- **Dropped frames (RCA).** `lantern_replication_dropped_total{peer,reason}`
+  (reasons: `self_echo`, `subscribe_failed`, `snapshot_failed`, `dial_failed`,
+  `peerstatus_failed`, `catchup_failed`, `ctx_cancel`, `clean`),
+  `lantern_origin_states_count` (distinct writers ever seen ≈ peer-set size).
+
+### 5.5 In-process pub/sub (client CDC) — "are local subscribers keeping up?"
+
+*Persona P3 · role: RCA + saturation.* Distinct from the cross-pod replication
+streams: `lantern_subscription_queue_depth` (histogram),
+`lantern_subscription_dropped_total{policy=drop_newest|drop_oldest|drop_newest_after_oldest}`,
+`lantern_subscription_dispatch_duration_seconds`. These answer whether a slow
+CDC consumer is shedding events and under which `FullPolicy`.
+
+### 5.6 Admission control & back-pressure — "what did we refuse, and why?"
+
+*Persona P2, P3 · role: RCA.* `lantern_validation_rejected_total{reason}` (the
+bounded reason set: `empty_key`, `key_too_long`, `empty_batch`,
+`batch_too_large`, `nil_item`, `bad_weight`, `step_too_large`, `k_too_large`,
+`bad_ttl`, `bad_cursor`, plus `unknown`), `lantern_rate_limit_rejected_total`
+(token-bucket `ResourceExhausted`; registered even when the limiter is off so
+deployments compare uniformly), `lantern_tombstone_clamp_rejected_total` (LWW
+lost against a live tombstone or newer value — a sustained rate flags clock skew
+or causally-late frames). The first separates *client bug* from *server
+saturation*; the last is a subtle correctness signal unique to the HLC model.
+
+### 5.7 Query subsystems — illuminate / scan / search
+
+*Persona P3, P5 · role: RCA + capacity.* Hot-path histograms, label-pre-warmed
+so dashboards render the full variant set from process start:
+
+- **Illuminate** (graph walk): `lantern_illuminate_visited_vertices` /
+  `_visited_edges` / `_duration_seconds`, labelled by the orthogonal axes
+  `algorithm × objective × weighting` (12 combos, #410) plus a `phase`
+  (`traversal` | `optimize`) on duration.
+- **Scan / count**: `lantern_scan_results{op}`, `lantern_scan_duration_seconds{op}`.
+- **Search** (optional index): `lantern_search_results`,
+  `lantern_search_duration_seconds`, and the index-size gauges
+  `lantern_search_index_terms` / `_docs` (0 unless `LANTERN_SEARCH_ENABLED`).
+- **Batch shape**: `lantern_batch_size{op}` — the plural-RPC item count, so a
+  "slow write" can be split into "large batch" vs "slow per-item".
+
+### 5.8 Recall quality & dedup — "is the cache actually answering?"
+
+*Persona P3 · role: RCA + product-health.* `lantern_get_vertex_hits_total` /
+`_misses_total` and the edge pair give recall ratio = `hits/(hits+misses)`; a
+falling ratio means TTLs are too short or clients are asking for the wrong keys.
+`lantern_edge_contrib_deduped_total` confirms idempotent `AddEdge` retries are
+being suppressed (not double-counting weight, #588).
+
+### 5.9 Internal health — leaks, GC, runtime
+
+*Persona P5 · role: RCA + regression watch.* The per-structure cardinality
+gauges `lantern_vertex_hlc_entries` and `lantern_vertex_hlc_entries_high_water`
+(the LWW watermark map — monotonic growth across GC ticks was the #700 leak
+fingerprint), alongside the standard `go_*` (goroutines, heap, GC) and
+`process_*` (RSS, CPU, FDs) collectors. These rarely page, but they are the
+first place a maintainer looks when "it gets slower / fatter over days".
+
+---
+
+## 6. Logs
+
+**Model.** Structured `log/slog`, JSON by default. Two tiers:
+
+1. **Per-RPC** (`LoggingInterceptor`) — one `info` "started call" and one `info`
+   "finished call" per unary RPC, with keys deliberately retaining the
+   `grpc.*` prefix (`grpc.method`, `grpc.code`, `grpc.duration_ms`) for
+   log-search continuity.
+2. **Targeted channels** (#223) — discrete operational events worth grepping
+   without a metrics stack. The current set (see [`../server/README.md`](../server/README.md)
+   for the canonical table):
+
+| Message | Level | Trigger | Key attrs |
+|---|---|---|---|
+| `slow rpc` | warn | handler exceeded `LANTERN_SLOW_RPC_THRESHOLD_MS` | `method`, `code`, `duration_ms`, `threshold_ms` |
+| `validation rejected` | debug | validation interceptor returned `InvalidArgument` | `reason`, `error` |
+| `graph cache: gc tick` | info | every `GraphCache.Watch` tick | `vertices_expired`, `edges_expired`, `dangling_edges_removed`, `vertices_remaining`, `edges_remaining`, `duration_ms` |
+| `anti-entropy: gap exceeds warn threshold` | warn | per-origin gap over threshold | `origin`, `gap`, `threshold` |
+| `replication pump: peer transition` | info/warn | connect / disconnect / snapshot start / finish | `peer`, `transition`, `reason` |
+| `pubsub: drop {newest,oldest}` | warn | subscription channel full | drop policy context |
+
+**What logs answer that metrics can't.** The *specific* input that tripped a
+rejection, the *exact* peer transition sequence during a flap, the error string
+behind a code. Every targeted channel is paired with a metric (the metric
+alerts; the log explains) — that pairing is the design intent, not redundancy.
+
+**Correlation.** Attach bounded, joinable context: `grpc.method`, `grpc.code`,
+`peer`, `origin`, and at most a **key *prefix*** — never the full key, and
+**never the value**. Today logs carry no trace/span id, so logs↔traces cannot be
+joined; closing that is a §8 proposal.
+
+**Levels policy.** `error` = operator must act; `warn` = degraded but
+self-healing (slow rpc, peer flap, drops); `info` = lifecycle + per-call;
+`debug` = high-volume detail (validation rejects) off by default. **What not to
+log:** full keys/values (cardinality + sensitivity), anything per-mutation on
+the apply hot path (use a counter), secrets/TLS material.
+
+---
+
+## 7. Traces
+
+**Model.** OpenTelemetry via `otelhttp.NewHandler` wrapped around the h2c
+listener (`server/provider/lantern_listener.go`), so **every** request —
+Connect, gRPC, gRPC-Web, health, reflection — gets a server-side span with no
+per-handler wiring. Export is **opt-in and zero-overhead when off**: a provider
+is installed only when `OTEL_EXPORTER_OTLP_ENDPOINT` (or the trace-specific
+variant) is set; otherwise the global tracer stays noop. `OTEL_EXPORTER_OTLP_PROTOCOL`
+selects `grpc` (default) or `http/protobuf`; W3C `tracecontext` + `baggage`
+propagation is installed so spans link across services; the provider is flushed
+on graceful shutdown (`server/provider/tracing.go`).
+
+**What traces answer that metrics/logs can't.** The **causal latency
+breakdown** of a single slow call, and — uniquely for Lantern — the propagation
+path of a write as it crosses peers. Metrics tell you p99 rose; a trace tells
+you *which hop* (handler vs lock vs fan-out) owns the regression.
+
+**Current coverage & gaps.** Today there is exactly **one span per request** at
+the listener; there are **no internal child spans** (illuminate phases, the
+apply path, snapshot replay) and the streaming RPCs get only the outer span. So
+traces currently answer "which RPC was slow" but not "which *phase* of it" — a
+§8 candidate, and one to apply **selectively**.
+
+**When tracing earns its keep — and when it doesn't.** Lantern's hot paths are
+sub-millisecond in-memory operations; a span per internal hop would cost more
+than it reveals and inflate export volume. The high-value targets are the
+**slow, branchy paths** (illuminate traversal+optimize, snapshot replay) and the
+**cross-peer propagation** path, sampled at a low rate. The steady-state
+per-mutation apply loop is explicitly **not** a tracing target (§9) — its health
+is a counter (`lantern_replication_apply_total`), not a span.
+
+---
+
+## 8. Ideal vs current — proposed additions
+
+Not bound by the current implementation. Each candidate names the question it
+unlocks, the persona, the cost, and a verdict. **None are implemented here** —
+they are the backlog this design argues for, each worth its own issue.
+
+| # | Candidate signal | Question it answers | Persona | Cost | Verdict |
+|---|---|---|---|---|---|
+| A | **Replication propagation latency** (wall-clock, from write-accept on A to apply on B; derive from the HLC delta) | "How stale *in seconds* can a replica be?" — `lag_seq` only gives seq distance | P1 | medium (plumb HLC time into the apply hook) | **worth it** |
+| B | **Per-method in-flight gauge** (`grpc_server_in_flight{grpc_method}`) | "Which handler is stuck / saturating right now?" | P2 | low (bounded by method count) | **worth it** |
+| C | **trace_id / span_id in slog records** (from context) | "Jump from this log line to its trace" — joins two pillars | P2 | low | **worth it** |
+| D | **Selective internal spans** (illuminate phases, snapshot replay) | "Which *phase* of a slow call owns the latency" | P3, P5 | medium; sample low | **worth it (selective)** |
+| E | **Backup / restore metrics** (snapshot-to-disk count/bytes/duration, restore outcome) — currently a durability blind spot in metrics (logs only) | "Did the periodic dump succeed; did restore-on-start replay?" | P1 | low | **worth it** |
+| F | **Subscribe fan-out backlog gauge** (per-subscriber lag, ahead of `ErrGapped`) | "Which subscriber is about to gap?" — earlier than the drop counter | P1, P3 | low (per-peer, bounded) | **maybe** |
+| G | **Readiness-transition counter** (`/readyz` flips) | "Is readiness flapping?" — alert on the edge, not the level | P1 | low | **maybe** |
+| H | **Cross-replica divergence gauge** (applied-seq spread per origin) | "Are replicas in sync, in one query?" | P1 | low–med | **maybe** — likely a Prometheus recording rule over existing signals, not a new metric |
+| I | **Value-kind distribution** (mix of stored value types) | "What kind of data lives here?" | P4 | med (risk of cardinality) | **defer** — product analytic, better as a sampled log/exemplar than a metric |
+
+Verdicts are deliberately conservative: B, C, E are cheap wins; A and D are the
+high-value-but-non-trivial ones; H argues *against* a new metric when a derived
+rule suffices.
+
+---
+
+## 9. Anti-patterns — signals we deliberately don't build
+
+Choosing **not** to implement is part of the design. These are ruled out on
+purpose:
+
+- **Per-key / per-vertex / per-edge metric labels.** Unbounded cardinality —
+  the fastest way to melt a Prometheus. Key-shaped questions belong in logs (as
+  a *prefix*) or traces, never in a label.
+- **Labels that grow with data, not with topology.** `peer` and `origin` are
+  acceptable because they are bounded by cluster size; a label bounded by row
+  count is not. New labels must be justified against a fixed, small domain.
+- **Full keys or values in logs.** Cardinality *and* sensitivity. Log a prefix
+  or a hash; never the payload.
+- **A span per internal hot-path hop.** For sub-millisecond in-memory ops the
+  span overhead and export volume dwarf the insight. Trace the slow, branchy
+  paths only (§7).
+- **Metrics with no owner and no action.** If no persona in §2 would alert or
+  dashboard on it, it is noise that still costs ingestion. Every signal needs a
+  question from §3.
+- **Re-implementing a log as a high-cardinality metric** (or a metric as a log
+  you have to count). Pick the right pillar once (§4).
+- **Server-side per-client-call vanity metrics.** Client-side latency/retry
+  accounting belongs in the SDK, not baked into every server label set.
+
+---
+
+## 10. Signal selection — liveness vs RCA vs cost
+
+The catalogue is large by design; consumption should be tiered. Three views:
+
+- **Liveness / alerting (page on these).** The four golden signals, distilled:
+  `up` and health probes (availability); `grpc_server_handled_total{grpc_code}`
+  error ratio + `grpc_server_handling_seconds` p99 (errors + latency);
+  `lantern_peer_connected` and `lantern_replication_lag_seq` /
+  `anti_entropy_gaps_found_total` (HA liveness); `lantern_mutation_log_fill_ratio`
+  and `lantern_rate_limit_rejected_total` (saturation).
+- **RCA / dashboards (reach for these during triage).** Everything in §5.4–§5.8
+  plus the per-channel logs (§6) and, when enabled, traces (§7).
+- **Capacity / cost (trend these).** `lantern_vertices` / `lantern_edges`,
+  RPC rate, `process_resident_memory_bytes`, and the leak gauges (§5.9).
+
+**The cost lens.** Counter-intuitively, the generic `go_*` / `process_*` /
+`promhttp_*` collectors are *not* the bulk of the scrape. Measured on an idle
+single pod they are only ~40 series (~4%), while the `lantern_*` families are
+~95% of the ~960-series total — dominated by the illuminate/scan **histograms**,
+whose `_bucket` series (`lantern_illuminate_duration_seconds`,
+`lantern_illuminate_visited_vertices`, `lantern_illuminate_visited_edges`, plus
+the `lantern_scan_*` / `lantern_batch_size` families) account for several hundred
+series on their own. So a scrape-time **keep-allowlist** — every `lantern_*` and
+`grpc_server_*` (the latter emitted *lazily*, only once the first unary RPC
+creates its labelled children) plus a minimal runtime subset (`up`,
+`go_goroutines`, `go_memstats_heap_inuse_bytes`, `process_resident_memory_bytes`,
+`process_cpu_seconds_total`), dropping the rest — is **signal curation, not a
+major ingestion-cost lever**: it removes the generic collectors that carry no
+Lantern-specific signal, but since those are only ~4% of series it barely moves
+the bill. The real cardinality dial is the histogram bucket layout, not the
+collector set. The allowlist still earns its place — every liveness/RCA signal
+above survives it — and wiring it into the deployment (a GMP `PodMonitoring`
+`metricRelabeling`) is a deployment-layer change, kept out of this design note.
+
+---
+
+## 11. Open questions & next steps
+
+- File one tracking issue per §8 candidate (B/C/E first — cheap wins).
+- Decide §8-H (divergence) as metric vs recording rule before building it.
+- Land the §10 signal-curation allowlist as a deployment-layer change once the
+  signal set here is ratified (it curates the scrape to Lantern-specific signal;
+  it is not a major ingestion-cost saving).
+- Keep this note in sync with `server/metrics/metrics.go` and the runbook: when
+  a signal is added or renamed pre-v1.0.0, amend §5 in the same PR.

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -142,10 +142,11 @@ remote `nodeID` is only used by the comparator in §5.4.
 
 If `r.wallNs > now + MaxSkew` (default `MaxSkew = 500ms`, per D3), the wall
 component is **clamped** to `now + MaxSkew` and an `OnSkewExceeded` callback
-fires (default wiring: increment `lantern_hlc_skew_clamped_total`). The
-remote timestamp is never rejected — replication keeps making progress even
-when peers drift, and operators observe the drift through the counter and
-are expected to fix NTP. (Earlier drafts of this RFC rejected with
+fires. The intended default wiring increments `lantern_hlc_skew_clamped_total`,
+but that counter is **not yet wired** (the provider leaves `OnSkewExceeded`
+nil — see #180 and #182); until then, monitor NTP directly. The remote
+timestamp is never rejected — replication keeps making progress even when
+peers drift, and operators are expected to fix NTP. (Earlier drafts of this RFC rejected with
 `OutOfRange`; that was changed during #176 implementation because rejecting
 risks a cascading replication stall while the clock heals.)
 
@@ -489,7 +490,7 @@ spec:
 ```
 
 Scale the StatefulSet up/down and observe
-`lantern_replication_peer_up{peer=...}` add/remove series within one
+`lantern_peer_connected{peer=...}` add/remove series within one
 discovery interval.
 
 **Manual verification recipe (Docker Compose).**
@@ -536,10 +537,10 @@ The [HA runbook](ha-runbook.md) describes detection (`lantern_replication_lag_se
 | Failure | Detection | Recovery |
 |---|---|---|
 | Single pod crash | k8s probe / Compose healthcheck | k8s/Compose restarts pod → bootstraps from peers. |
-| Pod falls behind > buffer | `Subscribe` returns `OutOfRange` | Pump auto re-snapshots and resumes. |
+| Pod falls behind > buffer | `Subscribe` returns `FailedPrecondition` (reason `gapped`) | Pump auto re-snapshots and resumes. |
 | All peers unreachable on boot | `Snapshot` fails on every peer | Pod stays `NOT_SERVING`; operator alert on readiness. |
 | Total-cluster loss | every replica down | **Accepted data loss** (D1) — bring the cluster back empty, *or* run snapshot backups (`LANTERN_BACKUP_*`, [backup.md](backup.md)) so each node restores its newest dump on boot. |
-| NTP skew > 500ms | `lantern_hlc_skew_clamped_total > 0` | Fix NTP. Mutations from the drifted peer keep applying (their HLC wall is clamped, §5.3); convergence is preserved but the drifted peer's stamps land behind real wall time until it heals. |
+| NTP skew > 500ms | `lantern_hlc_skew_clamped_total > 0` (planned — #180/#182) | Fix NTP. Mutations from the drifted peer keep applying (their HLC wall is clamped, §5.3); convergence is preserved but the drifted peer's stamps land behind real wall time until it heals. |
 | Network partition < tombstone TTL | `lantern_replication_lag_seq` spike | Auto-converges via anti-entropy (#186) when partition heals. |
 | Network partition > tombstone TTL | same | Resurrection possible (§10). Manual reconciliation or operator-driven re-snapshot of the winning side. |
 

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -74,7 +74,7 @@ is required for either reads or writes.
 | D4 | Tombstone TTL | **Cluster-wide config, default 1 year (8760h).** Any `Add*` / `Put*` whose TTL would exceed tombstone TTL is **rejected** with `InvalidArgument`. | Resurrection-proof deletes require tombstones to outlive every live contribution. This is a real backwards-incompatible constraint. |
 | D5 | Workload kind (k8s reference impl) | **StatefulSet** (not Deployment). | Stable pod identity simplifies peer discovery; leaves room for an optional WAL PVC later. The *user experience* is Deployment-like; the *resource kind* is `StatefulSet`. |
 | D6 | Cluster membership v1 | **Static `LANTERN_PEERS` env var.** v2 adds DNS-based discovery (#190). | Smallest surface that ships. Any DNS-routable platform (k8s headless Service, Compose service name, Nomad, plain DNS A-records) can populate it trivially. |
-| D7 | Supported deployment topologies | **Tier A (full HA):** k8s StatefulSet, Nomad, plain VMs, Docker Compose with stable peer hostnames. **Tier B (single-instance, no HA):** any container PaaS — Docker Compose single service, Cloud Run, Azure Container Apps, App Runner. **Not supported:** running multiple Cloud Run / ACA *instances* as a replicated cluster. | Leaderless P2P needs **stable inter-instance addressing** and **long-lived inbound gRPC streams between peers**. Serverless container platforms intentionally hide instance addresses and recycle instances; they fit single-instance deploys (still useful as a fast in-memory KVS) but not the replicated topology. |
+| D7 | Supported deployment topologies | **Full HA:** k8s StatefulSet, Nomad, plain VMs, Docker Compose with stable peer hostnames. **Single-instance (no HA):** any platform without stable per-instance addressing — Docker Compose single service, or any container runtime that hides/recycles instance addresses. **Not supported:** running multiple address-hidden instances as a replicated cluster. | Leaderless P2P needs **stable inter-instance addressing** and **long-lived inbound gRPC streams between peers**. Platforms that intentionally hide instance addresses and recycle instances fit single-instance deploys (still useful as a fast in-memory KVS) but not the replicated topology. |
 
 ## 4. CRDT semantics per RPC
 
@@ -554,9 +554,7 @@ carries the full per-platform instructions; this is the summary.
 | Docker Compose (explicit `lantern-N` services + shared DNS alias) | ✅ | ✅ | Example in `deploy/compose/` (#191, #435). Best for local dev / single-host. |
 | Nomad + Consul DNS | ✅ | ✅ | User-configured; same `LANTERN_PEER_DISCOVERY=dns` works. |
 | Plain VMs / bare metal | ✅ | ✅ | Static `LANTERN_PEERS` CSV or DNS round-robin. |
-| Google Cloud Run | ❌ HA not supported | ✅ | Instance-level addressing hidden; long-lived peer streams incompatible with the request-scoped lifecycle. Use as a fast in-memory KVS with CDC via `Subscribe`. |
-| Azure Container Apps | ❌ HA not supported | ✅ | Same reason as Cloud Run. Single-revision, single-replica works fine. |
-| AWS App Runner / Fly Machines (autoscale) | ❌ HA not supported | ✅ | Same reason. |
+| Platforms that hide per-instance addresses (autoscaled, request-scoped runtimes) | ❌ HA not supported | ✅ | Instance-level addressing hidden; long-lived peer streams incompatible with the request-scoped lifecycle. Use as a fast in-memory KVS with CDC via `Subscribe`. |
 
 For every "not supported" platform, the **single-instance** deploy is fully
 supported: leave `LANTERN_PEERS` empty, the server runs without a pump, the
@@ -571,8 +569,8 @@ external WAL consumer are in place.
 - Cross-DC replication (D3).
 - ACL-gated `Subscribe` for external CDC consumers (D2 ships the unified RPC;
   policy is layered later).
-- Multi-instance Cloud Run / ACA support (D7 — fundamental platform
-  incompatibility, not a v2 backlog item).
+- Multi-instance support on platforms that hide per-instance addressing
+  (D7 — fundamental platform incompatibility, not a v2 backlog item).
 
 ---
 

--- a/server/backup/backup.go
+++ b/server/backup/backup.go
@@ -3,9 +3,8 @@
 // plus restore-on-startup that re-seeds the in-memory graph from the newest
 // dump before the server begins serving. It is the automation layer on top
 // of the on-demand backup/restore primitives shipped in #685 — the
-// rolling-update insurance for single-instance (Tier B) Cloud Run / ACA
-// deploys where the in-memory graph would otherwise be lost on every
-// revision rotation.
+// rolling-update insurance for single-instance deploys where the
+// in-memory graph would otherwise be lost on every restart.
 //
 // Reuse, not reinvention: the periodic dump drives the existing
 // LanternService.BackupSnapshot RPC verbatim through a file-backed Sender,
@@ -15,9 +14,9 @@
 // apply automatically — an entry whose TTL already elapsed since the dump
 // is correctly NOT resurrected.
 //
-// Shared storage is never assumed safe for concurrent writes (Cloud Run
-// GCS FUSE / NFS have no file locking; ACA Azure Files leaves multi-writer
-// coordination to the app), so every writer owns a per-instance file
+// Shared storage is never assumed safe for concurrent writes (networked
+// or FUSE-backed filesystems generally have no reliable file locking), so
+// every writer owns a per-instance file
 // (name carries InstanceID) and restore selects the newest valid file.
 // Writes are atomic via a temp file + rename; a half-written file is never
 // a restore candidate.

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -465,10 +465,10 @@ func newMetricsMux(reg *prometheus.Registry, gate *readiness.Gate, enablePprof b
 		_, _ = w.Write([]byte("ok"))
 	})
 	// /readyz and /healthz/ready both consult the readiness Gate so HTTP
-	// probes (k8s httpGet, Cloud Run / ACA startup probes, plain LB
+	// probes (k8s httpGet, container-platform startup probes, plain LB
 	// health probes) see the same drain signal as the `grpc.health.v1`
 	// overall ("") entry served on the primary listener. Single-instance
-	// mode returns 200 immediately — PaaS startup behaviour is unchanged.
+	// mode returns 200 immediately — platform startup behaviour is unchanged.
 	readyHandler := func(w http.ResponseWriter, _ *http.Request) {
 		if gate == nil || gate.Ready() {
 			w.WriteHeader(http.StatusOK)

--- a/server/readiness/gate.go
+++ b/server/readiness/gate.go
@@ -10,7 +10,7 @@
 //
 // Single-instance mode (no peers configured) bypasses gating entirely: the
 // Gate is born already-ready and any subsequent SetLag calls are no-ops.
-// This preserves the PaaS startup contract — empty LANTERN_PEERS means the
+// This preserves the platform startup contract — empty LANTERN_PEERS means the
 // readiness probe goes green as soon as the server is up.
 package readiness
 

--- a/server/replication/antientropy.go
+++ b/server/replication/antientropy.go
@@ -109,7 +109,7 @@ type AntiEntropyConfig struct {
 
 	// HTTPClient is the http.Client used to open Connect-Go streams
 	// against each peer. Defaults to defaultH2CClient() (plaintext
-	// HTTP/2 for the in-cluster Tier-A topology).
+	// HTTP/2 for the in-cluster HA topology).
 	HTTPClient *http.Client
 
 	// Logger receives lifecycle events. slog.Default() when nil.

--- a/server/replication/discovery.go
+++ b/server/replication/discovery.go
@@ -65,10 +65,9 @@ type HostLookup interface {
 // replica), HashiCorp Nomad service discovery via Consul DNS, or any
 // plain DNS round-robin A-record list.
 //
-// Serverless container PaaS that do not expose per-instance DNS
-// (Cloud Run, ACA, App Runner) remain explicitly unsupported as
-// multi-instance topologies — see RFC #175 §D7. Those deployments
-// keep using single-instance mode (empty peer list).
+// Platforms that do not expose per-instance DNS remain explicitly
+// unsupported as multi-instance topologies — see RFC #175 §D7. Those
+// deployments keep using single-instance mode (empty peer list).
 type DNSSource struct {
 	// Name is the DNS hostname to resolve (no port). Example:
 	// "lantern-headless.default.svc.cluster.local".

--- a/server/replication/h2c.go
+++ b/server/replication/h2c.go
@@ -4,7 +4,7 @@
 // AntiEntropyConfig.HTTPClient.
 //
 // The default speaks HTTP/2 over plaintext (h2c) so the cluster-internal
-// replication path (Tier-A topology) works without TLS plumbing.
+// replication path (HA topology) works without TLS plumbing.
 // Operators that need TLS supply their own http.Client backed by an
 // http2.Transport with a real *tls.Config.
 //

--- a/server/replication/pump.go
+++ b/server/replication/pump.go
@@ -25,9 +25,8 @@
 // must filter their own writes back out.
 //
 // LANTERN_PEERS="" (the default) yields a no-op pump: Run returns
-// immediately and no goroutines are spawned. This is the
-// single-instance mode used on serverless PaaS (Cloud Run / ACA);
-// the rest of the server behaves identically.
+// immediately and no goroutines are spawned. This is single-instance
+// mode; the rest of the server behaves identically.
 package replication
 
 import (
@@ -141,7 +140,7 @@ type Config struct {
 	// HTTPClient is the http.Client used to open Connect-Go streams
 	// against each peer. When nil, defaultH2CClient() is used so the
 	// pump talks plain HTTP/2 over the cluster network — sufficient
-	// for the Tier-A topology where peers are only reachable via the
+	// for the HA topology where peers are only reachable via the
 	// cluster network. For TLS, supply an http.Client backed by an
 	// http2.Transport with a real *tls.Config.
 	HTTPClient *http.Client


### PR DESCRIPTION
## What

This branch bundles the GKE Autopilot Helm work with a documentation-accuracy
pass. Six commits, grouped:

### Helm / GMP (feature)
- `feat(helm): rework chart for minimal GKE Autopilot deployment` — slims the
  chart down to what Autopilot actually needs.
- `feat(helm): add opt-in GMP PodMonitoring for GKE Managed Service for
  Prometheus` — opt-in `PodMonitoring` for GMP.
- `feat(helm): add opt-in GMP metricRelabeling allowlist to PodMonitoring` —
  opt-in allowlist (exact-name `keep` matchers, GMP managed API). Verified live
  on `lantern-cluster-01` (asia-northeast1): allowlist active at helm rev 3,
  KEEP/DROP empirically confirmed against the running collector.

### Docs (accuracy)
- `docs: drop serverless-platform (Cloud Run/ACA) references` — removes stale
  serverless platform guidance (README, deploy/compose, docs/*) plus a few
  comment-only Go touch-ups (behaviourally no-op).
- `docs: align HA/deploy docs with implemented metric names and reasons` — the
  main discrepancy sweep. Every fix cross-checked against
  `server/metrics/metrics.go`, `connect_middleware.go`,
  `service/replication.go`, and `replication/pump.go`:
  - `lantern_replication_peer_up` → `lantern_peer_connected` (the former never
    existed) in the helm README, compose README, and replication.md.
  - `grep peer_discovery` → `grep "peer transition"` — the pump logs
    `replication pump: peer transition`; there is no `peer_discovery` token.
  - `lantern_replication_lag` → `lantern_replication_lag_seq`.
  - subscribe drop reason `out_of_range` → `gapped`; the gapped subscribe path
    surfaces `FailedPrecondition`, not `OutOfRange`.
  - ha-runbook §4 metric table: `lag_seq` gains `{origin}`; `applied_total` is
    `{origin}`; `dropped_total` reason set matches `metrics.go`; `build_info`
    gains `go_version`; `grpc_server_*` family is (started / handled / handling
    time) — no `received`/`sent`.
  - removed the `LANTERN_MUTATION_LOG_CAPACITY` "(if/when the env knob exists)"
    hedge — the knob exists (default 100000).
  - `lantern_hlc_skew_clamped_total` marked **planned (#180/#182)** — the
    `OnSkewExceeded` hook is intentionally left nil today.
  - stale `HA runbook: see issue #192 (in flight)` link → `docs/ha-runbook.md`.
- `docs: add observability design note` — new `docs/observability.md` design
  draft (implemented series + labels, log-token conventions, a cost lens, and a
  backlog of not-yet-implemented metrics).

## Notes
- The `docs: add observability design note` commit is self-contained and can be
  dropped from this PR if you'd rather land the observability note separately.
- Doc-only edits are issue-first-exempt; the helm commits implement the
  GKE-Autopilot/GMP enablement work already validated against the live cluster.

## Verification
- `gofmt -l .` clean (no Go changed in the doc commits).
- Repo-wide grep confirms zero remaining stale tokens
  (`replication_peer_up`, `peer_discovery` log refs, `out_of_range`,
  `older_hlc`, bare `lantern_replication_lag`, `received / sent`).
