### PR TITLE
test(bench): exercise real branching, PPR, and community topology

### DIFF
--- a/testbed/bench/README.md
+++ b/testbed/bench/README.md
@@ -89,6 +89,7 @@ scenario declares a `perf_gate:` block — the perf-gate verdict
 | `replication_apply_churn.yaml` | replicated write churn; asserts `lantern_vertex_hlc_entries` returns to baseline (#700, #705) |
 | `edge_contrib_idempotent.yaml` | AddEdge/AddEdges with repeated ContribIDs; verifies at-most-once dedup stays bounded (#706) |
 | `backup_under_load.yaml`  | BackupSnapshot concurrent with sustained writes — on-demand only, not in release sweep (#707) |
+| `broad_illuminate.yaml` | Six named traversal producers over a verified 64-way/3-hop walk and planted dense communities; preflight rejects a collapsed topology (#994) |
 
 Each YAML declares the phases (`warmup`, `steady`, `cooldown`), the ghz
 target (`call` + `data_template`), optional `subscribe` and `chaos`
@@ -115,6 +116,13 @@ scenario fails the schema PR instead of the next nightly (#934). If you
 retire or rename a wire field, migrate every scenario that sends it in the
 same PR.
 
+`broad_illuminate` additionally has a semantic topology gate. Before warmup,
+the harness seeds a deterministic graph, then verifies the requested 64-way
+three-hop BFS shape, tuned PPR touch count, and a 32-member weak-bridge
+community reduced to a directed arborescence. Its six named producers are
+gated independently as well as in aggregate, so a cheap BFS cannot hide a
+PPR or community regression.
+
 ### Perf gate (`perf_gate:` block)
 
 A scenario MAY additionally declare throughput/latency floors over its
@@ -133,6 +141,21 @@ for the scenario. The aggregation matches the release summary table
 `fail` folds into run.sh's exit code exactly like the leak gate: the
 blocking nightly (`bench-nightly.yml`) enforces it, the release-time bench
 stays advisory (`continue-on-error`, #256/#394).
+
+For a fan-out scenario, `perf_gate.producers` may define the same thresholds
+per named `target.calls[]` producer:
+
+```yaml
+perf_gate:
+  producers:
+    ppr_tuned:
+      min_steady_rps: 50
+      max_p99_ms: 1000
+      max_non_ok_ratio: 0.02
+```
+
+All named producer gates are conjunctive with the aggregate gate and appear
+as separate rows in `perf_gate.json` and the rendered report.
 
 Sizing rules (all seven release scenarios carry a block sized this way):
 

--- a/testbed/bench/preflight/main.go
+++ b/testbed/bench/preflight/main.go
@@ -1,0 +1,85 @@
+// preflight seeds and validates benchmark topologies that cannot be expressed
+// safely as incidental steady-state ghz mutation traffic.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/anaregdesign/lantern/testbed/bench/topology"
+)
+
+func main() {
+	endpointsFlag := flag.String("endpoints", "http://localhost:6380", "comma-separated Lantern h2c endpoints")
+	reportPath := flag.String("report", "", "write the verified topology report to this path")
+	flag.Parse()
+
+	endpoints := strings.Split(*endpointsFlag, ",")
+	if len(endpoints) == 0 || endpoints[0] == "" {
+		fatalf("at least one endpoint is required")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	writer, err := client.NewLantern(endpoints[0])
+	if err != nil {
+		fatalf("dial writer: %v", err)
+	}
+	defer func() { _ = writer.Close() }()
+
+	report, err := topology.SeedBroadIlluminate(ctx, writer, time.Now().Add(30*time.Minute))
+	if err != nil {
+		fatalf("seed/verify writer: %v", err)
+	}
+	for _, endpoint := range endpoints[1:] {
+		lantern, err := client.NewLantern(endpoint)
+		if err != nil {
+			fatalf("dial replica %s: %v", endpoint, err)
+		}
+		if err := waitForReplica(ctx, lantern); err != nil {
+			_ = lantern.Close()
+			fatalf("replica %s: %v", endpoint, err)
+		}
+		replicaReport, err := topology.VerifyBroadIlluminate(ctx, lantern)
+		_ = lantern.Close()
+		if err != nil {
+			fatalf("verify replica %s: %v", endpoint, err)
+		}
+		if replicaReport != report {
+			fatalf("replica %s topology report differs: got %+v, writer %+v", endpoint, replicaReport, report)
+		}
+	}
+
+	encoded, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		fatalf("encode report: %v", err)
+	}
+	if *reportPath != "" {
+		if err := os.WriteFile(*reportPath, append(encoded, '\n'), 0o644); err != nil {
+			fatalf("write report: %v", err)
+		}
+	}
+	fmt.Println(string(encoded))
+}
+
+func waitForReplica(ctx context.Context, lantern *client.Lantern) error {
+	for {
+		if _, err := lantern.GetVertex(ctx, topology.WalkSeed); err == nil {
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("timed out waiting for %s: %w", topology.WalkSeed, err)
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "preflight: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/testbed/bench/release-scenarios.txt
+++ b/testbed/bench/release-scenarios.txt
@@ -26,9 +26,8 @@
 # 60s sweep at least twice to measure steady state rather than transients —
 # hence 2m is the spec-correct floor, not an arbitrary truncation.
 #
-# ORDER MATTERS: broad_rw populates the k-* vertices AND the k-*->k-* edges
-# that broad_illuminate then traverses, so broad_rw MUST precede
-# broad_illuminate. Do not reorder.
+# broad_illuminate seeds and validates its own topology in preflight (#994),
+# so it is independent of broad_rw's incidental k-* mutation traffic.
 #
 # Wall-time decomposes into two parts. The scenario PHASE time is deterministic
 # (ghz runs each phase for exactly its -z duration): broad_rw 150s +
@@ -82,9 +81,9 @@
 # read / write / scan / edge / delete call surface (12-way fan-out, #708)
 broad_rw
 
-# graph traversal across the params-oneof families (BFS variants + PPR +
-# local community; 6-way fan-out) — runs AFTER broad_rw so the k-* graph it
-# traverses is populated.
+# graph traversal across the params-oneof families (BFS variants + tuned PPR +
+# local community/arborescence; 6-way fan-out) over its verified self-contained
+# topology.
 broad_illuminate
 
 # edge SET / plural-add / delete / prefix-delete / backup surface (9-way

--- a/testbed/bench/report/render.go
+++ b/testbed/bench/report/render.go
@@ -88,6 +88,27 @@ type PerfGate struct {
 		NonOKTotal     int64   `json:"non_ok_total"`
 		NonOKRatio     float64 `json:"non_ok_ratio"`
 	} `json:"observed"`
+	ProducerResults []PerfProducerResult `json:"producer_results"`
+	Verdict         string               `json:"verdict"`
+}
+
+// PerfProducerResult is one named steady-state producer's independent gate.
+// It prevents an inexpensive producer from hiding a regression in another
+// traversal family when a scenario fans out across multiple ghz processes.
+type PerfProducerResult struct {
+	Name       string `json:"name"`
+	Thresholds struct {
+		MinSteadyRps  *float64 `json:"min_steady_rps"`
+		MaxP99Ms      *float64 `json:"max_p99_ms"`
+		MaxNonOKRatio *float64 `json:"max_non_ok_ratio"`
+	} `json:"thresholds"`
+	Observed struct {
+		SteadyRps  float64 `json:"steady_rps"`
+		P99Ms      float64 `json:"p99_ms"`
+		Count      int64   `json:"count"`
+		NonOK      int64   `json:"non_ok"`
+		NonOKRatio float64 `json:"non_ok_ratio"`
+	} `json:"observed"`
 	Verdict string `json:"verdict"`
 }
 
@@ -270,6 +291,19 @@ func RenderReport(w io.Writer, in Input) error {
 		bw.printf("| non-OK ratio (ceiling) | %s | %.5f |\n",
 			perfThreshold(pg.Thresholds.MaxNonOKRatio, "%.5f"), pg.Observed.NonOKRatio)
 		bw.printf("\n")
+		if len(pg.ProducerResults) > 0 {
+			bw.printf("Named producer gates are conjunctive with the aggregate gate: every row must pass.\n\n")
+			bw.printf("| producer | verdict | rps (floor) | p99 ms (ceiling) | non-OK ratio (ceiling) |\n")
+			bw.printf("| --- | --- | ---: | ---: | ---: |\n")
+			for _, producer := range pg.ProducerResults {
+				bw.printf("| `%s` | `%s` | %.1f (%s) | %.2f (%s) | %.5f (%s) |\n",
+					producer.Name, producer.Verdict,
+					producer.Observed.SteadyRps, perfThreshold(producer.Thresholds.MinSteadyRps, "%.1f"),
+					producer.Observed.P99Ms, perfThreshold(producer.Thresholds.MaxP99Ms, "%.2f"),
+					producer.Observed.NonOKRatio, perfThreshold(producer.Thresholds.MaxNonOKRatio, "%.5f"))
+			}
+			bw.printf("\n")
+		}
 	}
 
 	bw.printf("## ghz runs\n\n")

--- a/testbed/bench/report/render_test.go
+++ b/testbed/bench/report/render_test.go
@@ -152,6 +152,32 @@ func TestRenderReport_HandlesMissingArtifactsGracefully(t *testing.T) {
 	}
 }
 
+func TestRenderReport_ShowsIndependentProducerGates(t *testing.T) {
+	minRPS, maxP99 := 10.0, 250.0
+	pg := &PerfGate{Verdict: "fail"}
+	pg.ProducerResults = []PerfProducerResult{{Name: "community_arborescence_min", Verdict: "fail"}}
+	pg.ProducerResults[0].Thresholds.MinSteadyRps = &minRPS
+	pg.ProducerResults[0].Thresholds.MaxP99Ms = &maxP99
+	pg.ProducerResults[0].Observed.SteadyRps = 8
+	pg.ProducerResults[0].Observed.P99Ms = 300
+	var buf bytes.Buffer
+	if err := RenderReport(&buf, Input{Scenario: "x", Timestamp: "t", PerfGate: pg}); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"Named producer gates are conjunctive",
+		"`community_arborescence_min`",
+		"`fail`",
+		"8.0 (10.0)",
+		"300.00 (250.00)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in report:\n%s", want, out)
+		}
+	}
+}
+
 func TestLoadInput_AssemblesFromDisk(t *testing.T) {
 	dir := t.TempDir()
 

--- a/testbed/bench/run.sh
+++ b/testbed/bench/run.sh
@@ -167,6 +167,32 @@ wait_ready() {
 }
 wait_ready
 
+# ----- optional semantic topology preflight ---------------------------------
+# A schema-valid ghz template can still benchmark an empty or accidentally
+# linear graph. Scenario-owned preflight kinds seed and verify live data after
+# every replica is ready but before warmup/snapshots. Kinds are deliberately
+# allow-listed here rather than evaluated as arbitrary YAML shell so a scenario
+# remains declarative and reviewable.
+preflight_kind="$(yq -r '.preflight.kind // ""' "$SCENARIO_FILE")"
+case "$preflight_kind" in
+  "") ;;
+  broad_illuminate)
+    preflight_endpoints=""
+    for port in "${REPLICA_GRPC_PORTS[@]}"; do
+      if [[ -n "$preflight_endpoints" ]]; then preflight_endpoints+=","; fi
+      preflight_endpoints+="http://localhost:${port}"
+    done
+    log "preflight: broad_illuminate topology"
+    (
+      cd "$REPO_ROOT"
+      go run ./testbed/bench/preflight \
+        -endpoints "$preflight_endpoints" \
+        -report "$OUTDIR/topology_preflight.json"
+    )
+    ;;
+  *) die "unknown preflight.kind $preflight_kind in $SCENARIO_FILE" ;;
+esac
+
 # ----- helpers ---------------------------------------------------------------
 
 # Extract a single Prom metric value from a /metrics text exposition.
@@ -326,11 +352,13 @@ fi
 calls_len="$(yq -r '.target.calls | length // 0' "$SCENARIO_FILE")"
 prod_pids=()
 prod_files=()
+prod_names=()
 if [[ "$calls_len" != "0" && "$calls_len" != "null" ]]; then
   per_rps=$(( steady_rps / calls_len ))
   for i in $(seq 0 $(( calls_len - 1 ))); do
     call="$(yq -r ".target.calls[$i].call" "$SCENARIO_FILE")"
     data="$(yq -r ".target.calls[$i].data_template" "$SCENARIO_FILE")"
+    name="$(yq -r ".target.calls[$i].name // \"producer-$i\"" "$SCENARIO_FILE")"
     ep="${endpoints[$(( i % ${#endpoints[@]} ))]}"
     f="$OUTDIR/ghz_steady_${i}_${ep//[:.]/_}.json"
     ghz --insecure \
@@ -338,6 +366,7 @@ if [[ "$calls_len" != "0" && "$calls_len" != "null" ]]; then
       -d "$data" --format json -o "$f" "$ep" >/dev/null 2>&1 &
     prod_pids+=( "$!" )
     prod_files+=( "$f" )
+    prod_names+=( "$name" )
   done
   wait "${prod_pids[@]}"
 else
@@ -346,6 +375,7 @@ else
   ep="${endpoints[0]}"
   f="$(run_ghz steady "$ep" "$call" "$data" "$steady_conc" "$steady_rps" "$steady_duration")"
   prod_files+=( "$f" )
+  prod_names+=( "primary" )
 fi
 
 # Reap background helpers (subscribers run for steady_duration; they exit on
@@ -456,33 +486,77 @@ log "leak gate verdict: $verdict"
 perf_min_rps="$(yq -r '.perf_gate.min_steady_rps_total // ""' "$SCENARIO_FILE")"
 perf_max_p99="$(yq -r '.perf_gate.max_p99_ms // ""' "$SCENARIO_FILE")"
 perf_max_non_ok="$(yq -r '.perf_gate.max_non_ok_ratio // ""' "$SCENARIO_FILE")"
+perf_producer_gates="$(yq -o=json '.perf_gate.producers // {}' "$SCENARIO_FILE")"
 perf_verdict="skipped"
-if [[ -n "${perf_min_rps}${perf_max_p99}${perf_max_non_ok}" ]]; then
-  perf_json="$(jq -s \
+if [[ -n "${perf_min_rps}${perf_max_p99}${perf_max_non_ok}" || "$perf_producer_gates" != "{}" ]]; then
+  producer_observations=()
+  for i in "${!prod_files[@]}"; do
+    producer_observations+=( "$(jq -n \
+      --arg name "${prod_names[$i]}" \
+      --slurpfile run "${prod_files[$i]}" '
+        $run[0] as $r |
+        {
+          name: $name,
+          observed: {
+            steady_rps: $r.rps,
+            p99_ms: (((($r.latencyDistribution // []) | map(select(.percentage == 99)) | .[0].latency) // 0) / 1e6),
+            count: $r.count,
+            non_ok: (($r.statusCodeDistribution // {}) | to_entries | map(select(.key != "OK") | .value) | add // 0)
+          }
+        }')" )
+  done
+  producer_json="$(printf '%s\n' "${producer_observations[@]}" | jq -s '.')"
+  perf_json="$(jq -n \
     --arg min_rps "$perf_min_rps" \
     --arg max_p99 "$perf_max_p99" \
-    --arg max_non_ok "$perf_max_non_ok" '
+    --arg max_non_ok "$perf_max_non_ok" \
+    --argjson producer_gates "$perf_producer_gates" \
+    --argjson producer_observations "$producer_json" '
+    def optionalNumber($value): if $value == "" then null else ($value | tonumber) end;
+    def verdict($thresholds; $observed):
+      if   ($thresholds.min_steady_rps != null and $observed.steady_rps < $thresholds.min_steady_rps) then "fail"
+      elif ($thresholds.max_p99_ms != null and $observed.p99_ms > $thresholds.max_p99_ms) then "fail"
+      elif ($thresholds.max_non_ok_ratio != null and $observed.non_ok_ratio > $thresholds.max_non_ok_ratio) then "fail"
+      else "pass" end;
+    [ $producer_observations[] |
+      . as $producer |
+      ($producer_gates[$producer.name] // {}) as $raw |
+      {
+        name: $producer.name,
+        thresholds: {
+          min_steady_rps: ($raw.min_steady_rps // null),
+          max_p99_ms: ($raw.max_p99_ms // null),
+          max_non_ok_ratio: ($raw.max_non_ok_ratio // null)
+        },
+        observed: ($producer.observed + {
+          non_ok_ratio: (if $producer.observed.count > 0 then ($producer.observed.non_ok / $producer.observed.count) else 0 end)
+        })
+      } |
+      . + {verdict: verdict(.thresholds; .observed)}
+    ] as $producers |
     {
-      producers: length,
-      steady_rps_total: (map(.rps) | add),
-      p99_worst_ms: ((map(((.latencyDistribution // []) | map(select(.percentage == 99)) | .[0].latency) // 0) | max) / 1e6),
-      count_total: (map(.count) | add),
-      non_ok_total: (map((.statusCodeDistribution // {}) | to_entries | map(select(.key != "OK") | .value) | add // 0) | add)
-    } as $o |
-    ($o + {non_ok_ratio: (if $o.count_total > 0 then ($o.non_ok_total / $o.count_total) else 0 end)}) as $obs |
+      producers: ($producers | length),
+      steady_rps_total: ($producers | map(.observed.steady_rps) | add),
+      p99_worst_ms: ($producers | map(.observed.p99_ms) | max),
+      count_total: ($producers | map(.observed.count) | add),
+      non_ok_total: ($producers | map(.observed.non_ok) | add)
+    } as $aggregateRaw |
+    ($aggregateRaw + {non_ok_ratio: (if $aggregateRaw.count_total > 0 then ($aggregateRaw.non_ok_total / $aggregateRaw.count_total) else 0 end)}) as $obs |
     {
       thresholds: {
-        min_steady_rps_total: (if $min_rps == "" then null else ($min_rps | tonumber) end),
-        max_p99_ms: (if $max_p99 == "" then null else ($max_p99 | tonumber) end),
-        max_non_ok_ratio: (if $max_non_ok == "" then null else ($max_non_ok | tonumber) end)
+        min_steady_rps_total: optionalNumber($min_rps),
+        max_p99_ms: optionalNumber($max_p99),
+        max_non_ok_ratio: optionalNumber($max_non_ok)
       },
-      observed: $obs
+      observed: $obs,
+      producer_results: $producers
     } |
     . + {verdict: (
       if   (.thresholds.min_steady_rps_total != null and $obs.steady_rps_total < .thresholds.min_steady_rps_total) then "fail"
       elif (.thresholds.max_p99_ms != null and $obs.p99_worst_ms > .thresholds.max_p99_ms) then "fail"
       elif (.thresholds.max_non_ok_ratio != null and $obs.non_ok_ratio > .thresholds.max_non_ok_ratio) then "fail"
-      else "pass" end)}' "${prod_files[@]}")"
+      elif any(.producer_results[]; .verdict == "fail") then "fail"
+      else "pass" end)}')"
   printf '%s\n' "$perf_json" > "$OUTDIR/perf_gate.json"
   perf_verdict="$(jq -r '.verdict' "$OUTDIR/perf_gate.json")"
 fi

--- a/testbed/bench/scenarios/broad_illuminate.yaml
+++ b/testbed/bench/scenarios/broad_illuminate.yaml
@@ -12,65 +12,76 @@
 #       families — in one 2m steady window (brackets the 60s GC sweep twice
 #       for the leak gate).
 #
-# Dependency: every variant seeds k-* (uint enums per proto/graph/v1/graph.proto:
-#   Reduction 1=MST 2=SPT, Objective 1=MINIMIZE 2=MAXIMIZE, Weighting 2=TFIDF).
-#   The k-* vertices AND the k-*→k-* edges are populated by broad_rw, so this
-#   scenario MUST run AFTER broad_rw in the release sweep (release-scenarios.txt).
-#   Run standalone against an empty graph, Illuminate still returns codes.OK with
-#   an empty subgraph — there is just no traversal work to measure.
+# Topology: `preflight.kind=broad_illuminate` seeds a self-contained fixture
+# before warmup. It has a 64-way directed walk with three reachable hops plus
+# two planted 32-member dense communities joined by weak bridges. Preflight
+# drives BFS/PPR/community+reduction against the live server and fails unless
+# degree, depth, touched PPR members, and community shape all hold. This avoids
+# treating a wire-valid traversal over an accidentally linear graph as a
+# benchmark (#994).
 name: broad_illuminate
+preflight:
+  kind: broad_illuminate
 phases:
   warmup:   { duration: 15s, concurrency: 8,  rps: 200 }
   steady:   { duration: 2m,  concurrency: 16, rps: 4000 }
   cooldown: 15s
 target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
-  # 6 parallel ghz invocations (one per variant), each at steady.rps/6 ≈ 666
+  # 6 parallel ghz invocations (one per family/axis variant), each at
+  # steady.rps/6 ≈ 666
   # rps and the full steady.concurrency (16) → 96 concurrent traversals total.
   calls:
     # [0] raw discovered subgraph (BFS, no reduction, default MAXIMIZE + RAW) —
     #     also what warmup replays. Keep this first.
-    - call: graph.v1.LanternService/Illuminate
+    - name: bfs_raw
+      call: graph.v1.LanternService/Illuminate
       data_template: |
-        {"seed":"k-{{mod .RequestNumber 1000}}","bfs":{"step":2,"fan_out":32}}
+        {"seed":"bench:walk:root","bfs":{"step":2,"fan_out":32}}
     # [1] minimum spanning tree, cost-minimizing direction, raw weights.
-    - call: graph.v1.LanternService/Illuminate
+    - name: bfs_arborescence_min
+      call: graph.v1.LanternService/Illuminate
       data_template: |
-        {"seed":"k-{{mod .RequestNumber 1000}}","bfs":{"step":2,"fan_out":32,"objective":1,"reduction":1}}
+        {"seed":"bench:walk:root","bfs":{"step":2,"fan_out":32,"objective":1,"reduction":1}}
     # [2] shortest-path tree, relevance-maximizing, TF-IDF re-scored weights.
-    - call: graph.v1.LanternService/Illuminate
+    - name: bfs_spt_tfidf
+      call: graph.v1.LanternService/Illuminate
       data_template: |
-        {"seed":"k-{{mod .RequestNumber 1000}}","weighting":2,"bfs":{"step":2,"fan_out":32,"objective":2,"reduction":2}}
+        {"seed":"bench:walk:root","weighting":2,"bfs":{"step":2,"fan_out":32,"objective":2,"reduction":2}}
     # [3] deeper + wider traversal (heaviest BFS fan-out) over the raw subgraph.
-    - call: graph.v1.LanternService/Illuminate
+    - name: bfs_depth3_fanout64
+      call: graph.v1.LanternService/Illuminate
       data_template: |
-        {"seed":"k-{{mod .RequestNumber 1000}}","bfs":{"step":3,"fan_out":64}}
-    # [4] Personalized-PageRank relevance star (#801) — forward-push family,
-    #     top-32 by mass with the default α/ε.
-    - call: graph.v1.LanternService/Illuminate
+        {"seed":"bench:walk:root","bfs":{"step":3,"fan_out":64}}
+    # [4] tuned Personalized-PageRank relevance star (#801): top-32 by mass,
+    #     α=0.2 and ε=1e-6 exercise the actual forward-push work budget.
+    - name: ppr_tuned
+      call: graph.v1.LanternService/Illuminate
       data_template: |
-        {"seed":"k-{{mod .RequestNumber 1000}}","ppr":{"top_n":32}}
-    # [5] conductance-optimal local community (#845) — PageRank-Nibble sweep
-    #     cut, bounded to 32 members, default α/ε, induced subgraph (no
-    #     reduction).
-    - call: graph.v1.LanternService/Illuminate
+        {"seed":"bench:walk:root","ppr":{"top_n":32,"restart_prob":0.2,"epsilon":0.000001}}
+    # [5] tuned PageRank-Nibble local community (#845), then a minimum directed
+    #     arborescence reduction over the planted 32-member community.
+    - name: community_arborescence_min
+      call: graph.v1.LanternService/Illuminate
       data_template: |
-        {"seed":"k-{{mod .RequestNumber 1000}}","community":{"max_size":32}}
+        {"seed":"bench:community:alpha:00","community":{"max_size":32,"restart_prob":0.2,"epsilon":0.000001,"objective":1,"reduction":1}}
 leak_gate:
   goroutine_max_delta: 25
-  heap_alloc_max_delta_mb: 64
-# Floors sized from the nightly baselines. rps and non-OK were sized off the
-# 2026-06-29 → 2026-07-03 4-way runs (rps 3998–4000 of 4000 offered, a handful
-# of non-OK per ~480k) and still hold for the wider mix. The 2026-07 fan-out
-# widened to 6 calls (added PPR + community — #936), so p99 shipped ungated
-# pending a re-baseline (#939): the first green nightly on the new mix
-# (2026-07-04) held worst-producer p99 at 47.75ms with all six producers
-# clustered 46–48ms, so max_p99_ms is restored at 250ms — ~5x headroom,
-# deliberately generous off a single re-baseline sample and matching the
-# ttl_churn/many_subscribers multiplier band. It gates a step-change traversal
-# regression in the BFS/PPR/community families, not night-over-night drift (see
-# the perf-gate sizing rule in testbed/bench/README.md).
+  heap_alloc_max_delta_mb: 32
+# Re-baselined locally on 2026-07-11 after replacing the linear k-* fixture
+# with the real topology: aggregate 2094 RPS, worst p99 219.43 ms, worst
+# heap_alloc delta 1.16 MiB, zero goroutine growth. Floors retain >2× RPS and
+# >4× latency/heap headroom; the first nightly runs refresh the canonical
+# shared-runner record. Individual gates prevent a cheap raw BFS producer from
+# masking a regression in PPR, community, or the depth-3/fan-out-64 path.
 perf_gate:
-  min_steady_rps_total: 2000
-  max_p99_ms: 250
+  min_steady_rps_total: 1000
+  max_p99_ms: 1000
   max_non_ok_ratio: 0.02
+  producers:
+    bfs_raw: { min_steady_rps: 50, max_p99_ms: 1000, max_non_ok_ratio: 0.02 }
+    bfs_arborescence_min: { min_steady_rps: 50, max_p99_ms: 1000, max_non_ok_ratio: 0.02 }
+    bfs_spt_tfidf: { min_steady_rps: 50, max_p99_ms: 1000, max_non_ok_ratio: 0.02 }
+    bfs_depth3_fanout64: { min_steady_rps: 50, max_p99_ms: 1000, max_non_ok_ratio: 0.02 }
+    ppr_tuned: { min_steady_rps: 50, max_p99_ms: 1000, max_non_ok_ratio: 0.02 }
+    community_arborescence_min: { min_steady_rps: 50, max_p99_ms: 1000, max_non_ok_ratio: 0.02 }

--- a/testbed/bench/scenarios/broad_rw.yaml
+++ b/testbed/bench/scenarios/broad_rw.yaml
@@ -14,9 +14,9 @@
 #
 # Ordering: calls[0] (PutVertex over k-*) is what warmup replays — run.sh warms
 #           ONLY calls[0] — so it must be the working-set filler. The AddEdge
-#           path also seeds the k-* graph that the broad_illuminate scenario
-#           traverses next, so broad_rw MUST run before broad_illuminate in the
-#           release sweep (see release-scenarios.txt).
+#           path exercises the additive k-* graph write shape. broad_illuminate
+#           owns a separate, verified topology preflight (#994), so no release
+#           scenario ordering depends on these incidental edges.
 name: broad_rw
 phases:
   warmup:   { duration: 15s, concurrency: 16, rps: 1000 }
@@ -51,7 +51,7 @@ target:
     - call: graph.v1.LanternService/GetVertices
       data_template: |
         {"keys":["k-{{mod .RequestNumber 2000}}","kb-{{mod .RequestNumber 2000}}"]}
-    # [4] additive edge write — builds the k-* graph broad_illuminate traverses.
+    # [4] additive edge write — exercises the k-* edge-mutation hot path.
     - call: graph.v1.LanternService/AddEdge
       data_template: |
         {"edge":{"tail":"k-{{mod .RequestNumber 2000}}","head":"k-{{mod .RequestNumber 1000}}","weight":1.0}}

--- a/testbed/bench/scenarios_gate_test.go
+++ b/testbed/bench/scenarios_gate_test.go
@@ -24,6 +24,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/anaregdesign/lantern/testbed/bench/topology"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
@@ -38,6 +39,7 @@ import (
 // scenarioCall is one (call, data_template) pair wherever it appears in a
 // scenario document.
 type scenarioCall struct {
+	Name         string `yaml:"name"`
 	Call         string `yaml:"call"`
 	DataTemplate string `yaml:"data_template"`
 }
@@ -59,18 +61,77 @@ type scenarioDoc struct {
 	} `yaml:"subscribe"`
 }
 
+// TestBroadIlluminateScenarioTopologyContract is the #994 semantic guard that
+// complements TestScenarioTemplates_MatchWireSchema. A proto-valid Illuminate
+// request can still run over an empty or one-edge graph, so pin both the
+// self-contained topology preflight and each family producer's real workload.
+func TestBroadIlluminateScenarioTopologyContract(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("scenarios", "broad_illuminate.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Preflight struct {
+			Kind string `yaml:"kind"`
+		} `yaml:"preflight"`
+		Target struct {
+			Calls []scenarioCall `yaml:"calls"`
+		} `yaml:"target"`
+		PerfGate struct {
+			Producers map[string]map[string]float64 `yaml:"producers"`
+		} `yaml:"perf_gate"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse broad_illuminate: %v", err)
+	}
+	if doc.Preflight.Kind != "broad_illuminate" {
+		t.Fatalf("preflight.kind = %q, want broad_illuminate", doc.Preflight.Kind)
+	}
+	fixture := topology.NewBroadIlluminateFixture(time.Now().Add(time.Hour))
+	if len(fixture.Vertices) < 1+topology.BroadIlluminateDepth*topology.BroadIlluminateFanOut+2*topology.BroadIlluminateCommunitySize {
+		t.Fatalf("fixture vertices = %d, topology unexpectedly collapsed", len(fixture.Vertices))
+	}
+
+	calls := make(map[string]string, len(doc.Target.Calls))
+	for _, call := range doc.Target.Calls {
+		if call.Name == "" {
+			t.Fatal("broad_illuminate has an unnamed producer")
+		}
+		calls[call.Name] = strings.TrimSpace(call.DataTemplate)
+		if _, ok := doc.PerfGate.Producers[call.Name]; !ok {
+			t.Errorf("producer %q has no independent perf gate", call.Name)
+		}
+	}
+	for name, want := range map[string][]string{
+		"bfs_depth3_fanout64":        {`"seed":"bench:walk:root"`, `"step":3`, `"fan_out":64`},
+		"ppr_tuned":                  {`"top_n":32`, `"restart_prob":0.2`, `"epsilon":0.000001`},
+		"community_arborescence_min": {`"seed":"bench:community:alpha:00"`, `"max_size":32`, `"reduction":1`, `"objective":1`, `"restart_prob":0.2`, `"epsilon":0.000001`},
+	} {
+		template, ok := calls[name]
+		if !ok {
+			t.Errorf("missing %s producer", name)
+			continue
+		}
+		for _, fragment := range want {
+			if !strings.Contains(template, fragment) {
+				t.Errorf("%s template missing %q: %s", name, fragment, template)
+			}
+		}
+	}
+}
+
 // calls flattens every (call, data_template) pair in the document, tagged
 // with where it came from so failures point at the offending YAML path.
 func (d scenarioDoc) calls() map[string]scenarioCall {
 	out := map[string]scenarioCall{}
 	if d.Target.Call != "" {
-		out["target"] = scenarioCall{d.Target.Call, d.Target.DataTemplate}
+		out["target"] = scenarioCall{Call: d.Target.Call, DataTemplate: d.Target.DataTemplate}
 	}
 	for i, c := range d.Target.Calls {
 		out[fmt.Sprintf("target.calls[%d]", i)] = c
 	}
 	if d.Subscribe.Call != "" {
-		out["subscribe"] = scenarioCall{d.Subscribe.Call, d.Subscribe.DataTemplate}
+		out["subscribe"] = scenarioCall{Call: d.Subscribe.Call, DataTemplate: d.Subscribe.DataTemplate}
 	}
 	for i, c := range d.Subscribe.Consumers {
 		out[fmt.Sprintf("subscribe.consumers[%d]", i)] = c

--- a/testbed/bench/topology/broad_illuminate.go
+++ b/testbed/bench/topology/broad_illuminate.go
@@ -1,0 +1,211 @@
+// Package topology defines deterministic graph fixtures used by the bench
+// harness. Keeping the fixture as Go data, rather than an incidental stream of
+// ghz AddEdge calls, lets the harness assert the work each traversal family
+// actually performs before it measures it.
+package topology
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+const (
+	// BroadIlluminateFanOut and BroadIlluminateDepth mirror the largest BFS
+	// request in broad_illuminate.yaml. Each non-leaf walk vertex has exactly
+	// this fan-out; the three layers are shared so the fixture is dense enough
+	// to exercise branching without materialising 64^3 distinct paths.
+	BroadIlluminateFanOut = 64
+	BroadIlluminateDepth  = 3
+
+	// BroadIlluminateCommunitySize is the planted clique size and the max_size
+	// requested by the community producer.
+	BroadIlluminateCommunitySize = 32
+
+	WalkSeed             = "bench:walk:root"
+	CommunitySeed        = "bench:community:alpha:00"
+	communityAlphaPrefix = "bench:community:alpha:"
+	communityBetaPrefix  = "bench:community:beta:"
+)
+
+// BroadIlluminateFixture is the self-contained topology for the
+// broad_illuminate scenario. The fixture comprises:
+//
+//   - a 64-way, three-hop directed layered walk rooted at WalkSeed; and
+//   - two dense 32-member communities joined by a weak reciprocal bridge.
+//
+// The shared walk layers intentionally make the vertex count O(fan_out), while
+// every measured non-leaf still has fan_out outgoing edges. This makes the
+// breadth/depth request real without turning the release benchmark into a
+// million-edge fixture.
+type BroadIlluminateFixture struct {
+	Vertices []client.VertexInput
+	Edges    []client.EdgeInput
+}
+
+// NewBroadIlluminateFixture constructs the deterministic #994 fixture. The
+// caller supplies expiration so preflight can choose a lifetime that covers
+// the whole benchmark run.
+func NewBroadIlluminateFixture(expiration time.Time) BroadIlluminateFixture {
+	fixture := BroadIlluminateFixture{
+		Vertices: make([]client.VertexInput, 0, 1+BroadIlluminateDepth*BroadIlluminateFanOut+2*BroadIlluminateCommunitySize),
+		Edges:    make([]client.EdgeInput, 0, BroadIlluminateFanOut+2*BroadIlluminateFanOut*BroadIlluminateFanOut+2*BroadIlluminateCommunitySize*(BroadIlluminateCommunitySize-1)+2),
+	}
+	addVertex := func(key string) {
+		fixture.Vertices = append(fixture.Vertices, client.VertexInput{Key: key, Value: key, Expiration: expiration})
+	}
+	addEdge := func(tail, head string, weight float32) {
+		fixture.Edges = append(fixture.Edges, client.EdgeInput{Tail: tail, Head: head, Weight: weight, Expiration: expiration})
+	}
+
+	addVertex(WalkSeed)
+	for layer := 1; layer <= BroadIlluminateDepth; layer++ {
+		for i := 0; i < BroadIlluminateFanOut; i++ {
+			addVertex(walkKey(layer, i))
+		}
+	}
+	for i := 0; i < BroadIlluminateFanOut; i++ {
+		addEdge(WalkSeed, walkKey(1, i), 1)
+	}
+	for layer := 1; layer < BroadIlluminateDepth; layer++ {
+		for tail := 0; tail < BroadIlluminateFanOut; tail++ {
+			for head := 0; head < BroadIlluminateFanOut; head++ {
+				addEdge(walkKey(layer, tail), walkKey(layer+1, head), 1)
+			}
+		}
+	}
+
+	for _, prefix := range []string{communityAlphaPrefix, communityBetaPrefix} {
+		for i := 0; i < BroadIlluminateCommunitySize; i++ {
+			addVertex(communityKey(prefix, i))
+		}
+		for tail := 0; tail < BroadIlluminateCommunitySize; tail++ {
+			for head := 0; head < BroadIlluminateCommunitySize; head++ {
+				if tail != head {
+					addEdge(communityKey(prefix, tail), communityKey(prefix, head), 1)
+				}
+			}
+		}
+	}
+	addEdge(communityKey(communityAlphaPrefix, 0), communityKey(communityBetaPrefix, 0), 0.01)
+	addEdge(communityKey(communityBetaPrefix, 0), communityKey(communityAlphaPrefix, 0), 0.01)
+	return fixture
+}
+
+// SeedBroadIlluminate writes the fixture idempotently through the plural SDK
+// surface, then validates the live RPC result shapes. PutEdges is intentional:
+// rerunning preflight replaces the known fixture weights instead of making
+// additive contributions accumulate between local benchmark attempts.
+func SeedBroadIlluminate(ctx context.Context, lantern *client.Lantern, expiration time.Time) (BroadIlluminateVerification, error) {
+	fixture := NewBroadIlluminateFixture(expiration)
+	if err := lantern.PutVertices(ctx, fixture.Vertices); err != nil {
+		return BroadIlluminateVerification{}, fmt.Errorf("seed vertices: %w", err)
+	}
+	if err := lantern.PutEdges(ctx, fixture.Edges); err != nil {
+		return BroadIlluminateVerification{}, fmt.Errorf("seed edges: %w", err)
+	}
+	return VerifyBroadIlluminate(ctx, lantern)
+}
+
+// BroadIlluminateVerification is written by the preflight command so a bench
+// artifact records the observed topology, not merely the YAML intent.
+type BroadIlluminateVerification struct {
+	WalkVertices    int `json:"walk_vertices"`
+	WalkEdges       int `json:"walk_edges"`
+	WalkRootDegree  int `json:"walk_root_degree"`
+	WalkLayer1      int `json:"walk_layer1_vertices"`
+	WalkLayer2      int `json:"walk_layer2_vertices"`
+	WalkLayer3      int `json:"walk_layer3_vertices"`
+	PPRVertices     int `json:"ppr_vertices"`
+	CommunityMember int `json:"community_members"`
+	CommunityEdges  int `json:"community_edges"`
+}
+
+// VerifyBroadIlluminate exercises each family against the live fixture and
+// rejects a bench run when branching, depth, PPR touch count, or the planted
+// community/reduction shape has regressed. This is deliberately stricter than
+// a schema check: a wire-valid YAML request against an accidentally linear
+// graph is not a meaningful traversal benchmark.
+func VerifyBroadIlluminate(ctx context.Context, lantern *client.Lantern) (BroadIlluminateVerification, error) {
+	var report BroadIlluminateVerification
+	walk, err := lantern.Illuminate(ctx, WalkSeed, client.WithBFS(client.BFSOpts{
+		Step: BroadIlluminateDepth, FanOut: BroadIlluminateFanOut,
+	}))
+	if err != nil {
+		return report, fmt.Errorf("verify BFS: %w", err)
+	}
+	report.WalkVertices = len(walk.Vertices)
+	report.WalkEdges = edgeCount(walk)
+	report.WalkRootDegree = len(walk.Edges[WalkSeed])
+	for key := range walk.Vertices {
+		switch {
+		case hasWalkLayer(key, 1):
+			report.WalkLayer1++
+		case hasWalkLayer(key, 2):
+			report.WalkLayer2++
+		case hasWalkLayer(key, 3):
+			report.WalkLayer3++
+		}
+	}
+	if report.WalkRootDegree != BroadIlluminateFanOut ||
+		report.WalkLayer1 != BroadIlluminateFanOut ||
+		report.WalkLayer2 != BroadIlluminateFanOut ||
+		report.WalkLayer3 != BroadIlluminateFanOut {
+		return report, fmt.Errorf("BFS topology mismatch: root degree=%d, layers=%d/%d/%d; want %d each",
+			report.WalkRootDegree, report.WalkLayer1, report.WalkLayer2, report.WalkLayer3, BroadIlluminateFanOut)
+	}
+
+	ppr, err := lantern.Illuminate(ctx, WalkSeed, client.WithPPR(client.PPROpts{
+		TopN: 32, RestartProb: 0.2, Epsilon: 1e-6,
+	}))
+	if err != nil {
+		return report, fmt.Errorf("verify PPR: %w", err)
+	}
+	report.PPRVertices = len(ppr.Vertices)
+	if report.PPRVertices < 17 { // seed plus a non-trivial portion of top-32
+		return report, fmt.Errorf("PPR touched only %d vertices, want at least 17", report.PPRVertices)
+	}
+
+	community, err := lantern.Illuminate(ctx, CommunitySeed, client.WithLocalCommunity(client.LocalCommunityOpts{
+		MaxSize: BroadIlluminateCommunitySize, RestartProb: 0.2, Epsilon: 1e-6,
+		Reduction: client.ReductionMinimumSpanningTree, Objective: client.ObjectiveMinimize,
+	}))
+	if err != nil {
+		return report, fmt.Errorf("verify community: %w", err)
+	}
+	for i := 0; i < BroadIlluminateCommunitySize; i++ {
+		key := communityKey(communityAlphaPrefix, i)
+		if _, ok := community.Vertices[key]; !ok {
+			return report, fmt.Errorf("community missing planted member %q", key)
+		}
+		report.CommunityMember++
+	}
+	for i := 0; i < BroadIlluminateCommunitySize; i++ {
+		if _, ok := community.Vertices[communityKey(communityBetaPrefix, i)]; ok {
+			return report, fmt.Errorf("community leaked weak-bridge member %q", communityKey(communityBetaPrefix, i))
+		}
+	}
+	report.CommunityEdges = edgeCount(community)
+	if report.CommunityEdges != BroadIlluminateCommunitySize-1 {
+		return report, fmt.Errorf("community arborescence edges=%d, want %d", report.CommunityEdges, BroadIlluminateCommunitySize-1)
+	}
+	return report, nil
+}
+
+func walkKey(layer, index int) string { return fmt.Sprintf("bench:walk:l%d:%02d", layer, index) }
+
+func communityKey(prefix string, index int) string { return fmt.Sprintf("%s%02d", prefix, index) }
+
+func hasWalkLayer(key string, layer int) bool {
+	return len(key) >= len("bench:walk:l1:") && key[:len("bench:walk:l1:")] == fmt.Sprintf("bench:walk:l%d:", layer)
+}
+
+func edgeCount(graph *client.Graph) int {
+	count := 0
+	for _, heads := range graph.Edges {
+		count += len(heads)
+	}
+	return count
+}

--- a/testbed/bench/topology/broad_illuminate_test.go
+++ b/testbed/bench/topology/broad_illuminate_test.go
@@ -1,0 +1,49 @@
+package topology
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNewBroadIlluminateFixture_SemanticTopologyGuard is the static companion
+// to preflight's live RPC assertions. It prevents an apparently harmless
+// fixture edit from collapsing the branching/depth/community work that the
+// broad_illuminate release producer claims to measure.
+func TestNewBroadIlluminateFixture_SemanticTopologyGuard(t *testing.T) {
+	fixture := NewBroadIlluminateFixture(time.Now().Add(time.Hour))
+	adj := make(map[string]map[string]float32)
+	for _, edge := range fixture.Edges {
+		if adj[edge.Tail] == nil {
+			adj[edge.Tail] = make(map[string]float32)
+		}
+		adj[edge.Tail][edge.Head] = edge.Weight
+	}
+	if got := len(adj[WalkSeed]); got != BroadIlluminateFanOut {
+		t.Fatalf("walk root degree = %d, want %d", got, BroadIlluminateFanOut)
+	}
+	for layer := 1; layer < BroadIlluminateDepth; layer++ {
+		for i := 0; i < BroadIlluminateFanOut; i++ {
+			if got := len(adj[walkKey(layer, i)]); got != BroadIlluminateFanOut {
+				t.Fatalf("%s degree = %d, want %d", walkKey(layer, i), got, BroadIlluminateFanOut)
+			}
+		}
+	}
+	for i := 0; i < BroadIlluminateFanOut; i++ {
+		if _, ok := adj[walkKey(BroadIlluminateDepth-1, i)][walkKey(BroadIlluminateDepth, i)]; !ok {
+			t.Fatalf("missing a third-hop path through %s", walkKey(BroadIlluminateDepth-1, i))
+		}
+	}
+	for _, prefix := range []string{communityAlphaPrefix, communityBetaPrefix} {
+		for i := 0; i < BroadIlluminateCommunitySize; i++ {
+			if got := len(adj[communityKey(prefix, i)]); got < BroadIlluminateCommunitySize-1 {
+				t.Fatalf("%s internal degree = %d, want >= %d", communityKey(prefix, i), got, BroadIlluminateCommunitySize-1)
+			}
+		}
+	}
+	if got := adj[communityKey(communityAlphaPrefix, 0)][communityKey(communityBetaPrefix, 0)]; got != 0.01 {
+		t.Fatalf("alpha→beta bridge = %v, want 0.01", got)
+	}
+	if got := adj[communityKey(communityBetaPrefix, 0)][communityKey(communityAlphaPrefix, 0)]; got != 0.01 {
+		t.Fatalf("beta→alpha bridge = %v, want 0.01", got)
+	}
+}


### PR DESCRIPTION
## Summary
- seed and verify a deterministic branching traversal topology before the broad benchmark
- exercise BFS, PPR, and local-community scenarios against real graph structure
- fail the release sweep when topology preparation or coverage proof is missing

## Validation
- full root and all Go module test gate
- server `go vet ./...` and golangci-lint changed-lines gate
- full Docker broad_illuminate run: 2093.698 aggregate RPS, worst p99 219.431ms, leak gate passed

Closes #994