### PR TITLE
feat(server): aggregate capacity soft caps with RESOURCE_EXHAUSTED fail-fast

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -35,10 +35,12 @@ value is treated as unset for the non-string kinds. The MCP server's
 | `LANTERN_LOG_LEVEL` | level | `info` | Structured-log level: debug, info, warn, or error. |
 | `LANTERN_MAX_BATCH_SIZE` | int | `10000` | Maximum items accepted per batch RPC (Put/Get/Add/Delete plural forms). |
 | `LANTERN_MAX_CONCURRENT_STREAMS` | uint32 | `1024` | HTTP/2 max concurrent streams per connection (0 = unlimited). |
+| `LANTERN_MAX_EDGES` | int | `0` | Soft cap on live edges (0 = unlimited). Local write RPCs that would exceed it fail with RESOURCE_EXHAUSTED; replication apply and backup restore bypass the cap. |
 | `LANTERN_MAX_KEY_LEN` | int | `1024` | Maximum accepted vertex-key length in bytes. |
 | `LANTERN_MAX_RECV_MSG_BYTES` | int | `16777216` | Maximum accepted request message size in bytes. |
 | `LANTERN_MAX_REPLICATION_LAG` | int | `10000` | Readiness gate: maximum tolerated replication lag (entries) before /readyz reports not ready. |
 | `LANTERN_MAX_SEND_MSG_BYTES` | int | `16777216` | Maximum produced response message size in bytes. |
+| `LANTERN_MAX_VERTICES` | int | `0` | Soft cap on live vertices (0 = unlimited). Local write RPCs that would exceed it fail with RESOURCE_EXHAUSTED; replication apply and backup restore bypass the cap. Conservative pre-check: edge writes count both endpoints as potentially new. |
 | `LANTERN_METRICS_ADDR` | string | `:9090` | host:port for the /metrics + /healthz + /readyz HTTP listener (empty disables it). |
 | `LANTERN_MUTATION_LOG_CAPACITY` | int | `100000` | Replication mutation-log ring capacity in entries; size for peak_cluster_rps x retention_seconds. |
 | `LANTERN_MUTATION_LOG_SUBSCRIBER_BUFFER` | int | `512` | Per-subscriber outbound channel depth; a subscriber that falls further behind is gapped. |

--- a/docs/ha-runbook.md
+++ b/docs/ha-runbook.md
@@ -351,6 +351,31 @@ Two truisms:
   accumulate during one snapshot pause. Default `10000` (entries)
   works for write rates up to a few thousand mut/s.
 
