### PR TITLE
fix(sdks/go): reject conflicting traversal family options

### DIFF
--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -224,6 +224,12 @@ carries its own TTL); `PutEdge` is **idempotent replace** (single weight,
 single TTL). See the in-line discussion in `example/main.go` for the
 semantic difference.
 
+`Illuminate` accepts at most one traversal family option (`WithBFS`,
+`WithPPR`, or `WithLocalCommunity`). Combining them returns a local error that
+matches both `ErrInvalidArgument` and `ErrConflictingIlluminateFamilies` before
+any RPC is sent; the same contract applies to `NewLanternFailover`. Shared
+axes (`WithWeighting`, `WithVertexPrefix`) remain composable.
+
 `PutVertexIfAbsent` / `PutVerticesIfAbsent` are conditional writes (SET NX,
 #896): each applies only when no **live** vertex already exists at the key,
 closing the check-then-act race of a `GetVertex` → `PutVertex` sequence. The

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -37,6 +37,12 @@ var ErrNotFound = errors.New("not found")
 // caller-fixable input errors vs. transient failures.
 var ErrInvalidArgument = errors.New("invalid argument")
 
+// ErrConflictingIlluminateFamilies reports a local misuse of Illuminate:
+// exactly zero or one traversal-family option may be supplied. It is joined
+// with ErrInvalidArgument so callers can classify it alongside server-side
+// invalid arguments without sending an RPC.
+var ErrConflictingIlluminateFamilies = errors.New("conflicting illuminate traversal families")
+
 // ErrResourceExhausted wraps connect.CodeResourceExhausted responses
 // (rate limiter, server-side back-pressure). Callers that see this
 // should back off before retrying.
@@ -796,8 +802,9 @@ func NewGraph() *Graph {
 }
 
 // IlluminateOption configures a single Illuminate call. Select the traversal
-// family with at most one of WithBFS / WithPPR (the last one passed wins,
-// mirroring the wire oneof; omitting both runs BFS with server defaults —
+// family with at most one of WithBFS / WithPPR / WithLocalCommunity; supplying
+// more than one is a local ErrConflictingIlluminateFamilies error. Omitting all
+// runs BFS with server defaults —
 // the bare illuminate), and combine it with the shared axes WithWeighting /
 // WithVertexPrefix. Per-family knobs live on BFSOpts / PPROpts, so a knob
 // that another family would ignore is not expressible (#846).
@@ -809,6 +816,17 @@ type illuminateConfig struct {
 	bfs          *BFSOpts
 	ppr          *PPROpts
 	community    *LocalCommunityOpts
+	family       string
+	conflictWith string
+}
+
+func (c *illuminateConfig) selectFamily(family string) bool {
+	if c.family != "" {
+		c.conflictWith = family
+		return false
+	}
+	c.family = family
+	return true
 }
 
 // BFSOpts tunes the greedy per-hop top-k BFS walk and its optional
@@ -877,23 +895,35 @@ type LocalCommunityOpts struct {
 }
 
 // WithBFS selects the BFS traversal family with the supplied knobs.
-// Mutually exclusive with the other family options (last option wins).
+// Combining it with any other family option is rejected before the RPC.
 func WithBFS(o BFSOpts) IlluminateOption {
-	return func(c *illuminateConfig) { c.bfs, c.ppr, c.community = &o, nil, nil }
+	return func(c *illuminateConfig) {
+		if c.selectFamily("bfs") {
+			c.bfs = &o
+		}
+	}
 }
 
 // WithPPR selects the Personalized PageRank traversal family with the
-// supplied knobs. Mutually exclusive with the other family options (last
-// option wins).
+// supplied knobs. Combining it with any other family option is rejected
+// before the RPC.
 func WithPPR(o PPROpts) IlluminateOption {
-	return func(c *illuminateConfig) { c.ppr, c.bfs, c.community = &o, nil, nil }
+	return func(c *illuminateConfig) {
+		if c.selectFamily("pagerank") {
+			c.ppr = &o
+		}
+	}
 }
 
 // WithLocalCommunity selects the local community extraction family (#845)
-// with the supplied knobs. Mutually exclusive with the other family options
-// (last option wins).
+// with the supplied knobs. Combining it with any other family option is
+// rejected before the RPC.
 func WithLocalCommunity(o LocalCommunityOpts) IlluminateOption {
-	return func(c *illuminateConfig) { c.community, c.bfs, c.ppr = &o, nil, nil }
+	return func(c *illuminateConfig) {
+		if c.selectFamily("community") {
+			c.community = &o
+		}
+	}
 }
 
 // WithWeighting toggles the edge-weight transform applied BEFORE the
@@ -928,6 +958,12 @@ func (l *Lantern) Illuminate(ctx context.Context, seed string, opts ...Illuminat
 	var cfg illuminateConfig
 	for _, opt := range opts {
 		opt(&cfg)
+	}
+	if cfg.conflictWith != "" {
+		return nil, errors.Join(
+			ErrInvalidArgument,
+			fmt.Errorf("%w: %s and %s", ErrConflictingIlluminateFamilies, cfg.family, cfg.conflictWith),
+		)
 	}
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"testing"
 	"time"
 
@@ -416,8 +417,8 @@ func TestWithWeightingWiring(t *testing.T) {
 // TestIlluminateParamsWiring verifies the #846 typed per-family options
 // marshal to the intended oneof arm: no family option ⇒ params unset (the
 // bare illuminate); WithBFS ⇒ the bfs arm with its four knobs; WithPPR ⇒
-// the ppr arm with its three knobs; and the last family option wins,
-// mirroring the wire oneof.
+// the ppr arm with its three knobs; and multiple family options fail locally
+// before a request is sent.
 func TestIlluminateParamsWiring(t *testing.T) {
 	newClient := func(t *testing.T) (*Lantern, *captureIlluminate) {
 		t.Helper()
@@ -477,16 +478,42 @@ func TestIlluminateParamsWiring(t *testing.T) {
 		}
 	})
 
-	t.Run("last family option wins", func(t *testing.T) {
-		l, capt := newClient(t)
-		if _, err := l.Illuminate(context.Background(), "seed",
-			WithPPR(PPROpts{TopN: 5}),
-			WithBFS(BFSOpts{Step: 1}),
-		); err != nil {
-			t.Fatalf("Illuminate: %v", err)
+	families := []struct {
+		name string
+		opt  IlluminateOption
+	}{
+		{"bfs", WithBFS(BFSOpts{Step: 1})},
+		{"pagerank", WithPPR(PPROpts{TopN: 5})},
+		{"community", WithLocalCommunity(LocalCommunityOpts{MaxSize: 5})},
+	}
+	for _, first := range families {
+		for _, second := range families {
+			t.Run(first.name+" then "+second.name, func(t *testing.T) {
+				l, capt := newClient(t)
+				_, err := l.Illuminate(context.Background(), "seed", first.opt, second.opt)
+				if !errors.Is(err, ErrInvalidArgument) || !errors.Is(err, ErrConflictingIlluminateFamilies) {
+					t.Fatalf("Illuminate error = %v, want ErrInvalidArgument + ErrConflictingIlluminateFamilies", err)
+				}
+				if len(capt.reqs) != 0 {
+					t.Fatalf("conflicting options sent %d requests, want 0", len(capt.reqs))
+				}
+			})
 		}
-		if capt.reqs[0].GetBfs() == nil || capt.reqs[0].GetPpr() != nil {
-			t.Fatalf("want bfs arm to win, got params = %T", capt.reqs[0].GetParams())
+	}
+	for _, first := range families {
+		for _, second := range families {
+			for _, third := range families {
+				if first.name == second.name || first.name == third.name || second.name == third.name {
+					continue
+				}
+				t.Run(first.name+" then "+second.name+" then "+third.name, func(t *testing.T) {
+					l, capt := newClient(t)
+					_, err := l.Illuminate(context.Background(), "seed", first.opt, second.opt, third.opt)
+					if !errors.Is(err, ErrConflictingIlluminateFamilies) || len(capt.reqs) != 0 {
+						t.Fatalf("all-family conflict err=%v requests=%d, want local conflict and no requests", err, len(capt.reqs))
+					}
+				})
+			}
 		}
-	})
+	}
 }

--- a/sdks/go/doc.go
+++ b/sdks/go/doc.go
@@ -37,6 +37,15 @@
 // injects a hidden default expiration — an omitted/zero TTL is honoured
 // as permanent end to end (see #523).
 //
+// # Illuminate family selection
+//
+// Illuminate accepts zero or one traversal family option: WithBFS, WithPPR,
+// or WithLocalCommunity. Passing more than one returns a local error matching
+// both ErrInvalidArgument and ErrConflictingIlluminateFamilies before any
+// endpoint is contacted. The same rule applies through NewLanternFailover.
+// Shared axes such as WithWeighting and WithVertexPrefix remain freely
+// composable with the one family option.
+//
 // # Retry policy
 //
 // Retries are opt-in and off by default — a zero-config client behaves


### PR DESCRIPTION
## Summary
- make Illuminate family selection fail closed when callers supply multiple family options
- preserve safe bare-request behavior while validating option composition
- document and test every conflict permutation

## Validation
- full root and all Go module test gate
- server `go vet ./...`
- golangci-lint changed-lines gate (CI-pinned v2.12.2)

Closes #998