### PR TITLE
docs: drop relationship-type labels from the README graph diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,13 @@ Most caches flatten relationships away entirely. Lantern sits in the gap:
 
 ### Never used a graph? It's just entries + connections
 
-A key-value cache stores isolated entries. A **graph** adds exactly one
-concept on top: *edges* — directed, weighted connections between entries.
-The entries themselves become *vertices*. Same data, one new dimension:
+A key-value cache stores isolated entries. Lantern turns those entries into
+a **graph in the mathematical sense** — the weighted directed graph of
+graph theory, *G = (V, E, w)*: vertices, directed edges between them, a
+real-valued weight on each edge, and (Lantern's cache-native twist) a TTL
+on all of it. Not the *property graph* of graph databases, with typed,
+attribute-laden edges — the plain mathematical object. Same data, one new
+dimension:
 
 ```mermaid
 flowchart TB
@@ -87,25 +91,27 @@ flowchart TB
 That's the entire vocabulary you need:
 
 - **Vertex** — one cache entry: a key and its value (`user:42 = alice`), with a TTL.
-- **Edge** — a directed link between two keys. It carries exactly two things:
-  a weight and a TTL — no type, label, or property bag. If you need
-  relationship kinds ("clicked" vs "bought"), encode them in your key design
-  or weight conventions.
+- **Edge** — an ordered pair of keys with a weight and a TTL: one element
+  of *E*, nothing more — no type, label, or property bag. If you need
+  relationship kinds ("clicked" vs "bought"), encode them in your key
+  design or weight conventions.
 - **Weight** — how strong that link is right now. In Lantern it's the live
   sum of decaying contributions, so recent events count more than old ones.
 - **TTL** — everything above expires on its own; nothing needs a cleanup job.
 
-That austerity is deliberate — label-free edges are what keep the rest of
-Lantern simple and fast:
+Staying with the mathematical object is deliberate — it is what keeps the
+rest of Lantern simple and fast:
 
+- **The classic algorithms apply directly.** Spanning trees, shortest
+  paths, PageRank, community detection — graph theory defines them on
+  exactly this object, a weighted directed graph. `illuminate` runs them
+  natively over every edge, with no "which relationship types does this
+  walk follow?" configuration and no schema the server has to know about;
+  a property graph has to be flattened down to weights before any of that
+  theory applies.
 - **Every event can pile onto the same edge.** The additive, decaying
   weight model works because merging contributions is just addition —
   there are no per-type aggregation rules to define.
-- **Every algorithm works on every edge.** `illuminate`'s MST / SPT /
-  PageRank / community walks and the TF-IDF / BM25 hub-damping all compare
-  edges by one uniform number. There is no "which relationship types does
-  this traversal follow?" configuration, and no schema the server has to
-  know about.
 - **Nothing to design up front, nothing to migrate.** A new kind of event
   starts flowing into the graph the moment you write it — cache semantics
   extend to the data model itself.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ That's the entire vocabulary you need:
   sum of decaying contributions, so recent events count more than old ones.
 - **TTL** — everything above expires on its own; nothing needs a cleanup job.
 
+That austerity is deliberate — label-free edges are what keep the rest of
+Lantern simple and fast:
+
+- **Every event can pile onto the same edge.** The additive, decaying
+  weight model works because merging contributions is just addition —
+  there are no per-type aggregation rules to define.
+- **Every algorithm works on every edge.** `illuminate`'s MST / SPT /
+  PageRank / community walks and the TF-IDF / BM25 hub-damping all compare
+  edges by one uniform number. There is no "which relationship types does
+  this traversal follow?" configuration, and no schema the server has to
+  know about.
+- **Nothing to design up front, nothing to migrate.** A new kind of event
+  starts flowing into the graph the moment you write it — cache semantics
+  extend to the data model itself.
+- **Edges stay tiny.** A contribution is a weight and an expiration, which
+  is why a large working set fits in one process's memory in the first
+  place.
+
 The payoff: questions like *"what has this user interacted with lately, and
 how strongly?"* stop being JOINs over event logs in your warehouse and
 become a one-RPC lookup against the cache.

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ flowchart TB
     end
     subgraph after["A Key-Vertex-Store — the same entries, connected"]
         direction LR
-        u42(("user:42<br/>alice")) -- "clicked · 1.5" --> i7(("item:7<br/>lamp"))
-        u42 -- "viewed · 0.3" --> i9(("item:9<br/>desk"))
-        u99(("user:99<br/>bob")) -- "bought · 2.0" --> i7
+        u42(("user:42<br/>alice")) -- "1.5" --> i7(("item:7<br/>lamp"))
+        u42 -- "0.3" --> i9(("item:9<br/>desk"))
+        u99(("user:99<br/>bob")) -- "2.0" --> i7
     end
     before -->|"add edge …"| after
 ```
@@ -87,7 +87,10 @@ flowchart TB
 That's the entire vocabulary you need:
 
 - **Vertex** — one cache entry: a key and its value (`user:42 = alice`), with a TTL.
-- **Edge** — a directed link between two keys: *"user:42 did something to item:7"*.
+- **Edge** — a directed link between two keys. It carries exactly two things:
+  a weight and a TTL — no type, label, or property bag. If you need
+  relationship kinds ("clicked" vs "bought"), encode them in your key design
+  or weight conventions.
 - **Weight** — how strong that link is right now. In Lantern it's the live
   sum of decaying contributions, so recent events count more than old ones.
 - **TTL** — everything above expires on its own; nothing needs a cleanup job.


### PR DESCRIPTION
## What changed

Follow-up to #912. The "never used a graph?" explainer now rests on an explicit premise: **Lantern stores the mathematical graph of graph theory — a weighted directed graph *G = (V, E, w)* with TTLs — not the property graph of graph databases.**

- **Premise stated up front.** The section intro defines the model as the plain mathematical object (vertices, directed edges, a real-valued weight per edge, TTL on all of it) and names the contrast with typed, attribute-laden property-graph edges.
- **Edge labels corrected.** The KVS-vs-Key-Vertex-Store Mermaid diagram had edges labelled `clicked · 1.5` / `viewed · 0.3` / `bought · 2.0`, implying typed edges. Labels are now plain weights, matching the `illuminate` example diagrams.
- **Glossary tightened.** An **Edge** is defined as one element of *E*: an ordered pair of keys with a weight and a TTL, nothing more — with key design or weight conventions as the escape hatch for relationship kinds.
- **Benefits of staying mathematical.** A new list after the glossary leads with the consequence that matters: spanning trees, shortest paths, PageRank, and community detection are defined on exactly this object, so `illuminate` runs them natively with no type-filter configuration or server-side schema — a property graph has to be flattened down to weights before any of that theory applies. Plus: contributions merge by plain addition, nothing to design or migrate, and edges stay small enough for the working set to fit in process memory.

Remaining edge annotations are all factual: the hero diagram shows `1.0 · ttl 30m` (the weight and TTL set by the demo command), and the architecture diagram labels are protocol names, not graph edges.

## Why

The explainer sits exactly where a newcomer forms their mental model. The original diagram suggested property-graph semantics Lantern doesn't have; the corrected version presents the model as what it is — the mathematical object graph algorithms are defined on — and explains why that's a feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)