### PR TITLE
fix(cli,admin): normalize family grammar float semantics

### DIFF
--- a/admin/app/lib/cli/illuminate-axes.test.ts
+++ b/admin/app/lib/cli/illuminate-axes.test.ts
@@ -327,9 +327,9 @@ describe("formatFamilyClick ↔ parse round-trip", () => {
       expect(cmd.topN).toBe(axes.k);
       expect(cmd.weighting).toBe(axes.weighting);
       expect(cmd.vertexPrefix).toBe(axes.vertexPrefix);
-      // The α/ε knobs survive the round-trip for pagerank (#801).
-      expect(cmd.restartProb).toBe(axes.restartProb);
-      expect(cmd.epsilon).toBe(axes.epsilon);
+      // The parsed command carries the exact float32 values sent on the wire.
+      expect(cmd.restartProb).toBe(Math.fround(axes.restartProb));
+      expect(cmd.epsilon).toBe(Math.fround(axes.epsilon));
     } else if (cmd.verb === "community") {
       expect(cmd.seed).toBe("user:alice");
       // community's single positional is max_size, sourced from the k axis;
@@ -339,9 +339,9 @@ describe("formatFamilyClick ↔ parse round-trip", () => {
       expect(cmd.objective).toBe(axes.objective);
       expect(cmd.weighting).toBe(axes.weighting);
       expect(cmd.vertexPrefix).toBe(axes.vertexPrefix);
-      // The α/ε knobs survive the round-trip for community too (#942).
-      expect(cmd.restartProb).toBe(axes.restartProb);
-      expect(cmd.epsilon).toBe(axes.epsilon);
+      // The parsed command carries the exact float32 values sent on the wire.
+      expect(cmd.restartProb).toBe(Math.fround(axes.restartProb));
+      expect(cmd.epsilon).toBe(Math.fround(axes.epsilon));
     } else {
       throw new Error(`unexpected verb from click formatter: ${cmd.verb}`);
     }

--- a/admin/app/lib/cli/verbs.ts
+++ b/admin/app/lib/cli/verbs.ts
@@ -941,24 +941,36 @@ function parseInt10(s: string): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+const MAX_UINT32 = 0xffff_ffff;
+
+function parseFamilyUint32(s: string): number | null {
+  if (!/^\d+$/.test(s)) return null;
+  const n = Number(s);
+  return Number.isSafeInteger(n) && n <= MAX_UINT32 ? n : null;
+}
+
 function parsePositiveFamilyInt(s: string): number | null {
-  const n = parseInt10(s);
+  const n = parseFamilyUint32(s);
   return n !== null && n > 0 ? n : null;
 }
 
 function parseNonNegativeFamilyInt(s: string): number | null {
-  const n = parseInt10(s);
+  const n = parseFamilyUint32(s);
   return n !== null && n >= 0 ? n : null;
 }
 
 function parseFamilyRestartProb(s: string): number | null {
   const n = parseFloatStrict(s);
-  return n !== null && n > 0 && n < 1 ? n : null;
+  if (n === null) return null;
+  const f = Math.fround(n);
+  return Number.isFinite(f) && f > 0 && f < 1 ? f : null;
 }
 
 function parsePositiveFamilyFloat(s: string): number | null {
   const n = parseFloatStrict(s);
-  return n !== null && n > 0 ? n : null;
+  if (n === null) return null;
+  const f = Math.fround(n);
+  return Number.isFinite(f) && f > 0 ? f : null;
 }
 
 /**

--- a/admin/app/lib/client/usecase/cli/dispatcher.test.ts
+++ b/admin/app/lib/client/usecase/cli/dispatcher.test.ts
@@ -693,7 +693,7 @@ describe("dispatch family verbs map to the per-family oneofs (#975)", () => {
     expect(opts.ppr).toBeUndefined();
   });
 
-  test("community passes restart_prob / epsilon through unchanged", async () => {
+  test("community passes float32-normalized restart_prob / epsilon", async () => {
     const fake = new FakeLanternClient();
     fake.stub("illuminate", emptyGraph);
     const parsed = parse("community a1 5 restart_prob=0.25 epsilon=0.001");
@@ -708,8 +708,8 @@ describe("dispatch family verbs map to the per-family oneofs (#975)", () => {
     ];
     expect(opts.community).toEqual({
       maxSize: 5,
-      restartProb: 0.25,
-      epsilon: 0.001,
+      restartProb: Math.fround(0.25),
+      epsilon: Math.fround(0.001),
       reduction: SdkReduction.UNSPECIFIED,
       objective: SdkObjective.MAXIMIZE,
     });
@@ -759,8 +759,8 @@ describe("dispatch family verbs map to the per-family oneofs (#975)", () => {
     // objective (its relevance star is already a tree).
     expect(opts.ppr).toEqual({
       topN: 15,
-      restartProb: 0.25,
-      epsilon: 0.001,
+      restartProb: Math.fround(0.25),
+      epsilon: Math.fround(0.001),
     });
     expect(opts.bfs).toBeUndefined();
     expect(opts.community).toBeUndefined();

--- a/admin/test/cli-grammar/grammar.test.ts
+++ b/admin/test/cli-grammar/grammar.test.ts
@@ -15,12 +15,14 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { parse } from "~/lib/cli/parser";
+import type { Command } from "~/lib/cli/types";
 
 const fixturePath = resolve(import.meta.dirname, "verbs.json");
 
 interface FixtureCase {
   input: string;
   comment?: string;
+  readonly expected?: Record<string, unknown>;
 }
 
 interface Fixture {
@@ -29,6 +31,53 @@ interface Fixture {
 }
 
 const fx = JSON.parse(readFileSync(fixturePath, "utf8")) as Fixture;
+
+function float32Bits(value: number): number {
+  const bytes = new ArrayBuffer(4);
+  const view = new DataView(bytes);
+  view.setFloat32(0, value, false);
+  return view.getUint32(0, false);
+}
+
+function normalizeFamilyCommand(command: Command): Record<string, unknown> {
+  switch (command.verb) {
+    case "bfs":
+      return {
+        family: "bfs",
+        seed: command.seed,
+        step: command.step,
+        fan_out: command.fanOut,
+        reduction: command.reduction,
+        objective: command.objective,
+        weighting: command.weighting,
+        prefix: command.vertexPrefix,
+      };
+    case "pagerank":
+      return {
+        family: "pagerank",
+        seed: command.seed,
+        top_n: command.topN,
+        restart_prob_f32_bits: float32Bits(command.restartProb),
+        epsilon_f32_bits: float32Bits(command.epsilon),
+        weighting: command.weighting,
+        prefix: command.vertexPrefix,
+      };
+    case "community":
+      return {
+        family: "community",
+        seed: command.seed,
+        max_size: command.maxSize,
+        restart_prob_f32_bits: float32Bits(command.restartProb),
+        epsilon_f32_bits: float32Bits(command.epsilon),
+        reduction: command.reduction,
+        objective: command.objective,
+        weighting: command.weighting,
+        prefix: command.vertexPrefix,
+      };
+    default:
+      throw new Error(`expected family command, got ${command.verb}`);
+  }
+}
 
 describe("CLI grammar fixture (#411) — valid inputs", () => {
   for (const c of fx.valid) {
@@ -40,6 +89,14 @@ describe("CLI grammar fixture (#411) — valid inputs", () => {
         );
       }
       expect(result.ok).toBe(true);
+      if (["bfs", "pagerank", "community"].includes(result.command.verb)) {
+        if (c.expected === undefined) {
+          throw new Error(
+            `family fixture ${JSON.stringify(c.input)} is missing its expected normalized AST`,
+          );
+        }
+        expect(normalizeFamilyCommand(result.command)).toEqual(c.expected);
+      }
     });
   }
 });

--- a/admin/test/cli-grammar/verbs.json
+++ b/admin/test/cli-grammar/verbs.json
@@ -88,71 +88,322 @@
     { "input": "keys users/ 100", "comment": "#674: keys with optional limit" },
     {
       "input": "bfs alice",
-      "comment": "#975: bare seed uses defaults step=5 fan_out=3"
+      "comment": "#975: bare seed uses defaults step=5 fan_out=3",
+      "expected": {
+        "family": "bfs",
+        "seed": "alice",
+        "step": 5,
+        "fan_out": 3,
+        "reduction": "none",
+        "objective": "max",
+        "weighting": "raw",
+        "prefix": ""
+      }
     },
     {
-      "input": "bfs alice 2 5",
-      "comment": "#975: positional step and fan_out"
+      "input": "bfs Alice 002 005 prefix=Team:",
+      "comment": "#985: uint32 decimal values normalise while seed/prefix retain case",
+      "expected": {
+        "family": "bfs",
+        "seed": "Alice",
+        "step": 2,
+        "fan_out": 5,
+        "reduction": "none",
+        "objective": "max",
+        "weighting": "raw",
+        "prefix": "Team:"
+      }
     },
     {
       "input": "bfs alice step=2 fan_out=5",
-      "comment": "#975: step and fan_out as kwargs"
+      "comment": "#975: step and fan_out as kwargs",
+      "expected": {
+        "family": "bfs",
+        "seed": "alice",
+        "step": 2,
+        "fan_out": 5,
+        "reduction": "none",
+        "objective": "max",
+        "weighting": "raw",
+        "prefix": ""
+      }
     },
     {
       "input": "bfs alice fan_out=5",
-      "comment": "#975: step defaults, fan_out kwarg"
+      "comment": "#975: step defaults, fan_out kwarg",
+      "expected": {
+        "family": "bfs",
+        "seed": "alice",
+        "step": 5,
+        "fan_out": 5,
+        "reduction": "none",
+        "objective": "max",
+        "weighting": "raw",
+        "prefix": ""
+      }
     },
-    { "input": "bfs alice 2 5 reduction=mst" },
-    { "input": "bfs alice 2 5 reduction=spt objective=max" },
     {
-      "input": "bfs alice 2 5 reduction=spt objective=max weighting=tfidf"
+      "input": "bfs alice 2 5 reduction=mst",
+      "expected": {
+        "family": "bfs",
+        "seed": "alice",
+        "step": 2,
+        "fan_out": 5,
+        "reduction": "mst",
+        "objective": "max",
+        "weighting": "raw",
+        "prefix": ""
+      }
+    },
+    {
+      "input": "bfs alice 2 5 reduction=spt objective=max",
+      "expected": {
+        "family": "bfs",
+        "seed": "alice",
+        "step": 2,
+        "fan_out": 5,
+        "reduction": "spt",
+        "objective": "max",
+        "weighting": "raw",
+        "prefix": ""
+      }
+    },
+    {
+      "input": "bfs alice 2 5 reduction=spt objective=max weighting=tfidf",
+      "expected": {
+        "family": "bfs",
+        "seed": "alice",
+        "step": 2,
+        "fan_out": 5,
+        "reduction": "spt",
+        "objective": "max",
+        "weighting": "tfidf",
+        "prefix": ""
+      }
     },
     {
       "input": "bfs alice 2 5 weighting=tfidf objective=max reduction=spt",
-      "comment": "keyword args may appear in any order"
+      "comment": "keyword args may appear in any order",
+      "expected": {
+        "family": "bfs",
+        "seed": "alice",
+        "step": 2,
+        "fan_out": 5,
+        "reduction": "spt",
+        "objective": "max",
+        "weighting": "tfidf",
+        "prefix": ""
+      }
     },
     {
       "input": "bfs alice 2 5 reduction=spt objective=min prefix=team:",
-      "comment": "#975: bfs closed-set axes and the free-text prefix compose"
+      "comment": "#975: bfs closed-set axes and the free-text prefix compose",
+      "expected": {
+        "family": "bfs",
+        "seed": "alice",
+        "step": 2,
+        "fan_out": 5,
+        "reduction": "spt",
+        "objective": "min",
+        "weighting": "raw",
+        "prefix": "team:"
+      }
     },
     {
       "input": "pagerank alice",
-      "comment": "#975: bare seed uses default top_n=10; α/ε server-resolved"
+      "comment": "#975: bare seed uses default top_n=10; α/ε server-resolved",
+      "expected": {
+        "family": "pagerank",
+        "seed": "alice",
+        "top_n": 10,
+        "restart_prob_f32_bits": 0,
+        "epsilon_f32_bits": 0,
+        "weighting": "raw",
+        "prefix": ""
+      }
     },
-    { "input": "pagerank alice 15", "comment": "#975: positional top_n" },
-    { "input": "pagerank alice top_n=15", "comment": "#975: top_n kwarg" },
+    {
+      "input": "pagerank alice 15",
+      "comment": "#975: positional top_n",
+      "expected": {
+        "family": "pagerank",
+        "seed": "alice",
+        "top_n": 15,
+        "restart_prob_f32_bits": 0,
+        "epsilon_f32_bits": 0,
+        "weighting": "raw",
+        "prefix": ""
+      }
+    },
+    {
+      "input": "pagerank alice top_n=15",
+      "comment": "#975: top_n kwarg",
+      "expected": {
+        "family": "pagerank",
+        "seed": "alice",
+        "top_n": 15,
+        "restart_prob_f32_bits": 0,
+        "epsilon_f32_bits": 0,
+        "weighting": "raw",
+        "prefix": ""
+      }
+    },
     {
       "input": "pagerank alice 15 restart_prob=0.25 epsilon=0.001",
-      "comment": "#801: pagerank with explicit restart_prob / epsilon floats"
+      "comment": "#985: pagerank normalises explicit α/ε to their float32 wire values",
+      "expected": {
+        "family": "pagerank",
+        "seed": "alice",
+        "top_n": 15,
+        "restart_prob_f32_bits": 1048576000,
+        "epsilon_f32_bits": 981668463,
+        "weighting": "raw",
+        "prefix": ""
+      }
     },
     {
       "input": "pagerank alice weighting=bm25 restart_prob=0.2",
-      "comment": "#801: pagerank composes with the weighting axis"
+      "comment": "#801: pagerank composes with the weighting axis",
+      "expected": {
+        "family": "pagerank",
+        "seed": "alice",
+        "top_n": 10,
+        "restart_prob_f32_bits": 1045220557,
+        "epsilon_f32_bits": 0,
+        "weighting": "bm25",
+        "prefix": ""
+      }
     },
     {
       "input": "pagerank alice epsilon=1e-4",
-      "comment": "#801: scientific-notation knob value (Go strconv.ParseFloat parity)"
+      "comment": "#985: scientific notation normalises after float32 coercion",
+      "expected": {
+        "family": "pagerank",
+        "seed": "alice",
+        "top_n": 10,
+        "restart_prob_f32_bits": 0,
+        "epsilon_f32_bits": 953267991,
+        "weighting": "raw",
+        "prefix": ""
+      }
+    },
+    {
+      "input": "pagerank alice top_n=0",
+      "comment": "#985: explicit zero top_n is preserved as the server-owned cap sentinel",
+      "expected": {
+        "family": "pagerank",
+        "seed": "alice",
+        "top_n": 0,
+        "restart_prob_f32_bits": 0,
+        "epsilon_f32_bits": 0,
+        "weighting": "raw",
+        "prefix": ""
+      }
     },
     {
       "input": "community alice",
-      "comment": "#975: bare seed; the conductance sweep decides the size (max_size=0)"
+      "comment": "#975: bare seed; the conductance sweep decides the size (max_size=0)",
+      "expected": {
+        "family": "community",
+        "seed": "alice",
+        "max_size": 0,
+        "restart_prob_f32_bits": 0,
+        "epsilon_f32_bits": 0,
+        "reduction": "none",
+        "objective": "max",
+        "weighting": "raw",
+        "prefix": ""
+      }
     },
-    { "input": "community alice 20", "comment": "#975: positional max_size" },
+    {
+      "input": "community alice 20",
+      "comment": "#975: positional max_size",
+      "expected": {
+        "family": "community",
+        "seed": "alice",
+        "max_size": 20,
+        "restart_prob_f32_bits": 0,
+        "epsilon_f32_bits": 0,
+        "reduction": "none",
+        "objective": "max",
+        "weighting": "raw",
+        "prefix": ""
+      }
+    },
     {
       "input": "community alice max_size=20",
-      "comment": "#975: max_size kwarg"
+      "comment": "#975: max_size kwarg",
+      "expected": {
+        "family": "community",
+        "seed": "alice",
+        "max_size": 20,
+        "restart_prob_f32_bits": 0,
+        "epsilon_f32_bits": 0,
+        "reduction": "none",
+        "objective": "max",
+        "weighting": "raw",
+        "prefix": ""
+      }
     },
     {
       "input": "community alice 20 restart_prob=0.25 epsilon=1e-3",
-      "comment": "#942: community shares the pagerank restart_prob / epsilon locality knobs"
+      "comment": "#985: community shares the pagerank float32-normalised locality knobs",
+      "expected": {
+        "family": "community",
+        "seed": "alice",
+        "max_size": 20,
+        "restart_prob_f32_bits": 1048576000,
+        "epsilon_f32_bits": 981668463,
+        "reduction": "none",
+        "objective": "max",
+        "weighting": "raw",
+        "prefix": ""
+      }
     },
     {
       "input": "community alice 20 reduction=mst",
-      "comment": "#961: local community rendered as an MST tree view"
+      "comment": "#961: local community rendered as an MST tree view",
+      "expected": {
+        "family": "community",
+        "seed": "alice",
+        "max_size": 20,
+        "restart_prob_f32_bits": 0,
+        "epsilon_f32_bits": 0,
+        "reduction": "mst",
+        "objective": "max",
+        "weighting": "raw",
+        "prefix": ""
+      }
     },
     {
       "input": "community alice 20 reduction=spt objective=min",
-      "comment": "#961: community reduction direction set by objective"
+      "comment": "#961: community reduction direction set by objective",
+      "expected": {
+        "family": "community",
+        "seed": "alice",
+        "max_size": 20,
+        "restart_prob_f32_bits": 0,
+        "epsilon_f32_bits": 0,
+        "reduction": "spt",
+        "objective": "min",
+        "weighting": "raw",
+        "prefix": ""
+      }
+    },
+    {
+      "input": "community alice max_size=0",
+      "comment": "#985: explicit zero max_size is preserved as the server-owned cap sentinel",
+      "expected": {
+        "family": "community",
+        "seed": "alice",
+        "max_size": 0,
+        "restart_prob_f32_bits": 0,
+        "epsilon_f32_bits": 0,
+        "reduction": "none",
+        "objective": "max",
+        "weighting": "raw",
+        "prefix": ""
+      }
     },
     {
       "input": "Get VERTEX alice",
@@ -164,19 +415,59 @@
     },
     {
       "input": "bfs alice 2 5 Reduction=SPT Objective=Max Weighting=TFIDF",
-      "comment": "#437: family kwarg key + closed-set value case-insensitive"
+      "comment": "#437: family kwarg key + closed-set value case-insensitive",
+      "expected": {
+        "family": "bfs",
+        "seed": "alice",
+        "step": 2,
+        "fan_out": 5,
+        "reduction": "spt",
+        "objective": "max",
+        "weighting": "tfidf",
+        "prefix": ""
+      }
     },
     {
       "input": "bfs alice prefix=team:",
-      "comment": "#606: free-text vertex-prefix kwarg"
+      "comment": "#606: free-text vertex-prefix kwarg",
+      "expected": {
+        "family": "bfs",
+        "seed": "alice",
+        "step": 5,
+        "fan_out": 3,
+        "reduction": "none",
+        "objective": "max",
+        "weighting": "raw",
+        "prefix": "team:"
+      }
     },
     {
       "input": "bfs alice prefix=users/ reduction=spt objective=min",
-      "comment": "#606: prefix mixes with the closed-set axes in any order"
+      "comment": "#606: prefix mixes with the closed-set axes in any order",
+      "expected": {
+        "family": "bfs",
+        "seed": "alice",
+        "step": 5,
+        "fan_out": 3,
+        "reduction": "spt",
+        "objective": "min",
+        "weighting": "raw",
+        "prefix": "users/"
+      }
     },
     {
       "input": "bfs alice PREFIX=Users/Alice",
-      "comment": "#606: prefix key case-insensitive, value case-sensitive (verbatim)"
+      "comment": "#606: prefix key case-insensitive, value case-sensitive (verbatim)",
+      "expected": {
+        "family": "bfs",
+        "seed": "alice",
+        "step": 5,
+        "fan_out": 3,
+        "reduction": "none",
+        "objective": "max",
+        "weighting": "raw",
+        "prefix": "Users/Alice"
+      }
     },
     {
       "input": "put vertex greeting \"hello world\"",
@@ -320,6 +611,14 @@
     { "input": "bfs alice notanint", "comment": "#975: non-numeric step" },
     { "input": "bfs alice -1", "comment": "#980: negative step" },
     { "input": "bfs alice 0", "comment": "#980: zero step" },
+    {
+      "input": "bfs alice +2 +5",
+      "comment": "#985: family integers use unsigned decimal syntax; signs are rejected"
+    },
+    {
+      "input": "bfs alice 4294967296",
+      "comment": "#985: family integers must fit the uint32 wire range"
+    },
     { "input": "bfs alice 1 -2", "comment": "#980: negative fan_out" },
     { "input": "bfs alice 1 0", "comment": "#980: zero fan_out" },
     {
@@ -375,6 +674,14 @@
       "comment": "#980: negative top_n is rejected"
     },
     {
+      "input": "pagerank alice +5",
+      "comment": "#985: signed top_n is rejected even though Go's host int would accept it"
+    },
+    {
+      "input": "pagerank alice top_n=4294967296",
+      "comment": "#985: top_n must fit the uint32 wire range"
+    },
+    {
       "input": "pagerank alice restart_prob=0",
       "comment": "#980: explicit restart_prob must be in the open interval (0,1)"
     },
@@ -383,12 +690,20 @@
       "comment": "#980: restart_prob=1 is outside the open interval"
     },
     {
+      "input": "pagerank alice restart_prob=0.99999999",
+      "comment": "#985: validate restart_prob after float32 coercion (rounds to 1)"
+    },
+    {
       "input": "pagerank alice epsilon=tiny",
       "comment": "#801: non-numeric epsilon is rejected"
     },
     {
       "input": "pagerank alice epsilon=0",
       "comment": "#980: explicit epsilon must be positive; omission still defers to the server default"
+    },
+    {
+      "input": "pagerank alice epsilon=1e-50",
+      "comment": "#985: validate epsilon after float32 coercion (underflows to 0)"
     },
     {
       "input": "community alice reduction=bogus",
@@ -403,12 +718,28 @@
       "comment": "#980: negative max_size is rejected"
     },
     {
+      "input": "community alice +5",
+      "comment": "#985: signed max_size is rejected"
+    },
+    {
+      "input": "community alice max_size=4294967296",
+      "comment": "#985: max_size must fit the uint32 wire range"
+    },
+    {
       "input": "community alice restart_prob=0",
       "comment": "#980: explicit restart_prob must be in the open interval (0,1)"
     },
     {
       "input": "community alice epsilon=0",
       "comment": "#980: explicit epsilon must be positive; omission still defers to the server default"
+    },
+    {
+      "input": "community alice restart_prob=0.99999999",
+      "comment": "#985: float32 rounding is checked before command acceptance"
+    },
+    {
+      "input": "community alice epsilon=1e-50",
+      "comment": "#985: float32 underflow is checked before command acceptance"
     },
     {
       "input": "put vertex greeting \"hello world",

--- a/cli/parser/grammar_fixture_test.go
+++ b/cli/parser/grammar_fixture_test.go
@@ -2,8 +2,11 @@ package parser_test
 
 import (
 	"encoding/json"
+	"fmt"
+	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/anaregdesign/lantern/cli/parser"
@@ -18,8 +21,9 @@ import (
 // time CI runs.
 type fixture struct {
 	Valid []struct {
-		Input   string `json:"input"`
-		Comment string `json:"comment,omitempty"`
+		Input    string          `json:"input"`
+		Comment  string          `json:"comment,omitempty"`
+		Expected json.RawMessage `json:"expected,omitempty"`
 	} `json:"valid"`
 	Invalid []struct {
 		Input   string `json:"input"`
@@ -71,5 +75,90 @@ func TestSharedGrammarFixture_Invalid(t *testing.T) {
 				t.Errorf("Validate(%q) accepted invalid input (%s)", tc.Input, tc.Comment)
 			}
 		})
+	}
+}
+
+func TestSharedGrammarFixture_FamilyNormalizedAST(t *testing.T) {
+	fx := loadFixture(t)
+	for _, tc := range fx.Valid {
+		s, err := parser.NewSource(tc.Input)
+		if err != nil {
+			t.Fatalf("NewSource(%q): %v", tc.Input, err)
+		}
+		verb, err := parser.Verb(s)
+		if err != nil {
+			t.Fatalf("Verb(%q): %v", tc.Input, err)
+		}
+		if verb != "bfs" && verb != "pagerank" && verb != "community" {
+			continue
+		}
+		t.Run(tc.Input, func(t *testing.T) {
+			if len(tc.Expected) == 0 {
+				t.Fatal("family fixture is missing its expected normalized AST")
+			}
+			got, err := normalizedFamilyAST(tc.Input)
+			if err != nil {
+				t.Fatalf("normalizedFamilyAST(%q): %v", tc.Input, err)
+			}
+			var want any
+			if err := json.Unmarshal(tc.Expected, &want); err != nil {
+				t.Fatalf("decode expected AST: %v", err)
+			}
+			b, err := json.Marshal(got)
+			if err != nil {
+				t.Fatalf("encode actual AST: %v", err)
+			}
+			var actual any
+			if err := json.Unmarshal(b, &actual); err != nil {
+				t.Fatalf("decode actual AST: %v", err)
+			}
+			if !reflect.DeepEqual(actual, want) {
+				t.Errorf("normalized AST mismatch\n got: %s\nwant: %s", b, tc.Expected)
+			}
+		})
+	}
+}
+
+func normalizedFamilyAST(input string) (map[string]any, error) {
+	s, err := parser.NewSource(input)
+	if err != nil {
+		return nil, err
+	}
+	verb, err := parser.Verb(s)
+	if err != nil {
+		return nil, err
+	}
+	switch verb {
+	case "bfs":
+		p, err := parser.BfsParam(s)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{
+			"family": "bfs", "seed": p.Seed, "step": p.Step, "fan_out": p.FanOut,
+			"reduction": p.Reduction, "objective": p.Objective, "weighting": p.Weighting, "prefix": p.Prefix,
+		}, nil
+	case "pagerank":
+		p, err := parser.PagerankParam(s)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{
+			"family": "pagerank", "seed": p.Seed, "top_n": p.TopN,
+			"restart_prob_f32_bits": math.Float32bits(p.RestartProb), "epsilon_f32_bits": math.Float32bits(p.Epsilon),
+			"weighting": p.Weighting, "prefix": p.Prefix,
+		}, nil
+	case "community":
+		p, err := parser.CommunityParam(s)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{
+			"family": "community", "seed": p.Seed, "max_size": p.MaxSize,
+			"restart_prob_f32_bits": math.Float32bits(p.RestartProb), "epsilon_f32_bits": math.Float32bits(p.Epsilon),
+			"reduction": p.Reduction, "objective": p.Objective, "weighting": p.Weighting, "prefix": p.Prefix,
+		}, nil
+	default:
+		return nil, fmt.Errorf("%q is not a family verb", verb)
 	}
 }

--- a/cli/parser/model.go
+++ b/cli/parser/model.go
@@ -79,8 +79,8 @@ type DeleteEdge struct {
 // as step=/fan_out= kwargs. bfs is the only family with step and reduction knobs.
 type Bfs struct {
 	Seed      string
-	Step      int    // walk depth (default 5)
-	FanOut    int    // per-hop top-k prune (default 3)
+	Step      uint32 // walk depth (default 5)
+	FanOut    uint32 // per-hop top-k prune (default 3)
 	Reduction string // "none" | "mst" | "spt" (default: "none")
 	Objective string // "min" | "max"          (default: "max")
 	Weighting string // "raw" | "tfidf" | "bm25" (default: "raw")
@@ -95,7 +95,7 @@ type Bfs struct {
 // reduction/objective knob.
 type Pagerank struct {
 	Seed        string
-	TopN        int     // cap the star to the top-N by mass (default 10; 0 = all)
+	TopN        uint32  // cap the star to the top-N by mass (default 10; 0 = all)
 	RestartProb float32 // restart prob α; 0 (default) = server default 0.15 (#801)
 	Epsilon     float32 // residual threshold ε; 0 (default) = server default 1e-4 (#801)
 	Weighting   string  // "raw" | "tfidf" | "bm25" (default: "raw")
@@ -109,7 +109,7 @@ type Pagerank struct {
 // reduction/objective render an optional tree view of the community (#845).
 type Community struct {
 	Seed        string
-	MaxSize     int     // size upper bound (default 0 = sweep decides)
+	MaxSize     uint32  // size upper bound (default 0 = sweep decides)
 	RestartProb float32 // restart prob α; 0 (default) = server default 0.15 (#845)
 	Epsilon     float32 // residual threshold ε; 0 (default) = server default 1e-4 (#845)
 	Reduction   string  // "none" | "mst" | "spt" (default: "none")

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -737,20 +737,43 @@ func CommunityParam(s *Source) (*Community, error) {
 	return m, nil
 }
 
-func positiveFamilyInt(value, label string) (int, error) {
-	n, err := strconv.Atoi(value)
-	if err != nil || n <= 0 {
+func positiveFamilyInt(value, label string) (uint32, error) {
+	n, err := familyUint32(value)
+	if err != nil || n == 0 {
 		return 0, errors.New(label + value + " (want a positive integer)")
 	}
 	return n, nil
 }
 
-func nonNegativeFamilyInt(value, label string) (int, error) {
-	n, err := strconv.Atoi(value)
-	if err != nil || n < 0 {
+func nonNegativeFamilyInt(value, label string) (uint32, error) {
+	n, err := familyUint32(value)
+	if err != nil {
 		return 0, errors.New(label + value + " (want a non-negative integer)")
 	}
 	return n, nil
+}
+
+// familyUint32 defines the shared family-verb integer grammar: ASCII decimal
+// digits only, with no sign, and the exact uint32 wire range. strconv.Atoi
+// accepts a leading plus and the host's wider int range, neither of which is a
+// stable cross-surface or wire-level contract.
+func familyUint32(value string) (uint32, error) {
+	if value == "" {
+		return 0, strconv.ErrSyntax
+	}
+	for i := 0; i < len(value); i++ {
+		if value[i] < '0' || value[i] > '9' {
+			return 0, strconv.ErrSyntax
+		}
+	}
+	n, err := strconv.ParseUint(value, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	if n > math.MaxUint32 {
+		return 0, strconv.ErrRange
+	}
+	return uint32(n), nil
 }
 
 func familyRestartProb(value, label string) (float32, error) {

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -450,7 +450,7 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 			return ErrBFS
 		}
 		opts := []client.IlluminateOption{
-			BfsOption(clampUint32(p.Step), clampUint32(p.FanOut), red, obj),
+			BfsOption(p.Step, p.FanOut, red, obj),
 			client.WithWeighting(w),
 		}
 		if p.Prefix != "" {
@@ -469,7 +469,7 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 			return ErrPagerank
 		}
 		opts := []client.IlluminateOption{
-			PagerankOption(clampUint32(p.TopN), p.RestartProb, p.Epsilon),
+			PagerankOption(p.TopN, p.RestartProb, p.Epsilon),
 			client.WithWeighting(w),
 		}
 		if p.Prefix != "" {
@@ -498,7 +498,7 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 			return ErrCommunity
 		}
 		opts := []client.IlluminateOption{
-			CommunityOption(clampUint32(p.MaxSize), red, obj, p.RestartProb, p.Epsilon),
+			CommunityOption(p.MaxSize, red, obj, p.RestartProb, p.Epsilon),
 			client.WithWeighting(w),
 		}
 		if p.Prefix != "" {
@@ -517,21 +517,6 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 		return ErrInvalidVerb
 	}
 	return nil
-}
-
-// clampUint32 saturates an int into uint32 range. The REPL parser produces
-// plain ints from strconv.Atoi; a negative or >32-bit value must not wrap
-// through the conversion into a huge step/k (CodeQL
-// go/incorrect-integer-conversion).
-func clampUint32(v int) uint32 {
-	if v < 0 {
-		return 0
-	}
-	u := uint64(v)
-	if u > math.MaxUint32 {
-		return math.MaxUint32
-	}
-	return uint32(u)
 }
 
 // BfsOption / PagerankOption / CommunityOption build the typed per-family SDK


### PR DESCRIPTION
## Summary
- make Go and TypeScript grammar fixtures compare normalized float32 semantics
- align family option parsing across CLI and Admin
- guard scientific notation, bounds, and canonical family axes in shared fixtures

## Validation
- full root and all Go module test gate
- server `go vet ./...` and golangci-lint changed-lines gate
- Node SDK build/typecheck/lint/format/test
- Admin format/lint/typecheck/unit/build

Closes #985