### PR TITLE
fix(admin): let /cli restart_prob & epsilon accept typed floats

### DIFF
--- a/admin/app/components/cli/CliAxisPicker/CliAxisPicker.tsx
+++ b/admin/app/components/cli/CliAxisPicker/CliAxisPicker.tsx
@@ -4,7 +4,7 @@ import {
   Option,
   type InputProps,
 } from "@fluentui/react-components";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import {
   CLI_ALGORITHMS,
   CLI_CLICK_K_MAX,
@@ -15,6 +15,7 @@ import {
   CLI_REDUCTIONS,
   CLI_WEIGHTINGS,
   formatIlluminateClick,
+  interpretPushKnobInput,
   type CliClickAxes,
 } from "~/lib/cli/illuminate-axes";
 import type {
@@ -89,31 +90,39 @@ export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
     [setAxis],
   );
 
-  // #801: PPR knobs are non-negative floats; an empty field means "0 = server
-  // default". Reject NaN / negative entries (the server owns the (0,1) / >0
-  // bounds) so a stray keystroke never persists a nonsensical knob.
+  // #801/#964: the α/ε knobs are non-negative floats, but they were built as
+  // native `type="number"` inputs whose `.value` goes empty for a syntactically
+  // in-progress entry ("0.", "1e-"), and whose displayed value was re-derived
+  // from the numeric axis every render (where 0 = "server default" renders
+  // blank). Together that erased the field on any keystroke that transiently
+  // parsed to 0, so decimals in (0,1) and scientific ε were literally
+  // un-typeable — the picker behaved as if only integers were allowed. Fix:
+  // hold the operator's RAW text as local state (displayed verbatim) and commit
+  // only a valid parse to the axis, so "0.15" / "1e-4" survive keystroke by
+  // keystroke. Seeded once from the already-hydrated axes; these two handlers
+  // are the sole writers of the knobs, so the text and the numeric axis never
+  // diverge without passing through here.
+  const [restartProbText, setRestartProbText] = useState(
+    axes.restartProb > 0 ? String(axes.restartProb) : "",
+  );
+  const [epsilonText, setEpsilonText] = useState(
+    axes.epsilon > 0 ? String(axes.epsilon) : "",
+  );
+
   const onRestartProbChange = useCallback<NonNullable<InputProps["onChange"]>>(
     (_, data) => {
-      if (data.value === "") {
-        setAxis("restartProb", 0);
-        return;
-      }
-      const n = Number.parseFloat(data.value);
-      if (!Number.isFinite(n) || n < 0) return;
-      setAxis("restartProb", n);
+      setRestartProbText(data.value);
+      const n = interpretPushKnobInput(data.value);
+      if (n !== null) setAxis("restartProb", n);
     },
     [setAxis],
   );
 
   const onEpsilonChange = useCallback<NonNullable<InputProps["onChange"]>>(
     (_, data) => {
-      if (data.value === "") {
-        setAxis("epsilon", 0);
-        return;
-      }
-      const n = Number.parseFloat(data.value);
-      if (!Number.isFinite(n) || n < 0) return;
-      setAxis("epsilon", n);
+      setEpsilonText(data.value);
+      const n = interpretPushKnobInput(data.value);
+      if (n !== null) setAxis("epsilon", n);
     },
     [setAxis],
   );
@@ -289,11 +298,9 @@ export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
             <span className={styles.label}>restart_prob</span>
             <Input
               className={styles.numberInput}
-              type="number"
-              min={0}
-              max={1}
-              step="any"
-              value={axes.restartProb > 0 ? String(axes.restartProb) : ""}
+              type="text"
+              inputMode="decimal"
+              value={restartProbText}
               onChange={onRestartProbChange}
               disabled={disabled}
               placeholder="0.15"
@@ -306,10 +313,9 @@ export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
             <span className={styles.label}>epsilon</span>
             <Input
               className={styles.numberInput}
-              type="number"
-              min={0}
-              step="any"
-              value={axes.epsilon > 0 ? String(axes.epsilon) : ""}
+              type="text"
+              inputMode="decimal"
+              value={epsilonText}
               onChange={onEpsilonChange}
               disabled={disabled}
               placeholder="1e-4"

--- a/admin/app/lib/cli/illuminate-axes.test.ts
+++ b/admin/app/lib/cli/illuminate-axes.test.ts
@@ -24,6 +24,7 @@ import {
   CLI_CLICK_AXIS_DEFAULTS,
   formatIlluminateClick,
   formatStoredFloat,
+  interpretPushKnobInput,
   parseStoredAlgorithm,
   parseStoredFloat,
   parseStoredK,
@@ -423,5 +424,36 @@ describe("parseStored* helpers", () => {
     for (const value of [0, 0.15, 0.25, 0.0001]) {
       expect(parseStoredFloat(formatStoredFloat(value))).toBe(value);
     }
+  });
+});
+
+describe("interpretPushKnobInput (live α/ε knob editing)", () => {
+  test("blank or whitespace commits 0 (= server default)", () => {
+    expect(interpretPushKnobInput("")).toBe(0);
+    expect(interpretPushKnobInput("   ")).toBe(0);
+  });
+
+  test("commits finite non-negative decimals and scientific notation", () => {
+    expect(interpretPushKnobInput("0")).toBe(0);
+    expect(interpretPushKnobInput("0.15")).toBe(0.15);
+    expect(interpretPushKnobInput("0.001")).toBe(0.001);
+    expect(interpretPushKnobInput("1e-4")).toBe(0.0001);
+  });
+
+  test("keeps a value for in-progress decimals so the field is never erased", () => {
+    // The regression this guards: typing "0.15" a key at a time used to pass
+    // through "0." → commit 0 → re-derive display from the numeric axis → blank,
+    // so a leading-zero decimal could never be built up. "0." / "0.0" must
+    // resolve to a committable 0 (the component keeps the raw text), not null.
+    expect(interpretPushKnobInput("0.")).toBe(0);
+    expect(interpretPushKnobInput("0.0")).toBe(0);
+  });
+
+  test("rejects garbage / negatives so a good knob is never destroyed", () => {
+    expect(interpretPushKnobInput("-0.1")).toBeNull();
+    expect(interpretPushKnobInput("-")).toBeNull();
+    expect(interpretPushKnobInput("abc")).toBeNull();
+    expect(interpretPushKnobInput("NaN")).toBeNull();
+    expect(interpretPushKnobInput("Infinity")).toBeNull();
   });
 });

