### PR TITLE
fix(search): make ranking deterministic across histories

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,8 @@ because the bridge is not traversable.
 
 `SearchVertices` runs relevance-ranked (BM25) full-text search over vertex
 *content* — key plus value — as the content-addressed counterpart to prefix
-scans. Ranked hits make natural seeds for a follow-up `bfs`, `pagerank`, or
-`community` walk:
+scans. Hits use the stable total order `(score DESC, raw key ASC)` and make
+natural seeds for a follow-up `bfs`, `pagerank`, or `community` walk:
 
 ```shell
 lantern-cli search "rolling update"              # OR-union of the query words

--- a/core/graphcache/batch_external_test.go
+++ b/core/graphcache/batch_external_test.go
@@ -1,6 +1,7 @@
 package graphcache_test
 
 import (
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -221,7 +222,7 @@ func TestBatchAPIs_ReturnCounts(t *testing.T) {
 func TestDeleteVertices_ClearsPrefixAndSearchIndexes(t *testing.T) {
 	c := graphcache.NewGraphCache[string, string](time.Minute)
 	c.EnablePrefixIndex(func(k string) string { return k })
-	c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+	c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, strings.Compare)
 
 	c.PutVertex("ns:a", "alpha")
 	c.PutVertex("ns:b", "bravo")

--- a/core/graphcache/bench_test.go
+++ b/core/graphcache/bench_test.go
@@ -479,7 +479,7 @@ func BenchmarkPutVertex_Search(b *testing.B) {
 
 	b.Run("Indexed", func(b *testing.B) {
 		c := NewGraphCache[string, string](time.Hour)
-		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -530,7 +530,7 @@ func BenchmarkSearchVertices(b *testing.B) {
 	const n = 5000
 	newSeeded := func() *GraphCache[string, string] {
 		c := NewGraphCache[string, string](time.Hour)
-		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
 		c.EnablePrefixIndex(func(s string) string { return s })
 		exp := time.Now().Add(time.Hour)
 		for i := 0; i < n; i++ {
@@ -618,7 +618,7 @@ func BenchmarkDeleteVertices_Indexed(b *testing.B) {
 				b.StopTimer()
 				c := NewGraphCache[string, string](time.Hour)
 				c.EnablePrefixIndex(func(k string) string { return k })
-				c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+				c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
 				vs := make([]VertexItem[string, string], n)
 				for i, k := range keys {
 					vs[i] = VertexItem[string, string]{Key: k, Value: benchSearchCorpus[i%len(benchSearchCorpus)], Expiration: exp}
@@ -653,7 +653,7 @@ func BenchmarkDeleteByPrefix_Indexed(b *testing.B) {
 				b.StopTimer()
 				c := NewGraphCache[string, string](time.Hour)
 				c.EnablePrefixIndex(func(k string) string { return k })
-				c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+				c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
 				vs := make([]VertexItem[string, string], n)
 				for i, k := range keys {
 					vs[i] = VertexItem[string, string]{Key: k, Value: benchSearchCorpus[i%len(benchSearchCorpus)], Expiration: exp}
@@ -704,7 +704,7 @@ func BenchmarkPutVerticesIndexed(b *testing.B) {
 
 	b.Run("SearchEnabled", func(b *testing.B) {
 		c := NewGraphCache[string, string](time.Hour)
-		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
 		items := makeBatch("k")
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -715,7 +715,7 @@ func BenchmarkPutVerticesIndexed(b *testing.B) {
 
 	b.Run("SearchEnabledParallel", func(b *testing.B) {
 		c := NewGraphCache[string, string](time.Hour)
-		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
 		var worker atomic.Int64
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -745,7 +745,7 @@ func BenchmarkApplyPutVerticesHLC(b *testing.B) {
 	}
 	newCache := func() *GraphCache[string, string] {
 		c := NewGraphCache[string, string](time.Hour)
-		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
 		return c
 	}
 	ts := hlc.Timestamp{WallNs: 1}

--- a/core/graphcache/cache_test.go
+++ b/core/graphcache/cache_test.go
@@ -375,7 +375,7 @@ func TestGraphCache_PutVertexWithExpiration_BornExpired(t *testing.T) {
 	newCache := func() *GraphCache[string, string] {
 		c := NewGraphCache[string, string](time.Minute)
 		c.EnablePrefixIndex(func(s string) string { return s })
-		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
 		return c
 	}
 	past := time.Now().Add(-time.Hour)
@@ -1457,7 +1457,7 @@ func TestSearchIndexStats(t *testing.T) {
 		t.Errorf("disabled: got (%d, %d), want (0, 0)", terms, docs)
 	}
 
-	c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) })
+	c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
 	exp := time.Now().Add(time.Hour)
 	c.PutVertexWithExpiration("key:1", "hello world", exp)
 	c.PutVertexWithExpiration("key:2", "foo bar", exp)

--- a/core/graphcache/gc_test.go
+++ b/core/graphcache/gc_test.go
@@ -13,7 +13,7 @@ import (
 func TestGraphCache_GCFlushMaintainsIndexesWatermarksAndDanglingEdges(t *testing.T) {
 	c := NewGraphCache[string, string](time.Minute)
 	c.EnablePrefixIndex(identityExtract)
-	c.EnableSearchIndex(textExtract)
+	c.EnableSearchIndex(textExtract, compareStringID)
 
 	now := time.Now()
 	liveExp := now.Add(time.Minute)

--- a/core/graphcache/indexes_test.go
+++ b/core/graphcache/indexes_test.go
@@ -9,7 +9,7 @@ import (
 func TestGraphCache_IndexLifecycle_ExplicitVertexAndEndpointCreation(t *testing.T) {
 	c := NewGraphCache[string, string](time.Minute)
 	c.EnablePrefixIndex(identityExtract)
-	c.EnableSearchIndex(textExtract)
+	c.EnableSearchIndex(textExtract, compareStringID)
 	exp := time.Now().Add(time.Minute)
 
 	c.PutVertexWithExpiration("user:1", "explicit searchable payload", exp)

--- a/core/graphcache/prefix_test.go
+++ b/core/graphcache/prefix_test.go
@@ -216,7 +216,7 @@ func TestGraphCache_PrefixIndex_DroppedOnDeleteVertex(t *testing.T) {
 func TestGraphCache_DeleteByPrefix_ClearsSearchIndex(t *testing.T) {
 	c := NewGraphCache[string, string](time.Minute)
 	c.EnablePrefixIndex(identityExtract)
-	c.EnableSearchIndex(textExtract)
+	c.EnableSearchIndex(textExtract, compareStringID)
 	c.PutVertex("doc:1", "alpha")
 	c.PutVertex("doc:2", "bravo")
 	c.PutVertex("keep:1", "zulu")

--- a/core/graphcache/production_gate_test.go
+++ b/core/graphcache/production_gate_test.go
@@ -529,7 +529,7 @@ func floatNear(a, b float32) bool {
 func testLogicalVertexVisibility(t *testing.T) {
 	c := NewGraphCache[string, string](time.Hour)
 	c.EnablePrefixIndex(identityExtract)
-	c.EnableSearchIndex(textExtract)
+	c.EnableSearchIndex(textExtract, compareStringID)
 	live := time.Now().Add(time.Hour)
 
 	c.PutVertexWithExpiration("live:1", "rivers", live)
@@ -610,7 +610,7 @@ func testLogicalVertexVisibility(t *testing.T) {
 func testLogicalGCNonObservable(t *testing.T) {
 	c := NewGraphCache[string, string](time.Hour)
 	c.EnablePrefixIndex(identityExtract)
-	c.EnableSearchIndex(textExtract)
+	c.EnableSearchIndex(textExtract, compareStringID)
 	live := time.Now().Add(time.Hour)
 
 	c.PutVertexWithExpiration("k:live", "rivers", live)
@@ -656,7 +656,7 @@ func testLogicalGCNonObservable(t *testing.T) {
 func testLogicalNoResurrection(t *testing.T) {
 	c := NewGraphCache[string, string](time.Hour)
 	c.EnablePrefixIndex(identityExtract)
-	c.EnableSearchIndex(textExtract)
+	c.EnableSearchIndex(textExtract, compareStringID)
 	live := time.Now().Add(time.Hour)
 
 	c.PutVertexWithExpiration("old:1", "phoenix", live)

--- a/core/graphcache/search.go
+++ b/core/graphcache/search.go
@@ -30,7 +30,7 @@ import (
 // The relevance gate (core/search/relevance, parity_gate_test.go) replicates
 // exactly this pipeline (with positions on) and ratchets its measured metrics
 // against the pinned Lucene baseline — change the two in lockstep.
-func newSearchIndex[S comparable](positions bool) *search.InvertedIndex[S, search.Document] {
+func newSearchIndex[S comparable](positions bool, compareID func(S, S) int) *search.InvertedIndex[S, search.Document] {
 	analyzer := search.NewScriptAwareAnalyzer()
 	scorer := search.ClassWeighted{
 		Base:       search.BM25{K1: search.DefaultBM25K1, B: search.DefaultBM25B},
@@ -40,7 +40,7 @@ func newSearchIndex[S comparable](positions bool) *search.InvertedIndex[S, searc
 	if positions {
 		opts = append(opts, search.WithPositions())
 	}
-	return search.NewInvertedIndex[S, search.Document](analyzer, scorer, opts...)
+	return search.NewInvertedIndex[S, search.Document](analyzer, scorer, compareID, opts...)
 }
 
 // SearchIndexOption configures the optional content-search index at
@@ -49,8 +49,8 @@ func newSearchIndex[S comparable](positions bool) *search.InvertedIndex[S, searc
 type SearchIndexOption func(*searchIndexConfig)
 
 // searchIndexConfig is the resolved EnableSearchIndex configuration. positions
-// defaults to true so the common call — EnableSearchIndex(extract) with no
-// options — keeps recording positions exactly as before #908.
+// defaults to true so the common call — EnableSearchIndex(extract, compareID)
+// with no options — keeps recording positions exactly as before #908.
 type searchIndexConfig struct {
 	positions bool
 }
@@ -71,7 +71,9 @@ func WithoutSearchPositions() SearchIndexOption {
 // vertex's string value). Like EnablePrefixIndex it must be called before any
 // vertex is stored, is idempotent, and panics on a non-empty cache so the
 // caller cannot silently observe an index that disagrees with point reads.
-// extract must not be nil. By default the index records positional postings for
+// extract and compareID must not be nil. compareID is the stable ascending
+// typed-key order used to break equal-score ties; production passes raw lexical
+// string-key comparison. By default the index records positional postings for
 // phrase and proximity queries; pass WithoutSearchPositions to build the leaner
 // position-free index (#908).
 //
@@ -82,9 +84,12 @@ func WithoutSearchPositions() SearchIndexOption {
 // they describe.
 // The index is a third opt-in secondary structure alongside the prefix index;
 // when it is left disabled the put / evict hot paths pay only a nil check.
-func (c *GraphCache[S, T]) EnableSearchIndex(extract func(T) search.Document, opts ...SearchIndexOption) {
+func (c *GraphCache[S, T]) EnableSearchIndex(extract func(T) search.Document, compareID func(S, S) int, opts ...SearchIndexOption) {
 	if extract == nil {
 		panic("graphcache: EnableSearchIndex extract must not be nil")
+	}
+	if compareID == nil {
+		panic("graphcache: EnableSearchIndex compareID must not be nil")
 	}
 	cfg := searchIndexConfig{positions: true}
 	for _, opt := range opts {
@@ -99,7 +104,7 @@ func (c *GraphCache[S, T]) EnableSearchIndex(extract func(T) search.Document, op
 		panic("graphcache: EnableSearchIndex must be called before any vertex is stored")
 	}
 	c.searchExtract = extract
-	c.searchIndex = newSearchIndex[S](cfg.positions)
+	c.searchIndex = newSearchIndex[S](cfg.positions, compareID)
 }
 
 // SearchVertices returns up to limit keys whose indexed content matches query,
@@ -114,7 +119,8 @@ func (c *GraphCache[S, T]) EnableSearchIndex(extract func(T) search.Document, op
 // GetVertex calls under the snapshot lock would surface. Because matching is
 // the index's boolean OR over the query terms, limit is applied after the
 // liveness and prefix filters so a full page of live, in-scope hits is
-// returned whenever one exists.
+// returned whenever one exists. Equal scores are ordered ascending by the
+// typed compareID function supplied to EnableSearchIndex.
 func (c *GraphCache[S, T]) SearchVertices(query string, limit int, keyPrefix string) []search.Result[S] {
 	return c.SearchVerticesMatch(query, limit, keyPrefix, search.MatchOptions{}, false)
 }

--- a/core/graphcache/search_test.go
+++ b/core/graphcache/search_test.go
@@ -15,6 +15,7 @@ import (
 // textExtract is the value projection used by the string-keyed tests: it makes
 // the stored string value itself the searchable document.
 func textExtract(s string) search.Document { return search.Text(s) }
+func compareStringID(a, b string) int      { return strings.Compare(a, b) }
 
 // keys returns just the IDs of a ranked result set, in rank order, for terse
 // assertions.
@@ -44,7 +45,7 @@ func TestGraphCache_EnableSearchIndex_AfterPutPanics(t *testing.T) {
 			t.Fatal("expected panic when enabling search index on non-empty cache")
 		}
 	}()
-	c.EnableSearchIndex(textExtract)
+	c.EnableSearchIndex(textExtract, compareStringID)
 }
 
 func TestGraphCache_EnableSearchIndex_NilExtractPanics(t *testing.T) {
@@ -54,13 +55,23 @@ func TestGraphCache_EnableSearchIndex_NilExtractPanics(t *testing.T) {
 			t.Fatal("expected panic when extract is nil")
 		}
 	}()
-	c.EnableSearchIndex(nil)
+	c.EnableSearchIndex(nil, compareStringID)
+}
+
+func TestGraphCache_EnableSearchIndex_NilComparatorPanics(t *testing.T) {
+	c := NewGraphCache[string, string](time.Minute)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when compareID is nil")
+		}
+	}()
+	c.EnableSearchIndex(textExtract, nil)
 }
 
 func TestGraphCache_EnableSearchIndex_Idempotent(t *testing.T) {
 	c := NewGraphCache[string, string](time.Minute)
-	c.EnableSearchIndex(textExtract)
-	c.EnableSearchIndex(textExtract) // must not panic
+	c.EnableSearchIndex(textExtract, compareStringID)
+	c.EnableSearchIndex(textExtract, compareStringID) // must not panic
 }
 
 // TestGraphCache_EnableSearchIndex_WithoutPositions covers the #908 opt-out:
@@ -84,7 +95,7 @@ func TestGraphCache_EnableSearchIndex_WithoutPositions(t *testing.T) {
 
 	t.Run("positions on verifies adjacency", func(t *testing.T) {
 		c := NewGraphCache[string, string](time.Minute)
-		c.EnableSearchIndex(textExtract) // default: positions on
+		c.EnableSearchIndex(textExtract, compareStringID) // default: positions on
 		seed(c)
 		if got := phraseHits(c); !reflect.DeepEqual(got, map[string]bool{"adj": true}) {
 			t.Fatalf("phrase hits = %v, want only {adj} (split's words are not adjacent)", got)
@@ -93,7 +104,7 @@ func TestGraphCache_EnableSearchIndex_WithoutPositions(t *testing.T) {
 
 	t.Run("positions off degrades to AND-intersection", func(t *testing.T) {
 		c := NewGraphCache[string, string](time.Minute)
-		c.EnableSearchIndex(textExtract, WithoutSearchPositions())
+		c.EnableSearchIndex(textExtract, compareStringID, WithoutSearchPositions())
 		seed(c)
 		if got := phraseHits(c); !reflect.DeepEqual(got, map[string]bool{"adj": true, "split": true}) {
 			t.Fatalf("phrase hits = %v, want {adj, split} (positions off => AND-intersection)", got)
@@ -104,7 +115,7 @@ func TestGraphCache_EnableSearchIndex_WithoutPositions(t *testing.T) {
 func TestGraphCache_SearchVertices(t *testing.T) {
 	t.Run("Ranking", func(t *testing.T) {
 		c := NewGraphCache[string, string](time.Minute)
-		c.EnableSearchIndex(textExtract)
+		c.EnableSearchIndex(textExtract, compareStringID)
 		c.PutVertex("exact", "arch")
 		c.PutVertex("infix", "research laboratory")
 		c.PutVertex("other", "a giant panda")
@@ -119,7 +130,7 @@ func TestGraphCache_SearchVertices(t *testing.T) {
 
 	t.Run("Overwrite drops stale postings", func(t *testing.T) {
 		c := NewGraphCache[string, string](time.Minute)
-		c.EnableSearchIndex(textExtract)
+		c.EnableSearchIndex(textExtract, compareStringID)
 		c.PutVertex("k", "alpha")
 		if got := keys(c.SearchVertices("alpha", 10, "")); !equalKeys(got, []string{"k"}) {
 			t.Fatalf("before overwrite: SearchVertices(alpha) = %v, want [k]", got)
@@ -137,7 +148,7 @@ func TestGraphCache_SearchVertices(t *testing.T) {
 
 	t.Run("Delete stops matching", func(t *testing.T) {
 		c := NewGraphCache[string, string](time.Minute)
-		c.EnableSearchIndex(textExtract)
+		c.EnableSearchIndex(textExtract, compareStringID)
 		c.PutVertex("k", "gamma unique")
 		if got := keys(c.SearchVertices("gamma", 10, "")); !equalKeys(got, []string{"k"}) {
 			t.Fatalf("before delete: got %v, want [k]", got)
@@ -154,7 +165,7 @@ func TestGraphCache_SearchVertices(t *testing.T) {
 
 	t.Run("Clear stops matching", func(t *testing.T) {
 		c := NewGraphCache[string, string](time.Minute)
-		c.EnableSearchIndex(textExtract)
+		c.EnableSearchIndex(textExtract, compareStringID)
 		c.PutVertex("a", "shared term")
 		c.PutVertex("b", "shared word")
 		// The inner cache's Clear fires SetOnEvict for every key, so the
@@ -167,7 +178,7 @@ func TestGraphCache_SearchVertices(t *testing.T) {
 
 	t.Run("TTL expiry stops matching", func(t *testing.T) {
 		c := NewGraphCache[string, string](time.Minute)
-		c.EnableSearchIndex(textExtract)
+		c.EnableSearchIndex(textExtract, compareStringID)
 		// Live and already-expired vertices share the term; only the live one
 		// must surface, even before the GC Flush runs (liveness filter).
 		c.PutVertex("live", "delta payload")
@@ -185,30 +196,30 @@ func TestGraphCache_SearchVertices(t *testing.T) {
 
 	t.Run("KeyPrefix scopes results", func(t *testing.T) {
 		c := NewGraphCache[string, string](time.Minute)
-		c.EnableSearchIndex(textExtract)
+		c.EnableSearchIndex(textExtract, compareStringID)
 		c.PutVertex("user:1", "common keyword")
 		c.PutVertex("user:2", "common keyword")
 		c.PutVertex("session:a", "common keyword")
 		got := c.SearchVertices("keyword", 10, "user:")
-		if want := []string{"user:1", "user:2"}; !sameSet(keys(got), want) {
+		if want := []string{"user:1", "user:2"}; !equalKeys(keys(got), want) {
 			t.Fatalf("SearchVertices(keyword, prefix user:) = %v, want %v", keys(got), want)
 		}
 	})
 
 	t.Run("Limit caps results", func(t *testing.T) {
 		c := NewGraphCache[string, string](time.Minute)
-		c.EnableSearchIndex(textExtract)
+		c.EnableSearchIndex(textExtract, compareStringID)
 		for _, k := range []string{"k1", "k2", "k3", "k4"} {
 			c.PutVertex(k, "common keyword")
 		}
-		if got := c.SearchVertices("keyword", 2, ""); len(got) != 2 {
-			t.Fatalf("SearchVertices(keyword, limit 2) returned %d hits, want 2", len(got))
+		if got := keys(c.SearchVertices("keyword", 2, "")); !equalKeys(got, []string{"k1", "k2"}) {
+			t.Fatalf("SearchVertices(keyword, limit 2) = %v, want [k1 k2]", got)
 		}
 	})
 
 	t.Run("Empty query returns nil", func(t *testing.T) {
 		c := NewGraphCache[string, string](time.Minute)
-		c.EnableSearchIndex(textExtract)
+		c.EnableSearchIndex(textExtract, compareStringID)
 		c.PutVertex("k", "anything")
 		if got := c.SearchVertices("", 10, ""); got != nil {
 			t.Fatalf("SearchVertices(empty) = %v, want nil", keys(got))
@@ -217,7 +228,7 @@ func TestGraphCache_SearchVertices(t *testing.T) {
 
 	t.Run("Non-positive limit returns nil", func(t *testing.T) {
 		c := NewGraphCache[string, string](time.Minute)
-		c.EnableSearchIndex(textExtract)
+		c.EnableSearchIndex(textExtract, compareStringID)
 		c.PutVertex("k", "anything")
 		if got := c.SearchVertices("anything", 0, ""); got != nil {
 			t.Fatalf("SearchVertices(limit 0) = %v, want nil", keys(got))
@@ -229,7 +240,7 @@ func TestGraphCache_SearchVertices(t *testing.T) {
 
 	t.Run("No match returns nil", func(t *testing.T) {
 		c := NewGraphCache[string, string](time.Minute)
-		c.EnableSearchIndex(textExtract)
+		c.EnableSearchIndex(textExtract, compareStringID)
 		c.PutVertex("k", "alpha beta")
 		if got := c.SearchVertices("zzzzz", 10, ""); got != nil {
 			t.Fatalf("SearchVertices(no-match) = %v, want nil", keys(got))
@@ -245,7 +256,7 @@ func TestGraphCache_SearchVertices(t *testing.T) {
 // time.
 func TestGraphCache_SearchVertices_Concurrent(t *testing.T) {
 	c := NewGraphCache[string, string](time.Minute)
-	c.EnableSearchIndex(textExtract)
+	c.EnableSearchIndex(textExtract, compareStringID)
 	c.EnablePrefixIndex(func(s string) string { return s })
 
 	const keysN = 200
@@ -320,25 +331,6 @@ func equalKeys(got, want []string) bool {
 	return true
 }
 
-// sameSet reports whether got and want contain the same keys regardless of
-// order — used where rank order between equally-scored docs is unspecified.
-func sameSet(got, want []string) bool {
-	if len(got) != len(want) {
-		return false
-	}
-	seen := make(map[string]int, len(got))
-	for _, k := range got {
-		seen[k]++
-	}
-	for _, k := range want {
-		if seen[k] == 0 {
-			return false
-		}
-		seen[k]--
-	}
-	return true
-}
-
 // TestGraphCache_PutVertices_SearchLifecycle verifies that moving search-document
 // analysis outside the aggregate write lock (#739) keeps the batch put path in
 // perfect lockstep with the search index: hits are visible synchronously after
@@ -351,7 +343,7 @@ func TestGraphCache_PutVertices_SearchLifecycle(t *testing.T) {
 
 	t.Run("batch puts are searchable synchronously", func(t *testing.T) {
 		c := NewGraphCache[string, string](time.Minute)
-		c.EnableSearchIndex(textExtract)
+		c.EnableSearchIndex(textExtract, compareStringID)
 		c.PutVerticesWithExpiration([]VertexItem[string, string]{
 			{Key: "a", Value: "alpha", Expiration: future()},
 			{Key: "b", Value: "bravo", Expiration: future()},
@@ -366,7 +358,7 @@ func TestGraphCache_PutVertices_SearchLifecycle(t *testing.T) {
 
 	t.Run("overwrite drops stale document", func(t *testing.T) {
 		c := NewGraphCache[string, string](time.Minute)
-		c.EnableSearchIndex(textExtract)
+		c.EnableSearchIndex(textExtract, compareStringID)
 		c.PutVerticesWithExpiration([]VertexItem[string, string]{
 			{Key: "a", Value: "alpha", Expiration: future()},
 		})
@@ -383,7 +375,7 @@ func TestGraphCache_PutVertices_SearchLifecycle(t *testing.T) {
 
 	t.Run("duplicate keys in one batch keep last write", func(t *testing.T) {
 		c := NewGraphCache[string, string](time.Minute)
-		c.EnableSearchIndex(textExtract)
+		c.EnableSearchIndex(textExtract, compareStringID)
 		c.PutVerticesWithExpiration([]VertexItem[string, string]{
 			{Key: "a", Value: "alpha", Expiration: future()},
 			{Key: "a", Value: "zulu", Expiration: future()},
@@ -398,7 +390,7 @@ func TestGraphCache_PutVertices_SearchLifecycle(t *testing.T) {
 
 	t.Run("born-expired item is neither stored nor indexed", func(t *testing.T) {
 		c := NewGraphCache[string, string](time.Minute)
-		c.EnableSearchIndex(textExtract)
+		c.EnableSearchIndex(textExtract, compareStringID)
 		c.PutVerticesWithExpiration([]VertexItem[string, string]{
 			{Key: "live", Value: "alpha", Expiration: future()},
 			{Key: "dead", Value: "bravo", Expiration: time.Now().Add(-time.Minute)},
@@ -423,7 +415,7 @@ func TestGraphCache_PutVertices_SearchLifecycle(t *testing.T) {
 func TestGraphCache_SearchVertices_LifecycleIntersection(t *testing.T) {
 	c := NewGraphCache[string, string](time.Hour)
 	c.EnablePrefixIndex(identityExtract)
-	c.EnableSearchIndex(textExtract)
+	c.EnableSearchIndex(textExtract, compareStringID)
 	live := time.Now().Add(time.Hour)
 
 	c.PutVertexWithExpiration("eu:1", "harbor", live)

--- a/core/graphcache/tombstone_test.go
+++ b/core/graphcache/tombstone_test.go
@@ -147,7 +147,7 @@ func TestDeleteByPrefixHLC_TombstonesPerVertex(t *testing.T) {
 func TestDeleteVerticesHLC_BatchTombstonesAllDeletesPresent(t *testing.T) {
 	c := NewGraphCache[string, string](time.Minute)
 	c.EnablePrefixIndex(identityExtract)
-	c.EnableSearchIndex(textExtract)
+	c.EnableSearchIndex(textExtract, compareStringID)
 	exp := time.Now().Add(time.Hour)
 	t0 := hlc.Timestamp{WallNs: 1000}
 	t1 := hlc.Timestamp{WallNs: 2000}

--- a/core/search/document_test.go
+++ b/core/search/document_test.go
@@ -36,7 +36,7 @@ func TestDocumentAdaptersIndexable(t *testing.T) {
 	// Every adapter must be usable as a real index payload: indexing a value and
 	// querying its rendered text should find it.
 	analyzer := NewAnalyzer([]Normalizer{LowercaseNormalizer{}}, UnicodeTokenizer{}, nil)
-	idx := NewInvertedIndex[string, Document](analyzer, BM25{K1: 1.2, B: 0.75})
+	idx := NewInvertedIndex[string, Document](analyzer, BM25{K1: 1.2, B: 0.75}, compareStringID)
 
 	idx.Index("int", Int(2026))
 	idx.Index("bool", Bool(false))

--- a/core/search/example/main.go
+++ b/core/search/example/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"log"
+	"strings"
 
 	"github.com/anaregdesign/lantern/core/search"
 )
@@ -73,7 +74,7 @@ func main() {
 	// of a term counts far more than the 10th) and B = 0.75 tunes how strongly a
 	// longer-than-average document is penalized for diluting a term.
 	scorer := search.BM25{K1: 1.2, B: 0.75}
-	idx := search.NewInvertedIndex[string, search.Text](analyzer, scorer)
+	idx := search.NewInvertedIndex[string, search.Text](analyzer, scorer, strings.Compare)
 
 	// Index documents under any comparable ID. Text adapts a plain string to a
 	// Document; the messy punctuation and spacing here is exactly what the
@@ -108,7 +109,7 @@ func main() {
 	// The folding normalizers also raise recall across scripts: the same index
 	// finds a document when the query differs only by accent or character width.
 	// A second index keeps this demo separate from the infix one above.
-	fold := search.NewInvertedIndex[string, search.Text](analyzer, scorer)
+	fold := search.NewInvertedIndex[string, search.Text](analyzer, scorer, strings.Compare)
 	fold.Index("cafe", search.Text("Café"))   // accented Latin
 	fold.Index("tokyo", search.Text("ＴＯＫＹＯ")) // full-width Latin
 	fold.Index("naive", search.Text("naïve"))
@@ -134,12 +135,12 @@ func main() {
 	// — the batteries-included baseline that only lowercases before bigramming,
 	// with no punctuation boundary and no whitespace filter — over the same three
 	// documents, querying "data".
-	tuned := search.NewInvertedIndex[string, search.Text](analyzer, scorer)
+	tuned := search.NewInvertedIndex[string, search.Text](analyzer, scorer, strings.Compare)
 	tuned.Index("database", search.Text("database"))
 	tuned.Index("data set", search.Text("data set"))
 	tuned.Index("data science", search.Text("data science and machine learning"))
 
-	naive := search.NewInvertedIndex[string, search.Text](search.NewNGramAnalyzer(2), scorer)
+	naive := search.NewInvertedIndex[string, search.Text](search.NewNGramAnalyzer(2), scorer, strings.Compare)
 	naive.Index("database", search.Text("database"))
 	naive.Index("data set", search.Text("data set"))
 	naive.Index("data science", search.Text("data science and machine learning"))
@@ -162,7 +163,7 @@ func main() {
 	for _, hit := range naive.Search("data") {
 		log.Printf("  %-12s %.3f", hit.ID, hit.Score)
 	}
-	// database      0.515  (ties with "data set"; Searcher leaves ties unordered,
-	// data set      0.515   so these two may print in either order)
+	// data set      0.515  (ties with "database"; raw ID ascending wins)
+	// database      0.515
 	// data science  0.277
 }

--- a/core/search/fuzzy.go
+++ b/core/search/fuzzy.go
@@ -1,6 +1,8 @@
 package search
 
 import (
+	"container/heap"
+	"sort"
 	"strings"
 	"unicode/utf8"
 
@@ -10,8 +12,8 @@ import (
 // MaxTermExpansions caps how many dictionary terms a single word-channel query
 // term expands to under prefix/fuzzy matching, so a hot prefix or a small
 // fuzziness over a large dictionary cannot blow up a query. It mirrors Lucene's
-// default multi-term rewrite cap; the exact term is always kept, then the scan
-// fills the remaining budget in dictionary id order (deterministic).
+// default multi-term rewrite cap. Selection is semantic and independent of
+// dictionary ids: exact first, then prefix quality, then fuzzy edit distance.
 const MaxTermExpansions = 50
 
 // expandsTerms reports whether the options request prefix or fuzzy term
@@ -37,9 +39,9 @@ type queryClause struct {
 // it. Auxiliary gram tokens and CJK grams (isExpandable is false for a run of
 // unbounded-script runes) are never expanded — they are fixed-width windows, so
 // prefix/fuzzy widening is meaningless. Callers hold idx.mu.
-func (idx *InvertedIndex[S, D]) buildClausesLocked(queryTerms map[Token]struct{}, opts MatchOptions) []queryClause {
+func (idx *InvertedIndex[S, D]) buildClausesLocked(queryTerms []Token, opts MatchOptions) []queryClause {
 	clauses := make([]queryClause, 0, len(queryTerms))
-	for token := range queryTerms {
+	for _, token := range queryTerms {
 		if int(token.Class) >= numTokenClasses {
 			continue
 		}
@@ -90,14 +92,14 @@ func (idx *InvertedIndex[S, D]) scoreClausesLocked(clauses []queryClause, opts M
 			df := pl.cardinality()
 			for it := pl.docs.Iterator(); it.HasNext(); {
 				ord := it.Next()
-				scores[ord] += idx.scorer.Score(TermStats{
+				addScore(scores, ord, idx.scorer.Score(TermStats{
 					TF:     pl.tf(ord),
 					DF:     df,
 					N:      cp.docCount,
 					DocLen: idx.docs[ord].lengths[cl.class],
 					AvgLen: avgLen,
 					Class:  cl.class,
-				})
+				}))
 			}
 			if union != nil {
 				union.Or(pl.docs)
@@ -109,6 +111,7 @@ func (idx *InvertedIndex[S, D]) scoreClausesLocked(clauses []queryClause, opts M
 			}
 		}
 	}
+	dropNonFiniteScores(scores)
 	if coverage != nil {
 		if threshold := coverageThreshold(opts, numWords); threshold > 0 {
 			for ord := range scores {
@@ -137,81 +140,217 @@ func isExpandable(term string) bool {
 	return false
 }
 
-// expand returns the interned term ids matching term under the expansion flags,
-// capped at limit: the exact term (if interned) first, then terms that have term
-// as a prefix (when prefix is set), and terms within maxEdits edit distance
-// (when maxEdits > 0). It scans the live term slice in id order, so the result
-// — including which terms survive the cap — is deterministic. Callers hold the
-// index lock. Intended for word terms; the caller skips CJK grams.
+// expansionKind orders non-exact candidates when prefix and fuzzy expansion are
+// combined. A literal continuation is stronger than a typo candidate; a term
+// matching both is classified once as prefix.
+type expansionKind uint8
+
+const (
+	expansionPrefix expansionKind = iota
+	expansionFuzzy
+)
+
+type expansionCandidate struct {
+	id      uint32
+	term    string
+	kind    expansionKind
+	quality int // prefix rune-extension length or Levenshtein distance
+}
+
+// betterExpansion defines the history-independent expansion order after the
+// exact term: kind, quality, then normalized UTF-8 term ascending.
+func betterExpansion(a, b expansionCandidate) bool {
+	if a.kind != b.kind {
+		return a.kind < b.kind
+	}
+	if a.quality != b.quality {
+		return a.quality < b.quality
+	}
+	return a.term < b.term
+}
+
+// expansionTopHeap keeps its weakest retained candidate at the root.
+type expansionTopHeap []expansionCandidate
+
+func (h expansionTopHeap) Len() int { return len(h) }
+func (h expansionTopHeap) Less(i, j int) bool {
+	return betterExpansion(h[j], h[i])
+}
+func (h expansionTopHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h *expansionTopHeap) Push(x any)   { *h = append(*h, x.(expansionCandidate)) }
+func (h *expansionTopHeap) Pop() any {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func retainExpansion(h *expansionTopHeap, candidate expansionCandidate, limit int) {
+	if len(*h) < limit {
+		if *h == nil {
+			*h = make(expansionTopHeap, 0, limit)
+		}
+		*h = append(*h, candidate)
+		if len(*h) == limit {
+			heap.Init(h)
+		}
+		return
+	}
+	if betterExpansion(candidate, (*h)[0]) {
+		(*h)[0] = candidate
+		heap.Fix(h, 0)
+	}
+}
+
+// expand returns interned term ids capped at limit in a semantic order
+// independent of term ids and mutation history: exact first; prefix matches by
+// (rune extension length, term); then fuzzy-only matches by (edit distance,
+// term). Callers hold the index lock. Intended for word terms; the caller skips
+// CJK grams.
 func (d *termDict) expand(term string, prefix bool, maxEdits, limit int) []uint32 {
 	if limit <= 0 {
 		return nil
 	}
 	out := make([]uint32, 0, min(limit, 8))
-	seen := make(map[uint32]struct{})
-	appendID := func(id uint32) bool {
-		if _, dup := seen[id]; dup {
-			return len(out) < limit
-		}
-		seen[id] = struct{}{}
-		out = append(out, id)
-		return len(out) < limit
-	}
 	if id, ok := d.ids[term]; ok {
-		if !appendID(id) {
+		out = append(out, id)
+		if len(out) == limit {
 			return out
 		}
 	}
 	if !prefix && maxEdits <= 0 {
 		return out
 	}
+
 	// Fuzzy matching converts each length-compatible candidate to runes and runs
-	// a two-row Levenshtein DP. Both the rune slice and the DP rows are sized at
-	// most len(qr)+maxEdits (the rune-length gate rejects anything longer), so a
-	// single scratch trio, allocated once here, serves the whole scan instead of
-	// a per-candidate allocation — the dominant cost of a fuzzy expansion over a
-	// large dictionary (#909). The scan still visits terms in id order, so the
-	// cap survivors are unchanged.
-	qr := []rune(term)
+	// a two-row Levenshtein DP. ASCII words up to 64 bytes use Myers' bit-vector
+	// algorithm instead, reducing each candidate to one pass of word-sized
+	// operations. The DP scratch is allocated lazily only if a Unicode candidate
+	// needs it. A bounded heap retains only the best remaining terms, so semantic
+	// selection uses O(limit) transient memory.
+	var asciiMasks [utf8.RuneSelf]uint64
+	useASCII := len(term) > 0 && len(term) <= 64 && isASCII(term)
+	queryLen := len(term)
+	var qr []rune
+	if useASCII {
+		for i := range term {
+			asciiMasks[term[i]] |= uint64(1) << i
+		}
+	} else {
+		qr = []rune(term)
+		queryLen = len(qr)
+	}
 	var candRunes []rune
 	var dpPrev, dpCurr []int
-	if maxEdits > 0 {
-		candRunes = make([]rune, 0, len(qr)+maxEdits)
-		dpPrev = make([]int, len(qr)+maxEdits+1)
-		dpCurr = make([]int, len(qr)+maxEdits+1)
+	ensureDPScratch := func() {
+		if dpPrev != nil {
+			return
+		}
+		if qr == nil {
+			qr = []rune(term)
+		}
+		candRunes = make([]rune, 0, queryLen+maxEdits)
+		dpPrev = make([]int, queryLen+maxEdits+1)
+		dpCurr = make([]int, queryLen+maxEdits+1)
 	}
+	remaining := limit - len(out)
+	var best expansionTopHeap
 	for id, cand := range d.terms {
 		if cand == "" || cand == term {
-			continue // released slot, or the exact term already added
+			continue
 		}
-		matched := prefix && strings.HasPrefix(cand, term)
-		if !matched && maxEdits > 0 {
-			// Rune-length gate before the O(len) rune conversion and DP: edit
-			// distance is at least the rune-length difference, so a candidate
-			// whose length is more than maxEdits from the query cannot match.
-			// utf8.RuneCountInString allocates nothing, so the rune decode and
-			// Levenshtein run only for the few length-compatible candidates while
-			// the rest of the scan stays a cheap length count. A skipped candidate
-			// would have failed withinEdits anyway (it bails on that same length
-			// difference), so the match set — and thus which terms survive the
-			// cap — is byte-for-byte the pre-gate result.
-			if cl := utf8.RuneCountInString(cand); cl-len(qr) <= maxEdits && len(qr)-cl <= maxEdits {
-				candRunes = candRunes[:0]
-				for _, r := range cand {
-					candRunes = append(candRunes, r)
-				}
-				if withinEditsRows(qr, candRunes, maxEdits, dpPrev, dpCurr) {
-					matched = true
-				}
-			}
+		if prefix && strings.HasPrefix(cand, term) {
+			retainExpansion(&best, expansionCandidate{
+				id:      uint32(id),
+				term:    cand,
+				kind:    expansionPrefix,
+				quality: utf8.RuneCountInString(cand) - queryLen,
+			}, remaining)
+			continue
 		}
-		if matched {
-			if !appendID(uint32(id)) {
-				return out
+		if maxEdits <= 0 {
+			continue
+		}
+		candidateASCII := useASCII && isASCII(cand)
+		cl := len(cand)
+		if !candidateASCII {
+			cl = utf8.RuneCountInString(cand)
+		}
+		if cl-queryLen > maxEdits || queryLen-cl > maxEdits {
+			continue
+		}
+		if candidateASCII {
+			if distance, ok := asciiLevenshteinWithin(len(term), cand, maxEdits, &asciiMasks); ok {
+				retainExpansion(&best, expansionCandidate{
+					id:      uint32(id),
+					term:    cand,
+					kind:    expansionFuzzy,
+					quality: distance,
+				}, remaining)
 			}
+			continue
+		}
+		ensureDPScratch()
+		candRunes = candRunes[:0]
+		for _, r := range cand {
+			candRunes = append(candRunes, r)
+		}
+		if distance, ok := editDistanceWithinRows(qr, candRunes, maxEdits, dpPrev, dpCurr); ok {
+			retainExpansion(&best, expansionCandidate{
+				id:      uint32(id),
+				term:    cand,
+				kind:    expansionFuzzy,
+				quality: distance,
+			}, remaining)
 		}
 	}
+	sort.Slice(best, func(i, j int) bool { return betterExpansion(best[i], best[j]) })
+	for _, candidate := range best {
+		out = append(out, candidate.id)
+	}
 	return out
+}
+
+func isASCII(s string) bool {
+	for i := range len(s) {
+		if s[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
+}
+
+// asciiLevenshteinWithin computes the exact distance from the ASCII pattern
+// represented by masks to candidate when it is at most maxEdits, using Myers'
+// bit-vector algorithm. The caller guarantees 1 <= patternLen <= 64 and an
+// ASCII candidate. A partial score may still fall as remaining candidate bytes
+// arrive, so rejection uses the safe lower bound score - remaining.
+func asciiLevenshteinWithin(patternLen int, candidate string, maxEdits int, masks *[utf8.RuneSelf]uint64) (int, bool) {
+	positive := ^uint64(0)
+	negative := uint64(0)
+	score := patternLen
+	highBit := uint64(1) << (patternLen - 1)
+	for i := range candidate {
+		equal := masks[candidate[i]]
+		vertical := equal | negative
+		horizontal := (((equal & positive) + positive) ^ positive) | equal
+		positiveHorizontal := negative | ^(horizontal | positive)
+		negativeHorizontal := positive & horizontal
+		if positiveHorizontal&highBit != 0 {
+			score++
+		} else if negativeHorizontal&highBit != 0 {
+			score--
+		}
+		positiveHorizontal = (positiveHorizontal << 1) | 1
+		negativeHorizontal <<= 1
+		positive = negativeHorizontal | ^(vertical | positiveHorizontal)
+		negative = positiveHorizontal & vertical
+		if score-(len(candidate)-i-1) > maxEdits {
+			return 0, false
+		}
+	}
+	return score, score <= maxEdits
 }
 
 // withinEdits reports whether the Levenshtein edit distance between rune slices
@@ -222,7 +361,8 @@ func withinEdits(a, b []rune, maxEdits int) bool {
 		return false
 	}
 	n := len(b) + 1
-	return withinEditsRows(a, b, maxEdits, make([]int, n), make([]int, n))
+	_, ok := editDistanceWithinRows(a, b, maxEdits, make([]int, n), make([]int, n))
+	return ok
 }
 
 // withinEditsRows is withinEdits over caller-provided scratch rows so a large
@@ -233,9 +373,16 @@ func withinEdits(a, b []rune, maxEdits int) bool {
 // exceeds maxEdits, so a bounded distance check over a large dictionary stays
 // cheap. Contents are fully overwritten each call, so stale scratch is fine.
 func withinEditsRows(a, b []rune, maxEdits int, prev, curr []int) bool {
+	_, ok := editDistanceWithinRows(a, b, maxEdits, prev, curr)
+	return ok
+}
+
+// editDistanceWithinRows returns the exact Levenshtein distance when it is at
+// most maxEdits, using caller-provided scratch rows.
+func editDistanceWithinRows(a, b []rune, maxEdits int, prev, curr []int) (int, bool) {
 	la, lb := len(a), len(b)
 	if la-lb > maxEdits || lb-la > maxEdits {
-		return false
+		return 0, false
 	}
 	prev, curr = prev[:lb+1], curr[:lb+1]
 	for j := 0; j <= lb; j++ {
@@ -255,9 +402,10 @@ func withinEditsRows(a, b []rune, maxEdits int, prev, curr []int) bool {
 			}
 		}
 		if rowMin > maxEdits {
-			return false
+			return 0, false
 		}
 		prev, curr = curr, prev
 	}
-	return prev[lb] <= maxEdits
+	distance := prev[lb]
+	return distance, distance <= maxEdits
 }

--- a/core/search/fuzzy_test.go
+++ b/core/search/fuzzy_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // TestWithinEdits covers the bounded Levenshtein check at distances 0/1/2,
@@ -41,6 +42,89 @@ func TestWithinEdits(t *testing.T) {
 	}
 }
 
+// TestASCIILevenshteinDistance compares the Myers fast path to the independent
+// full-matrix oracle across the complete supported pattern-length range.
+func TestASCIILevenshteinDistance(t *testing.T) {
+	rng := rand.New(rand.NewSource(1056))
+	randomASCII := func(n int) string {
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = byte('a' + rng.Intn(8))
+		}
+		return string(b)
+	}
+	for patternLen := 1; patternLen <= 64; patternLen++ {
+		for trial := 0; trial < 40; trial++ {
+			pattern := randomASCII(patternLen)
+			candidate := randomASCII(rng.Intn(71))
+			var masks [utf8.RuneSelf]uint64
+			for i := range pattern {
+				masks[pattern[i]] |= uint64(1) << i
+			}
+			want := naiveLevenshtein([]rune(pattern), []rune(candidate))
+			for _, maxEdits := range []int{0, 1, 2, want} {
+				got, ok := asciiLevenshteinWithin(len(pattern), candidate, maxEdits, &masks)
+				if wantOK := want <= maxEdits; ok != wantOK || ok && got != want {
+					t.Fatalf("patternLen=%d trial=%d distance(%q, %q, max=%d) = (%d,%v), want (%d,%v)", patternLen, trial, pattern, candidate, maxEdits, got, ok, want, wantOK)
+				}
+			}
+		}
+	}
+
+	// Exhaust every short binary string pair, including an empty candidate.
+	binaryStrings := []string{""}
+	for length := 1; length <= 5; length++ {
+		for bits := 0; bits < 1<<length; bits++ {
+			word := make([]byte, length)
+			for i := range word {
+				word[i] = "ab"[(bits>>i)&1]
+			}
+			binaryStrings = append(binaryStrings, string(word))
+		}
+	}
+	for _, pattern := range binaryStrings {
+		if pattern == "" {
+			continue
+		}
+		var masks [utf8.RuneSelf]uint64
+		for i := range pattern {
+			masks[pattern[i]] |= uint64(1) << i
+		}
+		for _, candidate := range binaryStrings {
+			want := naiveLevenshtein([]rune(pattern), []rune(candidate))
+			for maxEdits := 0; maxEdits <= 2; maxEdits++ {
+				got, ok := asciiLevenshteinWithin(len(pattern), candidate, maxEdits, &masks)
+				if wantOK := want <= maxEdits; ok != wantOK || ok && got != want {
+					t.Fatalf("binary distance(%q, %q, max=%d) = (%d,%v), want (%d,%v)", pattern, candidate, maxEdits, got, ok, want, wantOK)
+				}
+			}
+		}
+	}
+
+	// Pin the 64th-bit boundary plus valid ASCII NUL/DEL bytes.
+	boundary := "\x00" + strings.Repeat("a", 62) + "\x7f"
+	mutations := []string{
+		boundary,
+		"b" + boundary[1:],
+		boundary[:31] + "b" + boundary[32:],
+		boundary[:63] + "b",
+		boundary[:62],
+		boundary[:63],
+		boundary + "bb",
+	}
+	var masks [utf8.RuneSelf]uint64
+	for i := range boundary {
+		masks[boundary[i]] |= uint64(1) << i
+	}
+	for _, candidate := range mutations {
+		want := naiveLevenshtein([]rune(boundary), []rune(candidate))
+		got, ok := asciiLevenshteinWithin(len(boundary), candidate, want, &masks)
+		if !ok || got != want {
+			t.Fatalf("64-bit boundary distance(%q) = (%d,%v), want %d", candidate, got, ok, want)
+		}
+	}
+}
+
 // TestIsExpandable verifies word terms expand while CJK grams (all-unbounded
 // runs) and the empty term are exempt.
 func TestIsExpandable(t *testing.T) {
@@ -63,153 +147,220 @@ func TestIsExpandable(t *testing.T) {
 	}
 }
 
-// TestTermDictExpand covers exact/prefix/fuzzy expansion, the exact term coming
-// first, and the cap bounding the result deterministically.
+func expandedTerms(d *termDict, term string, prefix bool, edits, limit int) []string {
+	ids := d.expand(term, prefix, edits, limit)
+	out := make([]string, len(ids))
+	for i, id := range ids {
+		out[i] = d.terms[id]
+	}
+	return out
+}
+
+// TestTermDictExpand covers the semantic exact/prefix/fuzzy order, including
+// the combined-mode precedence and rune-counted prefix quality.
 func TestTermDictExpand(t *testing.T) {
 	d := newTermDict()
-	// Interned in this order, so ids are search=0 serch=1 searchh=2 xearch=3
-	// sea=4 searching=5 beta=6 (id order drives the deterministic scan).
 	for _, w := range []string{"search", "serch", "searchh", "xearch", "sea", "searching", "beta"} {
 		d.intern(w)
 	}
-	expandTerms := func(term string, prefix bool, edits, limit int) []string {
-		ids := d.expand(term, prefix, edits, limit)
-		out := make([]string, len(ids))
-		for i, id := range ids {
-			out[i] = d.terms[id]
-		}
-		return out
-	}
-	sorted := func(term string, prefix bool, edits, limit int) []string {
-		out := expandTerms(term, prefix, edits, limit)
-		sort.Strings(out)
-		return out
-	}
 
 	t.Run("exact only when no expansion", func(t *testing.T) {
-		if got := sorted("search", false, 0, 50); !equalStrings(got, []string{"search"}) {
+		if got := expandedTerms(d, "search", false, 0, 50); !equalStrings(got, []string{"search"}) {
 			t.Fatalf("exact = %v, want [search]", got)
 		}
 		if got := d.expand("absent", true, 2, 50); len(got) != 0 {
 			t.Fatalf("absent term = %v, want no matches", got)
 		}
 	})
-	t.Run("prefix reaches extending terms", func(t *testing.T) {
-		got := sorted("sea", true, 0, 50)
+	t.Run("prefix orders by extension then term", func(t *testing.T) {
+		got := expandedTerms(d, "sea", true, 0, 50)
 		if !equalStrings(got, []string{"sea", "search", "searchh", "searching"}) {
 			t.Fatalf("prefix 'sea' = %v, want [sea search searchh searching]", got)
 		}
 	})
-	t.Run("fuzzy reaches edit-distance-1 terms", func(t *testing.T) {
-		got := sorted("search", false, 1, 50)
+	t.Run("fuzzy orders by edit distance then term", func(t *testing.T) {
+		got := expandedTerms(d, "search", false, 1, 50)
 		if !equalStrings(got, []string{"search", "searchh", "serch", "xearch"}) {
 			t.Fatalf("fuzzy 'search' = %v, want [search searchh serch xearch]", got)
 		}
 	})
-	t.Run("exact term is always first", func(t *testing.T) {
-		got := expandTerms("search", true, 1, 50)
-		if len(got) == 0 || got[0] != "search" {
-			t.Fatalf("expansion = %v, want 'search' first", got)
+	t.Run("combined mode prefers prefix and deduplicates overlap", func(t *testing.T) {
+		both := newTermDict()
+		for _, term := range []string{"aaaa", "aaaab", "aaaaaa", "aaab", "baaa"} {
+			both.intern(term)
+		}
+		got := expandedTerms(both, "aaaa", true, 1, 50)
+		want := []string{"aaaa", "aaaab", "aaaaaa", "aaab", "baaa"}
+		if !equalStrings(got, want) {
+			t.Fatalf("combined expansion = %v, want %v", got, want)
 		}
 	})
-	t.Run("cap bounds the result", func(t *testing.T) {
-		got := expandTerms("sea", true, 0, 2)
-		if len(got) != 2 || got[0] != "sea" {
-			t.Fatalf("capped expansion = %v, want 2 entries starting with sea", got)
+	t.Run("prefix extension is counted in runes", func(t *testing.T) {
+		unicode := newTermDict()
+		for _, term := range []string{"é", "éaa", "é東", "éa"} {
+			unicode.intern(term)
+		}
+		got := expandedTerms(unicode, "é", true, 0, 50)
+		want := []string{"é", "éa", "é東", "éaa"}
+		if !equalStrings(got, want) {
+			t.Fatalf("unicode prefix expansion = %v, want %v", got, want)
+		}
+	})
+	t.Run("unicode fuzzy candidates use rune distance", func(t *testing.T) {
+		unicode := newTermDict()
+		for _, term := range []string{"cafe", "café", "cafés", "coffee"} {
+			unicode.intern(term)
+		}
+		if got, want := expandedTerms(unicode, "cafe", false, 1, 50), []string{"cafe", "café"}; !equalStrings(got, want) {
+			t.Fatalf("ASCII query Unicode candidate expansion = %v, want %v", got, want)
+		}
+		if got, want := expandedTerms(unicode, "café", false, 1, 50), []string{"café", "cafe", "cafés"}; !equalStrings(got, want) {
+			t.Fatalf("Unicode query expansion = %v, want %v", got, want)
+		}
+	})
+	t.Run("invalid UTF-8 stays on rune fallback", func(t *testing.T) {
+		invalid := newTermDict()
+		invalid.intern("\xfe")
+		// Go decodes each invalid byte as RuneError, so these terms have rune
+		// distance zero. Treating them as ASCII bytes would incorrectly return 1.
+		if got, want := expandedTerms(invalid, "\xff", false, 1, 50), []string{"\xfe"}; !equalStrings(got, want) {
+			t.Fatalf("invalid UTF-8 expansion = %q, want %q", got, want)
+		}
+	})
+	t.Run("65-byte query uses DP fallback", func(t *testing.T) {
+		query := strings.Repeat("a", 65)
+		candidate := query[:64] + "b"
+		long := newTermDict()
+		long.intern(candidate)
+		if got, want := expandedTerms(long, query, false, 1, 50), []string{candidate}; !equalStrings(got, want) {
+			t.Fatalf("65-byte expansion = %v, want one DP match", got)
 		}
 	})
 }
 
-// TestTermDictExpandMatchesReference proves the rune-length gate and reusable
-// DP buffers (#909) leave expand's result byte-identical to a naive
-// allocation-per-candidate oracle — same match set, same order, same cap
-// survivors — even after intern/release churn seeds tombstones and reused
-// (out-of-order) ids. referenceExpand shares no code with the optimized scan.
-func TestTermDictExpandMatchesReference(t *testing.T) {
-	rng := rand.New(rand.NewSource(9091))
-	d := newTermDict()
-	live := make(map[string]bool)
-	for i := 0; i < 4000; i++ {
-		w := randWord(rng)
-		d.intern(w)
-		live[w] = true
-		if rng.Intn(3) == 0 && len(live) > 0 { // churn: release a live term
-			for k := range live {
-				d.release(d.ids[k])
-				delete(live, k)
-				break
-			}
+// TestTermDictExpandHistoryIndependent builds the same >50-candidate vocabulary
+// in 100 insertion/release/reuse histories and compares the exact cap survivors
+// to an independent semantic oracle.
+func TestTermDictExpandHistoryIndependent(t *testing.T) {
+	vocabulary := []string{"aaaa"}
+	for i := 0; i < 80; i++ {
+		vocabulary = append(vocabulary, fmt.Sprintf("aaaa%03d", i))
+	}
+	for pos := 0; pos < 4; pos++ {
+		for ch := byte('b'); ch <= 'z'; ch++ {
+			word := []byte("aaaa")
+			word[pos] = ch
+			vocabulary = append(vocabulary, string(word))
 		}
 	}
-	queries := make([]string, 0, 40)
-	for k := range live {
-		queries = append(queries, k)
-		if len(queries) >= 20 {
-			break
-		}
+	for i := 0; i < 40; i++ {
+		vocabulary = append(vocabulary, fmt.Sprintf("noise%03d", i))
 	}
-	for i := 0; i < 20; i++ {
-		queries = append(queries, randWord(rng)) // include absent terms
-	}
-	kinds := []struct {
+
+	cases := []struct {
+		name   string
 		prefix bool
 		edits  int
-	}{{true, 0}, {false, 1}, {false, 2}, {true, 1}, {true, 2}}
-	for _, limit := range []int{3, 50, MaxTermExpansions} {
-		for _, q := range queries {
-			for _, k := range kinds {
-				got := d.expand(q, k.prefix, k.edits, limit)
-				want := referenceExpand(d, q, k.prefix, k.edits, limit)
-				if !slices.Equal(got, want) {
-					t.Fatalf("expand(%q, prefix=%v, edits=%d, limit=%d) = %v, want %v",
-						q, k.prefix, k.edits, limit, got, want)
-				}
+	}{
+		{"prefix", true, 0},
+		{"fuzzy", false, 2},
+		{"combined", true, 2},
+	}
+	rng := rand.New(rand.NewSource(1056))
+	var baseline map[string][]string
+	for trial := 0; trial < 100; trial++ {
+		order := append([]string(nil), vocabulary...)
+		rng.Shuffle(len(order), func(i, j int) { order[i], order[j] = order[j], order[i] })
+		d := newTermDict()
+		for _, term := range order {
+			d.intern(term)
+		}
+		// Force released-id reuse while restoring the identical live vocabulary.
+		for i := trial % 7; i < len(vocabulary); i += 7 {
+			d.release(d.ids[vocabulary[i]])
+		}
+		for i := len(vocabulary) - 1; i >= 0; i-- {
+			if _, live := d.ids[vocabulary[i]]; !live {
+				d.intern(vocabulary[i])
+			}
+		}
+
+		if baseline == nil {
+			baseline = make(map[string][]string, len(cases))
+		}
+		for _, tc := range cases {
+			gotIDs := d.expand("aaaa", tc.prefix, tc.edits, MaxTermExpansions)
+			wantIDs := referenceExpand(d, "aaaa", tc.prefix, tc.edits, MaxTermExpansions)
+			got := make([]string, len(gotIDs))
+			want := make([]string, len(wantIDs))
+			for i := range gotIDs {
+				got[i] = d.terms[gotIDs[i]]
+			}
+			for i := range wantIDs {
+				want[i] = d.terms[wantIDs[i]]
+			}
+			if !slices.Equal(got, want) {
+				t.Fatalf("trial=%d %s expansion = %v, want %v", trial, tc.name, got, want)
+			}
+			if trial == 0 {
+				baseline[tc.name] = append([]string(nil), got...)
+			} else if !slices.Equal(got, baseline[tc.name]) {
+				t.Fatalf("trial=%d %s expansion changed with history: got %v baseline %v", trial, tc.name, got, baseline[tc.name])
 			}
 		}
 	}
 }
 
-// referenceExpand is a deliberately naive mirror of termDict.expand used only as
-// an equivalence oracle: the exact id first, then a full id-order scan with
-// strings.HasPrefix and an un-gated full-matrix Levenshtein. It shares none of
-// expand's rune-length gate or reusable DP buffers, so a match confirms the
-// optimized scan is behaviour-preserving.
+// referenceExpand is a deliberately naive semantic oracle. It computes full
+// Levenshtein matrices and sorts every match, sharing neither the optimized DP
+// rows nor the bounded heap with termDict.expand.
 func referenceExpand(d *termDict, term string, prefix bool, maxEdits, limit int) []uint32 {
 	if limit <= 0 {
 		return nil
 	}
-	out := make([]uint32, 0)
-	seen := make(map[uint32]bool)
-	add := func(id uint32) bool {
-		if seen[id] {
-			return len(out) < limit
-		}
-		seen[id] = true
-		out = append(out, id)
-		return len(out) < limit
-	}
+	out := make([]uint32, 0, limit)
 	if id, ok := d.ids[term]; ok {
-		if !add(id) {
+		out = append(out, id)
+		if len(out) == limit {
 			return out
 		}
 	}
-	if !prefix && maxEdits <= 0 {
-		return out
+	type candidate struct {
+		id      uint32
+		term    string
+		kind    int
+		quality int
 	}
-	qr := []rune(term)
+	var candidates []candidate
 	for id, cand := range d.terms {
 		if cand == "" || cand == term {
 			continue
 		}
-		matched := prefix && strings.HasPrefix(cand, term)
-		if !matched && maxEdits > 0 {
-			matched = naiveLevenshtein([]rune(cand), qr) <= maxEdits
+		if prefix && strings.HasPrefix(cand, term) {
+			candidates = append(candidates, candidate{uint32(id), cand, 0, len([]rune(cand)) - len([]rune(term))})
+			continue
 		}
-		if matched {
-			if !add(uint32(id)) {
-				return out
+		if maxEdits > 0 {
+			distance := naiveLevenshtein([]rune(cand), []rune(term))
+			if distance <= maxEdits {
+				candidates = append(candidates, candidate{uint32(id), cand, 1, distance})
 			}
 		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].kind != candidates[j].kind {
+			return candidates[i].kind < candidates[j].kind
+		}
+		if candidates[i].quality != candidates[j].quality {
+			return candidates[i].quality < candidates[j].quality
+		}
+		return candidates[i].term < candidates[j].term
+	})
+	for _, candidate := range candidates {
+		if len(out) == limit {
+			break
+		}
+		out = append(out, candidate.id)
 	}
 	return out
 }
@@ -240,7 +391,7 @@ func naiveLevenshtein(a, b []rune) int {
 // TestSearchExpansion covers prefix and fuzzy term matching end to end: a query
 // that matches nothing exactly still finds the document once expansion is on.
 func TestSearchExpansion(t *testing.T) {
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 	idx.Index("d1", Text("lantern search index"))
 	idx.Index("d2", Text("beta gamma"))
 
@@ -273,7 +424,7 @@ func TestSearchExpansion(t *testing.T) {
 // MatchAll: each original query word is covered by ANY of its expansions, so a
 // two-word expanded query still requires both words, not both expansions of one.
 func TestSearchExpansionCoverage(t *testing.T) {
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 	idx.Index("both", Text("lantern search")) // lantern + search
 	idx.Index("oneL", Text("lantern here"))   // lantern only
 	idx.Index("oneS", Text("search here"))    // search only
@@ -294,7 +445,7 @@ func TestSearchExpansionCoverage(t *testing.T) {
 // TestSearchExpansionCJKExempt verifies a CJK query is not widened by fuzzy or
 // prefix expansion: its bigrams match exactly (Lucene CJKAnalyzer behavior).
 func TestSearchExpansionCJKExempt(t *testing.T) {
-	idx := NewInvertedIndex[string, Document](NewScriptAwareAnalyzer(), nil)
+	idx := NewInvertedIndex[string, Document](NewScriptAwareAnalyzer(), nil, compareStringID)
 	idx.Index("neko", Text("ねこがすき"))
 	idx.Index("inu", Text("いぬがすき"))
 
@@ -328,7 +479,7 @@ func randWord(rng *rand.Rand) string {
 // sub-benchmarks to decide whether a radix/automaton is worth adding.
 func BenchmarkSearchExpansion(b *testing.B) {
 	rng := rand.New(rand.NewSource(891))
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 	for i := 0; i < 20000; i++ {
 		idx.Index(fmt.Sprintf("d%05d", i), Text(randWord(rng)+" "+randWord(rng)+" "+randWord(rng)))
 	}
@@ -369,26 +520,104 @@ func buildExpandDict(size int) (*termDict, []string) {
 	return d, queries
 }
 
+// seedCapOverflowExpandDict replaces a bounded number of the dictionary's
+// random terms with one exact query term, more than MaxTermExpansions literal
+// continuations, and more than MaxTermExpansions edit-distance-1 neighbours.
+// The live dictionary size stays unchanged, while release/reuse churn makes
+// the benchmark independent of a favourable fresh-id layout.
+func seedCapOverflowExpandDict(d *termDict) string {
+	const query = "aaaaaaaa"
+	hot := []string{query}
+	for i := 0; i < 2*MaxTermExpansions; i++ {
+		hot = append(hot, fmt.Sprintf("%s%03d", query, i))
+	}
+	for pos := 0; pos < len(query); pos++ {
+		for replacement := byte('b'); replacement <= 'z'; replacement++ {
+			candidate := []byte(query)
+			candidate[pos] = replacement
+			hot = append(hot, string(candidate))
+		}
+	}
+
+	// A generated random term could theoretically equal a hot term. Only make
+	// room for genuinely new terms so the number of live dictionary entries is
+	// exactly preserved.
+	before := d.len()
+	hotSet := make(map[string]struct{}, len(hot))
+	for _, term := range hot {
+		hotSet[term] = struct{}{}
+	}
+	newTerms := hot[:0]
+	for _, term := range hot {
+		if _, exists := d.ids[term]; !exists {
+			newTerms = append(newTerms, term)
+		}
+	}
+	removed := 0
+	for id, term := range d.terms {
+		if term == "" {
+			continue
+		}
+		if _, keep := hotSet[term]; keep {
+			continue
+		}
+		d.release(uint32(id))
+		removed++
+		if removed == len(newTerms) {
+			break
+		}
+	}
+	for _, term := range newTerms {
+		d.intern(term)
+	}
+	if removed != len(newTerms) || d.len() != before {
+		panic("cap-overflow benchmark failed to preserve live dictionary size")
+	}
+	return query
+}
+
 // BenchmarkTermDictExpand isolates the dictionary-scan cost of termDict.expand
 // (#909) across dictionary sizes and expansion kinds. expand is O(dictionary):
 // prefix does a byte-prefix test per term, while fuzzy converts every candidate
-// to runes and runs bounded Levenshtein, so the sub-benchmarks expose whether a
-// sorted/radix structure is worth adding at each scale. Run under -bench only;
-// plain `go test` never pays for the 1M dictionary build.
+// to runes and runs bounded Levenshtein. The CapOverflow arms force more than
+// 50 semantic candidates after release/reuse churn, exposing the bounded heap's
+// selection cost instead of measuring only sparse matches. Together the arms
+// show whether a sorted/radix structure is worth adding at each scale. Each
+// sparse operation runs all eight fixed queries so benchmark calibration cannot
+// skew the query-length mix. Run under -bench only; plain `go test` never pays
+// for the 1M dictionary build.
 func BenchmarkTermDictExpand(b *testing.B) {
 	for _, size := range []int{10_000, 100_000, 1_000_000} {
 		d, queries := buildExpandDict(size)
 		b.Run(fmt.Sprintf("n=%d", size), func(b *testing.B) {
-			bench := func(b *testing.B, prefix bool, maxEdits int) {
+			bench := func(b *testing.B, query string, prefix bool, maxEdits int) {
 				b.ReportAllocs()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					expandSink = d.expand(queries[i%len(queries)], prefix, maxEdits, MaxTermExpansions)
+					expandSink = d.expand(query, prefix, maxEdits, MaxTermExpansions)
 				}
 			}
-			b.Run("Prefix", func(b *testing.B) { bench(b, true, 0) })
-			b.Run("Fuzzy1", func(b *testing.B) { bench(b, false, 1) })
-			b.Run("Fuzzy2", func(b *testing.B) { bench(b, false, 2) })
+			benchSparse := func(b *testing.B, prefix bool, maxEdits int) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					// One operation always executes the complete fixed query set.
+					// This prevents b.N calibration differences from changing the
+					// query-length mix between implementations.
+					for _, query := range queries {
+						expandSink = d.expand(query, prefix, maxEdits, MaxTermExpansions)
+					}
+				}
+			}
+			b.Run("Prefix", func(b *testing.B) { benchSparse(b, true, 0) })
+			b.Run("Fuzzy1", func(b *testing.B) { benchSparse(b, false, 1) })
+			b.Run("Fuzzy2", func(b *testing.B) { benchSparse(b, false, 2) })
+
+			hotQuery := seedCapOverflowExpandDict(d)
+			b.Run("CapOverflowPrefix", func(b *testing.B) { bench(b, hotQuery, true, 0) })
+			b.Run("CapOverflowFuzzy1", func(b *testing.B) { bench(b, hotQuery, false, 1) })
+			b.Run("CapOverflowFuzzy2", func(b *testing.B) { bench(b, hotQuery, false, 2) })
+			b.Run("CapOverflowCombined", func(b *testing.B) { bench(b, hotQuery, true, 2) })
 		})
 	}
 }

--- a/core/search/helpers_test.go
+++ b/core/search/helpers_test.go
@@ -1,5 +1,13 @@
 package search
 
+import (
+	"cmp"
+	"strings"
+)
+
+func compareStringID(a, b string) int { return strings.Compare(a, b) }
+func compareIntID(a, b int) int       { return cmp.Compare(a, b) }
+
 // equalStrings reports whether a and b contain the same strings in the same
 // order. Shared by the search package's white-box tests.
 func equalStrings(a, b []string) bool {

--- a/core/search/inverted_index.go
+++ b/core/search/inverted_index.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"container/heap"
+	"math"
 	"sort"
 	"sync"
 )
@@ -15,8 +16,8 @@ import (
 // It splits the two responsibilities of relevance search. The index owns
 // matching and the statistics behind it — per-document term frequencies and
 // document lengths — while a pluggable Scorer (BM25 by default) turns those
-// statistics into the ranking. Search returns hits ordered by descending
-// score.
+// statistics into the ranking. Search returns hits in the stable total order
+// (score descending, caller-provided typed ID comparator ascending).
 //
 // Terms live in per-class tables (#888): each TokenClass has its own term
 // dictionary, postings, and corpus statistics, so a dual-channel analyzer
@@ -32,6 +33,12 @@ import (
 type InvertedIndex[S comparable, D Document] struct {
 	analyzer Analyzer
 	scorer   Scorer
+	// compareID defines the stable ascending typed-ID order used to break
+	// equal-score ties.
+	// It is required because comparable alone does not imply an order, and an
+	// internal document ordinal would make externally visible ranking depend on
+	// insertion/delete history.
+	compareID func(S, S) int
 	// positions is fixed at construction (WithPositions): when set, Index
 	// records each primary-channel (ClassWord) term's token positions so
 	// SearchPhrase and the proximity boost can tell an exact phrase from
@@ -131,10 +138,15 @@ func WithProximityWeight(w float64) IndexOption {
 
 // NewInvertedIndex returns an empty index that analyzes both documents and
 // queries with analyzer and ranks matches with scorer. Passing a nil scorer
-// installs BM25 with the standard parameters (K1 = 1.2, B = 0.75). D is the
-// document type it accepts; use Text to index plain strings. Pass
-// WithPositions to enable phrase and proximity queries (SearchPhrase).
-func NewInvertedIndex[S comparable, D Document](analyzer Analyzer, scorer Scorer, opts ...IndexOption) *InvertedIndex[S, D] {
+// installs BM25 with the standard parameters (K1 = 1.2, B = 0.75). compareID
+// is the mandatory ascending total order for equal-score document IDs; it must
+// be stable across processes/replicas. D is the document type it accepts; use
+// Text to index plain strings. Pass WithPositions to enable phrase and
+// proximity queries (SearchPhrase).
+func NewInvertedIndex[S comparable, D Document](analyzer Analyzer, scorer Scorer, compareID func(S, S) int, opts ...IndexOption) *InvertedIndex[S, D] {
+	if compareID == nil {
+		panic("search: NewInvertedIndex compareID must not be nil")
+	}
 	if scorer == nil {
 		scorer = BM25{K1: DefaultBM25K1, B: DefaultBM25B}
 	}
@@ -146,6 +158,7 @@ func NewInvertedIndex[S comparable, D Document](analyzer Analyzer, scorer Scorer
 	idx := &InvertedIndex[S, D]{
 		analyzer:        analyzer,
 		scorer:          scorer,
+		compareID:       compareID,
 		positions:       cfg.positions,
 		proximityWeight: cfg.proximityWeight,
 		ords:            newOrdinals[S](),
@@ -364,7 +377,7 @@ func (idx *InvertedIndex[S, D]) deleteLocked(id S) {
 // in the query weights a document only once; the same spelling on two token
 // classes counts once per class, since the channels carry distinct evidence.
 // A query with no analyzable terms, or one that matches nothing, returns nil;
-// ties in score have an unspecified order.
+// equal scores use the required typed document-ID comparator ascending.
 //
 // Search is the MatchAny case of SearchMatch; pass a MatchOptions to require
 // every query term (MatchAll) or a minimum number of them (MatchMinShould).
@@ -372,18 +385,30 @@ func (idx *InvertedIndex[S, D]) Search(query string) []Result[S] {
 	return idx.SearchMatch(query, MatchOptions{})
 }
 
-// queryTerms analyzes query and collapses the tokens to the distinct
-// (class, term) set, so a term repeated in the query contributes a document's
-// weight once per channel, matching the boolean union.
-func (idx *InvertedIndex[S, D]) queryTerms(query string) map[Token]struct{} {
+// queryTerms analyzes query and collapses the tokens to a stable, distinct
+// (class, term) slice, so a term repeated in the query contributes a document's
+// weight once per channel and floating-point contributions are accumulated in
+// the same order on every call and replica.
+func (idx *InvertedIndex[S, D]) queryTerms(query string) []Token {
 	tokens := idx.analyzer.Analyze(query)
 	if len(tokens) == 0 {
 		return nil
 	}
-	queryTerms := make(map[Token]struct{}, len(tokens))
+	seen := make(map[Token]struct{}, len(tokens))
+	queryTerms := make([]Token, 0, len(tokens))
 	for _, token := range tokens {
-		queryTerms[token] = struct{}{}
+		if _, ok := seen[token]; ok {
+			continue
+		}
+		seen[token] = struct{}{}
+		queryTerms = append(queryTerms, token)
 	}
+	sort.Slice(queryTerms, func(i, j int) bool {
+		if queryTerms[i].Class != queryTerms[j].Class {
+			return queryTerms[i].Class < queryTerms[j].Class
+		}
+		return queryTerms[i].Term < queryTerms[j].Term
+	})
 	return queryTerms
 }
 
@@ -391,9 +416,9 @@ func (idx *InvertedIndex[S, D]) queryTerms(query string) map[Token]struct{} {
 // callers must hold idx.mu (read or write). A query token with an undefined
 // class matches nothing — the write side panics on such tokens, so no posting
 // can exist for one.
-func (idx *InvertedIndex[S, D]) scoreLocked(queryTerms map[Token]struct{}) map[uint32]float64 {
+func (idx *InvertedIndex[S, D]) scoreLocked(queryTerms []Token) map[uint32]float64 {
 	scores := make(map[uint32]float64)
-	for token := range queryTerms {
+	for _, token := range queryTerms {
 		if int(token.Class) >= numTokenClasses {
 			continue
 		}
@@ -413,17 +438,68 @@ func (idx *InvertedIndex[S, D]) scoreLocked(queryTerms map[Token]struct{}) map[u
 		avgLen := float64(cp.totalLen) / float64(cp.docCount)
 		for it := pl.docs.Iterator(); it.HasNext(); {
 			ord := it.Next()
-			scores[ord] += idx.scorer.Score(TermStats{
+			addScore(scores, ord, idx.scorer.Score(TermStats{
 				TF:     pl.tf(ord),
 				DF:     df,
 				N:      cp.docCount,
 				DocLen: idx.docs[ord].lengths[token.Class],
 				AvgLen: avgLen,
 				Class:  token.Class,
-			})
+			}))
 		}
 	}
+	dropNonFiniteScores(scores)
 	return scores
+}
+
+// addScore accumulates one contribution while poisoning a document whose
+// scorer emits NaN/Inf (or whose finite contributions overflow). The poison is
+// removed by dropNonFiniteScores, so non-finite custom scorer output can never
+// enter sorting or heap selection.
+func addScore(scores map[uint32]float64, ord uint32, contribution float64) {
+	current, exists := scores[ord]
+	if exists && math.IsNaN(current) {
+		return
+	}
+	if math.IsNaN(contribution) || math.IsInf(contribution, 0) {
+		scores[ord] = math.NaN()
+		return
+	}
+	total := current + contribution
+	if math.IsNaN(total) || math.IsInf(total, 0) {
+		scores[ord] = math.NaN()
+		return
+	}
+	scores[ord] = total
+}
+
+func dropNonFiniteScores(scores map[uint32]float64) {
+	for ord, score := range scores {
+		if math.IsNaN(score) || math.IsInf(score, 0) {
+			delete(scores, ord)
+		}
+	}
+}
+
+// betterResult is the single external ranking contract: score descending,
+// then the caller-supplied document ID order ascending.
+func (idx *InvertedIndex[S, D]) betterResult(a, b Result[S]) bool {
+	if a.Score != b.Score {
+		return a.Score > b.Score
+	}
+	return idx.compareID(a.ID, b.ID) < 0
+}
+
+func (idx *InvertedIndex[S, D]) rankedResultsLocked(scores map[uint32]float64) []Result[S] {
+	results := make([]Result[S], 0, len(scores))
+	for ord, score := range scores {
+		if math.IsNaN(score) || math.IsInf(score, 0) {
+			continue
+		}
+		results = append(results, Result[S]{ID: idx.docs[ord].id, Score: score})
+	}
+	sort.Slice(results, func(i, j int) bool { return idx.betterResult(results[i], results[j]) })
+	return results
 }
 
 // SearchTopK is the bounded-selection sibling of Search (#841): it computes
@@ -448,9 +524,9 @@ func (idx *InvertedIndex[S, D]) scoreLocked(queryTerms map[Token]struct{}) map[u
 // idx.mu — so no cycle is possible. accept must not call back into this
 // index's write methods.
 //
-// Results are ordered by descending score; ties at the k-th boundary keep an
-// unspecified subset, matching Search's unspecified tie order. k <= 0, an
-// unanalyzable query, or zero accepted matches return nil.
+// Results use the index's total order (score DESC, typed ID comparator ASC),
+// including at the k-th boundary. k <= 0, an unanalyzable query, or zero
+// accepted matches return nil.
 //
 // SearchTopK is the MatchAny case of SearchMatchTopK.
 func (idx *InvertedIndex[S, D]) SearchTopK(query string, k int, accept func(id S) bool) []Result[S] {
@@ -460,32 +536,35 @@ func (idx *InvertedIndex[S, D]) SearchTopK(query string, k int, accept func(id S
 // selectTopKLocked returns the k highest-scoring documents in scores that pass
 // accept, as a descending-ranked slice. It is the bounded-selection phase
 // shared by SearchTopK and SearchPhraseTopK: a size-k min-heap holds the
-// current best, accept is consulted lazily (only once a candidate's score
-// clears the heap boundary) so rejection never scales with the match set, and
-// ties at the k-th boundary keep an unspecified subset. Callers must hold
+// current best, and accept is consulted lazily only after a candidate clears
+// the same total-order boundary used by exhaustive ranking. Callers must hold
 // idx.mu; k > 0 is the caller's precondition.
 func (idx *InvertedIndex[S, D]) selectTopKLocked(scores map[uint32]float64, k int, accept func(id S) bool) []Result[S] {
-	h := topKHeap[S]{entries: make([]Result[S], 0, k)}
+	h := topKHeap[S]{entries: make([]Result[S], 0, k), better: idx.betterResult}
 	for ord, score := range scores {
-		if len(h.entries) == k && score <= h.entries[0].Score {
+		if math.IsNaN(score) || math.IsInf(score, 0) {
 			continue
 		}
 		id := idx.docs[ord].id
+		candidate := Result[S]{ID: id, Score: score}
+		if len(h.entries) == k && !idx.betterResult(candidate, h.entries[0]) {
+			continue
+		}
 		if accept != nil && !accept(id) {
 			continue
 		}
 		if len(h.entries) < k {
-			heap.Push(&h, Result[S]{ID: id, Score: score})
+			heap.Push(&h, candidate)
 			continue
 		}
-		h.entries[0] = Result[S]{ID: id, Score: score}
+		h.entries[0] = candidate
 		heap.Fix(&h, 0)
 	}
 	if len(h.entries) == 0 {
 		return nil
 	}
 	out := h.entries
-	sort.Slice(out, func(i, j int) bool { return out[i].Score > out[j].Score })
+	sort.Slice(out, func(i, j int) bool { return idx.betterResult(out[i], out[j]) })
 	return out
 }
 
@@ -493,12 +572,15 @@ func (idx *InvertedIndex[S, D]) selectTopKLocked(scores map[uint32]float64, k in
 // retained hit, evicted whenever a stronger accepted candidate arrives.
 type topKHeap[S comparable] struct {
 	entries []Result[S]
+	better  func(Result[S], Result[S]) bool
 }
 
-func (h topKHeap[S]) Len() int           { return len(h.entries) }
-func (h topKHeap[S]) Less(i, j int) bool { return h.entries[i].Score < h.entries[j].Score }
-func (h topKHeap[S]) Swap(i, j int)      { h.entries[i], h.entries[j] = h.entries[j], h.entries[i] }
-func (h *topKHeap[S]) Push(x any)        { h.entries = append(h.entries, x.(Result[S])) }
+func (h topKHeap[S]) Len() int { return len(h.entries) }
+func (h topKHeap[S]) Less(i, j int) bool {
+	return h.better(h.entries[j], h.entries[i]) // weakest result at the root
+}
+func (h topKHeap[S]) Swap(i, j int) { h.entries[i], h.entries[j] = h.entries[j], h.entries[i] }
+func (h *topKHeap[S]) Push(x any)   { h.entries = append(h.entries, x.(Result[S])) }
 func (h *topKHeap[S]) Pop() any {
 	old := h.entries
 	n := len(old)

--- a/core/search/inverted_index_test.go
+++ b/core/search/inverted_index_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/rand"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -26,7 +27,7 @@ func (fakeAnalyzer) Analyze(text string) []Token {
 }
 
 func TestInvertedIndex(t *testing.T) {
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 	idx.Index("doc1", Text("Alpha Beta"))
 	idx.Index("doc2", Text("beta gamma"))
 
@@ -55,7 +56,7 @@ func TestInvertedIndex(t *testing.T) {
 }
 
 func TestInvertedIndexDelete(t *testing.T) {
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 	idx.Index("doc1", Text("alpha beta"))
 	idx.Index("doc2", Text("beta gamma"))
 
@@ -96,7 +97,7 @@ func TestInvertedIndexDelete(t *testing.T) {
 // entries/length, and is a no-op for an empty input. It is the batch sibling
 // of Delete (#738).
 func TestInvertedIndexDeleteMany(t *testing.T) {
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 	idx.Index("doc1", Text("alpha beta"))
 	idx.Index("doc2", Text("beta gamma"))
 	idx.Index("doc3", Text("gamma delta"))
@@ -133,7 +134,7 @@ func TestInvertedIndexDeleteMany(t *testing.T) {
 }
 
 func TestInvertedIndexReindexReplaces(t *testing.T) {
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 	idx.Index("doc1", Text("alpha beta"))
 	// Re-index the same id with new text: the old terms must not linger.
 	idx.Index("doc1", Text("gamma"))
@@ -163,7 +164,7 @@ func TestInvertedIndexReindexReplaces(t *testing.T) {
 // all rank a document higher, and a query term repeated does not double-count.
 func TestInvertedIndexRanking(t *testing.T) {
 	t.Run("higher term frequency ranks first", func(t *testing.T) {
-		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 		idx.Index("more", Text("go go go rust"))
 		idx.Index("less", Text("go rust python"))
 		res := idx.Search("go")
@@ -179,7 +180,7 @@ func TestInvertedIndexRanking(t *testing.T) {
 	})
 
 	t.Run("shorter document ranks first at equal term frequency", func(t *testing.T) {
-		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 		idx.Index("short", Text("go rust"))
 		idx.Index("long", Text("go rust python java perl"))
 		res := idx.Search("go")
@@ -189,7 +190,7 @@ func TestInvertedIndexRanking(t *testing.T) {
 	})
 
 	t.Run("rarer query term lifts its document", func(t *testing.T) {
-		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 		idx.Index("a", Text("common rare"))
 		idx.Index("b", Text("common x"))
 		idx.Index("c", Text("common y"))
@@ -200,7 +201,7 @@ func TestInvertedIndexRanking(t *testing.T) {
 	})
 
 	t.Run("repeated query term scored once", func(t *testing.T) {
-		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 		idx.Index("d", Text("go rust"))
 		once := idx.Search("go")
 		twice := idx.Search("go go")
@@ -215,7 +216,7 @@ func TestInvertedIndexRanking(t *testing.T) {
 // final document count is deterministic: each writer keeps its odd-indexed
 // documents and deletes the even-indexed ones.
 func TestInvertedIndexConcurrent(t *testing.T) {
-	idx := NewInvertedIndex[int, Text](NewAnalyzer([]Normalizer{LowercaseNormalizer{}}, UnicodeTokenizer{}, nil), nil)
+	idx := NewInvertedIndex[int, Text](NewAnalyzer([]Normalizer{LowercaseNormalizer{}}, UnicodeTokenizer{}, nil), nil, compareIntID)
 
 	const writers = 8
 	const docsPerWriter = 200
@@ -251,11 +252,11 @@ func TestInvertedIndexConcurrent(t *testing.T) {
 // semantics.
 func TestInvertedIndexPrepared(t *testing.T) {
 	t.Run("IndexPrepared matches Index", func(t *testing.T) {
-		viaIndex := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+		viaIndex := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 		viaIndex.Index("doc1", Text("Alpha Beta"))
 		viaIndex.Index("doc2", Text("beta gamma"))
 
-		viaPrepared := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+		viaPrepared := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 		viaPrepared.IndexPrepared("doc1", viaPrepared.Prepare(Text("Alpha Beta")))
 		viaPrepared.IndexPrepared("doc2", viaPrepared.Prepare(Text("beta gamma")))
 
@@ -271,7 +272,7 @@ func TestInvertedIndexPrepared(t *testing.T) {
 	})
 
 	t.Run("empty prepared removes id", func(t *testing.T) {
-		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 		idx.IndexPrepared("doc1", idx.Prepare(Text("alpha beta")))
 		// Re-index doc1 with a document that analyzes to no terms: its postings
 		// must be dropped, matching Index's replace-with-empty behavior.
@@ -282,7 +283,7 @@ func TestInvertedIndexPrepared(t *testing.T) {
 	})
 
 	t.Run("IndexManyPrepared applies batch last-write", func(t *testing.T) {
-		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 		// doc1 appears twice; the later item must win (replace semantics in
 		// slice order). doc2's first document is later replaced by an empty one,
 		// so it must be absent at the end.
@@ -343,7 +344,7 @@ var benchVocab = []string{
 }
 
 func buildBigramIndex(corpus map[string]Text) *InvertedIndex[string, Text] {
-	idx := NewInvertedIndex[string, Text](bigramAnalyzer(), nil)
+	idx := NewInvertedIndex[string, Text](bigramAnalyzer(), nil, compareStringID)
 	for id, doc := range corpus {
 		idx.Index(id, doc)
 	}
@@ -355,7 +356,7 @@ func buildBigramIndex(corpus map[string]Text) *InvertedIndex[string, Text] {
 // state overhead. The bigram analyzer emits every term on the primary channel,
 // so every term carries positions — the worst case for the position store.
 func buildBigramIndexWithPositions(corpus map[string]Text) *InvertedIndex[string, Text] {
-	idx := NewInvertedIndex[string, Text](bigramAnalyzer(), nil, WithPositions())
+	idx := NewInvertedIndex[string, Text](bigramAnalyzer(), nil, compareStringID, WithPositions())
 	for id, doc := range corpus {
 		idx.Index(id, doc)
 	}
@@ -507,24 +508,16 @@ func BenchmarkSearchPhrase(b *testing.B) {
 }
 
 // TestSearchTopK property-checks the bounded selection (#841) against the
-// reference pipeline "full Search → filter by accept → truncate to k":
-// result length, membership, per-id scores, and the descending score
-// multiset must all agree (tie order at the k-th boundary is free).
+// reference pipeline "full Search → filter by accept → truncate to k". The
+// complete Result slice must agree exactly, including equal-score boundary
+// membership and score bits.
 func TestSearchTopK(t *testing.T) {
 	idx := NewInvertedIndex[string, Text](NewAnalyzer(
 		[]Normalizer{LowercaseNormalizer{}},
 		NGramTokenizer{N: 2},
 		nil,
-	), nil)
+	), nil, compareStringID)
 	rng := rand.New(rand.NewSource(841))
-	// Search and SearchTopK both accumulate BM25 contributions while iterating
-	// the distinct-term set (a Go map), so the floating-point addition order —
-	// and therefore the last ULP of a multi-term score — can differ between
-	// any two calls. Compare scores with a relative tolerance, not bitwise.
-	closeEnough := func(a, b float64) bool {
-		diff := math.Abs(a - b)
-		return diff <= 1e-9*math.Max(math.Abs(a), math.Abs(b))
-	}
 	words := []string{"alpha", "alps", "altitude", "beta", "bethel", "gamma", "gambit", "delta"}
 	docs := make(map[string]string, 120)
 	for i := 0; i < 120; i++ {
@@ -549,34 +542,13 @@ func TestSearchTopK(t *testing.T) {
 						want = append(want, r)
 					}
 				}
-				sort.SliceStable(want, func(i, j int) bool { return want[i].Score > want[j].Score })
 				if len(want) > k {
 					want = want[:k]
 				}
 
 				got := idx.SearchTopK(query, k, accept)
-				if len(got) != len(want) {
-					t.Fatalf("q=%q accept=%s k=%d: len=%d, want %d", query, name, k, len(got), len(want))
-				}
-				fullScore := make(map[string]float64, len(full))
-				for _, r := range full {
-					fullScore[r.ID] = r.Score
-				}
-				for i, r := range got {
-					if i > 0 && got[i-1].Score < r.Score {
-						t.Fatalf("q=%q accept=%s k=%d: not descending at %d: %v", query, name, k, i, got)
-					}
-					if s, ok := fullScore[r.ID]; !ok || !closeEnough(s, r.Score) {
-						t.Fatalf("q=%q accept=%s k=%d: id %s score %v disagrees with full search (%v, %v)", query, name, k, r.ID, r.Score, s, ok)
-					}
-					if accept != nil && !accept(r.ID) {
-						t.Fatalf("q=%q accept=%s k=%d: rejected id %s returned", query, name, k, r.ID)
-					}
-				}
-				for i := range got {
-					if !closeEnough(got[i].Score, want[i].Score) {
-						t.Fatalf("q=%q accept=%s k=%d: score multiset diverges at %d: got %v want %v", query, name, k, i, got, want)
-					}
+				if !slices.Equal(got, want) {
+					t.Fatalf("q=%q accept=%s k=%d: got %v, want %v", query, name, k, got, want)
 				}
 			}
 		}
@@ -592,6 +564,142 @@ func TestSearchTopK(t *testing.T) {
 	})
 }
 
+// TestSearchOrderingIndependentOfHistory proves the externally visible total
+// order is independent of document ordinals, insertion order, and delete /
+// reinsert churn. k deliberately cuts through a 64-way score tie.
+func TestSearchOrderingIndependentOfHistory(t *testing.T) {
+	ids := make([]string, 64)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("doc-%03d", i)
+	}
+	build := func(order []string, churn bool) *InvertedIndex[string, Text] {
+		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
+		for _, id := range order {
+			idx.Index(id, Text("common stable"))
+		}
+		if churn {
+			for i := 0; i < len(ids); i += 3 {
+				idx.Index(ids[i], Text("transient history term"))
+			}
+			for i := len(ids) - 1; i >= 0; i -= 3 {
+				idx.Index(ids[i], Text("common stable"))
+			}
+		}
+		return idx
+	}
+
+	reverse := append([]string(nil), ids...)
+	slices.Reverse(reverse)
+	random := append([]string(nil), ids...)
+	rand.New(rand.NewSource(1056)).Shuffle(len(random), func(i, j int) { random[i], random[j] = random[j], random[i] })
+	histories := []struct {
+		name  string
+		order []string
+		churn bool
+	}{
+		{"forward", ids, false},
+		{"reverse", reverse, false},
+		{"random", random, false},
+		{"release-reuse", random, true},
+	}
+
+	var baseline []Result[string]
+	for _, history := range histories {
+		t.Run(history.name, func(t *testing.T) {
+			idx := build(history.order, history.churn)
+			full := idx.Search("common stable")
+			if got := idsOf(full); !slices.Equal(got, ids) {
+				t.Fatalf("full order = %v, want lexical IDs", got)
+			}
+			if baseline == nil {
+				baseline = append([]Result[string](nil), full...)
+			} else if !slices.Equal(full, baseline) {
+				t.Fatalf("full results differ from baseline:\n got  %v\n want %v", full, baseline)
+			}
+			wantTop := baseline[:10]
+			for repeat := 0; repeat < 100; repeat++ {
+				if got := idx.SearchTopK("common stable", 10, nil); !slices.Equal(got, wantTop) {
+					t.Fatalf("repeat %d top-k = %v, want %v", repeat, got, wantTop)
+				}
+			}
+		})
+	}
+}
+
+// TestSearchScoreBitsRepeat verifies sorted query clauses fix floating-point
+// addition order and the resulting near-tie membership. The two small
+// contributions disappear when added after 1e16, but survive when accumulated
+// first; a map-order implementation can therefore flip both score bits and k=1.
+func TestSearchScoreBitsRepeat(t *testing.T) {
+	scorer := ScorerFunc(func(stats TermStats) float64 {
+		if stats.TF == 1 {
+			return 1e16
+		}
+		return 1
+	})
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, scorer, compareStringID)
+	idx.Index("huge-first", Text("a b b c c c")) // lexical contribution order: 1e16, 1, 1
+	idx.Index("huge-last", Text("a a b b c"))    // lexical contribution order: 1, 1, 1e16
+	want := []Result[string]{
+		{ID: "huge-last", Score: 1e16 + 2},
+		{ID: "huge-first", Score: 1e16},
+	}
+	for _, query := range []string{"a b c", "c a b", "b c a"} {
+		for repeat := 0; repeat < 100; repeat++ {
+			got := idx.Search(query)
+			if !slices.Equal(got, want) {
+				t.Fatalf("query %q repeat %d results = %v, want %v", query, repeat, got, want)
+			}
+			for i := range got {
+				if bits, wantBits := math.Float64bits(got[i].Score), math.Float64bits(want[i].Score); bits != wantBits {
+					t.Fatalf("query %q repeat %d result %d score bits = %x, want %x", query, repeat, i, bits, wantBits)
+				}
+			}
+			if top := idx.SearchTopK(query, 1, nil); !slices.Equal(top, want[:1]) {
+				t.Fatalf("query %q repeat %d top-k = %v, want %v", query, repeat, top, want[:1])
+			}
+		}
+	}
+}
+
+// TestSearchDropsNonFiniteScores keeps malformed custom scorer output out of
+// exhaustive and bounded ranking.
+func TestSearchDropsNonFiniteScores(t *testing.T) {
+	scorer := ScorerFunc(func(stats TermStats) float64 {
+		switch stats.TF {
+		case 1:
+			return math.NaN()
+		case 2:
+			return math.Inf(1)
+		case 3:
+			return math.Inf(-1)
+		default:
+			return 1
+		}
+	})
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, scorer, compareStringID)
+	idx.Index("nan", Text("x"))
+	idx.Index("positive-infinity", Text("x x"))
+	idx.Index("negative-infinity", Text("x x x"))
+	idx.Index("finite", Text("x x x x"))
+	want := []Result[string]{{ID: "finite", Score: 1}}
+	if got := idx.Search("x"); !slices.Equal(got, want) {
+		t.Fatalf("Search non-finite scores = %v, want %v", got, want)
+	}
+	if got := idx.SearchTopK("x", 10, nil); !slices.Equal(got, want) {
+		t.Fatalf("SearchTopK non-finite scores = %v, want %v", got, want)
+	}
+}
+
+func TestNewInvertedIndexRequiresComparator(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("nil comparator did not panic")
+		}
+	}()
+	NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, nil)
+}
+
 // BenchmarkSearchTopKBroadQuery pits the bounded selection against the full
 // sort on the workload #841 targets: a two-character query over a large
 // corpus (the bigram analyzer makes it match nearly everything), keeping
@@ -601,7 +709,7 @@ func BenchmarkSearchTopKBroadQuery(b *testing.B) {
 		[]Normalizer{LowercaseNormalizer{}},
 		NGramTokenizer{N: 2},
 		nil,
-	), nil)
+	), nil, compareStringID)
 	for i := 0; i < 20000; i++ {
 		idx.Index(fmt.Sprintf("doc-%05d", i), Text(fmt.Sprintf("alpha beta gamma delta %05d", i)))
 	}
@@ -632,6 +740,7 @@ func TestInvertedIndexDualClass(t *testing.T) {
 		return NewInvertedIndex[string, Text](
 			NewScriptAwareAnalyzer(),
 			ClassWeighted{Base: BM25{K1: DefaultBM25K1, B: DefaultBM25B}, GramWeight: DefaultGramWeight},
+			compareStringID,
 		)
 	}
 
@@ -683,7 +792,7 @@ func TestInvertedIndexDualClass(t *testing.T) {
 		bad := AnalyzerFunc(func(text string) []Token {
 			return []Token{{Term: text, Class: TokenClass(9)}}
 		})
-		idx := NewInvertedIndex[string, Text](bad, nil)
+		idx := NewInvertedIndex[string, Text](bad, nil, compareStringID)
 		defer func() {
 			if recover() == nil {
 				t.Fatal("indexing an undefined TokenClass did not panic")

--- a/core/search/match_mode.go
+++ b/core/search/match_mode.go
@@ -1,7 +1,5 @@
 package search
 
-import "sort"
-
 // MatchMode selects how a multi-term query's word-channel terms combine to
 // decide which documents match. It governs membership only — the Scorer still
 // ranks whatever matches — and counts distinct query terms on the primary
@@ -52,8 +50,8 @@ type MatchOptions struct {
 // raising precision on multi-word queries; the score is unchanged (still the
 // full word+gram BM25 sum), so ranking within the narrowed set is identical to
 // the OR-union's ranking of the same documents. A query with no analyzable
-// terms, or one that nothing satisfies, returns nil; ties in score have an
-// unspecified order.
+// terms, or one that nothing satisfies, returns nil. Equal scores use the
+// index's required typed document-ID comparator ascending.
 func (idx *InvertedIndex[S, D]) SearchMatch(query string, opts MatchOptions) []Result[S] {
 	queryTerms := idx.queryTerms(query)
 	if len(queryTerms) == 0 {
@@ -67,14 +65,7 @@ func (idx *InvertedIndex[S, D]) SearchMatch(query string, opts MatchOptions) []R
 	if len(scores) == 0 {
 		return nil
 	}
-	results := make([]Result[S], 0, len(scores))
-	for ord, score := range scores {
-		results = append(results, Result[S]{ID: idx.docs[ord].id, Score: score})
-	}
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].Score > results[j].Score
-	})
-	return results
+	return idx.rankedResultsLocked(scores)
 }
 
 // SearchMatchTopK is the bounded-selection sibling of SearchMatch, combining
@@ -108,7 +99,7 @@ func (idx *InvertedIndex[S, D]) SearchMatchTopK(query string, k int, accept func
 // expansion into both scoring and coverage); the exact-term default keeps using
 // scoreLocked + filterByCoverageLocked so it is byte-for-byte unchanged. Callers
 // must hold idx.mu.
-func (idx *InvertedIndex[S, D]) scoredMatchesLocked(queryTerms map[Token]struct{}, opts MatchOptions) map[uint32]float64 {
+func (idx *InvertedIndex[S, D]) scoredMatchesLocked(queryTerms []Token, opts MatchOptions) map[uint32]float64 {
 	var scores map[uint32]float64
 	if opts.expandsTerms() {
 		scores = idx.scoreClausesLocked(idx.buildClausesLocked(queryTerms, opts), opts)
@@ -122,6 +113,7 @@ func (idx *InvertedIndex[S, D]) scoredMatchesLocked(queryTerms map[Token]struct{
 		return scores
 	}
 	idx.applyProximityLocked(scores, queryTerms)
+	dropNonFiniteScores(scores)
 	return scores
 }
 
@@ -133,11 +125,11 @@ func (idx *InvertedIndex[S, D]) scoredMatchesLocked(queryTerms map[Token]struct{
 // bigrams, matching Lucene's CJKAnalyzer under AND. A query word term absent
 // from the corpus still raises the bar it can never meet, so an AND with any
 // missing term is correctly empty. Callers must hold idx.mu.
-func (idx *InvertedIndex[S, D]) filterByCoverageLocked(scores map[uint32]float64, queryTerms map[Token]struct{}, opts MatchOptions) {
+func (idx *InvertedIndex[S, D]) filterByCoverageLocked(scores map[uint32]float64, queryTerms []Token, opts MatchOptions) {
 	cp := &idx.classes[ClassWord]
 	numWords := 0
 	coverage := make(map[uint32]int, len(scores))
-	for token := range queryTerms {
+	for _, token := range queryTerms {
 		if token.Class != ClassWord {
 			continue
 		}

--- a/core/search/match_mode_test.go
+++ b/core/search/match_mode_test.go
@@ -11,7 +11,7 @@ import (
 // TestSearchMatchModes covers the three modes on a word-only analyzer, where
 // every match is a word match so the modes reduce to textbook boolean logic.
 func TestSearchMatchModes(t *testing.T) {
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 	idx.Index("all", Text("alpha beta gamma")) // alpha + beta
 	idx.Index("one", Text("alpha delta"))      // alpha only
 	idx.Index("other", Text("beta epsilon"))   // beta only
@@ -63,7 +63,7 @@ func TestMatchModeEquivalences(t *testing.T) {
 	rng := rand.New(rand.NewSource(890))
 	vocab := []string{"a", "b", "c", "d", "e"}
 	for trial := 0; trial < 60; trial++ {
-		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 		docWords := map[string]map[string]struct{}{}
 		nDocs := 5 + rng.Intn(40)
 		for i := 0; i < nDocs; i++ {
@@ -124,7 +124,7 @@ func TestMatchModeEquivalences(t *testing.T) {
 // a full page fills when one exists, k bounds it, accept filters, and k <= 0
 // returns nil.
 func TestSearchMatchTopK(t *testing.T) {
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil)
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 	idx.Index("all1", Text("alpha beta x"))
 	idx.Index("all2", Text("alpha beta y z"))
 	idx.Index("one", Text("alpha only"))
@@ -159,7 +159,7 @@ func TestSearchMatchTopK(t *testing.T) {
 // bigrams — the Lucene CJKAnalyzer + AND behavior — while MatchAny still
 // surfaces a document sharing only some.
 func TestSearchMatchModesCJK(t *testing.T) {
-	idx := NewInvertedIndex[string, Document](NewScriptAwareAnalyzer(), nil)
+	idx := NewInvertedIndex[string, Document](NewScriptAwareAnalyzer(), nil, compareStringID)
 	idx.Index("both", Text("データセット"))    // デー ータ タセ セッ ット
 	idx.Index("partial", Text("データベース")) // shares デー ータ only
 

--- a/core/search/phrase.go
+++ b/core/search/phrase.go
@@ -13,7 +13,8 @@ import "sort"
 // When the index was built without WithPositions the position refinement is
 // unavailable and SearchPhrase degrades to the pure AND-intersection (every
 // term present, order unverified). A query with no word terms, or one that
-// matches nothing, returns nil; ties in score have an unspecified order.
+// matches nothing, returns nil. Equal scores use the index's required typed
+// document-ID comparator ascending.
 func (idx *InvertedIndex[S, D]) SearchPhrase(query string) []Result[S] {
 	terms := idx.phraseQueryTerms(query)
 	if len(terms) == 0 {
@@ -28,12 +29,7 @@ func (idx *InvertedIndex[S, D]) SearchPhrase(query string) []Result[S] {
 		return nil
 	}
 	scores := idx.scorePhraseLocked(terms, ords)
-	results := make([]Result[S], 0, len(scores))
-	for ord, score := range scores {
-		results = append(results, Result[S]{ID: idx.docs[ord].id, Score: score})
-	}
-	sort.Slice(results, func(i, j int) bool { return results[i].Score > results[j].Score })
-	return results
+	return idx.rankedResultsLocked(scores)
 }
 
 // SearchPhraseTopK is the bounded-selection sibling of SearchPhrase, mirroring
@@ -157,16 +153,17 @@ func (idx *InvertedIndex[S, D]) scorePhraseLocked(terms []string, ords []uint32)
 		}
 		df := pl.cardinality()
 		for _, ord := range ords {
-			scores[ord] += idx.scorer.Score(TermStats{
+			addScore(scores, ord, idx.scorer.Score(TermStats{
 				TF:     pl.tf(ord),
 				DF:     df,
 				N:      cp.docCount,
 				DocLen: idx.docs[ord].lengths[ClassWord],
 				AvgLen: avgLen,
 				Class:  ClassWord,
-			})
+			}))
 		}
 	}
+	dropNonFiniteScores(scores)
 	return scores
 }
 

--- a/core/search/phrase_test.go
+++ b/core/search/phrase_test.go
@@ -1,6 +1,9 @@
 package search
 
 import (
+	"fmt"
+	"math"
+	"slices"
 	"sort"
 	"testing"
 )
@@ -9,7 +12,7 @@ import (
 // query's terms must occur at consecutive positions, so an adjacent phrase
 // matches while the same terms scattered apart do not.
 func TestSearchPhrase(t *testing.T) {
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, WithPositions())
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID, WithPositions())
 	idx.Index("adjacent", Text("the data set is clean"))   // data@1 set@2 — adjacent
 	idx.Index("scattered", Text("the set holds the data")) // set@1 data@4 — apart
 	idx.Index("partial", Text("only data here"))           // data only
@@ -52,7 +55,7 @@ func TestSearchPhrase(t *testing.T) {
 // repeated and adjacent in the document, exercising a term whose posting
 // carries more than one position.
 func TestSearchPhraseRepeatedWord(t *testing.T) {
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, WithPositions())
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID, WithPositions())
 	idx.Index("double", Text("go go rust")) // go@0 go@1
 	idx.Index("single", Text("go rust go")) // go@0 go@2 — not adjacent
 
@@ -66,7 +69,7 @@ func TestSearchPhraseRepeatedWord(t *testing.T) {
 // without WithPositions cannot verify adjacency, so SearchPhrase falls back to
 // the AND-intersection: every term present, order unverified.
 func TestSearchPhraseDegradesWithoutPositions(t *testing.T) {
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil) // no WithPositions
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID) // no WithPositions
 	idx.Index("adjacent", Text("the data set is clean"))
 	idx.Index("scattered", Text("the set holds the data"))
 	idx.Index("partial", Text("only data here")) // only one of the two terms
@@ -83,7 +86,7 @@ func TestSearchPhraseDegradesWithoutPositions(t *testing.T) {
 // survivor intact, and re-indexing with a different order updates them so a
 // stale phrase no longer matches.
 func TestSearchPhrasePositionsLifecycle(t *testing.T) {
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, WithPositions())
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID, WithPositions())
 	idx.Index("doc1", Text("data set one"))
 	idx.Index("doc2", Text("data set two"))
 
@@ -107,7 +110,7 @@ func TestSearchPhrasePositionsLifecycle(t *testing.T) {
 // query phrase's bigrams must occur at consecutive positions, exactly as they
 // do inside the matching run.
 func TestSearchPhraseCJK(t *testing.T) {
-	idx := NewInvertedIndex[string, Document](NewScriptAwareAnalyzer(), nil, WithPositions())
+	idx := NewInvertedIndex[string, Document](NewScriptAwareAnalyzer(), nil, compareStringID, WithPositions())
 	// "データセット" bigrams デー ータ タセ セッ ット appear consecutively here.
 	idx.Index("match", Text("データセットを解析する"))
 	// The same characters, but セット precedes データ — the phrase's bigrams
@@ -123,7 +126,7 @@ func TestSearchPhraseCJK(t *testing.T) {
 // TestSearchPhraseTopK covers the bounded-selection sibling: k caps the page,
 // accept filters candidates, and k <= 0 or no word terms return nil.
 func TestSearchPhraseTopK(t *testing.T) {
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, WithPositions())
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID, WithPositions())
 	idx.Index("a", Text("data set alpha"))
 	idx.Index("b", Text("data set beta data set"))
 	idx.Index("c", Text("no phrase here"))
@@ -154,6 +157,44 @@ func TestSearchPhraseTopK(t *testing.T) {
 			t.Fatalf("SearchPhraseTopK blank = %v, want nil", idsOf(got))
 		}
 	})
+}
+
+func TestSearchPhraseDeterministicTieOrder(t *testing.T) {
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID, WithPositions())
+	want := make([]string, 32)
+	for i := range want {
+		want[i] = fmt.Sprintf("doc-%03d", i)
+	}
+	for i := len(want) - 1; i >= 0; i-- {
+		idx.Index(want[i], Text("data set"))
+	}
+	if got := idsOf(idx.SearchPhrase("data set")); !slices.Equal(got, want) {
+		t.Fatalf("SearchPhrase order = %v, want %v", got, want)
+	}
+	for repeat := 0; repeat < 100; repeat++ {
+		if got := idsOf(idx.SearchPhraseTopK("data set", 10, nil)); !slices.Equal(got, want[:10]) {
+			t.Fatalf("repeat %d SearchPhraseTopK order = %v, want %v", repeat, got, want[:10])
+		}
+	}
+}
+
+func TestSearchPhraseDropsNonFiniteScores(t *testing.T) {
+	scorer := ScorerFunc(func(stats TermStats) float64 {
+		if stats.DocLen == 2 {
+			return math.NaN()
+		}
+		return 1
+	})
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, scorer, compareStringID, WithPositions())
+	idx.Index("invalid", Text("data set"))
+	idx.Index("finite", Text("data set extra"))
+	want := []string{"finite"}
+	if got := idsOf(idx.SearchPhrase("data set")); !slices.Equal(got, want) {
+		t.Fatalf("SearchPhrase non-finite = %v, want %v", got, want)
+	}
+	if got := idsOf(idx.SearchPhraseTopK("data set", 10, nil)); !slices.Equal(got, want) {
+		t.Fatalf("SearchPhraseTopK non-finite = %v, want %v", got, want)
+	}
 }
 
 // TestContainsSortedU32 covers the binary-search helper phrase adjacency relies

--- a/core/search/proximity.go
+++ b/core/search/proximity.go
@@ -26,7 +26,7 @@ const proximityBoostWeight = 0.3
 // It runs after scoreLocked over the same match set, so it never widens the
 // candidate pool: SearchTopK's bounded selection still sees exactly the
 // OR-union matches, now with tighter matches ranked higher.
-func (idx *InvertedIndex[S, D]) applyProximityLocked(scores map[uint32]float64, queryTerms map[Token]struct{}) {
+func (idx *InvertedIndex[S, D]) applyProximityLocked(scores map[uint32]float64, queryTerms []Token) {
 	if !idx.positions || idx.proximityWeight == 0 || len(scores) == 0 {
 		return
 	}
@@ -37,7 +37,7 @@ func (idx *InvertedIndex[S, D]) applyProximityLocked(scores map[uint32]float64, 
 	// Resolve the distinct word-channel query terms that exist in the corpus;
 	// fewer than two means there is no pair whose distance could matter.
 	var lists []*postingList
-	for token := range queryTerms {
+	for _, token := range queryTerms {
 		if token.Class != ClassWord {
 			continue
 		}
@@ -75,7 +75,7 @@ func (idx *InvertedIndex[S, D]) applyProximityLocked(scores map[uint32]float64, 
 		if span < 0 {
 			span = 0
 		}
-		scores[ord] += idx.proximityWeight * float64(len(present)-1) / float64(span+1)
+		addScore(scores, ord, idx.proximityWeight*float64(len(present)-1)/float64(span+1))
 	}
 }
 

--- a/core/search/proximity_test.go
+++ b/core/search/proximity_test.go
@@ -7,7 +7,7 @@ import "testing"
 // far apart the query terms sit, so the boost is the sole tie-breaker and the
 // adjacent document must rank first.
 func TestProximityBoostRanksTightMatchFirst(t *testing.T) {
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, WithPositions())
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID, WithPositions())
 	idx.Index("adjacent", Text("alpha quick fox beta gamma delta"))  // quick@1 fox@2
 	idx.Index("scattered", Text("quick alpha beta gamma delta fox")) // quick@0 fox@5
 
@@ -27,7 +27,7 @@ func TestProximityBoostRanksTightMatchFirst(t *testing.T) {
 // the same two documents score identically when the index tracks none, so the
 // OR-union ranking is unchanged.
 func TestProximityBoostInertWithoutPositions(t *testing.T) {
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil) // no WithPositions
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID) // no WithPositions
 	idx.Index("adjacent", Text("alpha quick fox beta gamma delta"))
 	idx.Index("scattered", Text("quick alpha beta gamma delta fox"))
 
@@ -50,7 +50,7 @@ func TestProximityBoostInertWithoutPositions(t *testing.T) {
 // 0.8*w — measured here at two weights to fix the slope.
 func TestProximityWeightScalesBoost(t *testing.T) {
 	build := func(w float64) []Result[string] {
-		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, WithPositions(), WithProximityWeight(w))
+		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID, WithPositions(), WithProximityWeight(w))
 		idx.Index("adjacent", Text("alpha quick fox beta gamma delta"))  // quick@1 fox@2
 		idx.Index("scattered", Text("quick alpha beta gamma delta fox")) // quick@0 fox@5
 		return idx.Search("quick fox")
@@ -91,7 +91,7 @@ func TestProximityWeightScalesBoost(t *testing.T) {
 // measure, so the boost is a no-op and ranking stays pure BM25 (the shorter,
 // denser document still wins on its own merits).
 func TestProximityBoostSingleTermNoOp(t *testing.T) {
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, WithPositions())
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID, WithPositions())
 	idx.Index("dense", Text("quick quick fox"))
 	idx.Index("sparse", Text("quick alpha beta gamma"))
 
@@ -104,7 +104,7 @@ func TestProximityBoostSingleTermNoOp(t *testing.T) {
 // TestProximityBoostTopK verifies the boost also reorders SearchTopK, which
 // applies it before bounded selection so a tight match can claim a scarce slot.
 func TestProximityBoostTopK(t *testing.T) {
-	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, WithPositions())
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID, WithPositions())
 	idx.Index("adjacent", Text("alpha quick fox beta gamma delta"))
 	idx.Index("scattered", Text("quick alpha beta gamma delta fox"))
 

--- a/core/search/quality_gate_test.go
+++ b/core/search/quality_gate_test.go
@@ -24,7 +24,7 @@ func gateAnalyzer() Analyzer {
 
 // gateIndex builds a fresh index wired with the example's analyzer and scorer.
 func gateIndex() *InvertedIndex[string, Text] {
-	return NewInvertedIndex[string, Text](gateAnalyzer(), BM25{K1: 1.2, B: 0.75})
+	return NewInvertedIndex[string, Text](gateAnalyzer(), BM25{K1: 1.2, B: 0.75}, compareStringID)
 }
 
 // foldingAnalyzer extends the gate analyzer with the width and diacritic
@@ -47,7 +47,7 @@ func foldingAnalyzer() Analyzer {
 // foldingIndex builds a fresh index wired with the folding analyzer and the
 // example's scorer.
 func foldingIndex() *InvertedIndex[string, Text] {
-	return NewInvertedIndex[string, Text](foldingAnalyzer(), BM25{K1: 1.2, B: 0.75})
+	return NewInvertedIndex[string, Text](foldingAnalyzer(), BM25{K1: 1.2, B: 0.75}, compareStringID)
 }
 
 // TestSearchQualityGateMultilingual indexes a small corpus per case and asserts
@@ -363,7 +363,7 @@ func TestSearchQualityGateFolding(t *testing.T) {
 }
 
 // sortedEqual reports whether got and want hold the same IDs regardless of
-// order, so set-membership assertions do not depend on score ties.
+// order for cases that intentionally assert membership separately from rank.
 func sortedEqual(got, want []string) bool {
 	g := append([]string(nil), got...)
 	w := append([]string(nil), want...)
@@ -390,6 +390,7 @@ func scriptAwareIndex() *InvertedIndex[string, Text] {
 	return NewInvertedIndex[string, Text](
 		NewScriptAwareAnalyzer(),
 		ClassWeighted{Base: BM25{K1: DefaultBM25K1, B: DefaultBM25B}, GramWeight: DefaultGramWeight},
+		compareStringID,
 	)
 }
 

--- a/core/search/relevance/metrics.go
+++ b/core/search/relevance/metrics.go
@@ -90,8 +90,8 @@ func RecallAt(k int, ranked []string, qrels map[string]int) float64 {
 // document IDs ordered most-relevant first — and macro-averages the metrics.
 // Each ranked list is truncated to EvalDepth first (see EvalDepth for why), so
 // rank may return more without affecting the result. Rankers built on a
-// Searcher should go through RankSearcher so score ties are broken
-// deterministically.
+// Searcher should go through RankSearcher so its production total order is
+// preserved without a harness-side tie repair.
 func Evaluate(c Corpus, rank func(q Query) []string) Metrics {
 	if len(c.Queries) == 0 {
 		return Metrics{}

--- a/core/search/relevance/parity_gate_test.go
+++ b/core/search/relevance/parity_gate_test.go
@@ -12,8 +12,10 @@ package relevance
 // the epic wants ratcheted upward).
 
 import (
+	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/anaregdesign/lantern/core/search"
@@ -43,15 +45,16 @@ func productionIndexWith(opts ...search.IndexOption) *search.InvertedIndex[strin
 			Base:       search.BM25{K1: search.DefaultBM25K1, B: search.DefaultBM25B},
 			GramWeight: search.DefaultGramWeight,
 		},
+		strings.Compare,
 		append([]search.IndexOption{search.WithPositions()}, opts...)...,
 	)
 }
 
 // productionFloors are the ratcheted minima per corpus, pinned from a measured
 // run of the current production pipeline (values truncated down to 3 decimals
-// so the assertion has headroom of at most one thousandth). RankSearcher
-// breaks score ties deterministically, so these numbers are exact and stable;
-// any drop below a floor is a real ranking change, not jitter.
+// so the assertion has headroom of at most one thousandth). The production
+// Searcher supplies the deterministic total order, so these numbers are exact
+// and stable; any drop below a floor is a real ranking change, not jitter.
 var productionFloors = map[string]Metrics{
 	// Re-pinned for #910's proximity qrels: the en and mixed corpora each gained
 	// a proximity-sensitive query (q27 "zephyr quokka", mq16 "marimba gable")
@@ -275,15 +278,9 @@ func TestMatchAllPrecision(t *testing.T) {
 	}
 }
 
-// rankResults orders search results most-relevant first, breaking score ties by
-// ID, matching RankSearcher's deterministic order.
+// rankResults preserves the production order; it must not repair ties inside
+// the relevance harness.
 func rankResults(results []search.Result[string]) []string {
-	sort.SliceStable(results, func(i, j int) bool {
-		if results[i].Score != results[j].Score {
-			return results[i].Score > results[j].Score
-		}
-		return results[i].ID < results[j].ID
-	})
 	ids := make([]string, len(results))
 	for i, r := range results {
 		ids[i] = r.ID
@@ -311,6 +308,7 @@ func TestFuzzyRecoversTypos(t *testing.T) {
 	idx := search.NewInvertedIndex[string, search.Text](
 		search.NewAnalyzer([]search.Normalizer{search.LowercaseNormalizer{}}, search.UnicodeTokenizer{}, nil),
 		nil,
+		strings.Compare,
 	)
 	en.IndexDocs(idx)
 	byID := queryByID(en)
@@ -341,6 +339,119 @@ func TestFuzzyRecoversTypos(t *testing.T) {
 	fuzzyTop := rankResults(idx.SearchMatch(clean.Text, search.MatchOptions{Fuzziness: 1}))
 	if len(exactTop) == 0 || len(fuzzyTop) == 0 || exactTop[0] != fuzzyTop[0] {
 		t.Errorf("clean query %q: fuzzy changed the top hit", clean.Text)
+	}
+}
+
+// TestExpansionCapRelevance is the judged cap-overflow corpus for #1056. It
+// measures the decision to keep raw BM25 scoring after semantic expansion:
+// expansion chooses the exact term plus the 49 strongest candidates, then
+// ordinary term statistics rank those documents without a hidden
+// distance/extension multiplier. The exact document has stronger term
+// frequency and must lead; every retained candidate is judged relevant.
+func TestExpansionCapRelevance(t *testing.T) {
+	type fixture struct {
+		name       string
+		query      string
+		candidates []string // already in semantic expansion order
+		opts       search.MatchOptions
+	}
+
+	query := "aaaa"
+	var fuzzyNear []string
+	for pos := range len(query) {
+		for replacement := byte('b'); replacement <= 'z'; replacement++ {
+			term := []byte(query)
+			term[pos] = replacement
+			fuzzyNear = append(fuzzyNear, string(term))
+		}
+	}
+	sort.Strings(fuzzyNear)
+	var fuzzyFar []string
+	for first := byte('b'); first <= 'z'; first++ {
+		for second := byte('b'); second <= 'z'; second++ {
+			fuzzyFar = append(fuzzyFar, string([]byte{first, second, 'a', 'a'}))
+			if len(fuzzyFar) == 30 {
+				break
+			}
+		}
+		if len(fuzzyFar) == 30 {
+			break
+		}
+	}
+	sort.Strings(fuzzyFar)
+
+	var prefixShort []string
+	for suffix := byte('a'); suffix <= 'z'; suffix++ {
+		prefixShort = append(prefixShort, query+string(suffix))
+	}
+	sort.Strings(prefixShort)
+	var prefixLong []string
+	for first := byte('a'); first <= 'z'; first++ {
+		for second := byte('a'); second <= 'z'; second++ {
+			prefixLong = append(prefixLong, query+string([]byte{first, second}))
+			if len(prefixLong) == 40 {
+				break
+			}
+		}
+		if len(prefixLong) == 40 {
+			break
+		}
+	}
+	sort.Strings(prefixLong)
+
+	fixtures := []fixture{
+		{
+			name:       "fuzzy distance",
+			query:      query,
+			candidates: append(fuzzyNear, fuzzyFar...),
+			opts:       search.MatchOptions{Fuzziness: 2},
+		},
+		{
+			name:       "prefix extension",
+			query:      query,
+			candidates: append(prefixShort, prefixLong...),
+			opts:       search.MatchOptions{PrefixTerms: true},
+		},
+	}
+
+	for _, tc := range fixtures {
+		t.Run(tc.name, func(t *testing.T) {
+			idx := search.NewInvertedIndex[string, search.Text](
+				search.NewAnalyzer([]search.Normalizer{search.LowercaseNormalizer{}}, search.UnicodeTokenizer{}, nil),
+				nil,
+				strings.Compare,
+			)
+			qrels := map[string]int{"exact": 3}
+			// Reverse semantic order on purpose: an internal-ID cap would retain
+			// the wrong documents and fail both recall and the relevance check.
+			for i := len(tc.candidates) - 1; i >= 0; i-- {
+				id := fmt.Sprintf("candidate-%03d", i)
+				idx.Index(id, search.Text(tc.candidates[i]))
+				if i < search.MaxTermExpansions-1 {
+					qrels[id] = 2
+				}
+			}
+			idx.Index("exact", search.Text(strings.Repeat(tc.query+" ", 4)))
+
+			ranked := rankResults(idx.SearchMatch(tc.query, tc.opts))
+			if len(ranked) != search.MaxTermExpansions {
+				t.Fatalf("results = %d, want expansion cap %d", len(ranked), search.MaxTermExpansions)
+			}
+			if ranked[0] != "exact" {
+				t.Fatalf("top result = %q, want exact", ranked[0])
+			}
+			for rank, id := range ranked {
+				if qrels[id] == 0 {
+					t.Fatalf("rank %d retained unjudged weaker candidate %q", rank+1, id)
+				}
+			}
+			ndcg := NDCGAt(NDCGDepth, ranked, qrels)
+			recall := RecallAt(EvalDepth, ranked, qrels)
+			if ndcg < 1-1e-12 || recall < 1-1e-12 {
+				t.Errorf("cap-overflow relevance below ideal: nDCG@10=%.6f Recall@50=%.6f", ndcg, recall)
+			}
+			t.Logf("raw-BM25 cap overflow: nDCG@10=%.4f MRR=%.4f Recall@50=%.4f", ndcg, ReciprocalRank(ranked, qrels), recall)
+		})
 	}
 }
 

--- a/core/search/relevance/relevance.go
+++ b/core/search/relevance/relevance.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"sort"
 
 	"github.com/anaregdesign/lantern/core/search"
 )
@@ -145,20 +144,12 @@ func (c Corpus) validate() error {
 	return nil
 }
 
-// RankSearcher adapts a Searcher into the ranking function Evaluate consumes,
-// breaking score ties by document ID. Search documents ties as unspecified
-// order; without a deterministic tie-break the metrics would jitter from run
-// to run whenever tied documents straddle a relevance grade, and a ratcheted
-// floor cannot tolerate jitter.
+// RankSearcher adapts a Searcher into the ranking function Evaluate consumes.
+// The production Searcher already owns the complete deterministic order; the
+// harness must preserve it rather than mask an implementation regression.
 func RankSearcher(s search.Searcher[string]) func(q Query) []string {
 	return func(q Query) []string {
 		results := s.Search(q.Text)
-		sort.SliceStable(results, func(i, j int) bool {
-			if results[i].Score != results[j].Score {
-				return results[i].Score > results[j].Score
-			}
-			return results[i].ID < results[j].ID
-		})
 		ids := make([]string, len(results))
 		for i, r := range results {
 			ids[i] = r.ID

--- a/core/search/relevance/relevance_test.go
+++ b/core/search/relevance/relevance_test.go
@@ -78,7 +78,7 @@ func TestIndexDocs(t *testing.T) {
 		Name: "unit",
 		Docs: []Doc{{ID: "a", Text: "full text search"}, {ID: "b", Text: "graph traversal"}},
 	}
-	idx := search.NewInvertedIndex[string, search.Text](search.NewNGramAnalyzer(2), nil)
+	idx := search.NewInvertedIndex[string, search.Text](search.NewNGramAnalyzer(2), nil, strings.Compare)
 	c.IndexDocs(idx)
 	results := idx.Search("search")
 	if len(results) != 1 || results[0].ID != "a" {
@@ -87,9 +87,9 @@ func TestIndexDocs(t *testing.T) {
 }
 
 func TestRankSearcher(t *testing.T) {
-	idx := search.NewInvertedIndex[string, search.Text](search.NewNGramAnalyzer(2), nil)
-	// Identical documents score identically; RankSearcher must break the tie
-	// by ID so evaluation is deterministic run to run.
+	idx := search.NewInvertedIndex[string, search.Text](search.NewNGramAnalyzer(2), nil, strings.Compare)
+	// Identical documents score identically; RankSearcher must preserve the
+	// core index's ID tie-break instead of repairing it itself.
 	idx.Index("zeta", search.Text("same text"))
 	idx.Index("alpha", search.Text("same text"))
 	idx.Index("miss", search.Text("unrelated"))

--- a/core/search/searcher.go
+++ b/core/search/searcher.go
@@ -13,8 +13,9 @@ type Result[S comparable] struct {
 // score, ordered from most to least relevant — the ranked seed candidates a
 // caller picks before a wider graph traversal, where the score can double as a
 // seed's initial weight. Documents that share no analyzed term with the query
-// are omitted, and a query with no analyzable terms yields no results. Ties in
-// score have an unspecified relative order.
+// are omitted, and a query with no analyzable terms yields no results.
+// Implementations provide a stable document-ID order for equal scores;
+// InvertedIndex requires a typed ascending ID comparator at construction.
 type Searcher[S comparable] interface {
 	Search(query string) []Result[S]
 }

--- a/pb/graph/v1/graph.pb.go
+++ b/pb/graph/v1/graph.pb.go
@@ -2324,8 +2324,8 @@ func (x *SearchVerticesRequest) GetOptions() *SearchOptions {
 
 type SearchVerticesResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// hits in descending relevance order (BM25). May be shorter than `limit`
-	// when fewer vertices match; empty when nothing matches.
+	// hits use the stable total order (score DESC, raw key ASC). May be shorter
+	// than `limit` when fewer vertices match; empty when nothing matches.
 	Hits          []*SearchHit `protobuf:"bytes,1,rep,name=hits,proto3" json:"hits,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -2369,7 +2369,8 @@ func (x *SearchVerticesResponse) GetHits() []*SearchHit {
 }
 
 // SearchHit pairs a matching vertex key with the relevance score the index
