### PR TITLE
fix(core,server): prevent SPT reduction from looping on negative cycles

### DIFF
--- a/core/graph/graph_test.go
+++ b/core/graph/graph_test.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 )
 
@@ -260,6 +261,36 @@ func TestGraph_ShortestPathTree_IndirectCheaper(t *testing.T) {
 	}
 	if totalEdges != 3 {
 		t.Errorf("SPT total edges = %d, want 3 (edges=%v)", totalEdges, spt.Edges)
+	}
+}
+
+func TestGraph_ShortestPathTreeContext_RejectsInvalidCosts(t *testing.T) {
+	base := func() *Graph[string, int] {
+		g := NewGraph[string, int]()
+		g.PutEdge("a", "b", 1)
+		g.PutEdge("b", "a", 1) // A negative cycle must fail rather than requeue forever.
+		return g
+	}
+
+	for _, tc := range []struct {
+		name string
+		cost func(float32) float32
+	}{
+		{"negative cycle", func(float32) float32 { return -1 }},
+		{"NaN", func(float32) float32 { return float32(math.NaN()) }},
+		{"positive infinity", func(float32) float32 { return float32(math.Inf(1)) }},
+		{"distance overflow", func(float32) float32 { return math.MaxFloat32 }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := base().ShortestPathTreeContext(context.Background(), "a", tc.cost)
+			if !errors.Is(err, ErrInvalidShortestPathCost) {
+				t.Fatalf("errors.Is(err, ErrInvalidShortestPathCost) = false; err = %v", err)
+			}
+			var invalid *InvalidShortestPathCostError
+			if !errors.As(err, &invalid) {
+				t.Fatalf("errors.As(err, *InvalidShortestPathCostError) = false; err = %v", err)
+			}
+		})
 	}
 }
 

--- a/core/graph/model.go
+++ b/core/graph/model.go
@@ -3,10 +3,34 @@ package graph
 import (
 	"container/heap"
 	"context"
+	"errors"
+	"fmt"
+	"math"
 
 	"github.com/anaregdesign/lantern/core/collection/pq"
 	"github.com/anaregdesign/lantern/core/collection/set"
 )
