### PR TITLE
feat(search): positions opt-out+encoding, fuzzy bounds, mode validation, proximity proof

### DIFF
--- a/core/graphcache/search.go
+++ b/core/graphcache/search.go
@@ -21,18 +21,49 @@ import (
 // Since #889 the index also records positional postings (WithPositions): the
 // token positions of each primary-channel term, so the search layer can tell
 // an exact phrase or a near match from scattered term hits. The cost is one
-// ascending position slice per (word term, vertex).
+// position store per (word term, vertex). positions is opt-out
+// (LANTERN_SEARCH_POSITIONS, #908): when false the index skips the position
+// store entirely — SearchPhrase degrades to the AND-intersection and the
+// proximity boost is inert, so an operator with a large corpus can trade
+// phrase/proximity support for the memory.
 //
 // The relevance gate (core/search/relevance, parity_gate_test.go) replicates
-// exactly this pipeline and ratchets its measured metrics against the pinned
-// Lucene baseline — change the two in lockstep.
-func newSearchIndex[S comparable]() *search.InvertedIndex[S, search.Document] {
+// exactly this pipeline (with positions on) and ratchets its measured metrics
+// against the pinned Lucene baseline — change the two in lockstep.
+func newSearchIndex[S comparable](positions bool) *search.InvertedIndex[S, search.Document] {
 	analyzer := search.NewScriptAwareAnalyzer()
 	scorer := search.ClassWeighted{
 		Base:       search.BM25{K1: search.DefaultBM25K1, B: search.DefaultBM25B},
 		GramWeight: search.DefaultGramWeight,
 	}
-	return search.NewInvertedIndex[S, search.Document](analyzer, scorer, search.WithPositions())
+	var opts []search.IndexOption
+	if positions {
+		opts = append(opts, search.WithPositions())
+	}
+	return search.NewInvertedIndex[S, search.Document](analyzer, scorer, opts...)
+}
+
+// SearchIndexOption configures the optional content-search index at
+// EnableSearchIndex time. The zero configuration records positional postings;
+// options only pare it back.
+type SearchIndexOption func(*searchIndexConfig)
+
+// searchIndexConfig is the resolved EnableSearchIndex configuration. positions
+// defaults to true so the common call — EnableSearchIndex(extract) with no
+// options — keeps recording positions exactly as before #908.
+type searchIndexConfig struct {
+	positions bool
+}
+
+// WithoutSearchPositions builds the search index without positional postings
+// (the LANTERN_SEARCH_POSITIONS=false path, #908). The index then pays nothing
+// for the per-(word term, vertex) position store; in exchange SearchPhrase
+// degrades to the AND-intersection (word terms all present, order/adjacency
+// unverified) and the proximity boost is inert. The SearchVertices RPC keeps
+// working — a phrase query simply widens to the AND-intersection rather than
+// failing.
+func WithoutSearchPositions() SearchIndexOption {
+	return func(c *searchIndexConfig) { c.positions = false }
 }
 
 // EnableSearchIndex turns on the optional content-search index, projecting each
@@ -40,7 +71,9 @@ func newSearchIndex[S comparable]() *search.InvertedIndex[S, search.Document] {
 // vertex's string value). Like EnablePrefixIndex it must be called before any
 // vertex is stored, is idempotent, and panics on a non-empty cache so the
 // caller cannot silently observe an index that disagrees with point reads.
-// extract must not be nil.
+// extract must not be nil. By default the index records positional postings for
+// phrase and proximity queries; pass WithoutSearchPositions to build the leaner
+// position-free index (#908).
 //
 // Once enabled, the index is kept in perfect lockstep with the vertex
 // lifecycle: every put (including overwrites) re-indexes the value, and
@@ -49,9 +82,13 @@ func newSearchIndex[S comparable]() *search.InvertedIndex[S, search.Document] {
 // they describe.
 // The index is a third opt-in secondary structure alongside the prefix index;
 // when it is left disabled the put / evict hot paths pay only a nil check.
-func (c *GraphCache[S, T]) EnableSearchIndex(extract func(T) search.Document) {
+func (c *GraphCache[S, T]) EnableSearchIndex(extract func(T) search.Document, opts ...SearchIndexOption) {
 	if extract == nil {
 		panic("graphcache: EnableSearchIndex extract must not be nil")
+	}
+	cfg := searchIndexConfig{positions: true}
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -62,7 +99,7 @@ func (c *GraphCache[S, T]) EnableSearchIndex(extract func(T) search.Document) {
 		panic("graphcache: EnableSearchIndex must be called before any vertex is stored")
 	}
 	c.searchExtract = extract
-	c.searchIndex = newSearchIndex[S]()
+	c.searchIndex = newSearchIndex[S](cfg.positions)
 }
 
 // SearchVertices returns up to limit keys whose indexed content matches query,

--- a/core/graphcache/search_test.go
+++ b/core/graphcache/search_test.go
@@ -63,6 +63,44 @@ func TestGraphCache_EnableSearchIndex_Idempotent(t *testing.T) {
 	c.EnableSearchIndex(textExtract) // must not panic
 }
 
+// TestGraphCache_EnableSearchIndex_WithoutPositions covers the #908 opt-out:
+// a position-free index answers phrase queries by the AND-intersection (both
+// query words present, adjacency unverified), while the default position-
+// tracking index verifies adjacency. Doc "adj" carries the words adjacently and
+// matches either way; doc "split" scatters them and matches only when positions
+// are dropped.
+func TestGraphCache_EnableSearchIndex_WithoutPositions(t *testing.T) {
+	seed := func(c *GraphCache[string, string]) {
+		c.PutVertex("adj", "alpha beta gamma")   // "alpha beta" adjacent, in order
+		c.PutVertex("split", "alpha gamma beta") // same words, not adjacent
+	}
+	phraseHits := func(c *GraphCache[string, string]) map[string]bool {
+		got := map[string]bool{}
+		for _, r := range c.SearchVerticesMatch("alpha beta", 50, "", search.MatchOptions{}, true) {
+			got[r.ID] = true
+		}
+		return got
+	}
+
+	t.Run("positions on verifies adjacency", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract) // default: positions on
+		seed(c)
+		if got := phraseHits(c); !reflect.DeepEqual(got, map[string]bool{"adj": true}) {
+			t.Fatalf("phrase hits = %v, want only {adj} (split's words are not adjacent)", got)
+		}
+	})
+
+	t.Run("positions off degrades to AND-intersection", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract, WithoutSearchPositions())
+		seed(c)
+		if got := phraseHits(c); !reflect.DeepEqual(got, map[string]bool{"adj": true, "split": true}) {
+			t.Fatalf("phrase hits = %v, want {adj, split} (positions off => AND-intersection)", got)
+		}
+	})
+}
+
 func TestGraphCache_SearchVertices(t *testing.T) {
 	t.Run("Ranking", func(t *testing.T) {
 		c := NewGraphCache[string, string](time.Minute)

--- a/core/search/fuzzy.go
+++ b/core/search/fuzzy.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"github.com/RoaringBitmap/roaring/v2"
 )
@@ -164,16 +165,44 @@ func (d *termDict) expand(term string, prefix bool, maxEdits, limit int) []uint3
 	if !prefix && maxEdits <= 0 {
 		return out
 	}
+	// Fuzzy matching converts each length-compatible candidate to runes and runs
+	// a two-row Levenshtein DP. Both the rune slice and the DP rows are sized at
+	// most len(qr)+maxEdits (the rune-length gate rejects anything longer), so a
+	// single scratch trio, allocated once here, serves the whole scan instead of
+	// a per-candidate allocation — the dominant cost of a fuzzy expansion over a
+	// large dictionary (#909). The scan still visits terms in id order, so the
+	// cap survivors are unchanged.
 	qr := []rune(term)
+	var candRunes []rune
+	var dpPrev, dpCurr []int
+	if maxEdits > 0 {
+		candRunes = make([]rune, 0, len(qr)+maxEdits)
+		dpPrev = make([]int, len(qr)+maxEdits+1)
+		dpCurr = make([]int, len(qr)+maxEdits+1)
+	}
 	for id, cand := range d.terms {
 		if cand == "" || cand == term {
 			continue // released slot, or the exact term already added
 		}
 		matched := prefix && strings.HasPrefix(cand, term)
 		if !matched && maxEdits > 0 {
-			cr := []rune(cand)
-			if dl := len(cr) - len(qr); dl <= maxEdits && -dl <= maxEdits && withinEdits(qr, cr, maxEdits) {
-				matched = true
+			// Rune-length gate before the O(len) rune conversion and DP: edit
+			// distance is at least the rune-length difference, so a candidate
+			// whose length is more than maxEdits from the query cannot match.
+			// utf8.RuneCountInString allocates nothing, so the rune decode and
+			// Levenshtein run only for the few length-compatible candidates while
+			// the rest of the scan stays a cheap length count. A skipped candidate
+			// would have failed withinEdits anyway (it bails on that same length
+			// difference), so the match set — and thus which terms survive the
+			// cap — is byte-for-byte the pre-gate result.
+			if cl := utf8.RuneCountInString(cand); cl-len(qr) <= maxEdits && len(qr)-cl <= maxEdits {
+				candRunes = candRunes[:0]
+				for _, r := range cand {
+					candRunes = append(candRunes, r)
+				}
+				if withinEditsRows(qr, candRunes, maxEdits, dpPrev, dpCurr) {
+					matched = true
+				}
 			}
 		}
 		if matched {
@@ -186,16 +215,29 @@ func (d *termDict) expand(term string, prefix bool, maxEdits, limit int) []uint3
 }
 
 // withinEdits reports whether the Levenshtein edit distance between rune slices
-// a and b is at most maxEdits. It runs the classic two-row DP and bails as soon
-// as every cell in a row exceeds maxEdits, so a bounded distance check over a
-// large dictionary stays cheap.
+// a and b is at most maxEdits. It allocates a fresh DP row pair; the hot
+// dictionary scan uses withinEditsRows with reusable buffers instead.
 func withinEdits(a, b []rune, maxEdits int) bool {
+	if len(a)-len(b) > maxEdits || len(b)-len(a) > maxEdits {
+		return false
+	}
+	n := len(b) + 1
+	return withinEditsRows(a, b, maxEdits, make([]int, n), make([]int, n))
+}
+
+// withinEditsRows is withinEdits over caller-provided scratch rows so a large
+// fuzzy scan reuses two buffers instead of allocating a DP pair per candidate.
+// prev and curr must each be at least len(b)+1 long (the fuzzy scan sizes them
+// to len(query)+maxEdits+1, which the rune-length gate guarantees is enough).
+// It runs the classic two-row DP and bails as soon as every cell in a row
+// exceeds maxEdits, so a bounded distance check over a large dictionary stays
+// cheap. Contents are fully overwritten each call, so stale scratch is fine.
+func withinEditsRows(a, b []rune, maxEdits int, prev, curr []int) bool {
 	la, lb := len(a), len(b)
 	if la-lb > maxEdits || lb-la > maxEdits {
 		return false
 	}
-	prev := make([]int, lb+1)
-	curr := make([]int, lb+1)
+	prev, curr = prev[:lb+1], curr[:lb+1]
 	for j := 0; j <= lb; j++ {
 		prev[j] = j
 	}

--- a/core/search/fuzzy_test.go
+++ b/core/search/fuzzy_test.go
@@ -3,7 +3,9 @@ package search
 import (
 	"fmt"
 	"math/rand"
+	"slices"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -118,6 +120,123 @@ func TestTermDictExpand(t *testing.T) {
 	})
 }
 
+// TestTermDictExpandMatchesReference proves the rune-length gate and reusable
+// DP buffers (#909) leave expand's result byte-identical to a naive
+// allocation-per-candidate oracle — same match set, same order, same cap
+// survivors — even after intern/release churn seeds tombstones and reused
+// (out-of-order) ids. referenceExpand shares no code with the optimized scan.
+func TestTermDictExpandMatchesReference(t *testing.T) {
+	rng := rand.New(rand.NewSource(9091))
+	d := newTermDict()
+	live := make(map[string]bool)
+	for i := 0; i < 4000; i++ {
+		w := randWord(rng)
+		d.intern(w)
+		live[w] = true
+		if rng.Intn(3) == 0 && len(live) > 0 { // churn: release a live term
+			for k := range live {
+				d.release(d.ids[k])
+				delete(live, k)
+				break
+			}
+		}
+	}
+	queries := make([]string, 0, 40)
+	for k := range live {
+		queries = append(queries, k)
+		if len(queries) >= 20 {
+			break
+		}
+	}
+	for i := 0; i < 20; i++ {
+		queries = append(queries, randWord(rng)) // include absent terms
+	}
+	kinds := []struct {
+		prefix bool
+		edits  int
+	}{{true, 0}, {false, 1}, {false, 2}, {true, 1}, {true, 2}}
+	for _, limit := range []int{3, 50, MaxTermExpansions} {
+		for _, q := range queries {
+			for _, k := range kinds {
+				got := d.expand(q, k.prefix, k.edits, limit)
+				want := referenceExpand(d, q, k.prefix, k.edits, limit)
+				if !slices.Equal(got, want) {
+					t.Fatalf("expand(%q, prefix=%v, edits=%d, limit=%d) = %v, want %v",
+						q, k.prefix, k.edits, limit, got, want)
+				}
+			}
+		}
+	}
+}
+
+// referenceExpand is a deliberately naive mirror of termDict.expand used only as
+// an equivalence oracle: the exact id first, then a full id-order scan with
+// strings.HasPrefix and an un-gated full-matrix Levenshtein. It shares none of
+// expand's rune-length gate or reusable DP buffers, so a match confirms the
+// optimized scan is behaviour-preserving.
+func referenceExpand(d *termDict, term string, prefix bool, maxEdits, limit int) []uint32 {
+	if limit <= 0 {
+		return nil
+	}
+	out := make([]uint32, 0)
+	seen := make(map[uint32]bool)
+	add := func(id uint32) bool {
+		if seen[id] {
+			return len(out) < limit
+		}
+		seen[id] = true
+		out = append(out, id)
+		return len(out) < limit
+	}
+	if id, ok := d.ids[term]; ok {
+		if !add(id) {
+			return out
+		}
+	}
+	if !prefix && maxEdits <= 0 {
+		return out
+	}
+	qr := []rune(term)
+	for id, cand := range d.terms {
+		if cand == "" || cand == term {
+			continue
+		}
+		matched := prefix && strings.HasPrefix(cand, term)
+		if !matched && maxEdits > 0 {
+			matched = naiveLevenshtein([]rune(cand), qr) <= maxEdits
+		}
+		if matched {
+			if !add(uint32(id)) {
+				return out
+			}
+		}
+	}
+	return out
+}
+
+// naiveLevenshtein is the textbook full-matrix edit distance, independent of
+// withinEdits, so the oracle inherits no bug from the bounded two-row DP.
+func naiveLevenshtein(a, b []rune) int {
+	m := make([][]int, len(a)+1)
+	for i := range m {
+		m[i] = make([]int, len(b)+1)
+		m[i][0] = i
+	}
+	for j := 0; j <= len(b); j++ {
+		m[0][j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			m[i][j] = min(m[i-1][j]+1, m[i][j-1]+1, m[i-1][j-1]+cost)
+		}
+	}
+	return m[len(a)][len(b)]
+}
+
 // TestSearchExpansion covers prefix and fuzzy term matching end to end: a query
 // that matches nothing exactly still finds the document once expansion is on.
 func TestSearchExpansion(t *testing.T) {
@@ -225,4 +344,51 @@ func BenchmarkSearchExpansion(b *testing.B) {
 	b.Run("Exact", func(b *testing.B) { run(b, MatchOptions{}) })
 	b.Run("Prefix", func(b *testing.B) { run(b, MatchOptions{PrefixTerms: true}) })
 	b.Run("Fuzzy1", func(b *testing.B) { run(b, MatchOptions{Fuzziness: 1}) })
+}
+
+// expandSink keeps BenchmarkTermDictExpand's result live so the compiler cannot
+// elide the expansion scan.
+var expandSink []uint32
+
+// buildExpandDict interns size distinct random words into a fresh term
+// dictionary and returns it with a handful of query terms drawn from the
+// interned set (so the exact-term hit always lands and prefix/fuzzy have real
+// neighbours to find). Deterministic for a stable sweep.
+func buildExpandDict(size int) (*termDict, []string) {
+	rng := rand.New(rand.NewSource(909))
+	d := newTermDict()
+	for d.len() < size {
+		d.intern(randWord(rng))
+	}
+	queries := make([]string, 0, 8)
+	for i := 0; i < len(d.terms) && len(queries) < 8; i += max(1, len(d.terms)/8) {
+		if d.terms[i] != "" {
+			queries = append(queries, d.terms[i])
+		}
+	}
+	return d, queries
+}
+
+// BenchmarkTermDictExpand isolates the dictionary-scan cost of termDict.expand
+// (#909) across dictionary sizes and expansion kinds. expand is O(dictionary):
+// prefix does a byte-prefix test per term, while fuzzy converts every candidate
+// to runes and runs bounded Levenshtein, so the sub-benchmarks expose whether a
+// sorted/radix structure is worth adding at each scale. Run under -bench only;
+// plain `go test` never pays for the 1M dictionary build.
+func BenchmarkTermDictExpand(b *testing.B) {
+	for _, size := range []int{10_000, 100_000, 1_000_000} {
+		d, queries := buildExpandDict(size)
+		b.Run(fmt.Sprintf("n=%d", size), func(b *testing.B) {
+			bench := func(b *testing.B, prefix bool, maxEdits int) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					expandSink = d.expand(queries[i%len(queries)], prefix, maxEdits, MaxTermExpansions)
+				}
+			}
+			b.Run("Prefix", func(b *testing.B) { bench(b, true, 0) })
+			b.Run("Fuzzy1", func(b *testing.B) { bench(b, false, 1) })
+			b.Run("Fuzzy2", func(b *testing.B) { bench(b, false, 2) })
+		})
+	}
 }

--- a/core/search/inverted_index.go
+++ b/core/search/inverted_index.go
@@ -38,6 +38,11 @@ type InvertedIndex[S comparable, D Document] struct {
 	// scattered matches. Read without the lock — it never changes after
 	// construction.
 	positions bool
+	// proximityWeight scales the proximity boost (see proximity.go); it
+	// defaults to proximityBoostWeight and is overridable with
+	// WithProximityWeight so the relevance harness can sweep it. 0 disables the
+	// boost. Read without the lock — it never changes after construction.
+	proximityWeight float64
 
 	mu sync.RWMutex
 	// classes holds one posting table per token class; a term's class is part
@@ -97,7 +102,8 @@ type IndexOption func(*indexConfig)
 
 // indexConfig holds the resolved construction options.
 type indexConfig struct {
-	positions bool
+	positions       bool
+	proximityWeight float64
 }
 
 // WithPositions makes the index record each term's token positions on the
@@ -112,6 +118,17 @@ func WithPositions() IndexOption {
 	return func(c *indexConfig) { c.positions = true }
 }
 
+// WithProximityWeight overrides the multiplier the proximity boost applies to a
+// multi-term query's OR-union scores (default proximityBoostWeight). It is the
+// injection point the relevance harness sweeps to justify the shipped value:
+// with it the boost's contribution is a measured number, not an unguarded
+// constant (#910). A weight of 0 disables the boost, making ranking pure
+// OR-union BM25 even under WithPositions; it is only meaningful together with
+// WithPositions, since the boost needs the positional postings.
+func WithProximityWeight(w float64) IndexOption {
+	return func(c *indexConfig) { c.proximityWeight = w }
+}
+
 // NewInvertedIndex returns an empty index that analyzes both documents and
 // queries with analyzer and ranks matches with scorer. Passing a nil scorer
 // installs BM25 with the standard parameters (K1 = 1.2, B = 0.75). D is the
@@ -122,15 +139,17 @@ func NewInvertedIndex[S comparable, D Document](analyzer Analyzer, scorer Scorer
 		scorer = BM25{K1: DefaultBM25K1, B: DefaultBM25B}
 	}
 	var cfg indexConfig
+	cfg.proximityWeight = proximityBoostWeight
 	for _, opt := range opts {
 		opt(&cfg)
 	}
 	idx := &InvertedIndex[S, D]{
-		analyzer:  analyzer,
-		scorer:    scorer,
-		positions: cfg.positions,
-		ords:      newOrdinals[S](),
-		docs:      make(map[uint32]docEntry[S]),
+		analyzer:        analyzer,
+		scorer:          scorer,
+		positions:       cfg.positions,
+		proximityWeight: cfg.proximityWeight,
+		ords:            newOrdinals[S](),
+		docs:            make(map[uint32]docEntry[S]),
 	}
 	for class := range idx.classes {
 		idx.classes[class] = classPostings{

--- a/core/search/posting.go
+++ b/core/search/posting.go
@@ -1,6 +1,10 @@
 package search
 
-import "github.com/RoaringBitmap/roaring/v2"
+import (
+	"encoding/binary"
+
+	"github.com/RoaringBitmap/roaring/v2"
+)
 
 // postingList is one term's posting set: which document ordinals contain the
 // term, plus their term frequencies and — when the index tracks positions —
@@ -13,11 +17,13 @@ import "github.com/RoaringBitmap/roaring/v2"
 // storage at all. positions is nil unless the index was built WithPositions
 // and the term carries at least one position in the document, so an index that
 // serves only OR-union ranking pays nothing for phrase/proximity support
-// (#889).
+// (#889). Each document's positions are stored delta+varint packed (#908): the
+// ascending token positions become a compact []byte instead of a []uint32, so
+// the store costs ~1 byte per position (short vertex values) rather than 4.
 type postingList struct {
-	docs      *roaring.Bitmap     // document ordinals containing this term
-	tfHi      map[uint32]uint16   // ordinal -> term frequency, recorded only when tf > 1
-	positions map[uint32][]uint32 // ordinal -> ascending token positions, only when the index tracks positions
+	docs      *roaring.Bitmap   // document ordinals containing this term
+	tfHi      map[uint32]uint16 // ordinal -> term frequency, recorded only when tf > 1
+	positions map[uint32][]byte // ordinal -> delta+varint packed ascending positions, only when the index tracks positions
 }
 
 // newPostingList returns an empty posting list ready to record documents.
@@ -30,8 +36,9 @@ func newPostingList() *postingList {
 // non-empty, are the term's ascending token positions in the document; they
 // are stored only when the index tracks positions (WithPositions) and only for
 // the primary word channel, so an OR-union-only index passes nil and pays
-// nothing. The slice is retained as-is (not copied): callers build a fresh
-// per-document slice, so no two posting lists alias it.
+// nothing. They are delta+varint packed into a fresh []byte, so the caller's
+// transient position slice is not retained and the store holds only the
+// compact bytes.
 func (p *postingList) set(ord uint32, tf int, positions []uint32) {
 	p.docs.Add(ord)
 	if tf > 1 {
@@ -42,9 +49,9 @@ func (p *postingList) set(ord uint32, tf int, positions []uint32) {
 	}
 	if len(positions) > 0 {
 		if p.positions == nil {
-			p.positions = make(map[uint32][]uint32)
+			p.positions = make(map[uint32][]byte)
 		}
-		p.positions[ord] = positions
+		p.positions[ord] = packPositions(positions)
 	}
 }
 
@@ -82,12 +89,54 @@ func (p *postingList) tf(ord uint32) int {
 
 // positionsOf returns document ord's ascending token positions for this term,
 // or nil when the index does not track positions (or ord carries none). The
-// slice is owned by the posting list; callers must not mutate it.
+// packed bytes are decoded into a fresh []uint32 on each call, so the returned
+// slice is owned by the caller and safe to mutate; it is not shared with the
+// posting list.
 func (p *postingList) positionsOf(ord uint32) []uint32 {
 	if p.positions == nil {
 		return nil
 	}
-	return p.positions[ord]
+	return unpackPositions(p.positions[ord])
+}
+
+// packPositions delta+varint encodes an ascending position slice: the first
+// value is emitted as-is (its delta from 0) and each subsequent value as the
+// gap from its predecessor, then each gap is written as an unsigned varint.
+// Positions in a document are strictly increasing (each word token advances the
+// counter), so gaps are small and pack into a single byte for the short vertex
+// values Lantern indexes — a ~4x shrink over the raw []uint32. positions must
+// be ascending; the indexer builds it that way.
+func packPositions(positions []uint32) []byte {
+	// One byte per position is the common case, so size the buffer for it.
+	buf := make([]byte, 0, len(positions))
+	var prev uint32
+	for _, pos := range positions {
+		buf = binary.AppendUvarint(buf, uint64(pos-prev))
+		prev = pos
+	}
+	return buf
+}
+
+// unpackPositions reverses packPositions, decoding the delta+varint bytes back
+// into the ascending absolute positions. It returns nil for empty input (a
+// document that carries no positions for the term).
+func unpackPositions(b []byte) []uint32 {
+	if len(b) == 0 {
+		return nil
+	}
+	// Each position occupies at least one byte, so len(b) bounds the count.
+	out := make([]uint32, 0, len(b))
+	var acc uint32
+	for i := 0; i < len(b); {
+		delta, n := binary.Uvarint(b[i:])
+		if n <= 0 {
+			break // malformed; only reachable on a corrupted buffer
+		}
+		acc += uint32(delta)
+		out = append(out, acc)
+		i += n
+	}
+	return out
 }
 
 // cardinality is the document frequency (DF): how many documents hold the term.

--- a/core/search/posting_test.go
+++ b/core/search/posting_test.go
@@ -1,6 +1,10 @@
 package search
 
-import "testing"
+import (
+	"math/rand"
+	"slices"
+	"testing"
+)
 
 func TestPostingList(t *testing.T) {
 	p := newPostingList()
@@ -61,6 +65,47 @@ func TestPostingListClampsTF(t *testing.T) {
 	}
 }
 
+// TestPackPositions proves the delta+varint position encoding (#908) is
+// lossless: unpack(pack(x)) reproduces the original ascending positions for
+// edge cases and for randomized sequences with wide, multi-byte-varint gaps.
+// This is the equivalence reference for the phrase/proximity readers, which now
+// consume the packed store via positionsOf.
+func TestPackPositions(t *testing.T) {
+	t.Run("edge cases round-trip; empty packs to no bytes", func(t *testing.T) {
+		cases := [][]uint32{
+			nil,
+			{0},
+			{5},
+			{0, 1, 2, 3},
+			{3, 7, 100, 128, 300},
+			{0, 1 << 7, 1 << 14, 1 << 21, 1 << 28}, // each gap crosses a varint width boundary
+			{1<<16 + 1, 1<<20 + 5},                 // beyond the uint16 fast-path ceiling
+		}
+		for _, in := range cases {
+			if got := unpackPositions(packPositions(in)); !slices.Equal(got, in) {
+				t.Fatalf("round-trip %v = %v", in, got)
+			}
+		}
+		if packed := packPositions(nil); len(packed) != 0 {
+			t.Fatalf("packPositions(nil) = %v, want no bytes", packed)
+		}
+	})
+
+	t.Run("randomized ascending sequences round-trip", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(1))
+		for iter := 0; iter < 2000; iter++ {
+			seq := make([]uint32, rng.Intn(64))
+			var acc uint32
+			for i := range seq {
+				acc += uint32(rng.Intn(1<<20) + 1) // strictly ascending, wide gaps
+				seq[i] = acc
+			}
+			if got := unpackPositions(packPositions(seq)); !slices.Equal(got, seq) {
+				t.Fatalf("iter %d round-trip mismatch:\n in=%v\nout=%v", iter, seq, got)
+			}
+		}
+	})
+}
 func TestOrdinals(t *testing.T) {
 	o := newOrdinals[string]()
 

--- a/core/search/proximity.go
+++ b/core/search/proximity.go
@@ -1,10 +1,15 @@
 package search
 
-// proximityBoostWeight scales the proximity bonus added to a multi-term query's
-// OR-union scores: a document where the query's word-channel terms cluster
-// close together is lifted above one where they are scattered, the way Lucene's
-// phrase/span proximity rewards tight matches. It is deliberately modest so it
-// reorders near-ties without overturning the BM25 ordering; 0 would disable it.
+// proximityBoostWeight is the default multiplier for the proximity bonus added
+// to a multi-term query's OR-union scores: a document where the query's
+// word-channel terms cluster close together is lifted above one where they are
+// scattered, the way Lucene's phrase/span proximity rewards tight matches. It
+// is deliberately modest so it reorders near-ties without overturning the BM25
+// ordering; 0 would disable it. WithProximityWeight overrides it per index, and
+// the relevance harness sweeps that override to justify this value (#910): the
+// proximity-sensitive qrels in the en and mixed corpora climb as the weight
+// rises and plateau at nDCG 1.0 by this default, so a higher weight buys no
+// further ranking gain while risking BM25 upsets — the plateau that pins it.
 const proximityBoostWeight = 0.3
 
 // applyProximityLocked adds a proximity bonus to the OR-union scores of a
@@ -15,13 +20,14 @@ const proximityBoostWeight = 0.3
 // exact or near phrase outranks the same terms scattered across a long
 // document. Documents with fewer than two present query terms — and every
 // document when positions are off or the query has a single word term — keep
-// their OR-union score untouched. Callers must hold idx.mu.
+// their OR-union score untouched, as does every document when the index's
+// proximity weight is 0 (WithProximityWeight(0)). Callers must hold idx.mu.
 //
 // It runs after scoreLocked over the same match set, so it never widens the
 // candidate pool: SearchTopK's bounded selection still sees exactly the
 // OR-union matches, now with tighter matches ranked higher.
 func (idx *InvertedIndex[S, D]) applyProximityLocked(scores map[uint32]float64, queryTerms map[Token]struct{}) {
-	if !idx.positions || len(scores) == 0 {
+	if !idx.positions || idx.proximityWeight == 0 || len(scores) == 0 {
 		return
 	}
 	cp := &idx.classes[ClassWord]
@@ -69,7 +75,7 @@ func (idx *InvertedIndex[S, D]) applyProximityLocked(scores map[uint32]float64, 
 		if span < 0 {
 			span = 0
 		}
-		scores[ord] += proximityBoostWeight * float64(len(present)-1) / float64(span+1)
+		scores[ord] += idx.proximityWeight * float64(len(present)-1) / float64(span+1)
 	}
 }
 

--- a/core/search/proximity_test.go
+++ b/core/search/proximity_test.go
@@ -41,6 +41,52 @@ func TestProximityBoostInertWithoutPositions(t *testing.T) {
 	}
 }
 
+// TestProximityWeightScalesBoost pins WithProximityWeight to the boost formula:
+// weight 0 makes the boost inert even under WithPositions (the two docs tie on
+// pure BM25), and the bonus the adjacent document earns is exactly linear in the
+// weight, so the harness can read the ranking off a swept weight. The adjacent
+// doc's window is 1 (span 0) and the scattered doc's is 5 (span 4), so at weight
+// w the bonuses are w/(0+1) and w/(4+1) and the tie-break gap is w - w/5 =
+// 0.8*w — measured here at two weights to fix the slope.
+func TestProximityWeightScalesBoost(t *testing.T) {
+	build := func(w float64) []Result[string] {
+		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, WithPositions(), WithProximityWeight(w))
+		idx.Index("adjacent", Text("alpha quick fox beta gamma delta"))  // quick@1 fox@2
+		idx.Index("scattered", Text("quick alpha beta gamma delta fox")) // quick@0 fox@5
+		return idx.Search("quick fox")
+	}
+
+	t.Run("ZeroDisables", func(t *testing.T) {
+		res := build(0)
+		if len(res) != 2 {
+			t.Fatalf("want 2 results, got %d", len(res))
+		}
+		if res[0].Score != res[1].Score {
+			t.Fatalf("weight 0 must tie like no boost, got %+v", res)
+		}
+	})
+
+	t.Run("LinearInWeight", func(t *testing.T) {
+		gap := func(res []Result[string]) float64 {
+			byID := map[string]float64{res[0].ID: res[0].Score, res[1].ID: res[1].Score}
+			return byID["adjacent"] - byID["scattered"]
+		}
+		g1 := gap(build(0.3))
+		g2 := gap(build(0.6))
+		if g1 <= 0 {
+			t.Fatalf("adjacent not boosted above scattered at weight 0.3: gap %.4f", g1)
+		}
+		// The bonus is linear in the weight, so doubling it doubles the gap.
+		if diff := g2 - 2*g1; diff > 1e-9 || diff < -1e-9 {
+			t.Fatalf("gap not linear in weight: g(0.3)=%.6f g(0.6)=%.6f", g1, g2)
+		}
+		// Slope check: the gap is 0.8*w by construction (windows 1 vs 5).
+		if diff := g1 - 0.8*0.3; diff > 1e-9 || diff < -1e-9 {
+			t.Fatalf("gap %.6f at weight 0.3 not 0.8*w = %.6f", g1, 0.8*0.3)
+		}
+	})
+}
+
 // TestProximityBoostSingleTermNoOp verifies a single-term query has no pair to
 // measure, so the boost is a no-op and ranking stays pure BM25 (the shorter,
 // denser document still wins on its own merits).

--- a/core/search/relevance/parity_gate_test.go
+++ b/core/search/relevance/parity_gate_test.go
@@ -27,13 +27,23 @@ import (
 // sibling under search) states the pipeline explicitly, and this comment plus
 // the one on newSearchIndex keep the two in sync.
 func productionIndex() *search.InvertedIndex[string, search.Text] {
+	return productionIndexWith()
+}
+
+// productionIndexWith builds the production pipeline with extra index options
+// appended after the fixed WithPositions — the seam the #910 proximity harness
+// uses to sweep WithProximityWeight without duplicating the analyzer/scorer
+// wiring. With no options it is byte-for-byte productionIndex (default
+// proximity weight), so the floors and Lucene gates keep measuring the shipped
+// pipeline.
+func productionIndexWith(opts ...search.IndexOption) *search.InvertedIndex[string, search.Text] {
 	return search.NewInvertedIndex[string, search.Text](
 		search.NewScriptAwareAnalyzer(),
 		search.ClassWeighted{
 			Base:       search.BM25{K1: search.DefaultBM25K1, B: search.DefaultBM25B},
 			GramWeight: search.DefaultGramWeight,
 		},
-		search.WithPositions(),
+		append([]search.IndexOption{search.WithPositions()}, opts...)...,
 	)
 }
 
@@ -43,15 +53,16 @@ func productionIndex() *search.InvertedIndex[string, search.Text] {
 // breaks score ties deterministically, so these numbers are exact and stable;
 // any drop below a floor is a real ranking change, not jitter.
 var productionFloors = map[string]Metrics{
-	// Re-pinned for #888's script-aware pipeline. Versus the pure-bigram
-	// floors it replaced: en nDCG@10 0.894 -> 0.927 and MRR 0.980 -> 1.0
-	// (whole-word evidence now dominates fragments), en Recall@50 gave back
-	// 0.958 -> 0.951 (an accepted trade: still far above Lucene's 0.828),
-	// ja unchanged (the CJK path is the same bigram strategy), mixed nDCG@10
-	// 0.947 -> 0.953.
-	"en":    {NDCG10: 0.927, MRR: 1.000, Recall50: 0.951},
+	// Re-pinned for #910's proximity qrels: the en and mixed corpora each gained
+	// a proximity-sensitive query (q27 "zephyr quokka", mq16 "marimba gable")
+	// whose two documents are exact word-multiset permutations — identical BM25,
+	// so the proximity boost is the sole tie-breaker. Under the boost the tight
+	// document ranks first (nDCG 1.0), lifting en nDCG@10 0.927 -> 0.930 and
+	// Recall@50 0.951 -> 0.953, and mixed nDCG@10 0.953 -> 0.956 and Recall@50
+	// 0.777 -> 0.791. ja is untouched by the new fixtures.
+	"en":    {NDCG10: 0.930, MRR: 1.000, Recall50: 0.953},
 	"ja":    {NDCG10: 0.911, MRR: 1.000, Recall50: 0.728},
-	"mixed": {NDCG10: 0.953, MRR: 1.000, Recall50: 0.777},
+	"mixed": {NDCG10: 0.956, MRR: 1.000, Recall50: 0.791},
 }
 
 func TestProductionPipelineRelevanceFloors(t *testing.T) {
@@ -347,4 +358,173 @@ func enCorpus(t *testing.T) Corpus {
 	}
 	t.Fatal("en corpus not found")
 	return Corpus{}
+}
+
+// corporaByName loads and indexes the golden corpora by name.
+func corporaByName(t *testing.T) map[string]Corpus {
+	t.Helper()
+	corpora, err := Corpora()
+	if err != nil {
+		t.Fatal(err)
+	}
+	byName := make(map[string]Corpus, len(corpora))
+	for _, c := range corpora {
+		byName[c.Name] = c
+	}
+	return byName
+}
+
+// proximityQueries are the queries #910 added to give the proximity boost a
+// yardstick. Each judges two documents that are exact word-multiset
+// permutations of each other — identical term frequencies and length, so BM25
+// ties them exactly — differing only in how close the query's two words sit.
+// The grade-3 document places them adjacent, the grade-1 one scatters them to
+// opposite ends; the scattered document sorts first by ID, so without the boost
+// the deterministic tie-break ranks it above the tight match (nDCG 0.71), and
+// only the proximity boost lifts the tight match to the top (nDCG 1.0). The
+// text is pinned so a fixture rename fails loudly.
+var proximityQueries = []struct{ corpus, id, text string }{
+	{"en", "q27", "zephyr quokka"},
+	{"mixed", "mq16", "marimba gable"},
+}
+
+// proximityNDCG indexes corpus c into a production pipeline whose proximity
+// weight is w and returns nDCG@10 for query q.
+func proximityNDCG(c Corpus, q Query, w float64) float64 {
+	idx := productionIndexWith(search.WithProximityWeight(w))
+	c.IndexDocs(idx)
+	return NDCGAt(NDCGDepth, RankSearcher(idx)(q), q.Qrels)
+}
+
+// TestProximityBoostImprovesRanking is the #910 yardstick that answers the
+// prove-or-retire question: on the permutation-pair queries the proximity boost
+// is the only signal that can separate the two documents, so turning it off
+// (WithProximityWeight(0)) drops the tight match below the scattered one and
+// turning it on at the shipped default lifts it to the ideal ranking. It also
+// pins that the boosted result is deterministic.
+func TestProximityBoostImprovesRanking(t *testing.T) {
+	byName := corporaByName(t)
+	for _, pq := range proximityQueries {
+		t.Run(pq.corpus+"/"+pq.id, func(t *testing.T) {
+			c, ok := byName[pq.corpus]
+			if !ok {
+				t.Fatalf("corpus %q not found", pq.corpus)
+			}
+			q, ok := queryByID(c)[pq.id]
+			if !ok {
+				t.Fatalf("proximity query %q missing from %s — fixtures stale", pq.id, pq.corpus)
+			}
+			if q.Text != pq.text {
+				t.Fatalf("proximity query %q text = %q, want %q — fixtures stale", pq.id, q.Text, pq.text)
+			}
+			if len(q.Qrels) != 2 {
+				t.Fatalf("proximity query %q should judge exactly 2 permutation docs, got %d", pq.id, len(q.Qrels))
+			}
+
+			off := proximityNDCG(c, q, 0)                       // boost disabled: permutations tie, ID order wins
+			on := NDCGAt(NDCGDepth, defaultRank(c, q), q.Qrels) // shipped default weight
+
+			if !(on > off) {
+				t.Errorf("proximity boost did not improve %s/%s: nDCG off=%.4f on=%.4f", pq.corpus, pq.id, off, on)
+			}
+			if on < 1.0-1e-9 {
+				t.Errorf("%s/%s: boosted nDCG@10 = %.4f, want ideal 1.0 (tight match first)", pq.corpus, pq.id, on)
+			}
+			if again := NDCGAt(NDCGDepth, defaultRank(c, q), q.Qrels); again != on {
+				t.Errorf("%s/%s: boosted nDCG not deterministic: %.6f vs %.6f", pq.corpus, pq.id, on, again)
+			}
+			t.Logf("%s/%s: nDCG@10 boost-off=%.4f -> default=%.4f", pq.corpus, pq.id, off, on)
+		})
+	}
+}
+
+// defaultRank ranks q through the shipped production pipeline (default proximity
+// weight), the exact index the floors and Lucene gates measure.
+func defaultRank(c Corpus, q Query) []string {
+	idx := productionIndex()
+	c.IndexDocs(idx)
+	return RankSearcher(idx)(q)
+}
+
+// proximitySweepWeights is the weight ladder TestProximityWeightSweep walks. It
+// spans zero (off) through the shipped 0.3 to deliberately excessive values, so
+// the recorded curve shows both that the boost earns its place and that pushing
+// the weight higher buys no further ranking gain.
+var proximitySweepWeights = []float64{0, 0.1, 0.3, 0.5, 1.0, 3.0}
+
+// TestProximityWeightSweep sweeps the proximity weight and records the curve,
+// the measurement that justifies the shipped 0.3 (#910). Per proximity query,
+// nDCG@10 climbs from the boost-off tie-break (0.71) to the ideal (1.0) as soon
+// as the weight is positive and then plateaus, so 0.3 sits safely on the
+// plateau while staying modest enough that the BM25-dominated floors gate (which
+// runs at 0.3) still holds. It asserts the plateau shape and logs the numbers
+// for the issue record; it does not re-pin anything.
+func TestProximityWeightSweep(t *testing.T) {
+	byName := corporaByName(t)
+	for _, pq := range proximityQueries {
+		t.Run(pq.corpus+"/"+pq.id, func(t *testing.T) {
+			c := byName[pq.corpus]
+			q := queryByID(c)[pq.id]
+
+			got := make([]float64, len(proximitySweepWeights))
+			prev := -1.0
+			for i, w := range proximitySweepWeights {
+				got[i] = proximityNDCG(c, q, w)
+				if got[i] < prev-1e-9 {
+					t.Errorf("nDCG@10 not monotonic in weight: w=%.2f nDCG=%.4f < previous %.4f", w, got[i], prev)
+				}
+				prev = got[i]
+			}
+			t.Logf("%s/%s weight sweep %v -> nDCG@10 %v", pq.corpus, pq.id, proximitySweepWeights, got)
+
+			off := got[0]
+			for i, w := range proximitySweepWeights {
+				if w == 0 {
+					continue
+				}
+				if !(got[i] > off) {
+					t.Errorf("weight %.2f did not beat boost-off nDCG %.4f (got %.4f)", w, off, got[i])
+				}
+				if got[i] < 1.0-1e-9 {
+					t.Errorf("weight %.2f nDCG@10 %.4f below the 1.0 plateau", w, got[i])
+				}
+			}
+		})
+	}
+}
+
+// proximityCorpusWeights is the wider ladder TestProximityWeightEarnsItsPlace
+// walks at the corpus level, reaching a deliberately excessive 10.0 so the
+// recorded curve shows the boost turning from help to harm.
+var proximityCorpusWeights = []float64{0, 0.3, 1.0, 3.0, 10.0}
+
+// TestProximityWeightEarnsItsPlace is the corpus-level half of the #910
+// prove-or-retire answer: it sweeps the whole en and mixed corpora (not just the
+// permutation query) and asserts the boost is a net win at the shipped 0.3 —
+// corpus nDCG@10 strictly above the boost-off baseline — which is what "earns
+// its weight" means. It also records the far end of the ladder, where an
+// oversized weight starts overturning BM25 (mixed MRR falls from 1.0 at 10.0),
+// the evidence that the constant must stay modest rather than be maximized.
+func TestProximityWeightEarnsItsPlace(t *testing.T) {
+	byName := corporaByName(t)
+	for _, name := range []string{"en", "mixed"} {
+		t.Run(name, func(t *testing.T) {
+			c := byName[name]
+			metrics := make([]Metrics, len(proximityCorpusWeights))
+			for i, w := range proximityCorpusWeights {
+				idx := productionIndexWith(search.WithProximityWeight(w))
+				c.IndexDocs(idx)
+				metrics[i] = Evaluate(c, RankSearcher(idx))
+				t.Logf("%-5s w=%5.2f nDCG@10=%.5f MRR=%.5f Recall@50=%.5f", name, w, metrics[i].NDCG10, metrics[i].MRR, metrics[i].Recall50)
+			}
+			off := metrics[0]     // weight 0: boost disabled
+			shipped := metrics[1] // weight 0.3: the shipped default
+			if !(shipped.NDCG10 > off.NDCG10) {
+				t.Errorf("%s: proximity boost is not a net win at 0.3: nDCG@10 off=%.5f shipped=%.5f", name, off.NDCG10, shipped.NDCG10)
+			}
+			if shipped.MRR < off.MRR-1e-9 {
+				t.Errorf("%s: proximity boost hurt MRR at 0.3: off=%.5f shipped=%.5f", name, off.MRR, shipped.MRR)
+			}
+		})
+	}
 }

--- a/core/search/relevance/testdata/en.json
+++ b/core/search/relevance/testdata/en.json
@@ -91,7 +91,9 @@
     {"id": "misc-02", "text": "Architecture reviews happen every Thursday afternoon."},
     {"id": "misc-03", "text": "Monarch butterflies migrate thousands of kilometers each autumn."},
     {"id": "misc-04", "text": "user:profile:9f2c settings cached at edge nodes"},
-    {"id": "misc-05", "text": "TOKYO office headcount grows to forty this quarter."}
+    {"id": "misc-05", "text": "TOKYO office headcount grows to forty this quarter."},
+    {"id": "en-prox-scatter", "text": "zephyr marlin pewter granite quokka"},
+    {"id": "en-prox-tight", "text": "marlin pewter granite zephyr quokka"}
   ],
   "queries": [
     {"id": "q01", "text": "espresso", "qrels": {"coffee-01": 3, "coffee-05": 2, "coffee-07": 2, "coffee-08": 2, "coffee-06": 1}},
@@ -119,6 +121,7 @@
     {"id": "q23", "text": "al dente spaghetti", "qrels": {"pasta-05": 3, "pasta-02": 1}},
     {"id": "q24", "text": "priority pass lounge", "qrels": {"travel-08": 3}},
     {"id": "q25", "text": "ttl expiration decay", "qrels": {"db-07": 3, "db-06": 1}},
-    {"id": "q26", "text": "ethiopia single origin", "qrels": {"coffee-05": 3, "coffee-07": 2}}
+    {"id": "q26", "text": "ethiopia single origin", "qrels": {"coffee-05": 3, "coffee-07": 2}},
+    {"id": "q27", "text": "zephyr quokka", "qrels": {"en-prox-tight": 3, "en-prox-scatter": 1}}
   ]
 }

--- a/core/search/relevance/testdata/lucene_runs.json
+++ b/core/search/relevance/testdata/lucene_runs.json
@@ -1,6 +1,6 @@
 {
   "engine": "lucene-9.11.1",
-  "generated": "2026-07-03T00:29:48.414269134Z",
+  "generated": "2026-07-03T11:45:23.842077045Z",
   "runs": {
     "en-standard": {
       "corpus": "en",
@@ -127,6 +127,10 @@
           "coffee-07",
           "coffee-05",
           "auth-09"
+        ],
+        "q27": [
+          "en-prox-scatter",
+          "en-prox-tight"
         ]
       }
     },
@@ -260,6 +264,10 @@
           "coffee-07",
           "coffee-05",
           "auth-09"
+        ],
+        "q27": [
+          "en-prox-scatter",
+          "en-prox-tight"
         ]
       }
     },
@@ -563,6 +571,10 @@
           "prod-04",
           "mdb-02",
           "mdev-03"
+        ],
+        "mq16": [
+          "mprox-scatter",
+          "mprox-tight"
         ]
       }
     },
@@ -620,6 +632,10 @@
         ],
         "mq15": [
           "prod-04"
+        ],
+        "mq16": [
+          "mprox-scatter",
+          "mprox-tight"
         ]
       }
     }

