### PR TITLE
fix(admin): truncate long keys in Browse tables instead of overflowing columns

### DIFF
--- a/admin/app/components/browse-edges/BrowseEdgesPage/BrowseEdgesPage.module.css
+++ b/admin/app/components/browse-edges/BrowseEdgesPage/BrowseEdgesPage.module.css
@@ -126,10 +126,27 @@
      Illuminate action pair and the Expires header render at full width
      without clipping (#657). */
   min-width: 680px;
+  /* Turn the percentage column widths into hard budgets so a long tail/head
+     key truncates inside its own cell instead of painting across the
+     neighbouring columns (#944). Fluent's native Table already applies this,
+     but pin it here so the Browse tables don't rely on that default. */
+  table-layout: fixed;
 }
 
 .colKey {
-  width: 30%;
+  width: 28%;
+  /* Clip an over-long key at the column edge; the ellipsis on .keyLink is the
+     visible truncation and this is the backstop (#944). */
+  overflow: hidden;
+}
+
+/* Fluent's TableCellLayout nests the key Link inside flex containers whose
+   items default to min-width:auto and so refuse to shrink below the (long)
+   key, which defeats the ellipsis. Let them shrink so .keyLink's
+   max-width:100% clamps to the fixed column width (#944). */
+.colKey :global(.fui-TableCellLayout__content),
+.colKey :global(.fui-TableCellLayout__main) {
+  min-width: 0;
 }
 
 .colWeight {
@@ -142,8 +159,13 @@
 }
 
 .colActions {
-  width: 12%;
+  width: 16%;
   text-align: right;
+  /* Keep the Edit + Illuminate pair on a single line (#944). Widened from 12%
+     to 16% — matching the Vertices table — so that single line does not clip
+     the Illuminate label; the 4% comes off the two 30%→28% key columns, which
+     now truncate anyway (#944). */
+  white-space: nowrap;
 }
 
 .keyLink {
@@ -155,6 +177,15 @@
     SFMono-Regular,
     monospace
   );
