### PR TITLE
perf(server,core): route ApplyMutation batches through the batch HLC cache methods

### DIFF
--- a/core/graphcache/batch.go
+++ b/core/graphcache/batch.go
@@ -225,9 +225,16 @@ func (c *GraphCache[S, T]) DeleteEdges(keys []EdgeKey[S]) int {
 // PutVerticesWithExpiration (the entry is removed, not stored) so the #698
 // high-water optimisation is preserved; the watermark is still recorded so a
 // later strictly-older write cannot resurrect the key.
-func (c *GraphCache[S, T]) PutVerticesWithExpirationHLC(items []VertexItem[S, T], ts hlc.Timestamp) {
+//
+// Returns the number of items REJECTED by those guards — tombstone fence or
+// LWW watermark — exactly the set the singular PutVertexWithExpirationHLC
+// reports as applied=false. Born-expired items are applied (dead on arrival,
+// watermark recorded) and are NOT counted, and nothing else contributes, so
+// the replication apply path (#840) can fire its clamp-reject metric once per
+// rejected item with the same meaning the per-item loop had.
+func (c *GraphCache[S, T]) PutVerticesWithExpirationHLC(items []VertexItem[S, T], ts hlc.Timestamp) (rejected int) {
 	if len(items) == 0 {
-		return
+		return 0
 	}
 	now := time.Now()
 	prepared := c.prepareSearchDocs(items, now)
@@ -236,12 +243,14 @@ func (c *GraphCache[S, T]) PutVerticesWithExpirationHLC(items []VertexItem[S, T]
 	for i := range items {
 		it := items[i]
 		if !c.vertexWriteAllowedLocked(it.Key, ts) {
+			rejected++
 			continue
 		}
 		c.putLocalVertexLockedAt(it.Key, it.Value, it.Expiration, now, preparedAt(prepared, i))
 		c.recordVertexHLCLocked(it.Key, ts)
 		c.clearVertexTombstoneLocked(it.Key)
 	}
+	return rejected
 }
 
 // PutEdgesWithExpirationHLC is the LWW-aware, single-lock batch sibling of
@@ -252,20 +261,31 @@ func (c *GraphCache[S, T]) PutVerticesWithExpirationHLC(items []VertexItem[S, T]
 // the same edge concurrently. Endpoint vertices are auto-created regardless of
 // the per-edge LWW outcome (matching PutEdgeWithExpirationHLC) so traversal
 // always sees the endpoints.
-func (c *GraphCache[S, T]) PutEdgesWithExpirationHLC(items []EdgeItem[S], ts hlc.Timestamp) {
+//
+// Returns the number of items REJECTED by the tombstone fence or by the
+// per-edge LWW watermark inside the storage layer — exactly the set the
+// singular PutEdgeWithExpirationHLC reports as applied=false — so the
+// replication apply path (#840) can fire its clamp-reject metric once per
+// rejected item with unchanged meaning. ContribID dedup never contributes
+// here (that is AddEdgesWithExpirationContribHLC's separate count).
+func (c *GraphCache[S, T]) PutEdgesWithExpirationHLC(items []EdgeItem[S], ts hlc.Timestamp) (rejected int) {
 	if len(items) == 0 {
-		return
+		return 0
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for _, it := range items {
 		if !c.edgeWriteAllowedLocked(it.Tail, it.Head, ts) {
+			rejected++
 			continue
 		}
 		if c.putEdgeHLCLocked(it.Tail, it.Head, it.Weight, it.Expiration, ts) {
 			c.clearEdgeTombstoneLocked(it.Tail, it.Head)
+		} else {
+			rejected++
 		}
 	}
+	return rejected
 }
 
 // AddEdgesWithExpirationContribHLC is the tombstone-aware, single-lock batch

--- a/core/graphcache/batch_external_test.go
+++ b/core/graphcache/batch_external_test.go
@@ -412,6 +412,27 @@ func TestPutVerticesWithExpirationHLC_BatchLWW(t *testing.T) {
 			t.Errorf("older batch put resurrected a tombstoned key")
 		}
 	})
+
+	// The rejected return (#840) counts exactly the tombstone/LWW-skipped
+	// items — never applied items, and never born-expired items (those are
+	// applied dead-on-arrival with their watermark recorded).
+	t.Run("RejectedCount", func(t *testing.T) {
+		c := graphcache.NewGraphCache[string, string](time.Minute)
+		if got := c.PutVerticesWithExpirationHLC([]graphcache.VertexItem[string, string]{
+			{Key: "a", Value: "v", Expiration: exp},
+			{Key: "b", Value: "v", Expiration: exp},
+		}, newer); got != 0 {
+			t.Fatalf("first batch rejected = %d, want 0", got)
+		}
+		if got := c.PutVerticesWithExpirationHLC([]graphcache.VertexItem[string, string]{
+			{Key: "a", Value: "stale", Expiration: exp},                       // rejected: LWW
+			{Key: "b", Value: "stale", Expiration: exp},                       // rejected: LWW
+			{Key: "c", Value: "fresh", Expiration: exp},                       // applied
+			{Key: "x", Value: "dead", Expiration: time.Now().Add(-time.Hour)}, // applied dead-on-arrival, NOT rejected
+		}, older); got != 2 {
+			t.Fatalf("mixed batch rejected = %d, want 2 (LWW losers only)", got)
+		}
+	})
 }
 
 // PutEdgesWithExpirationHLC is the edge LWW sibling: a strictly-older batch is
@@ -452,6 +473,32 @@ func TestPutEdgesWithExpirationHLC_BatchLWW(t *testing.T) {
 		}, older)
 		if _, ok := c.GetWeight("a", "b"); ok {
 			t.Errorf("older batch put resurrected a tombstoned edge")
+		}
+	})
+
+	// The rejected return (#840) counts tombstone-fenced and per-edge
+	// LWW-lost items — the same set the singular PutEdgeWithExpirationHLC
+	// reports as applied=false — and nothing else.
+	t.Run("RejectedCount", func(t *testing.T) {
+		c := graphcache.NewGraphCache[string, string](time.Minute)
+		if got := c.PutEdgesWithExpirationHLC([]graphcache.EdgeItem[string]{
+			{Tail: "a", Head: "b", Weight: 1.0, Expiration: exp},
+		}, newer); got != 0 {
+			t.Fatalf("first batch rejected = %d, want 0", got)
+		}
+		if got := c.PutEdgesWithExpirationHLC([]graphcache.EdgeItem[string]{
+			{Tail: "a", Head: "b", Weight: 9.9, Expiration: exp}, // rejected: LWW watermark
+			{Tail: "x", Head: "y", Weight: 1.0, Expiration: exp}, // applied: brand-new edge
+		}, older); got != 1 {
+			t.Fatalf("mixed batch rejected = %d, want 1 (LWW loser only)", got)
+		}
+		if n := c.DeleteEdgesHLC([]graphcache.EdgeKey[string]{{Tail: "x", Head: "y"}}, newer, exp); n != 1 {
+			t.Fatalf("delete: got %d, want 1", n)
+		}
+		if got := c.PutEdgesWithExpirationHLC([]graphcache.EdgeItem[string]{
+			{Tail: "x", Head: "y", Weight: 2.0, Expiration: exp}, // rejected: tombstone fence
+		}, older); got != 1 {
+			t.Fatalf("tombstone-fenced batch rejected = %d, want 1", got)
 		}
 	})
 }

