### PR TITLE
chore(release): bump module pins for cascade #11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.5.0
-	github.com/anaregdesign/lantern/core v0.15.0
+	github.com/anaregdesign/lantern/core v0.16.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
-	github.com/anaregdesign/lantern/pb v0.10.0
-	github.com/anaregdesign/lantern/sdks/go v0.21.0
+	github.com/anaregdesign/lantern/pb v0.11.0
+	github.com/anaregdesign/lantern/sdks/go v0.22.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -3,15 +3,15 @@ module github.com/anaregdesign/lantern/mcp
 go 1.26
 
 require (
-	github.com/anaregdesign/lantern/pb v0.10.0
-	github.com/anaregdesign/lantern/sdks/go v0.21.0
+	github.com/anaregdesign/lantern/pb v0.11.0
+	github.com/anaregdesign/lantern/sdks/go v0.22.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	google.golang.org/protobuf v1.36.11
 )
 
 require (
 	connectrpc.com/connect v1.20.0 // indirect
-	github.com/anaregdesign/lantern/core v0.15.0 // indirect
+	github.com/anaregdesign/lantern/core v0.16.0 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -4,8 +4,8 @@ go 1.26
 
 require (
 	connectrpc.com/connect v1.20.0
-	github.com/anaregdesign/lantern/core v0.15.0
-	github.com/anaregdesign/lantern/pb v0.10.0
+	github.com/anaregdesign/lantern/core v0.16.0
+	github.com/anaregdesign/lantern/pb v0.11.0
 	golang.org/x/net v0.56.0
 	google.golang.org/protobuf v1.36.11
 )

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lantern-sdk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Official TypeScript client SDK for Lantern — an in-memory graph KVS, over Connect (HTTP/2).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Release-prep pin bump, same shape as cascade #10 (#875). All pins are replace-backed locally (workspace); the versions are metadata for downstream `go get` consumers.

- `pb` v0.10.0 → **v0.11.0** — search match options on the wire (#904)
- `core` v0.15.0 → **v0.16.0** — search engine: relevance harness (#893), script-aware analyzer (#894), positional/phrase/proximity postings (#901), match modes AND/OR/msm (#902), fuzzy + prefix terms (#903), positions opt-out/encoding + fuzzy bounds (#914); perf: `TopVerticesByDegree` writer-stall bound (#931); `AddEdge` effective_weight excludes expired + born-expired if-absent accuracy (#925, #926)
- `sdks/go` v0.21.0 → **v0.22.0** — search match options (#904), contrib-id mint-once-per-failover + `batchChunkSize` uint16 clamp fixes (#928, #929)
- `sdks/node` 0.8.0 → **0.9.0** — search match options (#906), contrib_id + effective-weight + if_absent + edge/degree prefix surface (#915)

Modules with changes but no cross-module pin to bump ship on their own tag from the merged SHA: root **v0.28.0** (CLI search #905, `parser.Duration` fix #937, server born-expired #926, perf-gate/schema-drift/integration tests #936, #940), `mcp` **v0.11.0** (search #904, effective-weight from `AddEdge` #930), `admin` **v0.15.0** (search match-mode/phrase/fuzzy Data surface #907, CI unit tests #938).

Tags follow on the merged SHA in the documented order:
`pb/v0.11.0` → `core/v0.16.0` → `sdks/go/v0.22.0` → `v0.28.0` → `mcp/v0.11.0` / `sdks/node/v0.9.0` / `admin/v0.15.0`.