### PR TITLE
fix(core): gemini schema sanitizer — allowlist walk replaces one-key blocklist

### DIFF
--- a/core/llm/gemini/gemini.go
+++ b/core/llm/gemini/gemini.go
@@ -158,30 +158,83 @@ func New[T any](client *Client, instruction string, effort Effort) (llm.Model[T]
 }
 
 // sanitizeSchema rewrites the canonical JSON Schema produced by llm.SchemaFor
-// into the subset Gemini's responseSchema accepts. Gemini follows an OpenAPI 3.0
-// subset that rejects "additionalProperties", so it is stripped recursively.
+// into Gemini's OpenAPI-3.0-subset responseSchema via an ALLOWLIST walk
+// (#853): only the fields Gemini documents survive, everything else is
+// dropped or translated. The previous one-key blocklist
+// (delete "additionalProperties") rotted every time SchemaFor learned a new
+// keyword — a []byte field's contentEncoding:base64 already produced a
+// schema Gemini rejected with a remote 400. The allowlist fails closed:
+// an unknown keyword can never reach the wire.
 func sanitizeSchema(raw json.RawMessage) (json.RawMessage, error) {
 	var doc any
 	if err := json.Unmarshal(raw, &doc); err != nil {
 		return nil, err
 	}
-	stripUnsupported(doc)
-	return json.Marshal(doc)
+	return json.Marshal(sanitizeNode(doc))
 }
 
-// stripUnsupported walks a decoded JSON document and removes keys Gemini rejects.
-func stripUnsupported(node any) {
-	switch v := node.(type) {
-	case map[string]any:
-		delete(v, "additionalProperties")
-		for _, child := range v {
-			stripUnsupported(child)
-		}
-	case []any:
-		for _, child := range v {
-			stripUnsupported(child)
+// geminiFormats is the per-type format allowlist: Gemini accepts only these
+// format values; anything else (e.g. "uri", "email") is dropped rather than
+// forwarded — a missing format is valid, a foreign one is a 400.
+var geminiFormats = map[string]map[string]bool{
+	"string":  {"date-time": true, "enum": true},
+	"integer": {"int32": true, "int64": true},
+	"number":  {"float": true, "double": true},
+}
+
+// sanitizeNode rewrites one schema node (and its children) into the Gemini
+// subset. Non-object nodes pass through (enum value arrays, bools, ...).
+func sanitizeNode(node any) any {
+	obj, ok := node.(map[string]any)
+	if !ok {
+		return node
+	}
+
+	// []byte translation: SchemaFor emits {"type":"string",
+	// "contentEncoding":"base64"} — Gemini rejects the keyword, but a plain
+	// string still round-trips (encoding/json decodes base64 strings into
+	// []byte), so preserve the field and move the encoding note into the
+	// description instead of erroring.
+	if enc, ok := obj["contentEncoding"].(string); ok {
+		note := "content encoding: " + enc
+		if desc, ok := obj["description"].(string); ok && desc != "" {
+			obj["description"] = desc + " (" + note + ")"
+		} else {
+			obj["description"] = note
 		}
 	}
+
+	out := make(map[string]any, len(obj))
+	typ, _ := obj["type"].(string)
+	for key, val := range obj {
+		switch key {
+		case "type", "description", "nullable", "enum", "required",
+			"minItems", "maxItems", "propertyOrdering":
+			out[key] = sanitizeNode(val)
+		case "format":
+			// Constrain format per type: forward only the values Gemini
+			// documents for the node's declared type.
+			if f, ok := val.(string); ok && geminiFormats[typ][f] {
+				out[key] = f
+			}
+		case "items":
+			out[key] = sanitizeNode(val)
+		case "properties":
+			props, ok := val.(map[string]any)
+			if !ok {
+				continue
+			}
+			sanitized := make(map[string]any, len(props))
+			for name, sub := range props {
+				sanitized[name] = sanitizeNode(sub)
+			}
+			out[key] = sanitized
+		default:
+			// Unknown keyword (additionalProperties, contentEncoding, $schema,
+			// pattern, ...): dropped. The allowlist fails closed by design.
+		}
+	}
+	return out
 }
 
 // model binds an output type T, a fixed instruction, the derived JSON schema, and

--- a/core/llm/gemini/gemini_test.go
+++ b/core/llm/gemini/gemini_test.go
@@ -316,3 +316,115 @@ func TestResponseSchemaStripsAdditionalProperties(t *testing.T) {
 		t.Errorf("responseSchema must not contain additionalProperties: %s", gotBody.GenerationConfig.ResponseSchema)
 	}
 }
+
+// TestSanitizeSchema_Allowlist pins the #853 allowlist rewrite over a
+// struct exercising the SchemaFor surface: []byte (contentEncoding
+// translation), time.Time (date-time format retained), nested struct,
+// slice of struct, map[string]T, pointer-optional, and plain string.
+func TestSanitizeSchema_Allowlist(t *testing.T) {
+	type inner struct {
+		Label string  `json:"label"`
+		Score float64 `json:"score"`
+	}
+	type doc struct {
+		Blob    []byte         `json:"blob"`
+		When    time.Time      `json:"when"`
+		Nested  inner          `json:"nested"`
+		Items   []inner        `json:"items"`
+		Tags    map[string]int `json:"tags"`
+		Maybe   *string        `json:"maybe,omitempty"`
+		Comment string         `json:"comment"`
+	}
+
+	schema, err := llm.SchemaFor[doc]()
+	if err != nil {
+		t.Fatalf("SchemaFor: %v", err)
+	}
+	sanitized, err := sanitizeSchema(schema.Definition)
+	if err != nil {
+		t.Fatalf("sanitizeSchema: %v", err)
+	}
+	text := string(sanitized)
+
+	for _, banned := range []string{"contentEncoding", "additionalProperties", "$schema", "patternProperties"} {
+		if strings.Contains(text, banned) {
+			t.Errorf("sanitized schema still carries rejected keyword %q:\n%s", banned, text)
+		}
+	}
+	if !strings.Contains(text, `"date-time"`) {
+		t.Errorf("date-time format for time.Time must survive:\n%s", text)
+	}
+	if !strings.Contains(text, `"blob"`) {
+		t.Errorf("[]byte field must be preserved as a plain string, not dropped:\n%s", text)
+	}
+	if !strings.Contains(text, "content encoding: base64") {
+		t.Errorf("base64 note must move into the description:\n%s", text)
+	}
+
+	// Unknown formats are dropped rather than forwarded.
+	raw := json.RawMessage(`{"type":"string","format":"email"}`)
+	out, err := sanitizeSchema(raw)
+	if err != nil {
+		t.Fatalf("sanitizeSchema(email): %v", err)
+	}
+	if strings.Contains(string(out), "email") {
+		t.Errorf("foreign format leaked: %s", out)
+	}
+	// Type-scoped: int64 survives on integer, not on string.
+	raw = json.RawMessage(`{"type":"integer","format":"int64"}`)
+	out, _ = sanitizeSchema(raw)
+	if !strings.Contains(string(out), "int64") {
+		t.Errorf("int64 on integer must survive: %s", out)
+	}
+	raw = json.RawMessage(`{"type":"string","format":"int64"}`)
+	out, _ = sanitizeSchema(raw)
+	if strings.Contains(string(out), "int64") {
+		t.Errorf("int64 on string must be dropped: %s", out)
+	}
+}
+
+// TestNew_ByteFieldWireSchema is the construction-time regression from the
+// #853 sequencing note: binding a T that contains []byte must succeed via
+// New[T], and the schema that actually reaches the wire must carry no
+// keyword Gemini rejects.
+func TestNew_ByteFieldWireSchema(t *testing.T) {
+	type payload struct {
+		Data []byte `json:"data"`
+		Name string `json:"name"`
+	}
+	var wireSchema string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		if gc, ok := req["generationConfig"].(map[string]any); ok {
+			raw, _ := json.Marshal(gc["responseSchema"])
+			wireSchema = string(raw)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"modelVersion":"gemini-2.5-pro","candidates":[{"finishReason":"STOP",`+
+			`"content":{"parts":[{"text":"{\"data\":\"aGk=\",\"name\":\"x\"}"}]}}],`+
+			`"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}`)
+	}))
+	defer srv.Close()
+
+	m, err := New[payload](NewClient("key", "gemini-2.5-pro", WithBaseURL(srv.URL)), "decode", EffortLow)
+	if err != nil {
+		t.Fatalf("New[T] with []byte must construct: %v", err)
+	}
+	resp, err := m.Generate(context.Background(), "input")
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if string(resp.Output.Data) != "hi" {
+		t.Errorf("base64 string did not round-trip into []byte: %q", resp.Output.Data)
+	}
+	for _, banned := range []string{"contentEncoding", "additionalProperties"} {
+		if strings.Contains(wireSchema, banned) {
+			t.Errorf("wire schema carries rejected keyword %q:\n%s", banned, wireSchema)
+		}
+	}
+	if wireSchema == "" {
+		t.Fatal("wire schema not captured")
+	}
+}


