### PR TITLE
perf(core): bounded top-k selection with filter pushdown for SearchVertices

### DIFF
--- a/core/graphcache/search.go
+++ b/core/graphcache/search.go
@@ -93,34 +93,30 @@ func (c *GraphCache[S, T]) SearchVertices(query string, limit int, keyPrefix str
 		return nil
 	}
 	// Phase 2 — query analysis, BM25 ranking, and liveness/prefix filtering all
-	// run WITHOUT GraphCache.mu. The inverted index has its own RWMutex (Search
-	// takes RLock) and the vertex cache's Has is guarded by the inner cache
-	// lock, so writers and GC that need GraphCache.mu.Lock() are no longer
-	// blocked by a broad or expensive search (#741). Liveness is still checked
-	// at filter time via vertices.Has, so an expired-but-not-yet-flushed vertex
-	// is skipped exactly as before; the read may now race a concurrent
-	// Put/Delete on a given key and observe either side of it, which is the same
-	// racy point-read contract GetVertex provides (#740).
-	ranked := index.Search(query)
-	if len(ranked) == 0 {
-		return nil
-	}
-	out := make([]search.Result[S], 0, min(limit, len(ranked)))
-	for _, r := range ranked {
-		if !c.vertices.Has(r.ID) {
+	// run WITHOUT GraphCache.mu. Since #841 the liveness and prefix filters are
+	// pushed INTO the index's bounded top-k selection as the accept callback,
+	// so a broad query (the bigram analyzer makes a two-character query match
+	// most of the corpus) no longer materialises and fully sorts every match
+	// just to keep `limit` of them: SearchTopK selects in O(M log k) with O(k)
+	// result memory, and rejected documents never consume the page budget.
+	//
+	// Lock order: accept runs under the index's RLock and probes only the
+	// vertex cache's inner mutex (which never acquires the index lock), an
+	// order already established by index writes running under GraphCache.mu —
+	// documented on SearchTopK. Liveness is checked via vertices.Has exactly as
+	// before, so an expired-but-not-yet-flushed vertex is skipped; the read may
+	// race a concurrent Put/Delete on a given key and observe either side of
+	// it, which is the same racy point-read contract GetVertex provides (#740).
+	accept := func(id S) bool {
+		if !c.vertices.Has(id) {
 			// Expired between the index write and this read but the async
 			// Flush has not run yet; consistent with point-read semantics,
 			// treat as absent.
-			continue
+			return false
 		}
-		if keyPrefix != "" && !keyHasPrefix(prefixExtract, r.ID, keyPrefix) {
-			continue
-		}
-		out = append(out, r)
-		if len(out) == limit {
-			break
-		}
+		return keyPrefix == "" || keyHasPrefix(prefixExtract, id, keyPrefix)
 	}
+	out := index.SearchTopK(query, limit, accept)
 	if len(out) == 0 {
 		return nil
 	}

--- a/core/search/inverted_index.go
+++ b/core/search/inverted_index.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"container/heap"
 	"sort"
 	"sync"
 )
@@ -300,6 +301,128 @@ func (idx *InvertedIndex[S, D]) Search(query string) []Result[S] {
 		return results[i].Score > results[j].Score
 	})
 	return results