--- a/core/search/relevance/testdata/mixed.json
+++ b/core/search/relevance/testdata/mixed.json
@@ -43,7 +43,9 @@
     {"id": "mfood-05", "text": "タピオカミルクティーの再ブームが来ている。"},
     {"id": "mmisc-01", "text": "ＴＯＫＹＯマラソンの抽選倍率は十倍を超える。"},
     {"id": "mmisc-02", "text": "ｷｬｯｼｭﾚｽ決済のポイント還元が今月で終了する。"},
-    {"id": "mmisc-03", "text": "Wi-Fiルーターの設置場所は家の中心が理想。"}
+    {"id": "mmisc-03", "text": "Wi-Fiルーターの設置場所は家の中心が理想。"},
+    {"id": "mprox-scatter", "text": "marimba cinder plinth obsidian gable"},
+    {"id": "mprox-tight", "text": "cinder plinth obsidian marimba gable"}
   ],
   "queries": [
     {"id": "mq01", "text": "ローリングアップデート", "qrels": {"mk8s-01": 3, "mk8s-03": 1, "mk8s-02": 1}},
@@ -60,6 +62,7 @@
     {"id": "mq12", "text": "カフェラテ", "qrels": {"mfood-04": 3, "mfood-01": 2}},
     {"id": "mq13", "text": "ＴＯＫＹＯ", "qrels": {"mmisc-01": 3, "mtrv-01": 2, "mtrv-04": 1}},
     {"id": "mq14", "text": "ｷｬｯｼｭﾚｽ", "qrels": {"mmisc-02": 3}},
-    {"id": "mq15", "text": "電動自転車 バッテリー", "qrels": {"prod-04": 3, "prod-01": 1}}
+    {"id": "mq15", "text": "電動自転車 バッテリー", "qrels": {"prod-04": 3, "prod-01": 1}},
+    {"id": "mq16", "text": "marimba gable", "qrels": {"mprox-tight": 3, "mprox-scatter": 1}}
   ]
 }

