### PR TITLE
feat(core/search): positional postings for phrase and proximity ranking

### DIFF
--- a/core/graphcache/search.go
+++ b/core/graphcache/search.go
@@ -18,6 +18,11 @@ import (
 // same analyzer runs over both stored values and queries, so index-time and
 // query-time terms stay symmetric.
 //
+// Since #889 the index also records positional postings (WithPositions): the
+// token positions of each primary-channel term, so the search layer can tell
+// an exact phrase or a near match from scattered term hits. The cost is one
+// ascending position slice per (word term, vertex).
+//
 // The relevance gate (core/search/relevance, parity_gate_test.go) replicates
 // exactly this pipeline and ratchets its measured metrics against the pinned
 // Lucene baseline — change the two in lockstep.
@@ -27,7 +32,7 @@ func newSearchIndex[S comparable]() *search.InvertedIndex[S, search.Document] {
 		Base:       search.BM25{K1: search.DefaultBM25K1, B: search.DefaultBM25B},
 		GramWeight: search.DefaultGramWeight,
 	}
-	return search.NewInvertedIndex[S, search.Document](analyzer, scorer)
+	return search.NewInvertedIndex[S, search.Document](analyzer, scorer, search.WithPositions())
 }
 
 // EnableSearchIndex turns on the optional content-search index, projecting each

