### PR TITLE
feat(mcp)!: retarget as a multi-agent shared working context

### DIFF
--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -49,6 +49,11 @@ FROM gcr.io/distroless/static:nonroot
 # and DNS-rebinding protection (see mcp/README.md). The TTL ladder is
 # loaded from LANTERN_MCP_TTL_<BUCKET>=<duration> env overrides; see
 # mcp/internal/ttl for the 12 bucket names.
+# LANTERN_MCP_PROFILE selects the tool surface (#851): "context" (the
+# default; multi-agent shared working context) or "memory" (legacy
+# decaying-memory verbs, one-release deprecation window). Set
+# LANTERN_MCP_AGENT_ID per replica for stable fleet identity, and
+# LANTERN_TOKEN when the upstream runs with LANTERN_AUTH_TOKENS (#850).
 ENV LANTERN_ADDR=http://localhost:6380 \
     LANTERN_MCP_PING_TIMEOUT=3s \
     LANTERN_MCP_HTTP_ADDR=0.0.0.0:6390

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,19 +1,59 @@
 # lantern-mcp
 
 A [Model Context Protocol](https://modelcontextprotocol.io) server that
-exposes a remote [Lantern](https://github.com/anaregdesign/lantern) gRPC
-endpoint as **decaying graph memory** for LLM agents.
+exposes a remote [Lantern](https://github.com/anaregdesign/lantern)
+endpoint as a **shared working context for multi-agent fleets** —
+presence, advisory claims, activity heat, and a blackboard, all built on
+decaying state (#851).
 
-The pitch: **facts decay on a TTL ladder; relations are additive and
-decay independently**. Treating Lantern as a Redis-style KV with TTLs
-misses the point — the value lives in the graph that emerges when you
-let an agent reinforce useful relations and let weak ones die on their
-own schedule.
+The pitch: Lantern's primitive — additive TTL edges + decaying vertices —
+models **activity, not knowledge**. Expiry is semantically *correct*
+here: a stale claim SHOULD vanish, last hour's activity SHOULD outweigh
+last week's, a crashed agent's presence SHOULD evaporate. TTL is the
+lease/heartbeat mechanism; additive edges are who-touches-what heat that
+strengthens with repetition and fades with neglect; Illuminate answers
+"what is happening around X right now". One Lantern instance per
+team/fleet is the unit of shared context — pair it with bearer-token
+auth (`LANTERN_AUTH_TOKENS` server-side, `LANTERN_TOKEN` here, #850).
 
-For the end-user docs (Claude Desktop / VS Code / Cursor configs, agent
-session walkthrough), see the **"Use as an MCP server"** section in the
-[root README](../README.md#use-as-an-mcp-server). This file is the
-reference for operators and contributors.
+Two profiles exist behind `LANTERN_MCP_PROFILE`:
+
+- **`context` (default)** — the working-context surface documented below.
+- **`memory`** — the legacy decaying-memory verbs (`remember_*` /
+  `recall_*`), kept for one `mcp/vX` release for existing deployments,
+  then retired. See [Legacy memory profile](#legacy-memory-profile).
+
+Both profiles share one keyspace on the server; switching does NOT
+migrate or clean the other profile's data — TTL decay handles it.
+
+## Two-agent walkthrough
+
+Agent A (id `builder-1`) and agent B (id `reviewer-2`) share one Lantern:
+
+1. **A announces + works**: `announce {task:"refactoring auth middleware"}`
+   → visible in `list_agents`. As it edits, it calls
+   `track {resources:["repo.api.middleware.auth","ticket.API-17"]}` —
+   each call adds a decaying edge; repetition strengthens it.
+2. **A claims before the risky part**: `claim {resource:"repo.api.middleware.auth",
+   note:"rewriting, ~20min"}` → granted, ~10-minute lease, renewed by
+   re-claiming.
+3. **B looks before touching**: `whats_happening {key:"repo.api.middleware.auth"}`
+   → sees builder-1 (task line), the live claim (holder + expiry), and
+   builder-1's co-active resources. B works elsewhere.
+4. **B hits the conflict anyway**: `claim` on the same key returns
+   `{granted:false, holder:"builder-1", expires_at:…}` — a structured
+   result, not an error. B waits or coordinates; `force:true` steals
+   only after coordinating.
+5. **A signals**: `post_note {text:"auth middleware API changed, rebase
+   before touching", severity:"warn", links:["repo.api.middleware.auth"],
+   ttl:"task"}` → B's next `whats_happening` on that resource surfaces it.
+6. **A finishes**: `release` the claim. Then A crashes mid-session —
+   nothing to clean up: its presence (~2m) and any remaining leases
+   (~10m) expire on their own. The board never lies about the present.
+
+For MCP client configs (Claude Desktop / VS Code / Cursor), see
+[examples/](examples/). This file is the reference for operators and
+contributors.
 
 ## Run
 
@@ -63,11 +103,45 @@ The MCP endpoint is **unauthenticated**. The defaults are conservative:
 `SIGINT`/`SIGTERM` triggers a graceful drain (5s) of in-flight requests
 before exit.
 
-## Tools
+## Tools (context profile — the default)
 
-The tool set below is advertised at session-open via the server-instructions
-string in [`server.go`](server.go). Descriptions are reproduced verbatim
-from the source so the LLM and the human reader see the same contract.
+The tool set is advertised at session-open via the instructions string in
+[`server.go`](server.go); summaries below paraphrase the source
+descriptions.
+
+| Tool | Purpose |
+|---|---|
+| `announce` | "I am here, working on T" — presence heartbeat + task line at `agents.<id>` (TTL ≈ 2m, the `transient` bucket). Re-call to refresh; go silent and you disappear from the board. |
+| `list_agents` | Who is active right now. Expired presences are already gone, so the listing is always live. |
+| `track` | "I touched R" — adds a decaying `agents.<id>` → `R` edge (~1h, `conversation`). Repetition strengthens, silence fades; this feeds `whats_happening` for everyone. |
+| `claim` | Advisory lease on a resource at `claims.<resource>` (~10m, `turn`). A live foreign holder returns `{granted:false, holder, expires_at}` — a structured result, not an error; `force:true` steals. Re-claim to renew. The read-check-write window is documented and accepted (agents are slow writers); a server-side CAS RPC is the noted follow-up if contention materialises. |
+| `release` | Drop your lease. Non-holder release is refused with the holder reported; expired/never-claimed is idempotent success. |
+| `list_claims` | Live leases, optionally under a resource-key prefix. |
+| `post_note` | Blackboard signal at `notes.<id>` (`severity` ∈ info/warn/blocker; explicit TTL bucket), linked note→resources + author→note so it surfaces in `whats_happening` nearby. |
+| `whats_happening` | **The flagship read**: active neighborhood of a resource/agent/note — agents on it (with task lines), co-active resources (activity-weighted), live notes, live claims. A never-touched key returns a well-formed empty context. |
+| `context_stats` | Fleet glance: live agents / claims / notes / tracked resources, four numbers. |
+
+A `ping` tool also exists so operators can sanity-check the wire without
+mutating state.
+
+**Identity**: every call is attributed to `LANTERN_MCP_AGENT_ID` when
+set, else a stable per-process fallback `<hostname>-<pid>-<rand4>`.
+Fleet operators own id uniqueness — two sessions sharing an id
+last-writer-win on the presence vertex. There is deliberately no
+per-call id parameter (it would be spoofable and weaker than env-level).
+
+**Key scheme**: `agents.<id>`, `claims.<resource>`, `notes.<id>` are
+reserved; everything else is a resource, named by fleet convention with
+dotted keys (`repo.<name>.<path>`, `ticket.<id>`, `dataset.<name>`).
+Prefix scans give every listing for free; expiry makes them self-cleaning.
+
+## Legacy memory profile
+
+`LANTERN_MCP_PROFILE=memory` restores the decaying-memory verbs below for
+one release cycle. The framing fought the engine — knowledge should not
+decay, and single-agent memory never got dense enough for the graph to
+earn its keep — which is exactly why the context profile replaced it
+(#851 has the full decision record).
 
 | Tool | Purpose |
 |---|---|
@@ -89,7 +163,7 @@ from the source so the LLM and the human reader see the same contract.
 A `ping` tool also exists so operators can sanity-check the wire without
 mutating state.
 
-### TTL buckets (required parameter for every `remember_*` tool)
+### TTL buckets (used by `post_note`, and every `remember_*` tool in the memory profile)
 
 Twelve enum horizons. Picking a shorter bucket is almost always the
 right call ("when will this stop being true?"); writing again is cheap.
@@ -248,6 +322,9 @@ for `in`, and the union for `both`.
 | `LANTERN_MCP_PING_TIMEOUT` | `5s` | Bounds the startup health probe. A failed probe aborts startup with a non-zero exit so MCP clients surface a clear error. |
 | `LANTERN_MCP_TTL_<BUCKET>` | see table above | Per-bucket TTL override. |
 | `LANTERN_MCP_MAX_TTL` | unset (no cap) | Clamp every resolved bucket to at most this duration, matching a low upstream `LANTERN_TOMBSTONE_TTL`. Clamped writes report `"capped": true`. `time.ParseDuration` syntax. |
+| `LANTERN_MCP_PROFILE` | `context` | Tool surface: `context` (working context, #851) or `memory` (legacy decaying-memory verbs, one-release deprecation window). |
+| `LANTERN_MCP_AGENT_ID` | auto (`<hostname>-<pid>-<rand4>`) | Identity every context-profile call is attributed to. Fleet operators own uniqueness. |
+| `LANTERN_TOKEN` | unset | Bearer token sent to a Lantern running with `LANTERN_AUTH_TOKENS` (#850). |
 
 Logging is structured JSON via `log/slog` to stderr at `INFO` level;
 there is no log-level or format knob today.

--- a/mcp/context_keys.go
+++ b/mcp/context_keys.go
@@ -1,0 +1,97 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/anaregdesign/lantern/mcp/internal/value"
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+// Working-context key scheme (#851). Dotted, consistent with the lintKey
+// conventions the memory profile established:
+//
+//	agents.<id>          presence heartbeat (task line, TTL=transient)
+//	claims.<resource>    advisory lease on <resource> (TTL=turn)
+//	notes.<id>           blackboard note (explicit bucket)
+//	<anything else>      a resource — caller-chosen dotted key
+//	                     (e.g. repo.lantern.core.graphcache)
+//
+// Prefix scans give every listing for free and TTL expiry makes each one
+// self-cleaning. When the legacy memory profile ran against the same
+// server the two key populations share one keyspace; switching profiles
+// does NOT migrate or clean old data — TTL decay handles it.
+const (
+	agentKeyPrefix = "agents."
+	claimKeyPrefix = "claims."
+	noteKeyPrefix  = "notes."
+)
+
+func agentKey(id string) string       { return agentKeyPrefix + id }
+func claimKey(resource string) string { return claimKeyPrefix + resource }
+
+// contextKind classifies a vertex key into the working-context buckets
+// whats_happening reports. Anything outside the three reserved prefixes
+// is a resource by definition.
+func contextKind(key string) string {
+	switch {
+	case strings.HasPrefix(key, agentKeyPrefix):
+		return "agent"
+	case strings.HasPrefix(key, claimKeyPrefix):
+		return "claim"
+	case strings.HasPrefix(key, noteKeyPrefix):
+		return "note"
+	default:
+		return "resource"
+	}
+}
+
+// presenceRecord is the JSON payload stored at agents.<id>.
+type presenceRecord struct {
+	Task   string `json:"task"`
+	Detail string `json:"detail,omitempty"`
+	Since  string `json:"since,omitempty"` // RFC3339; first announce of this task line
+}
+
+// claimRecord is the JSON payload stored at claims.<resource>.
+type claimRecord struct {
+	Holder string `json:"holder"`
+	Note   string `json:"note,omitempty"`
+	At     string `json:"at,omitempty"` // RFC3339; when the lease was (re)granted
+}
+
+// noteRecord is the JSON payload stored at notes.<id>.
+type noteRecord struct {
+	Text     string   `json:"text"`
+	Author   string   `json:"author"`
+	Severity string   `json:"severity,omitempty"`
+	Links    []string `json:"links,omitempty"`
+}
+
+// encodeRecord marshals a context payload for PutVertex. JSON-in-string
+// keeps the wire value a plain string vertex, so the memory-profile tools
+// (and Admin) render it legibly if they ever meet it.
+func encodeRecord(v any) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// decodeRecord unmarshals a context payload from a fetched vertex into
+// out. Returns false when the vertex does not hold a JSON string of the
+// expected shape (foreign data sharing the keyspace) — callers surface
+// such entries raw instead of erroring.
+func decodeRecord(v *client.Vertex, out any) bool {
+	s := value.Text(v)
+	if s == "" {
+		return false
+	}
+	return json.Unmarshal([]byte(s), out) == nil
+}
+
+// expirationIn converts a resolved TTL duration into the absolute
+// expiration client.EdgeInput carries.
+func expirationIn(d time.Duration) time.Time { return time.Now().Add(d) }

--- a/mcp/doc.go
+++ b/mcp/doc.go
@@ -1,9 +1,12 @@
 // Package mcp hosts the lantern-mcp binary and its supporting packages.
 //
 // lantern-mcp is a Model Context Protocol (MCP) server that exposes a remote
-// Lantern instance as decaying graph memory for LLM agents. It is a
-// standalone executable, not a library: import paths under this module are
-// intentionally internal-leaning.
+// Lantern instance as a shared working context for multi-agent fleets
+// (#851): presence, advisory claims, activity heat, and a blackboard, all
+// built on decaying state. The legacy decaying-memory verbs remain
+// available behind LANTERN_MCP_PROFILE=memory for one release cycle. It is
+// a standalone executable, not a library: import paths under this module
+// are intentionally internal-leaning.
 //
 // Dependency boundary: this module imports only the public Lantern Go
 // surface — github.com/anaregdesign/lantern/pb and

--- a/mcp/helpers_test.go
+++ b/mcp/helpers_test.go
@@ -27,8 +27,22 @@ func newTestHarness(t *testing.T) *testHarness {
 // environment.
 func newTestHarnessWith(t *testing.T, r *ttl.Resolver) *testHarness {
 	t.Helper()
+	// The legacy tool tests exercise the memory profile; context-profile
+	// tests use newContextHarness below.
+	return newProfileHarness(t, r, ProfileMemory)
+}
+
+// newContextHarness is the working-context-profile (#851) sibling of
+// newTestHarness.
+func newContextHarness(t *testing.T) *testHarness {
+	t.Helper()
+	return newProfileHarness(t, mustDefaultResolver(t), ProfileContext)
+}
+
+func newProfileHarness(t *testing.T, r *ttl.Resolver, profile string) *testHarness {
+	t.Helper()
 	fake := &fakeLantern{}
-	srv := newServer(fake, r, slog.New(slog.NewJSONHandler(io.Discard, nil)))
+	srv := newServer(fake, r, slog.New(slog.NewJSONHandler(io.Discard, nil)), profile)
 
 	serverT, clientT := mcp.NewInMemoryTransports()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -137,4 +151,10 @@ func structuredAs(t *testing.T, res *mcp.CallToolResult, v any) {
 	if err := json.Unmarshal(b, v); err != nil {
 		t.Fatalf("unmarshal into %T: %v (raw=%s)", v, err, b)
 	}
+}
+
+// decodePayload unmarshals a JSON payload string captured by the fake
+// client into out — the raw-string sibling of decodeRecord for tests.
+func decodePayload(payload string, out any) error {
+	return json.Unmarshal([]byte(payload), out)
 }

--- a/mcp/internal/identity/identity.go
+++ b/mcp/internal/identity/identity.go
@@ -1,0 +1,72 @@
+// Package identity resolves the stable agent id every working-context
+// tool call is attributed to (#851).
+//
+// Resolution order:
+//
+//  1. LANTERN_MCP_AGENT_ID — the operator-owned identity. Fleet operators
+//     own uniqueness: two sessions sharing an id last-writer-win on the
+//     agents.<id> presence vertex (accepted and documented, not defended).
+//  2. Auto-generated stable fallback "<hostname>-<pid>-<rand4>", computed
+//     once per process so every tool call in a session attributes to the
+//     same agent.
+//
+// There is deliberately no per-call id parameter in v1 — a spoofable
+// request-level identity would be weaker than the env-level one, and a
+// fleet shares one trust domain anyway (transport auth is #850).
+package identity
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+)
+
+var (
+	once     sync.Once
+	resolved string
+)
+
+// Resolve returns the agent id for this process. The first call decides;
+// later calls return the same value even if the environment changed, so a
+// session can never change identity mid-flight.
+func Resolve() string {
+	once.Do(func() { resolved = resolve(os.Getenv("LANTERN_MCP_AGENT_ID")) })
+	return resolved
+}
+
+// resolve is the pure core, separated for tests (the package-level
+// Resolve memoises; tests call resolve directly with crafted inputs).
+func resolve(env string) string {
+	if id := sanitize(env); id != "" {
+		return id
+	}
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		host = "agent"
+	}
+	var buf [2]byte
+	_, _ = rand.Read(buf[:]) // rand.Read never fails on supported platforms
+	return fmt.Sprintf("%s-%d-%s", sanitize(host), os.Getpid(), hex.EncodeToString(buf[:]))
+}
+
+// sanitize makes an identity fragment safe for use inside a dotted
+// Lantern key: whitespace and dots collapse to '-' (dots would create
+// phantom key segments under the agents. prefix), and surrounding
+// junk is trimmed. Empty in, empty out.
+func sanitize(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r == '.' || r == ' ' || r == '\t' || r == '\n':
+			return '-'
+		default:
+			return r
+		}
+	}, s)
+}

--- a/mcp/internal/identity/identity_test.go
+++ b/mcp/internal/identity/identity_test.go
@@ -1,0 +1,44 @@
+package identity
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolve(t *testing.T) {
+	t.Run("env id wins", func(t *testing.T) {
+		if got := resolve("fleet-worker-7"); got != "fleet-worker-7" {
+			t.Fatalf("resolve(env) = %q, want fleet-worker-7", got)
+		}
+	})
+
+	t.Run("dots and whitespace sanitised out of env id", func(t *testing.T) {
+		got := resolve("team a.builder 1")
+		if strings.ContainsAny(got, ". \t\n") {
+			t.Fatalf("sanitised id still carries separators: %q", got)
+		}
+		if got != "team-a-builder-1" {
+			t.Fatalf("resolve = %q, want team-a-builder-1", got)
+		}
+	})
+
+	t.Run("fallback is host-pid-rand shaped and stable per call set", func(t *testing.T) {
+		a := resolve("")
+		if a == "" || strings.Contains(a, ".") {
+			t.Fatalf("fallback id malformed: %q", a)
+		}
+		// Distinct resolve("") calls differ in the random suffix — the
+		// process-level stability contract lives in Resolve's sync.Once,
+		// which memoises the FIRST resolution.
+		if parts := strings.Split(a, "-"); len(parts) < 3 {
+			t.Fatalf("fallback %q missing host-pid-rand shape", a)
+		}
+	})
+
+	t.Run("Resolve memoises", func(t *testing.T) {
+		first := Resolve()
+		if second := Resolve(); second != first {
+			t.Fatalf("Resolve changed identity mid-process: %q vs %q", first, second)
+		}
+	})
+}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -63,6 +63,14 @@ type Config struct {
 	// remember_* tools. If nil, Run loads it from environment via
 	// ttl.LoadFromEnv() on startup.
 	Resolver *ttl.Resolver
+	// Profile selects the registered tool surface (#851):
+	// "context" (default) — the multi-agent shared working context
+	// (announce / track / claim / whats_happening / ...);
+	// "memory" — the legacy decaying-memory verbs (remember_* / recall_*),
+	// kept for one mcp/vX release before retirement.
+	// Both profiles share one keyspace on the server; switching does NOT
+	// migrate or clean the other profile's data — TTL decay handles it.
+	Profile string
 }
 
 // DefaultConfig reads the standard env vars and returns a Config suitable
@@ -91,11 +99,19 @@ func DefaultConfig() (Config, error) {
 	if httpAddr == "" {
 		httpAddr = defaultHTTPAddr
 	}
+	profile := os.Getenv("LANTERN_MCP_PROFILE")
+	if profile == "" {
+		profile = ProfileContext
+	}
+	if profile != ProfileContext && profile != ProfileMemory {
+		return Config{}, fmt.Errorf("LANTERN_MCP_PROFILE=%q: must be %q or %q", profile, ProfileContext, ProfileMemory)
+	}
 	return Config{
 		LanternAddr: addr,
 		PingTimeout: timeout,
 		HTTPAddr:    httpAddr,
 		Logger:      slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		Profile:     profile,
 	}, nil
 }
 
@@ -164,7 +180,11 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 	logger.Info("mcp: lantern reachable, registering tools")
 
-	srv := newServer(lantern, resolver, logger)
+	profile := cfg.Profile
+	if profile == "" {
+		profile = ProfileContext
+	}
+	srv := newServer(lantern, resolver, logger, profile)
 	httpSrv := &http.Server{
 		Addr:              httpAddr,
 		Handler:           mcpHTTPHandler(srv, logger),
@@ -241,21 +261,41 @@ func NewServer(lantern *client.Lantern, logger *slog.Logger) (*mcp.Server, error
 	if err != nil {
 		return nil, fmt.Errorf("mcp: load ttl config: %w", err)
 	}
-	return newServer(lantern, resolver, logger), nil
+	profile := os.Getenv("LANTERN_MCP_PROFILE")
+	if profile == "" {
+		profile = ProfileContext
+	}
+	return newServer(lantern, resolver, logger, profile), nil
 }
 
-// newServer constructs the MCP server and registers the full tool set
-// (ping + the six fact/relation tools). Tests pass a fake lanternClient
-// and an in-memory resolver to exercise handlers without dialing the
-// Lantern server.
-func newServer(lc lanternClient, resolver *ttl.Resolver, logger *slog.Logger) *mcp.Server {
+// Profile names for Config.Profile / LANTERN_MCP_PROFILE (#851).
+const (
+	// ProfileContext is the default: the multi-agent shared working
+	// context (presence / claims / activity / blackboard).
+	ProfileContext = "context"
+	// ProfileMemory is the legacy decaying-memory surface, available for
+	// one mcp/vX release for existing deployments, then retired.
+	ProfileMemory = "memory"
+)
+
+// newServer constructs the MCP server and registers the tool set the
+// selected profile advertises (#851). Tests pass a fake lanternClient and
+// an in-memory resolver to exercise handlers without dialing the Lantern
+// server.
+func newServer(lc lanternClient, resolver *ttl.Resolver, logger *slog.Logger, profile string) *mcp.Server {
+	title := "Lantern shared working-context MCP server"
+	instructions := contextInstructions
+	if profile == ProfileMemory {
+		title = "Lantern decaying-memory MCP server"
+		instructions = serverInstructions
+	}
 	srv := mcp.NewServer(&mcp.Implementation{
 		Name:    "lantern-mcp",
-		Title:   "Lantern decaying-memory MCP server",
+		Title:   title,
 		Version: Version,
 	}, &mcp.ServerOptions{
 		Logger:       logger,
-		Instructions: serverInstructions,
+		Instructions: instructions,
 	})
 
 	// The ping tool exists so operators can sanity-check the wire to
@@ -273,23 +313,46 @@ func newServer(lc lanternClient, resolver *ttl.Resolver, logger *slog.Logger) *m
 		}, nil, nil
 	})
 
-	registerRememberFact(srv, lc, resolver)
-	registerRememberFacts(srv, lc, resolver)
-	registerRecallFact(srv, lc)
-	registerSearchFacts(srv, lc)
-	registerTouch(srv, lc, resolver)
-	registerForget(srv, lc)
-	registerForgetUnder(srv, lc)
-	registerListUnder(srv, lc)
-	registerListNamespaces(srv, lc)
-	registerMemoryStats(srv, lc, resolver)
-	registerRememberRelation(srv, lc, resolver)
-	registerRememberRelations(srv, lc, resolver)
-	registerRecallRelated(srv, lc, resolver)
-	registerRecallRelation(srv, lc)
+	if profile == ProfileMemory {
+		registerRememberFact(srv, lc, resolver)
+		registerRememberFacts(srv, lc, resolver)
+		registerRecallFact(srv, lc)
+		registerSearchFacts(srv, lc)
+		registerTouch(srv, lc, resolver)
+		registerForget(srv, lc)
+		registerForgetUnder(srv, lc)
+		registerListUnder(srv, lc)
+		registerListNamespaces(srv, lc)
+		registerMemoryStats(srv, lc, resolver)
+		registerRememberRelation(srv, lc, resolver)
+		registerRememberRelations(srv, lc, resolver)
+		registerRecallRelated(srv, lc, resolver)
+		registerRecallRelation(srv, lc)
+		return srv
+	}
+
+	// Context profile (#851): the multi-agent shared working context.
+	registerAnnounce(srv, lc, resolver)
+	registerListAgents(srv, lc)
+	registerTrack(srv, lc, resolver)
+	registerWhatsHappening(srv, lc)
+	registerClaim(srv, lc, resolver)
+	registerRelease(srv, lc)
+	registerListClaims(srv, lc)
+	registerPostNote(srv, lc, resolver)
+	registerContextStats(srv, lc)
 
 	return srv
 }
+
+// contextInstructions is the session-open guidance for the working-context
+// profile (#851). Same care as serverInstructions: this text shapes LLM
+// behaviour — treat changes like prompt updates and call them out in
+// release notes.
+const contextInstructions = "Lantern is the fleet's shared working context — a live board of who is doing what RIGHT NOW, built on decaying state: presence, claims, notes, and activity all expire on their own, so everything you read is current by construction. It is NOT long-term memory; never store durable knowledge here. " +
+	"Run this loop: (1) ON SESSION START: announce yourself (your task line), then context_stats or whats_happening on the resources you are about to touch to see who else is around. (2) WHILE WORKING: track the resources you touch as you touch them (repetition strengthens the signal); re-announce when your task changes and periodically as a heartbeat (~every minute — presence lives ~2m); claim a resource before making changes siblings could collide with, re-claim to renew (~10m lease), release when done; a claim conflict is a structured {granted:false, holder} result — coordinate, wait for expiry, or force only after coordinating. (3) SIGNAL: post_note for anything the whole fleet should know (build broken, API flaky, migration in progress), linked to the resource keys it concerns, with the SHORTEST plausible TTL bucket. (4) BEFORE TOUCHING anything contested: whats_happening on the key — who is on it, live claims, live notes; an empty context means the coast is clear. " +
+	"Key conventions: resources are dotted keys shared by convention across the fleet (repo.<name>.<path>, ticket.<id>, dataset.<name>) — use the SAME keys your siblings use or the coordination protects nothing. agents.*, claims.*, and notes.* are reserved for the tools. " +
+	"Everything here is expendable by design: a crashed agent's presence and claims evaporate on their own; silence is self-cleaning. If you need durable memory, use a different store."
 
 // serverInstructions is the system-prompt-style guidance the MCP server
 // advertises to the LLM at session-open. The wording is deliberate and

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -80,7 +80,7 @@ func newHandlerTestServer(t *testing.T) string {
 	t.Helper()
 	fake := &fakeLantern{}
 	r := mustDefaultResolver(t)
-	srv := newServer(fake, r, slog.New(slog.NewJSONHandler(io.Discard, nil)))
+	srv := newServer(fake, r, slog.New(slog.NewJSONHandler(io.Discard, nil)), ProfileMemory)
 	ts := httptest.NewServer(mcpHTTPHandler(srv, nil))
 	t.Cleanup(ts.Close)
 	return ts.URL
@@ -169,5 +169,65 @@ func TestServerInstructions_DefinesCaptureRecallLoop(t *testing.T) {
 		if !strings.Contains(serverInstructions, tool) {
 			t.Errorf("serverInstructions does not mention tool %q", tool)
 		}
+	}
+}
+
+// TestProfileToolMatrix pins the #851 cutover contract: each profile
+// registers exactly its own tool surface (plus the shared ping), so a
+// deployment can never see a mixed or missing verb set.
+func TestProfileToolMatrix(t *testing.T) {
+	contextTools := []string{
+		"ping", "announce", "list_agents", "track", "whats_happening",
+		"claim", "release", "list_claims", "post_note", "context_stats",
+	}
+	memoryTools := []string{
+		"ping", "remember_fact", "remember_facts", "recall_fact", "search_facts",
+		"touch", "forget", "forget_under", "list_under", "list_namespaces",
+		"memory_stats", "remember_relation", "remember_relations",
+		"recall_related", "recall_relation",
+	}
+	for _, tc := range []struct {
+		profile string
+		want    []string
+	}{
+		{ProfileContext, contextTools},
+		{ProfileMemory, memoryTools},
+	} {
+		t.Run(tc.profile, func(t *testing.T) {
+			fake := &fakeLantern{}
+			r := mustDefaultResolver(t)
+			srv := newServer(fake, r, slog.New(slog.NewJSONHandler(io.Discard, nil)), tc.profile)
+
+			serverT, clientT := mcp.NewInMemoryTransports()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ss, err := srv.Connect(ctx, serverT, nil)
+			if err != nil {
+				t.Fatalf("server connect: %v", err)
+			}
+			defer func() { _ = ss.Close() }()
+			cs, err := mcp.NewClient(&mcp.Implementation{Name: "matrix-test"}, nil).Connect(ctx, clientT, nil)
+			if err != nil {
+				t.Fatalf("client connect: %v", err)
+			}
+			defer func() { _ = cs.Close() }()
+
+			listed, err := cs.ListTools(ctx, &mcp.ListToolsParams{})
+			if err != nil {
+				t.Fatalf("ListTools: %v", err)
+			}
+			got := map[string]bool{}
+			for _, tool := range listed.Tools {
+				got[tool.Name] = true
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("profile %s registered %d tools, want %d: %v", tc.profile, len(got), len(tc.want), got)
+			}
+			for _, name := range tc.want {
+				if !got[name] {
+					t.Fatalf("profile %s missing tool %q (got %v)", tc.profile, name, got)
+				}
+			}
+		})
 	}
 }

--- a/mcp/tool_announce.go
+++ b/mcp/tool_announce.go
@@ -1,0 +1,83 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/anaregdesign/lantern/mcp/internal/identity"
+	"github.com/anaregdesign/lantern/mcp/internal/ttl"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// announceInput carries the presence heartbeat payload. The agent id is
+// deliberately NOT an input: it is resolved server-side from
+// LANTERN_MCP_AGENT_ID (or the stable per-process fallback) so a tool
+// call cannot impersonate another agent.
+type announceInput struct {
+	Task   string `json:"task" jsonschema:"One line describing what you are working on right now (e.g. 'refactoring auth middleware in repo.api'). Re-announce whenever the task changes AND periodically as a heartbeat - presence expires on its own if you go silent."`
+	Detail string `json:"detail,omitempty" jsonschema:"Optional second line of detail (branch, ticket, ETA). Keep it short; this is a status board, not a journal."`
+}
+
+type announceOutput struct {
+	AgentID   string `json:"agent_id"`
+	Task      string `json:"task"`
+	ExpiresAt string `json:"expires_at"`
+	// Renewed is true when a live presence vertex already existed for this
+	// agent (heartbeat refresh), false on first announce after an absence.
+	Renewed bool `json:"renewed"`
+}
+
+const announceDescription = "Announce your presence to the shared working context: \"I am here, working on T\". Call this at session start, whenever your task changes, and periodically as a heartbeat — presence lives ~2 minutes (the transient TTL bucket) and re-announcing refreshes it, so an agent that goes silent simply disappears from list_agents. The output tells you your agent_id; other agents see your task line via list_agents and whats_happening. Do NOT use this for durable knowledge — the working context is expendable by design."
+
+func registerAnnounce(srv *mcp.Server, lc lanternClient, r *ttl.Resolver) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "announce",
+		Description: announceDescription,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in announceInput) (*mcp.CallToolResult, announceOutput, error) {
+		if in.Task == "" {
+			return nil, announceOutput{}, fmt.Errorf("announce: task must not be empty")
+		}
+		id := identity.Resolve()
+		key := agentKey(id)
+
+		// Preserve the original since when this is a heartbeat refresh of
+		// the same task line, so "since" answers "how long has this agent
+		// been on this?" rather than "when did it last heartbeat?".
+		now := time.Now().UTC()
+		rec := presenceRecord{Task: in.Task, Detail: in.Detail, Since: now.Format(time.RFC3339)}
+		renewed := false
+		if prev, err := lc.GetVertex(ctx, key); err == nil {
+			renewed = true
+			var old presenceRecord
+			if decodeRecord(prev, &old) && old.Task == in.Task && old.Since != "" {
+				rec.Since = old.Since
+			}
+		}
+
+		payload, err := encodeRecord(rec)
+		if err != nil {
+			return nil, announceOutput{}, fmt.Errorf("announce: %w", err)
+		}
+		d, _ := r.ResolveCapped(ttl.Transient)
+		if err := lc.PutVertex(ctx, key, payload, d); err != nil {
+			return nil, announceOutput{}, mapSDKError("announce", err)
+		}
+
+		out := announceOutput{
+			AgentID:   id,
+			Task:      in.Task,
+			ExpiresAt: now.Add(d).Format(time.RFC3339),
+			Renewed:   renewed,
+		}
+		verb := "Announced"
+		if renewed {
+			verb = "Refreshed"
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf(
+				"%s presence as %s: %q (expires≈%s; re-announce to stay visible).",
+				verb, id, in.Task, out.ExpiresAt)}},
+		}, out, nil
+	})
+}

--- a/mcp/tool_announce_test.go
+++ b/mcp/tool_announce_test.go
@@ -1,0 +1,104 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/anaregdesign/lantern/mcp/internal/identity"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// presenceVertex builds a stored agents.<id> vertex carrying rec.
+func presenceVertex(t *testing.T, key string, rec presenceRecord) *client.Vertex {
+	t.Helper()
+	payload, err := encodeRecord(rec)
+	if err != nil {
+		t.Fatalf("encodeRecord: %v", err)
+	}
+	return &pb.Vertex{
+		Key:        key,
+		Value:      &pb.Vertex_String_{String_: payload},
+		Expiration: timestamppb.New(time.Now().Add(time.Minute)),
+	}
+}
+
+func TestAnnounce(t *testing.T) {
+	self := agentKey(identity.Resolve())
+
+	t.Run("first announce writes presence under agents.<id>", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.getVertexFn = func(_ context.Context, _ string) (*client.Vertex, error) {
+			return nil, client.ErrNotFound
+		}
+		res := h.call(t, "announce", map[string]any{"task": "reviewing PR 866"})
+		var out announceOutput
+		structuredAs(t, res, &out)
+		if out.AgentID == "" || out.Renewed {
+			t.Fatalf("first announce: %+v (want fresh, non-renewed, id set)", out)
+		}
+		if h.fake.lastPutKey != self {
+			t.Fatalf("presence written to %q, want %q", h.fake.lastPutKey, self)
+		}
+		var rec presenceRecord
+		payload, _ := h.fake.lastPutValue.(string)
+		if err := decodePayload(payload, &rec); err != nil || rec.Task != "reviewing PR 866" {
+			t.Fatalf("stored payload %q did not round-trip: %+v err=%v", payload, rec, err)
+		}
+	})
+
+	t.Run("re-announce is a heartbeat that preserves since for the same task", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.getVertexFn = func(_ context.Context, key string) (*client.Vertex, error) {
+			return presenceVertex(t, key, presenceRecord{Task: "reviewing PR 866", Since: "2026-07-02T00:00:00Z"}), nil
+		}
+		res := h.call(t, "announce", map[string]any{"task": "reviewing PR 866"})
+		var out announceOutput
+		structuredAs(t, res, &out)
+		if !out.Renewed {
+			t.Fatal("heartbeat refresh not flagged as renewed")
+		}
+		var rec presenceRecord
+		payload, _ := h.fake.lastPutValue.(string)
+		if err := decodePayload(payload, &rec); err != nil || rec.Since != "2026-07-02T00:00:00Z" {
+			t.Fatalf("since not preserved across heartbeat: %+v err=%v", rec, err)
+		}
+	})
+
+	t.Run("task change resets since", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.getVertexFn = func(_ context.Context, key string) (*client.Vertex, error) {
+			return presenceVertex(t, key, presenceRecord{Task: "old task", Since: "2026-07-02T00:00:00Z"}), nil
+		}
+		h.call(t, "announce", map[string]any{"task": "new task"})
+		var rec presenceRecord
+		payload, _ := h.fake.lastPutValue.(string)
+		if err := decodePayload(payload, &rec); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if rec.Since == "2026-07-02T00:00:00Z" {
+			t.Fatal("since must reset when the task line changes")
+		}
+	})
+
+	t.Run("empty task rejected", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.callExpectError(t, "announce", map[string]any{"task": ""})
+	})
+
+	t.Run("output surfaces the agent id", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.getVertexFn = func(_ context.Context, _ string) (*client.Vertex, error) {
+			return nil, client.ErrNotFound
+		}
+		res := h.call(t, "announce", map[string]any{"task": "t"})
+		var out announceOutput
+		structuredAs(t, res, &out)
+		if !strings.HasSuffix(self, out.AgentID) {
+			t.Fatalf("output agent id %q does not match resolved identity key %q", out.AgentID, self)
+		}
+	})
+}