--- a/docs/env.md
+++ b/docs/env.md
@@ -74,9 +74,10 @@ value is treated as unset for the non-string kinds. The MCP server's
 | `LANTERN_SCAN_MAX_LIMIT` | uint32 | `10000` | Ceiling a Scan* request's limit is clamped to. |
 | `LANTERN_SEARCH_DEFAULT_LIMIT` | uint32 | `100` | Ranked-hit count used when SearchVertices leaves limit unset. |
 | `LANTERN_SEARCH_DEFAULT_MIN_SHOULD` | uint32 | `1` | Minimum-should-match count applied when the mode resolves to min-should but the request leaves it 0. |
-| `LANTERN_SEARCH_DEFAULT_MODE` | string | `any` | Match mode applied when a SearchVertices request omits it: any (OR), all (AND), or min-should. |
+| `LANTERN_SEARCH_DEFAULT_MODE` | string | `any` | Match mode applied when a SearchVertices request omits it: any (OR), all (AND), or min-should. Validated at startup — an unrecognised value fails boot. |
 | `LANTERN_SEARCH_ENABLED` | bool | `true` | Build the full-text search index and serve SearchVertices (off = FAILED_PRECONDITION). |
 | `LANTERN_SEARCH_MAX_LIMIT` | uint32 | `1000` | Ceiling SearchVertices' limit is clamped to. |
