### PR TITLE
perf(core,server): push cursor seek and page limit into the prefix scans

### DIFF
--- a/core/graphcache/edge_prefix.go
+++ b/core/graphcache/edge_prefix.go
@@ -46,25 +46,53 @@ func (c *GraphCache[S, T]) ScanEdgesByPrefix(
 	tailPrefix, headPrefix string,
 	fn func(tailProjected string, tail S, headProjected string, head S, weight float32, expiration time.Time) bool,
 ) bool {
-	snapshot, enabled, collected := c.collectEdgeScanRows(ctx, tailPrefix, headPrefix)
+	_, ok := c.ScanEdgesByPrefixPage(ctx, tailPrefix, headPrefix, "", "", 0, fn)
+	return ok
+}
+
+// ScanEdgesByPrefixPage is the paged form of ScanEdgesByPrefix (#836): it
+// resumes strictly after the (afterTail, afterHead) pair — seeking the tail
+// radix to afterTail (inclusive, because that tail's remaining heads may
+// still qualify) and, WITHIN the resume tail only, seeking heads strictly
+// past afterHead — and buffers at most limit rows plus one sentinel
+// (limit <= 0 means unbounded, i.e. exactly ScanEdgesByPrefix). A resumed
+// page therefore costs O(depth + page) instead of O(every matching edge),
+// and per-call buffering is bounded by the page size instead of the whole
+// matching set.
+//
+// more reports whether at least one further matching edge exists past the
+// returned page; ok mirrors ScanEdgesByPrefix (false on disabled index, ctx
+// cancellation, or fn early-stop). Locking/consistency semantics are
+// unchanged: rows are collected under one c.mu.RLock, fn runs off-lock.
+func (c *GraphCache[S, T]) ScanEdgesByPrefixPage(
+	ctx context.Context,
+	tailPrefix, headPrefix, afterTail, afterHead string,
+	limit int,
+	fn func(tailProjected string, tail S, headProjected string, head S, weight float32, expiration time.Time) bool,
+) (more, ok bool) {
+	snapshot, enabled, collected := c.collectEdgeScanRows(ctx, tailPrefix, headPrefix, afterTail, afterHead, limit)
 	if !enabled {
-		return false
+		return false, false
 	}
 	// Collection was interrupted by ctx cancellation; report the walk as
 	// incomplete even if some rows were buffered.
 	if !collected {
-		return false
+		return false, false
+	}
+	if limit > 0 && len(snapshot) > limit {
+		more = true
+		snapshot = snapshot[:limit]
 	}
 	for i := range snapshot {
 		if err := ctx.Err(); err != nil {
-			return false
+			return more, false
 		}
 		r := &snapshot[i]
 		if !fn(r.tailProj, r.tail, r.headProj, r.head, r.weight, r.expiration) {
-			return false
+			return more, false
 		}
 	}
-	return true
+	return more, true
 }
 
 // edgeScanRow is one matched (tail, head) edge captured during the locked
@@ -79,15 +107,22 @@ type edgeScanRow[S comparable] struct {
 	expiration time.Time
 }
 
