### PR TITLE
feat(sdks/go): opt-in retry policy with backoff for idempotent RPCs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,11 @@ go test ./...                    # then repeat in EACH submodule:
 (cd sdks/go && go test ./...); (cd server && go vet ./... && go test ./...)
 ```
 
+CI additionally enforces **per-module coverage floors** (a ratchet — table in CONTRIBUTING.md "Coverage floor"; raise the floor in the same PR when coverage rises durably) and fails the `Proto (buf)` check on any uncommitted codegen diff — regenerate and commit before pushing.
+
 Admin SPA (`admin/`, Bun-managed, outside `go.work`): `bun run format && bun run lint && bun run typecheck && bun run test && bun run build` (use package scripts, never bare `bun test`). See [admin/AGENTS.md](admin/AGENTS.md).
+
+Node SDK (`sdks/node/`, Bun-managed, outside `go.work`, npm `lantern-sdk`): from `sdks/node/` run `bun run codegen` (must leave `src/generated` clean — CI fails otherwise), then `bun run lint && bun run format:check && bun run typecheck && bun test && bun run build`. Single-endpoint only — no counterpart to the Go SDK's failover.
 
 ## Architecture
 
@@ -50,6 +54,7 @@ Multi-module Go workspace ([go.work](go.work)); dependency direction is a DAG wi
 - **SDK value accessors are free functions, not methods**: `Kind(v)`, `IntValue(v)`, `StringValue(v)`, etc. `client.Vertex`/`client.Edge` are true aliases of the `pb` types. Adding a value type updates three sites in [sdks/go/value.go](sdks/go/value.go).
 - Server tests needing the client SDK (full-stack round-trips) go in `tests/integration/`, never under `server/`.
 - HA/replication work implements against [docs/replication.md](docs/replication.md) (RFC); [docs/ha-runbook.md](docs/ha-runbook.md) is the operator playbook.
+- `testbed/` is the release-QA harness (docker-compose Lantern+Prometheus, exhaustive CLI/SDK sweeps, HA smoke/recovery) — procedure in [testbed/SKILL.md](testbed/SKILL.md). `.github/skills/lantern-ops` is the canonical `lantern-cli` data-operations reference; `.github/skills/react-router-app-architecture` governs admin SPA work.
 - **Pre-v1.0.0: no backward-compat guarantees** — break the proto/wire schema, SDK APIs, CLI grammar, `LANTERN_*` env vars, and metric names freely; don't hedge for old clients. Canonical: CONTRIBUTING.md "Versioning & compatibility". Separate & still forbidden: `buf generate --clean`.
 
 ## Go conventions

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -219,24 +219,49 @@ func (l *Lantern) applyTimeout(ctx context.Context) (context.Context, context.Ca
 	return context.WithTimeout(ctx, l.opts.defaultTimeout)
 }
 
-// unary is the one-line forwarding helper every *Lantern RPC method
-// uses. It boxes req via connect.NewRequest, runs the typed Connect-Go
-// method, lifts errors through wrapConnectErr so the SDK sentinels
-// (ErrNotFound, etc.) match, and returns the unwrapped response.
+// unary is the forwarding helper every *Lantern RPC method uses. It boxes
+// req via connect.NewRequest, runs the typed Connect-Go method, lifts
+// errors through wrapConnectErr so the SDK sentinels (ErrNotFound, etc.)
+// match, and returns the unwrapped response.
+//
+// When WithRetry is armed (#849) and the request is retry-eligible
+// (requestRetryable — the code-enforced idempotency matrix), the call is
+// driven through the policy's bounded backoff loop. The request message is
+// built once and re-sent verbatim, so a retried AddEdges carries the SAME
+// ContribIDs on every attempt — the exactly-once property
+// WithIdempotentAdds provides.
 //
 // Callers are responsible for applyTimeout — unary leaves ctx alone so
 // batch helpers can drive a single outer deadline across multiple
 // chunks.
 func unary[Req, Resp any](
 	ctx context.Context,
+	l *Lantern,
 	req *Req,
 	fn func(context.Context, *connect.Request[Req]) (*connect.Response[Resp], error),
 ) (*Resp, error) {
-	resp, err := fn(ctx, connect.NewRequest(req))
-	if err != nil {
-		return nil, wrapConnectErr(err)
+	do := func() (*Resp, error) {
+		resp, err := fn(ctx, connect.NewRequest(req))
+		if err != nil {
+			return nil, wrapConnectErr(err)
+		}
+		return resp.Msg, nil
 	}
-	return resp.Msg, nil
+	if l == nil || l.opts.retry == nil || !requestRetryable(req) {
+		return do()
+	}
+	var out *Resp
+	err := l.opts.retry.run(ctx, func() error {
+		r, e := do()
+		if e == nil {
+			out = r
+		}
+		return e
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // wrapConnectErr lifts a *connect.Error into a joined error that
@@ -279,7 +304,7 @@ func wrapConnectErr(err error) error {
 func (l *Lantern) GetVertex(ctx context.Context, key string) (*Vertex, error) {
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	resp, err := unary(ctx, &pb.GetVertexRequest{Key: key}, l.client.GetVertex)
+	resp, err := unary(ctx, l, &pb.GetVertexRequest{Key: key}, l.client.GetVertex)
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +339,7 @@ func (l *Lantern) PutVertexAt(ctx context.Context, key string, value any, expira
 	}
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	_, err = unary(ctx, &pb.PutVerticesRequest{Vertices: []*pb.Vertex{v}}, l.client.PutVertices)
+	_, err = unary(ctx, l, &pb.PutVerticesRequest{Vertices: []*pb.Vertex{v}}, l.client.PutVertices)
 	return err
 }
 
@@ -340,7 +365,7 @@ func (l *Lantern) PutVertices(ctx context.Context, inputs []VertexInput) error {
 		vs = append(vs, v)
 	}
 	_, err := runBatchWrite(ctx, l, vs, func(ctx context.Context, chunk []*pb.Vertex) (int32, error) {
-		_, err := unary(ctx, &pb.PutVerticesRequest{Vertices: chunk}, l.client.PutVertices)
+		_, err := unary(ctx, l, &pb.PutVerticesRequest{Vertices: chunk}, l.client.PutVertices)
 		return 0, err
 	})
 	return err
@@ -352,7 +377,7 @@ func (l *Lantern) PutVertices(ctx context.Context, inputs []VertexInput) error {
 func (l *Lantern) DeleteVertex(ctx context.Context, key string) (bool, error) {
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	resp, err := unary(ctx, &pb.DeleteVertexRequest{Key: key}, l.client.DeleteVertex)
+	resp, err := unary(ctx, l, &pb.DeleteVertexRequest{Key: key}, l.client.DeleteVertex)
 	if err != nil {
 		return false, err
 	}
@@ -372,7 +397,7 @@ func (l *Lantern) DeleteVertex(ctx context.Context, key string) (bool, error) {
 // keys already deleted, so callers can resume with keys[err.Written:].
 func (l *Lantern) DeleteVertices(ctx context.Context, keys []string) (int, error) {
 	return runBatchWrite(ctx, l, keys, func(ctx context.Context, chunk []string) (int32, error) {
-		resp, err := unary(ctx, &pb.DeleteVerticesRequest{Keys: chunk}, l.client.DeleteVertices)
+		resp, err := unary(ctx, l, &pb.DeleteVerticesRequest{Keys: chunk}, l.client.DeleteVertices)
 		if err != nil {
 			return 0, err
 		}
@@ -387,7 +412,7 @@ func (l *Lantern) DeleteVertices(ctx context.Context, keys []string) (int, error
 // server's MaxBatchSize cap.
 func (l *Lantern) GetVertices(ctx context.Context, keys []string) (found []*Vertex, missing []string, err error) {
 	err = runBatchRead(ctx, l, keys, func(ctx context.Context, chunk []string) error {
-		resp, rerr := unary(ctx, &pb.GetVerticesRequest{Keys: chunk}, l.client.GetVertices)
+		resp, rerr := unary(ctx, l, &pb.GetVerticesRequest{Keys: chunk}, l.client.GetVertices)
 		if rerr != nil {
 			return rerr
 		}
@@ -405,7 +430,7 @@ func (l *Lantern) GetVertices(ctx context.Context, keys []string) (found []*Vert
 func (l *Lantern) GetEdge(ctx context.Context, tail string, head string) (*Edge, error) {
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	resp, err := unary(ctx, &pb.GetEdgeRequest{Tail: tail, Head: head}, l.client.GetEdge)
+	resp, err := unary(ctx, l, &pb.GetEdgeRequest{Tail: tail, Head: head}, l.client.GetEdge)
 	if err != nil {
 		return nil, err
 	}
@@ -428,7 +453,7 @@ func (l *Lantern) AddEdge(ctx context.Context, tail string, head string, weight 
 func (l *Lantern) AddEdgeAt(ctx context.Context, tail string, head string, weight float32, expiration time.Time) error {
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	_, err := unary(ctx, &pb.AddEdgesRequest{
+	_, err := unary(ctx, l, &pb.AddEdgesRequest{
 		Edges:      []*pb.Edge{{Tail: tail, Head: head, Weight: weight, Expiration: timestamppb.New(expiration)}},
 		ContribIds: l.nextContribIDs(1),
 	}, l.client.AddEdges)
@@ -453,7 +478,7 @@ func (l *Lantern) AddEdges(ctx context.Context, inputs []EdgeInput) error {
 		return nil
 	}
 	_, err := runBatchWrite(ctx, l, edgesFrom(inputs), func(ctx context.Context, chunk []*pb.Edge) (int32, error) {
-		_, err := unary(ctx, &pb.AddEdgesRequest{Edges: chunk, ContribIds: l.nextContribIDs(len(chunk))}, l.client.AddEdges)
+		_, err := unary(ctx, l, &pb.AddEdgesRequest{Edges: chunk, ContribIds: l.nextContribIDs(len(chunk))}, l.client.AddEdges)
 		return 0, err
 	})
 	return err
@@ -492,7 +517,7 @@ func (l *Lantern) PutEdge(ctx context.Context, tail string, head string, weight 
 func (l *Lantern) PutEdgeAt(ctx context.Context, tail string, head string, weight float32, expiration time.Time) error {
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	_, err := unary(ctx, &pb.PutEdgesRequest{
+	_, err := unary(ctx, l, &pb.PutEdgesRequest{
 		Edges: []*pb.Edge{{Tail: tail, Head: head, Weight: weight, Expiration: timestamppb.New(expiration)}},
 	}, l.client.PutEdges)
 	return err
@@ -510,7 +535,7 @@ func (l *Lantern) PutEdges(ctx context.Context, inputs []EdgeInput) error {
 		return nil
 	}
 	_, err := runBatchWrite(ctx, l, edgesFrom(inputs), func(ctx context.Context, chunk []*pb.Edge) (int32, error) {
-		_, err := unary(ctx, &pb.PutEdgesRequest{Edges: chunk}, l.client.PutEdges)
+		_, err := unary(ctx, l, &pb.PutEdgesRequest{Edges: chunk}, l.client.PutEdges)
 		return 0, err
 	})
 	return err
@@ -521,7 +546,7 @@ func (l *Lantern) PutEdges(ctx context.Context, inputs []EdgeInput) error {
 func (l *Lantern) DeleteEdge(ctx context.Context, tail string, head string) (bool, error) {
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	resp, err := unary(ctx, &pb.DeleteEdgeRequest{Tail: tail, Head: head}, l.client.DeleteEdge)
+	resp, err := unary(ctx, l, &pb.DeleteEdgeRequest{Tail: tail, Head: head}, l.client.DeleteEdge)
 	if err != nil {
 		return false, err
 	}
@@ -553,7 +578,7 @@ func (l *Lantern) DeleteEdges(ctx context.Context, refs []EdgeRef) (int, error) 
 		keys = append(keys, &pb.EdgeKey{Tail: r.Tail, Head: r.Head})
 	}
 	return runBatchWrite(ctx, l, keys, func(ctx context.Context, chunk []*pb.EdgeKey) (int32, error) {
-		resp, err := unary(ctx, &pb.DeleteEdgesRequest{Edges: chunk}, l.client.DeleteEdges)
+		resp, err := unary(ctx, l, &pb.DeleteEdgesRequest{Edges: chunk}, l.client.DeleteEdges)
 		if err != nil {
 			return 0, err
 		}
@@ -575,7 +600,7 @@ func (l *Lantern) GetEdges(ctx context.Context, refs []EdgeRef) (found []*Edge, 
 		keys = append(keys, &pb.EdgeKey{Tail: r.Tail, Head: r.Head})
 	}
 	err = runBatchRead(ctx, l, keys, func(ctx context.Context, chunk []*pb.EdgeKey) error {
-		resp, rerr := unary(ctx, &pb.GetEdgesRequest{Edges: chunk}, l.client.GetEdges)
+		resp, rerr := unary(ctx, l, &pb.GetEdgesRequest{Edges: chunk}, l.client.GetEdges)
 		if rerr != nil {
 			return rerr
 		}
@@ -771,7 +796,7 @@ func (l *Lantern) Illuminate(ctx context.Context, seed string, opts ...Illuminat
 			Reduction: cfg.bfs.Reduction,
 		}}
 	}
-	resp, err := unary(ctx, req, l.client.Illuminate)
+	resp, err := unary(ctx, l, req, l.client.Illuminate)
 	if err != nil {
 		return nil, err
 	}

--- a/sdks/go/doc.go
+++ b/sdks/go/doc.go
@@ -37,6 +37,37 @@
 // injects a hidden default expiration — an omitted/zero TTL is honoured
 // as permanent end to end (see #523).
 //
+// # Retry policy
+//
+// Retries are opt-in and off by default — a zero-config client behaves
+// exactly as before. WithRetry(RetryPolicy{...}) arms a bounded,
+// context-aware backoff loop with full-jitter exponential delays, applied
+// ONLY to RPCs that are idempotent under the client's configuration. The
+// eligibility matrix is enforced in code (see retry.go), not documentation:
+//
+//	RPC family                                   Retried?
+//	-------------------------------------------  ------------------------------
+//	Get*/Scan*/Count*/Search*/Illuminate/status  yes (reads are idempotent)
+//	Put*/Delete*/DeleteVerticesByPrefix          yes (idempotent by semantics)
+//	AddEdge/AddEdgeAt/AddEdges                    only under WithIdempotentAdds
+//	                                             (or explicit ContribIDs): the
+//	                                             per-edge keys let a retry record
+//	                                             each contribution exactly once
+//	Subscribe/Backup/Restore                     no (streaming / io, excluded v1)
+//
+// Never retried regardless of policy: deterministic outcomes (NotFound,
+// InvalidArgument, FailedPrecondition) and DeadlineExceeded/Canceled (the
+// caller's budget is already spent). The default retryable code is
+// Unavailable; add ResourceExhausted via RetryPolicy.RetryableCodes to retry
+// through the server-side capacity cap / rate limiter.
+//
+// Under NewLanternFailover the policy drives the ring walk: each retry
+// attempt re-runs the failover rotation, so a persistently-unavailable
+// endpoint is retried against its siblings with backoff and MaxAttempts is
+// the cross-replica budget — there is no second rotation mechanism. The
+// per-endpoint clients' own retry is neutralised so the attempt budget is
+// never squared.
+//
 // # Model definition policy
 //
 // This SDK follows a strict "no parallel models" rule: wherever a

--- a/sdks/go/edge_prefix.go
+++ b/sdks/go/edge_prefix.go
@@ -64,7 +64,7 @@ func (l *Lantern) ScanEdges(ctx context.Context, opts ...EdgeScanOption) (edges 
 	}
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	resp, err := unary(ctx, &pb.ScanEdgesRequest{
+	resp, err := unary(ctx, l, &pb.ScanEdgesRequest{
 		TailPrefix: o.tailPrefix,
 		HeadPrefix: o.headPrefix,
 		Limit:      o.limit,

--- a/sdks/go/example/main.go
+++ b/sdks/go/example/main.go
@@ -17,6 +17,9 @@ func main() {
 		panic(err)
 	}
 
+	// Opt-in retry + static-endpoint failover + idempotent adds (#849).
+	retryAndFailoverExample(ctx)
+
 	/*
 		PutVertex:
 		    Value can be string, int, float, bool, time.Time, []byte or nil
@@ -372,4 +375,60 @@ func main() {
 			*/
 		}
 	}
+}
+
+// retryAndFailoverExample shows the opt-in retry policy (#849) composed with
+// static-endpoint failover and idempotent adds. Retries are OFF unless
+// WithRetry is passed, and even then apply ONLY to RPCs that are idempotent
+// under the client's configuration: reads, Put*/Delete*, and — because
+// WithIdempotentAdds stamps a stable per-edge ContribID — AddEdge(s). A
+// deterministic error (NotFound, InvalidArgument) or an exhausted deadline is
+// never retried.
+func retryAndFailoverExample(ctx context.Context) {
+	// Single endpoint with a bounded, full-jitter exponential backoff. A
+	// transient Unavailable (rolling update, load-balancer flap) is retried
+	// transparently up to MaxAttempts; anything deterministic surfaces at once.
+	retrying, err := client.NewLantern(
+		"http://localhost:6380",
+		client.WithIdempotentAdds(),
+		client.WithRetry(client.RetryPolicy{
+			MaxAttempts: 4,
+			BaseDelay:   50 * time.Millisecond,
+			MaxDelay:    2 * time.Second,
+		}),
+	)
+	if err != nil {
+		log.Printf("retry example: dial: %v", err)
+		return
+	}
+	defer func() { _ = retrying.Close() }()
+
+	// AddEdges is retried safely: WithIdempotentAdds stamps a stable ContribID
+	// per edge, so a re-sent chunk records each weight exactly once. (Distinct
+	// keys keep this demo out of the Illuminate graph printed above.)
+	if err := retrying.AddEdges(ctx, []client.EdgeInput{
+		{Tail: "retry-demo:a", Head: "retry-demo:b", Weight: 1},
+		{Tail: "retry-demo:b", Head: "retry-demo:c", Weight: 1},
+	}); err != nil {
+		log.Printf("retry example: AddEdges: %v", err)
+	}
+
+	// Failover across a fixed replica set. The retry loop drives the ring
+	// walk: an Unavailable endpoint is retried against its siblings with
+	// backoff, so MaxAttempts is the cross-replica budget — no second rotation
+	// mechanism. Construction is lazy (no dial here); swap in real replicas.
+	failover, err := client.NewLanternFailover(
+		[]string{
+			"http://localhost:6380",
+			"http://localhost:6381",
+			"http://localhost:6382",
+		},
+		client.WithIdempotentAdds(),
+		client.WithRetry(client.RetryPolicy{MaxAttempts: 6}),
+	)
+	if err != nil {
+		log.Printf("retry example: failover: %v", err)
+		return
+	}
+	defer func() { _ = failover.Close() }()
 }

--- a/sdks/go/failover.go
+++ b/sdks/go/failover.go
@@ -51,6 +51,18 @@ import (
 type Failover struct {
 	nodes []failoverNode
 	cur   atomic.Uint64
+
+	// retry, when non-nil (WithRetry passed to NewLanternFailover), drives
+	// the ring walk through a bounded full-jitter backoff loop: each retry
+	// attempt re-runs try, resuming from the sticky cursor the previous
+	// attempt advanced on ErrUnavailable, so MaxAttempts is the cross-replica
+	// budget (#849). The endpoints' own per-node unary retry is neutralised
+	// (clearNodeRetry) so the loop runs exactly once, here.
+	retry *RetryPolicy
+	// idempotentAdds mirrors WithIdempotentAdds so call can gate the additive
+	// write surface (AddEdge/AddEdgeAt/AddEdges) — retried only when the nodes
+	// stamp per-edge ContribIDs.
+	idempotentAdds bool
 }
 
 // failoverNode is the unexported endpoint contract the ring walk delegates
@@ -106,9 +118,23 @@ func NewLanternFailover(addrs []string, opts ...Option) (*Failover, error) {
 	if len(addrs) == 0 {
 		return nil, errors.New("client: NewLanternFailover requires at least one address")
 	}
+	// Resolve the retry policy and idempotent-adds setting once, at the
+	// failover level: the ring walk is the sole retry driver, so every
+	// per-endpoint *Lantern client is built with its own unary retry
+	// neutralised (clearNodeRetry appended last) to avoid nested MaxAttempts²
+	// backoff. Reading them off a throwaway options mirrors how NewLantern
+	// applies opts.
+	var probe options
+	for _, apply := range opts {
+		apply(&probe)
+	}
+	nodeOpts := make([]Option, 0, len(opts)+1)
+	nodeOpts = append(nodeOpts, opts...)
+	nodeOpts = append(nodeOpts, clearNodeRetry)
+
 	nodes := make([]failoverNode, 0, len(addrs))
 	for _, addr := range addrs {
-		l, err := NewLantern(addr, opts...)
+		l, err := NewLantern(addr, nodeOpts...)
 		if err != nil {
 			for _, n := range nodes {
 				_ = n.Close()
@@ -117,8 +143,16 @@ func NewLanternFailover(addrs []string, opts ...Option) (*Failover, error) {
 		}
 		nodes = append(nodes, l)
 	}
-	return &Failover{nodes: nodes}, nil
+	return &Failover{nodes: nodes, retry: probe.retry, idempotentAdds: probe.idempotentAdds}, nil
 }
+
+// clearNodeRetry is an internal Option that NewLanternFailover appends to
+// every per-endpoint client's option list so the constructed *Lantern nodes
+// never run their own unary retry loop. The failover-level RetryPolicy held
+// on *Failover is the single retry driver — without this reset a WithRetry
+// passed to NewLanternFailover would arm BOTH levels, multiplying the attempt
+// budget (MaxAttempts per node × the ring walk).
+func clearNodeRetry(o *options) { o.retry = nil }
 
 // try runs fn against the sticky-current endpoint, rotating to the next
 // endpoint only on ErrUnavailable and walking the ring at most once. The
@@ -144,29 +178,45 @@ func (f *Failover) try(fn func(failoverNode) error) error {
 	return lastErr
 }
 
+// call wraps try in the retry policy when one is armed (WithRetry) and the
+// method is retry-eligible — retryableMethod consults the code-enforced
+// methodRetryClasses matrix and folds in idempotentAdds for the additive
+// write surface. Each retry attempt re-runs the whole ring walk, resuming
+// from the cursor the previous attempt advanced on ErrUnavailable, so
+// retries spread across replicas with no second rotation mechanism (#849);
+// backoff sleeps honour ctx. When no policy is armed or the method is not
+// eligible, call is a straight pass-through to try, so zero-config failover
+// clients behave exactly as before.
+func (f *Failover) call(ctx context.Context, method string, fn func(failoverNode) error) error {
+	if f.retry == nil || !retryableMethod(method, f.idempotentAdds) {
+		return f.try(fn)
+	}
+	return f.retry.run(ctx, func() error { return f.try(fn) })
+}
+
 // PutVertex forwards to the current endpoint's PutVertex, failing over on
 // ErrUnavailable.
 func (f *Failover) PutVertex(ctx context.Context, key string, value any, ttl time.Duration) error {
-	return f.try(func(l failoverNode) error { return l.PutVertex(ctx, key, value, ttl) })
+	return f.call(ctx, "PutVertex", func(l failoverNode) error { return l.PutVertex(ctx, key, value, ttl) })
 }
 
 // PutVertexAt forwards to the current endpoint's PutVertexAt, failing over
 // on ErrUnavailable.
 func (f *Failover) PutVertexAt(ctx context.Context, key string, value any, expiration time.Time) error {
-	return f.try(func(l failoverNode) error { return l.PutVertexAt(ctx, key, value, expiration) })
+	return f.call(ctx, "PutVertexAt", func(l failoverNode) error { return l.PutVertexAt(ctx, key, value, expiration) })
 }
 
 // PutVertices forwards to the current endpoint's PutVertices, failing over
 // on ErrUnavailable.
 func (f *Failover) PutVertices(ctx context.Context, inputs []VertexInput) error {
-	return f.try(func(l failoverNode) error { return l.PutVertices(ctx, inputs) })
+	return f.call(ctx, "PutVertices", func(l failoverNode) error { return l.PutVertices(ctx, inputs) })
 }
 
 // GetVertex forwards to the current endpoint's GetVertex, failing over on
 // ErrUnavailable.
 func (f *Failover) GetVertex(ctx context.Context, key string) (*Vertex, error) {
 	var out *Vertex
-	err := f.try(func(l failoverNode) error {
+	err := f.call(ctx, "GetVertex", func(l failoverNode) error {
 		v, e := l.GetVertex(ctx, key)
 		out = v
 		return e
@@ -177,7 +227,7 @@ func (f *Failover) GetVertex(ctx context.Context, key string) (*Vertex, error) {
 // GetVertices forwards to the current endpoint's GetVertices, failing over
 // on ErrUnavailable.
 func (f *Failover) GetVertices(ctx context.Context, keys []string) (found []*Vertex, missing []string, err error) {
-	e := f.try(func(l failoverNode) error {
+	e := f.call(ctx, "GetVertices", func(l failoverNode) error {
 		var ie error
 		found, missing, ie = l.GetVertices(ctx, keys)
 		return ie
@@ -189,7 +239,7 @@ func (f *Failover) GetVertices(ctx context.Context, keys []string) (found []*Ver
 // over on ErrUnavailable.
 func (f *Failover) DeleteVertex(ctx context.Context, key string) (bool, error) {
 	var existed bool
-	err := f.try(func(l failoverNode) error {
+	err := f.call(ctx, "DeleteVertex", func(l failoverNode) error {
 		b, e := l.DeleteVertex(ctx, key)
 		existed = b
 		return e
@@ -201,7 +251,7 @@ func (f *Failover) DeleteVertex(ctx context.Context, key string) (bool, error) {
 // over on ErrUnavailable.
 func (f *Failover) DeleteVertices(ctx context.Context, keys []string) (int, error) {
 	var deleted int
-	err := f.try(func(l failoverNode) error {
+	err := f.call(ctx, "DeleteVertices", func(l failoverNode) error {
 		d, e := l.DeleteVertices(ctx, keys)
 		deleted = d
 		return e
@@ -214,7 +264,7 @@ func (f *Failover) DeleteVertices(ctx context.Context, keys []string) (int, erro
 // replicated keyspace, so a cursor minted by one replica is valid against
 // any other — a mid-scan rotation resumes correctly.
 func (f *Failover) ScanVertices(ctx context.Context, prefix string, opts ...ScanOption) (vertices []*Vertex, nextCursor []byte, err error) {
-	e := f.try(func(l failoverNode) error {
+	e := f.call(ctx, "ScanVertices", func(l failoverNode) error {
 		var ie error
 		vertices, nextCursor, ie = l.ScanVertices(ctx, prefix, opts...)
 		return ie
@@ -227,7 +277,7 @@ func (f *Failover) ScanVertices(ctx context.Context, prefix string, opts ...Scan
 // position over the shared replicated keyspace, so a mid-scan rotation
 // resumes correctly against any replica.
 func (f *Failover) ScanVertexKeys(ctx context.Context, prefix string, opts ...ScanOption) (keys []string, nextCursor []byte, err error) {
-	e := f.try(func(l failoverNode) error {
+	e := f.call(ctx, "ScanVertexKeys", func(l failoverNode) error {
 		var ie error
 		keys, nextCursor, ie = l.ScanVertexKeys(ctx, prefix, opts...)
 		return ie
@@ -239,7 +289,7 @@ func (f *Failover) ScanVertexKeys(ctx context.Context, prefix string, opts ...Sc
 // over on ErrUnavailable. Search runs over the shared replicated keyspace, so
 // a mid-call rotation simply re-runs the query against the next replica.
 func (f *Failover) SearchVertices(ctx context.Context, query string, opts ...SearchOption) (hits []SearchHit, err error) {
-	e := f.try(func(l failoverNode) error {
+	e := f.call(ctx, "SearchVertices", func(l failoverNode) error {
 		var ie error
 		hits, ie = l.SearchVertices(ctx, query, opts...)
 		return ie
@@ -251,7 +301,7 @@ func (f *Failover) SearchVertices(ctx context.Context, query string, opts ...Sea
 // CountVerticesByPrefix, failing over on ErrUnavailable.
 func (f *Failover) CountVerticesByPrefix(ctx context.Context, prefix string) (uint64, error) {
 	var count uint64
-	err := f.try(func(l failoverNode) error {
+	err := f.call(ctx, "CountVerticesByPrefix", func(l failoverNode) error {
 		c, e := l.CountVerticesByPrefix(ctx, prefix)
 		count = c
 		return e
@@ -263,7 +313,7 @@ func (f *Failover) CountVerticesByPrefix(ctx context.Context, prefix string) (ui
 // DeleteVerticesByPrefix, failing over on ErrUnavailable.
 func (f *Failover) DeleteVerticesByPrefix(ctx context.Context, prefix string, opts ...DeleteByPrefixOption) (uint64, error) {
 	var deleted uint64
-	err := f.try(func(l failoverNode) error {
+	err := f.call(ctx, "DeleteVerticesByPrefix", func(l failoverNode) error {
 		d, e := l.DeleteVerticesByPrefix(ctx, prefix, opts...)
 		deleted = d
 		return e
@@ -276,44 +326,44 @@ func (f *Failover) DeleteVerticesByPrefix(ctx context.Context, prefix string, op
 // committed nothing, the additive contribution is retried on a sibling
 // replica without risk of double-counting.
 func (f *Failover) AddEdge(ctx context.Context, tail, head string, weight float32, ttl time.Duration) error {
-	return f.try(func(l failoverNode) error { return l.AddEdge(ctx, tail, head, weight, ttl) })
+	return f.call(ctx, "AddEdge", func(l failoverNode) error { return l.AddEdge(ctx, tail, head, weight, ttl) })
 }
 
 // AddEdgeAt forwards to the current endpoint's AddEdgeAt, failing over on
 // ErrUnavailable.
 func (f *Failover) AddEdgeAt(ctx context.Context, tail, head string, weight float32, expiration time.Time) error {
-	return f.try(func(l failoverNode) error { return l.AddEdgeAt(ctx, tail, head, weight, expiration) })
+	return f.call(ctx, "AddEdgeAt", func(l failoverNode) error { return l.AddEdgeAt(ctx, tail, head, weight, expiration) })
 }
 
 // AddEdges forwards to the current endpoint's AddEdges, failing over on
 // ErrUnavailable.
 func (f *Failover) AddEdges(ctx context.Context, inputs []EdgeInput) error {
-	return f.try(func(l failoverNode) error { return l.AddEdges(ctx, inputs) })
+	return f.call(ctx, "AddEdges", func(l failoverNode) error { return l.AddEdges(ctx, inputs) })
 }
 
 // PutEdge forwards to the current endpoint's PutEdge, failing over on
 // ErrUnavailable.
 func (f *Failover) PutEdge(ctx context.Context, tail, head string, weight float32, ttl time.Duration) error {
-	return f.try(func(l failoverNode) error { return l.PutEdge(ctx, tail, head, weight, ttl) })
+	return f.call(ctx, "PutEdge", func(l failoverNode) error { return l.PutEdge(ctx, tail, head, weight, ttl) })
 }
 
 // PutEdgeAt forwards to the current endpoint's PutEdgeAt, failing over on
 // ErrUnavailable.
 func (f *Failover) PutEdgeAt(ctx context.Context, tail, head string, weight float32, expiration time.Time) error {
-	return f.try(func(l failoverNode) error { return l.PutEdgeAt(ctx, tail, head, weight, expiration) })
+	return f.call(ctx, "PutEdgeAt", func(l failoverNode) error { return l.PutEdgeAt(ctx, tail, head, weight, expiration) })
 }
 
 // PutEdges forwards to the current endpoint's PutEdges, failing over on
 // ErrUnavailable.
 func (f *Failover) PutEdges(ctx context.Context, inputs []EdgeInput) error {
-	return f.try(func(l failoverNode) error { return l.PutEdges(ctx, inputs) })
+	return f.call(ctx, "PutEdges", func(l failoverNode) error { return l.PutEdges(ctx, inputs) })
 }
 
 // GetEdge forwards to the current endpoint's GetEdge, failing over on
 // ErrUnavailable.
 func (f *Failover) GetEdge(ctx context.Context, tail, head string) (*Edge, error) {
 	var out *Edge
-	err := f.try(func(l failoverNode) error {
+	err := f.call(ctx, "GetEdge", func(l failoverNode) error {
 		e, ie := l.GetEdge(ctx, tail, head)
 		out = e
 		return ie
@@ -324,7 +374,7 @@ func (f *Failover) GetEdge(ctx context.Context, tail, head string) (*Edge, error
 // GetEdges forwards to the current endpoint's GetEdges, failing over on
 // ErrUnavailable.
 func (f *Failover) GetEdges(ctx context.Context, refs []EdgeRef) (found []*Edge, missing []EdgeRef, err error) {
-	e := f.try(func(l failoverNode) error {
+	e := f.call(ctx, "GetEdges", func(l failoverNode) error {
 		var ie error
 		found, missing, ie = l.GetEdges(ctx, refs)
 		return ie
@@ -336,7 +386,7 @@ func (f *Failover) GetEdges(ctx context.Context, refs []EdgeRef) (found []*Edge,
 // ErrUnavailable. As with ScanVertices the cursor is a shared-keyspace
 // radix position, so a mid-scan rotation resumes correctly.
 func (f *Failover) ScanEdges(ctx context.Context, opts ...EdgeScanOption) (edges []*Edge, nextCursor []byte, err error) {
-	e := f.try(func(l failoverNode) error {
+	e := f.call(ctx, "ScanEdges", func(l failoverNode) error {
 		var ie error
 		edges, nextCursor, ie = l.ScanEdges(ctx, opts...)
 		return ie
@@ -348,7 +398,7 @@ func (f *Failover) ScanEdges(ctx context.Context, opts ...EdgeScanOption) (edges
 // ErrUnavailable.
 func (f *Failover) DeleteEdge(ctx context.Context, tail, head string) (bool, error) {
 	var existed bool
-	err := f.try(func(l failoverNode) error {
+	err := f.call(ctx, "DeleteEdge", func(l failoverNode) error {
 		b, e := l.DeleteEdge(ctx, tail, head)
 		existed = b
 		return e
@@ -360,7 +410,7 @@ func (f *Failover) DeleteEdge(ctx context.Context, tail, head string) (bool, err
 // on ErrUnavailable.
 func (f *Failover) DeleteEdges(ctx context.Context, refs []EdgeRef) (int, error) {
 	var deleted int
-	err := f.try(func(l failoverNode) error {
+	err := f.call(ctx, "DeleteEdges", func(l failoverNode) error {
 		d, e := l.DeleteEdges(ctx, refs)
 		deleted = d
 		return e
@@ -372,7 +422,7 @@ func (f *Failover) DeleteEdges(ctx context.Context, refs []EdgeRef) (int, error)
 // ErrUnavailable.
 func (f *Failover) Illuminate(ctx context.Context, seed string, opts ...IlluminateOption) (*Graph, error) {
 	var out *Graph
-	err := f.try(func(l failoverNode) error {
+	err := f.call(ctx, "Illuminate", func(l failoverNode) error {
 		g, e := l.Illuminate(ctx, seed, opts...)
 		out = g
 		return e

--- a/sdks/go/failover_test.go
+++ b/sdks/go/failover_test.go
@@ -257,3 +257,168 @@ func TestFailover_CloseClosesAllNodes(t *testing.T) {
 		t.Fatalf("close counts n0=%d n1=%d, want 1 and 1", node0.closed, node1.closed)
 	}
 }
+
+// testRetryPolicy is a normalised policy whose backoff sleeps are instant so
+// the failover retry tests never wait real time. noSleep lives in retry_test.go
+// (same package).
+func testRetryPolicy(maxAttempts int) *RetryPolicy {
+	p := RetryPolicy{MaxAttempts: maxAttempts, sleepFn: noSleep}.normalized()
+	return &p
+}
+
+func TestFailover_RetryRecoversAcrossRingWalks(t *testing.T) {
+	var n0, n1 int
+	node0 := &fakeNode{getVertexFn: func(context.Context, string) (*Vertex, error) {
+		n0++
+		return nil, unavailableErr()
+	}}
+	node1 := &fakeNode{getVertexFn: func(_ context.Context, key string) (*Vertex, error) {
+		n1++
+		if n1 < 2 { // dead on the first ring walk, healthy on the second
+			return nil, unavailableErr()
+		}
+		return &Vertex{Key: key}, nil
+	}}
+	f := &Failover{nodes: []failoverNode{node0, node1}, retry: testRetryPolicy(3)}
+
+	v, err := f.GetVertex(context.Background(), "k")
+	if err != nil {
+		t.Fatalf("GetVertex err = %v, want nil (retry recovers)", err)
+	}
+	if v == nil || v.Key != "k" {
+		t.Fatalf("GetVertex = %+v, want vertex key k", v)
+	}
+	// Ring walk 1: node0 + node1 both Unavailable → backoff. Ring walk 2:
+	// node0 Unavailable, node1 succeeds. Each node is hit once per walk.
+	if n0 != 2 || n1 != 2 {
+		t.Fatalf("counts n0=%d n1=%d, want 2 and 2", n0, n1)
+	}
+}
+
+func TestFailover_NoRetryFailsOnFirstRingWalk(t *testing.T) {
+	var n0, n1 int
+	node0 := &fakeNode{getVertexFn: func(context.Context, string) (*Vertex, error) {
+		n0++
+		return nil, unavailableErr()
+	}}
+	node1 := &fakeNode{getVertexFn: func(context.Context, string) (*Vertex, error) {
+		n1++
+		return nil, unavailableErr()
+	}}
+	// No retry policy: zero-config failover behaves exactly as before — one
+	// ring walk, then surface the error.
+	f := &Failover{nodes: []failoverNode{node0, node1}}
+
+	if _, err := f.GetVertex(context.Background(), "k"); !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable", err)
+	}
+	if n0 != 1 || n1 != 1 {
+		t.Fatalf("counts n0=%d n1=%d, want 1 and 1 (no retry)", n0, n1)
+	}
+}
+
+func TestFailover_RetryAlwaysReadIgnoresIdempotencySetting(t *testing.T) {
+	mk := func(c *int) *fakeNode {
+		return &fakeNode{getVertexFn: func(context.Context, string) (*Vertex, error) {
+			*c++
+			return nil, unavailableErr()
+		}}
+	}
+	var a, b int
+	// idempotentAdds=false must NOT gate a retryAlways read.
+	f := &Failover{nodes: []failoverNode{mk(&a), mk(&b)}, retry: testRetryPolicy(3), idempotentAdds: false}
+
+	if _, err := f.GetVertex(context.Background(), "k"); !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable", err)
+	}
+	// 3 ring walks × 1 hit per node each.
+	if a != 3 || b != 3 {
+		t.Fatalf("counts a=%d b=%d, want 3 and 3 (MaxAttempts ring walks)", a, b)
+	}
+}
+
+func TestFailover_RetryGatesAdditiveWritesByIdempotency(t *testing.T) {
+	mk := func(c *int) *fakeNode {
+		return &fakeNode{addEdgeFn: func(context.Context, string, string, float32, time.Duration) error {
+			*c++
+			return unavailableErr()
+		}}
+	}
+
+	t.Run("without idempotent adds a single ring walk, no backoff-retry", func(t *testing.T) {
+		var a, b int
+		f := &Failover{nodes: []failoverNode{mk(&a), mk(&b)}, retry: testRetryPolicy(3), idempotentAdds: false}
+		if err := f.AddEdge(context.Background(), "a", "b", 1, time.Minute); !errors.Is(err, ErrUnavailable) {
+			t.Fatalf("err = %v, want ErrUnavailable", err)
+		}
+		if a != 1 || b != 1 {
+			t.Fatalf("counts a=%d b=%d, want 1 and 1 (additive write not retried)", a, b)
+		}
+	})
+
+	t.Run("with idempotent adds the ring walk repeats MaxAttempts times", func(t *testing.T) {
+		var a, b int
+		f := &Failover{nodes: []failoverNode{mk(&a), mk(&b)}, retry: testRetryPolicy(3), idempotentAdds: true}
+		if err := f.AddEdge(context.Background(), "a", "b", 1, time.Minute); !errors.Is(err, ErrUnavailable) {
+			t.Fatalf("err = %v, want ErrUnavailable", err)
+		}
+		if a != 3 || b != 3 {
+			t.Fatalf("counts a=%d b=%d, want 3 and 3 (retry armed for idempotent adds)", a, b)
+		}
+	})
+}
+
+func TestFailover_RetryStopsOnNonUnavailable(t *testing.T) {
+	var n0, n1 int
+	node0 := &fakeNode{getVertexFn: func(context.Context, string) (*Vertex, error) {
+		n0++
+		return nil, ErrNotFound // deterministic: neither rotate nor retry
+	}}
+	node1 := &fakeNode{getVertexFn: func(context.Context, string) (*Vertex, error) {
+		n1++
+		return nil, nil
+	}}
+	f := &Failover{nodes: []failoverNode{node0, node1}, retry: testRetryPolicy(5)}
+
+	if _, err := f.GetVertex(context.Background(), "k"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+	if n0 != 1 || n1 != 0 {
+		t.Fatalf("counts n0=%d n1=%d, want 1 and 0 (deterministic error, no retry/rotation)", n0, n1)
+	}
+}
+
+func TestNewLanternFailover_RetryExtractedAndNodesNeutralised(t *testing.T) {
+	f, err := NewLanternFailover(
+		[]string{"http://127.0.0.1:6380", "http://127.0.0.1:6381"},
+		WithRetry(RetryPolicy{MaxAttempts: 4}),
+		WithIdempotentAdds(),
+	)
+	if err != nil {
+		t.Fatalf("NewLanternFailover err = %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if f.retry == nil || f.retry.MaxAttempts != 4 {
+		t.Fatalf("failover retry policy = %+v, want MaxAttempts 4", f.retry)
+	}
+	if !f.idempotentAdds {
+		t.Fatal("failover idempotentAdds not extracted from opts")
+	}
+	for i, n := range f.nodes {
+		l, ok := n.(*Lantern)
+		if !ok {
+			t.Fatalf("node %d is %T, want *Lantern", i, n)
+		}
+		// clearNodeRetry must neutralise per-node retry so the failover loop
+		// is the sole retry driver (no nested MaxAttempts² backoff)...
+		if l.opts.retry != nil {
+			t.Fatalf("node %d retry not stripped: %+v", i, l.opts.retry)
+		}
+		// ...while idempotent-adds still flows to the nodes so AddEdges stamps
+		// ContribIDs on every attempt.
+		if !l.opts.idempotentAdds {
+			t.Fatalf("node %d idempotentAdds not propagated", i)
+		}
+	}
+}

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -23,6 +23,7 @@ type options struct {
 	defaultTimeout time.Duration
 	batchChunkSize int
 	idempotentAdds bool
+	retry          *RetryPolicy
 }
 
 // Option configures a Lantern client built via NewLantern.
@@ -91,6 +92,20 @@ func (t authTokenInterceptor) WrapStreamingClient(next connect.StreamingClientFu
 
 func (t authTokenInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
 	return next // client-side only
+}
+
+// WithRetry arms the opt-in retry policy (#849): bounded attempts with
+// full-jitter exponential backoff, applied ONLY to RPCs that are
+// idempotent under the client's configuration (see the eligibility matrix
+// in retry.go / doc.go). Zero-config clients behave exactly as before.
+// Under NewLanternFailover the retry loop drives the endpoint rotation:
+// an Unavailable attempt advances the sticky endpoint, so MaxAttempts
+// doubles as the cross-replica budget.
+func WithRetry(p RetryPolicy) Option {
+	return func(o *options) {
+		n := p.normalized()
+		o.retry = &n
+	}
 }
 
 // WithDefaultTimeout applies a per-call timeout to every RPC whose

--- a/sdks/go/prefix.go
+++ b/sdks/go/prefix.go
@@ -70,7 +70,7 @@ func (l *Lantern) ScanVertices(ctx context.Context, prefix string, opts ...ScanO
 	}
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	resp, err := unary(ctx, &pb.ScanVerticesRequest{
+	resp, err := unary(ctx, l, &pb.ScanVerticesRequest{
 		Prefix: prefix,
 		Limit:  o.limit,
 		Cursor: o.cursor,
@@ -89,7 +89,7 @@ func (l *Lantern) ScanVertices(ctx context.Context, prefix string, opts ...ScanO
 func (l *Lantern) CountVerticesByPrefix(ctx context.Context, prefix string) (uint64, error) {
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	resp, err := unary(ctx, &pb.CountVerticesByPrefixRequest{Prefix: prefix}, l.client.CountVerticesByPrefix)
+	resp, err := unary(ctx, l, &pb.CountVerticesByPrefixRequest{Prefix: prefix}, l.client.CountVerticesByPrefix)
 	if err != nil {
 		return 0, err
 	}
@@ -117,7 +117,7 @@ func (l *Lantern) DeleteVerticesByPrefix(ctx context.Context, prefix string, opt
 	}
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	resp, err := unary(ctx, &pb.DeleteVerticesByPrefixRequest{
+	resp, err := unary(ctx, l, &pb.DeleteVerticesByPrefixRequest{
 		Prefix: prefix,
 		Limit:  o.limit,
 		DryRun: o.dryRun,
@@ -187,7 +187,7 @@ func (l *Lantern) ScanVertexKeys(ctx context.Context, prefix string, opts ...Sca
 	}
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	resp, err := unary(ctx, &pb.ScanVertexKeysRequest{
+	resp, err := unary(ctx, l, &pb.ScanVertexKeysRequest{
 		Prefix: prefix,
 		Limit:  o.limit,
 		Cursor: o.cursor,

--- a/sdks/go/replication_status.go
+++ b/sdks/go/replication_status.go
@@ -43,7 +43,7 @@ func PeerLag(s *ReplicationStatus, peer *ReplicationPeer) time.Duration {
 func (l *Lantern) GetReplicationStatus(ctx context.Context) (*ReplicationStatus, error) {
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	resp, err := unary(ctx, &pb.GetReplicationStatusRequest{}, l.client.GetReplicationStatus)
+	resp, err := unary(ctx, l, &pb.GetReplicationStatusRequest{}, l.client.GetReplicationStatus)
 	if err != nil {
 		return nil, err
 	}

--- a/sdks/go/retry.go
+++ b/sdks/go/retry.go
@@ -1,0 +1,263 @@
+// Package client: retry.go implements the opt-in retry policy (#849).
+//
+// The SDK long had every prerequisite for safe retries — the
+// ErrUnavailable sentinel, WithIdempotentAdds ContribID stamping, failover
+// rotation — and stopped one step short of performing them, so every
+// consumer hand-rolled the same backoff loop (or, in practice, didn't).
+// WithRetry closes that gap: exponential backoff with full jitter,
+// context-aware, bounded attempts, applied ONLY to RPCs that are
+// idempotent under the client's configuration.
+//
+// Eligibility is enforced in code, not docs (see requestRetryable):
+//
+//	reads (Get*/Scan*/Count*/Search*/Illuminate/status)  retryable
+//	PutVertex(es)/PutEdge(s)/Delete*                     retryable (idempotent semantics)
+//	AddEdge/AddEdges                                     retryable ONLY when every edge in the
+//	                                                     request carries a ContribID (WithIdempotentAdds
+//	                                                     stamps them; without one a retry double-counts)
+//	streaming / io (Subscribe/Backup/Restore/…)          never (v1)
+//	anything unclassified                                never (fail closed)
+//
+// Never retried regardless of policy: deterministic outcomes
+// (NotFound/InvalidArgument/FailedPrecondition) and DeadlineExceeded (the
+// budget is already spent). Default retryable code: Unavailable.
+// ResourceExhausted is opt-in via RetryableCodes so it composes with the
+// server-side capacity cap (#848) and rate limiter when the caller wants
+// retry-after-decay semantics.
+package client
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"time"
+
+	"connectrpc.com/connect"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+)
+
+// RetryPolicy configures WithRetry. The zero value is normalised to
+// MaxAttempts=3, BaseDelay=100ms, MaxDelay=2s, RetryableCodes={Unavailable}.
+type RetryPolicy struct {
+	// MaxAttempts is the total number of tries including the first.
+	// Values < 1 normalise to 3. Under NewLanternFailover the attempts
+	// double as the cross-replica budget: an Unavailable attempt advances
+	// the sticky endpoint, so the next attempt hits the sibling.
+	MaxAttempts int
+	// BaseDelay seeds the exponential backoff (default 100ms). The delay
+	// before attempt k (k >= 2) is uniformly random in
+	// (0, min(MaxDelay, BaseDelay·2^(k-2))] — "full jitter".
+	BaseDelay time.Duration
+	// MaxDelay caps a single backoff sleep (default 2s).
+	MaxDelay time.Duration
+	// RetryableCodes lists the connect codes worth another attempt.
+	// Empty defaults to {CodeUnavailable}. Add CodeResourceExhausted to
+	// retry through the #848 capacity cap / rate limiter.
+	RetryableCodes []connect.Code
+
+	// Test seams: injected sleep and randomness. Nil uses real time and
+	// math/rand. Unexported — production callers cannot (and must not)
+	// touch them.
+	sleepFn func(context.Context, time.Duration) error
+	randFn  func() float64
+}
+
+// normalized returns a copy with defaults applied.
+func (p RetryPolicy) normalized() RetryPolicy {
+	if p.MaxAttempts < 1 {
+		p.MaxAttempts = 3
+	}
+	if p.BaseDelay <= 0 {
+		p.BaseDelay = 100 * time.Millisecond
+	}
+	if p.MaxDelay <= 0 {
+		p.MaxDelay = 2 * time.Second
+	}
+	if len(p.RetryableCodes) == 0 {
+		p.RetryableCodes = []connect.Code{connect.CodeUnavailable}
+	}
+	if p.sleepFn == nil {
+		p.sleepFn = ctxSleep
+	}
+	if p.randFn == nil {
+		p.randFn = rand.Float64
+	}
+	return p
+}
+
+// retryableErr reports whether err is worth another attempt under the
+// policy. nil is never retryable (success); DeadlineExceeded/Canceled are
+// excluded structurally because the caller's ctx is already dead.
+func (p RetryPolicy) retryableErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	code := connect.CodeOf(err)
+	if code == connect.CodeDeadlineExceeded || code == connect.CodeCanceled {
+		return false
+	}
+	for _, c := range p.RetryableCodes {
+		if code == c {
+			return true
+		}
+	}
+	return false
+}
+
+// delay computes the full-jitter backoff before attempt number `attempt`
+// (0-based count of completed attempts): rand(0, min(MaxDelay, Base·2^n)].
+func (p RetryPolicy) delay(attempt int) time.Duration {
+	ceil := p.BaseDelay << attempt
+	if ceil <= 0 || ceil > p.MaxDelay { // <<-overflow guards land on MaxDelay
+		ceil = p.MaxDelay
+	}
+	return time.Duration(p.randFn() * float64(ceil))
+}
+
+// run drives attempt() under the policy: first try immediately, then up to
+// MaxAttempts-1 retries with jittered backoff. A non-retryable error (or
+// success) returns immediately. Backoff sleeps honour ctx; cancellation
+// mid-backoff aborts with the last attempt's error joined with ctx.Err().
+func (p RetryPolicy) run(ctx context.Context, attempt func() error) error {
+	var lastErr error
+	for i := 0; i < p.MaxAttempts; i++ {
+		if i > 0 {
+			if err := p.sleepFn(ctx, p.delay(i-1)); err != nil {
+				return errors.Join(lastErr, err)
+			}
+		}
+		lastErr = attempt()
+		if !p.retryableErr(lastErr) {
+			return lastErr
+		}
+	}
+	return lastErr
+}
+
+// ctxSleep sleeps for d or until ctx is done, whichever comes first.
+func ctxSleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// requestRetryable is the code-enforced eligibility matrix at the wire
+// boundary (#849): it classifies by the REQUEST message that is about to
+// be (re)sent, which uniformly covers both WithIdempotentAdds (ContribIDs
+// are stamped into the request before the first attempt, so every retry
+// re-sends the same keys) and explicitly-supplied ContribIDs. Unknown
+// request types are NOT retryable — fail closed; the paired matrix test
+// forces a classification for every public RPC method.
+func requestRetryable(req any) bool {
+	switch r := req.(type) {
+	case *pb.AddEdgeRequest:
+		return len(r.GetContribId()) > 0
+	case *pb.AddEdgesRequest:
+		if len(r.GetContribIds()) != len(r.GetEdges()) {
+			return false
+		}
+		for _, id := range r.GetContribIds() {
+			if len(id) == 0 {
+				return false
+			}
+		}
+		return len(r.GetEdges()) > 0
+	case *pb.GetVertexRequest, *pb.GetVerticesRequest,
+		*pb.GetEdgeRequest, *pb.GetEdgesRequest,
+		*pb.PutVertexRequest, *pb.PutVerticesRequest,
+		*pb.PutEdgeRequest, *pb.PutEdgesRequest,
+		*pb.DeleteVertexRequest, *pb.DeleteVerticesRequest,
+		*pb.DeleteEdgeRequest, *pb.DeleteEdgesRequest,
+		*pb.DeleteVerticesByPrefixRequest,
+		*pb.ScanVerticesRequest, *pb.ScanVertexKeysRequest,
+		*pb.ScanEdgesRequest, *pb.CountVerticesByPrefixRequest,
+		*pb.SearchVerticesRequest, *pb.IlluminateRequest,
+		*pb.GetServerStatusRequest, *pb.GetReplicationStatusRequest:
+		return true
+	}
+	return false
+}
+
+// methodRetryClass is the SDK-method-level eligibility matrix. It exists
+// for two consumers: the Failover wrappers (which dispatch per method, not
+// per wire request) and the paired reflection test that walks EVERY public
+// *Lantern RPC method and fails the build-time contract when a new method
+// lands without a classification — the forced-decision rule.
+type methodRetryClass int
+
+const (
+	// retryNever: never retried (streaming, or unclassified).
+	retryNever methodRetryClass = iota
+	// retryAlways: idempotent by semantics.
+	retryAlways
+	// retryIfIdempotentAdds: additive writes — retried only when the
+	// request provably carries per-edge ContribIDs.
+	retryIfIdempotentAdds
+)
+
+// methodRetryClasses classifies every public RPC-shaped method on *Lantern
+// (and therefore every Failover wrapper). Adding an RPC method without a
+// row here fails TestRetryEligibilityMatrix_CoversEveryRPC.
+var methodRetryClasses = map[string]methodRetryClass{
+	"GetVertex":              retryAlways,
+	"GetVertices":            retryAlways,
+	"GetEdge":                retryAlways,
+	"GetEdges":               retryAlways,
+	"PutVertex":              retryAlways,
+	"PutVertexAt":            retryAlways,
+	"PutVertices":            retryAlways,
+	"PutEdge":                retryAlways,
+	"PutEdgeAt":              retryAlways,
+	"PutEdges":               retryAlways,
+	"DeleteVertex":           retryAlways,
+	"DeleteVertices":         retryAlways,
+	"DeleteEdge":             retryAlways,
+	"DeleteEdges":            retryAlways,
+	"DeleteVerticesByPrefix": retryAlways,
+	"ScanVertices":           retryAlways,
+	"ScanVerticesAll":        retryAlways,
+	"ScanVertexKeys":         retryAlways,
+	"ScanVertexKeysAll":      retryAlways,
+	"ScanEdges":              retryAlways,
+	"ScanEdgesAll":           retryAlways,
+	"CountVerticesByPrefix":  retryAlways,
+	"SearchVertices":         retryAlways,
+	"Illuminate":             retryAlways,
+	"GetServerStatus":        retryAlways,
+	"GetReplicationStatus":   retryAlways,
+	"Ping":                   retryAlways,
+	"AddEdge":                retryIfIdempotentAdds,
+	"AddEdgeAt":              retryIfIdempotentAdds,
+	"AddEdges":               retryIfIdempotentAdds,
+	"Backup":                 retryNever, // whole-graph stream dump — excluded in v1
+	"Restore":                retryNever, // stream restore — excluded in v1
+	"Subscribe":              retryNever, // server-streaming replication feed
+	"NewIncrementalSearch":   retryNever, // session constructor; per-query retries ride unary
+}
+
+// retryableMethod is the method-name counterpart to requestRetryable,
+// consumed by the Failover wrappers — which dispatch per method, not per
+// wire request, so they cannot inspect the ContribIDs the way unary does.
+// It reads the code-enforced methodRetryClasses matrix and folds in the
+// caller's idempotent-adds setting for the additive write surface. Unknown
+// methods fail closed (retryNever is the zero value), so a mis-typed call
+// site silently disables retry rather than risking an unsafe one.
+func retryableMethod(method string, idempotentAdds bool) bool {
+	switch methodRetryClasses[method] {
+	case retryAlways:
+		return true
+	case retryIfIdempotentAdds:
+		return idempotentAdds
+	default:
+		return false
+	}
+}

--- a/sdks/go/retry_test.go
+++ b/sdks/go/retry_test.go
@@ -1,0 +1,488 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
+)
+
+// noSleep is a RetryPolicy.sleepFn seam that returns instantly so tests never
+// wait real backoff. It still honours a cancelled ctx so ctx-abort tests stay
+// meaningful.
+func noSleep(ctx context.Context, _ time.Duration) error { return ctx.Err() }
+
+// fixedRand returns a RetryPolicy.randFn seam that always yields v — used to
+// pin the full-jitter draw to a known point in [0,1).
+func fixedRand(v float64) func() float64 { return func() float64 { return v } }
+
+func TestRetryPolicy_Normalized(t *testing.T) {
+	t.Run("zero value gets defaults", func(t *testing.T) {
+		p := RetryPolicy{}.normalized()
+		if p.MaxAttempts != 3 {
+			t.Errorf("MaxAttempts = %d, want 3", p.MaxAttempts)
+		}
+		if p.BaseDelay != 100*time.Millisecond {
+			t.Errorf("BaseDelay = %v, want 100ms", p.BaseDelay)
+		}
+		if p.MaxDelay != 2*time.Second {
+			t.Errorf("MaxDelay = %v, want 2s", p.MaxDelay)
+		}
+		if len(p.RetryableCodes) != 1 || p.RetryableCodes[0] != connect.CodeUnavailable {
+			t.Errorf("RetryableCodes = %v, want {Unavailable}", p.RetryableCodes)
+		}
+		if p.sleepFn == nil || p.randFn == nil {
+			t.Error("normalized must install default sleepFn/randFn")
+		}
+	})
+
+	t.Run("negative MaxAttempts normalises to 3", func(t *testing.T) {
+		if got := (RetryPolicy{MaxAttempts: -5}).normalized().MaxAttempts; got != 3 {
+			t.Errorf("MaxAttempts = %d, want 3", got)
+		}
+	})
+
+	t.Run("explicit values are preserved", func(t *testing.T) {
+		p := RetryPolicy{
+			MaxAttempts:    7,
+			BaseDelay:      5 * time.Millisecond,
+			MaxDelay:       time.Minute,
+			RetryableCodes: []connect.Code{connect.CodeResourceExhausted},
+		}.normalized()
+		if p.MaxAttempts != 7 || p.BaseDelay != 5*time.Millisecond || p.MaxDelay != time.Minute {
+			t.Errorf("explicit knobs mutated: %+v", p)
+		}
+		if len(p.RetryableCodes) != 1 || p.RetryableCodes[0] != connect.CodeResourceExhausted {
+			t.Errorf("RetryableCodes = %v, want {ResourceExhausted}", p.RetryableCodes)
+		}
+	})
+}
+
+func TestRetryPolicy_RetryableErr(t *testing.T) {
+	def := RetryPolicy{}.normalized()
+	tests := []struct {
+		name string
+		p    RetryPolicy
+		err  error
+		want bool
+	}{
+		{"nil is never retryable", def, nil, false},
+		{"unavailable retryable by default", def, connect.NewError(connect.CodeUnavailable, errors.New("x")), true},
+		{"wrapped unavailable retryable", def, wrapConnectErr(connect.NewError(connect.CodeUnavailable, errors.New("x"))), true},
+		{"notfound not retryable", def, connect.NewError(connect.CodeNotFound, errors.New("x")), false},
+		{"invalid argument not retryable", def, connect.NewError(connect.CodeInvalidArgument, errors.New("x")), false},
+		{"deadline exceeded never retryable", def, connect.NewError(connect.CodeDeadlineExceeded, errors.New("x")), false},
+		{"canceled never retryable", def, connect.NewError(connect.CodeCanceled, errors.New("x")), false},
+		{"resource exhausted opt-out by default", def, connect.NewError(connect.CodeResourceExhausted, errors.New("x")), false},
+		{
+			"resource exhausted opt-in",
+			RetryPolicy{RetryableCodes: []connect.Code{connect.CodeUnavailable, connect.CodeResourceExhausted}}.normalized(),
+			connect.NewError(connect.CodeResourceExhausted, errors.New("x")),
+			true,
+		},
+		{
+			"deadline stays excluded even if listed",
+			RetryPolicy{RetryableCodes: []connect.Code{connect.CodeDeadlineExceeded}}.normalized(),
+			connect.NewError(connect.CodeDeadlineExceeded, errors.New("x")),
+			false,
+		},
+		{"plain error not retryable", def, errors.New("not a connect error"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.p.retryableErr(tt.err); got != tt.want {
+				t.Errorf("retryableErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryPolicy_Delay(t *testing.T) {
+	base := 100 * time.Millisecond
+	max := 2 * time.Second
+
+	t.Run("full-jitter draws in (0, ceil]", func(t *testing.T) {
+		// randFn=1 lands on the ceiling; randFn=0 lands on 0. The ceiling
+		// is BaseDelay<<attempt until it saturates at MaxDelay.
+		wantCeil := []time.Duration{base, 2 * base, 4 * base, 8 * base, 16 * base}
+		for attempt, ceil := range wantCeil {
+			p := RetryPolicy{BaseDelay: base, MaxDelay: max, randFn: fixedRand(1)}.normalized()
+			if got := p.delay(attempt); got != ceil {
+				t.Errorf("delay(%d) at rand=1 = %v, want ceil %v", attempt, got, ceil)
+			}
+			pz := RetryPolicy{BaseDelay: base, MaxDelay: max, randFn: fixedRand(0)}.normalized()
+			if got := pz.delay(attempt); got != 0 {
+				t.Errorf("delay(%d) at rand=0 = %v, want 0", attempt, got)
+			}
+		}
+	})
+
+	t.Run("ceiling saturates at MaxDelay", func(t *testing.T) {
+		p := RetryPolicy{BaseDelay: base, MaxDelay: max, randFn: fixedRand(1)}.normalized()
+		// 100ms<<5 = 3.2s > 2s cap.
+		if got := p.delay(5); got != max {
+			t.Errorf("delay(5) = %v, want capped %v", got, max)
+		}
+	})
+
+	t.Run("huge attempt overflow guards to MaxDelay", func(t *testing.T) {
+		p := RetryPolicy{BaseDelay: base, MaxDelay: max, randFn: fixedRand(1)}.normalized()
+		if got := p.delay(100); got != max {
+			t.Errorf("delay(100) overflow = %v, want %v", got, max)
+		}
+	})
+}
+
+func TestRetryPolicy_Run(t *testing.T) {
+	unavailable := func() error { return connect.NewError(connect.CodeUnavailable, errors.New("down")) }
+
+	t.Run("succeeds on first attempt", func(t *testing.T) {
+		p := RetryPolicy{MaxAttempts: 3, sleepFn: noSleep, randFn: fixedRand(0)}.normalized()
+		calls := 0
+		err := p.run(context.Background(), func() error { calls++; return nil })
+		if err != nil || calls != 1 {
+			t.Fatalf("calls=%d err=%v, want 1/nil", calls, err)
+		}
+	})
+
+	t.Run("fail-N-then-succeed retries then wins", func(t *testing.T) {
+		p := RetryPolicy{MaxAttempts: 4, sleepFn: noSleep, randFn: fixedRand(0)}.normalized()
+		calls := 0
+		err := p.run(context.Background(), func() error {
+			calls++
+			if calls < 3 {
+				return unavailable()
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+		if calls != 3 {
+			t.Fatalf("calls = %d, want 3 (2 failures + success)", calls)
+		}
+	})
+
+	t.Run("always-fail exhausts MaxAttempts and returns last error", func(t *testing.T) {
+		p := RetryPolicy{MaxAttempts: 3, sleepFn: noSleep, randFn: fixedRand(0)}.normalized()
+		calls := 0
+		err := p.run(context.Background(), func() error { calls++; return unavailable() })
+		if calls != 3 {
+			t.Fatalf("calls = %d, want 3", calls)
+		}
+		if connect.CodeOf(err) != connect.CodeUnavailable {
+			t.Fatalf("final err code = %v, want Unavailable", connect.CodeOf(err))
+		}
+	})
+
+	t.Run("non-retryable error stops immediately", func(t *testing.T) {
+		p := RetryPolicy{MaxAttempts: 5, sleepFn: noSleep, randFn: fixedRand(0)}.normalized()
+		calls := 0
+		err := p.run(context.Background(), func() error {
+			calls++
+			return connect.NewError(connect.CodeNotFound, errors.New("nope"))
+		})
+		if calls != 1 {
+			t.Fatalf("calls = %d, want 1 (no retry on NotFound)", calls)
+		}
+		if connect.CodeOf(err) != connect.CodeNotFound {
+			t.Fatalf("err code = %v, want NotFound", connect.CodeOf(err))
+		}
+	})
+
+	t.Run("ctx cancel mid-backoff aborts and joins ctx error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		sleepCalls := 0
+		p := RetryPolicy{
+			MaxAttempts: 5,
+			randFn:      fixedRand(1),
+			sleepFn: func(c context.Context, _ time.Duration) error {
+				sleepCalls++
+				cancel()
+				return c.Err()
+			},
+		}.normalized()
+		calls := 0
+		err := p.run(ctx, func() error { calls++; return unavailable() })
+		if calls != 1 || sleepCalls != 1 {
+			t.Fatalf("calls=%d sleepCalls=%d, want 1/1 (abort during first backoff)", calls, sleepCalls)
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want joined context.Canceled", err)
+		}
+		if connect.CodeOf(err) != connect.CodeUnavailable {
+			t.Fatalf("err must retain the last attempt's Unavailable; code = %v", connect.CodeOf(err))
+		}
+	})
+}
+
+func TestCtxSleep(t *testing.T) {
+	t.Run("non-positive duration returns immediately", func(t *testing.T) {
+		if err := ctxSleep(context.Background(), 0); err != nil {
+			t.Fatalf("ctxSleep(bg, 0) = %v, want nil", err)
+		}
+		if err := ctxSleep(context.Background(), -time.Second); err != nil {
+			t.Fatalf("ctxSleep(bg, -1s) = %v, want nil", err)
+		}
+	})
+
+	t.Run("positive duration elapses", func(t *testing.T) {
+		if err := ctxSleep(context.Background(), time.Millisecond); err != nil {
+			t.Fatalf("ctxSleep(bg, 1ms) = %v, want nil", err)
+		}
+	})
+
+	t.Run("cancelled ctx aborts before the timer fires", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := ctxSleep(ctx, time.Hour); !errors.Is(err, context.Canceled) {
+			t.Fatalf("ctxSleep(cancelled, 1h) = %v, want context.Canceled", err)
+		}
+	})
+}
+
+func TestRequestRetryable(t *testing.T) {
+	contrib := []byte("000000000000000000000001") // 24-byte canonical id shape
+
+	t.Run("reads and idempotent writes are retryable", func(t *testing.T) {
+		reqs := []any{
+			&pb.GetVertexRequest{}, &pb.GetVerticesRequest{}, &pb.GetEdgeRequest{}, &pb.GetEdgesRequest{},
+			&pb.PutVertexRequest{}, &pb.PutVerticesRequest{}, &pb.PutEdgeRequest{}, &pb.PutEdgesRequest{},
+			&pb.DeleteVertexRequest{}, &pb.DeleteVerticesRequest{}, &pb.DeleteEdgeRequest{}, &pb.DeleteEdgesRequest{},
+			&pb.DeleteVerticesByPrefixRequest{}, &pb.ScanVerticesRequest{}, &pb.ScanVertexKeysRequest{},
+			&pb.ScanEdgesRequest{}, &pb.CountVerticesByPrefixRequest{}, &pb.SearchVerticesRequest{},
+			&pb.IlluminateRequest{}, &pb.GetServerStatusRequest{}, &pb.GetReplicationStatusRequest{},
+		}
+		for _, r := range reqs {
+			if !requestRetryable(r) {
+				t.Errorf("requestRetryable(%T) = false, want true", r)
+			}
+		}
+	})
+
+	t.Run("unknown request type fails closed", func(t *testing.T) {
+		if requestRetryable(&pb.SubscribeRequest{}) {
+			t.Error("streaming SubscribeRequest must not be retryable")
+		}
+		if requestRetryable("not a proto") {
+			t.Error("unclassified type must not be retryable")
+		}
+	})
+
+	t.Run("AddEdge retryable only with a contrib id", func(t *testing.T) {
+		if requestRetryable(&pb.AddEdgeRequest{}) {
+			t.Error("AddEdge without contrib_id must not be retryable")
+		}
+		if !requestRetryable(&pb.AddEdgeRequest{ContribId: contrib}) {
+			t.Error("AddEdge with contrib_id must be retryable")
+		}
+	})
+
+	t.Run("AddEdges retryable only when every edge carries a contrib id", func(t *testing.T) {
+		edges := []*pb.Edge{{Tail: "a", Head: "b"}, {Tail: "c", Head: "d"}}
+		cases := []struct {
+			name string
+			req  *pb.AddEdgesRequest
+			want bool
+		}{
+			{"no ids", &pb.AddEdgesRequest{Edges: edges}, false},
+			{"count mismatch", &pb.AddEdgesRequest{Edges: edges, ContribIds: [][]byte{contrib}}, false},
+			{"one empty id", &pb.AddEdgesRequest{Edges: edges, ContribIds: [][]byte{contrib, {}}}, false},
+			{"all ids present", &pb.AddEdgesRequest{Edges: edges, ContribIds: [][]byte{contrib, contrib}}, true},
+			{"empty edges", &pb.AddEdgesRequest{}, false},
+		}
+		for _, tc := range cases {
+			if got := requestRetryable(tc.req); got != tc.want {
+				t.Errorf("%s: requestRetryable = %v, want %v", tc.name, got, tc.want)
+			}
+		}
+	})
+}
+
+func TestRetryableMethod(t *testing.T) {
+	cases := []struct {
+		method         string
+		idempotentAdds bool
+		want           bool
+	}{
+		{"GetVertex", false, true},
+		{"PutVertices", false, true},
+		{"DeleteEdges", false, true},
+		{"AddEdges", false, false},  // additive write, no idempotency
+		{"AddEdges", true, true},    // idempotency armed
+		{"AddEdge", true, true},     // idempotency armed
+		{"AddEdgeAt", false, false}, // additive write, no idempotency
+		{"Subscribe", true, false},  // streaming never retries
+		{"Backup", true, false},     // io stream never retries
+		{"NotAMethod", true, false}, // unknown fails closed
+	}
+	for _, c := range cases {
+		if got := retryableMethod(c.method, c.idempotentAdds); got != c.want {
+			t.Errorf("retryableMethod(%q, idempotent=%v) = %v, want %v", c.method, c.idempotentAdds, got, c.want)
+		}
+	}
+}
+
+// TestRetryEligibilityMatrix_CoversEveryRPC is the forced-decision guard: it
+// walks every exported context-first method on *Lantern and fails when one is
+// missing from methodRetryClasses, and conversely fails on any phantom map key
+// that is not a real method. A new RPC (or a rename) cannot land without a
+// deliberate retry classification.
+func TestRetryEligibilityMatrix_CoversEveryRPC(t *testing.T) {
+	ctxType := reflect.TypeOf((*context.Context)(nil)).Elem()
+	rt := reflect.TypeOf((*Lantern)(nil))
+
+	rpcMethods := map[string]bool{}
+	for i := 0; i < rt.NumMethod(); i++ {
+		m := rt.Method(i)
+		// RPC-shaped: first parameter after the receiver is context.Context.
+		// Close() (no ctx) and any non-ctx method are excluded.
+		if m.Type.NumIn() < 2 || m.Type.In(1) != ctxType {
+			continue
+		}
+		rpcMethods[m.Name] = true
+		if _, ok := methodRetryClasses[m.Name]; !ok {
+			t.Errorf("*Lantern.%s has no methodRetryClasses entry (forced-decision rule)", m.Name)
+		}
+	}
+
+	for name := range methodRetryClasses {
+		if !rpcMethods[name] {
+			t.Errorf("methodRetryClasses has phantom key %q with no matching *Lantern RPC method", name)
+		}
+	}
+}
+
+// scriptedClient is a fake LanternServiceClient that scripts per-method
+// success/failure sequences and records the requests it receives, so the
+// single-endpoint unary retry path can be exercised without a live server.
+// It embeds the interface (left nil) to satisfy the unused surface.
+type scriptedClient struct {
+	graphv1connect.LanternServiceClient
+
+	getVertexErrs []error
+	getVertexN    int
+
+	addEdgesErrs []error
+	addEdgesN    int
+	addEdgesReqs []*pb.AddEdgesRequest
+}
+
+func (c *scriptedClient) GetVertex(_ context.Context, req *connect.Request[pb.GetVertexRequest]) (*connect.Response[pb.GetVertexResponse], error) {
+	i := c.getVertexN
+	c.getVertexN++
+	if i < len(c.getVertexErrs) && c.getVertexErrs[i] != nil {
+		return nil, c.getVertexErrs[i]
+	}
+	return connect.NewResponse(&pb.GetVertexResponse{Vertex: &pb.Vertex{Key: req.Msg.GetKey()}}), nil
+}
+
+func (c *scriptedClient) AddEdges(_ context.Context, req *connect.Request[pb.AddEdgesRequest]) (*connect.Response[pb.AddEdgesResponse], error) {
+	c.addEdgesReqs = append(c.addEdgesReqs, req.Msg)
+	i := c.addEdgesN
+	c.addEdgesN++
+	if i < len(c.addEdgesErrs) && c.addEdgesErrs[i] != nil {
+		return nil, c.addEdgesErrs[i]
+	}
+	return connect.NewResponse(&pb.AddEdgesResponse{}), nil
+}
+
+func TestUnaryRetry_SingleEndpoint(t *testing.T) {
+	unavailable := connect.NewError(connect.CodeUnavailable, errors.New("down"))
+
+	t.Run("retries a read until it succeeds", func(t *testing.T) {
+		l := mustLantern(t, WithRetry(RetryPolicy{MaxAttempts: 3, sleepFn: noSleep}))
+		capt := &scriptedClient{getVertexErrs: []error{unavailable, unavailable, nil}}
+		l.client = capt
+		v, err := l.GetVertex(context.Background(), "k")
+		if err != nil {
+			t.Fatalf("GetVertex: %v", err)
+		}
+		if v.GetKey() != "k" {
+			t.Fatalf("vertex key = %q, want k", v.GetKey())
+		}
+		if capt.getVertexN != 3 {
+			t.Fatalf("attempts = %d, want 3", capt.getVertexN)
+		}
+	})
+
+	t.Run("exhausts attempts then surfaces Unavailable", func(t *testing.T) {
+		l := mustLantern(t, WithRetry(RetryPolicy{MaxAttempts: 2, sleepFn: noSleep}))
+		capt := &scriptedClient{getVertexErrs: []error{unavailable, unavailable}}
+		l.client = capt
+		_, err := l.GetVertex(context.Background(), "k")
+		if !errors.Is(err, ErrUnavailable) {
+			t.Fatalf("err = %v, want ErrUnavailable", err)
+		}
+		if capt.getVertexN != 2 {
+			t.Fatalf("attempts = %d, want 2", capt.getVertexN)
+		}
+	})
+
+	t.Run("does not retry a deterministic error", func(t *testing.T) {
+		l := mustLantern(t, WithRetry(RetryPolicy{MaxAttempts: 5, sleepFn: noSleep}))
+		capt := &scriptedClient{getVertexErrs: []error{connect.NewError(connect.CodeNotFound, errors.New("gone"))}}
+		l.client = capt
+		_, err := l.GetVertex(context.Background(), "k")
+		if !errors.Is(err, ErrNotFound) {
+			t.Fatalf("err = %v, want ErrNotFound", err)
+		}
+		if capt.getVertexN != 1 {
+			t.Fatalf("attempts = %d, want 1 (NotFound is deterministic)", capt.getVertexN)
+		}
+	})
+
+	t.Run("zero-config client never retries", func(t *testing.T) {
+		l := mustLantern(t) // no WithRetry
+		capt := &scriptedClient{getVertexErrs: []error{unavailable}}
+		l.client = capt
+		_, err := l.GetVertex(context.Background(), "k")
+		if !errors.Is(err, ErrUnavailable) {
+			t.Fatalf("err = %v, want ErrUnavailable", err)
+		}
+		if capt.getVertexN != 1 {
+			t.Fatalf("attempts = %d, want 1 (retry not armed)", capt.getVertexN)
+		}
+	})
+
+	t.Run("idempotent AddEdges retries with identical ContribIDs", func(t *testing.T) {
+		l := mustLantern(t, WithIdempotentAdds(), WithRetry(RetryPolicy{MaxAttempts: 3, sleepFn: noSleep}))
+		capt := &scriptedClient{addEdgesErrs: []error{unavailable, nil}}
+		l.client = capt
+		if err := l.AddEdges(context.Background(), []EdgeInput{{Tail: "a", Head: "b", Weight: 1}}); err != nil {
+			t.Fatalf("AddEdges: %v", err)
+		}
+		if capt.addEdgesN != 2 {
+			t.Fatalf("attempts = %d, want 2", capt.addEdgesN)
+		}
+		if len(capt.addEdgesReqs) != 2 {
+			t.Fatalf("recorded %d requests, want 2", len(capt.addEdgesReqs))
+		}
+		first, second := capt.addEdgesReqs[0].GetContribIds(), capt.addEdgesReqs[1].GetContribIds()
+		if len(first) != 1 || len(second) != 1 {
+			t.Fatalf("contrib id counts = %d,%d, want 1,1", len(first), len(second))
+		}
+		if !reflect.DeepEqual(first, second) {
+			t.Fatalf("retried request must carry identical ContribIDs; got %x vs %x", first, second)
+		}
+	})
+
+	t.Run("non-idempotent AddEdges is never retried", func(t *testing.T) {
+		l := mustLantern(t, WithRetry(RetryPolicy{MaxAttempts: 5, sleepFn: noSleep})) // no WithIdempotentAdds
+		capt := &scriptedClient{addEdgesErrs: []error{unavailable, nil}}
+		l.client = capt
+		err := l.AddEdges(context.Background(), []EdgeInput{{Tail: "a", Head: "b", Weight: 1}})
+		if !errors.Is(err, ErrUnavailable) {
+			t.Fatalf("err = %v, want ErrUnavailable (additive write not retried)", err)
+		}
+		if capt.addEdgesN != 1 {
+			t.Fatalf("attempts = %d, want 1 (double-count hazard blocks retry)", capt.addEdgesN)
+		}
+	})
+}

--- a/sdks/go/search.go
+++ b/sdks/go/search.go
@@ -65,7 +65,7 @@ func (l *Lantern) SearchVertices(ctx context.Context, query string, opts ...Sear
 	}
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	resp, err := unary(ctx, &pb.SearchVerticesRequest{
+	resp, err := unary(ctx, l, &pb.SearchVerticesRequest{
 		Query:  query,
 		Limit:  o.limit,
 		Prefix: o.prefix,

--- a/sdks/go/status.go
+++ b/sdks/go/status.go
@@ -45,7 +45,7 @@ func ServerUptime(s *ServerStatus) time.Duration {
 func (l *Lantern) GetServerStatus(ctx context.Context) (*ServerStatus, error) {
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
-	resp, err := unary(ctx, &pb.GetServerStatusRequest{}, l.client.GetServerStatus)
+	resp, err := unary(ctx, l, &pb.GetServerStatusRequest{}, l.client.GetServerStatus)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What & why

Closes #849. The SDK already shipped every prerequisite for safe retries — the
`ErrUnavailable` sentinel, `WithIdempotentAdds` ContribID stamping, and failover
rotation — but stopped one step short, so every consumer hand-rolled (or
skipped) the same backoff loop. This adds an **opt-in** client-level retry
policy. Zero-config clients behave exactly as before.

```go
c, _ := client.NewLantern("http://localhost:6380",
    client.WithIdempotentAdds(),
    client.WithRetry(client.RetryPolicy{MaxAttempts: 4}),
)
```

## Design

- **`RetryPolicy`** (`retry.go`): bounded attempts, full-jitter exponential
  backoff (`rand(0, min(MaxDelay, Base·2^n)]`), context-aware sleeps. Defaults:
  `MaxAttempts=3`, `BaseDelay=100ms`, `MaxDelay=2s`, `RetryableCodes={Unavailable}`
  (add `ResourceExhausted` to retry through the capacity cap / rate limiter).
- **Eligibility enforced in code, two axes:**
  - `requestRetryable` classifies by the **wire request** inside `unary`
    (single endpoint), so a retried `AddEdges` re-sends the request verbatim —
    **identical ContribIDs** on every attempt (the exactly-once property
    `WithIdempotentAdds` provides).
  - `methodRetryClasses` classifies **per method** for the Failover wrappers
    (which dispatch per method, not per wire request). `retryAlways` for
    reads/`Put*`/`Delete*`; `retryIfIdempotentAdds` for the additive
    `AddEdge(s)`; `retryNever` for streaming/io (`Subscribe`/`Backup`/`Restore`)
    and anything unclassified (fail closed).
- **Never retried regardless of policy:** deterministic outcomes
  (`NotFound`/`InvalidArgument`/`FailedPrecondition`) and
  `DeadlineExceeded`/`Canceled`.
- **Failover composition (issue point 4):** the policy drives the ring walk —
  each retry attempt re-runs `try`, resuming from the sticky cursor, so a
  persistently-unavailable endpoint is retried against its siblings with
  backoff and `MaxAttempts` is the cross-replica budget. `NewLanternFailover`
  neutralises each per-endpoint client's own retry (`clearNodeRetry`) so the
  attempt budget is never squared and there is **no second rotation mechanism**.

## Notable fix

`methodRetryClasses` had pre-existing drift: it keyed phantom
`BackupSnapshot`/`RestoreSnapshot` (not real methods) and was missing the real
`Backup`/`Restore`/`NewIncrementalSearch`. The new reflection test
`TestRetryEligibilityMatrix_CoversEveryRPC` walks every exported context-first
`*Lantern` method (forcing a classification for each) **and** rejects phantom
map keys — so this class of drift can't recur.

## Tests

- `retry_test.go`: policy normalisation, `retryableErr` codes, full-jitter
  bounds (injected rand), `run` (fail-N-then-succeed / always-fail /
  non-retryable-stop / ctx-cancel mid-backoff), `ctxSleep`, the
  `requestRetryable`/`retryableMethod` matrices, the reflection guard, and a
  scripted-transport single-endpoint integration proving reads retry, deadline
  errors don't, and idempotent `AddEdges` retries with **identical ContribIDs**
  while non-idempotent `AddEdges` is never retried.
- `failover_test.go`: retry drives the ring walk across attempts, gates
  additive writes by `idempotentAdds`, stops on deterministic errors, and
  `NewLanternFailover` extracts the policy while neutralising per-node retry.

## Scope / docs

- Go SDK only (Node SDK is single-endpoint; out of scope per the issue).
- `doc.go` gains a `# Retry policy` eligibility-matrix section;
  `example/main.go` gains a retry+failover+idempotent-adds combo.
- One unrelated `docs:` commit syncs `CLAUDE.md` (coverage-floor / Node SDK /
  testbed notes), carried here at the maintainer's request.

Local gate green: `gofmt` clean; `go test ./...` (incl. `-race`) across every
module; `sdks-go` coverage 46.3% (floor 37%).
