### PR TITLE
fix(cli): stop parser.Duration double-advancing the source

### DIFF
--- a/admin/test/cli-grammar/verbs.json
+++ b/admin/test/cli-grammar/verbs.json
@@ -165,7 +165,15 @@
       "input": "put edge alice bob notafloat",
       "comment": "non-numeric weight"
     },
+    {
+      "input": "put edge alice bob 1.5 60 extra",
+      "comment": "#932: trailing token after ttl_seconds"
+    },
     { "input": "add", "comment": "missing objective" },
+    {
+      "input": "add edge alice bob 1.0 60 extra",
+      "comment": "#932: trailing token after ttl_seconds"
+    },
     { "input": "add vertex alice", "comment": "add only supports edge" },
     { "input": "delete", "comment": "missing objective" },
     { "input": "delete edge alice", "comment": "missing head" },

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -141,7 +141,10 @@ func Value(s *Source) (any, error) {
 }
 
 func Duration(s *Source) (time.Duration, error) {
-	defer s.Next()
+	// Delegate cleanly to Integer, which already advances the source via its
+	// own `defer s.Next()`. An extra `defer s.Next()` here would double-advance
+	// and defeat the trailing EOF check in PutEdgeParam / AddEdgeParam (#932) —
+	// mirror the Float32 → Float delegation, which adds no extra advance.
 	i, err := Integer(s)
 	if err != nil {
 		return 0, err

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -363,6 +363,50 @@ func TestParam_OmittedTTLIsPermanent(t *testing.T) {
 	})
 }
 
+// TestEdgeParam_TrailingToken pins the #932 regression: Duration must advance
+// the source exactly once, so a token after ttl_seconds is rejected by the
+// final EOF check instead of being silently discarded. Mirrors the
+// TestCountVerticesParam "trailing token is error" case.
+func TestEdgeParam_TrailingToken(t *testing.T) {
+	t.Run("put edge", func(t *testing.T) {
+		t.Run("valid ttl parses", func(t *testing.T) {
+			s, _ := NewSource("a b 1.5 60")
+			m, err := PutEdgeParam(s)
+			if err != nil {
+				t.Fatalf("PutEdgeParam(a b 1.5 60): %v", err)
+			}
+			if m.TTL != 60*time.Second {
+				t.Errorf("TTL = %v, want 1m0s", m.TTL)
+			}
+		})
+		t.Run("trailing token is error", func(t *testing.T) {
+			s, _ := NewSource("a b 1.5 60 extra")
+			if _, err := PutEdgeParam(s); err == nil {
+				t.Errorf("PutEdgeParam(a b 1.5 60 extra) = nil, want error")
+			}
+		})
+	})
+
+	t.Run("add edge", func(t *testing.T) {
+		t.Run("valid ttl parses", func(t *testing.T) {
+			s, _ := NewSource("a b 1.5 60")
+			m, err := AddEdgeParam(s)
+			if err != nil {
+				t.Fatalf("AddEdgeParam(a b 1.5 60): %v", err)
+			}
+			if m.TTL != 60*time.Second {
+				t.Errorf("TTL = %v, want 1m0s", m.TTL)
+			}
+		})
+		t.Run("trailing token is error", func(t *testing.T) {
+			s, _ := NewSource("a b 1.5 60 extra")
+			if _, err := AddEdgeParam(s); err == nil {
+				t.Errorf("AddEdgeParam(a b 1.5 60 extra) = nil, want error")
+			}
+		})
+	})
+}
+
 // TestIlluminateParam_Prefix pins the #604 vertex-prefix kwarg. Unlike the
 // closed-set axes, prefix= is free-text: the key is case-insensitive but the
 // value is preserved verbatim (it matches vertex keys), it composes with the


### PR DESCRIPTION
## What

`parser.Duration` advanced the token source **twice** per call: it ran its own `defer s.Next()` *and* delegated to `Integer(s)`, which already defers `s.Next()`. Every other primitive advances exactly once (`Float32` shows the correct delegation pattern).

The double-advance pushed `pos` one past the real position, defeating the final `EOF(s)` check in `PutEdgeParam` (parser.go:360) and `AddEdgeParam` (parser.go:386) for exactly one trailing token:

```
"a b 1.5 60"              -> TTL=1m0s err=<nil>   (correct)
"a b 1.5 60 extra"        -> TTL=1m0s err=<nil>   (BUG: should be "not EOF")
"a b 1.5 60 extra extra2" -> err=not EOF          (correct)
```

So `add edge a b 1.5 60 extra` / `put edge a b 1.5 60 extra` were silently accepted with the trailing token discarded — a typo'd/miscopied REPL or bulk-script line succeeded instead of erroring.

## Fix

- Drop the `defer s.Next()` from `Duration`, delegating cleanly to `Integer` like `Float32` → `Float`.
- Add `TestEdgeParam_TrailingToken` with trailing-token rejection sub-tests for `PutEdgeParam` and `AddEdgeParam` (`"a b 1.5 60 extra"` → error), mirroring the existing `TestCountVerticesParam` "trailing token is error" case per the 1:1 test-pairing rule.

`PutVertexParam` parses its TTL inline via `Atoi` and is unaffected.

## Verification

- `gofmt -l` clean; `go build ./...` and `go test ./cli/...` green.
- Confirmed the new test **fails** with the bug reintroduced and **passes** with the fix.

Closes #932