### PR TITLE
fix(admin): serialize generated traversal commands safely

### DIFF
--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -18,22 +18,6 @@ import { IlluminateCanvas } from "~/components/illuminate/IlluminateCanvas/Illum
 import styles from "./CliPage.module.css";
 
 /**
- * Decode a `?seed=` query value. The browser already percent-decodes
- * `URLSearchParams`, but the seed handoff mirrors the retired Illuminate
- * page: try one more decode (some keys arrive double-encoded) and fall
- * back to the raw value when it is already decoded.
- */
-function decodeSeed(raw: string): string {
-  if (raw === "") return "";
-  try {
-    return decodeURIComponent(raw);
-  } catch {
-    // Browser already decoded once; pass through unmodified.
-    return raw;
-  }
-}
-
-/**
  * The /cli admin route. A Fluent UI command-line panel shared with the
  * Go REPL via the `lib/cli/parser` TypeScript port (#411).
  *
@@ -93,7 +77,10 @@ export function CliPage() {
     runRawRef.current = cli.runRaw;
   }, [cli.runRaw]);
   useEffect(() => {
-    const seed = decodeSeed(seedParam);
+    // URLSearchParams has already decoded this value exactly once. Decoding
+    // again corrupts literal percent escapes in valid vertex keys, e.g.
+    // `audit:%2F` becomes `audit:/` (#988).
+    const seed = seedParam;
     if (seed === "") {
       seedHandoffRef.current = null;
       return;

--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -832,6 +832,11 @@ export function IlluminateCanvas({
     const win = window as Window & {
       __illuminateCanvas?: {
         getNodePosition: (key: string) => { x: number; y: number } | null;
+        /**
+         * #988 test bridge: invoke the same callback a Sigma clickNode event
+         * would fire, but only for a node currently rendered in the graph.
+         */
+        clickNode: (key: string) => boolean;
         isNodeFixed: (key: string) => boolean;
         /**
          * #491 test bridge: whether an edge currently exists in
@@ -1038,6 +1043,11 @@ export function IlluminateCanvas({
           return null;
         }
         return { x: attrs.x, y: attrs.y };
+      },
+      clickNode: (key: string) => {
+        if (!graph.hasNode(key)) return false;
+        onNodeClickRef.current(key);
+        return true;
       },
       isNodeFixed: (key: string) => {
         if (!graph.hasNode(key)) return false;

--- a/admin/app/lib/cli/illuminate-axes.test.ts
+++ b/admin/app/lib/cli/illuminate-axes.test.ts
@@ -228,6 +228,35 @@ describe("formatFamilyClick", () => {
       "bfs user:alice 2 5",
     );
   });
+
+  test("safe keys stay human-readable while literal percent escapes stay literal", () => {
+    expect(formatFamilyClick("audit:%2F", CLI_CLICK_AXIS_DEFAULTS)).toBe(
+      "bfs audit:%2F 2 5",
+    );
+  });
+
+  test.each([
+    "audit key",
+    "audit:%2F",
+    'say "hi"',
+    "C:\\tmp\\key",
+    "tab\tand\nnewline",
+    "日本語",
+  ])("serialises seed and prefix losslessly: %p", (value) => {
+    const result = parse(
+      formatFamilyClick(value, {
+        ...CLI_CLICK_AXIS_DEFAULTS,
+        vertexPrefix: value,
+      }),
+    );
+    if (!result.ok) {
+      throw new Error(`formatter rejected ${JSON.stringify(value)}`);
+    }
+    expect(result.command.verb).toBe("bfs");
+    if (result.command.verb !== "bfs") return;
+    expect(result.command.seed).toBe(value);
+    expect(result.command.vertexPrefix).toBe(value);
+  });
 });
 
 describe("formatFamilyClick ↔ parse round-trip", () => {

--- a/admin/app/lib/cli/illuminate-axes.ts
+++ b/admin/app/lib/cli/illuminate-axes.ts
@@ -32,6 +32,7 @@ import type {
   ReductionName,
   WeightingName,
 } from "./types";
+import { quoteCliToken } from "./tokenise";
 import { parseFloatStrict } from "./verbs";
 
 /** Bounds for the step axis. Matches the Illuminate wire toolbar. */