--- a/core/graphcache/bench_test.go
+++ b/core/graphcache/bench_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/search"
 )
 
@@ -727,4 +728,78 @@ func BenchmarkPutVerticesIndexed(b *testing.B) {
 			}
 		})
 	})
+}
+
+// BenchmarkApplyPutVerticesHLC contrasts the two ways the replication apply
+// path can replay a 1k-vertex MutationOp_PutVertices with the search index
+// enabled (#840): the pre-#840 loop of singular PutVertexWithExpirationHLC
+// calls (N lock cycles, tokenization under GraphCache.mu) against one
+// PutVerticesWithExpirationHLC batch (one lock cycle, analysis off-lock).
+func BenchmarkApplyPutVerticesHLC(b *testing.B) {
+	const n = 1000
+	value := "the quick brown fox jumps over the lazy dog and keeps running through the forest"
+	exp := time.Now().Add(time.Hour)
+	items := make([]VertexItem[string, string], n)
+	for i := range items {
+		items[i] = VertexItem[string, string]{Key: makeKey("bench://apply", i, 40), Value: value, Expiration: exp}
+	}
+	newCache := func() *GraphCache[string, string] {
+		c := NewGraphCache[string, string](time.Hour)
+		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+		return c
+	}
+	ts := hlc.Timestamp{WallNs: 1}
+
+	b.Run("SingularLoop", func(b *testing.B) {
+		c := newCache()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for j := range items {
+				c.PutVertexWithExpirationHLC(items[j].Key, items[j].Value, items[j].Expiration, ts)
+			}
+		}
+	})
+	b.Run("Batch", func(b *testing.B) {
+		c := newCache()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			c.PutVerticesWithExpirationHLC(items, ts)
+		}
+	})
+
+	// The contended pair measures what the receiving replica's local READS
+	// experience while catch-up replay hammers the apply path — the singular
+	// loop tokenizes all N documents under GraphCache.mu, the batch analyzes
+	// off-lock and holds the write lock only for the map/index writes.
+	for _, mode := range []string{"SingularLoop", "Batch"} {
+		mode := mode
+		b.Run("GetVertexUnder/"+mode, func(b *testing.B) {
+			c := newCache()
+			c.PutVerticesWithExpirationHLC(items, ts)
+			var stop atomic.Bool
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				for !stop.Load() {
+					if mode == "Batch" {
+						c.PutVerticesWithExpirationHLC(items, ts)
+					} else {
+						for j := range items {
+							c.PutVertexWithExpirationHLC(items[j].Key, items[j].Value, items[j].Expiration, ts)
+						}
+					}
+				}
+			}()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = c.GetVertex(items[i%n].Key)
+			}
+			b.StopTimer()
+			stop.Store(true)
+			<-done
+		})
+	}
 }

