### PR TITLE
fix: apply weighting transform to LocalCommunity output edge weights

### DIFF
--- a/core/graphcache/traversal.go
+++ b/core/graphcache/traversal.go
@@ -583,10 +583,15 @@ func (c *GraphCache[S, T]) LocalCommunity(seed S, maxSize int, alpha, epsilon fl
 //
 // Output contract — unlike the PPR relevance star, structure is preserved:
 // the result is the INDUCED SUBGRAPH on the selected set: every member's
-// live value plus every live edge among members with its actual stored
-// weight (weighting-neutral — the transform steers membership, not the
-// returned weights) and expiration, in the same (graph, expirations) shape
-// as NeighborWithExpirationsContext. An unknown seed yields an empty graph.
+// live value plus every live edge among members with its weight and
+// expiration, in the same (graph, expirations) shape as
+// NeighborWithExpirationsContext. Edge weights carry the SAME weighting
+// transform the sweep used, consistent with the BFS family: WeightingRaw
+// (the default) returns the verbatim stored weight, so the structure-
+// preserving view is unchanged; WeightingTFIDF/WeightingBM25 return the
+// re-scored weight — which is also what a subsequent Reduction reduces
+// over, so the tree honours the weighting. An unknown seed yields an empty
+// graph.
 func (c *GraphCache[S, T]) LocalCommunityContext(ctx context.Context, seed S, maxSize int, alpha, epsilon float64, weighting EdgeWeighting, keep func(S) bool) (*graph.Graph[S, T], map[S]map[S]time.Time, error) {
 	if alpha <= 0 || alpha >= 1 {
 		alpha = DefaultPPRAlpha
@@ -774,9 +779,12 @@ func (c *GraphCache[S, T]) LocalCommunityContext(ctx context.Context, seed S, ma
 	}
 
 	// Materialize the induced subgraph on the selected set: live member
-	// values, and every live edge among members with its actual stored
-	// weight and expiration — the same response shape as
-	// NeighborWithExpirationsContext.
+	// values, and every live edge among members with its expiration and its
+	// weighting-transformed weight (WeightingRaw = the verbatim stored
+	// weight) — the same response shape, and the same scoreEdge transform,
+	// the BFS family uses. Applying the transform here keeps the returned
+	// weights consistent with the sweep's own d_w and makes any subsequent
+	// Reduction reduce over the weighted graph.
 	inS := make(map[S]bool, len(selected))
 	for _, v := range selected {
 		inS[v] = true
@@ -795,6 +803,9 @@ func (c *GraphCache[S, T]) LocalCommunityContext(ctx context.Context, seed S, ma
 		if !ok {
 			continue
 		}
+		// docLen is v's full out-degree — the BM25 document length, read the
+		// same way the sweep's adjacency pass and the BFS walk read it.
+		docLen := len(heads)
 		row := make(map[S]float32)
 		expRow := make(map[S]time.Time)
 		for headID, w := range heads {
@@ -809,7 +820,11 @@ func (c *GraphCache[S, T]) LocalCommunityContext(ctx context.Context, seed S, ma
 			if !nonZero {
 				continue
 			}
-			row[head] = sum
+			a := c.scoreEdge(weighting, sum, headID, docLen, bm25N, bm25AvgLen)
+			if a <= 0 {
+				continue
+			}
+			row[head] = a
 			expRow[head] = latest
 		}
 		if len(row) > 0 {

--- a/core/graphcache/traversal_test.go
+++ b/core/graphcache/traversal_test.go
@@ -782,4 +782,66 @@ func TestGraphCache_LocalCommunity(t *testing.T) {
 			t.Fatal("cancelled ctx must surface an error")
 		}
 	})
+
+	t.Run("output edge weights carry the weighting transform (#966)", func(t *testing.T) {
+		// Two cliques joined by a weak bridge (as in the first sub-test) so
+		// the seed community is the FULL seed clique A. Every member of A
+		// also receives the SAME number of external in-edges, so TF-IDF/BM25
+		// down-weight the intra-A edges by an identical factor: membership
+		// stays A under all three weightings, but the RETURNED weights
+		// differ. Raw = verbatim 1; TF-IDF/BM25 = the re-scored value. Pins
+		// that the induced-subgraph output is no longer weighting-neutral —
+		// it applies the same scoreEdge transform the BFS family does, so a
+		// subsequent Reduction honours weighting.
+		A := []string{"s", "a", "b", "c"}
+		B := []string{"x", "y", "z", "w"}
+		mk := func() *GraphCache[string, string] {
+			c := NewGraphCache[string, string](time.Hour)
+			buildClique(c, A, 1.0)
+			buildClique(c, B, 1.0)
+			c.PutEdgeWithExpiration("s", "x", 0.05, exp) // weak bridge each way
+			c.PutEdgeWithExpiration("x", "s", 0.05, exp)
+			for _, m := range A {
+				for i := 0; i < 4; i++ {
+					ext := fmt.Sprintf("%s_ext%d", m, i)
+					c.PutVertexWithExpiration(ext, "v", exp)
+					c.PutEdgeWithExpiration(ext, m, 1.0, exp) // in-edge only: skews docFreq, never joins the community
+				}
+			}
+			return c
+		}
+
+		raw, _, err := mk().LocalCommunityContext(context.Background(), "s", 0, 0.15, 1e-6, WeightingRaw, nil)
+		if err != nil {
+			t.Fatalf("Raw: %v", err)
+		}
+		wr, ok := raw.Edges["a"]["b"]
+		if !ok || wr != 1.0 {
+			t.Fatalf("Raw induced edge a->b = (%v,%v), want (1,true) — verbatim stored weight; community=%v", wr, ok, raw.Vertices)
+		}
+
+		tfidf, _, err := mk().LocalCommunityContext(context.Background(), "s", 0, 0.15, 1e-6, WeightingTFIDF, nil)
+		if err != nil {
+			t.Fatalf("TFIDF: %v", err)
+		}
+		wt, ok := tfidf.Edges["a"]["b"]
+		if !ok {
+			t.Fatalf("TFIDF induced edge a->b missing (community=%v)", tfidf.Vertices)
+		}
+		if !(wt > 0 && wt < wr) {
+			t.Errorf("TFIDF edge a->b = %v, want 0 < w < raw(%v) — idf must down-weight the popular head", wt, wr)
+		}
+
+		bm25, _, err := mk().LocalCommunityContext(context.Background(), "s", 0, 0.15, 1e-6, WeightingBM25, nil)
+		if err != nil {
+			t.Fatalf("BM25: %v", err)
+		}
+		wb, ok := bm25.Edges["a"]["b"]
+		if !ok {
+			t.Fatalf("BM25 induced edge a->b missing (community=%v)", bm25.Vertices)
+		}
+		if wb == wr {
+			t.Errorf("BM25 edge a->b = %v, want != raw(%v) — transform not applied", wb, wr)
+		}
+	})
 }

--- a/pb/graph/v1/graph.pb.go
+++ b/pb/graph/v1/graph.pb.go
@@ -1040,8 +1040,11 @@ func (x *BfsParams) GetReduction() Reduction {
 // p(v)/deg(v) and takes the prefix minimising directed weighted
 // conductance. Unlike the PPR relevance star, the response preserves
 // structure: it is the INDUCED SUBGRAPH on the selected members — the real
-// live edges among them with actual stored weights and expirations, in the
-// same response shape as the BFS family.
+// live edges among them with their expirations and weighting-transformed
+// weights (weighting RAW/UNSPECIFIED = the verbatim stored weight), in the
+// same response shape as the BFS family. Because the returned weights carry
+// the weighting transform, a reduction over the community honours weighting
+// too.
 type LocalCommunityParams struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// max_size is an UPPER BOUND on community size — NOT an exact count. The

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -142,8 +142,11 @@ message BfsParams {
 // p(v)/deg(v) and takes the prefix minimising directed weighted
 // conductance. Unlike the PPR relevance star, the response preserves
 // structure: it is the INDUCED SUBGRAPH on the selected members — the real
-// live edges among them with actual stored weights and expirations, in the
-// same response shape as the BFS family.
+// live edges among them with their expirations and weighting-transformed
+// weights (weighting RAW/UNSPECIFIED = the verbatim stored weight), in the
+// same response shape as the BFS family. Because the returned weights carry
+// the weighting transform, a reduction over the community honours weighting
+// too.
 message LocalCommunityParams {
   // max_size is an UPPER BOUND on community size — NOT an exact count. The
   // sweep stops at the conductance minimum, which may come before max_size.

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -853,7 +853,8 @@ type PPROpts struct {
 // around the seed (#845): PageRank-Nibble — the PPR forward-push followed
 // by a sweep cut. Unlike WithPPR's relevance star, the response preserves
 // structure: it is the induced subgraph on the selected members, with
-// actual stored edge weights and expirations.
+// weighting-transformed edge weights (WeightingRaw, the default, returns
+// the verbatim stored weight) and expirations.
 type LocalCommunityOpts struct {
 	// MaxSize is an UPPER BOUND on community size — not an exact count.
 	// The sweep stops at the conductance minimum, which may come earlier.

--- a/sdks/node/src/gen/graph/v1/graph_pb.ts
+++ b/sdks/node/src/gen/graph/v1/graph_pb.ts
@@ -290,8 +290,11 @@ export const BfsParamsSchema: GenMessage<BfsParams> = /*@__PURE__*/
  * p(v)/deg(v) and takes the prefix minimising directed weighted
  * conductance. Unlike the PPR relevance star, the response preserves
  * structure: it is the INDUCED SUBGRAPH on the selected members — the real
- * live edges among them with actual stored weights and expirations, in the
- * same response shape as the BFS family.
+ * live edges among them with their expirations and weighting-transformed
+ * weights (weighting RAW/UNSPECIFIED = the verbatim stored weight), in the
+ * same response shape as the BFS family. Because the returned weights carry
+ * the weighting transform, a reduction over the community honours weighting
+ * too.
  *
  * @generated from message graph.v1.LocalCommunityParams
  */

--- a/sdks/node/src/options.ts
+++ b/sdks/node/src/options.ts
@@ -58,7 +58,8 @@ export interface PprOptions {
  * Local-community-family knobs (#845): PageRank-Nibble — the PPR push
  * followed by a conductance sweep cut. Unlike the PPR relevance star the
  * response preserves structure: the induced subgraph on the selected
- * members with actual stored edge weights and expirations.
+ * members, with weighting-transformed edge weights (RAW/UNSPECIFIED = the
+ * verbatim stored weight) and expirations.
  */
 export interface LocalCommunityOptions {
   /**

--- a/server/service/backend.go
+++ b/server/service/backend.go
@@ -127,10 +127,11 @@ type Backend interface {
 	// community around seed (#845): the shared PPR forward-push followed by
 	// a sweep cut (PageRank-Nibble). maxSize is an UPPER BOUND (0 =
 	// unbounded); alpha/epsilon follow the PPR defaults; weighting steers
-	// the walk and the sweep only — the returned graph is the INDUCED
-	// SUBGRAPH on the selected members with actual stored edge weights and
-	// expirations, in the same (graph, expirations) shape as the BFS path.
-	// keep scopes both the walk and the community (seed exempt).
+	// the walk and the sweep AND is applied to the returned edge weights
+	// (WeightingRaw = the verbatim stored weight) — the returned graph is
+	// the INDUCED SUBGRAPH on the selected members with those weights and
+	// their expirations, in the same (graph, expirations) shape as the BFS
+	// path. keep scopes both the walk and the community (seed exempt).
 	LocalCommunityContext(
 		ctx context.Context,
 		seed string,

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -548,11 +548,13 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 		// Local community extraction (#845): PageRank-Nibble sweep cut over
 		// the shared push. Membership is decided by conductance (max_size is
 		// an upper bound, not a count) and the result is the induced
-		// subgraph — real edges with real weights and expirations, unlike
-		// the PPR star. An optional Reduction renders a tree VIEW rooted at
-		// the seed; sweep prefixes need not be connected, so members
-		// unreachable from the seed within the community stay as ISOLATED
-		// vertices rather than being dropped or wired up artificially.
+		// subgraph — real edges (weighting-transformed weights; RAW = the
+		// verbatim stored weight) with their expirations, unlike the PPR
+		// star. An optional Reduction renders a tree VIEW rooted at the
+		// seed, reducing over those weighting-transformed weights; sweep
+		// prefixes need not be connected, so members unreachable from the
+		// seed within the community stay as ISOLATED vertices rather than
+		// being dropped or wired up artificially.
 		comm := params.Community
 		alpha, epsilon := resolvePPRParams(comm.GetRestartProb(), comm.GetEpsilon())
 		traversalStart := time.Now()

--- a/tests/integration/illuminate_community_weighting_test.go
+++ b/tests/integration/illuminate_community_weighting_test.go
@@ -1,0 +1,128 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// TestIlluminate_CommunityWeightingTransform pins #966 over the real Connect/h2c
+// wire: the LocalCommunity family applies the weighting transform to its
+// returned induced-subgraph edge weights (matching the BFS family), rather than
+// echoing the verbatim stored weight regardless of the weighting axis.
+//
+// Fixture (mirrors the core sub-test): two cliques A={s,a,b,c} and B={x,y,z,w}
+// joined by a WEAK bridge s<->x, so the seed community is exactly the full seed
+// clique A. Every member of A also receives the SAME number of external
+// in-edges, so TF-IDF/BM25 down-weight the intra-A edges by an identical factor
+// — membership stays A under all three weightings, but the RETURNED a->b weight
+// differs: RAW = verbatim 1; TF-IDF/BM25 = the re-scored value.
+func TestIlluminate_CommunityWeightingTransform(t *testing.T) {
+	exp := timestamppb.New(time.Now().Add(time.Hour))
+	c, _ := newRawConnectClient(t, false)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	A := []string{"s", "a", "b", "c"}
+	B := []string{"x", "y", "z", "w"}
+
+	var verts []*pb.Vertex
+	seen := map[string]bool{}
+	addVert := func(k string) {
+		if seen[k] {
+			return
+		}
+		seen[k] = true
+		verts = append(verts, &pb.Vertex{Key: k, Value: &pb.Vertex_String_{String_: k}, Expiration: exp})
+	}
+	for _, k := range A {
+		addVert(k)
+	}
+	for _, k := range B {
+		addVert(k)
+	}
+
+	var edges []*pb.Edge
+	clique := func(members []string, w float32) {
+		for _, u := range members {
+			for _, v := range members {
+				if u != v {
+					edges = append(edges, &pb.Edge{Tail: u, Head: v, Weight: w, Expiration: exp})
+				}
+			}
+		}
+	}
+	clique(A, 1.0)
+	clique(B, 1.0)
+	edges = append(edges,
+		&pb.Edge{Tail: "s", Head: "x", Weight: 0.05, Expiration: exp}, // weak bridge each way
+		&pb.Edge{Tail: "x", Head: "s", Weight: 0.05, Expiration: exp},
+	)
+	// Symmetric external in-edges: skew docFreq of every A member identically so
+	// TF-IDF/BM25 keep membership = A but re-score the intra-A edges.
+	for _, m := range A {
+		for i := 0; i < 4; i++ {
+			ext := fmt.Sprintf("%s_ext%d", m, i)
+			addVert(ext)
+			edges = append(edges, &pb.Edge{Tail: ext, Head: m, Weight: 1.0, Expiration: exp})
+		}
+	}
+
+	if _, err := c.PutVertices(ctx, connect.NewRequest(&pb.PutVerticesRequest{Vertices: verts})); err != nil {
+		t.Fatalf("PutVertices: %v", err)
+	}
+	if _, err := c.PutEdges(ctx, connect.NewRequest(&pb.PutEdgesRequest{Edges: edges})); err != nil {
+		t.Fatalf("PutEdges: %v", err)
+	}
+
+	community := func(t *testing.T, w pb.Weighting) map[string]map[string]float32 {
+		t.Helper()
+		resp, err := c.Illuminate(ctx, connect.NewRequest(&pb.IlluminateRequest{
+			Seed:      "s",
+			Weighting: w,
+			Params: &pb.IlluminateRequest_Community{Community: &pb.LocalCommunityParams{
+				MaxSize: 0, RestartProb: 0.15, Epsilon: 1e-6,
+			}},
+		}))
+		if err != nil {
+			t.Fatalf("Illuminate(%v): %v", w, err)
+		}
+		out := map[string]map[string]float32{}
+		for _, e := range resp.Msg.GetGraph().GetEdges() {
+			if out[e.GetTail()] == nil {
+				out[e.GetTail()] = map[string]float32{}
+			}
+			out[e.GetTail()][e.GetHead()] = e.GetWeight()
+		}
+		return out
+	}
+
+	rawEdges := community(t, pb.Weighting_WEIGHTING_RAW)
+	wr, ok := rawEdges["a"]["b"]
+	if !ok || wr != 1.0 {
+		t.Fatalf("RAW induced edge a->b = (%v,%v), want (1,true) — verbatim stored weight", wr, ok)
+	}
+
+	tfidfEdges := community(t, pb.Weighting_WEIGHTING_TFIDF)
+	wt, ok := tfidfEdges["a"]["b"]
+	if !ok {
+		t.Fatalf("TFIDF induced edge a->b missing — membership shifted off A")
+	}
+	if !(wt > 0 && wt < wr) {
+		t.Errorf("TFIDF edge a->b = %v, want 0 < w < raw(%v) — idf must down-weight the popular head", wt, wr)
+	}
+
+	bm25Edges := community(t, pb.Weighting_WEIGHTING_BM25)
+	wb, ok := bm25Edges["a"]["b"]
+	if !ok {
+		t.Fatalf("BM25 induced edge a->b missing — membership shifted off A")
+	}
+	if wb == wr {
+		t.Errorf("BM25 edge a->b = %v, want != raw(%v) — transform not applied over the wire", wb, wr)
+	}
+}


### PR DESCRIPTION
## Summary

`LocalCommunity` returned the **verbatim stored weight** for every induced-subgraph edge regardless of the `weighting` axis, so `weighting` was a silent no-op for community output — and, transitively, for the community's MST/SPT **reduction**, which reduces over whatever weights the returned graph carries. BFS already returns weighting-transformed weights via `scoreEdge`, so the **same seed** produced varied weights under BFS+BM25 but all-`1` weights under LocalCommunity+BM25 (reported in the Admin UI and CLI).

This was a real design inconsistency, not a data-collapse bug: the community materialization stored the raw `sum` while the sweep that *defines* the community already scored edges through `scoreEdge` + an `a <= 0` drop.

## Fix

Materialize the induced subgraph through the **same `scoreEdge` transform the sweep's own adjacency pass uses** (identical `docLen`/`bm25N`/`bm25AvgLen`, and the same `a <= 0` drop):

- **`WeightingRaw`** (the default) → verbatim stored weight, so the structure-preserving view is **unchanged** (existing tests pass untouched).
- **`WeightingTFIDF` / `WeightingBM25`** → re-scored weight, matching the BFS family — and any subsequent `Reduction` now reduces over the weighted graph, so the tree honours `weighting` automatically.

No server logic change was needed — `coreWeighting` was already threaded into `LocalCommunityContext`; only the output loop and doc comments changed.

## Docs

Updated the contract statements that claimed "actual stored weights": `proto/graph/v1/graph.proto` (+ regenerated `pb/` and `sdks/node/src/gen`), `sdks/go/client.go`, `sdks/node/src/options.ts`, `server/service/backend.go`, and `server/service/service.go`.

## Tests

- **Core** (`core/graphcache/traversal_test.go`): new sub-test on `TestGraphCache_LocalCommunity` — two cliques + weak bridge + symmetric doc-frequency skew so membership stays constant while the returned `a→b` weight differs: RAW `==1`, TFIDF `∈(0,1)`, BM25 `!=1`.
- **Integration** (`tests/integration/illuminate_community_weighting_test.go`): the same contract over the real Connect/h2c wire — community+RAW returns verbatim weights; community+TFIDF/BM25 return the transformed weights.

## Quality gate

- `gofmt -l .` clean; `go generate ./...` clean (comment-only codegen diff, committed).
- `go test ./...` green from root **and** every submodule (`core`, `server` + `go vet`, `sdks/go`, `pb`, `mcp`).
- Node SDK: `codegen` clean, `lint` / `format:check` / `typecheck` / `test` / `build` all green.

Closes #966