+}
+
+// SearchTopK is the bounded-selection sibling of Search (#841): it computes
+// the same OR-union BM25 scores but returns only the k highest-scoring
+// documents that satisfy accept, without materialising or fully sorting the
+// complete match set. With the bigram analyzer a short query can match most
+// of the corpus, so Search's O(M log M) sort over all M matches dominates
+// broad queries; SearchTopK selects with a size-k bounded heap in
+// O(M log k) time and O(k) result memory instead.
+//
+// accept gates a document BEFORE it can occupy one of the k slots, so
+// filtered-out documents (dead vertices, out-of-scope keys) never consume
+// the page budget — a full page of accepted hits is returned whenever one
+// exists. accept may be nil (accept everything). To keep accept calls off
+// the O(M) score loop it is consulted lazily, only when a candidate's score
+// qualifies it for the heap.
+//
+// LOCK ORDER: accept runs while idx.mu is held for reading. The established
+// order is GraphCache.mu → idx.mu → (vertex-cache inner mutex): index writes
+// already run under GraphCache.mu, and accept's typical body (a vertex-cache
+// liveness probe) takes only the inner cache mutex, which never acquires
+// idx.mu — so no cycle is possible. accept must not call back into this
+// index's write methods.
+//
+// Results are ordered by descending score; ties at the k-th boundary keep an
+// unspecified subset, matching Search's unspecified tie order. k <= 0, an
+// unanalyzable query, or zero accepted matches return nil.
+func (idx *InvertedIndex[S, D]) SearchTopK(query string, k int, accept func(id S) bool) []Result[S] {
+	if k <= 0 {
+		return nil
+	}
+	tokens := idx.analyzer.Analyze(query)
+	if len(tokens) == 0 {
+		return nil
+	}
+	queryTerms := make(map[string]struct{}, len(tokens))
+	for _, token := range tokens {
+		queryTerms[token.Term] = struct{}{}
+	}
+
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	n := len(idx.docs)
+	if n == 0 {
+		return nil
+	}
+	avgLen := float64(idx.totalLen) / float64(n)
+
+	// Phase 1 — identical union scoring to Search: every matching document's
+	// full score must exist before selection, because a document's rank is
+	// the SUM over query terms.
+	scores := make(map[uint32]float64)
+	for term := range queryTerms {
+		tid, ok := idx.dict.lookup(term)
+		if !ok {
+			continue
+		}
+		pl, ok := idx.postings[tid]
+		if !ok {
+			continue
+		}
+		df := pl.cardinality()
+		for it := pl.docs.Iterator(); it.HasNext(); {
+			ord := it.Next()
+			scores[ord] += idx.scorer.Score(TermStats{
+				TF:     pl.tf(ord),
+				DF:     df,
+				N:      n,
+				DocLen: idx.docs[ord].length,
+				AvgLen: avgLen,
+			})
+		}
+	}
+	if len(scores) == 0 {
+		return nil
+	}
+
+	// Phase 2 — bounded selection. A min-heap of size k holds the current
+	// best accepted documents; a candidate consults accept only once its
+	// score beats the boundary, so rejection work never scales with the
+	// match set beyond the heap-qualified candidates.
+	h := topKHeap[S]{entries: make([]Result[S], 0, k)}
+	for ord, score := range scores {
+		if len(h.entries) == k && score <= h.entries[0].Score {
+			continue
+		}
+		id := idx.docs[ord].id
+		if accept != nil && !accept(id) {
+			continue
+		}
+		if len(h.entries) < k {
+			heap.Push(&h, Result[S]{ID: id, Score: score})
+			continue
+		}
+		h.entries[0] = Result[S]{ID: id, Score: score}
+		heap.Fix(&h, 0)
+	}
+	if len(h.entries) == 0 {
+		return nil
+	}
+	out := h.entries
+	sort.Slice(out, func(i, j int) bool { return out[i].Score > out[j].Score })
+	return out
+}
+
+// topKHeap is the size-k min-heap behind SearchTopK: the root is the weakest
+// retained hit, evicted whenever a stronger accepted candidate arrives.
+type topKHeap[S comparable] struct {
+	entries []Result[S]
+}
+
+func (h topKHeap[S]) Len() int           { return len(h.entries) }
+func (h topKHeap[S]) Less(i, j int) bool { return h.entries[i].Score < h.entries[j].Score }
+func (h topKHeap[S]) Swap(i, j int)      { h.entries[i], h.entries[j] = h.entries[j], h.entries[i] }
+func (h *topKHeap[S]) Push(x any)        { h.entries = append(h.entries, x.(Result[S])) }
+func (h *topKHeap[S]) Pop() any {
+	old := h.entries
+	n := len(old)
+	x := old[n-1]
+	h.entries = old[:n-1]
+	return x
 }
 
 // Stats returns the current number of distinct terms in the posting list and

