### PR TITLE
feat(core/llm): add generic structured-output LLM abstraction

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -13,6 +13,7 @@ specific to the gRPC/transport layer.
 | `concurrent/` | Concurrency primitives, including a typed pub/sub (`concurrent/pubsub`). |
 | `graph/` | In-memory graph model and traversal/scoring helpers. |
 | `graphcache/` | Graph-specialized cache: TTL'd vertices and additive decaying edges, with an optional prefix index. The server's primary store. |
+| `llm/` | Backend-agnostic abstractions for single-shot, structured-output language models. |
 | `model/function/` | Functional-style type aliases used across the other packages. |
 | `nlp/` | Lightweight NLP helpers. |
 

--- a/core/llm/doc.go
+++ b/core/llm/doc.go
@@ -1,0 +1,24 @@
+// Package llm defines backend-agnostic abstractions for single-shot,
+// structured-output language models.
+//
+// The interaction model is deliberately narrow: there is no conversation state.
+// A caller describes the desired output as a Go type T, supplies an Instruction
+// (what the model should do) and an Input (the payload to act on), and receives
+// a Response[T] whose Output is a decoded value of T. This single turn maps
+// cleanly onto the structured-output / JSON-mode features of the major providers
+// (OpenAI, Anthropic Claude, Google Gemini, ...), each of which is expected to
+// land later as a concrete Model implementation behind the interface defined
+// here.
+//
+// The central abstraction is the generic Model[T] interface, paired with
+// Request[T] and Response[T]. The JSON Schema describing T is derived from the
+// Go type by SchemaFor, so callers rarely write schema documents by hand.
+// Alongside the decoded Output, Response[T] carries the metadata that backends
+// report in common — token Usage, a normalized FinishReason, and the resolved
+// Model identifier.
+//
+// This package is a leaf: it depends on nothing beyond the standard library, so
+// concrete backends (which need provider SDKs or HTTP clients) belong in their
+// own subpackages or modules that import this one, keeping the abstraction
+// dependency-free.
+package llm

--- a/core/llm/generate.go
+++ b/core/llm/generate.go
@@ -1,0 +1,11 @@
+package llm
+
+import "context"
+
+// Generate is a convenience wrapper around a Model[T]: it builds a Request[T]
+// from instruction and input and forwards it to m. T is inferred from m, so a
+// caller need not spell it out. Construct a Request[T] and call Model.Generate
+// directly when more control is needed.
+func Generate[T any](ctx context.Context, m Model[T], instruction, input string) (Response[T], error) {
+	return m.Generate(ctx, Request[T]{Instruction: instruction, Input: input})
+}

--- a/core/llm/generate_test.go
+++ b/core/llm/generate_test.go
@@ -1,0 +1,39 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestGenerate(t *testing.T) {
+	t.Run("builds the request and returns a typed response", func(t *testing.T) {
+		var gotReq Request[person]
+		m := ModelFunc[person](func(_ context.Context, req Request[person]) (Response[person], error) {
+			gotReq = req
+			return Response[person]{Output: person{Name: "Ada", Age: 36}}, nil
+		})
+
+		resp, err := Generate[person](context.Background(), m, "extract", "Ada is 36")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gotReq.Instruction != "extract" || gotReq.Input != "Ada is 36" {
+			t.Errorf("forwarded request = %+v", gotReq)
+		}
+		if resp.Output != (person{Name: "Ada", Age: 36}) {
+			t.Errorf("Output = %+v", resp.Output)
+		}
+	})
+
+	t.Run("propagates the model error", func(t *testing.T) {
+		wantErr := errors.New("backend down")
+		m := ModelFunc[person](func(context.Context, Request[person]) (Response[person], error) {
+			return Response[person]{}, wantErr
+		})
+		_, err := Generate[person](context.Background(), m, "i", "x")
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("err = %v, want %v", err, wantErr)
+		}
+	})
+}

--- a/core/llm/helpers_test.go
+++ b/core/llm/helpers_test.go
@@ -1,0 +1,22 @@
+package llm
+
+// Shared struct fixtures for the llm package tests.
+
+type person struct {
+	Name string `json:"name"`
+	Age  int    `json:"age"`
+}
+
+type address struct {
+	City string `json:"city"`
+	Zip  string `json:"zip,omitempty"`
+}
+
+type profile struct {
+	Person  person            `json:"person"`
+	Emails  []string          `json:"emails"`
+	Address *address          `json:"address"`
+	Tags    map[string]string `json:"tags"`
+	Ignored string            `json:"-"`
+	note    string
+}

