### PR TITLE
feat(admin): add accessible traversal result companion

### DIFF
--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -14,6 +14,7 @@ import type { ScrollbackEntry } from "~/lib/client/usecase/cli/state";
 import { CliAxisPicker } from "~/components/cli/CliAxisPicker/CliAxisPicker";
 import { CliCommandReference } from "~/components/cli/CliCommandReference/CliCommandReference";
 import { JsonView } from "~/components/cli/JsonView/JsonView";
+import { TraversalResultCompanion } from "~/components/cli/TraversalResultCompanion/TraversalResultCompanion";
 import { IlluminateCanvas } from "~/components/illuminate/IlluminateCanvas/IlluminateCanvas";
 import styles from "./CliPage.module.css";
 
@@ -366,7 +367,7 @@ export function CliPage() {
                 {cli.latestGraph.source}
               </code>
               <span className={styles.canvasMetaHint}>
-                click a node →{" "}
+                Next walk →{" "}
                 <code data-testid="cli-click-hint">
                   {isAxisPickerCommandValid
                     ? formatFamilyClick("<key>", axisPicker.axes)
@@ -390,6 +391,10 @@ export function CliPage() {
                 fill
               />
             </div>
+            <TraversalResultCompanion
+              graph={cli.latestGraph}
+              onRunFromHere={onNodeClick}
+            />
           </div>
         </section>
       ) : null}

--- a/admin/app/components/cli/TraversalResultCompanion/TraversalResultCompanion.module.css
+++ b/admin/app/components/cli/TraversalResultCompanion/TraversalResultCompanion.module.css
@@ -1,0 +1,82 @@
+.root {
+  flex: 0 1 224px;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--spacingVerticalS, 8px) var(--spacingHorizontalM, 12px);
+  border-top: 1px solid var(--colorNeutralStroke2, #e0e0e0);
+  background: var(--colorNeutralBackground2, #fafafa);
+  color: var(--colorNeutralForeground1, #242424);
+}
+
+.heading {
+  display: flex;
+  gap: var(--spacingHorizontalS, 8px);
+  align-items: baseline;
+}
+
+.heading h2 {
+  margin: 0;
+  font-size: var(--fontSizeBase300, 14px);
+}
+
+.heading p {
+  margin: var(--spacingVerticalXXS, 2px) 0 var(--spacingVerticalS, 8px);
+  color: var(--colorNeutralForeground3, #707070);
+  font-size: var(--fontSizeBase100, 10px);
+}
+
+.summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(104px, 1fr));
+  gap: var(--spacingVerticalXXS, 2px) var(--spacingHorizontalM, 12px);
+  margin: 0 0 var(--spacingVerticalS, 8px);
+}
+
+.summary div {
+  min-width: 0;
+}
+
+.summary dt {
+  color: var(--colorNeutralForeground3, #707070);
+  font-size: var(--fontSizeBase100, 10px);
+}
+
+.summary dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-family: var(--fontFamilyMonospace, ui-monospace, monospace);
+  font-size: var(--fontSizeBase200, 12px);
+}
+
+.tableWrap {
+  overflow-x: auto;
+  margin-top: var(--spacingVerticalS, 8px);
+}
+
+.tableWrap table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--fontSizeBase200, 12px);
+}
+
+.tableWrap caption {
+  padding-bottom: var(--spacingVerticalXXS, 2px);
+  text-align: left;
+  font-weight: 600;
+}
+
+.tableWrap th,
+.tableWrap td {
+  padding: var(--spacingVerticalXXS, 2px) var(--spacingHorizontalXS, 4px);
+  border-top: 1px solid var(--colorNeutralStroke3, #ededed);
+  text-align: left;
+  vertical-align: middle;
+  overflow-wrap: anywhere;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacingHorizontalS, 8px);
+}