--- a/core/search/inverted_index_test.go
+++ b/core/search/inverted_index_test.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"runtime"
 	"sort"
@@ -407,4 +408,121 @@ func BenchmarkInvertedIndexFootprint(b *testing.B) {
 	b.ReportMetric(delta/(1024*1024), "MiB/index")
 	b.ReportMetric(delta/float64(docs), "B/doc")
 	b.ReportMetric(float64(after.HeapObjects-base.HeapObjects), "objects")
+}
+
+// TestSearchTopK property-checks the bounded selection (#841) against the
+// reference pipeline "full Search → filter by accept → truncate to k":
+// result length, membership, per-id scores, and the descending score
+// multiset must all agree (tie order at the k-th boundary is free).
+func TestSearchTopK(t *testing.T) {
+	idx := NewInvertedIndex[string, Text](NewAnalyzer(
+		[]Normalizer{LowercaseNormalizer{}},
+		NGramTokenizer{N: 2},
+		nil,
+	), nil)
+	rng := rand.New(rand.NewSource(841))
+	// Search and SearchTopK both accumulate BM25 contributions while iterating
+	// the distinct-term set (a Go map), so the floating-point addition order —
+	// and therefore the last ULP of a multi-term score — can differ between
+	// any two calls. Compare scores with a relative tolerance, not bitwise.
+	closeEnough := func(a, b float64) bool {
+		diff := math.Abs(a - b)
+		return diff <= 1e-9*math.Max(math.Abs(a), math.Abs(b))
+	}
+	words := []string{"alpha", "alps", "altitude", "beta", "bethel", "gamma", "gambit", "delta"}
+	docs := make(map[string]string, 120)
+	for i := 0; i < 120; i++ {
+		id := fmt.Sprintf("doc-%03d", i)
+		body := words[rng.Intn(len(words))] + " " + words[rng.Intn(len(words))] + " " + words[rng.Intn(len(words))]
+		docs[id] = body
+		idx.Index(id, Text(body))
+	}
+
+	accepts := map[string]func(string) bool{
+		"all":        nil,
+		"evens only": func(id string) bool { return (id[len(id)-1]-'0')%2 == 0 },
+		"none":       func(string) bool { return false },
+	}
+	for _, query := range []string{"al", "alpha", "ga", "zz"} {
+		full := idx.Search(query)
+		for name, accept := range accepts {
+			for _, k := range []int{1, 3, 10, 500} {
+				var want []Result[string]
+				for _, r := range full {
+					if accept == nil || accept(r.ID) {
+						want = append(want, r)
+					}
+				}
+				sort.SliceStable(want, func(i, j int) bool { return want[i].Score > want[j].Score })
+				if len(want) > k {
+					want = want[:k]
+				}
+
+				got := idx.SearchTopK(query, k, accept)
+				if len(got) != len(want) {
+					t.Fatalf("q=%q accept=%s k=%d: len=%d, want %d", query, name, k, len(got), len(want))
+				}
+				fullScore := make(map[string]float64, len(full))
+				for _, r := range full {
+					fullScore[r.ID] = r.Score
+				}
+				for i, r := range got {
+					if i > 0 && got[i-1].Score < r.Score {
+						t.Fatalf("q=%q accept=%s k=%d: not descending at %d: %v", query, name, k, i, got)
+					}
+					if s, ok := fullScore[r.ID]; !ok || !closeEnough(s, r.Score) {
+						t.Fatalf("q=%q accept=%s k=%d: id %s score %v disagrees with full search (%v, %v)", query, name, k, r.ID, r.Score, s, ok)
+					}
+					if accept != nil && !accept(r.ID) {
+						t.Fatalf("q=%q accept=%s k=%d: rejected id %s returned", query, name, k, r.ID)
+					}
+				}
+				for i := range got {
+					if !closeEnough(got[i].Score, want[i].Score) {
+						t.Fatalf("q=%q accept=%s k=%d: score multiset diverges at %d: got %v want %v", query, name, k, i, got, want)
+					}
+				}
+			}
+		}
+	}
+
+	t.Run("k<=0 and empty query return nil", func(t *testing.T) {
+		if got := idx.SearchTopK("al", 0, nil); got != nil {
+			t.Fatalf("k=0 got %v", got)
+		}
+		if got := idx.SearchTopK("", 5, nil); got != nil {
+			t.Fatalf("empty query got %v", got)
+		}
+	})
+}
+
+// BenchmarkSearchTopKBroadQuery pits the bounded selection against the full
+// sort on the workload #841 targets: a two-character query over a large
+// corpus (the bigram analyzer makes it match nearly everything), keeping
+// only a small page.
+func BenchmarkSearchTopKBroadQuery(b *testing.B) {
+	idx := NewInvertedIndex[string, Text](NewAnalyzer(
+		[]Normalizer{LowercaseNormalizer{}},
+		NGramTokenizer{N: 2},
+		nil,
+	), nil)
+	for i := 0; i < 20000; i++ {
+		idx.Index(fmt.Sprintf("doc-%05d", i), Text(fmt.Sprintf("alpha beta gamma delta %05d", i)))
+	}
+	b.Run("SearchTopK-10", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if got := idx.SearchTopK("alpha", 10, nil); len(got) != 10 {
+				b.Fatalf("len=%d", len(got))
+			}
+		}
+	})
+	b.Run("FullSearch", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if got := idx.Search("alpha"); len(got) < 10 {
+				b.Fatalf("len=%d", len(got))
+			}
+		}
+	})
 }


