### PR TITLE
perf(core): take whole-graph snapshots under RLock

### DIFF
--- a/core/graphcache/snapshot.go
+++ b/core/graphcache/snapshot.go
@@ -51,26 +51,29 @@ type GraphSnapshot[S comparable, T any] struct {
 }
 
 // SnapshotVertices returns a materialised snapshot of every live vertex
-// in the cache. The snapshot is taken under a single write-lock pass; the
-// returned slice is independent of the cache and safe to iterate without
-// further locking. Expired vertices (those past Expiration at snapshot
-// time) are skipped.
+// in the cache. Since #843 the snapshot is taken under a READ lock:
+// expired-but-unflushed entries are FILTERED (Range skips them) rather than
+// physically flushed, so concurrent readers — point reads, scans,
+// traversals — keep making progress while a backup or replication
+// bootstrap materialises the graph. Physical reclamation of expired
+// entries belongs solely to the GC tick. The returned slice is independent
+// of the cache and safe to iterate without further locking.
 //
 // Memory cost is O(N) in the live vertex count — the API is intended for
 // replication bootstrap (#184), which is a bounded, infrequent operation.
 // Hot read paths should keep using GetVertex.
 func (c *GraphCache[S, T]) SnapshotVertices() []SnapshotVertex[S, T] {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.snapshotVerticesLocked()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.snapshotVerticesRLocked()
 }
 
-// snapshotVerticesLocked materialises every live vertex. The caller MUST
-// hold c.mu as a WRITE lock: it calls c.vertices.Flush(), which mutates the
-// cache, so a read lock is insufficient. Factored out so SnapshotGraph can
+// snapshotVerticesRLocked materialises every live vertex. The caller must
+// hold c.mu (read lock suffices since #843 — the pass only filters expired
+// entries, never mutates). vertexHLC is safe to read here because every
+// writer of that map holds c.mu.Lock. Factored out so SnapshotGraph can
 // reuse it under a single lock acquisition.
