### PR TITLE
feat(core,server): pin the LLM auth matrix — token cache contract + Azure key header

### DIFF
--- a/core/llm/anthropic/example/main.go
+++ b/core/llm/anthropic/example/main.go
@@ -8,6 +8,13 @@
 //	export ANTHROPIC_API_KEY=sk-ant-...   # your key
 //	export ANTHROPIC_MODEL=claude-opus    # any model id (never hard-coded)
 //	go run ./llm/anthropic/example
+//
+// Cloud-credential recipe (#854 auth matrix — Anthropic on Vertex AI):
+//
+//	hc, _ := llmauth.NewGoogleDefaultHTTPClient(ctx)            // ADC; or NewGoogleServiceAccountHTTPClient
+//	c := anthropic.NewClient("", model,                         // empty key: transport owns auth
+//		anthropic.WithVertexAI(project, location),
+//		anthropic.WithHTTPClient(hc))
 package main
 
 import (

--- a/core/llm/doc.go
+++ b/core/llm/doc.go
@@ -40,4 +40,30 @@
 // raise the cap rather than retrying. Refusals and safety blocks remain
 // provider-typed (anthropic.ErrRefusal, openai.ErrRefusal, gemini.ErrBlocked)
 // because their semantics differ per provider.
+//
+// # Auth matrix (#854)
+//
+// The supported provider x endpoint x credential combinations, each pinned
+// by a request-shape test in the provider package (URL path + auth header),
+// so a broken combination fails CI instead of a user:
+//
+//	Provider   Endpoint          Credential            Recipe
+//	---------  ----------------  --------------------  ------------------------------------------
+//	openai     native            API key (Bearer)      NewClient(key, model)
+//	openai     Azure OpenAI      Entra (MI/secret)     NewClient("", model, WithBaseURL(resource),
+//	                                                     WithHTTPClient(llmauth.NewAzure*HTTPClient(...)))
+//	openai     Azure OpenAI      static api-key        NewClient(key, model, WithBaseURL(resource+"/openai"),
+//	                                                     WithAPIKeyHeader("api-key"))
+//	anthropic  native            API key (x-api-key)   NewClient(key, model)
+//	anthropic  Vertex AI         ADC / service acct    NewClient("", model, WithVertexAI(project, location),
+//	                                                     WithHTTPClient(llmauth.NewGoogle*HTTPClient(...)))
+//	gemini     native            API key (x-goog-...)  NewClient(key, model)
+//	gemini     Vertex AI         ADC / service acct    NewClient("", model, WithVertexAI(project, location),
+//	                                                     WithHTTPClient(llmauth.NewGoogle*HTTPClient(...)))
+//
+// llmauth (server/llmauth) builds the credentialed http.Client for the
+// token rows: Azure credentials sit behind an explicit expiry-aware
+// singleflight cache, and Google token sources behind
+// oauth2.ReuseTokenSource, so no combination pays a token round-trip per
+// request.
 package llm

--- a/core/llm/gemini/example/main.go
+++ b/core/llm/gemini/example/main.go
@@ -8,6 +8,13 @@
 //	export GEMINI_API_KEY=...           # your key
 //	export GEMINI_MODEL=gemini-3        # any model id (never hard-coded)
 //	go run ./llm/gemini/example
+//
+// Cloud-credential recipe (#854 auth matrix — Gemini on Vertex AI):
+//
+//	hc, _ := llmauth.NewGoogleDefaultHTTPClient(ctx)            // ADC; or NewGoogleServiceAccountHTTPClient
+//	c := gemini.NewClient("", model,                            // empty key: transport owns auth
+//		gemini.WithVertexAI(project, location),
+//		gemini.WithHTTPClient(hc))
 package main
 
 import (

--- a/core/llm/openai/example/main.go
+++ b/core/llm/openai/example/main.go
@@ -8,6 +8,18 @@
 //	export OPENAI_API_KEY=sk-...        # your key
 //	export OPENAI_MODEL=gpt-5.5         # any model id (never hard-coded)
 //	go run ./llm/openai/example
+//
+// Cloud-credential recipe (#854 auth matrix — Azure OpenAI): the server
+// module's llmauth package builds the credentialed client (core cannot
+// import it; module DAG):
+//
+//	hc, _ := llmauth.NewAzureManagedIdentityHTTPClient()        // or NewAzureClientSecretHTTPClient
+//	c := openai.NewClient("", model,                            // empty key: transport owns auth
+//		openai.WithBaseURL("https://<resource>.openai.azure.com/openai/v1"),
+//		openai.WithHTTPClient(hc))
+//
+// Classic static-key Azure uses WithAPIKeyHeader("api-key") instead of an
+// injected client.
 package main
 
 import (

--- a/core/llm/openai/openai.go
+++ b/core/llm/openai/openai.go
@@ -49,11 +49,12 @@ const (
 // Client is a non-generic, reusable handle to the OpenAI Responses API. It is
 // safe for concurrent use. Bind a structured-output type with New.
 type Client struct {
-	apiKey    string
-	model     string
-	baseURL   string
-	maxTokens int
-	http      *http.Client
+	apiKey       string
+	apiKeyHeader string
+	model        string
+	baseURL      string
+	maxTokens    int
+	http         *http.Client
 }
 
 // Option configures a Client.
@@ -66,6 +67,19 @@ func WithBaseURL(u string) Option {
 		if u != "" {
 			c.baseURL = strings.TrimRight(u, "/")
 		}
+	}
+}
+
+// WithAPIKeyHeader sends the API key in the named request header instead
+// of "Authorization: Bearer" (#854). The classic Azure OpenAI data plane
+// authenticates with "api-key: <key>"; pass "api-key" here together with
+// WithBaseURL("https://<resource>.openai.azure.com/openai/v1") to use a
+// static Azure key. Entra-credentialed access keeps using an empty key +
+// WithHTTPClient (see server/llmauth). An empty name keeps the Bearer
+// default.
+func WithAPIKeyHeader(name string) Option {
+	return func(c *Client) {
+		c.apiKeyHeader = name
 	}
 }
 
@@ -224,7 +238,11 @@ func (c *Client) generate(ctx context.Context, instruction, input, name string, 
 		return result{}, fmt.Errorf("openai: build request: %w", err)
 	}
 	if c.apiKey != "" {
-		httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+		if c.apiKeyHeader != "" {
+			httpReq.Header.Set(c.apiKeyHeader, c.apiKey)
+		} else {
+			httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+		}
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 

--- a/core/llm/openai/openai_test.go
+++ b/core/llm/openai/openai_test.go
@@ -195,3 +195,41 @@ func TestGenerateTruncated(t *testing.T) {
 		t.Fatalf("err = %v, want ErrTruncated", err)
 	}
 }
+
+// TestGenerateAzureAPIKeyHeader pins the classic Azure OpenAI static-key
+// row of the #854 auth matrix: WithAPIKeyHeader("api-key") sends the key
+// in that header (no Authorization), and WithBaseURL carries the Azure
+// resource path so the request lands on <resource>/openai/v1/responses.
+func TestGenerateAzureAPIKeyHeader(t *testing.T) {
+	var gotPath, gotAPIKey, gotAuthz string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAPIKey = r.Header.Get("api-key")
+		gotAuthz = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"model":"gpt-5.5","status":"completed",`+
+			`"output":[{"content":[{"type":"output_text","text":"{\"city\":\"Tokyo\",\"high\":31}"}]}],`+
+			`"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`)
+	}))
+	defer srv.Close()
+
+	m, err := New[weather](NewClient("azure-key", "gpt-5.5",
+		WithBaseURL(srv.URL+"/openai"),
+		WithAPIKeyHeader("api-key"),
+	), "weather", EffortLow)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := m.Generate(context.Background(), "Tokyo"); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if gotPath != "/openai/v1/responses" {
+		t.Errorf("path = %q, want /openai/v1/responses", gotPath)
+	}
+	if gotAPIKey != "azure-key" {
+		t.Errorf("api-key header = %q, want azure-key", gotAPIKey)
+	}
+	if gotAuthz != "" {
+		t.Errorf("Authorization must be absent in api-key-header mode; got %q", gotAuthz)
+	}
+}

