### PR TITLE
feat(observability): retain traversal labels on failures

### DIFF
--- a/admin/app/lib/client/usecase/ops/metrics/catalog.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/catalog.ts
@@ -130,6 +130,21 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
     ],
   },
   {
+    id: "traversal-outcomes",
+    group: "throughput",
+    title: "Illuminate outcomes",
+    description:
+      "Successful, failed, and timed-out traversals by family, phase, and Connect code.",
+    unit: "rate",
+    queries: [
+      {
+        expr: "rate(lantern_illuminate_calls_total[$__rate])",
+        by: ["algorithm", "phase", "code"],
+        legend: "{{algorithm}} · {{phase}} · {{code}}",
+      },
+    ],
+  },
+  {
     id: "rpc-latency",
     group: "latency",
     title: "RPC latency (p50 / p99)",

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -105,6 +105,7 @@ type DomainMetrics struct {
 	illuminateVisitedVertices *prometheus.HistogramVec
 	illuminateVisitedEdges    *prometheus.HistogramVec
 	illuminateDuration        *prometheus.HistogramVec
+	illuminateCalls           *prometheus.CounterVec
 	scanResults               *prometheus.HistogramVec
 	scanDuration              *prometheus.HistogramVec
 	batchSize                 *prometheus.HistogramVec
@@ -187,12 +188,14 @@ type DomainMetrics struct {
 // added in proto without a metrics update) fall through to "unknown"
 // so a new variant cannot break label pre-warming on existing dashboards.
 var (
-	algorithmLabels  = []string{"bfs", "ppr", "community"}
-	reductionLabels  = []string{"none", "mst", "spt"}
-	objectiveLabels  = []string{"minimize", "maximize"}
-	weightingLabels  = []string{"raw", "tfidf", "bm25"}
-	illuminatePhases = []string{"traversal", "optimize"}
-	scanOps          = []string{
+	algorithmLabels        = []string{"bfs", "ppr", "community"}
+	reductionLabels        = []string{"none", "mst", "spt"}
+	objectiveLabels        = []string{"minimize", "maximize"}
+	weightingLabels        = []string{"raw", "tfidf", "bm25"}
+	illuminatePhases       = []string{"traversal", "optimize"}
+	illuminateResultPhases = []string{"validation", "traversal", "reduction", "response", "complete"}
+	illuminateCodes        = []string{"ok", "canceled", "deadline_exceeded", "invalid_argument", "failed_precondition", "resource_exhausted", "internal", "unknown"}
+	scanOps                = []string{
 		"ScanVertices",
 		"ScanVertexKeys",
 		"ScanEdges",
@@ -359,6 +362,10 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 			Help:    "Wall-clock duration of Illuminate, partitioned by traversal family (algorithm) + reduction + objective + edge weighting and phase (traversal | optimize). #410, #963.",
 			Buckets: prometheus.ExponentialBuckets(0.0001, 4, 8), // 0.1ms .. ~1.6s
 		}, []string{"algorithm", "reduction", "objective", "weighting", "phase"}),
+		illuminateCalls: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "lantern_illuminate_calls_total",
+			Help: "Illuminate calls partitioned by traversal family, reduction, objective, weighting, terminal phase, and Connect code. Includes failures and timeouts (#999).",
+		}, []string{"algorithm", "reduction", "objective", "weighting", "phase", "code"}),
 		scanResults: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "lantern_scan_results",
 			Help:    "Number of results returned by a prefix scan or count RPC, partitioned by op (ScanVertices | ScanVertexKeys | ScanEdges | CountVerticesByPrefix | DeleteVerticesByPrefix | DeleteEdgesByPrefix).",
@@ -491,7 +498,7 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 		m.pubsubQueueDepth, m.pubsubDropped, m.pubsubDispatchDuration,
 		m.replicationApplied, m.replicationDropped, m.replicationLag,
 		m.antiEntropyCycles, m.antiEntropyGapsFound,
-		m.illuminateVisitedVertices, m.illuminateVisitedEdges, m.illuminateDuration,
+		m.illuminateVisitedVertices, m.illuminateVisitedEdges, m.illuminateDuration, m.illuminateCalls,
 		m.scanResults, m.scanDuration, m.batchSize,
 		m.getVertexHits, m.getVertexMisses, m.getEdgeHits, m.getEdgeMisses,
 		m.edgeContribDeduped,
@@ -536,6 +543,11 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 					m.illuminateVisitedEdges.WithLabelValues(algo, red, obj, w)
 					for _, ph := range illuminatePhases {
 						m.illuminateDuration.WithLabelValues(algo, red, obj, w, ph)
+					}
+					for _, ph := range illuminateResultPhases {
+						for _, code := range illuminateCodes {
+							m.illuminateCalls.WithLabelValues(algo, red, obj, w, ph, code)
+						}
 					}
 				}
 			}
