### PR TITLE
refactor(admin): model traversal controls per family

### DIFF
--- a/admin/app/components/cli/CliAxisPicker/CliAxisPicker.tsx
+++ b/admin/app/components/cli/CliAxisPicker/CliAxisPicker.tsx
@@ -8,16 +8,23 @@ import {
 import { useCallback, useEffect, useState } from "react";
 import {
   CLI_ALGORITHMS,
-  CLI_CLICK_K_MAX,
-  CLI_CLICK_K_MIN,
-  CLI_CLICK_STEP_MAX,
-  CLI_CLICK_STEP_MIN,
+  CLI_CLICK_BFS_FAN_OUT_MAX,
+  CLI_CLICK_BFS_FAN_OUT_MIN,
+  CLI_CLICK_BFS_STEP_MAX,
+  CLI_CLICK_BFS_STEP_MIN,
+  CLI_CLICK_MAX_SIZE_MAX,
+  CLI_CLICK_MAX_SIZE_MIN,
+  CLI_CLICK_TOP_N_MAX,
+  CLI_CLICK_TOP_N_MIN,
   CLI_OBJECTIVES,
   CLI_REDUCTIONS,
   CLI_WEIGHTINGS,
   formatFamilyClick,
   isReadyPushKnob,
+  type BfsCliClickAxes,
   type CliClickAxes,
+  type CommunityCliClickAxes,
+  type PagerankCliClickAxes,
   validateEpsilonInput,
   validateRestartProbInput,
 } from "~/lib/cli/illuminate-axes";
@@ -31,257 +38,275 @@ import styles from "./CliAxisPicker.module.css";
 
 export interface CliAxisPickerProps {
   axes: CliClickAxes;
-  setAxis<K extends keyof CliClickAxes>(key: K, value: CliClickAxes[K]): void;
-  /**
-   * Disable the strip while a command is in flight (#433). The hook
-   * state itself is preserved; only the controls go read-only so a
-   * mid-flight click cannot mutate the next click string.
-   */
+  selectFamily(family: AlgorithmName): void;
+  setAxes(axes: CliClickAxes): void;
   disabled?: boolean;
-  /**
-   * Reports whether the raw α/ε drafts can produce a family command. The
-   * parent gates canvas clicks on this signal, so invalid text cannot execute
-   * the last successfully committed axis value.
-   */
+  /** Lets the canvas block a click while an α/ε draft is incomplete. */
   onPushKnobValidityChange(valid: boolean): void;
 }
 
 /**
- * Click-to-illuminate axis picker (#464).
- *
- * Renders a single-line strip of Fluent UI primitives that map 1:1 to
- * the optional kwargs of the long-form illuminate verb (post-#410):
- * step, k, algorithm (family), reduction, objective, and a
- * raw/TF-IDF/BM25 weighting Dropdown, plus a free-text prefix filter.
- * The reduction Dropdown (#961) is hidden for the ppr family, which
- * returns a relevance star with no tree view. When a push-based family is
- * selected (algorithm=ppr or algorithm=community), two extra numeric
- * inputs (restart_prob / epsilon) appear for the shared locality knobs
- * (#801/#942); a blank knob means "server default", and the step input is
- * disabled because neither family gives it a wire meaning. Wraps on narrow
- * viewports without horizontal scroll, per the architecture skill's
- * responsive guidance.
- *
- * The component owns no business state — every change goes through
- * {@link CliAxisPickerProps.setAxis}, which the parent hook
- * (`useCliAxisPicker`) persists. Bounds are sourced from the same
- * registry the formatter uses so picker UI, persistence, and command
- * formatting never disagree on the legal range.
+ * Family-native controls for click-to-explore. The selected family is visible
+ * before a graph exists and TypeScript narrows every child to the controls its
+ * command grammar actually understands.
  */
 export function CliAxisPicker({
   axes,
-  setAxis,
+  selectFamily,
+  setAxes,
   disabled,
   onPushKnobValidityChange,
 }: CliAxisPickerProps) {
-  const onStepChange = useCallback<NonNullable<InputProps["onChange"]>>(
-    (_, data) => {
-      const n = Number.parseInt(data.value, 10);
-      if (!Number.isInteger(n)) return;
-      if (n < CLI_CLICK_STEP_MIN || n > CLI_CLICK_STEP_MAX) return;
-      setAxis("step", n);
-    },
-    [setAxis],
-  );
-
-  const onKChange = useCallback<NonNullable<InputProps["onChange"]>>(
-    (_, data) => {
-      const n = Number.parseInt(data.value, 10);
-      if (!Number.isInteger(n)) return;
-      if (n < CLI_CLICK_K_MIN || n > CLI_CLICK_K_MAX) return;
-      setAxis("k", n);
-    },
-    [setAxis],
-  );
-
-  // Free-text axis (#617): any string is valid, including "" (= no filter).
-  // The formatter only echoes a non-empty prefix, so clearing the field
-  // restores the canonical short-form click.
-  const onPrefixChange = useCallback<NonNullable<InputProps["onChange"]>>(
-    (_, data) => {
-      setAxis("vertexPrefix", data.value);
-    },
-    [setAxis],
-  );
-
-  // #801/#964: the α/ε knobs are non-negative floats, but they were built as
-  // native `type="number"` inputs whose `.value` goes empty for a syntactically
-  // in-progress entry ("0.", "1e-"), and whose displayed value was re-derived
-  // from the numeric axis every render (where 0 = "server default" renders
-  // blank). Together that erased the field on any keystroke that transiently
-  // parsed to 0, so decimals in (0,1) and scientific ε were literally
-  // un-typeable — the picker behaved as if only integers were allowed. Fix:
-  // hold the operator's RAW text as local state (displayed verbatim) and commit
-  // only a valid parse to the axis, so "0.15" / "1e-4" survive keystroke by
-  // keystroke. Seeded once from the already-hydrated axes; these two handlers
-  // are the sole writers of the knobs, so the text and the numeric axis never
-  // diverge without passing through here.
-  const [restartProbText, setRestartProbText] = useState(
-    axes.restartProb > 0 ? String(axes.restartProb) : "",
-  );
-  const [epsilonText, setEpsilonText] = useState(
-    axes.epsilon > 0 ? String(axes.epsilon) : "",
-  );
-
-  // #801/#942: pagerank and community are the two push-based families that
-  // carry the α/ε locality knobs; they also give the `step` axis no wire
-  // meaning.
-  const isPushFamily =
-    axes.algorithm === "pagerank" || axes.algorithm === "community";
-  const restartProbValidation = validateRestartProbInput(restartProbText);
-  const epsilonValidation = validateEpsilonInput(epsilonText);
-  const arePushKnobsReady =
-    !isPushFamily ||
-    (isReadyPushKnob(restartProbValidation) &&
-      isReadyPushKnob(epsilonValidation));
-
+  const [isPushCommandValid, setIsPushCommandValid] = useState(true);
   const reportPushKnobValidity = useCallback(
-    (restartProbDraft: string, epsilonDraft: string) => {
-      const ready =
-        !isPushFamily ||
-        (isReadyPushKnob(validateRestartProbInput(restartProbDraft)) &&
-          isReadyPushKnob(validateEpsilonInput(epsilonDraft)));
-      onPushKnobValidityChange(ready);
+    (valid: boolean) => {
+      setIsPushCommandValid(valid);
+      onPushKnobValidityChange(valid);
     },
-    [isPushFamily, onPushKnobValidityChange],
+    [onPushKnobValidityChange],
   );
-
-  // Selection changes can hide the fields or restore them from persisted
-  // axes, so report after every render as well as synchronously in handlers.
-  // The synchronous report closes the tiny window between a keystroke and the
-  // following canvas click.
   useEffect(() => {
-    onPushKnobValidityChange(arePushKnobsReady);
-  }, [arePushKnobsReady, onPushKnobValidityChange]);
-
-  const onRestartProbChange = useCallback<NonNullable<InputProps["onChange"]>>(
-    (_, data) => {
-      setRestartProbText(data.value);
-      const validation = validateRestartProbInput(data.value);
-      if (isReadyPushKnob(validation)) {
-        setAxis("restartProb", validation.value);
-      }
-      reportPushKnobValidity(data.value, epsilonText);
-    },
-    [epsilonText, reportPushKnobValidity, setAxis],
-  );
-
-  const onEpsilonChange = useCallback<NonNullable<InputProps["onChange"]>>(
-    (_, data) => {
-      setEpsilonText(data.value);
-      const validation = validateEpsilonInput(data.value);
-      if (isReadyPushKnob(validation)) setAxis("epsilon", validation.value);
-      reportPushKnobValidity(restartProbText, data.value);
-    },
-    [reportPushKnobValidity, restartProbText, setAxis],
-  );
-
-  const preview = arePushKnobsReady
-    ? formatFamilyClick("<key>", axes)
-    : "Fix push-knob validation errors before clicking a node.";
-
-  // #961: the tree reduction is honoured for the bfs and community families
-  // and ignored for pagerank (a relevance star has no tree view), so the
-  // Dropdown is hidden for pagerank rather than echoing a knob the server
-  // drops.
-  const showsReduction = axes.algorithm !== "pagerank";
-  // #942: for the community family `k` is the max_size UPPER BOUND (the
-  // conductance sweep may stop earlier), not an exact neighbour count.
-  const kTitle =
-    axes.algorithm === "community"
-      ? "k: max community size (upper bound; the sweep may stop earlier)"
-      : "k: top-k neighbours kept per hop";
+    if (axes.family === "bfs") reportPushKnobValidity(true);
+  }, [axes.family, reportPushKnobValidity]);
 
   return (
     <div
       className={styles.strip}
       data-testid="cli-axis-picker"
       role="group"
-      aria-label="Click-to-illuminate axes"
+      aria-label="Traversal family and click-to-explore controls"
       aria-describedby="cli-axis-picker-preview"
     >
       <label className={styles.field}>
-        <span className={styles.label}>step</span>
-        <Input
-          className={styles.numberInput}
-          type="number"
-          min={CLI_CLICK_STEP_MIN}
-          max={CLI_CLICK_STEP_MAX}
-          value={String(axes.step)}
-          onChange={onStepChange}
-          disabled={disabled || isPushFamily}
-          data-testid="cli-axis-step"
-          aria-label={`Step (${CLI_CLICK_STEP_MIN}–${CLI_CLICK_STEP_MAX})`}
-          title={
-            isPushFamily
-              ? "step has no meaning for the ppr / community families"
-              : undefined
-          }
-        />
-      </label>
-
-      <label className={styles.field}>
-        <span className={styles.label}>k</span>
-        <Input
-          className={styles.numberInput}
-          type="number"
-          min={CLI_CLICK_K_MIN}
-          max={CLI_CLICK_K_MAX}
-          value={String(axes.k)}
-          onChange={onKChange}
-          disabled={disabled}
-          data-testid="cli-axis-k"
-          aria-label={`K (${CLI_CLICK_K_MIN}–${CLI_CLICK_K_MAX})`}
-          title={kTitle}
-        />
-      </label>
-
-      <label className={styles.field}>
-        <span className={styles.label}>algorithm</span>
+        <span className={styles.label}>family</span>
         <Dropdown
           className={styles.dropdown}
-          value={labelFor(CLI_ALGORITHMS, axes.algorithm)}
-          selectedOptions={[axes.algorithm]}
+          value={labelFor(CLI_ALGORITHMS, axes.family)}
+          selectedOptions={[axes.family]}
           disabled={disabled}
           onOptionSelect={(_, data) => {
-            if (!data.optionValue) return;
-            setAxis("algorithm", data.optionValue as AlgorithmName);
+            if (data.optionValue)
+              selectFamily(data.optionValue as AlgorithmName);
           }}
           data-testid="cli-axis-algorithm"
-          aria-label="Algorithm"
+          aria-label="Traversal family"
         >
-          {CLI_ALGORITHMS.map((opt) => (
-            <Option key={opt.value} value={opt.value}>
-              {opt.label}
+          {CLI_ALGORITHMS.map((option) => (
+            <Option key={option.value} value={option.value}>
+              {option.label}
             </Option>
           ))}
         </Dropdown>
       </label>
 
-      {showsReduction && (
-        <label className={styles.field}>
-          <span className={styles.label}>reduction</span>
-          <Dropdown
-            className={styles.dropdown}
-            value={labelFor(CLI_REDUCTIONS, axes.reduction)}
-            selectedOptions={[axes.reduction]}
-            disabled={disabled}
-            onOptionSelect={(_, data) => {
-              if (!data.optionValue) return;
-              setAxis("reduction", data.optionValue as ReductionName);
-            }}
-            data-testid="cli-axis-reduction"
-            aria-label="Reduction"
-          >
-            {CLI_REDUCTIONS.map((opt) => (
-              <Option key={opt.value} value={opt.value}>
-                {opt.label}
-              </Option>
-            ))}
-          </Dropdown>
-        </label>
+      {axes.family === "bfs" ? (
+        <BfsControls axes={axes} setAxes={setAxes} disabled={disabled} />
+      ) : axes.family === "pagerank" ? (
+        <PagerankControls
+          axes={axes}
+          setAxes={setAxes}
+          disabled={disabled}
+          onPushKnobValidityChange={reportPushKnobValidity}
+        />
+      ) : (
+        <CommunityControls
+          axes={axes}
+          setAxes={setAxes}
+          disabled={disabled}
+          onPushKnobValidityChange={reportPushKnobValidity}
+        />
       )}
+      <Preview axes={axes} valid={isPushCommandValid} />
+    </div>
+  );
+}
 
+function BfsControls({
+  axes,
+  setAxes,
+  disabled,
+}: {
+  axes: BfsCliClickAxes;
+  setAxes(axes: CliClickAxes): void;
+  disabled?: boolean;
+}) {
+  return (
+    <>
+      <NumberField
+        label="step"
+        value={axes.step}
+        min={CLI_CLICK_BFS_STEP_MIN}
+        max={CLI_CLICK_BFS_STEP_MAX}
+        testId="cli-axis-step"
+        disabled={disabled}
+        onValue={(step) => setAxes({ ...axes, step })}
+      />
+      <NumberField
+        label="fan_out"
+        value={axes.fanOut}
+        min={CLI_CLICK_BFS_FAN_OUT_MIN}
+        max={CLI_CLICK_BFS_FAN_OUT_MAX}
+        testId="cli-axis-k"
+        disabled={disabled}
+        onValue={(fanOut) => setAxes({ ...axes, fanOut })}
+      />
+      <TreeControls axes={axes} setAxes={setAxes} disabled={disabled} />
+      <SharedControls axes={axes} setAxes={setAxes} disabled={disabled} />
+    </>
+  );
+}
+
+function PagerankControls({
+  axes,
+  setAxes,
+  disabled,
+  onPushKnobValidityChange,
+}: {
+  axes: PagerankCliClickAxes;
+  setAxes(axes: CliClickAxes): void;
+  disabled?: boolean;
+  onPushKnobValidityChange(valid: boolean): void;
+}) {
+  return (
+    <>
+      <NumberField
+        label="top_n"
+        value={axes.topN}
+        min={CLI_CLICK_TOP_N_MIN}
+        max={CLI_CLICK_TOP_N_MAX}
+        testId="cli-axis-k"
+        disabled={disabled}
+        title="0 returns every positive-mass vertex"
+        onValue={(topN) => setAxes({ ...axes, topN })}
+      />
+      <PushControls
+        key={axes.family}
+        axes={axes}
+        setAxes={setAxes}
+        disabled={disabled}
+        onPushKnobValidityChange={onPushKnobValidityChange}
+      />
+      <SharedControls axes={axes} setAxes={setAxes} disabled={disabled} />
+    </>
+  );
+}
+
+function CommunityControls({
+  axes,
+  setAxes,
+  disabled,
+  onPushKnobValidityChange,
+}: {
+  axes: CommunityCliClickAxes;
+  setAxes(axes: CliClickAxes): void;
+  disabled?: boolean;
+  onPushKnobValidityChange(valid: boolean): void;
+}) {
+  return (
+    <>
+      <NumberField
+        label="max_size"
+        value={axes.maxSize}
+        min={CLI_CLICK_MAX_SIZE_MIN}
+        max={CLI_CLICK_MAX_SIZE_MAX}
+        testId="cli-axis-k"
+        disabled={disabled}
+        title="0 lets the conductance sweep choose the community size"
+        onValue={(maxSize) => setAxes({ ...axes, maxSize })}
+      />
+      <PushControls
+        key={axes.family}
+        axes={axes}
+        setAxes={setAxes}
+        disabled={disabled}
+        onPushKnobValidityChange={onPushKnobValidityChange}
+      />
+      <TreeControls axes={axes} setAxes={setAxes} disabled={disabled} />
+      <SharedControls axes={axes} setAxes={setAxes} disabled={disabled} />
+    </>
+  );
+}
+
+function NumberField({
+  label,
+  value,
+  min,
+  max,
+  testId,
+  disabled,
+  title,
+  onValue,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  testId: string;
+  disabled?: boolean;
+  title?: string;
+  onValue(value: number): void;
+}) {
+  const onChange = (_: unknown, data: { value: string }) => {
+    if (!/^[+-]?\d+$/.test(data.value)) return;
+    const value = Number(data.value);
+    if (!Number.isSafeInteger(value) || value < min || value > max) return;
+    onValue(value);
+  };
+  return (
+    <label className={styles.field}>
+      <span className={styles.label}>{label}</span>
+      <Input
+        className={styles.numberInput}
+        type="number"
+        min={min}
+        max={max}
+        value={String(value)}
+        onChange={onChange as NonNullable<InputProps["onChange"]>}
+        disabled={disabled}
+        data-testid={testId}
+        aria-label={`${label} (${min}–${max})`}
+        title={title}
+      />
+    </label>
+  );
+}
+
+function TreeControls({
+  axes,
+  setAxes,
+  disabled,
+}: {
+  axes: BfsCliClickAxes | CommunityCliClickAxes;
+  setAxes(axes: CliClickAxes): void;
+  disabled?: boolean;
+}) {
+  return (
+    <>
+      <label className={styles.field}>
+        <span className={styles.label}>reduction</span>
+        <Dropdown
+          className={styles.dropdown}
+          value={labelFor(CLI_REDUCTIONS, axes.reduction)}
+          selectedOptions={[axes.reduction]}
+          disabled={disabled}
+          onOptionSelect={(_, data) => {
+            if (data.optionValue) {
+              setAxes({
+                ...axes,
+                reduction: data.optionValue as ReductionName,
+              });
+            }
+          }}
+          data-testid="cli-axis-reduction"
+          aria-label="Reduction"
+        >
+          {CLI_REDUCTIONS.map((option) => (
+            <Option key={option.value} value={option.value}>
+              {option.label}
+            </Option>
+          ))}
+        </Dropdown>
+      </label>
       <label className={styles.field}>
         <span className={styles.label}>objective</span>
         <Dropdown
@@ -290,20 +315,38 @@ export function CliAxisPicker({
           selectedOptions={[axes.objective]}
           disabled={disabled}
           onOptionSelect={(_, data) => {
-            if (!data.optionValue) return;
-            setAxis("objective", data.optionValue as ObjectiveName);
+            if (data.optionValue) {
+              setAxes({
+                ...axes,
+                objective: data.optionValue as ObjectiveName,
+              });
+            }
           }}
           data-testid="cli-axis-objective"
           aria-label="Objective"
         >
-          {CLI_OBJECTIVES.map((opt) => (
-            <Option key={opt.value} value={opt.value}>
-              {opt.label}
+          {CLI_OBJECTIVES.map((option) => (
+            <Option key={option.value} value={option.value}>
+              {option.label}
             </Option>
           ))}
         </Dropdown>
       </label>
+    </>
+  );
+}
 
+function SharedControls({
+  axes,
+  setAxes,
+  disabled,
+}: {
+  axes: CliClickAxes;
+  setAxes(axes: CliClickAxes): void;
+  disabled?: boolean;
+}) {
+  return (
+    <>
       <label className={styles.field}>
         <span className={styles.label}>weighting</span>
         <Dropdown
@@ -312,98 +355,131 @@ export function CliAxisPicker({
           selectedOptions={[axes.weighting]}
           disabled={disabled}
           onOptionSelect={(_, data) => {
-            if (!data.optionValue) return;
-            setAxis("weighting", data.optionValue as WeightingName);
+            if (data.optionValue) {
+              setAxes({
+                ...axes,
+                weighting: data.optionValue as WeightingName,
+              });
+            }
           }}
           data-testid="cli-axis-weighting"
           aria-label="Weighting"
         >
-          {CLI_WEIGHTINGS.map((opt) => (
-            <Option key={opt.value} value={opt.value}>
-              {opt.label}
+          {CLI_WEIGHTINGS.map((option) => (
+            <Option key={option.value} value={option.value}>
+              {option.label}
             </Option>
           ))}
         </Dropdown>
       </label>
-
       <label className={styles.field}>
         <span className={styles.label}>prefix</span>
         <Input
           className={styles.textInput}
           type="text"
           value={axes.vertexPrefix}
-          onChange={onPrefixChange}
+          onChange={(_, data) => setAxes({ ...axes, vertexPrefix: data.value })}
           disabled={disabled}
           placeholder="(none)"
           data-testid="cli-axis-prefix"
           aria-label="Vertex prefix (optional)"
         />
       </label>
+    </>
+  );
+}
 
-      {isPushFamily && (
-        <>
-          <Field
-            className={styles.knobField}
-            label="restart_prob"
-            validationState={
-              restartProbValidation.state === "invalid" ? "error" : "none"
-            }
-            validationMessage={
-              restartProbValidation.state === "invalid"
-                ? restartProbValidation.message
-                : undefined
-            }
-            data-testid="cli-axis-restart-prob-field"
-          >
-            <Input
-              className={styles.numberInput}
-              type="text"
-              inputMode="decimal"
-              value={restartProbText}
-              onChange={onRestartProbChange}
-              disabled={disabled}
-              placeholder="0.15"
-              data-testid="cli-axis-restart-prob"
-              aria-label="Restart probability α (0–1; blank = server default)"
-            />
-          </Field>
+function PushControls({
+  axes,
+  setAxes,
+  disabled,
+  onPushKnobValidityChange,
+}: {
+  axes: PagerankCliClickAxes | CommunityCliClickAxes;
+  setAxes(axes: CliClickAxes): void;
+  disabled?: boolean;
+  onPushKnobValidityChange(valid: boolean): void;
+}) {
+  const [restartProbText, setRestartProbText] = useState(
+    axes.restartProb > 0 ? String(axes.restartProb) : "",
+  );
+  const [epsilonText, setEpsilonText] = useState(
+    axes.epsilon > 0 ? String(axes.epsilon) : "",
+  );
+  const restartProbValidation = validateRestartProbInput(restartProbText);
+  const epsilonValidation = validateEpsilonInput(epsilonText);
+  const ready =
+    isReadyPushKnob(restartProbValidation) &&
+    isReadyPushKnob(epsilonValidation);
+  useEffect(() => {
+    onPushKnobValidityChange(ready);
+  }, [onPushKnobValidityChange, ready]);
 
-          <Field
-            className={styles.knobField}
-            label="epsilon"
-            validationState={
-              epsilonValidation.state === "invalid" ? "error" : "none"
-            }
-            validationMessage={
-              epsilonValidation.state === "invalid"
-                ? epsilonValidation.message
-                : undefined
-            }
-            data-testid="cli-axis-epsilon-field"
-          >
-            <Input
-              className={styles.numberInput}
-              type="text"
-              inputMode="decimal"
-              value={epsilonText}
-              onChange={onEpsilonChange}
-              disabled={disabled}
-              placeholder="1e-4"
-              data-testid="cli-axis-epsilon"
-              aria-label="Residual threshold ε (> 0; blank = server default)"
-            />
-          </Field>
-        </>
-      )}
-
-      <code
-        id="cli-axis-picker-preview"
-        className={styles.preview}
-        data-testid="cli-axis-preview"
+  return (
+    <>
+      <Field
+        className={styles.knobField}
+        label="restart_prob"
+        validationState={
+          restartProbValidation.state === "invalid" ? "error" : "none"
+        }
+        validationMessage={
+          restartProbValidation.state === "invalid"
+            ? restartProbValidation.message
+            : undefined
+        }
+        data-testid="cli-axis-restart-prob-field"
       >
-        {preview}
-      </code>
-      {!arePushKnobsReady && (
+        <Input
+          className={styles.numberInput}
+          type="text"
+          inputMode="decimal"
+          value={restartProbText}
+          onChange={(_, data) => {
+            setRestartProbText(data.value);
+            const validation = validateRestartProbInput(data.value);
+            if (isReadyPushKnob(validation)) {
+              setAxes({ ...axes, restartProb: validation.value });
+            }
+          }}
+          disabled={disabled}
+          placeholder="0.15"
+          data-testid="cli-axis-restart-prob"
+          aria-label="Restart probability α (0–1; blank = server default)"
+        />
+      </Field>
+      <Field
+        className={styles.knobField}
+        label="epsilon"
+        validationState={
+          epsilonValidation.state === "invalid" ? "error" : "none"
+        }
+        validationMessage={
+          epsilonValidation.state === "invalid"
+            ? epsilonValidation.message
+            : undefined
+        }
+        data-testid="cli-axis-epsilon-field"
+      >
+        <Input
+          className={styles.numberInput}
+          type="text"
+          inputMode="decimal"
+          value={epsilonText}
+          onChange={(_, data) => {
+            setEpsilonText(data.value);
+            const validation = validateEpsilonInput(data.value);
+            if (isReadyPushKnob(validation)) {
+              setAxes({ ...axes, epsilon: validation.value });
+            }
+          }}
+          disabled={disabled}
+          placeholder="1e-4"
+          data-testid="cli-axis-epsilon"
+          aria-label="Residual threshold ε (> 0; blank = server default)"
+        />
+      </Field>
+      {!ready ? (
         <span
           className={styles.blocked}
           data-testid="cli-axis-command-blocked"
@@ -411,8 +487,22 @@ export function CliAxisPicker({
         >
           Fix the incomplete or invalid push-knob input before clicking a node.
         </span>
-      )}
-    </div>
+      ) : null}
+    </>
+  );
+}
+
+function Preview({ axes, valid }: { axes: CliClickAxes; valid: boolean }) {
+  return (
+    <code
+      id="cli-axis-picker-preview"
+      className={styles.preview}
+      data-testid="cli-axis-preview"
+    >
+      {valid
+        ? formatFamilyClick("<key>", axes)
+        : "Fix push-knob validation errors before clicking a node."}
+    </code>
   );
 }
 
@@ -420,8 +510,5 @@ function labelFor<T extends string>(
   options: ReadonlyArray<{ value: T; label: string }>,
   value: T,
 ): string {
-  for (const opt of options) {
-    if (opt.value === value) return opt.label;
-  }
-  return value;
+  return options.find((option) => option.value === value)?.label ?? value;
 }

--- a/admin/app/components/cli/CliPage/CliPage.module.css
+++ b/admin/app/components/cli/CliPage/CliPage.module.css
@@ -116,6 +116,14 @@
   gap: var(--spacingHorizontalS, 8px);
 }
 
+/* Family-native picker is deliberately mounted in the terminal rather than
+ * the graph panel: a first command needs an intentional family selection too. */
+.axisControls {
+  flex: 0 0 auto;
+  border-bottom: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  background: var(--colorNeutralBackground2, #fafafa);
+}
+
 /* Scrollback body — transparent because the terminal box owns the frame. */
 .scrollback {
   flex: 1 1 auto;
@@ -275,8 +283,8 @@
   min-width: 0;
 }
 
-/* The canvas panel: integrated axis-picker control header, a meta line,
-   and the graph body. Mirrors the terminal's frame for visual symmetry. */
+/* The canvas panel contains the current graph and its source metadata. The
+   picker lives in the always-mounted terminal header above. */
 .canvasPanel {
   display: flex;
   flex-direction: column;
@@ -287,15 +295,6 @@
   background: var(--colorNeutralBackground1, #ffffff);
   box-shadow: var(--shadow4, 0 2px 4px rgba(0, 0, 0, 0.14));
   overflow: hidden;
-}
-
-/* Wraps the CliAxisPicker as the panel's control header; the picker itself
-   renders seamlessly (no frame of its own) so it reads as part of the
-   panel chrome. */
-.canvasControls {
-  flex: 0 0 auto;
-  border-bottom: 1px solid var(--colorNeutralStroke2, #e0e0e0);
-  background: var(--colorNeutralBackground2, #fafafa);
 }
 
 .canvasMeta {

--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -39,17 +39,14 @@ export function CliPage() {
   // UI state — it neither touches the dispatch loop nor the scrollback.
   const [helpOpen, setHelpOpen] = useState(false);
   // Drives the two-column grid + draggable splitter (#465). Only active
-  // when a graph is present; otherwise the right column owns the full
-  // width and the splitter handle is hidden by CSS.
+  // when a graph is present; otherwise the terminal owns the full width and
+  // the family picker remains available before the first graph exists.
   const rootRef = useRef<HTMLDivElement>(null);
   const splitter = useCliSplitter({
     enabled: cli.latestGraph !== null,
     rootRef,
   });
-  // Owns the click-to-illuminate axis picker strip state (#464). The
-  // hook hydrates from localStorage so a refresh preserves a tuned
-  // exploration session, and persists each axis change so the next page
-  // load picks up where the operator left off.
+  // Owns one persisted native-value set per traversal family (#991).
   const axisPicker = useCliAxisPicker();
   const [isAxisPickerCommandValid, setIsAxisPickerCommandValid] =
     useState(true);
@@ -65,7 +62,7 @@ export function CliPage() {
   // #651 deep-link handoff: a `/cli?seed=<key>` URL (from the Vertices /
   // Edges Browse rows and the Vertex-detail toolbar) auto-fires one
   // illuminate walk for that key — the same command a canvas click emits.
-  // The walk uses the canonical default axes (`bfs <seed> 2 5`) so a
+  // The walk uses the canonical BFS defaults (`bfs <seed> 5 3`) so a
   // cross-surface deep link is deterministic; the operator can re-tune and
   // re-click from the canvas afterwards. `runRaw` is captured in a ref so the
   // one-shot effect depends only on the seed string and never re-fires when
@@ -89,7 +86,7 @@ export function CliPage() {
     // no-op (mirrors the retired Illuminate page's lastSeedRef).
     if (seedHandoffRef.current === seed) return;
     seedHandoffRef.current = seed;
-    runRawRef.current(formatFamilyClick(seed, CLI_CLICK_AXIS_DEFAULTS));
+    runRawRef.current(formatFamilyClick(seed, CLI_CLICK_AXIS_DEFAULTS.bfs));
   }, [seedParam]);
 
   // Auto-scroll the scrollback to the bottom on every new entry so the
@@ -277,6 +274,18 @@ export function CliPage() {
           </span>
         </div>
 
+        {/* Family choice is available before the first graph. This keeps the
+            initial command intentional instead of silently assuming BFS. */}
+        <div className={styles.axisControls}>
+          <CliAxisPicker
+            axes={axisPicker.axes}
+            selectFamily={axisPicker.selectFamily}
+            setAxes={axisPicker.setAxes}
+            disabled={cli.busy}
+            onPushKnobValidityChange={onPushKnobValidityChange}
+          />
+        </div>
+
         <div
           className={styles.scrollback}
           ref={scrollRef}
@@ -342,22 +351,15 @@ export function CliPage() {
         />
       ) : null}
 
-      {/* Right column — the canvas with the axis picker fused into its
-          control header (#512). Mounts only when a graph is available. */}
+      {/* Right column — the current graph. Its family picker stays in the
+          always-mounted terminal header, so an operator can choose a family
+          before producing the first graph. */}
       {cli.latestGraph !== null ? (
         <section
           className={styles.canvasColumn}
           data-testid="cli-canvas-column"
         >
           <div className={styles.canvasPanel} data-testid="cli-canvas-panel">
-            <div className={styles.canvasControls}>
-              <CliAxisPicker
-                axes={axisPicker.axes}
-                setAxis={axisPicker.setAxis}
-                disabled={cli.busy}
-                onPushKnobValidityChange={onPushKnobValidityChange}
-              />
-            </div>
             <div className={styles.canvasMeta}>
               <span className={styles.canvasMetaLabel}>from</span>
               <code className={styles.canvasMetaSource}>

--- a/admin/app/lib/cli/illuminate-axes.test.ts
+++ b/admin/app/lib/cli/illuminate-axes.test.ts
@@ -1,487 +1,194 @@
-/**
- * Unit tests for the click-to-illuminate axis registry (#464, #975).
- *
- * Covers two distinct guarantees:
- *
- * 1. `formatFamilyClick` emits the family verb (bfs / pagerank / community)
- *    with its positional walk-size args and only appends the diverging
- *    kwargs, in the fixed order `reduction=` → `objective=` → `weighting=` →
- *    `prefix=` → `restart_prob=` → `epsilon=`. The default-short-form case
- *    (`bfs alice 2 5`) is the regression guard for #439 — the byte-for-byte
- *    stable click string the canvas snapshot test depends on.
- *
- * 2. Every shape this formatter can produce is parseable by the
- *    shared CLI parser in `./parser`, and round-trips to the same
- *    axes. Without this, a divergence between the picker and
- *    the parser (e.g. casing, kwarg name, value vocabulary) would
- *    silently break "click echoes a command I could have typed".
- */
 import { describe, expect, test } from "bun:test";
 
-import { parse } from "./parser";
 import {
+  AXIS_STORAGE_KEYS,
   CLI_CLICK_AXIS_DEFAULTS,
+  defaultCliClickPickerState,
   formatFamilyClick,
-  formatStoredFloat,
-  parseStoredAlgorithm,
-  parseStoredEpsilon,
-  parseStoredK,
-  parseStoredObjective,
-  parseStoredPrefix,
-  parseStoredRestartProb,
-  parseStoredReduction,
-  parseStoredStep,
-  parseStoredWeighting,
-  type CliClickAxes,
+  migrateLegacyCliClickPickerState,
+  parseStoredCliClickPickerState,
+  replaceCliClickFamilyAxes,
+  selectCliClickFamily,
+  serialiseCliClickPickerState,
   validateEpsilonInput,
   validateRestartProbInput,
 } from "./illuminate-axes";
+import { parse } from "./parser";
 
-describe("formatFamilyClick", () => {
-  test("default axes emit the byte-stable short form (#439)", () => {
-    expect(formatFamilyClick("alice", CLI_CLICK_AXIS_DEFAULTS)).toBe(
-      "bfs alice 2 5",
+describe("family-native click formatter", () => {
+  test("uses each parser family's documented default and zero sentinel", () => {
+    expect(formatFamilyClick("alice", CLI_CLICK_AXIS_DEFAULTS.bfs)).toBe(
+      "bfs alice 5 3",
+    );
+    expect(formatFamilyClick("alice", CLI_CLICK_AXIS_DEFAULTS.pagerank)).toBe(
+      "pagerank alice 10",
+    );
+    expect(formatFamilyClick("alice", CLI_CLICK_AXIS_DEFAULTS.community)).toBe(
+      "community alice 0",
     );
   });
 
-  test("only step changed → bumps positional, no kwargs", () => {
-    expect(
-      formatFamilyClick("alice", { ...CLI_CLICK_AXIS_DEFAULTS, step: 3 }),
-    ).toBe("bfs alice 3 5");
-  });
-
-  test("only k changed → bumps positional, no kwargs", () => {
-    expect(
-      formatFamilyClick("alice", { ...CLI_CLICK_AXIS_DEFAULTS, k: 10 }),
-    ).toBe("bfs alice 2 10");
-  });
-
-  test("only reduction off-default → single kwarg", () => {
-    expect(
-      formatFamilyClick("alice", {
-        ...CLI_CLICK_AXIS_DEFAULTS,
-        reduction: "spt",
-      }),
-    ).toBe("bfs alice 2 5 reduction=spt");
-  });
-
-  test("algorithm=community selects the community verb with a single positional", () => {
-    expect(
-      formatFamilyClick("alice", {
-        ...CLI_CLICK_AXIS_DEFAULTS,
-        algorithm: "community",
-      }),
-    ).toBe("community alice 5");
-  });
-
-  test("only objective off-default → single kwarg", () => {
-    expect(
-      formatFamilyClick("alice", {
-        ...CLI_CLICK_AXIS_DEFAULTS,
-        objective: "min",
-      }),
-    ).toBe("bfs alice 2 5 objective=min");
-  });
-
-  test("only weighting off-default → single kwarg", () => {
-    expect(
-      formatFamilyClick("alice", {
-        ...CLI_CLICK_AXIS_DEFAULTS,
-        weighting: "tfidf",
-      }),
-    ).toBe("bfs alice 2 5 weighting=tfidf");
-  });
-
-  test("only prefix off-default → single kwarg appended last", () => {
-    expect(
-      formatFamilyClick("alice", {
-        ...CLI_CLICK_AXIS_DEFAULTS,
-        vertexPrefix: "svc:",
-      }),
-    ).toBe("bfs alice 2 5 prefix=svc:");
-  });
-
-  test("prefix value is emitted verbatim (case-sensitive, #604)", () => {
-    expect(
-      formatFamilyClick("alice", {
-        ...CLI_CLICK_AXIS_DEFAULTS,
-        vertexPrefix: "Users/Alice",
-      }),
-    ).toBe("bfs alice 2 5 prefix=Users/Alice");
-  });
-
-  test("empty prefix emits no kwarg even with other axes off-default", () => {
-    expect(
-      formatFamilyClick("alice", {
+  test("emits only family-native BFS fields", () => {
+    const command = formatFamilyClick("alice", {
+      ...CLI_CLICK_AXIS_DEFAULTS.bfs,
+      step: 3,
+      fanOut: 8,
+      reduction: "spt",
+      objective: "min",
+      weighting: "tfidf",
+      vertexPrefix: "team:blue",
+    });
+    expect(command).toBe(
+      "bfs alice 3 8 reduction=spt objective=min weighting=tfidf prefix=team:blue",
+    );
+    expect(parse(command)).toEqual({
+      ok: true,
+      command: {
+        verb: "bfs",
+        seed: "alice",
         step: 3,
-        k: 10,
-        algorithm: "community",
+        fanOut: 8,
         reduction: "spt",
         objective: "min",
         weighting: "tfidf",
-        vertexPrefix: "",
-        restartProb: 0,
-        epsilon: 0,
-      }),
-    ).toBe("community alice 10 reduction=spt objective=min weighting=tfidf");
+        vertexPrefix: "team:blue",
+      },
+    });
   });
 
-  test("all axes off-default → fixed token order ending in prefix=", () => {
-    expect(
-      formatFamilyClick("alice", {
-        step: 3,
-        k: 10,
-        algorithm: "community",
-        reduction: "spt",
-        objective: "min",
-        weighting: "tfidf",
-        vertexPrefix: "svc:",
-        restartProb: 0,
-        epsilon: 0,
-      }),
-    ).toBe(
-      "community alice 10 reduction=spt objective=min weighting=tfidf prefix=svc:",
+  test("emits PageRank top_n=0 and push knobs without tree fields", () => {
+    const command = formatFamilyClick("alice", {
+      ...CLI_CLICK_AXIS_DEFAULTS.pagerank,
+      topN: 0,
+      restartProb: 0.25,
+      epsilon: 0.001,
+      weighting: "bm25",
+    });
+    expect(command).toBe(
+      "pagerank alice 0 weighting=bm25 restart_prob=0.25 epsilon=0.001",
     );
+    const result = parse(command);
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.command.verb !== "pagerank") return;
+    expect(result.command.topN).toBe(0);
+    expect(result.command.restartProb).toBe(0.25);
+    expect(result.command.epsilon).toBeCloseTo(0.001, 7);
   });
 
-  // #801: the push knobs are gated on the pagerank/community families AND a
-  // non-zero value; the bfs family never emits them.
-  test("algorithm=pagerank alone emits the bare positional star", () => {
-    expect(
-      formatFamilyClick("alice", {
-        ...CLI_CLICK_AXIS_DEFAULTS,
-        algorithm: "pagerank",
-      }),
-    ).toBe("pagerank alice 5");
-  });
-
-  test("pagerank knobs append after the positional in fixed order", () => {
-    expect(
-      formatFamilyClick("alice", {
-        ...CLI_CLICK_AXIS_DEFAULTS,
-        algorithm: "pagerank",
-        restartProb: 0.25,
-        epsilon: 0.001,
-      }),
-    ).toBe("pagerank alice 5 restart_prob=0.25 epsilon=0.001");
-  });
-
-  test("push knobs are suppressed for the bfs family", () => {
-    expect(
-      formatFamilyClick("alice", {
-        ...CLI_CLICK_AXIS_DEFAULTS,
-        reduction: "spt",
-        restartProb: 0.25,
-        epsilon: 0.001,
-      }),
-    ).toBe("bfs alice 2 5 reduction=spt");
-  });
-
-  // #942: the community family shares the pagerank α/ε knobs and the same
-  // non-zero emission gate, so the click formatter must reach it too.
-  test("algorithm=community alone emits the bare positional", () => {
-    expect(
-      formatFamilyClick("alice", {
-        ...CLI_CLICK_AXIS_DEFAULTS,
-        algorithm: "community",
-      }),
-    ).toBe("community alice 5");
-  });
-
-  test("community knobs append after the positional in fixed order", () => {
-    expect(
-      formatFamilyClick("alice", {
-        ...CLI_CLICK_AXIS_DEFAULTS,
-        algorithm: "community",
-        restartProb: 0.25,
-        epsilon: 0.001,
-      }),
-    ).toBe("community alice 5 restart_prob=0.25 epsilon=0.001");
-  });
-
-  // #961: the reduction axis is honoured for the community family (an MST /
-  // SPT tree rooted at the seed) and slots in right after the positional.
-  test("community + reduction emits both, reduction after the positional", () => {
-    expect(
-      formatFamilyClick("alice", {
-        ...CLI_CLICK_AXIS_DEFAULTS,
-        algorithm: "community",
-        reduction: "mst",
-      }),
-    ).toBe("community alice 5 reduction=mst");
-  });
-
-  // #961: pagerank renders a ranked vertex star, not a tree, so the reduction
-  // axis is meaningless there and the formatter suppresses it.
-  test("reduction is suppressed for the pagerank family", () => {
-    expect(
-      formatFamilyClick("alice", {
-        ...CLI_CLICK_AXIS_DEFAULTS,
-        algorithm: "pagerank",
-        reduction: "spt",
-      }),
-    ).toBe("pagerank alice 5");
-  });
-
-  test("seed containing a colon round-trips literally", () => {
-    expect(formatFamilyClick("user:alice", CLI_CLICK_AXIS_DEFAULTS)).toBe(
-      "bfs user:alice 2 5",
+  test("emits community max_size=0 and its optional tree fields", () => {
+    const command = formatFamilyClick("alice", {
+      ...CLI_CLICK_AXIS_DEFAULTS.community,
+      maxSize: 0,
+      reduction: "mst",
+      objective: "min",
+      restartProb: 0.15,
+      epsilon: 0.0001,
+    });
+    expect(command).toBe(
+      "community alice 0 reduction=mst objective=min restart_prob=0.15 epsilon=0.0001",
     );
+    const result = parse(command);
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.command.verb !== "community") return;
+    expect(result.command.maxSize).toBe(0);
+    expect(result.command.reduction).toBe("mst");
   });
 
-  test("safe keys stay human-readable while literal percent escapes stay literal", () => {
-    expect(formatFamilyClick("audit:%2F", CLI_CLICK_AXIS_DEFAULTS)).toBe(
-      "bfs audit:%2F 2 5",
-    );
-  });
-
-  test.each([
-    "audit key",
-    "audit:%2F",
-    'say "hi"',
-    "C:\\tmp\\key",
-    "tab\tand\nnewline",
-    "日本語",
-  ])("serialises seed and prefix losslessly: %p", (value) => {
-    const result = parse(
-      formatFamilyClick(value, {
-        ...CLI_CLICK_AXIS_DEFAULTS,
-        vertexPrefix: value,
-      }),
-    );
-    if (!result.ok) {
-      throw new Error(`formatter rejected ${JSON.stringify(value)}`);
-    }
-    expect(result.command.verb).toBe("bfs");
-    if (result.command.verb !== "bfs") return;
-    expect(result.command.seed).toBe(value);
-    expect(result.command.vertexPrefix).toBe(value);
+  test("quotes a free-text seed and prefix as one token", () => {
+    const command = formatFamilyClick("audit key", {
+      ...CLI_CLICK_AXIS_DEFAULTS.bfs,
+      vertexPrefix: "Users/Alice Smith",
+    });
+    const result = parse(command);
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.command.verb !== "bfs") return;
+    expect(result.command.seed).toBe("audit key");
+    expect(result.command.vertexPrefix).toBe("Users/Alice Smith");
   });
 });
 
-describe("formatFamilyClick ↔ parse round-trip", () => {
-  const matrix: Array<{ name: string; axes: CliClickAxes }> = [
-    { name: "all-default", axes: CLI_CLICK_AXIS_DEFAULTS },
-    {
-      name: "only step",
-      axes: { ...CLI_CLICK_AXIS_DEFAULTS, step: 4 },
-    },
-    {
-      name: "only k",
-      axes: { ...CLI_CLICK_AXIS_DEFAULTS, k: 16 },
-    },
-    {
-      name: "only reduction=mst",
-      axes: { ...CLI_CLICK_AXIS_DEFAULTS, reduction: "mst" },
-    },
-    {
-      name: "only reduction=spt",
-      axes: { ...CLI_CLICK_AXIS_DEFAULTS, reduction: "spt" },
-    },
-    {
-      name: "only algorithm=community",
-      axes: { ...CLI_CLICK_AXIS_DEFAULTS, algorithm: "community" },
-    },
-    {
-      name: "only objective=min",
-      axes: { ...CLI_CLICK_AXIS_DEFAULTS, objective: "min" },
-    },
-    {
-      name: "only weighting=tfidf",
-      axes: { ...CLI_CLICK_AXIS_DEFAULTS, weighting: "tfidf" },
-    },
-    {
-      name: "only prefix",
-      axes: { ...CLI_CLICK_AXIS_DEFAULTS, vertexPrefix: "team:" },
-    },
-    {
-      name: "all axes off-default",
-      axes: {
-        step: 3,
-        k: 10,
-        algorithm: "community",
-        reduction: "spt",
-        objective: "min",
-        weighting: "tfidf",
-        vertexPrefix: "svc:",
-        restartProb: 0.3,
-        epsilon: 0.002,
-      },
-    },
-    {
-      name: "pagerank with knobs",
-      axes: {
-        ...CLI_CLICK_AXIS_DEFAULTS,
-        algorithm: "pagerank",
-        restartProb: 0.25,
-        epsilon: 0.001,
-      },
-    },
-    {
-      name: "community with knobs",
-      axes: {
-        ...CLI_CLICK_AXIS_DEFAULTS,
-        algorithm: "community",
-        restartProb: 0.3,
-        epsilon: 0.002,
-      },
-    },
-    {
-      name: "bfs with reduction",
-      axes: { ...CLI_CLICK_AXIS_DEFAULTS, reduction: "mst", objective: "min" },
-    },
-  ];
+describe("family picker state", () => {
+  test("preserves each family's last values across switches", () => {
+    let state = defaultCliClickPickerState();
+    state = replaceCliClickFamilyAxes(state, {
+      ...state.families.bfs,
+      step: 4,
+      fanOut: 9,
+    });
+    state = selectCliClickFamily(state, "pagerank");
+    state = replaceCliClickFamilyAxes(state, {
+      ...state.families.pagerank,
+      topN: 0,
+      restartProb: 0.2,
+    });
+    state = selectCliClickFamily(state, "community");
+    state = replaceCliClickFamilyAxes(state, {
+      ...state.families.community,
+      maxSize: 7,
+      reduction: "spt",
+    });
+    state = selectCliClickFamily(state, "bfs");
 
-  test.each(matrix)("$name parses back to the same axes", ({ axes }) => {
-    const text = formatFamilyClick("user:alice", axes);
-    const result = parse(text);
-    if (!result.ok) {
-      throw new Error(
-        `formatter produced unparseable text: ${JSON.stringify({ text, usage: result.usage })}`,
-      );
-    }
-    // Since #975 the family is the verb itself, so each axis set round-trips
-    // to a different Command shape carrying the family-specific fields.
-    const cmd = result.command;
-    expect(cmd.verb).toBe(axes.algorithm);
-    if (cmd.verb === "bfs") {
-      expect(cmd.seed).toBe("user:alice");
-      expect(cmd.step).toBe(axes.step);
-      expect(cmd.fanOut).toBe(axes.k);
-      expect(cmd.reduction).toBe(axes.reduction);
-      expect(cmd.objective).toBe(axes.objective);
-      expect(cmd.weighting).toBe(axes.weighting);
-      expect(cmd.vertexPrefix).toBe(axes.vertexPrefix);
-    } else if (cmd.verb === "pagerank") {
-      expect(cmd.seed).toBe("user:alice");
-      // pagerank's single positional is top_n, sourced from the shared k axis.
-      expect(cmd.topN).toBe(axes.k);
-      expect(cmd.weighting).toBe(axes.weighting);
-      expect(cmd.vertexPrefix).toBe(axes.vertexPrefix);
-      // The parsed command carries the exact float32 values sent on the wire.
-      expect(cmd.restartProb).toBe(Math.fround(axes.restartProb));
-      expect(cmd.epsilon).toBe(Math.fround(axes.epsilon));
-    } else if (cmd.verb === "community") {
-      expect(cmd.seed).toBe("user:alice");
-      // community's single positional is max_size, sourced from the k axis;
-      // step has no meaning for this family and is dropped by the formatter.
-      expect(cmd.maxSize).toBe(axes.k);
-      expect(cmd.reduction).toBe(axes.reduction);
-      expect(cmd.objective).toBe(axes.objective);
-      expect(cmd.weighting).toBe(axes.weighting);
-      expect(cmd.vertexPrefix).toBe(axes.vertexPrefix);
-      // The parsed command carries the exact float32 values sent on the wire.
-      expect(cmd.restartProb).toBe(Math.fround(axes.restartProb));
-      expect(cmd.epsilon).toBe(Math.fround(axes.epsilon));
-    } else {
-      throw new Error(`unexpected verb from click formatter: ${cmd.verb}`);
-    }
+    expect(state.families.bfs).toMatchObject({ step: 4, fanOut: 9 });
+    expect(state.families.pagerank).toMatchObject({
+      topN: 0,
+      restartProb: 0.2,
+    });
+    expect(state.families.community).toMatchObject({
+      maxSize: 7,
+      reduction: "spt",
+    });
+  });
+
+  test("refuses a stale update from a no-longer-selected family", () => {
+    const state = selectCliClickFamily(
+      defaultCliClickPickerState(),
+      "pagerank",
+    );
+    const next = replaceCliClickFamilyAxes(state, {
+      ...state.families.bfs,
+      step: 1,
+    });
+    expect(next).toBe(state);
+  });
+
+  test("round-trips the versioned snapshot including typed zero sentinels", () => {
+    const state = defaultCliClickPickerState();
+    const restored = parseStoredCliClickPickerState(
+      serialiseCliClickPickerState(state),
+    );
+    expect(restored).toEqual(state);
+  });
+
+  test("migrates legacy k only to the selected family", () => {
+    const values = new Map<string, string>([
+      [AXIS_STORAGE_KEYS.algorithm, "pagerank"],
+      [AXIS_STORAGE_KEYS.step, "4"],
+      [AXIS_STORAGE_KEYS.k, "17"],
+      [AXIS_STORAGE_KEYS.reduction, "mst"],
+      [AXIS_STORAGE_KEYS.objective, "min"],
+      [AXIS_STORAGE_KEYS.weighting, "tfidf"],
+      [AXIS_STORAGE_KEYS.vertexPrefix, "legacy:"],
+      [AXIS_STORAGE_KEYS.restartProb, "0.2"],
+      [AXIS_STORAGE_KEYS.epsilon, "0.001"],
+    ]);
+    const migrated = migrateLegacyCliClickPickerState({
+      get: (key) => values.get(key) ?? null,
+    });
+
+    expect(migrated.selectedFamily).toBe("pagerank");
+    expect(migrated.families.bfs).toMatchObject({ step: 4, fanOut: 3 });
+    expect(migrated.families.pagerank).toMatchObject({
+      topN: 17,
+      restartProb: 0.2,
+      epsilon: 0.001,
+    });
+    expect(migrated.families.community).toMatchObject({ maxSize: 0 });
   });
 });
 
-describe("parseStored* helpers", () => {
-  test("step accepts the documented range and rejects everything else", () => {
-    expect(parseStoredStep("1")).toBe(1);
-    expect(parseStoredStep("5")).toBe(5);
-    expect(parseStoredStep("0")).toBeNull();
-    expect(parseStoredStep("6")).toBeNull();
-    expect(parseStoredStep("two")).toBeNull();
-    expect(parseStoredStep(null)).toBeNull();
-  });
-
-  test("k accepts the documented range and rejects everything else", () => {
-    expect(parseStoredK("1")).toBe(1);
-    expect(parseStoredK("32")).toBe(32);
-    expect(parseStoredK("0")).toBeNull();
-    expect(parseStoredK("33")).toBeNull();
-    expect(parseStoredK("five")).toBeNull();
-    expect(parseStoredK(null)).toBeNull();
-  });
-
-  test("axis enums only accept canonical lower-case CLI vocabulary", () => {
-    expect(parseStoredAlgorithm("bfs")).toBe("bfs");
-    expect(parseStoredAlgorithm("pagerank")).toBe("pagerank");
-    expect(parseStoredAlgorithm("community")).toBe("community");
-    // The reduction values are no longer part of the algorithm axis (#961).
-    expect(parseStoredAlgorithm("none")).toBeNull();
-    expect(parseStoredAlgorithm("mst")).toBeNull();
-    expect(parseStoredAlgorithm("spt")).toBeNull();
-    expect(parseStoredAlgorithm("BFS")).toBeNull();
-    expect(parseStoredAlgorithm("ALGORITHM_SHORTEST_PATH_TREE")).toBeNull();
-    expect(parseStoredAlgorithm(null)).toBeNull();
-
-    expect(parseStoredReduction("none")).toBe("none");
-    expect(parseStoredReduction("mst")).toBe("mst");
-    expect(parseStoredReduction("spt")).toBe("spt");
-    // The family values are not reductions.
-    expect(parseStoredReduction("bfs")).toBeNull();
-    expect(parseStoredReduction("pagerank")).toBeNull();
-    expect(parseStoredReduction("community")).toBeNull();
-    expect(parseStoredReduction("SPT")).toBeNull();
-    expect(parseStoredReduction("REDUCTION_SHORTEST_PATH_TREE")).toBeNull();
-    expect(parseStoredReduction(null)).toBeNull();
-
-    expect(parseStoredObjective("min")).toBe("min");
-    expect(parseStoredObjective("max")).toBe("max");
-    expect(parseStoredObjective("OBJECTIVE_MAXIMIZE")).toBeNull();
-
-    expect(parseStoredWeighting("raw")).toBe("raw");
-    expect(parseStoredWeighting("tfidf")).toBe("tfidf");
-    expect(parseStoredWeighting("bm25")).toBe("bm25");
-    expect(parseStoredWeighting("WEIGHTING_TFIDF")).toBeNull();
-  });
-
-  test("prefix is free text: any non-null string is valid, null stays null", () => {
-    expect(parseStoredPrefix("svc:")).toBe("svc:");
-    expect(parseStoredPrefix("Users/Alice")).toBe("Users/Alice");
-    // Empty is a legitimate stored value (= no filter), distinct from a
-    // missing key (null), which falls back to the default.
-    expect(parseStoredPrefix("")).toBe("");
-    expect(parseStoredPrefix(null)).toBeNull();
-  });
-
-  test("push-knob storage uses strict, family-specific float32 domains", () => {
-    expect(parseStoredRestartProb("")).toBe(0);
-    expect(parseStoredRestartProb("0.25")).toBe(0.25);
-    expect(parseStoredEpsilon("")).toBe(0);
-    expect(parseStoredEpsilon("1e-4")).toBe(0.0001);
-
-    // Legacy zero values, out-of-domain values, prefix parses, and values
-    // that change domain after float32 rounding must never hydrate.
-    for (const raw of [
-      "0",
-      "1",
-      "1.5",
-      "-0.1",
-      "0.25suffix",
-      "0.99999999",
-      "1e-50",
-      "NaN",
-      "Infinity",
-      " 0.25",
-      " ",
-    ]) {
-      expect(parseStoredRestartProb(raw)).toBeNull();
-    }
-    for (const raw of ["0", "-0.1", "1e-50", "0.25suffix"]) {
-      expect(parseStoredEpsilon(raw)).toBeNull();
-    }
-    expect(parseStoredRestartProb(null)).toBeNull();
-    expect(parseStoredEpsilon(null)).toBeNull();
-  });
-
-  test("formatStoredFloat writes blank defaults that both strict parsers restore", () => {
-    expect(formatStoredFloat(0)).toBe("");
-    for (const value of [0, 0.15, 0.25, 0.0001]) {
-      const stored = formatStoredFloat(value);
-      expect(parseStoredRestartProb(stored)).toBe(value);
-      expect(parseStoredEpsilon(stored)).toBe(value);
-    }
-  });
-});
-
-describe("strict live push-knob validation", () => {
-  test("blank alone commits the server default, while complete valid values commit", () => {
+describe("push-knob validation", () => {
+  test("accepts blank server defaults and valid float32 values", () => {
     expect(validateRestartProbInput("")).toEqual({
       state: "default",
       value: 0,
@@ -496,30 +203,10 @@ describe("strict live push-knob validation", () => {
     });
   });
 
-  test("incomplete decimal and scientific drafts stay intact without committing", () => {
-    for (const raw of [".", "0.", "+", "1e", "1e-"]) {
-      expect(validateRestartProbInput(raw)).toEqual({ state: "incomplete" });
-    }
-  });
-
-  test("restart_prob rejects malformed and out-of-domain float32 values", () => {
-    for (const raw of [
-      "0",
-      "1",
-      "1.5",
-      "-0.1",
-      " ",
-      "0.25suffix",
-      "0.99999999", // rounds to exactly 1 as float32
-      "1e-50", // underflows to exactly 0 as float32
-    ]) {
-      expect(validateRestartProbInput(raw).state).toBe("invalid");
-    }
-  });
-
-  test("epsilon rejects zero, malformed, and float32 underflow", () => {
-    for (const raw of ["0", "-0.1", "0.25suffix", "1e-50"]) {
-      expect(validateEpsilonInput(raw).state).toBe("invalid");
-    }
+  test("keeps incomplete drafts separate from invalid values", () => {
+    expect(validateRestartProbInput("0.").state).toBe("incomplete");
+    expect(validateEpsilonInput("1e-").state).toBe("incomplete");
+    expect(validateRestartProbInput("1").state).toBe("invalid");
+    expect(validateEpsilonInput("1e-50").state).toBe("invalid");
   });
 });

--- a/admin/app/lib/cli/illuminate-axes.ts
+++ b/admin/app/lib/cli/illuminate-axes.ts
@@ -1,29 +1,10 @@
 /**
- * Click-to-illuminate axis registry (#464).
+ * Family-native state and command formatting for the CLI graph explorer.
  *
- * The /cli page lets an operator click a vertex on the canvas to fire
- * an `illuminate` command for that key. Pre-#464 the click was hard-
- * coded to `illuminate <key> 2 5`, so configuring the post-#410 axes
- * (algorithm / objective / weighting) required typing the long form
- * by hand every time. This module exposes the *CLI-vocabulary* axis
- * options the picker strip renders, plus the small pure formatter
- * that turns the picker state into the exact text that will be echoed
- * into the scrollback.
- *
- * Why CLI vocabulary and not the wire enums?
- * The picker writes a *command string* into the CLI input buffer; the
- * same string a user could have typed. The Go REPL parser and the
- * TypeScript parser in `./verbs.ts` both accept the family axis
- * `bfs|ppr|community`, the orthogonal reduction axis `none|mst|spt`
- * (#961), plus `min|max` / `raw|tfidf|bm25`. Using the wire enums here
- * would mean the picker echoes something the parsers reject, breaking the
- * "every command echoed is something I could have typed" invariant the
- * /cli page is built on.
- *
- * Defaults match `parseIlluminate` in `./verbs.ts` so that an
- * untouched picker formats to the canonical short form
- * `illuminate <seed> 2 5` — the regression guard documented in #439
- * (default click must remain stable byte-for-byte).
+ * A picker selection writes a command the operator could type in the CLI, so
+ * this module deliberately uses the CLI vocabulary rather than wire enums.
+ * The traversal family is a discriminant: an impossible combination such as
+ * PageRank plus a BFS step or tree reduction has no TypeScript representation.
  */
 
 import type {
@@ -35,78 +16,135 @@ import type {
 import { quoteCliToken } from "./tokenise";
 import { parseFloatStrict } from "./verbs";
 
-/** Bounds for the step axis. Matches the Illuminate wire toolbar. */
-export const CLI_CLICK_STEP_MIN = 1;
-export const CLI_CLICK_STEP_MAX = 5;
-/** Bounds for the k axis. */
-export const CLI_CLICK_K_MIN = 1;
-export const CLI_CLICK_K_MAX = 32;
+export const CLI_CLICK_BFS_STEP_MIN = 1;
+export const CLI_CLICK_BFS_STEP_MAX = 5;
+export const CLI_CLICK_BFS_FAN_OUT_MIN = 1;
+export const CLI_CLICK_BFS_FAN_OUT_MAX = 32;
+export const CLI_CLICK_TOP_N_MIN = 0;
+export const CLI_CLICK_TOP_N_MAX = 32;
+export const CLI_CLICK_MAX_SIZE_MIN = 0;
+export const CLI_CLICK_MAX_SIZE_MAX = 32;
 
-export interface CliClickAxes {
-  step: number;
-  k: number;
-  /**
-   * Traversal FAMILY (#961): `bfs` (default), `ppr`, or `community`.
-   * Orthogonal to {@link reduction}.
-   */
-  algorithm: AlgorithmName;
-  /**
-   * Post-traversal tree REDUCTION (#961): `none` (default), `mst`, or `spt`.
-   * Honoured for the `bfs` and `community` families and ignored for `ppr`;
-   * {@link formatFamilyClick} only echoes it for a family that uses it.
-   */
+interface SharedCliClickAxes {
+  weighting: WeightingName;
+  /** Empty means no frontier-prefix filter. */
+  vertexPrefix: string;
+}
+
+interface TreeCliClickAxes extends SharedCliClickAxes {
   reduction: ReductionName;
   objective: ObjectiveName;
-  weighting: WeightingName;
-  /**
-   * Free-text vertex-prefix filter (#604/#617). Restricts the click-driven
-   * walk frontier to keys under this prefix; the seed is always kept as the
-   * anchor even when it does not match. Empty means "no filter". Matched
-   * against vertex keys verbatim (case-SENSITIVE), unlike the closed-set
-   * axes above.
-   */
-  vertexPrefix: string;
-  /**
-   * Push-family locality knobs (#801/#942), meaningful when
-   * `algorithm === "ppr"` or `algorithm === "community"`. `restartProb` is
-   * the restart/teleport-to-seed probability α in (0,1); `epsilon` is the
-   * forward-push residual threshold ε > 0. 0 means "leave to the server
-   * default" (α=0.15 / ε=1e-4) and is the value that keeps the bare click
-   * byte-for-byte the canonical short form — {@link formatFamilyClick}
-   * only emits these for a non-zero ppr/community walk.
-   */
+}
+
+export interface BfsCliClickAxes extends TreeCliClickAxes {
+  family: "bfs";
+  step: number;
+  fanOut: number;
+}
+
+export interface PagerankCliClickAxes extends SharedCliClickAxes {
+  family: "pagerank";
+  /** 0 returns every positive-mass vertex. */
+  topN: number;
+  /** 0 delegates to the server default. */
   restartProb: number;
+  /** 0 delegates to the server default. */
   epsilon: number;
 }
 
+export interface CommunityCliClickAxes extends TreeCliClickAxes {
+  family: "community";
+  /** 0 leaves the conductance sweep to decide the community size. */
+  maxSize: number;
+  /** 0 delegates to the server default. */
+  restartProb: number;
+  /** 0 delegates to the server default. */
+  epsilon: number;
+}
+
+export type CliClickAxes =
+  | BfsCliClickAxes
+  | PagerankCliClickAxes
+  | CommunityCliClickAxes;
+
+export interface CliClickAxesByFamily {
+  bfs: BfsCliClickAxes;
+  pagerank: PagerankCliClickAxes;
+  community: CommunityCliClickAxes;
+}
+
+export interface CliClickPickerState {
+  selectedFamily: AlgorithmName;
+  families: CliClickAxesByFamily;
+}
+
 /**
- * Defaults are wired to the same values `parseIlluminate` falls back
- * to when a long-form command omits the axis kwargs. Any drift here
- * silently breaks the regression guard in {@link formatIlluminateClick}.
+ * Click defaults intentionally match the parser's family defaults: BFS 5/3,
+ * PageRank top_n 10, and community max_size 0. The explicit zero values make
+ * the two push families' sentinel semantics visible in generated commands.
  */
-export const CLI_CLICK_AXIS_DEFAULTS: CliClickAxes = {
-  step: 2,
-  k: 5,
-  algorithm: "bfs",
-  // #961: no tree reduction by default — the bare click renders the raw
-  // discovered subgraph. Kept in lockstep with `parseIlluminate`.
-  reduction: "none",
-  // #560: the server resolves an unspecified objective to MAXIMIZE, and the
-  // objective now also steers the per-hop top-k pruning. Defaulting the
-  // picker to `max` keeps the bare click on the strongest neighbours
-  // (the pre-#560 de-facto behaviour) instead of silently inverting to
-  // the weakest once the click is dispatched.
-  objective: "max",
-  weighting: "raw",
-  // Empty = no prefix filter, so the bare click stays byte-for-byte the
-  // canonical short form `illuminate <seed> 2 5` (the #439 regression guard).
-  vertexPrefix: "",
-  // 0 = "use the server default" for both push knobs; the formatter omits
-  // them unless algorithm=ppr|community AND the value is non-zero, so the
-  // bare click is unaffected (#439 / #801 / #942).
-  restartProb: 0,
-  epsilon: 0,
+export const CLI_CLICK_AXIS_DEFAULTS: CliClickAxesByFamily = {
+  bfs: {
+    family: "bfs",
+    step: 5,
+    fanOut: 3,
+    reduction: "none",
+    objective: "max",
+    weighting: "raw",
+    vertexPrefix: "",
+  },
+  pagerank: {
+    family: "pagerank",
+    topN: 10,
+    restartProb: 0,
+    epsilon: 0,
+    weighting: "raw",
+    vertexPrefix: "",
+  },
+  community: {
+    family: "community",
+    maxSize: 0,
+    restartProb: 0,
+    epsilon: 0,
+    reduction: "none",
+    objective: "max",
+    weighting: "raw",
+    vertexPrefix: "",
+  },
 };
+
+export function defaultCliClickPickerState(): CliClickPickerState {
+  return {
+    selectedFamily: "bfs",
+    families: {
+      bfs: { ...CLI_CLICK_AXIS_DEFAULTS.bfs },
+      pagerank: { ...CLI_CLICK_AXIS_DEFAULTS.pagerank },
+      community: { ...CLI_CLICK_AXIS_DEFAULTS.community },
+    },
+  };
+}
+
+/** Select a family without touching the other families' last-used values. */
+export function selectCliClickFamily(
+  state: CliClickPickerState,
+  family: AlgorithmName,
+): CliClickPickerState {
+  return state.selectedFamily === family
+    ? state
+    : { ...state, selectedFamily: family };
+}
+
+/** Replace only the current family, refusing a stale cross-family update. */
+export function replaceCliClickFamilyAxes(
+  state: CliClickPickerState,
+  axes: CliClickAxes,
+): CliClickPickerState {
+  if (state.selectedFamily !== axes.family) return state;
+  return {
+    ...state,
+    families: { ...state.families, [axes.family]: axes },
+  };
+}
 
 export const CLI_ALGORITHMS: ReadonlyArray<{
   value: AlgorithmName;
@@ -144,73 +182,71 @@ export const CLI_WEIGHTINGS: ReadonlyArray<{
 ];
 
 /**
- * Format a click-to-illuminate command for {@link seed} as a family verb
- * (#975). The verb is `axes.algorithm` (bfs / pagerank / community): bfs emits
- * positional `<step> <fan_out>`, while pagerank / community emit a single
- * positional count (top_n / max_size), all sourced from `axes.k` (the shared
- * "count" axis). Optional kwargs are appended in fixed order only when they
- * diverge from {@link CLI_CLICK_AXIS_DEFAULTS}: `reduction=` / `objective=`
- * (bfs & community only — pagerank's relevance star is already a tree),
- * `weighting=`, `prefix=`, then the α/ε push knobs (pagerank / community only,
- * and only when non-zero). The fixed order keeps scrollback snapshots
- * deterministic and every echoed line is one the parser accepts.
- *
- * The function is intentionally pure so `bun:test` can round-trip it through
- * {@link parse} without a DOM.
+ * Formats a family-native click selection as a parser-accepted CLI command.
+ * Positional defaults stay explicit: this makes the click preview describe
+ * the exact request and keeps the zero sentinels visible for PageRank and
+ * community.
  */
 export function formatFamilyClick(seed: string, axes: CliClickAxes): string {
-  const verb = axes.algorithm;
-  const tokens: string[] = [verb, quoteCliToken(seed)];
-  // Positional walk-size args: bfs takes step + fan_out; pagerank / community
-  // take a single count (top_n / max_size). `axes.k` is the shared count axis.
-  if (verb === "bfs") {
-    tokens.push(String(axes.step), String(axes.k));
-  } else {
-    tokens.push(String(axes.k));
-  }
-  // reduction / objective apply to bfs and community (pagerank returns a
-  // relevance star with no tree view). Emit only when non-default so a bare
-  // click stays byte-stable (#439) and we never echo a knob pagerank ignores.
-  if (verb !== "pagerank") {
-    if (axes.reduction !== CLI_CLICK_AXIS_DEFAULTS.reduction) {
-      tokens.push(`reduction=${axes.reduction}`);
-    }
-    if (axes.objective !== CLI_CLICK_AXIS_DEFAULTS.objective) {
-      tokens.push(`objective=${axes.objective}`);
-    }
-  }
-  if (axes.weighting !== CLI_CLICK_AXIS_DEFAULTS.weighting) {
-    tokens.push(`weighting=${axes.weighting}`);
-  }
-  // #617: prefix is a FREE-TEXT axis. Emit `prefix=<value>` only when non-empty
-  // — the parser rejects an explicit empty `prefix=`, and an empty prefix means
-  // "no filter" anyway, so the bare click stays the canonical short form. The
-  // value is case-sensitive (#604), but quote the COMPLETE `prefix=value`
-  // token so whitespace and escape characters survive tokenisation.
-  if (axes.vertexPrefix !== "") {
-    tokens.push(quoteCliToken(`prefix=${axes.vertexPrefix}`));
-  }
-  // #801/#942: the α/ε knobs are meaningful for the two push-based families
-  // (pagerank and community — both carry the same `restart_prob`/`epsilon`
-  // locality knobs) and only when the operator has overridden the server
-  // default (0). Gating on both keeps the bare click byte-stable (#439) and
-  // never emits a knob the server ignores for the bfs family.
-  if (verb === "pagerank" || verb === "community") {
-    if (axes.restartProb > 0) {
-      tokens.push(`restart_prob=${axes.restartProb}`);
-    }
-    if (axes.epsilon > 0) {
-      tokens.push(`epsilon=${axes.epsilon}`);
-    }
+  const tokens = [axes.family, quoteCliToken(seed)];
+  switch (axes.family) {
+    case "bfs":
+      tokens.push(String(axes.step), String(axes.fanOut));
+      appendTreeTokens(tokens, axes, CLI_CLICK_AXIS_DEFAULTS.bfs);
+      break;
+    case "pagerank":
+      tokens.push(String(axes.topN));
+      appendSharedTokens(tokens, axes, CLI_CLICK_AXIS_DEFAULTS.pagerank);
+      appendPushTokens(tokens, axes);
+      break;
+    case "community":
+      tokens.push(String(axes.maxSize));
+      appendTreeTokens(tokens, axes, CLI_CLICK_AXIS_DEFAULTS.community);
+      appendPushTokens(tokens, axes);
+      break;
   }
   return tokens.join(" ");
 }
 
-/**
- * localStorage keys for the picker strip. Namespaced under `cli.click.*`
- * so they coexist with `cli.splitRatio` from #465 without collision.
- */
+function appendTreeTokens(
+  tokens: string[],
+  axes: TreeCliClickAxes,
+  defaults: TreeCliClickAxes,
+): void {
+  if (axes.reduction !== defaults.reduction) {
+    tokens.push(`reduction=${axes.reduction}`);
+  }
+  if (axes.objective !== defaults.objective) {
+    tokens.push(`objective=${axes.objective}`);
+  }
+  appendSharedTokens(tokens, axes, defaults);
+}
+
+function appendSharedTokens(
+  tokens: string[],
+  axes: SharedCliClickAxes,
+  defaults: SharedCliClickAxes,
+): void {
+  if (axes.weighting !== defaults.weighting) {
+    tokens.push(`weighting=${axes.weighting}`);
+  }
+  if (axes.vertexPrefix !== "") {
+    tokens.push(quoteCliToken(`prefix=${axes.vertexPrefix}`));
+  }
+}
+
+function appendPushTokens(
+  tokens: string[],
+  axes: Pick<PagerankCliClickAxes, "restartProb" | "epsilon">,
+): void {
+  if (axes.restartProb > 0) tokens.push(`restart_prob=${axes.restartProb}`);
+  if (axes.epsilon > 0) tokens.push(`epsilon=${axes.epsilon}`);
+}
+
+/** A versioned snapshot replaces the retired flat localStorage keys. */
 export const AXIS_STORAGE_KEYS = {
+  state: "cli.click.families.v2",
+  // Legacy flat-state keys. They are only read for one-time migration.
   step: "cli.click.step",
   k: "cli.click.k",
   algorithm: "cli.click.algorithm",
@@ -222,18 +258,117 @@ export const AXIS_STORAGE_KEYS = {
   epsilon: "cli.click.epsilon",
 } as const;
 
-/**
- * Parse a step value previously written to localStorage. Returns null
- * for missing / malformed / out-of-range values; the caller is expected
- * to fall back to {@link CLI_CLICK_AXIS_DEFAULTS}.step.
- */
-export function parseStoredStep(raw: string | null): number | null {
-  return parseStoredInt(raw, CLI_CLICK_STEP_MIN, CLI_CLICK_STEP_MAX);
+export interface LegacyAxisStorage {
+  get(key: string): string | null;
 }
 
-/** Like {@link parseStoredStep} but for the k axis. */
+/**
+ * Reads the old flat picker state without assigning `k` a new meaning for
+ * every family. Its value is migrated only to the family that was selected;
+ * the other families receive their own documented defaults.
+ */
+export function migrateLegacyCliClickPickerState(
+  storage: LegacyAxisStorage,
+): CliClickPickerState {
+  const selectedFamily =
+    parseStoredAlgorithm(storage.get(AXIS_STORAGE_KEYS.algorithm)) ?? "bfs";
+  const legacyStep =
+    parseStoredStep(storage.get(AXIS_STORAGE_KEYS.step)) ??
+    CLI_CLICK_AXIS_DEFAULTS.bfs.step;
+  const legacyK = parseStoredK(storage.get(AXIS_STORAGE_KEYS.k));
+  const reduction =
+    parseStoredReduction(storage.get(AXIS_STORAGE_KEYS.reduction)) ?? "none";
+  const objective =
+    parseStoredObjective(storage.get(AXIS_STORAGE_KEYS.objective)) ?? "max";
+  const weighting =
+    parseStoredWeighting(storage.get(AXIS_STORAGE_KEYS.weighting)) ?? "raw";
+  const vertexPrefix =
+    parseStoredPrefix(storage.get(AXIS_STORAGE_KEYS.vertexPrefix)) ?? "";
+  const restartProb =
+    parseStoredRestartProb(storage.get(AXIS_STORAGE_KEYS.restartProb)) ?? 0;
+  const epsilon =
+    parseStoredEpsilon(storage.get(AXIS_STORAGE_KEYS.epsilon)) ?? 0;
+
+  const state = defaultCliClickPickerState();
+  state.selectedFamily = selectedFamily;
+  state.families.bfs = {
+    ...state.families.bfs,
+    step: legacyStep,
+    fanOut:
+      selectedFamily === "bfs" && legacyK !== null
+        ? legacyK
+        : state.families.bfs.fanOut,
+    reduction,
+    objective,
+    weighting,
+    vertexPrefix,
+  };
+  state.families.pagerank = {
+    ...state.families.pagerank,
+    topN:
+      selectedFamily === "pagerank" && legacyK !== null
+        ? legacyK
+        : state.families.pagerank.topN,
+    restartProb,
+    epsilon,
+    weighting,
+    vertexPrefix,
+  };
+  state.families.community = {
+    ...state.families.community,
+    maxSize:
+      selectedFamily === "community" && legacyK !== null
+        ? legacyK
+        : state.families.community.maxSize,
+    restartProb,
+    epsilon,
+    reduction,
+    objective,
+    weighting,
+    vertexPrefix,
+  };
+  return state;
+}
+
+/** Returns null when the versioned snapshot is missing or malformed. */
+export function parseStoredCliClickPickerState(
+  raw: string | null,
+): CliClickPickerState | null {
+  if (raw === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed) || parsed.version !== 2 || !isRecord(parsed.families)) {
+    return null;
+  }
+  const selectedFamily = parseStoredAlgorithm(asString(parsed.selectedFamily));
+  const bfs = parseBfsAxes(parsed.families.bfs);
+  const pagerank = parsePagerankAxes(parsed.families.pagerank);
+  const community = parseCommunityAxes(parsed.families.community);
+  if (!selectedFamily || !bfs || !pagerank || !community) return null;
+  return { selectedFamily, families: { bfs, pagerank, community } };
+}
+
+export function serialiseCliClickPickerState(
+  state: CliClickPickerState,
+): string {
+  return JSON.stringify({ version: 2, ...state });
+}
+
+export function parseStoredStep(raw: string | null): number | null {
+  return parseStoredInt(raw, CLI_CLICK_BFS_STEP_MIN, CLI_CLICK_BFS_STEP_MAX);
+}
+
+/** Parses the legacy shared k axis, whose old legal range was 1..32. */
 export function parseStoredK(raw: string | null): number | null {
-  return parseStoredInt(raw, CLI_CLICK_K_MIN, CLI_CLICK_K_MAX);
+  return parseStoredInt(
+    raw,
+    CLI_CLICK_BFS_FAN_OUT_MIN,
+    CLI_CLICK_BFS_FAN_OUT_MAX,
+  );
 }
 
 export function parseStoredAlgorithm(raw: string | null): AlgorithmName | null {
@@ -263,13 +398,6 @@ export const RESTART_PROB_VALIDATION_MESSAGE =
 export const EPSILON_VALIDATION_MESSAGE =
   "epsilon must be a positive float32, or blank for the server default.";
 
-/**
- * Strictly validate a restart-probability draft. The input must match the
- * command grammar in full; its float32 representation (the value sent on the
- * wire) must then be in the open interval (0, 1). Empty text alone requests
- * the server default. Incomplete decimal/scientific drafts remain distinct so
- * the picker can preserve them without committing a stale or invalid value.
- */
 export function validateRestartProbInput(raw: string): PushKnobValidation {
   return validatePushKnob(
     raw,
@@ -278,11 +406,6 @@ export function validateRestartProbInput(raw: string): PushKnobValidation {
   );
 }
 
-/**
- * Strictly validate an epsilon draft. Its float32 wire value must be positive;
- * an underflow such as `1e-50` therefore remains invalid rather than silently
- * becoming the server-default zero value.
- */
 export function validateEpsilonInput(raw: string): PushKnobValidation {
   return validatePushKnob(
     raw,
@@ -291,52 +414,137 @@ export function validateEpsilonInput(raw: string): PushKnobValidation {
   );
 }
 
-/** Whether a draft can safely participate in a generated click command. */
 export function isReadyPushKnob(
   validation: PushKnobValidation,
 ): validation is Extract<PushKnobValidation, { value: number }> {
   return validation.state === "default" || validation.state === "valid";
 }
 
-/**
- * Parse the persisted restart-probability value with the same full-string and
- * float32-domain rules as the interactive field. A legacy stored `0` is
- * rejected and hydrates to the documented default instead.
- */
 export function parseStoredRestartProb(raw: string | null): number | null {
   return parseStoredPushKnob(raw, validateRestartProbInput);
 }
 
-/** Like {@link parseStoredRestartProb}, but for the positive epsilon domain. */
 export function parseStoredEpsilon(raw: string | null): number | null {
   return parseStoredPushKnob(raw, validateEpsilonInput);
 }
 
-/**
- * Parse a stored vertex prefix. Prefix is free text, so every non-null
- * string is valid (including ""); only a missing key returns null, letting
- * the caller fall back to {@link CLI_CLICK_AXIS_DEFAULTS}.vertexPrefix.
- */
 export function parseStoredPrefix(raw: string | null): string | null {
   return raw;
 }
 
-/** Inverse of the parse helpers; numeric axes serialise as base-10 ints. */
-export function formatStoredStep(value: number): string {
-  return String(value);
+function parseBfsAxes(value: unknown): BfsCliClickAxes | null {
+  if (!isRecord(value) || value.family !== "bfs") return null;
+  const reduction = parseStoredReduction(asString(value.reduction));
+  const objective = parseStoredObjective(asString(value.objective));
+  const weighting = parseStoredWeighting(asString(value.weighting));
+  const vertexPrefix = asString(value.vertexPrefix);
+  const step = parseStoredInt(
+    asString(value.step),
+    CLI_CLICK_BFS_STEP_MIN,
+    CLI_CLICK_BFS_STEP_MAX,
+  );
+  const fanOut = parseStoredInt(
+    asString(value.fanOut),
+    CLI_CLICK_BFS_FAN_OUT_MIN,
+    CLI_CLICK_BFS_FAN_OUT_MAX,
+  );
+  if (
+    !reduction ||
+    !objective ||
+    !weighting ||
+    vertexPrefix === null ||
+    !step ||
+    !fanOut
+  ) {
+    return null;
+  }
+  return {
+    family: "bfs",
+    step,
+    fanOut,
+    reduction,
+    objective,
+    weighting,
+    vertexPrefix,
+  };
 }
 
-export function formatStoredK(value: number): string {
-  return String(value);
+function parsePagerankAxes(value: unknown): PagerankCliClickAxes | null {
+  if (!isRecord(value) || value.family !== "pagerank") return null;
+  const weighting = parseStoredWeighting(asString(value.weighting));
+  const vertexPrefix = asString(value.vertexPrefix);
+  const topN = parseStoredInt(
+    asString(value.topN),
+    CLI_CLICK_TOP_N_MIN,
+    CLI_CLICK_TOP_N_MAX,
+  );
+  const restartProb = parseStoredV2PushKnob(
+    asString(value.restartProb),
+    validateRestartProbInput,
+  );
+  const epsilon = parseStoredV2PushKnob(
+    asString(value.epsilon),
+    validateEpsilonInput,
+  );
+  if (
+    !weighting ||
+    vertexPrefix === null ||
+    topN === null ||
+    restartProb === null ||
+    epsilon === null
+  ) {
+    return null;
+  }
+  return {
+    family: "pagerank",
+    topN,
+    restartProb,
+    epsilon,
+    weighting,
+    vertexPrefix,
+  };
 }
 
-/**
- * Serialise a validated PPR knob for localStorage. Defaults use blank text so
- * the next hydration distinguishes the documented default from a retired,
- * explicit zero value that no longer satisfies either family domain.
- */
-export function formatStoredFloat(value: number): string {
-  return value === 0 ? "" : String(value);
+function parseCommunityAxes(value: unknown): CommunityCliClickAxes | null {
+  if (!isRecord(value) || value.family !== "community") return null;
+  const reduction = parseStoredReduction(asString(value.reduction));
+  const objective = parseStoredObjective(asString(value.objective));
+  const weighting = parseStoredWeighting(asString(value.weighting));
+  const vertexPrefix = asString(value.vertexPrefix);
+  const maxSize = parseStoredInt(
+    asString(value.maxSize),
+    CLI_CLICK_MAX_SIZE_MIN,
+    CLI_CLICK_MAX_SIZE_MAX,
+  );
+  const restartProb = parseStoredV2PushKnob(
+    asString(value.restartProb),
+    validateRestartProbInput,
+  );
+  const epsilon = parseStoredV2PushKnob(
+    asString(value.epsilon),
+    validateEpsilonInput,
+  );
+  if (
+    !reduction ||
+    !objective ||
+    !weighting ||
+    vertexPrefix === null ||
+    maxSize === null ||
+    restartProb === null ||
+    epsilon === null
+  ) {
+    return null;
+  }
+  return {
+    family: "community",
+    maxSize,
+    restartProb,
+    epsilon,
+    reduction,
+    objective,
+    weighting,
+    vertexPrefix,
+  };
 }
 
 function validatePushKnob(
@@ -352,9 +560,6 @@ function validatePushKnob(
   if (!Number.isFinite(wireValue) || !acceptsFloat32(wireValue)) {
     return { state: "invalid", message };
   }
-  // Preserve the concise decimal the operator supplied. Domain checks use the
-  // float32 value above, so this remains wire-equivalent to the CLI parser
-  // without turning `1e-4` into a long binary32 decimal in the command text.
   return { state: "valid", value };
 }
 
@@ -376,15 +581,25 @@ function parseStoredPushKnob(
   return isReadyPushKnob(result) ? result.value : null;
 }
 
+// The retired flat keys treated an explicit "0" as malformed. In the v2
+// snapshot zero is an intentional, typed sentinel and is serialised as a JSON
+// number, so accept it before applying the shared text-field validation.
+function parseStoredV2PushKnob(
+  raw: string | null,
+  validate: (value: string) => PushKnobValidation,
+): number | null {
+  if (raw === "0") return 0;
+  return parseStoredPushKnob(raw, validate);
+}
+
 function parseStoredInt(
   raw: string | null,
   lo: number,
   hi: number,
 ): number | null {
-  if (raw === null) return null;
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isInteger(n)) return null;
-  if (n < lo || n > hi) return null;
+  if (raw === null || !/^[+-]?\d+$/.test(raw)) return null;
+  const n = Number(raw);
+  if (!Number.isSafeInteger(n) || n < lo || n > hi) return null;
   return n;
 }
 
@@ -393,8 +608,18 @@ function matchOption<T extends string>(
   options: ReadonlyArray<{ value: T }>,
 ): T | null {
   if (raw === null) return null;
-  for (const opt of options) {
-    if (opt.value === raw) return opt.value;
+  for (const option of options) {
+    if (option.value === raw) return option.value;
   }
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
   return null;
 }

--- a/admin/app/lib/client/usecase/cli/use-cli-axis-picker.ts
+++ b/admin/app/lib/client/usecase/cli/use-cli-axis-picker.ts
@@ -5,21 +5,15 @@ import {
 } from "~/lib/client/infrastructure/browser/storage";
 import {
   AXIS_STORAGE_KEYS,
-  CLI_CLICK_AXIS_DEFAULTS,
-  formatStoredFloat,
-  formatStoredK,
-  formatStoredStep,
-  parseStoredAlgorithm,
-  parseStoredEpsilon,
-  parseStoredK,
-  parseStoredObjective,
-  parseStoredPrefix,
-  parseStoredRestartProb,
-  parseStoredReduction,
-  parseStoredStep,
-  parseStoredWeighting,
+  migrateLegacyCliClickPickerState,
+  parseStoredCliClickPickerState,
+  replaceCliClickFamilyAxes,
+  selectCliClickFamily,
+  serialiseCliClickPickerState,
   type CliClickAxes,
+  type CliClickPickerState,
 } from "~/lib/cli/illuminate-axes";
+import type { AlgorithmName } from "~/lib/cli/types";
 
 export interface UseCliAxisPickerOptions {
   /** Override for tests. Defaults to {@link browserStorage}. */
@@ -27,25 +21,21 @@ export interface UseCliAxisPickerOptions {
 }
 
 export interface CliAxisPickerApi {
+  /** The selected family's native controls and no irrelevant fields. */
   axes: CliClickAxes;
-  setAxis<K extends keyof CliClickAxes>(key: K, value: CliClickAxes[K]): void;
+  selectFamily(family: AlgorithmName): void;
+  setAxes(axes: CliClickAxes): void;
 }
 
 /**
- * Owns the click-to-illuminate axis picker state on the /cli page (#464).
+ * Owns the family-native picker state. A versioned localStorage snapshot keeps
+ * one last-used value set per family, so switching from PageRank to BFS never
+ * turns `top_n` into `fan_out` or overwrites the PageRank configuration.
  *
- * The initial render lazily hydrates from localStorage so the picker
- * survives page reloads — a refresh is the most common way an operator
- * loses an in-flight exploration session, and the previous hard-coded
- * `step:2 k:5` click ignored any prior tuning. Each setter writes back
- * synchronously; invalid or out-of-range stored values are silently
- * replaced with the documented defaults so a corrupted entry never
- * crashes the page.
- *
- * The hook deliberately mirrors {@link useCliSplitter}: storage is
- * injectable for tests, the React surface is one piece of state plus
- * one setter, and DOM-coupled wiring (Fluent UI Dropdowns / Switches)
- * lives in the component that consumes the hook — not here.
+ * The first hydration migrates the retired flat keys. Its ambiguous `k` is
+ * applied solely to whichever family was selected at migration time; every
+ * other family gets its documented default. The v2 snapshot then takes
+ * precedence on all later loads.
  */
 export function useCliAxisPicker(
   options: UseCliAxisPickerOptions = {},
@@ -54,64 +44,24 @@ export function useCliAxisPicker(
     () => options.storage ?? browserStorage(),
     [options.storage],
   );
-
-  const [axes, setAxes] = useState<CliClickAxes>(() => ({
-    step:
-      parseStoredStep(store.get(AXIS_STORAGE_KEYS.step)) ??
-      CLI_CLICK_AXIS_DEFAULTS.step,
-    k:
-      parseStoredK(store.get(AXIS_STORAGE_KEYS.k)) ?? CLI_CLICK_AXIS_DEFAULTS.k,
-    algorithm:
-      parseStoredAlgorithm(store.get(AXIS_STORAGE_KEYS.algorithm)) ??
-      CLI_CLICK_AXIS_DEFAULTS.algorithm,
-    reduction:
-      parseStoredReduction(store.get(AXIS_STORAGE_KEYS.reduction)) ??
-      CLI_CLICK_AXIS_DEFAULTS.reduction,
-    objective:
-      parseStoredObjective(store.get(AXIS_STORAGE_KEYS.objective)) ??
-      CLI_CLICK_AXIS_DEFAULTS.objective,
-    weighting:
-      parseStoredWeighting(store.get(AXIS_STORAGE_KEYS.weighting)) ??
-      CLI_CLICK_AXIS_DEFAULTS.weighting,
-    vertexPrefix:
-      parseStoredPrefix(store.get(AXIS_STORAGE_KEYS.vertexPrefix)) ??
-      CLI_CLICK_AXIS_DEFAULTS.vertexPrefix,
-    restartProb:
-      parseStoredRestartProb(store.get(AXIS_STORAGE_KEYS.restartProb)) ??
-      CLI_CLICK_AXIS_DEFAULTS.restartProb,
-    epsilon:
-      parseStoredEpsilon(store.get(AXIS_STORAGE_KEYS.epsilon)) ??
-      CLI_CLICK_AXIS_DEFAULTS.epsilon,
-  }));
-
-  // Re-persist whenever the axes change. We persist all nine every time
-  // rather than diffing because the picker fires at most once per user
-  // gesture — a Dropdown selection, a Switch toggle, or a keystroke in the
-  // prefix field — so the cost is negligible and avoids subtle bugs from
-  // forgetting to persist a key after splitting setters apart.
-  useEffect(() => {
-    store.set(AXIS_STORAGE_KEYS.step, formatStoredStep(axes.step));
-    store.set(AXIS_STORAGE_KEYS.k, formatStoredK(axes.k));
-    store.set(AXIS_STORAGE_KEYS.algorithm, axes.algorithm);
-    store.set(AXIS_STORAGE_KEYS.reduction, axes.reduction);
-    store.set(AXIS_STORAGE_KEYS.objective, axes.objective);
-    store.set(AXIS_STORAGE_KEYS.weighting, axes.weighting);
-    store.set(AXIS_STORAGE_KEYS.vertexPrefix, axes.vertexPrefix);
-    store.set(
-      AXIS_STORAGE_KEYS.restartProb,
-      formatStoredFloat(axes.restartProb),
+  const [state, setState] = useState<CliClickPickerState>(() => {
+    return (
+      parseStoredCliClickPickerState(store.get(AXIS_STORAGE_KEYS.state)) ??
+      migrateLegacyCliClickPickerState(store)
     );
-    store.set(AXIS_STORAGE_KEYS.epsilon, formatStoredFloat(axes.epsilon));
-  }, [axes, store]);
+  });
 
-  const setAxis = useCallback(
-    <K extends keyof CliClickAxes>(key: K, value: CliClickAxes[K]) => {
-      setAxes((prev) =>
-        Object.is(prev[key], value) ? prev : { ...prev, [key]: value },
-      );
-    },
-    [],
-  );
+  useEffect(() => {
+    store.set(AXIS_STORAGE_KEYS.state, serialiseCliClickPickerState(state));
+  }, [state, store]);
 
-  return { axes, setAxis };
+  const selectFamily = useCallback((family: AlgorithmName) => {
+    setState((previous) => selectCliClickFamily(previous, family));
+  }, []);
+
+  const setAxes = useCallback((axes: CliClickAxes) => {
+    setState((previous) => replaceCliClickFamilyAxes(previous, axes));
+  }, []);
+
+  return { axes: state.families[state.selectedFamily], selectFamily, setAxes };
 }

--- a/admin/tests/e2e/browse.spec.ts
+++ b/admin/tests/e2e/browse.spec.ts
@@ -102,11 +102,12 @@ test.describe("/vertices", () => {
     await illuminate.click();
     // #651 folded Illuminate into the CLI: the row action now lands on /cli
     // with the row key as ?seed=, and the seed handoff auto-runs the
-    // canonical `bfs <key> 2 5`, so the canvas opens on that command.
+    // family-native default `bfs <key> 5 3`, so the canvas opens on that
+    // command.
     await expect(page).toHaveURL(/\/cli\?seed=e2e%3Avertex%3Aa/);
     await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
     await expect(page.getByTestId("cli-canvas-panel")).toContainText(
-      "bfs e2e:vertex:a 2 5",
+      "bfs e2e:vertex:a 5 3",
     );
   });
 
@@ -127,7 +128,7 @@ test.describe("/vertices", () => {
     // to the server.
     await expect(page).toHaveURL(/\/cli\?seed=e2e%3Aliteral%3A%252F/);
     await expect(page.getByTestId("cli-canvas-panel")).toContainText(
-      "bfs e2e:literal:%2F 2 5",
+      "bfs e2e:literal:%2F 5 3",
     );
   });
 
@@ -254,11 +255,12 @@ test.describe("/vertices — content search (#650)", () => {
     await expect(illuminate).toBeVisible();
     await illuminate.click();
     // #651 — content-search hit hands off to /cli, same as a prefix-scan
-    // row: the seed handoff runs `bfs <key> 2 5` onto the canvas.
+    // row: the seed handoff runs the family-native `bfs <key> 5 3` onto the
+    // canvas.
     await expect(page).toHaveURL(/\/cli\?seed=e2e%3Asearch%3Adoc3/);
     await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
     await expect(page.getByTestId("cli-canvas-panel")).toContainText(
-      "bfs e2e:search:doc3 2 5",
+      "bfs e2e:search:doc3 5 3",
     );
   });
 });

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -245,7 +245,7 @@ test.describe("/cli", () => {
     // The source records the exact command submitted by the canvas callback;
     // the depth-two-only target proves the RPC received `cli:quoted key`, not
     // the two tokens that an unquoted space would have produced.
-    await expect(panel).toContainText('bfs "cli:quoted key" 2 5');
+    await expect(panel).toContainText('bfs "cli:quoted key" 5 3');
     await expect
       .poll(() =>
         page.evaluate(() => {
@@ -613,26 +613,62 @@ test.describe("/cli", () => {
     page,
   }) => {
     await page.goto("/cli");
-    // The picker lives inside the canvas panel, so render a graph first
-    // to mount it (#512).
-    const input = page.getByTestId("cli-input");
-    await input.fill("get vertex cli:alpha");
-    await input.press("Enter");
-    await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
+    // Family choice is discoverable before a graph exists (#991).
+    await expect(page.getByTestId("cli-canvas-panel")).toHaveCount(0);
     const picker = page.getByTestId("cli-axis-picker");
     await expect(picker).toBeVisible();
-    // Defaults: step=2, k=5, algorithm=bfs, reduction=none, objective=max,
-    // weighting=raw → short form `bfs <key> 2 5`.
+    // Defaults match each native parser family; BFS starts at 5 hops and a
+    // fan-out of 3 rather than leaking the old shared step/k values.
     await expect(page.getByTestId("cli-axis-preview")).toHaveText(
-      "bfs <key> 2 5",
+      "bfs <key> 5 3",
     );
-    await expect(page.getByTestId("cli-axis-step")).toHaveValue("2");
-    await expect(page.getByTestId("cli-axis-k")).toHaveValue("5");
+    await expect(page.getByTestId("cli-axis-step")).toHaveValue("5");
+    await expect(page.getByTestId("cli-axis-k")).toHaveValue("3");
     await expect(page.getByTestId("cli-axis-weighting")).toBeVisible();
-    // Canvas-header hint mirrors the picker.
-    await expect(page.getByTestId("cli-click-hint")).toHaveText(
-      "bfs <key> 2 5",
+  });
+
+  test("family choice is usable before a graph on a phone viewport (#991)", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/cli");
+    const picker = page.getByTestId("cli-axis-picker");
+    await expect(picker).toBeVisible();
+    await page.getByTestId("cli-axis-algorithm").click();
+    await page.getByRole("option", { name: "Personalized PageRank" }).click();
+    await expect(page.getByTestId("cli-axis-preview")).toHaveText(
+      "pagerank <key> 10",
     );
+    await expect(page.getByTestId("cli-axis-step")).toHaveCount(0);
+    await expect(page.getByTestId("cli-axis-reduction")).toHaveCount(0);
+    await expect(page.getByTestId("cli-axis-k")).toHaveValue("10");
+  });
+
+  test("family switches keep separate last-used native values (#991)", async ({
+    page,
+  }) => {
+    await page.goto("/cli");
+    await page.getByTestId("cli-axis-step").fill("4");
+    await page.getByTestId("cli-axis-k").fill("9");
+    await expect(page.getByTestId("cli-axis-preview")).toHaveText(
+      "bfs <key> 4 9",
+    );
+
+    await page.getByTestId("cli-axis-algorithm").click();
+    await page.getByRole("option", { name: "Personalized PageRank" }).click();
+    await page.getByTestId("cli-axis-k").fill("0");
+    await expect(page.getByTestId("cli-axis-preview")).toHaveText(
+      "pagerank <key> 0",
+    );
+
+    await page.getByTestId("cli-axis-algorithm").click();
+    await page.getByRole("option", { name: "BFS (per-hop top-k)" }).click();
+    await expect(page.getByTestId("cli-axis-step")).toHaveValue("4");
+    await expect(page.getByTestId("cli-axis-k")).toHaveValue("9");
+
+    await page.getByTestId("cli-axis-algorithm").click();
+    await page.getByRole("option", { name: "Personalized PageRank" }).click();
+    await expect(page.getByTestId("cli-axis-k")).toHaveValue("0");
   });
 
   test("tuning axes updates the picker preview to the long form (#464)", async ({
@@ -646,12 +682,12 @@ test.describe("/cli", () => {
     await input.press("Enter");
     await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
     const preview = page.getByTestId("cli-axis-preview");
-    await expect(preview).toHaveText("bfs <key> 2 5");
+    await expect(preview).toHaveText("bfs <key> 5 3");
 
     // Bump step and k to long-form values.
     const step = page.getByTestId("cli-axis-step");
     await step.fill("3");
-    await expect(preview).toHaveText("bfs <key> 3 5");
+    await expect(preview).toHaveText("bfs <key> 3 3");
     const k = page.getByTestId("cli-axis-k");
     await k.fill("10");
     await expect(preview).toHaveText("bfs <key> 3 10");
@@ -661,21 +697,21 @@ test.describe("/cli", () => {
     // the preview drops the step and echoes `community <key> <max_size>`.
     await page.getByTestId("cli-axis-algorithm").click();
     await page.getByRole("option", { name: "Local community" }).click();
-    await expect(preview).toHaveText("community <key> 10");
+    await expect(preview).toHaveText("community <key> 0");
 
     // Pick reduction=spt via the reduction Dropdown (#961). The reduction
     // axis is orthogonal to the family and slots in right after the
     // max_size positional.
     await page.getByTestId("cli-axis-reduction").click();
     await page.getByRole("option", { name: "Shortest-path tree" }).click();
-    await expect(preview).toHaveText("community <key> 10 reduction=spt");
+    await expect(preview).toHaveText("community <key> 0 reduction=spt");
 
     // Pick objective=min (max is the default, so it would be omitted). For a
     // reduction this steers the tree direction (#961).
     await page.getByTestId("cli-axis-objective").click();
     await page.getByRole("option", { name: /Minimize/ }).click();
     await expect(preview).toHaveText(
-      "community <key> 10 reduction=spt objective=min",
+      "community <key> 0 reduction=spt objective=min",
     );
 
     // Pick weighting=bm25 via the Dropdown. Token order must be
@@ -683,12 +719,12 @@ test.describe("/cli", () => {
     await page.getByTestId("cli-axis-weighting").click();
     await page.getByRole("option", { name: "BM25" }).click();
     await expect(preview).toHaveText(
-      "community <key> 10 reduction=spt objective=min weighting=bm25",
+      "community <key> 0 reduction=spt objective=min weighting=bm25",
     );
 
     // The header hint tracks the picker.
     await expect(page.getByTestId("cli-click-hint")).toHaveText(
-      "community <key> 10 reduction=spt objective=min weighting=bm25",
+      "community <key> 0 reduction=spt objective=min weighting=bm25",
     );
   });
 
@@ -706,7 +742,7 @@ test.describe("/cli", () => {
     await input.press("Enter");
     await expect(page.getByTestId("cli-canvas-panel")).toBeVisible();
     const preview = page.getByTestId("cli-axis-preview");
-    await expect(preview).toHaveText("bfs <key> 2 5");
+    await expect(preview).toHaveText("bfs <key> 5 3");
 
     // The knobs are hidden until the pagerank family is active.
     await expect(page.getByTestId("cli-axis-restart-prob")).toHaveCount(0);
@@ -721,7 +757,7 @@ test.describe("/cli", () => {
     // from the click string until set.
     await page.getByTestId("cli-axis-algorithm").click();
     await page.getByRole("option", { name: "Personalized PageRank" }).click();
-    await expect(preview).toHaveText("pagerank <key> 5");
+    await expect(preview).toHaveText("pagerank <key> 10");
     const restartProb = page.getByTestId("cli-axis-restart-prob");
     const epsilon = page.getByTestId("cli-axis-epsilon");
     await expect(restartProb).toBeVisible();
@@ -733,10 +769,10 @@ test.describe("/cli", () => {
     // Tuning a knob appends it after the positional, in fixed order
     // restart_prob → epsilon.
     await restartProb.fill("0.25");
-    await expect(preview).toHaveText("pagerank <key> 5 restart_prob=0.25");
+    await expect(preview).toHaveText("pagerank <key> 10 restart_prob=0.25");
     await epsilon.fill("0.001");
     await expect(preview).toHaveText(
-      "pagerank <key> 5 restart_prob=0.25 epsilon=0.001",
+      "pagerank <key> 10 restart_prob=0.25 epsilon=0.001",
     );
 
     // Switching back to the default bfs family hides the knobs again and
@@ -747,7 +783,7 @@ test.describe("/cli", () => {
     await expect(page.getByTestId("cli-axis-restart-prob")).toHaveCount(0);
     await expect(page.getByTestId("cli-axis-epsilon")).toHaveCount(0);
     await expect(page.getByTestId("cli-axis-reduction")).toBeVisible();
-    await expect(preview).toHaveText("bfs <key> 2 5");
+    await expect(preview).toHaveText("bfs <key> 5 3");
   });
 
   // #964 — the α/ε knobs must accept floats typed a keystroke at a time, not
@@ -767,7 +803,7 @@ test.describe("/cli", () => {
 
     await page.getByTestId("cli-axis-algorithm").click();
     await page.getByRole("option", { name: "Personalized PageRank" }).click();
-    await expect(preview).toHaveText("pagerank <key> 5");
+    await expect(preview).toHaveText("pagerank <key> 10");
 
     // Type a leading-zero decimal one key at a time: the field must retain each
     // keystroke (no blanking on the intermediate "0" / "0.") and the preview
@@ -776,7 +812,7 @@ test.describe("/cli", () => {
     await restartProb.click();
     await restartProb.pressSequentially("0.15");
     await expect(restartProb).toHaveValue("0.15");
-    await expect(preview).toHaveText("pagerank <key> 5 restart_prob=0.15");
+    await expect(preview).toHaveText("pagerank <key> 10 restart_prob=0.15");
 
     // Scientific notation must survive too — a `type="number"` field reports an
     // empty value for the intermediate "1e" / "1e-". The raw text is echoed
@@ -786,7 +822,7 @@ test.describe("/cli", () => {
     await epsilon.pressSequentially("1e-4");
     await expect(epsilon).toHaveValue("1e-4");
     await expect(preview).toHaveText(
-      "pagerank <key> 5 restart_prob=0.15 epsilon=0.0001",
+      "pagerank <key> 10 restart_prob=0.15 epsilon=0.0001",
     );
   });
 
@@ -817,7 +853,7 @@ test.describe("/cli", () => {
     // Invalid persisted values hydrate to blank/server-default drafts.
     await expect(restartProb).toHaveValue("");
     await expect(epsilon).toHaveValue("");
-    await expect(preview).toHaveText("pagerank <key> 5");
+    await expect(preview).toHaveText("pagerank <key> 10");
 
     for (const raw of [
       "0",
@@ -845,7 +881,7 @@ test.describe("/cli", () => {
     }
 
     await restartProb.fill("");
-    await expect(preview).toHaveText("pagerank <key> 5");
+    await expect(preview).toHaveText("pagerank <key> 10");
 
     for (const raw of ["0", "-0.1", "0.25suffix", "1e-50"]) {
       await epsilon.fill(raw);
@@ -861,11 +897,11 @@ test.describe("/cli", () => {
     // Blank is the only default spelling. A complete valid scientific value
     // then commits and produces the same parser-accepted command text.
     await epsilon.fill("");
-    await expect(preview).toHaveText("pagerank <key> 5");
+    await expect(preview).toHaveText("pagerank <key> 10");
     await epsilon.fill("1e-4");
     await expect(epsilon).toHaveValue("1e-4");
-    await expect(preview).toHaveText("pagerank <key> 5 epsilon=0.0001");
-    await expect(hint).toHaveText("pagerank <key> 5 epsilon=0.0001");
+    await expect(preview).toHaveText("pagerank <key> 10 epsilon=0.0001");
+    await expect(hint).toHaveText("pagerank <key> 10 epsilon=0.0001");
     await expect(page.getByTestId("cli-axis-command-blocked")).toHaveCount(0);
   });
 


### PR DESCRIPTION
## Summary
- replace the shared traversal-axis state with family-native BFS, PageRank, and community models
- keep independent last-used values when switching families and expose only controls valid for the selected family
- preserve the explicit one-family SDK request contract and improve narrow-screen picker usability

## Validation
- all Go module tests, `go vet`, and new-diff `golangci-lint`
- Node SDK build, typecheck, lint, format check, and tests
- Admin typecheck, lint, format check, unit tests, and production build
- `playwright test cli.spec.ts` (34 passed)

Closes #991