### PR DESCRIPTION
Closes #841

## Problem

`SearchVertices` ranked and fully sorted **every** BM25 match — a two-character query against the bigram analyzer matches most of the corpus — just to keep `limit` results, and liveness/prefix filtering ran after ranking, so rejected documents still consumed page-budget slots and the whole match set was materialised.

## Change

- **`InvertedIndex.SearchTopK(query, k, accept)`** (core/search/inverted_index.go): identical phase-1 union scoring, then selection through a bounded min-heap — O(M log k) time, O(k) result memory instead of O(M log M)/O(M). The `accept` callback (liveness + prefix pushdown) is consulted **lazily**, only when a candidate would actually enter the heap, so filtered documents cost neither an accept probe per match nor a result slot.
- **`GraphCache.SearchVertices`** (core/graphcache/search.go): drops the Search→filter→truncate loop and pushes `vertices.Has` + key-prefix filtering into `accept`.

## Lock-order analysis (the #841 risk item)

`accept` runs under the index's `RLock` and probes only the vertex cache's inner mutex. The reverse order never occurs: eviction hooks (`onVerticesEvicted` → `searchIndex.DeleteMany`) fire strictly **after** the inner cache mutex is released (two-phase collect-then-fire in `Delete`/`DeleteMany`/`Flush`), and index writes under `GraphCache.mu` never hold the inner cache lock. Documented on `SearchTopK`; the existing concurrent search-vs-writers test now exercises the new path and passes `-race -count=2`.

## Tests

- `TestSearchTopK`: property test pinning `SearchTopK(q,k,accept)` against reference `Search(q)`→filter→truncate as a descending score multiset across 4 queries × 3 accept modes × 4 k values (tolerance-based comparison — distinct-term map iteration makes FP accumulation order non-deterministic even between two `Search` calls), plus k≤0 / empty-query / reject-all edges.
- `TestGraphCache_SearchVertices_Concurrent` (existing) is the lock-order regression guard, now routed through the new path.

## Benchmark (20k docs, broad query, k=10)

| | ns/op | B/op |
|---|---|---|
| SearchTopK-10 | 4,410,741 | 1,183,727 |
| Full Search | 4,734,823 | 1,666,557 |

Phase-1 scoring dominates at this corpus size; the win is the bounded result memory (−29% B/op) and the eliminated per-match filter probes, which grow with corpus size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)