### PR TITLE
feat: unify LLM reasoning effort across OpenAI/Anthropic/Gemini

### DIFF
--- a/core/llm/anthropic/anthropic.go
+++ b/core/llm/anthropic/anthropic.go
@@ -36,6 +36,19 @@ const DefaultMaxTokens = 1024
 // ErrRefusal is returned when the model declines to answer.
 var ErrRefusal = errors.New("anthropic: model refused to answer")
 
+// Effort selects the extended-thinking effort for thinking-capable models. The
+// empty value disables extended thinking and omits the parameter entirely.
+type Effort string
+
+const (
+	// EffortLow requests low thinking effort.
+	EffortLow Effort = "low"
+	// EffortMedium requests medium thinking effort.
+	EffortMedium Effort = "medium"
+	// EffortHigh requests high thinking effort.
+	EffortHigh Effort = "high"
+)
+
 // Client is a non-generic, reusable handle to the Anthropic Messages API. It is
 // safe for concurrent use. Bind a structured-output type with New.
 type Client struct {
@@ -106,28 +119,30 @@ func NewClient(apiKey, model string, opts ...Option) *Client {
 	return c
 }
 
-// New binds output type T and a fixed system instruction to client, yielding an
-// llm.Model[T]. The JSON schema is derived from T once; each Generate sends the
-// instruction plus the call's input. The model is reusable and concurrent-safe.
-func New[T any](client *Client, instruction string) (llm.Model[T], error) {
+// New binds output type T, a fixed system instruction, and a thinking effort to
+// client, yielding an llm.Model[T]. The JSON schema is derived from T once; each
+// Generate sends the instruction plus the call's input. An empty effort omits
+// extended thinking. The model is reusable and concurrent-safe.
+func New[T any](client *Client, instruction string, effort Effort) (llm.Model[T], error) {
 	schema, err := llm.SchemaFor[T]()
 	if err != nil {
 		return nil, err
 	}
-	return &model[T]{client: client, instruction: instruction, schema: schema.Definition}, nil
+	return &model[T]{client: client, instruction: instruction, schema: schema.Definition, effort: effort}, nil
 }
 
-// model binds an output type T, a fixed instruction, and the derived JSON schema
-// to a Client. It satisfies llm.Model[T].
+// model binds an output type T, a fixed instruction, the derived JSON schema, and
+// a thinking effort to a Client. It satisfies llm.Model[T].
 type model[T any] struct {
 	client      *Client
 	instruction string
 	schema      json.RawMessage
+	effort      Effort
 }
 
 // Generate sends the instruction plus input, then decodes the response JSON into T.
 func (m *model[T]) Generate(ctx context.Context, input string) (llm.Response[T], error) {
-	r, err := m.client.generate(ctx, m.instruction, input, m.schema)
+	r, err := m.client.generate(ctx, m.instruction, input, m.schema, m.effort)
 	if err != nil {
 		return llm.Response[T]{}, err
 	}
@@ -139,11 +154,17 @@ func (m *model[T]) Generate(ctx context.Context, input string) (llm.Response[T],
 }
 
 type request struct {
-	Model        string        `json:"model"`
-	MaxTokens    int           `json:"max_tokens"`
-	System       string        `json:"system,omitempty"`
-	Messages     []message     `json:"messages"`
-	OutputConfig *outputConfig `json:"output_config,omitempty"`
+	Model        string          `json:"model"`
+	MaxTokens    int             `json:"max_tokens"`
+	System       string          `json:"system,omitempty"`
+	Messages     []message       `json:"messages"`
+	OutputConfig *outputConfig   `json:"output_config,omitempty"`
+	Thinking     *thinkingConfig `json:"thinking,omitempty"`
+}
+
+type thinkingConfig struct {
+	Type   string `json:"type"`
+	Effort string `json:"effort"`
 }
 
 type message struct {
@@ -182,7 +203,11 @@ type result struct {
 	model  string
 }
 
-func (c *Client) generate(ctx context.Context, instruction, input string, schema json.RawMessage) (result, error) {
+func (c *Client) generate(ctx context.Context, instruction, input string, schema json.RawMessage, effort Effort) (result, error) {
+	var thinking *thinkingConfig
+	if effort != "" {
+		thinking = &thinkingConfig{Type: "enabled", Effort: string(effort)}
+	}
 	body, err := json.Marshal(request{
 		Model:     c.model,
 		MaxTokens: c.maxTokens,
@@ -192,6 +217,7 @@ func (c *Client) generate(ctx context.Context, instruction, input string, schema
 			Type:   "json_schema",
 			Schema: schema,
 		}},
+		Thinking: thinking,
 	})
 	if err != nil {
 		return result{}, fmt.Errorf("anthropic: marshal request: %w", err)

--- a/core/llm/anthropic/anthropic_test.go
+++ b/core/llm/anthropic/anthropic_test.go
@@ -34,7 +34,7 @@ func TestGenerate(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	m, err := New[weather](NewClient("sk-test", "claude-opus", WithBaseURL(srv.URL)), "report weather")
+	m, err := New[weather](NewClient("sk-test", "claude-opus", WithBaseURL(srv.URL)), "report weather", EffortHigh)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -70,6 +70,9 @@ func TestGenerate(t *testing.T) {
 	if gotBody.OutputConfig == nil || gotBody.OutputConfig.Format.Type != "json_schema" {
 		t.Errorf("output_config = %+v", gotBody.OutputConfig)
 	}
+	if gotBody.Thinking == nil || gotBody.Thinking.Type != "enabled" || gotBody.Thinking.Effort != "high" {
+		t.Errorf("thinking = %+v, want enabled/high", gotBody.Thinking)
+	}
 }
 
 func TestGenerateRefusal(t *testing.T) {
@@ -78,7 +81,7 @@ func TestGenerateRefusal(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x", "")
 	if _, err := m.Generate(context.Background(), "y"); !errors.Is(err, ErrRefusal) {
 		t.Fatalf("err = %v, want ErrRefusal", err)
 	}
@@ -91,7 +94,7 @@ func TestGenerateLength(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x", "")
 	resp, err := m.Generate(context.Background(), "y")
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -108,7 +111,7 @@ func TestGenerateHTTPError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x", "")
 	_, err := m.Generate(context.Background(), "y")
 	if err == nil || !strings.Contains(err.Error(), "401") {
 		t.Fatalf("err = %v, want 401", err)

--- a/core/llm/anthropic/example/main.go
+++ b/core/llm/anthropic/example/main.go
@@ -49,7 +49,7 @@ func main() {
 
 	// New binds output type T plus a fixed instruction into an llm.Model[T].
 	// Reuse one Client across many models with different instructions/types.
-	m, err := anthropic.New[weather](client, "Report the weather as structured data.")
+	m, err := anthropic.New[weather](client, "Report the weather as structured data.", anthropic.EffortMedium)
 	if err != nil {
 		log.Fatalf("New: %v", err)
 	}

--- a/core/llm/gemini/example/main.go
+++ b/core/llm/gemini/example/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	// New binds output type T plus a fixed instruction into an llm.Model[T].
 	// Reuse one Client across many models with different instructions/types.
-	m, err := gemini.New[weather](client, "Report the weather as structured data.")
+	m, err := gemini.New[weather](client, "Report the weather as structured data.", gemini.EffortMedium)
 	if err != nil {
 		log.Fatalf("New: %v", err)
 	}

--- a/core/llm/gemini/gemini.go
+++ b/core/llm/gemini/gemini.go
@@ -30,6 +30,19 @@ const DefaultBaseURL = "https://generativelanguage.googleapis.com"
 // filter and no usable output is produced.
 var ErrBlocked = errors.New("gemini: response blocked")
 
+// Effort selects the thinking level for thinking-capable models. The empty value
+// lets the server decide and omits the parameter entirely.
+type Effort string
+
+const (
+	// EffortLow requests low thinking.
+	EffortLow Effort = "low"
+	// EffortMedium requests medium thinking.
+	EffortMedium Effort = "medium"
+	// EffortHigh requests high thinking.
+	EffortHigh Effort = "high"
+)
+
 // Client is a non-generic, reusable handle to the Gemini generateContent API. It
 // is safe for concurrent use. Bind a structured-output type with New.
 type Client struct {
@@ -87,28 +100,30 @@ func NewClient(apiKey, model string, opts ...Option) *Client {
 	return c
 }
 
-// New binds output type T and a fixed system instruction to client, yielding an
-// llm.Model[T]. The JSON schema is derived from T once; each Generate sends the
-// instruction plus the call's input. The model is reusable and concurrent-safe.
-func New[T any](client *Client, instruction string) (llm.Model[T], error) {
+// New binds output type T, a fixed system instruction, and a thinking effort to
+// client, yielding an llm.Model[T]. The JSON schema is derived from T once; each
+// Generate sends the instruction plus the call's input. An empty effort lets the
+// server decide. The model is reusable and concurrent-safe.
+func New[T any](client *Client, instruction string, effort Effort) (llm.Model[T], error) {
 	schema, err := llm.SchemaFor[T]()
 	if err != nil {
 		return nil, err
 	}
-	return &model[T]{client: client, instruction: instruction, schema: schema.Definition}, nil
+	return &model[T]{client: client, instruction: instruction, schema: schema.Definition, effort: effort}, nil
 }
 
-// model binds an output type T, a fixed instruction, and the derived JSON schema
-// to a Client. It satisfies llm.Model[T].
+// model binds an output type T, a fixed instruction, the derived JSON schema, and
+// a thinking effort to a Client. It satisfies llm.Model[T].
 type model[T any] struct {
 	client      *Client
 	instruction string
 	schema      json.RawMessage
+	effort      Effort
 }
 
 // Generate sends the instruction plus input, then decodes the response JSON into T.
 func (m *model[T]) Generate(ctx context.Context, input string) (llm.Response[T], error) {
-	r, err := m.client.generate(ctx, m.instruction, input, m.schema)
+	r, err := m.client.generate(ctx, m.instruction, input, m.schema, m.effort)
 	if err != nil {
 		return llm.Response[T]{}, err
 	}
@@ -138,6 +153,11 @@ type generationConfig struct {
 	ResponseMimeType string          `json:"responseMimeType"`
 	ResponseSchema   json.RawMessage `json:"responseSchema"`
 	MaxOutputTokens  int             `json:"maxOutputTokens,omitempty"`
+	ThinkingConfig   *thinkingConfig `json:"thinkingConfig,omitempty"`
+}
+
+type thinkingConfig struct {
+	ThinkingLevel string `json:"thinkingLevel"`
 }
 
 type response struct {
@@ -162,7 +182,11 @@ type result struct {
 	model  string
 }
 
-func (c *Client) generate(ctx context.Context, instruction, input string, schema json.RawMessage) (result, error) {
+func (c *Client) generate(ctx context.Context, instruction, input string, schema json.RawMessage, effort Effort) (result, error) {
+	var thinking *thinkingConfig
+	if effort != "" {
+		thinking = &thinkingConfig{ThinkingLevel: string(effort)}
+	}
 	body, err := json.Marshal(request{
 		SystemInstruction: &content{Parts: []part{{Text: instruction}}},
 		Contents:          []content{{Role: "user", Parts: []part{{Text: input}}}},
@@ -170,6 +194,7 @@ func (c *Client) generate(ctx context.Context, instruction, input string, schema
 			ResponseMimeType: "application/json",
 			ResponseSchema:   schema,
 			MaxOutputTokens:  c.maxTokens,
+			ThinkingConfig:   thinking,
 		},
 	})
 	if err != nil {

--- a/core/llm/gemini/gemini_test.go
+++ b/core/llm/gemini/gemini_test.go
@@ -33,7 +33,7 @@ func TestGenerate(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	m, err := New[weather](NewClient("sk-test", "gemini-3", WithBaseURL(srv.URL)), "report weather")
+	m, err := New[weather](NewClient("sk-test", "gemini-3", WithBaseURL(srv.URL)), "report weather", EffortHigh)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -67,6 +67,9 @@ func TestGenerate(t *testing.T) {
 	if gotBody.GenerationConfig.ResponseMimeType != "application/json" {
 		t.Errorf("responseMimeType = %q", gotBody.GenerationConfig.ResponseMimeType)
 	}
+	if gotBody.GenerationConfig.ThinkingConfig == nil || gotBody.GenerationConfig.ThinkingConfig.ThinkingLevel != "high" {
+		t.Errorf("thinkingConfig = %+v, want level high", gotBody.GenerationConfig.ThinkingConfig)
+	}
 }
 
 func TestGenerateBlocked(t *testing.T) {
@@ -75,7 +78,7 @@ func TestGenerateBlocked(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x", "")
 	if _, err := m.Generate(context.Background(), "y"); !errors.Is(err, ErrBlocked) {
 		t.Fatalf("err = %v, want ErrBlocked", err)
 	}
@@ -88,7 +91,7 @@ func TestGenerateLength(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x", "")
 	resp, err := m.Generate(context.Background(), "y")
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -105,7 +108,7 @@ func TestGenerateHTTPError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x", "")
 	_, err := m.Generate(context.Background(), "y")
 	if err == nil || !strings.Contains(err.Error(), "401") {
 		t.Fatalf("err = %v, want 401", err)

--- a/core/llm/openai/example/main.go
+++ b/core/llm/openai/example/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	// New binds output type T plus a fixed instruction into an llm.Model[T].
 	// Reuse one Client across many models with different instructions/types.
-	m, err := openai.New[weather](client, "Report the weather as structured data.")
+	m, err := openai.New[weather](client, "Report the weather as structured data.", openai.EffortMedium)
 	if err != nil {
 		log.Fatalf("New: %v", err)
 	}

--- a/core/llm/openai/openai.go
+++ b/core/llm/openai/openai.go
@@ -29,6 +29,21 @@ const DefaultBaseURL = "https://api.openai.com"
 // is wrapped for context.
 var ErrRefusal = errors.New("openai: model refused to answer")
 
+// Effort selects the reasoning effort for reasoning-capable models. The empty
+// value lets the server decide and omits the parameter entirely.
+type Effort string
+
+const (
+	// EffortMinimal requests the least reasoning.
+	EffortMinimal Effort = "minimal"
+	// EffortLow requests low reasoning.
+	EffortLow Effort = "low"
+	// EffortMedium requests medium reasoning.
+	EffortMedium Effort = "medium"
+	// EffortHigh requests high reasoning.
+	EffortHigh Effort = "high"
+)
+
 // Client is a non-generic, reusable handle to the OpenAI Responses API. It is
 // safe for concurrent use. Bind a structured-output type with New.
 type Client struct {
@@ -86,10 +101,11 @@ func NewClient(apiKey, model string, opts ...Option) *Client {
 	return c
 }
 
-// New binds output type T and a fixed system instruction to client, yielding an
-// llm.Model[T]. The JSON schema is derived from T once; each Generate sends the
-// instruction plus the call's input. The model is reusable and concurrent-safe.
-func New[T any](client *Client, instruction string) (llm.Model[T], error) {
+// New binds output type T, a fixed system instruction, and a reasoning effort to
+// client, yielding an llm.Model[T]. The JSON schema is derived from T once; each
+// Generate sends the instruction plus the call's input. An empty effort omits
+// the reasoning parameter. The model is reusable and concurrent-safe.
+func New[T any](client *Client, instruction string, effort Effort) (llm.Model[T], error) {
 	schema, err := llm.SchemaFor[T]()
 	if err != nil {
 		return nil, err
@@ -98,21 +114,22 @@ func New[T any](client *Client, instruction string) (llm.Model[T], error) {
 	if name == "" {
 		name = "output"
 	}
-	return &model[T]{client: client, instruction: instruction, name: name, schema: schema.Definition}, nil
+	return &model[T]{client: client, instruction: instruction, name: name, schema: schema.Definition, effort: effort}, nil
 }
 
-// model binds an output type T, a fixed instruction, and the derived JSON schema
-// to a Client. It satisfies llm.Model[T].
+// model binds an output type T, a fixed instruction, the derived JSON schema, and
+// a reasoning effort to a Client. It satisfies llm.Model[T].
 type model[T any] struct {
 	client      *Client
 	instruction string
 	name        string
 	schema      json.RawMessage
+	effort      Effort
 }
 
 // Generate sends the instruction plus input, then decodes the response JSON into T.
 func (m *model[T]) Generate(ctx context.Context, input string) (llm.Response[T], error) {
-	r, err := m.client.generate(ctx, m.instruction, input, m.name, m.schema)
+	r, err := m.client.generate(ctx, m.instruction, input, m.name, m.schema, m.effort)
 	if err != nil {
 		return llm.Response[T]{}, err
 	}
@@ -124,11 +141,16 @@ func (m *model[T]) Generate(ctx context.Context, input string) (llm.Response[T],
 }
 
 type request struct {
-	Model           string     `json:"model"`
-	Instructions    string     `json:"instructions,omitempty"`
-	Input           string     `json:"input"`
-	Text            textConfig `json:"text"`
-	MaxOutputTokens int        `json:"max_output_tokens,omitempty"`
+	Model           string           `json:"model"`
+	Instructions    string           `json:"instructions,omitempty"`
+	Input           string           `json:"input"`
+	Text            textConfig       `json:"text"`
+	MaxOutputTokens int              `json:"max_output_tokens,omitempty"`
+	Reasoning       *reasoningConfig `json:"reasoning,omitempty"`
+}
+
+type reasoningConfig struct {
+	Effort string `json:"effort"`
 }
 
 type textConfig struct {
@@ -171,7 +193,11 @@ type result struct {
 	model  string
 }
 
-func (c *Client) generate(ctx context.Context, instruction, input, name string, schema json.RawMessage) (result, error) {
+func (c *Client) generate(ctx context.Context, instruction, input, name string, schema json.RawMessage, effort Effort) (result, error) {
+	var reasoning *reasoningConfig
+	if effort != "" {
+		reasoning = &reasoningConfig{Effort: string(effort)}
+	}
 	body, err := json.Marshal(request{
 		Model:        c.model,
 		Instructions: instruction,
@@ -183,6 +209,7 @@ func (c *Client) generate(ctx context.Context, instruction, input, name string, 
 			Schema: schema,
 		}},
 		MaxOutputTokens: c.maxTokens,
+		Reasoning:       reasoning,
 	})
 	if err != nil {
 		return result{}, fmt.Errorf("openai: marshal request: %w", err)

--- a/core/llm/openai/openai_test.go
+++ b/core/llm/openai/openai_test.go
@@ -33,7 +33,7 @@ func TestGenerate(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	m, err := New[weather](NewClient("sk-test", "gpt-5.5", WithBaseURL(srv.URL)), "report weather")
+	m, err := New[weather](NewClient("sk-test", "gpt-5.5", WithBaseURL(srv.URL)), "report weather", EffortHigh)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -63,6 +63,9 @@ func TestGenerate(t *testing.T) {
 	if gotBody.Model != "gpt-5.5" || gotBody.Instructions != "report weather" || !gotBody.Text.Format.Strict {
 		t.Errorf("request = %+v", gotBody)
 	}
+	if gotBody.Reasoning == nil || gotBody.Reasoning.Effort != "high" {
+		t.Errorf("reasoning = %+v, want effort high", gotBody.Reasoning)
+	}
 }
 
 func TestGenerateRefusal(t *testing.T) {
@@ -71,7 +74,7 @@ func TestGenerateRefusal(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x", "")
 	if _, err := m.Generate(context.Background(), "y"); !errors.Is(err, ErrRefusal) {
 		t.Fatalf("err = %v, want ErrRefusal", err)
 	}
@@ -84,7 +87,7 @@ func TestGenerateLength(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x", "")
 	resp, err := m.Generate(context.Background(), "y")
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -101,7 +104,7 @@ func TestGenerateHTTPError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x")
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x", "")
 	_, err := m.Generate(context.Background(), "y")
 	if err == nil || !strings.Contains(err.Error(), "401") {
 		t.Fatalf("err = %v, want 401", err)


### PR DESCRIPTION
Unifies reasoning/thinking on a shared `Effort` enum (low/medium/high) bound at `New()`.

- OpenAI: `reasoning.effort`
- Anthropic: `thinking.effort` (replaces deprecated budget_tokens)
- Gemini: `thinkingConfig.thinkingLevel` (replaces thinkingBudget)

Empty effort omits the parameter. Examples and tests updated; gofmt clean, tests pass.

Closes #822