+**Saturation guard (`LANTERN_MAX_VERTICES` / `LANTERN_MAX_EDGES`, #848):**
+
+For an in-memory store the kernel OOM kill is the worst failure mode — it
+takes down *all* data on the pod (and forces a re-bootstrap from peers),
+instead of degrading the one misbehaving writer. Cap the entry counts so a
+write burst faster than TTL decay fails fast instead:
+
+- Set both caps from the sizing estimate above: divide the memory budget
+  you allocated to graph data by your measured per-entry heap cost and
+  leave slack for the soft-cap overshoot (concurrent in-flight batches).
+- The caps are enforced at the **local write-RPC boundary only**. At
+  capacity, `PutVertices` / `AddEdges` / `PutEdges` return
+  `RESOURCE_EXHAUSTED` naming the knob; reads, deletes, replication apply
+  and backup restore always proceed (rejecting writes peers already
+  committed would break convergence). In HA every node applies its own
+  cap at its own boundary, which bounds the cluster.
+- There is **no eviction policy**: a rejected writer must wait for TTL
+  decay, GC, or deletes to free capacity, then retry. This is decay-first
+  by design.
+- Alert on fill ratio: `lantern_vertices / lantern_capacity_limit{kind="vertex"} > 0.8`
+  (same for edges). `lantern_validation_rejected_total{reason="capacity"}`
+  counts rejected writes.
+- Keep `GOMEMLIMIT` (set below `resources.limits.memory`) as the second
+  line of defense — the caps bound entry counts, not bytes.
+
 ---
 
 ## 6. Partition behaviour & split-brain

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -126,6 +126,7 @@ func newLanternService(
 	clock *hlc.Clock,
 	dm *domainmetrics.DomainMetrics,
 ) *service.LanternService {
+	dm.SetCapacityLimits(cc.MaxVertices, cc.MaxEdges)
 	svc := service.NewLanternService(backend).
 		WithScanLimits(service.ScanLimits{
 			ScanDefaultLimit:           sc.ScanDefaultLimit,
@@ -142,6 +143,10 @@ func newLanternService(
 		WithAppliedHook(dm.OnReplicationApplied).
 		WithReplicationApplyHook(dm.OnReplicationApply).
 		WithValidationRejectHook(dm.OnValidationRejected).
+		WithCapacityLimits(service.CapacityLimits{
+			MaxVertices: cc.MaxVertices,
+			MaxEdges:    cc.MaxEdges,
+		}).
 		WithTombstoneClampRejectHook(dm.OnTombstoneClampRejected).
 		WithTombstoneTTL(rc.TombstoneTTL).
 		WithTraversalTimeout(trc.Timeout).

--- a/server/internal/envdoc/envdoc.go
+++ b/server/internal/envdoc/envdoc.go
@@ -49,6 +49,8 @@ var descriptions = map[string]string{
 
 	"LANTERN_MAX_KEY_LEN":         "Maximum accepted vertex-key length in bytes.",
 	"LANTERN_MAX_BATCH_SIZE":      "Maximum items accepted per batch RPC (Put/Get/Add/Delete plural forms).",
+	"LANTERN_MAX_VERTICES":        "Soft cap on live vertices (0 = unlimited). Local write RPCs that would exceed it fail with RESOURCE_EXHAUSTED; replication apply and backup restore bypass the cap. Conservative pre-check: edge writes count both endpoints as potentially new.",
+	"LANTERN_MAX_EDGES":           "Soft cap on live edges (0 = unlimited). Local write RPCs that would exceed it fail with RESOURCE_EXHAUSTED; replication apply and backup restore bypass the cap.",
 	"LANTERN_ILLUMINATE_MAX_STEP": "Upper bound on the Illuminate BFS step parameter.",
 	"LANTERN_ILLUMINATE_MAX_K":    "Upper bound on the Illuminate k parameter.",
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -85,6 +85,7 @@ type DomainMetrics struct {
 	// (tombstone clamp). Pre-warmed so dashboards render the full reason
 	// set as 0 from process start.
 	validationRejected     *prometheus.CounterVec
+	capacityLimit          *prometheus.GaugeVec
 	rateLimitRejected      prometheus.Counter
 	tombstoneClampRejected prometheus.Counter
 
@@ -237,6 +238,7 @@ var (
 		"k_too_large",
 		"bad_ttl",
 		"bad_cursor",
+		"capacity",
 	}
 )
 
@@ -448,6 +450,10 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 			Name: "lantern_validation_rejected_total",
 			Help: "Total requests rejected by server-side input validation, partitioned by reason (empty_key, key_too_long, empty_batch, batch_too_large, nil_item, bad_weight, step_too_large, k_too_large, bad_ttl, bad_cursor). Counted before the handler runs (ValidationInterceptor) or during validateExpiration / cursor decode in the service layer.",
 		}, []string{"reason"}),
+		capacityLimit: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "lantern_capacity_limit",
+			Help: "Configured soft capacity cap per kind (vertex, edge) from LANTERN_MAX_VERTICES / LANTERN_MAX_EDGES (#848). 0 = unlimited. Divide lantern_vertices / lantern_edges by this for a fill ratio; alert above 0.8.",
+		}, []string{"kind"}),
 		rateLimitRejected: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "lantern_rate_limit_rejected_total",
 			Help: "Total RPCs rejected by the process-wide token-bucket rate limiter (codes.ResourceExhausted). Registered at 0 even when LANTERN_RATE_LIMIT_RPS=0 so dashboards can compare deployments uniformly.",
@@ -478,7 +484,7 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 		m.snapshotVertices, m.snapshotEdges, m.snapshotDuration,
 		m.mutationLogFillRatio, m.mutationLogEvicted, m.originStatesCount,
 		m.validationRejected, m.rateLimitRejected, m.tombstoneClampRejected,
-		m.mutationLogSubscriberDropped)
+		m.mutationLogSubscriberDropped, m.capacityLimit)
 
 	// Pre-create label rows so empty counters scrape as 0.
 	for _, r := range []string{"gapped", "send_failed"} {
@@ -745,6 +751,15 @@ func (m *DomainMetrics) OnReplicationApply(op string) {
 func (m *DomainMetrics) OnValidationRejected(reason string) {
 	r := sanitizeLabel(reason, validationRejectReasons, "unknown")
 	m.validationRejected.WithLabelValues(r).Inc()
+}
+
+// SetCapacityLimits publishes the configured aggregate soft caps (#848) as
+// lantern_capacity_limit{kind}. Called once at wiring time; 0 means the cap
+// is disabled. Exposing the limit (not just the counts) lets dashboards
+// compute a fill ratio without knowing the deployment's env configuration.
+func (m *DomainMetrics) SetCapacityLimits(maxVertices, maxEdges int) {
+	m.capacityLimit.WithLabelValues("vertex").Set(float64(maxVertices))
+	m.capacityLimit.WithLabelValues("edge").Set(float64(maxEdges))
 }
 
 // OnRateLimitRejected increments lantern_rate_limit_rejected_total when

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -94,13 +94,29 @@ type ObservabilityConfig struct {
 	BlockProfileRate     int
 }
 
-// CacheConfig sizes the GraphCache TTL and its GC tick.
+// CacheConfig sizes the GraphCache TTL and its GC tick, plus the optional
+// aggregate capacity caps (#848).
 //
 //   - LANTERN_DEFAULT_TTL_SECONDS        (default 60)
 //   - LANTERN_GC_INTERVAL_SECONDS        (default 60) — GraphCache.Watch tick
+//   - LANTERN_MAX_VERTICES               (default 0 = unlimited)
+//   - LANTERN_MAX_EDGES                  (default 0 = unlimited)
+//
+// The caps are SOFT, enforced at the local write-RPC boundary only: when a
+// batch would push the live count past the cap the RPC fails fast with
+// RESOURCE_EXHAUSTED instead of growing until the kernel OOM-kills the
+// process (which loses ALL data, not just the misbehaving writer's).
+// Replication apply and backup restore bypass the caps — rejecting writes
+// peers already committed would break convergence — so the caps bound
+// locally-originated growth; in HA every node applies its own cap at its
+// own RPC boundary. Deletes and TTL decay free capacity naturally; there
+// is deliberately no eviction policy. Pair with GOMEMLIMIT as the second
+// line of defense.
 type CacheConfig struct {
-	TTL        time.Duration
-	GCInterval time.Duration
+	TTL         time.Duration
+	GCInterval  time.Duration
+	MaxVertices int
+	MaxEdges    int
 }
 
 // ShutdownConfig is the graceful-shutdown timing.
@@ -235,8 +251,10 @@ func NewConfig() (*Config, error) {
 			BlockProfileRate:     envconfig.Int("LANTERN_BLOCK_PROFILE_RATE", 0),
 		},
 		Cache: CacheConfig{
-			TTL:        time.Duration(envconfig.Int("LANTERN_DEFAULT_TTL_SECONDS", 60)) * time.Second,
-			GCInterval: time.Duration(envconfig.Int("LANTERN_GC_INTERVAL_SECONDS", 60)) * time.Second,
+			TTL:         time.Duration(envconfig.Int("LANTERN_DEFAULT_TTL_SECONDS", 60)) * time.Second,
+			GCInterval:  time.Duration(envconfig.Int("LANTERN_GC_INTERVAL_SECONDS", 60)) * time.Second,
+			MaxVertices: envconfig.Int("LANTERN_MAX_VERTICES", 0),
+			MaxEdges:    envconfig.Int("LANTERN_MAX_EDGES", 0),
 		},
 		Shutdown: ShutdownConfig{
 			Timeout:    time.Duration(envconfig.Int("LANTERN_SHUTDOWN_TIMEOUT_SECONDS", 30)) * time.Second,

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -56,6 +56,7 @@ type LanternService struct {
 	onTombstoneClampReject func()
 	metrics                HotPathMetrics
 	traversalTimeout       time.Duration
+	capacity               CapacityLimits
 
 	// statusInfo + startedAt + startedAtOnce back GetServerStatus
 	// (#314). Populated by WithStatusInfo / MarkStarted from the
@@ -162,6 +163,68 @@ func (s *LanternService) WithScanLimits(l ScanLimits) *LanternService {
 func (s *LanternService) WithSearchLimits(l SearchLimits) *LanternService {
 	s.search = l
 	return s
+}
+
+// CapacityLimits carries the aggregate soft caps (#848). Zero (the default)
+// means unlimited. Enforced only at the local write-RPC boundary — see
+// checkVertexCapacity / checkEdgeCapacity for the conservative formulas and
+// the deliberate slack in both directions. ApplyMutation and backup restore
+// bypass the caps: rejecting writes peers already committed would break
+// convergence, so the caps bound locally-originated growth and every HA node
+// applies its own cap at its own RPC boundary.
+type CapacityLimits struct {
+	MaxVertices int
+	MaxEdges    int
+}
+
+// WithCapacityLimits returns s with its aggregate capacity caps replaced.
+// Intended for the wire provider to thread provider.CacheConfig into the
+// service.
+func (s *LanternService) WithCapacityLimits(l CapacityLimits) *LanternService {
+	s.capacity = l
+	return s
+}
+
+// checkVertexCapacity rejects a local write that could push the live vertex
+// count past the cap. newVertices is the worst-case number of NEW vertices
+// the batch can create: len(items) for PutVertices, 2*len(items) for edge
+// writes (every edge auto-creates up to two endpoint vertices).
+//
+// The check is deliberately approximate in both directions (soft cap): a
+// batch whose keys mostly already exist can be over-rejected near the cap,
+// and concurrent in-flight batches that each passed the check can overshoot
+// by their combined size. Neither is an invariant violation — the cap exists
+// to fail fast instead of growing until the kernel OOM-kills the process.
+func (s *LanternService) checkVertexCapacity(newVertices int) error {
+	if s.capacity.MaxVertices <= 0 {
+		return nil
+	}
+	if s.cache.VertexCount()+newVertices <= s.capacity.MaxVertices {
+		return nil
+	}
+	if s.onValidationReject != nil {
+		s.onValidationReject("capacity")
+	}
+	return connect.NewError(connect.CodeResourceExhausted, fmt.Errorf(
+		"vertex capacity: %d live + up to %d new would exceed LANTERN_MAX_VERTICES=%d (soft cap, counted conservatively); retry after TTL decay or deletes free capacity",
+		s.cache.VertexCount(), newVertices, s.capacity.MaxVertices))
+}
+
+// checkEdgeCapacity is the edge-side sibling of checkVertexCapacity;
+// newEdges is len(items) (each item writes exactly one (tail, head) bucket).
+func (s *LanternService) checkEdgeCapacity(newEdges int) error {
+	if s.capacity.MaxEdges <= 0 {
+		return nil
+	}
+	if s.cache.EdgeCount()+newEdges <= s.capacity.MaxEdges {
+		return nil
+	}
+	if s.onValidationReject != nil {
+		s.onValidationReject("capacity")
+	}
+	return connect.NewError(connect.CodeResourceExhausted, fmt.Errorf(
+		"edge capacity: %d live + up to %d new would exceed LANTERN_MAX_EDGES=%d (soft cap, counted conservatively); retry after TTL decay or deletes free capacity",
+		s.cache.EdgeCount(), newEdges, s.capacity.MaxEdges))
 }
 
 // WithReplication attaches the mutation log, hybrid logical clock, and an
@@ -589,6 +652,11 @@ func (s *LanternService) PutVertices(ctx context.Context, request *pb.PutVertice
 			liveCount++
 		}
 	}
+	// Aggregate capacity soft cap (#848): fail fast BEFORE any cache or log
+	// mutation so a rejected batch is all-or-nothing.
+	if err := s.checkVertexCapacity(len(items)); err != nil {
+		return nil, err
+	}
 	// When replication is enabled (clock wired) every local write is stamped
 	// with the SAME HLC it is logged under, via the *HLC cache method, so the
 	// origin's own PutVertex participates in last-writer-wins on equal footing
@@ -743,6 +811,15 @@ func (s *LanternService) AddEdges(ctx context.Context, request *pb.AddEdgesReque
 		}
 		items = append(items, item)
 	}
+	// Aggregate capacity soft caps (#848): every edge item writes one bucket
+	// and can auto-create up to two endpoint vertices, so both caps are
+	// consulted with conservative worst-case deltas.
+	if err := s.checkVertexCapacity(2 * len(items)); err != nil {
+		return nil, err
+	}
+	if err := s.checkEdgeCapacity(len(items)); err != nil {
+		return nil, err
+	}
 	// Additive merge converges via ContribID set semantics regardless of
 	// delivery order, but when replication is enabled the contribution must
 	// still be fenced by the edge tombstone at the SAME HLC it is logged
@@ -801,6 +878,14 @@ func (s *LanternService) PutEdges(ctx context.Context, request *pb.PutEdgesReque
 			Weight:     e.GetWeight(),
 			Expiration: e.GetExpiration().AsTime(),
 		})
+	}
+	// Aggregate capacity soft caps (#848) — same conservative deltas as
+	// AddEdges: one bucket per item, up to two auto-created endpoints.
+	if err := s.checkVertexCapacity(2 * len(items)); err != nil {
+		return nil, err
+	}
+	if err := s.checkEdgeCapacity(len(items)); err != nil {
+		return nil, err
 	}
 	// PutEdges*WithExpiration takes the cache write lock once for the whole
 	// batch, so concurrent GetEdge readers never observe a transient NotFound

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"strings"
 	"testing"
@@ -1594,6 +1595,130 @@ func TestLanternService_Illuminate_TraversalBudget(t *testing.T) {
 		}
 		if elapsed := time.Since(start); elapsed > 5*time.Second {
 			t.Fatalf("client deadline did not win: took %v", elapsed)
+		}
+	})
+}
+
+// TestLanternService_CapacityCaps pins the #848 soft-cap contract at the
+// write-RPC boundary: caps unset leave behavior unchanged; a batch that
+// exactly reaches the cap succeeds while the next single-item write fails
+// with RESOURCE_EXHAUSTED naming the env knob; deletes free capacity; edge
+// writes consult BOTH caps with the conservative 2-endpoints-per-item vertex
+// delta (over-rejection near the cap for existing keys is the documented
+// soft-cap slack, not a bug); ApplyMutation bypasses the caps entirely; and
+// each rejection fires the validation-reject hook with reason "capacity".
+func TestLanternService_CapacityCaps(t *testing.T) {
+	ctx := context.Background()
+	exp := timestamppb.New(time.Now().Add(time.Hour))
+	vertex := func(key string) *pb.Vertex {
+		return &pb.Vertex{Key: key, Value: &pb.Vertex_Nil{Nil: true}, Expiration: exp}
+	}
+	newSvc := func(l CapacityLimits, rejects *[]string) *LanternService {
+		cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+		svc := NewLanternService(cache).WithCapacityLimits(l)
+		if rejects != nil {
+			svc = svc.WithValidationRejectHook(func(reason string) { *rejects = append(*rejects, reason) })
+		}
+		return svc
+	}
+	isExhausted := func(t *testing.T, err error, knob string) {
+		t.Helper()
+		if connect.CodeOf(err) != connect.CodeResourceExhausted {
+			t.Fatalf("code = %v (err=%v), want ResourceExhausted", connect.CodeOf(err), err)
+		}
+		if !strings.Contains(err.Error(), knob) {
+			t.Fatalf("error %q does not name the knob %s", err.Error(), knob)
+		}
+	}
+
+	t.Run("UnsetCapsUnchanged", func(t *testing.T) {
+		svc := newSvc(CapacityLimits{}, nil)
+		for i := 0; i < 50; i++ {
+			if _, err := svc.PutVertex(ctx, &pb.PutVertexRequest{Vertex: vertex(fmt.Sprintf("k%02d", i))}); err != nil {
+				t.Fatalf("put %d with caps unset: %v", i, err)
+			}
+		}
+	})
+
+	t.Run("VertexBoundary", func(t *testing.T) {
+		var rejects []string
+		svc := newSvc(CapacityLimits{MaxVertices: 3}, &rejects)
+		// A batch that exactly reaches the cap succeeds.
+		if _, err := svc.PutVertices(ctx, &pb.PutVerticesRequest{Vertices: []*pb.Vertex{
+			vertex("a"), vertex("b"), vertex("c"),
+		}}); err != nil {
+			t.Fatalf("exact-fit batch: %v", err)
+		}
+		// The next single-item write fails, naming the knob.
+		_, err := svc.PutVertex(ctx, &pb.PutVertexRequest{Vertex: vertex("d")})
+		isExhausted(t, err, "LANTERN_MAX_VERTICES")
+		// Over-rejection slack: re-putting an EXISTING key at the cap is
+		// rejected too — the pre-check cannot know the key already exists.
+		// This is the documented conservative behavior, not a bug.
+		_, err = svc.PutVertex(ctx, &pb.PutVertexRequest{Vertex: vertex("a")})
+		isExhausted(t, err, "LANTERN_MAX_VERTICES")
+		// Deletes free capacity.
+		if _, err := svc.DeleteVertex(ctx, &pb.DeleteVertexRequest{Key: "a"}); err != nil {
+			t.Fatalf("delete: %v", err)
+		}
+		if _, err := svc.PutVertex(ctx, &pb.PutVertexRequest{Vertex: vertex("d")}); err != nil {
+			t.Fatalf("put after delete freed capacity: %v", err)
+		}
+		for i, r := range rejects {
+			if r != "capacity" {
+				t.Fatalf("reject %d reason = %q, want capacity", i, r)
+			}
+		}
+		if len(rejects) != 2 {
+			t.Fatalf("hook fired %d times, want 2", len(rejects))
+		}
+	})
+
+	t.Run("EdgeCapsBothSides", func(t *testing.T) {
+		var rejects []string
+		svc := newSvc(CapacityLimits{MaxVertices: 4, MaxEdges: 1}, &rejects)
+		// One edge: 2 potential endpoints <= 4, 1 edge <= 1 — fits.
+		if _, err := svc.AddEdge(ctx, &pb.AddEdgeRequest{Edge: &pb.Edge{Tail: "t", Head: "h", Weight: 1, Expiration: exp}}); err != nil {
+			t.Fatalf("first edge: %v", err)
+		}
+		// Second edge trips the EDGE cap.
+		_, err := svc.AddEdge(ctx, &pb.AddEdgeRequest{Edge: &pb.Edge{Tail: "t", Head: "h2", Weight: 1, Expiration: exp}})
+		isExhausted(t, err, "LANTERN_MAX_EDGES")
+		// Vertex cap via the conservative 2-per-item delta: 2 live + 2*2 > 4.
+		svc2 := newSvc(CapacityLimits{MaxVertices: 4}, nil)
+		if _, err := svc2.AddEdge(ctx, &pb.AddEdgeRequest{Edge: &pb.Edge{Tail: "t", Head: "h", Weight: 1, Expiration: exp}}); err != nil {
+			t.Fatalf("edge within vertex cap: %v", err)
+		}
+		_, err = svc2.AddEdges(ctx, &pb.AddEdgesRequest{Edges: []*pb.Edge{
+			{Tail: "x1", Head: "y1", Weight: 1, Expiration: exp},
+			{Tail: "x2", Head: "y2", Weight: 1, Expiration: exp},
+		}})
+		isExhausted(t, err, "LANTERN_MAX_VERTICES")
+		// PutEdges shares the same guards.
+		_, err = svc.PutEdges(ctx, &pb.PutEdgesRequest{Edges: []*pb.Edge{{Tail: "p", Head: "q", Weight: 1, Expiration: exp}}})
+		isExhausted(t, err, "LANTERN_MAX_EDGES")
+	})
+
+	t.Run("ApplyMutationBypasses", func(t *testing.T) {
+		svc := newSvc(CapacityLimits{MaxVertices: 1, MaxEdges: 1}, nil)
+		origin := bytes16("origin-A")
+		m := &pb.Mutation{Seq: 1, Hlc: newHLC(1, origin), Origin: origin[:], Op: &pb.MutationOp{Op: &pb.MutationOp_PutVertices{
+			PutVertices: &pb.PutVerticesRequest{Vertices: []*pb.Vertex{vertex("r1"), vertex("r2"), vertex("r3")}},
+		}}}
+		if err := svc.ApplyMutation(ctx, m); err != nil {
+			t.Fatalf("replicated apply must bypass the cap: %v", err)
+		}
+		if got := svc.cache.VertexCount(); got != 3 {
+			t.Fatalf("VertexCount = %d, want 3 (apply ignores the cap)", got)
+		}
+		m2 := &pb.Mutation{Seq: 2, Hlc: newHLC(2, origin), Origin: origin[:], Op: &pb.MutationOp{Op: &pb.MutationOp_AddEdges{
+			AddEdges: &pb.AddEdgesRequest{Edges: []*pb.Edge{
+				{Tail: "r1", Head: "r2", Weight: 1, Expiration: exp},
+				{Tail: "r2", Head: "r3", Weight: 1, Expiration: exp},
+			}},
+		}}}
+		if err := svc.ApplyMutation(ctx, m2); err != nil {
+			t.Fatalf("replicated edge apply must bypass the cap: %v", err)
 		}
 	})
 }