+| `LANTERN_SEARCH_POSITIONS` | bool | `true` | Record positional postings so phrase queries verify adjacency and the proximity boost ranks tight matches higher. Off drops the per-(word term, vertex) position store: phrase degrades to the AND-intersection and the boost goes inert, shrinking the index on large corpora. |
 | `LANTERN_SHUTDOWN_TIMEOUT_SECONDS` | int | `30` | Graceful-shutdown drain budget for in-flight requests before a hard close. |
 | `LANTERN_SLOW_RPC_THRESHOLD_MS` | int | `500` | RPCs slower than this emit a warn-level "slow rpc" log line (0 disables). |
 | `LANTERN_STRICT_CONFIG` | bool | `false` | Refuse to boot when any LANTERN_* value is malformed or an unknown LANTERN_* variable is set. |

--- a/server/internal/envdoc/envdoc.go
+++ b/server/internal/envdoc/envdoc.go
@@ -72,9 +72,10 @@ var descriptions = map[string]string{
 	"LANTERN_DELETE_BY_PREFIX_MAX_LIMIT":     "Ceiling DeleteVerticesByPrefix's limit is clamped to.",
 
 	"LANTERN_SEARCH_ENABLED":            "Build the full-text search index and serve SearchVertices (off = FAILED_PRECONDITION).",
+	"LANTERN_SEARCH_POSITIONS":          "Record positional postings so phrase queries verify adjacency and the proximity boost ranks tight matches higher. Off drops the per-(word term, vertex) position store: phrase degrades to the AND-intersection and the boost goes inert, shrinking the index on large corpora.",
 	"LANTERN_SEARCH_DEFAULT_LIMIT":      "Ranked-hit count used when SearchVertices leaves limit unset.",
 	"LANTERN_SEARCH_MAX_LIMIT":          "Ceiling SearchVertices' limit is clamped to.",
-	"LANTERN_SEARCH_DEFAULT_MODE":       "Match mode applied when a SearchVertices request omits it: any (OR), all (AND), or min-should.",
+	"LANTERN_SEARCH_DEFAULT_MODE":       "Match mode applied when a SearchVertices request omits it: any (OR), all (AND), or min-should. Validated at startup — an unrecognised value fails boot.",
 	"LANTERN_SEARCH_DEFAULT_MIN_SHOULD": "Minimum-should-match count applied when the mode resolves to min-should but the request leaves it 0.",
 
 	"LANTERN_MUTATION_LOG_CAPACITY":          "Replication mutation-log ring capacity in entries; size for peak_cluster_rps x retention_seconds.",

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/anaregdesign/lantern/server/internal/envconfig"
 	domainmetrics "github.com/anaregdesign/lantern/server/metrics"
 	"github.com/anaregdesign/lantern/server/readiness"
+	"github.com/anaregdesign/lantern/server/service"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -177,6 +178,7 @@ type ScanConfig struct {
 // count the same way ScanConfig caps the prefix RPCs.
 //
 //   - LANTERN_SEARCH_ENABLED           (default true)
+//   - LANTERN_SEARCH_POSITIONS         (default true)
 //   - LANTERN_SEARCH_DEFAULT_LIMIT     (default 100)
 //   - LANTERN_SEARCH_MAX_LIMIT         (default 1000)
 //   - LANTERN_SEARCH_DEFAULT_MODE      (default "any": any|all|min-should)
@@ -185,9 +187,18 @@ type SearchConfig struct {
 	Enabled      bool
 	DefaultLimit uint32
 	MaxLimit     uint32
+	// Positions is opt-out (LANTERN_SEARCH_POSITIONS, default true): when true
+	// the search index records positional postings so phrase queries verify
+	// adjacency and the proximity boost ranks tight matches higher. Setting it
+	// false drops the per-(word term, vertex) position store — phrase queries
+	// degrade to the AND-intersection and the proximity boost goes inert —
+	// trading phrase/proximity fidelity for a smaller index on large corpora
+	// (#908). Ignored when Enabled is false.
+	Positions bool
 	// DefaultMode is the match mode applied when a SearchVertices request omits
 	// options or leaves match_mode unspecified: "any" (OR), "all" (AND), or
-	// "min-should". An unrecognised value falls back to "any".
+	// "min-should". The value is validated at startup (service.ValidateMatchMode);
+	// an unrecognised spelling fails boot rather than silently defaulting (#911).
 	DefaultMode string
 	// DefaultMinShould is the minimum-should-match count applied when the mode
 	// resolves to min-should but the request leaves min_should_match at 0.
@@ -293,6 +304,7 @@ func NewConfig() (*Config, error) {
 		},
 		Search: SearchConfig{
 			Enabled:          envconfig.Bool("LANTERN_SEARCH_ENABLED", true),
+			Positions:        envconfig.Bool("LANTERN_SEARCH_POSITIONS", true),
 			DefaultLimit:     envconfig.Uint32("LANTERN_SEARCH_DEFAULT_LIMIT", 100),
 			MaxLimit:         envconfig.Uint32("LANTERN_SEARCH_MAX_LIMIT", 1000),
 			DefaultMode:      envconfig.String("LANTERN_SEARCH_DEFAULT_MODE", "any"),
@@ -306,7 +318,18 @@ func NewConfig() (*Config, error) {
 		CORS:        loadCORSConfig(),
 		Backup:      loadBackupConfig(),
 	}
-	return cfg, validateEnv(os.Environ())
+	if err := validateEnv(os.Environ()); err != nil {
+		return nil, err
+	}
+	// Unlike the malformed/unknown-variable findings (warn, and only fail under
+	// LANTERN_STRICT_CONFIG), an unrecognised LANTERN_SEARCH_DEFAULT_MODE always
+	// fails boot: the value is a valid string, so it slips past parsing, but a
+	// typo silently rewrites server-wide default ranking semantics — an operator
+	// must learn about it at startup, not from confusing search results (#911).
+	if err := service.ValidateMatchMode(cfg.Search.DefaultMode); err != nil {
+		return nil, err
+	}
+	return cfg, nil
 }
 
 // foreignEnvPrefixes names LANTERN_*-prefixed namespaces owned by sibling
@@ -411,9 +434,15 @@ func NewGraphCache(c CacheConfig, sc SearchConfig) *graphcache.GraphCache[string
 	// Content search (#624) is opt-out. EnableSearchIndex carries the same
 	// "before any insert" contract as EnablePrefixIndex, so it must also be
 	// called here; gating on sc.Enabled keeps the put hot path free of the
-	// inverted-index cost when an operator turns the feature off.
+	// inverted-index cost when an operator turns the feature off. Positional
+	// postings are a second opt-out (LANTERN_SEARCH_POSITIONS, #908): dropping
+	// them shrinks the index at the cost of phrase/proximity fidelity.
 	if sc.Enabled {
-		gc.EnableSearchIndex(vertexSearchDocument)
+		var opts []graphcache.SearchIndexOption
+		if !sc.Positions {
+			opts = append(opts, graphcache.WithoutSearchPositions())
+		}
+		gc.EnableSearchIndex(vertexSearchDocument, opts...)
 	}
 	return gc
 }

--- a/server/provider/provider_test.go
+++ b/server/provider/provider_test.go
@@ -133,6 +133,35 @@ func TestNewConfigValidation(t *testing.T) {
 			t.Fatalf("error does not name LANTERN_NODE_ID: %v", err)
 		}
 	})
+
+	// #911: an unrecognised LANTERN_SEARCH_DEFAULT_MODE always fails boot,
+	// independent of LANTERN_STRICT_CONFIG — the value parses as a string but a
+	// typo would silently rewrite server-wide default ranking semantics.
+	t.Run("invalid DEFAULT_MODE fails boot even without strict", func(t *testing.T) {
+		envconfig.ResetForTesting()
+		t.Setenv("LANTERN_STRICT_CONFIG", "false")
+		t.Setenv("LANTERN_SEARCH_DEFAULT_MODE", "min_shold") // typo of min-should
+		_, err := NewConfig()
+		if err == nil {
+			t.Fatal("NewConfig accepted an unrecognised LANTERN_SEARCH_DEFAULT_MODE")
+		}
+		if !strings.Contains(err.Error(), "LANTERN_SEARCH_DEFAULT_MODE") || !strings.Contains(err.Error(), "min_shold") {
+			t.Fatalf("error does not name the offending value: %v", err)
+		}
+		if !strings.Contains(err.Error(), "any|all|min-should") {
+			t.Fatalf("error does not list the allowed values: %v", err)
+		}
+	})
+
+	t.Run("canonical and alias DEFAULT_MODE spellings boot", func(t *testing.T) {
+		for _, mode := range []string{"any", "all", "min-should", "minshould", "min_should", "ALL", ""} {
+			envconfig.ResetForTesting()
+			t.Setenv("LANTERN_SEARCH_DEFAULT_MODE", mode)
+			if _, err := NewConfig(); err != nil {
+				t.Fatalf("NewConfig rejected DEFAULT_MODE=%q: %v", mode, err)
+			}
+		}
+	})
 }
 
 // TestMetricsMux groups the HTTP-shim tests for newMetricsMux. The

