### PR TITLE
fix(sdks): clamp batchChunkSize to the uint16 contrib-id index space

### DIFF
--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -15,6 +15,14 @@ import (
 // leave headroom for per-message overhead.
 const defaultBatchChunkSize = 1000
 
+// maxBatchChunkSize caps WithBatchChunkSize. Contrib-ID idempotency keys
+// (#588) pack a uint16 per-chunk index into their low bytes, so a single
+// chunk of more than 65536 edges would wrap index 65536 back to 0 and
+// collide two contributions under one seq — silently dropping a weight. We
+// clamp rather than error, matching the existing non-positive normalization
+// (and the Node SDK's MAX_BATCH_CHUNK_SIZE).
+const maxBatchChunkSize = 1 << 16
+
 // options collects the knobs a Connect-backed Lantern client accepts.
 // Callers configure them via the WithXxx helpers below.
 type options struct {
@@ -118,11 +126,14 @@ func WithDefaultTimeout(d time.Duration) Option {
 // WithBatchChunkSize overrides the auto-chunk size used by
 // PutVertices, AddEdges, PutEdges, DeleteVertices, DeleteEdges,
 // GetVertices, and GetEdges. Must be > 0; otherwise the default
-// (1000) is kept.
+// (1000) is kept. Values above 65536 are clamped to 65536, because the
+// additive write surface stamps a uint16 per-chunk index onto each
+// contrib-ID idempotency key (#588) — a larger chunk would wrap that index
+// and collide two contributions.
 func WithBatchChunkSize(n int) Option {
 	return func(o *options) {
 		if n > 0 {
-			o.batchChunkSize = n
+			o.batchChunkSize = min(n, maxBatchChunkSize)
 		}
 	}
 }

--- a/sdks/go/options_test.go
+++ b/sdks/go/options_test.go
@@ -1,0 +1,36 @@
+package client
+
+import "testing"
+
+// TestWithBatchChunkSize_ClampedToContribIndexSpace pins that
+// WithBatchChunkSize clamps to the uint16 contrib-ID index space (65536) so
+// no single chunk can wrap the per-chunk index and collide two contributions
+// (#919), while preserving the existing non-positive → default fallback.
+func TestWithBatchChunkSize_ClampedToContribIndexSpace(t *testing.T) {
+	cases := []struct {
+		in   int
+		want int
+	}{
+		{in: 70000, want: 1 << 16},   // above the uint16 contrib-id index space: clamped
+		{in: 1 << 16, want: 1 << 16}, // exactly the ceiling: kept
+		{in: 1000, want: 1000},       // below the ceiling: kept verbatim
+	}
+	for _, tc := range cases {
+		var o options
+		WithBatchChunkSize(tc.in)(&o)
+		if o.batchChunkSize != tc.want {
+			t.Fatalf("WithBatchChunkSize(%d) → %d, want %d", tc.in, o.batchChunkSize, tc.want)
+		}
+	}
+
+	// Non-positive values are ignored (the clamp must not disturb this): the
+	// field is left at its zero value here, and NewLantern seeds the default
+	// before applying options, so 0/negative fall through to defaultBatchChunkSize.
+	for _, in := range []int{0, -1, -65536} {
+		var o options
+		WithBatchChunkSize(in)(&o)
+		if o.batchChunkSize != 0 {
+			t.Fatalf("WithBatchChunkSize(%d) must not set the field (got %d); non-positive keeps the default", in, o.batchChunkSize)
+		}
+	}
+}

--- a/sdks/node/src/client.ts
+++ b/sdks/node/src/client.ts
@@ -85,6 +85,15 @@ import {
 } from "./incremental-search.js";
 import { contribIdFrom, makeNonce, validateContribId } from "./contrib.js";
 
+/**
+ * Upper bound for the auto-chunk size. Contrib-ID idempotency keys (#895)
+ * pack a uint16 per-chunk index into their low bytes, so a chunk larger than
+ * 65536 edges would wrap index 65536 back to 0 and collide two contributions
+ * under one sequence — silently dropping a weight. chunkSize() clamps to this
+ * (mirrors the Go SDK's maxBatchChunkSize).
+ */
+const MAX_BATCH_CHUNK_SIZE = 1 << 16;
+
 /** Maps the SDK's string match mode onto the wire enum. */
 function toPbMatchMode(m: MatchMode | undefined): PbMatchMode {
   switch (m) {
@@ -878,7 +887,8 @@ export class Lantern {
 
   private chunkSize(): number {
     const n = this.options.batchChunkSize ?? DEFAULT_BATCH_CHUNK_SIZE;
-    return n > 0 ? n : DEFAULT_BATCH_CHUNK_SIZE;
+    const positive = n > 0 ? n : DEFAULT_BATCH_CHUNK_SIZE;
+    return Math.min(positive, MAX_BATCH_CHUNK_SIZE);
   }
 
   /** Whether automatic contrib IDs are enabled for Add calls (#895). */

--- a/sdks/node/src/options.ts
+++ b/sdks/node/src/options.ts
@@ -178,7 +178,13 @@ export interface DeleteEdgesByPrefixOptions {
 export interface ConnectOptions {
   /** Per-call deadline (ms) applied when the caller did not set one. */
   defaultTimeoutMs?: number;
-  /** Auto-chunk size for putVertices / addEdges / putEdges / delete* (default 1000). */
+  /**
+   * Auto-chunk size for putVertices / addEdges / putEdges / delete* (default
+   * 1000). Values above 65536 are clamped to 65536, because the additive
+   * write surface stamps a uint16 per-chunk index onto each contrib-ID
+   * idempotency key (#895) — a larger chunk would wrap that index and collide
+   * two contributions.
+   */
   batchChunkSize?: number;
   /** Override the built-in retry + round_robin Connect service config. */
   serviceConfigJson?: string;

--- a/sdks/node/test/client.test.ts
+++ b/sdks/node/test/client.test.ts
@@ -545,6 +545,37 @@ describe("AddEdge contrib IDs (#895)", () => {
     }
   });
 
+  test("batchChunkSize above 65536 is clamped — no contrib-id collision inside one chunk", async () => {
+    // A chunk larger than the uint16 index space would wrap index 65536 back
+    // to 0 and collide two ids under one seq (#919). Clamp splits at 65536 so
+    // the 65537th edge lands in a second chunk under a fresh seq.
+    const c = connect(baseUrl, {
+      options: { idempotentAdds: true, batchChunkSize: 70000 },
+      transportOptions: { httpVersion: "1.1" },
+    });
+    try {
+      state.addEdgesCalls = [];
+      const edges = Array.from({ length: 65537 }, (_, i) => ({
+        tail: "t",
+        head: "h" + i,
+        weight: 1,
+      }));
+      await c.addEdges(edges);
+
+      // Unfixed code sends ONE 65537-edge chunk; fixed code splits at the clamp.
+      expect(state.addEdgesCalls.map((call) => call.tails.length)).toEqual([65536, 1]);
+
+      // The item that previously wrapped (index 65536 & 0xffff === 0) now lives
+      // in a second chunk under a FRESH seq, so its id differs from chunk 0,
+      // index 0.
+      const first = state.addEdgesCalls[0].contribIds[0];
+      const boundary = state.addEdgesCalls[1].contribIds[0];
+      expect([...boundary]).not.toEqual([...first]);
+    } finally {
+      c.close();
+    }
+  });
+
   test("successive idempotent addEdges calls advance the sequence (distinct ids)", async () => {
     const c = idempotentClient();
     try {


### PR DESCRIPTION
## What

Fixes the silent weight-drop from an oversized batch chunk (#919, child of epic #924). Both SDKs stamp contrib-ID idempotency keys that pack a **uint16 per-chunk index** into the low bytes (`(seq<<16)|uint16(idx)`), so a `batchChunkSize` above 65536 lets index 65536 wrap back to 0 and collide with index 0 under the same seq — dropping a contribution on a same-`(tail,head)` workload.

## How

Clamp `batchChunkSize` to `65536`, matching the existing non-positive → default normalization (both SDKs already silently normalize, so a hard error would be the odd one out):

- **Go** (`sdks/go/options.go`): new `const maxBatchChunkSize = 1 << 16`; `WithBatchChunkSize` now does `min(n, maxBatchChunkSize)` alongside the `n > 0` check, with the ceiling documented on the option.
- **Node** (`sdks/node/src`): `chunkSize()` returns `Math.min(positive, MAX_BATCH_CHUNK_SIZE)` (module-local const, nothing new exported); same sentence added to `batchChunkSize`'s JSDoc.

This bounds the per-request index space; #916's `contribIDGen.next` independently rolls `seq` every 65536 as defense-in-depth. **No wire change** — the server's uint16 assertion stays defensive.

## Tests

- **Go** (`sdks/go/options_test.go`, new — the one permitted pairing for `options.go`): `WithBatchChunkSize(70000)` → 65536; `65536` → 65536; `1000` → 1000; non-positive still falls through to the default.
- **Node** (`test/client.test.ts`): a `batchChunkSize: 70000`, `idempotentAdds: true` client feeding 65537 same-`(tail,head)` edges asserts the chunk split is `[65536, 1]` and that the boundary id (formerly wrapping to index 0) now lands under a fresh seq and differs from chunk 0. Verified it fails on the pre-clamp code.

## Gate

Go: `gofmt -l .` clean; `(cd sdks/go && go test ./...)` green. Node (from `sdks/node/`): `bun run codegen` leaves the tree clean, then `bun run lint && bun run format:check && bun run typecheck && bun test && bun run build` — all green (92 tests pass).

Closes #919

---
> Stacked on #928 (#916). Base retargets to `main` when #928 merges. Do not merge out of order. Part of epic #924.
