### PR TITLE
feat(sdks/dart): add secure mobile transport foundation

### DIFF
--- a/.github/workflows/dart-sdk.yml
+++ b/.github/workflows/dart-sdk.yml
@@ -7,12 +7,16 @@ on:
       - "sdks/dart/**"
       - "proto/**"
       - "buf.yaml"
+      - "buf.gen.yaml"
+      - "generate.go"
       - ".github/workflows/dart-sdk.yml"
   pull_request:
     paths:
       - "sdks/dart/**"
       - "proto/**"
       - "buf.yaml"
+      - "buf.gen.yaml"
+      - "generate.go"
       - ".github/workflows/dart-sdk.yml"
 
 permissions:
@@ -40,6 +44,24 @@ jobs:
           flutter-version: 3.44.6
           cache: true
 
+      - name: Start Lantern real-wire server
+        working-directory: .
+        run: |
+          go run ./server/cmd > "$RUNNER_TEMP/lantern-dart-server.log" 2>&1 &
+          echo $! > "$RUNNER_TEMP/lantern-dart-server.pid"
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent --show-error --max-time 2 \
+              -H 'Content-Type: application/json' \
+              -H 'Connect-Protocol-Version: 1' \
+              --data '{}' \
+              http://127.0.0.1:6380/grpc.health.v1.Health/Check >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          cat "$RUNNER_TEMP/lantern-dart-server.log"
+          exit 1
+
       - name: Resolve dependencies
         run: dart pub get --enforce-lockfile
 
@@ -60,8 +82,21 @@ jobs:
       - name: Test
         run: dart test
 
+      - name: Real-wire test
+        env:
+          LANTERN_DART_REAL_WIRE_ENDPOINT: http://127.0.0.1:6380
+        run: dart test test/real_wire_test.dart
+
       - name: Build API documentation
         run: dart doc --validate-links
 
       - name: Validate package shape
         run: dart pub publish --dry-run