--- a/mcp/tool_claim.go
+++ b/mcp/tool_claim.go
@@ -1,0 +1,124 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/anaregdesign/lantern/mcp/internal/identity"
+	"github.com/anaregdesign/lantern/mcp/internal/ttl"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type claimInput struct {
+	Resource string `json:"resource" jsonschema:"Dotted resource key to lease (e.g. repo.lantern.core.graphcache). Use the same key everyone tracks with, or the claim protects nothing."`
+	Note     string `json:"note,omitempty" jsonschema:"Optional one-liner shown to whoever hits the conflict (what you're doing, expected duration)."`
+	Force    bool   `json:"force,omitempty" jsonschema:"Steal the lease even if another live holder exists. Use only after coordinating (or when the holder is provably gone); the previous holder is reported in the output."`
+}
+
+type claimOutput struct {
+	Granted  bool   `json:"granted"`
+	Resource string `json:"resource"`
+	AgentID  string `json:"agent_id"`
+	// Renewed is true when the caller already held the lease (re-claim =
+	// renewal, the intended heartbeat for long work).
+	Renewed bool `json:"renewed,omitempty"`
+	// Stolen is true when force displaced a live foreign holder.
+	Stolen bool `json:"stolen,omitempty"`
+	// Holder/HolderNote/ExpiresAt describe the CURRENT lease after the
+	// call: on grant they echo the caller, on conflict the blocking agent.
+	Holder     string `json:"holder,omitempty"`
+	HolderNote string `json:"holder_note,omitempty"`
+	ExpiresAt  string `json:"expires_at,omitempty"`
+}
+
+const claimDescription = "Take an ADVISORY lease on a resource so sibling agents don't collide with you. A live claim by another agent returns {granted:false, holder, expires_at} — a structured result, NOT an error; coordinate or pass force:true to steal after coordinating. Re-claim the same resource to renew (leases live ~10 minutes, the turn bucket, and expire on their own — a crashed agent's claim simply evaporates). Release when done. Advisory means exactly that: nothing on the server ENFORCES the lease (the check-then-write window is documented and accepted — agents are slow writers, contention is rare); honour claims you see."
+
+func registerClaim(srv *mcp.Server, lc lanternClient, r *ttl.Resolver) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "claim",
+		Description: claimDescription,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in claimInput) (*mcp.CallToolResult, claimOutput, error) {
+		if in.Resource == "" {
+			return nil, claimOutput{}, fmt.Errorf("claim: resource must not be empty")
+		}
+		id := identity.Resolve()
+		key := claimKey(in.Resource)
+
+		// Advisory read-check-write. A live foreign holder blocks unless
+		// force; an expired claim is already gone (GetVertex → NotFound).
+		var prev claimRecord
+		havePrev := false
+		var prevExpires time.Time
+		if v, err := lc.GetVertex(ctx, key); err == nil {
+			if decodeRecord(v, &prev) {
+				havePrev = true
+				prevExpires = client.VertexExpiration(v)
+			}
+		} else if !errors.Is(err, client.ErrNotFound) {
+			return nil, claimOutput{}, mapSDKError("claim", err)
+		}
+
+		if havePrev && prev.Holder != id && !in.Force {
+			out := claimOutput{
+				Granted:    false,
+				Resource:   in.Resource,
+				AgentID:    id,
+				Holder:     prev.Holder,
+				HolderNote: prev.Note,
+			}
+			if !prevExpires.IsZero() {
+				out.ExpiresAt = prevExpires.UTC().Format(time.RFC3339)
+			}
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf(
+					"Resource %q is claimed by %s (expires≈%s)%s. Coordinate with the holder, wait for expiry, or re-call with force:true.",
+					in.Resource, out.Holder, out.ExpiresAt, noteSuffix(prev.Note))}},
+			}, out, nil
+		}
+
+		now := time.Now().UTC()
+		payload, err := encodeRecord(claimRecord{Holder: id, Note: in.Note, At: now.Format(time.RFC3339)})
+		if err != nil {
+			return nil, claimOutput{}, fmt.Errorf("claim: %w", err)
+		}
+		d, _ := r.ResolveCapped(ttl.Turn)
+		if err := lc.PutVertex(ctx, key, payload, d); err != nil {
+			return nil, claimOutput{}, mapSDKError("claim", err)
+		}
+		// The activity edge makes the lease visible in whats_happening's
+		// neighborhood, not just under the claims. prefix.
+		_ = lc.AddEdge(ctx, agentKey(id), in.Resource, 1, d)
+
+		out := claimOutput{
+			Granted:   true,
+			Resource:  in.Resource,
+			AgentID:   id,
+			Renewed:   havePrev && prev.Holder == id,
+			Stolen:    havePrev && prev.Holder != id,
+			Holder:    id,
+			ExpiresAt: now.Add(d).Format(time.RFC3339),
+		}
+		verb := "Claimed"
+		switch {
+		case out.Renewed:
+			verb = "Renewed claim on"
+		case out.Stolen:
+			verb = fmt.Sprintf("STOLE claim (from %s) on", prev.Holder)
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf(
+				"%s %q as %s (expires≈%s; re-claim to renew, release when done).",
+				verb, in.Resource, id, out.ExpiresAt)}},
+		}, out, nil
+	})
+}
+
+func noteSuffix(note string) string {
+	if note == "" {
+		return ""
+	}
+	return fmt.Sprintf(" — holder says: %q", note)
+}