-// assigned it (BM25; higher is more relevant). The value and TTL are not
+// assigned it (BM25; higher is more relevant). Equal scores are ordered by the
+// raw, unnormalised key in ascending lexical order. The value and TTL are not
 // included — callers that need them issue a follow-up GetVertices with the
 // returned keys.
 type SearchHit struct {

--- a/pb/graph/v1/graphv1connect/graph.connect.go
+++ b/pb/graph/v1/graphv1connect/graph.connect.go
@@ -128,10 +128,10 @@ type LanternServiceClient interface {
 	// RPC for the `keys` CLI verb. A non-empty prefix is REQUIRED. Plural-only.
 	ScanVertexKeys(context.Context, *connect.Request[v1.ScanVertexKeysRequest]) (*connect.Response[v1.ScanVertexKeysResponse], error)
 	// SearchVertices returns vertices ranked by full-text relevance over their
-	// content (key + value), optionally scoped to a key prefix. Requires the
-	// server-side search index (LANTERN_SEARCH_ENABLED, on by default);
-	// returns FAILED_PRECONDITION when disabled. Plural-only — ranked search
-	// is inherently plural.
+	// content (key + value), optionally scoped to a key prefix, in stable
+	// (score DESC, raw key ASC) order. Requires the server-side search index
+	// (LANTERN_SEARCH_ENABLED, on by default); returns FAILED_PRECONDITION when
+	// disabled. Plural-only — ranked search is inherently plural.
 	SearchVertices(context.Context, *connect.Request[v1.SearchVerticesRequest]) (*connect.Response[v1.SearchVerticesResponse], error)
 	// CountVerticesByPrefix returns the number of live vertices whose key
 	// starts with the given prefix.
@@ -549,10 +549,10 @@ type LanternServiceHandler interface {
 	// RPC for the `keys` CLI verb. A non-empty prefix is REQUIRED. Plural-only.
 	ScanVertexKeys(context.Context, *connect.Request[v1.ScanVertexKeysRequest]) (*connect.Response[v1.ScanVertexKeysResponse], error)
 	// SearchVertices returns vertices ranked by full-text relevance over their
-	// content (key + value), optionally scoped to a key prefix. Requires the
-	// server-side search index (LANTERN_SEARCH_ENABLED, on by default);
-	// returns FAILED_PRECONDITION when disabled. Plural-only — ranked search
-	// is inherently plural.
+	// content (key + value), optionally scoped to a key prefix, in stable
+	// (score DESC, raw key ASC) order. Requires the server-side search index
+	// (LANTERN_SEARCH_ENABLED, on by default); returns FAILED_PRECONDITION when
+	// disabled. Plural-only — ranked search is inherently plural.
 	SearchVertices(context.Context, *connect.Request[v1.SearchVerticesRequest]) (*connect.Response[v1.SearchVerticesResponse], error)
 	// CountVerticesByPrefix returns the number of live vertices whose key
 	// starts with the given prefix.

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -439,13 +439,14 @@ message SearchVerticesRequest {
 }
 
 message SearchVerticesResponse {
-  // hits in descending relevance order (BM25). May be shorter than `limit`
-  // when fewer vertices match; empty when nothing matches.
+  // hits use the stable total order (score DESC, raw key ASC). May be shorter
+  // than `limit` when fewer vertices match; empty when nothing matches.
   repeated SearchHit hits = 1;
 }
 
 // SearchHit pairs a matching vertex key with the relevance score the index
-// assigned it (BM25; higher is more relevant). The value and TTL are not
+// assigned it (BM25; higher is more relevant). Equal scores are ordered by the
+// raw, unnormalised key in ascending lexical order. The value and TTL are not
 // included — callers that need them issue a follow-up GetVertices with the
 // returned keys.
 message SearchHit {
@@ -904,10 +905,10 @@ service LanternService {
   rpc ScanVertexKeys(ScanVertexKeysRequest) returns (ScanVertexKeysResponse);
 
   // SearchVertices returns vertices ranked by full-text relevance over their
-  // content (key + value), optionally scoped to a key prefix. Requires the
-  // server-side search index (LANTERN_SEARCH_ENABLED, on by default);
-  // returns FAILED_PRECONDITION when disabled. Plural-only — ranked search
-  // is inherently plural.
+  // content (key + value), optionally scoped to a key prefix, in stable
+  // (score DESC, raw key ASC) order. Requires the server-side search index
+  // (LANTERN_SEARCH_ENABLED, on by default); returns FAILED_PRECONDITION when
+  // disabled. Plural-only — ranked search is inherently plural.
   rpc SearchVertices(SearchVerticesRequest) returns (SearchVerticesResponse);
 
   // CountVerticesByPrefix returns the number of live vertices whose key

--- a/sdks/dart/lib/src/gen/graph/v1/graph.connect.client.dart
+++ b/sdks/dart/lib/src/gen/graph/v1/graph.connect.client.dart
@@ -171,10 +171,10 @@ extension type LanternServiceClient (connect.Transport _transport) {
   }
 
   /// SearchVertices returns vertices ranked by full-text relevance over their
-  /// content (key + value), optionally scoped to a key prefix. Requires the
-  /// server-side search index (LANTERN_SEARCH_ENABLED, on by default);
-  /// returns FAILED_PRECONDITION when disabled. Plural-only — ranked search
-  /// is inherently plural.
+  /// content (key + value), optionally scoped to a key prefix, in stable
+  /// (score DESC, raw key ASC) order. Requires the server-side search index
+  /// (LANTERN_SEARCH_ENABLED, on by default); returns FAILED_PRECONDITION when
+  /// disabled. Plural-only — ranked search is inherently plural.
   Future<graphv1graph.SearchVerticesResponse> searchVertices(
     graphv1graph.SearchVerticesRequest input, {
     connect.Headers? headers,

--- a/sdks/dart/lib/src/gen/graph/v1/graph.connect.spec.dart
+++ b/sdks/dart/lib/src/gen/graph/v1/graph.connect.spec.dart
@@ -83,10 +83,10 @@ abstract final class LanternService {
   );
 
   /// SearchVertices returns vertices ranked by full-text relevance over their
-  /// content (key + value), optionally scoped to a key prefix. Requires the
-  /// server-side search index (LANTERN_SEARCH_ENABLED, on by default);
-  /// returns FAILED_PRECONDITION when disabled. Plural-only — ranked search
-  /// is inherently plural.
+  /// content (key + value), optionally scoped to a key prefix, in stable
+  /// (score DESC, raw key ASC) order. Requires the server-side search index
+  /// (LANTERN_SEARCH_ENABLED, on by default); returns FAILED_PRECONDITION when
+  /// disabled. Plural-only — ranked search is inherently plural.
   static const searchVertices = connect.Spec(
     '/$name/SearchVertices',
     connect.StreamType.unary,

--- a/sdks/dart/lib/src/gen/graph/v1/graph.pb.dart
+++ b/sdks/dart/lib/src/gen/graph/v1/graph.pb.dart
@@ -2371,14 +2371,15 @@ class SearchVerticesResponse extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<SearchVerticesResponse>(create);
   static SearchVerticesResponse? _defaultInstance;
 
-  /// hits in descending relevance order (BM25). May be shorter than `limit`
-  /// when fewer vertices match; empty when nothing matches.
+  /// hits use the stable total order (score DESC, raw key ASC). May be shorter
+  /// than `limit` when fewer vertices match; empty when nothing matches.
   @$pb.TagNumber(1)
   $pb.PbList<SearchHit> get hits => $_getList(0);
 }
 
 /// SearchHit pairs a matching vertex key with the relevance score the index
-/// assigned it (BM25; higher is more relevant). The value and TTL are not
+/// assigned it (BM25; higher is more relevant). Equal scores are ordered by the
+/// raw, unnormalised key in ascending lexical order. The value and TTL are not
 /// included — callers that need them issue a follow-up GetVertices with the
 /// returned keys.
 class SearchHit extends $pb.GeneratedMessage {
@@ -5173,10 +5174,10 @@ class LanternServiceApi {
           'ScanVertexKeys', request, ScanVertexKeysResponse());
 
   /// SearchVertices returns vertices ranked by full-text relevance over their
-  /// content (key + value), optionally scoped to a key prefix. Requires the
-  /// server-side search index (LANTERN_SEARCH_ENABLED, on by default);
-  /// returns FAILED_PRECONDITION when disabled. Plural-only — ranked search
-  /// is inherently plural.
+  /// content (key + value), optionally scoped to a key prefix, in stable
+  /// (score DESC, raw key ASC) order. Requires the server-side search index
+  /// (LANTERN_SEARCH_ENABLED, on by default); returns FAILED_PRECONDITION when
+  /// disabled. Plural-only — ranked search is inherently plural.
   $async.Future<SearchVerticesResponse> searchVertices(
           $pb.ClientContext? ctx, SearchVerticesRequest request) =>
       _client.invoke<SearchVerticesResponse>(ctx, 'LanternService',

--- a/sdks/dart/lib/src/search.dart
+++ b/sdks/dart/lib/src/search.dart
@@ -50,7 +50,7 @@ final class SearchOptions {
   final bool? prefixTerms;
 }
 
-/// One immutable BM25-ranked hit.
+/// One immutable BM25-ranked hit; equal scores use raw [key] ascending.
 final class SearchHit {
   /// Creates a ranked hit.
   const SearchHit({required this.key, required this.score});
@@ -73,7 +73,7 @@ final class SearchEnabled extends SearchResult {
   SearchEnabled(Iterable<SearchHit> hits)
     : hits = List<SearchHit>.unmodifiable(hits);
 
-  /// Ranked hits, possibly empty.
+  /// Ranked hits in stable `(score DESC, raw key ASC)` order, possibly empty.
   final List<SearchHit> hits;
 }
 

--- a/sdks/go/search.go
+++ b/sdks/go/search.go
@@ -8,9 +8,10 @@ import (
 
 // SearchHit is one ranked result from Lantern.SearchVertices: the key of a
 // matching vertex paired with its full-text relevance Score (higher is more
-// relevant). Like EdgeRef it is a flat SDK-native value, not a proto alias —
-// it carries only the key and score, so call GetVertex / GetVertices on the
-// keys to hydrate the stored value and TTL.
+// relevant). Equal scores are ordered by raw Key ascending. Like EdgeRef it is
+// a flat SDK-native value, not a proto alias — it carries only the key and
+// score, so call GetVertex / GetVertices on the keys to hydrate the stored
+// value and TTL.
 type SearchHit struct {
 	Key   string
 	Score float64
@@ -98,9 +99,9 @@ func WithPrefixTerms() SearchOption {
 }
 
 // SearchVertices returns vertices ranked by full-text relevance over their
-// indexed content (key + value), most relevant first. It is the content
-// counterpart to ScanVertices' lexicographic key walk: search by a
-// remembered topic word instead of an exact key prefix.
+// indexed content (key + value) in stable (score DESC, raw key ASC) order. It
+// is the content counterpart to ScanVertices' lexicographic key walk: search
+// by a remembered topic word instead of an exact key prefix.
 //
 // Empty result vs. error: an empty, unanalysable, or simply non-matching
 // query is a zero-hit success — the returned slice is empty (never nil) and

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -269,10 +269,11 @@ you want the `EdgeInput[]` without sending it.
 
 `searchVertices` runs a relevance-ranked full-text query over vertex
 _content_ (key + value) — unlike `scanVertices`, which is a lexicographic
-key-prefix walk. It returns `{ key, score }` hits in descending BM25 order:
-the seed candidates to pick before an `illuminate` traversal, where `score`
-doubles as the seed's initial weight. Hits carry only the key and score, so
-hydrate value/TTL with a follow-up `getVertices`, preserving rank order.
+key-prefix walk. It returns `{ key, score }` hits in stable `(score DESC, raw
+key ASC)` order: the seed candidates to pick before an `illuminate` traversal,
+where `score` doubles as the seed's initial weight. Hits carry only the key and
+score, so hydrate value/TTL with a follow-up `getVertices`, preserving rank
+order.
 
 ```ts
 const hits = await client.searchVertices("quarterly revenue", { limit: 10, prefix: "doc/" });

--- a/sdks/node/src/client.ts
+++ b/sdks/node/src/client.ts
@@ -541,9 +541,10 @@ export class Lantern {
   /**
    * Content-addressed vertex search. Runs a relevance-ranked full-text
    * query over vertex *content* (key + value) via the server-side
-   * index, returning ranked `{ key, score }` hits in descending BM25
-   * order — the seed candidates a caller picks before an `illuminate`
-   * traversal, where `score` doubles as the seed's initial weight.
+   * index, returning ranked `{ key, score }` hits in stable `(score DESC,
+   * raw key ASC)` order — the seed candidates a caller picks before an
+   * `illuminate` traversal, where `score` doubles as the seed's initial
+   * weight.
    *
    * Unlike `scanVertices` (a lexicographic key-prefix walk), this
    * matches the *value*. `opts.limit` caps the ranked hits (0 = server

--- a/sdks/node/src/gen/graph/v1/graph_pb.ts
+++ b/sdks/node/src/gen/graph/v1/graph_pb.ts
@@ -24,6 +24,8 @@ export type Vertex = Message<"graph.v1.Vertex"> & {
   key: string;
 
   /**
+   * Absolute expiration. An absent timestamp means permanent storage.
+   *
    * @generated from field: google.protobuf.Timestamp expiration = 2;
    */
   expiration?: Timestamp | undefined;
@@ -137,6 +139,8 @@ export type Edge = Message<"graph.v1.Edge"> & {
   weight: number;
 
   /**
+   * Absolute expiration. An absent timestamp means permanent storage.
+   *
    * @generated from field: google.protobuf.Timestamp expiration = 4;
    */
   expiration?: Timestamp | undefined;
@@ -974,8 +978,8 @@ export const SearchVerticesRequestSchema: GenMessage<SearchVerticesRequest> = /*
  */
 export type SearchVerticesResponse = Message<"graph.v1.SearchVerticesResponse"> & {
   /**
-   * hits in descending relevance order (BM25). May be shorter than `limit`
-   * when fewer vertices match; empty when nothing matches.
+   * hits use the stable total order (score DESC, raw key ASC). May be shorter
+   * than `limit` when fewer vertices match; empty when nothing matches.
    *
    * @generated from field: repeated graph.v1.SearchHit hits = 1;
    */
@@ -991,7 +995,8 @@ export const SearchVerticesResponseSchema: GenMessage<SearchVerticesResponse> = 
 
 /**
  * SearchHit pairs a matching vertex key with the relevance score the index
- * assigned it (BM25; higher is more relevant). The value and TTL are not
+ * assigned it (BM25; higher is more relevant). Equal scores are ordered by the
+ * raw, unnormalised key in ascending lexical order. The value and TTL are not
  * included — callers that need them issue a follow-up GetVertices with the
  * returned keys.
  *
@@ -2446,10 +2451,10 @@ export const LanternService: GenService<{
   },
   /**
    * SearchVertices returns vertices ranked by full-text relevance over their
-   * content (key + value), optionally scoped to a key prefix. Requires the
-   * server-side search index (LANTERN_SEARCH_ENABLED, on by default);
-   * returns FAILED_PRECONDITION when disabled. Plural-only — ranked search
-   * is inherently plural.
+   * content (key + value), optionally scoped to a key prefix, in stable
+   * (score DESC, raw key ASC) order. Requires the server-side search index
+   * (LANTERN_SEARCH_ENABLED, on by default); returns FAILED_PRECONDITION when
+   * disabled. Plural-only — ranked search is inherently plural.
    *
    * @generated from rpc graph.v1.LanternService.SearchVertices
    */

--- a/sdks/node/src/gen/graph/v1/replication_pb.ts
+++ b/sdks/node/src/gen/graph/v1/replication_pb.ts
@@ -399,6 +399,8 @@ export type SnapshotEdgeContribution = Message<"graph.v1.SnapshotEdgeContributio
   weight: number;
 
   /**
+   * Absolute expiration. An absent timestamp means a permanent contribution.
+   *
    * @generated from field: google.protobuf.Timestamp expiration = 2;
    */
   expiration?: Timestamp | undefined;

--- a/sdks/node/src/values.ts
+++ b/sdks/node/src/values.ts
@@ -242,11 +242,11 @@ export interface Graph {
 /**
  * A single relevance-ranked result from `searchVertices`. `key` is the
  * matching vertex key; `score` is the BM25 relevance (higher = more
- * relevant) the server-side index assigned, which doubles as the
- * seed's initial weight for a follow-up `illuminate`. The value and
- * TTL are intentionally omitted — callers that need them issue a
- * follow-up `getVertices` with the returned keys, preserving rank
- * order.
+ * relevant) the server-side index assigned. Equal scores use raw key
+ * ascending. The score doubles as the seed's initial weight for a follow-up
+ * `illuminate`. The value and TTL are intentionally omitted — callers that
+ * need them issue a follow-up `getVertices` with the returned keys,
+ * preserving rank order.
  */
 export interface SearchHit {
   readonly key: string;

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -474,7 +474,7 @@ func NewGraphCache(c CacheConfig, sc SearchConfig) *graphcache.GraphCache[string
 		if !sc.Positions {
 			opts = append(opts, graphcache.WithoutSearchPositions())
 		}
-		gc.EnableSearchIndex(vertexSearchDocument, opts...)
+		gc.EnableSearchIndex(vertexSearchDocument, strings.Compare, opts...)
 	}
 	return gc
 }

--- a/server/service/backend.go
+++ b/server/service/backend.go
@@ -193,11 +193,12 @@ type Backend interface {
 
 	// SearchVertices returns vertices ranked by full-text relevance over
 	// their indexed content, optionally scoped to keyPrefix, capped at
-	// limit (limit <= 0 returns nil). The returned slice is ordered by
-	// descending score. It returns nil when the search index is disabled,
-	// the query has no analysable terms, or nothing matches — the three
-	// are indistinguishable here, so the handler decides FAILED_PRECONDITION
-	// from its own SearchConfig.Enabled flag, not this return value (#624).
+	// limit (limit <= 0 returns nil). The returned slice uses the stable
+	// production order (score DESC, raw key ASC). It returns nil when the
+	// search index is disabled, the query has no analysable terms, or nothing
+	// matches — the three are indistinguishable here, so the handler decides
+	// FAILED_PRECONDITION from its own SearchConfig.Enabled flag, not this return
+	// value (#624).
 	SearchVertices(query string, limit int, keyPrefix string) []search.Result[string]
 	SearchVerticesMatch(query string, limit int, keyPrefix string, opts search.MatchOptions, phrase bool) []search.Result[string]
 

--- a/server/service/search.go
+++ b/server/service/search.go
@@ -21,9 +21,9 @@ import (
 var errSearchDisabled = errors.New("vertex search is disabled on this server; set LANTERN_SEARCH_ENABLED=true to enable it")
 
 // SearchVertices returns vertices ranked by full-text relevance over their
-// indexed content (key + value), most relevant first. It is the content
-// counterpart to ScanVertices' lexicographic key walk: callers search by
-// remembered topic words instead of an exact key prefix.
+// indexed content (key + value) in stable (score DESC, raw key ASC) order. It
+// is the content counterpart to ScanVertices' lexicographic key walk: callers
+// search by remembered topic words instead of an exact key prefix.
 //
 // Gating: when the server was started without the search index
 // (LANTERN_SEARCH_ENABLED=false) the RPC returns FAILED_PRECONDITION. The

--- a/testbed/bench/scenarios/search_churn.yaml
+++ b/testbed/bench/scenarios/search_churn.yaml
@@ -7,6 +7,11 @@
 #   under the InvertedIndex RWMutex.
 # - consistency: SearchVertices skips vertices whose TTL has expired but
 #   whose Flush has not yet run.
+# - expansion: one two-clause query drives both semantic cap-overflow paths:
+#   `topic` prefix-expands over the live unique-term set, while `fuzz000`
+#   fuzzy-expands over 100 live neighbours at edit distance <= 2. Both exceed
+#   MaxTermExpansions=50, so the release sweep exercises capped survivor
+#   selection rather than an exact-only dictionary lookup (#1056).
 #
 # steady >= 2m so the leak window brackets the GC sweep repeatedly.
 # Assert lantern_search_index_terms and lantern_search_index_docs return
@@ -31,13 +36,22 @@ target:
     # [0] short-TTL string vertex. The 50k key space is larger than the
     #     ~15k live set at 1k writes/s with 15s expirations, so keys are not
     #     refreshed before they age out and GC churns the index during steady.
-    - call: graph.v1.LanternService/PutVertex
+    #     topicNNNNN supplies thousands of live prefix candidates; fuzzNNN is
+    #     a bounded 100-term family whose every member lies within two edits of
+    #     fuzz000. Keeping them in one value preserves the existing 2-producer
+    #     split while making both expansion caps overflow.
+    - name: writer
+      call: graph.v1.LanternService/PutVertex
       data_template: |
-        {"vertex":{"key":"search-{{mod .RequestNumber 50000}}","string":"topic {{mod .RequestNumber 100}}","expiration":"{{ now | dateModify `15s` | date `2006-01-02T15:04:05.999999999Z07:00` }}"}}
-    # [1] full-text query over the indexed content.
-    - call: graph.v1.LanternService/SearchVertices
+        {"vertex":{"key":"search-{{mod .RequestNumber 50000}}","string":"topic{{ printf `%05d` (mod .RequestNumber 50000) }} fuzz{{ printf `%03d` (mod .RequestNumber 100) }}","expiration":"{{ now | dateModify `15s` | date `2006-01-02T15:04:05.999999999Z07:00` }}"}}
+    # [1] Both query clauses overflow the 50-term expansion cap independently:
+    #     topic matches every live topicNNNNN by prefix, and fuzz000 reaches all
+    #     fuzz000..fuzz099 with fuzziness=2. Auxiliary grams still exercise the
+    #     production script-aware ranking path around those word clauses.
+    - name: prefix_fuzzy_cap_overflow
+      call: graph.v1.LanternService/SearchVertices
       data_template: |
-        {"query":"topic {{mod .RequestNumber 100}}","limit":20}
+        {"query":"topic fuzz000","limit":20,"options":{"prefixTerms":true,"fuzziness":2}}
 leak_gate:
   goroutine_max_delta: 20
   heap_alloc_max_delta_mb: 32
@@ -48,3 +62,10 @@ perf_gate:
   min_steady_rps_total: 800
   max_p99_ms: 1250
   max_non_ok_ratio: 0.02
+  # Producer names make the advanced-search leg independently measurable in
+  # perf_gate.json. Error budgets are safe to gate immediately; throughput and
+  # p99 need fresh nightly baselines for this heavier query before they can be
+  # sized with the README-mandated >=2x headroom.
+  producers:
+    writer: { max_non_ok_ratio: 0.02 }
+    prefix_fuzzy_cap_overflow: { max_non_ok_ratio: 0.02 }

--- a/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/graph.connect.client.dart
+++ b/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/graph.connect.client.dart
@@ -171,10 +171,10 @@ extension type LanternServiceClient (connect.Transport _transport) {
   }
 
   /// SearchVertices returns vertices ranked by full-text relevance over their
-  /// content (key + value), optionally scoped to a key prefix. Requires the
-  /// server-side search index (LANTERN_SEARCH_ENABLED, on by default);
-  /// returns FAILED_PRECONDITION when disabled. Plural-only — ranked search
-  /// is inherently plural.
+  /// content (key + value), optionally scoped to a key prefix, in stable
+  /// (score DESC, raw key ASC) order. Requires the server-side search index
+  /// (LANTERN_SEARCH_ENABLED, on by default); returns FAILED_PRECONDITION when
+  /// disabled. Plural-only — ranked search is inherently plural.
   Future<graphv1graph.SearchVerticesResponse> searchVertices(
     graphv1graph.SearchVerticesRequest input, {
     connect.Headers? headers,

--- a/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/graph.connect.spec.dart
+++ b/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/graph.connect.spec.dart
@@ -83,10 +83,10 @@ abstract final class LanternService {
   );
 
   /// SearchVertices returns vertices ranked by full-text relevance over their
-  /// content (key + value), optionally scoped to a key prefix. Requires the
-  /// server-side search index (LANTERN_SEARCH_ENABLED, on by default);
-  /// returns FAILED_PRECONDITION when disabled. Plural-only — ranked search
-  /// is inherently plural.
+  /// content (key + value), optionally scoped to a key prefix, in stable
+  /// (score DESC, raw key ASC) order. Requires the server-side search index
+  /// (LANTERN_SEARCH_ENABLED, on by default); returns FAILED_PRECONDITION when
+  /// disabled. Plural-only — ranked search is inherently plural.
   static const searchVertices = connect.Spec(
     '/$name/SearchVertices',
     connect.StreamType.unary,

--- a/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/graph.pb.dart
+++ b/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/graph.pb.dart
@@ -2371,14 +2371,15 @@ class SearchVerticesResponse extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<SearchVerticesResponse>(create);
   static SearchVerticesResponse? _defaultInstance;
 
-  /// hits in descending relevance order (BM25). May be shorter than `limit`
-  /// when fewer vertices match; empty when nothing matches.
+  /// hits use the stable total order (score DESC, raw key ASC). May be shorter
+  /// than `limit` when fewer vertices match; empty when nothing matches.
   @$pb.TagNumber(1)
   $pb.PbList<SearchHit> get hits => $_getList(0);
 }
 
 /// SearchHit pairs a matching vertex key with the relevance score the index
-/// assigned it (BM25; higher is more relevant). The value and TTL are not
+/// assigned it (BM25; higher is more relevant). Equal scores are ordered by the
+/// raw, unnormalised key in ascending lexical order. The value and TTL are not
 /// included — callers that need them issue a follow-up GetVertices with the
 /// returned keys.
 class SearchHit extends $pb.GeneratedMessage {
@@ -5173,10 +5174,10 @@ class LanternServiceApi {
           'ScanVertexKeys', request, ScanVertexKeysResponse());
 
   /// SearchVertices returns vertices ranked by full-text relevance over their
-  /// content (key + value), optionally scoped to a key prefix. Requires the
-  /// server-side search index (LANTERN_SEARCH_ENABLED, on by default);
-  /// returns FAILED_PRECONDITION when disabled. Plural-only — ranked search
-  /// is inherently plural.
+  /// content (key + value), optionally scoped to a key prefix, in stable
+  /// (score DESC, raw key ASC) order. Requires the server-side search index
+  /// (LANTERN_SEARCH_ENABLED, on by default); returns FAILED_PRECONDITION when
+  /// disabled. Plural-only — ranked search is inherently plural.
   $async.Future<SearchVerticesResponse> searchVertices(
           $pb.ClientContext? ctx, SearchVerticesRequest request) =>
       _client.invoke<SearchVerticesResponse>(ctx, 'LanternService',

--- a/testbed/dart-transport-probe/grpc/lib/src/gen/graph/v1/graph.pb.dart
+++ b/testbed/dart-transport-probe/grpc/lib/src/gen/graph/v1/graph.pb.dart
@@ -2325,14 +2325,15 @@ class SearchVerticesResponse extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<SearchVerticesResponse>(create);
   static SearchVerticesResponse? _defaultInstance;
 
-  /// hits in descending relevance order (BM25). May be shorter than `limit`
-  /// when fewer vertices match; empty when nothing matches.
+  /// hits use the stable total order (score DESC, raw key ASC). May be shorter
+  /// than `limit` when fewer vertices match; empty when nothing matches.
   @$pb.TagNumber(1)
   $pb.PbList<SearchHit> get hits => $_getList(0);
 }
 
 /// SearchHit pairs a matching vertex key with the relevance score the index
-/// assigned it (BM25; higher is more relevant). The value and TTL are not
+/// assigned it (BM25; higher is more relevant). Equal scores are ordered by the
+/// raw, unnormalised key in ascending lexical order. The value and TTL are not
 /// included — callers that need them issue a follow-up GetVertices with the
 /// returned keys.
 class SearchHit extends $pb.GeneratedMessage {

--- a/testbed/dart-transport-probe/grpc/lib/src/gen/graph/v1/graph.pbgrpc.dart
+++ b/testbed/dart-transport-probe/grpc/lib/src/gen/graph/v1/graph.pbgrpc.dart
@@ -105,10 +105,10 @@ class LanternServiceClient extends $grpc.Client {
   }
 
   /// SearchVertices returns vertices ranked by full-text relevance over their
-  /// content (key + value), optionally scoped to a key prefix. Requires the
-  /// server-side search index (LANTERN_SEARCH_ENABLED, on by default);
-  /// returns FAILED_PRECONDITION when disabled. Plural-only — ranked search
-  /// is inherently plural.
+  /// content (key + value), optionally scoped to a key prefix, in stable
+  /// (score DESC, raw key ASC) order. Requires the server-side search index
+  /// (LANTERN_SEARCH_ENABLED, on by default); returns FAILED_PRECONDITION when
+  /// disabled. Plural-only — ranked search is inherently plural.
   $grpc.ResponseFuture<$0.SearchVerticesResponse> searchVertices(
     $0.SearchVerticesRequest request, {
     $grpc.CallOptions? options,

--- a/tests/integration/search_vertices_test.go
+++ b/tests/integration/search_vertices_test.go
@@ -1,13 +1,19 @@
 package integration_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"math/rand"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"connectrpc.com/connect"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/anaregdesign/lantern/core/graphcache"
@@ -43,7 +49,7 @@ func newSearchRawClient(t *testing.T, enabled bool) graphv1connect.LanternServic
 	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	cache.EnablePrefixIndex(func(k string) string { return k })
 	if enabled {
-		cache.EnableSearchIndex(searchVertexDocument)
+		cache.EnableSearchIndex(searchVertexDocument, strings.Compare)
 	}
 	svc := service.NewLanternService(cache).WithSearchLimits(service.SearchLimits{
 		Enabled:      enabled,
@@ -63,7 +69,7 @@ func newSearchSDKClient(t *testing.T, enabled bool) *client.Lantern {
 	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	cache.EnablePrefixIndex(func(k string) string { return k })
 	if enabled {
-		cache.EnableSearchIndex(searchVertexDocument)
+		cache.EnableSearchIndex(searchVertexDocument, strings.Compare)
 	}
 	svc := service.NewLanternService(cache).WithSearchLimits(service.SearchLimits{
 		Enabled:      enabled,
@@ -291,6 +297,146 @@ func TestSearchVertices_Options(t *testing.T) {
 	})
 }
 
+// TestSearchVertices_DeterministicAcrossHistories drives cap-overflow prefix
+// and fuzzy expansion through independent real Connect/h2c servers whose final
+// corpora are identical but whose document/term ordinal histories differ. The
+// complete protobuf bytes (ordered keys and float bits) must agree on every
+// repeated call.
+func TestSearchVertices_DeterministicAcrossHistories(t *testing.T) {
+	type document struct {
+		key   string
+		value string
+	}
+	var documents []document
+	var prefixWant []string
+	for i := 0; i < 80; i++ {
+		key := fmt.Sprintf("docp-%03d", i)
+		documents = append(documents, document{key: key, value: fmt.Sprintf("pr%03d", i)})
+		if i < search.MaxTermExpansions {
+			prefixWant = append(prefixWant, key)
+		}
+	}
+	var fuzzyTerms []string
+	for ch := byte('b'); ch <= 'z'; ch++ {
+		fuzzyTerms = append(fuzzyTerms, string([]byte{ch, 'a'}), string([]byte{'a', ch}))
+	}
+	for digit := byte('0'); digit <= '9'; digit++ {
+		fuzzyTerms = append(fuzzyTerms, string([]byte{'a', digit, 'a'}))
+	}
+	sort.Strings(fuzzyTerms)
+	var fuzzyWant []string
+	for i, term := range fuzzyTerms {
+		key := fmt.Sprintf("docf-%03d", i)
+		documents = append(documents, document{key: key, value: term})
+		if i < search.MaxTermExpansions {
+			fuzzyWant = append(fuzzyWant, key)
+		}
+	}
+
+	seed := func(t *testing.T, c graphv1connect.LanternServiceClient, order []int, churn bool) {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		exp := timestamppb.New(time.Now().Add(time.Hour))
+		if churn {
+			var transient []*pb.Vertex
+			for i := 0; i < len(documents); i += 3 {
+				transient = append(transient, &pb.Vertex{
+					Key:        documents[i].key,
+					Value:      &pb.Vertex_String_{String_: fmt.Sprintf("temporary%03d", i)},
+					Expiration: exp,
+				})
+			}
+			if _, err := c.PutVertices(ctx, connect.NewRequest(&pb.PutVerticesRequest{Vertices: transient})); err != nil {
+				t.Fatalf("PutVertices transient: %v", err)
+			}
+		}
+		vertices := make([]*pb.Vertex, 0, len(order))
+		for _, i := range order {
+			vertices = append(vertices, &pb.Vertex{
+				Key:        documents[i].key,
+				Value:      &pb.Vertex_String_{String_: documents[i].value},
+				Expiration: exp,
+			})
+		}
+		if _, err := c.PutVertices(ctx, connect.NewRequest(&pb.PutVerticesRequest{Vertices: vertices})); err != nil {
+			t.Fatalf("PutVertices final: %v", err)
+		}
+	}
+
+	forward := make([]int, len(documents))
+	for i := range forward {
+		forward[i] = i
+	}
+	reverse := append([]int(nil), forward...)
+	for i, j := 0, len(reverse)-1; i < j; i, j = i+1, j-1 {
+		reverse[i], reverse[j] = reverse[j], reverse[i]
+	}
+	random := append([]int(nil), forward...)
+	rand.New(rand.NewSource(1056)).Shuffle(len(random), func(i, j int) {
+		random[i], random[j] = random[j], random[i]
+	})
+	histories := []struct {
+		name  string
+		order []int
+		churn bool
+	}{
+		{"forward", forward, false},
+		{"reverse", reverse, false},
+		{"random", random, false},
+		{"release-reuse", reverse, true},
+	}
+	tests := []struct {
+		name    string
+		query   string
+		options *pb.SearchOptions
+		want    []string
+	}{
+		{"prefix", "pr", &pb.SearchOptions{PrefixTerms: true}, prefixWant},
+		{"fuzzy", "aa", &pb.SearchOptions{Fuzziness: 1}, fuzzyWant},
+	}
+
+	baseline := make(map[string][]byte, len(tests))
+	for _, history := range histories {
+		t.Run(history.name, func(t *testing.T) {
+			c := newSearchRawClient(t, true)
+			seed(t, c, history.order, history.churn)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			for _, tc := range tests {
+				t.Run(tc.name, func(t *testing.T) {
+					for repeat := 0; repeat < 100; repeat++ {
+						resp, err := c.SearchVertices(ctx, connect.NewRequest(&pb.SearchVerticesRequest{
+							Query:   tc.query,
+							Limit:   100,
+							Options: tc.options,
+						}))
+						if err != nil {
+							t.Fatalf("repeat %d SearchVertices: %v", repeat, err)
+						}
+						gotKeys := make([]string, len(resp.Msg.GetHits()))
+						for i, hit := range resp.Msg.GetHits() {
+							gotKeys[i] = hit.GetKey()
+						}
+						if !slices.Equal(gotKeys, tc.want) {
+							t.Fatalf("repeat %d keys = %v, want %v", repeat, gotKeys, tc.want)
+						}
+						wire, err := proto.MarshalOptions{Deterministic: true}.Marshal(resp.Msg)
+						if err != nil {
+							t.Fatalf("marshal response: %v", err)
+						}
+						if want, ok := baseline[tc.name]; !ok {
+							baseline[tc.name] = append([]byte(nil), wire...)
+						} else if !bytes.Equal(wire, want) {
+							t.Fatalf("repeat %d response bytes differ across calls/histories", repeat)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
 // TestSearchVertices_PositionsOff verifies the #908 opt-out end to end through
 // the RPC: with LANTERN_SEARCH_POSITIONS=false the index keeps no positions, so
 // a phrase query degrades to the AND-intersection (every word present, adjacency
@@ -300,7 +446,7 @@ func TestSearchVertices_PositionsOff(t *testing.T) {
 	// Build a search-enabled service whose cache index tracks no positions.
 	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
 	cache.EnablePrefixIndex(func(k string) string { return k })
-	cache.EnableSearchIndex(searchVertexDocument, graphcache.WithoutSearchPositions())
+	cache.EnableSearchIndex(searchVertexDocument, strings.Compare, graphcache.WithoutSearchPositions())
 	svc := service.NewLanternService(cache).WithSearchLimits(service.SearchLimits{
 		Enabled:      true,
 		DefaultLimit: 100,


### PR DESCRIPTION
## Summary

- define one external search order: `(score DESC, raw key ASC)` in production and `(score DESC, typed ID comparator ASC)` in generic core
- sort distinct query clauses before scoring so floating-point contribution order and score bits are repeatable
- select exact/prefix/fuzzy expansion survivors semantically instead of by reusable internal term IDs
- exclude NaN, infinity, and finite overflow from exhaustive, top-k, phrase, and proximity ranking
- remove relevance-harness tie repair and publish the contract through proto, generated bindings, SDK docs, and examples

## Contract decisions

- `PrefixTerms + Fuzziness` orders exact first, then prefix matches by `(rune extension length ASC, normalized term ASC)`, then fuzzy-only matches by `(edit distance ASC, normalized term ASC)`. Prefix/fuzzy overlap is classified once as prefix.
- Expanded terms retain the existing raw BM25 sum. The new cap-overflow qrels measure this decision; no unmeasured distance multiplier was added.
- `S comparable` cannot provide a history-independent total order. `NewInvertedIndex` and `GraphCache.EnableSearchIndex` therefore require a typed comparator; production passes `strings.Compare`. This is an intentional pre-v1 source API change.
- Full mutation-stream, snapshot, anti-entropy, and restore convergence remains #1062. This PR proves the deterministic prerequisite across equivalent history-divergent indexes and independent real h2c servers.

## Implementation

- centralize exhaustive and bounded ranking on one comparator, including the k-th tie boundary and phrase results
- replace map-iteration scoring with stable `(class, normalized term)` slices
- retain semantic best-50 expansions with an O(50) query-local heap; no retained dictionary structure is added
- use a verified Myers bit-vector fast path for valid ASCII queries up to 64 bytes, with lazy rune-DP fallback for Unicode, invalid UTF-8, and longer queries
- keep release/reuse churn semantics and term IDs private to storage
- make `search_churn` exercise independent prefix and fuzzy cap-overflow clauses under TTL churn

## Verification

Functional and property coverage:

- forward, reverse, fixed-random, and release/reuse histories
- 100 repeated equal-score and near-tie queries with exact score-bit and top-k membership assertions
- independent full-sort Levenshtein expansion oracle over 100 shuffled histories
- exhaustive short-binary Myers parity, every pattern length 1..64, boundary mutations, NUL/DEL, invalid UTF-8, Unicode, and 65-byte fallback
- four independent real Connect/h2c servers, 100 calls per prefix/fuzzy mode, exact deterministic protobuf-byte equality
- cap-overflow prefix/fuzzy qrels: nDCG@10=1.0000, MRR=1.0000, Recall@50=1.0000
- existing relevance floors remain unchanged and green: en 0.9307/1.0000/0.9531, ja 0.9118/1.0000/0.7282, mixed 0.9567/1.0000/0.7917

Quality gates:

- `go test ./...` passed in root, pb, core, sdks/go, server, and mcp modules
- `go test -race ./search ./graphcache` passed
- Dart format/analyze/test passed; analyze still reports the pre-existing info at `traversal.dart:151`
- Node typecheck/lint/format/test/build passed
- Buf lint/format and generated-code idempotency passed

Performance on Apple M3 Max, 200 ms, count=3:

- balanced sparse 1M dictionary average per query: Prefix 5.04 ms, Fuzzy1 15.09 ms, Fuzzy2 19.40 ms
- 1M cap-overflow: Prefix 3.25 ms, Fuzzy1 10.84 ms, Fuzzy2 12.95 ms, combined 13.00 ms
- cap-overflow allocation is constant across 10k/100k/1M: 2,672 B and 9 allocs per query
- broad SearchTopK-10 median is 5.07 ms versus 4.93 ms on `origin/main` on the same machine; result bytes are effectively unchanged
- exhaustive all-tie Search is 8.01 ms versus 5.48 ms because the new contract now performs the required lexical tie sort; the production RPC uses bounded top-k

Full Docker `search_churn` release scenario:

- leak gate: pass; post-cooldown heap_alloc deltas were -6.0, -13.1, and -6.5 MiB
- perf gate: pass at 1999.9 aggregate RPS, 15.50 ms worst p99, and 3/239,998 non-OK calls (closed-connection Unavailable, ratio 0.0000125)

Generated Node output also picked up pre-existing proto expiration comments when the official codegen script was rerun; this is comment-only generated drift.

Closes #1056