### PR TITLE
test(docs): compile SDK examples and reject retired traversal grammar

### DIFF
--- a/.github/agents/User.agent.md
+++ b/.github/agents/User.agent.md
@@ -439,11 +439,11 @@ lantern-cli get edge user:alice item:laptop
 # Output: 1.000000
 
 # Walk from a seed (1-hop neighborhood)
-lantern-cli illuminate user:alice --step 1 --k 5
+lantern-cli bfs user:alice 1 5
 # Output: {"vertices":{...},"edges":{...}}
 
-# With algorithm + objective (e.g., MST, cost-weighted)
-lantern-cli illuminate user:alice --step 2 --k 10 --algorithm mst --objective min
+# Render the BFS result as a cost-weighted spanning tree
+lantern-cli bfs user:alice 2 10 reduction=mst objective=min
 ```
 
 ### Cleaning Up Test Data

--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -70,6 +70,8 @@ jobs:
         run: bun run format:check
       - name: Typecheck
         run: bun run typecheck
+      - name: Typecheck maintained example
+        run: bun run example:typecheck
       - name: Test
         run: bun test
       - name: Build

--- a/README.md
+++ b/README.md
@@ -380,15 +380,31 @@ npm install lantern-sdk
 ```
 
 ```ts
-import { connect } from "lantern-sdk";
+import { Objective, Reduction, Weighting, connect } from "lantern-sdk";
 
 const client = connect("http://localhost:6380");
 try {
   await client.putVertex({ key: "user:42", value: "alice", ttlSeconds: 3600 });
   await client.addEdge({ tail: "user:42", head: "item:7", weight: 1.0, ttlSeconds: 1800 });
 
-  const graph = await client.illuminate("user:42", { step: 2, k: 16 });
+  const bfs = await client.illuminate("user:42", {
+    bfs: {
+      step: 2,
+      fanOut: 16,
+      reduction: Reduction.SHORTEST_PATH_TREE,
+      objective: Objective.MAXIMIZE,
+    },
+    weighting: Weighting.TFIDF,
+  });
+  const pagerank = await client.illuminate("user:42", {
+    ppr: { topN: 16, restartProb: 0.15, epsilon: 0.0001 },
+  });
+  const community = await client.illuminate("user:42", {
+    community: { maxSize: 16, restartProb: 0.15, epsilon: 0.0001 },
+  });
   const hits  = await client.searchVertices("desk lamp", { limit: 10 });
+
+  console.log(bfs.vertices.size, pagerank.vertices.size, community.vertices.size);
 
   for await (const page of client.scanVerticesAll("user:", 500)) {
     for (const v of page) console.log(v.key);

--- a/admin/Caddyfile
+++ b/admin/Caddyfile
@@ -2,7 +2,7 @@
 #
 # Caddy serves the React Router (SPA mode) build from /srv with:
 #   - SPA fallback to /index.html so client-side routes (e.g. /browse,
-#     /illuminate, /ops) work on direct navigation or refresh.
+#     /cli, /ops) work on direct navigation or refresh.
 #   - Aggressive cache headers on hashed asset paths (Vite emits
 #     `/assets/<name>-<hash>.js|css`), no-cache on index.html so a new
 #     deploy is picked up on next page load.

--- a/admin/README.md
+++ b/admin/README.md
@@ -57,7 +57,7 @@ Follows the React Router app architecture conventions used in this repo. Key
 points:
 
 - `app/routes/` — FlatRoute file routing (`_index.tsx`, `browse.tsx`,
-  `illuminate.tsx`, `ops.tsx`).
+  `cli.tsx`, `ops.tsx`). The graph explorer is part of the CLI workspace.
 - `app/components/<feature>/<Component>/` — one React component per `.tsx`,
   filename matches export, CSS Module colocated.
 - `app/lib/client/usecase/` — UI-facing use cases (e.g. `connection/`,

--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -312,7 +312,7 @@ export function CliPage() {
               }}
               onKeyDown={onKeyDown}
               onPaste={onPaste}
-              placeholder="get vertex alice    |    illuminate alice 2 5 reduction=spt"
+              placeholder="get vertex alice    |    bfs alice 2 5 reduction=spt"
               data-testid="cli-input"
               aria-label="CLI command input"
               autoComplete="off"

--- a/mcp/examples/README.md
+++ b/mcp/examples/README.md
@@ -143,11 +143,12 @@ exchange — with sensible TTL buckets and the `user.*` / `project.*` /
 
 Everything the agent captures lands in the same Lantern the MCP server writes
 to, so you can watch the graph fill in live. Point the
-[**lantern-admin**](../../admin/) SPA at that Lantern and open **Illuminate**:
+[**lantern-admin**](../../admin/) SPA at that Lantern and open the **CLI**
+workspace:
 
 - In the [compose stack](../../README.md#run-with-docker-compose--open-the-admin-ui)
   the Admin is served at **<http://localhost:8080>** — open it and go to
-  **Illuminate** (`/illuminate`).
+  **CLI** (`/cli`).
 - Seed the walk with a namespace root you have been writing under — e.g.
   `user.identity.name` or `project.lantern` — then increase the hop count to
   watch related facts and relations fan out.

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -160,7 +160,7 @@ a parallel struct:
 ```go
 type Vertex    = pb.Vertex
 type Edge      = pb.Edge