--- a/core/search/inverted_index.go
+++ b/core/search/inverted_index.go
@@ -32,6 +32,12 @@ import (
 type InvertedIndex[S comparable, D Document] struct {
 	analyzer Analyzer
 	scorer   Scorer
+	// positions is fixed at construction (WithPositions): when set, Index
+	// records each primary-channel (ClassWord) term's token positions so
+	// SearchPhrase and the proximity boost can tell an exact phrase from
+	// scattered matches. Read without the lock — it never changes after
+	// construction.
+	positions bool
 
 	mu sync.RWMutex
 	// classes holds one posting table per token class; a term's class is part
@@ -86,19 +92,45 @@ type docEntry[S comparable] struct {
 	terms [numTokenClasses][]uint32
 }
 
+// IndexOption configures an InvertedIndex at construction time.
+type IndexOption func(*indexConfig)
+
+// indexConfig holds the resolved construction options.
+type indexConfig struct {
+	positions bool
+}
+
+// WithPositions makes the index record each term's token positions on the
+// primary word channel (ClassWord), which SearchPhrase and the proximity boost
+// need to tell an exact phrase from scattered term matches. It costs one
+// ascending []uint32 per (word term, document); an index left without it ranks
+// by the OR-union BM25 alone and stores no positions. The auxiliary gram
+// channel never carries positions: phrase and proximity are word-level, and a
+// CJK run's adjacency is already encoded by its overlapping bigrams on the
+// word channel, so pos+1 verification works there too (#889).
+func WithPositions() IndexOption {
+	return func(c *indexConfig) { c.positions = true }
+}
+
 // NewInvertedIndex returns an empty index that analyzes both documents and
 // queries with analyzer and ranks matches with scorer. Passing a nil scorer
 // installs BM25 with the standard parameters (K1 = 1.2, B = 0.75). D is the
-// document type it accepts; use Text to index plain strings.
-func NewInvertedIndex[S comparable, D Document](analyzer Analyzer, scorer Scorer) *InvertedIndex[S, D] {
+// document type it accepts; use Text to index plain strings. Pass
+// WithPositions to enable phrase and proximity queries (SearchPhrase).
+func NewInvertedIndex[S comparable, D Document](analyzer Analyzer, scorer Scorer, opts ...IndexOption) *InvertedIndex[S, D] {
 	if scorer == nil {
 		scorer = BM25{K1: DefaultBM25K1, B: DefaultBM25B}
 	}
+	var cfg indexConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 	idx := &InvertedIndex[S, D]{
-		analyzer: analyzer,
-		scorer:   scorer,
-		ords:     newOrdinals[S](),
-		docs:     make(map[uint32]docEntry[S]),
+		analyzer:  analyzer,
+		scorer:    scorer,
+		positions: cfg.positions,
+		ords:      newOrdinals[S](),
+		docs:      make(map[uint32]docEntry[S]),
 	}
 	for class := range idx.classes {
 		idx.classes[class] = classPostings{
@@ -187,11 +219,25 @@ func (idx *InvertedIndex[S, D]) indexPreparedLocked(id S, tokens []Token) {
 	// statistics are recorded independently. perClass slices are transient
 	// scratch; only the compact distinct-term slices are retained.
 	var perClass [numTokenClasses][]string
+	// wordPositions maps each primary (ClassWord) term to its ascending token
+	// positions in this document, recorded only when the index tracks positions.
+	// Position counts word tokens only (auxiliary grams are skipped), so
+	// "data set" yields data@0 set@1 and a CJK run's consecutive bigrams get
+	// consecutive positions — both let SearchPhrase verify adjacency with pos+1.
+	var wordPositions map[string][]uint32
+	if idx.positions {
+		wordPositions = make(map[string][]uint32)
+	}
+	var wordPos uint32
 	for _, token := range tokens {
 		if int(token.Class) >= numTokenClasses {
 			panic("search: token with undefined TokenClass")
 		}
 		perClass[token.Class] = append(perClass[token.Class], token.Term)
+		if wordPositions != nil && token.Class == ClassWord {
+			wordPositions[token.Term] = append(wordPositions[token.Term], wordPos)
+			wordPos++
+		}
 	}
 	ord := idx.ords.assign(id)
 	entry := docEntry[S]{id: id}
@@ -224,7 +270,11 @@ func (idx *InvertedIndex[S, D]) indexPreparedLocked(id S, tokens []Token) {
 				pl = newPostingList()
 				cp.postings[tid] = pl
 			}
-			pl.set(ord, j-i) // term frequency = run length of this term
+			var pos []uint32
+			if wordPositions != nil && class == int(ClassWord) {
+				pos = wordPositions[sorted[i]]
+			}
+			pl.set(ord, j-i, pos) // term frequency = run length of this term
 			terms = append(terms, tid)
 			i = j
 		}
@@ -309,6 +359,8 @@ func (idx *InvertedIndex[S, D]) Search(query string) []Result[S] {
 	if len(scores) == 0 {
 		return nil
 	}
+	// Lift documents whose query terms cluster tightly (positions permitting).
+	idx.applyProximityLocked(scores, queryTerms)
 	results := make([]Result[S], 0, len(scores))
 	for ord, score := range scores {
 		results = append(results, Result[S]{ID: idx.docs[ord].id, Score: score})
@@ -411,18 +463,27 @@ func (idx *InvertedIndex[S, D]) SearchTopK(query string, k int, accept func(id S
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
 
-	// Phase 1 — identical union scoring to Search: every matching document's
-	// full score must exist before selection, because a document's rank is
-	// the SUM over query terms.
+	// Phase 1 — union scoring identical to Search, then the same proximity
+	// boost, so a document's full score exists before selection: its rank is
+	// the SUM over query terms, adjusted for how tightly they cluster.
 	scores := idx.scoreLocked(queryTerms)
 	if len(scores) == 0 {
 		return nil
 	}
+	idx.applyProximityLocked(scores, queryTerms)
 
-	// Phase 2 — bounded selection. A min-heap of size k holds the current
-	// best accepted documents; a candidate consults accept only once its
-	// score beats the boundary, so rejection work never scales with the
-	// match set beyond the heap-qualified candidates.
+	// Phase 2 — bounded selection, shared with SearchPhraseTopK.
+	return idx.selectTopKLocked(scores, k, accept)
+}
+
+// selectTopKLocked returns the k highest-scoring documents in scores that pass
+// accept, as a descending-ranked slice. It is the bounded-selection phase
+// shared by SearchTopK and SearchPhraseTopK: a size-k min-heap holds the
+// current best, accept is consulted lazily (only once a candidate's score
+// clears the heap boundary) so rejection never scales with the match set, and
+// ties at the k-th boundary keep an unspecified subset. Callers must hold
+// idx.mu; k > 0 is the caller's precondition.
+func (idx *InvertedIndex[S, D]) selectTopKLocked(scores map[uint32]float64, k int, accept func(id S) bool) []Result[S] {
 	h := topKHeap[S]{entries: make([]Result[S], 0, k)}
 	for ord, score := range scores {
 		if len(h.entries) == k && score <= h.entries[0].Score {

--- a/core/search/inverted_index_test.go
+++ b/core/search/inverted_index_test.go
@@ -350,6 +350,18 @@ func buildBigramIndex(corpus map[string]Text) *InvertedIndex[string, Text] {
 	return idx
 }
 
+// buildBigramIndexWithPositions is buildBigramIndex built WithPositions, for
+// the #889 benchmarks that measure the positional postings' build and steady-
+// state overhead. The bigram analyzer emits every term on the primary channel,
+// so every term carries positions — the worst case for the position store.
+func buildBigramIndexWithPositions(corpus map[string]Text) *InvertedIndex[string, Text] {
+	idx := NewInvertedIndex[string, Text](bigramAnalyzer(), nil, WithPositions())
+	for id, doc := range corpus {
+		idx.Index(id, doc)
+	}
+	return idx
+}
+
 // makeBigramCorpus builds n deterministic documents whose ids mimic
 // hierarchical vertex keys and whose text draws from benchVocab, so the
 // resulting index resembles a production content index.
@@ -408,6 +420,90 @@ func BenchmarkInvertedIndexFootprint(b *testing.B) {
 	b.ReportMetric(delta/(1024*1024), "MiB/index")
 	b.ReportMetric(delta/float64(docs), "B/doc")
 	b.ReportMetric(float64(after.HeapObjects-base.HeapObjects), "objects")
+}
+
+// BenchmarkInvertedIndexBuildWithPositions is the WithPositions counterpart of
+// BenchmarkInvertedIndexBuild: -benchmem against it reports the build-time
+// allocation cost of the positional postings (#889).
+func BenchmarkInvertedIndexBuildWithPositions(b *testing.B) {
+	corpus := makeBigramCorpus(1000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runtime.KeepAlive(buildBigramIndexWithPositions(corpus))
+	}
+}
+
+// BenchmarkInvertedIndexFootprintWithPositions is the WithPositions counterpart
+// of BenchmarkInvertedIndexFootprint: the retained-heap delta against the
+// positions-off footprint is the steady-state cost of the position slices.
+func BenchmarkInvertedIndexFootprintWithPositions(b *testing.B) {
+	const docs = 4000
+	corpus := makeBigramCorpus(docs)
+
+	runtime.GC()
+	var base runtime.MemStats
+	runtime.ReadMemStats(&base)
+
+	var idx *InvertedIndex[string, Text]
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		idx = buildBigramIndexWithPositions(corpus)
+	}
+	b.StopTimer()
+
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	runtime.KeepAlive(idx)
+	runtime.KeepAlive(corpus)
+
+	delta := float64(after.HeapInuse) - float64(base.HeapInuse)
+	b.ReportMetric(delta/(1024*1024), "MiB/index")
+	b.ReportMetric(delta/float64(docs), "B/doc")
+	b.ReportMetric(float64(after.HeapObjects-base.HeapObjects), "objects")
+}
+
+// BenchmarkSearchProximity measures multi-term query latency with and without
+// the proximity boost, which runs only when the index tracks positions. Both
+// sub-benchmarks share the corpus and query set so -benchmem/ns compares the
+// boost's per-query cost directly (#889).
+func BenchmarkSearchProximity(b *testing.B) {
+	const docs = 4000
+	corpus := makeBigramCorpus(docs)
+	queries := []string{"al", "search index", "alpha beta gamma"}
+
+	b.Run("WithoutPositions", func(b *testing.B) {
+		idx := buildBigramIndex(corpus)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			idx.Search(queries[i%len(queries)])
+		}
+	})
+	b.Run("WithPositions", func(b *testing.B) {
+		idx := buildBigramIndexWithPositions(corpus)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			idx.Search(queries[i%len(queries)])
+		}
+	})
+}
+
+// BenchmarkSearchPhrase measures phrase-query latency (AND-intersection plus
+// positional adjacency verification) on the positions-enabled bigram index.
+func BenchmarkSearchPhrase(b *testing.B) {
+	const docs = 4000
+	corpus := makeBigramCorpus(docs)
+	idx := buildBigramIndexWithPositions(corpus)
+	queries := []string{"search index", "alpha beta", "vertex edge decay"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		idx.SearchPhrase(queries[i%len(queries)])
+	}
 }
 
 // TestSearchTopK property-checks the bounded selection (#841) against the

--- a/core/search/phrase.go
+++ b/core/search/phrase.go
@@ -1,0 +1,218 @@
+package search
+
+import "sort"
+
+// SearchPhrase returns the documents that contain the query's word-channel
+// terms as a consecutive phrase, ranked by BM25 over those terms. It is the
+// precision counterpart to Search's recall-oriented OR-union: "data set"
+// matches a document with "... data set ..." but not one that merely scatters
+// "data" and "set" far apart. Matching is the AND-intersection of the query's
+// primary (ClassWord) postings, refined by position — the query terms must
+// occur at consecutive positions (p, p+1, ...) in query order.
+//
+// When the index was built without WithPositions the position refinement is
+// unavailable and SearchPhrase degrades to the pure AND-intersection (every
+// term present, order unverified). A query with no word terms, or one that
+// matches nothing, returns nil; ties in score have an unspecified order.
+func (idx *InvertedIndex[S, D]) SearchPhrase(query string) []Result[S] {
+	terms := idx.phraseQueryTerms(query)
+	if len(terms) == 0 {
+		return nil
+	}
+
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	ords := idx.phraseMatchLocked(terms)
+	if len(ords) == 0 {
+		return nil
+	}
+	scores := idx.scorePhraseLocked(terms, ords)
+	results := make([]Result[S], 0, len(scores))
+	for ord, score := range scores {
+		results = append(results, Result[S]{ID: idx.docs[ord].id, Score: score})
+	}
+	sort.Slice(results, func(i, j int) bool { return results[i].Score > results[j].Score })
+	return results
+}
+
+// SearchPhraseTopK is the bounded-selection sibling of SearchPhrase, mirroring
+// SearchTopK (#841): it phrase-matches then returns only the k highest-scoring
+// documents that satisfy accept, without fully sorting the match set. accept
+// gates a document before it can occupy one of the k slots (dead vertices,
+// out-of-scope keys) and may be nil (accept everything). The lock order and
+// accept contract are identical to SearchTopK. k <= 0, a query with no word
+// terms, or zero accepted matches return nil.
+func (idx *InvertedIndex[S, D]) SearchPhraseTopK(query string, k int, accept func(id S) bool) []Result[S] {
+	if k <= 0 {
+		return nil
+	}
+	terms := idx.phraseQueryTerms(query)
+	if len(terms) == 0 {
+		return nil
+	}
+
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	ords := idx.phraseMatchLocked(terms)
+	if len(ords) == 0 {
+		return nil
+	}
+	scores := idx.scorePhraseLocked(terms, ords)
+	return idx.selectTopKLocked(scores, k, accept)
+}
+
+// phraseQueryTerms analyzes query and returns its primary (ClassWord) tokens in
+// order — the sequence a phrase must match consecutively. Auxiliary gram tokens
+// are dropped because phrase adjacency is defined on the word channel; a CJK
+// run's grams are themselves ClassWord, so they are kept and verified by the
+// same pos+1 rule.
+func (idx *InvertedIndex[S, D]) phraseQueryTerms(query string) []string {
+	tokens := idx.analyzer.Analyze(query)
+	var terms []string
+	for _, t := range tokens {
+		if t.Class == ClassWord {
+			terms = append(terms, t.Term)
+		}
+	}
+	return terms
+}
+
+// phraseMatchLocked returns the ordinals whose primary-channel postings satisfy
+// the phrase: every query term present (AND-intersection) and, when the index
+// tracks positions, occurring at consecutive positions in query order. terms is
+// the ordered ClassWord query terms with duplicates kept, so a repeated word
+// must appear repeated and adjacent. Callers must hold idx.mu.
+func (idx *InvertedIndex[S, D]) phraseMatchLocked(terms []string) []uint32 {
+	cp := &idx.classes[ClassWord]
+	if cp.docCount == 0 {
+		return nil
+	}
+	// Resolve every query term's posting list; a missing term means the phrase
+	// cannot occur anywhere.
+	lists := make([]*postingList, len(terms))
+	for i, term := range terms {
+		tid, ok := cp.dict.lookup(term)
+		if !ok {
+			return nil
+		}
+		pl := cp.postings[tid]
+		if pl == nil {
+			return nil
+		}
+		lists[i] = pl
+	}
+	// AND-intersect membership, starting from the rarest term so the running
+	// intersection shrinks fastest.
+	rarest := 0
+	for i := 1; i < len(lists); i++ {
+		if lists[i].cardinality() < lists[rarest].cardinality() {
+			rarest = i
+		}
+	}
+	intersection := lists[rarest].docs.Clone()
+	for i := range lists {
+		if i != rarest {
+			intersection.And(lists[i].docs)
+		}
+	}
+	if intersection.IsEmpty() {
+		return nil
+	}
+	out := make([]uint32, 0, intersection.GetCardinality())
+	for it := intersection.Iterator(); it.HasNext(); {
+		ord := it.Next()
+		if phraseAdjacent(lists, ord) {
+			out = append(out, ord)
+		}
+	}
+	return out
+}
+
+// scorePhraseLocked scores the phrase-matched ordinals over the query's
+// distinct word terms with the same BM25 statistics as the OR-union path,
+// restricted to the ClassWord channel (phrase terms are word-class). Callers
+// must hold idx.mu.
+func (idx *InvertedIndex[S, D]) scorePhraseLocked(terms []string, ords []uint32) map[uint32]float64 {
+	cp := &idx.classes[ClassWord]
+	if cp.docCount == 0 {
+		return nil
+	}
+	avgLen := float64(cp.totalLen) / float64(cp.docCount)
+	scores := make(map[uint32]float64, len(ords))
+	seen := make(map[string]struct{}, len(terms))
+	for _, term := range terms {
+		if _, dup := seen[term]; dup {
+			continue
+		}
+		seen[term] = struct{}{}
+		tid, ok := cp.dict.lookup(term)
+		if !ok {
+			continue
+		}
+		pl := cp.postings[tid]
+		if pl == nil {
+			continue
+		}
+		df := pl.cardinality()
+		for _, ord := range ords {
+			scores[ord] += idx.scorer.Score(TermStats{
+				TF:     pl.tf(ord),
+				DF:     df,
+				N:      cp.docCount,
+				DocLen: idx.docs[ord].lengths[ClassWord],
+				AvgLen: avgLen,
+				Class:  ClassWord,
+			})
+		}
+	}
+	return scores
+}
+
+// phraseAdjacent reports whether the query terms occur at consecutive positions
+// in document ord, in query order. When the index tracks no positions (the
+// first term's slice is nil) it returns true, degrading the phrase to the
+// AND-intersection the caller already established. A single-term phrase is
+// trivially adjacent. lists holds one posting list per query term in order; ord
+// is a member of all of them.
+func phraseAdjacent(lists []*postingList, ord uint32) bool {
+	if len(lists) < 2 {
+		return true
+	}
+	first := lists[0].positionsOf(ord)
+	if first == nil {
+		return true // positions not tracked: degrade to AND
+	}
+	// The phrase occurs iff some position p of the first term is followed by
+	// term i at p+i for every i. Positions are ascending, so each follow-on
+	// check is a binary search.
+	for _, p := range first {
+		if phraseStartsAt(lists, ord, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// phraseStartsAt reports whether every term i (i >= 1) occurs at position
+// start+i in document ord, i.e. the phrase begins at start.
+func phraseStartsAt(lists []*postingList, ord uint32, start uint32) bool {
+	for i := 1; i < len(lists); i++ {
+		pos := lists[i].positionsOf(ord)
+		if pos == nil {
+			return true // positions not tracked mid-list: degrade to AND
+		}
+		if !containsSortedU32(pos, start+uint32(i)) {
+			return false
+		}
+	}
+	return true
+}
+
+// containsSortedU32 reports whether the ascending slice s contains v, via binary
+// search.
+func containsSortedU32(s []uint32, v uint32) bool {
+	i := sort.Search(len(s), func(i int) bool { return s[i] >= v })
+	return i < len(s) && s[i] == v
+}

--- a/core/search/phrase_test.go
+++ b/core/search/phrase_test.go
@@ -1,0 +1,177 @@
+package search
+
+import (
+	"sort"
+	"testing"
+)
+
+// TestSearchPhrase covers phrase matching over the primary word channel: the
+// query's terms must occur at consecutive positions, so an adjacent phrase
+// matches while the same terms scattered apart do not.
+func TestSearchPhrase(t *testing.T) {
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, WithPositions())
+	idx.Index("adjacent", Text("the data set is clean"))   // data@1 set@2 — adjacent
+	idx.Index("scattered", Text("the set holds the data")) // set@1 data@4 — apart
+	idx.Index("partial", Text("only data here"))           // data only
+
+	t.Run("matches the consecutive phrase, not the scattered terms", func(t *testing.T) {
+		got := idsOf(idx.SearchPhrase("data set"))
+		if !equalStrings(got, []string{"adjacent"}) {
+			t.Fatalf(`SearchPhrase("data set") = %v, want [adjacent]`, got)
+		}
+	})
+
+	t.Run("order matters: the reversed phrase matches neither document", func(t *testing.T) {
+		if got := idx.SearchPhrase("set data"); got != nil {
+			t.Fatalf(`SearchPhrase("set data") = %v, want nil`, idsOf(got))
+		}
+	})
+
+	t.Run("single-term phrase behaves like a term search", func(t *testing.T) {
+		got := idsOf(idx.SearchPhrase("data"))
+		sort.Strings(got)
+		if !equalStrings(got, []string{"adjacent", "partial", "scattered"}) {
+			t.Fatalf(`SearchPhrase("data") = %v, want all three`, got)
+		}
+	})
+
+	t.Run("a missing term matches nothing", func(t *testing.T) {
+		if got := idx.SearchPhrase("data absent"); got != nil {
+			t.Fatalf("SearchPhrase with absent term = %v, want nil", idsOf(got))
+		}
+	})
+
+	t.Run("a query with no word terms returns nil", func(t *testing.T) {
+		if got := idx.SearchPhrase("   "); got != nil {
+			t.Fatalf("SearchPhrase(blank) = %v, want nil", idsOf(got))
+		}
+	})
+}
+
+// TestSearchPhraseRepeatedWord verifies a repeated query word must appear
+// repeated and adjacent in the document, exercising a term whose posting
+// carries more than one position.
+func TestSearchPhraseRepeatedWord(t *testing.T) {
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, WithPositions())
+	idx.Index("double", Text("go go rust")) // go@0 go@1
+	idx.Index("single", Text("go rust go")) // go@0 go@2 — not adjacent
+
+	got := idsOf(idx.SearchPhrase("go go"))
+	if !equalStrings(got, []string{"double"}) {
+		t.Fatalf(`SearchPhrase("go go") = %v, want [double]`, got)
+	}
+}
+
+// TestSearchPhraseDegradesWithoutPositions verifies that an index built
+// without WithPositions cannot verify adjacency, so SearchPhrase falls back to
+// the AND-intersection: every term present, order unverified.
+func TestSearchPhraseDegradesWithoutPositions(t *testing.T) {
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil) // no WithPositions
+	idx.Index("adjacent", Text("the data set is clean"))
+	idx.Index("scattered", Text("the set holds the data"))
+	idx.Index("partial", Text("only data here")) // only one of the two terms
+
+	got := idsOf(idx.SearchPhrase("data set"))
+	sort.Strings(got)
+	if !equalStrings(got, []string{"adjacent", "scattered"}) {
+		t.Fatalf(`SearchPhrase("data set") without positions = %v, want [adjacent scattered] (AND)`, got)
+	}
+}
+
+// TestSearchPhrasePositionsLifecycle proves positions survive delete and
+// re-index with replace semantics: a deleted document's positions leave the
+// survivor intact, and re-indexing with a different order updates them so a
+// stale phrase no longer matches.
+func TestSearchPhrasePositionsLifecycle(t *testing.T) {
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, WithPositions())
+	idx.Index("doc1", Text("data set one"))
+	idx.Index("doc2", Text("data set two"))
+
+	idx.Delete("doc1")
+	if got := idsOf(idx.SearchPhrase("data set")); !equalStrings(got, []string{"doc2"}) {
+		t.Fatalf(`SearchPhrase after delete = %v, want [doc2]`, got)
+	}
+
+	// Re-index doc2 reversed: the old "data set" adjacency must not linger.
+	idx.Index("doc2", Text("set data now"))
+	if got := idx.SearchPhrase("data set"); got != nil {
+		t.Fatalf(`SearchPhrase("data set") after reversed re-index = %v, want nil`, idsOf(got))
+	}
+	if got := idsOf(idx.SearchPhrase("set data")); !equalStrings(got, []string{"doc2"}) {
+		t.Fatalf(`SearchPhrase("set data") after re-index = %v, want [doc2]`, got)
+	}
+}
+
+// TestSearchPhraseCJK verifies phrase adjacency over the script-aware analyzer,
+// where a CJK run indexes overlapping bigrams as the primary (word) channel: a
+// query phrase's bigrams must occur at consecutive positions, exactly as they
+// do inside the matching run.
+func TestSearchPhraseCJK(t *testing.T) {
+	idx := NewInvertedIndex[string, Document](NewScriptAwareAnalyzer(), nil, WithPositions())
+	// "データセット" bigrams デー ータ タセ セッ ット appear consecutively here.
+	idx.Index("match", Text("データセットを解析する"))
+	// The same characters, but セット precedes データ — the phrase's bigrams
+	// are not consecutive.
+	idx.Index("split", Text("セットのデータを見る"))
+
+	got := idsOf(idx.SearchPhrase("データセット"))
+	if !equalStrings(got, []string{"match"}) {
+		t.Fatalf(`SearchPhrase("データセット") = %v, want [match]`, got)
+	}
+}
+
+// TestSearchPhraseTopK covers the bounded-selection sibling: k caps the page,
+// accept filters candidates, and k <= 0 or no word terms return nil.
+func TestSearchPhraseTopK(t *testing.T) {
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, WithPositions())
+	idx.Index("a", Text("data set alpha"))
+	idx.Index("b", Text("data set beta data set"))
+	idx.Index("c", Text("no phrase here"))
+
+	t.Run("k bounds the page to the top hit", func(t *testing.T) {
+		got := idx.SearchPhraseTopK("data set", 1, nil)
+		if len(got) != 1 {
+			t.Fatalf("SearchPhraseTopK k=1 returned %d results, want 1", len(got))
+		}
+	})
+
+	t.Run("accept filters a candidate out", func(t *testing.T) {
+		got := idsOf(idx.SearchPhraseTopK("data set", 10, func(id string) bool { return id != "b" }))
+		sort.Strings(got)
+		if !equalStrings(got, []string{"a"}) {
+			t.Fatalf("SearchPhraseTopK with accept = %v, want [a]", got)
+		}
+	})
+
+	t.Run("k <= 0 returns nil", func(t *testing.T) {
+		if got := idx.SearchPhraseTopK("data set", 0, nil); got != nil {
+			t.Fatalf("SearchPhraseTopK k=0 = %v, want nil", idsOf(got))
+		}
+	})
+
+	t.Run("no word terms returns nil", func(t *testing.T) {
+		if got := idx.SearchPhraseTopK("   ", 10, nil); got != nil {
+			t.Fatalf("SearchPhraseTopK blank = %v, want nil", idsOf(got))
+		}
+	})
+}
+
+// TestContainsSortedU32 covers the binary-search helper phrase adjacency relies
+// on, including the empty slice and both boundary elements.
+func TestContainsSortedU32(t *testing.T) {
+	s := []uint32{2, 5, 5, 9}
+	cases := []struct {
+		v    uint32
+		want bool
+	}{
+		{2, true}, {9, true}, {5, true}, {0, false}, {3, false}, {10, false},
+	}
+	for _, c := range cases {
+		if got := containsSortedU32(s, c.v); got != c.want {
+			t.Fatalf("containsSortedU32(%v, %d) = %v, want %v", s, c.v, got, c.want)
+		}
+	}
+	if containsSortedU32(nil, 1) {
+		t.Fatal("containsSortedU32(nil, 1) = true, want false")
+	}
+}

--- a/core/search/posting.go
+++ b/core/search/posting.go
@@ -3,15 +3,21 @@ package search
 import "github.com/RoaringBitmap/roaring/v2"
 
 // postingList is one term's posting set: which document ordinals contain the
-// term, plus their term frequencies. Membership lives in a Roaring bitmap —
-// compressed and mutable, so it fits the decaying workload's constant add /
-// remove without the per-entry overhead of a map keyed by the document id.
-// Frequencies default to 1 and only the comparatively rare term that occurs
-// more than once in a document is recorded in tfHi, so the common case carries
-// no per-(term, document) frequency storage at all.
+// term, plus their term frequencies and — when the index tracks positions —
+// the token positions the term occupies in each document. Membership lives in
+// a Roaring bitmap — compressed and mutable, so it fits the decaying
+// workload's constant add / remove without the per-entry overhead of a map
+// keyed by the document id. Frequencies default to 1 and only the
+// comparatively rare term that occurs more than once in a document is recorded
+// in tfHi, so the common case carries no per-(term, document) frequency
+// storage at all. positions is nil unless the index was built WithPositions
+// and the term carries at least one position in the document, so an index that
+// serves only OR-union ranking pays nothing for phrase/proximity support
+// (#889).
 type postingList struct {
-	docs *roaring.Bitmap   // document ordinals containing this term
-	tfHi map[uint32]uint16 // ordinal -> term frequency, recorded only when tf > 1
+	docs      *roaring.Bitmap     // document ordinals containing this term
+	tfHi      map[uint32]uint16   // ordinal -> term frequency, recorded only when tf > 1
+	positions map[uint32][]uint32 // ordinal -> ascending token positions, only when the index tracks positions
 }
 
 // newPostingList returns an empty posting list ready to record documents.
@@ -20,8 +26,13 @@ func newPostingList() *postingList {
 }
 
 // set records that document ord contains the term tf times (tf >= 1). A tf of 1
-// — the common case — costs only the bitmap membership bit.
-func (p *postingList) set(ord uint32, tf int) {
+// — the common case — costs only the bitmap membership bit. positions, when
+// non-empty, are the term's ascending token positions in the document; they
+// are stored only when the index tracks positions (WithPositions) and only for
+// the primary word channel, so an OR-union-only index passes nil and pays
+// nothing. The slice is retained as-is (not copied): callers build a fresh
+// per-document slice, so no two posting lists alias it.
+func (p *postingList) set(ord uint32, tf int, positions []uint32) {
 	p.docs.Add(ord)
 	if tf > 1 {
 		if p.tfHi == nil {
@@ -29,16 +40,30 @@ func (p *postingList) set(ord uint32, tf int) {
 		}
 		p.tfHi[ord] = clampTF(tf)
 	}
+	if len(positions) > 0 {
+		if p.positions == nil {
+			p.positions = make(map[uint32][]uint32)
+		}
+		p.positions[ord] = positions
+	}
 }
 
 // remove drops document ord and reports whether the list is now empty, so the
-// caller can delete it and release the term id in lockstep.
+// caller can delete it and release the term id in lockstep. Positions are
+// dropped in the same step, so the decaying delete path never leaks a
+// document's position slice.
 func (p *postingList) remove(ord uint32) (empty bool) {
 	p.docs.Remove(ord)
 	if p.tfHi != nil {
 		delete(p.tfHi, ord)
 		if len(p.tfHi) == 0 {
 			p.tfHi = nil
+		}
+	}
+	if p.positions != nil {
+		delete(p.positions, ord)
+		if len(p.positions) == 0 {
+			p.positions = nil
 		}
 	}
 	return p.docs.IsEmpty()
@@ -53,6 +78,16 @@ func (p *postingList) tf(ord uint32) int {
 		}
 	}
 	return 1
+}
+
+// positionsOf returns document ord's ascending token positions for this term,
+// or nil when the index does not track positions (or ord carries none). The
+// slice is owned by the posting list; callers must not mutate it.
+func (p *postingList) positionsOf(ord uint32) []uint32 {
+	if p.positions == nil {
+		return nil
+	}
+	return p.positions[ord]
 }
 
 // cardinality is the document frequency (DF): how many documents hold the term.

--- a/core/search/posting_test.go
+++ b/core/search/posting_test.go
@@ -6,8 +6,8 @@ func TestPostingList(t *testing.T) {
 	p := newPostingList()
 
 	t.Run("set records membership; tf defaults to 1, overrides above it", func(t *testing.T) {
-		p.set(10, 1)
-		p.set(20, 3) // tf > 1 is recorded in tfHi
+		p.set(10, 1, nil)
+		p.set(20, 3, nil) // tf > 1 is recorded in tfHi
 		if got := p.cardinality(); got != 2 {
 			t.Fatalf("cardinality = %d, want 2", got)
 		}
@@ -33,11 +33,29 @@ func TestPostingList(t *testing.T) {
 			t.Fatalf("cardinality after emptying = %d, want 0", got)
 		}
 	})
+
+	t.Run("positions are recorded, read back, and dropped on remove", func(t *testing.T) {
+		q := newPostingList()
+		q.set(1, 2, []uint32{3, 7}) // two occurrences at positions 3 and 7
+		q.set(2, 1, nil)            // present, but no positions tracked
+		if got := q.positionsOf(1); len(got) != 2 || got[0] != 3 || got[1] != 7 {
+			t.Fatalf("positionsOf(1) = %v, want [3 7]", got)
+		}
+		if got := q.positionsOf(2); got != nil {
+			t.Fatalf("positionsOf(2) = %v, want nil (set with nil positions)", got)
+		}
+		if empty := q.remove(1); empty {
+			t.Fatal("remove(1) reported empty while ord 2 remains")
+		}
+		if got := q.positionsOf(1); got != nil {
+			t.Fatalf("positionsOf(1) after remove = %v, want nil (positions dropped)", got)
+		}
+	})
 }
 
 func TestPostingListClampsTF(t *testing.T) {
 	p := newPostingList()
-	p.set(1, 1<<20) // far above the uint16 ceiling
+	p.set(1, 1<<20, nil) // far above the uint16 ceiling
 	if got, want := p.tf(1), int(^uint16(0)); got != want {
 		t.Fatalf("tf clamp = %d, want %d", got, want)
 	}

--- a/core/search/proximity.go
+++ b/core/search/proximity.go
@@ -1,0 +1,113 @@
+package search
+
+// proximityBoostWeight scales the proximity bonus added to a multi-term query's
+// OR-union scores: a document where the query's word-channel terms cluster
+// close together is lifted above one where they are scattered, the way Lucene's
+// phrase/span proximity rewards tight matches. It is deliberately modest so it
+// reorders near-ties without overturning the BM25 ordering; 0 would disable it.
+const proximityBoostWeight = 0.3
+
+// applyProximityLocked adds a proximity bonus to the OR-union scores of a
+// multi-term query when the index tracks positions (WithPositions). For each
+// already-matched document carrying at least two of the query's distinct
+// word-channel terms, it finds the smallest window covering one occurrence of
+// each present term and adds a bonus that grows as that window tightens, so an
+// exact or near phrase outranks the same terms scattered across a long
+// document. Documents with fewer than two present query terms — and every
+// document when positions are off or the query has a single word term — keep
+// their OR-union score untouched. Callers must hold idx.mu.
+//
+// It runs after scoreLocked over the same match set, so it never widens the
+// candidate pool: SearchTopK's bounded selection still sees exactly the
+// OR-union matches, now with tighter matches ranked higher.
+func (idx *InvertedIndex[S, D]) applyProximityLocked(scores map[uint32]float64, queryTerms map[Token]struct{}) {
+	if !idx.positions || len(scores) == 0 {
+		return
+	}
+	cp := &idx.classes[ClassWord]
+	if cp.docCount == 0 {
+		return
+	}
+	// Resolve the distinct word-channel query terms that exist in the corpus;
+	// fewer than two means there is no pair whose distance could matter.
+	var lists []*postingList
+	for token := range queryTerms {
+		if token.Class != ClassWord {
+			continue
+		}
+		tid, ok := cp.dict.lookup(token.Term)
+		if !ok {
+			continue
+		}
+		if pl := cp.postings[tid]; pl != nil {
+			lists = append(lists, pl)
+		}
+	}
+	if len(lists) < 2 {
+		return
+	}
+	present := make([][]uint32, 0, len(lists))
+	for ord := range scores {
+		present = present[:0]
+		for _, pl := range lists {
+			if pos := pl.positionsOf(ord); pos != nil {
+				present = append(present, pos)
+			}
+		}
+		if len(present) < 2 {
+			continue
+		}
+		w := smallestWindow(present)
+		if w < 0 {
+			continue
+		}
+		// The tightest window for t present terms spans t-1 gaps (consecutive
+		// positions), so span is the excess spread over that ideal: 0 for an
+		// exact adjacency, growing as the terms drift apart. The bonus decays
+		// as 1/(span+1) and scales with the number of clustered terms.
+		span := w - (len(present) - 1)
+		if span < 0 {
+			span = 0
+		}
+		scores[ord] += proximityBoostWeight * float64(len(present)-1) / float64(span+1)
+	}
+}
+
+// smallestWindow returns the width (largest position minus smallest) of the
+// smallest window that includes at least one position from each list, or -1 if
+// any list is empty. Each list must be ascending. It is the classic "smallest
+// range covering elements from k sorted lists" sweep: repeatedly advance the
+// pointer sitting at the current minimum — the only move that can shrink the
+// window — until that list is exhausted.
+func smallestWindow(lists [][]uint32) int {
+	ptr := make([]int, len(lists))
+	best := -1
+	for {
+		lo := ^uint32(0)
+		var hi uint32
+		loList := -1
+		for i, l := range lists {
+			if len(l) == 0 {
+				return -1
+			}
+			p := l[ptr[i]]
+			if p < lo {
+				lo = p
+				loList = i
+			}
+			if p > hi {
+				hi = p
+			}
+		}
+		if w := int(hi - lo); best < 0 || w < best {
+			best = w
+			if best == 0 {
+				return 0
+			}
+		}
+		ptr[loList]++
+		if ptr[loList] == len(lists[loList]) {
+			return best
+		}
+	}
+}

--- a/core/search/proximity_test.go
+++ b/core/search/proximity_test.go
@@ -1,0 +1,93 @@
+package search
+
+import "testing"
+
+// TestProximityBoostRanksTightMatchFirst isolates the proximity boost: two
+// documents with identical length and term frequencies, differing only in how
+// far apart the query terms sit, so the boost is the sole tie-breaker and the
+// adjacent document must rank first.
+func TestProximityBoostRanksTightMatchFirst(t *testing.T) {
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, WithPositions())
+	idx.Index("adjacent", Text("alpha quick fox beta gamma delta"))  // quick@1 fox@2
+	idx.Index("scattered", Text("quick alpha beta gamma delta fox")) // quick@0 fox@5
+
+	res := idx.Search("quick fox")
+	if len(res) != 2 {
+		t.Fatalf(`Search("quick fox") returned %d results, want 2`, len(res))
+	}
+	if res[0].ID != "adjacent" {
+		t.Fatalf("proximity boost did not rank the adjacent doc first: %+v", res)
+	}
+	if res[0].Score <= res[1].Score {
+		t.Fatalf("adjacent score %.4f not above scattered %.4f", res[0].Score, res[1].Score)
+	}
+}
+
+// TestProximityBoostInertWithoutPositions verifies the boost needs positions:
+// the same two documents score identically when the index tracks none, so the
+// OR-union ranking is unchanged.
+func TestProximityBoostInertWithoutPositions(t *testing.T) {
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil) // no WithPositions
+	idx.Index("adjacent", Text("alpha quick fox beta gamma delta"))
+	idx.Index("scattered", Text("quick alpha beta gamma delta fox"))
+
+	res := idx.Search("quick fox")
+	if len(res) != 2 {
+		t.Fatalf(`Search("quick fox") returned %d results, want 2`, len(res))
+	}
+	// Identical BM25 statistics and no proximity signal: the scores tie exactly.
+	if res[0].Score != res[1].Score {
+		t.Fatalf("scores differ without positions: %+v", res)
+	}
+}
+
+// TestProximityBoostSingleTermNoOp verifies a single-term query has no pair to
+// measure, so the boost is a no-op and ranking stays pure BM25 (the shorter,
+// denser document still wins on its own merits).
+func TestProximityBoostSingleTermNoOp(t *testing.T) {
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, WithPositions())
+	idx.Index("dense", Text("quick quick fox"))
+	idx.Index("sparse", Text("quick alpha beta gamma"))
+
+	res := idx.Search("quick")
+	if len(res) != 2 || res[0].ID != "dense" {
+		t.Fatalf(`Search("quick") = %+v, want "dense" first on term frequency`, res)
+	}
+}
+
+// TestProximityBoostTopK verifies the boost also reorders SearchTopK, which
+// applies it before bounded selection so a tight match can claim a scarce slot.
+func TestProximityBoostTopK(t *testing.T) {
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, WithPositions())
+	idx.Index("adjacent", Text("alpha quick fox beta gamma delta"))
+	idx.Index("scattered", Text("quick alpha beta gamma delta fox"))
+
+	res := idx.SearchTopK("quick fox", 1, nil)
+	if len(res) != 1 || res[0].ID != "adjacent" {
+		t.Fatalf(`SearchTopK("quick fox", 1) = %+v, want [adjacent]`, res)
+	}
+}
+
+// TestSmallestWindow covers the smallest-range sweep: adjacency, spread, three
+// lists, choosing the closest occurrences, a single list, and an empty list.
+func TestSmallestWindow(t *testing.T) {
+	tests := []struct {
+		name  string
+		lists [][]uint32
+		want  int
+	}{
+		{"two adjacent", [][]uint32{{1}, {2}}, 1},
+		{"two apart", [][]uint32{{0}, {5}}, 5},
+		{"three consecutive", [][]uint32{{0}, {1}, {2}}, 2},
+		{"picks the closest occurrences", [][]uint32{{0, 10}, {9}}, 1},
+		{"single list has zero width", [][]uint32{{3, 7}}, 0},
+		{"an empty list has no window", [][]uint32{{1}, {}}, -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := smallestWindow(tt.lists); got != tt.want {
+				t.Fatalf("smallestWindow(%v) = %d, want %d", tt.lists, got, tt.want)
+			}
+		})
+	}
+}

--- a/core/search/relevance/parity_gate_test.go
+++ b/core/search/relevance/parity_gate_test.go
@@ -20,10 +20,11 @@ import (
 
 // productionIndex replicates the exact index core/graphcache.newSearchIndex
 // builds for SearchVertices — since #888 the script-aware dual-channel
-// analyzer with class-weighted BM25. It is intentionally a replica, not an
-// import: graphcache depends on search, so this package (a sibling under
-// search) states the pipeline explicitly, and this comment plus the one on
-// newSearchIndex keep the two in sync.
+// analyzer with class-weighted BM25, and since #889 with positional postings
+// (WithPositions) for phrase and proximity ranking. It is intentionally a
+// replica, not an import: graphcache depends on search, so this package (a
+// sibling under search) states the pipeline explicitly, and this comment plus
+// the one on newSearchIndex keep the two in sync.
 func productionIndex() *search.InvertedIndex[string, search.Text] {
 	return search.NewInvertedIndex[string, search.Text](
 		search.NewScriptAwareAnalyzer(),
@@ -31,6 +32,7 @@ func productionIndex() *search.InvertedIndex[string, search.Text] {
 			Base:       search.BM25{K1: search.DefaultBM25K1, B: search.DefaultBM25B},
 			GramWeight: search.DefaultGramWeight,
 		},
+		search.WithPositions(),
 	)
 }
 


### PR DESCRIPTION
## Summary

Implements #889 (epic #886 — search relevance parity with Lucene): opt-in
**positional postings** and the phrase / proximity rankers built on them.

`postingList` gained a `positions` map recorded only when the index is built
`WithPositions()` and only on the primary word channel (phrase and proximity are
word-level; a CJK run's grams already live on the word channel, so `pos+1`
adjacency works for both scripts). The production graphcache index and the
relevance parity-gate replica enable it in lockstep.

### What lands

- **Positional postings** (`posting.go`): `positions map[uint32][]uint32`, opt-in,
  mirroring the `tfHi` lifecycle (zero cost when off, dropped on `remove` in
  lockstep with the decaying delete path).
- **`WithPositions()` index option** (`inverted_index.go`) + ClassWord position
  recording; `SearchTopK`'s selection phase factored into a shared
  `selectTopKLocked`.
- **Phrase search** (`phrase.go`): `SearchPhrase` / `SearchPhraseTopK` —
  AND-intersect the query's word postings, then verify consecutive positions in
  query order. Degrades to the AND-intersection when positions are off.
- **Proximity boost** (`proximity.go`): a modest bonus on multi-term OR-union
  scores that lifts documents whose query terms cluster tightly (smallest
  covering window), applied over the existing match set so `SearchTopK`'s bounded
  selection is untouched.

### Relevance impact

The proximity boost leaves **every ratchet floor unchanged** on the golden
corpora (en 0.9280 / ja 0.9118 / mixed 0.9538) — it reorders near-ties without
overturning BM25 — and keeps **ja an exact tie with Lucene's CJKAnalyzer**, so
`TestLuceneBaselineComparison` and `TestProductionPipelineRelevanceFloors` stay
green with no floor edits. On this small corpus phrase search trades recall for
precision (so nDCG is a wash), so a new `TestPhraseSearchPrecision` gate asserts
the phrase path returns only relevant hits with a direct hit on top for the
corpus's phrasal queries (`kubernetes rolling update`, `data set`).

### Tests & benchmarks

- Unit: positions survive index/delete/re-index; adjacency across word + CJK
  classes; phrase degrades to AND without positions; proximity ranks tight
  matches first and is inert without positions / for single-term queries; the
  smallest-window sweep.
- Benchmarks: build + footprint with/without positions, proximity search
  with/without positions, and phrase search.

Local gate green: `gofmt`, `go vet`, `go test ./...` (+ `-race` on search) in
`core`; `server` and root modules build and test clean.

Closes #889