--- a/mcp/tool_claim_test.go
+++ b/mcp/tool_claim_test.go
@@ -1,0 +1,96 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/anaregdesign/lantern/mcp/internal/identity"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// claimVertex builds a stored claims.<resource> vertex carrying rec.
+func claimVertex(t *testing.T, key string, rec claimRecord) *client.Vertex {
+	t.Helper()
+	payload, err := encodeRecord(rec)
+	if err != nil {
+		t.Fatalf("encodeRecord: %v", err)
+	}
+	return &pb.Vertex{
+		Key:        key,
+		Value:      &pb.Vertex_String_{String_: payload},
+		Expiration: timestamppb.New(time.Now().Add(10 * time.Minute)),
+	}
+}
+
+func TestClaim(t *testing.T) {
+	self := identity.Resolve()
+
+	t.Run("grant on unclaimed resource", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.getVertexFn = func(_ context.Context, _ string) (*client.Vertex, error) {
+			return nil, client.ErrNotFound
+		}
+		res := h.call(t, "claim", map[string]any{"resource": "repo.lantern.core", "note": "refactor"})
+		var out claimOutput
+		structuredAs(t, res, &out)
+		if !out.Granted || out.Renewed || out.Stolen || out.Holder != self {
+			t.Fatalf("grant: %+v", out)
+		}
+		if h.fake.lastPutKey != claimKey("repo.lantern.core") {
+			t.Fatalf("claim written to %q", h.fake.lastPutKey)
+		}
+	})
+
+	t.Run("conflict with live foreign holder is a structured result", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.getVertexFn = func(_ context.Context, key string) (*client.Vertex, error) {
+			return claimVertex(t, key, claimRecord{Holder: "other-agent", Note: "migrating"}), nil
+		}
+		res := h.call(t, "claim", map[string]any{"resource": "repo.lantern.core"})
+		var out claimOutput
+		structuredAs(t, res, &out)
+		if out.Granted {
+			t.Fatal("conflict must not grant")
+		}
+		if out.Holder != "other-agent" || out.HolderNote != "migrating" || out.ExpiresAt == "" {
+			t.Fatalf("conflict must report holder/note/expiry: %+v", out)
+		}
+		if h.fake.putVertexCalls != 0 {
+			t.Fatal("conflict must not write")
+		}
+	})
+
+	t.Run("force steals a live foreign lease", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.getVertexFn = func(_ context.Context, key string) (*client.Vertex, error) {
+			return claimVertex(t, key, claimRecord{Holder: "other-agent"}), nil
+		}
+		res := h.call(t, "claim", map[string]any{"resource": "repo.lantern.core", "force": true})
+		var out claimOutput
+		structuredAs(t, res, &out)
+		if !out.Granted || !out.Stolen || out.Holder != self {
+			t.Fatalf("steal: %+v", out)
+		}
+	})
+
+	t.Run("re-claim by the holder renews", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.getVertexFn = func(_ context.Context, key string) (*client.Vertex, error) {
+			return claimVertex(t, key, claimRecord{Holder: self}), nil
+		}
+		res := h.call(t, "claim", map[string]any{"resource": "repo.lantern.core"})
+		var out claimOutput
+		structuredAs(t, res, &out)
+		if !out.Granted || !out.Renewed || out.Stolen {
+			t.Fatalf("renew: %+v", out)
+		}
+	})
+
+	t.Run("empty resource rejected", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.callExpectError(t, "claim", map[string]any{"resource": ""})
+	})
+}