-type Algorithm = pb.Algorithm
+type Reduction = pb.Reduction
 type Objective = pb.Objective
 type Weighting = pb.Weighting
 ```

--- a/sdks/go/example/main.go
+++ b/sdks/go/example/main.go
@@ -355,7 +355,7 @@ func main() {
 		log.Printf("deleted %d orders/ vertices\n", deleted)
 	}
 
-	// illuminate from a with step 2 and fan-out 2
+	// BFS: traverse two hops with a fan-out of two.
 	if graph, err := cli.Illuminate(ctx, "a", client.WithBFS(client.BFSOpts{Step: 2, FanOut: 2})); err == nil {
 		if jsonString, err := json.MarshalIndent(graph, "", "\t"); err == nil {
 			log.Printf("%s\n", jsonString)
@@ -409,6 +409,24 @@ func main() {
 				}
 			*/
 		}
+	}
+
+	// Personalized PageRank: return the three most relevant vertices around a.
+	if graph, err := cli.Illuminate(ctx, "a", client.WithPPR(client.PPROpts{
+		TopN:        3,
+		RestartProb: 0.15,
+		Epsilon:     0.0001,
+	})); err == nil {
+		log.Printf("PPR graph has %d vertices", len(graph.Vertices))
+	}
+
+	// Local community: return the conductance-selected induced subgraph around a.
+	if graph, err := cli.Illuminate(ctx, "a", client.WithLocalCommunity(client.LocalCommunityOpts{
+		MaxSize:     3,
+		RestartProb: 0.15,
+		Epsilon:     0.0001,
+	})); err == nil {
+		log.Printf("local community graph has %d vertices", len(graph.Vertices))
 	}
 }
 

--- a/sdks/node/example/main.ts
+++ b/sdks/node/example/main.ts
@@ -1,4 +1,13 @@
-import { Algorithm, Objective, Weighting, connect } from "lantern-sdk";
+import { Objective, Reduction, Weighting, connect, type Graph } from "lantern-sdk";
+
+function printGraph(name: string, graph: Graph): void {
+  console.log(`${name}: vertices=${graph.vertices.size}`);
+  for (const [tail, row] of graph.edges) {
+    for (const [head, weight] of row) {
+      console.log(`${name}: edge ${tail} -> ${head} = ${weight}`);
+    }
+  }
+}
 
 async function main(): Promise<void> {
   const client = connect("http://localhost:6380");
@@ -6,41 +15,57 @@ async function main(): Promise<void> {
   try {
     // PutVertex — value can be string, number, bigint, boolean, Date,
     // Uint8Array, null, or a typed wrapper (Int32/Uint32/Uint64/Float32/Duration).
-    await client.putVertex("string", "A", { ttlSeconds: 60 });
-    await client.putVertex("int", 1, { ttlSeconds: 60 });
-    await client.putVertex("float", 1.1, { ttlSeconds: 60 });
-    await client.putVertex("bool", true, { ttlSeconds: 60 });
-    await client.putVertex("time", new Date(), { ttlSeconds: 60 });
-    await client.putVertex("bytes", new Uint8Array([0x41]), { ttlSeconds: 60 });
-    await client.putVertex("nil", null, { ttlSeconds: 60 });
+    await client.putVertex({ key: "string", value: "A", ttlSeconds: 60 });
+    await client.putVertex({ key: "int", value: 1, ttlSeconds: 60 });
+    await client.putVertex({ key: "float", value: 1.1, ttlSeconds: 60 });
+    await client.putVertex({ key: "bool", value: true, ttlSeconds: 60 });
+    await client.putVertex({ key: "time", value: new Date(), ttlSeconds: 60 });
+    await client.putVertex({ key: "bytes", value: new Uint8Array([0x41]), ttlSeconds: 60 });
+    await client.putVertex({ key: "nil", value: null, ttlSeconds: 60 });
 
     // GetVertex
     const v = await client.getVertex("string");
     console.log(`${v.key}: kind=${v.kind} value=${String(v.value)}`);
 
     // Edges
-    await client.addEdge("string", "int", 1.0, { ttlSeconds: 60 });
-    await client.addEdge("string", "float", 1.0, { ttlSeconds: 60 });
-    await client.addEdge("int", "bool", 1.0, { ttlSeconds: 60 });
+    await client.addEdge({ tail: "string", head: "int", weight: 1.0, ttlSeconds: 60 });
+    await client.addEdge({ tail: "string", head: "float", weight: 1.0, ttlSeconds: 60 });
+    await client.addEdge({ tail: "int", head: "bool", weight: 1.0, ttlSeconds: 60 });
 
-    // Illuminate — neighborhood graph traversal. The three orthogonal
-    // axes (algorithm × objective × weighting) replaced the legacy
-    // `tfidf` flag + `optimization` enum in #410. UNSPECIFIED on every
-    // axis defers to the server's defaults (raw subgraph, minimise,
-    // raw weighting).
-    const graph = await client.illuminate("string", {
-      step: 2,
-      k: 16,
-      algorithm: Algorithm.UNSPECIFIED,
-      objective: Objective.UNSPECIFIED,
+    // Illuminate selects exactly one traversal family. BFS supports the
+    // per-hop controls and optional tree rendering; the shared weighting is
+    // applied before the family walk.
+    const bfs = await client.illuminate("string", {
+      bfs: {
+        step: 2,
+        fanOut: 16,
+        reduction: Reduction.SHORTEST_PATH_TREE,
+        objective: Objective.MAXIMIZE,
+      },
       weighting: Weighting.UNSPECIFIED,
     });
-    console.log(`vertices: ${graph.vertices.size}`);
-    for (const [tail, row] of graph.edges) {
-      for (const [head, weight] of row) {
-        console.log(`edge ${tail} -> ${head} = ${weight}`);
-      }
-    }
+    printGraph("bfs", bfs);
+
+    // Personalized PageRank is a relevance star around the seed.
+    const pagerank = await client.illuminate("string", {
+      ppr: { topN: 16, restartProb: 0.15, epsilon: 0.0001 },
+      weighting: Weighting.TFIDF,
+    });
+    printGraph("pagerank", pagerank);
+
+    // Local community returns the induced subgraph selected by a
+    // conductance sweep, with an optional tree view of those members.
+    const community = await client.illuminate("string", {
+      community: {
+        maxSize: 16,
+        restartProb: 0.15,
+        epsilon: 0.0001,
+        reduction: Reduction.MINIMUM_SPANNING_TREE,
+        objective: Objective.MINIMIZE,
+      },
+      weighting: Weighting.BM25,
+    });
+    printGraph("community", community);
 
     // Prefix count
     const count = await client.countVerticesByPrefix("");

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -49,6 +49,7 @@
     "codegen": "bash scripts/codegen.sh",
     "build": "tsup",
     "typecheck": "tsc --noEmit",
+    "example:typecheck": "tsc -p tsconfig.example.json --noEmit",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/sdks/node/tsconfig.example.json
+++ b/sdks/node/tsconfig.example.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "lantern-sdk": ["./src/index.ts"]
+    },
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src/**/*", "example/**/*"],
+  "exclude": ["node_modules", "dist", "src/generated"]
+}

--- a/tests/integration/docs_gate_test.go
+++ b/tests/integration/docs_gate_test.go
@@ -1,0 +1,127 @@
+package integration_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/anaregdesign/lantern/cli/parser"
+)
+
+// TestTraversalDocumentationGate keeps the maintained consumer examples and
+// UI copy aligned with the family-verb grammar. The wire RPC and SDK method
+// intentionally remain named Illuminate; this gate only rejects retired CLI
+// grammar and routes, then parses every documented family command through the
+// production parser.
+func TestTraversalDocumentationGate(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+
+	files := map[string]struct {
+		required []string
+		retired  []string
+	}{
+		"README.md": {
+			required: []string{"bfs: {", "ppr: {", "community: {"},
+		},
+		"sdks/node/example/main.ts": {
+			required: []string{"bfs: {", "ppr: {", "community: {"},
+			retired:  []string{"Algorithm", "algorithm:"},
+		},
+		"sdks/go/example/main.go": {
+			required: []string{"client.WithBFS", "client.WithPPR", "client.WithLocalCommunity"},
+		},
+		"sdks/go/README.md": {
+			required: []string{"type Reduction = pb.Reduction"},
+			retired:  []string{"type Algorithm = pb.Algorithm"},
+		},
+		"admin/app/components/cli/CliPage/CliPage.tsx": {
+			required: []string{"bfs alice 2 5 reduction=spt"},
+			retired:  []string{"illuminate alice 2 5"},
+		},
+		"admin/README.md": {
+			required: []string{"`cli.tsx`", "CLI workspace"},
+			retired:  []string{"`illuminate.tsx`"},
+		},
+		"admin/Caddyfile": {
+			required: []string{"/cli, /ops"},
+			retired:  []string{"/illuminate"},
+		},
+		"mcp/examples/README.md": {
+			required: []string{"**CLI** (`/cli`)"},
+			retired:  []string{"/illuminate"},
+		},
+		".github/agents/User.agent.md": {
+			required: []string{
+				"lantern-cli bfs user:alice 1 5",
+				"lantern-cli bfs user:alice 2 10 reduction=mst objective=min",
+			},
+			retired: []string{"lantern-cli illuminate"},
+		},
+	}
+
+	for path, checks := range files {
+		t.Run(path, func(t *testing.T) {
+			contents, readErr := os.ReadFile(filepath.Join(repoRoot, path))
+			if readErr != nil {
+				t.Fatalf("read %s: %v", path, readErr)
+			}
+			text := string(contents)
+			for _, want := range checks.required {
+				if !strings.Contains(text, want) {
+					t.Errorf("%s is missing maintained example/copy %q", path, want)
+				}
+			}
+			for _, retired := range checks.retired {
+				if strings.Contains(text, retired) {
+					t.Errorf("%s still contains retired traversal grammar/copy %q", path, retired)
+				}
+			}
+		})
+	}
+
+	for _, example := range []string{
+		"bfs user:42 3 8 reduction=spt objective=max",
+		"pagerank user:42 10 restart_prob=0.15 epsilon=0.0001",
+		"community user:42 30 reduction=mst objective=min",
+		"bfs alice 2 5 reduction=spt",
+		"lantern-cli bfs user:alice 1 5",
+		"lantern-cli bfs user:alice 2 10 reduction=mst objective=min",
+	} {
+		t.Run(example, func(t *testing.T) {
+			parseTraversalDocumentationCommand(t, example)
+		})
+	}
+}
+
+func parseTraversalDocumentationCommand(t *testing.T, command string) {
+	t.Helper()
+	command = strings.TrimPrefix(command, "lantern-cli ")
+	source, err := parser.NewSource(command)
+	if err != nil {
+		t.Fatalf("tokenise %q: %v", command, err)
+	}
+	verb, err := parser.Verb(source)
+	if err != nil {
+		t.Fatalf("parse verb in %q: %v", command, err)
+	}
+	switch verb {
+	case "bfs":
+		_, err = parser.BfsParam(source)
+	case "pagerank":
+		_, err = parser.PagerankParam(source)
+	case "community":
+		_, err = parser.CommunityParam(source)
+	default:
+		t.Fatalf("unexpected traversal verb %q", verb)
+	}
+	if err != nil {
+		t.Fatalf("parse %q: %v", command, err)
+	}
+	if err := parser.EOF(source); err != nil {
+		t.Fatalf("trailing token in %q: %v", command, err)
+	}
+}


### PR DESCRIPTION
## Summary
- compile the Node example in CI and build the Go example in the ordinary gate
- add a cross-workspace documentation gate for current family grammar and routes
- update maintained examples and agent copy to the supported BFS/PPR/community surface

## Validation
- full root and all Go module test gate; server `go vet ./...`; golangci-lint changed-lines gate
- Node SDK build/typecheck/example:typecheck/lint/format/test
- Admin format/lint/typecheck/unit/build

Closes #990