### PR TITLE
fix(core): make equal-score traversal selection deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ optimization direction, and weighting:
 | `objective` | `max` (default) / `min` | Keep strongest edges vs cheapest edges — the direction of both the `bfs` per-hop top-k prune and any tree reduction (ignored by `pagerank`, which ranks by mass) |
 | `weighting` | `raw` (default) / `tfidf` / `bm25` | Edge-weight transform applied before the walk — TF-IDF and BM25 damp hub vertices like "popular" items |
 
+When a bounded BFS hop or PageRank top-N cut has equal scores at its boundary,
+Lantern retains the ascending vertex keys. This makes result membership stable
+across identical requests; callers must still treat map iteration order as
+unspecified.
+
 Seeing is believing. Say the store holds this graph (labels are weights):
 
 ```mermaid

--- a/core/collection/pq/map.go
+++ b/core/collection/pq/map.go
@@ -14,7 +14,18 @@ func NewSortableMap[S comparable, T Number]() SortableMap[S, T] {
 // holds k or fewer entries the receiver is returned as-is (no copy). For
 // k <= 0 an empty map is returned.
 func (m SortableMap[S, T]) Top(k int) SortableMap[S, T] {
-	return m.selectK(k, false)
+	return m.selectK(k, false, nil)
+}
+
+// TopStable returns the k entries with the largest values. Equal-priority
+// entries are resolved with less: the key for which less(a, b) is true wins
+// over b. Passing nil preserves Top's existing unspecified tie behavior.
+//
+// Use TopStable when membership is externally observable. Lantern's
+// traversals, for example, use ascending vertex keys so tied scores produce
+// the same subgraph regardless of map iteration order.
+func (m SortableMap[S, T]) TopStable(k int, less func(a, b S) bool) SortableMap[S, T] {
+	return m.selectK(k, false, less)
 }
 
 // Bottom returns the k entries with the smallest values. It mirrors Top —
@@ -23,7 +34,14 @@ func (m SortableMap[S, T]) Top(k int) SortableMap[S, T] {
 // uses it for per-hop pruning when the Objective is MINIMIZE so the cheapest
 // edges a cost-minimiser cares about survive instead of the costliest (#560).
 func (m SortableMap[S, T]) Bottom(k int) SortableMap[S, T] {
-	return m.selectK(k, true)
+	return m.selectK(k, true, nil)
+}
+
+// BottomStable returns the k entries with the smallest values. Equal-priority
+// entries are resolved with less: the key for which less(a, b) is true wins
+// over b. Passing nil preserves Bottom's existing unspecified tie behavior.
+func (m SortableMap[S, T]) BottomStable(k int, less func(a, b S) bool) SortableMap[S, T] {
+	return m.selectK(k, true, less)
 }
 
 // selectK returns the k entries at one extreme of the value distribution: the
@@ -37,7 +55,7 @@ func (m SortableMap[S, T]) Bottom(k int) SortableMap[S, T] {
 // or, when it belongs deeper in the retained set than the root, replaces the
 // root via heap.Fix. Time complexity is O(N log k) versus O(N + k log N) for a
 // "build a full heap, pop k times" approach, and peak memory is O(k) not O(N).
-func (m SortableMap[S, T]) selectK(k int, smallest bool) SortableMap[S, T] {
+func (m SortableMap[S, T]) selectK(k int, smallest bool, less func(a, b S) bool) SortableMap[S, T] {
 	if k <= 0 {
 		return NewSortableMap[S, T]()
 	}
@@ -45,7 +63,7 @@ func (m SortableMap[S, T]) selectK(k int, smallest bool) SortableMap[S, T] {
 		return m
 	}
 
-	h := boundedKHeap[S, T]{entries: make([]kEntry[S, T], 0, k), smallest: smallest}
+	h := boundedKHeap[S, T]{entries: make([]kEntry[S, T], 0, k), smallest: smallest, less: less}
 	for key, val := range m {
 		if len(h.entries) < k {
 			heap.Push(&h, kEntry[S, T]{value: key, priority: val})
@@ -55,7 +73,7 @@ func (m SortableMap[S, T]) selectK(k int, smallest bool) SortableMap[S, T] {
 		// Replace it only when the candidate belongs deeper in the retained
 		// set. Strict inequality keeps the operation cheap when many entries
 		// tie at the boundary.
-		if h.replaces(val, h.entries[0].priority) {
+		if h.replaces(key, val, h.entries[0]) {
 			h.entries[0] = kEntry[S, T]{value: key, priority: val}
 			heap.Fix(&h, 0)
 		}
@@ -86,6 +104,7 @@ type kEntry[S comparable, T Number] struct {
 type boundedKHeap[S comparable, T Number] struct {
 	entries  []kEntry[S, T]
 	smallest bool
+	less     func(a, b S) bool
 }
 
 func (h boundedKHeap[S, T]) Len() int { return len(h.entries) }
@@ -93,6 +112,12 @@ func (h boundedKHeap[S, T]) Len() int { return len(h.entries) }
 func (h boundedKHeap[S, T]) Less(i, j int) bool {
 	// Order the root toward the first entry to evict: the smallest priority
 	// for Top (min-heap), the largest priority for Bottom (max-heap).
+	if h.entries[i].priority == h.entries[j].priority && h.less != nil {
+		// The heap root is the entry first to evict. A stable comparator names
+		// the preferred entry, so reverse it here and put the larger/worse key
+		// at the root for both heap orientations.
+		return h.less(h.entries[j].value, h.entries[i].value)
+	}
 	if h.smallest {
 		return h.entries[i].priority > h.entries[j].priority
 	}
@@ -120,9 +145,15 @@ func (h *boundedKHeap[S, T]) Pop() any {
 // retained entry; for Bottom it must be strictly smaller than the largest
 // retained. Strict inequality keeps boundary ties cheap (no churn when many
 // entries tie at the boundary).
-func (h boundedKHeap[S, T]) replaces(candidate, root T) bool {
+func (h boundedKHeap[S, T]) replaces(candidateKey S, candidate T, root kEntry[S, T]) bool {
 	if h.smallest {
-		return candidate < root
+		if candidate != root.priority {
+			return candidate < root.priority
+		}
+		return h.less != nil && h.less(candidateKey, root.value)
 	}
-	return candidate > root
+	if candidate != root.priority {
+		return candidate > root.priority
+	}
+	return h.less != nil && h.less(candidateKey, root.value)
 }

--- a/core/collection/pq/map_test.go
+++ b/core/collection/pq/map_test.go
@@ -103,6 +103,32 @@ func TestSortableMap_Top_TieBoundary(t *testing.T) {
 	}
 }
 
+func TestSortableMap_StableTieBreak(t *testing.T) {
+	const runs = 100
+	keys := []string{"delta", "bravo", "alpha", "charlie"}
+	want := SortableMap[string, int]{"alpha": 5, "bravo": 5}
+
+	for run := 0; run < runs; run++ {
+		order := append([]string(nil), keys...)
+		rand.New(rand.NewSource(int64(run))).Shuffle(len(order), func(i, j int) {
+			order[i], order[j] = order[j], order[i]
+		})
+		m := NewSortableMap[string, int]()
+		for _, key := range order {
+			m[key] = 5
+		}
+
+		for _, got := range []SortableMap[string, int]{
+			m.TopStable(2, func(a, b string) bool { return a < b }),
+			m.BottomStable(2, func(a, b string) bool { return a < b }),
+		} {
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("run %d stable tie selection = %v, want %v", run, got, want)
+			}
+		}
+	}
+}
+
 // TestSortableMap_Top_LargeRandom cross-checks the new O(N log k) algorithm
 // against a straightforward sort-based reference on a randomized input. Only
 // the priority *values* of the top-k matter (ties may pick different keys).

--- a/core/graphcache/traversal.go
+++ b/core/graphcache/traversal.go
@@ -215,9 +215,9 @@ func (c *GraphCache[S, T]) neighborContext(ctx context.Context, seed S, step int
 		// smallest weights when selectSmallest (MINIMIZE), the k largest
 		// otherwise (#560) — then trim expirations to the survivors.
 		if selectSmallest {
-			edges = edges.Bottom(k)
+			edges = edges.BottomStable(k, stableKeyLess[S])
 		} else {
-			edges = edges.Top(k)
+			edges = edges.TopStable(k, stableKeyLess[S])
 		}
 		if expRow != nil {
 			filtered := make(map[S]time.Time, len(edges))
@@ -411,9 +411,9 @@ func (c *GraphCache[S, T]) PersonalizedPageRankContext(ctx context.Context, seed
 		return nil, err
 	}
 
-	// Rank by PPR mass, excluding the seed, and keep the top-N. Reusing
-	// pq.SortableMap.Top mirrors the per-hop prune in neighborContext so the
-	// tie-breaking semantics are identical across both traversal paths.
+	// Rank by PPR mass, excluding the seed, and keep the top-N. Reusing the
+	// stable selector mirrors the per-hop prune in neighborContext so both
+	// traversal paths resolve equal scores by ascending vertex key.
 	scores := make(pq.SortableMap[S, float32], len(p))
 	for key, mass := range p {
 		if key == seed || mass <= 0 {
@@ -422,7 +422,7 @@ func (c *GraphCache[S, T]) PersonalizedPageRankContext(ctx context.Context, seed
 		scores[key] = float32(mass)
 	}
 	if topN > 0 {
-		scores = scores.Top(topN)
+		scores = scores.TopStable(topN, stableKeyLess[S])
 	}
 	if len(scores) > 0 {
 		row := make(map[S]float32, len(scores))
@@ -438,6 +438,19 @@ func (c *GraphCache[S, T]) PersonalizedPageRankContext(ctx context.Context, seed
 	}
 
 	return g, nil
+}
+
+// stableKeyLess gives all string-keyed Lantern graphs a cheap, documented
+// ascending-key tie-break. GraphCache remains generic for embedded callers;
+// its fallback keeps the same deterministic textual identity for other
+// comparable key types. Public RPC and SDK keys are strings.
+func stableKeyLess[S comparable](a, b S) bool {
+	if aString, ok := any(a).(string); ok {
+		if bString, ok := any(b).(string); ok {
+			return aString < bString
+		}
+	}
+	return fmt.Sprint(a) < fmt.Sprint(b)
 }
 
 // pprPushLocked runs the Andersen–Chung–Lang local forward-push from seed and

--- a/core/graphcache/traversal_test.go
+++ b/core/graphcache/traversal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/rand"
 	"reflect"
 	"strings"
 	"testing"
@@ -106,6 +107,47 @@ func TestGraphCache_Neighbor_ObjectiveDirection(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGraphCache_EqualScoreSelectionIsStable pins the externally observable
+// tie rule shared by BFS per-hop pruning and PPR top-N: ascending vertex key
+// wins, independently of the underlying Go map's iteration order.
+func TestGraphCache_EqualScoreSelectionIsStable(t *testing.T) {
+	const runs = 100
+	keys := []string{"delta", "bravo", "alpha", "charlie"}
+	want := map[string]bool{"alpha": true, "bravo": true}
+
+	for run := 0; run < runs; run++ {
+		order := append([]string(nil), keys...)
+		rand.New(rand.NewSource(int64(run))).Shuffle(len(order), func(i, j int) {
+			order[i], order[j] = order[j], order[i]
+		})
+
+		c := NewGraphCache[string, string](time.Minute)
+		for _, key := range order {
+			c.AddEdge("seed", key, 1)
+		}
+
+		bfs := c.Neighbor("seed", 1, 2, WeightingRaw, false, nil)
+		if got := headSet(bfs, "seed"); !reflect.DeepEqual(got, want) {
+			t.Fatalf("run %d BFS heads = %v, want %v", run, got, want)
+		}
+
+		ppr := c.PersonalizedPageRank("seed", 2, 0.15, 1e-7, WeightingRaw, nil)
+		if got := headSet(ppr, "seed"); !reflect.DeepEqual(got, want) {
+			t.Fatalf("run %d PPR heads = %v, want %v", run, got, want)
+		}
+	}
+}
+
+func headSet(g *graph.Graph[string, string], tail string) map[string]bool {
+	got := map[string]bool{}
+	if g != nil {
+		for head := range g.Edges[tail] {
+			got[head] = true
+		}
+	}
+	return got
 }
 
 // TestGraphCache_NeighborKeep pins the #601 frontier predicate: keep func(S) bool

--- a/docs/illuminate-complexity.md
+++ b/docs/illuminate-complexity.md
@@ -84,6 +84,10 @@ $$
 and the pruning *shrinks* the frontier handed to the next hop, which usually
 makes $E_{sub}$ far smaller than the reachable component.
 
+At an equal-score boundary, both BFS pruning and PageRank top-$N$ retain
+ascending Lantern vertex keys. That determines membership reproducibly; the
+map-shaped response itself has no iteration-order guarantee.
+
 ### Optional MST / SPT reduction
 
 When the caller asks for a spanning-tree reduction, the server runs Prim /

--- a/tests/integration/client_test.go
+++ b/tests/integration/client_test.go
@@ -166,6 +166,75 @@ func TestLantern_Illuminate(t *testing.T) {
 	}
 }
 
+// TestLantern_Illuminate_EqualScoresUseAscendingKeys exercises the public
+// Connect/h2c path for #1000. Both BFS and PPR cap four exactly-tied heads to
+// two, so the stable ascending-key membership is observable to SDK callers.
+func TestLantern_Illuminate_EqualScoresUseAscendingKeys(t *testing.T) {
+	l, cleanup := newInProcessClient(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	for _, key := range []string{"seed", "alpha", "bravo", "charlie", "delta"} {
+		if err := l.PutVertex(ctx, key, key, time.Minute); err != nil {
+			t.Fatalf("PutVertex %q: %v", key, err)
+		}
+	}
+	for _, key := range []string{"delta", "bravo", "alpha", "charlie"} {
+		if err := l.PutEdge(ctx, "seed", key, 1, time.Minute); err != nil {
+			t.Fatalf("PutEdge seed->%s: %v", key, err)
+		}
+	}
+
+	want := map[string]bool{"alpha": true, "bravo": true}
+	for _, test := range []struct {
+		name string
+		opts []client.IlluminateOption
+	}{
+		{
+			name: "bfs",
+			opts: []client.IlluminateOption{
+				client.WithBFS(client.BFSOpts{Step: 1, FanOut: 2}),
+			},
+		},
+		{
+			name: "pagerank",
+			opts: []client.IlluminateOption{
+				client.WithPPR(client.PPROpts{TopN: 2, RestartProb: 0.15, Epsilon: 1e-7}),
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for run := 0; run < 20; run++ {
+				g, err := l.Illuminate(ctx, "seed", test.opts...)
+				if err != nil {
+					t.Fatalf("Illuminate run %d: %v", run, err)
+				}
+				got := map[string]bool{}
+				for key := range g.Edges["seed"] {
+					got[key] = true
+				}
+				if !mapsEqual(got, want) {
+					t.Fatalf("run %d retained %v, want %v", run, got, want)
+				}
+			}
+		})
+	}
+}
+
+func mapsEqual(got, want map[string]bool) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for key := range want {
+		if !got[key] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestLantern_GetVertices_BatchPartialMiss(t *testing.T) {
 	l, cleanup := newInProcessClient(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary
- add stable top/bottom priority-queue selection with key tie-breaks
- use deterministic membership at BFS and PageRank cutoffs
- prove repeated and real-wire equal-score results are stable

## Validation
- full root and all Go module test gate
- server `go vet ./...`
- golangci-lint changed-lines gate (CI-pinned v2.12.2)

Closes #1000