### PR TITLE
fix(cli): close family verb grammar drift

### DIFF
--- a/.github/skills/lantern-ops/SKILL.md
+++ b/.github/skills/lantern-ops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lantern-ops
-description: "Operate Lantern data through the `lantern-cli` CLI — read, write, delete, scan, count, bulk-load, back up/restore, and graph-walk vertices and edges from the command line. Use whenever the request involves manipulating data in a running Lantern server (get/put/delete a vertex or edge, prefix scan or count, bulk NDJSON load, whole-graph dump/restore backup, prefix delete, or an illuminate graph walk), or driving Lantern from an interactive/agentic system. Do NOT use this skill for editing Lantern's own Go source, regenerating protobuf/wire code, server deployment/IaC, or the MCP working-context tools."
+description: "Operate Lantern data through the `lantern-cli` CLI — read, write, delete, scan, count, bulk-load, back up/restore, and graph-walk vertices and edges from the command line. Use whenever the request involves manipulating data in a running Lantern server (get/put/delete a vertex or edge, prefix scan or count, bulk NDJSON load, whole-graph dump/restore backup, prefix delete, or a bfs/pagerank/community graph walk), or driving Lantern from an interactive/agentic system. Do NOT use this skill for editing Lantern's own Go source, regenerating protobuf/wire code, server deployment/IaC, or the MCP working-context tools."
 ---
 
 # Lantern Ops — CLI command reference
@@ -71,7 +71,9 @@ Examples worth reading before first use:
 ```shell
 lantern-cli put --help               # vertex/edge writes: value typing (type=) + ttl_seconds
 lantern-cli add --help               # additive vs idempotent edge write semantics
-lantern-cli illuminate --help        # the algorithm × reduction × objective × weighting axes
+lantern-cli bfs --help               # breadth-first family knobs: step/fan-out + reduction/objective/weighting
+lantern-cli pagerank --help          # Personalized PageRank knobs: top-n + restart-prob/epsilon
+lantern-cli community --help         # local-community knobs: max-size + reduction/objective/weighting
 lantern-cli delete-prefix --help     # the destructive-delete safety gate
 ```
 
@@ -312,33 +314,28 @@ lantern-cli scan edges user: 100 head=post:
 lantern-cli scan edges "" head=post: all=true > posts.json
 ```
 
-## `illuminate <seed>` — graph walk
+## Graph walks: `bfs`, `pagerank`, `community`
 
-Run a bounded breadth-first walk from `<seed>` and emit the visited subgraph as
-indented JSON `{vertices: {...}, edges: {tail: {head: weight}}}`. Read-only and
-idempotent. Flags:
+Run a read-only graph walk from `<seed>` and emit the visited subgraph as
+indented JSON `{vertices: {...}, edges: {tail: {head: weight}}}`. The CLI has
+one verb per traversal family; each verb also accepts the REPL positional
+grammar when more than the seed is supplied.
 
-| Flag | Default | Meaning |
+| Verb | Main knobs | Meaning |
 |---|---|---|
-| `--step <uint32>` | `1` | max walk depth from the seed. BFS-family only — ignored (has no meaning) under `--algorithm ppr` |
-| `--k <uint32>` | `10` | max neighbours visited per node. On the wire (#846) this maps to `bfs.fan_out` (per-hop top-k) for `none`/`mst`/`spt`, or `ppr.top_n` (total ranked vertices) for `ppr` |
-| `--algorithm <mode>` | `none` | traversal family + reduction. On the wire (#846) `none`/`mst`/`spt` select the BFS family (`mst`/`spt` are its post-traversal tree *reductions*), `ppr` selects the Personalized PageRank family (seed-anchored ranking via ACL forward-push), and `community` (#845) selects conductance-based local community extraction (PageRank-Nibble sweep cut over the PPR push; `--k` is then an UPPER bound — the sweep may stop earlier — and the result is the real induced subgraph, not a relevance star). The CLI keeps the single friendly flag; the typed split is server-side |
-| `--objective <dir>` | `max` | optimisation direction; governs **both** per-hop top-k pruning and the reduction: `max` (largest-weight wins; weight = relevance) or `min` (smallest-weight wins; weight = cost). Ignored by `--algorithm ppr`, which always ranks by PPR mass |
-| `--weighting <mode>` | `raw` | edge-weight transform before the walk: `raw`, `tfidf` (re-score by TF-IDF over per-vertex out-edge distribution), or `bm25` (re-score by Okapi BM25, k1=1.2/b=0.75, over the same distribution — IDF saturation + out-degree length-normalisation, consistent with full-text search) |
-| `--prefix <string>` | — | restrict the walk **frontier** to vertices with this key prefix (case-sensitive); the seed is always kept as anchor. Applied server-side before top-k and any reduction, so `--prefix` + `mst`/`spt` yields a tree over the prefix-induced subgraph, not a path in the full graph |
-| `--restart-prob <float>` | `0` (server `α=0.15`) | **`ppr` only.** Teleport/restart probability α. Higher α keeps the ranking closer to the seed; `0` defers to the server default |
-| `--epsilon <float>` | `0` (server `ε=1e-4`) | **`ppr` only.** Forward-push residual threshold ε. Smaller ε pushes more nodes (higher recall, more work); `0` defers to the server default |
+| `bfs <seed>` | `--step`, `--fan-out`, `--reduction`, `--objective`, `--weighting`, `--prefix` | Greedy per-hop top-k breadth-first walk. `reduction=mst|spt` renders a tree view; `objective=min|max` controls both pruning and reduction direction. |
+| `pagerank <seed>` | `--top-n`, `--restart-prob`, `--epsilon`, `--weighting`, `--prefix` | Personalized PageRank relevance star. No `reduction` or `objective` knob; `restart_prob` must be in `(0,1)` when supplied and `epsilon` must be positive when supplied. |
+| `community <seed>` | `--max-size`, `--restart-prob`, `--epsilon`, `--reduction`, `--objective`, `--weighting`, `--prefix` | Conductance-cut local community. `max_size=0` lets the sweep decide; optional tree reduction renders a backbone view. |
 
 ```shell
-lantern-cli illuminate alice                                   # raw 1-hop, top-10 by weight
-lantern-cli illuminate alice --step 2 --k 5 --weighting tfidf  # 2-hop, TF-IDF re-rank
-lantern-cli illuminate alice --step 2 --k 5 --weighting bm25   # 2-hop, Okapi BM25 re-rank
-lantern-cli illuminate alice --step 3 --k 20 --algorithm mst --objective min  # min-weight spanning tree
-lantern-cli illuminate alice --step 3 --k 20 --algorithm spt --objective max  # relevance-weighted SPT
-lantern-cli illuminate alice --step 2 --k 8 --algorithm ppr                    # PPR neighbourhood, server-default locality
-lantern-cli illuminate alice --step 2 --k 8 --algorithm ppr --restart-prob 0.25  # tighter, more seed-local PPR
-lantern-cli illuminate alice --k 30 --algorithm community                        # conductance-cut community (k = upper bound)
-lantern-cli illuminate alice --step 2 --k 5 --prefix users/    # frontier restricted to users/
+lantern-cli bfs alice                                      # depth-5, per-hop top-3 defaults
+lantern-cli bfs alice --step 2 --fan-out 5 --weighting tfidf
+lantern-cli bfs alice 3 20 reduction=mst objective=min     # same grammar as the REPL
+lantern-cli bfs alice --step 2 --fan-out 5 --prefix users/ # frontier restricted to users/
+lantern-cli pagerank alice --top-n 8                       # PPR neighbourhood, server-default locality
+lantern-cli pagerank alice 8 restart_prob=0.25 epsilon=1e-4
+lantern-cli community alice --max-size 30                  # conductance-cut community
+lantern-cli community alice 30 reduction=mst objective=min # community as a spanning-tree backbone
 ```
 
 ## `bulk` — NDJSON bulk load
@@ -418,7 +415,7 @@ lantern-cli get edge userA itemX | jq .weight     # → 2
 
 # Walk a relevance graph against a non-default replica over TLS
 lantern-cli --tls --tls-ca ./ca.pem -H lantern.example.com -p 443 \
-  illuminate userA --step 2 --k 10 --weighting tfidf
+  bfs userA --step 2 --fan-out 10 --weighting tfidf
 ```
 
 ## Gotchas checklist

