### PR TITLE
feat(admin): add `decaying-edge` verb to the embedded CLI

### DIFF
--- a/admin/app/lib/cli/complete.test.ts
+++ b/admin/app/lib/cli/complete.test.ts
@@ -54,8 +54,17 @@ describe("completeCommandLine — objectives (slot 1)", () => {
     ]);
   });
 
-  test("add offers only edge", () => {
-    expect(completeCommandLine("add ", KEYS).candidates).toEqual(["edge"]);
+  test("add offers edge and decaying-edge", () => {
+    expect(completeCommandLine("add ", KEYS).candidates).toEqual([
+      "edge",
+      "decaying-edge",
+    ]);
+  });
+
+  test("add filters to decaying-edge by prefix", () => {
+    expect(completeCommandLine("add d", KEYS).candidates).toEqual([
+      "decaying-edge",
+    ]);
   });
 
   test("scan offers the plural objectives", () => {

--- a/admin/app/lib/cli/complete.ts
+++ b/admin/app/lib/cli/complete.ts
@@ -159,7 +159,7 @@ function objectivesFor(verb: string): readonly string[] | null {
     case "delete":
       return ["vertex", "edge"];
     case "add":
-      return ["edge"];
+      return ["edge", "decaying-edge"];
     case "scan":
       return ["vertices", "edges"];
     case "count":

--- a/admin/app/lib/cli/types.ts
+++ b/admin/app/lib/cli/types.ts
@@ -54,6 +54,25 @@ export type Command =
       ttlSeconds: number | null;
     }
   | {
+      /**
+       * `add decaying-edge <tail> <head> <initial_weight> <ratio> <steps>
+       * <interval_seconds>` (#953). Client-side geometric decay: the SDK
+       * (`addDecayingEdge`) expands it into one staggered-TTL `AddEdges`
+       * batch. The parser validates operand *types* only — numeric-range
+       * checks (`ratio` in (0,1), `steps` in [1, MAX_DECAY_STEPS],
+       * `intervalSeconds` > 0) are deferred to the SDK's `DecayOptions`
+       * contract, mirroring the Go parser which defers to `client.DecayOpts`.
+       */
+      verb: "add";
+      objective: "decaying-edge";
+      tail: string;
+      head: string;
+      initialWeight: number;
+      ratio: number;
+      steps: number;
+      intervalSeconds: number;
+    }
+  | {
       verb: "scan";
       objective: "vertices";
       prefix: string;

--- a/admin/app/lib/cli/verbs.test.ts
+++ b/admin/app/lib/cli/verbs.test.ts
@@ -118,6 +118,106 @@ describe("parseAdd / parsePut weight uses parseFloatStrict (#434)", () => {
   });
 });
 
+describe("parseAdd decaying-edge (#953 — client-side decay staircase)", () => {
+  test("accepts the canonical 6-operand form", () => {
+    const r = parseAdd([
+      "decaying-edge",
+      "alice",
+      "bob",
+      "16",
+      "0.5",
+      "5",
+      "1",
+    ]);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.command).toEqual({
+        verb: "add",
+        objective: "decaying-edge",
+        tail: "alice",
+        head: "bob",
+        initialWeight: 16,
+        ratio: 0.5,
+        steps: 5,
+        intervalSeconds: 1,
+      });
+    }
+  });
+
+  test("validates operand types only — an out-of-range ratio still parses", () => {
+    // Range enforcement (ratio ∈ (0,1), steps ∈ [1,MAX], interval > 0) is the
+    // SDK's job; the parser must not reject a well-typed but out-of-range curve,
+    // matching the Go parser which defers to client.DecayOpts.
+    const r = parseAdd(["decaying-edge", "alice", "bob", "16", "2", "5", "1"]);
+    expect(r.ok).toBe(true);
+    if (
+      r.ok &&
+      r.command.verb === "add" &&
+      r.command.objective === "decaying-edge"
+    ) {
+      expect(r.command.ratio).toBe(2);
+    }
+  });
+
+  test("rejects a missing interval_seconds (5 operands)", () => {
+    const r = parseAdd(["decaying-edge", "alice", "bob", "16", "0.5", "5"]);
+    expect(r.ok).toBe(false);
+  });
+
+  test("rejects a trailing token after interval_seconds (7 operands)", () => {
+    const r = parseAdd([
+      "decaying-edge",
+      "alice",
+      "bob",
+      "16",
+      "0.5",
+      "5",
+      "1",
+      "extra",
+    ]);
+    expect(r.ok).toBe(false);
+  });
+
+  test("rejects a non-numeric initial_weight", () => {
+    const r = parseAdd([
+      "decaying-edge",
+      "alice",
+      "bob",
+      "notafloat",
+      "0.5",
+      "5",
+      "1",
+    ]);
+    expect(r.ok).toBe(false);
+  });
+
+  test("rejects non-integer steps", () => {
+    const r = parseAdd([
+      "decaying-edge",
+      "alice",
+      "bob",
+      "16",
+      "0.5",
+      "2.5",
+      "1",
+    ]);
+    expect(r.ok).toBe(false);
+  });
+
+  test("rejects a fractional interval_seconds (bare integer of seconds)", () => {
+    const r = parseAdd([
+      "decaying-edge",
+      "alice",
+      "bob",
+      "16",
+      "0.5",
+      "5",
+      "1.5",
+    ]);
+    expect(r.ok).toBe(false);
+  });
+});
+
 describe("parseHelp (#436 — help verb)", () => {
   test("bare `help` returns a help command", () => {
     const r = parseHelp([]);

--- a/admin/app/lib/cli/verbs.ts
+++ b/admin/app/lib/cli/verbs.ts
@@ -196,26 +196,31 @@ export function parseDelete(rest: string[]): ParseResult {
   return { ok: false, usage: "usage: delete { vertex | edge }" };
 }
 
+const ADD_EDGE_USAGE =
+  "usage: add edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]";
+const ADD_DECAYING_EDGE_USAGE =
+  "usage: add decaying-edge <tail: string> <head: string> <initial_weight: float> <ratio: float> <steps: int> <interval_seconds: int>";
+
 export function parseAdd(rest: string[]): ParseResult {
   const [obj, ...args] = rest;
-  if (obj?.toLowerCase() !== "edge") {
-    return { ok: false, usage: "usage: add edge ... " };
+  const o = obj?.toLowerCase();
+  if (o === "edge") {
+    return parseAddEdge(args);
   }
+  if (o === "decaying-edge") {
+    return parseAddDecayingEdge(args);
+  }
+  return { ok: false, usage: "usage: add { edge | decaying-edge } ... " };
+}
+
+function parseAddEdge(args: string[]): ParseResult {
   if (args.length < 3 || args.length > 4) {
-    return {
-      ok: false,
-      usage:
-        "usage: add edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
-    };
+    return { ok: false, usage: ADD_EDGE_USAGE };
   }
   const [tail, head, weightTok, ttlTok] = args;
   const weight = parseFloatStrict(weightTok);
   if (weight === null) {
-    return {
-      ok: false,
-      usage:
-        "usage: add edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
-    };
+    return { ok: false, usage: ADD_EDGE_USAGE };
   }
   // Omitted ttl_seconds ⇒ permanent (no decay); only an explicit but
   // malformed token is a usage error (#523).
@@ -223,11 +228,7 @@ export function parseAdd(rest: string[]): ParseResult {
   if (ttlTok !== undefined) {
     ttlSeconds = parseInt10(ttlTok);
     if (ttlSeconds === null) {
-      return {
-        ok: false,
-        usage:
-          "usage: add edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
-      };
+      return { ok: false, usage: ADD_EDGE_USAGE };
     }
   }
   return {
@@ -239,6 +240,45 @@ export function parseAdd(rest: string[]): ParseResult {
       head,
       weight,
       ttlSeconds,
+    },
+  };
+}
+
+// `add decaying-edge <tail> <head> <initial_weight> <ratio> <steps>
+// <interval_seconds>` (#953). Mirrors the Go parser's `AddDecayingEdgeParam`:
+// exactly six operands, validated for *type* only. Numeric-range checks
+// (ratio in (0,1), steps in [1, MAX_DECAY_STEPS], interval > 0) are deferred
+// to the SDK's `DecayOptions` contract, so a grammatically well-formed but
+// out-of-range command parses here and fails at execution with the SDK's
+// error, exactly as the Go CLI defers to `client.DecayOpts`.
+function parseAddDecayingEdge(args: string[]): ParseResult {
+  if (args.length !== 6) {
+    return { ok: false, usage: ADD_DECAYING_EDGE_USAGE };
+  }
+  const [tail, head, initialTok, ratioTok, stepsTok, intervalTok] = args;
+  const initialWeight = parseFloatStrict(initialTok);
+  const ratio = parseFloatStrict(ratioTok);
+  const steps = parseInt10(stepsTok);
+  const intervalSeconds = parseInt10(intervalTok);
+  if (
+    initialWeight === null ||
+    ratio === null ||
+    steps === null ||
+    intervalSeconds === null
+  ) {
+    return { ok: false, usage: ADD_DECAYING_EDGE_USAGE };
+  }
+  return {
+    ok: true,
+    command: {
+      verb: "add",
+      objective: "decaying-edge",
+      tail,
+      head,
+      initialWeight,
+      ratio,
+      steps,
+      intervalSeconds,
     },
   };
 }
@@ -535,6 +575,7 @@ export const HELP_TEXT = [
   "  put    vertex <key: string> <value: string|int|float|bool|datetime> [<ttl_seconds: int>] [type=auto|string|int|float|bool|datetime|duration|json]",
   "  put    edge   <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
   "  add    edge   <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]",
+  "  add    decaying-edge <tail: string> <head: string> <initial_weight: float> <ratio: float> <steps: int> <interval_seconds: int>",
   "  delete vertex <key: string> [<key: string> ...]",
   "  delete edge   <tail: string> <head: string> [<tail: string> <head: string> ...]",
   "  scan   vertices <prefix: string> [<limit: int>] [all=true]",
@@ -638,6 +679,15 @@ export const CLI_COMMAND_REFERENCE: readonly CliCommandDoc[] = [
     summary:
       "Add weight onto an edge (additive); creates it if absent. TTL seconds optional.",
     example: "add edge alice bob 0.5",
+  },
+  {
+    group: "Edges",
+    verb: "add",
+    signature:
+      "add decaying-edge <tail> <head> <initial_weight> <ratio> <steps> <interval_seconds>",
+    summary:
+      "Add a geometric decay staircase: the edge starts at initial_weight and decays by ratio each step, one contribution per interval_seconds. Client-side only; range checks apply at execution.",
+    example: "add decaying-edge alice bob 16 0.5 5 1",
   },
   {
     group: "Edges",

--- a/admin/app/lib/client/infrastructure/api/add-decaying-edge.ts
+++ b/admin/app/lib/client/infrastructure/api/add-decaying-edge.ts
@@ -1,0 +1,45 @@
+import type { LanternClient } from "./lantern-client";
+import { LanternApiError } from "./error";
+import type { AddDecayingEdgeBody, AddDecayingEdgeResponse } from "./types";
+
+export type { AddDecayingEdgeBody, AddDecayingEdgeResponse } from "./types";
+
+/**
+ * Calls the SDK's `Lantern.addDecayingEdge` (#953) — the client-side
+ * geometric decay staircase that expands into one staggered-TTL
+ * `AddEdges` batch. Non-idempotent, like a plain `add edge`: each call
+ * accumulates a fresh decaying contribution onto the (tail, head) edge.
+ *
+ * The SDK validates the `DecayOptions` contract synchronously and throws
+ * `InvalidArgumentError` when the curve is ill-formed (ratio outside
+ * (0, 1), steps outside [1, MAX_DECAY_STEPS], non-positive interval, or a
+ * curve that underflows float32 to zero). We surface that — and any wire
+ * fault — as the usual `LanternApiError` the scrollback already renders.
+ *
+ * Returns the edge's effective (live-sum) weight immediately after the
+ * add, which the dispatcher echoes as `total`.
+ */
+export async function addDecayingEdge(
+  client: LanternClient,
+  tail: string,
+  head: string,
+  body: AddDecayingEdgeBody,
+  init?: { signal?: AbortSignal },
+): Promise<AddDecayingEdgeResponse> {
+  try {
+    const effectiveWeight = await client.addDecayingEdge(
+      tail,
+      head,
+      {
+        initialWeight: body.initialWeight,
+        ratio: body.ratio,
+        steps: body.steps,
+        intervalSeconds: body.intervalSeconds,
+      },
+      init?.signal,
+    );
+    return { effectiveWeight };
+  } catch (err) {
+    throw LanternApiError.fromUnknown("AddDecayingEdge", err);
+  }
+}

--- a/admin/app/lib/client/infrastructure/api/types.ts
+++ b/admin/app/lib/client/infrastructure/api/types.ts
@@ -134,6 +134,22 @@ export interface AddEdgeResponse {
   edge?: Edge;
 }
 
+export interface AddDecayingEdgeBody {
+  initialWeight: number;
+  ratio: number;
+  steps: number;
+  intervalSeconds: number;
+}
+
+export interface AddDecayingEdgeResponse {
+  /**
+   * Effective (live-sum) weight on (tail, head) immediately after the
+   * decaying add — any preexisting live weight plus `initialWeight`.
+   * Returned by the SDK's `addDecayingEdge` and surfaced in the echo.
+   */
+  effectiveWeight: number;
+}
+
 export interface PutEdgeBody {
   edge?: Edge;
 }

--- a/admin/app/lib/client/usecase/cli/dispatcher.test.ts
+++ b/admin/app/lib/client/usecase/cli/dispatcher.test.ts
@@ -81,6 +81,14 @@ class FakeLanternClient {
   addEdge(input: unknown, signal?: AbortSignal): unknown {
     return this.invoke("addEdge", [input, signal]);
   }
+  addDecayingEdge(
+    tail: string,
+    head: string,
+    opts: unknown,
+    signal?: AbortSignal,
+  ): unknown {
+    return this.invoke("addDecayingEdge", [tail, head, opts, signal]);
+  }
   deleteEdge(tail: string, head: string, signal?: AbortSignal): unknown {
     return this.invoke("deleteEdge", [tail, head, signal]);
   }
@@ -443,6 +451,72 @@ describe("dispatch write echo surfaces the applied TTL/expiry (#653)", () => {
     const ms = new Date(out.expiresAt!).getTime();
     expect(ms).toBeGreaterThanOrEqual(before + 30_000);
     expect(ms).toBeLessThanOrEqual(after + 30_000);
+  });
+});
+
+describe("dispatch add decaying-edge (#953)", () => {
+  test("calls addDecayingEdge with the parsed DecayOptions", async () => {
+    const fake = new FakeLanternClient();
+    fake.stub("addDecayingEdge", () => 31);
+    const cmd: Command = {
+      verb: "add",
+      objective: "decaying-edge",
+      tail: "x",
+      head: "y",
+      initialWeight: 16,
+      ratio: 0.5,
+      steps: 5,
+      intervalSeconds: 1,
+    };
+    await dispatch({ client: asClient(fake), command: cmd });
+    const call = fake.calls.find((c) => c.method === "addDecayingEdge");
+    expect(call).toBeDefined();
+    expect(call!.args[0]).toBe("x");
+    expect(call!.args[1]).toBe("y");
+    expect(call!.args[2]).toEqual({
+      initialWeight: 16,
+      ratio: 0.5,
+      steps: 5,
+      intervalSeconds: 1,
+    });
+  });
+
+  test("echoes the decay params, returned total, and full-horizon expiry", async () => {
+    const fake = new FakeLanternClient();
+    fake.stub("addDecayingEdge", () => 31);
+    const cmd: Command = {
+      verb: "add",
+      objective: "decaying-edge",
+      tail: "x",
+      head: "y",
+      initialWeight: 16,
+      ratio: 0.5,
+      steps: 5,
+      intervalSeconds: 1,
+    };
+    const before = Date.now();
+    const out = (await dispatch({ client: asClient(fake), command: cmd })) as {
+      tail: string;
+      head: string;
+      initialWeight: number;
+      ratio: number;
+      steps: number;
+      total: number;
+      ttlSeconds: number | null;
+      expiresAt: string | null;
+    };
+    const after = Date.now();
+    expect(out.tail).toBe("x");
+    expect(out.head).toBe("y");
+    expect(out.initialWeight).toBe(16);
+    expect(out.ratio).toBe(0.5);
+    expect(out.steps).toBe(5);
+    expect(out.total).toBe(31);
+    // Horizon = steps × intervalSeconds = 5 × 1 = 5s.
+    expect(out.ttlSeconds).toBe(5);
+    const ms = new Date(out.expiresAt!).getTime();
+    expect(ms).toBeGreaterThanOrEqual(before + 5_000);
+    expect(ms).toBeLessThanOrEqual(after + 5_000);
   });
 });
 

--- a/admin/app/lib/client/usecase/cli/dispatcher.ts
+++ b/admin/app/lib/client/usecase/cli/dispatcher.ts
@@ -29,6 +29,7 @@
  */
 
 import type { LanternClient } from "~/lib/client/infrastructure/api/lantern-client";
+import { addDecayingEdge } from "~/lib/client/infrastructure/api/add-decaying-edge";
 import { addEdge } from "~/lib/client/infrastructure/api/add-edge";
 import { countVerticesByPrefix } from "~/lib/client/infrastructure/api/count-vertices-by-prefix";
 import { deleteEdge } from "~/lib/client/infrastructure/api/delete-edge";
@@ -188,6 +189,38 @@ export async function dispatch(input: DispatchInput): Promise<unknown> {
       }
       return { deleted: await deleteEdges(client, command.pairs, { signal }) };
     case "add": {
+      if (command.objective === "decaying-edge") {
+        // The staircase has staggered per-step TTLs, so there is no single
+        // applied TTL; echo the full decay horizon (steps × interval) as the
+        // effective expiry — when the edge decays to zero — mirroring the Go
+        // REPL's `add decaying-edge` echo.
+        const horizonSeconds = command.steps * command.intervalSeconds;
+        const expiration = ttlSecondsToExpiration(horizonSeconds);
+        const { effectiveWeight } = await addDecayingEdge(
+          client,
+          command.tail,
+          command.head,
+          {
+            initialWeight: command.initialWeight,
+            ratio: command.ratio,
+            steps: command.steps,
+            intervalSeconds: command.intervalSeconds,
+          },
+          { signal },
+        );
+        return writeEcho(
+          {
+            tail: command.tail,
+            head: command.head,
+            initialWeight: command.initialWeight,
+            ratio: command.ratio,
+            steps: command.steps,
+            total: effectiveWeight,
+          },
+          horizonSeconds,
+          expiration,
+        );
+      }
       const expiration = ttlSecondsToExpiration(command.ttlSeconds);
       await addEdge(
         client,

--- a/admin/app/lib/client/usecase/cli/graph-view.test.ts
+++ b/admin/app/lib/client/usecase/cli/graph-view.test.ts
@@ -344,6 +344,31 @@ describe("commandResultToGraphMerge", () => {
     expect(merge.focus).toBe("alice");
   });
 
+  it("projects an add decaying-edge as an additive edge at its S(0) weight", () => {
+    const cmd: Command = {
+      verb: "add",
+      objective: "decaying-edge",
+      tail: "alice",
+      head: "bob",
+      initialWeight: 16,
+      ratio: 0.5,
+      steps: 5,
+      intervalSeconds: 1,
+    };
+    const merge = commandResultToGraphMerge(cmd)!;
+    expect(merge.nodes.map((n) => n.id).sort()).toEqual(["alice", "bob"]);
+    expect(merge.edges).toHaveLength(1);
+    expect(merge.edges[0].id).toBe("alice→bob");
+    // The canvas shows the initial live weight (S(0)); per-step contributions
+    // are an SDK/server detail.
+    expect(merge.edges[0].weight).toBe(16);
+    expect(merge.edges[0].edge.weight).toBe(16);
+    // Expiry is the full decay horizon (steps × interval = 5s).
+    expect(typeof merge.edges[0].edge.expiration).toBe("string");
+    expect(merge.additive).toBe(true);
+    expect(merge.focus).toBe("alice");
+  });
+
   it("returns null for verbs that carry no mergeable element", () => {
     expect(
       commandResultToGraphMerge({

--- a/admin/app/lib/client/usecase/cli/graph-view.ts
+++ b/admin/app/lib/client/usecase/cli/graph-view.ts
@@ -406,6 +406,37 @@ export function commandResultToGraphMerge(command: Command): GraphMerge | null {
       focus: command.tail,
     };
   }
+  if (command.verb === "add" && command.objective === "decaying-edge") {
+    // Render the staircase as a single additive edge at its S(0) live weight
+    // (`initialWeight`), decaying over the full horizon (steps × interval).
+    // The canvas shows one edge per (tail, head); the per-step contributions
+    // are an SDK/server implementation detail, so the initial live sum is the
+    // faithful visual weight.
+    const horizonSeconds = command.steps * command.intervalSeconds;
+    const edge: Edge = {
+      tail: command.tail,
+      head: command.head,
+      weight: command.initialWeight,
+      expiration: ttlSecondsToExpiration(horizonSeconds),
+    };
+    return {
+      nodes: [
+        mergeNode(command.tail, { key: command.tail }),
+        mergeNode(command.head, { key: command.head }),
+      ],
+      edges: [
+        {
+          id: `${command.tail}→${command.head}`,
+          source: command.tail,
+          target: command.head,
+          weight: command.initialWeight,
+          edge,
+        },
+      ],
+      additive: true,
+      focus: command.tail,
+    };
+  }
   return null;
 }
 

--- a/admin/test/cli-grammar/verbs.json
+++ b/admin/test/cli-grammar/verbs.json
@@ -23,6 +23,18 @@
     { "input": "put edge alice bob 1.5 60" },
     { "input": "add edge alice bob 1.0" },
     { "input": "add edge alice bob 1.0 60" },
+    {
+      "input": "add decaying-edge alice bob 16 0.5 5 1",
+      "comment": "#953: geometric decay staircase (16→8→4→2→1→0 over 5s)"
+    },
+    {
+      "input": "add decaying-edge alice bob 1.5 0.9 16 5",
+      "comment": "#953: steps at MAX_DECAY_STEPS (16)"
+    },
+    {
+      "input": "add decaying-edge alice bob 16 2 5 1",
+      "comment": "#953: the parser validates operand types only — an out-of-range ratio (2 ∉ (0,1)) parses here and is rejected by the SDK at execution, matching the Go parser which defers to client.DecayOpts"
+    },
     { "input": "delete vertex alice" },
     { "input": "delete edge alice bob" },
     { "input": "scan vertices users/" },
@@ -182,7 +194,30 @@
       "input": "add edge alice bob 1.0 60 extra",
       "comment": "#932: trailing token after ttl_seconds"
     },
-    { "input": "add vertex alice", "comment": "add only supports edge" },
+    {
+      "input": "add vertex alice",
+      "comment": "add only supports edge and decaying-edge"
+    },
+    {
+      "input": "add decaying-edge alice bob 16 0.5 5",
+      "comment": "#953: missing interval_seconds (5 operands, needs 6)"
+    },
+    {
+      "input": "add decaying-edge alice bob 16 0.5 5 1 extra",
+      "comment": "#953: trailing token after interval_seconds"
+    },
+    {
+      "input": "add decaying-edge alice bob notafloat 0.5 5 1",
+      "comment": "#953: non-numeric initial_weight"
+    },
+    {
+      "input": "add decaying-edge alice bob 16 0.5 2.5 1",
+      "comment": "#953: non-integer steps"
+    },
+    {
+      "input": "add decaying-edge alice bob 16 0.5 5 1.5",
+      "comment": "#953: interval_seconds is a bare integer of seconds, not a float"
+    },
     { "input": "delete", "comment": "missing objective" },
     { "input": "delete edge alice", "comment": "missing head" },
     { "input": "scan", "comment": "missing objective" },

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -220,6 +220,32 @@ test.describe("/cli", () => {
     );
   });
 
+  // #953 — `add decaying-edge` runs the geometric decay staircase entirely
+  // through the workspace-linked lantern-sdk (one staggered-TTL AddEdges
+  // batch). The echo surfaces the SDK's returned live-sum total, and the
+  // additive edge lands on the canvas at its initial weight.
+  test("add decaying-edge writes an additive edge and echoes its total (#953)", async ({
+    page,
+  }) => {
+    await page.goto("/cli");
+    await expect(page.getByTestId("cli-canvas-panel")).toHaveCount(0);
+    const input = page.getByTestId("cli-input");
+    await input.fill("add decaying-edge cli:dk-a cli:dk-b 16 0.5 5 1");
+    await input.press("Enter");
+    // The write dispatches straight through and echoes an ok chip carrying
+    // the decay params and the returned live-sum total.
+    const ok = page.getByTestId("cli-entry-ok").last();
+    await expect(ok).toBeVisible();
+    await expect(ok).toContainText("total");
+    await expect(ok).toContainText("16");
+    // The canvas opens with the command as its source label and the edge
+    // between the two endpoints.
+    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
+    await expect(page.getByTestId("cli-canvas-panel")).toContainText(
+      "add decaying-edge cli:dk-a cli:dk-b 16 0.5 5 1",
+    );
+  });
+
   // #433 — Ctrl+L is the editor-conventional clear-screen binding and
   // the only way to clear the scrollback now that the Clear button has
   // been removed (#512). It empties the scrollback in place, leaving the
@@ -670,6 +696,7 @@ test.describe("/cli", () => {
     const drawer = page.getByTestId("cli-command-reference");
     await expect(drawer).toBeVisible();
     await expect(drawer).toContainText("illuminate");
+    await expect(drawer).toContainText("add decaying-edge");
     await expect(page.getByTestId("cli-command-row").first()).toBeVisible();
     // The dismiss button closes it again.
     await page.getByTestId("cli-command-reference-close").click();


### PR DESCRIPTION
## What & why

The admin SPA's embedded `/cli` re-implements the Go REPL grammar in TypeScript, but it was missing the `add decaying-edge` verb that #953 added to the Go CLI and #957 ported to the Node SDK (`lantern-sdk` `v0.10.0`). This brings the admin CLI to grammar parity with the Go CLI so both accept the same command, executed against the workspace-linked SDK.

The Go CLI/REPL already fully supports the verb (#953) — no Go code changes here beyond the **shared** grammar fixture.

Closes #959

## Grammar (matches the Go parser exactly)

```
add decaying-edge <tail: string> <head: string> <initial_weight: float> <ratio: float> <steps: int> <interval_seconds: int>
```

Exactly 6 operands, **type-only** validation. Numeric-range checks (ratio ∈ (0,1), steps ∈ [1, MAX_DECAY_STEPS], interval > 0) are deferred to the SDK's `DecayOptions` contract — mirroring the Go parser, which defers to `client.DecayOpts`. `interval_seconds` is a bare integer of seconds.

## Changes

**Grammar (`admin/app/lib/cli/`)**
- `types.ts`: new `add` / `objective: "decaying-edge"` `Command` variant.
- `verbs.ts`: `parseAdd` routes `edge` vs `decaying-edge`; adds the `HELP_TEXT` line (byte-matched to the Go `HelpText`) and a `CLI_COMMAND_REFERENCE` entry (auto-rendered by the Commands drawer).
- `complete.ts`: `decaying-edge` added to `objectivesFor("add")`.

**Execution (`admin/app/lib/client/`)**
- `infrastructure/api/add-decaying-edge.ts` (new): thin adapter over `client.addDecayingEdge`, errors mapped to `LanternApiError`.
- `usecase/cli/dispatcher.ts`: `add` case branches on objective; echoes the SDK's returned live-sum `total` and the full decay horizon (steps × interval) as the effective expiry.
- `usecase/cli/graph-view.ts`: renders the additive edge on the canvas at its S(0) initial weight.

**Fixture / tests**
- `test/cli-grammar/verbs.json`: valid + invalid `decaying-edge` cases — the shared drift fixture consumed by **both** `cli/parser/grammar_fixture_test.go` and the admin Bun test, so the two parsers can't diverge.
- Unit tests: parser, completion, dispatcher, graph-view.
- E2E (`tests/e2e/cli.spec.ts`): the Commands drawer lists the verb, and a full-stack case runs `add decaying-edge` against a real Lantern server + the linked SDK, asserting the echo and canvas edge.

## Verification

- Admin gate: `format` ✓ · `lint` ✓ (no new issues) · `typecheck` ✓ · `test` (742 pass) ✓ · `build` ✓
- Go: `gofmt -l cli/` clean · `go test ./cli/...` ✓ (shared fixture, 8 new `decaying-edge` cases)
- Playwright: reference-drawer + full-stack execution tests pass against a real server

## Non-goals

Go CLI/REPL (already complete in #953). No new server/wire surface — pure client-side expansion over `AddEdges`, so no `tests/integration/` addition is required.