### PR TITLE
feat(core): typed retryable error taxonomy for the llm provider clients

### DIFF
--- a/core/llm/anthropic/anthropic.go
+++ b/core/llm/anthropic/anthropic.go
@@ -193,7 +193,7 @@ func (m *model[T]) Generate(ctx context.Context, input string) (llm.Response[T],
 	}
 	var out T
 	if err := json.Unmarshal([]byte(r.text), &out); err != nil {
-		return llm.Response[T]{}, fmt.Errorf("anthropic: decode output: %w", err)
+		return llm.Response[T]{}, llm.DecodeFailure("anthropic", r.finish, err)
 	}
 	return llm.Response[T]{Output: out, Usage: r.usage, FinishReason: r.finish, Model: r.model}, nil
 }
@@ -303,12 +303,16 @@ func (c *Client) generate(ctx context.Context, instruction, input string, schema
 	}
 	defer httpResp.Body.Close()
 
+	// Classify failures BEFORE reading an unbounded body: the error path
+	// reads at most llm.ErrBodyLimit bytes and maps the status onto the
+	// shared retryability taxonomy (#852).
+	if httpResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(httpResp.Body, llm.ErrBodyLimit))
+		return result{}, llm.ClassifyHTTP("anthropic", httpResp.StatusCode, httpResp.Header, bytes.TrimSpace(body))
+	}
 	payload, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		return result{}, fmt.Errorf("anthropic: read response: %w", err)
-	}
-	if httpResp.StatusCode != http.StatusOK {
-		return result{}, fmt.Errorf("anthropic: status %d: %s", httpResp.StatusCode, strings.TrimSpace(string(payload)))
 	}
 
 	var r response

--- a/core/llm/anthropic/anthropic_test.go
+++ b/core/llm/anthropic/anthropic_test.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/anaregdesign/lantern/core/llm"
 )
@@ -223,15 +225,66 @@ func TestGenerateLength(t *testing.T) {
 }
 
 func TestGenerateHTTPError(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     int
+		retryAfter string
+		sentinel   error
+	}{
+		{"401 unauthorized", http.StatusUnauthorized, "", llm.ErrUnauthorized},
+		{"429 rate limited with Retry-After", http.StatusTooManyRequests, "7", llm.ErrRateLimited},
+		{"529 overloaded is unavailable", 529, "", llm.ErrUnavailable},
+		{"400 bad request", http.StatusBadRequest, "", llm.ErrBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.retryAfter != "" {
+					w.Header().Set("Retry-After", tc.retryAfter)
+				}
+				w.WriteHeader(tc.status)
+				_, _ = io.WriteString(w, `{"type":"error"}`)
+			}))
+			defer srv.Close()
+
+			m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x", "")
+			_, err := m.Generate(context.Background(), "y")
+			if !errors.Is(err, tc.sentinel) {
+				t.Fatalf("err = %v, want sentinel for status %d", err, tc.status)
+			}
+			var api *llm.APIError
+			if !errors.As(err, &api) {
+				t.Fatalf("err = %v, want APIError", err)
+			}
+			if api.Provider != "anthropic" || api.StatusCode != tc.status {
+				t.Fatalf("APIError = %+v", api)
+			}
+			if tc.retryAfter != "" && api.RetryAfter != 7*time.Second {
+				t.Fatalf("RetryAfter = %v, want 7s", api.RetryAfter)
+			}
+			if !strings.Contains(err.Error(), strconv.Itoa(tc.status)) {
+				t.Fatalf("Error() = %q, want status in message", err.Error())
+			}
+		})
+	}
+}
+
+func TestGenerateTruncated(t *testing.T) {
+	// max_tokens cut generation mid-JSON: the decode failure must be
+	// diagnosed as ErrTruncated (with the WithMaxTokens remedy), not a
+	// bare decode error (#852).
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = io.WriteString(w, "bad key")
+		_, _ = io.WriteString(w, `{"stop_reason":"max_tokens",`+
+			`"content":[{"type":"text","text":"{\"city\":\"Tok"}]}`)
 	}))
 	defer srv.Close()
 
 	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x", "")
 	_, err := m.Generate(context.Background(), "y")