--- a/tests/integration/capacity_test.go
+++ b/tests/integration/capacity_test.go
@@ -1,0 +1,85 @@
+package integration_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/graphcache"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/anaregdesign/lantern/server/provider"
+	"github.com/anaregdesign/lantern/server/service"
+)
+
+// newCapacityClient stands up an in-process server with the #848 aggregate
+// soft caps configured and (optionally) the GC loop running on a fast tick,
+// so the test can observe TTL decay freeing capacity end-to-end.
+func newCapacityClient(t *testing.T, limits service.CapacityLimits, gcTick time.Duration) *client.Lantern {
+	t.Helper()
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+	if gcTick > 0 {
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		go cache.Watch(ctx, gcTick)
+	}
+	svc := service.NewLanternService(cache).WithCapacityLimits(limits)
+	val := provider.NewValidationInterceptor(defaultIntegrationValidationLimits())
+	srv := newConnectTestServer(t, svc, nil, val.ConnectInterceptor())
+	return newConnectClientFor(t, srv.url)
+}
+
+// TestCapacityCap_SDKSurface fills the vertex cap through the SDK and pins
+// the client-visible contract: the rejection surfaces as a typed
+// ErrResourceExhausted (retryable-after-decay), deletes free capacity
+// immediately, and TTL decay + GC frees capacity without any client action.
+func TestCapacityCap_SDKSurface(t *testing.T) {
+	l := newCapacityClient(t, service.CapacityLimits{MaxVertices: 3}, 50*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	longExp := time.Now().Add(time.Minute)
+	if err := l.PutVertices(ctx, []client.VertexInput{
+		{Key: "keep-1", Value: "v", Expiration: longExp},
+		{Key: "keep-2", Value: "v", Expiration: longExp},
+		{Key: "short", Value: "v", Expiration: time.Now().Add(300 * time.Millisecond)},
+	}); err != nil {
+		t.Fatalf("fill to cap: %v", err)
+	}
+
+	// At capacity: the typed sentinel must surface through the SDK.
+	err := l.PutVertex(ctx, "overflow", "v", time.Minute)
+	if !errors.Is(err, client.ErrResourceExhausted) {
+		t.Fatalf("at-cap put: got %v, want errors.Is ErrResourceExhausted", err)
+	}
+
+	// TTL decay frees capacity: once "short" expires and a GC tick flushes
+	// it, the same write goes through with no deletes issued.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		err = l.PutVertex(ctx, "overflow", "v", time.Minute)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, client.ErrResourceExhausted) {
+			t.Fatalf("unexpected error while waiting for decay: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("capacity never freed by TTL decay: %v", err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Back at capacity; a delete frees a slot immediately.
+	err = l.PutVertex(ctx, "one-more", "v", time.Minute)
+	if !errors.Is(err, client.ErrResourceExhausted) {
+		t.Fatalf("re-filled cap: got %v, want ErrResourceExhausted", err)
+	}
+	if _, err := l.DeleteVertex(ctx, "keep-1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if err := l.PutVertex(ctx, "one-more", "v", time.Minute); err != nil {
+		t.Fatalf("put after delete: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #848

## Problem

The only aggregate memory bound was TTL decay. A write burst faster than decay — or a client writing with long/no expirations — grows the vertex map, edge buckets, dictionary, radix, and search postings until the kernel OOM-kills the process, which takes down **all** data instead of degrading the one misbehaving writer. `ValidationLimits` caps per-request dimensions; nothing capped the aggregate.

## Change

**`LANTERN_MAX_VERTICES` / `LANTERN_MAX_EDGES`** (`CacheConfig`, default 0 = unlimited — behavior unchanged unless opted in), enforced at the local write-RPC boundary with the formula pinned in the issue's sequencing comment:

- `PutVertices`: reject when `VertexCount() + len(items) > MaxVertices`
- `AddEdges` / `PutEdges`: `VertexCount() + 2*len(items) > MaxVertices` (each item can auto-create both endpoints) and `EdgeCount() + len(items) > MaxEdges`

Rejections are `RESOURCE_EXHAUSTED` with a message naming the knob and the retry-after-decay contract. Singular facades inherit via the plural routing. **Two-sided slack is documented soft-cap semantics**: over-rejection near the cap when batch keys already exist, overshoot bounded by concurrent in-flight batches — the cap exists to fail fast instead of OOM, not as an invariant.

**Exemptions by design**: `ApplyMutation` and backup restore bypass the caps (rejecting writes peers already committed breaks convergence). Each HA node bounds its own RPC boundary, which bounds the cluster. No eviction policy — decay/GC/deletes free capacity (decay-first model).

**Observability**: `lantern_capacity_limit{kind="vertex"|"edge"}` gauges (fill ratio against the existing count gauges), new `capacity` reason on `lantern_validation_rejected_total` via the existing hook plumbing. Uses #838's O(1) `VertexCount`/`EdgeCount` — the pre-check is two integer reads.

**Docs**: env contract regenerated; ha-runbook §5 gains a saturation-guard subsection (sizing from per-entry heap estimate, 0.8 fill-ratio alert, `GOMEMLIMIT` as second line of defense).

## Tests

- `TestLanternService_CapacityCaps`: boundary table — caps unset unchanged; exact-fit batch succeeds and the next single write fails naming the knob; existing-key over-rejection near the cap pinned as intended behavior; deletes free capacity; edge writes trip either cap via the conservative deltas; `ApplyMutation` bypasses; hook fires with reason `capacity` exactly per rejection.
- `TestCapacityCap_SDKSurface` (integration): fill to cap through the SDK, typed `client.ErrResourceExhausted` surfaces, TTL decay + GC tick frees capacity end-to-end, delete frees a slot immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)