### PR TITLE
feat(sdks/go,cli): server-free exponential edge-weight decay helper (AddDecayingEdge)

### DIFF
--- a/.github/skills/lantern-ops/SKILL.md
+++ b/.github/skills/lantern-ops/SKILL.md
@@ -264,6 +264,20 @@ lantern-cli add edge alice bob 0.5            # weight now 2.0
 lantern-cli add edge alice bob 0.1 1800       # weight 2.1, TTL reset to 30m
 ```
 
+### `add decaying-edge <tail> <head> <initial_weight> <ratio> <steps> <interval_seconds>`
+Client-side sugar (no dedicated RPC — it fans out into one additive `AddEdges`
+batch) that lays down a **geometrically decaying** weight curve on `(tail, head)`.
+The live weight starts at `<initial_weight>` and is multiplied by `<ratio>` (open
+interval `0 < ratio < 1`) every `<interval_seconds>`, reaching zero after
+`<steps>` intervals. All six arguments are **required**; `<steps>` is capped at
+16. The contributions telescope, so they sum to `<initial_weight>` (a
+`16 → 8 → 4 → 2 → 1 → 0` staircase is written as `{8,4,2,1,1}`, not `{16,…}`).
+The echo reports the full decay horizon (`steps × interval`) as the TTL.
+```shell
+# weight 16 now, halving every 60s: 16 → 8 → 4 → 2 → 1 → 0 over 5 minutes
+lantern-cli add decaying-edge alice bob 16 0.5 5 60
+```
+
 ### `put edge <tail> <head> <weight> [ttl_seconds]`  (idempotent)
 Replace the `(tail, head)` weight. Optional trailing `ttl_seconds`
 (default permanent). Prints `OK`.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,16 @@ co-occurrence is one append, and *"how strong is this relationship right
 now"* falls out of the math — no batch job. Need classic idempotent
 replace instead? That's `put edge`.
 
+**Want a smooth geometric decay instead of a flat TTL cliff?** The Go SDK's
+`AddDecayingEdge` is a client-side helper (no extra RPC — the server stays a
+dumb additive store) that expands one
+`DecayOpts{InitialWeight, Ratio, Steps, Interval}` into a handful of
+staggered-TTL contributions and ships them as a single `AddEdges` batch, so
+the live weight steps down geometrically (e.g. `16 → 8 → 4 → 2 → 1 → 0`)
+rather than disappearing all at once. The contributions telescope, so they
+sum to `InitialWeight` (writing `{8,4,2,1,1}`, not `{16,8,4,2,1}`). CLI:
+`add decaying-edge <tail> <head> <initial_weight> <ratio> <steps> <interval_seconds>`.
+
 Vertices also auto-materialize on edge writes (inheriting the edge's TTL),
 so ingesting an event stream is just a stream of edge writes.
 
@@ -315,6 +325,10 @@ _ = cli.PutVertex(ctx, "item:7",  "lamp",  1*time.Hour)
 
 // Each AddEdge appends a contribution with its own TTL and returns the live sum.
 _, _ = cli.AddEdge(ctx, "user:42", "item:7", 1.0, 30*time.Minute)
+
+// One call → a geometric decay curve (client-side fan-out over AddEdges, no new RPC).
+_, _ = cli.AddDecayingEdge(ctx, "user:42", "item:7",
+    client.DecayOpts{InitialWeight: 16, Ratio: 0.5, Steps: 5, Interval: time.Minute})
 
 // Walk: 2 hops, top-3 per hop, TF-IDF weighted.
 g, _ := cli.Illuminate(ctx, "user:42",

--- a/cli/cmd/grammar.go
+++ b/cli/cmd/grammar.go
@@ -14,6 +14,7 @@ import (
 //	lantern-cli delete vertex <key>
 //	lantern-cli get    edge   <tail> <head>
 //	lantern-cli add    edge   <tail> <head> <weight> [ttl_seconds]
+//	lantern-cli add    decaying-edge <tail> <head> <initial_weight> <ratio> <steps> <interval_seconds>
 //	lantern-cli put    edge   <tail> <head> <weight> [ttl_seconds]
 //	lantern-cli delete edge   <tail> <head>
 //	lantern-cli scan   vertices <prefix> [limit]
@@ -83,18 +84,28 @@ put edge REPLACES the weight (idempotent); use "add edge" to accumulate.`,
 }
 
 var grammarAddCmd = &cobra.Command{
-	Use:   "add edge <tail> <head> <weight> [ttl_seconds]",
-	Short: "Additive edge write: sum weight onto (tail,head) (REPL grammar)",
+	Use:   "add { edge <tail> <head> <weight> [ttl_seconds] | decaying-edge <tail> <head> <initial_weight> <ratio> <steps> <interval_seconds> }",
+	Short: "Additive edge write: sum weight onto (tail,head), optionally decaying (REPL grammar)",
 	Long: `Accumulate an edge weight using the same verb-first grammar as the REPL:
 
   lantern-cli add edge <tail> <head> <weight> [ttl_seconds]
+  lantern-cli add decaying-edge <tail> <head> <initial_weight> <ratio> <steps> <interval_seconds>
 
 add edge is ADDITIVE: repeated calls on the same (tail, head) pair sum their
 weights server-side ("add edge a b 1.5" then "add edge a b 0.5" leaves 2.0).
 Use "put edge" when the weight is a measured property to replace wholesale.
 
 The optional trailing ttl_seconds is a positional integer (the REPL form);
-omit it for a permanent (no-decay) edge.`,
+omit it for a permanent (no-decay) edge.
+
+add decaying-edge writes a geometric decay staircase entirely client-side (no
+server support): the edge's contributed weight starts at <initial_weight> and
+is multiplied by <ratio> (0 < ratio < 1) every <interval_seconds>, reaching
+zero after <steps> intervals. It expands into <steps> additive contributions
+with staggered TTLs in one AddEdges batch, so "add decaying-edge a b 16 0.5 5 1"
+makes the live weight fall 16 → 8 → 4 → 2 → 1 → 0 over five seconds. steps is
+capped (see the SDK's MaxDecaySteps) and steps×interval must fit the server's
+tombstone-TTL horizon or the whole write is rejected.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGrammarLine(cmd, "add", args)
 	},

--- a/cli/cmd/repl.go
+++ b/cli/cmd/repl.go
@@ -35,6 +35,7 @@ The REPL accepts whitespace-delimited verbs:
   delete vertex <key>
   get edge <tail> <head>
   add edge <tail> <head> <weight> [ttl_seconds]
+  add decaying-edge <tail> <head> <initial_weight> <ratio> <steps> <interval_seconds>
   put edge <tail> <head> <weight> [ttl_seconds]
   delete edge <tail> <head>
   scan vertices <prefix> [limit]
@@ -146,6 +147,8 @@ EXAMPLE
 				fmt.Println("Usage: delete edge <tail: string> <head: string>")
 			case service.ErrAddEdge:
 				fmt.Println("Usage: add edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]")
+			case service.ErrAddDecayingEdge:
+				fmt.Println("Usage: add decaying-edge <tail: string> <head: string> <initial_weight: float> <ratio: float> <steps: int> <interval_seconds: int>")
 			case service.ErrScan:
 				fmt.Println("Usage: scan { vertices <prefix: string> [<limit: int>] | edges <tail-prefix: string> [<limit: int>] }")
 			case service.ErrKeys:
@@ -155,7 +158,7 @@ EXAMPLE
 			case service.ErrInvalidVerb:
 				fmt.Println("Usage: { get | put | delete | add | scan | illuminate | help | exit } ...")
 			case service.ErrInvalidObjective:
-				fmt.Println("{ get { vertex | edge } | put { vertex | edge } | delete { vertex | edge } | add edge | scan { vertices | edges } | illuminate {...} } ...")
+				fmt.Println("{ get { vertex | edge } | put { vertex | edge } | delete { vertex | edge } | add { edge | decaying-edge } | scan { vertices | edges } | illuminate {...} } ...")
 			case service.ErrConnection:
 				fmt.Println("server error")
 			default:

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -107,6 +107,7 @@ EXAMPLES
   lantern-cli put vertex alice "Alice" 3600        # value + TTL seconds
   lantern-cli put vertex cfg '{"a":1}' type=json   # forced value type
   lantern-cli add edge alice bob 1.5 3600          # additive edge write
+  lantern-cli add decaying-edge alice bob 16 0.5 5 1  # 16→8→4→2→1→0 over 5s
   lantern-cli scan vertices users/ 100 all=true    # paged prefix scan
   lantern-cli count vertices users/                # prefix cardinality
   lantern-cli delete vertex alice bob carol        # variadic batch delete

--- a/cli/parser/model.go
+++ b/cli/parser/model.go
@@ -36,6 +36,24 @@ type AddEdge struct {
 	TTL    time.Duration
 }
 
+// AddDecayingEdge backs
+// `add decaying-edge <tail> <head> <initial_weight> <ratio> <steps> <interval_seconds>`.
+// The fields map 1:1 onto client.DecayOpts: the edge's contributed live weight
+// starts at InitialWeight and is multiplied by Ratio every Interval, reaching
+// zero after Steps intervals. The dispatcher expands it client-side into an
+// AddEdges batch of staggered-TTL contributions — no server support required
+// (#952). Numeric-range validation (Ratio in (0,1), Steps in
+// [1, client.MaxDecaySteps], Interval > 0) is deferred to the SDK, which owns
+// the DecayOpts contract.
+type AddDecayingEdge struct {
+	Tail          string
+	Head          string
+	InitialWeight float32
+	Ratio         float32
+	Steps         int
+	Interval      time.Duration
+}
+
 // DeleteVertex backs `delete vertex <key> [<key> …]`. Keys holds one or
 // more keys; the dispatcher forwards a one-element batch to DeleteVertex
 // and a multi-element batch to DeleteVertices.

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -38,6 +38,16 @@ var (
 		"edges",
 	}
 
+	// AddObjectives are the objectives accepted by the `add` verb. Unlike
+	// the shared Objectives (vertex/edge, used by get/put/delete), `add`
+	// takes only edge forms: the plain additive edge and the client-expanded
+	// decaying edge (#952). A dedicated set keeps `add vertex` a clean parse
+	// error and stops the decay sugar leaking into get/put/delete grammar.
+	AddObjectives = []string{
+		"edge",
+		"decaying-edge",
+	}
+
 	// IlluminateAlgorithms / IlluminateObjectives / IlluminateWeightings
 	// are the canonical sets the REPL accepts for the keyword arguments of
 	// the modernised illuminate verb (#410). The keyword form replaces the
@@ -191,6 +201,10 @@ func Objective(s *Source) (string, error) {
 
 func ScanObjective(s *Source) (string, error) {
 	return AnyOf(s, ScanObjectives)
+}
+
+func AddObjective(s *Source) (string, error) {
+	return AnyOf(s, AddObjectives)
 }
 
 func GetVertexParam(s *Source) (*GetVertex, error) {
@@ -392,7 +406,40 @@ func AddEdgeParam(s *Source) (*AddEdge, error) {
 	return m, nil
 }
 
-// DeleteVertexParam parses `delete vertex <key> [<key> …]` — one or more
+// AddDecayingEdgeParam parses
+// `add decaying-edge <tail> <head> <initial_weight> <ratio> <steps> <interval_seconds>`.
+// All six positional arguments are required (unlike AddEdgeParam's optional
+// trailing ttl_seconds) because the decay curve is meaningless without every
+// parameter. Numeric-range checks are the SDK's job — this only enforces
+// shape and token types, then EOF so a stray trailing token is a usage error
+// (mirrors AddEdgeParam's #932 trailing-token guard).
+func AddDecayingEdgeParam(s *Source) (*AddDecayingEdge, error) {
+	var err error
+	m := &AddDecayingEdge{}
+	if m.Tail, err = String(s); err != nil {
+		return nil, err
+	}
+	if m.Head, err = String(s); err != nil {
+		return nil, err
+	}
+	if m.InitialWeight, err = Float32(s); err != nil {
+		return nil, err
+	}
+	if m.Ratio, err = Float32(s); err != nil {
+		return nil, err
+	}
+	if m.Steps, err = Integer(s); err != nil {
+		return nil, err
+	}
+	if m.Interval, err = Duration(s); err != nil {
+		return nil, err
+	}
+	if err := EOF(s); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // keys. A one-element batch deletes a single vertex; more than one routes
 // to DeleteVertices in the dispatcher.
 func DeleteVertexParam(s *Source) (*DeleteVertex, error) {
@@ -740,6 +787,7 @@ const HelpText = `Lantern CLI grammar:
   put    vertex <key: string> <value: string|int|float|bool|datetime> [<ttl_seconds: int>] [type=auto|string|int|float|bool|datetime|duration|json]
   put    edge   <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]
   add    edge   <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]
+  add    decaying-edge <tail: string> <head: string> <initial_weight: float> <ratio: float> <steps: int> <interval_seconds: int>
   delete vertex <key: string> [<key: string> ...]
   delete edge   <tail: string> <head: string> [<tail: string> <head: string> ...]
   scan   vertices <prefix: string> [<limit: int>] [all=true]

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -407,6 +407,51 @@ func TestEdgeParam_TrailingToken(t *testing.T) {
 	})
 }
 
+// TestAddDecayingEdgeParam pins the six-positional decay grammar (#952):
+// tail, head, initial_weight, ratio, steps, interval_seconds — all required —
+// plus the trailing-token EOF guard. Numeric-range validation (ratio in
+// (0,1), steps ≤ MaxDecaySteps) is the SDK's job, so out-of-range values parse
+// cleanly here.
+func TestAddDecayingEdgeParam(t *testing.T) {
+	t.Run("full form parses", func(t *testing.T) {
+		s, _ := NewSource("a b 16 0.5 5 1")
+		m, err := AddDecayingEdgeParam(s)
+		if err != nil {
+			t.Fatalf("AddDecayingEdgeParam(a b 16 0.5 5 1): %v", err)
+		}
+		if m.Tail != "a" || m.Head != "b" {
+			t.Fatalf("endpoints = (%q,%q), want (a,b)", m.Tail, m.Head)
+		}
+		if m.InitialWeight != 16 || m.Ratio != 0.5 || m.Steps != 5 {
+			t.Fatalf("got initial=%v ratio=%v steps=%d, want 16 0.5 5", m.InitialWeight, m.Ratio, m.Steps)
+		}
+		if m.Interval != time.Second {
+			t.Fatalf("interval = %v, want 1s", m.Interval)
+		}
+	})
+
+	t.Run("out-of-range values still parse (SDK validates)", func(t *testing.T) {
+		s, _ := NewSource("a b 16 2 99 1")
+		if _, err := AddDecayingEdgeParam(s); err != nil {
+			t.Fatalf("parser must defer range checks to the SDK, got %v", err)
+		}
+	})
+
+	t.Run("missing or trailing tokens are errors", func(t *testing.T) {
+		for _, in := range []string{
+			"a b 16 0.5 5",         // missing interval
+			"a b 16 0.5",           // missing steps + interval
+			"a b",                  // missing all numerics
+			"a b 16 0.5 5 1 extra", // trailing token
+		} {
+			s, _ := NewSource(in)
+			if _, err := AddDecayingEdgeParam(s); err == nil {
+				t.Errorf("AddDecayingEdgeParam(%q) = nil, want error", in)
+			}
+		}
+	})
+}
+
 // TestIlluminateParam_Prefix pins the #604 vertex-prefix kwarg. Unlike the
 // closed-set axes, prefix= is free-text: the key is case-insensitive but the
 // value is preserved verbatim (it matches vertex keys), it composes with the

--- a/cli/parser/validate.go
+++ b/cli/parser/validate.go
@@ -70,17 +70,21 @@ func Validate(input string) error {
 			return errors.New("usage: delete { vertex | edge }")
 		}
 	case "add":
-		o, err := Objective(s)
+		o, err := AddObjective(s)
 		if err != nil {
-			return errors.New("usage: add edge ... ")
+			return errors.New("usage: add { edge | decaying-edge } ... ")
 		}
 		switch o {
 		case "edge":
 			if _, err := AddEdgeParam(s); err != nil {
 				return errors.New("usage: add edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]")
 			}
+		case "decaying-edge":
+			if _, err := AddDecayingEdgeParam(s); err != nil {
+				return errors.New("usage: add decaying-edge <tail: string> <head: string> <initial_weight: float> <ratio: float> <steps: int> <interval_seconds: int>")
+			}
 		default:
-			return errors.New("usage: add edge ... ")
+			return errors.New("usage: add { edge | decaying-edge } ... ")
 		}
 	case "scan":
 		o, err := ScanObjective(s)

--- a/cli/parser/validate_test.go
+++ b/cli/parser/validate_test.go
@@ -17,6 +17,7 @@ func FuzzValidate(f *testing.F) {
 		"put vertex price 1234 type=int", "put vertex name 007 type=string",
 		"put edge alice bob 1.5", "put edge alice bob 1.5 60",
 		"add edge alice bob 1.0",
+		"add decaying-edge alice bob 16 0.5 5 1",
 		"delete vertex alice", "delete vertex alice bob carol",
 		"delete edge alice bob", "delete edge alice bob carol dave",
 		"scan vertices users/", "scan vertices users/ 100 all=true",
@@ -53,4 +54,32 @@ func FuzzValidate(f *testing.F) {
 			_, _ = Verb(s)
 		}
 	})
+}
+
+// TestValidate_AddDecayingEdge covers the #952 decay verb through the
+// dispatcher: the full six-arg form validates, while short/trailing forms and
+// `add vertex` (which the add verb never accepted) are rejected. The shared
+// grammar fixture deliberately omits this verb (Go-only until the TS parser
+// gains parity), so its Validate coverage lives here.
+func TestValidate_AddDecayingEdge(t *testing.T) {
+	valid := []string{
+		"add decaying-edge alice bob 16 0.5 5 1",
+		"add decaying-edge a b -8 0.9 16 3",
+	}
+	for _, in := range valid {
+		if err := Validate(in); err != nil {
+			t.Errorf("Validate(%q) = %v, want nil", in, err)
+		}
+	}
+	invalid := []string{
+		"add decaying-edge alice bob",          // missing numerics
+		"add decaying-edge alice bob 16 0.5 5", // missing interval
+		"add decaying-edge a b 16 0.5 5 1 x",   // trailing token
+		"add vertex alice",                     // add never took vertex
+	}
+	for _, in := range invalid {
+		if err := Validate(in); err == nil {
+			t.Errorf("Validate(%q) = nil, want error", in)
+		}
+	}
 }

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -24,6 +24,7 @@ var (
 	ErrDeleteVertex     = errors.New("delete vertex error")
 	ErrDeleteEdge       = errors.New("delete edge error")
 	ErrAddEdge          = errors.New("add edge error")
+	ErrAddDecayingEdge  = errors.New("add decaying-edge error")
 	ErrScan             = errors.New("scan error")
 	ErrCount            = errors.New("count error")
 	ErrDeletePrefix     = errors.New("delete-prefix error")
@@ -112,7 +113,7 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 			return ErrInvalidObjective
 		}
 	case "add":
-		obj, err := parser.Objective(s)
+		obj, err := parser.AddObjective(s)
 		if err != nil {
 			fmt.Printf("Error: %s\n", err)
 			return ErrInvalidObjective
@@ -130,6 +131,37 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 				return ErrConnection
 			}
 			fmt.Println(formatWriteEcho(fmt.Sprintf("add edge %q -> %q (weight %g, total %g)", p.Tail, p.Head, p.Weight, effective), p.TTL, time.Now()))
+			return nil
+		case "decaying-edge":
+			p, err := parser.AddDecayingEdgeParam(s)
+			if err != nil {
+				fmt.Printf("Error: %s\n", err)
+				return ErrAddDecayingEdge
+			}
+			opts := client.DecayOpts{
+				InitialWeight: p.InitialWeight,
+				Ratio:         p.Ratio,
+				Steps:         p.Steps,
+				Interval:      p.Interval,
+			}
+			effective, err := c.client.AddDecayingEdge(ctx, p.Tail, p.Head, opts)
+			if err != nil {
+				fmt.Printf("Error: %s\n", err)
+				// A rejected DecayOpts (ratio/steps/interval out of range,
+				// underflowing curve) is a client-side usage error, not a
+				// transport failure; only genuine wire faults are ErrConnection.
+				if errors.Is(err, client.ErrInvalidArgument) {
+					return ErrAddDecayingEdge
+				}
+				return ErrConnection
+			}
+			// Echo the full decay horizon (Steps×Interval) as the effective
+			// TTL so the operator sees when the edge fully decays to zero.
+			horizon := time.Duration(p.Steps) * p.Interval
+			fmt.Println(formatWriteEcho(
+				fmt.Sprintf("add decaying-edge %q -> %q (initial %g, ratio %g, steps %d, total %g)",
+					p.Tail, p.Head, p.InitialWeight, p.Ratio, p.Steps, effective),
+				horizon, time.Now()))
 			return nil
 		default:
 			return ErrInvalidObjective

--- a/cli/service/service_test.go
+++ b/cli/service/service_test.go
@@ -93,3 +93,28 @@ func TestRunArgs(t *testing.T) {
 		}
 	})
 }
+
+// TestRunArgs_AddDecayingEdge exercises the decay verb's dispatch branches
+// that do not touch the client (#952): a malformed decay line fails at parse
+// time and returns ErrAddDecayingEdge, and a bad add-objective returns
+// ErrInvalidObjective — both before any RPC, so a nil-client service proves
+// the parse guards fire ahead of the client dereference. The happy-path
+// round-trip lives in tests/integration.
+func TestRunArgs_AddDecayingEdge(t *testing.T) {
+	svc := NewCLIService(nil)
+	ctx := context.Background()
+
+	t.Run("MalformedDecayLineReturnsErrAddDecayingEdge", func(t *testing.T) {
+		// Missing steps + interval — parse fails before c.client is used.
+		err := svc.RunArgs(ctx, []string{"add", "decaying-edge", "a", "b", "16", "0.5"})
+		if err != ErrAddDecayingEdge {
+			t.Errorf("RunArgs(add decaying-edge a b 16 0.5) = %v, want ErrAddDecayingEdge", err)
+		}
+	})
+
+	t.Run("UnknownAddObjectiveReturnsErrInvalidObjective", func(t *testing.T) {
+		if err := svc.RunArgs(ctx, []string{"add", "bogus", "a", "b"}); err != ErrInvalidObjective {
+			t.Errorf("RunArgs(add bogus ...) = %v, want ErrInvalidObjective", err)
+		}
+	})
+}

--- a/sdks/go/decay.go
+++ b/sdks/go/decay.go
@@ -1,0 +1,191 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+)
+
+// MaxDecaySteps is the default per-call fan-out ceiling for AddDecayingEdge /
+// DecayContributions: a single decaying add expands into at most this many
+// additive contributions. It is a safety rail, not the fundamental limit —
+// the binding constraints are the server's LANTERN_TOMBSTONE_TTL horizon
+// (which caps Steps*Interval) and float32 underflow. Geometric decay with
+// Ratio <= 0.5 is already negligible (below 2^-16 of the initial weight) by 16
+// steps; callers who want a smoother or longer curve raise Interval / the
+// half-life rather than the step count. Kept a named constant so the ceiling
+// can move without an API change.
+const MaxDecaySteps = 16
+
+// DecayOpts specifies a geometric ("exponential") decay staircase for the
+// live weight contributed by one AddDecayingEdge call. The contributed live
+// weight starts at InitialWeight and is multiplied by Ratio every Interval,
+// reaching exactly zero after Steps intervals. It is realized as up to Steps
+// additive edge contributions with staggered TTLs; no server-side support is
+// required (see DecayContributions for the exact expansion).
+type DecayOpts struct {
+	// InitialWeight is S(0): the live-sum weight this call contributes to the
+	// edge immediately after it is applied. It may be negative (a decaying
+	// negative reinforcement) but must be non-zero.
+	InitialWeight float32
+	// Ratio is the per-step multiplier r, which must lie in the open interval
+	// (0, 1): the contributed live weight on step k is InitialWeight*r^k.
+	Ratio float32
+	// Steps is the number of decay steps N; it must satisfy
+	// 1 <= Steps <= MaxDecaySteps. Steps == 1 degenerates to a single
+	// AddEdge(InitialWeight) expiring after Interval.
+	Steps int
+	// Interval is the wall-clock duration of one decay step; it must be > 0.
+	Interval time.Duration
+}
+
+// validate reports the first way opts is ill-formed, or nil when it is a
+// well-formed decay spec. Errors wrap ErrInvalidArgument so callers can match
+// them with errors.Is, mirroring the server's InvalidArgument mapping for the
+// server-side checks (expiration horizon, capacity) that only surface on the
+// wire.
+func (o DecayOpts) validate() error {
+	switch {
+	case o.InitialWeight == 0:
+		return fmt.Errorf("%w: DecayOpts.InitialWeight must be non-zero", ErrInvalidArgument)
+	case !(o.Ratio > 0 && o.Ratio < 1):
+		return fmt.Errorf("%w: DecayOpts.Ratio must be in the open interval (0, 1); got %v", ErrInvalidArgument, o.Ratio)
+	case o.Steps < 1:
+		return fmt.Errorf("%w: DecayOpts.Steps must be >= 1; got %d", ErrInvalidArgument, o.Steps)
+	case o.Steps > MaxDecaySteps:
+		return fmt.Errorf("%w: DecayOpts.Steps must be <= MaxDecaySteps (%d); got %d", ErrInvalidArgument, MaxDecaySteps, o.Steps)
+	case o.Interval <= 0:
+		return fmt.Errorf("%w: DecayOpts.Interval must be > 0; got %v", ErrInvalidArgument, o.Interval)
+	}
+	return nil
+}
+
+// DecayContributions expands a geometric decay spec into the additive edge
+// contributions that realize it, relative to base as t=0. It is the pure,
+// deterministic core of AddDecayingEdge: contribution j (1-indexed) targets
+// the same (tail, head), expires at base+j*Interval, and carries the step
+// drop
+//
+//	c_j = S(j-1) - S(j)   for j = 1..N-1
+//	c_N = S(N-1)          (the residual, folded into the last step)
+//
+// where S(k) = InitialWeight * Ratio^k is the target live-sum on step k and
+// N = Steps. Because a read sums every live contribution, these telescope to
+// S(0) = InitialWeight: the edge's live weight is InitialWeight right after
+// the add and then follows the staircase InitialWeight, InitialWeight*Ratio,
+// …, and exactly 0 once the last contribution expires at base+N*Interval.
+//
+// Note the contribution weights are the step DROPS, not the live-sum values:
+// InitialWeight=16, Ratio=0.5, Steps=5 yields weights 8,4,2,1,1 (not
+// 16,8,4,2,1, whose live sum would start at 31). Specifying the target curve
+// rather than the raw weights is the whole point of the helper.
+//
+// Contributions that underflow to exactly zero in float32 (deep in a fast
+// decay) are omitted — they would add nothing while still auto-materializing
+// endpoints and consuming server capacity — so the returned slice may be
+// shorter than Steps. The math is done in float64 and rounded once to float32
+// per contribution, so a caller comparing the read-back live weight against
+// InitialWeight should allow a small float32 tolerance.
+//
+// It returns an error wrapping ErrInvalidArgument when opts is ill-formed, or
+// when InitialWeight is so small the entire curve underflows float32 to zero.
+func DecayContributions(tail, head string, opts DecayOpts, base time.Time) ([]EdgeInput, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+	w0 := float64(opts.InitialWeight)
+	r := float64(opts.Ratio)
+	out := make([]EdgeInput, 0, opts.Steps)
+	for j := 1; j <= opts.Steps; j++ {
+		// c_j is the drop S(j-1)-S(j) = w0*r^(j-1)*(1-r) for every step but
+		// the last, which carries the whole residual S(N-1) = w0*r^(N-1) so
+		// the live weight reaches exactly zero at base+N*Interval.
+		exp := float64(j - 1)
+		var c float64
+		if j < opts.Steps {
+			c = w0 * math.Pow(r, exp) * (1 - r)
+		} else {
+			c = w0 * math.Pow(r, exp)
+		}
+		w := float32(c)
+		if w == 0 {
+			continue
+		}
+		out = append(out, EdgeInput{
+			Tail:       tail,
+			Head:       head,
+			Weight:     w,
+			Expiration: base.Add(time.Duration(j) * opts.Interval),
+		})
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf(
+			"%w: DecayOpts curve underflows float32 to zero (InitialWeight %v is too small)",
+			ErrInvalidArgument, opts.InitialWeight)
+	}
+	return out, nil
+}
+
+// HalfLifeDecay builds a DecayOpts from a half-life instead of an explicit
+// ratio: the contributed weight halves every halfLife, sampled every interval
+// over the given horizon. It sets
+//
+//	Ratio = 2^(-interval/halfLife)
+//	Steps = ceil(horizon/interval), clamped to [1, MaxDecaySteps]
+//
+// The result is fed to AddDecayingEdge / DecayContributions, which validate
+// it; HalfLifeDecay itself does not error, so a non-positive
+// halfLife/interval/horizon yields a DecayOpts that those functions reject.
+func HalfLifeDecay(initialWeight float32, halfLife, interval, horizon time.Duration) DecayOpts {
+	opts := DecayOpts{InitialWeight: initialWeight, Interval: interval}
+	if halfLife > 0 && interval > 0 {
+		opts.Ratio = float32(math.Pow(0.5, float64(interval)/float64(halfLife)))
+	}
+	if interval > 0 {
+		steps := int(math.Ceil(float64(horizon) / float64(interval)))
+		switch {
+		case steps < 1:
+			steps = 1
+		case steps > MaxDecaySteps:
+			steps = MaxDecaySteps
+		}
+		opts.Steps = steps
+	}
+	return opts
+}
+
+// AddDecayingEdge accumulates a single edge whose contributed live weight
+// follows the geometric decay staircase described by opts, using time.Now()
+// as the t=0 reference. It expands opts (see DecayContributions) into up to
+// opts.Steps additive contributions and applies them in one AddEdges batch,
+// so it inherits AddEdges' automatic chunking, WithIdempotentAdds dedup
+// (#588), retry policy, and post-accumulation effective-weight reporting
+// (#897).
+//
+// It returns the edge's effective (live-sum) weight immediately after the
+// add — any preexisting live weight on (tail, head) plus opts.InitialWeight.
+//
+// The whole curve is a single AddEdges request (Steps <= MaxDecaySteps is far
+// below the batch chunk size), so the server validates every contribution's
+// expiration before applying any: a horizon longer than the server's
+// LANTERN_TOMBSTONE_TTL rejects the entire add with ErrInvalidArgument rather
+// than writing a truncated staircase. A later PutEdge or DeleteEdge on the
+// same endpoints replaces or removes every contribution, discarding whatever
+// remains of the schedule.
+func (l *Lantern) AddDecayingEdge(ctx context.Context, tail, head string, opts DecayOpts) (float32, error) {
+	inputs, err := DecayContributions(tail, head, opts, time.Now())
+	if err != nil {
+		return 0, err
+	}
+	effective, err := l.AddEdges(ctx, inputs)
+	if err != nil {
+		return 0, err
+	}
+	// The contributions share (tail, head) and are applied in order, so the
+	// last entry's effective weight is the full post-add live sum.
+	if len(effective) == 0 {
+		return 0, nil
+	}
+	return effective[len(effective)-1], nil
+}

--- a/sdks/go/decay_test.go
+++ b/sdks/go/decay_test.go
@@ -1,0 +1,284 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
+)
+
+// approxEqual reports whether a and b are within tol, the float32 rounding
+// slack DecayContributions warns about (the curve is computed in float64 and
+// rounded once per contribution).
+func approxEqual(a, b, tol float32) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d <= tol
+}
+
+// TestDecayContributions pins the pure expansion: the "16 → 8,4,2,1,1 (not
+// 16,8,4,2,1)" golden staircase, the telescoping-to-InitialWeight invariant,
+// staggered expirations, the exact-zero residual fold, negative weights, the
+// Steps==1 degenerate, and the whole-curve underflow guard.
+func TestDecayContributions(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+
+	t.Run("golden staircase 16 r0.5 N5 → drops 8,4,2,1,1", func(t *testing.T) {
+		opts := DecayOpts{InitialWeight: 16, Ratio: 0.5, Steps: 5, Interval: time.Second}
+		got, err := DecayContributions("a", "b", opts, base)
+		if err != nil {
+			t.Fatalf("DecayContributions: %v", err)
+		}
+		wantW := []float32{8, 4, 2, 1, 1}
+		if len(got) != len(wantW) {
+			t.Fatalf("want %d contributions, got %d", len(wantW), len(got))
+		}
+		var sum float32
+		for i, in := range got {
+			if in.Tail != "a" || in.Head != "b" {
+				t.Fatalf("contribution %d endpoints = (%q,%q), want (a,b)", i, in.Tail, in.Head)
+			}
+			if !approxEqual(in.Weight, wantW[i], 1e-4) {
+				t.Fatalf("contribution %d weight = %v, want %v", i, in.Weight, wantW[i])
+			}
+			wantExp := base.Add(time.Duration(i+1) * time.Second)
+			if !in.Expiration.Equal(wantExp) {
+				t.Fatalf("contribution %d expiration = %v, want %v", i, in.Expiration, wantExp)
+			}
+			sum += in.Weight
+		}
+		// Telescoping: the live sum right after the add is InitialWeight (16),
+		// NOT the sum of a 16,8,4,2,1 raw schedule (31).
+		if !approxEqual(sum, 16, 1e-4) {
+			t.Fatalf("sum of drops = %v, want 16 (the live weight at t=0)", sum)
+		}
+	})
+
+	t.Run("telescoping sum equals InitialWeight", func(t *testing.T) {
+		cases := []DecayOpts{
+			{InitialWeight: 100, Ratio: 0.9, Steps: 16, Interval: time.Second},
+			{InitialWeight: 7, Ratio: 0.3, Steps: 4, Interval: time.Minute},
+			{InitialWeight: 1, Ratio: 0.5, Steps: 1, Interval: time.Second},
+		}
+		for _, opts := range cases {
+			got, err := DecayContributions("x", "y", opts, base)
+			if err != nil {
+				t.Fatalf("DecayContributions(%+v): %v", opts, err)
+			}
+			var sum float32
+			for _, in := range got {
+				sum += in.Weight
+			}
+			// Tolerance scales with the initial magnitude — float32 rounding
+			// accumulates across up to MaxDecaySteps drops.
+			tol := float32(math.Abs(float64(opts.InitialWeight))) * 1e-4
+			if tol < 1e-4 {
+				tol = 1e-4
+			}
+			if !approxEqual(sum, opts.InitialWeight, tol) {
+				t.Fatalf("sum for %+v = %v, want %v", opts, sum, opts.InitialWeight)
+			}
+		}
+	})
+
+	t.Run("Steps==1 is a single AddEdge(InitialWeight)", func(t *testing.T) {
+		opts := DecayOpts{InitialWeight: 5, Ratio: 0.5, Steps: 1, Interval: 2 * time.Second}
+		got, err := DecayContributions("a", "b", opts, base)
+		if err != nil {
+			t.Fatalf("DecayContributions: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("want 1 contribution, got %d", len(got))
+		}
+		if !approxEqual(got[0].Weight, 5, 1e-6) {
+			t.Fatalf("weight = %v, want 5", got[0].Weight)
+		}
+		if !got[0].Expiration.Equal(base.Add(2 * time.Second)) {
+			t.Fatalf("expiration = %v, want base+2s", got[0].Expiration)
+		}
+	})
+
+	t.Run("negative InitialWeight yields negative drops summing to it", func(t *testing.T) {
+		opts := DecayOpts{InitialWeight: -16, Ratio: 0.5, Steps: 5, Interval: time.Second}
+		got, err := DecayContributions("a", "b", opts, base)
+		if err != nil {
+			t.Fatalf("DecayContributions: %v", err)
+		}
+		var sum float32
+		for _, in := range got {
+			if in.Weight >= 0 {
+				t.Fatalf("negative decay must contribute negative weights, got %v", in.Weight)
+			}
+			sum += in.Weight
+		}
+		if !approxEqual(sum, -16, 1e-4) {
+			t.Fatalf("sum = %v, want -16", sum)
+		}
+	})
+
+	t.Run("whole-curve underflow is rejected", func(t *testing.T) {
+		opts := DecayOpts{InitialWeight: math.SmallestNonzeroFloat32, Ratio: 0.5, Steps: 5, Interval: time.Second}
+		_, err := DecayContributions("a", "b", opts, base)
+		if !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("want ErrInvalidArgument for underflowing curve, got %v", err)
+		}
+	})
+}
+
+// TestDecayOptsValidation is the rejection table for DecayContributions'
+// front-door validation; every ill-formed field wraps ErrInvalidArgument so
+// callers can errors.Is it, matching the server's InvalidArgument mapping.
+func TestDecayOptsValidation(t *testing.T) {
+	base := time.Now()
+	valid := DecayOpts{InitialWeight: 16, Ratio: 0.5, Steps: 5, Interval: time.Second}
+
+	if _, err := DecayContributions("a", "b", valid, base); err != nil {
+		t.Fatalf("valid opts rejected: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		opts DecayOpts
+	}{
+		{"zero InitialWeight", DecayOpts{InitialWeight: 0, Ratio: 0.5, Steps: 5, Interval: time.Second}},
+		{"ratio zero", DecayOpts{InitialWeight: 16, Ratio: 0, Steps: 5, Interval: time.Second}},
+		{"ratio one", DecayOpts{InitialWeight: 16, Ratio: 1, Steps: 5, Interval: time.Second}},
+		{"ratio above one", DecayOpts{InitialWeight: 16, Ratio: 1.5, Steps: 5, Interval: time.Second}},
+		{"ratio negative", DecayOpts{InitialWeight: 16, Ratio: -0.5, Steps: 5, Interval: time.Second}},
+		{"steps zero", DecayOpts{InitialWeight: 16, Ratio: 0.5, Steps: 0, Interval: time.Second}},
+		{"steps above cap", DecayOpts{InitialWeight: 16, Ratio: 0.5, Steps: MaxDecaySteps + 1, Interval: time.Second}},
+		{"interval zero", DecayOpts{InitialWeight: 16, Ratio: 0.5, Steps: 5, Interval: 0}},
+		{"interval negative", DecayOpts{InitialWeight: 16, Ratio: 0.5, Steps: 5, Interval: -time.Second}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DecayContributions("a", "b", tc.opts, base)
+			if !errors.Is(err, ErrInvalidArgument) {
+				t.Fatalf("want ErrInvalidArgument, got %v", err)
+			}
+		})
+	}
+}
+
+// TestHalfLifeDecay checks the half-life → ratio/steps derivation and that
+// the result feeds cleanly into DecayContributions.
+func TestHalfLifeDecay(t *testing.T) {
+	t.Run("interval == halfLife gives ratio 0.5", func(t *testing.T) {
+		opts := HalfLifeDecay(10, time.Second, time.Second, 5*time.Second)
+		if !approxEqual(opts.Ratio, 0.5, 1e-6) {
+			t.Fatalf("ratio = %v, want 0.5", opts.Ratio)
+		}
+		if opts.Steps != 5 {
+			t.Fatalf("steps = %d, want 5", opts.Steps)
+		}
+	})
+
+	t.Run("interval == 2*halfLife gives ratio 0.25", func(t *testing.T) {
+		opts := HalfLifeDecay(10, time.Second, 2*time.Second, 4*time.Second)
+		if !approxEqual(opts.Ratio, 0.25, 1e-6) {
+			t.Fatalf("ratio = %v, want 0.25", opts.Ratio)
+		}
+		if opts.Steps != 2 {
+			t.Fatalf("steps = %d, want 2", opts.Steps)
+		}
+	})
+
+	t.Run("steps clamp to MaxDecaySteps", func(t *testing.T) {
+		opts := HalfLifeDecay(10, time.Second, time.Second, 1000*time.Second)
+		if opts.Steps != MaxDecaySteps {
+			t.Fatalf("steps = %d, want clamp to %d", opts.Steps, MaxDecaySteps)
+		}
+	})
+
+	t.Run("non-positive horizon clamps to 1 step", func(t *testing.T) {
+		opts := HalfLifeDecay(10, time.Second, time.Second, 0)
+		if opts.Steps != 1 {
+			t.Fatalf("steps = %d, want 1", opts.Steps)
+		}
+	})
+
+	t.Run("result validates and expands", func(t *testing.T) {
+		opts := HalfLifeDecay(64, time.Minute, 30*time.Second, 3*time.Minute)
+		got, err := DecayContributions("a", "b", opts, time.Now())
+		if err != nil {
+			t.Fatalf("DecayContributions on HalfLifeDecay opts: %v", err)
+		}
+		if len(got) == 0 {
+			t.Fatal("want contributions, got none")
+		}
+	})
+}
+
+// decayEchoClient is a fake LanternServiceClient that records AddEdges
+// requests and answers with cumulative effective weights — the live sum a
+// fresh edge would report as each contribution accumulates. It lets the
+// AddDecayingEdge delegation test assert both the expanded wire payload and
+// the returned post-add live weight without a server.
+type decayEchoClient struct {
+	graphv1connect.LanternServiceClient
+	reqs []*pb.AddEdgesRequest
+}
+
+func (c *decayEchoClient) AddEdges(_ context.Context, req *connect.Request[pb.AddEdgesRequest]) (*connect.Response[pb.AddEdgesResponse], error) {
+	c.reqs = append(c.reqs, req.Msg)
+	edges := req.Msg.GetEdges()
+	eff := make([]float32, len(edges))
+	var running float32
+	for i, e := range edges {
+		running += e.GetWeight()
+		eff[i] = running
+	}
+	return connect.NewResponse(&pb.AddEdgesResponse{
+		Written:          int32(len(edges)),
+		EffectiveWeights: eff,
+	}), nil
+}
+
+// TestAddDecayingEdge covers the method's delegation: one AddEdges batch
+// carrying the expanded staircase, and a return value equal to the post-add
+// live weight (InitialWeight for a fresh edge — the "16 not 31" check at the
+// SDK boundary), plus validation short-circuiting before any RPC.
+func TestAddDecayingEdge(t *testing.T) {
+	t.Run("sends one expanded batch and returns InitialWeight", func(t *testing.T) {
+		l := mustLantern(t)
+		capt := &decayEchoClient{}
+		l.client = capt
+
+		opts := DecayOpts{InitialWeight: 16, Ratio: 0.5, Steps: 5, Interval: time.Second}
+		got, err := l.AddDecayingEdge(context.Background(), "a", "b", opts)
+		if err != nil {
+			t.Fatalf("AddDecayingEdge: %v", err)
+		}
+		if len(capt.reqs) != 1 {
+			t.Fatalf("want 1 AddEdges request, got %d", len(capt.reqs))
+		}
+		if n := len(capt.reqs[0].GetEdges()); n != 5 {
+			t.Fatalf("want 5 edges in the batch, got %d", n)
+		}
+		if !approxEqual(got, 16, 1e-4) {
+			t.Fatalf("post-add live weight = %v, want 16", got)
+		}
+	})
+
+	t.Run("invalid opts short-circuit before any RPC", func(t *testing.T) {
+		l := mustLantern(t)
+		capt := &decayEchoClient{}
+		l.client = capt
+
+		opts := DecayOpts{InitialWeight: 16, Ratio: 2, Steps: 5, Interval: time.Second}
+		if _, err := l.AddDecayingEdge(context.Background(), "a", "b", opts); !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("want ErrInvalidArgument, got %v", err)
+		}
+		if len(capt.reqs) != 0 {
+			t.Fatalf("invalid opts must not send an RPC, got %d", len(capt.reqs))
+		}
+	})
+}

--- a/sdks/go/example/main.go
+++ b/sdks/go/example/main.go
@@ -225,6 +225,37 @@ func main() {
 	time.Sleep(1 * time.Second)
 
 	/*
+		AddDecayingEdge:
+			AddDecayingEdge is a client-side helper (no new RPC) that shapes a
+			geometrically decaying weight curve out of the additive edge model.
+			It expands one DecayOpts into several contributions with staggered
+			TTLs and sends them as a single AddEdges batch, so the live weight
+			starts at InitialWeight and steps down by Ratio each Interval until
+			it vanishes.
+
+			The contributions telescope: a 16 -> 8 -> 4 -> 2 -> 1 -> 0 staircase
+			is written as weights {8,4,2,1,1}, which SUM to 16 (not 31). The
+			return value is the immediate post-add live weight (≈ InitialWeight).
+	*/
+	if live, err := cli.AddDecayingEdge(ctx, "p", "q", client.DecayOpts{
+		InitialWeight: 16,
+		Ratio:         0.5,         // halve every step
+		Steps:         5,           // capped at client.MaxDecaySteps
+		Interval:      time.Second, // one step per second
+	}); err != nil {
+		log.Fatal(err)
+	} else {
+		log.Printf("decaying p->q live weight right after add: %f\n", live) // ≈ 16
+	}
+
+	// HalfLifeDecay is a convenience constructor: pick a half-life and a horizon
+	// and it derives Ratio/Steps for you.
+	if _, err := cli.AddDecayingEdge(ctx, "p", "q2",
+		client.HalfLifeDecay(10, 2*time.Second, time.Second, 8*time.Second)); err != nil {
+		log.Fatal(err)
+	}
+
+	/*
 		Illuminate:
 			Illuminate returns a subgraph rooted at `seed`. The walk runs
 			server-side; select the traversal family with a typed per-family

--- a/sdks/go/failover.go
+++ b/sdks/go/failover.go
@@ -436,6 +436,34 @@ func (f *Failover) AddEdges(ctx context.Context, inputs []EdgeInput) ([]float32,
 	return effective, err
 }
 
+// AddDecayingEdge forwards the geometric decay staircase (see the *Lantern
+// method of the same name) through the failover ring. The curve is expanded
+// ONCE — a single base time and a single mint of the per-contribution ids,
+// both captured before the retry loop — so every attempt and every node
+// replays byte-identical contributions and ids and a mid-flight Unavailable
+// retry cannot double-count or skew the schedule (#916). It returns the edge's
+// post-add effective (live-sum) weight.
+func (f *Failover) AddDecayingEdge(ctx context.Context, tail, head string, opts DecayOpts) (float32, error) {
+	inputs, err := DecayContributions(tail, head, opts, time.Now())
+	if err != nil {
+		return 0, err
+	}
+	ids := f.nextContribIDs(len(inputs))
+	var effective []float32
+	err = f.call(ctx, "AddDecayingEdge", func(l failoverNode) error {
+		w, e := l.addEdgesWithIDs(ctx, inputs, ids)
+		effective = w
+		return e
+	})
+	if err != nil {
+		return 0, err
+	}
+	if len(effective) == 0 {
+		return 0, nil
+	}
+	return effective[len(effective)-1], nil
+}
+
 // nextContribIDs mints n contrib ids from the failover-level generator, or
 // nil when idempotent adds are disabled (contribIDs is nil) — the legacy
 // non-idempotent additive path. Minting at the failover layer (not per node)

--- a/sdks/go/failover_test.go
+++ b/sdks/go/failover_test.go
@@ -537,3 +537,88 @@ func TestNewLanternFailover_RetryExtractedAndNodesNeutralised(t *testing.T) {
 		}
 	}
 }
+
+// TestFailover_AddDecayingEdge covers the decay staircase over the ring: it
+// rotates to a healthy replica on Unavailable and reports the post-add live
+// weight, and it expands the curve exactly once — every attempt and node sees
+// byte-identical contributions (weights + expirations) and contrib ids, so a
+// mid-flight retry can neither double-count nor skew the schedule (#916).
+func TestFailover_AddDecayingEdge(t *testing.T) {
+	opts := DecayOpts{InitialWeight: 16, Ratio: 0.5, Steps: 5, Interval: time.Second}
+
+	t.Run("rotates on unavailable and returns post-add live weight", func(t *testing.T) {
+		var n0, n1 int
+		node0 := &fakeNode{addEdgesWithIDsFn: func(context.Context, []EdgeInput, [][]byte) ([]float32, error) {
+			n0++
+			return nil, unavailableErr()
+		}}
+		node1 := &fakeNode{addEdgesWithIDsFn: func(_ context.Context, inputs []EdgeInput, _ [][]byte) ([]float32, error) {
+			n1++
+			eff := make([]float32, len(inputs))
+			var running float32
+			for i, in := range inputs {
+				running += in.Weight
+				eff[i] = running
+			}
+			return eff, nil
+		}}
+		f := &Failover{nodes: []failoverNode{node0, node1}}
+
+		got, err := f.AddDecayingEdge(context.Background(), "a", "b", opts)
+		if err != nil {
+			t.Fatalf("AddDecayingEdge err = %v", err)
+		}
+		if n0 != 1 || n1 != 1 {
+			t.Fatalf("call counts n0=%d n1=%d, want 1 and 1 (rotate on unavailable)", n0, n1)
+		}
+		if d := got - 16; d < -1e-4 || d > 1e-4 {
+			t.Fatalf("post-add live weight = %v, want 16", got)
+		}
+	})
+
+	t.Run("expands once — identical contributions and ids across attempts", func(t *testing.T) {
+		type attempt struct {
+			inputs []EdgeInput
+			ids    [][]byte
+		}
+		var seen []attempt
+		record := func() *fakeNode {
+			return &fakeNode{addEdgesWithIDsFn: func(_ context.Context, inputs []EdgeInput, ids [][]byte) ([]float32, error) {
+				ic := append([]EdgeInput(nil), inputs...)
+				idc := make([][]byte, len(ids))
+				for i, id := range ids {
+					idc[i] = append([]byte(nil), id...)
+				}
+				seen = append(seen, attempt{inputs: ic, ids: idc})
+				return nil, unavailableErr()
+			}}
+		}
+		f := &Failover{
+			nodes:          []failoverNode{record(), record()},
+			retry:          testRetryPolicy(3),
+			idempotentAdds: true,
+			contribIDs:     &contribIDGen{},
+		}
+		if _, err := f.AddDecayingEdge(context.Background(), "a", "b", opts); !errors.Is(err, ErrUnavailable) {
+			t.Fatalf("err = %v, want ErrUnavailable", err)
+		}
+		if len(seen) < 4 {
+			t.Fatalf("attempts observed = %d, want >= 4 (retry × ring walk)", len(seen))
+		}
+		first := seen[0]
+		if len(first.inputs) != 5 || len(first.ids) != 5 {
+			t.Fatalf("attempt 0 = %d inputs / %d ids, want 5 and 5", len(first.inputs), len(first.ids))
+		}
+		for ai, at := range seen[1:] {
+			for i := range first.inputs {
+				if at.inputs[i].Weight != first.inputs[i].Weight ||
+					!at.inputs[i].Expiration.Equal(first.inputs[i].Expiration) {
+					t.Fatalf("attempt %d contribution %d differs — curve re-expanded per attempt", ai+1, i)
+				}
+				if !bytes.Equal(at.ids[i], first.ids[i]) {
+					t.Fatalf("attempt %d id[%d] re-minted — double-count risk", ai+1, i)
+				}
+			}
+		}
+	})
+}

--- a/sdks/go/retry.go
+++ b/sdks/go/retry.go
@@ -242,10 +242,12 @@ var methodRetryClasses = map[string]methodRetryClass{
 	"AddEdge":                retryIfIdempotentAdds,
 	"AddEdgeAt":              retryIfIdempotentAdds,
 	"AddEdges":               retryIfIdempotentAdds,
-	"Backup":                 retryNever, // whole-graph stream dump — excluded in v1
-	"Restore":                retryNever, // stream restore — excluded in v1
-	"Subscribe":              retryNever, // server-streaming replication feed
-	"NewIncrementalSearch":   retryNever, // session constructor; per-query retries ride unary
+	"AddDecayingEdge":        retryIfIdempotentAdds, // fans out into an AddEdges batch
+
+	"Backup":               retryNever, // whole-graph stream dump — excluded in v1
+	"Restore":              retryNever, // stream restore — excluded in v1
+	"Subscribe":            retryNever, // server-streaming replication feed
+	"NewIncrementalSearch": retryNever, // session constructor; per-query retries ride unary
 }
 
 // retryableMethod is the method-name counterpart to requestRetryable,

--- a/tests/integration/decaying_edge_test.go
+++ b/tests/integration/decaying_edge_test.go
@@ -1,0 +1,150 @@
+package integration_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/graphcache"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/anaregdesign/lantern/server/provider"
+	"github.com/anaregdesign/lantern/server/service"
+)
+
+// This file pins the server-free exponential edge-weight decay helper (#952)
+// as an externally observable contract over the real Connect/h2c wire path.
+// AddDecayingEdge expands a geometric target curve into staggered-TTL additive
+// contributions client-side; the server sees only an ordinary AddEdges batch,
+// so the guarantees under test are: (1) the live weight right after the add is
+// the target InitialWeight — S(0), NOT the sum of the raw per-step schedule —
+// (2) the weight decays monotonically and the edge eventually vanishes, and
+// (3) a curve whose horizon overruns the server's tombstone-TTL is rejected
+// whole (all-or-nothing), never written as a truncated staircase.
+
+// newTombstoneClient stands up an in-process server whose delete/expiration
+// retention window (LANTERN_TOMBSTONE_TTL) is clamped to ttl, so a write whose
+// expiration exceeds now+ttl is rejected with InvalidArgument — the guard the
+// decay-horizon rejection test exercises.
+func newTombstoneClient(t *testing.T, ttl time.Duration) *client.Lantern {
+	t.Helper()
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+	svc := service.NewLanternService(cache).WithTombstoneTTL(ttl)
+	val := provider.NewValidationInterceptor(defaultIntegrationValidationLimits())
+	srv := newConnectTestServer(t, svc, nil, val.ConnectInterceptor())
+	return newConnectClientFor(t, srv.url)
+}
+
+func TestAddDecayingEdge_ExternallyObservableDecay(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// seedEndpoints writes both endpoints with a long TTL so referential
+	// closure (#750) never hides the edge before its own contributions decay —
+	// isolating edge-weight decay as the only variable.
+	seedEndpoints := func(t *testing.T, l *client.Lantern, tail, head string) {
+		t.Helper()
+		if err := l.PutVertex(ctx, tail, 1, time.Hour); err != nil {
+			t.Fatalf("PutVertex %s: %v", tail, err)
+		}
+		if err := l.PutVertex(ctx, head, 2, time.Hour); err != nil {
+			t.Fatalf("PutVertex %s: %v", head, err)
+		}
+	}
+
+	t.Run("immediate live weight is InitialWeight, not the raw-schedule sum", func(t *testing.T) {
+		l, cleanup := newInProcessClient(t)
+		defer cleanup()
+		seedEndpoints(t, l, "a", "b")
+
+		// 16 → 8 → 4 → 2 → 1 → 0. The contributions are 8,4,2,1,1 (sum 16); a
+		// naive 16,8,4,2,1 schedule would read 31 right after the add. The
+		// returned effective weight and an immediate GetEdge must both be ~16.
+		opts := client.DecayOpts{InitialWeight: 16, Ratio: 0.5, Steps: 5, Interval: time.Second}
+		effective, err := l.AddDecayingEdge(ctx, "a", "b", opts)
+		if err != nil {
+			t.Fatalf("AddDecayingEdge: %v", err)
+		}
+		if effective <= 14 || effective >= 18 {
+			t.Fatalf("returned effective weight = %v, want ~16 (NOT 31 — the raw-schedule sum)", effective)
+		}
+		edge, err := l.GetEdge(ctx, "a", "b")
+		if err != nil {
+			t.Fatalf("GetEdge right after add: %v", err)
+		}
+		if edge.Weight <= 14 || edge.Weight >= 18 {
+			t.Fatalf("live edge weight = %v, want ~16 (NOT 31)", edge.Weight)
+		}
+	})
+
+	t.Run("weight decays after the first step and the edge eventually vanishes", func(t *testing.T) {
+		l, cleanup := newInProcessClient(t)
+		defer cleanup()
+		seedEndpoints(t, l, "c", "d")
+
+		opts := client.DecayOpts{InitialWeight: 16, Ratio: 0.5, Steps: 5, Interval: time.Second}
+		if _, err := l.AddDecayingEdge(ctx, "c", "d", opts); err != nil {
+			t.Fatalf("AddDecayingEdge: %v", err)
+		}
+
+		// After more than one interval the first contribution (8, expiring at
+		// +1s) has dropped from the live sum, so the weight is strictly below
+		// InitialWeight yet still positive. The read excludes expired
+		// contributions deterministically by absolute expiration, so this does
+		// not depend on GC timing — only on the wall clock passing +1s.
+		time.Sleep(1500 * time.Millisecond)
+		edge, err := l.GetEdge(ctx, "c", "d")
+		if err != nil {
+			t.Fatalf("GetEdge mid-decay: %v", err)
+		}
+		if edge.Weight <= 0 || edge.Weight >= 16 {
+			t.Fatalf("mid-decay weight = %v, want 0 < w < 16 (first step decayed)", edge.Weight)
+		}
+
+		// Past the full horizon (5×1s) every contribution has expired, so the
+		// edge is gone from the point read even though both endpoints live on.
+		eventuallyNotFound(t, "decaying edge", func() error {
+			_, err := l.GetEdge(ctx, "c", "d")
+			return err
+		})
+		if _, err := l.GetVertex(ctx, "c"); err != nil {
+			t.Fatalf("tail vertex must survive the decayed edge: %v", err)
+		}
+	})
+}
+
+// TestAddDecayingEdge_TombstoneTTLRejection pins the horizon guard: when
+// Steps×Interval overruns the server's tombstone-TTL, the later contributions'
+// expirations exceed now+tombstoneTTL and the whole AddEdges batch is rejected
+// with a typed ErrInvalidArgument — the client never sees a partially written
+// staircase (single-chunk, validate-before-apply atomicity).
+func TestAddDecayingEdge_TombstoneTTLRejection(t *testing.T) {
+	l := newTombstoneClient(t, 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Endpoints are seeded within the 3s retention window (the tombstone TTL
+	// clamps every expiration, endpoints included) and read back immediately,
+	// so they are live when we assert the edge was not written.
+	if err := l.PutVertex(ctx, "x", 1, 2*time.Second); err != nil {
+		t.Fatalf("PutVertex x: %v", err)
+	}
+	if err := l.PutVertex(ctx, "y", 2, 2*time.Second); err != nil {
+		t.Fatalf("PutVertex y: %v", err)
+	}
+
+	// Horizon 5s ≫ tombstone 3s: contributions at +4s/+5s exceed the retention
+	// window, so the server rejects the whole batch.
+	opts := client.DecayOpts{InitialWeight: 16, Ratio: 0.5, Steps: 5, Interval: time.Second}
+	_, err := l.AddDecayingEdge(ctx, "x", "y", opts)
+	if !errors.Is(err, client.ErrInvalidArgument) {
+		t.Fatalf("over-horizon decay: got %v, want errors.Is ErrInvalidArgument", err)
+	}
+
+	// All-or-nothing: no contribution was written, so the edge does not exist
+	// even though both endpoints are still live.
+	if _, err := l.GetEdge(ctx, "x", "y"); !errors.Is(err, client.ErrNotFound) {
+		t.Fatalf("rejected decay must write nothing; GetEdge = %v, want ErrNotFound", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a **client-side** helper that shapes a geometrically ("exponentially") decaying weight curve out of Lantern's existing **additive** edge model. There is **no new RPC, proto, or wire surface** — one `DecayOpts{InitialWeight, Ratio, Steps, Interval}` expands into up to `MaxDecaySteps` (16) staggered-TTL contributions and is sent as a single `AddEdges` batch. The live weight starts at `InitialWeight` and steps down by `Ratio` each `Interval` until it vanishes. The server stays a dumb additive store — this keeps the feature squarely inside the client's responsibility.

### The "16, not 31" subtlety
The contributions **telescope**: a `16 → 8 → 4 → 2 → 1 → 0` staircase is written as weights `{8,4,2,1,1}` (sum **16**), *not* the raw `{16,8,4,2,1}` (whose live sum would start at **31**). Specifying the target curve rather than the raw per-step weights is the whole point of the helper. Math is done in `float64` and rounded once per contribution to `float32`; contributions that underflow to exactly zero are skipped, and a wholly-underflowing curve is rejected with `ErrInvalidArgument`.

## Changes

- **`sdks/go/decay.go`** — `MaxDecaySteps`, `DecayOpts`+`validate()`, the pure `DecayContributions(tail, head, opts, base)`, the `AddDecayingEdge(ctx, tail, head, opts)` method, and the `HalfLifeDecay(initialWeight, halfLife, interval, horizon)` convenience constructor.
- **`sdks/go/retry.go`** — classify `AddDecayingEdge` as `retryIfIdempotentAdds` (required by the forced-decision retry-coverage guard).
- **`sdks/go/failover.go`** — `Failover.AddDecayingEdge` expands the curve and mints contrib ids **once** before the retry loop, so every attempt/node replays byte-identical inputs (no double-count on a mid-flight `Unavailable`, per #916).
- **CLI** — `add decaying-edge <tail> <head> <initial_weight> <ratio> <steps> <interval_seconds>` (REPL + cobra), routed through a dedicated `AddObjective` so `add vertex` stays a clean parse error and the decay sugar never leaks into `get`/`put`/`delete`. All six args required; range validation is delegated to the SDK.
- **`tests/integration/decaying_edge_test.go`** — externally observable decay over the real Connect/h2c wire: immediate live weight ~16 (not 31), monotonic decay + eventual vanish, and whole-batch rejection when the horizon overruns `LANTERN_TOMBSTONE_TTL` (all-or-nothing, never a truncated staircase).
- **Docs** — SDK `example/main.go` snippet, README decay note, and a `lantern-ops` skill verb entry.

## Design notes / caps
- **Steps capped at 16** (`MaxDecaySteps`) as a safety rail — with `Ratio ≤ 0.5` the curve is already below `2^-16` of the initial weight by 16 steps; smoother/longer curves raise `Interval`/half-life, not the step count.
- The whole curve is a single `AddEdges` request (16 ≪ chunk size), so the server validates every contribution's expiration before applying any — a horizon longer than the tombstone TTL rejects the entire add rather than writing a partial staircase.
- A later `PutEdge`/`DeleteEdge` on the same endpoints replaces/removes every contribution, discarding the rest of the schedule.

## Testing
- `gofmt -l .` clean.
- `go test ./...` green from root **and** each submodule (`core`, `pb`, `sdks/go`, `mcp`, and `server` with `go vet`).
- New white-box (`decay_test.go`), failover (`failover_test.go`), CLI (parser/validate/service), and wire-level integration tests all pass.

## Follow-up
Admin TS CLI-parser parity for the new verb is a documented follow-up (the Go/TS grammar has no enforced cross-language equality test; the shared fixture checks soundness only, and all existing `add` entries stay correct under `AddObjective`).

Closes #952