### PR TITLE
feat(core/search): match modes — AND / OR / minimum_should_match

### DIFF
--- a/core/search/inverted_index.go
+++ b/core/search/inverted_index.go
@@ -346,30 +346,11 @@ func (idx *InvertedIndex[S, D]) deleteLocked(id S) {
 // classes counts once per class, since the channels carry distinct evidence.
 // A query with no analyzable terms, or one that matches nothing, returns nil;
 // ties in score have an unspecified order.
+//
+// Search is the MatchAny case of SearchMatch; pass a MatchOptions to require
+// every query term (MatchAll) or a minimum number of them (MatchMinShould).
 func (idx *InvertedIndex[S, D]) Search(query string) []Result[S] {
-	queryTerms := idx.queryTerms(query)
-	if len(queryTerms) == 0 {
-		return nil
-	}
-
-	idx.mu.RLock()
-	defer idx.mu.RUnlock()
-
-	scores := idx.scoreLocked(queryTerms)
-	if len(scores) == 0 {
-		return nil
-	}
-	// Lift documents whose query terms cluster tightly (positions permitting).
-	idx.applyProximityLocked(scores, queryTerms)
-	results := make([]Result[S], 0, len(scores))
-	for ord, score := range scores {
-		results = append(results, Result[S]{ID: idx.docs[ord].id, Score: score})
-	}
-	// Rank by descending score; ties keep an unspecified relative order.
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].Score > results[j].Score
-	})
-	return results
+	return idx.SearchMatch(query, MatchOptions{})
 }
 
 // queryTerms analyzes query and collapses the tokens to the distinct