--- a/server/service/search.go
+++ b/server/service/search.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -93,16 +94,46 @@ func matchModeFromPB(m pb.MatchMode, fallback search.MatchMode) search.MatchMode
 	}
 }
 
-// ParseMatchMode maps a LANTERN_SEARCH_DEFAULT_MODE value to a core match mode;
-// an empty or unrecognised value is MatchAny. Exported for the wire seam in
-// package main, which converts provider config to service config.
-func ParseMatchMode(s string) search.MatchMode {
+// parseMatchMode maps a LANTERN_SEARCH_DEFAULT_MODE value to a core match mode
+// and reports whether the spelling was recognised. The empty string is
+// recognised as the default (MatchAny), so a bare `LANTERN_SEARCH_DEFAULT_MODE=`
+// still means "use the default"; any other unrecognised value reports ok ==
+// false so the caller can reject it (ValidateMatchMode) instead of laundering a
+// typo into MatchAny. It is the single source of truth for the accepted
+// spellings, shared by ParseMatchMode and ValidateMatchMode.
+func parseMatchMode(s string) (search.MatchMode, bool) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "any":
+		return search.MatchAny, true
 	case "all":
-		return search.MatchAll
+		return search.MatchAll, true
 	case "min-should", "minshould", "min_should":
-		return search.MatchMinShould
+		return search.MatchMinShould, true
 	default:
-		return search.MatchAny
+		return search.MatchAny, false
 	}