--- a/.github/workflows/_verify.yml
+++ b/.github/workflows/_verify.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           check-latest: true
 
       - name: Verify formatting

--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           check-latest: true
       - name: Install bench prerequisites (ghz, yq)
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Initialize CodeQL

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           check-latest: true
       - name: Install bench prerequisites (ghz, yq)
         run: |
@@ -178,7 +178,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           check-latest: true
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           check-latest: true
 
       - name: Verify formatting
@@ -143,7 +143,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           check-latest: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -161,7 +161,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           check-latest: true
       - uses: bufbuild/buf-setup-action@v1
         with:
@@ -191,7 +191,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           check-latest: true
       - name: Install govulncheck
         # Pinned to v1.3.0: govulncheck@latest (v1.4.0) builds against
@@ -217,7 +217,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           check-latest: true
       # Active-mutation smoke run for every `func Fuzz*` target. The Build &
       # Test job already replays the committed seed corpora under -race (Go

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 *edges* connect them. So alongside "get me this value", your request-path
 code can ask, in a single millisecond-scale RPC:
 
-- *"What's near this key right now?"* — `illuminate` walks the live graph
-  and returns a subgraph already shaped for your use case (k-NN, spanning
-  tree, shortest paths, PageRank, community).
+- *"What's near this key right now?"* — `bfs`, `pagerank`, and `community`
+  walk the live graph and return a subgraph already shaped for your use case
+  (k-NN, spanning tree, shortest paths, PageRank, community).
 - *"How strongly are these two related at this moment?"* — edge weights are
   live sums of TTL'd contributions, so relationship strength decays on its
   own as events age out.
@@ -32,7 +32,7 @@ record.
 > put vertex user:42 "alice"
 > put vertex item:7  "lamp"
 > add edge user:42 item:7 1.0 1800     # each event appends a decaying contribution
-> illuminate user:42 2 10              # 2 hops out, top-10 per hop — one RPC
+> bfs user:42 2 10                     # 2 hops out, top-10 per hop — one RPC
 { "vertices": { ... }, "edges": { ... } }
 ```
 
@@ -104,11 +104,11 @@ rest of Lantern simple and fast:
 
 - **The classic algorithms apply directly.** Spanning trees, shortest
   paths, PageRank, community detection — graph theory defines them on
-  exactly this object, a weighted directed graph. `illuminate` runs them
-  natively over every edge, with no "which relationship types does this
-  walk follow?" configuration and no schema the server has to know about;
-  a property graph has to be flattened down to weights before any of that
-  theory applies.
+  exactly this object, a weighted directed graph. The traversal RPC runs
+  them natively over every edge, with no "which relationship types does
+  this walk follow?" configuration and no schema the server has to know
+  about; a property graph has to be flattened down to weights before any
+  of that theory applies.
 - **Every event can pile onto the same edge.** The additive, decaying
   weight model works because merging contributions is just addition —
   there are no per-type aggregation rules to define.
@@ -171,13 +171,16 @@ so ingesting an event stream is just a stream of edge writes.
 
 ### Graph queries as single RPCs
 
-One `Illuminate` call walks the live graph from a seed and returns exactly
-the shape you asked for. Three orthogonal axes select it:
+One `Illuminate` RPC walks the live graph from a seed and returns exactly
+the shape you asked for. The CLI exposes that RPC as three family verbs —
+`bfs`, `pagerank`, and `community` — with orthogonal knobs for tree rendering,
+optimization direction, and weighting:
 
 | Axis | Options | What it picks |
 |---|---|---|
-| `algorithm` | `none` (default) / `mst` / `spt` / `ppr` / `community` | Raw k-NN subgraph, spanning tree, shortest-path tree, Personalized PageRank neighbourhood, or the seed's natural community (conductance-cut, returned as a real induced subgraph) |
-| `objective` | `max` (default) / `min` | Keep strongest edges vs cheapest edges — the direction of both the per-hop top-k prune and the tree reduction (ignored by `ppr`, which ranks by mass) |
+| family verb | `bfs` / `pagerank` / `community` | Greedy per-hop top-k neighbourhood, Personalized PageRank relevance star, or the seed's natural community (conductance-cut, returned as a real induced subgraph) |
+| `reduction` | `none` (default) / `mst` / `spt` | Return the raw family result, or render the `bfs` / `community` result as a spanning-tree or shortest-path-tree view rooted at the seed |
+| `objective` | `max` (default) / `min` | Keep strongest edges vs cheapest edges — the direction of both the `bfs` per-hop top-k prune and any tree reduction (ignored by `pagerank`, which ranks by mass) |
 | `weighting` | `raw` (default) / `tfidf` / `bm25` | Edge-weight transform applied before the walk — TF-IDF and BM25 damp hub vertices like "popular" items |
 
 Seeing is believing. Say the store holds this graph (labels are weights):
@@ -192,7 +195,7 @@ graph LR
     c -- 4 --> f((f))
 ```
 
-`illuminate a 2 2 reduction=spt objective=max` treats heavy edges as cheap
+`bfs a 2 2 reduction=spt objective=max` treats heavy edges as cheap
 (cost = 1/weight), so one RPC hands back the **strongest-relationship
 tree** — no client-side post-processing:
 
@@ -219,21 +222,20 @@ graph LR
 A few more combinations and what they buy you:
 
 ```text
-illuminate user:42 2 10                              # raw 2-hop neighbourhood
-illuminate user:42 3 8 reduction=spt objective=max   # most-relevant path tree (BFS)
-illuminate user:42 3 8 reduction=mst objective=min   # clustering / dedup backbone (BFS)
-illuminate user:42 2 10 algorithm=ppr                # PageRank-ranked neighbourhood
-illuminate user:42 2 10 algorithm=community          # the seed's natural community
-illuminate user:42 2 10 algorithm=community reduction=mst objective=min
-                                                     # …that community, as a spanning-tree backbone
-illuminate user:42 2 10 weighting=tfidf              # suppress hub items
+bfs user:42 2 10                                      # raw 2-hop neighbourhood
+bfs user:42 3 8 reduction=spt objective=max           # most-relevant path tree
+bfs user:42 3 8 reduction=mst objective=min           # clustering / dedup backbone
+pagerank user:42 10                                   # PageRank-ranked neighbourhood
+community user:42 30                                  # the seed's natural community
+community user:42 30 reduction=mst objective=min      # …as a spanning-tree backbone
+bfs user:42 2 10 weighting=tfidf                      # suppress hub items
 ```
 
