### PR TITLE
perf(core): memoize endpoint liveness in the GC dangling-edge sweep

### DIFF
--- a/core/graphcache/gc.go
+++ b/core/graphcache/gc.go
@@ -22,16 +22,30 @@ func (c *GraphCache[S, T]) flush() (zero, dangling int) {
 	c.sweepExpiredTombstonesLocked(time.Now())
 	c.sweepStaleVertexHLCLocked()
 
+	// Per-flush endpoint-liveness memo (#839). The sweep consults keep once
+	// per EDGE, which used to cost two dict resolves plus two vertex-cache
+	// probes each — four lock round-trips per edge inside the most global
+	// critical section the server has, with the tail re-paying them for
+	// every head in its bucket and popular heads re-paying across tails.
+	// Memoizing per distinct endpoint collapses that to one resolve+probe
+	// per endpoint per tick.
+	//
+	// Scope: exactly this flush call. A budgeted sweep (#744) processes one
+	// batch per flush call, so the memo never outlives a tick — a vertex
+	// deleted between ticks is re-evaluated by the next tick's fresh memo,
+	// and an ID recycled between ticks resolves against current state.
+	liveByID := make(map[vertexID]bool)
+	liveID := func(id vertexID) bool {
+		if live, ok := liveByID[id]; ok {
+			return live
+		}
+		key, ok := c.edges.resolveID(id)
+		live := ok && c.vertices.Has(key)
+		liveByID[id] = live
+		return live
+	}
 	keep := func(tailID, headID vertexID) bool {
-		tail, ok := c.edges.resolveID(tailID)
-		if !ok {
-			return false
-		}
-		head, ok := c.edges.resolveID(headID)
-		if !ok {
-			return false
-		}
-		return c.vertices.Has(tail) && c.vertices.Has(head)
+		return liveID(tailID) && liveID(headID)
 	}
 	onDelete := c.headIndexOnFlushDeleteLocked()
 

--- a/core/graphcache/gc_test.go
+++ b/core/graphcache/gc_test.go
@@ -3,6 +3,7 @@ package graphcache
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -246,4 +247,88 @@ func TestGraphCache_GCIncrementalEdgeSweep(t *testing.T) {
 			t.Fatalf("full sweep left %d edges (removed %d this tick)", c.edges.count(), z)
 		}
 	})
+}
+
+// TestGraphCache_GCLivenessMemoScope pins the #839 contract that the
+// endpoint-liveness memo lives for exactly ONE flush call: a vertex deleted
+// between budgeted ticks must be seen as dead by the next tick's sweep, and
+// a full (unbudgeted) sweep after a delete reclaims every dangling edge in a
+// single call — including edges into a shared, formerly-memoized head.
+func TestGraphCache_GCLivenessMemoScope(t *testing.T) {
+	t.Run("full sweep after delete reclaims shared-head fan-in at once", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		exp := time.Now().Add(time.Minute)
+		for _, tail := range []string{"a", "b", "c"} {
+			c.AddEdgeWithExpiration(tail, "hub", 1, exp)
+		}
+		if !c.DeleteVertex("hub") {
+			t.Fatal("DeleteVertex(hub) = false")
+		}
+		zero, dangling := c.flush()
+		if zero != 0 || dangling != 3 {
+			t.Fatalf("flush = (%d, %d), want (0, 3)", zero, dangling)
+		}
+		if got := c.EdgeCount(); got != 0 {
+			t.Fatalf("EdgeCount = %d, want 0", got)
+		}
+	})
+
+	t.Run("budgeted ticks never keep a mid-cycle delete alive", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		exp := time.Now().Add(time.Minute)
+		c.AddEdgeWithExpiration("a", "hub", 1, exp)
+		c.AddEdgeWithExpiration("b", "hub", 1, exp)
+		c.SetGCEdgeBudget(1)
+
+		// Tick 1 sweeps one tail while hub is live: nothing is reclaimed.
+		if zero, dangling := c.flush(); zero != 0 || dangling != 0 {
+			t.Fatalf("tick1 = (%d, %d), want (0, 0)", zero, dangling)
+		}
+
+		if !c.DeleteVertex("hub") {
+			t.Fatal("DeleteVertex(hub) = false")
+		}
+
+		// The remaining ticks — finishing this cycle and running the next
+		// full cycle — must reclaim BOTH dangling edges. A memo leaking
+		// across flush calls would keep hub "live" and strand them.
+		removed := 0
+		for i := 0; i < 4; i++ {
+			_, dangling := c.flush()
+			removed += dangling
+		}
+		if removed != 2 {
+			t.Fatalf("dangling reclaimed across ticks = %d, want 2", removed)
+		}
+		if got := c.EdgeCount(); got != 0 {
+			t.Fatalf("EdgeCount = %d, want 0", got)
+		}
+	})
+}
+
+// BenchmarkGCFlushDanglingSweep measures one full GC edge sweep over a graph
+// whose hub endpoints were just deleted — the workload #839's per-flush
+// liveness memo targets (high fan-out tails plus popular shared heads).
+func BenchmarkGCFlushDanglingSweep(b *testing.B) {
+	const tails, headsPerTail = 500, 20
+	exp := time.Now().Add(time.Hour)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		c := NewGraphCache[string, string](time.Hour)
+		for t := 0; t < tails; t++ {
+			tail := "tail-" + strconv.Itoa(t)
+			for h := 0; h < headsPerTail; h++ {
+				c.AddEdgeWithExpiration(tail, "head-"+strconv.Itoa(h), 1, exp)
+			}
+		}
+		// Delete every shared head so the sweep reclaims all edges.
+		for h := 0; h < headsPerTail; h++ {
+			c.DeleteVertex("head-" + strconv.Itoa(h))
+		}
+		b.StartTimer()
+		if _, dangling := c.flush(); dangling != tails*headsPerTail {
+			b.Fatalf("dangling = %d, want %d", dangling, tails*headsPerTail)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Implements #839 (issue + sequencing comment): the `flush()` keep predicate now consults a per-flush `map[vertexID]bool` liveness memo, so each distinct endpoint costs one `resolveID` + one `vertices.Has` per tick instead of per edge — previously 4 lock round-trips per edge under both `GraphCache.mu.Lock` AND `edgeCache.mu.Lock`, with tails re-paying per head and shared heads re-paying per tail.

Design decision from the sequencing comment honoured: the memo's scope is exactly one `flush()` call. The budgeted sweep (#744) processes one batch per call, so the memo never crosses ticks — a vertex deleted mid-cycle is re-evaluated fresh, and a recycled ID resolves against current state. `sweepHeadsLocked`/`flushFunc`/`flushTails` signatures are untouched (the change is entirely in gc.go), keeping the #744 cursor contract intact.

Merge-order note: lands on top of #838 per the cluster sequencing.

## Tests / bench

- `TestGraphCache_GCLivenessMemoScope`: (a) full sweep after deleting a shared hub reclaims all fan-in in ONE call — the fresh-memo evaluation; (b) budget=1, delete a shared head between ticks, remaining ticks reclaim both dangling edges — a leaked memo would strand them.
- Existing GC/index/watermark and budgeted-sweep suites unchanged and green (behavior parity: identical zero/dangling accounting, onDelete still fires per removal).
- `BenchmarkGCFlushDanglingSweep` (500 tails × 20 shared heads, all heads deleted): ~1.23ms / 20 allocs per full 10k-edge reclaim sweep.

Quality gate: gofmt clean; go vet + full tests green in core and root.

Closes #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)