--- a/core/llm/jsonschema.go
+++ b/core/llm/jsonschema.go
@@ -1,0 +1,175 @@
+package llm
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+)
+
+var (
+	timeType       = reflect.TypeOf(time.Time{})
+	rawMessageType = reflect.TypeFor[json.RawMessage]()
+)
+
+// reflectSchema builds a JSON Schema document (as a map ready for json.Marshal)
+// describing t. seen guards against recursive types.
+func reflectSchema(t reflect.Type, seen map[reflect.Type]bool) (map[string]any, error) {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	switch t {
+	case timeType:
+		return map[string]any{"type": "string", "format": "date-time"}, nil
+	case rawMessageType:
+		return map[string]any{}, nil // arbitrary JSON
+	}
+
+	switch t.Kind() {
+	case reflect.Bool:
+		return map[string]any{"type": "boolean"}, nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return map[string]any{"type": "integer"}, nil
+	case reflect.Float32, reflect.Float64:
+		return map[string]any{"type": "number"}, nil
+	case reflect.String:
+		return map[string]any{"type": "string"}, nil
+	case reflect.Slice:
+		if t.Elem().Kind() == reflect.Uint8 { // []byte marshals to a base64 string
+			return map[string]any{"type": "string", "contentEncoding": "base64"}, nil
+		}
+		return arraySchema(t, seen)
+	case reflect.Array:
+		return arraySchema(t, seen)
+	case reflect.Map:
+		if t.Key().Kind() != reflect.String {
+			return nil, fmt.Errorf("llm: map key type %s is not a string", t.Key())
+		}
+		values, err := reflectSchema(t.Elem(), seen)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"type": "object", "additionalProperties": values}, nil
+	case reflect.Struct:
+		return structSchema(t, seen)
+	case reflect.Interface:
+		return map[string]any{}, nil // arbitrary JSON
+	default:
+		return nil, fmt.Errorf("llm: unsupported type %s (kind %s)", t, t.Kind())
+	}
+}
+
+func arraySchema(t reflect.Type, seen map[reflect.Type]bool) (map[string]any, error) {
+	items, err := reflectSchema(t.Elem(), seen)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"type": "array", "items": items}, nil
+}
+
+func structSchema(t reflect.Type, seen map[reflect.Type]bool) (map[string]any, error) {
+	if seen[t] {
+		return nil, fmt.Errorf("llm: recursive type %s is not supported", t)
+	}
+	seen[t] = true
+	defer delete(seen, t)
+
+	properties := map[string]any{}
+	var required []string
+
+	// walk handles a struct's fields, flattening anonymous embedded structs to
+	// mirror how encoding/json promotes their fields.
+	var walk func(reflect.Type) error
+	walk = func(t reflect.Type) error {
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			name, opts := parseJSONTag(f.Tag.Get("json"))
+			if name == "-" {
+				continue
+			}
+			if f.Anonymous && name == "" {
+				et := f.Type
+				for et.Kind() == reflect.Pointer {
+					et = et.Elem()
+				}
+				if et.Kind() == reflect.Struct {
+					if err := walk(et); err != nil {
+						return err
+					}
+					continue
+				}
+			}
+			if !f.IsExported() {
+				continue
+			}
+			if name == "" {
+				name = f.Name
+			}
+			fieldSchema, err := reflectSchema(f.Type, seen)
+			if err != nil {
+				return err
+			}
+			properties[name] = fieldSchema
+			if !opts.contains("omitempty") && f.Type.Kind() != reflect.Pointer {
+				required = append(required, name)
+			}
+		}
+		return nil
+	}
+	if err := walk(t); err != nil {
+		return nil, err
+	}
+
+	schema := map[string]any{
+		"type":                 "object",
+		"properties":           properties,
+		"additionalProperties": false,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema, nil
+}
+
+// schemaName returns a JSON-schema name for t: its type name, or "output" when t
+// is unnamed (e.g. an anonymous struct).
+func schemaName(t reflect.Type) string {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if name := t.Name(); name != "" {
+		return name
+	}
+	return "output"
+}
+
+type jsonTagOptions string
+
+// parseJSONTag splits a struct tag's `json` value into the field name and the
+// comma-separated options that follow it.
+func parseJSONTag(tag string) (name string, opts jsonTagOptions) {
+	if i := strings.Index(tag, ","); i >= 0 {
+		return tag[:i], jsonTagOptions(tag[i+1:])
+	}
+	return tag, ""
+}
+
+// contains reports whether opt is present in the option list.
+func (o jsonTagOptions) contains(opt string) bool {
+	rest := string(o)
+	for rest != "" {
+		var cur string
+		if i := strings.Index(rest, ","); i >= 0 {
+			cur, rest = rest[:i], rest[i+1:]
+		} else {
+			cur, rest = rest, ""
+		}
+		if cur == opt {
+			return true
+		}
+	}
+	return false
+}