--- a/mcp/tool_context_stats.go
+++ b/mcp/tool_context_stats.go
@@ -1,0 +1,62 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type contextStatsInput struct {
+	// No parameters: the stats are a fleet-wide glance.
+}
+
+type contextStatsOutput struct {
+	Agents    int `json:"agents"`
+	Claims    int `json:"claims"`
+	Notes     int `json:"notes"`
+	Resources int `json:"resources"`
+}
+
+const contextStatsDescription = "Fleet activity overview in four numbers: live agents, live claims, live notes, and tracked resources. Everything counted is currently alive (TTL already pruned the rest), so a shrinking count means the fleet is going quiet, not that data was lost. Cheap — safe to call at session start to decide whether the working context is worth reading in detail."
+
+func registerContextStats(srv *mcp.Server, lc lanternClient) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "context_stats",
+		Description: contextStatsDescription,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ contextStatsInput) (*mcp.CallToolResult, contextStatsOutput, error) {
+		var out contextStatsOutput
+		total := 0
+		for _, probe := range []struct {
+			prefix string
+			dst    *int
+		}{
+			{agentKeyPrefix, &out.Agents},
+			{claimKeyPrefix, &out.Claims},
+			{noteKeyPrefix, &out.Notes},
+			{"", &total},
+		} {
+			n, err := lc.CountVerticesByPrefix(ctx, probe.prefix)
+			if err != nil {
+				return nil, contextStatsOutput{}, mapSDKError("context_stats", err)
+			}
+			*probe.dst = int(n)
+		}
+		// Resources = everything that is not one of the reserved prefixes.
+		// Approximate by subtraction; foreign keys sharing the server (e.g.
+		// legacy memory-profile data) count as resources, which is honest:
+		// they ARE part of the shared keyspace.
+		out.Resources = max(total-out.Agents-out.Claims-out.Notes, 0)
+
+		var b strings.Builder
+		fmt.Fprintf(&b, "Working context: %d agent(s), %d claim(s), %d note(s), %d tracked resource(s).",
+			out.Agents, out.Claims, out.Notes, out.Resources)
+		if out.Agents == 0 && out.Claims == 0 && out.Notes == 0 {
+			b.WriteString(" The fleet is quiet — announce yourself to start the board.")
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: b.String()}},
+		}, out, nil
+	})
+}

--- a/mcp/tool_context_stats_test.go
+++ b/mcp/tool_context_stats_test.go
@@ -1,0 +1,48 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+)
+
+func TestContextStats(t *testing.T) {
+	t.Run("counts per reserved prefix and derives resources by subtraction", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.countByPrefixFn = func(_ context.Context, prefix string) (uint64, error) {
+			switch prefix {
+			case agentKeyPrefix:
+				return 3, nil
+			case claimKeyPrefix:
+				return 2, nil
+			case noteKeyPrefix:
+				return 1, nil
+			case "":
+				return 10, nil
+			}
+			t.Fatalf("unexpected count prefix %q", prefix)
+			return 0, nil
+		}
+		res := h.call(t, "context_stats", map[string]any{})
+		var out contextStatsOutput
+		structuredAs(t, res, &out)
+		if out.Agents != 3 || out.Claims != 2 || out.Notes != 1 || out.Resources != 4 {
+			t.Fatalf("stats: %+v", out)
+		}
+	})
+
+	t.Run("resources never go negative", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.countByPrefixFn = func(_ context.Context, prefix string) (uint64, error) {
+			if prefix == "" {
+				return 1, nil
+			}
+			return 5, nil
+		}
+		res := h.call(t, "context_stats", map[string]any{})
+		var out contextStatsOutput
+		structuredAs(t, res, &out)
+		if out.Resources != 0 {
+			t.Fatalf("resources = %d, want clamped 0", out.Resources)
+		}
+	})
+}