@@ -159,7 +160,7 @@ export const CLI_WEIGHTINGS: ReadonlyArray<{
  */
 export function formatFamilyClick(seed: string, axes: CliClickAxes): string {
   const verb = axes.algorithm;
-  const tokens: string[] = [verb, seed];
+  const tokens: string[] = [verb, quoteCliToken(seed)];
   // Positional walk-size args: bfs takes step + fan_out; pagerank / community
   // take a single count (top_n / max_size). `axes.k` is the shared count axis.
   if (verb === "bfs") {
@@ -184,9 +185,10 @@ export function formatFamilyClick(seed: string, axes: CliClickAxes): string {
   // #617: prefix is a FREE-TEXT axis. Emit `prefix=<value>` only when non-empty
   // — the parser rejects an explicit empty `prefix=`, and an empty prefix means
   // "no filter" anyway, so the bare click stays the canonical short form. The
-  // value is echoed verbatim (case-SENSITIVE, #604).
+  // value is case-sensitive (#604), but quote the COMPLETE `prefix=value`
+  // token so whitespace and escape characters survive tokenisation.
   if (axes.vertexPrefix !== "") {
-    tokens.push(`prefix=${axes.vertexPrefix}`);
+    tokens.push(quoteCliToken(`prefix=${axes.vertexPrefix}`));
   }
   // #801/#942: the α/ε knobs are meaningful for the two push-based families
   // (pagerank and community — both carry the same `restart_prob`/`epsilon`

--- a/admin/app/lib/cli/tokenise.test.ts
+++ b/admin/app/lib/cli/tokenise.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { tokenise } from "~/lib/cli/tokenise";
+import { quoteCliToken, tokenise } from "~/lib/cli/tokenise";
 
 function ok(input: string): string[] {
   const r = tokenise(input);
@@ -151,5 +151,24 @@ describe("tokenise — errors (#438)", () => {
 
   test("unknown backslash escape inside double-quote", () => {
     expect(err('"bad \\q escape"')).toBe("error: invalid escape sequence \\q");
+  });
+});
+
+describe("quoteCliToken (#988)", () => {
+  test.each([
+    ["plain", "plain"],
+    ["audit:%2F", "audit:%2F"],
+    ["audit key", '"audit key"'],
+    ['say "hi"', '"say \\"hi\\""'],
+    ["C:\\tmp\\key", "C:\\tmp\\key"],
+    ["tab\tand\nnewline", '"tab\\tand\\nnewline"'],
+    ["日本語", "日本語"],
+    ["", '""'],
+    ['"starts with a quote', '"\\"starts with a quote"'],
+    ["'starts with a quote", '"\'starts with a quote"'],
+  ])("serialises %p as %p and tokenises it back", (value, want) => {
+    const serialised = quoteCliToken(value);
+    expect(serialised).toBe(want);
+    expect(ok(serialised)).toEqual([value]);
   });
 });

--- a/admin/app/lib/cli/tokenise.ts
+++ b/admin/app/lib/cli/tokenise.ts
@@ -37,6 +37,29 @@ export type TokeniseResult =
 
 const WHITESPACE = /\s/;
 
+/**
+ * Serialise one token for this grammar without changing its tokenised value.
+ * Bare tokens remain readable whenever possible; tokens requiring protection
+ * are double-quoted with exactly the escape sequences {@link tokenise}
+ * accepts. Generated command paths must use this instead of ad-hoc quoting.
+ */
+export function quoteCliToken(value: string): string {
+  if (
+    value !== "" &&
+    !WHITESPACE.test(value) &&
+    !value.startsWith('"') &&
+    !value.startsWith("'")
+  ) {
+    return value;
+  }
+  return `"${value
+    .replaceAll("\\", "\\\\")
+    .replaceAll('"', '\\"')
+    .replaceAll("\n", "\\n")
+    .replaceAll("\r", "\\r")
+    .replaceAll("\t", "\\t")}"`;
+}
+
 export function tokenise(input: string): TokeniseResult {
   const tokens: string[] = [];
   let i = 0;

--- a/admin/tests/e2e/browse.spec.ts
+++ b/admin/tests/e2e/browse.spec.ts
@@ -31,6 +31,7 @@ async function seed() {
     { key: "e2e:vertex:b", int32: 42 },
     { key: "e2e:vertex:c", bool: true },
     { key: "e2e:other:z", string: "ignored" },
+    { key: "e2e:literal:%2F", string: "literal percent escape" },
     // Content-search corpus (#650). Deliberately rare tokens so a keyword
     // query matches exactly these rows and nothing else on the shared
     // server instance: `zorptangle` in two docs, `quibblefrost` in one.
@@ -106,6 +107,27 @@ test.describe("/vertices", () => {
     await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
     await expect(page.getByTestId("cli-canvas-panel")).toContainText(
       "bfs e2e:vertex:a 2 5",
+    );
+  });
+
+  test("Illuminate handoff preserves a literal percent escape in the row key (#988)", async ({
+    page,
+  }) => {
+    await page.goto("/vertices");
+    await page.getByTestId("vertex-prefix-input").fill("e2e:literal:");
+    const table = page.getByTestId("vertices-table");
+    const illuminate = table.getByRole("button", {
+      name: "Illuminate from e2e:literal:%2F",
+    });
+    await expect(illuminate).toBeVisible();
+    await illuminate.click();
+
+    // Navigation percent-encodes the literal `%` as `%25`; URLSearchParams
+    // decodes it exactly once before the CLI formatter sends the original key
+    // to the server.
+    await expect(page).toHaveURL(/\/cli\?seed=e2e%3Aliteral%3A%252F/);
+    await expect(page.getByTestId("cli-canvas-panel")).toContainText(
+      "bfs e2e:literal:%2F 2 5",
     );
   });
 

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -11,10 +11,16 @@ test.beforeAll(async () => {
   await putVertices([
     { key: "cli:alpha", string: "first" },
     { key: "cli:beta", string: "second" },
+    { key: "cli:quoted key", string: "quoted seed" },
+    { key: "cli:quoted target", string: "reachable only from quoted seed" },
   ]);
   // Edge so bfs / get edge happy-paths in the canvas spec
   // below have something to render.
   await putEdges([{ tail: "cli:alpha", head: "cli:beta", weight: 2 }]);
+  await putEdges([
+    { tail: "cli:alpha", head: "cli:quoted key", weight: 1 },
+    { tail: "cli:quoted key", head: "cli:quoted target", weight: 1 },
+  ]);
 
   // #942 — a barbell so `community <seed>` has a
   // clean cluster to extract. Two tight triangles (internal weight 5,
@@ -141,6 +147,45 @@ test.describe("/cli", () => {
     await expect(page.getByTestId("cli-canvas-panel")).toContainText(
       "bfs cli:alpha 2 5",
     );
+  });
+
+  test("canvas node click quotes an arbitrary key before reaching the RPC (#988)", async ({
+    page,
+  }) => {
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    // One hop exposes the space-containing node but not its unique target.
+    await input.fill("bfs cli:alpha 1 5");
+    await input.press("Enter");
+    const panel = page.getByTestId("cli-canvas-panel");
+    await expect(panel).toBeVisible();
+
+    const clicked = await page.evaluate(() => {
+      const win = window as Window & {
+        __illuminateCanvas?: { clickNode: (key: string) => boolean };
+      };
+      return win.__illuminateCanvas?.clickNode("cli:quoted key") ?? false;
+    });
+    expect(clicked).toBe(true);
+
+    // The source records the exact command submitted by the canvas callback;
+    // the depth-two-only target proves the RPC received `cli:quoted key`, not
+    // the two tokens that an unquoted space would have produced.
+    await expect(panel).toContainText('bfs "cli:quoted key" 2 5');
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const win = window as Window & {
+            __illuminateCanvas?: {
+              getNodePosition: (key: string) => unknown;
+            };
+          };
+          return (
+            win.__illuminateCanvas?.getNodePosition("cli:quoted target") != null
+          );
+        }),
+      )
+      .toBe(true);
   });
 
   // #942 — the `community` verb must reach the LocalCommunity (#845)


### PR DESCRIPTION
## Summary
- serialize generated traversal commands through a shared token quoting helper
- preserve arbitrary vertex keys across Browse handoff and canvas interactions
- add unit and Playwright coverage for whitespace and percent-escaped keys

## Validation
- all Go module tests, `go vet`, and new-diff `golangci-lint`
- Node SDK build, typecheck, lint, format check, and tests
- Admin typecheck, lint, format check, unit tests, and production build
- `playwright test cli.spec.ts browse.spec.ts` (41 passed)

Closes #988