### PR TITLE
chore(release): bump module pins for cascade #9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.4.0
-	github.com/anaregdesign/lantern/core v0.13.0
+	github.com/anaregdesign/lantern/core v0.14.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
-	github.com/anaregdesign/lantern/pb v0.8.0
-	github.com/anaregdesign/lantern/sdks/go v0.19.0
+	github.com/anaregdesign/lantern/pb v0.9.0
+	github.com/anaregdesign/lantern/sdks/go v0.20.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -3,15 +3,15 @@ module github.com/anaregdesign/lantern/mcp
 go 1.26
 
 require (
-	github.com/anaregdesign/lantern/pb v0.8.0
-	github.com/anaregdesign/lantern/sdks/go v0.15.1
+	github.com/anaregdesign/lantern/pb v0.9.0
+	github.com/anaregdesign/lantern/sdks/go v0.20.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	google.golang.org/protobuf v1.36.11
 )
 
 require (
 	connectrpc.com/connect v1.20.0 // indirect
-	github.com/anaregdesign/lantern/core v0.7.0 // indirect
+	github.com/anaregdesign/lantern/core v0.14.0 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/mcp/go.sum
+++ b/mcp/go.sum
@@ -1,7 +1,7 @@
 connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=
 connectrpc.com/connect v1.20.0/go.mod h1:A2ygJrukXwWy32vkCAAHNVguZrqZ+jeZ9rGRnGR4dN4=
-github.com/anaregdesign/lantern/core v0.7.0 h1:0CGZFSMZv4EGD/Etbydt5xXBJ52ZiE6pk7M9ufnVg18=
-github.com/anaregdesign/lantern/core v0.7.0/go.mod h1:qJpBTt6AWmBIlabDQI2bWjgnx7kDiRwWGcVdcBFgALw=
+github.com/anaregdesign/lantern/core v0.14.0 h1:/pcd3/uQbXIH6+lidNIP+B0K8qgohcR94IGOrfM0qAo=
+github.com/anaregdesign/lantern/core v0.14.0/go.mod h1:P9G9uYZ+hIlt2/6Yd9t/WSZqGN+4w22AOqjOSo2ZS4A=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -4,8 +4,8 @@ go 1.26
 
 require (
 	connectrpc.com/connect v1.20.0
-	github.com/anaregdesign/lantern/core v0.13.0
-	github.com/anaregdesign/lantern/pb v0.8.0
+	github.com/anaregdesign/lantern/core v0.14.0
+	github.com/anaregdesign/lantern/pb v0.9.0
 	golang.org/x/net v0.56.0
 	google.golang.org/protobuf v1.36.11
 )

--- a/sdks/go/go.sum
+++ b/sdks/go/go.sum
@@ -1,7 +1,7 @@
 connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=
 connectrpc.com/connect v1.20.0/go.mod h1:A2ygJrukXwWy32vkCAAHNVguZrqZ+jeZ9rGRnGR4dN4=
-github.com/anaregdesign/lantern/core v0.13.0 h1:5O097d7Kb43yAEJql41ZGdAMYh/9Si/5BXidsZGPqXw=
-github.com/anaregdesign/lantern/core v0.13.0/go.mod h1:P9G9uYZ+hIlt2/6Yd9t/WSZqGN+4w22AOqjOSo2ZS4A=
+github.com/anaregdesign/lantern/core v0.14.0 h1:/pcd3/uQbXIH6+lidNIP+B0K8qgohcR94IGOrfM0qAo=
+github.com/anaregdesign/lantern/core v0.14.0/go.mod h1:P9G9uYZ+hIlt2/6Yd9t/WSZqGN+4w22AOqjOSo2ZS4A=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lantern-sdk",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Official TypeScript client SDK for Lantern — an in-memory graph KVS, over Connect (HTTP/2).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Release-mechanics prep PR for the cascade-#9 release.

Bumps module `require` pins so downstream `go get` / `npm install` consumers resolve the new tags being cut this cascade:

- `pb` v0.8.0 → **v0.9.0** (ppr/bm25 proto schema additions)
- `core` v0.13.0 → **v0.14.0** (PPR, BM25 edge weighting, pubsub fix)
- `sdks/go` v0.19.0 → **v0.20.0**
- `sdks/node` package.json version 0.6.0 → **0.7.0** (VERSION-BUMP-BEFORE-TAG)

All inter-module deps are `replace`-backed locally, so this is metadata-only for the workspace/CI build (go.sum gains only the already-published `core/v0.14.0` hashes, since `sdks/go`/`mcp` have no `replace` for `core`). `server` keeps its pseudo-version + replace (never tagged).

No issue — release-pin mechanics (precedent: #668, #678).