### PR TITLE
fix(core): AddEdge effective_weight excludes expired contributions

### DIFF
--- a/core/graphcache/batch_external_test.go
+++ b/core/graphcache/batch_external_test.go
@@ -374,6 +374,33 @@ func TestAddEdgesWithExpirationContrib_Dedup(t *testing.T) {
 			t.Fatalf("facade weight = %v, want 6 (AddEdgesWithExpiration stays additive)", w)
 		}
 	})
+
+	// #917: the effective weight returned by the add path must agree with the
+	// read path once contributions expire below the compaction floor. Guards
+	// the wiring up to AddEdgesWithExpirationContrib, not just the weight unit.
+	t.Run("effective agrees with GetWeight after contributions expire", func(t *testing.T) {
+		c := graphcache.NewGraphCache[string, int](time.Minute)
+		shortExp := time.Now().Add(40 * time.Millisecond)
+		for i := 0; i < 50; i++ { // below the compaction floor: no structural flush
+			c.AddEdgesWithExpirationContrib([]graphcache.EdgeItem[string]{
+				{Tail: "s", Head: "h", Weight: 1, Expiration: shortExp},
+			})
+		}
+		time.Sleep(60 * time.Millisecond) // let them expire
+		effective, _ := c.AddEdgesWithExpirationContrib([]graphcache.EdgeItem[string]{
+			{Tail: "s", Head: "h", Weight: 1, Expiration: time.Now().Add(time.Hour)},
+		})
+		w, ok := c.GetWeight("s", "h")
+		if !ok {
+			t.Fatal("edge missing")
+		}
+		if len(effective) != 1 || effective[0] != w {
+			t.Fatalf("AddEdges effective = %v but GetWeight = %v — #917: the add path leaked expired weight", effective, w)
+		}
+		if effective[0] != 1 {
+			t.Fatalf("effective = %v, want 1 (unfixed code reports 51)", effective[0])
+		}
+	})
 }
 
 // itoa avoids pulling in strconv just to label test keys.

--- a/core/graphcache/edge.go
+++ b/core/graphcache/edge.go
@@ -32,11 +32,31 @@ type weight struct {
 	// ~2× the working set even on write-only hot edges that no reader
 	// touches between GC ticks, while keeping the amortized add cost O(1).
 	lastFlushLen int
+	// minExp is the earliest expiration among the *expiring* contributions
+	// currently in values (permanent contributions — zero or ≤epoch
+	// expiration, which cache.IsLiveAt treats as never-expiring — are
+	// excluded). The zero value means "nothing here can expire". It gates
+	// the reconcile-at-read in addWithExpirationContribAt (#917): the moment
+	// now reaches minExp at least one contribution has decayed, so the
+	// cached sum must be flushed before it is returned as effective. When
+	// now is still before minExp, sum is already exact and the read stays
+	// O(1). The invariant that keeps this correct is minExp must never be
+	// *later* than the true earliest expiration: stale-early costs one
+	// wasted flush, stale-late would leak expired weight back into the sum.
+	minExp time.Time
 	// lastHLC is the most recent HLC timestamp accepted by a Put-style
 	// (LWW) write. Zero value means "no LWW write has happened yet" — in
 	// that case the next Put-with-HLC always wins. Used only by the
 	// replication apply path; local writers do not touch it.
 	lastHLC hlc.Timestamp
+}
+
+// expires reports whether an expiration can actually decay (i.e. it is a real
+// positive deadline). It mirrors the "no expiration" sentinels honored by
+// cache.IsLiveAt — Go zero time and any instant at or before the Unix epoch
+// are permanent and never contribute to minExp.
+func expires(expiration time.Time) bool {
+	return !expiration.IsZero() && expiration.Unix() > 0
 }
 
 // weightCompactMin is the floor under the 2× growth trigger. Below this we
