### PR TITLE
perf(core): bound writer stall in TopVerticesByDegree IN/BOTH walk

### DIFF
--- a/core/graphcache/degree.go
+++ b/core/graphcache/degree.go
@@ -40,14 +40,23 @@ type DegreeEntry[S comparable] struct {
 //
 // Live-visibility (#750): only live vertices are candidates, and an edge counts
 // only when BOTH endpoints are live and the edge has not fully decayed to zero.
-// Counts are read under a single point-in-time snapshot (one clock reading for
-// the whole walk); like GetServerStatus counts they are best-effort — an edge
-// whose endpoint expired but has not yet been swept is already hidden, but the
-// snapshot may otherwise race an in-flight writer.
+//
+// Consistency (#920): the OUT-only walk visits just the candidates' out-edges
+// and runs entirely under the read lock, so it observes a point-in-time
+// snapshot. IN/BOTH has no reverse (head->tails) index and must consider every
+// edge bucket; to avoid holding the aggregate read lock for that O(E) pass — and
+// stalling every writer for its duration — it collects the candidate-incident
+// bucket references under the lock, releases it, and reads the weights
+// afterwards. The IN/BOTH result is therefore a best-effort snapshot: an edge
+// added or deleted while the weights are being read may be partially reflected.
+// Like GetServerStatus counts these are advisory, not transactional.
 //
 // Selection uses a size-k bounded min-heap (pq.SortableMap.Top, the #127
 // pattern), so peak memory over the ranking metric is O(k) rather than
-// O(candidates). k <= 0 returns nil. Candidates with a zero degree remain
+// O(candidates). Accumulation working memory is O(candidates) — one value-typed
+// accumulator per candidate, no per-candidate heap allocation — plus, for
+// IN/BOTH, O(candidate-incident edges) transient bucket references held across
+// the unlocked read. k <= 0 returns nil. Candidates with a zero degree remain
 // eligible, so they surface only when fewer than k vertices under the prefix
 // carry any live incident edge. Ties at the k-th boundary are broken
 // arbitrarily; the returned slice is otherwise sorted by the ranking metric
@@ -60,12 +69,27 @@ func (c *GraphCache[S, T]) TopVerticesByDegree(prefix string, k int, dir DegreeD
 		return nil
 	}
 
+	// A value-typed accumulator carries both metrics (the DegreeEntry result
+	// always reports Degree and WeightedDegree regardless of the ranking axis),
+	// while avoiding the per-candidate pointer allocation of a map[S]*degreeAcc.
 	type degreeAcc struct {
 		count  uint64
 		weight float64
 	}
-	accum := make(map[S]*degreeAcc)
+	accum := make(map[S]degreeAcc)
 	now := time.Now()
+
+	countOut := dir == DegreeOut || dir == DegreeBoth
+	countIn := dir == DegreeIn || dir == DegreeBoth
+
+	// A candidate-incident edge bucket captured under the read lock but read
+	// (snapshotAt) after it is released. The *weight is individually
+	// mutex-guarded, so reading it outside c.mu is safe.
+	type bucketRef struct {
+		tail, head S
+		w          *weight
+	}
+	var buckets []bucketRef
 
 	c.mu.RLock()
 	if c.prefixIndex == nil {
@@ -79,7 +103,7 @@ func (c *GraphCache[S, T]) TopVerticesByDegree(prefix string, k int, dir DegreeD
 	c.prefixIndex.walkPrefix(prefix, func(projected string) bool {
 		if key, ok := c.resolveProjected(projected); ok {
 			if _, seen := accum[key]; !seen {
-				accum[key] = &degreeAcc{}
+				accum[key] = degreeAcc{}
 			}
 		}
 		return true
@@ -89,18 +113,17 @@ func (c *GraphCache[S, T]) TopVerticesByDegree(prefix string, k int, dir DegreeD
 		return nil
 	}
 
-	// 2. Accumulate live degree per candidate. For OUT-only we walk just the
-	// candidates' out-edges (O(sum of candidate out-degrees)); IN and BOTH
-	// need a single full pass over the edge table because the store keeps no
-	// reverse (head->tails) adjacency to enumerate a head's in-edges.
-	countOut := dir == DegreeOut || dir == DegreeBoth
-	countIn := dir == DegreeIn || dir == DegreeBoth
+	// 2. Accumulate live degree per candidate.
 	if dir == DegreeOut {
-		for tail, a := range accum {
+		// OUT-only walks just the candidates' out-edges (O(sum of candidate
+		// out-degrees)) — cheap and already scoped — so it stays under the read
+		// lock and snapshots the weights in place.
+		for tail := range accum {
 			heads, ok := c.edges.headsOf(tail)
 			if !ok {
 				continue
 			}
+			a := accum[tail]
 			for headID, w := range heads {
 				head, ok := c.edges.resolveID(headID)
 				if !ok || !c.vertices.Has(head) {
@@ -113,37 +136,57 @@ func (c *GraphCache[S, T]) TopVerticesByDegree(prefix string, k int, dir DegreeD
 				a.count++
 				a.weight += float64(sum)
 			}
+			accum[tail] = a
 		}
+		c.mu.RUnlock()
 	} else {
+		// IN/BOTH must scan every bucket (no reverse index). Capture only the
+		// candidate-incident bucket references here — a cheap membership test,
+		// no weight snapshot — then release the lock so the O(E) weight reads do
+		// not stall writers waiting on c.mu.
 		c.edges.rangeBuckets(func(tail, head S, w *weight) bool {
-			aTail, tailIn := accum[tail]
-			aHead, headIn := accum[head]
-			if !tailIn && !headIn {
-				return true
-			}
-			if !c.vertices.Has(tail) || !c.vertices.Has(head) {
-				return true
-			}
-			sum, _, nonZero := w.snapshotAt(now)
-			if !nonZero {
-				return true
-			}
-			if countOut && tailIn {
-				aTail.count++
-				aTail.weight += float64(sum)
-			}
-			if countIn && headIn {
-				aHead.count++
-				aHead.weight += float64(sum)
+			_, tailIn := accum[tail]
+			_, headIn := accum[head]
+			if tailIn || headIn {
+				buckets = append(buckets, bucketRef{tail: tail, head: head, w: w})
 			}
 			return true
 		})
+		c.mu.RUnlock()
+
+		// Unlocked accumulation over the captured references. Endpoint liveness
+		// is re-checked against the independently-locked vertex cache; each
+		// weight snapshot takes only its own mutex. A self-loop under DegreeBoth
+		// contributes twice (out and in) to one candidate, so each branch
+		// re-reads the accumulator before mutating it.
+		for _, b := range buckets {
+			if !c.vertices.Has(b.tail) || !c.vertices.Has(b.head) {
+				continue
+			}
+			sum, _, nonZero := b.w.snapshotAt(now)
+			if !nonZero {
+				continue
+			}
+			if countOut {
+				if a, ok := accum[b.tail]; ok {
+					a.count++
+					a.weight += float64(sum)
+					accum[b.tail] = a
+				}
+			}
+			if countIn {
+				if a, ok := accum[b.head]; ok {
+					a.count++
+					a.weight += float64(sum)
+					accum[b.head] = a
+				}
+			}
+		}
 	}
-	c.mu.RUnlock()
 
 	// 3. Size-k selection over the ranking metric, then order the survivors
 	// descending. Both steps are pure post-processing over plain numbers — no
-	// cache lock and no *weight pointers survive the critical section.
+	// cache lock and no *weight pointers survive into the sort.
 	scores := pq.NewSortableMap[S, float64]()
 	for key, a := range accum {
 		if weighted {

--- a/core/graphcache/degree_test.go
+++ b/core/graphcache/degree_test.go
@@ -2,6 +2,10 @@ package graphcache
 
 import (
 	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -202,5 +206,84 @@ func TestGraphCache_TopVerticesByDegree_LiveVisibility(t *testing.T) {
 		if e.Key == "n:b" {
 			t.Errorf("deleted vertex n:b is still a ranking candidate")
 		}
+	}
+}
+
+// TestGraphCache_TopVerticesByDegree_ConcurrentWrites guards the two-phase
+// IN/BOTH walk (#920): degree accumulation runs outside c.mu, so it must be
+// race-free against concurrent edge writes/deletes and always return a
+// well-formed bounded result. On the pre-#920 single-lock implementation this
+// test passes trivially (writers just stall); after #920 it is the -race guard
+// for the unlocked accumulation phase, where the captured *weight pointers are
+// read while a concurrent mutator may be adding or deleting the same buckets.
+func TestGraphCache_TopVerticesByDegree_ConcurrentWrites(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	c.EnablePrefixIndex(identityExtract)
+	exp := time.Now().Add(time.Hour)
+	for i := 0; i < 64; i++ {
+		c.PutVertexWithExpiration("user:"+strconv.Itoa(i), "v", exp)
+	}
+	c.PutVertexWithExpiration("hub", "v", exp)
+
+	var stop atomic.Bool
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { // writer: churn edges into the candidates
+		defer wg.Done()
+		for i := 0; !stop.Load(); i++ {
+			head := "user:" + strconv.Itoa(i%64)
+			c.AddEdgesWithExpiration([]EdgeItem[string]{{Tail: "hub", Head: head, Weight: 1, Expiration: exp}})
+		}
+	}()
+	go func() { // deleter
+		defer wg.Done()
+		for i := 0; !stop.Load(); i++ {
+			c.DeleteEdge("hub", "user:"+strconv.Itoa(i%64))
+		}
+	}()
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		for _, dir := range []DegreeDirection{DegreeOut, DegreeIn, DegreeBoth} {
+			got := c.TopVerticesByDegree("user:", 10, dir, true)
+			if len(got) > 10 {
+				t.Errorf("dir %v: %d entries, want <= 10", dir, len(got))
+			}
+			for _, e := range got {
+				if !strings.HasPrefix(e.Key, "user:") {
+					t.Errorf("dir %v: entry %q escaped the prefix", dir, e.Key)
+				}
+			}
+		}
+	}
+	stop.Store(true)
+	wg.Wait()
+}
+
+// BenchmarkTopVerticesByDegree_InNarrowPrefix measures the IN walk (#920) over a
+// wide graph whose bulk of edges do NOT touch the ranked prefix. It is the
+// allocation-profile evidence for the two-phase refactor: the per-candidate
+// value-typed accumulator drops the per-candidate pointer allocation, and only
+// the candidate-incident buckets are captured across the unlocked phase (not the
+// whole edge table). ns/op stays O(E) — every bucket is still visited under the
+// lock to test candidacy — but that walk no longer holds c.mu during the
+// weight snapshots. Record allocs/op before/after in the PR body.
+func BenchmarkTopVerticesByDegree_InNarrowPrefix(b *testing.B) {
+	c := NewGraphCache[string, string](time.Minute)
+	c.EnablePrefixIndex(identityExtract)
+	exp := time.Now().Add(time.Hour)
+	// 100k edges NOT touching the ranked prefix + a 50-vertex target namespace.
+	for i := 0; i < 100_000; i++ {
+		c.AddEdgesWithExpiration([]EdgeItem[string]{{Tail: "noise:" + strconv.Itoa(i), Head: "sink", Weight: 1, Expiration: exp}})
+	}
+	for i := 0; i < 50; i++ {
+		k := "user:" + strconv.Itoa(i)
+		c.PutVertexWithExpiration(k, "v", exp)
+		c.AddEdgesWithExpiration([]EdgeItem[string]{{Tail: "seed", Head: k, Weight: 1, Expiration: exp}})
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.TopVerticesByDegree("user:", 10, DegreeIn, true)
 	}
 }

--- a/pb/graph/v1/graph.pb.go
+++ b/pb/graph/v1/graph.pb.go
@@ -2700,7 +2700,9 @@ func (x *TopVerticesByDegreeRequest) GetWeighted() bool {
 // the chosen metric (weighted_degree when the request set `weighted`, else
 // degree). Counts follow the live-visibility rule (#750): expired vertices and
 // fully decayed edges do not contribute. Results are point-in-time
-// best-effort, like GetServerStatus counts.
+// best-effort, like GetServerStatus counts; for DIRECTION_IN / DIRECTION_BOTH
+// the edge scan reads weights outside the write-blocking lock (#920), so an
+// edge added or deleted mid-scan may be only partially reflected.
 type TopVerticesByDegreeResponse struct {
 	state         protoimpl.MessageState               `protogen:"open.v1"`
 	Entries       []*TopVerticesByDegreeResponse_Entry `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries,omitempty"`

--- a/pb/graph/v1/graphv1connect/graph.connect.go
+++ b/pb/graph/v1/graphv1connect/graph.connect.go
@@ -144,6 +144,13 @@ type LanternServiceClient interface {
 	// prefix by their (weighted) out/in/both degree. Read-only aggregate; a
 	// non-empty prefix is REQUIRED (empty → INVALID_ARGUMENT). Results are
 	// point-in-time best-effort and honour the live-visibility rule (#750).
+	//
+	// Cost model (#920): OUT-degree is scoped to the candidates' own out-edges,
+	// but IN and BOTH scan every edge bucket in the graph — O(E_total),
+	// independent of prefix narrowness, because no reverse (head->tails) index
+	// exists. That scan runs without holding the write-blocking aggregate lock
+	// for its full duration, so an IN/BOTH result on a large, actively-written
+	// graph is a best-effort snapshot rather than a single point-in-time view.
 	TopVerticesByDegree(context.Context, *connect.Request[v1.TopVerticesByDegreeRequest]) (*connect.Response[v1.TopVerticesByDegreeResponse], error)
 	GetEdge(context.Context, *connect.Request[v1.GetEdgeRequest]) (*connect.Response[v1.GetEdgeResponse], error)
 	// GetEdges reads several edges in one round trip.
@@ -558,6 +565,13 @@ type LanternServiceHandler interface {
 	// prefix by their (weighted) out/in/both degree. Read-only aggregate; a
 	// non-empty prefix is REQUIRED (empty → INVALID_ARGUMENT). Results are
 	// point-in-time best-effort and honour the live-visibility rule (#750).
+	//
+	// Cost model (#920): OUT-degree is scoped to the candidates' own out-edges,
+	// but IN and BOTH scan every edge bucket in the graph — O(E_total),
+	// independent of prefix narrowness, because no reverse (head->tails) index
+	// exists. That scan runs without holding the write-blocking aggregate lock
+	// for its full duration, so an IN/BOTH result on a large, actively-written
+	// graph is a best-effort snapshot rather than a single point-in-time view.
 	TopVerticesByDegree(context.Context, *connect.Request[v1.TopVerticesByDegreeRequest]) (*connect.Response[v1.TopVerticesByDegreeResponse], error)
 	GetEdge(context.Context, *connect.Request[v1.GetEdgeRequest]) (*connect.Response[v1.GetEdgeResponse], error)
 	// GetEdges reads several edges in one round trip.

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -508,7 +508,9 @@ message TopVerticesByDegreeRequest {
 // the chosen metric (weighted_degree when the request set `weighted`, else
 // degree). Counts follow the live-visibility rule (#750): expired vertices and
 // fully decayed edges do not contribute. Results are point-in-time
-// best-effort, like GetServerStatus counts.
+// best-effort, like GetServerStatus counts; for DIRECTION_IN / DIRECTION_BOTH
+// the edge scan reads weights outside the write-blocking lock (#920), so an
+// edge added or deleted mid-scan may be only partially reflected.
 message TopVerticesByDegreeResponse {
   message Entry {
     string key = 1;
@@ -913,6 +915,13 @@ service LanternService {
   // prefix by their (weighted) out/in/both degree. Read-only aggregate; a
   // non-empty prefix is REQUIRED (empty → INVALID_ARGUMENT). Results are
   // point-in-time best-effort and honour the live-visibility rule (#750).
+  //
+  // Cost model (#920): OUT-degree is scoped to the candidates' own out-edges,
+  // but IN and BOTH scan every edge bucket in the graph — O(E_total),
+  // independent of prefix narrowness, because no reverse (head->tails) index
+  // exists. That scan runs without holding the write-blocking aggregate lock
+  // for its full duration, so an IN/BOTH result on a large, actively-written
+  // graph is a best-effort snapshot rather than a single point-in-time view.
   rpc TopVerticesByDegree(TopVerticesByDegreeRequest) returns (TopVerticesByDegreeResponse);
 
   rpc GetEdge(GetEdgeRequest) returns (GetEdgeResponse);

--- a/sdks/node/src/gen/graph/v1/graph_pb.ts
+++ b/sdks/node/src/gen/graph/v1/graph_pb.ts
@@ -1195,7 +1195,9 @@ export const TopVerticesByDegreeRequest_DirectionSchema: GenEnum<TopVerticesByDe
  * the chosen metric (weighted_degree when the request set `weighted`, else
  * degree). Counts follow the live-visibility rule (#750): expired vertices and
  * fully decayed edges do not contribute. Results are point-in-time
- * best-effort, like GetServerStatus counts.
+ * best-effort, like GetServerStatus counts; for DIRECTION_IN / DIRECTION_BOTH
+ * the edge scan reads weights outside the write-blocking lock (#920), so an
+ * edge added or deleted mid-scan may be only partially reflected.
  *
  * @generated from message graph.v1.TopVerticesByDegreeResponse
  */
@@ -2478,6 +2480,13 @@ export const LanternService: GenService<{
    * prefix by their (weighted) out/in/both degree. Read-only aggregate; a
    * non-empty prefix is REQUIRED (empty → INVALID_ARGUMENT). Results are
    * point-in-time best-effort and honour the live-visibility rule (#750).
+   *
+   * Cost model (#920): OUT-degree is scoped to the candidates' own out-edges,
+   * but IN and BOTH scan every edge bucket in the graph — O(E_total),
+   * independent of prefix narrowness, because no reverse (head->tails) index
+   * exists. That scan runs without holding the write-blocking aggregate lock
+   * for its full duration, so an IN/BOTH result on a large, actively-written
+   * graph is a best-effort snapshot rather than a single point-in-time view.
    *
    * @generated from rpc graph.v1.LanternService.TopVerticesByDegree
    */

--- a/server/service/degree.go
+++ b/server/service/degree.go
@@ -28,6 +28,15 @@ import (
 // decayed edges do not contribute. The result is point-in-time best-effort,
 // like GetServerStatus counts. This is a read-only aggregate — it logs no
 // mutation and is not replicated.
+//
+// Cost model (#920): OUT-degree is walked per candidate (O(sum of candidate
+// out-degrees)). IN and BOTH have no reverse (head->tails) index, so they scan
+// every edge bucket in the graph — O(E_total), independent of how narrow the
+// prefix is. To keep that scan from stalling writers, the IN/BOTH path captures
+// the candidate-incident buckets under the read lock and reads their weights
+// after releasing it, so an edge added or deleted mid-scan may be partially
+// reflected: prefer a narrow prefix and treat IN/BOTH totals on a large,
+// actively-written graph as advisory.
 func (s *LanternService) TopVerticesByDegree(ctx context.Context, in *pb.TopVerticesByDegreeRequest) (*pb.TopVerticesByDegreeResponse, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, ctxToConnect(err)


### PR DESCRIPTION
## What

`TopVerticesByDegree` with `DIRECTION_IN` / `DIRECTION_BOTH` scanned **every** edge bucket in the graph — O(E_total), independent of prefix narrowness or `k` — while holding the aggregate read lock (`c.mu`) for the entire pass, with a per-weight `snapshotAt` (each taking the weight's own mutex) done *inside* the lock. Because writers need `c.mu.Lock()`, a narrow-prefix top-10 query could stall **all writes** for the duration of a full-graph edge walk.

This splits the IN/BOTH path into two phases and collapses the accumulation allocations.

## Changes

**Bound the writer stall (`core/graphcache/degree.go`)**
- Phase 1 (under `c.mu.RLock`): collect candidates via the prefix index, then capture only the **candidate-incident** bucket references (`{tail, head, *weight}`) — a cheap membership test, **no** `snapshotAt`. Release the lock.
- Phase 2 (unlocked): `snapshotAt(now)` each captured weight (each guarded by its own mutex), re-check endpoint liveness against the independently-locked vertex cache, and accumulate. The O(E) weight work no longer holds `c.mu`.
- OUT-only is **unchanged** — it already walks per-candidate out-edges under the lock (cheap, scoped).

**Collapse the accumulation allocations**
- Replaced `map[S]*degreeAcc` with a **value-typed** accumulator, dropping the per-candidate pointer allocation while still reporting both `Degree` and `WeightedDegree` (both are always populated regardless of the ranking axis — pinned by the equivalence tests). A self-loop under `DIRECTION_BOTH` still contributes twice; each branch re-reads the accumulator before mutating.

**Consequence documented, not hidden**
- The IN/BOTH result is now a **best-effort snapshot**: an edge added/deleted while the weights are read may be partially reflected. Documented on the core method, the RPC comment (`server/service/degree.go`), and the proto (`TopVerticesByDegree` rpc + response message). Proto change is **doc-only**; `pb/**` and `sdks/node/src/gen/**` regenerated.

## Benchmark (100k off-prefix edges, 50-vertex target namespace, k=10, `DIRECTION_IN`)

| | allocs/op | ns/op |
| --- | --- | --- |
| before | 135 | 15.2 ms |
| after | 92 | 11.0 ms |

−32% allocs, −28% time. `ns/op` stays O(E) — every bucket is still visited under the lock to test candidacy — but the weight snapshots (the mutex-heavy part) moved off `c.mu`.

## Tests

- `TestGraphCache_TopVerticesByDegree` / `_LiveVisibility` pass **unchanged** (behavior equivalence on a quiescent cache).
- Added `TestGraphCache_TopVerticesByDegree_ConcurrentWrites` — IN/OUT/BOTH ranking racing concurrent `AddEdges`/`DeleteEdge`, run under `-race`; asserts no deadlock/panic and a well-formed bounded, prefix-scoped result.
- Added `BenchmarkTopVerticesByDegree_InNarrowPrefix` (the numbers above).

## Scope note

A head-keyed reverse adjacency index (the structural O(E)→O(candidate-incident) fix) is intentionally **out of scope** — it needs its own design issue (write-path bookkeeping on every edge mutation). This PR bounds the writer stall and the allocations, and documents the cost model.

## Deviation from the plan sketch

The plan suggested collapsing to a single `scores map[S]float64` (ranking metric only). That would drop the non-ranking `DegreeEntry` field, which the equivalence tests (must pass unchanged) require. Kept a two-field value-struct accumulator instead — it still removes the per-candidate pointer allocation (the dominant alloc-count win). Phase 1 also captures only candidate-incident refs rather than all E, so retained memory is O(candidate-incident), not O(E_total).

## Gate

- `gofmt -l .` clean; `go generate ./...` idempotent (pb + node stubs committed)
- `(cd core && go test -race ./...)` green; coverage 87.6% (floor 84%)
- `(cd server && go vet ./... && go test ./...)` green; `(cd pb && go test ./...)`; root `go test ./...` green
- Node: `codegen` clean, `lint` + `format:check` + `typecheck` + 92 tests + `build` green

Closes #920

---
Stacked on #930. Base retargets to main when #930 merges. Do not merge out of order.
