### PR TITLE
chore(dart): raise supported SDK floor to 3.10

### DIFF
--- a/.github/workflows/dart-sdk.yml
+++ b/.github/workflows/dart-sdk.yml
@@ -162,7 +162,7 @@ jobs:
           fi
 
   minimum-dart:
-    name: Minimum Dart 3.7
+    name: Minimum Dart 3.10
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -173,7 +173,7 @@ jobs:
       - name: Set up minimum supported Dart
         uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
         with:
-          sdk: 3.7.0
+          sdk: 3.10.0
 
       - name: Resolve at the minimum floor
         # The maintained Flutter example intentionally follows the pinned

--- a/docs/decisions/0001-dart-mobile-transport.md
+++ b/docs/decisions/0001-dart-mobile-transport.md
@@ -20,7 +20,7 @@ HTTP/1.1 client. Use these exact initial pins:
 - runtime: `connectrpc 1.0.0`, `protobuf 4.2.0`, `fixnum 1.1.1`;
 - code generation: `buf.build/connectrpc/dart:v1.0.0` and
   `buf.build/protocolbuffers/dart:v22.5.0`;
-- Dart floor: 3.7.0, matching Connect-Dart's supported language floor;
+- Dart floor: 3.10.0, allowing the maintained lints and test toolchain;
 - validated Flutter toolchain: Flutter 3.44.6 / Dart 3.12.2;
 - supported production platforms: Android and iOS native only; Flutter Web is
   outside this decision.

--- a/sdks/dart/README.md
+++ b/sdks/dart/README.md
@@ -197,7 +197,7 @@ Protobuf `<5.0.0` ceiling is required by Connect-Dart 1.x.
 
 The supported toolchain policy is recorded in
 [ADR 0001](https://github.com/anaregdesign/lantern/blob/main/docs/decisions/0001-dart-mobile-transport.md):
-CI tests the package's Dart 3.7 floor and the pinned current Flutter/Dart pair.
+CI tests the package's Dart 3.10 floor and the pinned current Flutter/Dart pair.
 Generator/runtime compatibility pins move together through reviewed PRs.
 
 Generated files are committed under `lib/src/gen` and must never be edited by

--- a/sdks/dart/lib/src/client.dart
+++ b/sdks/dart/lib/src/client.dart
@@ -426,12 +426,11 @@ final class LanternClient {
         'must be positive',
       );
     }
