### PR TITLE
chore(dart): raise supported SDK floor to 3.11

### DIFF
--- a/.github/workflows/dart-sdk.yml
+++ b/.github/workflows/dart-sdk.yml
@@ -162,7 +162,7 @@ jobs:
           fi
 
   minimum-dart:
-    name: Minimum Dart 3.10
+    name: Minimum Dart 3.11
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -173,7 +173,7 @@ jobs:
       - name: Set up minimum supported Dart
         uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
         with:
-          sdk: 3.10.0
+          sdk: 3.11.0
 
       - name: Resolve at the minimum floor
         # The maintained Flutter example intentionally follows the pinned

--- a/docs/decisions/0001-dart-mobile-transport.md
+++ b/docs/decisions/0001-dart-mobile-transport.md
@@ -20,7 +20,7 @@ HTTP/1.1 client. Use these exact initial pins:
 - runtime: `connectrpc 1.0.0`, `protobuf 4.2.0`, `fixnum 1.1.1`;
 - code generation: `buf.build/connectrpc/dart:v1.0.0` and
   `buf.build/protocolbuffers/dart:v22.5.0`;
-- Dart floor: 3.10.0, allowing the maintained lints and test toolchain;
+- Dart floor: 3.11.0, allowing the maintained lints and test toolchain;
 - validated Flutter toolchain: Flutter 3.44.6 / Dart 3.12.2;
 - supported production platforms: Android and iOS native only; Flutter Web is
   outside this decision.

--- a/sdks/dart/README.md
+++ b/sdks/dart/README.md
@@ -197,7 +197,7 @@ Protobuf `<5.0.0` ceiling is required by Connect-Dart 1.x.
 
 The supported toolchain policy is recorded in
 [ADR 0001](https://github.com/anaregdesign/lantern/blob/main/docs/decisions/0001-dart-mobile-transport.md):
-CI tests the package's Dart 3.10 floor and the pinned current Flutter/Dart pair.
+CI tests the package's Dart 3.11 floor and the pinned current Flutter/Dart pair.
 Generator/runtime compatibility pins move together through reviewed PRs.
 
 Generated files are committed under `lib/src/gen` and must never be edited by

--- a/sdks/dart/pubspec.yaml
+++ b/sdks/dart/pubspec.yaml
@@ -11,7 +11,7 @@ topics:
   - lantern
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
+  sdk: ">=3.11.0 <4.0.0"
 
 dependencies:
   connectrpc: ">=1.0.0 <2.0.0"
@@ -19,6 +19,6 @@ dependencies:
   protobuf: ">=4.2.0 <5.0.0"
 
 dev_dependencies:
-  # Keep dev resolution compatible with the documented Dart 3.10 floor.
+  # Keep dev resolution compatible with the documented Dart 3.11 floor.
   lints: 5.1.1
   test: 1.30.0


### PR DESCRIPTION
## What changed

- Raise `lantern_client`'s Dart SDK floor from 3.10 to 3.11.
- Run the minimum-Dart CI job on Dart 3.11.
- Synchronize ADR 0001 and the SDK README with the supported toolchain policy.

## Why

Dependabot PR #1044 updates `test` to 1.31.2, which requires Dart 3.11 or later. The maintained Flutter example already uses Dart 3.12.2.

## Compatibility

This intentionally drops support for pure-Dart consumers on Dart 3.10. Backward compatibility is not required for the pre-v1 SDK.

Closes #1053

## Local validation

- `dart pub get --enforce-lockfile`
- `dart format --output=none --set-exit-if-changed lib/lantern_client.dart lib/src/*.dart test`
- `dart analyze`
- `dart test`
- `flutter pub get --enforce-lockfile`
- `flutter analyze`
- `flutter test`

The PR CI validates the actual Dart 3.11 floor and the Android/iOS real-wire gates.
