### PR TITLE
perf(core): O(1) edge counters, single clock sample per walk, frontier queue

### DIFF
--- a/core/graphcache/edge.go
+++ b/core/graphcache/edge.go
@@ -174,9 +174,18 @@ func (w *weight) replace(value float32, expiration time.Time) {
 // (getDetail) should prefer this over chaining isZero / value /
 // latestExpiration, which triple-lock and triple-scan.
 func (w *weight) snapshot() (sum float32, latest time.Time, nonZero bool) {
+	return w.snapshotAt(time.Now())
+}
+
+// snapshotAt is snapshot with the liveness clock supplied by the caller
+// (#838). A traversal samples time.Now() ONCE and passes the same instant to
+// every visited edge, so (a) a walk over E' edges performs one clock read
+// instead of E', and (b) every edge in one walk decides liveness against the
+// same reference time instead of instants that drift as the walk progresses.
+func (w *weight) snapshotAt(now time.Time) (sum float32, latest time.Time, nonZero bool) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	w.flushLocked()
+	w.flushLockedAt(now)
 	for _, v := range w.values {
 		if v.expiration.After(latest) {
 			latest = v.expiration
@@ -216,7 +225,12 @@ func (w *weight) snapshotEntry(now time.Time) ([]SnapshotContribution, hlc.Times
 // flushLocked compacts expired entries in place and recomputes the cached sum.
 // Caller must hold w.mu.
 func (w *weight) flushLocked() {
-	now := time.Now()
+	w.flushLockedAt(time.Now())
+}
+
+// flushLockedAt is flushLocked against a caller-supplied instant (#838).
+// Caller must hold w.mu.
+func (w *weight) flushLockedAt(now time.Time) {
 	write := 0
 	var sum float32
 	for _, v := range w.values {
@@ -247,6 +261,15 @@ type edgeCache[S comparable] struct {
 	dict       *dictionary[S]
 	tf         map[vertexID]map[vertexID]*weight
 	df         map[vertexID]int
+	// edgeCount tracks the number of (tail, head) buckets held in tf,
+	// incremented at every bucket creation and decremented in deleteLocked
+	// (#838). It makes count() and corpusStats O(1) instead of an O(#tails)
+	// walk — count() is sampled by Prometheus on every scrape and
+	// corpusStats runs once per BM25-weighted traversal. Bucket create and
+	// delete both happen under c.mu.Lock, so the counter shares tf's
+	// locking contract (including the lock-free corpusStats read, which the
+	// caller serializes via GraphCache.mu exactly as for len(c.tf)).
+	edgeCount int
 }
 
 func newEdgeCache[S comparable](defaultTTL time.Duration, dict *dictionary[S]) *edgeCache[S] {
@@ -355,11 +378,7 @@ func (c *edgeCache[S]) docFreq(head vertexID) int {
 // count() it takes no edgeCache lock, so it composes inside the Neighbor read
 // path which already holds GraphCache.mu read-locked.
 func (c *edgeCache[S]) corpusStats() (tails, edges int) {
-	tails = len(c.tf)
-	for _, heads := range c.tf {
-		edges += len(heads)
-	}
-	return tails, edges
+	return len(c.tf), c.edgeCount
 }
 
 // resolveID resolves a vertexID back to S without locking the edgeCache.
@@ -531,6 +550,7 @@ func (c *edgeCache[S]) addWithExpirationContrib(tail, head S, w float32, expirat
 		edge = newWeight()
 		heads[headID] = edge
 		c.df[headID]++
+		c.edgeCount++
 		created = true
 	} else if c.dict != nil {
 		// Edge already present: revert the intern bumps to keep the
@@ -591,6 +611,7 @@ func (c *edgeCache[S]) putWithExpiration(tail, head S, w float32, expiration tim
 		edge = newWeight()
 		heads[headID] = edge
 		c.df[headID]++
+		c.edgeCount++
 		created = true
 	} else if c.dict != nil {
 		c.dict.release(tailID)
@@ -669,6 +690,7 @@ func (c *edgeCache[S]) putWithExpirationHLC(tail, head S, w float32, expiration 
 		edge = newWeight()
 		heads[headID] = edge
 		c.df[headID]++
+		c.edgeCount++
 		created = true
 	} else if c.dict != nil {
 		c.dict.release(tailID)
@@ -721,6 +743,7 @@ func (c *edgeCache[S]) deleteLocked(tailID, headID vertexID) bool {
 	if c.df[headID] <= 0 {
 		delete(c.df, headID)
 	}
+	c.edgeCount--
 	if len(heads) == 0 {
 		delete(c.tf, tailID)
 	}
@@ -843,9 +866,5 @@ func (c *edgeCache[S]) sweepHeadsLocked(tailID vertexID, heads map[vertexID]*wei
 func (c *edgeCache[S]) count() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	n := 0
-	for _, heads := range c.tf {
-		n += len(heads)
-	}
-	return n
+	return c.edgeCount
 }

--- a/core/graphcache/edge_test.go
+++ b/core/graphcache/edge_test.go
@@ -592,3 +592,117 @@ func Test_edgeCache_addExistingContribByID(t *testing.T) {
 		}
 	})
 }
+
+// Test_weight_snapshotAt pins the caller-supplied-clock contract (#838): the
+// SAME bucket answers differently depending only on the instant passed in,
+// so a traversal that samples time.Now() once observes consistent liveness
+// across every edge it visits.
+func Test_weight_snapshotAt(t *testing.T) {
+	base := time.Now()
+	w := newWeight()
+	w.addWithExpiration(2, base.Add(50*time.Millisecond))
+	w.addWithExpiration(3, base.Add(200*time.Millisecond))
+
+	if sum, latest, nonZero := w.snapshotAt(base); !nonZero || sum != 5 || !latest.Equal(base.Add(200*time.Millisecond)) {
+		t.Fatalf("snapshotAt(base) = (%v, %v, %v), want (5, +200ms, true)", sum, latest, nonZero)
+	}
+	// Between the two expirations only the later contribution survives.
+	if sum, _, nonZero := w.snapshotAt(base.Add(100 * time.Millisecond)); !nonZero || sum != 3 {
+		t.Fatalf("snapshotAt(+100ms) sum = %v, want 3", sum)
+	}
+	// Past both expirations the bucket is fully decayed.
+	if _, _, nonZero := w.snapshotAt(base.Add(300 * time.Millisecond)); nonZero {
+		t.Fatal("snapshotAt(+300ms) still nonZero, want decayed")
+	}
+}
+
+// Test_edgeCache_edgeCount is the parity property for the O(1) bucket
+// counter (#838): after every mutation mix — additive creates (with and
+// without dict, with and without ContribID), LWW puts, in-place put
+// replaces, deletes, zero-weight flushes, and keep-predicate sweeps — the
+// counter must equal a fresh O(E) walk of tf.
+func Test_edgeCache_edgeCount(t *testing.T) {
+	walk := func(c *edgeCache[string]) int {
+		c.mu.RLock()
+		defer c.mu.RUnlock()
+		n := 0
+		for _, heads := range c.tf {
+			n += len(heads)
+		}
+		return n
+	}
+	check := func(t *testing.T, c *edgeCache[string], want int) {
+		t.Helper()
+		if got := c.count(); got != want {
+			t.Fatalf("count() = %d, want %d", got, want)
+		}
+		if got := walk(c); got != c.edgeCount {
+			t.Fatalf("edgeCount = %d, walk = %d", c.edgeCount, got)
+		}
+		tails, edges := c.corpusStats()
+		if edges != want || tails != len(c.tf) {
+			t.Fatalf("corpusStats = (%d, %d), want (%d, %d)", tails, edges, len(c.tf), want)
+		}
+	}
+
+	t.Run("create paths and deletes agree with the walk", func(t *testing.T) {
+		c := newEdgeCache[string](time.Minute, newDictionary[string]())
+		exp := time.Now().Add(time.Minute)
+
+		c.addWithExpiration("a", "b", 1, exp) // additive create
+		c.addWithExpiration("a", "b", 1, exp) // existing bucket: no change
+		c.putWithExpiration("a", "c", 1, exp) // put create
+		c.putWithExpiration("a", "c", 2, exp) // in-place replace: no change
+		c.addWithExpirationContrib("b", "c", 1, exp, ContribID{1})
+		c.addWithExpirationContrib("b", "c", 1, exp, ContribID{1}) // deduped: no change
+		c.putWithExpirationHLC("c", "a", 1, exp, hlc.Timestamp{WallNs: 1})
+		check(t, c, 4)
+
+		if deleted, _, _ := c.delete("a", "b"); !deleted {
+			t.Fatal("delete(a,b) = false")
+		}
+		if deleted, _, _ := c.delete("a", "b"); deleted {
+			t.Fatal("double delete(a,b) = true")
+		}
+		check(t, c, 3)
+	})
+
+	t.Run("dict-nil test caches keep parity", func(t *testing.T) {
+		// Without a dict every endpoint resolves to vertexID 0, so all edges
+		// collapse into the single (0, 0) bucket — the pre-existing dict-nil
+		// degenerate shape. The counter must track that reality (one bucket),
+		// not the logical key pairs.
+		c := newEdgeCache[string](time.Minute, nil)
+		exp := time.Now().Add(time.Minute)
+		c.addWithExpiration("a", "b", 1, exp)
+		c.addWithExpiration("a", "c", 1, exp)
+		check(t, c, 1)
+	})
+
+	t.Run("zero-weight flush and keep-predicate sweep decrement", func(t *testing.T) {
+		c := newEdgeCache[string](time.Minute, newDictionary[string]())
+		live := time.Now().Add(time.Minute)
+		dead := time.Now().Add(-time.Minute)
+
+		c.addWithExpiration("a", "b", 1, dead) // fully decayed
+		c.addWithExpiration("a", "c", 1, live)
+		c.addWithExpiration("d", "e", 1, live)
+		check(t, c, 3)
+
+		if removed := c.flush(); removed != 1 {
+			t.Fatalf("flush removed %d, want 1", removed)
+		}
+		check(t, c, 2)
+
+		// Sweep away everything whose tail is "d" via the keep predicate.
+		dID, ok := c.dict.lookup("d")
+		if !ok {
+			t.Fatal("dict.lookup(d) miss")
+		}
+		zero, dangling := c.flushFunc(func(tail, _ vertexID) bool { return tail != dID }, nil)
+		if zero != 0 || dangling != 1 {
+			t.Fatalf("flushFunc = (%d, %d), want (0, 1)", zero, dangling)
+		}
+		check(t, c, 1)
+	})
+}

--- a/core/graphcache/traversal.go
+++ b/core/graphcache/traversal.go
@@ -119,12 +119,15 @@ func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int
 	}
 
 	var mu sync.Mutex
-	// targets / seen are accessed only from the main goroutine (between
-	// wg.Wait barriers), so plain maps suffice — no need for the locked
-	// set.Set wrapper. mu protects concurrent writes to g.Edges and
-	// (when requested) expirations.
-	targets := map[S]struct{}{seed: {}}
-	seen := make(map[S]struct{})
+	// seen marks every vertex ever queued into a frontier so each vertex is
+	// expanded at most once; the frontier slices below replace the historical
+	// grow-only targets map, whose full rescan each step cost
+	// O(steps x discovered) (#838). Both are accessed only from the main
+	// goroutine (between wg.Wait barriers), so plain structures suffice.
+	// mu protects concurrent writes to g.Edges and (when requested)
+	// expirations.
+	seen := map[S]struct{}{seed: {}}
+	frontier := []S{seed}
 	// expirations is allocated up front so per-tail goroutines can publish
 	// their surviving heads without an extra coordination pass.
 	var expirations map[S]map[S]time.Time
@@ -136,6 +139,10 @@ func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int
 	// edgeCache.headsOf / docFreq accessors are safe to call directly.
 	// This turns the per-call cost from O(V+E) (snapshotTF + snapshotDF)
 	// into O(sum of degrees of visited tails).
+
+	// One liveness instant for the whole walk (#838): every edge snapshot in
+	// this traversal decides expiration against the same clock reading.
+	now := time.Now()
 
 	// BM25 corpus statistics are read once here (O(#tails), and only for the
 	// BM25 weighting) under the same RLock the per-edge accessors rely on.
@@ -192,7 +199,7 @@ func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int
 			if keep != nil && !keep(head) {
 				continue
 			}
-			sum, latest, nonZero := w.snapshot()
+			sum, latest, nonZero := w.snapshotAt(now)
 			if !nonZero {
 				continue
 			}
@@ -232,15 +239,8 @@ func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int
 		if err := ctx.Err(); err != nil {
 			return nil, nil, err
 		}
-
-		// Collect this step's frontier (targets not yet processed). Marking
-		// happens after wg.Wait so the goroutines need not touch `seen`.
-		frontier := make([]S, 0, len(targets))
-		for t := range targets {
-			if _, ok := seen[t]; ok {
-				continue
-			}
-			frontier = append(frontier, t)
+		if len(frontier) == 0 {
+			break
 		}
 
 		// Small frontiers run sequentially: goroutine startup and the
@@ -275,19 +275,19 @@ func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int
 			wg.Wait()
 		}
 
-		// Mark this step's frontier as processed.
-		for _, t := range frontier {
-			seen[t] = struct{}{}
-		}
-
-		// Find all next targets
-		for _, heads := range g.Edges {
-			for head := range heads {
+		// The next frontier is exactly the surviving heads of the tails just
+		// processed that have never been queued before — no rescan of the
+		// whole discovered graph per step (#838).
+		var next []S
+		for _, tail := range frontier {
+			for head := range g.Edges[tail] {
 				if _, ok := seen[head]; !ok {
-					targets[head] = struct{}{}
+					seen[head] = struct{}{}
+					next = append(next, head)
 				}
 			}
 		}
+		frontier = next
 	}
 
 	// Add vertices to the graph. Every endpoint reached here was gated on
@@ -428,10 +428,13 @@ func (c *GraphCache[S, T]) PersonalizedPageRankContext(ctx context.Context, seed
 	inQueue := map[S]bool{seed: true}
 	maxPushes := pprMaxPushes(alpha, epsilon)
 
+	// One liveness instant for the whole push (#838), mirroring
+	// neighborContext; and an index cursor instead of queue = queue[1:], so
+	// the loop does not re-slice while retaining the consumed backing head.
+	now := time.Now()
 	pushes := 0
-	for len(queue) > 0 {
-		u := queue[0]
-		queue = queue[1:]
+	for qi := 0; qi < len(queue); qi++ {
+		u := queue[qi]
 		inQueue[u] = false
 		ru := r[u]
 
@@ -456,7 +459,7 @@ func (c *GraphCache[S, T]) PersonalizedPageRankContext(ctx context.Context, seed
 					if keep != nil && !keep(head) {
 						continue
 					}
-					sum, _, nonZero := w.snapshot()
+					sum, _, nonZero := w.snapshotAt(now)
 					if !nonZero {
 						continue
 					}


### PR DESCRIPTION
## Summary

Implements #838 (see the issue body + sequencing comment). Three independent hot-path costs in core/graphcache:

1. **O(1) edge counter**: `edgeCache.edgeCount` incremented at all three bucket-creation sites (additive slow path, put, put-HLC) and decremented in `deleteLocked` (the single removal chokepoint shared by delete/flushFunc/flushTails). `count()` — Prometheus gauge every scrape, snapshot preallocation — and `corpusStats()` — once per BM25 Illuminate/PPR — stop walking every tail bucket. The counter shares tf's locking contract, including the documented lock-free `corpusStats` read under `GraphCache.mu`.
2. **One clock sample per walk**: `weight.snapshotAt(now)` / `flushLockedAt(now)`; `neighborContext` and the PPR push sample `time.Now()` once, so a walk over E' edges performs one clock read instead of E' and decides liveness against one consistent instant.
3. **Frontier bookkeeping**: the BFS's grow-only `targets` map (rescanned fully per step, plus a full `g.Edges` rescan per step for next-target discovery) becomes explicit frontier slices + a seen-set — next frontier is derived only from the just-processed tails' surviving heads. The PPR queue uses an index cursor instead of the head-retaining `queue = queue[1:]`.

This is the Phase-A base of the core cluster: #839 (same-file merge order), #843 (count preallocation), #848 (O(1) EdgeCount), and #845 (single-`now` push helper) all build on it.

## Tests

- `Test_edgeCache_edgeCount`: parity property — counter == O(E) walk == `corpusStats` across additive/put/put-HLC creates, dedup no-ops, in-place replaces, deletes, zero-weight flushes, and keep-predicate sweeps; includes the dict-nil degenerate cache (documented single-bucket collapse).
- `Test_weight_snapshotAt`: deterministic caller-clock contract (same bucket, three instants, three liveness answers).
- Full existing traversal/production/ACID suites green (BFS semantics unchanged by the frontier rewrite).

Quality gate run locally: gofmt clean; go vet + go test green in root, core, mcp, pb, sdks/go, server.

Closes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)