### PR TITLE
fix(server,core): bound PPR/community work and graph lock time

### DIFF
--- a/core/graphcache/traversal.go
+++ b/core/graphcache/traversal.go
@@ -2,6 +2,7 @@ package graphcache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"runtime"
@@ -320,34 +321,55 @@ const (
 	// caller passes a non-positive epsilon. 1e-4 keeps the push budget small
 	// (O(1/(alpha*eps))) while staying accurate enough for ranking.
 	DefaultPPREpsilon = 1e-4
-	// pprCtxCheckInterval is how often (in pushes) the forward-push loop polls
-	// ctx for cancellation, amortising the check off the hot path the same way
-	// neighborContext checks once per BFS step.
-	pprCtxCheckInterval = 1024
+	// pprCtxCheckInterval bounds cancellation latency both between pushes and
+	// while scanning a high-degree adjacency row.
+	pprCtxCheckInterval = 256
+	// pprQueueCompactThreshold avoids retaining a grow-only queue backing
+	// array after most of its entries have been consumed.
+	pprQueueCompactThreshold = 1024
 )
 
-// pprMaxPushes is a hard guard on the forward-push budget against pathological
-// inputs (a tiny eps or alpha). The Andersen–Chung–Lang bound is ~1/(alpha*eps)
-// pushes; we allow a generous multiple plus a floor so a small graph with a
-// modest eps is never truncated before it converges, and clamp to a hard cap so
-// an adversarial request cannot spin indefinitely.
-func pprMaxPushes(alpha, epsilon float64) int {
-	const (
-		floor   = 1 << 16 // 65k — never truncate a small, well-behaved walk
-		hardCap = 1 << 27 // ~134M — absolute ceiling regardless of eps/alpha
-	)
-	if alpha <= 0 || epsilon <= 0 {
-		return floor
+// PPRWorkBudget bounds actual forward-push work, independently of response
+// size. Both fields must be positive; zero and negative values are normalised
+// to the safe defaults so no caller accidentally opts into unbounded work.
+// The server supplies its operator-owned budget for RPCs; direct core callers
+// receive the same finite defaults.
+type PPRWorkBudget struct {
+	MaxPushes       int
+	MaxTouchedEdges int
+}
+
+var ErrPPRWorkBudgetExceeded = errors.New("personalized pagerank work budget exhausted")
+
+// PPRWorkBudgetExceededError reports a rejected, non-converged traversal. It
+// deliberately contains counters rather than a partial graph: returning a
+// truncated result as though it converged would give callers false confidence.
+type PPRWorkBudgetExceededError struct {
+	Budget       PPRWorkBudget
+	Pushes       int
+	TouchedEdges int
+}
+
+func (e *PPRWorkBudgetExceededError) Error() string {
+	return fmt.Sprintf("%v: pushes=%d/%d touched_edges=%d/%d", ErrPPRWorkBudgetExceeded,
+		e.Pushes, e.Budget.MaxPushes, e.TouchedEdges, e.Budget.MaxTouchedEdges)
+}
+
+func (e *PPRWorkBudgetExceededError) Unwrap() error { return ErrPPRWorkBudgetExceeded }
+
+func defaultPPRWorkBudget() PPRWorkBudget {
+	return PPRWorkBudget{MaxPushes: 1_000_000, MaxTouchedEdges: 10_000_000}
+}
+
+func (b PPRWorkBudget) normalized() PPRWorkBudget {
+	d := defaultPPRWorkBudget()
+	if b.MaxPushes <= 0 {
+		b.MaxPushes = d.MaxPushes
 	}
-	bound := 8.0 / (alpha * epsilon)
-	if bound >= hardCap {
-		return hardCap
+	if b.MaxTouchedEdges <= 0 {
+		b.MaxTouchedEdges = d.MaxTouchedEdges
 	}
-	n := int(bound) + floor
-	if n > hardCap {
-		return hardCap
-	}
-	return n
+	return b
 }
 
 // PersonalizedPageRank is the context-free convenience wrapper over
@@ -377,15 +399,22 @@ func (c *GraphCache[S, T]) PersonalizedPageRank(seed S, topN int, alpha, epsilon
 // (raw / tfidf / bm25, via the shared scoreEdge kernel) so BM25-weighted PPR
 // composes for free. keep is the optional frontier predicate (#601): a head is
 // only walked into (and ranked) when keep(head) is true; the seed is the
-// anchor exemption. ctx is polled every pprCtxCheckInterval pushes and returns
-// ctx.Err() when cancelled. topN caps the ranked vertices returned (the request
-// k); topN <= 0 returns every vertex with positive mass. An unknown seed yields
-// an empty graph (the seed vertex alone is never emitted without neighbours).
+// anchor exemption. It uses the finite default PPRWorkBudget. Call
+// PersonalizedPageRankWithWorkBudgetContext when the caller owns stricter
+// operational limits.
 func (c *GraphCache[S, T]) PersonalizedPageRankContext(ctx context.Context, seed S, topN int, alpha, epsilon float64, weighting EdgeWeighting, keep func(S) bool) (*graph.Graph[S, T], error) {
-	if alpha <= 0 || alpha >= 1 {
+	return c.PersonalizedPageRankWithWorkBudgetContext(ctx, seed, topN, alpha, epsilon, weighting, keep, defaultPPRWorkBudget())
+}
+
+// PersonalizedPageRankWithWorkBudgetContext is PersonalizedPageRankContext
+// with an explicit bound on forward pushes and scanned adjacency entries. A
+// budget exhaustion returns ErrPPRWorkBudgetExceeded instead of a partial,
+// falsely-converged relevance star.
+func (c *GraphCache[S, T]) PersonalizedPageRankWithWorkBudgetContext(ctx context.Context, seed S, topN int, alpha, epsilon float64, weighting EdgeWeighting, keep func(S) bool, budget PPRWorkBudget) (*graph.Graph[S, T], error) {
+	if alpha <= 0 || alpha >= 1 || math.IsNaN(alpha) || math.IsInf(alpha, 0) {
 		alpha = DefaultPPRAlpha
 	}
-	if epsilon <= 0 {
+	if epsilon <= 0 || math.IsNaN(epsilon) || math.IsInf(epsilon, 0) {
 		epsilon = DefaultPPREpsilon
 	}
 
@@ -406,7 +435,7 @@ func (c *GraphCache[S, T]) PersonalizedPageRankContext(ctx context.Context, seed
 	// One liveness instant for the whole push (#838), mirroring
 	// neighborContext.
 	now := time.Now()
-	p, err := c.pprPushLocked(ctx, seed, alpha, epsilon, weighting, keep, now)
+	p, err := c.pprPushLocked(ctx, seed, alpha, epsilon, weighting, keep, now, budget)
 	if err != nil {
 		return nil, err
 	}
@@ -443,11 +472,12 @@ func (c *GraphCache[S, T]) PersonalizedPageRankContext(ctx context.Context, seed
 // pprPushLocked runs the Andersen–Chung–Lang local forward-push from seed and
 // returns the approximate PPR vector p. Factored out of
 // PersonalizedPageRankContext (#845) so the sweep-cut community extraction
-// shares one push implementation — same defaults, caps, ctx polling, keep
+// shares one push implementation — same defaults, work budget, ctx polling, keep
 // predicate, and #750 liveness rules. Caller must hold c.mu.RLock and have
 // resolved alpha/epsilon to their in-range values; now is the single liveness
 // instant for the whole walk (#838).
-func (c *GraphCache[S, T]) pprPushLocked(ctx context.Context, seed S, alpha, epsilon float64, weighting EdgeWeighting, keep func(S) bool, now time.Time) (map[S]float64, error) {
+func (c *GraphCache[S, T]) pprPushLocked(ctx context.Context, seed S, alpha, epsilon float64, weighting EdgeWeighting, keep func(S) bool, now time.Time, budget PPRWorkBudget) (map[S]float64, error) {
+	budget = budget.normalized()
 	// BM25 corpus statistics are read once, only for the BM25 weighting, under
 	// the same RLock the per-edge accessors rely on — identical to
 	// neighborContext so PPR transitions and the BFS prune weight edges alike.
@@ -473,13 +503,20 @@ func (c *GraphCache[S, T]) pprPushLocked(ctx context.Context, seed S, alpha, eps
 	r := map[S]float64{seed: 1}
 	queue := []S{seed}
 	inQueue := map[S]bool{seed: true}
-	maxPushes := pprMaxPushes(alpha, epsilon)
+	pushes, touchedEdges := 0, 0
+	compactQueue := func(qi int) ([]S, int) {
+		if qi < pprQueueCompactThreshold || qi*2 < len(queue) {
+			return queue, qi
+		}
+		active := append([]S(nil), queue[qi:]...)
+		return active, 0
+	}
 
-	// Index cursor instead of queue = queue[1:], so the loop does not
-	// re-slice while retaining the consumed backing head.
-	pushes := 0
-	for qi := 0; qi < len(queue); qi++ {
+	for qi := 0; qi < len(queue); {
 		u := queue[qi]
+		var zero S
+		queue[qi] = zero
+		qi++
 		inQueue[u] = false
 		ru := r[u]
 
@@ -494,6 +531,15 @@ func (c *GraphCache[S, T]) pprPushLocked(ctx context.Context, seed S, alpha, eps
 				docLen = len(heads) // BM25 document length = raw out-degree
 				outs = make([]scoredEdge, 0, len(heads))
 				for headID, w := range heads {
+					touchedEdges++
+					if touchedEdges > budget.MaxTouchedEdges {
+						return nil, &PPRWorkBudgetExceededError{Budget: budget, Pushes: pushes, TouchedEdges: touchedEdges}
+					}
+					if touchedEdges%pprCtxCheckInterval == 0 {
+						if err := ctx.Err(); err != nil {
+							return nil, err
+						}
+					}
 					head, ok := c.edges.resolveID(headID)
 					if !ok {
 						continue
@@ -523,7 +569,11 @@ func (c *GraphCache[S, T]) pprPushLocked(ctx context.Context, seed S, alpha, eps
 		// alpha share is absorbed into p and the remaining mass leaks — using a
 		// degree floor of 1 so a non-trivial residual is not stranded forever.
 		if ru < epsilon*float64(max(len(outs), 1)) {
+			queue, qi = compactQueue(qi)
 			continue
+		}
+		if pushes >= budget.MaxPushes {
+			return nil, &PPRWorkBudgetExceededError{Budget: budget, Pushes: pushes, TouchedEdges: touchedEdges}
 		}
 
 		r[u] = 0
@@ -540,14 +590,12 @@ func (c *GraphCache[S, T]) pprPushLocked(ctx context.Context, seed S, alpha, eps
 		}
 
 		pushes++
-		if pushes >= maxPushes {
-			break
-		}
 		if pushes%pprCtxCheckInterval == 0 {
 			if err := ctx.Err(); err != nil {
 				return nil, err
 			}
 		}
+		queue, qi = compactQueue(qi)
 	}
 	return p, nil
 }
@@ -593,10 +641,17 @@ func (c *GraphCache[S, T]) LocalCommunity(seed S, maxSize int, alpha, epsilon fl
 // over, so the tree honours the weighting. An unknown seed yields an empty
 // graph.
 func (c *GraphCache[S, T]) LocalCommunityContext(ctx context.Context, seed S, maxSize int, alpha, epsilon float64, weighting EdgeWeighting, keep func(S) bool) (*graph.Graph[S, T], map[S]map[S]time.Time, error) {
-	if alpha <= 0 || alpha >= 1 {
+	return c.LocalCommunityWithWorkBudgetContext(ctx, seed, maxSize, alpha, epsilon, weighting, keep, defaultPPRWorkBudget())
+}
+
+// LocalCommunityWithWorkBudgetContext is LocalCommunityContext with an
+// explicit budget for the shared PageRank-Nibble forward push. Exhaustion
+// returns ErrPPRWorkBudgetExceeded; it never emits a partial community.
+func (c *GraphCache[S, T]) LocalCommunityWithWorkBudgetContext(ctx context.Context, seed S, maxSize int, alpha, epsilon float64, weighting EdgeWeighting, keep func(S) bool, budget PPRWorkBudget) (*graph.Graph[S, T], map[S]map[S]time.Time, error) {
+	if alpha <= 0 || alpha >= 1 || math.IsNaN(alpha) || math.IsInf(alpha, 0) {
 		alpha = DefaultPPRAlpha
 	}
-	if epsilon <= 0 {
+	if epsilon <= 0 || math.IsNaN(epsilon) || math.IsInf(epsilon, 0) {
 		epsilon = DefaultPPREpsilon
 	}
 
@@ -613,7 +668,7 @@ func (c *GraphCache[S, T]) LocalCommunityContext(ctx context.Context, seed S, ma
 	}
 
 	now := time.Now()
-	p, err := c.pprPushLocked(ctx, seed, alpha, epsilon, weighting, keep, now)
+	p, err := c.pprPushLocked(ctx, seed, alpha, epsilon, weighting, keep, now, budget)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/core/graphcache/traversal_test.go
+++ b/core/graphcache/traversal_test.go
@@ -2,6 +2,7 @@ package graphcache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"reflect"
@@ -577,6 +578,54 @@ func TestGraphCache_PersonalizedPageRank(t *testing.T) {
 		}
 	})
 
+	t.Run("WorkBudgetReturnsTypedErrorInsteadOfPartialStar", func(t *testing.T) {
+		c := NewGraphCache[string, int](time.Minute)
+		c.AddEdge("seed", "a", 1)
+		c.AddEdge("a", "seed", 1)
+		_, err := c.PersonalizedPageRankWithWorkBudgetContext(context.Background(), "seed", 0, 0.15, 1e-9, WeightingRaw, nil,
+			PPRWorkBudget{MaxPushes: 1, MaxTouchedEdges: 100})
+		if !errors.Is(err, ErrPPRWorkBudgetExceeded) {
+			t.Fatalf("errors.Is(err, ErrPPRWorkBudgetExceeded) = false; err = %v", err)
+		}
+		var exhausted *PPRWorkBudgetExceededError
+		if !errors.As(err, &exhausted) || exhausted.Pushes != 1 {
+			t.Fatalf("budget error = %+v, want typed error after one push", exhausted)
+		}
+	})
+
+	t.Run("WorkBudgetCapsHighDegreeAdjacencyScans", func(t *testing.T) {
+		c := NewGraphCache[string, int](time.Minute)
+		c.AddEdge("seed", "a", 1)
+		c.AddEdge("seed", "b", 1)
+		_, err := c.PersonalizedPageRankWithWorkBudgetContext(context.Background(), "seed", 0, 0.15, 1e-9, WeightingRaw, nil,
+			PPRWorkBudget{MaxPushes: 100, MaxTouchedEdges: 1})
+		if !errors.Is(err, ErrPPRWorkBudgetExceeded) {
+			t.Fatalf("errors.Is(err, ErrPPRWorkBudgetExceeded) = false; err = %v", err)
+		}
+	})
+
+	t.Run("CancellationIsPolledInsideHighDegreeAdjacencyScans", func(t *testing.T) {
+		c := NewGraphCache[string, int](time.Minute)
+		for i := range 512 {
+			c.AddEdge("seed", fmt.Sprintf("v-%d", i), 1)
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		seen := 0
+		keep := func(string) bool {
+			seen++
+			if seen == 300 {
+				cancel()
+			}
+			return true
+		}
+		_, err := c.PersonalizedPageRankWithWorkBudgetContext(ctx, "seed", 0, 0.15, 1e-9, WeightingRaw, keep,
+			PPRWorkBudget{MaxPushes: 100, MaxTouchedEdges: 10_000})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("errors.Is(err, context.Canceled) = false; err = %v", err)
+		}
+	})
+
 	t.Run("UnknownSeed", func(t *testing.T) {
 		c := NewGraphCache[string, int](time.Minute)
 		c.AddEdge("seed", "a", 1)
@@ -596,6 +645,20 @@ func TestGraphCache_PersonalizedPageRank(t *testing.T) {
 		star := g.Edges["seed"]
 		if star == nil || !(star["a"] > star["b"]) {
 			t.Errorf("defaulted PPR should still rank the heavier head first: %+v", star)
+		}
+	})
+
+	t.Run("DefaultsOnNonFiniteParams", func(t *testing.T) {
+		c := NewGraphCache[string, int](time.Minute)
+		c.AddEdge("seed", "a", 2)
+		c.AddEdge("seed", "b", 1)
+		g, err := c.PersonalizedPageRankContext(context.Background(), "seed", 0, math.NaN(), math.NaN(), WeightingRaw, nil)
+		if err != nil {
+			t.Fatalf("PersonalizedPageRankContext: %v", err)
+		}
+		star := g.Edges["seed"]
+		if star == nil || math.IsNaN(float64(star["a"])) || math.IsNaN(float64(star["b"])) {
+			t.Fatalf("non-finite parameters poisoned PPR output: %+v", star)
 		}
 	})
 }

--- a/docs/env.md
+++ b/docs/env.md
@@ -85,5 +85,8 @@ value is treated as unset for the non-string kinds. The MCP server's
 | `LANTERN_TLS_CLIENT_CA_FILE` | string | (empty) | PEM client-CA bundle path; setting it additionally enables mTLS client verification. |
 | `LANTERN_TLS_KEY_FILE` | string | (empty) | PEM private-key path; pairs with LANTERN_TLS_CERT_FILE. |
 | `LANTERN_TOMBSTONE_TTL` | duration | `8760h0m0s` | Delete-tombstone retention window and the upper bound on caller-supplied expirations. |
-| `LANTERN_TRAVERSAL_TIMEOUT_MS` | int | `0` | Server-side wall-clock budget for Illuminate traversals in milliseconds (0 = client-owned deadlines only); expiry surfaces as DEADLINE_EXCEEDED. |
+| `LANTERN_TRAVERSAL_MAX_PUSHES` | int | `1000000` | Maximum PPR/PageRank-Nibble forward pushes per Illuminate call; exhaustion returns RESOURCE_EXHAUSTED, never a partial result. |
+| `LANTERN_TRAVERSAL_MAX_RESULTS` | int | `1024` | Maximum PPR star members or local-community members returned by Illuminate; wire top_n=0/max_size=0 resolve to this cap. |
+| `LANTERN_TRAVERSAL_MAX_TOUCHED_EDGES` | int | `10000000` | Maximum adjacency entries scanned by PPR/PageRank-Nibble per Illuminate call; exhaustion returns RESOURCE_EXHAUSTED. |
+| `LANTERN_TRAVERSAL_TIMEOUT_MS` | int | `5000` | Server-side wall-clock budget for Illuminate traversals in milliseconds (default 5000; 0 explicitly disables it); expiry surfaces as DEADLINE_EXCEEDED. |
 | `LANTERN_VERSION` | string | (empty) | Overrides the version label reported in lantern_build_info and GetServerStatus. |

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
 	"github.com/anaregdesign/lantern/server/backup"
@@ -162,6 +163,13 @@ func newLanternService(
 		WithTombstoneClampRejectHook(dm.OnTombstoneClampRejected).
 		WithTombstoneTTL(rc.TombstoneTTL).
 		WithTraversalTimeout(trc.Timeout).
+		WithTraversalLimits(service.TraversalLimits{
+			WorkBudget: graphcache.PPRWorkBudget{
+				MaxPushes:       trc.MaxPushes,
+				MaxTouchedEdges: trc.MaxTouchedEdges,
+			},
+			MaxResults: trc.MaxResults,
+		}).
 		WithHotPathMetrics(dm).
 		WithLogger(logger).
 		WithStatusInfo(service.StatusInfo{

--- a/server/internal/envdoc/envdoc.go
+++ b/server/internal/envdoc/envdoc.go
@@ -109,7 +109,10 @@ var descriptions = map[string]string{
 
 	"LANTERN_STRICT_CONFIG": "Refuse to boot when any LANTERN_* value is malformed or an unknown LANTERN_* variable is set.",
 
-	"LANTERN_TRAVERSAL_TIMEOUT_MS": "Server-side wall-clock budget for Illuminate traversals in milliseconds (0 = client-owned deadlines only); expiry surfaces as DEADLINE_EXCEEDED.",
+	"LANTERN_TRAVERSAL_MAX_PUSHES":        "Maximum PPR/PageRank-Nibble forward pushes per Illuminate call; exhaustion returns RESOURCE_EXHAUSTED, never a partial result.",
+	"LANTERN_TRAVERSAL_MAX_RESULTS":       "Maximum PPR star members or local-community members returned by Illuminate; wire top_n=0/max_size=0 resolve to this cap.",
+	"LANTERN_TRAVERSAL_MAX_TOUCHED_EDGES": "Maximum adjacency entries scanned by PPR/PageRank-Nibble per Illuminate call; exhaustion returns RESOURCE_EXHAUSTED.",
+	"LANTERN_TRAVERSAL_TIMEOUT_MS":        "Server-side wall-clock budget for Illuminate traversals in milliseconds (default 5000; 0 explicitly disables it); expiry surfaces as DEADLINE_EXCEEDED.",
 }
 
 // Render produces the docs/env.md markdown for the given registry specs. It

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -142,13 +142,19 @@ type ShutdownConfig struct {
 // Illuminate RPC (#842). A deadline-less client running an expensive PPR or
 // deep BFS holds GraphCache.mu.RLock for the whole walk, stalling every
 // writer and the GC tick; this knob lets the SERVER cap that hold time
-// regardless of client behaviour. 0 (the default) preserves the historical
-// client-owned-deadline behaviour. The budget only ever tightens: a client
-// deadline shorter than the budget still wins.
+// regardless of client behaviour. The non-zero default protects a server even
+// when clients omit deadlines; 0 is an explicit opt-out. The budget only ever
+// tightens: a client deadline shorter than the budget still wins.
 //
-//   - LANTERN_TRAVERSAL_TIMEOUT_MS      (default 0 = disabled)
+//   - LANTERN_TRAVERSAL_TIMEOUT_MS                (default 5000)
+//   - LANTERN_TRAVERSAL_MAX_PUSHES                 (default 1000000)
+//   - LANTERN_TRAVERSAL_MAX_TOUCHED_EDGES          (default 10000000)
+//   - LANTERN_TRAVERSAL_MAX_RESULTS                (default 1024)
 type TraversalConfig struct {
-	Timeout time.Duration
+	Timeout         time.Duration
+	MaxPushes       int
+	MaxTouchedEdges int
+	MaxResults      int
 }
 
 // ScanConfig caps the per-call pagination knobs for the prefix RPCs.
@@ -288,9 +294,7 @@ func NewConfig() (*Config, error) {
 			IlluminateMaxStep: envconfig.Int("LANTERN_ILLUMINATE_MAX_STEP", 16),
 			IlluminateMaxK:    envconfig.Int("LANTERN_ILLUMINATE_MAX_K", 1024),
 		},
-		Traversal: TraversalConfig{
-			Timeout: time.Duration(envconfig.Int("LANTERN_TRAVERSAL_TIMEOUT_MS", 0)) * time.Millisecond,
-		},
+		Traversal: loadTraversalConfig(),
 		Auth: AuthConfig{
 			Tokens:           splitTokens(envconfig.String("LANTERN_AUTH_TOKENS", "")),
 			ExemptReflection: envconfig.Bool("LANTERN_AUTH_EXEMPT_REFLECTION", true),
@@ -330,6 +334,34 @@ func NewConfig() (*Config, error) {
 		return nil, err
 	}
 	return cfg, nil
+}
+
+func loadTraversalConfig() TraversalConfig {
+	const (
+		defaultTimeoutMS      = 5_000
+		defaultMaxPushes      = 1_000_000
+		defaultMaxTouchedEdge = 10_000_000
+		defaultMaxResults     = 1_024
+	)
+	timeoutMS := envconfig.Int("LANTERN_TRAVERSAL_TIMEOUT_MS", defaultTimeoutMS)
+	if timeoutMS < 0 {
+		envconfig.Malformed("LANTERN_TRAVERSAL_TIMEOUT_MS", fmt.Sprint(timeoutMS), "must be zero or a positive millisecond duration")
+		timeoutMS = defaultTimeoutMS
+	}
+	positive := func(key string, def int) int {
+		v := envconfig.Int(key, def)
+		if v <= 0 {
+			envconfig.Malformed(key, fmt.Sprint(v), "must be positive")
+			return def
+		}
+		return v
+	}
+	return TraversalConfig{
+		Timeout:         time.Duration(timeoutMS) * time.Millisecond,
+		MaxPushes:       positive("LANTERN_TRAVERSAL_MAX_PUSHES", defaultMaxPushes),
+		MaxTouchedEdges: positive("LANTERN_TRAVERSAL_MAX_TOUCHED_EDGES", defaultMaxTouchedEdge),
+		MaxResults:      positive("LANTERN_TRAVERSAL_MAX_RESULTS", defaultMaxResults),
+	}
 }
 
 // foreignEnvPrefixes names LANTERN_*-prefixed namespaces owned by sibling

--- a/server/provider/provider_test.go
+++ b/server/provider/provider_test.go
@@ -70,6 +70,34 @@ func TestWireCacheGCHooks_EmitsTickSummary(t *testing.T) {
 // failure happens inside NewConfig — the first provider wire constructs — so
 // a refused boot never reaches listener construction.
 func TestNewConfigValidation(t *testing.T) {
+	t.Run("traversal safety defaults are finite", func(t *testing.T) {
+		envconfig.ResetForTesting()
+		for _, key := range []string{
+			"LANTERN_TRAVERSAL_TIMEOUT_MS",
+			"LANTERN_TRAVERSAL_MAX_PUSHES",
+			"LANTERN_TRAVERSAL_MAX_TOUCHED_EDGES",
+			"LANTERN_TRAVERSAL_MAX_RESULTS",
+		} {
+			t.Setenv(key, "")
+		}
+		cfg, err := NewConfig()
+		if err != nil {
+			t.Fatalf("NewConfig: %v", err)
+		}
+		if got, want := cfg.Traversal.Timeout, 5*time.Second; got != want {
+			t.Errorf("Traversal.Timeout = %v, want %v", got, want)
+		}
+		if got, want := cfg.Traversal.MaxPushes, 1_000_000; got != want {
+			t.Errorf("Traversal.MaxPushes = %d, want %d", got, want)
+		}
+		if got, want := cfg.Traversal.MaxTouchedEdges, 10_000_000; got != want {
+			t.Errorf("Traversal.MaxTouchedEdges = %d, want %d", got, want)
+		}
+		if got, want := cfg.Traversal.MaxResults, 1024; got != want {
+			t.Errorf("Traversal.MaxResults = %d, want %d", got, want)
+		}
+	})
+
 	t.Run("defaults survive a malformed value without strict", func(t *testing.T) {
 		envconfig.ResetForTesting()
 		t.Setenv("LANTERN_STRICT_CONFIG", "false")

--- a/server/service/backend.go
+++ b/server/service/backend.go
@@ -123,30 +123,32 @@ type Backend interface {
 		keep func(string) bool,
 	) (*coregraph.Graph[string, *pb.Vertex], map[string]map[string]time.Time, error)
 
-	// LocalCommunityContext extracts the conductance-optimal local
+	// LocalCommunityWithWorkBudgetContext extracts the conductance-optimal local
 	// community around seed (#845): the shared PPR forward-push followed by
-	// a sweep cut (PageRank-Nibble). maxSize is an UPPER BOUND (0 =
-	// unbounded); alpha/epsilon follow the PPR defaults; weighting steers
+	// a sweep cut (PageRank-Nibble). maxSize is an UPPER BOUND; the service
+	// resolves wire zero to its configured result cap before calling this
+	// backend. alpha/epsilon follow the PPR defaults; weighting steers
 	// the walk and the sweep AND is applied to the returned edge weights
 	// (WeightingRaw = the verbatim stored weight) — the returned graph is
 	// the INDUCED SUBGRAPH on the selected members with those weights and
 	// their expirations, in the same (graph, expirations) shape as the BFS
 	// path. keep scopes both the walk and the community (seed exempt).
-	LocalCommunityContext(
+	LocalCommunityWithWorkBudgetContext(
 		ctx context.Context,
 		seed string,
 		maxSize int,
 		alpha, epsilon float64,
 		weighting graphcache.EdgeWeighting,
 		keep func(string) bool,
+		budget graphcache.PPRWorkBudget,
 	) (*coregraph.Graph[string, *pb.Vertex], map[string]map[string]time.Time, error)
 
-	// PersonalizedPageRankContext computes the seed-anchored Personalized
+	// PersonalizedPageRankWithWorkBudgetContext computes the seed-anchored Personalized
 	// PageRank vector via Andersen–Chung–Lang forward-push (#801) and returns
 	// it as a one-hop "relevance star": g.Edges[seed][v] carries v's PPR mass
-	// pi[v] for the topN highest-mass vertices (topN <= 0 means every
-	// positive-mass vertex), with the seed excluded from its own star. This is
-	// a distinct traversal path, NOT a post-traversal reduction of the BFS
+	// pi[v] for the topN highest-mass vertices, with the seed excluded from its
+	// own star. The service resolves wire top_n=0 to its configured result cap.
+	// This is a distinct traversal path, NOT a post-traversal reduction of the BFS
 	// neighbourhood — alpha is the restart/teleport-to-seed probability and
 	// epsilon the residual threshold; out-of-range alpha (<=0 or >=1) and
 	// non-positive epsilon fall back to the core defaults. weighting transforms
@@ -155,13 +157,14 @@ type Backend interface {
 	// (a non-matching head never accrues mass; the seed is exempt; nil accepts
 	// every head). There is no expirations map — the star edges are synthetic
 	// relevance weights, not stored edges.
-	PersonalizedPageRankContext(
+	PersonalizedPageRankWithWorkBudgetContext(
 		ctx context.Context,
 		seed string,
 		topN int,
 		alpha, epsilon float64,
 		weighting graphcache.EdgeWeighting,
 		keep func(string) bool,
+		budget graphcache.PPRWorkBudget,
 	) (*coregraph.Graph[string, *pb.Vertex], error)
 
 	// prefix scan / count / delete. ScanByPrefixPage (#836) invokes fn for

--- a/server/service/errors.go
+++ b/server/service/errors.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 
 	"connectrpc.com/connect"
+	"github.com/anaregdesign/lantern/core/graphcache"
 )
 
 // ctxToConnect translates ctx.Err() (or any wrapped form thereof) into
@@ -34,4 +35,14 @@ func ctxToConnect(err error) error {
 	default:
 		return err
 	}
+}
+
+// traversalToConnect adds stable resource-safety errors on top of the shared
+// context mapping. A PPR/community work budget exhaustion is deliberately a
+// RESOURCE_EXHAUSTED failure, never a successful-but-truncated graph.
+func traversalToConnect(err error) error {
+	if errors.Is(err, graphcache.ErrPPRWorkBudgetExceeded) {
+		return connect.NewError(connect.CodeResourceExhausted, err)
+	}
+	return ctxToConnect(err)
 }

--- a/server/service/fake_backend_test.go
+++ b/server/service/fake_backend_test.go
@@ -46,6 +46,7 @@ type fakeBackend struct {
 	lastCommunityEpsilon float64
 	lastCommunityWeight  graphcache.EdgeWeighting
 	lastCommunityKeep    func(string) bool
+	lastCommunityBudget  graphcache.PPRWorkBudget
 	communityGraph       *coregraph.Graph[string, *pb.Vertex]
 	communityExpirations map[string]map[string]time.Time
 	communityErr         error
@@ -62,6 +63,7 @@ type fakeBackend struct {
 	lastPPREpsilon   float64
 	lastPPRWeighting graphcache.EdgeWeighting
 	lastPPRKeep      func(string) bool
+	lastPPRBudget    graphcache.PPRWorkBudget
 	pprErr           error
 
 	putVerticesCalls int
@@ -242,13 +244,14 @@ func (f *fakeBackend) NeighborWithExpirationsContext(
 	return g, map[string]map[string]time.Time{}, nil
 }
 
-func (f *fakeBackend) LocalCommunityContext(
+func (f *fakeBackend) LocalCommunityWithWorkBudgetContext(
 	_ context.Context,
 	seed string,
 	maxSize int,
 	alpha, epsilon float64,
 	weighting graphcache.EdgeWeighting,
 	keep func(string) bool,
+	budget graphcache.PPRWorkBudget,
 ) (*coregraph.Graph[string, *pb.Vertex], map[string]map[string]time.Time, error) {
 	f.communityCalls++
 	f.lastCommunityMaxSize = maxSize
@@ -256,6 +259,7 @@ func (f *fakeBackend) LocalCommunityContext(
 	f.lastCommunityEpsilon = epsilon
 	f.lastCommunityWeight = weighting
 	f.lastCommunityKeep = keep
+	f.lastCommunityBudget = budget
 	if f.communityErr != nil {
 		return nil, nil, f.communityErr
 	}
@@ -267,13 +271,14 @@ func (f *fakeBackend) LocalCommunityContext(
 	return g, nil, nil
 }
 
-func (f *fakeBackend) PersonalizedPageRankContext(
+func (f *fakeBackend) PersonalizedPageRankWithWorkBudgetContext(
 	ctx context.Context,
 	seed string,
 	topN int,
 	alpha, epsilon float64,
 	weighting graphcache.EdgeWeighting,
 	keep func(string) bool,
+	budget graphcache.PPRWorkBudget,
 ) (*coregraph.Graph[string, *pb.Vertex], error) {
 	f.pprCalls++
 	f.lastPPRSeed = seed
@@ -282,6 +287,7 @@ func (f *fakeBackend) PersonalizedPageRankContext(
 	f.lastPPREpsilon = epsilon
 	f.lastPPRWeighting = weighting
 	f.lastPPRKeep = keep
+	f.lastPPRBudget = budget
 	if f.pprErr != nil {
 		return nil, f.pprErr
 	}

--- a/server/service/optimizer.go
+++ b/server/service/optimizer.go
@@ -66,11 +66,11 @@ func inverseCost(weight float32) float32 {
 // epsilon must be positive (0/unset → DefaultPPREpsilon=1e-4).
 func resolvePPRParams(restartProb, epsilon float32) (alpha, eps float64) {
 	alpha = float64(restartProb)
-	if alpha <= 0 || alpha >= 1 {
+	if alpha <= 0 || alpha >= 1 || math.IsNaN(alpha) || math.IsInf(alpha, 0) {
 		alpha = graphcache.DefaultPPRAlpha
 	}
 	eps = float64(epsilon)
-	if eps <= 0 {
+	if eps <= 0 || math.IsNaN(eps) || math.IsInf(eps, 0) {
 		eps = graphcache.DefaultPPREpsilon
 	}
 	return alpha, eps

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -57,6 +57,8 @@ type LanternService struct {
 	onTombstoneClampReject func()
 	metrics                HotPathMetrics
 	traversalTimeout       time.Duration
+	traversalWorkBudget    graphcache.PPRWorkBudget
+	traversalMaxResults    int
 	capacity               CapacityLimits
 
 	// statusInfo + startedAt + startedAtOnce back GetServerStatus
@@ -151,7 +153,16 @@ func defaultSearchLimits() SearchLimits {
 }
 
 func NewLanternService(cache Backend) *LanternService {
-	return &LanternService{cache: cache, scan: defaultScanLimits(), search: defaultSearchLimits(), origins: newOriginStateTracker(), metrics: noopHotPathMetrics{}}
+	return &LanternService{
+		cache:               cache,
+		scan:                defaultScanLimits(),
+		search:              defaultSearchLimits(),
+		origins:             newOriginStateTracker(),
+		metrics:             noopHotPathMetrics{},
+		traversalTimeout:    5 * time.Second,
+		traversalWorkBudget: graphcache.PPRWorkBudget{MaxPushes: 1_000_000, MaxTouchedEdges: 10_000_000},
+		traversalMaxResults: 1024,
+	}
 }
 
 // WithScanLimits returns s with its prefix-RPC limits replaced. Intended
@@ -329,16 +340,51 @@ func (s *LanternService) WithTombstoneClampRejectHook(f func()) *LanternService 
 }
 
 // WithTraversalTimeout installs the server-side wall-clock budget for the
-// traversal-heavy Illuminate RPC (#842). When d > 0 every Illuminate runs
+// traversal-heavy Illuminate RPC (#842). By default every Illuminate runs
 // under context.WithTimeout(ctx, d), so a deadline-less client cannot hold
 // the graph read lock indefinitely with an expensive PPR or deep BFS; expiry
 // surfaces as CodeDeadlineExceeded via the existing ctx polling inside the
-// walks. d <= 0 (the default) keeps deadlines client-owned. The budget only
+// walks. Passing d <= 0 explicitly keeps deadlines client-owned. The budget only
 // tightens: a shorter client deadline still wins. Streaming RPCs and scans
 // are deliberately NOT covered — scans are collection-bounded by ScanLimits.
 func (s *LanternService) WithTraversalTimeout(d time.Duration) *LanternService {
 	s.traversalTimeout = d
 	return s
+}
+
+// TraversalLimits are the server-owned ceilings for PPR and local-community
+// work. The zero-valued wire sentinels top_n=0 and max_size=0 resolve to
+// MaxResults, never an unbounded response. MaxPushes and MaxTouchedEdges are
+// passed to the core push loop, which returns a typed exhaustion error rather
+// than a partial result.
+type TraversalLimits struct {
+	WorkBudget graphcache.PPRWorkBudget
+	MaxResults int
+}
+
+// WithTraversalLimits replaces the PPR/community work and result ceilings.
+// Non-positive values retain the safe constructor defaults.
+func (s *LanternService) WithTraversalLimits(l TraversalLimits) *LanternService {
+	if l.WorkBudget.MaxPushes > 0 {
+		s.traversalWorkBudget.MaxPushes = l.WorkBudget.MaxPushes
+	}
+	if l.WorkBudget.MaxTouchedEdges > 0 {
+		s.traversalWorkBudget.MaxTouchedEdges = l.WorkBudget.MaxTouchedEdges
+	}
+	if l.MaxResults > 0 {
+		s.traversalMaxResults = l.MaxResults
+	}
+	return s
+}
+
+func (s *LanternService) effectiveTraversalResultLimit(requested int, field string) (int, error) {
+	if requested == 0 {
+		return s.traversalMaxResults, nil
+	}
+	if requested > s.traversalMaxResults {
+		return 0, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("%s %d exceeds traversal result cap %d", field, requested, s.traversalMaxResults))
+	}
+	return requested, nil
 }
 
 // validateExpiration enforces the LANTERN_TOMBSTONE_TTL clamp on
@@ -535,12 +581,16 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 		// the star by mass. There is no expirations map because the star
 		// edges are synthetic.
 		ppr := params.Ppr
+		topN, limitErr := s.effectiveTraversalResultLimit(int(ppr.GetTopN()), "ppr.top_n")
+		if limitErr != nil {
+			return nil, limitErr
+		}
 		alpha, epsilon := resolvePPRParams(ppr.GetRestartProb(), ppr.GetEpsilon())
 		traversalStart := time.Now()
-		g, err = s.cache.PersonalizedPageRankContext(ctx, request.GetSeed(), int(ppr.GetTopN()), alpha, epsilon, coreWeighting, keep)
+		g, err = s.cache.PersonalizedPageRankWithWorkBudgetContext(ctx, request.GetSeed(), topN, alpha, epsilon, coreWeighting, keep, s.traversalWorkBudget)
 		traversalDur = time.Since(traversalStart)
 		if err != nil {
-			return nil, ctxToConnect(err)
+			return nil, traversalToConnect(err)
 		}
 		algoLabel, redLabel, objLabel = "ppr", "none", "maximize"
 
@@ -556,12 +606,16 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 		// seed within the community stay as ISOLATED vertices rather than
 		// being dropped or wired up artificially.
 		comm := params.Community
+		maxSize, limitErr := s.effectiveTraversalResultLimit(int(comm.GetMaxSize()), "community.max_size")
+		if limitErr != nil {
+			return nil, limitErr
+		}
 		alpha, epsilon := resolvePPRParams(comm.GetRestartProb(), comm.GetEpsilon())
 		traversalStart := time.Now()
-		g, expirations, err = s.cache.LocalCommunityContext(ctx, request.GetSeed(), int(comm.GetMaxSize()), alpha, epsilon, coreWeighting, keep)
+		g, expirations, err = s.cache.LocalCommunityWithWorkBudgetContext(ctx, request.GetSeed(), maxSize, alpha, epsilon, coreWeighting, keep, s.traversalWorkBudget)
 		traversalDur = time.Since(traversalStart)
 		if err != nil {
-			return nil, ctxToConnect(err)
+			return nil, traversalToConnect(err)
 		}
 		if opt := resolveOptimizer(comm.GetReduction(), comm.GetObjective()); opt != nil {
 			optStart := time.Now()

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -1004,7 +1004,7 @@ func TestLanternService_FakeBackend_Illuminate_PPRRouting(t *testing.T) {
 	})
 
 	t.Run("out-of-range restart_prob falls back to default", func(t *testing.T) {
-		for _, rp := range []float32{0, 1, 1.5, -0.2} {
+		for _, rp := range []float32{0, 1, 1.5, -0.2, float32(math.NaN())} {
 			fb := newSeeded()
 			svc := NewLanternService(fb)
 			if _, err := svc.Illuminate(context.Background(), &pb.IlluminateRequest{
@@ -1039,6 +1039,34 @@ func TestLanternService_FakeBackend_Illuminate_PPRRouting(t *testing.T) {
 		}
 		if !keep("users/42") || keep("orgs/9") {
 			t.Errorf(`keep mis-scoped: keep("users/42")=%v keep("orgs/9")=%v`, keep("users/42"), keep("orgs/9"))
+		}
+	})
+
+	t.Run("zero top_n resolves to the operator cap and forwards the work budget", func(t *testing.T) {
+		fb := newSeeded()
+		budget := graphcache.PPRWorkBudget{MaxPushes: 7, MaxTouchedEdges: 11}
+		svc := NewLanternService(fb).WithTraversalLimits(TraversalLimits{WorkBudget: budget, MaxResults: 1})
+		if _, err := svc.Illuminate(context.Background(), &pb.IlluminateRequest{
+			Seed: "s", Params: &pb.IlluminateRequest_Ppr{Ppr: &pb.PprParams{}},
+		}); err != nil {
+			t.Fatalf("Illuminate: %v", err)
+		}
+		if fb.lastPPRTopN != 1 {
+			t.Errorf("top_n=0 forwarded as %d, want configured cap 1", fb.lastPPRTopN)
+		}
+		if fb.lastPPRBudget != budget {
+			t.Errorf("PPR budget = %+v, want %+v", fb.lastPPRBudget, budget)
+		}
+	})
+
+	t.Run("explicit top_n above the operator cap is rejected", func(t *testing.T) {
+		fb := newSeeded()
+		svc := NewLanternService(fb).WithTraversalLimits(TraversalLimits{MaxResults: 1})
+		_, err := svc.Illuminate(context.Background(), &pb.IlluminateRequest{
+			Seed: "s", Params: &pb.IlluminateRequest_Ppr{Ppr: &pb.PprParams{TopN: 2}},
+		})
+		if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+			t.Fatalf("Illuminate code = %v, want InvalidArgument (err=%v)", got, err)
 		}
 	})
 
@@ -1708,6 +1736,18 @@ func TestExpirationClamp_FiresValidationRejectHook(t *testing.T) {
 // default injects no deadline at all (client-owned behaviour unchanged), and
 // an already-shorter client deadline still wins.
 func TestLanternService_Illuminate_TraversalBudget(t *testing.T) {
+	t.Run("default budget reaches the backend as a deadline", func(t *testing.T) {
+		fb := newFakeBackend()
+		svc := NewLanternService(fb)
+
+		if _, err := svc.Illuminate(context.Background(), &pb.IlluminateRequest{Seed: "a"}); err != nil {
+			t.Fatalf("Illuminate: %v", err)
+		}
+		if !fb.lastNeighborHadDeadline {
+			t.Fatal("default traversal budget carried no deadline")
+		}
+	})
+
 	t.Run("budget cancels an over-long traversal as DeadlineExceeded", func(t *testing.T) {
 		fb := newFakeBackend()
 		fb.neighborBlockUntilCtxDone = true
@@ -1719,9 +1759,9 @@ func TestLanternService_Illuminate_TraversalBudget(t *testing.T) {
 		}
 	})
 
-	t.Run("disabled budget injects no deadline", func(t *testing.T) {
+	t.Run("explicitly disabled budget injects no deadline", func(t *testing.T) {
 		fb := newFakeBackend()
-		svc := NewLanternService(fb)
+		svc := NewLanternService(fb).WithTraversalTimeout(0)
 
 		if _, err := svc.Illuminate(context.Background(), &pb.IlluminateRequest{Seed: "a"}); err != nil {
 			t.Fatalf("Illuminate: %v", err)
@@ -1986,6 +2026,23 @@ func TestLanternService_Illuminate_LocalCommunity(t *testing.T) {
 		if fb.lastCommunityAlpha != graphcache.DefaultPPRAlpha || fb.lastCommunityEpsilon != graphcache.DefaultPPREpsilon {
 			t.Errorf("defaults = %v/%v, want %v/%v", fb.lastCommunityAlpha, fb.lastCommunityEpsilon,
 				graphcache.DefaultPPRAlpha, graphcache.DefaultPPREpsilon)
+		}
+	})
+
+	t.Run("zero max_size resolves to the operator cap and forwards the work budget", func(t *testing.T) {
+		fb := newFakeBackend()
+		budget := graphcache.PPRWorkBudget{MaxPushes: 7, MaxTouchedEdges: 11}
+		svc := NewLanternService(fb).WithTraversalLimits(TraversalLimits{WorkBudget: budget, MaxResults: 3})
+		if _, err := svc.Illuminate(ctx, &pb.IlluminateRequest{
+			Seed: "s", Params: &pb.IlluminateRequest_Community{Community: &pb.LocalCommunityParams{}},
+		}); err != nil {
+			t.Fatalf("Illuminate: %v", err)
+		}
+		if fb.lastCommunityMaxSize != 3 {
+			t.Errorf("max_size=0 forwarded as %d, want configured cap 3", fb.lastCommunityMaxSize)
+		}
+		if fb.lastCommunityBudget != budget {
+			t.Errorf("community budget = %+v, want %+v", fb.lastCommunityBudget, budget)
 		}
 	})
 

--- a/tests/integration/illuminate_budget_test.go
+++ b/tests/integration/illuminate_budget_test.go
@@ -1,0 +1,72 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/anaregdesign/lantern/core/graphcache"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
+	"github.com/anaregdesign/lantern/server/service"
+)
+
+func TestLantern_Illuminate_PPRWorkBudgetFailsWithoutRetainingReadLock(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		request func() *pb.IlluminateRequest
+	}{
+		{
+			name: "PPR",
+			request: func() *pb.IlluminateRequest {
+				return &pb.IlluminateRequest{Seed: "seed", Params: &pb.IlluminateRequest_Ppr{Ppr: &pb.PprParams{Epsilon: 1e-9}}}
+			},
+		},
+		{
+			name: "local community",
+			request: func() *pb.IlluminateRequest {
+				return &pb.IlluminateRequest{Seed: "seed", Params: &pb.IlluminateRequest_Community{Community: &pb.LocalCommunityParams{Epsilon: 1e-9}}}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+			svc := service.NewLanternService(cache).
+				WithTraversalTimeout(time.Second).
+				WithTraversalLimits(service.TraversalLimits{
+					WorkBudget: graphcache.PPRWorkBudget{MaxPushes: 1, MaxTouchedEdges: 100},
+					MaxResults: 8,
+				})
+			srv := newConnectTestServer(t, svc, nil)
+			c := graphv1connect.NewLanternServiceClient(h2cClient(), srv.url)
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			t.Cleanup(cancel)
+			if _, err := c.PutVertices(ctx, connect.NewRequest(&pb.PutVerticesRequest{Vertices: []*pb.Vertex{
+				{Key: "seed", Value: &pb.Vertex_String_{String_: "seed"}},
+				{Key: "a", Value: &pb.Vertex_String_{String_: "a"}},
+			}})); err != nil {
+				t.Fatalf("PutVertices: %v", err)
+			}
+			if _, err := c.PutEdges(ctx, connect.NewRequest(&pb.PutEdgesRequest{Edges: []*pb.Edge{
+				{Tail: "seed", Head: "a", Weight: 1},
+				{Tail: "a", Head: "seed", Weight: 1},
+			}})); err != nil {
+				t.Fatalf("PutEdges: %v", err)
+			}
+
+			_, err := c.Illuminate(ctx, connect.NewRequest(tc.request()))
+			if got := connect.CodeOf(err); got != connect.CodeResourceExhausted {
+				t.Fatalf("Illuminate code = %v, want ResourceExhausted (err=%v)", got, err)
+			}
+
+			// This needs the cache write lock. Its prompt completion proves the
+			// exhausted forward-push released GraphCache.mu.RLock.
+			if _, err := c.PutVertices(ctx, connect.NewRequest(&pb.PutVerticesRequest{Vertices: []*pb.Vertex{
+				{Key: "after-budget", Value: &pb.Vertex_String_{String_: "ok"}},
+			}})); err != nil {
+				t.Fatalf("PutVertices after exhausted Illuminate: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- bound PPR/community work and intermediate queue growth
- snapshot traversal inputs so expensive ranking runs outside the graph lock
- expose validation/runtime limits and cover exhaustion contracts

## Validation
- full root and all Go module test gate
- server `go vet ./...`
- golangci-lint changed-lines gate (CI-pinned v2.12.2)

Closes #984