-	if err == nil || !strings.Contains(err.Error(), "401") {
-		t.Fatalf("err = %v, want 401", err)
+	if !errors.Is(err, llm.ErrTruncated) {
+		t.Fatalf("err = %v, want ErrTruncated", err)
+	}
+	if !strings.Contains(err.Error(), "WithMaxTokens") {
+		t.Fatalf("err = %v, want remedy in message", err)
 	}
 }

--- a/core/llm/doc.go
+++ b/core/llm/doc.go
@@ -22,4 +22,22 @@
 // concrete backends (which need provider SDKs or HTTP clients) belong in their
 // own subpackages or modules that import this one, keeping the abstraction
 // dependency-free.
+//
+// # Error handling
+//
+// Provider HTTP failures carry a shared, errors.Is-able taxonomy (#852) so
+// callers can build retry loops and circuit breakers without string-matching
+// provider text:
+//
+//	ErrRateLimited   429; retry after backing off (APIError.RetryAfter when sent)
+//	ErrUnavailable   5xx (incl. Anthropic 529), 408, 409; transient, retry
+//	ErrUnauthorized  401/403; credential problem, do not retry
+//	ErrBadRequest    other 4xx; deterministic request problem, do not retry
+//
+// errors.As(&APIError{}) recovers the provider name, status code, Retry-After
+// hint, and a body excerpt bounded by ErrBodyLimit. Separately, ErrTruncated
+// marks a Generate whose structured output was cut by the max-token cap —
+// raise the cap rather than retrying. Refusals and safety blocks remain
+// provider-typed (anthropic.ErrRefusal, openai.ErrRefusal, gemini.ErrBlocked)
+// because their semantics differ per provider.
 package llm

