### PR TITLE
feat(admin): expose search match-mode, phrase & fuzzy on the Data surface

### DIFF
--- a/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.module.css
+++ b/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.module.css
@@ -75,6 +75,17 @@
   gap: var(--spacingHorizontalM, 12px);
 }
 
+.searchOptions {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--spacingHorizontalL, 16px);
+  flex-wrap: wrap;
+}
+
+.searchOptionsMode {
+  min-width: 180px;
+}
+
 .alert {
   margin: 0;
 }

--- a/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.tsx
+++ b/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.tsx
@@ -2,12 +2,15 @@ import { useState } from "react";
 import {
   Badge,
   Button,
+  Dropdown,
   Field,
   Input,
   MessageBar,
   MessageBarBody,
   MessageBarTitle,
+  Option,
   Spinner,
+  Switch,
   Tab,
   TabList,
   Table,
@@ -34,6 +37,7 @@ import {
   formatScore,
   selectCaption,
 } from "~/lib/client/usecase/search-vertices/selectors";
+import type { SearchMatchMode } from "~/lib/client/usecase/search-vertices/state";
 import type { Vertex } from "~/lib/client/infrastructure/api/types";
 import { ValueCell } from "../ValueCell/ValueCell";
 import { ExpirationCell } from "../ExpirationCell/ExpirationCell";
@@ -48,6 +52,13 @@ import styles from "./BrowseVerticesPage.module.css";
  *    a prefix scan and a content query land in the same table.
  */
 type FindMode = "prefix" | "search";
+
+/** Human labels for the content-search match modes (#892). */
+const MATCH_MODE_LABELS: Record<SearchMatchMode, string> = {
+  any: "Any word (OR)",
+  all: "All words (AND)",
+  "min-should": "Most words",
+};
 
 /** A vertex row normalised across both find modes. */
 interface VertexRow {
@@ -68,10 +79,13 @@ export function BrowseVerticesPage() {
   const [mode, setMode] = useState<FindMode>("prefix");
   const [prefix, setPrefix] = useState("");
   const [query, setQuery] = useState("");
+  const [matchMode, setMatchMode] = useState<SearchMatchMode>("any");
+  const [phrase, setPhrase] = useState(false);
+  const [fuzzy, setFuzzy] = useState(false);
   const browse = useBrowseVertices(prefix, {
     pageSize: DEFAULT_VERTEX_PAGE_SIZE,
   });
-  const search = useSearchVertices(query);
+  const search = useSearchVertices(query, { matchMode, phrase, fuzzy });
   const navigate = useNavigate();
 
   const searching = mode === "search";
@@ -197,6 +211,44 @@ export function BrowseVerticesPage() {
           )}
         </div>
       </section>
+
+      {searching ? (
+        <section className={styles.searchOptions} data-testid="search-options">
+          <Field label="Match">
+            <Dropdown
+              className={styles.searchOptionsMode}
+              selectedOptions={[matchMode]}
+              value={MATCH_MODE_LABELS[matchMode]}
+              onOptionSelect={(_, data) =>
+                setMatchMode((data.optionValue as SearchMatchMode) ?? "any")
+              }
+              data-testid="search-mode"
+            >
+              <Option value="any" text="Any word (OR)">
+                Any word (OR)
+              </Option>
+              <Option value="all" text="All words (AND)">
+                All words (AND)
+              </Option>
+              <Option value="min-should" text="Most words">
+                Most words
+              </Option>
+            </Dropdown>
+          </Field>
+          <Switch
+            label="Phrase"
+            checked={phrase}
+            onChange={(_, data) => setPhrase(data.checked)}
+            data-testid="search-phrase"
+          />
+          <Switch
+            label="Fuzzy"
+            checked={fuzzy}
+            onChange={(_, data) => setFuzzy(data.checked)}
+            data-testid="search-fuzzy"
+          />
+        </section>
+      ) : null}
 
       {searching ? (
         <p className={styles.caption} data-testid="search-caption">

--- a/admin/app/lib/client/infrastructure/api/search-vertices.ts
+++ b/admin/app/lib/client/infrastructure/api/search-vertices.ts
@@ -34,7 +34,14 @@ export async function searchVertices(
   try {
     const hits: SearchHit[] = await client.searchVertices(
       request.query,
-      { limit: request.limit ?? 0, prefix: request.prefix ?? "" },
+      {
+        limit: request.limit ?? 0,
+        prefix: request.prefix ?? "",
+        matchMode: request.matchMode,
+        phrase: request.phrase,
+        // The admin exposes fuzzy as one toggle: one edit of slack + prefix terms.
+        ...(request.fuzzy ? { fuzziness: 1, prefixTerms: true } : {}),
+      },
       init?.signal,
     );
     return { hits };

--- a/admin/app/lib/client/infrastructure/api/types.ts
+++ b/admin/app/lib/client/infrastructure/api/types.ts
@@ -102,10 +102,19 @@ export interface ScanVerticesResponse {
 // `{ key, score }` hits — the admin search usecase hydrates the keys back
 // into full vertices via GetVertices, preserving rank order.
 
+/** How a multi-word content-search query's words combine (#892). */
+export type SearchMatchMode = "any" | "all" | "min-should";
+
 export interface SearchVerticesRequest {
   query: string;
   limit?: number;
   prefix?: string;
+  /** Word combination: "any" (OR, default), "all" (AND), or "min-should". */
+  matchMode?: SearchMatchMode;
+  /** Require the query's words to occur adjacently, in order. */
+  phrase?: boolean;
+  /** Tolerate typos and match word prefixes (edit distance 1 + prefix terms). */
+  fuzzy?: boolean;
 }
 
 export interface SearchHit {

--- a/admin/app/lib/client/usecase/search-vertices/handlers.ts
+++ b/admin/app/lib/client/usecase/search-vertices/handlers.ts
@@ -2,7 +2,7 @@ import { LanternApiError } from "~/lib/client/infrastructure/api/error";
 import { getVertices } from "~/lib/client/infrastructure/api/get-vertices";
 import type { LanternClient } from "~/lib/client/infrastructure/api/lantern-client";
 import { searchVertices } from "~/lib/client/infrastructure/api/search-vertices";
-import type { SearchResultRow } from "./state";
+import type { SearchQueryOptions, SearchResultRow } from "./state";
 import type { SearchVerticesAction } from "./reducer";
 
 export interface FetchSearchResultsInput {
@@ -10,6 +10,7 @@ export interface FetchSearchResultsInput {
   query: string;
   limit: number;
   prefix?: string;
+  options: SearchQueryOptions;
   epoch: number;
   signal?: AbortSignal;
 }
@@ -36,7 +37,14 @@ export async function fetchSearchResults(
   try {
     const { hits } = await searchVertices(
       input.client,
-      { query: input.query, limit: input.limit, prefix: input.prefix },
+      {
+        query: input.query,
+        limit: input.limit,
+        prefix: input.prefix,
+        matchMode: input.options.matchMode,
+        phrase: input.options.phrase,
+        fuzzy: input.options.fuzzy,
+      },
       { signal: input.signal },
     );
     if (hits.length === 0) {

--- a/admin/app/lib/client/usecase/search-vertices/reducer.test.ts
+++ b/admin/app/lib/client/usecase/search-vertices/reducer.test.ts
@@ -154,4 +154,71 @@ describe("searchVerticesReducer", () => {
     expect(afterStale).toBe(seeded);
     expect(afterStale.status).toBe("idle");
   });
+
+  it("bumps the epoch and re-runs the live query when an option changes", () => {
+    const seeded = reduce(
+      INITIAL_SEARCH_VERTICES_STATE,
+      { type: "QUERY_CHANGED", query: "alpha beta" },
+      { type: "SEARCH_REQUESTED", epoch: 1 },
+      { type: "SEARCH_RECEIVED", epoch: 1, results: [ROW] },
+    );
+    const next = searchVerticesReducer(seeded, {
+      type: "OPTIONS_CHANGED",
+      options: { matchMode: "all", phrase: false, fuzzy: false },
+    });
+    expect(next.options.matchMode).toBe("all");
+    // A changed control re-runs the query, exactly like a keystroke.
+    expect(next.queryEpoch).toBe(2);
+    expect(next.status).toBe("idle");
+    expect(next.results).toEqual([]);
+    expect(next.error).toBeNull();
+  });
+
+  it("ignores an OPTIONS_CHANGED that changes nothing", () => {
+    const seeded = reduce(INITIAL_SEARCH_VERTICES_STATE, {
+      type: "QUERY_CHANGED",
+      query: "alpha",
+    });
+    const same = searchVerticesReducer(seeded, {
+      type: "OPTIONS_CHANGED",
+      options: { matchMode: "any", phrase: false, fuzzy: false },
+    });
+    // Identity preserved → no epoch bump, no re-fetch.
+    expect(same).toBe(seeded);
+    expect(same.queryEpoch).toBe(1);
+  });
+
+  it("advances the epoch but stays inert when options change with no query", () => {
+    const next = searchVerticesReducer(INITIAL_SEARCH_VERTICES_STATE, {
+      type: "OPTIONS_CHANGED",
+      options: { matchMode: "any", phrase: true, fuzzy: false },
+    });
+    expect(next.options.phrase).toBe(true);
+    // Epoch advances so a slow reply from the prior options cannot land,
+    // but the empty query means the effect issues no fetch.
+    expect(next.queryEpoch).toBe(1);
+    expect(next.query).toBe("");
+    expect(next.status).toBe("idle");
+  });
+
+  it("preserves the chosen options when the query is cleared", () => {
+    const seeded = reduce(
+      INITIAL_SEARCH_VERTICES_STATE,
+      { type: "QUERY_CHANGED", query: "alpha" },
+      {
+        type: "OPTIONS_CHANGED",
+        options: { matchMode: "all", phrase: true, fuzzy: false },
+      },
+    );
+    const cleared = searchVerticesReducer(seeded, {
+      type: "QUERY_CHANGED",
+      query: "",
+    });
+    expect(cleared.query).toBe("");
+    expect(cleared.options).toEqual({
+      matchMode: "all",
+      phrase: true,
+      fuzzy: false,
+    });
+  });
 });

--- a/admin/app/lib/client/usecase/search-vertices/reducer.ts
+++ b/admin/app/lib/client/usecase/search-vertices/reducer.ts
@@ -1,11 +1,13 @@
 import {
   INITIAL_SEARCH_VERTICES_STATE,
+  type SearchQueryOptions,
   type SearchResultRow,
   type SearchVerticesState,
 } from "./state";
 
 export type SearchVerticesAction =
   | { type: "QUERY_CHANGED"; query: string }
+  | { type: "OPTIONS_CHANGED"; options: SearchQueryOptions }
   | { type: "SEARCH_REQUESTED"; epoch: number }
   | { type: "SEARCH_RECEIVED"; epoch: number; results: SearchResultRow[] }
   | { type: "SEARCH_FAILED"; epoch: number; error: string }
@@ -31,8 +33,13 @@ export function searchVerticesReducer(
       const queryEpoch = state.queryEpoch + 1;
       if (action.query.length === 0) {
         // Empty query shows no results and issues no request, but the
-        // epoch still advances so any in-flight reply is discarded.
-        return { ...INITIAL_SEARCH_VERTICES_STATE, queryEpoch };
+        // epoch still advances so any in-flight reply is discarded. The
+        // operator's chosen options survive the clear.
+        return {
+          ...INITIAL_SEARCH_VERTICES_STATE,
+          options: state.options,
+          queryEpoch,
+        };
       }
       return {
         ...state,
@@ -74,8 +81,36 @@ export function searchVerticesReducer(
       // outcome (opt-out), not a failure. Clear any prior error.
       return { ...state, status: "disabled", results: [], error: null };
     }
+    case "OPTIONS_CHANGED": {
+      if (sameOptions(action.options, state.options)) {
+        return state;
+      }
+      // A changed relevance control re-runs the live query under a fresh
+      // epoch, exactly like a keystroke. An empty query stays inert (the
+      // effect skips the fetch), but the epoch still advances so a slow
+      // reply from the previous options cannot land.
+      const queryEpoch = state.queryEpoch + 1;
+      if (state.query.length === 0) {
+        return { ...state, options: action.options, queryEpoch };
+      }
+      return {
+        ...state,
+        options: action.options,
+        queryEpoch,
+        status: "idle",
+        results: [],
+        error: null,
+      };
+    }
     default: {
       return state;
     }
   }
+}
+
+/** Structural equality for the relevance controls, used to drop no-op changes. */
+function sameOptions(a: SearchQueryOptions, b: SearchQueryOptions): boolean {
+  return (
+    a.matchMode === b.matchMode && a.phrase === b.phrase && a.fuzzy === b.fuzzy
+  );
 }

--- a/admin/app/lib/client/usecase/search-vertices/state.ts
+++ b/admin/app/lib/client/usecase/search-vertices/state.ts
@@ -38,10 +38,29 @@ export interface SearchResultRow {
   vertex: Vertex | null;
 }
 
+/** How a multi-word content-search query's words combine. */
+export type SearchMatchMode = "any" | "all" | "min-should";
+
+/** The relevance controls the search box exposes (#892). */
+export interface SearchQueryOptions {
+  /** Word combination: "any" (OR, default), "all" (AND), or "min-should". */
+  matchMode: SearchMatchMode;
+  /** Require the query's words to occur adjacently, in order. */
+  phrase: boolean;
+  /** Tolerate typos and match word prefixes. */
+  fuzzy: boolean;
+}
+
+export const DEFAULT_SEARCH_QUERY_OPTIONS: SearchQueryOptions = {
+  matchMode: "any",
+  phrase: false,
+  fuzzy: false,
+};
+
 export interface SearchVerticesState {
   /** The debounced query currently being searched. */
   query: string;
-  /** Monotonic counter bumped on every query change. */
+  /** Monotonic counter bumped on every query or option change. */
   queryEpoch: number;
   /** Lifecycle of the in-flight (or last completed) search. */
   status: SearchVerticesStatus;
@@ -49,6 +68,8 @@ export interface SearchVerticesState {
   results: SearchResultRow[];
   /** Human-readable error from the last failed search, if any. */
   error: string | null;
+  /** The relevance controls applied to `query`. */
+  options: SearchQueryOptions;
 }
 
 export const INITIAL_SEARCH_VERTICES_STATE: SearchVerticesState = {
@@ -57,4 +78,5 @@ export const INITIAL_SEARCH_VERTICES_STATE: SearchVerticesState = {
   status: "idle",
   results: [],
   error: null,
+  options: DEFAULT_SEARCH_QUERY_OPTIONS,
 };

--- a/admin/app/lib/client/usecase/search-vertices/use-search-vertices.ts
+++ b/admin/app/lib/client/usecase/search-vertices/use-search-vertices.ts
@@ -4,6 +4,7 @@ import { fetchSearchResults } from "./handlers";
 import { searchVerticesReducer, type SearchVerticesAction } from "./reducer";
 import {
   INITIAL_SEARCH_VERTICES_STATE,
+  type SearchMatchMode,
   type SearchVerticesState,
 } from "./state";
 
@@ -26,6 +27,12 @@ export interface UseSearchVerticesOptions {
   /** Optional key-prefix filter applied to the ranked hits server-side. */
   prefix?: string;
   debounceMs?: number;
+  /** Word combination: "any" (OR, default), "all" (AND), or "min-should". */
+  matchMode?: SearchMatchMode;
+  /** Require the query's words to occur adjacently, in order. */
+  phrase?: boolean;
+  /** Tolerate typos and match word prefixes. */
+  fuzzy?: boolean;
 }
 
 export interface UseSearchVerticesResult {
@@ -47,6 +54,9 @@ export function useSearchVertices(
   const limit = options.limit ?? DEFAULT_SEARCH_LIMIT;
   const prefix = options.prefix;
   const debounceMs = options.debounceMs ?? SEARCH_DEBOUNCE_MS;
+  const matchMode = options.matchMode ?? "any";
+  const phrase = options.phrase ?? false;
+  const fuzzy = options.fuzzy ?? false;
   const client = useLanternClient();
   const [state, dispatch] = useReducer(
     searchVerticesReducer,
@@ -60,6 +70,16 @@ export function useSearchVertices(
     }, debounceMs);
     return () => window.clearTimeout(handle);
   }, [rawQuery, debounceMs]);
+
+  // Fold option changes into the reducer immediately: toggling a control is
+  // a deliberate act, not a per-keystroke storm, so it needs no debounce.
+  // The reducer bumps the epoch, which re-runs the live query below.
+  useEffect(() => {
+    dispatch({
+      type: "OPTIONS_CHANGED",
+      options: { matchMode, phrase, fuzzy },
+    });
+  }, [matchMode, phrase, fuzzy]);
 
   // On every query change, search + hydrate under a fresh AbortController.
   const lastEpochRef = useRef<number>(-1);
@@ -79,13 +99,14 @@ export function useSearchVertices(
         query: state.query,
         limit,
         prefix,
+        options: state.options,
         epoch: state.queryEpoch,
         signal: controller.signal,
       },
       dispatch as (action: SearchVerticesAction) => void,
     );
     return () => controller.abort();
-  }, [client, state.query, state.queryEpoch, limit, prefix]);
+  }, [client, state.query, state.queryEpoch, state.options, limit, prefix]);
 
   const retry = useCallback(() => {
     if (state.query.length === 0) {
@@ -99,11 +120,12 @@ export function useSearchVertices(
         query: state.query,
         limit,
         prefix,
+        options: state.options,
         epoch: state.queryEpoch,
       },
       dispatch as (action: SearchVerticesAction) => void,
     );
-  }, [client, state.query, state.queryEpoch, limit, prefix]);
+  }, [client, state.query, state.queryEpoch, state.options, limit, prefix]);
 
   return useMemo<UseSearchVerticesResult>(
     () => ({ state, retry }),

--- a/admin/tests/e2e/browse.spec.ts
+++ b/admin/tests/e2e/browse.spec.ts
@@ -174,6 +174,43 @@ test.describe("/vertices — content search (#650)", () => {
     ).toBeVisible();
   });
 
+  test("match-mode control narrows a multi-word query from OR to AND (#892)", async ({
+    page,
+  }) => {
+    await page.goto("/vertices");
+    await page.getByRole("tab", { name: "Content search" }).click();
+
+    // The relevance controls appear alongside the query box.
+    await expect(page.getByTestId("search-options")).toBeVisible();
+    await expect(page.getByTestId("search-mode")).toBeVisible();
+    await expect(page.getByTestId("search-phrase")).toBeVisible();
+    await expect(page.getByTestId("search-fuzzy")).toBeVisible();
+
+    // "zorptangle consensus": only doc1 carries both words; doc2 has
+    // "zorptangle" but not "consensus".
+    await page.getByTestId("search-query-input").fill("zorptangle consensus");
+
+    const table = page.getByTestId("search-results-table");
+    await expect(table).toBeVisible();
+    // Any-word (default OR): doc2 rides in on the shared "zorptangle".
+    await expect(
+      table.getByRole("link", { name: "e2e:search:doc2" }),
+    ).toBeVisible();
+
+    // Switch to All-words (AND): doc2, missing "consensus", drops out while
+    // doc1 (both words) stays. This proves the mode flows through to the
+    // server and re-runs the query.
+    await page.getByTestId("search-mode").click();
+    await page.getByRole("option", { name: "All words (AND)" }).click();
+
+    await expect(
+      table.getByRole("link", { name: "e2e:search:doc1" }),
+    ).toBeVisible();
+    await expect(
+      table.getByRole("link", { name: "e2e:search:doc2" }),
+    ).toHaveCount(0);
+  });
+
   test("Illuminate action seeds the CLI explorer with the hit key", async ({
     page,
   }) => {


### PR DESCRIPTION
Completes epic #886 (search relevance parity with Lucene) by surfacing the
`SearchOptions` relevance controls added in #904/#906 on the admin **Data**
surface.

## What

The Vertices content-search find mode gains three controls next to the query box:

- **Match** dropdown — Any word (OR, default) / All words (AND) / Most words (min-should)
- **Phrase** switch — require the query's words adjacent, in order
- **Fuzzy** switch — tolerate typos + match word prefixes (edit distance 1 + prefix terms)

The options thread through the `search-vertices` usecase → Node SDK → server:

- `state.ts` — `SearchQueryOptions` added to the reducer state.
- `reducer.ts` — new `OPTIONS_CHANGED` action bumps `queryEpoch` so a changed
  control re-runs the live query exactly like a keystroke (empty query stays
  inert); options survive a query clear.
- `handlers.ts` / `use-search-vertices.ts` — pass `state.options` into the fetch.
- `infrastructure/api/search-vertices.ts` — map the admin's simplified `fuzzy`
  toggle to `fuzziness: 1 + prefixTerms`, forward `matchMode`/`phrase`.
- `BrowseVerticesPage.tsx` — Fluent `Dropdown` + `Switch` controls.

The default (no-options) search path is byte-identical, so the relevance floors hold.

## Tests

- `reducer.test.ts` — 4 new cases for `OPTIONS_CHANGED` (epoch bump + re-run,
  no-op when unchanged, inert on empty query, options preserved on clear).
- `browse.spec.ts` — new e2e: controls render, and switching Any→All narrows
  `zorptangle consensus` so doc2 (missing "consensus") drops out — proving the
  mode reaches the server.

Local gate green: `format` / `lint` / `typecheck` / `test` (696 pass), `build`,
and `playwright` browse spec (11 pass).

Closes #892