--- a/mcp/tool_list_agents.go
+++ b/mcp/tool_list_agents.go
@@ -1,0 +1,76 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type listAgentsInput struct {
+	// No parameters: the fleet is the scope. Expired presences are already
+	// gone (TTL), so the scan is self-cleaning.
+}
+
+type activeAgent struct {
+	AgentID   string `json:"agent_id"`
+	Task      string `json:"task,omitempty"`
+	Detail    string `json:"detail,omitempty"`
+	Since     string `json:"since,omitempty"`
+	ExpiresAt string `json:"expires_at,omitempty"`
+}
+
+type listAgentsOutput struct {
+	Agents []activeAgent `json:"agents"`
+	Count  int           `json:"count"`
+}
+
+const listAgentsDescription = "List every agent currently active in the shared working context — who is here and what each one says it is working on. Presence expires on its own (~2 minutes without an announce), so this list is always live: no tombstones, no stale entries. Call it before picking up work to avoid colliding with a sibling, or when whats_happening shows an agent id you don't recognise."
+
+func registerListAgents(srv *mcp.Server, lc lanternClient) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "list_agents",
+		Description: listAgentsDescription,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ listAgentsInput) (*mcp.CallToolResult, listAgentsOutput, error) {
+		vs, _, err := lc.ScanVertices(ctx, agentKeyPrefix, client.WithScanLimit(500))
+		if err != nil {
+			return nil, listAgentsOutput{}, mapSDKError("list_agents", err)
+		}
+		out := listAgentsOutput{Agents: make([]activeAgent, 0, len(vs))}
+		for _, v := range vs {
+			a := activeAgent{AgentID: strings.TrimPrefix(v.GetKey(), agentKeyPrefix)}
+			var rec presenceRecord
+			if decodeRecord(v, &rec) {
+				a.Task, a.Detail, a.Since = rec.Task, rec.Detail, rec.Since
+			}
+			if exp := client.VertexExpiration(v); !exp.IsZero() {
+				a.ExpiresAt = exp.UTC().Format(time.RFC3339)
+			}
+			out.Agents = append(out.Agents, a)
+		}
+		sort.Slice(out.Agents, func(i, j int) bool { return out.Agents[i].AgentID < out.Agents[j].AgentID })
+		out.Count = len(out.Agents)
+
+		if out.Count == 0 {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "No agents are currently announced. You may be the first — call announce to show up here."}},
+			}, out, nil
+		}
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d agent(s) active:\n", out.Count)
+		for _, a := range out.Agents {
+			fmt.Fprintf(&b, "- %s: %s", a.AgentID, a.Task)
+			if a.Detail != "" {
+				fmt.Fprintf(&b, " (%s)", a.Detail)
+			}
+			b.WriteString("\n")
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: strings.TrimRight(b.String(), "\n")}},
+		}, out, nil
+	})
+}

--- a/mcp/tool_list_agents_test.go
+++ b/mcp/tool_list_agents_test.go
@@ -1,0 +1,48 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+func TestListAgents(t *testing.T) {
+	t.Run("lists and decodes live presences sorted by id", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.scanVerticesFn = func(_ context.Context, prefix string, _ ...client.ScanOption) ([]*client.Vertex, []byte, error) {
+			if prefix != agentKeyPrefix {
+				t.Fatalf("scan prefix = %q, want %q", prefix, agentKeyPrefix)
+			}
+			return []*client.Vertex{
+				presenceVertex(t, "agents.zeta", presenceRecord{Task: "docs"}),
+				presenceVertex(t, "agents.alpha", presenceRecord{Task: "build", Detail: "branch main"}),
+			}, nil, nil
+		}
+		res := h.call(t, "list_agents", map[string]any{})
+		var out listAgentsOutput
+		structuredAs(t, res, &out)
+		if out.Count != 2 || out.Agents[0].AgentID != "alpha" || out.Agents[1].AgentID != "zeta" {
+			t.Fatalf("agents: %+v", out)
+		}
+		if out.Agents[0].Task != "build" || out.Agents[0].Detail != "branch main" {
+			t.Fatalf("decode: %+v", out.Agents[0])
+		}
+		if out.Agents[0].ExpiresAt == "" {
+			t.Fatal("expiry missing from listing")
+		}
+	})
+
+	t.Run("empty fleet is a friendly empty result", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.scanVerticesFn = func(_ context.Context, _ string, _ ...client.ScanOption) ([]*client.Vertex, []byte, error) {
+			return nil, nil, nil
+		}
+		res := h.call(t, "list_agents", map[string]any{})
+		var out listAgentsOutput
+		structuredAs(t, res, &out)
+		if out.Count != 0 || out.Agents == nil {
+			t.Fatalf("empty fleet: %+v", out)
+		}
+	})
+}

--- a/mcp/tool_list_claims.go
+++ b/mcp/tool_list_claims.go
@@ -1,0 +1,75 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type listClaimsInput struct {
+	Prefix string `json:"prefix,omitempty" jsonschema:"Optional resource-key prefix to scope the listing (e.g. 'repo.lantern.' lists leases under that subtree). Empty lists every live claim."`
+}
+
+type liveClaim struct {
+	Resource  string `json:"resource"`
+	Holder    string `json:"holder,omitempty"`
+	Note      string `json:"note,omitempty"`
+	At        string `json:"at,omitempty"`
+	ExpiresAt string `json:"expires_at,omitempty"`
+}
+
+type listClaimsOutput struct {
+	Claims []liveClaim `json:"claims"`
+	Count  int         `json:"count"`
+}
+
+const listClaimsDescription = "List live advisory leases, optionally scoped to a resource-key prefix. Expired claims are already gone (TTL), so everything returned is current. Call it before starting work in a namespace to see what siblings have staked out, or to find your own leases to release."
+
+func registerListClaims(srv *mcp.Server, lc lanternClient) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "list_claims",
+		Description: listClaimsDescription,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in listClaimsInput) (*mcp.CallToolResult, listClaimsOutput, error) {
+		vs, _, err := lc.ScanVertices(ctx, claimKeyPrefix+in.Prefix, client.WithScanLimit(500))
+		if err != nil {
+			return nil, listClaimsOutput{}, mapSDKError("list_claims", err)
+		}
+		out := listClaimsOutput{Claims: make([]liveClaim, 0, len(vs))}
+		for _, v := range vs {
+			c := liveClaim{Resource: strings.TrimPrefix(v.GetKey(), claimKeyPrefix)}
+			var rec claimRecord
+			if decodeRecord(v, &rec) {
+				c.Holder, c.Note, c.At = rec.Holder, rec.Note, rec.At
+			}
+			if exp := client.VertexExpiration(v); !exp.IsZero() {
+				c.ExpiresAt = exp.UTC().Format(time.RFC3339)
+			}
+			out.Claims = append(out.Claims, c)
+		}
+		sort.Slice(out.Claims, func(i, j int) bool { return out.Claims[i].Resource < out.Claims[j].Resource })
+		out.Count = len(out.Claims)
+
+		if out.Count == 0 {
+			scope := "anywhere"
+			if in.Prefix != "" {
+				scope = fmt.Sprintf("under %q", in.Prefix)
+			}
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("No live claims %s.", scope)}},
+			}, out, nil
+		}
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d live claim(s):\n", out.Count)
+		for _, c := range out.Claims {
+			fmt.Fprintf(&b, "- %s ← %s (expires≈%s)%s\n", c.Resource, c.Holder, c.ExpiresAt, noteSuffix(c.Note))
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: strings.TrimRight(b.String(), "\n")}},
+		}, out, nil
+	})
+}

--- a/mcp/tool_list_claims_test.go
+++ b/mcp/tool_list_claims_test.go
@@ -1,0 +1,44 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+func TestListClaims(t *testing.T) {
+	t.Run("prefix scopes the scan under claims.", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.scanVerticesFn = func(_ context.Context, prefix string, _ ...client.ScanOption) ([]*client.Vertex, []byte, error) {
+			if prefix != claimKeyPrefix+"repo.lantern." {
+				t.Fatalf("scan prefix = %q", prefix)
+			}
+			return []*client.Vertex{
+				claimVertex(t, "claims.repo.lantern.core", claimRecord{Holder: "a1", Note: "wip"}),
+			}, nil, nil
+		}
+		res := h.call(t, "list_claims", map[string]any{"prefix": "repo.lantern."})
+		var out listClaimsOutput
+		structuredAs(t, res, &out)
+		if out.Count != 1 || out.Claims[0].Resource != "repo.lantern.core" || out.Claims[0].Holder != "a1" {
+			t.Fatalf("claims: %+v", out)
+		}
+		if out.Claims[0].ExpiresAt == "" {
+			t.Fatal("expiry missing")
+		}
+	})
+
+	t.Run("no live claims", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.scanVerticesFn = func(_ context.Context, _ string, _ ...client.ScanOption) ([]*client.Vertex, []byte, error) {
+			return nil, nil, nil
+		}
+		res := h.call(t, "list_claims", map[string]any{})
+		var out listClaimsOutput
+		structuredAs(t, res, &out)
+		if out.Count != 0 {
+			t.Fatalf("want empty: %+v", out)
+		}
+	})
+}

--- a/mcp/tool_post_note.go
+++ b/mcp/tool_post_note.go
@@ -1,0 +1,105 @@
+package mcp
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/anaregdesign/lantern/mcp/internal/identity"
+	"github.com/anaregdesign/lantern/mcp/internal/ttl"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type postNoteInput struct {
+	Text     string   `json:"text" jsonschema:"The signal, one or two sentences (e.g. 'build broken on main since 14:02, suspect PR 866'). Write for a sibling agent that has zero context."`
+	Severity string   `json:"severity,omitempty" jsonschema:"Optional severity: info | warn | blocker. Default info."`
+	Links    []string `json:"links,omitempty" jsonschema:"Resource keys this note is about (e.g. ['repo.lantern.ci','branch.main']). Linking is what makes the note surface in whats_happening for those resources."`
+	TTL      string   `json:"ttl" jsonschema:"Required decay horizon (string) - when will this signal stop being true? Buckets (monotonic): seconds (~30s) | transient (~2m) | turn (~10m) | conversation (~1h) | task (~4h) | workday (~12h) | day (~24h) | week (~7d) | sprint (~14d) | month (~30d) | quarter (~90d) | durable (~180d). Pick the SHORTER plausible bucket; a stale warning is noise."`
+}
+
+type postNoteOutput struct {
+	NoteID    string   `json:"note_id"`
+	Author    string   `json:"author"`
+	Severity  string   `json:"severity"`
+	Links     []string `json:"links,omitempty"`
+	ExpiresAt string   `json:"expires_at"`
+}
+
+const postNoteDescription = "Post a blackboard note the whole fleet can see: environment state, hazards, coordination signals ('build broken on main', 'API X flaky, backoff in place', 'migrating table users — writes frozen'). Link it to the resource keys it concerns so whats_happening surfaces it to anyone working nearby. Notes decay on the TTL you choose and vanish on their own — post facts about NOW, not documentation. severity=blocker is the loudest signal; use it sparingly."
+
+func registerPostNote(srv *mcp.Server, lc lanternClient, r *ttl.Resolver) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "post_note",
+		Description: postNoteDescription,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in postNoteInput) (*mcp.CallToolResult, postNoteOutput, error) {
+		if strings.TrimSpace(in.Text) == "" {
+			return nil, postNoteOutput{}, fmt.Errorf("post_note: text must not be empty")
+		}
+		sev := in.Severity
+		switch sev {
+		case "":
+			sev = "info"
+		case "info", "warn", "blocker":
+		default:
+			return nil, postNoteOutput{}, fmt.Errorf("post_note: severity %q (want info|warn|blocker)", in.Severity)
+		}
+		bucket, err := ttl.ParseBucket(in.TTL)
+		if err != nil {
+			return nil, postNoteOutput{}, fmt.Errorf("post_note: %w", err)
+		}
+
+		author := identity.Resolve()
+		var rnd [4]byte
+		_, _ = rand.Read(rnd[:])
+		noteID := fmt.Sprintf("%s-%s", time.Now().UTC().Format("20060102T150405"), hex.EncodeToString(rnd[:]))
+		key := noteKeyPrefix + noteID
+
+		payload, err := encodeRecord(noteRecord{Text: in.Text, Author: author, Severity: sev, Links: in.Links})
+		if err != nil {
+			return nil, postNoteOutput{}, fmt.Errorf("post_note: %w", err)
+		}
+		d, _ := r.ResolveCapped(bucket)
+		if err := lc.PutVertex(ctx, key, payload, d); err != nil {
+			return nil, postNoteOutput{}, mapSDKError("post_note", err)
+		}
+
+		// Link note→resource so the note rides into whats_happening's
+		// neighborhood for each linked resource, and author→note so the
+		// note shows up around its author too.
+		edges := make([]client.EdgeInput, 0, len(in.Links)+1)
+		for _, res := range in.Links {
+			if strings.TrimSpace(res) == "" {
+				continue
+			}
+			edges = append(edges, client.EdgeInput{Tail: key, Head: res, Weight: 1, Expiration: expirationIn(d)})
+		}
+		edges = append(edges, client.EdgeInput{Tail: agentKey(author), Head: key, Weight: 1, Expiration: expirationIn(d)})
+		if err := lc.AddEdges(ctx, edges); err != nil {
+			return nil, postNoteOutput{}, mapSDKError("post_note", err)
+		}
+
+		out := postNoteOutput{
+			NoteID:    noteID,
+			Author:    author,
+			Severity:  sev,
+			Links:     in.Links,
+			ExpiresAt: time.Now().Add(d).UTC().Format(time.RFC3339),
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf(
+				"Posted %s note %s (expires≈%s)%s.",
+				sev, noteID, out.ExpiresAt, linkSuffix(in.Links))}},
+		}, out, nil
+	})
+}
+
+func linkSuffix(links []string) string {
+	if len(links) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(", linked to %s", strings.Join(links, ", "))
+}

