### PR TITLE
feat(search): model structured vertex fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,9 +261,11 @@ because the bridge is not traversable.
 
 ### Full-text search over the same store
 
-`SearchVertices` runs relevance-ranked (BM25) full-text search over vertex
-*content* — key plus value — as the content-addressed counterpart to prefix
-scans. Hits use the stable total order `(score DESC, raw key ASC)` and make
+`SearchVertices` runs relevance-ranked (BM25) full-text search over separate
+vertex key and value fields as the content-addressed counterpart to prefix
+scans. Phrase/proximity never cross key/value or JSON string-leaf boundaries;
+edge-created endpoint vertices are immediately searchable by key. Hits use the
+stable total order `(score DESC, raw key ASC)` and make
 natural seeds for a follow-up `bfs`, `pagerank`, or `community` walk:
 
 ```shell

--- a/core/graphcache/batch.go
+++ b/core/graphcache/batch.go
@@ -102,7 +102,7 @@ func (c *GraphCache[S, T]) prepareSearchDocsBounded(items []VertexItem[S, T], in
 		}
 		preparation.ready[i] = true
 		if cache.IsLiveAt(items[i].Expiration, now) {
-			preparation.documents[i], _, preparation.errs[i] = c.searchIndex.Prepare(c.searchExtract(items[i].Value))
+			preparation.documents[i], _, preparation.errs[i] = c.searchIndex.Prepare(c.searchExtract(items[i].Key, items[i].Value))
 		}
 	}
 }

--- a/core/graphcache/batch_external_test.go
+++ b/core/graphcache/batch_external_test.go
@@ -22,14 +22,14 @@ func (d countingSearchDocument) String() string {
 	return d.text
 }
 
-func countingSearchExtract(d countingSearchDocument) search.Document { return d }
+func countingSearchExtract(_ string, d countingSearchDocument) search.Document { return d }
 
 func compareStringID(a, b string) int { return strings.Compare(a, b) }
 
 func TestPutVerticesWithExpiration_SearchBatchPreparation(t *testing.T) {
 	t.Run("one write lock and final duplicate state", func(t *testing.T) {
 		c := graphcache.NewGraphCache[string, string](time.Minute)
-		c.EnableSearchIndex(func(value string) search.Document { return search.Text(value) }, compareStringID)
+		c.EnableSearchIndex(func(_ string, value string) search.Document { return search.Text(value) }, compareStringID)
 		exp := time.Now().Add(time.Minute)
 		if err := c.PutVerticesWithExpiration([]graphcache.VertexItem[string, string]{
 			{Key: "gone", Value: "old gone", Expiration: exp},
@@ -133,7 +133,7 @@ func TestPutVerticesWithExpiration_SearchBatchPreparation(t *testing.T) {
 func TestPutVerticesWithExpiration_SearchBatchVisibility(t *testing.T) {
 	const documents = 128
 	c := graphcache.NewGraphCache[string, string](time.Minute)
-	c.EnableSearchIndex(func(value string) search.Document { return search.Text(value) }, compareStringID)
+	c.EnableSearchIndex(func(_ string, value string) search.Document { return search.Text(value) }, compareStringID)
 	exp := time.Now().Add(time.Minute)
 	items := make([]graphcache.VertexItem[string, string], documents)
 	keys := make([]string, documents)
@@ -386,7 +386,7 @@ func TestBatchAPIs_ReturnCounts(t *testing.T) {
 func TestDeleteVertices_ClearsPrefixAndSearchIndexes(t *testing.T) {
 	c := graphcache.NewGraphCache[string, string](time.Minute)
 	c.EnablePrefixIndex(func(k string) string { return k })
-	c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, strings.Compare)
+	c.EnableSearchIndex(func(_ string, v string) search.Document { return search.Text(v) }, strings.Compare)
 
 	c.PutVertex("ns:a", "alpha")
 	c.PutVertex("ns:b", "bravo")

--- a/core/graphcache/bench_test.go
+++ b/core/graphcache/bench_test.go
@@ -479,7 +479,7 @@ func BenchmarkPutVertex_Search(b *testing.B) {
 
 	b.Run("Indexed", func(b *testing.B) {
 		c := NewGraphCache[string, string](time.Hour)
-		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
+		c.EnableSearchIndex(func(_ string, v string) search.Document { return search.Text(v) }, compareStringID)
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -530,7 +530,7 @@ func BenchmarkSearchVertices(b *testing.B) {
 	const n = 5000
 	newSeeded := func() *GraphCache[string, string] {
 		c := NewGraphCache[string, string](time.Hour)
-		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
+		c.EnableSearchIndex(func(_ string, v string) search.Document { return search.Text(v) }, compareStringID)
 		c.EnablePrefixIndex(func(s string) string { return s })
 		exp := time.Now().Add(time.Hour)
 		for i := 0; i < n; i++ {
@@ -618,7 +618,7 @@ func BenchmarkDeleteVertices_Indexed(b *testing.B) {
 				b.StopTimer()
 				c := NewGraphCache[string, string](time.Hour)
 				c.EnablePrefixIndex(func(k string) string { return k })
-				c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
+				c.EnableSearchIndex(func(_ string, v string) search.Document { return search.Text(v) }, compareStringID)
 				vs := make([]VertexItem[string, string], n)
 				for i, k := range keys {
 					vs[i] = VertexItem[string, string]{Key: k, Value: benchSearchCorpus[i%len(benchSearchCorpus)], Expiration: exp}
@@ -653,7 +653,7 @@ func BenchmarkDeleteByPrefix_Indexed(b *testing.B) {
 				b.StopTimer()
 				c := NewGraphCache[string, string](time.Hour)
 				c.EnablePrefixIndex(func(k string) string { return k })
-				c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
+				c.EnableSearchIndex(func(_ string, v string) search.Document { return search.Text(v) }, compareStringID)
 				vs := make([]VertexItem[string, string], n)
 				for i, k := range keys {
 					vs[i] = VertexItem[string, string]{Key: k, Value: benchSearchCorpus[i%len(benchSearchCorpus)], Expiration: exp}
@@ -704,7 +704,7 @@ func BenchmarkPutVerticesIndexed(b *testing.B) {
 
 	b.Run("SearchEnabled", func(b *testing.B) {
 		c := NewGraphCache[string, string](time.Hour)
-		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
+		c.EnableSearchIndex(func(_ string, v string) search.Document { return search.Text(v) }, compareStringID)
 		items := makeBatch("k")
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -715,7 +715,7 @@ func BenchmarkPutVerticesIndexed(b *testing.B) {
 
 	b.Run("SearchEnabledParallel", func(b *testing.B) {
 		c := NewGraphCache[string, string](time.Hour)
-		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
+		c.EnableSearchIndex(func(_ string, v string) search.Document { return search.Text(v) }, compareStringID)
 		var worker atomic.Int64
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -779,7 +779,7 @@ func BenchmarkPutVerticesIndexedBatchPreparation(b *testing.B) {
 				if !positions {
 					opts = append(opts, WithoutSearchPositions())
 				}
-				c.EnableSearchIndex(func(value string) search.Document { return search.Text(value) }, compareStringID, opts...)
+				c.EnableSearchIndex(func(_ string, value string) search.Document { return search.Text(value) }, compareStringID, opts...)
 				if scenario.skipped {
 					if err := c.PutVerticesWithExpiration(items); err != nil {
 						b.Fatal(err)
@@ -829,7 +829,7 @@ func BenchmarkApplyPutVerticesHLC(b *testing.B) {
 	}
 	newCache := func() *GraphCache[string, string] {
 		c := NewGraphCache[string, string](time.Hour)
-		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
+		c.EnableSearchIndex(func(_ string, v string) search.Document { return search.Text(v) }, compareStringID)
 		return c
 	}
 	ts := hlc.Timestamp{WallNs: 1}

--- a/core/graphcache/cache.go
+++ b/core/graphcache/cache.go
@@ -61,8 +61,8 @@ type GraphCache[S comparable, T any] struct {
 	headByTail map[vertexID]*headIndex
 
 	// searchIndex is an optional secondary inverted index (see
-	// EnableSearchIndex) that ranks live vertices by how well their
-	// projected value matches a query (BM25). Like prefixIndex it is opt-in
+	// EnableSearchIndex) that ranks live vertices by how well their projected
+	// key and value fields match a query (BM25). Like prefixIndex it is opt-in
 	// and maintained under c.mu, but it differs in one way: it is refreshed
 	// on EVERY put, not just the first insert, because a vertex's value —
 	// and therefore its postings — changes on overwrite. Entries are dropped
@@ -72,7 +72,7 @@ type GraphCache[S comparable, T any] struct {
 	// the later cache Flush hook is an idempotent delete. When nil the put /
 	// evict paths pay only a single nil check.
 	searchIndex   *search.InvertedIndex[S, search.Document]
-	searchExtract func(T) search.Document
+	searchExtract func(S, T) search.Document
 	// searchCommitMu makes a prepared vertex batch visible to Search as one
 	// transition across both the vertex store and inverted index. Searches hold
 	// RLock across the same bounded execution interval that takes the index read
@@ -202,7 +202,7 @@ func (c *GraphCache[S, T]) putVertexLocked(key S, value T, expiration time.Time)
 func (c *GraphCache[S, T]) upsertVertexLocked(key S, value T, expiration time.Time) {
 	c.upsertVertexStorageLocked(key, value, expiration)
 	if c.searchIndex != nil {
-		if err := c.searchIndex.IndexWithExpiration(key, c.searchExtract(value), expiration); err != nil {
+		if err := c.searchIndex.IndexWithExpiration(key, c.searchExtract(key, value), expiration); err != nil {
 			c.searchIndex.MarkIncomplete()
 		}
 	}
@@ -276,12 +276,12 @@ func (c *GraphCache[S, T]) ensureVertexLocked(key S, expiration time.Time) {
 	if c.vertices.Has(key) {
 		return
 	}
-	if c.dict != nil {
+	var value T
+	physicallyExisted := c.vertices.UpsertWithExpiration(key, value, expiration)
+	if !physicallyExisted && c.dict != nil {
 		c.dict.intern(key)
 	}
-	var noop T
-	c.vertices.PutWithExpiration(key, noop, expiration)
-	c.onEndpointVertexCreatedLocked(key)
+	c.onEndpointVertexCreatedLocked(key, expiration, !physicallyExisted)
 }
 
 // GetVertex returns the live value stored for key. It is a point read that

--- a/core/graphcache/cache_test.go
+++ b/core/graphcache/cache_test.go
@@ -375,7 +375,7 @@ func TestGraphCache_PutVertexWithExpiration_BornExpired(t *testing.T) {
 	newCache := func() *GraphCache[string, string] {
 		c := NewGraphCache[string, string](time.Minute)
 		c.EnablePrefixIndex(func(s string) string { return s })
-		c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
+		c.EnableSearchIndex(func(_ string, v string) search.Document { return search.Text(v) }, compareStringID)
 		return c
 	}
 	past := time.Now().Add(-time.Hour)
@@ -1457,7 +1457,7 @@ func TestSearchIndexStats(t *testing.T) {
 		t.Errorf("disabled: got (%d, %d), want (0, 0)", terms, docs)
 	}
 
-	c.EnableSearchIndex(func(v string) search.Document { return search.Text(v) }, compareStringID)
+	c.EnableSearchIndex(func(_ string, v string) search.Document { return search.Text(v) }, compareStringID)
 	exp := time.Now().Add(time.Hour)
 	c.PutVertexWithExpiration("key:1", "hello world", exp)
 	c.PutVertexWithExpiration("key:2", "foo bar", exp)

--- a/core/graphcache/causality.go
+++ b/core/graphcache/causality.go
@@ -38,7 +38,7 @@ func (c *GraphCache[S, T]) PutVertexWithExpirationHLC(key S, value T, expiration
 	var prepared search.PreparedDocument
 	var prepErr error
 	if c.searchIndex != nil {
-		prepared, _, prepErr = c.searchIndex.Prepare(c.searchExtract(value))
+		prepared, _, prepErr = c.searchIndex.Prepare(c.searchExtract(key, value))
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/core/graphcache/indexes.go
+++ b/core/graphcache/indexes.go
@@ -1,5 +1,7 @@
 package graphcache
 
+import "time"
+
 // onVerticesEvicted keeps all vertex-owned side structures in sync with a batch
 // of vertex cache evictions. It is installed as cache.Cache.SetOnEvictMany and
 // may be invoked by Delete, DeleteMany, Clear, or Flush (a single-key Delete
@@ -20,11 +22,19 @@ func (c *GraphCache[S, T]) onVerticesEvicted(keys []S) {
 }
 
 // onEndpointVertexCreatedLocked updates the vertex-side indexes for an
-// auto-created edge endpoint. Endpoint creation records key existence for
-// prefix scans but deliberately does not index search content: the zero T value
-// is not an explicit user document. Caller must hold c.mu.
-func (c *GraphCache[S, T]) onEndpointVertexCreatedLocked(key S) {
-	c.insertVertexPrefixLocked(key)
+// auto-created edge endpoint. Prefix membership is inserted once per physical
+// slot; search projection runs on every creation/revival so an extractor can
+// emit a key-only document from (key, zero T). Caller must hold c.mu.
+func (c *GraphCache[S, T]) onEndpointVertexCreatedLocked(key S, expiration time.Time, firstInsert bool) {
+	if firstInsert {
+		c.insertVertexPrefixLocked(key)
+	}
+	if c.searchIndex != nil {
+		var value T
+		if err := c.searchIndex.IndexWithExpiration(key, c.searchExtract(key, value), expiration); err != nil {
+			c.searchIndex.MarkIncomplete()
+		}
+	}
 }
 
 func (c *GraphCache[S, T]) insertVertexPrefixLocked(key S) {

--- a/core/graphcache/search.go
+++ b/core/graphcache/search.go
@@ -38,12 +38,13 @@ func newSearchIndex[S comparable](positions bool, limits search.SearchAnalysisLi
 		Base:       search.BM25{K1: search.DefaultBM25K1, B: search.DefaultBM25B},
 		GramWeight: search.DefaultGramWeight,
 	}
+	fieldScorer := search.FieldWeighted{Base: scorer, KeyWeight: search.DefaultKeyFieldWeight, ValueWeight: 1}
 	var opts []search.IndexOption
 	if positions {
 		opts = append(opts, search.WithPositions())
 	}
 	opts = append(opts, search.WithAnalysisLimits(limits))
-	return search.NewInvertedIndex[S, search.Document](analyzer, scorer, compareID, opts...)
+	return search.NewInvertedIndex[S, search.Document](analyzer, fieldScorer, compareID, opts...)
 }
 
 // SearchIndexOption configures the optional content-search index at
@@ -77,8 +78,9 @@ func WithSearchAnalysisLimits(limits search.SearchAnalysisLimits) SearchIndexOpt
 }
 
 // EnableSearchIndex turns on the optional content-search index, projecting each
-// stored value T into the search.Document that gets indexed (for example the
-// vertex's string value). Like EnablePrefixIndex it must be called before any
+// stored (key, value) pair into the search.Document that gets indexed. Receiving
+// the key lets a structured projection index implicit endpoint vertices as
+// key-only documents. Like EnablePrefixIndex it must be called before any
 // vertex is stored, is idempotent, and panics on a non-empty cache so the
 // caller cannot silently observe an index that disagrees with point reads.
 // extract and compareID must not be nil. compareID is the stable ascending
@@ -94,7 +96,7 @@ func WithSearchAnalysisLimits(limits search.SearchAnalysisLimits) SearchIndexOpt
 // timing cannot affect live-corpus ranking.
 // The index is a third opt-in secondary structure alongside the prefix index;
 // when it is left disabled the put / evict hot paths pay only a nil check.
-func (c *GraphCache[S, T]) EnableSearchIndex(extract func(T) search.Document, compareID func(S, S) int, opts ...SearchIndexOption) {
+func (c *GraphCache[S, T]) EnableSearchIndex(extract func(S, T) search.Document, compareID func(S, S) int, opts ...SearchIndexOption) {
 	if extract == nil {
 		panic("graphcache: EnableSearchIndex extract must not be nil")
 	}
@@ -133,7 +135,7 @@ func (c *GraphCache[S, T]) rebuildSearchIndexLocked() error {
 	items := make([]search.PreparedItem[S], 0, c.vertices.Count())
 	var firstErr error
 	c.vertices.Range(func(key S, value T, expiration time.Time) bool {
-		prepared, _, err := c.searchIndex.Prepare(c.searchExtract(value))
+		prepared, _, err := c.searchIndex.Prepare(c.searchExtract(key, value))
 		if err != nil {
 			firstErr = err
 			return false

--- a/core/graphcache/search_test.go
+++ b/core/graphcache/search_test.go
@@ -18,8 +18,15 @@ import (
 
 // textExtract is the value projection used by the string-keyed tests: it makes
 // the stored string value itself the searchable document.
-func textExtract(s string) search.Document { return search.Text(s) }
-func compareStringID(a, b string) int      { return strings.Compare(a, b) }
+func textExtract(_ string, s string) search.Document { return search.Text(s) }
+func compareStringID(a, b string) int                { return strings.Compare(a, b) }
+func keyValueExtract(key, value string) search.Document {
+	fields := search.Fields{{ID: search.FieldKey, Text: key}}
+	if value != "" {
+		fields = append(fields, search.DocumentField{ID: search.FieldValue, Text: value})
+	}
+	return fields
+}
 
 func TestGraphCacheSearchAnalysisLimits(t *testing.T) {
 	limits := search.SearchAnalysisLimits{
@@ -396,6 +403,44 @@ func TestGraphCache_SearchVertices(t *testing.T) {
 		got := c.SearchVertices("keyword", 10, "user:")
 		if want := []string{"user:1", "user:2"}; !equalKeys(keys(got), want) {
 			t.Fatalf("SearchVertices(keyword, prefix user:) = %v, want %v", keys(got), want)
+		}
+	})
+
+	t.Run("Implicit endpoints are key-searchable and follow vertex lifecycle", func(t *testing.T) {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(keyValueExtract, compareStringID)
+		expiration := time.Now().Add(time.Hour)
+		c.AddEdgeWithExpiration("implicit-tail-unique", "implicit-head-unique", 1, expiration)
+		if got := keys(c.SearchVertices("tail", 10, "")); !equalKeys(got, []string{"implicit-tail-unique"}) {
+			t.Fatalf("implicit tail search = %v", got)
+		}
+		if got := keys(c.SearchVertices("head", 10, "")); !equalKeys(got, []string{"implicit-head-unique"}) {
+			t.Fatalf("implicit head search = %v", got)
+		}
+		if err := c.PutVertexWithExpiration("implicit-tail-unique", "explicit-content", expiration); err != nil {
+			t.Fatal(err)
+		}
+		if got := keys(c.SearchVertices("content", 10, "")); !equalKeys(got, []string{"implicit-tail-unique"}) {
+			t.Fatalf("explicit value search = %v", got)
+		}
+		if !c.DeleteVertex("implicit-tail-unique") {
+			t.Fatal("DeleteVertex returned false")
+		}
+		if got := c.SearchVertices("tail content", 10, ""); got != nil {
+			t.Fatalf("deleted endpoint remained searchable: %v", keys(got))
+		}
+
+		expiring := NewGraphCache[string, string](time.Minute)
+		expiring.EnableSearchIndex(keyValueExtract, compareStringID)
+		due := time.Now().Add(10 * time.Millisecond)
+		expiring.AddEdgeWithExpiration("revived-tail", "revived-head", 1, due)
+		time.Sleep(time.Until(due) + 5*time.Millisecond)
+		if got := expiring.SearchVertices("revived", 10, ""); got != nil {
+			t.Fatalf("expired endpoints searchable: %v", keys(got))
+		}
+		expiring.PutEdgeWithExpiration("revived-tail", "revived-head", 1, time.Now().Add(time.Hour))
+		if got := keys(expiring.SearchVertices("tail", 10, "")); !equalKeys(got, []string{"revived-tail"}) {
+			t.Fatalf("revived endpoint search = %v", got)
 		}
 	})
 

--- a/core/search/document.go
+++ b/core/search/document.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"strconv"
+	"strings"
 	"time"
 	"unicode/utf8"
 )
@@ -16,9 +17,55 @@ type Document interface {
 	String() string
 }
 
+// FieldID is a stable semantic search field. FieldDefault preserves the
+// single-text Document contract; FieldKey and FieldValue let layered stores
+// keep identifier and content evidence separate without importing their
+// domain types into core.
+type FieldID uint8
+
+const (
+	FieldDefault FieldID = iota
+	FieldKey
+	FieldValue
+	numDocumentFields
+)
+
+// DocumentField is one independently analyzed field instance. Multiple
+// FieldValue entries are allowed (for example JSON string leaves); phrase and
+// proximity never cross from one instance to another.
+type DocumentField struct {
+	ID   FieldID
+	Text string
+}
+
+// FieldedDocument exposes structured search fields. It remains a Document so
+// existing generic index bounds and diagnostics keep a plain-text fallback,
+// but Prepare uses SearchFields directly when this interface is present.
+type FieldedDocument interface {
+	Document
+	SearchFields() []DocumentField
+}
+
+// Fields is a convenient immutable FieldedDocument for callers that already
+// have projected text instances.
+type Fields []DocumentField
+
+func (f Fields) SearchFields() []DocumentField { return f }
+
+func (f Fields) String() string {
+	var b strings.Builder
+	for _, field := range f {
+		if b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(field.Text)
+	}
+	return b.String()
+}
+
 // SizedDocument can expose a cheap upper bound before String performs an
 // expensive projection. The production vertex projection uses it to reject a
-// large JSON/string payload before parsing or concatenating it.
+// large JSON/string payload before parsing or projecting its fields.
 type SizedDocument interface {
 	Document
 	SizeHint() int

--- a/core/search/executor.go
+++ b/core/search/executor.go
@@ -3,6 +3,7 @@ package search
 import (
 	"container/heap"
 	"math"
+	"slices"
 	"sort"
 
 	"github.com/RoaringBitmap/roaring/v2"
@@ -19,7 +20,6 @@ type CandidateSource[S comparable] func(yield func(S) bool)
 type scoringTerm struct {
 	class TokenClass
 	pl    *postingList
-	df    int
 }
 
 type scoringClause struct {
@@ -31,22 +31,24 @@ type scoringPlan struct {
 	clauses   []scoringClause
 	wordCount int
 	threshold int
-	proximity []*postingList
+	proximity [numDocumentFields][]*postingList
 }
 
 type executorScratch struct {
-	positions [][]uint32
-	present   [][]uint32
+	positions [][]uint64
+	present   [][]uint64
 	pointers  []int
+	instances []uint32
+	instance  [][]uint64
 }
 
-func (s *executorScratch) decode(lists []*postingList, ord uint32, work *workTracker) ([][]uint32, error) {
+func (s *executorScratch) decode(lists []*postingList, ord uint32, field FieldID, work *workTracker) ([][]uint64, error) {
 	if len(s.positions) < len(lists) {
-		s.positions = append(s.positions, make([][]uint32, len(lists)-len(s.positions))...)
+		s.positions = append(s.positions, make([][]uint64, len(lists)-len(s.positions))...)
 	}
 	s.present = s.present[:0]
 	for i, pl := range lists {
-		s.positions[i] = pl.positionsInto(ord, s.positions[i])
+		s.positions[i] = pl.positionsInto(ord, field, s.positions[i])
 		if len(s.positions[i]) == 0 {
 			continue
 		}
@@ -92,7 +94,7 @@ func (idx *InvertedIndex[S, D]) buildScoringPlanLocked(queryTerms []Token, opts 
 		cp := &idx.classes[clause.class]
 		for _, tid := range clause.termIDs {
 			if pl := cp.postings[tid]; pl != nil {
-				resolved.terms = append(resolved.terms, scoringTerm{class: clause.class, pl: pl, df: pl.cardinality()})
+				resolved.terms = append(resolved.terms, scoringTerm{class: clause.class, pl: pl})
 			}
 		}
 		plan.clauses = append(plan.clauses, resolved)
@@ -107,7 +109,9 @@ func (idx *InvertedIndex[S, D]) buildScoringPlanLocked(queryTerms []Token, opts 
 			}
 			if tid, ok := cp.dict.lookup(token.Term); ok {
 				if pl := cp.postings[tid]; pl != nil {
-					plan.proximity = append(plan.proximity, pl)
+					for field := FieldID(0); field < numDocumentFields; field++ {
+						plan.proximity[field] = append(plan.proximity[field], pl)
+					}
 				}
 			}
 		}
@@ -116,7 +120,7 @@ func (idx *InvertedIndex[S, D]) buildScoringPlanLocked(queryTerms []Token, opts 
 }
 
 func (idx *InvertedIndex[S, D]) scoreCandidateLocked(ord uint32, plan scoringPlan, scratch *executorScratch, work *workTracker, chargeProbes bool) (float64, bool, error) {
-	entry, ok := idx.docs[ord]
+	_, ok := idx.docs[ord]
 	if !ok {
 		return 0, false, nil
 	}
@@ -129,11 +133,9 @@ func (idx *InvertedIndex[S, D]) scoreCandidateLocked(ord uint32, plan scoringPla
 			return 0, false, err
 		}
 		clauseMatched := false
-		cp := &idx.classes[clause.class]
-		if cp.docCount == 0 {
+		if idx.classes[clause.class].docCount == 0 {
 			continue
 		}
-		avgLen := float64(cp.totalLen) / float64(cp.docCount)
 		for _, term := range clause.terms {
 			if chargeProbes {
 				if err := work.visit(WorkPostingVisits, 1); err != nil {
@@ -145,14 +147,7 @@ func (idx *InvertedIndex[S, D]) scoreCandidateLocked(ord uint32, plan scoringPla
 			}
 			matched = true
 			clauseMatched = true
-			contribution := idx.scorer.Score(TermStats{
-				TF:     term.pl.tf(ord),
-				DF:     term.df,
-				N:      cp.docCount,
-				DocLen: entry.lengths[term.class],
-				AvgLen: avgLen,
-				Class:  term.class,
-			})
+			contribution := idx.termScoreLocked(ord, term.class, term.pl)
 			if math.IsNaN(contribution) || math.IsInf(contribution, 0) {
 				poisoned = true
 				continue
@@ -171,32 +166,77 @@ func (idx *InvertedIndex[S, D]) scoreCandidateLocked(ord uint32, plan scoringPla
 	if !matched || coverage < plan.threshold || poisoned {
 		return 0, false, nil
 	}
-	if len(plan.proximity) >= 2 {
-		present, err := scratch.decode(plan.proximity, ord, work)
+	var bestProximity float64
+	for field := FieldID(0); field < numDocumentFields; field++ {
+		if len(plan.proximity[field]) < 2 {
+			continue
+		}
+		present, err := scratch.decode(plan.proximity[field], ord, field, work)
 		if err != nil {
 			return 0, false, err
 		}
-		if len(present) >= 2 {
-			if len(scratch.pointers) < len(present) {
-				scratch.pointers = make([]int, len(present))
-			}
-			window, err := smallestWindowWithPointersTracked(present, scratch.pointers[:len(present)], work)
-			if err != nil {
-				return 0, false, err
-			}
-			if window >= 0 {
-				span := window - (len(present) - 1)
-				if span < 0 {
-					span = 0
-				}
-				score += idx.proximityWeight * float64(len(present)-1) / float64(span+1)
-			}
+		bonus, err := scratch.proximityBonus(present, work)
+		if err != nil {
+			return 0, false, err
+		}
+		if bonus > bestProximity {
+			bestProximity = bonus
 		}
 	}
+	score += idx.proximityWeight * bestProximity
 	if math.IsNaN(score) || math.IsInf(score, 0) {
 		return 0, false, nil
 	}
 	return score, true, nil
+}
+
+func (s *executorScratch) proximityBonus(lists [][]uint64, work *workTracker) (float64, error) {
+	if len(lists) < 2 {
+		return 0, nil
+	}
+	s.instances = s.instances[:0]
+	for _, positions := range lists {
+		for _, position := range positions {
+			instance := uint32(position >> 32)
+			if len(s.instances) == 0 || s.instances[len(s.instances)-1] != instance {
+				s.instances = append(s.instances, instance)
+			}
+		}
+	}
+	slices.Sort(s.instances)
+	s.instances = slices.Compact(s.instances)
+	var best float64
+	for _, instance := range s.instances {
+		s.instance = s.instance[:0]
+		lo := uint64(instance) << 32
+		hi := lo | uint64(1<<32-1)
+		for _, positions := range lists {
+			start := sort.Search(len(positions), func(i int) bool { return positions[i] >= lo })
+			end := sort.Search(len(positions), func(i int) bool { return positions[i] > hi })
+			if start < end {
+				s.instance = append(s.instance, positions[start:end])
+			}
+		}
+		if len(s.instance) < 2 {
+			continue
+		}
+		if len(s.pointers) < len(s.instance) {
+			s.pointers = make([]int, len(s.instance))
+		}
+		window, err := smallestWindowWithPointersTracked(s.instance, s.pointers[:len(s.instance)], work)
+		if err != nil {
+			return 0, err
+		}
+		span := window - (len(s.instance) - 1)
+		if span < 0 {
+			span = 0
+		}
+		bonus := float64(len(s.instance)-1) / float64(span+1)
+		if bonus > best {
+			best = bonus
+		}
+	}
+	return best, nil
 }
 
 type postingCursor struct {
@@ -340,7 +380,6 @@ func (idx *InvertedIndex[S, D]) executePhraseTopKLocked(terms []string, k int, a
 		seen[term] = struct{}{}
 		distinct = append(distinct, lists[i])
 	}
-	avgLen := float64(cp.totalLen) / float64(cp.docCount)
 	h := topKHeap[S]{entries: make([]Result[S], 0, k), better: idx.betterResult}
 	var scratch executorScratch
 	visit := func(ord uint32, chargeProbes bool) error {
@@ -354,30 +393,35 @@ func (idx *InvertedIndex[S, D]) executePhraseTopKLocked(terms []string, k int, a
 		if accept != nil && !accept(entry.id) {
 			return work.candidateSkip()
 		}
-		for _, list := range lists {
-			if chargeProbes {
-				if err := work.visit(WorkPostingVisits, 1); err != nil {
-					return err
+		matchedPhrase := false
+		for field := FieldID(0); field < numDocumentFields && !matchedPhrase; field++ {
+			present := true
+			for _, list := range lists {
+				if chargeProbes {
+					if err := work.visit(WorkPostingVisits, 1); err != nil {
+						return err
+					}
+				}
+				if !list.containsField(ord, field) {
+					present = false
+					break
 				}
 			}
-			if !list.docs.Contains(ord) {
-				return work.candidateSkip()
+			if !present {
+				continue
 			}
+			positions, err := scratch.decode(lists, ord, field, work)
+			if err != nil {
+				return err
+			}
+			matchedPhrase = phraseAdjacentDecoded(positions)
 		}
-		positions, err := scratch.decode(lists, ord, work)
-		if err != nil {
-			return err
-		}
-		adjacent := phraseAdjacentDecoded(positions)
-		if !adjacent {
+		if !matchedPhrase {
 			return work.candidateSkip()
 		}
 		var score float64
 		for _, list := range distinct {
-			contribution := idx.scorer.Score(TermStats{
-				TF: list.tf(ord), DF: list.cardinality(), N: cp.docCount,
-				DocLen: entry.lengths[ClassWord], AvgLen: avgLen, Class: ClassWord,
-			})
+			contribution := idx.termScoreLocked(ord, ClassWord, list)
 			if math.IsNaN(contribution) || math.IsInf(contribution, 0) {
 				return work.candidateSkip()
 			}
@@ -439,14 +483,14 @@ func (idx *InvertedIndex[S, D]) executePhraseTopKLocked(terms []string, k int, a
 	return out, nil
 }
 
-func phraseAdjacentDecoded(positions [][]uint32) bool {
+func phraseAdjacentDecoded(positions [][]uint64) bool {
 	if len(positions) < 2 {
 		return true
 	}
 	for _, start := range positions[0] {
 		matched := true
 		for i := 1; i < len(positions); i++ {
-			if !containsSortedU32(positions[i], start+uint32(i)) {
+			if !containsSortedU64(positions[i], start+uint64(i)) {
 				matched = false
 				break
 			}

--- a/core/search/executor_test.go
+++ b/core/search/executor_test.go
@@ -179,6 +179,43 @@ func TestBoundedPhraseExecutorMatchesExhaustive(t *testing.T) {
 	}
 }
 
+func TestBoundedExecutorStructuredFieldsMatchExhaustive(t *testing.T) {
+	scorer := FieldWeighted{Base: BM25{K1: DefaultBM25K1, B: DefaultBM25B}, KeyWeight: DefaultKeyFieldWeight, ValueWeight: 1}
+	idx := NewInvertedIndex[string, Document](fakeAnalyzer{}, scorer, compareStringID, WithPositions())
+	for i := 0; i < 150; i++ {
+		doc := Fields{
+			{ID: FieldKey, Text: fmt.Sprintf("tenant%d alpha", i%7)},
+			{ID: FieldValue, Text: "beta gamma"},
+			{ID: FieldValue, Text: "delta alpha"},
+		}
+		if i%5 == 0 {
+			doc[1].Text = "alpha beta gamma"
+		}
+		if err := idx.Index(fmt.Sprintf("doc-%03d", i), doc); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, tc := range []struct {
+		query string
+		opts  MatchOptions
+	}{
+		{"alpha beta", MatchOptions{}},
+		{"alpha beta", MatchOptions{Mode: MatchAll}},
+		{"alp", MatchOptions{PrefixTerms: true}},
+		{"gama", MatchOptions{Fuzziness: 1}},
+	} {
+		want := exhaustiveTopK(idx.SearchMatch(tc.query, tc.opts), 17, nil)
+		got := idx.SearchMatchTopK(tc.query, 17, nil, tc.opts)
+		if !slices.Equal(got, want) {
+			t.Fatalf("query=%q opts=%+v:\n got  %v\n want %v", tc.query, tc.opts, got, want)
+		}
+	}
+	wantPhrase := exhaustiveTopK(idx.SearchPhrase("alpha beta"), 11, nil)
+	if got := idx.SearchPhraseTopK("alpha beta", 11, nil); !slices.Equal(got, wantPhrase) {
+		t.Fatalf("phrase:\n got  %v\n want %v", got, wantPhrase)
+	}
+}
+
 func TestBoundedTopKAllocationsDoNotScaleWithMatches(t *testing.T) {
 	build := func(n int) *InvertedIndex[string, Text] {
 		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID, WithPositions())

--- a/core/search/expiry.go
+++ b/core/search/expiry.go
@@ -91,10 +91,7 @@ func (idx *InvertedIndex[S, D]) purgeExpired(work *workTracker, now time.Time) e
 			heap.Pop(&idx.expirations)
 			continue
 		}
-		postingVisits := 0
-		for class := range entry.terms {
-			postingVisits += len(entry.terms[class])
-		}
+		postingVisits := entry.postingEntries
 		if err := work.visit(WorkPostingVisits, int64(postingVisits)); err != nil {
 			return err
 		}

--- a/core/search/fuzzy.go
+++ b/core/search/fuzzy.go
@@ -99,7 +99,6 @@ func (idx *InvertedIndex[S, D]) scoreClausesTrackedLocked(clauses []queryClause,
 		if cp.docCount == 0 || len(cl.termIDs) == 0 {
 			continue
 		}
-		avgLen := float64(cp.totalLen) / float64(cp.docCount)
 		var union *roaring.Bitmap
 		if coverage != nil && cl.class == ClassWord {
 			union = roaring.New()
@@ -109,7 +108,6 @@ func (idx *InvertedIndex[S, D]) scoreClausesTrackedLocked(clauses []queryClause,
 			if pl == nil {
 				continue
 			}
-			df := pl.cardinality()
 			for it := pl.docs.Iterator(); it.HasNext(); {
 				if err := work.visit(WorkPostingVisits, 1); err != nil {
 					return nil, err
@@ -118,14 +116,7 @@ func (idx *InvertedIndex[S, D]) scoreClausesTrackedLocked(clauses []queryClause,
 				if union != nil {
 					union.Add(ord)
 				}
-				addScore(scores, ord, idx.scorer.Score(TermStats{
-					TF:     pl.tf(ord),
-					DF:     df,
-					N:      cp.docCount,
-					DocLen: idx.docs[ord].lengths[cl.class],
-					AvgLen: avgLen,
-					Class:  cl.class,
-				}))
+				addScore(scores, ord, idx.termScoreLocked(ord, cl.class, pl))
 			}
 		}
 		if union != nil {

--- a/core/search/inverted_index.go
+++ b/core/search/inverted_index.go
@@ -23,7 +23,8 @@ import (
 // (score descending, caller-provided typed ID comparator ascending).
 //
 // Terms live in per-class tables (#888): each TokenClass has its own term
-// dictionary, postings, and corpus statistics, so a dual-channel analyzer
+// dictionary and postings. Corpus statistics and posting payloads are further
+// scoped by semantic Document field (#1061), so a dual-channel analyzer
 // (ScriptAwareTokenizer's whole words + auxiliary intra-word grams) never
 // mixes the two channels' document frequencies or lengths, and a class-aware
 // Scorer (ClassWeighted) can weight them apart. A single-channel pipeline
@@ -99,6 +100,10 @@ type classPostings struct {
 	// docCount is how many documents carry at least one token of this class —
 	// the class's corpus size, the N of its TermStats.
 	docCount int
+	// Field-local corpus statistics back BM25F-style scoring while the shared
+	// dictionary and docs bitmap preserve key-or-value recall and expansion.
+	fieldTotalLen [numDocumentFields]int
+	fieldDocCount [numDocumentFields]int
 }
 
 // docEntry is the forward-index entry recorded for each indexed document, keyed
@@ -111,12 +116,15 @@ type docEntry[S comparable] struct {
 	// the |d| that each class's length normalization compares against the
 	// class average.
 	lengths [numTokenClasses]int
+	// fieldLengths keeps length normalization inside a semantic field.
+	fieldLengths [numTokenClasses][numDocumentFields]int
 	// terms is the de-duplicated list of distinct term ids the document was
 	// indexed under, per class (see termDict), used to drop its postings on
 	// delete or re-index. A []uint32 keeps the per-document forward index
 	// compact.
 	terms           [numTokenClasses][]uint32
 	positionEntries int
+	postingEntries  int
 	expiry          *expiryRecord
 }
 
@@ -249,14 +257,26 @@ type PreparedDocument struct {
 }
 
 type preparedClass struct {
-	length int
-	terms  []preparedTerm
+	length       int
+	fieldLengths [numDocumentFields]int
+	terms        []preparedTerm
 }
 
 type preparedTerm struct {
 	term      string
 	frequency int
-	positions []uint32
+	fields    [numDocumentFields]preparedFieldTerm
+}
+
+type preparedFieldTerm struct {
+	frequency int
+	positions []uint64
+}
+
+type preparedOccurrence struct {
+	token    Token
+	field    FieldID
+	position uint64
 }
 
 // PreparedItem pairs an id with its PreparedDocument for IndexManyPrepared.
@@ -266,7 +286,8 @@ type PreparedItem[S comparable] struct {
 	Expiration time.Time
 }
 
-// Prepare analyzes doc.String() WITHOUT taking the index lock and returns the
+// Prepare analyzes a FieldedDocument's field instances (or doc.String() as one
+// default field) WITHOUT taking the index lock and returns the
 // bounded tokens IndexPrepared needs, their AnalysisStats, or a typed
 // AnalysisLimitError. The analyzer is immutable and stateless, so Prepare is
 // safe to call concurrently and from outside any of the caller's locks.
@@ -277,85 +298,116 @@ func (idx *InvertedIndex[S, D]) Prepare(doc D) (PreparedDocument, AnalysisStats,
 			return PreparedDocument{}, AnalysisStats{ProjectedBytes: hint}, err
 		}
 	}
-	text := doc.String()
-	stats := AnalysisStats{ProjectedBytes: len(text)}
+	fields := []DocumentField{{ID: FieldDefault, Text: doc.String()}}
+	if fielded, ok := any(doc).(FieldedDocument); ok {
+		fields = fielded.SearchFields()
+	}
+	var stats AnalysisStats
+	for _, field := range fields {
+		if field.ID >= numDocumentFields {
+			panic("search: document with undefined FieldID")
+		}
+		stats.ProjectedBytes += len(field.Text)
+	}
 	if err := limitError(LimitDocumentBytes, int64(stats.ProjectedBytes), int64(idx.limits.MaxDocumentBytes)); err != nil {
 		return PreparedDocument{}, stats, err
 	}
-	var tokens []Token
-	if analyzer, ok := idx.analyzer.(boundedAnalyzer); ok {
-		var exceeded bool
-		tokens, exceeded = analyzer.AnalyzeBounded(text, idx.limits.MaxDocumentTokens)
-		if exceeded {
-			return PreparedDocument{}, stats, &AnalysisLimitError{Kind: LimitDocumentTokens, Got: int64(idx.limits.MaxDocumentTokens + 1), Limit: int64(idx.limits.MaxDocumentTokens)}
-		}
-	} else {
-		tokens = idx.analyzer.Analyze(text)
-	}
-	stats.Tokens = len(tokens)
-	if err := limitError(LimitDocumentTokens, int64(stats.Tokens), int64(idx.limits.MaxDocumentTokens)); err != nil {
-		return PreparedDocument{}, stats, err
-	}
 	prepared := PreparedDocument{}
-	var wordPositions map[string][]uint32
-	if idx.positions {
-		wordPositions = make(map[string][]uint32)
-	}
-	var wordPosition uint32
-	for _, token := range tokens {
-		if int(token.Class) >= numTokenClasses {
-			panic("search: token with undefined TokenClass")
+	var occurrences []preparedOccurrence
+	var fieldInstances [numDocumentFields]uint32
+	for _, field := range fields {
+		instance := fieldInstances[field.ID]
+		fieldInstances[field.ID]++
+		remaining := 0
+		if idx.limits.MaxDocumentTokens > 0 {
+			remaining = idx.limits.MaxDocumentTokens - stats.Tokens
+			if remaining < 1 {
+				remaining = 1
+			}
 		}
-		if idx.positions && token.Class == ClassWord {
-			wordPositions[token.Term] = append(wordPositions[token.Term], wordPosition)
-			wordPosition++
+		var tokens []Token
+		if analyzer, ok := idx.analyzer.(boundedAnalyzer); ok {
+			var exceeded bool
+			tokens, exceeded = analyzer.AnalyzeBounded(field.Text, remaining)
+			if exceeded {
+				return PreparedDocument{}, stats, &AnalysisLimitError{Kind: LimitDocumentTokens, Got: int64(idx.limits.MaxDocumentTokens + 1), Limit: int64(idx.limits.MaxDocumentTokens)}
+			}
+		} else {
+			tokens = idx.analyzer.Analyze(field.Text)
+		}
+		stats.Tokens += len(tokens)
+		if err := limitError(LimitDocumentTokens, int64(stats.Tokens), int64(idx.limits.MaxDocumentTokens)); err != nil {
+			return PreparedDocument{}, stats, err
+		}
+		var wordPosition uint32
+		for _, token := range tokens {
+			if int(token.Class) >= numTokenClasses {
+				panic("search: token with undefined TokenClass")
+			}
+			occurrence := preparedOccurrence{token: token, field: field.ID}
+			if idx.positions && token.Class == ClassWord {
+				occurrence.position = uint64(instance)<<32 | uint64(wordPosition)
+				wordPosition++
+				prepared.positionEntries++
+			}
+			occurrences = append(occurrences, occurrence)
+			prepared.classes[token.Class].length++
+			prepared.classes[token.Class].fieldLengths[field.ID]++
 		}
 	}
-	// The analyzer owns this token slice for the call, so sort it in place
-	// instead of allocating a second occurrence-sized scratch representation.
-	// Positions were captured above while tokens were still in source order.
-	slices.SortFunc(tokens, func(a, b Token) int {
-		if a.Class < b.Class {
+	slices.SortFunc(occurrences, func(a, b preparedOccurrence) int {
+		if a.token.Class < b.token.Class {
 			return -1
 		}
-		if a.Class > b.Class {
+		if a.token.Class > b.token.Class {
 			return 1
 		}
-		return strings.Compare(a.Term, b.Term)
+		if cmp := strings.Compare(a.token.Term, b.token.Term); cmp != 0 {
+			return cmp
+		}
+		if a.field < b.field {
+			return -1
+		}
+		if a.field > b.field {
+			return 1
+		}
+		if a.position < b.position {
+			return -1
+		}
+		if a.position > b.position {
+			return 1
+		}
+		return 0
 	})
-	var distinct [numTokenClasses]int
-	for i := 0; i < len(tokens); {
+	for i := 0; i < len(occurrences); {
 		j := i + 1
-		for j < len(tokens) && tokens[j] == tokens[i] {
+		for j < len(occurrences) && occurrences[j].token == occurrences[i].token {
 			j++
 		}
-		distinct[tokens[i].Class]++
-		i = j
-	}
-	for class, count := range distinct {
-		if count > 0 {
-			prepared.classes[class].terms = make([]preparedTerm, 0, count)
+		class := occurrences[i].token.Class
+		term := preparedTerm{term: occurrences[i].token.Term, frequency: j - i}
+		for k := i; k < j; {
+			end := k + 1
+			for end < j && occurrences[end].field == occurrences[k].field {
+				end++
+			}
+			fieldTerm := &term.fields[occurrences[k].field]
+			fieldTerm.frequency = end - k
+			if idx.positions && class == ClassWord {
+				fieldTerm.positions = make([]uint64, 0, end-k)
+				for _, occurrence := range occurrences[k:end] {
+					fieldTerm.positions = append(fieldTerm.positions, occurrence.position)
+				}
+			}
+			prepared.postings++
+			k = end
 		}
-	}
-	for i := 0; i < len(tokens); {
-		j := i + 1
-		for j < len(tokens) && tokens[j] == tokens[i] {
-			j++
-		}
-		class := tokens[i].Class
-		term := preparedTerm{term: tokens[i].Term, frequency: j - i}
-		if idx.positions && class == ClassWord {
-			term.positions = wordPositions[term.term]
-		}
-		prepared.classes[class].length += j - i
 		prepared.classes[class].terms = append(prepared.classes[class].terms, term)
-		prepared.postings++
 		i = j
 	}
-	if idx.positions {
-		prepared.positionEntries = int(wordPosition)
+	for class := range prepared.classes {
+		stats.UniqueTerms += len(prepared.classes[class].terms)
 	}
-	stats.UniqueTerms = prepared.postings
 	stats.Postings = prepared.postings
 	stats.PositionEntries = prepared.positionEntries
 	if err := limitError(LimitDocumentTerms, int64(stats.UniqueTerms), int64(idx.limits.MaxDocumentTerms)); err != nil {
@@ -473,24 +525,31 @@ func (idx *InvertedIndex[S, D]) indexPreparedLocked(item PreparedItem[S], now ti
 				pl = newPostingList()
 				cp.postings[tid] = pl
 			}
-			pl.set(ord, preparedTerm.frequency, preparedTerm.positions)
+			pl.setFields(ord, preparedTerm.fields)
 			terms = append(terms, tid)
 		}
 		entry.lengths[class] = preparedClass.length
+		entry.fieldLengths[class] = preparedClass.fieldLengths
 		entry.terms[class] = terms
 		cp.totalLen += preparedClass.length
 		cp.docCount++
+		for field, length := range preparedClass.fieldLengths {
+			if length == 0 {
+				continue
+			}
+			cp.fieldTotalLen[field] += length
+			cp.fieldDocCount[field]++
+		}
 	}
 	entry.positionEntries = item.Prepared.positionEntries
+	entry.postingEntries = item.Prepared.postings
 	if expirationFinite(item.Expiration) {
 		record := &expiryRecord{at: item.Expiration, ord: ord, index: -1}
 		heap.Push(&idx.expirations, record)
 		entry.expiry = record
 	}
 	idx.docs[ord] = entry
-	for class := range entry.terms {
-		idx.livePostings += int64(len(entry.terms[class]))
-	}
+	idx.livePostings += int64(entry.postingEntries)
 	idx.livePositions += int64(entry.positionEntries)
 }
 
@@ -532,12 +591,12 @@ func (idx *InvertedIndex[S, D]) validatePreparedLocked(items []PreparedItem[S], 
 	for id := range last {
 		if ord, ok := idx.ords.lookup(id); ok {
 			entry := idx.docs[ord]
+			postings -= int64(entry.postingEntries)
 			for class := range entry.terms {
 				for _, tid := range entry.terms[class] {
 					key := termKey{class: TokenClass(class), term: idx.classes[class].dict.terms[tid]}
 					loadDF(key)
 					deltaDF[key]--
-					postings--
 				}
 			}
 			positions -= int64(entry.positionEntries)
@@ -553,7 +612,11 @@ func (idx *InvertedIndex[S, D]) validatePreparedLocked(items []PreparedItem[S], 
 				key := termKey{class: TokenClass(class), term: term.term}
 				loadDF(key)
 				deltaDF[key]++
-				postings++
+				for _, fieldTerm := range term.fields {
+					if fieldTerm.frequency > 0 {
+						postings++
+					}
+				}
 			}
 		}
 		positions += int64(prepared.positionEntries)
@@ -621,9 +684,7 @@ func (idx *InvertedIndex[S, D]) deleteLocked(id S) {
 		heap.Remove(&idx.expirations, entry.expiry.index)
 		entry.expiry = nil
 	}
-	for class := range entry.terms {
-		idx.livePostings -= int64(len(entry.terms[class]))
-	}
+	idx.livePostings -= int64(entry.postingEntries)
 	idx.livePositions -= int64(entry.positionEntries)
 	for class := range entry.terms {
 		cp := &idx.classes[class]
@@ -636,6 +697,13 @@ func (idx *InvertedIndex[S, D]) deleteLocked(id S) {
 		if entry.lengths[class] > 0 {
 			cp.totalLen -= entry.lengths[class]
 			cp.docCount--
+		}
+		for field, length := range entry.fieldLengths[class] {
+			if length == 0 {
+				continue
+			}
+			cp.fieldTotalLen[field] -= length
+			cp.fieldDocCount[field]--
 		}
 	}
 	delete(idx.docs, ord)
@@ -723,36 +791,51 @@ func (idx *InvertedIndex[S, D]) compactLocked() {
 		prepared := PreparedDocument{positionEntries: entry.positionEntries}
 		for class := range entry.terms {
 			preparedClass := preparedClass{
-				length: entry.lengths[class],
-				terms:  make([]preparedTerm, 0, len(entry.terms[class])),
+				length:       entry.lengths[class],
+				fieldLengths: entry.fieldLengths[class],
+				terms:        make([]preparedTerm, 0, len(entry.terms[class])),
 			}
-			frequencySum := 0
+			var frequencySum [numDocumentFields]int
 			for _, tid := range entry.terms[class] {
 				pl := idx.classes[class].postings[tid]
-				positions := []uint32(nil)
-				frequency := pl.tf(ord)
-				if idx.positions && class == int(ClassWord) {
-					positions = pl.positionsOf(ord)
-					frequency = len(positions)
+				term := preparedTerm{term: idx.classes[class].dict.terms[tid]}
+				for field := FieldID(0); field < numDocumentFields; field++ {
+					frequency := pl.tfInField(ord, field)
+					if frequency == 0 {
+						continue
+					}
+					positions := []uint64(nil)
+					if idx.positions && class == int(ClassWord) {
+						positions = pl.positionsInField(ord, field)
+						frequency = len(positions)
+					}
+					term.fields[field] = preparedFieldTerm{frequency: frequency, positions: positions}
+					term.frequency += frequency
+					frequencySum[field] += frequency
+					prepared.postings++
 				}
-				preparedClass.terms = append(preparedClass.terms, preparedTerm{
-					term:      idx.classes[class].dict.terms[tid],
-					frequency: frequency,
-					positions: positions,
-				})
-				frequencySum += frequency
+				preparedClass.terms = append(preparedClass.terms, term)
 			}
 			// Frequencies above uint16 are intentionally clamped in postingList.
 			// Preserve the exact document length across compaction by assigning
 			// the unobservable excess to one already-saturated term.
-			if missing := preparedClass.length - frequencySum; missing > 0 && len(preparedClass.terms) > 0 {
-				preparedClass.terms[0].frequency += missing
+			for field, length := range preparedClass.fieldLengths {
+				missing := length - frequencySum[field]
+				if missing <= 0 {
+					continue
+				}
+				for i := range preparedClass.terms {
+					if preparedClass.terms[i].fields[field].frequency > 0 {
+						preparedClass.terms[i].fields[field].frequency += missing
+						preparedClass.terms[i].frequency += missing
+						break
+					}
+				}
 			}
 			sort.Slice(preparedClass.terms, func(i, j int) bool {
 				return preparedClass.terms[i].term < preparedClass.terms[j].term
 			})
 			prepared.classes[class] = preparedClass
-			prepared.postings += len(preparedClass.terms)
 		}
 		var expiration time.Time
 		if entry.expiry != nil {
@@ -848,25 +931,48 @@ func (idx *InvertedIndex[S, D]) scoreTrackedLocked(queryTerms []Token, work *wor
 		if !ok {
 			continue
 		}
-		df := pl.cardinality()
-		avgLen := float64(cp.totalLen) / float64(cp.docCount)
 		for it := pl.docs.Iterator(); it.HasNext(); {
 			if err := work.visit(WorkPostingVisits, 1); err != nil {
 				return nil, err
 			}
 			ord := it.Next()
-			addScore(scores, ord, idx.scorer.Score(TermStats{
-				TF:     pl.tf(ord),
-				DF:     df,
-				N:      cp.docCount,
-				DocLen: idx.docs[ord].lengths[token.Class],
-				AvgLen: avgLen,
-				Class:  token.Class,
-			}))
+			addScore(scores, ord, idx.termScoreLocked(ord, token.Class, pl))
 		}
 	}
 	dropNonFiniteScores(scores)
 	return scores, nil
+}
+
+// termScoreLocked sums one term's field-local contributions for ord. Corpus
+// statistics and length normalization never cross fields; the shared posting
+// bitmap still makes result membership key-or-value.
+func (idx *InvertedIndex[S, D]) termScoreLocked(ord uint32, class TokenClass, pl *postingList) float64 {
+	cp := &idx.classes[class]
+	entry := idx.docs[ord]
+	var score float64
+	for field := FieldID(0); field < numDocumentFields; field++ {
+		tf := pl.tfInField(ord, field)
+		if tf == 0 || cp.fieldDocCount[field] == 0 {
+			continue
+		}
+		contribution := idx.scorer.Score(TermStats{
+			TF:     tf,
+			DF:     pl.fieldCardinality(field),
+			N:      cp.fieldDocCount[field],
+			DocLen: entry.fieldLengths[class][field],
+			AvgLen: float64(cp.fieldTotalLen[field]) / float64(cp.fieldDocCount[field]),
+			Class:  class,
+			Field:  field,
+		})
+		if math.IsNaN(contribution) || math.IsInf(contribution, 0) {
+			return math.NaN()
+		}
+		score += contribution
+		if math.IsNaN(score) || math.IsInf(score, 0) {
+			return math.NaN()
+		}
+	}
+	return score
 }
 
 // addScore accumulates one contribution while poisoning a document whose
@@ -1028,8 +1134,8 @@ func (idx *InvertedIndex[S, D]) MemoryStats() IndexMemoryStats {
 		stats.Documents--
 		stats.ExpiredDocuments++
 		stats.PositionEntries -= int64(entry.positionEntries)
+		stats.Postings -= int64(entry.postingEntries)
 		for class := range entry.terms {
-			stats.Postings -= int64(len(entry.terms[class]))
 			if len(entry.terms[class]) > 0 && expiredDF[class] == nil {
 				expiredDF[class] = make(map[uint32]int, len(entry.terms[class]))
 			}

--- a/core/search/inverted_index_test.go
+++ b/core/search/inverted_index_test.go
@@ -36,6 +36,61 @@ func (fakeAnalyzer) Analyze(text string) []Token {
 	return tokens
 }
 
+func TestInvertedIndexStructuredFields(t *testing.T) {
+	newIndex := func(weight float64, opts ...IndexOption) *InvertedIndex[string, Document] {
+		scorer := FieldWeighted{Base: BM25{K1: DefaultBM25K1, B: DefaultBM25B}, KeyWeight: weight, ValueWeight: 1}
+		return NewInvertedIndex[string, Document](fakeAnalyzer{}, scorer, compareStringID, opts...)
+	}
+
+	t.Run("phrase cannot cross semantic field or value instance", func(t *testing.T) {
+		idx := newIndex(1, WithPositions())
+		docs := map[string]Fields{
+			"key-value-split": {{ID: FieldKey, Text: "alpha"}, {ID: FieldValue, Text: "beta"}},
+			"value-split":     {{ID: FieldValue, Text: "alpha"}, {ID: FieldValue, Text: "beta"}},
+			"key-phrase":      {{ID: FieldKey, Text: "alpha beta"}},
+			"value-phrase":    {{ID: FieldValue, Text: "alpha beta"}},
+		}
+		for id, doc := range docs {
+			if err := idx.Index(id, doc); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if got, want := idsOf(idx.SearchPhrase("alpha beta")), []string{"key-phrase", "value-phrase"}; !slices.Equal(got, want) {
+			t.Fatalf("phrase hits = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("proximity is local to one value instance", func(t *testing.T) {
+		idx := newIndex(1, WithPositions())
+		idx.Index("together", Fields{{ID: FieldValue, Text: "alpha beta"}})
+		idx.Index("split", Fields{{ID: FieldValue, Text: "alpha"}, {ID: FieldValue, Text: "beta"}})
+		results := idx.Search("alpha beta")
+		if len(results) != 2 || results[0].ID != "together" || results[0].Score <= results[1].Score {
+			t.Fatalf("proximity results = %+v, want together strictly first", results)
+		}
+	})
+
+	t.Run("key weight uses field-local corpus statistics", func(t *testing.T) {
+		idx := newIndex(DefaultKeyFieldWeight)
+		idx.Index("key", Fields{{ID: FieldKey, Text: "alpha"}})
+		idx.Index("value", Fields{{ID: FieldValue, Text: "alpha"}})
+		results := idx.Search("alpha")
+		if len(results) != 2 || results[0].ID != "key" || results[0].Score <= results[1].Score {
+			t.Fatalf("field-weighted results = %+v, want key strictly first", results)
+		}
+	})
+
+	t.Run("compaction preserves fields and boundaries", func(t *testing.T) {
+		idx := newIndex(1, WithPositions())
+		idx.Index("cross", Fields{{ID: FieldKey, Text: "alpha"}, {ID: FieldValue, Text: "beta"}})
+		idx.Index("within", Fields{{ID: FieldValue, Text: "alpha beta"}})
+		idx.Compact()
+		if got := idsOf(idx.SearchPhrase("alpha beta")); !slices.Equal(got, []string{"within"}) {
+			t.Fatalf("phrase after compaction = %v", got)
+		}
+	})
+}
+
 func TestInvertedIndexAnalysisLimits(t *testing.T) {
 	t.Run("document dimensions", func(t *testing.T) {
 		unicodeIndex := NewInvertedIndex[string, Text](NewScriptAwareAnalyzer(), nil, compareStringID,
@@ -54,6 +109,20 @@ func TestInvertedIndexAnalysisLimits(t *testing.T) {
 			WithAnalysisLimits(SearchAnalysisLimits{MaxDocumentTerms: 2}))
 		if _, _, err := termIndex.Prepare(Text("a b c a")); !isAnalysisLimit(err, LimitDocumentTerms) {
 			t.Fatalf("Prepare term cap err = %v", err)
+		}
+	})
+
+	t.Run("structured fields share aggregate limits and retain field postings", func(t *testing.T) {
+		idx := NewInvertedIndex[string, Document](fakeAnalyzer{}, nil, compareStringID,
+			WithAnalysisLimits(SearchAnalysisLimits{MaxDocumentTokens: 3}))
+		_, stats, err := idx.Prepare(Fields{{ID: FieldKey, Text: "alpha beta"}, {ID: FieldValue, Text: "alpha gamma"}})
+		if !isAnalysisLimit(err, LimitDocumentTokens) || stats.Tokens != 4 {
+			t.Fatalf("structured token limit stats=%+v err=%v", stats, err)
+		}
+		unbounded := NewInvertedIndex[string, Document](fakeAnalyzer{}, nil, compareStringID)
+		_, stats, err = unbounded.Prepare(Fields{{ID: FieldKey, Text: "alpha"}, {ID: FieldValue, Text: "alpha"}})
+		if err != nil || stats.UniqueTerms != 1 || stats.Postings != 2 {
+			t.Fatalf("structured stats=%+v err=%v, want terms=1 postings=2", stats, err)
 		}
 	})
 
@@ -442,10 +511,10 @@ func TestInvertedIndexPrepared(t *testing.T) {
 		if words.length != 3 || len(words.terms) != 2 || prepared.postings != 2 || prepared.positionEntries != 3 {
 			t.Fatalf("prepared = %+v", prepared)
 		}
-		if got := words.terms[0]; got.term != "alpha" || got.frequency != 1 || !slices.Equal(got.positions, []uint32{1}) {
+		if got := words.terms[0]; got.term != "alpha" || got.frequency != 1 || !slices.Equal(got.fields[FieldDefault].positions, []uint64{1}) {
 			t.Fatalf("first grouped term = %+v", got)
 		}
-		if got := words.terms[1]; got.term != "beta" || got.frequency != 2 || !slices.Equal(got.positions, []uint32{0, 2}) {
+		if got := words.terms[1]; got.term != "beta" || got.frequency != 2 || !slices.Equal(got.fields[FieldDefault].positions, []uint64{0, 2}) {
 			t.Fatalf("second grouped term = %+v", got)
 		}
 	})
@@ -737,6 +806,47 @@ func BenchmarkSearchProximity(b *testing.B) {
 			idx.Search(queries[i%len(queries)])
 		}
 	})
+}
+
+// BenchmarkStructuredFieldSearch records the query-time cost and retained
+// logical bytes of the v2 field model against the historical flattened text.
+func BenchmarkStructuredFieldSearch(b *testing.B) {
+	const documents = 20_000
+	for _, structured := range []bool{false, true} {
+		name := map[bool]string{false: "Flat", true: "Structured"}[structured]
+		b.Run(name, func(b *testing.B) {
+			runtime.GC()
+			var before runtime.MemStats
+			runtime.ReadMemStats(&before)
+			scorer := FieldWeighted{Base: BM25{K1: DefaultBM25K1, B: DefaultBM25B}, KeyWeight: DefaultKeyFieldWeight, ValueWeight: 1}
+			idx := NewInvertedIndex[string, Document](fakeAnalyzer{}, scorer, compareStringID, WithPositions())
+			for i := 0; i < documents; i++ {
+				key := fmt.Sprintf("tenant.%03d.note.%06d", i%100, i)
+				valueA := fmt.Sprintf("alpha topic%d", i%100)
+				valueB := "beta searchable content"
+				var doc Document = Text(key + " " + valueA + " " + valueB)
+				if structured {
+					doc = Fields{{ID: FieldKey, Text: key}, {ID: FieldValue, Text: valueA}, {ID: FieldValue, Text: valueB}}
+				}
+				if err := idx.Index(key, doc); err != nil {
+					b.Fatal(err)
+				}
+			}
+			runtime.GC()
+			var after runtime.MemStats
+			runtime.ReadMemStats(&after)
+			heapBytesPerDoc := float64(after.HeapAlloc-before.HeapAlloc) / documents
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if results := idx.SearchTopK("alpha beta", 10, nil); len(results) != 10 {
+					b.Fatalf("results=%d", len(results))
+				}
+			}
+			runtime.KeepAlive(idx)
+			b.ReportMetric(heapBytesPerDoc, "heap-B/doc")
+		})
+	}
 }
 
 // BenchmarkSearchPhrase measures phrase-query latency (AND-intersection plus

--- a/core/search/normalizer.go
+++ b/core/search/normalizer.go
@@ -130,39 +130,41 @@ type JSONStringValueNormalizer struct{}
 // Normalize returns the space-joined string values of a JSON object or array,
 // or the input unchanged when it is not such a document.
 func (JSONStringValueNormalizer) Normalize(text string) string {
+	values, structured := (JSONStringValueNormalizer{}).Values(text)
+	if !structured {
+		return text
+	}
+	return strings.Join(values, " ")
+}
+
+// Values returns each JSON string leaf as a separate deterministic field
+// instance. structured is false for plain text and malformed JSON, whose
+// caller should preserve the original input as one field.
+func (JSONStringValueNormalizer) Values(text string) (values []string, structured bool) {
 	trimmed := strings.TrimSpace(text)
 	// Only a JSON object or array is treated as structured JSON. Plain prose
 	// and bare scalars (including a quoted JSON string) are left untouched, so
 	// values like "true" or "42" stay searchable as their literal text.
 	if len(trimmed) == 0 || (trimmed[0] != '{' && trimmed[0] != '[') {
-		return text
+		return nil, false
 	}
 	var parsed any
 	if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
-		return text // looked like JSON but is not: index the raw text as-is.
+		return nil, false // looked like JSON but is not: preserve raw text.
 	}
-	var b strings.Builder
-	appendJSONStringValues(&b, parsed)
-	return b.String()
+	appendJSONStringValueFields(&values, parsed)
+	return values, true
 }
 
-// appendJSONStringValues walks a value decoded from JSON and appends every
-// string it contains to b, separated by single spaces. Object keys and
-// non-string scalars are skipped; objects are visited in sorted-key order for
-// deterministic output.
-func appendJSONStringValues(b *strings.Builder, v any) {
+func appendJSONStringValueFields(out *[]string, v any) {
 	switch val := v.(type) {
 	case string:
-		if val == "" {
-			return
+		if val != "" {
+			*out = append(*out, val)
 		}
-		if b.Len() > 0 {
-			b.WriteByte(' ')
-		}
-		b.WriteString(val)
 	case []any:
 		for _, e := range val {
-			appendJSONStringValues(b, e)
+			appendJSONStringValueFields(out, e)
 		}
 	case map[string]any:
 		keys := make([]string, 0, len(val))
@@ -171,10 +173,9 @@ func appendJSONStringValues(b *strings.Builder, v any) {
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			appendJSONStringValues(b, val[k])
+			appendJSONStringValueFields(out, val[k])
 		}
 	}
-	// float64 (numbers), bool, and nil carry no searchable text: skipped.
 }
 
 // dropNonspacingMark returns r unless r is a Unicode nonspacing combining mark

--- a/core/search/normalizer_test.go
+++ b/core/search/normalizer_test.go
@@ -1,6 +1,9 @@
 package search
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestLowercaseNormalizer(t *testing.T) {
 	if got := (LowercaseNormalizer{}).Normalize("HeLLo Wörld"); got != "hello wörld" {
@@ -123,5 +126,15 @@ func TestJSONStringValueNormalizer(t *testing.T) {
 				t.Fatalf("Normalize(%q) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestJSONStringValueNormalizerValuesPreserveBoundaries(t *testing.T) {
+	values, structured := (JSONStringValueNormalizer{}).Values(`{"b":["beta","gamma"],"a":"alpha","n":4}`)
+	if !structured || !slices.Equal(values, []string{"alpha", "beta", "gamma"}) {
+		t.Fatalf("Values = %v, %t", values, structured)
+	}
+	if values, structured := (JSONStringValueNormalizer{}).Values("plain text"); structured || values != nil {
+		t.Fatalf("plain Values = %v, %t", values, structured)
 	}
 }

--- a/core/search/phrase.go
+++ b/core/search/phrase.go
@@ -147,8 +147,9 @@ func (idx *InvertedIndex[S, D]) phraseMatchTrackedLocked(terms []string, work *w
 		}
 		lists[i] = pl
 	}
-	// AND-intersect membership, starting from the rarest term so the running
-	// intersection shrinks fastest.
+	// Stream the globally rarest term, then require every term inside one field.
+	// Global membership alone is insufficient: key=alpha/value=beta must not
+	// synthesize the phrase "alpha beta" across the boundary.
 	rarest := 0
 	for i := 1; i < len(lists); i++ {
 		if lists[i].cardinality() < lists[rarest].cardinality() {
@@ -161,27 +162,28 @@ func (idx *InvertedIndex[S, D]) phraseMatchTrackedLocked(terms []string, work *w
 			return nil, err
 		}
 		ord := it.Next()
-		present := true
-		for i, list := range lists {
-			if i == rarest {
+		matched := false
+		for field := FieldID(0); field < numDocumentFields && !matched; field++ {
+			present := true
+			for _, list := range lists {
+				if err := work.visit(WorkPostingVisits, 1); err != nil {
+					return nil, err
+				}
+				if !list.containsField(ord, field) {
+					present = false
+					break
+				}
+			}
+			if !present {
 				continue
 			}
-			if err := work.visit(WorkPostingVisits, 1); err != nil {
+			adjacent, err := phraseAdjacentFieldTracked(lists, ord, field, work)
+			if err != nil {
 				return nil, err
 			}
-			if !list.docs.Contains(ord) {
-				present = false
-				break
-			}
+			matched = adjacent
 		}
-		if !present {
-			continue
-		}
-		adjacent, err := phraseAdjacentTracked(lists, ord, work)
-		if err != nil {
-			return nil, err
-		}
-		if adjacent {
+		if matched {
 			out = append(out, ord)
 		}
 	}
@@ -202,7 +204,6 @@ func (idx *InvertedIndex[S, D]) scorePhraseTrackedLocked(terms []string, ords []
 	if cp.docCount == 0 {
 		return nil, nil
 	}
-	avgLen := float64(cp.totalLen) / float64(cp.docCount)
 	scores := make(map[uint32]float64, len(ords))
 	seen := make(map[string]struct{}, len(terms))
 	for _, term := range terms {
@@ -221,19 +222,11 @@ func (idx *InvertedIndex[S, D]) scorePhraseTrackedLocked(terms []string, ords []
 		if pl == nil {
 			continue
 		}
-		df := pl.cardinality()
 		for _, ord := range ords {
 			if err := work.visit(WorkPostingVisits, 1); err != nil {
 				return nil, err
 			}
-			addScore(scores, ord, idx.scorer.Score(TermStats{
-				TF:     pl.tf(ord),
-				DF:     df,
-				N:      cp.docCount,
-				DocLen: idx.docs[ord].lengths[ClassWord],
-				AvgLen: avgLen,
-				Class:  ClassWord,
-			}))
+			addScore(scores, ord, idx.termScoreLocked(ord, ClassWord, pl))
 		}
 	}
 	dropNonFiniteScores(scores)
@@ -252,10 +245,14 @@ func phraseAdjacent(lists []*postingList, ord uint32) bool {
 }
 
 func phraseAdjacentTracked(lists []*postingList, ord uint32, work *workTracker) (bool, error) {
+	return phraseAdjacentFieldTracked(lists, ord, FieldDefault, work)
+}
+
+func phraseAdjacentFieldTracked(lists []*postingList, ord uint32, field FieldID, work *workTracker) (bool, error) {
 	if len(lists) < 2 {
 		return true, nil
 	}
-	first := lists[0].positionsOf(ord)
+	first := lists[0].positionsInField(ord, field)
 	if first == nil {
 		return true, nil // positions not tracked: degrade to AND
 	}
@@ -266,7 +263,7 @@ func phraseAdjacentTracked(lists []*postingList, ord uint32, work *workTracker) 
 	// term i at p+i for every i. Positions are ascending, so each follow-on
 	// check is a binary search.
 	for _, p := range first {
-		ok, err := phraseStartsAtTracked(lists, ord, p, work)
+		ok, err := phraseStartsAtFieldTracked(lists, ord, field, p, work)
 		if err != nil {
 			return false, err
 		}
@@ -278,15 +275,19 @@ func phraseAdjacentTracked(lists []*postingList, ord uint32, work *workTracker) 
 }
 
 func phraseStartsAtTracked(lists []*postingList, ord uint32, start uint32, work *workTracker) (bool, error) {
+	return phraseStartsAtFieldTracked(lists, ord, FieldDefault, uint64(start), work)
+}
+
+func phraseStartsAtFieldTracked(lists []*postingList, ord uint32, field FieldID, start uint64, work *workTracker) (bool, error) {
 	for i := 1; i < len(lists); i++ {
-		pos := lists[i].positionsOf(ord)
+		pos := lists[i].positionsInField(ord, field)
 		if pos == nil {
 			return true, nil
 		}
 		if err := work.visit(WorkPositionVisits, int64(len(pos))); err != nil {
 			return false, err
 		}
-		if !containsSortedU32(pos, start+uint32(i)) {
+		if !containsSortedU64(pos, start+uint64(i)) {
 			return false, nil
 		}
 	}
@@ -296,21 +297,18 @@ func phraseStartsAtTracked(lists []*postingList, ord uint32, start uint32, work 
 // phraseStartsAt reports whether every term i (i >= 1) occurs at position
 // start+i in document ord, i.e. the phrase begins at start.
 func phraseStartsAt(lists []*postingList, ord uint32, start uint32) bool {
-	for i := 1; i < len(lists); i++ {
-		pos := lists[i].positionsOf(ord)
-		if pos == nil {
-			return true // positions not tracked mid-list: degrade to AND
-		}
-		if !containsSortedU32(pos, start+uint32(i)) {
-			return false
-		}
-	}
-	return true
+	ok, _ := phraseStartsAtTracked(lists, ord, start, newWorkTracker(nil, Budget{}))
+	return ok
 }
 
 // containsSortedU32 reports whether the ascending slice s contains v, via binary
 // search.
 func containsSortedU32(s []uint32, v uint32) bool {
+	i := sort.Search(len(s), func(i int) bool { return s[i] >= v })
+	return i < len(s) && s[i] == v
+}
+
+func containsSortedU64(s []uint64, v uint64) bool {
 	i := sort.Search(len(s), func(i int) bool { return s[i] >= v })
 	return i < len(s) && s[i] == v
 }

--- a/core/search/posting.go
+++ b/core/search/posting.go
@@ -7,23 +7,26 @@ import (
 )
 
 // postingList is one term's posting set: which document ordinals contain the
-// term, plus their term frequencies and — when the index tracks positions —
-// the token positions the term occupies in each document. Membership lives in
-// a Roaring bitmap — compressed and mutable, so it fits the decaying
+// term, plus field-local term frequencies and — when the index tracks positions
+// — token positions. Union membership lives in a Roaring bitmap; structured
+// fields add sparse per-field bitmaps while the single default-field path reuses
+// the union bitmap and pays no duplicate membership store. This fits the decaying
 // workload's constant add / remove without the per-entry overhead of a map
 // keyed by the document id. Frequencies default to 1 and only the
 // comparatively rare term that occurs more than once in a document is recorded
 // in tfHi, so the common case carries no per-(term, document) frequency
-// storage at all. positions is nil unless the index was built WithPositions
-// and the term carries at least one position in the document, so an index that
+// storage at all. fieldPosition entries exist only when the index was built WithPositions
+// and the term carries at least one position in that field, so an index that
 // serves only OR-union ranking pays nothing for phrase/proximity support
-// (#889). Each document's positions are stored delta+varint packed (#908): the
-// ascending token positions become a compact []byte instead of a []uint32, so
+// (#889). Each document's positions are stored delta+varint packed (#908): a
+// uint64 combines field-instance and token offset before compact encoding, so
 // the store costs ~1 byte per position (short vertex values) rather than 4.
 type postingList struct {
-	docs      *roaring.Bitmap   // document ordinals containing this term
-	tfHi      map[uint32]uint16 // ordinal -> term frequency, recorded only when tf > 1
-	positions map[uint32][]byte // ordinal -> delta+varint packed ascending positions, only when the index tracks positions
+	docs          *roaring.Bitmap // document ordinals containing this term in any field
+	hasNonDefault bool
+	fieldDocs     [numDocumentFields]*roaring.Bitmap
+	fieldTFHi     [numDocumentFields]map[uint32]uint16
+	fieldPosition [numDocumentFields]map[uint32][]byte
 }
 
 // newPostingList returns an empty posting list ready to record documents.
@@ -31,7 +34,7 @@ func newPostingList() *postingList {
 	return &postingList{docs: roaring.New()}
 }
 
-// set records that document ord contains the term tf times (tf >= 1). A tf of 1
+// set records a default-field term and backs legacy single-text documents. A tf of 1
 // — the common case — costs only the bitmap membership bit. positions, when
 // non-empty, are the term's ascending token positions in the document; they
 // are stored only when the index tracks positions (WithPositions) and only for
@@ -39,19 +42,51 @@ func newPostingList() *postingList {
 // nothing. They are delta+varint packed into a fresh []byte, so the caller's
 // transient position slice is not retained and the store holds only the
 // compact bytes.
-func (p *postingList) set(ord uint32, tf int, positions []uint32) {
-	p.docs.Add(ord)
-	if tf > 1 {
-		if p.tfHi == nil {
-			p.tfHi = make(map[uint32]uint16)
+func (p *postingList) set(ord uint32, tf int, positions []uint64) {
+	var fields [numDocumentFields]preparedFieldTerm
+	fields[FieldDefault] = preparedFieldTerm{frequency: tf, positions: positions}
+	p.setFields(ord, fields)
+}
+
+func (p *postingList) setFields(ord uint32, fields [numDocumentFields]preparedFieldTerm) {
+	if !p.hasNonDefault {
+		for field := FieldKey; field < numDocumentFields; field++ {
+			if fields[field].frequency == 0 {
+				continue
+			}
+			p.hasNonDefault = true
+			if !p.docs.IsEmpty() {
+				p.fieldDocs[FieldDefault] = p.docs.Clone()
+			}
+			break
 		}
-		p.tfHi[ord] = clampTF(tf)
 	}
-	if len(positions) > 0 {
-		if p.positions == nil {
-			p.positions = make(map[uint32][]byte)
+	p.docs.Add(ord)
+	for field, value := range fields {
+		if value.frequency == 0 {
+			continue
 		}
-		p.positions[ord] = packPositions(positions)
+		if FieldID(field) == FieldDefault && !p.hasNonDefault {
+			// Until a non-default field appears, the union bitmap is exactly the
+			// default-field bitmap; do not duplicate it.
+		} else if p.fieldDocs[field] == nil {
+			p.fieldDocs[field] = roaring.New()
+		}
+		if p.fieldDocs[field] != nil {
+			p.fieldDocs[field].Add(ord)
+		}
+		if value.frequency > 1 {
+			if p.fieldTFHi[field] == nil {
+				p.fieldTFHi[field] = make(map[uint32]uint16)
+			}
+			p.fieldTFHi[field][ord] = clampTF(value.frequency)
+		}
+		if len(value.positions) > 0 {
+			if p.fieldPosition[field] == nil {
+				p.fieldPosition[field] = make(map[uint32][]byte)
+			}
+			p.fieldPosition[field][ord] = packPositions(value.positions)
+		}
 	}
 }
 
@@ -61,16 +96,26 @@ func (p *postingList) set(ord uint32, tf int, positions []uint32) {
 // document's position slice.
 func (p *postingList) remove(ord uint32) (empty bool) {
 	p.docs.Remove(ord)
-	if p.tfHi != nil {
-		delete(p.tfHi, ord)
-		if len(p.tfHi) == 0 {
-			p.tfHi = nil
+	for field := range p.fieldDocs {
+		if FieldID(field) == FieldDefault && !p.hasNonDefault {
+			// p.docs owns default membership in the single-field fast path.
+		} else if p.fieldDocs[field] != nil {
+			p.fieldDocs[field].Remove(ord)
+			if p.fieldDocs[field].IsEmpty() {
+				p.fieldDocs[field] = nil
+			}
 		}
-	}
-	if p.positions != nil {
-		delete(p.positions, ord)
-		if len(p.positions) == 0 {
-			p.positions = nil
+		if p.fieldTFHi[field] != nil {
+			delete(p.fieldTFHi[field], ord)
+			if len(p.fieldTFHi[field]) == 0 {
+				p.fieldTFHi[field] = nil
+			}
+		}
+		if p.fieldPosition[field] != nil {
+			delete(p.fieldPosition[field], ord)
+			if len(p.fieldPosition[field]) == 0 {
+				p.fieldPosition[field] = nil
+			}
 		}
 	}
 	return p.docs.IsEmpty()
@@ -79,34 +124,70 @@ func (p *postingList) remove(ord uint32) (empty bool) {
 // tf returns document ord's frequency for this term: 1 unless an override was
 // recorded. Callers iterate p.docs, so ord is always a member.
 func (p *postingList) tf(ord uint32) int {
-	if p.tfHi != nil {
-		if f, ok := p.tfHi[ord]; ok {
-			return int(f)
+	var total int
+	for field := FieldID(0); field < numDocumentFields; field++ {
+		total += p.tfInField(ord, field)
+	}
+	if total == 0 {
+		return 1
+	}
+	return total
+}
+
+func (p *postingList) tfInField(ord uint32, field FieldID) int {
+	docs := p.fieldDocs[field]
+	if field == FieldDefault && !p.hasNonDefault {
+		docs = p.docs
+	}
+	if docs == nil || !docs.Contains(ord) {
+		return 0
+	}
+	if p.fieldTFHi[field] != nil {
+		if frequency, ok := p.fieldTFHi[field][ord]; ok {
+			return int(frequency)
 		}
 	}
 	return 1
 }
 
-// positionsOf returns document ord's ascending token positions for this term,
+func (p *postingList) containsField(ord uint32, field FieldID) bool {
+	if field == FieldDefault && !p.hasNonDefault {
+		return p.docs.Contains(ord)
+	}
+	return p.fieldDocs[field] != nil && p.fieldDocs[field].Contains(ord)
+}
+
+func (p *postingList) fieldCardinality(field FieldID) int {
+	if field == FieldDefault && !p.hasNonDefault {
+		return int(p.docs.GetCardinality())
+	}
+	if p.fieldDocs[field] == nil {
+		return 0
+	}
+	return int(p.fieldDocs[field].GetCardinality())
+}
+
+// positionsOf returns document ord's ascending default-field positions,
 // or nil when the index does not track positions (or ord carries none). The
-// packed bytes are decoded into a fresh []uint32 on each call, so the returned
+// packed bytes are decoded into a fresh []uint64 on each call, so the returned
 // slice is owned by the caller and safe to mutate; it is not shared with the
 // posting list.
-func (p *postingList) positionsOf(ord uint32) []uint32 {
-	if p.positions == nil {
-		return nil
-	}
-	return unpackPositionsInto(nil, p.positions[ord])
+func (p *postingList) positionsOf(ord uint32) []uint64 {
+	return p.positionsInField(ord, FieldDefault)
 }
 
 // positionsInto decodes ord's positions into dst, reusing its capacity. The
 // bounded query executor keeps one scratch slice per query term so positional
 // work does not allocate once per matching document.
-func (p *postingList) positionsInto(ord uint32, dst []uint32) []uint32 {
-	if p.positions == nil {
-		return nil
+func (p *postingList) positionsInto(ord uint32, field FieldID, dst []uint64) []uint64 {
+	if p.fieldPosition[field] == nil {
+		return dst[:0]
 	}
-	return unpackPositionsInto(dst[:0], p.positions[ord])
+	return unpackPositionsInto(dst[:0], p.fieldPosition[field][ord])
+}
+
+func (p *postingList) positionsInField(ord uint32, field FieldID) []uint64 {
+	return p.positionsInto(ord, field, nil)
 }
 
 // packPositions delta+varint encodes an ascending position slice: the first
@@ -116,12 +197,12 @@ func (p *postingList) positionsInto(ord uint32, dst []uint32) []uint32 {
 // counter), so gaps are small and pack into a single byte for the short vertex
 // values Lantern indexes — a ~4x shrink over the raw []uint32. positions must
 // be ascending; the indexer builds it that way.
-func packPositions(positions []uint32) []byte {
+func packPositions(positions []uint64) []byte {
 	// One byte per position is the common case, so size the buffer for it.
 	buf := make([]byte, 0, len(positions))
-	var prev uint32
+	var prev uint64
 	for _, pos := range positions {
-		buf = binary.AppendUvarint(buf, uint64(pos-prev))
+		buf = binary.AppendUvarint(buf, pos-prev)
 		prev = pos
 	}
 	return buf
@@ -130,26 +211,26 @@ func packPositions(positions []uint32) []byte {
 // unpackPositions reverses packPositions, decoding the delta+varint bytes back
 // into the ascending absolute positions. It returns nil for empty input (a
 // document that carries no positions for the term).
-func unpackPositions(b []byte) []uint32 {
+func unpackPositions(b []byte) []uint64 {
 	return unpackPositionsInto(nil, b)
 }
 
-func unpackPositionsInto(dst []uint32, b []byte) []uint32 {
+func unpackPositionsInto(dst []uint64, b []byte) []uint64 {
 	if len(b) == 0 {
 		return dst[:0]
 	}
 	// Each position occupies at least one byte, so len(b) bounds the count.
 	out := dst
 	if cap(out) < len(b) {
-		out = make([]uint32, 0, len(b))
+		out = make([]uint64, 0, len(b))
 	}
-	var acc uint32
+	var acc uint64
 	for i := 0; i < len(b); {
 		delta, n := binary.Uvarint(b[i:])
 		if n <= 0 {
 			break // malformed; only reachable on a corrupted buffer
 		}
-		acc += uint32(delta)
+		acc += delta
 		out = append(out, acc)
 		i += n
 	}

--- a/core/search/posting_test.go
+++ b/core/search/posting_test.go
@@ -40,7 +40,7 @@ func TestPostingList(t *testing.T) {
 
 	t.Run("positions are recorded, read back, and dropped on remove", func(t *testing.T) {
 		q := newPostingList()
-		q.set(1, 2, []uint32{3, 7}) // two occurrences at positions 3 and 7
+		q.set(1, 2, []uint64{3, 7}) // two occurrences at positions 3 and 7
 		q.set(2, 1, nil)            // present, but no positions tracked
 		if got := q.positionsOf(1); len(got) != 2 || got[0] != 3 || got[1] != 7 {
 			t.Fatalf("positionsOf(1) = %v, want [3 7]", got)
@@ -53,6 +53,20 @@ func TestPostingList(t *testing.T) {
 		}
 		if got := q.positionsOf(1); got != nil {
 			t.Fatalf("positionsOf(1) after remove = %v, want nil (positions dropped)", got)
+		}
+	})
+
+	t.Run("default fast path migrates when structured fields appear", func(t *testing.T) {
+		q := newPostingList()
+		q.set(1, 1, nil)
+		var fields [numDocumentFields]preparedFieldTerm
+		fields[FieldKey] = preparedFieldTerm{frequency: 1}
+		q.setFields(2, fields)
+		if !q.containsField(1, FieldDefault) || q.containsField(2, FieldDefault) || !q.containsField(2, FieldKey) {
+			t.Fatalf("field membership default/key = %t/%t/%t", q.containsField(1, FieldDefault), q.containsField(2, FieldDefault), q.containsField(2, FieldKey))
+		}
+		if q.fieldCardinality(FieldDefault) != 1 || q.fieldCardinality(FieldKey) != 1 {
+			t.Fatalf("field cardinalities = %d/%d", q.fieldCardinality(FieldDefault), q.fieldCardinality(FieldKey))
 		}
 	})
 }
@@ -72,7 +86,7 @@ func TestPostingListClampsTF(t *testing.T) {
 // consume the packed store via positionsOf.
 func TestPackPositions(t *testing.T) {
 	t.Run("edge cases round-trip; empty packs to no bytes", func(t *testing.T) {
-		cases := [][]uint32{
+		cases := [][]uint64{
 			nil,
 			{0},
 			{5},
@@ -94,10 +108,10 @@ func TestPackPositions(t *testing.T) {
 	t.Run("randomized ascending sequences round-trip", func(t *testing.T) {
 		rng := rand.New(rand.NewSource(1))
 		for iter := 0; iter < 2000; iter++ {
-			seq := make([]uint32, rng.Intn(64))
-			var acc uint32
+			seq := make([]uint64, rng.Intn(64))
+			var acc uint64
 			for i := range seq {
-				acc += uint32(rng.Intn(1<<20) + 1) // strictly ascending, wide gaps
+				acc += uint64(rng.Intn(1<<20) + 1) // strictly ascending, wide gaps
 				seq[i] = acc
 			}
 			if got := unpackPositions(packPositions(seq)); !slices.Equal(got, seq) {
@@ -107,9 +121,9 @@ func TestPackPositions(t *testing.T) {
 	})
 
 	t.Run("decode reuses caller scratch", func(t *testing.T) {
-		dst := make([]uint32, 0, 8)
-		got := unpackPositionsInto(dst, packPositions([]uint32{2, 5, 9}))
-		if !slices.Equal(got, []uint32{2, 5, 9}) {
+		dst := make([]uint64, 0, 8)
+		got := unpackPositionsInto(dst, packPositions([]uint64{2, 5, 9}))
+		if !slices.Equal(got, []uint64{2, 5, 9}) {
 			t.Fatalf("decoded = %v", got)
 		}
 		if &got[0] != &dst[:1][0] {

--- a/core/search/proximity.go
+++ b/core/search/proximity.go
@@ -59,39 +59,28 @@ func (idx *InvertedIndex[S, D]) applyProximityTrackedLocked(scores map[uint32]fl
 	if len(lists) < 2 {
 		return nil
 	}
-	present := make([][]uint32, 0, len(lists))
+	var scratch executorScratch
 	for ord := range scores {
 		if err := work.check(); err != nil {
 			return err
 		}
-		present = present[:0]
-		for _, pl := range lists {
-			if pos := pl.positionsOf(ord); pos != nil {
-				if err := work.visit(WorkPositionVisits, int64(len(pos))); err != nil {
-					return err
-				}
-				present = append(present, pos)
+		var best float64
+		for field := FieldID(0); field < numDocumentFields; field++ {
+			present, err := scratch.decode(lists, ord, field, work)
+			if err != nil {
+				return err
+			}
+			bonus, err := scratch.proximityBonus(present, work)
+			if err != nil {
+				return err
+			}
+			if bonus > best {
+				best = bonus
 			}
 		}
-		if len(present) < 2 {
-			continue
+		if best > 0 {
+			addScore(scores, ord, idx.proximityWeight*best)
 		}
-		w, err := smallestWindowTracked(present, work)
-		if err != nil {
-			return err
-		}
-		if w < 0 {
-			continue
-		}
-		// The tightest window for t present terms spans t-1 gaps (consecutive
-		// positions), so span is the excess spread over that ideal: 0 for an
-		// exact adjacency, growing as the terms drift apart. The bonus decays
-		// as 1/(span+1) and scales with the number of clustered terms.
-		span := w - (len(present) - 1)
-		if span < 0 {
-			span = 0
-		}
-		addScore(scores, ord, idx.proximityWeight*float64(len(present)-1)/float64(span+1))
 	}
 	return nil
 }
@@ -102,25 +91,25 @@ func (idx *InvertedIndex[S, D]) applyProximityTrackedLocked(scores map[uint32]fl
 // range covering elements from k sorted lists" sweep: repeatedly advance the
 // pointer sitting at the current minimum — the only move that can shrink the
 // window — until that list is exhausted.
-func smallestWindow(lists [][]uint32) int {
+func smallestWindow(lists [][]uint64) int {
 	best, _ := smallestWindowTracked(lists, newWorkTracker(nil, Budget{}))
 	return best
 }
 
-func smallestWindowTracked(lists [][]uint32, work *workTracker) (int, error) {
+func smallestWindowTracked(lists [][]uint64, work *workTracker) (int, error) {
 	ptr := make([]int, len(lists))
 	return smallestWindowWithPointersTracked(lists, ptr, work)
 }
 
-func smallestWindowWithPointersTracked(lists [][]uint32, ptr []int, work *workTracker) (int, error) {
+func smallestWindowWithPointersTracked(lists [][]uint64, ptr []int, work *workTracker) (int, error) {
 	clear(ptr)
 	best := -1
 	for {
 		if err := work.check(); err != nil {
 			return -1, err
 		}
-		lo := ^uint32(0)
-		var hi uint32
+		lo := ^uint64(0)
+		var hi uint64
 		loList := -1
 		for i, l := range lists {
 			if len(l) == 0 {

--- a/core/search/proximity_test.go
+++ b/core/search/proximity_test.go
@@ -119,15 +119,15 @@ func TestProximityBoostTopK(t *testing.T) {
 func TestSmallestWindow(t *testing.T) {
 	tests := []struct {
 		name  string
-		lists [][]uint32
+		lists [][]uint64
 		want  int
 	}{
-		{"two adjacent", [][]uint32{{1}, {2}}, 1},
-		{"two apart", [][]uint32{{0}, {5}}, 5},
-		{"three consecutive", [][]uint32{{0}, {1}, {2}}, 2},
-		{"picks the closest occurrences", [][]uint32{{0, 10}, {9}}, 1},
-		{"single list has zero width", [][]uint32{{3, 7}}, 0},
-		{"an empty list has no window", [][]uint32{{1}, {}}, -1},
+		{"two adjacent", [][]uint64{{1}, {2}}, 1},
+		{"two apart", [][]uint64{{0}, {5}}, 5},
+		{"three consecutive", [][]uint64{{0}, {1}, {2}}, 2},
+		{"picks the closest occurrences", [][]uint64{{0, 10}, {9}}, 1},
+		{"single list has zero width", [][]uint64{{3, 7}}, 0},
+		{"an empty list has no window", [][]uint64{{1}, {}}, -1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/core/search/scorer.go
+++ b/core/search/scorer.go
@@ -17,6 +17,11 @@ const (
 	// Lucene baselines on all corpora, with the extremes offering no durable
 	// advantage over this midpoint.
 	DefaultGramWeight = 0.2
+	// DefaultKeyFieldWeight is the measured production key-field multiplier.
+	// The structured-field qrels plateau across [1.75, 2.25]; 1.75 is the
+	// lowest measured weight that lifts exact namespace evidence without
+	// overwhelming value-only matches.
+	DefaultKeyFieldWeight = 1.75
 )
 
 // TermStats carries the corpus statistics a Scorer needs to weight one
@@ -24,9 +29,9 @@ const (
 // index while computing a result; a Scorer treats it as read-only input and
 // holds no state of its own, so a single Scorer is safe for concurrent use.
 //
-// Every count is scoped to the term's token class (#888): the index keeps
-// separate postings and statistics per class, so DF, N, DocLen, and AvgLen
-// describe only the channel the term matched on. For a single-channel
+// Every count is scoped to the term's token class and semantic field
+// (#888/#1061): DF, N, DocLen, and AvgLen describe only that channel/field.
+// For a single-channel, single-field
 // pipeline that scoping is invisible — the class's corpus is the corpus.
 type TermStats struct {
 	// TF is how many times the term occurs in this document (term frequency).
@@ -45,6 +50,8 @@ type TermStats struct {
 	// Class is the matching channel the term belongs to, so a class-aware
 	// Scorer (ClassWeighted) can weight primary and auxiliary evidence apart.
 	Class TokenClass
+	// Field identifies the semantic document field supplying this evidence.
+	Field FieldID
 }
 
 // Scorer assigns a relevance weight to a single (query term, document)
@@ -159,6 +166,36 @@ type ClassWeighted struct {
 	GramWeight float64
 }
 
+// FieldWeighted layers stable key/value weights over a base scorer. Default
+// text and value evidence use weight 1 unless explicitly overridden.
+type FieldWeighted struct {
+	Base        Scorer
+	KeyWeight   float64
+	ValueWeight float64
+}
+
+func (s FieldWeighted) Score(stats TermStats) float64 {
+	base := s.Base
+	if base == nil {
+		base = BM25{K1: DefaultBM25K1, B: DefaultBM25B}
+	}
+	weight := 1.0
+	switch stats.Field {
+	case FieldKey:
+		if s.KeyWeight != 0 {
+			weight = s.KeyWeight
+		}
+	case FieldValue:
+		if s.ValueWeight != 0 {
+			weight = s.ValueWeight
+		}
+	}
+	if weight < 0 {
+		weight = 0
+	}
+	return base.Score(stats) * weight
+}
+
 // Score returns the base score, scaled by GramWeight for auxiliary-channel
 // matches.
 func (s ClassWeighted) Score(stats TermStats) float64 {
@@ -184,4 +221,5 @@ func (s ClassWeighted) Score(stats TermStats) float64 {
 var (
 	_ Scorer = BM25{}
 	_ Scorer = ClassWeighted{}
+	_ Scorer = FieldWeighted{}
 )

--- a/core/search/scorer_test.go
+++ b/core/search/scorer_test.go
@@ -181,3 +181,51 @@ func TestClassWeighted(t *testing.T) {
 		}
 	})
 }
+
+func TestFieldWeighted(t *testing.T) {
+	base := ScorerFunc(func(TermStats) float64 { return 2 })
+	scorer := FieldWeighted{Base: base, KeyWeight: 1.5, ValueWeight: 0.75}
+	if got := scorer.Score(TermStats{Field: FieldDefault}); got != 2 {
+		t.Fatalf("default score = %v", got)
+	}
+	if got := scorer.Score(TermStats{Field: FieldKey}); got != 3 {
+		t.Fatalf("key score = %v", got)
+	}
+	if got := scorer.Score(TermStats{Field: FieldValue}); got != 1.5 {
+		t.Fatalf("value score = %v", got)
+	}
+}
+
+func TestDefaultKeyFieldWeightMeasuredPlateau(t *testing.T) {
+	type fixture struct {
+		query string
+		want  string
+	}
+	fixtures := []fixture{{"alpha", "z-key-alpha"}, {"settings", "z-key-settings"}, {"calm", "value-calm"}}
+	measure := func(weight float64) int {
+		idx := NewInvertedIndex[string, Document](fakeAnalyzer{}, FieldWeighted{
+			Base: BM25{K1: DefaultBM25K1, B: DefaultBM25B}, KeyWeight: weight, ValueWeight: 1,
+		}, compareStringID)
+		idx.Index("a-value-alpha", Fields{{ID: FieldValue, Text: "alpha"}})
+		idx.Index("z-key-alpha", Fields{{ID: FieldKey, Text: "alpha"}})
+		idx.Index("a-value-settings", Fields{{ID: FieldValue, Text: "settings"}})
+		idx.Index("z-key-settings", Fields{{ID: FieldKey, Text: "settings"}})
+		idx.Index("value-calm", Fields{{ID: FieldValue, Text: "calm concise"}})
+		correct := 0
+		for _, fixture := range fixtures {
+			results := idx.Search(fixture.query)
+			if len(results) > 0 && results[0].ID == fixture.want {
+				correct++
+			}
+		}
+		return correct
+	}
+	if baseline := measure(1); baseline >= len(fixtures) {
+		t.Fatalf("unweighted baseline unexpectedly perfect: %d/%d", baseline, len(fixtures))
+	}
+	for _, weight := range []float64{DefaultKeyFieldWeight, 2, 2.25} {
+		if got := measure(weight); got != len(fixtures) {
+			t.Fatalf("key weight %.2f qrels = %d/%d", weight, got, len(fixtures))
+		}
+	}
+}

--- a/docs/decisions/0006-structured-search-fields.md
+++ b/docs/decisions/0006-structured-search-fields.md
@@ -1,0 +1,64 @@
+# 0006: Preserve key and value field boundaries in full-text search
+
+Status: Accepted
+
+## Context
+
+The original production projection concatenated a vertex key, one space, and
+its rendered value. JSON string leaves were also space-joined. That made a
+synthetic `key=alpha, value=beta` document satisfy phrase `alpha beta`, allowed
+proximity across unrelated JSON leaves, and mixed key/value length and document
+frequency statistics. Edge-created endpoint vertices were visible to point and
+prefix reads but absent from full-text search until an explicit vertex put.
+
+## Decision
+
+`core/search.Document` keeps its single-text contract and gains the optional
+`FieldedDocument` interface. Structured documents expose stable `FieldKey` and
+`FieldValue` instances; unstructured callers continue to use `FieldDefault`
+with byte-for-byte compatible behavior.
+
+The term dictionary and global candidate bitmap remain shared so exact,
+fuzzy, prefix-term, and match-mode membership retain key-or-value recall. Each
+posting additionally records field-local membership, term frequency, document
+length, corpus size, document frequency, and positions. BM25 therefore runs
+inside one field. Positions encode a field-instance number plus token offset;
+phrase and proximity require one common field instance and can never cross a
+key/value or JSON-leaf boundary.
+
+Key evidence uses a `1.75` multiplier; value/default evidence uses `1.0`. A
+pinned three-query qrel sweep records `1/3` top-1 accuracy without weighting
+and `3/3` across the measured `[1.75, 2.25]` plateau. The lowest plateau value
+is selected to lift exact namespace evidence conservatively.
+
+GraphCache's extractor receives `(key, value)`. Every endpoint auto-creation
+indexes a key-only structured document with the endpoint TTL; a later explicit
+put replaces it atomically with key plus value fields. JSON object traversal
+remains key-sorted, field names and non-string scalars remain excluded, and
+each string leaf becomes a separate value instance.
+
+The observable projection version changes from `vertex-key-value-v1` to
+`vertex-fields-v2` and remains part of the search config fingerprint.
+
+On the 20,000-document structured benchmark (Apple M3 Max, positions and
+two-term proximity enabled), the flattened and structured paths measured:
+
+| Projection | query latency | query alloc | retained heap |
+|---|---:|---:|---:|
+| flattened | 6.53 ms/op | 2,080 B/op, 54 allocs | 1,356 B/document |
+| structured | 6.67 ms/op | 2,058 B/op, 52 allocs | 1,478 B/document |
+
+The enabled default therefore paid about 2% query latency and 9% retained heap
+in this fixture; query allocations did not regress.
+
+## Consequences
+
+- Synthetic boundaries no longer create phrase or proximity evidence.
+- Key and value relevance can evolve through measured field weights without
+  changing the analyzer or duplicating dictionaries.
+- Field-local bitmaps and corpus counters add retained memory. The structured
+  benchmark records this cost next to query allocations and latency.
+- `MaxLivePostings` now counts `(document, term, field)` memberships, matching
+  the retained posting structures rather than only the shared term union.
+- Nodes with different projection versions are observably incompatible for
+  deterministic search convergence and future cursor portability.

--- a/sdks/go/search.go
+++ b/sdks/go/search.go
@@ -219,7 +219,9 @@ func validateSearchOptions(o searchOptions) error {
 }
 
 // SearchVertices returns vertices ranked by full-text relevance over their
-// indexed content (key + value) in stable (score DESC, raw key ASC) order. It
+// indexed key and value fields in stable (score DESC, raw key ASC) order. Field
+// boundaries are preserved for phrase/proximity and key evidence is weighted
+// independently by the server. It
 // is the content counterpart to ScanVertices' lexicographic key walk: search
 // by a remembered topic word instead of an exact key prefix.
 //

--- a/server/provider/search.go
+++ b/server/provider/search.go
@@ -15,12 +15,9 @@ import (
 // non-JSON text through unchanged (#758). It is stateless and safe to share.
 var jsonStringValueNormalizer search.JSONStringValueNormalizer
 
-// vertexSearchDocument projects a vertex into the text that the full-text
-// index analyses (#624). It folds the key together with the value so a query
-// matches either the namespace path or the stored content — this mirrors the
-// MCP search_facts semantics, where a remembered topic word may live in the
-// key (e.g. "user.preferences.tone") or in the value, and the caller should
-// not need to know which.
+// vertexSearchDocument projects a vertex into explicit key and value fields.
+// A query still matches either namespace path or stored content, but BM25,
+// phrase, and proximity evidence never cross their synthetic boundary (#1061).
 //
 // The value side is rendered to its natural human string: text and bytes
 // pass through, scalars are formatted decimally, timestamps use RFC3339 and
@@ -28,23 +25,38 @@ var jsonStringValueNormalizer search.JSONStringValueNormalizer
 // existence-only vertex is still discoverable by its key alone.
 //
 // String values that hold a JSON object or array are projected to just their
-// string values (#758): JSONStringValueNormalizer drops the field names and
-// non-string scalars so a serialized document is searchable by its content,
-// not by its structure. A JSON document carrying no string content therefore
-// folds in nothing and the vertex is indexed by its key alone.
-type vertexSearchProjection struct{ vertex *v1.Vertex }
+// string values (#758): JSONStringValueNormalizer drops field names and
+// non-string scalars, and each string leaf remains a separate value-field
+// instance. A JSON document carrying no string content is key-only.
+type vertexSearchProjection struct {
+	key    string
+	vertex *v1.Vertex
+}
 
-func vertexSearchDocument(v *v1.Vertex) search.Document { return vertexSearchProjection{vertex: v} }
+func vertexSearchDocument(key string, v *v1.Vertex) search.Document {
+	return vertexSearchProjection{key: key, vertex: v}
+}
+
+func (p vertexSearchProjection) SearchFields() []search.DocumentField {
+	fields := make([]search.DocumentField, 0, 2)
+	if p.key != "" {
+		fields = append(fields, search.DocumentField{ID: search.FieldKey, Text: p.key})
+	}
+	for _, text := range vertexValueTexts(p.vertex) {
+		if text != "" {
+			fields = append(fields, search.DocumentField{ID: search.FieldValue, Text: text})
+		}
+	}
+	return fields
+}
 
 func (p vertexSearchProjection) String() string {
-	if p.vertex == nil {
-		return ""
-	}
 	var b strings.Builder
-	b.WriteString(p.vertex.GetKey())
-	if text, ok := vertexValueText(p.vertex); ok && text != "" {
-		b.WriteByte(' ')
-		b.WriteString(text)
+	for _, field := range p.SearchFields() {
+		if b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(field.Text)
 	}
 	return b.String()
 }
@@ -54,9 +66,9 @@ func (p vertexSearchProjection) String() string {
 // it into an object tree. Invalid UTF-8 bytes are binary and contribute zero.
 func (p vertexSearchProjection) SizeHint() int {
 	if p.vertex == nil {
-		return 0
+		return len(p.key)
 	}
-	n := len(p.vertex.GetKey())
+	n := len(p.key)
 	var valueBytes int
 	switch value := p.vertex.GetValue().(type) {
 	case *v1.Vertex_String_:
@@ -80,41 +92,52 @@ func (p vertexSearchProjection) SizeHint() int {
 // whether the value carries any text at all. The unset and explicit-nil
 // variants return ("", false) so callers index the key only.
 func vertexValueText(v *v1.Vertex) (string, bool) {
+	values := vertexValueTexts(v)
+	return strings.Join(values, " "), len(values) > 0
+}
+
+func vertexValueTexts(v *v1.Vertex) []string {
+	if v == nil {
+		return nil
+	}
 	switch val := v.GetValue().(type) {
 	case *v1.Vertex_String_:
 		// A string value is often a serialized JSON document; index only its
 		// string values, never the JSON field names or non-string scalars
 		// (#758). Non-JSON text passes through unchanged. An all-structure or
 		// empty result folds in nothing (the caller drops empty value text).
-		return jsonStringValueNormalizer.Normalize(val.String_), true
+		if values, structured := jsonStringValueNormalizer.Values(val.String_); structured {
+			return values
+		}
+		return []string{val.String_}
 	case *v1.Vertex_Bytes:
 		// Binary payloads are not text by accident: only valid UTF-8 participates
 		// in full-text search. The projected-document byte budget is enforced by
 		// the index before tokenization.
 		if !utf8.Valid(val.Bytes) {
-			return "", false
+			return nil
 		}
-		return string(val.Bytes), true
+		return []string{string(val.Bytes)}
 	case *v1.Vertex_Float64:
-		return strconv.FormatFloat(val.Float64, 'g', -1, 64), true
+		return []string{strconv.FormatFloat(val.Float64, 'g', -1, 64)}
 	case *v1.Vertex_Float32:
-		return strconv.FormatFloat(float64(val.Float32), 'g', -1, 32), true
+		return []string{strconv.FormatFloat(float64(val.Float32), 'g', -1, 32)}
 	case *v1.Vertex_Int32:
-		return strconv.FormatInt(int64(val.Int32), 10), true
+		return []string{strconv.FormatInt(int64(val.Int32), 10)}
 	case *v1.Vertex_Int64:
-		return strconv.FormatInt(val.Int64, 10), true
+		return []string{strconv.FormatInt(val.Int64, 10)}
 	case *v1.Vertex_Uint32:
-		return strconv.FormatUint(uint64(val.Uint32), 10), true
+		return []string{strconv.FormatUint(uint64(val.Uint32), 10)}
 	case *v1.Vertex_Uint64:
-		return strconv.FormatUint(val.Uint64, 10), true
+		return []string{strconv.FormatUint(val.Uint64, 10)}
 	case *v1.Vertex_Bool:
-		return strconv.FormatBool(val.Bool), true
+		return []string{strconv.FormatBool(val.Bool)}
 	case *v1.Vertex_Timestamp:
-		return val.Timestamp.AsTime().Format(time.RFC3339Nano), true
+		return []string{val.Timestamp.AsTime().Format(time.RFC3339Nano)}
 	case *v1.Vertex_Duration:
-		return val.Duration.AsDuration().String(), true
+		return []string{val.Duration.AsDuration().String()}
 	default:
 		// Vertex_Nil and the unset oneof: key-only indexing.
-		return "", false
+		return nil
 	}
 }

--- a/server/provider/search_test.go
+++ b/server/provider/search_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -84,10 +85,46 @@ func TestVertexSearchDocument(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := vertexSearchDocument(tc.vertex).String(); got != tc.want {
+			if got := vertexSearchDocument(tc.vertex.GetKey(), tc.vertex).String(); got != tc.want {
 				t.Errorf("vertexSearchDocument = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestVertexSearchDocumentPreservesFieldInstances(t *testing.T) {
+	doc := vertexSearchDocument("alpha", &v1.Vertex{
+		Key: "alpha", Value: &v1.Vertex_String_{String_: `{"b":"beta gamma","a":"delta"}`},
+	}).(vertexSearchProjection)
+	want := []search.DocumentField{
+		{ID: search.FieldKey, Text: "alpha"},
+		{ID: search.FieldValue, Text: "delta"},
+		{ID: search.FieldValue, Text: "beta gamma"},
+	}
+	if got := doc.SearchFields(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("fields = %+v, want %+v", got, want)
+	}
+	endpoint := vertexSearchDocument("implicit.endpoint", nil).(vertexSearchProjection)
+	if got := endpoint.SearchFields(); !reflect.DeepEqual(got, []search.DocumentField{{ID: search.FieldKey, Text: "implicit.endpoint"}}) {
+		t.Fatalf("endpoint fields = %+v", got)
+	}
+}
+
+func TestNewGraphCacheSearchFieldBoundariesAndImplicitEndpoints(t *testing.T) {
+	gc := NewGraphCache(CacheConfig{TTL: time.Minute}, SearchConfig{Enabled: true, Positions: true})
+	expiration := time.Now().Add(time.Hour)
+	if err := gc.PutVertexWithExpiration("alpha", &v1.Vertex{Key: "alpha", Value: &v1.Vertex_String_{String_: "beta"}}, expiration); err != nil {
+		t.Fatal(err)
+	}
+	if err := gc.PutVertexWithExpiration("json", &v1.Vertex{Key: "json", Value: &v1.Vertex_String_{String_: `{"a":"alpha","b":"beta"}`}}, expiration); err != nil {
+		t.Fatal(err)
+	}
+	if hits := gc.SearchVerticesMatch("alpha beta", 10, "", search.MatchOptions{}, true); len(hits) != 0 {
+		t.Fatalf("synthetic cross-field phrase hits = %+v", hits)
+	}
+	gc.AddEdgeWithExpiration("implicit-tail", "implicit-head", 1, expiration)
+	if hits := gc.SearchVertices("tail", 10, ""); len(hits) == 0 || hits[0].ID != "implicit-tail" {
+		t.Fatalf("implicit endpoint hits = %+v", hits)
 	}
 }
 

--- a/server/service/search.go
+++ b/server/service/search.go
@@ -27,11 +27,11 @@ var errSearchPositionsDisabled = errors.New("phrase search requires positional p
 const (
 	searchMaxFuzziness      = uint32(2)
 	searchAnalyzerVersion   = "script-aware-v1"
-	searchProjectionVersion = "vertex-key-value-v1"
+	searchProjectionVersion = "vertex-fields-v2"
 )
 
 // SearchVertices returns vertices ranked by full-text relevance over their
-// indexed content (key + value) in stable (score DESC, raw key ASC) order. It
+// field-separated key and value content in stable (score DESC, raw key ASC) order. It
 // is the content counterpart to ScanVertices' lexicographic key walk: callers
 // search by remembered topic words instead of an exact key prefix.
 //

--- a/server/service/status_test.go
+++ b/server/service/status_test.go
@@ -144,7 +144,7 @@ func TestLanternService_GetServerStatus(t *testing.T) {
 		if got.GetDefaultMatchMode() != pb.MatchMode_MATCH_MODE_MIN_SHOULD || got.GetDefaultMinShouldMatch() != 2 {
 			t.Errorf("search defaults = %v/%d, want MIN_SHOULD/2", got.GetDefaultMatchMode(), got.GetDefaultMinShouldMatch())
 		}
-		if got.GetMaxFuzziness() != 2 || got.GetAnalyzerVersion() == "" || got.GetProjectionVersion() == "" {
+		if got.GetMaxFuzziness() != 2 || got.GetAnalyzerVersion() == "" || got.GetProjectionVersion() != "vertex-fields-v2" {
 			t.Errorf("search implementation capabilities incomplete: %+v", got)
 		}
 		if got.GetTimeoutMs() != 1500 || got.GetMaxQueryBytes() != 4096 || got.GetMaxQueryTerms() != 12 ||

--- a/testbed/bench/scenarios/search_churn.yaml
+++ b/testbed/bench/scenarios/search_churn.yaml
@@ -5,6 +5,8 @@
 #   slower vertex GC; the later eviction hook is an idempotent delete (#1057).
 # - thread-safety: concurrent index-write (PutVertex) vs Search read
 #   under the InvertedIndex RWMutex.
+# - structured projection: every write updates separate key/value field
+#   postings and field-local BM25/positions (`vertex-fields-v2`, #1061).
 # - consistency: SearchVertices purges vertices whose TTL has expired but whose
 #   Flush has not yet run, so BM25 stats and vocabulary use the returned live
 #   corpus rather than merely hiding dead keys (#1057).

--- a/tests/integration/search_vertices_test.go
+++ b/tests/integration/search_vertices_test.go
@@ -24,6 +24,7 @@ import (
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
 	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/anaregdesign/lantern/server/provider"
 	"github.com/anaregdesign/lantern/server/service"
 )
 
@@ -33,14 +34,12 @@ import (
 // integration suite cannot import the unexported provider helper, and the
 // exact value-type rendering is covered by the provider unit test — here we
 // only need a live index behind the RPC.
-func searchVertexDocument(v *pb.Vertex) search.Document {
-	var b strings.Builder
-	b.WriteString(v.GetKey())
-	if s := v.GetString_(); s != "" {
-		b.WriteByte(' ')
-		b.WriteString(s)
+func searchVertexDocument(key string, v *pb.Vertex) search.Document {
+	fields := search.Fields{{ID: search.FieldKey, Text: key}}
+	if v != nil && v.GetString_() != "" {
+		fields = append(fields, search.DocumentField{ID: search.FieldValue, Text: v.GetString_()})
 	}
-	return search.Text(b.String())
+	return fields
 }
 
 func wireSearchErrorReason(t *testing.T, err error) pb.SearchErrorReason {
@@ -618,6 +617,52 @@ func TestSearchVertices_PrefixCandidatePushdownOverRealH2C(t *testing.T) {
 	}
 	if observation := <-metrics.executions; observation.outcome != "ok" || observation.stats.CandidateVisits != 0 {
 		t.Fatalf("missing-prefix execution=%+v, want zero candidate visits", observation)
+	}
+}
+
+func TestSearchVertices_ProductionStructuredFieldsOverRealH2C(t *testing.T) {
+	cache := provider.NewGraphCache(provider.CacheConfig{TTL: time.Hour}, provider.SearchConfig{Enabled: true, Positions: true})
+	svc := service.NewLanternService(cache).WithSearchLimits(service.SearchLimits{
+		Enabled: true, PositionsEnabled: true, DefaultLimit: 20, MaxLimit: 100,
+	})
+	srv := newConnectTestServer(t, svc, nil)
+	raw := graphv1connect.NewLanternServiceClient(h2cClient(), srv.url)
+	sdk := newConnectClientFor(t, srv.url)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	expiration := time.Now().Add(time.Hour)
+	if err := sdk.PutVertices(ctx, []client.VertexInput{
+		{Key: "alpha", Value: "beta", Expiration: expiration},
+		{Key: "json-boundaries", Value: `{"a":"alpha","b":"beta"}`, Expiration: expiration},
+		{Key: "within-value", Value: "alpha beta", Expiration: expiration},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	phrase, err := raw.SearchVertices(ctx, connect.NewRequest(&pb.SearchVerticesRequest{
+		Query: "alpha beta", Limit: 20, Options: &pb.SearchOptions{Phrase: true},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hits := phrase.Msg.GetHits(); len(hits) != 1 || hits[0].GetKey() != "within-value" {
+		t.Fatalf("phrase hits = %+v, want only within-value", hits)
+	}
+	if _, err := sdk.AddEdge(ctx, "implicit-tail-key", "implicit-head-key", 1, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	endpoint, err := sdk.SearchVertices(ctx, "implicit-tail-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(endpoint) == 0 || endpoint[0].Key != "implicit-tail-key" {
+		t.Fatalf("implicit endpoint hits = %+v", endpoint)
+	}
+	status, err := raw.GetServerStatus(ctx, connect.NewRequest(&pb.GetServerStatusRequest{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := status.Msg.GetSearch().GetProjectionVersion(); got != "vertex-fields-v2" {
+		t.Fatalf("projection version = %q", got)
 	}
 }
 


### PR DESCRIPTION
## What changed

- add `FieldedDocument` with stable default/key/value fields while preserving the existing single-text `Document` API
- keep one term dictionary/candidate bitmap, but store field-local membership, TF, DF/N/length statistics, and field-instance positions
- prevent phrase/proximity evidence from crossing key/value or separate JSON string leaves
- add measured field weighting (`key=1.75`, value/default `1.0`) and preserve exact bounded/exhaustive agreement
- change the GraphCache extractor seam to `(key, value)` and index auto-created/revived endpoints as key-only documents
- split production JSON string leaves into independent value fields and expose projection version `vertex-fields-v2` in status/fingerprint
- add an ADR, README/SDK guidance, benchmark, lifecycle/race tests, and a production-composed real Connect/h2c contract

## Why

The v1 projector concatenated key and rendered value into one token stream. That synthesized phrases such as `key=alpha, value=beta`, allowed proximity across unrelated JSON leaves, mixed field statistics, and left edge-created endpoint vertices absent from full-text search.

The v2 model preserves key-or-value recall while making phrase, proximity, scoring, and endpoint lifecycle truthful.

## Measured impact

- pinned key-field qrels: unweighted `1/3` top-1; weights `1.75`, `2.0`, and `2.25` all `3/3`; selected the lowest plateau value
- 20K docs, positions/proximity enabled, 3 query iterations on Apple M3 Max:
  - flat: `6.53 ms/op`, `2,080 B/op`, `54 allocs/op`, `1,356 retained heap B/doc`
  - structured: `6.67 ms/op`, `2,058 B/op`, `52 allocs/op`, `1,478 retained heap B/doc`
  - about +2% latency / +9% retained heap, with no query-allocation regression

## Validation

- `gofmt -l .` and `git diff --check`
- pinned `golangci-lint v2.12.2` on the branch diff: 0 issues
- `go vet`, `go build`, and `go test ./...` in all six Go modules
- targeted `-race` for structured scoring, endpoint lifecycle, concurrent prefix search/write/cancellation, provider composition, and real h2c
- full core relevance floors
- Dart package format/analyze/test and Flutter example format/analyze/test
- real h2c happy path: key/value/JSON boundaries, implicit endpoint lookup, and projection capability v2
- edge contracts: cross-boundary phrase returns no hit; endpoint delete/TTL/revival leaves no stale postings

Closes #1061