+
+// ErrInvalidShortestPathCost reports a cost that violates Dijkstra's
+// finite, non-negative cost precondition. Callers can use errors.Is to
+// distinguish invalid graph data or a cost transform from cancellation and
+// other traversal failures.
+var ErrInvalidShortestPathCost = errors.New("shortest-path tree requires finite, non-negative costs")
+
+// InvalidShortestPathCostError identifies the edge cost or candidate distance
+// that made a shortest-path-tree traversal unsafe. It unwraps to
+// ErrInvalidShortestPathCost so callers need not parse its diagnostic text.
+type InvalidShortestPathCostError struct {
+	Weight   float32
+	Cost     float32
+	Distance float32
+}
+
+func (e *InvalidShortestPathCostError) Error() string {
+	return fmt.Sprintf("%v: weight=%g cost=%g candidate_distance=%g", ErrInvalidShortestPathCost, e.Weight, e.Cost, e.Distance)
+}
+
+func (e *InvalidShortestPathCostError) Unwrap() error { return ErrInvalidShortestPathCost }
 
 type Graph[S comparable, T any] struct {
 	Vertices map[S]T             `json:"vertices,omitempty"`
@@ -174,7 +198,10 @@ func (g *Graph[S, T]) spanningTreeContext(ctx context.Context, seed S, negate bo
  * ShortestPathTree returns a shortest path tree of the graph from the seed.
  * The costFunc is a function that returns the cost of the edge.
  * Typically, if the weight means like `importance`, the costFunc is a function that returns the 1 / weight.
- * It is calculated by Dijkstra's algorithm, so the costFunc must return a positive value.
+ * It is calculated by Dijkstra's algorithm, so the costFunc must return a
+ * finite, non-negative value. This convenience variant returns nil when that
+ * precondition is violated; callers that need the typed error should use
+ * ShortestPathTreeContext.
  */
 func (g *Graph[S, T]) ShortestPathTree(seed S, costFunc func(x float32) float32) *Graph[S, T] {
 	spt, _ := g.ShortestPathTreeContext(context.Background(), seed, costFunc)
@@ -197,8 +224,10 @@ func (g *Graph[S, T]) ShortestPathTree(seed S, costFunc func(x float32) float32)
 // avoided here.
 //
 // PriorityQueue is a max-heap; priorities are negated so the smallest dist
-// surfaces first. costFunc must return non-negative values (Dijkstra
-// precondition).
+// surfaces first. costFunc must return finite, non-negative values (Dijkstra
+// precondition). Costs and candidate distances are validated before they enter
+// the queue: negative costs can otherwise make a reachable cycle relax
+// forever, while NaN/Inf makes priority ordering undefined.
 func (g *Graph[S, T]) ShortestPathTreeContext(ctx context.Context, seed S, costFunc func(x float32) float32) (*Graph[S, T], error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -227,7 +256,14 @@ func (g *Graph[S, T]) ShortestPathTreeContext(ctx context.Context, seed S, costF
 			continue // stale
 		}
 		for v, w := range g.Edges[u] {
-			alt := dist[u] + costFunc(w)
+			cost := costFunc(w)
+			if cost < 0 || math.IsNaN(float64(cost)) || math.IsInf(float64(cost), 0) {
+				return nil, &InvalidShortestPathCostError{Weight: w, Cost: cost}
+			}
+			alt := dist[u] + cost
+			if math.IsNaN(float64(alt)) || math.IsInf(float64(alt), 0) {
+				return nil, &InvalidShortestPathCostError{Weight: w, Cost: cost, Distance: alt}
+			}
 			if d, ok := dist[v]; !ok || alt < d {
 				dist[v] = alt
 				prev[v] = u

--- a/server/service/optimizer.go
+++ b/server/service/optimizer.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"context"
+	"errors"
 	"math"
 
+	"connectrpc.com/connect"
 	coregraph "github.com/anaregdesign/lantern/core/graph"
 	"github.com/anaregdesign/lantern/core/graphcache"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
@@ -54,6 +56,17 @@ func inverseCost(weight float32) float32 {
 		return math.MaxFloat32
 	}
 	return 1 / weight
+}
+
+// optimizerToConnect maps reduction-specific data preconditions to stable
+// wire errors while retaining ctxToConnect's cancellation semantics. In
+// particular, Dijkstra must not receive negative or non-finite costs: it can
+// otherwise continue relaxing a negative cycle indefinitely.
+func optimizerToConnect(err error) error {
+	if errors.Is(err, coregraph.ErrInvalidShortestPathCost) {
+		return connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+	return ctxToConnect(err)
 }
 
 // resolvePPRParams resolves the Personalized PageRank restart probability

--- a/server/service/optimizer_test.go
+++ b/server/service/optimizer_test.go
@@ -1,0 +1,36 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	coregraph "github.com/anaregdesign/lantern/core/graph"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+)
+
+func TestResolveOptimizer_ShortestPathTreeRejectsNegativeCosts(t *testing.T) {
+	g := coregraph.NewGraph[string, *pb.Vertex]()
+	g.PutEdge("a", "b", -1)
+	g.PutEdge("b", "a", -1)
+
+	for _, objective := range []pb.Objective{
+		pb.Objective_OBJECTIVE_MINIMIZE,
+		pb.Objective_OBJECTIVE_MAXIMIZE,
+	} {
+		t.Run(objective.String(), func(t *testing.T) {
+			opt := resolveOptimizer(pb.Reduction_REDUCTION_SHORTEST_PATH_TREE, objective)
+			if opt == nil {
+				t.Fatal("resolveOptimizer returned nil")
+			}
+			_, err := opt(context.Background(), g, "a")
+			if !errors.Is(err, coregraph.ErrInvalidShortestPathCost) {
+				t.Fatalf("errors.Is(err, ErrInvalidShortestPathCost) = false; err = %v", err)
+			}
+			if got := connect.CodeOf(optimizerToConnect(err)); got != connect.CodeFailedPrecondition {
+				t.Fatalf("optimizer error code = %v, want FailedPrecondition", got)
+			}
+		})
+	}
+}

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -567,7 +567,7 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 			optStart := time.Now()
 			reduced, rerr := opt(ctx, g, request.GetSeed())
 			if rerr != nil {
-				return nil, ctxToConnect(rerr)
+				return nil, optimizerToConnect(rerr)
 			}
 			// Membership is preserved: re-add community members the tree
 			// could not reach as isolated vertices, then trim expirations to
@@ -618,7 +618,7 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 			g, err = opt(ctx, g, request.GetSeed())
 			optimizeDur = time.Since(optStart)
 			if err != nil {
-				return nil, ctxToConnect(err)
+				return nil, optimizerToConnect(err)
 			}
 		}
 		algoLabel, redLabel, objLabel = "bfs", reductionLabel(bfs.GetReduction()), objectiveLabel(objective)

--- a/tests/integration/illuminate_reduction_test.go
+++ b/tests/integration/illuminate_reduction_test.go
@@ -1,0 +1,54 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestLantern_Illuminate_ShortestPathTreeRejectsNegativeCycles(t *testing.T) {
+	for _, objective := range []pb.Objective{
+		pb.Objective_OBJECTIVE_MINIMIZE,
+		pb.Objective_OBJECTIVE_MAXIMIZE,
+	} {
+		t.Run(objective.String(), func(t *testing.T) {
+			c, _ := newRawConnectClient(t, false)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			t.Cleanup(cancel)
+			exp := timestamppb.New(time.Now().Add(time.Hour))
+			if _, err := c.PutVertices(ctx, connect.NewRequest(&pb.PutVerticesRequest{Vertices: []*pb.Vertex{
+				{Key: "a", Value: &pb.Vertex_String_{String_: "a"}, Expiration: exp},
+				{Key: "b", Value: &pb.Vertex_String_{String_: "b"}, Expiration: exp},
+			}})); err != nil {
+				t.Fatalf("PutVertices: %v", err)
+			}
+			if _, err := c.PutEdges(ctx, connect.NewRequest(&pb.PutEdgesRequest{Edges: []*pb.Edge{
+				{Tail: "a", Head: "b", Weight: -1, Expiration: exp},
+				{Tail: "b", Head: "a", Weight: -1, Expiration: exp},
+			}})); err != nil {
+				t.Fatalf("PutEdges: %v", err)
+			}
+
+			_, err := c.Illuminate(ctx, connect.NewRequest(&pb.IlluminateRequest{
+				Seed: "a",
+				Params: &pb.IlluminateRequest_Bfs{Bfs: &pb.BfsParams{
+					Step: 3, FanOut: 8,
+					Reduction: pb.Reduction_REDUCTION_SHORTEST_PATH_TREE,
+					Objective: objective,
+				}},
+			}))
+			if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+				t.Fatalf("Illuminate code = %v, want FailedPrecondition (err=%v)", got, err)
+			}
+
+			// A follow-up RPC proves the failed reduction released the graph read lock.
+			if _, err := c.GetVertex(ctx, connect.NewRequest(&pb.GetVertexRequest{Key: "a"})); err != nil {
+				t.Fatalf("GetVertex after failed Illuminate: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- reject non-finite and negative shortest-path costs before running Dijkstra
- propagate a stable failed-precondition error through the server reduction path
- cover negative cycles and invalid weights over the real Connect/h2c surface

## Validation
- full root and all Go module test gate
- server `go vet ./...`
- golangci-lint changed-lines gate (CI-pinned v2.12.2)

Closes #982