--- a/core/llm/error.go
+++ b/core/llm/error.go
@@ -1,0 +1,136 @@
+package llm
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Typed failure taxonomy (#852). Every provider backend maps a non-200 HTTP
+// response through ClassifyHTTP so callers can branch on class instead of
+// string-matching provider error text:
+//
+//   - errors.Is(err, ErrRateLimited)  → back off (honour APIError.RetryAfter)
+//   - errors.Is(err, ErrUnavailable)  → transient; retry with backoff
+//   - errors.Is(err, ErrUnauthorized) → credential/config problem; do NOT retry
+//   - errors.Is(err, ErrBadRequest)   → deterministic request problem; do NOT retry
+//
+// errors.As(&APIError{}) recovers the provider, status code, Retry-After
+// hint, and a bounded excerpt of the response body.
+//
+// ErrTruncated is a separate, response-level condition: the model's output
+// was cut by the max-token cap and the structured JSON could not be decoded.
+// Retrying without raising the cap will fail the same way.
+var (
+	// ErrRateLimited marks HTTP 429. Retryable after a backoff; when the
+	// provider sent Retry-After it is parsed into APIError.RetryAfter.
+	ErrRateLimited = errors.New("llm: rate limited")
+	// ErrUnavailable marks transient provider-side failures — HTTP 5xx
+	// (including Anthropic's 529 overloaded), plus 408/409. Retryable.
+	ErrUnavailable = errors.New("llm: provider unavailable")
+	// ErrUnauthorized marks HTTP 401/403 — a credential or permission
+	// problem. Not retryable.
+	ErrUnauthorized = errors.New("llm: unauthorized")
+	// ErrBadRequest marks the remaining 4xx — a deterministic problem with
+	// the request (schema, model id, payload shape). Not retryable.
+	ErrBadRequest = errors.New("llm: bad request")
+	// ErrTruncated marks a Generate whose output was cut by the max-token
+	// cap before the structured JSON completed (FinishLength + decode
+	// failure). Raise the cap (WithMaxTokens) instead of retrying.
+	ErrTruncated = errors.New("llm: output truncated by max tokens")
+)
+
+// ErrBodyLimit bounds how many bytes of a provider error body are retained
+// on an APIError (and therefore how much can ever reach a log line). Provider
+// backends read error bodies through a reader capped at this size.
+const ErrBodyLimit = 2048
+
+// APIError is the structured form of a non-200 provider response. Unwrap
+// returns the classification sentinel, so errors.Is picks the class and
+// errors.As recovers the detail.
+type APIError struct {
+	// Provider is the backend that produced the failure: "anthropic",
+	// "gemini", or "openai".
+	Provider string
+	// StatusCode is the HTTP status of the response.
+	StatusCode int
+	// RetryAfter is the parsed Retry-After hint for rate limits; zero when
+	// the header was absent or unparseable.
+	RetryAfter time.Duration
+	// Body is the response body, truncated to ErrBodyLimit bytes.
+	Body string
+
+	sentinel error
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("%s: status %d: %s", e.Provider, e.StatusCode, e.Body)
+}
+
+func (e *APIError) Unwrap() error { return e.sentinel }
+
+// ClassifyHTTP builds the APIError for a non-200 provider response. body may
+// be arbitrarily large; it is truncated to ErrBodyLimit. The Retry-After
+// header is honoured in both delta-seconds and HTTP-date forms (a past date
+// yields zero).
+func ClassifyHTTP(provider string, status int, header http.Header, body []byte) error {
+	if len(body) > ErrBodyLimit {
+		body = body[:ErrBodyLimit]
+	}
+	e := &APIError{
+		Provider:   provider,
+		StatusCode: status,
+		Body:       string(body),
+	}
+	switch {
+	case status == http.StatusTooManyRequests:
+		e.sentinel = ErrRateLimited
+		e.RetryAfter = parseRetryAfter(header.Get("Retry-After"))
+	case status == http.StatusUnauthorized || status == http.StatusForbidden:
+		e.sentinel = ErrUnauthorized
+	case status == http.StatusRequestTimeout || status == http.StatusConflict:
+		e.sentinel = ErrUnavailable
+	case status >= 500:
+		// Includes Anthropic's non-standard 529 overloaded_error.
+		e.sentinel = ErrUnavailable
+	default:
+		e.sentinel = ErrBadRequest
+	}
+	return e
+}
+
+// parseRetryAfter accepts the two wire forms of Retry-After: delta-seconds
+// ("30") and HTTP-date. Absent, unparseable, or already-elapsed values yield
+// zero.
+func parseRetryAfter(v string) time.Duration {
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs < 0 {
+			return 0
+		}
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+
+// DecodeFailure is the shared Generate-side diagnosis for a JSON decode
+// failure (#852): when generation stopped at the token cap the decode failure
+// is a symptom, not the cause, so it is wrapped as ErrTruncated with the
+// remedy in the message. Any other decode failure stays a plain decode error.
+// Provider backends call this from their Generate implementations.
+func DecodeFailure(provider string, finish FinishReason, decodeErr error) error {
+	if finish == FinishLength {
+		return fmt.Errorf("%s: output truncated at the max-token cap before the structured JSON completed (raise WithMaxTokens): %w",
+			provider, errors.Join(ErrTruncated, decodeErr))
+	}
+	return fmt.Errorf("%s: decode output: %w", provider, decodeErr)
+}

--- a/core/llm/error_test.go
+++ b/core/llm/error_test.go
@@ -1,0 +1,125 @@
+package llm
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClassifyHTTP(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   int
+		header   http.Header
+		sentinel error
+		retry    time.Duration
+	}{
+		{"429 is rate limited", http.StatusTooManyRequests, nil, ErrRateLimited, 0},
+		{"429 honours delta-seconds Retry-After", http.StatusTooManyRequests,
+			http.Header{"Retry-After": []string{"30"}}, ErrRateLimited, 30 * time.Second},
+		{"401 is unauthorized", http.StatusUnauthorized, nil, ErrUnauthorized, 0},
+		{"403 is unauthorized", http.StatusForbidden, nil, ErrUnauthorized, 0},
+		{"408 is unavailable", http.StatusRequestTimeout, nil, ErrUnavailable, 0},
+		{"409 is unavailable", http.StatusConflict, nil, ErrUnavailable, 0},
+		{"500 is unavailable", http.StatusInternalServerError, nil, ErrUnavailable, 0},
+		{"503 is unavailable", http.StatusServiceUnavailable, nil, ErrUnavailable, 0},
+		{"529 overloaded is unavailable", 529, nil, ErrUnavailable, 0},
+		{"400 is bad request", http.StatusBadRequest, nil, ErrBadRequest, 0},
+		{"404 is bad request", http.StatusNotFound, nil, ErrBadRequest, 0},
+		{"422 is bad request", http.StatusUnprocessableEntity, nil, ErrBadRequest, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := tc.header
+			if h == nil {
+				h = http.Header{}
+			}
+			err := ClassifyHTTP("testprov", tc.status, h, []byte(`{"error":"x"}`))
+			if !errors.Is(err, tc.sentinel) {
+				t.Fatalf("errors.Is(%v, sentinel) = false for status %d", err, tc.status)
+			}
+			var api *APIError
+			if !errors.As(err, &api) {
+				t.Fatalf("errors.As APIError failed: %v", err)
+			}
+			if api.Provider != "testprov" || api.StatusCode != tc.status {
+				t.Fatalf("APIError = %+v", api)
+			}
+			if api.RetryAfter != tc.retry {
+				t.Fatalf("RetryAfter = %v, want %v", api.RetryAfter, tc.retry)
+			}
+			if !strings.Contains(err.Error(), "testprov") || !strings.Contains(err.Error(), `{"error":"x"}`) {
+				t.Fatalf("Error() = %q", err.Error())
+			}
+		})
+	}
+
+	t.Run("HTTP-date Retry-After yields a positive duration", func(t *testing.T) {
+		h := http.Header{"Retry-After": []string{time.Now().Add(90 * time.Second).UTC().Format(http.TimeFormat)}}
+		err := ClassifyHTTP("p", http.StatusTooManyRequests, h, nil)
+		var api *APIError
+		if !errors.As(err, &api) {
+			t.Fatal("no APIError")
+		}
+		if api.RetryAfter <= 0 || api.RetryAfter > 91*time.Second {
+			t.Fatalf("RetryAfter = %v, want ~90s", api.RetryAfter)
+		}
+	})
+
+	t.Run("past HTTP-date and garbage Retry-After yield zero", func(t *testing.T) {
+		for _, v := range []string{
+			time.Now().Add(-time.Minute).UTC().Format(http.TimeFormat),
+			"soon",
+			"-5",
+		} {
+			h := http.Header{"Retry-After": []string{v}}
+			var api *APIError
+			if !errors.As(ClassifyHTTP("p", 429, h, nil), &api) {
+				t.Fatal("no APIError")
+			}
+			if api.RetryAfter != 0 {
+				t.Fatalf("RetryAfter(%q) = %v, want 0", v, api.RetryAfter)
+			}
+		}
+	})
+
+	t.Run("body is truncated to ErrBodyLimit", func(t *testing.T) {
+		big := strings.Repeat("x", ErrBodyLimit+500)
+		var api *APIError
+		if !errors.As(ClassifyHTTP("p", 500, http.Header{}, []byte(big)), &api) {
+			t.Fatal("no APIError")
+		}
+		if len(api.Body) != ErrBodyLimit {
+			t.Fatalf("len(Body) = %d, want %d", len(api.Body), ErrBodyLimit)
+		}
+	})
+}
+
+func TestDecodeFailure(t *testing.T) {
+	base := errors.New("unexpected end of JSON input")
+
+	t.Run("FinishLength wraps as ErrTruncated and keeps the decode error", func(t *testing.T) {
+		err := DecodeFailure("p", FinishLength, base)
+		if !errors.Is(err, ErrTruncated) {
+			t.Fatalf("not ErrTruncated: %v", err)
+		}
+		if !errors.Is(err, base) {
+			t.Fatalf("decode cause lost: %v", err)
+		}
+		if !strings.Contains(err.Error(), "WithMaxTokens") {
+			t.Fatalf("remedy missing from message: %v", err)
+		}
+	})
+
+	t.Run("FinishStop stays an untyped decode error", func(t *testing.T) {
+		err := DecodeFailure("p", FinishStop, base)
+		if errors.Is(err, ErrTruncated) {
+			t.Fatalf("FinishStop must not classify as truncation: %v", err)
+		}
+		if !errors.Is(err, base) {
+			t.Fatalf("decode cause lost: %v", err)
+		}
+	})
+}