--- a/server/llmauth/llmauth.go
+++ b/server/llmauth/llmauth.go
@@ -1,5 +1,14 @@
 // Package llmauth builds credential-bearing HTTP clients for core/llm provider
 // clients. It lives in server so cloud SDK dependencies do not leak into core.
+//
+// The full provider x endpoint x credential support matrix lives in
+// core/llm/doc.go ("Auth matrix"); every row is pinned by a request-shape
+// test. Token acquisition is cached on both cloud paths (#854): Azure
+// credentials behind an explicit expiry-aware singleflight cache (see
+// cachedTokenCredential — correctness does not depend on MSAL internals),
+// Google token sources behind oauth2.ReuseTokenSource. No combination pays
+// a token round-trip per LLM request, and a cold-start burst coalesces
+// into one token fetch.
 package llmauth
 
 import (
@@ -7,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -90,10 +100,77 @@ func NewAzureCredentialHTTPClient(cred azcore.TokenCredential, scope string, opt
 		scope = AzureOpenAIScope
 	}
 	o := resolveOptions(opts)
+	// The credential is wrapped in an explicit expiry-aware cache with
+	// singleflight (#854): correctness no longer depends on the MSAL
+	// in-memory cache being an azidentity implementation detail, a custom
+	// azcore.TokenCredential without caching cannot make every LLM call
+	// pay an AAD round-trip, and a cold-start burst coalesces into one
+	// token request — mirroring what oauth2.ReuseTokenSource already gives
+	// the Google path.
 	return &http.Client{
-		Transport: azureBearerTransport{credential: cred, scope: scope, base: o.base},
+		Transport: azureBearerTransport{credential: &cachedTokenCredential{inner: cred}, scope: scope, base: o.base},
 		Timeout:   o.timeout,
 	}, nil
+}
+
+// tokenRefreshMargin renews a cached Azure token this long before its
+// ExpiresOn so a request never rides a token that dies mid-flight.
+const tokenRefreshMargin = 2 * time.Minute
+
+// cachedTokenCredential is an expiry-aware, singleflight token cache over
+// an azcore.TokenCredential (#854). Hand-rolled (mutex + per-flight
+// channel) rather than pulling golang.org/x/sync — per the workspace
+// dependency rule the module gets no new dep for twenty lines.
+//
+// Failure contract: every waiter of a failed flight receives that
+// flight's error (never a poisoned cache entry), and the NEXT GetToken
+// starts a fresh flight.
+type cachedTokenCredential struct {
+	inner azcore.TokenCredential
+
+	mu     sync.Mutex
+	token  azcore.AccessToken
+	valid  bool
+	flight *tokenFlight
+}
+
+type tokenFlight struct {
+	done  chan struct{}
+	token azcore.AccessToken
+	err   error
+}
+
+func (c *cachedTokenCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	c.mu.Lock()
+	if c.valid && time.Until(c.token.ExpiresOn) > tokenRefreshMargin {
+		t := c.token
+		c.mu.Unlock()
+		return t, nil
+	}
+	if f := c.flight; f != nil {
+		c.mu.Unlock()
+		select {
+		case <-f.done:
+			return f.token, f.err
+		case <-ctx.Done():
+			return azcore.AccessToken{}, ctx.Err()
+		}
+	}
+	f := &tokenFlight{done: make(chan struct{})}
+	c.flight = f
+	c.mu.Unlock()
+
+	tok, err := c.inner.GetToken(ctx, opts)
+
+	c.mu.Lock()
+	c.flight = nil
+	if err == nil {
+		c.token, c.valid = tok, true
+	}
+	f.token, f.err = tok, err
+	close(f.done)
+	c.mu.Unlock()
+	return tok, err
 }
 
 type azureBearerTransport struct {

--- a/server/llmauth/llmauth_test.go
+++ b/server/llmauth/llmauth_test.go
@@ -3,9 +3,12 @@ package llmauth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -136,4 +139,193 @@ func textResponse(status int, body string) *http.Response {
 		Body:       io.NopCloser(strings.NewReader(body)),
 		Header:     make(http.Header),
 	}
+}
+
+// countingCredential is a fake azcore.TokenCredential that counts GetToken
+// calls and can be scripted to fail — the #854 cache-contract probe.
+type countingCredential struct {
+	mu      sync.Mutex
+	calls   int
+	expires time.Time
+	fail    error
+	block   chan struct{} // when non-nil, GetToken waits here (concurrency tests)
+}
+
+func (c *countingCredential) GetToken(ctx context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	c.mu.Lock()
+	c.calls++
+	n := c.calls
+	fail := c.fail
+	expires := c.expires
+	block := c.block
+	c.mu.Unlock()
+	if block != nil {
+		select {
+		case <-block:
+		case <-ctx.Done():
+			return azcore.AccessToken{}, ctx.Err()
+		}
+	}
+	if fail != nil {
+		return azcore.AccessToken{}, fail
+	}
+	return azcore.AccessToken{Token: fmt.Sprintf("tok-%d", n), ExpiresOn: expires}, nil
+}
+
+func (c *countingCredential) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls
+}
+
+// TestCachedTokenCredential pins the #854 token-cache contract so
+// correctness never again depends on MSAL internals: (a) N concurrent
+// cold-start requests coalesce into exactly one GetToken (singleflight),
+// (b) passage of the expiry margin triggers exactly one refresh, (c) a
+// failed flight delivers the error to every waiter WITHOUT poisoning the
+// cache — the next request starts a fresh flight.
+func TestCachedTokenCredential(t *testing.T) {
+	ctx := context.Background()
+	opts := policy.TokenRequestOptions{Scopes: []string{AzureOpenAIScope}}
+
+	t.Run("concurrent cold start coalesces to one GetToken", func(t *testing.T) {
+		block := make(chan struct{})
+		inner := &countingCredential{expires: time.Now().Add(time.Hour), block: block}
+		cache := &cachedTokenCredential{inner: inner}
+
+		const n = 16
+		var wg sync.WaitGroup
+		tokens := make([]string, n)
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				tok, err := cache.GetToken(ctx, opts)
+				if err != nil {
+					t.Errorf("GetToken %d: %v", i, err)
+					return
+				}
+				tokens[i] = tok.Token
+			}(i)
+		}
+		// Give the herd time to pile onto the single flight, then release.
+		time.Sleep(20 * time.Millisecond)
+		close(block)
+		wg.Wait()
+		if got := inner.count(); got != 1 {
+			t.Fatalf("GetToken calls = %d, want 1 (singleflight)", got)
+		}
+		for i, tok := range tokens {
+			if tok != "tok-1" {
+				t.Fatalf("waiter %d got %q, want the shared tok-1", i, tok)
+			}
+		}
+	})
+
+	t.Run("fresh token served from cache; margin passage refreshes once", func(t *testing.T) {
+		inner := &countingCredential{expires: time.Now().Add(time.Hour)}
+		cache := &cachedTokenCredential{inner: inner}
+		for i := 0; i < 5; i++ {
+			if _, err := cache.GetToken(ctx, opts); err != nil {
+				t.Fatalf("GetToken: %v", err)
+			}
+		}
+		if got := inner.count(); got != 1 {
+			t.Fatalf("calls = %d, want 1 (cache hit)", got)
+		}
+		// Age the cached token into the refresh margin.
+		cache.mu.Lock()
+		cache.token.ExpiresOn = time.Now().Add(tokenRefreshMargin / 2)
+		cache.mu.Unlock()
+		for i := 0; i < 5; i++ {
+			if _, err := cache.GetToken(ctx, opts); err != nil {
+				t.Fatalf("GetToken after aging: %v", err)
+			}
+		}
+		if got := inner.count(); got != 2 {
+			t.Fatalf("calls = %d, want 2 (exactly one refresh)", got)
+		}
+	})
+
+	t.Run("failed flight surfaces to all waiters and does not poison", func(t *testing.T) {
+		boom := errors.New("aad down")
+		block := make(chan struct{})
+		inner := &countingCredential{expires: time.Now().Add(time.Hour), fail: boom, block: block}
+		cache := &cachedTokenCredential{inner: inner}
+
+		const n = 8
+		var wg sync.WaitGroup
+		errs := make([]error, n)
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				_, errs[i] = cache.GetToken(ctx, opts)
+			}(i)
+		}
+		time.Sleep(20 * time.Millisecond)
+		close(block)
+		wg.Wait()
+		if got := inner.count(); got != 1 {
+			t.Fatalf("calls = %d, want 1", got)
+		}
+		for i, err := range errs {
+			if !errors.Is(err, boom) {
+				t.Fatalf("waiter %d err = %v, want the flight error", i, err)
+			}
+		}
+		// Not poisoned: the next request starts a fresh (now succeeding) flight.
+		inner.mu.Lock()
+		inner.fail = nil
+		inner.block = nil
+		inner.mu.Unlock()
+		if _, err := cache.GetToken(ctx, opts); err != nil {
+			t.Fatalf("retry after failed flight: %v", err)
+		}
+		if got := inner.count(); got != 2 {
+			t.Fatalf("calls = %d, want 2 (one retry flight)", got)
+		}
+	})
+}
+
+// TestGoogleTransport_ReusesToken is the Google-side counting twin: the
+// oauth2.ReuseTokenSource wrapper must serve repeated requests from one
+// underlying token fetch.
+func TestGoogleTransport_ReusesToken(t *testing.T) {
+	var fetches int
+	source := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "g-tok", Expiry: time.Now().Add(time.Hour)})
+	counting := oauth2.TokenSource(countingTokenSource{inner: source, calls: &fetches})
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer g-tok" {
+			t.Errorf("Authorization = %q", got)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	client, err := NewGoogleTokenSourceHTTPClient(counting)
+	if err != nil {
+		t.Fatalf("NewGoogleTokenSourceHTTPClient: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		resp, err := client.Get(backend.URL)
+		if err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+		_ = resp.Body.Close()
+	}
+	if fetches != 1 {
+		t.Fatalf("token fetches = %d, want 1 (ReuseTokenSource)", fetches)
+	}
+}
+
+type countingTokenSource struct {
+	inner oauth2.TokenSource
+	calls *int
+}
+
+func (c countingTokenSource) Token() (*oauth2.Token, error) {
+	*c.calls++
+	return c.inner.Token()
 }