@@ -850,6 +862,18 @@ func (m *DomainMetrics) OnIlluminate(algorithm, reduction, objective, weighting 
 	if optimize > 0 {
 		m.illuminateDuration.WithLabelValues(a, r, o, w, "optimize").Observe(optimize.Seconds())
 	}
+}
+
+// OnIlluminateResult records the terminal outcome of every Illuminate call,
+// including failures that return before the success histograms are observed.
+func (m *DomainMetrics) OnIlluminateResult(algorithm, reduction, objective, weighting, phase, code string) {
+	a := sanitizeLabel(algorithm, algorithmLabels, "unknown")
+	r := sanitizeLabel(reduction, reductionLabels, "unknown")
+	o := sanitizeLabel(objective, objectiveLabels, "unknown")
+	w := sanitizeLabel(weighting, weightingLabels, "unknown")
+	p := sanitizeLabel(phase, illuminateResultPhases, "response")
+	c := sanitizeLabel(code, illuminateCodes, "unknown")
+	m.illuminateCalls.WithLabelValues(a, r, o, w, p, c).Inc()
 }
 
 // OnScan records one prefix-scan RPC: result count and wall-clock

--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -198,6 +198,7 @@ func TestDomainMetrics_HotPathFamilies(t *testing.T) {
 
 	m.OnIlluminate("bfs", "mst", "minimize", "raw", 17, 42, 5*time.Millisecond, 2*time.Millisecond)
 	m.OnIlluminate("bfs", "none", "minimize", "raw", 1, 0, 100*time.Microsecond, 0) // optimize=0 → no observation on optimize phase
+	m.OnIlluminateResult("ppr", "none", "maximize", "raw", "traversal", "deadline_exceeded")
 	m.OnScan("ScanVertices", 64, 750*time.Microsecond)
 	m.OnScan("ScanVertexKeys", 32, 500*time.Microsecond)
 	m.OnScan("ScanEdges", 128, time.Millisecond)
@@ -220,6 +221,7 @@ func TestDomainMetrics_HotPathFamilies(t *testing.T) {
 		"lantern_illuminate_visited_vertices",
 		"lantern_illuminate_visited_edges",
 		"lantern_illuminate_duration_seconds",
+		"lantern_illuminate_calls_total",
 		"lantern_scan_results",
 		"lantern_scan_duration_seconds",
 		"lantern_batch_size",
@@ -262,6 +264,9 @@ func TestDomainMetrics_HotPathFamilies(t *testing.T) {
 	// p99 toward zero on RPCs that didn't run an algorithm).
 	if got := histSampleCount(t, m.illuminateDuration.WithLabelValues("bfs", "none", "minimize", "raw", "optimize")); got != 0 {
 		t.Errorf("illuminate_duration{bfs,none,minimize,raw,optimize} sample count = %v, want 0 (optimize=0 must not observe)", got)
+	}
+	if got := testutil.ToFloat64(m.illuminateCalls.WithLabelValues("ppr", "none", "maximize", "raw", "traversal", "deadline_exceeded")); got != 1 {
+		t.Errorf("illuminate_calls_total{ppr,traversal,deadline_exceeded} = %v, want 1", got)
 	}
 
 	for _, op := range scanOps {

--- a/server/provider/connect_middleware.go
+++ b/server/provider/connect_middleware.go
@@ -33,6 +33,10 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 )
 
 // ConnectInterceptor returns a connect.UnaryInterceptorFunc that emits
@@ -50,16 +54,24 @@ import (
 func (s *SlowRPCInterceptor) ConnectInterceptor() connect.UnaryInterceptorFunc {
 	return func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			labels, hasLabels := illuminateTelemetryLabelsFor(req.Any())
+			if hasLabels {
+				setIlluminateSpanAttributes(ctx, labels)
+			}
 			start := time.Now()
 			resp, err := next(ctx, req)
 			d := time.Since(start)
 			if d > s.threshold {
-				s.logger.LogAttrs(ctx, slog.LevelWarn, "slow rpc",
+				attrs := []slog.Attr{
 					slog.String("method", req.Spec().Procedure),
 					slog.String("code", connectCodeString(err)),
 					slog.Int64("duration_ms", d.Milliseconds()),
 					slog.Int64("threshold_ms", s.threshold.Milliseconds()),
-				)
+				}
+				if hasLabels {
+					attrs = append(attrs, labels.slogAttrs()...)
+				}
+				s.logger.LogAttrs(ctx, slog.LevelWarn, "slow rpc", attrs...)
 			}
 			return resp, err
 		}
@@ -91,26 +103,121 @@ func NewLoggingInterceptor(logger *slog.Logger) *LoggingInterceptor {
 // ValidationInterceptor.ConnectInterceptor() so the listener wiring
 // reads uniformly.
 func (l *LoggingInterceptor) ConnectInterceptor() connect.UnaryInterceptorFunc {
-	if l == nil || l.logger == nil {
-		return func(next connect.UnaryFunc) connect.UnaryFunc { return next }
-	}
 	return func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			labels, hasLabels := illuminateTelemetryLabelsFor(req.Any())
+			if hasLabels {
+				setIlluminateSpanAttributes(ctx, labels)
+			}
 			method := req.Spec().Procedure
 			start := time.Now()
-			l.logger.LogAttrs(ctx, slog.LevelInfo, "started call",
-				slog.String("protocol", "connect"),
-				slog.String("grpc.method", method),
-			)
+			if l != nil && l.logger != nil {
+				attrs := []slog.Attr{slog.String("protocol", "connect"), slog.String("grpc.method", method)}
+				if hasLabels {
+					attrs = append(attrs, labels.slogAttrs()...)
+				}
+				l.logger.LogAttrs(ctx, slog.LevelInfo, "started call", attrs...)
+			}
 			resp, err := next(ctx, req)
-			l.logger.LogAttrs(ctx, slog.LevelInfo, "finished call",
-				slog.String("protocol", "connect"),
-				slog.String("grpc.method", method),
-				slog.String("grpc.code", connectCodeString(err)),
-				slog.Int64("grpc.duration_ms", time.Since(start).Milliseconds()),
-			)
+			if l != nil && l.logger != nil {
+				attrs := []slog.Attr{
+					slog.String("protocol", "connect"),
+					slog.String("grpc.method", method),
+					slog.String("grpc.code", connectCodeString(err)),
+					slog.Int64("grpc.duration_ms", time.Since(start).Milliseconds()),
+				}
+				if hasLabels {
+					attrs = append(attrs, labels.slogAttrs()...)
+				}
+				l.logger.LogAttrs(ctx, slog.LevelInfo, "finished call", attrs...)
+			}
 			return resp, err
 		}
+	}
+}
+
+type illuminateTelemetryLabels struct {
+	family, reduction, objective, weighting string
+}
+
+func illuminateTelemetryLabelsFor(message any) (illuminateTelemetryLabels, bool) {
+	req, ok := message.(*pb.IlluminateRequest)
+	if !ok {
+		return illuminateTelemetryLabels{}, false
+	}
+	labels := illuminateTelemetryLabels{
+		family: "unknown", reduction: "none", objective: "maximize", weighting: telemetryWeighting(req.GetWeighting()),
+	}
+	switch params := req.GetParams().(type) {
+	case *pb.IlluminateRequest_Bfs:
+		labels.family = "bfs"
+		if params.Bfs != nil {
+			labels.reduction = telemetryReduction(params.Bfs.GetReduction())
+			labels.objective = telemetryObjective(params.Bfs.GetObjective())
+		}
+	case *pb.IlluminateRequest_Ppr:
+		labels.family = "ppr"
+	case *pb.IlluminateRequest_Community:
+		labels.family = "community"
+		if params.Community != nil {
+			labels.reduction = telemetryReduction(params.Community.GetReduction())
+			labels.objective = telemetryObjective(params.Community.GetObjective())
+		}
+	}
+	return labels, true
+}
+
+func (l illuminateTelemetryLabels) slogAttrs() []slog.Attr {
+	return []slog.Attr{
+		slog.String("illuminate.family", l.family),
+		slog.String("illuminate.reduction", l.reduction),
+		slog.String("illuminate.objective", l.objective),
+		slog.String("illuminate.weighting", l.weighting),
+	}
+}
+
+func setIlluminateSpanAttributes(ctx context.Context, labels illuminateTelemetryLabels) {
+	trace.SpanFromContext(ctx).SetAttributes(
+		attribute.String("lantern.illuminate.family", labels.family),
+		attribute.String("lantern.illuminate.reduction", labels.reduction),
+		attribute.String("lantern.illuminate.objective", labels.objective),
+		attribute.String("lantern.illuminate.weighting", labels.weighting),
+	)
+}
+
+func telemetryReduction(value pb.Reduction) string {
+	switch value {
+	case pb.Reduction_REDUCTION_UNSPECIFIED:
+		return "none"
+	case pb.Reduction_REDUCTION_MINIMUM_SPANNING_TREE:
+		return "mst"
+	case pb.Reduction_REDUCTION_SHORTEST_PATH_TREE:
+		return "spt"
+	default:
+		return "unknown"
+	}
+}
+
+func telemetryObjective(value pb.Objective) string {
+	if value == pb.Objective_OBJECTIVE_MINIMIZE {
+		return "minimize"
+	}
+	if value == pb.Objective_OBJECTIVE_UNSPECIFIED || value == pb.Objective_OBJECTIVE_MAXIMIZE {
+		return "maximize"
+	}
+	return "unknown"
+}
+
+func telemetryWeighting(value pb.Weighting) string {
+	switch value {
+	case pb.Weighting_WEIGHTING_UNSPECIFIED, pb.Weighting_WEIGHTING_RAW:
+		return "raw"
+	case pb.Weighting_WEIGHTING_TFIDF:
+		return "tfidf"
+	case pb.Weighting_WEIGHTING_BM25:
+		return "bm25"
+	default:
+		return "unknown"
 	}
 }
 

--- a/server/provider/slowrpc_test.go
+++ b/server/provider/slowrpc_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 )
@@ -123,5 +125,46 @@ func TestSlowRPCInterceptor_ConnectSilentOnFastHandler(t *testing.T) {
 	}
 	if buf.Len() != 0 {
 		t.Errorf("unexpected log output: %s", buf.String())
+	}
+}
+
+func TestSlowRPCInterceptor_IlluminateFamilyFields(t *testing.T) {
+	var buf bytes.Buffer
+	s := NewSlowRPCInterceptor(time.Nanosecond, newJSONLogger(&buf, slog.LevelWarn))
+	next := connect.UnaryFunc(func(_ context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("bad reduction"))
+	})
+	req := connect.NewRequest(&pb.IlluminateRequest{Params: &pb.IlluminateRequest_Bfs{Bfs: &pb.BfsParams{
+		Step: 1, FanOut: 1, Reduction: pb.Reduction_REDUCTION_SHORTEST_PATH_TREE,
+	}}})
+	_, _ = s.ConnectInterceptor()(next)(context.Background(), req)
+	recs := decodeRecords(t, &buf)
+	if len(recs) != 1 || recs[0]["illuminate.family"] != "bfs" || recs[0]["illuminate.reduction"] != "spt" {
+		t.Fatalf("slow Illuminate fields = %+v, want family=bfs reduction=spt", recs)
+	}
+}
+
+func TestLoggingInterceptor_IlluminateSpanAttributes(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := trace.NewTracerProvider(trace.WithSpanProcessor(recorder))
+	ctx, span := provider.Tracer("test").Start(context.Background(), "Illuminate")
+	next := connect.UnaryFunc(func(_ context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+		return connect.NewResponse(&pb.IlluminateResponse{}), nil
+	})
+	req := connect.NewRequest(&pb.IlluminateRequest{Params: &pb.IlluminateRequest_Ppr{Ppr: &pb.PprParams{TopN: 2}}})
+	if _, err := NewLoggingInterceptor(nil).ConnectInterceptor()(next)(ctx, req); err != nil {
+		t.Fatalf("interceptor: %v", err)
+	}
+	span.End()
+	ended := recorder.Ended()
+	if len(ended) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(ended))
+	}
+	attrs := map[string]string{}
+	for _, attr := range ended[0].Attributes() {
+		attrs[string(attr.Key)] = attr.Value.AsString()
+	}
+	if attrs["lantern.illuminate.family"] != "ppr" || attrs["lantern.illuminate.reduction"] != "none" {
+		t.Fatalf("Illuminate span attributes = %+v", attrs)
 	}
 }