--- a/mcp/tool_post_note_test.go
+++ b/mcp/tool_post_note_test.go
@@ -1,0 +1,69 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/anaregdesign/lantern/mcp/internal/identity"
+)
+
+func TestPostNote(t *testing.T) {
+	self := identity.Resolve()
+
+	t.Run("writes the note and links note→resources plus author→note", func(t *testing.T) {
+		h := newContextHarness(t)
+		res := h.call(t, "post_note", map[string]any{
+			"text":     "build broken on main",
+			"severity": "blocker",
+			"links":    []string{"repo.lantern.ci", "branch.main"},
+			"ttl":      "turn",
+		})
+		var out postNoteOutput
+		structuredAs(t, res, &out)
+		if out.NoteID == "" || out.Author != self || out.Severity != "blocker" {
+			t.Fatalf("note: %+v", out)
+		}
+		if !strings.HasPrefix(h.fake.lastPutKey, noteKeyPrefix) {
+			t.Fatalf("note stored at %q", h.fake.lastPutKey)
+		}
+		var rec noteRecord
+		payload, _ := h.fake.lastPutValue.(string)
+		if err := decodePayload(payload, &rec); err != nil || rec.Text != "build broken on main" || rec.Author != self {
+			t.Fatalf("payload: %+v err=%v", rec, err)
+		}
+		// 2 note→resource links + 1 author→note edge.
+		if len(h.fake.lastAddEdges) != 3 {
+			t.Fatalf("edges = %d, want 3: %+v", len(h.fake.lastAddEdges), h.fake.lastAddEdges)
+		}
+		noteKey := h.fake.lastPutKey
+		var linked, authored int
+		for _, e := range h.fake.lastAddEdges {
+			switch {
+			case e.Tail == noteKey:
+				linked++
+			case e.Tail == agentKey(self) && e.Head == noteKey:
+				authored++
+			}
+		}
+		if linked != 2 || authored != 1 {
+			t.Fatalf("edge shape: linked=%d authored=%d", linked, authored)
+		}
+	})
+
+	t.Run("severity defaults to info and rejects unknown values", func(t *testing.T) {
+		h := newContextHarness(t)
+		res := h.call(t, "post_note", map[string]any{"text": "x", "ttl": "turn"})
+		var out postNoteOutput
+		structuredAs(t, res, &out)
+		if out.Severity != "info" {
+			t.Fatalf("default severity: %+v", out)
+		}
+		h.callExpectError(t, "post_note", map[string]any{"text": "x", "ttl": "turn", "severity": "loud"})
+	})
+
+	t.Run("empty text and bad ttl rejected", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.callExpectError(t, "post_note", map[string]any{"text": " ", "ttl": "turn"})
+		h.callExpectError(t, "post_note", map[string]any{"text": "x", "ttl": "forever"})
+	})
+}

--- a/mcp/tool_release.go
+++ b/mcp/tool_release.go
@@ -1,0 +1,71 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/anaregdesign/lantern/mcp/internal/identity"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type releaseInput struct {
+	Resource string `json:"resource" jsonschema:"Resource key whose lease you hold and want to drop."`
+}
+
+type releaseOutput struct {
+	Released bool   `json:"released"`
+	Resource string `json:"resource"`
+	AgentID  string `json:"agent_id"`
+	// Holder is set when the release was refused because another agent
+	// holds the lease (structured result, not an error).
+	Holder string `json:"holder,omitempty"`
+}
+
+const releaseDescription = "Drop your advisory lease on a resource as soon as you finish with it — don't make siblings wait out the TTL. Releasing a resource you don't hold returns {released:false, holder} (a structured result, NOT an error) and leaves the foreign lease intact; an already-expired or never-claimed resource returns {released:true} idempotently."
+
+func registerRelease(srv *mcp.Server, lc lanternClient) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "release",
+		Description: releaseDescription,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in releaseInput) (*mcp.CallToolResult, releaseOutput, error) {
+		if in.Resource == "" {
+			return nil, releaseOutput{}, fmt.Errorf("release: resource must not be empty")
+		}
+		id := identity.Resolve()
+		key := claimKey(in.Resource)
+
+		v, err := lc.GetVertex(ctx, key)
+		if err != nil {
+			if errors.Is(err, client.ErrNotFound) {
+				// Nothing to release — idempotent success (the lease may
+				// simply have expired, which is the same end state).
+				out := releaseOutput{Released: true, Resource: in.Resource, AgentID: id}
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf(
+						"No live claim on %q (already expired or never claimed) — nothing to do.", in.Resource)}},
+				}, out, nil
+			}
+			return nil, releaseOutput{}, mapSDKError("release", err)
+		}
+
+		var rec claimRecord
+		if decodeRecord(v, &rec) && rec.Holder != id {
+			out := releaseOutput{Released: false, Resource: in.Resource, AgentID: id, Holder: rec.Holder}
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf(
+					"Claim on %q belongs to %s, not you — left intact. Use claim with force:true if you truly need to displace it.",
+					in.Resource, rec.Holder)}},
+			}, out, nil
+		}
+
+		if _, err := lc.DeleteVertex(ctx, key); err != nil {
+			return nil, releaseOutput{}, mapSDKError("release", err)
+		}
+		out := releaseOutput{Released: true, Resource: in.Resource, AgentID: id}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Released claim on %q.", in.Resource)}},
+		}, out, nil
+	})
+}

--- a/mcp/tool_release_test.go
+++ b/mcp/tool_release_test.go
@@ -1,0 +1,59 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/anaregdesign/lantern/mcp/internal/identity"
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+func TestRelease(t *testing.T) {
+	self := identity.Resolve()
+
+	t.Run("holder releases own lease", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.getVertexFn = func(_ context.Context, key string) (*client.Vertex, error) {
+			return claimVertex(t, key, claimRecord{Holder: self}), nil
+		}
+		h.fake.deleteVertexFn = func(_ context.Context, _ string) (bool, error) { return true, nil }
+		res := h.call(t, "release", map[string]any{"resource": "repo.lantern.core"})
+		var out releaseOutput
+		structuredAs(t, res, &out)
+		if !out.Released {
+			t.Fatalf("release: %+v", out)
+		}
+		if h.fake.lastDeleteKey != claimKey("repo.lantern.core") {
+			t.Fatalf("deleted %q", h.fake.lastDeleteKey)
+		}
+	})
+
+	t.Run("non-holder release refused, lease intact", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.getVertexFn = func(_ context.Context, key string) (*client.Vertex, error) {
+			return claimVertex(t, key, claimRecord{Holder: "other-agent"}), nil
+		}
+		res := h.call(t, "release", map[string]any{"resource": "repo.lantern.core"})
+		var out releaseOutput
+		structuredAs(t, res, &out)
+		if out.Released || out.Holder != "other-agent" {
+			t.Fatalf("non-holder release: %+v", out)
+		}
+		if h.fake.lastDeleteKey != "" {
+			t.Fatal("foreign lease must not be deleted")
+		}
+	})
+
+	t.Run("expired or never-claimed is idempotent success", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.getVertexFn = func(_ context.Context, _ string) (*client.Vertex, error) {
+			return nil, client.ErrNotFound
+		}
+		res := h.call(t, "release", map[string]any{"resource": "repo.lantern.core"})
+		var out releaseOutput
+		structuredAs(t, res, &out)
+		if !out.Released {
+			t.Fatalf("idempotent release: %+v", out)
+		}
+	})
+}

--- a/mcp/tool_track.go
+++ b/mcp/tool_track.go
@@ -1,0 +1,60 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/anaregdesign/lantern/mcp/internal/identity"
+	"github.com/anaregdesign/lantern/mcp/internal/ttl"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type trackInput struct {
+	Resources []string `json:"resources" jsonschema:"Dotted resource keys you just touched (file, module, ticket, dataset...) - e.g. ['repo.lantern.core.graphcache','ticket.LANT-42']. One call per work step with everything it touched is ideal; repetition across calls is the SIGNAL (it strengthens the association), so do not deduplicate across turns."`
+}
+
+type trackOutput struct {
+	AgentID   string   `json:"agent_id"`
+	Resources []string `json:"resources"`
+	Tracked   int      `json:"tracked"`
+}
+
+const trackDescription = "Record \"I touched R\" into the shared activity graph. Each call adds a decaying agent->resource edge: repetition strengthens the connection, silence lets it fade (~1 hour horizon), so the graph always reflects RECENT attention, not history. Call it as you work — after editing a file, reading a ticket, querying a dataset — with the dotted resource keys involved. This is what makes whats_happening useful for everyone else; resources appear in the context automatically (no registration step). Do NOT use it for durable provenance — the decay is the feature."
+
+func registerTrack(srv *mcp.Server, lc lanternClient, r *ttl.Resolver) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "track",
+		Description: trackDescription,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in trackInput) (*mcp.CallToolResult, trackOutput, error) {
+		if len(in.Resources) == 0 {
+			return nil, trackOutput{}, fmt.Errorf("track: resources must not be empty")
+		}
+		for _, res := range in.Resources {
+			if strings.TrimSpace(res) == "" {
+				return nil, trackOutput{}, fmt.Errorf("track: resources must not contain empty keys")
+			}
+		}
+		id := identity.Resolve()
+		d, _ := r.ResolveCapped(ttl.Conversation)
+		edges := make([]client.EdgeInput, 0, len(in.Resources))
+		for _, res := range in.Resources {
+			edges = append(edges, client.EdgeInput{
+				Tail:       agentKey(id),
+				Head:       res,
+				Weight:     1,
+				Expiration: expirationIn(d),
+			})
+		}
+		if err := lc.AddEdges(ctx, edges); err != nil {
+			return nil, trackOutput{}, mapSDKError("track", err)
+		}
+		out := trackOutput{AgentID: id, Resources: in.Resources, Tracked: len(edges)}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf(
+				"Tracked %d resource(s) for %s: %s. Repetition strengthens; silence decays (~%s).",
+				out.Tracked, id, strings.Join(in.Resources, ", "), d)}},
+		}, out, nil
+	})
+}

