### PR TITLE
feat(server): validate env config at boot and generate the env reference

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -170,13 +170,17 @@ jobs:
         run: buf format -d --exit-code
       - name: buf lint
         run: buf lint
-      - name: Generated code is up to date (wire + buf)
+      - name: Generated code is up to date (wire + buf + envdoc)
         env:
           GOWORK: 'off'
         run: |
           go generate ./...
+          # docs/env.md is generated from the server module's envconfig
+          # registry (#847); go generate from the repo root does not descend
+          # into the nested module, so regenerate it explicitly.
+          (cd server && go run ./internal/envdoc/cmd -out ../docs/env.md)
           if ! git diff --exit-code; then
-            echo "::error::generated files are stale; run 'go generate ./...' and commit the result"
+            echo "::error::generated files are stale; run 'go generate ./...' and 'make envdoc', then commit the result"
             exit 1
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ifeq ($(BUF),)
 BUF := go run github.com/bufbuild/buf/cmd/buf@$(BUF_VERSION)
 endif
 
-.PHONY: all generate wire proto proto-lint proto-format proto-breaking proto-deps \
+.PHONY: all generate wire envdoc proto proto-lint proto-format proto-breaking proto-deps \
         build test test-race fmt vet lint tidy vuln clean
 
 # `go generate ./...` is the single source of truth: it runs `go tool wire`
@@ -23,6 +23,11 @@ generate:
 # Backwards-compatible aliases for muscle memory.
 wire:
 	cd server && go tool wire ./cmd
+
+# Regenerate the operator-facing env-var reference (docs/env.md) from the
+# envconfig registry (#847). Also runs as part of `go generate ./...`.
+envdoc:
+	cd server && go run ./internal/envdoc/cmd -out ../docs/env.md
 
 proto:
 	$(BUF) generate

