### PR TITLE
feat: conductance-based local community extraction (PageRank-Nibble sweep cut)

### DIFF
--- a/.github/skills/lantern-ops/SKILL.md
+++ b/.github/skills/lantern-ops/SKILL.md
@@ -277,7 +277,7 @@ idempotent. Flags:
 |---|---|---|
 | `--step <uint32>` | `1` | max walk depth from the seed. BFS-family only — ignored (has no meaning) under `--algorithm ppr` |
 | `--k <uint32>` | `10` | max neighbours visited per node. On the wire (#846) this maps to `bfs.fan_out` (per-hop top-k) for `none`/`mst`/`spt`, or `ppr.top_n` (total ranked vertices) for `ppr` |
-| `--algorithm <mode>` | `none` | traversal family + reduction. On the wire (#846) `none`/`mst`/`spt` select the BFS family (`mst`/`spt` are its post-traversal tree *reductions*), while `ppr` selects the separate Personalized PageRank family (seed-anchored ranking via ACL forward-push). The CLI keeps the single friendly flag; the typed split is server-side |
+| `--algorithm <mode>` | `none` | traversal family + reduction. On the wire (#846) `none`/`mst`/`spt` select the BFS family (`mst`/`spt` are its post-traversal tree *reductions*), `ppr` selects the Personalized PageRank family (seed-anchored ranking via ACL forward-push), and `community` (#845) selects conductance-based local community extraction (PageRank-Nibble sweep cut over the PPR push; `--k` is then an UPPER bound — the sweep may stop earlier — and the result is the real induced subgraph, not a relevance star). The CLI keeps the single friendly flag; the typed split is server-side |
 | `--objective <dir>` | `max` | optimisation direction; governs **both** per-hop top-k pruning and the reduction: `max` (largest-weight wins; weight = relevance) or `min` (smallest-weight wins; weight = cost). Ignored by `--algorithm ppr`, which always ranks by PPR mass |
 | `--weighting <mode>` | `raw` | edge-weight transform before the walk: `raw`, `tfidf` (re-score by TF-IDF over per-vertex out-edge distribution), or `bm25` (re-score by Okapi BM25, k1=1.2/b=0.75, over the same distribution — IDF saturation + out-degree length-normalisation, consistent with full-text search) |
 | `--prefix <string>` | — | restrict the walk **frontier** to vertices with this key prefix (case-sensitive); the seed is always kept as anchor. Applied server-side before top-k and any reduction, so `--prefix` + `mst`/`spt` yields a tree over the prefix-induced subgraph, not a path in the full graph |
@@ -292,6 +292,7 @@ lantern-cli illuminate alice --step 3 --k 20 --algorithm mst --objective min  # 
 lantern-cli illuminate alice --step 3 --k 20 --algorithm spt --objective max  # relevance-weighted SPT
 lantern-cli illuminate alice --step 2 --k 8 --algorithm ppr                    # PPR neighbourhood, server-default locality
 lantern-cli illuminate alice --step 2 --k 8 --algorithm ppr --restart-prob 0.25  # tighter, more seed-local PPR
+lantern-cli illuminate alice --k 30 --algorithm community                        # conductance-cut community (k = upper bound)
 lantern-cli illuminate alice --step 2 --k 5 --prefix users/    # frontier restricted to users/
 ```
 

--- a/admin/app/lib/cli/types.ts
+++ b/admin/app/lib/cli/types.ts
@@ -14,7 +14,7 @@
  * Tokenisation matches the Go side: lower-cased, whitespace-split.
  */
 
-export type AlgorithmName = "none" | "mst" | "spt" | "ppr";
+export type AlgorithmName = "none" | "mst" | "spt" | "ppr" | "community";
 export type ObjectiveName = "min" | "max";
 export type WeightingName = "raw" | "tfidf" | "bm25";
 

--- a/admin/app/lib/cli/verbs.ts
+++ b/admin/app/lib/cli/verbs.ts
@@ -11,7 +11,7 @@ import type {
   WeightingName,
 } from "./types";
 
-const ILL_ALGORITHMS = new Set<AlgorithmName>(["none", "mst", "spt", "ppr"]);
+const ILL_ALGORITHMS = new Set<AlgorithmName>(["none", "mst", "spt", "ppr", "community"]);
 const ILL_OBJECTIVES = new Set<ObjectiveName>(["min", "max"]);
 const ILL_WEIGHTINGS = new Set<WeightingName>(["raw", "tfidf", "bm25"]);
 
@@ -410,7 +410,7 @@ export function parseDeletePrefix(rest: string[]): ParseResult {
 
 export function parseIlluminate(rest: string[]): ParseResult {
   const usage =
-    "usage: illuminate <key: string> <step: int> <k: int> [algorithm=none|mst|spt|ppr] [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>] [restart_prob=<float>] [epsilon=<float>]";
+    "usage: illuminate <key: string> <step: int> <k: int> [algorithm=none|mst|spt|ppr|community] [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>] [restart_prob=<float>] [epsilon=<float>]";
   if (rest.length < 3) {
     return { ok: false, usage };
   }
@@ -537,7 +537,7 @@ export const HELP_TEXT = [
   "  delete-prefix vertices <prefix: string> [limit=<int>] [confirm=yes|dry_run=true]",
   "  keys   <prefix: string> [<limit: int>]",
   "  illuminate <seed: string> <step: int> <k: int>",
-  "             [algorithm={none|mst|spt|ppr}] default=none",
+  "             [algorithm={none|mst|spt|ppr|community}] default=none",
   "             [objective={min|max}]       default=max",
   "             [weighting={raw|tfidf|bm25}] default=raw",
   "             [prefix=<string>]           default=all keys",
@@ -675,7 +675,7 @@ export const CLI_COMMAND_REFERENCE: readonly CliCommandDoc[] = [
     group: "Explore",
     verb: "illuminate",
     signature:
-      "illuminate <seed> <step> <k> [algorithm=none|mst|spt|ppr] [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>] [restart_prob=<float>] [epsilon=<float>]",
+      "illuminate <seed> <step> <k> [algorithm=none|mst|spt|ppr|community] [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>] [restart_prob=<float>] [epsilon=<float>]",
     summary:
       "Walk the graph from a seed (step hops, top-k per hop) and render the subgraph. algorithm=ppr runs Personalized PageRank (tune locality with restart_prob/epsilon); the other axes reduce/weight the discovered subgraph.",
     example: "illuminate alice 2 5 algorithm=ppr restart_prob=0.25",

--- a/admin/app/lib/cli/verbs.ts
+++ b/admin/app/lib/cli/verbs.ts
@@ -11,7 +11,13 @@ import type {
   WeightingName,
 } from "./types";
 
-const ILL_ALGORITHMS = new Set<AlgorithmName>(["none", "mst", "spt", "ppr", "community"]);
+const ILL_ALGORITHMS = new Set<AlgorithmName>([
+  "none",
+  "mst",
+  "spt",
+  "ppr",
+  "community",
+]);
 const ILL_OBJECTIVES = new Set<ObjectiveName>(["min", "max"]);
 const ILL_WEIGHTINGS = new Set<WeightingName>(["raw", "tfidf", "bm25"]);
 

--- a/cli/cmd/illuminate.go
+++ b/cli/cmd/illuminate.go
@@ -131,7 +131,7 @@ REPL GRAMMAR (one-liner parity, #672)
   In addition to the flags above, illuminate accepts the REPL's positional
   form so the prompt and the shell share one grammar:
 
-    lantern-cli illuminate <seed> <step> <k> [algorithm=none|mst|spt|ppr] \
+    lantern-cli illuminate <seed> <step> <k> [algorithm=none|mst|spt|ppr|community] \
             [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>] \
             [restart_prob=<float>] [epsilon=<float>]
 
@@ -173,7 +173,7 @@ REPL GRAMMAR (one-liner parity, #672)
 
 		famOpt, ok := service.IlluminateFamilyOption(illuminateAlgorithmStr, illuminateStep, illuminateK, obj, illuminateRestartProb, illuminateEpsilon)
 		if !ok {
-			return fmt.Errorf("unknown --algorithm %q (want none|mst|spt|ppr)", illuminateAlgorithmStr)
+			return fmt.Errorf("unknown --algorithm %q (want none|mst|spt|ppr|community)", illuminateAlgorithmStr)
 		}
 		opts := []client.IlluminateOption{
 			famOpt,
@@ -195,7 +195,7 @@ REPL GRAMMAR (one-liner parity, #672)
 func init() {
 	illuminateCmd.Flags().Uint32Var(&illuminateStep, "step", 1, "maximum walk depth from the seed")
 	illuminateCmd.Flags().Uint32Var(&illuminateK, "k", 10, "max neighbours visited per node")
-	illuminateCmd.Flags().StringVar(&illuminateAlgorithmStr, "algorithm", "none", "Illuminate algorithm: none|mst|spt|ppr (#410, #801)")
+	illuminateCmd.Flags().StringVar(&illuminateAlgorithmStr, "algorithm", "none", "Illuminate algorithm: none|mst|spt|ppr|community (#410, #801, #845)")
 	illuminateCmd.Flags().StringVar(&illuminateObjectiveStr, "objective", "max", "optimisation direction: min|max; governs per-hop top-k pruning AND reduction (#560)")
 	illuminateCmd.Flags().StringVar(&illuminateWeightingStr, "weighting", "raw", "edge-weight transform before walk: raw|tfidf|bm25 (#410, #800)")
 	illuminateCmd.Flags().StringVar(&illuminatePrefixStr, "prefix", "", "restrict walk frontier to vertices with this key prefix; seed always kept, empty = no filter (#604)")

--- a/cli/cmd/repl.go
+++ b/cli/cmd/repl.go
@@ -40,7 +40,7 @@ The REPL accepts whitespace-delimited verbs:
   scan vertices <prefix> [limit]
   scan edges <tail-prefix> [limit]
   keys <prefix> [limit]
-  illuminate <seed> <step> <k> [algorithm=none|mst|spt|ppr] [objective=min|max] [weighting=raw|tfidf|bm25] [restart_prob=<float>] [epsilon=<float>]
+  illuminate <seed> <step> <k> [algorithm=none|mst|spt|ppr|community] [objective=min|max] [weighting=raw|tfidf|bm25] [restart_prob=<float>] [epsilon=<float>]
   help
   exit
 
@@ -151,7 +151,7 @@ EXAMPLE
 			case service.ErrKeys:
 				fmt.Println("Usage: keys <prefix: string> [<limit: int>]")
 			case service.ErrIlluminate:
-				fmt.Println("Usage: illuminate <seed: string> <step: int> <k: int> [algorithm=none|mst|spt|ppr] [objective=min|max] [weighting=raw|tfidf|bm25] [restart_prob=<float>] [epsilon=<float>]")
+				fmt.Println("Usage: illuminate <seed: string> <step: int> <k: int> [algorithm=none|mst|spt|ppr|community] [objective=min|max] [weighting=raw|tfidf|bm25] [restart_prob=<float>] [epsilon=<float>]")
 			case service.ErrInvalidVerb:
 				fmt.Println("Usage: { get | put | delete | add | scan | illuminate | help | exit } ...")
 			case service.ErrInvalidObjective:

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -42,7 +42,7 @@ var (
 	// are the canonical sets the REPL accepts for the keyword arguments of
 	// the modernised illuminate verb (#410). The keyword form replaces the
 	// legacy positional grammar (neighbor / spt_* / mst_*) entirely.
-	IlluminateAlgorithms = []string{"none", "mst", "spt", "ppr"}
+	IlluminateAlgorithms = []string{"none", "mst", "spt", "ppr", "community"}
 	IlluminateObjectives = []string{"min", "max"}
 	IlluminateWeightings = []string{"raw", "tfidf", "bm25"}
 
@@ -437,7 +437,7 @@ func DeleteEdgeParam(s *Source) (*DeleteEdge, error) {
 
 // IlluminateParam parses the modernised illuminate grammar (#410, #604, #801):
 //
-//	illuminate <seed> <step> <k> [algorithm=none|mst|spt|ppr] [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>] [restart_prob=<float>] [epsilon=<float>]
+//	illuminate <seed> <step> <k> [algorithm=none|mst|spt|ppr|community] [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>] [restart_prob=<float>] [epsilon=<float>]
 //
 // The keyword arguments may appear in any order and any subset. The three
 // closed-set axes default to the strongest-edge behaviour (algorithm=none,
@@ -481,7 +481,7 @@ func IlluminateParam(s *Source) (*Illuminate, error) {
 		switch key {
 		case "algorithm":
 			if !contains(IlluminateAlgorithms, lvalue) {
-				return nil, errors.New("illuminate: algorithm=" + value + " (want none|mst|spt|ppr)")
+				return nil, errors.New("illuminate: algorithm=" + value + " (want none|mst|spt|ppr|community)")
 			}
 			m.Algorithm = lvalue
 		case "objective":
@@ -745,7 +745,7 @@ const HelpText = `Lantern CLI grammar:
   delete-prefix vertices <prefix: string> [limit=<int>] [confirm=yes|dry_run=true]
   keys   <prefix: string> [<limit: int>]
   illuminate <seed: string> <step: int> <k: int>
-             [algorithm={none|mst|spt|ppr}] default=none
+             [algorithm={none|mst|spt|ppr|community}] default=none
              [objective={min|max}]       default=max
              [weighting={raw|tfidf|bm25}] default=raw
              [prefix=<string>]           default=all keys

--- a/cli/parser/validate.go
+++ b/cli/parser/validate.go
@@ -131,7 +131,7 @@ func Validate(input string) error {
 		}
 	case "illuminate":
 		if _, err := IlluminateParam(s); err != nil {
-			return errors.New("usage: illuminate <key: string> <step: int> <k: int> [algorithm=none|mst|spt|ppr] [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>] [restart_prob=<float>] [epsilon=<float>]")
+			return errors.New("usage: illuminate <key: string> <step: int> <k: int> [algorithm=none|mst|spt|ppr|community] [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>] [restart_prob=<float>] [epsilon=<float>]")
 		}
 
 	case "help":

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -475,6 +475,10 @@ func IlluminateFamilyOption(algo string, step, k uint32, obj client.Objective, r
 	switch algo {
 	case "ppr":
 		return client.WithPPR(client.PPROpts{TopN: k, RestartProb: restartProb, Epsilon: epsilon}), true
+	case "community":
+		// Local community extraction (#845): k is the max_size UPPER BOUND
+		// (the sweep may stop earlier); step has no meaning here.
+		return client.WithLocalCommunity(client.LocalCommunityOpts{MaxSize: k, RestartProb: restartProb, Epsilon: epsilon}), true
 	case "", "none":
 		return client.WithBFS(client.BFSOpts{Step: step, FanOut: k, Objective: obj}), true
 	case "mst":

--- a/core/graphcache/bench_test.go
+++ b/core/graphcache/bench_test.go
@@ -803,3 +803,50 @@ func BenchmarkApplyPutVerticesHLC(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkLocalCommunity pits the #845 sweep-cut extraction against plain
+// PPR top-N on a planted-partition graph (20 communities of 50, dense
+// intra-community edges + sparse cross links). The sweep's target cost is
+// O(touched·log touched + edges(touched)) on top of the shared push.
+func BenchmarkLocalCommunity(b *testing.B) {
+	const (
+		communities = 20
+		size        = 50
+	)
+	c := NewGraphCache[string, string](time.Hour)
+	exp := time.Now().Add(time.Hour)
+	key := func(ci, vi int) string { return fmt.Sprintf("c%02d/v%02d", ci, vi) }
+	for ci := 0; ci < communities; ci++ {
+		for vi := 0; vi < size; vi++ {
+			c.PutVertexWithExpiration(key(ci, vi), "v", exp)
+		}
+	}
+	for ci := 0; ci < communities; ci++ {
+		for vi := 0; vi < size; vi++ {
+			// Dense ring+chords inside the community.
+			for d := 1; d <= 5; d++ {
+				c.PutEdgeWithExpiration(key(ci, vi), key(ci, (vi+d)%size), 1.0, exp)
+			}
+			// One weak cross-community link per vertex.
+			c.PutEdgeWithExpiration(key(ci, vi), key((ci+1)%communities, vi), 0.02, exp)
+		}
+	}
+	b.Run("LocalCommunity", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			g, _, err := c.LocalCommunityContext(context.Background(), key(3, 7), 0, 0.15, 1e-5, WeightingRaw, nil)
+			if err != nil || len(g.Vertices) == 0 {
+				b.Fatalf("g=%v err=%v", len(g.Vertices), err)
+			}
+		}
+	})
+	b.Run("PPRTopN", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			g, err := c.PersonalizedPageRankContext(context.Background(), key(3, 7), size, 0.15, 1e-5, WeightingRaw, nil)
+			if err != nil || len(g.Vertices) == 0 {
+				b.Fatalf("g=%v err=%v", len(g.Vertices), err)
+			}
+		}
+	})
+}

--- a/core/graphcache/traversal.go
+++ b/core/graphcache/traversal.go
@@ -2,8 +2,10 @@ package graphcache
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"runtime"
+	"sort"
 	"sync"
 	"time"
 
@@ -401,6 +403,51 @@ func (c *GraphCache[S, T]) PersonalizedPageRankContext(ctx context.Context, seed
 	}
 	g.Vertices[seed] = sv
 
+	// One liveness instant for the whole push (#838), mirroring
+	// neighborContext.
+	now := time.Now()
+	p, err := c.pprPushLocked(ctx, seed, alpha, epsilon, weighting, keep, now)
+	if err != nil {
+		return nil, err
+	}
+
+	// Rank by PPR mass, excluding the seed, and keep the top-N. Reusing
+	// pq.SortableMap.Top mirrors the per-hop prune in neighborContext so the
+	// tie-breaking semantics are identical across both traversal paths.
+	scores := make(pq.SortableMap[S, float32], len(p))
+	for key, mass := range p {
+		if key == seed || mass <= 0 {
+			continue
+		}
+		scores[key] = float32(mass)
+	}
+	if topN > 0 {
+		scores = scores.Top(topN)
+	}
+	if len(scores) > 0 {
+		row := make(map[S]float32, len(scores))
+		for key, mass := range scores {
+			if v, ok := c.vertices.Get(key); ok {
+				g.Vertices[key] = v
+				row[key] = mass
+			}
+		}
+		if len(row) > 0 {
+			g.Edges[seed] = row
+		}
+	}
+
+	return g, nil
+}
+
+// pprPushLocked runs the Andersen–Chung–Lang local forward-push from seed and
+// returns the approximate PPR vector p. Factored out of
+// PersonalizedPageRankContext (#845) so the sweep-cut community extraction
+// shares one push implementation — same defaults, caps, ctx polling, keep
+// predicate, and #750 liveness rules. Caller must hold c.mu.RLock and have
+// resolved alpha/epsilon to their in-range values; now is the single liveness
+// instant for the whole walk (#838).
+func (c *GraphCache[S, T]) pprPushLocked(ctx context.Context, seed S, alpha, epsilon float64, weighting EdgeWeighting, keep func(S) bool, now time.Time) (map[S]float64, error) {
 	// BM25 corpus statistics are read once, only for the BM25 weighting, under
 	// the same RLock the per-edge accessors rely on — identical to
 	// neighborContext so PPR transitions and the BFS prune weight edges alike.
@@ -428,10 +475,8 @@ func (c *GraphCache[S, T]) PersonalizedPageRankContext(ctx context.Context, seed
 	inQueue := map[S]bool{seed: true}
 	maxPushes := pprMaxPushes(alpha, epsilon)
 
-	// One liveness instant for the whole push (#838), mirroring
-	// neighborContext; and an index cursor instead of queue = queue[1:], so
-	// the loop does not re-slice while retaining the consumed backing head.
-	now := time.Now()
+	// Index cursor instead of queue = queue[1:], so the loop does not
+	// re-slice while retaining the consumed backing head.
 	pushes := 0
 	for qi := 0; qi < len(queue); qi++ {
 		u := queue[qi]
@@ -504,32 +549,300 @@ func (c *GraphCache[S, T]) PersonalizedPageRankContext(ctx context.Context, seed
 			}
 		}
 	}
+	return p, nil
+}
 
-	// Rank by PPR mass, excluding the seed, and keep the top-N. Reusing
-	// pq.SortableMap.Top mirrors the per-hop prune in neighborContext so the
-	// tie-breaking semantics are identical across both traversal paths.
-	scores := make(pq.SortableMap[S, float32], len(p))
-	for key, mass := range p {
-		if key == seed || mass <= 0 {
+// LocalCommunity is the context-free convenience wrapper over
+// LocalCommunityContext using context.Background(). See that method for the
+// full contract.
+func (c *GraphCache[S, T]) LocalCommunity(seed S, maxSize int, alpha, epsilon float64, weighting EdgeWeighting, keep func(S) bool) (*graph.Graph[S, T], map[S]map[S]time.Time) {
+	g, exp, _ := c.LocalCommunityContext(context.Background(), seed, maxSize, alpha, epsilon, weighting, keep)
+	return g, exp
+}
+
+// LocalCommunityContext extracts the conductance-optimal local community
+// around seed (#845): PageRank-Nibble — the shared ACL forward-push followed
+// by a sweep cut. Vertices touched by the push are ordered by p(v)/d_w(v)
+// descending (d_w = weighted out-degree after the weighting transform; sinks
+// use a degree floor of 1; ties broken by ascending key order for
+// determinism, with the seed always first) and the prefix minimising the
+// directed weighted out-volume conductance is selected:
+//
+//	phi(S) = cut(S) / min(vol(S), volTouched − vol(S))
+//
+// maintained incrementally from out-adjacency alone. The volume universe is
+// the touched set — the subgraph the push localised — which keeps the sweep
+// O(touched·log touched + edges(touched)) instead of scanning the whole
+// graph; edges leaving the touched set still count toward cut(S).
+//
+// maxSize caps the prefix length (the wire max_size — an UPPER BOUND, not an
+// exact count: the sweep stops at the conductance minimum, which may come
+// earlier). Degenerate sweeps (fewer than 3 touched vertices, or a monotone
+// conductance profile with no interior minimum) fall back to top-maxSize by
+// PPR mass, so selection degrades to the PPR arm's behaviour.
+//
+// Output contract — unlike the PPR relevance star, structure is preserved:
+// the result is the INDUCED SUBGRAPH on the selected set: every member's
+// live value plus every live edge among members with its actual stored
+// weight (weighting-neutral — the transform steers membership, not the
+// returned weights) and expiration, in the same (graph, expirations) shape
+// as NeighborWithExpirationsContext. An unknown seed yields an empty graph.
+func (c *GraphCache[S, T]) LocalCommunityContext(ctx context.Context, seed S, maxSize int, alpha, epsilon float64, weighting EdgeWeighting, keep func(S) bool) (*graph.Graph[S, T], map[S]map[S]time.Time, error) {
+	if alpha <= 0 || alpha >= 1 {
+		alpha = DefaultPPRAlpha
+	}
+	if epsilon <= 0 {
+		epsilon = DefaultPPREpsilon
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	g := graph.NewGraph[S, T]()
+
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	sv, ok := c.vertices.Get(seed)
+	if !ok {
+		return g, nil, nil
+	}
+
+	now := time.Now()
+	p, err := c.pprPushLocked(ctx, seed, alpha, epsilon, weighting, keep, now)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// The same BM25 stats the push used, re-read for the sweep's d_w — cheap
+	// (corpusStats is O(1) since #838) and keeps pprPushLocked's signature
+	// narrow.
+	var bm25N int
+	var bm25AvgLen float64
+	if weighting == WeightingBM25 {
+		tails, totalEdges := c.edges.corpusStats()
+		bm25N = tails
+		if tails > 0 {
+			bm25AvgLen = float64(totalEdges) / float64(tails)
+		}
+	}
+
+	// Collect the touched vertices with positive mass, their transformed
+	// out-adjacency (live + kept, same rules as the push), and weighted
+	// out-degrees. Only edges into other TOUCHED vertices matter for the
+	// incremental cut bookkeeping keyed by member sets, but edges to
+	// untouched vertices still contribute to d_w — and therefore to cut —
+	// so the boundary they form is not invisible to the sweep.
+	type outEdge struct {
+		head S
+		a    float64
+	}
+	touched := make([]S, 0, len(p))
+	for v, mass := range p {
+		if mass <= 0 {
 			continue
 		}
-		scores[key] = float32(mass)
+		touched = append(touched, v)
 	}
-	if topN > 0 {
-		scores = scores.Top(topN)
-	}
-	if len(scores) > 0 {
-		row := make(map[S]float32, len(scores))
-		for key, mass := range scores {
-			if v, ok := c.vertices.Get(key); ok {
-				g.Vertices[key] = v
-				row[key] = mass
+	adj := make(map[S][]outEdge, len(touched))
+	dw := make(map[S]float64, len(touched))
+	var volTouched float64
+	for _, u := range touched {
+		var outs []outEdge
+		var du float64
+		if heads, ok := c.edges.headsOf(u); ok {
+			docLen := len(heads)
+			for headID, w := range heads {
+				head, ok := c.edges.resolveID(headID)
+				if !ok {
+					continue
+				}
+				if !c.vertices.Has(head) {
+					continue
+				}
+				if keep != nil && !keep(head) && head != seed {
+					continue
+				}
+				sum, _, nonZero := w.snapshotAt(now)
+				if !nonZero {
+					continue
+				}
+				a := float64(c.scoreEdge(weighting, sum, headID, docLen, bm25N, bm25AvgLen))
+				if a <= 0 {
+					continue
+				}
+				outs = append(outs, outEdge{head: head, a: a})
+				du += a
 			}
 		}
-		if len(row) > 0 {
-			g.Edges[seed] = row
+		adj[u] = outs
+		dw[u] = du
+		volTouched += du
+	}
+
+	// Sweep order: p(v)/max(d_w(v),1) descending, ties by ascending key; the
+	// seed is forced to position 0 so it is a member of every prefix.
+	order := make([]S, 0, len(touched))
+	for _, v := range touched {
+		if v != seed {
+			order = append(order, v)
+		}
+	}
+	rate := func(v S) float64 { return p[v] / math.Max(dw[v], 1) }
+	sort.Slice(order, func(i, j int) bool {
+		ri, rj := rate(order[i]), rate(order[j])
+		if ri != rj {
+			return ri > rj
+		}
+		return lessKey(order[i], order[j])
+	})
+	order = append([]S{seed}, order...)
+
+	// Incremental sweep. members is the growing prefix S; frontierWeight[x]
+	// aggregates Σ_{u∈S} w(u→x) for x∉S so admitting x later removes its
+	// incoming boundary weight from cut in O(1).
+	limit := len(order)
+	if maxSize > 0 && maxSize < limit {
+		limit = maxSize
+	}
+	members := make(map[S]bool, limit)
+	frontierWeight := make(map[S]float64)
+	var cut, vol float64
+	bestPhi := math.Inf(1)
+	bestLen := 0
+	phis := make([]float64, 0, limit)
+	for i := 0; i < limit; i++ {
+		v := order[i]
+		members[v] = true
+		cut -= frontierWeight[v]
+		delete(frontierWeight, v)
+		for _, e := range adj[v] {
+			if members[e.head] {
+				continue
+			}
+			cut += e.a
+			frontierWeight[e.head] += e.a
+		}
+		vol += dw[v]
+
+		denom := math.Min(vol, volTouched-vol)
+		var phi float64
+		switch {
+		case denom <= 0:
+			// The prefix swallowed (at least) the whole touched volume — the
+			// trivial "everything" cut. Score it +Inf so the sweep can never
+			// select the full universe just because its boundary vanished.
+			phi = math.Inf(1)
+		case cut == 0:
+			// A closed prefix (no boundary at all) is a perfect community.
+			phi = 0
+		default:
+			phi = cut / denom
+		}
+		phis = append(phis, phi)
+		if phi < bestPhi {
+			bestPhi = phi
+			bestLen = i + 1
 		}
 	}
 
-	return g, nil
+	// Degenerate sweep → fall back to top-maxSize by mass so behaviour
+	// degrades to the PPR arm's selection. Degenerate means: too few touched
+	// vertices to define a boundary, or a monotone conductance profile (no
+	// interior minimum to call the community edge).
+	selected := order[:max(bestLen, 1)]
+	if len(touched) < 3 || isMonotone(phis) {
+		// Deterministic mass ranking: (p desc, key asc). The pq.Top helper
+		// breaks score ties arbitrarily, which would make tied memberships
+		// flap across runs — the sweep's determinism contract covers the
+		// fallback too.
+		byMass := make([]S, 0, len(touched))
+		for _, v := range touched {
+			if v != seed {
+				byMass = append(byMass, v)
+			}
+		}
+		sort.Slice(byMass, func(i, j int) bool {
+			if p[byMass[i]] != p[byMass[j]] {
+				return p[byMass[i]] > p[byMass[j]]
+			}
+			return lessKey(byMass[i], byMass[j])
+		})
+		if maxSize > 0 && maxSize-1 < len(byMass) {
+			byMass = byMass[:maxSize-1] // -1: the seed occupies one slot
+		}
+		selected = append([]S{seed}, byMass...)
+	}
+
+	// Materialize the induced subgraph on the selected set: live member
+	// values, and every live edge among members with its actual stored
+	// weight and expiration — the same response shape as
+	// NeighborWithExpirationsContext.
+	inS := make(map[S]bool, len(selected))
+	for _, v := range selected {
+		inS[v] = true
+	}
+	g.Vertices[seed] = sv
+	expirations := make(map[S]map[S]time.Time, len(selected))
+	for _, v := range selected {
+		if v != seed {
+			val, ok := c.vertices.Get(v)
+			if !ok {
+				continue
+			}
+			g.Vertices[v] = val
+		}
+		heads, ok := c.edges.headsOf(v)
+		if !ok {
+			continue
+		}
+		row := make(map[S]float32)
+		expRow := make(map[S]time.Time)
+		for headID, w := range heads {
+			head, ok := c.edges.resolveID(headID)
+			if !ok || !inS[head] {
+				continue
+			}
+			if !c.vertices.Has(head) {
+				continue
+			}
+			sum, latest, nonZero := w.snapshotAt(now)
+			if !nonZero {
+				continue
+			}
+			row[head] = sum
+			expRow[head] = latest
+		}
+		if len(row) > 0 {
+			g.Edges[v] = row
+			expirations[v] = expRow
+		}
+	}
+	return g, expirations, nil
+}
+
+// isMonotone reports whether the conductance profile has no interior
+// minimum: non-increasing throughout or non-decreasing throughout. A
+// monotone profile means the sweep never found a boundary — the caller
+// falls back to mass-ranked selection.
+func isMonotone(phis []float64) bool {
+	if len(phis) < 3 {
+		return true
+	}
+	nonInc, nonDec := true, true
+	for i := 1; i < len(phis); i++ {
+		if phis[i] > phis[i-1] {
+			nonInc = false
+		}
+		if phis[i] < phis[i-1] {
+			nonDec = false
+		}
+	}
+	return nonInc || nonDec
+}
+
+// lessKey is the deterministic tie-breaker for the sweep ordering: a total
+// order over arbitrary comparable keys via their fmt representation. Only
+// evaluated on exact p/d_w ties, so the formatting cost is negligible.
+func lessKey[S comparable](a, b S) bool {
+	return fmt.Sprint(a) < fmt.Sprint(b)
 }

--- a/core/graphcache/traversal_test.go
+++ b/core/graphcache/traversal_test.go
@@ -599,3 +599,187 @@ func TestGraphCache_PersonalizedPageRank(t *testing.T) {
 		}
 	})
 }
+
+// TestGraphCache_LocalCommunity pins the #845 PageRank-Nibble contract:
+// sweep-cut boundary detection over the shared push, deterministic ordering,
+// the maxSize cap, keep scoping, liveness, the degenerate fallback, and the
+// induced-subgraph output shape (real edges + expirations, not a star).
+func TestGraphCache_LocalCommunity(t *testing.T) {
+	exp := time.Now().Add(time.Hour)
+
+	// clique wires every ordered pair inside members with weight w.
+	buildClique := func(c *GraphCache[string, string], members []string, w float32) {
+		for _, u := range members {
+			c.PutVertexWithExpiration(u, "v", exp)
+		}
+		for _, u := range members {
+			for _, v := range members {
+				if u != v {
+					c.PutEdgeWithExpiration(u, v, w, exp)
+				}
+			}
+		}
+	}
+
+	t.Run("two cliques with weak bridge: community is exactly the seed clique", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Hour)
+		a := []string{"a1", "a2", "a3", "a4"}
+		b := []string{"b1", "b2", "b3", "b4"}
+		buildClique(c, a, 1.0)
+		buildClique(c, b, 1.0)
+		// One weak directed bridge each way so mass can leak but the cut is cheap.
+		c.PutEdgeWithExpiration("a1", "b1", 0.05, exp)
+		c.PutEdgeWithExpiration("b1", "a1", 0.05, exp)
+
+		g, expirations, err := c.LocalCommunityContext(context.Background(), "a2", 0, 0.15, 1e-6, WeightingRaw, nil)
+		if err != nil {
+			t.Fatalf("LocalCommunityContext: %v", err)
+		}
+		got := make(map[string]bool, len(g.Vertices))
+		for k := range g.Vertices {
+			got[k] = true
+		}
+		for _, m := range a {
+			if !got[m] {
+				t.Errorf("clique member %s missing from community: %v", m, got)
+			}
+		}
+		for _, m := range b {
+			if got[m] {
+				t.Errorf("cross-bridge vertex %s leaked into the community: %v", m, got)
+			}
+		}
+		// Induced subgraph, not a star: intra-clique edges must be present
+		// with their REAL stored weights, from tails other than the seed.
+		if w, ok := g.Edges["a1"]["a3"]; !ok || w != 1.0 {
+			t.Errorf("induced edge a1->a3 = (%v,%v), want (1.0,true)", w, ok)
+		}
+		if len(expirations["a1"]) == 0 {
+			t.Errorf("expirations missing for member tail a1")
+		}
+		// The weak bridge edge to the excluded clique must NOT be present.
+		if _, ok := g.Edges["a1"]["b1"]; ok {
+			t.Errorf("edge to excluded vertex b1 leaked into the induced subgraph")
+		}
+	})
+
+	t.Run("maxSize caps the community", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Hour)
+		a := []string{"a1", "a2", "a3", "a4", "a5", "a6"}
+		buildClique(c, a, 1.0)
+		g, _, err := c.LocalCommunityContext(context.Background(), "a1", 3, 0.15, 1e-6, WeightingRaw, nil)
+		if err != nil {
+			t.Fatalf("LocalCommunityContext: %v", err)
+		}
+		if len(g.Vertices) > 3 {
+			t.Errorf("community size %d exceeds maxSize=3: %v", len(g.Vertices), g.Vertices)
+		}
+		if _, ok := g.Vertices["a1"]; !ok {
+			t.Errorf("seed evicted by the cap")
+		}
+	})
+
+	t.Run("keep predicate scopes the community", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Hour)
+		buildClique(c, []string{"p:1", "p:2", "p:3"}, 1.0)
+		c.PutVertexWithExpiration("q:x", "v", exp)
+		c.PutEdgeWithExpiration("p:1", "q:x", 5.0, exp) // strong but out-of-scope
+		g, _, err := c.LocalCommunityContext(context.Background(), "p:1", 0, 0.15, 1e-6, WeightingRaw,
+			func(s string) bool { return strings.HasPrefix(s, "p:") })
+		if err != nil {
+			t.Fatalf("LocalCommunityContext: %v", err)
+		}
+		if _, ok := g.Vertices["q:x"]; ok {
+			t.Errorf("keep-rejected vertex q:x entered the community")
+		}
+		if len(g.Vertices) < 3 {
+			t.Errorf("scoped community lost members: %v", g.Vertices)
+		}
+	})
+
+	t.Run("deterministic under ties", func(t *testing.T) {
+		// A symmetric star: every satellite has identical mass and degree, so
+		// the sweep ordering beyond the seed is decided purely by the
+		// (p/deg desc, key asc) tie-breaker. Repeated runs must agree exactly.
+		c := NewGraphCache[string, string](time.Hour)
+		sat := []string{"s1", "s2", "s3", "s4", "s5"}
+		c.PutVertexWithExpiration("hub", "v", exp)
+		for _, s := range sat {
+			c.PutVertexWithExpiration(s, "v", exp)
+			c.PutEdgeWithExpiration("hub", s, 1.0, exp)
+			c.PutEdgeWithExpiration(s, "hub", 1.0, exp)
+		}
+		var first map[string]bool
+		for i := 0; i < 10; i++ {
+			g, _, err := c.LocalCommunityContext(context.Background(), "hub", 3, 0.15, 1e-6, WeightingRaw, nil)
+			if err != nil {
+				t.Fatalf("run %d: %v", i, err)
+			}
+			got := make(map[string]bool, len(g.Vertices))
+			for k := range g.Vertices {
+				got[k] = true
+			}
+			if first == nil {
+				first = got
+				continue
+			}
+			if !reflect.DeepEqual(first, got) {
+				t.Fatalf("membership not deterministic: run 0 %v vs run %d %v", first, i, got)
+			}
+		}
+	})
+
+	t.Run("expired member never selected (#750)", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Hour)
+		buildClique(c, []string{"a1", "a2", "a3"}, 1.0)
+		c.PutVertexWithExpiration("dead", "v", time.Now().Add(20*time.Millisecond))
+		c.PutEdgeWithExpiration("a1", "dead", 10.0, exp)
+		c.PutEdgeWithExpiration("dead", "a1", 10.0, exp)
+		time.Sleep(30 * time.Millisecond)
+		g, _, err := c.LocalCommunityContext(context.Background(), "a1", 0, 0.15, 1e-6, WeightingRaw, nil)
+		if err != nil {
+			t.Fatalf("LocalCommunityContext: %v", err)
+		}
+		if _, ok := g.Vertices["dead"]; ok {
+			t.Errorf("expired vertex entered the community")
+		}
+	})
+
+	t.Run("degenerate touched set falls back to mass ranking", func(t *testing.T) {
+		// Seed with a single neighbour: touched < 3, so the sweep is
+		// undefined and the fallback must return the seed + its neighbour —
+		// the same set top-k-by-mass selects.
+		c := NewGraphCache[string, string](time.Hour)
+		c.PutVertexWithExpiration("a", "v", exp)
+		c.PutVertexWithExpiration("b", "v", exp)
+		c.PutEdgeWithExpiration("a", "b", 1.0, exp)
+		g, _, err := c.LocalCommunityContext(context.Background(), "a", 0, 0.15, 1e-6, WeightingRaw, nil)
+		if err != nil {
+			t.Fatalf("LocalCommunityContext: %v", err)
+		}
+		if _, ok := g.Vertices["a"]; !ok {
+			t.Errorf("seed missing")
+		}
+		if _, ok := g.Vertices["b"]; !ok {
+			t.Errorf("fallback dropped the only neighbour: %v", g.Vertices)
+		}
+	})
+
+	t.Run("unknown seed yields empty graph", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Hour)
+		g, _, err := c.LocalCommunityContext(context.Background(), "ghost", 0, 0, 0, WeightingRaw, nil)
+		if err != nil || len(g.Vertices) != 0 {
+			t.Fatalf("unknown seed: g=%v err=%v", g.Vertices, err)
+		}
+	})
+
+	t.Run("ctx cancel propagates", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Hour)
+		buildClique(c, []string{"a1", "a2", "a3"}, 1.0)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if _, _, err := c.LocalCommunityContext(ctx, "a1", 0, 0, 0, WeightingRaw, nil); err == nil {
+			t.Fatal("cancelled ctx must surface an error")
+		}
+	})
+}

