### PR TITLE
fix(search): make incremental search latest-input-wins across Go, Node, and Admin

### DIFF
--- a/admin/app/lib/client/usecase/search-vertices/driver.test.ts
+++ b/admin/app/lib/client/usecase/search-vertices/driver.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "bun:test";
+import type { SearchResultRow, SearchVerticesState } from "./state";
+import {
+  INITIAL_SEARCH_VERTICES_STATE,
+  DEFAULT_SEARCH_QUERY_OPTIONS,
+} from "./state";
+import { searchVerticesReducer, type SearchVerticesAction } from "./reducer";
+import {
+  createSearchVerticesDriver,
+  type SearchVerticesInput,
+  type SearchVerticesRunner,
+  type SearchVerticesScheduler,
+} from "./driver";
+
+class FakeScheduler implements SearchVerticesScheduler {
+  #now = 0;
+  #nextID = 0;
+  #tasks = new Map<number, { at: number; callback: () => void }>();
+
+  setTimeout(callback: () => void, delayMs: number): number {
+    const id = ++this.#nextID;
+    this.#tasks.set(id, { at: this.#now + delayMs, callback });
+    return id;
+  }
+
+  clearTimeout(handle: unknown): void {
+    this.#tasks.delete(handle as number);
+  }
+
+  advanceBy(delayMs: number): void {
+    const target = this.#now + delayMs;
+    for (;;) {
+      const next = [...this.#tasks.entries()]
+        .filter(([, task]) => task.at <= target)
+        .sort((a, b) => a[1].at - b[1].at || a[0] - b[0])[0];
+      if (next === undefined) break;
+      const [id, task] = next;
+      this.#tasks.delete(id);
+      this.#now = task.at;
+      task.callback();
+    }
+    this.#now = target;
+  }
+
+  get pending(): number {
+    return this.#tasks.size;
+  }
+}
+
+interface PendingCall {
+  query: string;
+  epoch: number;
+  signal: AbortSignal;
+  resolve: (rows: SearchResultRow[]) => void;
+  reject: (error: Error) => void;
+}
+
+function harness() {
+  const scheduler = new FakeScheduler();
+  let state: SearchVerticesState = INITIAL_SEARCH_VERTICES_STATE;
+  const dispatch = (action: SearchVerticesAction) => {
+    state = searchVerticesReducer(state, action);
+  };
+  const calls: PendingCall[] = [];
+  const run: SearchVerticesRunner = (request, send) => {
+    send({ type: "SEARCH_REQUESTED", epoch: request.epoch });
+    return new Promise<SearchResultRow[]>((resolve, reject) => {
+      calls.push({
+        query: request.query,
+        epoch: request.epoch,
+        signal: request.signal!,
+        resolve,
+        reject,
+      });
+    }).then(
+      (results) =>
+        send({ type: "SEARCH_RECEIVED", epoch: request.epoch, results }),
+      (error: Error) =>
+        send({
+          type: "SEARCH_FAILED",
+          epoch: request.epoch,
+          error: error.message,
+        }),
+    );
+  };
+  const driver = createSearchVerticesDriver({ dispatch, run, scheduler });
+  const input = (
+    query: string,
+    options = DEFAULT_SEARCH_QUERY_OPTIONS,
+  ): SearchVerticesInput => ({
+    client: {} as SearchVerticesInput["client"],
+    query,
+    limit: 25,
+    options,
+  });
+  return { scheduler, calls, driver, input, state: () => state };
+}
+
+const OLD_ROW: SearchResultRow = {
+  key: "old",
+  score: 1,
+  vertex: null,
+};
+
+describe("search vertices latest-input-wins driver", () => {
+  for (const outcome of ["success", "error"] as const) {
+    it(`invalidates an old ${outcome} before the next debounce expires`, async () => {
+      const h = harness();
+      h.driver.update(h.input("old"), 100);
+      h.scheduler.advanceBy(100);
+      expect(h.calls).toHaveLength(1);
+      expect(h.state().status).toBe("loading");
+
+      h.driver.update(h.input("new"), 100);
+      expect(h.calls[0]!.signal.aborted).toBe(true);
+      expect(h.state().query).toBe("new");
+      expect(h.state().status).toBe("idle");
+
+      if (outcome === "success") h.calls[0]!.resolve([OLD_ROW]);
+      else h.calls[0]!.reject(new Error("late old error"));
+      await Promise.resolve();
+      expect(h.state().results).toEqual([]);
+      expect(h.state().error).toBeNull();
+
+      h.scheduler.advanceBy(99);
+      expect(h.calls).toHaveLength(1);
+      h.scheduler.advanceBy(1);
+      expect(h.calls.map((call) => call.query)).toEqual(["old", "new"]);
+    });
+  }
+
+  it("clears an empty input synchronously and makes no replacement call", () => {
+    const h = harness();
+    h.driver.update(h.input("old"), 10);
+    h.scheduler.advanceBy(10);
+
+    h.driver.update(h.input(""), 10);
+    expect(h.calls[0]!.signal.aborted).toBe(true);
+    expect(h.state().query).toBe("");
+    expect(h.state().status).toBe("idle");
+    expect(h.scheduler.pending).toBe(0);
+    h.scheduler.advanceBy(100);
+    expect(h.calls).toHaveLength(1);
+  });
+
+  it("tracks retry work and invalidates it on newer options or cleanup", async () => {
+    const h = harness();
+    const firstEpoch = h.driver.update(h.input("alpha beta"), 10);
+    h.scheduler.advanceBy(10);
+    h.driver.retry(h.input("alpha beta"), firstEpoch);
+    expect(h.calls).toHaveLength(2);
+    expect(h.calls[0]!.signal.aborted).toBe(true);
+    expect(h.state().queryEpoch).toBe(firstEpoch + 1);
+    h.calls[0]!.resolve([OLD_ROW]); // cancellation loses, but epoch must win
+    await Promise.resolve();
+    expect(h.state().results).toEqual([]);
+
+    const nextEpoch = h.driver.update(
+      h.input("alpha beta", {
+        matchMode: "all",
+        phrase: false,
+        fuzzy: false,
+      }),
+      10,
+    );
+    expect(h.calls[1]!.signal.aborted).toBe(true);
+    expect(h.state().queryEpoch).toBe(nextEpoch);
+    expect(h.state().options.matchMode).toBe("all");
+    expect(h.scheduler.pending).toBe(1);
+
+    h.driver.cancel();
+    expect(h.scheduler.pending).toBe(0);
+    h.scheduler.advanceBy(100);
+    expect(h.calls).toHaveLength(2);
+  });
+});

--- a/admin/app/lib/client/usecase/search-vertices/driver.ts
+++ b/admin/app/lib/client/usecase/search-vertices/driver.ts
@@ -1,0 +1,122 @@
+import type { SearchVerticesAction } from "./reducer";
+import type { FetchSearchResultsInput } from "./handlers";
+import type { SearchQueryOptions } from "./state";
+
+export interface SearchVerticesInput {
+  client: FetchSearchResultsInput["client"];
+  query: string;
+  limit: number;
+  prefix?: string;
+  options: SearchQueryOptions;
+}
+
+export interface SearchVerticesScheduler {
+  setTimeout(callback: () => void, delayMs: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
+export type SearchVerticesRunner = (
+  input: FetchSearchResultsInput,
+  dispatch: (action: SearchVerticesAction) => void,
+) => Promise<void>;
+
+export interface SearchVerticesDriver {
+  /** Invalidates old work immediately and debounces only the new RPC start. */
+  update(input: SearchVerticesInput, debounceMs: number): number;
+  /** Re-runs the current input immediately when its epoch is still live. */
+  retry(input: SearchVerticesInput, epoch: number): void;
+  /** Cancels timers, primary calls, and retries owned by this lifecycle. */
+  cancel(): void;
+}
+
+interface CreateSearchVerticesDriverOptions {
+  dispatch: (action: SearchVerticesAction) => void;
+  run: SearchVerticesRunner;
+  scheduler: SearchVerticesScheduler;
+}
+
+/**
+ * Owns latest-input-wins orchestration independently of React rendering.
+ * Keeping timer and AbortController ownership here makes input invalidation
+ * synchronous and lets tests drive the debounce with a deterministic clock.
+ */
+export function createSearchVerticesDriver({
+  dispatch,
+  run,
+  scheduler,
+}: CreateSearchVerticesDriverOptions): SearchVerticesDriver {
+  let epoch = 0;
+  let timer: unknown;
+  const active = new Set<AbortController>();
+
+  const clearTimer = () => {
+    if (timer === undefined) return;
+    scheduler.clearTimeout(timer);
+    timer = undefined;
+  };
+
+  const abortActive = () => {
+    for (const controller of active) controller.abort();
+    active.clear();
+  };
+
+  const start = (input: SearchVerticesInput, expectedEpoch: number) => {
+    if (expectedEpoch !== epoch) return;
+    const controller = new AbortController();
+    active.add(controller);
+    void run(
+      { ...input, epoch: expectedEpoch, signal: controller.signal },
+      dispatch,
+    ).finally(() => active.delete(controller));
+  };
+
+  return {
+    update(input, debounceMs) {
+      epoch++;
+      const nextEpoch = epoch;
+      clearTimer();
+      abortActive();
+      dispatch({
+        type: "INPUT_CHANGED",
+        query: input.query,
+        options: input.options,
+        epoch: nextEpoch,
+      });
+
+      if (input.query.length === 0) return nextEpoch;
+      timer = scheduler.setTimeout(() => {
+        timer = undefined;
+        start(input, nextEpoch);
+      }, debounceMs);
+      return nextEpoch;
+    },
+
+    retry(input, expectedEpoch) {
+      if (input.query.length === 0 || expectedEpoch !== epoch) return;
+      epoch++;
+      const retryEpoch = epoch;
+      clearTimer();
+      abortActive();
+      // A retry is a distinct attempt. Advancing the reducer epoch prevents
+      // an aborted predecessor that still fulfills from overwriting it.
+      dispatch({
+        type: "INPUT_CHANGED",
+        query: input.query,
+        options: input.options,
+        epoch: retryEpoch,
+      });
+      start(input, retryEpoch);
+    },
+
+    cancel() {
+      epoch++;
+      clearTimer();
+      abortActive();
+    },
+  };
+}
+
+export const browserSearchVerticesScheduler: SearchVerticesScheduler = {
+  setTimeout: (callback, delayMs) => window.setTimeout(callback, delayMs),
+  clearTimeout: (handle) => window.clearTimeout(handle as number),
+};

--- a/admin/app/lib/client/usecase/search-vertices/reducer.test.ts
+++ b/admin/app/lib/client/usecase/search-vertices/reducer.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from "bun:test";
 import { searchVerticesReducer, type SearchVerticesAction } from "./reducer";
 import {
+  DEFAULT_SEARCH_QUERY_OPTIONS,
   INITIAL_SEARCH_VERTICES_STATE,
   type SearchResultRow,
   type SearchVerticesState,
 } from "./state";
+
+function input(
+  query: string,
+  epoch: number,
+  options = DEFAULT_SEARCH_QUERY_OPTIONS,
+): SearchVerticesAction {
+  return { type: "INPUT_CHANGED", query, epoch, options };
+}
 
 function reduce(
   state: SearchVerticesState,
@@ -21,10 +30,7 @@ const ROW: SearchResultRow = {
 
 describe("searchVerticesReducer", () => {
   it("bumps the epoch and clears prior results on a new query", () => {
-    const next = reduce(INITIAL_SEARCH_VERTICES_STATE, {
-      type: "QUERY_CHANGED",
-      query: "alpha",
-    });
+    const next = reduce(INITIAL_SEARCH_VERTICES_STATE, input("alpha", 1));
     expect(next.query).toBe("alpha");
     expect(next.queryEpoch).toBe(1);
     expect(next.status).toBe("idle");
@@ -32,16 +38,10 @@ describe("searchVerticesReducer", () => {
     expect(next.error).toBeNull();
   });
 
-  it("ignores a QUERY_CHANGED that does not change the query", () => {
-    const seeded = reduce(INITIAL_SEARCH_VERTICES_STATE, {
-      type: "QUERY_CHANGED",
-      query: "alpha",
-    });
-    const same = searchVerticesReducer(seeded, {
-      type: "QUERY_CHANGED",
-      query: "alpha",
-    });
-    // Identity preserved → no epoch bump, no re-fetch.
+  it("ignores an input action whose epoch is not newer", () => {
+    const seeded = reduce(INITIAL_SEARCH_VERTICES_STATE, input("alpha", 1));
+    const same = searchVerticesReducer(seeded, input("alpha", 1));
+    // Identity preserved: an old effect cannot rewind the live lifecycle.
     expect(same).toBe(seeded);
     expect(same.queryEpoch).toBe(1);
   });
@@ -49,14 +49,11 @@ describe("searchVerticesReducer", () => {
   it("resets to the empty state (but advances epoch) when the query is cleared", () => {
     const seeded = reduce(
       INITIAL_SEARCH_VERTICES_STATE,
-      { type: "QUERY_CHANGED", query: "alpha" },
+      input("alpha", 1),
       { type: "SEARCH_REQUESTED", epoch: 1 },
       { type: "SEARCH_RECEIVED", epoch: 1, results: [ROW] },
     );
-    const cleared = searchVerticesReducer(seeded, {
-      type: "QUERY_CHANGED",
-      query: "",
-    });
+    const cleared = searchVerticesReducer(seeded, input("", 2));
     expect(cleared.query).toBe("");
     expect(cleared.results).toEqual([]);
     expect(cleared.status).toBe("idle");
@@ -67,7 +64,7 @@ describe("searchVerticesReducer", () => {
   it("applies a search result that matches the live epoch", () => {
     const next = reduce(
       INITIAL_SEARCH_VERTICES_STATE,
-      { type: "QUERY_CHANGED", query: "alpha" },
+      input("alpha", 1),
       { type: "SEARCH_REQUESTED", epoch: 1 },
       { type: "SEARCH_RECEIVED", epoch: 1, results: [ROW] },
     );
@@ -78,7 +75,7 @@ describe("searchVerticesReducer", () => {
   it("treats a zero-result response as a ready, empty success", () => {
     const next = reduce(
       INITIAL_SEARCH_VERTICES_STATE,
-      { type: "QUERY_CHANGED", query: "nomatch" },
+      input("nomatch", 1),
       { type: "SEARCH_REQUESTED", epoch: 1 },
       { type: "SEARCH_RECEIVED", epoch: 1, results: [] },
     );
@@ -91,9 +88,9 @@ describe("searchVerticesReducer", () => {
     // Type "ab" (epoch 1), then "abc" (epoch 2) before "ab"'s search lands.
     const seeded = reduce(
       INITIAL_SEARCH_VERTICES_STATE,
-      { type: "QUERY_CHANGED", query: "ab" },
+      input("ab", 1),
       { type: "SEARCH_REQUESTED", epoch: 1 },
-      { type: "QUERY_CHANGED", query: "abc" },
+      input("abc", 2),
     );
     expect(seeded.queryEpoch).toBe(2);
 
@@ -119,7 +116,7 @@ describe("searchVerticesReducer", () => {
   it("records a search failure and clears results on the live epoch", () => {
     const next = reduce(
       INITIAL_SEARCH_VERTICES_STATE,
-      { type: "QUERY_CHANGED", query: "boom" },
+      input("boom", 1),
       { type: "SEARCH_REQUESTED", epoch: 1 },
       { type: "SEARCH_RECEIVED", epoch: 1, results: [ROW] },
       { type: "SEARCH_FAILED", epoch: 1, error: "unavailable" },
@@ -132,7 +129,7 @@ describe("searchVerticesReducer", () => {
   it("enters the disabled state (no error) when the index is off", () => {
     const next = reduce(
       INITIAL_SEARCH_VERTICES_STATE,
-      { type: "QUERY_CHANGED", query: "alpha" },
+      input("alpha", 1),
       { type: "SEARCH_REQUESTED", epoch: 1 },
       { type: "SEARCH_DISABLED", epoch: 1 },
     );
@@ -144,8 +141,8 @@ describe("searchVerticesReducer", () => {
   it("drops a stale SEARCH_DISABLED from an abandoned query", () => {
     const seeded = reduce(
       INITIAL_SEARCH_VERTICES_STATE,
-      { type: "QUERY_CHANGED", query: "ab" },
-      { type: "QUERY_CHANGED", query: "abc" },
+      input("ab", 1),
+      input("abc", 2),
     );
     const afterStale = searchVerticesReducer(seeded, {
       type: "SEARCH_DISABLED",
@@ -158,14 +155,18 @@ describe("searchVerticesReducer", () => {
   it("bumps the epoch and re-runs the live query when an option changes", () => {
     const seeded = reduce(
       INITIAL_SEARCH_VERTICES_STATE,
-      { type: "QUERY_CHANGED", query: "alpha beta" },
+      input("alpha beta", 1),
       { type: "SEARCH_REQUESTED", epoch: 1 },
       { type: "SEARCH_RECEIVED", epoch: 1, results: [ROW] },
     );
-    const next = searchVerticesReducer(seeded, {
-      type: "OPTIONS_CHANGED",
-      options: { matchMode: "all", phrase: false, fuzzy: false },
-    });
+    const next = searchVerticesReducer(
+      seeded,
+      input("alpha beta", 2, {
+        matchMode: "all",
+        phrase: false,
+        fuzzy: false,
+      }),
+    );
     expect(next.options.matchMode).toBe("all");
     // A changed control re-runs the query, exactly like a keystroke.
     expect(next.queryEpoch).toBe(2);
@@ -174,25 +175,11 @@ describe("searchVerticesReducer", () => {
     expect(next.error).toBeNull();
   });
 
-  it("ignores an OPTIONS_CHANGED that changes nothing", () => {
-    const seeded = reduce(INITIAL_SEARCH_VERTICES_STATE, {
-      type: "QUERY_CHANGED",
-      query: "alpha",
-    });
-    const same = searchVerticesReducer(seeded, {
-      type: "OPTIONS_CHANGED",
-      options: { matchMode: "any", phrase: false, fuzzy: false },
-    });
-    // Identity preserved → no epoch bump, no re-fetch.
-    expect(same).toBe(seeded);
-    expect(same.queryEpoch).toBe(1);
-  });
-
   it("advances the epoch but stays inert when options change with no query", () => {
-    const next = searchVerticesReducer(INITIAL_SEARCH_VERTICES_STATE, {
-      type: "OPTIONS_CHANGED",
-      options: { matchMode: "any", phrase: true, fuzzy: false },
-    });
+    const next = searchVerticesReducer(
+      INITIAL_SEARCH_VERTICES_STATE,
+      input("", 1, { matchMode: "any", phrase: true, fuzzy: false }),
+    );
     expect(next.options.phrase).toBe(true);
     // Epoch advances so a slow reply from the prior options cannot land,
     // but the empty query means the effect issues no fetch.
@@ -204,16 +191,17 @@ describe("searchVerticesReducer", () => {
   it("preserves the chosen options when the query is cleared", () => {
     const seeded = reduce(
       INITIAL_SEARCH_VERTICES_STATE,
-      { type: "QUERY_CHANGED", query: "alpha" },
-      {
-        type: "OPTIONS_CHANGED",
-        options: { matchMode: "all", phrase: true, fuzzy: false },
-      },
+      input("alpha", 1),
+      input("alpha", 2, {
+        matchMode: "all",
+        phrase: true,
+        fuzzy: false,
+      }),
     );
-    const cleared = searchVerticesReducer(seeded, {
-      type: "QUERY_CHANGED",
-      query: "",
-    });
+    const cleared = searchVerticesReducer(
+      seeded,
+      input("", 3, { matchMode: "all", phrase: true, fuzzy: false }),
+    );
     expect(cleared.query).toBe("");
     expect(cleared.options).toEqual({
       matchMode: "all",

--- a/admin/app/lib/client/usecase/search-vertices/reducer.ts
+++ b/admin/app/lib/client/usecase/search-vertices/reducer.ts
@@ -6,8 +6,12 @@ import {
 } from "./state";
 
 export type SearchVerticesAction =
-  | { type: "QUERY_CHANGED"; query: string }
-  | { type: "OPTIONS_CHANGED"; options: SearchQueryOptions }
+  | {
+      type: "INPUT_CHANGED";
+      query: string;
+      options: SearchQueryOptions;
+      epoch: number;
+    }
   | { type: "SEARCH_REQUESTED"; epoch: number }
   | { type: "SEARCH_RECEIVED"; epoch: number; results: SearchResultRow[] }
   | { type: "SEARCH_FAILED"; epoch: number; error: string }
@@ -19,32 +23,32 @@ export type SearchVerticesAction =
  * `queryEpoch` is dropped, so a slow reply from an abandoned query cannot
  * overwrite fresher results even if its AbortController loses the race.
  * This is the unit-testable heart of the debounce-and-cancel behaviour
- * required by #627.
+ * required by #627 and the latest-input-wins contract in #1052.
  */
 export function searchVerticesReducer(
   state: SearchVerticesState,
   action: SearchVerticesAction,
 ): SearchVerticesState {
   switch (action.type) {
-    case "QUERY_CHANGED": {
-      if (action.query === state.query) {
+    case "INPUT_CHANGED": {
+      if (action.epoch <= state.queryEpoch) {
         return state;
       }
-      const queryEpoch = state.queryEpoch + 1;
       if (action.query.length === 0) {
         // Empty query shows no results and issues no request, but the
         // epoch still advances so any in-flight reply is discarded. The
         // operator's chosen options survive the clear.
         return {
           ...INITIAL_SEARCH_VERTICES_STATE,
-          options: state.options,
-          queryEpoch,
+          options: action.options,
+          queryEpoch: action.epoch,
         };
       }
       return {
         ...state,
         query: action.query,
-        queryEpoch,
+        queryEpoch: action.epoch,
+        options: action.options,
         status: "idle",
         results: [],
         error: null,
@@ -81,36 +85,8 @@ export function searchVerticesReducer(
       // outcome (opt-out), not a failure. Clear any prior error.
       return { ...state, status: "disabled", results: [], error: null };
     }
-    case "OPTIONS_CHANGED": {
-      if (sameOptions(action.options, state.options)) {
-        return state;
-      }
-      // A changed relevance control re-runs the live query under a fresh
-      // epoch, exactly like a keystroke. An empty query stays inert (the
-      // effect skips the fetch), but the epoch still advances so a slow
-      // reply from the previous options cannot land.
-      const queryEpoch = state.queryEpoch + 1;
-      if (state.query.length === 0) {
-        return { ...state, options: action.options, queryEpoch };
-      }
-      return {
-        ...state,
-        options: action.options,
-        queryEpoch,
-        status: "idle",
-        results: [],
-        error: null,
-      };
-    }
     default: {
       return state;
     }
   }
-}
-
-/** Structural equality for the relevance controls, used to drop no-op changes. */
-function sameOptions(a: SearchQueryOptions, b: SearchQueryOptions): boolean {
-  return (
-    a.matchMode === b.matchMode && a.phrase === b.phrase && a.fuzzy === b.fuzzy
-  );
 }

--- a/admin/app/lib/client/usecase/search-vertices/state.ts
+++ b/admin/app/lib/client/usecase/search-vertices/state.ts
@@ -3,8 +3,8 @@ import type { Vertex } from "~/lib/client/infrastructure/api/types";
 /**
  * State for the vertex content-search screen (#627).
  *
- * The screen debounces the user's query, runs the server's BM25 keyword
- * search, then hydrates the ranked `{ key, score }` hits back into full
+ * The screen invalidates on every input immediately, debounces the matching
+ * BM25 keyword search, then hydrates ranked `{ key, score }` hits into full
  * vertices (preserving rank order) for display. Async I/O lives in
  * `handlers.ts`; this module and `reducer.ts` are the pure, unit-testable
  * core. Every server response carries the `queryEpoch` it was issued
@@ -58,7 +58,7 @@ export const DEFAULT_SEARCH_QUERY_OPTIONS: SearchQueryOptions = {
 };
 
 export interface SearchVerticesState {
-  /** The debounced query currently being searched. */
+  /** The latest input query; only the matching RPC start is debounced. */
   query: string;
   /** Monotonic counter bumped on every query or option change. */
   queryEpoch: number;

--- a/admin/app/lib/client/usecase/search-vertices/use-search-vertices.ts
+++ b/admin/app/lib/client/usecase/search-vertices/use-search-vertices.ts
@@ -1,7 +1,18 @@
-import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useReducer,
+  useState,
+} from "react";
 import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
 import { fetchSearchResults } from "./handlers";
-import { searchVerticesReducer, type SearchVerticesAction } from "./reducer";
+import {
+  browserSearchVerticesScheduler,
+  createSearchVerticesDriver,
+  type SearchVerticesInput,
+} from "./driver";
+import { searchVerticesReducer } from "./reducer";
 import {
   INITIAL_SEARCH_VERTICES_STATE,
   type SearchMatchMode,
@@ -63,69 +74,35 @@ export function useSearchVertices(
     INITIAL_SEARCH_VERTICES_STATE,
   );
 
-  // Debounce the live query into the reducer.
-  useEffect(() => {
-    const handle = window.setTimeout(() => {
-      dispatch({ type: "QUERY_CHANGED", query: rawQuery });
-    }, debounceMs);
-    return () => window.clearTimeout(handle);
-  }, [rawQuery, debounceMs]);
+  const [driver] = useState(() =>
+    createSearchVerticesDriver({
+      dispatch,
+      run: fetchSearchResults,
+      scheduler: browserSearchVerticesScheduler,
+    }),
+  );
 
-  // Fold option changes into the reducer immediately: toggling a control is
-  // a deliberate act, not a per-keystroke storm, so it needs no debounce.
-  // The reducer bumps the epoch, which re-runs the live query below.
-  useEffect(() => {
-    dispatch({
-      type: "OPTIONS_CHANGED",
+  const input = useMemo<SearchVerticesInput>(
+    () => ({
+      client,
+      query: rawQuery,
+      limit,
+      prefix,
       options: { matchMode, phrase, fuzzy },
-    });
-  }, [matchMode, phrase, fuzzy]);
+    }),
+    [client, rawQuery, limit, prefix, matchMode, phrase, fuzzy],
+  );
 
-  // On every query change, search + hydrate under a fresh AbortController.
-  const lastEpochRef = useRef<number>(-1);
-  useEffect(() => {
-    if (state.queryEpoch === lastEpochRef.current) {
-      return;
-    }
-    lastEpochRef.current = state.queryEpoch;
-    if (state.query.length === 0) {
-      // Empty query: nothing to fetch (the reducer already cleared state).
-      return;
-    }
-    const controller = new AbortController();
-    void fetchSearchResults(
-      {
-        client,
-        query: state.query,
-        limit,
-        prefix,
-        options: state.options,
-        epoch: state.queryEpoch,
-        signal: controller.signal,
-      },
-      dispatch as (action: SearchVerticesAction) => void,
-    );
-    return () => controller.abort();
-  }, [client, state.query, state.queryEpoch, state.options, limit, prefix]);
+  // Invalidate the old epoch during the commit that displays the new input.
+  // Only starting the replacement RPC is debounced.
+  useLayoutEffect(() => {
+    driver.update(input, debounceMs);
+    return () => driver.cancel();
+  }, [driver, input, debounceMs]);
 
   const retry = useCallback(() => {
-    if (state.query.length === 0) {
-      return;
-    }
-    // Re-run under the live epoch so the reducer accepts the response; the
-    // detached controller mirrors Browse Vertices' manual refresh.
-    void fetchSearchResults(
-      {
-        client,
-        query: state.query,
-        limit,
-        prefix,
-        options: state.options,
-        epoch: state.queryEpoch,
-      },
-      dispatch as (action: SearchVerticesAction) => void,
-    );
-  }, [client, state.query, state.queryEpoch, state.options, limit, prefix]);
+    driver.retry(input, state.queryEpoch);
+  }, [driver, input, state.queryEpoch]);
 
   return useMemo<UseSearchVerticesResult>(
     () => ({ state, retry }),

--- a/sdks/dart/test/search_test.dart
+++ b/sdks/dart/test/search_test.dart
@@ -152,6 +152,7 @@ void main() {
     'newer query cancels and stale success or error cannot overwrite',
     () async {
       final firstStarted = Completer<void>();
+      final firstCanceled = Completer<void>();
       final first = Completer<graph.SearchVerticesResponse>();
       final transport = FakeTransportBuilder()
           .unary<graph.SearchVerticesRequest, graph.SearchVerticesResponse>(
@@ -159,6 +160,9 @@ void main() {
             (request, context) {
               if (request.query == 'old') {
                 firstStarted.complete();
+                context.signal.future.then((_) {
+                  if (!firstCanceled.isCompleted) firstCanceled.complete();
+                });
                 return first.future;
               }
               return graph.SearchVerticesResponse(
@@ -168,7 +172,9 @@ void main() {
           )
           .build();
       final session = _client(transport).incrementalSearch(
-        options: const IncrementalSearchOptions(debounce: Duration.zero),
+        options: const IncrementalSearchOptions(
+          debounce: Duration(milliseconds: 80),
+        ),
       );
       addTearDown(session.dispose);
       final delivered = <SearchUpdate>[];
@@ -178,6 +184,9 @@ void main() {
       session.search('old');
       await firstStarted.future;
       session.search('new');
+      // Cancellation belongs to the input call, before the replacement's
+      // debounce expires.
+      await firstCanceled.future.timeout(const Duration(milliseconds: 30));
       await session.updates.firstWhere(
         (update) =>
             update.query == 'new' && update.phase == SearchUpdatePhase.results,

--- a/sdks/go/search_incremental.go
+++ b/sdks/go/search_incremental.go
@@ -95,19 +95,21 @@ type IncrementalSearch struct {
 	opts incrementalSearchOptions
 
 	updates chan SearchUpdate
-	wake    chan struct{}
 
 	ctx    context.Context
 	cancel context.CancelFunc
 	done   chan struct{}
 
-	mu     sync.Mutex
-	latest string
-	dirty  bool
+	mu           sync.Mutex
+	closed       bool
+	timer        *time.Timer
+	searchCancel context.CancelFunc
+	searchEpoch  uint64
+	workers      sync.WaitGroup
 
-	// epoch is bumped once per dispatched search (real or short-circuit). A
-	// reply is delivered only while epoch still equals the value its dispatch
-	// recorded, so a late reply from a superseded query is dropped.
+	// epoch is bumped once per input, before its debounce starts. A reply is
+	// delivered only while epoch still equals the value that input recorded,
+	// so an old RPC cannot publish during the next input's debounce window.
 	epoch     atomic.Uint64
 	deliverMu sync.Mutex
 
@@ -115,9 +117,9 @@ type IncrementalSearch struct {
 }
 
 // NewIncrementalSearch starts a search-as-you-type driver bound to ctx and
-// returns it. The driver owns one background goroutine that debounces Search
-// calls, issues SearchVertices, and publishes results to Updates. Cancel ctx
-// or call Close to stop it.
+// returns it. The driver tracks every debounce callback and SearchVertices
+// call so cancellation and Close can wait for all owned work. Cancel ctx or
+// call Close to stop it.
 func (l *Lantern) NewIncrementalSearch(ctx context.Context, opts ...IncrementalSearchOption) *IncrementalSearch {
 	o := incrementalSearchOptions{
 		debounce:       defaultIncrementalDebounce,
@@ -137,28 +139,47 @@ func (l *Lantern) NewIncrementalSearch(ctx context.Context, opts ...IncrementalS
 		l:       l,
 		opts:    o,
 		updates: make(chan SearchUpdate, 1),
-		wake:    make(chan struct{}, 1),
 		ctx:     dctx,
 		cancel:  cancel,
 		done:    make(chan struct{}),
 	}
-	go s.run()
+	go func() {
+		<-dctx.Done()
+		s.shutdown()
+	}()
 	return s
 }
 
-// Search records query as the latest pending search and wakes the driver. It
-// never blocks: repeated calls before the debounce window elapses overwrite
-// the pending query, so only the final keystroke's text is searched. A call
+// Search makes query the latest input immediately: it invalidates buffered
+// output, stops the previous debounce timer, and cancels the active RPC before
+// starting the new debounce window. It never blocks on network work. A call
 // after Close (or ctx cancellation) is a no-op.
 func (s *IncrementalSearch) Search(query string) {
 	s.mu.Lock()
-	s.latest = query
-	s.dirty = true
-	s.mu.Unlock()
-	select {
-	case s.wake <- struct{}{}:
-	default:
+	if s.closed || s.ctx.Err() != nil {
+		s.mu.Unlock()
+		return
 	}
+	epoch := s.epoch.Add(1)
+	s.stopTimerLocked()
+	s.cancelSearchLocked()
+	s.invalidateBuffered()
+
+	if len([]rune(query)) < s.opts.minQueryLength {
+		s.mu.Unlock()
+		// Too short to search: reset immediately, without waiting for debounce.
+		s.deliver(epoch, SearchUpdate{Query: query, Hits: []SearchHit{}})
+		return
+	}
+
+	// Account for the timer callback before publishing the timer pointer.
+	// shutdown changes closed under the same lock, so Wait cannot race an Add.
+	s.workers.Add(1)
+	s.timer = time.AfterFunc(s.opts.debounce, func() {
+		defer s.workers.Done()
+		s.dispatch(epoch, query)
+	})
+	s.mu.Unlock()
 }
 
 // Updates is the stream of search results, one SearchUpdate per dispatched
@@ -176,71 +197,35 @@ func (s *IncrementalSearch) Updates() <-chan SearchUpdate {
 // goroutine; it always returns nil (the error return mirrors io.Closer for
 // composability).
 func (s *IncrementalSearch) Close() error {
-	s.closeOnce.Do(func() { s.cancel() })
+	s.cancel()
+	s.shutdown()
 	<-s.done
 	return nil
 }
 
-// run is the single driver goroutine. It owns the debounce timer and the
-// in-flight search's cancel func, so neither needs its own lock.
-func (s *IncrementalSearch) run() {
-	defer close(s.done)
-
-	timer := time.NewTimer(s.opts.debounce)
-	if !timer.Stop() {
-		<-timer.C
+// dispatch starts the RPC only if the input that armed this timer is still
+// current. The timer callback itself owns the blocking RPC, so shutdown can
+// deterministically wait for every background worker.
+func (s *IncrementalSearch) dispatch(epoch uint64, query string) {
+	s.mu.Lock()
+	if s.closed || s.ctx.Err() != nil || s.epoch.Load() != epoch {
+		s.mu.Unlock()
+		return
 	}
-	armed := false
+	s.timer = nil
+	sctx, cancel := context.WithCancel(s.ctx)
+	s.searchCancel = cancel
+	s.searchEpoch = epoch
+	s.mu.Unlock()
 
-	var searchCancel context.CancelFunc
-	cancelInFlight := func() {
-		if searchCancel != nil {
-			searchCancel()
-			searchCancel = nil
-		}
+	s.doSearch(sctx, epoch, query)
+
+	s.mu.Lock()
+	if s.searchEpoch == epoch {
+		s.searchCancel = nil
+		s.searchEpoch = 0
 	}
-
-	for {
-		select {
-		case <-s.ctx.Done():
-			timer.Stop()
-			cancelInFlight()
-			return
-
-		case <-s.wake:
-			// (Re)arm the debounce window on every keystroke.
-			if armed && !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
-			timer.Reset(s.opts.debounce)
-			armed = true
-
-		case <-timer.C:
-			armed = false
-			s.mu.Lock()
-			query := s.latest
-			had := s.dirty
-			s.dirty = false
-			s.mu.Unlock()
-			if !had {
-				continue
-			}
-			// A newer dispatch supersedes any in-flight search.
-			cancelInFlight()
-			epoch := s.epoch.Add(1)
-			if len([]rune(query)) < s.opts.minQueryLength {
-				// Too short to search: answer immediately, no round-trip.
-				s.deliver(epoch, SearchUpdate{Query: query, Hits: []SearchHit{}})
-				continue
-			}
-			sctx, c := context.WithCancel(s.ctx)
-			searchCancel = c
-			go s.doSearch(sctx, epoch, query)
-		}
-	}
+	s.mu.Unlock()
 }
 
 // doSearch issues one SearchVertices call and delivers its result unless the
@@ -278,4 +263,54 @@ func (s *IncrementalSearch) deliver(epoch uint64, u SearchUpdate) {
 	case s.updates <- u:
 	default:
 	}
+}
+
+// invalidateBuffered removes a result that was delivered before the newest
+// input but not yet consumed. Callers must hold s.mu; deliverMu serializes the
+// drain against a finishing RPC.
+func (s *IncrementalSearch) invalidateBuffered() {
+	s.deliverMu.Lock()
+	defer s.deliverMu.Unlock()
+	select {
+	case <-s.updates:
+	default:
+	}
+}
+
+// stopTimerLocked stops and releases the pending debounce timer. A timer that
+// has already started owns its workers.Done call; a timer stopped here never
+// runs, so this method balances the Add performed by Search.
+func (s *IncrementalSearch) stopTimerLocked() {
+	if s.timer == nil {
+		return
+	}
+	if s.timer.Stop() {
+		s.workers.Done()
+	}
+	s.timer = nil
+}
+
+func (s *IncrementalSearch) cancelSearchLocked() {
+	if s.searchCancel == nil {
+		return
+	}
+	s.searchCancel()
+	s.searchCancel = nil
+	s.searchEpoch = 0
+}
+
+// shutdown is shared by Close and parent-context cancellation. It prevents
+// new timers, cancels current work, and closes done only after every timer/RPC
+// callback has returned.
+func (s *IncrementalSearch) shutdown() {
+	s.closeOnce.Do(func() {
+		s.mu.Lock()
+		s.closed = true
+		s.epoch.Add(1)
+		s.stopTimerLocked()
+		s.cancelSearchLocked()
+		s.mu.Unlock()
+		s.workers.Wait()
+		close(s.done)
+	})
 }

--- a/sdks/go/search_incremental_test.go
+++ b/sdks/go/search_incremental_test.go
@@ -19,11 +19,16 @@ import (
 // replays per-query canned hits (or a single canned error for every query).
 type fakeIncSearch struct {
 	graphv1connect.LanternServiceClient
-	mu    sync.Mutex
-	reqs  []*pb.SearchVerticesRequest
-	delay map[string]time.Duration
-	hits  map[string][]*pb.SearchHit
-	err   error
+	mu           sync.Mutex
+	reqs         []*pb.SearchVerticesRequest
+	delay        map[string]time.Duration
+	hits         map[string][]*pb.SearchHit
+	err          error
+	errByQuery   map[string]error
+	started      map[string]chan struct{}
+	release      map[string]chan struct{}
+	canceled     map[string]chan struct{}
+	ignoreCancel map[string]bool
 }
 
 func (f *fakeIncSearch) SearchVertices(ctx context.Context, req *connect.Request[pb.SearchVerticesRequest]) (*connect.Response[pb.SearchVerticesResponse], error) {
@@ -32,8 +37,28 @@ func (f *fakeIncSearch) SearchVertices(ctx context.Context, req *connect.Request
 	f.reqs = append(f.reqs, req.Msg)
 	d := f.delay[q]
 	h := f.hits[q]
-	e := f.err
+	e := f.errByQuery[q]
+	if e == nil {
+		e = f.err
+	}
+	started := f.started[q]
+	release := f.release[q]
+	canceled := f.canceled[q]
+	ignoreCancel := f.ignoreCancel[q]
 	f.mu.Unlock()
+	signal(started)
+	if release != nil {
+		if ignoreCancel {
+			<-release
+		} else {
+			select {
+			case <-release:
+			case <-ctx.Done():
+				signal(canceled)
+				return nil, ctx.Err()
+			}
+		}
+	}
 	if e != nil {
 		return nil, e
 	}
@@ -45,6 +70,16 @@ func (f *fakeIncSearch) SearchVertices(ctx context.Context, req *connect.Request
 		}
 	}
 	return connect.NewResponse(&pb.SearchVerticesResponse{Hits: h}), nil
+}
+
+func signal(ch chan struct{}) {
+	if ch == nil {
+		return
+	}
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
 }
 
 func (f *fakeIncSearch) calls() []string {
@@ -90,6 +125,15 @@ func waitUpdate(t *testing.T, is *IncrementalSearch) SearchUpdate {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for a SearchUpdate")
 		return SearchUpdate{}
+	}
+}
+
+func assertSignal(t *testing.T, ch <-chan struct{}, within time.Duration, name string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(within):
+		t.Fatalf("timed out waiting for %s", name)
 	}
 }
 
@@ -180,19 +224,24 @@ func TestIncrementalSearch_DebounceCoalesces(t *testing.T) {
 }
 
 func TestIncrementalSearch_CancelsInFlight(t *testing.T) {
+	started := make(chan struct{}, 1)
+	canceled := make(chan struct{}, 1)
 	fake := &fakeIncSearch{
-		delay: map[string]time.Duration{"slow": 500 * time.Millisecond},
 		hits: map[string][]*pb.SearchHit{
 			"slow": {{Key: "slow.hit", Score: 9}},
 			"fast": {{Key: "fast.hit", Score: 1}},
 		},
+		started:  map[string]chan struct{}{"slow": started},
+		release:  map[string]chan struct{}{"slow": make(chan struct{})},
+		canceled: map[string]chan struct{}{"slow": canceled},
 	}
-	is := newDriver(t, fake, WithDebounce(5*time.Millisecond))
+	is := newDriver(t, fake, WithDebounce(80*time.Millisecond))
 
 	is.Search("slow")
-	// Let "slow" dispatch and enter its 500ms delay before superseding it.
-	time.Sleep(60 * time.Millisecond)
+	assertSignal(t, started, time.Second, "slow RPC start")
 	is.Search("fast")
+	// Cancellation belongs to the input call, not the next timer firing.
+	assertSignal(t, canceled, 30*time.Millisecond, "slow RPC cancellation")
 
 	u := waitUpdate(t, is)
 	if u.Query != "fast" {
@@ -207,12 +256,51 @@ func TestIncrementalSearch_CancelsInFlight(t *testing.T) {
 	}
 }
 
+func TestIncrementalSearch_DropsCompletionDuringNextDebounce(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "result"},
+		{name: "error", err: errors.New("late failure")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			started := make(chan struct{}, 1)
+			release := make(chan struct{})
+			fake := &fakeIncSearch{
+				hits:         map[string][]*pb.SearchHit{"old": {{Key: "stale", Score: 1}}},
+				errByQuery:   map[string]error{"old": tc.err},
+				started:      map[string]chan struct{}{"old": started},
+				release:      map[string]chan struct{}{"old": release},
+				ignoreCancel: map[string]bool{"old": true},
+			}
+			is := newDriver(t, fake, WithDebounce(100*time.Millisecond))
+
+			is.Search("old")
+			assertSignal(t, started, time.Second, "old RPC start")
+			is.Search("new")
+			close(release) // transport loses the cancellation race
+
+			select {
+			case got := <-is.Updates():
+				t.Fatalf("stale update delivered during new debounce: %+v", got)
+			case <-time.After(30 * time.Millisecond):
+			}
+		})
+	}
+}
+
 func TestIncrementalSearch_MinQueryLength(t *testing.T) {
 	fake := &fakeIncSearch{}
-	is := newDriver(t, fake, WithDebounce(5*time.Millisecond), WithMinQueryLength(3))
+	is := newDriver(t, fake, WithDebounce(time.Hour), WithMinQueryLength(3))
 
 	is.Search("ab") // shorter than 3 runes
-	u := waitUpdate(t, is)
+	var u SearchUpdate
+	select {
+	case u = <-is.Updates():
+	default:
+		t.Fatal("too-short input did not reset synchronously")
+	}
 
 	if u.Query != "ab" {
 		t.Errorf("query = %q, want %q", u.Query, "ab")
@@ -225,6 +313,29 @@ func TestIncrementalSearch_MinQueryLength(t *testing.T) {
 	}
 	if got := fake.calls(); len(got) != 0 {
 		t.Errorf("calls = %v, want no RPC for a too-short query", got)
+	}
+}
+
+func TestIncrementalSearch_NewInputInvalidatesBufferedUpdate(t *testing.T) {
+	fake := &fakeIncSearch{hits: map[string][]*pb.SearchHit{
+		"old": {{Key: "old", Score: 1}},
+	}}
+	is := newDriver(t, fake, WithDebounce(0))
+
+	is.Search("old")
+	// Wait until the result is buffered without consuming it.
+	deadline := time.Now().Add(time.Second)
+	for len(is.updates) == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if len(is.updates) == 0 {
+		t.Fatal("old result was not buffered")
+	}
+	is.Search("new")
+	select {
+	case got := <-is.Updates():
+		t.Fatalf("new input left buffered stale update: %+v", got)
+	default:
 	}
 }
 
@@ -241,18 +352,47 @@ func TestIncrementalSearch_DeliversError(t *testing.T) {
 	}
 }
 
-func TestIncrementalSearch_CloseIsIdempotent(t *testing.T) {
-	fake := &fakeIncSearch{}
-	l := mustLantern(t)
-	l.client = fake
-	is := l.NewIncrementalSearch(context.Background(), WithDebounce(5*time.Millisecond))
+func TestIncrementalSearch_Close(t *testing.T) {
+	t.Run("idempotent and cancels pending debounce", func(t *testing.T) {
+		fake := &fakeIncSearch{}
+		l := mustLantern(t)
+		l.client = fake
+		is := l.NewIncrementalSearch(context.Background(), WithDebounce(time.Hour))
+		is.Search("pending")
 
-	if err := is.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-	if err := is.Close(); err != nil {
-		t.Fatalf("second Close: %v", err)
-	}
-	// A Search after Close must not panic or block.
-	is.Search("ignored")
+		if err := is.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		if err := is.Close(); err != nil {
+			t.Fatalf("second Close: %v", err)
+		}
+		// A Search after Close must not panic, block, or reach the wire.
+		is.Search("ignored")
+		if got := fake.calls(); len(got) != 0 {
+			t.Fatalf("calls after closing pending debounce = %v, want none", got)
+		}
+	})
+
+	t.Run("cancels active RPC before returning", func(t *testing.T) {
+		started := make(chan struct{}, 1)
+		canceled := make(chan struct{}, 1)
+		fake := &fakeIncSearch{
+			started:  map[string]chan struct{}{"active": started},
+			release:  map[string]chan struct{}{"active": make(chan struct{})},
+			canceled: map[string]chan struct{}{"active": canceled},
+		}
+		l := mustLantern(t)
+		l.client = fake
+		is := l.NewIncrementalSearch(context.Background(), WithDebounce(0))
+		is.Search("active")
+		assertSignal(t, started, time.Second, "active RPC start")
+
+		closed := make(chan struct{})
+		go func() {
+			_ = is.Close()
+			close(closed)
+		}()
+		assertSignal(t, canceled, time.Second, "active RPC cancellation")
+		assertSignal(t, closed, time.Second, "Close return")
+	})
 }

--- a/sdks/node/src/incremental-search.ts
+++ b/sdks/node/src/incremental-search.ts
@@ -59,6 +59,17 @@ export type SearchFn = (
   signal?: AbortSignal,
 ) => Promise<SearchHit[]>;
 
+/** Clock abstraction used to test debounce behavior without wall-clock sleeps. */
+export interface IncrementalSearchScheduler {
+  setTimeout(callback: () => void, delayMs: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
+const systemScheduler: IncrementalSearchScheduler = {
+  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+  clearTimeout: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
 /**
  * A search-as-you-type driver. Push queries with `search` as the user types;
  * receive ranked results via `subscribe` (which returns an unsubscribe) or by
@@ -75,11 +86,14 @@ export interface IncrementalSearch {
 /**
  * Builds an {@link IncrementalSearch} around any {@link SearchFn}. Most callers
  * use `Lantern.incrementalSearch()`, which binds `searchVertices`; this factory
- * is exported for tests and for driving a custom search primitive.
+ * is exported for tests and for driving a custom search primitive. The
+ * scheduler parameter supports deterministic clocks; applications normally
+ * leave it at the system default.
  */
 export function createIncrementalSearch(
   searchFn: SearchFn,
   options: IncrementalSearchOptions = {},
+  scheduler: IncrementalSearchScheduler = systemScheduler,
 ): IncrementalSearch {
   const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
   const minQueryLength = options.minQueryLength ?? DEFAULT_MIN_QUERY_LENGTH;
@@ -87,7 +101,7 @@ export function createIncrementalSearch(
 
   const listeners = new Set<(update: SearchUpdate) => void>();
   let epoch = 0;
-  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timer: unknown;
   let inFlight: AbortController | undefined;
   let closed = false;
 
@@ -108,18 +122,8 @@ export function createIncrementalSearch(
     }
   }
 
-  function dispatch(query: string): void {
-    if (closed) return;
-    // A newer dispatch supersedes any in-flight search.
-    inFlight?.abort();
-    inFlight = undefined;
-    const myEpoch = ++epoch;
-
-    if ([...query].length < minQueryLength) {
-      // Too short to search: answer immediately, no round-trip.
-      emit({ query, hits: [] });
-      return;
-    }
+  function dispatch(query: string, myEpoch: number): void {
+    if (closed || myEpoch !== epoch) return;
 
     const controller = new AbortController();
     inFlight = controller;
@@ -138,18 +142,35 @@ export function createIncrementalSearch(
 
   function search(query: string): void {
     if (closed) return;
-    if (timer !== undefined) clearTimeout(timer);
-    timer = setTimeout(() => {
+    // Latest INPUT wins: invalidate buffered output, the pending debounce,
+    // and the active RPC before waiting to dispatch the new query.
+    const myEpoch = ++epoch;
+    buffered = undefined;
+    if (timer !== undefined) {
+      scheduler.clearTimeout(timer);
       timer = undefined;
-      dispatch(query);
+    }
+    inFlight?.abort();
+    inFlight = undefined;
+
+    if ([...query].length < minQueryLength) {
+      // Too short to search: reset immediately, with no debounce or RPC.
+      emit({ query, hits: [] });
+      return;
+    }
+
+    timer = scheduler.setTimeout(() => {
+      timer = undefined;
+      dispatch(query, myEpoch);
     }, debounceMs);
   }
 
   function close(): void {
     if (closed) return;
     closed = true;
+    epoch++;
     if (timer !== undefined) {
-      clearTimeout(timer);
+      scheduler.clearTimeout(timer);
       timer = undefined;
     }
     inFlight?.abort();

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -59,6 +59,7 @@ export {
 export type {
   IncrementalSearch,
   IncrementalSearchOptions,
+  IncrementalSearchScheduler,
   SearchFn,
   SearchUpdate,
 } from "./incremental-search.js";

--- a/sdks/node/test/incremental-search.test.ts
+++ b/sdks/node/test/incremental-search.test.ts
@@ -5,9 +5,41 @@ import {
   DEFAULT_DEBOUNCE_MS,
   DEFAULT_MIN_QUERY_LENGTH,
   type IncrementalSearch,
+  type IncrementalSearchScheduler,
   type SearchFn,
   type SearchUpdate,
 } from "../src/incremental-search.js";
+
+class FakeScheduler implements IncrementalSearchScheduler {
+  private now = 0;
+  private nextID = 0;
+  private readonly tasks = new Map<number, { at: number; callback: () => void }>();
+
+  setTimeout(callback: () => void, delayMs: number): number {
+    const id = ++this.nextID;
+    this.tasks.set(id, { at: this.now + delayMs, callback });
+    return id;
+  }
+
+  clearTimeout(handle: unknown): void {
+    this.tasks.delete(handle as number);
+  }
+
+  advanceBy(delayMs: number): void {
+    const target = this.now + delayMs;
+    for (;;) {
+      const next = [...this.tasks.entries()]
+        .filter(([, task]) => task.at <= target)
+        .sort((a, b) => a[1].at - b[1].at || a[0] - b[0])[0];
+      if (next === undefined) break;
+      const [id, task] = next;
+      this.tasks.delete(id);
+      this.now = task.at;
+      task.callback();
+    }
+    this.now = target;
+  }
+}
 
 // nextUpdate resolves with the first update the driver emits.
 function nextUpdate(is: IncrementalSearch): Promise<SearchUpdate> {
@@ -65,26 +97,33 @@ describe("createIncrementalSearch", () => {
   });
 
   test("a newer query aborts the in-flight search and only its result is delivered", async () => {
+    const scheduler = new FakeScheduler();
     const seen: string[] = [];
+    let notifyAbort: (() => void) | undefined;
+    const aborted = new Promise<void>((resolve) => {
+      notifyAbort = resolve;
+    });
     const searchFn: SearchFn = async (query, _opts, signal) => {
       seen.push(query);
       if (query === "slow") {
-        await new Promise<void>((resolve, reject) => {
-          const t = setTimeout(resolve, 500);
+        await new Promise<void>((_resolve, reject) => {
           signal?.addEventListener("abort", () => {
-            clearTimeout(t);
+            notifyAbort?.();
             reject(new Error("aborted"));
           });
         });
       }
       return [{ key: `${query}.hit`, score: 1 }];
     };
-    const is = createIncrementalSearch(searchFn, { debounceMs: 5 });
+    const is = createIncrementalSearch(searchFn, { debounceMs: 80 }, scheduler);
 
     is.search("slow");
-    await tick(40); // let "slow" dispatch and enter its delay
+    scheduler.advanceBy(80);
     is.search("fast");
-    const u = await nextUpdate(is);
+    await aborted;
+    const update = nextUpdate(is);
+    scheduler.advanceBy(80);
+    const u = await update;
     is.close();
 
     expect(u.query).toBe("fast");
@@ -92,22 +131,71 @@ describe("createIncrementalSearch", () => {
     expect(seen).toEqual(["slow", "fast"]);
   });
 
-  test("a too-short query resolves to an empty result with no RPC", async () => {
+  test.each(["resolve", "reject"] as const)(
+    "drops an old %s during the next input's debounce window",
+    async (outcome) => {
+      const scheduler = new FakeScheduler();
+      let settleOld: (() => void) | undefined;
+      const searchFn: SearchFn = (query) => {
+        if (query !== "old") return Promise.resolve([]);
+        return new Promise<SearchUpdate["hits"]>((resolve, reject) => {
+          settleOld = () =>
+            outcome === "resolve"
+              ? resolve([{ key: "stale", score: 1 }])
+              : reject(new Error("late failure"));
+        });
+      };
+      const is = createIncrementalSearch(searchFn, { debounceMs: 80 }, scheduler);
+      const updates: SearchUpdate[] = [];
+      const unsubscribe = is.subscribe((update) => updates.push(update));
+
+      is.search("old");
+      scheduler.advanceBy(80);
+      is.search("new");
+      settleOld?.(); // simulate a transport that fulfills despite abort
+      await Promise.resolve();
+
+      expect(updates).toEqual([]);
+      unsubscribe();
+      is.close();
+    },
+  );
+
+  test("a too-short query resets synchronously with no RPC", async () => {
     let calls = 0;
     const searchFn: SearchFn = async () => {
       calls++;
       return [];
     };
-    const is = createIncrementalSearch(searchFn, { debounceMs: 5, minQueryLength: 3 });
+    const is = createIncrementalSearch(searchFn, { debounceMs: 60_000, minQueryLength: 3 });
+    const updates: SearchUpdate[] = [];
+    const unsubscribe = is.subscribe((update) => updates.push(update));
 
     is.search("ab");
-    const u = await nextUpdate(is);
+    const u = updates[0];
+    unsubscribe();
     is.close();
 
+    expect(u).toBeDefined();
     expect(u.query).toBe("ab");
     expect(u.hits).toEqual([]);
     expect(u.error).toBeUndefined();
     expect(calls).toBe(0);
+  });
+
+  test("a new input removes an unread async-iterator result", async () => {
+    const searchFn: SearchFn = async (query) => [{ key: query, score: 1 }];
+    const is = createIncrementalSearch(searchFn, { debounceMs: 5 });
+    const iterator = is[Symbol.asyncIterator]();
+
+    is.search("old");
+    await tick(20); // old result is now buffered in the iterator
+    is.search("new");
+    const next = iterator.next();
+    const { value } = await next;
+    is.close();
+
+    expect(value?.query).toBe("new");
   });
 
   test("delivers a search rejection as SearchUpdate.error", async () => {
@@ -125,20 +213,33 @@ describe("createIncrementalSearch", () => {
     expect(u.hits).toEqual([]);
   });
 
-  test("close is idempotent and search after close is a no-op", async () => {
+  test("close cancels pending and active work, is idempotent, and prevents new work", async () => {
+    const scheduler = new FakeScheduler();
     let calls = 0;
-    const searchFn: SearchFn = async () => {
+    let activeAborted = false;
+    const searchFn: SearchFn = (_query, _opts, signal) => {
       calls++;
-      return [];
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener("abort", () => {
+          activeAborted = true;
+          reject(new Error("aborted"));
+        });
+      });
     };
-    const is = createIncrementalSearch(searchFn, { debounceMs: 5 });
+    const is = createIncrementalSearch(searchFn, { debounceMs: 10 }, scheduler);
 
+    is.search("pending");
+    is.search("active");
+    scheduler.advanceBy(10);
+    expect(calls).toBe(1);
     is.close();
     is.close(); // must not throw
     is.search("ignored");
-    await tick(20);
+    scheduler.advanceBy(100);
+    await Promise.resolve();
 
-    expect(calls).toBe(0);
+    expect(activeAborted).toBe(true);
+    expect(calls).toBe(1);
   });
 
   test("is async-iterable, yielding the latest update", async () => {

--- a/tests/integration/search_vertices_test.go
+++ b/tests/integration/search_vertices_test.go
@@ -216,6 +216,57 @@ func TestSearchVertices_SDKForwarder(t *testing.T) {
 	})
 }
 
+// TestSearchVertices_IncrementalLatestInputWins drives the Go SDK's
+// search-as-you-type orchestration over the real Connect/h2c path. The final
+// query in a burst is the only result exposed, and an empty input invalidates
+// pending debounce work immediately without a later stale delivery (#1052).
+func TestSearchVertices_IncrementalLatestInputWins(t *testing.T) {
+	l := newSearchSDKClient(t, true)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := l.PutVertices(ctx, []client.VertexInput{
+		{Key: "doc.alpha", Value: "alpha", Expiration: time.Now().Add(time.Hour)},
+		{Key: "doc.beta", Value: "beta", Expiration: time.Now().Add(time.Hour)},
+	}); err != nil {
+		t.Fatalf("PutVertices: %v", err)
+	}
+
+	const debounce = 30 * time.Millisecond
+	incremental := l.NewIncrementalSearch(ctx, client.WithDebounce(debounce))
+	defer incremental.Close()
+
+	incremental.Search("alpha")
+	incremental.Search("beta")
+	select {
+	case update := <-incremental.Updates():
+		if update.Err != nil {
+			t.Fatalf("incremental beta: %v", update.Err)
+		}
+		if update.Query != "beta" || len(update.Hits) != 1 || update.Hits[0].Key != "doc.beta" {
+			t.Fatalf("update = %+v, want beta/doc.beta", update)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for incremental beta result")
+	}
+
+	incremental.Search("alpha")
+	incremental.Search("")
+	select {
+	case update := <-incremental.Updates():
+		if update.Query != "" || update.Err != nil || len(update.Hits) != 0 {
+			t.Fatalf("empty reset = %+v, want synchronous empty update", update)
+		}
+	default:
+		t.Fatal("empty input did not reset synchronously")
+	}
+	select {
+	case update := <-incremental.Updates():
+		t.Fatalf("pending alpha search delivered after empty input: %+v", update)
+	case <-time.After(2 * debounce):
+	}
+}
+
 // TestSearchVertices_Options drives the #892 SearchOptions end to end through
 // the raw Connect handler: match mode, phrase adjacency, fuzzy/prefix term
 // expansion, and minimum-should-match, each over a live index.

--- a/tests/integration/search_vertices_test.go
+++ b/tests/integration/search_vertices_test.go
@@ -234,7 +234,11 @@ func TestSearchVertices_IncrementalLatestInputWins(t *testing.T) {
 
 	const debounce = 30 * time.Millisecond
 	incremental := l.NewIncrementalSearch(ctx, client.WithDebounce(debounce))
-	defer incremental.Close()
+	defer func() {
+		if err := incremental.Close(); err != nil {
+			t.Errorf("Close incremental search: %v", err)
+		}
+	}()
 
 	incremental.Search("alpha")
 	incremental.Search("beta")


### PR DESCRIPTION
## Summary

- invalidate Go and Node incremental-search generations on input receipt, before the replacement debounce starts
- give Admin search one coordinator that owns debounce timers, primary RPCs, and manual retries; empty input resets immediately
- align Dart cancellation coverage and add a real Connect/h2c Go SDK regression test

## Why

Previously, Go, Node, and Admin advanced their stale-response guard only when the next debounced request dispatched. An older RPC could therefore complete after the user had already changed the input and still publish a result or error during the new debounce window. Admin retries also were not owned by the same cancellation lifecycle.

The new contract is latest input wins: every input or option change advances the generation and cancels old work immediately; debounce controls only when the new eligible RPC starts.

## Impact

- stale results and errors are not exposed after newer input is observed
- empty or too-short input resets synchronously without a wire call
- Close/dispose cancels pending timers and active calls deterministically
- Admin option changes and manual retries participate in the same generation contract

## Validation

- `go test -race ./...` in `sdks/go`
- `go test ./...` at root and in `pb`, `core`, `sdks/go`, `server`, and `mcp`
- `go test ./tests/integration -run TestSearchVertices_IncrementalLatestInputWins -count=10`
- `bun test && bun run typecheck && bun run lint && bun run format:check` in `sdks/node`
- `bun run test && bun run typecheck && bun run lint && bun run format:check && bun run build` in `admin`
- `dart format --output=none --set-exit-if-changed lib/lantern_client.dart lib/src/*.dart test && dart analyze && dart test` in `sdks/dart`

Closes #1052
