### PR TITLE
feat(core/llm): Anthropic Messages structured-output backend

### DIFF
--- a/core/llm/anthropic/anthropic.go
+++ b/core/llm/anthropic/anthropic.go
@@ -1,0 +1,251 @@
+// Package anthropic implements the llm.Model interface against Anthropic's
+// Messages API (POST /v1/messages) using structured JSON-schema output. It
+// depends only on the standard library and the parent llm package, so core
+// stays a leaf.
+//
+// A non-generic Client captures the endpoint, key, model, and HTTP client; the
+// generic New binds a structured-output type T and a fixed system instruction
+// into an llm.Model[T]. Go methods cannot take type parameters, so the schema is
+// fixed at construction by New rather than per call.
+package anthropic
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/llm"
+)
+
+// DefaultBaseURL is the Anthropic API root used when none is configured.
+const DefaultBaseURL = "https://api.anthropic.com"
+
+// DefaultVersion is the anthropic-version header sent when none is configured.
+const DefaultVersion = "2023-06-01"
+
+// DefaultMaxTokens caps output when WithMaxTokens is not set; the Messages API
+// requires max_tokens, so unlike OpenAI it cannot be left to the server.
+const DefaultMaxTokens = 1024
+
+// ErrRefusal is returned when the model declines to answer.
+var ErrRefusal = errors.New("anthropic: model refused to answer")
+
+// Client is a non-generic, reusable handle to the Anthropic Messages API. It is
+// safe for concurrent use. Bind a structured-output type with New.
+type Client struct {
+	apiKey    string
+	model     string
+	baseURL   string
+	version   string
+	maxTokens int
+	http      *http.Client
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithBaseURL overrides the API root (e.g. a proxy). An empty string is ignored.
+// The path "/v1/messages" is always appended.
+func WithBaseURL(u string) Option {
+	return func(c *Client) {
+		if u != "" {
+			c.baseURL = strings.TrimRight(u, "/")
+		}
+	}
+}
+
+// WithVersion overrides the anthropic-version header. An empty string is ignored.
+func WithVersion(v string) Option {
+	return func(c *Client) {
+		if v != "" {
+			c.version = v
+		}
+	}
+}
+
+// WithHTTPClient sets the HTTP client used for requests. A nil client is ignored.
+func WithHTTPClient(h *http.Client) Option {
+	return func(c *Client) {
+		if h != nil {
+			c.http = h
+		}
+	}
+}
+
+// WithMaxTokens caps output tokens. Non-positive values keep DefaultMaxTokens.
+func WithMaxTokens(n int) Option {
+	return func(c *Client) {
+		if n > 0 {
+			c.maxTokens = n
+		}
+	}
+}
+
+// NewClient builds a Client for the given model. apiKey authenticates via the
+// x-api-key header; model is the provider model identifier (caller-supplied,
+// never hard-coded). Defaults: DefaultBaseURL, DefaultVersion, DefaultMaxTokens,
+// and a 60s-timeout http.Client.
+func NewClient(apiKey, model string, opts ...Option) *Client {
+	c := &Client{
+		apiKey:    apiKey,
+		model:     model,
+		baseURL:   DefaultBaseURL,
+		version:   DefaultVersion,
+		maxTokens: DefaultMaxTokens,
+		http:      &http.Client{Timeout: 60 * time.Second},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// New binds output type T and a fixed system instruction to client, yielding an
+// llm.Model[T]. The JSON schema is derived from T once; each Generate sends the
+// instruction plus the call's input. The model is reusable and concurrent-safe.
+func New[T any](client *Client, instruction string) (llm.Model[T], error) {
+	schema, err := llm.SchemaFor[T]()
+	if err != nil {
+		return nil, err
+	}
+	return &model[T]{client: client, instruction: instruction, schema: schema.Definition}, nil
+}
+
+// model binds an output type T, a fixed instruction, and the derived JSON schema
+// to a Client. It satisfies llm.Model[T].
+type model[T any] struct {
+	client      *Client
+	instruction string
+	schema      json.RawMessage
+}
+
+// Generate sends the instruction plus input, then decodes the response JSON into T.
+func (m *model[T]) Generate(ctx context.Context, input string) (llm.Response[T], error) {
+	r, err := m.client.generate(ctx, m.instruction, input, m.schema)
+	if err != nil {
+		return llm.Response[T]{}, err
+	}
+	var out T
+	if err := json.Unmarshal([]byte(r.text), &out); err != nil {
+		return llm.Response[T]{}, fmt.Errorf("anthropic: decode output: %w", err)
+	}
+	return llm.Response[T]{Output: out, Usage: r.usage, FinishReason: r.finish, Model: r.model}, nil
+}
+
+type request struct {
+	Model        string        `json:"model"`
+	MaxTokens    int           `json:"max_tokens"`
+	System       string        `json:"system,omitempty"`
+	Messages     []message     `json:"messages"`
+	OutputConfig *outputConfig `json:"output_config,omitempty"`
+}
+
+type message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type outputConfig struct {
+	Format formatConfig `json:"format"`
+}
+
+type formatConfig struct {
+	Type   string          `json:"type"`
+	Schema json.RawMessage `json:"schema"`
+}
+
+type response struct {
+	Model      string `json:"model"`
+	StopReason string `json:"stop_reason"`
+	Content    []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+	Usage struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+// result is generate's non-generic output: the raw JSON text plus metadata. The
+// generic New closure decodes text into T.
+type result struct {
+	text   string
+	usage  llm.Usage
+	finish llm.FinishReason
+	model  string
+}
+
+func (c *Client) generate(ctx context.Context, instruction, input string, schema json.RawMessage) (result, error) {
+	body, err := json.Marshal(request{
+		Model:     c.model,
+		MaxTokens: c.maxTokens,
+		System:    instruction,
+		Messages:  []message{{Role: "user", Content: input}},
+		OutputConfig: &outputConfig{Format: formatConfig{
+			Type:   "json_schema",
+			Schema: schema,
+		}},
+	})
+	if err != nil {
+		return result{}, fmt.Errorf("anthropic: marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/messages", bytes.NewReader(body))
+	if err != nil {
+		return result{}, fmt.Errorf("anthropic: build request: %w", err)
+	}
+	httpReq.Header.Set("x-api-key", c.apiKey)
+	httpReq.Header.Set("anthropic-version", c.version)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := c.http.Do(httpReq)
+	if err != nil {
+		return result{}, fmt.Errorf("anthropic: do request: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	payload, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return result{}, fmt.Errorf("anthropic: read response: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		return result{}, fmt.Errorf("anthropic: status %d: %s", httpResp.StatusCode, strings.TrimSpace(string(payload)))
+	}
+
+	var r response
+	if err := json.Unmarshal(payload, &r); err != nil {
+		return result{}, fmt.Errorf("anthropic: decode response: %w", err)
+	}
+	if r.StopReason == "refusal" {
+		return result{}, ErrRefusal
+	}
+	for _, part := range r.Content {
+		if part.Type == "text" {
+			return result{
+				text:   part.Text,
+				usage:  llm.Usage{InputTokens: r.Usage.InputTokens, OutputTokens: r.Usage.OutputTokens, TotalTokens: r.Usage.InputTokens + r.Usage.OutputTokens},
+				finish: finishReason(r.StopReason),
+				model:  r.Model,
+			}, nil
+		}
+	}
+	return result{}, errors.New("anthropic: no text in response")
+}
+
+func finishReason(stop string) llm.FinishReason {
+	switch stop {
+	case "end_turn", "stop_sequence":
+		return llm.FinishStop
+	case "max_tokens":
+		return llm.FinishLength
+	default:
+		return llm.FinishOther
+	}
+}

--- a/core/llm/anthropic/anthropic_test.go
+++ b/core/llm/anthropic/anthropic_test.go
@@ -1,0 +1,116 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/anaregdesign/lantern/core/llm"
+)
+
+type weather struct {
+	City string `json:"city"`
+	High int    `json:"high"`
+}
+
+func TestGenerate(t *testing.T) {
+	var gotPath, gotKey, gotVersion string
+	var gotBody request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotKey = r.Header.Get("x-api-key")
+		gotVersion = r.Header.Get("anthropic-version")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"model":"claude-opus","stop_reason":"end_turn",`+
+			`"content":[{"type":"text","text":"{\"city\":\"Tokyo\",\"high\":31}"}],`+
+			`"usage":{"input_tokens":12,"output_tokens":7}}`)
+	}))
+	defer srv.Close()
+
+	m, err := New[weather](NewClient("sk-test", "claude-opus", WithBaseURL(srv.URL)), "report weather")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	resp, err := m.Generate(context.Background(), "Tokyo")
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if resp.Output != (weather{City: "Tokyo", High: 31}) {
+		t.Errorf("Output = %+v, want Tokyo/31", resp.Output)
+	}
+	if resp.Usage != (llm.Usage{InputTokens: 12, OutputTokens: 7, TotalTokens: 19}) {
+		t.Errorf("Usage = %+v", resp.Usage)
+	}
+	if resp.FinishReason != llm.FinishStop {
+		t.Errorf("FinishReason = %q, want stop", resp.FinishReason)
+	}
+	if resp.Model != "claude-opus" {
+		t.Errorf("Model = %q", resp.Model)
+	}
+	if gotPath != "/v1/messages" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotKey != "sk-test" {
+		t.Errorf("x-api-key = %q", gotKey)
+	}
+	if gotVersion != DefaultVersion {
+		t.Errorf("anthropic-version = %q", gotVersion)
+	}
+	if gotBody.Model != "claude-opus" || gotBody.System != "report weather" || gotBody.MaxTokens != DefaultMaxTokens {
+		t.Errorf("request = %+v", gotBody)
+	}
+	if gotBody.OutputConfig == nil || gotBody.OutputConfig.Format.Type != "json_schema" {
+		t.Errorf("output_config = %+v", gotBody.OutputConfig)
+	}
+}
+
+func TestGenerateRefusal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"stop_reason":"refusal","content":[]}`)
+	}))
+	defer srv.Close()
+
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	if _, err := m.Generate(context.Background(), "y"); !errors.Is(err, ErrRefusal) {
+		t.Fatalf("err = %v, want ErrRefusal", err)
+	}
+}
+
+func TestGenerateLength(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"stop_reason":"max_tokens",`+
+			`"content":[{"type":"text","text":"{\"city\":\"A\",\"high\":1}"}]}`)
+	}))
+	defer srv.Close()
+
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	resp, err := m.Generate(context.Background(), "y")
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if resp.FinishReason != llm.FinishLength {
+		t.Errorf("FinishReason = %q, want length", resp.FinishReason)
+	}
+}
+
+func TestGenerateHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, "bad key")
+	}))
+	defer srv.Close()
+
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	_, err := m.Generate(context.Background(), "y")
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Fatalf("err = %v, want 401", err)
+	}
+}

--- a/core/llm/anthropic/example/main.go
+++ b/core/llm/anthropic/example/main.go
@@ -1,0 +1,76 @@
+// Command example shows the public API of the core/llm/anthropic package: build
+// a reusable Client, bind a structured-output type with New, and call Generate
+// to get a fully decoded value plus token usage and finish reason.
+//
+// It needs a real Anthropic key, so it reads two env vars and is a no-op without
+// them. Run it from the core module with:
+//
+//	export ANTHROPIC_API_KEY=sk-ant-...   # your key
+//	export ANTHROPIC_MODEL=claude-opus    # any model id (never hard-coded)
+//	go run ./llm/anthropic/example
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"os"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/llm"
+	"github.com/anaregdesign/lantern/core/llm/anthropic"
+)
+
+// weather is the structured-output schema: New derives a strict JSON Schema from
+// it, and Generate decodes the model's JSON answer back into this type. Use
+// `json` tags for field names and the parent llm package's schema rules.
+type weather struct {
+	City string `json:"city"`
+	High int    `json:"high"`
+}
+
+func main() {
+	log.SetFlags(0)
+
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	model := os.Getenv("ANTHROPIC_MODEL")
+	if apiKey == "" || model == "" {
+		log.Println("set ANTHROPIC_API_KEY and ANTHROPIC_MODEL to run this example")
+		return
+	}
+
+	// A Client is non-generic, reusable, and concurrent-safe — it captures the
+	// key, model, and HTTP setup. The model id comes from the caller (env here),
+	// never hard-coded. Options tune the endpoint, version, and token cap.
+	client := anthropic.NewClient(apiKey, model,
+		anthropic.WithMaxTokens(256),
+		// anthropic.WithBaseURL("https://my-proxy.example.com"), // proxy
+	)
+
+	// New binds output type T plus a fixed instruction into an llm.Model[T].
+	// Reuse one Client across many models with different instructions/types.
+	m, err := anthropic.New[weather](client, "Report the weather as structured data.")
+	if err != nil {
+		log.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	resp, err := m.Generate(ctx, "What's the weather in Tokyo today? Make up a plausible high.")
+	if err != nil {
+		// A model decline maps to ErrRefusal; everything else is a real error.
+		if errors.Is(err, anthropic.ErrRefusal) {
+			log.Printf("refused: %v", err)
+			return
+		}
+		log.Fatalf("Generate: %v", err)
+	}
+
+	// Output is the decoded weather; the rest is normalized metadata.
+	log.Printf("city=%s high=%d", resp.Output.City, resp.Output.High)
+	log.Printf("model=%s finish=%s tokens=%d", resp.Model, resp.FinishReason, resp.Usage.TotalTokens)
+	if resp.FinishReason == llm.FinishLength {
+		log.Println("note: output was truncated by max tokens")
+	}
+}


### PR DESCRIPTION
## Summary
Adds `core/llm/anthropic` — a net/http-only backend implementing `llm.Model[T]` against Anthropic's Messages API (POST /v1/messages), mirroring the OpenAI backend (#819).

- Non-generic `Client` (key/model/baseURL/version/maxTokens/http) + generic `New[T]` binding schema at construction.
- `x-api-key` + `anthropic-version` headers; system instruction; json_schema output_config.
- max_tokens required by the API → `DefaultMaxTokens`; model id caller-supplied (env edge).
- stop_reason → FinishReason mapping; `refusal` → `ErrRefusal`; hermetic httptest tables; env-driven example.

Part of #818 (Anthropic of OpenAI/Anthropic/Gemini). Gemini + server wiring follow.

Refs #818