### PR TITLE
test(bench,tests,docs): perf-gate floors, schema-drift gate, AddEdges/TTL integration tests, testing DoD

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -1,13 +1,15 @@
 name: Bench (nightly leak gate)
 
-# Nightly BLOCKING leak gate. Runs the same compact scenario sweep as the
-# release-time bench (testbed/bench/release-scenarios.txt) against a
+# Nightly BLOCKING leak + perf gate. Runs the same compact scenario sweep as
+# the release-time bench (testbed/bench/release-scenarios.txt) against a
 # freshly-built lantern:local image, but — unlike the release bench, which is
 # deliberately `continue-on-error` so a hiccup can never block shipping
 # (#256, #394) — this job has NO continue-on-error. release.sh exits non-zero
-# when any scenario's goroutine/heap leak gate trips, so a leak regression
-# fails this required check rather than merely warning in an advisory artifact.
-# This is the enforcement half of #716.
+# when any scenario's goroutine/heap leak gate trips OR any scenario's
+# perf_gate floors (min steady rps / max p99 / max non-OK ratio, #935) are
+# breached, so a leak or step-change performance regression fails this
+# nightly check rather than merely warning in an advisory artifact.
+# This is the enforcement half of #716 (leaks) and #935 (perf floors).
 #
 # It also runs with RELEASE_BENCH_BUDGET_SECONDS=0 (the sweep's graceful
 # wall-clock cutoff disabled), so every scenario runs to completion and no leak

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,20 @@ CI: [.github/workflows/go.yml](.github/workflows/go.yml) runs `go build` + `go t
 - **wire and generics**: as the `// Avoiding bug of 'wire'. Generic type is not supported.` comment in `service.go` notes, wire cannot handle generic type arguments, so the provider returns the concrete `GraphCache[string, *Vertex]`. Re-check this constraint before trying to introduce generics there.
 - **Regenerating proto**: `go_package_prefix` in `buf.gen.yaml` is `github.com/anaregdesign/lantern/pb`, so the generated files land **inside the standalone `pb/` module** at `pb/graph/v1`. `go generate ./...` (or `make proto`) runs `buf generate` and rebuilds everything under `pb/`. **Do NOT pass `--clean`** — `buf`'s output root is `pb/`, and `--clean` would delete `pb/go.mod` and `pb/doc.go` along with the stubs. `buf.yaml` (v2 workspace) and `buf.gen.yaml` live at the repo root. `buf` does not need to be installed locally — the directive in [generate.go](generate.go) falls back to running buf via `go run` at the version pinned there (mirrored as `BUF_VERSION` in the Makefile — bump both together). Treat `pb/` as generated-only — never hand-edit, never add domain code there.
 - **Multi-module layout**: the workspace modules are stitched together for local dev via [go.work](go.work) and via `replace` directives in each importing module's `go.mod`. When adding a dep, place it in the module that actually uses it (e.g. server-only middleware → `server/go.mod`; client transport → `sdks/go/go.mod`; cli/integration-test only → root `go.mod`). After dependency changes run `go mod tidy` in **every** affected module. The `tool github.com/google/wire/cmd/wire` directive lives in `server/go.mod` (not root), so wire regen must be run from `server/`.