--- a/docs/env.md
+++ b/docs/env.md
@@ -25,8 +25,8 @@ value is treated as unset for the non-string kinds. The MCP server's
 | `LANTERN_COMMIT` | string | (empty) | Overrides the commit label reported in lantern_build_info. |
 | `LANTERN_CORS_ALLOWED_ORIGINS` | string | (empty) | Comma-separated browser origins allowed by CORS (e.g. the admin SPA origin); empty disables CORS. |
 | `LANTERN_DEFAULT_TTL_SECONDS` | int | `60` | Reported in GetServerStatus and startup logs only; RPC writes without an expiration are permanent (decay is opt-in per write, #523). |
-| `LANTERN_DELETE_BY_PREFIX_DEFAULT_LIMIT` | int | `10000` | Deletion cap used when DeleteVerticesByPrefix leaves limit unset. |
-| `LANTERN_DELETE_BY_PREFIX_MAX_LIMIT` | int | `100000` | Ceiling DeleteVerticesByPrefix's limit is clamped to. |
+| `LANTERN_DELETE_BY_PREFIX_DEFAULT_LIMIT` | uint32 | `10000` | Deletion cap used when DeleteVerticesByPrefix leaves limit unset. |
+| `LANTERN_DELETE_BY_PREFIX_MAX_LIMIT` | uint32 | `100000` | Ceiling DeleteVerticesByPrefix's limit is clamped to. |
 | `LANTERN_DRAIN_DELAY_SECONDS` | int | `0` | Zero-drop rolling-update window: keep serving this long after readiness flips NOT_SERVING (0 = disabled). |
 | `LANTERN_GC_INTERVAL_SECONDS` | int | `60` | Graph-cache GC tick interval in seconds (expired vertex/edge sweep). |
 | `LANTERN_ILLUMINATE_MAX_K` | int | `1024` | Upper bound on the Illuminate k parameter. |
@@ -34,7 +34,7 @@ value is treated as unset for the non-string kinds. The MCP server's
 | `LANTERN_LOG_FORMAT` | string | `json` | Log output format: json or text. |
 | `LANTERN_LOG_LEVEL` | level | `info` | Structured-log level: debug, info, warn, or error. |
 | `LANTERN_MAX_BATCH_SIZE` | int | `10000` | Maximum items accepted per batch RPC (Put/Get/Add/Delete plural forms). |
-| `LANTERN_MAX_CONCURRENT_STREAMS` | int | `1024` | HTTP/2 max concurrent streams per connection (0 = unlimited). |
+| `LANTERN_MAX_CONCURRENT_STREAMS` | uint32 | `1024` | HTTP/2 max concurrent streams per connection (0 = unlimited). |
 | `LANTERN_MAX_KEY_LEN` | int | `1024` | Maximum accepted vertex-key length in bytes. |
 | `LANTERN_MAX_RECV_MSG_BYTES` | int | `16777216` | Maximum accepted request message size in bytes. |
 | `LANTERN_MAX_REPLICATION_LAG` | int | `10000` | Readiness gate: maximum tolerated replication lag (entries) before /readyz reports not ready. |
@@ -56,8 +56,8 @@ value is treated as unset for the non-string kinds. The MCP server's
 | `LANTERN_RATE_LIMIT_BURST` | int | `0` | Token-bucket burst size; when unset or <= 0 it resolves to 2x LANTERN_RATE_LIMIT_RPS. |
 | `LANTERN_RATE_LIMIT_RPS` | float | `0` | Process-wide token-bucket refill rate in requests/second (0 disables rate limiting). |
 | `LANTERN_REFLECTION` | bool | `true` | Serve gRPC server reflection on the primary listener. |
-| `LANTERN_SCAN_DEFAULT_LIMIT` | int | `1000` | Page size used when a Scan* request leaves limit unset. |
-| `LANTERN_SCAN_MAX_LIMIT` | int | `10000` | Ceiling a Scan* request's limit is clamped to. |
+| `LANTERN_SCAN_DEFAULT_LIMIT` | uint32 | `1000` | Page size used when a Scan* request leaves limit unset. |
+| `LANTERN_SCAN_MAX_LIMIT` | uint32 | `10000` | Ceiling a Scan* request's limit is clamped to. |
 | `LANTERN_SEARCH_DEFAULT_LIMIT` | uint32 | `100` | Ranked-hit count used when SearchVertices leaves limit unset. |
 | `LANTERN_SEARCH_ENABLED` | bool | `true` | Build the full-text search index and serve SearchVertices (off = FAILED_PRECONDITION). |
 | `LANTERN_SEARCH_MAX_LIMIT` | uint32 | `1000` | Ceiling SearchVertices' limit is clamped to. |

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,0 +1,71 @@
+# Lantern server environment variables
+
+<!-- GENERATED FILE - do not edit. Regenerate with `make envdoc` (or `go generate ./...`). -->
+
+Every `LANTERN_*` variable the server reads, generated from the envconfig
+registry (#847). A set-but-malformed value logs a startup warning and falls
+back to its default; an unknown `LANTERN_*` name logs a typo warning; with
+`LANTERN_STRICT_CONFIG=true` either condition fails boot. An explicitly empty
+value is treated as unset for the non-string kinds. The MCP server's
+`LANTERN_MCP_*` namespace belongs to that process and is not listed here.
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `LANTERN_ANTI_ENTROPY_GAP_WARN_THRESHOLD` | int | `1024` | Origin-seq gap size above which the anti-entropy sweep logs a warning. |
+| `LANTERN_ANTI_ENTROPY_INTERVAL_MS` | int | `30000` | Anti-entropy sweep cadence in milliseconds. |
+| `LANTERN_ANTI_ENTROPY_SUBSCRIBE_TIMEOUT_MS` | int | `30000` | Per-peer anti-entropy catch-up subscribe timeout in milliseconds. |
+| `LANTERN_BACKUP_DIR` | string | (empty) | Mounted directory dumps are written to and restored from. |
+| `LANTERN_BACKUP_ENABLED` | bool | `false` | Enable the periodic whole-graph dump loop (requires LANTERN_BACKUP_DIR). |
+| `LANTERN_BACKUP_INSTANCE_ID` | string | (empty) | Per-instance dump filename token for shared storage; defaults to the hostname. |
+| `LANTERN_BACKUP_INTERVAL` | duration | `5m0s` | Dump cadence (Go duration). |
+| `LANTERN_BACKUP_RESTORE_ON_START` | bool | `true` | Replay the newest valid dump as a baseline before serving. |
+| `LANTERN_BACKUP_RESTORE_REQUIRED` | bool | `false` | Fail boot when restore-on-startup errors instead of starting with current state. |
+| `LANTERN_BACKUP_RETAIN` | int | `3` | How many of this instance's own dumps to keep, newest first (0 keeps all). |
+| `LANTERN_BLOCK_PROFILE_RATE` | int | `0` | runtime.SetBlockProfileRate in nanoseconds between samples (0 = disabled). |
+| `LANTERN_COMMIT` | string | (empty) | Overrides the commit label reported in lantern_build_info. |
+| `LANTERN_CORS_ALLOWED_ORIGINS` | string | (empty) | Comma-separated browser origins allowed by CORS (e.g. the admin SPA origin); empty disables CORS. |
+| `LANTERN_DEFAULT_TTL_SECONDS` | int | `60` | Reported in GetServerStatus and startup logs only; RPC writes without an expiration are permanent (decay is opt-in per write, #523). |
+| `LANTERN_DELETE_BY_PREFIX_DEFAULT_LIMIT` | int | `10000` | Deletion cap used when DeleteVerticesByPrefix leaves limit unset. |
+| `LANTERN_DELETE_BY_PREFIX_MAX_LIMIT` | int | `100000` | Ceiling DeleteVerticesByPrefix's limit is clamped to. |
+| `LANTERN_DRAIN_DELAY_SECONDS` | int | `0` | Zero-drop rolling-update window: keep serving this long after readiness flips NOT_SERVING (0 = disabled). |
+| `LANTERN_GC_INTERVAL_SECONDS` | int | `60` | Graph-cache GC tick interval in seconds (expired vertex/edge sweep). |
+| `LANTERN_ILLUMINATE_MAX_K` | int | `1024` | Upper bound on the Illuminate k parameter. |
+| `LANTERN_ILLUMINATE_MAX_STEP` | int | `16` | Upper bound on the Illuminate BFS step parameter. |
+| `LANTERN_LOG_FORMAT` | string | `json` | Log output format: json or text. |
+| `LANTERN_LOG_LEVEL` | level | `info` | Structured-log level: debug, info, warn, or error. |
+| `LANTERN_MAX_BATCH_SIZE` | int | `10000` | Maximum items accepted per batch RPC (Put/Get/Add/Delete plural forms). |
+| `LANTERN_MAX_CONCURRENT_STREAMS` | int | `1024` | HTTP/2 max concurrent streams per connection (0 = unlimited). |
+| `LANTERN_MAX_KEY_LEN` | int | `1024` | Maximum accepted vertex-key length in bytes. |
+| `LANTERN_MAX_RECV_MSG_BYTES` | int | `16777216` | Maximum accepted request message size in bytes. |
+| `LANTERN_MAX_REPLICATION_LAG` | int | `10000` | Readiness gate: maximum tolerated replication lag (entries) before /readyz reports not ready. |
+| `LANTERN_MAX_SEND_MSG_BYTES` | int | `16777216` | Maximum produced response message size in bytes. |
+| `LANTERN_METRICS_ADDR` | string | `:9090` | host:port for the /metrics + /healthz + /readyz HTTP listener (empty disables it). |
+| `LANTERN_MUTATION_LOG_CAPACITY` | int | `100000` | Replication mutation-log ring capacity in entries; size for peak_cluster_rps x retention_seconds. |
+| `LANTERN_MUTATION_LOG_SUBSCRIBER_BUFFER` | int | `512` | Per-subscriber outbound channel depth; a subscriber that falls further behind is gapped. |
+| `LANTERN_MUTEX_PROFILE_FRACTION` | int | `0` | runtime.SetMutexProfileFraction sampling rate (0 = disabled; has runtime cost). |
+| `LANTERN_NODE_ID` | string | (empty) | Stable 32-hex-char (16-byte) node identity for HLC/replication; random per boot when unset. |
+| `LANTERN_PEERS` | string | (empty) | Comma-separated static peer list (host:port) for the replication pump; empty = single instance. |
+| `LANTERN_PEER_DEFAULT_PORT` | string | `50051` | Port appended to DNS-discovered peer addresses. |
+| `LANTERN_PEER_DISCOVERY` | string | `static` | Peer discovery mode: static or dns. |
+| `LANTERN_PEER_DISCOVERY_INTERVAL_MS` | int | `10000` | Peer re-resolution cadence in milliseconds (0 = resolve once at startup). |
+| `LANTERN_PEER_DNS_NAME` | string | (empty) | DNS name resolved for peer discovery when LANTERN_PEER_DISCOVERY=dns (e.g. a headless Service). |
+| `LANTERN_PORT` | int | `6380` | TCP port of the primary Connect/h2c listener. |
+| `LANTERN_PPROF_ENABLED` | bool | `false` | Mount /debug/pprof/* on the metrics listener (keep the listener internal-only). |
+| `LANTERN_PUMP_BACKOFF_MAX_MS` | int | `30000` | Reconnect backoff ceiling, in milliseconds. |
+| `LANTERN_PUMP_BACKOFF_MIN_MS` | int | `250` | Initial reconnect backoff after a peer session error, in milliseconds. |
+| `LANTERN_RATE_LIMIT_BURST` | int | `0` | Token-bucket burst size; when unset or <= 0 it resolves to 2x LANTERN_RATE_LIMIT_RPS. |
+| `LANTERN_RATE_LIMIT_RPS` | float | `0` | Process-wide token-bucket refill rate in requests/second (0 disables rate limiting). |
+| `LANTERN_REFLECTION` | bool | `true` | Serve gRPC server reflection on the primary listener. |
+| `LANTERN_SCAN_DEFAULT_LIMIT` | int | `1000` | Page size used when a Scan* request leaves limit unset. |
+| `LANTERN_SCAN_MAX_LIMIT` | int | `10000` | Ceiling a Scan* request's limit is clamped to. |
+| `LANTERN_SEARCH_DEFAULT_LIMIT` | uint32 | `100` | Ranked-hit count used when SearchVertices leaves limit unset. |
+| `LANTERN_SEARCH_ENABLED` | bool | `true` | Build the full-text search index and serve SearchVertices (off = FAILED_PRECONDITION). |
+| `LANTERN_SEARCH_MAX_LIMIT` | uint32 | `1000` | Ceiling SearchVertices' limit is clamped to. |
+| `LANTERN_SHUTDOWN_TIMEOUT_SECONDS` | int | `30` | Graceful-shutdown drain budget for in-flight requests before a hard close. |
+| `LANTERN_SLOW_RPC_THRESHOLD_MS` | int | `500` | RPCs slower than this emit a warn-level "slow rpc" log line (0 disables). |
+| `LANTERN_STRICT_CONFIG` | bool | `false` | Refuse to boot when any LANTERN_* value is malformed or an unknown LANTERN_* variable is set. |
+| `LANTERN_TLS_CERT_FILE` | string | (empty) | PEM certificate path; setting cert + key enables TLS on the primary listener. |
+| `LANTERN_TLS_CLIENT_CA_FILE` | string | (empty) | PEM client-CA bundle path; setting it additionally enables mTLS client verification. |
+| `LANTERN_TLS_KEY_FILE` | string | (empty) | PEM private-key path; pairs with LANTERN_TLS_CERT_FILE. |
+| `LANTERN_TOMBSTONE_TTL` | duration | `8760h0m0s` | Delete-tombstone retention window and the upper bound on caller-supplied expirations. |
+| `LANTERN_VERSION` | string | (empty) | Overrides the version label reported in lantern_build_info and GetServerStatus. |

--- a/server/README.md
+++ b/server/README.md
@@ -86,8 +86,12 @@ aggregate `*Config` because they need multiple slices at once.
 
 ## Environment variables
 
-The exhaustive list lives in [`internal/envconfig`](internal/envconfig); the
-most common knobs:
+The exhaustive, generated reference is [`docs/env.md`](../docs/env.md)
+(regenerate with `make envdoc`; the parsing helpers live in
+[`internal/envconfig`](internal/envconfig)). A set-but-malformed value warns
+and falls back to its default, an unknown `LANTERN_*` name warns as a
+probable typo, and `LANTERN_STRICT_CONFIG=true` turns either into a boot
+failure (#847). The most common knobs:
 
 | Variable | Default | Purpose |
 | --- | --- | --- |

--- a/server/cmd/wire_gen.go
+++ b/server/cmd/wire_gen.go
@@ -14,7 +14,10 @@ import (
 // Injectors from wire.go:
 
 func initializeApp() (*App, error) {
-	config := provider.NewConfig()
+	config, err := provider.NewConfig()
+	if err != nil {
+		return nil, err
+	}
 	observabilityConfig := provider.NewObservabilityConfig(config)
 	logger := provider.NewLogger(observabilityConfig)
 	cacheConfig := provider.NewCacheConfig(config)

--- a/server/generate.go
+++ b/server/generate.go
@@ -7,3 +7,4 @@
 package server
 
 //go:generate go tool wire ./cmd
+//go:generate go run ./internal/envdoc/cmd -out ../docs/env.md

--- a/server/internal/envconfig/envconfig.go
+++ b/server/internal/envconfig/envconfig.go
@@ -5,34 +5,288 @@
 // reimplementing the same os.Getenv + strconv dance.
 //
 // All helpers fall back to the supplied default when the variable is unset
-// or malformed — they never return an error.
+// or malformed — they never return an error. Since #847 they additionally
+// feed two process-wide records so the composition root can fail loudly at
+// boot instead of silently running on defaults:
+//
+//   - a REGISTRY of every variable a helper has been asked about (name,
+//     parsed kind, rendered default) — the source of truth for the unknown-
+//     variable sweep and the generated docs/env.md reference;
+//   - a FINDINGS list of variables that were SET but unparseable, so the
+//     startup validation can warn (or, under LANTERN_STRICT_CONFIG, abort)
+//     with the exact key and reason instead of nothing at all.
+//
+// An explicitly empty value ("", or whitespace for the trimmed kinds) is
+// treated as UNSET for the non-string kinds — `LANTERN_FOO=` in a manifest
+// conventionally means "use the default" and must not trip strict mode.
 package envconfig
 
 import (
 	"log/slog"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
+
+// Prefix is the namespace the unknown-variable sweep scans for.
+const Prefix = "LANTERN_"
+
+// Spec describes one known environment variable: its name, the kind the
+// loader parses it as, and the rendered default used when it is unset or
+// malformed. Registered as a side effect of every helper call, so the set of
+// Specs after a full config load is exactly the server's env contract.
+type Spec struct {
+	Key     string
+	Kind    string
+	Default string
+}
+
+// Finding records a variable that was set but failed to parse; the loader
+// fell back to its default. Raw is the offending value verbatim.
+type Finding struct {
+	Key    string
+	Raw    string
+	Reason string
+}
+
+// Unknown is one LANTERN_*-prefixed environment variable that no loader ever
+// registered — almost always an operator typo. Suggestion carries the
+// closest registered key when one is plausibly close, else "".
+type Unknown struct {
+	Key        string
+	Suggestion string
+}
+
+var (
+	mu       sync.Mutex
+	registry = map[string]Spec{}
+	findings []Finding
+	setKeys  = map[string]struct{}{}
+)
+
+func register(key, kind, def string) {
+	mu.Lock()
+	defer mu.Unlock()
+	if _, ok := registry[key]; !ok {
+		registry[key] = Spec{Key: key, Kind: kind, Default: def}
+	}
+}
+
+func markSet(key string) {
+	mu.Lock()
+	defer mu.Unlock()
+	setKeys[key] = struct{}{}
+}
+
+// Malformed records a set-but-unparseable value for key. The typed helpers
+// call it internally; it is exported for the few loaders that parse a raw
+// String themselves (e.g. the LANTERN_NODE_ID hex decode) so custom parse
+// failures land in the same startup report as everything else.
+func Malformed(key, raw, reason string) {
+	mu.Lock()
+	defer mu.Unlock()
+	findings = append(findings, Finding{Key: key, Raw: raw, Reason: reason})
+}
+
+// Known returns every registered variable, sorted by key.
+func Known() []Spec {
+	mu.Lock()
+	defer mu.Unlock()
+	out := make([]Spec, 0, len(registry))
+	for _, s := range registry {
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out
+}
+
+// Findings returns the malformed-value records collected so far, in call
+// order.
+func Findings() []Finding {
+	mu.Lock()
+	defer mu.Unlock()
+	return append([]Finding(nil), findings...)
+}
+
+// SetKeys returns the sorted names of registered variables that were set in
+// the environment (whether or not they parsed). Values are deliberately not
+// reported — a future secret-bearing variable must never end up in the boot
+// log.
+func SetKeys() []string {
+	mu.Lock()
+	defer mu.Unlock()
+	out := make([]string, 0, len(setKeys))
+	for k := range setKeys {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ResetForTesting clears the registry, findings, and set-key records so a
+// test can load a fresh config without cross-test bleed. Not for production
+// use.
+func ResetForTesting() {
+	mu.Lock()
+	defer mu.Unlock()
+	registry = map[string]Spec{}
+	findings = nil
+	setKeys = map[string]struct{}{}
+}
+
+// UnknownLanternVars scans environ (the os.Environ() slice format,
+// "KEY=value") for Prefix-named variables that were never registered by any
+// loader. Names starting with any of ignorePrefixes are skipped — that is
+// the escape hatch for sibling processes that legitimately share an env file
+// (e.g. the MCP server's LANTERN_MCP_* namespace). Results are sorted by
+// key, each with a did-you-mean suggestion when a registered key is within
+// small edit distance.
+func UnknownLanternVars(environ []string, ignorePrefixes ...string) []Unknown {
+	mu.Lock()
+	known := make([]string, 0, len(registry))
+	for k := range registry {
+		known = append(known, k)
+	}
+	mu.Unlock()
+
+	var out []Unknown
+	for _, kv := range environ {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		key := kv[:eq]
+		if !strings.HasPrefix(key, Prefix) {
+			continue
+		}
+		if func() bool {
+			for _, p := range ignorePrefixes {
+				if strings.HasPrefix(key, p) {
+					return true
+				}
+			}
+			return false
+		}() {
+			continue
+		}
+		if func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			_, ok := registry[key]
+			return ok
+		}() {
+			continue
+		}
+		out = append(out, Unknown{Key: key, Suggestion: suggest(key, known)})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out
+}
+
+// suggest returns the registered key closest to key when the edit distance
+// is small enough to plausibly be a typo (≤3), else "".
+func suggest(key string, known []string) string {
+	best, bestDist := "", 4
+	for _, k := range known {
+		if d := editDistance(key, k, bestDist); d < bestDist {
+			best, bestDist = k, d
+		}
+	}
+	return best
+}
+
+// editDistance is a bounded Levenshtein distance: it returns limit as soon
+// as the true distance is provably >= limit, which keeps the sweep cheap for
+// wholly unrelated names.
+func editDistance(a, b string, limit int) int {
+	if d := len(a) - len(b); d >= limit || -d >= limit {
+		return limit
+	}
+	prev := make([]int, len(b)+1)
+	cur := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		cur[0] = i
+		rowMin := cur[0]
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			m := prev[j-1] + cost
+			if v := prev[j] + 1; v < m {
+				m = v
+			}
+			if v := cur[j-1] + 1; v < m {
+				m = v
+			}
+			cur[j] = m
+			if m < rowMin {
+				rowMin = m
+			}
+		}
+		if rowMin >= limit {
+			return limit
+		}
+		prev, cur = cur, prev
+	}
+	if prev[len(b)] > limit {
+		return limit
+	}
+	return prev[len(b)]
+}
+
+// lookup fetches key, treating an all-whitespace value as unset for the
+// non-string kinds (a bare `LANTERN_FOO=` conventionally means "default").
+func lookup(key string) (string, bool) {
+	raw, ok := os.LookupEnv(key)
+	if !ok {
+		return "", false
+	}
+	markSet(key)
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", false
+	}
+	return trimmed, true
+}
 
 // Duration returns the time.Duration value of the named env var (accepted
 // by time.ParseDuration, e.g. "24h", "500ms"), or def when unset or
 // unparseable.
 func Duration(key string, def time.Duration) time.Duration {
-	if v, err := time.ParseDuration(strings.TrimSpace(os.Getenv(key))); err == nil {
-		return v
+	register(key, "duration", def.String())
+	raw, ok := lookup(key)
+	if !ok {
+		return def
 	}
-	return def
+	v, err := time.ParseDuration(raw)
+	if err != nil {
+		Malformed(key, raw, `not a Go duration (e.g. "30s", "24h")`)
+		return def
+	}
+	return v
 }
 
 // Int returns the integer value of the named env var, or def when unset or
 // not a valid base-10 integer.
 func Int(key string, def int) int {
-	if v, err := strconv.Atoi(os.Getenv(key)); err == nil {
-		return v
+	register(key, "int", strconv.Itoa(def))
+	raw, ok := lookup(key)
+	if !ok {
+		return def
 	}
-	return def
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		Malformed(key, raw, "not a base-10 integer")
+		return def
+	}
+	return v
 }
 
 // Uint32 returns the uint32 value of the named env var, or def when unset,
@@ -40,26 +294,42 @@ func Int(key string, def int) int {
 // with a 32-bit size makes the conversion bounds-safe: an out-of-range value
 // yields an error (and the default) rather than silently truncating.
 func Uint32(key string, def uint32) uint32 {
-	if v, err := strconv.ParseUint(os.Getenv(key), 10, 32); err == nil {
-		return uint32(v)
+	register(key, "uint32", strconv.FormatUint(uint64(def), 10))
+	raw, ok := lookup(key)
+	if !ok {
+		return def
 	}
-	return def
+	v, err := strconv.ParseUint(raw, 10, 32)
+	if err != nil {
+		Malformed(key, raw, "not an unsigned 32-bit integer")
+		return def
+	}
+	return uint32(v)
 }
 
 // Float returns the float64 value of the named env var, or def when unset
 // or not a valid float.
 func Float(key string, def float64) float64 {
-	if v, err := strconv.ParseFloat(os.Getenv(key), 64); err == nil {
-		return v
+	register(key, "float", strconv.FormatFloat(def, 'g', -1, 64))
+	raw, ok := lookup(key)
+	if !ok {
+		return def
 	}
-	return def
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		Malformed(key, raw, "not a floating-point number")
+		return def
+	}
+	return v
 }
 
 // String returns the value of the named env var, or def when unset.
 // An explicitly empty value ("") is returned as-is — only a missing variable
 // falls back to the default.
 func String(key, def string) string {
+	register(key, "string", def)
 	if v, ok := os.LookupEnv(key); ok {
+		markSet(key)
 		return v
 	}
 	return def
@@ -69,23 +339,51 @@ func String(key, def string) string {
 // not one of the recognised truthy/falsy spellings ("1"/"true"/"yes"/"on"
 // vs "0"/"false"/"no"/"off", case- and whitespace-insensitive).
 func Bool(key string, def bool) bool {
-	v, ok := os.LookupEnv(key)
+	register(key, "bool", strconv.FormatBool(def))
+	raw, ok := lookup(key)
 	if !ok {
 		return def
 	}
-	switch strings.ToLower(strings.TrimSpace(v)) {
+	switch strings.ToLower(raw) {
 	case "1", "true", "yes", "on":
 		return true
 	case "0", "false", "no", "off":
 		return false
 	default:
+		Malformed(key, raw, `not a boolean ("true"/"false"/"1"/"0"/"yes"/"no"/"on"/"off")`)
+		return def
+	}
+}
+
+// Level returns the slog level of the named env var ("debug"/"info"/
+// "warn"|"warning"/"error", case- and whitespace-insensitive), or def when
+// unset or unrecognised. It is the registry-aware sibling of LogLevel.
+func Level(key string, def slog.Level) slog.Level {
+	register(key, "level", strings.ToLower(def.String()))
+	raw, ok := lookup(key)
+	if !ok {
+		return def
+	}
+	switch strings.ToLower(raw) {
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		Malformed(key, raw, `not a log level ("debug"/"info"/"warn"/"error")`)
 		return def
 	}
 }
 
 // LogLevel parses a slog level from a free-form string ("debug"/"info"/
 // "warn"|"warning"/"error", case- and whitespace-insensitive). Anything
-// unrecognised falls back to slog.LevelInfo.
+// unrecognised falls back to slog.LevelInfo. Prefer Level for env-var reads —
+// it registers the key and reports malformed values; LogLevel remains for
+// callers that already hold the raw string.
 func LogLevel(s string) slog.Level {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "debug":

--- a/server/internal/envconfig/envconfig_test.go
+++ b/server/internal/envconfig/envconfig_test.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 )
 
 func TestInt(t *testing.T) {
@@ -173,6 +174,142 @@ func TestLogLevel(t *testing.T) {
 				t.Fatalf("LogLevel(%q)=%v, want %v", tc.in, got, tc.expect)
 			}
 		})
+	}
+}
+
+func TestDuration(t *testing.T) {
+	const key = "LANTERN_TEST_DURATION"
+	cases := []struct {
+		name   string
+		set    bool
+		value  string
+		def    time.Duration
+		expect time.Duration
+	}{
+		{"unset returns default", false, "", time.Minute, time.Minute},
+		{"valid value", true, "90s", time.Minute, 90 * time.Second},
+		{"empty value falls back", true, "", time.Minute, time.Minute},
+		{"garbage falls back", true, "soon", time.Minute, time.Minute},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(key, tc.value)
+			} else {
+				unset(t, key)
+			}
+			if got := Duration(key, tc.def); got != tc.expect {
+				t.Fatalf("Duration(%q)=%v, want %v", tc.value, got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestLevel(t *testing.T) {
+	const key = "LANTERN_TEST_LEVEL"
+	t.Run("unset returns default", func(t *testing.T) {
+		unset(t, key)
+		if got := Level(key, slog.LevelWarn); got != slog.LevelWarn {
+			t.Fatalf("got %v, want warn", got)
+		}
+	})
+	t.Run("valid value", func(t *testing.T) {
+		t.Setenv(key, "debug")
+		if got := Level(key, slog.LevelInfo); got != slog.LevelDebug {
+			t.Fatalf("got %v, want debug", got)
+		}
+	})
+	t.Run("garbage falls back and records a finding", func(t *testing.T) {
+		ResetForTesting()
+		t.Setenv(key, "verbose")
+		if got := Level(key, slog.LevelInfo); got != slog.LevelInfo {
+			t.Fatalf("got %v, want info", got)
+		}
+		fs := Findings()
+		if len(fs) != 1 || fs[0].Key != key || fs[0].Raw != "verbose" {
+			t.Fatalf("findings = %+v, want one for %s", fs, key)
+		}
+	})
+}
+
+func TestRegistryAndFindings(t *testing.T) {
+	t.Run("registry captures key, kind, and default", func(t *testing.T) {
+		ResetForTesting()
+		unset(t, "LANTERN_TEST_REG_INT")
+		unset(t, "LANTERN_TEST_REG_DUR")
+		_ = Int("LANTERN_TEST_REG_INT", 42)
+		_ = Duration("LANTERN_TEST_REG_DUR", 5*time.Minute)
+		specs := Known()
+		if len(specs) != 2 {
+			t.Fatalf("Known() = %+v, want 2 specs", specs)
+		}
+		// Known() sorts by key: DUR < INT.
+		if specs[0].Key != "LANTERN_TEST_REG_DUR" || specs[0].Kind != "duration" || specs[0].Default != "5m0s" {
+			t.Fatalf("spec[0] = %+v", specs[0])
+		}
+		if specs[1].Key != "LANTERN_TEST_REG_INT" || specs[1].Kind != "int" || specs[1].Default != "42" {
+			t.Fatalf("spec[1] = %+v", specs[1])
+		}
+	})
+
+	t.Run("malformed set values are recorded, unset and empty are not", func(t *testing.T) {
+		ResetForTesting()
+		unset(t, "LANTERN_TEST_F_UNSET")
+		_ = Int("LANTERN_TEST_F_UNSET", 1)
+		t.Setenv("LANTERN_TEST_F_EMPTY", "  ")
+		_ = Int("LANTERN_TEST_F_EMPTY", 1)
+		t.Setenv("LANTERN_TEST_F_BAD", "abc")
+		_ = Int("LANTERN_TEST_F_BAD", 1)
+		fs := Findings()
+		if len(fs) != 1 || fs[0].Key != "LANTERN_TEST_F_BAD" || fs[0].Raw != "abc" {
+			t.Fatalf("findings = %+v, want exactly the malformed set value", fs)
+		}
+	})
+
+	t.Run("SetKeys reports set variables without values", func(t *testing.T) {
+		ResetForTesting()
+		t.Setenv("LANTERN_TEST_SET", "9")
+		unset(t, "LANTERN_TEST_UNSET")
+		_ = Int("LANTERN_TEST_SET", 1)
+		_ = Int("LANTERN_TEST_UNSET", 1)
+		keys := SetKeys()
+		if len(keys) != 1 || keys[0] != "LANTERN_TEST_SET" {
+			t.Fatalf("SetKeys() = %v", keys)
+		}
+	})
+
+	t.Run("Malformed records custom-parser failures", func(t *testing.T) {
+		ResetForTesting()
+		Malformed("LANTERN_TEST_CUSTOM", "zz", "not hex")
+		fs := Findings()
+		if len(fs) != 1 || fs[0].Reason != "not hex" {
+			t.Fatalf("findings = %+v", fs)
+		}
+	})
+}
+
+func TestUnknownLanternVars(t *testing.T) {
+	ResetForTesting()
+	unset(t, "LANTERN_TEST_PORT")
+	_ = Int("LANTERN_TEST_PORT", 6380)
+
+	environ := []string{
+		"PATH=/usr/bin",               // non-LANTERN: ignored
+		"LANTERN_TEST_PORT=6380",      // registered: ignored
+		"LANTERN_TEST_PROT=6380",      // typo of a registered key: flagged with suggestion
+		"LANTERN_TOTALLY_DIFFERENT=1", // unknown, nothing close: flagged without suggestion
+		"LANTERN_MCP_AGENT_ID=foo",    // foreign namespace: ignored
+		"MALFORMED-NO-EQUALS",         // not KEY=value: ignored
+	}
+	got := UnknownLanternVars(environ, "LANTERN_MCP_")
+	if len(got) != 2 {
+		t.Fatalf("UnknownLanternVars = %+v, want 2 entries", got)
+	}
+	if got[0].Key != "LANTERN_TEST_PROT" || got[0].Suggestion != "LANTERN_TEST_PORT" {
+		t.Fatalf("typo entry = %+v, want suggestion LANTERN_TEST_PORT", got[0])
+	}
+	if got[1].Key != "LANTERN_TOTALLY_DIFFERENT" || got[1].Suggestion != "" {
+		t.Fatalf("unrelated entry = %+v, want no suggestion", got[1])
 	}
 }
 

--- a/server/internal/envdoc/cmd/main.go
+++ b/server/internal/envdoc/cmd/main.go
@@ -1,0 +1,42 @@
+// Command envdoc regenerates the operator-facing environment-variable
+// reference (docs/env.md) from the envconfig registry. Invoked by the
+// go:generate directive in server/generate.go; see #847.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/anaregdesign/lantern/server/internal/envconfig"
+	"github.com/anaregdesign/lantern/server/internal/envdoc"
+	"github.com/anaregdesign/lantern/server/provider"
+)
+
+func main() {
+	out := flag.String("out", "", "output path (default: stdout)")
+	flag.Parse()
+
+	// Scrub the process environment first so the captured registry reflects
+	// pure defaults and the rendered file is deterministic regardless of the
+	// invoking shell (a dev with LANTERN_* exported must produce the same
+	// bytes CI does).
+	os.Clearenv()
+	if _, err := provider.NewConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, "envdoc: config load:", err)
+		os.Exit(1)
+	}
+	doc, err := envdoc.Render(envconfig.Known())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "envdoc:", err)
+		os.Exit(1)
+	}
+	if *out == "" {
+		fmt.Print(doc)
+		return
+	}
+	if err := os.WriteFile(*out, []byte(doc), 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, "envdoc:", err)
+		os.Exit(1)
+	}
+}

--- a/server/internal/envdoc/envdoc.go
+++ b/server/internal/envdoc/envdoc.go
@@ -1,0 +1,143 @@
+// Package envdoc renders the generated operator-facing reference of every
+// LANTERN_* environment variable the server reads (docs/env.md). The variable
+// set itself comes from the envconfig registry — populated as a side effect of
+// provider.NewConfig() — so the reference cannot silently drift from the code:
+// a variable added without a description here, or a description left behind
+// after a variable is removed, fails Render (and with it `go generate` and the
+// generated-code CI check). See #847.
+package envdoc
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/anaregdesign/lantern/server/internal/envconfig"
+)
+
+// descriptions is the curated one-line operator description per variable.
+// Render enforces that this table and the envconfig registry agree exactly.
+var descriptions = map[string]string{
+	"LANTERN_PORT":                   "TCP port of the primary Connect/h2c listener.",
+	"LANTERN_MAX_RECV_MSG_BYTES":     "Maximum accepted request message size in bytes.",
+	"LANTERN_MAX_SEND_MSG_BYTES":     "Maximum produced response message size in bytes.",
+	"LANTERN_MAX_CONCURRENT_STREAMS": "HTTP/2 max concurrent streams per connection (0 = unlimited).",
+
+	"LANTERN_TLS_CERT_FILE":      "PEM certificate path; setting cert + key enables TLS on the primary listener.",
+	"LANTERN_TLS_KEY_FILE":       "PEM private-key path; pairs with LANTERN_TLS_CERT_FILE.",
+	"LANTERN_TLS_CLIENT_CA_FILE": "PEM client-CA bundle path; setting it additionally enables mTLS client verification.",
+
+	"LANTERN_RATE_LIMIT_RPS":   "Process-wide token-bucket refill rate in requests/second (0 disables rate limiting).",
+	"LANTERN_RATE_LIMIT_BURST": "Token-bucket burst size; when unset or <= 0 it resolves to 2x LANTERN_RATE_LIMIT_RPS.",
+
+	"LANTERN_LOG_LEVEL":              "Structured-log level: debug, info, warn, or error.",
+	"LANTERN_LOG_FORMAT":             "Log output format: json or text.",
+	"LANTERN_METRICS_ADDR":           "host:port for the /metrics + /healthz + /readyz HTTP listener (empty disables it).",
+	"LANTERN_REFLECTION":             "Serve gRPC server reflection on the primary listener.",
+	"LANTERN_VERSION":                "Overrides the version label reported in lantern_build_info and GetServerStatus.",
+	"LANTERN_COMMIT":                 "Overrides the commit label reported in lantern_build_info.",
+	"LANTERN_SLOW_RPC_THRESHOLD_MS":  "RPCs slower than this emit a warn-level \"slow rpc\" log line (0 disables).",
+	"LANTERN_PPROF_ENABLED":          "Mount /debug/pprof/* on the metrics listener (keep the listener internal-only).",
+	"LANTERN_MUTEX_PROFILE_FRACTION": "runtime.SetMutexProfileFraction sampling rate (0 = disabled; has runtime cost).",
+	"LANTERN_BLOCK_PROFILE_RATE":     "runtime.SetBlockProfileRate in nanoseconds between samples (0 = disabled).",
+
+	"LANTERN_DEFAULT_TTL_SECONDS": "Reported in GetServerStatus and startup logs only; RPC writes without an expiration are permanent (decay is opt-in per write, #523).",
+	"LANTERN_GC_INTERVAL_SECONDS": "Graph-cache GC tick interval in seconds (expired vertex/edge sweep).",
+
+	"LANTERN_SHUTDOWN_TIMEOUT_SECONDS": "Graceful-shutdown drain budget for in-flight requests before a hard close.",
+	"LANTERN_DRAIN_DELAY_SECONDS":      "Zero-drop rolling-update window: keep serving this long after readiness flips NOT_SERVING (0 = disabled).",
+
+	"LANTERN_MAX_KEY_LEN":         "Maximum accepted vertex-key length in bytes.",
+	"LANTERN_MAX_BATCH_SIZE":      "Maximum items accepted per batch RPC (Put/Get/Add/Delete plural forms).",
+	"LANTERN_ILLUMINATE_MAX_STEP": "Upper bound on the Illuminate BFS step parameter.",
+	"LANTERN_ILLUMINATE_MAX_K":    "Upper bound on the Illuminate k parameter.",
+
+	"LANTERN_SCAN_DEFAULT_LIMIT":             "Page size used when a Scan* request leaves limit unset.",
+	"LANTERN_SCAN_MAX_LIMIT":                 "Ceiling a Scan* request's limit is clamped to.",
+	"LANTERN_DELETE_BY_PREFIX_DEFAULT_LIMIT": "Deletion cap used when DeleteVerticesByPrefix leaves limit unset.",
+	"LANTERN_DELETE_BY_PREFIX_MAX_LIMIT":     "Ceiling DeleteVerticesByPrefix's limit is clamped to.",
+
+	"LANTERN_SEARCH_ENABLED":       "Build the full-text search index and serve SearchVertices (off = FAILED_PRECONDITION).",
+	"LANTERN_SEARCH_DEFAULT_LIMIT": "Ranked-hit count used when SearchVertices leaves limit unset.",
+	"LANTERN_SEARCH_MAX_LIMIT":     "Ceiling SearchVertices' limit is clamped to.",
+
+	"LANTERN_MUTATION_LOG_CAPACITY":          "Replication mutation-log ring capacity in entries; size for peak_cluster_rps x retention_seconds.",
+	"LANTERN_MUTATION_LOG_SUBSCRIBER_BUFFER": "Per-subscriber outbound channel depth; a subscriber that falls further behind is gapped.",
+	"LANTERN_NODE_ID":                        "Stable 32-hex-char (16-byte) node identity for HLC/replication; random per boot when unset.",
+	"LANTERN_TOMBSTONE_TTL":                  "Delete-tombstone retention window and the upper bound on caller-supplied expirations.",
+
+	"LANTERN_PEERS":                      "Comma-separated static peer list (host:port) for the replication pump; empty = single instance.",
+	"LANTERN_PEER_DISCOVERY":             "Peer discovery mode: static or dns.",
+	"LANTERN_PEER_DNS_NAME":              "DNS name resolved for peer discovery when LANTERN_PEER_DISCOVERY=dns (e.g. a headless Service).",
+	"LANTERN_PEER_DEFAULT_PORT":          "Port appended to DNS-discovered peer addresses.",
+	"LANTERN_PEER_DISCOVERY_INTERVAL_MS": "Peer re-resolution cadence in milliseconds (0 = resolve once at startup).",
+	"LANTERN_PUMP_BACKOFF_MIN_MS":        "Initial reconnect backoff after a peer session error, in milliseconds.",
+	"LANTERN_PUMP_BACKOFF_MAX_MS":        "Reconnect backoff ceiling, in milliseconds.",
+
+	"LANTERN_ANTI_ENTROPY_INTERVAL_MS":          "Anti-entropy sweep cadence in milliseconds.",
+	"LANTERN_ANTI_ENTROPY_SUBSCRIBE_TIMEOUT_MS": "Per-peer anti-entropy catch-up subscribe timeout in milliseconds.",
+	"LANTERN_ANTI_ENTROPY_GAP_WARN_THRESHOLD":   "Origin-seq gap size above which the anti-entropy sweep logs a warning.",
+
+	"LANTERN_MAX_REPLICATION_LAG": "Readiness gate: maximum tolerated replication lag (entries) before /readyz reports not ready.",
+
+	"LANTERN_CORS_ALLOWED_ORIGINS": "Comma-separated browser origins allowed by CORS (e.g. the admin SPA origin); empty disables CORS.",
+
+	"LANTERN_BACKUP_ENABLED":          "Enable the periodic whole-graph dump loop (requires LANTERN_BACKUP_DIR).",
+	"LANTERN_BACKUP_DIR":              "Mounted directory dumps are written to and restored from.",
+	"LANTERN_BACKUP_INTERVAL":         "Dump cadence (Go duration).",
+	"LANTERN_BACKUP_RETAIN":           "How many of this instance's own dumps to keep, newest first (0 keeps all).",
+	"LANTERN_BACKUP_INSTANCE_ID":      "Per-instance dump filename token for shared storage; defaults to the hostname.",
+	"LANTERN_BACKUP_RESTORE_ON_START": "Replay the newest valid dump as a baseline before serving.",
+	"LANTERN_BACKUP_RESTORE_REQUIRED": "Fail boot when restore-on-startup errors instead of starting with current state.",
+
+	"LANTERN_STRICT_CONFIG": "Refuse to boot when any LANTERN_* value is malformed or an unknown LANTERN_* variable is set.",
+}
+
+// Render produces the docs/env.md markdown for the given registry specs. It
+// returns an error when the description table and the registry disagree in
+// either direction, so the generated reference can never drift from the code.
+func Render(specs []envconfig.Spec) (string, error) {
+	var missing, extra []string
+	seen := map[string]bool{}
+	for _, s := range specs {
+		seen[s.Key] = true
+		if _, ok := descriptions[s.Key]; !ok {
+			missing = append(missing, s.Key)
+		}
+	}
+	for k := range descriptions {
+		if !seen[k] {
+			extra = append(extra, k)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+	if len(missing) > 0 || len(extra) > 0 {
+		return "", fmt.Errorf("envdoc: description table out of sync with envconfig registry: missing descriptions %v, stale descriptions %v", missing, extra)
+	}
+
+	sorted := append([]envconfig.Spec(nil), specs...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Key < sorted[j].Key })
+
+	var b strings.Builder
+	b.WriteString("# Lantern server environment variables\n\n")
+	b.WriteString("<!-- GENERATED FILE - do not edit. Regenerate with `make envdoc` (or `go generate ./...`). -->\n\n")
+	b.WriteString("Every `LANTERN_*` variable the server reads, generated from the envconfig\n")
+	b.WriteString("registry (#847). A set-but-malformed value logs a startup warning and falls\n")
+	b.WriteString("back to its default; an unknown `LANTERN_*` name logs a typo warning; with\n")
+	b.WriteString("`LANTERN_STRICT_CONFIG=true` either condition fails boot. An explicitly empty\n")
+	b.WriteString("value is treated as unset for the non-string kinds. The MCP server's\n")
+	b.WriteString("`LANTERN_MCP_*` namespace belongs to that process and is not listed here.\n\n")
+	b.WriteString("| Variable | Type | Default | Description |\n")
+	b.WriteString("|---|---|---|---|\n")
+	for _, s := range sorted {
+		def := s.Default
+		if def == "" {
+			def = "(empty)"
+		} else {
+			def = "`" + def + "`"
+		}
+		fmt.Fprintf(&b, "| `%s` | %s | %s | %s |\n", s.Key, s.Kind, def, descriptions[s.Key])
+	}
+	return b.String(), nil
+}

--- a/server/internal/envdoc/envdoc_test.go
+++ b/server/internal/envdoc/envdoc_test.go
@@ -1,0 +1,51 @@
+package envdoc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/anaregdesign/lantern/server/internal/envconfig"
+	"github.com/anaregdesign/lantern/server/provider"
+)
+
+// TestRenderCoversFullRegistry loads the real config so the envconfig
+// registry holds the server's complete env contract, then requires Render to
+// succeed — i.e. every registered variable has a description and no
+// description is stale. This is the drift gate: adding a LANTERN_* variable
+// without documenting it (or removing one and leaving its row) fails here
+// and in `go generate` (#847).
+func TestRenderCoversFullRegistry(t *testing.T) {
+	envconfig.ResetForTesting()
+	// Strict mode aborts NewConfig on any pre-existing junk in the test
+	// host's environment; force it off so this test only checks coverage.
+	t.Setenv("LANTERN_STRICT_CONFIG", "false")
+	if _, err := provider.NewConfig(); err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+	doc, err := Render(envconfig.Known())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	for _, want := range []string{"| `LANTERN_PORT` |", "| `LANTERN_STRICT_CONFIG` |", "GENERATED FILE"} {
+		if !strings.Contains(doc, want) {
+			t.Fatalf("rendered doc missing %q", want)
+		}
+	}
+}
+
+// TestRenderRejectsDrift feeds Render a registry that disagrees with the
+// description table in both directions and expects a descriptive error.
+func TestRenderRejectsDrift(t *testing.T) {
+	_, err := Render([]envconfig.Spec{{Key: "LANTERN_NOT_DOCUMENTED", Kind: "int", Default: "1"}})
+	if err == nil {
+		t.Fatal("Render accepted a registry/description mismatch")
+	}
+	if !strings.Contains(err.Error(), "LANTERN_NOT_DOCUMENTED") {
+		t.Fatalf("error does not name the undocumented variable: %v", err)
+	}
+	// Every curated description is stale relative to this one-entry registry,
+	// so the stale side must be reported too.
+	if !strings.Contains(err.Error(), "LANTERN_PORT") {
+		t.Fatalf("error does not name stale descriptions: %v", err)
+	}
+}

--- a/server/provider/backup.go
+++ b/server/provider/backup.go
@@ -51,13 +51,19 @@ func loadBackupConfig() backup.Config {
 		}
 	}
 
+	// Read unconditionally (not short-circuited behind `active &&`) so the
+	// variable always lands in the envconfig registry — the generated env
+	// reference and the unknown-variable sweep depend on every loader
+	// registering its keys on every boot (#847).
+	restoreOnStart := envconfig.Bool("LANTERN_BACKUP_RESTORE_ON_START", true)
+
 	return backup.Config{
 		Enabled:         active,
 		Dir:             dir,
 		Interval:        envconfig.Duration("LANTERN_BACKUP_INTERVAL", 5*time.Minute),
 		Retain:          envconfig.Int("LANTERN_BACKUP_RETAIN", 3),
 		InstanceID:      sanitizeInstanceID(instance),
-		RestoreOnStart:  active && envconfig.Bool("LANTERN_BACKUP_RESTORE_ON_START", true),
+		RestoreOnStart:  active && restoreOnStart,
 		RestoreRequired: envconfig.Bool("LANTERN_BACKUP_RESTORE_REQUIRED", false),
 	}
 }

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -179,14 +180,19 @@ type Config struct {
 	Backup        backup.Config
 }
 
-func NewConfig() *Config {
+// NewConfig loads every sub-config from the environment, then validates the
+// load (#847): set-but-malformed values and unknown LANTERN_* names are
+// logged as warnings, and — when LANTERN_STRICT_CONFIG=true — turned into a
+// boot failure so a typo is caught in staging instead of silently running on
+// defaults. The returned error is non-nil only in strict mode.
+func NewConfig() (*Config, error) {
 	rps := envconfig.Float("LANTERN_RATE_LIMIT_RPS", 0)
 	burst := envconfig.Int("LANTERN_RATE_LIMIT_BURST", int(2*rps))
 	if burst <= 0 && rps > 0 {
 		burst = int(2 * rps)
 	}
 	peer := loadPeerConfig()
-	return &Config{
+	cfg := &Config{
 		Net: NetConfig{
 			Port:                 envconfig.Int("LANTERN_PORT", 6380),
 			MaxRecvMsgBytes:      envconfig.Int("LANTERN_MAX_RECV_MSG_BYTES", 16*1024*1024),
@@ -194,21 +200,21 @@ func NewConfig() *Config {
 			MaxConcurrentStreams: uint32(envconfig.Int("LANTERN_MAX_CONCURRENT_STREAMS", 1024)),
 		},
 		TLS: TLSConfig{
-			CertFile:     os.Getenv("LANTERN_TLS_CERT_FILE"),
-			KeyFile:      os.Getenv("LANTERN_TLS_KEY_FILE"),
-			ClientCAFile: os.Getenv("LANTERN_TLS_CLIENT_CA_FILE"),
+			CertFile:     envconfig.String("LANTERN_TLS_CERT_FILE", ""),
+			KeyFile:      envconfig.String("LANTERN_TLS_KEY_FILE", ""),
+			ClientCAFile: envconfig.String("LANTERN_TLS_CLIENT_CA_FILE", ""),
 		},
 		RateLimit: RateLimitConfig{
 			RPS:   rps,
 			Burst: burst,
 		},
 		Observability: ObservabilityConfig{
-			LogLevel:             envconfig.LogLevel(os.Getenv("LANTERN_LOG_LEVEL")),
+			LogLevel:             envconfig.Level("LANTERN_LOG_LEVEL", slog.LevelInfo),
 			LogFormat:            envconfig.String("LANTERN_LOG_FORMAT", "json"),
 			MetricsAddr:          envconfig.String("LANTERN_METRICS_ADDR", ":9090"),
 			EnableReflection:     envconfig.Bool("LANTERN_REFLECTION", true),
-			Version:              os.Getenv("LANTERN_VERSION"),
-			Commit:               os.Getenv("LANTERN_COMMIT"),
+			Version:              envconfig.String("LANTERN_VERSION", ""),
+			Commit:               envconfig.String("LANTERN_COMMIT", ""),
 			SlowRPCThreshold:     time.Duration(envconfig.Int("LANTERN_SLOW_RPC_THRESHOLD_MS", 500)) * time.Millisecond,
 			EnablePprof:          envconfig.Bool("LANTERN_PPROF_ENABLED", false),
 			MutexProfileFraction: envconfig.Int("LANTERN_MUTEX_PROFILE_FRACTION", 0),
@@ -247,6 +253,66 @@ func NewConfig() *Config {
 		CORS:        loadCORSConfig(),
 		Backup:      loadBackupConfig(),
 	}
+	return cfg, validateEnv(os.Environ())
+}
+
+// foreignEnvPrefixes names LANTERN_*-prefixed namespaces owned by sibling
+// processes that legitimately share an env file with the server, so the
+// unknown-variable sweep does not flag them (#847). The MCP server reads
+// LANTERN_MCP_* in its own process; it never registers here.
+var foreignEnvPrefixes = []string{"LANTERN_MCP_"}
+
+// validateEnv is the boot-time config validation pass (#847). It runs after
+// every loader has registered its variables, so the envconfig registry is
+// the complete env contract at this point. It reports through slog.Default()
+// (the structured logger replaces the default later in the wire graph; these
+// lines still land on stderr) and fails only under LANTERN_STRICT_CONFIG.
+func validateEnv(environ []string) error {
+	strict := envconfig.Bool("LANTERN_STRICT_CONFIG", false)
+	log := slog.Default()
+
+	findings := envconfig.Findings()
+	for _, f := range findings {
+		log.Warn("config: malformed value, using default",
+			slog.String("key", f.Key),
+			slog.String("value", f.Raw),
+			slog.String("reason", f.Reason))
+	}
+
+	unknown := envconfig.UnknownLanternVars(environ, foreignEnvPrefixes...)
+	for _, u := range unknown {
+		if u.Suggestion != "" {
+			log.Warn("config: unknown LANTERN_* variable (typo?)",
+				slog.String("key", u.Key),
+				slog.String("did_you_mean", u.Suggestion))
+		} else {
+			log.Warn("config: unknown LANTERN_* variable",
+				slog.String("key", u.Key))
+		}
+	}
+
+	// One summary line naming which knobs are set (keys only — values are
+	// deliberately withheld so a future secret-bearing variable can never
+	// leak into the boot log).
+	if set := envconfig.SetKeys(); len(set) > 0 {
+		log.Info("config: environment overrides active", slog.Any("keys", set))
+	}
+
+	if strict && (len(findings) > 0 || len(unknown) > 0) {
+		var parts []string
+		for _, f := range findings {
+			parts = append(parts, fmt.Sprintf("malformed %s=%q (%s)", f.Key, f.Raw, f.Reason))
+		}
+		for _, u := range unknown {
+			if u.Suggestion != "" {
+				parts = append(parts, fmt.Sprintf("unknown %s (did you mean %s?)", u.Key, u.Suggestion))
+			} else {
+				parts = append(parts, fmt.Sprintf("unknown %s", u.Key))
+			}
+		}
+		return fmt.Errorf("LANTERN_STRICT_CONFIG: refusing to boot: %s", strings.Join(parts, "; "))
+	}
+	return nil
 }
 
 // Sub-config selectors. Wire uses these to inject each focused struct into

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -197,7 +197,7 @@ func NewConfig() (*Config, error) {
 			Port:                 envconfig.Int("LANTERN_PORT", 6380),
 			MaxRecvMsgBytes:      envconfig.Int("LANTERN_MAX_RECV_MSG_BYTES", 16*1024*1024),
 			MaxSendMsgBytes:      envconfig.Int("LANTERN_MAX_SEND_MSG_BYTES", 16*1024*1024),
-			MaxConcurrentStreams: uint32(envconfig.Int("LANTERN_MAX_CONCURRENT_STREAMS", 1024)),
+			MaxConcurrentStreams: envconfig.Uint32("LANTERN_MAX_CONCURRENT_STREAMS", 1024),
 		},
 		TLS: TLSConfig{
 			CertFile:     envconfig.String("LANTERN_TLS_CERT_FILE", ""),
@@ -235,10 +235,10 @@ func NewConfig() (*Config, error) {
 			IlluminateMaxK:    envconfig.Int("LANTERN_ILLUMINATE_MAX_K", 1024),
 		},
 		Scan: ScanConfig{
-			ScanDefaultLimit:           uint32(envconfig.Int("LANTERN_SCAN_DEFAULT_LIMIT", 1000)),
-			ScanMaxLimit:               uint32(envconfig.Int("LANTERN_SCAN_MAX_LIMIT", 10000)),
-			DeleteByPrefixDefaultLimit: uint32(envconfig.Int("LANTERN_DELETE_BY_PREFIX_DEFAULT_LIMIT", 10000)),
-			DeleteByPrefixMaxLimit:     uint32(envconfig.Int("LANTERN_DELETE_BY_PREFIX_MAX_LIMIT", 100000)),
+			ScanDefaultLimit:           envconfig.Uint32("LANTERN_SCAN_DEFAULT_LIMIT", 1000),
+			ScanMaxLimit:               envconfig.Uint32("LANTERN_SCAN_MAX_LIMIT", 10000),
+			DeleteByPrefixDefaultLimit: envconfig.Uint32("LANTERN_DELETE_BY_PREFIX_DEFAULT_LIMIT", 10000),
+			DeleteByPrefixMaxLimit:     envconfig.Uint32("LANTERN_DELETE_BY_PREFIX_MAX_LIMIT", 100000),
 		},
 		Search: SearchConfig{
 			Enabled:      envconfig.Bool("LANTERN_SEARCH_ENABLED", true),

--- a/server/provider/provider_test.go
+++ b/server/provider/provider_test.go
@@ -7,11 +7,13 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/anaregdesign/lantern/core/graphcache"
 	v1 "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/server/internal/envconfig"
 	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
 	"github.com/anaregdesign/lantern/server/readiness"
 	"github.com/prometheus/client_golang/prometheus"
@@ -60,6 +62,77 @@ func TestWireCacheGCHooks_EmitsTickSummary(t *testing.T) {
 			t.Errorf("missing field %q in record: %v", k, rec)
 		}
 	}
+}
+
+// TestNewConfigValidation covers the #847 boot-time validation pass: a
+// malformed value or an unknown LANTERN_* variable is tolerated (warn +
+// default) by default and fatal under LANTERN_STRICT_CONFIG. The strict
+// failure happens inside NewConfig — the first provider wire constructs — so
+// a refused boot never reaches listener construction.
+func TestNewConfigValidation(t *testing.T) {
+	t.Run("defaults survive a malformed value without strict", func(t *testing.T) {
+		envconfig.ResetForTesting()
+		t.Setenv("LANTERN_STRICT_CONFIG", "false")
+		t.Setenv("LANTERN_PORT", "not-a-number")
+		cfg, err := NewConfig()
+		if err != nil {
+			t.Fatalf("NewConfig: %v", err)
+		}
+		if cfg.Net.Port != 6380 {
+			t.Fatalf("Port = %d, want default 6380", cfg.Net.Port)
+		}
+	})
+
+	t.Run("strict mode rejects a malformed value", func(t *testing.T) {
+		envconfig.ResetForTesting()
+		t.Setenv("LANTERN_STRICT_CONFIG", "true")
+		t.Setenv("LANTERN_PORT", "not-a-number")
+		_, err := NewConfig()
+		if err == nil {
+			t.Fatal("NewConfig accepted a malformed value under strict mode")
+		}
+		if !strings.Contains(err.Error(), "LANTERN_PORT") || !strings.Contains(err.Error(), "not-a-number") {
+			t.Fatalf("error does not name the offending variable: %v", err)
+		}
+	})
+
+	t.Run("strict mode rejects an unknown variable with a suggestion", func(t *testing.T) {
+		envconfig.ResetForTesting()
+		t.Setenv("LANTERN_STRICT_CONFIG", "true")
+		t.Setenv("LANTERN_PROT", "6381") // typo of LANTERN_PORT
+		_, err := NewConfig()
+		if err == nil {
+			t.Fatal("NewConfig accepted an unknown LANTERN_* variable under strict mode")
+		}
+		if !strings.Contains(err.Error(), "LANTERN_PROT") {
+			t.Fatalf("error does not name the unknown variable: %v", err)
+		}
+		if !strings.Contains(err.Error(), "LANTERN_PORT") {
+			t.Fatalf("error does not carry the did-you-mean suggestion: %v", err)
+		}
+	})
+
+	t.Run("foreign namespaces are exempt from the sweep", func(t *testing.T) {
+		envconfig.ResetForTesting()
+		t.Setenv("LANTERN_STRICT_CONFIG", "true")
+		t.Setenv("LANTERN_MCP_AGENT_ID", "agent-a")
+		if _, err := NewConfig(); err != nil {
+			t.Fatalf("NewConfig rejected a foreign-namespace variable: %v", err)
+		}
+	})
+
+	t.Run("malformed NodeID reaches the strict gate via Malformed", func(t *testing.T) {
+		envconfig.ResetForTesting()
+		t.Setenv("LANTERN_STRICT_CONFIG", "true")
+		t.Setenv("LANTERN_NODE_ID", "zz-not-hex")
+		_, err := NewConfig()
+		if err == nil {
+			t.Fatal("NewConfig accepted a malformed LANTERN_NODE_ID under strict mode")
+		}
+		if !strings.Contains(err.Error(), "LANTERN_NODE_ID") {
+			t.Fatalf("error does not name LANTERN_NODE_ID: %v", err)
+		}
+	})
 }
 
 // TestMetricsMux groups the HTTP-shim tests for newMetricsMux. The

--- a/server/provider/replication.go
+++ b/server/provider/replication.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"log/slog"
-	"os"
 	"strings"
 	"time"
 
@@ -74,7 +73,7 @@ func loadMutationLogConfig() MutationLogConfig {
 func loadReplicationConfig() ReplicationConfig {
 	ttl := envconfig.Duration("LANTERN_TOMBSTONE_TTL", 365*24*time.Hour) // 1 year
 	var id hlc.NodeID
-	raw := strings.TrimSpace(os.Getenv("LANTERN_NODE_ID"))
+	raw := strings.TrimSpace(envconfig.String("LANTERN_NODE_ID", ""))
 	raw = strings.TrimPrefix(raw, "0x")
 	if raw != "" {
 		if b, err := hex.DecodeString(raw); err == nil && len(b) == len(id) {
@@ -82,7 +81,10 @@ func loadReplicationConfig() ReplicationConfig {
 			return ReplicationConfig{NodeID: id, TombstoneTTL: ttl}
 		}
 		// Fall through to random on malformed input. Logged here so the
-		// operator sees the fallback without crashing startup.
+		// operator sees the fallback without crashing startup, and recorded
+		// in the envconfig findings so LANTERN_STRICT_CONFIG treats it like
+		// every other malformed value (#847).
+		envconfig.Malformed("LANTERN_NODE_ID", raw, "must be 32 hex chars (16 bytes)")
 		slog.Warn("ignoring malformed LANTERN_NODE_ID; using random NodeID",
 			slog.String("value", raw))
 	}


### PR DESCRIPTION
## Summary

Implements the #847 plan (see the issue body + its sequencing comment for the full spec):

- **envconfig collector + registry**: every helper registers its variable (name/kind/default) and records set-but-malformed values; empty values stay "unset" so `LANTERN_FOO=` in a manifest never trips validation. New `Level` helper replaces the raw `LogLevel(os.Getenv(...))` call site; `Malformed` is exported for custom parsers (used by the `LANTERN_NODE_ID` hex decode).
- **Boot validation in `NewConfig`** (now `(*Config, error)`, wire regen included): warns per malformed value, sweeps `os.Environ()` for unknown `LANTERN_*` names with bounded-Levenshtein did-you-mean suggestions (`LANTERN_MCP_*` exempt as a foreign namespace), logs one keys-only "overrides active" summary (values withheld so future secret vars can't leak into logs), and fails boot under `LANTERN_STRICT_CONFIG=true` — before any listener binds, since `NewConfig` is the first provider in the wire graph.
- **Generated reference**: `docs/env.md` rendered from the registry by `server/internal/envdoc` with a description table that must match the registry exactly in both directions — `make envdoc`, a `go:generate` directive in `server/generate.go`, and an explicit regen in the generated-code CI step, so drift fails CI.
- The drift gate immediately caught a real registration bug: `LANTERN_BACKUP_RESTORE_ON_START` was short-circuited behind `active &&` and never registered when backups were off; and the `LANTERN_DEFAULT_TTL_SECONDS` description now matches the #523 contract (status-only, not applied to writes).

## Tests

- envconfig: registry capture, malformed-vs-unset/empty findings, `SetKeys`, `Malformed`, `Level`, unknown-var sweep with suggestion/foreign-prefix/ignore cases, `Duration`.
- envdoc: full-registry description coverage via a real `NewConfig` load; drift rejection in both directions.
- provider: strict-off default fallback, strict rejection of malformed values and unknown names (with suggestion), foreign-namespace exemption, NodeID custom-parse strict path.

Quality gate run locally: `gofmt -l` clean; `go test ./...` green in root, core, mcp, pb, sdks/go, and server (with `go vet`).

Closes #847

🤖 Generated with [Claude Code](https://claude.com/claude-code)