### PR TITLE
feat(admin): queue CLI keystrokes + multi-line paste while a command runs

### DIFF
--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -104,40 +104,30 @@ export function CliPage() {
     if (el) el.scrollTop = el.scrollHeight;
   }, [cli.scrollback]);
 
-  // The prompt is `disabled` while a dispatch is in flight (busy) — that
-  // preserves the `Cancel`/busy semantics and lets the window-level Esc
-  // handler own cancellation. But the browser blurs a disabled element and
-  // never restores focus when it re-enables, so after every Enter-submitted
-  // command the caret would be ejected to <body> and the operator would
-  // have to click back in (#520). Refocus the prompt + park the caret at
-  // the end on the disabled→enabled edge. This is the Enter counterpart
-  // to the Tab refocus in `onKeyDown` (#519); here the cause is the
-  // disabled→blur edge (not Tabster), so no rAF deferral is needed. Only
-  // reclaim focus if the disable left it on <body> — respect a deliberate
-  // focus move (e.g. into the axis picker) the operator made mid-command.
-  const promptDisabled = cli.busy;
-  const wasPromptDisabled = useRef(promptDisabled);
-  useEffect(() => {
-    const justEnabled = wasPromptDisabled.current && !promptDisabled;
-    wasPromptDisabled.current = promptDisabled;
-    if (!justEnabled) return;
-    const active = document.activeElement;
-    if (active !== null && active !== document.body) return;
-    const node = inputRef.current;
-    if (!node) return;
-    node.focus();
-    const end = node.value.length;
-    node.setSelectionRange(end, end);
-  }, [promptDisabled]);
+  // Multi-line paste is a script (#945): each line runs as its own command
+  // via the controller's pending-command queue, so pasting a seed script
+  // from a doc or an issue reproduces a graph state instead of the newlines
+  // flattening into the single-line input. A single-line paste keeps the
+  // browser default (drop the text into the prompt for the operator to edit).
+  const onPaste = useCallback(
+    (e: React.ClipboardEvent<HTMLInputElement>) => {
+      const text = e.clipboardData.getData("text");
+      if (!text.includes("\n")) return;
+      e.preventDefault();
+      cli.enqueueScript(text.split("\n"));
+    },
+    [cli],
+  );
 
   // Click-to-illuminate (#439, #464). Writes the picker-formatted
   // illuminate command into the prompt and submits it through the same
   // parser path the user would hit by typing it. With the picker at its
   // defaults the formatter emits the canonical short form
