### PR TITLE
fix(search): unify option contract across surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ scans. Hits use the stable total order `(score DESC, raw key ASC)` and make
 natural seeds for a follow-up `bfs`, `pagerank`, or `community` walk:
 
 ```shell
-lantern-cli search "rolling update"              # OR-union of the query words
+lantern-cli search "rolling update"              # use the server's configured mode
 lantern-cli search "rolling update" --mode all   # require every word (AND)
 lantern-cli search "rolling update" --phrase     # adjacent, in order
 lantern-cli search serach --fuzziness 1          # typos still hit
@@ -282,6 +282,20 @@ positions rejects `phrase=true` with the typed reason
 `SEARCH_POSITIONS_DISABLED`; it never silently returns unordered AND matches.
 `GetServerStatus.search` exposes these capabilities, their defaults and limits,
 implementation versions, and a configuration fingerprint.
+
+Search option interpretation is identical on every surface:
+
+| Request | Membership behavior |
+| --- | --- |
+| options omitted, or `match_mode=UNSPECIFIED` | Always use `LANTERN_SEARCH_DEFAULT_MODE`, even when fuzziness or prefix terms are set |
+| explicit `ANY` / `ALL` / `MIN_SHOULD` | Override the server default |
+| `MIN_SHOULD` with `min_should_match=0` | Use `LANTERN_SEARCH_DEFAULT_MIN_SHOULD` |
+| non-zero `min_should_match` with any other mode | `INVALID_ARGUMENT` |
+| phrase plus an explicit mode, fuzziness, or prefix terms | `INVALID_ARGUMENT` until those compositions are implemented |
+
+Unknown enum values, fuzziness outside `0..2`, and option fields that would be
+ignored are rejected rather than clamped or silently reinterpreted. Go, Node,
+and Dart validate the same combinations locally before issuing an RPC.
 
 ---
 

--- a/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.tsx
+++ b/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.tsx
@@ -38,7 +38,10 @@ import {
   formatScore,
   selectCaption,
 } from "~/lib/client/usecase/search-vertices/selectors";
-import type { SearchMatchMode } from "~/lib/client/usecase/search-vertices/state";
+import type {
+  SearchFuzziness,
+  SearchMatchMode,
+} from "~/lib/client/usecase/search-vertices/state";
 import type { Vertex } from "~/lib/client/infrastructure/api/types";
 import { getServerStatus } from "~/lib/client/infrastructure/api/get-server-status";
 import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-client";
@@ -58,9 +61,10 @@ type FindMode = "prefix" | "search";
 
 /** Human labels for the content-search match modes (#892). */
 const MATCH_MODE_LABELS: Record<SearchMatchMode, string> = {
+  server: "Server default",
   any: "Any word (OR)",
   all: "All words (AND)",
-  "min-should": "Most words",
+  "min-should": "At least N words",
 };
 
 /** A vertex row normalised across both find modes. */
@@ -82,9 +86,12 @@ export function BrowseVerticesPage() {
   const [mode, setMode] = useState<FindMode>("prefix");
   const [prefix, setPrefix] = useState("");
   const [query, setQuery] = useState("");
-  const [matchMode, setMatchMode] = useState<SearchMatchMode>("any");
+  const [searchPrefix, setSearchPrefix] = useState("");
+  const [matchMode, setMatchMode] = useState<SearchMatchMode>("server");
+  const [minShouldMatch, setMinShouldMatch] = useState(2);
   const [phrase, setPhrase] = useState(false);
-  const [fuzzy, setFuzzy] = useState(false);
+  const [fuzziness, setFuzziness] = useState<SearchFuzziness>(0);
+  const [prefixTerms, setPrefixTerms] = useState(false);
   // null = loading, undefined = capability lookup failed.
   const [positionsEnabled, setPositionsEnabled] = useState<
     boolean | null | undefined
@@ -93,7 +100,14 @@ export function BrowseVerticesPage() {
   const browse = useBrowseVertices(prefix, {
     pageSize: DEFAULT_VERTEX_PAGE_SIZE,
   });
-  const search = useSearchVertices(client, query, { matchMode, phrase, fuzzy });
+  const search = useSearchVertices(client, query, {
+    prefix: searchPrefix,
+    matchMode,
+    minShouldMatch,
+    phrase,
+    fuzziness,
+    prefixTerms,
+  });
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -113,6 +127,8 @@ export function BrowseVerticesPage() {
 
   const searching = mode === "search";
   const searchStatus = search.state.status;
+  const phraseCompatible =
+    matchMode === "server" && fuzziness === 0 && !prefixTerms;
 
   // Normalise both find modes into a single row list so the table markup
   // (and the Edit + Illuminate handoffs) stays a single code path.
@@ -242,46 +258,94 @@ export function BrowseVerticesPage() {
               className={styles.searchOptionsMode}
               selectedOptions={[matchMode]}
               value={MATCH_MODE_LABELS[matchMode]}
+              disabled={phrase}
               onOptionSelect={(_, data) =>
-                setMatchMode((data.optionValue as SearchMatchMode) ?? "any")
+                setMatchMode((data.optionValue as SearchMatchMode) ?? "server")
               }
               data-testid="search-mode"
             >
+              <Option value="server" text="Server default">
+                Server default
+              </Option>
               <Option value="any" text="Any word (OR)">
                 Any word (OR)
               </Option>
               <Option value="all" text="All words (AND)">
                 All words (AND)
               </Option>
-              <Option value="min-should" text="Most words">
-                Most words
+              <Option value="min-should" text="At least N words">
+                At least N words
               </Option>
             </Dropdown>
           </Field>
+          {matchMode === "min-should" ? (
+            <Field label="Minimum words">
+              <Input
+                type="number"
+                min={1}
+                step={1}
+                value={String(minShouldMatch)}
+                disabled={phrase}
+                onChange={(_, data) => {
+                  const value = Number(data.value);
+                  if (Number.isInteger(value) && value > 0) {
+                    setMinShouldMatch(value);
+                  }
+                }}
+                data-testid="search-min-should"
+              />
+            </Field>
+          ) : null}
+          <Field label="Key namespace prefix">
+            <Input
+              value={searchPrefix}
+              onChange={(_, data) => setSearchPrefix(data.value)}
+              placeholder="e.g. user:"
+              data-testid="search-prefix"
+            />
+          </Field>
+          <Field label="Fuzziness">
+            <Dropdown
+              selectedOptions={[String(fuzziness)]}
+              value={String(fuzziness)}
+              disabled={phrase}
+              onOptionSelect={(_, data) =>
+                setFuzziness(Number(data.optionValue ?? 0) as SearchFuzziness)
+              }
+              data-testid="search-fuzzy"
+            >
+              <Option value="0">0 (exact)</Option>
+              <Option value="1">1 edit</Option>
+              <Option value="2">2 edits</Option>
+            </Dropdown>
+          </Field>
+          <Switch
+            label="Prefix terms"
+            checked={prefixTerms}
+            disabled={phrase}
+            onChange={(_, data) => setPrefixTerms(data.checked)}
+            data-testid="search-prefix-terms"
+          />
           <div>
             <Switch
               label="Phrase"
               checked={phrase}
-              disabled={positionsEnabled !== true}
+              disabled={positionsEnabled !== true || !phraseCompatible}
               onChange={(_, data) => setPhrase(data.checked)}
               data-testid="search-phrase"
             />
-            {positionsEnabled !== true ? (
+            {positionsEnabled !== true || !phraseCompatible ? (
               <small data-testid="search-phrase-unavailable">
-                {positionsEnabled === false
-                  ? "Unavailable: this server does not store positional postings."
-                  : positionsEnabled === undefined
-                    ? "Unavailable: server phrase capabilities could not be loaded."
-                    : "Checking server phrase capabilities…"}
+                {!phraseCompatible
+                  ? "Choose Server default, fuzziness 0, and disable prefix terms to use phrase search."
+                  : positionsEnabled === false
+                    ? "Unavailable: this server does not store positional postings."
+                    : positionsEnabled === undefined
+                      ? "Unavailable: server phrase capabilities could not be loaded."
+                      : "Checking server phrase capabilities…"}
               </small>
             ) : null}
           </div>
-          <Switch
-            label="Fuzzy"
-            checked={fuzzy}
-            onChange={(_, data) => setFuzzy(data.checked)}
-            data-testid="search-fuzzy"
-          />
         </section>
       ) : null}
 
@@ -457,3 +521,6 @@ export function BrowseVerticesPage() {
     </div>
   );
 }
+<Option value="server" text="Server default">
+  Server default
+</Option>;

--- a/admin/app/lib/client/infrastructure/api/search-vertices.ts
+++ b/admin/app/lib/client/infrastructure/api/search-vertices.ts
@@ -37,10 +37,15 @@ export async function searchVertices(
       {
         limit: request.limit ?? 0,
         prefix: request.prefix ?? "",
-        matchMode: request.matchMode,
+        matchMode:
+          request.matchMode === "server" ? undefined : request.matchMode,
+        minShouldMatch:
+          request.matchMode === "min-should"
+            ? request.minShouldMatch
+            : undefined,
         phrase: request.phrase,
-        // The admin exposes fuzzy as one toggle: one edit of slack + prefix terms.
-        ...(request.fuzzy ? { fuzziness: 1, prefixTerms: true } : {}),
+        fuzziness: request.fuzziness,
+        prefixTerms: request.prefixTerms,
       },
       init?.signal,
     );

--- a/admin/app/lib/client/infrastructure/api/types.ts
+++ b/admin/app/lib/client/infrastructure/api/types.ts
@@ -103,18 +103,22 @@ export interface ScanVerticesResponse {
 // into full vertices via GetVertices, preserving rank order.
 
 /** How a multi-word content-search query's words combine (#892). */
-export type SearchMatchMode = "any" | "all" | "min-should";
+export type SearchMatchMode = "server" | "any" | "all" | "min-should";
 
 export interface SearchVerticesRequest {
   query: string;
   limit?: number;
   prefix?: string;
-  /** Word combination: "any" (OR, default), "all" (AND), or "min-should". */
+  /** Word combination, or "server" to preserve the server default. */
   matchMode?: SearchMatchMode;
+  /** Explicit threshold for "min-should". */
+  minShouldMatch?: number;
   /** Require the query's words to occur adjacently, in order. */
   phrase?: boolean;
-  /** Tolerate typos and match word prefixes (edit distance 1 + prefix terms). */
-  fuzzy?: boolean;
+  /** Maximum fuzzy edit distance (0, 1, or 2). */
+  fuzziness?: 0 | 1 | 2;
+  /** Match dictionary terms that extend a query word. */
+  prefixTerms?: boolean;
 }
 
 export interface SearchHit {

--- a/admin/app/lib/client/usecase/search-vertices/driver.test.ts
+++ b/admin/app/lib/client/usecase/search-vertices/driver.test.ts
@@ -157,9 +157,8 @@ describe("search vertices latest-input-wins driver", () => {
 
     const nextEpoch = h.driver.update(
       h.input("alpha beta", {
+        ...DEFAULT_SEARCH_QUERY_OPTIONS,
         matchMode: "all",
-        phrase: false,
-        fuzzy: false,
       }),
       10,
     );

--- a/admin/app/lib/client/usecase/search-vertices/handlers.ts
+++ b/admin/app/lib/client/usecase/search-vertices/handlers.ts
@@ -42,8 +42,10 @@ export async function fetchSearchResults(
         limit: input.limit,
         prefix: input.prefix,
         matchMode: input.options.matchMode,
+        minShouldMatch: input.options.minShouldMatch,
         phrase: input.options.phrase,
-        fuzzy: input.options.fuzzy,
+        fuzziness: input.options.fuzziness,
+        prefixTerms: input.options.prefixTerms,
       },
       { signal: input.signal },
     );

--- a/admin/app/lib/client/usecase/search-vertices/reducer.test.ts
+++ b/admin/app/lib/client/usecase/search-vertices/reducer.test.ts
@@ -162,9 +162,8 @@ describe("searchVerticesReducer", () => {
     const next = searchVerticesReducer(
       seeded,
       input("alpha beta", 2, {
+        ...DEFAULT_SEARCH_QUERY_OPTIONS,
         matchMode: "all",
-        phrase: false,
-        fuzzy: false,
       }),
     );
     expect(next.options.matchMode).toBe("all");
@@ -178,7 +177,7 @@ describe("searchVerticesReducer", () => {
   it("advances the epoch but stays inert when options change with no query", () => {
     const next = searchVerticesReducer(
       INITIAL_SEARCH_VERTICES_STATE,
-      input("", 1, { matchMode: "any", phrase: true, fuzzy: false }),
+      input("", 1, { ...DEFAULT_SEARCH_QUERY_OPTIONS, phrase: true }),
     );
     expect(next.options.phrase).toBe(true);
     // Epoch advances so a slow reply from the prior options cannot land,
@@ -193,20 +192,24 @@ describe("searchVerticesReducer", () => {
       INITIAL_SEARCH_VERTICES_STATE,
       input("alpha", 1),
       input("alpha", 2, {
-        matchMode: "all",
+        ...DEFAULT_SEARCH_QUERY_OPTIONS,
+        matchMode: "server",
         phrase: true,
-        fuzzy: false,
       }),
     );
     const cleared = searchVerticesReducer(
       seeded,
-      input("", 3, { matchMode: "all", phrase: true, fuzzy: false }),
+      input("", 3, {
+        ...DEFAULT_SEARCH_QUERY_OPTIONS,
+        matchMode: "server",
+        phrase: true,
+      }),
     );
     expect(cleared.query).toBe("");
     expect(cleared.options).toEqual({
-      matchMode: "all",
+      ...DEFAULT_SEARCH_QUERY_OPTIONS,
+      matchMode: "server",
       phrase: true,
-      fuzzy: false,
     });
   });
 });

--- a/admin/app/lib/client/usecase/search-vertices/state.ts
+++ b/admin/app/lib/client/usecase/search-vertices/state.ts
@@ -39,22 +39,31 @@ export interface SearchResultRow {
 }
 
 /** How a multi-word content-search query's words combine. */
-export type SearchMatchMode = "any" | "all" | "min-should";
+export type SearchMatchMode = "server" | "any" | "all" | "min-should";
+
+/** Supported fuzzy edit-distance capability. */
+export type SearchFuzziness = 0 | 1 | 2;
 
 /** The relevance controls the search box exposes (#892). */
 export interface SearchQueryOptions {
-  /** Word combination: "any" (OR, default), "all" (AND), or "min-should". */
+  /** Word combination, or "server" to preserve the server default. */
   matchMode: SearchMatchMode;
+  /** Explicit threshold used only by "min-should". */
+  minShouldMatch: number;
   /** Require the query's words to occur adjacently, in order. */
   phrase: boolean;
-  /** Tolerate typos and match word prefixes. */
-  fuzzy: boolean;
+  /** Maximum fuzzy edit distance. */
+  fuzziness: SearchFuzziness;
+  /** Match dictionary terms that extend a query word. */
+  prefixTerms: boolean;
 }
 
 export const DEFAULT_SEARCH_QUERY_OPTIONS: SearchQueryOptions = {
-  matchMode: "any",
+  matchMode: "server",
+  minShouldMatch: 2,
   phrase: false,
-  fuzzy: false,
+  fuzziness: 0,
+  prefixTerms: false,
 };
 
 export interface SearchVerticesState {

--- a/admin/app/lib/client/usecase/search-vertices/use-search-vertices.ts
+++ b/admin/app/lib/client/usecase/search-vertices/use-search-vertices.ts
@@ -16,6 +16,7 @@ import { searchVerticesReducer } from "./reducer";
 import {
   INITIAL_SEARCH_VERTICES_STATE,
   type SearchMatchMode,
+  type SearchFuzziness,
   type SearchVerticesState,
 } from "./state";
 
@@ -38,12 +39,16 @@ export interface UseSearchVerticesOptions {
   /** Optional key-prefix filter applied to the ranked hits server-side. */
   prefix?: string;
   debounceMs?: number;
-  /** Word combination: "any" (OR, default), "all" (AND), or "min-should". */
+  /** Word combination, or "server" to preserve the server default. */
   matchMode?: SearchMatchMode;
+  /** Explicit threshold used by "min-should". */
+  minShouldMatch?: number;
   /** Require the query's words to occur adjacently, in order. */
   phrase?: boolean;
-  /** Tolerate typos and match word prefixes. */
-  fuzzy?: boolean;
+  /** Maximum fuzzy edit distance. */
+  fuzziness?: SearchFuzziness;
+  /** Match dictionary terms that extend a query word. */
+  prefixTerms?: boolean;
 }
 
 export interface UseSearchVerticesResult {
@@ -66,9 +71,11 @@ export function useSearchVertices(
   const limit = options.limit ?? DEFAULT_SEARCH_LIMIT;
   const prefix = options.prefix;
   const debounceMs = options.debounceMs ?? SEARCH_DEBOUNCE_MS;
-  const matchMode = options.matchMode ?? "any";
+  const matchMode = options.matchMode ?? "server";
+  const minShouldMatch = options.minShouldMatch ?? 2;
   const phrase = options.phrase ?? false;
-  const fuzzy = options.fuzzy ?? false;
+  const fuzziness = options.fuzziness ?? 0;
+  const prefixTerms = options.prefixTerms ?? false;
   const [state, dispatch] = useReducer(
     searchVerticesReducer,
     INITIAL_SEARCH_VERTICES_STATE,
@@ -88,9 +95,25 @@ export function useSearchVertices(
       query: rawQuery,
       limit,
       prefix,
-      options: { matchMode, phrase, fuzzy },
+      options: {
+        matchMode,
+        minShouldMatch,
+        phrase,
+        fuzziness,
+        prefixTerms,
+      },
     }),
-    [client, rawQuery, limit, prefix, matchMode, phrase, fuzzy],
+    [
+      client,
+      rawQuery,
+      limit,
+      prefix,
+      matchMode,
+      minShouldMatch,
+      phrase,
+      fuzziness,
+      prefixTerms,
+    ],
   );
 
   // Invalidate the old epoch during the commit that displays the new input.

--- a/admin/tests/e2e/browse.spec.ts
+++ b/admin/tests/e2e/browse.spec.ts
@@ -215,6 +215,16 @@ test.describe("/vertices — content search (#650)", () => {
     await expect(page.getByTestId("search-mode")).toBeVisible();
     await expect(page.getByTestId("search-phrase")).toBeVisible();
     await expect(page.getByTestId("search-fuzzy")).toBeVisible();
+    await expect(page.getByTestId("search-prefix")).toBeVisible();
+    await expect(page.getByTestId("search-prefix-terms")).toBeVisible();
+
+    // The minimum mode exposes a real positive threshold, then returning to
+    // Server default removes the explicit override before the query runs.
+    await page.getByTestId("search-mode").click();
+    await page.getByRole("option", { name: "At least N words" }).click();
+    await expect(page.getByTestId("search-min-should")).toHaveValue("2");
+    await page.getByTestId("search-mode").click();
+    await page.getByRole("option", { name: "Server default" }).click();
 
     // "zorptangle consensus": only doc1 carries both words; doc2 has
     // "zorptangle" but not "consensus".
@@ -222,7 +232,8 @@ test.describe("/vertices — content search (#650)", () => {
 
     const table = page.getByTestId("search-results-table");
     await expect(table).toBeVisible();
-    // Any-word (default OR): doc2 rides in on the shared "zorptangle".
+    // The e2e server's configured default is OR, so doc2 rides in on the
+    // shared "zorptangle" without the admin forcing an explicit ANY mode.
     await expect(
       table.getByRole("link", { name: "e2e:search:doc2" }),
     ).toBeVisible();

--- a/cli/cmd/search.go
+++ b/cli/cmd/search.go
@@ -22,14 +22,16 @@ var (
 // parseSearchMode maps the --mode flag onto a client.MatchMode.
 func parseSearchMode(s string) (client.MatchMode, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", "any":
+	case "", "server", "default", "unset":
+		return client.MatchServerDefault, nil
+	case "any":
 		return client.MatchAny, nil
 	case "all":
 		return client.MatchAll, nil
 	case "min-should", "minshould", "min_should":
 		return client.MatchMinShould, nil
 	default:
-		return 0, fmt.Errorf("unknown --mode %q (want any|all|min-should)", s)
+		return 0, fmt.Errorf("unknown --mode %q (want server|any|all|min-should)", s)
 	}
 }
 
@@ -44,8 +46,9 @@ per line as "<key>\t<score>", most relevant first; a query that matches nothing
 prints nothing and exits 0. Requires the server's search index
 (LANTERN_SEARCH_ENABLED, on by default).
 
-The default is an OR-union over the query's words. Tune relevance with:
+By default the server chooses how query words combine. Override it with:
 
+	--mode server         defer to LANTERN_SEARCH_DEFAULT_MODE (default)
   --mode all            require every query word (AND)
   --mode min-should --min-should N   require at least N distinct query words
   --phrase              require the words to occur adjacently, in order
@@ -69,16 +72,13 @@ EXAMPLES
 		if err != nil {
 			return err
 		}
-		cli, err := dial()
-		if err != nil {
-			return err
-		}
-		defer func() { _ = cli.Close() }()
 
 		opts := []client.SearchOption{
 			client.WithSearchLimit(searchLimit),
 			client.WithSearchPrefix(searchPrefix),
-			client.WithMatchMode(mode),
+		}
+		if mode != client.MatchServerDefault {
+			opts = append(opts, client.WithMatchMode(mode))
 		}
 		if searchMinShould > 0 {
 			opts = append(opts, client.WithMinShouldMatch(searchMinShould))
@@ -92,6 +92,15 @@ EXAMPLES
 		if searchPhrase {
 			opts = append(opts, client.WithPhrase())
 		}
+		if err := client.ValidateSearchOptions(opts...); err != nil {
+			return err
+		}
+
+		cli, err := dial()
+		if err != nil {
+			return err
+		}
+		defer func() { _ = cli.Close() }()
 
 		hits, err := cli.SearchVertices(cmd.Context(), args[0], opts...)
 		if err != nil {
@@ -120,7 +129,7 @@ func init() {
 	f := searchCmd.Flags()
 	f.Uint32Var(&searchLimit, "limit", 0, "maximum hits to return (0 = server default)")
 	f.StringVar(&searchPrefix, "prefix", "", "restrict hits to vertices whose key carries this prefix")
-	f.StringVar(&searchMode, "mode", "any", "term combination: any|all|min-should")
+	f.StringVar(&searchMode, "mode", "server", "term combination: server|any|all|min-should")
 	f.Uint32Var(&searchMinShould, "min-should", 0, "minimum distinct query words a hit must carry (with --mode min-should)")
 	f.Uint32Var(&searchFuzziness, "fuzziness", 0, "maximum edit distance for fuzzy term matching (0-2)")
 	f.BoolVar(&searchPrefixTerms, "prefix-terms", false, "also match dictionary terms that extend a query word")

--- a/cli/cmd/search_test.go
+++ b/cli/cmd/search_test.go
@@ -14,7 +14,10 @@ func TestParseSearchMode(t *testing.T) {
 		want    client.MatchMode
 		wantErr bool
 	}{
-		{"", client.MatchAny, false},
+		{"", client.MatchServerDefault, false},
+		{"server", client.MatchServerDefault, false},
+		{"default", client.MatchServerDefault, false},
+		{"unset", client.MatchServerDefault, false},
 		{"any", client.MatchAny, false},
 		{"ANY", client.MatchAny, false},
 		{"all", client.MatchAll, false},
@@ -36,6 +39,25 @@ func TestParseSearchMode(t *testing.T) {
 		if got != c.want {
 			t.Errorf("parseSearchMode(%q) = %v, want %v", c.in, got, c.want)
 		}
+	}
+}
+
+func TestSearchFlagOptionsValidateBeforeDial(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []client.SearchOption
+	}{
+		{"minimum without min mode", []client.SearchOption{client.WithMinShouldMatch(1)}},
+		{"phrase with explicit mode", []client.SearchOption{client.WithPhrase(), client.WithMatchMode(client.MatchAny)}},
+		{"phrase with fuzzy", []client.SearchOption{client.WithPhrase(), client.WithFuzziness(1)}},
+		{"fuzziness outside range", []client.SearchOption{client.WithFuzziness(3)}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := client.ValidateSearchOptions(tc.opts...); !errors.Is(err, client.ErrInvalidArgument) {
+				t.Fatalf("ValidateSearchOptions = %v, want ErrInvalidArgument", err)
+			}
+		})
 	}
 }
 

--- a/pb/graph/v1/graph.pb.go
+++ b/pb/graph/v1/graph.pb.go
@@ -265,9 +265,8 @@ func (ScanOrder) EnumDescriptor() ([]byte, []int) {
 type MatchMode int32
 
 const (
-	// MATCH_MODE_UNSPECIFIED defers to the server default
-	// (LANTERN_SEARCH_DEFAULT_MODE, itself defaulting to ANY), so an unset field
-	// keeps the OR-union behavior.
+	// MATCH_MODE_UNSPECIFIED always defers to LANTERN_SEARCH_DEFAULT_MODE,
+	// including when other SearchOptions fields are present.
 	MatchMode_MATCH_MODE_UNSPECIFIED MatchMode = 0
 	// MATCH_MODE_ANY keeps every vertex sharing at least one query term (OR).
 	MatchMode_MATCH_MODE_ANY MatchMode = 1
@@ -2201,20 +2200,24 @@ func (x *ScanVertexKeysResponse) GetNextCursor() []byte {
 }
 
 // SearchOptions carries the optional relevance controls for SearchVertices
-// (#892): match mode, phrase adjacency, and prefix/fuzzy term expansion. Every
-// field is optional and the zero value reproduces the default OR-union search,
-// so leaving options unset is identical to the pre-#892 request.
+// (#892): match mode, phrase adjacency, and prefix/fuzzy term expansion. An
+// omitted message and an all-zero message both defer match membership to the
+// server default. The server rejects unknown enums, out-of-domain numeric
+// values, and combinations whose fields would otherwise be ignored (#1055).
 type SearchOptions struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// match_mode selects AND / OR / minimum-should-match membership (#890).
+	// match_mode selects AND / OR / minimum-should-match membership (#890), or
+	// defers to the server default when unspecified.
 	MatchMode MatchMode `protobuf:"varint,1,opt,name=match_mode,json=matchMode,proto3,enum=graph.v1.MatchMode" json:"match_mode,omitempty"`
 	// min_should_match is the minimum number of distinct query word terms a
-	// vertex must carry when match_mode is MATCH_MODE_MIN_SHOULD; clamped to
-	// [1, number of query word terms]. Ignored for other modes.
+	// vertex must carry. A non-zero value is valid only with an explicit
+	// MATCH_MODE_MIN_SHOULD. Zero with that mode uses the server's configured
+	// LANTERN_SEARCH_DEFAULT_MIN_SHOULD value.
 	MinShouldMatch uint32 `protobuf:"varint,2,opt,name=min_should_match,json=minShouldMatch,proto3" json:"min_should_match,omitempty"`
 	// phrase requires the query's word terms to occur adjacently, in order
-	// (#889) — the precision counterpart to the OR-union. It takes precedence
-	// over match_mode.
+	// (#889). Until phrase composition is implemented, phrase=true requires
+	// match_mode unspecified, min_should_match=0, fuzziness=0, and
+	// prefix_terms=false; conflicting combinations return INVALID_ARGUMENT.
 	Phrase bool `protobuf:"varint,3,opt,name=phrase,proto3" json:"phrase,omitempty"`
 	// fuzziness is the maximum edit distance (0, 1, or 2) at which a query word
 	// also matches dictionary terms, so a typo still finds the term (#891). 0

--- a/proto/graph/v1/graph.proto
+++ b/proto/graph/v1/graph.proto
@@ -378,9 +378,8 @@ message ScanVertexKeysResponse {
 // matches. Coverage counts word-channel terms, so requiring "all" of a CJK run
 // means all of its bigrams.
 enum MatchMode {
-  // MATCH_MODE_UNSPECIFIED defers to the server default
-  // (LANTERN_SEARCH_DEFAULT_MODE, itself defaulting to ANY), so an unset field
-  // keeps the OR-union behavior.
+  // MATCH_MODE_UNSPECIFIED always defers to LANTERN_SEARCH_DEFAULT_MODE,
+  // including when other SearchOptions fields are present.
   MATCH_MODE_UNSPECIFIED = 0;
   // MATCH_MODE_ANY keeps every vertex sharing at least one query term (OR).
   MATCH_MODE_ANY = 1;
@@ -392,19 +391,23 @@ enum MatchMode {
 }
 
 // SearchOptions carries the optional relevance controls for SearchVertices
-// (#892): match mode, phrase adjacency, and prefix/fuzzy term expansion. Every
-// field is optional and the zero value reproduces the default OR-union search,
-// so leaving options unset is identical to the pre-#892 request.
+// (#892): match mode, phrase adjacency, and prefix/fuzzy term expansion. An
+// omitted message and an all-zero message both defer match membership to the
+// server default. The server rejects unknown enums, out-of-domain numeric
+// values, and combinations whose fields would otherwise be ignored (#1055).
 message SearchOptions {
-  // match_mode selects AND / OR / minimum-should-match membership (#890).
+  // match_mode selects AND / OR / minimum-should-match membership (#890), or
+  // defers to the server default when unspecified.
   MatchMode match_mode = 1;
   // min_should_match is the minimum number of distinct query word terms a
-  // vertex must carry when match_mode is MATCH_MODE_MIN_SHOULD; clamped to
-  // [1, number of query word terms]. Ignored for other modes.
+  // vertex must carry. A non-zero value is valid only with an explicit
+  // MATCH_MODE_MIN_SHOULD. Zero with that mode uses the server's configured
+  // LANTERN_SEARCH_DEFAULT_MIN_SHOULD value.
   uint32 min_should_match = 2;
   // phrase requires the query's word terms to occur adjacently, in order
-  // (#889) — the precision counterpart to the OR-union. It takes precedence
-  // over match_mode.
+  // (#889). Until phrase composition is implemented, phrase=true requires
+  // match_mode unspecified, min_should_match=0, fuzziness=0, and
+  // prefix_terms=false; conflicting combinations return INVALID_ARGUMENT.
   bool phrase = 3;
   // fuzziness is the maximum edit distance (0, 1, or 2) at which a query word
   // also matches dictionary terms, so a typo still finds the term (#891). 0

--- a/sdks/dart/README.md
+++ b/sdks/dart/README.md
@@ -118,7 +118,10 @@ caps one call only. The SDK never retries or silently loops prefix Delete.
 `searchVertices` exposes prefix scope, limit, any/all/min-should-match modes,
 phrase matching, fuzziness, and prefix-term expansion. Nullable relevance
 fields preserve the distinction between omitted server defaults and explicit
-values. A server with search disabled returns the `SearchDisabled` result,
+values. `SearchMatchMode.minShouldMatch` accepts a null/zero
+`minShouldMatch` as the server-threshold sentinel. Non-zero thresholds under
+another mode and phrase combined with an explicit mode/fuzziness/prefix terms
+fail locally before transport. A server with search disabled returns the `SearchDisabled` result,
 which lets UI code render a calm unavailable state without classifying an
 exception. Only the typed `SearchErrorReason.searchDisabled` detail maps to
 that result; missing positional postings remain a

--- a/sdks/dart/lib/src/gen/graph/v1/graph.pb.dart
+++ b/sdks/dart/lib/src/gen/graph/v1/graph.pb.dart
@@ -2086,9 +2086,10 @@ class ScanVertexKeysResponse extends $pb.GeneratedMessage {
 }
 
 /// SearchOptions carries the optional relevance controls for SearchVertices
-/// (#892): match mode, phrase adjacency, and prefix/fuzzy term expansion. Every
-/// field is optional and the zero value reproduces the default OR-union search,
-/// so leaving options unset is identical to the pre-#892 request.
+/// (#892): match mode, phrase adjacency, and prefix/fuzzy term expansion. An
+/// omitted message and an all-zero message both defer match membership to the
+/// server default. The server rejects unknown enums, out-of-domain numeric
+/// values, and combinations whose fields would otherwise be ignored (#1055).
 class SearchOptions extends $pb.GeneratedMessage {
   factory SearchOptions({
     MatchMode? matchMode,
@@ -2151,7 +2152,8 @@ class SearchOptions extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<SearchOptions>(create);
   static SearchOptions? _defaultInstance;
 
-  /// match_mode selects AND / OR / minimum-should-match membership (#890).
+  /// match_mode selects AND / OR / minimum-should-match membership (#890), or
+  /// defers to the server default when unspecified.
   @$pb.TagNumber(1)
   MatchMode get matchMode => $_getN(0);
   @$pb.TagNumber(1)
@@ -2162,8 +2164,9 @@ class SearchOptions extends $pb.GeneratedMessage {
   void clearMatchMode() => $_clearField(1);
 
   /// min_should_match is the minimum number of distinct query word terms a
-  /// vertex must carry when match_mode is MATCH_MODE_MIN_SHOULD; clamped to
-  /// [1, number of query word terms]. Ignored for other modes.
+  /// vertex must carry. A non-zero value is valid only with an explicit
+  /// MATCH_MODE_MIN_SHOULD. Zero with that mode uses the server's configured
+  /// LANTERN_SEARCH_DEFAULT_MIN_SHOULD value.
   @$pb.TagNumber(2)
   $core.int get minShouldMatch => $_getIZ(1);
   @$pb.TagNumber(2)
@@ -2174,8 +2177,9 @@ class SearchOptions extends $pb.GeneratedMessage {
   void clearMinShouldMatch() => $_clearField(2);
 
   /// phrase requires the query's word terms to occur adjacently, in order
-  /// (#889) — the precision counterpart to the OR-union. It takes precedence
-  /// over match_mode.
+  /// (#889). Until phrase composition is implemented, phrase=true requires
+  /// match_mode unspecified, min_should_match=0, fuzziness=0, and
+  /// prefix_terms=false; conflicting combinations return INVALID_ARGUMENT.
   @$pb.TagNumber(3)
   $core.bool get phrase => $_getBF(2);
   @$pb.TagNumber(3)

--- a/sdks/dart/lib/src/gen/graph/v1/graph.pbenum.dart
+++ b/sdks/dart/lib/src/gen/graph/v1/graph.pbenum.dart
@@ -146,9 +146,8 @@ class ScanOrder extends $pb.ProtobufEnum {
 /// matches. Coverage counts word-channel terms, so requiring "all" of a CJK run
 /// means all of its bigrams.
 class MatchMode extends $pb.ProtobufEnum {
-  /// MATCH_MODE_UNSPECIFIED defers to the server default
-  /// (LANTERN_SEARCH_DEFAULT_MODE, itself defaulting to ANY), so an unset field
-  /// keeps the OR-union behavior.
+  /// MATCH_MODE_UNSPECIFIED always defers to LANTERN_SEARCH_DEFAULT_MODE,
+  /// including when other SearchOptions fields are present.
   static const MatchMode MATCH_MODE_UNSPECIFIED =
       MatchMode._(0, _omitEnumNames ? '' : 'MATCH_MODE_UNSPECIFIED');
 

--- a/sdks/dart/lib/src/search.dart
+++ b/sdks/dart/lib/src/search.dart
@@ -49,7 +49,8 @@ final class SearchOptions {
   /// Optional query-term membership mode.
   final SearchMatchMode? matchMode;
 
-  /// Required positive term count for [SearchMatchMode.minShouldMatch].
+  /// Optional term count for [SearchMatchMode.minShouldMatch]. Zero or null
+  /// selects the server's configured threshold.
   final int? minShouldMatch;
 
   /// Whether word terms must occur adjacently and in order.
@@ -325,21 +326,36 @@ extension LanternSearch on LanternClient {
 void _validateSearchOptions(SearchOptions options) {
   _validateUint32(options.limit, 'limit');
   final min = options.minShouldMatch;
-  if (options.matchMode == SearchMatchMode.minShouldMatch) {
-    if (min == null || min <= 0) {
-      throw _invalidArgumentException(
-        'minShouldMatch must be positive for minShouldMatch mode',
-      );
-    }
-  } else if (min != null) {
+  if (min != null) _validateUint32(min, 'minShouldMatch');
+  if (min != null &&
+      min != 0 &&
+      options.matchMode != SearchMatchMode.minShouldMatch) {
     throw _invalidArgumentException(
       'minShouldMatch requires minShouldMatch mode',
     );
   }
-  if (min != null) _validateUint32(min, 'minShouldMatch');
   final fuzziness = options.fuzziness;
   if (fuzziness != null && (fuzziness < 0 || fuzziness > 2)) {
     throw _invalidArgumentException('fuzziness must be 0, 1, or 2');
+  }
+  if (options.phrase != true) return;
+  if (options.matchMode != null) {
+    throw _invalidArgumentException(
+      'phrase cannot be combined with an explicit matchMode',
+    );
+  }
+  if (min != null && min != 0) {
+    throw _invalidArgumentException(
+      'phrase cannot be combined with minShouldMatch',
+    );
+  }
+  if (fuzziness != null && fuzziness != 0) {
+    throw _invalidArgumentException('phrase cannot be combined with fuzziness');
+  }
+  if (options.prefixTerms == true) {
+    throw _invalidArgumentException(
+      'phrase cannot be combined with prefixTerms',
+    );
   }
 }
 

--- a/sdks/dart/test/search_test.dart
+++ b/sdks/dart/test/search_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 
 void main() {
   test(
-    'one-shot search preserves every wire option and ranked result',
+    'one-shot search preserves every composable wire option and ranked result',
     () async {
       late graph.SearchVerticesRequest captured;
       final transport = FakeTransportBuilder()
@@ -32,7 +32,6 @@ void main() {
           prefix: 'p:',
           matchMode: SearchMatchMode.minShouldMatch,
           minShouldMatch: 1,
-          phrase: true,
           fuzziness: 2,
           prefixTerms: true,
         ),
@@ -47,11 +46,63 @@ void main() {
       expect(captured.hasOptions(), isTrue);
       expect(captured.options.matchMode, graph.MatchMode.MATCH_MODE_MIN_SHOULD);
       expect(captured.options.minShouldMatch, 1);
-      expect(captured.options.phrase, isTrue);
+      expect(captured.options.phrase, isFalse);
       expect(captured.options.fuzziness, 2);
       expect(captured.options.prefixTerms, isTrue);
     },
   );
+
+  test('phrase alone is forwarded with server-default membership', () async {
+    late graph.SearchVerticesRequest captured;
+    final transport = FakeTransportBuilder()
+        .unary<graph.SearchVerticesRequest, graph.SearchVerticesResponse>(
+          LanternService.searchVertices,
+          (request, context) {
+            captured = request.clone();
+            return graph.SearchVerticesResponse();
+          },
+        )
+        .build();
+    await _client(transport).searchVertices(
+      'alpha beta',
+      searchOptions: const SearchOptions(phrase: true),
+    );
+    expect(captured.options.matchMode, graph.MatchMode.MATCH_MODE_UNSPECIFIED);
+    expect(captured.options.phrase, isTrue);
+  });
+
+  test('minimum mode accepts the server threshold sentinel', () async {
+    var calls = 0;
+    final transport = FakeTransportBuilder()
+        .unary<graph.SearchVerticesRequest, graph.SearchVerticesResponse>(
+          LanternService.searchVertices,
+          (request, context) {
+            calls++;
+            expect(
+              request.options.matchMode,
+              graph.MatchMode.MATCH_MODE_MIN_SHOULD,
+            );
+            expect(request.options.minShouldMatch, 0);
+            return graph.SearchVerticesResponse();
+          },
+        )
+        .build();
+    final client = _client(transport);
+    await client.searchVertices(
+      'alpha beta',
+      searchOptions: const SearchOptions(
+        matchMode: SearchMatchMode.minShouldMatch,
+      ),
+    );
+    await client.searchVertices(
+      'alpha beta',
+      searchOptions: const SearchOptions(
+        matchMode: SearchMatchMode.minShouldMatch,
+        minShouldMatch: 0,
+      ),
+    );
+    expect(calls, 2);
+  });
 
   test('omitted relevance controls omit SearchOptions', () async {
     late graph.SearchVerticesRequest captured;
@@ -144,10 +195,10 @@ void main() {
     for (final options in [
       const SearchOptions(fuzziness: 3),
       const SearchOptions(minShouldMatch: 1),
-      const SearchOptions(
-        matchMode: SearchMatchMode.minShouldMatch,
-        minShouldMatch: 0,
-      ),
+      const SearchOptions(matchMode: SearchMatchMode.any, minShouldMatch: 1),
+      const SearchOptions(phrase: true, matchMode: SearchMatchMode.all),
+      const SearchOptions(phrase: true, fuzziness: 1),
+      const SearchOptions(phrase: true, prefixTerms: true),
       const SearchOptions(limit: -1),
     ]) {
       await expectLater(

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -236,6 +236,15 @@ matches `ErrSearchPositionsDisabled`; both also match
 `ErrFailedPrecondition`. `SearchFailureReason` returns the bounded wire reason,
 and `ServerStatus.GetSearch()` exposes positions, defaults, limits,
 implementation versions, and the HA configuration fingerprint.
+Leaving `WithMatchMode` unset always preserves the server's configured match
+mode, including when `WithFuzziness` or `WithPrefixTerms` is present.
+`WithMatchMode(MatchMinShould)` plus `WithMinShouldMatch(0)` selects the
+server's threshold. `ValidateSearchOptions` and `SearchVertices` reject
+non-zero thresholds under another mode, fuzziness above 2, and phrase combined
+with an explicit mode/fuzziness/prefix terms as `ErrInvalidArgument` before an
+RPC. `WithIncrementalSearchOptions` forwards the complete one-shot option set;
+the package-level `NewIncrementalSearch` accepts the narrow `Searcher`
+interface implemented by both `Lantern` and `Failover`.
 
 `Illuminate` accepts at most one traversal family option (`WithBFS`,
 `WithPPR`, or `WithLocalCommunity`). Combining them returns a local error that

--- a/sdks/go/search.go
+++ b/sdks/go/search.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"connectrpc.com/connect"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
@@ -56,11 +57,13 @@ type SearchHit struct {
 }
 
 // MatchMode selects how SearchVertices combines a multi-word query's terms:
-// MatchAny (OR, the server default), MatchAll (AND), or MatchMinShould (at
+// MatchServerDefault, MatchAny (OR), MatchAll (AND), or MatchMinShould (at
 // least WithMinShouldMatch terms). It is a thin alias of the wire enum.
 type MatchMode = pb.MatchMode
 
 const (
+	// MatchServerDefault defers membership semantics to the server.
+	MatchServerDefault = pb.MatchMode_MATCH_MODE_UNSPECIFIED
 	// MatchAny keeps vertices sharing at least one query term (OR-union).
 	MatchAny = pb.MatchMode_MATCH_MODE_ANY
 	// MatchAll keeps vertices carrying every query word term (AND).
@@ -85,6 +88,8 @@ type searchOptions struct {
 	prefixTerms    bool
 	phrase         bool
 }
+
+const maxSearchFuzziness = uint32(2)
 
 // WithSearchLimit caps the number of hits the server returns from one
 // SearchVertices call. 0 (the default) lets the server apply its configured
@@ -116,9 +121,9 @@ func WithMinShouldMatch(n uint32) SearchOption {
 	return func(o *searchOptions) { o.minShouldMatch = n }
 }
 
-// WithPhrase requires the query's word terms to occur adjacently, in order —
-// the precision counterpart to the default OR-union. It takes precedence over
-// WithMatchMode (#889).
+// WithPhrase requires the query's word terms to occur adjacently, in order.
+// Phrase currently cannot compose with an explicit match mode, fuzziness, or
+// prefix terms; ValidateSearchOptions rejects those combinations (#889).
 func WithPhrase() SearchOption {
 	return func(o *searchOptions) { o.phrase = true }
 }
@@ -134,6 +139,51 @@ func WithFuzziness(edits uint32) SearchOption {
 // "lan" finds "lantern" (#891).
 func WithPrefixTerms() SearchOption {
 	return func(o *searchOptions) { o.prefixTerms = true }
+}
+
+// ValidateSearchOptions checks SearchOption values without dialing a server.
+// Invalid combinations wrap ErrInvalidArgument, matching an INVALID_ARGUMENT
+// response from the server. SearchVertices calls it automatically; command
+// surfaces may call it before opening a transport.
+func ValidateSearchOptions(opts ...SearchOption) error {
+	o := searchOptions{}
+	for _, apply := range opts {
+		apply(&o)
+	}
+	return validateSearchOptions(o)
+}
+
+func validateSearchOptions(o searchOptions) error {
+	switch o.matchMode {
+	case pb.MatchMode_MATCH_MODE_UNSPECIFIED,
+		pb.MatchMode_MATCH_MODE_ANY,
+		pb.MatchMode_MATCH_MODE_ALL,
+		pb.MatchMode_MATCH_MODE_MIN_SHOULD:
+	default:
+		return fmt.Errorf("%w: search match mode %d is not recognized", ErrInvalidArgument, o.matchMode)
+	}
+	if o.minShouldMatch != 0 && o.matchMode != pb.MatchMode_MATCH_MODE_MIN_SHOULD {
+		return fmt.Errorf("%w: WithMinShouldMatch requires WithMatchMode(MatchMinShould)", ErrInvalidArgument)
+	}
+	if o.fuzziness > maxSearchFuzziness {
+		return fmt.Errorf("%w: WithFuzziness must be 0, 1, or 2", ErrInvalidArgument)
+	}
+	if !o.phrase {
+		return nil
+	}
+	if o.matchMode != pb.MatchMode_MATCH_MODE_UNSPECIFIED {
+		return fmt.Errorf("%w: WithPhrase cannot be combined with an explicit match mode", ErrInvalidArgument)
+	}
+	if o.minShouldMatch != 0 {
+		return fmt.Errorf("%w: WithPhrase cannot be combined with WithMinShouldMatch", ErrInvalidArgument)
+	}
+	if o.fuzziness != 0 {
+		return fmt.Errorf("%w: WithPhrase cannot be combined with WithFuzziness", ErrInvalidArgument)
+	}
+	if o.prefixTerms {
+		return fmt.Errorf("%w: WithPhrase cannot be combined with WithPrefixTerms", ErrInvalidArgument)
+	}
+	return nil
 }
 
 // SearchVertices returns vertices ranked by full-text relevance over their
@@ -156,6 +206,9 @@ func (l *Lantern) SearchVertices(ctx context.Context, query string, opts ...Sear
 	o := searchOptions{}
 	for _, apply := range opts {
 		apply(&o)
+	}
+	if err := validateSearchOptions(o); err != nil {
+		return nil, err
 	}
 	ctx, cancel := l.applyTimeout(ctx)
 	defer cancel()

--- a/sdks/go/search_incremental.go
+++ b/sdks/go/search_incremental.go
@@ -45,8 +45,7 @@ type IncrementalSearchOption func(*incrementalSearchOptions)
 
 type incrementalSearchOptions struct {
 	debounce       time.Duration
-	limit          uint32
-	prefix         string
+	search         searchOptions
 	minQueryLength int
 }
 
@@ -62,14 +61,24 @@ func WithDebounce(d time.Duration) IncrementalSearchOption {
 // SearchVertices RPC the driver issues, exactly like WithSearchLimit on a
 // one-shot call. 0 (the default) lets the server apply its configured default.
 func WithIncrementalSearchLimit(n uint32) IncrementalSearchOption {
-	return func(o *incrementalSearchOptions) { o.limit = n }
+	return func(o *incrementalSearchOptions) { o.search.limit = n }
 }
 
 // WithIncrementalSearchPrefix scopes every issued search to vertices whose key
 // carries the given prefix, exactly like WithSearchPrefix on a one-shot call.
 // An empty prefix (the default) searches every live vertex.
 func WithIncrementalSearchPrefix(p string) IncrementalSearchOption {
-	return func(o *incrementalSearchOptions) { o.prefix = p }
+	return func(o *incrementalSearchOptions) { o.search.prefix = p }
+}
+
+// WithIncrementalSearchOptions applies the same relevance options accepted by
+// one-shot SearchVertices to every dispatched incremental search.
+func WithIncrementalSearchOptions(opts ...SearchOption) IncrementalSearchOption {
+	return func(o *incrementalSearchOptions) {
+		for _, apply := range opts {
+			apply(&o.search)
+		}
+	}
 }
 
 // WithMinQueryLength sets the shortest query, counted in runes, that triggers
@@ -91,8 +100,8 @@ func WithMinQueryLength(n int) IncrementalSearchOption {
 // (a consumer ranging over it should also select on its own done signal) and
 // further Search calls are dropped.
 type IncrementalSearch struct {
-	l    *Lantern
-	opts incrementalSearchOptions
+	searcher Searcher
+	opts     incrementalSearchOptions
 
 	updates chan SearchUpdate
 
@@ -121,6 +130,17 @@ type IncrementalSearch struct {
 // call so cancellation and Close can wait for all owned work. Cancel ctx or
 // call Close to stop it.
 func (l *Lantern) NewIncrementalSearch(ctx context.Context, opts ...IncrementalSearchOption) *IncrementalSearch {
+	return NewIncrementalSearch(ctx, l, opts...)
+}
+
+// Searcher is the narrow one-shot capability IncrementalSearch requires.
+// Both Lantern and Failover implement it.
+type Searcher interface {
+	SearchVertices(context.Context, string, ...SearchOption) ([]SearchHit, error)
+}
+
+// NewIncrementalSearch starts a search-as-you-type driver over any Searcher.
+func NewIncrementalSearch(ctx context.Context, searcher Searcher, opts ...IncrementalSearchOption) *IncrementalSearch {
 	o := incrementalSearchOptions{
 		debounce:       defaultIncrementalDebounce,
 		minQueryLength: defaultMinQueryLength,
@@ -136,18 +156,23 @@ func (l *Lantern) NewIncrementalSearch(ctx context.Context, opts ...IncrementalS
 	}
 	dctx, cancel := context.WithCancel(ctx)
 	s := &IncrementalSearch{
-		l:       l,
-		opts:    o,
-		updates: make(chan SearchUpdate, 1),
-		ctx:     dctx,
-		cancel:  cancel,
-		done:    make(chan struct{}),
+		searcher: searcher,
+		opts:     o,
+		updates:  make(chan SearchUpdate, 1),
+		ctx:      dctx,
+		cancel:   cancel,
+		done:     make(chan struct{}),
 	}
 	go func() {
 		<-dctx.Done()
 		s.shutdown()
 	}()
 	return s
+}
+
+// NewIncrementalSearch starts a failover-aware incremental search driver.
+func (f *Failover) NewIncrementalSearch(ctx context.Context, opts ...IncrementalSearchOption) *IncrementalSearch {
+	return NewIncrementalSearch(ctx, f, opts...)
 }
 
 // Search makes query the latest input immediately: it invalidates buffered
@@ -231,14 +256,8 @@ func (s *IncrementalSearch) dispatch(epoch uint64, query string) {
 // doSearch issues one SearchVertices call and delivers its result unless the
 // call was cancelled (superseded by a newer query) before it returned.
 func (s *IncrementalSearch) doSearch(ctx context.Context, epoch uint64, query string) {
-	opts := make([]SearchOption, 0, 2)
-	if s.opts.limit > 0 {
-		opts = append(opts, WithSearchLimit(s.opts.limit))
-	}
-	if s.opts.prefix != "" {
-		opts = append(opts, WithSearchPrefix(s.opts.prefix))
-	}
-	hits, err := s.l.SearchVertices(ctx, query, opts...)
+	configured := s.opts.search
+	hits, err := s.searcher.SearchVertices(ctx, query, func(o *searchOptions) { *o = configured })
 	if ctx.Err() != nil {
 		return // superseded or shut down: drop the stale reply
 	}

--- a/sdks/go/search_incremental_test.go
+++ b/sdks/go/search_incremental_test.go
@@ -160,11 +160,11 @@ func TestIncrementalSearchOptions(t *testing.T) {
 		if o.debounce != 7*time.Millisecond {
 			t.Errorf("debounce = %v, want 7ms", o.debounce)
 		}
-		if o.limit != 9 {
-			t.Errorf("limit = %d, want 9", o.limit)
+		if o.search.limit != 9 {
+			t.Errorf("limit = %d, want 9", o.search.limit)
 		}
-		if o.prefix != "user." {
-			t.Errorf("prefix = %q, want %q", o.prefix, "user.")
+		if o.search.prefix != "user." {
+			t.Errorf("prefix = %q, want %q", o.search.prefix, "user.")
 		}
 		if o.minQueryLength != 3 {
 			t.Errorf("minQueryLength = %d, want 3", o.minQueryLength)
@@ -177,7 +177,8 @@ func TestIncrementalSearch_ForwardsAndDelivers(t *testing.T) {
 		"hello": {{Key: "user.hi", Score: 1.5}},
 	}}
 	is := newDriver(t, fake, WithDebounce(5*time.Millisecond),
-		WithIncrementalSearchLimit(7), WithIncrementalSearchPrefix("user."))
+		WithIncrementalSearchLimit(7), WithIncrementalSearchPrefix("user."),
+		WithIncrementalSearchOptions(WithMatchMode(MatchMinShould), WithMinShouldMatch(2), WithFuzziness(1), WithPrefixTerms()))
 
 	is.Search("hello")
 	u := waitUpdate(t, is)
@@ -200,6 +201,32 @@ func TestIncrementalSearch_ForwardsAndDelivers(t *testing.T) {
 	}
 	if req.GetPrefix() != "user." {
 		t.Errorf("prefix = %q, want %q", req.GetPrefix(), "user.")
+	}
+	if got := req.GetOptions(); got.GetMatchMode() != pb.MatchMode_MATCH_MODE_MIN_SHOULD || got.GetMinShouldMatch() != 2 || got.GetFuzziness() != 1 || !got.GetPrefixTerms() {
+		t.Errorf("options = %+v, want complete one-shot options", got)
+	}
+}
+
+type fakeSearcher struct {
+	queries []string
+}
+
+func (f *fakeSearcher) SearchVertices(_ context.Context, query string, _ ...SearchOption) ([]SearchHit, error) {
+	f.queries = append(f.queries, query)
+	return []SearchHit{{Key: "narrow", Score: 1}}, nil
+}
+
+func TestIncrementalSearch_AcceptsNarrowSearcher(t *testing.T) {
+	fake := &fakeSearcher{}
+	is := NewIncrementalSearch(context.Background(), fake, WithDebounce(0))
+	t.Cleanup(func() { _ = is.Close() })
+	is.Search("hello")
+	u := waitUpdate(t, is)
+	if len(u.Hits) != 1 || u.Hits[0].Key != "narrow" {
+		t.Fatalf("hits = %+v, want narrow Searcher result", u.Hits)
+	}
+	if len(fake.queries) != 1 || fake.queries[0] != "hello" {
+		t.Fatalf("queries = %v, want [hello]", fake.queries)
 	}
 }
 

--- a/sdks/go/search_test.go
+++ b/sdks/go/search_test.go
@@ -37,6 +37,37 @@ func TestSearchOptions_Apply(t *testing.T) {
 	}
 }
 
+func TestValidateSearchOptions(t *testing.T) {
+	valid := [][]SearchOption{
+		nil,
+		{WithFuzziness(1)},
+		{WithMatchMode(MatchAny)},
+		{WithMatchMode(MatchMinShould)},
+		{WithMatchMode(MatchMinShould), WithMinShouldMatch(2)},
+		{WithPhrase()},
+	}
+	for i, opts := range valid {
+		if err := ValidateSearchOptions(opts...); err != nil {
+			t.Errorf("valid case %d: %v", i, err)
+		}
+	}
+
+	invalid := [][]SearchOption{
+		{WithMatchMode(MatchMode(99))},
+		{WithMinShouldMatch(1)},
+		{WithMatchMode(MatchAny), WithMinShouldMatch(1)},
+		{WithFuzziness(3)},
+		{WithPhrase(), WithMatchMode(MatchAll)},
+		{WithPhrase(), WithFuzziness(1)},
+		{WithPhrase(), WithPrefixTerms()},
+	}
+	for i, opts := range invalid {
+		if err := ValidateSearchOptions(opts...); !errors.Is(err, ErrInvalidArgument) {
+			t.Errorf("invalid case %d: err = %v, want ErrInvalidArgument", i, err)
+		}
+	}
+}
+
 // captureSearch is a fake LanternServiceClient that records every
 // SearchVerticesRequest it receives and replays a canned response (or error).
 // It embeds the interface (left nil) so it satisfies the full surface while
@@ -106,6 +137,17 @@ func TestSearchVertices(t *testing.T) {
 		}
 		if got.GetPrefix() != "" {
 			t.Errorf("default prefix = %q, want empty", got.GetPrefix())
+		}
+	})
+
+	t.Run("invalid options fail locally without transport", func(t *testing.T) {
+		l, capt := newClient(t)
+		_, err := l.SearchVertices(context.Background(), "alpha beta", WithPhrase(), WithFuzziness(1))
+		if !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("error = %v, want ErrInvalidArgument", err)
+		}
+		if len(capt.reqs) != 0 {
+			t.Fatalf("transport received %d requests, want 0", len(capt.reqs))
 		}
 	})
 

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -290,6 +290,14 @@ positional postings is distinct:
 lets clients discover positions, defaults, limits, implementation versions,
 and the HA configuration fingerprint before issuing a query.
 
+An omitted `matchMode` always sends `MATCH_MODE_UNSPECIFIED`, even when another
+relevance option is present, so the server default remains authoritative.
+`matchMode: "min-should"` accepts `minShouldMatch: 0` as the server-threshold
+sentinel. Invalid integers/ranges, a non-zero threshold under another mode,
+and phrase combined with an explicit mode/fuzziness/prefix terms reject locally
+with `InvalidArgumentError` before transport. `incrementalSearch` accepts and
+forwards the same complete `SearchOptions` set as one-shot search.
+
 ## Backup & restore
 
 `backup(opts?)` streams a whole-graph, point-in-time dump as an **async

--- a/sdks/node/src/client.ts
+++ b/sdks/node/src/client.ts
@@ -113,8 +113,51 @@ function toPbMatchMode(m: MatchMode | undefined): PbMatchMode {
       return PbMatchMode.ALL;
     case "min-should":
       return PbMatchMode.MIN_SHOULD;
+    case undefined:
+      return PbMatchMode.UNSPECIFIED;
     default:
       return PbMatchMode.ANY;
+  }
+}
+
+const MAX_UINT32 = 0xffff_ffff;
+
+function validateSearchInteger(name: string, value: number | undefined, max = MAX_UINT32): void {
+  if (value === undefined) return;
+  if (!Number.isFinite(value) || !Number.isInteger(value) || value < 0 || value > max) {
+    throw new InvalidArgumentError(
+      `search: ${name} must be an integer in [0, ${max}]; got ${value}`,
+    );
+  }
+}
+
+function validateSearchOptions(opts: SearchOptions): void {
+  validateSearchInteger("limit", opts.limit);
+  validateSearchInteger("minShouldMatch", opts.minShouldMatch);
+  validateSearchInteger("fuzziness", opts.fuzziness, 2);
+  if (
+    opts.matchMode !== undefined &&
+    opts.matchMode !== "any" &&
+    opts.matchMode !== "all" &&
+    opts.matchMode !== "min-should"
+  ) {
+    throw new InvalidArgumentError(`search: unrecognized matchMode ${String(opts.matchMode)}`);
+  }
+  if ((opts.minShouldMatch ?? 0) !== 0 && opts.matchMode !== "min-should") {
+    throw new InvalidArgumentError('search: minShouldMatch requires matchMode "min-should"');
+  }
+  if (!opts.phrase) return;
+  if (opts.matchMode !== undefined) {
+    throw new InvalidArgumentError("search: phrase cannot be combined with an explicit matchMode");
+  }
+  if ((opts.minShouldMatch ?? 0) !== 0) {
+    throw new InvalidArgumentError("search: phrase cannot be combined with minShouldMatch");
+  }
+  if ((opts.fuzziness ?? 0) !== 0) {
+    throw new InvalidArgumentError("search: phrase cannot be combined with fuzziness");
+  }
+  if (opts.prefixTerms === true) {
+    throw new InvalidArgumentError("search: phrase cannot be combined with prefixTerms");
   }
 }
 
@@ -568,6 +611,7 @@ export class Lantern {
     signal?: AbortSignal,
   ): Promise<SearchHit[]> {
     return this.invoke(async () => {
+      validateSearchOptions(opts);
       const resp = await this.client.searchVertices(
         {
           query,

--- a/sdks/node/src/gen/graph/v1/graph_pb.ts
+++ b/sdks/node/src/gen/graph/v1/graph_pb.ts
@@ -866,15 +866,17 @@ export const ScanVertexKeysResponseSchema: GenMessage<ScanVertexKeysResponse> = 
 
 /**
  * SearchOptions carries the optional relevance controls for SearchVertices
- * (#892): match mode, phrase adjacency, and prefix/fuzzy term expansion. Every
- * field is optional and the zero value reproduces the default OR-union search,
- * so leaving options unset is identical to the pre-#892 request.
+ * (#892): match mode, phrase adjacency, and prefix/fuzzy term expansion. An
+ * omitted message and an all-zero message both defer match membership to the
+ * server default. The server rejects unknown enums, out-of-domain numeric
+ * values, and combinations whose fields would otherwise be ignored (#1055).
  *
  * @generated from message graph.v1.SearchOptions
  */
 export type SearchOptions = Message<"graph.v1.SearchOptions"> & {
   /**
-   * match_mode selects AND / OR / minimum-should-match membership (#890).
+   * match_mode selects AND / OR / minimum-should-match membership (#890), or
+   * defers to the server default when unspecified.
    *
    * @generated from field: graph.v1.MatchMode match_mode = 1;
    */
@@ -882,8 +884,9 @@ export type SearchOptions = Message<"graph.v1.SearchOptions"> & {
 
   /**
    * min_should_match is the minimum number of distinct query word terms a
-   * vertex must carry when match_mode is MATCH_MODE_MIN_SHOULD; clamped to
-   * [1, number of query word terms]. Ignored for other modes.
+   * vertex must carry. A non-zero value is valid only with an explicit
+   * MATCH_MODE_MIN_SHOULD. Zero with that mode uses the server's configured
+   * LANTERN_SEARCH_DEFAULT_MIN_SHOULD value.
    *
    * @generated from field: uint32 min_should_match = 2;
    */
@@ -891,8 +894,9 @@ export type SearchOptions = Message<"graph.v1.SearchOptions"> & {
 
   /**
    * phrase requires the query's word terms to occur adjacently, in order
-   * (#889) — the precision counterpart to the OR-union. It takes precedence
-   * over match_mode.
+   * (#889). Until phrase composition is implemented, phrase=true requires
+   * match_mode unspecified, min_should_match=0, fuzziness=0, and
+   * prefix_terms=false; conflicting combinations return INVALID_ARGUMENT.
    *
    * @generated from field: bool phrase = 3;
    */
@@ -2416,9 +2420,8 @@ export const ScanOrderSchema: GenEnum<ScanOrder> = /*@__PURE__*/
  */
 export enum MatchMode {
   /**
-   * MATCH_MODE_UNSPECIFIED defers to the server default
-   * (LANTERN_SEARCH_DEFAULT_MODE, itself defaulting to ANY), so an unset field
-   * keeps the OR-union behavior.
+   * MATCH_MODE_UNSPECIFIED always defers to LANTERN_SEARCH_DEFAULT_MODE,
+   * including when other SearchOptions fields are present.
    *
    * @generated from enum value: MATCH_MODE_UNSPECIFIED = 0;
    */

--- a/sdks/node/src/incremental-search.ts
+++ b/sdks/node/src/incremental-search.ts
@@ -12,6 +12,8 @@
  */
 
 import type { SearchHit } from "./values.js";
+import type { SearchOptions } from "./options.js";
+import { InvalidArgumentError } from "./errors.js";
 
 /** Default debounce window (ms); mirrors the admin SPA's `SUGGEST_DEBOUNCE_MS`. */
 export const DEFAULT_DEBOUNCE_MS = 150;
@@ -19,13 +21,9 @@ export const DEFAULT_DEBOUNCE_MS = 150;
 /** Default shortest query (in code points) that triggers an RPC. */
 export const DEFAULT_MIN_QUERY_LENGTH = 1;
 
-export interface IncrementalSearchOptions {
+export interface IncrementalSearchOptions extends SearchOptions {
   /** Quiet period after the last `search` call before the RPC fires (default 150). */
   debounceMs?: number;
-  /** Per-call hit cap forwarded to every `searchVertices` RPC (0/omitted = server default). */
-  limit?: number;
-  /** Key-prefix namespace scope forwarded to every `searchVertices` RPC. */
-  prefix?: string;
   /**
    * Shortest query (code points) that triggers an RPC; a shorter one resolves
    * immediately to an empty result with no round-trip (default 1). Pass 0 to
@@ -55,7 +53,7 @@ export interface SearchUpdate {
  */
 export type SearchFn = (
   query: string,
-  opts: { limit?: number; prefix?: string },
+  opts: SearchOptions,
   signal?: AbortSignal,
 ) => Promise<SearchHit[]>;
 
@@ -97,7 +95,15 @@ export function createIncrementalSearch(
 ): IncrementalSearch {
   const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
   const minQueryLength = options.minQueryLength ?? DEFAULT_MIN_QUERY_LENGTH;
-  const searchOpts = { limit: options.limit, prefix: options.prefix };
+  for (const [name, value] of [
+    ["debounceMs", debounceMs],
+    ["minQueryLength", minQueryLength],
+  ] as const) {
+    if (!Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+      throw new InvalidArgumentError(`incremental search: ${name} must be a non-negative integer`);
+    }
+  }
+  const { debounceMs: _debounceMs, minQueryLength: _minQueryLength, ...searchOpts } = options;
 
   const listeners = new Set<(update: SearchUpdate) => void>();
   let epoch = 0;

--- a/sdks/node/src/options.ts
+++ b/sdks/node/src/options.ts
@@ -142,8 +142,8 @@ export interface EdgeScanOptions extends ScanOptions {
 
 /**
  * How a multi-word query's terms combine when choosing which vertices match
- * (see {@link SearchOptions.matchMode}): "any" (OR-union, the default), "all"
- * (AND), or "min-should" (at least {@link SearchOptions.minShouldMatch} terms).
+ * (see {@link SearchOptions.matchMode}): omitted defers to the server, "any"
+ * is OR, "all" is AND, and "min-should" requires a threshold.
  */
 export type MatchMode = "any" | "all" | "min-should";
 
@@ -152,7 +152,7 @@ export interface SearchOptions {
   limit?: number;
   /** Restrict hits to vertices whose key carries this prefix (empty/omitted = no namespace scope). */
   prefix?: string;
-  /** How the query's words combine: "any" (OR, default), "all" (AND), or "min-should". */
+  /** How query words combine; omitted always defers to the server default. */
   matchMode?: MatchMode;
   /** With matchMode "min-should", the minimum distinct query words a hit must carry (0 = server default). */
   minShouldMatch?: number;

--- a/sdks/node/test/client.test.ts
+++ b/sdks/node/test/client.test.ts
@@ -47,6 +47,7 @@ import {
   VertexSchema,
   EdgeSchema,
   ScanOrder,
+  MatchMode,
   SearchErrorDetailSchema,
 } from "../src/gen/graph/v1/graph_pb.js";
 
@@ -65,7 +66,16 @@ interface StubState {
     epsilon: number;
   };
   /** Last SearchVerticesRequest the stub observed, for request-building assertions (#639). */
-  lastSearch?: { query: string; limit: number; prefix: string };
+  lastSearch?: {
+    query: string;
+    limit: number;
+    prefix: string;
+    matchMode?: number;
+    minShouldMatch?: number;
+    phrase?: boolean;
+    fuzziness?: number;
+    prefixTerms?: boolean;
+  };
   /** Ranked hits the searchVertices stub returns (descending relevance). */
   searchHits?: { key: string; score: number }[];
   /** When true, searchVertices rejects with FAILED_PRECONDITION (index disabled). */
@@ -198,7 +208,20 @@ function newStubRoutes(state: StubState) {
       // SearchVerticesRequest (#639) and exercises the FAILED_PRECONDITION
       // (index-disabled) branch. Returns the configured ranked hits.
       async searchVertices(req) {
-        state.lastSearch = { query: req.query, limit: req.limit, prefix: req.prefix };
+        state.lastSearch = {
+          query: req.query,
+          limit: req.limit,
+          prefix: req.prefix,
+          ...(req.options
+            ? {
+                matchMode: req.options.matchMode,
+                minShouldMatch: req.options.minShouldMatch,
+                phrase: req.options.phrase,
+                fuzziness: req.options.fuzziness,
+                prefixTerms: req.options.prefixTerms,
+              }
+            : {}),
+        };
         if (state.searchPositionsDisabled) {
           throw new ConnectError(
             "phrase search requires positional postings",
@@ -1302,6 +1325,59 @@ describe("searchVertices request building (#639)", () => {
     try {
       await c.searchVertices("q");
       expect(state.lastSearch).toEqual({ query: "q", limit: 0, prefix: "" });
+    } finally {
+      c.close();
+    }
+  });
+
+  test("other relevance options preserve the server-default match mode", async () => {
+    const c = newClient();
+    try {
+      await c.searchVertices("alpha beta", { fuzziness: 1 });
+      expect(state.lastSearch?.matchMode).toBe(MatchMode.UNSPECIFIED);
+      expect(state.lastSearch?.fuzziness).toBe(1);
+    } finally {
+      c.close();
+    }
+  });
+
+  test("forwards the complete valid relevance option set", async () => {
+    const c = newClient();
+    try {
+      await c.searchVertices("alpha beta", {
+        matchMode: "min-should",
+        minShouldMatch: 2,
+        fuzziness: 1,
+        prefixTerms: true,
+      });
+      expect(state.lastSearch).toMatchObject({
+        matchMode: MatchMode.MIN_SHOULD,
+        minShouldMatch: 2,
+        fuzziness: 1,
+        prefixTerms: true,
+      });
+    } finally {
+      c.close();
+    }
+  });
+
+  test.each([
+    { minShouldMatch: 1 },
+    { matchMode: "any", minShouldMatch: 1 },
+    { fuzziness: 3 },
+    { limit: Number.NaN },
+    { limit: 1.5 },
+    { phrase: true, matchMode: "all" },
+    { phrase: true, fuzziness: 1 },
+    { phrase: true, prefixTerms: true },
+  ] as const)("rejects invalid options locally without transport: %o", async (opts) => {
+    const c = newClient();
+    const before = state.lastSearch;
+    try {
+      await expect(c.searchVertices("alpha beta", opts as never)).rejects.toBeInstanceOf(
+        InvalidArgumentError,
+      );
+      expect(state.lastSearch).toBe(before);
     } finally {
       c.close();
     }

--- a/sdks/node/test/incremental-search.test.ts
+++ b/sdks/node/test/incremental-search.test.ts
@@ -9,6 +9,7 @@ import {
   type SearchFn,
   type SearchUpdate,
 } from "../src/incremental-search.js";
+import type { SearchOptions } from "../src/options.js";
 
 class FakeScheduler implements IncrementalSearchScheduler {
   private now = 0;
@@ -60,12 +61,20 @@ describe("createIncrementalSearch", () => {
   });
 
   test("forwards limit/prefix and delivers ranked hits", async () => {
-    const calls: { query: string; opts: { limit?: number; prefix?: string } }[] = [];
+    const calls: { query: string; opts: SearchOptions }[] = [];
     const searchFn: SearchFn = async (query, opts) => {
       calls.push({ query, opts });
       return [{ key: "user.hi", score: 1.5 }];
     };
-    const is = createIncrementalSearch(searchFn, { debounceMs: 5, limit: 7, prefix: "user." });
+    const is = createIncrementalSearch(searchFn, {
+      debounceMs: 5,
+      limit: 7,
+      prefix: "user.",
+      matchMode: "min-should",
+      minShouldMatch: 2,
+      fuzziness: 1,
+      prefixTerms: true,
+    });
 
     is.search("hello");
     const u = await nextUpdate(is);
@@ -75,7 +84,17 @@ describe("createIncrementalSearch", () => {
     expect(u.query).toBe("hello");
     expect(u.hits).toEqual([{ key: "user.hi", score: 1.5 }]);
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toEqual({ query: "hello", opts: { limit: 7, prefix: "user." } });
+    expect(calls[0]).toEqual({
+      query: "hello",
+      opts: {
+        limit: 7,
+        prefix: "user.",
+        matchMode: "min-should",
+        minShouldMatch: 2,
+        fuzziness: 1,
+        prefixTerms: true,
+      },
+    });
   });
 
   test("debounce coalesces a burst into one search of the final query", async () => {

--- a/server/service/search.go
+++ b/server/service/search.go
@@ -49,6 +49,9 @@ func (s *LanternService) SearchVertices(ctx context.Context, in *pb.SearchVertic
 	if err := ctx.Err(); err != nil {
 		return nil, ctxToConnect(err)
 	}
+	if err := validateSearchOptions(in.GetOptions()); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
 	if !s.search.Enabled {
 		return nil, newSearchPreconditionError(pb.SearchErrorReason_SEARCH_DISABLED, errSearchDisabled)
 	}
@@ -59,9 +62,6 @@ func (s *LanternService) SearchVertices(ctx context.Context, in *pb.SearchVertic
 	if phrase && !s.search.PositionsEnabled {
 		return nil, newSearchPreconditionError(pb.SearchErrorReason_SEARCH_POSITIONS_DISABLED, errSearchPositionsDisabled)
 	}
-	if in.GetOptions().GetFuzziness() > searchMaxFuzziness {
-		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("search fuzziness must be at most %d", searchMaxFuzziness))
-	}
 	ranked := s.cache.SearchVerticesMatch(in.GetQuery(), int(limit), in.GetPrefix(), opts, phrase)
 	hits := make([]*pb.SearchHit, 0, len(ranked))
 	for _, r := range ranked {
@@ -69,6 +69,45 @@ func (s *LanternService) SearchVertices(ctx context.Context, in *pb.SearchVertic
 	}
 	s.metrics.OnSearch(len(hits), time.Since(start))
 	return &pb.SearchVerticesResponse{Hits: hits}, nil
+}
+
+// validateSearchOptions is the authoritative request-boundary decision table
+// for SearchOptions. It rejects values that the backend would otherwise ignore
+// or reinterpret, so every accepted field has one observable meaning (#1055).
+func validateSearchOptions(o *pb.SearchOptions) error {
+	if o == nil {
+		return nil
+	}
+	switch o.GetMatchMode() {
+	case pb.MatchMode_MATCH_MODE_UNSPECIFIED,
+		pb.MatchMode_MATCH_MODE_ANY,
+		pb.MatchMode_MATCH_MODE_ALL,
+		pb.MatchMode_MATCH_MODE_MIN_SHOULD:
+	default:
+		return fmt.Errorf("search match_mode %d is not recognized", o.GetMatchMode())
+	}
+	if o.GetMinShouldMatch() != 0 && o.GetMatchMode() != pb.MatchMode_MATCH_MODE_MIN_SHOULD {
+		return errors.New("search min_should_match requires match_mode MATCH_MODE_MIN_SHOULD")
+	}
+	if o.GetFuzziness() > searchMaxFuzziness {
+		return fmt.Errorf("search fuzziness must be at most %d", searchMaxFuzziness)
+	}
+	if !o.GetPhrase() {
+		return nil
+	}
+	if o.GetMatchMode() != pb.MatchMode_MATCH_MODE_UNSPECIFIED {
+		return errors.New("search phrase cannot be combined with an explicit match_mode")
+	}
+	if o.GetMinShouldMatch() != 0 {
+		return errors.New("search phrase cannot be combined with min_should_match")
+	}
+	if o.GetFuzziness() != 0 {
+		return errors.New("search phrase cannot be combined with fuzziness")
+	}
+	if o.GetPrefixTerms() {
+		return errors.New("search phrase cannot be combined with prefix_terms")
+	}
+	return nil
 }
 
 func newSearchPreconditionError(reason pb.SearchErrorReason, cause error) error {
@@ -86,7 +125,8 @@ func newSearchPreconditionError(reason pb.SearchErrorReason, cause error) error 
 // server defaults apply; when it sends them, the request values are taken
 // literally — an unspecified match_mode still falls back to the default, but a
 // zero fuzziness or false prefix_terms means off, so a client can turn any
-// option off. phrase takes precedence over the match mode.
+// option off. validateSearchOptions has already rejected combinations the core
+// backend cannot compose.
 func (s *LanternService) resolveSearchOptions(o *pb.SearchOptions) (search.MatchOptions, bool) {
 	if o == nil {
 		return search.MatchOptions{Mode: s.search.DefaultMode, MinShouldMatch: int(s.search.DefaultMinShould)}, false

--- a/server/service/search_test.go
+++ b/server/service/search_test.go
@@ -55,23 +55,71 @@ func TestSearchVertices_PhraseWithoutPositionsFailsClosed(t *testing.T) {
 	}
 }
 
-func TestSearchVertices_RejectsFuzzinessAboveCapability(t *testing.T) {
-	fb := newFakeBackend()
-	svc := NewLanternService(fb).WithSearchLimits(SearchLimits{
-		Enabled:          true,
-		PositionsEnabled: true,
-		DefaultLimit:     100,
-		MaxLimit:         1000,
-	})
-	_, err := svc.SearchVertices(context.Background(), &pb.SearchVerticesRequest{
-		Query:   "serach",
-		Options: &pb.SearchOptions{Fuzziness: 3},
-	})
-	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
-		t.Fatalf("code = %v, want InvalidArgument", got)
+func TestSearchVertices_RejectsInvalidOptionsBeforeBackend(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *pb.SearchOptions
+	}{
+		{"unknown match mode", &pb.SearchOptions{MatchMode: pb.MatchMode(99)}},
+		{"minimum with unspecified mode", &pb.SearchOptions{MinShouldMatch: 1}},
+		{"minimum with any", &pb.SearchOptions{MatchMode: pb.MatchMode_MATCH_MODE_ANY, MinShouldMatch: 1}},
+		{"fuzziness above capability", &pb.SearchOptions{Fuzziness: 3}},
+		{"phrase with explicit mode", &pb.SearchOptions{Phrase: true, MatchMode: pb.MatchMode_MATCH_MODE_ALL}},
+		{"phrase with fuzziness", &pb.SearchOptions{Phrase: true, Fuzziness: 1}},
+		{"phrase with prefix terms", &pb.SearchOptions{Phrase: true, PrefixTerms: true}},
 	}
-	if fb.searchCalls != 0 {
-		t.Errorf("backend SearchVertices called %d times, want 0", fb.searchCalls)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fb := newFakeBackend()
+			// Keep search disabled to prove malformed requests are rejected at
+			// the request boundary before feature gating or backend access.
+			svc := NewLanternService(fb)
+			_, err := svc.SearchVertices(context.Background(), &pb.SearchVerticesRequest{
+				Query:   "alpha beta",
+				Options: tc.opts,
+			})
+			if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+				t.Fatalf("code = %v, want InvalidArgument (err=%v)", got, err)
+			}
+			if fb.searchCalls != 0 {
+				t.Errorf("backend SearchVertices called %d times, want 0", fb.searchCalls)
+			}
+		})
+	}
+}
+
+func TestSearchVertices_AcceptsOptionsDecisionTable(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *pb.SearchOptions
+	}{
+		{"omitted", nil},
+		{"all zero", &pb.SearchOptions{}},
+		{"explicit any", &pb.SearchOptions{MatchMode: pb.MatchMode_MATCH_MODE_ANY}},
+		{"explicit all", &pb.SearchOptions{MatchMode: pb.MatchMode_MATCH_MODE_ALL}},
+		{"minimum server threshold", &pb.SearchOptions{MatchMode: pb.MatchMode_MATCH_MODE_MIN_SHOULD}},
+		{"minimum explicit threshold", &pb.SearchOptions{MatchMode: pb.MatchMode_MATCH_MODE_MIN_SHOULD, MinShouldMatch: 2}},
+		{"fuzzy with server mode", &pb.SearchOptions{Fuzziness: 1}},
+		{"prefix terms with server mode", &pb.SearchOptions{PrefixTerms: true}},
+		{"phrase alone", &pb.SearchOptions{Phrase: true}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fb := newFakeBackend()
+			svc := NewLanternService(fb).WithSearchLimits(SearchLimits{
+				Enabled:          true,
+				PositionsEnabled: true,
+				DefaultLimit:     100,
+				MaxLimit:         1000,
+			})
+			_, err := svc.SearchVertices(context.Background(), &pb.SearchVerticesRequest{Query: "alpha beta", Options: tc.opts})
+			if err != nil {
+				t.Fatalf("SearchVertices: %v", err)
+			}
+			if fb.searchCalls != 1 {
+				t.Errorf("backend SearchVertices called %d times, want 1", fb.searchCalls)
+			}
+		})
 	}
 }
 

--- a/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/graph.pb.dart
+++ b/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/graph.pb.dart
@@ -2086,9 +2086,10 @@ class ScanVertexKeysResponse extends $pb.GeneratedMessage {
 }
 
 /// SearchOptions carries the optional relevance controls for SearchVertices
-/// (#892): match mode, phrase adjacency, and prefix/fuzzy term expansion. Every
-/// field is optional and the zero value reproduces the default OR-union search,
-/// so leaving options unset is identical to the pre-#892 request.
+/// (#892): match mode, phrase adjacency, and prefix/fuzzy term expansion. An
+/// omitted message and an all-zero message both defer match membership to the
+/// server default. The server rejects unknown enums, out-of-domain numeric
+/// values, and combinations whose fields would otherwise be ignored (#1055).
 class SearchOptions extends $pb.GeneratedMessage {
   factory SearchOptions({
     MatchMode? matchMode,
@@ -2151,7 +2152,8 @@ class SearchOptions extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<SearchOptions>(create);
   static SearchOptions? _defaultInstance;
 
-  /// match_mode selects AND / OR / minimum-should-match membership (#890).
+  /// match_mode selects AND / OR / minimum-should-match membership (#890), or
+  /// defers to the server default when unspecified.
   @$pb.TagNumber(1)
   MatchMode get matchMode => $_getN(0);
   @$pb.TagNumber(1)
@@ -2162,8 +2164,9 @@ class SearchOptions extends $pb.GeneratedMessage {
   void clearMatchMode() => $_clearField(1);
 
   /// min_should_match is the minimum number of distinct query word terms a
-  /// vertex must carry when match_mode is MATCH_MODE_MIN_SHOULD; clamped to
-  /// [1, number of query word terms]. Ignored for other modes.
+  /// vertex must carry. A non-zero value is valid only with an explicit
+  /// MATCH_MODE_MIN_SHOULD. Zero with that mode uses the server's configured
+  /// LANTERN_SEARCH_DEFAULT_MIN_SHOULD value.
   @$pb.TagNumber(2)
   $core.int get minShouldMatch => $_getIZ(1);
   @$pb.TagNumber(2)
@@ -2174,8 +2177,9 @@ class SearchOptions extends $pb.GeneratedMessage {
   void clearMinShouldMatch() => $_clearField(2);
 
   /// phrase requires the query's word terms to occur adjacently, in order
-  /// (#889) — the precision counterpart to the OR-union. It takes precedence
-  /// over match_mode.
+  /// (#889). Until phrase composition is implemented, phrase=true requires
+  /// match_mode unspecified, min_should_match=0, fuzziness=0, and
+  /// prefix_terms=false; conflicting combinations return INVALID_ARGUMENT.
   @$pb.TagNumber(3)
   $core.bool get phrase => $_getBF(2);
   @$pb.TagNumber(3)

--- a/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/graph.pbenum.dart
+++ b/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/graph.pbenum.dart
@@ -146,9 +146,8 @@ class ScanOrder extends $pb.ProtobufEnum {
 /// matches. Coverage counts word-channel terms, so requiring "all" of a CJK run
 /// means all of its bigrams.
 class MatchMode extends $pb.ProtobufEnum {
-  /// MATCH_MODE_UNSPECIFIED defers to the server default
-  /// (LANTERN_SEARCH_DEFAULT_MODE, itself defaulting to ANY), so an unset field
-  /// keeps the OR-union behavior.
+  /// MATCH_MODE_UNSPECIFIED always defers to LANTERN_SEARCH_DEFAULT_MODE,
+  /// including when other SearchOptions fields are present.
   static const MatchMode MATCH_MODE_UNSPECIFIED =
       MatchMode._(0, _omitEnumNames ? '' : 'MATCH_MODE_UNSPECIFIED');
 

--- a/testbed/dart-transport-probe/grpc/lib/src/gen/graph/v1/graph.pb.dart
+++ b/testbed/dart-transport-probe/grpc/lib/src/gen/graph/v1/graph.pb.dart
@@ -2050,9 +2050,10 @@ class ScanVertexKeysResponse extends $pb.GeneratedMessage {
 }
 
 /// SearchOptions carries the optional relevance controls for SearchVertices
-/// (#892): match mode, phrase adjacency, and prefix/fuzzy term expansion. Every
-/// field is optional and the zero value reproduces the default OR-union search,
-/// so leaving options unset is identical to the pre-#892 request.
+/// (#892): match mode, phrase adjacency, and prefix/fuzzy term expansion. An
+/// omitted message and an all-zero message both defer match membership to the
+/// server default. The server rejects unknown enums, out-of-domain numeric
+/// values, and combinations whose fields would otherwise be ignored (#1055).
 class SearchOptions extends $pb.GeneratedMessage {
   factory SearchOptions({
     MatchMode? matchMode,
@@ -2111,7 +2112,8 @@ class SearchOptions extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<SearchOptions>(create);
   static SearchOptions? _defaultInstance;
 
-  /// match_mode selects AND / OR / minimum-should-match membership (#890).
+  /// match_mode selects AND / OR / minimum-should-match membership (#890), or
+  /// defers to the server default when unspecified.
   @$pb.TagNumber(1)
   MatchMode get matchMode => $_getN(0);
   @$pb.TagNumber(1)
@@ -2122,8 +2124,9 @@ class SearchOptions extends $pb.GeneratedMessage {
   void clearMatchMode() => $_clearField(1);
 
   /// min_should_match is the minimum number of distinct query word terms a
-  /// vertex must carry when match_mode is MATCH_MODE_MIN_SHOULD; clamped to
-  /// [1, number of query word terms]. Ignored for other modes.
+  /// vertex must carry. A non-zero value is valid only with an explicit
+  /// MATCH_MODE_MIN_SHOULD. Zero with that mode uses the server's configured
+  /// LANTERN_SEARCH_DEFAULT_MIN_SHOULD value.
   @$pb.TagNumber(2)
   $core.int get minShouldMatch => $_getIZ(1);
   @$pb.TagNumber(2)
@@ -2134,8 +2137,9 @@ class SearchOptions extends $pb.GeneratedMessage {
   void clearMinShouldMatch() => $_clearField(2);
 
   /// phrase requires the query's word terms to occur adjacently, in order
-  /// (#889) — the precision counterpart to the OR-union. It takes precedence
-  /// over match_mode.
+  /// (#889). Until phrase composition is implemented, phrase=true requires
+  /// match_mode unspecified, min_should_match=0, fuzziness=0, and
+  /// prefix_terms=false; conflicting combinations return INVALID_ARGUMENT.
   @$pb.TagNumber(3)
   $core.bool get phrase => $_getBF(2);
   @$pb.TagNumber(3)

--- a/testbed/dart-transport-probe/grpc/lib/src/gen/graph/v1/graph.pbenum.dart
+++ b/testbed/dart-transport-probe/grpc/lib/src/gen/graph/v1/graph.pbenum.dart
@@ -146,9 +146,8 @@ class ScanOrder extends $pb.ProtobufEnum {
 /// matches. Coverage counts word-channel terms, so requiring "all" of a CJK run
 /// means all of its bigrams.
 class MatchMode extends $pb.ProtobufEnum {
-  /// MATCH_MODE_UNSPECIFIED defers to the server default
-  /// (LANTERN_SEARCH_DEFAULT_MODE, itself defaulting to ANY), so an unset field
-  /// keeps the OR-union behavior.
+  /// MATCH_MODE_UNSPECIFIED always defers to LANTERN_SEARCH_DEFAULT_MODE,
+  /// including when other SearchOptions fields are present.
   static const MatchMode MATCH_MODE_UNSPECIFIED =
       MatchMode._(0, _omitEnumNames ? '' : 'MATCH_MODE_UNSPECIFIED');
 

--- a/tests/integration/search_vertices_test.go
+++ b/tests/integration/search_vertices_test.go
@@ -65,19 +65,95 @@ func wireSearchErrorReason(t *testing.T, err error) pb.SearchErrorReason {
 // production composition root makes.
 func newSearchRawClient(t *testing.T, enabled bool) graphv1connect.LanternServiceClient {
 	t.Helper()
-	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
-	cache.EnablePrefixIndex(func(k string) string { return k })
-	if enabled {
-		cache.EnableSearchIndex(searchVertexDocument, strings.Compare)
-	}
-	svc := service.NewLanternService(cache).WithSearchLimits(service.SearchLimits{
+	return newSearchRawClientWithLimits(t, service.SearchLimits{
 		Enabled:          enabled,
 		PositionsEnabled: enabled,
 		DefaultLimit:     100,
 		MaxLimit:         1000,
 	})
+}
+
+func newSearchRawClientWithLimits(t *testing.T, limits service.SearchLimits) graphv1connect.LanternServiceClient {
+	t.Helper()
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+	cache.EnablePrefixIndex(func(k string) string { return k })
+	if limits.Enabled {
+		cache.EnableSearchIndex(searchVertexDocument, strings.Compare)
+	}
+	svc := service.NewLanternService(cache).WithSearchLimits(limits)
 	srv := newConnectTestServer(t, svc, nil)
 	return graphv1connect.NewLanternServiceClient(h2cClient(), srv.url)
+}
+
+// TestSearchVertices_OptionsContract proves the #1055 decision table over the
+// real Connect/h2c path. In particular, adding fuzziness must not turn an
+// omitted match mode into ANY when this server is configured for ALL.
+func TestSearchVertices_OptionsContract(t *testing.T) {
+	c := newSearchRawClientWithLimits(t, service.SearchLimits{
+		Enabled:          true,
+		PositionsEnabled: true,
+		DefaultLimit:     100,
+		MaxLimit:         1000,
+		DefaultMode:      search.MatchAll,
+		DefaultMinShould: 2,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	exp := timestamppb.New(time.Now().Add(time.Hour))
+	if _, err := c.PutVertices(ctx, connect.NewRequest(&pb.PutVerticesRequest{Vertices: []*pb.Vertex{
+		{Key: "doc.both", Value: &pb.Vertex_String_{String_: "alpha beta"}, Expiration: exp},
+		{Key: "doc.alpha", Value: &pb.Vertex_String_{String_: "alpha"}, Expiration: exp},
+		{Key: "doc.beta", Value: &pb.Vertex_String_{String_: "beta"}, Expiration: exp},
+	}})); err != nil {
+		t.Fatalf("PutVertices: %v", err)
+	}
+
+	keys := func(query string, options *pb.SearchOptions) []string {
+		t.Helper()
+		resp, err := c.SearchVertices(ctx, connect.NewRequest(&pb.SearchVerticesRequest{Query: query, Options: options}))
+		if err != nil {
+			t.Fatalf("SearchVertices(%q, %+v): %v", query, options, err)
+		}
+		got := make([]string, len(resp.Msg.GetHits()))
+		for i, hit := range resp.Msg.GetHits() {
+			got[i] = hit.GetKey()
+		}
+		sort.Strings(got)
+		return got
+	}
+	assertKeys := func(name string, got, want []string) {
+		t.Helper()
+		if !slices.Equal(got, want) {
+			t.Errorf("%s keys = %v, want %v", name, got, want)
+		}
+	}
+
+	assertKeys("omitted uses ALL", keys("alpha beta", nil), []string{"doc.both"})
+	assertKeys("fuzziness preserves omitted ALL", keys("alpga beta", &pb.SearchOptions{Fuzziness: 1}), []string{"doc.both"})
+	assertKeys("explicit ANY", keys("alpha beta", &pb.SearchOptions{MatchMode: pb.MatchMode_MATCH_MODE_ANY}), []string{"doc.alpha", "doc.beta", "doc.both"})
+	assertKeys("MIN zero uses server threshold", keys("alpha beta", &pb.SearchOptions{MatchMode: pb.MatchMode_MATCH_MODE_MIN_SHOULD}), []string{"doc.both"})
+	assertKeys("MIN explicit one", keys("alpha beta", &pb.SearchOptions{MatchMode: pb.MatchMode_MATCH_MODE_MIN_SHOULD, MinShouldMatch: 1}), []string{"doc.alpha", "doc.beta", "doc.both"})
+
+	invalid := []struct {
+		name string
+		opts *pb.SearchOptions
+	}{
+		{"unknown mode", &pb.SearchOptions{MatchMode: pb.MatchMode(99)}},
+		{"minimum without explicit MIN", &pb.SearchOptions{MinShouldMatch: 1}},
+		{"minimum with ANY", &pb.SearchOptions{MatchMode: pb.MatchMode_MATCH_MODE_ANY, MinShouldMatch: 1}},
+		{"fuzziness out of range", &pb.SearchOptions{Fuzziness: 3}},
+		{"phrase with explicit mode", &pb.SearchOptions{Phrase: true, MatchMode: pb.MatchMode_MATCH_MODE_ALL}},
+		{"phrase with fuzziness", &pb.SearchOptions{Phrase: true, Fuzziness: 1}},
+		{"phrase with prefix terms", &pb.SearchOptions{Phrase: true, PrefixTerms: true}},
+	}
+	for _, tc := range invalid {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := c.SearchVertices(ctx, connect.NewRequest(&pb.SearchVerticesRequest{Query: "alpha beta", Options: tc.opts}))
+			if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+				t.Fatalf("code = %v, want InvalidArgument (err=%v)", got, err)
+			}
+		})
+	}
 }
 
 // newSearchSDKClient mirrors newSearchRawClient but returns the high-level


### PR DESCRIPTION
## Summary

- make `MATCH_MODE_UNSPECIFIED` consistently preserve the server default and reject ignored/conflicting option combinations at the server boundary
- mirror the decision table in Go, Node, and Dart local validation; give Go/Node incremental search complete one-shot option parity and Failover-compatible Go orchestration
- expose Server default, real minimum-word threshold, fuzziness 0/1/2, prefix terms, and namespace prefix controls in CLI/Admin
- document the contract, regenerate every affected SDK/probe, and cover the matrix over real Connect/h2c

## Validation

- `gofmt -l .` (empty) and `git diff --check`
- `go test ./...` from root and `pb`, `core`, `sdks/go`, `server`, `mcp`
- Dart SDK: format, analyze (one pre-existing info), full test; Flutter example analyze/test
- Dart transport probes: analyze/test for Connect and gRPC
- Node SDK: format check, typecheck, 145 tests, build
- Admin: format check, lint (one pre-existing warning), typecheck, 799 tests, build
- Admin Playwright: focused Browse Vertices option-control scenario

Closes #1055