### PR DESCRIPTION
Closes #854

## What

1. **Token-cache contract (llmauth)**: `azureBearerTransport` called `credential.GetToken` on every request, relying on MSAL's in-memory cache — a third-party implementation detail nothing asserted. Credentials are now wrapped in `cachedTokenCredential`: expiry-aware (2-min refresh margin ahead of `AccessToken.ExpiresOn`) with **singleflight** coalescing. Per the sequencing note, singleflight is hand-rolled (mutex + per-flight channel) — no `golang.org/x/sync` dependency for twenty lines. The failure contract from the test clarification is pinned exactly: all waiters of a failed flight receive that flight's error, the cache is never poisoned, and the next request starts a fresh flight. The Google side already had `oauth2.ReuseTokenSource`; it now has the matching counting test, ending the undocumented asymmetry.
2. **Azure OpenAI key auth — option (a)**: `openai.WithAPIKeyHeader("api-key")` sends the key in the classic Azure data-plane header instead of `Authorization: Bearer`. Shape test asserts the full path (`/openai/v1/responses` under the resource base), the `api-key` header value, and that `Authorization` is absent.
3. **One documented matrix**: `core/llm/doc.go` gains the provider × endpoint × credential × recipe table (openai native/Azure-Entra/Azure-key, anthropic native/Vertex, gemini native/Vertex), each row backed by a request-shape test (the Vertex and injected-transport rows were already pinned by the existing `TestGenerateVertexAI` / `TestGenerateWithInjectedAuthTransport` suites; this PR adds the missing Azure-key row). `llmauth`'s package doc mirrors the pointer and states the caching contract. Each provider example shows its cloud-credential recipe (as comments — `core` cannot import `server/llmauth` per the module DAG).

## Tests

- `TestCachedTokenCredential` (`-race`): 16 concurrent cold-start requests → **exactly 1** `GetToken`, every waiter sharing the token; repeated fresh calls served from cache; aging past the margin → exactly 1 refresh; scripted failure under singleflight → all 8 waiters get the error, count stays 1, and the post-failure retry succeeds with exactly one new flight.
- `TestGoogleTransport_ReusesToken`: 5 requests → 1 underlying token fetch through `ReuseTokenSource`.
- `TestGenerateAzureAPIKeyHeader`: the new matrix row's exact URL + header shape.

Non-goals unchanged: no new credential types, no token-acquisition retry beyond coalescing (transient AAD failures surface; #852 classifies the resulting 401s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)