### PR TITLE
ci(admin): run the admin unit test suite in CI

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
+      - name: Test
+        run: bun run test
+
       - name: Build
         run: bun run build
 

--- a/admin/README.md
+++ b/admin/README.md
@@ -48,6 +48,7 @@ the top-right header. The choice is persisted to `localStorage`.
 | `bun run typecheck` | `react-router typegen` then `tsc -b`. |
 | `bun run lint`      | ESLint (flat config).                 |
 | `bun run format`    | Prettier write.                       |
+| `bun run test`      | Unit tests (Bun test runner).         |
 | `bun run test:e2e`  | Playwright smoke tests.               |
 
 ## Project layout


### PR DESCRIPTION
## Problem

`.github/workflows/admin.yml` runs lint → format:check → typecheck → build → Playwright e2e, but never `bun run test`. The unit suite exists (`admin/package.json`: `"test": "bun test app test/cli-grammar"`) and is part of the documented quality gate (CLAUDE.md Admin SPA section and `admin/AGENTS.md` pre-push gate). Today a PR that breaks an admin unit test merges green.

## Fix

- **`.github/workflows/admin.yml`** — add a `Test` step (`bun run test`) between `Typecheck` and `Build`, matching the documented gate order (lint → format:check → typecheck → test → build). Uses the package script, not bare `bun test`.
- **`admin/README.md`** — add a `bun run test` row to the Scripts table, immediately above `bun run test:e2e`.

## Verification

Verified locally over the real CI path (admin links the Node SDK via `file:../sdks/node`):

```
cd sdks/node && bun install --frozen-lockfile && bun run build
cd admin   && bun install --frozen-lockfile && bun run test
# → 696 pass, 0 fail
```

Focused 2-file change; no other files touched.

Closes #933