### PR TITLE
feat(admin): vertices pager shows "Page N of M"

### DIFF
--- a/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.tsx
+++ b/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.tsx
@@ -33,6 +33,7 @@ import {
   DEFAULT_VERTEX_PAGE_SIZE,
 } from "~/lib/client/usecase/browse-vertices/use-browse-vertices";
 import { useSearchVertices } from "~/lib/client/usecase/search-vertices/use-search-vertices";
+import { selectTotalPages } from "~/lib/client/usecase/browse-vertices/selectors";
 import {
   formatScore,
   selectCaption,
@@ -410,6 +411,7 @@ export function BrowseVerticesPage() {
       {!searching ? (
         <Pager
           pageNumber={browse.pageNumber}
+          totalPages={selectTotalPages(browse.state, browse.pageSize)}
           canGoPrevious={browse.canGoPrevious}
           canGoNext={browse.canGoNext}
           loading={browse.state.status === "loading"}

--- a/admin/app/components/browse-vertices/Pager/Pager.tsx
+++ b/admin/app/components/browse-vertices/Pager/Pager.tsx
@@ -7,6 +7,15 @@ import styles from "./Pager.module.css";
 
 export interface PagerProps {
   pageNumber: number;
+  /**
+   * Total page count for the active prefix, derived from
+   * `CountVerticesByPrefix` (see `selectTotalPages`). When present the
+   * indicator reads "Page N of M"; when `null`/`undefined` (no fresh count)
+   * it falls back to the bare "Page N". Display-only — navigability stays
+   * cursor-driven via `canGoNext`, since the count is approximate under
+   * concurrent writes.
+   */
+  totalPages?: number | null;
   canGoPrevious: boolean;
   canGoNext: boolean;
   loading: boolean;
@@ -22,6 +31,7 @@ export interface PagerProps {
  */
 export function Pager({
   pageNumber,
+  totalPages,
   canGoPrevious,
   canGoNext,
   loading,
@@ -40,7 +50,9 @@ export function Pager({
         Previous
       </Button>
       <span className={styles.indicator} data-testid="pager-page">
-        Page {pageNumber}
+        {totalPages != null
+          ? `Page ${pageNumber} of ${totalPages}`
+          : `Page ${pageNumber}`}
       </span>
       <Button
         appearance="subtle"

--- a/admin/app/lib/client/usecase/browse-vertices/reducer.test.ts
+++ b/admin/app/lib/client/usecase/browse-vertices/reducer.test.ts
@@ -32,7 +32,7 @@ describe("browseVerticesReducer", () => {
   });
 
   it("resets state and bumps epoch on PREFIX_CHANGED", () => {
-    const base = withEpoch(INITIAL_BROWSE_VERTICES_STATE, 3);
+    const base = { ...withEpoch(INITIAL_BROWSE_VERTICES_STATE, 3), count: 99 };
     const next = browseVerticesReducer(base, {
       type: "PREFIX_CHANGED",
       prefix: "user:",
@@ -42,6 +42,9 @@ describe("browseVerticesReducer", () => {
     expect(next.pages).toEqual([]);
     expect(next.currentPageIndex).toBe(-1);
     expect(next.status).toBe("idle");
+    // A stale count must be cleared so `selectTotalPages` never renders a wrong
+    // total while the operator retypes the prefix (#946).
+    expect(next.count).toBeNull();
   });
 
   it("ignores PAGE_REQUESTED from a stale epoch", () => {

--- a/admin/app/lib/client/usecase/browse-vertices/selectors.test.ts
+++ b/admin/app/lib/client/usecase/browse-vertices/selectors.test.ts
@@ -4,6 +4,7 @@ import {
   selectCanGoPrevious,
   selectCurrentPage,
   selectPageNumber,
+  selectTotalPages,
   selectVisibleVertices,
 } from "./selectors";
 import {
@@ -66,5 +67,36 @@ describe("browse-vertices selectors", () => {
     const state = stateWithPages([PAGE_A, PAGE_B], 1);
     expect(selectCanGoNext(state)).toBe(false);
     expect(selectCanGoPrevious(state)).toBe(true);
+  });
+});
+
+describe("selectTotalPages", () => {
+  function stateWithCount(count: number | null): BrowseVerticesState {
+    return { ...INITIAL_BROWSE_VERTICES_STATE, count };
+  }
+
+  it("divides an exact multiple", () => {
+    expect(selectTotalPages(stateWithCount(100), 50)).toBe(2);
+  });
+
+  it("rounds a remainder up to the next page", () => {
+    expect(selectTotalPages(stateWithCount(101), 50)).toBe(3);
+  });
+
+  it("returns a single page when the count fits exactly on one page", () => {
+    expect(selectTotalPages(stateWithCount(50), 50)).toBe(1);
+  });
+
+  it("returns 1 for an empty prefix so the pager reads 'Page 1 of 1'", () => {
+    expect(selectTotalPages(stateWithCount(0), 50)).toBe(1);
+  });
+
+  it("returns null when the count is not yet known (fresh-count guard)", () => {
+    expect(selectTotalPages(stateWithCount(null), 50)).toBeNull();
+  });
+
+  it("returns null for a non-positive page size", () => {
+    expect(selectTotalPages(stateWithCount(100), 0)).toBeNull();
+    expect(selectTotalPages(stateWithCount(100), -50)).toBeNull();
   });
 });

--- a/admin/app/lib/client/usecase/browse-vertices/selectors.ts
+++ b/admin/app/lib/client/usecase/browse-vertices/selectors.ts
@@ -36,3 +36,31 @@ export function selectCanGoNext(state: BrowseVerticesState): boolean {
 export function selectPageNumber(state: BrowseVerticesState): number {
   return state.currentPageIndex + 1;
 }
+
+/**
+ * Total number of pages for the active prefix, derived from the cached
+ * `CountVerticesByPrefix` result so the pager can read "Page N of M" instead
+ * of a bare "Page N".
+ *
+ * Returns `null` when there is no usable total to show:
+ *   - `state.count === null` — no fresh count. The reducer resets `count` to
+ *     `null` on every prefix change, so a non-null count is always fresh for
+ *     the prefix currently on screen; a stale total never renders while the
+ *     operator retypes the prefix.
+ *   - `pageSize <= 0` — guards against a divide-by-zero / negative page size.
+ *
+ * `count === 0` yields `1` (via the `Math.max`) so an empty prefix still reads
+ * "Page 1 of 1" beside the empty table the pager is rendered next to.
+ *
+ * Display-only: navigability stays cursor-driven (see `selectCanGoNext`)
+ * because the count is approximate under concurrent writes.
+ */
+export function selectTotalPages(
+  state: BrowseVerticesState,
+  pageSize: number,
+): number | null {
+  if (state.count === null || pageSize <= 0) {
+    return null;
+  }
+  return Math.max(1, Math.ceil(state.count / pageSize));
+}

--- a/admin/app/lib/client/usecase/browse-vertices/use-browse-vertices.ts
+++ b/admin/app/lib/client/usecase/browse-vertices/use-browse-vertices.ts
@@ -35,6 +35,9 @@ export interface UseBrowseVerticesResult {
   state: BrowseVerticesState;
   prefix: string;
   pageNumber: number;
+  /** Page size in effect for this scan — the single source of truth for
+   * page-count math (see `selectTotalPages`). */
+  pageSize: number;
   vertices: ReturnType<typeof selectVisibleVertices>;
   count: number | null;
   canGoPrevious: boolean;
@@ -159,6 +162,7 @@ export function useBrowseVertices(
       state,
       prefix: state.prefix,
       pageNumber: selectPageNumber(state),
+      pageSize,
       vertices: selectVisibleVertices(state),
       count: state.count,
       canGoPrevious: selectCanGoPrevious(state),
@@ -168,6 +172,6 @@ export function useBrowseVertices(
       goNext,
       retry,
     }),
-    [state, setPrefix, goPrevious, goNext, retry],
+    [state, pageSize, setPrefix, goPrevious, goNext, retry],
   );
 }


### PR DESCRIPTION
## Summary

The browse-vertices pager read a bare `Previous · Page 1 · Next` even though the page already fetches the exact prefix match count (`CountVerticesByPrefix`, shown in the `N vertices` badge) and uses a fixed page size (50). The total is derivable from state we already hold — operators no longer have to divide in their head.

Now the vertices pager reads **`Page 2 of 14`** when a fresh count is available, falling back to the bare **`Page 2`** otherwise.

## Changes

- **`selectors.ts`** — add `selectTotalPages(state, pageSize)`: returns `null` when the count is not fresh (`count === null`) or `pageSize <= 0`, else `Math.max(1, Math.ceil(count / pageSize))`. The reducer already resets `count` to `null` on every prefix change (it spreads `INITIAL_BROWSE_VERTICES_STATE` on `PREFIX_CHANGED`), so a non-null count is always fresh for the prefix on screen — no staleness fix was needed. `count === 0` yields `1` so an empty prefix reads `Page 1 of 1` beside the empty table the pager is still rendered next to.
- **`Pager.tsx` (browse-vertices copy only)** — add optional `totalPages?: number | null`; render `Page N of M` when non-null, `Page N` otherwise. **Navigability stays cursor-driven** — `canGoPrevious`/`canGoNext` are unchanged, since the count is approximate under concurrent writes and the scan cursor is the sole source of truth for whether a next page exists.
- **`use-browse-vertices.ts`** — expose `pageSize` from the hook result so the page has a single source of truth for the page-count math.
- **`BrowseVerticesPage.tsx`** — pass `totalPages={selectTotalPages(browse.state, browse.pageSize)}`.

The **browse-edges Pager is left untouched** — it's a deliberate separate copy (F2 boundary comment) and there is no `CountEdgesByPrefix` RPC. Parity there is a server-surface issue, not this one.

## Tests

- `selectors.test.ts`: `selectTotalPages` cases — `100/50 → 2`, `101 → 3`, `50 → 1`, `0 → 1`, `null → null`, non-positive `pageSize → null`.
- `reducer.test.ts`: pin `count === null` right after `PREFIX_CHANGED` (a stale total must never render while the operator retypes the prefix).

## Quality gate

`cd admin && bun run format && bun run lint && bun run typecheck && bun run test && bun run build` — all green (704 unit tests pass; lint reports only a pre-existing warning in an unrelated file). Per the shared-resource note, `test:e2e` was skipped to avoid port contention with sibling sessions; the logic is fully unit-covered and no existing e2e/unit spec asserts on the `pager-page` string.

Closes #946