### PR TITLE
feat(sdks,admin,testbed): bearer-token support for the TS surfaces

### DIFF
--- a/admin/app/components/shared/ConnectionSwitcher/ConnectionSwitcher.tsx
+++ b/admin/app/components/shared/ConnectionSwitcher/ConnectionSwitcher.tsx
@@ -17,15 +17,17 @@ import { DEFAULT_BASE_URL } from "~/lib/client/usecase/connection/base-url";
 import styles from "./ConnectionSwitcher.module.css";
 
 export function ConnectionSwitcher() {
-  const { connection, setBaseUrl, reset } = useConnection();
+  const { connection, setBaseUrl, setToken, reset } = useConnection();
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState(connection.baseUrl);
+  const [tokenDraft, setTokenDraft] = useState(connection.token);
   const [error, setError] = useState<string | null>(null);
 
   const onOpenChange = (next: boolean) => {
     setOpen(next);
     if (next) {
       setDraft(connection.baseUrl);
+      setTokenDraft(connection.token);
       setError(null);
     }
   };
@@ -36,6 +38,7 @@ export function ConnectionSwitcher() {
       setError("Enter an http(s) URL like http://localhost:6380");
       return;
     }
+    setToken(tokenDraft);
     setOpen(false);
   };
 
@@ -73,6 +76,17 @@ export function ConnectionSwitcher() {
                   placeholder={DEFAULT_BASE_URL}
                 />
               </Field>
+              <Field
+                label="Bearer token"
+                hint="Leave blank unless the server sets LANTERN_AUTH_TOKENS (#850)."
+              >
+                <Input
+                  type="password"
+                  value={tokenDraft}
+                  onChange={(_, data) => setTokenDraft(data.value)}
+                  placeholder="(no auth)"
+                />
+              </Field>
             </div>
           </DialogContent>
           <DialogActions>
@@ -81,6 +95,7 @@ export function ConnectionSwitcher() {
               onClick={() => {
                 reset();
                 setDraft(DEFAULT_BASE_URL);
+                setTokenDraft("");
                 setError(null);
               }}
             >

--- a/admin/app/lib/client/infrastructure/api/lantern-client.ts
+++ b/admin/app/lib/client/infrastructure/api/lantern-client.ts
@@ -10,6 +10,8 @@ export type LanternClient = Lantern;
 
 export interface LanternClientOptions {
   baseUrl: string;
+  /** Optional bearer token for LANTERN_AUTH_TOKENS servers (#850). */
+  token?: string;
 }
 
 /**
@@ -25,5 +27,7 @@ export interface LanternClientOptions {
  * fewer adapter layer to maintain.
  */
 export function createLanternClient(opts: LanternClientOptions): LanternClient {
-  return connectWeb(opts.baseUrl.replace(/\/$/, ""));
+  return connectWeb(opts.baseUrl.replace(/\/$/, ""), {
+    token: opts.token || undefined,
+  });
 }

--- a/admin/app/lib/client/infrastructure/api/use-lantern-client.ts
+++ b/admin/app/lib/client/infrastructure/api/use-lantern-client.ts
@@ -10,7 +10,11 @@ import { useConnection } from "~/lib/client/usecase/connection/connection-contex
 export function useLanternClient(): LanternClient {
   const { connection } = useConnection();
   return useMemo(
-    () => createLanternClient({ baseUrl: connection.baseUrl }),
-    [connection.baseUrl],
+    () =>
+      createLanternClient({
+        baseUrl: connection.baseUrl,
+        token: connection.token,
+      }),
+    [connection.baseUrl, connection.token],
   );
 }

--- a/admin/app/lib/client/infrastructure/browser/storage.ts
+++ b/admin/app/lib/client/infrastructure/browser/storage.ts
@@ -1,4 +1,5 @@
 const STORAGE_KEY = "lantern.admin.baseUrl";
+const TOKEN_STORAGE_KEY = "lantern.admin.authToken";
 const PROMETHEUS_STORAGE_KEY = "lantern.admin.prometheusUrl";
 const METRICS_RANGE_STORAGE_KEY = "lantern.admin.metricsRange";
 const METRICS_AGG_MODE_STORAGE_KEY = "lantern.admin.metricsAggMode";
@@ -39,6 +40,13 @@ function memoryStorage(): BrowserStorage {
 }
 
 export const connectionStorageKey = STORAGE_KEY;
+
+/**
+ * localStorage key for the optional bearer token sent as
+ * `Authorization: Bearer` when the server runs with LANTERN_AUTH_TOKENS
+ * (#850). Empty/absent = no auth header (the default open behaviour).
+ */
+export const connectionTokenStorageKey = TOKEN_STORAGE_KEY;
 
 /**
  * localStorage key the admin SPA stores the Prometheus query base URL

--- a/admin/app/lib/client/usecase/connection/connection-context.tsx
+++ b/admin/app/lib/client/usecase/connection/connection-context.tsx
@@ -10,16 +10,23 @@ import {
 import {
   browserStorage,
   connectionStorageKey,
+  connectionTokenStorageKey,
 } from "~/lib/client/infrastructure/browser/storage";
 import { DEFAULT_BASE_URL, normaliseBaseUrl } from "./base-url";
 
 export interface Connection {
   baseUrl: string;
+  /**
+   * Optional bearer token for servers running with LANTERN_AUTH_TOKENS
+   * (#850). Empty string = no auth header.
+   */
+  token: string;
 }
 
 export interface ConnectionContextValue {
   connection: Connection;
   setBaseUrl: (input: string) => boolean;
+  setToken: (input: string) => void;
   reset: () => void;
 }
 
@@ -48,9 +55,21 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     return DEFAULT_BASE_URL;
   });
 