--- a/mcp/tool_track_test.go
+++ b/mcp/tool_track_test.go
@@ -1,0 +1,53 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/anaregdesign/lantern/mcp/internal/identity"
+)
+
+func TestTrack(t *testing.T) {
+	self := agentKey(identity.Resolve())
+
+	t.Run("adds one additive edge per resource from the agent vertex", func(t *testing.T) {
+		h := newContextHarness(t)
+		res := h.call(t, "track", map[string]any{
+			"resources": []string{"repo.lantern.core.graphcache", "ticket.LANT-42"},
+		})
+		var out trackOutput
+		structuredAs(t, res, &out)
+		if out.Tracked != 2 {
+			t.Fatalf("tracked = %d, want 2", out.Tracked)
+		}
+		if len(h.fake.lastAddEdges) != 2 {
+			t.Fatalf("AddEdges received %d edges", len(h.fake.lastAddEdges))
+		}
+		for i, e := range h.fake.lastAddEdges {
+			if e.Tail != self {
+				t.Fatalf("edge %d tail = %q, want %q", i, e.Tail, self)
+			}
+			if e.Weight != 1 {
+				t.Fatalf("edge %d weight = %v, want 1 (unit pulses; repetition is the signal)", i, e.Weight)
+			}
+			if e.Expiration.IsZero() {
+				t.Fatalf("edge %d missing expiration", i)
+			}
+		}
+	})
+
+	t.Run("repetition is observed as repeated AddEdges calls, not deduped", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.call(t, "track", map[string]any{"resources": []string{"repo.x"}})
+		first := len(h.fake.lastAddEdges)
+		h.call(t, "track", map[string]any{"resources": []string{"repo.x"}})
+		if first != 1 || len(h.fake.lastAddEdges) != 1 {
+			t.Fatalf("each call must send its own additive edge (got %d then %d)", first, len(h.fake.lastAddEdges))
+		}
+	})
+
+	t.Run("empty inputs rejected", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.callExpectError(t, "track", map[string]any{"resources": []string{}})
+		h.callExpectError(t, "track", map[string]any{"resources": []string{"ok", " "}})
+	})
+}