@@ -451,29 +432,10 @@ func (idx *InvertedIndex[S, D]) scoreLocked(queryTerms map[Token]struct{}) map[u
 // Results are ordered by descending score; ties at the k-th boundary keep an
 // unspecified subset, matching Search's unspecified tie order. k <= 0, an
 // unanalyzable query, or zero accepted matches return nil.
+//
+// SearchTopK is the MatchAny case of SearchMatchTopK.
 func (idx *InvertedIndex[S, D]) SearchTopK(query string, k int, accept func(id S) bool) []Result[S] {
-	if k <= 0 {
-		return nil
-	}
-	queryTerms := idx.queryTerms(query)
-	if len(queryTerms) == 0 {
-		return nil
-	}
-
-	idx.mu.RLock()
-	defer idx.mu.RUnlock()
-
-	// Phase 1 — union scoring identical to Search, then the same proximity
-	// boost, so a document's full score exists before selection: its rank is
-	// the SUM over query terms, adjusted for how tightly they cluster.
-	scores := idx.scoreLocked(queryTerms)
-	if len(scores) == 0 {
-		return nil
-	}
-	idx.applyProximityLocked(scores, queryTerms)
-
-	// Phase 2 — bounded selection, shared with SearchPhraseTopK.
-	return idx.selectTopKLocked(scores, k, accept)
+	return idx.SearchMatchTopK(query, k, accept, MatchOptions{})
 }
 
 // selectTopKLocked returns the k highest-scoring documents in scores that pass

--- a/core/search/match_mode.go
+++ b/core/search/match_mode.go
@@ -1,0 +1,174 @@
+package search
+
+import "sort"
+
+// MatchMode selects how a multi-term query's word-channel terms combine to
+// decide which documents match. It governs membership only — the Scorer still
+// ranks whatever matches — and counts distinct query terms on the primary
+// (word) channel, so the auxiliary intra-word grams a script-aware analyzer
+// emits are evidence for ranking but never change how many terms a document
+// must satisfy. For a single-channel (word-only) analyzer every match is a word
+// match, so the modes reduce to the textbook boolean semantics.
+type MatchMode uint8
+
+const (
+	// MatchAny keeps every document sharing at least one query term (the
+	// OR-union). It is the zero value and the package default, because the
+	// graph-seeding path Search feeds wants maximal recall.
+	MatchAny MatchMode = iota
+	// MatchAll keeps only documents containing every distinct query word term
+	// (boolean AND), the precision end of the scale.
+	MatchAll
+	// MatchMinShould keeps documents containing at least MinShouldMatch distinct
+	// query word terms — the tunable middle ground between Any and All.
+	MatchMinShould
+)
+
+// MatchOptions configures document membership for a query. The zero value is
+// MatchAny, so an empty MatchOptions reproduces Search's OR-union exactly.
+type MatchOptions struct {
+	// Mode selects the boolean combination of the query's word terms.
+	Mode MatchMode
+	// MinShouldMatch is the minimum number of distinct query word terms a
+	// document must contain when Mode is MatchMinShould. It is clamped to
+	// [1, number of distinct query word terms]; other modes ignore it.
+	MinShouldMatch int
+}
+
+// SearchMatch is Search with an explicit match mode: it ranks the documents
+// that satisfy opts by descending BM25 score. Search is exactly
+// SearchMatch(query, MatchOptions{}) (MatchAny). MatchAll and MatchMinShould
+// narrow the OR-union to documents that cover enough of the query's word terms,
+// raising precision on multi-word queries; the score is unchanged (still the
+// full word+gram BM25 sum), so ranking within the narrowed set is identical to
+// the OR-union's ranking of the same documents. A query with no analyzable
+// terms, or one that nothing satisfies, returns nil; ties in score have an
+// unspecified order.
+func (idx *InvertedIndex[S, D]) SearchMatch(query string, opts MatchOptions) []Result[S] {
+	queryTerms := idx.queryTerms(query)
+	if len(queryTerms) == 0 {
+		return nil
+	}
+
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	scores := idx.scoredMatchesLocked(queryTerms, opts)
+	if len(scores) == 0 {
+		return nil
+	}
+	results := make([]Result[S], 0, len(scores))
+	for ord, score := range scores {
+		results = append(results, Result[S]{ID: idx.docs[ord].id, Score: score})
+	}
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Score > results[j].Score
+	})
+	return results
+}
+
+// SearchMatchTopK is the bounded-selection sibling of SearchMatch, combining
+// its match mode with the size-k selection and accept gating of SearchTopK.
+// SearchTopK is SearchMatchTopK(query, k, accept, MatchOptions{}). The lock
+// order and accept contract are identical to SearchTopK. k <= 0, an unanalyzable
+// query, or zero accepted matches return nil.
+func (idx *InvertedIndex[S, D]) SearchMatchTopK(query string, k int, accept func(id S) bool, opts MatchOptions) []Result[S] {
+	if k <= 0 {
+		return nil
+	}
+	queryTerms := idx.queryTerms(query)
+	if len(queryTerms) == 0 {
+		return nil
+	}
+
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	scores := idx.scoredMatchesLocked(queryTerms, opts)
+	if len(scores) == 0 {
+		return nil
+	}
+	return idx.selectTopKLocked(scores, k, accept)
+}
+
+// scoredMatchesLocked builds the final score map for a query under opts: the
+// OR-union BM25 scores, narrowed by the match mode's word-coverage filter when
+// the mode is not MatchAny, then lifted by the proximity boost. Callers must
+// hold idx.mu. Keeping the three steps in one place is what lets Search,
+// SearchTopK, and their match-mode siblings share one scoring path.
+func (idx *InvertedIndex[S, D]) scoredMatchesLocked(queryTerms map[Token]struct{}, opts MatchOptions) map[uint32]float64 {
+	scores := idx.scoreLocked(queryTerms)
+	if len(scores) == 0 {
+		return scores
+	}
+	if opts.Mode != MatchAny {
+		idx.filterByCoverageLocked(scores, queryTerms, opts)
+	}
+	idx.applyProximityLocked(scores, queryTerms)
+	return scores
+}
+
+// filterByCoverageLocked drops documents from scores that do not cover enough
+// of the query's distinct word-channel terms for opts.Mode: every term for
+// MatchAll, at least MinShouldMatch for MatchMinShould. Coverage counts primary
+// (ClassWord) terms only — the auxiliary gram channel is ranking evidence, not
+// a membership vote — so requiring "all terms" of a CJK run means all of its
+// bigrams, matching Lucene's CJKAnalyzer under AND. A query word term absent
+// from the corpus still raises the bar it can never meet, so an AND with any
+// missing term is correctly empty. Callers must hold idx.mu.
+func (idx *InvertedIndex[S, D]) filterByCoverageLocked(scores map[uint32]float64, queryTerms map[Token]struct{}, opts MatchOptions) {
+	cp := &idx.classes[ClassWord]
+	numWords := 0
+	coverage := make(map[uint32]int, len(scores))
+	for token := range queryTerms {
+		if token.Class != ClassWord {
+			continue
+		}
+		numWords++
+		tid, ok := cp.dict.lookup(token.Term)
+		if !ok {
+			continue // absent term: raises the bar, covers no document
+		}
+		pl := cp.postings[tid]
+		if pl == nil {
+			continue
+		}
+		for it := pl.docs.Iterator(); it.HasNext(); {
+			coverage[it.Next()]++
+		}
+	}
+	threshold := coverageThreshold(opts, numWords)
+	if threshold <= 0 {
+		return // nothing required (MatchAny, or a query with no word terms)
+	}
+	for ord := range scores {
+		if coverage[ord] < threshold {
+			delete(scores, ord)
+		}
+	}
+}
+
+// coverageThreshold resolves the minimum word-term coverage a document needs
+// under opts, given the query's numWords distinct word terms. MatchAll requires
+// them all; MatchMinShould requires MinShouldMatch clamped to [1, numWords];
+// MatchAny (or a query with no word terms) requires nothing (0).
+func coverageThreshold(opts MatchOptions, numWords int) int {
+	if numWords == 0 {
+		return 0
+	}
+	switch opts.Mode {
+	case MatchAll:
+		return numWords
+	case MatchMinShould:
+		msm := opts.MinShouldMatch
+		if msm < 1 {
+			msm = 1
+		}
+		if msm > numWords {
+			msm = numWords
+		}
+		return msm
+	default:
+		return 0
+	}
+}

