### PR TITLE
fix(ci): remove circular Dart release blockers

### DIFF
--- a/.github/workflows/dart-sdk.yml
+++ b/.github/workflows/dart-sdk.yml
@@ -341,7 +341,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          for issue in 1008 1009 1011 1014 1016 1017 1020 1021 1022; do
+          # Check only work that must be complete before the release starts.
+          # Release-tracking Issues #1020 and #1022 close after publishing, and
+          # the Phase 2 offline-design Issue #1021 is not a v0.1 blocker.
+          for issue in 1008 1009 1011 1014 1016 1017; do
             state=$(gh issue view "$issue" --json state --jq .state)
             if [[ "$state" != CLOSED ]]; then
               echo "::error::First Dart release is blocked by open Issue #$issue"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,10 +304,13 @@ number rather than force-moving the tag.
   pub.dev confirms the version exists; its title is exactly the tag.
 
 **One-time first Dart publish.** pub.dev requires an authorized uploader to publish the
-first package version manually. For `0.1.0`, first complete every epic blocker and both
-physical-device columns in `sdks/dart/example/physical-device-smoke.md`. From a clean
-tagged checkout, after the tag workflow's verification jobs pass and its publish job
-reports the expected first-version block, run:
+first package version manually. For `0.1.0`, the tag workflow requires the v0.1
+implementation leaves (#1008, #1009, #1011, #1014, and #1016) and the physical-device
+gate (#1017) to be closed. Release-tracking Issues #1020 and #1022 remain open until the
+publish and exact-title GitHub Release are verified; the Phase 2 offline-design Issue
+#1021 is not a v0.1 release blocker. From a clean tagged checkout, after the tag
+workflow's verification jobs pass and its publish job reports the expected
+first-version block, run:
 
 ```bash
 git switch --detach sdks/dart/v0.1.0

--- a/tests/integration/docs_gate_test.go
+++ b/tests/integration/docs_gate_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -94,6 +95,45 @@ func TestTraversalDocumentationGate(t *testing.T) {
 		t.Run(example, func(t *testing.T) {
 			parseTraversalDocumentationCommand(t, example)
 		})
+	}
+}
+
+// TestDartFirstReleaseBlockerGate keeps the executable v0.1 release gate
+// aligned with the documented dependency spine. Release-tracking Issues must
+// remain open until publishing is verified, and Phase 2 design work must not
+// silently become a v0.1 blocker.
+func TestDartFirstReleaseBlockerGate(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+
+	workflowPath := filepath.Join(repoRoot, ".github", "workflows", "dart-sdk.yml")
+	workflow, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("read Dart SDK workflow: %v", err)
+	}
+
+	match := regexp.MustCompile(`for issue in ([0-9 ]+); do`).FindStringSubmatch(string(workflow))
+	if len(match) != 2 {
+		t.Fatal("Dart SDK workflow is missing the first-release Issue gate")
+	}
+	const wantBlockers = "1008 1009 1011 1014 1016 1017"
+	if got := strings.Join(strings.Fields(match[1]), " "); got != wantBlockers {
+		t.Fatalf("Dart v0.1 blockers = %q, want %q", got, wantBlockers)
+	}
+
+	contributing, err := os.ReadFile(filepath.Join(repoRoot, "CONTRIBUTING.md"))
+	if err != nil {
+		t.Fatalf("read CONTRIBUTING.md: %v", err)
+	}
+	for _, contract := range []string{
+		"Release-tracking Issues #1020 and #1022 remain open",
+		"#1021 is not a v0.1 release blocker",
+	} {
+		if !strings.Contains(string(contributing), contract) {
+			t.Errorf("CONTRIBUTING.md is missing Dart release contract %q", contract)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- limit the Dart v0.1 release gate to implementation leaves that can close before publishing
- keep release-tracking Issues #1020 and #1022 open until pub.dev and the exact-title GitHub Release are verified
- keep the Phase 2 offline-design Issue #1021 out of the v0.1 release path
- add a regression gate that keeps the workflow and CONTRIBUTING contract aligned

## Root cause

The publish job required #1020 and #1022 to be closed even though those Issues track completion of the publish and Release steps themselves. It also promoted #1021 to a release blocker despite the epic declaring that work Phase 2. The tag workflow therefore could not reach the expected first-package manual-publish handoff without prematurely closing its tracking Issues.

## Validation

- workflow YAML parse
- `go test ./...`
- Dart SDK CI-scope format check
- `dart analyze`
- `dart test`
- Flutter example format check
- `flutter analyze`
- `flutter test`

Refs #1020
Refs #1022