### PR TITLE
feat(core/llm): Gemini generateContent structured-output backend

### DIFF
--- a/core/llm/gemini/example/main.go
+++ b/core/llm/gemini/example/main.go
@@ -1,0 +1,77 @@
+// Command example shows the public API of the core/llm/gemini package: build a
+// reusable Client, bind a structured-output type with New, and call Generate to
+// get a fully decoded value plus token usage and finish reason.
+//
+// It needs a real Gemini key, so it reads two env vars and is a no-op without
+// them. Run it from the core module with:
+//
+//	export GEMINI_API_KEY=...           # your key
+//	export GEMINI_MODEL=gemini-3        # any model id (never hard-coded)
+//	go run ./llm/gemini/example
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"os"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/llm"
+	"github.com/anaregdesign/lantern/core/llm/gemini"
+)
+
+// weather is the structured-output schema: New derives a strict JSON Schema from
+// it, and Generate decodes the model's JSON answer back into this type. Use
+// `json` tags for field names and the parent llm package's schema rules.
+type weather struct {
+	City string `json:"city"`
+	High int    `json:"high"`
+}
+
+func main() {
+	log.SetFlags(0)
+
+	apiKey := os.Getenv("GEMINI_API_KEY")
+	model := os.Getenv("GEMINI_MODEL")
+	if apiKey == "" || model == "" {
+		log.Println("set GEMINI_API_KEY and GEMINI_MODEL to run this example")
+		return
+	}
+
+	// A Client is non-generic, reusable, and concurrent-safe — it captures the
+	// key, model, and HTTP setup. The model id comes from the caller (env here),
+	// never hard-coded. Options tune the endpoint and limits; defaults are the
+	// public Gemini API and a 60s-timeout client.
+	client := gemini.NewClient(apiKey, model,
+		gemini.WithMaxTokens(256),
+		// gemini.WithBaseURL("https://my-proxy.example.com"), // proxy
+	)
+
+	// New binds output type T plus a fixed instruction into an llm.Model[T].
+	// Reuse one Client across many models with different instructions/types.
+	m, err := gemini.New[weather](client, "Report the weather as structured data.")
+	if err != nil {
+		log.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	resp, err := m.Generate(ctx, "What's the weather in Tokyo today? Make up a plausible high.")
+	if err != nil {
+		// A blocked response maps to ErrBlocked; everything else is a real error.
+		if errors.Is(err, gemini.ErrBlocked) {
+			log.Printf("blocked: %v", err)
+			return
+		}
+		log.Fatalf("Generate: %v", err)
+	}
+
+	// Output is the decoded weather; the rest is normalized metadata.
+	log.Printf("city=%s high=%d", resp.Output.City, resp.Output.High)
+	log.Printf("model=%s finish=%s tokens=%d", resp.Model, resp.FinishReason, resp.Usage.TotalTokens)
+	if resp.FinishReason == llm.FinishLength {
+		log.Println("note: output was truncated by max tokens")
+	}
+}

--- a/core/llm/gemini/gemini.go
+++ b/core/llm/gemini/gemini.go
@@ -1,0 +1,234 @@
+// Package gemini implements the llm.Model interface against Google's Gemini
+// generateContent API using a response schema (responseMimeType=application/json
+// + responseSchema). It depends only on the standard library and the parent llm
+// package, so core stays a leaf.
+//
+// A non-generic Client captures the endpoint, key, model, and HTTP client; the
+// generic New binds a structured-output type T and a fixed system instruction
+// into an llm.Model[T]. Go methods cannot take type parameters, so the schema is
+// fixed at construction by New rather than per call.
+package gemini
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/llm"
+)
+
+// DefaultBaseURL is the Gemini API root used when none is configured.
+const DefaultBaseURL = "https://generativelanguage.googleapis.com"
+
+// ErrBlocked is returned when generation is stopped by a safety or recitation
+// filter and no usable output is produced.
+var ErrBlocked = errors.New("gemini: response blocked")
+
+// Client is a non-generic, reusable handle to the Gemini generateContent API. It
+// is safe for concurrent use. Bind a structured-output type with New.
+type Client struct {
+	apiKey    string
+	model     string
+	baseURL   string
+	maxTokens int
+	http      *http.Client
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithBaseURL overrides the API root (e.g. a proxy). An empty string is ignored.
+// The path "/v1beta/models/{model}:generateContent" is always appended.
+func WithBaseURL(u string) Option {
+	return func(c *Client) {
+		if u != "" {
+			c.baseURL = strings.TrimRight(u, "/")
+		}
+	}
+}
+
+// WithHTTPClient sets the HTTP client used for requests. A nil client is ignored.
+func WithHTTPClient(h *http.Client) Option {
+	return func(c *Client) {
+		if h != nil {
+			c.http = h
+		}
+	}
+}
+
+// WithMaxTokens caps output tokens. Zero (the default) lets the server decide.
+func WithMaxTokens(n int) Option {
+	return func(c *Client) {
+		if n > 0 {
+			c.maxTokens = n
+		}
+	}
+}
+
+// NewClient builds a Client for the given model. apiKey authenticates via the
+// x-goog-api-key header; model is the provider model identifier (caller-supplied,
+// never hard-coded). Defaults: DefaultBaseURL and a 60s-timeout http.Client.
+func NewClient(apiKey, model string, opts ...Option) *Client {
+	c := &Client{
+		apiKey:  apiKey,
+		model:   model,
+		baseURL: DefaultBaseURL,
+		http:    &http.Client{Timeout: 60 * time.Second},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// New binds output type T and a fixed system instruction to client, yielding an
+// llm.Model[T]. The JSON schema is derived from T once; each Generate sends the
+// instruction plus the call's input. The model is reusable and concurrent-safe.
+func New[T any](client *Client, instruction string) (llm.Model[T], error) {
+	schema, err := llm.SchemaFor[T]()
+	if err != nil {
+		return nil, err
+	}
+	return &model[T]{client: client, instruction: instruction, schema: schema.Definition}, nil
+}
+
+// model binds an output type T, a fixed instruction, and the derived JSON schema
+// to a Client. It satisfies llm.Model[T].
+type model[T any] struct {
+	client      *Client
+	instruction string
+	schema      json.RawMessage
+}
+
+// Generate sends the instruction plus input, then decodes the response JSON into T.
+func (m *model[T]) Generate(ctx context.Context, input string) (llm.Response[T], error) {
+	r, err := m.client.generate(ctx, m.instruction, input, m.schema)
+	if err != nil {
+		return llm.Response[T]{}, err
+	}
+	var out T
+	if err := json.Unmarshal([]byte(r.text), &out); err != nil {
+		return llm.Response[T]{}, fmt.Errorf("gemini: decode output: %w", err)
+	}
+	return llm.Response[T]{Output: out, Usage: r.usage, FinishReason: r.finish, Model: r.model}, nil
+}
+
+type request struct {
+	SystemInstruction *content         `json:"systemInstruction,omitempty"`
+	Contents          []content        `json:"contents"`
+	GenerationConfig  generationConfig `json:"generationConfig"`
+}
+
+type content struct {
+	Role  string `json:"role,omitempty"`
+	Parts []part `json:"parts"`
+}
+
+type part struct {
+	Text string `json:"text"`
+}
+
+type generationConfig struct {
+	ResponseMimeType string          `json:"responseMimeType"`
+	ResponseSchema   json.RawMessage `json:"responseSchema"`
+	MaxOutputTokens  int             `json:"maxOutputTokens,omitempty"`
+}
+
+type response struct {
+	ModelVersion string `json:"modelVersion"`
+	Candidates   []struct {
+		Content      content `json:"content"`
+		FinishReason string  `json:"finishReason"`
+	} `json:"candidates"`
+	UsageMetadata struct {
+		PromptTokenCount     int `json:"promptTokenCount"`
+		CandidatesTokenCount int `json:"candidatesTokenCount"`
+		TotalTokenCount      int `json:"totalTokenCount"`
+	} `json:"usageMetadata"`
+}
+
+// result is generate's non-generic output: the raw JSON text plus metadata. The
+// generic New closure decodes text into T.
+type result struct {
+	text   string
+	usage  llm.Usage
+	finish llm.FinishReason
+	model  string
+}
+
+func (c *Client) generate(ctx context.Context, instruction, input string, schema json.RawMessage) (result, error) {
+	body, err := json.Marshal(request{
+		SystemInstruction: &content{Parts: []part{{Text: instruction}}},
+		Contents:          []content{{Role: "user", Parts: []part{{Text: input}}}},
+		GenerationConfig: generationConfig{
+			ResponseMimeType: "application/json",
+			ResponseSchema:   schema,
+			MaxOutputTokens:  c.maxTokens,
+		},
+	})
+	if err != nil {
+		return result{}, fmt.Errorf("gemini: marshal request: %w", err)
+	}
+
+	url := c.baseURL + "/v1beta/models/" + c.model + ":generateContent"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return result{}, fmt.Errorf("gemini: build request: %w", err)
+	}
+	httpReq.Header.Set("x-goog-api-key", c.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := c.http.Do(httpReq)
+	if err != nil {
+		return result{}, fmt.Errorf("gemini: do request: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	payload, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return result{}, fmt.Errorf("gemini: read response: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		return result{}, fmt.Errorf("gemini: status %d: %s", httpResp.StatusCode, strings.TrimSpace(string(payload)))
+	}
+
+	var r response
+	if err := json.Unmarshal(payload, &r); err != nil {
+		return result{}, fmt.Errorf("gemini: decode response: %w", err)
+	}
+	usage := llm.Usage{
+		InputTokens:  r.UsageMetadata.PromptTokenCount,
+		OutputTokens: r.UsageMetadata.CandidatesTokenCount,
+		TotalTokens:  r.UsageMetadata.TotalTokenCount,
+	}
+	for _, cand := range r.Candidates {
+		for _, p := range cand.Content.Parts {
+			if p.Text != "" {
+				return result{text: p.Text, usage: usage, finish: finishReason(cand.FinishReason), model: r.ModelVersion}, nil
+			}
+		}
+		if cand.FinishReason == "SAFETY" || cand.FinishReason == "RECITATION" {
+			return result{}, fmt.Errorf("%w: %s", ErrBlocked, cand.FinishReason)
+		}
+	}
+	return result{}, errors.New("gemini: no content in response")
+}
+
+func finishReason(r string) llm.FinishReason {
+	switch r {
+	case "STOP":
+		return llm.FinishStop
+	case "MAX_TOKENS":
+		return llm.FinishLength
+	case "SAFETY", "RECITATION":
+		return llm.FinishContentFilter
+	default:
+		return llm.FinishOther
+	}
+}

--- a/core/llm/gemini/gemini_test.go
+++ b/core/llm/gemini/gemini_test.go
@@ -1,0 +1,113 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/anaregdesign/lantern/core/llm"
+)
+
+type weather struct {
+	City string `json:"city"`
+	High int    `json:"high"`
+}
+
+func TestGenerate(t *testing.T) {
+	var gotPath, gotKey string
+	var gotBody request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotKey = r.Header.Get("x-goog-api-key")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"modelVersion":"gemini-3","candidates":[{"content":{"parts":[`+
+			`{"text":"{\"city\":\"Tokyo\",\"high\":31}"}]},"finishReason":"STOP"}],`+
+			`"usageMetadata":{"promptTokenCount":12,"candidatesTokenCount":7,"totalTokenCount":19}}`)
+	}))
+	defer srv.Close()
+
+	m, err := New[weather](NewClient("sk-test", "gemini-3", WithBaseURL(srv.URL)), "report weather")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	resp, err := m.Generate(context.Background(), "Tokyo")
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if resp.Output != (weather{City: "Tokyo", High: 31}) {
+		t.Errorf("Output = %+v, want Tokyo/31", resp.Output)
+	}
+	if resp.Usage != (llm.Usage{InputTokens: 12, OutputTokens: 7, TotalTokens: 19}) {
+		t.Errorf("Usage = %+v", resp.Usage)
+	}
+	if resp.FinishReason != llm.FinishStop {
+		t.Errorf("FinishReason = %q, want stop", resp.FinishReason)
+	}
+	if resp.Model != "gemini-3" {
+		t.Errorf("Model = %q", resp.Model)
+	}
+	if gotPath != "/v1beta/models/gemini-3:generateContent" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotKey != "sk-test" {
+		t.Errorf("x-goog-api-key = %q", gotKey)
+	}
+	if gotBody.SystemInstruction == nil || len(gotBody.SystemInstruction.Parts) != 1 ||
+		gotBody.SystemInstruction.Parts[0].Text != "report weather" {
+		t.Errorf("systemInstruction = %+v", gotBody.SystemInstruction)
+	}
+	if gotBody.GenerationConfig.ResponseMimeType != "application/json" {
+		t.Errorf("responseMimeType = %q", gotBody.GenerationConfig.ResponseMimeType)
+	}
+}
+
+func TestGenerateBlocked(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"candidates":[{"content":{"parts":[]},"finishReason":"SAFETY"}]}`)
+	}))
+	defer srv.Close()
+
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	if _, err := m.Generate(context.Background(), "y"); !errors.Is(err, ErrBlocked) {
+		t.Fatalf("err = %v, want ErrBlocked", err)
+	}
+}
+
+func TestGenerateLength(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"candidates":[{"content":{"parts":[{"text":"{\"city\":\"A\",\"high\":1}"}]},`+
+			`"finishReason":"MAX_TOKENS"}]}`)
+	}))
+	defer srv.Close()
+
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	resp, err := m.Generate(context.Background(), "y")
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if resp.FinishReason != llm.FinishLength {
+		t.Errorf("FinishReason = %q, want length", resp.FinishReason)
+	}
+}
+
+func TestGenerateHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, "bad key")
+	}))
+	defer srv.Close()
+
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	_, err := m.Generate(context.Background(), "y")
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Fatalf("err = %v, want 401", err)
+	}
+}


### PR DESCRIPTION
Adds `core/llm/gemini` — net/http backend implementing `llm.Model[T]` via generateContent (responseMimeType=application/json + responseSchema), mirroring OpenAI (#819) / Anthropic (#820). x-goog-api-key header, systemInstruction, finishReason mapping (SAFETY/RECITATION→ErrBlocked), hermetic httptest tables, env-driven example. Refs #818