### PR TITLE
fix(proto,server,sdks): require explicit BFS parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ the shape you asked for. The CLI exposes that RPC as three family verbs —
 `bfs`, `pagerank`, and `community` — with orthogonal knobs for tree rendering,
 optimization direction, and weighting:
 
+Every request selects one family explicitly. SDK calls use `WithBFS`,
+`WithPPR`, or `WithLocalCommunity` (or the matching Node options arm); raw
+requests with no `params` arm are rejected. BFS also requires positive `step`
+and `fan_out` — unlike PageRank `top_n=0` and community `max_size=0`, zero is
+not a default sentinel for BFS.
+
 | Axis | Options | What it picks |
 |---|---|---|
 | family verb | `bfs` / `pagerank` / `community` | Greedy per-hop top-k neighbourhood, Personalized PageRank relevance star, or the seed's natural community (conductance-cut, returned as a real induced subgraph) |

--- a/admin/app/lib/client/infrastructure/api/illuminate.ts
+++ b/admin/app/lib/client/infrastructure/api/illuminate.ts
@@ -11,23 +11,6 @@ import {
 
 export type { Edge, Graph, IlluminateResponse, Vertex } from "./types";
 
-// The admin UI tracks each axis as a stable string so router
-// serialisation and Playwright fixtures keep one human-readable
-// vocabulary across surfaces. Since #846 the wire request is a params
-// ONEOF (bfs | ppr | community); since #961 the admin vocabulary matches
-// that shape directly — the traversal FAMILY and the post-traversal tree
-// REDUCTION are orthogonal axes. This adapter owns the translation from
-// admin's flat axis vocabulary to the typed per-family SDK options: the
-// `reduction` axis feeds the bfs and community families' Reduction knob
-// (ignored for ppr), ppr selects the PPR family (step has no PPR meaning
-// and is dropped; k becomes topN), and community selects the
-// local-community family (#845; step dropped, k becomes the max_size upper
-// bound, reduction/objective drive the optional tree view).
-export type Family =
-  | "FAMILY_BFS"
-  | "FAMILY_PERSONALIZED_PAGERANK"
-  | "FAMILY_LOCAL_COMMUNITY";
-
 export type Reduction =
   | "REDUCTION_UNSPECIFIED"
   | "REDUCTION_MINIMUM_SPANNING_TREE"
@@ -44,46 +27,39 @@ export type Weighting =
   | "WEIGHTING_TFIDF"
   | "WEIGHTING_BM25";
 
-export interface IlluminateRequest {
+interface BaseIlluminateRequest {
   seed: string;
-  step?: number;
-  k?: number;
-  /**
-   * Traversal family (#846/#961). Omitted/`FAMILY_BFS` runs the greedy
-   * per-hop top-k BFS walk; `FAMILY_PERSONALIZED_PAGERANK` runs a
-   * seed-anchored PPR walk; `FAMILY_LOCAL_COMMUNITY` runs PageRank-Nibble
-   * local community extraction (#845).
-   */
-  family?: Family;
-  /**
-   * Post-traversal tree reduction (#961), rooted at the seed. Applied to
-   * the bfs and community families (ignored for ppr):
-   * `REDUCTION_UNSPECIFIED` returns the raw induced subgraph,
-   * `REDUCTION_MINIMUM_SPANNING_TREE` / `REDUCTION_SHORTEST_PATH_TREE`
-   * return the corresponding tree view. `objective` steers the direction.
-   */
-  reduction?: Reduction;
-  objective?: Objective;
-  weighting?: Weighting;
-  /**
-   * Restrict the traversal frontier to vertices whose key has this prefix
-   * (#606). The seed is always retained as the anchor even if it does not
-   * match. Empty/omitted = no filter. Applied server-side BEFORE per-hop
-   * top-k and before any MST/SPT reduction (induced-subgraph semantics).
-   */
-  vertexPrefix?: string;
-  /**
-   * Personalized PageRank / local-community knobs, consulted when
-   * `family === "FAMILY_PERSONALIZED_PAGERANK"` (#801) or
-   * `family === "FAMILY_LOCAL_COMMUNITY"` (#845) — both families
-   * share the same α/ε locality knobs. `restartProb` is the
-   * restart/teleport-to-seed probability α in (0,1); `epsilon` is the
-   * forward-push residual threshold ε > 0. 0/omitted lets the server apply
-   * its defaults (α=0.15 / ε=1e-4).
-   */
-  restartProb?: number;
-  epsilon?: number;
+  weighting: Weighting;
+  /** Empty means no frontier-prefix filter. */
+  vertexPrefix: string;
 }
+
+/**
+ * The API boundary follows the wire oneof. A caller has to select exactly one
+ * family and cannot attach a BFS-only or tree-only knob to PageRank.
+ */
+export type IlluminateRequest =
+  | (BaseIlluminateRequest & {
+      family: "bfs";
+      step: number;
+      fanOut: number;
+      reduction: Reduction;
+      objective: Objective;
+    })
+  | (BaseIlluminateRequest & {
+      family: "pagerank";
+      topN: number;
+      restartProb: number;
+      epsilon: number;
+    })
+  | (BaseIlluminateRequest & {
+      family: "community";
+      maxSize: number;
+      restartProb: number;
+      epsilon: number;
+      reduction: Reduction;
+      objective: Objective;
+    });
 
 const REDUCTION_TO_SDK: Record<Reduction, SdkReduction> = {
   REDUCTION_UNSPECIFIED: SdkReduction.UNSPECIFIED,
@@ -105,17 +81,10 @@ const WEIGHTING_TO_SDK: Record<Weighting, SdkWeighting> = {
 /**
  * Calls `LanternService.Illuminate` via `lantern-sdk/web`.
  *
- * Runs a k-bounded BFS from the supplied seed. Optional knobs (step
- * / k / family / reduction / objective / weighting / prefix) default
- * server-side when omitted; `family=FAMILY_PERSONALIZED_PAGERANK` switches
- * to a seed-anchored PPR walk tuned by restartProb / epsilon (#801), and
- * `family=FAMILY_LOCAL_COMMUNITY` switches to PageRank-Nibble local
- * community extraction (#845; k is the max_size upper bound, α/ε tune the
- * push). The `reduction` axis (#961) renders the bfs or community
- * neighbourhood as an MST / SPT tree rooted at the seed. The SDK returns a
- * rich-shape Graph with `Map<>` values; this adapter flattens it back to
- * admin's array-of-flat-JSON shape so the existing canvas + table consumers
- * keep working unchanged (#409, #410).
+ * The discriminated request selects the SDK's matching typed family options.
+ * The SDK returns a rich-shape Graph with `Map<>` values; this adapter
+ * flattens it back to admin's array-of-flat-JSON shape for the canvas and
+ * table consumers.
  */
 export async function illuminate(
   client: LanternClient,
@@ -126,49 +95,44 @@ export async function illuminate(
     throw new Error("illuminate: seed must be non-empty");
   }
   try {
-    const opts: SdkIlluminateOptions = {
-      weighting:
-        request.weighting !== undefined
-          ? WEIGHTING_TO_SDK[request.weighting]
-          : undefined,
-      vertexPrefix: request.vertexPrefix ?? "",
-    };
-    if (request.family === "FAMILY_PERSONALIZED_PAGERANK") {
-      opts.ppr = {
-        topN: request.k ?? 0,
-        restartProb: request.restartProb ?? 0,
-        epsilon: request.epsilon ?? 0,
+    const opts: SdkIlluminateOptions = (() => {
+      const shared = {
+        weighting: WEIGHTING_TO_SDK[request.weighting],
+        vertexPrefix: request.vertexPrefix,
       };
-    } else if (request.family === "FAMILY_LOCAL_COMMUNITY") {
-      // Local community extraction (#845): PageRank-Nibble. Mirrors the Go
-      // CLI translation (`cli/service/service.go` `IlluminateFamilyOption`,
-      // `case "community"`): k is the max_size UPPER BOUND (the conductance
-      // sweep may stop earlier), step has no meaning here and is dropped,
-      // and α/ε pass through (0 = server default, α=0.15 / ε=1e-4). Since
-      // #961 the optional tree reduction/objective pass through too.
-      opts.community = {
-        maxSize: request.k ?? 0,
-        restartProb: request.restartProb ?? 0,
-        epsilon: request.epsilon ?? 0,
-        reduction:
-          REDUCTION_TO_SDK[request.reduction ?? "REDUCTION_UNSPECIFIED"],
-        objective:
-          request.objective !== undefined
-            ? OBJECTIVE_TO_SDK[request.objective]
-            : undefined,
-      };
-    } else {
-      opts.bfs = {
-        step: request.step ?? 0,
-        fanOut: request.k ?? 0,
-        objective:
-          request.objective !== undefined
-            ? OBJECTIVE_TO_SDK[request.objective]
-            : undefined,
-        reduction:
-          REDUCTION_TO_SDK[request.reduction ?? "REDUCTION_UNSPECIFIED"],
-      };
-    }
+      switch (request.family) {
+        case "bfs":
+          return {
+            ...shared,
+            bfs: {
+              step: request.step,
+              fanOut: request.fanOut,
+              objective: OBJECTIVE_TO_SDK[request.objective],
+              reduction: REDUCTION_TO_SDK[request.reduction],
+            },
+          };
+        case "pagerank":
+          return {
+            ...shared,
+            ppr: {
+              topN: request.topN,
+              restartProb: request.restartProb,
+              epsilon: request.epsilon,
+            },
+          };
+        case "community":
+          return {
+            ...shared,
+            community: {
+              maxSize: request.maxSize,
+              restartProb: request.restartProb,
+              epsilon: request.epsilon,
+              reduction: REDUCTION_TO_SDK[request.reduction],
+              objective: OBJECTIVE_TO_SDK[request.objective],
+            },
+          };
+      }
+    })();
     const sdkGraph = await client.illuminate(request.seed, opts, init?.signal);
     const graph: Graph = {
       vertices: Array.from(sdkGraph.vertices.values()).map(sdkVertexToFlat),

--- a/admin/app/lib/client/usecase/cli/dispatcher.ts
+++ b/admin/app/lib/client/usecase/cli/dispatcher.ts
@@ -296,9 +296,9 @@ export async function dispatch(input: DispatchInput): Promise<unknown> {
         client,
         {
           seed: command.seed,
+          family: "bfs",
           step: command.step,
-          k: command.fanOut,
-          family: "FAMILY_BFS",
+          fanOut: command.fanOut,
           reduction: REDUCTION_TO_API[command.reduction],
           objective: OBJECTIVE_TO_API[command.objective],
           weighting: WEIGHTING_TO_API[command.weighting],
@@ -311,8 +311,8 @@ export async function dispatch(input: DispatchInput): Promise<unknown> {
         client,
         {
           seed: command.seed,
-          k: command.topN,
-          family: "FAMILY_PERSONALIZED_PAGERANK",
+          family: "pagerank",
+          topN: command.topN,
           weighting: WEIGHTING_TO_API[command.weighting],
           vertexPrefix: command.vertexPrefix,
           restartProb: command.restartProb,
@@ -325,8 +325,8 @@ export async function dispatch(input: DispatchInput): Promise<unknown> {
         client,
         {
           seed: command.seed,
-          k: command.maxSize,
-          family: "FAMILY_LOCAL_COMMUNITY",
+          family: "community",
+          maxSize: command.maxSize,
           reduction: REDUCTION_TO_API[command.reduction],
           objective: OBJECTIVE_TO_API[command.objective],
           weighting: WEIGHTING_TO_API[command.weighting],

--- a/mcp/tool_recall_related.go
+++ b/mcp/tool_recall_related.go
@@ -102,8 +102,8 @@ type reinforceEdge struct {
 
 type recallRelatedInput struct {
 	Seed            string                 `json:"seed"                jsonschema:"Starting fact key for the walk. The seed itself is returned at depth 0."`
-	Step            uint32                 `json:"step,omitempty"      jsonschema:"BFS depth (default 2). Larger values explore further at quadratic cost. Server enforces a hard cap. Applies to the out-direction walk only."`
-	K               uint32                 `json:"k,omitempty"         jsonschema:"Per-hop fan-out: keep the top-k strongest outgoing edges at each step (default 8). Server enforces a hard cap. Applies to the out-direction walk only."`
+	Step            uint32                 `json:"step,omitempty"      jsonschema:"BFS depth (default 2). Required to be positive for BFS; ignored by PageRank and community. Larger values explore further at quadratic cost. Server enforces a hard cap. Applies to the out-direction walk only."`
+	K               uint32                 `json:"k,omitempty"         jsonschema:"Family-native size knob: BFS fan-out (default 8, must be positive), PageRank top_n (0 = all), or community max_size (0 = sweep decides). Server enforces hard caps. Applies to the out-direction walk only."`
 	Direction       recallRelatedDirection `json:"direction,omitempty" jsonschema:"Which edge direction to follow from the seed: out (default - forward BFS over out-edges, the historical behaviour), in (reverse - return the seed's direct predecessors, so seeding a pure sink is no longer empty), or both (union of the two). step/k/algorithm/reduction/objective/weighting shape the out walk; the in pass is a single bounded reverse-adjacency hop."`
 	Algorithm       recallRelatedAlgorithm `json:"algorithm,omitempty" jsonschema:"Traversal FAMILY run from the seed: one of: bfs (default - breadth-first walk over the top-k strongest edges per hop), ppr (Personalized PageRank - rank facts by random-walk-with-restart proximity to the seed, surfacing globally well-connected context rather than just direct neighbours; tuned by restart_prob/epsilon), or community (local community extraction - return the seed's natural cluster by a sweep over a Personalized PageRank vector; k caps the community size, tuned by restart_prob/epsilon). Orthogonal to reduction."`
 	Reduction       recallRelatedReduction `json:"reduction,omitempty" jsonschema:"Post-traversal tree REDUCTION applied to the bfs/community subgraph, rooted at the seed: one of: none (default - the raw subgraph), mst (minimum/maximum spanning-tree backbone depending on objective), or spt (shortest-path tree from the seed). Orthogonal to algorithm: e.g. algorithm=community reduction=mst returns the seed's community as a spanning-tree backbone. Ignored when algorithm=ppr (PPR returns a ranked star, not a subgraph)."`
@@ -227,14 +227,21 @@ func registerRecallRelated(srv *mcp.Server, lc lanternClient, r *ttl.Resolver) {
 		acc := newNeighborAccumulator()
 		var truncated bool
 
-		// out / both: forward BFS over out-edges via Illuminate (the
-		// historical behaviour). step/k/algorithm/objective/weighting
-		// shape this walk.
+		// out / both: traverse forward edges through the selected family.
+		// Step/fan-out are BFS-only: resolve its MCP defaults here so zero
+		// cannot leak through as the now-invalid BFS wire value. PPR top_n=0
+		// and community max_size=0 retain their own explicit sentinels.
 		if direction == directionOut || direction == directionBoth {
-			// The typed family option (#846) carries every per-family knob;
-			// zero values (step/k/α/ε unset) are resolved server-side to the
-			// documented defaults exactly as the flat fields were.
-			famOpt, err := mapFamilyOption(algorithm, red, in.Step, in.K, obj, restartProb, epsilon)
+			step, k := in.Step, in.K
+			if algorithm == algorithmBFS {
+				if step == 0 {
+					step = 2
+				}
+				if k == 0 {
+					k = 8
+				}
+			}
+			famOpt, err := mapFamilyOption(algorithm, red, step, k, obj, restartProb, epsilon)
 			if err != nil {
 				return nil, recallRelatedOutput{}, fmt.Errorf("recall_related: %w", err)
 			}
@@ -348,6 +355,9 @@ func registerRecallRelated(srv *mcp.Server, lc lanternClient, r *ttl.Resolver) {
 func mapFamilyOption(a recallRelatedAlgorithm, red client.Reduction, step, k uint32, obj client.Objective, restartProb, epsilon float32) (client.IlluminateOption, error) {
 	switch a {
 	case algorithmBFS:
+		if step == 0 || k == 0 {
+			return nil, fmt.Errorf("bfs step and k must both be positive")
+		}
 		return client.WithBFS(client.BFSOpts{Step: step, FanOut: k, Objective: obj, Reduction: red}), nil
 	case algorithmPPR:
 		return client.WithPPR(client.PPROpts{TopN: k, RestartProb: restartProb, Epsilon: epsilon}), nil

--- a/mcp/tool_recall_related_test.go
+++ b/mcp/tool_recall_related_test.go
@@ -89,6 +89,32 @@ func TestRecallRelated_RejectsEmptySeed(t *testing.T) {
 	h.callExpectError(t, "recall_related", map[string]any{"seed": ""})
 }
 
+func TestMapFamilyOption_RejectsZeroBFSDimensions(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		step uint32
+		k    uint32
+	}{
+		{name: "zero step", step: 0, k: 1},
+		{name: "zero fan-out", step: 1, k: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := mapFamilyOption(
+				algorithmBFS,
+				client.ReductionNone,
+				tc.step,
+				tc.k,
+				client.ObjectiveMaximize,
+				0,
+				0,
+			)
+			if err == nil {
+				t.Fatal("mapFamilyOption() error = nil, want zero BFS dimension rejection")
+			}
+		})
+	}
+}
+
 // TestRecallRelated_AcceptsBM25Weighting pins the #800 BM25 axis on the MCP
 // surface: weighting=bm25 must be accepted and forwarded as an Illuminate
 // option rather than rejected as an unknown value.

--- a/pb/graph/v1/graph.pb.go
+++ b/pb/graph/v1/graph.pb.go
@@ -91,7 +91,7 @@ func (Reduction) EnumDescriptor() ([]byte, []int) {
 // tree wins); MAXIMIZE treats them as relevance (keeps the k largest-weight
 // edges per hop; largest tree wins, equivalent to the historical
 // "inverse-SPT" / "max-MST" variants and the default strongest-neighbour
-// behaviour of a bare illuminate).
+// behaviour of an Objective-unspecified BFS request).
 type Objective int32
 
 const (
@@ -837,8 +837,9 @@ type IlluminateRequest struct {
 	VertexPrefix string `protobuf:"bytes,9,opt,name=vertex_prefix,json=vertexPrefix,proto3" json:"vertex_prefix,omitempty"`
 	// params selects the traversal family AND carries only the knobs that
 	// family understands (#846) — cross-algorithm misconfiguration (PPR with
-	// step, MST with epsilon, …) is structurally unrepresentable. Unset params
-	// means BfsParams with server defaults: the historical bare illuminate.
+	// step, MST with epsilon, …) is structurally unrepresentable. A family arm
+	// is REQUIRED; unset params is rejected with INVALID_ARGUMENT rather than
+	// silently becoming an ambiguous zero-hop BFS request.
 	//
 	// Types that are valid to be assigned to Params:
 	//
@@ -957,15 +958,15 @@ func (*IlluminateRequest_Ppr) isIlluminateRequest_Params() {}
 
 func (*IlluminateRequest_Community) isIlluminateRequest_Params() {}
 
-// BfsParams tunes the greedy per-hop top-k BFS walk (the default traversal
-// family) and its optional post-traversal tree reduction.
+// BfsParams tunes the greedy per-hop top-k BFS walk and its optional
+// post-traversal tree reduction.
 type BfsParams struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// step is the BFS depth. 0 = server default.
+	// step is the BFS depth and MUST be positive. 0 is INVALID_ARGUMENT.
 	Step uint32 `protobuf:"varint,1,opt,name=step,proto3" json:"step,omitempty"`
 	// fan_out is the per-hop top-k prune: at each hop only the fan_out
 	// strongest (or cheapest, under OBJECTIVE_MINIMIZE) edges survive.
-	// 0 = server default. (Formerly the overloaded "k".)
+	// It MUST be positive. 0 is INVALID_ARGUMENT. (Formerly the overloaded "k".)
 	FanOut uint32 `protobuf:"varint,2,opt,name=fan_out,json=fanOut,proto3" json:"fan_out,omitempty"`
 	// objective governs BOTH the per-hop pruning and the reduction direction
 	// (#560), so a cost-minimiser is never handed a candidate set already

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -65,7 +65,7 @@ enum Reduction {
 // tree wins); MAXIMIZE treats them as relevance (keeps the k largest-weight
 // edges per hop; largest tree wins, equivalent to the historical
 // "inverse-SPT" / "max-MST" variants and the default strongest-neighbour
-// behaviour of a bare illuminate).
+// behaviour of an Objective-unspecified BFS request).
 enum Objective {
   OBJECTIVE_UNSPECIFIED = 0;
   OBJECTIVE_MINIMIZE = 1;
@@ -103,8 +103,9 @@ message IlluminateRequest {
   string vertex_prefix = 9;
   // params selects the traversal family AND carries only the knobs that
   // family understands (#846) — cross-algorithm misconfiguration (PPR with
-  // step, MST with epsilon, …) is structurally unrepresentable. Unset params
-  // means BfsParams with server defaults: the historical bare illuminate.
+  // step, MST with epsilon, …) is structurally unrepresentable. A family arm
+  // is REQUIRED; unset params is rejected with INVALID_ARGUMENT rather than
+  // silently becoming an ambiguous zero-hop BFS request.
   oneof params {
     BfsParams bfs = 12;
     PprParams ppr = 13;
@@ -115,19 +116,19 @@ message IlluminateRequest {
   // "algorithm", "objective", "restart_prob", "epsilon") by the per-family
   // params redesign (#846). All stay reserved so a stale client whose
   // binary still emits the old flat field numbers cannot silently alias
-  // newer fields — such a request decodes as params-unset (BFS defaults).
+  // newer fields — such a request decodes as params-unset and is rejected.
   reserved 2, 3, 4, 5, 6, 7, 10, 11;
   reserved "step", "k", "tfidf", "optimization", "algorithm", "objective", "restart_prob", "epsilon";
 }
 
-// BfsParams tunes the greedy per-hop top-k BFS walk (the default traversal
-// family) and its optional post-traversal tree reduction.
+// BfsParams tunes the greedy per-hop top-k BFS walk and its optional
+// post-traversal tree reduction.
 message BfsParams {
-  // step is the BFS depth. 0 = server default.
+  // step is the BFS depth and MUST be positive. 0 is INVALID_ARGUMENT.
   uint32 step = 1;
   // fan_out is the per-hop top-k prune: at each hop only the fan_out
   // strongest (or cheapest, under OBJECTIVE_MINIMIZE) edges survive.
-  // 0 = server default. (Formerly the overloaded "k".)
+  // It MUST be positive. 0 is INVALID_ARGUMENT. (Formerly the overloaded "k".)
   uint32 fan_out = 2;
   // objective governs BOTH the per-hop pruning and the reduction direction
   // (#560), so a cost-minimiser is never handed a candidate set already

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -40,6 +40,11 @@ See [`example/main.go`](example/main.go) for a comprehensive end-to-end
 walkthrough covering vertices, edges (`AddEdge` vs `PutEdge` semantics),
 `Illuminate`, prefix scans, batches, and TLS.
 
+`Illuminate` requires exactly one family option: `WithBFS`, `WithPPR`, or
+`WithLocalCommunity`. A BFS also requires positive `BFSOpts.Step` and
+`BFSOpts.FanOut`; a missing family or either zero dimension returns
+`ErrInvalidArgument` before an RPC is sent.
+
 ## Transport
 
 The SDK is Connect-only (Connect-Go over h2c by default, or HTTP/2 over

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -803,13 +803,13 @@ func NewGraph() *Graph {
 	}
 }
 
-// IlluminateOption configures a single Illuminate call. Select the traversal
-// family with at most one of WithBFS / WithPPR / WithLocalCommunity; supplying
-// more than one is a local ErrConflictingIlluminateFamilies error. Omitting all
-// runs BFS with server defaults —
-// the bare illuminate), and combine it with the shared axes WithWeighting /
-// WithVertexPrefix. Per-family knobs live on BFSOpts / PPROpts, so a knob
-// that another family would ignore is not expressible (#846).
+// IlluminateOption configures a single Illuminate call. Every call must select
+// exactly one traversal family with WithBFS / WithPPR / WithLocalCommunity;
+// omitting the family returns ErrInvalidArgument, while supplying more than one
+// also wraps ErrConflictingIlluminateFamilies. Both fail before any RPC.
+// Combine the family with WithWeighting / WithVertexPrefix. Per-family knobs
+// live on BFSOpts / PPROpts, so a knob that another family would ignore is not
+// expressible (#846).
 type IlluminateOption func(*illuminateConfig)
 
 type illuminateConfig struct {
@@ -832,13 +832,15 @@ func (c *illuminateConfig) selectFamily(family string) bool {
 }
 
 // BFSOpts tunes the greedy per-hop top-k BFS walk and its optional
-// post-traversal tree reduction. The zero value is the server-default walk.
+// post-traversal tree reduction. Step and FanOut must both be positive; zero
+// is rejected as ErrInvalidArgument rather than ambiguously requesting a
+// server default.
 type BFSOpts struct {
-	// Step is the BFS depth. 0 = server default.
+	// Step is the BFS depth and must be positive.
 	Step uint32
 	// FanOut is the per-hop top-k prune: at each hop only the FanOut
 	// strongest (or cheapest, under ObjectiveMinimize) edges survive.
-	// 0 = server default. (Formerly the overloaded "k".)
+	// It must be positive. (Formerly the overloaded "k".)
 	FanOut uint32
 	// Objective governs both the per-hop pruning and the Reduction
 	// direction (#560). Unspecified = ObjectiveMaximize.
@@ -951,11 +953,12 @@ func WithVertexPrefix(prefix string) IlluminateOption {
 	return func(c *illuminateConfig) { c.vertexPrefix = prefix }
 }
 
-// Illuminate cuts the neighbourhood subgraph around seed. Select the
-// traversal family with WithBFS / WithPPR (omitting both runs BFS with
-// server defaults — the bare illuminate) and the shared axes with
-// WithWeighting / WithVertexPrefix. See #846 for the per-family design and
-// #801 for the Personalized PageRank semantics.
+// Illuminate cuts the neighbourhood subgraph around seed. Select exactly one
+// traversal family with WithBFS / WithPPR / WithLocalCommunity and combine it
+// with shared axes WithWeighting / WithVertexPrefix. Family omission,
+// conflicting families, and zero BFS step/fan-out return ErrInvalidArgument
+// without sending an ambiguous request. See #846 for the per-family design
+// and #801 for the Personalized PageRank semantics.
 func (l *Lantern) Illuminate(ctx context.Context, seed string, opts ...IlluminateOption) (*Graph, error) {
 	var cfg illuminateConfig
 	for _, opt := range opts {
@@ -966,6 +969,12 @@ func (l *Lantern) Illuminate(ctx context.Context, seed string, opts ...Illuminat
 			ErrInvalidArgument,
 			fmt.Errorf("%w: %s and %s", ErrConflictingIlluminateFamilies, cfg.family, cfg.conflictWith),
 		)
+	}
+	if cfg.family == "" {
+		return nil, fmt.Errorf("%w: Illuminate requires exactly one traversal family", ErrInvalidArgument)
+	}
+	if cfg.bfs != nil && (cfg.bfs.Step == 0 || cfg.bfs.FanOut == 0) {
+		return nil, fmt.Errorf("%w: BFSOpts.Step and BFSOpts.FanOut must both be positive", ErrInvalidArgument)
 	}
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -356,7 +356,7 @@ func TestWithVertexPrefixWiring(t *testing.T) {
 
 	t.Run("default leaves vertex_prefix empty", func(t *testing.T) {
 		l, capt := newClient(t)
-		if _, err := l.Illuminate(context.Background(), "seed"); err != nil {
+		if _, err := l.Illuminate(context.Background(), "seed", WithBFS(BFSOpts{Step: 1, FanOut: 1})); err != nil {
 			t.Fatalf("Illuminate: %v", err)
 		}
 		if len(capt.reqs) != 1 {
@@ -369,7 +369,7 @@ func TestWithVertexPrefixWiring(t *testing.T) {
 
 	t.Run("WithVertexPrefix sets the field", func(t *testing.T) {
 		l, capt := newClient(t)
-		if _, err := l.Illuminate(context.Background(), "users/1", WithVertexPrefix("users/")); err != nil {
+		if _, err := l.Illuminate(context.Background(), "users/1", WithBFS(BFSOpts{Step: 1, FanOut: 1}), WithVertexPrefix("users/")); err != nil {
 			t.Fatalf("Illuminate: %v", err)
 		}
 		if got := capt.reqs[0].GetVertexPrefix(); got != "users/" {
@@ -393,7 +393,7 @@ func TestWithWeightingWiring(t *testing.T) {
 
 	t.Run("default leaves weighting unspecified", func(t *testing.T) {
 		l, capt := newClient(t)
-		if _, err := l.Illuminate(context.Background(), "seed"); err != nil {
+		if _, err := l.Illuminate(context.Background(), "seed", WithBFS(BFSOpts{Step: 1, FanOut: 1})); err != nil {
 			t.Fatalf("Illuminate: %v", err)
 		}
 		if got := capt.reqs[0].GetWeighting(); got != WeightingUnspecified {
@@ -404,7 +404,7 @@ func TestWithWeightingWiring(t *testing.T) {
 	for _, w := range []Weighting{WeightingRaw, WeightingTFIDF, WeightingBM25} {
 		t.Run(w.String(), func(t *testing.T) {
 			l, capt := newClient(t)
-			if _, err := l.Illuminate(context.Background(), "seed", WithWeighting(w)); err != nil {
+			if _, err := l.Illuminate(context.Background(), "seed", WithBFS(BFSOpts{Step: 1, FanOut: 1}), WithWeighting(w)); err != nil {
 				t.Fatalf("Illuminate: %v", err)
 			}
 			if got := capt.reqs[0].GetWeighting(); got != w {
@@ -415,10 +415,10 @@ func TestWithWeightingWiring(t *testing.T) {
 }
 
 // TestIlluminateParamsWiring verifies the #846 typed per-family options
-// marshal to the intended oneof arm: no family option ⇒ params unset (the
-// bare illuminate); WithBFS ⇒ the bfs arm with its four knobs; WithPPR ⇒
-// the ppr arm with its three knobs; and multiple family options fail locally
-// before a request is sent.
+// marshal to the intended oneof arm: exactly one family is required;
+// WithBFS ⇒ the bfs arm with its four knobs; WithPPR ⇒ the ppr arm with its
+// three knobs; conflicting selections and zero BFS dimensions fail locally
+// without sending an ambiguous wire request.
 func TestIlluminateParamsWiring(t *testing.T) {
 	newClient := func(t *testing.T) (*Lantern, *captureIlluminate) {
 		t.Helper()
@@ -428,13 +428,13 @@ func TestIlluminateParamsWiring(t *testing.T) {
 		return l, capt
 	}
 
-	t.Run("no family option leaves params unset", func(t *testing.T) {
+	t.Run("no family option fails without sending a request", func(t *testing.T) {
 		l, capt := newClient(t)
-		if _, err := l.Illuminate(context.Background(), "seed"); err != nil {
-			t.Fatalf("Illuminate: %v", err)
+		if _, err := l.Illuminate(context.Background(), "seed"); !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("Illuminate error = %v, want ErrInvalidArgument", err)
 		}
-		if capt.reqs[0].GetParams() != nil {
-			t.Fatalf("default params want unset, got %T", capt.reqs[0].GetParams())
+		if len(capt.reqs) != 0 {
+			t.Fatalf("missing family sent %d requests, want 0", len(capt.reqs))
 		}
 	})
 
@@ -482,7 +482,7 @@ func TestIlluminateParamsWiring(t *testing.T) {
 		name string
 		opt  IlluminateOption
 	}{
-		{"bfs", WithBFS(BFSOpts{Step: 1})},
+		{"bfs", WithBFS(BFSOpts{Step: 1, FanOut: 1})},
 		{"pagerank", WithPPR(PPROpts{TopN: 5})},
 		{"community", WithLocalCommunity(LocalCommunityOpts{MaxSize: 5})},
 	}
@@ -516,4 +516,14 @@ func TestIlluminateParamsWiring(t *testing.T) {
 			}
 		}
 	}
+
+	t.Run("zero BFS dimension fails without sending a request", func(t *testing.T) {
+		l, capt := newClient(t)
+		if _, err := l.Illuminate(context.Background(), "seed", WithBFS(BFSOpts{Step: 0, FanOut: 1})); !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("Illuminate error = %v, want ErrInvalidArgument", err)
+		}
+		if len(capt.reqs) != 0 {
+			t.Fatalf("zero BFS dimension sent %d requests, want 0", len(capt.reqs))
+		}
+	})
 }

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -44,6 +44,12 @@ try {
 }
 ```
 
+`illuminate()` requires exactly one options arm: `bfs`, `ppr`, or
+`community`. BFS requires positive `step` and `fanOut`; missing/conflicting
+families and zero BFS dimensions raise `InvalidArgumentError` before any RPC.
+`ppr.topN = 0` and `community.maxSize = 0` remain their families' explicit
+sentinels.
+
 ## Vertex values
 
 Each method on `Lantern` accepts these JavaScript types and maps each
@@ -384,7 +390,7 @@ import { connectWeb, Reduction } from "lantern-sdk/web";
 
 const client = connectWeb("https://lantern.example.com:6380");
 const graph = await client.illuminate("hello", {
-  bfs: { reduction: Reduction.SHORTEST_PATH_TREE },
+  bfs: { step: 2, fanOut: 16, reduction: Reduction.SHORTEST_PATH_TREE },
 });
 console.log(`vertices=${graph.vertices.size}`);
 ```

--- a/sdks/node/src/client.ts
+++ b/sdks/node/src/client.ts
@@ -835,16 +835,27 @@ export class Lantern {
     });
   }
 
-  async illuminate(
-    seed: string,
-    opts: IlluminateOptions = {},
-    signal?: AbortSignal,
-  ): Promise<Graph> {
+  async illuminate(seed: string, opts: IlluminateOptions, signal?: AbortSignal): Promise<Graph>;
+  async illuminate(seed: string, opts?: IlluminateOptions, signal?: AbortSignal): Promise<Graph> {
     if (!seed) throw new InvalidArgumentError("illuminate: seed is required");
+    if (!opts) {
+      throw new InvalidArgumentError("illuminate: traversal family is required");
+    }
     const families = [opts.bfs, opts.ppr, opts.community].filter((f) => f !== undefined).length;
-    if (families > 1) {
+    if (families !== 1) {
       throw new InvalidArgumentError(
-        "illuminate: bfs, ppr and community are mutually exclusive (the traversal family is a wire oneof)",
+        "illuminate: exactly one of bfs, ppr and community is required (the traversal family is a wire oneof)",
+      );
+    }
+    if (
+      opts.bfs &&
+      (!Number.isSafeInteger(opts.bfs.step) ||
+        !Number.isSafeInteger(opts.bfs.fanOut) ||
+        opts.bfs.step <= 0 ||
+        opts.bfs.fanOut <= 0)
+    ) {
+      throw new InvalidArgumentError(
+        "illuminate: bfs step and fanOut must both be positive integers",
       );
     }
     return this.invoke(async () => {
@@ -876,8 +887,8 @@ export class Lantern {
             ? ({
                 case: "bfs" as const,
                 value: {
-                  step: opts.bfs.step ?? 0,
-                  fanOut: opts.bfs.fanOut ?? 0,
+                  step: opts.bfs.step,
+                  fanOut: opts.bfs.fanOut,
                   objective:
                     OBJECTIVE_TO_PB[opts.bfs.objective ?? Objective.UNSPECIFIED] ??
                     PbObjective.UNSPECIFIED,

--- a/sdks/node/src/gen/graph/v1/graph_pb.ts
+++ b/sdks/node/src/gen/graph/v1/graph_pb.ts
@@ -202,8 +202,9 @@ export type IlluminateRequest = Message<"graph.v1.IlluminateRequest"> & {
   /**
    * params selects the traversal family AND carries only the knobs that
    * family understands (#846) — cross-algorithm misconfiguration (PPR with
-   * step, MST with epsilon, …) is structurally unrepresentable. Unset params
-   * means BfsParams with server defaults: the historical bare illuminate.
+   * step, MST with epsilon, …) is structurally unrepresentable. A family arm
+   * is REQUIRED; unset params is rejected with INVALID_ARGUMENT rather than
+   * silently becoming an ambiguous zero-hop BFS request.
    *
    * @generated from oneof graph.v1.IlluminateRequest.params
    */
@@ -236,14 +237,14 @@ export const IlluminateRequestSchema: GenMessage<IlluminateRequest> = /*@__PURE_
   messageDesc(file_graph_v1_graph, 3);
 
 /**
- * BfsParams tunes the greedy per-hop top-k BFS walk (the default traversal
- * family) and its optional post-traversal tree reduction.
+ * BfsParams tunes the greedy per-hop top-k BFS walk and its optional
+ * post-traversal tree reduction.
  *
  * @generated from message graph.v1.BfsParams
  */
 export type BfsParams = Message<"graph.v1.BfsParams"> & {
   /**
-   * step is the BFS depth. 0 = server default.
+   * step is the BFS depth and MUST be positive. 0 is INVALID_ARGUMENT.
    *
    * @generated from field: uint32 step = 1;
    */
@@ -252,7 +253,7 @@ export type BfsParams = Message<"graph.v1.BfsParams"> & {
   /**
    * fan_out is the per-hop top-k prune: at each hop only the fan_out
    * strongest (or cheapest, under OBJECTIVE_MINIMIZE) edges survive.
-   * 0 = server default. (Formerly the overloaded "k".)
+   * It MUST be positive. 0 is INVALID_ARGUMENT. (Formerly the overloaded "k".)
    *
    * @generated from field: uint32 fan_out = 2;
    */
@@ -2202,7 +2203,7 @@ export const ReductionSchema: GenEnum<Reduction> = /*@__PURE__*/
  * tree wins); MAXIMIZE treats them as relevance (keeps the k largest-weight
  * edges per hop; largest tree wins, equivalent to the historical
  * "inverse-SPT" / "max-MST" variants and the default strongest-neighbour
- * behaviour of a bare illuminate).
+ * behaviour of an Objective-unspecified BFS request).
  *
  * @generated from enum graph.v1.Objective
  */

--- a/sdks/node/src/options.ts
+++ b/sdks/node/src/options.ts
@@ -9,13 +9,13 @@ import { Objective, Reduction, Weighting } from "./values.js";
  * post-traversal tree reduction.
  */
 export interface BfsOptions {
-  /** BFS depth limit (0 = server default; treated as "no expansion"). */
-  step?: number;
+  /** BFS depth limit. Must be a positive integer; zero is rejected. */
+  step: number;
   /**
-   * Per-hop fan-out: top-k neighbours kept at each frontier (0 = unlimited).
-   * Formerly the overloaded `k`.
+   * Per-hop fan-out: top-k neighbours kept at each frontier. Must be a
+   * positive integer; zero is rejected. Formerly the overloaded `k`.
    */
-  fanOut?: number;
+  fanOut: number;
   /**
    * Direction for both the per-hop pruning and the reduction (#560).
    * Server resolves UNSPECIFIED to MAXIMIZE.
@@ -82,18 +82,7 @@ export interface LocalCommunityOptions {
   objective?: Objective;
 }
 
-export interface IlluminateOptions {
-  /**
-   * Select the BFS traversal family with its knobs (#846). The family
-   * options are mutually exclusive — supplying more than one is an
-   * InvalidArgumentError. Omitting all runs BFS with server defaults (the
-   * bare illuminate).
-   */
-  bfs?: BfsOptions;
-  /** Select the Personalized PageRank family. Mutually exclusive. */
-  ppr?: PprOptions;
-  /** Select the local community extraction family (#845). Mutually exclusive. */
-  community?: LocalCommunityOptions;
+interface SharedIlluminateOptions {
   /**
    * Edge-weight transform applied BEFORE the walk (any family). Server
    * resolves UNSPECIFIED to RAW.
@@ -107,6 +96,28 @@ export interface IlluminateOptions {
    */
   vertexPrefix?: string;
 }
+
+/**
+ * Exactly one traversal family is required. The union makes cross-family
+ * combinations unrepresentable in TypeScript; JavaScript callers receive an
+ * InvalidArgumentError for an absent or conflicting arm at runtime.
+ */
+export type IlluminateOptions =
+  | (SharedIlluminateOptions & {
+      bfs: BfsOptions;
+      ppr?: never;
+      community?: never;
+    })
+  | (SharedIlluminateOptions & {
+      bfs?: never;
+      ppr: PprOptions;
+      community?: never;
+    })
+  | (SharedIlluminateOptions & {
+      bfs?: never;
+      ppr?: never;
+      community: LocalCommunityOptions;
+    });
 
 export interface ScanOptions {
   /** Page size (0 = server default). */

--- a/sdks/node/src/values.ts
+++ b/sdks/node/src/values.ts
@@ -153,7 +153,8 @@ export type VertexKind =
 
 /**
  * Illuminate axes for Lantern.illuminate (#846). The traversal family is
- * selected by the per-family options object (`bfs` or `ppr` on
+ * selected by the required per-family options object (`bfs`, `ppr`, or
+ * `community` on
  * IlluminateOptions — the wire oneof); the enums below are the shared and
  * BFS-family axes.
  *

--- a/sdks/node/test/client.test.ts
+++ b/sdks/node/test/client.test.ts
@@ -39,6 +39,7 @@ import {
   backupRecordFromNdjson,
   HealthStatusError,
   type BackupRecord,
+  type IlluminateOptions,
 } from "../src/index.js";
 import {
   LanternService,
@@ -1168,12 +1169,12 @@ describe("illuminate request building (#605)", () => {
     }
   });
 
-  test("omitting both families leaves the params oneof unset (bare illuminate)", async () => {
+  test("omitting the family is an InvalidArgumentError", async () => {
     const c = newClient();
     try {
-      await c.illuminate("alice", {});
-      expect(state.lastIlluminate?.paramsCase).toBeUndefined();
-      expect(state.lastIlluminate?.vertexPrefix).toBe("");
+      const before = state.lastIlluminate;
+      await expect(c.illuminate("alice", {} as never)).rejects.toThrow(/exactly one/);
+      expect(state.lastIlluminate).toBe(before);
     } finally {
       c.close();
     }
@@ -1209,9 +1210,28 @@ describe("illuminate request building (#605)", () => {
   test("supplying both bfs and ppr is an InvalidArgumentError", async () => {
     const c = newClient();
     try {
-      await expect(c.illuminate("alice", { bfs: {}, ppr: {} })).rejects.toThrow(
-        /mutually exclusive/,
+      await expect(
+        c.illuminate("alice", {
+          bfs: { step: 1, fanOut: 1 },
+          ppr: {},
+        } as unknown as IlluminateOptions),
+      ).rejects.toThrow(/exactly one/);
+    } finally {
+      c.close();
+    }
+  });
+
+  test("rejects a zero BFS step or fanOut before the wire", async () => {
+    const c = newClient();
+    try {
+      const before = state.lastIlluminate;
+      await expect(c.illuminate("alice", { bfs: { step: 0, fanOut: 1 } })).rejects.toThrow(
+        /must both be positive integers/,
       );
+      await expect(c.illuminate("alice", { bfs: { step: 1, fanOut: 0 } })).rejects.toThrow(
+        /must both be positive integers/,
+      );
+      expect(state.lastIlluminate).toBe(before);
     } finally {
       c.close();
     }
@@ -1220,7 +1240,9 @@ describe("illuminate request building (#605)", () => {
   test("forwards the reduction on the bfs arm", async () => {
     const c = newClient();
     try {
-      await c.illuminate("alice", { bfs: { reduction: Reduction.SHORTEST_PATH_TREE } });
+      await c.illuminate("alice", {
+        bfs: { step: 1, fanOut: 1, reduction: Reduction.SHORTEST_PATH_TREE },
+      });
       expect(state.lastIlluminate?.paramsCase).toBe("bfs");
       expect(state.lastIlluminate?.reduction).toBe(Reduction.SHORTEST_PATH_TREE);
     } finally {

--- a/server/service/optimizer.go
+++ b/server/service/optimizer.go
@@ -25,8 +25,8 @@ type optimizer func(ctx context.Context, g *coregraph.Graph[string, *pb.Vertex],
 //
 // Note: Reduction UNSPECIFIED → nil (no reduction). Objective
 // OBJECTIVE_UNSPECIFIED resolves to MAXIMIZE per the proto-level default
-// (#560): a bare illuminate keeps the strongest edges both when pruning the
-// per-hop top-k and when reducing the discovered subgraph.
+// (#560): an objective-unspecified BFS request keeps the strongest edges both
+// when pruning the per-hop top-k and when reducing the discovered subgraph.
 func resolveOptimizer(red pb.Reduction, obj pb.Objective) optimizer {
 	switch red {
 	case pb.Reduction_REDUCTION_MINIMUM_SPANNING_TREE:

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -566,12 +566,19 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 
 	// Dispatch on the params oneof (#846): the selected case IS the traversal
 	// family, and each arm reads only the knobs its family understands —
-	// cross-algorithm misconfiguration is unrepresentable on the wire. An
-	// unset oneof is the historical bare illuminate: BFS with server defaults.
-	// A stale pre-#846 client emitting the retired flat field numbers decodes
-	// as exactly that (the numbers are reserved), never as a different arm.
-	switch params := request.GetParams().(type) {
+	// cross-algorithm misconfiguration is unrepresentable on the wire. Family
+	// selection is required: an unset oneof (including a stale pre-#846 request
+	// that only carries retired fields) is rejected rather than silently becoming
+	// a zero-hop BFS walk.
+	params := request.GetParams()
+	if params == nil {
+		return nil, invalidIlluminateParams("traversal family is required")
+	}
+	switch params := params.(type) {
 	case *pb.IlluminateRequest_Ppr:
+		if params.Ppr == nil {
+			return nil, invalidIlluminateParams("ppr params are required")
+		}
 		// Personalized PageRank is a distinct traversal path, not a
 		// post-traversal reduction (#801): it row-normalises the weighted
 		// out-edges into a transition matrix and runs ACL forward-push from the
@@ -595,6 +602,9 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 		algoLabel, redLabel, objLabel = "ppr", "none", "maximize"
 
 	case *pb.IlluminateRequest_Community:
+		if params.Community == nil {
+			return nil, invalidIlluminateParams("community params are required")
+		}
 		// Local community extraction (#845): PageRank-Nibble sweep cut over
 		// the shared push. Membership is decided by conductance (max_size is
 		// an upper bound, not a count) and the result is the induced
@@ -651,8 +661,14 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 		}
 		algoLabel, redLabel, objLabel = "community", reductionLabel(comm.GetReduction()), objectiveLabel(comm.GetObjective())
 
-	default: // *pb.IlluminateRequest_Bfs or unset — the BFS family.
-		bfs := request.GetBfs() // nil-safe: getters yield zero values on an unset oneof
+	case *pb.IlluminateRequest_Bfs:
+		if params.Bfs == nil {
+			return nil, invalidIlluminateParams("bfs params are required")
+		}
+		bfs := params.Bfs
+		if bfs.GetStep() == 0 || bfs.GetFanOut() == 0 {
+			return nil, invalidIlluminateParams("bfs step and fan_out must both be positive")
+		}
 		// Objective steers the per-hop top-k pruning as well as the
 		// post-traversal reduction (#560): a MINIMIZE caller keeps the
 		// fan_out smallest-weight edges at each hop so the cost-minimiser is
@@ -676,6 +692,8 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 			}
 		}
 		algoLabel, redLabel, objLabel = "bfs", reductionLabel(bfs.GetReduction()), objectiveLabel(objective)
+	default:
+		return nil, invalidIlluminateParams("unknown traversal family")
 	}
 
 	if err := ctx.Err(); err != nil {
@@ -710,6 +728,10 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 	return &pb.IlluminateResponse{
 		Graph: &pb.Graph{Vertices: vertices, Edges: edges},
 	}, nil
+}
+
+func invalidIlluminateParams(message string) error {
+	return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("illuminate: %s", message))
 }
 
 func (s *LanternService) GetVertex(ctx context.Context, request *pb.GetVertexRequest) (*pb.GetVertexResponse, error) {

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -504,7 +504,7 @@ func TestLanternService_Illuminate_NoAlgorithm(t *testing.T) {
 // arm (#846) against every shared axis: the BFS family across reduction ×
 // objective × weighting, and the PPR family across weighting. Every tuple
 // must run to completion and return at least one vertex against the
-// triangle seed. The params-unset default is covered separately by the
+// triangle seed. The explicit raw-BFS baseline is covered separately by the
 // _NoAlgorithm test above.
 func TestLanternService_Illuminate_AllAxisCombos(t *testing.T) {
 	reductions := []pb.Reduction{
@@ -1740,7 +1740,9 @@ func TestLanternService_Illuminate_TraversalBudget(t *testing.T) {
 		fb := newFakeBackend()
 		svc := NewLanternService(fb)
 
-		if _, err := svc.Illuminate(context.Background(), &pb.IlluminateRequest{Seed: "a"}); err != nil {
+		if _, err := svc.Illuminate(context.Background(), &pb.IlluminateRequest{
+			Seed: "a", Params: &pb.IlluminateRequest_Bfs{Bfs: &pb.BfsParams{Step: 1, FanOut: 1}},
+		}); err != nil {
 			t.Fatalf("Illuminate: %v", err)
 		}
 		if !fb.lastNeighborHadDeadline {
@@ -1753,7 +1755,7 @@ func TestLanternService_Illuminate_TraversalBudget(t *testing.T) {
 		fb.neighborBlockUntilCtxDone = true
 		svc := NewLanternService(fb).WithTraversalTimeout(20 * time.Millisecond)
 
-		_, err := svc.Illuminate(context.Background(), &pb.IlluminateRequest{Seed: "a"})
+		_, err := svc.Illuminate(context.Background(), &pb.IlluminateRequest{Seed: "a", Params: &pb.IlluminateRequest_Bfs{Bfs: &pb.BfsParams{Step: 1, FanOut: 1}}})
 		if connect.CodeOf(err) != connect.CodeDeadlineExceeded {
 			t.Fatalf("err = %v, want CodeDeadlineExceeded", err)
 		}
@@ -1763,7 +1765,7 @@ func TestLanternService_Illuminate_TraversalBudget(t *testing.T) {
 		fb := newFakeBackend()
 		svc := NewLanternService(fb).WithTraversalTimeout(0)
 
-		if _, err := svc.Illuminate(context.Background(), &pb.IlluminateRequest{Seed: "a"}); err != nil {
+		if _, err := svc.Illuminate(context.Background(), &pb.IlluminateRequest{Seed: "a", Params: &pb.IlluminateRequest_Bfs{Bfs: &pb.BfsParams{Step: 1, FanOut: 1}}}); err != nil {
 			t.Fatalf("Illuminate: %v", err)
 		}
 		if fb.lastNeighborHadDeadline {
@@ -1775,7 +1777,7 @@ func TestLanternService_Illuminate_TraversalBudget(t *testing.T) {
 		fb := newFakeBackend()
 		svc := NewLanternService(fb).WithTraversalTimeout(time.Hour)
 
-		if _, err := svc.Illuminate(context.Background(), &pb.IlluminateRequest{Seed: "a"}); err != nil {
+		if _, err := svc.Illuminate(context.Background(), &pb.IlluminateRequest{Seed: "a", Params: &pb.IlluminateRequest_Bfs{Bfs: &pb.BfsParams{Step: 1, FanOut: 1}}}); err != nil {
 			t.Fatalf("Illuminate: %v", err)
 		}
 		if !fb.lastNeighborHadDeadline {
@@ -1791,7 +1793,7 @@ func TestLanternService_Illuminate_TraversalBudget(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 		defer cancel()
 		start := time.Now()
-		_, err := svc.Illuminate(ctx, &pb.IlluminateRequest{Seed: "a"})
+		_, err := svc.Illuminate(ctx, &pb.IlluminateRequest{Seed: "a", Params: &pb.IlluminateRequest_Bfs{Bfs: &pb.BfsParams{Step: 1, FanOut: 1}}})
 		if connect.CodeOf(err) != connect.CodeDeadlineExceeded {
 			t.Fatalf("err = %v, want CodeDeadlineExceeded", err)
 		}
@@ -1928,8 +1930,8 @@ func TestLanternService_CapacityCaps(t *testing.T) {
 // TestIlluminate_FlatFieldGhost is the #846 reserved-range regression: a
 // stale pre-oneof client whose binary still emits the retired FLAT field
 // numbers (2 step, 3 k, 6 algorithm, 7 objective, 10 restart_prob,
-// 11 epsilon) must decode as params-unset — the BFS-defaults bare
-// illuminate — never alias onto the new oneof arms (12/13) or steer the
+// 11 epsilon) must decode as params-unset and be rejected as
+// InvalidArgument — never alias onto the new oneof arms (12/13) or steer a
 // dispatch. Proves the `reserved` ranges actually shield against stale
 // clients rather than just documenting intent.
 func TestIlluminate_FlatFieldGhost(t *testing.T) {
@@ -1960,26 +1962,19 @@ func TestIlluminate_FlatFieldGhost(t *testing.T) {
 		t.Fatalf("ghost flat fields decoded into params oneof: %T", req.GetParams())
 	}
 
-	// End-to-end through the dispatcher: the ghost must run the BFS-defaults
-	// arm (Neighbor with step=0, fanOut=0, strongest-first), NOT the PPR arm
-	// the stale algorithm=3 byte asked for.
+	// End-to-end through the dispatcher: the stale request must fail before it
+	// reaches either traversal family. A retired algorithm=3 byte cannot turn
+	// an invalid request into PPR (or a silent zero-hop BFS).
 	fb := newFakeBackend()
 	svc := NewLanternService(fb)
-	if _, err := svc.Illuminate(context.Background(), &req); err != nil {
-		t.Fatalf("Illuminate(ghost): %v", err)
+	if _, err := svc.Illuminate(context.Background(), &req); connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("Illuminate(ghost) code = %v, want InvalidArgument (err = %v)", connect.CodeOf(err), err)
 	}
 	if fb.pprCalls != 0 {
-		t.Fatalf("pprCalls = %d, want 0 — retired algorithm byte steered the dispatch", fb.pprCalls)
+		t.Fatalf("pprCalls = %d, want 0 — stale request reached PPR", fb.pprCalls)
 	}
-	if fb.neighborCalls != 1 {
-		t.Fatalf("neighborCalls = %d, want 1 (BFS defaults arm)", fb.neighborCalls)
-	}
-	if fb.lastNeighborStep != 0 || fb.lastNeighborK != 0 {
-		t.Fatalf("ghost step/k leaked into the walk: step=%d k=%d, want 0/0",
-			fb.lastNeighborStep, fb.lastNeighborK)
-	}
-	if fb.lastNeighborSelectSmall {
-		t.Fatal("ghost objective byte flipped pruning to smallest; want strongest-first default")
+	if fb.neighborCalls != 0 {
+		t.Fatalf("neighborCalls = %d, want 0 — stale request reached BFS", fb.neighborCalls)
 	}
 }
 

--- a/tests/integration/illuminate_prefix_test.go
+++ b/tests/integration/illuminate_prefix_test.go
@@ -185,12 +185,12 @@ func TestLantern_Illuminate_VertexPrefix(t *testing.T) {
 	})
 }
 
-// TestIlluminate_OneofArmRoundTrips drives one round-trip per params arm
-// (#846) through the wire: params-unset (bare illuminate), the bfs arm (with
-// and without an MST/SPT reduction), the ppr arm, and the community arm (with
-// and without a reduction, #961) must each reach the server, dispatch to
-// their family, apply any post-traversal tree reduction, and return a graph
-// rooted at the seed.
+// TestIlluminate_OneofArmRoundTrips drives each params arm (#846) through the
+// real wire. Params-unset and zero BFS dimensions must fail with
+// InvalidArgument; explicit bfs (with and without an MST/SPT reduction), ppr,
+// and community (with and without a reduction, #961) must dispatch to their
+// family, apply any post-traversal tree reduction, and return a graph rooted
+// at the seed.
 func TestIlluminate_OneofArmRoundTrips(t *testing.T) {
 	exp := timestamppb.New(time.Now().Add(time.Hour))
 	c, _ := newRawConnectClient(t, false)
@@ -218,15 +218,15 @@ func TestIlluminate_OneofArmRoundTrips(t *testing.T) {
 		return m
 	}
 	cases := []struct {
-		name     string
-		req      *pb.IlluminateRequest
-		seedOnly bool
+		name        string
+		req         *pb.IlluminateRequest
+		wantInvalid bool
 	}{
-		// step/fan_out zero means no hops, so the unset arm returns just the
-		// seed — the same contract the flat request had (0 was never
-		// defaulted server-side); the point here is that it dispatches
-		// cleanly rather than erroring.
-		{"params unset = bare illuminate", &pb.IlluminateRequest{Seed: "s"}, true},
+		{"params unset is rejected", &pb.IlluminateRequest{Seed: "s"}, true},
+		{"zero BFS step is rejected", &pb.IlluminateRequest{Seed: "s",
+			Params: &pb.IlluminateRequest_Bfs{Bfs: &pb.BfsParams{Step: 0, FanOut: 5}}}, true},
+		{"zero BFS fan-out is rejected", &pb.IlluminateRequest{Seed: "s",
+			Params: &pb.IlluminateRequest_Bfs{Bfs: &pb.BfsParams{Step: 2, FanOut: 0}}}, true},
 		{"bfs arm", &pb.IlluminateRequest{Seed: "s",
 			Params: &pb.IlluminateRequest_Bfs{Bfs: &pb.BfsParams{Step: 2, FanOut: 5}}}, false},
 		{"bfs arm with reduction", &pb.IlluminateRequest{Seed: "s",
@@ -243,6 +243,12 @@ func TestIlluminate_OneofArmRoundTrips(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			resp, err := c.Illuminate(ctx, connect.NewRequest(tc.req))
+			if tc.wantInvalid {
+				if connect.CodeOf(err) != connect.CodeInvalidArgument {
+					t.Fatalf("Illuminate code = %v, want InvalidArgument (err = %v)", connect.CodeOf(err), err)
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("Illuminate: %v", err)
 			}
@@ -250,7 +256,7 @@ func TestIlluminate_OneofArmRoundTrips(t *testing.T) {
 			if !got["s"] {
 				t.Fatalf("seed missing from result: %v", got)
 			}
-			if !tc.seedOnly && len(got) < 2 {
+			if len(got) < 2 {
 				t.Fatalf("expected at least one neighbour beside the seed, got %v", got)
 			}
 		})


### PR DESCRIPTION
## Summary
- make traversal family selection explicit across wire, server, Go/Node SDKs, MCP compatibility, and Admin adapter
- reject omitted family and zero BFS step/fan_out instead of applying contradictory defaults
- preserve #998 conflict sentinels and update real-wire/default-budget coverage

## Validation
- `go generate ./...` with no generated drift
- full root and all Go module test gate; server `go vet ./...`; golangci-lint changed-lines gate
- Node SDK codegen/build/typecheck/lint/format/test
- Admin format/lint/typecheck/unit/build

Closes #992