### PR TITLE
chore(sdks/node): bump lantern-sdk to 0.10.0 for release

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lantern-sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Official TypeScript client SDK for Lantern — an in-memory graph KVS, over Connect (HTTP/2).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Version bump to publish the Node SDK parity features (decay / backup-restore / ping) merged in #957.

`npm publish` (via `node-sdk.yml`) reads the version from `package.json`, so 0.9.0 -> 0.10.0 must land on `main` before the `sdks/node/v0.10.0` release tag is pushed.

- No code/lockfile changes: `bun install --frozen-lockfile` is a no-op.
- Pairs with the Go SDK release `sdks/go/v0.23.0` (`AddDecayingEdge`, #953).

Refs #954
