### PR TITLE
test(sdks,server): golden-vector tests pinning the 24-byte contrib-ID layout across Go/Node/server

### DIFF
--- a/core/graphcache/batch.go
+++ b/core/graphcache/batch.go
@@ -63,11 +63,12 @@ func (c *GraphCache[S, T]) PutVerticesWithExpiration(items []VertexItem[S, T]) {
 // PutVerticesWithExpirationIfAbsent writes each vertex only when no live vertex
 // exists at its key (SET NX semantics, #896). It returns the number of vertices
 // actually written and, in request order, the keys skipped because a live
-// vertex already existed. Liveness follows the live-visibility rule (#750): an
-// expired-but-uncollected vertex does not block its write. The whole batch
-// commits under a single write lock, so the existence check and store are
-// atomic per key; within one batch a key's first accepted write makes it live,
-// so a later duplicate of that key is reported as skipped.
+// vertex already existed. A vertex whose expiration is already past is discarded
+// and counted as neither written nor skipped (#918). Liveness follows the
+// live-visibility rule (#750): an expired-but-uncollected vertex does not block
+// its write. The whole batch commits under a single write lock, so the existence
+// check and store are atomic per key; within one batch a key's first accepted
+// write makes it live, so a later duplicate of that key is reported as skipped.
 func (c *GraphCache[S, T]) PutVerticesWithExpirationIfAbsent(items []VertexItem[S, T]) (written int, skipped []S) {
 	if len(items) == 0 {
 		return 0, nil
@@ -81,8 +82,9 @@ func (c *GraphCache[S, T]) PutVerticesWithExpirationIfAbsent(items []VertexItem[
 			skipped = append(skipped, items[i].Key)
 			continue
 		}
-		c.putLocalVertexLockedAt(items[i].Key, items[i].Value, items[i].Expiration, now, preparedAt(prepared, i))
-		written++
+		if c.putLocalVertexLockedAt(items[i].Key, items[i].Value, items[i].Expiration, now, preparedAt(prepared, i)) {
+			written++
+		}
 	}
 	return written, skipped
 }
@@ -309,13 +311,14 @@ func (c *GraphCache[S, T]) PutVerticesWithExpirationHLC(items []VertexItem[S, T]
 // forbidden by the causal fence (a strictly newer delete/put watermark) is
 // reported as skipped rather than resurrected.
 //
-// It returns the indices of items that passed the absence check (in request
-// order) so the caller can both count them and replicate only that live subset
-// as an unconditional LWW put, and the keys skipped because a live vertex
-// already existed. Two concurrent if-absent writers on different nodes can both
-// report their write as accepted locally; the replicated unconditional puts
-// then converge via higher-HLC-wins (documented best-effort, like Redis SETNX
-// with async replicas).
+// It returns the indices of items that passed the absence check AND were
+// actually stored (in request order) so the caller can both count them and
+// replicate only that live subset as an unconditional LWW put, and the keys
+// skipped because a live vertex already existed. A born-expired item is
+// discarded and appears in neither slice (#918). Two concurrent if-absent
+// writers on different nodes can both report their write as accepted locally;
+// the replicated unconditional puts then converge via higher-HLC-wins
+// (documented best-effort, like Redis SETNX with async replicas).
 func (c *GraphCache[S, T]) PutVerticesWithExpirationIfAbsentHLC(items []VertexItem[S, T], ts hlc.Timestamp) (writtenIdx []int, skipped []S) {
 	if len(items) == 0 {
 		return nil, nil
@@ -334,7 +337,13 @@ func (c *GraphCache[S, T]) PutVerticesWithExpirationIfAbsentHLC(items []VertexIt
 			skipped = append(skipped, it.Key)
 			continue
 		}
-		c.putLocalVertexLockedAt(it.Key, it.Value, it.Expiration, now, preparedAt(prepared, i))
+		if !c.putLocalVertexLockedAt(it.Key, it.Value, it.Expiration, now, preparedAt(prepared, i)) {
+			// Born expired: nothing stored, so it is neither written nor
+			// skipped. Deliberately do NOT stamp an HLC watermark or clear a
+			// tombstone for a non-write — that would fence later valid writes
+			// to this key behind a watermark for a value that never existed.
+			continue
+		}
 		c.recordVertexHLCLocked(it.Key, ts)
 		c.clearVertexTombstoneLocked(it.Key)
 		writtenIdx = append(writtenIdx, i)
@@ -387,9 +396,10 @@ func (c *GraphCache[S, T]) PutEdgesWithExpirationHLC(items []EdgeItem[S], ts hlc
 // a matching live ContribID are deduped as in the non-HLC variant. Returns,
 // index-aligned with items, the post-apply LIVE weight sum for each edge
 // (#897) plus the number of items that added no weight (tombstone-dropped or
-// ContribID-deduped). A tombstone-dropped item applied nothing, so its
-// effective entry is left at 0 rather than paying an extra read for its live
-// sum; ContribID-deduped items still report the current live sum.
+// ContribID-deduped). A tombstone-dropped item applied nothing, but its
+// effective entry still reports the edge's current live sum — matching the
+// ContribID-deduped path — so a genuinely nonzero live weight (e.g. from a
+// newer contribution that re-created the edge) is never misreported as 0 (#918).
 func (c *GraphCache[S, T]) AddEdgesWithExpirationContribHLC(items []EdgeItem[S], ts hlc.Timestamp) (effective []float32, deduped int) {
 	if len(items) == 0 {
 		return nil, 0
@@ -400,6 +410,10 @@ func (c *GraphCache[S, T]) AddEdgesWithExpirationContribHLC(items []EdgeItem[S],
 	defer c.mu.Unlock()
 	for i, it := range items {
 		if !c.edgeWriteAllowedLocked(it.Tail, it.Head, ts) {
+			// Fenced by a newer tombstone: this item applies nothing, but the
+			// edge may still hold live weight from another contribution. Report
+			// that real live sum, the same value the dedup no-op path returns.
+			effective[i] = c.edges.liveSumAt(it.Tail, it.Head, now)
 			deduped++
 			continue
 		}

--- a/core/graphcache/batch_external_test.go
+++ b/core/graphcache/batch_external_test.go
@@ -374,6 +374,33 @@ func TestAddEdgesWithExpirationContrib_Dedup(t *testing.T) {
 			t.Fatalf("facade weight = %v, want 6 (AddEdgesWithExpiration stays additive)", w)
 		}
 	})
+
+	// #917: the effective weight returned by the add path must agree with the
+	// read path once contributions expire below the compaction floor. Guards
+	// the wiring up to AddEdgesWithExpirationContrib, not just the weight unit.
+	t.Run("effective agrees with GetWeight after contributions expire", func(t *testing.T) {
+		c := graphcache.NewGraphCache[string, int](time.Minute)
+		shortExp := time.Now().Add(40 * time.Millisecond)
+		for i := 0; i < 50; i++ { // below the compaction floor: no structural flush
+			c.AddEdgesWithExpirationContrib([]graphcache.EdgeItem[string]{
+				{Tail: "s", Head: "h", Weight: 1, Expiration: shortExp},
+			})
+		}
+		time.Sleep(60 * time.Millisecond) // let them expire
+		effective, _ := c.AddEdgesWithExpirationContrib([]graphcache.EdgeItem[string]{
+			{Tail: "s", Head: "h", Weight: 1, Expiration: time.Now().Add(time.Hour)},
+		})
+		w, ok := c.GetWeight("s", "h")
+		if !ok {
+			t.Fatal("edge missing")
+		}
+		if len(effective) != 1 || effective[0] != w {
+			t.Fatalf("AddEdges effective = %v but GetWeight = %v — #917: the add path leaked expired weight", effective, w)
+		}
+		if effective[0] != 1 {
+			t.Fatalf("effective = %v, want 1 (unfixed code reports 51)", effective[0])
+		}
+	})
 }
 
 // itoa avoids pulling in strconv just to label test keys.

--- a/core/graphcache/batch_external_test.go
+++ b/core/graphcache/batch_external_test.go
@@ -578,13 +578,39 @@ func TestAddEdgesWithExpirationContribHLC_TombstoneFenced(t *testing.T) {
 		if deduped != 1 {
 			t.Errorf("deduped: got %d, want 1 (tombstone-dropped)", deduped)
 		}
-		// A tombstone-dropped item applied nothing, so its effective entry is
-		// left at 0 (#897).
+		// A tombstone-dropped item applied nothing; its effective entry reports
+		// the current live sum, which is 0 here because the edge is deleted (#918).
 		if len(effective) != 1 || effective[0] != 0 {
 			t.Errorf("effective: got %v, want [0] (tombstone-dropped adds nothing)", effective)
 		}
 		if _, ok := c.GetWeight("a", "b"); ok {
 			t.Errorf("older contribution resurrected a tombstoned edge")
+		}
+	})
+
+	t.Run("FencedItemReportsCurrentLiveSum", func(t *testing.T) {
+		c := graphcache.NewGraphCache[string, string](time.Minute)
+		// Record a newer tombstone, then rebuild live weight via the non-HLC
+		// contrib path (which does not consult the tombstone fence).
+		if n := c.DeleteEdgesHLC([]graphcache.EdgeKey[string]{{Tail: "a", Head: "b"}}, newer, exp); n != 0 {
+			t.Fatalf("delete of absent edge: got %d, want 0", n)
+		}
+		c.AddEdgesWithExpirationContrib([]graphcache.EdgeItem[string]{
+			{Tail: "a", Head: "b", Weight: 5.0, Expiration: exp, ContribID: graphcache.ContribID{0: 1}},
+		})
+		// An older HLC contribution is fenced by the tombstone: it adds nothing,
+		// but its effective entry must report the current live sum (5), not 0 (#918).
+		effective, deduped := c.AddEdgesWithExpirationContribHLC([]graphcache.EdgeItem[string]{
+			{Tail: "a", Head: "b", Weight: 7.0, Expiration: exp, ContribID: graphcache.ContribID{0: 2}},
+		}, older)
+		if deduped != 1 {
+			t.Errorf("deduped: got %d, want 1 (tombstone-fenced)", deduped)
+		}
+		if len(effective) != 1 || effective[0] != 5.0 {
+			t.Errorf("effective: got %v, want [5] (fenced item reports current live sum)", effective)
+		}
+		if got, ok := c.GetWeight("a", "b"); !ok || got != 5.0 {
+			t.Errorf("a->b weight: got (%v,%v), want (5.0,true) — fenced contribution must not add", got, ok)
 		}
 	})
 
@@ -682,6 +708,26 @@ func TestPutVerticesWithExpirationIfAbsent(t *testing.T) {
 			t.Fatalf("value = %q, want \"fresh\"", v)
 		}
 	})
+
+	t.Run("BornExpiredNeitherWrittenNorSkipped", func(t *testing.T) {
+		c := graphcache.NewGraphCache[string, string](time.Minute)
+		written, skipped := c.PutVerticesWithExpirationIfAbsent([]graphcache.VertexItem[string, string]{
+			{Key: "dead", Value: "x", Expiration: past}, // discarded: born expired
+			{Key: "fresh", Value: "y", Expiration: future},
+		})
+		if written != 1 {
+			t.Fatalf("written = %d, want 1 (born-expired must not count)", written)
+		}
+		if len(skipped) != 0 {
+			t.Fatalf("skipped = %v, want [] (born-expired is discarded, not skipped)", skipped)
+		}
+		if _, ok := c.GetVertex("dead"); ok {
+			t.Fatal("born-expired vertex was stored, want miss")
+		}
+		if v, ok := c.GetVertex("fresh"); !ok || v != "y" {
+			t.Fatalf("fresh = (%q,%v), want (\"y\",true)", v, ok)
+		}
+	})
 }
 
 // TestPutVerticesWithExpirationIfAbsentHLC pins the replication-aware SET NX
@@ -730,6 +776,24 @@ func TestPutVerticesWithExpirationIfAbsentHLC(t *testing.T) {
 		}
 		if _, ok := c.GetVertex("d"); ok {
 			t.Fatal("older if-absent put resurrected a tombstoned key")
+		}
+	})
+
+	t.Run("BornExpiredExcludedFromWrittenIdx", func(t *testing.T) {
+		c := graphcache.NewGraphCache[string, string](time.Minute)
+		past := time.Now().Add(-time.Hour)
+		writtenIdx, skipped := c.PutVerticesWithExpirationIfAbsentHLC([]graphcache.VertexItem[string, string]{
+			{Key: "dead", Value: "x", Expiration: past}, // idx 0: discarded (born expired)
+			{Key: "fresh", Value: "y", Expiration: exp}, // idx 1: written
+		}, newer)
+		if len(writtenIdx) != 1 || writtenIdx[0] != 1 {
+			t.Fatalf("writtenIdx = %v, want [1] (born-expired must be excluded)", writtenIdx)
+		}
+		if len(skipped) != 0 {
+			t.Fatalf("skipped = %v, want [] (born-expired is discarded, not skipped)", skipped)
+		}
+		if _, ok := c.GetVertex("dead"); ok {
+			t.Fatal("born-expired vertex was stored, want miss")
 		}
 	})
 }