--- a/pb/graph/v1/graph.pb.go
+++ b/pb/graph/v1/graph.pb.go
@@ -262,7 +262,7 @@ func (x ReplicationPeer_State) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ReplicationPeer_State.Descriptor instead.
 func (ReplicationPeer_State) EnumDescriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{51, 0}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{52, 0}
 }
 
 type Vertex struct {
@@ -667,6 +667,7 @@ type IlluminateRequest struct {
 	//
 	//	*IlluminateRequest_Bfs
 	//	*IlluminateRequest_Ppr
+	//	*IlluminateRequest_Community
 	Params        isIlluminateRequest_Params `protobuf_oneof:"params"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -748,6 +749,15 @@ func (x *IlluminateRequest) GetPpr() *PprParams {
 	return nil
 }
 
+func (x *IlluminateRequest) GetCommunity() *LocalCommunityParams {
+	if x != nil {
+		if x, ok := x.Params.(*IlluminateRequest_Community); ok {
+			return x.Community
+		}
+	}
+	return nil
+}
+
 type isIlluminateRequest_Params interface {
 	isIlluminateRequest_Params()
 }
@@ -760,9 +770,15 @@ type IlluminateRequest_Ppr struct {
 	Ppr *PprParams `protobuf:"bytes,13,opt,name=ppr,proto3,oneof"`
 }
 
+type IlluminateRequest_Community struct {
+	Community *LocalCommunityParams `protobuf:"bytes,14,opt,name=community,proto3,oneof"`
+}
+
 func (*IlluminateRequest_Bfs) isIlluminateRequest_Params() {}
 
 func (*IlluminateRequest_Ppr) isIlluminateRequest_Params() {}
+
+func (*IlluminateRequest_Community) isIlluminateRequest_Params() {}
 
 // BfsParams tunes the greedy per-hop top-k BFS walk (the default traversal
 // family) and its optional post-traversal tree reduction.
@@ -843,6 +859,112 @@ func (x *BfsParams) GetReduction() Reduction {
 	return Reduction_REDUCTION_UNSPECIFIED
 }
 
+// LocalCommunityParams extracts the conductance-optimal local community
+// around the seed (#845): PageRank-Nibble — the same ACL forward-push the
+// PPR family runs, followed by a sweep cut that orders touched vertices by
+// p(v)/deg(v) and takes the prefix minimising directed weighted
+// conductance. Unlike the PPR relevance star, the response preserves
+// structure: it is the INDUCED SUBGRAPH on the selected members — the real
+// live edges among them with actual stored weights and expirations, in the
+// same response shape as the BFS family.
+type LocalCommunityParams struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// max_size is an UPPER BOUND on community size — NOT an exact count. The
+	// sweep stops at the conductance minimum, which may come before max_size.
+	// 0 = unbounded (the sweep alone decides). (The PPR family's top_n by
+	// contrast always returns exactly N regardless of the natural boundary.)
+	MaxSize uint32 `protobuf:"varint,1,opt,name=max_size,json=maxSize,proto3" json:"max_size,omitempty"`
+	// restart_prob (α) — locality knob, same semantics and defaults as
+	// PprParams.restart_prob: higher α → tighter, more seed-proximate
+	// community. Honoured only in (0,1); unset falls back to 0.15.
+	RestartProb float32 `protobuf:"fixed32,2,opt,name=restart_prob,json=restartProb,proto3" json:"restart_prob,omitempty"`
+	// epsilon (ε) — push accuracy / work budget, same semantics and defaults
+	// as PprParams.epsilon: smaller ε → more accurate mass and a larger
+	// touched set. Honoured only when > 0; unset falls back to 1e-4.
+	Epsilon float32 `protobuf:"fixed32,3,opt,name=epsilon,proto3" json:"epsilon,omitempty"`
+	// reduction optionally reduces the community to a tree VIEW rooted at the
+	// seed (for visualization, explanation paths, token-bounded consumption).
+	// The induced subgraph stays the source of truth — density is exactly
+	// what the sweep selected for. Sweep prefixes need not be connected, so
+	// the tree spans only the seed's reachable component within the
+	// community; unreachable members are still returned as ISOLATED vertices
+	// (membership preserved, no edges fabricated). UNSPECIFIED = the full
+	// induced subgraph (the default).
+	Reduction Reduction `protobuf:"varint,4,opt,name=reduction,proto3,enum=graph.v1.Reduction" json:"reduction,omitempty"`
+	// objective sets the direction/cost mapping for the reduction ONLY
+	// (membership is decided by PPR mass, not by this): MINIMIZE → identity
+	// cost, MAXIMIZE/UNSPECIFIED → inverse cost, exactly as the BFS family.
+	// Ignored when reduction is UNSPECIFIED.
+	Objective     Objective `protobuf:"varint,5,opt,name=objective,proto3,enum=graph.v1.Objective" json:"objective,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LocalCommunityParams) Reset() {
+	*x = LocalCommunityParams{}
+	mi := &file_graph_v1_graph_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LocalCommunityParams) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LocalCommunityParams) ProtoMessage() {}
+
+func (x *LocalCommunityParams) ProtoReflect() protoreflect.Message {
+	mi := &file_graph_v1_graph_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LocalCommunityParams.ProtoReflect.Descriptor instead.
+func (*LocalCommunityParams) Descriptor() ([]byte, []int) {
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *LocalCommunityParams) GetMaxSize() uint32 {
+	if x != nil {
+		return x.MaxSize
+	}
+	return 0
+}
+
+func (x *LocalCommunityParams) GetRestartProb() float32 {
+	if x != nil {
+		return x.RestartProb
+	}
+	return 0
+}
+
+func (x *LocalCommunityParams) GetEpsilon() float32 {
+	if x != nil {
+		return x.Epsilon
+	}
+	return 0
+}
+
+func (x *LocalCommunityParams) GetReduction() Reduction {
+	if x != nil {
+		return x.Reduction
+	}
+	return Reduction_REDUCTION_UNSPECIFIED
+}
+
+func (x *LocalCommunityParams) GetObjective() Objective {
+	if x != nil {
+		return x.Objective
+	}
+	return Objective_OBJECTIVE_UNSPECIFIED
+}
+
 // PprParams runs seed-anchored Personalized PageRank (Random-Walk-with-
 // Restart) by local forward-push (Andersen–Chung–Lang) instead of the BFS
 // walk (#801). The result is a relevance star rooted at the seed — the
@@ -870,7 +992,7 @@ type PprParams struct {
 
 func (x *PprParams) Reset() {
 	*x = PprParams{}
-	mi := &file_graph_v1_graph_proto_msgTypes[5]
+	mi := &file_graph_v1_graph_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -882,7 +1004,7 @@ func (x *PprParams) String() string {
 func (*PprParams) ProtoMessage() {}
 
 func (x *PprParams) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[5]
+	mi := &file_graph_v1_graph_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -895,7 +1017,7 @@ func (x *PprParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PprParams.ProtoReflect.Descriptor instead.
 func (*PprParams) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{5}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *PprParams) GetTopN() uint32 {
@@ -928,7 +1050,7 @@ type IlluminateResponse struct {
 
 func (x *IlluminateResponse) Reset() {
 	*x = IlluminateResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[6]
+	mi := &file_graph_v1_graph_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -940,7 +1062,7 @@ func (x *IlluminateResponse) String() string {
 func (*IlluminateResponse) ProtoMessage() {}
 
 func (x *IlluminateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[6]
+	mi := &file_graph_v1_graph_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -953,7 +1075,7 @@ func (x *IlluminateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IlluminateResponse.ProtoReflect.Descriptor instead.
 func (*IlluminateResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{6}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *IlluminateResponse) GetGraph() *Graph {
@@ -972,7 +1094,7 @@ type GetVertexRequest struct {
 
 func (x *GetVertexRequest) Reset() {
 	*x = GetVertexRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[7]
+	mi := &file_graph_v1_graph_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -984,7 +1106,7 @@ func (x *GetVertexRequest) String() string {
 func (*GetVertexRequest) ProtoMessage() {}
 
 func (x *GetVertexRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[7]
+	mi := &file_graph_v1_graph_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -997,7 +1119,7 @@ func (x *GetVertexRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVertexRequest.ProtoReflect.Descriptor instead.
 func (*GetVertexRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{7}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GetVertexRequest) GetKey() string {
@@ -1016,7 +1138,7 @@ type GetVertexResponse struct {
 
 func (x *GetVertexResponse) Reset() {
 	*x = GetVertexResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[8]
+	mi := &file_graph_v1_graph_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1028,7 +1150,7 @@ func (x *GetVertexResponse) String() string {
 func (*GetVertexResponse) ProtoMessage() {}
 
 func (x *GetVertexResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[8]
+	mi := &file_graph_v1_graph_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1041,7 +1163,7 @@ func (x *GetVertexResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVertexResponse.ProtoReflect.Descriptor instead.
 func (*GetVertexResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{8}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *GetVertexResponse) GetVertex() *Vertex {
@@ -1062,7 +1184,7 @@ type GetVerticesRequest struct {
 
 func (x *GetVerticesRequest) Reset() {
 	*x = GetVerticesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[9]
+	mi := &file_graph_v1_graph_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1074,7 +1196,7 @@ func (x *GetVerticesRequest) String() string {
 func (*GetVerticesRequest) ProtoMessage() {}
 
 func (x *GetVerticesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[9]
+	mi := &file_graph_v1_graph_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1087,7 +1209,7 @@ func (x *GetVerticesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVerticesRequest.ProtoReflect.Descriptor instead.
 func (*GetVerticesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{9}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *GetVerticesRequest) GetKeys() []string {
@@ -1110,7 +1232,7 @@ type GetVerticesResponse struct {
 
 func (x *GetVerticesResponse) Reset() {
 	*x = GetVerticesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[10]
+	mi := &file_graph_v1_graph_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1122,7 +1244,7 @@ func (x *GetVerticesResponse) String() string {
 func (*GetVerticesResponse) ProtoMessage() {}
 
 func (x *GetVerticesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[10]
+	mi := &file_graph_v1_graph_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1135,7 +1257,7 @@ func (x *GetVerticesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVerticesResponse.ProtoReflect.Descriptor instead.
 func (*GetVerticesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{10}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *GetVerticesResponse) GetVertices() []*Vertex {
@@ -1165,7 +1287,7 @@ type PutVertexRequest struct {
 
 func (x *PutVertexRequest) Reset() {
 	*x = PutVertexRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[11]
+	mi := &file_graph_v1_graph_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1177,7 +1299,7 @@ func (x *PutVertexRequest) String() string {
 func (*PutVertexRequest) ProtoMessage() {}
 
 func (x *PutVertexRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[11]
+	mi := &file_graph_v1_graph_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1190,7 +1312,7 @@ func (x *PutVertexRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutVertexRequest.ProtoReflect.Descriptor instead.
 func (*PutVertexRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{11}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *PutVertexRequest) GetVertex() *Vertex {
@@ -1208,7 +1330,7 @@ type PutVertexResponse struct {
 
 func (x *PutVertexResponse) Reset() {
 	*x = PutVertexResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[12]
+	mi := &file_graph_v1_graph_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1220,7 +1342,7 @@ func (x *PutVertexResponse) String() string {
 func (*PutVertexResponse) ProtoMessage() {}
 
 func (x *PutVertexResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[12]
+	mi := &file_graph_v1_graph_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1233,7 +1355,7 @@ func (x *PutVertexResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutVertexResponse.ProtoReflect.Descriptor instead.
 func (*PutVertexResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{12}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{13}
 }
 
 // PutVerticesRequest writes vertices with upsert semantics: each Vertex.key
@@ -1248,7 +1370,7 @@ type PutVerticesRequest struct {
 
 func (x *PutVerticesRequest) Reset() {
 	*x = PutVerticesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[13]
+	mi := &file_graph_v1_graph_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1260,7 +1382,7 @@ func (x *PutVerticesRequest) String() string {
 func (*PutVerticesRequest) ProtoMessage() {}
 
 func (x *PutVerticesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[13]
+	mi := &file_graph_v1_graph_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1273,7 +1395,7 @@ func (x *PutVerticesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutVerticesRequest.ProtoReflect.Descriptor instead.
 func (*PutVerticesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{13}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *PutVerticesRequest) GetVertices() []*Vertex {
@@ -1295,7 +1417,7 @@ type PutVerticesResponse struct {
 
 func (x *PutVerticesResponse) Reset() {
 	*x = PutVerticesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[14]
+	mi := &file_graph_v1_graph_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1307,7 +1429,7 @@ func (x *PutVerticesResponse) String() string {
 func (*PutVerticesResponse) ProtoMessage() {}
 
 func (x *PutVerticesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[14]
+	mi := &file_graph_v1_graph_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1320,7 +1442,7 @@ func (x *PutVerticesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutVerticesResponse.ProtoReflect.Descriptor instead.
 func (*PutVerticesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{14}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *PutVerticesResponse) GetWritten() int32 {
@@ -1343,7 +1465,7 @@ type DeleteVertexRequest struct {
 
 func (x *DeleteVertexRequest) Reset() {
 	*x = DeleteVertexRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[15]
+	mi := &file_graph_v1_graph_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1355,7 +1477,7 @@ func (x *DeleteVertexRequest) String() string {
 func (*DeleteVertexRequest) ProtoMessage() {}
 
 func (x *DeleteVertexRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[15]
+	mi := &file_graph_v1_graph_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1368,7 +1490,7 @@ func (x *DeleteVertexRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteVertexRequest.ProtoReflect.Descriptor instead.
 func (*DeleteVertexRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{15}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *DeleteVertexRequest) GetKey() string {
@@ -1388,7 +1510,7 @@ type DeleteVertexResponse struct {
 
 func (x *DeleteVertexResponse) Reset() {
 	*x = DeleteVertexResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[16]
+	mi := &file_graph_v1_graph_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1400,7 +1522,7 @@ func (x *DeleteVertexResponse) String() string {
 func (*DeleteVertexResponse) ProtoMessage() {}
 
 func (x *DeleteVertexResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[16]
+	mi := &file_graph_v1_graph_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1413,7 +1535,7 @@ func (x *DeleteVertexResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteVertexResponse.ProtoReflect.Descriptor instead.
 func (*DeleteVertexResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{16}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *DeleteVertexResponse) GetExisted() bool {
@@ -1435,7 +1557,7 @@ type DeleteVerticesRequest struct {
 
 func (x *DeleteVerticesRequest) Reset() {
 	*x = DeleteVerticesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[17]
+	mi := &file_graph_v1_graph_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1447,7 +1569,7 @@ func (x *DeleteVerticesRequest) String() string {
 func (*DeleteVerticesRequest) ProtoMessage() {}
 
 func (x *DeleteVerticesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[17]
+	mi := &file_graph_v1_graph_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1460,7 +1582,7 @@ func (x *DeleteVerticesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteVerticesRequest.ProtoReflect.Descriptor instead.
 func (*DeleteVerticesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{17}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *DeleteVerticesRequest) GetKeys() []string {
@@ -1480,7 +1602,7 @@ type DeleteVerticesResponse struct {
 
 func (x *DeleteVerticesResponse) Reset() {
 	*x = DeleteVerticesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[18]
+	mi := &file_graph_v1_graph_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1492,7 +1614,7 @@ func (x *DeleteVerticesResponse) String() string {
 func (*DeleteVerticesResponse) ProtoMessage() {}
 
 func (x *DeleteVerticesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[18]
+	mi := &file_graph_v1_graph_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1505,7 +1627,7 @@ func (x *DeleteVerticesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteVerticesResponse.ProtoReflect.Descriptor instead.
 func (*DeleteVerticesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{18}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *DeleteVerticesResponse) GetDeleted() int32 {
@@ -1535,7 +1657,7 @@ type ScanVerticesRequest struct {
 
 func (x *ScanVerticesRequest) Reset() {
 	*x = ScanVerticesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[19]
+	mi := &file_graph_v1_graph_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1547,7 +1669,7 @@ func (x *ScanVerticesRequest) String() string {
 func (*ScanVerticesRequest) ProtoMessage() {}
 
 func (x *ScanVerticesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[19]
+	mi := &file_graph_v1_graph_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1560,7 +1682,7 @@ func (x *ScanVerticesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScanVerticesRequest.ProtoReflect.Descriptor instead.
 func (*ScanVerticesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{19}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ScanVerticesRequest) GetPrefix() string {
@@ -1598,7 +1720,7 @@ type ScanVerticesResponse struct {
 
 func (x *ScanVerticesResponse) Reset() {
 	*x = ScanVerticesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[20]
+	mi := &file_graph_v1_graph_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1610,7 +1732,7 @@ func (x *ScanVerticesResponse) String() string {
 func (*ScanVerticesResponse) ProtoMessage() {}
 
 func (x *ScanVerticesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[20]
+	mi := &file_graph_v1_graph_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1623,7 +1745,7 @@ func (x *ScanVerticesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScanVerticesResponse.ProtoReflect.Descriptor instead.
 func (*ScanVerticesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{20}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ScanVerticesResponse) GetVertices() []*Vertex {
@@ -1668,7 +1790,7 @@ type ScanVertexKeysRequest struct {
 
 func (x *ScanVertexKeysRequest) Reset() {
 	*x = ScanVertexKeysRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[21]
+	mi := &file_graph_v1_graph_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1680,7 +1802,7 @@ func (x *ScanVertexKeysRequest) String() string {
 func (*ScanVertexKeysRequest) ProtoMessage() {}
 
 func (x *ScanVertexKeysRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[21]
+	mi := &file_graph_v1_graph_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1693,7 +1815,7 @@ func (x *ScanVertexKeysRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScanVertexKeysRequest.ProtoReflect.Descriptor instead.
 func (*ScanVertexKeysRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{21}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ScanVertexKeysRequest) GetPrefix() string {
@@ -1731,7 +1853,7 @@ type ScanVertexKeysResponse struct {
 
 func (x *ScanVertexKeysResponse) Reset() {
 	*x = ScanVertexKeysResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[22]
+	mi := &file_graph_v1_graph_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1743,7 +1865,7 @@ func (x *ScanVertexKeysResponse) String() string {
 func (*ScanVertexKeysResponse) ProtoMessage() {}
 
 func (x *ScanVertexKeysResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[22]
+	mi := &file_graph_v1_graph_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1756,7 +1878,7 @@ func (x *ScanVertexKeysResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScanVertexKeysResponse.ProtoReflect.Descriptor instead.
 func (*ScanVertexKeysResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{22}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ScanVertexKeysResponse) GetKeys() []string {
@@ -1798,7 +1920,7 @@ type SearchVerticesRequest struct {
 
 func (x *SearchVerticesRequest) Reset() {
 	*x = SearchVerticesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[23]
+	mi := &file_graph_v1_graph_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1810,7 +1932,7 @@ func (x *SearchVerticesRequest) String() string {
 func (*SearchVerticesRequest) ProtoMessage() {}
 
 func (x *SearchVerticesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[23]
+	mi := &file_graph_v1_graph_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1823,7 +1945,7 @@ func (x *SearchVerticesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchVerticesRequest.ProtoReflect.Descriptor instead.
 func (*SearchVerticesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{23}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *SearchVerticesRequest) GetQuery() string {
@@ -1858,7 +1980,7 @@ type SearchVerticesResponse struct {
 
 func (x *SearchVerticesResponse) Reset() {
 	*x = SearchVerticesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[24]
+	mi := &file_graph_v1_graph_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1870,7 +1992,7 @@ func (x *SearchVerticesResponse) String() string {
 func (*SearchVerticesResponse) ProtoMessage() {}
 
 func (x *SearchVerticesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[24]
+	mi := &file_graph_v1_graph_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1883,7 +2005,7 @@ func (x *SearchVerticesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchVerticesResponse.ProtoReflect.Descriptor instead.
 func (*SearchVerticesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{24}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *SearchVerticesResponse) GetHits() []*SearchHit {
@@ -1907,7 +2029,7 @@ type SearchHit struct {
 
 func (x *SearchHit) Reset() {
 	*x = SearchHit{}
-	mi := &file_graph_v1_graph_proto_msgTypes[25]
+	mi := &file_graph_v1_graph_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1919,7 +2041,7 @@ func (x *SearchHit) String() string {
 func (*SearchHit) ProtoMessage() {}
 
 func (x *SearchHit) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[25]
+	mi := &file_graph_v1_graph_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1932,7 +2054,7 @@ func (x *SearchHit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchHit.ProtoReflect.Descriptor instead.
 func (*SearchHit) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{25}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *SearchHit) GetKey() string {
@@ -1960,7 +2082,7 @@ type CountVerticesByPrefixRequest struct {
 
 func (x *CountVerticesByPrefixRequest) Reset() {
 	*x = CountVerticesByPrefixRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[26]
+	mi := &file_graph_v1_graph_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1972,7 +2094,7 @@ func (x *CountVerticesByPrefixRequest) String() string {
 func (*CountVerticesByPrefixRequest) ProtoMessage() {}
 
 func (x *CountVerticesByPrefixRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[26]
+	mi := &file_graph_v1_graph_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1985,7 +2107,7 @@ func (x *CountVerticesByPrefixRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CountVerticesByPrefixRequest.ProtoReflect.Descriptor instead.
 func (*CountVerticesByPrefixRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{26}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *CountVerticesByPrefixRequest) GetPrefix() string {
@@ -2004,7 +2126,7 @@ type CountVerticesByPrefixResponse struct {
 
 func (x *CountVerticesByPrefixResponse) Reset() {
 	*x = CountVerticesByPrefixResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[27]
+	mi := &file_graph_v1_graph_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2016,7 +2138,7 @@ func (x *CountVerticesByPrefixResponse) String() string {
 func (*CountVerticesByPrefixResponse) ProtoMessage() {}
 
 func (x *CountVerticesByPrefixResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[27]
+	mi := &file_graph_v1_graph_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2029,7 +2151,7 @@ func (x *CountVerticesByPrefixResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CountVerticesByPrefixResponse.ProtoReflect.Descriptor instead.
 func (*CountVerticesByPrefixResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{27}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *CountVerticesByPrefixResponse) GetCount() uint64 {
@@ -2055,7 +2177,7 @@ type DeleteVerticesByPrefixRequest struct {
 
 func (x *DeleteVerticesByPrefixRequest) Reset() {
 	*x = DeleteVerticesByPrefixRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[28]
+	mi := &file_graph_v1_graph_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2067,7 +2189,7 @@ func (x *DeleteVerticesByPrefixRequest) String() string {
 func (*DeleteVerticesByPrefixRequest) ProtoMessage() {}
 
 func (x *DeleteVerticesByPrefixRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[28]
+	mi := &file_graph_v1_graph_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2080,7 +2202,7 @@ func (x *DeleteVerticesByPrefixRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteVerticesByPrefixRequest.ProtoReflect.Descriptor instead.
 func (*DeleteVerticesByPrefixRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{28}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *DeleteVerticesByPrefixRequest) GetPrefix() string {
@@ -2113,7 +2235,7 @@ type DeleteVerticesByPrefixResponse struct {
 
 func (x *DeleteVerticesByPrefixResponse) Reset() {
 	*x = DeleteVerticesByPrefixResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[29]
+	mi := &file_graph_v1_graph_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2125,7 +2247,7 @@ func (x *DeleteVerticesByPrefixResponse) String() string {
 func (*DeleteVerticesByPrefixResponse) ProtoMessage() {}
 
 func (x *DeleteVerticesByPrefixResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[29]
+	mi := &file_graph_v1_graph_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2138,7 +2260,7 @@ func (x *DeleteVerticesByPrefixResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteVerticesByPrefixResponse.ProtoReflect.Descriptor instead.
 func (*DeleteVerticesByPrefixResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{29}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *DeleteVerticesByPrefixResponse) GetDeleted() uint64 {
@@ -2158,7 +2280,7 @@ type GetEdgeRequest struct {
 
 func (x *GetEdgeRequest) Reset() {
 	*x = GetEdgeRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[30]
+	mi := &file_graph_v1_graph_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2170,7 +2292,7 @@ func (x *GetEdgeRequest) String() string {
 func (*GetEdgeRequest) ProtoMessage() {}
 
 func (x *GetEdgeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[30]
+	mi := &file_graph_v1_graph_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2183,7 +2305,7 @@ func (x *GetEdgeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEdgeRequest.ProtoReflect.Descriptor instead.
 func (*GetEdgeRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{30}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetEdgeRequest) GetTail() string {
@@ -2209,7 +2331,7 @@ type GetEdgeResponse struct {
 
 func (x *GetEdgeResponse) Reset() {
 	*x = GetEdgeResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[31]
+	mi := &file_graph_v1_graph_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2221,7 +2343,7 @@ func (x *GetEdgeResponse) String() string {
 func (*GetEdgeResponse) ProtoMessage() {}
 
 func (x *GetEdgeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[31]
+	mi := &file_graph_v1_graph_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2234,7 +2356,7 @@ func (x *GetEdgeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEdgeResponse.ProtoReflect.Descriptor instead.
 func (*GetEdgeResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{31}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *GetEdgeResponse) GetEdge() *Edge {
@@ -2255,7 +2377,7 @@ type GetEdgesRequest struct {
 
 func (x *GetEdgesRequest) Reset() {
 	*x = GetEdgesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[32]
+	mi := &file_graph_v1_graph_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2267,7 +2389,7 @@ func (x *GetEdgesRequest) String() string {
 func (*GetEdgesRequest) ProtoMessage() {}
 
 func (x *GetEdgesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[32]
+	mi := &file_graph_v1_graph_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2280,7 +2402,7 @@ func (x *GetEdgesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEdgesRequest.ProtoReflect.Descriptor instead.
 func (*GetEdgesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{32}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *GetEdgesRequest) GetEdges() []*EdgeKey {
@@ -2305,7 +2427,7 @@ type GetEdgesResponse struct {
 
 func (x *GetEdgesResponse) Reset() {
 	*x = GetEdgesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[33]
+	mi := &file_graph_v1_graph_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2317,7 +2439,7 @@ func (x *GetEdgesResponse) String() string {
 func (*GetEdgesResponse) ProtoMessage() {}
 
 func (x *GetEdgesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[33]
+	mi := &file_graph_v1_graph_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2330,7 +2452,7 @@ func (x *GetEdgesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEdgesResponse.ProtoReflect.Descriptor instead.
 func (*GetEdgesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{33}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *GetEdgesResponse) GetEdges() []*Edge {
@@ -2357,7 +2479,7 @@ type DeleteEdgeRequest struct {
 
 func (x *DeleteEdgeRequest) Reset() {
 	*x = DeleteEdgeRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[34]
+	mi := &file_graph_v1_graph_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2369,7 +2491,7 @@ func (x *DeleteEdgeRequest) String() string {
 func (*DeleteEdgeRequest) ProtoMessage() {}
 
 func (x *DeleteEdgeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[34]
+	mi := &file_graph_v1_graph_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2382,7 +2504,7 @@ func (x *DeleteEdgeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEdgeRequest.ProtoReflect.Descriptor instead.
 func (*DeleteEdgeRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{34}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *DeleteEdgeRequest) GetTail() string {
@@ -2409,7 +2531,7 @@ type DeleteEdgeResponse struct {
 
 func (x *DeleteEdgeResponse) Reset() {
 	*x = DeleteEdgeResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[35]
+	mi := &file_graph_v1_graph_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2421,7 +2543,7 @@ func (x *DeleteEdgeResponse) String() string {
 func (*DeleteEdgeResponse) ProtoMessage() {}
 
 func (x *DeleteEdgeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[35]
+	mi := &file_graph_v1_graph_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2434,7 +2556,7 @@ func (x *DeleteEdgeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEdgeResponse.ProtoReflect.Descriptor instead.
 func (*DeleteEdgeResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{35}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *DeleteEdgeResponse) GetExisted() bool {
@@ -2455,7 +2577,7 @@ type EdgeKey struct {
 
 func (x *EdgeKey) Reset() {
 	*x = EdgeKey{}
-	mi := &file_graph_v1_graph_proto_msgTypes[36]
+	mi := &file_graph_v1_graph_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2467,7 +2589,7 @@ func (x *EdgeKey) String() string {
 func (*EdgeKey) ProtoMessage() {}
 
 func (x *EdgeKey) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[36]
+	mi := &file_graph_v1_graph_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2480,7 +2602,7 @@ func (x *EdgeKey) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EdgeKey.ProtoReflect.Descriptor instead.
 func (*EdgeKey) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{36}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *EdgeKey) GetTail() string {
@@ -2526,7 +2648,7 @@ type ScanEdgesRequest struct {
 
 func (x *ScanEdgesRequest) Reset() {
 	*x = ScanEdgesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[37]
+	mi := &file_graph_v1_graph_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2538,7 +2660,7 @@ func (x *ScanEdgesRequest) String() string {
 func (*ScanEdgesRequest) ProtoMessage() {}
 
 func (x *ScanEdgesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[37]
+	mi := &file_graph_v1_graph_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2551,7 +2673,7 @@ func (x *ScanEdgesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScanEdgesRequest.ProtoReflect.Descriptor instead.
 func (*ScanEdgesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{37}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ScanEdgesRequest) GetTailPrefix() string {
@@ -2596,7 +2718,7 @@ type ScanEdgesResponse struct {
 
 func (x *ScanEdgesResponse) Reset() {
 	*x = ScanEdgesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[38]
+	mi := &file_graph_v1_graph_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2608,7 +2730,7 @@ func (x *ScanEdgesResponse) String() string {
 func (*ScanEdgesResponse) ProtoMessage() {}
 
 func (x *ScanEdgesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[38]
+	mi := &file_graph_v1_graph_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2621,7 +2743,7 @@ func (x *ScanEdgesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScanEdgesResponse.ProtoReflect.Descriptor instead.
 func (*ScanEdgesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{38}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *ScanEdgesResponse) GetEdges() []*Edge {
@@ -2649,7 +2771,7 @@ type DeleteEdgesRequest struct {
 
 func (x *DeleteEdgesRequest) Reset() {
 	*x = DeleteEdgesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[39]
+	mi := &file_graph_v1_graph_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2661,7 +2783,7 @@ func (x *DeleteEdgesRequest) String() string {
 func (*DeleteEdgesRequest) ProtoMessage() {}
 
 func (x *DeleteEdgesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[39]
+	mi := &file_graph_v1_graph_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2674,7 +2796,7 @@ func (x *DeleteEdgesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEdgesRequest.ProtoReflect.Descriptor instead.
 func (*DeleteEdgesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{39}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *DeleteEdgesRequest) GetEdges() []*EdgeKey {
@@ -2694,7 +2816,7 @@ type DeleteEdgesResponse struct {
 
 func (x *DeleteEdgesResponse) Reset() {
 	*x = DeleteEdgesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[40]
+	mi := &file_graph_v1_graph_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2706,7 +2828,7 @@ func (x *DeleteEdgesResponse) String() string {
 func (*DeleteEdgesResponse) ProtoMessage() {}
 
 func (x *DeleteEdgesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[40]
+	mi := &file_graph_v1_graph_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2719,7 +2841,7 @@ func (x *DeleteEdgesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEdgesResponse.ProtoReflect.Descriptor instead.
 func (*DeleteEdgesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{40}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *DeleteEdgesResponse) GetDeleted() int32 {
@@ -2751,7 +2873,7 @@ type AddEdgeRequest struct {
 
 func (x *AddEdgeRequest) Reset() {
 	*x = AddEdgeRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[41]
+	mi := &file_graph_v1_graph_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2763,7 +2885,7 @@ func (x *AddEdgeRequest) String() string {
 func (*AddEdgeRequest) ProtoMessage() {}
 
 func (x *AddEdgeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[41]
+	mi := &file_graph_v1_graph_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2776,7 +2898,7 @@ func (x *AddEdgeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddEdgeRequest.ProtoReflect.Descriptor instead.
 func (*AddEdgeRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{41}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *AddEdgeRequest) GetEdge() *Edge {
@@ -2801,7 +2923,7 @@ type AddEdgeResponse struct {
 
 func (x *AddEdgeResponse) Reset() {
 	*x = AddEdgeResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[42]
+	mi := &file_graph_v1_graph_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2813,7 +2935,7 @@ func (x *AddEdgeResponse) String() string {
 func (*AddEdgeResponse) ProtoMessage() {}
 
 func (x *AddEdgeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[42]
+	mi := &file_graph_v1_graph_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2826,7 +2948,7 @@ func (x *AddEdgeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddEdgeResponse.ProtoReflect.Descriptor instead.
 func (*AddEdgeResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{42}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{43}
 }
 
 // AddEdgesRequest accumulates weight onto each (tail, head) pair: repeated
@@ -2849,7 +2971,7 @@ type AddEdgesRequest struct {
 
 func (x *AddEdgesRequest) Reset() {
 	*x = AddEdgesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[43]
+	mi := &file_graph_v1_graph_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2861,7 +2983,7 @@ func (x *AddEdgesRequest) String() string {
 func (*AddEdgesRequest) ProtoMessage() {}
 
 func (x *AddEdgesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[43]
+	mi := &file_graph_v1_graph_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2874,7 +2996,7 @@ func (x *AddEdgesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddEdgesRequest.ProtoReflect.Descriptor instead.
 func (*AddEdgesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{43}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *AddEdgesRequest) GetEdges() []*Edge {
@@ -2901,7 +3023,7 @@ type AddEdgesResponse struct {
 
 func (x *AddEdgesResponse) Reset() {
 	*x = AddEdgesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[44]
+	mi := &file_graph_v1_graph_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2913,7 +3035,7 @@ func (x *AddEdgesResponse) String() string {
 func (*AddEdgesResponse) ProtoMessage() {}
 
 func (x *AddEdgesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[44]
+	mi := &file_graph_v1_graph_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2926,7 +3048,7 @@ func (x *AddEdgesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddEdgesResponse.ProtoReflect.Descriptor instead.
 func (*AddEdgesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{44}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *AddEdgesResponse) GetWritten() int32 {
@@ -2948,7 +3070,7 @@ type PutEdgeRequest struct {
 
 func (x *PutEdgeRequest) Reset() {
 	*x = PutEdgeRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[45]
+	mi := &file_graph_v1_graph_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2960,7 +3082,7 @@ func (x *PutEdgeRequest) String() string {
 func (*PutEdgeRequest) ProtoMessage() {}
 
 func (x *PutEdgeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[45]
+	mi := &file_graph_v1_graph_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2973,7 +3095,7 @@ func (x *PutEdgeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutEdgeRequest.ProtoReflect.Descriptor instead.
 func (*PutEdgeRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{45}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *PutEdgeRequest) GetEdge() *Edge {
@@ -2991,7 +3113,7 @@ type PutEdgeResponse struct {
 
 func (x *PutEdgeResponse) Reset() {
 	*x = PutEdgeResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[46]
+	mi := &file_graph_v1_graph_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3003,7 +3125,7 @@ func (x *PutEdgeResponse) String() string {
 func (*PutEdgeResponse) ProtoMessage() {}
 
 func (x *PutEdgeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[46]
+	mi := &file_graph_v1_graph_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3016,7 +3138,7 @@ func (x *PutEdgeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutEdgeResponse.ProtoReflect.Descriptor instead.
 func (*PutEdgeResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{46}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{47}
 }
 
 // PutEdgesRequest overwrites each (tail, head) pair, replacing any existing
@@ -3030,7 +3152,7 @@ type PutEdgesRequest struct {
 
 func (x *PutEdgesRequest) Reset() {
 	*x = PutEdgesRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[47]
+	mi := &file_graph_v1_graph_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3042,7 +3164,7 @@ func (x *PutEdgesRequest) String() string {
 func (*PutEdgesRequest) ProtoMessage() {}
 
 func (x *PutEdgesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[47]
+	mi := &file_graph_v1_graph_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3055,7 +3177,7 @@ func (x *PutEdgesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutEdgesRequest.ProtoReflect.Descriptor instead.
 func (*PutEdgesRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{47}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *PutEdgesRequest) GetEdges() []*Edge {
@@ -3075,7 +3197,7 @@ type PutEdgesResponse struct {
 
 func (x *PutEdgesResponse) Reset() {
 	*x = PutEdgesResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[48]
+	mi := &file_graph_v1_graph_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3087,7 +3209,7 @@ func (x *PutEdgesResponse) String() string {
 func (*PutEdgesResponse) ProtoMessage() {}
 
 func (x *PutEdgesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[48]
+	mi := &file_graph_v1_graph_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3100,7 +3222,7 @@ func (x *PutEdgesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutEdgesResponse.ProtoReflect.Descriptor instead.
 func (*PutEdgesResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{48}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *PutEdgesResponse) GetWritten() int32 {
@@ -3123,7 +3245,7 @@ type GetServerStatusRequest struct {
 
 func (x *GetServerStatusRequest) Reset() {
 	*x = GetServerStatusRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[49]
+	mi := &file_graph_v1_graph_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3135,7 +3257,7 @@ func (x *GetServerStatusRequest) String() string {
 func (*GetServerStatusRequest) ProtoMessage() {}
 
 func (x *GetServerStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[49]
+	mi := &file_graph_v1_graph_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3148,7 +3270,7 @@ func (x *GetServerStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetServerStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetServerStatusRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{49}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{50}
 }
 
 type GetServerStatusResponse struct {
@@ -3196,7 +3318,7 @@ type GetServerStatusResponse struct {
 
 func (x *GetServerStatusResponse) Reset() {
 	*x = GetServerStatusResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[50]
+	mi := &file_graph_v1_graph_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3208,7 +3330,7 @@ func (x *GetServerStatusResponse) String() string {
 func (*GetServerStatusResponse) ProtoMessage() {}
 
 func (x *GetServerStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[50]
+	mi := &file_graph_v1_graph_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3221,7 +3343,7 @@ func (x *GetServerStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetServerStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetServerStatusResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{50}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *GetServerStatusResponse) GetVersion() string {
@@ -3345,7 +3467,7 @@ type ReplicationPeer struct {
 
 func (x *ReplicationPeer) Reset() {
 	*x = ReplicationPeer{}
-	mi := &file_graph_v1_graph_proto_msgTypes[51]
+	mi := &file_graph_v1_graph_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3357,7 +3479,7 @@ func (x *ReplicationPeer) String() string {
 func (*ReplicationPeer) ProtoMessage() {}
 
 func (x *ReplicationPeer) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[51]
+	mi := &file_graph_v1_graph_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3370,7 +3492,7 @@ func (x *ReplicationPeer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplicationPeer.ProtoReflect.Descriptor instead.
 func (*ReplicationPeer) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{51}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *ReplicationPeer) GetAddress() string {
@@ -3418,7 +3540,7 @@ type GetReplicationStatusRequest struct {
 
 func (x *GetReplicationStatusRequest) Reset() {
 	*x = GetReplicationStatusRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[52]
+	mi := &file_graph_v1_graph_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3430,7 +3552,7 @@ func (x *GetReplicationStatusRequest) String() string {
 func (*GetReplicationStatusRequest) ProtoMessage() {}
 
 func (x *GetReplicationStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[52]
+	mi := &file_graph_v1_graph_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3443,7 +3565,7 @@ func (x *GetReplicationStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetReplicationStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetReplicationStatusRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{52}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{53}
 }
 
 type GetReplicationStatusResponse struct {
@@ -3471,7 +3593,7 @@ type GetReplicationStatusResponse struct {
 
 func (x *GetReplicationStatusResponse) Reset() {
 	*x = GetReplicationStatusResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[53]
+	mi := &file_graph_v1_graph_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3483,7 +3605,7 @@ func (x *GetReplicationStatusResponse) String() string {
 func (*GetReplicationStatusResponse) ProtoMessage() {}
 
 func (x *GetReplicationStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[53]
+	mi := &file_graph_v1_graph_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3496,7 +3618,7 @@ func (x *GetReplicationStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetReplicationStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetReplicationStatusResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{53}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *GetReplicationStatusResponse) GetNodeId() string {
@@ -3540,7 +3662,7 @@ type BackupSnapshotRequest struct {
 
 func (x *BackupSnapshotRequest) Reset() {
 	*x = BackupSnapshotRequest{}
-	mi := &file_graph_v1_graph_proto_msgTypes[54]
+	mi := &file_graph_v1_graph_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3552,7 +3674,7 @@ func (x *BackupSnapshotRequest) String() string {
 func (*BackupSnapshotRequest) ProtoMessage() {}
 
 func (x *BackupSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[54]
+	mi := &file_graph_v1_graph_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3565,7 +3687,7 @@ func (x *BackupSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackupSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*BackupSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{54}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *BackupSnapshotRequest) GetVertexPrefix() string {
@@ -3592,7 +3714,7 @@ type BackupSnapshotResponse struct {
 
 func (x *BackupSnapshotResponse) Reset() {
 	*x = BackupSnapshotResponse{}
-	mi := &file_graph_v1_graph_proto_msgTypes[55]
+	mi := &file_graph_v1_graph_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3604,7 +3726,7 @@ func (x *BackupSnapshotResponse) String() string {
 func (*BackupSnapshotResponse) ProtoMessage() {}
 
 func (x *BackupSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_graph_v1_graph_proto_msgTypes[55]
+	mi := &file_graph_v1_graph_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3617,7 +3739,7 @@ func (x *BackupSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackupSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*BackupSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_graph_v1_graph_proto_rawDescGZIP(), []int{55}
+	return file_graph_v1_graph_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *BackupSnapshotResponse) GetRecord() isBackupSnapshotResponse_Record {
@@ -3694,20 +3816,27 @@ const file_graph_v1_graph_proto_rawDesc = "" +
 	"expiration\"[\n" +
 	"\x05Graph\x12,\n" +
 	"\bvertices\x18\x01 \x03(\v2\x10.graph.v1.VertexR\bvertices\x12$\n" +
-	"\x05edges\x18\x02 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\"\xd6\x02\n" +
+	"\x05edges\x18\x02 \x03(\v2\x0e.graph.v1.EdgeR\x05edges\"\x96\x03\n" +
 	"\x11IlluminateRequest\x12\x12\n" +
 	"\x04seed\x18\x01 \x01(\tR\x04seed\x121\n" +
 	"\tweighting\x18\b \x01(\x0e2\x13.graph.v1.WeightingR\tweighting\x12#\n" +
 	"\rvertex_prefix\x18\t \x01(\tR\fvertexPrefix\x12'\n" +
 	"\x03bfs\x18\f \x01(\v2\x13.graph.v1.BfsParamsH\x00R\x03bfs\x12'\n" +
-	"\x03ppr\x18\r \x01(\v2\x13.graph.v1.PprParamsH\x00R\x03pprB\b\n" +
+	"\x03ppr\x18\r \x01(\v2\x13.graph.v1.PprParamsH\x00R\x03ppr\x12>\n" +
+	"\tcommunity\x18\x0e \x01(\v2\x1e.graph.v1.LocalCommunityParamsH\x00R\tcommunityB\b\n" +
 	"\x06paramsJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04J\x04\b\x04\x10\x05J\x04\b\x05\x10\x06J\x04\b\x06\x10\aJ\x04\b\a\x10\bJ\x04\b\n" +
 	"\x10\vJ\x04\b\v\x10\fR\x04stepR\x01kR\x05tfidfR\foptimizationR\talgorithmR\tobjectiveR\frestart_probR\aepsilon\"\x9e\x01\n" +
 	"\tBfsParams\x12\x12\n" +
 	"\x04step\x18\x01 \x01(\rR\x04step\x12\x17\n" +
 	"\afan_out\x18\x02 \x01(\rR\x06fanOut\x121\n" +
 	"\tobjective\x18\x03 \x01(\x0e2\x13.graph.v1.ObjectiveR\tobjective\x121\n" +
-	"\treduction\x18\x04 \x01(\x0e2\x13.graph.v1.ReductionR\treduction\"]\n" +
+	"\treduction\x18\x04 \x01(\x0e2\x13.graph.v1.ReductionR\treduction\"\xd4\x01\n" +
+	"\x14LocalCommunityParams\x12\x19\n" +
+	"\bmax_size\x18\x01 \x01(\rR\amaxSize\x12!\n" +
+	"\frestart_prob\x18\x02 \x01(\x02R\vrestartProb\x12\x18\n" +
+	"\aepsilon\x18\x03 \x01(\x02R\aepsilon\x121\n" +
+	"\treduction\x18\x04 \x01(\x0e2\x13.graph.v1.ReductionR\treduction\x121\n" +
+	"\tobjective\x18\x05 \x01(\x0e2\x13.graph.v1.ObjectiveR\tobjective\"]\n" +
 	"\tPprParams\x12\x13\n" +
 	"\x05top_n\x18\x01 \x01(\rR\x04topN\x12!\n" +
 	"\frestart_prob\x18\x02 \x01(\x02R\vrestartProb\x12\x18\n" +
@@ -3927,7 +4056,7 @@ func file_graph_v1_graph_proto_rawDescGZIP() []byte {
 }
 
 var file_graph_v1_graph_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_graph_v1_graph_proto_msgTypes = make([]protoimpl.MessageInfo, 56)
+var file_graph_v1_graph_proto_msgTypes = make([]protoimpl.MessageInfo, 57)
 var file_graph_v1_graph_proto_goTypes = []any{
 	(Reduction)(0),                         // 0: graph.v1.Reduction
 	(Objective)(0),                         // 1: graph.v1.Objective
@@ -3938,151 +4067,155 @@ var file_graph_v1_graph_proto_goTypes = []any{
 	(*Graph)(nil),                          // 6: graph.v1.Graph
 	(*IlluminateRequest)(nil),              // 7: graph.v1.IlluminateRequest
 	(*BfsParams)(nil),                      // 8: graph.v1.BfsParams
-	(*PprParams)(nil),                      // 9: graph.v1.PprParams
-	(*IlluminateResponse)(nil),             // 10: graph.v1.IlluminateResponse
-	(*GetVertexRequest)(nil),               // 11: graph.v1.GetVertexRequest
-	(*GetVertexResponse)(nil),              // 12: graph.v1.GetVertexResponse
-	(*GetVerticesRequest)(nil),             // 13: graph.v1.GetVerticesRequest
-	(*GetVerticesResponse)(nil),            // 14: graph.v1.GetVerticesResponse
-	(*PutVertexRequest)(nil),               // 15: graph.v1.PutVertexRequest
-	(*PutVertexResponse)(nil),              // 16: graph.v1.PutVertexResponse
-	(*PutVerticesRequest)(nil),             // 17: graph.v1.PutVerticesRequest
-	(*PutVerticesResponse)(nil),            // 18: graph.v1.PutVerticesResponse
-	(*DeleteVertexRequest)(nil),            // 19: graph.v1.DeleteVertexRequest
-	(*DeleteVertexResponse)(nil),           // 20: graph.v1.DeleteVertexResponse
-	(*DeleteVerticesRequest)(nil),          // 21: graph.v1.DeleteVerticesRequest
-	(*DeleteVerticesResponse)(nil),         // 22: graph.v1.DeleteVerticesResponse
-	(*ScanVerticesRequest)(nil),            // 23: graph.v1.ScanVerticesRequest
-	(*ScanVerticesResponse)(nil),           // 24: graph.v1.ScanVerticesResponse
-	(*ScanVertexKeysRequest)(nil),          // 25: graph.v1.ScanVertexKeysRequest
-	(*ScanVertexKeysResponse)(nil),         // 26: graph.v1.ScanVertexKeysResponse
-	(*SearchVerticesRequest)(nil),          // 27: graph.v1.SearchVerticesRequest
-	(*SearchVerticesResponse)(nil),         // 28: graph.v1.SearchVerticesResponse
-	(*SearchHit)(nil),                      // 29: graph.v1.SearchHit
-	(*CountVerticesByPrefixRequest)(nil),   // 30: graph.v1.CountVerticesByPrefixRequest
-	(*CountVerticesByPrefixResponse)(nil),  // 31: graph.v1.CountVerticesByPrefixResponse
-	(*DeleteVerticesByPrefixRequest)(nil),  // 32: graph.v1.DeleteVerticesByPrefixRequest
-	(*DeleteVerticesByPrefixResponse)(nil), // 33: graph.v1.DeleteVerticesByPrefixResponse
-	(*GetEdgeRequest)(nil),                 // 34: graph.v1.GetEdgeRequest
-	(*GetEdgeResponse)(nil),                // 35: graph.v1.GetEdgeResponse
-	(*GetEdgesRequest)(nil),                // 36: graph.v1.GetEdgesRequest
-	(*GetEdgesResponse)(nil),               // 37: graph.v1.GetEdgesResponse
-	(*DeleteEdgeRequest)(nil),              // 38: graph.v1.DeleteEdgeRequest
-	(*DeleteEdgeResponse)(nil),             // 39: graph.v1.DeleteEdgeResponse
-	(*EdgeKey)(nil),                        // 40: graph.v1.EdgeKey
-	(*ScanEdgesRequest)(nil),               // 41: graph.v1.ScanEdgesRequest
-	(*ScanEdgesResponse)(nil),              // 42: graph.v1.ScanEdgesResponse
-	(*DeleteEdgesRequest)(nil),             // 43: graph.v1.DeleteEdgesRequest
-	(*DeleteEdgesResponse)(nil),            // 44: graph.v1.DeleteEdgesResponse
-	(*AddEdgeRequest)(nil),                 // 45: graph.v1.AddEdgeRequest
-	(*AddEdgeResponse)(nil),                // 46: graph.v1.AddEdgeResponse
-	(*AddEdgesRequest)(nil),                // 47: graph.v1.AddEdgesRequest
-	(*AddEdgesResponse)(nil),               // 48: graph.v1.AddEdgesResponse
-	(*PutEdgeRequest)(nil),                 // 49: graph.v1.PutEdgeRequest
-	(*PutEdgeResponse)(nil),                // 50: graph.v1.PutEdgeResponse
-	(*PutEdgesRequest)(nil),                // 51: graph.v1.PutEdgesRequest
-	(*PutEdgesResponse)(nil),               // 52: graph.v1.PutEdgesResponse
-	(*GetServerStatusRequest)(nil),         // 53: graph.v1.GetServerStatusRequest
-	(*GetServerStatusResponse)(nil),        // 54: graph.v1.GetServerStatusResponse
-	(*ReplicationPeer)(nil),                // 55: graph.v1.ReplicationPeer
-	(*GetReplicationStatusRequest)(nil),    // 56: graph.v1.GetReplicationStatusRequest
-	(*GetReplicationStatusResponse)(nil),   // 57: graph.v1.GetReplicationStatusResponse
-	(*BackupSnapshotRequest)(nil),          // 58: graph.v1.BackupSnapshotRequest
-	(*BackupSnapshotResponse)(nil),         // 59: graph.v1.BackupSnapshotResponse
-	(*timestamppb.Timestamp)(nil),          // 60: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),            // 61: google.protobuf.Duration
+	(*LocalCommunityParams)(nil),           // 9: graph.v1.LocalCommunityParams
+	(*PprParams)(nil),                      // 10: graph.v1.PprParams
+	(*IlluminateResponse)(nil),             // 11: graph.v1.IlluminateResponse
+	(*GetVertexRequest)(nil),               // 12: graph.v1.GetVertexRequest
+	(*GetVertexResponse)(nil),              // 13: graph.v1.GetVertexResponse
+	(*GetVerticesRequest)(nil),             // 14: graph.v1.GetVerticesRequest
+	(*GetVerticesResponse)(nil),            // 15: graph.v1.GetVerticesResponse
+	(*PutVertexRequest)(nil),               // 16: graph.v1.PutVertexRequest
+	(*PutVertexResponse)(nil),              // 17: graph.v1.PutVertexResponse
+	(*PutVerticesRequest)(nil),             // 18: graph.v1.PutVerticesRequest
+	(*PutVerticesResponse)(nil),            // 19: graph.v1.PutVerticesResponse
+	(*DeleteVertexRequest)(nil),            // 20: graph.v1.DeleteVertexRequest
+	(*DeleteVertexResponse)(nil),           // 21: graph.v1.DeleteVertexResponse
+	(*DeleteVerticesRequest)(nil),          // 22: graph.v1.DeleteVerticesRequest
+	(*DeleteVerticesResponse)(nil),         // 23: graph.v1.DeleteVerticesResponse
+	(*ScanVerticesRequest)(nil),            // 24: graph.v1.ScanVerticesRequest
+	(*ScanVerticesResponse)(nil),           // 25: graph.v1.ScanVerticesResponse
+	(*ScanVertexKeysRequest)(nil),          // 26: graph.v1.ScanVertexKeysRequest
+	(*ScanVertexKeysResponse)(nil),         // 27: graph.v1.ScanVertexKeysResponse
+	(*SearchVerticesRequest)(nil),          // 28: graph.v1.SearchVerticesRequest
+	(*SearchVerticesResponse)(nil),         // 29: graph.v1.SearchVerticesResponse
+	(*SearchHit)(nil),                      // 30: graph.v1.SearchHit
+	(*CountVerticesByPrefixRequest)(nil),   // 31: graph.v1.CountVerticesByPrefixRequest
+	(*CountVerticesByPrefixResponse)(nil),  // 32: graph.v1.CountVerticesByPrefixResponse
+	(*DeleteVerticesByPrefixRequest)(nil),  // 33: graph.v1.DeleteVerticesByPrefixRequest
+	(*DeleteVerticesByPrefixResponse)(nil), // 34: graph.v1.DeleteVerticesByPrefixResponse
+	(*GetEdgeRequest)(nil),                 // 35: graph.v1.GetEdgeRequest
+	(*GetEdgeResponse)(nil),                // 36: graph.v1.GetEdgeResponse
+	(*GetEdgesRequest)(nil),                // 37: graph.v1.GetEdgesRequest
+	(*GetEdgesResponse)(nil),               // 38: graph.v1.GetEdgesResponse
+	(*DeleteEdgeRequest)(nil),              // 39: graph.v1.DeleteEdgeRequest
+	(*DeleteEdgeResponse)(nil),             // 40: graph.v1.DeleteEdgeResponse
+	(*EdgeKey)(nil),                        // 41: graph.v1.EdgeKey
+	(*ScanEdgesRequest)(nil),               // 42: graph.v1.ScanEdgesRequest
+	(*ScanEdgesResponse)(nil),              // 43: graph.v1.ScanEdgesResponse
+	(*DeleteEdgesRequest)(nil),             // 44: graph.v1.DeleteEdgesRequest
+	(*DeleteEdgesResponse)(nil),            // 45: graph.v1.DeleteEdgesResponse
+	(*AddEdgeRequest)(nil),                 // 46: graph.v1.AddEdgeRequest
+	(*AddEdgeResponse)(nil),                // 47: graph.v1.AddEdgeResponse
+	(*AddEdgesRequest)(nil),                // 48: graph.v1.AddEdgesRequest
+	(*AddEdgesResponse)(nil),               // 49: graph.v1.AddEdgesResponse
+	(*PutEdgeRequest)(nil),                 // 50: graph.v1.PutEdgeRequest
+	(*PutEdgeResponse)(nil),                // 51: graph.v1.PutEdgeResponse
+	(*PutEdgesRequest)(nil),                // 52: graph.v1.PutEdgesRequest
+	(*PutEdgesResponse)(nil),               // 53: graph.v1.PutEdgesResponse
+	(*GetServerStatusRequest)(nil),         // 54: graph.v1.GetServerStatusRequest
+	(*GetServerStatusResponse)(nil),        // 55: graph.v1.GetServerStatusResponse
+	(*ReplicationPeer)(nil),                // 56: graph.v1.ReplicationPeer
+	(*GetReplicationStatusRequest)(nil),    // 57: graph.v1.GetReplicationStatusRequest
+	(*GetReplicationStatusResponse)(nil),   // 58: graph.v1.GetReplicationStatusResponse
+	(*BackupSnapshotRequest)(nil),          // 59: graph.v1.BackupSnapshotRequest
+	(*BackupSnapshotResponse)(nil),         // 60: graph.v1.BackupSnapshotResponse
+	(*timestamppb.Timestamp)(nil),          // 61: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),            // 62: google.protobuf.Duration
 }
 var file_graph_v1_graph_proto_depIdxs = []int32{
-	60, // 0: graph.v1.Vertex.expiration:type_name -> google.protobuf.Timestamp
-	60, // 1: graph.v1.Vertex.timestamp:type_name -> google.protobuf.Timestamp
-	61, // 2: graph.v1.Vertex.duration:type_name -> google.protobuf.Duration
-	60, // 3: graph.v1.Edge.expiration:type_name -> google.protobuf.Timestamp
+	61, // 0: graph.v1.Vertex.expiration:type_name -> google.protobuf.Timestamp
+	61, // 1: graph.v1.Vertex.timestamp:type_name -> google.protobuf.Timestamp
+	62, // 2: graph.v1.Vertex.duration:type_name -> google.protobuf.Duration
+	61, // 3: graph.v1.Edge.expiration:type_name -> google.protobuf.Timestamp
 	4,  // 4: graph.v1.Graph.vertices:type_name -> graph.v1.Vertex
 	5,  // 5: graph.v1.Graph.edges:type_name -> graph.v1.Edge
 	2,  // 6: graph.v1.IlluminateRequest.weighting:type_name -> graph.v1.Weighting
 	8,  // 7: graph.v1.IlluminateRequest.bfs:type_name -> graph.v1.BfsParams
-	9,  // 8: graph.v1.IlluminateRequest.ppr:type_name -> graph.v1.PprParams
-	1,  // 9: graph.v1.BfsParams.objective:type_name -> graph.v1.Objective
-	0,  // 10: graph.v1.BfsParams.reduction:type_name -> graph.v1.Reduction
-	6,  // 11: graph.v1.IlluminateResponse.graph:type_name -> graph.v1.Graph
-	4,  // 12: graph.v1.GetVertexResponse.vertex:type_name -> graph.v1.Vertex
-	4,  // 13: graph.v1.GetVerticesResponse.vertices:type_name -> graph.v1.Vertex
-	4,  // 14: graph.v1.PutVertexRequest.vertex:type_name -> graph.v1.Vertex
-	4,  // 15: graph.v1.PutVerticesRequest.vertices:type_name -> graph.v1.Vertex
-	4,  // 16: graph.v1.ScanVerticesResponse.vertices:type_name -> graph.v1.Vertex
-	29, // 17: graph.v1.SearchVerticesResponse.hits:type_name -> graph.v1.SearchHit
-	5,  // 18: graph.v1.GetEdgeResponse.edge:type_name -> graph.v1.Edge
-	40, // 19: graph.v1.GetEdgesRequest.edges:type_name -> graph.v1.EdgeKey
-	5,  // 20: graph.v1.GetEdgesResponse.edges:type_name -> graph.v1.Edge
-	40, // 21: graph.v1.GetEdgesResponse.missing:type_name -> graph.v1.EdgeKey
-	5,  // 22: graph.v1.ScanEdgesResponse.edges:type_name -> graph.v1.Edge
-	40, // 23: graph.v1.DeleteEdgesRequest.edges:type_name -> graph.v1.EdgeKey
-	5,  // 24: graph.v1.AddEdgeRequest.edge:type_name -> graph.v1.Edge
-	5,  // 25: graph.v1.AddEdgesRequest.edges:type_name -> graph.v1.Edge
-	5,  // 26: graph.v1.PutEdgeRequest.edge:type_name -> graph.v1.Edge
-	5,  // 27: graph.v1.PutEdgesRequest.edges:type_name -> graph.v1.Edge
-	60, // 28: graph.v1.GetServerStatusResponse.started_at:type_name -> google.protobuf.Timestamp
-	61, // 29: graph.v1.GetServerStatusResponse.uptime:type_name -> google.protobuf.Duration
-	61, // 30: graph.v1.GetServerStatusResponse.default_ttl:type_name -> google.protobuf.Duration
-	3,  // 31: graph.v1.ReplicationPeer.state:type_name -> graph.v1.ReplicationPeer.State
-	60, // 32: graph.v1.ReplicationPeer.last_event_at:type_name -> google.protobuf.Timestamp
-	60, // 33: graph.v1.GetReplicationStatusResponse.local_now:type_name -> google.protobuf.Timestamp
-	55, // 34: graph.v1.GetReplicationStatusResponse.peers:type_name -> graph.v1.ReplicationPeer
-	4,  // 35: graph.v1.BackupSnapshotResponse.vertex:type_name -> graph.v1.Vertex
-	5,  // 36: graph.v1.BackupSnapshotResponse.edge:type_name -> graph.v1.Edge
-	7,  // 37: graph.v1.LanternService.Illuminate:input_type -> graph.v1.IlluminateRequest
-	11, // 38: graph.v1.LanternService.GetVertex:input_type -> graph.v1.GetVertexRequest
-	13, // 39: graph.v1.LanternService.GetVertices:input_type -> graph.v1.GetVerticesRequest
-	15, // 40: graph.v1.LanternService.PutVertex:input_type -> graph.v1.PutVertexRequest
-	17, // 41: graph.v1.LanternService.PutVertices:input_type -> graph.v1.PutVerticesRequest
-	19, // 42: graph.v1.LanternService.DeleteVertex:input_type -> graph.v1.DeleteVertexRequest
-	21, // 43: graph.v1.LanternService.DeleteVertices:input_type -> graph.v1.DeleteVerticesRequest
-	23, // 44: graph.v1.LanternService.ScanVertices:input_type -> graph.v1.ScanVerticesRequest
-	25, // 45: graph.v1.LanternService.ScanVertexKeys:input_type -> graph.v1.ScanVertexKeysRequest
-	27, // 46: graph.v1.LanternService.SearchVertices:input_type -> graph.v1.SearchVerticesRequest
-	30, // 47: graph.v1.LanternService.CountVerticesByPrefix:input_type -> graph.v1.CountVerticesByPrefixRequest
-	32, // 48: graph.v1.LanternService.DeleteVerticesByPrefix:input_type -> graph.v1.DeleteVerticesByPrefixRequest
-	34, // 49: graph.v1.LanternService.GetEdge:input_type -> graph.v1.GetEdgeRequest
-	36, // 50: graph.v1.LanternService.GetEdges:input_type -> graph.v1.GetEdgesRequest
-	45, // 51: graph.v1.LanternService.AddEdge:input_type -> graph.v1.AddEdgeRequest
-	47, // 52: graph.v1.LanternService.AddEdges:input_type -> graph.v1.AddEdgesRequest
-	49, // 53: graph.v1.LanternService.PutEdge:input_type -> graph.v1.PutEdgeRequest
-	51, // 54: graph.v1.LanternService.PutEdges:input_type -> graph.v1.PutEdgesRequest
-	38, // 55: graph.v1.LanternService.DeleteEdge:input_type -> graph.v1.DeleteEdgeRequest
-	43, // 56: graph.v1.LanternService.DeleteEdges:input_type -> graph.v1.DeleteEdgesRequest
-	41, // 57: graph.v1.LanternService.ScanEdges:input_type -> graph.v1.ScanEdgesRequest
-	53, // 58: graph.v1.LanternService.GetServerStatus:input_type -> graph.v1.GetServerStatusRequest
-	56, // 59: graph.v1.LanternService.GetReplicationStatus:input_type -> graph.v1.GetReplicationStatusRequest
-	58, // 60: graph.v1.LanternService.BackupSnapshot:input_type -> graph.v1.BackupSnapshotRequest
-	10, // 61: graph.v1.LanternService.Illuminate:output_type -> graph.v1.IlluminateResponse
-	12, // 62: graph.v1.LanternService.GetVertex:output_type -> graph.v1.GetVertexResponse
-	14, // 63: graph.v1.LanternService.GetVertices:output_type -> graph.v1.GetVerticesResponse
-	16, // 64: graph.v1.LanternService.PutVertex:output_type -> graph.v1.PutVertexResponse
-	18, // 65: graph.v1.LanternService.PutVertices:output_type -> graph.v1.PutVerticesResponse
-	20, // 66: graph.v1.LanternService.DeleteVertex:output_type -> graph.v1.DeleteVertexResponse
-	22, // 67: graph.v1.LanternService.DeleteVertices:output_type -> graph.v1.DeleteVerticesResponse
-	24, // 68: graph.v1.LanternService.ScanVertices:output_type -> graph.v1.ScanVerticesResponse
-	26, // 69: graph.v1.LanternService.ScanVertexKeys:output_type -> graph.v1.ScanVertexKeysResponse
-	28, // 70: graph.v1.LanternService.SearchVertices:output_type -> graph.v1.SearchVerticesResponse
-	31, // 71: graph.v1.LanternService.CountVerticesByPrefix:output_type -> graph.v1.CountVerticesByPrefixResponse
-	33, // 72: graph.v1.LanternService.DeleteVerticesByPrefix:output_type -> graph.v1.DeleteVerticesByPrefixResponse
-	35, // 73: graph.v1.LanternService.GetEdge:output_type -> graph.v1.GetEdgeResponse
-	37, // 74: graph.v1.LanternService.GetEdges:output_type -> graph.v1.GetEdgesResponse
-	46, // 75: graph.v1.LanternService.AddEdge:output_type -> graph.v1.AddEdgeResponse
-	48, // 76: graph.v1.LanternService.AddEdges:output_type -> graph.v1.AddEdgesResponse
-	50, // 77: graph.v1.LanternService.PutEdge:output_type -> graph.v1.PutEdgeResponse
-	52, // 78: graph.v1.LanternService.PutEdges:output_type -> graph.v1.PutEdgesResponse
-	39, // 79: graph.v1.LanternService.DeleteEdge:output_type -> graph.v1.DeleteEdgeResponse
-	44, // 80: graph.v1.LanternService.DeleteEdges:output_type -> graph.v1.DeleteEdgesResponse
-	42, // 81: graph.v1.LanternService.ScanEdges:output_type -> graph.v1.ScanEdgesResponse
-	54, // 82: graph.v1.LanternService.GetServerStatus:output_type -> graph.v1.GetServerStatusResponse
-	57, // 83: graph.v1.LanternService.GetReplicationStatus:output_type -> graph.v1.GetReplicationStatusResponse
-	59, // 84: graph.v1.LanternService.BackupSnapshot:output_type -> graph.v1.BackupSnapshotResponse
-	61, // [61:85] is the sub-list for method output_type
-	37, // [37:61] is the sub-list for method input_type
-	37, // [37:37] is the sub-list for extension type_name
-	37, // [37:37] is the sub-list for extension extendee
-	0,  // [0:37] is the sub-list for field type_name
+	10, // 8: graph.v1.IlluminateRequest.ppr:type_name -> graph.v1.PprParams
+	9,  // 9: graph.v1.IlluminateRequest.community:type_name -> graph.v1.LocalCommunityParams
+	1,  // 10: graph.v1.BfsParams.objective:type_name -> graph.v1.Objective
+	0,  // 11: graph.v1.BfsParams.reduction:type_name -> graph.v1.Reduction
+	0,  // 12: graph.v1.LocalCommunityParams.reduction:type_name -> graph.v1.Reduction
+	1,  // 13: graph.v1.LocalCommunityParams.objective:type_name -> graph.v1.Objective
+	6,  // 14: graph.v1.IlluminateResponse.graph:type_name -> graph.v1.Graph
+	4,  // 15: graph.v1.GetVertexResponse.vertex:type_name -> graph.v1.Vertex
+	4,  // 16: graph.v1.GetVerticesResponse.vertices:type_name -> graph.v1.Vertex
+	4,  // 17: graph.v1.PutVertexRequest.vertex:type_name -> graph.v1.Vertex
+	4,  // 18: graph.v1.PutVerticesRequest.vertices:type_name -> graph.v1.Vertex
+	4,  // 19: graph.v1.ScanVerticesResponse.vertices:type_name -> graph.v1.Vertex
+	30, // 20: graph.v1.SearchVerticesResponse.hits:type_name -> graph.v1.SearchHit
+	5,  // 21: graph.v1.GetEdgeResponse.edge:type_name -> graph.v1.Edge
+	41, // 22: graph.v1.GetEdgesRequest.edges:type_name -> graph.v1.EdgeKey
+	5,  // 23: graph.v1.GetEdgesResponse.edges:type_name -> graph.v1.Edge
+	41, // 24: graph.v1.GetEdgesResponse.missing:type_name -> graph.v1.EdgeKey
+	5,  // 25: graph.v1.ScanEdgesResponse.edges:type_name -> graph.v1.Edge
+	41, // 26: graph.v1.DeleteEdgesRequest.edges:type_name -> graph.v1.EdgeKey
+	5,  // 27: graph.v1.AddEdgeRequest.edge:type_name -> graph.v1.Edge
+	5,  // 28: graph.v1.AddEdgesRequest.edges:type_name -> graph.v1.Edge
+	5,  // 29: graph.v1.PutEdgeRequest.edge:type_name -> graph.v1.Edge
+	5,  // 30: graph.v1.PutEdgesRequest.edges:type_name -> graph.v1.Edge
+	61, // 31: graph.v1.GetServerStatusResponse.started_at:type_name -> google.protobuf.Timestamp
+	62, // 32: graph.v1.GetServerStatusResponse.uptime:type_name -> google.protobuf.Duration
+	62, // 33: graph.v1.GetServerStatusResponse.default_ttl:type_name -> google.protobuf.Duration
+	3,  // 34: graph.v1.ReplicationPeer.state:type_name -> graph.v1.ReplicationPeer.State
+	61, // 35: graph.v1.ReplicationPeer.last_event_at:type_name -> google.protobuf.Timestamp
+	61, // 36: graph.v1.GetReplicationStatusResponse.local_now:type_name -> google.protobuf.Timestamp
+	56, // 37: graph.v1.GetReplicationStatusResponse.peers:type_name -> graph.v1.ReplicationPeer
+	4,  // 38: graph.v1.BackupSnapshotResponse.vertex:type_name -> graph.v1.Vertex
+	5,  // 39: graph.v1.BackupSnapshotResponse.edge:type_name -> graph.v1.Edge
+	7,  // 40: graph.v1.LanternService.Illuminate:input_type -> graph.v1.IlluminateRequest
+	12, // 41: graph.v1.LanternService.GetVertex:input_type -> graph.v1.GetVertexRequest
+	14, // 42: graph.v1.LanternService.GetVertices:input_type -> graph.v1.GetVerticesRequest
+	16, // 43: graph.v1.LanternService.PutVertex:input_type -> graph.v1.PutVertexRequest
+	18, // 44: graph.v1.LanternService.PutVertices:input_type -> graph.v1.PutVerticesRequest
+	20, // 45: graph.v1.LanternService.DeleteVertex:input_type -> graph.v1.DeleteVertexRequest
+	22, // 46: graph.v1.LanternService.DeleteVertices:input_type -> graph.v1.DeleteVerticesRequest
+	24, // 47: graph.v1.LanternService.ScanVertices:input_type -> graph.v1.ScanVerticesRequest
+	26, // 48: graph.v1.LanternService.ScanVertexKeys:input_type -> graph.v1.ScanVertexKeysRequest
+	28, // 49: graph.v1.LanternService.SearchVertices:input_type -> graph.v1.SearchVerticesRequest
+	31, // 50: graph.v1.LanternService.CountVerticesByPrefix:input_type -> graph.v1.CountVerticesByPrefixRequest
+	33, // 51: graph.v1.LanternService.DeleteVerticesByPrefix:input_type -> graph.v1.DeleteVerticesByPrefixRequest
+	35, // 52: graph.v1.LanternService.GetEdge:input_type -> graph.v1.GetEdgeRequest
+	37, // 53: graph.v1.LanternService.GetEdges:input_type -> graph.v1.GetEdgesRequest
+	46, // 54: graph.v1.LanternService.AddEdge:input_type -> graph.v1.AddEdgeRequest
+	48, // 55: graph.v1.LanternService.AddEdges:input_type -> graph.v1.AddEdgesRequest
+	50, // 56: graph.v1.LanternService.PutEdge:input_type -> graph.v1.PutEdgeRequest
+	52, // 57: graph.v1.LanternService.PutEdges:input_type -> graph.v1.PutEdgesRequest
+	39, // 58: graph.v1.LanternService.DeleteEdge:input_type -> graph.v1.DeleteEdgeRequest
+	44, // 59: graph.v1.LanternService.DeleteEdges:input_type -> graph.v1.DeleteEdgesRequest
+	42, // 60: graph.v1.LanternService.ScanEdges:input_type -> graph.v1.ScanEdgesRequest
+	54, // 61: graph.v1.LanternService.GetServerStatus:input_type -> graph.v1.GetServerStatusRequest
+	57, // 62: graph.v1.LanternService.GetReplicationStatus:input_type -> graph.v1.GetReplicationStatusRequest
+	59, // 63: graph.v1.LanternService.BackupSnapshot:input_type -> graph.v1.BackupSnapshotRequest
+	11, // 64: graph.v1.LanternService.Illuminate:output_type -> graph.v1.IlluminateResponse
+	13, // 65: graph.v1.LanternService.GetVertex:output_type -> graph.v1.GetVertexResponse
+	15, // 66: graph.v1.LanternService.GetVertices:output_type -> graph.v1.GetVerticesResponse
+	17, // 67: graph.v1.LanternService.PutVertex:output_type -> graph.v1.PutVertexResponse
+	19, // 68: graph.v1.LanternService.PutVertices:output_type -> graph.v1.PutVerticesResponse
+	21, // 69: graph.v1.LanternService.DeleteVertex:output_type -> graph.v1.DeleteVertexResponse
+	23, // 70: graph.v1.LanternService.DeleteVertices:output_type -> graph.v1.DeleteVerticesResponse
+	25, // 71: graph.v1.LanternService.ScanVertices:output_type -> graph.v1.ScanVerticesResponse
+	27, // 72: graph.v1.LanternService.ScanVertexKeys:output_type -> graph.v1.ScanVertexKeysResponse
+	29, // 73: graph.v1.LanternService.SearchVertices:output_type -> graph.v1.SearchVerticesResponse
+	32, // 74: graph.v1.LanternService.CountVerticesByPrefix:output_type -> graph.v1.CountVerticesByPrefixResponse
+	34, // 75: graph.v1.LanternService.DeleteVerticesByPrefix:output_type -> graph.v1.DeleteVerticesByPrefixResponse
+	36, // 76: graph.v1.LanternService.GetEdge:output_type -> graph.v1.GetEdgeResponse
+	38, // 77: graph.v1.LanternService.GetEdges:output_type -> graph.v1.GetEdgesResponse
+	47, // 78: graph.v1.LanternService.AddEdge:output_type -> graph.v1.AddEdgeResponse
+	49, // 79: graph.v1.LanternService.AddEdges:output_type -> graph.v1.AddEdgesResponse
+	51, // 80: graph.v1.LanternService.PutEdge:output_type -> graph.v1.PutEdgeResponse
+	53, // 81: graph.v1.LanternService.PutEdges:output_type -> graph.v1.PutEdgesResponse
+	40, // 82: graph.v1.LanternService.DeleteEdge:output_type -> graph.v1.DeleteEdgeResponse
+	45, // 83: graph.v1.LanternService.DeleteEdges:output_type -> graph.v1.DeleteEdgesResponse
+	43, // 84: graph.v1.LanternService.ScanEdges:output_type -> graph.v1.ScanEdgesResponse
+	55, // 85: graph.v1.LanternService.GetServerStatus:output_type -> graph.v1.GetServerStatusResponse
+	58, // 86: graph.v1.LanternService.GetReplicationStatus:output_type -> graph.v1.GetReplicationStatusResponse
+	60, // 87: graph.v1.LanternService.BackupSnapshot:output_type -> graph.v1.BackupSnapshotResponse
+	64, // [64:88] is the sub-list for method output_type
+	40, // [40:64] is the sub-list for method input_type
+	40, // [40:40] is the sub-list for extension type_name
+	40, // [40:40] is the sub-list for extension extendee
+	0,  // [0:40] is the sub-list for field type_name
 }
 
 func init() { file_graph_v1_graph_proto_init() }
@@ -4107,8 +4240,9 @@ func file_graph_v1_graph_proto_init() {
 	file_graph_v1_graph_proto_msgTypes[3].OneofWrappers = []any{
 		(*IlluminateRequest_Bfs)(nil),
 		(*IlluminateRequest_Ppr)(nil),
+		(*IlluminateRequest_Community)(nil),
 	}
-	file_graph_v1_graph_proto_msgTypes[55].OneofWrappers = []any{
+	file_graph_v1_graph_proto_msgTypes[56].OneofWrappers = []any{
 		(*BackupSnapshotResponse_Vertex)(nil),
 		(*BackupSnapshotResponse_Edge)(nil),
 	}
@@ -4118,7 +4252,7 @@ func file_graph_v1_graph_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_graph_v1_graph_proto_rawDesc), len(file_graph_v1_graph_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   56,
+			NumMessages:   57,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -106,6 +106,7 @@ message IlluminateRequest {
   oneof params {
     BfsParams bfs = 12;
     PprParams ppr = 13;
+    LocalCommunityParams community = 14;
   }
   // Field numbers 4/5 ("tfidf", "optimization") were retired by the
   // orthogonal-axes redesign (#410); 2/3/6/7/10/11 ("step", "k",
@@ -133,6 +134,44 @@ message BfsParams {
   // reduction optionally reduces the discovered neighbourhood to a tree
   // rooted at the seed. UNSPECIFIED = no reduction (raw subgraph).
   Reduction reduction = 4;
+}
+
+// LocalCommunityParams extracts the conductance-optimal local community
+// around the seed (#845): PageRank-Nibble — the same ACL forward-push the
+// PPR family runs, followed by a sweep cut that orders touched vertices by
+// p(v)/deg(v) and takes the prefix minimising directed weighted
+// conductance. Unlike the PPR relevance star, the response preserves
+// structure: it is the INDUCED SUBGRAPH on the selected members — the real
+// live edges among them with actual stored weights and expirations, in the
+// same response shape as the BFS family.
+message LocalCommunityParams {
+  // max_size is an UPPER BOUND on community size — NOT an exact count. The
+  // sweep stops at the conductance minimum, which may come before max_size.
+  // 0 = unbounded (the sweep alone decides). (The PPR family's top_n by
+  // contrast always returns exactly N regardless of the natural boundary.)
+  uint32 max_size = 1;
+  // restart_prob (α) — locality knob, same semantics and defaults as
+  // PprParams.restart_prob: higher α → tighter, more seed-proximate
+  // community. Honoured only in (0,1); unset falls back to 0.15.
+  float restart_prob = 2;
+  // epsilon (ε) — push accuracy / work budget, same semantics and defaults
+  // as PprParams.epsilon: smaller ε → more accurate mass and a larger
+  // touched set. Honoured only when > 0; unset falls back to 1e-4.
+  float epsilon = 3;
+  // reduction optionally reduces the community to a tree VIEW rooted at the
+  // seed (for visualization, explanation paths, token-bounded consumption).
+  // The induced subgraph stays the source of truth — density is exactly
+  // what the sweep selected for. Sweep prefixes need not be connected, so
+  // the tree spans only the seed's reachable component within the
+  // community; unreachable members are still returned as ISOLATED vertices
+  // (membership preserved, no edges fabricated). UNSPECIFIED = the full
+  // induced subgraph (the default).
+  Reduction reduction = 4;
+  // objective sets the direction/cost mapping for the reduction ONLY
+  // (membership is decided by PPR mass, not by this): MINIMIZE → identity
+  // cost, MAXIMIZE/UNSPECIFIED → inverse cost, exactly as the BFS family.
+  // Ignored when reduction is UNSPECIFIED.
+  Objective objective = 5;
 }
 
 // PprParams runs seed-anchored Personalized PageRank (Random-Walk-with-

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -614,6 +614,7 @@ type illuminateConfig struct {
 	vertexPrefix string
 	bfs          *BFSOpts
 	ppr          *PPROpts
+	community    *LocalCommunityOpts
 }
 
 // BFSOpts tunes the greedy per-hop top-k BFS walk and its optional
@@ -654,16 +655,50 @@ type PPROpts struct {
 	Epsilon float32
 }
 
+// LocalCommunityOpts extracts the conductance-optimal local community
+// around the seed (#845): PageRank-Nibble — the PPR forward-push followed
+// by a sweep cut. Unlike WithPPR's relevance star, the response preserves
+// structure: it is the induced subgraph on the selected members, with
+// actual stored edge weights and expirations.
+type LocalCommunityOpts struct {
+	// MaxSize is an UPPER BOUND on community size — not an exact count.
+	// The sweep stops at the conductance minimum, which may come earlier.
+	// 0 = unbounded (the sweep alone decides).
+	MaxSize uint32
+	// RestartProb is the locality knob α, same semantics/defaults as
+	// PPROpts.RestartProb.
+	RestartProb float32
+	// Epsilon is the push accuracy/work budget ε, same semantics/defaults
+	// as PPROpts.Epsilon.
+	Epsilon float32
+	// Reduction optionally renders a tree VIEW of the community rooted at
+	// the seed. Members unreachable from the seed within the community are
+	// returned as isolated vertices (membership preserved). ReductionNone
+	// (default) returns the full induced subgraph.
+	Reduction Reduction
+	// Objective sets the direction/cost mapping for the Reduction only;
+	// ignored when Reduction is ReductionNone.
+	Objective Objective
+}
+
 // WithBFS selects the BFS traversal family with the supplied knobs.
-// Mutually exclusive with WithPPR (last option wins).
+// Mutually exclusive with the other family options (last option wins).
 func WithBFS(o BFSOpts) IlluminateOption {
-	return func(c *illuminateConfig) { c.bfs, c.ppr = &o, nil }
+	return func(c *illuminateConfig) { c.bfs, c.ppr, c.community = &o, nil, nil }
 }
 
 // WithPPR selects the Personalized PageRank traversal family with the
-// supplied knobs. Mutually exclusive with WithBFS (last option wins).
+// supplied knobs. Mutually exclusive with the other family options (last
+// option wins).
 func WithPPR(o PPROpts) IlluminateOption {
-	return func(c *illuminateConfig) { c.ppr, c.bfs = &o, nil }
+	return func(c *illuminateConfig) { c.ppr, c.bfs, c.community = &o, nil, nil }
+}
+
+// WithLocalCommunity selects the local community extraction family (#845)
+// with the supplied knobs. Mutually exclusive with the other family options
+// (last option wins).
+func WithLocalCommunity(o LocalCommunityOpts) IlluminateOption {
+	return func(c *illuminateConfig) { c.community, c.bfs, c.ppr = &o, nil, nil }
 }
 
 // WithWeighting toggles the edge-weight transform applied BEFORE the
@@ -707,6 +742,14 @@ func (l *Lantern) Illuminate(ctx context.Context, seed string, opts ...Illuminat
 		VertexPrefix: cfg.vertexPrefix,
 	}
 	switch {
+	case cfg.community != nil:
+		req.Params = &pb.IlluminateRequest_Community{Community: &pb.LocalCommunityParams{
+			MaxSize:     cfg.community.MaxSize,
+			RestartProb: cfg.community.RestartProb,
+			Epsilon:     cfg.community.Epsilon,
+			Reduction:   cfg.community.Reduction,
+			Objective:   cfg.community.Objective,
+		}}
 	case cfg.ppr != nil:
 		req.Params = &pb.IlluminateRequest_Ppr{Ppr: &pb.PprParams{
 			TopN:        cfg.ppr.TopN,

--- a/sdks/node/src/client.ts
+++ b/sdks/node/src/client.ts
@@ -563,36 +563,52 @@ export class Lantern {
     signal?: AbortSignal,
   ): Promise<Graph> {
     if (!seed) throw new InvalidArgumentError("illuminate: seed is required");
-    if (opts.bfs && opts.ppr) {
+    const families = [opts.bfs, opts.ppr, opts.community].filter((f) => f !== undefined).length;
+    if (families > 1) {
       throw new InvalidArgumentError(
-        "illuminate: bfs and ppr are mutually exclusive (the traversal family is a wire oneof)",
+        "illuminate: bfs, ppr and community are mutually exclusive (the traversal family is a wire oneof)",
       );
     }
     return this.invoke(async () => {
-      const params = opts.ppr
+      const params = opts.community
         ? ({
-            case: "ppr" as const,
+            case: "community" as const,
             value: {
-              topN: opts.ppr.topN ?? 0,
-              restartProb: opts.ppr.restartProb ?? 0,
-              epsilon: opts.ppr.epsilon ?? 0,
+              maxSize: opts.community.maxSize ?? 0,
+              restartProb: opts.community.restartProb ?? 0,
+              epsilon: opts.community.epsilon ?? 0,
+              reduction:
+                REDUCTION_TO_PB[opts.community.reduction ?? Reduction.UNSPECIFIED] ??
+                PbReduction.UNSPECIFIED,
+              objective:
+                OBJECTIVE_TO_PB[opts.community.objective ?? Objective.UNSPECIFIED] ??
+                PbObjective.UNSPECIFIED,
             },
           } as const)
-        : opts.bfs
+        : opts.ppr
           ? ({
-              case: "bfs" as const,
+              case: "ppr" as const,
               value: {
-                step: opts.bfs.step ?? 0,
-                fanOut: opts.bfs.fanOut ?? 0,
-                objective:
-                  OBJECTIVE_TO_PB[opts.bfs.objective ?? Objective.UNSPECIFIED] ??
-                  PbObjective.UNSPECIFIED,
-                reduction:
-                  REDUCTION_TO_PB[opts.bfs.reduction ?? Reduction.UNSPECIFIED] ??
-                  PbReduction.UNSPECIFIED,
+                topN: opts.ppr.topN ?? 0,
+                restartProb: opts.ppr.restartProb ?? 0,
+                epsilon: opts.ppr.epsilon ?? 0,
               },
             } as const)
-          : undefined;
+          : opts.bfs
+            ? ({
+                case: "bfs" as const,
+                value: {
+                  step: opts.bfs.step ?? 0,
+                  fanOut: opts.bfs.fanOut ?? 0,
+                  objective:
+                    OBJECTIVE_TO_PB[opts.bfs.objective ?? Objective.UNSPECIFIED] ??
+                    PbObjective.UNSPECIFIED,
+                  reduction:
+                    REDUCTION_TO_PB[opts.bfs.reduction ?? Reduction.UNSPECIFIED] ??
+                    PbReduction.UNSPECIFIED,
+                },
+              } as const)
+            : undefined;
       const resp = await this.client.illuminate(
         {
           seed,

--- a/sdks/node/src/gen/graph/v1/graph_pb.ts
+++ b/sdks/node/src/gen/graph/v1/graph_pb.ts
@@ -12,7 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file graph/v1/graph.proto.
  */
 export const file_graph_v1_graph: GenFile = /*@__PURE__*/
-  fileDesc("ChRncmFwaC92MS9ncmFwaC5wcm90bxIIZ3JhcGgudjEi3AIKBlZlcnRleBILCgNrZXkYASABKAkSLgoKZXhwaXJhdGlvbhgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASEQoHZmxvYXQ2NBgKIAEoAUgAEhEKB2Zsb2F0MzIYCyABKAJIABIPCgVpbnQzMhgMIAEoBUgAEg8KBWludDY0GA0gASgDSAASEAoGdWludDMyGA4gASgNSAASEAoGdWludDY0GA8gASgESAASDgoEYm9vbBgQIAEoCEgAEhAKBnN0cmluZxgRIAEoCUgAEg8KBWJ5dGVzGBIgASgMSAASLwoJdGltZXN0YW1wGBMgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcEgAEi0KCGR1cmF0aW9uGBQgASgLMhkuZ29vZ2xlLnByb3RvYnVmLkR1cmF0aW9uSAASDQoDbmlsGB4gASgISABCBwoFdmFsdWUiYgoERWRnZRIMCgR0YWlsGAEgASgJEgwKBGhlYWQYAiABKAkSDgoGd2VpZ2h0GAMgASgCEi4KCmV4cGlyYXRpb24YBCABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wIkoKBUdyYXBoEiIKCHZlcnRpY2VzGAEgAygLMhAuZ3JhcGgudjEuVmVydGV4Eh0KBWVkZ2VzGAIgAygLMg4uZ3JhcGgudjEuRWRnZSKtAgoRSWxsdW1pbmF0ZVJlcXVlc3QSDAoEc2VlZBgBIAEoCRImCgl3ZWlnaHRpbmcYCCABKA4yEy5ncmFwaC52MS5XZWlnaHRpbmcSFQoNdmVydGV4X3ByZWZpeBgJIAEoCRIiCgNiZnMYDCABKAsyEy5ncmFwaC52MS5CZnNQYXJhbXNIABIiCgNwcHIYDSABKAsyEy5ncmFwaC52MS5QcHJQYXJhbXNIAEIICgZwYXJhbXNKBAgCEANKBAgDEARKBAgEEAVKBAgFEAZKBAgGEAdKBAgHEAhKBAgKEAtKBAgLEAxSBHN0ZXBSAWtSBXRmaWRmUgxvcHRpbWl6YXRpb25SCWFsZ29yaXRobVIJb2JqZWN0aXZlUgxyZXN0YXJ0X3Byb2JSB2Vwc2lsb24iegoJQmZzUGFyYW1zEgwKBHN0ZXAYASABKA0SDwoHZmFuX291dBgCIAEoDRImCglvYmplY3RpdmUYAyABKA4yEy5ncmFwaC52MS5PYmplY3RpdmUSJgoJcmVkdWN0aW9uGAQgASgOMhMuZ3JhcGgudjEuUmVkdWN0aW9uIkEKCVBwclBhcmFtcxINCgV0b3BfbhgBIAEoDRIUCgxyZXN0YXJ0X3Byb2IYAiABKAISDwoHZXBzaWxvbhgDIAEoAiI0ChJJbGx1bWluYXRlUmVzcG9uc2USHgoFZ3JhcGgYASABKAsyDy5ncmFwaC52MS5HcmFwaCIfChBHZXRWZXJ0ZXhSZXF1ZXN0EgsKA2tleRgBIAEoCSI1ChFHZXRWZXJ0ZXhSZXNwb25zZRIgCgZ2ZXJ0ZXgYASABKAsyEC5ncmFwaC52MS5WZXJ0ZXgiIgoSR2V0VmVydGljZXNSZXF1ZXN0EgwKBGtleXMYASADKAkiSgoTR2V0VmVydGljZXNSZXNwb25zZRIiCgh2ZXJ0aWNlcxgBIAMoCzIQLmdyYXBoLnYxLlZlcnRleBIPCgdtaXNzaW5nGAIgAygJIjQKEFB1dFZlcnRleFJlcXVlc3QSIAoGdmVydGV4GAEgASgLMhAuZ3JhcGgudjEuVmVydGV4IhMKEVB1dFZlcnRleFJlc3BvbnNlIjgKElB1dFZlcnRpY2VzUmVxdWVzdBIiCgh2ZXJ0aWNlcxgBIAMoCzIQLmdyYXBoLnYxLlZlcnRleCImChNQdXRWZXJ0aWNlc1Jlc3BvbnNlEg8KB3dyaXR0ZW4YASABKAUiIgoTRGVsZXRlVmVydGV4UmVxdWVzdBILCgNrZXkYASABKAkiJwoURGVsZXRlVmVydGV4UmVzcG9uc2USDwoHZXhpc3RlZBgBIAEoCCIlChVEZWxldGVWZXJ0aWNlc1JlcXVlc3QSDAoEa2V5cxgBIAMoCSIpChZEZWxldGVWZXJ0aWNlc1Jlc3BvbnNlEg8KB2RlbGV0ZWQYASABKAUiRAoTU2NhblZlcnRpY2VzUmVxdWVzdBIOCgZwcmVmaXgYASABKAkSDQoFbGltaXQYAiABKA0SDgoGY3Vyc29yGAMgASgMIk8KFFNjYW5WZXJ0aWNlc1Jlc3BvbnNlEiIKCHZlcnRpY2VzGAEgAygLMhAuZ3JhcGgudjEuVmVydGV4EhMKC25leHRfY3Vyc29yGAIgASgMIkYKFVNjYW5WZXJ0ZXhLZXlzUmVxdWVzdBIOCgZwcmVmaXgYASABKAkSDQoFbGltaXQYAiABKA0SDgoGY3Vyc29yGAMgASgMIjsKFlNjYW5WZXJ0ZXhLZXlzUmVzcG9uc2USDAoEa2V5cxgBIAMoCRITCgtuZXh0X2N1cnNvchgCIAEoDCJFChVTZWFyY2hWZXJ0aWNlc1JlcXVlc3QSDQoFcXVlcnkYASABKAkSDQoFbGltaXQYAiABKA0SDgoGcHJlZml4GAMgASgJIjsKFlNlYXJjaFZlcnRpY2VzUmVzcG9uc2USIQoEaGl0cxgBIAMoCzITLmdyYXBoLnYxLlNlYXJjaEhpdCInCglTZWFyY2hIaXQSCwoDa2V5GAEgASgJEg0KBXNjb3JlGAIgASgBIi4KHENvdW50VmVydGljZXNCeVByZWZpeFJlcXVlc3QSDgoGcHJlZml4GAEgASgJIi4KHUNvdW50VmVydGljZXNCeVByZWZpeFJlc3BvbnNlEg0KBWNvdW50GAEgASgEIk8KHURlbGV0ZVZlcnRpY2VzQnlQcmVmaXhSZXF1ZXN0Eg4KBnByZWZpeBgBIAEoCRINCgVsaW1pdBgCIAEoDRIPCgdkcnlfcnVuGAMgASgIIjEKHkRlbGV0ZVZlcnRpY2VzQnlQcmVmaXhSZXNwb25zZRIPCgdkZWxldGVkGAEgASgEIiwKDkdldEVkZ2VSZXF1ZXN0EgwKBHRhaWwYASABKAkSDAoEaGVhZBgCIAEoCSIvCg9HZXRFZGdlUmVzcG9uc2USHAoEZWRnZRgBIAEoCzIOLmdyYXBoLnYxLkVkZ2UiMwoPR2V0RWRnZXNSZXF1ZXN0EiAKBWVkZ2VzGAEgAygLMhEuZ3JhcGgudjEuRWRnZUtleSJVChBHZXRFZGdlc1Jlc3BvbnNlEh0KBWVkZ2VzGAEgAygLMg4uZ3JhcGgudjEuRWRnZRIiCgdtaXNzaW5nGAIgAygLMhEuZ3JhcGgudjEuRWRnZUtleSIvChFEZWxldGVFZGdlUmVxdWVzdBIMCgR0YWlsGAEgASgJEgwKBGhlYWQYAiABKAkiJQoSRGVsZXRlRWRnZVJlc3BvbnNlEg8KB2V4aXN0ZWQYASABKAgiJQoHRWRnZUtleRIMCgR0YWlsGAEgASgJEgwKBGhlYWQYAiABKAkiWwoQU2NhbkVkZ2VzUmVxdWVzdBITCgt0YWlsX3ByZWZpeBgBIAEoCRITCgtoZWFkX3ByZWZpeBgCIAEoCRINCgVsaW1pdBgDIAEoDRIOCgZjdXJzb3IYBCABKAwiRwoRU2NhbkVkZ2VzUmVzcG9uc2USHQoFZWRnZXMYASADKAsyDi5ncmFwaC52MS5FZGdlEhMKC25leHRfY3Vyc29yGAIgASgMIjYKEkRlbGV0ZUVkZ2VzUmVxdWVzdBIgCgVlZGdlcxgBIAMoCzIRLmdyYXBoLnYxLkVkZ2VLZXkiJgoTRGVsZXRlRWRnZXNSZXNwb25zZRIPCgdkZWxldGVkGAEgASgFIkIKDkFkZEVkZ2VSZXF1ZXN0EhwKBGVkZ2UYASABKAsyDi5ncmFwaC52MS5FZGdlEhIKCmNvbnRyaWJfaWQYAiABKAwiEQoPQWRkRWRnZVJlc3BvbnNlIkUKD0FkZEVkZ2VzUmVxdWVzdBIdCgVlZGdlcxgBIAMoCzIOLmdyYXBoLnYxLkVkZ2USEwoLY29udHJpYl9pZHMYAiADKAwiIwoQQWRkRWRnZXNSZXNwb25zZRIPCgd3cml0dGVuGAEgASgFIi4KDlB1dEVkZ2VSZXF1ZXN0EhwKBGVkZ2UYASABKAsyDi5ncmFwaC52MS5FZGdlIhEKD1B1dEVkZ2VSZXNwb25zZSIwCg9QdXRFZGdlc1JlcXVlc3QSHQoFZWRnZXMYASADKAsyDi5ncmFwaC52MS5FZGdlIiMKEFB1dEVkZ2VzUmVzcG9uc2USDwoHd3JpdHRlbhgBIAEoBSIYChZHZXRTZXJ2ZXJTdGF0dXNSZXF1ZXN0IogDChdHZXRTZXJ2ZXJTdGF0dXNSZXNwb25zZRIPCgd2ZXJzaW9uGAEgASgJEhIKCmdvX3ZlcnNpb24YAiABKAkSLgoKc3RhcnRlZF9hdBgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASKQoGdXB0aW1lGAQgASgLMhkuZ29vZ2xlLnByb3RvYnVmLkR1cmF0aW9uEi4KC2RlZmF1bHRfdHRsGAUgASgLMhkuZ29vZ2xlLnByb3RvYnVmLkR1cmF0aW9uEhYKDm1heF9iYXRjaF9zaXplGAYgASgNEhUKDW1heF9rZXlfYnl0ZXMYByABKA0SGgoSc2Nhbl9kZWZhdWx0X2xpbWl0GAggASgNEhYKDnNjYW5fbWF4X2xpbWl0GAkgASgNEhMKC3Rsc19lbmFibGVkGAogASgIEhsKE3JlcGxpY2F0aW9uX2VuYWJsZWQYCyABKAgSFAoMdmVydGV4X2NvdW50GAwgASgEEhIKCmVkZ2VfY291bnQYDSABKAQimQIKD1JlcGxpY2F0aW9uUGVlchIPCgdhZGRyZXNzGAEgASgJEi4KBXN0YXRlGAIgASgOMh8uZ3JhcGgudjEuUmVwbGljYXRpb25QZWVyLlN0YXRlEjEKDWxhc3RfZXZlbnRfYXQYAyABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEhMKC2FwcGxpZWRfc2VxGAQgASgEEg0KBWVycm9yGAUgASgJIm4KBVN0YXRlEhUKEVNUQVRFX1VOU1BFQ0lGSUVEEAASFAoQU1RBVEVfQ09OTkVDVElORxABEhMKD1NUQVRFX1NUUkVBTUlORxACEhEKDVNUQVRFX0JBQ0tPRkYQAxIQCgxTVEFURV9DTE9TRUQQBCIdChtHZXRSZXBsaWNhdGlvblN0YXR1c1JlcXVlc3QimQEKHEdldFJlcGxpY2F0aW9uU3RhdHVzUmVzcG9uc2USDwoHbm9kZV9pZBgBIAEoCRItCglsb2NhbF9ub3cYAiABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEg8KB2VuYWJsZWQYAyABKAgSKAoFcGVlcnMYCiADKAsyGS5ncmFwaC52MS5SZXBsaWNhdGlvblBlZXIiLgoVQmFja3VwU25hcHNob3RSZXF1ZXN0EhUKDXZlcnRleF9wcmVmaXgYASABKAkiZgoWQmFja3VwU25hcHNob3RSZXNwb25zZRIiCgZ2ZXJ0ZXgYASABKAsyEC5ncmFwaC52MS5WZXJ0ZXhIABIeCgRlZGdlGAIgASgLMg4uZ3JhcGgudjEuRWRnZUgAQggKBnJlY29yZCptCglSZWR1Y3Rpb24SGQoVUkVEVUNUSU9OX1VOU1BFQ0lGSUVEEAASIwofUkVEVUNUSU9OX01JTklNVU1fU1BBTk5JTkdfVFJFRRABEiAKHFJFRFVDVElPTl9TSE9SVEVTVF9QQVRIX1RSRUUQAipWCglPYmplY3RpdmUSGQoVT0JKRUNUSVZFX1VOU1BFQ0lGSUVEEAASFgoST0JKRUNUSVZFX01JTklNSVpFEAESFgoST0JKRUNUSVZFX01BWElNSVpFEAIqYgoJV2VpZ2h0aW5nEhkKFVdFSUdIVElOR19VTlNQRUNJRklFRBAAEhEKDVdFSUdIVElOR19SQVcQARITCg9XRUlHSFRJTkdfVEZJREYQAhISCg5XRUlHSFRJTkdfQk0yNRADMusOCg5MYW50ZXJuU2VydmljZRJHCgpJbGx1bWluYXRlEhsuZ3JhcGgudjEuSWxsdW1pbmF0ZVJlcXVlc3QaHC5ncmFwaC52MS5JbGx1bWluYXRlUmVzcG9uc2USRAoJR2V0VmVydGV4EhouZ3JhcGgudjEuR2V0VmVydGV4UmVxdWVzdBobLmdyYXBoLnYxLkdldFZlcnRleFJlc3BvbnNlEkoKC0dldFZlcnRpY2VzEhwuZ3JhcGgudjEuR2V0VmVydGljZXNSZXF1ZXN0Gh0uZ3JhcGgudjEuR2V0VmVydGljZXNSZXNwb25zZRJECglQdXRWZXJ0ZXgSGi5ncmFwaC52MS5QdXRWZXJ0ZXhSZXF1ZXN0GhsuZ3JhcGgudjEuUHV0VmVydGV4UmVzcG9uc2USSgoLUHV0VmVydGljZXMSHC5ncmFwaC52MS5QdXRWZXJ0aWNlc1JlcXVlc3QaHS5ncmFwaC52MS5QdXRWZXJ0aWNlc1Jlc3BvbnNlEk0KDERlbGV0ZVZlcnRleBIdLmdyYXBoLnYxLkRlbGV0ZVZlcnRleFJlcXVlc3QaHi5ncmFwaC52MS5EZWxldGVWZXJ0ZXhSZXNwb25zZRJTCg5EZWxldGVWZXJ0aWNlcxIfLmdyYXBoLnYxLkRlbGV0ZVZlcnRpY2VzUmVxdWVzdBogLmdyYXBoLnYxLkRlbGV0ZVZlcnRpY2VzUmVzcG9uc2USTQoMU2NhblZlcnRpY2VzEh0uZ3JhcGgudjEuU2NhblZlcnRpY2VzUmVxdWVzdBoeLmdyYXBoLnYxLlNjYW5WZXJ0aWNlc1Jlc3BvbnNlElMKDlNjYW5WZXJ0ZXhLZXlzEh8uZ3JhcGgudjEuU2NhblZlcnRleEtleXNSZXF1ZXN0GiAuZ3JhcGgudjEuU2NhblZlcnRleEtleXNSZXNwb25zZRJTCg5TZWFyY2hWZXJ0aWNlcxIfLmdyYXBoLnYxLlNlYXJjaFZlcnRpY2VzUmVxdWVzdBogLmdyYXBoLnYxLlNlYXJjaFZlcnRpY2VzUmVzcG9uc2USaAoVQ291bnRWZXJ0aWNlc0J5UHJlZml4EiYuZ3JhcGgudjEuQ291bnRWZXJ0aWNlc0J5UHJlZml4UmVxdWVzdBonLmdyYXBoLnYxLkNvdW50VmVydGljZXNCeVByZWZpeFJlc3BvbnNlEmsKFkRlbGV0ZVZlcnRpY2VzQnlQcmVmaXgSJy5ncmFwaC52MS5EZWxldGVWZXJ0aWNlc0J5UHJlZml4UmVxdWVzdBooLmdyYXBoLnYxLkRlbGV0ZVZlcnRpY2VzQnlQcmVmaXhSZXNwb25zZRI+CgdHZXRFZGdlEhguZ3JhcGgudjEuR2V0RWRnZVJlcXVlc3QaGS5ncmFwaC52MS5HZXRFZGdlUmVzcG9uc2USQQoIR2V0RWRnZXMSGS5ncmFwaC52MS5HZXRFZGdlc1JlcXVlc3QaGi5ncmFwaC52MS5HZXRFZGdlc1Jlc3BvbnNlEj4KB0FkZEVkZ2USGC5ncmFwaC52MS5BZGRFZGdlUmVxdWVzdBoZLmdyYXBoLnYxLkFkZEVkZ2VSZXNwb25zZRJBCghBZGRFZGdlcxIZLmdyYXBoLnYxLkFkZEVkZ2VzUmVxdWVzdBoaLmdyYXBoLnYxLkFkZEVkZ2VzUmVzcG9uc2USPgoHUHV0RWRnZRIYLmdyYXBoLnYxLlB1dEVkZ2VSZXF1ZXN0GhkuZ3JhcGgudjEuUHV0RWRnZVJlc3BvbnNlEkEKCFB1dEVkZ2VzEhkuZ3JhcGgudjEuUHV0RWRnZXNSZXF1ZXN0GhouZ3JhcGgudjEuUHV0RWRnZXNSZXNwb25zZRJHCgpEZWxldGVFZGdlEhsuZ3JhcGgudjEuRGVsZXRlRWRnZVJlcXVlc3QaHC5ncmFwaC52MS5EZWxldGVFZGdlUmVzcG9uc2USSgoLRGVsZXRlRWRnZXMSHC5ncmFwaC52MS5EZWxldGVFZGdlc1JlcXVlc3QaHS5ncmFwaC52MS5EZWxldGVFZGdlc1Jlc3BvbnNlEkQKCVNjYW5FZGdlcxIaLmdyYXBoLnYxLlNjYW5FZGdlc1JlcXVlc3QaGy5ncmFwaC52MS5TY2FuRWRnZXNSZXNwb25zZRJWCg9HZXRTZXJ2ZXJTdGF0dXMSIC5ncmFwaC52MS5HZXRTZXJ2ZXJTdGF0dXNSZXF1ZXN0GiEuZ3JhcGgudjEuR2V0U2VydmVyU3RhdHVzUmVzcG9uc2USZQoUR2V0UmVwbGljYXRpb25TdGF0dXMSJS5ncmFwaC52MS5HZXRSZXBsaWNhdGlvblN0YXR1c1JlcXVlc3QaJi5ncmFwaC52MS5HZXRSZXBsaWNhdGlvblN0YXR1c1Jlc3BvbnNlElUKDkJhY2t1cFNuYXBzaG90Eh8uZ3JhcGgudjEuQmFja3VwU25hcHNob3RSZXF1ZXN0GiAuZ3JhcGgudjEuQmFja3VwU25hcHNob3RSZXNwb25zZTABQlsKDGNvbS5ncmFwaC52MUIKR3JhcGhQcm90b1ABogIDR1hYqgIIR3JhcGguVjHKAghHcmFwaFxWMeICFEdyYXBoXFYxXEdQQk1ldGFkYXRh6gIJR3JhcGg6OlYxYgZwcm90bzM", [file_google_protobuf_duration, file_google_protobuf_timestamp]);
+  fileDesc("ChRncmFwaC92MS9ncmFwaC5wcm90bxIIZ3JhcGgudjEi3AIKBlZlcnRleBILCgNrZXkYASABKAkSLgoKZXhwaXJhdGlvbhgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASEQoHZmxvYXQ2NBgKIAEoAUgAEhEKB2Zsb2F0MzIYCyABKAJIABIPCgVpbnQzMhgMIAEoBUgAEg8KBWludDY0GA0gASgDSAASEAoGdWludDMyGA4gASgNSAASEAoGdWludDY0GA8gASgESAASDgoEYm9vbBgQIAEoCEgAEhAKBnN0cmluZxgRIAEoCUgAEg8KBWJ5dGVzGBIgASgMSAASLwoJdGltZXN0YW1wGBMgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcEgAEi0KCGR1cmF0aW9uGBQgASgLMhkuZ29vZ2xlLnByb3RvYnVmLkR1cmF0aW9uSAASDQoDbmlsGB4gASgISABCBwoFdmFsdWUiYgoERWRnZRIMCgR0YWlsGAEgASgJEgwKBGhlYWQYAiABKAkSDgoGd2VpZ2h0GAMgASgCEi4KCmV4cGlyYXRpb24YBCABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wIkoKBUdyYXBoEiIKCHZlcnRpY2VzGAEgAygLMhAuZ3JhcGgudjEuVmVydGV4Eh0KBWVkZ2VzGAIgAygLMg4uZ3JhcGgudjEuRWRnZSLiAgoRSWxsdW1pbmF0ZVJlcXVlc3QSDAoEc2VlZBgBIAEoCRImCgl3ZWlnaHRpbmcYCCABKA4yEy5ncmFwaC52MS5XZWlnaHRpbmcSFQoNdmVydGV4X3ByZWZpeBgJIAEoCRIiCgNiZnMYDCABKAsyEy5ncmFwaC52MS5CZnNQYXJhbXNIABIiCgNwcHIYDSABKAsyEy5ncmFwaC52MS5QcHJQYXJhbXNIABIzCgljb21tdW5pdHkYDiABKAsyHi5ncmFwaC52MS5Mb2NhbENvbW11bml0eVBhcmFtc0gAQggKBnBhcmFtc0oECAIQA0oECAMQBEoECAQQBUoECAUQBkoECAYQB0oECAcQCEoECAoQC0oECAsQDFIEc3RlcFIBa1IFdGZpZGZSDG9wdGltaXphdGlvblIJYWxnb3JpdGhtUglvYmplY3RpdmVSDHJlc3RhcnRfcHJvYlIHZXBzaWxvbiJ6CglCZnNQYXJhbXMSDAoEc3RlcBgBIAEoDRIPCgdmYW5fb3V0GAIgASgNEiYKCW9iamVjdGl2ZRgDIAEoDjITLmdyYXBoLnYxLk9iamVjdGl2ZRImCglyZWR1Y3Rpb24YBCABKA4yEy5ncmFwaC52MS5SZWR1Y3Rpb24inwEKFExvY2FsQ29tbXVuaXR5UGFyYW1zEhAKCG1heF9zaXplGAEgASgNEhQKDHJlc3RhcnRfcHJvYhgCIAEoAhIPCgdlcHNpbG9uGAMgASgCEiYKCXJlZHVjdGlvbhgEIAEoDjITLmdyYXBoLnYxLlJlZHVjdGlvbhImCglvYmplY3RpdmUYBSABKA4yEy5ncmFwaC52MS5PYmplY3RpdmUiQQoJUHByUGFyYW1zEg0KBXRvcF9uGAEgASgNEhQKDHJlc3RhcnRfcHJvYhgCIAEoAhIPCgdlcHNpbG9uGAMgASgCIjQKEklsbHVtaW5hdGVSZXNwb25zZRIeCgVncmFwaBgBIAEoCzIPLmdyYXBoLnYxLkdyYXBoIh8KEEdldFZlcnRleFJlcXVlc3QSCwoDa2V5GAEgASgJIjUKEUdldFZlcnRleFJlc3BvbnNlEiAKBnZlcnRleBgBIAEoCzIQLmdyYXBoLnYxLlZlcnRleCIiChJHZXRWZXJ0aWNlc1JlcXVlc3QSDAoEa2V5cxgBIAMoCSJKChNHZXRWZXJ0aWNlc1Jlc3BvbnNlEiIKCHZlcnRpY2VzGAEgAygLMhAuZ3JhcGgudjEuVmVydGV4Eg8KB21pc3NpbmcYAiADKAkiNAoQUHV0VmVydGV4UmVxdWVzdBIgCgZ2ZXJ0ZXgYASABKAsyEC5ncmFwaC52MS5WZXJ0ZXgiEwoRUHV0VmVydGV4UmVzcG9uc2UiOAoSUHV0VmVydGljZXNSZXF1ZXN0EiIKCHZlcnRpY2VzGAEgAygLMhAuZ3JhcGgudjEuVmVydGV4IiYKE1B1dFZlcnRpY2VzUmVzcG9uc2USDwoHd3JpdHRlbhgBIAEoBSIiChNEZWxldGVWZXJ0ZXhSZXF1ZXN0EgsKA2tleRgBIAEoCSInChREZWxldGVWZXJ0ZXhSZXNwb25zZRIPCgdleGlzdGVkGAEgASgIIiUKFURlbGV0ZVZlcnRpY2VzUmVxdWVzdBIMCgRrZXlzGAEgAygJIikKFkRlbGV0ZVZlcnRpY2VzUmVzcG9uc2USDwoHZGVsZXRlZBgBIAEoBSJEChNTY2FuVmVydGljZXNSZXF1ZXN0Eg4KBnByZWZpeBgBIAEoCRINCgVsaW1pdBgCIAEoDRIOCgZjdXJzb3IYAyABKAwiTwoUU2NhblZlcnRpY2VzUmVzcG9uc2USIgoIdmVydGljZXMYASADKAsyEC5ncmFwaC52MS5WZXJ0ZXgSEwoLbmV4dF9jdXJzb3IYAiABKAwiRgoVU2NhblZlcnRleEtleXNSZXF1ZXN0Eg4KBnByZWZpeBgBIAEoCRINCgVsaW1pdBgCIAEoDRIOCgZjdXJzb3IYAyABKAwiOwoWU2NhblZlcnRleEtleXNSZXNwb25zZRIMCgRrZXlzGAEgAygJEhMKC25leHRfY3Vyc29yGAIgASgMIkUKFVNlYXJjaFZlcnRpY2VzUmVxdWVzdBINCgVxdWVyeRgBIAEoCRINCgVsaW1pdBgCIAEoDRIOCgZwcmVmaXgYAyABKAkiOwoWU2VhcmNoVmVydGljZXNSZXNwb25zZRIhCgRoaXRzGAEgAygLMhMuZ3JhcGgudjEuU2VhcmNoSGl0IicKCVNlYXJjaEhpdBILCgNrZXkYASABKAkSDQoFc2NvcmUYAiABKAEiLgocQ291bnRWZXJ0aWNlc0J5UHJlZml4UmVxdWVzdBIOCgZwcmVmaXgYASABKAkiLgodQ291bnRWZXJ0aWNlc0J5UHJlZml4UmVzcG9uc2USDQoFY291bnQYASABKAQiTwodRGVsZXRlVmVydGljZXNCeVByZWZpeFJlcXVlc3QSDgoGcHJlZml4GAEgASgJEg0KBWxpbWl0GAIgASgNEg8KB2RyeV9ydW4YAyABKAgiMQoeRGVsZXRlVmVydGljZXNCeVByZWZpeFJlc3BvbnNlEg8KB2RlbGV0ZWQYASABKAQiLAoOR2V0RWRnZVJlcXVlc3QSDAoEdGFpbBgBIAEoCRIMCgRoZWFkGAIgASgJIi8KD0dldEVkZ2VSZXNwb25zZRIcCgRlZGdlGAEgASgLMg4uZ3JhcGgudjEuRWRnZSIzCg9HZXRFZGdlc1JlcXVlc3QSIAoFZWRnZXMYASADKAsyES5ncmFwaC52MS5FZGdlS2V5IlUKEEdldEVkZ2VzUmVzcG9uc2USHQoFZWRnZXMYASADKAsyDi5ncmFwaC52MS5FZGdlEiIKB21pc3NpbmcYAiADKAsyES5ncmFwaC52MS5FZGdlS2V5Ii8KEURlbGV0ZUVkZ2VSZXF1ZXN0EgwKBHRhaWwYASABKAkSDAoEaGVhZBgCIAEoCSIlChJEZWxldGVFZGdlUmVzcG9uc2USDwoHZXhpc3RlZBgBIAEoCCIlCgdFZGdlS2V5EgwKBHRhaWwYASABKAkSDAoEaGVhZBgCIAEoCSJbChBTY2FuRWRnZXNSZXF1ZXN0EhMKC3RhaWxfcHJlZml4GAEgASgJEhMKC2hlYWRfcHJlZml4GAIgASgJEg0KBWxpbWl0GAMgASgNEg4KBmN1cnNvchgEIAEoDCJHChFTY2FuRWRnZXNSZXNwb25zZRIdCgVlZGdlcxgBIAMoCzIOLmdyYXBoLnYxLkVkZ2USEwoLbmV4dF9jdXJzb3IYAiABKAwiNgoSRGVsZXRlRWRnZXNSZXF1ZXN0EiAKBWVkZ2VzGAEgAygLMhEuZ3JhcGgudjEuRWRnZUtleSImChNEZWxldGVFZGdlc1Jlc3BvbnNlEg8KB2RlbGV0ZWQYASABKAUiQgoOQWRkRWRnZVJlcXVlc3QSHAoEZWRnZRgBIAEoCzIOLmdyYXBoLnYxLkVkZ2USEgoKY29udHJpYl9pZBgCIAEoDCIRCg9BZGRFZGdlUmVzcG9uc2UiRQoPQWRkRWRnZXNSZXF1ZXN0Eh0KBWVkZ2VzGAEgAygLMg4uZ3JhcGgudjEuRWRnZRITCgtjb250cmliX2lkcxgCIAMoDCIjChBBZGRFZGdlc1Jlc3BvbnNlEg8KB3dyaXR0ZW4YASABKAUiLgoOUHV0RWRnZVJlcXVlc3QSHAoEZWRnZRgBIAEoCzIOLmdyYXBoLnYxLkVkZ2UiEQoPUHV0RWRnZVJlc3BvbnNlIjAKD1B1dEVkZ2VzUmVxdWVzdBIdCgVlZGdlcxgBIAMoCzIOLmdyYXBoLnYxLkVkZ2UiIwoQUHV0RWRnZXNSZXNwb25zZRIPCgd3cml0dGVuGAEgASgFIhgKFkdldFNlcnZlclN0YXR1c1JlcXVlc3QiiAMKF0dldFNlcnZlclN0YXR1c1Jlc3BvbnNlEg8KB3ZlcnNpb24YASABKAkSEgoKZ29fdmVyc2lvbhgCIAEoCRIuCgpzdGFydGVkX2F0GAMgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIpCgZ1cHRpbWUYBCABKAsyGS5nb29nbGUucHJvdG9idWYuRHVyYXRpb24SLgoLZGVmYXVsdF90dGwYBSABKAsyGS5nb29nbGUucHJvdG9idWYuRHVyYXRpb24SFgoObWF4X2JhdGNoX3NpemUYBiABKA0SFQoNbWF4X2tleV9ieXRlcxgHIAEoDRIaChJzY2FuX2RlZmF1bHRfbGltaXQYCCABKA0SFgoOc2Nhbl9tYXhfbGltaXQYCSABKA0SEwoLdGxzX2VuYWJsZWQYCiABKAgSGwoTcmVwbGljYXRpb25fZW5hYmxlZBgLIAEoCBIUCgx2ZXJ0ZXhfY291bnQYDCABKAQSEgoKZWRnZV9jb3VudBgNIAEoBCKZAgoPUmVwbGljYXRpb25QZWVyEg8KB2FkZHJlc3MYASABKAkSLgoFc3RhdGUYAiABKA4yHy5ncmFwaC52MS5SZXBsaWNhdGlvblBlZXIuU3RhdGUSMQoNbGFzdF9ldmVudF9hdBgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASEwoLYXBwbGllZF9zZXEYBCABKAQSDQoFZXJyb3IYBSABKAkibgoFU3RhdGUSFQoRU1RBVEVfVU5TUEVDSUZJRUQQABIUChBTVEFURV9DT05ORUNUSU5HEAESEwoPU1RBVEVfU1RSRUFNSU5HEAISEQoNU1RBVEVfQkFDS09GRhADEhAKDFNUQVRFX0NMT1NFRBAEIh0KG0dldFJlcGxpY2F0aW9uU3RhdHVzUmVxdWVzdCKZAQocR2V0UmVwbGljYXRpb25TdGF0dXNSZXNwb25zZRIPCgdub2RlX2lkGAEgASgJEi0KCWxvY2FsX25vdxgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASDwoHZW5hYmxlZBgDIAEoCBIoCgVwZWVycxgKIAMoCzIZLmdyYXBoLnYxLlJlcGxpY2F0aW9uUGVlciIuChVCYWNrdXBTbmFwc2hvdFJlcXVlc3QSFQoNdmVydGV4X3ByZWZpeBgBIAEoCSJmChZCYWNrdXBTbmFwc2hvdFJlc3BvbnNlEiIKBnZlcnRleBgBIAEoCzIQLmdyYXBoLnYxLlZlcnRleEgAEh4KBGVkZ2UYAiABKAsyDi5ncmFwaC52MS5FZGdlSABCCAoGcmVjb3JkKm0KCVJlZHVjdGlvbhIZChVSRURVQ1RJT05fVU5TUEVDSUZJRUQQABIjCh9SRURVQ1RJT05fTUlOSU1VTV9TUEFOTklOR19UUkVFEAESIAocUkVEVUNUSU9OX1NIT1JURVNUX1BBVEhfVFJFRRACKlYKCU9iamVjdGl2ZRIZChVPQkpFQ1RJVkVfVU5TUEVDSUZJRUQQABIWChJPQkpFQ1RJVkVfTUlOSU1JWkUQARIWChJPQkpFQ1RJVkVfTUFYSU1JWkUQAipiCglXZWlnaHRpbmcSGQoVV0VJR0hUSU5HX1VOU1BFQ0lGSUVEEAASEQoNV0VJR0hUSU5HX1JBVxABEhMKD1dFSUdIVElOR19URklERhACEhIKDldFSUdIVElOR19CTTI1EAMy6w4KDkxhbnRlcm5TZXJ2aWNlEkcKCklsbHVtaW5hdGUSGy5ncmFwaC52MS5JbGx1bWluYXRlUmVxdWVzdBocLmdyYXBoLnYxLklsbHVtaW5hdGVSZXNwb25zZRJECglHZXRWZXJ0ZXgSGi5ncmFwaC52MS5HZXRWZXJ0ZXhSZXF1ZXN0GhsuZ3JhcGgudjEuR2V0VmVydGV4UmVzcG9uc2USSgoLR2V0VmVydGljZXMSHC5ncmFwaC52MS5HZXRWZXJ0aWNlc1JlcXVlc3QaHS5ncmFwaC52MS5HZXRWZXJ0aWNlc1Jlc3BvbnNlEkQKCVB1dFZlcnRleBIaLmdyYXBoLnYxLlB1dFZlcnRleFJlcXVlc3QaGy5ncmFwaC52MS5QdXRWZXJ0ZXhSZXNwb25zZRJKCgtQdXRWZXJ0aWNlcxIcLmdyYXBoLnYxLlB1dFZlcnRpY2VzUmVxdWVzdBodLmdyYXBoLnYxLlB1dFZlcnRpY2VzUmVzcG9uc2USTQoMRGVsZXRlVmVydGV4Eh0uZ3JhcGgudjEuRGVsZXRlVmVydGV4UmVxdWVzdBoeLmdyYXBoLnYxLkRlbGV0ZVZlcnRleFJlc3BvbnNlElMKDkRlbGV0ZVZlcnRpY2VzEh8uZ3JhcGgudjEuRGVsZXRlVmVydGljZXNSZXF1ZXN0GiAuZ3JhcGgudjEuRGVsZXRlVmVydGljZXNSZXNwb25zZRJNCgxTY2FuVmVydGljZXMSHS5ncmFwaC52MS5TY2FuVmVydGljZXNSZXF1ZXN0Gh4uZ3JhcGgudjEuU2NhblZlcnRpY2VzUmVzcG9uc2USUwoOU2NhblZlcnRleEtleXMSHy5ncmFwaC52MS5TY2FuVmVydGV4S2V5c1JlcXVlc3QaIC5ncmFwaC52MS5TY2FuVmVydGV4S2V5c1Jlc3BvbnNlElMKDlNlYXJjaFZlcnRpY2VzEh8uZ3JhcGgudjEuU2VhcmNoVmVydGljZXNSZXF1ZXN0GiAuZ3JhcGgudjEuU2VhcmNoVmVydGljZXNSZXNwb25zZRJoChVDb3VudFZlcnRpY2VzQnlQcmVmaXgSJi5ncmFwaC52MS5Db3VudFZlcnRpY2VzQnlQcmVmaXhSZXF1ZXN0GicuZ3JhcGgudjEuQ291bnRWZXJ0aWNlc0J5UHJlZml4UmVzcG9uc2USawoWRGVsZXRlVmVydGljZXNCeVByZWZpeBInLmdyYXBoLnYxLkRlbGV0ZVZlcnRpY2VzQnlQcmVmaXhSZXF1ZXN0GiguZ3JhcGgudjEuRGVsZXRlVmVydGljZXNCeVByZWZpeFJlc3BvbnNlEj4KB0dldEVkZ2USGC5ncmFwaC52MS5HZXRFZGdlUmVxdWVzdBoZLmdyYXBoLnYxLkdldEVkZ2VSZXNwb25zZRJBCghHZXRFZGdlcxIZLmdyYXBoLnYxLkdldEVkZ2VzUmVxdWVzdBoaLmdyYXBoLnYxLkdldEVkZ2VzUmVzcG9uc2USPgoHQWRkRWRnZRIYLmdyYXBoLnYxLkFkZEVkZ2VSZXF1ZXN0GhkuZ3JhcGgudjEuQWRkRWRnZVJlc3BvbnNlEkEKCEFkZEVkZ2VzEhkuZ3JhcGgudjEuQWRkRWRnZXNSZXF1ZXN0GhouZ3JhcGgudjEuQWRkRWRnZXNSZXNwb25zZRI+CgdQdXRFZGdlEhguZ3JhcGgudjEuUHV0RWRnZVJlcXVlc3QaGS5ncmFwaC52MS5QdXRFZGdlUmVzcG9uc2USQQoIUHV0RWRnZXMSGS5ncmFwaC52MS5QdXRFZGdlc1JlcXVlc3QaGi5ncmFwaC52MS5QdXRFZGdlc1Jlc3BvbnNlEkcKCkRlbGV0ZUVkZ2USGy5ncmFwaC52MS5EZWxldGVFZGdlUmVxdWVzdBocLmdyYXBoLnYxLkRlbGV0ZUVkZ2VSZXNwb25zZRJKCgtEZWxldGVFZGdlcxIcLmdyYXBoLnYxLkRlbGV0ZUVkZ2VzUmVxdWVzdBodLmdyYXBoLnYxLkRlbGV0ZUVkZ2VzUmVzcG9uc2USRAoJU2NhbkVkZ2VzEhouZ3JhcGgudjEuU2NhbkVkZ2VzUmVxdWVzdBobLmdyYXBoLnYxLlNjYW5FZGdlc1Jlc3BvbnNlElYKD0dldFNlcnZlclN0YXR1cxIgLmdyYXBoLnYxLkdldFNlcnZlclN0YXR1c1JlcXVlc3QaIS5ncmFwaC52MS5HZXRTZXJ2ZXJTdGF0dXNSZXNwb25zZRJlChRHZXRSZXBsaWNhdGlvblN0YXR1cxIlLmdyYXBoLnYxLkdldFJlcGxpY2F0aW9uU3RhdHVzUmVxdWVzdBomLmdyYXBoLnYxLkdldFJlcGxpY2F0aW9uU3RhdHVzUmVzcG9uc2USVQoOQmFja3VwU25hcHNob3QSHy5ncmFwaC52MS5CYWNrdXBTbmFwc2hvdFJlcXVlc3QaIC5ncmFwaC52MS5CYWNrdXBTbmFwc2hvdFJlc3BvbnNlMAFCWwoMY29tLmdyYXBoLnYxQgpHcmFwaFByb3RvUAGiAgNHWFiqAghHcmFwaC5WMcoCCEdyYXBoXFYx4gIUR3JhcGhcVjFcR1BCTWV0YWRhdGHqAglHcmFwaDo6VjFiBnByb3RvMw", [file_google_protobuf_duration, file_google_protobuf_timestamp]);
 
 /**
  * @generated from message graph.v1.Vertex
@@ -219,6 +219,12 @@ export type IlluminateRequest = Message<"graph.v1.IlluminateRequest"> & {
      */
     value: PprParams;
     case: "ppr";
+  } | {
+    /**
+     * @generated from field: graph.v1.LocalCommunityParams community = 14;
+     */
+    value: LocalCommunityParams;
+    case: "community";
   } | { case: undefined; value?: undefined };
 };
 
@@ -278,6 +284,79 @@ export const BfsParamsSchema: GenMessage<BfsParams> = /*@__PURE__*/
   messageDesc(file_graph_v1_graph, 4);
 
 /**
+ * LocalCommunityParams extracts the conductance-optimal local community
+ * around the seed (#845): PageRank-Nibble — the same ACL forward-push the
+ * PPR family runs, followed by a sweep cut that orders touched vertices by
+ * p(v)/deg(v) and takes the prefix minimising directed weighted
+ * conductance. Unlike the PPR relevance star, the response preserves
+ * structure: it is the INDUCED SUBGRAPH on the selected members — the real
+ * live edges among them with actual stored weights and expirations, in the
+ * same response shape as the BFS family.
+ *
+ * @generated from message graph.v1.LocalCommunityParams
+ */
+export type LocalCommunityParams = Message<"graph.v1.LocalCommunityParams"> & {
+  /**
+   * max_size is an UPPER BOUND on community size — NOT an exact count. The
+   * sweep stops at the conductance minimum, which may come before max_size.
+   * 0 = unbounded (the sweep alone decides). (The PPR family's top_n by
+   * contrast always returns exactly N regardless of the natural boundary.)
+   *
+   * @generated from field: uint32 max_size = 1;
+   */
+  maxSize: number;
+
+  /**
+   * restart_prob (α) — locality knob, same semantics and defaults as
+   * PprParams.restart_prob: higher α → tighter, more seed-proximate
+   * community. Honoured only in (0,1); unset falls back to 0.15.
+   *
+   * @generated from field: float restart_prob = 2;
+   */
+  restartProb: number;
+
+  /**
+   * epsilon (ε) — push accuracy / work budget, same semantics and defaults
+   * as PprParams.epsilon: smaller ε → more accurate mass and a larger
+   * touched set. Honoured only when > 0; unset falls back to 1e-4.
+   *
+   * @generated from field: float epsilon = 3;
+   */
+  epsilon: number;
+
+  /**
+   * reduction optionally reduces the community to a tree VIEW rooted at the
+   * seed (for visualization, explanation paths, token-bounded consumption).
+   * The induced subgraph stays the source of truth — density is exactly
+   * what the sweep selected for. Sweep prefixes need not be connected, so
+   * the tree spans only the seed's reachable component within the
+   * community; unreachable members are still returned as ISOLATED vertices
+   * (membership preserved, no edges fabricated). UNSPECIFIED = the full
+   * induced subgraph (the default).
+   *
+   * @generated from field: graph.v1.Reduction reduction = 4;
+   */
+  reduction: Reduction;
+
+  /**
+   * objective sets the direction/cost mapping for the reduction ONLY
+   * (membership is decided by PPR mass, not by this): MINIMIZE → identity
+   * cost, MAXIMIZE/UNSPECIFIED → inverse cost, exactly as the BFS family.
+   * Ignored when reduction is UNSPECIFIED.
+   *
+   * @generated from field: graph.v1.Objective objective = 5;
+   */
+  objective: Objective;
+};
+
+/**
+ * Describes the message graph.v1.LocalCommunityParams.
+ * Use `create(LocalCommunityParamsSchema)` to create a new message.
+ */
+export const LocalCommunityParamsSchema: GenMessage<LocalCommunityParams> = /*@__PURE__*/
+  messageDesc(file_graph_v1_graph, 5);
+
+/**
  * PprParams runs seed-anchored Personalized PageRank (Random-Walk-with-
  * Restart) by local forward-push (Andersen–Chung–Lang) instead of the BFS
  * walk (#801). The result is a relevance star rooted at the seed — the
@@ -322,7 +401,7 @@ export type PprParams = Message<"graph.v1.PprParams"> & {
  * Use `create(PprParamsSchema)` to create a new message.
  */
 export const PprParamsSchema: GenMessage<PprParams> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 5);
+  messageDesc(file_graph_v1_graph, 6);
 
 /**
  * @generated from message graph.v1.IlluminateResponse
@@ -339,7 +418,7 @@ export type IlluminateResponse = Message<"graph.v1.IlluminateResponse"> & {
  * Use `create(IlluminateResponseSchema)` to create a new message.
  */
 export const IlluminateResponseSchema: GenMessage<IlluminateResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 6);
+  messageDesc(file_graph_v1_graph, 7);
 
 /**
  * @generated from message graph.v1.GetVertexRequest
@@ -356,7 +435,7 @@ export type GetVertexRequest = Message<"graph.v1.GetVertexRequest"> & {
  * Use `create(GetVertexRequestSchema)` to create a new message.
  */
 export const GetVertexRequestSchema: GenMessage<GetVertexRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 7);
+  messageDesc(file_graph_v1_graph, 8);
 
 /**
  * @generated from message graph.v1.GetVertexResponse
@@ -373,7 +452,7 @@ export type GetVertexResponse = Message<"graph.v1.GetVertexResponse"> & {
  * Use `create(GetVertexResponseSchema)` to create a new message.
  */
 export const GetVertexResponseSchema: GenMessage<GetVertexResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 8);
+  messageDesc(file_graph_v1_graph, 9);
 
 /**
  * GetVerticesRequest reads several vertices in one round trip. Subject to
@@ -393,7 +472,7 @@ export type GetVerticesRequest = Message<"graph.v1.GetVerticesRequest"> & {
  * Use `create(GetVerticesRequestSchema)` to create a new message.
  */
 export const GetVerticesRequestSchema: GenMessage<GetVerticesRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 9);
+  messageDesc(file_graph_v1_graph, 10);
 
 /**
  * @generated from message graph.v1.GetVerticesResponse
@@ -420,7 +499,7 @@ export type GetVerticesResponse = Message<"graph.v1.GetVerticesResponse"> & {
  * Use `create(GetVerticesResponseSchema)` to create a new message.
  */
 export const GetVerticesResponseSchema: GenMessage<GetVerticesResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 10);
+  messageDesc(file_graph_v1_graph, 11);
 
 /**
  * PutVertexRequest writes a single vertex with upsert semantics. The
@@ -442,7 +521,7 @@ export type PutVertexRequest = Message<"graph.v1.PutVertexRequest"> & {
  * Use `create(PutVertexRequestSchema)` to create a new message.
  */
 export const PutVertexRequestSchema: GenMessage<PutVertexRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 11);
+  messageDesc(file_graph_v1_graph, 12);
 
 /**
  * @generated from message graph.v1.PutVertexResponse
@@ -455,7 +534,7 @@ export type PutVertexResponse = Message<"graph.v1.PutVertexResponse"> & {
  * Use `create(PutVertexResponseSchema)` to create a new message.
  */
 export const PutVertexResponseSchema: GenMessage<PutVertexResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 12);
+  messageDesc(file_graph_v1_graph, 13);
 
 /**
  * PutVerticesRequest writes vertices with upsert semantics: each Vertex.key
@@ -476,7 +555,7 @@ export type PutVerticesRequest = Message<"graph.v1.PutVerticesRequest"> & {
  * Use `create(PutVerticesRequestSchema)` to create a new message.
  */
 export const PutVerticesRequestSchema: GenMessage<PutVerticesRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 13);
+  messageDesc(file_graph_v1_graph, 14);
 
 /**
  * @generated from message graph.v1.PutVerticesResponse
@@ -497,7 +576,7 @@ export type PutVerticesResponse = Message<"graph.v1.PutVerticesResponse"> & {
  * Use `create(PutVerticesResponseSchema)` to create a new message.
  */
 export const PutVerticesResponseSchema: GenMessage<PutVerticesResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 14);
+  messageDesc(file_graph_v1_graph, 15);
 
 /**
  * DeleteVertexRequest removes the vertex at `key`. Edges incident to the
@@ -519,7 +598,7 @@ export type DeleteVertexRequest = Message<"graph.v1.DeleteVertexRequest"> & {
  * Use `create(DeleteVertexRequestSchema)` to create a new message.
  */
 export const DeleteVertexRequestSchema: GenMessage<DeleteVertexRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 15);
+  messageDesc(file_graph_v1_graph, 16);
 
 /**
  * @generated from message graph.v1.DeleteVertexResponse
@@ -538,7 +617,7 @@ export type DeleteVertexResponse = Message<"graph.v1.DeleteVertexResponse"> & {
  * Use `create(DeleteVertexResponseSchema)` to create a new message.
  */
 export const DeleteVertexResponseSchema: GenMessage<DeleteVertexResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 16);
+  messageDesc(file_graph_v1_graph, 17);
 
 /**
  * DeleteVerticesRequest removes several vertices in one round trip. Same
@@ -559,7 +638,7 @@ export type DeleteVerticesRequest = Message<"graph.v1.DeleteVerticesRequest"> & 
  * Use `create(DeleteVerticesRequestSchema)` to create a new message.
  */
 export const DeleteVerticesRequestSchema: GenMessage<DeleteVerticesRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 17);
+  messageDesc(file_graph_v1_graph, 18);
 
 /**
  * @generated from message graph.v1.DeleteVerticesResponse
@@ -578,7 +657,7 @@ export type DeleteVerticesResponse = Message<"graph.v1.DeleteVerticesResponse"> 
  * Use `create(DeleteVerticesResponseSchema)` to create a new message.
  */
 export const DeleteVerticesResponseSchema: GenMessage<DeleteVerticesResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 18);
+  messageDesc(file_graph_v1_graph, 19);
 
 /**
  * ScanVerticesRequest streams vertices whose key starts with `prefix` in
@@ -616,7 +695,7 @@ export type ScanVerticesRequest = Message<"graph.v1.ScanVerticesRequest"> & {
  * Use `create(ScanVerticesRequestSchema)` to create a new message.
  */
 export const ScanVerticesRequestSchema: GenMessage<ScanVerticesRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 19);
+  messageDesc(file_graph_v1_graph, 20);
 
 /**
  * @generated from message graph.v1.ScanVerticesResponse
@@ -644,7 +723,7 @@ export type ScanVerticesResponse = Message<"graph.v1.ScanVerticesResponse"> & {
  * Use `create(ScanVerticesResponseSchema)` to create a new message.
  */
 export const ScanVerticesResponseSchema: GenMessage<ScanVerticesResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 20);
+  messageDesc(file_graph_v1_graph, 21);
 
 /**
  * ScanVertexKeysRequest streams vertex KEYS (no values) whose key starts
@@ -692,7 +771,7 @@ export type ScanVertexKeysRequest = Message<"graph.v1.ScanVertexKeysRequest"> & 
  * Use `create(ScanVertexKeysRequestSchema)` to create a new message.
  */
 export const ScanVertexKeysRequestSchema: GenMessage<ScanVertexKeysRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 21);
+  messageDesc(file_graph_v1_graph, 22);
 
 /**
  * @generated from message graph.v1.ScanVertexKeysResponse
@@ -720,7 +799,7 @@ export type ScanVertexKeysResponse = Message<"graph.v1.ScanVertexKeysResponse"> 
  * Use `create(ScanVertexKeysResponseSchema)` to create a new message.
  */
 export const ScanVertexKeysResponseSchema: GenMessage<ScanVertexKeysResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 22);
+  messageDesc(file_graph_v1_graph, 23);
 
 /**
  * SearchVerticesRequest runs a relevance-ranked full-text search over vertex
@@ -762,7 +841,7 @@ export type SearchVerticesRequest = Message<"graph.v1.SearchVerticesRequest"> & 
  * Use `create(SearchVerticesRequestSchema)` to create a new message.
  */
 export const SearchVerticesRequestSchema: GenMessage<SearchVerticesRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 23);
+  messageDesc(file_graph_v1_graph, 24);
 
 /**
  * @generated from message graph.v1.SearchVerticesResponse
@@ -782,7 +861,7 @@ export type SearchVerticesResponse = Message<"graph.v1.SearchVerticesResponse"> 
  * Use `create(SearchVerticesResponseSchema)` to create a new message.
  */
 export const SearchVerticesResponseSchema: GenMessage<SearchVerticesResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 24);
+  messageDesc(file_graph_v1_graph, 25);
 
 /**
  * SearchHit pairs a matching vertex key with the relevance score the index
@@ -809,7 +888,7 @@ export type SearchHit = Message<"graph.v1.SearchHit"> & {
  * Use `create(SearchHitSchema)` to create a new message.
  */
 export const SearchHitSchema: GenMessage<SearchHit> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 25);
+  messageDesc(file_graph_v1_graph, 26);
 
 /**
  * CountVerticesByPrefixRequest returns the number of live vertex keys with
@@ -829,7 +908,7 @@ export type CountVerticesByPrefixRequest = Message<"graph.v1.CountVerticesByPref
  * Use `create(CountVerticesByPrefixRequestSchema)` to create a new message.
  */
 export const CountVerticesByPrefixRequestSchema: GenMessage<CountVerticesByPrefixRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 26);
+  messageDesc(file_graph_v1_graph, 27);
 
 /**
  * @generated from message graph.v1.CountVerticesByPrefixResponse
@@ -846,7 +925,7 @@ export type CountVerticesByPrefixResponse = Message<"graph.v1.CountVerticesByPre
  * Use `create(CountVerticesByPrefixResponseSchema)` to create a new message.
  */
 export const CountVerticesByPrefixResponseSchema: GenMessage<CountVerticesByPrefixResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 27);
+  messageDesc(file_graph_v1_graph, 28);
 
 /**
  * DeleteVerticesByPrefixRequest deletes up to `limit` vertices whose key
@@ -879,7 +958,7 @@ export type DeleteVerticesByPrefixRequest = Message<"graph.v1.DeleteVerticesByPr
  * Use `create(DeleteVerticesByPrefixRequestSchema)` to create a new message.
  */
 export const DeleteVerticesByPrefixRequestSchema: GenMessage<DeleteVerticesByPrefixRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 28);
+  messageDesc(file_graph_v1_graph, 29);
 
 /**
  * @generated from message graph.v1.DeleteVerticesByPrefixResponse
@@ -896,7 +975,7 @@ export type DeleteVerticesByPrefixResponse = Message<"graph.v1.DeleteVerticesByP
  * Use `create(DeleteVerticesByPrefixResponseSchema)` to create a new message.
  */
 export const DeleteVerticesByPrefixResponseSchema: GenMessage<DeleteVerticesByPrefixResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 29);
+  messageDesc(file_graph_v1_graph, 30);
 
 /**
  * @generated from message graph.v1.GetEdgeRequest
@@ -918,7 +997,7 @@ export type GetEdgeRequest = Message<"graph.v1.GetEdgeRequest"> & {
  * Use `create(GetEdgeRequestSchema)` to create a new message.
  */
 export const GetEdgeRequestSchema: GenMessage<GetEdgeRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 30);
+  messageDesc(file_graph_v1_graph, 31);
 
 /**
  * @generated from message graph.v1.GetEdgeResponse
@@ -935,7 +1014,7 @@ export type GetEdgeResponse = Message<"graph.v1.GetEdgeResponse"> & {
  * Use `create(GetEdgeResponseSchema)` to create a new message.
  */
 export const GetEdgeResponseSchema: GenMessage<GetEdgeResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 31);
+  messageDesc(file_graph_v1_graph, 32);
 
 /**
  * GetEdgesRequest reads several edges in one round trip. Subject to the
@@ -955,7 +1034,7 @@ export type GetEdgesRequest = Message<"graph.v1.GetEdgesRequest"> & {
  * Use `create(GetEdgesRequestSchema)` to create a new message.
  */
 export const GetEdgesRequestSchema: GenMessage<GetEdgesRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 32);
+  messageDesc(file_graph_v1_graph, 33);
 
 /**
  * @generated from message graph.v1.GetEdgesResponse
@@ -984,7 +1063,7 @@ export type GetEdgesResponse = Message<"graph.v1.GetEdgesResponse"> & {
  * Use `create(GetEdgesResponseSchema)` to create a new message.
  */
 export const GetEdgesResponseSchema: GenMessage<GetEdgesResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 33);
+  messageDesc(file_graph_v1_graph, 34);
 
 /**
  * @generated from message graph.v1.DeleteEdgeRequest
@@ -1006,7 +1085,7 @@ export type DeleteEdgeRequest = Message<"graph.v1.DeleteEdgeRequest"> & {
  * Use `create(DeleteEdgeRequestSchema)` to create a new message.
  */
 export const DeleteEdgeRequestSchema: GenMessage<DeleteEdgeRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 34);
+  messageDesc(file_graph_v1_graph, 35);
 
 /**
  * @generated from message graph.v1.DeleteEdgeResponse
@@ -1025,7 +1104,7 @@ export type DeleteEdgeResponse = Message<"graph.v1.DeleteEdgeResponse"> & {
  * Use `create(DeleteEdgeResponseSchema)` to create a new message.
  */
 export const DeleteEdgeResponseSchema: GenMessage<DeleteEdgeResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 35);
+  messageDesc(file_graph_v1_graph, 36);
 
 /**
  * EdgeKey identifies an edge by its (tail, head) pair without weight.
@@ -1049,7 +1128,7 @@ export type EdgeKey = Message<"graph.v1.EdgeKey"> & {
  * Use `create(EdgeKeySchema)` to create a new message.
  */
 export const EdgeKeySchema: GenMessage<EdgeKey> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 36);
+  messageDesc(file_graph_v1_graph, 37);
 
 /**
  * ScanEdgesRequest streams edges whose tail key starts with `tail_prefix`
@@ -1100,7 +1179,7 @@ export type ScanEdgesRequest = Message<"graph.v1.ScanEdgesRequest"> & {
  * Use `create(ScanEdgesRequestSchema)` to create a new message.
  */
 export const ScanEdgesRequestSchema: GenMessage<ScanEdgesRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 37);
+  messageDesc(file_graph_v1_graph, 38);
 
 /**
  * @generated from message graph.v1.ScanEdgesResponse
@@ -1128,7 +1207,7 @@ export type ScanEdgesResponse = Message<"graph.v1.ScanEdgesResponse"> & {
  * Use `create(ScanEdgesResponseSchema)` to create a new message.
  */
 export const ScanEdgesResponseSchema: GenMessage<ScanEdgesResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 38);
+  messageDesc(file_graph_v1_graph, 39);
 
 /**
  * DeleteEdgesRequest removes several edges in one round trip. Subject to the
@@ -1148,7 +1227,7 @@ export type DeleteEdgesRequest = Message<"graph.v1.DeleteEdgesRequest"> & {
  * Use `create(DeleteEdgesRequestSchema)` to create a new message.
  */
 export const DeleteEdgesRequestSchema: GenMessage<DeleteEdgesRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 39);
+  messageDesc(file_graph_v1_graph, 40);
 
 /**
  * @generated from message graph.v1.DeleteEdgesResponse
@@ -1167,7 +1246,7 @@ export type DeleteEdgesResponse = Message<"graph.v1.DeleteEdgesResponse"> & {
  * Use `create(DeleteEdgesResponseSchema)` to create a new message.
  */
 export const DeleteEdgesResponseSchema: GenMessage<DeleteEdgesResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 40);
+  messageDesc(file_graph_v1_graph, 41);
 
 /**
  * AddEdgeRequest accumulates weight onto a single (tail, head) pair: repeated
@@ -1203,7 +1282,7 @@ export type AddEdgeRequest = Message<"graph.v1.AddEdgeRequest"> & {
  * Use `create(AddEdgeRequestSchema)` to create a new message.
  */
 export const AddEdgeRequestSchema: GenMessage<AddEdgeRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 41);
+  messageDesc(file_graph_v1_graph, 42);
 
 /**
  * @generated from message graph.v1.AddEdgeResponse
@@ -1216,7 +1295,7 @@ export type AddEdgeResponse = Message<"graph.v1.AddEdgeResponse"> & {
  * Use `create(AddEdgeResponseSchema)` to create a new message.
  */
 export const AddEdgeResponseSchema: GenMessage<AddEdgeResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 42);
+  messageDesc(file_graph_v1_graph, 43);
 
 /**
  * AddEdgesRequest accumulates weight onto each (tail, head) pair: repeated
@@ -1250,7 +1329,7 @@ export type AddEdgesRequest = Message<"graph.v1.AddEdgesRequest"> & {
  * Use `create(AddEdgesRequestSchema)` to create a new message.
  */
 export const AddEdgesRequestSchema: GenMessage<AddEdgesRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 43);
+  messageDesc(file_graph_v1_graph, 44);
 
 /**
  * @generated from message graph.v1.AddEdgesResponse
@@ -1269,7 +1348,7 @@ export type AddEdgesResponse = Message<"graph.v1.AddEdgesResponse"> & {
  * Use `create(AddEdgesResponseSchema)` to create a new message.
  */
 export const AddEdgesResponseSchema: GenMessage<AddEdgesResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 44);
+  messageDesc(file_graph_v1_graph, 45);
 
 /**
  * PutEdgeRequest overwrites a single (tail, head) pair, replacing any
@@ -1290,7 +1369,7 @@ export type PutEdgeRequest = Message<"graph.v1.PutEdgeRequest"> & {
  * Use `create(PutEdgeRequestSchema)` to create a new message.
  */
 export const PutEdgeRequestSchema: GenMessage<PutEdgeRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 45);
+  messageDesc(file_graph_v1_graph, 46);
 
 /**
  * @generated from message graph.v1.PutEdgeResponse
@@ -1303,7 +1382,7 @@ export type PutEdgeResponse = Message<"graph.v1.PutEdgeResponse"> & {
  * Use `create(PutEdgeResponseSchema)` to create a new message.
  */
 export const PutEdgeResponseSchema: GenMessage<PutEdgeResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 46);
+  messageDesc(file_graph_v1_graph, 47);
 
 /**
  * PutEdgesRequest overwrites each (tail, head) pair, replacing any existing
@@ -1323,7 +1402,7 @@ export type PutEdgesRequest = Message<"graph.v1.PutEdgesRequest"> & {
  * Use `create(PutEdgesRequestSchema)` to create a new message.
  */
 export const PutEdgesRequestSchema: GenMessage<PutEdgesRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 47);
+  messageDesc(file_graph_v1_graph, 48);
 
 /**
  * @generated from message graph.v1.PutEdgesResponse
@@ -1342,7 +1421,7 @@ export type PutEdgesResponse = Message<"graph.v1.PutEdgesResponse"> & {
  * Use `create(PutEdgesResponseSchema)` to create a new message.
  */
 export const PutEdgesResponseSchema: GenMessage<PutEdgesResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 48);
+  messageDesc(file_graph_v1_graph, 49);
 
 /**
  * GetServerStatusRequest carries no parameters — the response is a flat
@@ -1361,7 +1440,7 @@ export type GetServerStatusRequest = Message<"graph.v1.GetServerStatusRequest"> 
  * Use `create(GetServerStatusRequestSchema)` to create a new message.
  */
 export const GetServerStatusRequestSchema: GenMessage<GetServerStatusRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 49);
+  messageDesc(file_graph_v1_graph, 50);
 
 /**
  * @generated from message graph.v1.GetServerStatusResponse
@@ -1473,7 +1552,7 @@ export type GetServerStatusResponse = Message<"graph.v1.GetServerStatusResponse"
  * Use `create(GetServerStatusResponseSchema)` to create a new message.
  */
 export const GetServerStatusResponseSchema: GenMessage<GetServerStatusResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 50);
+  messageDesc(file_graph_v1_graph, 51);
 
 /**
  * ReplicationPeer is one row of the GetReplicationStatus snapshot.
@@ -1532,7 +1611,7 @@ export type ReplicationPeer = Message<"graph.v1.ReplicationPeer"> & {
  * Use `create(ReplicationPeerSchema)` to create a new message.
  */
 export const ReplicationPeerSchema: GenMessage<ReplicationPeer> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 51);
+  messageDesc(file_graph_v1_graph, 52);
 
 /**
  * @generated from enum graph.v1.ReplicationPeer.State
@@ -1580,7 +1659,7 @@ export enum ReplicationPeer_State {
  * Describes the enum graph.v1.ReplicationPeer.State.
  */
 export const ReplicationPeer_StateSchema: GenEnum<ReplicationPeer_State> = /*@__PURE__*/
-  enumDesc(file_graph_v1_graph, 51, 0);
+  enumDesc(file_graph_v1_graph, 52, 0);
 
 /**
  * GetReplicationStatusRequest carries no parameters. The response is a
@@ -1596,7 +1675,7 @@ export type GetReplicationStatusRequest = Message<"graph.v1.GetReplicationStatus
  * Use `create(GetReplicationStatusRequestSchema)` to create a new message.
  */
 export const GetReplicationStatusRequestSchema: GenMessage<GetReplicationStatusRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 52);
+  messageDesc(file_graph_v1_graph, 53);
 
 /**
  * @generated from message graph.v1.GetReplicationStatusResponse
@@ -1645,7 +1724,7 @@ export type GetReplicationStatusResponse = Message<"graph.v1.GetReplicationStatu
  * Use `create(GetReplicationStatusResponseSchema)` to create a new message.
  */
 export const GetReplicationStatusResponseSchema: GenMessage<GetReplicationStatusResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 53);
+  messageDesc(file_graph_v1_graph, 54);
 
 /**
  * BackupSnapshotRequest parameterises a whole-graph backup stream.
@@ -1667,7 +1746,7 @@ export type BackupSnapshotRequest = Message<"graph.v1.BackupSnapshotRequest"> & 
  * Use `create(BackupSnapshotRequestSchema)` to create a new message.
  */
 export const BackupSnapshotRequestSchema: GenMessage<BackupSnapshotRequest> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 54);
+  messageDesc(file_graph_v1_graph, 55);
 
 /**
  * BackupSnapshotResponse is one frame of the BackupSnapshot stream:
@@ -1701,7 +1780,7 @@ export type BackupSnapshotResponse = Message<"graph.v1.BackupSnapshotResponse"> 
  * Use `create(BackupSnapshotResponseSchema)` to create a new message.
  */
 export const BackupSnapshotResponseSchema: GenMessage<BackupSnapshotResponse> = /*@__PURE__*/
-  messageDesc(file_graph_v1_graph, 55);
+  messageDesc(file_graph_v1_graph, 56);
 
 /**
  * Reduction is the optional post-traversal tree view applied to a

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -77,6 +77,7 @@ export type {
   EdgeScanOptions,
   BfsOptions,
   IlluminateOptions,
+  LocalCommunityOptions,
   PprOptions,
   ScanOptions,
   SearchOptions,

--- a/sdks/node/src/options.ts
+++ b/sdks/node/src/options.ts
@@ -54,15 +54,45 @@ export interface PprOptions {
   epsilon?: number;
 }
 
+/**
+ * Local-community-family knobs (#845): PageRank-Nibble — the PPR push
+ * followed by a conductance sweep cut. Unlike the PPR relevance star the
+ * response preserves structure: the induced subgraph on the selected
+ * members with actual stored edge weights and expirations.
+ */
+export interface LocalCommunityOptions {
+  /**
+   * UPPER BOUND on community size — not an exact count; the sweep stops at
+   * the conductance minimum, which may come earlier. 0 = unbounded.
+   */
+  maxSize?: number;
+  /** Locality knob α, same semantics/defaults as PprOptions.restartProb. */
+  restartProb?: number;
+  /** Push accuracy ε, same semantics/defaults as PprOptions.epsilon. */
+  epsilon?: number;
+  /**
+   * Optional tree VIEW of the community rooted at the seed. Members
+   * unreachable from the seed within the community are returned as
+   * isolated vertices (membership preserved). UNSPECIFIED = the full
+   * induced subgraph.
+   */
+  reduction?: Reduction;
+  /** Direction/cost mapping for `reduction` only; ignored without one. */
+  objective?: Objective;
+}
+
 export interface IlluminateOptions {
   /**
-   * Select the BFS traversal family with its knobs (#846). Mutually
-   * exclusive with `ppr` — supplying both is an InvalidArgumentError.
-   * Omitting both runs BFS with server defaults (the bare illuminate).
+   * Select the BFS traversal family with its knobs (#846). The family
+   * options are mutually exclusive — supplying more than one is an
+   * InvalidArgumentError. Omitting all runs BFS with server defaults (the
+   * bare illuminate).
    */
   bfs?: BfsOptions;
-  /** Select the Personalized PageRank family. Mutually exclusive with `bfs`. */
+  /** Select the Personalized PageRank family. Mutually exclusive. */
   ppr?: PprOptions;
+  /** Select the local community extraction family (#845). Mutually exclusive. */
+  community?: LocalCommunityOptions;
   /**
    * Edge-weight transform applied BEFORE the walk (any family). Server
    * resolves UNSPECIFIED to RAW.

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -181,7 +181,7 @@ type DomainMetrics struct {
 // added in proto without a metrics update) fall through to "unknown"
 // so a new variant cannot break label pre-warming on existing dashboards.
 var (
-	algorithmLabels  = []string{"none", "mst", "spt", "ppr"}
+	algorithmLabels  = []string{"none", "mst", "spt", "ppr", "community"}
 	objectiveLabels  = []string{"minimize", "maximize"}
 	weightingLabels  = []string{"raw", "tfidf", "bm25"}
 	illuminatePhases = []string{"traversal", "optimize"}

--- a/server/provider/extra.go
+++ b/server/provider/extra.go
@@ -188,6 +188,10 @@ func (v *ValidationInterceptor) validate(req any) error {
 			if v.limits.IlluminateMaxK > 0 && int(params.Ppr.GetTopN()) > v.limits.IlluminateMaxK {
 				return v.reject("k_too_large", "ppr.top_n %d exceeds max %d", params.Ppr.GetTopN(), v.limits.IlluminateMaxK)
 			}
+		case *pb.IlluminateRequest_Community:
+			if v.limits.IlluminateMaxK > 0 && int(params.Community.GetMaxSize()) > v.limits.IlluminateMaxK {
+				return v.reject("k_too_large", "community.max_size %d exceeds max %d", params.Community.GetMaxSize(), v.limits.IlluminateMaxK)
+			}
 		}
 	}
 	return nil

--- a/server/provider/extra_test.go
+++ b/server/provider/extra_test.go
@@ -105,6 +105,11 @@ func TestValidationInterceptor_RejectHookFiresPerReason(t *testing.T) {
 			return connectCallValidator(t, v, &pb.IlluminateRequest{Seed: "s",
 				Params: &pb.IlluminateRequest_Ppr{Ppr: &pb.PprParams{TopN: 99}}}) // > IlluminateMaxK=5
 		}},
+		{"community_max_size_too_large", "k_too_large", func(t *testing.T, v *ValidationInterceptor) error {
+			// IlluminateMaxK caps community.max_size on the community arm (#845).
+			return connectCallValidator(t, v, &pb.IlluminateRequest{Seed: "s",
+				Params: &pb.IlluminateRequest_Community{Community: &pb.LocalCommunityParams{MaxSize: 99}}}) // > IlluminateMaxK=5
+		}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/service/backend.go
+++ b/server/service/backend.go
@@ -109,6 +109,23 @@ type Backend interface {
 		keep func(string) bool,
 	) (*coregraph.Graph[string, *pb.Vertex], map[string]map[string]time.Time, error)
 
+	// LocalCommunityContext extracts the conductance-optimal local
+	// community around seed (#845): the shared PPR forward-push followed by
+	// a sweep cut (PageRank-Nibble). maxSize is an UPPER BOUND (0 =
+	// unbounded); alpha/epsilon follow the PPR defaults; weighting steers
+	// the walk and the sweep only — the returned graph is the INDUCED
+	// SUBGRAPH on the selected members with actual stored edge weights and
+	// expirations, in the same (graph, expirations) shape as the BFS path.
+	// keep scopes both the walk and the community (seed exempt).
+	LocalCommunityContext(
+		ctx context.Context,
+		seed string,
+		maxSize int,
+		alpha, epsilon float64,
+		weighting graphcache.EdgeWeighting,
+		keep func(string) bool,
+	) (*coregraph.Graph[string, *pb.Vertex], map[string]map[string]time.Time, error)
+
 	// PersonalizedPageRankContext computes the seed-anchored Personalized
 	// PageRank vector via Andersen–Chung–Lang forward-push (#801) and returns
 	// it as a one-hop "relevance star": g.Edges[seed][v] carries v's PPR mass

--- a/server/service/fake_backend_test.go
+++ b/server/service/fake_backend_test.go
@@ -38,6 +38,17 @@ type fakeBackend struct {
 	lastNeighborStep        int
 	lastNeighborK           int
 
+	// LocalCommunityContext bookkeeping (#845).
+	communityCalls       int
+	lastCommunityMaxSize int
+	lastCommunityAlpha   float64
+	lastCommunityEpsilon float64
+	lastCommunityWeight  graphcache.EdgeWeighting
+	lastCommunityKeep    func(string) bool
+	communityGraph       *coregraph.Graph[string, *pb.Vertex]
+	communityExpirations map[string]map[string]time.Time
+	communityErr         error
+
 	// captured args from the most recent PersonalizedPageRankContext call
 	// (#801), so tests can assert the Illuminate handler routes algorithm=ppr
 	// to the forward-push path (not the BFS+reduction one), resolves the
@@ -194,6 +205,31 @@ func (f *fakeBackend) NeighborWithExpirationsContext(
 		g.Vertices[seed] = v
 	}
 	return g, map[string]map[string]time.Time{}, nil
+}
+
+func (f *fakeBackend) LocalCommunityContext(
+	_ context.Context,
+	seed string,
+	maxSize int,
+	alpha, epsilon float64,
+	weighting graphcache.EdgeWeighting,
+	keep func(string) bool,
+) (*coregraph.Graph[string, *pb.Vertex], map[string]map[string]time.Time, error) {
+	f.communityCalls++
+	f.lastCommunityMaxSize = maxSize
+	f.lastCommunityAlpha = alpha
+	f.lastCommunityEpsilon = epsilon
+	f.lastCommunityWeight = weighting
+	f.lastCommunityKeep = keep
+	if f.communityErr != nil {
+		return nil, nil, f.communityErr
+	}
+	if f.communityGraph != nil {
+		return f.communityGraph, f.communityExpirations, nil
+	}
+	g := coregraph.NewGraph[string, *pb.Vertex]()
+	g.Vertices[seed] = &pb.Vertex{Key: seed}
+	return g, nil, nil
 }
 
 func (f *fakeBackend) PersonalizedPageRankContext(

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -535,6 +535,57 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 		}
 		paramsLabel, objLabel = "ppr", "maximize"
 
+	case *pb.IlluminateRequest_Community:
+		// Local community extraction (#845): PageRank-Nibble sweep cut over
+		// the shared push. Membership is decided by conductance (max_size is
+		// an upper bound, not a count) and the result is the induced
+		// subgraph — real edges with real weights and expirations, unlike
+		// the PPR star. An optional Reduction renders a tree VIEW rooted at
+		// the seed; sweep prefixes need not be connected, so members
+		// unreachable from the seed within the community stay as ISOLATED
+		// vertices rather than being dropped or wired up artificially.
+		comm := params.Community
+		alpha, epsilon := resolvePPRParams(comm.GetRestartProb(), comm.GetEpsilon())
+		traversalStart := time.Now()
+		g, expirations, err = s.cache.LocalCommunityContext(ctx, request.GetSeed(), int(comm.GetMaxSize()), alpha, epsilon, coreWeighting, keep)
+		traversalDur = time.Since(traversalStart)
+		if err != nil {
+			return nil, ctxToConnect(err)
+		}
+		if opt := resolveOptimizer(comm.GetReduction(), comm.GetObjective()); opt != nil {
+			optStart := time.Now()
+			reduced, rerr := opt(ctx, g, request.GetSeed())
+			if rerr != nil {
+				return nil, ctxToConnect(rerr)
+			}
+			// Membership is preserved: re-add community members the tree
+			// could not reach as isolated vertices, then trim expirations to
+			// the surviving tree edges.
+			for k, v := range g.Vertices {
+				if _, ok := reduced.Vertices[k]; !ok {
+					reduced.Vertices[k] = v
+				}
+			}
+			g = reduced
+			trimmed := make(map[string]map[string]time.Time, len(g.Edges))
+			for tail, heads := range g.Edges {
+				if expRow, ok := expirations[tail]; ok {
+					row := make(map[string]time.Time, len(heads))
+					for head := range heads {
+						if exp, has := expRow[head]; has {
+							row[head] = exp
+						}
+					}
+					if len(row) > 0 {
+						trimmed[tail] = row
+					}
+				}
+			}
+			expirations = trimmed
+			optimizeDur = time.Since(optStart)
+		}
+		paramsLabel, objLabel = "community", objectiveLabel(comm.GetObjective())
+
 	default: // *pb.IlluminateRequest_Bfs or unset — the BFS family.
 		bfs := request.GetBfs() // nil-safe: getters yield zero values on an unset oneof
 		// Objective steers the per-hop top-k pruning as well as the

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	coregraph "github.com/anaregdesign/lantern/core/graph"
 	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
@@ -1797,4 +1798,134 @@ func TestIlluminate_FlatFieldGhost(t *testing.T) {
 	if fb.lastNeighborSelectSmall {
 		t.Fatal("ghost objective byte flipped pruning to smallest; want strongest-first default")
 	}
+}
+
+// TestLanternService_Illuminate_LocalCommunity pins the #845 wire arm:
+// dispatch to LocalCommunityContext with max_size/α/ε plumbing, the
+// "community" metric label, a response carrying real induced edges (not a
+// star), the optional tree reduction with the isolated-vertex membership
+// contract, and reduction-unset output identical to the raw arm.
+func TestLanternService_Illuminate_LocalCommunity(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("dispatch and knob plumbing", func(t *testing.T) {
+		fb := newFakeBackend()
+		svc := NewLanternService(fb)
+		if _, err := svc.Illuminate(ctx, &pb.IlluminateRequest{
+			Seed: "s",
+			Params: &pb.IlluminateRequest_Community{Community: &pb.LocalCommunityParams{
+				MaxSize: 7, RestartProb: 0.3, Epsilon: 1e-3,
+			}},
+		}); err != nil {
+			t.Fatalf("Illuminate: %v", err)
+		}
+		if fb.communityCalls != 1 || fb.pprCalls != 0 || fb.neighborCalls != 0 {
+			t.Fatalf("dispatch: community=%d ppr=%d neighbor=%d, want 1/0/0",
+				fb.communityCalls, fb.pprCalls, fb.neighborCalls)
+		}
+		if fb.lastCommunityMaxSize != 7 {
+			t.Errorf("maxSize = %d, want 7", fb.lastCommunityMaxSize)
+		}
+		if math.Abs(fb.lastCommunityAlpha-0.3) > 1e-6 || math.Abs(fb.lastCommunityEpsilon-1e-3) > 1e-9 {
+			t.Errorf("alpha/epsilon = %v/%v, want 0.3/1e-3", fb.lastCommunityAlpha, fb.lastCommunityEpsilon)
+		}
+	})
+
+	t.Run("unset knobs resolve to PPR defaults", func(t *testing.T) {
+		fb := newFakeBackend()
+		svc := NewLanternService(fb)
+		if _, err := svc.Illuminate(ctx, &pb.IlluminateRequest{
+			Seed:   "s",
+			Params: &pb.IlluminateRequest_Community{Community: &pb.LocalCommunityParams{}},
+		}); err != nil {
+			t.Fatalf("Illuminate: %v", err)
+		}
+		if fb.lastCommunityAlpha != graphcache.DefaultPPRAlpha || fb.lastCommunityEpsilon != graphcache.DefaultPPREpsilon {
+			t.Errorf("defaults = %v/%v, want %v/%v", fb.lastCommunityAlpha, fb.lastCommunityEpsilon,
+				graphcache.DefaultPPRAlpha, graphcache.DefaultPPREpsilon)
+		}
+	})
+
+	t.Run("real induced edges end to end, not a star", func(t *testing.T) {
+		s := newTestService(t)
+		seedTriangle(t, s)
+		resp, err := s.Illuminate(ctx, &pb.IlluminateRequest{
+			Seed:   "a",
+			Params: &pb.IlluminateRequest_Community{Community: &pb.LocalCommunityParams{}},
+		})
+		if err != nil {
+			t.Fatalf("Illuminate: %v", err)
+		}
+		// The triangle's non-seed-tail edges must survive — a star would
+		// only ever emit edges with tail == seed.
+		nonSeedTail := false
+		for _, e := range resp.Graph.Edges {
+			if e.Tail != "a" {
+				nonSeedTail = true
+			}
+			if e.Expiration == nil {
+				t.Errorf("induced edge %s->%s missing expiration", e.Tail, e.Head)
+			}
+		}
+		if !nonSeedTail {
+			t.Fatalf("no non-seed-tail edge in response — looks like a star: %+v", resp.Graph.Edges)
+		}
+	})
+
+	t.Run("reduction keeps unreachable members as isolated vertices", func(t *testing.T) {
+		// Fake community {s, m, island}: island is a member but has no edge
+		// from s's reachable component. The SPT view must keep island as an
+		// isolated vertex, and tree edges must not exceed |reachable|-1.
+		fb := newFakeBackend()
+		g := coregraph.NewGraph[string, *pb.Vertex]()
+		for _, k := range []string{"s", "m", "island"} {
+			g.Vertices[k] = &pb.Vertex{Key: k, Value: &pb.Vertex_Nil{Nil: true}}
+		}
+		g.Edges["s"] = map[string]float32{"m": 1}
+		fb.communityGraph = g
+		fb.communityExpirations = map[string]map[string]time.Time{
+			"s": {"m": time.Now().Add(time.Hour)},
+		}
+		svc := NewLanternService(fb)
+		resp, err := svc.Illuminate(ctx, &pb.IlluminateRequest{
+			Seed: "s",
+			Params: &pb.IlluminateRequest_Community{Community: &pb.LocalCommunityParams{
+				Reduction: pb.Reduction_REDUCTION_SHORTEST_PATH_TREE,
+			}},
+		})
+		if err != nil {
+			t.Fatalf("Illuminate: %v", err)
+		}
+		keys := map[string]bool{}
+		for _, v := range resp.Graph.Vertices {
+			keys[v.GetKey()] = true
+		}
+		if !keys["island"] {
+			t.Fatalf("unreachable member dropped by the reduction: %v", keys)
+		}
+		if len(resp.Graph.Edges) > 1 {
+			t.Fatalf("tree has %d edges, want <= |reachable|-1 = 1", len(resp.Graph.Edges))
+		}
+	})
+
+	t.Run("reduction unset equals raw induced output", func(t *testing.T) {
+		build := func(red pb.Reduction) *pb.IlluminateResponse {
+			s := newTestService(t)
+			seedTriangle(t, s)
+			resp, err := s.Illuminate(ctx, &pb.IlluminateRequest{
+				Seed:   "a",
+				Params: &pb.IlluminateRequest_Community{Community: &pb.LocalCommunityParams{Reduction: red}},
+			})
+			if err != nil {
+				t.Fatalf("Illuminate: %v", err)
+			}
+			return resp
+		}
+		raw := build(pb.Reduction_REDUCTION_UNSPECIFIED)
+		again := build(pb.Reduction_REDUCTION_UNSPECIFIED)
+		if len(raw.Graph.Vertices) != len(again.Graph.Vertices) || len(raw.Graph.Edges) != len(again.Graph.Edges) {
+			t.Fatalf("reduction-unset output not stable: %d/%d vs %d/%d vertices/edges",
+				len(raw.Graph.Vertices), len(raw.Graph.Edges), len(again.Graph.Vertices), len(again.Graph.Edges))
+		}
+	})
 }

--- a/tests/integration/illuminate_prefix_test.go
+++ b/tests/integration/illuminate_prefix_test.go
@@ -232,6 +232,8 @@ func TestIlluminate_OneofArmRoundTrips(t *testing.T) {
 				Reduction: pb.Reduction_REDUCTION_SHORTEST_PATH_TREE, Objective: pb.Objective_OBJECTIVE_MINIMIZE}}}, false},
 		{"ppr arm", &pb.IlluminateRequest{Seed: "s",
 			Params: &pb.IlluminateRequest_Ppr{Ppr: &pb.PprParams{TopN: 5, RestartProb: 0.2, Epsilon: 1e-3}}}, false},
+		{"community arm", &pb.IlluminateRequest{Seed: "s",
+			Params: &pb.IlluminateRequest_Community{Community: &pb.LocalCommunityParams{MaxSize: 5, Epsilon: 1e-5}}}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #845

## What

`ALGORITHM_LOCAL_COMMUNITY` becomes the third Illuminate family: the same ACL forward-push the PPR arm runs (#801), followed by a **sweep cut** — vertices ordered by π(v)/d_w(v), prefix minimising directed weighted out-volume conductance — i.e. PageRank-Nibble (Andersen–Chung–Lang, FOCS 2006). Where PPR's `top_n` arbitrarily truncates (splitting tight communities or dragging in a neighboring one), the sweep finds the natural boundary; and where PPR returns a synthetic relevance star, this returns the **induced subgraph** — real live edges among members with actual stored weights and expirations, in the BFS path's response shape.

## Core (`core/graphcache/traversal.go`)

- Push loop factored into `pprPushLocked`, shared verbatim by both families (defaults, `pprMaxPushes` cap, ctx polling, `keep`, #750 liveness, single #838 clock). Existing PPR tests pass unchanged on the refactor.
- Incremental sweep per the issue's pinned formula: `frontierWeight[x] = Σ_{u∈S} w(u→x)` gives O(1) cut updates; `φ = cut / min(vol, volTouched − vol)`; the volume universe is the **touched set** (the subgraph the push localised — keeps the sweep `O(touched·log touched + edges(touched))`; edges leaving it still count toward the cut), and the full-universe prefix scores +Inf so a vanishing boundary can never win.
- Determinism (the sequencing-comment addition): ordering is `(p/d_w desc, key asc)` with the seed pinned first; the degenerate fallback (<3 touched or monotone φ profile) uses the same deterministic `(mass desc, key asc)` ranking rather than `pq.Top`'s arbitrary tie-breaks. Pinned by a symmetric-star exact-tie fixture run 10×.
- `maxSize` is an **upper bound** — the sweep may stop earlier.

## Wire / server (on #846's oneof)

- `LocalCommunityParams{max_size, restart_prob, epsilon, reduction, objective}` = field 14 in the params oneof, exactly the #846 spec.
- New dispatch arm; metric label `community` (additive; existing values untouched); `ValidationInterceptor` caps `community.max_size` under `IlluminateMaxK` with a paired test.
- **Optional tree view** per the issue's reduction contract: applied over the induced subgraph rooted at the seed; sweep prefixes need not be connected, so members unreachable from the seed remain as **isolated vertices** (membership preserved, no fabricated edges — pinned by test); expirations trimmed to surviving tree edges; reduction unset = raw induced subgraph.

## Consumers

Go SDK `WithLocalCommunity(LocalCommunityOpts)`; node SDK `community` option object (family mutual-exclusion widened); CLI + admin TS grammar gain `algorithm=community`; lantern-ops skill updated. Admin UI exposure stays a follow-up per the issue; MCP retarget is #851.

## Tests & bench

Two-clique weak-bridge boundary exactness (community from a clique-A seed is exactly A), maxSize cap, keep scoping, tie determinism, #750 liveness, degenerate fallback, ctx cancel, unknown seed; server dispatch/knob/default plumbing, real-induced-edges end-to-end (non-seed-tail edges with expirations — provably not a star), isolated-vertex reduction contract; integration round-trip per arm.

Planted-partition bench (20 communities × 50, dense intra + weak cross links): `LocalCommunity` 808µs vs `PPRTopN` 609µs — the sweep adds ~33% on top of the shared push, within the target cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)