### PR TITLE
feat(cli): search command with match-mode / phrase / fuzzy options

### DIFF
--- a/.github/skills/lantern-ops/SKILL.md
+++ b/.github/skills/lantern-ops/SKILL.md
@@ -199,6 +199,37 @@ lantern-cli keys users/ 100
 lantern-cli keys users/ | xargs -n1 lantern-cli get vertex   # hydrate values
 ```
 
+### `search <query>` — content relevance (BM25)
+Full-text search over vertex **content** (key + value), ranked by BM25 — the
+content counterpart to `scan vertices`' lexicographic key walk. Hits print one
+per line as `<key>` and `<score>` (tab-separated), most relevant first. Requires
+the server's search index (`LANTERN_SEARCH_ENABLED`, on by default; off ⇒
+`FAILED_PRECONDITION`).
+
+The default is an OR-union over the query words. Flags tune relevance (#892):
+
+| flag | meaning |
+|---|---|
+| `--mode any\|all\|min-should` | term combination: OR (default), AND, or minimum-should-match |
+| `--min-should <n>` | with `--mode min-should`, require at least `n` distinct query words |
+| `--phrase` | require the words adjacent, in order (highest precision) |
+| `--fuzziness 1\|2` | also match terms within that edit distance (typo tolerance) |
+| `--prefix-terms` | also match terms that extend a query word (`lan` → `lantern`) |
+| `--prefix <p>` | scope hits to a key namespace |
+| `--limit <n>` | cap the ranked-hit count (`0` = server default) |
+
+```shell
+lantern-cli search "calm concise"
+lantern-cli search "rolling update" --mode all
+lantern-cli search "rolling update" --phrase
+lantern-cli search serach --fuzziness 1          # finds "search"
+lantern-cli search lan --prefix-terms            # finds "lantern"
+lantern-cli search espresso --prefix user. --limit 20
+```
+
+Unlike `get` / `scan` / `keys`, `search` is a flag-based command (not part of the
+shared REPL grammar), because its many relevance controls read better as flags.
+
 ### `delete-prefix vertices <prefix>` (DESTRUCTIVE)
 Bulk-delete every live vertex under `<prefix>`, up to `limit=<n>` per call.
 **Safety gate:** running without `dry_run=true` or `confirm=yes` is **refused**

--- a/cli/cmd/search.go
+++ b/cli/cmd/search.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/spf13/cobra"
+)
+
+var (
+	searchLimit       uint32
+	searchPrefix      string
+	searchMode        string
+	searchMinShould   uint32
+	searchFuzziness   uint32
+	searchPrefixTerms bool
+	searchPhrase      bool
+)
+
+// parseSearchMode maps the --mode flag onto a client.MatchMode.
+func parseSearchMode(s string) (client.MatchMode, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "any":
+		return client.MatchAny, nil
+	case "all":
+		return client.MatchAll, nil
+	case "min-should", "minshould", "min_should":
+		return client.MatchMinShould, nil
+	default:
+		return 0, fmt.Errorf("unknown --mode %q (want any|all|min-should)", s)
+	}
+}
+
+var searchCmd = &cobra.Command{
+	Use:   "search <query>",
+	Short: "Full-text search vertices by content relevance (BM25)",
+	Long: `Search vertices by relevance-ranked full-text over their key and value.
+
+This is the content counterpart to "scan vertices" (a lexicographic key walk):
+search by remembered topic words instead of an exact key prefix. Hits print one
+per line as "<key>\t<score>", most relevant first; a query that matches nothing
+prints nothing and exits 0. Requires the server's search index
+(LANTERN_SEARCH_ENABLED, on by default).
+
+The default is an OR-union over the query's words. Tune relevance with:
+
+  --mode all            require every query word (AND)
+  --mode min-should --min-should N   require at least N distinct query words
+  --phrase              require the words to occur adjacently, in order
+  --fuzziness 1|2       also match terms within that edit distance (typos)
+  --prefix-terms        also match terms that extend a query word ("lan"→"lantern")
+
+--prefix scopes hits to a key namespace; --limit caps the ranked-hit count
+(0 lets the server apply its configured default).
+
+EXAMPLES
+  lantern-cli search "calm concise"
+  lantern-cli search "rolling update" --mode all
+  lantern-cli search "rolling update" --phrase
+  lantern-cli search serach --fuzziness 1
+  lantern-cli search lan --prefix-terms
+  lantern-cli --address host:6380 search espresso --prefix user. --limit 20
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		mode, err := parseSearchMode(searchMode)
+		if err != nil {
+			return err
+		}
+		cli, err := dial()
+		if err != nil {
+			return err
+		}
+		defer func() { _ = cli.Close() }()
+
+		opts := []client.SearchOption{
+			client.WithSearchLimit(searchLimit),
+			client.WithSearchPrefix(searchPrefix),
+			client.WithMatchMode(mode),
+		}
+		if searchMinShould > 0 {
+			opts = append(opts, client.WithMinShouldMatch(searchMinShould))
+		}
+		if searchFuzziness > 0 {
+			opts = append(opts, client.WithFuzziness(searchFuzziness))
+		}
+		if searchPrefixTerms {
+			opts = append(opts, client.WithPrefixTerms())
+		}
+		if searchPhrase {
+			opts = append(opts, client.WithPhrase())
+		}
+
+		hits, err := cli.SearchVertices(cmd.Context(), args[0], opts...)
+		if err != nil {
+			return err
+		}
+		out := cmd.OutOrStdout()
+		for _, h := range hits {
+			_, _ = fmt.Fprintf(out, "%s\t%.4f\n", h.Key, h.Score)
+		}
+		return nil
+	},
+}
+
+func init() {
+	f := searchCmd.Flags()
+	f.Uint32Var(&searchLimit, "limit", 0, "maximum hits to return (0 = server default)")
+	f.StringVar(&searchPrefix, "prefix", "", "restrict hits to vertices whose key carries this prefix")
+	f.StringVar(&searchMode, "mode", "any", "term combination: any|all|min-should")
+	f.Uint32Var(&searchMinShould, "min-should", 0, "minimum distinct query words a hit must carry (with --mode min-should)")
+	f.Uint32Var(&searchFuzziness, "fuzziness", 0, "maximum edit distance for fuzzy term matching (0-2)")
+	f.BoolVar(&searchPrefixTerms, "prefix-terms", false, "also match dictionary terms that extend a query word")
+	f.BoolVar(&searchPhrase, "phrase", false, "require the query's words to occur adjacently, in order")
+	rootCmd.AddCommand(searchCmd)
+}