+}
+
+// ParseMatchMode maps a LANTERN_SEARCH_DEFAULT_MODE value to a core match mode.
+// It is deliberately tolerant — the empty string and any unrecognised value
+// resolve to MatchAny — because the provider validates the value at startup
+// (ValidateMatchMode) before this wire seam converts provider config to service
+// config, so an unrecognised value can no longer reach it in a booted server.
+// Exported for that seam in package main.
+func ParseMatchMode(s string) search.MatchMode {
+	mode, _ := parseMatchMode(s)
+	return mode
+}
+
+// ValidateMatchMode reports an error when s is not an accepted
+// LANTERN_SEARCH_DEFAULT_MODE spelling — the canonical any|all|min-should, their
+// documented aliases (minshould, min_should), or the empty string for "use the
+// default". The provider calls it at startup so a typo (min_shold, AND, or)
+// fails boot with the allowed values listed, rather than silently defaulting to
+// "any" and changing server-wide ranking semantics (#911).
+func ValidateMatchMode(s string) error {
+	if _, ok := parseMatchMode(s); !ok {
+		return fmt.Errorf("LANTERN_SEARCH_DEFAULT_MODE=%q: must be one of any|all|min-should", s)
+	}
+	return nil
 }

--- a/server/service/search_test.go
+++ b/server/service/search_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -123,4 +124,50 @@ func TestSearchVertices_CanceledContext(t *testing.T) {
 	if fb.searchCalls != 0 {
 		t.Errorf("backend called despite canceled context")
 	}
+}
+
+func TestParseMatchMode(t *testing.T) {
+	tests := []struct {
+		in   string
+		want search.MatchMode
+	}{
+		{"", search.MatchAny},
+		{"any", search.MatchAny},
+		{"ANY", search.MatchAny},
+		{"  all  ", search.MatchAll},
+		{"min-should", search.MatchMinShould},
+		{"minshould", search.MatchMinShould},
+		{"min_should", search.MatchMinShould},
+		// Unrecognised launders to MatchAny — a dead path in a booted server
+		// because the provider rejects the value at startup, but kept tolerant
+		// so the wire seam never has to handle an error.
+		{"min_shold", search.MatchAny},
+		{"or", search.MatchAny},
+	}
+	for _, tc := range tests {
+		if got := ParseMatchMode(tc.in); got != tc.want {
+			t.Errorf("ParseMatchMode(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestValidateMatchMode(t *testing.T) {
+	t.Run("accepts canonical, aliases, and empty", func(t *testing.T) {
+		for _, in := range []string{"", "any", "all", "min-should", "minshould", "min_should", "  ALL  "} {
+			if err := ValidateMatchMode(in); err != nil {
+				t.Errorf("ValidateMatchMode(%q) = %v, want nil", in, err)
+			}
+		}
+	})
+	t.Run("rejects a typo naming the value and allowed set", func(t *testing.T) {
+		err := ValidateMatchMode("min_shold")
+		if err == nil {
+			t.Fatal("ValidateMatchMode accepted a typo")
+		}
+		for _, want := range []string{"min_shold", "any|all|min-should"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q does not contain %q", err, want)
+			}
+		}
+	})
 }

--- a/tests/integration/search_vertices_test.go
+++ b/tests/integration/search_vertices_test.go
@@ -291,6 +291,55 @@ func TestSearchVertices_Options(t *testing.T) {
 	})
 }
 
