### PR TITLE
feat(core/search): fuzzy (edit-distance) and prefix term matching

### DIFF
--- a/core/search/fuzzy.go
+++ b/core/search/fuzzy.go
@@ -1,0 +1,221 @@
+package search
+
+import (
+	"strings"
+
+	"github.com/RoaringBitmap/roaring/v2"
+)
+
+// MaxTermExpansions caps how many dictionary terms a single word-channel query
+// term expands to under prefix/fuzzy matching, so a hot prefix or a small
+// fuzziness over a large dictionary cannot blow up a query. It mirrors Lucene's
+// default multi-term rewrite cap; the exact term is always kept, then the scan
+// fills the remaining budget in dictionary id order (deterministic).
+const MaxTermExpansions = 50
+
+// expandsTerms reports whether the options request prefix or fuzzy term
+// expansion (as opposed to exact-term matching).
+func (o MatchOptions) expandsTerms() bool {
+	return o.PrefixTerms || o.Fuzziness > 0
+}
+
+// queryClause is one distinct analyzed query token together with the dictionary
+// term ids it matches after expansion. Without expansion the ids are just the
+// token's own interned id (or none, if the term is absent); with prefix/fuzzy
+// expansion on a word-class token the ids include the reachable terms, capped
+// at MaxTermExpansions. Coverage (match modes) treats a clause as satisfied when
+// a document carries ANY of its ids, so an expanded term still counts toward its
+// original query term rather than as a separate required term.
+type queryClause struct {
+	class   TokenClass
+	termIDs []uint32
+}
+
+// buildClausesLocked turns the distinct query tokens into scoring clauses,
+// expanding word-channel terms by prefix and/or edit distance when opts request
+// it. Auxiliary gram tokens and CJK grams (isExpandable is false for a run of
+// unbounded-script runes) are never expanded — they are fixed-width windows, so
+// prefix/fuzzy widening is meaningless. Callers hold idx.mu.
+func (idx *InvertedIndex[S, D]) buildClausesLocked(queryTerms map[Token]struct{}, opts MatchOptions) []queryClause {
+	clauses := make([]queryClause, 0, len(queryTerms))
+	for token := range queryTerms {
+		if int(token.Class) >= numTokenClasses {
+			continue
+		}
+		cp := &idx.classes[token.Class]
+		var ids []uint32
+		if token.Class == ClassWord && opts.expandsTerms() && isExpandable(token.Term) {
+			ids = cp.dict.expand(token.Term, opts.PrefixTerms, opts.Fuzziness, MaxTermExpansions)
+		} else if tid, ok := cp.dict.lookup(token.Term); ok {
+			ids = []uint32{tid}
+		}
+		clauses = append(clauses, queryClause{class: token.Class, termIDs: ids})
+	}
+	return clauses
+}
+
+// scoreClausesLocked scores documents over expanded query clauses: each clause
+// contributes the BM25 sum of its matching terms, and — when a match mode is
+// active — a document's coverage counts each satisfied word clause once (via the
+// clause's posting union), so prefix/fuzzy expansions of the same query word
+// still count as one term. Callers hold idx.mu. It is the expansion-aware
+// counterpart of scoreLocked + filterByCoverageLocked; the non-expansion path
+// keeps using those so the default query is byte-for-byte unchanged.
+func (idx *InvertedIndex[S, D]) scoreClausesLocked(clauses []queryClause, opts MatchOptions) map[uint32]float64 {
+	scores := make(map[uint32]float64)
+	var coverage map[uint32]int
+	numWords := 0
+	if opts.Mode != MatchAny {
+		coverage = make(map[uint32]int)
+	}
+	for _, cl := range clauses {
+		if coverage != nil && cl.class == ClassWord {
+			numWords++ // count every word clause, even an unmatched typo, toward the bar
+		}
+		cp := &idx.classes[cl.class]
+		if cp.docCount == 0 || len(cl.termIDs) == 0 {
+			continue
+		}
+		avgLen := float64(cp.totalLen) / float64(cp.docCount)
+		var union *roaring.Bitmap
+		if coverage != nil && cl.class == ClassWord {
+			union = roaring.New()
+		}
+		for _, tid := range cl.termIDs {
+			pl := cp.postings[tid]
+			if pl == nil {
+				continue
+			}
+			df := pl.cardinality()
+			for it := pl.docs.Iterator(); it.HasNext(); {
+				ord := it.Next()
+				scores[ord] += idx.scorer.Score(TermStats{
+					TF:     pl.tf(ord),
+					DF:     df,
+					N:      cp.docCount,
+					DocLen: idx.docs[ord].lengths[cl.class],
+					AvgLen: avgLen,
+					Class:  cl.class,
+				})
+			}
+			if union != nil {
+				union.Or(pl.docs)
+			}
+		}
+		if union != nil {
+			for it := union.Iterator(); it.HasNext(); {
+				coverage[it.Next()]++
+			}
+		}
+	}
+	if coverage != nil {
+		if threshold := coverageThreshold(opts, numWords); threshold > 0 {
+			for ord := range scores {
+				if coverage[ord] < threshold {
+					delete(scores, ord)
+				}
+			}
+		}
+	}
+	return scores
+}
+
+// isExpandable reports whether a word-channel term should be widened by
+// prefix/fuzzy expansion. A term made entirely of unbounded-script runes is a
+// CJK gram — a fixed-width window, not a word — so it is exempt (#891); any term
+// carrying at least one space-delimited-script rune is a word and expandable.
+func isExpandable(term string) bool {
+	if term == "" {
+		return false
+	}
+	for _, r := range term {
+		if !isUnboundedScript(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// expand returns the interned term ids matching term under the expansion flags,
+// capped at limit: the exact term (if interned) first, then terms that have term
+// as a prefix (when prefix is set), and terms within maxEdits edit distance
+// (when maxEdits > 0). It scans the live term slice in id order, so the result
+// — including which terms survive the cap — is deterministic. Callers hold the
+// index lock. Intended for word terms; the caller skips CJK grams.
+func (d *termDict) expand(term string, prefix bool, maxEdits, limit int) []uint32 {
+	if limit <= 0 {
+		return nil
+	}
+	out := make([]uint32, 0, min(limit, 8))
+	seen := make(map[uint32]struct{})
+	appendID := func(id uint32) bool {
+		if _, dup := seen[id]; dup {
+			return len(out) < limit
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+		return len(out) < limit
+	}
+	if id, ok := d.ids[term]; ok {
+		if !appendID(id) {
+			return out
+		}
+	}
+	if !prefix && maxEdits <= 0 {
+		return out
+	}
+	qr := []rune(term)
+	for id, cand := range d.terms {
+		if cand == "" || cand == term {
+			continue // released slot, or the exact term already added
+		}
+		matched := prefix && strings.HasPrefix(cand, term)
+		if !matched && maxEdits > 0 {
+			cr := []rune(cand)
+			if dl := len(cr) - len(qr); dl <= maxEdits && -dl <= maxEdits && withinEdits(qr, cr, maxEdits) {
+				matched = true
+			}
+		}
+		if matched {
+			if !appendID(uint32(id)) {
+				return out
+			}
+		}
+	}
+	return out
+}
+
+// withinEdits reports whether the Levenshtein edit distance between rune slices
+// a and b is at most maxEdits. It runs the classic two-row DP and bails as soon
+// as every cell in a row exceeds maxEdits, so a bounded distance check over a
+// large dictionary stays cheap.
+func withinEdits(a, b []rune, maxEdits int) bool {
+	la, lb := len(a), len(b)
+	if la-lb > maxEdits || lb-la > maxEdits {
+		return false
+	}
+	prev := make([]int, lb+1)
+	curr := make([]int, lb+1)
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= la; i++ {
+		curr[0] = i
+		rowMin := curr[0]
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(prev[j]+1, curr[j-1]+1, prev[j-1]+cost)
+			if curr[j] < rowMin {
+				rowMin = curr[j]
+			}
+		}
+		if rowMin > maxEdits {
+			return false
+		}
+		prev, curr = curr, prev
+	}
+	return prev[lb] <= maxEdits
+}

--- a/core/search/fuzzy_test.go
+++ b/core/search/fuzzy_test.go
@@ -1,0 +1,228 @@
+package search
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+)
+
+// TestWithinEdits covers the bounded Levenshtein check at distances 0/1/2,
+// including insert/delete/substitute, a transposition (which costs two edits),
+// and multibyte (accented and CJK) runes so distance is counted per rune.
+func TestWithinEdits(t *testing.T) {
+	r := func(s string) []rune { return []rune(s) }
+	cases := []struct {
+		a, b string
+		max  int
+		want bool
+	}{
+		{"search", "search", 0, true},
+		{"search", "serch", 1, true},   // delete 'a'
+		{"search", "searchh", 1, true}, // insert 'h'
+		{"search", "xearch", 1, true},  // substitute s->x
+		{"search", "serach", 1, false}, // transposition = 2 edits
+		{"search", "serach", 2, true},
+		{"search", "beta", 2, false},
+		{"café", "cafe", 1, true}, // accent substitution (multibyte)
+		{"ねこ", "いこ", 1, true},     // CJK single-rune substitution
+		{"ねこ", "いぬ", 1, false},    // two CJK substitutions
+		{"ねこ", "いぬ", 2, true},
+		{"", "", 0, true},
+		{"a", "", 1, true},
+		{"a", "", 0, false},
+	}
+	for _, c := range cases {
+		if got := withinEdits(r(c.a), r(c.b), c.max); got != c.want {
+			t.Errorf("withinEdits(%q, %q, %d) = %v, want %v", c.a, c.b, c.max, got, c.want)
+		}
+	}
+}
+
+// TestIsExpandable verifies word terms expand while CJK grams (all-unbounded
+// runs) and the empty term are exempt.
+func TestIsExpandable(t *testing.T) {
+	cases := []struct {
+		term string
+		want bool
+	}{
+		{"search", true},
+		{"café", true}, // accented letters are word runes
+		{"a1", true},   // digits are word runes
+		{"デー", false},  // katakana bigram — exempt
+		{"人々", false},  // kanji + iteration mark — exempt
+		{"aあ", true},   // one word rune is enough
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isExpandable(c.term); got != c.want {
+			t.Errorf("isExpandable(%q) = %v, want %v", c.term, got, c.want)
+		}
+	}
+}
+
+// TestTermDictExpand covers exact/prefix/fuzzy expansion, the exact term coming
+// first, and the cap bounding the result deterministically.
+func TestTermDictExpand(t *testing.T) {
+	d := newTermDict()
+	// Interned in this order, so ids are search=0 serch=1 searchh=2 xearch=3
+	// sea=4 searching=5 beta=6 (id order drives the deterministic scan).
+	for _, w := range []string{"search", "serch", "searchh", "xearch", "sea", "searching", "beta"} {
+		d.intern(w)
+	}
+	expandTerms := func(term string, prefix bool, edits, limit int) []string {
+		ids := d.expand(term, prefix, edits, limit)
+		out := make([]string, len(ids))
+		for i, id := range ids {
+			out[i] = d.terms[id]
+		}
+		return out
+	}
+	sorted := func(term string, prefix bool, edits, limit int) []string {
+		out := expandTerms(term, prefix, edits, limit)
+		sort.Strings(out)
+		return out
+	}
+
+	t.Run("exact only when no expansion", func(t *testing.T) {
+		if got := sorted("search", false, 0, 50); !equalStrings(got, []string{"search"}) {
+			t.Fatalf("exact = %v, want [search]", got)
+		}
+		if got := d.expand("absent", true, 2, 50); len(got) != 0 {
+			t.Fatalf("absent term = %v, want no matches", got)
+		}
+	})
+	t.Run("prefix reaches extending terms", func(t *testing.T) {
+		got := sorted("sea", true, 0, 50)
+		if !equalStrings(got, []string{"sea", "search", "searchh", "searching"}) {
+			t.Fatalf("prefix 'sea' = %v, want [sea search searchh searching]", got)
+		}
+	})
+	t.Run("fuzzy reaches edit-distance-1 terms", func(t *testing.T) {
+		got := sorted("search", false, 1, 50)
+		if !equalStrings(got, []string{"search", "searchh", "serch", "xearch"}) {
+			t.Fatalf("fuzzy 'search' = %v, want [search searchh serch xearch]", got)
+		}
+	})
+	t.Run("exact term is always first", func(t *testing.T) {
+		got := expandTerms("search", true, 1, 50)
+		if len(got) == 0 || got[0] != "search" {
+			t.Fatalf("expansion = %v, want 'search' first", got)
+		}
+	})
+	t.Run("cap bounds the result", func(t *testing.T) {
+		got := expandTerms("sea", true, 0, 2)
+		if len(got) != 2 || got[0] != "sea" {
+			t.Fatalf("capped expansion = %v, want 2 entries starting with sea", got)
+		}
+	})
+}
+
+// TestSearchExpansion covers prefix and fuzzy term matching end to end: a query
+// that matches nothing exactly still finds the document once expansion is on.
+func TestSearchExpansion(t *testing.T) {
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+	idx.Index("d1", Text("lantern search index"))
+	idx.Index("d2", Text("beta gamma"))
+
+	t.Run("prefix finds the extending term", func(t *testing.T) {
+		if exact := idx.SearchMatch("lan", MatchOptions{}); len(exact) != 0 {
+			t.Fatalf("exact 'lan' = %v, want none", idsOf(exact))
+		}
+		got := idsOf(idx.SearchMatch("lan", MatchOptions{PrefixTerms: true}))
+		if !equalStrings(got, []string{"d1"}) {
+			t.Fatalf("prefix 'lan' = %v, want [d1]", got)
+		}
+	})
+	t.Run("fuzzy finds the mistyped term", func(t *testing.T) {
+		if exact := idx.SearchMatch("serch", MatchOptions{}); len(exact) != 0 {
+			t.Fatalf("exact 'serch' = %v, want none", idsOf(exact))
+		}
+		got := idsOf(idx.SearchMatch("serch", MatchOptions{Fuzziness: 1}))
+		if !equalStrings(got, []string{"d1"}) {
+			t.Fatalf("fuzzy 'serch' = %v, want [d1]", got)
+		}
+	})
+	t.Run("fuzzy keeps precision on unrelated terms", func(t *testing.T) {
+		if got := idx.SearchMatch("beto", MatchOptions{Fuzziness: 1}); !equalStrings(idsOf(got), []string{"d2"}) {
+			t.Fatalf("fuzzy 'beto' = %v, want [d2] (beta only)", idsOf(got))
+		}
+	})
+}
+
+// TestSearchExpansionCoverage verifies that expansion composes correctly with
+// MatchAll: each original query word is covered by ANY of its expansions, so a
+// two-word expanded query still requires both words, not both expansions of one.
+func TestSearchExpansionCoverage(t *testing.T) {
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+	idx.Index("both", Text("lantern search")) // lantern + search
+	idx.Index("oneL", Text("lantern here"))   // lantern only
+	idx.Index("oneS", Text("search here"))    // search only
+
+	// "lan" -> lantern (prefix), "serch" -> search (fuzzy). MatchAll needs both.
+	got := idsOf(idx.SearchMatch("lan serch", MatchOptions{Mode: MatchAll, PrefixTerms: true, Fuzziness: 1}))
+	if !equalStrings(got, []string{"both"}) {
+		t.Fatalf("MatchAll expanded = %v, want [both]", got)
+	}
+	// MatchAny surfaces all three (each has one of the two words).
+	any := idsOf(idx.SearchMatch("lan serch", MatchOptions{Mode: MatchAny, PrefixTerms: true, Fuzziness: 1}))
+	sort.Strings(any)
+	if !equalStrings(any, []string{"both", "oneL", "oneS"}) {
+		t.Fatalf("MatchAny expanded = %v, want [both oneL oneS]", any)
+	}
+}
+
+// TestSearchExpansionCJKExempt verifies a CJK query is not widened by fuzzy or
+// prefix expansion: its bigrams match exactly (Lucene CJKAnalyzer behavior).
+func TestSearchExpansionCJKExempt(t *testing.T) {
+	idx := NewInvertedIndex[string, Document](NewScriptAwareAnalyzer(), nil)
+	idx.Index("neko", Text("ねこがすき"))
+	idx.Index("inu", Text("いぬがすき"))
+
+	// Exact and fuzzy give the same result — the CJK bigrams are exempt, so
+	// "ねこ" never fuzzy-expands into "いぬ".
+	exact := idsOf(idx.SearchMatch("ねこ", MatchOptions{}))
+	fuzzy := idsOf(idx.SearchMatch("ねこ", MatchOptions{Fuzziness: 2, PrefixTerms: true}))
+	sort.Strings(exact)
+	sort.Strings(fuzzy)
+	if !equalStrings(exact, fuzzy) {
+		t.Fatalf("CJK exact %v != fuzzy %v (bigrams must be exempt)", exact, fuzzy)
+	}
+	if !equalStrings(exact, []string{"neko"}) {
+		t.Fatalf("CJK 'ねこ' = %v, want [neko]", exact)
+	}
+}
+
+// randWord builds a deterministic pseudo-word for the expansion benchmarks.
+func randWord(rng *rand.Rand) string {
+	n := 3 + rng.Intn(6)
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+// BenchmarkSearchExpansion measures query latency over a large word dictionary
+// with expansion off, prefix on, and fuzzy on, so the cost of the dictionary
+// scan is visible (#891). The brute-force scan is O(dictionary); compare the
+// sub-benchmarks to decide whether a radix/automaton is worth adding.
+func BenchmarkSearchExpansion(b *testing.B) {
+	rng := rand.New(rand.NewSource(891))
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+	for i := 0; i < 20000; i++ {
+		idx.Index(fmt.Sprintf("d%05d", i), Text(randWord(rng)+" "+randWord(rng)+" "+randWord(rng)))
+	}
+	queries := []string{"abc", "lan", "sear"}
+
+	run := func(b *testing.B, opts MatchOptions) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			idx.SearchMatch(queries[i%len(queries)], opts)
+		}
+	}
+	b.Run("Exact", func(b *testing.B) { run(b, MatchOptions{}) })
+	b.Run("Prefix", func(b *testing.B) { run(b, MatchOptions{PrefixTerms: true}) })
+	b.Run("Fuzzy1", func(b *testing.B) { run(b, MatchOptions{Fuzziness: 1}) })
+}

--- a/core/search/match_mode.go
+++ b/core/search/match_mode.go
@@ -25,7 +25,8 @@ const (
 )
 
 // MatchOptions configures document membership for a query. The zero value is
-// MatchAny, so an empty MatchOptions reproduces Search's OR-union exactly.
+// MatchAny with no term expansion, so an empty MatchOptions reproduces Search's
+// OR-union exactly.
 type MatchOptions struct {
 	// Mode selects the boolean combination of the query's word terms.
 	Mode MatchMode
@@ -33,6 +34,15 @@ type MatchOptions struct {
 	// document must contain when Mode is MatchMinShould. It is clamped to
 	// [1, number of distinct query word terms]; other modes ignore it.
 	MinShouldMatch int
+	// Fuzziness is the maximum edit distance (0, 1, or 2) at which a word-channel
+	// query term also matches dictionary terms, so a typo like "serach" still
+	// finds "search". 0 (the default) disables fuzzy matching. CJK grams are
+	// exempt. Expansion per query term is capped at MaxTermExpansions.
+	Fuzziness int
+	// PrefixTerms, when set, also matches dictionary terms that extend a
+	// word-channel query term, so "lan" finds "lantern" (a prefix query). CJK
+	// grams are exempt; expansion is capped at MaxTermExpansions.
+	PrefixTerms bool
 }
 
 // SearchMatch is Search with an explicit match mode: it ranks the documents
@@ -93,16 +103,23 @@ func (idx *InvertedIndex[S, D]) SearchMatchTopK(query string, k int, accept func
 
 // scoredMatchesLocked builds the final score map for a query under opts: the
 // OR-union BM25 scores, narrowed by the match mode's word-coverage filter when
-// the mode is not MatchAny, then lifted by the proximity boost. Callers must
-// hold idx.mu. Keeping the three steps in one place is what lets Search,
-// SearchTopK, and their match-mode siblings share one scoring path.
+// the mode is not MatchAny, then lifted by the proximity boost. When opts request
+// prefix or fuzzy expansion it runs the clause-based path instead (which folds
+// expansion into both scoring and coverage); the exact-term default keeps using
+// scoreLocked + filterByCoverageLocked so it is byte-for-byte unchanged. Callers
+// must hold idx.mu.
 func (idx *InvertedIndex[S, D]) scoredMatchesLocked(queryTerms map[Token]struct{}, opts MatchOptions) map[uint32]float64 {
-	scores := idx.scoreLocked(queryTerms)
+	var scores map[uint32]float64
+	if opts.expandsTerms() {
+		scores = idx.scoreClausesLocked(idx.buildClausesLocked(queryTerms, opts), opts)
+	} else {
+		scores = idx.scoreLocked(queryTerms)
+		if opts.Mode != MatchAny {
+			idx.filterByCoverageLocked(scores, queryTerms, opts)
+		}
+	}
 	if len(scores) == 0 {
 		return scores
-	}
-	if opts.Mode != MatchAny {
-		idx.filterByCoverageLocked(scores, queryTerms, opts)
 	}
 	idx.applyProximityLocked(scores, queryTerms)
 	return scores

--- a/core/search/relevance/parity_gate_test.go
+++ b/core/search/relevance/parity_gate_test.go
@@ -161,19 +161,7 @@ func corpusHasQuery(c Corpus, id string) bool {
 // pipeline — the shared setup for the phrase and match-mode precision gates.
 func indexedEnCorpus(t *testing.T) (Corpus, *search.InvertedIndex[string, search.Text]) {
 	t.Helper()
-	corpora, err := Corpora()
-	if err != nil {
-		t.Fatal(err)
-	}
-	var en Corpus
-	for _, c := range corpora {
-		if c.Name == "en" {
-			en = c
-		}
-	}
-	if en.Name == "" {
-		t.Fatal("en corpus not found")
-	}
+	en := enCorpus(t)
 	idx := productionIndex()
 	en.IndexDocs(idx)
 	return en, idx
@@ -290,4 +278,73 @@ func rankResults(results []search.Result[string]) []string {
 		ids[i] = r.ID
 	}
 	return ids
+}
+
+// typoQueries maps a misspelled query (one edit from a real query word) to the
+// en query ID whose judgments it shares — same intent, one typo away.
+var typoQueries = map[string]string{
+	"expresso":   "q01", // espresso
+	"kubernets":  "q02", // kubernetes
+	"carbonarra": "q07", // carbonara
+}
+
+// TestFuzzyRecoversTypos is the #891 yardstick. It indexes the en corpus with a
+// word-only analyzer — deliberately without the bigram channel that already
+// gives the production pipeline some typo tolerance — so the measurement
+// isolates fuzzy term expansion: an exact search for a misspelled query recovers
+// little, and Fuzziness=1 recovers the relevant documents, so recall rises. It
+// also checks a clean query keeps its top hit under fuzzy, i.e. no precision
+// cost when there is no typo.
+func TestFuzzyRecoversTypos(t *testing.T) {
+	en := enCorpus(t)
+	idx := search.NewInvertedIndex[string, search.Text](
+		search.NewAnalyzer([]search.Normalizer{search.LowercaseNormalizer{}}, search.UnicodeTokenizer{}, nil),
+		nil,
+	)
+	en.IndexDocs(idx)
+	byID := queryByID(en)
+
+	improved := false
+	for typo, qid := range typoQueries {
+		q, ok := byID[qid]
+		if !ok {
+			t.Fatalf("typo subset references unknown query %q", qid)
+		}
+		exact := RecallAt(EvalDepth, rankResults(idx.Search(typo)), q.Qrels)
+		fuzzy := RecallAt(EvalDepth, rankResults(idx.SearchMatch(typo, search.MatchOptions{Fuzziness: 1})), q.Qrels)
+		if fuzzy < exact {
+			t.Errorf("typo %q (%s): fuzzy recall %.3f below exact %.3f", typo, qid, fuzzy, exact)
+		}
+		if fuzzy > exact {
+			improved = true
+		}
+		t.Logf("typo %q (%s): exact recall %.3f -> fuzzy %.3f", typo, qid, exact, fuzzy)
+	}
+	if !improved {
+		t.Error("fuzzy expansion did not improve recall on any typo query")
+	}
+
+	// No precision cost on a clean query: fuzzy must not displace its top hit.
+	clean := byID["q01"]
+	exactTop := rankResults(idx.Search(clean.Text))
+	fuzzyTop := rankResults(idx.SearchMatch(clean.Text, search.MatchOptions{Fuzziness: 1}))
+	if len(exactTop) == 0 || len(fuzzyTop) == 0 || exactTop[0] != fuzzyTop[0] {
+		t.Errorf("clean query %q: fuzzy changed the top hit", clean.Text)
+	}
+}
+
+// enCorpus returns the en golden corpus, failing the test if it is missing.
+func enCorpus(t *testing.T) Corpus {
+	t.Helper()
+	corpora, err := Corpora()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range corpora {
+		if c.Name == "en" {
+			return c
+		}
+	}
+	t.Fatal("en corpus not found")
+	return Corpus{}
 }


### PR DESCRIPTION
## Summary

Implements #891 (epic #886 — search relevance parity with Lucene): opt-in
**prefix and fuzzy term matching** so a typo or a prefix still finds the term,
replacing the reliance on bigram infix recall now that word tokens dominate
ranking (#888).

### What lands

- `MatchOptions` gains **`Fuzziness`** (0/1/2 edit distance) and **`PrefixTerms`**
  — both widen a word-channel query term to the dictionary terms it reaches,
  capped at **`MaxTermExpansions` (50)**, Lucene's default rewrite cap.
- **`termDict.expand`** does a deterministic id-order scan with a bounded
  Levenshtein (`withinEdits`) and length cutoffs — a first brute-force
  implementation per the issue (a radix/automaton only if the scan measurably
  hurts). `BenchmarkSearchExpansion` measures it over a 20k-term dictionary.
- **CJK grams are exempt** (`isExpandable`): fixed-width bigrams, so prefix/fuzzy
  widening is meaningless (Lucene `CJKAnalyzer` behavior preserved).
- **Composes with match modes via query clauses**: a document covers an original
  query word when it carries *any* of that word's expansions, so `fuzzy+MatchAll`
  still requires both words — not both expansions of one.

### Scope / risk

The exact-term default keeps using `scoreLocked`, so it is byte-for-byte
unchanged, and `SearchVertices` is untouched (the wire surface is #892). Every
ratchet floor holds (en 0.9280 / ja 0.9118 / mixed 0.9538, unchanged).

### Measured effect

`TestFuzzyRecoversTypos` (word-only index, isolating fuzzy from the bigram
channel) shows recall on misspelled queries rising sharply, with the clean-query
top hit unchanged:

| typo | query | exact recall | fuzzy recall |
|---|---|---|---|
| `expresso` | espresso | 0.000 | **0.800** |
| `kubernets` | kubernetes | 0.000 | **0.200** |
| `carbonarra` | carbonara | 0.000 | **0.667** |

### Tests

- Bounded Levenshtein at distances 0/1/2 including multibyte (accented, CJK)
  runes; `termDict` expansion (exact-first, prefix, fuzzy, cap enforcement, CJK
  exemption); end-to-end prefix/fuzzy search; the expansion+`MatchAll` coverage
  composition; the typo eval gate; and a dictionary-scan benchmark.

Local gate green: `gofmt`, `go vet`, `go test ./...` (+ `-race` on search) in
`core`; `server` and root build and test clean.

Closes #891