--- a/core/graphcache/cache.go
+++ b/core/graphcache/cache.go
@@ -217,8 +217,8 @@ func (c *GraphCache[S, T]) upsertVertexLocked(key S, value T, expiration time.Ti
 // route through here: it must preserve LWW/HLC/tombstone causality and records
 // a per-key watermark after the store, so it keeps calling putVertexLocked
 // directly. Caller must hold c.mu.
-func (c *GraphCache[S, T]) putLocalVertexLocked(key S, value T, expiration time.Time) {
-	c.putLocalVertexLockedAt(key, value, expiration, time.Now(), nil)
+func (c *GraphCache[S, T]) putLocalVertexLocked(key S, value T, expiration time.Time) bool {
+	return c.putLocalVertexLockedAt(key, value, expiration, time.Now(), nil)
 }
 
 // putLocalVertexLockedAt is putLocalVertexLocked with the liveness clock and an
@@ -227,16 +227,23 @@ func (c *GraphCache[S, T]) putLocalVertexLocked(key S, value T, expiration time.
 // document outside c.mu (see prepareSearchDocs), then calls this per item so the
 // only work under c.mu is the cheap store + postings mutation. A nil prepared
 // falls back to inline analysis. Caller must hold c.mu (#739).
-func (c *GraphCache[S, T]) putLocalVertexLockedAt(key S, value T, expiration, now time.Time, prepared *search.PreparedDocument) {
+//
+// It returns stored=false when the write was discarded because its expiration
+// was already past (dead on arrival), and true when the value was upserted.
+// The if-absent write paths use this to count only writes that actually landed
+// so a born-expired item is reported as neither written nor skipped (#918);
+// unconditional callers may ignore the return.
+func (c *GraphCache[S, T]) putLocalVertexLockedAt(key S, value T, expiration, now time.Time, prepared *search.PreparedDocument) (stored bool) {
 	if !cache.IsLiveAt(expiration, now) {
 		// Dead on arrival. Delete is a cheap map-miss when the key is absent
 		// (the common churn case) and fires the eviction hook — releasing the
 		// dictionary reference and dropping prefix/search postings — when it is
 		// present, so an overwrite-to-expired still takes effect.
 		c.vertices.Delete(key)
-		return
+		return false
 	}
 	c.upsertVertexLocked(key, value, expiration, prepared)
+	return true
 }
 
 // ensureVertexLocked auto-creates an endpoint vertex (used by edge writes)
@@ -330,11 +337,12 @@ func (c *GraphCache[S, T]) PutVertexWithExpiration(key S, value T, expiration ti
 
 // PutVertexWithExpirationIfAbsent writes the vertex only when no live vertex
 // exists at key (SET NX, #896). It returns true when the write was applied and
-// false when an existing live vertex caused it to be skipped, in which case the
-// stored value and expiration are left untouched. Liveness follows the
-// live-visibility rule (#750): an expired-but-uncollected vertex does not block
-// the write. The existence check and the store happen under the same write lock,
-// so two racing if-absent writers cannot both observe "absent" and both write.
+// false when it was skipped — either because an existing live vertex blocked it
+// (the stored value and expiration are left untouched) or because the vertex was
+// born expired and discarded (#918). Liveness follows the live-visibility rule
+// (#750): an expired-but-uncollected vertex does not block the write. The
+// existence check and the store happen under the same write lock, so two racing
+// if-absent writers cannot both observe "absent" and both write.
 func (c *GraphCache[S, T]) PutVertexWithExpirationIfAbsent(key S, value T, expiration time.Time) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -342,8 +350,7 @@ func (c *GraphCache[S, T]) PutVertexWithExpirationIfAbsent(key S, value T, expir
 	if c.vertices.Has(key) {
 		return false
 	}
-	c.putLocalVertexLocked(key, value, expiration)
-	return true
+	return c.putLocalVertexLocked(key, value, expiration)
 }
 
 func (c *GraphCache[S, T]) PutVertexWithTTL(key S, value T, ttl time.Duration) {

--- a/core/graphcache/cache_test.go
+++ b/core/graphcache/cache_test.go
@@ -473,6 +473,18 @@ func TestGraphCache_PutVertexWithExpirationIfAbsent(t *testing.T) {
 			t.Fatalf("value = %q, want \"fresh\" (expired vertex must not block)", v)
 		}
 	})
+
+	t.Run("BornExpiredReportsNotWritten", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		// An absent key with an already-past expiration is discarded on arrival:
+		// nothing is stored, so the accepted flag must be false (#918).
+		if got := c.PutVertexWithExpirationIfAbsent("k", "dead", past); got {
+			t.Fatal("PutVertexWithExpirationIfAbsent = true for a born-expired vertex, want false")
+		}
+		if _, ok := c.GetVertex("k"); ok {
+			t.Fatal("born-expired vertex was stored, want miss")
+		}
+	})
 }
 
 func TestGraphCache_PutVertexWithTTL(t *testing.T) {

--- a/core/graphcache/edge.go
+++ b/core/graphcache/edge.go
@@ -369,6 +369,32 @@ func (c *edgeCache[S]) get(tail, head S) (float32, bool) {
 	return v, ok
 }
 
+// liveSumAt returns the current live weight sum for (tail, head) at now, or 0
+// when the edge is absent. Unlike get/getDetail it does not gate on endpoint
+// liveness or the nonZero flag — it reports exactly what the weight bucket
+// holds, matching the sum the ContribID-dedup no-op path returns. Intended for
+// callers already holding GraphCache.mu (the locked write path): it resolves
+// ids without pinning (safe under the aggregate lock, where tf/dict are
+// stable) and reads the weight under its own mutex, the same nesting the
+// locked add path uses (#918).
+func (c *edgeCache[S]) liveSumAt(tail, head S, now time.Time) float32 {
+	tailID, headID, ok := c.lookupIDs(tail, head)
+	if !ok {
+		return 0
+	}
+	c.mu.RLock()
+	var w *weight
+	if heads, ok := c.tf[tailID]; ok {
+		w = heads[headID]
+	}
+	c.mu.RUnlock()
+	if w == nil {
+		return 0
+	}
+	sum, _, _ := w.snapshotAt(now)
+	return sum
+}
+
 // getDetail returns the current weight and the latest contribution
 // expiration, so callers can surface the edge's effective deadline.
 //

--- a/core/graphcache/edge.go
+++ b/core/graphcache/edge.go
@@ -32,11 +32,31 @@ type weight struct {
 	// ~2× the working set even on write-only hot edges that no reader
 	// touches between GC ticks, while keeping the amortized add cost O(1).
 	lastFlushLen int
+	// minExp is the earliest expiration among the *expiring* contributions
+	// currently in values (permanent contributions — zero or ≤epoch
+	// expiration, which cache.IsLiveAt treats as never-expiring — are
+	// excluded). The zero value means "nothing here can expire". It gates
+	// the reconcile-at-read in addWithExpirationContribAt (#917): the moment
+	// now reaches minExp at least one contribution has decayed, so the
+	// cached sum must be flushed before it is returned as effective. When
+	// now is still before minExp, sum is already exact and the read stays
+	// O(1). The invariant that keeps this correct is minExp must never be
+	// *later* than the true earliest expiration: stale-early costs one
+	// wasted flush, stale-late would leak expired weight back into the sum.
+	minExp time.Time
 	// lastHLC is the most recent HLC timestamp accepted by a Put-style
 	// (LWW) write. Zero value means "no LWW write has happened yet" — in
 	// that case the next Put-with-HLC always wins. Used only by the
 	// replication apply path; local writers do not touch it.
 	lastHLC hlc.Timestamp
+}
+
+// expires reports whether an expiration can actually decay (i.e. it is a real
+// positive deadline). It mirrors the "no expiration" sentinels honored by
+// cache.IsLiveAt — Go zero time and any instant at or before the Unix epoch
+// are permanent and never contribute to minExp.
+func expires(expiration time.Time) bool {
+	return !expiration.IsZero() && expiration.Unix() > 0
 }
 
 // weightCompactMin is the floor under the 2× growth trigger. Below this we
@@ -46,6 +66,18 @@ const weightCompactMin = 64
 
 func newWeight() *weight {
 	return &weight{}
+}
+
+// noteExpirationLocked folds a newly-appended contribution's expiration into
+// minExp. Caller must hold w.mu. Permanent contributions are ignored so they
+// never trip the reconcile-at-read trigger.
+func (w *weight) noteExpirationLocked(expiration time.Time) {
+	if !expires(expiration) {
+		return
+	}
+	if w.minExp.IsZero() || expiration.Before(w.minExp) {
+		w.minExp = expiration
+	}
 }
 
 func (w *weight) value() float32 {
@@ -82,34 +114,12 @@ func (w *weight) addWithExpiration(value float32, expiration time.Time) {
 // needs when a peer re-delivers a mutation. A zero contribID disables
 // dedup and behaves exactly like addWithExpiration; this is the local
 // (non-replicated) write path.
+//
+// It is a thin facade over addWithExpirationContribAt with now = time.Now();
+// the two must not drift, so the whole body lives in the *At form (#917).
 func (w *weight) addWithExpirationContrib(value float32, expiration time.Time, contribID ContribID) bool {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	if !contribID.IsZero() {
-		now := time.Now()
-		for _, v := range w.values {
-			if v.contribID == contribID && cache.IsLiveAt(v.expiration, now) {
-				return false
-			}
-		}
-	}
-	w.values = append(w.values, weightValue{
-		value:      value,
-		expiration: expiration,
-		contribID:  contribID,
-	})
-	w.sum += value
-
-	// Amortized compaction: a write-only hot edge that no reader visits
-	// between GC ticks would otherwise grow without bound, and the eventual
-	// flush (on read or on GC) would be O(N) over a giant slice. Trigger
-	// compaction once the slice has doubled past its last post-flush size,
-	// with a small floor so we skip the work on tiny edges. Cost stays O(1)
-	// amortized; worst-case write latency variance rises but is bounded.
-	if n := len(w.values); n > weightCompactMin && n > 2*w.lastFlushLen {
-		w.flushLocked()
-	}
-	return true
+	applied, _ := w.addWithExpirationContribAt(value, expiration, contribID, time.Now())
+	return applied
 }
 
 // addWithExpirationContribAt is addWithExpirationContrib with a caller-supplied
@@ -118,16 +128,26 @@ func (w *weight) addWithExpirationContrib(value float32, expiration time.Time, c
 // race-free increment-then-check counter. It uses the SAME amortized-compaction
 // trigger as addWithExpirationContrib so the hot add path stays O(1) amortized:
 // force-flushing on every call would make a write-only hot edge O(N) per add and
-// O(N²) overall (regressing #743's fast path). The returned `effective` is the
-// running sum after the append; the amortized flush bounds how long expired-but-
-// unflushed contributions linger in it, and it reconciles to the exact live sum
-// on the next flush (on the compaction trigger, on a value() read, or on GC). In
-// the increment-then-check counter use-case the edge is live-dominated, so the
-// returned sum equals the true rolling-window value. On a contrib_id dedup no-op
-// it returns applied=false and the current running sum.
+// O(N²) overall (regressing #743's fast path).
+//
+// The returned `effective` is always the exact live sum (#917). Before reading
+// sum back, the method reconciles expired-but-unflushed contributions, but only
+// when minExp shows something has actually decayed — so the live-dominated hot
+// path (nothing expired) still returns in O(1) with no flush, while the
+// short-TTL rolling-window counter no longer reports a sum inflated by expired
+// contributions lingering below the compaction floor. Both return paths are
+// exact: the applied path (`true, w.sum`) and the ContribID-dedup no-op path
+// (`false, w.sum`).
 func (w *weight) addWithExpirationContribAt(value float32, expiration time.Time, contribID ContribID, now time.Time) (applied bool, effective float32) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	// Reconcile before we read sum back: once now reaches the earliest
+	// expiration, at least one contribution has decayed and sum is stale.
+	// This is a single compare when nothing has expired (minExp in the
+	// future or absent), and a bounded flush exactly when staleness exists.
+	if !w.minExp.IsZero() && !now.Before(w.minExp) {
+		w.flushLockedAt(now)
+	}
 	if !contribID.IsZero() {
 		for _, v := range w.values {
 			if v.contribID == contribID && cache.IsLiveAt(v.expiration, now) {
@@ -141,6 +161,7 @@ func (w *weight) addWithExpirationContribAt(value float32, expiration time.Time,
 		contribID:  contribID,
 	})
 	w.sum += value
+	w.noteExpirationLocked(expiration)
 	if n := len(w.values); n > weightCompactMin && n > 2*w.lastFlushLen {
 		w.flushLockedAt(now)
 	}
@@ -171,6 +192,8 @@ func (w *weight) putWithExpirationHLC(value float32, expiration time.Time, ts hl
 	w.values = append(w.values, weightValue{value: value, expiration: expiration})
 	w.sum = value
 	w.lastFlushLen = 1
+	w.minExp = time.Time{}
+	w.noteExpirationLocked(expiration)
 	w.lastHLC = ts
 	return true
 }
@@ -200,6 +223,8 @@ func (w *weight) replace(value float32, expiration time.Time) {
 	w.values = append(w.values, weightValue{value: value, expiration: expiration})
 	w.sum = value
 	w.lastFlushLen = 1
+	w.minExp = time.Time{}
+	w.noteExpirationLocked(expiration)
 	w.lastHLC = hlc.Timestamp{}
 }
 
@@ -264,20 +289,26 @@ func (w *weight) flushLocked() {
 }
 
 // flushLockedAt is flushLocked against a caller-supplied instant (#838).
-// Caller must hold w.mu.
+// Caller must hold w.mu. It also recomputes minExp over the survivors so the
+// reconcile-at-read trigger (#917) tracks the new earliest expiration.
 func (w *weight) flushLockedAt(now time.Time) {
 	write := 0
 	var sum float32
+	var minExp time.Time
 	for _, v := range w.values {
 		if cache.IsLiveAt(v.expiration, now) {
 			w.values[write] = v
 			write++
 			sum += v.value
+			if expires(v.expiration) && (minExp.IsZero() || v.expiration.Before(minExp)) {
+				minExp = v.expiration
+			}
 		}
 	}
 	w.values = w.values[:write]
 	w.sum = sum
 	w.lastFlushLen = write
+	w.minExp = minExp
 }
 
 // edgeCache stores directed weighted edges using compact vertexID keys

--- a/core/graphcache/edge_test.go
+++ b/core/graphcache/edge_test.go
@@ -716,3 +716,69 @@ func Test_edgeCache_edgeCount(t *testing.T) {
 		check(t, c, 1)
 	})
 }
+
+// Test_weight_effectiveExcludesExpired pins #917: the effective weight returned
+// by the contrib add path must equal the LIVE sum (what snapshot()/GetEdge
+// reports), even when expired entries sit below the amortized compaction floor
+// and no structural flush has fired. It also guards the perf intent of the
+// 4f5d67f amortized trigger: a live-dominated run must not flush.
+func Test_weight_effectiveExcludesExpired(t *testing.T) {
+	base := time.Now()
+
+	t.Run("expired below the compaction floor are excluded", func(t *testing.T) {
+		w := newWeight()
+		shortExp := base.Add(50 * time.Millisecond)
+		for i := 0; i < 50; i++ { // 50 < weightCompactMin(64): the 2x trigger never fires
+			if applied, _ := w.addWithExpirationContribAt(1, shortExp, ContribID{}, base); !applied {
+				t.Fatalf("add %d not applied", i)
+			}
+		}
+		now2 := base.Add(time.Second) // all 50 are now expired, none flushed
+		_, effective := w.addWithExpirationContribAt(1, now2.Add(time.Hour), ContribID{}, now2)
+		if effective != 1 {
+			t.Fatalf("effective = %v, want 1 — must exclude the 50 expired contributions (unfixed code returns 51)", effective)
+		}
+		sum, _, _ := w.snapshot()
+		if sum != effective {
+			t.Fatalf("snapshot sum %v != add-path effective %v — write and read paths must agree", sum, effective)
+		}
+	})
+
+	t.Run("ContribID dedup no-op also reports the live sum", func(t *testing.T) {
+		w := newWeight()
+		id := ContribID{0: 7}
+		w.addWithExpirationContribAt(2, base.Add(time.Hour), id, base)                    // live, deduplicable
+		w.addWithExpirationContribAt(5, base.Add(50*time.Millisecond), ContribID{}, base) // will expire
+		now2 := base.Add(time.Second)
+		applied, effective := w.addWithExpirationContribAt(2, now2.Add(time.Hour), id, now2) // replay
+		if applied {
+			t.Fatal("replay of a live ContribID must dedup")
+		}
+		if effective != 2 {
+			t.Fatalf("dedup effective = %v, want 2 (unfixed code returns 7: 2 live + 5 expired-unflushed)", effective)
+		}
+	})
+
+	t.Run("permanent contributions are never flushed away", func(t *testing.T) {
+		w := newWeight()
+		w.addWithExpirationContribAt(3, time.Time{}, ContribID{}, base) // zero expiration = permanent
+		_, effective := w.addWithExpirationContribAt(1, base.Add(time.Hour), ContribID{}, base.Add(time.Minute))
+		if effective != 4 {
+			t.Fatalf("effective = %v, want 4 (permanent entry must survive the minExp reconcile)", effective)
+		}
+	})
+
+	t.Run("all-live adds below the trigger do not flush", func(t *testing.T) {
+		w := newWeight()
+		exp := base.Add(time.Hour)
+		for i := 0; i < 60; i++ { // 60 < weightCompactMin(64)
+			w.addWithExpirationContribAt(1, exp, ContribID{}, base)
+		}
+		w.mu.Lock()
+		n, flushed := len(w.values), w.lastFlushLen
+		w.mu.Unlock()
+		if n != 60 || flushed != 0 {
+			t.Fatalf("values=%d lastFlushLen=%d — live-dominated adds must stay O(1), no flush (minExp trigger must not fire when nothing expired)", n, flushed)
+		}
+	})
+}

--- a/pb/graph/v1/graph.pb.go
+++ b/pb/graph/v1/graph.pb.go
@@ -3583,6 +3583,19 @@ type AddEdgesRequest struct {
 	// shorter list, a missing entry, or an empty/zero value leaves the
 	// corresponding edge on the legacy non-idempotent additive path. Each id is
 	// opaque to the server.
+	//
+	// Canonical 24-byte layout (the one spec; drift breaks cross-SDK dedup):
+	//
+	//	bytes [0:16] = client nonce / origin NodeID
+	//	bytes [16:24] = big-endian uint64 (seq<<16)|idx
+	//
+	// where seq is a per-client/per-mutation monotonic counter and idx is the
+	// edge's position within its batch (folding idx into the low 16 bits lets
+	// one batch carry up to 65 536 distinct ids under a single seq). Three
+	// hand-written encoders must stay byte-identical: sdks/go/client.go
+	// nextContribIDs, sdks/node/src/contrib.ts contribIdFrom, and
+	// server/service/apply.go contribIDFor. Golden-vector tests in all three
+	// suites (#922) fail CI on any unilateral change.
 	ContribIds    [][]byte `protobuf:"bytes,2,rep,name=contrib_ids,json=contribIds,proto3" json:"contrib_ids,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/pb/graph/v1/graph.pb.go
+++ b/pb/graph/v1/graph.pb.go
@@ -1509,8 +1509,10 @@ func (x *PutVertexRequest) GetIfAbsent() bool {
 
 type PutVertexResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the write was applied; false when if_absent skipped it because
-	// a live vertex already existed. Always true for an unconditional put.
+	// True when the write was applied; false when it was skipped — either
+	// because if_absent found a live vertex already at the key, or because the
+	// vertex was born expired (expiration already past) and discarded. Always
+	// true for an unconditional put with a live expiration.
 	Written       bool `protobuf:"varint,1,opt,name=written,proto3" json:"written,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1614,9 +1616,12 @@ func (x *PutVerticesRequest) GetIfAbsent() bool {
 type PutVerticesResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Number of vertices actually written. For an unconditional put this equals
-	// the request size on success; under if_absent it excludes skipped keys.
+	// the request size on success; under if_absent it excludes skipped keys. A
+	// vertex whose expiration is already past is discarded and counts as neither
+	// written nor skipped (it appears in neither this count nor skipped_keys).
 	Written int32 `protobuf:"varint,1,opt,name=written,proto3" json:"written,omitempty"`
-	// Keys skipped because a live vertex already existed (if_absent only).
+	// Keys skipped because a live vertex already existed (if_absent only). A
+	// born-expired vertex is NOT reported here — it is silently discarded.
 	SkippedKeys   []string `protobuf:"bytes,2,rep,name=skipped_keys,json=skippedKeys,proto3" json:"skipped_keys,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -673,6 +673,17 @@ message AddEdgesRequest {
   // shorter list, a missing entry, or an empty/zero value leaves the
   // corresponding edge on the legacy non-idempotent additive path. Each id is
   // opaque to the server.
+  //
+  // Canonical 24-byte layout (the one spec; drift breaks cross-SDK dedup):
+  //   bytes [0:16] = client nonce / origin NodeID
+  //   bytes [16:24] = big-endian uint64 (seq<<16)|idx
+  // where seq is a per-client/per-mutation monotonic counter and idx is the
+  // edge's position within its batch (folding idx into the low 16 bits lets
+  // one batch carry up to 65 536 distinct ids under a single seq). Three
+  // hand-written encoders must stay byte-identical: sdks/go/client.go
+  // nextContribIDs, sdks/node/src/contrib.ts contribIdFrom, and
+  // server/service/apply.go contribIDFor. Golden-vector tests in all three
+  // suites (#922) fail CI on any unilateral change.
   repeated bytes contrib_ids = 2;
 }
 

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -234,8 +234,10 @@ message PutVertexRequest {
 }
 
 message PutVertexResponse {
-  // True when the write was applied; false when if_absent skipped it because
-  // a live vertex already existed. Always true for an unconditional put.
+  // True when the write was applied; false when it was skipped — either
+  // because if_absent found a live vertex already at the key, or because the
+  // vertex was born expired (expiration already past) and discarded. Always
+  // true for an unconditional put with a live expiration.
   bool written = 1;
 }
 
@@ -252,9 +254,12 @@ message PutVerticesRequest {
 
 message PutVerticesResponse {
   // Number of vertices actually written. For an unconditional put this equals
-  // the request size on success; under if_absent it excludes skipped keys.
+  // the request size on success; under if_absent it excludes skipped keys. A
+  // vertex whose expiration is already past is discarded and counts as neither
+  // written nor skipped (it appears in neither this count nor skipped_keys).
   int32 written = 1;
-  // Keys skipped because a live vertex already existed (if_absent only).
+  // Keys skipped because a live vertex already existed (if_absent only). A
+  // born-expired vertex is NOT reported here — it is silently discarded.
   repeated string skipped_keys = 2;
 }
 

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -152,6 +152,37 @@ func TestNextContribIDs(t *testing.T) {
 	})
 }
 
+// TestContribIDGoldenVectors pins the 24-byte wire layout byte-for-byte:
+// [0:16] client nonce/origin ‖ [16:24] big-endian uint64 (seq<<16)|idx. The
+// SAME literals live in sdks/node/test/contrib.test.ts and
+// server/service/apply_test.go (#922) — if this test needs editing, those two
+// must change in the same commit or cross-SDK idempotency dedup interop breaks.
+// Unlike the decodeContribID-based tests above, it does NOT re-derive the
+// formula: a self-consistent shift/endianness/nonce-length refactor of
+// nextContribIDs turns this red while the tautological tests stay green.
+func TestContribIDGoldenVectors(t *testing.T) {
+	nonce := [16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f}
+	want := func(low8 ...byte) []byte { return append(append([]byte(nil), nonce[:]...), low8...) }
+
+	l := &Lantern{}
+	l.opts.idempotentAdds = true
+	l.nonce = nonce // zero-valued callSeq: the first nextContribIDs call uses seq=1
+
+	ids := l.nextContribIDs(2)
+	if got := want(0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00); !bytes.Equal(ids[0], got) {
+		t.Fatalf("V1 (seq=1, idx=0):\n  got  %x\n  want %x", ids[0], got)
+	}
+	if got := want(0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01); !bytes.Equal(ids[1], got) {
+		t.Fatalf("V2 (seq=1, idx=1):\n  got  %x\n  want %x", ids[1], got)
+	}
+
+	l.callSeq.Store(0xABCC) // next call → seq=0xABCD
+	ids = l.nextContribIDs(1 << 16)
+	if got := want(0x00, 0x00, 0x00, 0x00, 0xab, 0xcd, 0xff, 0xff); !bytes.Equal(ids[0xFFFF], got) {
+		t.Fatalf("V3 (seq=0xABCD, idx=0xFFFF):\n  got  %x\n  want %x", ids[0xFFFF], got)
+	}
+}
+
 // captureAddEdges is a fake LanternServiceClient that records every
 // AddEdgesRequest it receives. It embeds the interface (left nil) so it
 // satisfies the full surface while only overriding AddEdges — the single

--- a/sdks/node/src/gen/graph/v1/graph_pb.ts
+++ b/sdks/node/src/gen/graph/v1/graph_pb.ts
@@ -536,8 +536,10 @@ export const PutVertexRequestSchema: GenMessage<PutVertexRequest> = /*@__PURE__*
  */
 export type PutVertexResponse = Message<"graph.v1.PutVertexResponse"> & {
   /**
-   * True when the write was applied; false when if_absent skipped it because
-   * a live vertex already existed. Always true for an unconditional put.
+   * True when the write was applied; false when it was skipped — either
+   * because if_absent found a live vertex already at the key, or because the
+   * vertex was born expired (expiration already past) and discarded. Always
+   * true for an unconditional put with a live expiration.
    *
    * @generated from field: bool written = 1;
    */
@@ -587,14 +589,17 @@ export const PutVerticesRequestSchema: GenMessage<PutVerticesRequest> = /*@__PUR
 export type PutVerticesResponse = Message<"graph.v1.PutVerticesResponse"> & {
   /**
    * Number of vertices actually written. For an unconditional put this equals
-   * the request size on success; under if_absent it excludes skipped keys.
+   * the request size on success; under if_absent it excludes skipped keys. A
+   * vertex whose expiration is already past is discarded and counts as neither
+   * written nor skipped (it appears in neither this count nor skipped_keys).
    *
    * @generated from field: int32 written = 1;
    */
   written: number;
 
   /**
-   * Keys skipped because a live vertex already existed (if_absent only).
+   * Keys skipped because a live vertex already existed (if_absent only). A
+   * born-expired vertex is NOT reported here — it is silently discarded.
    *
    * @generated from field: repeated string skipped_keys = 2;
    */

--- a/sdks/node/src/gen/graph/v1/graph_pb.ts
+++ b/sdks/node/src/gen/graph/v1/graph_pb.ts
@@ -1665,6 +1665,17 @@ export type AddEdgesRequest = Message<"graph.v1.AddEdgesRequest"> & {
    * corresponding edge on the legacy non-idempotent additive path. Each id is
    * opaque to the server.
    *
+   * Canonical 24-byte layout (the one spec; drift breaks cross-SDK dedup):
+   *   bytes [0:16] = client nonce / origin NodeID
+   *   bytes [16:24] = big-endian uint64 (seq<<16)|idx
+   * where seq is a per-client/per-mutation monotonic counter and idx is the
+   * edge's position within its batch (folding idx into the low 16 bits lets
+   * one batch carry up to 65 536 distinct ids under a single seq). Three
+   * hand-written encoders must stay byte-identical: sdks/go/client.go
+   * nextContribIDs, sdks/node/src/contrib.ts contribIdFrom, and
+   * server/service/apply.go contribIDFor. Golden-vector tests in all three
+   * suites (#922) fail CI on any unilateral change.
+   *
    * @generated from field: repeated bytes contrib_ids = 2;
    */
   contribIds: Uint8Array[];

--- a/sdks/node/test/contrib.test.ts
+++ b/sdks/node/test/contrib.test.ts
@@ -63,4 +63,28 @@ describe("contrib IDs (#895)", () => {
     expect(() => validateContribId(new Uint8Array(25))).toThrow(InvalidArgumentError);
     expect(() => validateContribId(new Uint8Array(0))).toThrow(InvalidArgumentError);
   });
+
+  test("golden vectors — byte-for-byte identical to the Go SDK and server (#922)", () => {
+    // SAME literals as sdks/go/client_test.go TestContribIDGoldenVectors and
+    // server/service/apply_test.go TestContribIDForGoldenVectors. Never edit
+    // one copy alone: a unilateral change here breaks idempotency dedup against
+    // clients on the other implementation. Unlike the tests above, these do NOT
+    // re-derive (seq<<16)|index — they are written out literally so a
+    // coordinated shift/endianness/nonce-length refactor fails CI.
+    const nonce = new Uint8Array([
+      0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+      0x0f,
+    ]);
+    const v = (low8: number[]) => [...nonce, ...low8];
+
+    expect([...contribIdFrom(nonce, 1n, 0)]).toEqual(
+      v([0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00]),
+    );
+    expect([...contribIdFrom(nonce, 1n, 1)]).toEqual(
+      v([0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01]),
+    );
+    expect([...contribIdFrom(nonce, 0xabcdn, 0xffff)]).toEqual(
+      v([0x00, 0x00, 0x00, 0x00, 0xab, 0xcd, 0xff, 0xff]),
+    );
+  });
 });

--- a/server/service/apply_test.go
+++ b/server/service/apply_test.go
@@ -1154,3 +1154,32 @@ func FuzzContribIDFromBytes(f *testing.F) {
 		}
 	})
 }
+
+// TestContribIDForGoldenVectors pins the 24-byte wire layout byte-for-byte:
+// [0:16] origin nonce ‖ [16:24] big-endian uint64 (seq<<16)|idx. The SAME
+// literals live in sdks/go/client_test.go TestContribIDGoldenVectors and
+// sdks/node/test/contrib.test.ts (#922) — a unilateral change to any one
+// implementation's shift width, endianness, or nonce length turns exactly this
+// suite red while the dedup-behavior tests above stay green, catching the
+// coordinated-drift refactor that would silently break cross-SDK idempotency.
+func TestContribIDForGoldenVectors(t *testing.T) {
+	origin := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f}
+	cases := []struct {
+		seq  uint64
+		idx  uint16
+		low8 [8]byte
+	}{
+		{1, 0, [8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00}},
+		{1, 1, [8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01}},
+		{0xABCD, 0xFFFF, [8]byte{0x00, 0x00, 0x00, 0x00, 0xab, 0xcd, 0xff, 0xff}},
+	}
+	for _, tc := range cases {
+		got := contribIDFor(origin, tc.seq, tc.idx)
+		var wantID graphcache.ContribID
+		copy(wantID[:16], origin)
+		copy(wantID[16:], tc.low8[:])
+		if got != wantID {
+			t.Fatalf("contribIDFor(origin, %#x, %#x):\n  got  %x\n  want %x", tc.seq, tc.idx, got[:], wantID[:])
+		}
+	}
+}

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -743,14 +743,16 @@ func (s *LanternService) PutVertices(ctx context.Context, request *pb.PutVertice
 	if request.GetIfAbsent() {
 		if s.clock != nil {
 			ts := s.clock.Now()
+			// Core returns only indices that were actually stored — a
+			// born-expired item is discarded and excluded (#918), so
+			// writtenIdx is all-live by construction and needs no second
+			// liveness filter before replication.
 			writtenIdx, skipped := s.cache.PutVerticesWithExpirationIfAbsentHLC(items, ts)
-			live := make([]*pb.Vertex, 0, len(writtenIdx))
-			for _, i := range writtenIdx {
-				if cache.IsLiveAt(items[i].Expiration, now) {
+			if len(writtenIdx) > 0 {
+				live := make([]*pb.Vertex, 0, len(writtenIdx))
+				for _, i := range writtenIdx {
 					live = append(live, in[i])
 				}
-			}
-			if len(live) > 0 {
 				s.logMutationAt(&pb.MutationOp{Op: &pb.MutationOp_PutVertices{PutVertices: &pb.PutVerticesRequest{Vertices: live}}}, ts)
 			}
 			return &pb.PutVerticesResponse{Written: int32(len(writtenIdx)), SkippedKeys: skipped}, nil

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -134,6 +134,25 @@ func TestLanternService_PutVertexIfAbsent(t *testing.T) {
 			t.Errorf("value = %q, want \"two\" (unconditional put must overwrite)", got)
 		}
 	})
+
+	t.Run("BornExpiredReportsNotWritten", func(t *testing.T) {
+		s := newTestService(t)
+		dead := &pb.Vertex{
+			Key:        "k",
+			Value:      &pb.Vertex_String_{String_: "dead"},
+			Expiration: timestamppb.New(time.Now().Add(-time.Hour)),
+		}
+		resp, err := s.PutVertex(ctx, &pb.PutVertexRequest{Vertex: dead, IfAbsent: true})
+		if err != nil {
+			t.Fatalf("PutVertex: %v", err)
+		}
+		if resp.GetWritten() {
+			t.Fatal("born-expired if_absent PutVertex Written = true, want false")
+		}
+		if _, err := s.GetVertex(ctx, &pb.GetVertexRequest{Key: "k"}); connect.CodeOf(err) != connect.CodeNotFound {
+			t.Fatalf("GetVertex after born-expired put: code = %v, want NotFound", connect.CodeOf(err))
+		}
+	})
 }
 
 func TestLanternService_GetVertex_NotFound(t *testing.T) {
@@ -1322,6 +1341,29 @@ func TestLanternService_PutVertices_BornExpiredNotReplicated(t *testing.T) {
 			}
 		case <-time.After(2 * time.Second):
 			t.Fatal("timed out")
+		}
+	})
+
+	t.Run("IfAbsent_WrittenExcludesBornExpired", func(t *testing.T) {
+		s, _, appendCount := newSvc(t)
+		resp, err := s.PutVertices(context.Background(), &pb.PutVerticesRequest{
+			Vertices: []*pb.Vertex{
+				{Key: "dead", Expiration: past},    // discarded: born expired
+				{Key: "fresh", Expiration: future}, // written
+			},
+			IfAbsent: true,
+		})
+		if err != nil {
+			t.Fatalf("PutVertices(if_absent): %v", err)
+		}
+		if resp.GetWritten() != 1 {
+			t.Fatalf("Written = %d, want 1 (born-expired must not count)", resp.GetWritten())
+		}
+		if got := resp.GetSkippedKeys(); len(got) != 0 {
+			t.Fatalf("SkippedKeys = %v, want [] (born-expired is discarded, not skipped)", got)
+		}
+		if *appendCount != 1 {
+			t.Fatalf("appendCount = %d, want 1 (only the live if-absent write replicates)", *appendCount)
 		}
 	})
 }


### PR DESCRIPTION
Part of epic #924 (post-merge hardening of #915). Stacked on #926 (#918); base retargets to `main` when #926 merges.

## Problem
Three hand-written encoders must produce byte-identical 24-byte contrib IDs (`[0:16]` nonce/origin ‖ `[16:24]` big-endian `(seq<<16)|idx`): `sdks/go/client.go nextContribIDs`, `sdks/node/src/contrib.ts contribIdFrom`, `server/service/apply.go contribIDFor`. They agree today, but **every existing test re-derives the formula it tests** — so a self-consistent refactor to any one (shift width, endianness, nonce length) passes all suites while silently breaking cross-SDK idempotency dedup (duplicate weights on retry → production data corruption).

## Fix
Add the **same hard-coded golden vectors** (literal nonce/seq/idx inputs → literal 24 expected bytes) to all three suites so any unilateral drift fails CI:
- `sdks/go/client_test.go`: `TestContribIDGoldenVectors`
- `server/service/apply_test.go`: `TestContribIDForGoldenVectors`
- `sdks/node/test/contrib.test.ts`: additive `golden vectors …` case (existing roundtrip tests kept)

Records the canonical byte layout as the spec comment on `AddEdgesRequest.contrib_ids` in `proto/graph/v1/graph.proto`, naming all three implementing sites (regenerated `pb` + node stubs, doc-only).

### Canonical vectors
- nonce/origin: `00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f`
- V1 `(seq=1, idx=0)` → low8 `00 00 00 00 00 01 00 00`
- V2 `(seq=1, idx=1)` → `00 00 00 00 00 01 00 01`
- V3 `(seq=0xABCD, idx=0xFFFF)` → `00 00 00 00 ab cd ff ff`

## Verification
Confirmed once that flipping the Go shift to `seq<<20` reddens **only** the golden test while the `decodeContribID`-based self-consistency tests stay green — exactly the coordinated-drift class this guards.

## Gate
`gofmt -l .` clean; `go test ./...` green in sdks/go, server (with `go vet`), pb; `go generate ./...` idempotent (pb committed); full Node gate (codegen clean, lint/format:check/typecheck/test/build) green.

Closes #922