+
+      - name: Stop Lantern real-wire server
+        if: always()
+        working-directory: .
+        run: |
+          if [ -f "$RUNNER_TEMP/lantern-dart-server.pid" ]; then
+            kill "$(cat "$RUNNER_TEMP/lantern-dart-server.pid")" || true
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Dependency direction (must remain a DAG, no back edges):
          core ◀──────────────┘
 ```
 
-Tag scheme: `vX.Y.Z` for server+CLI (root module), `sdks/go/vX.Y.Z` for the SDK, `core/vX.Y.Z` for core, `pb/vX.Y.Z` for the proto stubs, `mcp/vX.Y.Z` for the MCP server image (cut independently of the root release cadence).
+Tag scheme: `vX.Y.Z` for server+CLI (root module), `sdks/go/vX.Y.Z` for the SDK, `core/vX.Y.Z` for core, `pb/vX.Y.Z` for the proto stubs, `sdks/dart/vX.Y.Z` for the independent pub.dev SDK, and `mcp/vX.Y.Z` for the MCP server image (cut independently of the root release cadence).
 
 ## Architecture notes
 
@@ -45,7 +45,7 @@ Tag scheme: `vX.Y.Z` for server+CLI (root module), `sdks/go/vX.Y.Z` for the SDK,
   - `sdks/go/` imports `pb/` only — **never** `core/...` or `server/...`.
   - `server/` imports `pb/` and `core/` only — **never** the client SDK. If a server test needs the client (e.g. a full-stack bufconn round-trip), put it in `tests/integration/` instead of under `server/`.
   - The root module (cli + tests/integration) is the only Go module that depends on all five workspace submodules.
-  - `sdks/dart/` is a standalone pure-Dart package generated from `proto/`; it never joins `go.work` or imports a Go module. Its generated `lib/src/gen/**` files are regenerated with `sdks/dart/scripts/codegen.sh`, never hand-edited.
+  - `sdks/dart/` is a standalone pure-Dart package generated from `proto/`; it never joins `go.work` or imports a Go module. Its generated `lib/src/gen/**` files are regenerated with `sdks/dart/scripts/codegen.sh`, never hand-edited. The public `LanternClient` foundation owns secure transport/auth/deadline/cancellation policy and probes the auth-exempt gRPC Health-v1 endpoint; CRUD/query facades layer on it in follow-up Issues.
   - `Illuminate*` returns the SDK-local `client.Graph` (field shape `{Vertices map[string]*Vertex; Edges map[string]map[string]float32}`, JSON-compatible with `core/graph.Graph`). The server owns every traversal family and post-traversal reduction; since #846 `IlluminateRequest` carries a per-family `params` oneof (`bfs` / `ppr` / `community`) instead of a flat `Algorithm` axis — pass the typed SDK options `client.WithBFS(BFSOpts{Step, FanOut, Objective, Reduction})`, `client.WithPPR(PPROpts{TopN, RestartProb, Epsilon})`, or `client.WithLocalCommunity(LocalCommunityOpts{…})` (#845), plus the shared `client.WithWeighting` / `client.WithVertexPrefix`.
 - **Decay model**: edges are **additive** and carry their own TTL. Be mindful of the difference between `AddEdge` and `PutEdge` (idempotency) — see the discussion in [sdks/go/example/main.go](sdks/go/example/main.go).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ created**:
 | --- | --- |
 | `Track` | `Admin` / `HA` / `Connect` / `SDK` / `Maintenance` / `Docs` |
 | `Module` | `pb` / `core` / `server` / `sdks-go` / `sdks-dart` / `sdks-node` / `sdks-python` / `admin` / `mcp` / `tests` / `docs` / `ci` |
-| `Release target` | `next pb` / `next sdks-go` / `next root` / `next mcp` / `next admin-internal` / `unscheduled` |
+| `Release target` | `next pb` / `next sdks-go` / `next sdks-dart` / `next root` / `next mcp` / `next admin-internal` / `unscheduled` |
 | `Priority` | `P0` / `P1` / `P2` |
 
 Rules:

--- a/README.md
+++ b/README.md
@@ -429,9 +429,11 @@ powers the [admin SPA](admin/). Full API:
 ### Dart / Flutter
 
 [`lantern_client`](sdks/dart/) is the official pure-Dart, Android/iOS-first
-package. Its initial package exposes generated `Vertex`, `Edge`, and `Graph`
-types with reproducible Connect-Dart codegen; the high-level mobile client is
-being added in the following SDK changes. See
+package. It exports generated `Vertex`, `Edge`, and `Graph` values plus the
+reusable `LanternClient` transport foundation (secure endpoint validation,
+short-lived token providers, deadlines, cancellation, typed failures, and
+auth-exempt gRPC Health-v1 probing). CRUD/query facades build on this
+foundation in subsequent SDK changes. See
 [sdks/dart/README.md](sdks/dart/README.md) for the current supported surface.
 
 ### Anything else

--- a/sdks/dart/CHANGELOG.md
+++ b/sdks/dart/CHANGELOG.md
@@ -5,3 +5,7 @@
 - Scaffold the pure-Dart `lantern_client` package.
 - Add reproducible Connect-Dart and Protobuf code generation.
 - Expose the generated `Vertex`, `Edge`, and `Graph` value types.
+- Add the secure, injectable `LanternClient` transport foundation with
+  per-call token providers, deadlines, cancellation, typed errors, and close.
+- Add auth-exempt gRPC Health-v1 `ping()` probing with typed non-serving status
+  errors.

--- a/sdks/dart/README.md
+++ b/sdks/dart/README.md
@@ -3,10 +3,10 @@
 Official pure-Dart package for [Lantern](https://github.com/anaregdesign/lantern),
 an in-memory graph key-vertex store with TTL-aware vertices and edges.
 
-The initial package establishes the generated wire types and reproducible
-Connect-Dart toolchain. High-level transport, auth, CRUD, query, and traversal
-APIs land in follow-up changes; this version deliberately does not claim those
-behaviors yet.
+The package includes the reusable transport foundation used by the later CRUD,
+query, and traversal facades: secure endpoint validation, per-call bearer-token
+providers, deadlines, cancellation, typed failures, health probing, and
+deterministic cleanup. Generated RPC request/response types remain private.
 
 ## Scope
 
@@ -26,10 +26,24 @@ final edge = Edge(tail: 'user:42', head: 'item:7', weight: 1);
 final graph = Graph(vertices: [vertex], edges: [edge]);
 ```
 
-Only `Vertex`, `Edge`, `Graph`, and the generated vertex oneof discriminator
-are exported today. Generated request/response types, the raw Connect client,
-and replication service remain under `lib/src/gen` so later facade work can
-classify the public surface intentionally.
+`Vertex`, `Edge`, `Graph`, the generated vertex oneof discriminator, and the
+`LanternClient` foundation are exported. `LanternClient.connect` requires HTTPS
+by default; pass `allowInsecure: true` only for local development. Supply a
+short-lived `tokenProvider` for application calls. `ping()` uses the
+auth-exempt gRPC Health-v1 Connect+JSON endpoint and throws
+`LanternHealthStatusException` when the server is not serving. Generated
+request/response types, the raw Connect client, and replication service remain
+under `lib/src/gen`.
+
+```dart
+final client = LanternClient.connect(
+  Uri.parse('https://lantern.example.com'),
+  tokenProvider: () async => session.accessToken,
+);
+await client.ping();
+// Cancel screen-owned calls with LanternCallOptions(cancellation: token).
+await client.close();
+```
 
 ## Generate wire code
 

--- a/sdks/dart/lib/lantern_client.dart
+++ b/sdks/dart/lib/lantern_client.dart
@@ -1,8 +1,31 @@
-/// Official pure-Dart types for Lantern clients.
+/// Official pure-Dart types and mobile transport foundation for Lantern clients.
 ///
-/// The high-level mobile client is intentionally introduced in later changes.
-/// This library currently exposes only the stable graph value types; generated
-/// service and replication internals remain private to the package.
+/// Generated service and replication internals remain private to the package;
+/// CRUD and query facades are layered on the reusable [LanternClient].
 library;
 
+export 'src/client.dart'
+    show
+        LanternCallOptions,
+        LanternCanceledException,
+        LanternCancellationToken,
+        LanternClient,
+        LanternCloseCallback,
+        LanternCode,
+        LanternDeadlineExceededException,
+        LanternException,
+        LanternFailedPreconditionException,
+        LanternHealthStatusException,
+        LanternHttpClientFactory,
+        LanternInterceptor,
+        LanternInternalException,
+        LanternInvalidArgumentException,
+        LanternNotFoundException,
+        LanternPermissionDeniedException,
+        LanternResourceExhaustedException,
+        LanternTransport,
+        LanternTransportFactory,
+        LanternUnauthenticatedException,
+        LanternUnavailableException,
+        TokenProvider;
 export 'src/gen/graph/v1/graph.pb.dart' show Edge, Graph, Vertex, Vertex_Value;

--- a/sdks/dart/lib/src/client.dart
+++ b/sdks/dart/lib/src/client.dart
@@ -1,0 +1,992 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:connectrpc/connect.dart' as connect;
+import 'package:connectrpc/io.dart' as connect_io;
+import 'package:connectrpc/protobuf.dart';
+import 'package:connectrpc/protocol/connect.dart' as protocol;
+
+/// Supplies the bearer token for one logical RPC.
+///
+/// The provider is invoked for every call and stream subscription. Returning
+/// `null` or an empty string sends no authorization header.
+typedef TokenProvider = FutureOr<String?> Function();
+
+/// Creates a native Dart HTTP client owned by [LanternClient].
+typedef LanternHttpClientFactory = io.HttpClient Function();
+
+/// The low-level Connect transport accepted for advanced injection.
+typedef LanternTransport = connect.Transport;
+
+/// A Connect interceptor accepted by the default or factory transport.
+typedef LanternInterceptor = connect.Interceptor;
+
+/// Creates a Connect transport for a normalized endpoint.
+typedef LanternTransportFactory =
+    LanternTransport Function(
+      Uri endpoint,
+      List<LanternInterceptor> interceptors,
+    );
+
+/// Releases resources owned by an injected transport.
+typedef LanternCloseCallback = FutureOr<void> Function();
+
+/// Caller-controlled cancellation shared by unary and streaming RPCs.
+final class LanternCancellationToken {
+  final Set<void Function(Object?)> _listeners = {};
+  bool _isCanceled = false;
+  Object? _reason;
+
+  /// Whether [cancel] has already been called.
+  bool get isCanceled => _isCanceled;
+
+  /// Cancels every active call using this token.
+  ///
+  /// The optional [reason] is retained as the exception cause but is never
+  /// included in its text. Repeated calls are no-ops.
+  void cancel([Object? reason]) {
+    if (_isCanceled) return;
+    _isCanceled = true;
+    _reason = reason;
+    for (final listener in _listeners.toList(growable: false)) {
+      listener(reason);
+    }
+    _listeners.clear();
+  }
+
+  void Function() _listen(void Function(Object?) listener) {
+    if (_isCanceled) {
+      scheduleMicrotask(() => listener(_reason));
+      return () {};
+    }
+    _listeners.add(listener);
+    return () => _listeners.remove(listener);
+  }
+}
+
+/// Per-call deadline and cancellation overrides.
+final class LanternCallOptions {
+  /// Creates call options.
+  ///
+  /// [timeout] and [deadline] are mutually exclusive. A per-call value replaces
+  /// the client's default timeout; cancellation always composes with it.
+  LanternCallOptions({this.timeout, this.deadline, this.cancellation}) {
+    if (timeout != null && deadline != null) {
+      throw ArgumentError('timeout and deadline are mutually exclusive');
+    }
+    if (timeout != null && timeout! <= Duration.zero) {
+      throw ArgumentError.value(timeout, 'timeout', 'must be positive');
+    }
+  }
+
+  /// Relative timeout replacing the client default for this call.
+  final Duration? timeout;
+
+  /// Absolute deadline replacing the client default for this call.
+  final DateTime? deadline;
+
+  /// Caller-controlled cancellation token.
+  final LanternCancellationToken? cancellation;
+}
+
+/// Stable SDK error categories suitable for mobile UI handling.
+enum LanternCode {
+  /// The caller canceled the operation.
+  canceled,
+
+  /// Input was invalid regardless of server state.
+  invalidArgument,
+
+  /// The configured deadline expired.
+  deadlineExceeded,
+
+  /// The requested entity was not found.
+  notFound,
+
+  /// The authenticated caller lacks permission.
+  permissionDenied,
+
+  /// A server or client resource limit was exhausted.
+  resourceExhausted,
+
+  /// The operation is invalid in the current state.
+  failedPrecondition,
+
+  /// Authentication is missing or invalid.
+  unauthenticated,
+
+  /// The endpoint is temporarily unavailable.
+  unavailable,
+
+  /// An internal, unknown, or unmapped failure occurred.
+  internal,
+}
+
+/// Base class for typed Lantern client failures.
+sealed class LanternException implements Exception {
+  LanternException._({
+    required this.code,
+    required this.transportCode,
+    required this.transportCodeName,
+    required this.message,
+    required this.cause,
+    required this.headers,
+    required this.trailers,
+    required this.metadata,
+  });
+
+  /// Stable SDK category.
+  final LanternCode code;
+
+  /// Original Connect/gRPC-compatible numeric status code.
+  final int transportCode;
+
+  /// Original Connect status name.
+  final String transportCodeName;
+
+  /// Credential-safe transport message.
+  final String message;
+
+  /// Underlying failure, when one exists.
+  final Object? cause;
+
+  /// Response headers observed before the failure.
+  final Map<String, List<String>> headers;
+
+  /// Response trailers observed before the failure.
+  final Map<String, List<String>> trailers;
+
+  /// Union metadata retained when headers and trailers cannot be distinguished.
+  final Map<String, List<String>> metadata;
+
+  @override
+  String toString() =>
+      message.isEmpty ? '[${code.name}]' : '[${code.name}] $message';
+}
+
+/// A caller-canceled operation.
+final class LanternCanceledException extends LanternException {
+  LanternCanceledException._(_ErrorData data)
+    : super._(
+        code: LanternCode.canceled,
+        transportCode: data.transportCode,
+        transportCodeName: data.transportCodeName,
+        message: data.message,
+        cause: data.cause,
+        headers: data.headers,
+        trailers: data.trailers,
+        metadata: data.metadata,
+      );
+}
+
+/// An invalid request.
+final class LanternInvalidArgumentException extends LanternException {
+  LanternInvalidArgumentException._(_ErrorData data)
+    : super._(
+        code: LanternCode.invalidArgument,
+        transportCode: data.transportCode,
+        transportCodeName: data.transportCodeName,
+        message: data.message,
+        cause: data.cause,
+        headers: data.headers,
+        trailers: data.trailers,
+        metadata: data.metadata,
+      );
+}
+
+/// An operation whose deadline expired.
+final class LanternDeadlineExceededException extends LanternException {
+  LanternDeadlineExceededException._(_ErrorData data)
+    : super._(
+        code: LanternCode.deadlineExceeded,
+        transportCode: data.transportCode,
+        transportCodeName: data.transportCodeName,
+        message: data.message,
+        cause: data.cause,
+        headers: data.headers,
+        trailers: data.trailers,
+        metadata: data.metadata,
+      );
+}
+
+/// A missing entity.
+final class LanternNotFoundException extends LanternException {
+  LanternNotFoundException._(_ErrorData data)
+    : super._(
+        code: LanternCode.notFound,
+        transportCode: data.transportCode,
+        transportCodeName: data.transportCodeName,
+        message: data.message,
+        cause: data.cause,
+        headers: data.headers,
+        trailers: data.trailers,
+        metadata: data.metadata,
+      );
+}
+
+/// A permission-denied operation.
+final class LanternPermissionDeniedException extends LanternException {
+  LanternPermissionDeniedException._(_ErrorData data)
+    : super._(
+        code: LanternCode.permissionDenied,
+        transportCode: data.transportCode,
+        transportCodeName: data.transportCodeName,
+        message: data.message,
+        cause: data.cause,
+        headers: data.headers,
+        trailers: data.trailers,
+        metadata: data.metadata,
+      );
+}
+
+/// A resource-exhausted operation.
+final class LanternResourceExhaustedException extends LanternException {
+  LanternResourceExhaustedException._(_ErrorData data)
+    : super._(
+        code: LanternCode.resourceExhausted,
+        transportCode: data.transportCode,
+        transportCodeName: data.transportCodeName,
+        message: data.message,
+        cause: data.cause,
+        headers: data.headers,
+        trailers: data.trailers,
+        metadata: data.metadata,
+      );
+}
+
+/// An operation that failed a state precondition.
+final class LanternFailedPreconditionException extends LanternException {
+  LanternFailedPreconditionException._(_ErrorData data)
+    : super._(
+        code: LanternCode.failedPrecondition,
+        transportCode: data.transportCode,
+        transportCodeName: data.transportCodeName,
+        message: data.message,
+        cause: data.cause,
+        headers: data.headers,
+        trailers: data.trailers,
+        metadata: data.metadata,
+      );
+}
+
+/// The health endpoint replied successfully but reported a non-serving state.
+final class LanternHealthStatusException extends LanternException {
+  LanternHealthStatusException._(this.status, _ErrorData data)
+    : super._(
+        code: LanternCode.failedPrecondition,
+        transportCode: data.transportCode,
+        transportCodeName: data.transportCodeName,
+        message: data.message,
+        cause: data.cause,
+        headers: data.headers,
+        trailers: data.trailers,
+        metadata: data.metadata,
+      );
+
+  /// Symbolic gRPC Health status returned by the server.
+  final String status;
+}
+
+/// An unauthenticated operation.
+final class LanternUnauthenticatedException extends LanternException {
+  LanternUnauthenticatedException._(_ErrorData data)
+    : super._(
+        code: LanternCode.unauthenticated,
+        transportCode: data.transportCode,
+        transportCodeName: data.transportCodeName,
+        message: data.message,
+        cause: data.cause,
+        headers: data.headers,
+        trailers: data.trailers,
+        metadata: data.metadata,
+      );
+}
+
+/// An unavailable endpoint.
+final class LanternUnavailableException extends LanternException {
+  LanternUnavailableException._(_ErrorData data)
+    : super._(
+        code: LanternCode.unavailable,
+        transportCode: data.transportCode,
+        transportCodeName: data.transportCodeName,
+        message: data.message,
+        cause: data.cause,
+        headers: data.headers,
+        trailers: data.trailers,
+        metadata: data.metadata,
+      );
+}
+
+/// An internal, unknown, or unmapped transport failure.
+final class LanternInternalException extends LanternException {
+  LanternInternalException._(_ErrorData data)
+    : super._(
+        code: LanternCode.internal,
+        transportCode: data.transportCode,
+        transportCodeName: data.transportCodeName,
+        message: data.message,
+        cause: data.cause,
+        headers: data.headers,
+        trailers: data.trailers,
+        metadata: data.metadata,
+      );
+}
+
+/// Reusable Android/iOS-first Lantern client foundation.
+final class LanternClient {
+  LanternClient._({
+    required this.endpoint,
+    required LanternInvoker invoker,
+    required LanternCloseCallback? closeCallback,
+    required io.HttpClient? healthHttpClient,
+    required Duration? defaultTimeout,
+  }) : _invoker = invoker,
+       _closeCallback = closeCallback,
+       _healthHttpClient = healthHttpClient,
+       _defaultTimeout = defaultTimeout;
+
+  /// Creates a client for [endpoint].
+  ///
+  /// HTTPS is required unless [allowInsecure] is true. [token] is for trusted
+  /// internal applications and tests; public mobile apps should use
+  /// [tokenProvider] with short-lived user/device credentials.
+  ///
+  /// [transport], [transportFactory], and [httpClientFactory] are mutually
+  /// exclusive. Interceptors cannot be added to an already-created [transport].
+  /// A client created by [httpClientFactory] is owned and closed by this object.
+  factory LanternClient.connect(
+    Uri endpoint, {
+    TokenProvider? tokenProvider,
+    String? token,
+    Duration? defaultTimeout = const Duration(seconds: 10),
+    bool allowInsecure = false,
+    LanternTransport? transport,
+    LanternTransportFactory? transportFactory,
+    LanternHttpClientFactory? httpClientFactory,
+    Iterable<LanternInterceptor> interceptors = const [],
+    LanternCloseCallback? onClose,
+  }) {
+    final normalized = _normalizeEndpoint(
+      endpoint,
+      allowInsecure: allowInsecure,
+    );
+    if (tokenProvider != null && token != null) {
+      throw ArgumentError('token and tokenProvider are mutually exclusive');
+    }
+    if (token != null && token.isEmpty) {
+      throw ArgumentError.value(token, 'token', 'must not be empty');
+    }
+    if (defaultTimeout != null && defaultTimeout <= Duration.zero) {
+      throw ArgumentError.value(
+        defaultTimeout,
+        'defaultTimeout',
+        'must be positive',
+      );
+    }
+    final injectionCount =
+        [
+          transport != null,
+          transportFactory != null,
+          httpClientFactory != null,
+        ].where((value) => value).length;
+    if (injectionCount > 1) {
+      throw ArgumentError(
+        'transport, transportFactory, and httpClientFactory are mutually exclusive',
+      );
+    }
+    final interceptorList = List<LanternInterceptor>.unmodifiable(interceptors);
+    if (transport != null && interceptorList.isNotEmpty) {
+      throw ArgumentError(
+        'interceptors must be configured by an injected transport',
+      );
+    }
+
+    io.HttpClient? ownedHttpClient;
+    io.HttpClient? healthHttpClient;
+    final resolvedTransport = switch ((transport, transportFactory)) {
+      (final injected?, _) => injected,
+      (_, final factory?) => factory(normalized, interceptorList),
+      _ => () {
+        ownedHttpClient = httpClientFactory?.call() ?? io.HttpClient();
+        healthHttpClient = ownedHttpClient;
+        return protocol.Transport(
+          baseUrl: normalized.toString(),
+          codec: const ProtoCodec(),
+          httpClient: connect_io.createHttpClient(ownedHttpClient!),
+          interceptors: interceptorList,
+        );
+      }(),
+    };
+    final provider = tokenProvider ?? (token == null ? null : () => token);
+    return LanternClient._(
+      endpoint: normalized,
+      invoker: LanternInvoker(
+        transport: resolvedTransport,
+        tokenProvider: provider,
+        defaultTimeout: defaultTimeout,
+      ),
+      closeCallback: () async {
+        ownedHttpClient?.close(force: true);
+        await onClose?.call();
+      },
+      healthHttpClient: healthHttpClient,
+      defaultTimeout: defaultTimeout,
+    );
+  }
+
+  /// Normalized endpoint used by this client.
+  final Uri endpoint;
+
+  // Retained for the CRUD/query facades that build on this foundation.
+  // ignore: unused_field
+  final LanternInvoker _invoker;
+  final LanternCloseCallback? _closeCallback;
+  final io.HttpClient? _healthHttpClient;
+  final Duration? _defaultTimeout;
+  Future<void>? _closing;
+
+  /// Whether shutdown has started.
+  bool get isClosed => _closing != null;
+
+  /// Probes the gRPC Health-v1 endpoint and resolves only when it is serving.
+  ///
+  /// Health checks intentionally do not send the configured bearer token: the
+  /// server's health surface is auth-exempt and this keeps readiness probes
+  /// safe to use before application credentials are available. A client built
+  /// around an injected transport has no raw HTTP path and must use its own
+  /// health probe; calling [ping] on it returns [LanternInvalidArgumentException].
+  Future<void> ping({LanternCallOptions? options}) async {
+    _ensureOpen();
+    final httpClient = _healthHttpClient;
+    if (httpClient == null) {
+      throw _invalidArgumentException(
+        'ping requires a URL-backed client; provide a raw HTTP health probe',
+      );
+    }
+    final context = _InvocationContext(options, _defaultTimeout);
+    io.HttpClientRequest? request;
+    try {
+      final activeRequest = await _raceAbort(
+        httpClient.postUrl(_healthEndpoint(endpoint)),
+        context.signal,
+      );
+      request = activeRequest;
+      activeRequest.headers.contentType = io.ContentType.json;
+      activeRequest.headers.set('Connect-Protocol-Version', '1');
+      activeRequest.add(utf8.encode('{}'));
+      final response = await _raceAbort(
+        activeRequest.close(),
+        context.signal,
+        onAbort: (error) => request?.abort(error),
+      );
+      context.onHeader(_connectHeadersFromIo(response.headers));
+      final body = await _raceAbort(
+        response.transform(utf8.decoder).join(),
+        context.signal,
+        onAbort: (error) => request?.abort(error),
+      );
+      if (response.statusCode != io.HttpStatus.ok) {
+        throw connect.ConnectException(
+          _codeForHttpStatus(response.statusCode),
+          'health probe returned HTTP ${response.statusCode}',
+        );
+      }
+      final decoded = jsonDecode(body);
+      if (decoded is! Map || decoded['status'] is! String) {
+        throw connect.ConnectException(
+          connect.Code.internal,
+          'health response missing status',
+        );
+      }
+      final status = decoded['status'] as String;
+      if (!_isServingStatus(status)) {
+        throw LanternHealthStatusException._(
+          status,
+          _ErrorData(
+            transportCode: connect.Code.failedPrecondition.value,
+            transportCodeName: connect.Code.failedPrecondition.name,
+            message:
+                'server health status = ${status.isEmpty ? '(empty)' : status}',
+            headers: _headersToMap(context.headers),
+            trailers: _headersToMap(context.trailers),
+            metadata: const {},
+          ),
+        );
+      }
+    } on connect.ConnectException catch (error) {
+      throw _mapConnectException(error, context);
+    } on LanternException {
+      rethrow;
+    } catch (error) {
+      throw _mapUnknownException(error, context);
+    } finally {
+      context.dispose();
+    }
+  }
+
+  /// Closes owned networking resources exactly once.
+  Future<void> close() => _closing ??= _closeOnce();
+
+  Future<void> _closeOnce() async => _closeCallback?.call();
+
+  void _ensureOpen() {
+    if (isClosed) throw _closedException();
+  }
+}
+
+/// Internal shared invocation engine used by every Dart facade method.
+///
+/// This class lives under `lib/src` and is not exported by the package barrel.
+final class LanternInvoker {
+  /// Creates an invocation engine around [transport].
+  LanternInvoker({
+    required this.transport,
+    TokenProvider? tokenProvider,
+    Duration? defaultTimeout,
+  }) : _tokenProvider = tokenProvider,
+       _defaultTimeout = defaultTimeout;
+
+  /// Low-level transport used by generated clients.
+  final LanternTransport transport;
+
+  final TokenProvider? _tokenProvider;
+  final Duration? _defaultTimeout;
+
+  /// Invokes a unary generated-client method with common policy.
+  Future<T> invokeUnary<T>({
+    required LanternUnaryCall<T> call,
+    LanternCallOptions? options,
+  }) async {
+    final context = _InvocationContext(options, _defaultTimeout);
+    try {
+      final headers = await _requestHeaders(context);
+      return await call(
+        headers: headers,
+        signal: context.signal,
+        onHeader: context.onHeader,
+        onTrailer: context.onTrailer,
+      );
+    } on connect.ConnectException catch (error) {
+      throw _mapConnectException(error, context);
+    } on LanternException {
+      rethrow;
+    } catch (error) {
+      throw _mapUnknownException(error, context);
+    } finally {
+      context.dispose();
+    }
+  }
+
+  /// Invokes a streaming generated-client method with common policy.
+  ///
+  /// Canceling the returned subscription cancels the underlying RPC signal.
+  Stream<T> invokeStream<T>({
+    required LanternStreamCall<T> call,
+    LanternCallOptions? options,
+  }) {
+    _InvocationContext? context;
+    late final StreamController<T> controller;
+    StreamSubscription<T>? subscription;
+
+    // Keep the mapping/finally policy in an async* body, but put a controller
+    // in front of it so cancellation of the public subscription is observable
+    // immediately.  Dart async* cancellation otherwise waits for the current
+    // await (which can leave a network read alive until its timeout). Create
+    // the context on listen so an un-listened stream owns no timer or token
+    // listener.
+    controller = StreamController<T>(
+      sync: true,
+      onListen: () {
+        final invocation =
+            context = _InvocationContext(options, _defaultTimeout);
+        final body = _invokeStreamBody(call, invocation);
+        subscription = body.listen(
+          controller.add,
+          onError: (Object error, StackTrace stack) {
+            controller.addError(error, stack);
+          },
+          onDone: controller.close,
+        );
+      },
+      onCancel: () {
+        final invocation = context;
+        invocation?.signal.cancel();
+        invocation?.dispose();
+        final active = subscription;
+        if (active != null) {
+          // Do not make the caller wait for a non-cooperative injected stream
+          // to finish.  The signal is already canceled, and Connect's native
+          // transport observes it to abort the underlying request.
+          unawaited(active.cancel());
+        }
+      },
+    );
+    return controller.stream;
+  }
+
+  Stream<T> _invokeStreamBody<T>(
+    LanternStreamCall<T> call,
+    _InvocationContext context,
+  ) async* {
+    try {
+      final headers = await _requestHeaders(context);
+      yield* call(
+        headers: headers,
+        signal: context.signal,
+        onHeader: context.onHeader,
+        onTrailer: context.onTrailer,
+      );
+    } on connect.ConnectException catch (error) {
+      throw _mapConnectException(error, context);
+    } on LanternException {
+      rethrow;
+    } catch (error) {
+      throw _mapUnknownException(error, context);
+    } finally {
+      context.signal.cancel();
+      context.dispose();
+    }
+  }
+
+  Future<connect.Headers> _requestHeaders(_InvocationContext context) async {
+    final headers = connect.Headers();
+    final provider = _tokenProvider;
+    if (provider == null) return headers;
+    final signal = context.signal;
+    String? token;
+    try {
+      token =
+          (await Future.any<_TokenProviderResult>([
+            Future<String?>.sync(provider).then(_TokenProviderResult.value),
+            signal.future.then<_TokenProviderResult>(
+              (error) => throw _SignalAbort(error),
+            ),
+          ])).token;
+    } on _SignalAbort catch (error) {
+      // Preserve cancellation/deadline status from our signal. Provider
+      // failures are handled below and never expose provider-supplied text.
+      throw error.exception;
+    } catch (error) {
+      // A token provider is application code and may throw a ConnectException
+      // whose message contains credential material. Keep the public message
+      // fixed while retaining the original exception as a diagnostic cause.
+      throw connect.ConnectException(
+        connect.Code.unknown,
+        'token provider failed',
+        cause: error,
+      );
+    }
+    if (token != null && token.isNotEmpty) {
+      context.token = token;
+      headers['authorization'] = 'Bearer $token';
+    }
+    return headers;
+  }
+}
+
+/// Result wrapper used to distinguish a token provider's failure from the
+/// caller-controlled signal in the race above.
+final class _TokenProviderResult {
+  const _TokenProviderResult.value(this.token);
+
+  final String? token;
+}
+
+/// Internal marker preserving cancellation/deadline errors from [_CallSignal]
+/// without allowing provider-thrown [connect.ConnectException] values to leak
+/// their messages through the public SDK error.
+final class _SignalAbort {
+  const _SignalAbort(this.exception);
+
+  final connect.ConnectException exception;
+}
+
+/// Callback shape for a unary generated-client method.
+typedef LanternUnaryCall<T> =
+    Future<T> Function({
+      required connect.Headers headers,
+      required connect.AbortSignal signal,
+      required void Function(connect.Headers) onHeader,
+      required void Function(connect.Headers) onTrailer,
+    });
+
+/// Callback shape for a streaming generated-client method.
+typedef LanternStreamCall<T> =
+    Stream<T> Function({
+      required connect.Headers headers,
+      required connect.AbortSignal signal,
+      required void Function(connect.Headers) onHeader,
+      required void Function(connect.Headers) onTrailer,
+    });
+
+final class _InvocationContext {
+  _InvocationContext(LanternCallOptions? options, Duration? defaultTimeout)
+    : signal = _CallSignal(
+        timeout:
+            options?.timeout ??
+            (options?.deadline == null ? defaultTimeout : null),
+        deadline: options?.deadline,
+        cancellation: options?.cancellation,
+      );
+
+  final _CallSignal signal;
+  connect.Headers headers = connect.Headers();
+  connect.Headers trailers = connect.Headers();
+  String? token;
+
+  void onHeader(connect.Headers value) => headers = connect.Headers.from(value);
+
+  void onTrailer(connect.Headers value) =>
+      trailers = connect.Headers.from(value);
+
+  void dispose() => signal.dispose();
+}
+
+final class _CallSignal implements connect.AbortSignal {
+  _CallSignal({
+    Duration? timeout,
+    DateTime? deadline,
+    LanternCancellationToken? cancellation,
+  }) {
+    final now = DateTime.now();
+    final requestedDeadline =
+        deadline ?? (timeout == null ? null : now.add(timeout));
+    this.deadline = requestedDeadline;
+    if (requestedDeadline != null) {
+      final remaining = requestedDeadline.difference(now);
+      if (remaining <= Duration.zero) {
+        scheduleMicrotask(_expire);
+      } else {
+        _timer = Timer(remaining, _expire);
+      }
+    }
+    _removeCancellationListener = cancellation?._listen(_cancelFromCaller);
+  }
+
+  final Completer<connect.ConnectException> _completer = Completer();
+  Timer? _timer;
+  void Function()? _removeCancellationListener;
+
+  @override
+  late final DateTime? deadline;
+
+  @override
+  Future<connect.ConnectException> get future => _completer.future;
+
+  void cancel([Object? reason]) {
+    _complete(
+      connect.ConnectException(
+        connect.Code.canceled,
+        'operation canceled',
+        cause: reason,
+      ),
+    );
+  }
+
+  void _cancelFromCaller(Object? reason) => cancel(reason);
+
+  void _expire() {
+    _complete(
+      connect.ConnectException(
+        connect.Code.deadlineExceeded,
+        'operation exceeded deadline',
+      ),
+    );
+  }
+
+  void _complete(connect.ConnectException error) {
+    if (!_completer.isCompleted) _completer.complete(error);
+  }
+
+  void dispose() {
+    _timer?.cancel();
+    _removeCancellationListener?.call();
+    _removeCancellationListener = null;
+  }
+}
+
+Uri _normalizeEndpoint(Uri endpoint, {required bool allowInsecure}) {
+  final scheme = endpoint.scheme.toLowerCase();
+  if (!endpoint.hasScheme || endpoint.host.isEmpty) {
+    throw ArgumentError.value(endpoint, 'endpoint', 'must be an absolute URI');
+  }
+  if (scheme != 'https' && scheme != 'http') {
+    throw ArgumentError.value(endpoint, 'endpoint', 'must use https or http');
+  }
+  if (scheme == 'http' && !allowInsecure) {
+    throw ArgumentError.value(
+      endpoint,
+      'endpoint',
+      'plaintext requires allowInsecure: true',
+    );
+  }
+  if (endpoint.userInfo.isNotEmpty ||
+      endpoint.hasQuery ||
+      endpoint.hasFragment) {
+    throw ArgumentError.value(
+      endpoint,
+      'endpoint',
+      'userinfo, query, and fragment are not supported',
+    );
+  }
+  final normalized = endpoint.normalizePath();
+  final path = normalized.path.replaceFirst(RegExp(r'/+$'), '');
+  return normalized.replace(scheme: scheme, path: path);
+}
+
+Uri _healthEndpoint(Uri endpoint) {
+  final path = endpoint.path.isEmpty ? '' : endpoint.path;
+  return endpoint.replace(path: '$path/grpc.health.v1.Health/Check');
+}
+
+bool _isServingStatus(String status) =>
+    status == 'SERVING' || status == 'SERVING_STATUS_SERVING';
+
+connect.Code _codeForHttpStatus(int statusCode) => switch (statusCode) {
+  400 => connect.Code.invalidArgument,
+  401 => connect.Code.unauthenticated,
+  403 => connect.Code.permissionDenied,
+  404 => connect.Code.notFound,
+  408 => connect.Code.deadlineExceeded,
+  409 => connect.Code.aborted,
+  429 => connect.Code.resourceExhausted,
+  >= 500 && < 600 => connect.Code.unavailable,
+  _ => connect.Code.unknown,
+};
+
+connect.Headers _connectHeadersFromIo(io.HttpHeaders source) {
+  final headers = connect.Headers();
+  source.forEach((name, values) {
+    for (final value in values) {
+      headers.add(name, value);
+    }
+  });
+  return headers;
+}
+
+Future<T> _raceAbort<T>(
+  Future<T> operation,
+  _CallSignal signal, {
+  void Function(Object reason)? onAbort,
+}) {
+  final abort = signal.future.then<T>((error) {
+    onAbort?.call(error);
+    throw error;
+  });
+  return Future.any<T>([operation, abort]);
+}
+
+LanternException _invalidArgumentException(String message) {
+  return LanternInvalidArgumentException._(
+    _ErrorData(
+      transportCode: connect.Code.invalidArgument.value,
+      transportCodeName: connect.Code.invalidArgument.name,
+      message: message,
+      headers: const {},
+      trailers: const {},
+      metadata: const {},
+    ),
+  );
+}
+
+LanternException _closedException() {
+  return LanternFailedPreconditionException._(
+    _ErrorData(
+      transportCode: connect.Code.failedPrecondition.value,
+      transportCodeName: connect.Code.failedPrecondition.name,
+      message: 'client is closed',
+      headers: const {},
+      trailers: const {},
+      metadata: const {},
+    ),
+  );
+}
+
+LanternException _mapConnectException(
+  connect.ConnectException error,
+  _InvocationContext context,
+) {
+  final data = _ErrorData(
+    transportCode: error.code.value,
+    transportCodeName: error.code.name,
+    message: _redactSecret(error.message, context.token),
+    cause: error.cause,
+    headers: _headersToMap(context.headers, context.token),
+    trailers: _headersToMap(context.trailers, context.token),
+    metadata: _headersToMap(error.metadata, context.token),
+  );
+  return switch (error.code) {
+    connect.Code.canceled => LanternCanceledException._(data),
+    connect.Code.invalidArgument => LanternInvalidArgumentException._(data),
+    connect.Code.deadlineExceeded => LanternDeadlineExceededException._(data),
+    connect.Code.notFound => LanternNotFoundException._(data),
+    connect.Code.permissionDenied => LanternPermissionDeniedException._(data),
+    connect.Code.resourceExhausted => LanternResourceExhaustedException._(data),
+    connect.Code.failedPrecondition => LanternFailedPreconditionException._(
+      data,
+    ),
+    connect.Code.unauthenticated => LanternUnauthenticatedException._(data),
+    connect.Code.unavailable => LanternUnavailableException._(data),
+    _ => LanternInternalException._(data),
+  };
+}
+
+LanternException _mapUnknownException(
+  Object error,
+  _InvocationContext context,
+) {
+  return LanternInternalException._(
+    _ErrorData(
+      transportCode: connect.Code.unknown.value,
+      transportCodeName: connect.Code.unknown.name,
+      message: 'transport failed',
+      cause: error,
+      headers: _headersToMap(context.headers, context.token),
+      trailers: _headersToMap(context.trailers, context.token),
+      metadata: const {},
+    ),
+  );
+}
+
+Map<String, List<String>> _headersToMap(
+  connect.Headers headers, [
+  String? secret,
+]) {
+  final values = <String, List<String>>{};
+  for (final entry in headers.entries) {
+    values
+        .putIfAbsent(entry.name, () => [])
+        .add(_redactSecret(entry.value, secret));
+  }
+  return Map.unmodifiable(
+    values.map(
+      (name, items) => MapEntry(name, List<String>.unmodifiable(items)),
+    ),
+  );
+}
+
+String _redactSecret(String value, String? secret) {
+  if (secret == null || secret.isEmpty) return value;
+  return value.replaceAll(secret, '[REDACTED]');
+}
+
+final class _ErrorData {
+  const _ErrorData({
+    required this.transportCode,
+    required this.transportCodeName,
+    required this.message,
+    this.cause,
+    required this.headers,
+    required this.trailers,
+    required this.metadata,
+  });
+
+  final int transportCode;
+  final String transportCodeName;
+  final String message;
+  final Object? cause;
+  final Map<String, List<String>> headers;
+  final Map<String, List<String>> trailers;
+  final Map<String, List<String>> metadata;
+}

--- a/sdks/dart/test/client_test.dart
+++ b/sdks/dart/test/client_test.dart
@@ -1,0 +1,358 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:connectrpc/connect.dart' as connect;
+import 'package:connectrpc/test.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:lantern_client/src/client.dart';
+import 'package:lantern_client/src/gen/graph/v1/graph.connect.client.dart';
+import 'package:lantern_client/src/gen/graph/v1/graph.connect.spec.dart';
+import 'package:lantern_client/src/gen/graph/v1/graph.pb.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('health ping uses auth-exempt Connect JSON and maps status', () async {
+    final requests = <io.HttpRequest>[];
+    final server = await io.HttpServer.bind('127.0.0.1', 0);
+    addTearDown(() => server.close(force: true));
+    server.listen((request) async {
+      requests.add(request);
+      await utf8.decoder.bind(request).join();
+      request.response.headers.contentType = io.ContentType.json;
+      request.response.write(jsonEncode({'status': 'SERVING_STATUS_SERVING'}));
+      await request.response.close();
+    });
+
+    final client = LanternClient.connect(
+      Uri.parse('http://127.0.0.1:${server.port}'),
+      allowInsecure: true,
+      token: 'must-not-be-sent-to-health',
+    );
+    await client.ping();
+    expect(requests, hasLength(1));
+    expect(requests.single.method, 'POST');
+    expect(requests.single.uri.path, '/grpc.health.v1.Health/Check');
+    expect(requests.single.headers.value('content-type'), contains('json'));
+    expect(requests.single.headers.value('connect-protocol-version'), '1');
+    expect(requests.single.headers.value('authorization'), isNull);
+    await client.close();
+  });
+
+  test('health ping preserves non-serving status', () async {
+    final server = await io.HttpServer.bind('127.0.0.1', 0);
+    addTearDown(() => server.close(force: true));
+    server.listen((request) async {
+      request.response.headers.contentType = io.ContentType.json;
+      request.response.write(jsonEncode({'status': 'NOT_SERVING'}));
+      await request.response.close();
+    });
+
+    final client = LanternClient.connect(
+      Uri.parse('http://127.0.0.1:${server.port}'),
+      allowInsecure: true,
+    );
+    await expectLater(
+      client.ping(),
+      throwsA(
+        isA<LanternHealthStatusException>().having(
+          (error) => error.status,
+          'status',
+          'NOT_SERVING',
+        ),
+      ),
+    );
+    await client.close();
+  });
+
+  test('normalizes secure endpoints and rejects unsafe forms', () {
+    final client = LanternClient.connect(
+      Uri.parse('HTTPS://example.test/base/'),
+      transport: FakeTransportBuilder().build(),
+    );
+    expect(client.endpoint, Uri.parse('https://example.test/base'));
+
+    expect(
+      () => LanternClient.connect(
+        Uri.parse('http://example.test'),
+        transport: FakeTransportBuilder().build(),
+      ),
+      throwsArgumentError,
+    );
+    expect(
+      () => LanternClient.connect(
+        Uri.parse('https://example.test?token=secret'),
+        transport: FakeTransportBuilder().build(),
+      ),
+      throwsArgumentError,
+    );
+    expect(
+      () => LanternClient.connect(
+        Uri.parse('http://example.test'),
+        allowInsecure: true,
+        transport: FakeTransportBuilder().build(),
+        transportFactory: (_, _) => FakeTransportBuilder().build(),
+      ),
+      throwsArgumentError,
+    );
+    expect(
+      () => LanternCallOptions(
+        timeout: const Duration(seconds: 1),
+        deadline: DateTime.now().add(const Duration(seconds: 1)),
+      ),
+      throwsArgumentError,
+    );
+  });
+
+  test('sends a fresh bearer token for every unary call', () async {
+    var tokenCalls = 0;
+    final transport =
+        FakeTransportBuilder()
+            .unary<GetServerStatusRequest, GetServerStatusResponse>(
+              LanternService.getServerStatus,
+              (request, FakeHandlerContext context) {
+                expect(
+                  context.requestHeaders['authorization'],
+                  'Bearer token-$tokenCalls',
+                );
+                context.responseHeaders.add('x-request-id', 'request-1');
+                context.responseTrailers.add('x-server', 'lantern');
+                return GetServerStatusResponse(
+                  version: 'test',
+                  goVersion: 'go1.test',
+                  tlsEnabled: true,
+                  replicationEnabled: false,
+                  vertexCount: Int64(7),
+                  edgeCount: Int64(11),
+                );
+              },
+            )
+            .build();
+    final invoker = LanternInvoker(
+      tokenProvider: () => 'token-${++tokenCalls}',
+      transport: transport,
+      defaultTimeout: const Duration(seconds: 1),
+    );
+    final raw = LanternServiceClient(invoker.transport);
+
+    Future<GetServerStatusResponse> call() => invoker.invokeUnary(
+      call:
+          ({
+            required headers,
+            required signal,
+            required onHeader,
+            required onTrailer,
+          }) => raw.getServerStatus(
+            GetServerStatusRequest(),
+            headers: headers,
+            signal: signal,
+            onHeader: onHeader,
+            onTrailer: onTrailer,
+          ),
+    );
+    expect((await call()).version, 'test');
+    expect((await call()).version, 'test');
+    expect(tokenCalls, 2);
+  });
+
+  test('maps transport failures without exposing token metadata', () async {
+    final transport =
+        FakeTransportBuilder()
+            .unary<GetServerStatusRequest, GetServerStatusResponse>(
+              LanternService.getServerStatus,
+              (request, FakeHandlerContext context) =>
+                  throw connect.ConnectException(
+                    connect.Code.unauthenticated,
+                    'credentials rejected',
+                    metadata:
+                        connect.Headers()..add('www-authenticate', 'Bearer'),
+                  ),
+            )
+            .build();
+    final invoker = LanternInvoker(
+      tokenProvider: () => 'do-not-log-me',
+      transport: transport,
+    );
+    final raw = LanternServiceClient(invoker.transport);
+
+    final error = await expectLater(
+      invoker.invokeUnary(
+        call:
+            ({
+              required headers,
+              required signal,
+              required onHeader,
+              required onTrailer,
+            }) => raw.getServerStatus(
+              GetServerStatusRequest(),
+              headers: headers,
+              signal: signal,
+              onHeader: onHeader,
+              onTrailer: onTrailer,
+            ),
+      ),
+      throwsA(
+        isA<LanternUnauthenticatedException>()
+            .having((value) => value.code, 'code', LanternCode.unauthenticated)
+            .having((value) => value.message, 'message', 'credentials rejected')
+            .having((value) => value.metadata['www-authenticate'], 'metadata', [
+              'Bearer',
+            ]),
+      ),
+    );
+    expect(error, isNull);
+  });
+
+  test('deadline and caller cancellation map to typed failures', () async {
+    final pending = Completer<GetServerStatusResponse>();
+    final transport =
+        FakeTransportBuilder()
+            .unary<GetServerStatusRequest, GetServerStatusResponse>(
+              LanternService.getServerStatus,
+              (request, FakeHandlerContext context) async {
+                await Future.any<GetServerStatusResponse>([
+                  pending.future,
+                  context.signal.future.then<GetServerStatusResponse>(
+                    (connect.ConnectException error) => throw error,
+                  ),
+                ]);
+                return pending.future;
+              },
+            )
+            .build();
+    final invoker = LanternInvoker(
+      transport: transport,
+      defaultTimeout: const Duration(milliseconds: 1),
+    );
+    final raw = LanternServiceClient(invoker.transport);
+    Future<GetServerStatusResponse> call(LanternCallOptions? options) =>
+        invoker.invokeUnary(
+          options: options,
+          call:
+              ({
+                required headers,
+                required signal,
+                required onHeader,
+                required onTrailer,
+              }) => raw.getServerStatus(
+                GetServerStatusRequest(),
+                headers: headers,
+                signal: signal,
+                onHeader: onHeader,
+                onTrailer: onTrailer,
+              ),
+        );
+
+    await expectLater(
+      call(null),
+      throwsA(isA<LanternDeadlineExceededException>()),
+    );
+
+    final cancellation = LanternCancellationToken();
+    final uncanceledInvoker = LanternInvoker(
+      transport: transport,
+      defaultTimeout: null,
+    );
+    final uncanceledRaw = LanternServiceClient(uncanceledInvoker.transport);
+    final canceledCall = uncanceledInvoker.invokeUnary(
+      options: LanternCallOptions(cancellation: cancellation),
+      call:
+          ({
+            required headers,
+            required signal,
+            required onHeader,
+            required onTrailer,
+          }) => uncanceledRaw.getServerStatus(
+            GetServerStatusRequest(),
+            headers: headers,
+            signal: signal,
+            onHeader: onHeader,
+            onTrailer: onTrailer,
+          ),
+    );
+    cancellation.cancel('screen disposed');
+    await expectLater(canceledCall, throwsA(isA<LanternCanceledException>()));
+  });
+
+  test('close is idempotent and rejects later calls', () async {
+    var closeCalls = 0;
+    final client = LanternClient.connect(
+      Uri.parse('https://example.test'),
+      transport: FakeTransportBuilder().build(),
+      onClose: () => closeCalls++,
+    );
+
+    final first = client.close();
+    final second = client.close();
+    await Future.wait([first, second]);
+    expect(closeCalls, 1);
+    expect(client.isClosed, isTrue);
+    expect(
+      () => client.ping(),
+      throwsA(isA<LanternFailedPreconditionException>()),
+    );
+  });
+
+  test('redacts the token from transport diagnostics', () async {
+    const secret = 'secret-token';
+    final invoker = LanternInvoker(
+      transport: FakeTransportBuilder().build(),
+      tokenProvider: () => secret,
+    );
+
+    final call = invoker.invokeUnary<Object?>(
+      call: ({
+        required headers,
+        required signal,
+        required onHeader,
+        required onTrailer,
+      }) async {
+        onHeader(connect.Headers()..add('x-secret', secret));
+        onTrailer(connect.Headers()..add('x-trailer-secret', secret));
+        throw connect.ConnectException(
+          connect.Code.unauthenticated,
+          'invalid $secret',
+          metadata: connect.Headers()..add('x-metadata-secret', secret),
+        );
+      },
+    );
+
+    try {
+      await call;
+      fail('expected an authentication error');
+    } on LanternUnauthenticatedException catch (error) {
+      expect(error.message, 'invalid [REDACTED]');
+      expect(error.headers['x-secret'], ['[REDACTED]']);
+      expect(error.trailers['x-trailer-secret'], ['[REDACTED]']);
+      expect(error.metadata['x-metadata-secret'], ['[REDACTED]']);
+      expect(error.toString(), isNot(contains(secret)));
+    }
+  });
+
+  test(
+    'canceling a stream subscription aborts its signal immediately',
+    () async {
+      final source = StreamController<int>();
+      final signalReady = Completer<connect.AbortSignal>();
+      final invoker = LanternInvoker(transport: FakeTransportBuilder().build());
+      final stream = invoker.invokeStream<int>(
+        call: ({
+          required headers,
+          required signal,
+          required onHeader,
+          required onTrailer,
+        }) {
+          signalReady.complete(signal);
+          return source.stream;
+        },
+      );
+
+      final subscription = stream.listen((_) {});
+      final signal = await signalReady.future;
+      await subscription.cancel();
+
+      await expectLater(signal.future, completes);
+      await source.close();
+    },
+  );
+}

--- a/sdks/dart/test/real_wire_test.dart
+++ b/sdks/dart/test/real_wire_test.dart
@@ -1,0 +1,23 @@
+import 'dart:io' as io;
+
+import 'package:lantern_client/lantern_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('health ping reaches a real Lantern listener when configured', () async {
+    final configured =
+        io.Platform.environment['LANTERN_DART_REAL_WIRE_ENDPOINT'];
+    if (configured == null || configured.isEmpty) {
+      markTestSkipped('LANTERN_DART_REAL_WIRE_ENDPOINT is not configured');
+      return;
+    }
+    final endpoint = Uri.parse(configured);
+    final client = LanternClient.connect(
+      endpoint,
+      allowInsecure: endpoint.scheme == 'http',
+      defaultTimeout: const Duration(seconds: 5),
+    );
+    addTearDown(client.close);
+    await client.ping();
+  });
+}


### PR DESCRIPTION
Closes #1008

## What changed
- Add the public `LanternClient` foundation for the pure-Dart mobile SDK.
- Enforce HTTPS by default with explicit local HTTP opt-in and injectable Connect/HTTP transports.
- Add fresh per-call token providers, deadlines, cancellation, typed Connect errors, credential redaction, stream cancellation, and idempotent close.
- Implement auth-exempt Connect+JSON gRPC Health-v1 `ping()` with typed non-serving status errors.
- Add unit coverage and an env-gated Dart VM real-wire test; update SDK/release documentation and workflow path triggers.

## Validation
- `gofmt -l .`
- `go test ./...` (root)
- `go test ./...` in `core`, `mcp`, `pb`, and `sdks/go`; `go vet ./... && go test ./...` in `server`
- `dart format --output=none --set-exit-if-changed ...`
- `dart analyze`
- `dart test` (14 pass, 1 env-gated skip locally; real-wire test passed against a running Lantern listener)
- `dart doc --validate-links`