-  // `illuminate <key> 2 5` (regression guard).
+  // `illuminate <key> 2 5` (regression guard). A click while a command is
+  // in flight enqueues (#945) rather than being swallowed, so the walk runs
+  // as soon as the current dispatch settles.
   const onNodeClick = useCallback(
     (key: string) => {
-      if (cli.busy) return;
       cli.runRaw(formatIlluminateClick(key, axisPicker.axes));
     },
     [cli, axisPicker.axes],
@@ -145,10 +135,12 @@ export function CliPage() {
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      // Esc / Ctrl+L are owned by the window-level handler in `useCli`
-      // so they work even while the input is `disabled` (busy state) or
-      // without focus. Enter / ArrowUp / ArrowDown stay local because
-      // they read and write input state.
+      // Esc / Ctrl+L are owned by the window-level handler in `useCli` so
+      // they work without focus (and, historically, while the input was
+      // `disabled`). The prompt is always editable now (#945), but keeping
+      // them at window scope means they still fire from anywhere. Enter /
+      // ArrowUp / ArrowDown stay local because they read and write input
+      // state.
       if (e.key === "Tab") {
         // Terminal-style completion (#515). Resolve the active token,
         // then either apply the sole candidate, advance to the longest
@@ -302,8 +294,10 @@ export function CliPage() {
           {renderedScrollback}
 
           {/* Live prompt — an inline terminal line that scrolls with the
-              output, not a detached form (#515). Always rendered so the
-              `cli-input` testid and disabled-while-busy semantics hold. */}
+              output, not a detached form (#515). Always editable, even
+              while a command is in flight: Enter buffers into the
+              controller's pending-command queue instead of dropping the
+              keystrokes into a `disabled` input (#945). */}
           <div className={styles.promptRow}>
             <span className={styles.prompt} aria-hidden="true">
               ❯
@@ -317,8 +311,8 @@ export function CliPage() {
                 cli.setInput(e.target.value);
               }}
               onKeyDown={onKeyDown}
+              onPaste={onPaste}
               placeholder="get vertex alice    |    illuminate alice 2 5 algorithm=spt"
-              disabled={promptDisabled}
               data-testid="cli-input"
               aria-label="CLI command input"
               autoComplete="off"

--- a/admin/app/lib/client/usecase/cli/reducer.test.ts
+++ b/admin/app/lib/client/usecase/cli/reducer.test.ts
@@ -92,16 +92,32 @@ describe("cliReducer", () => {
     });
   });
 
-  describe("COMMAND_SUBMITTED", () => {
-    it("pushes to history, resets the cursor, and clears the prompt", () => {
+  describe("HISTORY_APPENDED", () => {
+    it("pushes to history at run time and resets the cursor without touching the prompt", () => {
       const base = withHistory(["a"], 0);
       const next = cliReducer(
-        { ...base, input: "get vertex bob" },
-        { type: "COMMAND_SUBMITTED", raw: "get vertex bob" },
+        { ...base, input: "typing next" },
+        { type: "HISTORY_APPENDED", raw: "get vertex bob" },
       );
       expect(next.history).toEqual(["a", "get vertex bob"]);
       expect(next.historyIndex).toBeNull();
+      // The prompt is deliberately untouched: a queued command joins history
+      // when it drains, and the operator may be mid-typing the next line
+      // (#945) — clearing it here would drop those keystrokes.
+      expect(next.input).toBe("typing next");
+    });
+  });
+
+  describe("PROMPT_CLEARED", () => {
+    it("clears the prompt + history cursor without touching history", () => {
+      const base = withHistory(["a", "b"], 1);
+      const next = cliReducer(
+        { ...base, input: "half typed" },
+        { type: "PROMPT_CLEARED" },
+      );
       expect(next.input).toBe("");
+      expect(next.historyIndex).toBeNull();
+      expect(next.history).toEqual(["a", "b"]);
     });
   });
 
@@ -157,6 +173,110 @@ describe("cliReducer", () => {
       expect(running.phase).toBe("running");
       const idle = cliReducer(running, { type: "RUN_SETTLED" });
       expect(idle.phase).toBe("idle");
+    });
+  });
+
+  describe("pending-command queue (#945)", () => {
+    const putX: Command = {
+      verb: "put",
+      objective: "vertex",
+      key: "x",
+      value: "1",
+      ttlSeconds: 0,
+      valueType: "auto",
+    };
+
+    it("ENQUEUE appends raw input in FIFO order without echoing to scrollback", () => {
+      let state = cliReducer(INITIAL_CLI_STATE, {
+        type: "ENQUEUE",
+        input: "put vertex a 1",
+      });
+      state = cliReducer(state, { type: "ENQUEUE", input: "put vertex b 2" });
+      expect(state.queue).toEqual(["put vertex a 1", "put vertex b 2"]);
+      // No scrollback echo yet — it happens when the command actually runs,
+      // so scrollback order stays execution order.
+      expect(state.scrollback).toEqual(INITIAL_CLI_STATE.scrollback);
+    });
+
+    it("ENQUEUE appends while a dispatch is running", () => {
+      const running = cliReducer(INITIAL_CLI_STATE, { type: "RUN_STARTED" });
+      const next = cliReducer(running, {
+        type: "ENQUEUE",
+        input: "get vertex a",
+      });
+      expect(next.phase).toBe("running");
+      expect(next.queue).toEqual(["get vertex a"]);
+    });
+
+    it("DEQUEUE drops the head, preserving FIFO drain order", () => {
+      let state: CliState = {
+        ...INITIAL_CLI_STATE,
+        queue: ["one", "two", "three"],
+      };
+      state = cliReducer(state, { type: "DEQUEUE" });
+      expect(state.queue).toEqual(["two", "three"]);
+      state = cliReducer(state, { type: "DEQUEUE" });
+      expect(state.queue).toEqual(["three"]);
+    });
+
+    it("DEQUEUE on an empty queue is identity", () => {
+      const next = cliReducer(INITIAL_CLI_STATE, { type: "DEQUEUE" });
+      expect(next).toBe(INITIAL_CLI_STATE);
+    });
+
+    it("QUEUE_CLEARED drops every pending command (Esc = stop the script)", () => {
+      const state: CliState = {
+        ...INITIAL_CLI_STATE,
+        queue: ["one", "two", "three"],
+      };
+      const next = cliReducer(state, { type: "QUEUE_CLEARED" });
+      expect(next.queue).toEqual([]);
+      // No scrollback entry — the "aborted" line already explains the stop.
+      expect(next.scrollback).toEqual(INITIAL_CLI_STATE.scrollback);
+    });
+
+    it("RUN_FAILED clears the queue and appends an info entry with the dropped count", () => {
+      const state: CliState = {
+        ...INITIAL_CLI_STATE,
+        queue: ["two", "three", "four"],
+      };
+      const next = cliReducer(state, { type: "RUN_FAILED" });
+      expect(next.queue).toEqual([]);
+      const last = next.scrollback[next.scrollback.length - 1];
+      expect(last.kind).toBe("info");
+      expect(last.text).toBe(
+        "queue cleared after error (3 pending commands dropped)",
+      );
+      expect(next.nextEntryId).toBe(INITIAL_CLI_STATE.nextEntryId + 1);
+    });
+
+    it("RUN_FAILED singularises the count for a single dropped command", () => {
+      const state: CliState = { ...INITIAL_CLI_STATE, queue: ["only"] };
+      const next = cliReducer(state, { type: "RUN_FAILED" });
+      const last = next.scrollback[next.scrollback.length - 1];
+      expect(last.text).toBe(
+        "queue cleared after error (1 pending command dropped)",
+      );
+    });
+
+    it("RUN_FAILED with an empty queue is identity (a lone error shows only its chip)", () => {
+      const next = cliReducer(INITIAL_CLI_STATE, { type: "RUN_FAILED" });
+      expect(next).toBe(INITIAL_CLI_STATE);
+    });
+
+    it("survives GRAPH_UPDATED and GRAPH_MERGED untouched", () => {
+      const base: CliState = {
+        ...INITIAL_CLI_STATE,
+        queue: ["pending one", "pending two"],
+      };
+      const updated = cliReducer(base, { type: "GRAPH_UPDATED", graph: GRAPH });
+      expect(updated.queue).toEqual(["pending one", "pending two"]);
+      const merged = cliReducer(base, {
+        type: "GRAPH_MERGED",
+        source: "put vertex x 1",
+        merge: commandResultToGraphMerge(putX)!,
+      });
+      expect(merged.queue).toEqual(["pending one", "pending two"]);
     });
   });
 

--- a/admin/app/lib/client/usecase/cli/reducer.ts
+++ b/admin/app/lib/client/usecase/cli/reducer.ts
@@ -13,8 +13,30 @@ export type CliAction =
   | { type: "HISTORY_PREV" }
   /** Arrow-down: move toward the newest history entry / empty prompt. */
   | { type: "HISTORY_NEXT" }
-  /** A raw line was submitted: push to history and clear the prompt. */
-  | { type: "COMMAND_SUBMITTED"; raw: string }
+  /**
+   * A raw line was accepted for execution: push it to `history` (at run
+   * time, so history order === execution order — queued lines join here
+   * when they drain, not when they were typed). Does NOT touch the prompt.
+   */
+  | { type: "HISTORY_APPENDED"; raw: string }
+  /** The prompt was submitted (Enter): clear the input box + history cursor. */
+  | { type: "PROMPT_CLEARED" }
+  /**
+   * A line was submitted while a dispatch was in flight (#945): append it
+   * to the pending-command queue instead of dropping the keystrokes. No
+   * scrollback echo yet — the echo happens when the command actually runs
+   * (see `HISTORY_APPENDED`/`ENTRY_APPENDED`), so scrollback order stays
+   * execution order.
+   */
+  | { type: "ENQUEUE"; input: string }
+  /** Drop the head of the pending-command queue (the drain step ran it). */
+  | { type: "DEQUEUE" }
+  /**
+   * Discard every pending command (#945). Wired to cancellation (Esc /
+   * Cancel): hitting Esc mid-script means "stop the script", not "skip one
+   * line". No scrollback entry — the `aborted` line already explains it.
+   */
+  | { type: "QUEUE_CLEARED" }
   /** Append a scrollback line (auto-assigns the next id). */
   | { type: "ENTRY_APPENDED"; entry: Omit<ScrollbackEntry, "id"> }
   /** Reset the scrollback to just the banner (Clear / Ctrl+L). */
@@ -23,6 +45,16 @@ export type CliAction =
   | { type: "RUN_STARTED" }
   /** A dispatch settled (ok, error, or abort): return to `idle`. */
   | { type: "RUN_SETTLED" }
+  /**
+   * A command errored (#945). Clears the remaining queue so a fail-fast
+   * halt keeps a typo'd or rejected line from letting the rest of a pasted
+   * script mutate the graph, and — when there were pending commands —
+   * appends an info line naming how many were dropped. The red error chip
+   * itself is a separate `ENTRY_APPENDED`; this action only owns the
+   * queue-clear + the "dropped N" notice. Phase returns to idle via the
+   * always-run `RUN_SETTLED`.
+   */
+  | { type: "RUN_FAILED" }
   /** A graph-producing verb landed: replace the canvas view. */
   | { type: "GRAPH_UPDATED"; graph: LatestGraph }
   /**
@@ -60,13 +92,30 @@ export function cliReducer(state: CliState, action: CliAction): CliState {
       }
       return { ...state, historyIndex: next, input: state.history[next] };
     }
-    case "COMMAND_SUBMITTED": {
+    case "HISTORY_APPENDED": {
       return {
         ...state,
         history: [...state.history, action.raw],
         historyIndex: null,
-        input: "",
       };
+    }
+    case "PROMPT_CLEARED": {
+      return { ...state, historyIndex: null, input: "" };
+    }
+    case "ENQUEUE": {
+      return { ...state, queue: [...state.queue, action.input] };
+    }
+    case "DEQUEUE": {
+      if (state.queue.length === 0) {
+        return state;
+      }
+      return { ...state, queue: state.queue.slice(1) };
+    }
+    case "QUEUE_CLEARED": {
+      if (state.queue.length === 0) {
+        return state;
+      }
+      return { ...state, queue: [] };
     }
     case "ENTRY_APPENDED": {
       return {
@@ -86,6 +135,34 @@ export function cliReducer(state: CliState, action: CliAction): CliState {
     }
     case "RUN_SETTLED": {
       return { ...state, phase: "idle" };
+    }
+    case "RUN_FAILED": {
+      // Fail-fast (#945): drop the rest of a pasted/queued script the
+      // moment one line errors, so a mistyped or server-rejected command
+      // can't let the lines after it keep mutating the graph. The operator
+      // re-issues from a known-good point instead of chasing a half-applied
+      // batch. Only annotate the drop when commands were actually pending —
+      // a lone failing command (queue empty) just shows its red error chip.
+      const pending = state.queue.length;
+      if (pending === 0) {
+        return state;
+      }
+      return {
+        ...state,
+        queue: [],
+        scrollback: [
+          ...state.scrollback,
+          {
+            id: state.nextEntryId,
+            input: "",
+            kind: "info",
+            text: `queue cleared after error (${pending} pending command${
+              pending === 1 ? "" : "s"
+            } dropped)`,
+          },
+        ],
+        nextEntryId: state.nextEntryId + 1,
+      };
     }
     case "GRAPH_UPDATED": {
       return { ...state, latestGraph: action.graph };

--- a/admin/app/lib/client/usecase/cli/state.ts
+++ b/admin/app/lib/client/usecase/cli/state.ts
@@ -37,6 +37,15 @@ export interface CliState {
   /** Dispatch lifecycle phase. */
   phase: CliPhase;
   /**
+   * Pending-command FIFO (#945). Raw input strings waiting to run while a
+   * dispatch is in flight. `submit`/paste enqueue here instead of dropping
+   * keystrokes into a `disabled` prompt; the controller drains the head on
+   * each successful settle so exactly one RPC is ever in flight. Cleared
+   * wholesale on cancel (Esc = "stop the script") and on any command error
+   * (fail-fast). Session-local — never persisted.
+   */
+  queue: string[];
+  /**
    * Most recent canvas frame. Read verbs replace it; mutating verbs
    * (`put`/`add`) fold the new element onto it (#518) so the operator
    * keeps their exploration context after a write. Null until the first
@@ -70,6 +79,7 @@ export const INITIAL_CLI_STATE: CliState = {
   history: [],
   historyIndex: null,
   phase: "idle",
+  queue: [],
   latestGraph: null,
   nextEntryId: 2,
 };

--- a/admin/app/lib/client/usecase/cli/use-cli.ts
+++ b/admin/app/lib/client/usecase/cli/use-cli.ts
@@ -23,12 +23,25 @@ import {
   type ScrollbackEntry,
 } from "./state";
 
+/**
+ * Upper bound on the number of commands a single paste may enqueue (#945).
+ * A batch larger than this is refused wholesale with a scrollback error so a
+ * mispaste (e.g. dropping a whole file onto the prompt) can't flood the
+ * server with hundreds of RPCs. Generous enough for the seed scripts the
+ * page is meant to run — the #942 barbell script is 14 lines.
+ */
+const MAX_PASTE_LINES = 100;
+
 export interface UseCliResult {
   /** Durable scrollback log, ready to render. */
   scrollback: ScrollbackEntry[];
   /** Current prompt text. */
   input: string;
-  /** True while a dispatch is in flight (drives `Cancel` + disabled prompt). */
+  /**
+   * True while a dispatch is in flight. Drives the `Cancel` control and the
+   * busy spinner; the prompt itself stays editable so keystrokes buffer
+   * instead of dropping (#945).
+   */
   busy: boolean;
   /** Most recent graph-producing command's view, or null. */
   latestGraph: LatestGraph | null;
@@ -39,10 +52,15 @@ export interface UseCliResult {
   knownKeys: string[];
   /** Update the prompt text. */
   setInput: (value: string) => void;
-  /** Run the current prompt text (Enter). */
+  /** Submit the current prompt text (Enter): enqueue it and clear the box. */
   submit: () => void;
-  /** Run an arbitrary raw line (click-to-illuminate). */
+  /** Enqueue an arbitrary raw line (click-to-illuminate / seed handoff). */
   runRaw: (raw: string) => void;
+  /**
+   * Enqueue a pasted multi-line script (#945): each non-blank line becomes a
+   * queued command, run in order. Over-cap batches are refused.
+   */
+  enqueueScript: (lines: string[]) => void;
   /** Recall an older history entry (ArrowUp). */
   historyPrev: () => void;
   /** Move toward the newest history entry (ArrowDown). */
@@ -165,6 +183,9 @@ export function useCli(): UseCliResult {
               durationMs: elapsed,
             },
           });
+          // Esc / Cancel mid-script stops the whole batch, not just this
+          // line — discard anything still queued behind it (#945).
+          dispatch({ type: "QUEUE_CLEARED" });
         } else {
           dispatch({
             type: "ENTRY_APPENDED",
@@ -175,6 +196,9 @@ export function useCli(): UseCliResult {
               durationMs: elapsed,
             },
           });
+          // Fail-fast: a server-rejected line drops the rest of the queued
+          // script so it can't keep mutating the graph (#945).
+          dispatch({ type: "RUN_FAILED" });
         }
       } finally {
         abortRef.current = null;
@@ -184,16 +208,25 @@ export function useCli(): UseCliResult {
     [client],
   );
 
-  const runRaw = useCallback(
+  // Executes one accepted line end-to-end: records it in `history` (at run
+  // time, so history order === execution order — queued lines join when they
+  // drain, not when they were typed), then either renders a local response
+  // (exit / help / parse error) or dispatches the parsed verb through the RPC
+  // path. This is the queue's single execution site — only the drain effect
+  // below calls it, so there is exactly one place a command actually runs.
+  const execute = useCallback(
     async (raw: string) => {
       if (raw.trim() === "") return;
-      dispatch({ type: "COMMAND_SUBMITTED", raw });
+      dispatch({ type: "HISTORY_APPENDED", raw });
       const result: ParseResult = parse(raw);
       if (!result.ok) {
         dispatch({
           type: "ENTRY_APPENDED",
           entry: { input: raw, kind: "error", text: result.usage },
         });
+        // A parse error is an error too: fail-fast so a typo'd line 3 can't
+        // let lines 4-14 of a pasted script run (#945).
+        dispatch({ type: "RUN_FAILED" });
         return;
       }
       if (result.command.verb === "exit") {
@@ -219,9 +252,67 @@ export function useCli(): UseCliResult {
     [runCommand],
   );
 
+  // Drain loop (#945): the sole driver of the pending-command queue.
+  // Whenever the dispatch loop is idle and a command is waiting, pull the
+  // head and run it — exactly one RPC in flight at a time, in FIFO order.
+  // A successful run leaves the tail intact so the next commit drains the
+  // next line; a cancel (QUEUE_CLEARED) or error (RUN_FAILED) empties the
+  // queue, so the loop stops without any separate "keep going?" flag.
+  // Routing every submission through enqueue → this effect (rather than
+  // running the first line inline) keeps a synchronous paste loop race-free:
+  // the effect always observes committed state, never a stale closure.
+  useEffect(() => {
+    if (state.phase !== "idle") return;
+    if (state.queue.length === 0) return;
+    const head = state.queue[0];
+    dispatch({ type: "DEQUEUE" });
+    void execute(head);
+  }, [state.phase, state.queue, execute]);
+
+  // Enter on the prompt. The line is queued (not run inline) so pressing
+  // Enter while a command is in flight buffers it instead of dropping the
+  // keystrokes — the prompt is no longer `disabled` while busy (#945). The
+  // prompt clears now (the Enter affordance); the queued line re-enters
+  // history when it actually runs, so the operator can keep typing the next
+  // command without losing either one.
   const submit = useCallback(() => {
-    void runRaw(state.input);
-  }, [runRaw, state.input]);
+    if (state.input.trim() === "") return;
+    dispatch({ type: "ENQUEUE", input: state.input });
+    dispatch({ type: "PROMPT_CLEARED" });
+  }, [state.input]);
+
+  // Enqueue an arbitrary raw line without touching the prompt: click-to-
+  // illuminate (#439), the `?seed=` handoff (#651), and each pasted script
+  // line. Same buffering as `submit`, minus the prompt clear.
+  const runRaw = useCallback((raw: string) => {
+    if (raw.trim() === "") return;
+    dispatch({ type: "ENQUEUE", input: raw });
+  }, []);
+
+  // Paste-as-script (#945): enqueue a batch of lines in order. Blank lines
+  // are dropped; a batch over the cap is refused wholesale with a scrollback
+  // error so a mispaste can't hammer the server. The first line runs as soon
+  // as the drain effect sees the idle prompt; the rest follow in FIFO order.
+  const enqueueScript = useCallback((lines: string[]) => {
+    const cleaned = lines
+      .map((line) => line.trim())
+      .filter((line) => line !== "");
+    if (cleaned.length === 0) return;
+    if (cleaned.length > MAX_PASTE_LINES) {
+      dispatch({
+        type: "ENTRY_APPENDED",
+        entry: {
+          input: "",
+          kind: "error",
+          text: `paste rejected: ${cleaned.length} lines exceeds the ${MAX_PASTE_LINES}-line limit`,
+        },
+      });
+      return;
+    }
+    for (const line of cleaned) {
+      dispatch({ type: "ENQUEUE", input: line });
+    }
+  }, []);
 
   const setInput = useCallback((value: string) => {
     dispatch({ type: "INPUT_CHANGED", value });
@@ -255,10 +346,13 @@ export function useCli(): UseCliResult {
   }, []);
 
   // Window-level keyboard shortcuts (#433):
-  //   - Esc while a command is in flight aborts the dispatch. The prompt
-  //     `<Input>` is `disabled` while busy and so cannot receive its own
-  //     keydown events; binding at window scope is the only way to make
-  //     Esc reach `cancelInFlight`.
+  //   - Esc while a command is in flight aborts the dispatch. Bound at
+  //     window scope so it fires regardless of where focus sits (the prompt,
+  //     the axis picker, or nowhere) — and, historically, so it worked even
+  //     while the prompt was `disabled`. The prompt is now always editable
+  //     (#945), but the window binding stays: it's still the simplest way to
+  //     reach `cancelInFlight` no matter the focus target, and it clears the
+  //     pending-command queue via the abort path.
   //   - Ctrl+L / Cmd+L clears the scrollback. Bound globally so it works
   //     whether the prompt has focus or not (matches xterm / bash).
   useEffect(() => {
@@ -297,7 +391,8 @@ export function useCli(): UseCliResult {
       knownKeys,
       setInput,
       submit,
-      runRaw: (raw: string) => void runRaw(raw),
+      runRaw,
+      enqueueScript,
       historyPrev,
       historyNext,
       clearScrollback,
@@ -312,6 +407,7 @@ export function useCli(): UseCliResult {
       setInput,
       submit,
       runRaw,
+      enqueueScript,
       historyPrev,
       historyNext,
       clearScrollback,

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -180,8 +180,9 @@ test.describe("/cli", () => {
     const input = page.getByTestId("cli-input");
     await input.fill("get vertex cli:alpha");
     await input.press("Enter");
-    // Input disables while busy; Cancel button appears.
-    await expect(input).toBeDisabled();
+    // The prompt stays editable while busy (#945) — only the Cancel
+    // button appears to mark the in-flight dispatch.
+    await expect(input).toBeEnabled();
     await expect(page.getByTestId("cli-cancel")).toBeVisible();
     await page.getByTestId("cli-cancel").click();
     // The dispatch unwinds and the scrollback gains an info chip
@@ -206,8 +207,8 @@ test.describe("/cli", () => {
     await input.fill("get vertex cli:alpha");
     await input.press("Enter");
     await expect(page.getByTestId("cli-cancel")).toBeVisible();
-    // Input is disabled while busy, but it still owns focus and
-    // receives keypresses, so Esc reaches the onKeyDown handler.
+    // The prompt stays enabled and focused while busy (#945), so Esc
+    // reaches the window-level onKeyDown handler either way.
     await input.press("Escape");
     await expect(page.getByTestId("cli-entry-info").last()).toContainText(
       "aborted",
@@ -527,13 +528,13 @@ test.describe("/cli", () => {
     await expect(input).toBeFocused();
   });
 
-  // #520 — Enter submits a command, which disables the prompt while the
-  // dispatch is in flight. The browser blurs a disabled element, so the
-  // component must restore focus when the input re-enables; otherwise the
-  // operator is ejected to <body> after every command and has to click
-  // back in. Slow-route the RPC so the disabled→blurred window is
-  // observable, then assert focus returns to the prompt once it settles.
-  test("prompt regains focus after an Enter-submitted command settles (#520)", async ({
+  // #520 / #945 — Enter submits a command and the dispatch goes in flight.
+  // The prompt used to be `disabled` while busy, which blurred it to <body>
+  // and forced a focus-restore workaround. Since #945 the prompt is never
+  // disabled, so it must simply keep focus (and stay editable) for the whole
+  // dispatch — no eject-then-restore round trip. Slow-route the RPC so the
+  // in-flight window is observable, then assert focus never leaves the prompt.
+  test("prompt stays enabled and focused while a command is in flight (#520, #945)", async ({
     page,
   }) => {
     await page.route("**/graph.v1.LanternService/**", async (route) => {
@@ -545,15 +546,17 @@ test.describe("/cli", () => {
     await input.click();
     await input.fill("get vertex cli:alpha");
     await input.press("Enter");
-    // While in flight the prompt is disabled and the browser has moved
-    // focus off it (to <body>) — this is the regression's trigger.
-    await expect(input).toBeDisabled();
-    await expect(input).not.toBeFocused();
-    // Once the command settles the component restores focus to the prompt
-    // so the next command can be typed without a click.
+    // In flight: the Cancel affordance is up, but the prompt is still
+    // enabled and still owns focus — no ejection to <body>.
+    await expect(page.getByTestId("cli-cancel")).toBeVisible();
+    await expect(input).toBeEnabled();
+    await expect(input).toBeFocused();
+    // After settle the prompt is unchanged — still editable, still focused,
+    // ready for the next command without a click.
     await expect(page.getByTestId("cli-entry-ok").last()).toContainText(
       "first",
     );
+    await expect(page.getByTestId("cli-cancel")).toHaveCount(0);
     await expect(input).toBeEnabled();
     await expect(input).toBeFocused();
   });
@@ -584,5 +587,86 @@ test.describe("/cli", () => {
     // The dismiss button closes it again.
     await page.getByTestId("cli-command-reference-close").click();
     await expect(page.getByTestId("cli-command-reference")).toHaveCount(0);
+  });
+
+  // #945 — pasting a multi-line script into the prompt runs each line in
+  // order through the pending-command queue instead of flattening the
+  // newlines into one uneditable line. Synthesize a real paste event (with
+  // multi-line clipboard data) so React's onPaste fires the way a Cmd/Ctrl+V
+  // would. Every line lands as an ok chip in submission order, and the canvas
+  // reflects the last graph-carrying command.
+  test("pasting a multi-line script runs each line in order (#945)", async ({
+    page,
+  }) => {
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    await input.click();
+    const script = [
+      "get vertex cli:alpha",
+      "get vertex cli:beta",
+      "illuminate cli:alpha 2 5",
+    ].join("\n");
+    // Dispatch a paste event carrying the script as text/plain. `bubbles`
+    // lets it reach React's root-level paste listener; the DataTransfer is
+    // what `e.clipboardData.getData("text")` reads in the handler.
+    await input.evaluate((el, text) => {
+      const dt = new DataTransfer();
+      dt.setData("text/plain", text);
+      el.dispatchEvent(
+        new ClipboardEvent("paste", {
+          clipboardData: dt,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    }, script);
+    // All three lines drain in order — three ok chips, none dropped.
+    const ok = page.getByTestId("cli-entry-ok");
+    await expect(ok).toHaveCount(3);
+    await expect(ok.nth(0)).toContainText("get vertex cli:alpha");
+    await expect(ok.nth(0)).toContainText("first");
+    await expect(ok.nth(1)).toContainText("get vertex cli:beta");
+    await expect(ok.nth(1)).toContainText("second");
+    await expect(ok.nth(2)).toContainText("illuminate cli:alpha 2 5");
+    // The canvas reflects the last graph-carrying command in the script.
+    await expect(page.getByTestId("cli-canvas-panel")).toContainText(
+      "illuminate cli:alpha 2 5",
+    );
+    // The paste never leaked into the editable prompt (preventDefault held).
+    await expect(input).toHaveValue("");
+  });
+
+  // #945 — the core regression: keystrokes typed while a command is in
+  // flight must not be dropped. The prompt used to be `disabled` while busy,
+  // so the browser silently discarded keys. Slow-route the RPC, submit a
+  // command, then type the next one character-by-character while it's still
+  // running and assert every character survived once the dispatch settles.
+  test("keystrokes typed while a command is in flight are not dropped (#945)", async ({
+    page,
+  }) => {
+    await page.route("**/graph.v1.LanternService/**", async (route) => {
+      await new Promise((r) => setTimeout(r, 1200));
+      await route.continue();
+    });
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    await input.click();
+    await input.fill("get vertex cli:alpha");
+    await input.press("Enter");
+    // In flight — Enter cleared the prompt but it stays editable (#945).
+    await expect(page.getByTestId("cli-cancel")).toBeVisible();
+    await expect(input).toHaveValue("");
+    // Type the next command while the first is still running. Real
+    // per-key events, the exact path that used to lose characters.
+    await input.pressSequentially("get vertex cli:beta");
+    // The characters buffer live in the prompt, none lost.
+    await expect(input).toHaveValue("get vertex cli:beta");
+    // After the first command settles the typed text is still intact and
+    // was NOT auto-submitted (typing never enqueues — only Enter does).
+    await expect(page.getByTestId("cli-entry-ok").last()).toContainText(
+      "first",
+    );
+    await expect(page.getByTestId("cli-cancel")).toHaveCount(0);
+    await expect(input).toHaveValue("get vertex cli:beta");
   });
 });


### PR DESCRIPTION
## Summary

The admin SPA `/cli` prompt had two data losses:
1. **Dropped keystrokes** — the prompt `<Input>` was literally `disabled` while a command was in flight, so the browser silently discarded anything typed during a dispatch.
2. **No multi-line paste** — pasting a seed/repro script flattened the newlines into a single uneditable line, so it could never run.

Per the issue's authoritative plan, both are modeled as **one mechanism: a pending-command FIFO queue** in the CLI reducer.

## What changed

- **`state.ts`** — add `queue: string[]` to `CliState` + `INITIAL_CLI_STATE` (session-local React state, no persistence).
- **`reducer.ts`**
  - `ENQUEUE` — append raw input; **no** scrollback echo yet (the echo happens when the command actually runs, so scrollback order === execution order).
  - `DEQUEUE` — drop the head.
  - `QUEUE_CLEARED` — Esc/Cancel clears the **whole** script, not one line ("stop the script", not "skip a line").
  - `RUN_FAILED` — **fail-fast**: clear the remaining queue and, when commands were pending, append an info line `queue cleared after error (N pending command(s) dropped)` so a typo'd line 3 can't let lines 4–14 mutate the graph. Design decision documented in a code comment.
  - Split the old `COMMAND_SUBMITTED` into `HISTORY_APPENDED` (history at run time) + `PROMPT_CLEARED` (clear the box on Enter) so typing while a script drains isn't clobbered.
- **`use-cli.ts`** — uniform enqueue + a single **drain effect** that runs the head whenever idle: exactly one RPC in flight, FIFO order, `abortRef` always aimed at the current line. `submit()` enqueues + clears the prompt; `runRaw()` (click-to-illuminate / seed) and `enqueueScript()` (paste) feed the same queue. Parse errors and RPC errors both fail-fast. 100-line paste cap.
- **`CliPage.tsx`** — the prompt is **never** `disabled` now: dropped the `disabled` attr, the now-obsolete disabled→enabled refocus workaround (#520), and the `onNodeClick` busy guard. Added `onPaste`: a multi-line clipboard becomes a script (`preventDefault`, split, trim, drop blanks); a single-line paste keeps the browser default. No special-casing of destructive verbs (delete-prefix already demands `confirm=yes | dry_run=true` at parse time).

## Verification

- Re-verified window-level **Esc** cancel, **Tab** autocomplete, and **arrow-history** still work while a command is in flight; did not regress the #465 splitter keyboard handling or the #439 click-to-illuminate flow.
- **`reducer.test.ts`** extended: ENQUEUE appends / FIFO drain via DEQUEUE / cancel clears the queue / RUN_FAILED clears + appends the info entry with the correct count (singular + plural) / queue survives `GRAPH_UPDATED` + `GRAPH_MERGED` untouched.
- **`cli.spec.ts`** extended: paste a 3-line script → 3 scrollback ok-entries in order + canvas reflects the last graph-carrying command; type into the prompt while a command is in flight → no characters lost (input value intact after settle). Updated the disabled-while-busy assertions to the always-editable contract.

Quality gate (all green): `bun run format && bun run lint && bun run typecheck && bun run test` (708 pass) `&& bun run build && bun run test:e2e` (60 pass).

Closes #945