@@ -46,6 +66,18 @@ const weightCompactMin = 64
 
 func newWeight() *weight {
 	return &weight{}
+}
+
+// noteExpirationLocked folds a newly-appended contribution's expiration into
+// minExp. Caller must hold w.mu. Permanent contributions are ignored so they
+// never trip the reconcile-at-read trigger.
+func (w *weight) noteExpirationLocked(expiration time.Time) {
+	if !expires(expiration) {
+		return
+	}
+	if w.minExp.IsZero() || expiration.Before(w.minExp) {
+		w.minExp = expiration
+	}
 }
 
 func (w *weight) value() float32 {
@@ -82,34 +114,12 @@ func (w *weight) addWithExpiration(value float32, expiration time.Time) {
 // needs when a peer re-delivers a mutation. A zero contribID disables
 // dedup and behaves exactly like addWithExpiration; this is the local
 // (non-replicated) write path.
+//
+// It is a thin facade over addWithExpirationContribAt with now = time.Now();
+// the two must not drift, so the whole body lives in the *At form (#917).
 func (w *weight) addWithExpirationContrib(value float32, expiration time.Time, contribID ContribID) bool {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	if !contribID.IsZero() {
-		now := time.Now()
-		for _, v := range w.values {
-			if v.contribID == contribID && cache.IsLiveAt(v.expiration, now) {
-				return false
-			}
-		}
-	}
-	w.values = append(w.values, weightValue{
-		value:      value,
-		expiration: expiration,
-		contribID:  contribID,
-	})
-	w.sum += value
-
-	// Amortized compaction: a write-only hot edge that no reader visits
-	// between GC ticks would otherwise grow without bound, and the eventual
-	// flush (on read or on GC) would be O(N) over a giant slice. Trigger
-	// compaction once the slice has doubled past its last post-flush size,
-	// with a small floor so we skip the work on tiny edges. Cost stays O(1)
-	// amortized; worst-case write latency variance rises but is bounded.
-	if n := len(w.values); n > weightCompactMin && n > 2*w.lastFlushLen {
-		w.flushLocked()
-	}
-	return true
+	applied, _ := w.addWithExpirationContribAt(value, expiration, contribID, time.Now())
+	return applied
 }
 
 // addWithExpirationContribAt is addWithExpirationContrib with a caller-supplied
@@ -118,16 +128,26 @@ func (w *weight) addWithExpirationContrib(value float32, expiration time.Time, c
 // race-free increment-then-check counter. It uses the SAME amortized-compaction
 // trigger as addWithExpirationContrib so the hot add path stays O(1) amortized:
 // force-flushing on every call would make a write-only hot edge O(N) per add and
-// O(N²) overall (regressing #743's fast path). The returned `effective` is the
-// running sum after the append; the amortized flush bounds how long expired-but-
-// unflushed contributions linger in it, and it reconciles to the exact live sum
-// on the next flush (on the compaction trigger, on a value() read, or on GC). In
-// the increment-then-check counter use-case the edge is live-dominated, so the
-// returned sum equals the true rolling-window value. On a contrib_id dedup no-op
-// it returns applied=false and the current running sum.
+// O(N²) overall (regressing #743's fast path).
+//
+// The returned `effective` is always the exact live sum (#917). Before reading
+// sum back, the method reconciles expired-but-unflushed contributions, but only
+// when minExp shows something has actually decayed — so the live-dominated hot
+// path (nothing expired) still returns in O(1) with no flush, while the
+// short-TTL rolling-window counter no longer reports a sum inflated by expired
+// contributions lingering below the compaction floor. Both return paths are
+// exact: the applied path (`true, w.sum`) and the ContribID-dedup no-op path
+// (`false, w.sum`).
 func (w *weight) addWithExpirationContribAt(value float32, expiration time.Time, contribID ContribID, now time.Time) (applied bool, effective float32) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	// Reconcile before we read sum back: once now reaches the earliest
+	// expiration, at least one contribution has decayed and sum is stale.
+	// This is a single compare when nothing has expired (minExp in the
+	// future or absent), and a bounded flush exactly when staleness exists.
+	if !w.minExp.IsZero() && !now.Before(w.minExp) {
+		w.flushLockedAt(now)
+	}
 	if !contribID.IsZero() {
 		for _, v := range w.values {
 			if v.contribID == contribID && cache.IsLiveAt(v.expiration, now) {
@@ -141,6 +161,7 @@ func (w *weight) addWithExpirationContribAt(value float32, expiration time.Time,
 		contribID:  contribID,
 	})
 	w.sum += value
+	w.noteExpirationLocked(expiration)
 	if n := len(w.values); n > weightCompactMin && n > 2*w.lastFlushLen {
 		w.flushLockedAt(now)
 	}
@@ -171,6 +192,8 @@ func (w *weight) putWithExpirationHLC(value float32, expiration time.Time, ts hl
 	w.values = append(w.values, weightValue{value: value, expiration: expiration})
 	w.sum = value
 	w.lastFlushLen = 1
+	w.minExp = time.Time{}
+	w.noteExpirationLocked(expiration)
 	w.lastHLC = ts
 	return true
 }
@@ -200,6 +223,8 @@ func (w *weight) replace(value float32, expiration time.Time) {
 	w.values = append(w.values, weightValue{value: value, expiration: expiration})
 	w.sum = value
 	w.lastFlushLen = 1
+	w.minExp = time.Time{}
+	w.noteExpirationLocked(expiration)
 	w.lastHLC = hlc.Timestamp{}
 }
 
@@ -264,20 +289,26 @@ func (w *weight) flushLocked() {
 }
 
 // flushLockedAt is flushLocked against a caller-supplied instant (#838).
-// Caller must hold w.mu.
+// Caller must hold w.mu. It also recomputes minExp over the survivors so the
+// reconcile-at-read trigger (#917) tracks the new earliest expiration.
 func (w *weight) flushLockedAt(now time.Time) {
 	write := 0
 	var sum float32
+	var minExp time.Time
 	for _, v := range w.values {
 		if cache.IsLiveAt(v.expiration, now) {
 			w.values[write] = v
 			write++
 			sum += v.value
+			if expires(v.expiration) && (minExp.IsZero() || v.expiration.Before(minExp)) {
+				minExp = v.expiration
+			}
 		}
 	}
 	w.values = w.values[:write]
 	w.sum = sum
 	w.lastFlushLen = write
+	w.minExp = minExp
 }
 
 // edgeCache stores directed weighted edges using compact vertexID keys

--- a/core/graphcache/edge_test.go
+++ b/core/graphcache/edge_test.go
@@ -716,3 +716,69 @@ func Test_edgeCache_edgeCount(t *testing.T) {
 		check(t, c, 1)
 	})
 }
+
+// Test_weight_effectiveExcludesExpired pins #917: the effective weight returned
+// by the contrib add path must equal the LIVE sum (what snapshot()/GetEdge
+// reports), even when expired entries sit below the amortized compaction floor
+// and no structural flush has fired. It also guards the perf intent of the
+// 4f5d67f amortized trigger: a live-dominated run must not flush.
+func Test_weight_effectiveExcludesExpired(t *testing.T) {
+	base := time.Now()
+
+	t.Run("expired below the compaction floor are excluded", func(t *testing.T) {
+		w := newWeight()
+		shortExp := base.Add(50 * time.Millisecond)
+		for i := 0; i < 50; i++ { // 50 < weightCompactMin(64): the 2x trigger never fires
+			if applied, _ := w.addWithExpirationContribAt(1, shortExp, ContribID{}, base); !applied {
+				t.Fatalf("add %d not applied", i)
+			}
+		}
+		now2 := base.Add(time.Second) // all 50 are now expired, none flushed
+		_, effective := w.addWithExpirationContribAt(1, now2.Add(time.Hour), ContribID{}, now2)
+		if effective != 1 {
+			t.Fatalf("effective = %v, want 1 — must exclude the 50 expired contributions (unfixed code returns 51)", effective)
+		}
+		sum, _, _ := w.snapshot()
+		if sum != effective {
+			t.Fatalf("snapshot sum %v != add-path effective %v — write and read paths must agree", sum, effective)
+		}
+	})
+
+	t.Run("ContribID dedup no-op also reports the live sum", func(t *testing.T) {
+		w := newWeight()
+		id := ContribID{0: 7}
+		w.addWithExpirationContribAt(2, base.Add(time.Hour), id, base)                    // live, deduplicable
+		w.addWithExpirationContribAt(5, base.Add(50*time.Millisecond), ContribID{}, base) // will expire
+		now2 := base.Add(time.Second)
+		applied, effective := w.addWithExpirationContribAt(2, now2.Add(time.Hour), id, now2) // replay
+		if applied {
+			t.Fatal("replay of a live ContribID must dedup")
+		}
+		if effective != 2 {
+			t.Fatalf("dedup effective = %v, want 2 (unfixed code returns 7: 2 live + 5 expired-unflushed)", effective)
+		}
+	})
+
+	t.Run("permanent contributions are never flushed away", func(t *testing.T) {
+		w := newWeight()
+		w.addWithExpirationContribAt(3, time.Time{}, ContribID{}, base) // zero expiration = permanent
+		_, effective := w.addWithExpirationContribAt(1, base.Add(time.Hour), ContribID{}, base.Add(time.Minute))
+		if effective != 4 {
+			t.Fatalf("effective = %v, want 4 (permanent entry must survive the minExp reconcile)", effective)
+		}
+	})
+
+	t.Run("all-live adds below the trigger do not flush", func(t *testing.T) {
+		w := newWeight()
+		exp := base.Add(time.Hour)
+		for i := 0; i < 60; i++ { // 60 < weightCompactMin(64)
+			w.addWithExpirationContribAt(1, exp, ContribID{}, base)
+		}
+		w.mu.Lock()
+		n, flushed := len(w.values), w.lastFlushLen
+		w.mu.Unlock()
+		if n != 60 || flushed != 0 {
+			t.Fatalf("values=%d lastFlushLen=%d — live-dominated adds must stay O(1), no flush (minExp trigger must not fire when nothing expired)", n, flushed)
+		}
+	})
+}


### PR DESCRIPTION
Part of epic #924 (post-merge hardening of #915), Wave 1.

## Problem

`weight.addWithExpirationContribAt` returned `w.sum` after appending, but
expired entries were only reconciled on the amortized `2×`-growth trigger
(`n > weightCompactMin(64) && n > 2*lastFlushLen`). For the short-TTL
rolling-window counter the proto doc advertises, the trigger never fires,
so `AddEdge(s)WithExpirationContrib(HLC)` returned an `effective_weight`
that still included long-expired contributions — disagreeing with an
immediately-following `GetEdge` on the same edge (a rate-limit client
over-rejects valid traffic).

## Fix

Track `minExp` (earliest expiration among *expiring* contributions) on the
`weight` struct and reconcile the cached sum at the top of
`addWithExpirationContribAt`, but only when `now` has reached `minExp`:

- Live-dominated hot path (nothing expired): a single compare, no flush → O(1), preserving the 4f5d67f perf intent.
- Short-TTL path: a bounded flush exactly when staleness exists.

Both return paths — the applied path and the ContribID-dedup no-op — are
now exact. Permanent contributions (zero / `≤epoch` expiration) are excluded
from `minExp` so they never trip it. `minExp` is recomputed over survivors in
`flushLockedAt` and reset on `replace` / `putWithExpirationHLC`.

Also collapses the duplicated `addWithExpirationContrib` body into a thin
facade over the `*At` form so the fix lands once.

No wire/proto change.

## Tests

- `edge_test.go` `Test_weight_effectiveExcludesExpired`: expired-below-floor exclusion, dedup no-op live sum, permanent survivors, and a hot-path guard (all-live adds below the trigger do not flush).
- `batch_external_test.go` `TestAddEdgesWithExpirationContrib_Dedup`: effective agrees with `GetWeight` after contributions expire.

Gate: `gofmt -l` clean; core / server / root `go test ./...` green.

Closes #917