-    final injectionCount =
-        [
-          transport != null,
-          transportFactory != null,
-          httpClientFactory != null,
-        ].where((value) => value).length;
+    final injectionCount = [
+      transport != null,
+      transportFactory != null,
+      httpClientFactory != null,
+    ].where((value) => value).length;
     if (injectionCount > 1) {
       throw ArgumentError(
         'transport, transportFactory, and httpClientFactory are mutually exclusive',
@@ -656,8 +655,10 @@ final class LanternInvoker {
     controller = StreamController<T>(
       sync: true,
       onListen: () {
-        final invocation =
-            context = _InvocationContext(options, _defaultTimeout);
+        final invocation = context = _InvocationContext(
+          options,
+          _defaultTimeout,
+        );
         final body = _invokeStreamBody(call, invocation);
         subscription = body.listen(
           controller.add,
@@ -718,13 +719,12 @@ final class LanternInvoker {
     final signal = context.signal;
     String? token;
     try {
-      token =
-          (await Future.any<_TokenProviderResult>([
-            Future<String?>.sync(provider).then(_TokenProviderResult.value),
-            signal.future.then<_TokenProviderResult>(
-              (error) => throw _SignalAbort(error),
-            ),
-          ])).token;
+      token = (await Future.any<_TokenProviderResult>([
+        Future<String?>.sync(provider).then(_TokenProviderResult.value),
+        signal.future.then<_TokenProviderResult>(
+          (error) => throw _SignalAbort(error),
+        ),
+      ])).token;
     } on _SignalAbort catch (error) {
       // Preserve cancellation/deadline status from our signal. Provider
       // failures are handled below and never expose provider-supplied text.

--- a/sdks/dart/lib/src/data.dart
+++ b/sdks/dart/lib/src/data.dart
@@ -560,8 +560,9 @@ Vertex _vertexFromProto($graph.Vertex value) {
   return Vertex(
     key: value.key,
     value: decoded,
-    expiration:
-        value.hasExpiration() ? _timestampFromProto(value.expiration) : null,
+    expiration: value.hasExpiration()
+        ? _timestampFromProto(value.expiration)
+        : null,
   );
 }
 
@@ -579,8 +580,9 @@ Edge _edgeFromProto($graph.Edge value) => Edge(
   tail: value.tail,
   head: value.head,
   weight: _finiteFloatFromProto(value.weight, 'edge weight'),
-  expiration:
-      value.hasExpiration() ? _timestampFromProto(value.expiration) : null,
+  expiration: value.hasExpiration()
+      ? _timestampFromProto(value.expiration)
+      : null,
 );
 
 LanternException _internalSdkException(String message) =>

--- a/sdks/dart/lib/src/decay.dart
+++ b/sdks/dart/lib/src/decay.dart
@@ -40,8 +40,10 @@ DecayOptions halfLifeDecay({
       'halfLife, interval, and horizon must be positive',
     );
   }
-  final ratio =
-      pow(0.5, interval.inMicroseconds / halfLife.inMicroseconds).toDouble();
+  final ratio = pow(
+    0.5,
+    interval.inMicroseconds / halfLife.inMicroseconds,
+  ).toDouble();
   var steps = (horizon.inMicroseconds / interval.inMicroseconds).ceil();
   if (steps < 1) steps = 1;
   if (steps > maxDecaySteps) steps = maxDecaySteps;
@@ -68,12 +70,11 @@ List<EdgeInput> decayContributions({
   final output = <EdgeInput>[];
   for (var step = 1; step <= options.steps; step++) {
     final exponent = step - 1;
-    final contribution =
-        step < options.steps
-            ? options.initialWeight *
-                pow(options.ratio, exponent) *
-                (1 - options.ratio)
-            : options.initialWeight * pow(options.ratio, exponent);
+    final contribution = step < options.steps
+        ? options.initialWeight *
+              pow(options.ratio, exponent) *
+              (1 - options.ratio)
+        : options.initialWeight * pow(options.ratio, exponent);
     final weight = _normalizeFloat32(contribution.toDouble());
     if (weight == 0) continue;
     DateTime expiration;

--- a/sdks/dart/lib/src/retry.dart
+++ b/sdks/dart/lib/src/retry.dart
@@ -27,10 +27,9 @@ final class RetryPolicy {
 
   _NormalizedRetryPolicy _normalized() => _NormalizedRetryPolicy(
     maxAttempts: maxAttempts < 1 ? 3 : maxAttempts,
-    baseDelay:
-        baseDelay <= Duration.zero
-            ? const Duration(milliseconds: 100)
-            : baseDelay,
+    baseDelay: baseDelay <= Duration.zero
+        ? const Duration(milliseconds: 100)
+        : baseDelay,
     maxDelay: maxDelay <= Duration.zero ? const Duration(seconds: 2) : maxDelay,
     retryResourceExhausted: retryResourceExhausted,
   );

--- a/sdks/dart/lib/src/scan.dart
+++ b/sdks/dart/lib/src/scan.dart
@@ -86,14 +86,13 @@ extension LanternScan on LanternClient {
   }) => _scanPageStream(
     initialCursor: cursor,
     options: options,
-    fetch:
-        (next, linkedOptions) => scanVertices(
-          prefix: prefix,
-          limit: limit,
-          cursor: next,
-          order: order,
-          options: linkedOptions,
-        ),
+    fetch: (next, linkedOptions) => scanVertices(
+      prefix: prefix,
+      limit: limit,
+      cursor: next,
+      order: order,
+      options: linkedOptions,
+    ),
   );
 
   /// Fetches one keys-only page without decoding vertex values.
@@ -140,14 +139,13 @@ extension LanternScan on LanternClient {
   }) => _scanPageStream(
     initialCursor: cursor,
     options: options,
-    fetch:
-        (next, linkedOptions) => scanVertexKeys(
-          prefix: prefix,
-          limit: limit,
-          cursor: next,
-          order: order,
-          options: linkedOptions,
-        ),
+    fetch: (next, linkedOptions) => scanVertexKeys(
+      prefix: prefix,
+      limit: limit,
+      cursor: next,
+      order: order,
+      options: linkedOptions,
+    ),
   );
 
   /// Fetches one ascending `(tail, head)` edge page.
@@ -193,14 +191,13 @@ extension LanternScan on LanternClient {
   }) => _scanPageStream(
     initialCursor: cursor,
     options: options,
-    fetch:
-        (next, linkedOptions) => scanEdges(
-          tailPrefix: tailPrefix,
-          headPrefix: headPrefix,
-          limit: limit,
-          cursor: next,
-          options: linkedOptions,
-        ),
+    fetch: (next, linkedOptions) => scanEdges(
+      tailPrefix: tailPrefix,
+      headPrefix: headPrefix,
+      limit: limit,
+      cursor: next,
+      options: linkedOptions,
+    ),
   );
 
   /// Counts live vertex keys under [prefix] without page materialization.

--- a/sdks/dart/lib/src/status.dart
+++ b/sdks/dart/lib/src/status.dart
@@ -226,15 +226,13 @@ extension LanternStatus on LanternClient {
     return ServerStatus._(
       version: response.version,
       goVersion: response.goVersion,
-      startedAt:
-          response.hasStartedAt()
-              ? _timestampFromProto(response.startedAt)
-              : null,
+      startedAt: response.hasStartedAt()
+          ? _timestampFromProto(response.startedAt)
+          : null,
       uptime: response.hasUptime() ? _durationFromProto(response.uptime) : null,
-      defaultTtl:
-          response.hasDefaultTtl()
-              ? _durationFromProto(response.defaultTtl)
-              : null,
+      defaultTtl: response.hasDefaultTtl()
+          ? _durationFromProto(response.defaultTtl)
+          : null,
       maxBatchSize: response.maxBatchSize,
       maxKeyBytes: response.maxKeyBytes,
       scanDefaultLimit: response.scanDefaultLimit,
@@ -262,27 +260,26 @@ extension LanternStatus on LanternClient {
         onTrailer: onTrailer,
       ),
     );
-    final peers = response.peers
-        .map(
-          (peer) => ReplicationPeerStatus(
-            address: peer.address,
-            state: _replicationPeerStateFromProto(peer.state),
-            lastEventAt:
-                peer.hasLastEventAt()
+    final peers =
+        response.peers
+            .map(
+              (peer) => ReplicationPeerStatus(
+                address: peer.address,
+                state: _replicationPeerStateFromProto(peer.state),
+                lastEventAt: peer.hasLastEventAt()
                     ? _timestampFromProto(peer.lastEventAt)
                     : null,
-            appliedSequence: _uint64ToBigInt(peer.appliedSeq),
-            error: peer.error.isEmpty ? null : peer.error,
-          ),
-        )
-        .toList(growable: false)
-      ..sort((left, right) => left.address.compareTo(right.address));
+                appliedSequence: _uint64ToBigInt(peer.appliedSeq),
+                error: peer.error.isEmpty ? null : peer.error,
+              ),
+            )
+            .toList(growable: false)
+          ..sort((left, right) => left.address.compareTo(right.address));
     return ReplicationStatus._(
       nodeId: response.nodeId,
-      localNow:
-          response.hasLocalNow()
-              ? _timestampFromProto(response.localNow)
-              : null,
+      localNow: response.hasLocalNow()
+          ? _timestampFromProto(response.localNow)
+          : null,
       enabled: response.enabled,
       peers: peers,
     );

--- a/sdks/dart/lib/src/traversal.dart
+++ b/sdks/dart/lib/src/traversal.dart
@@ -203,10 +203,9 @@ extension LanternTraversal on LanternClient {
         _validateProbabilityAndEpsilon(restartProbability, epsilon);
         request.ppr = $graph.PprParams(
           topN: topN,
-          restartProb:
-              restartProbability == null
-                  ? null
-                  : _normalizeFloat32(restartProbability),
+          restartProb: restartProbability == null
+              ? null
+              : _normalizeFloat32(restartProbability),
           epsilon: epsilon == null ? null : _normalizeFloat32(epsilon),
         );
       case LocalCommunityOptions(
@@ -220,10 +219,9 @@ extension LanternTraversal on LanternClient {
         _validateProbabilityAndEpsilon(restartProbability, epsilon);
         request.community = $graph.LocalCommunityParams(
           maxSize: maxSize,
-          restartProb:
-              restartProbability == null
-                  ? null
-                  : _normalizeFloat32(restartProbability),
+          restartProb: restartProbability == null
+              ? null
+              : _normalizeFloat32(restartProbability),
           epsilon: epsilon == null ? null : _normalizeFloat32(epsilon),
           objective: _objectiveToProto(objective),
           reduction: _reductionToProto(reduction),
@@ -282,13 +280,13 @@ void _validateProbabilityAndEpsilon(double? probability, double? epsilon) {
   }
 }
 
-$graph.Objective _objectiveToProto(
-  TraversalObjective objective,
-) => switch (objective) {
-  TraversalObjective.serverDefault => $graph.Objective.OBJECTIVE_UNSPECIFIED,
-  TraversalObjective.minimize => $graph.Objective.OBJECTIVE_MINIMIZE,
-  TraversalObjective.maximize => $graph.Objective.OBJECTIVE_MAXIMIZE,
-};
+$graph.Objective _objectiveToProto(TraversalObjective objective) =>
+    switch (objective) {
+      TraversalObjective.serverDefault =>
+        $graph.Objective.OBJECTIVE_UNSPECIFIED,
+      TraversalObjective.minimize => $graph.Objective.OBJECTIVE_MINIMIZE,
+      TraversalObjective.maximize => $graph.Objective.OBJECTIVE_MAXIMIZE,
+    };
 
 $graph.Reduction _reductionToProto(TraversalReduction reduction) =>
     switch (reduction) {
@@ -299,11 +297,11 @@ $graph.Reduction _reductionToProto(TraversalReduction reduction) =>
         $graph.Reduction.REDUCTION_SHORTEST_PATH_TREE,
     };
 
-$graph.Weighting _weightingToProto(
-  TraversalWeighting weighting,
-) => switch (weighting) {
-  TraversalWeighting.serverDefault => $graph.Weighting.WEIGHTING_UNSPECIFIED,
-  TraversalWeighting.raw => $graph.Weighting.WEIGHTING_RAW,
-  TraversalWeighting.tfidf => $graph.Weighting.WEIGHTING_TFIDF,
-  TraversalWeighting.bm25 => $graph.Weighting.WEIGHTING_BM25,
-};
+$graph.Weighting _weightingToProto(TraversalWeighting weighting) =>
+    switch (weighting) {
+      TraversalWeighting.serverDefault =>
+        $graph.Weighting.WEIGHTING_UNSPECIFIED,
+      TraversalWeighting.raw => $graph.Weighting.WEIGHTING_RAW,
+      TraversalWeighting.tfidf => $graph.Weighting.WEIGHTING_TFIDF,
+      TraversalWeighting.bm25 => $graph.Weighting.WEIGHTING_BM25,
+    };

--- a/sdks/dart/pubspec.yaml
+++ b/sdks/dart/pubspec.yaml
@@ -11,7 +11,7 @@ topics:
   - lantern
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   connectrpc: ">=1.0.0 <2.0.0"
@@ -19,6 +19,6 @@ dependencies:
   protobuf: ">=4.2.0 <5.0.0"
 
 dev_dependencies:
-  # Keep dev resolution compatible with the documented Dart 3.7 floor.
+  # Keep dev resolution compatible with the documented Dart 3.10 floor.
   lints: 5.1.1
   test: 1.30.0

--- a/sdks/dart/test/client_test.dart
+++ b/sdks/dart/test/client_test.dart
@@ -106,28 +106,27 @@ void main() {
 
   test('sends a fresh bearer token for every unary call', () async {
     var tokenCalls = 0;
-    final transport =
-        FakeTransportBuilder()
-            .unary<GetServerStatusRequest, GetServerStatusResponse>(
-              LanternService.getServerStatus,
-              (request, FakeHandlerContext context) {
-                expect(
-                  context.requestHeaders['authorization'],
-                  'Bearer token-$tokenCalls',
-                );
-                context.responseHeaders.add('x-request-id', 'request-1');
-                context.responseTrailers.add('x-server', 'lantern');
-                return GetServerStatusResponse(
-                  version: 'test',
-                  goVersion: 'go1.test',
-                  tlsEnabled: true,
-                  replicationEnabled: false,
-                  vertexCount: Int64(7),
-                  edgeCount: Int64(11),
-                );
-              },
-            )
-            .build();
+    final transport = FakeTransportBuilder()
+        .unary<GetServerStatusRequest, GetServerStatusResponse>(
+          LanternService.getServerStatus,
+          (request, FakeHandlerContext context) {
+            expect(
+              context.requestHeaders['authorization'],
+              'Bearer token-$tokenCalls',
+            );
+            context.responseHeaders.add('x-request-id', 'request-1');
+            context.responseTrailers.add('x-server', 'lantern');
+            return GetServerStatusResponse(
+              version: 'test',
+              goVersion: 'go1.test',
+              tlsEnabled: true,
+              replicationEnabled: false,
+              vertexCount: Int64(7),
+              edgeCount: Int64(11),
+            );
+          },
+        )
+        .build();
     final invoker = LanternInvoker(
       tokenProvider: () => 'token-${++tokenCalls}',
       transport: transport,
@@ -156,19 +155,17 @@ void main() {
   });
 
   test('maps transport failures without exposing token metadata', () async {
-    final transport =
-        FakeTransportBuilder()
-            .unary<GetServerStatusRequest, GetServerStatusResponse>(
-              LanternService.getServerStatus,
-              (request, FakeHandlerContext context) =>
-                  throw connect.ConnectException(
-                    connect.Code.unauthenticated,
-                    'credentials rejected',
-                    metadata:
-                        connect.Headers()..add('www-authenticate', 'Bearer'),
-                  ),
-            )
-            .build();
+    final transport = FakeTransportBuilder()
+        .unary<GetServerStatusRequest, GetServerStatusResponse>(
+          LanternService.getServerStatus,
+          (request, FakeHandlerContext context) =>
+              throw connect.ConnectException(
+                connect.Code.unauthenticated,
+                'credentials rejected',
+                metadata: connect.Headers()..add('www-authenticate', 'Bearer'),
+              ),
+        )
+        .build();
     final invoker = LanternInvoker(
       tokenProvider: () => 'do-not-log-me',
       transport: transport,
@@ -205,21 +202,20 @@ void main() {
 
   test('deadline and caller cancellation map to typed failures', () async {
     final pending = Completer<GetServerStatusResponse>();
-    final transport =
-        FakeTransportBuilder()
-            .unary<GetServerStatusRequest, GetServerStatusResponse>(
-              LanternService.getServerStatus,
-              (request, FakeHandlerContext context) async {
-                await Future.any<GetServerStatusResponse>([
-                  pending.future,
-                  context.signal.future.then<GetServerStatusResponse>(
-                    (connect.ConnectException error) => throw error,
-                  ),
-                ]);
-                return pending.future;
-              },
-            )
-            .build();
+    final transport = FakeTransportBuilder()
+        .unary<GetServerStatusRequest, GetServerStatusResponse>(
+          LanternService.getServerStatus,
+          (request, FakeHandlerContext context) async {
+            await Future.any<GetServerStatusResponse>([
+              pending.future,
+              context.signal.future.then<GetServerStatusResponse>(
+                (connect.ConnectException error) => throw error,
+              ),
+            ]);
+            return pending.future;
+          },
+        )
+        .build();
     final invoker = LanternInvoker(
       transport: transport,
       defaultTimeout: const Duration(milliseconds: 1),
@@ -301,20 +297,21 @@ void main() {
     );
 
     final call = invoker.invokeUnary<Object?>(
-      call: ({
-        required headers,
-        required signal,
-        required onHeader,
-        required onTrailer,
-      }) async {
-        onHeader(connect.Headers()..add('x-secret', secret));
-        onTrailer(connect.Headers()..add('x-trailer-secret', secret));
-        throw connect.ConnectException(
-          connect.Code.unauthenticated,
-          'invalid $secret',
-          metadata: connect.Headers()..add('x-metadata-secret', secret),
-        );
-      },
+      call:
+          ({
+            required headers,
+            required signal,
+            required onHeader,
+            required onTrailer,
+          }) async {
+            onHeader(connect.Headers()..add('x-secret', secret));
+            onTrailer(connect.Headers()..add('x-trailer-secret', secret));
+            throw connect.ConnectException(
+              connect.Code.unauthenticated,
+              'invalid $secret',
+              metadata: connect.Headers()..add('x-metadata-secret', secret),
+            );
+          },
     );
 
     try {
@@ -336,15 +333,16 @@ void main() {
       final signalReady = Completer<connect.AbortSignal>();
       final invoker = LanternInvoker(transport: FakeTransportBuilder().build());
       final stream = invoker.invokeStream<int>(
-        call: ({
-          required headers,
-          required signal,
-          required onHeader,
-          required onTrailer,
-        }) {
-          signalReady.complete(signal);
-          return source.stream;
-        },
+        call:
+            ({
+              required headers,
+              required signal,
+              required onHeader,
+              required onTrailer,
+            }) {
+              signalReady.complete(signal);
+              return source.stream;
+            },
       );
 
       final subscription = stream.listen((_) {});

--- a/sdks/dart/test/crud_test.dart
+++ b/sdks/dart/test/crud_test.dart
@@ -10,21 +10,20 @@ import 'package:test/test.dart';
 void main() {
   test('plural reads chunk and preserve present and missing values', () async {
     final requests = <List<String>>[];
-    final transport =
-        FakeTransportBuilder()
-            .unary<graph.GetVerticesRequest, graph.GetVerticesResponse>(
-              LanternService.getVertices,
-              (request, context) {
-                requests.add(request.keys.toList());
-                return graph.GetVerticesResponse(
-                  vertices: request.keys
-                      .where((key) => key != 'missing')
-                      .map((key) => graph.Vertex(key: key, string: key)),
-                  missing: request.keys.where((key) => key == 'missing'),
-                );
-              },
-            )
-            .build();
+    final transport = FakeTransportBuilder()
+        .unary<graph.GetVerticesRequest, graph.GetVerticesResponse>(
+          LanternService.getVertices,
+          (request, context) {
+            requests.add(request.keys.toList());
+            return graph.GetVerticesResponse(
+              vertices: request.keys
+                  .where((key) => key != 'missing')
+                  .map((key) => graph.Vertex(key: key, string: key)),
+              missing: request.keys.where((key) => key == 'missing'),
+            );
+          },
+        )
+        .build();
     final client = _client(transport);
 
     final result = await client.getVertices([
@@ -45,18 +44,20 @@ void main() {
 
   test('duplicate edge refs remain explicit and index-preserving', () async {
     late List<graph.EdgeKey> requested;
-    final transport =
-        FakeTransportBuilder().unary<
-          graph.GetEdgesRequest,
-          graph.GetEdgesResponse
-        >(LanternService.getEdges, (request, context) {
-          requested = request.edges.toList();
-          return graph.GetEdgesResponse(
-            edges: request.edges.map(
-              (edge) => graph.Edge(tail: edge.tail, head: edge.head, weight: 1),
-            ),
-          );
-        }).build();
+    final transport = FakeTransportBuilder()
+        .unary<graph.GetEdgesRequest, graph.GetEdgesResponse>(
+          LanternService.getEdges,
+          (request, context) {
+            requested = request.edges.toList();
+            return graph.GetEdgesResponse(
+              edges: request.edges.map(
+                (edge) =>
+                    graph.Edge(tail: edge.tail, head: edge.head, weight: 1),
+              ),
+            );
+          },
+        )
+        .build();
     final client = _client(transport);
     const ref = EdgeRef('a', 'b');
 
@@ -74,21 +75,23 @@ void main() {
     () async {
       var clockCalls = 0;
       final expirations = <DateTime?>[];
-      final transport =
-          FakeTransportBuilder().unary<
-            graph.PutVerticesRequest,
-            graph.PutVerticesResponse
-          >(LanternService.putVertices, (request, context) {
-            expirations.addAll(
-              request.vertices.map(
-                (value) =>
-                    value.hasExpiration()
-                        ? value.expiration.toDateTime()
-                        : null,
-              ),
-            );
-            return graph.PutVerticesResponse(written: request.vertices.length);
-          }).build();
+      final transport = FakeTransportBuilder()
+          .unary<graph.PutVerticesRequest, graph.PutVerticesResponse>(
+            LanternService.putVertices,
+            (request, context) {
+              expirations.addAll(
+                request.vertices.map(
+                  (value) => value.hasExpiration()
+                      ? value.expiration.toDateTime()
+                      : null,
+                ),
+              );
+              return graph.PutVerticesResponse(
+                written: request.vertices.length,
+              );
+            },
+          )
+          .build();
       final client = LanternClient.connect(
         Uri.parse('https://example.test'),
         transport: transport,
@@ -124,23 +127,22 @@ void main() {
 
   test('invalid TTL and contrib ID fail before network I/O', () async {
     var calls = 0;
-    final transport =
-        FakeTransportBuilder()
-            .unary<graph.PutVerticesRequest, graph.PutVerticesResponse>(
-              LanternService.putVertices,
-              (request, context) {
-                calls++;
-                return graph.PutVerticesResponse();
-              },
-            )
-            .unary<graph.AddEdgesRequest, graph.AddEdgesResponse>(
-              LanternService.addEdges,
-              (request, context) {
-                calls++;
-                return graph.AddEdgesResponse();
-              },
-            )
-            .build();
+    final transport = FakeTransportBuilder()
+        .unary<graph.PutVerticesRequest, graph.PutVerticesResponse>(
+          LanternService.putVertices,
+          (request, context) {
+            calls++;
+            return graph.PutVerticesResponse();
+          },
+        )
+        .unary<graph.AddEdgesRequest, graph.AddEdgesResponse>(
+          LanternService.addEdges,
+          (request, context) {
+            calls++;
+            return graph.AddEdgesResponse();
+          },
+        )
+        .build();
     final client = _client(transport);
 
     await expectLater(
@@ -183,20 +185,23 @@ void main() {
     'partial write reports confirmed committed count and typed cause',
     () async {
       var calls = 0;
-      final transport =
-          FakeTransportBuilder().unary<
-            graph.PutVerticesRequest,
-            graph.PutVerticesResponse
-          >(LanternService.putVertices, (request, context) {
-            calls++;
-            if (calls == 2) {
-              throw connect.ConnectException(
-                connect.Code.unavailable,
-                'forced second-chunk failure',
+      final transport = FakeTransportBuilder()
+          .unary<graph.PutVerticesRequest, graph.PutVerticesResponse>(
+            LanternService.putVertices,
+            (request, context) {
+              calls++;
+              if (calls == 2) {
+                throw connect.ConnectException(
+                  connect.Code.unavailable,
+                  'forced second-chunk failure',
+                );
+              }
+              return graph.PutVerticesResponse(
+                written: request.vertices.length,
               );
-            }
-            return graph.PutVerticesResponse(written: request.vertices.length);
-          }).build();
+            },
+          )
+          .build();
       final client = _client(transport);
 
       await expectLater(
@@ -222,17 +227,15 @@ void main() {
   );
 
   test('server batch rejection remains a typed failure', () async {
-    final transport =
-        FakeTransportBuilder()
-            .unary<graph.PutEdgesRequest, graph.PutEdgesResponse>(
-              LanternService.putEdges,
-              (request, context) =>
-                  throw connect.ConnectException(
-                    connect.Code.resourceExhausted,
-                    'server max batch exceeded',
-                  ),
-            )
-            .build();
+    final transport = FakeTransportBuilder()
+        .unary<graph.PutEdgesRequest, graph.PutEdgesResponse>(
+          LanternService.putEdges,
+          (request, context) => throw connect.ConnectException(
+            connect.Code.resourceExhausted,
+            'server max batch exceeded',
+          ),
+        )
+        .build();
     final client = _client(transport);
 
     await expectLater(
@@ -243,16 +246,15 @@ void main() {
 
   test('cancellation between chunks reports partial progress', () async {
     final cancellation = LanternCancellationToken();
-    final transport =
-        FakeTransportBuilder()
-            .unary<graph.PutEdgesRequest, graph.PutEdgesResponse>(
-              LanternService.putEdges,
-              (request, context) {
-                cancellation.cancel('stop after first chunk');
-                return graph.PutEdgesResponse(written: request.edges.length);
-              },
-            )
-            .build();
+    final transport = FakeTransportBuilder()
+        .unary<graph.PutEdgesRequest, graph.PutEdgesResponse>(
+          LanternService.putEdges,
+          (request, context) {
+            cancellation.cancel('stop after first chunk');
+            return graph.PutEdgesResponse(written: request.edges.length);
+          },
+        )
+        .build();
     final client = _client(transport);
 
     await expectLater(
@@ -282,26 +284,25 @@ void main() {
       final id = Uint8List(24)..[0] = 7;
       final addRequests = <graph.AddEdgesRequest>[];
       final putRequests = <graph.PutEdgesRequest>[];
-      final transport =
-          FakeTransportBuilder()
-              .unary<graph.AddEdgesRequest, graph.AddEdgesResponse>(
-                LanternService.addEdges,
-                (request, context) {
-                  addRequests.add(request.deepCopy());
-                  return graph.AddEdgesResponse(
-                    written: request.edges.length,
-                    effectiveWeights: [3, 5],
-                  );
-                },
-              )
-              .unary<graph.PutEdgesRequest, graph.PutEdgesResponse>(
-                LanternService.putEdges,
-                (request, context) {
-                  putRequests.add(request.deepCopy());
-                  return graph.PutEdgesResponse(written: request.edges.length);
-                },
-              )
-              .build();
+      final transport = FakeTransportBuilder()
+          .unary<graph.AddEdgesRequest, graph.AddEdgesResponse>(
+            LanternService.addEdges,
+            (request, context) {
+              addRequests.add(request.deepCopy());
+              return graph.AddEdgesResponse(
+                written: request.edges.length,
+                effectiveWeights: [3, 5],
+              );
+            },
+          )
+          .unary<graph.PutEdgesRequest, graph.PutEdgesResponse>(
+            LanternService.putEdges,
+            (request, context) {
+              putRequests.add(request.deepCopy());
+              return graph.PutEdgesResponse(written: request.edges.length);
+            },
+          )
+          .build();
       final client = _client(transport);
       final inputs = [
         EdgeInput(tail: 'a', head: 'b', weight: 1),
@@ -320,35 +321,35 @@ void main() {
   test(
     'singular facades retain missing, skipped, and existed contracts',
     () async {
-      final transport =
-          FakeTransportBuilder()
-              .unary<graph.GetVerticesRequest, graph.GetVerticesResponse>(
-                LanternService.getVertices,
-                (request, context) =>
-                    graph.GetVerticesResponse(missing: request.keys),
-              )
-              .unary<graph.PutVerticesRequest, graph.PutVerticesResponse>(
-                LanternService.putVertices,
-                (request, context) => graph.PutVerticesResponse(
-                  written: request.ifAbsent ? 0 : request.vertices.length,
-                  skippedKeys:
-                      request.ifAbsent ? [request.vertices.single.key] : [],
-                ),
-              )
-              .unary<graph.DeleteVerticesRequest, graph.DeleteVerticesResponse>(
-                LanternService.deleteVertices,
-                (request, context) => graph.DeleteVerticesResponse(deleted: 0),
-              )
-              .unary<graph.GetEdgesRequest, graph.GetEdgesResponse>(
-                LanternService.getEdges,
-                (request, context) =>
-                    graph.GetEdgesResponse(missing: request.edges),
-              )
-              .unary<graph.DeleteEdgesRequest, graph.DeleteEdgesResponse>(
-                LanternService.deleteEdges,
-                (request, context) => graph.DeleteEdgesResponse(deleted: 0),
-              )
-              .build();
+      final transport = FakeTransportBuilder()
+          .unary<graph.GetVerticesRequest, graph.GetVerticesResponse>(
+            LanternService.getVertices,
+            (request, context) =>
+                graph.GetVerticesResponse(missing: request.keys),
+          )
+          .unary<graph.PutVerticesRequest, graph.PutVerticesResponse>(
+            LanternService.putVertices,
+            (request, context) => graph.PutVerticesResponse(
+              written: request.ifAbsent ? 0 : request.vertices.length,
+              skippedKeys: request.ifAbsent
+                  ? [request.vertices.single.key]
+                  : [],
+            ),
+          )
+          .unary<graph.DeleteVerticesRequest, graph.DeleteVerticesResponse>(
+            LanternService.deleteVertices,
+            (request, context) => graph.DeleteVerticesResponse(deleted: 0),
+          )
+          .unary<graph.GetEdgesRequest, graph.GetEdgesResponse>(
+            LanternService.getEdges,
+            (request, context) =>
+                graph.GetEdgesResponse(missing: request.edges),
+          )
+          .unary<graph.DeleteEdgesRequest, graph.DeleteEdgesResponse>(
+            LanternService.deleteEdges,
+            (request, context) => graph.DeleteEdgesResponse(deleted: 0),
+          )
+          .build();
       final client = _client(transport);
 
       await expectLater(

--- a/sdks/dart/test/data_test.dart
+++ b/sdks/dart/test/data_test.dart
@@ -14,14 +14,15 @@ import 'package:test/test.dart';
 void main() {
   test('all exact value kinds encode without guessing or collapsing', () async {
     late List<graph.Vertex> encoded;
-    final transport =
-        FakeTransportBuilder().unary<
-          graph.PutVerticesRequest,
-          graph.PutVerticesResponse
-        >(LanternService.putVertices, (request, context) {
-          encoded = request.vertices.toList();
-          return graph.PutVerticesResponse(written: request.vertices.length);
-        }).build();
+    final transport = FakeTransportBuilder()
+        .unary<graph.PutVerticesRequest, graph.PutVerticesResponse>(
+          LanternService.putVertices,
+          (request, context) {
+            encoded = request.vertices.toList();
+            return graph.PutVerticesResponse(written: request.vertices.length);
+          },
+        )
+        .build();
     final client = LanternClient.connect(
       Uri.parse('https://example.test'),
       transport: transport,
@@ -88,35 +89,34 @@ void main() {
     final timestamp = wkt_timestamp.Timestamp.fromDateTime(
       DateTime.parse('2026-07-12T01:02:03.456Z'),
     );
-    final transport =
-        FakeTransportBuilder()
-            .unary<graph.GetVerticesRequest, graph.GetVerticesResponse>(
-              LanternService.getVertices,
-              (request, context) => graph.GetVerticesResponse(
-                vertices: [
-                  graph.Vertex(key: 'f64', float64: 1.25),
-                  graph.Vertex(key: 'f32', float32: 2.5),
-                  graph.Vertex(key: 'i32', int32: -7),
-                  graph.Vertex(key: 'i64', int64: Int64.MIN_VALUE),
-                  graph.Vertex(key: 'u32', uint32: 0xffffffff),
-                  graph.Vertex(key: 'u64', uint64: Int64(-1)),
-                  graph.Vertex(key: 'bool', bool_16: true),
-                  graph.Vertex(key: 'string', string: 'lantern'),
-                  graph.Vertex(key: 'bytes', bytes: [1, 2, 3]),
-                  graph.Vertex(key: 'timestamp', timestamp: timestamp),
-                  graph.Vertex(
-                    key: 'duration',
-                    duration: wkt_duration.Duration(
-                      seconds: Int64(12),
-                      nanos: 345000,
-                    ),
-                  ),
-                  graph.Vertex(key: 'nil', nil: true),
-                  graph.Vertex(key: 'unset'),
-                ],
+    final transport = FakeTransportBuilder()
+        .unary<graph.GetVerticesRequest, graph.GetVerticesResponse>(
+          LanternService.getVertices,
+          (request, context) => graph.GetVerticesResponse(
+            vertices: [
+              graph.Vertex(key: 'f64', float64: 1.25),
+              graph.Vertex(key: 'f32', float32: 2.5),
+              graph.Vertex(key: 'i32', int32: -7),
+              graph.Vertex(key: 'i64', int64: Int64.MIN_VALUE),
+              graph.Vertex(key: 'u32', uint32: 0xffffffff),
+              graph.Vertex(key: 'u64', uint64: Int64(-1)),
+              graph.Vertex(key: 'bool', bool_16: true),
+              graph.Vertex(key: 'string', string: 'lantern'),
+              graph.Vertex(key: 'bytes', bytes: [1, 2, 3]),
+              graph.Vertex(key: 'timestamp', timestamp: timestamp),
+              graph.Vertex(
+                key: 'duration',
+                duration: wkt_duration.Duration(
+                  seconds: Int64(12),
+                  nanos: 345000,
+                ),
               ),
-            )
-            .build();
+              graph.Vertex(key: 'nil', nil: true),
+              graph.Vertex(key: 'unset'),
+            ],
+          ),
+        )
+        .build();
     final client = LanternClient.connect(
       Uri.parse('https://example.test'),
       transport: transport,
@@ -186,15 +186,14 @@ void main() {
   );
 
   test('non-finite wire values fail closed as server errors', () async {
-    final transport =
-        FakeTransportBuilder()
-            .unary<graph.GetVerticesRequest, graph.GetVerticesResponse>(
-              LanternService.getVertices,
-              (request, context) => graph.GetVerticesResponse(
-                vertices: [graph.Vertex(key: 'bad', float64: double.nan)],
-              ),
-            )
-            .build();
+    final transport = FakeTransportBuilder()
+        .unary<graph.GetVerticesRequest, graph.GetVerticesResponse>(
+          LanternService.getVertices,
+          (request, context) => graph.GetVerticesResponse(
+            vertices: [graph.Vertex(key: 'bad', float64: double.nan)],
+          ),
+        )
+        .build();
     final client = LanternClient.connect(
       Uri.parse('https://example.test'),
       transport: transport,

--- a/sdks/dart/test/decay_test.dart
+++ b/sdks/dart/test/decay_test.dart
@@ -97,19 +97,18 @@ void main() {
     'AddDecayingEdge sends one curve and returns final effective weight',
     () async {
       late graph.AddEdgesRequest captured;
-      final transport =
-          FakeTransportBuilder()
-              .unary<graph.AddEdgesRequest, graph.AddEdgesResponse>(
-                LanternService.addEdges,
-                (request, context) {
-                  captured = request.deepCopy();
-                  return graph.AddEdgesResponse(
-                    written: request.edges.length,
-                    effectiveWeights: [8, 12, 14, 15, 16],
-                  );
-                },
-              )
-              .build();
+      final transport = FakeTransportBuilder()
+          .unary<graph.AddEdgesRequest, graph.AddEdgesResponse>(
+            LanternService.addEdges,
+            (request, context) {
+              captured = request.deepCopy();
+              return graph.AddEdgesResponse(
+                written: request.edges.length,
+                effectiveWeights: [8, 12, 14, 15, 16],
+              );
+            },
+          )
+          .build();
       final client = LanternClient.connect(
         Uri.parse('https://example.test'),
         transport: transport,
@@ -141,14 +140,15 @@ void main() {
 
   test('decaying Add without IDs is not retried', () async {
     var calls = 0;
-    final transport =
-        FakeTransportBuilder().unary<
-          graph.AddEdgesRequest,
-          graph.AddEdgesResponse
-        >(LanternService.addEdges, (request, context) {
-          calls++;
-          throw connect.ConnectException(connect.Code.unavailable, 'lost');
-        }).build();
+    final transport = FakeTransportBuilder()
+        .unary<graph.AddEdgesRequest, graph.AddEdgesResponse>(
+          LanternService.addEdges,
+          (request, context) {
+            calls++;
+            throw connect.ConnectException(connect.Code.unavailable, 'lost');
+          },
+        )
+        .build();
     final client = LanternClient.connect(
       Uri.parse('https://example.test'),
       transport: transport,

--- a/sdks/dart/test/real_wire_test.dart
+++ b/sdks/dart/test/real_wire_test.dart
@@ -377,21 +377,19 @@ void main() {
       expected.take(4),
     );
 
-    final ascending =
-        await client
-            .scanVerticesAll(prefix: scanPrefix, limit: 2)
-            .expand((page) => page.items)
-            .map((vertex) => vertex.key)
-            .toList();
-    final descending =
-        await client
-            .scanVertexKeysAll(
-              prefix: scanPrefix,
-              limit: 2,
-              order: ScanOrder.descending,
-            )
-            .expand((page) => page.items)
-            .toList();
+    final ascending = await client
+        .scanVerticesAll(prefix: scanPrefix, limit: 2)
+        .expand((page) => page.items)
+        .map((vertex) => vertex.key)
+        .toList();
+    final descending = await client
+        .scanVertexKeysAll(
+          prefix: scanPrefix,
+          limit: 2,
+          order: ScanOrder.descending,
+        )
+        .expand((page) => page.items)
+        .toList();
     expect(ascending, expected);
     expect(descending, expected.reversed);
 
@@ -426,15 +424,14 @@ void main() {
     });
     await client.putEdges(edges);
 
-    final scanned =
-        await client
-            .scanEdgesAll(
-              tailPrefix: tailPrefix,
-              headPrefix: '$prefix-edge-head:even:',
-              limit: 1,
-            )
-            .expand((page) => page.items)
-            .toList();
+    final scanned = await client
+        .scanEdgesAll(
+          tailPrefix: tailPrefix,
+          headPrefix: '$prefix-edge-head:even:',
+          limit: 1,
+        )
+        .expand((page) => page.items)
+        .toList();
     expect(scanned.map((edge) => edge.head), matchingHeads);
     expect(scanned.map((edge) => edge.tail), [
       '${tailPrefix}0',
@@ -761,10 +758,9 @@ void main() {
       final result = await disabledClient.searchVertices('anything');
       expect(result, isA<SearchDisabled>());
     },
-    skip:
-        disabledSearchEndpoint == null || disabledSearchEndpoint.isEmpty
-            ? 'LANTERN_DART_SEARCH_DISABLED_ENDPOINT is not configured'
-            : false,
+    skip: disabledSearchEndpoint == null || disabledSearchEndpoint.isEmpty
+        ? 'LANTERN_DART_SEARCH_DISABLED_ENDPOINT is not configured'
+        : false,
   );
 
   test(

--- a/sdks/dart/test/retry_test.dart
+++ b/sdks/dart/test/retry_test.dart
@@ -37,14 +37,15 @@ void main() {
 
   test('read retries unavailable and exhaustion remains typed', () async {
     var calls = 0;
-    final transport =
-        FakeTransportBuilder().unary<
-          graph.GetVerticesRequest,
-          graph.GetVerticesResponse
-        >(LanternService.getVertices, (request, context) {
-          calls++;
-          throw connect.ConnectException(connect.Code.unavailable, 'down');
-        }).build();
+    final transport = FakeTransportBuilder()
+        .unary<graph.GetVerticesRequest, graph.GetVerticesResponse>(
+          LanternService.getVertices,
+          (request, context) {
+            calls++;
+            throw connect.ConnectException(connect.Code.unavailable, 'down');
+          },
+        )
+        .build();
     final client = _client(
       transport,
       retryPolicy: const RetryPolicy(
@@ -71,14 +72,15 @@ void main() {
 
   test('Add retries only with IDs and reuses bytes across attempts', () async {
     var unsafeCalls = 0;
-    final unsafeTransport =
-        FakeTransportBuilder().unary<
-          graph.AddEdgesRequest,
-          graph.AddEdgesResponse
-        >(LanternService.addEdges, (request, context) {
-          unsafeCalls++;
-          throw connect.ConnectException(connect.Code.unavailable, 'lost');
-        }).build();
+    final unsafeTransport = FakeTransportBuilder()
+        .unary<graph.AddEdgesRequest, graph.AddEdgesResponse>(
+          LanternService.addEdges,
+          (request, context) {
+            unsafeCalls++;
+            throw connect.ConnectException(connect.Code.unavailable, 'lost');
+          },
+        )
+        .build();
     final unsafe = _client(unsafeTransport, retryPolicy: _fastRetry);
     await expectLater(
       unsafe.addEdge(EdgeInput(tail: 'a', head: 'b', weight: 1)),
@@ -88,23 +90,24 @@ void main() {
 
     var safeCalls = 0;
     final seen = <List<List<int>>>[];
-    final safeTransport =
-        FakeTransportBuilder().unary<
-          graph.AddEdgesRequest,
-          graph.AddEdgesResponse
-        >(LanternService.addEdges, (request, context) {
-          safeCalls++;
-          seen.add(
-            request.contribIds.map((value) => List<int>.from(value)).toList(),
-          );
-          if (safeCalls == 1) {
-            throw connect.ConnectException(
-              connect.Code.unavailable,
-              'response lost',
+    final safeTransport = FakeTransportBuilder()
+        .unary<graph.AddEdgesRequest, graph.AddEdgesResponse>(
+          LanternService.addEdges,
+          (request, context) {
+            safeCalls++;
+            seen.add(
+              request.contribIds.map((value) => List<int>.from(value)).toList(),
             );
-          }
-          return graph.AddEdgesResponse(written: 2, effectiveWeights: [1, 2]);
-        }).build();
+            if (safeCalls == 1) {
+              throw connect.ConnectException(
+                connect.Code.unavailable,
+                'response lost',
+              );
+            }
+            return graph.AddEdgesResponse(written: 2, effectiveWeights: [1, 2]);
+          },
+        )
+        .build();
     final safe = _client(
       safeTransport,
       retryPolicy: _fastRetry,
@@ -129,18 +132,19 @@ void main() {
   test('stable Put replays one request and one absolute expiration', () async {
     var calls = 0;
     final expirations = <DateTime>[];
-    final transport =
-        FakeTransportBuilder().unary<
-          graph.PutVerticesRequest,
-          graph.PutVerticesResponse
-        >(LanternService.putVertices, (request, context) {
-          calls++;
-          expirations.add(request.vertices.single.expiration.toDateTime());
-          if (calls == 1) {
-            throw connect.ConnectException(connect.Code.unavailable, 'lost');
-          }
-          return graph.PutVerticesResponse(written: 1);
-        }).build();
+    final transport = FakeTransportBuilder()
+        .unary<graph.PutVerticesRequest, graph.PutVerticesResponse>(
+          LanternService.putVertices,
+          (request, context) {
+            calls++;
+            expirations.add(request.vertices.single.expiration.toDateTime());
+            if (calls == 1) {
+              throw connect.ConnectException(connect.Code.unavailable, 'lost');
+            }
+            return graph.PutVerticesResponse(written: 1);
+          },
+        )
+        .build();
     var clockCalls = 0;
     final client = _client(
       transport,
@@ -169,29 +173,22 @@ void main() {
   test('PutIfAbsent and Delete preserve ambiguous result semantics', () async {
     var putCalls = 0;
     var deleteCalls = 0;
-    final transport =
-        FakeTransportBuilder()
-            .unary<graph.PutVerticesRequest, graph.PutVerticesResponse>(
-              LanternService.putVertices,
-              (request, context) {
-                putCalls++;
-                throw connect.ConnectException(
-                  connect.Code.unavailable,
-                  'lost',
-                );
-              },
-            )
-            .unary<graph.DeleteVerticesRequest, graph.DeleteVerticesResponse>(
-              LanternService.deleteVertices,
-              (request, context) {
-                deleteCalls++;
-                throw connect.ConnectException(
-                  connect.Code.unavailable,
-                  'lost',
-                );
-              },
-            )
-            .build();
+    final transport = FakeTransportBuilder()
+        .unary<graph.PutVerticesRequest, graph.PutVerticesResponse>(
+          LanternService.putVertices,
+          (request, context) {
+            putCalls++;
+            throw connect.ConnectException(connect.Code.unavailable, 'lost');
+          },
+        )
+        .unary<graph.DeleteVerticesRequest, graph.DeleteVerticesResponse>(
+          LanternService.deleteVertices,
+          (request, context) {
+            deleteCalls++;
+            throw connect.ConnectException(connect.Code.unavailable, 'lost');
+          },
+        )
+        .build();
     final client = _client(transport, retryPolicy: _fastRetry);
 
     await expectLater(
@@ -211,24 +208,23 @@ void main() {
   test('resource exhausted requires explicit opt-in', () async {
     Future<void> run({required bool optIn, required int expectedCalls}) async {
       var calls = 0;
-      final transport =
-          FakeTransportBuilder()
-              .unary<graph.GetVerticesRequest, graph.GetVerticesResponse>(
-                LanternService.getVertices,
-                (request, context) {
-                  calls++;
-                  if (calls == 1) {
-                    throw connect.ConnectException(
-                      connect.Code.resourceExhausted,
-                      'busy',
-                    );
-                  }
-                  return graph.GetVerticesResponse(
-                    vertices: [graph.Vertex(key: 'key', nil: true)],
-                  );
-                },
-              )
-              .build();
+      final transport = FakeTransportBuilder()
+          .unary<graph.GetVerticesRequest, graph.GetVerticesResponse>(
+            LanternService.getVertices,
+            (request, context) {
+              calls++;
+              if (calls == 1) {
+                throw connect.ConnectException(
+                  connect.Code.resourceExhausted,
+                  'busy',
+                );
+              }
+              return graph.GetVerticesResponse(
+                vertices: [graph.Vertex(key: 'key', nil: true)],
+              );
+            },
+          )
+          .build();
       final client = _client(
         transport,
         retryPolicy: RetryPolicy(
@@ -255,14 +251,15 @@ void main() {
 
   test('cancellation and overall deadline stop backoff immediately', () async {
     final firstAttempt = Completer<void>();
-    final transport =
-        FakeTransportBuilder().unary<
-          graph.GetVerticesRequest,
-          graph.GetVerticesResponse
-        >(LanternService.getVertices, (request, context) {
-          if (!firstAttempt.isCompleted) firstAttempt.complete();
-          throw connect.ConnectException(connect.Code.unavailable, 'down');
-        }).build();
+    final transport = FakeTransportBuilder()
+        .unary<graph.GetVerticesRequest, graph.GetVerticesResponse>(
+          LanternService.getVertices,
+          (request, context) {
+            if (!firstAttempt.isCompleted) firstAttempt.complete();
+            throw connect.ConnectException(connect.Code.unavailable, 'down');
+          },
+        )
+        .build();
     final cancellation = LanternCancellationToken();
     final client = _client(
       transport,
@@ -290,12 +287,12 @@ void main() {
   });
 
   test('retry registry covers every generated RPC and fails closed', () {
-    final source =
-        File('lib/src/gen/graph/v1/graph.connect.spec.dart').readAsStringSync();
-    final generated =
-        RegExp(
-          r"'/\$name/([A-Za-z]+)'",
-        ).allMatches(source).map((match) => match.group(1)!).toSet();
+    final source = File(
+      'lib/src/gen/graph/v1/graph.connect.spec.dart',
+    ).readAsStringSync();
+    final generated = RegExp(
+      r"'/\$name/([A-Za-z]+)'",
+    ).allMatches(source).map((match) => match.group(1)!).toSet();
 
     expect(RetryRegistry.classifications.keys.toSet(), containsAll(generated));
     expect(RetryRegistry.classify('FutureUnknownMethod'), RpcRetryClass.never);

--- a/sdks/dart/test/rpc_manifest_test.dart
+++ b/sdks/dart/test/rpc_manifest_test.dart
@@ -12,12 +12,12 @@ void main() {
   });
 
   test('every app-facing RPC is intentionally classified', () {
-    final source =
-        File('lib/src/gen/graph/v1/graph.connect.spec.dart').readAsStringSync();
-    final generated =
-        RegExp(
-          r"'/\$name/([A-Za-z]+)'",
-        ).allMatches(source).map((match) => match.group(1)!).toSet();
+    final source = File(
+      'lib/src/gen/graph/v1/graph.connect.spec.dart',
+    ).readAsStringSync();
+    final generated = RegExp(
+      r"'/\$name/([A-Za-z]+)'",
+    ).allMatches(source).map((match) => match.group(1)!).toSet();
 
     expect(generated, _appFacingRpcs);
   });

--- a/sdks/dart/test/scan_test.dart
+++ b/sdks/dart/test/scan_test.dart
@@ -15,19 +15,18 @@ void main() {
     () async {
       late graph.ScanVerticesRequest captured;
       final responseCursor = Uint8List.fromList([1, 2, 3]);
-      final transport =
-          FakeTransportBuilder()
-              .unary<graph.ScanVerticesRequest, graph.ScanVerticesResponse>(
-                LanternService.scanVertices,
-                (request, context) {
-                  captured = request.clone();
-                  return graph.ScanVerticesResponse(
-                    vertices: [graph.Vertex(key: 'v', string: 'value')],
-                    nextCursor: responseCursor,
-                  );
-                },
-              )
-              .build();
+      final transport = FakeTransportBuilder()
+          .unary<graph.ScanVerticesRequest, graph.ScanVerticesResponse>(
+            LanternService.scanVertices,
+            (request, context) {
+              captured = request.clone();
+              return graph.ScanVerticesResponse(
+                vertices: [graph.Vertex(key: 'v', string: 'value')],
+                nextCursor: responseCursor,
+              );
+            },
+          )
+          .build();
       final client = _client(transport);
       final inputBytes = Uint8List.fromList([9, 8]);
       final cursor = ScanCursor.fromBytes(inputBytes);
@@ -58,25 +57,24 @@ void main() {
   test('keys-only and edge pages use their own wire requests', () async {
     late graph.ScanVertexKeysRequest keyRequest;
     late graph.ScanEdgesRequest edgeRequest;
-    final transport =
-        FakeTransportBuilder()
-            .unary<graph.ScanVertexKeysRequest, graph.ScanVertexKeysResponse>(
-              LanternService.scanVertexKeys,
-              (request, context) {
-                keyRequest = request.clone();
-                return graph.ScanVertexKeysResponse(keys: ['p:a', 'p:b']);
-              },
-            )
-            .unary<graph.ScanEdgesRequest, graph.ScanEdgesResponse>(
-              LanternService.scanEdges,
-              (request, context) {
-                edgeRequest = request.clone();
-                return graph.ScanEdgesResponse(
-                  edges: [graph.Edge(tail: 't:a', head: 'h:b', weight: 2)],
-                );
-              },
-            )
-            .build();
+    final transport = FakeTransportBuilder()
+        .unary<graph.ScanVertexKeysRequest, graph.ScanVertexKeysResponse>(
+          LanternService.scanVertexKeys,
+          (request, context) {
+            keyRequest = request.clone();
+            return graph.ScanVertexKeysResponse(keys: ['p:a', 'p:b']);
+          },
+        )
+        .unary<graph.ScanEdgesRequest, graph.ScanEdgesResponse>(
+          LanternService.scanEdges,
+          (request, context) {
+            edgeRequest = request.clone();
+            return graph.ScanEdgesResponse(
+              edges: [graph.Edge(tail: 't:a', head: 'h:b', weight: 2)],
+            );
+          },
+        )
+        .build();
     final client = _client(transport);
 
     final keys = await client.scanVertexKeys(
@@ -100,27 +98,31 @@ void main() {
     var maxActive = 0;
     var activeCanceled = false;
     final secondStarted = Completer<void>();
-    final transport =
-        FakeTransportBuilder().unary<
-          graph.ScanVertexKeysRequest,
-          graph.ScanVertexKeysResponse
-        >(LanternService.scanVertexKeys, (request, context) async {
-          calls++;
-          active++;
-          if (active > maxActive) maxActive = active;
-          if (calls == 1) {
+    final transport = FakeTransportBuilder()
+        .unary<graph.ScanVertexKeysRequest, graph.ScanVertexKeysResponse>(
+          LanternService.scanVertexKeys,
+          (request, context) async {
+            calls++;
+            active++;
+            if (active > maxActive) maxActive = active;
+            if (calls == 1) {
+              active--;
+              return graph.ScanVertexKeysResponse(
+                keys: ['p:a'],
+                nextCursor: [1],
+              );
+            }
+            secondStarted.complete();
+            await context.signal.future;
+            activeCanceled = true;
             active--;
-            return graph.ScanVertexKeysResponse(keys: ['p:a'], nextCursor: [1]);
-          }
-          secondStarted.complete();
-          await context.signal.future;
-          activeCanceled = true;
-          active--;
-          throw connect.ConnectException(
-            connect.Code.canceled,
-            'expected cancellation',
-          );
-        }).build();
+            throw connect.ConnectException(
+              connect.Code.canceled,
+              'expected cancellation',
+            );
+          },
+        )
+        .build();
     final client = _client(transport);
     late StreamSubscription<Page<String>> subscription;
     final firstPage = Completer<void>();
@@ -149,14 +151,15 @@ void main() {
     final cancellation = LanternCancellationToken();
     final firstPage = Completer<void>();
     final canceled = Completer<Object>();
-    final transport =
-        FakeTransportBuilder().unary<
-          graph.ScanVertexKeysRequest,
-          graph.ScanVertexKeysResponse
-        >(LanternService.scanVertexKeys, (request, context) {
-          calls++;
-          return graph.ScanVertexKeysResponse(keys: ['p:a'], nextCursor: [1]);
-        }).build();
+    final transport = FakeTransportBuilder()
+        .unary<graph.ScanVertexKeysRequest, graph.ScanVertexKeysResponse>(
+          LanternService.scanVertexKeys,
+          (request, context) {
+            calls++;
+            return graph.ScanVertexKeysResponse(keys: ['p:a'], nextCursor: [1]);
+          },
+        )
+        .build();
     final client = _client(transport);
     late StreamSubscription<Page<String>> subscription;
     subscription = client
@@ -184,31 +187,30 @@ void main() {
       final maxUint64 = Int64.fromInts(0xffffffff, 0xffffffff);
       late graph.DeleteVerticesByPrefixRequest vertexDelete;
       late graph.DeleteEdgesByPrefixRequest edgeDelete;
-      final transport =
-          FakeTransportBuilder()
-              .unary<
-                graph.CountVerticesByPrefixRequest,
-                graph.CountVerticesByPrefixResponse
-              >(
-                LanternService.countVerticesByPrefix,
-                (request, context) =>
-                    graph.CountVerticesByPrefixResponse(count: maxUint64),
-              )
-              .unary<
-                graph.DeleteVerticesByPrefixRequest,
-                graph.DeleteVerticesByPrefixResponse
-              >(LanternService.deleteVerticesByPrefix, (request, context) {
-                vertexDelete = request.clone();
-                return graph.DeleteVerticesByPrefixResponse(deleted: Int64(2));
-              })
-              .unary<
-                graph.DeleteEdgesByPrefixRequest,
-                graph.DeleteEdgesByPrefixResponse
-              >(LanternService.deleteEdgesByPrefix, (request, context) {
-                edgeDelete = request.clone();
-                return graph.DeleteEdgesByPrefixResponse(deleted: Int64(3));
-              })
-              .build();
+      final transport = FakeTransportBuilder()
+          .unary<
+            graph.CountVerticesByPrefixRequest,
+            graph.CountVerticesByPrefixResponse
+          >(
+            LanternService.countVerticesByPrefix,
+            (request, context) =>
+                graph.CountVerticesByPrefixResponse(count: maxUint64),
+          )
+          .unary<
+            graph.DeleteVerticesByPrefixRequest,
+            graph.DeleteVerticesByPrefixResponse
+          >(LanternService.deleteVerticesByPrefix, (request, context) {
+            vertexDelete = request.clone();
+            return graph.DeleteVerticesByPrefixResponse(deleted: Int64(2));
+          })
+          .unary<
+            graph.DeleteEdgesByPrefixRequest,
+            graph.DeleteEdgesByPrefixResponse
+          >(LanternService.deleteEdgesByPrefix, (request, context) {
+            edgeDelete = request.clone();
+            return graph.DeleteEdgesByPrefixResponse(deleted: Int64(3));
+          })
+          .build();
       final client = _client(transport);
 
       expect(
@@ -235,29 +237,28 @@ void main() {
   test('unsafe prefix deletes validate locally and never retry', () async {
     var vertexCalls = 0;
     var edgeCalls = 0;
-    final transport =
-        FakeTransportBuilder()
-            .unary<
-              graph.DeleteVerticesByPrefixRequest,
-              graph.DeleteVerticesByPrefixResponse
-            >(LanternService.deleteVerticesByPrefix, (request, context) {
-              vertexCalls++;
-              throw connect.ConnectException(
-                connect.Code.unavailable,
-                'lost committed response',
-              );
-            })
-            .unary<
-              graph.DeleteEdgesByPrefixRequest,
-              graph.DeleteEdgesByPrefixResponse
-            >(LanternService.deleteEdgesByPrefix, (request, context) {
-              edgeCalls++;
-              throw connect.ConnectException(
-                connect.Code.unavailable,
-                'lost committed response',
-              );
-            })
-            .build();
+    final transport = FakeTransportBuilder()
+        .unary<
+          graph.DeleteVerticesByPrefixRequest,
+          graph.DeleteVerticesByPrefixResponse
+        >(LanternService.deleteVerticesByPrefix, (request, context) {
+          vertexCalls++;
+          throw connect.ConnectException(
+            connect.Code.unavailable,
+            'lost committed response',
+          );
+        })
+        .unary<
+          graph.DeleteEdgesByPrefixRequest,
+          graph.DeleteEdgesByPrefixResponse
+        >(LanternService.deleteEdgesByPrefix, (request, context) {
+          edgeCalls++;
+          throw connect.ConnectException(
+            connect.Code.unavailable,
+            'lost committed response',
+          );
+        })
+        .build();
     final client = _client(transport, retry: const RetryPolicy());
 
     await expectLater(

--- a/sdks/dart/test/search_test.dart
+++ b/sdks/dart/test/search_test.dart
@@ -12,18 +12,17 @@ void main() {
     'one-shot search preserves every wire option and ranked result',
     () async {
       late graph.SearchVerticesRequest captured;
-      final transport =
-          FakeTransportBuilder()
-              .unary<graph.SearchVerticesRequest, graph.SearchVerticesResponse>(
-                LanternService.searchVertices,
-                (request, context) {
-                  captured = request.clone();
-                  return graph.SearchVerticesResponse(
-                    hits: [graph.SearchHit(key: 'p:a', score: 3.5)],
-                  );
-                },
-              )
-              .build();
+      final transport = FakeTransportBuilder()
+          .unary<graph.SearchVerticesRequest, graph.SearchVerticesResponse>(
+            LanternService.searchVertices,
+            (request, context) {
+              captured = request.clone();
+              return graph.SearchVerticesResponse(
+                hits: [graph.SearchHit(key: 'p:a', score: 3.5)],
+              );
+            },
+          )
+          .build();
       final client = _client(transport);
 
       final result = await client.searchVertices(
@@ -56,33 +55,30 @@ void main() {
 
   test('omitted relevance controls omit SearchOptions', () async {
     late graph.SearchVerticesRequest captured;
-    final transport =
-        FakeTransportBuilder()
-            .unary<graph.SearchVerticesRequest, graph.SearchVerticesResponse>(
-              LanternService.searchVertices,
-              (request, context) {
-                captured = request.clone();
-                return graph.SearchVerticesResponse();
-              },
-            )
-            .build();
+    final transport = FakeTransportBuilder()
+        .unary<graph.SearchVerticesRequest, graph.SearchVerticesResponse>(
+          LanternService.searchVertices,
+          (request, context) {
+            captured = request.clone();
+            return graph.SearchVerticesResponse();
+          },
+        )
+        .build();
     final result = await _client(transport).searchVertices('none');
     expect((result as SearchEnabled).hits, isEmpty);
     expect(captured.hasOptions(), isFalse);
   });
 
   test('search-disabled is a calm typed result', () async {
-    final transport =
-        FakeTransportBuilder()
-            .unary<graph.SearchVerticesRequest, graph.SearchVerticesResponse>(
-              LanternService.searchVertices,
-              (request, context) =>
-                  throw connect.ConnectException(
-                    connect.Code.failedPrecondition,
-                    'search is disabled',
-                  ),
-            )
-            .build();
+    final transport = FakeTransportBuilder()
+        .unary<graph.SearchVerticesRequest, graph.SearchVerticesResponse>(
+          LanternService.searchVertices,
+          (request, context) => throw connect.ConnectException(
+            connect.Code.failedPrecondition,
+            'search is disabled',
+          ),
+        )
+        .build();
     final result = await _client(transport).searchVertices('q');
     expect(result, isA<SearchDisabled>());
     expect(
@@ -93,16 +89,15 @@ void main() {
 
   test('invalid relevance combinations fail before transport', () async {
     var calls = 0;
-    final transport =
-        FakeTransportBuilder()
-            .unary<graph.SearchVerticesRequest, graph.SearchVerticesResponse>(
-              LanternService.searchVertices,
-              (request, context) {
-                calls++;
-                return graph.SearchVerticesResponse();
-              },
-            )
-            .build();
+    final transport = FakeTransportBuilder()
+        .unary<graph.SearchVerticesRequest, graph.SearchVerticesResponse>(
+          LanternService.searchVertices,
+          (request, context) {
+            calls++;
+            return graph.SearchVerticesResponse();
+          },
+        )
+        .build();
     final client = _client(transport);
     for (final options in [
       const SearchOptions(fuzziness: 3),
@@ -125,18 +120,17 @@ void main() {
     'incremental search debounces and emits only the latest query',
     () async {
       final requests = <String>[];
-      final transport =
-          FakeTransportBuilder()
-              .unary<graph.SearchVerticesRequest, graph.SearchVerticesResponse>(
-                LanternService.searchVertices,
-                (request, context) {
-                  requests.add(request.query);
-                  return graph.SearchVerticesResponse(
-                    hits: [graph.SearchHit(key: request.query, score: 1)],
-                  );
-                },
-              )
-              .build();
+      final transport = FakeTransportBuilder()
+          .unary<graph.SearchVerticesRequest, graph.SearchVerticesResponse>(
+            LanternService.searchVertices,
+            (request, context) {
+              requests.add(request.query);
+              return graph.SearchVerticesResponse(
+                hits: [graph.SearchHit(key: request.query, score: 1)],
+              );
+            },
+          )
+          .build();
       final session = _client(transport).incrementalSearch(
         options: const IncrementalSearchOptions(
           debounce: Duration(milliseconds: 10),
@@ -159,21 +153,20 @@ void main() {
     () async {
       final firstStarted = Completer<void>();
       final first = Completer<graph.SearchVerticesResponse>();
-      final transport =
-          FakeTransportBuilder()
-              .unary<graph.SearchVerticesRequest, graph.SearchVerticesResponse>(
-                LanternService.searchVertices,
-                (request, context) {
-                  if (request.query == 'old') {
-                    firstStarted.complete();
-                    return first.future;
-                  }
-                  return graph.SearchVerticesResponse(
-                    hits: [graph.SearchHit(key: 'new', score: 2)],
-                  );
-                },
-              )
-              .build();
+      final transport = FakeTransportBuilder()
+          .unary<graph.SearchVerticesRequest, graph.SearchVerticesResponse>(
+            LanternService.searchVertices,
+            (request, context) {
+              if (request.query == 'old') {
+                firstStarted.complete();
+                return first.future;
+              }
+              return graph.SearchVerticesResponse(
+                hits: [graph.SearchHit(key: 'new', score: 2)],
+              );
+            },
+          )
+          .build();
       final session = _client(transport).incrementalSearch(
         options: const IncrementalSearchOptions(debounce: Duration.zero),
       );
@@ -212,17 +205,18 @@ void main() {
       var calls = 0;
       final active = Completer<void>();
       var canceled = false;
-      final transport =
-          FakeTransportBuilder().unary<
-            graph.SearchVerticesRequest,
-            graph.SearchVerticesResponse
-          >(LanternService.searchVertices, (request, context) async {
-            calls++;
-            active.complete();
-            await context.signal.future;
-            canceled = true;
-            throw connect.ConnectException(connect.Code.canceled, 'disposed');
-          }).build();
+      final transport = FakeTransportBuilder()
+          .unary<graph.SearchVerticesRequest, graph.SearchVerticesResponse>(
+            LanternService.searchVertices,
+            (request, context) async {
+              calls++;
+              active.complete();
+              await context.signal.future;
+              canceled = true;
+              throw connect.ConnectException(connect.Code.canceled, 'disposed');
+            },
+          )
+          .build();
       final session = _client(transport).incrementalSearch(
         options: const IncrementalSearchOptions(
           debounce: Duration.zero,

--- a/sdks/dart/test/status_test.dart
+++ b/sdks/dart/test/status_test.dart
@@ -15,8 +15,8 @@ void main() {
     () async {
       late graph.TopVerticesByDegreeRequest captured;
       final maxUint64 = Int64.fromInts(0xffffffff, 0xffffffff);
-      final transport =
-          FakeTransportBuilder().unary<
+      final transport = FakeTransportBuilder()
+          .unary<
             graph.TopVerticesByDegreeRequest,
             graph.TopVerticesByDegreeResponse
           >(LanternService.topVerticesByDegree, (request, context) {
@@ -35,7 +35,8 @@ void main() {
                 ),
               ],
             );
-          }).build();
+          })
+          .build();
       final entries = await _client(transport).topVerticesByDegree(
         prefix: 'p:',
         limit: 2,
@@ -57,14 +58,15 @@ void main() {
 
   test('degree ranking requires a scoped prefix before transport', () async {
     var calls = 0;
-    final transport =
-        FakeTransportBuilder().unary<
+    final transport = FakeTransportBuilder()
+        .unary<
           graph.TopVerticesByDegreeRequest,
           graph.TopVerticesByDegreeResponse
         >(LanternService.topVerticesByDegree, (request, context) {
           calls++;
           return graph.TopVerticesByDegreeResponse();
-        }).build();
+        })
+        .build();
     await expectLater(
       _client(transport).topVerticesByDegree(prefix: ''),
       throwsA(isA<LanternInvalidArgumentException>()),
@@ -76,30 +78,26 @@ void main() {
     'server status converts exact timestamps, durations, and uint64',
     () async {
       final started = DateTime.parse('2026-07-12T01:02:03Z');
-      final transport =
-          FakeTransportBuilder()
-              .unary<
-                graph.GetServerStatusRequest,
-                graph.GetServerStatusResponse
-              >(
-                LanternService.getServerStatus,
-                (request, context) => graph.GetServerStatusResponse(
-                  version: 'v0.1.0',
-                  goVersion: 'go-test',
-                  startedAt: Timestamp.fromDateTime(started),
-                  uptime: duration_proto.Duration(seconds: Int64(90)),
-                  defaultTtl: duration_proto.Duration(seconds: Int64(300)),
-                  maxBatchSize: 65536,
-                  maxKeyBytes: 1024,
-                  scanDefaultLimit: 100,
-                  scanMaxLimit: 1000,
-                  tlsEnabled: true,
-                  replicationEnabled: false,
-                  vertexCount: Int64(7),
-                  edgeCount: Int64(8),
-                ),
-              )
-              .build();
+      final transport = FakeTransportBuilder()
+          .unary<graph.GetServerStatusRequest, graph.GetServerStatusResponse>(
+            LanternService.getServerStatus,
+            (request, context) => graph.GetServerStatusResponse(
+              version: 'v0.1.0',
+              goVersion: 'go-test',
+              startedAt: Timestamp.fromDateTime(started),
+              uptime: duration_proto.Duration(seconds: Int64(90)),
+              defaultTtl: duration_proto.Duration(seconds: Int64(300)),
+              maxBatchSize: 65536,
+              maxKeyBytes: 1024,
+              scanDefaultLimit: 100,
+              scanMaxLimit: 1000,
+              tlsEnabled: true,
+              replicationEnabled: false,
+              vertexCount: Int64(7),
+              edgeCount: Int64(8),
+            ),
+          )
+          .build();
       final status = await _client(transport).getServerStatus();
 
       expect(status.version, 'v0.1.0');
@@ -118,36 +116,35 @@ void main() {
     'replication snapshot sorts peers and computes server-clock lag',
     () async {
       final now = DateTime.parse('2026-07-12T02:00:00Z');
-      final transport =
-          FakeTransportBuilder()
-              .unary<
-                graph.GetReplicationStatusRequest,
-                graph.GetReplicationStatusResponse
-              >(
-                LanternService.getReplicationStatus,
-                (request, context) => graph.GetReplicationStatusResponse(
-                  nodeId: 'abc',
-                  localNow: Timestamp.fromDateTime(now),
-                  enabled: true,
-                  peers: [
-                    graph.ReplicationPeer(
-                      address: 'z:6380',
-                      state: graph.ReplicationPeer_State.STATE_BACKOFF,
-                      appliedSeq: Int64(4),
-                      error: 'offline',
-                    ),
-                    graph.ReplicationPeer(
-                      address: 'a:6380',
-                      state: graph.ReplicationPeer_State.STATE_STREAMING,
-                      lastEventAt: Timestamp.fromDateTime(
-                        now.subtract(const Duration(seconds: 5)),
-                      ),
-                      appliedSeq: Int64(9),
-                    ),
-                  ],
+      final transport = FakeTransportBuilder()
+          .unary<
+            graph.GetReplicationStatusRequest,
+            graph.GetReplicationStatusResponse
+          >(
+            LanternService.getReplicationStatus,
+            (request, context) => graph.GetReplicationStatusResponse(
+              nodeId: 'abc',
+              localNow: Timestamp.fromDateTime(now),
+              enabled: true,
+              peers: [
+                graph.ReplicationPeer(
+                  address: 'z:6380',
+                  state: graph.ReplicationPeer_State.STATE_BACKOFF,
+                  appliedSeq: Int64(4),
+                  error: 'offline',
                 ),
-              )
-              .build();
+                graph.ReplicationPeer(
+                  address: 'a:6380',
+                  state: graph.ReplicationPeer_State.STATE_STREAMING,
+                  lastEventAt: Timestamp.fromDateTime(
+                    now.subtract(const Duration(seconds: 5)),
+                  ),
+                  appliedSeq: Int64(9),
+                ),
+              ],
+            ),
+          )
+          .build();
       final status = await _client(transport).getReplicationStatus();
 
       expect(status.enabled, isTrue);

--- a/sdks/dart/test/traversal_test.dart
+++ b/sdks/dart/test/traversal_test.dart
@@ -143,13 +143,12 @@ void main() {
 
 connect.Transport _capture(
   graph.IlluminateResponse Function(graph.IlluminateRequest request) handler,
-) =>
-    FakeTransportBuilder()
-        .unary<graph.IlluminateRequest, graph.IlluminateResponse>(
-          LanternService.illuminate,
-          (request, context) => handler(request),
-        )
-        .build();
+) => FakeTransportBuilder()
+    .unary<graph.IlluminateRequest, graph.IlluminateResponse>(
+      LanternService.illuminate,
+      (request, context) => handler(request),
+    )
+    .build();
 
 LanternClient _client(connect.Transport transport) => LanternClient.connect(
   Uri.parse('https://example.test'),


### PR DESCRIPTION
## What changed

- Raise `lantern_client`'s Dart SDK floor from 3.7 to 3.10.
- Run the minimum-Dart CI job on Dart 3.10.
- Synchronize ADR 0001 and the SDK README with the supported toolchain policy.

## Why

`lints` 6.1.0 and `test` 1.31.2 require a newer Dart SDK. The maintained Flutter example already uses Dart 3.12.2, so it is unaffected.

## Compatibility

This intentionally drops support for pure-Dart consumers on Dart 3.7–3.9. The SDK is pre-v1 and the repository allows breaking changes before v1.0.0.

Closes #1045

## Local validation

- `dart format --output=none --set-exit-if-changed lib/lantern_client.dart lib/src/*.dart test`
- `dart pub get --enforce-lockfile`
- `dart analyze`
- `dart test`
- `flutter pub get --enforce-lockfile`
- `flutter analyze`
- `flutter test`

The PR CI validates the actual Dart 3.10 floor and the Android/iOS real-wire gates.