### PR DESCRIPTION
Closes #853

## Problem

`sanitizeSchema` deleted exactly one key (`additionalProperties`). Every other keyword `llm.SchemaFor` emits leaked to the wire — and at least one already breaks: a `[]byte` field becomes `{"type":"string","contentEncoding":"base64"}`, which Gemini's OpenAPI-3.0-subset `responseSchema` rejects with a remote 400. The failure was late (request time) and opaque instead of local; and a blocklist of one rots every time `SchemaFor` learns a keyword.

## Change (scoped per the sequencing decision)

- **Allowlist walk**: only Gemini's documented fields survive (`type`, `format`, `description`, `nullable`, `enum`, `items`, `properties`, `required`, `minItems`/`maxItems`, `propertyOrdering`); everything else is dropped — the sanitizer fails closed, so an unknown keyword can never reach the wire again.
- **Per-type `format` constraint**: `date-time` on string, `int32`/`int64` on integer, `float`/`double` on number; foreign values (e.g. `email`, or `int64` on a string) are dropped rather than forwarded.
- **`[]byte` translation instead of rejection**: the field survives as a plain string with the encoding noted in `description` — `encoding/json` still decodes the base64 string into `[]byte`, so data round-trips.
- **`propertyOrdering` deferred** exactly per the issue comment: the sanitizer decodes into `map[string]any` (key order lost), so ordering must be emitted by `SchemaFor` with per-provider strict-mode acceptance — a follow-up, not part of this fix's blast radius. The allowlist already forwards the keyword when it appears.

Canonical `SchemaFor` output is untouched (OpenAI strict mode keeps wanting `additionalProperties:false`).

## Tests

- Golden allowlist walk over a struct exercising `{[]byte, time.Time, nested struct, slice of struct, map, pointer-optional, string}`: banned keywords absent, `date-time` retained, base64 note present in `description`.
- Per-type format matrix (foreign format dropped; `int64` survives on integer, dropped on string).
- The sequencing-comment regression: **binding via `New[T]` with a `[]byte`-bearing T succeeds**, the schema captured off the wire carries no rejected keyword, and the base64 payload round-trips into `[]byte` end-to-end through `Generate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)