--- a/admin/app/lib/cli/illuminate-axes.ts
+++ b/admin/app/lib/cli/illuminate-axes.ts
@@ -275,6 +275,33 @@ export function parseStoredFloat(raw: string | null): number | null {
 }
 
 /**
+ * Interpret a raw push-knob (restart_prob / epsilon) input string into the
+ * number to COMMIT to the axis during live editing (#801).
+ *
+ * The CliAxisPicker knob fields keep the operator's raw keystrokes as the
+ * displayed value — so a half-typed "0." or "1e-" survives instead of being
+ * round-tripped through the numeric axis (where 0 = "server default" renders
+ * blank) and erased mid-edit — and feed every keystroke through this helper to
+ * decide what, if anything, to persist:
+ *   - blank / whitespace → 0, i.e. "leave the knob at the server default";
+ *   - a finite, non-negative parse (incl. "0", "0.", "0.15", "1e-4") → that
+ *     number, committed so the live preview updates;
+ *   - anything else (negative, NaN, "abc", a lone "-") → null, meaning "keep the
+ *     previously committed value" so a stray keystroke never destroys a good knob.
+ *
+ * This is the live-edit sibling of {@link parseStoredFloat} (which guards
+ * localStorage hydration). Both stay lenient about the (0,1) / >0 bounds — the
+ * server remains the final authority — but neither ever resurrects a NaN or a
+ * negative knob.
+ */
+export function interpretPushKnobInput(raw: string): number | null {
+  if (raw.trim() === "") return 0;
+  const n = Number.parseFloat(raw);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n;
+}
+
+/**
  * Parse a stored vertex prefix. Prefix is free text, so every non-null
  * string is valid (including ""); only a missing key returns null, letting
  * the caller fall back to {@link CLI_CLICK_AXIS_DEFAULTS}.vertexPrefix.

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -606,6 +606,48 @@ test.describe("/cli", () => {
     await expect(preview).toHaveText("illuminate <key> 2 5");
   });
 
+  // #964 — the α/ε knobs must accept floats typed a keystroke at a time, not
+  // just Playwright's atomic .fill(). The pre-fix inputs were `type="number"`
+  // whose `.value` goes empty for an in-progress "0." / "1e-", and the field
+  // was re-derived from the numeric axis (0 → blank), so a human typing "0.15"
+  // saw every keystroke erased and could only enter integers.
+  test("ppr knobs accept floats typed character-by-character (#964)", async ({
+    page,
+  }) => {
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    await input.fill("get vertex cli:alpha");
+    await input.press("Enter");
+    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
+    const preview = page.getByTestId("cli-axis-preview");
+
+    await page.getByTestId("cli-axis-algorithm").click();
+    await page.getByRole("option", { name: "Personalized PageRank" }).click();
+    await expect(preview).toHaveText("illuminate <key> 2 5 algorithm=ppr");
+
+    // Type a leading-zero decimal one key at a time: the field must retain each
+    // keystroke (no blanking on the intermediate "0" / "0.") and the preview
+    // must build up the full float.
+    const restartProb = page.getByTestId("cli-axis-restart-prob");
+    await restartProb.click();
+    await restartProb.pressSequentially("0.15");
+    await expect(restartProb).toHaveValue("0.15");
+    await expect(preview).toHaveText(
+      "illuminate <key> 2 5 algorithm=ppr restart_prob=0.15",
+    );
+
+    // Scientific notation must survive too — a `type="number"` field reports an
+    // empty value for the intermediate "1e" / "1e-". The raw text is echoed
+    // verbatim while the committed number normalises to decimal in the command.
+    const epsilon = page.getByTestId("cli-axis-epsilon");
+    await epsilon.click();
+    await epsilon.pressSequentially("1e-4");
+    await expect(epsilon).toHaveValue("1e-4");
+    await expect(preview).toHaveText(
+      "illuminate <key> 2 5 algorithm=ppr restart_prob=0.15 epsilon=0.0001",
+    );
+  });
+
   test("picker state persists across a reload (#464)", async ({ page }) => {
     await page.goto("/cli");
     // Render a graph so the picker mounts (#512).


### PR DESCRIPTION
## What

On the Admin `/cli` page, the Personalized-PageRank / Local-Community locality knobs **`restart_prob`** and **`epsilon`** (`CliAxisPicker`) could not accept fractional values typed by hand — entering `0.15` or `1e-4` was impossible, so the fields behaved as if only integers were allowed.

## Root cause

Two defects compounded in `CliAxisPicker.tsx`:

1. The inputs were `type="number"`, whose `.value` goes **empty** for a syntactically in-progress entry (`"0."`, `"1e"`, `"1e-"`). So typing a decimal/scientific value one key at a time delivered `""` to `onChange` at the intermediate steps.
2. The displayed value was re-derived from the numeric axis every render — `value={axes.restartProb > 0 ? String(axes.restartProb) : ""}` — where `0` (= "server default") renders blank, and `onChange` committed `0` on empty input. So **any keystroke that transiently parsed to 0 blanked the field**, discarding the in-progress decimal.

The existing e2e didn't catch it because Playwright's `.fill("0.25")` sets the value atomically, never passing through the `0` / `0.` intermediate states a human types.

## Fix

- Hold the operator's **raw input text** in local component state (displayed verbatim); commit only a valid parse to the numeric axis. Blank still means "server default" (0).
- New pure helper `interpretPushKnobInput(raw)` centralises the commit decision (blank → 0; finite non-negative → that number; garbage/negative → keep previous), unit-tested in `illuminate-axes.test.ts`.
- Switch both fields to `type="text"` + `inputMode="decimal"` so the browser stops sanitising in-progress decimals to `""`.
- Upgrade the `/cli` e2e to type the knobs **character-by-character** (`pressSequentially`), proving `0.15` and `1e-4` now persist and build the preview.

## Test

- `bun run format && lint && typecheck && test` (764 pass) + `build` — all green.
- Targeted e2e (`go run` server + admin preview + chromium) — both the existing `.fill` knob test and the new keystroke test pass.

Admin-only, user-facing UI fix → ships as `admin/v0.18.0`.

Closes #964