--- a/server/service/optimizer.go
+++ b/server/service/optimizer.go
@@ -138,6 +138,33 @@ func weightingLabel(w pb.Weighting) string {
 	return "unknown"
 }
 
+// illuminateMetricLabels resolves the bounded family axes before execution so
+// failures and timeouts retain the same attribution as successful calls.
+func illuminateMetricLabels(request *pb.IlluminateRequest) (algorithm, reduction, objective, weighting string) {
+	algorithm, reduction, objective = "unknown", "none", "maximize"
+	if request == nil {
+		return algorithm, reduction, objective, "raw"
+	}
+	weighting = weightingLabel(request.GetWeighting())
+	switch params := request.GetParams().(type) {
+	case *pb.IlluminateRequest_Bfs:
+		algorithm = "bfs"
+		if params.Bfs != nil {
+			reduction = reductionLabel(params.Bfs.GetReduction())
+			objective = objectiveLabel(params.Bfs.GetObjective())
+		}
+	case *pb.IlluminateRequest_Ppr:
+		algorithm, reduction, objective = "ppr", "none", "maximize"
+	case *pb.IlluminateRequest_Community:
+		algorithm = "community"
+		if params.Community != nil {
+			reduction = reductionLabel(params.Community.GetReduction())
+			objective = objectiveLabel(params.Community.GetObjective())
+		}
+	}
+	return algorithm, reduction, objective, weighting
+}
+
 // weightingToCore maps the wire weighting axis to the core edge-weight
 // transform. UNSPECIFIED/RAW collapse to the verbatim weight; an unknown
 // future enum value also falls back to RAW so a proto-only addition never

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -86,6 +86,7 @@ type LanternService struct {
 // Implementations must be safe for concurrent use.
 type HotPathMetrics interface {
 	OnIlluminate(algorithm, reduction, objective, weighting string, visitedVertices, visitedEdges int, traversal, optimize time.Duration)
+	OnIlluminateResult(algorithm, reduction, objective, weighting, phase, code string)
 	OnScan(op string, results int, duration time.Duration)
 	OnSearch(results int, duration time.Duration)
 	OnBatch(op string, size int)
@@ -97,6 +98,8 @@ type HotPathMetrics interface {
 type noopHotPathMetrics struct{}
 
 func (noopHotPathMetrics) OnIlluminate(string, string, string, string, int, int, time.Duration, time.Duration) {
+}
+func (noopHotPathMetrics) OnIlluminateResult(string, string, string, string, string, string) {
 }
 func (noopHotPathMetrics) OnScan(string, int, time.Duration) {}
 func (noopHotPathMetrics) OnSearch(int, time.Duration)       {}
@@ -521,7 +524,17 @@ func (s *LanternService) logMutationAt(op *pb.MutationOp, ts hlc.Timestamp) uint
 // walk. Edge weighting (RAW vs TF-IDF) is applied BEFORE the walk and
 // therefore feeds into both the frontier ranking and any subsequent
 // reduction. See #410, #963.
-func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateRequest) (*pb.IlluminateResponse, error) {
+func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateRequest) (_ *pb.IlluminateResponse, retErr error) {
+	algoLabel, redLabel, objLabel, weightLabel := illuminateMetricLabels(request)
+	phase := "validation"
+	defer func() {
+		code := "ok"
+		if retErr != nil {
+			code = connect.CodeOf(retErr).String()
+		}
+		s.metrics.OnIlluminateResult(algoLabel, redLabel, objLabel, weightLabel, phase, code)
+	}()
+
 	if err := ctx.Err(); err != nil {
 		return nil, ctxToConnect(err)
 	}
@@ -559,9 +572,6 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 		traversalDur time.Duration
 		optimizeDur  time.Duration
 		err          error
-		algoLabel    string
-		redLabel     string
-		objLabel     string
 	)
 
 	// Dispatch on the params oneof (#846): the selected case IS the traversal
@@ -593,13 +603,14 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 			return nil, limitErr
 		}
 		alpha, epsilon := resolvePPRParams(ppr.GetRestartProb(), ppr.GetEpsilon())
+		phase = "traversal"
 		traversalStart := time.Now()
 		g, err = s.cache.PersonalizedPageRankWithWorkBudgetContext(ctx, request.GetSeed(), topN, alpha, epsilon, coreWeighting, keep, s.traversalWorkBudget)
 		traversalDur = time.Since(traversalStart)
 		if err != nil {
 			return nil, traversalToConnect(err)
 		}
-		algoLabel, redLabel, objLabel = "ppr", "none", "maximize"
+		phase = "response"
 
 	case *pb.IlluminateRequest_Community:
 		if params.Community == nil {
@@ -621,13 +632,16 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 			return nil, limitErr
 		}
 		alpha, epsilon := resolvePPRParams(comm.GetRestartProb(), comm.GetEpsilon())
+		phase = "traversal"
 		traversalStart := time.Now()
 		g, expirations, err = s.cache.LocalCommunityWithWorkBudgetContext(ctx, request.GetSeed(), maxSize, alpha, epsilon, coreWeighting, keep, s.traversalWorkBudget)
 		traversalDur = time.Since(traversalStart)
 		if err != nil {
 			return nil, traversalToConnect(err)
 		}
+		phase = "response"
 		if opt := resolveOptimizer(comm.GetReduction(), comm.GetObjective()); opt != nil {
+			phase = "reduction"
 			optStart := time.Now()
 			reduced, rerr := opt(ctx, g, request.GetSeed())
 			if rerr != nil {
@@ -658,8 +672,8 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 			}
 			expirations = trimmed
 			optimizeDur = time.Since(optStart)
+			phase = "response"
 		}
-		algoLabel, redLabel, objLabel = "community", reductionLabel(comm.GetReduction()), objectiveLabel(comm.GetObjective())
 
 	case *pb.IlluminateRequest_Bfs:
 		if params.Bfs == nil {
@@ -676,22 +690,25 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 		// UNSPECIFIED resolves to MAXIMIZE (strongest edges).
 		objective := bfs.GetObjective()
 		selectSmallest := objective == pb.Objective_OBJECTIVE_MINIMIZE
+		phase = "traversal"
 		traversalStart := time.Now()
 		g, expirations, err = s.cache.NeighborWithExpirationsContext(ctx, request.GetSeed(), int(bfs.GetStep()), int(bfs.GetFanOut()), coreWeighting, selectSmallest, keep)
 		traversalDur = time.Since(traversalStart)
 		if err != nil {
 			return nil, ctxToConnect(err)
 		}
+		phase = "response"
 
 		if opt := resolveOptimizer(bfs.GetReduction(), objective); opt != nil {
+			phase = "reduction"
 			optStart := time.Now()
 			g, err = opt(ctx, g, request.GetSeed())
 			optimizeDur = time.Since(optStart)
 			if err != nil {
 				return nil, optimizerToConnect(err)
 			}
+			phase = "response"
 		}
-		algoLabel, redLabel, objLabel = "bfs", reductionLabel(bfs.GetReduction()), objectiveLabel(objective)
 	default:
 		return nil, invalidIlluminateParams("unknown traversal family")
 	}
@@ -723,7 +740,8 @@ func (s *LanternService) Illuminate(ctx context.Context, request *pb.IlluminateR
 		}
 	}
 
