### PR TITLE
chore(release): bump core module pin to v0.17.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.5.0
-	github.com/anaregdesign/lantern/core v0.16.0
+	github.com/anaregdesign/lantern/core v0.17.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.11.0
 	github.com/anaregdesign/lantern/sdks/go v0.22.0


### PR DESCRIPTION
Pins the root module to `core/v0.17.0` — the LocalCommunity weighting-transform fix (#966, shipped in #967) — ahead of the root `v0.31.0` release tag.

The `replace github.com/anaregdesign/lantern/core => ./core` directive keeps in-tree/CI builds on the local source; this bump lifts the `require` floor so external `go get` consumers and the release build resolve the freshly-tagged `core/v0.17.0`.

go.sum is unchanged (the replace redirects to the local path, so there is no module download to hash). Build verified locally.