-The `algorithm` axis picks the traversal **family** (`bfs` default, `ppr`,
-`community`) and the orthogonal `reduction` axis (`none` default, `mst`, `spt`)
-renders the `bfs`/`community` result as a tree rooted at the seed — so a local
-community can be handed back as its own minimum-spanning-tree backbone in one
-RPC. `reduction` is ignored for `ppr`, which returns a ranked star.
+The family verb picks the traversal (`bfs`, `pagerank`, `community`) and the
+orthogonal `reduction` axis (`none` default, `mst`, `spt`) renders the
+`bfs`/`community` result as a tree rooted at the seed — so a local community
+can be handed back as its own minimum-spanning-tree backbone in one RPC.
+`reduction` is not accepted by `pagerank`, which returns a ranked star.
 
 PPR takes two locality knobs (`restart_prob`, `epsilon` — higher restart
 keeps the walk closer to the seed; smaller epsilon pushes further for more
@@ -246,7 +248,8 @@ because the bridge is not traversable.
 
 `SearchVertices` runs relevance-ranked (BM25) full-text search over vertex
 *content* — key plus value — as the content-addressed counterpart to prefix
-scans. Ranked hits make natural seeds for a follow-up `illuminate`:
+scans. Ranked hits make natural seeds for a follow-up `bfs`, `pagerank`, or
+`community` walk:
 
 ```shell
 lantern-cli search "rolling update"              # OR-union of the query words
@@ -294,7 +297,7 @@ OK (0.8ms)
 > get edge alice bob                    # live sum of unexpired contributions
 2.000000
 OK (0.6ms)
-> illuminate alice 2 5
+> bfs alice 2 5
 {
         "vertices": { ... },
         "edges":    { ... }
@@ -408,8 +411,8 @@ multiplexes Connect (JSON or proto), gRPC, and gRPC-Web over the same
 **Good fit**
 
 - **Real-time recommenders** — user → item interactions as decaying edges;
-  `illuminate(user, step=2, k=10, weighting=tfidf)` returns a candidate set
-  that already discounts popular items.
+  `bfs user 2 10 weighting=tfidf` returns a candidate set that already
+  discounts popular items.
 - **Session-aware personalization** — a short-TTL session graph layered on a
   long-TTL preference graph in the same store.
 - **Fraud / abuse co-occurrence** — accounts, devices, IPs as vertices;
@@ -419,7 +422,8 @@ multiplexes Connect (JSON or proto), gRPC, and gRPC-Web over the same
 - **Online graph features for ML** — neighborhood aggregations served at
   request time instead of from a batch feature store.
 - **Short-lived shared context for agents / sessions** — entity-relation
-  state scoped to a session TTL, queried with `illuminate`.
+  state scoped to a session TTL, queried with `bfs`, `pagerank`, or
+  `community`.
 
 **Not a good fit**
 
@@ -428,8 +432,8 @@ multiplexes Connect (JSON or proto), gRPC, and gRPC-Web over the same
   is built in, but there is no WAL). Replay your event stream on boot, or
   put a queue in front.
 - **Whole-graph analytics** — global PageRank, community detection across
-  billions of edges. (Seed-local PPR and community via `illuminate` *are*
-  supported online queries.)
+  billions of edges. (Seed-local PPR and community *are* supported online
+  queries.)
 - **Working sets beyond one process's RAM.** Built-in leaderless
   replication gives you HA — every replica holds the full graph — but there
   is no sharding.
@@ -549,9 +553,13 @@ scan   edges    <tail-prefix> [limit] [head=<prefix>] [all=true]
 count  vertices <prefix>
 delete-prefix vertices <prefix> [limit=<int>] [confirm=yes|dry_run=true]
 keys   <prefix> [limit]
-illuminate <seed> <step> <k> [algorithm=bfs|ppr|community] [reduction=none|mst|spt] [objective=min|max] \
-           [weighting=raw|tfidf|bm25] [prefix=<string>] \
-           [restart_prob=<float>] [epsilon=<float>]
+bfs        <seed> [step] [fan_out] [reduction=none|mst|spt] [objective=min|max] \
+           [weighting=raw|tfidf|bm25] [prefix=<string>]
+pagerank   <seed> [top_n] [restart_prob=<float>] [epsilon=<float>] \
+           [weighting=raw|tfidf|bm25] [prefix=<string>]
+community  <seed> [max_size] [restart_prob=<float>] [epsilon=<float>] \
+           [reduction=none|mst|spt] [objective=min|max] \
+           [weighting=raw|tfidf|bm25] [prefix=<string>]
 help
 exit
 ```
@@ -597,8 +605,8 @@ cd deploy/compose
 docker compose up -d --pull always
 ```
 
-Then open **<http://localhost:8080>** — the Admin loads ready to
-`illuminate`, browse, search, and run ops against the live cluster. The
+Then open **<http://localhost:8080>** — the Admin loads ready to explore,
+browse, search, and run ops against the live cluster. The
 replicas pin host ports `6380`–`6382` (the Admin's **Gateway** button picks
 which one to hit); Prometheus scrapes them all on `:9091`. Details and load
 balancing options: [deploy/compose/README.md](deploy/compose/README.md).

--- a/admin/app/lib/cli/verbs.test.ts
+++ b/admin/app/lib/cli/verbs.test.ts
@@ -338,6 +338,15 @@ describe("parseBfs prefix= kwarg (#606 / #975)", () => {
   test("rejects an explicit empty prefix= value", () => {
     expect(parseBfs(["alice", "2", "5", "prefix="]).ok).toBe(false);
   });
+
+  test("rejects non-positive step and fan_out values (#980)", () => {
+    expect(parseBfs(["alice", "0"]).ok).toBe(false);
+    expect(parseBfs(["alice", "-1"]).ok).toBe(false);
+    expect(parseBfs(["alice", "1", "0"]).ok).toBe(false);
+    expect(parseBfs(["alice", "1", "-2"]).ok).toBe(false);
+    expect(parseBfs(["alice", "step=0"]).ok).toBe(false);
+    expect(parseBfs(["alice", "fan_out=0"]).ok).toBe(false);
+  });
 });
 
 describe("parsePagerank knobs (#801 / #975)", () => {
@@ -377,6 +386,21 @@ describe("parsePagerank knobs (#801 / #975)", () => {
 
   test("rejects a non-numeric epsilon value", () => {
     expect(parsePagerank(["alice", "5", "epsilon=tiny"]).ok).toBe(false);
+  });
+
+  test("accepts top_n=0 but rejects negative top_n (#980)", () => {
+    expect(pagerank(["alice", "0"]).topN).toBe(0);
+    expect(pagerank(["alice", "top_n=0"]).topN).toBe(0);
+    expect(parsePagerank(["alice", "-1"]).ok).toBe(false);
+    expect(parsePagerank(["alice", "top_n=-1"]).ok).toBe(false);
+  });
+
+  test("rejects explicit restart_prob outside (0,1) and epsilon <= 0 (#980)", () => {
+    expect(parsePagerank(["alice", "restart_prob=0"]).ok).toBe(false);
+    expect(parsePagerank(["alice", "restart_prob=1"]).ok).toBe(false);
+    expect(parsePagerank(["alice", "restart_prob=-0.1"]).ok).toBe(false);
+    expect(parsePagerank(["alice", "epsilon=0"]).ok).toBe(false);
+    expect(parsePagerank(["alice", "epsilon=-1e-4"]).ok).toBe(false);
   });
 
   test("rejects reduction= / objective= (the relevance star is already a tree)", () => {
@@ -425,6 +449,21 @@ describe("parseCommunity (#845 / #975)", () => {
   test("rejects an unknown kwarg (top_n=) and a second bare positional", () => {
     expect(parseCommunity(["alice", "20", "top_n=5"]).ok).toBe(false);
     expect(parseCommunity(["alice", "20", "30"]).ok).toBe(false);
+  });
+
+  test("accepts max_size=0 but rejects negative max_size (#980)", () => {
+    expect(community(["alice", "0"]).maxSize).toBe(0);
+    expect(community(["alice", "max_size=0"]).maxSize).toBe(0);
+    expect(parseCommunity(["alice", "-1"]).ok).toBe(false);
+    expect(parseCommunity(["alice", "max_size=-1"]).ok).toBe(false);
+  });
+
+  test("rejects explicit restart_prob outside (0,1) and epsilon <= 0 (#980)", () => {
+    expect(parseCommunity(["alice", "restart_prob=0"]).ok).toBe(false);
+    expect(parseCommunity(["alice", "restart_prob=1"]).ok).toBe(false);
+    expect(parseCommunity(["alice", "restart_prob=-0.1"]).ok).toBe(false);
+    expect(parseCommunity(["alice", "epsilon=0"]).ok).toBe(false);
+    expect(parseCommunity(["alice", "epsilon=-1e-4"]).ok).toBe(false);
   });
 });
 

--- a/admin/app/lib/cli/verbs.ts
+++ b/admin/app/lib/cli/verbs.ts
@@ -474,11 +474,11 @@ export function parseBfs(rest: string[]): ParseResult {
       const value = tok.slice(eq + 1);
       const lvalue = value.toLowerCase();
       if (key === "step") {
-        const n = parseInt10(value);
+        const n = parsePositiveFamilyInt(value);
         if (n === null) return { ok: false, usage };
         step = n;
       } else if (key === "fan_out") {
-        const n = parseInt10(value);
+        const n = parsePositiveFamilyInt(value);
         if (n === null) return { ok: false, usage };
         fanOut = n;
       } else if (key === "reduction") {
@@ -502,11 +502,11 @@ export function parseBfs(rest: string[]): ParseResult {
       continue;
     }
     if (pos === 0) {
-      const n = parseInt10(tok);
+      const n = parsePositiveFamilyInt(tok);
       if (n === null) return { ok: false, usage };
       step = n;
     } else if (pos === 1) {
-      const n = parseInt10(tok);
+      const n = parsePositiveFamilyInt(tok);
       if (n === null) return { ok: false, usage };
       fanOut = n;
     } else {
@@ -555,15 +555,15 @@ export function parsePagerank(rest: string[]): ParseResult {
       const value = tok.slice(eq + 1);
       const lvalue = value.toLowerCase();
       if (key === "top_n") {
-        const n = parseInt10(value);
+        const n = parseNonNegativeFamilyInt(value);
         if (n === null) return { ok: false, usage };
         topN = n;
       } else if (key === "restart_prob") {
-        const f = parseFloatStrict(value);
+        const f = parseFamilyRestartProb(value);
         if (f === null) return { ok: false, usage };
         restartProb = f;
       } else if (key === "epsilon") {
-        const f = parseFloatStrict(value);
+        const f = parsePositiveFamilyFloat(value);
         if (f === null) return { ok: false, usage };
         epsilon = f;
       } else if (key === "weighting") {
@@ -579,7 +579,7 @@ export function parsePagerank(rest: string[]): ParseResult {
       continue;
     }
     if (pos === 0) {
-      const n = parseInt10(tok);
+      const n = parseNonNegativeFamilyInt(tok);
       if (n === null) return { ok: false, usage };
       topN = n;
     } else {
@@ -628,15 +628,15 @@ export function parseCommunity(rest: string[]): ParseResult {
       const value = tok.slice(eq + 1);
       const lvalue = value.toLowerCase();
       if (key === "max_size") {
-        const n = parseInt10(value);
+        const n = parseNonNegativeFamilyInt(value);
         if (n === null) return { ok: false, usage };
         maxSize = n;
       } else if (key === "restart_prob") {
-        const f = parseFloatStrict(value);
+        const f = parseFamilyRestartProb(value);
         if (f === null) return { ok: false, usage };
         restartProb = f;
       } else if (key === "epsilon") {
-        const f = parseFloatStrict(value);
+        const f = parsePositiveFamilyFloat(value);
         if (f === null) return { ok: false, usage };
         epsilon = f;
       } else if (key === "reduction") {
@@ -660,7 +660,7 @@ export function parseCommunity(rest: string[]): ParseResult {
       continue;
     }
     if (pos === 0) {
-      const n = parseInt10(tok);
+      const n = parseNonNegativeFamilyInt(tok);
       if (n === null) return { ok: false, usage };
       maxSize = n;
     } else {
@@ -939,6 +939,26 @@ function parseInt10(s: string): number | null {
   }
   const n = Number.parseInt(s, 10);
   return Number.isFinite(n) ? n : null;
+}
+
+function parsePositiveFamilyInt(s: string): number | null {
+  const n = parseInt10(s);
+  return n !== null && n > 0 ? n : null;
+}
+
+function parseNonNegativeFamilyInt(s: string): number | null {
+  const n = parseInt10(s);
+  return n !== null && n >= 0 ? n : null;
+}
+
+function parseFamilyRestartProb(s: string): number | null {
+  const n = parseFloatStrict(s);
+  return n !== null && n > 0 && n < 1 ? n : null;
+}
+
+function parsePositiveFamilyFloat(s: string): number | null {
+  const n = parseFloatStrict(s);
+  return n !== null && n > 0 ? n : null;
 }
 
 /**

--- a/admin/test/cli-grammar/verbs.json
+++ b/admin/test/cli-grammar/verbs.json
@@ -318,6 +318,10 @@
     { "input": "pagerank", "comment": "#975: pagerank missing seed" },
     { "input": "community", "comment": "#975: community missing seed" },
     { "input": "bfs alice notanint", "comment": "#975: non-numeric step" },
+    { "input": "bfs alice -1", "comment": "#980: negative step" },
+    { "input": "bfs alice 0", "comment": "#980: zero step" },
+    { "input": "bfs alice 1 -2", "comment": "#980: negative fan_out" },
+    { "input": "bfs alice 1 0", "comment": "#980: zero fan_out" },
     {
       "input": "bfs alice 1 2 3",
       "comment": "#975: a third bare positional is rejected"
@@ -367,8 +371,24 @@
       "comment": "#801: non-numeric restart_prob is rejected"
     },
     {
+      "input": "pagerank alice -1",
+      "comment": "#980: negative top_n is rejected"
+    },
+    {
+      "input": "pagerank alice restart_prob=0",
+      "comment": "#980: explicit restart_prob must be in the open interval (0,1)"
+    },
+    {
+      "input": "pagerank alice restart_prob=1",
+      "comment": "#980: restart_prob=1 is outside the open interval"
+    },
+    {
       "input": "pagerank alice epsilon=tiny",
       "comment": "#801: non-numeric epsilon is rejected"
+    },
+    {
+      "input": "pagerank alice epsilon=0",
+      "comment": "#980: explicit epsilon must be positive; omission still defers to the server default"
     },
     {
       "input": "community alice reduction=bogus",
@@ -377,6 +397,18 @@
     {
       "input": "community alice top_n=5",
       "comment": "#975: top_n is a pagerank knob, not valid on community"
+    },
+    {
+      "input": "community alice -1",
+      "comment": "#980: negative max_size is rejected"
+    },
+    {
+      "input": "community alice restart_prob=0",
+      "comment": "#980: explicit restart_prob must be in the open interval (0,1)"
+    },
+    {
+      "input": "community alice epsilon=0",
+      "comment": "#980: explicit epsilon must be positive; omission still defers to the server default"
     },
     {
       "input": "put vertex greeting \"hello world",

--- a/cli/cmd/bfs.go
+++ b/cli/cmd/bfs.go
@@ -57,8 +57,17 @@ EXAMPLES
 `,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := rejectMixedFamilyGrammar(cmd, args); err != nil {
+			return err
+		}
 		if len(args) > 1 {
 			return forwardFamilyPositional(cmd, "bfs", args)
+		}
+		if err := validatePositiveUint32Flag("step", bfsStep); err != nil {
+			return err
+		}
+		if err := validatePositiveUint32Flag("fan-out", bfsFanOut); err != nil {
+			return err
 		}
 		obj, ok := objectiveByName[bfsObjectiveStr]
 		if !ok {

--- a/cli/cmd/community.go
+++ b/cli/cmd/community.go
@@ -57,8 +57,17 @@ EXAMPLES
 `,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := rejectMixedFamilyGrammar(cmd, args); err != nil {
+			return err
+		}
 		if len(args) > 1 {
 			return forwardFamilyPositional(cmd, "community", args)
+		}
+		if err := validateExplicitRestartProbFlag(cmd, "restart-prob", communityRestartProb); err != nil {
+			return err
+		}
+		if err := validateExplicitPositiveFloat32Flag(cmd, "epsilon", communityEpsilon); err != nil {
+			return err
 		}
 		obj, ok := objectiveByName[communityObjectiveStr]
 		if !ok {

--- a/cli/cmd/family.go
+++ b/cli/cmd/family.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
 
 	"github.com/anaregdesign/lantern/cli/service"
 	client "github.com/anaregdesign/lantern/sdks/go"
@@ -46,6 +49,42 @@ func forwardFamilyPositional(cmd *cobra.Command, verb string, args []string) err
 	}
 	defer func() { _ = cli.Close() }()
 	return service.NewCLIService(cli).RunArgs(cmd.Context(), append([]string{verb}, args...))
+}
+
+func rejectMixedFamilyGrammar(cmd *cobra.Command, args []string) error {
+	if len(args) > 1 && cmd.Flags().NFlag() > 0 {
+		return errors.New("cannot mix flags with the positional grammar; use one or the other")
+	}
+	return nil
+}
+
+func validatePositiveUint32Flag(name string, value uint32) error {
+	if value == 0 {
+		return fmt.Errorf("--%s must be a positive integer", name)
+	}
+	return nil
+}
+
+func validateExplicitRestartProbFlag(cmd *cobra.Command, name string, value float32) error {
+	if !cmd.Flags().Changed(name) {
+		return nil
+	}
+	f := float64(value)
+	if math.IsNaN(f) || math.IsInf(f, 0) || f <= 0 || f >= 1 {
+		return fmt.Errorf("--%s must be a float in (0,1)", name)
+	}
+	return nil
+}
+
+func validateExplicitPositiveFloat32Flag(cmd *cobra.Command, name string, value float32) error {
+	if !cmd.Flags().Changed(name) {
+		return nil
+	}
+	f := float64(value)
+	if math.IsNaN(f) || math.IsInf(f, 0) || f <= 0 {
+		return fmt.Errorf("--%s must be a positive float", name)
+	}
+	return nil
 }
 
 // runFamilyFlagPath executes a flag-driven family walk (the bare-<seed> form

--- a/cli/cmd/grammar_test.go
+++ b/cli/cmd/grammar_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/anaregdesign/lantern/cli/parser"
@@ -94,4 +95,71 @@ func TestRunGrammarLineEmptyArgsShowsHelp(t *testing.T) {
 	if err := runGrammarLine(c, "get", nil); err != nil {
 		t.Errorf("runGrammarLine(empty) = %v, want nil (help shown)", err)
 	}
+}
+
+func TestFamilyCommandsRejectMixedFlagsAndPositionalGrammar(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		cmd   *cobra.Command
+		flag  string
+		value string
+		args  []string
+	}{
+		{name: "Bfs", cmd: bfsCmd, flag: "step", value: "2", args: []string{"alice", "3"}},
+		{name: "Pagerank", cmd: pagerankCmd, flag: "top-n", value: "5", args: []string{"alice", "3"}},
+		{name: "Community", cmd: communityCmd, flag: "max-size", value: "5", args: []string{"alice", "3"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withChangedFlag(t, tc.cmd, tc.flag, tc.value)
+			err := tc.cmd.RunE(tc.cmd, tc.args)
+			if err == nil || !strings.Contains(err.Error(), "cannot mix flags with the positional grammar") {
+				t.Fatalf("RunE(%v with --%s) = %v, want mixed-grammar error", tc.args, tc.flag, err)
+			}
+		})
+	}
+}
+
+func TestFamilyCommandsValidateFlagDomainsBeforeDial(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		cmd      *cobra.Command
+		flag     string
+		value    string
+		wantText string
+	}{
+		{name: "BfsZeroStep", cmd: bfsCmd, flag: "step", value: "0", wantText: "--step must be a positive integer"},
+		{name: "BfsZeroFanOut", cmd: bfsCmd, flag: "fan-out", value: "0", wantText: "--fan-out must be a positive integer"},
+		{name: "PagerankZeroRestartProb", cmd: pagerankCmd, flag: "restart-prob", value: "0", wantText: "--restart-prob must be a float in (0,1)"},
+		{name: "PagerankOneRestartProb", cmd: pagerankCmd, flag: "restart-prob", value: "1", wantText: "--restart-prob must be a float in (0,1)"},
+		{name: "PagerankZeroEpsilon", cmd: pagerankCmd, flag: "epsilon", value: "0", wantText: "--epsilon must be a positive float"},
+		{name: "CommunityZeroRestartProb", cmd: communityCmd, flag: "restart-prob", value: "0", wantText: "--restart-prob must be a float in (0,1)"},
+		{name: "CommunityZeroEpsilon", cmd: communityCmd, flag: "epsilon", value: "0", wantText: "--epsilon must be a positive float"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withChangedFlag(t, tc.cmd, tc.flag, tc.value)
+			err := tc.cmd.RunE(tc.cmd, []string{"alice"})
+			if err == nil || !strings.Contains(err.Error(), tc.wantText) {
+				t.Fatalf("RunE(alice with --%s=%s) = %v, want %q", tc.flag, tc.value, err, tc.wantText)
+			}
+		})
+	}
+}
+
+func withChangedFlag(t *testing.T, cmd *cobra.Command, name, value string) {
+	t.Helper()
+	flag := cmd.Flags().Lookup(name)
+	if flag == nil {
+		t.Fatalf("missing flag %q on %s", name, cmd.Name())
+	}
+	oldValue := flag.Value.String()
+	oldChanged := flag.Changed
+	if err := cmd.Flags().Set(name, value); err != nil {
+		t.Fatalf("set --%s=%s: %v", name, value, err)
+	}
+	t.Cleanup(func() {
+		if err := cmd.Flags().Set(name, oldValue); err != nil {
+			t.Fatalf("restore --%s=%s: %v", name, oldValue, err)
+		}
+		flag.Changed = oldChanged
+	})
 }

--- a/cli/cmd/pagerank.go
+++ b/cli/cmd/pagerank.go
@@ -56,8 +56,17 @@ EXAMPLES
 `,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := rejectMixedFamilyGrammar(cmd, args); err != nil {
+			return err
+		}
 		if len(args) > 1 {
 			return forwardFamilyPositional(cmd, "pagerank", args)
+		}
+		if err := validateExplicitRestartProbFlag(cmd, "restart-prob", pagerankRestartProb); err != nil {
+			return err
+		}
+		if err := validateExplicitPositiveFloat32Flag(cmd, "epsilon", pagerankEpsilon); err != nil {
+			return err
 		}
 		w, ok := weightingByName[pagerankWeightingStr]
 		if !ok {

--- a/cli/cmd/repl.go
+++ b/cli/cmd/repl.go
@@ -156,12 +156,16 @@ EXAMPLE
 				fmt.Println("Usage: scan { vertices <prefix: string> [<limit: int>] | edges <tail-prefix: string> [<limit: int>] }")
 			case service.ErrKeys:
 				fmt.Println("Usage: keys <prefix: string> [<limit: int>]")
-			case service.ErrIlluminate:
-				fmt.Println("Usage: illuminate <seed: string> <step: int> <k: int> [algorithm=bfs|ppr|community] [reduction=none|mst|spt] [objective=min|max] [weighting=raw|tfidf|bm25] [restart_prob=<float>] [epsilon=<float>]")
+			case service.ErrBFS:
+				fmt.Println("Usage: bfs <seed: string> [step: int] [fan_out: int] [reduction=none|mst|spt] [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>]")
+			case service.ErrPagerank:
+				fmt.Println("Usage: pagerank <seed: string> [top_n: int] [restart_prob=<float>] [epsilon=<float>] [weighting=raw|tfidf|bm25] [prefix=<string>]")
+			case service.ErrCommunity:
+				fmt.Println("Usage: community <seed: string> [max_size: int] [restart_prob=<float>] [epsilon=<float>] [reduction=none|mst|spt] [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>]")
 			case service.ErrInvalidVerb:
-				fmt.Println("Usage: { get | put | delete | add | scan | illuminate | help | exit } ...")
+				fmt.Println("Usage: { get | put | delete | add | scan | count | delete-prefix | keys | bfs | pagerank | community | help | exit } ...")
 			case service.ErrInvalidObjective:
-				fmt.Println("{ get { vertex | edge } | put { vertex | edge } | delete { vertex | edge } | add { edge | decaying-edge } | scan { vertices | edges } | illuminate {...} } ...")
+				fmt.Println("{ get { vertex | edge } | put { vertex | edge } | delete { vertex | edge } | add { edge | decaying-edge } | scan { vertices | edges } | count vertices | delete-prefix vertices | keys {...} | bfs {...} | pagerank {...} | community {...} } ...")
 			case service.ErrConnection:
 				fmt.Println("server error")
 			default:

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -521,15 +522,15 @@ func BfsParam(s *Source) (*Bfs, error) {
 			lvalue := strings.ToLower(value)
 			switch key {
 			case "step":
-				n, perr := strconv.Atoi(value)
+				n, perr := positiveFamilyInt(value, "bfs: step=")
 				if perr != nil {
-					return nil, errors.New("bfs: step=" + value + " (want an integer)")
+					return nil, perr
 				}
 				m.Step = n
 			case "fan_out":
-				n, perr := strconv.Atoi(value)
+				n, perr := positiveFamilyInt(value, "bfs: fan_out=")
 				if perr != nil {
-					return nil, errors.New("bfs: fan_out=" + value + " (want an integer)")
+					return nil, perr
 				}
 				m.FanOut = n
 			case "reduction":
@@ -559,15 +560,15 @@ func BfsParam(s *Source) (*Bfs, error) {
 		}
 		switch pos {
 		case 0:
-			n, perr := strconv.Atoi(tok)
+			n, perr := positiveFamilyInt(tok, "bfs: step ")
 			if perr != nil {
-				return nil, errors.New("bfs: step " + tok + " (want an integer)")
+				return nil, perr
 			}
 			m.Step = n
 		case 1:
-			n, perr := strconv.Atoi(tok)
+			n, perr := positiveFamilyInt(tok, "bfs: fan_out ")
 			if perr != nil {
-				return nil, errors.New("bfs: fan_out " + tok + " (want an integer)")
+				return nil, perr
 			}
 			m.FanOut = n
 		default:
@@ -605,23 +606,23 @@ func PagerankParam(s *Source) (*Pagerank, error) {
 			lvalue := strings.ToLower(value)
 			switch key {
 			case "top_n":
-				n, perr := strconv.Atoi(value)
+				n, perr := nonNegativeFamilyInt(value, "pagerank: top_n=")
 				if perr != nil {
-					return nil, errors.New("pagerank: top_n=" + value + " (want an integer)")
+					return nil, perr
 				}
 				m.TopN = n
 			case "restart_prob":
-				rp, perr := strconv.ParseFloat(value, 32)
+				rp, perr := familyRestartProb(value, "pagerank: restart_prob=")
 				if perr != nil {
-					return nil, errors.New("pagerank: restart_prob=" + value + " (want a float in (0,1))")
+					return nil, perr
 				}
-				m.RestartProb = float32(rp)
+				m.RestartProb = rp
 			case "epsilon":
-				eps, perr := strconv.ParseFloat(value, 32)
+				eps, perr := positiveFamilyFloat(value, "pagerank: epsilon=")
 				if perr != nil {
-					return nil, errors.New("pagerank: epsilon=" + value + " (want a positive float)")
+					return nil, perr
 				}
-				m.Epsilon = float32(eps)
+				m.Epsilon = eps
 			case "weighting":
 				if !contains(TraversalWeightings, lvalue) {
 					return nil, errors.New("pagerank: weighting=" + value + " (want raw|tfidf|bm25)")
@@ -639,9 +640,9 @@ func PagerankParam(s *Source) (*Pagerank, error) {
 		}
 		switch pos {
 		case 0:
-			n, perr := strconv.Atoi(tok)
+			n, perr := nonNegativeFamilyInt(tok, "pagerank: top_n ")
 			if perr != nil {
-				return nil, errors.New("pagerank: top_n " + tok + " (want an integer)")
+				return nil, perr
 			}
 			m.TopN = n
 		default:
@@ -679,23 +680,23 @@ func CommunityParam(s *Source) (*Community, error) {
 			lvalue := strings.ToLower(value)
 			switch key {
 			case "max_size":
-				n, perr := strconv.Atoi(value)
+				n, perr := nonNegativeFamilyInt(value, "community: max_size=")
 				if perr != nil {
-					return nil, errors.New("community: max_size=" + value + " (want an integer)")
+					return nil, perr
 				}
 				m.MaxSize = n
 			case "restart_prob":
-				rp, perr := strconv.ParseFloat(value, 32)
+				rp, perr := familyRestartProb(value, "community: restart_prob=")
 				if perr != nil {
-					return nil, errors.New("community: restart_prob=" + value + " (want a float in (0,1))")
+					return nil, perr
 				}
-				m.RestartProb = float32(rp)
+				m.RestartProb = rp
 			case "epsilon":
-				eps, perr := strconv.ParseFloat(value, 32)
+				eps, perr := positiveFamilyFloat(value, "community: epsilon=")
 				if perr != nil {
-					return nil, errors.New("community: epsilon=" + value + " (want a positive float)")
+					return nil, perr
 				}
-				m.Epsilon = float32(eps)
+				m.Epsilon = eps
 			case "reduction":
 				if !contains(TraversalReductions, lvalue) {
 					return nil, errors.New("community: reduction=" + value + " (want none|mst|spt)")
@@ -723,9 +724,9 @@ func CommunityParam(s *Source) (*Community, error) {
 		}
 		switch pos {
 		case 0:
-			n, perr := strconv.Atoi(tok)
+			n, perr := nonNegativeFamilyInt(tok, "community: max_size ")
 			if perr != nil {
-				return nil, errors.New("community: max_size " + tok + " (want an integer)")
+				return nil, perr
 			}
 			m.MaxSize = n
 		default:
@@ -734,6 +735,38 @@ func CommunityParam(s *Source) (*Community, error) {
 		pos++
 	}
 	return m, nil
+}
+
+func positiveFamilyInt(value, label string) (int, error) {
+	n, err := strconv.Atoi(value)
+	if err != nil || n <= 0 {
+		return 0, errors.New(label + value + " (want a positive integer)")
+	}
+	return n, nil
+}
+
+func nonNegativeFamilyInt(value, label string) (int, error) {
+	n, err := strconv.Atoi(value)
+	if err != nil || n < 0 {
+		return 0, errors.New(label + value + " (want a non-negative integer)")
+	}
+	return n, nil
+}
+
+func familyRestartProb(value, label string) (float32, error) {
+	f, err := strconv.ParseFloat(value, 32)
+	if err != nil || math.IsNaN(f) || math.IsInf(f, 0) || f <= 0 || f >= 1 {
+		return 0, errors.New(label + value + " (want a float in (0,1))")
+	}
+	return float32(f), nil
+}
+
+func positiveFamilyFloat(value, label string) (float32, error) {
+	f, err := strconv.ParseFloat(value, 32)
+	if err != nil || math.IsNaN(f) || math.IsInf(f, 0) || f <= 0 {
+		return 0, errors.New(label + value + " (want a positive float)")
+	}
+	return float32(f), nil
 }
 
 func splitKeyValue(tok string) (key, value string, ok bool) {

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -525,7 +525,15 @@ func TestBfsParam(t *testing.T) {
 			"alice prefix=",
 			"alice 1 2 3",    // third bare positional
 			"alice notanint", // non-integer step
-			"alice top_n=5",  // pagerank kwarg not valid on bfs
+			"alice -1 2",     // negative step
+			"alice 0 2",      // zero step
+			"alice 1 -2",     // negative fan_out
+			"alice 1 0",      // zero fan_out
+			"alice step=-1",
+			"alice step=0",
+			"alice fan_out=-1",
+			"alice fan_out=0",
+			"alice top_n=5", // pagerank kwarg not valid on bfs
 		} {
 			s, _ := NewSource(in)
 			if _, err := BfsParam(s); err == nil {
@@ -566,6 +574,19 @@ func TestPagerankParam(t *testing.T) {
 		}
 	})
 
+	t.Run("top_n zero means all positive-mass vertices", func(t *testing.T) {
+		for _, in := range []string{"alice 0", "alice top_n=0"} {
+			s, _ := NewSource(in)
+			m, err := PagerankParam(s)
+			if err != nil {
+				t.Fatalf("PagerankParam(%q): %v", in, err)
+			}
+			if m.TopN != 0 {
+				t.Fatalf("PagerankParam(%q).TopN = %d, want 0", in, m.TopN)
+			}
+		}
+	})
+
 	t.Run("top_n/restart_prob/epsilon in any order", func(t *testing.T) {
 		s, _ := NewSource("alice epsilon=0.001 restart_prob=0.25 top_n=15")
 		m, err := PagerankParam(s)
@@ -592,8 +613,17 @@ func TestPagerankParam(t *testing.T) {
 		for _, in := range []string{
 			"alice reduction=mst", // pagerank has no reduction
 			"alice objective=max", // pagerank has no objective
+			"alice -1",            // top_n cannot be negative
+			"alice top_n=-1",
 			"alice restart_prob=high",
+			"alice restart_prob=0",
+			"alice restart_prob=1",
+			"alice restart_prob=-0.1",
+			"alice restart_prob=NaN",
 			"alice epsilon=tiny",
+			"alice epsilon=0",
+			"alice epsilon=-0.1",
+			"alice epsilon=NaN",
 			"alice prefix=",
 			"alice 1 2", // second bare positional
 		} {
@@ -655,7 +685,17 @@ func TestCommunityParam(t *testing.T) {
 			"alice reduction=bogus",
 			"alice objective=bogus",
 			"alice top_n=5", // pagerank kwarg not valid on community
+			"alice -1",      // max_size cannot be negative
+			"alice max_size=-1",
 			"alice restart_prob=high",
+			"alice restart_prob=0",
+			"alice restart_prob=1",
+			"alice restart_prob=-0.1",
+			"alice restart_prob=NaN",
+			"alice epsilon=tiny",
+			"alice epsilon=0",
+			"alice epsilon=-0.1",
+			"alice epsilon=NaN",
 			"alice prefix=",
 			"alice 1 2", // second bare positional
 		} {

--- a/cli/parser/validate.go
+++ b/cli/parser/validate.go
@@ -14,7 +14,7 @@ func Validate(input string) error {
 	}
 	v, err := Verb(s)
 	if err != nil {
-		return errors.New("usage: { get | put | delete | add | scan | keys | bfs | pagerank | community | help | exit } ... ")
+		return errors.New("usage: { get | put | delete | add | scan | count | delete-prefix | keys | bfs | pagerank | community | help | exit } ... ")
 	}
 
 	switch v {
@@ -155,7 +155,7 @@ func Validate(input string) error {
 	case "exit":
 
 	default:
-		return errors.New("usage: { get | put | delete | add | scan | keys | bfs | pagerank | community | help | exit } ... ")
+		return errors.New("usage: { get | put | delete | add | scan | count | delete-prefix | keys | bfs | pagerank | community | help | exit } ... ")
 	}
 	return nil
 }

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -29,7 +29,9 @@ var (
 	ErrCount            = errors.New("count error")
 	ErrDeletePrefix     = errors.New("delete-prefix error")
 	ErrKeys             = errors.New("keys error")
-	ErrIlluminate       = errors.New("illuminate error")
+	ErrBFS              = errors.New("bfs error")
+	ErrPagerank         = errors.New("pagerank error")
+	ErrCommunity        = errors.New("community error")
 	ErrConnection       = errors.New("connection error")
 )
 
@@ -430,22 +432,22 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 		p, err := parser.BfsParam(s)
 		if err != nil {
 			fmt.Printf("Error: %s\n", err)
-			return ErrIlluminate
+			return ErrBFS
 		}
 		obj, ok := objectiveByREPLName[p.Objective]
 		if !ok {
 			fmt.Printf("Error: bfs: unknown objective %q\n", p.Objective)
-			return ErrIlluminate
+			return ErrBFS
 		}
 		red, ok := reductionByREPLName[p.Reduction]
 		if !ok {
 			fmt.Printf("Error: bfs: unknown reduction %q\n", p.Reduction)
-			return ErrIlluminate
+			return ErrBFS
 		}
 		w, ok := weightingByREPLName[p.Weighting]
 		if !ok {
 			fmt.Printf("Error: bfs: unknown weighting %q\n", p.Weighting)
-			return ErrIlluminate
+			return ErrBFS
 		}
 		opts := []client.IlluminateOption{
 			BfsOption(clampUint32(p.Step), clampUint32(p.FanOut), red, obj),
@@ -459,12 +461,12 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 		p, err := parser.PagerankParam(s)
 		if err != nil {
 			fmt.Printf("Error: %s\n", err)
-			return ErrIlluminate
+			return ErrPagerank
 		}
 		w, ok := weightingByREPLName[p.Weighting]
 		if !ok {
 			fmt.Printf("Error: pagerank: unknown weighting %q\n", p.Weighting)
-			return ErrIlluminate
+			return ErrPagerank
 		}
 		opts := []client.IlluminateOption{
 			PagerankOption(clampUint32(p.TopN), p.RestartProb, p.Epsilon),
@@ -478,22 +480,22 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 		p, err := parser.CommunityParam(s)
 		if err != nil {
 			fmt.Printf("Error: %s\n", err)
-			return ErrIlluminate
+			return ErrCommunity
 		}
 		obj, ok := objectiveByREPLName[p.Objective]
 		if !ok {
 			fmt.Printf("Error: community: unknown objective %q\n", p.Objective)
-			return ErrIlluminate
+			return ErrCommunity
 		}
 		red, ok := reductionByREPLName[p.Reduction]
 		if !ok {
 			fmt.Printf("Error: community: unknown reduction %q\n", p.Reduction)
-			return ErrIlluminate
+			return ErrCommunity
 		}
 		w, ok := weightingByREPLName[p.Weighting]
 		if !ok {
 			fmt.Printf("Error: community: unknown weighting %q\n", p.Weighting)
-			return ErrIlluminate
+			return ErrCommunity
 		}
 		opts := []client.IlluminateOption{
 			CommunityOption(clampUint32(p.MaxSize), red, obj, p.RestartProb, p.Epsilon),

--- a/cli/service/service_test.go
+++ b/cli/service/service_test.go
@@ -118,3 +118,27 @@ func TestRunArgs_AddDecayingEdge(t *testing.T) {
 		}
 	})
 }
+
+func TestRunArgs_FamilyParseErrorsReturnSpecificSentinels(t *testing.T) {
+	svc := NewCLIService(nil)
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want error
+	}{
+		{name: "BfsMissingSeed", args: []string{"bfs"}, want: ErrBFS},
+		{name: "BfsInvalidStep", args: []string{"bfs", "alice", "0"}, want: ErrBFS},
+		{name: "PagerankMissingSeed", args: []string{"pagerank"}, want: ErrPagerank},
+		{name: "PagerankInvalidRestartProb", args: []string{"pagerank", "alice", "restart_prob=1"}, want: ErrPagerank},
+		{name: "CommunityMissingSeed", args: []string{"community"}, want: ErrCommunity},
+		{name: "CommunityInvalidEpsilon", args: []string{"community", "alice", "epsilon=0"}, want: ErrCommunity},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := svc.RunArgs(ctx, tc.args); err != tc.want {
+				t.Errorf("RunArgs(%v) = %v, want %v", tc.args, err, tc.want)
+			}
+		})
+	}
+}

--- a/testbed/SKILL.md
+++ b/testbed/SKILL.md
@@ -20,7 +20,7 @@ testbed/
 ├── docker-compose.auth.yml # overlay: bearer-token auth armed (#850)
 ├── prometheus.yml          # 5s scrape against lantern:9090
 ├── scripts/
-│   ├── exercise-cli.sh     # 28 CLI scenarios; per-step rc + log capture
+│   ├── exercise-cli.sh     # 39 CLI scenarios; per-step rc + log capture
 │   ├── exercise-sdk.go     # 39 SDK scenarios; uses workspace replace
 │   └── query-metrics.sh    # curl /metrics → json snapshots
 └── out/                    # gitignored — logs, metric snapshots, reports
@@ -64,9 +64,9 @@ docker compose down -v
 
 ## What "green" looks like
 
-- `exercise-cli.sh`: 28 logs in `out/cli/`. Exactly three may exit non-zero
-  (the deliberate `NotFound` checks: `vertex get missing`, `edge get missing`,
-  `vertex delete missing`). Anything else is a regression.
+- `exercise-cli.sh`: 39 logs in `out/cli/`. Exactly three may exit non-zero
+  (the deliberate `NotFound` checks: `vertex-get-missing`, `edge-get-missing`,
+  `vertex-get-ephem-expired`). Anything else is a regression.
 - `exercise-sdk.go`: prints `ok` for all 39 steps, ending with
   `SDK report written to .../out/sdk/report.txt`.
 - `lantern_build_info` reports the real release tag/commit (post-[#99][p99]).

--- a/testbed/scripts/exercise-cli.sh
+++ b/testbed/scripts/exercise-cli.sh
@@ -36,38 +36,40 @@ run version            version
 run help               --help
 
 # -- vertex put/get/delete (single) ----------------------------------
-run vertex-put-string  "${META[@]}" vertex put alice 'Alice Smith' --ttl 5m
-run vertex-put-int     "${META[@]}" vertex put count 42 --ttl 5m
-run vertex-put-float   "${META[@]}" vertex put price 19.99 --ttl 5m
-run vertex-put-bool    "${META[@]}" vertex put alive true --ttl 5m
-run vertex-put-json    "${META[@]}" vertex put bob '{"age":30}' --value-type=json --ttl 5m
-run vertex-put-dt      "${META[@]}" vertex put epoch '2025-01-01T00:00:00Z' --value-type=datetime --ttl 5m
-run vertex-put-dur     "${META[@]}" vertex put cooldown 30s --value-type=duration --ttl 5m
-run vertex-put-zip     "${META[@]}" vertex put zip 01234 --value-type=string --ttl 5m
-run vertex-put-shortlived "${META[@]}" vertex put ephem hi --ttl 2s
+run vertex-put-string  "${META[@]}" put vertex alice 'Alice Smith' 300
+run vertex-put-int     "${META[@]}" put vertex count 42 300
+run vertex-put-float   "${META[@]}" put vertex price 19.99 300
+run vertex-put-bool    "${META[@]}" put vertex alive true 300
+run vertex-put-json    "${META[@]}" put vertex bob '{"age":30}' 300 type=json
+run vertex-put-dt      "${META[@]}" put vertex epoch '2025-01-01T00:00:00Z' 300 type=datetime
+run vertex-put-dur     "${META[@]}" put vertex cooldown 30s 300 type=duration
+run vertex-put-zip     "${META[@]}" put vertex zip 01234 300 type=string
+run vertex-put-shortlived "${META[@]}" put vertex ephem hi 2
 
-run vertex-get-string  "${META[@]}" vertex get alice
-run vertex-get-int     "${META[@]}" vertex get count
-run vertex-get-json    "${META[@]}" vertex get bob
-run vertex-get-missing "${META[@]}" vertex get does-not-exist
+run vertex-get-string  "${META[@]}" get vertex alice
+run vertex-get-int     "${META[@]}" get vertex count
+run vertex-get-json    "${META[@]}" get vertex bob
+run vertex-get-missing "${META[@]}" get vertex does-not-exist
 
 # -- edge add/put/get/delete (single) --------------------------------
-run edge-add-1         "${META[@]}" edge add alice bob 1.5 --ttl 5m
-run edge-add-2         "${META[@]}" edge add alice bob 0.5 --ttl 5m
-run edge-get-additive  "${META[@]}" edge get alice bob
-run edge-put-replace   "${META[@]}" edge put alice bob 0.25 --ttl 5m
-run edge-get-after-put "${META[@]}" edge get alice bob
-run edge-get-missing   "${META[@]}" edge get alice nobody
+run edge-add-1         "${META[@]}" add edge alice bob 1.5 300
+run edge-add-2         "${META[@]}" add edge alice bob 0.5 300
+run edge-get-additive  "${META[@]}" get edge alice bob
+run edge-put-replace   "${META[@]}" put edge alice bob 0.25 300
+run edge-get-after-put "${META[@]}" get edge alice bob
+run edge-get-missing   "${META[@]}" get edge alice nobody
 
-# -- illuminate every optimization mode ------------------------------
-run edge-add-carol      "${META[@]}" edge add alice carol 0.8 --ttl 5m
-run edge-add-dave       "${META[@]}" edge add bob dave 0.6 --ttl 5m
-run edge-add-carol-dave "${META[@]}" edge add carol dave 0.4 --ttl 5m
+# -- graph walk family verbs -----------------------------------------
+run edge-add-carol      "${META[@]}" add edge alice carol 0.8 300
+run edge-add-dave       "${META[@]}" add edge bob dave 0.6 300
+run edge-add-carol-dave "${META[@]}" add edge carol dave 0.4 300
 
-for mode in none mst max-st spt inverse-spt; do
-  run "illuminate-$mode" "${META[@]}" illuminate alice --step 3 --k 10 --optimize "$mode"
-done
-run illuminate-tfidf    "${META[@]}" illuminate alice --step 2 --k 5 --tfidf
+run bfs-none             "${META[@]}" bfs alice --step 3 --fan-out 10
+run bfs-mst-min          "${META[@]}" bfs alice --step 3 --fan-out 10 --reduction mst --objective min
+run bfs-spt-max          "${META[@]}" bfs alice --step 3 --fan-out 10 --reduction spt --objective max
+run bfs-tfidf            "${META[@]}" bfs alice --step 2 --fan-out 5 --weighting tfidf
+run pagerank-default     "${META[@]}" pagerank alice --top-n 8
+run community-mst        "${META[@]}" community alice --max-size 30 --reduction mst --objective min
 
 # -- bulk: NDJSON ----------------------------------------------------
 {
@@ -95,16 +97,16 @@ echo "==> bulk-vertices-stdin"
 tail -n1 "$OUT/bulk-vertices-stdin.log" | sed 's/^/    /'
 
 # -- batch delete ----------------------------------------------------
-run vertex-delete-batch "${META[@]}" vertex delete bulk-v1 bulk-v2 bulk-v3 bulk-v4 bulk-v5
-run edge-delete-batch   "${META[@]}" edge delete alice:bob alice:carol bob:dave carol:dave
+run vertex-delete-batch "${META[@]}" delete vertex bulk-v1 bulk-v2 bulk-v3 bulk-v4 bulk-v5
+run edge-delete-batch   "${META[@]}" delete edge alice bob alice carol bob dave carol dave
 
 # -- TTL expiry observation ------------------------------------------
 echo "==> waiting 4s for 'ephem' (2s TTL) to expire ..."
 sleep 4
-run vertex-get-ephem-expired "${META[@]}" vertex get ephem
+run vertex-get-ephem-expired "${META[@]}" get vertex ephem
 
 # -- gzip compression ------------------------------------------------
-run vertex-put-gzip    "${META[@]}" --compression gzip vertex put gz hello --ttl 5m
-run vertex-get-gzip    "${META[@]}" --compression gzip vertex get gz
+run vertex-put-gzip    "${META[@]}" --compression gzip put vertex gz hello 300
+run vertex-get-gzip    "${META[@]}" --compression gzip get vertex gz
 
 echo "DONE. Logs in $OUT/"

--- a/tests/integration/cli_family_verbs_test.go
+++ b/tests/integration/cli_family_verbs_test.go
@@ -61,4 +61,27 @@ func TestCLI_FamilyVerbs_RealWire(t *testing.T) {
 	if err := svc.RunArgs(ctx, []string{"pagerank", "a", "reduction=mst"}); err == nil {
 		t.Error("RunArgs(pagerank a reduction=mst) = nil, want a parse error")
 	}
+
+	// Numeric-domain failure contract (#980): the CLI parser rejects out-of-range
+	// family knobs before constructing SDK options or reaching the server.
+	for _, tc := range []struct {
+		name string
+		args []string
+		want error
+	}{
+		{name: "BfsZeroStep", args: []string{"bfs", "a", "0"}, want: cliservice.ErrBFS},
+		{name: "BfsZeroFanOut", args: []string{"bfs", "a", "1", "0"}, want: cliservice.ErrBFS},
+		{name: "PagerankNegativeTopN", args: []string{"pagerank", "a", "-1"}, want: cliservice.ErrPagerank},
+		{name: "PagerankRestartProbBoundary", args: []string{"pagerank", "a", "restart_prob=1"}, want: cliservice.ErrPagerank},
+		{name: "PagerankZeroEpsilon", args: []string{"pagerank", "a", "epsilon=0"}, want: cliservice.ErrPagerank},
+		{name: "CommunityNegativeMaxSize", args: []string{"community", "a", "-1"}, want: cliservice.ErrCommunity},
+		{name: "CommunityRestartProbBoundary", args: []string{"community", "a", "restart_prob=0"}, want: cliservice.ErrCommunity},
+		{name: "CommunityZeroEpsilon", args: []string{"community", "a", "epsilon=0"}, want: cliservice.ErrCommunity},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := svc.RunArgs(ctx, tc.args); err != tc.want {
+				t.Errorf("RunArgs(%v) = %v, want %v", tc.args, err, tc.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- tighten CLI family verb numeric validation for `bfs`, `pagerank`, and `community` across shared parser and Cobra flag paths
- return family-specific CLI service sentinels and refresh REPL/parser usage hints
- mirror the grammar in the admin parser, shared fixture, integration tests, README, lantern-ops skill, and testbed CLI sweep

## Validation
- `go test ./cli/parser ./cli/service ./cli/cmd ./tests/integration -run 'Test(BfsParam|PagerankParam|CommunityParam|GrammarFixture|Validate|RunArgs_FamilyParseErrorsReturnSpecificSentinels|FamilyCommands|CLI_FamilyVerbs_RealWire)'`
- `cd admin && bun run typecheck && bun run test`
- `bash -n testbed/scripts/exercise-cli.sh`
- `gofmt -l . && go test ./...`
- `for m in core mcp pb sdks/go server; do (cd "$m" && if [[ "$m" == "server" ]]; then go vet ./... && go test ./...; else go test ./...; fi) || exit 1; done`
- `cd admin && bun run lint && bun run build` (passes with one pre-existing hook dependency warning in `VertexDetailPage.tsx`)
- `cd admin && bun run format`
- `git diff --check`

Closes #977
closes #978
closes #979
closes #980