### PR TITLE
test(bench): restore broad_illuminate max_p99_ms after 6-way re-baseline

### DIFF
--- a/testbed/bench/scenarios/broad_illuminate.yaml
+++ b/testbed/bench/scenarios/broad_illuminate.yaml
@@ -59,11 +59,18 @@ target:
 leak_gate:
   goroutine_max_delta: 25
   heap_alloc_max_delta_mb: 64
-# Floors sized from the 2026-06-29 → 2026-07-03 nightly baselines (4-way BFS
-# fan-out: rps 3998–4000 of 4000 offered, worst p99 39.77ms). The 2026-07 fan-out
-# widened to 6 calls (PPR + community), so p99 is deliberately NOT gated until a
-# few nightlies re-baseline the new mix — add `max_p99_ms` once observed p99 is
-# stable (see the perf-gate re-baselining rule in testbed/bench/README.md).
+# Floors sized from the nightly baselines. rps and non-OK were sized off the
+# 2026-06-29 → 2026-07-03 4-way runs (rps 3998–4000 of 4000 offered, a handful
+# of non-OK per ~480k) and still hold for the wider mix. The 2026-07 fan-out
+# widened to 6 calls (added PPR + community — #936), so p99 shipped ungated
+# pending a re-baseline (#939): the first green nightly on the new mix
+# (2026-07-04) held worst-producer p99 at 47.75ms with all six producers
+# clustered 46–48ms, so max_p99_ms is restored at 250ms — ~5x headroom,
+# deliberately generous off a single re-baseline sample and matching the
+# ttl_churn/many_subscribers multiplier band. It gates a step-change traversal
+# regression in the BFS/PPR/community families, not night-over-night drift (see
+# the perf-gate sizing rule in testbed/bench/README.md).
 perf_gate:
   min_steady_rps_total: 2000
+  max_p99_ms: 250
   max_non_ok_ratio: 0.02


### PR DESCRIPTION
## What

Restores the `max_p99_ms` perf-gate ceiling on `broad_illuminate.yaml`, deferred in #936 when the scenario widened its Illuminate fan-out from 4 BFS calls to 6 (adding the PPR and local-community families).

```diff
 perf_gate:
   min_steady_rps_total: 2000
+  max_p99_ms: 250
   max_non_ok_ratio: 0.02
```

## Why 250ms

Per the re-baselining rule in `testbed/bench/README.md` ("Perf gate"), I read the worst-producer p99 from the **first green nightly on the new 6-way mix** — [run 28717091697](https://github.com/anaregdesign/lantern/actions/runs/28717091697) (2026-07-04, `pass`):

| producer | p99 (ms) |
| --- | ---: |
| ghz_steady_0 | 47.35 |
| ghz_steady_1 | 47.51 |
| ghz_steady_2 | 47.42 |
| ghz_steady_3 | 46.89 |
| ghz_steady_4 | 45.95 |
| ghz_steady_5 | **47.75** |

Worst-producer p99 **47.75ms**, all six clustered 46–48ms (4% spread). The old 4-way baseline was 39.77ms worst — +20% p99 for +50% calls, unremarkable.

`250ms` is ~5.2× headroom, matching the ttl_churn (5.6×) / many_subscribers (5.2×) multiplier band for the low-latency, tight-clustered scenarios. It gates a **step-change** traversal-latency regression in the BFS/PPR/community families (accidental O(n²), lock convoy, a dropped fan-out) without flagging night-over-night drift — `rps` and non-OK were already gated.

## Note on sample count

#939 suggested waiting for "a few nightlies," but only **one** has run since #936 merged (~1 day ago). The single sample is very tight, and the ceiling is deliberately generous off it; a future nightly can tighten it if the observed p99 proves stably lower. The yaml comment records this rationale.

## Testing

- `go test ./...` (root) — green; `testbed/bench` schema-drift gate + report tests pass.
- `gofmt -l .` clean (YAML-only change).
- Confirmed `run.sh` reads `.perf_gate.max_p99_ms` and fails when `p99_worst_ms > max_p99_ms`, so the gate is live.

No integration test required — this is a nightly perf-gate threshold, not externally observable behaviour (no RPC/SDK/CLI/MCP/env/TTL surface change).

Closes #939