### PR TITLE
fix(core): strip additionalProperties from Gemini responseSchema

### DIFF
--- a/core/llm/gemini/gemini.go
+++ b/core/llm/gemini/gemini.go
@@ -109,7 +109,38 @@ func New[T any](client *Client, instruction string, effort Effort) (llm.Model[T]
 	if err != nil {
 		return nil, err
 	}
-	return &model[T]{client: client, instruction: instruction, schema: schema.Definition, effort: effort}, nil
+	def, err := sanitizeSchema(schema.Definition)
+	if err != nil {
+		return nil, fmt.Errorf("gemini: sanitize schema: %w", err)
+	}
+	return &model[T]{client: client, instruction: instruction, schema: def, effort: effort}, nil
+}
+
+// sanitizeSchema rewrites the canonical JSON Schema produced by llm.SchemaFor
+// into the subset Gemini's responseSchema accepts. Gemini follows an OpenAPI 3.0
+// subset that rejects "additionalProperties", so it is stripped recursively.
+func sanitizeSchema(raw json.RawMessage) (json.RawMessage, error) {
+	var doc any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, err
+	}
+	stripUnsupported(doc)
+	return json.Marshal(doc)
+}
+
+// stripUnsupported walks a decoded JSON document and removes keys Gemini rejects.
+func stripUnsupported(node any) {
+	switch v := node.(type) {
+	case map[string]any:
+		delete(v, "additionalProperties")
+		for _, child := range v {
+			stripUnsupported(child)
+		}
+	case []any:
+		for _, child := range v {
+			stripUnsupported(child)
+		}
+	}
 }
 
 // model binds an output type T, a fixed instruction, the derived JSON schema, and

--- a/core/llm/gemini/gemini_test.go
+++ b/core/llm/gemini/gemini_test.go
@@ -114,3 +114,25 @@ func TestGenerateHTTPError(t *testing.T) {
 		t.Fatalf("err = %v, want 401", err)
 	}
 }
+
+func TestResponseSchemaStripsAdditionalProperties(t *testing.T) {
+	var gotBody request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		_, _ = io.WriteString(w, `{"candidates":[{"content":{"parts":[`+
+			`{"text":"{\"city\":\"Tokyo\",\"high\":1}"}]},"finishReason":"STOP"}]}`)
+	}))
+	defer srv.Close()
+
+	m, err := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := m.Generate(context.Background(), "y"); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if strings.Contains(string(gotBody.GenerationConfig.ResponseSchema), "additionalProperties") {
+		t.Errorf("responseSchema must not contain additionalProperties: %s", gotBody.GenerationConfig.ResponseSchema)
+	}
+}


### PR DESCRIPTION
## Summary
`core/llm/gemini` was unusable for structured output: `llm.SchemaFor` emits `additionalProperties:false` (OpenAI strict mode), which Gemini's `responseSchema` (OpenAPI 3.0 subset) rejects — every call returned `400 Unknown name "additionalProperties"`.

`gemini.New` now strips `additionalProperties` recursively before binding the schema.

## Verification
- New regression test asserts the sent `responseSchema` has no `additionalProperties`.
- `go test ./llm/gemini/` passes; `gofmt` clean.
- Real call against `gemini-3.5-flash` returns `{"city":"Tokyo","high":20}`.

Closes #824