### PR TITLE
perf(search): prepare batch index mutations off lock

### DIFF
--- a/core/graphcache/batch.go
+++ b/core/graphcache/batch.go
@@ -43,11 +43,14 @@ type EdgeKey[S comparable] struct {
 // post-batch state — never an intermediate snapshot where some keys are
 // present and others are not.
 //
-// Search-document analysis (tokenization) for the whole batch runs BEFORE the
-// lock is taken (see prepareSearchDocsBounded) so the expensive per-vertex work never
-// serializes other writers behind the aggregate graph lock; only the cheap
-// store + postings mutation happens under c.mu (#739). A search-analysis limit
-// error rejects the complete batch before either structure changes.
+// Search-document projection, tokenization, sorting, and term aggregation run
+// BEFORE the lock is taken (see prepareSearchDocsBounded), so expensive
+// per-vertex work never serializes other writers behind the aggregate graph
+// lock. The accepted compact mutations are applied through one index write-lock
+// acquisition. SearchVertices holds the shared side of searchCommitMu, so it
+// observes the complete pre-batch or post-batch state, never a midpoint. A
+// search-analysis limit error rejects the complete batch before either
+// structure changes (#739, #1051).
 func (c *GraphCache[S, T]) PutVerticesWithExpiration(items []VertexItem[S, T]) error {
 	return c.PutVerticesWithExpirationChecked(items)
 }
@@ -66,53 +69,130 @@ func (c *GraphCache[S, T]) PutVerticesWithExpirationIfAbsent(items []VertexItem[
 	return written, skipped
 }
 
-// prepareSearchDocsBounded analyzes every live item outside c.mu, returning a
-// 1:1 prepared/error pair. Born-expired items are left empty and skipped.
-func (c *GraphCache[S, T]) prepareSearchDocsBounded(items []VertexItem[S, T], now time.Time) ([]search.PreparedDocument, []error) {
-	if c.searchIndex == nil {
-		return nil, nil
-	}
-	prepared := make([]search.PreparedDocument, len(items))
-	errs := make([]error, len(items))
-	for i := range items {
-		if cache.IsLiveAt(items[i].Expiration, now) {
-			prepared[i], _, errs[i] = c.searchIndex.Prepare(c.searchExtract(items[i].Value))
-		}
-	}
-	return prepared, errs
+// searchPreparation holds index-aligned compact documents across optimistic
+// planning retries. A ready entry has either a prepared document or an error;
+// skipped entries remain untouched and perform no analysis.
+type searchPreparation struct {
+	documents []search.PreparedDocument
+	errs      []error
+	ready     []bool
 }
 
-// preparedAt returns a pointer to the i-th prepared document, or nil when no
-// search index produced a batch (prepared == nil) so the callee falls back to
-// inline analysis. The pointer is safe to take because prepared is a
-// fixed-size slice that is never appended to after preparation returns.
-func preparedAt(prepared []search.PreparedDocument, i int) *search.PreparedDocument {
-	if prepared == nil {
+func (c *GraphCache[S, T]) newSearchPreparation(n int) *searchPreparation {
+	if c.searchIndex == nil {
 		return nil
 	}
-	return &prepared[i]
+	return &searchPreparation{
+		documents: make([]search.PreparedDocument, n),
+		errs:      make([]error, n),
+		ready:     make([]bool, n),
+	}
+}
+
+// prepareSearchDocsBounded performs the expensive projection, tokenization,
+// sorting, and aggregation for selected items outside c.mu. Born-expired items
+// are marked ready with the zero prepared document, which represents deletion.
+func (c *GraphCache[S, T]) prepareSearchDocsBounded(items []VertexItem[S, T], indexes []int, now time.Time, preparation *searchPreparation) {
+	if preparation == nil {
+		return
+	}
+	for _, i := range indexes {
+		if preparation.ready[i] {
+			continue
+		}
+		preparation.ready[i] = true
+		if cache.IsLiveAt(items[i].Expiration, now) {
+			preparation.documents[i], _, preparation.errs[i] = c.searchIndex.Prepare(c.searchExtract(items[i].Value))
+		}
+	}
+}
+
+// finalVertexIndexes returns the last accepted item for each key, in request
+// order of those final occurrences. Only these values can affect the final
+// secondary-index state; preparing earlier duplicates is wasted work.
+func finalVertexIndexes[S comparable, T any](items []VertexItem[S, T], accepted []int) []int {
+	last := make(map[S]int, len(accepted))
+	for _, i := range accepted {
+		last[items[i].Key] = i
+	}
+	final := make([]int, 0, len(last))
+	for _, i := range accepted {
+		if last[items[i].Key] == i {
+			final = append(final, i)
+		}
+	}
+	return final
+}
+
+func allVertexIndexes[S comparable, T any](items []VertexItem[S, T]) []int {
+	indexes := make([]int, len(items))
+	for i := range items {
+		indexes[i] = i
+	}
+	return indexes
+}
+
+func missingPreparedIndexes(preparation *searchPreparation, indexes []int) []int {
+	if preparation == nil {
+		return nil
+	}
+	var missing []int
+	for _, i := range indexes {
+		if !preparation.ready[i] {
+			missing = append(missing, i)
+		}
+	}
+	return missing
+}
+
+func preparedItemsForIndexes[S comparable, T any](items []VertexItem[S, T], indexes []int, preparation *searchPreparation) []search.PreparedItem[S] {
+	if preparation == nil {
+		return nil
+	}
+	out := make([]search.PreparedItem[S], 0, len(indexes))
+	for _, i := range indexes {
+		out = append(out, search.PreparedItem[S]{ID: items[i].Key, Prepared: preparation.documents[i]})
+	}
+	return out
 }
 
 // PutVerticesWithExpirationChecked is the bounded, all-or-nothing local write
 // path. Analysis and aggregate-limit validation complete before either the
 // vertex cache or secondary index is mutated.
 func (c *GraphCache[S, T]) PutVerticesWithExpirationChecked(items []VertexItem[S, T]) error {
+	return c.putVerticesWithExpirationChecked(items, nil)
+}
+
+func (c *GraphCache[S, T]) putVerticesWithExpirationChecked(items []VertexItem[S, T], observeLock func(time.Duration)) error {
 	if len(items) == 0 {
 		return nil
 	}
 	now := time.Now()
-	prepared, errs := c.prepareSearchDocsBounded(items, now)
-	for _, err := range errs {
-		if err != nil {
-			return err
+	preparation := c.newSearchPreparation(len(items))
+	var final []int
+	if preparation != nil {
+		final = finalVertexIndexes(items, allVertexIndexes(items))
+		c.prepareSearchDocsBounded(items, final, now, preparation)
+		for _, i := range final {
+			if preparation.errs[i] != nil {
+				return preparation.errs[i]
+			}
 		}
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if observeLock != nil {
+		lockedAt := time.Now()
+		defer func() { observeLock(time.Since(lockedAt)) }()
+	}
+	if c.searchIndex != nil {
+		c.searchCommitMu.Lock()
+		defer c.searchCommitMu.Unlock()
+	}
 	if c.searchIndex != nil && c.searchIndex.Health() != search.IndexHealthy {
 		return search.ErrIndexIncomplete
 	}
-	indexItems := preparedItems(items, prepared)
+	indexItems := preparedItemsForIndexes(items, final, preparation)
 	if c.searchIndex != nil {
 		if err := c.searchIndex.ValidateManyPrepared(indexItems); err != nil {
 			return err
@@ -120,7 +200,7 @@ func (c *GraphCache[S, T]) PutVerticesWithExpirationChecked(items []VertexItem[S
 		c.searchIndex.IndexManyPreparedValidated(indexItems)
 	}
 	for i := range items {
-		c.putLocalVertexLockedAtMode(items[i].Key, items[i].Value, items[i].Expiration, now, preparedAt(prepared, i), false)
+		c.putLocalVertexLockedAtMode(items[i].Key, items[i].Value, items[i].Expiration, now, false)
 	}
 	if c.searchIndex != nil && c.searchIndex.Health() != search.IndexHealthy {
 		return c.rebuildSearchIndexLocked()
@@ -128,46 +208,98 @@ func (c *GraphCache[S, T]) PutVerticesWithExpirationChecked(items []VertexItem[S
 	return nil
 }
 
-func preparedItems[S comparable, T any](items []VertexItem[S, T], prepared []search.PreparedDocument) []search.PreparedItem[S] {
-	if prepared == nil {
-		return nil
-	}
-	out := make([]search.PreparedItem[S], len(items))
-	for i := range items {
-		out[i] = search.PreparedItem[S]{ID: items[i].Key, Prepared: prepared[i]}
-	}
-	return out
-}
-
 // PutVerticesWithExpirationIfAbsentChecked is the conditional sibling of the
 // bounded local path. Limits are evaluated only for items that would actually
 // be accepted; an oversized skipped item cannot poison an otherwise valid
 // batch.
 func (c *GraphCache[S, T]) PutVerticesWithExpirationIfAbsentChecked(items []VertexItem[S, T]) (written int, skipped []S, err error) {
-	accepted, skipped, err := c.putVerticesIfAbsentChecked(items, hlc.Timestamp{}, false)
+	accepted, skipped, err := c.putVerticesIfAbsentChecked(items, hlc.Timestamp{}, false, nil)
 	return len(accepted), skipped, err
 }
 
 // PutVerticesWithExpirationIfAbsentHLCChecked is the local replicated-origin
 // path: accepted writes are bounded before graph or HLC mutation.
 func (c *GraphCache[S, T]) PutVerticesWithExpirationIfAbsentHLCChecked(items []VertexItem[S, T], ts hlc.Timestamp) (writtenIdx []int, skipped []S, err error) {
-	return c.putVerticesIfAbsentChecked(items, ts, true)
+	return c.putVerticesIfAbsentChecked(items, ts, true, nil)
 }
 
-func (c *GraphCache[S, T]) putVerticesIfAbsentChecked(items []VertexItem[S, T], ts hlc.Timestamp, useHLC bool) ([]int, []S, error) {
+func (c *GraphCache[S, T]) putVerticesIfAbsentChecked(items []VertexItem[S, T], ts hlc.Timestamp, useHLC bool, observeLock func(time.Duration)) ([]int, []S, error) {
 	if len(items) == 0 {
 		return nil, nil, nil
 	}
 	now := time.Now()
-	prepared, errs := c.prepareSearchDocsBounded(items, now)
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.searchIndex != nil && c.searchIndex.Health() != search.IndexHealthy {
-		return nil, nil, search.ErrIndexIncomplete
+	preparation := c.newSearchPreparation(len(items))
+	for {
+		c.mu.Lock()
+		lockedAt := time.Time{}
+		if observeLock != nil {
+			lockedAt = time.Now()
+		}
+		unlock := func() {
+			if observeLock != nil {
+				observeLock(time.Since(lockedAt))
+			}
+			c.mu.Unlock()
+		}
+		if c.searchIndex != nil && c.searchIndex.Health() != search.IndexHealthy {
+			unlock()
+			return nil, nil, search.ErrIndexIncomplete
+		}
+		accepted, skipped := c.planVerticesIfAbsentLocked(items, ts, useHLC, now)
+		missing := missingPreparedIndexes(preparation, accepted)
+		if len(missing) > 0 {
+			unlock()
+			c.prepareSearchDocsBounded(items, missing, now, preparation)
+			continue
+		}
+		if preparation != nil {
+			for _, i := range accepted {
+				if preparation.errs[i] != nil {
+					unlock()
+					return nil, nil, preparation.errs[i]
+				}
+			}
+		}
+		if c.searchIndex != nil {
+			c.searchCommitMu.Lock()
+		}
+		indexItems := preparedItemsForIndexes(items, accepted, preparation)
+		if c.searchIndex != nil {
+			if err := c.searchIndex.ValidateManyPrepared(indexItems); err != nil {
+				c.searchCommitMu.Unlock()
+				unlock()
+				return nil, nil, err
+			}
+			c.searchIndex.IndexManyPreparedValidated(indexItems)
+		}
+		for _, i := range accepted {
+			item := items[i]
+			c.putLocalVertexLockedAtMode(item.Key, item.Value, item.Expiration, now, false)
+			if useHLC {
+				c.recordVertexHLCLocked(item.Key, ts)
+				c.clearVertexTombstoneLocked(item.Key)
+			}
+		}
+		if c.searchIndex != nil && c.searchIndex.Health() != search.IndexHealthy {
+			if err := c.rebuildSearchIndexLocked(); err != nil {
+				c.searchCommitMu.Unlock()
+				unlock()
+				return nil, nil, err
+			}
+		}
+		if c.searchIndex != nil {
+			c.searchCommitMu.Unlock()
+		}
+		unlock()
+		return accepted, skipped, nil
 	}
+}
+
+// planVerticesIfAbsentLocked performs only cheap liveness/causality checks.
+// Callers release c.mu before preparing the returned documents, then retry the
+// plan before commit; a stable skipped item is therefore never analyzed.
+func (c *GraphCache[S, T]) planVerticesIfAbsentLocked(items []VertexItem[S, T], ts hlc.Timestamp, useHLC bool, now time.Time) (accepted []int, skipped []S) {
 	reserved := make(map[S]struct{})
-	var accepted []int
-	var skipped []S
 	for i, item := range items {
 		_, duplicate := reserved[item.Key]
 		if c.vertices.Has(item.Key) || duplicate || (useHLC && !c.vertexWriteAllowedLocked(item.Key, ts)) {
@@ -177,38 +309,10 @@ func (c *GraphCache[S, T]) putVerticesIfAbsentChecked(items []VertexItem[S, T], 
 		if !cache.IsLiveAt(item.Expiration, now) {
 			continue
 		}
-		if errs != nil && errs[i] != nil {
-			return nil, nil, errs[i]
-		}
 		accepted = append(accepted, i)
 		reserved[item.Key] = struct{}{}
 	}
-	indexItems := make([]search.PreparedItem[S], 0, len(accepted))
-	if c.searchIndex != nil {
-		for _, i := range accepted {
-			indexItems = append(indexItems, search.PreparedItem[S]{ID: items[i].Key, Prepared: prepared[i]})
-		}
-	}
-	if c.searchIndex != nil {
-		if err := c.searchIndex.ValidateManyPrepared(indexItems); err != nil {
-			return nil, nil, err
-		}
-		c.searchIndex.IndexManyPreparedValidated(indexItems)
-	}
-	for _, i := range accepted {
-		item := items[i]
-		c.putLocalVertexLockedAtMode(item.Key, item.Value, item.Expiration, now, preparedAt(prepared, i), false)
-		if useHLC {
-			c.recordVertexHLCLocked(item.Key, ts)
-			c.clearVertexTombstoneLocked(item.Key)
-		}
-	}
-	if c.searchIndex != nil && c.searchIndex.Health() != search.IndexHealthy {
-		if err := c.rebuildSearchIndexLocked(); err != nil {
-			return nil, nil, err
-		}
-	}
-	return accepted, skipped, nil
+	return accepted, skipped
 }
 
 // AddEdgesWithExpiration additively writes every supplied edge under a
@@ -309,8 +413,8 @@ func (c *GraphCache[S, T]) PutEdgesWithExpiration(items []EdgeItem[S]) {
 
 // DeleteVertices removes every supplied vertex under a single write lock
 // and returns the count of keys that were actually present (and therefore
-// deleted). Concurrent readers observe either the pre-batch or the
-// post-batch state. Vertex-owned side indexes (dict refs, prefix radix,
+// deleted). Concurrent SearchVertices readers observe either the pre-batch or
+// the post-batch state through searchCommitMu. Vertex-owned side indexes (dict refs, prefix radix,
 // search postings) are cleaned in one pass via the batch eviction hook so a
 // large delete pays one acquisition per index instead of one per key (#738).
 func (c *GraphCache[S, T]) DeleteVertices(keys []S) int {
@@ -319,6 +423,10 @@ func (c *GraphCache[S, T]) DeleteVertices(keys []S) int {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.searchIndex != nil {
+		c.searchCommitMu.Lock()
+		defer c.searchCommitMu.Unlock()
+	}
 	n := len(c.vertices.DeleteMany(keys))
 	c.rebuildIncompleteSearchLocked()
 	return n
@@ -387,54 +495,75 @@ func (c *GraphCache[S, T]) putVerticesWithExpirationHLC(items []VertexItem[S, T]
 		return 0, nil
 	}
 	now := time.Now()
-	prepared, prepErrs := c.prepareSearchDocsBounded(items, now)
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if strict && c.searchIndex != nil && c.searchIndex.Health() != search.IndexHealthy {
-		return 0, search.ErrIndexIncomplete
+	preparation := c.newSearchPreparation(len(items))
+	for {
+		c.mu.Lock()
+		accepted, rejected := c.planVerticesHLCLocked(items, ts)
+		var final []int
+		var indexErr error
+		if c.searchIndex != nil && c.searchIndex.Health() != search.IndexHealthy {
+			indexErr = search.ErrIndexIncomplete
+		} else if preparation != nil {
+			final = finalVertexIndexes(items, accepted)
+			missing := missingPreparedIndexes(preparation, final)
+			if len(missing) > 0 {
+				c.mu.Unlock()
+				c.prepareSearchDocsBounded(items, missing, now, preparation)
+				continue
+			}
+			if preparation != nil {
+				for _, i := range final {
+					if preparation.errs[i] != nil {
+						indexErr = preparation.errs[i]
+						break
+					}
+				}
+			}
+		}
+		indexItems := preparedItemsForIndexes(items, final, preparation)
+		if c.searchIndex != nil {
+			c.searchCommitMu.Lock()
+		}
+		if indexErr == nil && c.searchIndex != nil {
+			indexErr = c.searchIndex.ValidateManyPrepared(indexItems)
+		}
+		if strict && indexErr != nil {
+			if c.searchIndex != nil {
+				c.searchCommitMu.Unlock()
+			}
+			c.mu.Unlock()
+			return rejected, indexErr
+		}
+		if c.searchIndex != nil && indexErr == nil {
+			c.searchIndex.IndexManyPreparedValidated(indexItems)
+		}
+		if indexErr != nil && c.searchIndex != nil {
+			c.searchIndex.MarkIncomplete()
+		}
+		for _, i := range accepted {
+			item := items[i]
+			c.putLocalVertexLockedAtMode(item.Key, item.Value, item.Expiration, now, false)
+			c.recordVertexHLCLocked(item.Key, ts)
+			c.clearVertexTombstoneLocked(item.Key)
+		}
+		if c.searchIndex != nil {
+			c.searchCommitMu.Unlock()
+		}
+		c.mu.Unlock()
+		return rejected, nil
 	}
-	accepted := make([]int, 0, len(items))
+}
+
+func (c *GraphCache[S, T]) planVerticesHLCLocked(items []VertexItem[S, T], ts hlc.Timestamp) (accepted []int, rejected int) {
+	accepted = make([]int, 0, len(items))
 	for i := range items {
-		it := items[i]
-		if !c.vertexWriteAllowedLocked(it.Key, ts) {
+		if !c.vertexWriteAllowedLocked(items[i].Key, ts) {
 			rejected++
 			continue
 		}
 		accepted = append(accepted, i)
 	}
-	indexItems := make([]search.PreparedItem[S], 0, len(accepted))
-	var indexErr error
-	if c.searchIndex != nil && c.searchIndex.Health() != search.IndexHealthy {
-		indexErr = search.ErrIndexIncomplete
-	} else if c.searchIndex != nil {
-		for _, i := range accepted {
-			if prepErrs != nil && prepErrs[i] != nil {
-				indexErr = prepErrs[i]
-				break
-			}
-			indexItems = append(indexItems, search.PreparedItem[S]{ID: items[i].Key, Prepared: prepared[i]})
-		}
-	}
-	if indexErr == nil && c.searchIndex != nil {
-		indexErr = c.searchIndex.ValidateManyPrepared(indexItems)
-	}
-	if strict && indexErr != nil {
-		return rejected, indexErr
-	}
-	updateSearch := c.searchIndex != nil && indexErr == nil
-	if updateSearch {
-		c.searchIndex.IndexManyPreparedValidated(indexItems)
-	}
-	if indexErr != nil && c.searchIndex != nil {
-		c.searchIndex.MarkIncomplete()
-	}
-	for _, i := range accepted {
-		it := items[i]
-		c.putLocalVertexLockedAtMode(it.Key, it.Value, it.Expiration, now, preparedAt(prepared, i), false)
-		c.recordVertexHLCLocked(it.Key, ts)
-		c.clearVertexTombstoneLocked(it.Key)
-	}
-	return rejected, nil
+	return accepted, rejected
 }
 
 // PutVerticesWithExpirationIfAbsentHLC is the replication-aware sibling of

--- a/core/graphcache/batch_external_test.go
+++ b/core/graphcache/batch_external_test.go
@@ -12,6 +12,170 @@ import (
 	"github.com/anaregdesign/lantern/core/search"
 )
 
+type countingSearchDocument struct {
+	text  string
+	calls *atomic.Int64
+}
+
+func (d countingSearchDocument) String() string {
+	d.calls.Add(1)
+	return d.text
+}
+
+func countingSearchExtract(d countingSearchDocument) search.Document { return d }
+
+func compareStringID(a, b string) int { return strings.Compare(a, b) }
+
+func TestPutVerticesWithExpiration_SearchBatchPreparation(t *testing.T) {
+	t.Run("one write lock and final duplicate state", func(t *testing.T) {
+		c := graphcache.NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(func(value string) search.Document { return search.Text(value) }, compareStringID)
+		exp := time.Now().Add(time.Minute)
+		if err := c.PutVerticesWithExpiration([]graphcache.VertexItem[string, string]{
+			{Key: "gone", Value: "old gone", Expiration: exp},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		before := c.SearchIndexMemoryStats().WriteLockAcquisitions
+		if err := c.PutVerticesWithExpiration([]graphcache.VertexItem[string, string]{
+			{Key: "duplicate", Value: "obsolete", Expiration: exp},
+			{Key: "gone", Value: "must disappear", Expiration: time.Now().Add(-time.Second)},
+			{Key: "fresh", Value: "batchterm", Expiration: exp},
+			{Key: "duplicate", Value: "final batchterm", Expiration: exp},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		after := c.SearchIndexMemoryStats().WriteLockAcquisitions
+		if got := after - before; got != 1 {
+			t.Fatalf("index write-lock acquisitions = %d, want 1", got)
+		}
+		if got := c.SearchVerticesMatch("obsolete", 10, "", search.MatchOptions{Mode: search.MatchAll}, false); len(got) != 0 {
+			t.Fatalf("obsolete duplicate remained searchable: %v", got)
+		}
+		if got := c.SearchVerticesMatch("gone", 10, "", search.MatchOptions{Mode: search.MatchAll}, false); len(got) != 0 {
+			t.Fatalf("born-expired overwrite remained searchable: %v", got)
+		}
+		if got := c.SearchVertices("batchterm", 10, ""); len(got) != 2 {
+			t.Fatalf("batchterm results = %v, want 2", got)
+		}
+		if stats := c.SearchIndexMemoryStats(); stats.Documents != 2 {
+			t.Fatalf("indexed documents = %d, want 2", stats.Documents)
+		}
+		if deleted := c.DeleteVertices([]string{"duplicate", "gone", "fresh"}); deleted != 2 {
+			t.Fatalf("DeleteVertices = %d, want 2", deleted)
+		}
+		if stats := c.SearchIndexMemoryStats(); stats.Documents != 0 || stats.LiveTerms != 0 || stats.Postings != 0 || stats.PositionEntries != 0 {
+			t.Fatalf("index refs after delete = %+v, want empty live state", stats)
+		}
+	})
+
+	t.Run("stable skips and duplicates avoid analysis", func(t *testing.T) {
+		var calls atomic.Int64
+		value := func(text string) countingSearchDocument {
+			return countingSearchDocument{text: text, calls: &calls}
+		}
+		c := graphcache.NewGraphCache[string, countingSearchDocument](time.Minute)
+		c.EnableSearchIndex(countingSearchExtract, compareStringID)
+		exp := time.Now().Add(time.Minute)
+		if err := c.PutVerticesWithExpiration([]graphcache.VertexItem[string, countingSearchDocument]{
+			{Key: "taken", Value: value("taken"), Expiration: exp},
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		calls.Store(0)
+		written, skipped, err := c.PutVerticesWithExpirationIfAbsentChecked([]graphcache.VertexItem[string, countingSearchDocument]{
+			{Key: "taken", Value: value("must not analyze"), Expiration: exp},
+			{Key: "fresh", Value: value("accepted"), Expiration: exp},
+			{Key: "fresh", Value: value("duplicate must not analyze"), Expiration: exp},
+			{Key: "expired", Value: value("born expired"), Expiration: time.Now().Add(-time.Second)},
+		})
+		if err != nil || written != 1 || len(skipped) != 2 || skipped[0] != "taken" || skipped[1] != "fresh" {
+			t.Fatalf("written=%d skipped=%v err=%v", written, skipped, err)
+		}
+		if got := calls.Load(); got != 1 {
+			t.Fatalf("if-absent document analyses = %d, want 1", got)
+		}
+
+		calls.Store(0)
+		if err := c.PutVerticesWithExpiration([]graphcache.VertexItem[string, countingSearchDocument]{
+			{Key: "duplicate", Value: value("first"), Expiration: exp},
+			{Key: "duplicate", Value: value("second"), Expiration: exp},
+			{Key: "duplicate", Value: value("final"), Expiration: exp},
+			{Key: "expired", Value: value("born expired"), Expiration: time.Now().Add(-time.Second)},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if got := calls.Load(); got != 1 {
+			t.Fatalf("unconditional document analyses = %d, want final duplicate only", got)
+		}
+
+		calls.Store(0)
+		if rejected, err := c.PutVerticesWithExpirationHLCChecked([]graphcache.VertexItem[string, countingSearchDocument]{
+			{Key: "taken", Value: value("newer"), Expiration: exp},
+		}, hlc.Timestamp{WallNs: 20}); err != nil || rejected != 0 {
+			t.Fatalf("seed HLC rejected=%d err=%v", rejected, err)
+		}
+		calls.Store(0)
+		rejected, err := c.PutVerticesWithExpirationHLCChecked([]graphcache.VertexItem[string, countingSearchDocument]{
+			{Key: "taken", Value: value("stale must not analyze"), Expiration: exp},
+			{Key: "hlc-fresh", Value: value("accepted"), Expiration: exp},
+		}, hlc.Timestamp{WallNs: 10})
+		if err != nil || rejected != 1 {
+			t.Fatalf("stale HLC rejected=%d err=%v", rejected, err)
+		}
+		if got := calls.Load(); got != 1 {
+			t.Fatalf("HLC document analyses = %d, want 1", got)
+		}
+	})
+}
+
+func TestPutVerticesWithExpiration_SearchBatchVisibility(t *testing.T) {
+	const documents = 128
+	c := graphcache.NewGraphCache[string, string](time.Minute)
+	c.EnableSearchIndex(func(value string) search.Document { return search.Text(value) }, compareStringID)
+	exp := time.Now().Add(time.Minute)
+	items := make([]graphcache.VertexItem[string, string], documents)
+	keys := make([]string, documents)
+	for i := range items {
+		key := "batch-" + itoa(i)
+		keys[i] = key
+		items[i] = graphcache.VertexItem[string, string]{Key: key, Value: "atomicbatchterm", Expiration: exp}
+	}
+
+	var stop atomic.Bool
+	var reads atomic.Int64
+	var partial atomic.Int64
+	var readers sync.WaitGroup
+	readers.Add(4)
+	for range 4 {
+		go func() {
+			defer readers.Done()
+			for !stop.Load() {
+				got := len(c.SearchVertices("atomicbatchterm", documents+1, ""))
+				reads.Add(1)
+				if got != 0 && got != documents {
+					partial.Add(1)
+				}
+			}
+		}()
+	}
+	for range 50 {
+		if err := c.PutVerticesWithExpiration(items); err != nil {
+			t.Fatal(err)
+		}
+		c.DeleteVertices(keys)
+	}
+	stop.Store(true)
+	readers.Wait()
+	if reads.Load() == 0 {
+		t.Fatal("reader never executed")
+	}
+	if got := partial.Load(); got != 0 {
+		t.Fatalf("search observed %d partial batch snapshots", got)
+	}
+}
+
 // TestAddEdgesWithExpiration_AtomicNeighborSnapshot verifies that a
 // concurrent reader using Neighbor (which holds the cache RLock for the
 // duration of a single call) observes either the pre-batch state (no

--- a/core/graphcache/bench_test.go
+++ b/core/graphcache/bench_test.go
@@ -730,6 +730,90 @@ func BenchmarkPutVerticesIndexed(b *testing.B) {
 	})
 }
 
+// BenchmarkPutVerticesIndexedBatchPreparation covers #1051's production batch
+// shapes. In addition to Go's ns/op and allocation metrics it reports the time
+// actually spent holding GraphCache.mu, input throughput, and search-index
+// write-lock acquisitions so off-lock preparation is visible independently of
+// total analysis cost. Run with -benchmem; use -benchtime=1x for the 65k arms.
+func BenchmarkPutVerticesIndexedBatchPreparation(b *testing.B) {
+	type scenario struct {
+		name       string
+		n          int
+		value      string
+		duplicates int
+		skipped    bool
+	}
+	short := "alpha beta gamma delta"
+	long := strings.Repeat("alpha beta gamma delta epsilon zeta eta theta ", 64)
+	scenarios := []scenario{
+		{name: "UniqueShort/1k", n: 1_000, value: short},
+		{name: "UniqueShort/10k", n: 10_000, value: short},
+		{name: "UniqueShort/65k", n: 65_000, value: short},
+		{name: "UniqueLong/1k", n: 1_000, value: long},
+		{name: "DuplicateHeavy/65k", n: 65_000, value: short, duplicates: 128},
+		{name: "SkippedHeavy/65k", n: 65_000, value: short, skipped: true},
+	}
+	for _, positions := range []bool{true, false} {
+		positionName := "PositionsOn"
+		if !positions {
+			positionName = "PositionsOff"
+		}
+		for _, scenario := range scenarios {
+			scenario := scenario
+			b.Run(positionName+"/"+scenario.name, func(b *testing.B) {
+				exp := time.Now().Add(time.Hour)
+				items := make([]VertexItem[string, string], scenario.n)
+				for i := range items {
+					keyIndex := i
+					if scenario.duplicates > 0 {
+						keyIndex %= scenario.duplicates
+					}
+					items[i] = VertexItem[string, string]{
+						Key:        makeKey("batch://", keyIndex, 32),
+						Value:      scenario.value,
+						Expiration: exp,
+					}
+				}
+				c := NewGraphCache[string, string](time.Hour)
+				var opts []SearchIndexOption
+				if !positions {
+					opts = append(opts, WithoutSearchPositions())
+				}
+				c.EnableSearchIndex(func(value string) search.Document { return search.Text(value) }, compareStringID, opts...)
+				if scenario.skipped {
+					if err := c.PutVerticesWithExpiration(items); err != nil {
+						b.Fatal(err)
+					}
+				}
+
+				var graphLock time.Duration
+				observe := func(d time.Duration) { graphLock += d }
+				beforeLocks := c.SearchIndexMemoryStats().WriteLockAcquisitions
+				b.ReportAllocs()
+				b.ResetTimer()
+				for range b.N {
+					if scenario.skipped {
+						if _, _, err := c.putVerticesIfAbsentChecked(items, hlc.Timestamp{}, false, observe); err != nil {
+							b.Fatal(err)
+						}
+						continue
+					}
+					if err := c.putVerticesWithExpirationChecked(items, observe); err != nil {
+						b.Fatal(err)
+					}
+				}
+				elapsed := b.Elapsed()
+				afterLocks := c.SearchIndexMemoryStats().WriteLockAcquisitions
+				if b.N > 0 {
+					b.ReportMetric(float64(graphLock.Nanoseconds())/float64(b.N), "graph_lock_ns/op")
+					b.ReportMetric(float64(afterLocks-beforeLocks)/float64(b.N), "index_write_locks/op")
+					b.ReportMetric(float64(scenario.n*b.N)/elapsed.Seconds(), "items/s")
+				}
+			})
+		}
+	}
+}
+
 // BenchmarkApplyPutVerticesHLC contrasts the two ways the replication apply
 // path can replay a 1k-vertex MutationOp_PutVertices with the search index
 // enabled (#840): the pre-#840 loop of singular PutVertexWithExpirationHLC

--- a/core/graphcache/cache.go
+++ b/core/graphcache/cache.go
@@ -72,6 +72,18 @@ type GraphCache[S comparable, T any] struct {
 	// only a single nil check.
 	searchIndex   *search.InvertedIndex[S, search.Document]
 	searchExtract func(T) search.Document
+	// searchCommitMu makes a prepared vertex batch visible to Search as one
+	// transition across both the vertex store and inverted index. Searches hold
+	// RLock across the same bounded execution interval that takes the index read
+	// lock; batch analysis is complete before the writer takes Lock.
+	searchCommitMu sync.RWMutex
+	// searchPreappliedEvictions suppresses the search-index portion of the
+	// synchronous vertex eviction hook when a prepared batch has already
+	// applied the same deletion through IndexManyPrepared. Dictionary and
+	// prefix cleanup still run normally. The separate mutex is required because
+	// eviction hooks may fire without GraphCache.mu.
+	searchEvictionMu          sync.Mutex
+	searchPreappliedEvictions map[S]int
 
 	// vertexHLC tracks the last HLC accepted by PutVertexWithExpirationHLC
 	// (the LWW replication apply path; #182). It is only populated when
@@ -171,10 +183,10 @@ func (c *GraphCache[S, T]) EnablePrefixIndex(extract func(S) string) {
 // putVertexLocked inserts (or refreshes) a vertex entry with its search
 // document analyzed inline (under c.mu). It backs the replicated apply path
 // (PutVertexWithExpirationHLC) and the inline-analysis fallback for single
-// local writes; batch writers precompute the search document outside c.mu and
-// call upsertVertexLocked with it directly. Caller must hold c.mu.
+// local writes. Prepared batch writers bypass it after applying their compact
+// mutations once through IndexManyPrepared. Caller must hold c.mu.
 func (c *GraphCache[S, T]) putVertexLocked(key S, value T, expiration time.Time) {
-	c.upsertVertexLocked(key, value, expiration, nil)
+	c.upsertVertexLocked(key, value, expiration)
 }
 
 // upsertVertexLocked stores/refreshes the vertex and updates its secondary
@@ -183,19 +195,13 @@ func (c *GraphCache[S, T]) putVertexLocked(key S, value T, expiration time.Time)
 // side effects — dictionary interning and prefix insertion — so an
 // expired-but-not-yet-flushed overwrite neither re-interns the key (which would
 // inflate its dictionary refcount past the single live slot) nor re-inserts it
-// into the prefix index. When prepared is non-nil its pre-analyzed tokens are
-// applied to the search index — analysis having run outside c.mu — otherwise
-// the document is analyzed inline. Caller must hold c.mu (#739).
-func (c *GraphCache[S, T]) upsertVertexLocked(key S, value T, expiration time.Time, prepared *search.PreparedDocument) {
+// into the prefix index. The singular path analyzes the document inline;
+// prepared batch paths call upsertVertexStorageLocked directly after their one
+// IndexManyPrepared mutation. Caller must hold c.mu (#739, #1051).
+func (c *GraphCache[S, T]) upsertVertexLocked(key S, value T, expiration time.Time) {
 	c.upsertVertexStorageLocked(key, value, expiration)
 	if c.searchIndex != nil {
-		var err error
-		if prepared != nil {
-			err = c.searchIndex.IndexPrepared(key, *prepared)
-		} else {
-			err = c.searchIndex.Index(key, c.searchExtract(value))
-		}
-		if err != nil {
+		if err := c.searchIndex.Index(key, c.searchExtract(value)); err != nil {
 			c.searchIndex.MarkIncomplete()
 		}
 	}
@@ -226,36 +232,36 @@ func (c *GraphCache[S, T]) upsertVertexStorageLocked(key S, value T, expiration 
 // a per-key watermark after the store, so it keeps calling putVertexLocked
 // directly. Caller must hold c.mu.
 func (c *GraphCache[S, T]) putLocalVertexLocked(key S, value T, expiration time.Time) bool {
-	return c.putLocalVertexLockedAt(key, value, expiration, time.Now(), nil)
+	return c.putLocalVertexLockedAt(key, value, expiration, time.Now())
 }
 
-// putLocalVertexLockedAt is putLocalVertexLocked with the liveness clock and an
-// optional precomputed search document supplied by the caller. A batch writer
-// samples time.Now() once for the whole batch and analyzes every search
-// document outside c.mu (see prepareSearchDocsBounded), then calls this per item so the
-// only work under c.mu is the cheap store + postings mutation. A nil prepared
-// falls back to inline analysis. Caller must hold c.mu (#739).
+// putLocalVertexLockedAt is putLocalVertexLocked with the liveness clock
+// supplied by the caller. Caller must hold c.mu.
 //
 // It returns stored=false when the write was discarded because its expiration
 // was already past (dead on arrival), and true when the value was upserted.
 // The if-absent write paths use this to count only writes that actually landed
 // so a born-expired item is reported as neither written nor skipped (#918);
 // unconditional callers may ignore the return.
-func (c *GraphCache[S, T]) putLocalVertexLockedAt(key S, value T, expiration, now time.Time, prepared *search.PreparedDocument) (stored bool) {
-	return c.putLocalVertexLockedAtMode(key, value, expiration, now, prepared, true)
+func (c *GraphCache[S, T]) putLocalVertexLockedAt(key S, value T, expiration, now time.Time) (stored bool) {
+	return c.putLocalVertexLockedAtMode(key, value, expiration, now, true)
 }
 
-func (c *GraphCache[S, T]) putLocalVertexLockedAtMode(key S, value T, expiration, now time.Time, prepared *search.PreparedDocument, updateSearch bool) (stored bool) {
+func (c *GraphCache[S, T]) putLocalVertexLockedAtMode(key S, value T, expiration, now time.Time, updateSearch bool) (stored bool) {
 	if !cache.IsLiveAt(expiration, now) {
 		// Dead on arrival. Delete is a cheap map-miss when the key is absent
 		// (the common churn case) and fires the eviction hook — releasing the
 		// dictionary reference and dropping prefix/search postings — when it is
 		// present, so an overwrite-to-expired still takes effect.
-		c.vertices.Delete(key)
+		if updateSearch {
+			c.vertices.Delete(key)
+		} else {
+			c.deleteVertexStoragePreindexedLocked(key)
+		}
 		return false
 	}
 	if updateSearch {
-		c.upsertVertexLocked(key, value, expiration, prepared)
+		c.upsertVertexLocked(key, value, expiration)
 	} else {
 		c.upsertVertexStorageLocked(key, value, expiration)
 	}

--- a/core/graphcache/indexes.go
+++ b/core/graphcache/indexes.go
@@ -48,8 +48,64 @@ func (c *GraphCache[S, T]) deleteVerticesIndexes(keys []S) {
 		c.prefixIndex.deleteMany(prefixes)
 	}
 	if c.searchIndex != nil {
-		c.searchIndex.DeleteMany(keys)
+		c.searchIndex.DeleteMany(c.searchEvictionsNotPreapplied(keys))
 	}
+}
+
+// deleteVertexStoragePreindexedLocked removes a born-expired batch item after
+// its zero PreparedDocument has already removed the key from the search index.
+// The cache eviction hook remains responsible for dictionary/prefix cleanup,
+// but consumes the marker and skips a redundant search write-lock acquisition.
+func (c *GraphCache[S, T]) deleteVertexStoragePreindexedLocked(key S) bool {
+	if c.searchIndex == nil {
+		return c.vertices.Delete(key)
+	}
+	c.searchEvictionMu.Lock()
+	if c.searchPreappliedEvictions == nil {
+		c.searchPreappliedEvictions = make(map[S]int)
+	}
+	c.searchPreappliedEvictions[key]++
+	c.searchEvictionMu.Unlock()
+
+	deleted := c.vertices.Delete(key)
+
+	// An absent key fires no hook, so remove an unconsumed marker here. When
+	// Delete did fire the synchronous hook, that hook already consumed it.
+	c.searchEvictionMu.Lock()
+	if count := c.searchPreappliedEvictions[key]; count > 1 {
+		c.searchPreappliedEvictions[key] = count - 1
+	} else {
+		delete(c.searchPreappliedEvictions, key)
+	}
+	if len(c.searchPreappliedEvictions) == 0 {
+		c.searchPreappliedEvictions = nil
+	}
+	c.searchEvictionMu.Unlock()
+	return deleted
+}
+
+func (c *GraphCache[S, T]) searchEvictionsNotPreapplied(keys []S) []S {
+	c.searchEvictionMu.Lock()
+	defer c.searchEvictionMu.Unlock()
+	if len(c.searchPreappliedEvictions) == 0 {
+		return keys
+	}
+	pending := make([]S, 0, len(keys))
+	for _, key := range keys {
+		if count := c.searchPreappliedEvictions[key]; count > 0 {
+			if count == 1 {
+				delete(c.searchPreappliedEvictions, key)
+			} else {
+				c.searchPreappliedEvictions[key] = count - 1
+			}
+			continue
+		}
+		pending = append(pending, key)
+	}
+	if len(c.searchPreappliedEvictions) == 0 {
+		c.searchPreappliedEvictions = nil
+	}
+	return pending
 }
 
 // onEdgeAddedLocked maintains the per-tail head index after a successful

--- a/core/graphcache/prefix.go
+++ b/core/graphcache/prefix.go
@@ -203,6 +203,10 @@ func (c *GraphCache[S, T]) DeleteByPrefix(ctx context.Context, prefix string, li
 		victims = append(victims, key)
 		return true
 	})
+	if c.searchIndex != nil && len(victims) > 0 {
+		c.searchCommitMu.Lock()
+		defer c.searchCommitMu.Unlock()
+	}
 	deleted := len(c.vertices.DeleteMany(victims))
 	c.rebuildIncompleteSearchLocked()
 	return deleted

--- a/core/graphcache/search.go
+++ b/core/graphcache/search.go
@@ -167,6 +167,11 @@ func (c *GraphCache[S, T]) rebuildIncompleteSearchLocked() {
 // liveness and prefix filters so a full page of live, in-scope hits is
 // returned whenever one exists. Equal scores are ordered ascending by the
 // typed compareID function supplied to EnableSearchIndex.
+//
+// Plural vertex writes/deletes publish their vertex and index mutations through
+// one commit barrier, so a concurrent search observes the complete pre-batch or
+// post-batch result set. Singular writes retain GetVertex's point-read contract
+// and may race a search on that one key.
 func (c *GraphCache[S, T]) SearchVertices(query string, limit int, keyPrefix string) []search.Result[S] {
 	return c.SearchVerticesMatch(query, limit, keyPrefix, search.MatchOptions{}, false)
 }
@@ -203,15 +208,23 @@ func (c *GraphCache[S, T]) SearchVerticesMatchContext(ctx context.Context, query
 	if index == nil {
 		return nil, search.Stats{}, nil
 	}
+	// A prepared vertex batch updates the index and vertex store under the
+	// exclusive side of this barrier. Holding the shared side for ranking plus
+	// liveness filtering guarantees a search observes the complete pre-batch or
+	// post-batch view, never an index/store midpoint. The barrier does not cover
+	// analysis or any unrelated graph operation.
+	c.searchCommitMu.RLock()
+	defer c.searchCommitMu.RUnlock()
 	// Phase 2 — query analysis, BM25 ranking, and liveness/prefix filtering all
 	// run WITHOUT GraphCache.mu. The liveness and prefix filters are pushed INTO
 	// the index's bounded top-k selection as the accept callback (#841), so a
 	// broad query (the bigram analyzer makes a two-character query match most of
 	// the corpus) never materialises and fully sorts its whole match set.
 	//
-	// Lock order: accept runs under the index's RLock and probes only the vertex
-	// cache's inner mutex (which never acquires the index lock), an order already
-	// established by index writes running under GraphCache.mu. Liveness is
+	// Lock order: accept runs under searchCommitMu.RLock and the index's RLock,
+	// then probes only the vertex cache's inner mutex (which never acquires the
+	// index lock). This preserves the order already established by index writes
+	// running under GraphCache.mu. Liveness is
 	// checked via vertices.Has, so an expired-but-not-yet-flushed vertex is
 	// skipped; the read may race a concurrent Put/Delete and observe either side
 	// of it, the same racy point-read contract GetVertex provides (#740).

--- a/core/graphcache/tombstone.go
+++ b/core/graphcache/tombstone.go
@@ -113,6 +113,10 @@ func (c *GraphCache[S, T]) DeleteVerticesHLC(keys []S, ts hlc.Timestamp, expirat
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.searchIndex != nil {
+		c.searchCommitMu.Lock()
+		defer c.searchCommitMu.Unlock()
+	}
 	// DeleteMany batches the vertex-index maintenance into one pass (#738);
 	// it returns only the keys that were present, which is exactly the count
 	// we report. Tombstones still go on EVERY key (including absent ones) so
@@ -179,6 +183,10 @@ func (c *GraphCache[S, T]) DeleteByPrefixHLC(ctx context.Context, prefix string,
 	})
 	if err := ctx.Err(); err != nil {
 		return 0, err
+	}
+	if c.searchIndex != nil && len(victims) > 0 {
+		c.searchCommitMu.Lock()
+		defer c.searchCommitMu.Unlock()
 	}
 	// victims are all live (resolveProjected confirms via the vertex cache),
 	// so DeleteMany removes them all; batch it into one index-maintenance pass

--- a/core/search/analysis_limits.go
+++ b/core/search/analysis_limits.go
@@ -80,6 +80,7 @@ type IndexMemoryStats struct {
 	EstimatedRetainedBytes int64
 	RebuildCount           uint64
 	LastRebuildDuration    time.Duration
+	WriteLockAcquisitions  uint64
 	Health                 IndexHealth
 }
 

--- a/core/search/inverted_index.go
+++ b/core/search/inverted_index.go
@@ -3,7 +3,9 @@ package search
 import (
 	"container/heap"
 	"math"
+	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -65,12 +67,13 @@ type InvertedIndex[S comparable, D Document] struct {
 	// docs is the forward index: document ordinal -> the id, per-class lengths,
 	// and term ids needed to score, return, and drop the document in
 	// O(terms-in-doc).
-	docs                map[uint32]docEntry[S]
-	livePostings        int64
-	livePositions       int64
-	health              IndexHealth
-	rebuildCount        uint64
-	lastRebuildDuration time.Duration
+	docs                  map[uint32]docEntry[S]
+	livePostings          int64
+	livePositions         int64
+	health                IndexHealth
+	rebuildCount          uint64
+	lastRebuildDuration   time.Duration
+	writeLockAcquisitions uint64
 }
 
 // classPostings is one token class's slice of the index: its term dictionary,
@@ -208,13 +211,27 @@ func (idx *InvertedIndex[S, D]) Index(id S, doc D) error {
 	return idx.IndexPrepared(id, prepared)
 }
 
-// PreparedDocument carries the analyzed tokens of a document so the expensive
-// analysis (doc.String() + tokenization) can run outside the index write lock.
-// Produce one with Prepare and apply it with IndexPrepared or IndexManyPrepared.
-// The zero value is a valid empty document: applying it removes the id, matching
-// Index of a document with no analyzable terms.
+// PreparedDocument carries an already grouped document representation so all
+// analysis, partitioning, sorting, frequency aggregation, and position
+// collection complete before the index write lock is acquired. Produce one
+// with Prepare and apply it with IndexPrepared or IndexManyPrepared. The zero
+// value is a valid empty document: applying it removes the id, matching Index
+// of a document with no analyzable terms.
 type PreparedDocument struct {
-	tokens []Token
+	classes         [numTokenClasses]preparedClass
+	postings        int
+	positionEntries int
+}
+
+type preparedClass struct {
+	length int
+	terms  []preparedTerm
+}
+
+type preparedTerm struct {
+	term      string
+	frequency int
+	positions []uint32
 }
 
 // PreparedItem pairs an id with its PreparedDocument for IndexManyPrepared.
@@ -253,22 +270,72 @@ func (idx *InvertedIndex[S, D]) Prepare(doc D) (PreparedDocument, AnalysisStats,
 	if err := limitError(LimitDocumentTokens, int64(stats.Tokens), int64(idx.limits.MaxDocumentTokens)); err != nil {
 		return PreparedDocument{}, stats, err
 	}
-	seen := make(map[Token]struct{}, len(tokens))
+	prepared := PreparedDocument{}
+	var wordPositions map[string][]uint32
+	if idx.positions {
+		wordPositions = make(map[string][]uint32)
+	}
+	var wordPosition uint32
 	for _, token := range tokens {
 		if int(token.Class) >= numTokenClasses {
 			panic("search: token with undefined TokenClass")
 		}
-		seen[token] = struct{}{}
 		if idx.positions && token.Class == ClassWord {
-			stats.PositionEntries++
+			wordPositions[token.Term] = append(wordPositions[token.Term], wordPosition)
+			wordPosition++
 		}
 	}
-	stats.UniqueTerms = len(seen)
-	stats.Postings = len(seen)
+	// The analyzer owns this token slice for the call, so sort it in place
+	// instead of allocating a second occurrence-sized scratch representation.
+	// Positions were captured above while tokens were still in source order.
+	slices.SortFunc(tokens, func(a, b Token) int {
+		if a.Class < b.Class {
+			return -1
+		}
+		if a.Class > b.Class {
+			return 1
+		}
+		return strings.Compare(a.Term, b.Term)
+	})
+	var distinct [numTokenClasses]int
+	for i := 0; i < len(tokens); {
+		j := i + 1
+		for j < len(tokens) && tokens[j] == tokens[i] {
+			j++
+		}
+		distinct[tokens[i].Class]++
+		i = j
+	}
+	for class, count := range distinct {
+		if count > 0 {
+			prepared.classes[class].terms = make([]preparedTerm, 0, count)
+		}
+	}
+	for i := 0; i < len(tokens); {
+		j := i + 1
+		for j < len(tokens) && tokens[j] == tokens[i] {
+			j++
+		}
+		class := tokens[i].Class
+		term := preparedTerm{term: tokens[i].Term, frequency: j - i}
+		if idx.positions && class == ClassWord {
+			term.positions = wordPositions[term.term]
+		}
+		prepared.classes[class].length += j - i
+		prepared.classes[class].terms = append(prepared.classes[class].terms, term)
+		prepared.postings++
+		i = j
+	}
+	if idx.positions {
+		prepared.positionEntries = int(wordPosition)
+	}
+	stats.UniqueTerms = prepared.postings
+	stats.Postings = prepared.postings
+	stats.PositionEntries = prepared.positionEntries
 	if err := limitError(LimitDocumentTerms, int64(stats.UniqueTerms), int64(idx.limits.MaxDocumentTerms)); err != nil {
 		return PreparedDocument{}, stats, err
 	}
-	return PreparedDocument{tokens: tokens}, stats, nil
+	return prepared, stats, nil
 }
 
 // IndexPrepared records id's postings from a PreparedDocument produced by
@@ -276,12 +343,12 @@ func (idx *InvertedIndex[S, D]) Prepare(doc D) (PreparedDocument, AnalysisStats,
 // Index: any previous postings for id are dropped first, and an empty prepared
 // document simply removes id.
 func (idx *InvertedIndex[S, D]) IndexPrepared(id S, prepared PreparedDocument) error {
-	idx.mu.Lock()
+	idx.lockWrite()
 	defer idx.mu.Unlock()
 	if err := idx.validatePreparedLocked([]PreparedItem[S]{{ID: id, Prepared: prepared}}); err != nil {
 		return err
 	}
-	idx.indexPreparedLocked(id, prepared.tokens)
+	idx.indexPreparedLocked(id, prepared)
 	idx.compactIfNeededLocked()
 	return nil
 }
@@ -295,13 +362,13 @@ func (idx *InvertedIndex[S, D]) IndexManyPrepared(items []PreparedItem[S]) error
 	if len(items) == 0 {
 		return nil
 	}
-	idx.mu.Lock()
+	idx.lockWrite()
 	defer idx.mu.Unlock()
 	if err := idx.validatePreparedLocked(items); err != nil {
 		return err
 	}
 	for _, it := range finalPreparedItems(items) {
-		idx.indexPreparedLocked(it.ID, it.Prepared.tokens)
+		idx.indexPreparedLocked(it.ID, it.Prepared)
 	}
 	idx.compactIfNeededLocked()
 	return nil
@@ -323,10 +390,10 @@ func (idx *InvertedIndex[S, D]) IndexManyPreparedValidated(items []PreparedItem[
 	if len(items) == 0 {
 		return
 	}
-	idx.mu.Lock()
+	idx.lockWrite()
 	defer idx.mu.Unlock()
 	for _, item := range finalPreparedItems(items) {
-		idx.indexPreparedLocked(item.ID, item.Prepared.tokens)
+		idx.indexPreparedLocked(item.ID, item.Prepared)
 	}
 	idx.compactIfNeededLocked()
 }
@@ -346,86 +413,39 @@ func finalPreparedItems[S comparable](items []PreparedItem[S]) []PreparedItem[S]
 }
 
 // indexPreparedLocked is the shared postings-mutation core of IndexPrepared and
-// IndexManyPrepared; callers must hold idx.mu for writing. A token with an
-// undefined class panics: that is a broken analyzer, not a malformed document.
-func (idx *InvertedIndex[S, D]) indexPreparedLocked(id S, tokens []Token) {
+// IndexManyPrepared; callers must hold idx.mu for writing. Prepare has already
+// validated classes and reduced every class to sorted distinct terms.
+func (idx *InvertedIndex[S, D]) indexPreparedLocked(id S, prepared PreparedDocument) {
 	// Replace semantics: drop any postings from a previous Index(id, ...)
 	// before recording the new ones.
 	idx.deleteLocked(id)
-	if len(tokens) == 0 {
+	if prepared.postings == 0 {
 		return
-	}
-	// Partition the document's terms by class; each class's postings and
-	// statistics are recorded independently. perClass slices are transient
-	// scratch; only the compact distinct-term slices are retained.
-	var perClass [numTokenClasses][]string
-	// wordPositions maps each primary (ClassWord) term to its ascending token
-	// positions in this document, recorded only when the index tracks positions.
-	// Position counts word tokens only (auxiliary grams are skipped), so
-	// "data set" yields data@0 set@1 and a CJK run's consecutive bigrams get
-	// consecutive positions — both let SearchPhrase verify adjacency with pos+1.
-	var wordPositions map[string][]uint32
-	if idx.positions {
-		wordPositions = make(map[string][]uint32)
-	}
-	var wordPos uint32
-	for _, token := range tokens {
-		if int(token.Class) >= numTokenClasses {
-			panic("search: token with undefined TokenClass")
-		}
-		perClass[token.Class] = append(perClass[token.Class], token.Term)
-		if wordPositions != nil && token.Class == ClassWord {
-			wordPositions[token.Term] = append(wordPositions[token.Term], wordPos)
-			wordPos++
-		}
 	}
 	ord := idx.ords.assign(id)
 	entry := docEntry[S]{id: id}
-	for class, sorted := range perClass {
-		if len(sorted) == 0 {
+	for class, preparedClass := range prepared.classes {
+		if len(preparedClass.terms) == 0 {
 			continue
 		}
-		// Sort this class's terms so the distinct terms and their frequencies
-		// (the run length of each equal stretch) can be read in one linear pass.
-		sort.Strings(sorted)
-
-		// Count distinct terms up front so the retained forward-index slice is
-		// allocated at its exact length (no spare capacity held per document).
-		distinct := 1
-		for i := 1; i < len(sorted); i++ {
-			if sorted[i] != sorted[i-1] {
-				distinct++
-			}
-		}
 		cp := &idx.classes[class]
-		terms := make([]uint32, 0, distinct)
-		for i := 0; i < len(sorted); {
-			j := i + 1
-			for j < len(sorted) && sorted[j] == sorted[i] {
-				j++
-			}
-			tid := cp.dict.intern(sorted[i])
+		terms := make([]uint32, 0, len(preparedClass.terms))
+		for _, preparedTerm := range preparedClass.terms {
+			tid := cp.dict.intern(preparedTerm.term)
 			pl, ok := cp.postings[tid]
 			if !ok {
 				pl = newPostingList()
 				cp.postings[tid] = pl
 			}
-			var pos []uint32
-			if wordPositions != nil && class == int(ClassWord) {
-				pos = wordPositions[sorted[i]]
-			}
-			pl.set(ord, j-i, pos) // term frequency = run length of this term
+			pl.set(ord, preparedTerm.frequency, preparedTerm.positions)
 			terms = append(terms, tid)
-			i = j
 		}
-		entry.lengths[class] = len(sorted)
+		entry.lengths[class] = preparedClass.length
 		entry.terms[class] = terms
-		cp.totalLen += len(sorted)
+		cp.totalLen += preparedClass.length
 		cp.docCount++
 	}
-	if idx.positions {
-		entry.positionEntries = entry.lengths[ClassWord]
-	}
+	entry.positionEntries = prepared.positionEntries
 	idx.docs[ord] = entry
 	for class := range entry.terms {
 		idx.livePostings += int64(len(entry.terms[class]))
@@ -483,19 +503,15 @@ func (idx *InvertedIndex[S, D]) validatePreparedLocked(items []PreparedItem[S]) 
 		}
 	}
 	for _, prepared := range last {
-		seen := make(map[termKey]struct{}, len(prepared.tokens))
-		for _, token := range prepared.tokens {
-			key := termKey{class: token.Class, term: token.Term}
-			if _, ok := seen[key]; !ok {
-				seen[key] = struct{}{}
+		for class, preparedClass := range prepared.classes {
+			for _, term := range preparedClass.terms {
+				key := termKey{class: TokenClass(class), term: term.term}
 				loadDF(key)
 				deltaDF[key]++
 				postings++
 			}
-			if idx.positions && token.Class == ClassWord {
-				positions++
-			}
 		}
+		positions += int64(prepared.positionEntries)
 	}
 	liveTerms := 0
 	for class := range idx.classes {
@@ -524,7 +540,7 @@ func (idx *InvertedIndex[S, D]) validatePreparedLocked(items []PreparedItem[S]) 
 // id was never indexed. A term whose last document is removed is dropped
 // entirely, so a delete-heavy workload never leaks empty posting sets.
 func (idx *InvertedIndex[S, D]) Delete(id S) {
-	idx.mu.Lock()
+	idx.lockWrite()
 	defer idx.mu.Unlock()
 	idx.deleteLocked(id)
 	idx.compactIfNeededLocked()
@@ -539,7 +555,7 @@ func (idx *InvertedIndex[S, D]) DeleteMany(ids []S) {
 	if len(ids) == 0 {
 		return
 	}
-	idx.mu.Lock()
+	idx.lockWrite()
 	defer idx.mu.Unlock()
 	for _, id := range ids {
 		idx.deleteLocked(id)
@@ -579,7 +595,7 @@ func (idx *InvertedIndex[S, D]) deleteLocked(id S) {
 
 // MarkIncomplete makes all subsequent context-aware searches fail closed.
 func (idx *InvertedIndex[S, D]) MarkIncomplete() {
-	idx.mu.Lock()
+	idx.lockWrite()
 	idx.health = IndexIncomplete
 	idx.mu.Unlock()
 }
@@ -594,7 +610,7 @@ func (idx *InvertedIndex[S, D]) Health() IndexHealth {
 // Compact atomically rebuilds dictionaries, ordinals, postings, and document
 // maps from the live logical corpus. Searches observe either complete state.
 func (idx *InvertedIndex[S, D]) Compact() {
-	idx.mu.Lock()
+	idx.lockWrite()
 	defer idx.mu.Unlock()
 	idx.compactLocked()
 }
@@ -613,7 +629,7 @@ func (idx *InvertedIndex[S, D]) RebuildPrepared(items []PreparedItem[S]) error {
 	if err := tmp.IndexManyPrepared(items); err != nil {
 		return err
 	}
-	idx.mu.Lock()
+	idx.lockWrite()
 	defer idx.mu.Unlock()
 	idx.classes, idx.ords, idx.docs = tmp.classes, tmp.ords, tmp.docs
 	idx.livePostings, idx.livePositions = tmp.livePostings, tmp.livePositions
@@ -654,49 +670,41 @@ func (idx *InvertedIndex[S, D]) compactLocked() {
 	start := time.Now()
 	items := make([]PreparedItem[S], 0, len(idx.docs))
 	for ord, entry := range idx.docs {
-		var tokens []Token
-		wordStart := len(tokens)
-		if idx.positions && entry.positionEntries > 0 {
-			words := make([]Token, entry.positionEntries)
-			for _, tid := range entry.terms[ClassWord] {
-				term := idx.classes[ClassWord].dict.terms[tid]
-				for _, pos := range idx.classes[ClassWord].postings[tid].positionsOf(ord) {
-					if int(pos) < len(words) {
-						words[pos] = Token{Term: term, Class: ClassWord}
-					}
-				}
+		prepared := PreparedDocument{positionEntries: entry.positionEntries}
+		for class := range entry.terms {
+			preparedClass := preparedClass{
+				length: entry.lengths[class],
+				terms:  make([]preparedTerm, 0, len(entry.terms[class])),
 			}
-			tokens = append(tokens, words...)
-		} else {
-			for _, tid := range entry.terms[ClassWord] {
-				pl := idx.classes[ClassWord].postings[tid]
-				for range pl.tf(ord) {
-					tokens = append(tokens, Token{Term: idx.classes[ClassWord].dict.terms[tid], Class: ClassWord})
-				}
-			}
-		}
-		if missing := entry.lengths[ClassWord] - (len(tokens) - wordStart); missing > 0 && len(entry.terms[ClassWord]) > 0 {
-			term := idx.classes[ClassWord].dict.terms[entry.terms[ClassWord][0]]
-			for range missing {
-				tokens = append(tokens, Token{Term: term, Class: ClassWord})
-			}
-		}
-		for class := int(ClassWord) + 1; class < numTokenClasses; class++ {
-			classStart := len(tokens)
+			frequencySum := 0
 			for _, tid := range entry.terms[class] {
 				pl := idx.classes[class].postings[tid]
-				for range pl.tf(ord) {
-					tokens = append(tokens, Token{Term: idx.classes[class].dict.terms[tid], Class: TokenClass(class)})
+				positions := []uint32(nil)
+				frequency := pl.tf(ord)
+				if idx.positions && class == int(ClassWord) {
+					positions = pl.positionsOf(ord)
+					frequency = len(positions)
 				}
+				preparedClass.terms = append(preparedClass.terms, preparedTerm{
+					term:      idx.classes[class].dict.terms[tid],
+					frequency: frequency,
+					positions: positions,
+				})
+				frequencySum += frequency
 			}
-			if missing := entry.lengths[class] - (len(tokens) - classStart); missing > 0 && len(entry.terms[class]) > 0 {
-				term := idx.classes[class].dict.terms[entry.terms[class][0]]
-				for range missing {
-					tokens = append(tokens, Token{Term: term, Class: TokenClass(class)})
-				}
+			// Frequencies above uint16 are intentionally clamped in postingList.
+			// Preserve the exact document length across compaction by assigning
+			// the unobservable excess to one already-saturated term.
+			if missing := preparedClass.length - frequencySum; missing > 0 && len(preparedClass.terms) > 0 {
+				preparedClass.terms[0].frequency += missing
 			}
+			sort.Slice(preparedClass.terms, func(i, j int) bool {
+				return preparedClass.terms[i].term < preparedClass.terms[j].term
+			})
+			prepared.classes[class] = preparedClass
+			prepared.postings += len(preparedClass.terms)
 		}
-		items = append(items, PreparedItem[S]{ID: entry.id, Prepared: PreparedDocument{tokens: tokens}})
+		items = append(items, PreparedItem[S]{ID: entry.id, Prepared: prepared})
 	}
 	var opts []IndexOption
 	if idx.positions {
@@ -967,13 +975,14 @@ func (idx *InvertedIndex[S, D]) MemoryStats() IndexMemoryStats {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
 	stats := IndexMemoryStats{
-		Documents:           len(idx.docs),
-		Postings:            idx.livePostings,
-		PositionEntries:     idx.livePositions,
-		RetainedOrdinals:    int(idx.ords.next),
-		RebuildCount:        idx.rebuildCount,
-		LastRebuildDuration: idx.lastRebuildDuration,
-		Health:              idx.health,
+		Documents:             len(idx.docs),
+		Postings:              idx.livePostings,
+		PositionEntries:       idx.livePositions,
+		RetainedOrdinals:      int(idx.ords.next),
+		RebuildCount:          idx.rebuildCount,
+		LastRebuildDuration:   idx.lastRebuildDuration,
+		WriteLockAcquisitions: idx.writeLockAcquisitions,
+		Health:                idx.health,
 	}
 	var termBytes int64
 	for class := range idx.classes {
@@ -989,6 +998,11 @@ func (idx *InvertedIndex[S, D]) MemoryStats() IndexMemoryStats {
 	stats.EstimatedLiveBytes = termBytes + int64(stats.Documents)*32 + stats.Postings*12 + stats.PositionEntries
 	stats.EstimatedRetainedBytes = stats.EstimatedLiveBytes + int64(stats.RetainedTermSlots-stats.LiveTerms)*16 + int64(stats.RetainedOrdinals-stats.Documents)*8
 	return stats
+}
+
+func (idx *InvertedIndex[S, D]) lockWrite() {
+	idx.mu.Lock()
+	idx.writeLockAcquisitions++
 }
 
 // Interface assertions: InvertedIndex is both an Indexer and a Searcher.

--- a/core/search/inverted_index_test.go
+++ b/core/search/inverted_index_test.go
@@ -435,6 +435,20 @@ func TestInvertedIndexPrepared(t *testing.T) {
 		}
 		return prepared
 	}
+	t.Run("Prepare groups sorted frequencies and positions", func(t *testing.T) {
+		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID, WithPositions())
+		prepared := mustPrepare(t, idx, Text("Beta alpha beta"))
+		words := prepared.classes[ClassWord]
+		if words.length != 3 || len(words.terms) != 2 || prepared.postings != 2 || prepared.positionEntries != 3 {
+			t.Fatalf("prepared = %+v", prepared)
+		}
+		if got := words.terms[0]; got.term != "alpha" || got.frequency != 1 || !slices.Equal(got.positions, []uint32{1}) {
+			t.Fatalf("first grouped term = %+v", got)
+		}
+		if got := words.terms[1]; got.term != "beta" || got.frequency != 2 || !slices.Equal(got.positions, []uint32{0, 2}) {
+			t.Fatalf("second grouped term = %+v", got)
+		}
+	})
 	t.Run("IndexPrepared matches Index", func(t *testing.T) {
 		viaIndex := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
 		viaIndex.Index("doc1", Text("Alpha Beta"))

--- a/tests/integration/search_vertices_test.go
+++ b/tests/integration/search_vertices_test.go
@@ -9,6 +9,8 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -540,6 +542,94 @@ func TestSearchVertices_EndToEnd(t *testing.T) {
 	}
 	if got := empty.Msg.GetHits(); len(got) != 0 {
 		t.Fatalf("empty-query hits = %d, want 0", len(got))
+	}
+}
+
+// TestSearchVertices_PluralWriteVisibilityOverWire pins #1051's batch
+// visibility contract over the real Connect/h2c path: a search concurrent with
+// PutVertices/DeleteVertices observes the complete pre-batch or post-batch hit
+// set, never the midpoint between the prepared index update and vertex commit.
+func TestSearchVertices_PluralWriteVisibilityOverWire(t *testing.T) {
+	const documents = 128
+	c := newSearchRawClient(t, true)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	exp := timestamppb.New(time.Now().Add(time.Hour))
+	vertices := make([]*pb.Vertex, documents)
+	keys := make([]string, documents)
+	for i := range vertices {
+		key := fmt.Sprintf("wire-batch-%03d", i)
+		keys[i] = key
+		vertices[i] = &pb.Vertex{Key: key, Value: &pb.Vertex_String_{String_: "wireatomicterm"}, Expiration: exp}
+	}
+	put := func() error {
+		_, err := c.PutVertices(ctx, connect.NewRequest(&pb.PutVerticesRequest{Vertices: vertices}))
+		return err
+	}
+	del := func() error {
+		_, err := c.DeleteVertices(ctx, connect.NewRequest(&pb.DeleteVerticesRequest{Keys: keys}))
+		return err
+	}
+	searchCount := func() (int, error) {
+		resp, err := c.SearchVertices(ctx, connect.NewRequest(&pb.SearchVerticesRequest{Query: "wireatomicterm", Limit: documents + 1}))
+		if err != nil {
+			return 0, err
+		}
+		return len(resp.Msg.GetHits()), nil
+	}
+
+	if err := put(); err != nil {
+		t.Fatalf("initial PutVertices: %v", err)
+	}
+	if got, err := searchCount(); err != nil || got != documents {
+		t.Fatalf("post-batch hits=%d err=%v, want %d", got, err, documents)
+	}
+	if err := del(); err != nil {
+		t.Fatalf("initial DeleteVertices: %v", err)
+	}
+
+	var stop atomic.Bool
+	var reads atomic.Int64
+	var partial atomic.Int64
+	errCh := make(chan error, 1)
+	var reader sync.WaitGroup
+	reader.Add(1)
+	go func() {
+		defer reader.Done()
+		for !stop.Load() {
+			got, err := searchCount()
+			if err != nil {
+				select {
+				case errCh <- err:
+				default:
+				}
+				return
+			}
+			reads.Add(1)
+			if got != 0 && got != documents {
+				partial.Add(1)
+			}
+		}
+	}()
+	for range 20 {
+		if err := put(); err != nil {
+			t.Fatalf("PutVertices: %v", err)
+		}
+		if err := del(); err != nil {
+			t.Fatalf("DeleteVertices: %v", err)
+		}
+	}
+	stop.Store(true)
+	reader.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("SearchVertices: %v", err)
+	}
+	if reads.Load() == 0 {
+		t.Fatal("wire reader never executed")
+	}
+	if got := partial.Load(); got != 0 {
+		t.Fatalf("wire search observed %d partial plural-write snapshots", got)
 	}
 }
 


### PR DESCRIPTION
Closes #1051

## What changed

- replaces raw-token `PreparedDocument` with sorted, grouped per-class term/frequency/position records built entirely outside the index and graph locks
- applies each accepted production vertex batch through one `IndexManyPrepared` write-lock acquisition
- prepares only the final unconditional duplicate and uses optimistic two-phase planning for SET NX/LWW paths, so stable skips, causal losers, earlier duplicates, and born-expired values avoid full analysis
- suppresses redundant search eviction-hook writes when a prepared zero document already removed a born-expired key, while preserving dictionary and prefix cleanup
- adds a search commit barrier so plural Put/Delete is observed as a complete pre-batch or post-batch state across the index and vertex store
- records index write-lock acquisitions in core memory stats for tests/benchmarks

## Correctness coverage

- duplicate last-write, born-expired overwrite, SET NX skip, LWW reject, mixed accepted/skipped batches, and exact live posting/position cleanup
- production-path assertion that a mixed live/delete batch takes exactly one index write lock
- concurrent Search/Put/Delete pre/post visibility in core and over the real Connect/h2c wire path
- final grouped frequencies/positions and existing compaction, phrase, scoring, aggregate-limit, and replication tests
- race coverage for `core/search`, `core/graphcache`, and the real-wire visibility contract

## Benchmark evidence

Apple M3 Max, `-benchtime=1x -count=5 -benchmem`, identical public-API harness on merged #1050 vs this branch:

| workload | positions | time | B/op | allocs/op |
|---|---:|---:|---:|---:|
| unique short 10k | on | median ~10% lower (not significant at n=5) | -12.0% | -17.6% |
| unique long 1k | on | -8.0% | -49.1% | -1.2% |
| duplicate-heavy 65k | on | -97.4% | -95.1% | -99.7% |
| skipped-heavy 65k | on | -96.9% | -94.7% | -100.0% |
| unique short 10k | off | -13.3% | -13.3% | -20.9% |
| unique long 1k | off | -7.8% | -49.7% | -1.2% |
| duplicate-heavy 65k | off | -97.3% | -95.2% | -99.8% |
| skipped-heavy 65k | off | -96.7% | -94.7% | -100.0% |

Geomean: time -83.8%, B/op -81.7%, allocs/op -98.7%.

The committed 1k/10k/65k benchmark also reports graph-lock hold and lock cycles. Final 65k unique results use exactly `1.000 index_write_locks/op`; graph lock is 85.8ms of 262.3ms with positions on and 61.0ms of 221.7ms off. Duplicate-heavy reaches 14.3–15.0M input items/s; skipped-heavy performs zero analysis and zero index write locks.

## Validation

- `gofmt -l` clean and `git diff --check`
- `go test ./...` from root, `pb`, `core`, `sdks/go`, `server`, and `mcp`
- `go vet ./...` in `core`
- `go test -race ./graphcache ./search`
- `go test -race ./tests/integration -run '^TestSearchVertices_PluralWriteVisibilityOverWire$'`
- `BenchmarkPutVerticesIndexedBatchPreparation` all 12 arms
- Dart format/analyze/test (one pre-existing analyzer info in `traversal.dart`)