--- a/core/llm/jsonschema_test.go
+++ b/core/llm/jsonschema_test.go
@@ -1,0 +1,118 @@
+package llm
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestReflectSchema_Scalars(t *testing.T) {
+	cases := []struct {
+		name string
+		typ  reflect.Type
+		want map[string]any
+	}{
+		{"bool", reflect.TypeFor[bool](), map[string]any{"type": "boolean"}},
+		{"int", reflect.TypeFor[int](), map[string]any{"type": "integer"}},
+		{"uint", reflect.TypeFor[uint32](), map[string]any{"type": "integer"}},
+		{"float", reflect.TypeFor[float64](), map[string]any{"type": "number"}},
+		{"string", reflect.TypeFor[string](), map[string]any{"type": "string"}},
+		{"bytes", reflect.TypeFor[[]byte](), map[string]any{"type": "string", "contentEncoding": "base64"}},
+		{"slice", reflect.TypeFor[[]string](), map[string]any{"type": "array", "items": map[string]any{"type": "string"}}},
+		{"map", reflect.TypeFor[map[string]int](), map[string]any{"type": "object", "additionalProperties": map[string]any{"type": "integer"}}},
+		{"pointer unwraps", reflect.TypeFor[*string](), map[string]any{"type": "string"}},
+		{"time", reflect.TypeFor[time.Time](), map[string]any{"type": "string", "format": "date-time"}},
+		{"raw json", reflect.TypeFor[json.RawMessage](), map[string]any{}},
+		{"any", reflect.TypeFor[any](), map[string]any{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := reflectSchema(tc.typ, map[reflect.Type]bool{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("reflectSchema(%s) = %v, want %v", tc.typ, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReflectSchema_Struct(t *testing.T) {
+	// Sanity-touch the unexported field so it is genuinely part of the fixture.
+	if p := (profile{note: "x"}); p.note != "x" {
+		t.Fatal("fixture sanity check failed")
+	}
+
+	got, err := reflectSchema(reflect.TypeFor[profile](), map[reflect.Type]bool{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	props, _ := got["properties"].(map[string]any)
+	// json:"-" and unexported fields are skipped.
+	if _, ok := props["Ignored"]; ok {
+		t.Error(`Ignored (json:"-") leaked into properties`)
+	}
+	if _, ok := props["note"]; ok {
+		t.Error("unexported note leaked into properties")
+	}
+	for _, name := range []string{"person", "emails", "address", "tags"} {
+		if _, ok := props[name]; !ok {
+			t.Errorf("properties missing %q: %v", name, props)
+		}
+	}
+
+	// required: non-pointer, non-omitempty fields only; the *address pointer is
+	// optional.
+	required := toStringSet(got["required"])
+	for _, name := range []string{"person", "emails", "tags"} {
+		if !required[name] {
+			t.Errorf("required missing %q: %v", name, got["required"])
+		}
+	}
+	if required["address"] {
+		t.Error("pointer field address must not be required")
+	}
+}
+
+func TestReflectSchema_OmitemptyOptional(t *testing.T) {
+	got, err := reflectSchema(reflect.TypeFor[address](), map[reflect.Type]bool{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	required := toStringSet(got["required"])
+	if !required["city"] {
+		t.Error("city must be required")
+	}
+	if required["zip"] {
+		t.Error("zip (omitempty) must not be required")
+	}
+}
+
+func TestReflectSchema_Errors(t *testing.T) {
+	t.Run("recursive type", func(t *testing.T) {
+		type node struct {
+			Next *node `json:"next"`
+		}
+		if _, err := reflectSchema(reflect.TypeFor[node](), map[reflect.Type]bool{}); err == nil {
+			t.Error("expected error for recursive type, got nil")
+		}
+	})
+
+	t.Run("non-string map key", func(t *testing.T) {
+		if _, err := reflectSchema(reflect.TypeFor[map[int]string](), map[reflect.Type]bool{}); err == nil {
+			t.Error("expected error for non-string map key, got nil")
+		}
+	})
+}
+
+func toStringSet(v any) map[string]bool {
+	set := map[string]bool{}
+	items, _ := v.([]string)
+	for _, s := range items {
+		set[s] = true
+	}
+	return set
+}

--- a/core/llm/metadata.go
+++ b/core/llm/metadata.go
@@ -1,0 +1,37 @@
+package llm
+
+// Usage reports the token accounting a model returns with a Response. The three
+// counts are the common ground between providers: InputTokens is OpenAI's
+// prompt_tokens (Responses API input_tokens) and Gemini's promptTokenCount;
+// OutputTokens is OpenAI's completion_tokens (output_tokens) and Gemini's
+// candidatesTokenCount; TotalTokens is OpenAI's total_tokens and Gemini's
+// totalTokenCount. A count is zero when the backend does not report it.
+type Usage struct {
+	InputTokens  int
+	OutputTokens int
+	TotalTokens  int
+}
+
+// FinishReason is the normalized reason a model stopped generating, mapped from
+// each provider's own vocabulary onto a small backend-agnostic set.
+//
+// The mapping from the major providers is:
+//
+//	FinishStop          OpenAI "stop"            Gemini "STOP"
+//	FinishLength        OpenAI "length"          Gemini "MAX_TOKENS"
+//	FinishContentFilter OpenAI "content_filter"  Gemini "SAFETY", "RECITATION"
+//	FinishOther         anything else (e.g. tool/function calls) or unset
+type FinishReason string
+
+const (
+	// FinishStop means the model emitted a natural, complete stop.
+	FinishStop FinishReason = "stop"
+	// FinishLength means generation was truncated by a token limit; the Output
+	// may be incomplete and fail to satisfy the schema.
+	FinishLength FinishReason = "length"
+	// FinishContentFilter means generation was cut short by a safety or content
+	// policy filter.
+	FinishContentFilter FinishReason = "content_filter"
+	// FinishOther covers any other or unspecified reason.
+	FinishOther FinishReason = "other"
+)

--- a/core/llm/metadata_test.go
+++ b/core/llm/metadata_test.go
@@ -1,0 +1,19 @@
+package llm
+
+import "testing"
+
+// TestFinishReasonValues pins the wire-stable string values, since backends map
+// their provider's vocabulary onto these constants.
+func TestFinishReasonValues(t *testing.T) {
+	cases := map[FinishReason]string{
+		FinishStop:          "stop",
+		FinishLength:        "length",
+		FinishContentFilter: "content_filter",
+		FinishOther:         "other",
+	}
+	for got, want := range cases {
+		if string(got) != want {
+			t.Errorf("FinishReason = %q, want %q", string(got), want)
+		}
+	}
+}

--- a/core/llm/model.go
+++ b/core/llm/model.go
@@ -1,0 +1,58 @@
+package llm
+
+import "context"
+
+// Model is a single-shot, structured-output language model whose output conforms
+// to the Go type T. Given a Request, Generate returns a Response whose Output is
+// a fully decoded value of T. A Model keeps no state between calls: every
+// Generate is independent, with no conversation history.
+//
+// T is the structured-output schema: the JSON Schema sent to the provider is
+// derived from T (see SchemaFor), and the provider's JSON answer is decoded back
+// into a T. Binding the type to the interface keeps a backend's input and output
+// in lockstep and lets callers work with ordinary Go values instead of raw JSON.
+//
+// Concrete implementations wrap a specific backend (OpenAI, Anthropic Claude,
+// Google Gemini, a local model, ...) — typically a thin generic adapter over a
+// shared, non-generic client. Implementations should be safe for concurrent use
+// by multiple goroutines and must honor ctx cancellation.
+type Model[T any] interface {
+	Generate(ctx context.Context, req Request[T]) (Response[T], error)
+}
+
+// ModelFunc adapts an ordinary function to the Model interface. It is handy for
+// tests and for lightweight, stateless backends.
+type ModelFunc[T any] func(ctx context.Context, req Request[T]) (Response[T], error)
+
+// Generate calls f(ctx, req).
+func (f ModelFunc[T]) Generate(ctx context.Context, req Request[T]) (Response[T], error) {
+	return f(ctx, req)
+}
+
+// Request is a single, self-contained generation request for output type T. It
+// carries no conversation history.
+//
+// Instruction is the system-level directive describing the task — the role and
+// the "how". Input is the user-provided payload the model should act on — the
+// "what". The output schema is not carried here: it is derived from T by the
+// model (see SchemaFor). Keeping the directive separate from the payload lets a
+// caller reuse one Instruction across many Inputs.
+type Request[T any] struct {
+	Instruction string
+	Input       string
+}
+
+// Response is a Model's answer to a Request[T]. Output is the decoded result;
+// the remaining fields carry the metadata that both OpenAI and Gemini report
+// alongside the content.
+//
+// Output is the structured result, already decoded into T. Usage reports token
+// consumption. FinishReason is the normalized reason generation stopped. Model
+// is the provider's resolved model/version identifier (OpenAI "model", Gemini
+// "modelVersion").
+type Response[T any] struct {
+	Output       T
+	Usage        Usage
+	FinishReason FinishReason
+	Model        string
+}

--- a/core/llm/model_test.go
+++ b/core/llm/model_test.go
@@ -1,0 +1,45 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestModelFunc_Generate(t *testing.T) {
+	wantErr := errors.New("boom")
+	var gotReq Request[person]
+	f := ModelFunc[person](func(_ context.Context, req Request[person]) (Response[person], error) {
+		gotReq = req
+		return Response[person]{
+			Output:       person{Name: "Ada", Age: 36},
+			Usage:        Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+			FinishReason: FinishStop,
+			Model:        "fake-1",
+		}, wantErr
+	})
+
+	// ModelFunc[T] must satisfy Model[T].
+	var m Model[person] = f
+
+	resp, err := m.Generate(context.Background(), Request[person]{Instruction: "do", Input: "x"})
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	if resp.Output != (person{Name: "Ada", Age: 36}) {
+		t.Errorf("Output = %+v", resp.Output)
+	}
+	if resp.Usage != (Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15}) {
+		t.Errorf("Usage = %+v", resp.Usage)
+	}
+	if resp.FinishReason != FinishStop {
+		t.Errorf("FinishReason = %q, want %q", resp.FinishReason, FinishStop)
+	}
+	if resp.Model != "fake-1" {
+		t.Errorf("Model = %q, want fake-1", resp.Model)
+	}
+	if gotReq.Instruction != "do" || gotReq.Input != "x" {
+		t.Errorf("forwarded request = %+v", gotReq)
+	}
+}

--- a/core/llm/schema.go
+++ b/core/llm/schema.go
@@ -1,0 +1,57 @@
+package llm
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// Schema is a backend-agnostic description of the structure a Model's output
+// must conform to. It is expressed as a JSON Schema document — the interchange
+// format understood by every supported backend (OpenAI structured outputs,
+// Gemini response schemas, Claude tool input schemas, ...). The document is a
+// canonical, strict-leaning form (objects pin additionalProperties to false and
+// list every non-optional field in required); each backend translates it into
+// the subset its provider accepts.
+//
+// Name identifies the schema; some backends require a non-empty name for a
+// structured-output request. Description is an optional human-readable summary.
+// Definition is the JSON Schema document itself. When Strict is true the output
+// must validate against Definition exactly; backends that always enforce their
+// response schema may treat the flag as implied.
+type Schema struct {
+	Name        string
+	Description string
+	Definition  json.RawMessage
+	Strict      bool
+}
+
+// SchemaFor derives a strict Schema from the Go type T by reflection, so a
+// caller describes the desired output as an ordinary struct rather than by
+// hand-writing JSON Schema. Name defaults to T's type name ("output" when T is
+// unnamed); set Name or Description on the result to override.
+//
+// The supported subset covers what structured-output backends accept: structs
+// (honoring json tags, with embedded structs flattened and json:"-" fields
+// skipped), bool, the integer and float kinds, string, []byte (as a base64
+// string), slices and arrays, string-keyed maps, pointers (which mark a field
+// optional), and time.Time (as a date-time string). A non-optional field — one
+// without omitempty and not a pointer — is added to the object's required list.
+// SchemaFor returns an error for types it cannot represent (channels, funcs,
+// non-string map keys) and for recursive types.
+func SchemaFor[T any]() (Schema, error) {
+	t := reflect.TypeFor[T]()
+	def, err := reflectSchema(t, map[reflect.Type]bool{})
+	if err != nil {
+		return Schema{}, err
+	}
+	raw, err := json.Marshal(def)
+	if err != nil {
+		return Schema{}, fmt.Errorf("llm: marshal JSON schema for %s: %w", t, err)
+	}
+	return Schema{
+		Name:       schemaName(t),
+		Definition: raw,
+		Strict:     true,
+	}, nil
+}

--- a/core/llm/schema_test.go
+++ b/core/llm/schema_test.go
@@ -1,0 +1,56 @@
+package llm
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSchemaFor(t *testing.T) {
+	t.Run("derives name, strictness, and an object schema from a struct", func(t *testing.T) {
+		s, err := SchemaFor[person]()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s.Name != "person" {
+			t.Errorf("Name = %q, want person", s.Name)
+		}
+		if !s.Strict {
+			t.Error("Strict = false, want true")
+		}
+
+		var doc map[string]any
+		if err := json.Unmarshal(s.Definition, &doc); err != nil {
+			t.Fatalf("Definition is not valid JSON: %v", err)
+		}
+		if doc["type"] != "object" {
+			t.Errorf("type = %v, want object", doc["type"])
+		}
+		if doc["additionalProperties"] != false {
+			t.Errorf("additionalProperties = %v, want false", doc["additionalProperties"])
+		}
+		props, _ := doc["properties"].(map[string]any)
+		for _, name := range []string{"name", "age"} {
+			if _, ok := props[name]; !ok {
+				t.Errorf("properties missing %q: %v", name, props)
+			}
+		}
+	})
+
+	t.Run("names an unnamed type output", func(t *testing.T) {
+		s, err := SchemaFor[struct {
+			OK bool `json:"ok"`
+		}]()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s.Name != "output" {
+			t.Errorf("Name = %q, want output", s.Name)
+		}
+	})
+
+	t.Run("rejects unsupported types", func(t *testing.T) {
+		if _, err := SchemaFor[chan int](); err == nil {
+			t.Error("expected error for chan int, got nil")
+		}
+	})
+}


### PR DESCRIPTION
## What

Introduce `core/llm` — a dependency-free, backend-agnostic abstraction for **single-shot, structured-output** language models. `core` stays a leaf (stdlib only); concrete provider backends will import it.

## Design

- **Generics end-to-end**: `Model[T any]` with `Request[T]` / `Response[T]` and a `ModelFunc[T]` adapter. Go can't put type parameters on interface methods, so the output type is bound to the interface — keeping a backend's input and output in lockstep and letting callers work with Go values, not raw JSON.
- **Common response metadata** on `Response[T]` (researched against OpenAI & Gemini):
  - `Usage{InputTokens, OutputTokens, TotalTokens}` — OpenAI `prompt_tokens`/`completion_tokens`/`total_tokens` ↔ Gemini `promptTokenCount`/`candidatesTokenCount`/`totalTokenCount`.
  - normalized `FinishReason` (`stop`/`length`/`content_filter`/`other`).
  - resolved `Model` id — OpenAI `model` ↔ Gemini `modelVersion`.
- **Struct → JSON Schema**: `SchemaFor[T]()` derives a strict schema by reflection (no external deps) — `json` tags, embedded-struct flattening, `omitempty`/pointer → optional, `time.Time` → date-time, `[]byte` → base64, string-keyed maps. Emits a canonical strict form (`additionalProperties:false` + `required`); each backend adapter translates to its provider subset. Recursive types and unsupported kinds (chan/func, non-string map keys) error.
- `Generate[T]` convenience helper (infers `T` from the model).

## Tests

Unit tests follow the repo's 1:1 source↔test pairing with shared fixtures in `helpers_test.go`. Local gate green: `gofmt -l` clean, `go vet`/`go test ./...` in `core` pass, `golangci-lint v2.12.2` reports 0 issues.

## Follow-up

Concrete provider backends (OpenAI/Gemini/...) will be implemented in the **server module** (`server/`), which already depends on `core` — a thin generic adapter per type over a shared non-generic client, keeping the abstraction a leaf.

Closes #814