### PR TITLE
docs(lantern-ops): document Homebrew install as first-choice CLI path

### DIFF
--- a/.github/skills/lantern-ops/SKILL.md
+++ b/.github/skills/lantern-ops/SKILL.md
@@ -17,21 +17,33 @@ as a scriptable subcommand plus an interactive REPL.
 
 ## Invoking the CLI
 
-From inside this repo (no install needed):
+On **macOS** the lowest-friction path is the Homebrew cask — it installs a
+released, prebuilt `lantern-cli` binary with no Go toolchain or repo checkout
+required (first choice):
+
+```shell
+brew tap anaregdesign/tap
+brew install --cask lantern-cli    # installs the `lantern-cli` binary
+```
+
+On Linux/Windows, grab the `lantern-cli` binary attached to any GitHub Release.
+The Go-toolchain / in-repo routes below are the build-from-source fallback.
+
+From inside this repo (no install, but needs the Go toolchain):
 
 ```shell
 go run ./cli <args>                 # recompiles each call; fine for one-offs
 ```
 
-Build once, then reuse the binary (preferred for repeated calls):
+Build once, then reuse the binary (preferred for repeated calls from a checkout):
 
 ```shell
 go build -o lantern-cli ./cli
 ./lantern-cli <args>
 ```
 
-A released binary and the in-repo build above are both named `lantern-cli`.
-**All examples below use `lantern-cli <args>`** — substitute
+The Homebrew/release binary and the in-repo build above are all named
+`lantern-cli`. **All examples below use `lantern-cli <args>`** — substitute
 `go run ./cli <args>` or `./lantern-cli <args>` as appropriate.
 
 Default target is **`http://localhost:6380`** over plaintext h2c, which matches


### PR DESCRIPTION
## Summary

Reframes the **"Invoking the CLI"** section of
`.github/skills/lantern-ops/SKILL.md` so the released, prebuilt `lantern-cli`
binary is the first-choice acquisition path instead of an afterthought.

Previously the section described only the Go-toolchain routes
(`go run ./cli` / `go build -o lantern-cli ./cli`), implying a build step is
mandatory even though the CLI ships as a Homebrew cask from
`anaregdesign/homebrew-tap` (already documented in README → "Install via
Homebrew (macOS)").

## Changes

- Lead with the Homebrew cask as the **first choice on macOS** (no Go toolchain
  or checkout required):

  ```shell
  brew tap anaregdesign/tap
  brew install --cask lantern-cli    # installs the `lantern-cli` binary
  ```
- Point Linux/Windows users at the `lantern-cli` binary attached to each GitHub
  Release.
- Reframe `go run ./cli` / `go build -o lantern-cli ./cli` as the
  build-from-source / in-repo fallback rather than the default.
- Keep the existing "all examples use `lantern-cli <args>`" note and the
  unchanged default-target / global-flags content.

Docs-only change (skill reference text); the `brew` commands match the README
verbatim.

Closes #799
