### PR TITLE
chore(release): bump module pins for cascade #10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.5.0
-	github.com/anaregdesign/lantern/core v0.14.1
+	github.com/anaregdesign/lantern/core v0.15.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
-	github.com/anaregdesign/lantern/pb v0.9.0
-	github.com/anaregdesign/lantern/sdks/go v0.20.0
+	github.com/anaregdesign/lantern/pb v0.10.0
+	github.com/anaregdesign/lantern/sdks/go v0.21.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -3,15 +3,15 @@ module github.com/anaregdesign/lantern/mcp
 go 1.26
 
 require (
-	github.com/anaregdesign/lantern/pb v0.9.0
-	github.com/anaregdesign/lantern/sdks/go v0.20.0
+	github.com/anaregdesign/lantern/pb v0.10.0
+	github.com/anaregdesign/lantern/sdks/go v0.21.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	google.golang.org/protobuf v1.36.11
 )
 
 require (
 	connectrpc.com/connect v1.20.0 // indirect
-	github.com/anaregdesign/lantern/core v0.14.1 // indirect
+	github.com/anaregdesign/lantern/core v0.15.0 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -4,8 +4,8 @@ go 1.26
 
 require (
 	connectrpc.com/connect v1.20.0
-	github.com/anaregdesign/lantern/core v0.14.1
-	github.com/anaregdesign/lantern/pb v0.9.0
+	github.com/anaregdesign/lantern/core v0.15.0
+	github.com/anaregdesign/lantern/pb v0.10.0
 	golang.org/x/net v0.56.0
 	google.golang.org/protobuf v1.36.11
 )

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lantern-sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Official TypeScript client SDK for Lantern — an in-memory graph KVS, over Connect (HTTP/2).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Release-prep pin bump, same shape as cascade #9 (#808):

- `pb` v0.9.0 → **v0.10.0** — breaking Illuminate params oneof (#846) + `LocalCommunityParams` (#845)
- `core` v0.14.1 → **v0.15.0** — scan paging (#836), dict refcounts (#837), traversal counters (#838), GC memo (#839), batch HLC returns (#840), SearchTopK (#841), snapshot RLock (#843), local community (#845), llm error taxonomy (#852) + gemini allowlist (#853) + Azure key header (#854)
- `sdks/go` v0.20.0 → **v0.21.0** — typed Illuminate families (#846), WithAuthToken (#850), retry policy (#849)
- `sdks/node` 0.7.0 → **0.8.0** — typed illuminate options (#846/#845), token option (#850)

All pins are replace-backed locally (workspace); the versions are metadata for downstream `go get` consumers. Tags follow on the merged SHA in the documented order: `pb/v0.10.0` → `core/v0.15.0` → `sdks/go/v0.21.0` → `v0.27.0` → `mcp/v0.10.0` / `sdks/node/v0.8.0` / `admin/v0.14.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)