### PR TITLE
test(traversal): complete the family coverage matrix

### DIFF
--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -11,13 +11,15 @@ test.beforeAll(async () => {
   await putVertices([
     { key: "cli:alpha", string: "first" },
     { key: "cli:beta", string: "second" },
+    { key: "cli:gamma", string: "third" },
     { key: "cli:quoted key", string: "quoted seed" },
     { key: "cli:quoted target", string: "reachable only from quoted seed" },
   ]);
   // Edge so bfs / get edge happy-paths in the canvas spec
   // below have something to render.
-  await putEdges([{ tail: "cli:alpha", head: "cli:beta", weight: 2 }]);
   await putEdges([
+    { tail: "cli:alpha", head: "cli:beta", weight: 2 },
+    { tail: "cli:beta", head: "cli:gamma", weight: 1 },
     { tail: "cli:alpha", head: "cli:quoted key", weight: 1 },
     { tail: "cli:quoted key", head: "cli:quoted target", weight: 1 },
   ]);
@@ -186,6 +188,33 @@ test.describe("/cli", () => {
         }),
       )
       .toBe(true);
+  });
+
+  // #997 — Admin must dispatch the typed PPR arm over the real Connect path,
+  // not reuse BFS. The graph contains a second-hop beta→gamma edge: a
+  // breadth walk retains it, whereas PPR renders only seed-ranked star edges.
+  test("pagerank renders a seed star, not a BFS subgraph (#997)", async ({
+    page,
+  }) => {
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    await input.fill("pagerank cli:alpha 10 restart_prob=0.25 epsilon=0.001");
+    await input.press("Enter");
+    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
+
+    type CanvasBridge = { hasEdge: (key: string) => boolean };
+    await page.waitForFunction(() => {
+      const win = window as Window & { __illuminateCanvas?: CanvasBridge };
+      return !!win.__illuminateCanvas?.hasEdge;
+    });
+    const hasEdge = (key: string): Promise<boolean> =>
+      page.evaluate((edgeKey) => {
+        const win = window as Window & { __illuminateCanvas?: CanvasBridge };
+        return win.__illuminateCanvas?.hasEdge(edgeKey) ?? false;
+      }, key);
+
+    await expect.poll(() => hasEdge("cli:alpha→cli:beta")).toBe(true);
+    expect(await hasEdge("cli:beta→cli:gamma")).toBe(false);
   });
 
   // #942 — the `community` verb must reach the LocalCommunity (#845)

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -417,8 +417,9 @@ func TestWithWeightingWiring(t *testing.T) {
 // TestIlluminateParamsWiring verifies the #846 typed per-family options
 // marshal to the intended oneof arm: exactly one family is required;
 // WithBFS ⇒ the bfs arm with its four knobs; WithPPR ⇒ the ppr arm with its
-// three knobs; conflicting selections and zero BFS dimensions fail locally
-// without sending an ambiguous wire request.
+// three knobs; WithLocalCommunity ⇒ the community arm plus every shared axis;
+// conflicting selections and zero BFS dimensions fail locally without sending
+// an ambiguous wire request.
 func TestIlluminateParamsWiring(t *testing.T) {
 	newClient := func(t *testing.T) (*Lantern, *captureIlluminate) {
 		t.Helper()
@@ -475,6 +476,36 @@ func TestIlluminateParamsWiring(t *testing.T) {
 		}
 		if ppr.GetTopN() != 10 || ppr.GetRestartProb() != 0.25 || ppr.GetEpsilon() != 1e-3 {
 			t.Fatalf("ppr knobs = (%d,%v,%v), want (10,0.25,1e-3)", ppr.GetTopN(), ppr.GetRestartProb(), ppr.GetEpsilon())
+		}
+	})
+
+	t.Run("WithLocalCommunity marshals its arm and shared axes", func(t *testing.T) {
+		l, capt := newClient(t)
+		if _, err := l.Illuminate(context.Background(), "seed",
+			WithLocalCommunity(LocalCommunityOpts{
+				MaxSize:     17,
+				RestartProb: 0.25,
+				Epsilon:     1e-3,
+				Reduction:   ReductionMinimumSpanningTree,
+				Objective:   ObjectiveMinimize,
+			}),
+			WithWeighting(WeightingBM25),
+			WithVertexPrefix("team:"),
+		); err != nil {
+			t.Fatalf("Illuminate: %v", err)
+		}
+		community := capt.reqs[0].GetCommunity()
+		if community == nil {
+			t.Fatalf("community arm not set; params = %T", capt.reqs[0].GetParams())
+		}
+		if community.GetMaxSize() != 17 || community.GetRestartProb() != 0.25 || community.GetEpsilon() != 1e-3 {
+			t.Fatalf("community knobs = (%d,%v,%v), want (17,0.25,1e-3)", community.GetMaxSize(), community.GetRestartProb(), community.GetEpsilon())
+		}
+		if community.GetReduction() != ReductionMinimumSpanningTree || community.GetObjective() != ObjectiveMinimize {
+			t.Fatalf("community reduction/objective = (%v,%v)", community.GetReduction(), community.GetObjective())
+		}
+		if capt.reqs[0].GetWeighting() != WeightingBM25 || capt.reqs[0].GetVertexPrefix() != "team:" {
+			t.Fatalf("shared axes = weighting=%v prefix=%q", capt.reqs[0].GetWeighting(), capt.reqs[0].GetVertexPrefix())
 		}
 	})
 

--- a/testbed/SKILL.md
+++ b/testbed/SKILL.md
@@ -21,7 +21,7 @@ testbed/
 ├── prometheus.yml          # 5s scrape against lantern:9090
 ├── scripts/
 │   ├── exercise-cli.sh     # 39 CLI scenarios; per-step rc + log capture
-│   ├── exercise-sdk.go     # 39 SDK scenarios; uses workspace replace
+│   ├── exercise-sdk.go     # 42 SDK scenarios; uses workspace replace
 │   └── query-metrics.sh    # curl /metrics → json snapshots
 └── out/                    # gitignored — logs, metric snapshots, reports
 ```
@@ -67,7 +67,7 @@ docker compose down -v
 - `exercise-cli.sh`: 39 logs in `out/cli/`. Exactly three may exit non-zero
   (the deliberate `NotFound` checks: `vertex-get-missing`, `edge-get-missing`,
   `vertex-get-ephem-expired`). Anything else is a regression.
-- `exercise-sdk.go`: prints `ok` for all 39 steps, ending with
+- `exercise-sdk.go`: prints `ok` for all 42 steps, ending with
   `SDK report written to .../out/sdk/report.txt`.
 - `lantern_build_info` reports the real release tag/commit (post-[#99][p99]).
   If it still shows `version="(devel)"`, you're running a pre-#99 build.

--- a/testbed/scripts/exercise-sdk.go
+++ b/testbed/scripts/exercise-sdk.go
@@ -356,7 +356,7 @@ func run() error {
 		return nil
 	})
 
-	// ---- Illuminate every Optimization ------------------------------
+	// ---- Illuminate every family and optimization -------------------
 	// Re-build a small graph: alice -> bob (0.9), alice -> carol (0.1), bob -> dave (0.8), carol -> dave (0.2)
 	step("seed illuminate graph", func() error {
 		now := time.Now().Add(5 * time.Minute)
@@ -409,6 +409,36 @@ func run() error {
 		}
 		if len(g.Vertices) == 0 {
 			return fmt.Errorf("empty vertex set")
+		}
+		return nil
+	})
+	step("Illuminate PPR tuned", func() error {
+		g, err := lc.Illuminate(ctx, "ill:alice", client.WithPPR(client.PPROpts{
+			TopN:        2,
+			RestartProb: 0.25,
+			Epsilon:     1e-3,
+		}), client.WithWeighting(client.WeightingBM25))
+		if err != nil {
+			return err
+		}
+		if len(g.Edges["ill:alice"]) == 0 || len(g.Edges) != 1 {
+			return fmt.Errorf("want non-empty PPR seed star, got %+v", g.Edges)
+		}
+		return nil
+	})
+	step("Illuminate community tuned + reduction", func() error {
+		g, err := lc.Illuminate(ctx, "ill:alice", client.WithLocalCommunity(client.LocalCommunityOpts{
+			MaxSize:     4,
+			RestartProb: 0.25,
+			Epsilon:     1e-3,
+			Reduction:   client.ReductionMinimumSpanningTree,
+			Objective:   client.ObjectiveMinimize,
+		}))
+		if err != nil {
+			return err
+		}
+		if len(g.Vertices) == 0 || len(g.Edges) == 0 {
+			return fmt.Errorf("want non-empty reduced community, got vertices=%d edges=%v", len(g.Vertices), g.Edges)
 		}
 		return nil
 	})

--- a/tests/integration/cli_family_verbs_test.go
+++ b/tests/integration/cli_family_verbs_test.go
@@ -3,7 +3,10 @@ package integration_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -31,7 +34,7 @@ func TestCLI_FamilyVerbs_RealWire(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	for _, k := range []string{"a", "b", "c"} {
+	for _, k := range []string{"a", "b", "c", "cm:a1", "cm:a2", "cm:a3", "cm:b1", "cm:b2", "cm:b3"} {
 		if err := l.PutVertex(ctx, k, k, time.Minute); err != nil {
 			t.Fatalf("PutVertex %s: %v", k, err)
 		}
@@ -41,6 +44,20 @@ func TestCLI_FamilyVerbs_RealWire(t *testing.T) {
 	}
 	if err := l.PutEdge(ctx, "b", "c", 1, time.Minute); err != nil {
 		t.Fatalf("PutEdge b->c: %v", err)
+	}
+	for _, pair := range [][2]string{
+		{"cm:a1", "cm:a2"}, {"cm:a2", "cm:a1"}, {"cm:a2", "cm:a3"}, {"cm:a3", "cm:a2"}, {"cm:a1", "cm:a3"}, {"cm:a3", "cm:a1"},
+		{"cm:b1", "cm:b2"}, {"cm:b2", "cm:b1"}, {"cm:b2", "cm:b3"}, {"cm:b3", "cm:b2"}, {"cm:b1", "cm:b3"}, {"cm:b3", "cm:b1"},
+	} {
+		if err := l.PutEdge(ctx, pair[0], pair[1], 5, time.Minute); err != nil {
+			t.Fatalf("PutEdge %s->%s: %v", pair[0], pair[1], err)
+		}
+	}
+	if err := l.PutEdge(ctx, "cm:a1", "cm:b1", 0.1, time.Minute); err != nil {
+		t.Fatalf("PutEdge cm:a1->cm:b1: %v", err)
+	}
+	if err := l.PutEdge(ctx, "cm:b1", "cm:a1", 0.1, time.Minute); err != nil {
+		t.Fatalf("PutEdge cm:b1->cm:a1: %v", err)
 	}
 
 	svc := cliservice.NewCLIService(l)
@@ -62,6 +79,33 @@ func TestCLI_FamilyVerbs_RealWire(t *testing.T) {
 		if err := svc.RunArgs(ctx, args); err != nil {
 			t.Errorf("RunArgs(%v) = %v, want nil", args, err)
 		}
+	}
+
+	// Family-specific result shapes are an external contract, not just a
+	// no-error condition: BFS keeps traversal edges, PPR returns a seed-star,
+	// and community plus reduction returns its induced cluster as a tree.
+	bfs := runCLIForGraph(t, svc, ctx, []string{"bfs", "a", "3", "10"})
+	if _, ok := bfs.Edges["b"]["c"]; !ok {
+		t.Fatalf("BFS must retain traversal edge b->c, got %+v", bfs.Edges)
+	}
+	ppr := runCLIForGraph(t, svc, ctx, []string{"pagerank", "a", "2", "restart_prob=0.25", "epsilon=0.001"})
+	if len(ppr.Edges) != 1 || ppr.Edges["a"] == nil {
+		t.Fatalf("PPR must return a seed-star, got %+v", ppr.Edges)
+	}
+	if _, ok := ppr.Edges["b"]; ok {
+		t.Fatalf("PPR must not retain BFS edge b->c, got %+v", ppr.Edges)
+	}
+	community := runCLIForGraph(t, svc, ctx, []string{"community", "cm:a1", "3", "restart_prob=0.25", "epsilon=0.001", "reduction=mst"})
+	for _, key := range []string{"cm:a1", "cm:a2", "cm:a3"} {
+		if _, ok := community.Vertices[key]; !ok {
+			t.Fatalf("community result missing %q: %+v", key, community.Vertices)
+		}
+	}
+	if _, ok := community.Vertices["cm:b1"]; ok {
+		t.Fatalf("community crossed weak bridge: %+v", community.Vertices)
+	}
+	if got := graphEdgeCount(community); got != 2 {
+		t.Fatalf("reduced 3-member community edge count = %d, want 2: %+v", got, community.Edges)
 	}
 
 	// Grammar failure contract: pagerank has no reduction axis (#975), so the
@@ -229,4 +273,47 @@ func runLanternCLI(t *testing.T, binary, endpoint string, args ...string) (stdou
 		t.Fatalf("run lantern-cli %v: %v", args, err)
 	}
 	return stdoutBuffer.String(), stderrBuffer.String(), exitErr.ExitCode()
+}
+
+// runCLIForGraph captures the CLI's JSON output while retaining the real
+// Connect/h2c request underneath. Integration tests in this package are not
+// parallel, so temporarily redirecting process stdout is safe here.
+type cliGraph struct {
+	Vertices map[string]json.RawMessage    `json:"vertices"`
+	Edges    map[string]map[string]float32 `json:"edges"`
+}
+
+func runCLIForGraph(t *testing.T, svc *cliservice.CLIService, ctx context.Context, args []string) *cliGraph {
+	t.Helper()
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	previous := os.Stdout
+	os.Stdout = write
+	err = svc.RunArgs(ctx, args)
+	_ = write.Close()
+	os.Stdout = previous
+	if err != nil {
+		_ = read.Close()
+		t.Fatalf("RunArgs(%v): %v", args, err)
+	}
+	output, readErr := io.ReadAll(read)
+	_ = read.Close()
+	if readErr != nil {
+		t.Fatalf("read CLI output: %v", readErr)
+	}
+	var graph cliGraph
+	if err := json.Unmarshal(output, &graph); err != nil {
+		t.Fatalf("decode CLI output %q: %v", output, err)
+	}
+	return &graph
+}
+
+func graphEdgeCount(graph *cliGraph) int {
+	count := 0
+	for _, heads := range graph.Edges {
+		count += len(heads)
+	}
+	return count
 }


### PR DESCRIPTION
## Summary
- verify all three Go SDK family option arms, including community shared axes and conflict combinations
- assert real CLI/Connect result-shape differences for BFS, PPR, and local community
- extend testbed exercise coverage and add Admin Playwright proof that pagerank renders a seed-star rather than a BFS subgraph

## Validation
- all Go module tests, `go vet`, and new-diff `golangci-lint`
- Node SDK build, typecheck, lint, format check, and tests
- Admin typecheck, lint, format check, unit tests, and production build
- `playwright test cli.spec.ts` (30 passed after merging #988/#995 fixtures)

Closes #997