### PR TITLE
feat(search): correct Unicode analysis and two-rune infix semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,12 @@ edge-created endpoint vertices are immediately searchable by key. Hits use the
 stable total order `(score DESC, raw key ASC)` and make
 natural seeds for a follow-up `bfs`, `pagerank`, or `community` walk:
 
+The production analyzer uses Unicode full case folding and canonical NFC,
+preserves meaningful Thai/Indic/accent marks, and keeps emoji/Unicode symbols
+searchable. A two-rune Latin query participates in both the exact-word and
+auxiliary infix channels (`ar` recalls `search`), while exact whole-word
+evidence retains the higher score.
+
 ```shell
 lantern-cli search "rolling update"              # use the server's configured mode
 lantern-cli search "rolling update" --mode all   # require every word (AND)

--- a/core/graphcache/search.go
+++ b/core/graphcache/search.go
@@ -10,15 +10,16 @@ import (
 
 // newSearchIndex builds the inverted index used by the optional content-search
 // feature. Since #888 it installs the script-aware dual-channel pipeline
-// (search.NewScriptAwareAnalyzer): width / diacritic / lowercase / punctuation
-// / space normalizers feed a ScriptAwareTokenizer whose word runs index whole
+// (search.NewScriptAwareAnalyzer): width / NFC / full-case / emoji-presentation
+// / punctuation / space normalizers feed a ScriptAwareTokenizer whose word runs index whole
 // words (primary) plus intra-word bigrams (auxiliary, for infix and typo
 // recall) and whose unbounded-script (CJK-like) runs index bigrams as the
 // word-level unit. Matches are ranked by Okapi BM25 with the standard
 // parameters, wrapped in ClassWeighted so auxiliary gram evidence counts at
 // DefaultGramWeight and a whole-word match dominates fragment matches. The
-// same analyzer runs over both stored values and queries, so index-time and
-// query-time terms stay symmetric.
+// Query analysis adds only the two-rune auxiliary term needed to make short
+// infix recall continuous. Match modes count ClassWord terms only; document
+// postings and corpus statistics remain unchanged.
 //
 // Since #889 the index also records positional postings (WithPositions): the
 // token positions of each primary-channel term, so the search layer can tell

--- a/core/search/analyzer.go
+++ b/core/search/analyzer.go
@@ -1,11 +1,22 @@
 package search
 
-// Analyzer converts raw text into the sequence of index terms used by both
-// indexing and querying. Running the same Analyzer on documents and on queries
-// is what keeps the two sides symmetric. Implementations in this package are
+import "unicode/utf8"
+
+// Analyzer converts raw text into index terms. Queries use the same Analyze
+// method unless the dynamic implementation also provides QueryAnalyzer for a
+// documented query-only recall channel. Implementations in this package are
 // stateless and safe for concurrent use by multiple goroutines.
 type Analyzer interface {
 	Analyze(text string) []Token
+}
+
+// QueryAnalyzer is an optional asymmetric analysis extension. An index always
+// calls Analyze for documents; when the dynamic Analyzer also implements this
+// interface it calls AnalyzeQuery for search input. Match-mode coverage remains
+// defined solely by ClassWord; extra ClassGram terms are ranking evidence.
+type QueryAnalyzer interface {
+	Analyzer
+	AnalyzeQuery(text string) []Token
 }
 
 // boundedAnalyzer lets the index stop a production analysis pipeline as soon
@@ -65,8 +76,9 @@ func NewNGramAnalyzer(n int) Analyzer {
 }
 
 // NewScriptAwareAnalyzer returns the production analyzer for mixed-script
-// content search (#888): the full folding pipeline — width, diacritic,
-// lowercase, punctuation, and space normalizers — feeding a
+// content search (#888, #1067): width folding, canonical normalization, full
+// Unicode case folding, emoji-presentation folding, punctuation boundaries,
+// and space normalization feeding a
 // ScriptAwareTokenizer at N = 2. Space-delimited scripts index whole words as
 // primary tokens plus intra-word bigrams as auxiliary tokens, and unbounded
 // (CJK-like) scripts index bigrams as primary tokens, so one analyzer serves
@@ -75,20 +87,50 @@ func NewNGramAnalyzer(n int) Analyzer {
 // ClassWeighted scorer so the auxiliary grams keep infix and typo recall
 // without outranking whole-word matches. No token filter is needed: the
 // tokenizer already drops delimiters and never emits a gram across a word
-// boundary.
+// boundary. Query analysis adds a ClassGram copy of a two-rune primary term,
+// making "ar" recall "search" while the exact whole-word document still wins
+// through the higher-weight ClassWord channel. Document postings stay unchanged.
 func NewScriptAwareAnalyzer() Analyzer {
-	return NewAnalyzer(
+	pipeline := NewAnalyzer(
 		[]Normalizer{
 			WidthNormalizer{},
-			DiacriticNormalizer{},
-			LowercaseNormalizer{},
-			PunctuationNormalizer{},
+			CanonicalNormalizer{},
+			CaseFoldNormalizer{},
+			EmojiPresentationNormalizer{},
+			SymbolPreservingPunctuationNormalizer{},
 			SpaceNormalizer{},
 		},
 		ScriptAwareTokenizer{N: 2},
 		nil,
 	)
+	return &scriptAwareAnalyzer{pipeline: pipeline.(*pipelineAnalyzer)}
 }
+
+type scriptAwareAnalyzer struct {
+	pipeline *pipelineAnalyzer
+}
+
+func (a *scriptAwareAnalyzer) Analyze(text string) []Token {
+	return a.pipeline.Analyze(text)
+}
+
+func (a *scriptAwareAnalyzer) AnalyzeBounded(text string, maxTokens int) ([]Token, bool) {
+	return a.pipeline.AnalyzeBounded(text, maxTokens)
+}
+
+func (a *scriptAwareAnalyzer) AnalyzeQuery(text string) []Token {
+	tokens := a.Analyze(text)
+	baseLen := len(tokens)
+	for i := 0; i < baseLen; i++ {
+		if tokens[i].Class == ClassWord && utf8.RuneCountInString(tokens[i].Term) == 2 && !isCJKPrimaryTerm(tokens[i].Term) {
+			tokens = append(tokens, Token{Term: tokens[i].Term, Class: ClassGram})
+		}
+	}
+	return tokens
+}
+
+var _ QueryAnalyzer = (*scriptAwareAnalyzer)(nil)
+var _ boundedAnalyzer = (*scriptAwareAnalyzer)(nil)
 
 // Analyze runs text through the normalizers, tokenizer, and filter chain.
 func (a *pipelineAnalyzer) Analyze(text string) []Token {

--- a/core/search/analyzer_test.go
+++ b/core/search/analyzer_test.go
@@ -86,10 +86,10 @@ func TestNewScriptAwareAnalyzer(t *testing.T) {
 			{Term: "ok", Class: ClassGram},
 			{Term: "ky", Class: ClassGram},
 			{Term: "yo", Class: ClassGram},
-			{Term: "cafe", Class: ClassWord},
+			{Term: "café", Class: ClassWord},
 			{Term: "ca", Class: ClassGram},
 			{Term: "af", Class: ClassGram},
-			{Term: "fe", Class: ClassGram},
+			{Term: "fé", Class: ClassGram},
 		}
 		if !tokensEqual(got, want) {
 			t.Fatalf("Analyze = %v, want %v", got, want)
@@ -122,4 +122,116 @@ func TestNewScriptAwareAnalyzer(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("FullCaseFoldAndCanonicalEquivalence", func(t *testing.T) {
+		if got, want := a.Analyze("Straße ΟΣ cafe\u0301"), a.Analyze("STRASSE ος café"); !tokensEqual(got, want) {
+			t.Fatalf("case/canonical equivalents differ:\n got %v\nwant %v", got, want)
+		}
+	})
+
+	t.Run("MeaningfulMarksRemainInPrimaryTerms", func(t *testing.T) {
+		for _, pair := range [][2]string{{"กา", "ก่า"}, {"कल", "काल"}, {"cafe", "café"}} {
+			left := primaryTerms(a.Analyze(pair[0]))
+			right := primaryTerms(a.Analyze(pair[1]))
+			if tokensEqual(left, right) {
+				t.Fatalf("Analyze(%q) and Analyze(%q) collapsed to %v", pair[0], pair[1], left)
+			}
+		}
+	})
+
+	t.Run("EmojiPresentationEquivalentButZWJIntentDistinct", func(t *testing.T) {
+		if got, want := a.Analyze("❤"), a.Analyze("❤️"); !tokensEqual(got, want) {
+			t.Fatalf("emoji presentation differs: %v vs %v", got, want)
+		}
+		if tokensEqual(a.Analyze("👩‍💻"), a.Analyze("👩‍🔬")) {
+			t.Fatal("distinct ZWJ emoji sequences collapsed")
+		}
+	})
+
+	t.Run("TwoRuneQueryAddsAuxiliaryChannel", func(t *testing.T) {
+		qa, ok := a.(QueryAnalyzer)
+		if !ok {
+			t.Fatal("production analyzer does not implement QueryAnalyzer")
+		}
+		want := []Token{{Term: "ar", Class: ClassWord}, {Term: "ar", Class: ClassGram}}
+		if got := qa.AnalyzeQuery("ar"); !tokensEqual(got, want) {
+			t.Fatalf("AnalyzeQuery(ar) = %v, want %v", got, want)
+		}
+		if got := a.Analyze("ar"); !tokensEqual(got, want[:1]) {
+			t.Fatalf("document Analyze(ar) = %v, want word channel only", got)
+		}
+		cjk := []Token{{Term: "東京", Class: ClassWord}}
+		if got := qa.AnalyzeQuery("東京"); !tokensEqual(got, cjk) {
+			t.Fatalf("AnalyzeQuery(東京) = %v, want unchanged primary CJK bigram", got)
+		}
+	})
+}
+
+func primaryTerms(tokens []Token) []Token {
+	out := make([]Token, 0, len(tokens))
+	for _, token := range tokens {
+		if token.Class == ClassWord {
+			out = append(out, token)
+		}
+	}
+	return out
+}
+
+func FuzzScriptAwareAnalyzer(f *testing.F) {
+	for _, seed := range []string{"Straße", "cafe\u0301", "สวัสดี", "हिन्दी", "👩‍💻", string([]byte{0xff, 'a', 0xfe})} {
+		f.Add(seed, uint8(16))
+	}
+	a := NewScriptAwareAnalyzer()
+	f.Fuzz(func(t *testing.T, text string, rawLimit uint8) {
+		limit := int(rawLimit) + 1
+		tokens := a.Analyze(text)
+		// Each input rune can produce at most one primary token plus one
+		// auxiliary bigram, with a small constant allowance for case-fold
+		// expansion and symbol clusters. This catches accidental unbounded
+		// expansion while accepting malformed UTF-8's replacement runes.
+		if len(tokens) > 2*len([]rune(text))+4 {
+			t.Fatalf("Analyze expanded %d runes to %d tokens", len([]rune(text)), len(tokens))
+		}
+		bounded, ok := a.(boundedAnalyzer)
+		if !ok {
+			t.Fatal("production analyzer is not bounded")
+		}
+		got, exceeded := bounded.AnalyzeBounded(text, limit)
+		if exceeded && got != nil {
+			t.Fatalf("bounded overflow retained %d tokens", len(got))
+		}
+		if !exceeded && len(got) > limit {
+			t.Fatalf("bounded analysis returned %d tokens over limit %d", len(got), limit)
+		}
+	})
+}
+
+// BenchmarkScriptAwareAnalyzerVersions measures the CPU/allocation cost of the
+// #1067 Unicode policy against the previously shipped v1 pipeline.
+func BenchmarkScriptAwareAnalyzerVersions(b *testing.B) {
+	v1 := NewAnalyzer(
+		[]Normalizer{WidthNormalizer{}, DiacriticNormalizer{}, LowercaseNormalizer{}, PunctuationNormalizer{}, SpaceNormalizer{}},
+		ScriptAwareTokenizer{N: 2}, nil,
+	)
+	v2 := NewScriptAwareAnalyzer()
+	// Keep the comparison corpus on scripts whose tokenizer policy did not
+	// change, isolating the analyzer v2 transforms from the separately tested
+	// Thai/Indic/emoji tokenization behavior.
+	text := "Straße café ΟΣ 東京 2026 full-text search"
+	for _, tc := range []struct {
+		name     string
+		analyzer Analyzer
+	}{
+		{"V1", v1},
+		{"V2", v2},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if got := tc.analyzer.Analyze(text); len(got) == 0 {
+					b.Fatal("no tokens")
+				}
+			}
+		})
+	}
 }

--- a/core/search/inverted_index.go
+++ b/core/search/inverted_index.go
@@ -13,8 +13,9 @@ import (
 // InvertedIndex is a generic, in-memory inverted index that maps each
 // analyzed term to the documents whose text contains it. It is the default
 // Indexer + Searcher implementation: indexed documents (any Document, via
-// doc.String()) and raw queries pass through the same Analyzer, so index-time
-// and query-time terms stay symmetric.
+// doc.String()) and raw queries pass through the configured Analyzer. An
+// optional QueryAnalyzer may add query-only evidence; otherwise index-time and
+// query-time terms stay symmetric.
 //
 // It splits the two responsibilities of relevance search. The index owns
 // matching and the statistics behind it — per-document term frequencies and
@@ -879,7 +880,7 @@ func (idx *InvertedIndex[S, D]) Search(query string) []Result[S] {
 // weight once per channel and floating-point contributions are accumulated in
 // the same order on every call and replica.
 func (idx *InvertedIndex[S, D]) queryTerms(query string) []Token {
-	tokens := idx.analyzer.Analyze(query)
+	tokens := idx.analyzeQuery(query)
 	if len(tokens) == 0 {
 		return nil
 	}
@@ -899,6 +900,13 @@ func (idx *InvertedIndex[S, D]) queryTerms(query string) []Token {
 		return queryTerms[i].Term < queryTerms[j].Term
 	})
 	return queryTerms
+}
+
+func (idx *InvertedIndex[S, D]) analyzeQuery(query string) []Token {
+	if analyzer, ok := idx.analyzer.(QueryAnalyzer); ok {
+		return analyzer.AnalyzeQuery(query)
+	}
+	return idx.analyzer.Analyze(query)
 }
 
 // scoreLocked computes the OR-union score map for a distinct query-term set;

--- a/core/search/inverted_index_test.go
+++ b/core/search/inverted_index_test.go
@@ -1088,6 +1088,53 @@ func BenchmarkSearchTopKBroadQuery(b *testing.B) {
 	})
 }
 
+// BenchmarkSearchTwoRuneInfix measures the production #1067 path on a broad
+// two-rune query and records retained heap next to the pre-v2 comparable
+// four-rune query. The corpus is identical across cases.
+func BenchmarkSearchTwoRuneInfix(b *testing.B) {
+	const documents = 20_000
+	legacy := func() Analyzer {
+		return NewAnalyzer(
+			[]Normalizer{WidthNormalizer{}, DiacriticNormalizer{}, LowercaseNormalizer{}, PunctuationNormalizer{}, SpaceNormalizer{}},
+			ScriptAwareTokenizer{N: 2}, nil,
+		)
+	}
+	for _, tc := range []struct {
+		name     string
+		analyzer func() Analyzer
+		query    string
+	}{
+		{"V1-arch", legacy, "arch"},
+		{"V2-arch", NewScriptAwareAnalyzer, "arch"},
+		{"V2-ar", NewScriptAwareAnalyzer, "ar"},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			runtime.GC()
+			var before runtime.MemStats
+			runtime.ReadMemStats(&before)
+			idx := NewInvertedIndex[string, Text](tc.analyzer(), ClassWeighted{
+				Base: BM25{K1: DefaultBM25K1, B: DefaultBM25B}, GramWeight: DefaultGramWeight,
+			}, compareStringID)
+			for i := 0; i < documents; i++ {
+				idx.Index(fmt.Sprintf("doc-%05d", i), Text(fmt.Sprintf("full text search archive shard %05d", i)))
+			}
+			runtime.GC()
+			var after runtime.MemStats
+			runtime.ReadMemStats(&after)
+			heapBytesPerDoc := float64(after.HeapAlloc-before.HeapAlloc) / documents
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if got := idx.SearchTopK(tc.query, 10, nil); len(got) != 10 {
+					b.Fatalf("results=%d", len(got))
+				}
+			}
+			runtime.KeepAlive(idx)
+			b.ReportMetric(heapBytesPerDoc, "heap-B/doc")
+		})
+	}
+}
+
 // TestInvertedIndexDualClass covers the per-class posting tables (#888): the
 // two channels keep separate statistics and identities, a class-aware scorer
 // ranks whole-word evidence above fragment evidence, and deletes reclaim both

--- a/core/search/match_mode.go
+++ b/core/search/match_mode.go
@@ -62,6 +62,7 @@ func (idx *InvertedIndex[S, D]) SearchMatch(query string, opts MatchOptions) []R
 		return nil
 	}
 	queryTerms := idx.queryTerms(query)
+	queryTerms = queryTermsForMatchOptions(queryTerms, opts)
 	if len(queryTerms) == 0 {
 		return nil
 	}
@@ -115,6 +116,7 @@ func (idx *InvertedIndex[S, D]) SearchMatchTopKCandidatesContextAt(ctx context.C
 		return nil, work.stats, err
 	}
 	queryTerms := idx.queryTerms(query)
+	queryTerms = queryTermsForMatchOptions(queryTerms, opts)
 	if err := work.visit(WorkQueryTerms, int64(len(queryTerms))); err != nil {
 		return nil, work.stats, err
 	}
@@ -137,6 +139,32 @@ func (idx *InvertedIndex[S, D]) SearchMatchTopKCandidatesContextAt(ctx context.C
 		return nil, work.stats, err
 	}
 	return results, work.stats, nil
+}
+
+// queryTermsForMatchOptions removes the query-only exact-width gram when the
+// primary term is itself undergoing prefix/fuzzy expansion. Keeping both would
+// let the exact gram bypass the bounded semantic-expansion candidate set. The
+// ordinary exact path retains it for #1067 two-rune infix recall.
+func queryTermsForMatchOptions(terms []Token, opts MatchOptions) []Token {
+	if !opts.expandsTerms() {
+		return terms
+	}
+	words := make(map[string]struct{}, len(terms))
+	for _, term := range terms {
+		if term.Class == ClassWord {
+			words[term.Term] = struct{}{}
+		}
+	}
+	out := terms[:0]
+	for _, term := range terms {
+		if term.Class == ClassGram {
+			if _, duplicate := words[term.Term]; duplicate {
+				continue
+			}
+		}
+		out = append(out, term)
+	}
+	return out
 }
 
 // scoredMatchesLocked builds the final score map for a query under opts: the

--- a/core/search/normalizer.go
+++ b/core/search/normalizer.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"unicode"
 
+	"golang.org/x/text/cases"
 	"golang.org/x/text/unicode/norm"
 	"golang.org/x/text/width"
 )
@@ -29,6 +30,24 @@ type LowercaseNormalizer struct{}
 
 // Normalize returns the lower-cased text.
 func (LowercaseNormalizer) Normalize(text string) string { return strings.ToLower(text) }
+
+// CaseFoldNormalizer applies Unicode's language-neutral full case fold. Unlike
+// lowercasing, case folding expands equivalences such as German sharp-s to
+// "ss" and maps both Greek sigma forms to sigma. It deliberately does not
+// apply locale-specific mappings (for example Turkish dotted/dotless I).
+type CaseFoldNormalizer struct{}
+
+// Normalize returns the Unicode case-folded text.
+func (CaseFoldNormalizer) Normalize(text string) string { return cases.Fold().String(text) }
+
+// CanonicalNormalizer converts canonically equivalent spellings to NFC while
+// preserving every combining mark. It is the conservative production choice:
+// composed/decomposed input matches, but Thai tones, Indic viramas/matras,
+// accents, niqqud, and harakat are never erased as a recall shortcut.
+type CanonicalNormalizer struct{}
+
+// Normalize returns text in Unicode NFC.
+func (CanonicalNormalizer) Normalize(text string) string { return norm.NFC.String(text) }
 
 // SpaceNormalizer collapses every run of Unicode whitespace to a single ASCII
 // space and trims the ends. It is useful in front of a WhitespaceTokenizer when
@@ -54,6 +73,39 @@ func (PunctuationNormalizer) Normalize(text string) string {
 	return strings.Map(func(r rune) rune {
 		if isPunctOrSymbol(r) {
 			return ' '
+		}
+		return r
+	}, text)
+}
+
+// SymbolPreservingPunctuationNormalizer replaces Unicode punctuation with a
+// boundary while retaining symbols as searchable content. Production search
+// uses it so emoji and intentional mathematical/currency symbols do not vanish;
+// callers that want the older punctuation-and-symbol boundary policy can keep
+// using PunctuationNormalizer.
+type SymbolPreservingPunctuationNormalizer struct{}
+
+// Normalize replaces punctuation, but not symbols, with an ASCII space.
+func (SymbolPreservingPunctuationNormalizer) Normalize(text string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsPunct(r) {
+			return ' '
+		}
+		return r
+	}, text)
+}
+
+// EmojiPresentationNormalizer removes the text/emoji presentation selectors
+// U+FE0E and U+FE0F. Presentation is a rendering preference rather than lexical
+// identity, so "❤", "❤︎", and "❤️" share one searchable term. ZWJ and skin-tone
+// modifiers remain significant.
+type EmojiPresentationNormalizer struct{}
+
+// Normalize removes Unicode variation selectors 15 and 16.
+func (EmojiPresentationNormalizer) Normalize(text string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\ufe0e' || r == '\ufe0f' {
+			return -1
 		}
 		return r
 	}, text)

--- a/core/search/normalizer_test.go
+++ b/core/search/normalizer_test.go
@@ -11,6 +11,38 @@ func TestLowercaseNormalizer(t *testing.T) {
 	}
 }
 
+func TestCaseFoldNormalizer(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"GermanSharpS", "Straße", "strasse"},
+		{"GreekFinalSigma", "ΟΣ ος οσ", "οσ οσ οσ"},
+		{"TurkishIsLanguageNeutral", "İ I ı i", "i̇ i ı i"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := (CaseFoldNormalizer{}).Normalize(tc.in); got != tc.want {
+				t.Fatalf("Normalize(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalNormalizer(t *testing.T) {
+	composed := "café"
+	decomposed := "cafe\u0301"
+	if got := (CanonicalNormalizer{}).Normalize(decomposed); got != composed {
+		t.Fatalf("Normalize(%q) = %q, want NFC %q", decomposed, got, composed)
+	}
+	for _, text := range []string{"สวัสดี", "हिन्दी", "Ελλάδα", "ёж"} {
+		if got := (CanonicalNormalizer{}).Normalize(text); got != text {
+			t.Fatalf("Normalize(%q) = %q, want meaningful marks preserved", text, got)
+		}
+	}
+}
+
 func TestSpaceNormalizer(t *testing.T) {
 	if got := (SpaceNormalizer{}).Normalize("  a\t\nb   c  "); got != "a b c" {
 		t.Fatalf("Normalize = %q, want %q", got, "a b c")
@@ -33,6 +65,19 @@ func TestPunctuationNormalizer(t *testing.T) {
 	// than being preserved as PunctuationFilter would.
 	if got := (PunctuationNormalizer{}).Normalize("a=b+node-1"); got != "a b node 1" {
 		t.Fatalf("Normalize = %q, want %q", got, "a b node 1")
+	}
+}
+
+func TestSymbolPreservingPunctuationNormalizer(t *testing.T) {
+	got := (SymbolPreservingPunctuationNormalizer{}).Normalize("go,node+❤ 👩‍💻")
+	if got != "go node+❤ 👩‍💻" {
+		t.Fatalf("Normalize = %q, want punctuation boundaries and symbols preserved", got)
+	}
+}
+
+func TestEmojiPresentationNormalizer(t *testing.T) {
+	if got := (EmojiPresentationNormalizer{}).Normalize("❤︎ ❤️"); got != "❤ ❤" {
+		t.Fatalf("Normalize = %q, want presentation selectors removed", got)
 	}
 }
 

--- a/core/search/phrase.go
+++ b/core/search/phrase.go
@@ -105,7 +105,7 @@ func (idx *InvertedIndex[S, D]) SearchPhraseTopKCandidatesContextAt(ctx context.
 // run's grams are themselves ClassWord, so they are kept and verified by the
 // same pos+1 rule.
 func (idx *InvertedIndex[S, D]) phraseQueryTerms(query string) []string {
-	tokens := idx.analyzer.Analyze(query)
+	tokens := idx.analyzeQuery(query)
 	var terms []string
 	for _, t := range tokens {
 		if t.Class == ClassWord {

--- a/core/search/quality_gate_test.go
+++ b/core/search/quality_gate_test.go
@@ -489,3 +489,96 @@ func TestSearchQualityGateScriptAware(t *testing.T) {
 		})
 	}
 }
+
+// TestSearchQualityGateUnicodeMinimalPairs is the reviewed #1067 qrel set.
+// Grade 3 identifies the intended lexical identity; grade 1 permits an
+// auxiliary-gram recall hit without allowing it to outrank the exact word.
+func TestSearchQualityGateUnicodeMinimalPairs(t *testing.T) {
+	docs := map[string]string{
+		"sharp":       "Straße",
+		"ss":          "Strasse",
+		"accented":    "café",
+		"plain":       "cafe",
+		"thai-plain":  "กา",
+		"thai-tone":   "ก่า",
+		"indic-short": "कल",
+		"indic-long":  "काल",
+		"heart":       "❤",
+		"heart-emoji": "❤️",
+		"developer":   "👩‍💻",
+		"scientist":   "👩‍🔬",
+		"cjk":         "東京",
+		"digits":      "2026",
+		"mixed":       "東京 Go 2026",
+	}
+	queries := []struct {
+		name  string
+		text  string
+		qrels map[string]int
+	}{
+		{"case-fold-sharp-s", "STRASSE", map[string]int{"sharp": 3, "ss": 3}},
+		{"canonical-composition", "cafe\u0301", map[string]int{"accented": 3, "plain": 1}},
+		{"accent-distinction", "cafe", map[string]int{"plain": 3, "accented": 1}},
+		{"thai-mark-distinction", "ก่า", map[string]int{"thai-tone": 3}},
+		{"indic-mark-distinction", "काल", map[string]int{"indic-long": 3}},
+		{"emoji-presentation", "❤️", map[string]int{"heart": 3, "heart-emoji": 3}},
+		{"emoji-zwj-distinction", "👩‍💻", map[string]int{"developer": 3}},
+		{"cjk", "東京", map[string]int{"cjk": 3, "mixed": 2}},
+		{"digits", "2026", map[string]int{"digits": 3, "mixed": 2}},
+	}
+
+	idx := scriptAwareIndex()
+	for id, text := range docs {
+		idx.Index(id, Text(text))
+	}
+	for _, query := range queries {
+		t.Run(query.name, func(t *testing.T) {
+			results := idx.Search(query.text)
+			if len(results) == 0 {
+				t.Fatal("no results")
+			}
+			if grade := query.qrels[results[0].ID]; grade != 3 {
+				t.Fatalf("top %q has grade %d, want 3; results=%v", results[0].ID, grade, idsOf(results))
+			}
+			for id, grade := range query.qrels {
+				if grade == 3 && !containsID(results, id) {
+					t.Errorf("missing grade-3 result %q; results=%v", id, idsOf(results))
+				}
+			}
+		})
+	}
+}
+
+func containsID(results []Result[string], id string) bool {
+	for _, result := range results {
+		if result.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSearchQualityGateTwoRuneInfix(t *testing.T) {
+	idx := scriptAwareIndex()
+	idx.Index("exact", Text("ar"))
+	idx.Index("carrier", Text("search"))
+	idx.Index("noise", Text("graph"))
+	results := idx.Search("ar")
+	if got := idsOf(results); !equalStrings(got, []string{"exact", "carrier"}) {
+		t.Fatalf("Search(ar) = %v, want exact then carrier", got)
+	}
+	all := idx.SearchMatch("ar", MatchOptions{Mode: MatchAll})
+	if got := idsOf(all); !equalStrings(got, []string{"exact"}) {
+		t.Fatalf("SearchMatch(ar, all) = %v, want only exact channel-complete word", got)
+	}
+	cjk := scriptAwareIndex()
+	cjk.Index("exact", Text("東京"))
+	cjk.Index("carrier", Text("東京都"))
+	if got := idsOf(cjk.SearchMatch("東京", MatchOptions{Mode: MatchAll})); !equalStrings(got, []string{"exact", "carrier"}) {
+		t.Fatalf("CJK MatchAll = %v, want primary-bigram behavior preserved", got)
+	}
+	prefix := idx.SearchMatch("ar", MatchOptions{PrefixTerms: true})
+	if got := idsOf(prefix); !equalStrings(got, []string{"exact"}) {
+		t.Fatalf("prefix SearchMatch(ar) = %v, supplemental gram bypassed expansion semantics", got)
+	}
+}

--- a/core/search/relevance/parity_gate_test.go
+++ b/core/search/relevance/parity_gate_test.go
@@ -24,7 +24,8 @@ import (
 // productionIndex replicates the exact index core/graphcache.newSearchIndex
 // builds for SearchVertices — since #888 the script-aware dual-channel
 // analyzer with class-weighted BM25, and since #889 with positional postings
-// (WithPositions) for phrase and proximity ranking. It is intentionally a
+// (WithPositions) for phrase and proximity ranking. Since #1067 query analysis
+// adds a two-rune auxiliary term and Unicode identity follows analyzer v2. It is intentionally a
 // replica, not an import: graphcache depends on search, so this package (a
 // sibling under search) states the pipeline explicitly, and this comment plus
 // the one on newSearchIndex keep the two in sync.

--- a/core/search/script_tokenizer.go
+++ b/core/search/script_tokenizer.go
@@ -15,18 +15,22 @@ import "unicode"
 //     bigram pipeline's infix recall ("arch" finding "search") and typo
 //     tolerance; pair the index with ClassWeighted so this redundant channel
 //     stays evidence, not the ranking.
-//   - A run of an unbounded script — one written without spaces between
-//     words: Han, Hiragana, Katakana, Hangul, Thai, Lao, Khmer, Myanmar —
+//   - A CJKBigram run — Unicode Ideographic characters, Hiragana, Katakana,
+//     and Hangul, following Lucene's documented CJKBigramFilter script set —
 //     emits its N-rune windows as primary tokens, exactly the strategy of
 //     Lucene's CJKAnalyzer, because there the gram is the word-level unit. A
 //     run shorter than N (a lone ideograph) is emitted whole, so single-
 //     character words stay searchable.
-//   - Every other rune (whitespace, punctuation, symbols) delimits runs and
-//     is dropped, so no gram ever straddles a word boundary and the
+//   - Combining marks continue the preceding lexical run, preserving Thai and
+//     Indic identity. Each Unicode symbol is searchable as one primary token;
+//     ZWJ-linked symbols form one token and adjacent unjoined symbols do not.
+//   - Every other rune (whitespace and punctuation) delimits runs and is
+//     dropped, so no gram ever straddles a word boundary and the
 //     WhitespaceFilter step of the plain n-gram pipeline is unnecessary.
 //
-// Run it after the folding normalizers (width, diacritic, lowercase,
-// punctuation, space) — NewScriptAwareAnalyzer wires that pipeline. In
+// Run it after the production normalizers (width, canonical composition, full
+// case fold, emoji presentation, punctuation, space) — NewScriptAwareAnalyzer
+// wires that pipeline. In
 // particular WidthNormalizer must run first so half-width katakana joins the
 // katakana run it belongs to. N < 2 is treated as 2 (bigrams), so the zero
 // value is the production configuration. It holds no state and is safe for
@@ -58,7 +62,7 @@ func (t ScriptAwareTokenizer) TokenizeBounded(text string, maxTokens int) ([]Tok
 		switch r := runes[i]; {
 		case isUnboundedScript(r):
 			j := i + 1
-			for j < len(runes) && isUnboundedScript(runes[j]) {
+			for j < len(runes) && (isUnboundedScript(runes[j]) || unicode.IsMark(runes[j])) {
 				j++
 			}
 			var exceeded bool
@@ -69,7 +73,7 @@ func (t ScriptAwareTokenizer) TokenizeBounded(text string, maxTokens int) ([]Tok
 			i = j
 		case isWordRune(r):
 			j := i + 1
-			for j < len(runes) && isWordRune(runes[j]) {
+			for j < len(runes) && (isWordRune(runes[j]) || unicode.IsMark(runes[j]) || unicode.Is(unicode.Join_Control, runes[j])) {
 				j++
 			}
 			word := runes[i:j]
@@ -78,9 +82,9 @@ func (t ScriptAwareTokenizer) TokenizeBounded(text string, maxTokens int) ([]Tok
 				return nil, true
 			}
 			if len(word) > n {
-				// Strictly longer than one window: a word of exactly N runes
-				// would emit itself again, and the word token already carries
-				// that evidence on the primary channel.
+				// Document analysis omits a redundant exact-width gram. The
+				// production QueryAnalyzer adds it only to queries, where it
+				// closes the short-infix discontinuity without growing postings.
 				var exceeded bool
 				tokens, exceeded = appendRunGramsBounded(tokens, word, n, ClassGram, maxTokens)
 				if exceeded {
@@ -88,12 +92,35 @@ func (t ScriptAwareTokenizer) TokenizeBounded(text string, maxTokens int) ([]Tok
 				}
 			}
 			i = j
+		case unicode.IsSymbol(r):
+			j := symbolClusterEnd(runes, i)
+			tokens = append(tokens, Token{Term: string(runes[i:j]), Class: ClassWord})
+			if maxTokens > 0 && len(tokens) > maxTokens {
+				return nil, true
+			}
+			i = j
 		default:
-			i++ // delimiter: whitespace, punctuation, symbols
+			i++ // delimiter: whitespace, punctuation, orphaned mark/control
 		}
 	}
 	return tokens, false
 }
+
+func symbolClusterEnd(runes []rune, start int) int {
+	j := start + 1
+	for j < len(runes) && (unicode.IsMark(runes[j]) || isEmojiModifier(runes[j])) {
+		j++
+	}
+	for j+1 < len(runes) && runes[j] == '\u200d' && unicode.IsSymbol(runes[j+1]) {
+		j += 2
+		for j < len(runes) && (unicode.IsMark(runes[j]) || isEmojiModifier(runes[j])) {
+			j++
+		}
+	}
+	return j
+}
+
+func isEmojiModifier(r rune) bool { return r >= 0x1f3fb && r <= 0x1f3ff }
 
 // appendRunGramsBounded emits every n-rune window, stopping at the cap. A
 // short run is emitted whole (the CJKBigramFilter unigram fallback).
@@ -111,19 +138,15 @@ func appendRunGramsBounded(tokens []Token, run []rune, n int, class TokenClass, 
 	return tokens, false
 }
 
-// unboundedScripts are the scripts written without spaces between words, for
-// which n-grams are the word-level indexing unit: the CJKBigramFilter set
-// (Han, Hiragana, Katakana, Hangul) plus the space-free Southeast Asian
-// scripts.
+// unboundedScripts mirrors Lucene CJKBigramFilter's documented script set.
+// Han membership is derived from Unicode's Ideographic property below rather
+// than a hand-maintained block list; the remaining scripts have standard Go
+// Unicode tables. Southeast Asian scripts follow UAX #29's default lexical
+// runs and retain auxiliary grams, avoiding an invented per-script list.
 var unboundedScripts = []*unicode.RangeTable{
-	unicode.Han,
 	unicode.Hiragana,
 	unicode.Katakana,
 	unicode.Hangul,
-	unicode.Thai,
-	unicode.Lao,
-	unicode.Khmer,
-	unicode.Myanmar,
 }
 
 // isUnboundedScript reports whether r belongs to a script indexed by n-grams.
@@ -135,12 +158,27 @@ func isUnboundedScript(r rune) bool {
 	case 'ー', '々', '〆':
 		return true
 	}
+	if unicode.Is(unicode.Ideographic, r) {
+		return true
+	}
 	for _, table := range unboundedScripts {
 		if unicode.Is(table, r) {
 			return true
 		}
 	}
 	return false
+}
+
+func isCJKPrimaryTerm(term string) bool {
+	if term == "" {
+		return false
+	}
+	for _, r := range term {
+		if !isUnboundedScript(r) && !unicode.IsMark(r) {
+			return false
+		}
+	}
+	return true
 }
 
 // isWordRune reports whether r continues a word run of a space-delimited

--- a/core/search/script_tokenizer_test.go
+++ b/core/search/script_tokenizer_test.go
@@ -39,9 +39,7 @@ func TestScriptAwareTokenizer(t *testing.T) {
 			},
 		},
 		{
-			name: "TwoRuneWordSkipsRedundantGram",
-			// A word of exactly N runes would emit itself again as a gram;
-			// the word token already carries that evidence.
+			name: "TwoRuneDocumentSkipsRedundantGram",
 			text: "go",
 			want: []Token{{Term: "go", Class: ClassWord}},
 		},
@@ -126,11 +124,43 @@ func TestScriptAwareTokenizer(t *testing.T) {
 			},
 		},
 		{
-			name: "ThaiIsUnbounded",
+			name: "ThaiUsesWordAndAuxiliaryGrams",
 			text: "ไทย",
 			want: []Token{
-				{Term: "ไท", Class: ClassWord},
-				{Term: "ทย", Class: ClassWord},
+				{Term: "ไทย", Class: ClassWord},
+				{Term: "ไท", Class: ClassGram},
+				{Term: "ทย", Class: ClassGram},
+			},
+		},
+		{
+			name: "ThaiMarksStayAttached",
+			text: "ก่า",
+			want: []Token{
+				{Term: "ก่า", Class: ClassWord},
+				{Term: "ก่", Class: ClassGram},
+				{Term: "่า", Class: ClassGram},
+			},
+		},
+		{
+			name: "IndicMarksStayInsideWord",
+			text: "हिन्दी",
+			want: []Token{
+				{Term: "हिन्दी", Class: ClassWord},
+				{Term: "हि", Class: ClassGram},
+				{Term: "िन", Class: ClassGram},
+				{Term: "न्", Class: ClassGram},
+				{Term: "्द", Class: ClassGram},
+				{Term: "दी", Class: ClassGram},
+			},
+		},
+		{
+			name: "EmojiClustersAreSearchable",
+			text: "❤ 👩‍💻 😀👍",
+			want: []Token{
+				{Term: "❤", Class: ClassWord},
+				{Term: "👩‍💻", Class: ClassWord},
+				{Term: "😀", Class: ClassWord},
+				{Term: "👍", Class: ClassWord},
 			},
 		},
 		{

--- a/docs/decisions/0007-unicode-search-analysis.md
+++ b/docs/decisions/0007-unicode-search-analysis.md
@@ -1,0 +1,103 @@
+# 0007: Preserve Unicode lexical identity and separate two-rune query analysis
+
+Status: Accepted
+
+## Context
+
+The v1 production analyzer lowercased rather than applying full Unicode case
+folding, erased every nonspacing mark, discarded every Unicode symbol, and
+treated combining marks as token boundaries. Those choices collapsed Thai and
+Indic distinctions, made emoji-only content unsearchable, and did not equate
+sharp-s or Greek final sigma. Its shared document/query analyzer also omitted
+an auxiliary gram for a two-rune word: documents containing `search` indexed
+`ar`, but the query `ar` emitted only a primary word token.
+
+UAX #29 word/grapheme segmentation was evaluated. Go's pinned `x/text` provides
+case, normalization, and width transforms but no complete dictionary word
+breaker for the Southeast Asian scripts in scope. Adding an unmeasured
+language-specific segmenter would violate this Issue's non-goal and increase
+binary/dependency cost. The implementation instead follows UAX #29's essential
+extend behavior (marks continue a lexical run), retains whole Southeast Asian
+runs plus bounded auxiliary grams, and derives Han membership from Unicode's
+`Ideographic` property. CJK primary bigrams retain Lucene CJKBigramFilter's
+documented Han/Hiragana/Katakana/Hangul set.
+
+## Decision
+
+Analyzer v2 applies, in order:
+
+1. width folding;
+2. canonical NFC without deleting marks;
+3. Unicode language-neutral full case folding (`x/text/cases`);
+4. removal of emoji text/graphic presentation selectors only;
+5. punctuation boundaries that preserve Unicode symbols;
+6. whitespace normalization and script-aware tokenization.
+
+Combining marks remain in the preceding word. Unicode symbols are searchable
+primary tokens; adjacent symbols are separate unless joined by U+200D, and
+skin-tone modifiers remain significant. Presentation selectors are not lexical
+identity, so `❤`, `❤︎`, and `❤️` are equivalent. The aggressive public
+`DiacriticNormalizer` remains available as an explicit opt-in, but production
+no longer uses it. Fuzzy search remains the explicit way to request recall
+across distinct accented spellings.
+
+`QueryAnalyzer` is an optional extension to `Analyzer`. Documents always use
+`Analyze`; query paths use `AnalyzeQuery` when supported. Production query
+analysis adds a `ClassGram` copy of each two-rune `ClassWord`. Thus `ar` finds
+the gram carried by `search`, while a document whose whole word is `ar` also
+matches the higher-weight primary channel and ranks first. Match modes already
+count only distinct `ClassWord` terms, so auxiliary evidence never raises their
+coverage threshold. Corpus statistics and retained document postings remain
+unchanged.
+
+When prefix or fuzzy expansion is requested, the duplicate auxiliary gram is
+removed before clause construction: the primary word already owns that bounded
+semantic expansion, and retaining an exact gram alongside it would bypass the
+expansion cap. Phrase search continues to use primary terms only.
+
+The discoverable analyzer version changes from `script-aware-v1` to
+`script-aware-v2`. It already participates in `SearchCapabilities`' SHA-256
+configuration fingerprint, so HA members with different analysis semantics are
+observable as incompatible. Search currently has no pagination cursor; future
+search cursors must bind this fingerprint.
+
+## Measurement
+
+The committed benchmarks compare v1/v2 analysis and a 20,000-document broad
+query corpus. On an Apple M3 Max (`darwin/arm64`, three runs), they measured:
+
+| Path | latency | query allocation | retained heap |
+|---|---:|---:|---:|
+| v1 analyzer | 3.03 µs/op | 2,664 B/op, 44 allocs | — |
+| v2 analyzer | 3.05 µs/op | 3,512 B/op, 48 allocs | — |
+| v1 `arch` top-10 | 7.34 ms/op | 2,544 B/op, 52 allocs | 795 B/document |
+| v2 `arch` top-10 | 7.47 ms/op | 2,800 B/op, 53 allocs | 794 B/document |
+| v2 `ar` top-10 | 3.12 ms/op | 2,152 B/op, 39 allocs | 794 B/document |
+
+The common-script analyzer fixture isolates the changed transforms on scripts
+whose tokenizer policy stayed fixed: CPU was within 1%, with four additional
+allocations. The comparable broad-query path was within about 2%, adds one query allocation,
+and retains no additional per-document heap. The newly enabled two-rune path
+remains below the comparable four-rune broad query.
+
+Reproduce with:
+
+```shell
+go test ./core/search -run '^$' -bench 'BenchmarkScriptAwareAnalyzerVersions|BenchmarkSearchTwoRuneInfix' -benchmem -count=5
+```
+
+The relevance gates include reviewed multilingual minimal-pair qrels for case
+folding, composition, accents, Thai/Indic marks, emoji, CJK, digits, and mixed
+scripts. Existing English/Japanese/mixed floors and Lucene comparisons remain
+blocking.
+
+## Consequences
+
+- Canonically equivalent and full-case-fold-equivalent text matches reliably.
+- Meaningful marks and ZWJ emoji intent no longer disappear at analysis time.
+- Accentless matching is no longer silently global; callers can opt into fuzzy
+  expansion when that recall tradeoff is desired.
+- A two-rune query performs one additional bounded dictionary/posting lookup on
+  the auxiliary channel. Document token counts and retained postings do not grow.
+- The tokenizer is not claimed to be an optimal morphological analyzer for any
+  language; its documented bounded units remain intentionally language-neutral.

--- a/server/service/search.go
+++ b/server/service/search.go
@@ -26,7 +26,7 @@ var errSearchPositionsDisabled = errors.New("phrase search requires positional p
 
 const (
 	searchMaxFuzziness      = uint32(2)
-	searchAnalyzerVersion   = "script-aware-v1"
+	searchAnalyzerVersion   = "script-aware-v2"
 	searchProjectionVersion = "vertex-fields-v2"
 )
 

--- a/server/service/status_test.go
+++ b/server/service/status_test.go
@@ -144,7 +144,7 @@ func TestLanternService_GetServerStatus(t *testing.T) {
 		if got.GetDefaultMatchMode() != pb.MatchMode_MATCH_MODE_MIN_SHOULD || got.GetDefaultMinShouldMatch() != 2 {
 			t.Errorf("search defaults = %v/%d, want MIN_SHOULD/2", got.GetDefaultMatchMode(), got.GetDefaultMinShouldMatch())
 		}
-		if got.GetMaxFuzziness() != 2 || got.GetAnalyzerVersion() == "" || got.GetProjectionVersion() != "vertex-fields-v2" {
+		if got.GetMaxFuzziness() != 2 || got.GetAnalyzerVersion() != "script-aware-v2" || got.GetProjectionVersion() != "vertex-fields-v2" {
 			t.Errorf("search implementation capabilities incomplete: %+v", got)
 		}
 		if got.GetTimeoutMs() != 1500 || got.GetMaxQueryBytes() != 4096 || got.GetMaxQueryTerms() != 12 ||

--- a/tests/integration/search_vertices_test.go
+++ b/tests/integration/search_vertices_test.go
@@ -635,6 +635,13 @@ func TestSearchVertices_ProductionStructuredFieldsOverRealH2C(t *testing.T) {
 		{Key: "alpha", Value: "beta", Expiration: expiration},
 		{Key: "json-boundaries", Value: `{"a":"alpha","b":"beta"}`, Expiration: expiration},
 		{Key: "within-value", Value: "alpha beta", Expiration: expiration},
+		{Key: "two-rune-exact", Value: "ar", Expiration: expiration},
+		{Key: "two-rune-carrier", Value: "search", Expiration: expiration},
+		{Key: "case-fold", Value: "Straße", Expiration: expiration},
+		{Key: "thai-plain", Value: "กา", Expiration: expiration},
+		{Key: "thai-tone", Value: "ก่า", Expiration: expiration},
+		{Key: "emoji-developer", Value: "👩‍💻", Expiration: expiration},
+		{Key: "emoji-scientist", Value: "👩‍🔬", Expiration: expiration},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -657,6 +664,25 @@ func TestSearchVertices_ProductionStructuredFieldsOverRealH2C(t *testing.T) {
 	if len(endpoint) == 0 || endpoint[0].Key != "implicit-tail-key" {
 		t.Fatalf("implicit endpoint hits = %+v", endpoint)
 	}
+	twoRune, err := sdk.SearchVertices(ctx, "ar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(twoRune) < 2 || twoRune[0].Key != "two-rune-exact" || !searchHitsContain(twoRune, "two-rune-carrier") {
+		t.Fatalf("two-rune hits = %+v, want exact first and infix carrier present", twoRune)
+	}
+	caseFold, err := sdk.SearchVertices(ctx, "STRASSE")
+	if err != nil || len(caseFold) == 0 || caseFold[0].Key != "case-fold" {
+		t.Fatalf("case-fold hits = %+v err=%v", caseFold, err)
+	}
+	thai, err := sdk.SearchVertices(ctx, "ก่า")
+	if err != nil || len(thai) == 0 || thai[0].Key != "thai-tone" {
+		t.Fatalf("Thai mark hits = %+v err=%v", thai, err)
+	}
+	emoji, err := sdk.SearchVertices(ctx, "👩‍💻")
+	if err != nil || len(emoji) != 1 || emoji[0].Key != "emoji-developer" {
+		t.Fatalf("emoji ZWJ hits = %+v err=%v", emoji, err)
+	}
 	status, err := raw.GetServerStatus(ctx, connect.NewRequest(&pb.GetServerStatusRequest{}))
 	if err != nil {
 		t.Fatal(err)
@@ -664,6 +690,21 @@ func TestSearchVertices_ProductionStructuredFieldsOverRealH2C(t *testing.T) {
 	if got := status.Msg.GetSearch().GetProjectionVersion(); got != "vertex-fields-v2" {
 		t.Fatalf("projection version = %q", got)
 	}
+	if got := status.Msg.GetSearch().GetAnalyzerVersion(); got != "script-aware-v2" {
+		t.Fatalf("analyzer version = %q", got)
+	}
+	if got := status.Msg.GetSearch().GetConfigFingerprint(); len(got) != 64 {
+		t.Fatalf("config fingerprint = %q, want 64 hex chars", got)
+	}
+}
+
+func searchHitsContain(hits []client.SearchHit, key string) bool {
+	for _, hit := range hits {
+		if hit.Key == key {
+			return true
+		}
+	}
+	return false
 }
 
 // newSearchSDKClient mirrors newSearchRawClient but returns the high-level


### PR DESCRIPTION
## Summary

- add Unicode full case folding and canonical NFC while preserving meaningful Thai, Indic, accent, Hebrew, and Arabic marks
- keep Unicode symbols and emoji searchable with presentation-selector equivalence and ZWJ sequence identity
- derive Han bigram membership from Unicode's `Ideographic` property and keep the documented Lucene CJK script set while treating Southeast Asian marks as lexical continuations
- add query-only two-rune auxiliary grams so `ar` recalls `search` while exact `ar` ranks first; prevent the supplemental gram from bypassing prefix/fuzzy expansion caps
- publish `script-aware-v2` through search capabilities and its HA config fingerprint
- add multilingual minimal-pair qrels, malformed-Unicode fuzzing, broad-query benchmarks, ADR 0007, and production-composed Connect/h2c coverage

## Validation

- `gofmt -l .` (clean)
- golangci-lint v2.12.2: 0 issues
- `go test ./...` in root, `pb`, `core`, `sdks/go`, `server`, and `mcp`
- `go vet ./...` and `go build ./...` in all six Go modules
- targeted `go test -race` over core search/graphcache, service, and real h2c integration
- `FuzzScriptAwareAnalyzer`: 10 seconds, 243k+ executions, no failure
- all production relevance floors and pinned Lucene comparisons remain green
- Dart format/analyze/test (existing `use_null_aware_elements` info only) and Flutter format/analyze/test

## Benchmark

Apple M3 Max, darwin/arm64, 3 runs:

| Path | latency | allocation | retained heap |
|---|---:|---:|---:|
| v1 analyzer | 3.03 µs/op | 2,664 B/op, 44 allocs | — |
| v2 analyzer | 3.05 µs/op | 3,512 B/op, 48 allocs | — |
| v1 `arch` top-10, 20k docs | 7.34 ms/op | 2,544 B/op, 52 allocs | 795 B/doc |
| v2 `arch` top-10, 20k docs | 7.47 ms/op | 2,800 B/op, 53 allocs | 794 B/doc |
| v2 `ar` top-10, 20k docs | 3.12 ms/op | 2,152 B/op, 39 allocs | 794 B/doc |

Closes #1067