-func (c *GraphCache[S, T]) snapshotVerticesLocked() []SnapshotVertex[S, T] {
-	c.vertices.Flush()
+func (c *GraphCache[S, T]) snapshotVerticesRLocked() []SnapshotVertex[S, T] {
 	out := make([]SnapshotVertex[S, T], 0, c.vertices.Count())
 	c.vertices.Range(func(key S, value T, expiration time.Time) bool {
 		var ts hlc.Timestamp
@@ -89,8 +92,8 @@ func (c *GraphCache[S, T]) snapshotVerticesLocked() []SnapshotVertex[S, T] {
 }
 
 // SnapshotEdges returns a materialised snapshot of every live edge in the
-// cache, preserving the per-contribution weight decomposition. The
-// snapshot is taken under a single write-lock pass; the returned slice is
+// cache, preserving the per-contribution weight decomposition. Taken under
+// a READ lock since #843 (see SnapshotVertices); the returned slice is
 // independent of the cache. Edges whose every contribution has decayed
 // are skipped (they would otherwise show up as ghost entries with zero
 // total weight).
@@ -98,15 +101,16 @@ func (c *GraphCache[S, T]) snapshotVerticesLocked() []SnapshotVertex[S, T] {
 // Memory cost is O(E + sum of bucket sizes); same scope rationale as
 // SnapshotVertices.
 func (c *GraphCache[S, T]) SnapshotEdges() []SnapshotEdge[S] {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.snapshotEdgesLocked(time.Now())
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.snapshotEdgesRLocked(time.Now())
 }
 
-// snapshotEdgesLocked materialises every live edge as of now. The caller
-// MUST hold c.mu (write lock — symmetric with snapshotVerticesLocked so
-// SnapshotGraph can take the lock once for both sides).
-func (c *GraphCache[S, T]) snapshotEdgesLocked(now time.Time) []SnapshotEdge[S] {
+// snapshotEdgesRLocked materialises every live edge as of now. The caller
+// must hold c.mu (read lock suffices — rangeBuckets takes the edgeCache
+// RLock, snapshotEntry the per-weight mutex, and edgeEndpointsLive the
+// inner vertex-cache lock; nothing here mutates).
+func (c *GraphCache[S, T]) snapshotEdgesRLocked(now time.Time) []SnapshotEdge[S] {
 	out := make([]SnapshotEdge[S], 0, c.edges.count())
 	c.edges.rangeBuckets(func(tail, head S, w *weight) bool {
 		contribs, ts, nonEmpty := w.snapshotEntry(now)
@@ -114,11 +118,10 @@ func (c *GraphCache[S, T]) snapshotEdgesLocked(now time.Time) []SnapshotEdge[S] 
 			return true
 		}
 		// Referential closure (#750): a snapshot must not stream an edge whose
-		// tail or head vertex is not live. SnapshotGraph flushes expired
-		// vertices before this runs; standalone SnapshotEdges relies on
-		// vertices.Has to hide expired-but-not-flushed endpoints without a
-		// prior flush, so neither path leaks a dangling edge to a deleted or
-		// expired vertex ahead of the GC sweep.
+		// tail or head vertex is not live. vertices.Has hides
+		// expired-but-not-flushed endpoints without any prior flush (#843), so
+		// no path leaks a dangling edge to a deleted or expired vertex ahead
+		// of the GC sweep.
 		if !c.edgeEndpointsLive(tail, head) {
 			return true
 		}
@@ -134,11 +137,20 @@ func (c *GraphCache[S, T]) snapshotEdgesLocked(now time.Time) []SnapshotEdge[S] 
 }
 
 // SnapshotGraph returns a materialised whole-graph snapshot — every live
-// vertex and edge — taken under a SINGLE write-lock pass, so the vertex and
-// edge sides reflect the same instant. Calling SnapshotVertices and
-// SnapshotEdges separately locks twice and can observe a vertex/edge set
-// that never co-existed; SnapshotGraph closes that window, which is what a
-// whole-graph backup/restore needs.
+// vertex and edge — taken under a SINGLE continuous lock pass, so the
+// vertex and edge sides reflect the same instant. Calling SnapshotVertices
+// and SnapshotEdges separately locks twice and can observe a vertex/edge
+// set that never co-existed; SnapshotGraph closes that window, which is
+// what a whole-graph backup/restore needs.
+//
+// Since #843 the pass holds c.mu as a READ lock: every mutator that can
+// change the vertex or edge SETS takes c.mu.Lock, so set-level
+// point-in-time consistency is identical to the historical write-lock pass
+// — while concurrent readers keep serving. The one non-excluded writer is
+// the lock-free hot-edge weight append (tryAddExistingEdgeContrib), which
+// never held c.mu under the old write lock either: it cannot change the
+// edge set, and per-bucket atomicity is provided by the weight's own mutex,
+// so the race surface is unchanged.
 //
 // The returned slices are independent of the cache and safe to iterate
 // without further locking. Expired vertices and fully-decayed edges are
@@ -147,10 +159,10 @@ func (c *GraphCache[S, T]) snapshotEdgesLocked(now time.Time) []SnapshotEdge[S] 
 // bounded, infrequent operations (backup, replication bootstrap), not hot
 // read paths.
 func (c *GraphCache[S, T]) SnapshotGraph() GraphSnapshot[S, T] {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return GraphSnapshot[S, T]{
-		Vertices: c.snapshotVerticesLocked(),
-		Edges:    c.snapshotEdgesLocked(time.Now()),
+		Vertices: c.snapshotVerticesRLocked(),
+		Edges:    c.snapshotEdgesRLocked(time.Now()),
 	}
 }

--- a/core/graphcache/snapshot_test.go
+++ b/core/graphcache/snapshot_test.go
@@ -2,6 +2,7 @@ package graphcache
 
 import (
 	"reflect"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -210,5 +211,89 @@ func TestGraphCache_Snapshot_ReferentialClosure(t *testing.T) {
 		if _, ok := edgeByEndpoints(got.Edges)[danglingKey]; ok {
 			t.Errorf("snapshot kept edge to expired-not-flushed endpoint: %v", got.Edges)
 		}
+	})
+}
+
+// TestSnapshotRLockContract pins the #843 lock downgrade: snapshots must be
+// takeable while another goroutine holds the aggregate READ lock (a write
+// lock would deadlock this test), must FILTER expired-but-unflushed entries
+// without physically removing them (reclamation belongs to the GC tick),
+// and must keep set-level vertex/edge co-existence under concurrent writers.
+func TestSnapshotRLockContract(t *testing.T) {
+	t.Run("snapshots proceed under a held read lock", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.PutVertexWithExpiration("a", "va", time.Now().Add(time.Minute))
+
+		c.mu.RLock()
+		defer c.mu.RUnlock()
+		done := make(chan GraphSnapshot[string, string], 1)
+		go func() { done <- c.SnapshotGraph() }()
+		select {
+		case snap := <-done:
+			if len(snap.Vertices) != 1 {
+				t.Fatalf("Vertices = %d, want 1", len(snap.Vertices))
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("SnapshotGraph blocked behind a concurrent RLock — write lock regression")
+		}
+	})
+
+	t.Run("expired entries are filtered, not flushed", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.PutVertexWithExpiration("live", "v", time.Now().Add(time.Minute))
+		c.PutVertexWithExpiration("dead", "v", time.Now().Add(20*time.Millisecond))
+		time.Sleep(30 * time.Millisecond)
+
+		snap := c.SnapshotGraph()
+		if len(snap.Vertices) != 1 || snap.Vertices[0].Key != "live" {
+			t.Fatalf("snapshot vertices = %+v, want only live", snap.Vertices)
+		}
+		// The expired slot must still be physically present afterwards —
+		// the snapshot pass no longer mutates; only the GC tick reclaims.
+		if got := c.vertices.Count(); got != 2 {
+			t.Fatalf("physical vertex count after snapshot = %d, want 2 (no flush side effect)", got)
+		}
+		if _, ok := c.GetVertex("dead"); ok {
+			t.Fatal("expired vertex visible to point reads")
+		}
+	})
+
+	t.Run("vertex-edge co-existence holds under concurrent writers", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		exp := time.Now().Add(time.Minute)
+		stop := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				k := "w" + strconv.Itoa(i%64)
+				c.PutVertexWithExpiration(k, "v", exp)
+				c.AddEdgeWithExpiration(k, "hub-"+strconv.Itoa(i%8), 1, exp)
+				if i%16 == 0 {
+					c.DeleteVertex(k)
+				}
+			}
+		}()
+
+		for i := 0; i < 50; i++ {
+			snap := c.SnapshotGraph()
+			present := make(map[string]bool, len(snap.Vertices))
+			for _, v := range snap.Vertices {
+				present[v.Key] = true
+			}
+			for _, e := range snap.Edges {
+				if !present[e.Tail] || !present[e.Head] {
+					t.Fatalf("snapshot %d: edge %s->%s references a vertex absent from the SAME snapshot", i, e.Tail, e.Head)
+				}
+			}
+		}
+		close(stop)
+		wg.Wait()
 	})
 }


### PR DESCRIPTION
## Summary

Implements #843 (issue + sequencing comment): the three snapshot entry points downgrade from `c.mu.Lock()` to `c.mu.RLock()`, so point reads, scans, and traversals keep serving while a periodic backup (#770) or replication bootstrap materialises the graph.

- The write lock existed solely for the inline `vertices.Flush()`; that side effect is removed. Liveness filtering already existed without mutation: `Range` skips expired entries, `edgeEndpointsLive` hides expired/deleted endpoints (#750). **Behavior change called out per the sequencing comment**: taking a snapshot no longer physically reclaims expired entries — the GC tick owns reclamation. No test relied on the old side effect (verified; the production-gate suites assert visibility, which is unchanged).
- `vertexHLC` reads under RLock are safe (all writers hold `c.mu.Lock`).
- Co-existence guarantee (#689) preserved: both sides are collected under one continuous RLock and every vertex/edge SET mutator takes the write lock; the lock-free hot-edge weight append never held `c.mu` before either, so its per-bucket-atomic race surface is unchanged (documented on `SnapshotGraph`).
- Preallocation picks up #838's O(1) `count()` automatically.

## Tests

`TestSnapshotRLockContract` (with `-race`):
1. deterministic lock-mode pin — `SnapshotGraph` completes while another goroutine holds `c.mu.RLock` (a write-lock regression would deadlock the 5s timeout);
2. expired-but-unflushed vertices are excluded from the snapshot AND still physically present afterwards (no flush side effect), while remaining hidden from point reads;
3. vertex/edge co-existence property under concurrent Put/Add/Delete writers: every edge in a snapshot references vertices present in the SAME snapshot, across 50 snapshots.

Full core + root + server suites green; gofmt/vet clean.

Closes #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)