### PR TITLE
feat(core/search): script-aware analyzer — word tokens for space-delimited scripts, bigrams for CJK

### DIFF
--- a/core/graphcache/search.go
+++ b/core/graphcache/search.go
@@ -7,28 +7,26 @@ import (
 )
 
 // newSearchIndex builds the inverted index used by the optional content-search
-// feature. It installs the multilingual bigram pipeline documented in
-// core/search/example as the best general-purpose setup: width / diacritic /
-// lowercase / punctuation / space normalizers feed an NGramTokenizer{N: 2}
-// whose grams keep two-character (e.g. CJK) words indexable while still
-// matching infixes, and a single WhitespaceFilter drops the grams that straddle
-// a word boundary. Matches are ranked by Okapi BM25 with the standard
-// parameters. The same analyzer runs over both stored values and queries, so
-// index-time and query-time terms stay symmetric.
+// feature. Since #888 it installs the script-aware dual-channel pipeline
+// (search.NewScriptAwareAnalyzer): width / diacritic / lowercase / punctuation
+// / space normalizers feed a ScriptAwareTokenizer whose word runs index whole
+// words (primary) plus intra-word bigrams (auxiliary, for infix and typo
+// recall) and whose unbounded-script (CJK-like) runs index bigrams as the
+// word-level unit. Matches are ranked by Okapi BM25 with the standard
+// parameters, wrapped in ClassWeighted so auxiliary gram evidence counts at
+// DefaultGramWeight and a whole-word match dominates fragment matches. The
+// same analyzer runs over both stored values and queries, so index-time and
+// query-time terms stay symmetric.
+//
+// The relevance gate (core/search/relevance, parity_gate_test.go) replicates
+// exactly this pipeline and ratchets its measured metrics against the pinned
+// Lucene baseline — change the two in lockstep.
 func newSearchIndex[S comparable]() *search.InvertedIndex[S, search.Document] {
-	normalizers := []search.Normalizer{
-		search.WidthNormalizer{},
-		search.DiacriticNormalizer{},
-		search.LowercaseNormalizer{},
-		search.PunctuationNormalizer{},
-		search.SpaceNormalizer{},
+	analyzer := search.NewScriptAwareAnalyzer()
+	scorer := search.ClassWeighted{
+		Base:       search.BM25{K1: search.DefaultBM25K1, B: search.DefaultBM25B},
+		GramWeight: search.DefaultGramWeight,
 	}
-	analyzer := search.NewAnalyzer(
-		normalizers,
-		search.NGramTokenizer{N: 2},
-		[]search.TokenFilter{search.WhitespaceFilter{}},
-	)
-	scorer := search.BM25{K1: 1.2, B: 0.75}
 	return search.NewInvertedIndex[S, search.Document](analyzer, scorer)
 }
 

--- a/core/search/analyzer.go
+++ b/core/search/analyzer.go
@@ -58,6 +58,32 @@ func NewNGramAnalyzer(n int) Analyzer {
 	return NewAnalyzer([]Normalizer{LowercaseNormalizer{}}, NGramTokenizer{N: n}, nil)
 }
 
+// NewScriptAwareAnalyzer returns the production analyzer for mixed-script
+// content search (#888): the full folding pipeline — width, diacritic,
+// lowercase, punctuation, and space normalizers — feeding a
+// ScriptAwareTokenizer at N = 2. Space-delimited scripts index whole words as
+// primary tokens plus intra-word bigrams as auxiliary tokens, and unbounded
+// (CJK-like) scripts index bigrams as primary tokens, so one analyzer serves
+// word-precise ranking for languages with word boundaries and Lucene
+// CJKAnalyzer-style recall for those without. Pair the index with a
+// ClassWeighted scorer so the auxiliary grams keep infix and typo recall
+// without outranking whole-word matches. No token filter is needed: the
+// tokenizer already drops delimiters and never emits a gram across a word
+// boundary.
+func NewScriptAwareAnalyzer() Analyzer {
+	return NewAnalyzer(
+		[]Normalizer{
+			WidthNormalizer{},
+			DiacriticNormalizer{},
+			LowercaseNormalizer{},
+			PunctuationNormalizer{},
+			SpaceNormalizer{},
+		},
+		ScriptAwareTokenizer{N: 2},
+		nil,
+	)
+}
+
 // Analyze runs text through the normalizers, tokenizer, and filter chain.
 func (a *pipelineAnalyzer) Analyze(text string) []Token {
 	for _, n := range a.normalizers {

--- a/core/search/analyzer_test.go
+++ b/core/search/analyzer_test.go
@@ -72,3 +72,54 @@ func TestAnalyzerFunc(t *testing.T) {
 		t.Fatalf("Analyze = %v, want [x]", got)
 	}
 }
+
+func TestNewScriptAwareAnalyzer(t *testing.T) {
+	a := NewScriptAwareAnalyzer()
+
+	t.Run("FoldsWidthDiacriticsCaseAndPunctuation", func(t *testing.T) {
+		// Full-width "ＴＯＫＹＯ!" folds to "tokyo" with the "!" becoming a
+		// boundary, then tokenizes as one word plus its auxiliary bigrams.
+		got := a.Analyze("ＴＯＫＹＯ! Café")
+		want := []Token{
+			{Term: "tokyo", Class: ClassWord},
+			{Term: "to", Class: ClassGram},
+			{Term: "ok", Class: ClassGram},
+			{Term: "ky", Class: ClassGram},
+			{Term: "yo", Class: ClassGram},
+			{Term: "cafe", Class: ClassWord},
+			{Term: "ca", Class: ClassGram},
+			{Term: "af", Class: ClassGram},
+			{Term: "fe", Class: ClassGram},
+		}
+		if !tokensEqual(got, want) {
+			t.Fatalf("Analyze = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("HalfWidthKatakanaJoinsKatakanaRun", func(t *testing.T) {
+		// WidthNormalizer runs before tokenization, so ﾗｰﾒﾝ folds to ラーメン
+		// and bigrams as one run.
+		got := a.Analyze("ﾗｰﾒﾝ")
+		want := []Token{
+			{Term: "ラー", Class: ClassWord},
+			{Term: "ーメ", Class: ClassWord},
+			{Term: "メン", Class: ClassWord},
+		}
+		if !tokensEqual(got, want) {
+			t.Fatalf("Analyze = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("NoTokenBridgesAWordBoundary", func(t *testing.T) {
+		for _, tok := range a.Analyze("data set 東京 タワー") {
+			if len(tok.Term) == 0 {
+				t.Fatal("empty term emitted")
+			}
+			for _, r := range tok.Term {
+				if r == ' ' {
+					t.Fatalf("token %q bridges a word boundary", tok.Term)
+				}
+			}
+		}
+	})
+}

--- a/core/search/example/main.go
+++ b/core/search/example/main.go
@@ -17,11 +17,15 @@ func main() {
 	log.SetFlags(0)
 
 	// An InvertedIndex is the default Indexer + Searcher. The Analyzer below is
-	// the *highest-quality general-purpose setup for n-gram search* — the lineup
-	// of normalizers and the single filter that, with NGramTokenizer{N: 2}, give
-	// the best recall and precision when one index must serve *many languages*
-	// and still match *infixes* (a query found inside a longer word, which a
-	// word-splitting tokenizer can never surface). Four stages:
+	// the *highest-quality setup for pure n-gram search* — the lineup of
+	// normalizers and the single filter that, with NGramTokenizer{N: 2}, give
+	// the best recall and precision when every match must come from grams:
+	// one index serving *many languages* and still matching *infixes* (a query
+	// found inside a longer word). Since #888 production content search goes
+	// one step further — NewScriptAwareAnalyzer indexes whole words alongside
+	// these grams so a whole-word match outranks a fragment; this example
+	// stays on the single-channel pipeline because it is the clearest way to
+	// see each analysis stage at work. Four stages:
 	//   1. Normalizers clean and fold the raw text before tokenization, and their
 	//      order matters — each step assumes the earlier ones ran. This weighs on
 	//      n-grams more than on word tokens: NGramTokenizer slides its window over

--- a/core/search/filter.go
+++ b/core/search/filter.go
@@ -48,7 +48,7 @@ func (PunctuationFilter) Filter(tokens []Token) []Token {
 		if trimmed == "" {
 			continue
 		}
-		out = append(out, Token{Term: trimmed})
+		out = append(out, Token{Term: trimmed, Class: t.Class})
 	}
 	return out
 }

--- a/core/search/filter_test.go
+++ b/core/search/filter_test.go
@@ -3,14 +3,14 @@ package search
 import "testing"
 
 func TestLowercaseFilter(t *testing.T) {
-	got := termsOf(LowercaseFilter{}.Filter([]Token{{"Foo"}, {"BAR"}, {"baz"}}))
+	got := termsOf(LowercaseFilter{}.Filter([]Token{{Term: "Foo"}, {Term: "BAR"}, {Term: "baz"}}))
 	if !equalStrings(got, []string{"foo", "bar", "baz"}) {
 		t.Fatalf("Filter = %v", got)
 	}
 }
 
 func TestPunctuationFilter(t *testing.T) {
-	in := []Token{{"hello,"}, {"!!!"}, {"node-1."}, {"(world)"}}
+	in := []Token{{Term: "hello,"}, {Term: "!!!"}, {Term: "node-1."}, {Term: "(world)"}}
 	got := termsOf(PunctuationFilter{}.Filter(in))
 	want := []string{"hello", "node-1", "world"}
 	if !equalStrings(got, want) {
@@ -19,20 +19,20 @@ func TestPunctuationFilter(t *testing.T) {
 }
 
 func TestEmptyTokenFilter(t *testing.T) {
-	got := termsOf(EmptyTokenFilter{}.Filter([]Token{{"a"}, {""}, {"  "}, {"b"}}))
+	got := termsOf(EmptyTokenFilter{}.Filter([]Token{{Term: "a"}, {Term: ""}, {Term: "  "}, {Term: "b"}}))
 	if !equalStrings(got, []string{"a", "b"}) {
 		t.Fatalf("Filter = %v, want [a b]", got)
 	}
 }
 
 func TestLengthFilter(t *testing.T) {
-	in := []Token{{"a"}, {"ab"}, {"abcd"}, {"abcde"}}
+	in := []Token{{Term: "a"}, {Term: "ab"}, {Term: "abcd"}, {Term: "abcde"}}
 	got := termsOf(LengthFilter{Min: 2, Max: 4}.Filter(in))
 	if !equalStrings(got, []string{"ab", "abcd"}) {
 		t.Fatalf("Filter = %v, want [ab abcd]", got)
 	}
 	// Max 0 means no upper bound.
-	got = termsOf(LengthFilter{Min: 3}.Filter([]Token{{"hi"}, {"hey"}, {"hello"}}))
+	got = termsOf(LengthFilter{Min: 3}.Filter([]Token{{Term: "hi"}, {Term: "hey"}, {Term: "hello"}}))
 	if !equalStrings(got, []string{"hey", "hello"}) {
 		t.Fatalf("Filter = %v, want [hey hello]", got)
 	}
@@ -40,7 +40,7 @@ func TestLengthFilter(t *testing.T) {
 
 func TestStopWordFilter(t *testing.T) {
 	f := NewStopWordFilter("the", "is", "A")
-	got := termsOf(f.Filter([]Token{{"THE"}, {"cat"}, {"is"}, {"a"}, {"hat"}}))
+	got := termsOf(f.Filter([]Token{{Term: "THE"}, {Term: "cat"}, {Term: "is"}, {Term: "a"}, {Term: "hat"}}))
 	if !equalStrings(got, []string{"cat", "hat"}) {
 		t.Fatalf("Filter = %v, want [cat hat]", got)
 	}
@@ -49,7 +49,7 @@ func TestStopWordFilter(t *testing.T) {
 func TestWhitespaceFilter(t *testing.T) {
 	// Cross-boundary grams (those holding a space) are dropped; intra-word grams
 	// and space-free tokens survive, regardless of which whitespace rune appears.
-	in := []Token{{"sea"}, {"a g"}, {"gia"}, {"t\tp"}, {"ねこ"}, {" x"}, {"y "}, {"ok"}}
+	in := []Token{{Term: "sea"}, {Term: "a g"}, {Term: "gia"}, {Term: "t\tp"}, {Term: "ねこ"}, {Term: " x"}, {Term: "y "}, {Term: "ok"}}
 	got := termsOf(WhitespaceFilter{}.Filter(in))
 	want := []string{"sea", "gia", "ねこ", "ok"}
 	if !equalStrings(got, want) {
@@ -57,7 +57,7 @@ func TestWhitespaceFilter(t *testing.T) {
 	}
 	// A token written without spaces (CJK) is never touched: no-op for scripts
 	// that do not separate words with whitespace.
-	got = termsOf(WhitespaceFilter{}.Filter([]Token{{"東京"}, {"京都"}}))
+	got = termsOf(WhitespaceFilter{}.Filter([]Token{{Term: "東京"}, {Term: "京都"}}))
 	if !equalStrings(got, []string{"東京", "京都"}) {
 		t.Fatalf("Filter = %v, want [東京 京都]", got)
 	}
@@ -65,7 +65,7 @@ func TestWhitespaceFilter(t *testing.T) {
 
 func TestTokenFilterFunc(t *testing.T) {
 	var f TokenFilter = TokenFilterFunc(func(ts []Token) []Token { return ts[:0] })
-	if got := f.Filter([]Token{{"a"}}); len(got) != 0 {
+	if got := f.Filter([]Token{{Term: "a"}}); len(got) != 0 {
 		t.Fatalf("Filter = %v, want empty", got)
 	}
 }

--- a/core/search/helpers_test.go
+++ b/core/search/helpers_test.go
@@ -33,3 +33,24 @@ func idsOf[S comparable](results []Result[S]) []S {
 	}
 	return out
 }
+
+// postingsCount sums the live posting lists across the index's token classes,
+// so reclamation tests can assert "everything released" without caring which
+// channel a term lived on.
+func postingsCount[S comparable, D Document](idx *InvertedIndex[S, D]) int {
+	n := 0
+	for class := range idx.classes {
+		n += len(idx.classes[class].postings)
+	}
+	return n
+}
+
+// totalLenSum sums the per-class document-length totals, the cross-class
+// equivalent of the old single totalLen counter.
+func totalLenSum[S comparable, D Document](idx *InvertedIndex[S, D]) int {
+	n := 0
+	for class := range idx.classes {
+		n += idx.classes[class].totalLen
+	}
+	return n
+}

--- a/core/search/inverted_index.go
+++ b/core/search/inverted_index.go
@@ -18,6 +18,13 @@ import (
 // statistics into the ranking. Search returns hits ordered by descending
 // score.
 //
+// Terms live in per-class tables (#888): each TokenClass has its own term
+// dictionary, postings, and corpus statistics, so a dual-channel analyzer
+// (ScriptAwareTokenizer's whole words + auxiliary intra-word grams) never
+// mixes the two channels' document frequencies or lengths, and a class-aware
+// Scorer (ClassWeighted) can weight them apart. A single-channel pipeline
+// simply leaves the other class empty at zero cost.
+//
 // InvertedIndex is safe for concurrent use by multiple goroutines: reads
 // (Search) take a shared lock and writes (Index, Delete) take an exclusive
 // one, and text analysis runs outside the lock to keep the critical section
@@ -27,25 +34,39 @@ type InvertedIndex[S comparable, D Document] struct {
 	scorer   Scorer
 
 	mu sync.RWMutex
-	// dict assigns each distinct term a compact uint32 id so postings and the
-	// per-document forward lists key on the id instead of repeating the term
-	// string; the term itself is stored exactly once, in the dictionary.
-	dict *termDict
+	// classes holds one posting table per token class; a term's class is part
+	// of its identity, so the same spelling on two channels never collides.
+	classes [numTokenClasses]classPostings
 	// ords assigns each distinct document a compact uint32 ordinal so postings
 	// address documents by integer (a Roaring bitmap member) instead of
 	// repeating the caller's id (typically a string vertex key) in every posting
 	// the document appears in.
 	ords *ordinals[S]
-	// postings is the inverted index proper: term id -> the document ordinals
-	// carrying the term and their frequencies. Search reads it; the per-document
-	// frequency is what the Scorer needs to weight a match.
-	postings map[uint32]*postingList
-	// docs is the forward index: document ordinal -> the id, length, and term ids
-	// needed to score, return, and drop the document in O(terms-in-doc).
+	// docs is the forward index: document ordinal -> the id, per-class lengths,
+	// and term ids needed to score, return, and drop the document in
+	// O(terms-in-doc).
 	docs map[uint32]docEntry[S]
-	// totalLen is the sum of every document's length, so the mean document
-	// length (for length normalization) is totalLen/len(docs) without a scan.
+}
+
+// classPostings is one token class's slice of the index: its term dictionary,
+// its postings, and the class-scoped corpus statistics BM25 length
+// normalization and IDF need. Keeping them per class is what stops auxiliary
+// gram evidence from inflating the word channel's document lengths (and vice
+// versa) when one document feeds both channels.
+type classPostings struct {
+	// dict assigns each distinct term of this class a compact uint32 id so
+	// postings and the per-document forward lists key on the id instead of
+	// repeating the term string; the term itself is stored exactly once.
+	dict *termDict
+	// postings is the inverted index proper: term id -> the document ordinals
+	// carrying the term and their frequencies.
+	postings map[uint32]*postingList
+	// totalLen is the sum of this class's per-document token counts, so the
+	// class's mean document length is totalLen/docCount without a scan.
 	totalLen int
+	// docCount is how many documents carry at least one token of this class —
+	// the class's corpus size, the N of its TermStats.
+	docCount int
 }
 
 // docEntry is the forward-index entry recorded for each indexed document, keyed
@@ -54,13 +75,15 @@ type docEntry[S comparable] struct {
 	// id is the caller's document identifier, returned in search results and used
 	// to resolve a delete (id -> ordinal -> entry).
 	id S
-	// length is the document's size in tokens, repeats included — the |d| that
-	// length normalization compares against the corpus average.
-	length int
+	// lengths is the document's size in tokens per class, repeats included —
+	// the |d| that each class's length normalization compares against the
+	// class average.
+	lengths [numTokenClasses]int
 	// terms is the de-duplicated list of distinct term ids the document was
-	// indexed under (see termDict), used to drop its postings on delete or
-	// re-index. A []uint32 keeps the per-document forward index compact.
-	terms []uint32
+	// indexed under, per class (see termDict), used to drop its postings on
+	// delete or re-index. A []uint32 keeps the per-document forward index
+	// compact.
+	terms [numTokenClasses][]uint32
 }
 
 // NewInvertedIndex returns an empty index that analyzes both documents and
@@ -71,14 +94,19 @@ func NewInvertedIndex[S comparable, D Document](analyzer Analyzer, scorer Scorer
 	if scorer == nil {
 		scorer = BM25{K1: DefaultBM25K1, B: DefaultBM25B}
 	}
-	return &InvertedIndex[S, D]{
+	idx := &InvertedIndex[S, D]{
 		analyzer: analyzer,
 		scorer:   scorer,
-		dict:     newTermDict(),
 		ords:     newOrdinals[S](),
-		postings: make(map[uint32]*postingList),
 		docs:     make(map[uint32]docEntry[S]),
 	}
+	for class := range idx.classes {
+		idx.classes[class] = classPostings{
+			dict:     newTermDict(),
+			postings: make(map[uint32]*postingList),
+		}
+	}
+	return idx
 }
 
 // Index makes id discoverable under every term the Analyzer extracts from
@@ -146,7 +174,8 @@ func (idx *InvertedIndex[S, D]) IndexManyPrepared(items []PreparedItem[S]) {
 }
 
 // indexPreparedLocked is the shared postings-mutation core of IndexPrepared and
-// IndexManyPrepared; callers must hold idx.mu for writing.
+// IndexManyPrepared; callers must hold idx.mu for writing. A token with an
+// undefined class panics: that is a broken analyzer, not a malformed document.
 func (idx *InvertedIndex[S, D]) indexPreparedLocked(id S, tokens []Token) {
 	// Replace semantics: drop any postings from a previous Index(id, ...)
 	// before recording the new ones.
@@ -154,43 +183,57 @@ func (idx *InvertedIndex[S, D]) indexPreparedLocked(id S, tokens []Token) {
 	if len(tokens) == 0 {
 		return
 	}
-	// Sort this document's terms so the distinct terms and their frequencies
-	// (the run length of each equal stretch) can be read in one linear pass.
-	// sorted is transient scratch; only the compact distinct-term slice is
-	// retained in docStats.
-	sorted := make([]string, len(tokens))
-	for i, token := range tokens {
-		sorted[i] = token.Term
-	}
-	sort.Strings(sorted)
-
-	// Count distinct terms up front so the retained forward-index slice is
-	// allocated at its exact length (no spare capacity held per document).
-	distinct := 1
-	for i := 1; i < len(sorted); i++ {
-		if sorted[i] != sorted[i-1] {
-			distinct++
+	// Partition the document's terms by class; each class's postings and
+	// statistics are recorded independently. perClass slices are transient
+	// scratch; only the compact distinct-term slices are retained.
+	var perClass [numTokenClasses][]string
+	for _, token := range tokens {
+		if int(token.Class) >= numTokenClasses {
+			panic("search: token with undefined TokenClass")
 		}
+		perClass[token.Class] = append(perClass[token.Class], token.Term)
 	}
 	ord := idx.ords.assign(id)
-	terms := make([]uint32, 0, distinct)
-	for i := 0; i < len(sorted); {
-		j := i + 1
-		for j < len(sorted) && sorted[j] == sorted[i] {
-			j++
+	entry := docEntry[S]{id: id}
+	for class, sorted := range perClass {
+		if len(sorted) == 0 {
+			continue
 		}
-		tid := idx.dict.intern(sorted[i])
-		pl, ok := idx.postings[tid]
-		if !ok {
-			pl = newPostingList()
-			idx.postings[tid] = pl
+		// Sort this class's terms so the distinct terms and their frequencies
+		// (the run length of each equal stretch) can be read in one linear pass.
+		sort.Strings(sorted)
+
+		// Count distinct terms up front so the retained forward-index slice is
+		// allocated at its exact length (no spare capacity held per document).
+		distinct := 1
+		for i := 1; i < len(sorted); i++ {
+			if sorted[i] != sorted[i-1] {
+				distinct++
+			}
 		}
-		pl.set(ord, j-i) // term frequency = run length of this term
-		terms = append(terms, tid)
-		i = j
+		cp := &idx.classes[class]
+		terms := make([]uint32, 0, distinct)
+		for i := 0; i < len(sorted); {
+			j := i + 1
+			for j < len(sorted) && sorted[j] == sorted[i] {
+				j++
+			}
+			tid := cp.dict.intern(sorted[i])
+			pl, ok := cp.postings[tid]
+			if !ok {
+				pl = newPostingList()
+				cp.postings[tid] = pl
+			}
+			pl.set(ord, j-i) // term frequency = run length of this term
+			terms = append(terms, tid)
+			i = j
+		}
+		entry.lengths[class] = len(sorted)
+		entry.terms[class] = terms
+		cp.totalLen += len(sorted)
+		cp.docCount++
 	}
-	idx.docs[ord] = docEntry[S]{id: id, length: len(tokens), terms: terms}
-	idx.totalLen += len(tokens)
+	idx.docs[ord] = entry
 }
 
 // Delete removes id and all of its postings from the index. It is a no-op when
@@ -227,13 +270,19 @@ func (idx *InvertedIndex[S, D]) deleteLocked(id S) {
 		return
 	}
 	entry := idx.docs[ord]
-	for _, tid := range entry.terms {
-		if idx.postings[tid].remove(ord) {
-			delete(idx.postings, tid)
-			idx.dict.release(tid)
+	for class := range entry.terms {
+		cp := &idx.classes[class]
+		for _, tid := range entry.terms[class] {
+			if cp.postings[tid].remove(ord) {
+				delete(cp.postings, tid)
+				cp.dict.release(tid)
+			}
+		}
+		if entry.lengths[class] > 0 {
+			cp.totalLen -= entry.lengths[class]
+			cp.docCount--
 		}
 	}
-	idx.totalLen -= entry.length
 	delete(idx.docs, ord)
 	idx.ords.release(id, ord)
 }
@@ -243,52 +292,20 @@ func (idx *InvertedIndex[S, D]) deleteLocked(id S) {
 // relevant. The set of matches is the union (OR) of the query's terms, which
 // maximizes recall for seeding a wider traversal, while the Scorer (BM25 by
 // default) ranks that set so the strongest seeds come first. A term repeated
-// in the query weights a document only once. A query with no analyzable terms,
-// or one that matches nothing, returns nil; ties in score have an unspecified
-// order.
+// in the query weights a document only once; the same spelling on two token
+// classes counts once per class, since the channels carry distinct evidence.
+// A query with no analyzable terms, or one that matches nothing, returns nil;
+// ties in score have an unspecified order.
 func (idx *InvertedIndex[S, D]) Search(query string) []Result[S] {
-	tokens := idx.analyzer.Analyze(query)
-	if len(tokens) == 0 {
+	queryTerms := idx.queryTerms(query)
+	if len(queryTerms) == 0 {
 		return nil
-	}
-	// Collapse the query to its distinct terms so a term repeated in the query
-	// contributes a document's weight once, matching the boolean union.
-	queryTerms := make(map[string]struct{}, len(tokens))
-	for _, token := range tokens {
-		queryTerms[token.Term] = struct{}{}
 	}
 
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
 
-	n := len(idx.docs)
-	if n == 0 {
-		return nil
-	}
-	avgLen := float64(idx.totalLen) / float64(n)
-
-	scores := make(map[uint32]float64)
-	for term := range queryTerms {
-		tid, ok := idx.dict.lookup(term)
-		if !ok {
-			continue
-		}
-		pl, ok := idx.postings[tid]
-		if !ok {
-			continue
-		}
-		df := pl.cardinality()
-		for it := pl.docs.Iterator(); it.HasNext(); {
-			ord := it.Next()
-			scores[ord] += idx.scorer.Score(TermStats{
-				TF:     pl.tf(ord),
-				DF:     df,
-				N:      n,
-				DocLen: idx.docs[ord].length,
-				AvgLen: avgLen,
-			})
-		}
-	}
+	scores := idx.scoreLocked(queryTerms)
 	if len(scores) == 0 {
 		return nil
 	}
@@ -303,10 +320,64 @@ func (idx *InvertedIndex[S, D]) Search(query string) []Result[S] {
 	return results
 }
 
+// queryTerms analyzes query and collapses the tokens to the distinct
+// (class, term) set, so a term repeated in the query contributes a document's
+// weight once per channel, matching the boolean union.
+func (idx *InvertedIndex[S, D]) queryTerms(query string) map[Token]struct{} {
+	tokens := idx.analyzer.Analyze(query)
+	if len(tokens) == 0 {
+		return nil
+	}
+	queryTerms := make(map[Token]struct{}, len(tokens))
+	for _, token := range tokens {
+		queryTerms[token] = struct{}{}
+	}
+	return queryTerms
+}
+
+// scoreLocked computes the OR-union score map for a distinct query-term set;
+// callers must hold idx.mu (read or write). A query token with an undefined
+// class matches nothing — the write side panics on such tokens, so no posting
+// can exist for one.
+func (idx *InvertedIndex[S, D]) scoreLocked(queryTerms map[Token]struct{}) map[uint32]float64 {
+	scores := make(map[uint32]float64)
+	for token := range queryTerms {
+		if int(token.Class) >= numTokenClasses {
+			continue
+		}
+		cp := &idx.classes[token.Class]
+		if cp.docCount == 0 {
+			continue
+		}
+		tid, ok := cp.dict.lookup(token.Term)
+		if !ok {
+			continue
+		}
+		pl, ok := cp.postings[tid]
+		if !ok {
+			continue
+		}
+		df := pl.cardinality()
+		avgLen := float64(cp.totalLen) / float64(cp.docCount)
+		for it := pl.docs.Iterator(); it.HasNext(); {
+			ord := it.Next()
+			scores[ord] += idx.scorer.Score(TermStats{
+				TF:     pl.tf(ord),
+				DF:     df,
+				N:      cp.docCount,
+				DocLen: idx.docs[ord].lengths[token.Class],
+				AvgLen: avgLen,
+				Class:  token.Class,
+			})
+		}
+	}
+	return scores
+}
+
 // SearchTopK is the bounded-selection sibling of Search (#841): it computes
 // the same OR-union BM25 scores but returns only the k highest-scoring
 // documents that satisfy accept, without materialising or fully sorting the
-// complete match set. With the bigram analyzer a short query can match most
+// complete match set. With a bigram analyzer a short query can match most
 // of the corpus, so Search's O(M log M) sort over all M matches dominates
 // broad queries; SearchTopK selects with a size-k bounded heap in
 // O(M log k) time and O(k) result memory instead.
@@ -332,49 +403,18 @@ func (idx *InvertedIndex[S, D]) SearchTopK(query string, k int, accept func(id S
 	if k <= 0 {
 		return nil
 	}
-	tokens := idx.analyzer.Analyze(query)
-	if len(tokens) == 0 {
+	queryTerms := idx.queryTerms(query)
+	if len(queryTerms) == 0 {
 		return nil
-	}
-	queryTerms := make(map[string]struct{}, len(tokens))
-	for _, token := range tokens {
-		queryTerms[token.Term] = struct{}{}
 	}
 
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
 
-	n := len(idx.docs)
-	if n == 0 {
-		return nil
-	}
-	avgLen := float64(idx.totalLen) / float64(n)
-
 	// Phase 1 — identical union scoring to Search: every matching document's
 	// full score must exist before selection, because a document's rank is
 	// the SUM over query terms.
-	scores := make(map[uint32]float64)
-	for term := range queryTerms {
-		tid, ok := idx.dict.lookup(term)
-		if !ok {
-			continue
-		}
-		pl, ok := idx.postings[tid]
-		if !ok {
-			continue
-		}
-		df := pl.cardinality()
-		for it := pl.docs.Iterator(); it.HasNext(); {
-			ord := it.Next()
-			scores[ord] += idx.scorer.Score(TermStats{
-				TF:     pl.tf(ord),
-				DF:     df,
-				N:      n,
-				DocLen: idx.docs[ord].length,
-				AvgLen: avgLen,
-			})
-		}
-	}
+	scores := idx.scoreLocked(queryTerms)
 	if len(scores) == 0 {
 		return nil
 	}
@@ -425,15 +465,18 @@ func (h *topKHeap[S]) Pop() any {
 	return x
 }
 
-// Stats returns the current number of distinct terms in the posting list and
-// the number of indexed documents. The counts are approximate under concurrent
-// load (a concurrent Index or Delete may be in progress), but are accurate
-// enough for a Prometheus gauge sampled on a regular cadence. The call does
-// not block writers.
+// Stats returns the current number of distinct terms in the posting lists
+// (summed across token classes) and the number of indexed documents. The
+// counts are approximate under concurrent load (a concurrent Index or Delete
+// may be in progress), but are accurate enough for a Prometheus gauge sampled
+// on a regular cadence. The call does not block writers.
 func (idx *InvertedIndex[S, D]) Stats() (terms, docs int) {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
-	return len(idx.postings), len(idx.docs)
+	for class := range idx.classes {
+		terms += len(idx.classes[class].postings)
+	}
+	return terms, len(idx.docs)
 }
 
 // Interface assertions: InvertedIndex is both an Indexer and a Searcher.

--- a/core/search/inverted_index_test.go
+++ b/core/search/inverted_index_test.go
@@ -80,14 +80,14 @@ func TestInvertedIndexDelete(t *testing.T) {
 	}
 	// Empty posting sets, forward entries, and the length total must be
 	// reclaimed, not leaked.
-	if len(idx.postings) != 0 {
-		t.Fatalf("postings not fully reclaimed: %v", idx.postings)
+	if n := postingsCount(idx); n != 0 {
+		t.Fatalf("postings not fully reclaimed: %d live terms", n)
 	}
 	if len(idx.docs) != 0 {
 		t.Fatalf("forward docs not fully reclaimed: %v", idx.docs)
 	}
-	if idx.totalLen != 0 {
-		t.Fatalf("totalLen not reset: %d", idx.totalLen)
+	if n := totalLenSum(idx); n != 0 {
+		t.Fatalf("totalLen not reset: %d", n)
 	}
 }
 
@@ -121,14 +121,14 @@ func TestInvertedIndexDeleteMany(t *testing.T) {
 
 	// Removing the last remaining doc empties every internal map.
 	idx.DeleteMany([]string{"doc2"})
-	if len(idx.postings) != 0 {
-		t.Fatalf("postings not fully reclaimed: %v", idx.postings)
+	if n := postingsCount(idx); n != 0 {
+		t.Fatalf("postings not fully reclaimed: %d live terms", n)
 	}
 	if len(idx.docs) != 0 {
 		t.Fatalf("forward docs not fully reclaimed: %v", idx.docs)
 	}
-	if idx.totalLen != 0 {
-		t.Fatalf("totalLen not reset: %d", idx.totalLen)
+	if n := totalLenSum(idx); n != 0 {
+		t.Fatalf("totalLen not reset: %d", n)
 	}
 }
 
@@ -153,8 +153,8 @@ func TestInvertedIndexReindexReplaces(t *testing.T) {
 	if got := idx.Search("gamma"); got != nil {
 		t.Fatalf(`Search("gamma") after empty re-index = %v, want nil`, got)
 	}
-	if idx.totalLen != 0 {
-		t.Fatalf("totalLen not reset after removing last doc: %d", idx.totalLen)
+	if n := totalLenSum(idx); n != 0 {
+		t.Fatalf("totalLen not reset after removing last doc: %d", n)
 	}
 }
 
@@ -523,6 +523,88 @@ func BenchmarkSearchTopKBroadQuery(b *testing.B) {
 			if got := idx.Search("alpha"); len(got) < 10 {
 				b.Fatalf("len=%d", len(got))
 			}
+		}
+	})
+}
+
+// TestInvertedIndexDualClass covers the per-class posting tables (#888): the
+// two channels keep separate statistics and identities, a class-aware scorer
+// ranks whole-word evidence above fragment evidence, and deletes reclaim both
+// channels.
+func TestInvertedIndexDualClass(t *testing.T) {
+	newIdx := func() *InvertedIndex[string, Text] {
+		return NewInvertedIndex[string, Text](
+			NewScriptAwareAnalyzer(),
+			ClassWeighted{Base: BM25{K1: DefaultBM25K1, B: DefaultBM25B}, GramWeight: DefaultGramWeight},
+		)
+	}
+
+	t.Run("whole word outranks infix fragment", func(t *testing.T) {
+		idx := newIdx()
+		idx.Index("exact", Text("a stone arch"))
+		idx.Index("infix", Text("full text search"))
+		idx.Index("infix2", Text("academic research"))
+		res := idx.Search("arch")
+		if len(res) != 3 {
+			t.Fatalf("Search(arch) returned %d results, want 3 (infix recall preserved)", len(res))
+		}
+		if res[0].ID != "exact" {
+			t.Fatalf("ranked %q first, want \"exact\" (word evidence dominates)", res[0].ID)
+		}
+	})
+
+	t.Run("same spelling on both channels does not collide", func(t *testing.T) {
+		// "se" exists as a whole word in doc1 and as an intra-word gram of
+		// "sea" in doc2. A word query for "se" must rank the word carrier
+		// first even though the gram channel also knows the spelling.
+		idx := newIdx()
+		idx.Index("word", Text("se"))
+		idx.Index("gram", Text("sea"))
+		res := idx.Search("se")
+		if len(res) == 0 || res[0].ID != "word" {
+			t.Fatalf("Search(se) = %+v, want \"word\" first", res)
+		}
+	})
+
+	t.Run("delete reclaims both channels", func(t *testing.T) {
+		idx := newIdx()
+		idx.Index("doc", Text("search 東京"))
+		idx.Delete("doc")
+		if n := postingsCount(idx); n != 0 {
+			t.Fatalf("postings not fully reclaimed: %d live terms", n)
+		}
+		if n := totalLenSum(idx); n != 0 {
+			t.Fatalf("totalLen not reset: %d", n)
+		}
+		for class := range idx.classes {
+			if idx.classes[class].docCount != 0 {
+				t.Fatalf("class %d docCount not reset: %d", class, idx.classes[class].docCount)
+			}
+		}
+	})
+
+	t.Run("undefined class panics on index", func(t *testing.T) {
+		bad := AnalyzerFunc(func(text string) []Token {
+			return []Token{{Term: text, Class: TokenClass(9)}}
+		})
+		idx := NewInvertedIndex[string, Text](bad, nil)
+		defer func() {
+			if recover() == nil {
+				t.Fatal("indexing an undefined TokenClass did not panic")
+			}
+		}()
+		idx.Index("doc", Text("boom"))
+	})
+
+	t.Run("cjk stays searchable alongside words", func(t *testing.T) {
+		idx := newIdx()
+		idx.Index("ja", Text("東京の醤油ラーメン"))
+		idx.Index("en", Text("tokyo ramen guide"))
+		if res := idx.Search("ラーメン"); len(res) != 1 || res[0].ID != "ja" {
+			t.Fatalf("Search(ラーメン) = %+v, want just ja", res)
+		}
+		if res := idx.Search("ramen"); len(res) != 1 || res[0].ID != "en" {
+			t.Fatalf("Search(ramen) = %+v, want just en", res)
 		}
 	})
 }

--- a/core/search/quality_gate_test.go
+++ b/core/search/quality_gate_test.go
@@ -382,3 +382,109 @@ func approxEqual(a, b float64) bool {
 	}
 	return d <= eps
 }
+
+// scriptAwareIndex builds a fresh index wired exactly like the production
+// content-search index since #888 (graphcache.newSearchIndex): the
+// script-aware dual-channel analyzer with class-weighted BM25.
+func scriptAwareIndex() *InvertedIndex[string, Text] {
+	return NewInvertedIndex[string, Text](
+		NewScriptAwareAnalyzer(),
+		ClassWeighted{Base: BM25{K1: DefaultBM25K1, B: DefaultBM25B}, GramWeight: DefaultGramWeight},
+	)
+}
+
+// TestSearchQualityGateScriptAware gates the #888 pipeline end to end on the
+// behaviors the dual-channel design promises beyond the bigram pipeline:
+// whole-word matches dominate infix fragments while infix recall survives,
+// single-character words become searchable, folding still applies, and CJK
+// behavior matches the bigram strategy it kept.
+func TestSearchQualityGateScriptAware(t *testing.T) {
+	cases := []struct {
+		name     string
+		docs     map[string]string
+		query    string
+		wantTop  string
+		wantHits []string
+	}{
+		{
+			// The bigram gate above pins "arch" ranking by fragment strength;
+			// here the whole word must win while fragments still surface.
+			name:     "WholeWordBeatsInfix",
+			docs:     map[string]string{"search": "Full-text search.", "research": "Academic  research", "arch": "A stone arch", "panda": "A giant panda"},
+			query:    "arch",
+			wantTop:  "arch",
+			wantHits: []string{"arch", "research", "search"},
+		},
+		{
+			name:     "SingleLetterWordSearchable",
+			docs:     map[string]string{"unit": "vitamin b complex", "other": "vitamin c serum"},
+			query:    "b",
+			wantTop:  "unit",
+			wantHits: []string{"unit"},
+		},
+		{
+			name:     "TypoStillRecalls",
+			docs:     map[string]string{"k8s": "kubernetes deployment guide", "cook": "carbonara recipe"},
+			query:    "kubernets",
+			wantTop:  "k8s",
+			wantHits: []string{"k8s"},
+		},
+		{
+			// kyoto also surfaces — "tokyo" and "kyoto" share the grams
+			// to/ky/yo on the auxiliary channel — but the whole-word match
+			// must stay on top.
+			name:     "WidthAndCaseFoldAcrossChannels",
+			docs:     map[string]string{"tokyo": "ＴＯＫＹＯ tower", "kyoto": "Kyoto station"},
+			query:    "tokyo",
+			wantTop:  "tokyo",
+			wantHits: []string{"kyoto", "tokyo"},
+		},
+		{
+			name:     "CJKBigramMatching",
+			docs:     map[string]string{"ramen": "東京の醤油ラーメン", "sushi": "銀座の寿司職人"},
+			query:    "ラーメン",
+			wantTop:  "ramen",
+			wantHits: []string{"ramen"},
+		},
+		{
+			name:     "LoneIdeographSearchable",
+			docs:     map[string]string{"noodle": "麺", "rice": "米"},
+			query:    "麺",
+			wantTop:  "noodle",
+			wantHits: []string{"noodle"},
+		},
+		{
+			// backup also surfaces — アップデート and バックアップ share the
+			// CJK grams アッ/ップ under the OR union — but the document
+			// matching both query halves must stay on top.
+			name:     "MixedScriptValue",
+			docs:     map[string]string{"deploy": "Kubernetesのローリングアップデート", "backup": "PostgreSQLのバックアップ"},
+			query:    "kubernetes アップデート",
+			wantTop:  "deploy",
+			wantHits: []string{"backup", "deploy"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			idx := scriptAwareIndex()
+			for id, text := range tc.docs {
+				idx.Index(id, Text(text))
+			}
+			results := idx.Search(tc.query)
+			if len(results) == 0 {
+				t.Fatalf("Search(%q) returned nothing", tc.query)
+			}
+			if results[0].ID != tc.wantTop {
+				t.Fatalf("Search(%q) top = %q, want %q (results %v)", tc.query, results[0].ID, tc.wantTop, results)
+			}
+			got := idsOf(results)
+			sort.Strings(got)
+			want := append([]string(nil), tc.wantHits...)
+			sort.Strings(want)
+			if !equalStrings(got, want) {
+				t.Fatalf("Search(%q) hits = %v, want %v", tc.query, got, want)
+			}
+		})
+	}
+}

--- a/core/search/relevance/parity_gate_test.go
+++ b/core/search/relevance/parity_gate_test.go
@@ -19,24 +19,19 @@ import (
 )
 
 // productionIndex replicates the exact index core/graphcache.newSearchIndex
-// builds for SearchVertices — the multilingual bigram pipeline plus BM25. It
-// is intentionally a replica, not an import: graphcache depends on search, so
-// this package (a sibling under search) states the pipeline explicitly, and
-// this comment plus the one on newSearchIndex keep the two in sync.
+// builds for SearchVertices — since #888 the script-aware dual-channel
+// analyzer with class-weighted BM25. It is intentionally a replica, not an
+// import: graphcache depends on search, so this package (a sibling under
+// search) states the pipeline explicitly, and this comment plus the one on
+// newSearchIndex keep the two in sync.
 func productionIndex() *search.InvertedIndex[string, search.Text] {
-	normalizers := []search.Normalizer{
-		search.WidthNormalizer{},
-		search.DiacriticNormalizer{},
-		search.LowercaseNormalizer{},
-		search.PunctuationNormalizer{},
-		search.SpaceNormalizer{},
-	}
-	analyzer := search.NewAnalyzer(
-		normalizers,
-		search.NGramTokenizer{N: 2},
-		[]search.TokenFilter{search.WhitespaceFilter{}},
+	return search.NewInvertedIndex[string, search.Text](
+		search.NewScriptAwareAnalyzer(),
+		search.ClassWeighted{
+			Base:       search.BM25{K1: search.DefaultBM25K1, B: search.DefaultBM25B},
+			GramWeight: search.DefaultGramWeight,
+		},
 	)
-	return search.NewInvertedIndex[string, search.Text](analyzer, search.BM25{K1: search.DefaultBM25K1, B: search.DefaultBM25B})
 }
 
 // productionFloors are the ratcheted minima per corpus, pinned from a measured
@@ -45,9 +40,15 @@ func productionIndex() *search.InvertedIndex[string, search.Text] {
 // breaks score ties deterministically, so these numbers are exact and stable;
 // any drop below a floor is a real ranking change, not jitter.
 var productionFloors = map[string]Metrics{
-	"en":    {NDCG10: 0.894, MRR: 0.980, Recall50: 0.958},
+	// Re-pinned for #888's script-aware pipeline. Versus the pure-bigram
+	// floors it replaced: en nDCG@10 0.894 -> 0.927 and MRR 0.980 -> 1.0
+	// (whole-word evidence now dominates fragments), en Recall@50 gave back
+	// 0.958 -> 0.951 (an accepted trade: still far above Lucene's 0.828),
+	// ja unchanged (the CJK path is the same bigram strategy), mixed nDCG@10
+	// 0.947 -> 0.953.
+	"en":    {NDCG10: 0.927, MRR: 1.000, Recall50: 0.951},
 	"ja":    {NDCG10: 0.911, MRR: 1.000, Recall50: 0.728},
-	"mixed": {NDCG10: 0.947, MRR: 1.000, Recall50: 0.777},
+	"mixed": {NDCG10: 0.953, MRR: 1.000, Recall50: 0.777},
 }
 
 func TestProductionPipelineRelevanceFloors(t *testing.T) {
@@ -81,9 +82,11 @@ func TestProductionPipelineRelevanceFloors(t *testing.T) {
 
 // TestLuceneBaselineComparison replays the pinned Lucene rankings (produced
 // offline by testbed/lucene-baseline; CI never runs a JVM) through the same
-// metric functions and logs Lantern's delta per corpus. It reports rather than
-// asserts: the epic's definition of done (#886) — Lantern >= Lucene on every
-// corpus — becomes an assertion only once the gap-closing issues land.
+// metric functions and ASSERTS the epic's definition of done (#886): the
+// production pipeline scores at least as high as every pinned Lucene run on
+// every metric of every corpus. #888 (script-aware analyzer) is what made
+// this hold; keeping it as an assertion means later ranking work (#889,
+// #890, #891) may reshuffle results but never below Lucene.
 func TestLuceneBaselineComparison(t *testing.T) {
 	runs, err := LoadBaselineRuns(BaselineRunsFile)
 	if os.IsNotExist(err) {
@@ -123,6 +126,20 @@ func TestLuceneBaselineComparison(t *testing.T) {
 				run.Corpus, runs.Engine, run.Analyzer,
 				lucene.NDCG10, lucene.MRR, lucene.Recall50,
 				lantern.NDCG10, lantern.MRR, lantern.Recall50)
+
+			// Both sides are deterministic; the epsilon only forgives the
+			// float-summation ULPs of a legitimate exact tie (ja matches
+			// Lucene's CJK bigrams ranking-for-ranking).
+			const eps = 1e-9
+			if lantern.NDCG10 < lucene.NDCG10-eps {
+				t.Errorf("nDCG@10 %.4f below Lucene %s %.4f", lantern.NDCG10, run.Analyzer, lucene.NDCG10)
+			}
+			if lantern.MRR < lucene.MRR-eps {
+				t.Errorf("MRR %.4f below Lucene %s %.4f", lantern.MRR, run.Analyzer, lucene.MRR)
+			}
+			if lantern.Recall50 < lucene.Recall50-eps {
+				t.Errorf("Recall@50 %.4f below Lucene %s %.4f", lantern.Recall50, run.Analyzer, lucene.Recall50)
+			}
 		})
 	}
 }

--- a/core/search/scorer.go
+++ b/core/search/scorer.go
@@ -10,25 +10,41 @@ const (
 	// DefaultBM25B controls document-length normalization, from 0 (off) to 1
 	// (full): how strongly a long document is penalized for diluting a term.
 	DefaultBM25B = 0.75
+	// DefaultGramWeight is the production ClassWeighted.GramWeight: how much
+	// a match on the auxiliary intra-word gram channel counts relative to a
+	// whole-word match. 0.2 sits in the middle of the plateau the relevance
+	// harness measured for #888 — every weight in [0.1, 0.3] beat the pinned
+	// Lucene baselines on all corpora, with the extremes offering no durable
+	// advantage over this midpoint.
+	DefaultGramWeight = 0.2
 )
 
 // TermStats carries the corpus statistics a Scorer needs to weight one
 // (query term, matching document) pairing. The Searcher fills it in from the
 // index while computing a result; a Scorer treats it as read-only input and
 // holds no state of its own, so a single Scorer is safe for concurrent use.
+//
+// Every count is scoped to the term's token class (#888): the index keeps
+// separate postings and statistics per class, so DF, N, DocLen, and AvgLen
+// describe only the channel the term matched on. For a single-channel
+// pipeline that scoping is invisible — the class's corpus is the corpus.
 type TermStats struct {
 	// TF is how many times the term occurs in this document (term frequency).
 	TF int
 	// DF is how many documents in the corpus contain the term (document
 	// frequency); it drives the inverse-document-frequency weight.
 	DF int
-	// N is the total number of documents in the corpus.
+	// N is the number of documents carrying at least one token of the term's
+	// class — the corpus size of the term's channel.
 	N int
-	// DocLen is the length, in tokens, of this document.
+	// DocLen is the length of this document in tokens of the term's class.
 	DocLen int
-	// AvgLen is the mean document length across the corpus, used to normalize
-	// DocLen so long and short documents compete fairly.
+	// AvgLen is the mean DocLen across the class's N documents, used to
+	// normalize DocLen so long and short documents compete fairly.
 	AvgLen float64
+	// Class is the matching channel the term belongs to, so a class-aware
+	// Scorer (ClassWeighted) can weight primary and auxiliary evidence apart.
+	Class TokenClass
 }
 
 // Scorer assigns a relevance weight to a single (query term, document)
@@ -122,5 +138,50 @@ func BM25Score(tf, avgLen float64, df, n, docLen int, k1, b float64) float64 {
 	return idf * (tf * (k1 + 1)) / denom
 }
 
-// Interface assertion: BM25 is a Scorer.
-var _ Scorer = BM25{}
+// ClassWeighted layers per-class weighting over a base Scorer (#888): a match
+// on the auxiliary gram channel (ClassGram) is multiplied by GramWeight while
+// primary evidence (ClassWord) passes through unchanged. With the dual-class
+// ScriptAwareTokenizer this is what makes a whole-word match dominate the
+// redundant intra-word fragments that only exist to keep infix recall: the
+// fragments still surface a document, but at a fraction of the weight, so
+// "arch" ranks the document containing the word above the ones merely
+// containing the substring.
+//
+// GramWeight is clamped to [0, 1]; 0 silences the auxiliary channel entirely
+// and 1 restores unweighted scoring. A nil Base falls back to BM25 with the
+// standard parameters, so the zero value scores like the default scorer with
+// the gram channel muted. ClassWeighted holds no mutable state and is safe
+// for concurrent use.
+type ClassWeighted struct {
+	// Base scores each pairing before weighting; nil means standard BM25.
+	Base Scorer
+	// GramWeight multiplies ClassGram matches, clamped to [0, 1].
+	GramWeight float64
+}
+
+// Score returns the base score, scaled by GramWeight for auxiliary-channel
+// matches.
+func (s ClassWeighted) Score(stats TermStats) float64 {
+	base := s.Base
+	if base == nil {
+		base = BM25{K1: DefaultBM25K1, B: DefaultBM25B}
+	}
+	score := base.Score(stats)
+	if stats.Class == ClassGram {
+		w := s.GramWeight
+		switch {
+		case w < 0:
+			w = 0
+		case w > 1:
+			w = 1
+		}
+		score *= w
+	}
+	return score
+}
+
+// Interface assertions: BM25 and ClassWeighted are Scorers.
+var (
+	_ Scorer = BM25{}
+	_ Scorer = ClassWeighted{}
+)

--- a/core/search/scorer_test.go
+++ b/core/search/scorer_test.go
@@ -143,3 +143,41 @@ func TestScorerFunc(t *testing.T) {
 		t.Fatalf("Score = %v, want 4.2", got)
 	}
 }
+
+func TestClassWeighted(t *testing.T) {
+	stats := func(class TokenClass) TermStats {
+		return TermStats{TF: 2, DF: 1, N: 10, DocLen: 5, AvgLen: 5, Class: class}
+	}
+	base := BM25{K1: DefaultBM25K1, B: DefaultBM25B}
+
+	t.Run("WordPassesThrough", func(t *testing.T) {
+		s := ClassWeighted{Base: base, GramWeight: 0.2}
+		if got, want := s.Score(stats(ClassWord)), base.Score(stats(ClassWord)); got != want {
+			t.Fatalf("word score = %v, want base %v", got, want)
+		}
+	})
+
+	t.Run("GramScaled", func(t *testing.T) {
+		s := ClassWeighted{Base: base, GramWeight: 0.2}
+		if got, want := s.Score(stats(ClassGram)), 0.2*base.Score(stats(ClassGram)); got != want {
+			t.Fatalf("gram score = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("WeightClamped", func(t *testing.T) {
+		if got := (ClassWeighted{Base: base, GramWeight: -1}).Score(stats(ClassGram)); got != 0 {
+			t.Fatalf("negative weight score = %v, want 0", got)
+		}
+		over := ClassWeighted{Base: base, GramWeight: 7}
+		if got, want := over.Score(stats(ClassGram)), base.Score(stats(ClassGram)); got != want {
+			t.Fatalf("over-1 weight score = %v, want unscaled %v", got, want)
+		}
+	})
+
+	t.Run("NilBaseIsStandardBM25", func(t *testing.T) {
+		s := ClassWeighted{GramWeight: 1}
+		if got, want := s.Score(stats(ClassWord)), base.Score(stats(ClassWord)); got != want {
+			t.Fatalf("nil base score = %v, want BM25 default %v", got, want)
+		}
+	})
+}

--- a/core/search/script_tokenizer.go
+++ b/core/search/script_tokenizer.go
@@ -1,0 +1,131 @@
+package search
+
+import "unicode"
+
+// ScriptAwareTokenizer is the production tokenizer for mixed-script content
+// search (#888). It splits text into script runs and picks the right unit per
+// run, instead of forcing one strategy onto every language the way a pure
+// word or pure n-gram tokenizer does:
+//
+//   - A run of a space-delimited script (Latin, Cyrillic, Greek, digits, …)
+//     emits the whole word as a primary token (ClassWord) — the unit Lucene's
+//     StandardAnalyzer indexes, and what lets a whole-word match outrank an
+//     infix fragment. Words of at least N runes additionally emit every
+//     N-rune window as auxiliary tokens (ClassGram), which is what keeps the
+//     bigram pipeline's infix recall ("arch" finding "search") and typo
+//     tolerance; pair the index with ClassWeighted so this redundant channel
+//     stays evidence, not the ranking.
+//   - A run of an unbounded script — one written without spaces between
+//     words: Han, Hiragana, Katakana, Hangul, Thai, Lao, Khmer, Myanmar —
+//     emits its N-rune windows as primary tokens, exactly the strategy of
+//     Lucene's CJKAnalyzer, because there the gram is the word-level unit. A
+//     run shorter than N (a lone ideograph) is emitted whole, so single-
+//     character words stay searchable.
+//   - Every other rune (whitespace, punctuation, symbols) delimits runs and
+//     is dropped, so no gram ever straddles a word boundary and the
+//     WhitespaceFilter step of the plain n-gram pipeline is unnecessary.
+//
+// Run it after the folding normalizers (width, diacritic, lowercase,
+// punctuation, space) — NewScriptAwareAnalyzer wires that pipeline. In
+// particular WidthNormalizer must run first so half-width katakana joins the
+// katakana run it belongs to. N < 2 is treated as 2 (bigrams), so the zero
+// value is the production configuration. It holds no state and is safe for
+// concurrent use.
+type ScriptAwareTokenizer struct {
+	// N is the gram width, for unbounded-script runs and the auxiliary
+	// intra-word grams alike. N < 2 is treated as 2.
+	N int
+}
+
+// Tokenize splits text into script runs and emits per-run tokens as described
+// on the type.
+func (t ScriptAwareTokenizer) Tokenize(text string) []Token {
+	n := t.N
+	if n < 2 {
+		n = 2
+	}
+	runes := []rune(text)
+	var tokens []Token
+	for i := 0; i < len(runes); {
+		switch r := runes[i]; {
+		case isUnboundedScript(r):
+			j := i + 1
+			for j < len(runes) && isUnboundedScript(runes[j]) {
+				j++
+			}
+			tokens = appendRunGrams(tokens, runes[i:j], n, ClassWord)
+			i = j
+		case isWordRune(r):
+			j := i + 1
+			for j < len(runes) && isWordRune(runes[j]) {
+				j++
+			}
+			word := runes[i:j]
+			tokens = append(tokens, Token{Term: string(word), Class: ClassWord})
+			if len(word) > n {
+				// Strictly longer than one window: a word of exactly N runes
+				// would emit itself again, and the word token already carries
+				// that evidence on the primary channel.
+				tokens = appendRunGrams(tokens, word, n, ClassGram)
+			}
+			i = j
+		default:
+			i++ // delimiter: whitespace, punctuation, symbols
+		}
+	}
+	return tokens
+}
+
+// appendRunGrams appends every n-rune window of run as a token of the given
+// class; a run shorter than n is emitted whole, so it stays matchable rather
+// than vanishing (the CJKBigramFilter unigram fallback).
+func appendRunGrams(tokens []Token, run []rune, n int, class TokenClass) []Token {
+	if len(run) < n {
+		return append(tokens, Token{Term: string(run), Class: class})
+	}
+	for i := 0; i+n <= len(run); i++ {
+		tokens = append(tokens, Token{Term: string(run[i : i+n]), Class: class})
+	}
+	return tokens
+}
+
+// unboundedScripts are the scripts written without spaces between words, for
+// which n-grams are the word-level indexing unit: the CJKBigramFilter set
+// (Han, Hiragana, Katakana, Hangul) plus the space-free Southeast Asian
+// scripts.
+var unboundedScripts = []*unicode.RangeTable{
+	unicode.Han,
+	unicode.Hiragana,
+	unicode.Katakana,
+	unicode.Hangul,
+	unicode.Thai,
+	unicode.Lao,
+	unicode.Khmer,
+	unicode.Myanmar,
+}
+
+// isUnboundedScript reports whether r belongs to a script indexed by n-grams.
+// The prolonged-sound and iteration marks (ー, 々, 〆) carry script Common but
+// occur inside Japanese words ("ラーメン", "人々"), so they are kept in the run
+// rather than treated as delimiters.
+func isUnboundedScript(r rune) bool {
+	switch r {
+	case 'ー', '々', '〆':
+		return true
+	}
+	for _, table := range unboundedScripts {
+		if unicode.Is(table, r) {
+			return true
+		}
+	}
+	return false
+}
+
+// isWordRune reports whether r continues a word run of a space-delimited
+// script: letters and digits, minus the runes the unbounded scripts claim.
+func isWordRune(r rune) bool {
+	return (unicode.IsLetter(r) || unicode.IsDigit(r)) && !isUnboundedScript(r)
+}
+
+// Interface assertion: ScriptAwareTokenizer is a Tokenizer.
+var _ Tokenizer = ScriptAwareTokenizer{}

--- a/core/search/script_tokenizer_test.go
+++ b/core/search/script_tokenizer_test.go
@@ -1,0 +1,180 @@
+package search
+
+import (
+	"testing"
+)
+
+// tokensEqual compares full tokens (term + class), the property this
+// tokenizer exists to get right.
+func tokensEqual(a, b []Token) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestScriptAwareTokenizer(t *testing.T) {
+	tok := ScriptAwareTokenizer{} // zero value: N = 2, the production shape
+
+	cases := []struct {
+		name string
+		text string
+		want []Token
+	}{
+		{
+			name: "LatinWordEmitsWordPlusAuxGrams",
+			text: "search",
+			want: []Token{
+				{Term: "search", Class: ClassWord},
+				{Term: "se", Class: ClassGram},
+				{Term: "ea", Class: ClassGram},
+				{Term: "ar", Class: ClassGram},
+				{Term: "rc", Class: ClassGram},
+				{Term: "ch", Class: ClassGram},
+			},
+		},
+		{
+			name: "TwoRuneWordSkipsRedundantGram",
+			// A word of exactly N runes would emit itself again as a gram;
+			// the word token already carries that evidence.
+			text: "go",
+			want: []Token{{Term: "go", Class: ClassWord}},
+		},
+		{
+			name: "SingleRuneWordStaysSearchable",
+			// The pure bigram pipeline dropped one-letter words entirely.
+			text: "a",
+			want: []Token{{Term: "a", Class: ClassWord}},
+		},
+		{
+			name: "DigitsAreWords",
+			text: "2024 v2",
+			want: []Token{
+				{Term: "2024", Class: ClassWord},
+				{Term: "20", Class: ClassGram},
+				{Term: "02", Class: ClassGram},
+				{Term: "24", Class: ClassGram},
+				{Term: "v2", Class: ClassWord},
+			},
+		},
+		{
+			name: "CJKRunEmitsPrimaryBigrams",
+			text: "東京駅",
+			want: []Token{
+				{Term: "東京", Class: ClassWord},
+				{Term: "京駅", Class: ClassWord},
+			},
+		},
+		{
+			name: "LoneIdeographEmittedWhole",
+			// CJKBigramFilter unigram fallback: a single character must not
+			// vanish below the window.
+			text: "麺",
+			want: []Token{{Term: "麺", Class: ClassWord}},
+		},
+		{
+			name: "ProlongedSoundMarkStaysInKatakanaRun",
+			// ー is script Common but must not split ラーメン.
+			text: "ラーメン",
+			want: []Token{
+				{Term: "ラー", Class: ClassWord},
+				{Term: "ーメ", Class: ClassWord},
+				{Term: "メン", Class: ClassWord},
+			},
+		},
+		{
+			name: "IterationMarkStaysInHanRun",
+			text: "人々",
+			want: []Token{{Term: "人々", Class: ClassWord}},
+		},
+		{
+			name: "MixedScriptSplitsAtScriptBoundary",
+			// "4k" is a word run; "モニター" is a katakana run — no token
+			// bridges the boundary.
+			text: "4kモニター",
+			want: []Token{
+				{Term: "4k", Class: ClassWord},
+				{Term: "モニ", Class: ClassWord},
+				{Term: "ニタ", Class: ClassWord},
+				{Term: "ター", Class: ClassWord},
+			},
+		},
+		{
+			name: "DelimitersDropAndNeverBridge",
+			// Space and punctuation split runs; no gram straddles them, so
+			// the n-gram pipeline's WhitespaceFilter step is unnecessary.
+			text: "go, rust",
+			want: []Token{
+				{Term: "go", Class: ClassWord},
+				{Term: "rust", Class: ClassWord},
+				{Term: "ru", Class: ClassGram},
+				{Term: "us", Class: ClassGram},
+				{Term: "st", Class: ClassGram},
+			},
+		},
+		{
+			name: "HangulIsUnbounded",
+			text: "한국어",
+			want: []Token{
+				{Term: "한국", Class: ClassWord},
+				{Term: "국어", Class: ClassWord},
+			},
+		},
+		{
+			name: "ThaiIsUnbounded",
+			text: "ไทย",
+			want: []Token{
+				{Term: "ไท", Class: ClassWord},
+				{Term: "ทย", Class: ClassWord},
+			},
+		},
+		{
+			name: "Empty",
+			text: "",
+			want: nil,
+		},
+		{
+			name: "OnlyDelimiters",
+			text: " ,. !",
+			want: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tok.Tokenize(tc.text)
+			if !tokensEqual(got, tc.want) {
+				t.Fatalf("Tokenize(%q) = %v, want %v", tc.text, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("WiderGramWidth", func(t *testing.T) {
+		got := ScriptAwareTokenizer{N: 3}.Tokenize("search 東京都庁")
+		want := []Token{
+			{Term: "search", Class: ClassWord},
+			{Term: "sea", Class: ClassGram},
+			{Term: "ear", Class: ClassGram},
+			{Term: "arc", Class: ClassGram},
+			{Term: "rch", Class: ClassGram},
+			{Term: "東京都", Class: ClassWord},
+			{Term: "京都庁", Class: ClassWord},
+		}
+		if !tokensEqual(got, want) {
+			t.Fatalf("N=3 Tokenize = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("ShortCJKRunUnderWiderWidthEmittedWhole", func(t *testing.T) {
+		got := ScriptAwareTokenizer{N: 3}.Tokenize("東京")
+		want := []Token{{Term: "東京", Class: ClassWord}}
+		if !tokensEqual(got, want) {
+			t.Fatalf("N=3 Tokenize(東京) = %v, want %v", got, want)
+		}
+	})
+}

--- a/core/search/tokenizer.go
+++ b/core/search/tokenizer.go
@@ -11,7 +11,36 @@ import (
 type Token struct {
 	// Term is the analyzed text of this token.
 	Term string
+	// Class labels the matching channel the token belongs to; the zero value
+	// (ClassWord) is the primary channel, so tokenizers that predate classes
+	// keep their exact behavior.
+	Class TokenClass
 }
+
+// TokenClass separates a token's matching channel (#888). The inverted index
+// keys terms, corpus statistics (document frequency, document length, corpus
+// size), and postings per class, so the two channels never share BM25
+// statistics, and a class-aware Scorer (ClassWeighted) can weight them apart.
+// Only the constants below are valid: indexing a token with an undefined
+// class panics, and a query token with an undefined class simply matches
+// nothing.
+type TokenClass uint8
+
+const (
+	// ClassWord is the primary channel: whole words of space-delimited
+	// scripts, the n-grams of unbounded (CJK-like) script runs — where the
+	// gram is the word-level unit — and every token of a single-channel
+	// pipeline such as NewNGramAnalyzer. It is deliberately the zero value.
+	ClassWord TokenClass = iota
+	// ClassGram is the auxiliary channel: intra-word n-gram fragments emitted
+	// alongside the word they came from (ScriptAwareTokenizer) so infix and
+	// typo-tolerant matching keeps working. Pair with ClassWeighted so this
+	// redundant evidence never outranks a whole-word match.
+	ClassGram
+
+	// numTokenClasses sizes the index's per-class tables.
+	numTokenClasses = int(ClassGram) + 1
+)
 
 // Tokenizer splits text into tokens. Implementations in this package are
 // stateless and therefore safe for concurrent use by multiple goroutines.


### PR DESCRIPTION
## What

The biggest accuracy lever of the Lucene-parity epic (#886), implemented as the issue's recommended option (a) — dual-class emission:

- **`TokenClass` on `Token`** — `ClassWord` (primary: whole words of space-delimited scripts; bigrams of unbounded CJK-like runs, which are the word-level unit there, per Lucene `CJKAnalyzer`) and `ClassGram` (auxiliary: intra-word bigrams that keep the old pipeline's infix + typo recall). Zero value is `ClassWord`, so every existing tokenizer/pipeline keeps its exact behavior.
- **`ScriptAwareTokenizer`** — segments text into script runs: word runs emit the whole word plus auxiliary intra-word bigrams (skipped when redundant, i.e. word length ≤ N); Han/Kana/Hangul/Thai/Lao/Khmer/Myanmar runs emit bigrams, with the `CJKBigramFilter`-style unigram fallback for lone ideographs. ー/々/〆 (script Common) stay inside their runs so ラーメン doesn't split. Single-letter words become searchable (pure bigrams dropped them).
- **Per-class index statistics** — `InvertedIndex` keys term dictionaries, postings, DF, corpus size N, document length, and average length per class (BM25F-style field separation), so auxiliary gram evidence never inflates the word channel's statistics. Single-channel pipelines see zero behavioral change.
- **`ClassWeighted` scorer** — multiplies `ClassGram` matches by `DefaultGramWeight = 0.2`; whole-word evidence passes through, so a word match dominates fragments while fragments still surface documents.
- **`graphcache.newSearchIndex`** swaps to `NewScriptAwareAnalyzer()` + `ClassWeighted`; the relevance gate replica and floors are re-pinned in lockstep.

## Measured (on the #887 harness, deterministic)

| corpus | metric | bigram (before) | script-aware (after) | Lucene best |
|---|---|---|---|---|
| en | nDCG@10 | 0.895 | **0.928** | 0.919 (EnglishAnalyzer) |
| en | MRR | 0.981 | **1.000** | 1.000 |
| en | Recall@50 | 0.959 | 0.951 | 0.828 |
| ja | all three | 0.912 / 1.000 / 0.728 | unchanged | identical (CJKAnalyzer) |
| mixed | nDCG@10 | 0.948 | **0.954** | 0.948 (CJKAnalyzer) |

GramWeight sweep: every value in [0.1, 0.3] beats all Lucene references on all corpora; 0.2 is the plateau midpoint (0.1 was marginally best but risks overfitting the fixtures). The en Recall@50 give-back (0.959 → 0.951) is the accepted trade for the nDCG/MRR gains — still 12 points above Lucene's best.

**Lantern now scores ≥ every pinned Lucene run on every metric of every corpus, so `TestLuceneBaselineComparison` is promoted from report to assertion — #886's definition of done is enforced by CI from this PR on.** Remaining epic issues (#889 positions/phrase, #890 match modes, #891 fuzzy) broaden robustness on top of this floor.

Memory: 4k-doc footprint measured ~8% *smaller* than the bigram pipeline (fewer redundant gram postings; word channel is cheap).

## Tests

- `script_tokenizer_test.go`: script-run segmentation across Latin/digits/CJK/Hangul/Thai, prolonged-sound/iteration marks, unigram fallback, N=3, boundary-bridging impossibility.
- `inverted_index_test.go` + `TestInvertedIndexDualClass`: word-beats-infix ranking, same-spelling-two-channels no-collision, dual-channel reclamation on delete, undefined-class panic, CJK+word coexistence.
- `scorer_test.go` + `TestClassWeighted`: pass-through, scaling, clamping, nil-base default.
- `quality_gate_test.go` + `TestSearchQualityGateScriptAware`: production-pipeline gate (whole-word dominance, typo recall, width/case folding, CJK, lone ideograph, mixed-script values); the existing bigram gate is untouched — that pipeline still ships as `NewNGramAnalyzer`/the example.
- Relevance floors re-pinned (en nDCG 0.894 → 0.927, en MRR 0.980 → 1.000, mixed 0.947 → 0.953); verified stable across repeated runs.

Full pre-push gate: root + core + mcp + pb + sdks/go + server (vet+test) green, `gofmt` clean.

Closes #888

🤖 Generated with [Claude Code](https://claude.com/claude-code)