-	s.metrics.OnIlluminate(algoLabel, redLabel, objLabel, weightingLabel(weighting), len(vertices), edgeCount, traversalDur, optimizeDur)
+	s.metrics.OnIlluminate(algoLabel, redLabel, objLabel, weightLabel, len(vertices), edgeCount, traversalDur, optimizeDur)
+	phase = "complete"
 
 	return &pb.IlluminateResponse{
 		Graph: &pb.Graph{Vertices: vertices, Edges: edges},

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -1418,6 +1418,7 @@ func itoa(i int) string {
 // the service-layer instrumentation hooks fire on the right callbacks.
 type fakeHotPathMetrics struct {
 	illuminate []illuminateObs
+	results    []illuminateResultObs
 	scan       []scanObs
 	search     []searchObs
 	batch      []batchObs
@@ -1430,6 +1431,10 @@ type illuminateObs struct {
 	algorithm, reduction, objective, weighting string
 	visitedVertices, visitedEdges              int
 	traversal, optimize                        time.Duration
+}
+
+type illuminateResultObs struct {
+	algorithm, reduction, objective, weighting, phase, code string
 }
 
 type scanObs struct {
@@ -1455,6 +1460,9 @@ type hitMissObs struct {
 
 func (f *fakeHotPathMetrics) OnIlluminate(algorithm, reduction, objective, weighting string, vV, vE int, traversal, optimize time.Duration) {
 	f.illuminate = append(f.illuminate, illuminateObs{algorithm, reduction, objective, weighting, vV, vE, traversal, optimize})
+}
+func (f *fakeHotPathMetrics) OnIlluminateResult(algorithm, reduction, objective, weighting, phase, code string) {
+	f.results = append(f.results, illuminateResultObs{algorithm, reduction, objective, weighting, phase, code})
 }
 func (f *fakeHotPathMetrics) OnScan(op string, results int, d time.Duration) {
 	f.scan = append(f.scan, scanObs{op, results, d})
@@ -1526,6 +1534,9 @@ func TestLanternService_HotPathMetrics_EmitsOnceForBatchAndIlluminate(t *testing
 	}
 	if got := fm.illuminate[0]; got.algorithm != "bfs" || got.reduction != "mst" || got.objective != "minimize" || got.weighting != "raw" || got.visitedVertices < 1 {
 		t.Errorf("illuminate[0] = %+v, want algorithm=bfs reduction=mst objective=minimize weighting=raw visitedVertices≥1", got)
+	}
+	if len(fm.results) != 1 || fm.results[0].phase != "complete" || fm.results[0].code != "ok" {
+		t.Fatalf("illuminate result observations = %+v, want one complete/ok", fm.results)
 	}
 
 	// Singular forwarders must NOT double-instrument: GetVertex forwards

--- a/tests/integration/illuminate_metrics_test.go
+++ b/tests/integration/illuminate_metrics_test.go
@@ -1,8 +1,10 @@
 package integration_test
 
 import (
+	"bytes"
 	"context"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -10,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
@@ -124,6 +127,85 @@ func TestLantern_Illuminate_MetricReductionLabel(t *testing.T) {
 		"algorithm": "ppr", "reduction": "none", "objective": "maximize", "weighting": "raw",
 	}); !ok || got < 1 {
 		t.Errorf("%s{algorithm=ppr,reduction=none,objective=maximize,weighting=raw} = %v (present=%v), want ≥1", vertsCount, got, ok)
+	}
+}
+
+func TestLantern_Illuminate_FailureObservability(t *testing.T) {
+	t.Run("PPR timeout retains family and traversal phase", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		m := metrics.New(reg, metrics.Options{SampleInterval: time.Hour})
+		cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+		svc := service.NewLanternService(cache).
+			WithHotPathMetrics(m).
+			WithTraversalTimeout(time.Nanosecond)
+		var logs bytes.Buffer
+		slow := provider.NewSlowRPCInterceptor(time.Nanosecond, slog.New(slog.NewJSONHandler(&logs, nil)))
+		val := provider.NewValidationInterceptor(defaultIntegrationValidationLimits())
+		srv := newConnectTestServer(t, svc, nil, val.ConnectInterceptor(), slow.ConnectInterceptor())
+		l := newConnectClientFor(t, srv.url)
+		scrape := httptest.NewServer(promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+		t.Cleanup(scrape.Close)
+
+		_, err := l.Illuminate(context.Background(), "seed", client.WithPPR(client.PPROpts{TopN: 4}))
+		if connect.CodeOf(err) != connect.CodeDeadlineExceeded {
+			t.Fatalf("PPR error code = %v, want deadline_exceeded: %v", connect.CodeOf(err), err)
+		}
+		body := scrapeMetrics(t, scrape.URL)
+		if got, ok := metricSeriesValue(t, body, "lantern_illuminate_calls_total", map[string]string{
+			"algorithm": "ppr", "reduction": "none", "objective": "maximize", "weighting": "raw", "phase": "traversal", "code": "deadline_exceeded",
+		}); !ok || got != 1 {
+			t.Fatalf("PPR timeout outcome = %v (present=%v), want 1", got, ok)
+		}
+		assertIlluminateSlowLog(t, logs.String(), "ppr", "none")
+	})
+
+	t.Run("BFS reduction failure retains reduction and code", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		m := metrics.New(reg, metrics.Options{SampleInterval: time.Hour})
+		cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+		svc := service.NewLanternService(cache).WithHotPathMetrics(m)
+		var logs bytes.Buffer
+		slow := provider.NewSlowRPCInterceptor(time.Nanosecond, slog.New(slog.NewJSONHandler(&logs, nil)))
+		val := provider.NewValidationInterceptor(defaultIntegrationValidationLimits())
+		srv := newConnectTestServer(t, svc, nil, val.ConnectInterceptor(), slow.ConnectInterceptor())
+		l := newConnectClientFor(t, srv.url)
+		scrape := httptest.NewServer(promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+		t.Cleanup(scrape.Close)
+
+		for _, key := range []string{"seed", "negative"} {
+			if err := l.PutVertex(context.Background(), key, key, time.Minute); err != nil {
+				t.Fatalf("PutVertex %s: %v", key, err)
+			}
+		}
+		if err := l.PutEdge(context.Background(), "seed", "negative", -1, time.Minute); err != nil {
+			t.Fatalf("PutEdge negative: %v", err)
+		}
+		_, err := l.Illuminate(context.Background(), "seed", client.WithBFS(client.BFSOpts{
+			Step: 1, FanOut: 4, Reduction: client.ReductionShortestPathTree, Objective: client.ObjectiveMinimize,
+		}))
+		if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+			t.Fatalf("BFS reduction error code = %v, want failed_precondition: %v", connect.CodeOf(err), err)
+		}
+		body := scrapeMetrics(t, scrape.URL)
+		if got, ok := metricSeriesValue(t, body, "lantern_illuminate_calls_total", map[string]string{
+			"algorithm": "bfs", "reduction": "spt", "objective": "minimize", "weighting": "raw", "phase": "reduction", "code": "failed_precondition",
+		}); !ok || got != 1 {
+			t.Fatalf("BFS reduction outcome = %v (present=%v), want 1", got, ok)
+		}
+		assertIlluminateSlowLog(t, logs.String(), "bfs", "spt")
+	})
+}
+
+func assertIlluminateSlowLog(t *testing.T, logs, family, reduction string) {
+	t.Helper()
+	for _, want := range []string{
+		`"msg":"slow rpc"`,
+		`"illuminate.family":"` + family + `"`,
+		`"illuminate.reduction":"` + reduction + `"`,
+	} {
+		if !strings.Contains(logs, want) {
+			t.Fatalf("slow log missing %q: %s", want, logs)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- record `lantern_illuminate_calls_total` with family and traversal-axis labels for both success and failure
- preserve family labels across validation errors, timeouts, spans, and slow-RPC logging
- add an Admin Ops panel plus real h2c integration coverage for PPR timeout and SPT validation failure

## Validation
- all Go module tests, `go vet`, and new-diff `golangci-lint`
- Node SDK build, typecheck, lint, format check, and tests
- Admin typecheck, lint, format check, unit tests, and production build

Closes #999