--- a/core/llm/gemini/gemini.go
+++ b/core/llm/gemini/gemini.go
@@ -201,7 +201,7 @@ func (m *model[T]) Generate(ctx context.Context, input string) (llm.Response[T],
 	}
 	var out T
 	if err := json.Unmarshal([]byte(r.text), &out); err != nil {
-		return llm.Response[T]{}, fmt.Errorf("gemini: decode output: %w", err)
+		return llm.Response[T]{}, llm.DecodeFailure("gemini", r.finish, err)
 	}
 	return llm.Response[T]{Output: out, Usage: r.usage, FinishReason: r.finish, Model: r.model}, nil
 }
@@ -238,6 +238,13 @@ type response struct {
 		Content      content `json:"content"`
 		FinishReason string  `json:"finishReason"`
 	} `json:"candidates"`
+	// PromptFeedback carries prompt-level (pre-generation) blocking: when the
+	// PROMPT itself is rejected, candidates is empty and blockReason names the
+	// filter — the only signal distinguishing a block from an empty response
+	// (#852).
+	PromptFeedback struct {
+		BlockReason string `json:"blockReason"`
+	} `json:"promptFeedback"`
 	UsageMetadata struct {
 		PromptTokenCount     int `json:"promptTokenCount"`
 		CandidatesTokenCount int `json:"candidatesTokenCount"`
@@ -299,12 +306,16 @@ func (c *Client) generate(ctx context.Context, instruction, input string, schema
 	}
 	defer httpResp.Body.Close()
 
+	// Classify failures BEFORE reading an unbounded body: the error path
+	// reads at most llm.ErrBodyLimit bytes and maps the status onto the
+	// shared retryability taxonomy (#852).
+	if httpResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(httpResp.Body, llm.ErrBodyLimit))
+		return result{}, llm.ClassifyHTTP("gemini", httpResp.StatusCode, httpResp.Header, bytes.TrimSpace(body))
+	}
 	payload, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		return result{}, fmt.Errorf("gemini: read response: %w", err)
