### PR TITLE
fix(core): define correct directed semantics for MST reductions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ optimization direction, and weighting:
 | Axis | Options | What it picks |
 |---|---|---|
 | family verb | `bfs` / `pagerank` / `community` | Greedy per-hop top-k neighbourhood, Personalized PageRank relevance star, or the seed's natural community (conductance-cut, returned as a real induced subgraph) |
-| `reduction` | `none` (default) / `mst` / `spt` | Return the raw family result, or render the `bfs` / `community` result as a spanning-tree or shortest-path-tree view rooted at the seed |
+| `reduction` | `none` (default) / `mst` / `spt` | Return the raw family result, or render the `bfs` / `community` result as a rooted directed arborescence (`mst`) or shortest-path tree (`spt`) |
 | `objective` | `max` (default) / `min` | Keep strongest edges vs cheapest edges — the direction of both the `bfs` per-hop top-k prune and any tree reduction (ignored by `pagerank`, which ranks by mass) |
 | `weighting` | `raw` (default) / `tfidf` / `bm25` | Edge-weight transform applied before the walk — TF-IDF and BM25 damp hub vertices like "popular" items |
 
@@ -234,7 +234,10 @@ bfs user:42 2 10 weighting=tfidf                      # suppress hub items
 The family verb picks the traversal (`bfs`, `pagerank`, `community`) and the
 orthogonal `reduction` axis (`none` default, `mst`, `spt`) renders the
 `bfs`/`community` result as a tree rooted at the seed — so a local community
-can be handed back as its own minimum-spanning-tree backbone in one RPC.
+can be handed back as its own minimum/maximum rooted directed arborescence in
+one RPC. `mst` optimises over the actual directed edges: every reachable
+non-seed vertex has one incoming tree edge, rather than applying undirected
+Prim semantics to asymmetric relationships.
 `reduction` is not accepted by `pagerank`, which returns a ranked star.
 
 PPR takes two locality knobs (`restart_prob`, `epsilon` — higher restart

--- a/core/graph/graph_test.go
+++ b/core/graph/graph_test.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	"errors"
+	"strconv"
 	"testing"
 )
 
@@ -129,8 +130,8 @@ func TestGraph_MinimumSpanningTree(t *testing.T) {
 	}
 }
 
-// TestGraph_MinimumSpanningTree_Larger exercises Prim on a 5-vertex graph
-// with a clear optimum, to guard against the incremental-push refactor.
+// TestGraph_MinimumSpanningTree_Larger exercises the directed-arborescence
+// solver on a reciprocal graph with a clear optimum.
 //
 //	a -1- b
 //	|  \  |