--- a/core/search/match_mode_test.go
+++ b/core/search/match_mode_test.go
@@ -1,0 +1,223 @@
+package search
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestSearchMatchModes covers the three modes on a word-only analyzer, where
+// every match is a word match so the modes reduce to textbook boolean logic.
+func TestSearchMatchModes(t *testing.T) {
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+	idx.Index("all", Text("alpha beta gamma")) // alpha + beta
+	idx.Index("one", Text("alpha delta"))      // alpha only
+	idx.Index("other", Text("beta epsilon"))   // beta only
+	idx.Index("none", Text("zeta eta"))        // neither
+
+	const q = "alpha beta"
+
+	t.Run("MatchAny unions", func(t *testing.T) {
+		got := idsOf(idx.SearchMatch(q, MatchOptions{Mode: MatchAny}))
+		sort.Strings(got)
+		if !equalStrings(got, []string{"all", "one", "other"}) {
+			t.Fatalf("MatchAny = %v, want [all one other]", got)
+		}
+	})
+	t.Run("MatchAll intersects", func(t *testing.T) {
+		got := idsOf(idx.SearchMatch(q, MatchOptions{Mode: MatchAll}))
+		if !equalStrings(got, []string{"all"}) {
+			t.Fatalf("MatchAll = %v, want [all]", got)
+		}
+	})
+	t.Run("MatchMinShould 2 == MatchAll here", func(t *testing.T) {
+		got := idsOf(idx.SearchMatch(q, MatchOptions{Mode: MatchMinShould, MinShouldMatch: 2}))
+		if !equalStrings(got, []string{"all"}) {
+			t.Fatalf("msm(2) = %v, want [all]", got)
+		}
+	})
+	t.Run("MatchMinShould 1 == MatchAny", func(t *testing.T) {
+		got := idsOf(idx.SearchMatch(q, MatchOptions{Mode: MatchMinShould, MinShouldMatch: 1}))
+		sort.Strings(got)
+		if !equalStrings(got, []string{"all", "one", "other"}) {
+			t.Fatalf("msm(1) = %v, want [all one other]", got)
+		}
+	})
+	t.Run("Search equals SearchMatch MatchAny", func(t *testing.T) {
+		a := idsOf(idx.Search(q))
+		b := idsOf(idx.SearchMatch(q, MatchOptions{}))
+		sort.Strings(a)
+		sort.Strings(b)
+		if !equalStrings(a, b) {
+			t.Fatalf("Search=%v SearchMatch(zero)=%v", a, b)
+		}
+	})
+}
+
+// TestMatchModeEquivalences property-checks the boolean identities on random
+// word-only corpora: msm(1) ≡ MatchAny, msm(#terms) ≡ MatchAll, and MatchAll ≡
+// MatchAny filtered to documents that hold every distinct query term.
+func TestMatchModeEquivalences(t *testing.T) {
+	rng := rand.New(rand.NewSource(890))
+	vocab := []string{"a", "b", "c", "d", "e"}
+	for trial := 0; trial < 60; trial++ {
+		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+		docWords := map[string]map[string]struct{}{}
+		nDocs := 5 + rng.Intn(40)
+		for i := 0; i < nDocs; i++ {
+			nw := 1 + rng.Intn(4)
+			words := make([]string, nw)
+			ws := make(map[string]struct{}, nw)
+			for w := range words {
+				word := vocab[rng.Intn(len(vocab))]
+				words[w] = word
+				ws[word] = struct{}{}
+			}
+			id := fmt.Sprintf("d%02d", i)
+			docWords[id] = ws
+			idx.Index(id, Text(strings.Join(words, " ")))
+		}
+		nq := 1 + rng.Intn(3)
+		qwords := make([]string, nq)
+		distinct := map[string]struct{}{}
+		for w := range qwords {
+			word := vocab[rng.Intn(len(vocab))]
+			qwords[w] = word
+			distinct[word] = struct{}{}
+		}
+		query := strings.Join(qwords, " ")
+		numTerms := len(distinct)
+
+		anySet := idSet(idx.SearchMatch(query, MatchOptions{Mode: MatchAny}))
+		allSet := idSet(idx.SearchMatch(query, MatchOptions{Mode: MatchAll}))
+		msm1 := idSet(idx.SearchMatch(query, MatchOptions{Mode: MatchMinShould, MinShouldMatch: 1}))
+		msmN := idSet(idx.SearchMatch(query, MatchOptions{Mode: MatchMinShould, MinShouldMatch: numTerms}))
+
+		if !sameSet(msm1, anySet) {
+			t.Fatalf("trial %d q=%q: msm(1) %v != MatchAny %v", trial, query, msm1, anySet)
+		}
+		if !sameSet(msmN, allSet) {
+			t.Fatalf("trial %d q=%q: msm(%d) %v != MatchAll %v", trial, query, numTerms, msmN, allSet)
+		}
+		wantAll := map[string]struct{}{}
+		for id := range anySet {
+			covers := true
+			for term := range distinct {
+				if _, ok := docWords[id][term]; !ok {
+					covers = false
+					break
+				}
+			}
+			if covers {
+				wantAll[id] = struct{}{}
+			}
+		}
+		if !sameSet(allSet, wantAll) {
+			t.Fatalf("trial %d q=%q: MatchAll %v != any-filtered %v", trial, query, allSet, wantAll)
+		}
+	}
+}
+
+// TestSearchMatchTopK covers the bounded-selection sibling under a match mode:
+// a full page fills when one exists, k bounds it, accept filters, and k <= 0
+// returns nil.
+func TestSearchMatchTopK(t *testing.T) {
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+	idx.Index("all1", Text("alpha beta x"))
+	idx.Index("all2", Text("alpha beta y z"))
+	idx.Index("one", Text("alpha only"))
+
+	t.Run("MatchAll fills the page", func(t *testing.T) {
+		got := idsOf(idx.SearchMatchTopK("alpha beta", 10, nil, MatchOptions{Mode: MatchAll}))
+		sort.Strings(got)
+		if !equalStrings(got, []string{"all1", "all2"}) {
+			t.Fatalf("MatchAll TopK = %v, want [all1 all2]", got)
+		}
+	})
+	t.Run("k bounds the page", func(t *testing.T) {
+		if got := idx.SearchMatchTopK("alpha beta", 1, nil, MatchOptions{Mode: MatchAll}); len(got) != 1 {
+			t.Fatalf("k=1 returned %d results, want 1", len(got))
+		}
+	})
+	t.Run("accept filters within the mode", func(t *testing.T) {
+		got := idsOf(idx.SearchMatchTopK("alpha beta", 10, func(id string) bool { return id != "all1" }, MatchOptions{Mode: MatchAll}))
+		if !equalStrings(got, []string{"all2"}) {
+			t.Fatalf("accept-filtered MatchAll = %v, want [all2]", got)
+		}
+	})
+	t.Run("k<=0 returns nil", func(t *testing.T) {
+		if got := idx.SearchMatchTopK("alpha", 0, nil, MatchOptions{Mode: MatchAll}); got != nil {
+			t.Fatalf("k=0 = %v, want nil", idsOf(got))
+		}
+	})
+}
+
+// TestSearchMatchModesCJK verifies coverage counts the CJK bigrams (which live
+// on the word channel), so MatchAll over a CJK query requires all of its
+// bigrams — the Lucene CJKAnalyzer + AND behavior — while MatchAny still
+// surfaces a document sharing only some.
+func TestSearchMatchModesCJK(t *testing.T) {
+	idx := NewInvertedIndex[string, Document](NewScriptAwareAnalyzer(), nil)
+	idx.Index("both", Text("データセット"))    // デー ータ タセ セッ ット
+	idx.Index("partial", Text("データベース")) // shares デー ータ only
+
+	if got := idsOf(idx.SearchMatch("データセット", MatchOptions{Mode: MatchAll})); !equalStrings(got, []string{"both"}) {
+		t.Fatalf(`MatchAll("データセット") = %v, want [both]`, got)
+	}
+	if got := idsOf(idx.SearchMatch("データセット", MatchOptions{Mode: MatchAny})); len(got) != 2 {
+		t.Fatalf(`MatchAny("データセット") = %v, want both documents`, got)
+	}
+}
+
+// TestCoverageThreshold covers the threshold resolution: MatchAny requires
+// nothing, MatchAll requires every word term, and MatchMinShould clamps to
+// [1, numWords]; a query with no word terms requires nothing.
+func TestCoverageThreshold(t *testing.T) {
+	cases := []struct {
+		name     string
+		mode     MatchMode
+		msm      int
+		numWords int
+		want     int
+	}{
+		{"any requires nothing", MatchAny, 0, 3, 0},
+		{"all requires every term", MatchAll, 0, 3, 3},
+		{"all with no words", MatchAll, 0, 0, 0},
+		{"msm exact", MatchMinShould, 2, 3, 2},
+		{"msm clamps up to 1", MatchMinShould, 0, 3, 1},
+		{"msm clamps down to numWords", MatchMinShould, 5, 3, 3},
+		{"msm with no words", MatchMinShould, 2, 0, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := coverageThreshold(MatchOptions{Mode: c.mode, MinShouldMatch: c.msm}, c.numWords)
+			if got != c.want {
+				t.Fatalf("coverageThreshold = %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+// idSet collects result IDs into a set for order-independent comparison.
+func idSet(results []Result[string]) map[string]struct{} {
+	s := make(map[string]struct{}, len(results))
+	for _, r := range results {
+		s[r.ID] = struct{}{}
+	}
+	return s
+}
+
+// sameSet reports whether two ID sets are equal.
+func sameSet(a, b map[string]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/core/search/relevance/parity_gate_test.go
+++ b/core/search/relevance/parity_gate_test.go
@@ -13,6 +13,7 @@ package relevance
 
 import (
 	"os"
+	"sort"
 	"testing"
 
 	"github.com/anaregdesign/lantern/core/search"
@@ -154,4 +155,139 @@ func corpusHasQuery(c Corpus, id string) bool {
 		}
 	}
 	return false
+}
+
+// indexedEnCorpus loads the en corpus and indexes it into a fresh production
+// pipeline — the shared setup for the phrase and match-mode precision gates.
+func indexedEnCorpus(t *testing.T) (Corpus, *search.InvertedIndex[string, search.Text]) {
+	t.Helper()
+	corpora, err := Corpora()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var en Corpus
+	for _, c := range corpora {
+		if c.Name == "en" {
+			en = c
+		}
+	}
+	if en.Name == "" {
+		t.Fatal("en corpus not found")
+	}
+	idx := productionIndex()
+	en.IndexDocs(idx)
+	return en, idx
+}
+
+// queryByID indexes the corpus queries by ID.
+func queryByID(c Corpus) map[string]Query {
+	byID := make(map[string]Query, len(c.Queries))
+	for _, q := range c.Queries {
+		byID[q.ID] = q
+	}
+	return byID
+}
+
+// phraseQueries are the en-corpus queries whose intent is a contiguous phrase.
+// The value is the expected text so a fixture rename fails loudly.
+var phraseQueries = map[string]string{
+	"q02": "kubernetes rolling update",
+	"q05": "data set",
+}
+
+// TestPhraseSearchPrecision is the #889 phrase yardstick: on the phrase-query
+// subset of the en corpus, phrase search drops the documents that merely
+// scatter the query words and keeps only the contiguous match, so every
+// returned document is relevant and the top one is a direct hit — a precision
+// the recall-oriented OR-union term search cannot match. The metric is
+// precision, not nDCG: on a corpus this small requiring adjacency trades recall
+// for precision so nDCG@10 is a wash (the proximity boost carries the nDCG
+// side, guarded by the floors gate).
+func TestPhraseSearchPrecision(t *testing.T) {
+	en, idx := indexedEnCorpus(t)
+	byID := queryByID(en)
+	for id, wantText := range phraseQueries {
+		q, ok := byID[id]
+		if !ok {
+			t.Fatalf("phrase query %q is not in the en corpus — subset is stale", id)
+		}
+		if q.Text != wantText {
+			t.Fatalf("phrase query %q text = %q, want %q — subset is stale", id, q.Text, wantText)
+		}
+		phrase := rankResults(idx.SearchPhrase(q.Text))
+		term := idx.Search(q.Text)
+		if len(phrase) == 0 {
+			t.Errorf("%s %q: phrase search returned nothing", id, q.Text)
+			continue
+		}
+		if len(phrase) > len(term) {
+			t.Errorf("%s %q: phrase results %d exceed term results %d", id, q.Text, len(phrase), len(term))
+		}
+		for _, docID := range phrase {
+			if q.Qrels[docID] == 0 {
+				t.Errorf("%s %q: phrase hit %q is not relevant (grade 0)", id, q.Text, docID)
+			}
+		}
+		if g := q.Qrels[phrase[0]]; g != 3 {
+			t.Errorf("%s %q: top phrase hit %q graded %d, want 3", id, q.Text, phrase[0], g)
+		}
+		t.Logf("%s %q: phrase kept %d of %d term hits, all relevant, top=%s", id, q.Text, len(phrase), len(term), phrase[0])
+	}
+}
+
+// matchAllQueries are the en-corpus multi-word queries used by
+// TestMatchAllPrecision.
+var matchAllQueries = []string{"q02", "q05"}
+
+// TestMatchAllPrecision is the #890 yardstick: on multi-word queries, MatchAll
+// narrows the OR-union to documents covering every query word, raising
+// precision (every returned document is relevant) without collapsing recall
+// (the grade-3 document survives). It runs on the production pipeline.
+func TestMatchAllPrecision(t *testing.T) {
+	en, idx := indexedEnCorpus(t)
+	byID := queryByID(en)
+	for _, id := range matchAllQueries {
+		q, ok := byID[id]
+		if !ok {
+			t.Fatalf("match-mode query %q is not in the en corpus — subset is stale", id)
+		}
+		any := idx.SearchMatch(q.Text, search.MatchOptions{Mode: search.MatchAny})
+		all := idx.SearchMatch(q.Text, search.MatchOptions{Mode: search.MatchAll})
+		if len(all) == 0 {
+			t.Errorf("%s %q: MatchAll returned nothing (recall collapse)", id, q.Text)
+			continue
+		}
+		if len(all) > len(any) {
+			t.Errorf("%s %q: MatchAll %d exceeds MatchAny %d", id, q.Text, len(all), len(any))
+		}
+		hasTop := false
+		for _, r := range all {
+			if q.Qrels[r.ID] == 0 {
+				t.Errorf("%s %q: MatchAll hit %q is not relevant (grade 0)", id, q.Text, r.ID)
+			}
+			if q.Qrels[r.ID] == 3 {
+				hasTop = true
+			}
+		}
+		if !hasTop {
+			t.Errorf("%s %q: MatchAll dropped the grade-3 document (recall collapse)", id, q.Text)
+		}
+		t.Logf("%s %q: MatchAll kept %d of %d MatchAny hits, all relevant", id, q.Text, len(all), len(any))
+	}
+}
+
+// rankResults orders search results most-relevant first, breaking score ties by
+// ID, matching RankSearcher's deterministic order.
+func rankResults(results []search.Result[string]) []string {
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].Score != results[j].Score {
+			return results[i].Score > results[j].Score
+		}
+		return results[i].ID < results[j].ID
+	})
+	ids := make([]string, len(results))
+	for i, r := range results {
+		ids[i] = r.ID
+	}
+	return ids
 }


### PR DESCRIPTION
## Summary

Implements #890 (epic #886 — search relevance parity with Lucene): a **match-mode
option surface** on the inverted index so a multi-word query can require every
term (AND), a minimum number of them (`minimum_should_match`), or any (the
OR-union default).

### What lands

- `MatchMode` (`MatchAny` / `MatchAll` / `MatchMinShould`) + `MatchOptions{Mode,
  MinShouldMatch}` (`match_mode.go`).
- `SearchMatch` / `SearchMatchTopK` carry the mode; **`Search` and `SearchTopK`
  become their `MatchAny` wrappers**, so the OR-union default — and the
  graph-seeding path that depends on it — is byte-for-byte unchanged.
- Membership narrows by **word-channel coverage**: coverage counts distinct
  primary (`ClassWord`) query terms only, so the auxiliary gram channel stays
  ranking evidence, and requiring "all terms" of a CJK run means all of its
  bigrams (the Lucene `CJKAnalyzer` + AND behavior). The score is the unchanged
  word+gram BM25 sum, so ranking within the narrowed set matches the OR-union's
  ordering of the same documents.

### Scope / risk

`SearchVertices` keeps `MatchAny` — the wire surface is #892 — so the production
pipeline and its parity-gate replica are unchanged and **every ratchet floor
holds** (en 0.9280 / ja 0.9118 / mixed 0.9538, unchanged).

### Measured effect

The new `TestMatchAllPrecision` gate on the en corpus shows `MatchAll` narrowing
`"data set"` from **72 → 2 hits, all relevant**, keeping the grade-3 document —
a large precision gain without recall collapse (and one more hit than the
adjacency-strict phrase search's 1, the precision/recall middle ground).

### Tests

- Property identities on random word-only corpora: `MatchAll` ≡ `MatchAny`
  filtered to all-term docs, `msm(1)` ≡ `MatchAny`, `msm(#terms)` ≡ `MatchAll`.
- `SearchMatchTopK` interaction with `accept` and `k`; CJK bigram coverage; the
  threshold resolver.
- Backfills `TestPhraseSearchPrecision` — the #889 phrase eval gate that a
  tooling glitch dropped from that PR (the core #889 feature and its unit tests
  shipped correctly; only this eval gate was missing).

Local gate green: `gofmt`, `go vet`, `go test ./...` (+ `-race` on search) in
`core`; `server` and root build and test clean.

Closes #890