-	}
-	if httpResp.StatusCode != http.StatusOK {
-		return result{}, fmt.Errorf("gemini: status %d: %s", httpResp.StatusCode, strings.TrimSpace(string(payload)))
 	}
 
 	var r response
@@ -325,6 +336,11 @@ func (c *Client) generate(ctx context.Context, instruction, input string, schema
 		if cand.FinishReason == "SAFETY" || cand.FinishReason == "RECITATION" {
 			return result{}, fmt.Errorf("%w: %s", ErrBlocked, cand.FinishReason)
 		}
+	}
+	// A blocked PROMPT produces no candidates at all; surface it as the same
+	// typed ErrBlocked instead of the generic no-content error (#852).
+	if r.PromptFeedback.BlockReason != "" {
+		return result{}, fmt.Errorf("%w: prompt blocked: %s", ErrBlocked, r.PromptFeedback.BlockReason)
 	}
 	return result{}, errors.New("gemini: no content in response")
 }

--- a/core/llm/gemini/gemini_test.go
+++ b/core/llm/gemini/gemini_test.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/anaregdesign/lantern/core/llm"
 )
@@ -214,16 +216,82 @@ func TestGenerateLength(t *testing.T) {
 }
 
 func TestGenerateHTTPError(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     int
+		retryAfter string
+		sentinel   error
+	}{
+		{"401 unauthorized", http.StatusUnauthorized, "", llm.ErrUnauthorized},
+		{"429 rate limited with Retry-After", http.StatusTooManyRequests, "7", llm.ErrRateLimited},
+		{"503 unavailable", http.StatusServiceUnavailable, "", llm.ErrUnavailable},
+		{"400 bad request", http.StatusBadRequest, "", llm.ErrBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.retryAfter != "" {
+					w.Header().Set("Retry-After", tc.retryAfter)
+				}
+				w.WriteHeader(tc.status)
+				_, _ = io.WriteString(w, `{"error":{}}`)
+			}))
+			defer srv.Close()
+
+			m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x", "")
+			_, err := m.Generate(context.Background(), "y")
+			if !errors.Is(err, tc.sentinel) {
+				t.Fatalf("err = %v, want sentinel for status %d", err, tc.status)
+			}
+			var api *llm.APIError
+			if !errors.As(err, &api) {
+				t.Fatalf("err = %v, want APIError", err)
+			}
+			if api.Provider != "gemini" || api.StatusCode != tc.status {
+				t.Fatalf("APIError = %+v", api)
+			}
+			if tc.retryAfter != "" && api.RetryAfter != 7*time.Second {
+				t.Fatalf("RetryAfter = %v, want 7s", api.RetryAfter)
+			}
+			if !strings.Contains(err.Error(), strconv.Itoa(tc.status)) {
+				t.Fatalf("Error() = %q, want status in message", err.Error())
+			}
+		})
+	}
+}
+
+func TestGeneratePromptBlocked(t *testing.T) {
+	// A blocked PROMPT yields no candidates at all; the reason lives only in
+	// promptFeedback.blockReason and must surface as ErrBlocked, not the
+	// generic no-content error (#852).
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = io.WriteString(w, "bad key")
+		_, _ = io.WriteString(w, `{"promptFeedback":{"blockReason":"PROHIBITED_CONTENT"}}`)
 	}))
 	defer srv.Close()
 
 	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x", "")
 	_, err := m.Generate(context.Background(), "y")
