### PR TITLE
perf(search): bound exact top-k retrieval

### DIFF
--- a/core/graphcache/radix.go
+++ b/core/graphcache/radix.go
@@ -207,6 +207,21 @@ func (r *radix) deleteAt(n *radixNode, key string) bool {
 func (r *radix) walkPrefix(prefix string, fn func(key string) bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
+	r.walkPrefixLocked(prefix, fn)
+}
+
+// withPrefixWalk holds the radix read lock while fn consumes a lock-free walk
+// closure. It lets a layered query establish radix -> downstream-index lock
+// order once and stream candidates without materialising the prefix subtree.
+func (r *radix) withPrefixWalk(prefix string, fn func(walk func(func(string) bool))) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	fn(func(visit func(string) bool) { r.walkPrefixLocked(prefix, visit) })
+}
+
+// walkPrefixLocked is walkPrefix without synchronization. Caller holds at
+// least r.mu.RLock.
+func (r *radix) walkPrefixLocked(prefix string, fn func(key string) bool) {
 	node, accumulated, ok := r.descend(prefix)
 	if !ok {
 		return

--- a/core/graphcache/search.go
+++ b/core/graphcache/search.go
@@ -181,9 +181,9 @@ func (c *GraphCache[S, T]) SearchVertices(query string, limit int, keyPrefix str
 // requires the query's word terms to occur adjacently, in order. phrase takes
 // precedence over opts.Mode — a phrase query is served by the index's phrase
 // search. SearchVertices is exactly SearchVerticesMatch with the zero
-// MatchOptions and phrase == false (the default OR-union). Liveness and prefix
-// scoping are identical, and the bounded top-k selection still pushes them into
-// the accept callback so a broad query never materialises its whole match set.
+// MatchOptions and phrase == false (the default OR-union). Liveness is pushed
+// into the accept callback; when the prefix radix is enabled, prefix membership
+// is streamed into core as a CandidateSource before scoring.
 func (c *GraphCache[S, T]) SearchVerticesMatch(query string, limit int, keyPrefix string, opts search.MatchOptions, phrase bool) []search.Result[S] {
 	results, _, _ := c.SearchVerticesMatchContext(context.Background(), query, limit, keyPrefix, opts, phrase, search.Budget{})
 	return results
@@ -203,6 +203,7 @@ func (c *GraphCache[S, T]) SearchVerticesMatchContext(ctx context.Context, query
 	c.mu.RLock()
 	index := c.searchIndex
 	prefixExtract := c.prefixExtract
+	prefixIndex := c.prefixIndex
 	c.mu.RUnlock()
 
 	if index == nil {
@@ -217,10 +218,12 @@ func (c *GraphCache[S, T]) SearchVerticesMatchContext(ctx context.Context, query
 	defer c.searchCommitMu.RUnlock()
 	queryNow := time.Now()
 	// Phase 2 — query analysis, BM25 ranking, and liveness/prefix filtering all
-	// run WITHOUT GraphCache.mu. The liveness and prefix filters are pushed INTO
-	// the index's bounded top-k selection as the accept callback (#841), so a
+	// run WITHOUT GraphCache.mu. Liveness is pushed into bounded execution as an
+	// accept callback (#841), so a
 	// broad query (the bigram analyzer makes a two-character query match most of
-	// the corpus) never materialises and fully sorts its whole match set.
+	// the corpus) never materialises and fully sorts its whole match set. A
+	// non-empty prefix is pushed down separately through the radix candidate
+	// source below, avoiding global scoring.
 	//
 	// Lock order: accept runs under searchCommitMu.RLock and the index's RLock,
 	// then probes only the vertex cache's inner mutex (which never acquires the
@@ -242,10 +245,27 @@ func (c *GraphCache[S, T]) SearchVerticesMatchContext(ctx context.Context, query
 	var out []search.Result[S]
 	var stats search.Stats
 	var err error
-	if phrase {
-		out, stats, err = index.SearchPhraseTopKContextAt(ctx, query, limit, accept, budget, queryNow)
+	execute := func(candidates search.CandidateSource[S]) {
+		if phrase {
+			out, stats, err = index.SearchPhraseTopKCandidatesContextAt(ctx, query, limit, accept, budget, queryNow, candidates)
+		} else {
+			out, stats, err = index.SearchMatchTopKCandidatesContextAt(ctx, query, limit, accept, opts, budget, queryNow, candidates)
+		}
+	}
+	if keyPrefix != "" && prefixIndex != nil {
+		// Establish radix -> inverted-index lock order and retain the radix read
+		// lock only for the synchronous query. Writers already mutate the prefix
+		// radix before search postings under GraphCache.mu, so this cannot cycle.
+		prefixIndex.withPrefixWalk(keyPrefix, func(walk func(func(string) bool)) {
+			execute(func(yield func(S) bool) {
+				walk(func(projected string) bool {
+					id, ok := c.keyForProjection(projected)
+					return !ok || yield(id)
+				})
+			})
+		})
 	} else {
-		out, stats, err = index.SearchMatchTopKContextAt(ctx, query, limit, accept, opts, budget, queryNow)
+		execute(nil)
 	}
 	if err != nil {
 		return nil, stats, err
@@ -273,4 +293,16 @@ func keyHasPrefix[S comparable](prefixExtract func(S) string, key S, prefix stri
 		return strings.HasPrefix(s, prefix)
 	}
 	return false
+}
+
+// keyForProjection reverses the radix projection without applying liveness.
+// Search evaluates liveness once at queryNow in accept; keeping projection and
+// liveness separate avoids resampling the clock while candidates stream.
+func (c *GraphCache[S, T]) keyForProjection(projected string) (S, bool) {
+	var zero S
+	if _, isString := any(zero).(string); isString {
+		key, ok := any(projected).(S)
+		return key, ok
+	}
+	return c.dict.findByProjection(c.prefixExtract, projected)
 }

--- a/core/graphcache/search_test.go
+++ b/core/graphcache/search_test.go
@@ -173,6 +173,7 @@ func TestGraphCache_SearchExpirationIndependentOfBackgroundGC(t *testing.T) {
 func TestGraphCache_SearchConcurrentMutationAndCancellation(t *testing.T) {
 	c := NewGraphCache[string, string](time.Minute)
 	c.EnableSearchIndex(textExtract, compareStringID)
+	c.EnablePrefixIndex(func(key string) string { return key })
 	for i := 0; i < 200; i++ {
 		c.PutVertex(fmt.Sprintf("seed-%03d", i), "alpha beta")
 	}
@@ -203,7 +204,7 @@ func TestGraphCache_SearchConcurrentMutationAndCancellation(t *testing.T) {
 			if i%2 == 0 {
 				cancel()
 			}
-			_, _, err := c.SearchVerticesMatchContext(ctx, "alpha beta", 10, "", search.MatchOptions{}, false, search.Budget{})
+			_, _, err := c.SearchVerticesMatchContext(ctx, "alpha beta", 10, "seed-", search.MatchOptions{}, false, search.Budget{})
 			cancel()
 			if err != nil && !errors.Is(err, context.Canceled) {
 				errs <- err
@@ -395,6 +396,43 @@ func TestGraphCache_SearchVertices(t *testing.T) {
 		got := c.SearchVertices("keyword", 10, "user:")
 		if want := []string{"user:1", "user:2"}; !equalKeys(keys(got), want) {
 			t.Fatalf("SearchVertices(keyword, prefix user:) = %v, want %v", keys(got), want)
+		}
+	})
+
+	t.Run("Prefix index pushes candidate scope into retrieval", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract, compareStringID)
+		c.EnablePrefixIndex(func(key string) string { return key })
+		items := make([]VertexItem[string, string], 0, 2010)
+		expiration := time.Now().Add(time.Hour)
+		for i := 0; i < 2000; i++ {
+			items = append(items, VertexItem[string, string]{Key: fmt.Sprintf("other:%04d", i), Value: "shared keyword", Expiration: expiration})
+		}
+		for i := 0; i < 10; i++ {
+			items = append(items, VertexItem[string, string]{Key: fmt.Sprintf("scope:%02d", i), Value: "shared keyword", Expiration: expiration})
+		}
+		if err := c.PutVerticesWithExpiration(items); err != nil {
+			t.Fatal(err)
+		}
+		scoped, scopedStats, err := c.SearchVerticesMatchContext(context.Background(), "keyword", 5, "scope:", search.MatchOptions{}, false, search.Budget{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		global, globalStats, err := c.SearchVerticesMatchContext(context.Background(), "keyword", 5, "", search.MatchOptions{}, false, search.Budget{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(scoped) != 5 || len(global) != 5 {
+			t.Fatalf("result sizes: scoped=%d global=%d, want 5/5", len(scoped), len(global))
+		}
+		if scopedStats.CandidateVisits != 10 {
+			t.Fatalf("scoped candidate visits=%d, want prefix population 10", scopedStats.CandidateVisits)
+		}
+		if globalStats.CandidateVisits != 2010 {
+			t.Fatalf("global candidate visits=%d, want corpus population 2010", globalStats.CandidateVisits)
+		}
+		if scopedStats.PostingVisits >= globalStats.PostingVisits/10 {
+			t.Fatalf("prefix pushdown did not bound posting work: scoped=%d global=%d", scopedStats.PostingVisits, globalStats.PostingVisits)
 		}
 	})
 

--- a/core/search/budget.go
+++ b/core/search/budget.go
@@ -15,6 +15,8 @@ const (
 	WorkPostingVisits    WorkKind = "posting_visits"
 	WorkPositionVisits   WorkKind = "position_visits"
 	WorkExpirationVisits WorkKind = "expiration_visits"
+	WorkCandidateVisits  WorkKind = "candidate_visits"
+	WorkCandidateSkips   WorkKind = "candidate_skips"
 )
 
 // ErrBudgetExceeded classifies deterministic query-work exhaustion.
@@ -37,6 +39,8 @@ type Stats struct {
 	PostingVisits    int64
 	PositionVisits   int64
 	ExpirationVisits int64
+	CandidateVisits  int64
+	CandidateSkips   int64
 }
 
 // BudgetExceededError records which stable counter exhausted its limit.
@@ -66,6 +70,9 @@ func newWorkTracker(ctx context.Context, budget Budget) *workTracker {
 
 func (w *workTracker) check() error { return w.ctx.Err() }
 
+func (w *workTracker) candidateVisit() error { return w.visit(WorkCandidateVisits, 1) }
+func (w *workTracker) candidateSkip() error  { return w.visit(WorkCandidateSkips, 1) }
+
 func (w *workTracker) visit(kind WorkKind, n int64) error {
 	if err := w.ctx.Err(); err != nil {
 		return err
@@ -83,6 +90,10 @@ func (w *workTracker) visit(kind WorkKind, n int64) error {
 		value, limit = &w.stats.PositionVisits, w.budget.MaxPositionVisits
 	case WorkExpirationVisits:
 		value, limit = &w.stats.ExpirationVisits, w.budget.MaxExpirationVisits
+	case WorkCandidateVisits:
+		value = &w.stats.CandidateVisits
+	case WorkCandidateSkips:
+		value = &w.stats.CandidateSkips
 	default:
 		panic("search: unknown work kind")
 	}

--- a/core/search/budget_test.go
+++ b/core/search/budget_test.go
@@ -112,8 +112,8 @@ func TestContextCancellationObservedInsideSearchLoops(t *testing.T) {
 			plain.Index(fmt.Sprintf("doc-%03d", i), Text("alpha"))
 		}
 		results, stats, err := plain.SearchMatchTopKContext(newStepCancelContext(110), "alpha", 10, nil, MatchOptions{}, Budget{})
-		if results != nil || !errors.Is(err, context.Canceled) || stats.PostingVisits != 100 {
-			t.Fatalf("results=%v stats=%+v err=%v, want cancellation during selection", results, stats, err)
+		if results != nil || !errors.Is(err, context.Canceled) || stats.CandidateVisits == 0 {
+			t.Fatalf("results=%v stats=%+v err=%v, want cancellation during candidate execution", results, stats, err)
 		}
 	})
 }

--- a/core/search/executor.go
+++ b/core/search/executor.go
@@ -1,0 +1,459 @@
+package search
+
+import (
+	"container/heap"
+	"math"
+	"sort"
+
+	"github.com/RoaringBitmap/roaring/v2"
+)
+
+// CandidateSource streams a distinct set of document IDs into a bounded
+// top-k query. A layered store can use it to push a selective secondary-index
+// scope (for example a key-prefix radix) into retrieval instead of scoring the
+// global posting union and filtering afterwards. The source is consumed
+// synchronously while the index read lock is held; it must not call an index
+// write method.
+type CandidateSource[S comparable] func(yield func(S) bool)
+
+type scoringTerm struct {
+	class TokenClass
+	pl    *postingList
+	df    int
+}
+
+type scoringClause struct {
+	class TokenClass
+	terms []scoringTerm
+}
+
+type scoringPlan struct {
+	clauses   []scoringClause
+	wordCount int
+	threshold int
+	proximity []*postingList
+}
+
+type executorScratch struct {
+	positions [][]uint32
+	present   [][]uint32
+	pointers  []int
+}
+
+func (s *executorScratch) decode(lists []*postingList, ord uint32, work *workTracker) ([][]uint32, error) {
+	if len(s.positions) < len(lists) {
+		s.positions = append(s.positions, make([][]uint32, len(lists)-len(s.positions))...)
+	}
+	s.present = s.present[:0]
+	for i, pl := range lists {
+		s.positions[i] = pl.positionsInto(ord, s.positions[i])
+		if len(s.positions[i]) == 0 {
+			continue
+		}
+		if err := work.visit(WorkPositionVisits, int64(len(s.positions[i]))); err != nil {
+			return nil, err
+		}
+		s.present = append(s.present, s.positions[i])
+	}
+	return s.present, nil
+}
+
+func (idx *InvertedIndex[S, D]) buildScoringPlanLocked(queryTerms []Token, opts MatchOptions, work *workTracker) (scoringPlan, error) {
+	var raw []queryClause
+	if opts.expandsTerms() {
+		var err error
+		raw, err = idx.buildClausesTrackedLocked(queryTerms, opts, work)
+		if err != nil {
+			return scoringPlan{}, err
+		}
+	} else {
+		raw = make([]queryClause, 0, len(queryTerms))
+		for _, token := range queryTerms {
+			if int(token.Class) >= numTokenClasses {
+				continue
+			}
+			var ids []uint32
+			if tid, ok := idx.classes[token.Class].dict.lookup(token.Term); ok {
+				ids = []uint32{tid}
+			}
+			raw = append(raw, queryClause{class: token.Class, termIDs: ids})
+		}
+	}
+
+	plan := scoringPlan{clauses: make([]scoringClause, 0, len(raw))}
+	for _, clause := range raw {
+		if err := work.check(); err != nil {
+			return scoringPlan{}, err
+		}
+		resolved := scoringClause{class: clause.class, terms: make([]scoringTerm, 0, len(clause.termIDs))}
+		if clause.class == ClassWord {
+			plan.wordCount++
+		}
+		cp := &idx.classes[clause.class]
+		for _, tid := range clause.termIDs {
+			if pl := cp.postings[tid]; pl != nil {
+				resolved.terms = append(resolved.terms, scoringTerm{class: clause.class, pl: pl, df: pl.cardinality()})
+			}
+		}
+		plan.clauses = append(plan.clauses, resolved)
+	}
+	plan.threshold = coverageThreshold(opts, plan.wordCount)
+
+	if idx.positions && idx.proximityWeight != 0 {
+		cp := &idx.classes[ClassWord]
+		for _, token := range queryTerms {
+			if token.Class != ClassWord {
+				continue
+			}
+			if tid, ok := cp.dict.lookup(token.Term); ok {
+				if pl := cp.postings[tid]; pl != nil {
+					plan.proximity = append(plan.proximity, pl)
+				}
+			}
+		}
+	}
+	return plan, nil
+}
+
+func (idx *InvertedIndex[S, D]) scoreCandidateLocked(ord uint32, plan scoringPlan, scratch *executorScratch, work *workTracker, chargeProbes bool) (float64, bool, error) {
+	entry, ok := idx.docs[ord]
+	if !ok {
+		return 0, false, nil
+	}
+	var score float64
+	matched := false
+	coverage := 0
+	poisoned := false
+	for _, clause := range plan.clauses {
+		if err := work.check(); err != nil {
+			return 0, false, err
+		}
+		clauseMatched := false
+		cp := &idx.classes[clause.class]
+		if cp.docCount == 0 {
+			continue
+		}
+		avgLen := float64(cp.totalLen) / float64(cp.docCount)
+		for _, term := range clause.terms {
+			if chargeProbes {
+				if err := work.visit(WorkPostingVisits, 1); err != nil {
+					return 0, false, err
+				}
+			}
+			if !term.pl.docs.Contains(ord) {
+				continue
+			}
+			matched = true
+			clauseMatched = true
+			contribution := idx.scorer.Score(TermStats{
+				TF:     term.pl.tf(ord),
+				DF:     term.df,
+				N:      cp.docCount,
+				DocLen: entry.lengths[term.class],
+				AvgLen: avgLen,
+				Class:  term.class,
+			})
+			if math.IsNaN(contribution) || math.IsInf(contribution, 0) {
+				poisoned = true
+				continue
+			}
+			if !poisoned {
+				score += contribution
+				if math.IsNaN(score) || math.IsInf(score, 0) {
+					poisoned = true
+				}
+			}
+		}
+		if clause.class == ClassWord && clauseMatched {
+			coverage++
+		}
+	}
+	if !matched || coverage < plan.threshold || poisoned {
+		return 0, false, nil
+	}
+	if len(plan.proximity) >= 2 {
+		present, err := scratch.decode(plan.proximity, ord, work)
+		if err != nil {
+			return 0, false, err
+		}
+		if len(present) >= 2 {
+			if len(scratch.pointers) < len(present) {
+				scratch.pointers = make([]int, len(present))
+			}
+			window, err := smallestWindowWithPointersTracked(present, scratch.pointers[:len(present)], work)
+			if err != nil {
+				return 0, false, err
+			}
+			if window >= 0 {
+				span := window - (len(present) - 1)
+				if span < 0 {
+					span = 0
+				}
+				score += idx.proximityWeight * float64(len(present)-1) / float64(span+1)
+			}
+		}
+	}
+	if math.IsNaN(score) || math.IsInf(score, 0) {
+		return 0, false, nil
+	}
+	return score, true, nil
+}
+
+type postingCursor struct {
+	it      roaring.IntPeekable
+	current uint32
+}
+
+type postingCursorHeap []*postingCursor
+
+func (h postingCursorHeap) Len() int           { return len(h) }
+func (h postingCursorHeap) Less(i, j int) bool { return h[i].current < h[j].current }
+func (h postingCursorHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *postingCursorHeap) Push(x any)        { *h = append(*h, x.(*postingCursor)) }
+func (h *postingCursorHeap) Pop() any {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func (idx *InvertedIndex[S, D]) executeTopKLocked(plan scoringPlan, k int, accept func(S) bool, source CandidateSource[S], work *workTracker) ([]Result[S], error) {
+	h := topKHeap[S]{entries: make([]Result[S], 0, k), better: idx.betterResult}
+	var scratch executorScratch
+	visit := func(ord uint32, chargeProbes bool) error {
+		if err := work.candidateVisit(); err != nil {
+			return err
+		}
+		entry, ok := idx.docs[ord]
+		if !ok {
+			return work.candidateSkip()
+		}
+		if accept != nil && !accept(entry.id) {
+			return work.candidateSkip()
+		}
+		score, matched, err := idx.scoreCandidateLocked(ord, plan, &scratch, work, chargeProbes)
+		if err != nil {
+			return err
+		}
+		if !matched {
+			return work.candidateSkip()
+		}
+		candidate := Result[S]{ID: entry.id, Score: score}
+		if len(h.entries) == k && !idx.betterResult(candidate, h.entries[0]) {
+			return nil
+		}
+		if len(h.entries) < k {
+			heap.Push(&h, candidate)
+		} else {
+			h.entries[0] = candidate
+			heap.Fix(&h, 0)
+		}
+		return nil
+	}
+
+	var executionErr error
+	if source != nil {
+		source(func(id S) bool {
+			ord, ok := idx.ords.lookup(id)
+			if !ok {
+				if err := work.candidateVisit(); err != nil {
+					executionErr = err
+					return false
+				}
+				if err := work.candidateSkip(); err != nil {
+					executionErr = err
+					return false
+				}
+				return true
+			}
+			if err := visit(ord, true); err != nil {
+				executionErr = err
+				return false
+			}
+			return true
+		})
+	} else {
+		cursors := make(postingCursorHeap, 0)
+		for _, clause := range plan.clauses {
+			for _, term := range clause.terms {
+				it := term.pl.docs.Iterator()
+				if it.HasNext() {
+					if err := work.visit(WorkPostingVisits, 1); err != nil {
+						return nil, err
+					}
+					cursors = append(cursors, &postingCursor{it: it, current: it.Next()})
+				}
+			}
+		}
+		heap.Init(&cursors)
+		for len(cursors) > 0 {
+			ord := cursors[0].current
+			if err := visit(ord, false); err != nil {
+				return nil, err
+			}
+			for len(cursors) > 0 && cursors[0].current == ord {
+				cursor := heap.Pop(&cursors).(*postingCursor)
+				if cursor.it.HasNext() {
+					if err := work.visit(WorkPostingVisits, 1); err != nil {
+						return nil, err
+					}
+					cursor.current = cursor.it.Next()
+					heap.Push(&cursors, cursor)
+				}
+			}
+		}
+	}
+	if executionErr != nil {
+		return nil, executionErr
+	}
+	if len(h.entries) == 0 {
+		return nil, nil
+	}
+	out := h.entries
+	sort.Slice(out, func(i, j int) bool { return idx.betterResult(out[i], out[j]) })
+	return out, nil
+}
+
+func (idx *InvertedIndex[S, D]) executePhraseTopKLocked(terms []string, k int, accept func(S) bool, source CandidateSource[S], work *workTracker) ([]Result[S], error) {
+	cp := &idx.classes[ClassWord]
+	if cp.docCount == 0 {
+		return nil, nil
+	}
+	lists := make([]*postingList, len(terms))
+	for i, term := range terms {
+		if err := work.check(); err != nil {
+			return nil, err
+		}
+		tid, ok := cp.dict.lookup(term)
+		if !ok || cp.postings[tid] == nil {
+			return nil, nil
+		}
+		lists[i] = cp.postings[tid]
+	}
+	distinct := make([]*postingList, 0, len(terms))
+	seen := make(map[string]struct{}, len(terms))
+	for i, term := range terms {
+		if _, ok := seen[term]; ok {
+			continue
+		}
+		seen[term] = struct{}{}
+		distinct = append(distinct, lists[i])
+	}
+	avgLen := float64(cp.totalLen) / float64(cp.docCount)
+	h := topKHeap[S]{entries: make([]Result[S], 0, k), better: idx.betterResult}
+	var scratch executorScratch
+	visit := func(ord uint32, chargeProbes bool) error {
+		if err := work.candidateVisit(); err != nil {
+			return err
+		}
+		entry, ok := idx.docs[ord]
+		if !ok {
+			return work.candidateSkip()
+		}
+		if accept != nil && !accept(entry.id) {
+			return work.candidateSkip()
+		}
+		for _, list := range lists {
+			if chargeProbes {
+				if err := work.visit(WorkPostingVisits, 1); err != nil {
+					return err
+				}
+			}
+			if !list.docs.Contains(ord) {
+				return work.candidateSkip()
+			}
+		}
+		positions, err := scratch.decode(lists, ord, work)
+		if err != nil {
+			return err
+		}
+		adjacent := phraseAdjacentDecoded(positions)
+		if !adjacent {
+			return work.candidateSkip()
+		}
+		var score float64
+		for _, list := range distinct {
+			contribution := idx.scorer.Score(TermStats{
+				TF: list.tf(ord), DF: list.cardinality(), N: cp.docCount,
+				DocLen: entry.lengths[ClassWord], AvgLen: avgLen, Class: ClassWord,
+			})
+			if math.IsNaN(contribution) || math.IsInf(contribution, 0) {
+				return work.candidateSkip()
+			}
+			score += contribution
+		}
+		if math.IsNaN(score) || math.IsInf(score, 0) {
+			return work.candidateSkip()
+		}
+		candidate := Result[S]{ID: entry.id, Score: score}
+		if len(h.entries) == k && !idx.betterResult(candidate, h.entries[0]) {
+			return nil
+		}
+		if len(h.entries) < k {
+			heap.Push(&h, candidate)
+		} else {
+			h.entries[0] = candidate
+			heap.Fix(&h, 0)
+		}
+		return nil
+	}
+
+	if source != nil {
+		var executionErr error
+		source(func(id S) bool {
+			ord, ok := idx.ords.lookup(id)
+			if !ok {
+				if executionErr = work.candidateVisit(); executionErr == nil {
+					executionErr = work.candidateSkip()
+				}
+				return executionErr == nil
+			}
+			executionErr = visit(ord, true)
+			return executionErr == nil
+		})
+		if executionErr != nil {
+			return nil, executionErr
+		}
+	} else {
+		rarest := lists[0]
+		for _, list := range lists[1:] {
+			if list.cardinality() < rarest.cardinality() {
+				rarest = list
+			}
+		}
+		for it := rarest.docs.Iterator(); it.HasNext(); {
+			if err := work.visit(WorkPostingVisits, 1); err != nil {
+				return nil, err
+			}
+			if err := visit(it.Next(), false); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if len(h.entries) == 0 {
+		return nil, nil
+	}
+	out := h.entries
+	sort.Slice(out, func(i, j int) bool { return idx.betterResult(out[i], out[j]) })
+	return out, nil
+}
+
+func phraseAdjacentDecoded(positions [][]uint32) bool {
+	if len(positions) < 2 {
+		return true
+	}
+	for _, start := range positions[0] {
+		matched := true
+		for i := 1; i < len(positions); i++ {
+			if !containsSortedU32(positions[i], start+uint32(i)) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}

--- a/core/search/executor_test.go
+++ b/core/search/executor_test.go
@@ -1,0 +1,220 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"slices"
+	"testing"
+	"time"
+)
+
+func exhaustiveTopK[S comparable](all []Result[S], k int, accept func(S) bool) []Result[S] {
+	out := make([]Result[S], 0, min(k, len(all)))
+	for _, result := range all {
+		if accept != nil && !accept(result.ID) {
+			continue
+		}
+		out = append(out, result)
+		if len(out) == k {
+			break
+		}
+	}
+	return out
+}
+
+func TestBoundedExecutorMatchesExhaustive(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	idx := NewInvertedIndex[string, Text](NewScriptAwareAnalyzer(), ClassWeighted{
+		Base: BM25{K1: DefaultBM25K1, B: DefaultBM25B}, GramWeight: DefaultGramWeight,
+	}, compareStringID, WithPositions(), WithIndexClock(func() time.Time { return now }))
+	rng := rand.New(rand.NewSource(1060))
+	words := []string{"alpha", "alpine", "beta", "better", "gamma", "garden", "delta", "search", "service", "vertex"}
+	ids := make([]string, 240)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("tenant-%02d/doc-%03d", i%12, i)
+		body := words[rng.Intn(len(words))] + " " + words[rng.Intn(len(words))] + " " + words[rng.Intn(len(words))]
+		if i%17 == 0 {
+			body += " alpha beta"
+		}
+		expiration := time.Time{}
+		if i%19 == 0 {
+			expiration = now.Add(time.Minute)
+		}
+		if err := idx.IndexWithExpiration(ids[i], Text(body), expiration); err != nil {
+			t.Fatal(err)
+		}
+	}
+	now = now.Add(2 * time.Minute)
+
+	tests := []struct {
+		query string
+		opts  MatchOptions
+	}{
+		{"alpha beta", MatchOptions{}},
+		{"alpha beta", MatchOptions{Mode: MatchAll}},
+		{"alpha beta gamma", MatchOptions{Mode: MatchMinShould, MinShouldMatch: 2}},
+		{"alp", MatchOptions{PrefixTerms: true}},
+		{"serch", MatchOptions{Fuzziness: 1}},
+		{"alp serch", MatchOptions{Mode: MatchAll, PrefixTerms: true, Fuzziness: 1}},
+	}
+	accepts := []func(string) bool{
+		nil,
+		func(id string) bool { return id[len(id)-1]%2 == 0 },
+	}
+	for _, tc := range tests {
+		full := idx.SearchMatch(tc.query, tc.opts)
+		for _, k := range []int{1, 7, 31, 500} {
+			for _, accept := range accepts {
+				got, _, err := idx.SearchMatchTopKContext(context.Background(), tc.query, k, accept, tc.opts, Budget{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := exhaustiveTopK(full, k, accept)
+				if !slices.Equal(got, want) {
+					t.Fatalf("query=%q opts=%+v k=%d:\n got  %v\n want %v", tc.query, tc.opts, k, got, want)
+				}
+			}
+		}
+
+		scopedIDs := make([]string, 0, len(ids)/12)
+		for _, id := range ids {
+			if len(id) >= len("tenant-03/") && id[:len("tenant-03/")] == "tenant-03/" {
+				scopedIDs = append(scopedIDs, id)
+			}
+		}
+		source := CandidateSource[string](func(yield func(string) bool) {
+			for _, id := range scopedIDs {
+				if !yield(id) {
+					return
+				}
+			}
+		})
+		got, stats, err := idx.SearchMatchTopKCandidatesContextAt(context.Background(), tc.query, 13, nil, tc.opts, Budget{}, time.Now(), source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		inScope := func(id string) bool { return id[:len("tenant-03/")] == "tenant-03/" }
+		want := exhaustiveTopK(full, 13, inScope)
+		if !slices.Equal(got, want) {
+			t.Fatalf("scoped query=%q opts=%+v:\n got  %v\n want %v", tc.query, tc.opts, got, want)
+		}
+		if stats.CandidateVisits != int64(len(scopedIDs)) {
+			t.Fatalf("scoped query=%q candidate visits=%d, want %d", tc.query, stats.CandidateVisits, len(scopedIDs))
+		}
+	}
+
+	t.Run("randomized modes and expansions", func(t *testing.T) {
+		for trial := 0; trial < 100; trial++ {
+			queryTerms := 1 + rng.Intn(3)
+			query := words[rng.Intn(len(words))]
+			for i := 1; i < queryTerms; i++ {
+				query += " " + words[rng.Intn(len(words))]
+			}
+			opts := MatchOptions{Mode: MatchMode(rng.Intn(3))}
+			if opts.Mode == MatchMinShould {
+				opts.MinShouldMatch = 1 + rng.Intn(queryTerms)
+			}
+			switch rng.Intn(4) {
+			case 1:
+				opts.PrefixTerms = true
+			case 2:
+				opts.Fuzziness = 1
+			case 3:
+				opts.PrefixTerms = true
+				opts.Fuzziness = 1
+			}
+			k := 1 + rng.Intn(40)
+			accept := func(id string) bool { return id[len(id)-1]%3 != 0 }
+			want := exhaustiveTopK(idx.SearchMatch(query, opts), k, accept)
+			got, _, err := idx.SearchMatchTopKContext(context.Background(), query, k, accept, opts, Budget{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Equal(got, want) {
+				t.Fatalf("trial=%d query=%q opts=%+v k=%d:\n got  %v\n want %v", trial, query, opts, k, got, want)
+			}
+		}
+	})
+}
+
+func TestBoundedPhraseExecutorMatchesExhaustive(t *testing.T) {
+	idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID, WithPositions())
+	for i := 0; i < 120; i++ {
+		body := "alpha gap beta"
+		if i%3 == 0 {
+			body = "alpha beta gamma"
+		}
+		if i%7 == 0 {
+			body = "beta alpha beta"
+		}
+		if err := idx.Index(fmt.Sprintf("scope-%d/doc-%03d", i%5, i), Text(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, query := range []string{"alpha beta", "beta alpha beta"} {
+		full := idx.SearchPhrase(query)
+		for _, k := range []int{1, 9, 200} {
+			got := idx.SearchPhraseTopK(query, k, nil)
+			want := exhaustiveTopK(full, k, nil)
+			if !slices.Equal(got, want) {
+				t.Fatalf("query=%q k=%d:\n got  %v\n want %v", query, k, got, want)
+			}
+		}
+		source := CandidateSource[string](func(yield func(string) bool) {
+			for i := 0; i < 120; i++ {
+				if i%5 == 2 && !yield(fmt.Sprintf("scope-%d/doc-%03d", i%5, i)) {
+					return
+				}
+			}
+		})
+		got, _, err := idx.SearchPhraseTopKCandidatesContextAt(context.Background(), query, 10, nil, Budget{}, time.Now(), source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := exhaustiveTopK(full, 10, func(id string) bool { return id[:len("scope-2/")] == "scope-2/" })
+		if !slices.Equal(got, want) {
+			t.Fatalf("scoped phrase=%q:\n got  %v\n want %v", query, got, want)
+		}
+	}
+}
+
+func TestBoundedTopKAllocationsDoNotScaleWithMatches(t *testing.T) {
+	build := func(n int) *InvertedIndex[string, Text] {
+		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID, WithPositions())
+		for i := 0; i < n; i++ {
+			if err := idx.Index(fmt.Sprintf("doc-%06d", i), Text("shared phrase")); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return idx
+	}
+	small := build(1_000)
+	large := build(20_000)
+	smallAllocs := testing.AllocsPerRun(5, func() { _ = small.SearchTopK("shared phrase", 10, nil) })
+	largeAllocs := testing.AllocsPerRun(5, func() { _ = large.SearchTopK("shared phrase", 10, nil) })
+	if largeAllocs > smallAllocs+4 {
+		t.Fatalf("allocations scale with matches: 1k=%0.1f 20k=%0.1f", smallAllocs, largeAllocs)
+	}
+}
+
+func BenchmarkBoundedTopKOneMillion(b *testing.B) {
+	for _, documents := range []int{1_000, 1_000_000} {
+		b.Run(fmt.Sprintf("documents=%d", documents), func(b *testing.B) {
+			idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID, WithPositions())
+			for i := 0; i < documents; i++ {
+				if err := idx.Index(fmt.Sprintf("doc-%07d", i), Text("shared phrase")); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				results := idx.SearchTopK("shared phrase", 10, nil)
+				if len(results) != 10 {
+					b.Fatalf("results=%d, want 10", len(results))
+				}
+			}
+		})
+	}
+}

--- a/core/search/inverted_index.go
+++ b/core/search/inverted_index.go
@@ -919,20 +919,18 @@ func (idx *InvertedIndex[S, D]) rankedResultsLocked(scores map[uint32]float64) [
 	return results
 }
 
-// SearchTopK is the bounded-selection sibling of Search (#841): it computes
-// the same OR-union BM25 scores but returns only the k highest-scoring
-// documents that satisfy accept, without materialising or fully sorting the
-// complete match set. With a bigram analyzer a short query can match most
-// of the corpus, so Search's O(M log M) sort over all M matches dominates
-// broad queries; SearchTopK selects with a size-k bounded heap in
-// O(M log k) time and O(k) result memory instead.
+// SearchTopK is the bounded-execution sibling of Search (#841/#1060): it
+// multiway-merges sorted postings, scores one document at a time, and retains
+// only the k highest-scoring accepted documents. It therefore avoids both the
+// exhaustive ordinal-to-score map and the complete result sort. Working memory
+// is O(k + query clauses), independent of the total match count M.
 //
-// accept gates a document BEFORE it can occupy one of the k slots, so
-// filtered-out documents (dead vertices, out-of-scope keys) never consume
-// the page budget — a full page of accepted hits is returned whenever one
-// exists. accept may be nil (accept everything). To keep accept calls off
-// the O(M) score loop it is consulted lazily, only when a candidate's score
-// qualifies it for the heap.
+// accept gates a document before scoring and before it can occupy one of the k
+// slots, so filtered-out documents (for example dead vertices) consume neither
+// scoring work nor page budget. accept may be nil (accept everything). A
+// layered store with a selective secondary index should use CandidateSource
+// through SearchMatchTopKCandidatesContextAt instead of expressing that scope
+// as an O(M) accept predicate.
 //
 // LOCK ORDER: accept runs while idx.mu is held for reading. The established
 // order is GraphCache.mu → idx.mu → (vertex-cache inner mutex): index writes
@@ -948,49 +946,6 @@ func (idx *InvertedIndex[S, D]) rankedResultsLocked(scores map[uint32]float64) [
 // SearchTopK is the MatchAny case of SearchMatchTopK.
 func (idx *InvertedIndex[S, D]) SearchTopK(query string, k int, accept func(id S) bool) []Result[S] {
 	return idx.SearchMatchTopK(query, k, accept, MatchOptions{})
-}
-
-// selectTopKLocked returns the k highest-scoring documents in scores that pass
-// accept, as a descending-ranked slice. It is the bounded-selection phase
-// shared by SearchTopK and SearchPhraseTopK: a size-k min-heap holds the
-// current best, and accept is consulted lazily only after a candidate clears
-// the same total-order boundary used by exhaustive ranking. Callers must hold
-// idx.mu; k > 0 is the caller's precondition.
-func (idx *InvertedIndex[S, D]) selectTopKLocked(scores map[uint32]float64, k int, accept func(id S) bool) []Result[S] {
-	out, _ := idx.selectTopKTrackedLocked(scores, k, accept, newWorkTracker(nil, Budget{}))
-	return out
-}
-
-func (idx *InvertedIndex[S, D]) selectTopKTrackedLocked(scores map[uint32]float64, k int, accept func(id S) bool, work *workTracker) ([]Result[S], error) {
-	h := topKHeap[S]{entries: make([]Result[S], 0, k), better: idx.betterResult}
-	for ord, score := range scores {
-		if err := work.check(); err != nil {
-			return nil, err
-		}
-		if math.IsNaN(score) || math.IsInf(score, 0) {
-			continue
-		}
-		id := idx.docs[ord].id
-		candidate := Result[S]{ID: id, Score: score}
-		if len(h.entries) == k && !idx.betterResult(candidate, h.entries[0]) {
-			continue
-		}
-		if accept != nil && !accept(id) {
-			continue
-		}
-		if len(h.entries) < k {
-			heap.Push(&h, candidate)
-			continue
-		}
-		h.entries[0] = candidate
-		heap.Fix(&h, 0)
-	}
-	if len(h.entries) == 0 {
-		return nil, nil
-	}
-	out := h.entries
-	sort.Slice(out, func(i, j int) bool { return idx.betterResult(out[i], out[j]) })
-	return out, nil
 }
 
 // topKHeap is the size-k min-heap behind SearchTopK: the root is the weakest

--- a/core/search/match_mode.go
+++ b/core/search/match_mode.go
@@ -76,8 +76,8 @@ func (idx *InvertedIndex[S, D]) SearchMatch(query string, opts MatchOptions) []R
 	return idx.rankedResultsLocked(scores)
 }
 
-// SearchMatchTopK is the bounded-selection sibling of SearchMatch, combining
-// its match mode with the size-k selection and accept gating of SearchTopK.
+// SearchMatchTopK is the bounded-execution sibling of SearchMatch, combining
+// its match mode with the streaming candidate execution and size-k heap of SearchTopK.
 // SearchTopK is SearchMatchTopK(query, k, accept, MatchOptions{}). The lock
 // order and accept contract are identical to SearchTopK. k <= 0, an unanalyzable
 // query, or zero accepted matches return nil.
@@ -96,6 +96,14 @@ func (idx *InvertedIndex[S, D]) SearchMatchTopKContext(ctx context.Context, quer
 // liveness instant. Layered stores use it to share one sampled now between
 // index expiration and their accept callback.
 func (idx *InvertedIndex[S, D]) SearchMatchTopKContextAt(ctx context.Context, query string, k int, accept func(id S) bool, opts MatchOptions, budget Budget, now time.Time) ([]Result[S], Stats, error) {
+	return idx.SearchMatchTopKCandidatesContextAt(ctx, query, k, accept, opts, budget, now, nil)
+}
+
+// SearchMatchTopKCandidatesContextAt is SearchMatchTopKContextAt with an
+// optional streaming candidate scope. Supplying a source makes retrieval score
+// only those IDs while retaining global corpus statistics, so filtering does
+// not silently change BM25 IDF or length normalization.
+func (idx *InvertedIndex[S, D]) SearchMatchTopKCandidatesContextAt(ctx context.Context, query string, k int, accept func(id S) bool, opts MatchOptions, budget Budget, now time.Time, candidates CandidateSource[S]) ([]Result[S], Stats, error) {
 	work := newWorkTracker(ctx, budget)
 	if idx.Health() != IndexHealthy {
 		return nil, work.stats, ErrIndexIncomplete
@@ -120,14 +128,11 @@ func (idx *InvertedIndex[S, D]) SearchMatchTopKContextAt(ctx context.Context, qu
 		return nil, work.stats, ErrIndexIncomplete
 	}
 
-	scores, err := idx.scoredMatchesTrackedLocked(queryTerms, opts, work)
+	plan, err := idx.buildScoringPlanLocked(queryTerms, opts, work)
 	if err != nil {
 		return nil, work.stats, err
 	}
-	if len(scores) == 0 {
-		return nil, work.stats, nil
-	}
-	results, err := idx.selectTopKTrackedLocked(scores, k, accept, work)
+	results, err := idx.executeTopKLocked(plan, k, accept, candidates, work)
 	if err != nil {
 		return nil, work.stats, err
 	}

--- a/core/search/phrase.go
+++ b/core/search/phrase.go
@@ -39,9 +39,10 @@ func (idx *InvertedIndex[S, D]) SearchPhrase(query string) []Result[S] {
 	return idx.rankedResultsLocked(scores)
 }
 
-// SearchPhraseTopK is the bounded-selection sibling of SearchPhrase, mirroring
-// SearchTopK (#841): it phrase-matches then returns only the k highest-scoring
-// documents that satisfy accept, without fully sorting the match set. accept
+// SearchPhraseTopK is the bounded-execution sibling of SearchPhrase, mirroring
+// SearchTopK (#841/#1060): it streams the rarest posting, verifies and scores
+// one phrase candidate at a time, and retains only the k highest-scoring
+// documents that satisfy accept. accept
 // gates a document before it can occupy one of the k slots (dead vertices,
 // out-of-scope keys) and may be nil (accept everything). The lock order and
 // accept contract are identical to SearchTopK. k <= 0, a query with no word
@@ -60,6 +61,13 @@ func (idx *InvertedIndex[S, D]) SearchPhraseTopKContext(ctx context.Context, que
 // SearchPhraseTopKContextAt is SearchPhraseTopKContext with an explicit
 // liveness instant shared with a layered store's accept callback.
 func (idx *InvertedIndex[S, D]) SearchPhraseTopKContextAt(ctx context.Context, query string, k int, accept func(id S) bool, budget Budget, now time.Time) ([]Result[S], Stats, error) {
+	return idx.SearchPhraseTopKCandidatesContextAt(ctx, query, k, accept, budget, now, nil)
+}
+
+// SearchPhraseTopKCandidatesContextAt is SearchPhraseTopKContextAt with an
+// optional streaming candidate scope. It keeps the same global BM25 corpus
+// statistics while avoiding work outside a selective layered-store scope.
+func (idx *InvertedIndex[S, D]) SearchPhraseTopKCandidatesContextAt(ctx context.Context, query string, k int, accept func(id S) bool, budget Budget, now time.Time, candidates CandidateSource[S]) ([]Result[S], Stats, error) {
 	work := newWorkTracker(ctx, budget)
 	if idx.Health() != IndexHealthy {
 		return nil, work.stats, ErrIndexIncomplete
@@ -84,18 +92,7 @@ func (idx *InvertedIndex[S, D]) SearchPhraseTopKContextAt(ctx context.Context, q
 		return nil, work.stats, ErrIndexIncomplete
 	}
 
-	ords, err := idx.phraseMatchTrackedLocked(terms, work)
-	if err != nil {
-		return nil, work.stats, err
-	}
-	if len(ords) == 0 {
-		return nil, work.stats, nil
-	}
-	scores, err := idx.scorePhraseTrackedLocked(terms, ords, work)
-	if err != nil {
-		return nil, work.stats, err
-	}
-	results, err := idx.selectTopKTrackedLocked(scores, k, accept, work)
+	results, err := idx.executePhraseTopKLocked(terms, k, accept, candidates, work)
 	if err != nil {
 		return nil, work.stats, err
 	}

--- a/core/search/posting.go
+++ b/core/search/posting.go
@@ -96,7 +96,17 @@ func (p *postingList) positionsOf(ord uint32) []uint32 {
 	if p.positions == nil {
 		return nil
 	}
-	return unpackPositions(p.positions[ord])
+	return unpackPositionsInto(nil, p.positions[ord])
+}
+
+// positionsInto decodes ord's positions into dst, reusing its capacity. The
+// bounded query executor keeps one scratch slice per query term so positional
+// work does not allocate once per matching document.
+func (p *postingList) positionsInto(ord uint32, dst []uint32) []uint32 {
+	if p.positions == nil {
+		return nil
+	}
+	return unpackPositionsInto(dst[:0], p.positions[ord])
 }
 
 // packPositions delta+varint encodes an ascending position slice: the first
@@ -121,11 +131,18 @@ func packPositions(positions []uint32) []byte {
 // into the ascending absolute positions. It returns nil for empty input (a
 // document that carries no positions for the term).
 func unpackPositions(b []byte) []uint32 {
+	return unpackPositionsInto(nil, b)
+}
+
+func unpackPositionsInto(dst []uint32, b []byte) []uint32 {
 	if len(b) == 0 {
-		return nil
+		return dst[:0]
 	}
 	// Each position occupies at least one byte, so len(b) bounds the count.
-	out := make([]uint32, 0, len(b))
+	out := dst
+	if cap(out) < len(b) {
+		out = make([]uint32, 0, len(b))
+	}
 	var acc uint32
 	for i := 0; i < len(b); {
 		delta, n := binary.Uvarint(b[i:])

--- a/core/search/posting_test.go
+++ b/core/search/posting_test.go
@@ -105,6 +105,17 @@ func TestPackPositions(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("decode reuses caller scratch", func(t *testing.T) {
+		dst := make([]uint32, 0, 8)
+		got := unpackPositionsInto(dst, packPositions([]uint32{2, 5, 9}))
+		if !slices.Equal(got, []uint32{2, 5, 9}) {
+			t.Fatalf("decoded = %v", got)
+		}
+		if &got[0] != &dst[:1][0] {
+			t.Fatal("decode replaced sufficient caller scratch")
+		}
+	})
 }
 func TestOrdinals(t *testing.T) {
 	o := newOrdinals[string]()

--- a/core/search/proximity.go
+++ b/core/search/proximity.go
@@ -109,6 +109,11 @@ func smallestWindow(lists [][]uint32) int {
 
 func smallestWindowTracked(lists [][]uint32, work *workTracker) (int, error) {
 	ptr := make([]int, len(lists))
+	return smallestWindowWithPointersTracked(lists, ptr, work)
+}
+
+func smallestWindowWithPointersTracked(lists [][]uint32, ptr []int, work *workTracker) (int, error) {
+	clear(ptr)
 	best := -1
 	for {
 		if err := work.check(); err != nil {

--- a/docs/decisions/0005-bounded-top-k-retrieval.md
+++ b/docs/decisions/0005-bounded-top-k-retrieval.md
@@ -1,0 +1,55 @@
+# 0005: Stream exact top-k retrieval and preserve global BM25 statistics
+
+Status: Accepted
+
+## Context
+
+The first bounded `SearchVertices(limit=k)` implementation replaced a complete
+result sort with a size-`k` heap, but it still built an
+`O(total matches)` ordinal-to-score map before selection. A selective key
+prefix was also evaluated after global scoring, so one tenant's query work and
+temporary heap grew with every out-of-scope tenant.
+
+Prefix scoping raises a separate relevance choice: statistics could describe
+either the complete live corpus or only the prefix subtree. Changing `N`,
+`DF`, or average document length per prefix would change score bits and ranking
+relative to the existing API.
+
+## Decision
+
+Top-k search uses an exact document-at-a-time executor. For an unscoped query,
+it multiway-merges the sorted posting iterators and scores each distinct
+candidate once. Match-mode coverage, fuzzy/prefix-expanded clauses, class
+weights, and proximity are evaluated for that candidate before a size-`k`
+heap retains it. Phrase search streams the rarest posting and verifies the
+remaining postings and positions one candidate at a time. The exhaustive score
+map remains the test and benchmark oracle.
+
+A layered store may pass a streaming `CandidateSource` into core search.
+GraphCache uses the key-prefix radix as that source, establishing radix then
+inverted-index lock order and never materialising the prefix subtree as a
+bitmap or slice. Core search remains independent of GraphCache.
+
+Prefix defines membership only. BM25 `N`, `DF`, and average document length
+remain statistics of the complete live corpus after query-time expiration
+purge. This preserves the established score and ordering contract; a result
+does not acquire a different relevance score merely because the caller adds a
+prefix that still contains it.
+
+The executor records `candidate_visits` and `candidate_skips` alongside the
+existing posting, dictionary, position, and expiration counters. Existing
+posting/position budgets and context checkpoints bound the dominant work; an
+error returns no partial results.
+
+## Consequences
+
+- Unscoped top-k working memory is `O(k + query clauses/expansions)` and does
+  not grow with the number of matching documents.
+- Prefix-scoped work is proportional to prefix population times query
+  complexity, independent of the out-of-scope corpus.
+- Exact scores and the stable `(score DESC, key ASC)` boundary agree with the
+  exhaustive implementation, including match modes, expansions, phrase, and
+  proximity.
+- Prefix traversal holds a read lock for the synchronous query. Very large
+  prefixes can therefore delay prefix-index writers even though memory stays
+  bounded; work budgets and cancellation remain the operational escape hatch.

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -261,6 +261,8 @@ var (
 		string(search.WorkPostingVisits),
 		string(search.WorkPositionVisits),
 		string(search.WorkExpirationVisits),
+		string(search.WorkCandidateVisits),
+		string(search.WorkCandidateSkips),
 	}
 	// replicationApplyOps covers every pb.MutationOp oneof variant. The
 	// service layer translates the proto-internal case selector into one
@@ -1040,6 +1042,8 @@ func (m *DomainMetrics) OnSearchExecution(outcome, reason string, stats search.S
 		{string(search.WorkPostingVisits), stats.PostingVisits},
 		{string(search.WorkPositionVisits), stats.PositionVisits},
 		{string(search.WorkExpirationVisits), stats.ExpirationVisits},
+		{string(search.WorkCandidateVisits), stats.CandidateVisits},
+		{string(search.WorkCandidateSkips), stats.CandidateSkips},
 	} {
 		m.searchWork.WithLabelValues(item.kind).Observe(float64(item.value))
 	}

--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -307,12 +307,18 @@ func TestDomainMetrics_HotPathFamilies(t *testing.T) {
 	if got := histSampleCount(t, m.searchDuration); got != 1 {
 		t.Errorf("search_duration sample count = %v, want 1", got)
 	}
-	m.OnSearchExecution("resource_exhausted", string(search.WorkPostingVisits), search.Stats{PostingVisits: 17})
+	m.OnSearchExecution("resource_exhausted", string(search.WorkPostingVisits), search.Stats{PostingVisits: 17, CandidateVisits: 11, CandidateSkips: 3})
 	if got := testutil.ToFloat64(m.searchCalls.WithLabelValues("resource_exhausted", string(search.WorkPostingVisits))); got != 1 {
 		t.Errorf("search_calls_total{resource_exhausted,posting_visits} = %v, want 1", got)
 	}
 	if got := histSampleCount(t, m.searchWork.WithLabelValues(string(search.WorkPostingVisits))); got != 1 {
 		t.Errorf("search_work{posting_visits} sample count = %v, want 1", got)
+	}
+	if got := histSampleCount(t, m.searchWork.WithLabelValues(string(search.WorkCandidateVisits))); got != 1 {
+		t.Errorf("search_work{candidate_visits} sample count = %v, want 1", got)
+	}
+	if got := histSampleCount(t, m.searchWork.WithLabelValues(string(search.WorkCandidateSkips))); got != 1 {
+		t.Errorf("search_work{candidate_skips} sample count = %v, want 1", got)
 	}
 	m.OnSearchExecution("resource_exhausted", string(search.WorkExpirationVisits), search.Stats{ExpirationVisits: 5})
 	if got := histSampleCount(t, m.searchWork.WithLabelValues(string(search.WorkExpirationVisits))); got != 2 {

--- a/server/service/search.go
+++ b/server/service/search.go
@@ -62,6 +62,8 @@ func (s *LanternService) SearchVertices(ctx context.Context, in *pb.SearchVertic
 			attribute.Int64("lantern.search.posting_visits", stats.PostingVisits),
 			attribute.Int64("lantern.search.position_visits", stats.PositionVisits),
 			attribute.Int64("lantern.search.expiration_visits", stats.ExpirationVisits),
+			attribute.Int64("lantern.search.candidate_visits", stats.CandidateVisits),
+			attribute.Int64("lantern.search.candidate_skips", stats.CandidateSkips),
 		)
 	}()
 	if err := ctx.Err(); err != nil {

--- a/server/service/search_test.go
+++ b/server/service/search_test.go
@@ -395,7 +395,7 @@ func TestSearchVertices_RecordsBoundedTraceWork(t *testing.T) {
 	ctx, span := provider.Tracer("test").Start(context.Background(), "search")
 	fb := newFakeBackend()
 	fb.searchContextFn = func(context.Context) ([]search.Result[string], search.Stats, error) {
-		return nil, search.Stats{QueryTerms: 2, DictionaryVisits: 3, PostingVisits: 5, PositionVisits: 7}, nil
+		return nil, search.Stats{QueryTerms: 2, DictionaryVisits: 3, PostingVisits: 5, PositionVisits: 7, CandidateVisits: 11, CandidateSkips: 4}, nil
 	}
 	svc := NewLanternService(fb).WithSearchLimits(SearchLimits{Enabled: true, DefaultLimit: 10, MaxLimit: 100})
 	if _, err := svc.SearchVertices(ctx, &pb.SearchVerticesRequest{Query: "alpha beta"}); err != nil {
@@ -418,6 +418,8 @@ func TestSearchVertices_RecordsBoundedTraceWork(t *testing.T) {
 		"lantern.search.dictionary_visits": int64(3),
 		"lantern.search.posting_visits":    int64(5),
 		"lantern.search.position_visits":   int64(7),
+		"lantern.search.candidate_visits":  int64(11),
+		"lantern.search.candidate_skips":   int64(4),
 	} {
 		if got := attrs[key]; got != want {
 			t.Errorf("attribute %s = %#v, want %#v", key, got, want)

--- a/testbed/bench/scenarios/search_churn.yaml
+++ b/testbed/bench/scenarios/search_churn.yaml
@@ -8,8 +8,8 @@
 # - consistency: SearchVertices purges vertices whose TTL has expired but whose
 #   Flush has not yet run, so BM25 stats and vocabulary use the returned live
 #   corpus rather than merely hiding dead keys (#1057).
-# - execution budgets: separate broad-posting, fuzzy-dictionary, and broad-
-#   phrase producers exercise every dominant read-work family, including
+# - execution budgets: separate broad-posting, prefix-scoped, fuzzy-dictionary,
+#   and broad-phrase producers exercise every dominant read-work family, including
 #   expiration_visits as short TTLs mature, while the writer p99 exposes
 #   index-lock delay. The harness captures CPU, alloc, mutex, and block profiles
 #   around the same steady window (#1049, #1057).
@@ -39,8 +39,8 @@ phases:
   cooldown: 60s
 target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
-  # Four parallel streams per fan-out rule: one writer plus broad-posting,
-  # fuzzy-dictionary, and broad-phrase reads. per_rps = 500 rps each.
+  # Five parallel streams per fan-out rule: one writer plus broad-posting,
+  # prefix-scoped, fuzzy-dictionary, and broad-phrase reads. per_rps = 400 rps each.
   calls:
     # [0] short-TTL string vertex. The 50k key space is larger than the
     #     ~7.5k live set at 500 writes/s with 15s expirations, so keys are not
@@ -58,7 +58,13 @@ target:
       call: graph.v1.LanternService/SearchVertices
       data_template: |
         {"query":"shared","limit":20}
-    # [2] Both query clauses overflow the 50-term expansion cap independently:
+    # [2] A selective key scope exercises radix -> bounded retrieval pushdown.
+    #     Candidate visits must track this subtree, not the global live corpus.
+    - name: prefix_scoped
+      call: graph.v1.LanternService/SearchVertices
+      data_template: |
+        {"query":"shared","limit":20,"prefix":"search-000"}
+    # [3] Both query clauses overflow the 50-term expansion cap independently:
     #     topic matches every live topicNNNNN by prefix, and fuzz000 reaches all
     #     fuzz000..fuzz099 with fuzziness=2. Auxiliary grams still exercise the
     #     production script-aware ranking path around those word clauses.
@@ -66,7 +72,7 @@ target:
       call: graph.v1.LanternService/SearchVertices
       data_template: |
         {"query":"topic fuzz000","limit":20,"options":{"prefixTerms":true,"fuzziness":2}}
-    # [3] Broad positional intersection and adjacency verification.
+    # [4] Broad positional intersection and adjacency verification.
     - name: broad_phrase
       call: graph.v1.LanternService/SearchVertices
       data_template: |
@@ -85,5 +91,6 @@ perf_gate:
   producers:
     writer: { max_p99_ms: 2000, max_non_ok_ratio: 0.02 }
     broad_posting: { max_p99_ms: 4000, max_non_ok_ratio: 0.02 }
+    prefix_scoped: { max_p99_ms: 2000, max_non_ok_ratio: 0.02 }
     prefix_fuzzy_cap_overflow: { max_p99_ms: 4000, max_non_ok_ratio: 0.02 }
     broad_phrase: { max_p99_ms: 4000, max_non_ok_ratio: 0.02 }

--- a/tests/integration/search_vertices_test.go
+++ b/tests/integration/search_vertices_test.go
@@ -560,6 +560,67 @@ func TestSearchVertices_CancellationAndAdmissionOverWire(t *testing.T) {
 	}
 }
 
+func TestSearchVertices_PrefixCandidatePushdownOverRealH2C(t *testing.T) {
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Hour)
+	cache.EnablePrefixIndex(func(key string) string { return key })
+	cache.EnableSearchIndex(searchVertexDocument, strings.Compare)
+	expiration := time.Now().Add(time.Hour)
+	items := make([]graphcache.VertexItem[string, *pb.Vertex], 0, 2010)
+	for i := 0; i < 2000; i++ {
+		key := fmt.Sprintf("other/%04d", i)
+		items = append(items, graphcache.VertexItem[string, *pb.Vertex]{
+			Key: key, Value: &pb.Vertex{Key: key, Value: &pb.Vertex_String_{String_: "shared payload"}}, Expiration: expiration,
+		})
+	}
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("scope/%02d", i)
+		items = append(items, graphcache.VertexItem[string, *pb.Vertex]{
+			Key: key, Value: &pb.Vertex{Key: key, Value: &pb.Vertex_String_{String_: "shared payload"}}, Expiration: expiration,
+		})
+	}
+	if err := cache.PutVerticesWithExpiration(items); err != nil {
+		t.Fatal(err)
+	}
+
+	metrics := &wireSearchMetrics{executions: make(chan wireSearchExecution, 4)}
+	svc := service.NewLanternService(cache).WithSearchLimits(service.SearchLimits{
+		Enabled: true, PositionsEnabled: true, DefaultLimit: 10, MaxLimit: 100,
+	}).WithHotPathMetrics(metrics)
+	srv := newConnectTestServer(t, svc, nil)
+	c := graphv1connect.NewLanternServiceClient(h2cClient(), srv.url)
+
+	resp, err := c.SearchVertices(context.Background(), connect.NewRequest(&pb.SearchVerticesRequest{
+		Query: "shared", Prefix: "scope/", Limit: 5,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Msg.GetHits()) != 5 {
+		t.Fatalf("scoped hits=%d, want 5", len(resp.Msg.GetHits()))
+	}
+	for _, hit := range resp.Msg.GetHits() {
+		if !strings.HasPrefix(hit.GetKey(), "scope/") {
+			t.Fatalf("out-of-scope hit %q", hit.GetKey())
+		}
+	}
+	if observation := <-metrics.executions; observation.outcome != "ok" || observation.stats.CandidateVisits != 10 {
+		t.Fatalf("scoped execution=%+v, want 10 candidate visits", observation)
+	}
+
+	empty, err := c.SearchVertices(context.Background(), connect.NewRequest(&pb.SearchVerticesRequest{
+		Query: "shared", Prefix: "missing/", Limit: 5,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(empty.Msg.GetHits()) != 0 {
+		t.Fatalf("missing-prefix hits=%d, want 0", len(empty.Msg.GetHits()))
+	}
+	if observation := <-metrics.executions; observation.outcome != "ok" || observation.stats.CandidateVisits != 0 {
+		t.Fatalf("missing-prefix execution=%+v, want zero candidate visits", observation)
+	}
+}
+
 // newSearchSDKClient mirrors newSearchRawClient but returns the high-level
 // *client.Lantern so the SDK SearchVertices forwarder (#625) is exercised
 // against the real service handler — the SDK package itself keeps only


### PR DESCRIPTION
## What changed

- replace top-k's exhaustive `map[ordinal]score` with an exact document-at-a-time executor that multiway-merges sorted postings and retains only a size-`k` heap
- stream match-mode coverage, fuzzy/prefix-expanded clauses, proximity, and phrase verification with bounded reusable scratch
- push GraphCache key-prefix membership into core through a generic streaming `CandidateSource`, preserving the core -> graphcache dependency boundary
- expose `candidate_visits` / `candidate_skips` through search stats, Prometheus, and trace attributes
- document that prefix changes membership while BM25 `N`, `DF`, and average length remain global
- add exhaustive equivalence/property tests, allocation/race/cancellation coverage, real Connect/h2c coverage, and a prefix-scoped release-sweep producer

## Why

The prior size-`k` selection removed the final full sort but still materialized a score map for every match. Broad searches therefore allocated with corpus size, and selective namespace searches still scored out-of-scope tenants before filtering.

The new executor keeps working memory at `O(k + query clauses/expansions)`. Prefix-scoped work is proportional to the streamed radix scope times query complexity. Global BM25 statistics preserve existing score bits and ordering.

## Validation

- `gofmt -l .`
- `go vet ./...` in all six Go modules
- `go build ./...` in all six Go modules
- `go test ./...` in all six Go modules
- targeted `go test -race` for bounded search and concurrent prefix search/write/cancellation
- pinned `golangci-lint v2.12.2` on the branch diff: 0 issues
- Dart package format/analyze/test/dartdoc/publish dry-run and Flutter example format/analyze/test
- real Connect/h2c prefix pushdown happy path and empty-scope edge case
- 1K vs 1M documents, positions/proximity enabled, `k=10`: both `1,864 B/op`, `47 allocs/op`; 1M measured `535.6 ms/op`
- 1M benchmark process maximum resident set: `695,877,632` bytes including the complete in-memory corpus

Closes #1060