+  const [token, setTokenState] = useState<string>(
+    () => storage.get(connectionTokenStorageKey) ?? "",
+  );
+
   useEffect(() => {
     storage.set(connectionStorageKey, baseUrl);
   }, [baseUrl, storage]);
+
+  useEffect(() => {
+    if (token) {
+      storage.set(connectionTokenStorageKey, token);
+    } else {
+      storage.remove(connectionTokenStorageKey);
+    }
+  }, [token, storage]);
 
   const setBaseUrl = useCallback((input: string) => {
     const normalised = normaliseBaseUrl(input);
@@ -61,17 +80,23 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     return true;
   }, []);
 
+  const setToken = useCallback((input: string) => {
+    setTokenState(input.trim());
+  }, []);
+
   const reset = useCallback(() => {
     setBaseUrlState(DEFAULT_BASE_URL);
+    setTokenState("");
   }, []);
 
   const value = useMemo<ConnectionContextValue>(
     () => ({
-      connection: { baseUrl },
+      connection: { baseUrl, token },
       setBaseUrl,
+      setToken,
       reset,
     }),
-    [baseUrl, setBaseUrl, reset],
+    [baseUrl, token, setBaseUrl, setToken, reset],
   );
 
   return (

--- a/sdks/node/src/client.ts
+++ b/sdks/node/src/client.ts
@@ -89,6 +89,14 @@ import {
 export interface LanternArgs {
   options?: ConnectOptions;
   /**
+   * Bearer token for servers running with LANTERN_AUTH_TOKENS (#850).
+   * Attached as `Authorization: Bearer <token>` on every call via a
+   * Connect interceptor prepended ahead of `interceptors`. Bearer tokens
+   * over plaintext h2c are sniffable — use an https:// baseUrl outside
+   * trusted networks.
+   */
+  token?: string;
+  /**
    * Optional list of Connect interceptors run on every unary call.
    * The order matches @connectrpc/connect's `Interceptor[]` chain —
    * the first entry sees outgoing requests first and responses last.
@@ -126,6 +134,24 @@ const WEIGHTING_TO_PB: Record<number, PbWeighting> = {
   [Weighting.TFIDF]: PbWeighting.TFIDF,
   [Weighting.BM25]: PbWeighting.BM25,
 };
+
+/**
+ * Build the client-side bearer interceptor behind `LanternArgs.token`
+ * (#850). Exported for the entrypoints; not part of the public API
+ * surface beyond them.
+ */
+export function authTokenInterceptor(token: string): Interceptor {
+  return (next) => (req) => {
+    req.header.set("Authorization", `Bearer ${token}`);
+    return next(req);
+  };
+}
+
+/** Prepend the token interceptor (when configured) ahead of user interceptors. */
+export function withTokenInterceptors(args: LanternArgs): Interceptor[] | undefined {
+  if (!args.token) return args.interceptors;
+  return [authTokenInterceptor(args.token), ...(args.interceptors ?? [])];
+}
 
 function normaliseBaseUrl(caller: string, baseUrl: string): string {
   if (!baseUrl) {

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -24,7 +24,7 @@
  * @packageDocumentation
  */
 
-import { Lantern, normaliseBaseUrl, type LanternArgs } from "./client.js";
+import { Lantern, normaliseBaseUrl, withTokenInterceptors, type LanternArgs } from "./client.js";
 import { makeNodeTransport } from "./transport-node.js";
 
 /**
@@ -43,7 +43,7 @@ import { makeNodeTransport } from "./transport-node.js";
 export function connect(baseUrl: string, args: LanternArgs = {}): Lantern {
   const normalised = normaliseBaseUrl("connect", baseUrl);
   return Lantern.withTransport(
-    makeNodeTransport(normalised, args.interceptors, args.transportOptions),
+    makeNodeTransport(normalised, withTokenInterceptors(args), args.transportOptions),
     args.options,
   );
 }

--- a/sdks/node/src/web.ts
+++ b/sdks/node/src/web.ts
@@ -20,7 +20,7 @@
  * @packageDocumentation
  */
 
-import { Lantern, normaliseBaseUrl, type LanternArgs } from "./client.js";
+import { Lantern, normaliseBaseUrl, withTokenInterceptors, type LanternArgs } from "./client.js";
 import { makeWebTransport } from "./transport-web.js";
 
 /**
@@ -37,7 +37,7 @@ import { makeWebTransport } from "./transport-web.js";
 export function connectWeb(baseUrl: string, args: LanternArgs = {}): Lantern {
   const normalised = normaliseBaseUrl("connectWeb", baseUrl);
   return Lantern.withTransport(
-    makeWebTransport(normalised, args.interceptors, args.transportOptions),
+    makeWebTransport(normalised, withTokenInterceptors(args), args.transportOptions),
     args.options,
   );
 }

--- a/sdks/node/test/client.test.ts
+++ b/sdks/node/test/client.test.ts
@@ -395,3 +395,44 @@ describe("searchVertices request building (#639)", () => {
     }
   });
 });
+
+describe("bearer token option (#850)", () => {
+  test("token attaches Authorization on every call", async () => {
+    let seen: string | null = null;
+    const c = connect(baseUrl, {
+      token: "n0de-s3cret",
+      transportOptions: { httpVersion: "1.1" },
+      interceptors: [
+        (next) => (req) => {
+          seen = req.header.get("Authorization");
+          return next(req);
+        },
+      ],
+    });
+    try {
+      await c.getVertex("nope").catch(() => undefined);
+      expect(seen).toBe("Bearer n0de-s3cret");
+    } finally {
+      c.close();
+    }
+  });
+
+  test("no token leaves the header absent", async () => {
+    let seen: string | null = "sentinel";
+    const c = connect(baseUrl, {
+      transportOptions: { httpVersion: "1.1" },
+      interceptors: [
+        (next) => (req) => {
+          seen = req.header.get("Authorization");
+          return next(req);
+        },
+      ],
+    });
+    try {
+      await c.getVertex("nope").catch(() => undefined);
+      expect(seen).toBeNull();
+    } finally {
+      c.close();
+    }
+  });
+});

--- a/testbed/SKILL.md
+++ b/testbed/SKILL.md
@@ -17,6 +17,7 @@ the running server while capturing logs + metrics. Used to validate releases
 ```
 testbed/
 ├── docker-compose.yml      # lantern + prom/prometheus
+├── docker-compose.auth.yml # overlay: bearer-token auth armed (#850)
 ├── prometheus.yml          # 5s scrape against lantern:9090
 ├── scripts/
 │   ├── exercise-cli.sh     # 28 CLI scenarios; per-step rc + log capture
@@ -27,7 +28,9 @@ testbed/
 
 The `lantern` service in compose defaults to `image: ${LANTERN_IMAGE:-lantern:local}`
 so you can flip between a locally-built image and a pinned release with
-`LANTERN_IMAGE=ghcr.io/anaregdesign/lantern:v0.7.1 docker compose up -d`.
+`LANTERN_IMAGE=ghcr.io/anaregdesign/lantern:v0.7.1 docker compose up -d
+# auth-on variant (#850): clients then need --token testbed-secret / LANTERN_TOKEN
+# docker compose -f docker-compose.yml -f docker-compose.auth.yml up -d`.
 
 ## End-to-end procedure
 

--- a/testbed/docker-compose.auth.yml
+++ b/testbed/docker-compose.auth.yml
@@ -1,0 +1,21 @@
+# Auth-on overlay (#850): run the testbed with bearer-token auth armed.
+#
+# Usage:
+#   cd testbed
+#   docker compose -f docker-compose.yml -f docker-compose.auth.yml up -d
+#   LANTERN_TOKEN=testbed-secret lantern-cli get vertex alice     # env form
+#   lantern-cli --token testbed-secret get vertex alice           # flag form
+#
+# Notes:
+#   - LANTERN_AUTH_TOKENS carries two entries to exercise the documented
+#     zero-downtime rotation shape (clients may present either).
+#   - The healthcheck needs no token: /readyz lives on the metrics
+#     listener (bind-scoped, no auth by design) and grpc.health.v1 is
+#     always exempt.
+#   - Bearer tokens over plaintext h2c are sniffable; this overlay is for
+#     LOCAL testbed exercise only — see docs/ha-runbook.md "Securing the
+#     cluster" for the token+TLS guidance.
+services:
+  lantern:
+    environment:
+      LANTERN_AUTH_TOKENS: "testbed-secret,testbed-secret-rotating"


### PR DESCRIPTION
Refs #850 (second tranche of the issue's suggested PR split; the server interceptor, replication peers, Go SDK, CLI, MCP passthrough and docs landed via #868)

- **node SDK**: `LanternArgs.token` attaches `Authorization: Bearer <token>` via a Connect interceptor prepended ahead of user interceptors, on both the Node (`connect`) and browser (`connectWeb`) entrypoints. Tests pin header presence with a token and absence without.
- **admin SPA**: the gateway connection dialog gains a bearer-token field (password input; persisted under `lantern.admin.authToken`; cleared on Reset). `useLanternClient` re-memoises when the token changes and threads it into `connectWeb`.
- **testbed**: `docker-compose.auth.yml` overlay arms `LANTERN_AUTH_TOKENS` with a rotation-shaped two-entry set; `SKILL.md` documents the variant and why the healthcheck needs no token (`/readyz` lives on the bind-scoped metrics listener; `grpc.health.v1` is always exempt).

Gates: node SDK codegen/lint/format:check/typecheck/test/build green; admin format/lint/typecheck/test/build green (one pre-existing unrelated hook warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)