-	if err == nil || !strings.Contains(err.Error(), "401") {
-		t.Fatalf("err = %v, want 401", err)
+	if !errors.Is(err, ErrBlocked) {
+		t.Fatalf("err = %v, want ErrBlocked", err)
+	}
+	if !strings.Contains(err.Error(), "PROHIBITED_CONTENT") {
+		t.Fatalf("err = %v, want block reason in message", err)
+	}
+}
+
+func TestGenerateTruncated(t *testing.T) {
+	// MAX_TOKENS cut generation mid-JSON: the decode failure must be
+	// diagnosed as ErrTruncated with the WithMaxTokens remedy (#852).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"candidates":[{"content":{"parts":[{"text":"{\"city\":\"Tok"}]},`+
+			`"finishReason":"MAX_TOKENS"}]}`)
+	}))
+	defer srv.Close()
+
+	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x", "")
+	_, err := m.Generate(context.Background(), "y")
+	if !errors.Is(err, llm.ErrTruncated) {
+		t.Fatalf("err = %v, want ErrTruncated", err)
 	}
 }
 

--- a/core/llm/openai/openai.go
+++ b/core/llm/openai/openai.go
@@ -139,7 +139,7 @@ func (m *model[T]) Generate(ctx context.Context, input string) (llm.Response[T],
 	}
 	var out T
 	if err := json.Unmarshal([]byte(r.text), &out); err != nil {
-		return llm.Response[T]{}, fmt.Errorf("openai: decode output: %w", err)
+		return llm.Response[T]{}, llm.DecodeFailure("openai", r.finish, err)
 	}
 	return llm.Response[T]{Output: out, Usage: r.usage, FinishReason: r.finish, Model: r.model}, nil
 }
@@ -234,12 +234,16 @@ func (c *Client) generate(ctx context.Context, instruction, input, name string, 
 	}
 	defer httpResp.Body.Close()
 
+	// Classify failures BEFORE reading an unbounded body: the error path
+	// reads at most llm.ErrBodyLimit bytes and maps the status onto the
+	// shared retryability taxonomy (#852).
+	if httpResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(httpResp.Body, llm.ErrBodyLimit))
+		return result{}, llm.ClassifyHTTP("openai", httpResp.StatusCode, httpResp.Header, bytes.TrimSpace(body))
+	}
 	payload, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		return result{}, fmt.Errorf("openai: read response: %w", err)
-	}
-	if httpResp.StatusCode != http.StatusOK {
-		return result{}, fmt.Errorf("openai: status %d: %s", httpResp.StatusCode, strings.TrimSpace(string(payload)))
 	}
 
 	var r response

--- a/core/llm/openai/openai_test.go
+++ b/core/llm/openai/openai_test.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/anaregdesign/lantern/core/llm"
 )
