### PR TITLE
feat(sdks/node): decay, backup/restore and ping parity with Go SDK

### DIFF
--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -220,6 +220,45 @@ if (would > 0n) {
 }
 ```
 
+## Decaying edges
+
+`addDecayingEdge(tail, head, opts)` accumulates a single edge whose **live
+(summed) weight decays geometrically over time** — starting at
+`opts.initialWeight`, multiplied by `opts.ratio` every `opts.intervalSeconds`,
+reaching zero after `opts.steps` intervals. It expands the curve into a
+telescoping set of additive contributions with staggered absolute expirations
+and applies them in one `addEdges` batch (so it inherits contrib-id dedup when
+`idempotentAdds` is on), returning the edge's effective weight right after the
+add.
+
+```ts
+// weight ≈ 16 now, ~8 after 1h, ~4 after 2h, … gone after 5h.
+const live = await client.addDecayingEdge("user:42", "topic:ml", {
+  initialWeight: 16,
+  ratio: 0.5,
+  steps: 5,
+  intervalSeconds: 3600,
+});
+```
+
+Prefer a half-life to hand-tuned steps? `halfLifeDecay(initialWeight,
+halfLifeSeconds, intervalSeconds, horizonSeconds)` builds the `DecayOptions` for
+you (clamped to `MAX_DECAY_STEPS` = 16):
+
+```ts
+import { halfLifeDecay } from "lantern-sdk";
+// Halve every 24h, sampled hourly, out to a 7-day horizon.
+const opts = halfLifeDecay(10, 86_400, 3_600, 604_800);
+await client.addDecayingEdge("a", "b", opts);
+```
+
+The whole curve is one `addEdges` request, so the server validates every
+contribution's expiration before applying any: a horizon longer than the
+server's `LANTERN_TOMBSTONE_TTL` rejects the entire add. A curve that underflows
+float32 to zero, or ill-formed `opts`, rejects with `InvalidArgumentError`. The
+pure `decayContributions(tail, head, opts, baseMs)` helper is exported too, if
+you want the `EdgeInput[]` without sending it.
+
 ## Content search
 
 `searchVertices` runs a relevance-ranked full-text query over vertex
@@ -238,6 +277,64 @@ An empty or unmatched query resolves to `[]` (not an error). When the
 server's index is disabled (`LANTERN_SEARCH_ENABLED=false`) the call rejects
 with `FailedPreconditionError`, so callers can render a calm "search not
 enabled" state instead of treating it as a hard failure.
+
+## Backup & restore
+
+`backup(opts?)` streams a whole-graph, point-in-time dump as an **async
+iterable** of `BackupRecord`s — every live vertex, then every folded live edge.
+Each record is decoded kind-preservingly, so narrow numeric value types
+(int32/uint32/uint64/float32/duration) round-trip through `restore` exactly.
+`restore(source, opts?)` replays any (sync or async) iterable of records back
+through the batch `putVertices` / `putEdges` surface and returns the counts
+loaded.
+
+```ts
+// Dump → NDJSON file.
+import { createWriteStream } from "node:fs";
+const out = createWriteStream("graph.ndjson");
+for await (const rec of client.backup()) {
+  out.write(backupRecordToNdjson(rec) + "\n");
+}
+
+// NDJSON file → restore.
+import { createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
+async function* records() {
+  const rl = createInterface({ input: createReadStream("graph.ndjson") });
+  for await (const line of rl) if (line) yield backupRecordFromNdjson(line);
+}
+const stats = await client.restore(records()); // { vertices, edges }
+```
+
+Pass `{ prefix }` to scope a backup to a key namespace, and `{ chunkSize }`
+(default 1000) to tune restore batch size. The `backupRecordToNdjson` /
+`backupRecordFromNdjson` line codec is a **Node-native** format (a
+`"kind"`-discriminated JSON object per line; int64/uint64 magnitudes as strings
+so values above 2^53 survive) — it is safe and lossless for Node→Node dumps,
+but is not interchangeable with the Go SDK's `FormatNDJSON`. Restore is not
+transactional — a mid-stream failure leaves already-flushed batches in place;
+re-running is safe because `Put` is idempotent.
+
+## Ping / health check
+
+`ping(signal?)` probes server readiness via the gRPC-Health-v1 `Health/Check`
+that rides the primary listener. It resolves when the server reports SERVING,
+throws `HealthStatusError` (with the reported `.status`) on any other status,
+and a generic `LanternError` on transport / non-200 / decode failure.
+
+```ts
+try {
+  await client.ping();
+} catch (err) {
+  if (err instanceof HealthStatusError) console.warn("not serving:", err.status);
+  else throw err;
+}
+```
+
+`ping` needs the server's base URL, so it works on clients built via `connect()`
+/ `connectWeb()` (or a `withTransport` client given a `baseUrl`); a
+transport-only client rejects with `InvalidArgumentError`. The client's
+`defaultTimeoutMs`, if set, bounds the probe.
 
 ## Cancellation
 

--- a/sdks/node/src/backup.ts
+++ b/sdks/node/src/backup.ts
@@ -1,0 +1,99 @@
+/**
+ * Whole-graph backup / restore for the Node SDK (#685, parity with the Go
+ * SDK's `backup.go`). `Lantern.backup` streams the server's `BackupSnapshot`
+ * RPC as an async iterable of decoded {@link BackupRecord}s; `Lantern.restore`
+ * replays those records through the batch `putVertices` / `putEdges` surface
+ * (there is no dedicated restore RPC).
+ *
+ * Unlike the Go SDK — which serialises to an `io.Writer` in one of two wire
+ * formats — the Node SDK yields the record stream directly, leaving
+ * serialisation to the caller. {@link backupRecordToNdjson} /
+ * {@link backupRecordFromNdjson} provide a ready **Node-native** NDJSON line
+ * codec for the common "dump to a file, restore it later" workflow: a naive
+ * `JSON.stringify(record)` is a footgun (it throws on `bigint` values and
+ * mangles `Uint8Array` / `Date` / `Duration`), whereas this codec preserves
+ * every value type exactly. It is a Node↔Node format — it does **not** share a
+ * byte layout with the Go SDK's `FormatNDJSON` (Go frames a
+ * `{type,value}` envelope and emits 64-bit ints as bare JSON numbers, which JS
+ * cannot read back losslessly above 2^53), so cross-SDK NDJSON exchange is out
+ * of scope. The `BackupRecord` stream itself is lossless: decoded vertices
+ * carry their `kind`, so narrow numeric value types
+ * (int32/uint32/uint64/float32/duration) survive a round-trip exactly.
+ */
+
+import { InvalidArgumentError } from "./errors.js";
+import {
+  edgeRecordToJson,
+  fromEdgeJson,
+  fromVertexJson,
+  vertexRecordToJson,
+  type Edge,
+  type Vertex,
+} from "./values.js";
+
+/**
+ * One frame of a backup stream: either a live vertex or a folded live edge
+ * (weight summed across contributions, expiration = the furthest-future
+ * contribution). Consumers route on the `kind` discriminator.
+ */
+export type BackupRecord =
+  | { readonly kind: "vertex"; readonly vertex: Vertex }
+  | { readonly kind: "edge"; readonly edge: Edge };
+
+/** Counts of what a {@link import("./client.js").Lantern.restore} call loaded. */
+export interface RestoreStats {
+  vertices: number;
+  edges: number;
+}
+
+/**
+ * Accepted input to `restore`: any sync or async iterable of
+ * {@link BackupRecord} — the output of `backup`, a decoded NDJSON file, an
+ * in-memory array, etc. `for await` consumes both kinds.
+ */
+export type RestoreSource = Iterable<BackupRecord> | AsyncIterable<BackupRecord>;
+
+/**
+ * Default batch size for the `putVertices` / `putEdges` calls `restore`
+ * issues. Mirrors the Go SDK's `defaultRestoreChunkSize`.
+ */
+export const DEFAULT_RESTORE_CHUNK_SIZE = 1000;
+
+/**
+ * Render a {@link BackupRecord} as a single NDJSON line (no trailing newline),
+ * splicing a `"kind"` discriminator (`"vertex"` / `"edge"`) onto the flat
+ * protobuf-JSON value shape. int64/uint64 magnitudes are carried as strings
+ * (so values above 2^53 survive) and every narrow numeric kind is preserved,
+ * so the line round-trips losslessly through {@link backupRecordFromNdjson}.
+ * Prefer this over a naive `JSON.stringify(record)`, which throws on `bigint`
+ * values and mangles `Uint8Array` / `Date` / `Duration`. This is a Node-native
+ * layout — see the module header; it is not interchangeable with the Go SDK's
+ * `FormatNDJSON`.
+ */
+export function backupRecordToNdjson(rec: BackupRecord): string {
+  if (rec.kind === "vertex") {
+    return JSON.stringify({ kind: "vertex", ...vertexRecordToJson(rec.vertex) });
+  }
+  return JSON.stringify({ kind: "edge", ...edgeRecordToJson(rec.edge) });
+}
+
+/**
+ * Parse one NDJSON line produced by {@link backupRecordToNdjson} back into a
+ * {@link BackupRecord}. Routes on the `"kind"` field; the discriminator is
+ * ignored by the value decoders.
+ *
+ * @throws {InvalidArgumentError} when `kind` is missing or unrecognised.
+ */
+export function backupRecordFromNdjson(line: string): BackupRecord {
+  const obj = JSON.parse(line) as Record<string, unknown>;
+  switch (obj.kind) {
+    case "vertex":
+      return { kind: "vertex", vertex: fromVertexJson(obj) };
+    case "edge":
+      return { kind: "edge", edge: fromEdgeJson(obj) };
+    default:
+      throw new InvalidArgumentError(
+        `backup: unknown or missing record kind ${JSON.stringify(obj.kind)}`,
+      );
+  }
+}

--- a/sdks/node/src/client.ts
+++ b/sdks/node/src/client.ts
@@ -41,8 +41,10 @@ import {
   ScanOrder as PbScanOrder,
   Weighting as PbWeighting,
   VertexSchema,
+  type Edge as PbEdge,
   type GetReplicationStatusResponse,
   type GetServerStatusResponse,
+  type Vertex as PbVertex,
 } from "./gen/graph/v1/graph_pb.js";
 
 import {
@@ -60,6 +62,8 @@ import {
   fromVertexJson,
   toEdgeJson,
   toVertexJson,
+  edgeRecordToJson,
+  vertexRecordToJson,
   type Edge,
   type EdgeInput,
   type Graph,
@@ -84,6 +88,14 @@ import {
   type IncrementalSearchOptions,
 } from "./incremental-search.js";
 import { contribIdFrom, makeNonce, validateContribId } from "./contrib.js";
+import { decayContributions, type DecayOptions } from "./decay.js";
+import {
+  DEFAULT_RESTORE_CHUNK_SIZE,
+  type BackupRecord,
+  type RestoreSource,
+  type RestoreStats,
+} from "./backup.js";
+import { pingHealth, type PingOptions } from "./health.js";
 
 /**
  * Upper bound for the auto-chunk size. Contrib-ID idempotency keys (#895)
@@ -239,14 +251,27 @@ export { normaliseBaseUrl };
 export class Lantern {
   private readonly client: Client<typeof LanternService>;
   private readonly options: ConnectOptions;
+  /**
+   * The normalised base URL (`http(s)://host:port`, no trailing slash) the
+   * client was built with, or undefined when constructed via
+   * {@link Lantern.withTransport} without one. Only `ping()` needs it — it
+   * POSTs a Connect+JSON Health/Check to the gRPC-Health-v1 endpoint that
+   * rides the same listener, which the typed `client` does not expose.
+   */
+  private readonly baseUrl?: string;
   /** Lazily-minted per-client nonce seeding automatic contrib IDs (#895). */
   private nonce: Uint8Array | null = null;
   /** Monotonic per-call sequence folded into automatic contrib IDs (#895). */
   private callSeq = 0n;
 
-  private constructor(client: Client<typeof LanternService>, options: ConnectOptions) {
+  private constructor(
+    client: Client<typeof LanternService>,
+    options: ConnectOptions,
+    baseUrl?: string,
+  ) {
     this.client = client;
     this.options = options;
+    this.baseUrl = baseUrl;
   }
 
   /**
@@ -263,12 +288,26 @@ export class Lantern {
    *     transport, …),
    *   - the test injects a mock transport,
    *   - the runtime is unsupported by the bundled transport helpers.
+   *
+   * `baseUrl` is optional and used only by `ping()`, which POSTs a
+   * Connect+JSON Health/Check outside the typed transport (the
+   * gRPC-Health-v1 surface is not part of `LanternService`). The
+   * `connect()` / `connectWeb()` helpers fill it in automatically;
+   * a `withTransport` client built without one throws from `ping()`.
    */
-  static withTransport(transport: Transport, options: ConnectOptions = {}): Lantern {
-    return new Lantern(createClient(LanternService, transport), {
-      batchChunkSize: DEFAULT_BATCH_CHUNK_SIZE,
-      ...options,
-    });
+  static withTransport(
+    transport: Transport,
+    options: ConnectOptions = {},
+    baseUrl?: string,
+  ): Lantern {
+    return new Lantern(
+      createClient(LanternService, transport),
+      {
+        batchChunkSize: DEFAULT_BATCH_CHUNK_SIZE,
+        ...options,
+      },
+      baseUrl,
+    );
   }
 
   /**
@@ -663,6 +702,43 @@ export class Lantern {
     return effective;
   }
 
+  /**
+   * Accumulates a single edge whose contributed live weight follows the
+   * geometric decay staircase described by `opts`, using `Date.now()` as the
+   * t=0 reference (#953, parity with the Go SDK's `AddDecayingEdge`). It
+   * expands `opts` (see {@link decayContributions}) into up to `opts.steps`
+   * additive contributions and applies them in one `addEdges` batch, so it
+   * inherits that path's automatic chunking, contrib-id dedup (when
+   * `idempotentAdds` is on), and post-accumulation effective-weight
+   * reporting.
+   *
+   * Returns the edge's effective (live-sum) weight immediately after the add
+   * — any preexisting live weight on `(tail, head)` plus `opts.initialWeight`.
+   *
+   * The whole curve is a single `addEdges` request (steps <=
+   * MAX_DECAY_STEPS is far below the batch chunk size), so the server
+   * validates every contribution's expiration before applying any: a horizon
+   * longer than the server's `LANTERN_TOMBSTONE_TTL` rejects the entire add
+   * rather than writing a truncated staircase. A later `putEdge` or
+   * `deleteEdge` on the same endpoints replaces or removes every
+   * contribution, discarding whatever remains of the schedule.
+   *
+   * @throws {InvalidArgumentError} synchronously (as a rejected promise) when
+   * `opts` is ill-formed or its curve underflows float32 to zero.
+   */
+  async addDecayingEdge(
+    tail: string,
+    head: string,
+    opts: DecayOptions,
+    signal?: AbortSignal,
+  ): Promise<number> {
+    const inputs = decayContributions(tail, head, opts, Date.now());
+    const effective = await this.addEdges(inputs, signal);
+    // The contributions share (tail, head) and are applied in order, so the
+    // last entry's effective weight is the full post-add live sum.
+    return effective[effective.length - 1] ?? 0;
+  }
+
   async putEdges(inputs: readonly EdgeInput[], signal?: AbortSignal): Promise<void> {
     if (inputs.length === 0) return;
     await this.runBatchWrite(inputs, async (chunk) => {
@@ -861,6 +937,129 @@ export class Lantern {
    */
   async getReplicationStatus(signal?: AbortSignal): Promise<GetReplicationStatusResponse> {
     return this.invoke(() => this.client.getReplicationStatus({}, this.callOpts(signal)));
+  }
+
+  // --- Backup / restore (#685) ---
+
+  /**
+   * Stream a whole-graph, point-in-time dump as an async iterable of
+   * {@link BackupRecord}s — every live vertex followed by every folded live
+   * edge. Consumes the server-streaming `BackupSnapshot` RPC and decodes each
+   * frame **kind-preservingly**, so narrow numeric value types survive to
+   * {@link restore} losslessly.
+   *
+   * `opts.prefix` scopes the dump to vertices whose key begins with the given
+   * prefix (and edges incident to them); omit it to dump the whole graph.
+   * Pass a `signal` to abort mid-stream. Serialise the records yourself, or
+   * pipe them through {@link backupRecordToNdjson} for a Node-native NDJSON
+   * file you can later feed back to {@link restore}.
+   *
+   * @example
+   * for await (const rec of client.backup()) {
+   *   process.stdout.write(backupRecordToNdjson(rec) + "\n");
+   * }
+   */
+  async *backup(opts: { prefix?: string } = {}, signal?: AbortSignal): AsyncIterable<BackupRecord> {
+    const stream = this.client.backupSnapshot(
+      { vertexPrefix: opts.prefix ?? "" },
+      this.callOpts(signal),
+    );
+    try {
+      for await (const frame of stream) {
+        if (frame.record.case === "vertex") {
+          const flat = toJson(VertexSchema, frame.record.value) as Record<string, unknown>;
+          yield { kind: "vertex", vertex: fromVertexJson(flat) };
+        } else if (frame.record.case === "edge") {
+          const flat = toJson(EdgeSchema, frame.record.value) as Record<string, unknown>;
+          yield { kind: "edge", edge: fromEdgeJson(flat) };
+        }
+      }
+    } catch (err) {
+      throw wrapConnectError(err);
+    }
+  }
+
+  /**
+   * Replay a dump — the output of {@link backup}, a decoded NDJSON file, or
+   * any (async) iterable of {@link BackupRecord}s — back into the graph via
+   * the batch `putVertices` / `putEdges` surface (there is no dedicated
+   * restore RPC). Records are re-encoded kind-preservingly, so the load is
+   * lossless. Batches flush every `opts.chunkSize` records
+   * (default {@link DEFAULT_RESTORE_CHUNK_SIZE}); a final flush writes any
+   * remainder **vertices before edges**, so real vertex values land before
+   * `PutEdges` would otherwise auto-create bare endpoints.
+   *
+   * Returns the number of vertices and edges written. Restore is **not**
+   * transactional — a mid-stream error leaves already-flushed batches in
+   * place.
+   */
+  async restore(
+    source: RestoreSource,
+    opts: { chunkSize?: number } = {},
+    signal?: AbortSignal,
+  ): Promise<RestoreStats> {
+    const chunkSize =
+      opts.chunkSize && opts.chunkSize > 0 ? opts.chunkSize : DEFAULT_RESTORE_CHUNK_SIZE;
+    const stats: RestoreStats = { vertices: 0, edges: 0 };
+    let vbatch: PbVertex[] = [];
+    let ebatch: PbEdge[] = [];
+
+    const flushVertices = async (): Promise<void> => {
+      if (vbatch.length === 0) return;
+      const vertices = vbatch;
+      vbatch = [];
+      await this.invoke(() => this.client.putVertices({ vertices }, this.callOpts(signal)));
+      stats.vertices += vertices.length;
+    };
+    const flushEdges = async (): Promise<void> => {
+      if (ebatch.length === 0) return;
+      const edges = ebatch;
+      ebatch = [];
+      await this.invoke(() => this.client.putEdges({ edges }, this.callOpts(signal)));
+      stats.edges += edges.length;
+    };
+
+    for await (const rec of source) {
+      if (rec.kind === "vertex") {
+        vbatch.push(fromJson(VertexSchema, vertexRecordToJson(rec.vertex) as JsonValue));
+        if (vbatch.length >= chunkSize) await flushVertices();
+      } else {
+        ebatch.push(fromJson(EdgeSchema, edgeRecordToJson(rec.edge) as JsonValue));
+        if (ebatch.length >= chunkSize) await flushEdges();
+      }
+    }
+    await flushVertices();
+    await flushEdges();
+    return stats;
+  }
+
+  // --- Health ---
+
+  /**
+   * Probe server readiness via the gRPC-Health-v1 `Health/Check` that rides
+   * the primary listener (auth-exempt). Resolves when the server reports
+   * SERVING; throws {@link HealthStatusError} on any other status, or a
+   * generic {@link LanternError} on transport / non-200 / decode failure. A
+   * `signal` (and the client's `defaultTimeoutMs`, if set) bound the call.
+   *
+   * Only available on clients built through `connect()` / `connectWeb()` — or
+   * a `withTransport` client given a `baseUrl` — since the probe POSTs outside
+   * the typed transport. A transport-only client has no URL and throws
+   * {@link InvalidArgumentError}.
+   */
+  async ping(signal?: AbortSignal): Promise<void> {
+    if (!this.baseUrl) {
+      throw new InvalidArgumentError(
+        "ping requires a base URL; build the client via connect()/connectWeb(), " +
+          "or pass baseUrl to withTransport()",
+      );
+    }
+    const opts: PingOptions = {};
+    if (signal) opts.signal = signal;
+    if (this.options.defaultTimeoutMs && this.options.defaultTimeoutMs > 0) {
+      opts.timeoutMs = this.options.defaultTimeoutMs;
+    }
+    await pingHealth(this.baseUrl, opts);
   }
 
   // --- internals ---

--- a/sdks/node/src/decay.ts
+++ b/sdks/node/src/decay.ts
@@ -1,0 +1,201 @@
+/**
+ * Geometric ("exponential") decay for additive edge weights — the Node
+ * port of the Go SDK's `decay.go` (#953). A single decaying add expands,
+ * entirely client-side, into a staircase of additive edge contributions
+ * with staggered absolute expirations, so the edge's live (summed) weight
+ * starts at `initialWeight` and is multiplied by `ratio` every
+ * `intervalSeconds`, reaching exactly zero after `steps` intervals. No
+ * server-side support is required: the contributions ride the ordinary
+ * `AddEdges` batch path (chunking, contrib-id dedup, effective-weight
+ * reporting).
+ *
+ * `decayContributions` is the pure, deterministic core (mirrors Go's
+ * `DecayContributions`); `Lantern.addDecayingEdge` applies it with
+ * `Date.now()` as the t=0 reference.
+ */
+
+import { InvalidArgumentError } from "./errors.js";
+import type { EdgeInput } from "./values.js";
+
+/**
+ * Default per-call fan-out ceiling for {@link decayContributions} /
+ * `Lantern.addDecayingEdge`: one decaying add expands into at most this
+ * many additive contributions. It is a safety rail, not the fundamental
+ * limit — the binding constraints are the server's
+ * `LANTERN_TOMBSTONE_TTL` horizon (which caps `steps * intervalSeconds`)
+ * and float32 underflow. Geometric decay with `ratio <= 0.5` is already
+ * negligible (below 2^-16 of the initial weight) by 16 steps; callers who
+ * want a smoother or longer curve raise `intervalSeconds` / the half-life
+ * rather than the step count. Matches Go's `MaxDecaySteps`.
+ */
+export const MAX_DECAY_STEPS = 16;
+
+/**
+ * Specifies a geometric decay staircase for the live weight contributed by
+ * one `addDecayingEdge` call. The idiomatic Node counterpart of Go's
+ * `DecayOpts` — the only shape difference is `intervalSeconds` (a number of
+ * seconds, matching the SDK's `ttlSeconds` convention) in place of Go's
+ * `time.Duration`.
+ */
+export interface DecayOptions {
+  /**
+   * S(0): the live-sum weight this call contributes to the edge
+   * immediately after it is applied. May be negative (a decaying negative
+   * reinforcement) but must be non-zero and finite.
+   */
+  initialWeight: number;
+  /**
+   * The per-step multiplier r, which must lie in the open interval (0, 1):
+   * the contributed live weight on step k is `initialWeight * r^k`.
+   */
+  ratio: number;
+  /**
+   * The number of decay steps N; must satisfy `1 <= steps <=
+   * MAX_DECAY_STEPS`. `steps === 1` degenerates to a single
+   * `addEdge(initialWeight)` expiring after `intervalSeconds`.
+   */
+  steps: number;
+  /**
+   * The wall-clock duration of one decay step, in seconds; must be > 0.
+   * Fractional (sub-second) values are allowed.
+   */
+  intervalSeconds: number;
+}
+
+/**
+ * Reports the first way `opts` is ill-formed by throwing
+ * {@link InvalidArgumentError}, or returns cleanly when it is a well-formed
+ * decay spec. Mirrors Go's `DecayOpts.validate`, plus the finiteness guards
+ * JS needs (Go's float32 arithmetic cannot silently produce NaN/Infinity
+ * the way JS numbers can).
+ */
+function validateDecayOptions(opts: DecayOptions): void {
+  if (!Number.isFinite(opts.initialWeight) || opts.initialWeight === 0) {
+    throw new InvalidArgumentError(
+      `decay: initialWeight must be a non-zero finite number; got ${opts.initialWeight}`,
+    );
+  }
+  if (!Number.isFinite(opts.ratio) || !(opts.ratio > 0 && opts.ratio < 1)) {
+    throw new InvalidArgumentError(
+      `decay: ratio must be in the open interval (0, 1); got ${opts.ratio}`,
+    );
+  }
+  if (!Number.isInteger(opts.steps) || opts.steps < 1) {
+    throw new InvalidArgumentError(`decay: steps must be an integer >= 1; got ${opts.steps}`);
+  }
+  if (opts.steps > MAX_DECAY_STEPS) {
+    throw new InvalidArgumentError(
+      `decay: steps must be <= MAX_DECAY_STEPS (${MAX_DECAY_STEPS}); got ${opts.steps}`,
+    );
+  }
+  if (!Number.isFinite(opts.intervalSeconds) || opts.intervalSeconds <= 0) {
+    throw new InvalidArgumentError(
+      `decay: intervalSeconds must be > 0; got ${opts.intervalSeconds}`,
+    );
+  }
+}
+
+/**
+ * Expands a geometric decay spec into the additive edge contributions that
+ * realize it, relative to `baseMs` (epoch milliseconds) as t=0. It is the
+ * pure, deterministic core of `addDecayingEdge`: contribution j (1-indexed)
+ * targets the same `(tail, head)`, expires at `baseMs + j*intervalSeconds`,
+ * and carries the step drop
+ *
+ * ```text
+ *   c_j = S(j-1) - S(j)   for j = 1..N-1
+ *   c_N = S(N-1)          (the residual, folded into the last step)
+ * ```
+ *
+ * where `S(k) = initialWeight * ratio^k` is the target live-sum on step k
+ * and N = `steps`. Because a read sums every live contribution, these
+ * telescope to `S(0) = initialWeight`: the edge's live weight is
+ * `initialWeight` right after the add and then follows the staircase
+ * `initialWeight`, `initialWeight*ratio`, …, and exactly 0 once the last
+ * contribution expires at `baseMs + N*intervalSeconds`.
+ *
+ * Note the contribution weights are the step DROPS, not the live-sum
+ * values: `initialWeight=16, ratio=0.5, steps=5` yields weights
+ * `8,4,2,1,1` (not `16,8,4,2,1`, whose live sum would start at 31).
+ * Specifying the target curve rather than the raw weights is the whole
+ * point of the helper.
+ *
+ * Contributions that underflow to exactly zero in float32 (deep in a fast
+ * decay) are omitted — they would add nothing while still auto-materializing
+ * endpoints and consuming server capacity — so the returned array may be
+ * shorter than `steps`. Each contribution is rounded once to float32 via
+ * {@link Math.fround} (the wire weight type), so a caller comparing the
+ * read-back live weight against `initialWeight` should allow a small
+ * float32 tolerance.
+ *
+ * @throws {InvalidArgumentError} when `opts` is ill-formed, or when
+ * `initialWeight` is so small the entire curve underflows float32 to zero.
+ */
+export function decayContributions(
+  tail: string,
+  head: string,
+  opts: DecayOptions,
+  baseMs: number,
+): EdgeInput[] {
+  validateDecayOptions(opts);
+  const w0 = opts.initialWeight;
+  const r = opts.ratio;
+  const out: EdgeInput[] = [];
+  for (let j = 1; j <= opts.steps; j++) {
+    // c_j is the drop S(j-1)-S(j) = w0*r^(j-1)*(1-r) for every step but the
+    // last, which carries the whole residual S(N-1) = w0*r^(N-1) so the live
+    // weight reaches exactly zero at baseMs + N*intervalSeconds.
+    const exp = j - 1;
+    const c = j < opts.steps ? w0 * Math.pow(r, exp) * (1 - r) : w0 * Math.pow(r, exp);
+    // Round to float32 (the wire weight type) and drop underflows. `=== 0`
+    // catches both +0 and -0 (a tiny negative contribution rounds to -0).
+    const w = Math.fround(c);
+    if (w === 0) continue;
+    out.push({
+      tail,
+      head,
+      weight: w,
+      expiration: new Date(baseMs + j * opts.intervalSeconds * 1000),
+    });
+  }
+  if (out.length === 0) {
+    throw new InvalidArgumentError(
+      `decay: curve underflows float32 to zero (initialWeight ${opts.initialWeight} is too small)`,
+    );
+  }
+  return out;
+}
+
+/**
+ * Builds a {@link DecayOptions} from a half-life instead of an explicit
+ * ratio: the contributed weight halves every `halfLifeSeconds`, sampled
+ * every `intervalSeconds` over `horizonSeconds`. It sets
+ *
+ * ```text
+ *   ratio = 2^(-intervalSeconds/halfLifeSeconds)
+ *   steps = ceil(horizonSeconds/intervalSeconds), clamped to [1, MAX_DECAY_STEPS]
+ * ```
+ *
+ * The result feeds `addDecayingEdge` / {@link decayContributions}, which
+ * validate it; `halfLifeDecay` itself does not throw, so a non-positive
+ * `halfLifeSeconds`/`intervalSeconds`/`horizonSeconds` yields a
+ * `DecayOptions` those functions reject. Mirrors Go's `HalfLifeDecay`.
+ */
+export function halfLifeDecay(
+  initialWeight: number,
+  halfLifeSeconds: number,
+  intervalSeconds: number,
+  horizonSeconds: number,
+): DecayOptions {
+  const opts: DecayOptions = { initialWeight, ratio: 0, steps: 0, intervalSeconds };
+  if (halfLifeSeconds > 0 && intervalSeconds > 0) {
+    opts.ratio = Math.fround(Math.pow(0.5, intervalSeconds / halfLifeSeconds));
+  }
+  if (intervalSeconds > 0) {
+    let steps = Math.ceil(horizonSeconds / intervalSeconds);
+    if (steps < 1) steps = 1;
+    else if (steps > MAX_DECAY_STEPS) steps = MAX_DECAY_STEPS;
+    opts.steps = steps;
+  }
+  return opts;
+}

--- a/sdks/node/src/health.ts
+++ b/sdks/node/src/health.ts
@@ -1,0 +1,114 @@
+/**
+ * Server readiness probe for the Node SDK (parity with the Go SDK's
+ * `health.go`). Lantern mounts the gRPC-Health-v1 surface
+ * (connectrpc grpchealth) on the **same** listener as `LanternService`, but
+ * that service is not part of the typed Connect client. `pingHealth` therefore
+ * POSTs a Connect+JSON `Health/Check` with a raw `fetch` against the same base
+ * URL the client was built with — the server speaks HTTP/1.1 and the health
+ * surface is auth-exempt, so this works from Node and the browser alike.
+ */
+
+import { LanternError } from "./errors.js";
+
+/**
+ * URL path the connectrpc grpchealth handler exposes. Fixed by the
+ * gRPC-Health-v1 spec — never override.
+ */
+export const HEALTH_CHECK_PROCEDURE = "/grpc.health.v1.Health/Check";
+
+/**
+ * Whether a `HealthCheckResponse.status` string denotes SERVING. The
+ * connectrpc grpchealth descriptor prefixes its enum constants
+ * (`SERVING_STATUS_SERVING`); other gRPC-Health-v1 servers use the bare
+ * `SERVING`. Accept both, matching the Go SDK's `servingStatusOK`.
+ */
+export function servingStatusOk(status: string): boolean {
+  return status === "SERVING" || status === "SERVING_STATUS_SERVING";
+}
+
+/**
+ * Raised by {@link pingHealth} / {@link import("./client.js").Lantern.ping}
+ * when the server replies with a non-SERVING health status. The symbolic
+ * status name (e.g. `NOT_SERVING`, `SERVING_STATUS_NOT_SERVING`) is preserved
+ * on `.status` for logging and branching.
+ */
+export class HealthStatusError extends LanternError {
+  readonly status: string;
+  constructor(status: string) {
+    super(`lantern: server health status = ${status || "(empty)"}`);
+    this.name = "HealthStatusError";
+    this.status = status;
+  }
+}
+
+/** Knobs for {@link pingHealth}. */
+export interface PingOptions {
+  /** Caller abort signal; aborting rejects the ping. */
+  signal?: AbortSignal;
+  /** Deadline in milliseconds, combined with `signal` via `AbortSignal.any`. */
+  timeoutMs?: number;
+  /** Override the global `fetch` (test injection / custom pipeline). */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * POST a Connect+JSON `Health/Check` to `baseUrl` and resolve iff the server
+ * reports SERVING. Throws {@link HealthStatusError} on any other status and a
+ * generic {@link LanternError} on transport, non-200, or JSON-decode failure.
+ * `baseUrl` must be the normalised origin (`http(s)://host:port`, no trailing
+ * slash) the client was built with.
+ */
+export async function pingHealth(baseUrl: string, opts: PingOptions = {}): Promise<void> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const signal = combineSignals(opts.signal, opts.timeoutMs);
+
+  let resp: Response;
+  try {
+    resp = await fetchImpl(baseUrl + HEALTH_CHECK_PROCEDURE, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Connect-Protocol-Version": "1",
+      },
+      body: "{}",
+      ...(signal ? { signal } : {}),
+    });
+  } catch (err) {
+    throw new LanternError(`lantern: ping request failed: ${stringify(err)}`, { cause: err });
+  }
+
+  if (!resp.ok) {
+    throw new LanternError(`lantern: ping returned HTTP ${resp.status}`);
+  }
+
+  let body: { status?: string };
+  try {
+    body = (await resp.json()) as { status?: string };
+  } catch (err) {
+    throw new LanternError(`lantern: ping decode failed: ${stringify(err)}`, { cause: err });
+  }
+
+  const status = body.status ?? "";
+  if (!servingStatusOk(status)) {
+    throw new HealthStatusError(status);
+  }
+}
+
+/**
+ * Fold a caller signal and a timeout into a single `AbortSignal` (or
+ * undefined when neither is set). Uses `AbortSignal.timeout` /
+ * `AbortSignal.any`, available on Node 20+, Bun, and modern browsers.
+ */
+function combineSignals(signal?: AbortSignal, timeoutMs?: number): AbortSignal | undefined {
+  const signals: AbortSignal[] = [];
+  if (signal) signals.push(signal);
+  if (timeoutMs && timeoutMs > 0) signals.push(AbortSignal.timeout(timeoutMs));
+  if (signals.length === 0) return undefined;
+  if (signals.length === 1) return signals[0];
+  return AbortSignal.any(signals);
+}
+
+function stringify(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -45,6 +45,7 @@ export function connect(baseUrl: string, args: LanternArgs = {}): Lantern {
   return Lantern.withTransport(
     makeNodeTransport(normalised, withTokenInterceptors(args), args.transportOptions),
     args.options,
+    normalised,
   );
 }
 
@@ -63,6 +64,16 @@ export type {
 } from "./incremental-search.js";
 export { ReplicationPeer_State } from "./gen/graph/v1/graph_pb.js";
 export { CONTRIB_ID_BYTES } from "./contrib.js";
+export { MAX_DECAY_STEPS, decayContributions, halfLifeDecay } from "./decay.js";
+export type { DecayOptions } from "./decay.js";
+export {
+  DEFAULT_RESTORE_CHUNK_SIZE,
+  backupRecordFromNdjson,
+  backupRecordToNdjson,
+} from "./backup.js";
+export type { BackupRecord, RestoreSource, RestoreStats } from "./backup.js";
+export { HEALTH_CHECK_PROCEDURE, HealthStatusError, servingStatusOk } from "./health.js";
+export type { PingOptions } from "./health.js";
 export {
   BatchError,
   FailedPreconditionError,

--- a/sdks/node/src/values.ts
+++ b/sdks/node/src/values.ts
@@ -308,6 +308,73 @@ export function fromEdgeJson(json: Record<string, unknown>): Edge {
   };
 }
 
+/**
+ * Re-encode a decoded {@link Vertex} back into its protobuf JSON shape — the
+ * inverse of {@link fromVertexJson}, keyed on the vertex's `kind`. Unlike
+ * {@link toVertexJson} (which infers the wire type from a JS value and so
+ * collapses the narrow numeric kinds — int32/uint32/uint64/float32/duration —
+ * onto int64/float64), this preserves the exact kind, making a
+ * backup→restore round-trip lossless. Feeds `fromJson(VertexSchema, ...)`.
+ */
+export function vertexRecordToJson(v: Vertex): Record<string, unknown> {
+  const out: Record<string, unknown> = { key: v.key };
+  if (v.expiration) out.expiration = v.expiration.toISOString();
+  switch (v.kind) {
+    case "float64":
+      out.float64 = v.value as number;
+      break;
+    case "float32":
+      out.float32 = v.value as number;
+      break;
+    case "int32":
+      out.int32 = v.value as number;
+      break;
+    case "int64":
+      out.int64 = String(v.value);
+      break;
+    case "uint32":
+      out.uint32 = v.value as number;
+      break;
+    case "uint64":
+      out.uint64 = String(v.value);
+      break;
+    case "bool":
+      out.bool = v.value as boolean;
+      break;
+    case "string":
+      out.string = v.value as string;
+      break;
+    case "bytes":
+      out.bytes = bytesToBase64(v.value as Uint8Array);
+      break;
+    case "timestamp":
+      out.timestamp = (v.value as Date).toISOString();
+      break;
+    case "duration":
+      out.duration = (v.value as Duration).toString();
+      break;
+    case "nil":
+      // Existence-only marker: the proto `nil` field is a bool, always true
+      // when present.
+      out.nil = true;
+      break;
+    case "unset":
+      // No value oneof set — emit no value field.
+      break;
+  }
+  return out;
+}
+
+/**
+ * Re-encode a decoded {@link Edge} into its protobuf JSON shape (inverse of
+ * {@link fromEdgeJson}). Feeds `fromJson(EdgeSchema, ...)`.
+ */
+export function edgeRecordToJson(e: Edge): Record<string, unknown> {
+  const out: Record<string, unknown> = { tail: e.tail, head: e.head, weight: e.weight };
+  if (e.expiration) out.expiration = e.expiration.toISOString();
+  return out;
+}
+
 // ----------------------------------------------------------------------------
 // Internals
 // ----------------------------------------------------------------------------

--- a/sdks/node/src/web.ts
+++ b/sdks/node/src/web.ts
@@ -39,12 +39,23 @@ export function connectWeb(baseUrl: string, args: LanternArgs = {}): Lantern {
   return Lantern.withTransport(
     makeWebTransport(normalised, withTokenInterceptors(args), args.transportOptions),
     args.options,
+    normalised,
   );
 }
 
 export { Lantern } from "./client.js";
 export type { LanternArgs } from "./client.js";
 export { ReplicationPeer_State } from "./gen/graph/v1/graph_pb.js";
+export { MAX_DECAY_STEPS, decayContributions, halfLifeDecay } from "./decay.js";
+export type { DecayOptions } from "./decay.js";
+export {
+  DEFAULT_RESTORE_CHUNK_SIZE,
+  backupRecordFromNdjson,
+  backupRecordToNdjson,
+} from "./backup.js";
+export type { BackupRecord, RestoreSource, RestoreStats } from "./backup.js";
+export { HEALTH_CHECK_PROCEDURE, HealthStatusError, servingStatusOk } from "./health.js";
+export type { PingOptions } from "./health.js";
 export {
   BatchError,
   FailedPreconditionError,

--- a/sdks/node/test/client.test.ts
+++ b/sdks/node/test/client.test.ts
@@ -22,7 +22,7 @@ import * as http from "node:http";
 import { type AddressInfo } from "node:net";
 
 import { Code, ConnectError, type ConnectRouter } from "@connectrpc/connect";
-import { connectNodeAdapter } from "@connectrpc/connect-node";
+import { connectNodeAdapter, createConnectTransport } from "@connectrpc/connect-node";
 import { create } from "@bufbuild/protobuf";
 
 import {
@@ -32,8 +32,20 @@ import {
   NotFoundError,
   connect,
   Reduction,
+  Int32,
+  Uint64,
+  Float32,
+  backupRecordToNdjson,
+  backupRecordFromNdjson,
+  HealthStatusError,
+  type BackupRecord,
 } from "../src/index.js";
-import { LanternService, VertexSchema, ScanOrder } from "../src/gen/graph/v1/graph_pb.js";
+import {
+  LanternService,
+  VertexSchema,
+  EdgeSchema,
+  ScanOrder,
+} from "../src/gen/graph/v1/graph_pb.js";
 
 interface StubState {
   vertices: Map<string, ReturnType<typeof create<typeof VertexSchema>>>;
@@ -58,7 +70,7 @@ interface StubState {
   /** Last AddEdgeRequest the stub observed, for contrib-id assertions (#895). */
   lastAddEdge?: { contribId: Uint8Array };
   /** Every AddEdgesRequest the stub observed, in order, for chunk-alignment assertions (#895). */
-  addEdgesCalls: { contribIds: Uint8Array[]; tails: string[] }[];
+  addEdgesCalls: { contribIds: Uint8Array[]; tails: string[]; weights: number[] }[];
   /** Edge weights keyed tail → head → weight, seeded by DeleteEdgesByPrefix tests (#899). */
   edges: Map<string, Map<string, number>>;
   /** Last DeleteEdgesByPrefixRequest the stub observed, for request-building assertions (#899). */
@@ -70,6 +82,17 @@ interface StubState {
   };
   /** ScanOrder of the last scanVertices / scanVertexKeys request (#898). */
   lastScanOrder?: number;
+  /**
+   * Ordered log of putVertices / putEdges batch sizes, for restore
+   * ordering + chunking assertions (#685). Reset per restore test.
+   */
+  writeLog: { kind: "vertices" | "edges"; count: number }[];
+  /**
+   * Controls the stub gRPC-Health-v1 endpoint for ping() tests (#685-adjacent
+   * parity work). `status` is the JSON `status` string returned on a 200;
+   * `httpStatus`, when set to non-200, drives the transport-error branch.
+   */
+  health?: { status?: string; httpStatus?: number };
 }
 
 function newStubRoutes(state: StubState) {
@@ -105,6 +128,7 @@ function newStubRoutes(state: StubState) {
           }
           return { written, skippedKeys };
         }
+        state.writeLog.push({ kind: "vertices", count: req.vertices.length });
         for (const v of req.vertices) {
           state.vertices.set(v.key, v);
         }
@@ -121,8 +145,22 @@ function newStubRoutes(state: StubState) {
         state.addEdgesCalls.push({
           contribIds: req.contribIds,
           tails: req.edges.map((e) => e.tail),
+          weights: req.edges.map((e) => e.weight),
         });
-        return { effectiveWeights: req.edges.map((e) => e.weight) };
+        // Model the server's additive accumulation: the effective weight
+        // reported for each edge is the running live sum over its (tail,head)
+        // seen so far within this request. Distinct endpoints therefore echo
+        // their own weight; repeated endpoints (e.g. a decay staircase on one
+        // pair) return the telescoped cumulative sum, whose last entry is the
+        // full post-add live weight.
+        const running = new Map<string, number>();
+        const effectiveWeights = req.edges.map((e) => {
+          const key = `${e.tail}\u0000${e.head}`;
+          const sum = (running.get(key) ?? 0) + e.weight;
+          running.set(key, sum);
+          return sum;
+        });
+        return { effectiveWeights };
       },
       async deleteVertex(req) {
         const existed = state.vertices.delete(req.key);
@@ -245,6 +283,37 @@ function newStubRoutes(state: StubState) {
         }
         return { deleted: BigInt(victims.length) };
       },
+      // Batch edge upsert (#685 restore path): records batch size for
+      // ordering/chunking assertions and stores weights into state.edges so
+      // a subsequent backup reflects them.
+      async putEdges(req) {
+        state.writeLog.push({ kind: "edges", count: req.edges.length });
+        for (const e of req.edges) {
+          if (!state.edges.has(e.tail)) state.edges.set(e.tail, new Map());
+          state.edges.get(e.tail)!.set(e.head, e.weight);
+        }
+        return { written: req.edges.length };
+      },
+      // Whole-graph point-in-time stream (#685 backup path): emits every
+      // vertex (as the `vertex` oneof arm) followed by every edge (as the
+      // `edge` arm), honoring the vertexPrefix filter. Server-streaming, so
+      // the handler is an async generator.
+      async *backupSnapshot(req) {
+        for (const [key, v] of state.vertices) {
+          if (req.vertexPrefix && !key.startsWith(req.vertexPrefix)) continue;
+          yield { record: { case: "vertex" as const, value: v } };
+        }
+        for (const [tail, heads] of state.edges) {
+          for (const [head, weight] of heads) {
+            yield {
+              record: {
+                case: "edge" as const,
+                value: create(EdgeSchema, { tail, head, weight }),
+              },
+            };
+          }
+        }
+      },
       // Remaining methods are intentionally absent — the connect-node
       // adapter rejects them with Code.Unimplemented, which the SDK
       // surfaces as the generic LanternError. Tests that need these
@@ -255,7 +324,7 @@ function newStubRoutes(state: StubState) {
 
 let server: http.Server;
 let baseUrl: string;
-const state: StubState = { vertices: new Map(), addEdgesCalls: [], edges: new Map() };
+const state: StubState = { vertices: new Map(), addEdgesCalls: [], edges: new Map(), writeLog: [] };
 
 beforeAll(async () => {
   // HTTP/1.1 server (not http2) — Bun's test runner has rough edges
@@ -263,7 +332,23 @@ beforeAll(async () => {
   // "Premature close" errors on the second call. HTTP/1.1 is plenty
   // for the round-trip semantics this test covers, and connect-node
   // negotiates the Connect protocol over both transports identically.
-  server = http.createServer(connectNodeAdapter({ routes: newStubRoutes(state) }));
+  //
+  // The gRPC-Health-v1 surface (which ping() probes) rides the same listener
+  // on the real server; here we mount a hand-rolled JSON responder for
+  // `/grpc.health.v1.Health/Check` in front of the Connect adapter so ping()
+  // has an endpoint to hit. Everything else falls through to the adapter.
+  const adapter = connectNodeAdapter({ routes: newStubRoutes(state) });
+  server = http.createServer((req, res) => {
+    if (req.url === "/grpc.health.v1.Health/Check") {
+      const httpStatus = state.health?.httpStatus ?? 200;
+      res.writeHead(httpStatus, { "Content-Type": "application/json" });
+      res.end(
+        httpStatus === 200 ? JSON.stringify({ status: state.health?.status ?? "SERVING" }) : "{}",
+      );
+      return;
+    }
+    adapter(req, res);
+  });
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
   const addr = server.address() as AddressInfo;
   baseUrl = `http://127.0.0.1:${addr.port}`;
@@ -626,6 +711,281 @@ describe("AddEdge contrib IDs (#895)", () => {
     const c = newClient();
     try {
       expect(await c.addEdges([])).toEqual([]);
+    } finally {
+      c.close();
+    }
+  });
+});
+
+describe("addDecayingEdge (#953)", () => {
+  test("sends one expanded staircase batch and returns the post-add live weight", async () => {
+    const c = newClient();
+    try {
+      state.addEdgesCalls = [];
+      const live = await c.addDecayingEdge("a", "b", {
+        initialWeight: 16,
+        ratio: 0.5,
+        steps: 5,
+        intervalSeconds: 1,
+      });
+      // One AddEdges batch carrying the 8,4,2,1,1 drops...
+      expect(state.addEdgesCalls.length).toBe(1);
+      const call = state.addEdgesCalls[0];
+      expect(call.tails).toEqual(["a", "a", "a", "a", "a"]);
+      call.weights.forEach((w, i) => expect(w).toBeCloseTo([8, 4, 2, 1, 1][i], 4));
+      // ...and the returned live weight is initialWeight (16), not the raw
+      // 16,8,4,2,1 schedule's sum (31) — the telescoping check at the wire.
+      expect(live).toBeCloseTo(16, 4);
+    } finally {
+      c.close();
+    }
+  });
+
+  test("invalid opts short-circuit before any RPC", async () => {
+    const c = newClient();
+    try {
+      state.addEdgesCalls = [];
+      await expect(
+        c.addDecayingEdge("a", "b", { initialWeight: 16, ratio: 2, steps: 5, intervalSeconds: 1 }),
+      ).rejects.toThrow(InvalidArgumentError);
+      expect(state.addEdgesCalls.length).toBe(0);
+    } finally {
+      c.close();
+    }
+  });
+});
+
+describe("backup / restore (#685)", () => {
+  test("backup streams every vertex then every edge, decoded", async () => {
+    const c = newClient();
+    try {
+      state.vertices.clear();
+      state.edges.clear();
+      await c.putVertex({ key: "bk/v/1", value: "alice" });
+      await c.putVertex({ key: "bk/v/2", value: 42 });
+      // Seed an edge directly (no AddEdge stub state coupling).
+      state.edges.set("bk/v/1", new Map([["bk/v/2", 3.5]]));
+
+      const records: BackupRecord[] = [];
+      for await (const rec of c.backup()) records.push(rec);
+
+      const verts = records.filter((r) => r.kind === "vertex");
+      const edges = records.filter((r) => r.kind === "edge");
+      expect(verts.length).toBe(2);
+      expect(edges.length).toBe(1);
+      // Vertices precede edges in the stream.
+      expect(records.findIndex((r) => r.kind === "edge")).toBe(2);
+
+      const v1 = verts.find((r) => r.kind === "vertex" && r.vertex.key === "bk/v/1");
+      expect(v1?.kind === "vertex" && v1.vertex.value).toBe("alice");
+      const e = edges[0];
+      expect(e.kind === "edge" && e.edge.tail).toBe("bk/v/1");
+      expect(e.kind === "edge" && e.edge.head).toBe("bk/v/2");
+      expect(e.kind === "edge" && e.edge.weight).toBeCloseTo(3.5, 5);
+    } finally {
+      c.close();
+    }
+  });
+
+  test("backup honors the vertex prefix filter", async () => {
+    const c = newClient();
+    try {
+      state.vertices.clear();
+      state.edges.clear();
+      await c.putVertex({ key: "keep/1", value: 1 });
+      await c.putVertex({ key: "drop/1", value: 2 });
+
+      const keys: string[] = [];
+      for await (const rec of c.backup({ prefix: "keep/" })) {
+        if (rec.kind === "vertex") keys.push(rec.vertex.key);
+      }
+      expect(keys).toEqual(["keep/1"]);
+    } finally {
+      c.close();
+    }
+  });
+
+  test("restore flushes remaining vertices before edges and reports counts", async () => {
+    const c = newClient();
+    try {
+      state.vertices.clear();
+      state.edges.clear();
+      state.writeLog = [];
+      // Interleaved input under a large chunk size: nothing flushes mid-stream,
+      // so the final flush ordering is observed in isolation — the remaining
+      // vertices must be written before the remaining edges (real vertex values
+      // stay authoritative over PutEdges' auto-created bare endpoints).
+      const records: BackupRecord[] = [
+        { kind: "vertex", vertex: { key: "r/v/1", value: "x", kind: "string", expiration: null } },
+        { kind: "edge", edge: { tail: "r/v/1", head: "r/v/2", weight: 1, expiration: null } },
+        { kind: "vertex", vertex: { key: "r/v/2", value: "y", kind: "string", expiration: null } },
+        { kind: "edge", edge: { tail: "r/v/2", head: "r/v/3", weight: 2, expiration: null } },
+      ];
+
+      const stats = await c.restore(records);
+      expect(stats).toEqual({ vertices: 2, edges: 2 });
+      expect(state.writeLog).toEqual([
+        { kind: "vertices", count: 2 },
+        { kind: "edges", count: 2 },
+      ]);
+    } finally {
+      c.close();
+    }
+  });
+
+  test("restore chunks batches at chunkSize", async () => {
+    const c = newClient();
+    try {
+      state.vertices.clear();
+      state.edges.clear();
+      state.writeLog = [];
+      // Five vertices then two edges — the real backup ordering. chunkSize 2
+      // flushes vertices in [2,2] mid-stream, leaving a trailing [1]; the two
+      // edges flush once at the end.
+      const records: BackupRecord[] = [
+        { kind: "vertex", vertex: { key: "c/v/1", value: 1, kind: "int64", expiration: null } },
+        { kind: "vertex", vertex: { key: "c/v/2", value: 2, kind: "int64", expiration: null } },
+        { kind: "vertex", vertex: { key: "c/v/3", value: 3, kind: "int64", expiration: null } },
+        { kind: "vertex", vertex: { key: "c/v/4", value: 4, kind: "int64", expiration: null } },
+        { kind: "vertex", vertex: { key: "c/v/5", value: 5, kind: "int64", expiration: null } },
+        { kind: "edge", edge: { tail: "c/v/1", head: "c/v/2", weight: 1, expiration: null } },
+        { kind: "edge", edge: { tail: "c/v/2", head: "c/v/3", weight: 1, expiration: null } },
+      ];
+
+      const stats = await c.restore(records, { chunkSize: 2 });
+      expect(stats).toEqual({ vertices: 5, edges: 2 });
+      expect(state.writeLog.filter((w) => w.kind === "vertices").map((w) => w.count)).toEqual([
+        2, 2, 1,
+      ]);
+      expect(state.writeLog.filter((w) => w.kind === "edges").map((w) => w.count)).toEqual([2]);
+    } finally {
+      c.close();
+    }
+  });
+
+  test("backup → restore preserves narrow numeric + bytes kinds losslessly", async () => {
+    const c = newClient();
+    try {
+      state.vertices.clear();
+      state.edges.clear();
+      await c.putVertex({ key: "orig/i32", value: new Int32(-5) });
+      await c.putVertex({ key: "orig/u64", value: new Uint64(2n ** 63n + 7n) });
+      await c.putVertex({ key: "orig/f32", value: new Float32(1.5) });
+      await c.putVertex({ key: "orig/bytes", value: new Uint8Array([1, 2, 3]) });
+
+      // Dump, re-key under a fresh prefix, replay, then read back — the whole
+      // decode → re-encode → putVertices → getVertex path must not widen kinds.
+      const dumped: BackupRecord[] = [];
+      for await (const rec of c.backup({ prefix: "orig/" })) dumped.push(rec);
+      const rekeyed: BackupRecord[] = dumped.map((r) =>
+        r.kind === "vertex"
+          ? { kind: "vertex", vertex: { ...r.vertex, key: r.vertex.key.replace("orig/", "rest/") } }
+          : r,
+      );
+      await c.restore(rekeyed);
+
+      const i32 = await c.getVertex("rest/i32");
+      expect(i32.kind).toBe("int32");
+      expect(i32.value).toBe(-5);
+      const u64 = await c.getVertex("rest/u64");
+      expect(u64.kind).toBe("uint64");
+      expect(u64.value).toBe(2n ** 63n + 7n);
+      const f32 = await c.getVertex("rest/f32");
+      expect(f32.kind).toBe("float32");
+      expect(f32.value).toBeCloseTo(1.5, 6);
+      const b = await c.getVertex("rest/bytes");
+      expect(b.kind).toBe("bytes");
+      expect(Array.from(b.value as Uint8Array)).toEqual([1, 2, 3]);
+    } finally {
+      c.close();
+    }
+  });
+
+  test("NDJSON line codec round-trips records and is stable", () => {
+    const recs: BackupRecord[] = [
+      { kind: "vertex", vertex: { key: "n/i32", value: -5, kind: "int32", expiration: null } },
+      {
+        kind: "vertex",
+        vertex: { key: "n/u64", value: 2n ** 63n + 7n, kind: "uint64", expiration: null },
+      },
+      {
+        kind: "vertex",
+        vertex: {
+          key: "n/bytes",
+          value: new Uint8Array([9, 8, 7]),
+          kind: "bytes",
+          expiration: null,
+        },
+      },
+      { kind: "edge", edge: { tail: "n/i32", head: "n/u64", weight: 2.5, expiration: null } },
+    ];
+    for (const rec of recs) {
+      const line = backupRecordToNdjson(rec);
+      expect(line).not.toContain("\n");
+      const back = backupRecordFromNdjson(line);
+      // Re-serialising the decoded record must be byte-identical (stable codec).
+      expect(backupRecordToNdjson(back)).toBe(line);
+    }
+    // uint64 magnitude is carried as a string, not a lossy JS number.
+    expect(backupRecordToNdjson(recs[1])).toContain(`"uint64":"${2n ** 63n + 7n}"`);
+  });
+
+  test("backupRecordFromNdjson rejects an unknown record kind", () => {
+    expect(() => backupRecordFromNdjson(JSON.stringify({ kind: "bogus", key: "x" }))).toThrow(
+      InvalidArgumentError,
+    );
+  });
+});
+
+describe("ping (health check)", () => {
+  test("resolves when the server reports SERVING", async () => {
+    const c = newClient();
+    try {
+      state.health = { status: "SERVING" };
+      await expect(c.ping()).resolves.toBeUndefined();
+    } finally {
+      c.close();
+    }
+  });
+
+  test("accepts the connectrpc-prefixed SERVING_STATUS_SERVING enum name", async () => {
+    const c = newClient();
+    try {
+      state.health = { status: "SERVING_STATUS_SERVING" };
+      await expect(c.ping()).resolves.toBeUndefined();
+    } finally {
+      c.close();
+    }
+  });
+
+  test("throws HealthStatusError on a non-SERVING status", async () => {
+    const c = newClient();
+    try {
+      state.health = { status: "NOT_SERVING" };
+      await expect(c.ping()).rejects.toBeInstanceOf(HealthStatusError);
+      await expect(c.ping()).rejects.toMatchObject({ status: "NOT_SERVING" });
+    } finally {
+      state.health = { status: "SERVING" };
+      c.close();
+    }
+  });
+
+  test("throws a generic LanternError on a non-200 health response", async () => {
+    const c = newClient();
+    try {
+      state.health = { httpStatus: 503 };
+      await expect(c.ping()).rejects.toThrow(/HTTP 503/);
+    } finally {
+      state.health = { status: "SERVING" };
+      c.close();
+    }
+  });
+
+  test("a withTransport client built without a baseUrl rejects ping", async () => {
+    const transport = createConnectTransport({ baseUrl, httpVersion: "1.1" });
+    const c = Lantern.withTransport(transport);
+    try {
+      await expect(c.ping()).rejects.toBeInstanceOf(InvalidArgumentError);
     } finally {
       c.close();
     }

--- a/sdks/node/test/decay.test.ts
+++ b/sdks/node/test/decay.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Pure unit tests for the client-side geometric decay helpers (#953),
+ * mirroring the Go SDK's `decay_test.go` vectors. The `addDecayingEdge`
+ * wire round-trip (one expanded `addEdges` batch, returned post-add live
+ * weight) lives in `client.test.ts` alongside the other transport tests.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { MAX_DECAY_STEPS, decayContributions, halfLifeDecay } from "../src/decay.js";
+import { InvalidArgumentError } from "../src/errors.js";
+import type { DecayOptions } from "../src/index.js";
+
+const BASE_MS = Date.UTC(2024, 0, 1, 0, 0, 0);
+
+describe("decayContributions", () => {
+  test("golden staircase initialWeight=16 ratio=0.5 steps=5 → drops 8,4,2,1,1", () => {
+    const opts: DecayOptions = { initialWeight: 16, ratio: 0.5, steps: 5, intervalSeconds: 1 };
+    const got = decayContributions("a", "b", opts, BASE_MS);
+    const wantW = [8, 4, 2, 1, 1];
+    expect(got.length).toBe(wantW.length);
+    let sum = 0;
+    got.forEach((e, i) => {
+      expect(e.tail).toBe("a");
+      expect(e.head).toBe("b");
+      expect(e.weight).toBeCloseTo(wantW[i], 4);
+      // Contribution j (1-indexed) expires at base + j*intervalSeconds.
+      expect(e.expiration?.getTime()).toBe(BASE_MS + (i + 1) * 1000);
+      sum += e.weight;
+    });
+    // Telescoping: the live sum right after the add is initialWeight (16),
+    // NOT the sum of a raw 16,8,4,2,1 schedule (31).
+    expect(sum).toBeCloseTo(16, 4);
+  });
+
+  test("telescoping sum equals initialWeight across several curves", () => {
+    const cases: DecayOptions[] = [
+      { initialWeight: 100, ratio: 0.9, steps: 16, intervalSeconds: 1 },
+      { initialWeight: 7, ratio: 0.3, steps: 4, intervalSeconds: 60 },
+      { initialWeight: 1, ratio: 0.5, steps: 1, intervalSeconds: 1 },
+    ];
+    for (const opts of cases) {
+      const got = decayContributions("x", "y", opts, BASE_MS);
+      const sum = got.reduce((acc, e) => acc + e.weight, 0);
+      const tol = Math.max(Math.abs(opts.initialWeight) * 1e-4, 1e-4);
+      expect(Math.abs(sum - opts.initialWeight)).toBeLessThanOrEqual(tol);
+    }
+  });
+
+  test("steps===1 is a single addEdge(initialWeight)", () => {
+    const opts: DecayOptions = { initialWeight: 5, ratio: 0.5, steps: 1, intervalSeconds: 2 };
+    const got = decayContributions("a", "b", opts, BASE_MS);
+    expect(got.length).toBe(1);
+    expect(got[0].weight).toBeCloseTo(5, 6);
+    expect(got[0].expiration?.getTime()).toBe(BASE_MS + 2000);
+  });
+
+  test("negative initialWeight yields negative drops summing to it", () => {
+    const opts: DecayOptions = { initialWeight: -16, ratio: 0.5, steps: 5, intervalSeconds: 1 };
+    const got = decayContributions("a", "b", opts, BASE_MS);
+    let sum = 0;
+    for (const e of got) {
+      expect(e.weight).toBeLessThan(0);
+      sum += e.weight;
+    }
+    expect(sum).toBeCloseTo(-16, 4);
+  });
+
+  test("sub-second fractional interval is honoured", () => {
+    const opts: DecayOptions = { initialWeight: 4, ratio: 0.5, steps: 2, intervalSeconds: 0.5 };
+    const got = decayContributions("a", "b", opts, BASE_MS);
+    expect(got.length).toBe(2);
+    expect(got[0].expiration?.getTime()).toBe(BASE_MS + 500);
+    expect(got[1].expiration?.getTime()).toBe(BASE_MS + 1000);
+  });
+
+  test("whole-curve underflow is rejected", () => {
+    // Smallest positive float32 subnormal is ~1.4e-45; halving it underflows
+    // every contribution to zero, so the whole curve is rejected.
+    const opts: DecayOptions = {
+      initialWeight: 1.401298464324817e-45,
+      ratio: 0.5,
+      steps: 5,
+      intervalSeconds: 1,
+    };
+    expect(() => decayContributions("a", "b", opts, BASE_MS)).toThrow(InvalidArgumentError);
+  });
+
+  test("deep-curve underflow skips zero contributions (shorter than steps)", () => {
+    // A fast decay from a tiny initial weight: the leading drops survive as
+    // float32 subnormals, the deepest ones round to zero and are dropped, so
+    // the returned array is non-empty but shorter than steps — and carries no
+    // zero weights.
+    const opts: DecayOptions = { initialWeight: 1e-44, ratio: 0.5, steps: 16, intervalSeconds: 1 };
+    const got = decayContributions("a", "b", opts, BASE_MS);
+    expect(got.length).toBeGreaterThan(0);
+    expect(got.length).toBeLessThan(opts.steps);
+    for (const e of got) expect(e.weight).not.toBe(0);
+  });
+});
+
+describe("decayContributions validation", () => {
+  const valid: DecayOptions = { initialWeight: 16, ratio: 0.5, steps: 5, intervalSeconds: 1 };
+  const table: { name: string; opts: DecayOptions }[] = [
+    { name: "zero initialWeight", opts: { ...valid, initialWeight: 0 } },
+    { name: "non-finite initialWeight", opts: { ...valid, initialWeight: Number.NaN } },
+    { name: "ratio zero", opts: { ...valid, ratio: 0 } },
+    { name: "ratio one", opts: { ...valid, ratio: 1 } },
+    { name: "ratio above one", opts: { ...valid, ratio: 1.5 } },
+    { name: "ratio negative", opts: { ...valid, ratio: -0.5 } },
+    { name: "steps zero", opts: { ...valid, steps: 0 } },
+    { name: "steps non-integer", opts: { ...valid, steps: 2.5 } },
+    { name: "steps above cap", opts: { ...valid, steps: MAX_DECAY_STEPS + 1 } },
+    { name: "interval zero", opts: { ...valid, intervalSeconds: 0 } },
+    { name: "interval negative", opts: { ...valid, intervalSeconds: -1 } },
+  ];
+  for (const tc of table) {
+    test(`rejects ${tc.name}`, () => {
+      expect(() => decayContributions("a", "b", tc.opts, BASE_MS)).toThrow(InvalidArgumentError);
+    });
+  }
+
+  test("accepts the well-formed baseline", () => {
+    expect(() => decayContributions("a", "b", valid, BASE_MS)).not.toThrow();
+  });
+});
+
+describe("halfLifeDecay", () => {
+  test("interval == halfLife gives ratio 0.5", () => {
+    const opts = halfLifeDecay(10, 1, 1, 5);
+    expect(opts.ratio).toBeCloseTo(0.5, 6);
+    expect(opts.steps).toBe(5);
+  });
+
+  test("interval == 2*halfLife gives ratio 0.25", () => {
+    const opts = halfLifeDecay(10, 1, 2, 4);
+    expect(opts.ratio).toBeCloseTo(0.25, 6);
+    expect(opts.steps).toBe(2);
+  });
+
+  test("steps clamp to MAX_DECAY_STEPS", () => {
+    const opts = halfLifeDecay(10, 1, 1, 1000);
+    expect(opts.steps).toBe(MAX_DECAY_STEPS);
+  });
+
+  test("non-positive horizon clamps to 1 step", () => {
+    const opts = halfLifeDecay(10, 1, 1, 0);
+    expect(opts.steps).toBe(1);
+  });
+
+  test("result validates and expands", () => {
+    const opts = halfLifeDecay(64, 60, 30, 180);
+    const got = decayContributions("a", "b", opts, BASE_MS);
+    expect(got.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What & why

Follow-up to the Go↔Node client-surface audit in #954. The Node SDK's public method set was a strict subset of the Go SDK's; this PR closes the three **genuine** gaps so both SDKs offer equivalent client-side functionality — no new server/wire surface is added (all three are helpers over RPCs the generated client already exposes).

| Feature | Go reference | Node addition |
|---|---|---|
| `addDecayingEdge` (+ `decayContributions`, `halfLifeDecay`, `MAX_DECAY_STEPS`) | `sdks/go/decay.go` (#953) | `src/decay.ts` + `Lantern.addDecayingEdge` |
| `backup` / `restore` (+ NDJSON line codec) | `sdks/go/backup.go` | `src/backup.ts` + `Lantern.backup`/`restore` |
| `ping` | `sdks/go/health.go` | `src/health.ts` + `Lantern.ping` |

## Notes

- **Decay** expands the geometric staircase into one additive `addEdges` batch (per-contribution relative TTL, `Math.fround` float32 rounding, underflow-skip, `InvalidArgumentError` on ill-formed opts), returning the post-add live weight. Reuses the pinned contrib-ID layout (#927).
- **Backup/restore** streams `BackupSnapshot` as an async iterable of kind-preserving `BackupRecord`s; `restore` replays them chunked (`chunkSize`, default 1000) through `putVertices`/`putEdges`, vertices before edges on the final flush. Decoded vertices carry their `kind`, so narrow numeric value types (int32/uint32/uint64/float32/duration) round-trip losslessly. Adds inverse `vertexRecordToJson`/`edgeRecordToJson` to `values.ts` for the lossless re-encode path.
  - The bundled `backupRecordToNdjson`/`backupRecordFromNdjson` codec is deliberately a **Node-native** format (safe/lossless for Node→Node dumps; avoids the `JSON.stringify` bigint/`Uint8Array`/`Date` footguns). It is **not** interchangeable with Go's `FormatNDJSON` — Go frames a `{type,value}` envelope and emits 64-bit ints as bare JSON numbers, which JS `JSON.parse` cannot read back losslessly above 2^53. True cross-SDK NDJSON byte-interop would need a coordinated JS-safe representation on both sides and is out of scope here.
- **Ping** POSTs Connect+JSON to the gRPC-Health-v1 endpoint riding the primary listener (server serves HTTP/1.1 and health is auth-exempt). Accepts both the bare and connectrpc-prefixed `SERVING` spellings; throws `HealthStatusError` otherwise; guards the no-baseURL case with `InvalidArgumentError`.
- All new surface is exported from both the node (`index.ts`) and web (`web.ts`) entrypoints.

## Deferred (documented non-goals, per #954)
- `subscribe` (replication server-stream) — Node is single-endpoint / non-HA by design (parallels the SDK's documented lack of a failover counterpart).
- App-level `WithRetry` equivalent — Connect-Node's built-in retry service config already covers idempotent-RPC retry.

## Tests / gate
Real-wire-path round-trips added to `test/client.test.ts` (decay staircase + effective weight; backup/restore final-flush ordering, chunk sizing, and lossless narrow-kind round-trip; NDJSON codec; ping happy / non-serving / non-200 / no-baseURL) plus 24 pure `test/decay.test.ts` cases. Full Node SDK gate green: `codegen` (clean), `lint`, `format:check`, `typecheck`, `test` (130 pass), `build`.

Closes #954