--- a/cli/cmd/search_test.go
+++ b/cli/cmd/search_test.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"testing"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+func TestParseSearchMode(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    client.MatchMode
+		wantErr bool
+	}{
+		{"", client.MatchAny, false},
+		{"any", client.MatchAny, false},
+		{"ANY", client.MatchAny, false},
+		{"all", client.MatchAll, false},
+		{"min-should", client.MatchMinShould, false},
+		{"minshould", client.MatchMinShould, false},
+		{"bogus", client.MatchAny, true},
+	}
+	for _, c := range cases {
+		got, err := parseSearchMode(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("parseSearchMode(%q) err = nil, want error", c.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseSearchMode(%q) err = %v", c.in, err)
+		}
+		if got != c.want {
+			t.Errorf("parseSearchMode(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+// TestSearchCommandRegistered guards that search is a top-level command with the
+// full option flag set (#892).
+func TestSearchCommandRegistered(t *testing.T) {
+	var found bool
+	for _, c := range rootCmd.Commands() {
+		if c.Name() != "search" {
+			continue
+		}
+		found = true
+		for _, name := range []string{"mode", "phrase", "fuzziness", "prefix-terms", "min-should", "limit", "prefix"} {
+			if c.Flags().Lookup(name) == nil {
+				t.Errorf("search command missing --%s flag", name)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("search command not registered on rootCmd")
+	}
+}


### PR DESCRIPTION
Part of #892 (epic #886). Adds the CLI content-search surface.

`lantern-cli search <query>` is the BM25 content-relevance counterpart to `scan vertices`, printing tab-separated key/score most-relevant-first. Flags expose the relevance controls the Go SDK gained in #904:

- `--mode any|all|min-should` + `--min-should <n>` (#890)
- `--phrase` (#889)
- `--fuzziness 1|2` + `--prefix-terms` (#891)
- `--prefix`, `--limit`

It is a flag-based cobra command (like dump/restore/bulk), NOT a shared REPL grammar verb, so the grammar drift guards are unaffected. Documented in the lantern-ops skill.

Verified: gofmt clean, `go build ./cli/...`, `go test ./cli/...` green (parseSearchMode + command/flag registration).

The Node SDK + admin UI follow in the final PR to close #892.

Refs #892