-// collectEdgeScanRows gathers every matching edge into a snapshot under a
-// single c.mu.RLock, reusing the same fast/fallback head walk as the live
-// scan. enabled is false when the prefix index is disabled (the caller maps
-// this to a false return); collected is false when ctx was cancelled mid-walk.
-// The visitor is NOT called here — collection appends rows and always keeps
-// going, so early-stop is honoured later during replay, matching ScanByPrefix.
+// collectEdgeScanRows gathers matching edges into a snapshot under a single
+// c.mu.RLock, reusing the same fast/fallback head walk as the live scan.
+// enabled is false when the prefix index is disabled (the caller maps this
+// to a false return); collected is false when ctx was cancelled mid-walk.
+// The visitor is NOT called here — collection appends rows (stopping one
+// row past limit when limit > 0, so the caller can answer `more`), and
+// fn early-stop is honoured later during replay, matching ScanByPrefix.
+//
+// The (afterTail, afterHead) resume point (#836) seeks the tail walk to
+// afterTail INCLUSIVE — the cursor tail's remaining heads may still qualify
+// — and applies afterHead as a strictly-greater head bound on that one
+// resume tail only; every later tail walks its full matching head set.
 func (c *GraphCache[S, T]) collectEdgeScanRows(
 	ctx context.Context,
-	tailPrefix, headPrefix string,
+	tailPrefix, headPrefix, afterTail, afterHead string,
+	limit int,
 ) (snapshot []edgeScanRow[S], enabled, collected bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -95,6 +130,7 @@ func (c *GraphCache[S, T]) collectEdgeScanRows(
 		return nil, false, false
 	}
 	collected = true
+	full := func() bool { return limit > 0 && len(snapshot) > limit }
 	collect := func(tailProj string, tail S, headProj string, head S, weight float32, expiration time.Time) bool {
 		snapshot = append(snapshot, edgeScanRow[S]{
 			tailProj:   tailProj,
@@ -104,11 +140,21 @@ func (c *GraphCache[S, T]) collectEdgeScanRows(
 			weight:     weight,
 			expiration: expiration,
 		})
-		return true
+		return !full()
 	}
-	c.prefixIndex.walkPrefix(tailPrefix, func(tailProj string) bool {
+	tailWalk := func(visit func(string) bool) {
+		if afterTail == "" && afterHead == "" {
+			c.prefixIndex.walkPrefix(tailPrefix, visit)
+			return
+		}
+		c.prefixIndex.walkPrefixBound(tailPrefix, afterTail, true, visit)
+	}
+	tailWalk(func(tailProj string) bool {
 		if err := ctx.Err(); err != nil {
 			collected = false
+			return false
+		}
+		if full() {
 			return false
 		}
 		tail, ok := c.resolveProjected(tailProj)
@@ -119,12 +165,16 @@ func (c *GraphCache[S, T]) collectEdgeScanRows(
 		if !ok || len(heads) == 0 {
 			return true
 		}
-		if c.headByTail != nil {
-			c.scanTailHeadsFast(tail, tailProj, headPrefix, heads, collect)
-		} else {
-			c.scanTailHeadsFallback(tail, tailProj, headPrefix, heads, collect)
+		headAfter := ""
+		if tailProj == afterTail {
+			headAfter = afterHead
 		}
-		return true
+		if c.headByTail != nil {
+			c.scanTailHeadsFast(tail, tailProj, headPrefix, headAfter, heads, collect)
+		} else {
+			c.scanTailHeadsFallback(tail, tailProj, headPrefix, headAfter, heads, collect)
+		}
+		return !full()
 	})
 	return snapshot, true, collected
 }
@@ -137,22 +187,22 @@ func (c *GraphCache[S, T]) collectEdgeScanRows(
 func (c *GraphCache[S, T]) scanTailHeadsFast(
 	tail S,
 	tailProj string,
-	headPrefix string,
+	headPrefix, headAfter string,
 	heads map[vertexID]*weight,
 	fn func(tailProjected string, tail S, headProjected string, head S, weight float32, expiration time.Time) bool,
 ) bool {
 	tailID, ok := c.edges.dict.lookup(tail)
 	if !ok {
-		return c.scanTailHeadsFallback(tail, tailProj, headPrefix, heads, fn)
+		return c.scanTailHeadsFallback(tail, tailProj, headPrefix, headAfter, heads, fn)
 	}
 	hi, ok := c.headByTail[tailID]
 	if !ok || hi == nil {
 		// No per-tail index yet (or out of sync). Fall back to the safe
 		// path so we never silently under-report.
-		return c.scanTailHeadsFallback(tail, tailProj, headPrefix, heads, fn)
+		return c.scanTailHeadsFallback(tail, tailProj, headPrefix, headAfter, heads, fn)
 	}
 	keepGoing := true
-	hi.walkPrefix(headPrefix, func(headProj string, headID vertexID) bool {
+	hi.walkPrefixBound(headPrefix, headAfter, func(headProj string, headID vertexID) bool {
 		w, ok := heads[headID]
 		if !ok {
 			// Index/edge drift: skip rather than crash. This window is
@@ -190,7 +240,7 @@ func (c *GraphCache[S, T]) scanTailHeadsFast(
 func (c *GraphCache[S, T]) scanTailHeadsFallback(
 	tail S,
 	tailProj string,
-	headPrefix string,
+	headPrefix, headAfter string,
 	heads map[vertexID]*weight,
 	fn func(tailProjected string, tail S, headProjected string, head S, weight float32, expiration time.Time) bool,
 ) bool {
@@ -207,6 +257,11 @@ func (c *GraphCache[S, T]) scanTailHeadsFallback(
 		}
 		proj := c.prefixExtract(head)
 		if headPrefix != "" && !strings.HasPrefix(proj, headPrefix) {
+			continue
+		}
+		// Resume-tail head bound (#836): only heads strictly past the
+		// cursor's last emitted head qualify.
+		if headAfter != "" && proj <= headAfter {
 			continue
 		}
 		entries = append(entries, headEntry{proj: proj, head: head, w: w})

--- a/core/graphcache/edge_prefix_test.go
+++ b/core/graphcache/edge_prefix_test.go
@@ -3,6 +3,8 @@ package graphcache
 import (
 	"context"
 	"fmt"
+	"math/rand"
+	"reflect"
 	"runtime"
 	"sort"
 	"sync"
@@ -479,6 +481,82 @@ func TestGraphCache_ScanEdgesByPrefix_HidesDeadEndpoints(t *testing.T) {
 			}
 			if got := scanEdgesCollect(t, c, "t:", ""); len(got) != 0 {
 				t.Fatalf("scan after deleting tail = %v, want empty", got)
+			}
+		})
+	}
+}
+
+// TestScanEdgesByPrefixPage property-checks the paged edge scan (#836):
+// stitching (afterTail, afterHead, limit) pages must reproduce the unpaged
+// (tail, head) sequence exactly for both the fast per-tail head index and
+// the disabled-index fallback, including pages that split a tail's head set
+// (the inclusive-tail resume).
+func TestScanEdgesByPrefixPage(t *testing.T) {
+	build := func(t *testing.T, disableHeadIndex bool) *GraphCache[string, string] {
+		c := NewGraphCache[string, string](time.Hour)
+		c.EnablePrefixIndex(func(s string) string { return s })
+		exp := time.Now().Add(time.Hour)
+		rng := rand.New(rand.NewSource(167))
+		for i := 0; i < 60; i++ {
+			tail := fmt.Sprintf("t%d", rng.Intn(8))
+			head := fmt.Sprintf("h%02d", rng.Intn(30))
+			c.AddEdgeWithExpiration(tail, head, 1, exp)
+		}
+		if disableHeadIndex {
+			c.disableHeadIndexForTesting()
+		}
+		return c
+	}
+
+	type pair struct{ tail, head string }
+	for _, mode := range []struct {
+		name    string
+		disable bool
+	}{{"fast head index", false}, {"fallback", true}} {
+		t.Run(mode.name, func(t *testing.T) {
+			c := build(t, mode.disable)
+			for _, tp := range []struct{ tailPrefix, headPrefix string }{
+				{"", ""}, {"t1", ""}, {"", "h1"}, {"t", "h0"},
+			} {
+				var want []pair
+				if !c.ScanEdgesByPrefix(context.Background(), tp.tailPrefix, tp.headPrefix,
+					func(_ string, tail string, _ string, head string, _ float32, _ time.Time) bool {
+						want = append(want, pair{tail, head})
+						return true
+					}) {
+					t.Fatal("unpaged edge scan reported early stop")
+				}
+
+				for _, limit := range []int{1, 2, 5, len(want) + 3} {
+					var got []pair
+					afterTail, afterHead := "", ""
+					for page := 0; ; page++ {
+						var rows []pair
+						more, ok := c.ScanEdgesByPrefixPage(context.Background(), tp.tailPrefix, tp.headPrefix, afterTail, afterHead, limit,
+							func(_ string, tail string, _ string, head string, _ float32, _ time.Time) bool {
+								rows = append(rows, pair{tail, head})
+								return true
+							})
+						if !ok {
+							t.Fatalf("%+v limit=%d page=%d not ok", tp, limit, page)
+						}
+						if len(rows) > limit {
+							t.Fatalf("%+v limit=%d page=%d overflowed", tp, limit, page)
+						}
+						got = append(got, rows...)
+						if !more {
+							break
+						}
+						last := rows[len(rows)-1]
+						afterTail, afterHead = last.tail, last.head
+						if page > len(want)+2 {
+							t.Fatalf("%+v limit=%d: pagination did not terminate", tp, limit)
+						}
+					}
+					if !reflect.DeepEqual(got, want) {
+						t.Fatalf("%s %+v limit=%d:\n got  %v\n want %v", mode.name, tp, limit, got, want)
+					}
+				}
 			}
 		})
 	}

--- a/core/graphcache/head_index.go
+++ b/core/graphcache/head_index.go
@@ -72,8 +72,15 @@ func (h *headIndex) delete(headID vertexID, projected string) (empty bool) {
 // Locking: walkPrefix takes the underlying radix's RLock for the whole
 // traversal, so fn must not call insert or delete on this headIndex.
 func (h *headIndex) walkPrefix(prefix string, fn func(projected string, headID vertexID) bool) {
+	h.walkPrefixBound(prefix, "", fn)
+}
+
+// walkPrefixBound is walkPrefix restricted to projected keys strictly
+// greater than after (#836) — the resume seek for a partially-consumed tail
+// in ScanEdgesByPrefixPage. An empty after is exactly walkPrefix.
+func (h *headIndex) walkPrefixBound(prefix, after string, fn func(projected string, headID vertexID) bool) {
 	stopped := false
-	h.radix.walkPrefix(prefix, func(projected string) bool {
+	visit := func(projected string) bool {
 		if stopped {
 			return false
 		}
@@ -84,5 +91,10 @@ func (h *headIndex) walkPrefix(prefix string, fn func(projected string, headID v
 			}
 		}
 		return true
-	})
+	}
+	if after == "" {
+		h.radix.walkPrefix(prefix, visit)
+		return
+	}
+	h.radix.walkPrefixBound(prefix, after, false, visit)
 }

--- a/core/graphcache/prefix.go
+++ b/core/graphcache/prefix.go
@@ -39,6 +39,27 @@ import "context"
 // other S the projection is intentionally lossy and the original key is
 // the one suitable for downstream GraphCache calls.
 func (c *GraphCache[S, T]) ScanByPrefix(ctx context.Context, prefix string, fn func(projected string, key S, value T) bool) bool {
+	_, ok := c.ScanByPrefixPage(ctx, prefix, "", 0, fn)
+	return ok
+}
+
+// ScanByPrefixPage is the paged form of ScanByPrefix (#836): it visits only
+// live vertices whose projected key starts with prefix AND sorts strictly
+// after `after`, and collects at most limit of them (limit <= 0 means
+// unbounded, i.e. exactly ScanByPrefix). The radix walk SEEKS past `after`
+// instead of re-walking and discarding everything before the cursor, and
+// collection stops one row past the page boundary, so a resumed page costs
+// O(depth + page) instead of O(everything matching prefix) in both time and
+// buffered memory.
+//
+// more reports whether at least one further matching key exists beyond the
+// returned page — the signal a paginating caller uses to mint a next cursor
+// without a second walk. ok mirrors ScanByPrefix's return: false when the
+// prefix index is disabled, ctx was cancelled, or fn stopped early. Locking
+// and consistency semantics are unchanged from ScanByPrefix: rows are
+// collected into a point-in-time snapshot under c.mu.RLock and fn runs
+// after the lock is released.
+func (c *GraphCache[S, T]) ScanByPrefixPage(ctx context.Context, prefix, after string, limit int, fn func(projected string, key S, value T) bool) (more, ok bool) {
 	type entry struct {
 		projected string
 		key       S
@@ -55,7 +76,7 @@ func (c *GraphCache[S, T]) ScanByPrefix(ctx context.Context, prefix string, fn f
 		// cannot mutate the cache here \u2014 the visitor runs AFTER the
 		// lock is released to avoid sync.RWMutex reentrancy deadlocks
 		// (see method doc and #202).
-		c.prefixIndex.walkPrefix(prefix, func(projected string) bool {
+		collect := func(projected string) bool {
 			if err := ctx.Err(); err != nil {
 				return false
 			}
@@ -74,27 +95,38 @@ func (c *GraphCache[S, T]) ScanByPrefix(ctx context.Context, prefix string, fn f
 				return true
 			}
 			snapshot = append(snapshot, entry{projected: projected, key: key, value: value})
-			return true
-		})
+			// Collect one row PAST the page so `more` is answered by this
+			// same walk; the sentinel row is never replayed to fn.
+			return limit <= 0 || len(snapshot) <= limit
+		}
+		if after == "" {
+			c.prefixIndex.walkPrefix(prefix, collect)
+		} else {
+			c.prefixIndex.walkPrefixBound(prefix, after, false, collect)
+		}
 		return true
 	}()
 	if !enabled {
-		return false
+		return false, false
 	}
 	// If snapshot collection was interrupted by ctx cancellation, report
 	// the walk as incomplete even when the visitor never ran.
 	if err := ctx.Err(); err != nil {
-		return false
+		return false, false
+	}
+	if limit > 0 && len(snapshot) > limit {
+		more = true
+		snapshot = snapshot[:limit]
 	}
 	for _, e := range snapshot {
 		if err := ctx.Err(); err != nil {
-			return false
+			return more, false
 		}
 		if !fn(e.projected, e.key, e.value) {
-			return false
+			return more, false
 		}
 	}
-	return true
+	return more, true
 }
 
 // CountByPrefix returns the number of LIVE vertices whose projected key starts

--- a/core/graphcache/prefix_test.go
+++ b/core/graphcache/prefix_test.go
@@ -3,6 +3,8 @@ package graphcache
 import (
 	"context"
 	"fmt"
+	"math/rand"
+	"reflect"
 	"sort"
 	"sync"
 	"testing"
@@ -421,5 +423,65 @@ func TestGraphCache_CountByPrefix_EqualsLiveScan(t *testing.T) {
 	// Concrete check: the live u: set is exactly {u:1, u:2}.
 	if got := c.CountByPrefix("u:"); got != 2 {
 		t.Errorf("CountByPrefix(u:) = %d, want 2 (u:1, u:2)", got)
+	}
+}
+
+// TestScanByPrefixPage property-checks the paged scan (#836) against the
+// unpaged walk: for random keyspaces and every page size, stitching pages
+// together via (after, limit) must reproduce the unpaged sequence exactly —
+// no duplicates, no gaps — with `more` true on every page except the last.
+func TestScanByPrefixPage(t *testing.T) {
+	c := NewGraphCache[string, string](time.Hour)
+	c.EnablePrefixIndex(func(s string) string { return s })
+	exp := time.Now().Add(time.Hour)
+	rng := rand.New(rand.NewSource(836))
+	for i := 0; i < 200; i++ {
+		c.PutVertexWithExpiration(fmt.Sprintf("ns%d:key%04d", rng.Intn(3), rng.Intn(500)), "v", exp)
+	}
+	// A sprinkle of expired-but-unflushed entries that every page must skip.
+	for i := 0; i < 20; i++ {
+		c.PutVertexWithExpiration(fmt.Sprintf("ns1:dead%03d", i), "v", time.Now().Add(-time.Minute))
+	}
+
+	for _, prefix := range []string{"", "ns1:", "ns1:key02", "missing:"} {
+		var want []string
+		if !c.ScanByPrefix(context.Background(), prefix, func(_ string, key string, _ string) bool {
+			want = append(want, key)
+			return true
+		}) {
+			t.Fatalf("unpaged scan reported early stop")
+		}
+
+		for _, limit := range []int{1, 3, 7, len(want) + 5} {
+			var got []string
+			after := ""
+			for page := 0; ; page++ {
+				var pageKeys []string
+				more, ok := c.ScanByPrefixPage(context.Background(), prefix, after, limit, func(_ string, key string, _ string) bool {
+					pageKeys = append(pageKeys, key)
+					return true
+				})
+				if !ok {
+					t.Fatalf("prefix=%q limit=%d page=%d not ok", prefix, limit, page)
+				}
+				if len(pageKeys) > limit {
+					t.Fatalf("prefix=%q limit=%d page=%d overflowed: %d rows", prefix, limit, page, len(pageKeys))
+				}
+				got = append(got, pageKeys...)
+				if !more {
+					break
+				}
+				if len(pageKeys) == 0 {
+					t.Fatalf("prefix=%q limit=%d: more=true with empty page", prefix, limit)
+				}
+				after = pageKeys[len(pageKeys)-1]
+				if page > len(want)+2 {
+					t.Fatalf("prefix=%q limit=%d: pagination did not terminate", prefix, limit)
+				}
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("prefix=%q limit=%d:\n got  %v\n want %v", prefix, limit, got, want)
+			}
+		}
 	}
 }

--- a/core/graphcache/radix.go
+++ b/core/graphcache/radix.go
@@ -1,6 +1,9 @@
 package graphcache
 
-import "sync"
+import (
+	"strings"
+	"sync"
+)
 
 // radix is a minimal, concurrency-safe Patricia (compressed) trie over
 // byte strings. It is the secondary index that powers prefix-keyed
@@ -208,7 +211,133 @@ func (r *radix) walkPrefix(prefix string, fn func(key string) bool) {
 	if !ok {
 		return
 	}
-	walkAll(node, accumulated, fn)
+	buf := append(make([]byte, 0, len(accumulated)+16), accumulated...)
+	walkAll(node, &buf, fn)
+}
+
+// walkPrefixBound is the seek-aware sibling of walkPrefix (#836): it visits,
+// in lexicographic order, every stored key that has prefix as a prefix AND
+// sits past bound — strictly greater when inclusive is false (the resume-
+// after-cursor case), or >= bound when inclusive is true (the resume-AT case
+// the edge scan needs for its partially-consumed tail). Children are sorted,
+// so whole subtrees on the wrong side of bound are skipped without being
+// visited — a resumed page costs O(depth + page), not O(everything before
+// the cursor). A bound lexicographically below the prefix subtree degrades
+// to a plain walkPrefix; an empty bound with inclusive=false is exactly
+// walkPrefix.
+func (r *radix) walkPrefixBound(prefix, bound string, inclusive bool, fn func(key string) bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	node, accumulated, ok := r.descend(prefix)
+	if !ok {
+		return
+	}
+	buf := append(make([]byte, 0, len(accumulated)+16), accumulated...)
+	walkBound(node, &buf, bound, inclusive, fn)
+}
+
+// walkBound visits the terminals under n (whose accumulated path is *buf)
+// that satisfy the bound, pruning subtrees that provably cannot. The three
+// path-vs-bound relationships drive it:
+//
+//   - path > bound: every key below starts with path, so all qualify —
+//     degrade to the plain walkAll.
+//   - path is not a prefix of bound (and path <= bound): every key below
+//     shares path's divergence point with bound, so all compare < bound —
+//     skip the whole subtree.
+//   - path is a (possibly equal) prefix of bound: the boundary chain. The
+//     terminal at exactly bound is emitted only when inclusive; children are
+//     binary-searched so subtrees entirely below the bound's next byte are
+//     skipped, the one straddling it recurses, and everything after it walks
+//     freely.
+func walkBound(n *radixNode, buf *[]byte, bound string, inclusive bool, fn func(string) bool) bool {
+	path := string(*buf)
+	if path > bound {
+		return walkAll(n, buf, fn)
+	}
+	if !strings.HasPrefix(bound, path) {
+		// path <= bound and diverges from it: everything below is < bound.
+		return true
+	}
+	rest := bound[len(path):]
+	if rest == "" {
+		// path == bound: emit the exact-match terminal only when inclusive;
+		// every child subtree is strictly greater and walks freely.
+		if n.terminal && inclusive {
+			if !fn(path) {
+				return false
+			}
+		}
+		for _, c := range n.children {
+			*buf = append(*buf, c.label...)
+			ok := walkAll(c, buf, fn)
+			*buf = (*buf)[:len(*buf)-len(c.label)]
+			if !ok {
+				return false
+			}
+		}
+		return true
+	}
+	// path is a proper prefix of bound: the terminal here is < bound (skip).
+	// Find the first child that could reach the bound: children with a first
+	// byte below rest[0] are entirely < bound.
+	idx, exact := n.findChild(rest[0])
+	if exact == nil {
+		// No child straddles the boundary byte; children from idx on are
+		// strictly greater.
+	} else {
+		c := exact
+		m := len(c.label)
+		if len(rest) < m {
+			m = len(rest)
+		}
+		switch {
+		case c.label[:m] < rest[:m]:
+			// Entire child subtree < bound (diverges below) — skip it and
+			// continue with the strictly-greater children after it.
+			idx++
+		case c.label[:m] > rest[:m]:
+			// Entire child subtree > bound (diverges above while sharing the
+			// boundary byte) — walk it freely here; the tail loop below skips
+			// the boundary byte and would otherwise drop it.
+			*buf = append(*buf, c.label...)
+			ok := walkAll(c, buf, fn)
+			*buf = (*buf)[:len(*buf)-len(c.label)]
+			if !ok {
+				return false
+			}
+			idx++
+		default:
+			// Shared prefix for the full overlap: the child either still
+			// tracks the bound (label consumed by rest → recurse) or has
+			// already overrun it (label longer than rest → path+label starts
+			// with bound and is longer, i.e. strictly greater → walk freely;
+			// walkBound's path>bound arm handles that uniformly).
+			*buf = append(*buf, c.label...)
+			ok := walkBound(c, buf, bound, inclusive, fn)
+			*buf = (*buf)[:len(*buf)-len(c.label)]
+			if !ok {
+				return false
+			}
+			idx++
+		}
+	}
+	for _, c := range n.children[idx:] {
+		if c.label[0] < rest[0] {
+			continue
+		}
+		if c.label[0] == rest[0] {
+			// Only reachable when exact was handled above; skip defensively.
+			continue
+		}
+		*buf = append(*buf, c.label...)
+		ok := walkAll(c, buf, fn)
+		*buf = (*buf)[:len(*buf)-len(c.label)]
+		if !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // countPrefix returns the number of stored keys with prefix as a prefix.
@@ -262,17 +391,22 @@ func (r *radix) descend(prefix string) (*radixNode, string, bool) {
 	}
 }
 
-// walkAll visits every terminal in the subtree rooted at n, prepending
-// the path label accumulated to reach n. fn returning false aborts the
-// walk; the boolean propagates up so iteration stops promptly.
-func walkAll(n *radixNode, path string, fn func(string) bool) bool {
+// walkAll visits every terminal in the subtree rooted at n. The accumulated
+// path lives in a single shared byte buffer that is appended on descent and
+// truncated on ascent (#836), so a walk allocates one string per EMITTED
+// terminal instead of one per visited node edge. fn returning false aborts
+// the walk; the boolean propagates up so iteration stops promptly.
+func walkAll(n *radixNode, buf *[]byte, fn func(string) bool) bool {
 	if n.terminal {
-		if !fn(path) {
+		if !fn(string(*buf)) {
 			return false
 		}
 	}
 	for _, c := range n.children {
-		if !walkAll(c, path+c.label, fn) {
+		*buf = append(*buf, c.label...)
+		ok := walkAll(c, buf, fn)
+		*buf = (*buf)[:len(*buf)-len(c.label)]
+		if !ok {
 			return false
 		}
 	}

--- a/core/graphcache/radix_test.go
+++ b/core/graphcache/radix_test.go
@@ -1,7 +1,10 @@
 package graphcache
 
 import (
+	"math/rand"
+	"reflect"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -214,4 +217,75 @@ func equalSlices(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// TestRadixWalkPrefixBound property-checks the seek walker (#836) against a
+// naive filter over every stored key, across randomized key sets and
+// boundary shapes: bounds landing mid-edge-label, exactly on stored keys,
+// below the prefix subtree, past its end, and the empty bound.
+func TestRadixWalkPrefixBound(t *testing.T) {
+	rng := rand.New(rand.NewSource(836))
+	alphabet := []string{"a", "b", "ab", "ba", "session:", "msg:", ":", "0", "1"}
+	randKey := func() string {
+		n := 1 + rng.Intn(4)
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			sb.WriteString(alphabet[rng.Intn(len(alphabet))])
+		}
+		return sb.String()
+	}
+
+	for trial := 0; trial < 200; trial++ {
+		r := newRadix()
+		keys := map[string]bool{}
+		for i := 0; i < 30; i++ {
+			k := randKey()
+			keys[k] = true
+			r.insert(k)
+		}
+		sorted := make([]string, 0, len(keys))
+		for k := range keys {
+			sorted = append(sorted, k)
+		}
+		sort.Strings(sorted)
+
+		prefixes := []string{"", "a", "ab", "session:", "zzz", sorted[rng.Intn(len(sorted))]}
+		bounds := []string{"", "a", sorted[rng.Intn(len(sorted))], sorted[rng.Intn(len(sorted))] + "x", "zzzz", "\x00"}
+		for _, prefix := range prefixes {
+			for _, bound := range bounds {
+				for _, inclusive := range []bool{false, true} {
+					var want []string
+					for _, k := range sorted {
+						if !strings.HasPrefix(k, prefix) {
+							continue
+						}
+						if k > bound || (inclusive && k == bound) {
+							want = append(want, k)
+						}
+					}
+					var got []string
+					r.walkPrefixBound(prefix, bound, inclusive, func(k string) bool {
+						got = append(got, k)
+						return true
+					})
+					if !reflect.DeepEqual(got, want) {
+						t.Fatalf("trial %d prefix=%q bound=%q incl=%v:\n got  %v\n want %v\n keys %v",
+							trial, prefix, bound, inclusive, got, want, sorted)
+					}
+				}
+			}
+		}
+
+		// Early stop must truncate, not skip.
+		if len(sorted) > 2 {
+			var got []string
+			r.walkPrefixBound("", sorted[0], false, func(k string) bool {
+				got = append(got, k)
+				return len(got) < 2
+			})
+			if len(got) != 2 || got[0] != sorted[1] {
+				t.Fatalf("early stop got %v, want first two after %q of %v", got, sorted[0], sorted)
+			}
+		}
+	}
 }

--- a/server/service/backend.go
+++ b/server/service/backend.go
@@ -125,13 +125,15 @@ type Backend interface {
 		keep func(string) bool,
 	) (*coregraph.Graph[string, *pb.Vertex], error)
 
-	// prefix scan / count / delete. ScanByPrefix invokes fn for each live
-	// vertex whose key starts with prefix, in lexicographic order; fn
-	// returns false to stop early. CountByPrefix is an index-side count
-	// (may include not-yet-flushed expired entries; bounded by the GC
-	// tick). DeleteByPrefix removes matching vertices up to limit (limit
-	// <= 0 means unlimited) and returns how many were deleted.
-	ScanByPrefix(ctx context.Context, prefix string, fn func(projected string, key string, value *pb.Vertex) bool) bool
+	// prefix scan / count / delete. ScanByPrefixPage (#836) invokes fn for
+	// each live vertex whose key starts with prefix AND sorts strictly
+	// after `after`, in lexicographic order, up to limit rows (limit <= 0
+	// = unbounded); fn returns false to stop early. more reports whether
+	// further matches exist past the page — the handler's next-cursor
+	// signal. CountByPrefix counts only live matching vertices.
+	// DeleteByPrefix removes matching vertices up to limit (limit <= 0
+	// means unlimited) and returns how many were deleted.
+	ScanByPrefixPage(ctx context.Context, prefix, after string, limit int, fn func(projected string, key string, value *pb.Vertex) bool) (more, ok bool)
 	CountByPrefix(prefix string) int
 	DeleteByPrefix(ctx context.Context, prefix string, limit int) int
 
@@ -144,13 +146,15 @@ type Backend interface {
 	// from its own SearchConfig.Enabled flag, not this return value (#624).
 	SearchVertices(query string, limit int, keyPrefix string) []search.Result[string]
 
-	// edge-side prefix scan. ScanEdgesByPrefix invokes fn for each live
-	// edge whose tail starts with tailPrefix AND whose head starts with
-	// headPrefix, in ascending (tail, head) order. Either prefix may be
-	// empty to disable the corresponding filter. fn returns false to
-	// stop early. Plural-only on the wire (no CountEdges /
+	// edge-side prefix scan. ScanEdgesByPrefixPage (#836) invokes fn for
+	// each live edge whose tail starts with tailPrefix AND whose head
+	// starts with headPrefix, in ascending (tail, head) order, resuming
+	// strictly after the (afterTail, afterHead) pair and collecting at
+	// most limit rows (limit <= 0 = unbounded). Either prefix may be
+	// empty to disable the corresponding filter. more mirrors
+	// ScanByPrefixPage. Plural-only on the wire (no CountEdges /
 	// DeleteEdgesByPrefix in this phase).
-	ScanEdgesByPrefix(ctx context.Context, tailPrefix, headPrefix string, fn func(tailProjected string, tail string, headProjected string, head string, weight float32, expiration time.Time) bool) bool
+	ScanEdgesByPrefixPage(ctx context.Context, tailPrefix, headPrefix, afterTail, afterHead string, limit int, fn func(tailProjected string, tail string, headProjected string, head string, weight float32, expiration time.Time) bool) (more, ok bool)
 
 	// background GC loop driven by LanternServer.
 	Watch(ctx context.Context, interval time.Duration)

--- a/server/service/fake_backend_test.go
+++ b/server/service/fake_backend_test.go
@@ -244,12 +244,16 @@ func (f *fakeBackend) Watch(ctx context.Context, interval time.Duration) {
 // GraphCache via the bufconn harness; the fake just walks its in-memory
 // map in lexicographic order so unit tests can still hit the wrappers
 // without standing up the cache.
-func (f *fakeBackend) ScanByPrefix(_ context.Context, prefix string, fn func(string, string, *pb.Vertex) bool) bool {
+func (f *fakeBackend) ScanByPrefixPage(_ context.Context, prefix, after string, limit int, fn func(string, string, *pb.Vertex) bool) (bool, bool) {
 	keys := make([]string, 0, len(f.vertices))
 	for k := range f.vertices {
-		if prefix == "" || (len(k) >= len(prefix) && k[:len(prefix)] == prefix) {
-			keys = append(keys, k)
+		if prefix != "" && !(len(k) >= len(prefix) && k[:len(prefix)] == prefix) {
+			continue
 		}
+		if after != "" && k <= after {
+			continue
+		}
+		keys = append(keys, k)
 	}
 	// Sort to match the radix index's lexicographic walk order.
 	for i := 1; i < len(keys); i++ {
@@ -257,12 +261,17 @@ func (f *fakeBackend) ScanByPrefix(_ context.Context, prefix string, fn func(str
 			keys[j-1], keys[j] = keys[j], keys[j-1]
 		}
 	}
+	more := false
+	if limit > 0 && len(keys) > limit {
+		more = true
+		keys = keys[:limit]
+	}
 	for _, k := range keys {
 		if !fn(k, k, f.vertices[k]) {
-			return false
+			return more, false
 		}
 	}
-	return true
+	return more, true
 }
 
 func (f *fakeBackend) CountByPrefix(prefix string) int {
@@ -304,40 +313,43 @@ func (f *fakeBackend) DeleteByPrefix(_ context.Context, prefix string, limit int
 	return len(victims)
 }
 
-func (f *fakeBackend) ScanEdgesByPrefix(_ context.Context, tailPrefix, headPrefix string,
+func (f *fakeBackend) ScanEdgesByPrefixPage(_ context.Context, tailPrefix, headPrefix, afterTail, afterHead string, limit int,
 	fn func(string, string, string, string, float32, time.Time) bool,
-) bool {
-	tails := make([]string, 0, len(f.edges))
-	for t := range f.edges {
-		if tailPrefix == "" || (len(t) >= len(tailPrefix) && t[:len(tailPrefix)] == tailPrefix) {
-			tails = append(tails, t)
+) (bool, bool) {
+	type row struct{ t, h string }
+	var rows []row
+	for t, hs := range f.edges {
+		if tailPrefix != "" && !(len(t) >= len(tailPrefix) && t[:len(tailPrefix)] == tailPrefix) {
+			continue
+		}
+		for h := range hs {
+			if headPrefix != "" && !(len(h) >= len(headPrefix) && h[:len(headPrefix)] == headPrefix) {
+				continue
+			}
+			if afterTail != "" || afterHead != "" {
+				if t < afterTail || (t == afterTail && h <= afterHead) {
+					continue
+				}
+			}
+			rows = append(rows, row{t, h})
 		}
 	}
-	for i := 1; i < len(tails); i++ {
-		for j := i; j > 0 && tails[j-1] > tails[j]; j-- {
-			tails[j-1], tails[j] = tails[j], tails[j-1]
+	for i := 1; i < len(rows); i++ {
+		for j := i; j > 0 && (rows[j-1].t > rows[j].t || (rows[j-1].t == rows[j].t && rows[j-1].h > rows[j].h)); j-- {
+			rows[j-1], rows[j] = rows[j], rows[j-1]
 		}
 	}
-	for _, t := range tails {
-		row := f.edges[t]
-		heads := make([]string, 0, len(row))
-		for h := range row {
-			if headPrefix == "" || (len(h) >= len(headPrefix) && h[:len(headPrefix)] == headPrefix) {
-				heads = append(heads, h)
-			}
-		}
-		for i := 1; i < len(heads); i++ {
-			for j := i; j > 0 && heads[j-1] > heads[j]; j-- {
-				heads[j-1], heads[j] = heads[j], heads[j-1]
-			}
-		}
-		for _, h := range heads {
-			if !fn(t, t, h, h, row[h], time.Time{}) {
-				return false
-			}
+	more := false
+	if limit > 0 && len(rows) > limit {
+		more = true
+		rows = rows[:limit]
+	}
+	for _, r := range rows {
+		if !fn(r.t, r.t, r.h, r.h, f.edges[r.t][r.h], time.Time{}) {
+			return more, false
 		}
 	}
-	return true
+	return more, true
 }
 
 // Compile-time check that fakeBackend really satisfies Backend.

--- a/server/service/prefix.go
+++ b/server/service/prefix.go
@@ -37,26 +37,12 @@ func (s *LanternService) ScanVertices(ctx context.Context, in *pb.ScanVerticesRe
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	// Pre-allocate one extra slot so the callback can land the (limit+1)-th
-	// hit, see it overshoot, and stop without a reallocation. We trim back
-	// to limit before returning.
+	// The cursor seek and page limit are pushed into the index walk (#836):
+	// the backend resumes strictly after cursor.LastKey and buffers at most
+	// one page, so a resumed page costs O(page), not O(matching set).
 	vertices := make([]*pb.Vertex, 0, limit)
 	var lastKey string
-	hitLimit := false
-	s.cache.ScanByPrefix(ctx, in.GetPrefix(), func(_ string, key string, v *pb.Vertex) bool {
-		// Cursor skip: drop everything <= cursor.LastKey. ScanByPrefix
-		// walks in lexicographic order, so once we cross the cursor we
-		// will never see a <= key again — no need for a sorted-set
-		// state machine. This is O(cursor-page-size) overhead per
-		// resumed scan; if it ever shows up in profiles, push the seek
-		// into the radix walk.
-		if cursor.LastKey != "" && key <= cursor.LastKey {
-			return true
-		}
-		if uint32(len(vertices)) >= limit {
-			hitLimit = true
-			return false
-		}
+	more, _ := s.cache.ScanByPrefixPage(ctx, in.GetPrefix(), cursor.LastKey, int(limit), func(_ string, key string, v *pb.Vertex) bool {
 		// Normalise nil-valued vertices the same way GetVertex does so
 		// callers see a uniform shape.
 		if v == nil {
@@ -69,7 +55,7 @@ func (s *LanternService) ScanVertices(ctx context.Context, in *pb.ScanVerticesRe
 	})
 
 	resp := &pb.ScanVerticesResponse{Vertices: vertices}
-	if hitLimit && lastKey != "" {
+	if more && lastKey != "" {
 		resp.NextCursor = encodeCursor(scanCursor{LastKey: lastKey})
 	}
 	s.metrics.OnScan("ScanVertices", len(vertices), time.Since(start))
@@ -111,22 +97,14 @@ func (s *LanternService) ScanVertexKeys(ctx context.Context, in *pb.ScanVertexKe
 
 	keys := make([]string, 0, limit)
 	var lastKey string
-	hitLimit := false
-	s.cache.ScanByPrefix(ctx, in.GetPrefix(), func(_ string, key string, _ *pb.Vertex) bool {
-		if cursor.LastKey != "" && key <= cursor.LastKey {
-			return true
-		}
-		if uint32(len(keys)) >= limit {
-			hitLimit = true
-			return false
-		}
+	more, _ := s.cache.ScanByPrefixPage(ctx, in.GetPrefix(), cursor.LastKey, int(limit), func(_ string, key string, _ *pb.Vertex) bool {
 		keys = append(keys, key)
 		lastKey = key
 		return true
 	})
 
 	resp := &pb.ScanVertexKeysResponse{Keys: keys}
-	if hitLimit && lastKey != "" {
+	if more && lastKey != "" {
 		resp.NextCursor = encodeKeysCursor(scanKeysCursor{LastKey: lastKey})
 	}
 	s.metrics.OnScan("ScanVertexKeys", len(keys), time.Since(start))
@@ -226,25 +204,13 @@ func (s *LanternService) ScanEdges(ctx context.Context, in *pb.ScanEdgesRequest)
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
+	// Cursor resume and page limit are pushed into the index walk (#836):
+	// the backend seeks the tail radix to the cursor tail and, within it,
+	// past the cursor head, buffering at most one page.
 	edges := make([]*pb.Edge, 0, limit)
 	var lastTail, lastHead string
-	hitLimit := false
-	s.cache.ScanEdgesByPrefix(ctx, in.GetTailPrefix(), in.GetHeadPrefix(),
+	more, _ := s.cache.ScanEdgesByPrefixPage(ctx, in.GetTailPrefix(), in.GetHeadPrefix(), cursor.LastTail, cursor.LastHead, int(limit),
 		func(_ string, tail string, _ string, head string, weight float32, exp time.Time) bool {
-			// Cursor skip: drop everything whose (tail, head) is <=
-			// cursor's last emitted pair. The walk is in ascending
-			// (tail, head) order so once we cross the cursor we never
-			// revisit a smaller pair.
-			if cursor.LastTail != "" || cursor.LastHead != "" {
-				if tail < cursor.LastTail ||
-					(tail == cursor.LastTail && head <= cursor.LastHead) {
-					return true
-				}
-			}
-			if uint32(len(edges)) >= limit {
-				hitLimit = true
-				return false
-			}
 			edge := &pb.Edge{Tail: tail, Head: head, Weight: weight}
 			if !exp.IsZero() {
 				edge.Expiration = timestamppb.New(exp)
@@ -255,7 +221,7 @@ func (s *LanternService) ScanEdges(ctx context.Context, in *pb.ScanEdgesRequest)
 		})
 
 	resp := &pb.ScanEdgesResponse{Edges: edges}
-	if hitLimit && (lastTail != "" || lastHead != "") {
+	if more && (lastTail != "" || lastHead != "") {
 		resp.NextCursor = encodeEdgesCursor(scanEdgesCursor{LastTail: lastTail, LastHead: lastHead})
 	}
 	s.metrics.OnScan("ScanEdges", len(edges), time.Since(start))


### PR DESCRIPTION
## Summary

Implements #836 (issue + sequencing comment). Three layers:

1. **radix**: new `walkPrefixBound(prefix, bound, inclusive, fn)` — descends to the prefix subtree then prunes on the bound: subtrees whose accumulated path is `> bound` walk freely, subtrees that diverge below it are skipped whole, and only the boundary chain recurses (children binary-searched at each level). `inclusive` serves the edge scan's resume-AT-tail case. `walkAll`/`walkPrefix` also switch to a single shared append/truncate byte buffer, so a walk allocates one string per emitted terminal instead of one per visited node edge.
2. **GraphCache**: `ScanByPrefixPage(ctx, prefix, after, limit, fn) (more, ok)` and `ScanEdgesByPrefixPage(ctx, tailPrefix, headPrefix, afterTail, afterHead, limit, fn) (more, ok)` — seek past the cursor, collect at most limit+1 rows (the sentinel answers `more` in the same walk and is never replayed), preserve the #202/#742 collect-then-replay locking contract. Edge resume: tail seek is INCLUSIVE with the strictly-greater head bound applied only to the resume tail (both the per-tail head-radix fast path and the fallback honour it). The unpaged methods stay as wrappers (`after="", limit=0`), so the 7 core test files using them needed no changes.
3. **server**: Backend narrows to the paged methods; the three handlers drop their `key <= cursor` skip loops and pass cursor + clamped limit down; `more` replaces the hit-limit probe for next-cursor minting. Cursor wire format unchanged.

## Tests

- `TestRadixWalkPrefixBound`: 200 randomized trials × 6 prefixes × 6 bounds × 2 modes (~14k combos) against a naive filter — covers mid-edge-label bounds, exact stored keys, below-subtree and past-end bounds, plus early-stop truncation. (This property test caught a real walker bug during development: an upper sibling sharing the boundary byte was being dropped.)
- `TestScanByPrefixPage` / `TestScanEdgesByPrefixPage`: page-stitching equivalence properties — for random keyspaces and page sizes {1,2,3,5,7,N+}, stitched pages == the unpaged sequence exactly (no dups, no gaps), `more` true on every page but the last; edge variant runs under BOTH the fast head index and the disabled-index fallback, including pages splitting one tail's head set.
- Existing scan/cursor handler tests pass unchanged against the upgraded fake (which now honours after/limit).

Full gate: gofmt/vet clean; root, core(-race), server, mcp, sdks/go all green.

Closes #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)