--- a/admin/app/components/cli/TraversalResultCompanion/TraversalResultCompanion.tsx
+++ b/admin/app/components/cli/TraversalResultCompanion/TraversalResultCompanion.tsx
@@ -1,0 +1,140 @@
+import { Button } from "@fluentui/react-components";
+import { Link } from "react-router";
+import type { LatestGraph } from "~/lib/client/usecase/cli/state";
+import { buildTraversalResultModel } from "~/lib/client/usecase/cli/traversal-result";
+import styles from "./TraversalResultCompanion.module.css";
+
+export interface TraversalResultCompanionProps {
+  graph: LatestGraph;
+  onRunFromHere: (key: string) => void;
+}
+
+/**
+ * Keyboard-accessible counterpart to the visual Sigma canvas. It exposes the
+ * exact current result's metadata, vertices, edges, and family-specific
+ * ranking without relying on colour, hover, or pointer interaction.
+ */
+export function TraversalResultCompanion({
+  graph,
+  onRunFromHere,
+}: TraversalResultCompanionProps) {
+  if (graph.traversal === null) return null;
+  const model = buildTraversalResultModel(graph.traversal, graph.view);
+
+  return (
+    <section
+      className={styles.root}
+      aria-label="Traversal result companion"
+      data-testid="traversal-result-companion"
+    >
+      <div className={styles.heading}>
+        <div>
+          <h2>Current result: {model.familyLabel}</h2>
+          <p>
+            These are the parameters that produced this result. “Run from here”
+            uses the separate Next walk controls in the terminal.
+          </p>
+        </div>
+      </div>
+
+      <dl className={styles.summary} data-testid="traversal-result-summary">
+        {model.summary.map((item) => (
+          <div key={item.label}>
+            <dt>{item.label}</dt>
+            <dd>{item.value}</dd>
+          </div>
+        ))}
+      </dl>
+
+      {model.pageRank.length > 0 ? (
+        <ResultTable caption="PageRank mass ranking">
+          <thead>
+            <tr>
+              <th scope="col">Rank</th>
+              <th scope="col">Vertex</th>
+              <th scope="col">Mass</th>
+            </tr>
+          </thead>
+          <tbody>
+            {model.pageRank.map((row) => (
+              <tr key={row.key}>
+                <td>{row.rank}</td>
+                <td>{row.key}</td>
+                <td>{row.mass}</td>
+              </tr>
+            ))}
+          </tbody>
+        </ResultTable>
+      ) : null}
+
+      <ResultTable caption={`Vertices (${model.vertices.length})`}>
+        <thead>
+          <tr>
+            <th scope="col">Vertex</th>
+            <th scope="col">BFS hop</th>
+            <th scope="col">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {model.vertices.map((row) => (
+            <tr key={row.key}>
+              <td>{row.key}</td>
+              <td>{row.hop}</td>
+              <td className={styles.actions}>
+                <Button
+                  size="small"
+                  onClick={() => onRunFromHere(row.key)}
+                  aria-label={`Run from ${row.key} using next-walk controls`}
+                >
+                  Run from here
+                </Button>
+                <Link
+                  to={`/vertices/${encodeURIComponent(row.key)}`}
+                  aria-label={`Inspect ${row.key}`}
+                >
+                  Inspect
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </ResultTable>
+
+      <ResultTable caption={`Edges (${model.edges.length})`}>
+        <thead>
+          <tr>
+            <th scope="col">Tail</th>
+            <th scope="col">Head</th>
+            <th scope="col">Weight</th>
+          </tr>
+        </thead>
+        <tbody>
+          {model.edges.map((row) => (
+            <tr key={`${row.source}→${row.target}`}>
+              <td>{row.source}</td>
+              <td>{row.target}</td>
+              <td>{row.weight}</td>
+            </tr>
+          ))}
+        </tbody>
+      </ResultTable>
+    </section>
+  );
+}
+
+function ResultTable({
+  caption,
+  children,
+}: {
+  caption: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={styles.tableWrap}>
+      <table>
+        <caption>{caption}</caption>
+        {children}
+      </table>
+    </div>
+  );
+}

--- a/admin/app/lib/client/usecase/cli/reducer.test.ts
+++ b/admin/app/lib/client/usecase/cli/reducer.test.ts
@@ -24,6 +24,7 @@ const GRAPH: LatestGraph = {
     latestResultVertexKeys: new Set<string>(),
     latestResultEdgeIds: new Set<string>(),
   },
+  traversal: null,
 };
 
 describe("cliReducer", () => {
@@ -316,6 +317,7 @@ describe("cliReducer", () => {
       });
       expect(next.latestGraph?.source).toBe("put vertex x 1");
       expect(next.latestGraph?.view.nodes.map((n) => n.id)).toEqual(["x"]);
+      expect(next.latestGraph?.traversal).toBeNull();
     });
 
     it("merges onto the existing frame instead of replacing it", () => {

--- a/admin/app/lib/client/usecase/cli/reducer.ts
+++ b/admin/app/lib/client/usecase/cli/reducer.ts
@@ -173,6 +173,9 @@ export function cliReducer(state: CliState, action: CliAction): CliState {
         latestGraph: {
           source: action.source,
           view: mergeGraphView(state.latestGraph?.view ?? null, action.merge),
+          // A merged write is a new canvas frame, not a traversal result. Do not
+          // present stale family parameters as if they described this frame.
+          traversal: null,
         },
       };
     }

--- a/admin/app/lib/client/usecase/cli/state.ts
+++ b/admin/app/lib/client/usecase/cli/state.ts
@@ -1,3 +1,4 @@
+import type { Command } from "~/lib/cli/types";
 import type { GraphView } from "~/lib/client/usecase/illuminate/selectors";
 
 export type EntryKind = "ok" | "error" | "info";
@@ -10,10 +11,26 @@ export interface ScrollbackEntry {
   durationMs?: number;
 }
 
+/** The exact family-native command that produced a traversal result. */
+export type TraversalCommand =
+  | Extract<Command, { verb: "bfs" }>
+  | Extract<Command, { verb: "pagerank" }>
+  | Extract<Command, { verb: "community" }>;
+
+/**
+ * Metadata for the current traversal result. It deliberately captures the
+ * executed family and knobs rather than the mutable next-click picker state.
+ */
+export interface TraversalResultMetadata {
+  command: TraversalCommand;
+}
+
 export interface LatestGraph {
   /** The exact CLI input that produced this graph (`get vertex alice`, …). */
   source: string;
   view: GraphView;
+  /** Null for get/scan/mutated frames; set only for an executed family verb. */
+  traversal: TraversalResultMetadata | null;
 }
 
 /**

--- a/admin/app/lib/client/usecase/cli/traversal-result.test.ts
+++ b/admin/app/lib/client/usecase/cli/traversal-result.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "bun:test";
+import type { GraphView } from "~/lib/client/usecase/illuminate/selectors";
+import { buildTraversalResultModel } from "./traversal-result";
+
+const VIEW: GraphView = {
+  nodes: [
+    {
+      id: "seed",
+      label: "seed",
+      vertex: { key: "seed" },
+      isInitialSeed: true,
+      isExpansionOrigin: true,
+      importance: 1,
+      firstSeenExpansion: 0,
+      hopDistance: 0,
+    },
+    {
+      id: "bravo",
+      label: "bravo",
+      vertex: { key: "bravo" },
+      isInitialSeed: false,
+      isExpansionOrigin: false,
+      importance: 0.5,
+      firstSeenExpansion: 0,
+      hopDistance: 1,
+    },
+    {
+      id: "alpha",
+      label: "alpha",
+      vertex: { key: "alpha" },
+      isInitialSeed: false,
+      isExpansionOrigin: false,
+      importance: 0.5,
+      firstSeenExpansion: 0,
+      hopDistance: Number.POSITIVE_INFINITY,
+    },
+  ],
+  edges: [
+    {
+      id: "seed→bravo",
+      source: "seed",
+      target: "bravo",
+      weight: 0.2,
+      edge: { tail: "seed", head: "bravo", weight: 0.2 },
+    },
+    {
+      id: "seed→alpha",
+      source: "seed",
+      target: "alpha",
+      weight: 0.8,
+      edge: { tail: "seed", head: "alpha", weight: 0.8 },
+    },
+  ],
+  latestExpansionOrigin: "seed",
+  expansionOrigins: ["seed"],
+  overSoftCap: false,
+  latestResultVertexKeys: new Set(),
+  latestResultEdgeIds: new Set(),
+};
+
+describe("buildTraversalResultModel", () => {
+  it("keeps executed BFS metadata separate from the canvas projection", () => {
+    const result = buildTraversalResultModel(
+      {
+        command: {
+          verb: "bfs",
+          seed: "seed",
+          step: 3,
+          fanOut: 7,
+          reduction: "spt",
+          objective: "min",
+          weighting: "tfidf",
+          vertexPrefix: "team:",
+        },
+      },
+      VIEW,
+    );
+    expect(result.familyLabel).toBe("BFS");
+    expect(result.summary).toContainEqual({ label: "Step", value: "3" });
+    expect(result.summary).toContainEqual({
+      label: "Vertex prefix",
+      value: "team:",
+    });
+    expect(result.vertices.map((row) => row.key)).toEqual([
+      "alpha",
+      "bravo",
+      "seed",
+    ]);
+  });
+
+  it("ranks PageRank mass descending and breaks ties by key", () => {
+    const result = buildTraversalResultModel(
+      {
+        command: {
+          verb: "pagerank",
+          seed: "seed",
+          topN: 2,
+          restartProb: 0.25,
+          epsilon: 0.001,
+          weighting: "raw",
+          vertexPrefix: "",
+        },
+      },
+      VIEW,
+    );
+    expect(result.familyLabel).toBe("Personalized PageRank");
+    expect(result.pageRank).toEqual([
+      { rank: 1, key: "alpha", mass: 0.8 },
+      { rank: 2, key: "bravo", mass: 0.2 },
+    ]);
+  });
+
+  it("describes the LocalCommunity max-size sentinel and reduction", () => {
+    const result = buildTraversalResultModel(
+      {
+        command: {
+          verb: "community",
+          seed: "seed",
+          maxSize: 0,
+          restartProb: 0,
+          epsilon: 0,
+          reduction: "mst",
+          objective: "max",
+          weighting: "bm25",
+          vertexPrefix: "",
+        },
+      },
+      VIEW,
+    );
+    expect(result.familyLabel).toBe("Local community");
+    expect(result.summary).toContainEqual({
+      label: "Max size",
+      value: "unbounded",
+    });
+    expect(result.summary).toContainEqual({ label: "Reduction", value: "mst" });
+  });
+});

--- a/admin/app/lib/client/usecase/cli/traversal-result.ts
+++ b/admin/app/lib/client/usecase/cli/traversal-result.ts
@@ -1,0 +1,160 @@
+import type { GraphView } from "~/lib/client/usecase/illuminate/selectors";
+import type { TraversalResultMetadata } from "./state";
+
+export interface TraversalSummaryItem {
+  label: string;
+  value: string;
+}
+
+export interface TraversalVertexRow {
+  key: string;
+  hop: string;
+}
+
+export interface TraversalEdgeRow {
+  source: string;
+  target: string;
+  weight: number;
+}
+
+export interface PageRankRow {
+  rank: number;
+  key: string;
+  mass: number;
+}
+
+export interface TraversalResultModel {
+  familyLabel: string;
+  summary: TraversalSummaryItem[];
+  vertices: TraversalVertexRow[];
+  edges: TraversalEdgeRow[];
+  pageRank: PageRankRow[];
+}
+
+/**
+ * Builds an AT-friendly model from the exact result-producing command and
+ * the canvas projection. The executed command remains independent from the
+ * next-click picker, which may have changed after the result arrived.
+ */
+export function buildTraversalResultModel(
+  traversal: TraversalResultMetadata,
+  view: GraphView,
+): TraversalResultModel {
+  const vertices = [...view.nodes]
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map((node) => ({
+      key: node.id,
+      hop: Number.isFinite(node.hopDistance)
+        ? String(node.hopDistance)
+        : "not applicable",
+    }));
+  const edges = [...view.edges]
+    .sort(
+      (a, b) =>
+        a.source.localeCompare(b.source) || a.target.localeCompare(b.target),
+    )
+    .map((edge) => ({
+      source: edge.source,
+      target: edge.target,
+      weight: edge.weight,
+    }));
+  const common: TraversalSummaryItem[] = [
+    { label: "Seed", value: traversal.command.seed },
+    { label: "Members", value: String(vertices.length) },
+    { label: "Edges", value: String(edges.length) },
+    { label: "Weighting", value: traversal.command.weighting },
+  ];
+  if (traversal.command.vertexPrefix !== "") {
+    common.push({
+      label: "Vertex prefix",
+      value: traversal.command.vertexPrefix,
+    });
+  }
+
+  switch (traversal.command.verb) {
+    case "bfs": {
+      const hops = view.nodes
+        .map((node) => node.hopDistance)
+        .filter(Number.isFinite);
+      return {
+        familyLabel: "BFS",
+        summary: [
+          ...common,
+          {
+            label: "Hops returned",
+            value: hops.length === 0 ? "0" : String(Math.max(...hops)),
+          },
+          { label: "Step", value: String(traversal.command.step) },
+          { label: "Fan-out", value: String(traversal.command.fanOut) },
+          { label: "Reduction", value: traversal.command.reduction },
+          { label: "Objective", value: traversal.command.objective },
+        ],
+        vertices,
+        edges,
+        pageRank: [],
+      };
+    }
+    case "pagerank": {
+      const pageRank = view.edges
+        .filter((edge) => edge.source === traversal.command.seed)
+        .map((edge) => ({ key: edge.target, mass: edge.weight }))
+        .sort((a, b) => b.mass - a.mass || a.key.localeCompare(b.key))
+        .map((row, index) => ({ ...row, rank: index + 1 }));
+      return {
+        familyLabel: "Personalized PageRank",
+        summary: [
+          ...common,
+          {
+            label: "Top N",
+            value:
+              traversal.command.topN === 0
+                ? "all positive mass"
+                : String(traversal.command.topN),
+          },
+          {
+            label: "Restart probability",
+            value: formatPushKnob(traversal.command.restartProb),
+          },
+          {
+            label: "Epsilon",
+            value: formatPushKnob(traversal.command.epsilon),
+          },
+        ],
+        vertices,
+        edges,
+        pageRank,
+      };
+    }
+    case "community":
+      return {
+        familyLabel: "Local community",
+        summary: [
+          ...common,
+          {
+            label: "Max size",
+            value:
+              traversal.command.maxSize === 0
+                ? "unbounded"
+                : String(traversal.command.maxSize),
+          },
+          {
+            label: "Restart probability",
+            value: formatPushKnob(traversal.command.restartProb),
+          },
+          {
+            label: "Epsilon",
+            value: formatPushKnob(traversal.command.epsilon),
+          },
+          { label: "Reduction", value: traversal.command.reduction },
+          { label: "Objective", value: traversal.command.objective },
+        ],
+        vertices,
+        edges,
+        pageRank: [],
+      };
+  }
+}
+
+function formatPushKnob(value: number): string {
+  return value === 0 ? "server default" : String(value);
+}

--- a/admin/app/lib/client/usecase/cli/use-cli.ts
+++ b/admin/app/lib/client/usecase/cli/use-cli.ts
@@ -21,6 +21,7 @@ import {
   INITIAL_CLI_STATE,
   type LatestGraph,
   type ScrollbackEntry,
+  type TraversalResultMetadata,
 } from "./state";
 
 /**
@@ -159,7 +160,11 @@ export function useCli(): UseCliResult {
         if (view !== null) {
           dispatch({
             type: "GRAPH_UPDATED",
-            graph: { source: rawInput, view },
+            graph: {
+              source: rawInput,
+              view,
+              traversal: traversalResultMetadata(command),
+            },
           });
         } else {
           const merge = commandResultToGraphMerge(command);
@@ -418,6 +423,19 @@ export function useCli(): UseCliResult {
       cancelInFlight,
     ],
   );
+}
+
+function traversalResultMetadata(
+  command: Command,
+): TraversalResultMetadata | null {
+  switch (command.verb) {
+    case "bfs":
+    case "pagerank":
+    case "community":
+      return { command };
+    default:
+      return null;
+  }
 }
 
 function replacer(_key: string, value: unknown): unknown {

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -276,10 +276,16 @@ test.describe("/cli", () => {
     );
     await input.press("Enter");
     await expect(
-      companion.getByRole("heading", { name: "Current result: Local community" }),
+      companion.getByRole("heading", {
+        name: "Current result: Local community",
+      }),
     ).toBeVisible();
-    await expect(companion.getByText("Max size", { exact: true })).toBeVisible();
-    await expect(companion.getByText("Reduction", { exact: true })).toBeVisible();
+    await expect(
+      companion.getByText("Max size", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      companion.getByText("Reduction", { exact: true }),
+    ).toBeVisible();
   });
 
   test("canvas node click quotes an arbitrary key before reaching the RPC (#988)", async ({

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -101,6 +101,12 @@ async function assertNarrowExplorer(page: Page): Promise<void> {
   const labelControls = page.getByTestId("illuminate-label-controls");
   await expect(legend).toBeVisible();
   await expect(labelControls).toBeVisible();
+
+  // #996 — the visual canvas now has an AT-equivalent companion. It remains
+  // in the narrow stacked layout rather than being clipped below the canvas.
+  await expect(
+    page.getByRole("region", { name: "Traversal result companion" }),
+  ).toBeVisible();
   const legendBox = await legend.boundingBox();
   const controlsBox = await labelControls.boundingBox();
   if (!legendBox || !controlsBox) {
@@ -221,6 +227,59 @@ test.describe("/cli", () => {
     await expect(page.getByTestId("cli-canvas-panel")).toContainText(
       "bfs cli:alpha 2 5",
     );
+  });
+
+  // #996 — every traversal family exposes its executed parameters and result
+  // through semantic tables. Run-from-here is a real keyboard action, while
+  // Inspect remains a normal accessible link to the vertex surface.
+  test("family results expose an accessible companion with keyboard actions (#996)", async ({
+    page,
+  }) => {
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    const companion = page.getByRole("region", {
+      name: "Traversal result companion",
+    });
+
+    await input.fill("bfs cli:alpha 2 5");
+    await input.press("Enter");
+    await expect(
+      companion.getByRole("heading", { name: "Current result: BFS" }),
+    ).toBeVisible();
+    await expect(companion.getByText("Fan-out", { exact: true })).toBeVisible();
+    const runFromBeta = companion.getByRole("button", {
+      name: "Run from cli:beta using next-walk controls",
+    });
+    await runFromBeta.focus();
+    await expect(runFromBeta).toBeFocused();
+    await runFromBeta.press("Enter");
+    await expect(page.getByTestId("cli-canvas-panel")).toContainText(
+      "bfs cli:beta",
+    );
+
+    await input.fill("pagerank cli:alpha 10 restart_prob=0.25 epsilon=0.001");
+    await input.press("Enter");
+    await expect(
+      companion.getByRole("heading", {
+        name: "Current result: Personalized PageRank",
+      }),
+    ).toBeVisible();
+    await expect(
+      companion.getByRole("table", { name: "PageRank mass ranking" }),
+    ).toBeVisible();
+    await expect(
+      companion.getByRole("link", { name: "Inspect cli:alpha" }),
+    ).toBeVisible();
+
+    await input.fill(
+      "community cli:cmty:a1 3 restart_prob=0.25 epsilon=0.001 reduction=mst",
+    );
+    await input.press("Enter");
+    await expect(
+      companion.getByRole("heading", { name: "Current result: Local community" }),
+    ).toBeVisible();
+    await expect(companion.getByText("Max size", { exact: true })).toBeVisible();
+    await expect(companion.getByText("Reduction", { exact: true })).toBeVisible();
   });
 
   test("canvas node click quotes an arbitrary key before reaching the RPC (#988)", async ({


### PR DESCRIPTION
## Summary
- add a semantic traversal-result companion alongside the visual canvas
- expose executed BFS, PageRank, and Local Community parameters and accessible result tables
- provide keyboard-operable run-from-here actions and normal inspect links
- preserve family result metadata independently from the canvas projection

## Verification
- all six Go module test suites and server vet
- Admin format, lint, typecheck, unit tests (794), production build
- Playwright real-wire suite (74/74)
- Node SDK format, lint, typecheck, tests (131)

Closes #996