### PR TITLE
fix(sdks/go): mint contrib ids once per failover call so retries dedup

### DIFF
--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -147,12 +147,12 @@ type Lantern struct {
 	httpClient *http.Client
 	baseURL    string
 
-	// nonce + callSeq generate per-call ContribID idempotency keys when
-	// WithIdempotentAdds is set (#588). nonce is a per-client 128-bit random
-	// prefix that namespaces this client's keys; callSeq is bumped once per
-	// Add* request build. See nextContribIDs.
-	nonce   [16]byte
-	callSeq atomic.Uint64
+	// contribIDs mints the per-call ContribID idempotency keys when
+	// WithIdempotentAdds is set (#588). It is always non-nil after
+	// NewLantern (seeded with a per-client random nonce) but only consulted
+	// on the additive write surface when l.opts.idempotentAdds is set. See
+	// nextContribIDs and contribIDGen.
+	contribIDs *contribIDGen
 }
 
 // NewLantern dials the Lantern server at baseURL and returns a
@@ -189,10 +189,12 @@ func NewLantern(baseURL string, opts ...Option) (*Lantern, error) {
 	// A per-client random nonce namespaces this client's ContribIDs so two
 	// processes (or two NewLantern calls) never collide their idempotency
 	// keys. Only consulted when WithIdempotentAdds is set, but seeded
-	// unconditionally so the field is always valid.
-	if _, err := rand.Read(l.nonce[:]); err != nil {
-		return nil, fmt.Errorf("client: NewLantern could not seed idempotency nonce: %w", err)
+	// unconditionally so the generator is always valid.
+	gen, err := newContribIDGen()
+	if err != nil {
+		return nil, err
 	}
+	l.contribIDs = gen
 	return l, nil
 }
 
@@ -524,11 +526,19 @@ func (l *Lantern) AddEdge(ctx context.Context, tail string, head string, weight 
 
 // AddEdgeAt is AddEdge with an absolute expiration.
 func (l *Lantern) AddEdgeAt(ctx context.Context, tail string, head string, weight float32, expiration time.Time) (float32, error) {
+	return l.addEdgeAtWithIDs(ctx, tail, head, weight, expiration, l.nextContribIDs(1))
+}
+
+// addEdgeAtWithIDs is AddEdgeAt with caller-supplied contrib ids (or nil for
+// the legacy additive path). Splitting the id source out of the request
+// builder lets the failover ring mint the ids once and reuse them across
+// retry attempts, instead of re-minting a fresh key per attempt (#916).
+func (l *Lantern) addEdgeAtWithIDs(ctx context.Context, tail string, head string, weight float32, expiration time.Time, ids [][]byte) (float32, error) {
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()
 	resp, err := unary(ctx, l, &pb.AddEdgesRequest{
 		Edges:      []*pb.Edge{{Tail: tail, Head: head, Weight: weight, Expiration: timestamppb.New(expiration)}},
-		ContribIds: l.nextContribIDs(1),
+		ContribIds: ids,
 	}, l.client.AddEdges)
 	if err != nil {
 		return 0, err
@@ -555,22 +565,39 @@ func (l *Lantern) AddEdgeAt(ctx context.Context, tail string, head string, weigh
 //
 // With WithIdempotentAdds the SDK stamps each contribution with a per-call
 // idempotency key, so a transport-level retry of a chunk records its weight
-// exactly once. That key is regenerated on each AddEdges invocation, so it
-// does not make an application-level resume/retry from index 0 idempotent —
-// use err.Written to resume, as above.
+// exactly once. The keys are minted once for the whole call (one contiguous
+// id space across chunks), so they are regenerated on each AddEdges
+// invocation — this does not make an application-level resume/retry from
+// index 0 idempotent; use err.Written to resume, as above.
 func (l *Lantern) AddEdges(ctx context.Context, inputs []EdgeInput) ([]float32, error) {
+	return l.addEdgesWithIDs(ctx, inputs, l.nextContribIDs(len(inputs)))
+}
+
+// addEdgesWithIDs is AddEdges with caller-supplied contrib ids (or nil for
+// the legacy additive path). When ids is non-nil it must be index-aligned
+// with inputs; each chunk receives its contiguous sub-slice. Minting the ids
+// once here — rather than per attempt inside the request builder — is what
+// lets the failover ring reuse the same ids across retries and across a node
+// switch, so a mid-flight Unavailable retry cannot double-count (#916).
+func (l *Lantern) addEdgesWithIDs(ctx context.Context, inputs []EdgeInput, ids [][]byte) ([]float32, error) {
 	if len(inputs) == 0 {
 		return nil, nil
 	}
 	effective := make([]float32, 0, len(inputs))
+	sent := 0
 	_, err := runBatchWrite(ctx, l, edgesFrom(inputs), func(ctx context.Context, chunk []*pb.Edge) (int32, error) {
-		resp, err := unary(ctx, l, &pb.AddEdgesRequest{Edges: chunk, ContribIds: l.nextContribIDs(len(chunk))}, l.client.AddEdges)
+		var chunkIDs [][]byte
+		if ids != nil {
+			chunkIDs = ids[sent : sent+len(chunk)]
+		}
+		resp, err := unary(ctx, l, &pb.AddEdgesRequest{Edges: chunk, ContribIds: chunkIDs}, l.client.AddEdges)
 		if err != nil {
 			return 0, err
 		}
 		// effective_weights is index-aligned per chunk; appending in chunk
 		// order keeps the aggregate aligned with inputs.
 		effective = append(effective, resp.GetEffectiveWeights()...)
+		sent += len(chunk)
 		return 0, nil
 	})
 	if err != nil {
@@ -581,21 +608,61 @@ func (l *Lantern) AddEdges(ctx context.Context, inputs []EdgeInput) ([]float32, 
 
 // nextContribIDs returns n per-edge idempotency keys for one Add* request,
 // or nil when WithIdempotentAdds is not set (nil → the wire carries no
-// contrib_ids, i.e. the legacy additive path). It bumps callSeq exactly once
-// per call; key i packs the client nonce into bytes [0:16] and the
-// big-endian (seq<<16)|i into bytes [16:24], matching the server's ContribID
-// layout. Because the keys are baked into the request when it is built, a
-// transport retry that re-sends the same request re-sends the same keys, so
-// the contribution is recorded exactly once.
+// contrib_ids, i.e. the legacy additive path). It delegates to the client's
+// contribIDGen, whose byte layout is pinned by #922's golden vectors.
 func (l *Lantern) nextContribIDs(n int) [][]byte {
-	if !l.opts.idempotentAdds || n <= 0 {
+	if !l.opts.idempotentAdds {
 		return nil
 	}
-	seq := l.callSeq.Add(1)
+	return l.contribIDs.next(n)
+}
+
+// contribIDGen mints the 24-byte per-edge idempotency keys the additive
+// write surface stamps onto contributions when WithIdempotentAdds is set
+// (#588). A per-generator random nonce namespaces the keys; callSeq is a
+// monotonic counter advanced once per logical call. Its byte layout —
+// id[0:16] = nonce, big-endian (seq<<16)|idx in id[16:24] — is byte-for-byte
+// pinned by #922's golden vectors and must stay identical to the server's
+// contribIDFor and the Node SDK's contribIdFrom.
+//
+// One generator is shared per logical call site: each *Lantern holds its own,
+// and (crucially for #916) a *Failover holds a single generator so ids minted
+// for one logical call are reused verbatim across every retry attempt and
+// every node in the ring — a re-mint per attempt is exactly the double-count
+// bug this guards against.
+type contribIDGen struct {
+	nonce   [16]byte
+	callSeq atomic.Uint64
+}
+
+// newContribIDGen returns a generator seeded with a fresh random nonce.
+func newContribIDGen() (*contribIDGen, error) {
+	g := &contribIDGen{}
+	if _, err := rand.Read(g.nonce[:]); err != nil {
+		return nil, fmt.Errorf("client: could not seed idempotency nonce: %w", err)
+	}
+	return g, nil
+}
+
+// next returns n contiguous 24-byte contrib ids, or nil for n <= 0. It
+// reserves ceil(n/65536) sequence numbers atomically and advances the packed
+// seq every 65536 ids, so the low-16-bit idx field never aliases even when a
+// single logical call spans more than 65536 edges (the failover batch path
+// mints once for the whole request, unchipped by the per-chunk size). Within
+// one 65536-block the ids share a seq and differ only in idx.
+func (g *contribIDGen) next(n int) [][]byte {
+	if n <= 0 {
+		return nil
+	}
+	const block = 1 << 16
+	blocks := uint64((n + block - 1) / block) // ceil(n / 65536)
+	last := g.callSeq.Add(blocks)
+	base := last - blocks + 1
 	ids := make([][]byte, n)
 	for i := 0; i < n; i++ {
 		id := make([]byte, 24)
-		copy(id[:16], l.nonce[:])
+		copy(id[:16], g.nonce[:])
+		seq := base + uint64(i/block)
 		binary.BigEndian.PutUint64(id[16:], (seq<<16)|uint64(uint16(i)))
 		ids[i] = id
 	}

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -123,7 +123,7 @@ func TestNextContribIDs(t *testing.T) {
 		}
 		var seq0 uint64
 		for i, id := range ids {
-			if !bytes.Equal(id[:16], l.nonce[:]) {
+			if !bytes.Equal(id[:16], l.contribIDs.nonce[:]) {
 				t.Fatalf("id %d prefix must equal the client nonce", i)
 			}
 			seq, idx := decodeContribID(t, id)
@@ -159,16 +159,16 @@ func TestNextContribIDs(t *testing.T) {
 // must change in the same commit or cross-SDK idempotency dedup interop breaks.
 // Unlike the decodeContribID-based tests above, it does NOT re-derive the
 // formula: a self-consistent shift/endianness/nonce-length refactor of
-// nextContribIDs turns this red while the tautological tests stay green.
+// contribIDGen.next turns this red while the tautological tests stay green.
+// It drives the extracted contribIDGen directly (post-#916) so it pins the
+// generator regardless of which caller — *Lantern or *Failover — mints ids.
 func TestContribIDGoldenVectors(t *testing.T) {
 	nonce := [16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f}
 	want := func(low8 ...byte) []byte { return append(append([]byte(nil), nonce[:]...), low8...) }
 
-	l := &Lantern{}
-	l.opts.idempotentAdds = true
-	l.nonce = nonce // zero-valued callSeq: the first nextContribIDs call uses seq=1
+	gen := &contribIDGen{nonce: nonce} // zero-valued callSeq: the first next call uses seq=1
 
-	ids := l.nextContribIDs(2)
+	ids := gen.next(2)
 	if got := want(0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00); !bytes.Equal(ids[0], got) {
 		t.Fatalf("V1 (seq=1, idx=0):\n  got  %x\n  want %x", ids[0], got)
 	}
@@ -176,17 +176,63 @@ func TestContribIDGoldenVectors(t *testing.T) {
 		t.Fatalf("V2 (seq=1, idx=1):\n  got  %x\n  want %x", ids[1], got)
 	}
 
-	l.callSeq.Store(0xABCC) // next call → seq=0xABCD
-	ids = l.nextContribIDs(1 << 16)
+	gen.callSeq.Store(0xABCC) // next call → seq=0xABCD
+	ids = gen.next(1 << 16)
 	if got := want(0x00, 0x00, 0x00, 0x00, 0xab, 0xcd, 0xff, 0xff); !bytes.Equal(ids[0xFFFF], got) {
 		t.Fatalf("V3 (seq=0xABCD, idx=0xFFFF):\n  got  %x\n  want %x", ids[0xFFFF], got)
 	}
 }
 
-// captureAddEdges is a fake LanternServiceClient that records every
-// AddEdgesRequest it receives. It embeds the interface (left nil) so it
-// satisfies the full surface while only overriding AddEdges — the single
-// method the Add* helpers route through.
+// TestContribIDGenNext pins contribIDGen.next's block-advancing contract
+// (#916): a single call that spans more than 65536 ids must keep every id
+// unique by rolling the packed seq once per 65536-id block (the low 16 bits
+// alias otherwise), and it must reserve ceil(n/65536) sequence numbers
+// atomically so a following call never reuses a seq the big call already
+// handed out.
+func TestContribIDGenNext(t *testing.T) {
+	t.Run("nil for non-positive n", func(t *testing.T) {
+		g := &contribIDGen{}
+		if g.next(0) != nil || g.next(-1) != nil {
+			t.Fatal("next(<=0) must return nil")
+		}
+	})
+
+	t.Run("ids unique across a 65536 block boundary", func(t *testing.T) {
+		g := &contribIDGen{}
+		const n = (1 << 16) + 5 // spans two blocks
+		ids := g.next(n)
+		if len(ids) != n {
+			t.Fatalf("want %d ids, got %d", n, len(ids))
+		}
+		seen := make(map[string]struct{}, n)
+		for i, id := range ids {
+			if _, dup := seen[string(id)]; dup {
+				t.Fatalf("id %d duplicates an earlier id: %x", i, id)
+			}
+			seen[string(id)] = struct{}{}
+		}
+		// idx wraps at the block boundary; seq bumps by exactly one there.
+		seqFirst, idxFirst := decodeContribID(t, ids[0])
+		seqWrap, idxWrap := decodeContribID(t, ids[1<<16])
+		if idxFirst != 0 || idxWrap != 0 {
+			t.Fatalf("idx at block starts want 0,0 got %d,%d", idxFirst, idxWrap)
+		}
+		if seqWrap != seqFirst+1 {
+			t.Fatalf("seq must bump by 1 at the block boundary: %d then %d", seqFirst, seqWrap)
+		}
+	})
+
+	t.Run("reserves ceil(n/65536) seqs atomically", func(t *testing.T) {
+		g := &contribIDGen{}
+		g.next((1 << 16) + 1) // two blocks: reserves seq 1 and 2
+		next := g.next(1)     // must land on seq 3, not 2
+		seq, _ := decodeContribID(t, next[0])
+		if seq != 3 {
+			t.Fatalf("next call after a 2-block mint must use seq 3, got %d", seq)
+		}
+	})
+}
+
 type captureAddEdges struct {
 	graphv1connect.LanternServiceClient
 	reqs []*pb.AddEdgesRequest
@@ -199,7 +245,9 @@ func (c *captureAddEdges) AddEdges(_ context.Context, req *connect.Request[pb.Ad
 
 // TestAddContribIDWiring verifies the SDK attaches contrib_ids only when
 // WithIdempotentAdds is set, that AddEdge stamps exactly one key, and that
-// AddEdges stamps index-aligned keys per chunk with a fresh seq per chunk.
+// AddEdges mints keys once for the whole batch (#916) — one contiguous id
+// space (shared seq, index-aligned idx) sliced across chunks, not a fresh
+// seq per chunk.
 func TestAddContribIDWiring(t *testing.T) {
 	newClient := func(t *testing.T, opts ...Option) (*Lantern, *captureAddEdges) {
 		t.Helper()
@@ -231,12 +279,12 @@ func TestAddContribIDWiring(t *testing.T) {
 		if len(ids) != 1 {
 			t.Fatalf("want 1 contrib_id, got %d", len(ids))
 		}
-		if !bytes.Equal(ids[0][:16], l.nonce[:]) {
+		if !bytes.Equal(ids[0][:16], l.contribIDs.nonce[:]) {
 			t.Fatalf("contrib_id prefix must be the client nonce")
 		}
 	})
 
-	t.Run("WithIdempotentAdds stamps index-aligned keys per chunk (AddEdges)", func(t *testing.T) {
+	t.Run("WithIdempotentAdds mints one contiguous id space across chunks (AddEdges)", func(t *testing.T) {
 		l, capt := newClient(t, WithIdempotentAdds(), WithBatchChunkSize(2))
 		inputs := []EdgeInput{
 			{Tail: "a", Head: "b", Weight: 1},
@@ -253,17 +301,19 @@ func TestAddContribIDWiring(t *testing.T) {
 		if len(c0) != 2 || len(c1) != 1 {
 			t.Fatalf("chunk key counts want 2,1 got %d,%d", len(c0), len(c1))
 		}
+		// Ids are minted once for the whole batch: idx is contiguous across
+		// chunk boundaries (0,1 | 2) and every chunk shares one seq.
 		seq0, idx00 := decodeContribID(t, c0[0])
 		_, idx01 := decodeContribID(t, c0[1])
 		if idx00 != 0 || idx01 != 1 {
 			t.Fatalf("chunk 0 indices want 0,1 got %d,%d", idx00, idx01)
 		}
 		seq1, idx10 := decodeContribID(t, c1[0])
-		if idx10 != 0 {
-			t.Fatalf("chunk 1 index want 0 got %d", idx10)
+		if idx10 != 2 {
+			t.Fatalf("chunk 1 index want 2 (contiguous), got %d", idx10)
 		}
-		if seq1 == seq0 {
-			t.Fatalf("each chunk must use a distinct seq; got %d twice", seq0)
+		if seq1 != seq0 {
+			t.Fatalf("one batch shares a single seq; got %d then %d", seq0, seq1)
 		}
 	})
 

--- a/sdks/go/failover.go
+++ b/sdks/go/failover.go
@@ -29,7 +29,13 @@
 // Unavailable error means the request was actually processed (and rejected
 // or not-found) somewhere — failing over would be wrong, so we surface it
 // verbatim. Combined with WithIdempotentAdds (#588), even the residual
-// at-least-once window of a mid-flight Unavailable retry is dedup-safe.
+// at-least-once window of a mid-flight Unavailable retry is dedup-safe:
+// Failover mints the per-edge contrib ids ONCE per logical call (from its
+// own failover-level generator) and reuses those exact bytes across every
+// retry attempt AND every node it rotates through. Minting per attempt —
+// or per node — would re-count, because the replicas converge via
+// replication, so a re-mint through node B lands as a distinct contribution
+// just like a re-mint through node A (#916).
 package client
 
 import (
@@ -63,6 +69,12 @@ type Failover struct {
 	// write surface (AddEdge/AddEdgeAt/AddEdges) — retried only when the nodes
 	// stamp per-edge ContribIDs.
 	idempotentAdds bool
+	// contribIDs is the single failover-level ContribID generator. Non-nil
+	// only when idempotentAdds is set. Minting ids here — once per logical
+	// AddEdge/AddEdges call, before the retry loop — and reusing them across
+	// every attempt and every node is what makes a mid-flight Unavailable
+	// retry dedup-safe; a fresh id per attempt would double-count (#916).
+	contribIDs *contribIDGen
 }
 
 // failoverNode is the unexported endpoint contract the ring walk delegates
@@ -89,6 +101,12 @@ type failoverNode interface {
 	AddEdge(ctx context.Context, tail, head string, weight float32, ttl time.Duration) (float32, error)
 	AddEdgeAt(ctx context.Context, tail, head string, weight float32, expiration time.Time) (float32, error)
 	AddEdges(ctx context.Context, inputs []EdgeInput) ([]float32, error)
+	// addEdgeAtWithIDs / addEdgesWithIDs are the id-accepting seams the
+	// failover ring drives so it can mint contrib ids once per logical call
+	// and reuse them across retry attempts (#916). Unexported: they are an
+	// internal contract between *Failover and *Lantern, not client API.
+	addEdgeAtWithIDs(ctx context.Context, tail, head string, weight float32, expiration time.Time, ids [][]byte) (float32, error)
+	addEdgesWithIDs(ctx context.Context, inputs []EdgeInput, ids [][]byte) ([]float32, error)
 	PutEdge(ctx context.Context, tail, head string, weight float32, ttl time.Duration) error
 	PutEdgeAt(ctx context.Context, tail, head string, weight float32, expiration time.Time) error
 	PutEdges(ctx context.Context, inputs []EdgeInput) error
@@ -132,6 +150,18 @@ func NewLanternFailover(addrs []string, opts ...Option) (*Failover, error) {
 	for _, apply := range opts {
 		apply(&probe)
 	}
+	// Seed a single failover-level ContribID generator when idempotent adds
+	// are enabled, so every AddEdge/AddEdges call mints its ids once and
+	// reuses them across retries and node switches (#916). Done before
+	// dialing so a seed failure leaks no connections.
+	var contribIDs *contribIDGen
+	if probe.idempotentAdds {
+		g, err := newContribIDGen()
+		if err != nil {
+			return nil, err
+		}
+		contribIDs = g
+	}
 	nodeOpts := make([]Option, 0, len(opts)+1)
 	nodeOpts = append(nodeOpts, opts...)
 	nodeOpts = append(nodeOpts, clearNodeRetry)
@@ -147,7 +177,7 @@ func NewLanternFailover(addrs []string, opts ...Option) (*Failover, error) {
 		}
 		nodes = append(nodes, l)
 	}
-	return &Failover{nodes: nodes, retry: probe.retry, idempotentAdds: probe.idempotentAdds}, nil
+	return &Failover{nodes: nodes, retry: probe.retry, idempotentAdds: probe.idempotentAdds, contribIDs: contribIDs}, nil
 }
 
 // clearNodeRetry is an internal Option that NewLanternFailover appends to
@@ -367,24 +397,23 @@ func (f *Failover) DeleteVerticesByPrefix(ctx context.Context, prefix string, op
 // AddEdge forwards to the current endpoint's AddEdge, failing over on
 // ErrUnavailable. Because an Unavailable result means the dead node
 // committed nothing, the additive contribution is retried on a sibling
-// replica without risk of double-counting. It returns the post-accumulation
-// effective weight reported by the serving node (#897).
+// replica; with WithIdempotentAdds the contrib ids are minted once (below,
+// via AddEdgeAt) and reused across every attempt, so even the residual
+// at-least-once window of a mid-flight Unavailable retry cannot double-count
+// (#916). It returns the post-accumulation effective weight (#897).
 func (f *Failover) AddEdge(ctx context.Context, tail, head string, weight float32, ttl time.Duration) (float32, error) {
-	var effective float32
-	err := f.call(ctx, "AddEdge", func(l failoverNode) error {
-		w, e := l.AddEdge(ctx, tail, head, weight, ttl)
-		effective = w
-		return e
-	})
-	return effective, err
+	return f.AddEdgeAt(ctx, tail, head, weight, expirationFromTTL(ttl))
 }
 
 // AddEdgeAt forwards to the current endpoint's AddEdgeAt, failing over on
-// ErrUnavailable. It returns the post-accumulation effective weight (#897).
+// ErrUnavailable. It mints the contrib id ONCE, before the retry loop, and
+// reuses it across every attempt and node (#916). It returns the
+// post-accumulation effective weight (#897).
 func (f *Failover) AddEdgeAt(ctx context.Context, tail, head string, weight float32, expiration time.Time) (float32, error) {
+	ids := f.nextContribIDs(1)
 	var effective float32
 	err := f.call(ctx, "AddEdgeAt", func(l failoverNode) error {
-		w, e := l.AddEdgeAt(ctx, tail, head, weight, expiration)
+		w, e := l.addEdgeAtWithIDs(ctx, tail, head, weight, expiration, ids)
 		effective = w
 		return e
 	})
@@ -392,16 +421,32 @@ func (f *Failover) AddEdgeAt(ctx context.Context, tail, head string, weight floa
 }
 
 // AddEdges forwards to the current endpoint's AddEdges, failing over on
-// ErrUnavailable. It returns the per-edge post-accumulation effective
-// weights (#897), index-aligned with inputs.
+// ErrUnavailable. The per-edge contrib ids are minted ONCE for the whole
+// batch, before the retry loop, and reused across every attempt and node so a
+// retry cannot double-count (#916). It returns the per-edge post-accumulation
+// effective weights (#897), index-aligned with inputs.
 func (f *Failover) AddEdges(ctx context.Context, inputs []EdgeInput) ([]float32, error) {
+	ids := f.nextContribIDs(len(inputs))
 	var effective []float32
 	err := f.call(ctx, "AddEdges", func(l failoverNode) error {
-		w, e := l.AddEdges(ctx, inputs)
+		w, e := l.addEdgesWithIDs(ctx, inputs, ids)
 		effective = w
 		return e
 	})
 	return effective, err
+}
+
+// nextContribIDs mints n contrib ids from the failover-level generator, or
+// nil when idempotent adds are disabled (contribIDs is nil) — the legacy
+// non-idempotent additive path. Minting at the failover layer (not per node)
+// is deliberate: both replicas converge via replication, so re-minting
+// through a sibling on failover double-counts exactly like re-minting through
+// the same node (#916).
+func (f *Failover) nextContribIDs(n int) [][]byte {
+	if f.contribIDs == nil {
+		return nil
+	}
+	return f.contribIDs.next(n)
 }
 
 // PutEdge forwards to the current endpoint's PutEdge, failing over on

--- a/sdks/go/failover_test.go
+++ b/sdks/go/failover_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"testing"
@@ -15,9 +16,14 @@ import (
 // failover tests before the logic moved into the SDK (#592).
 type fakeNode struct {
 	getVertexFn func(ctx context.Context, key string) (*Vertex, error)
-	addEdgeFn   func(ctx context.Context, tail, head string, weight float32, ttl time.Duration) (float32, error)
-	pingErr     error
-	closed      int
+	// addEdgeAtWithIDsFn / addEdgesWithIDsFn drive the id-accepting seams the
+	// failover ring actually calls for additive writes (#916); the failover
+	// AddEdge/AddEdgeAt/AddEdges methods route through these, so tests wire
+	// them to observe the contrib ids passed down.
+	addEdgeAtWithIDsFn func(ctx context.Context, tail, head string, weight float32, expiration time.Time, ids [][]byte) (float32, error)
+	addEdgesWithIDsFn  func(ctx context.Context, inputs []EdgeInput, ids [][]byte) ([]float32, error)
+	pingErr            error
+	closed             int
 }
 
 func (f *fakeNode) PutVertex(context.Context, string, any, time.Duration) error { return nil }
@@ -56,16 +62,25 @@ func (f *fakeNode) CountVerticesByPrefix(context.Context, string) (uint64, error
 func (f *fakeNode) DeleteVerticesByPrefix(context.Context, string, ...DeleteByPrefixOption) (uint64, error) {
 	return 0, nil
 }
-func (f *fakeNode) AddEdge(ctx context.Context, tail, head string, weight float32, ttl time.Duration) (float32, error) {
-	if f.addEdgeFn != nil {
-		return f.addEdgeFn(ctx, tail, head, weight, ttl)
-	}
+func (f *fakeNode) AddEdge(context.Context, string, string, float32, time.Duration) (float32, error) {
 	return 0, nil
 }
 func (f *fakeNode) AddEdgeAt(context.Context, string, string, float32, time.Time) (float32, error) {
 	return 0, nil
 }
 func (f *fakeNode) AddEdges(context.Context, []EdgeInput) ([]float32, error) { return nil, nil }
+func (f *fakeNode) addEdgeAtWithIDs(ctx context.Context, tail, head string, weight float32, expiration time.Time, ids [][]byte) (float32, error) {
+	if f.addEdgeAtWithIDsFn != nil {
+		return f.addEdgeAtWithIDsFn(ctx, tail, head, weight, expiration, ids)
+	}
+	return 0, nil
+}
+func (f *fakeNode) addEdgesWithIDs(ctx context.Context, inputs []EdgeInput, ids [][]byte) ([]float32, error) {
+	if f.addEdgesWithIDsFn != nil {
+		return f.addEdgesWithIDsFn(ctx, inputs, ids)
+	}
+	return nil, nil
+}
 func (f *fakeNode) PutEdge(context.Context, string, string, float32, time.Duration) error {
 	return nil
 }
@@ -242,11 +257,11 @@ func TestFailover_PingAllNodesFailReturnsError(t *testing.T) {
 
 func TestFailover_AdditiveWriteRotatesOnUnavailable(t *testing.T) {
 	var n0, n1 int
-	node0 := &fakeNode{addEdgeFn: func(context.Context, string, string, float32, time.Duration) (float32, error) {
+	node0 := &fakeNode{addEdgeAtWithIDsFn: func(context.Context, string, string, float32, time.Time, [][]byte) (float32, error) {
 		n0++
 		return 0, unavailableErr()
 	}}
-	node1 := &fakeNode{addEdgeFn: func(context.Context, string, string, float32, time.Duration) (float32, error) {
+	node1 := &fakeNode{addEdgeAtWithIDsFn: func(context.Context, string, string, float32, time.Time, [][]byte) (float32, error) {
 		n1++
 		return 0, nil
 	}}
@@ -352,8 +367,10 @@ func TestFailover_RetryAlwaysReadIgnoresIdempotencySetting(t *testing.T) {
 }
 
 func TestFailover_RetryGatesAdditiveWritesByIdempotency(t *testing.T) {
+	// Failover.AddEdge routes through AddEdgeAt → node.addEdgeAtWithIDs, so the
+	// counting fakes wire the addEdgeAtWithIDs seam.
 	mk := func(c *int) *fakeNode {
-		return &fakeNode{addEdgeFn: func(context.Context, string, string, float32, time.Duration) (float32, error) {
+		return &fakeNode{addEdgeAtWithIDsFn: func(context.Context, string, string, float32, time.Time, [][]byte) (float32, error) {
 			*c++
 			return 0, unavailableErr()
 		}}
@@ -372,12 +389,89 @@ func TestFailover_RetryGatesAdditiveWritesByIdempotency(t *testing.T) {
 
 	t.Run("with idempotent adds the ring walk repeats MaxAttempts times", func(t *testing.T) {
 		var a, b int
-		f := &Failover{nodes: []failoverNode{mk(&a), mk(&b)}, retry: testRetryPolicy(3), idempotentAdds: true}
+		f := &Failover{nodes: []failoverNode{mk(&a), mk(&b)}, retry: testRetryPolicy(3), idempotentAdds: true, contribIDs: &contribIDGen{}}
 		if _, err := f.AddEdge(context.Background(), "a", "b", 1, time.Minute); !errors.Is(err, ErrUnavailable) {
 			t.Fatalf("err = %v, want ErrUnavailable", err)
 		}
 		if a != 3 || b != 3 {
 			t.Fatalf("counts a=%d b=%d, want 3 and 3 (retry armed for idempotent adds)", a, b)
+		}
+	})
+
+	t.Run("every retry attempt carries the SAME contrib ids", func(t *testing.T) {
+		// got collects the ids observed per attempt, across BOTH ring nodes —
+		// so this also pins id reuse across a node switch (a re-mint through
+		// node B double-counts exactly like a re-mint through node A: the two
+		// replicas converge via replication).
+		var got [][][]byte
+		record := func() *fakeNode {
+			return &fakeNode{addEdgeAtWithIDsFn: func(_ context.Context, _, _ string, _ float32, _ time.Time, ids [][]byte) (float32, error) {
+				cp := make([][]byte, len(ids))
+				for i, id := range ids {
+					cp[i] = append([]byte(nil), id...)
+				}
+				got = append(got, cp)
+				return 0, unavailableErr()
+			}}
+		}
+		f := &Failover{
+			nodes:          []failoverNode{record(), record()},
+			retry:          testRetryPolicy(3),
+			idempotentAdds: true,
+			contribIDs:     &contribIDGen{},
+		}
+		if _, err := f.AddEdge(context.Background(), "a", "b", 1, time.Minute); !errors.Is(err, ErrUnavailable) {
+			t.Fatalf("err = %v, want ErrUnavailable", err)
+		}
+		if len(got) < 4 {
+			t.Fatalf("attempts observed = %d, want >= 4 (retry × ring walk must have fired)", len(got))
+		}
+		first := got[0]
+		if len(first) != 1 || len(first[0]) != 24 {
+			t.Fatalf("attempt 0 ids = %v, want exactly one 24-byte id", first)
+		}
+		for i, ids := range got[1:] {
+			if len(ids) != 1 || !bytes.Equal(ids[0], first[0]) {
+				t.Fatalf("attempt %d re-minted its contrib id:\n  got  %x\n  want %x\n(a fresh id per attempt is exactly the double-count bug)", i+1, ids, first[0])
+			}
+		}
+	})
+
+	t.Run("AddEdges pre-mints one id per input, index-aligned, reused across attempts", func(t *testing.T) {
+		var calls [][][]byte
+		fake := &fakeNode{addEdgesWithIDsFn: func(_ context.Context, inputs []EdgeInput, ids [][]byte) ([]float32, error) {
+			if len(ids) != len(inputs) {
+				t.Fatalf("ids/inputs misaligned: %d ids for %d inputs", len(ids), len(inputs))
+			}
+			cp := make([][]byte, len(ids))
+			for i, id := range ids {
+				cp[i] = append([]byte(nil), id...)
+			}
+			calls = append(calls, cp)
+			return nil, unavailableErr()
+		}}
+		f := &Failover{nodes: []failoverNode{fake}, retry: testRetryPolicy(2), idempotentAdds: true, contribIDs: &contribIDGen{}}
+		inputs := []EdgeInput{
+			{Tail: "a", Head: "x", Weight: 1, Expiration: time.Now().Add(time.Minute)},
+			{Tail: "a", Head: "y", Weight: 1, Expiration: time.Now().Add(time.Minute)},
+			{Tail: "a", Head: "z", Weight: 1, Expiration: time.Now().Add(time.Minute)},
+		}
+		if _, err := f.AddEdges(context.Background(), inputs); !errors.Is(err, ErrUnavailable) {
+			t.Fatalf("err = %v, want ErrUnavailable", err)
+		}
+		if len(calls) < 2 {
+			t.Fatalf("attempts = %d, want >= 2", len(calls))
+		}
+		for atI := 1; atI < len(calls); atI++ {
+			for i := range calls[0] {
+				if !bytes.Equal(calls[atI][i], calls[0][i]) {
+					t.Fatalf("attempt %d id[%d] differs from attempt 0 — batch retry re-minted", atI, i)
+				}
+			}
+		}
+		// Distinctness within one call still holds (per-index packing).
+		if bytes.Equal(calls[0][0], calls[0][1]) || bytes.Equal(calls[0][1], calls[0][2]) {
+			t.Fatal("ids within one batch must be pairwise distinct")
 		}
 	})
 }
@@ -418,6 +512,13 @@ func TestNewLanternFailover_RetryExtractedAndNodesNeutralised(t *testing.T) {
 	}
 	if !f.idempotentAdds {
 		t.Fatal("failover idempotentAdds not extracted from opts")
+	}
+	// The failover-level ContribID generator must be armed when idempotent
+	// adds are on, so ids are minted once per call and reused across retries
+	// and node switches (#916). Without it every attempt would re-mint and
+	// double-count.
+	if f.contribIDs == nil {
+		t.Fatal("failover contribIDs generator not seeded under WithIdempotentAdds")
 	}
 	for i, n := range f.nodes {
 		l, ok := n.(*Lantern)


### PR DESCRIPTION
## What

Fixes the Go SDK failover double-count (#916, child of epic #924): under `WithIdempotentAdds`, `*Failover` re-minted a fresh `contrib_id` on every retry attempt and every node rotation, so a mid-flight `Unavailable` retry recorded the additive contribution **twice**. The server dedups by opaque id bytes, and replicas converge via replication — a re-mint through node B lands as a distinct contribution just like through node A.

## How

- **Extract** the id generator from `*Lantern` into an unexported `contribIDGen` (`nonce [16]byte` + `atomic.Uint64` seq). Byte layout is unchanged (`id[:16]=nonce`, big-endian `(seq<<16)|idx` in `id[16:24]`) — #922's golden vectors still pin it. One behavioral addition: `next` advances the packed seq every 65536 ids so a `>65536`-edge batch minted in one call can't alias the low-16-bit idx.
- **Add id-accepting seams** `addEdgeAtWithIDs` / `addEdgesWithIDs` on `*Lantern` and the `failoverNode` interface, splitting the id source out of the request builder.
- **Failover mints once**: `*Failover` owns a single `contribIDGen` (seeded in `NewLanternFailover` when idempotent adds are on) and mints ids **once per logical call**, before the retry loop, reusing those exact bytes across every attempt and node.
- Plain `*Lantern.AddEdges` now mints **one contiguous id space** for the whole batch (sliced per chunk) instead of a fresh seq per chunk — still unique / dedup-safe.

## Tests

- `failover_test.go`: rewired the count subtests to the new seam; added "every retry attempt carries the SAME contrib ids" (pins reuse across a node switch) and "AddEdges pre-mints one id per input, index-aligned, reused across attempts"; extended `TestNewLanternFailover_RetryExtractedAndNodesNeutralised` to assert the failover-level generator is armed.
- `client_test.go`: golden vectors now drive the extracted `contribIDGen` directly; added `TestContribIDGenNext` (65536-boundary uniqueness + atomic block reservation); updated the AddEdges wiring test to single-seq contiguous-idx semantics.

Go-SDK-only (imports `pb` only) — no proto/wire change, so no `pb/` / Node regen.

## Gate

`gofmt -l .` clean; `(cd sdks/go && go test ./...)` green; root `go test ./...` green (incl. `tests/integration/idempotent_add_test.go`).

Closes #916

---
> Stacked on #927 (#922). Base retargets to `main` when #927 merges. Do not merge out of order. Part of epic #924.
