### PR TITLE
fix(core/concurrent/pubsub): drop vestigial watch s.wg.Wait() racing worker Add(1)

### DIFF
--- a/core/concurrent/pubsub/subscription.go
+++ b/core/concurrent/pubsub/subscription.go
@@ -338,7 +338,18 @@ func (s *Subscription[T]) watch(ctx context.Context, interval time.Duration, ttl
 		case <-ticker.C:
 			s.salvage(interval, ttl)
 		case <-ctx.Done():
-			s.wg.Wait()
+			// Do NOT wait on s.wg here. s.wg counts the worker pool, and its
+			// Add(1) calls run in Subscribe's worker loop *after* this
+			// goroutine was spawned (the `go s.watch(...)` happens-before edge
+			// only covers code before the spawn). A Wait from this goroutine
+			// therefore has no happens-before to the first worker Add(1); an
+			// early ctx cancellation that lands here before worker
+			// registration finishes is a WaitGroup Add-concurrent-with-Wait
+			// misuse the race detector flags (#806). Subscribe already joins
+			// the workers via its own s.wg.Wait() before unregistering, so
+			// this Wait was both redundant and racy — vestigial from the
+			// pre-#231 one-goroutine-per-message model where s.wg counted
+			// in-flight handlers.
 			return
 		}
 	}

--- a/core/concurrent/pubsub/subscription_test.go
+++ b/core/concurrent/pubsub/subscription_test.go
@@ -82,6 +82,32 @@ func TestSubscription_Subscribe(t *testing.T) {
 			wg.Wait()
 		})
 	}
+
+	// Regression for #806: watch's ctx.Done path used to call s.wg.Wait(),
+	// which has no happens-before to Subscribe's per-worker s.wg.Add(1). An
+	// already-cancelled context lands watch on that path while Subscribe is
+	// still registering workers, so the Add raced the Wait under the race
+	// detector. With the vestigial Wait removed, Subscribe must still return
+	// promptly and cleanly. concurrency > 1 widens the worker-registration
+	// window the cancelled watch used to race against. Run under -race.
+	t.Run("CancelBeforeWorkerRegistration", func(t *testing.T) {
+		topic := NewTopic[int]("cancel-race")
+		sub := topic.NewSubscription("s", 8, time.Minute, time.Minute)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Done before Subscribe runs: watch takes its ctx.Done path immediately.
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			sub.Subscribe(ctx, func(*Message[int]) {})
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Subscribe did not return after an already-cancelled ctx")
+		}
+	})
 }
 
 func TestSubscription_Topic(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a **flaky data race** in `core/concurrent/pubsub` that the CI race
detector (`go test -race -shuffle=on`) surfaced as an intermittent
`TestSubscription_Subscribe` failure (seen once on an unrelated PR, #804, and
re-ran green). Root cause is a genuine `sync.WaitGroup`
`Add`-concurrent-with-`Wait` misuse, not test-only flake.

## Root cause

`Subscription.watch` waited on the subscription WaitGroup on cancellation:

```go
case <-ctx.Done():
    s.wg.Wait()   // <-- racy
    return
```

But `s.wg` counts the **worker pool**, whose `Add(1)` calls run in
`Subscribe`'s worker loop **after** `watch` was spawned (`go s.watch(...)`).
The spawn's happens-before edge only covers code *before* the `go` statement, so
`watch`'s `Wait` had **no happens-before to the first worker `Add(1)`**. The test
context has a 50 ms timeout, so on a loaded CI runner `watch` could reach its
`ctx.Done()` branch and call `s.wg.Wait()` while `Subscribe` was still doing the
first `s.wg.Add(1)` on a zero counter — exactly the misuse the `sync.WaitGroup`
docs forbid, which the race detector flags.

`watch`'s `s.wg.Wait()` is **vestigial**: it dates from the pre-#231
one-goroutine-per-message model where `s.wg` counted in-flight handlers. The
worker-pool refactor (#231) repurposed `s.wg` for the fixed worker goroutines
and added the authoritative `s.wg.Wait()` in `Subscribe` itself, which already
joins the workers before unregistering. `watch`'s own `Wait` became redundant
and racy.

## Fix

- Remove the `s.wg.Wait()` from `watch`'s `ctx.Done()` branch — `watch` now just
  returns. Workers are still correctly joined by `Subscribe.s.wg.Wait()`; `watch`
  no longer touches `s.wg`, closing the Add-concurrent-with-Wait window.
- Add a deterministic regression sub-test (`CancelBeforeWorkerRegistration`):
  an already-cancelled context plus concurrency 8 forces `watch` onto its
  `ctx.Done()` path while `Subscribe` registers workers. **Verified it
  reproduces the `DATA RACE` under `-race` with the old code and is clean after
  the fix** (30/30 `-race -shuffle` runs of the package green).

## Verification

- `core` module: `go test -race ./...` green; `gofmt`/`go vet`/`golangci-lint`
  (v2.12.2) clean on the package.
- `server` (the only importer of `pubsub`), `sdks/go`, `mcp`, `pb`, root: all
  `go test ./...` green.

Closes #806