@@ -134,15 +136,62 @@ func TestGenerateLength(t *testing.T) {
 }
 
 func TestGenerateHTTPError(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     int
+		retryAfter string
+		sentinel   error
+	}{
+		{"401 unauthorized", http.StatusUnauthorized, "", llm.ErrUnauthorized},
+		{"429 rate limited with Retry-After", http.StatusTooManyRequests, "7", llm.ErrRateLimited},
+		{"500 unavailable", http.StatusInternalServerError, "", llm.ErrUnavailable},
+		{"404 bad request", http.StatusNotFound, "", llm.ErrBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.retryAfter != "" {
+					w.Header().Set("Retry-After", tc.retryAfter)
+				}
+				w.WriteHeader(tc.status)
+				_, _ = io.WriteString(w, `{"error":{}}`)
+			}))
+			defer srv.Close()
+
+			m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x", "")
+			_, err := m.Generate(context.Background(), "y")
+			if !errors.Is(err, tc.sentinel) {
+				t.Fatalf("err = %v, want sentinel for status %d", err, tc.status)
+			}
+			var api *llm.APIError
+			if !errors.As(err, &api) {
+				t.Fatalf("err = %v, want APIError", err)
+			}
+			if api.Provider != "openai" || api.StatusCode != tc.status {
+				t.Fatalf("APIError = %+v", api)
+			}
+			if tc.retryAfter != "" && api.RetryAfter != 7*time.Second {
+				t.Fatalf("RetryAfter = %v, want 7s", api.RetryAfter)
+			}
+			if !strings.Contains(err.Error(), strconv.Itoa(tc.status)) {
+				t.Fatalf("Error() = %q, want status in message", err.Error())
+			}
+		})
+	}
+}
+
+func TestGenerateTruncated(t *testing.T) {
+	// max_output_tokens cut generation mid-JSON: the decode failure must be
+	// diagnosed as ErrTruncated with the WithMaxTokens remedy (#852).
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = io.WriteString(w, "bad key")
+		_, _ = io.WriteString(w, `{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},`+
+			`"output":[{"content":[{"type":"output_text","text":"{\"city\":\"Tok"}]}]}`)
 	}))
 	defer srv.Close()
 
 	m, _ := New[weather](NewClient("k", "m", WithBaseURL(srv.URL)), "x", "")
 	_, err := m.Generate(context.Background(), "y")
-	if err == nil || !strings.Contains(err.Error(), "401") {
-		t.Fatalf("err = %v, want 401", err)
+	if !errors.Is(err, llm.ErrTruncated) {
+		t.Fatalf("err = %v, want ErrTruncated", err)
 	}
 }


### PR DESCRIPTION
## Summary

Implements #852 (see the issue body + sequencing comment for the full spec):

- **`llm.APIError` + sentinels** (`error.go`, new): `ErrRateLimited` (429, with `RetryAfter` parsed from both delta-seconds and HTTP-date, past dates → 0), `ErrUnavailable` (5xx including Anthropic's 529, plus 408/409), `ErrUnauthorized` (401/403), `ErrBadRequest` (remaining 4xx). `Unwrap` returns the sentinel so `errors.Is` picks the class and `errors.As` recovers provider/status/retry-hint/body.
- **Bounded error bodies**: all three providers now classify BEFORE reading the body, through `io.LimitReader(…, llm.ErrBodyLimit)` — a proxy's multi-KB error page can no longer bloat error strings/logs.
- **Truncation diagnosis**: `llm.DecodeFailure` wraps a decode failure as `ErrTruncated` (naming the `WithMaxTokens` remedy) when `FinishReason == FinishLength`; a decode failure at `FinishStop` deliberately stays untyped (that's a schema/model bug, not truncation).
- **Gemini prompt-level blocks**: `promptFeedback.blockReason` is now read; a blocked prompt (empty candidates) surfaces as the typed `ErrBlocked` with the reason instead of the generic "no content in response".
- doc.go gains the error-handling contract section (which sentinels are retryable, where RetryAfter lives).

This is the input #828's Engine wrapper needs for budget/circuit-breaker policy (cross-referenced on that issue) and unblocks typed assertions in #853/#854.

## Tests

- `error_test.go` (new, 1:1 with `error.go`): full status matrix, both Retry-After forms + garbage/past-date → 0, body truncation at the limit, `DecodeFailure` both branches.
- Each provider's paired test: table-driven typed-error matrix over {401, 429+Retry-After, 5xx/529, 4xx} asserting sentinel + `APIError` fields, plus a truncated-JSON-at-token-cap → `ErrTruncated` case; gemini additionally covers the prompt-block path.

Quality gate: `gofmt -l` clean; `go vet` + `go test ./...` green in core (and untouched modules unaffected).

Closes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)