### PR TITLE
feat(core/llm): add OpenAI Responses API backend

### DIFF
--- a/core/llm/openai/example/main.go
+++ b/core/llm/openai/example/main.go
@@ -1,0 +1,77 @@
+// Command example shows the public API of the core/llm/openai package: build a
+// reusable Client, bind a structured-output type with New, and call Generate to
+// get a fully decoded value plus token usage and finish reason.
+//
+// It needs a real OpenAI key, so it reads two env vars and is a no-op without
+// them. Run it from the core module with:
+//
+//	export OPENAI_API_KEY=sk-...        # your key
+//	export OPENAI_MODEL=gpt-5.5         # any model id (never hard-coded)
+//	go run ./llm/openai/example
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"os"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/llm"
+	"github.com/anaregdesign/lantern/core/llm/openai"
+)
+
+// weather is the structured-output schema: New derives a strict JSON Schema from
+// it, and Generate decodes the model's JSON answer back into this type. Use
+// `json` tags for field names and the parent llm package's schema rules.
+type weather struct {
+	City string `json:"city"`
+	High int    `json:"high"`
+}
+
+func main() {
+	log.SetFlags(0)
+
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	model := os.Getenv("OPENAI_MODEL")
+	if apiKey == "" || model == "" {
+		log.Println("set OPENAI_API_KEY and OPENAI_MODEL to run this example")
+		return
+	}
+
+	// A Client is non-generic, reusable, and concurrent-safe — it captures the
+	// key, model, and HTTP setup. The model id comes from the caller (env here),
+	// never hard-coded. Options tune the endpoint and limits; defaults are the
+	// public OpenAI API and a 60s-timeout client.
+	client := openai.NewClient(apiKey, model,
+		openai.WithMaxTokens(256),
+		// openai.WithBaseURL("https://my-proxy.example.com"), // proxy / Azure
+	)
+
+	// New binds output type T plus a fixed instruction into an llm.Model[T].
+	// Reuse one Client across many models with different instructions/types.
+	m, err := openai.New[weather](client, "Report the weather as structured data.")
+	if err != nil {
+		log.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	resp, err := m.Generate(ctx, "What's the weather in Tokyo today? Make up a plausible high.")
+	if err != nil {
+		// A model decline maps to ErrRefusal; everything else is a real error.
+		if errors.Is(err, openai.ErrRefusal) {
+			log.Printf("refused: %v", err)
+			return
+		}
+		log.Fatalf("Generate: %v", err)
+	}
+
+	// Output is the decoded weather; the rest is normalized metadata.
+	log.Printf("city=%s high=%d", resp.Output.City, resp.Output.High)
+	log.Printf("model=%s finish=%s tokens=%d", resp.Model, resp.FinishReason, resp.Usage.TotalTokens)
+	if resp.FinishReason == llm.FinishLength {
+		log.Println("note: output was truncated by max tokens")
+	}
+}

--- a/core/llm/openai/openai.go
+++ b/core/llm/openai/openai.go
@@ -1,0 +1,242 @@
+// Package openai implements the llm.Model interface against OpenAI's Responses
+// API (POST /v1/responses) using strict structured output. It depends only on
+// the standard library and the parent llm package, so core stays a leaf.
+//
+// A non-generic Client captures the endpoint, key, model, and HTTP client; the
+// generic New binds a structured-output type T and a fixed system instruction
+// into an llm.Model[T]. Go methods cannot take type parameters, so the schema is
+// fixed at construction by New rather than per call.
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/llm"
+)
+
+// DefaultBaseURL is the OpenAI API root used when none is configured.
+const DefaultBaseURL = "https://api.openai.com"
+
+// ErrRefusal is returned when the model declines to answer; the refusal message
+// is wrapped for context.
+var ErrRefusal = errors.New("openai: model refused to answer")
+
+// Client is a non-generic, reusable handle to the OpenAI Responses API. It is
+// safe for concurrent use. Bind a structured-output type with New.
+type Client struct {
+	apiKey    string
+	model     string
+	baseURL   string
+	maxTokens int
+	http      *http.Client
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithBaseURL overrides the API root (e.g. a proxy or Azure endpoint). An empty
+// string is ignored. The path "/v1/responses" is always appended.
+func WithBaseURL(u string) Option {
+	return func(c *Client) {
+		if u != "" {
+			c.baseURL = strings.TrimRight(u, "/")
+		}
+	}
+}
+
+// WithHTTPClient sets the HTTP client used for requests. A nil client is ignored.
+func WithHTTPClient(h *http.Client) Option {
+	return func(c *Client) {
+		if h != nil {
+			c.http = h
+		}
+	}
+}
+
+// WithMaxTokens caps output tokens. Zero (the default) lets the server decide.
+func WithMaxTokens(n int) Option {
+	return func(c *Client) {
+		if n > 0 {
+			c.maxTokens = n
+		}
+	}
+}
+
+// NewClient builds a Client for the given model. apiKey authenticates as a
+// bearer token; model is the provider model identifier (caller-supplied, never
+// hard-coded). Defaults: DefaultBaseURL and a 60s-timeout http.Client.
+func NewClient(apiKey, model string, opts ...Option) *Client {
+	c := &Client{
+		apiKey:  apiKey,
+		model:   model,
+		baseURL: DefaultBaseURL,
+		http:    &http.Client{Timeout: 60 * time.Second},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// New binds output type T and a fixed system instruction to client, yielding an
+// llm.Model[T]. The JSON schema is derived from T once; each Generate sends the
+// instruction plus the call's input. The model is reusable and concurrent-safe.
+func New[T any](client *Client, instruction string) (llm.Model[T], error) {
+	schema, err := llm.SchemaFor[T]()
+	if err != nil {
+		return nil, err
+	}
+	name := schema.Name
+	if name == "" {
+		name = "output"
+	}
+	return &model[T]{client: client, instruction: instruction, name: name, schema: schema.Definition}, nil
+}
+
+// model binds an output type T, a fixed instruction, and the derived JSON schema
+// to a Client. It satisfies llm.Model[T].
+type model[T any] struct {
+	client      *Client
+	instruction string
+	name        string
+	schema      json.RawMessage
+}
+
+// Generate sends the instruction plus input, then decodes the response JSON into T.
+func (m *model[T]) Generate(ctx context.Context, input string) (llm.Response[T], error) {
+	r, err := m.client.generate(ctx, m.instruction, input, m.name, m.schema)
+	if err != nil {
+		return llm.Response[T]{}, err
+	}
+	var out T
+	if err := json.Unmarshal([]byte(r.text), &out); err != nil {
+		return llm.Response[T]{}, fmt.Errorf("openai: decode output: %w", err)
+	}
+	return llm.Response[T]{Output: out, Usage: r.usage, FinishReason: r.finish, Model: r.model}, nil
+}
+
+type request struct {
+	Model           string     `json:"model"`
+	Instructions    string     `json:"instructions,omitempty"`
+	Input           string     `json:"input"`
+	Text            textConfig `json:"text"`
+	MaxOutputTokens int        `json:"max_output_tokens,omitempty"`
+}
+
+type textConfig struct {
+	Format formatConfig `json:"format"`
+}
+
+type formatConfig struct {
+	Type   string          `json:"type"`
+	Name   string          `json:"name"`
+	Strict bool            `json:"strict"`
+	Schema json.RawMessage `json:"schema"`
+}
+
+type response struct {
+	Model             string `json:"model"`
+	Status            string `json:"status"`
+	IncompleteDetails *struct {
+		Reason string `json:"reason"`
+	} `json:"incomplete_details"`
+	Output []struct {
+		Content []struct {
+			Type    string `json:"type"`
+			Text    string `json:"text"`
+			Refusal string `json:"refusal"`
+		} `json:"content"`
+	} `json:"output"`
+	Usage struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+		TotalTokens  int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+// result is generate's non-generic output: the raw JSON text plus metadata. The
+// generic New closure decodes text into T.
+type result struct {
+	text   string
+	usage  llm.Usage
+	finish llm.FinishReason
+	model  string
+}
+
+func (c *Client) generate(ctx context.Context, instruction, input, name string, schema json.RawMessage) (result, error) {
+	body, err := json.Marshal(request{
+		Model:        c.model,
+		Instructions: instruction,
+		Input:        input,
+		Text: textConfig{Format: formatConfig{
+			Type:   "json_schema",
+			Name:   name,
+			Strict: true,
+			Schema: schema,
+		}},
+		MaxOutputTokens: c.maxTokens,
+	})
+	if err != nil {
+		return result{}, fmt.Errorf("openai: marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/responses", bytes.NewReader(body))
+	if err != nil {
+		return result{}, fmt.Errorf("openai: build request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := c.http.Do(httpReq)
+	if err != nil {
+		return result{}, fmt.Errorf("openai: do request: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	payload, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return result{}, fmt.Errorf("openai: read response: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		return result{}, fmt.Errorf("openai: status %d: %s", httpResp.StatusCode, strings.TrimSpace(string(payload)))
+	}
+
+	var r response
+	if err := json.Unmarshal(payload, &r); err != nil {
+		return result{}, fmt.Errorf("openai: decode response: %w", err)
+	}
+	for _, out := range r.Output {
+		for _, part := range out.Content {
+			if part.Type == "refusal" {
+				return result{}, fmt.Errorf("%w: %s", ErrRefusal, part.Refusal)
+			}
+			if part.Type == "output_text" {
+				return result{
+					text:   part.Text,
+					usage:  llm.Usage{InputTokens: r.Usage.InputTokens, OutputTokens: r.Usage.OutputTokens, TotalTokens: r.Usage.TotalTokens},
+					finish: finishReason(r),
+					model:  r.Model,
+				}, nil
+			}
+		}
+	}
+	return result{}, errors.New("openai: no output_text in response")
+}
+
+func finishReason(r response) llm.FinishReason {
+	if r.Status == "completed" {
+		return llm.FinishStop
+	}
+	if r.IncompleteDetails != nil && r.IncompleteDetails.Reason == "max_output_tokens" {
+		return llm.FinishLength
+	}
+	return llm.FinishOther
+}

--- a/core/llm/openai/openai_test.go
+++ b/core/llm/openai/openai_test.go
@@ -1,0 +1,109 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/anaregdesign/lantern/core/llm"
+)
+
+type weather struct {
+	City string `json:"city"`
+	High int    `json:"high"`
+}
+
+func TestGenerate(t *testing.T) {
+	var gotPath, gotAuth string
+	var gotBody request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"model":"gpt-5.5","status":"completed",`+
+			`"output":[{"content":[{"type":"output_text","text":"{\"city\":\"Tokyo\",\"high\":31}"}]}],`+
+			`"usage":{"input_tokens":12,"output_tokens":7,"total_tokens":19}}`)
+	}))
+	defer srv.Close()
+
+	m, err := New[weather](NewClient("sk-test", "gpt-5.5", WithBaseURL(srv.URL)), "report weather")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	resp, err := m.Generate(context.Background(), "Tokyo")
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if resp.Output != (weather{City: "Tokyo", High: 31}) {
+		t.Errorf("Output = %+v, want Tokyo/31", resp.Output)
+	}
+	if resp.Usage != (llm.Usage{InputTokens: 12, OutputTokens: 7, TotalTokens: 19}) {
+		t.Errorf("Usage = %+v", resp.Usage)
+	}
+	if resp.FinishReason != llm.FinishStop {
+		t.Errorf("FinishReason = %q, want stop", resp.FinishReason)
+	}
+	if resp.Model != "gpt-5.5" {
+		t.Errorf("Model = %q", resp.Model)
+	}
+	if gotPath != "/v1/responses" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotAuth != "Bearer sk-test" {
+		t.Errorf("auth = %q", gotAuth)
+	}
+	if gotBody.Model != "gpt-5.5" || gotBody.Instructions != "report weather" || !gotBody.Text.Format.Strict {
+		t.Errorf("request = %+v", gotBody)
+	}
+}
+
+func TestGenerateRefusal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"completed","output":[{"content":[{"type":"refusal","refusal":"no"}]}]}`)
+	}))
+	defer srv.Close()
+
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	if _, err := m.Generate(context.Background(), "y"); !errors.Is(err, ErrRefusal) {
+		t.Fatalf("err = %v, want ErrRefusal", err)
+	}
+}
+
+func TestGenerateLength(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},`+
+			`"output":[{"content":[{"type":"output_text","text":"{\"city\":\"A\",\"high\":1}"}]}]}`)
+	}))
+	defer srv.Close()
+
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	resp, err := m.Generate(context.Background(), "y")
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if resp.FinishReason != llm.FinishLength {
+		t.Errorf("FinishReason = %q, want length", resp.FinishReason)
+	}
+}
+
+func TestGenerateHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, "bad key")
+	}))
+	defer srv.Close()
+
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	_, err := m.Generate(context.Background(), "y")
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Fatalf("err = %v, want 401", err)
+	}
+}


### PR DESCRIPTION
Implements the first concrete `llm.Model[T]` backend over OpenAI's Responses API (`POST /v1/responses`) with strict structured output. stdlib-only, so `core` stays a leaf.

## What
- `Client` — non-generic, reusable, concurrent-safe handle (apiKey/model/baseURL/maxTokens/http). Options: `WithBaseURL`, `WithHTTPClient`, `WithMaxTokens`. Model id is caller-supplied (never hard-coded).
- `New[T](client, instruction) (llm.Model[T], error)` — derives the strict JSON schema from `T` once, returns an explicit `model[T]` implementer (not a closure); instruction goes in the top-level `instructions` field.
- `generate` maps refusal→`ErrRefusal`, `status`/`incomplete_details`→`FinishReason`, and `usage`→`llm.Usage`.
- Hermetic `httptest` tests (no key needed): success, refusal, length-truncation, HTTP error.
- Env-driven `example/` matching the other `core/*/example` style.

## Test
`gofmt` clean, `go vet`/`go test ./llm/...` green; verified live against the real API.

Closes #818