### PR TITLE
fix(cli): preserve RPC causes and failure exit status for family verbs

### DIFF
--- a/cli/cmd/family.go
+++ b/cli/cmd/family.go
@@ -9,6 +9,7 @@ import (
 	"github.com/anaregdesign/lantern/cli/service"
 	client "github.com/anaregdesign/lantern/sdks/go"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // objectiveByName / reductionByName / weightingByName map the human-friendly
@@ -52,7 +53,16 @@ func forwardFamilyPositional(cmd *cobra.Command, verb string, args []string) err
 }
 
 func rejectMixedFamilyGrammar(cmd *cobra.Command, args []string) error {
-	if len(args) > 1 && cmd.Flags().NFlag() > 0 {
+	// Persistent connection flags (--address, --timeout, …) apply to both
+	// grammar forms. Only a family command's own flags conflict with its
+	// positional arguments.
+	var hasChangedFamilyFlag bool
+	cmd.Flags().Visit(func(flag *pflag.Flag) {
+		if cmd.InheritedFlags().Lookup(flag.Name) == nil {
+			hasChangedFamilyFlag = true
+		}
+	})
+	if len(args) > 1 && hasChangedFamilyFlag {
 		return errors.New("cannot mix flags with the positional grammar; use one or the other")
 	}
 	return nil

--- a/cli/cmd/repl.go
+++ b/cli/cmd/repl.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -133,40 +134,40 @@ EXAMPLE
 			start := time.Now()
 			err = srv.Run(ctx, result)
 			elapsed := time.Since(start)
-			switch err {
-			case nil:
+			switch {
+			case err == nil:
 				fmt.Printf("OK (%v)\n", elapsed)
-			case service.ErrGetVertex:
+			case errors.Is(err, service.ErrGetVertex):
 				fmt.Println("Usage: get vertex <key: string>")
-			case service.ErrGetEdge:
+			case errors.Is(err, service.ErrGetEdge):
 				fmt.Println("Usage: get edge <tail: string> <head: string>")
-			case service.ErrPutVertex:
+			case errors.Is(err, service.ErrPutVertex):
 				fmt.Println("Usage: put vertex <key: string> <value: string> [<ttl_seconds: int>]")
-			case service.ErrPutEdge:
+			case errors.Is(err, service.ErrPutEdge):
 				fmt.Println("Usage: put edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]")
-			case service.ErrDeleteVertex:
+			case errors.Is(err, service.ErrDeleteVertex):
 				fmt.Println("Usage: delete vertex <key: string>")
-			case service.ErrDeleteEdge:
+			case errors.Is(err, service.ErrDeleteEdge):
 				fmt.Println("Usage: delete edge <tail: string> <head: string>")
-			case service.ErrAddEdge:
+			case errors.Is(err, service.ErrAddEdge):
 				fmt.Println("Usage: add edge <tail: string> <head: string> <weight: float> [<ttl_seconds: int>]")
-			case service.ErrAddDecayingEdge:
+			case errors.Is(err, service.ErrAddDecayingEdge):
 				fmt.Println("Usage: add decaying-edge <tail: string> <head: string> <initial_weight: float> <ratio: float> <steps: int> <interval_seconds: int>")
-			case service.ErrScan:
+			case errors.Is(err, service.ErrScan):
 				fmt.Println("Usage: scan { vertices <prefix: string> [<limit: int>] | edges <tail-prefix: string> [<limit: int>] }")
-			case service.ErrKeys:
+			case errors.Is(err, service.ErrKeys):
 				fmt.Println("Usage: keys <prefix: string> [<limit: int>]")
-			case service.ErrBFS:
+			case errors.Is(err, service.ErrBFS):
 				fmt.Println("Usage: bfs <seed: string> [step: int] [fan_out: int] [reduction=none|mst|spt] [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>]")
-			case service.ErrPagerank:
+			case errors.Is(err, service.ErrPagerank):
 				fmt.Println("Usage: pagerank <seed: string> [top_n: int] [restart_prob=<float>] [epsilon=<float>] [weighting=raw|tfidf|bm25] [prefix=<string>]")
-			case service.ErrCommunity:
+			case errors.Is(err, service.ErrCommunity):
 				fmt.Println("Usage: community <seed: string> [max_size: int] [restart_prob=<float>] [epsilon=<float>] [reduction=none|mst|spt] [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>]")
-			case service.ErrInvalidVerb:
+			case errors.Is(err, service.ErrInvalidVerb):
 				fmt.Println("Usage: { get | put | delete | add | scan | count | delete-prefix | keys | bfs | pagerank | community | help | exit } ...")
-			case service.ErrInvalidObjective:
+			case errors.Is(err, service.ErrInvalidObjective):
 				fmt.Println("{ get { vertex | edge } | put { vertex | edge } | delete { vertex | edge } | add { edge | decaying-edge } | scan { vertices | edges } | count vertices | delete-prefix vertices | keys {...} | bfs {...} | pagerank {...} | community {...} } ...")
-			case service.ErrConnection:
+			case errors.Is(err, service.ErrConnection):
 				fmt.Println("server error")
 			default:
 				fmt.Println(err)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -13,13 +13,13 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
@@ -132,15 +132,33 @@ EXAMPLES
 
 // Execute runs the root command. It is the only function main.go calls.
 func Execute() {
-	if err := rootCmd.ExecuteContext(signalContext()); err != nil {
-		fmt.Fprintln(os.Stderr, "Error:", err)
-		// Exit code 2 if the error came from the server (RPC errors carry an
-		// "rpc error:" prefix). Use 1 for everything else.
-		if strings.Contains(err.Error(), "rpc error") {
-			os.Exit(2)
-		}
-		os.Exit(1)
+	if code := runCommand(signalContext(), rootCmd); code != 0 {
+		os.Exit(code)
 	}
+}
+
+// runCommand executes a Cobra command and writes any command error to its
+// configured stderr. It is deliberately separate from Execute so callers and
+// tests can observe the CLI's exit-code contract without terminating the
+// process.
+func runCommand(ctx context.Context, command *cobra.Command) int {
+	if err := command.ExecuteContext(ctx); err != nil {
+		_, _ = fmt.Fprintln(command.ErrOrStderr(), "Error:", err)
+		return exitCode(err)
+	}
+	return 0
+}
+
+// exitCode distinguishes errors returned by a Connect server from local CLI
+// failures. The SDK keeps the original *connect.Error in its wrapped errors,
+// so errors.As works for both direct Connect failures and SDK sentinels without
+// depending on an unstable error-message prefix.
+func exitCode(err error) int {
+	var connectErr *connect.Error
+	if errors.As(err, &connectErr) {
+		return 2
+	}
+	return 1
 }
 
 // signalContext returns a context that is cancelled on SIGINT / SIGTERM so

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/spf13/cobra"
+)
+
+func TestRunCommand_ExitCodesAndStderr(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		err      error
+		wantCode int
+		wantText string
+	}{
+		{
+			name:     "ConnectErrorIsRPCFailureEvenWithoutRPCText",
+			err:      connect.NewError(connect.CodeInvalidArgument, errors.New("server rejected the request")),
+			wantCode: 2,
+			wantText: "server rejected the request",
+		},
+		{
+			name:     "WrappedConnectErrorIsRPCFailure",
+			err:      fmt.Errorf("family traversal: %w", connect.NewError(connect.CodeResourceExhausted, errors.New("work budget exhausted"))),
+			wantCode: 2,
+			wantText: "work budget exhausted",
+		},
+		{
+			name:     "LocalErrorMentioningRPCIsNotReclassified",
+			err:      errors.New("rpc error text from a local parser"),
+			wantCode: 1,
+			wantText: "rpc error text from a local parser",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			command := &cobra.Command{
+				Use:           "test",
+				SilenceErrors: true,
+				SilenceUsage:  true,
+				RunE: func(*cobra.Command, []string) error {
+					return tc.err
+				},
+			}
+			command.SetOut(&stdout)
+			command.SetErr(&stderr)
+
+			if got := runCommand(context.Background(), command); got != tc.wantCode {
+				t.Errorf("runCommand() = %d, want %d", got, tc.wantCode)
+			}
+			if got := stdout.String(); got != "" {
+				t.Errorf("stdout = %q, want empty", got)
+			}
+			if got := stderr.String(); !strings.Contains(got, tc.wantText) {
+				t.Errorf("stderr = %q, want original error detail %q", got, tc.wantText)
+			}
+		})
+	}
+}

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -431,23 +431,19 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 	case "bfs":
 		p, err := parser.BfsParam(s)
 		if err != nil {
-			fmt.Printf("Error: %s\n", err)
-			return ErrBFS
+			return fmt.Errorf("%w: %w", ErrBFS, err)
 		}
 		obj, ok := objectiveByREPLName[p.Objective]
 		if !ok {
-			fmt.Printf("Error: bfs: unknown objective %q\n", p.Objective)
-			return ErrBFS
+			return fmt.Errorf("%w: unknown objective %q", ErrBFS, p.Objective)
 		}
 		red, ok := reductionByREPLName[p.Reduction]
 		if !ok {
-			fmt.Printf("Error: bfs: unknown reduction %q\n", p.Reduction)
-			return ErrBFS
+			return fmt.Errorf("%w: unknown reduction %q", ErrBFS, p.Reduction)
 		}
 		w, ok := weightingByREPLName[p.Weighting]
 		if !ok {
-			fmt.Printf("Error: bfs: unknown weighting %q\n", p.Weighting)
-			return ErrBFS
+			return fmt.Errorf("%w: unknown weighting %q", ErrBFS, p.Weighting)
 		}
 		opts := []client.IlluminateOption{
 			BfsOption(clampUint32(p.Step), clampUint32(p.FanOut), red, obj),
@@ -460,13 +456,11 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 	case "pagerank":
 		p, err := parser.PagerankParam(s)
 		if err != nil {
-			fmt.Printf("Error: %s\n", err)
-			return ErrPagerank
+			return fmt.Errorf("%w: %w", ErrPagerank, err)
 		}
 		w, ok := weightingByREPLName[p.Weighting]
 		if !ok {
-			fmt.Printf("Error: pagerank: unknown weighting %q\n", p.Weighting)
-			return ErrPagerank
+			return fmt.Errorf("%w: unknown weighting %q", ErrPagerank, p.Weighting)
 		}
 		opts := []client.IlluminateOption{
 			PagerankOption(clampUint32(p.TopN), p.RestartProb, p.Epsilon),
@@ -479,23 +473,19 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 	case "community":
 		p, err := parser.CommunityParam(s)
 		if err != nil {
-			fmt.Printf("Error: %s\n", err)
-			return ErrCommunity
+			return fmt.Errorf("%w: %w", ErrCommunity, err)
 		}
 		obj, ok := objectiveByREPLName[p.Objective]
 		if !ok {
-			fmt.Printf("Error: community: unknown objective %q\n", p.Objective)
-			return ErrCommunity
+			return fmt.Errorf("%w: unknown objective %q", ErrCommunity, p.Objective)
 		}
 		red, ok := reductionByREPLName[p.Reduction]
 		if !ok {
-			fmt.Printf("Error: community: unknown reduction %q\n", p.Reduction)
-			return ErrCommunity
+			return fmt.Errorf("%w: unknown reduction %q", ErrCommunity, p.Reduction)
 		}
 		w, ok := weightingByREPLName[p.Weighting]
 		if !ok {
-			fmt.Printf("Error: community: unknown weighting %q\n", p.Weighting)
-			return ErrCommunity
+			return fmt.Errorf("%w: unknown weighting %q", ErrCommunity, p.Weighting)
 		}
 		opts := []client.IlluminateOption{
 			CommunityOption(clampUint32(p.MaxSize), red, obj, p.RestartProb, p.Epsilon),
@@ -561,8 +551,10 @@ func CommunityOption(maxSize uint32, red client.Reduction, obj client.Objective,
 func (c *CLIService) runIlluminate(ctx context.Context, seed string, opts []client.IlluminateOption) error {
 	g, err := c.client.Illuminate(ctx, seed, opts...)
 	if err != nil {
-		fmt.Printf("Error: %s\n", err)
-		return ErrConnection
+		// Keep the SDK/Connect error intact. One-shot commands classify it at
+		// the root and write it to stderr; replacing it with ErrConnection used
+		// to discard the server's code and detail on the positional path.
+		return err
 	}
 	jsonString, err := json.MarshalIndent(g, "", "\t")
 	if err != nil {

--- a/cli/service/service_test.go
+++ b/cli/service/service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -136,8 +137,8 @@ func TestRunArgs_FamilyParseErrorsReturnSpecificSentinels(t *testing.T) {
 		{name: "CommunityInvalidEpsilon", args: []string{"community", "alice", "epsilon=0"}, want: ErrCommunity},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := svc.RunArgs(ctx, tc.args); err != tc.want {
-				t.Errorf("RunArgs(%v) = %v, want %v", tc.args, err, tc.want)
+			if err := svc.RunArgs(ctx, tc.args); !errors.Is(err, tc.want) {
+				t.Errorf("RunArgs(%v) = %v, want an error matching %v", tc.args, err, tc.want)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.9
 	golang.org/x/net v0.56.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
@@ -49,7 +50,6 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 // indirect

--- a/tests/integration/cli_family_verbs_test.go
+++ b/tests/integration/cli_family_verbs_test.go
@@ -1,11 +1,20 @@
 package integration_test
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	cliservice "github.com/anaregdesign/lantern/cli/service"
+	"github.com/anaregdesign/lantern/core/graphcache"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/server/provider"
+	serverservice "github.com/anaregdesign/lantern/server/service"
 )
 
 // TestCLI_FamilyVerbs_RealWire exercises the #975 family verbs (bfs / pagerank /
@@ -79,9 +88,145 @@ func TestCLI_FamilyVerbs_RealWire(t *testing.T) {
 		{name: "CommunityZeroEpsilon", args: []string{"community", "a", "epsilon=0"}, want: cliservice.ErrCommunity},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := svc.RunArgs(ctx, tc.args); err != tc.want {
-				t.Errorf("RunArgs(%v) = %v, want %v", tc.args, err, tc.want)
+			if err := svc.RunArgs(ctx, tc.args); !errors.Is(err, tc.want) {
+				t.Errorf("RunArgs(%v) = %v, want an error matching %v", tc.args, err, tc.want)
 			}
 		})
 	}
+}
+
+// TestCLI_FamilyVerbs_RPCFailuresUseStderrAndExit2 exercises the actual CLI
+// executable against the real Connect/h2c handler. It protects the published
+// script contract from drifting separately between the flag and positional
+// family paths (#986): a server-side validation failure keeps its Connect
+// detail, prints only on stderr, and exits 2.
+func TestCLI_FamilyVerbs_RPCFailuresUseStderrAndExit2(t *testing.T) {
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+	svc := serverservice.NewLanternService(cache)
+	validator := provider.NewValidationInterceptor(defaultIntegrationValidationLimits())
+	srv := newConnectTestServer(t, svc, nil, validator.ConnectInterceptor())
+	binary := buildLanternCLI(t)
+	endpoint := strings.TrimPrefix(srv.url, "http://")
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantDetail string
+	}{
+		{
+			name:       "BFS/Flag",
+			args:       []string{"bfs", "any", "--step", "99", "--fan-out", "1"},
+			wantDetail: "bfs.step 99 exceeds max",
+		},
+		{
+			name:       "BFS/Positional",
+			args:       []string{"bfs", "any", "99", "1"},
+			wantDetail: "bfs.step 99 exceeds max",
+		},
+		{
+			name:       "PageRank/Flag",
+			args:       []string{"pagerank", "any", "--top-n", "999"},
+			wantDetail: "ppr.top_n 999 exceeds max",
+		},
+		{
+			name:       "PageRank/Positional",
+			args:       []string{"pagerank", "any", "999"},
+			wantDetail: "ppr.top_n 999 exceeds max",
+		},
+		{
+			name:       "Community/Flag",
+			args:       []string{"community", "any", "--max-size", "999"},
+			wantDetail: "community.max_size 999 exceeds max",
+		},
+		{
+			name:       "Community/Positional",
+			args:       []string{"community", "any", "999"},
+			wantDetail: "community.max_size 999 exceeds max",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, code := runLanternCLI(t, binary, endpoint, tc.args...)
+			if code != 2 {
+				t.Errorf("exit code = %d, want 2; stderr = %q", code, stderr)
+			}
+			if stdout != "" {
+				t.Errorf("stdout = %q, want empty so machine-readable output is not contaminated", stdout)
+			}
+			if !strings.Contains(stderr, "invalid_argument") {
+				t.Errorf("stderr = %q, want the Connect InvalidArgument code", stderr)
+			}
+			if !strings.Contains(stderr, tc.wantDetail) {
+				t.Errorf("stderr = %q, want preserved server detail %q", stderr, tc.wantDetail)
+			}
+			if strings.Contains(stderr, "connection error") {
+				t.Errorf("stderr = %q, must not replace the RPC cause with connection error", stderr)
+			}
+		})
+	}
+
+	// The same executable seam distinguishes local family validation from an
+	// RPC rejection. These arguments fail before Illuminate is invoked, so the
+	// documented local-error exit code remains 1 and stdout stays clean.
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		wantText string
+	}{
+		{
+			name:     "BFS/PositionalParse",
+			args:     []string{"bfs", "any", "0", "1"},
+			wantText: "step 0 (want a positive integer)",
+		},
+		{
+			name:     "PageRank/FlagValidation",
+			args:     []string{"pagerank", "any", "--restart-prob", "1"},
+			wantText: "--restart-prob must be a float in (0,1)",
+		},
+		{
+			name:     "Community/PositionalParse",
+			args:     []string{"community", "any", "restart_prob=1"},
+			wantText: "restart_prob=1 (want a float in (0,1))",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, code := runLanternCLI(t, binary, endpoint, tc.args...)
+			if code != 1 {
+				t.Errorf("exit code = %d, want 1; stderr = %q", code, stderr)
+			}
+			if stdout != "" {
+				t.Errorf("stdout = %q, want empty for local errors too", stdout)
+			}
+			if !strings.Contains(stderr, tc.wantText) {
+				t.Errorf("stderr = %q, want local error %q", stderr, tc.wantText)
+			}
+		})
+	}
+}
+
+func buildLanternCLI(t *testing.T) string {
+	t.Helper()
+	binary := filepath.Join(t.TempDir(), "lantern-cli")
+	build := exec.Command("go", "build", "-o", binary, "./cli")
+	build.Dir = filepath.Clean(filepath.Join("..", ".."))
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build ./cli: %v\n%s", err, output)
+	}
+	return binary
+}
+
+func runLanternCLI(t *testing.T, binary, endpoint string, args ...string) (stdout, stderr string, exitCode int) {
+	t.Helper()
+	command := exec.Command(binary, append([]string{"--address", endpoint}, args...)...)
+	var stdoutBuffer, stderrBuffer bytes.Buffer
+	command.Stdout = &stdoutBuffer
+	command.Stderr = &stderrBuffer
+	err := command.Run()
+	if err == nil {
+		return stdoutBuffer.String(), stderrBuffer.String(), 0
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("run lantern-cli %v: %v", args, err)
+	}
+	return stdoutBuffer.String(), stderrBuffer.String(), exitErr.ExitCode()
 }


### PR DESCRIPTION
## Summary
- return family RPC failures instead of printing and swallowing them
- route diagnostics through Cobra stderr and preserve exit code 2
- cover command, process, and real Connect failure contracts

## Validation
- full root and all Go module test gate
- server `go vet ./...`
- golangci-lint changed-lines gate (CI-pinned v2.12.2)

Closes #986