+// TestSearchVertices_PositionsOff verifies the #908 opt-out end to end through
+// the RPC: with LANTERN_SEARCH_POSITIONS=false the index keeps no positions, so
+// a phrase query degrades to the AND-intersection (every word present, adjacency
+// unverified) instead of failing — the scattered doc that a position-tracking
+// index would drop is now kept.
+func TestSearchVertices_PositionsOff(t *testing.T) {
+	// Build a search-enabled service whose cache index tracks no positions.
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache.EnablePrefixIndex(func(k string) string { return k })
+	cache.EnableSearchIndex(searchVertexDocument, graphcache.WithoutSearchPositions())
+	svc := service.NewLanternService(cache).WithSearchLimits(service.SearchLimits{
+		Enabled:      true,
+		DefaultLimit: 100,
+		MaxLimit:     1000,
+	})
+	srv := newConnectTestServer(t, svc, nil)
+	c := graphv1connect.NewLanternServiceClient(h2cClient(), srv.url)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	exp := timestamppb.New(time.Now().Add(time.Hour))
+	seed := []*pb.Vertex{
+		{Key: "doc.phrase", Value: &pb.Vertex_String_{String_: "the alpha beta end"}, Expiration: exp},
+		{Key: "doc.split", Value: &pb.Vertex_String_{String_: "beta stands well before the word alpha"}, Expiration: exp},
+	}
+	if _, err := c.PutVertices(ctx, connect.NewRequest(&pb.PutVerticesRequest{Vertices: seed})); err != nil {
+		t.Fatalf("PutVertices: %v", err)
+	}
+
+	resp, err := c.SearchVertices(ctx, connect.NewRequest(&pb.SearchVerticesRequest{
+		Query:   "alpha beta",
+		Options: &pb.SearchOptions{Phrase: true},
+	}))
+	if err != nil {
+		t.Fatalf("SearchVertices phrase: %v", err)
+	}
+	got := map[string]bool{}
+	for _, h := range resp.Msg.GetHits() {
+		got[h.GetKey()] = true
+	}
+	// Positions off: the phrase query is the AND-intersection, so BOTH the
+	// adjacent doc and the scattered doc come back (a position-tracking index
+	// would drop doc.split — asserted in TestSearchVertices_Options).
+	if !got["doc.phrase"] || !got["doc.split"] {
+		t.Errorf("positions-off phrase = %v, want both {doc.phrase, doc.split} (AND-intersection)", got)
+	}
+}
+
 // TestSearchVertices_SDKOptions drives the #892 options through the high-level
 // SDK: WithMatchMode(MatchAll) narrows the OR-union to the document holding
 // every term.


