### PR TITLE
refactor(mcp): report accumulated weight from AddEdge effective_weight

### DIFF
--- a/mcp/fake_lantern_test.go
+++ b/mcp/fake_lantern_test.go
@@ -62,6 +62,11 @@ type fakeLantern struct {
 	lastEdgeWeight float32
 	lastEdgeTTL    time.Duration
 	addEdgeCalls   int
+	// addEdgeEffectiveFn, when set, supplies the effective (live accumulated)
+	// weight AddEdge returns — modeling the serving node's
+	// AddEdgeResponse.effective_weight (#897). Unset → AddEdge echoes the
+	// increment, the legacy single-writer behavior.
+	addEdgeEffectiveFn func(tail, head string, weight float32) float32
 
 	// AddEdges
 	addEdgesFn   func(ctx context.Context, inputs []client.EdgeInput) error
@@ -190,6 +195,9 @@ func (f *fakeLantern) AddEdge(ctx context.Context, tail, head string, weight flo
 	}
 	if f.addEdgeErr != nil {
 		return 0, f.addEdgeErr
+	}
+	if f.addEdgeEffectiveFn != nil {
+		return f.addEdgeEffectiveFn(tail, head, weight), nil
 	}
 	return weight, nil
 }

--- a/mcp/tool_remember_relation.go
+++ b/mcp/tool_remember_relation.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/anaregdesign/lantern/mcp/internal/ttl"
-	client "github.com/anaregdesign/lantern/sdks/go"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -23,13 +22,16 @@ type rememberRelationOutput struct {
 	Bucket string `json:"bucket"`
 	// Increment is the weight this single additive write contributed.
 	Increment float32 `json:"increment"`
-	// AccumulatedWeight is the edge's resulting weight after the write, read
-	// back from the store. Because writes are additive, repeating a relation
-	// makes this grow — it is the signal that distinguishes a strong
-	// association from a weak one. Falls back to Increment when the post-write
-	// read-back is unavailable.
+	// AccumulatedWeight is the edge's live weight after this write, reported
+	// by the serving node in AddEdgeResponse.effective_weight (#897) — the
+	// atomic post-own-write sum, with no follow-up read. Because writes are
+	// additive, repeating a relation makes this grow; it is the signal that
+	// distinguishes a strong association from a weak one.
 	AccumulatedWeight float32 `json:"accumulated_weight"`
-	ExpiresAt         string  `json:"expires_at"`
+	// ExpiresAt is when THIS write's contribution decays (now + resolved TTL).
+	// It is this contribution's own horizon, not necessarily the edge's latest
+	// expiration across other concurrent contributions.
+	ExpiresAt string `json:"expires_at"`
 	// Capped is true when the bucket's nominal horizon was clamped down to
 	// LANTERN_MCP_MAX_TTL before writing, so the caller knows the stored
 	// expiry is shorter than the bucket label implies.
@@ -55,24 +57,16 @@ func registerRememberRelation(srv *mcp.Server, lc lanternClient, r *ttl.Resolver
 			weight = 1
 		}
 		d, capped := r.ResolveCapped(bucket)
-		if _, err := lc.AddEdge(ctx, in.From, in.To, weight, d); err != nil {
+		// AddEdge returns the live accumulated weight after applying this
+		// contribution (AddEdgeResponse.effective_weight, #897), so the agent
+		// sees the ACCUMULATED total — the whole point of the additive model —
+		// without a follow-up GetEdge (which reopened a TOCTOU window and could
+		// attribute a concurrent writer's weight to this call).
+		accumulated, err := lc.AddEdge(ctx, in.From, in.To, weight, d)
+		if err != nil {
 			return nil, rememberRelationOutput{}, mapSDKError("remember_relation", err)
 		}
-		// Read the edge back so the agent sees the ACCUMULATED weight, not just
-		// the increment it wrote — that read-back is the whole point of the
-		// additive model. It is best-effort: the write already succeeded, so a
-		// transient read failure must not fail the tool; fall back to reporting
-		// this write's increment and the computed expiry.
-		accumulated := weight
 		expiresAt := time.Now().Add(d).UTC().Format(time.RFC3339)
-		readBack := false
-		if e, gerr := lc.GetEdge(ctx, in.From, in.To); gerr == nil && e != nil {
-			accumulated = e.GetWeight()
-			readBack = true
-			if exp := client.EdgeExpiration(e); !exp.IsZero() {
-				expiresAt = exp.UTC().Format(time.RFC3339)
-			}
-		}
 		out := rememberRelationOutput{
 			From:              in.From,
 			To:                in.To,
@@ -82,12 +76,7 @@ func registerRememberRelation(srv *mcp.Server, lc lanternClient, r *ttl.Resolver
 			ExpiresAt:         expiresAt,
 			Capped:            capped,
 		}
-		var text string
-		if readBack {
-			text = fmt.Sprintf("Remembered relation %q -> %q (+%.2f, now %.2f total; bucket=%s, expires≈%s). Writes are additive — repeat to strengthen.", in.From, in.To, weight, accumulated, out.Bucket, out.ExpiresAt)
-		} else {
-			text = fmt.Sprintf("Remembered relation %q -> %q (+%.2f; bucket=%s, expires≈%s). Writes are additive — repeat to strengthen. (Could not read back the accumulated weight.)", in.From, in.To, weight, out.Bucket, out.ExpiresAt)
-		}
+		text := fmt.Sprintf("Remembered relation %q -> %q (+%.2f, now %.2f total; bucket=%s, expires≈%s). Writes are additive — repeat to strengthen.", in.From, in.To, weight, accumulated, out.Bucket, out.ExpiresAt)
 		if capped {
 			text += fmt.Sprintf(" Note: TTL clamped to the server cap (%s); re-remember before it expires to keep the relation alive.", d)
 		}

--- a/mcp/tool_remember_relation_test.go
+++ b/mcp/tool_remember_relation_test.go
@@ -8,7 +8,6 @@ import (
 
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	client "github.com/anaregdesign/lantern/sdks/go"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestRememberRelation_DefaultWeight(t *testing.T) {
@@ -24,10 +23,10 @@ func TestRememberRelation_DefaultWeight(t *testing.T) {
 	if out.Increment != 1 {
 		t.Fatalf("default increment = %v, want 1", out.Increment)
 	}
-	// With no edge to read back (default fake), the accumulated weight falls
-	// back to this write's increment.
+	// AccumulatedWeight now comes from AddEdge's effective_weight (#897); the
+	// default fake echoes the increment, so a single +1 write reports 1.
 	if out.AccumulatedWeight != 1 {
-		t.Fatalf("accumulated weight fallback = %v, want 1", out.AccumulatedWeight)
+		t.Fatalf("accumulated weight = %v, want 1", out.AccumulatedWeight)
 	}
 	if h.fake.lastEdgeTail != "a" || h.fake.lastEdgeHead != "b" {
 		t.Fatalf("edge args = (%s, %s)", h.fake.lastEdgeTail, h.fake.lastEdgeHead)
@@ -35,9 +34,9 @@ func TestRememberRelation_DefaultWeight(t *testing.T) {
 	if h.fake.lastEdgeTTL != 24*time.Hour {
 		t.Fatalf("TTL = %v, want 24h", h.fake.lastEdgeTTL)
 	}
-	// The handler must read the edge back by the exact endpoints it wrote.
-	if h.fake.lastGetEdgeTail != "a" || h.fake.lastGetEdgeHead != "b" {
-		t.Fatalf("GetEdge args = (%s, %s), want (a, b)", h.fake.lastGetEdgeTail, h.fake.lastGetEdgeHead)
+	// The obsolete GetEdge read-back (#897) must be gone — no TOCTOU window.
+	if h.fake.lastGetEdgeTail != "" || h.fake.lastGetEdgeHead != "" {
+		t.Fatalf("GetEdge was called (%s, %s) — the read-back is obsolete", h.fake.lastGetEdgeTail, h.fake.lastGetEdgeHead)
 	}
 }
 
@@ -105,17 +104,21 @@ func TestRememberRelation_TTLCappedToMaxTTL(t *testing.T) {
 	}
 }
 
-// TestRememberRelation_ReturnsAccumulatedWeight is the core #547 guard: after N
-// additive +1 writes the tool must report accumulated_weight = N (read back via
-// GetEdge), while increment stays at the per-write amount.
+// TestRememberRelation_ReturnsAccumulatedWeight is the core #547 guard, now
+// sourced from AddEdgeResponse.effective_weight (#897): after N additive +1
+// writes the tool must report accumulated_weight = N from AddEdge's return,
+// with NO GetEdge read-back (which reopened the TOCTOU window #897 closed).
 func TestRememberRelation_ReturnsAccumulatedWeight(t *testing.T) {
 	h := newTestHarness(t)
-	// Model additive accumulation: each remember_relation(+1) triggers exactly
-	// one GetEdge read-back, so the running total observed grows by 1 per call.
+	// Server-side accumulation arrives in AddEdgeResponse.effective_weight.
 	var total float32
+	h.fake.addEdgeEffectiveFn = func(_, _ string, weight float32) float32 {
+		total += weight
+		return total
+	}
+	// If the tool still read back via GetEdge it would see this poisoned value.
 	h.fake.getEdgeFn = func(_ context.Context, tail, head string) (*client.Edge, error) {
-		total++
-		return &pb.Edge{Tail: tail, Head: head, Weight: total}, nil
+		return &pb.Edge{Tail: tail, Head: head, Weight: 999}, nil
 	}
 	var lastText string
 	for i := 1; i <= 3; i++ {
@@ -131,30 +134,27 @@ func TestRememberRelation_ReturnsAccumulatedWeight(t *testing.T) {
 			t.Fatalf("write %d: increment = %v, want 1", i, out.Increment)
 		}
 		if out.AccumulatedWeight != float32(i) {
-			t.Fatalf("write %d: accumulated_weight = %v, want %d", i, out.AccumulatedWeight, i)
+			t.Fatalf("write %d: accumulated_weight = %v, want %d — must come from AddEdge's return, not a GetEdge read-back (999)", i, out.AccumulatedWeight, i)
 		}
 		lastText = contentText(res)
 	}
-	// The read-back must target the exact endpoints just written.
-	if h.fake.lastGetEdgeTail != "a" || h.fake.lastGetEdgeHead != "b" {
-		t.Fatalf("GetEdge args = (%s, %s), want (a, b)", h.fake.lastGetEdgeTail, h.fake.lastGetEdgeHead)
+	if h.fake.lastGetEdgeTail != "" || h.fake.lastGetEdgeHead != "" {
+		t.Fatalf("GetEdge was called (args %s,%s) — #897 made the read-back obsolete; the TOCTOU window is back", h.fake.lastGetEdgeTail, h.fake.lastGetEdgeHead)
 	}
-	// The accumulation read-back must surface in the human-readable text too.
 	if !strings.Contains(lastText, "now 3.00 total") {
 		t.Fatalf("text should report the accumulated total; got %q", lastText)
 	}
 }
 
-// TestRememberRelation_ReadBackUsesEdgeExpiry verifies the reported expires_at
-// reflects the stored edge's own expiration when the read-back succeeds.
-func TestRememberRelation_ReadBackUsesEdgeExpiry(t *testing.T) {
+// TestRememberRelation_ReportsOwnAtomicTotal is the concurrent-attribution
+// guard: AddEdge returns this call's own post-write live sum (3), while a
+// concurrent writer has since pushed the stored edge to 5. The tool must
+// report 3 — its own atomic total — never the poisoned read-back value.
+func TestRememberRelation_ReportsOwnAtomicTotal(t *testing.T) {
 	h := newTestHarness(t)
-	exp, err := time.Parse(time.RFC3339, "2031-02-03T04:05:06Z")
-	if err != nil {
-		t.Fatalf("parse time: %v", err)
-	}
+	h.fake.addEdgeEffectiveFn = func(_, _ string, _ float32) float32 { return 3 }
 	h.fake.getEdgeFn = func(_ context.Context, tail, head string) (*client.Edge, error) {
-		return &pb.Edge{Tail: tail, Head: head, Weight: 5, Expiration: timestamppb.New(exp)}, nil
+		return &pb.Edge{Tail: tail, Head: head, Weight: 5}, nil
 	}
 	res := h.call(t, "remember_relation", map[string]any{
 		"from": "a", "to": "b", "ttl": "day",
@@ -164,38 +164,32 @@ func TestRememberRelation_ReadBackUsesEdgeExpiry(t *testing.T) {
 	}
 	var out rememberRelationOutput
 	structuredAs(t, res, &out)
-	if out.AccumulatedWeight != 5 {
-		t.Fatalf("accumulated_weight = %v, want 5", out.AccumulatedWeight)
-	}
-	if out.ExpiresAt != "2031-02-03T04:05:06Z" {
-		t.Fatalf("expires_at = %q, want the edge's own expiry", out.ExpiresAt)
+	if out.AccumulatedWeight != 3 {
+		t.Fatalf("accumulated_weight = %v, want 3 (own atomic total, not the concurrent writer's 5)", out.AccumulatedWeight)
 	}
 }
 
-// TestRememberRelation_ReadBackFailureDegrades guards that a failed read-back
-// after a successful additive write does NOT fail the tool: the write already
-// landed, so the tool reports the increment as a best-effort accumulated value
-// and notes the read-back was unavailable.
-func TestRememberRelation_ReadBackFailureDegrades(t *testing.T) {
+// TestRememberRelation_ExpiresAtIsOwnHorizon pins the contract change from
+// #897: without the GetEdge read-back, expires_at is this write's own
+// now+TTL horizon (a "day" bucket → ~24h out), not the edge's latest
+// cross-contribution expiration. Tolerance-based; no exact clock match.
+func TestRememberRelation_ExpiresAtIsOwnHorizon(t *testing.T) {
 	h := newTestHarness(t)
-	h.fake.getEdgeFn = func(_ context.Context, _, _ string) (*client.Edge, error) {
-		return nil, client.ErrNotFound
-	}
+	before := time.Now()
 	res := h.call(t, "remember_relation", map[string]any{
-		"from": "a", "to": "b", "ttl": "day", "weight": 2,
+		"from": "a", "to": "b", "ttl": "day",
 	})
 	if res.IsError {
-		t.Fatalf("a failed read-back must not fail the write: text=%q", contentText(res))
+		t.Fatalf("IsError = true, text=%q", contentText(res))
 	}
 	var out rememberRelationOutput
 	structuredAs(t, res, &out)
-	if out.Increment != 2 {
-		t.Fatalf("increment = %v, want 2", out.Increment)
+	got, err := time.Parse(time.RFC3339, out.ExpiresAt)
+	if err != nil {
+		t.Fatalf("expires_at %q is not RFC3339: %v", out.ExpiresAt, err)
 	}
-	if out.AccumulatedWeight != 2 {
-		t.Fatalf("accumulated_weight fallback = %v, want 2 (the increment)", out.AccumulatedWeight)
-	}
-	if !strings.Contains(contentText(res), "Could not read back") {
-		t.Fatalf("text should note the read-back was unavailable; got %q", contentText(res))
+	want := before.Add(24 * time.Hour)
+	if diff := got.Sub(want); diff < -time.Minute || diff > time.Minute {
+		t.Fatalf("expires_at = %v, want ≈ now+24h (%v); off by %v", got, want, diff)
 	}
 }


### PR DESCRIPTION
## What

`remember_relation` reported the edge's live accumulated weight by issuing a **follow-up `GetEdge` read-back** after the additive `AddEdge`. This PR removes that read-back and sources the accumulated weight directly from `AddEdge`'s return value (`AddEdgeResponse.effective_weight`, added in #897).

## Why

- **Redundant round-trip.** Since #897, `AddEdge` returns the live accumulated weight after applying this contribution. The extra `GetEdge` was pure overhead.
- **TOCTOU / mis-attribution.** Between the write and the read-back, a concurrent writer could push the edge higher, so the tool would attribute *someone else's* weight to this call. Using `AddEdge`'s atomic post-own-write sum eliminates the window — the tool now always reports **its own** contribution's resulting total.

## Contract change

`expires_at` is now **this write's own `now + resolved-TTL` horizon**, not the edge's latest cross-contribution expiration observed by the (now-removed) read-back. This is the correct signal for "when does the contribution I just made decay"; the additive model means other concurrent contributions carry their own horizons.

## Changes

- `mcp/tool_remember_relation.go`: capture `accumulated, err := lc.AddEdge(...)`; drop the entire `GetEdge` read-back block and its degraded-fallback text branch; `AccumulatedWeight = accumulated`; `ExpiresAt = now + d`. Updated struct docs.
- `mcp/fake_lantern_test.go`: added `addEdgeEffectiveFn` hook so `AddEdge` can model the serving node's `effective_weight`.
- `mcp/tool_remember_relation_test.go`: rewrote `TestRememberRelation_ReturnsAccumulatedWeight` to drive accumulation via `AddEdge` (poisons `getEdgeFn` to prove it is never called); added `TestRememberRelation_ReportsOwnAtomicTotal` (concurrent-attribution guard: effective 3 vs stored 5 → reports 3); repurposed the old expiry test into `TestRememberRelation_ExpiresAtIsOwnHorizon` (pins `expires_at ≈ now+TTL`); updated `TestRememberRelation_DefaultWeight` to assert `GetEdge` is not called; removed the obsolete read-back-failure-degrades test.

## Gate

- `gofmt -l .` clean
- `(cd mcp && go test ./...)` green; module coverage 85.8% (floor 84%)
- root `go test ./...` green

Closes #921

---
Stacked on #929. Base retargets to main when #929 merges. Do not merge out of order.