@@ -200,6 +201,119 @@ func TestGraph_MaximumSpanningTree(t *testing.T) {
 	}
 	if total != 12 {
 		t.Errorf("Max spanning tree total = %v, want 12 (edges=%v)", total, mst.Edges)
+	}
+}
+
+func TestGraph_SpanningTree_DirectedArborescence(t *testing.T) {
+	// Lantern edges are directed. Classical Prim would greedily pick both
+	// root edges and return r->a(10) + r->b(11) = 21, but the optimal
+	// minimum rooted arborescence is r->b(11) + b->a(1) = 12.
+	//
+	//       10
+	//   r -----> a
+	//   |        ^
+	// 11|        |1
+	//   v        |
+	//   b --------
+	t.Run("minimum chooses the globally optimal directed tree", func(t *testing.T) {
+		g := NewGraph[string, int]()
+		g.PutEdge("r", "a", 10)
+		g.PutEdge("r", "b", 11)
+		g.PutEdge("b", "a", 1)
+
+		got := g.MinimumSpanningTree("r")
+		assertDirectedTree(t, got, map[string]map[string]float32{
+			"r": {"b": 11},
+			"b": {"a": 1},
+		})
+	})
+
+	t.Run("maximum chooses the globally optimal directed tree", func(t *testing.T) {
+		g := NewGraph[string, int]()
+		g.PutEdge("r", "a", 10)
+		g.PutEdge("r", "b", 11)
+		g.PutEdge("b", "a", 20)
+
+		got := g.MaximumSpanningTree("r")
+		assertDirectedTree(t, got, map[string]map[string]float32{
+			"r": {"b": 11},
+			"b": {"a": 20},
+		})
+	})
+
+	t.Run("contracts and expands a selected-edge cycle", func(t *testing.T) {
+		// The locally cheapest incoming edges select a<->b, which must be
+		// contracted. The optimum enters the cycle at a via r->a(5), then
+		// keeps a->b(1), rather than retaining the b->a cycle edge.
+		g := NewGraph[string, int]()
+		g.PutEdge("r", "a", 5)
+		g.PutEdge("r", "b", 6)
+		g.PutEdge("a", "b", 1)
+		g.PutEdge("b", "a", 1)
+		g.PutEdge("b", "c", 2)
+		g.PutEdge("r", "c", 10)
+
+		got := g.MinimumSpanningTree("r")
+		assertDirectedTree(t, got, map[string]map[string]float32{
+			"r": {"a": 5},
+			"a": {"b": 1},
+			"b": {"c": 2},
+		})
+	})
+}
+
+func assertDirectedTree(t *testing.T, got *Graph[string, int], want map[string]map[string]float32) {
+	t.Helper()
+	gotEdges := 0
+	for tail, heads := range got.Edges {
+		for head, weight := range heads {
+			gotEdges++
+			if wantWeight, ok := want[tail][head]; !ok || weight != wantWeight {
+				t.Errorf("unexpected edge %s->%s=%v (want %v)", tail, head, weight, want)
+			}
+		}
+	}
+	wantEdges := 0
+	for _, heads := range want {
+		wantEdges += len(heads)
+	}
+	if gotEdges != wantEdges {
+		t.Errorf("edge count = %d, want %d (edges=%v)", gotEdges, wantEdges, got.Edges)
+	}
+	for tail, heads := range want {
+		for head, wantWeight := range heads {
+			if gotWeight, ok := got.Edges[tail][head]; !ok || gotWeight != wantWeight {
+				t.Errorf("missing edge %s->%s=%v (edges=%v)", tail, head, wantWeight, got.Edges)
+			}
+		}
+	}
+}
+
+// BenchmarkGraph_MinimumSpanningTree_Directed is the representative #983
+// reduction benchmark. The graph has both a directed ring (which produces
+// selected-incoming-edge cycles before contraction) and root shortcuts, so it
+// exercises Chu–Liu/Edmonds rather than only the no-cycle fast path.
+func BenchmarkGraph_MinimumSpanningTree_Directed(b *testing.B) {
+	const vertices = 64
+	g := NewGraph[string, int]()
+	key := func(i int) string { return "v" + strconv.Itoa(i) }
+	for i := 0; i < vertices; i++ {
+		g.PutVertex(key(i), i)
+	}
+	for i := 0; i < vertices; i++ {
+		next := (i + 1) % vertices
+		prev := (i + vertices - 1) % vertices
+		g.PutEdge(key(i), key(next), 1)
+		g.PutEdge(key(i), key(prev), 2)
+		if i != 0 {
+			g.PutEdge(key(0), key(i), 10)
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if got := g.MinimumSpanningTree(key(0)); len(g.Vertices) != vertices {
+			b.Fatalf("vertices = %d, want %d", len(got.Vertices), vertices)
+		}
 	}
 }
 

--- a/core/graph/model.go
+++ b/core/graph/model.go
@@ -84,13 +84,18 @@ func (g *Graph[S, T]) ConnectedGraphContext(ctx context.Context, seed S) (*Graph
 	return connected, nil
 }
 
-// MinimumSpanningTree returns a minimum spanning tree of the graph rooted at seed.
+// MinimumSpanningTree returns the minimum-cost rooted directed arborescence
+// over every vertex reachable from seed. Lantern edges are directed, so this
+// is not an undirected Prim MST: every non-seed vertex has exactly one
+// selected incoming edge and remains reachable from seed in the result.
 func (g *Graph[S, T]) MinimumSpanningTree(seed S) *Graph[S, T] {
 	mst, _ := g.spanningTreeContext(context.Background(), seed, false)
 	return mst
 }
 
-// MaximumSpanningTree returns a maximum spanning tree of the graph rooted at seed.
+// MaximumSpanningTree returns the maximum-weight rooted directed arborescence
+// over every vertex reachable from seed. See [Graph.MinimumSpanningTree] for
+// the directed semantics.
 func (g *Graph[S, T]) MaximumSpanningTree(seed S) *Graph[S, T] {
 	mst, _ := g.spanningTreeContext(context.Background(), seed, true)
 	return mst
@@ -106,67 +111,188 @@ func (g *Graph[S, T]) MaximumSpanningTreeContext(ctx context.Context, seed S) (*
 	return g.spanningTreeContext(ctx, seed, true)
 }
 
-// spanningTreeContext computes either the minimum (negate=false) or maximum
-// (negate=true) spanning tree rooted at seed. It is the shared implementation
-// behind the exported MinimumSpanningTree / MaximumSpanningTree variants.
+// spanningTreeContext computes either the minimum (maximize=false) or
+// maximum (maximize=true) rooted directed arborescence. It is the shared
+// implementation behind the exported MinimumSpanningTree /
+// MaximumSpanningTree variants.
 //
-// Implementation: classic Prim. When a vertex enters the MST, only its
-// outgoing edges are pushed onto the priority queue, and stale entries
-// pointing at already-included vertices are skipped at pop time. Each edge
-// is therefore pushed and popped at most once, giving O((V+E) log V).
-// The previous version re-scanned mst.Vertices on every iteration of the
-// outer loop, paying an extra O(V) per added vertex.
-func (g *Graph[S, T]) spanningTreeContext(ctx context.Context, seed S, negate bool) (*Graph[S, T], error) {
+// Implementation: Chu–Liu/Edmonds. It selects the best incoming edge for
+// every non-root vertex, contracts any selected-edge cycles, recursively
+// solves the contracted graph, then expands the cycles by replacing precisely
+// the incoming edge where the chosen external edge enters. This gives the
+// optimal directed tree over the root-reachable subgraph, unlike Prim (whose
+// guarantee applies only to undirected graphs). The worst-case running time
+// is O(VE); traversal work limits bound this post-processing at the service
+// boundary.
+func (g *Graph[S, T]) spanningTreeContext(ctx context.Context, seed S, maximize bool) (*Graph[S, T], error) {
 	connected, err := g.ConnectedGraphContext(ctx, seed)
 	if err != nil {
 		return nil, err
 	}
 
-	type edge struct {
-		tail   S
-		head   S
-		weight float32
+	mst := NewGraph[S, T]()
+	if len(connected.Vertices) == 0 {
+		return mst, nil
 	}
 
-	mst := NewGraph[S, T]()
-	mst.PutVertex(seed, connected.Vertices[seed])
-
-	q := make(pq.PriorityQueue[*edge, float32], 0)
-	heap.Init(&q)
-
-	// pq is a max-heap; flip sign for the minimum-tree case so that the
-	// smallest original weight surfaces at the top.
-	pushOutgoing := func(tail S) {
-		for head, weight := range connected.Edges[tail] {
-			if _, ok := mst.Vertices[head]; ok {
+	vertices := make([]S, 0, len(connected.Vertices))
+	index := make(map[S]int, len(connected.Vertices))
+	for vertex := range connected.Vertices {
+		index[vertex] = len(vertices)
+		vertices = append(vertices, vertex)
+	}
+	root := index[seed]
+	edges := make([]*directedArborescenceEdge, 0)
+	for tail, heads := range connected.Edges {
+		from := index[tail]
+		for head, weight := range heads {
+			to := index[head]
+			if from == to {
+				// A self-loop cannot belong to a rooted arborescence.
 				continue
 			}
-			w := weight
-			if !negate {
-				w = -weight
+			cost := weight
+			if maximize {
+				// The solver minimizes. Negating retains the original edge
+				// weight for the returned graph while selecting the maximum
+				// total-weight arborescence.
+				cost = -cost
 			}
-			heap.Push(&q, &pq.Item[*edge, float32]{
-				Value:    &edge{tail: tail, head: head, weight: weight},
-				Priority: w,
+			edges = append(edges, &directedArborescenceEdge{
+				from:           from,
+				to:             to,
+				cost:           cost,
+				originalWeight: weight,
 			})
 		}
 	}
-	pushOutgoing(seed)
 
-	for q.Len() > 0 && len(mst.Vertices) < len(connected.Vertices) {
+	selected, err := minimumDirectedArborescence(ctx, len(vertices), root, edges)
+	if err != nil {
+		return nil, err
+	}
+	for _, vertex := range vertices {
+		mst.PutVertex(vertex, connected.Vertices[vertex])
+	}
+	for _, edge := range selected {
+		mst.PutEdge(vertices[edge.from], vertices[edge.to], edge.originalWeight)
+	}
+	return mst, nil
+}
+
+// directedArborescenceEdge is an edge in one Chu–Liu/Edmonds contraction
+// level. original points to the edge in the preceding level; top-level edges
+// have nil original and retain the source graph's endpoints and weight.
+type directedArborescenceEdge struct {
+	from, to       int
+	cost           float32
+	originalWeight float32
+	original       *directedArborescenceEdge
+}
+
+// minimumDirectedArborescence returns a minimum-cost arborescence rooted at
+// root. Its callers only pass a root-reachable graph, so every non-root node
+// has an incoming edge at every contraction level.
+func minimumDirectedArborescence(ctx context.Context, nodeCount, root int, edges []*directedArborescenceEdge) ([]*directedArborescenceEdge, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	incoming := make([]*directedArborescenceEdge, nodeCount)
+	for _, edge := range edges {
+		if edge.to == root {
+			continue
+		}
+		if current := incoming[edge.to]; current == nil || edge.cost < current.cost {
+			incoming[edge.to] = edge
+		}
+	}
+
+	// Find all cycles formed by the selected incoming edges. component is the
+	// contracted node ID; -1 marks a node not yet assigned to a component.
+	component := make([]int, nodeCount)
+	seen := make([]int, nodeCount)
+	for i := range component {
+		component[i] = -1
+		seen[i] = -1
+	}
+	componentCount := 0
+	for start := 0; start < nodeCount; start++ {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		picked := heap.Pop(&q).(*pq.Item[*edge, float32]).Value
-		if _, ok := mst.Vertices[picked.head]; ok {
-			// stale: head already absorbed via a better edge
+		vertex := start
+		for vertex != root && component[vertex] == -1 && seen[vertex] != start {
+			seen[vertex] = start
+			vertex = incoming[vertex].from
+		}
+		if vertex == root || component[vertex] != -1 {
 			continue
 		}
-		mst.PutVertex(picked.head, connected.Vertices[picked.head])
-		mst.PutEdge(picked.tail, picked.head, picked.weight)
-		pushOutgoing(picked.head)
+		for cycleVertex := incoming[vertex].from; cycleVertex != vertex; cycleVertex = incoming[cycleVertex].from {
+			component[cycleVertex] = componentCount
+		}
+		component[vertex] = componentCount
+		componentCount++
 	}
-	return mst, nil
+
+	if componentCount == 0 {
+		selected := make([]*directedArborescenceEdge, 0, nodeCount-1)
+		for vertex, edge := range incoming {
+			if vertex != root {
+				selected = append(selected, edge)
+			}
+		}
+		return selected, nil
+	}
+
+	// Give each non-cycle vertex a distinct component after the contracted
+	// cycles. The root cannot be in a selected-incoming-edge cycle.
+	for vertex := range component {
+		if component[vertex] == -1 {
+			component[vertex] = componentCount
+			componentCount++
+		}
+	}
+
+	contracted := make([]*directedArborescenceEdge, 0, len(edges))
+	for _, edge := range edges {
+		if edge.to == root {
+			// Root has no selected incoming edge, and no arborescence edge
+			// may enter it.
+			continue
+		}
+		from, to := component[edge.from], component[edge.to]
+		if from == to {
+			continue
+		}
+		contracted = append(contracted, &directedArborescenceEdge{
+			from:     from,
+			to:       to,
+			cost:     edge.cost - incoming[edge.to].cost,
+			original: edge,
+		})
+	}
+
+	selectedContracted, err := minimumDirectedArborescence(ctx, componentCount, component[root], contracted)
+	if err != nil {
+		return nil, err
+	}
+	// Begin with every locally best incoming edge. Each recursively selected
+	// contracted edge replaces the incoming edge for its original destination;
+	// when it enters a cycle that replacement is exactly the edge that breaks
+	// the cycle on expansion.
+	for _, edge := range selectedContracted {
+		incoming[edge.original.to] = edge.original
+	}
+
+	selected := make([]*directedArborescenceEdge, 0, nodeCount-1)
+	for vertex, edge := range incoming {
+		if vertex != root {
+			selected = append(selected, edge)
+		}
+	}
+	return selected, nil
 }
 
 // ShortestPathTree

--- a/docs/illuminate-complexity.md
+++ b/docs/illuminate-complexity.md
@@ -84,17 +84,19 @@ $$
 and the pruning *shrinks* the frontier handed to the next hop, which usually
 makes $E_{sub}$ far smaller than the reachable component.
 
-### Optional MST / SPT reduction
+### Optional directed-arborescence / SPT reduction
 
-When the caller asks for a spanning-tree reduction, the server runs Prim /
-Dijkstra-style selection over the already-collected subgraph
-(`spanningTreeContext` in `model.go`):
+When the caller asks for `reduction=mst`, the server computes a minimum or
+maximum rooted **directed arborescence** over the already-collected subgraph
+with Chu–Liu/Edmonds; it does not project asymmetric Lantern edges to an
+undirected graph or apply Prim. `reduction=spt` uses Dijkstra-style selection.
+The worst-case arborescence complexity is:
 
 $$
-O\!\left((V_{sub} + E_{sub})\,\log V_{sub}\right)
+O\!\left(V_{sub} E_{sub}\right)
 $$
 
-Still a function of the **visited subgraph only** — never of $N$ or $E$.
+Both are functions of the **visited subgraph only** — never of $N$ or $E$.
 
 > The walk processes tails through a worker pool, so wall-clock time also
 > benefits from parallelism, but that is a constant-factor effect and does not

--- a/pb/graph/v1/graph.pb.go
+++ b/pb/graph/v1/graph.pb.go
@@ -26,10 +26,12 @@ const (
 // Reduction is the optional post-traversal tree view applied to a
 // BFS-discovered neighbourhood (#846). UNSPECIFIED returns the raw
 // discovered subgraph; MINIMUM_SPANNING_TREE / SHORTEST_PATH_TREE reduce it
-// to a tree rooted at the seed. The MIN/MAX direction is independent and
-// carried by Objective. Reductions are a BfsParams knob — not sibling
-// traversals — which is why the former Algorithm enum (which conflated the
-// two; see #410/#801 history) left the request in the oneof redesign.
+// to a tree rooted at the seed. MINIMUM_SPANNING_TREE means a directed
+// minimum/maximum rooted arborescence over Lantern's directed edges (not an
+// undirected Prim projection); the MIN/MAX direction is carried by Objective.
+// Reductions are a BfsParams knob — not sibling traversals — which is why the
+// former Algorithm enum (which conflated the two; see #410/#801 history) left
+// the request in the oneof redesign.
 type Reduction int32
 
 const (

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -43,10 +43,12 @@ message Graph {
 // Reduction is the optional post-traversal tree view applied to a
 // BFS-discovered neighbourhood (#846). UNSPECIFIED returns the raw
 // discovered subgraph; MINIMUM_SPANNING_TREE / SHORTEST_PATH_TREE reduce it
-// to a tree rooted at the seed. The MIN/MAX direction is independent and
-// carried by Objective. Reductions are a BfsParams knob — not sibling
-// traversals — which is why the former Algorithm enum (which conflated the
-// two; see #410/#801 history) left the request in the oneof redesign.
+// to a tree rooted at the seed. MINIMUM_SPANNING_TREE means a directed
+// minimum/maximum rooted arborescence over Lantern's directed edges (not an
+// undirected Prim projection); the MIN/MAX direction is carried by Objective.
+// Reductions are a BfsParams knob — not sibling traversals — which is why the
+// former Algorithm enum (which conflated the two; see #410/#801 history) left
+// the request in the oneof redesign.
 enum Reduction {
   REDUCTION_UNSPECIFIED = 0;
   REDUCTION_MINIMUM_SPANNING_TREE = 1;

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -85,8 +85,9 @@ func EdgeExpiration(e *Edge) time.Time {
 // Reduction re-exports the server-side post-traversal tree-view enum so SDK
 // callers do not need to import the generated proto package directly. Per
 // the #846 oneof redesign, MST/SPT are a knob of the BFS family
-// (BFSOpts.Reduction) — not sibling algorithms — and Personalized PageRank
-// is selected by passing WithPPR instead.
+// (BFSOpts.Reduction) — not sibling algorithms. MST is a rooted directed
+// arborescence over Lantern's directed edges, and Personalized PageRank is
+// selected by passing WithPPR instead.
 type Reduction = pb.Reduction
 
 const (
@@ -98,8 +99,9 @@ const (
 // Objective is the direction of the weight-sensitive optimisation. It
 // governs both the per-hop top-k pruning and the post-traversal reduction
 // (#560): MINIMIZE treats edge weights as costs (keeps the k smallest-weight
-// edges per hop, smallest tree wins), MAXIMIZE treats them as relevance
-// (keeps the k largest-weight edges per hop, largest tree wins). Server
+// edges per hop, smallest directed arborescence wins), MAXIMIZE treats them
+// as relevance (keeps the k largest-weight edges per hop, largest directed
+// arborescence wins). Server
 // resolves ObjectiveUnspecified to ObjectiveMaximize.
 type Objective = pb.Objective
 

--- a/sdks/node/src/gen/graph/v1/graph_pb.ts
+++ b/sdks/node/src/gen/graph/v1/graph_pb.ts
@@ -2159,10 +2159,12 @@ export const BackupSnapshotResponseSchema: GenMessage<BackupSnapshotResponse> = 
  * Reduction is the optional post-traversal tree view applied to a
  * BFS-discovered neighbourhood (#846). UNSPECIFIED returns the raw
  * discovered subgraph; MINIMUM_SPANNING_TREE / SHORTEST_PATH_TREE reduce it
- * to a tree rooted at the seed. The MIN/MAX direction is independent and
- * carried by Objective. Reductions are a BfsParams knob — not sibling
- * traversals — which is why the former Algorithm enum (which conflated the
- * two; see #410/#801 history) left the request in the oneof redesign.
+ * to a tree rooted at the seed. MINIMUM_SPANNING_TREE means a directed
+ * minimum/maximum rooted arborescence over Lantern's directed edges (not an
+ * undirected Prim projection); the MIN/MAX direction is carried by Objective.
+ * Reductions are a BfsParams knob — not sibling traversals — which is why the
+ * former Algorithm enum (which conflated the two; see #410/#801 history) left
+ * the request in the oneof redesign.
  *
  * @generated from enum graph.v1.Reduction
  */

--- a/sdks/node/src/options.ts
+++ b/sdks/node/src/options.ts
@@ -22,8 +22,8 @@ export interface BfsOptions {
    */
   objective?: Objective;
   /**
-   * Optional tree view of the discovered neighbourhood (MST / SPT rooted at
-   * the seed). UNSPECIFIED = raw subgraph.
+   * Optional tree view of the discovered neighbourhood: a directed
+   * arborescence (MST) or SPT rooted at the seed. UNSPECIFIED = raw subgraph.
    */
   reduction?: Reduction;
 }

--- a/sdks/node/src/values.ts
+++ b/sdks/node/src/values.ts
@@ -158,9 +158,9 @@ export type VertexKind =
  * BFS-family axes.
  *
  *   - `Reduction`  optional post-traversal tree view of the BFS-discovered
- *                  neighbourhood: UNSPECIFIED (raw subgraph), MST, or SPT
- *                  (tree rooted at the seed). A BFS-family knob — PPR is a
- *                  different family, not a reduction.
+ *                  neighbourhood: UNSPECIFIED (raw subgraph), directed MST,
+ *                  or SPT (tree rooted at the seed). A BFS-family knob — PPR
+ *                  is a different family, not a reduction.
  *   - `Objective`  selects the direction: MINIMIZE (cost-weighted) or
  *                  MAXIMIZE (relevance-weighted). Governs both the per-hop
  *                  pruning and the reduction (#560).

--- a/server/service/optimizer.go
+++ b/server/service/optimizer.go
@@ -17,7 +17,9 @@ type optimizer func(ctx context.Context, g *coregraph.Graph[string, *pb.Vertex],
 // resolveOptimizer returns the post-traversal reduction for a
 // (reduction, objective) pair (#846: reductions are a BfsParams knob, not
 // sibling traversals). Returns nil when no reduction is needed — the caller
-// treats nil as "return the raw discovered subgraph".
+// treats nil as "return the raw discovered subgraph". The MST branch is a
+// minimum/maximum rooted directed arborescence, matching Lantern's directed
+// edge model.
 //
 // Note: Reduction UNSPECIFIED → nil (no reduction). Objective
 // OBJECTIVE_UNSPECIFIED resolves to MAXIMIZE per the proto-level default

--- a/testbed/bench/scenarios/illuminate_mst_max.yaml
+++ b/testbed/bench/scenarios/illuminate_mst_max.yaml
@@ -1,5 +1,5 @@
-# illuminate_mst_max — MAX-MST reduction at the baseline RPS.
-# Goal: cover the (reduction=mst, objective=maximize) path of the BFS
+# illuminate_mst_max — maximum directed-arborescence reduction at baseline RPS.
+# Goal: cover the Chu–Liu/Edmonds (reduction=mst, objective=maximize) path of the BFS
 # family of the params-oneof Illuminate API (#846). Uses the proto numeric
 # enum values directly to keep the JSON payload minimal:
 #

--- a/tests/integration/illuminate_prefix_test.go
+++ b/tests/integration/illuminate_prefix_test.go
@@ -256,3 +256,131 @@ func TestIlluminate_OneofArmRoundTrips(t *testing.T) {
 		})
 	}
 }
+
+// TestLantern_Illuminate_MSTReducesDirectedArborescence drives the #983
+// asymmetric counterexample through the actual Connect/h2c wire for both
+// reduction-capable families. A Prim-style outgoing-edge walk would choose
+// r->a(10) and r->b(11); the minimum rooted directed arborescence must instead
+// choose r->b(11) and b->a(9), whose total cost is 20.
+func TestLantern_Illuminate_MSTReducesDirectedArborescence(t *testing.T) {
+	exp := timestamppb.New(time.Now().Add(time.Hour))
+	putGraph := func(t *testing.T, keys []string, edges []*pb.Edge) (graphv1connect.LanternServiceClient, context.Context) {
+		t.Helper()
+		c, _ := newRawConnectClient(t, false)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+		vertices := make([]*pb.Vertex, len(keys))
+		for i, key := range keys {
+			vertices[i] = &pb.Vertex{Key: key, Value: &pb.Vertex_String_{String_: key}, Expiration: exp}
+		}
+		if _, err := c.PutVertices(ctx, connect.NewRequest(&pb.PutVerticesRequest{Vertices: vertices})); err != nil {
+			t.Fatalf("PutVertices: %v", err)
+		}
+		for _, edge := range edges {
+			edge.Expiration = exp
+		}
+		if _, err := c.PutEdges(ctx, connect.NewRequest(&pb.PutEdgesRequest{Edges: edges})); err != nil {
+			t.Fatalf("PutEdges: %v", err)
+		}
+		return c, ctx
+	}
+
+	assertArborescence := func(t *testing.T, graph *pb.Graph, wantCount int, want map[string]float32) {
+		t.Helper()
+		got := make(map[string]float32, len(graph.GetEdges()))
+		for _, edge := range graph.GetEdges() {
+			got[edge.GetTail()+"->"+edge.GetHead()] = edge.GetWeight()
+		}
+		if len(got) != wantCount {
+			t.Fatalf("tree edge count = %d, want %d (edges=%v)", len(got), wantCount, got)
+		}
+		for key, weight := range want {
+			if gotWeight, ok := got[key]; !ok || gotWeight != weight {
+				t.Errorf("tree edge %s = (%v,%v), want (%v,true); edges=%v", key, gotWeight, ok, weight, got)
+			}
+		}
+		if _, hasPrimEdge := got["r->a"]; hasPrimEdge {
+			t.Errorf("Prim-style edge r->a must not survive: %v", got)
+		}
+	}
+
+	cases := []struct {
+		name      string
+		keys      []string
+		edges     []*pb.Edge
+		req       *pb.IlluminateRequest
+		wantCount int
+		want      map[string]float32
+	}{
+		{
+			name:  "bfs",
+			keys:  []string{"r", "a", "b"},
+			edges: []*pb.Edge{{Tail: "r", Head: "a", Weight: 10}, {Tail: "r", Head: "b", Weight: 11}, {Tail: "b", Head: "a", Weight: 9}},
+			req: &pb.IlluminateRequest{Seed: "r", Params: &pb.IlluminateRequest_Bfs{Bfs: &pb.BfsParams{
+				Step: 2, FanOut: 2,
+				Reduction: pb.Reduction_REDUCTION_MINIMUM_SPANNING_TREE,
+				Objective: pb.Objective_OBJECTIVE_MINIMIZE,
+			}}},
+			wantCount: 2,
+			want:      map[string]float32{"r->b": 11, "b->a": 9},
+		},
+		{
+			name: "community",
+			keys: []string{"r", "a", "b", "c", "d", "e", "f", "g"},
+			edges: func() []*pb.Edge {
+				// Two strongly connected cliques joined by a weak bridge use the
+				// same real community shape as the core PageRank-Nibble contract.
+				// The first clique embeds the asymmetric arborescence counterexample.
+				members := []string{"r", "a", "b", "c"}
+				edges := make([]*pb.Edge, 0, 26)
+				for _, tail := range members {
+					for _, head := range members {
+						if tail != head {
+							edges = append(edges, &pb.Edge{Tail: tail, Head: head, Weight: 100})
+						}
+					}
+				}
+				for _, edge := range edges {
+					switch {
+					case edge.Tail == "r" && edge.Head == "a":
+						edge.Weight = 100
+					case edge.Tail == "r" && edge.Head == "b":
+						edge.Weight = 101
+					case edge.Tail == "r" && edge.Head == "c":
+						edge.Weight = 100
+					case edge.Tail == "b" && edge.Head == "a":
+						edge.Weight = 99
+					case (edge.Tail == "a" || edge.Tail == "c") && edge.Head == "b":
+						edge.Weight = 110
+					}
+				}
+				for _, tail := range []string{"d", "e", "f", "g"} {
+					for _, head := range []string{"d", "e", "f", "g"} {
+						if tail != head {
+							edges = append(edges, &pb.Edge{Tail: tail, Head: head, Weight: 1})
+						}
+					}
+				}
+				return append(edges, &pb.Edge{Tail: "c", Head: "d", Weight: 0.05}, &pb.Edge{Tail: "d", Head: "c", Weight: 0.05})
+			}(),
+			req: &pb.IlluminateRequest{Seed: "r", Params: &pb.IlluminateRequest_Community{Community: &pb.LocalCommunityParams{
+				MaxSize:   0,
+				Epsilon:   1e-6,
+				Reduction: pb.Reduction_REDUCTION_MINIMUM_SPANNING_TREE,
+				Objective: pb.Objective_OBJECTIVE_MINIMIZE,
+			}}},
+			wantCount: 3,
+			want:      map[string]float32{"r->b": 101, "b->a": 99},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, ctx := putGraph(t, tc.keys, tc.edges)
+			resp, err := c.Illuminate(ctx, connect.NewRequest(tc.req))
+			if err != nil {
+				t.Fatalf("Illuminate: %v", err)
+			}
+			assertArborescence(t, resp.Msg.GetGraph(), tc.wantCount, tc.want)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- replace the undirected MST projection with a rooted directed Chu-Liu/Edmonds arborescence
- preserve deterministic objective-aware tie handling and disconnected membership
- align proto/SDK docs and real-wire integration coverage with directed semantics

## Validation
- full root and all Go module test gate
- server `go vet ./...`
- golangci-lint changed-lines gate (CI-pinned v2.12.2)

Closes #983