### PR TITLE
fix(admin): reach LocalCommunity family from illuminate algorithm=community

### DIFF
--- a/admin/app/components/cli/CliAxisPicker/CliAxisPicker.tsx
+++ b/admin/app/components/cli/CliAxisPicker/CliAxisPicker.tsx
@@ -40,11 +40,13 @@ export interface CliAxisPickerProps {
  * Renders a single-line strip of Fluent UI primitives that map 1:1 to
  * the optional kwargs of the long-form illuminate verb (post-#410):
  * step, k, algorithm, objective, and a raw/TF-IDF/BM25 weighting
- * Dropdown, plus a free-text prefix filter. When algorithm=ppr is
- * selected, two extra numeric inputs (restart_prob / epsilon) appear for
- * the Personalized PageRank knobs (#801); a blank knob means "server
- * default". Wraps on narrow viewports without horizontal scroll, per the
- * architecture skill's responsive guidance.
+ * Dropdown, plus a free-text prefix filter. When a push-based family is
+ * selected (algorithm=ppr or algorithm=community), two extra numeric
+ * inputs (restart_prob / epsilon) appear for the shared locality knobs
+ * (#801/#942); a blank knob means "server default", and the step input is
+ * disabled because neither family gives it a wire meaning. Wraps on narrow
+ * viewports without horizontal scroll, per the architecture skill's
+ * responsive guidance.
  *
  * The component owns no business state — every change goes through
  * {@link CliAxisPickerProps.setAxis}, which the parent hook
@@ -114,6 +116,17 @@ export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
 
   const preview = formatIlluminateClick("<key>", axes);
 
+  // #801/#942: ppr and community are the two push-based families that carry
+  // the α/ε locality knobs; they also give the `step` axis no wire meaning.
+  const isPushFamily =
+    axes.algorithm === "ppr" || axes.algorithm === "community";
+  // #942: for the community family `k` is the max_size UPPER BOUND (the
+  // conductance sweep may stop earlier), not an exact neighbour count.
+  const kTitle =
+    axes.algorithm === "community"
+      ? "k: max community size (upper bound; the sweep may stop earlier)"
+      : "k: top-k neighbours kept per hop";
+
   return (
     <div
       className={styles.strip}
@@ -131,9 +144,14 @@ export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
           max={CLI_CLICK_STEP_MAX}
           value={String(axes.step)}
           onChange={onStepChange}
-          disabled={disabled}
+          disabled={disabled || isPushFamily}
           data-testid="cli-axis-step"
           aria-label={`Step (${CLI_CLICK_STEP_MIN}–${CLI_CLICK_STEP_MAX})`}
+          title={
+            isPushFamily
+              ? "step has no meaning for the ppr / community families"
+              : undefined
+          }
         />
       </label>
 
@@ -149,6 +167,7 @@ export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
           disabled={disabled}
           data-testid="cli-axis-k"
           aria-label={`K (${CLI_CLICK_K_MIN}–${CLI_CLICK_K_MAX})`}
+          title={kTitle}
         />
       </label>
 
@@ -232,7 +251,7 @@ export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
         />
       </label>
 
-      {axes.algorithm === "ppr" && (
+      {isPushFamily && (
         <>
           <label className={styles.field}>
             <span className={styles.label}>restart_prob</span>
@@ -247,7 +266,7 @@ export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
               disabled={disabled}
               placeholder="0.15"
               data-testid="cli-axis-restart-prob"
-              aria-label="PPR restart probability α (0–1; blank = server default)"
+              aria-label="Restart probability α (0–1; blank = server default)"
             />
           </label>
 
@@ -263,7 +282,7 @@ export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
               disabled={disabled}
               placeholder="1e-4"
               data-testid="cli-axis-epsilon"
-              aria-label="PPR residual threshold ε (> 0; blank = server default)"
+              aria-label="Residual threshold ε (> 0; blank = server default)"
             />
           </label>
         </>

--- a/admin/app/lib/cli/complete.test.ts
+++ b/admin/app/lib/cli/complete.test.ts
@@ -177,6 +177,7 @@ describe("completeCommandLine — illuminate option kwargs (slot ≥ 4)", () => 
       "algorithm=mst",
       "algorithm=spt",
       "algorithm=ppr",
+      "algorithm=community",
     ]);
   });
 

--- a/admin/app/lib/cli/illuminate-axes.test.ts
+++ b/admin/app/lib/cli/illuminate-axes.test.ts
@@ -163,6 +163,30 @@ describe("formatIlluminateClick", () => {
     ).toBe("illuminate alice 2 5 algorithm=spt");
   });
 
+  // #942: the community family shares the ppr α/ε knobs and the same
+  // non-zero emission gate, so the click formatter must reach it too.
+  test("algorithm=community alone emits just the algorithm kwarg", () => {
+    expect(
+      formatIlluminateClick("alice", {
+        ...CLI_CLICK_AXIS_DEFAULTS,
+        algorithm: "community",
+      }),
+    ).toBe("illuminate alice 2 5 algorithm=community");
+  });
+
+  test("community knobs append after the algorithm kwarg in fixed order", () => {
+    expect(
+      formatIlluminateClick("alice", {
+        ...CLI_CLICK_AXIS_DEFAULTS,
+        algorithm: "community",
+        restartProb: 0.25,
+        epsilon: 0.001,
+      }),
+    ).toBe(
+      "illuminate alice 2 5 algorithm=community restart_prob=0.25 epsilon=0.001",
+    );
+  });
+
   test("seed containing a colon round-trips literally", () => {
     expect(formatIlluminateClick("user:alice", CLI_CLICK_AXIS_DEFAULTS)).toBe(
       "illuminate user:alice 2 5",
@@ -223,6 +247,15 @@ describe("formatIlluminateClick ↔ parse round-trip", () => {
         epsilon: 0.001,
       },
     },
+    {
+      name: "community with knobs",
+      axes: {
+        ...CLI_CLICK_AXIS_DEFAULTS,
+        algorithm: "community",
+        restartProb: 0.3,
+        epsilon: 0.002,
+      },
+    },
   ];
 
   test.each(matrix)("$name parses back to the same axes", ({ axes }) => {
@@ -242,10 +275,10 @@ describe("formatIlluminateClick ↔ parse round-trip", () => {
     expect(result.command.objective).toBe(axes.objective);
     expect(result.command.weighting).toBe(axes.weighting);
     expect(result.command.vertexPrefix).toBe(axes.vertexPrefix);
-    // The PPR knobs only survive the round-trip for a ppr walk; for every
-    // other algorithm the formatter suppresses them and the parser defaults
-    // them back to 0 (#801).
-    if (axes.algorithm === "ppr") {
+    // The push-family knobs only survive the round-trip for a ppr or
+    // community walk; for every other algorithm the formatter suppresses
+    // them and the parser defaults them back to 0 (#801 / #942).
+    if (axes.algorithm === "ppr" || axes.algorithm === "community") {
       expect(result.command.restartProb).toBe(axes.restartProb);
       expect(result.command.epsilon).toBe(axes.epsilon);
     } else {
@@ -279,6 +312,7 @@ describe("parseStored* helpers", () => {
     expect(parseStoredAlgorithm("mst")).toBe("mst");
     expect(parseStoredAlgorithm("spt")).toBe("spt");
     expect(parseStoredAlgorithm("ppr")).toBe("ppr");
+    expect(parseStoredAlgorithm("community")).toBe("community");
     expect(parseStoredAlgorithm("SPT")).toBeNull();
     expect(parseStoredAlgorithm("ALGORITHM_SHORTEST_PATH_TREE")).toBeNull();
     expect(parseStoredAlgorithm(null)).toBeNull();

--- a/admin/app/lib/cli/illuminate-axes.ts
+++ b/admin/app/lib/cli/illuminate-axes.ts
@@ -49,12 +49,13 @@ export interface CliClickAxes {
    */
   vertexPrefix: string;
   /**
-   * Personalized PageRank knobs (#801), only meaningful when
-   * `algorithm === "ppr"`. `restartProb` is the restart/teleport-to-seed
-   * probability α in (0,1); `epsilon` is the forward-push residual threshold
-   * ε > 0. 0 means "leave to the server default" (α=0.15 / ε=1e-4) and is the
-   * value that keeps the bare click byte-for-byte the canonical short form —
-   * {@link formatIlluminateClick} only emits these for a non-zero ppr walk.
+   * Push-family locality knobs (#801/#942), meaningful when
+   * `algorithm === "ppr"` or `algorithm === "community"`. `restartProb` is
+   * the restart/teleport-to-seed probability α in (0,1); `epsilon` is the
+   * forward-push residual threshold ε > 0. 0 means "leave to the server
+   * default" (α=0.15 / ε=1e-4) and is the value that keeps the bare click
+   * byte-for-byte the canonical short form — {@link formatIlluminateClick}
+   * only emits these for a non-zero ppr/community walk.
    */
   restartProb: number;
   epsilon: number;
@@ -79,9 +80,9 @@ export const CLI_CLICK_AXIS_DEFAULTS: CliClickAxes = {
   // Empty = no prefix filter, so the bare click stays byte-for-byte the
   // canonical short form `illuminate <seed> 2 5` (the #439 regression guard).
   vertexPrefix: "",
-  // 0 = "use the server default" for both PPR knobs; the formatter omits them
-  // unless algorithm=ppr AND the value is non-zero, so the bare click is
-  // unaffected (#439 / #801).
+  // 0 = "use the server default" for both push knobs; the formatter omits
+  // them unless algorithm=ppr|community AND the value is non-zero, so the
+  // bare click is unaffected (#439 / #801 / #942).
   restartProb: 0,
   epsilon: 0,
 };
@@ -94,6 +95,7 @@ export const CLI_ALGORITHMS: ReadonlyArray<{
   { value: "mst", label: "Spanning tree" },
   { value: "spt", label: "Shortest-path tree" },
   { value: "ppr", label: "Personalized PageRank" },
+  { value: "community", label: "Local community" },
 ];
 
 export const CLI_OBJECTIVES: ReadonlyArray<{
@@ -121,8 +123,9 @@ export const CLI_WEIGHTINGS: ReadonlyArray<{
  * in fixed order (`algorithm=` → `objective=` → `weighting=` → `prefix=`
  * → `restart_prob=` → `epsilon=`) only for axes that diverge from the
  * default; the fixed order keeps scrollback snapshots deterministic and
- * matches the parser's usage string. The two PPR knobs are emitted only
- * when `algorithm=ppr` and the value is non-zero (#801).
+ * matches the parser's usage string. The two push knobs are emitted only
+ * when `algorithm=ppr` or `algorithm=community` and the value is non-zero
+ * (#801/#942).
  *
  * The function is intentionally pure so `bun:test` can round-trip it
  * through {@link parse} without a DOM.
@@ -155,10 +158,12 @@ export function formatIlluminateClick(
   if (axes.vertexPrefix !== "") {
     tokens.push(`prefix=${axes.vertexPrefix}`);
   }
-  // #801: PPR knobs are only meaningful for algorithm=ppr and only when the
-  // operator has overridden the server default (0). Gating on both keeps the
-  // bare click byte-stable (#439) and never emits a knob the server ignores.
-  if (axes.algorithm === "ppr") {
+  // #801/#942: the α/ε knobs are meaningful for the two push-based families
+  // (ppr and community — both carry the same `restart_prob`/`epsilon`
+  // locality knobs) and only when the operator has overridden the server
+  // default (0). Gating on both keeps the bare click byte-stable (#439) and
+  // never emits a knob the server ignores for the BFS families.
+  if (axes.algorithm === "ppr" || axes.algorithm === "community") {
     if (axes.restartProb > 0) {
       tokens.push(`restart_prob=${axes.restartProb}`);
     }

--- a/admin/app/lib/cli/verbs.ts
+++ b/admin/app/lib/cli/verbs.ts
@@ -683,8 +683,8 @@ export const CLI_COMMAND_REFERENCE: readonly CliCommandDoc[] = [
     signature:
       "illuminate <seed> <step> <k> [algorithm=none|mst|spt|ppr|community] [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>] [restart_prob=<float>] [epsilon=<float>]",
     summary:
-      "Walk the graph from a seed (step hops, top-k per hop) and render the subgraph. algorithm=ppr runs Personalized PageRank (tune locality with restart_prob/epsilon); the other axes reduce/weight the discovered subgraph.",
-    example: "illuminate alice 2 5 algorithm=ppr restart_prob=0.25",
+      "Walk the graph from a seed (step hops, top-k per hop) and render the subgraph. algorithm=ppr runs Personalized PageRank and algorithm=community extracts the seed's local community (#845) — both tune locality with restart_prob/epsilon; the other axes reduce/weight the discovered subgraph.",
+    example: "illuminate alice 2 5 algorithm=community",
   },
   {
     group: "Session",

--- a/admin/app/lib/client/infrastructure/api/illuminate.ts
+++ b/admin/app/lib/client/infrastructure/api/illuminate.ts
@@ -14,15 +14,18 @@ export type { Edge, Graph, IlluminateResponse, Vertex } from "./types";
 // The admin UI tracks each axis as a stable string so router
 // serialisation and Playwright fixtures keep one human-readable
 // vocabulary across surfaces. Since #846 the wire request is a params
-// ONEOF (bfs | ppr); this adapter owns the translation from admin's flat
-// axis vocabulary to the typed per-family SDK options — mst/spt select
-// the BFS family's Reduction, ppr selects the PPR family (step has no
-// PPR meaning and is dropped; k becomes topN).
+// ONEOF (bfs | ppr | community); this adapter owns the translation from
+// admin's flat axis vocabulary to the typed per-family SDK options —
+// mst/spt select the BFS family's Reduction, ppr selects the PPR family
+// (step has no PPR meaning and is dropped; k becomes topN), and
+// community selects the local-community family (#845; step dropped, k
+// becomes the max_size upper bound).
 export type Algorithm =
   | "ALGORITHM_UNSPECIFIED"
   | "ALGORITHM_MINIMUM_SPANNING_TREE"
   | "ALGORITHM_SHORTEST_PATH_TREE"
-  | "ALGORITHM_PERSONALIZED_PAGERANK";
+  | "ALGORITHM_PERSONALIZED_PAGERANK"
+  | "ALGORITHM_LOCAL_COMMUNITY";
 
 export type Objective =
   | "OBJECTIVE_UNSPECIFIED"
@@ -50,8 +53,10 @@ export interface IlluminateRequest {
    */
   vertexPrefix?: string;
   /**
-   * Personalized PageRank knobs (#801), only consulted when
-   * `algorithm === "ALGORITHM_PERSONALIZED_PAGERANK"`. `restartProb` is the
+   * Personalized PageRank / local-community knobs, consulted when
+   * `algorithm === "ALGORITHM_PERSONALIZED_PAGERANK"` (#801) or
+   * `algorithm === "ALGORITHM_LOCAL_COMMUNITY"` (#845) — both families
+   * share the same α/ε locality knobs. `restartProb` is the
    * restart/teleport-to-seed probability α in (0,1); `epsilon` is the
    * forward-push residual threshold ε > 0. 0/omitted lets the server apply
    * its defaults (α=0.15 / ε=1e-4).
@@ -66,6 +71,9 @@ const ALGORITHM_TO_REDUCTION: Record<Algorithm, SdkReduction> = {
   ALGORITHM_SHORTEST_PATH_TREE: SdkReduction.SHORTEST_PATH_TREE,
   // PPR is handled as its own oneof family, never as a reduction.
   ALGORITHM_PERSONALIZED_PAGERANK: SdkReduction.UNSPECIFIED,
+  // Local community (#845) is likewise its own oneof family, never a
+  // BFS reduction.
+  ALGORITHM_LOCAL_COMMUNITY: SdkReduction.UNSPECIFIED,
 };
 const OBJECTIVE_TO_SDK: Record<Objective, SdkObjective> = {
   OBJECTIVE_UNSPECIFIED: SdkObjective.UNSPECIFIED,
@@ -85,10 +93,12 @@ const WEIGHTING_TO_SDK: Record<Weighting, SdkWeighting> = {
  * Runs a k-bounded BFS from the supplied seed. Optional knobs (step
  * / k / algorithm / objective / weighting / prefix) default server-side
  * when omitted; `algorithm=ALGORITHM_PERSONALIZED_PAGERANK` switches to a
- * seed-anchored PPR walk tuned by restartProb / epsilon (#801). The SDK
- * returns a rich-shape Graph with `Map<>` values; this adapter flattens
- * it back to admin's array-of-flat-JSON shape so the existing canvas +
- * table consumers keep working unchanged (#409, #410).
+ * seed-anchored PPR walk tuned by restartProb / epsilon (#801), and
+ * `algorithm=ALGORITHM_LOCAL_COMMUNITY` switches to PageRank-Nibble local
+ * community extraction (#845; k is the max_size upper bound, α/ε tune the
+ * push). The SDK returns a rich-shape Graph with `Map<>` values; this
+ * adapter flattens it back to admin's array-of-flat-JSON shape so the
+ * existing canvas + table consumers keep working unchanged (#409, #410).
  */
 export async function illuminate(
   client: LanternClient,
@@ -109,6 +119,17 @@ export async function illuminate(
     if (request.algorithm === "ALGORITHM_PERSONALIZED_PAGERANK") {
       opts.ppr = {
         topN: request.k ?? 0,
+        restartProb: request.restartProb ?? 0,
+        epsilon: request.epsilon ?? 0,
+      };
+    } else if (request.algorithm === "ALGORITHM_LOCAL_COMMUNITY") {
+      // Local community extraction (#845): PageRank-Nibble. Mirrors the Go
+      // CLI translation (`cli/service/service.go` `IlluminateFamilyOption`,
+      // `case "community"`): k is the max_size UPPER BOUND (the conductance
+      // sweep may stop earlier), step has no meaning here and is dropped,
+      // and α/ε pass through (0 = server default, α=0.15 / ε=1e-4).
+      opts.community = {
+        maxSize: request.k ?? 0,
         restartProb: request.restartProb ?? 0,
         epsilon: request.epsilon ?? 0,
       };

--- a/admin/app/lib/client/usecase/cli/dispatcher.test.ts
+++ b/admin/app/lib/client/usecase/cli/dispatcher.test.ts
@@ -21,6 +21,7 @@ import {
   writeEcho,
 } from "./dispatcher";
 import type { Command } from "~/lib/cli/types";
+import { parse } from "~/lib/cli/parser";
 
 // ----------------------------------------------------------------------------
 // FakeLanternClient
@@ -571,5 +572,65 @@ describe("dispatch keys (#674)", () => {
     expect(prefix).toBe("user:");
     expect(opts.limit).toBe(50);
     expect((result as { keys: string[] }).keys).toEqual(["user:1", "user:2"]);
+  });
+});
+
+describe("dispatch illuminate maps the algorithm axis to the family oneof (#942)", () => {
+  // The bug: `algorithm=community` parsed fine but `ALGORITHM_TO_API` had no
+  // `community` entry, so the request silently fell back to a BFS walk. These
+  // tests drive the full parser → dispatcher → adapter seam and assert the
+  // community oneof reaches the SDK — and that neither BFS nor PPR does.
+  const emptyGraph = () => ({ vertices: new Map(), edges: new Map() });
+
+  test("algorithm=community builds the community oneof, not bfs/ppr", async () => {
+    const fake = new FakeLanternClient();
+    fake.stub("illuminate", emptyGraph);
+    const parsed = parse("illuminate a1 2 5 algorithm=community");
+    if (!parsed.ok) {
+      throw new Error(`fixture did not parse: ${parsed.usage}`);
+    }
+    await dispatch({ client: asClient(fake), command: parsed.command });
+
+    expect(fake.calls.map((c) => c.method)).toEqual(["illuminate"]);
+    const [seed, opts] = fake.calls[0].args as [
+      string,
+      { community?: unknown; bfs?: unknown; ppr?: unknown },
+    ];
+    expect(seed).toBe("a1");
+    // k (5) becomes the max_size UPPER BOUND; step (2) has no meaning here
+    // and is dropped; the α/ε knobs default to 0 = "server default". Mirrors
+    // the Go CLI `IlluminateFamilyOption` `case "community"`.
+    expect(opts.community).toEqual({
+      maxSize: 5,
+      restartProb: 0,
+      epsilon: 0,
+    });
+    // The #942 regression guard: the seam must NOT degrade to a BFS/PPR walk.
+    expect(opts.bfs).toBeUndefined();
+    expect(opts.ppr).toBeUndefined();
+  });
+
+  test("community passes restart_prob / epsilon through unchanged", async () => {
+    const fake = new FakeLanternClient();
+    fake.stub("illuminate", emptyGraph);
+    const parsed = parse(
+      "illuminate a1 2 5 algorithm=community restart_prob=0.25 epsilon=0.001",
+    );
+    if (!parsed.ok) {
+      throw new Error(`fixture did not parse: ${parsed.usage}`);
+    }
+    await dispatch({ client: asClient(fake), command: parsed.command });
+
+    const [, opts] = fake.calls[0].args as [
+      string,
+      { community?: unknown; bfs?: unknown; ppr?: unknown },
+    ];
+    expect(opts.community).toEqual({
+      maxSize: 5,
+      restartProb: 0.25,
+      epsilon: 0.001,
+    });
+    expect(opts.bfs).toBeUndefined();
+    expect(opts.ppr).toBeUndefined();
   });
 });

--- a/admin/app/lib/client/usecase/cli/dispatcher.ts
+++ b/admin/app/lib/client/usecase/cli/dispatcher.ts
@@ -51,7 +51,12 @@ import { scanEdges } from "~/lib/client/infrastructure/api/scan-edges";
 import { scanVertexKeys } from "~/lib/client/infrastructure/api/scan-vertex-keys";
 import { scanVertices } from "~/lib/client/infrastructure/api/scan-vertices";
 import type { Edge, Vertex } from "~/lib/client/infrastructure/api/types";
-import type { Command } from "~/lib/cli/types";
+import type {
+  AlgorithmName,
+  Command,
+  ObjectiveName,
+  WeightingName,
+} from "~/lib/cli/types";
 
 export interface DispatchInput {
   client: LanternClient;
@@ -59,17 +64,26 @@ export interface DispatchInput {
   signal?: AbortSignal;
 }
 
-const ALGORITHM_TO_API: Record<string, ApiAlgorithm> = {
+// Translate the CLI's friendly axis vocabulary to the wire enum the
+// illuminate adapter consumes. Keyed by the CLOSED axis unions from
+// `~/lib/cli/types` (not `string`) so that adding a token to
+// `AlgorithmName` / `ObjectiveName` / `WeightingName` without a matching
+// entry here is a `tsc` error, not a silent `undefined` that degrades to
+// the default family. This exhaustiveness guard is the root-cause fix for
+// #942, where `community` parsed but had no `ALGORITHM_TO_API` entry and
+// fell back to a BFS walk.
+const ALGORITHM_TO_API: Record<AlgorithmName, ApiAlgorithm> = {
   none: "ALGORITHM_UNSPECIFIED",
   mst: "ALGORITHM_MINIMUM_SPANNING_TREE",
   spt: "ALGORITHM_SHORTEST_PATH_TREE",
   ppr: "ALGORITHM_PERSONALIZED_PAGERANK",
+  community: "ALGORITHM_LOCAL_COMMUNITY",
 };
-const OBJECTIVE_TO_API: Record<string, ApiObjective> = {
+const OBJECTIVE_TO_API: Record<ObjectiveName, ApiObjective> = {
   min: "OBJECTIVE_MINIMIZE",
   max: "OBJECTIVE_MAXIMIZE",
 };
-const WEIGHTING_TO_API: Record<string, ApiWeighting> = {
+const WEIGHTING_TO_API: Record<WeightingName, ApiWeighting> = {
   raw: "WEIGHTING_RAW",
   tfidf: "WEIGHTING_TFIDF",
   bm25: "WEIGHTING_BM25",

--- a/admin/test/cli-grammar/verbs.json
+++ b/admin/test/cli-grammar/verbs.json
@@ -101,6 +101,14 @@
       "comment": "#801: scientific-notation knob value (Go strconv.ParseFloat parity)"
     },
     {
+      "input": "illuminate alice 2 5 algorithm=community",
+      "comment": "#942: local community (#845) family; knobs default to server values"
+    },
+    {
+      "input": "illuminate alice 2 5 algorithm=community restart_prob=0.25 epsilon=1e-3",
+      "comment": "#942: community shares the ppr restart_prob / epsilon locality knobs"
+    },
+    {
       "input": "Get VERTEX alice",
       "comment": "#437: verb + objective case-insensitive"
     },

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -15,6 +15,41 @@ test.beforeAll(async () => {
   // Edge so illuminate / get edge happy-paths in the canvas spec
   // below have something to render.
   await putEdges([{ tail: "cli:alpha", head: "cli:beta", weight: 2 }]);
+
+  // #942 — a barbell so `illuminate <seed> algorithm=community` has a
+  // clean cluster to extract. Two tight triangles (internal weight 5,
+  // bidirectional) joined by a single weak bridge (weight 0.1). A
+  // LocalCommunity (#845) sweep from a1 cuts the bridge and returns
+  // exactly {a1,a2,a3}; a plain BFS walk (the pre-fix regression) would
+  // instead cross the bridge and pull in b1 at hop 1. `cli:cmty:` prefix
+  // isolates the subgraph from the other seeds sharing this gateway.
+  await putVertices([
+    { key: "cli:cmty:a1", string: "a1" },
+    { key: "cli:cmty:a2", string: "a2" },
+    { key: "cli:cmty:a3", string: "a3" },
+    { key: "cli:cmty:b1", string: "b1" },
+    { key: "cli:cmty:b2", string: "b2" },
+    { key: "cli:cmty:b3", string: "b3" },
+  ]);
+  await putEdges([
+    // Triangle A (tight).
+    { tail: "cli:cmty:a1", head: "cli:cmty:a2", weight: 5 },
+    { tail: "cli:cmty:a2", head: "cli:cmty:a1", weight: 5 },
+    { tail: "cli:cmty:a2", head: "cli:cmty:a3", weight: 5 },
+    { tail: "cli:cmty:a3", head: "cli:cmty:a2", weight: 5 },
+    { tail: "cli:cmty:a1", head: "cli:cmty:a3", weight: 5 },
+    { tail: "cli:cmty:a3", head: "cli:cmty:a1", weight: 5 },
+    // Triangle B (tight).
+    { tail: "cli:cmty:b1", head: "cli:cmty:b2", weight: 5 },
+    { tail: "cli:cmty:b2", head: "cli:cmty:b1", weight: 5 },
+    { tail: "cli:cmty:b2", head: "cli:cmty:b3", weight: 5 },
+    { tail: "cli:cmty:b3", head: "cli:cmty:b2", weight: 5 },
+    { tail: "cli:cmty:b1", head: "cli:cmty:b3", weight: 5 },
+    { tail: "cli:cmty:b3", head: "cli:cmty:b1", weight: 5 },
+    // Weak bridge joining the two triangles.
+    { tail: "cli:cmty:a1", head: "cli:cmty:b1", weight: 0.1 },
+    { tail: "cli:cmty:b1", head: "cli:cmty:a1", weight: 0.1 },
+  ]);
 });
 
 test.beforeEach(async ({ page }) => {
@@ -106,6 +141,58 @@ test.describe("/cli", () => {
     await expect(page.getByTestId("cli-canvas-panel")).toContainText(
       "illuminate cli:alpha 2 5",
     );
+  });
+
+  // #942 — `algorithm=community` must reach the LocalCommunity (#845)
+  // family, not silently fall back to a BFS walk. Regression guard: before
+  // the fix, dispatcher.ts's `ALGORITHM_TO_API` lacked a `community` entry
+  // (typed `Record<string, …>`, so the miss was invisible) and the wire
+  // adapter built `opts.bfs` instead of `opts.community`. On the barbell
+  // seeded above, that BFS walk from a1 crosses the weak bridge and pulls in
+  // b1 at hop 1; the real community extraction cuts the bridge and returns
+  // exactly the seed's triangle {a1,a2,a3}. We assert on the rendered canvas
+  // membership via the test bridge (present/absent), which the CLI reconcile
+  // overwrites per frame (graph-view.ts), so stale nodes cannot leak in.
+  test("illuminate algorithm=community extracts the seed cluster, not a BFS frontier (#942)", async ({
+    page,
+  }) => {
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    await input.fill("illuminate cli:cmty:a1 2 5 algorithm=community");
+    await input.press("Enter");
+    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
+    await expect(page.getByTestId("cli-canvas-panel")).toContainText(
+      "illuminate cli:cmty:a1 2 5 algorithm=community",
+    );
+
+    // Wait for the canvas bridge, then the post-commit graphology reconcile
+    // (the useEffect that adds/drops nodes runs after the label commit above).
+    await page.waitForFunction(() => {
+      const win = window as Window & {
+        __illuminateCanvas?: { getNodePosition: (k: string) => unknown };
+      };
+      return !!win.__illuminateCanvas?.getNodePosition;
+    });
+    const present = (key: string): Promise<boolean> =>
+      page.evaluate((k) => {
+        const win = window as Window & {
+          __illuminateCanvas?: { getNodePosition: (key: string) => unknown };
+        };
+        return win.__illuminateCanvas?.getNodePosition(k) != null;
+      }, key);
+
+    // The seed's tight triangle IS the community. Poll a2 to let the
+    // reconcile land, then assert the rest of the triangle is present.
+    await expect.poll(() => present("cli:cmty:a2")).toBe(true);
+    expect(await present("cli:cmty:a1")).toBe(true);
+    expect(await present("cli:cmty:a3")).toBe(true);
+
+    // The far triangle across the weak bridge is NOT in the community.
+    // `b1` is the load-bearing discriminator: a plain BFS walk (the pre-fix
+    // behaviour) would render it at hop 1.
+    expect(await present("cli:cmty:b1")).toBe(false);
+    expect(await present("cli:cmty:b2")).toBe(false);
+    expect(await present("cli:cmty:b3")).toBe(false);
   });
 
   // #518 — a mutating verb (put/add) folds the new element onto the


### PR DESCRIPTION
## Summary

On the admin `/cli` page, `illuminate <seed> <step> <k> algorithm=community` silently ran a **BFS walk** instead of the LocalCommunity (#845) extraction — the community family was unreachable from the admin SPA.

**Root cause:** `ALGORITHM_TO_API` in `dispatcher.ts` was typed `Record<string, ApiAlgorithm>` and lacked a `community` entry, so the lookup returned `undefined` and the wire adapter (`illuminate.ts`) fell through its `else` branch to build `opts.bfs`. Because the map key type was `string`, the missing entry was invisible to the compiler.

## Fix

Wire the community family through the admin seam, and retype the axis maps so future vocabulary drift becomes a **compile error** instead of a silent fallback:

- **`illuminate.ts`** — add `ALGORITHM_LOCAL_COMMUNITY` to the `Algorithm` union + `ALGORITHM_TO_REDUCTION`; build `opts.community` (`k → maxSize` upper bound, `step` dropped, `restart_prob`/`epsilon` passthrough, `0 = server default`), mirroring the Go CLI `IlluminateFamilyOption` `case "community"`.
- **`dispatcher.ts`** — add the `community` entry and retype `ALGORITHM_TO_API` / `OBJECTIVE_TO_API` / `WEIGHTING_TO_API` as `Record<…Name, Api…>` (**the root-cause regression guard**).
- **`illuminate-axes.ts` + `CliAxisPicker.tsx`** — register the community algorithm, widen the `restart_prob`/`epsilon` knob gate to `ppr|community`, disable `step` + tooltip `k` for the push families, keep aria labels family-neutral.
- **`verbs.ts`** — extend `CLI_COMMAND_REFERENCE` only. `HELP_TEXT` left byte-locked to the Go `parser.HelpText` (already lists community).
- **`verbs.json`** — add community grammar fixtures (read by **both** the Go `grammar_fixture_test` and the TS `grammar.test`).

## Tests

- `dispatcher.test.ts` — real parser → dispatcher → adapter seam asserts `opts.community` (not `opts.bfs`/`opts.ppr`).
- `illuminate-axes.test.ts`, `complete.test.ts` — community coverage.
- `cli.spec.ts` (e2e) — runs `algorithm=community` on a barbell and asserts the canvas holds the seed's triangle `{a1,a2,a3}`, **not** the BFS frontier `b1` across the weak bridge.
- #439 bare-click-to-illuminate byte stability preserved.

## Quality gate

All green: `format`, `lint`, `typecheck`, `test` (705 unit), `build`, `test:e2e` (59 Playwright), and root `go test ./...`.

Closes #942