### PR DESCRIPTION
Four follow-ups from the #886 search epic, batched into one PR because #908 and #911 both touch `provider.go` / `env.md` / envdoc (parallel branches would conflict).

## #908 — `LANTERN_SEARCH_POSITIONS` opt-out + compact position encoding (perf, core+server)
- **Knob:** `graphcache.WithoutSearchPositions()` (via `SearchConfig.Positions`, default true, `LANTERN_SEARCH_POSITIONS`). Off ⇒ no per-`(word term, vertex)` position store; phrase queries degrade to the AND-intersection and the proximity boost goes inert. `SearchVertices` keeps working.
- **Encoding:** postings' positions packed as **delta+varint `[]byte`** instead of `[]uint32` (positions are built strictly ascending, so deltas are valid). Footprint bench (stash-based before/after): **live heap objects ~106k → ~26k (~75% fewer)**, retained **17.1 → 16.1 MiB**. Property test round-trips `packPositions`/`unpackPositions` (edge + 2000 randomized); integration test `TestSearchVertices_PositionsOff`.

## #909 — bound fuzzy/prefix expansion scan (perf, core)
- **Measured first:** `BenchmarkTermDictExpand` sweep (10k/100k/1M × prefix / fuzzy-1 / fuzzy-2). Prefix was already alloc-free O(dict); **fuzzy allocated two DP rows per length-compatible candidate (~1.1M allocs, ~45ms @ 1M terms)**.
- **Fix:** rune-length gate + reusable `[]rune`/DP scratch buffers in `expand`. Result: **fuzzy ~1.1M → 4–7 allocs/query, ~1.4–1.8× faster, byte-identical results** (churn property test vs an independent Levenshtein oracle). Prefix left linear — sorted/radix would return string-order matches and break the id-order cap-survivor determinism.

## #910 — prove or retire the proximity boost (perf/feat, core) → **PROVEN**
- Added **exact word-multiset permutation** doc pairs to the en + mixed corpora (`q27 "zephyr quokka"`, `mq16 "marimba gable"`): both docs share the identical multiset, so BM25 ties them and the proximity boost is the **sole** differentiator.
  - boost **off** → tie-break ranks the scattered doc first, **nDCG@10 0.71**
  - boost **on** (shipped 0.3) → tight match leads, **nDCG@10 1.0**
- Added `search.WithProximityWeight(w)` as the sweep seam (default `proximityBoostWeight=0.3`; `0` disables). Corpus sweep: **0.3 is a strict net win** (en 0.920→0.931, mixed 0.939→0.957) while an oversized weight (10) overturns BM25 on mixed (MRR 1.0→0.969) — the constant must stay modest.
- **Regenerated the pinned Lucene baseline** (deterministic; **0 drift** on existing queries; Lantern beats Lucene on the new proximity queries, 1.0 vs 0.71) and **re-pinned floors** (en 0.930 / mixed 0.956).

## #911 — fail boot on a bad `LANTERN_SEARCH_DEFAULT_MODE` (fix, server)
- A single `parseMatchMode` is the source of truth; `ValidateMatchMode` rejects a typo at startup (listing `any|all|min-should`) instead of silently defaulting to `"any"` and rewriting server-wide ranking semantics. `ParseMatchMode` stays tolerant behind the now-guaranteed-valid wire seam.

## Verification
- `gofmt -l .` clean; `go test ./...` green on root **and** every submodule (core, server, mcp, pb, sdks/go).
- `make wire` and `make envdoc` regenerate with no diff; `pb/**` untouched (no proto edits).

Closes #908, closes #909, closes #910, closes #911