+  /* Truncate an over-long key with an ellipsis instead of overflowing into the
+     Head/Weight columns; the full key stays reachable via the row's title
+     tooltip and the vertex detail page (#944). */
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
 }
 
 .keyLink:hover {

--- a/admin/app/components/browse-edges/BrowseEdgesPage/BrowseEdgesPage.tsx
+++ b/admin/app/components/browse-edges/BrowseEdgesPage/BrowseEdgesPage.tsx
@@ -133,6 +133,7 @@ export function BrowseEdgesPage() {
                       <Link
                         to={`/vertices/${encodeURIComponent(tail)}`}
                         className={styles.keyLink}
+                        title={tail}
                       >
                         {tail || "—"}
                       </Link>
@@ -143,6 +144,7 @@ export function BrowseEdgesPage() {
                       <Link
                         to={`/vertices/${encodeURIComponent(head)}`}
                         className={styles.keyLink}
+                        title={head}
                       >
                         {head || "—"}
                       </Link>

--- a/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.module.css
+++ b/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.module.css
@@ -144,10 +144,27 @@
      without clipping (#657, #652). Matches the Edges table floor now that
      both Browse surfaces carry the same two-button Actions cell. */
   min-width: 680px;
+  /* Turn the percentage column widths into hard budgets so a long key
+     truncates inside its own cell instead of bleeding into the Value column
+     (#944). Fluent's native Table already applies this, but pin it here so the
+     Browse tables don't rely on that default. */
+  table-layout: fixed;
 }
 
 .colKey {
   width: 32%;
+  /* Clip an over-long key at the column edge; the ellipsis on .keyLink is the
+     visible truncation and this is the backstop (#944). */
+  overflow: hidden;
+}
+
+/* Fluent's TableCellLayout nests the key Link inside flex containers whose
+   items default to min-width:auto and so refuse to shrink below the (long)
+   key, which defeats the ellipsis. Let them shrink so .keyLink's
+   max-width:100% clamps to the fixed column width (#944). */
+.colKey :global(.fui-TableCellLayout__content),
+.colKey :global(.fui-TableCellLayout__main) {
+  min-width: 0;
 }
 
 .colExp {
@@ -157,6 +174,8 @@
 .colActions {
   width: 16%;
   text-align: right;
+  /* Keep the Edit + Illuminate pair on a single line (#944). */
+  white-space: nowrap;
 }
 
 .colScore {
@@ -172,6 +191,15 @@
     SFMono-Regular,
     monospace
   );
+  /* Truncate an over-long key with an ellipsis instead of overflowing into the
+     Value column; the full key stays reachable via the row's title tooltip and
+     the vertex detail page (#944). */
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
 }
 
 .keyLink:hover {

--- a/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.tsx
+++ b/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.tsx
@@ -325,6 +325,7 @@ export function BrowseVerticesPage() {
                       <Link
                         to={`/vertices/${encodeURIComponent(row.key)}`}
                         className={styles.keyLink}
+                        title={row.key}
                       >
                         {row.key || "—"}
                       </Link>

--- a/admin/tests/e2e/browse.spec.ts
+++ b/admin/tests/e2e/browse.spec.ts
@@ -1,6 +1,13 @@
 import { expect, test } from "@playwright/test";
 
-import { CONNECT_URL, STORAGE_KEY, putEdges, putVertices } from "./helpers";
+import {
+  CONNECT_URL,
+  STORAGE_KEY,
+  connectCall,
+  deleteVerticesByPrefix,
+  putEdges,
+  putVertices,
+} from "./helpers";
 
 /**
  * Seeds a small graph for the Browse screen:
@@ -267,6 +274,66 @@ test.describe("/edges", () => {
     await expect(table.getByRole("link", { name: "e2e:vertex:c" })).toHaveCount(
       0,
     );
+  });
+});
+
+// #944: with realistic key lengths (spotify-style keys run ~45+ chars) an
+// un-clamped Tail cell paints its text straight across the Head column and
+// Head bleeds into Weight. The key cells must truncate with an ellipsis and
+// keep the full key reachable via a native `title` tooltip.
+test.describe("/edges — long keys truncate instead of overlapping (#944)", () => {
+  // Both endpoints are well past any column budget. If the fix regresses, the
+  // tail text overflows into the Head column and the bounding-box assertion
+  // below trips.
+  const longTail = `e2e-long:tail:${"t".repeat(60)}`;
+  const longHead = `e2e-long:head:${"h".repeat(60)}`;
+
+  test.beforeAll(async () => {
+    // Idempotent seed so a re-run (or a prior crash) can't leave a duplicate
+    // e2e-long row that would break the single-row locators.
+    await connectCall("DeleteEdge", { tail: longTail, head: longHead }).catch(
+      () => undefined,
+    );
+    await putEdges([{ tail: longTail, head: longHead, weight: 1 }]);
+  });
+
+  test.afterAll(async () => {
+    await connectCall("DeleteEdge", { tail: longTail, head: longHead }).catch(
+      () => undefined,
+    );
+    // PutEdges may materialise the endpoint vertices; clear the whole prefix.
+    await deleteVerticesByPrefix("e2e-long:").catch(() => undefined);
+  });
+
+  test("clamps the tail/head cells and exposes the full key via title", async ({
+    page,
+  }) => {
+    await page.goto("/edges");
+    await page.getByTestId("edge-tail-prefix-input").fill("e2e-long:");
+
+    const table = page.getByTestId("edges-table");
+    await expect(table).toBeVisible();
+
+    const tailLink = table.getByRole("link", { name: longTail });
+    const headLink = table.getByRole("link", { name: longHead });
+    await expect(tailLink).toBeVisible();
+    await expect(headLink).toBeVisible();
+
+    // The full key is truncated on screen but stays reachable on hover — the
+    // detail page remains the canonical full view.
+    await expect(tailLink).toHaveAttribute("title", longTail);
+    await expect(headLink).toHaveAttribute("title", longHead);
+
+    // No horizontal overlap: the rendered Tail link must end before the Head
+    // link begins (+1px slack for sub-pixel rounding). Without the ellipsis
+    // clamp the tail text runs across the Head column and this fails.
+    const tailBox = await tailLink.boundingBox();
+    const headBox = await headLink.boundingBox();
+    expect(tailBox).not.toBeNull();
+    expect(headBox).not.toBeNull();
+    if (tailBox && headBox) {
+      expect(tailBox.x + tailBox.width).toBeLessThanOrEqual(headBox.x + 1);
+    }
   });
 });
 


### PR DESCRIPTION
## What & why

Long vertex/edge keys (e.g. `spotify:content:album:06re45NBDCPah74jnVOISQ`) painted straight across the neighbouring **Head / Weight / Value** columns in the **Edges** and **Vertices** Browse tables, colliding with their text (see #944).

## The fix (CSS Modules + `title`, per the admin rule — no Fluent `makeStyles`, no new shared component)

- **Ellipsis clamp on the key `Link`** — `display:inline-block; max-width:100%; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; vertical-align:bottom`.
- **`table-layout: fixed`** on `.table` so the percentage widths become hard budgets.
- **Flex-truncation fix for Fluent's `TableCellLayout`** — `overflow:hidden` on the key cell plus `min-width:0` on `.fui-TableCellLayout__content` / `__main`, whose default `min-width:auto` otherwise refuses to shrink and defeats the ellipsis.
- **Full key stays reachable** via a native `title` tooltip on each key `Link` (`title={tail}` / `title={head}` / `title={row.key}`); the vertex detail page remains the canonical full view.
- **Actions stay on one line** — `white-space:nowrap` on `.colActions`, and the Edges Actions column widened `12% → 16%` (matching the Vertices table) by reclaiming 4% from the two key columns (`30% → 28%`, which now truncate anyway) so the **Illuminate** label no longer clips.

The same recipe is duplicated across both Browse pages (Edges + Vertices prefix table **and** the search-results key cell), keeping the F2 component boundary.

## Verification

- Manually verified in the browser at 1280px (keys truncate; Tail/Head/Weight/Value/Actions no longer collide; Edit + Illuminate render fully) and at the 680px table minimum (wrapper scrolls horizontally, consistent with the existing #657 mobile behaviour).
- Added a Playwright regression in `admin/tests/e2e/browse.spec.ts`: seeds an edge whose tail and head are both 60+ chars, asserts the two key cells do **not** overlap horizontally (`tailBox.x + tailBox.width <= headBox.x + 1`), and asserts each key `Link`'s `title` equals the full key; seeded data is cleaned up.
- Quality gate green: `format` / `lint` (0 errors) / `typecheck` / unit (698 pass) / `build`, and the full Playwright e2e suite (59 pass, single-worker CI-faithful run).

Closes #944