### PR TITLE
fix(admin): validate family push-knob drafts before command generation

### DIFF
--- a/admin/app/components/cli/CliAxisPicker/CliAxisPicker.module.css
+++ b/admin/app/components/cli/CliAxisPicker/CliAxisPicker.module.css
@@ -55,6 +55,14 @@
   min-width: 0;
 }
 
+/* Fluent Field owns the validation message for the two push-knob drafts.
+ * Keep the compact control strip layout while allowing the message to wrap
+ * underneath its own input instead of overflowing the canvas header. */
+.knobField {
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
 /* Dropdowns for algorithm / objective / weighting. The descendant selector
  * raises specificity above Fluent UI's default 250px min-width so the controls
  * can shrink and the strip never overflows a narrow canvas column. */
@@ -81,4 +89,10 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.blocked {
+  flex: 1 1 100%;
+  color: var(--colorPaletteRedForeground1, #bc2f32);
+  font-size: var(--fontSizeBase200, 12px);
 }

--- a/admin/app/components/cli/CliAxisPicker/CliAxisPicker.tsx
+++ b/admin/app/components/cli/CliAxisPicker/CliAxisPicker.tsx
@@ -1,10 +1,11 @@
 import {
   Dropdown,
+  Field,
   Input,
   Option,
   type InputProps,
 } from "@fluentui/react-components";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   CLI_ALGORITHMS,
   CLI_CLICK_K_MAX,
@@ -15,8 +16,10 @@ import {
   CLI_REDUCTIONS,
   CLI_WEIGHTINGS,
   formatFamilyClick,
-  interpretPushKnobInput,
+  isReadyPushKnob,
   type CliClickAxes,
+  validateEpsilonInput,
+  validateRestartProbInput,
 } from "~/lib/cli/illuminate-axes";
 import type {
   AlgorithmName,
@@ -35,6 +38,12 @@ export interface CliAxisPickerProps {
    * mid-flight click cannot mutate the next click string.
    */
   disabled?: boolean;
+  /**
+   * Reports whether the raw α/ε drafts can produce a family command. The
+   * parent gates canvas clicks on this signal, so invalid text cannot execute
+   * the last successfully committed axis value.
+   */
+  onPushKnobValidityChange(valid: boolean): void;
 }
 
 /**
@@ -59,7 +68,12 @@ export interface CliAxisPickerProps {
  * registry the formatter uses so picker UI, persistence, and command
  * formatting never disagree on the legal range.
  */
-export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
+export function CliAxisPicker({
+  axes,
+  setAxis,
+  disabled,
+  onPushKnobValidityChange,
+}: CliAxisPickerProps) {
   const onStepChange = useCallback<NonNullable<InputProps["onChange"]>>(
     (_, data) => {
       const n = Number.parseInt(data.value, 10);
@@ -109,31 +123,63 @@ export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
     axes.epsilon > 0 ? String(axes.epsilon) : "",
   );
 
-  const onRestartProbChange = useCallback<NonNullable<InputProps["onChange"]>>(
-    (_, data) => {
-      setRestartProbText(data.value);
-      const n = interpretPushKnobInput(data.value);
-      if (n !== null) setAxis("restartProb", n);
-    },
-    [setAxis],
-  );
-
-  const onEpsilonChange = useCallback<NonNullable<InputProps["onChange"]>>(
-    (_, data) => {
-      setEpsilonText(data.value);
-      const n = interpretPushKnobInput(data.value);
-      if (n !== null) setAxis("epsilon", n);
-    },
-    [setAxis],
-  );
-
-  const preview = formatFamilyClick("<key>", axes);
-
   // #801/#942: pagerank and community are the two push-based families that
   // carry the α/ε locality knobs; they also give the `step` axis no wire
   // meaning.
   const isPushFamily =
     axes.algorithm === "pagerank" || axes.algorithm === "community";
+  const restartProbValidation = validateRestartProbInput(restartProbText);
+  const epsilonValidation = validateEpsilonInput(epsilonText);
+  const arePushKnobsReady =
+    !isPushFamily ||
+    (isReadyPushKnob(restartProbValidation) &&
+      isReadyPushKnob(epsilonValidation));
+
+  const reportPushKnobValidity = useCallback(
+    (restartProbDraft: string, epsilonDraft: string) => {
+      const ready =
+        !isPushFamily ||
+        (isReadyPushKnob(validateRestartProbInput(restartProbDraft)) &&
+          isReadyPushKnob(validateEpsilonInput(epsilonDraft)));
+      onPushKnobValidityChange(ready);
+    },
+    [isPushFamily, onPushKnobValidityChange],
+  );
+
+  // Selection changes can hide the fields or restore them from persisted
+  // axes, so report after every render as well as synchronously in handlers.
+  // The synchronous report closes the tiny window between a keystroke and the
+  // following canvas click.
+  useEffect(() => {
+    onPushKnobValidityChange(arePushKnobsReady);
+  }, [arePushKnobsReady, onPushKnobValidityChange]);
+
+  const onRestartProbChange = useCallback<NonNullable<InputProps["onChange"]>>(
+    (_, data) => {
+      setRestartProbText(data.value);
+      const validation = validateRestartProbInput(data.value);
+      if (isReadyPushKnob(validation)) {
+        setAxis("restartProb", validation.value);
+      }
+      reportPushKnobValidity(data.value, epsilonText);
+    },
+    [epsilonText, reportPushKnobValidity, setAxis],
+  );
+
+  const onEpsilonChange = useCallback<NonNullable<InputProps["onChange"]>>(
+    (_, data) => {
+      setEpsilonText(data.value);
+      const validation = validateEpsilonInput(data.value);
+      if (isReadyPushKnob(validation)) setAxis("epsilon", validation.value);
+      reportPushKnobValidity(restartProbText, data.value);
+    },
+    [reportPushKnobValidity, restartProbText, setAxis],
+  );
+
+  const preview = arePushKnobsReady
+    ? formatFamilyClick("<key>", axes)
+    : "Fix push-knob validation errors before clicking a node.";
+
   // #961: the tree reduction is honoured for the bfs and community families
   // and ignored for pagerank (a relevance star has no tree view), so the
   // Dropdown is hidden for pagerank rather than echoing a knob the server
@@ -296,8 +342,19 @@ export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
 
       {isPushFamily && (
         <>
-          <label className={styles.field}>
-            <span className={styles.label}>restart_prob</span>
+          <Field
+            className={styles.knobField}
+            label="restart_prob"
+            validationState={
+              restartProbValidation.state === "invalid" ? "error" : "none"
+            }
+            validationMessage={
+              restartProbValidation.state === "invalid"
+                ? restartProbValidation.message
+                : undefined
+            }
+            data-testid="cli-axis-restart-prob-field"
+          >
             <Input
               className={styles.numberInput}
               type="text"
@@ -309,10 +366,21 @@ export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
               data-testid="cli-axis-restart-prob"
               aria-label="Restart probability α (0–1; blank = server default)"
             />
-          </label>
+          </Field>
 
-          <label className={styles.field}>
-            <span className={styles.label}>epsilon</span>
+          <Field
+            className={styles.knobField}
+            label="epsilon"
+            validationState={
+              epsilonValidation.state === "invalid" ? "error" : "none"
+            }
+            validationMessage={
+              epsilonValidation.state === "invalid"
+                ? epsilonValidation.message
+                : undefined
+            }
+            data-testid="cli-axis-epsilon-field"
+          >
             <Input
               className={styles.numberInput}
               type="text"
@@ -324,7 +392,7 @@ export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
               data-testid="cli-axis-epsilon"
               aria-label="Residual threshold ε (> 0; blank = server default)"
             />
-          </label>
+          </Field>
         </>
       )}
 
@@ -335,6 +403,15 @@ export function CliAxisPicker({ axes, setAxis, disabled }: CliAxisPickerProps) {
       >
         {preview}
       </code>
+      {!arePushKnobsReady && (
+        <span
+          className={styles.blocked}
+          data-testid="cli-axis-command-blocked"
+          role="status"
+        >
+          Fix the incomplete or invalid push-knob input before clicking a node.
+        </span>
+      )}
     </div>
   );
 }

--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -67,6 +67,16 @@ export function CliPage() {
   // exploration session, and persists each axis change so the next page
   // load picks up where the operator left off.
   const axisPicker = useCliAxisPicker();
+  const [isAxisPickerCommandValid, setIsAxisPickerCommandValid] =
+    useState(true);
+  const axisPickerCommandValidRef = useRef(true);
+  const onPushKnobValidityChange = useCallback((valid: boolean) => {
+    // Keep the ref in sync synchronously: a node click immediately after an
+    // input event must not sneak through before React has rendered the Field
+    // validation state.
+    axisPickerCommandValidRef.current = valid;
+    setIsAxisPickerCommandValid(valid);
+  }, []);
 
   // #651 deep-link handoff: a `/cli?seed=<key>` URL (from the Vertices /
   // Edges Browse rows and the Vertex-detail toolbar) auto-fires one
@@ -128,6 +138,7 @@ export function CliPage() {
   // as soon as the current dispatch settles.
   const onNodeClick = useCallback(
     (key: string) => {
+      if (!axisPickerCommandValidRef.current) return;
       cli.runRaw(formatFamilyClick(key, axisPicker.axes));
     },
     [cli, axisPicker.axes],
@@ -357,6 +368,7 @@ export function CliPage() {
                 axes={axisPicker.axes}
                 setAxis={axisPicker.setAxis}
                 disabled={cli.busy}
+                onPushKnobValidityChange={onPushKnobValidityChange}
               />
             </div>
             <div className={styles.canvasMeta}>
@@ -367,7 +379,9 @@ export function CliPage() {
               <span className={styles.canvasMetaHint}>
                 click a node →{" "}
                 <code data-testid="cli-click-hint">
-                  {formatFamilyClick("<key>", axisPicker.axes)}
+                  {isAxisPickerCommandValid
+                    ? formatFamilyClick("<key>", axisPicker.axes)
+                    : "Fix push-knob validation errors before clicking a node."}
                 </code>
               </span>
             </div>

--- a/admin/app/lib/cli/illuminate-axes.test.ts
+++ b/admin/app/lib/cli/illuminate-axes.test.ts
@@ -23,16 +23,18 @@ import {
   CLI_CLICK_AXIS_DEFAULTS,
   formatFamilyClick,
   formatStoredFloat,
-  interpretPushKnobInput,
   parseStoredAlgorithm,
-  parseStoredFloat,
+  parseStoredEpsilon,
   parseStoredK,
   parseStoredObjective,
   parseStoredPrefix,
+  parseStoredRestartProb,
   parseStoredReduction,
   parseStoredStep,
   parseStoredWeighting,
   type CliClickAxes,
+  validateEpsilonInput,
+  validateRestartProbInput,
 } from "./illuminate-axes";
 
 describe("formatFamilyClick", () => {
@@ -409,52 +411,86 @@ describe("parseStored* helpers", () => {
     expect(parseStoredPrefix(null)).toBeNull();
   });
 
-  test("PPR knobs accept finite non-negative floats and reject the rest", () => {
-    expect(parseStoredFloat("0")).toBe(0);
-    expect(parseStoredFloat("0.25")).toBe(0.25);
-    expect(parseStoredFloat("1e-4")).toBe(0.0001);
-    // 0 = "server default"; the picker stores it explicitly.
-    expect(parseStoredFloat("-0.1")).toBeNull();
-    expect(parseStoredFloat("NaN")).toBeNull();
-    expect(parseStoredFloat("Infinity")).toBeNull();
-    expect(parseStoredFloat("high")).toBeNull();
-    expect(parseStoredFloat(null)).toBeNull();
+  test("push-knob storage uses strict, family-specific float32 domains", () => {
+    expect(parseStoredRestartProb("")).toBe(0);
+    expect(parseStoredRestartProb("0.25")).toBe(0.25);
+    expect(parseStoredEpsilon("")).toBe(0);
+    expect(parseStoredEpsilon("1e-4")).toBe(0.0001);
+
+    // Legacy zero values, out-of-domain values, prefix parses, and values
+    // that change domain after float32 rounding must never hydrate.
+    for (const raw of [
+      "0",
+      "1",
+      "1.5",
+      "-0.1",
+      "0.25suffix",
+      "0.99999999",
+      "1e-50",
+      "NaN",
+      "Infinity",
+      " 0.25",
+      " ",
+    ]) {
+      expect(parseStoredRestartProb(raw)).toBeNull();
+    }
+    for (const raw of ["0", "-0.1", "1e-50", "0.25suffix"]) {
+      expect(parseStoredEpsilon(raw)).toBeNull();
+    }
+    expect(parseStoredRestartProb(null)).toBeNull();
+    expect(parseStoredEpsilon(null)).toBeNull();
   });
 
-  test("formatStoredFloat round-trips through parseStoredFloat", () => {
+  test("formatStoredFloat writes blank defaults that both strict parsers restore", () => {
+    expect(formatStoredFloat(0)).toBe("");
     for (const value of [0, 0.15, 0.25, 0.0001]) {
-      expect(parseStoredFloat(formatStoredFloat(value))).toBe(value);
+      const stored = formatStoredFloat(value);
+      expect(parseStoredRestartProb(stored)).toBe(value);
+      expect(parseStoredEpsilon(stored)).toBe(value);
     }
   });
 });
 
-describe("interpretPushKnobInput (live α/ε knob editing)", () => {
-  test("blank or whitespace commits 0 (= server default)", () => {
-    expect(interpretPushKnobInput("")).toBe(0);
-    expect(interpretPushKnobInput("   ")).toBe(0);
+describe("strict live push-knob validation", () => {
+  test("blank alone commits the server default, while complete valid values commit", () => {
+    expect(validateRestartProbInput("")).toEqual({
+      state: "default",
+      value: 0,
+    });
+    expect(validateRestartProbInput("0.15")).toEqual({
+      state: "valid",
+      value: 0.15,
+    });
+    expect(validateEpsilonInput("1e-4")).toEqual({
+      state: "valid",
+      value: 0.0001,
+    });
   });
 
-  test("commits finite non-negative decimals and scientific notation", () => {
-    expect(interpretPushKnobInput("0")).toBe(0);
-    expect(interpretPushKnobInput("0.15")).toBe(0.15);
-    expect(interpretPushKnobInput("0.001")).toBe(0.001);
-    expect(interpretPushKnobInput("1e-4")).toBe(0.0001);
+  test("incomplete decimal and scientific drafts stay intact without committing", () => {
+    for (const raw of [".", "0.", "+", "1e", "1e-"]) {
+      expect(validateRestartProbInput(raw)).toEqual({ state: "incomplete" });
+    }
   });
 
-  test("keeps a value for in-progress decimals so the field is never erased", () => {
-    // The regression this guards: typing "0.15" a key at a time used to pass
-    // through "0." → commit 0 → re-derive display from the numeric axis → blank,
-    // so a leading-zero decimal could never be built up. "0." / "0.0" must
-    // resolve to a committable 0 (the component keeps the raw text), not null.
-    expect(interpretPushKnobInput("0.")).toBe(0);
-    expect(interpretPushKnobInput("0.0")).toBe(0);
+  test("restart_prob rejects malformed and out-of-domain float32 values", () => {
+    for (const raw of [
+      "0",
+      "1",
+      "1.5",
+      "-0.1",
+      " ",
+      "0.25suffix",
+      "0.99999999", // rounds to exactly 1 as float32
+      "1e-50", // underflows to exactly 0 as float32
+    ]) {
+      expect(validateRestartProbInput(raw).state).toBe("invalid");
+    }
   });
 
-  test("rejects garbage / negatives so a good knob is never destroyed", () => {
-    expect(interpretPushKnobInput("-0.1")).toBeNull();
-    expect(interpretPushKnobInput("-")).toBeNull();
-    expect(interpretPushKnobInput("abc")).toBeNull();
-    expect(interpretPushKnobInput("NaN")).toBeNull();
-    expect(interpretPushKnobInput("Infinity")).toBeNull();
+  test("epsilon rejects zero, malformed, and float32 underflow", () => {
+    for (const raw of ["0", "-0.1", "0.25suffix", "1e-50"]) {
+      expect(validateEpsilonInput(raw).state).toBe("invalid");
+    }
   });
 });

--- a/admin/app/lib/cli/illuminate-axes.ts
+++ b/admin/app/lib/cli/illuminate-axes.ts
@@ -32,6 +32,7 @@ import type {
   ReductionName,
   WeightingName,
 } from "./types";
+import { parseFloatStrict } from "./verbs";
 
 /** Bounds for the step axis. Matches the Illuminate wire toolbar. */
 export const CLI_CLICK_STEP_MIN = 1;
@@ -249,46 +250,64 @@ export function parseStoredWeighting(raw: string | null): WeightingName | null {
   return matchOption(raw, CLI_WEIGHTINGS);
 }
 
+export type PushKnobValidation =
+  | { state: "default"; value: 0 }
+  | { state: "valid"; value: number }
+  | { state: "incomplete" }
+  | { state: "invalid"; message: string };
+
+export const RESTART_PROB_VALIDATION_MESSAGE =
+  "restart_prob must be a float32 in (0, 1), or blank for the server default.";
+export const EPSILON_VALIDATION_MESSAGE =
+  "epsilon must be a positive float32, or blank for the server default.";
+
 /**
- * Parse a stored PPR knob (restart_prob / epsilon). Accepts any finite,
- * non-negative number — 0 means "use the server default". Returns null for
- * missing / malformed / negative values so the caller falls back to the
- * documented default (0). Kept lenient (the server is the final authority on
- * the (0,1) / >0 bounds) but never resurrects a NaN or a negative knob (#801).
+ * Strictly validate a restart-probability draft. The input must match the
+ * command grammar in full; its float32 representation (the value sent on the
+ * wire) must then be in the open interval (0, 1). Empty text alone requests
+ * the server default. Incomplete decimal/scientific drafts remain distinct so
+ * the picker can preserve them without committing a stale or invalid value.
  */
-export function parseStoredFloat(raw: string | null): number | null {
-  if (raw === null) return null;
-  const n = Number.parseFloat(raw);
-  if (!Number.isFinite(n)) return null;
-  if (n < 0) return null;
-  return n;
+export function validateRestartProbInput(raw: string): PushKnobValidation {
+  return validatePushKnob(
+    raw,
+    (value) => value > 0 && value < 1,
+    RESTART_PROB_VALIDATION_MESSAGE,
+  );
 }
 
 /**
- * Interpret a raw push-knob (restart_prob / epsilon) input string into the
- * number to COMMIT to the axis during live editing (#801).
- *
- * The CliAxisPicker knob fields keep the operator's raw keystrokes as the
- * displayed value — so a half-typed "0." or "1e-" survives instead of being
- * round-tripped through the numeric axis (where 0 = "server default" renders
- * blank) and erased mid-edit — and feed every keystroke through this helper to
- * decide what, if anything, to persist:
- *   - blank / whitespace → 0, i.e. "leave the knob at the server default";
- *   - a finite, non-negative parse (incl. "0", "0.", "0.15", "1e-4") → that
- *     number, committed so the live preview updates;
- *   - anything else (negative, NaN, "abc", a lone "-") → null, meaning "keep the
- *     previously committed value" so a stray keystroke never destroys a good knob.
- *
- * This is the live-edit sibling of {@link parseStoredFloat} (which guards
- * localStorage hydration). Both stay lenient about the (0,1) / >0 bounds — the
- * server remains the final authority — but neither ever resurrects a NaN or a
- * negative knob.
+ * Strictly validate an epsilon draft. Its float32 wire value must be positive;
+ * an underflow such as `1e-50` therefore remains invalid rather than silently
+ * becoming the server-default zero value.
  */
-export function interpretPushKnobInput(raw: string): number | null {
-  if (raw.trim() === "") return 0;
-  const n = Number.parseFloat(raw);
-  if (!Number.isFinite(n) || n < 0) return null;
-  return n;
+export function validateEpsilonInput(raw: string): PushKnobValidation {
+  return validatePushKnob(
+    raw,
+    (value) => value > 0,
+    EPSILON_VALIDATION_MESSAGE,
+  );
+}
+
+/** Whether a draft can safely participate in a generated click command. */
+export function isReadyPushKnob(
+  validation: PushKnobValidation,
+): validation is Extract<PushKnobValidation, { value: number }> {
+  return validation.state === "default" || validation.state === "valid";
+}
+
+/**
+ * Parse the persisted restart-probability value with the same full-string and
+ * float32-domain rules as the interactive field. A legacy stored `0` is
+ * rejected and hydrates to the documented default instead.
+ */
+export function parseStoredRestartProb(raw: string | null): number | null {
+  return parseStoredPushKnob(raw, validateRestartProbInput);
+}
+
+/** Like {@link parseStoredRestartProb}, but for the positive epsilon domain. */
+export function parseStoredEpsilon(raw: string | null): number | null {
+  return parseStoredPushKnob(raw, validateEpsilonInput);
 }
 
 /**
@@ -309,9 +328,50 @@ export function formatStoredK(value: number): string {
   return String(value);
 }
 
-/** Serialise a PPR knob for localStorage; base-10, mirrors {@link parseStoredFloat}. */
+/**
+ * Serialise a validated PPR knob for localStorage. Defaults use blank text so
+ * the next hydration distinguishes the documented default from a retired,
+ * explicit zero value that no longer satisfies either family domain.
+ */
 export function formatStoredFloat(value: number): string {
-  return String(value);
+  return value === 0 ? "" : String(value);
+}
+
+function validatePushKnob(
+  raw: string,
+  acceptsFloat32: (value: number) => boolean,
+  message: string,
+): PushKnobValidation {
+  if (raw === "") return { state: "default", value: 0 };
+  if (isIncompleteFloatDraft(raw)) return { state: "incomplete" };
+  const value = parseFloatStrict(raw);
+  if (value === null) return { state: "invalid", message };
+  const wireValue = Math.fround(value);
+  if (!Number.isFinite(wireValue) || !acceptsFloat32(wireValue)) {
+    return { state: "invalid", message };
+  }
+  // Preserve the concise decimal the operator supplied. Domain checks use the
+  // float32 value above, so this remains wire-equivalent to the CLI parser
+  // without turning `1e-4` into a long binary32 decimal in the command text.
+  return { state: "valid", value };
+}
+
+function isIncompleteFloatDraft(raw: string): boolean {
+  return (
+    /^[+-]?$/.test(raw) ||
+    /^[+-]?\.$/.test(raw) ||
+    /^[+-]?\d+\.$/.test(raw) ||
+    /^[+-]?(?:\d+\.?\d*|\.\d+)[eE][+-]?$/.test(raw)
+  );
+}
+
+function parseStoredPushKnob(
+  raw: string | null,
+  validate: (value: string) => PushKnobValidation,
+): number | null {
+  if (raw === null) return null;
+  const result = validate(raw);
+  return isReadyPushKnob(result) ? result.value : null;
 }
 
 function parseStoredInt(

--- a/admin/app/lib/client/usecase/cli/use-cli-axis-picker.ts
+++ b/admin/app/lib/client/usecase/cli/use-cli-axis-picker.ts
@@ -10,10 +10,11 @@ import {
   formatStoredK,
   formatStoredStep,
   parseStoredAlgorithm,
-  parseStoredFloat,
+  parseStoredEpsilon,
   parseStoredK,
   parseStoredObjective,
   parseStoredPrefix,
+  parseStoredRestartProb,
   parseStoredReduction,
   parseStoredStep,
   parseStoredWeighting,
@@ -76,10 +77,10 @@ export function useCliAxisPicker(
       parseStoredPrefix(store.get(AXIS_STORAGE_KEYS.vertexPrefix)) ??
       CLI_CLICK_AXIS_DEFAULTS.vertexPrefix,
     restartProb:
-      parseStoredFloat(store.get(AXIS_STORAGE_KEYS.restartProb)) ??
+      parseStoredRestartProb(store.get(AXIS_STORAGE_KEYS.restartProb)) ??
       CLI_CLICK_AXIS_DEFAULTS.restartProb,
     epsilon:
-      parseStoredFloat(store.get(AXIS_STORAGE_KEYS.epsilon)) ??
+      parseStoredEpsilon(store.get(AXIS_STORAGE_KEYS.epsilon)) ??
       CLI_CLICK_AXIS_DEFAULTS.epsilon,
   }));
 

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -644,6 +644,85 @@ test.describe("/cli", () => {
     );
   });
 
+  // #987 — raw α/ε drafts must obey the same strict float32 domains as the
+  // parser before the picker can generate a click command. The test covers
+  // persisted corruption, complete-but-invalid values, suffix garbage,
+  // float32 rounding/underflow, blank defaults, and scientific notation.
+  test("push-knob validation blocks invalid click commands (#987)", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem("cli.click.restart_prob", "1.5");
+      localStorage.setItem("cli.click.epsilon", "0.25suffix");
+    });
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    await input.fill("get vertex cli:alpha");
+    await input.press("Enter");
+    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
+
+    await page.getByTestId("cli-axis-algorithm").click();
+    await page.getByRole("option", { name: "Personalized PageRank" }).click();
+    const restartProb = page.getByTestId("cli-axis-restart-prob");
+    const epsilon = page.getByTestId("cli-axis-epsilon");
+    const preview = page.getByTestId("cli-axis-preview");
+    const hint = page.getByTestId("cli-click-hint");
+
+    // Invalid persisted values hydrate to blank/server-default drafts.
+    await expect(restartProb).toHaveValue("");
+    await expect(epsilon).toHaveValue("");
+    await expect(preview).toHaveText("pagerank <key> 5");
+
+    for (const raw of [
+      "0",
+      "1",
+      "1.5",
+      "-0.1",
+      "0.25suffix",
+      "0.99999999", // float32 rounds to 1
+      "1e-50", // float32 underflows to 0
+    ]) {
+      await restartProb.fill(raw);
+      await expect(restartProb).toHaveValue(raw);
+      await expect(
+        page.getByTestId("cli-axis-restart-prob-field"),
+      ).toContainText("restart_prob must be a float32 in (0, 1)");
+      // Neither preview nor canvas hint carries an executable command while
+      // the parent click handler is gated on this invalid raw draft.
+      await expect(preview).toHaveText(
+        "Fix push-knob validation errors before clicking a node.",
+      );
+      await expect(hint).toHaveText(
+        "Fix push-knob validation errors before clicking a node.",
+      );
+      await expect(page.getByTestId("cli-axis-command-blocked")).toBeVisible();
+    }
+
+    await restartProb.fill("");
+    await expect(preview).toHaveText("pagerank <key> 5");
+
+    for (const raw of ["0", "-0.1", "0.25suffix", "1e-50"]) {
+      await epsilon.fill(raw);
+      await expect(epsilon).toHaveValue(raw);
+      await expect(page.getByTestId("cli-axis-epsilon-field")).toContainText(
+        "epsilon must be a positive float32",
+      );
+      await expect(preview).toHaveText(
+        "Fix push-knob validation errors before clicking a node.",
+      );
+    }
+
+    // Blank is the only default spelling. A complete valid scientific value
+    // then commits and produces the same parser-accepted command text.
+    await epsilon.fill("");
+    await expect(preview).toHaveText("pagerank <key> 5");
+    await epsilon.fill("1e-4");
+    await expect(epsilon).toHaveValue("1e-4");
+    await expect(preview).toHaveText("pagerank <key> 5 epsilon=0.0001");
+    await expect(hint).toHaveText("pagerank <key> 5 epsilon=0.0001");
+    await expect(page.getByTestId("cli-axis-command-blocked")).toHaveCount(0);
+  });
+
   test("picker state persists across a reload (#464)", async ({ page }) => {
     await page.goto("/cli");
     // Render a graph so the picker mounts (#512).


### PR DESCRIPTION
## Summary
- preserve incomplete numeric drafts without committing invalid traversal values
- enforce float32 domains for restart_prob and epsilon at the picker boundary
- align storage, generated commands, unit coverage, and rendered error behavior

## Validation
- full root and all Go module test gate; server `go vet ./...`; golangci-lint changed-lines gate
- rebuilt linked Node SDK
- Admin format/lint/typecheck/unit/build

Closes #987