--- a/mcp/tool_whats_happening.go
+++ b/mcp/tool_whats_happening.go
@@ -1,0 +1,263 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type whatsHappeningInput struct {
+	Key string `json:"key" jsonschema:"Seed to look around: a resource key (repo.lantern.core.graphcache), an agent (agents.<id>), or a note (notes.<id>). A key nobody has touched returns a well-formed empty context, not an error."`
+}
+
+type happeningAgent struct {
+	AgentID string  `json:"agent_id"`
+	Task    string  `json:"task,omitempty"`
+	Weight  float32 `json:"weight,omitempty"`
+}
+
+type happeningResource struct {
+	Key    string  `json:"key"`
+	Weight float32 `json:"weight,omitempty"`
+}
+
+type happeningNote struct {
+	NoteID   string `json:"note_id"`
+	Text     string `json:"text,omitempty"`
+	Author   string `json:"author,omitempty"`
+	Severity string `json:"severity,omitempty"`
+}
+
+type whatsHappeningOutput struct {
+	Seed      string              `json:"seed"`
+	Agents    []happeningAgent    `json:"agents"`
+	Resources []happeningResource `json:"resources"`
+	Notes     []happeningNote     `json:"notes"`
+	Claims    []liveClaim         `json:"claims"`
+	Empty     bool                `json:"empty"`
+}
+
+const whatsHappeningDescription = "THE situational-awareness read: the active neighborhood of a resource, agent, or note RIGHT NOW — which agents are on it, what else they are co-working (activity spreads through the decaying graph), live notes concerning it, and live claims on the nearby resources. Everything is recency-weighted and self-cleaning: an agent that went quiet, a stale note, an expired claim simply are not there. Call it before touching a resource (who else is on this?), when picking up a task (what is the current state of play?), or on a sibling agent's id to see their working set. A never-touched key returns an empty context — that itself is the answer: nobody is there."
+
+// happeningSeeder abstracts the seed-neighborhood source so the graph
+// walk can be swapped (BFS Illuminate today; the #845 local-community
+// arm is the designed upgrade) without touching the classification.
+type happeningSeeder func(ctx context.Context, lc lanternClient, seed string) (*client.Graph, error)
+
+// bfsSeeder is the default neighborhood source: a 2-hop, fan-out-16 BFS.
+func bfsSeeder(ctx context.Context, lc lanternClient, seed string) (*client.Graph, error) {
+	return lc.Illuminate(ctx, seed, client.WithBFS(client.BFSOpts{Step: 2, FanOut: 16}))
+}
+
+func registerWhatsHappening(srv *mcp.Server, lc lanternClient) {
+	registerWhatsHappeningWithSeeder(srv, lc, bfsSeeder)
+}
+
+func registerWhatsHappeningWithSeeder(srv *mcp.Server, lc lanternClient, seeder happeningSeeder) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "whats_happening",
+		Description: whatsHappeningDescription,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in whatsHappeningInput) (*mcp.CallToolResult, whatsHappeningOutput, error) {
+		if in.Key == "" {
+			return nil, whatsHappeningOutput{}, fmt.Errorf("whats_happening: key must not be empty")
+		}
+		out := whatsHappeningOutput{
+			Seed:      in.Key,
+			Agents:    []happeningAgent{},
+			Resources: []happeningResource{},
+			Notes:     []happeningNote{},
+			Claims:    []liveClaim{},
+		}
+
+		// Forward neighborhood: out-edges spread from agents (agent→resource,
+		// agent→note) and notes (note→resource), so seeding an agent or note
+		// walks naturally. Weight per vertex = strongest incoming edge in the
+		// walked subgraph — the recency/repetition heat track built up.
+		weights := map[string]float32{}
+		g, err := seeder(ctx, lc, in.Key)
+		if err != nil {
+			return nil, whatsHappeningOutput{}, mapSDKError("whats_happening", err)
+		}
+		for _, heads := range g.Edges {
+			for head, w := range heads {
+				if w > weights[head] {
+					weights[head] = w
+				}
+			}
+		}
+		members := map[string]bool{}
+		for k := range g.Vertices {
+			if k != in.Key {
+				members[k] = true
+			}
+		}
+
+		// Reverse edges: who points AT the seed (agents tracking a resource,
+		// notes linked to it). The head-prefix scan is an index probe; the
+		// exact-match filter below trims sibling keys sharing the prefix.
+		revEdges, _, err := lc.ScanEdges(ctx, client.WithEdgeScanHeadPrefix(in.Key), client.WithEdgeScanLimit(200))
+		if err != nil {
+			return nil, whatsHappeningOutput{}, mapSDKError("whats_happening", err)
+		}
+		for _, e := range revEdges {
+			if e.GetHead() != in.Key {
+				continue
+			}
+			members[e.GetTail()] = true
+			if w := e.GetWeight(); w > weights[e.GetTail()] {
+				weights[e.GetTail()] = w
+			}
+		}
+
+		// Classify members by key prefix, and collect the resource set the
+		// claim lookup below probes (the seed itself counts when it is a
+		// resource — its lease matters most of all).
+		var agentKeys, noteKeys, resourceKeys []string
+		if contextKind(in.Key) == "resource" {
+			resourceKeys = append(resourceKeys, in.Key)
+		}
+		for k := range members {
+			switch contextKind(k) {
+			case "agent":
+				agentKeys = append(agentKeys, k)
+			case "note":
+				noteKeys = append(noteKeys, k)
+			case "claim":
+				// claims.* vertices are reachable only if someone tracked one
+				// directly; the structured lease lookup below is the real
+				// source, so skip here.
+			default:
+				resourceKeys = append(resourceKeys, k)
+			}
+		}
+		sort.Strings(agentKeys)
+		sort.Strings(noteKeys)
+		sort.Strings(resourceKeys)
+
+		// Decode agents (live presence records) and notes in one batch each.
+		if len(agentKeys) > 0 {
+			found, _, err := lc.GetVertices(ctx, agentKeys)
+			if err != nil {
+				return nil, whatsHappeningOutput{}, mapSDKError("whats_happening", err)
+			}
+			live := map[string]*client.Vertex{}
+			for _, v := range found {
+				live[v.GetKey()] = v
+			}
+			for _, k := range agentKeys {
+				a := happeningAgent{AgentID: strings.TrimPrefix(k, agentKeyPrefix), Weight: weights[k]}
+				if v, ok := live[k]; ok {
+					var rec presenceRecord
+					if decodeRecord(v, &rec) {
+						a.Task = rec.Task
+					}
+				}
+				out.Agents = append(out.Agents, a)
+			}
+		}
+		if len(noteKeys) > 0 {
+			found, _, err := lc.GetVertices(ctx, noteKeys)
+			if err != nil {
+				return nil, whatsHappeningOutput{}, mapSDKError("whats_happening", err)
+			}
+			for _, v := range found {
+				n := happeningNote{NoteID: strings.TrimPrefix(v.GetKey(), noteKeyPrefix)}
+				var rec noteRecord
+				if decodeRecord(v, &rec) {
+					n.Text, n.Author, n.Severity = rec.Text, rec.Author, rec.Severity
+				}
+				out.Notes = append(out.Notes, n)
+			}
+			sort.Slice(out.Notes, func(i, j int) bool { return out.Notes[i].NoteID < out.Notes[j].NoteID })
+		}
+		for _, k := range resourceKeys {
+			if k == in.Key {
+				continue
+			}
+			out.Resources = append(out.Resources, happeningResource{Key: k, Weight: weights[k]})
+		}
+		sort.Slice(out.Resources, func(i, j int) bool {
+			if out.Resources[i].Weight != out.Resources[j].Weight {
+				return out.Resources[i].Weight > out.Resources[j].Weight
+			}
+			return out.Resources[i].Key < out.Resources[j].Key
+		})
+
+		// Live leases on the seed + nearby resources (capped — the context
+		// is a glance, not an audit).
+		const claimProbeCap = 20
+		probe := resourceKeys
+		if len(probe) > claimProbeCap {
+			probe = probe[:claimProbeCap]
+		}
+		if len(probe) > 0 {
+			keys := make([]string, len(probe))
+			for i, res := range probe {
+				keys[i] = claimKey(res)
+			}
+			found, _, err := lc.GetVertices(ctx, keys)
+			if err != nil {
+				return nil, whatsHappeningOutput{}, mapSDKError("whats_happening", err)
+			}
+			for _, v := range found {
+				c := liveClaim{Resource: strings.TrimPrefix(v.GetKey(), claimKeyPrefix)}
+				var rec claimRecord
+				if decodeRecord(v, &rec) {
+					c.Holder, c.Note, c.At = rec.Holder, rec.Note, rec.At
+				}
+				if exp := client.VertexExpiration(v); !exp.IsZero() {
+					c.ExpiresAt = exp.UTC().Format(time.RFC3339)
+				}
+				out.Claims = append(out.Claims, c)
+			}
+			sort.Slice(out.Claims, func(i, j int) bool { return out.Claims[i].Resource < out.Claims[j].Resource })
+		}
+
+		out.Empty = len(out.Agents) == 0 && len(out.Resources) == 0 && len(out.Notes) == 0 && len(out.Claims) == 0
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: renderHappening(out)}},
+		}, out, nil
+	})
+}
+
+func renderHappening(out whatsHappeningOutput) string {
+	if out.Empty {
+		return fmt.Sprintf("Nothing is happening around %q right now — no active agents, notes, or claims. The coast is clear.", out.Seed)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Around %q right now:\n", out.Seed)
+	if len(out.Agents) > 0 {
+		b.WriteString("Agents:\n")
+		for _, a := range out.Agents {
+			fmt.Fprintf(&b, "- %s", a.AgentID)
+			if a.Task != "" {
+				fmt.Fprintf(&b, ": %s", a.Task)
+			}
+			b.WriteString("\n")
+		}
+	}
+	if len(out.Claims) > 0 {
+		b.WriteString("Claims:\n")
+		for _, c := range out.Claims {
+			fmt.Fprintf(&b, "- %s ← %s (expires≈%s)\n", c.Resource, c.Holder, c.ExpiresAt)
+		}
+	}
+	if len(out.Notes) > 0 {
+		b.WriteString("Notes:\n")
+		for _, n := range out.Notes {
+			fmt.Fprintf(&b, "- [%s] %s (by %s)\n", n.Severity, n.Text, n.Author)
+		}
+	}
+	if len(out.Resources) > 0 {
+		b.WriteString("Co-active resources:\n")
+		for _, r := range out.Resources {
+			fmt.Fprintf(&b, "- %s\n", r.Key)
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/mcp/tool_whats_happening_test.go
+++ b/mcp/tool_whats_happening_test.go
@@ -1,0 +1,114 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+func TestWhatsHappening(t *testing.T) {
+	t.Run("classifies the neighborhood into agents/resources/notes/claims", func(t *testing.T) {
+		h := newContextHarness(t)
+		// Forward walk from the resource finds nothing (resources have no
+		// out-edges); the reverse scan finds an agent and a note pointing
+		// at it; the claim lookup finds a live lease on the seed.
+		h.fake.illuminateFn = func(_ context.Context, seed string, _ ...client.IlluminateOption) (*client.Graph, error) {
+			return &client.Graph{
+				Vertices: map[string]*client.Vertex{seed: {Key: seed}},
+				Edges:    map[string]map[string]float32{},
+			}, nil
+		}
+		h.fake.scanEdgesFn = func(_ context.Context, _ ...client.EdgeScanOption) ([]*client.Edge, []byte, error) {
+			return []*client.Edge{
+				{Tail: "agents.builder-1", Head: "repo.core", Weight: 3},
+				{Tail: "notes.n1", Head: "repo.core", Weight: 1},
+				{Tail: "agents.other", Head: "repo.core.sibling", Weight: 9}, // prefix sibling — must be filtered
+			}, nil, nil
+		}
+		h.fake.getVerticesFn = func(_ context.Context, keys []string) ([]*client.Vertex, []string, error) {
+			var found []*client.Vertex
+			for _, k := range keys {
+				switch k {
+				case "agents.builder-1":
+					found = append(found, presenceVertex(t, k, presenceRecord{Task: "building"}))
+				case "notes.n1":
+					payload, _ := encodeRecord(noteRecord{Text: "ci flaky", Author: "builder-1", Severity: "warn"})
+					found = append(found, &pb.Vertex{Key: k, Value: &pb.Vertex_String_{String_: payload}})
+				case "claims.repo.core":
+					found = append(found, claimVertex(t, k, claimRecord{Holder: "builder-1"}))
+				}
+			}
+			return found, nil, nil
+		}
+
+		res := h.call(t, "whats_happening", map[string]any{"key": "repo.core"})
+		var out whatsHappeningOutput
+		structuredAs(t, res, &out)
+		if out.Empty {
+			t.Fatalf("context not empty: %+v", out)
+		}
+		if len(out.Agents) != 1 || out.Agents[0].AgentID != "builder-1" || out.Agents[0].Task != "building" {
+			t.Fatalf("agents: %+v", out.Agents)
+		}
+		if len(out.Notes) != 1 || out.Notes[0].Text != "ci flaky" || out.Notes[0].Severity != "warn" {
+			t.Fatalf("notes: %+v", out.Notes)
+		}
+		if len(out.Claims) != 1 || out.Claims[0].Resource != "repo.core" || out.Claims[0].Holder != "builder-1" {
+			t.Fatalf("claims: %+v", out.Claims)
+		}
+		for _, a := range out.Agents {
+			if a.AgentID == "other" {
+				t.Fatal("prefix-sibling head leaked through the exact-match filter")
+			}
+		}
+	})
+
+	t.Run("agent seed walks forward to its working set", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.illuminateFn = func(_ context.Context, seed string, _ ...client.IlluminateOption) (*client.Graph, error) {
+			return &client.Graph{
+				Vertices: map[string]*client.Vertex{
+					seed:            {Key: seed},
+					"repo.core":     {Key: "repo.core"},
+					"ticket.LANT-1": {Key: "ticket.LANT-1"},
+				},
+				Edges: map[string]map[string]float32{
+					seed: {"repo.core": 5, "ticket.LANT-1": 2},
+				},
+			}, nil
+		}
+		res := h.call(t, "whats_happening", map[string]any{"key": "agents.builder-1"})
+		var out whatsHappeningOutput
+		structuredAs(t, res, &out)
+		if len(out.Resources) != 2 {
+			t.Fatalf("resources: %+v", out.Resources)
+		}
+		// Ordered by activity weight descending.
+		if out.Resources[0].Key != "repo.core" || out.Resources[0].Weight != 5 {
+			t.Fatalf("resource ordering by weight broken: %+v", out.Resources)
+		}
+	})
+
+	t.Run("never-touched key returns well-formed empty context", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.fake.illuminateFn = func(_ context.Context, seed string, _ ...client.IlluminateOption) (*client.Graph, error) {
+			return &client.Graph{Vertices: map[string]*client.Vertex{}, Edges: map[string]map[string]float32{}}, nil
+		}
+		res := h.call(t, "whats_happening", map[string]any{"key": "repo.ghost"})
+		var out whatsHappeningOutput
+		structuredAs(t, res, &out)
+		if !out.Empty {
+			t.Fatalf("expected empty context: %+v", out)
+		}
+		if out.Agents == nil || out.Resources == nil || out.Notes == nil || out.Claims == nil {
+			t.Fatal("empty context must still carry well-formed (non-null) arrays")
+		}
+	})
+
+	t.Run("empty key rejected", func(t *testing.T) {
+		h := newContextHarness(t)
+		h.callExpectError(t, "whats_happening", map[string]any{"key": ""})
+	})
+}

--- a/tests/integration/mcp_test.go
+++ b/tests/integration/mcp_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +19,11 @@ import (
 // the whole stack — schema inference, argument validation, SDK
 // round-trip, and result shape — agrees end-to-end.
 func TestMCP_EndToEnd(t *testing.T) {
+	// This suite exercises the LEGACY memory verbs, which live behind
+	// LANTERN_MCP_PROFILE=memory since the #851 working-context retarget
+	// (context is the default). TestMCP_ContextProfile_EndToEnd below is
+	// the default-profile sibling.
+	t.Setenv("LANTERN_MCP_PROFILE", lmcp.ProfileMemory)
 	lan, cleanup := newInProcessClientWithPrefix(t)
 	defer cleanup()
 
@@ -140,5 +146,87 @@ func TestMCP_EndToEnd(t *testing.T) {
 	decode(listRes, &list)
 	if list.Count < 2 {
 		t.Fatalf("expected at least 2 entries under fact.; got %d", list.Count)
+	}
+}
+
+// TestMCP_ContextProfile_EndToEnd is the #851 walkthrough over a real
+// Lantern service: agent A announces + tracks + claims; the shared board
+// (list_agents / whats_happening / list_claims) sees it; a note posted
+// against a resource surfaces in its context; release clears the lease.
+func TestMCP_ContextProfile_EndToEnd(t *testing.T) {
+	t.Setenv("LANTERN_MCP_PROFILE", lmcp.ProfileContext)
+	t.Setenv("LANTERN_MCP_AGENT_ID", "") // process identity is memoised; accept whatever it is
+	lan, cleanup := newInProcessClientWithPrefix(t)
+	defer cleanup()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	srv, err := lmcp.NewServer(lan, logger)
+	if err != nil {
+		t.Fatalf("lmcp.NewServer: %v", err)
+	}
+
+	serverT, clientT := mcp.NewInMemoryTransports()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	serverSession, err := srv.Connect(ctx, serverT, nil)
+	if err != nil {
+		t.Fatalf("server.Connect: %v", err)
+	}
+	defer func() { _ = serverSession.Close() }()
+	c := mcp.NewClient(&mcp.Implementation{Name: "integration-ctx", Version: "test"}, nil)
+	cs, err := c.Connect(ctx, clientT, nil)
+	if err != nil {
+		t.Fatalf("client.Connect: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	call := func(name string, args map[string]any) *mcp.CallToolResult {
+		t.Helper()
+		res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: args})
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if res.IsError {
+			t.Fatalf("%s returned tool error: %+v", name, res.Content)
+		}
+		return res
+	}
+	textOf := func(res *mcp.CallToolResult) string {
+		t.Helper()
+		for _, content := range res.Content {
+			if tc, ok := content.(*mcp.TextContent); ok {
+				return tc.Text
+			}
+		}
+		return ""
+	}
+
+	// A announces and works.
+	call("announce", map[string]any{"task": "refactoring auth middleware"})
+	call("track", map[string]any{"resources": []string{"repo.api.middleware.auth", "ticket.API-17"}})
+	call("claim", map[string]any{"resource": "repo.api.middleware.auth", "note": "rewriting"})
+	call("post_note", map[string]any{
+		"text": "auth middleware API changed", "severity": "warn",
+		"links": []string{"repo.api.middleware.auth"}, "ttl": "turn",
+	})
+
+	// The board sees all of it.
+	if got := textOf(call("list_agents", map[string]any{})); !strings.Contains(got, "refactoring auth middleware") {
+		t.Fatalf("list_agents missing the announced task: %q", got)
+	}
+	if got := textOf(call("list_claims", map[string]any{})); !strings.Contains(got, "repo.api.middleware.auth") {
+		t.Fatalf("list_claims missing the lease: %q", got)
+	}
+	happening := textOf(call("whats_happening", map[string]any{"key": "repo.api.middleware.auth"}))
+	for _, want := range []string{"refactoring auth middleware", "auth middleware API changed"} {
+		if !strings.Contains(happening, want) {
+			t.Fatalf("whats_happening missing %q:\n%s", want, happening)
+		}
+	}
+
+	// Release clears the lease.
+	call("release", map[string]any{"resource": "repo.api.middleware.auth"})
+	if got := textOf(call("list_claims", map[string]any{})); strings.Contains(got, "repo.api.middleware.auth") {
+		t.Fatalf("lease survived release: %q", got)
 	}
 }


### PR DESCRIPTION
Closes #851

**Breaking for MCP deployments that relied on the memory verbs by default** (mcp is pre-1.0 and independently tagged; the memory surface stays one release behind a flag — see cutover below).

## Why

The decision record is in the issue: the long-term-memory framing fought the engine (knowledge shouldn't decay; nobody pays the relation-extraction cost; single-agent memory doesn't need a graph), while Lantern's actual primitive — additive TTL edges + decaying vertices — models **activity**. TTL = lease/heartbeat expiry; additive edges = who-touches-what heat; Illuminate = "what is happening around X right now".

## What

**Identity** (`internal/identity`): `LANTERN_MCP_AGENT_ID` > stable `<hostname>-<pid>-<rand4>` fallback, memoised per process; sanitised so ids can't inject key segments; surfaced in every tool output. No per-call id (spoofable) — pinned design clarification: shared ids last-writer-win and fleet operators own uniqueness.

**Key scheme**: `agents.<id>` / `claims.<resource>` / `notes.<id>`; everything else is a resource. Keyspace-sharing with legacy memory data documented (no migration; decay cleans up).

**Tools** (phases 1+2 in one PR): `announce`, `list_agents`, `track`, `whats_happening`, `claim`, `release`, `list_claims`, `post_note`, `context_stats`. TTL mapping per the issue: presence=`transient`, claims=`turn`, activity=`conversation`, notes=explicit bucket. Claim conflicts are structured `{granted:false, holder, expires_at}` results (mirroring `touch`'s `found:false` convention); the advisory read-check-write window is documented with the CAS RPC as the known-limitation follow-up.

`whats_happening` combines the forward BFS Illuminate neighborhood with a reverse head-prefix edge scan (exact-match filtered), classifies by key prefix into {agents, resources, notes, claims}, decodes live presences/notes/leases via batched GetVertices, and returns a **well-formed empty context** for never-touched keys (pinned clarification). The seed-graph source sits behind a `happeningSeeder` seam so the #845 local-community arm can swap in without touching the classifier.

**Cutover (phase 3)**: `LANTERN_MCP_PROFILE=context|memory`, default `context`; memory verbs retire after one mcp/vX release. Per-profile session instructions (the coordination loop) and titles.

**Docs**: README rebuilt around the two-agent walkthrough from the issue (announce→track→claim→conflict→note→release→crash-and-evaporate), reserved-key and identity sections, env table (`LANTERN_MCP_PROFILE`, `LANTERN_MCP_AGENT_ID`, `LANTERN_TOKEN`), legacy profile section; Dockerfile env notes; doc.go.

## Tests

Per-tool paired suites: heartbeat refresh preserves `since` for the same task and resets on change; claim grant/conflict(no-write)/steal/renew; release by non-holder refused with lease intact, expired release idempotent; track sends unit pulses per call (repetition observed, never deduped); whats_happening classification incl. prefix-sibling head filtering, agent-seed forward walk ordered by activity weight, and the empty-context contract; note edge shape (note→resources + author→note); stats subtraction clamp; identity sanitisation/memoisation; and the **profile registration matrix** — each profile exposes exactly its own tool set, so a future tool added without a profile decision fails the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)