--- a/server/service/apply.go
+++ b/server/service/apply.go
@@ -116,12 +116,28 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 		opName = "PutVertex"
 
 	case *pb.MutationOp_PutVertices:
-		for _, v := range op.PutVertices.GetVertices() {
+		// Route the whole batch through the single-lock batch method (#840):
+		// one GraphCache.mu cycle instead of N, and search documents are
+		// analyzed OUTSIDE the lock (#739). Born-expired items follow the
+		// batch dead-on-arrival semantics (#698): nothing is stored, but the
+		// HLC watermark is still recorded so a later strictly-older write
+		// cannot resurrect the key — the singular path physically stored such
+		// entries until GC, which only inflated replica high-water.
+		vs := op.PutVertices.GetVertices()
+		items := make([]graphcache.VertexItem[string, *pb.Vertex], 0, len(vs))
+		for _, v := range vs {
 			if v == nil {
 				continue
 			}
-			applied := s.cache.PutVertexWithExpirationHLC(v.GetKey(), v, v.GetExpiration().AsTime(), ts)
-			if !applied && useTomb && s.onTombstoneClampReject != nil {
+			items = append(items, graphcache.VertexItem[string, *pb.Vertex]{
+				Key:        v.GetKey(),
+				Value:      v,
+				Expiration: v.GetExpiration().AsTime(),
+			})
+		}
+		rejected := s.cache.PutVerticesWithExpirationHLC(items, ts)
+		if useTomb && s.onTombstoneClampReject != nil {
+			for i := 0; i < rejected; i++ {
 				s.onTombstoneClampReject()
 			}
 		}
@@ -178,8 +194,13 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 		opName = "AddEdge"
 
 	case *pb.MutationOp_AddEdges:
+		// Batch-routed (#840): one lock cycle for the whole mutation. The
+		// ContribID synthesis fallback keys on the WIRE index (including nil
+		// slots) so a mutation with a nil edge in the middle produces the
+		// same per-edge dedup ids the singular loop did.
 		edges := op.AddEdges.GetEdges()
 		contribIDs := op.AddEdges.GetContribIds()
+		items := make([]graphcache.EdgeItem[string], 0, len(edges))
 		for i, e := range edges {
 			if e == nil {
 				continue
@@ -194,16 +215,26 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 			if cID.IsZero() {
 				cID = contribIDFor(origin, seq, uint16(i))
 			}
-			if useTomb {
-				applied := s.cache.AddEdgeWithExpirationContribHLC(e.GetTail(), e.GetHead(), e.GetWeight(),
-					e.GetExpiration().AsTime(), cID, ts)
-				if !applied && s.onTombstoneClampReject != nil {
+			items = append(items, graphcache.EdgeItem[string]{
+				Tail:       e.GetTail(),
+				Head:       e.GetHead(),
+				Weight:     e.GetWeight(),
+				Expiration: e.GetExpiration().AsTime(),
+				ContribID:  cID,
+			})
+		}
+		if useTomb {
+			// The batch return counts every item that added no weight —
+			// tombstone-dropped or ContribID-deduped — which is exactly the
+			// per-item applied=false set the singular loop fed the hook.
+			noWeight := s.cache.AddEdgesWithExpirationContribHLC(items, ts)
+			if s.onTombstoneClampReject != nil {
+				for i := 0; i < noWeight; i++ {
 					s.onTombstoneClampReject()
 				}
-			} else {
-				s.cache.AddEdgeWithExpirationContrib(e.GetTail(), e.GetHead(), e.GetWeight(),
-					e.GetExpiration().AsTime(), cID)
 			}
+		} else {
+			s.cache.AddEdgesWithExpirationContrib(items)
 		}
 		opName = "AddEdges"
 
@@ -220,13 +251,24 @@ func (s *LanternService) ApplyMutation(ctx context.Context, m *pb.Mutation) erro
 		opName = "PutEdge"
 
 	case *pb.MutationOp_PutEdges:
-		for _, e := range op.PutEdges.GetEdges() {
+		// Batch-routed (#840): one lock cycle; rejected counts tombstone-
+		// fenced and LWW-lost items, matching the singular applied=false set.
+		in := op.PutEdges.GetEdges()
+		items := make([]graphcache.EdgeItem[string], 0, len(in))
+		for _, e := range in {
 			if e == nil {
 				continue
 			}
-			applied := s.cache.PutEdgeWithExpirationHLC(e.GetTail(), e.GetHead(), e.GetWeight(),
-				e.GetExpiration().AsTime(), ts)
-			if !applied && useTomb && s.onTombstoneClampReject != nil {
+			items = append(items, graphcache.EdgeItem[string]{
+				Tail:       e.GetTail(),
+				Head:       e.GetHead(),
+				Weight:     e.GetWeight(),
+				Expiration: e.GetExpiration().AsTime(),
+			})
+		}
+		rejected := s.cache.PutEdgesWithExpirationHLC(items, ts)
+		if useTomb && s.onTombstoneClampReject != nil {
+			for i := 0; i < rejected; i++ {
 				s.onTombstoneClampReject()
 			}
 		}

--- a/server/service/apply_test.go
+++ b/server/service/apply_test.go
@@ -953,6 +953,69 @@ func mustMarshal(v *pb.Vertex) []byte {
 // Each scenario applies a "winner" mutation at a high HLC first, then
 // a strictly-older "loser" mutation for the same key/edge and asserts
 // the hook count.
+// TestApplyMutation_BatchBornExpiredAlignment pins the deliberate behavior
+// change of routing MutationOp_PutVertices through the batch HLC method
+// (#840): a born-expired item is now dead on arrival — NOTHING is stored
+// physically (the singular path stored it until GC, inflating replica
+// high-water) — but its HLC watermark IS recorded, so a later strictly-older
+// write for the same key still loses LWW and cannot resurrect it. Live items
+// in the same mixed batch apply normally, and nil entries are skipped.
+func TestApplyMutation_BatchBornExpiredAlignment(t *testing.T) {
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+	svc := NewLanternService(cache)
+	ctx := context.Background()
+	origin := bytes16("origin-A")
+
+	apply := func(t *testing.T, seq uint64, op *pb.MutationOp) {
+		t.Helper()
+		m := &pb.Mutation{Seq: seq, Hlc: newHLC(int64(seq), origin), Origin: origin[:], Op: op}
+		if err := svc.ApplyMutation(ctx, m); err != nil {
+			t.Fatalf("ApplyMutation seq=%d: %v", seq, err)
+		}
+	}
+
+	liveExp := timestamppb.New(time.Now().Add(time.Hour))
+	deadExp := timestamppb.New(time.Now().Add(-time.Hour))
+	apply(t, 5, &pb.MutationOp{Op: &pb.MutationOp_PutVertices{
+		PutVertices: &pb.PutVerticesRequest{Vertices: []*pb.Vertex{
+			{Key: "dead", Value: &pb.Vertex_Nil{Nil: true}, Expiration: deadExp},
+			nil, // wire nils are skipped, not applied
+			{Key: "live", Value: &pb.Vertex_Nil{Nil: true}, Expiration: liveExp},
+		}},
+	}})
+
+	// The born-expired key is not stored: invisible to reads AND absent from
+	// the physical count (no GC tick has run — the singular path would still
+	// hold it here).
+	if _, ok := cache.GetVertex("dead"); ok {
+		t.Fatalf("born-expired vertex is readable")
+	}
+	if got := cache.VertexCount(); got != 1 {
+		t.Fatalf("VertexCount = %d, want 1 (live only; born-expired must not be stored)", got)
+	}
+
+	// The watermark WAS recorded: a strictly-older replay for the same key is
+	// rejected, so it cannot resurrect the dead key with stale data.
+	apply(t, 1, &pb.MutationOp{Op: &pb.MutationOp_PutVertices{
+		PutVertices: &pb.PutVerticesRequest{Vertices: []*pb.Vertex{
+			{Key: "dead", Value: &pb.Vertex_Nil{Nil: true}, Expiration: liveExp},
+		}},
+	}})
+	if _, ok := cache.GetVertex("dead"); ok {
+		t.Fatalf("strictly-older put resurrected the born-expired key — watermark was not recorded")
+	}
+
+	// A strictly-newer put for the same key applies normally.
+	apply(t, 9, &pb.MutationOp{Op: &pb.MutationOp_PutVertices{
+		PutVertices: &pb.PutVerticesRequest{Vertices: []*pb.Vertex{
+			{Key: "dead", Value: &pb.Vertex_Nil{Nil: true}, Expiration: liveExp},
+		}},
+	}})
+	if _, ok := cache.GetVertex("dead"); !ok {
+		t.Fatalf("strictly-newer put after the born-expired watermark did not apply")
+	}
+}
+
 func TestApplyMutation_TombstoneClampRejectHook(t *testing.T) {
 	exp := timestamppb.New(time.Now().Add(time.Hour))
 	origin := bytes16("origin-A")

--- a/server/service/backend.go
+++ b/server/service/backend.go
@@ -65,8 +65,15 @@ type Backend interface {
 	// is off (clock nil) so non-replicated workloads pay nothing.
 	// AddEdgesWithExpirationContribHLC returns the count of items that added
 	// no weight (tombstone-dropped or ContribID-deduped).
-	PutVerticesWithExpirationHLC(items []graphcache.VertexItem[string, *pb.Vertex], ts hlc.Timestamp)
-	PutEdgesWithExpirationHLC(items []graphcache.EdgeItem[string], ts hlc.Timestamp)
+	//
+	// Since #840 these batch methods also serve the replication apply path
+	// (ApplyMutation), which previously looped the singular HLC methods. The
+	// Put* variants return the number of items rejected by the tombstone
+	// fence or LWW watermark — the same set the singular methods report as
+	// applied=false — so the apply path fires its clamp-reject metric once
+	// per rejected item with unchanged meaning.
+	PutVerticesWithExpirationHLC(items []graphcache.VertexItem[string, *pb.Vertex], ts hlc.Timestamp) int
+	PutEdgesWithExpirationHLC(items []graphcache.EdgeItem[string], ts hlc.Timestamp) int
 	AddEdgesWithExpirationContribHLC(items []graphcache.EdgeItem[string], ts hlc.Timestamp) int
 
 	// tombstone-aware Delete*/Add* entry points used by ApplyMutation

--- a/server/service/fake_backend_test.go
+++ b/server/service/fake_backend_test.go
@@ -387,12 +387,14 @@ func (f *fakeBackend) PutEdgeWithExpirationHLC(tail, head string, w float32, _ t
 // whether or not the service takes the replicated branch; real LWW / tombstone
 // convergence is covered by the core and integration tests against the real
 // backend.
-func (f *fakeBackend) PutVerticesWithExpirationHLC(items []graphcache.VertexItem[string, *pb.Vertex], _ hlc.Timestamp) {
+func (f *fakeBackend) PutVerticesWithExpirationHLC(items []graphcache.VertexItem[string, *pb.Vertex], _ hlc.Timestamp) int {
 	f.PutVerticesWithExpiration(items)
+	return 0
 }
 
-func (f *fakeBackend) PutEdgesWithExpirationHLC(items []graphcache.EdgeItem[string], _ hlc.Timestamp) {
+func (f *fakeBackend) PutEdgesWithExpirationHLC(items []graphcache.EdgeItem[string], _ hlc.Timestamp) int {
 	f.PutEdgesWithExpiration(items)
+	return 0
 }
 
 func (f *fakeBackend) AddEdgesWithExpirationContribHLC(items []graphcache.EdgeItem[string], _ hlc.Timestamp) int {


### PR DESCRIPTION
Closes #840

## Problem

`ApplyMutation` replayed `MutationOp_PutVertices` / `AddEdges` / `PutEdges` item-by-item through the singular HLC methods: N `GraphCache.mu` lock cycles per mutation, with search-document tokenization running **inside** the lock (`putVertexLocked` → analyzer with `prepared == nil`) — exactly the cost #739 removed from the local write path. During replication catch-up (pump replay after reconnect, post-snapshot resume) this stalls local reads on the receiving replica.

## Change

- The three batch arms build the item slice once and call `PutVerticesWithExpirationHLC` / `AddEdgesWithExpirationContribHLC` / `PutEdgesWithExpirationHLC` — one lock cycle, batch-prepared search docs off-lock. ContribID synthesis fallback keys on the **wire index** (including nil slots) so per-edge dedup ids are byte-identical to the singular loop. Singular arms unchanged.
- **Return-count contract**: the Put* batch methods now return `rejected` = tombstone-fenced / LWW-lost items — exactly the set the singular methods reported as `applied=false` — so `onTombstoneClampReject` fires once per rejected item with unchanged meaning. ContribID dedup never enters this count (AddEdges' existing `deduped` return already matched its singular hook semantics: tombstone-dropped **or** replay-deduped).

## Deliberate behavior change (#698 alignment)

A replica applying a **born-expired** `PutVertices` item now stores nothing physically (the singular path stored it until GC, inflating replica high-water) while the HLC watermark **is** still recorded, so a later strictly-older write cannot resurrect the key. Pinned by `TestApplyMutation_BatchBornExpiredAlignment` (VertexCount stays at live-only, older replay rejected, newer replay applies). LWW outcomes and watermarks are unchanged — **docs/replication.md needs no amendment** (verified: the RFC specifies LWW resolution and watermark rules, not physical storage of dead entries).

## Tests

- `TestApplyMutation_BatchBornExpiredAlignment` (new): the behavior-change pin, including wire-nil skipping in a mixed batch.
- `RejectedCount` sub-tests in the existing batch LWW tests: rejected counts LWW losers + tombstone-fenced only; applied and born-expired items never counted.
- Existing `TestApplyMutation_TombstoneClampRejectHook` / `_Convergence` / `_Idempotence` / `_WireContribIDDedupsAcrossSeq` pass unchanged on the new routing — the hook-parity and convergence guards.

## Benchmarks (1k-vertex mutation, search index enabled)

| | result |
|---|---|
| replay throughput: singular loop | 10.94 ms/mutation |
| replay throughput: batch | 10.54 ms/mutation |
| local `GetVertex` under continuous replay: singular | 168.7 ns/op |
| local `GetVertex` under continuous replay: batch | 131.2 ns/op (**−22%**) |

Single-threaded throughput is nearly a wash (same total work); the win is reader latency on the replica, which is what the issue targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)