-- **Test gaps**: there are no tests for the server/service layer, wire wiring, or client transport paths. For non-trivial changes, **add at least a minimal table test in the same PR**.
+- **External-surface testing policy (Definition of Done)** — canonical text in
+  [CONTRIBUTING.md](CONTRIBUTING.md) "External-surface testing policy". The always-on
+  summary: every PR that adds or changes externally observable behaviour (RPC surface,
+  SDKs, CLI grammar, MCP tools, `LANTERN_*` env contract, TTL/decay semantics) ships —
+  in the same PR — an integration test in `tests/integration/` over the real
+  Connect/h2c wire path covering the happy path plus at least one failure/edge
+  contract; perf-relevant hot paths also join a bench scenario in
+  `testbed/bench/scenarios/` (the release-sweep scenarios carry `perf_gate:`
+  throughput/latency floors enforced by the blocking nightly — sizing and
+  re-baselining rules in [testbed/bench/README.md](testbed/bench/README.md)). Bench
+  scenario templates are schema-checked against the proto surface by
+  `testbed/bench/scenarios_gate_test.go` at ordinary root `go test ./...` time, so a
+  wire-schema change must migrate the scenarios that send retired fields in the same
+  PR (#934).
 
 ## Docs / Links
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ Multi-module Go workspace ([go.work](go.work)); dependency direction is a DAG wi
 ## Workflow (hard rules)
 
 - **File a GitHub Issue before any non-trivial change** (exceptions: doc-only edits, in-flight PR-review follow-ups, one-line obvious fixes). PR closes it with one keyword per issue: `Closes #1, closes #2`.
+- **External-surface Definition of Done**: a PR that adds/changes the RPC surface, SDKs, CLI grammar, MCP tools, `LANTERN_*` env contract, or TTL/decay semantics ships an integration test in `tests/integration/` (real wire path; happy + failure/edge case) in the same PR; perf-relevant hot paths also join a bench scenario (`testbed/bench/scenarios/` — release-sweep scenarios carry `perf_gate:` floors gating the nightly). Wire-schema changes must migrate the bench scenario templates in the same PR (`testbed/bench/scenarios_gate_test.go` enforces this in root `go test ./...`). Canonical: CONTRIBUTING.md "External-surface testing policy".
 - **PR titles must be Conventional Commits** (`feat`/`fix`/`docs`/`chore`/`ci`/`refactor`/`perf`/`test`/`build`/`revert`) — a required check rejects others.
 - Wait for all required CI checks; never `--admin`/`--no-verify`; merge `--squash --delete-branch`; never push to `main` directly.
 - When work surfaces a fact another open Issue needs, comment it on that Issue in the same session (format in CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,43 @@ go tool cover -func=/tmp/cov.out | tail -1   # the `total:` line
 If a PR legitimately lowers a floor (e.g. deleting a well-covered package), say so in
 the PR body and update both the workflow and this table together.
 
+## External-surface testing policy (Definition of Done)
+
+Lantern is a database; its externally observable behaviour — the RPC surface, the
+Go/Node SDKs, the CLI grammar, the MCP tools, the `LANTERN_*` env contract, and the
+TTL/decay semantics — must not regress silently. Every PR that adds or changes any
+of that surface ships, **in the same PR**:
+
+1. **An integration test over the real wire path.** New or changed RPCs, SDK
+   methods, CLI verbs, and MCP tools get coverage in `tests/integration/` — a
+   Connect/h2c round-trip through the SDK, or the raw generated client for surface
+   the SDK does not wrap — asserting the happy path AND at least one failure/edge
+   contract (NotFound sentinel, batch partial-miss, chunking, TTL expiry,
+   idempotent retry, ...). Unit tests in the owning module complement but do not
+   replace this: the wire path is where the singular→plural facades, validation
+   interceptors, and codec behaviour actually live.
+2. **Bench coverage for perf-relevant paths.** A change on a hot path (reads,
+   writes, scans, traversals, streams) joins an existing scenario fan-out in
+   `testbed/bench/scenarios/` or gets a new scenario. The release-sweep scenarios
+   carry `perf_gate:` floors (min steady rps / max p99 / max non-OK ratio) enforced
+   by the blocking nightly (`bench-nightly.yml`); sizing and re-baselining rules
+   live in [testbed/bench/README.md](testbed/bench/README.md). Perf floors are a
+   ratchet like the coverage floors: when a PR legitimately moves one (an accepted
+   performance trade-off), adjust the floor in the same PR and say so in the PR
+   body.
+3. **Wire-schema changes keep the bench templates green.** The root
+   `go test ./...` includes `testbed/bench/scenarios_gate_test.go`, which renders
+   every scenario `data_template` and validates it against the current proto
+   schema. If you retire or rename a wire field, migrate every scenario that sends
+   it in the same PR (#934 — six Illuminate scenarios silently broke and the
+   nightly went red — is the cautionary tale).
+4. **Coverage floors hold** (previous section) and the pre-push quality gate
+   passes.
+
+Exemptions: doc-only changes, and pure refactors with no wire-visible behaviour
+change (still subject to the coverage ratchet). When in doubt, add the integration
+test.
+
 ## Before merging a PR
 
 - Wait for **all required checks** green. Never use `--admin` or `--no-verify`. One PR

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/net v0.56.0
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/testbed/bench/README.md
+++ b/testbed/bench/README.md
@@ -64,8 +64,9 @@ SKIP_UP=1 KEEP_UP=1 ./testbed/bench/run.sh mixed_rw
 PPROF_CPU=1 ./testbed/bench/run.sh addedge_contention
 ```
 
-The exit code mirrors the leak-gate verdict (`0`=pass, `1`=fail). Run
-artifacts are written under
+The exit code folds together the leak-gate verdict and — when the
+scenario declares a `perf_gate:` block — the perf-gate verdict
+(`0` = both pass, `1` = either failed). Run artifacts are written under
 `testbed/bench/out/<scenario>/<UTC-timestamp>/`.
 
 ## Scenarios
@@ -106,12 +107,59 @@ default TTL for cache-default paths; it does not rewrite explicit RPC payloads.
 Scenarios that need decay through `ghz` should include an `expiration` template
 in `data_template`.
 
+Every `data_template` is schema-checked at ordinary `go test ./...` time by
+`testbed/bench/scenarios_gate_test.go`: it renders each template with
+ghz-style data and protojson-unmarshals the result against the request
+message resolved from the `call` name, so a proto change that orphans a
+scenario fails the schema PR instead of the next nightly (#934). If you
+retire or rename a wire field, migrate every scenario that sends it in the
+same PR.
+
+### Perf gate (`perf_gate:` block)
+
+A scenario MAY additionally declare throughput/latency floors over its
+steady-phase producers (#935):
+
+```yaml
+perf_gate:
+  min_steady_rps_total: 1500   # floor on SUM of producer rps
+  max_p99_ms: 500              # ceiling on the WORST producer p99
+  max_non_ok_ratio: 0.02       # ceiling on Σnon-OK / Σcount
+```
+
+Every key is individually optional — gate only the metrics that are stable
+for the scenario. The aggregation matches the release summary table
+(`testbed/bench/release`), the verdict lands in `perf_gate.json`, and a
+`fail` folds into run.sh's exit code exactly like the leak gate: the
+blocking nightly (`bench-nightly.yml`) enforces it, the release-time bench
+stays advisory (`continue-on-error`, #256/#394).
+
+Sizing rules (all seven release scenarios carry a block sized this way):
+
+- Floors are **ratchet floors with ≥2x headroom** over the worst nightly
+  baseline — they exist to catch step-change regressions (accidental O(n²),
+  lock convoy, a dropped fan-out), NOT single-digit-% drift, which shared
+  `ubuntu-latest` runners cannot resolve. Do not tighten them to "just below
+  last night's number".
+- **Gate p99 only where it is stable.** Scenarios whose offered load
+  deliberately saturates the runner (`broad_rw`, `broad_mutate`) have
+  queue-depth p99 — observed varying 7x night-over-night — so they gate rps
+  and non-OK only.
+- **Re-baseline after changing a scenario's mix.** Adding/removing a
+  `target.calls` entry re-splits per-call rps and shifts every observed
+  metric; drop the affected ceilings in the same PR and restore them (from
+  fresh nightly numbers, with headroom) after a few green nightlies.
+- When a perf floor legitimately moves (accepted throughput/latency
+  trade-off), adjust it **in the same PR** and say so in the PR body — same
+  contract as the coverage-floor ratchet in CONTRIBUTING.md.
+
 ## Output layout
 
 ```
 testbed/bench/out/<scenario>/<ts>/
 ├── report.md                       # rendered summary (start here)
 ├── leak_gate.json                  # verdict + per-replica deltas + thresholds
+├── perf_gate.json                  # perf verdict + thresholds + observed (only when perf_gate: declared)
 ├── runtime_pre.json                # per-replica go_goroutines + heap_alloc/heap_inuse/heap_objects, after warmup
 ├── runtime_post.json               # same, after cooldown
 ├── ghz_warmup_<endpoint>.json      # raw ghz results, one per invocation

--- a/testbed/bench/release-scenarios.txt
+++ b/testbed/bench/release-scenarios.txt
@@ -7,8 +7,9 @@
 # never block a release (the deliberate design of #256, #394). The SAME sweep
 # ALSO runs nightly via `.github/workflows/bench-nightly.yml` WITHOUT
 # continue-on-error and with RELEASE_BENCH_BUDGET_SECONDS=0 (no truncation), so
-# a goroutine/heap-leak regression fails a required check there rather than
-# merely warning in an advisory artifact (#716). Rather than run ~16
+# a goroutine/heap-leak regression (#716) or a perf-floor breach (each scenario
+# below carries a `perf_gate:` block — see testbed/bench/README.md, #935) fails
+# a nightly check there rather than merely warning in an advisory artifact. Rather than run ~16
 # single-call scenarios (which paid per-scenario fixed overhead — warmup +
 # pre/post runtime+pprof snapshots + cooldown + 12 Prometheus range queries +
 # report render — for each call path), the sweep is compacted to SEVEN
@@ -81,8 +82,9 @@
 # read / write / scan / edge / delete call surface (12-way fan-out, #708)
 broad_rw
 
-# graph traversal across the orthogonal axes (4-way fan-out) — runs AFTER
-# broad_rw so the k-* graph it traverses is populated.
+# graph traversal across the params-oneof families (BFS variants + PPR +
+# local community; 6-way fan-out) — runs AFTER broad_rw so the k-* graph it
+# traverses is populated.
 broad_illuminate
 
 # edge SET / plural-add / delete / prefix-delete / backup surface (9-way

--- a/testbed/bench/release/main.go
+++ b/testbed/bench/release/main.go
@@ -55,6 +55,13 @@ type leakGate struct {
 	Verdict string `json:"verdict"`
 }
 
+// perfGate mirrors the subset of testbed/bench/report.PerfGate the summary
+// table needs (run.sh only writes perf_gate.json when the scenario declares
+// a `perf_gate:` block — absent file renders as "—").
+type perfGate struct {
+	Verdict string `json:"verdict"`
+}
+
 // ghzSummary mirrors the subset of testbed/bench/report.GhzSummary that
 // the summary table needs.
 type ghzSummary struct {
@@ -77,10 +84,11 @@ type scenarioInput struct {
 
 // summaryRow is the rendered values for one row in the Summary table.
 type summaryRow struct {
-	Verdict string // "pass", "fail", or "(failed)" if artifacts are missing
-	Rps     string // pre-formatted, e.g. "5000.0" or "—"
-	P99ms   string // pre-formatted, e.g. "0.89" or "—"
-	NonOK   string // pre-formatted, e.g. "0" or "—"
+	Verdict     string // "pass", "fail", or "(failed)" if artifacts are missing
+	PerfVerdict string // "pass", "fail", or "—" when the scenario gates no perf metric
+	Rps         string // pre-formatted, e.g. "5000.0" or "—"
+	P99ms       string // pre-formatted, e.g. "0.89" or "—"
+	NonOK       string // pre-formatted, e.g. "0" or "—"
 }
 
 // Header carries the fixed-format report header fields.
@@ -92,7 +100,7 @@ type Header struct {
 }
 
 func loadScenario(name, dir string) scenarioInput {
-	in := scenarioInput{Name: name, Dir: dir, Row: summaryRow{Verdict: "(failed)", Rps: "—", P99ms: "—", NonOK: "—"}}
+	in := scenarioInput{Name: name, Dir: dir, Row: summaryRow{Verdict: "(failed)", PerfVerdict: "—", Rps: "—", P99ms: "—", NonOK: "—"}}
 	if dir == "" {
 		return in
 	}
@@ -102,6 +110,14 @@ func loadScenario(name, dir string) scenarioInput {
 		var lg leakGate
 		if err := json.Unmarshal(b, &lg); err == nil && lg.Verdict != "" {
 			in.Row.Verdict = lg.Verdict
+		}
+	}
+
+	// Perf-gate verdict (optional artifact — see run.sh).
+	if b, err := os.ReadFile(filepath.Join(dir, "perf_gate.json")); err == nil {
+		var pg perfGate
+		if err := json.Unmarshal(b, &pg); err == nil && pg.Verdict != "" {
+			in.Row.PerfVerdict = pg.Verdict
 		}
 	}
 
@@ -195,11 +211,11 @@ func Render(w io.Writer, h Header, scenarios []scenarioInput) error {
 	bw.printf("- Captured: `%s`\n\n", h.Captured)
 
 	bw.printf("## Summary\n\n")
-	bw.printf("| scenario | leak gate | rps | p99 (ms) | non-OK |\n")
-	bw.printf("| --- | --- | ---: | ---: | ---: |\n")
+	bw.printf("| scenario | leak gate | perf gate | rps | p99 (ms) | non-OK |\n")
+	bw.printf("| --- | --- | --- | ---: | ---: | ---: |\n")
 	for _, s := range scenarios {
-		bw.printf("| `%s` | `%s` | %s | %s | %s |\n",
-			s.Name, s.Row.Verdict, s.Row.Rps, s.Row.P99ms, s.Row.NonOK)
+		bw.printf("| `%s` | `%s` | `%s` | %s | %s | %s |\n",
+			s.Name, s.Row.Verdict, s.Row.PerfVerdict, s.Row.Rps, s.Row.P99ms, s.Row.NonOK)
 	}
 	bw.printf("\n")
 

--- a/testbed/bench/release/main_test.go
+++ b/testbed/bench/release/main_test.go
@@ -34,7 +34,7 @@ func TestLoadScenario_MissingDir(t *testing.T) {
 	if s.Row.Verdict != "(failed)" {
 		t.Errorf("missing dir verdict: %q", s.Row.Verdict)
 	}
-	if s.Row.Rps != "—" || s.Row.P99ms != "—" || s.Row.NonOK != "—" {
+	if s.Row.PerfVerdict != "—" || s.Row.Rps != "—" || s.Row.P99ms != "—" || s.Row.NonOK != "—" {
 		t.Errorf("missing dir row: %+v", s.Row)
 	}
 }
@@ -42,6 +42,7 @@ func TestLoadScenario_MissingDir(t *testing.T) {
 func TestLoadScenario_PopulatesRowAndDetail(t *testing.T) {
 	dir := t.TempDir()
 	writeJSON(t, filepath.Join(dir, "leak_gate.json"), map[string]any{"verdict": "pass"})
+	writeJSON(t, filepath.Join(dir, "perf_gate.json"), map[string]any{"verdict": "fail"})
 	writeJSON(t, filepath.Join(dir, "ghz_steady_localhost_6380.json"), map[string]any{
 		"count":                  1000,
 		"rps":                    4995.5,
@@ -55,6 +56,9 @@ func TestLoadScenario_PopulatesRowAndDetail(t *testing.T) {
 	s := loadScenario("smoke_write_heavy", dir)
 	if s.Row.Verdict != "pass" {
 		t.Errorf("verdict: %q", s.Row.Verdict)
+	}
+	if s.Row.PerfVerdict != "fail" {
+		t.Errorf("perf verdict: %q", s.Row.PerfVerdict)
 	}
 	if s.Row.Rps != "4995.5" {
 		t.Errorf("rps: %q", s.Row.Rps)
@@ -89,6 +93,9 @@ func TestLoadScenario_AggregatesMultipleGhzFiles(t *testing.T) {
 	})
 
 	s := loadScenario("smoke_mixed_rw", dir)
+	if s.Row.PerfVerdict != "—" {
+		t.Errorf("perf verdict without perf_gate.json: %q", s.Row.PerfVerdict)
+	}
 	if s.Row.Rps != "5000.0" {
 		t.Errorf("rps aggregate: %q", s.Row.Rps)
 	}
@@ -105,11 +112,11 @@ func TestRender_FixedFormat(t *testing.T) {
 		{
 			Name:   "smoke_write_heavy",
 			Detail: "### Bench report — `smoke_write_heavy`\nbody\n",
-			Row:    summaryRow{Verdict: "pass", Rps: "5000.0", P99ms: "1.23", NonOK: "0"},
+			Row:    summaryRow{Verdict: "pass", PerfVerdict: "pass", Rps: "5000.0", P99ms: "1.23", NonOK: "0"},
 		},
 		{
 			Name: "smoke_read_heavy",
-			Row:  summaryRow{Verdict: "(failed)", Rps: "—", P99ms: "—", NonOK: "—"},
+			Row:  summaryRow{Verdict: "(failed)", PerfVerdict: "—", Rps: "—", P99ms: "—", NonOK: "—"},
 		},
 	}
 	var buf bytes.Buffer
@@ -124,9 +131,9 @@ func TestRender_FixedFormat(t *testing.T) {
 		"- Runner: `linux/amd64`",
 		"- Captured: `20260101T000000Z`",
 		"## Summary",
-		"| scenario | leak gate | rps | p99 (ms) | non-OK |",
-		"| `smoke_write_heavy` | `pass` | 5000.0 | 1.23 | 0 |",
-		"| `smoke_read_heavy` | `(failed)` | — | — | — |",
+		"| scenario | leak gate | perf gate | rps | p99 (ms) | non-OK |",
+		"| `smoke_write_heavy` | `pass` | `pass` | 5000.0 | 1.23 | 0 |",
+		"| `smoke_read_heavy` | `(failed)` | `—` | — | — | — |",
 		"## smoke_write_heavy",
 		"### Bench report — `smoke_write_heavy`",
 		"## smoke_read_heavy",

--- a/testbed/bench/report/render.go
+++ b/testbed/bench/report/render.go
@@ -69,6 +69,28 @@ type LeakGateReplica struct {
 	VertexHLCHighWaterPost int64 `json:"vertex_hlc_high_water_post"`
 }
 
+// PerfGate mirrors the schema written by run.sh's perf gate (#935): optional
+// per-scenario floors over the steady-phase producers. Thresholds are
+// pointers because every key is individually optional — nil means the metric
+// is not gated for this scenario (e.g. p99 on deliberately saturated
+// fan-outs).
+type PerfGate struct {
+	Thresholds struct {
+		MinSteadyRpsTotal *float64 `json:"min_steady_rps_total"`
+		MaxP99Ms          *float64 `json:"max_p99_ms"`
+		MaxNonOKRatio     *float64 `json:"max_non_ok_ratio"`
+	} `json:"thresholds"`
+	Observed struct {
+		Producers      int     `json:"producers"`
+		SteadyRpsTotal float64 `json:"steady_rps_total"`
+		P99WorstMs     float64 `json:"p99_worst_ms"`
+		CountTotal     int64   `json:"count_total"`
+		NonOKTotal     int64   `json:"non_ok_total"`
+		NonOKRatio     float64 `json:"non_ok_ratio"`
+	} `json:"observed"`
+	Verdict string `json:"verdict"`
+}
+
 // GhzSummary captures the subset of fields ghz writes that the report uses.
 // All durations are nanoseconds as serialised by ghz --format json.
 type GhzSummary struct {
@@ -98,6 +120,7 @@ type Input struct {
 	Scenario  string
 	Timestamp string
 	LeakGate  *LeakGate
+	PerfGate  *PerfGate
 	GhzFiles  []GhzFile
 	PromIndex []PromIndexEntry
 	PprofList []string
@@ -121,6 +144,16 @@ func LoadInput(dir, scenario, ts string) (Input, error) {
 			return in, fmt.Errorf("parse leak_gate.json: %w", err)
 		}
 		in.LeakGate = &lg
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return in, err
+	}
+
+	if b, err := os.ReadFile(filepath.Join(dir, "perf_gate.json")); err == nil {
+		var pg PerfGate
+		if err := json.Unmarshal(b, &pg); err != nil {
+			return in, fmt.Errorf("parse perf_gate.json: %w", err)
+		}
+		in.PerfGate = &pg
 	} else if !errors.Is(err, fs.ErrNotExist) {
 		return in, err
 	}
@@ -184,8 +217,13 @@ func RenderReport(w io.Writer, in Input) error {
 	if in.LeakGate != nil {
 		verdict = in.LeakGate.Verdict
 	}
+	perfVerdict := "(no perf gate configured)"
+	if in.PerfGate != nil {
+		perfVerdict = in.PerfGate.Verdict
+	}
 	bw.printf("# Bench report — `%s` @ `%s`\n\n", in.Scenario, in.Timestamp)
 	bw.printf("**Leak gate verdict:** `%s`\n\n", verdict)
+	bw.printf("**Perf gate verdict:** `%s`\n\n", perfVerdict)
 
 	bw.printf("## Leak gate\n\n")
 	if in.LeakGate == nil {
@@ -214,6 +252,23 @@ func RenderReport(w io.Writer, in Input) error {
 				r.VertexHLCEntriesPost, r.VertexHLCHighWaterPost,
 			)
 		}
+		bw.printf("\n")
+	}
+
+	bw.printf("## Perf gate\n\n")
+	if in.PerfGate == nil {
+		bw.printf("_not configured_\n\n")
+	} else {
+		pg := in.PerfGate
+		bw.printf("Aggregation over %d steady producer(s): rps = sum, p99 = worst producer, non-OK ratio = Σnon-OK / Σcount. `—` = metric not gated for this scenario.\n\n", pg.Observed.Producers)
+		bw.printf("| metric | threshold | observed |\n")
+		bw.printf("| --- | ---: | ---: |\n")
+		bw.printf("| steady rps (total, floor) | %s | %.1f |\n",
+			perfThreshold(pg.Thresholds.MinSteadyRpsTotal, "%.1f"), pg.Observed.SteadyRpsTotal)
+		bw.printf("| p99 ms (worst, ceiling) | %s | %.2f |\n",
+			perfThreshold(pg.Thresholds.MaxP99Ms, "%.2f"), pg.Observed.P99WorstMs)
+		bw.printf("| non-OK ratio (ceiling) | %s | %.5f |\n",
+			perfThreshold(pg.Thresholds.MaxNonOKRatio, "%.5f"), pg.Observed.NonOKRatio)
 		bw.printf("\n")
 	}
 
@@ -289,6 +344,15 @@ func RenderReport(w io.Writer, in Input) error {
 	bw.printf("   `go tool pprof -http=:0 -base <pre> <post>`\n")
 	bw.printf("3. For elevated tail latency, cross-reference the matching Prom histogram query with `<replica>__post__goroutine.pb.gz` (look for blocked stacks).\n")
 	return bw.err
+}
+
+// perfThreshold renders an optional perf-gate threshold: nil (metric not
+// gated) becomes "—".
+func perfThreshold(v *float64, format string) string {
+	if v == nil {
+		return "—"
+	}
+	return fmt.Sprintf(format, *v)
 }
 
 func percentileNs(s GhzSummary, pct int) int64 {

--- a/testbed/bench/report/render_test.go
+++ b/testbed/bench/report/render_test.go
@@ -30,6 +30,18 @@ func TestRenderReport_AllSectionsAndVerdict(t *testing.T) {
 				VertexHLCHighWaterPre: 200_000, VertexHLCHighWaterPost: 240_000,
 			}},
 		},
+		PerfGate: func() *PerfGate {
+			pg := &PerfGate{Verdict: "pass"}
+			minRps := 50.0
+			pg.Thresholds.MinSteadyRpsTotal = &minRps // p99 / non-OK deliberately un-gated
+			pg.Observed.Producers = 1
+			pg.Observed.SteadyRpsTotal = 100.5
+			pg.Observed.P99WorstMs = 50
+			pg.Observed.CountTotal = 1000
+			pg.Observed.NonOKTotal = 10
+			pg.Observed.NonOKRatio = 0.01
+			return pg
+		}(),
 		GhzFiles: []GhzFile{{
 			Name: "ghz_steady_localhost_6380.json",
 			Summary: GhzSummary{
@@ -54,7 +66,12 @@ func TestRenderReport_AllSectionsAndVerdict(t *testing.T) {
 	mustContain := []string{
 		"# Bench report — `write_heavy` @ `20250101T000000Z`",
 		"**Leak gate verdict:** `pass`",
+		"**Perf gate verdict:** `pass`",
 		"## Leak gate",
+		"## Perf gate",
+		"| steady rps (total, floor) | 50.0 | 100.5 |",
+		"| p99 ms (worst, ceiling) | — | 50.00 |", // un-gated metric renders "—"
+		"| non-OK ratio (ceiling) | — | 0.01000 |",
 		"goroutine_max_delta=20",
 		"heap_alloc_max_delta_mb=32",
 		"`localhost:9390`",
@@ -122,7 +139,9 @@ func TestRenderReport_HandlesMissingArtifactsGracefully(t *testing.T) {
 	out := buf.String()
 	for _, want := range []string{
 		"**Leak gate verdict:** `(no leak gate captured)`",
+		"**Perf gate verdict:** `(no perf gate configured)`",
 		"_not captured_",
+		"_not configured_",
 		"_no ghz artifacts found_",
 		"_no prom queries captured_",
 		"_no pprof profiles captured_",
@@ -141,6 +160,12 @@ func TestLoadInput_AssemblesFromDisk(t *testing.T) {
 	lg.Thresholds.HeapAllocMaxDeltaMB = 16
 	lg.Replicas = []LeakGateReplica{{Endpoint: "x", GoroutineDelta: 9, HeapAllocDeltaBytes: 1 << 20}}
 	mustWriteJSON(t, filepath.Join(dir, "leak_gate.json"), lg)
+
+	pg := PerfGate{Verdict: "fail"}
+	maxP99 := 250.0
+	pg.Thresholds.MaxP99Ms = &maxP99
+	pg.Observed.P99WorstMs = 900
+	mustWriteJSON(t, filepath.Join(dir, "perf_gate.json"), pg)
 
 	gh := GhzSummary{Count: 42, Rps: 1, Average: 1_000_000,
 		StatusCodeDistribution: map[string]int{"OK": 42},
@@ -171,6 +196,11 @@ func TestLoadInput_AssemblesFromDisk(t *testing.T) {
 	}
 	if in.LeakGate == nil || in.LeakGate.Verdict != "fail" {
 		t.Errorf("leak gate not loaded: %+v", in.LeakGate)
+	}
+	if in.PerfGate == nil || in.PerfGate.Verdict != "fail" ||
+		in.PerfGate.Thresholds.MaxP99Ms == nil || *in.PerfGate.Thresholds.MaxP99Ms != 250 ||
+		in.PerfGate.Thresholds.MinSteadyRpsTotal != nil {
+		t.Errorf("perf gate not loaded: %+v", in.PerfGate)
 	}
 	if len(in.GhzFiles) != 1 || in.GhzFiles[0].Summary.Count != 42 {
 		t.Errorf("ghz files: %+v", in.GhzFiles)

--- a/testbed/bench/run.sh
+++ b/testbed/bench/run.sh
@@ -20,7 +20,9 @@
 #                     nightly leak gate sets this so the un-truncated sweep fits a
 #                     sane CI timeout; the advisory release bench leaves it unset.
 #
-# Exits 0 if leak gate verdict == "pass", 1 otherwise. Exits 2 on misuse.
+# Exits 0 if the leak gate verdict is "pass" AND the perf gate (when the
+# scenario declares a `perf_gate:` block — see below) did not fail; exits 1
+# otherwise. Exits 2 on misuse.
 #
 # Prerequisites: bash 4+, docker, docker compose v2, ghz, yq (v4+), jq, curl,
 #                go (for the report renderer).
@@ -436,6 +438,56 @@ printf '%s\n' "$leak_json" > "$OUTDIR/leak_gate.json"
 verdict="$(jq -r '.verdict' "$OUTDIR/leak_gate.json")"
 log "leak gate verdict: $verdict"
 
+# ----- Perf gate --------------------------------------------------------------
+# Optional per-scenario floors over the steady-phase producers (#935). Same
+# enforcement model as the leak gate: a scenario without a `perf_gate:` block
+# is skipped; when present, the verdict lands in perf_gate.json and folds into
+# the exit code — the blocking nightly (bench-nightly.yml) thereby enforces it
+# while the release-time bench stays advisory (continue-on-error, #256/#394).
+#
+# Aggregation matches the release summary table (testbed/bench/release):
+# rps = SUM over steady producers, p99 = worst producer (MAX), non-OK ratio =
+# Σnon-OK / Σcount. Every key is individually optional — gate only the metrics
+# that are stable for the scenario (deliberately saturated fan-outs have
+# queue-depth p99, i.e. noise; see testbed/bench/README.md). Floors are
+# "ratchet floors" sized from nightly baselines with ≥2x headroom: they catch
+# step-change regressions (accidental O(n²), lock convoy, a dropped fan-out),
+# not single-digit-% drift, which shared runners cannot resolve.
+perf_min_rps="$(yq -r '.perf_gate.min_steady_rps_total // ""' "$SCENARIO_FILE")"
+perf_max_p99="$(yq -r '.perf_gate.max_p99_ms // ""' "$SCENARIO_FILE")"
+perf_max_non_ok="$(yq -r '.perf_gate.max_non_ok_ratio // ""' "$SCENARIO_FILE")"
+perf_verdict="skipped"
+if [[ -n "${perf_min_rps}${perf_max_p99}${perf_max_non_ok}" ]]; then
+  perf_json="$(jq -s \
+    --arg min_rps "$perf_min_rps" \
+    --arg max_p99 "$perf_max_p99" \
+    --arg max_non_ok "$perf_max_non_ok" '
+    {
+      producers: length,
+      steady_rps_total: (map(.rps) | add),
+      p99_worst_ms: ((map(((.latencyDistribution // []) | map(select(.percentage == 99)) | .[0].latency) // 0) | max) / 1e6),
+      count_total: (map(.count) | add),
+      non_ok_total: (map((.statusCodeDistribution // {}) | to_entries | map(select(.key != "OK") | .value) | add // 0) | add)
+    } as $o |
+    ($o + {non_ok_ratio: (if $o.count_total > 0 then ($o.non_ok_total / $o.count_total) else 0 end)}) as $obs |
+    {
+      thresholds: {
+        min_steady_rps_total: (if $min_rps == "" then null else ($min_rps | tonumber) end),
+        max_p99_ms: (if $max_p99 == "" then null else ($max_p99 | tonumber) end),
+        max_non_ok_ratio: (if $max_non_ok == "" then null else ($max_non_ok | tonumber) end)
+      },
+      observed: $obs
+    } |
+    . + {verdict: (
+      if   (.thresholds.min_steady_rps_total != null and $obs.steady_rps_total < .thresholds.min_steady_rps_total) then "fail"
+      elif (.thresholds.max_p99_ms != null and $obs.p99_worst_ms > .thresholds.max_p99_ms) then "fail"
+      elif (.thresholds.max_non_ok_ratio != null and $obs.non_ok_ratio > .thresholds.max_non_ok_ratio) then "fail"
+      else "pass" end)}' "${prod_files[@]}")"
+  printf '%s\n' "$perf_json" > "$OUTDIR/perf_gate.json"
+  perf_verdict="$(jq -r '.verdict' "$OUTDIR/perf_gate.json")"
+fi
+log "perf gate verdict: $perf_verdict"
+
 # ----- Render report ---------------------------------------------------------
 (
   cd "$REPO_ROOT"
@@ -449,4 +501,4 @@ if [[ "${KEEP_UP:-0}" != "1" ]]; then
   docker compose "${COMPOSE_FILES[@]}" down -v >/dev/null
 fi
 
-if [[ "$verdict" == "pass" ]]; then exit 0; else exit 1; fi
+if [[ "$verdict" == "pass" && "$perf_verdict" != "fail" ]]; then exit 0; else exit 1; fi

--- a/testbed/bench/scenarios/broad_illuminate.yaml
+++ b/testbed/bench/scenarios/broad_illuminate.yaml
@@ -1,16 +1,19 @@
 # broad_illuminate — single steady window that fans out across the Illuminate
-# orthogonal axes (Algorithm × Objective × Weighting) plus a deep/wide variant.
-# Replaces the separate illuminate / illuminate_mst_max / illuminate_spt_tfidf /
-# illuminate_hot scenarios in the release sweep: run.sh forks one ghz per entry
-# in `target.calls` and runs them all in parallel for the same steady window.
+# traversal families (BFS / PPR / local community, the #846 `params` oneof)
+# and, within BFS, the reduction × objective × weighting axes plus a deep/wide
+# variant. Replaces the separate illuminate / illuminate_mst_max /
+# illuminate_spt_tfidf / illuminate_hot scenarios in the release sweep: run.sh
+# forks one ghz per entry in `target.calls` and runs them all in parallel for
+# the same steady window.
 #
-# Goal: cover both reduction algorithms (MST, SPT) + the no-reduction path, both
-#       objectives (MINIMIZE, MAXIMIZE), both weightings (RAW, TFIDF), and a
-#       deeper/wider traversal — in one 2m steady window (brackets the 60s GC
-#       sweep twice for the leak gate).
+# Goal: cover both reduction algorithms (MST, SPT) + the no-reduction path,
+#       both objectives (MINIMIZE, MAXIMIZE), both weightings (RAW, TFIDF), a
+#       deeper/wider traversal, and the PPR (#801) + local-community (#845)
+#       families — in one 2m steady window (brackets the 60s GC sweep twice
+#       for the leak gate).
 #
 # Dependency: every variant seeds k-* (uint enums per proto/graph/v1/graph.proto:
-#   Algorithm 1=MST 2=SPT, Objective 1=MINIMIZE 2=MAXIMIZE, Weighting 2=TFIDF).
+#   Reduction 1=MST 2=SPT, Objective 1=MINIMIZE 2=MAXIMIZE, Weighting 2=TFIDF).
 #   The k-* vertices AND the k-*→k-* edges are populated by broad_rw, so this
 #   scenario MUST run AFTER broad_rw in the release sweep (release-scenarios.txt).
 #   Run standalone against an empty graph, Illuminate still returns codes.OK with
@@ -22,26 +25,45 @@ phases:
   cooldown: 15s
 target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
-  # 4 parallel ghz invocations (one per variant), each at steady.rps/4 = 1000
-  # rps and the full steady.concurrency (16) → 64 concurrent traversals total.
+  # 6 parallel ghz invocations (one per variant), each at steady.rps/6 ≈ 666
+  # rps and the full steady.concurrency (16) → 96 concurrent traversals total.
   calls:
-    # [0] raw discovered subgraph (no reduction, default MAXIMIZE + RAW) — also
-    #     what warmup replays. Keep this first.
+    # [0] raw discovered subgraph (BFS, no reduction, default MAXIMIZE + RAW) —
+    #     also what warmup replays. Keep this first.
     - call: graph.v1.LanternService/Illuminate
       data_template: |
-        {"seed":"k-{{mod .RequestNumber 1000}}","step":2,"k":32}
+        {"seed":"k-{{mod .RequestNumber 1000}}","bfs":{"step":2,"fan_out":32}}
     # [1] minimum spanning tree, cost-minimizing direction, raw weights.
     - call: graph.v1.LanternService/Illuminate
       data_template: |
-        {"seed":"k-{{mod .RequestNumber 1000}}","step":2,"k":32,"algorithm":1,"objective":1}
+        {"seed":"k-{{mod .RequestNumber 1000}}","bfs":{"step":2,"fan_out":32,"objective":1,"reduction":1}}
     # [2] shortest-path tree, relevance-maximizing, TF-IDF re-scored weights.
     - call: graph.v1.LanternService/Illuminate
       data_template: |
-        {"seed":"k-{{mod .RequestNumber 1000}}","step":2,"k":32,"algorithm":2,"objective":2,"weighting":2}
-    # [3] deeper + wider traversal (heaviest fan-out) over the raw subgraph.
+        {"seed":"k-{{mod .RequestNumber 1000}}","weighting":2,"bfs":{"step":2,"fan_out":32,"objective":2,"reduction":2}}
+    # [3] deeper + wider traversal (heaviest BFS fan-out) over the raw subgraph.
     - call: graph.v1.LanternService/Illuminate
       data_template: |
-        {"seed":"k-{{mod .RequestNumber 1000}}","step":3,"k":64}
+        {"seed":"k-{{mod .RequestNumber 1000}}","bfs":{"step":3,"fan_out":64}}
+    # [4] Personalized-PageRank relevance star (#801) — forward-push family,
+    #     top-32 by mass with the default α/ε.
+    - call: graph.v1.LanternService/Illuminate
+      data_template: |
+        {"seed":"k-{{mod .RequestNumber 1000}}","ppr":{"top_n":32}}
+    # [5] conductance-optimal local community (#845) — PageRank-Nibble sweep
+    #     cut, bounded to 32 members, default α/ε, induced subgraph (no
+    #     reduction).
+    - call: graph.v1.LanternService/Illuminate
+      data_template: |
+        {"seed":"k-{{mod .RequestNumber 1000}}","community":{"max_size":32}}
 leak_gate:
   goroutine_max_delta: 25
   heap_alloc_max_delta_mb: 64
+# Floors sized from the 2026-06-29 → 2026-07-03 nightly baselines (4-way BFS
+# fan-out: rps 3998–4000 of 4000 offered, worst p99 39.77ms). The 2026-07 fan-out
+# widened to 6 calls (PPR + community), so p99 is deliberately NOT gated until a
+# few nightlies re-baseline the new mix — add `max_p99_ms` once observed p99 is
+# stable (see the perf-gate re-baselining rule in testbed/bench/README.md).
+perf_gate:
+  min_steady_rps_total: 2000
+  max_non_ok_ratio: 0.02

--- a/testbed/bench/scenarios/broad_mutate.yaml
+++ b/testbed/bench/scenarios/broad_mutate.yaml
@@ -120,3 +120,12 @@ target:
 leak_gate:
   goroutine_max_delta: 40
   heap_alloc_max_delta_mb: 128
+# Floors from the 2026-06-29 → 2026-07-03 nightly baselines: aggregate steady
+# rps 3067–3202, non-OK 5–5528 of ~528k calls (the BackupSnapshot stream's
+# iteration accounting makes the non-OK count spiky — hence the looser ratio
+# than broad_rw's). p99 is deliberately ungated: the fan-out saturates the
+# runner (observed p99 9.6–19.8 s night-over-night — queue depth, not server
+# latency).
+perf_gate:
+  min_steady_rps_total: 1500
+  max_non_ok_ratio: 0.05

--- a/testbed/bench/scenarios/broad_rw.yaml
+++ b/testbed/bench/scenarios/broad_rw.yaml
@@ -109,3 +109,12 @@ target:
 leak_gate:
   goroutine_max_delta: 30
   heap_alloc_max_delta_mb: 192
+# Floors from the 2026-06-29 → 2026-07-03 nightly baselines: aggregate steady
+# rps 2683–3552 (offered 12000 — the fan-out saturates a shared runner by
+# design, so delivered throughput, not offered, is the signal), non-OK
+# 98–171 of ~510k calls. p99 is deliberately ungated: with the offered load
+# above capacity, tail latency is queue depth (observed 0.46–3.3 s
+# night-over-night) — pure runner noise.
+perf_gate:
+  min_steady_rps_total: 1300
+  max_non_ok_ratio: 0.02

--- a/testbed/bench/scenarios/illuminate.yaml
+++ b/testbed/bench/scenarios/illuminate.yaml
@@ -8,13 +8,13 @@ phases:
 target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
   call: graph.v1.LanternService/Illuminate
-  # IlluminateRequest fields (#410): seed, step, k, algorithm, objective,
-  # weighting. Missing axes default to UNSPECIFIED, which the server
-  # resolves to (algorithm=none, objective=minimize, weighting=raw) — i.e.
-  # the raw discovered subgraph. See `illuminate_mst_max` /
+  # IlluminateRequest carries a per-family `params` oneof (#846): bfs / ppr /
+  # community. BFS knobs (step, fan_out, objective, reduction) live inside
+  # `bfs`; unset objective/reduction default to (MAXIMIZE, no reduction) —
+  # i.e. the raw discovered subgraph. See `illuminate_mst_max` /
   # `illuminate_spt_tfidf` for the exercised-axes variants.
   data_template: |
-    {"seed":"k-{{mod .RequestNumber 1000}}","step":2,"k":32}
+    {"seed":"k-{{mod .RequestNumber 1000}}","bfs":{"step":2,"fan_out":32}}
 leak_gate:
   goroutine_max_delta: 20
   heap_alloc_max_delta_mb: 32

--- a/testbed/bench/scenarios/illuminate_heavy.yaml
+++ b/testbed/bench/scenarios/illuminate_heavy.yaml
@@ -10,7 +10,7 @@ target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
   call: graph.v1.LanternService/Illuminate
   data_template: |
-    {"seed":"k-{{mod .RequestNumber 1000}}","step":3,"k":64}
+    {"seed":"k-{{mod .RequestNumber 1000}}","bfs":{"step":3,"fan_out":64}}
 leak_gate:
   goroutine_max_delta: 20
   heap_alloc_max_delta_mb: 32

--- a/testbed/bench/scenarios/illuminate_hot.yaml
+++ b/testbed/bench/scenarios/illuminate_hot.yaml
@@ -11,7 +11,7 @@ target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
   call: graph.v1.LanternService/Illuminate
   data_template: |
-    {"seed":"k-{{mod .RequestNumber 1000}}","step":2,"k":32}
+    {"seed":"k-{{mod .RequestNumber 1000}}","bfs":{"step":2,"fan_out":32}}
 leak_gate:
   goroutine_max_delta: 20
   heap_alloc_max_delta_mb: 32

--- a/testbed/bench/scenarios/illuminate_mst_max.yaml
+++ b/testbed/bench/scenarios/illuminate_mst_max.yaml
@@ -1,9 +1,9 @@
 # illuminate_mst_max — MAX-MST reduction at the baseline RPS.
-# Goal: cover the (algorithm=mst, objective=maximize) path of the
-# orthogonal-axes Illuminate API (#410). Uses the proto numeric enum
-# values directly to keep the JSON payload minimal:
+# Goal: cover the (reduction=mst, objective=maximize) path of the BFS
+# family of the params-oneof Illuminate API (#846). Uses the proto numeric
+# enum values directly to keep the JSON payload minimal:
 #
-#   Algorithm.MINIMUM_SPANNING_TREE = 1
+#   Reduction.MINIMUM_SPANNING_TREE = 1
 #   Objective.MAXIMIZE              = 2
 #   Weighting.RAW                   = 1 (default, omitted)
 name: illuminate_mst_max
@@ -15,7 +15,7 @@ target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
   call: graph.v1.LanternService/Illuminate
   data_template: |
-    {"seed":"k-{{mod .RequestNumber 1000}}","step":2,"k":32,"algorithm":1,"objective":2}
+    {"seed":"k-{{mod .RequestNumber 1000}}","bfs":{"step":2,"fan_out":32,"objective":2,"reduction":1}}
 leak_gate:
   goroutine_max_delta: 20
   heap_alloc_max_delta_mb: 32

--- a/testbed/bench/scenarios/illuminate_spt_tfidf.yaml
+++ b/testbed/bench/scenarios/illuminate_spt_tfidf.yaml
@@ -1,9 +1,10 @@
 # illuminate_spt_tfidf — relevance-weighted SPT with TF-IDF reweighting.
-# Goal: cover the most expensive orthogonal-axes combination (algorithm=spt,
-# objective=maximize, weighting=tfidf) from #410. TF-IDF transforms edge
-# weights BEFORE the BFS walk; SPT/MAX then picks the maximum-weight tree.
+# Goal: cover the most expensive BFS-family combination (reduction=spt,
+# objective=maximize, weighting=tfidf) of the params-oneof API (#846).
+# TF-IDF transforms edge weights BEFORE the BFS walk; SPT/MAX then picks
+# the maximum-weight tree.
 #
-#   Algorithm.SHORTEST_PATH_TREE = 2
+#   Reduction.SHORTEST_PATH_TREE = 2
 #   Objective.MAXIMIZE           = 2
 #   Weighting.TFIDF              = 2
 name: illuminate_spt_tfidf
@@ -15,7 +16,7 @@ target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
   call: graph.v1.LanternService/Illuminate
   data_template: |
-    {"seed":"k-{{mod .RequestNumber 1000}}","step":2,"k":32,"algorithm":2,"objective":2,"weighting":2}
+    {"seed":"k-{{mod .RequestNumber 1000}}","weighting":2,"bfs":{"step":2,"fan_out":32,"objective":2,"reduction":2}}
 leak_gate:
   goroutine_max_delta: 20
   heap_alloc_max_delta_mb: 32

--- a/testbed/bench/scenarios/many_subscribers.yaml
+++ b/testbed/bench/scenarios/many_subscribers.yaml
@@ -44,3 +44,12 @@ leak_gate:
   # cover the working set across all three replicas. See #258 item 2
   # for the rationale and #419 for the Reading B capacity discussion.
   heap_alloc_max_delta_mb: 512
+# Floors from the 2026-06-29 → 2026-07-03 nightly baselines: the single
+# pinned-replica producer delivers 366–500 rps under the 64-stream fan-out
+# (offered 2000 — contention-bound by design) with p99 208–293 ms and non-OK
+# 20–32. The gate only reads the producer's ghz report; stream health is
+# assessed via lantern_subscription_* series (see #258 item 4).
+perf_gate:
+  min_steady_rps_total: 180
+  max_p99_ms: 1500
+  max_non_ok_ratio: 0.02

--- a/testbed/bench/scenarios/replication_apply_churn.yaml
+++ b/testbed/bench/scenarios/replication_apply_churn.yaml
@@ -49,3 +49,10 @@ target:
 leak_gate:
   goroutine_max_delta: 30
   heap_alloc_max_delta_mb: 64
+# Floors from the 2026-06-29 → 2026-07-03 nightly baselines: aggregate steady
+# rps 2921–3000 (offered 3000), worst-producer p99 55–110 ms, non-OK 2–96 of
+# ~540k.
+perf_gate:
+  min_steady_rps_total: 1500
+  max_p99_ms: 500
+  max_non_ok_ratio: 0.02

--- a/testbed/bench/scenarios/replication_soak.yaml
+++ b/testbed/bench/scenarios/replication_soak.yaml
@@ -16,12 +16,15 @@ target:
     {"vertex":{"key":"soak-{{.RequestNumber}}","int64":"{{.RequestNumber}}"}}
 subscribe:
   consumers:
+    # Empty from_seq_per_origin = cold-start: deliver every retained entry
+    # from every origin (#415 leaderless Subscribe — the flat `from_seq`
+    # cursor this scenario predates no longer exists).
     - endpoint: localhost:6381
       call: graph.v1.LanternReplicationService/Subscribe
-      data_template: '{"fromSeq":"1"}'
+      data_template: '{}'
     - endpoint: localhost:6382
       call: graph.v1.LanternReplicationService/Subscribe
-      data_template: '{"fromSeq":"1"}'
+      data_template: '{}'
 leak_gate:
   goroutine_max_delta: 30
   heap_alloc_max_delta_mb: 64

--- a/testbed/bench/scenarios/search_churn.yaml
+++ b/testbed/bench/scenarios/search_churn.yaml
@@ -41,3 +41,10 @@ target:
 leak_gate:
   goroutine_max_delta: 20
   heap_alloc_max_delta_mb: 32
+# Floors from the 2026-06-29 → 2026-07-03 nightly baselines: aggregate steady
+# rps 1614–1843 (offered 2000), worst-producer p99 149–248 ms (the
+# SearchVertices leg dominates), non-OK 25–64 of ~380k.
+perf_gate:
+  min_steady_rps_total: 800
+  max_p99_ms: 1250
+  max_non_ok_ratio: 0.02

--- a/testbed/bench/scenarios/ttl_churn.yaml
+++ b/testbed/bench/scenarios/ttl_churn.yaml
@@ -27,3 +27,11 @@ leak_gate:
   # cooldown is long enough that expirations have drained; tighter bounds.
   goroutine_max_delta: 15
   heap_alloc_max_delta_mb: 16
+# Floors from the 2026-06-29 → 2026-07-03 nightly baselines: the single
+# producer sustains the offered 4000 rps essentially exactly (3999.6–4000.0)
+# with p99 12–27 ms and non-OK 2–12 of ~480k — the most stable scenario in
+# the sweep, so all three metrics are gated.
+perf_gate:
+  min_steady_rps_total: 2000
+  max_p99_ms: 150
+  max_non_ok_ratio: 0.02

--- a/testbed/bench/scenarios_gate_test.go
+++ b/testbed/bench/scenarios_gate_test.go
@@ -1,0 +1,213 @@
+// Package bench_test hosts cross-cutting gates over the bench-harness
+// scenario corpus (testbed/bench/scenarios/*.yaml).
+//
+// TestScenarioTemplates_MatchWireSchema is the schema-drift gate (#934):
+// ghz resolves request messages via server reflection and rejects any JSON
+// key that is not a field of the resolved message, so a proto change that
+// retires a field silently orphans every scenario template that still sends
+// it — the failure then only surfaces as a red nightly leak-gate run, days
+// after the schema PR merged (exactly how #866 broke broad_illuminate).
+// This test reproduces ghz's construction path at `go test ./...` time: it
+// renders every data_template with ghz-style template data and unmarshals
+// the result via protojson (which, like ghz, accepts both original and
+// lowerCamel field names and rejects unknown ones) against the request
+// message resolved from the scenario's `call` name.
+package bench_test
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/dynamicpb"
+	"gopkg.in/yaml.v3"
+
+	// Register the graph.v1 file descriptors (messages + both services) in
+	// protoregistry.GlobalFiles so `call` names resolve.
+	_ "github.com/anaregdesign/lantern/pb/graph/v1"
+)
+
+// scenarioCall is one (call, data_template) pair wherever it appears in a
+// scenario document.
+type scenarioCall struct {
+	Call         string `yaml:"call"`
+	DataTemplate string `yaml:"data_template"`
+}
+
+// scenarioDoc is the subset of the scenario schema that names RPCs. Keep in
+// sync with the extraction sites in testbed/bench/run.sh (target.call,
+// target.calls[], subscribe, subscribe.consumers[]).
+type scenarioDoc struct {
+	Name   string `yaml:"name"`
+	Target struct {
+		Call         string         `yaml:"call"`
+		DataTemplate string         `yaml:"data_template"`
+		Calls        []scenarioCall `yaml:"calls"`
+	} `yaml:"target"`
+	Subscribe struct {
+		Call         string         `yaml:"call"`
+		DataTemplate string         `yaml:"data_template"`
+		Consumers    []scenarioCall `yaml:"consumers"`
+	} `yaml:"subscribe"`
+}
+
+// calls flattens every (call, data_template) pair in the document, tagged
+// with where it came from so failures point at the offending YAML path.
+func (d scenarioDoc) calls() map[string]scenarioCall {
+	out := map[string]scenarioCall{}
+	if d.Target.Call != "" {
+		out["target"] = scenarioCall{d.Target.Call, d.Target.DataTemplate}
+	}
+	for i, c := range d.Target.Calls {
+		out[fmt.Sprintf("target.calls[%d]", i)] = c
+	}
+	if d.Subscribe.Call != "" {
+		out["subscribe"] = scenarioCall{d.Subscribe.Call, d.Subscribe.DataTemplate}
+	}
+	for i, c := range d.Subscribe.Consumers {
+		out[fmt.Sprintf("subscribe.consumers[%d]", i)] = c
+	}
+	return out
+}
+
+// ghzTemplateData mirrors the call-scoped variables ghz injects into
+// data_template. Only the fields the scenario corpus actually uses are
+// modelled; extend when a scenario starts using more of ghz's surface.
+type ghzTemplateData struct {
+	RequestNumber int64
+	Timestamp     string
+}
+
+// ghzFuncs approximates the sprig subset the corpus uses (ghz embeds sprig).
+// Numeric args are `any` because sprig coerces (cast.ToInt64) — templates mix
+// int64 fields with literal ints.
+func ghzFuncs() template.FuncMap {
+	toInt64 := func(v any) int64 {
+		switch n := v.(type) {
+		case int:
+			return int64(n)
+		case int64:
+			return n
+		default:
+			panic(fmt.Sprintf("unsupported integer type %T", v))
+		}
+	}
+	return template.FuncMap{
+		"mod": func(a, b any) int64 { return toInt64(a) % toInt64(b) },
+		"add": func(vs ...any) int64 {
+			var sum int64
+			for _, v := range vs {
+				sum += toInt64(v)
+			}
+			return sum
+		},
+		"b64enc": func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) },
+		"now":    time.Now,
+		"dateModify": func(d string, t time.Time) (time.Time, error) {
+			dur, err := time.ParseDuration(d)
+			if err != nil {
+				return time.Time{}, err
+			}
+			return t.Add(dur), nil
+		},
+		"date": func(layout string, t time.Time) string { return t.Format(layout) },
+	}
+}
+
+// requestDescriptor resolves "pkg.Service/Method" to the method's input
+// message descriptor via the global protoregistry — the same resolution ghz
+// performs over server reflection.
+func requestDescriptor(call string) (protoreflect.MessageDescriptor, error) {
+	svcName, method, ok := strings.Cut(call, "/")
+	if !ok {
+		return nil, fmt.Errorf("call %q is not Service/Method", call)
+	}
+	d, err := protoregistry.GlobalFiles.FindDescriptorByName(protoreflect.FullName(svcName))
+	if err != nil {
+		return nil, fmt.Errorf("service %q not registered: %w", svcName, err)
+	}
+	sd, ok := d.(protoreflect.ServiceDescriptor)
+	if !ok {
+		return nil, fmt.Errorf("%q is not a service", svcName)
+	}
+	md := sd.Methods().ByName(protoreflect.Name(method))
+	if md == nil {
+		return nil, fmt.Errorf("service %q has no method %q", svcName, method)
+	}
+	return md.Input(), nil
+}
+
+func TestScenarioTemplates_MatchWireSchema(t *testing.T) {
+	paths, err := filepath.Glob(filepath.Join("scenarios", "*.yaml"))
+	if err != nil {
+		t.Fatalf("glob scenarios: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("no scenario yamls found — glob root moved?")
+	}
+
+	// Two samples: RequestNumber 0 exercises the zero/modulo edge, a large
+	// value exercises the padded printf/b64enc contrib-id paths.
+	samples := []ghzTemplateData{
+		{RequestNumber: 0, Timestamp: time.Now().UTC().Format(time.RFC3339Nano)},
+		{RequestNumber: 987654321, Timestamp: time.Now().UTC().Format(time.RFC3339Nano)},
+	}
+
+	for _, path := range paths {
+		stem := strings.TrimSuffix(filepath.Base(path), ".yaml")
+		t.Run(stem, func(t *testing.T) {
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			var doc scenarioDoc
+			if err := yaml.Unmarshal(raw, &doc); err != nil {
+				t.Fatalf("parse yaml: %v", err)
+			}
+			calls := doc.calls()
+			if len(calls) == 0 {
+				t.Fatal("scenario declares no target/subscribe calls — run.sh could not drive it")
+			}
+			for site, c := range calls {
+				if c.Call == "" {
+					t.Errorf("%s: empty call", site)
+					continue
+				}
+				if strings.TrimSpace(c.DataTemplate) == "" {
+					t.Errorf("%s (%s): empty data_template", site, c.Call)
+					continue
+				}
+				desc, err := requestDescriptor(c.Call)
+				if err != nil {
+					t.Errorf("%s: %v", site, err)
+					continue
+				}
+				tmpl, err := template.New(site).Funcs(ghzFuncs()).Parse(c.DataTemplate)
+				if err != nil {
+					t.Errorf("%s (%s): parse template: %v", site, c.Call, err)
+					continue
+				}
+				for _, data := range samples {
+					var sb strings.Builder
+					if err := tmpl.Execute(&sb, data); err != nil {
+						t.Errorf("%s (%s): render @%d: %v", site, c.Call, data.RequestNumber, err)
+						continue
+					}
+					msg := dynamicpb.NewMessage(desc)
+					if err := protojson.Unmarshal([]byte(sb.String()), msg); err != nil {
+						t.Errorf("%s (%s): rendered template does not match %s:\n  %s\n  %v",
+							site, c.Call, desc.FullName(), strings.TrimSpace(sb.String()), err)
+					}
+				}
+			}
+		})
+	}
+}

--- a/tests/integration/idempotent_add_test.go
+++ b/tests/integration/idempotent_add_test.go
@@ -113,3 +113,118 @@ func TestAddEdge_IdempotentRetry_SingleContribution(t *testing.T) {
 		}
 	})
 }
+
+// TestAddEdges_BatchSemantics covers the canonical plural additive write over
+// the real Connect/h2c wire — the AddEdges surface previously had no
+// integration coverage at all (#935): accumulation across calls, the
+// index-aligned effective-weights contract (#897), chunked delivery
+// (WithBatchChunkSize), and at-least-once re-delivery dedup for the batch
+// path under WithIdempotentAdds.
+func TestAddEdges_BatchSemantics(t *testing.T) {
+	ctx := context.Background()
+	exp := time.Now().Add(time.Hour) // EdgeInput carries an absolute expiration; zero would be born-expired
+
+	inputs := func(w0, w1, w2 float32) []client.EdgeInput {
+		return []client.EdgeInput{
+			{Tail: "a", Head: "b", Weight: w0, Expiration: exp},
+			{Tail: "a", Head: "c", Weight: w1, Expiration: exp},
+			{Tail: "b", Head: "c", Weight: w2, Expiration: exp},
+		}
+	}
+
+	t.Run("accumulates and returns index-aligned effective weights", func(t *testing.T) {
+		l := newIdempotencyHarness(t)
+		eff, err := l.AddEdges(ctx, inputs(1, 2, 3))
+		if err != nil {
+			t.Fatalf("AddEdges #1: %v", err)
+		}
+		if len(eff) != 3 || eff[0] != 1 || eff[1] != 2 || eff[2] != 3 {
+			t.Fatalf("first AddEdges effective weights = %v, want [1 2 3]", eff)
+		}
+		eff, err = l.AddEdges(ctx, inputs(1, 2, 3))
+		if err != nil {
+			t.Fatalf("AddEdges #2: %v", err)
+		}
+		if len(eff) != 3 || eff[0] != 2 || eff[1] != 4 || eff[2] != 6 {
+			t.Fatalf("second AddEdges must report accumulated weights [2 4 6], got %v", eff)
+		}
+		e, err := l.GetEdge(ctx, "a", "c")
+		if err != nil {
+			t.Fatalf("GetEdge: %v", err)
+		}
+		if e.Weight != 4 {
+			t.Fatalf("stored weight after two additive batches = %v, want 4", e.Weight)
+		}
+	})
+
+	t.Run("chunked batch applies every input and stitches effective weights", func(t *testing.T) {
+		l := newIdempotencyHarness(t, client.WithBatchChunkSize(2))
+		batch := make([]client.EdgeInput, 5)
+		for i := range batch {
+			batch[i] = client.EdgeInput{
+				Tail:       "hub",
+				Head:       string(rune('p' + i)),
+				Weight:     float32(i + 1),
+				Expiration: exp,
+			}
+		}
+		eff, err := l.AddEdges(ctx, batch) // 5 inputs / chunk size 2 → 3 RPCs
+		if err != nil {
+			t.Fatalf("AddEdges: %v", err)
+		}
+		if len(eff) != len(batch) {
+			t.Fatalf("effective weights len = %d, want %d (must span chunks)", len(eff), len(batch))
+		}
+		for i, in := range batch {
+			if eff[i] != in.Weight {
+				t.Errorf("eff[%d] = %v, want %v", i, eff[i], in.Weight)
+			}
+			e, err := l.GetEdge(ctx, in.Tail, in.Head)
+			if err != nil {
+				t.Fatalf("GetEdge(%s→%s): %v", in.Tail, in.Head, err)
+			}
+			if e.Weight != in.Weight {
+				t.Errorf("stored weight %s→%s = %v, want %v", in.Tail, in.Head, e.Weight, in.Weight)
+			}
+		}
+	})
+
+	t.Run("WithIdempotentAdds dedups a re-delivered batch", func(t *testing.T) {
+		l := newIdempotencyHarness(t,
+			client.WithIdempotentAdds(),
+			client.WithConnectClientOption(connect.WithInterceptors(doubleSendInterceptor{})),
+		)
+		if _, err := l.AddEdges(ctx, inputs(1, 2, 3)); err != nil {
+			t.Fatalf("AddEdges: %v", err)
+		}
+		for _, tc := range inputs(1, 2, 3) {
+			e, err := l.GetEdge(ctx, tc.Tail, tc.Head)
+			if err != nil {
+				t.Fatalf("GetEdge(%s→%s): %v", tc.Tail, tc.Head, err)
+			}
+			if e.Weight != tc.Weight {
+				t.Errorf("re-delivered batch must contribute once: %s→%s weight = %v, want %v",
+					tc.Tail, tc.Head, e.Weight, tc.Weight)
+			}
+		}
+	})
+
+	t.Run("legacy batch path double-counts a re-delivered batch", func(t *testing.T) {
+		l := newIdempotencyHarness(t,
+			client.WithConnectClientOption(connect.WithInterceptors(doubleSendInterceptor{})),
+		)
+		if _, err := l.AddEdges(ctx, inputs(1, 2, 3)); err != nil {
+			t.Fatalf("AddEdges: %v", err)
+		}
+		for _, tc := range inputs(1, 2, 3) {
+			e, err := l.GetEdge(ctx, tc.Tail, tc.Head)
+			if err != nil {
+				t.Fatalf("GetEdge(%s→%s): %v", tc.Tail, tc.Head, err)
+			}
+			if e.Weight != 2*tc.Weight {
+				t.Errorf("default path is additive on re-delivery: %s→%s weight = %v, want %v",
+					tc.Tail, tc.Head, e.Weight, 2*tc.Weight)
+			}
+		}
+	})
+}

--- a/tests/integration/ttl_expiry_test.go
+++ b/tests/integration/ttl_expiry_test.go
@@ -1,0 +1,116 @@
+package integration_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+// This file pins Lantern's defining product semantic — data decays — as an
+// externally observable contract (#935): a client that writes with a TTL
+// must see the entry vanish from every point read once the TTL elapses.
+// Reads hide expired-but-not-yet-swept entries lazily (vertices.Has routes
+// through Get; edges are hidden unless both endpoints are live, #750), so
+// none of these assertions depend on GC timing. Expiry itself does depend on
+// the wall clock, hence the poll helper: assert liveness strictly before the
+// TTL, then poll with a generous deadline for the flip to ErrNotFound.
+
+const (
+	expiryTTL          = 500 * time.Millisecond
+	expiryPollDeadline = 10 * time.Second
+	expiryPollTick     = 20 * time.Millisecond
+)
+
+// eventuallyNotFound polls read until it reports client.ErrNotFound, failing
+// the test if the entry is still readable after expiryPollDeadline.
+func eventuallyNotFound(t *testing.T, what string, read func() error) {
+	t.Helper()
+	deadline := time.Now().Add(expiryPollDeadline)
+	for {
+		err := read()
+		if errors.Is(err, client.ErrNotFound) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s still readable %v after its TTL (last err: %v)", what, expiryPollDeadline, err)
+		}
+		if err != nil {
+			t.Fatalf("%s: unexpected error while waiting for expiry: %v", what, err)
+		}
+		time.Sleep(expiryPollTick)
+	}
+}
+
+func TestTTL_ExternallyObservableDecay(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	t.Run("vertex expires after its TTL", func(t *testing.T) {
+		l, cleanup := newInProcessClient(t)
+		defer cleanup()
+
+		if err := l.PutVertex(ctx, "mortal", "v", expiryTTL); err != nil {
+			t.Fatalf("PutVertex: %v", err)
+		}
+		if _, err := l.GetVertex(ctx, "mortal"); err != nil {
+			t.Fatalf("vertex must be readable before its TTL: %v", err)
+		}
+		eventuallyNotFound(t, "vertex", func() error {
+			_, err := l.GetVertex(ctx, "mortal")
+			return err
+		})
+	})
+
+	t.Run("edge expires after its TTL while endpoints stay live", func(t *testing.T) {
+		l, cleanup := newInProcessClient(t)
+		defer cleanup()
+
+		if err := l.PutVertex(ctx, "tail", 1, time.Hour); err != nil {
+			t.Fatalf("PutVertex tail: %v", err)
+		}
+		if err := l.PutVertex(ctx, "head", 2, time.Hour); err != nil {
+			t.Fatalf("PutVertex head: %v", err)
+		}
+		if _, err := l.AddEdge(ctx, "tail", "head", 1, expiryTTL); err != nil {
+			t.Fatalf("AddEdge: %v", err)
+		}
+		if _, err := l.GetEdge(ctx, "tail", "head"); err != nil {
+			t.Fatalf("edge must be readable before its TTL: %v", err)
+		}
+		eventuallyNotFound(t, "edge", func() error {
+			_, err := l.GetEdge(ctx, "tail", "head")
+			return err
+		})
+		// The endpoints outlive their edge.
+		if _, err := l.GetVertex(ctx, "tail"); err != nil {
+			t.Fatalf("tail vertex must survive its edge: %v", err)
+		}
+	})
+
+	t.Run("expired endpoint hides a still-live edge", func(t *testing.T) {
+		// Referential closure (#750): an edge may physically outlive an
+		// expired endpoint until GC, but no read may expose it.
+		l, cleanup := newInProcessClient(t)
+		defer cleanup()
+
+		if err := l.PutVertex(ctx, "ephemeral", 1, expiryTTL); err != nil {
+			t.Fatalf("PutVertex ephemeral: %v", err)
+		}
+		if err := l.PutVertex(ctx, "durable", 2, time.Hour); err != nil {
+			t.Fatalf("PutVertex durable: %v", err)
+		}
+		if _, err := l.AddEdge(ctx, "ephemeral", "durable", 1, time.Hour); err != nil {
+			t.Fatalf("AddEdge: %v", err)
+		}
+		if _, err := l.GetEdge(ctx, "ephemeral", "durable"); err != nil {
+			t.Fatalf("edge must be readable while both endpoints live: %v", err)
+		}
+		eventuallyNotFound(t, "edge with expired tail", func() error {
+			_, err := l.GetEdge(ctx, "ephemeral", "durable")
+			return err
+		})
+	})
+}


### PR DESCRIPTION
Closes #934, closes #935

## What

Three-part hardening so functional and performance regressions on the external surface fail CI instead of shipping — plus the fix for the currently-red nightly.

### 1. Fix the red nightly + prevent the class (#934)

- The nightly leak gate has failed since 2026-07-02: #866 (`params` oneof) retired the flat `step`/`k`/`algorithm`/`objective` `IlluminateRequest` fields, and six bench scenario templates kept sending them; ghz could not build the warmup message and `broad_illuminate` died with no artifacts. All six templates are migrated (`bfs:{step, fan_out, objective, reduction}`), and the on-demand `replication_soak` is migrated off the equally-retired flat Subscribe `from_seq` cursor (→ empty `from_seq_per_origin` cold start).
- **New schema-drift gate** [`testbed/bench/scenarios_gate_test.go`](testbed/bench/scenarios_gate_test.go): renders every `data_template` in every scenario (ghz-style template funcs + protoregistry method resolution + protojson strict unmarshal) so a proto change that orphans a bench scenario now fails ordinary root `go test ./...` at PR time. It caught the `replication_soak` breakage the nightly never saw.
- `broad_illuminate` additionally folds in `ppr` and `community` variants (#801/#845/#867 previously had zero bench coverage).

### 2. Performance-regression gate (#935)

- `run.sh` gains an opt-in per-scenario `perf_gate:` block — `min_steady_rps_total` (Σ producer rps), `max_p99_ms` (worst producer), `max_non_ok_ratio` (Σnon-OK/Σcount) — evaluated from the steady-phase ghz artifacts and folded into the exit code exactly like the leak gate: the **blocking nightly enforces it**, the release-time bench stays advisory (#256/#394 design preserved).
- All seven release-sweep scenarios carry floors sized from the 2026-06-29 → 2026-07-03 nightly baselines with ≥2x headroom (rps ≈ 50% of the worst observed night). p99 is deliberately **not** gated on the saturated fan-outs (`broad_rw`, `broad_mutate`, observed 7x night-over-night p99 swings = queue depth, not server latency) nor on `broad_illuminate` until its new 6-way mix re-baselines — rules documented in [testbed/bench/README.md](testbed/bench/README.md).
- The per-scenario report gains a `Perf gate` section and the release summary a `perf gate` column.

### 3. Missing integration tests + testing policy (#935)

- **`AddEdges` had zero integration coverage** (the canonical plural additive write). Added to `idempotent_add_test.go`: batch accumulation with index-aligned effective weights (#897), chunked delivery via `WithBatchChunkSize`, and `WithIdempotentAdds` re-delivery dedup vs. legacy double-count for the batch path.
- **TTL decay had no direct external-surface test.** New `tests/integration/ttl_expiry_test.go`: short-TTL vertex/edge flip to `ErrNotFound` through the SDK over the wire, and an expired endpoint hides a still-live edge (referential closure #750). Poll-based; reads hide expired entries lazily so no GC dependency.
- **Testing Definition of Done** documented: CONTRIBUTING.md "External-surface testing policy" (canonical — integration test over the real wire path in the same PR, bench coverage for perf-relevant paths, perf floors as a ratchet, schema changes migrate bench templates), with always-on summaries in AGENTS.md (replacing the stale "no service-layer tests" note) and CLAUDE.md.

## Testing

- `gofmt -l .` clean; root + all five submodule `go test ./...` green (server with `go vet`).
- New schema gate validates all 26 scenarios; perf-gate jq verified against synthetic ghz fixtures for all three breach paths + missing-field edge cases; `bash -n run.sh` clean.
- `make lint` reports 3 pre-existing govet hits in `admin/node_modules/**` vendored files only (absent on a clean CI checkout).

Note for reviewers: the perf floors will first be exercised by the next scheduled nightly; if a floor flaps there, the intended remedy is widening that scenario's floor (they are deliberately coarse), not reverting the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)