### PR TITLE
test(search): evaluate production projection across SDKs

### DIFF
--- a/.github/workflows/dart-sdk.yml
+++ b/.github/workflows/dart-sdk.yml
@@ -11,6 +11,10 @@ on:
       - "buf.yaml"
       - "buf.gen.yaml"
       - "generate.go"
+      - "core/search/**"
+      - "core/graphcache/**"
+      - "server/**"
+      - "testdata/search/**"
       - ".github/workflows/dart-sdk.yml"
   pull_request:
     paths:
@@ -19,6 +23,10 @@ on:
       - "buf.yaml"
       - "buf.gen.yaml"
       - "generate.go"
+      - "core/search/**"
+      - "core/graphcache/**"
+      - "server/**"
+      - "testdata/search/**"
       - ".github/workflows/dart-sdk.yml"
 
 permissions:
@@ -53,30 +61,31 @@ jobs:
       - name: Start Lantern real-wire server
         working-directory: .
         run: |
-          env LANTERN_METRICS_ADDR=:9090 \
-            go run ./server/cmd > "$RUNNER_TEMP/lantern-dart-server.log" 2>&1 &
-          echo $! > "$RUNNER_TEMP/lantern-dart-server.pid"
-          env LANTERN_PORT=6381 LANTERN_METRICS_ADDR=:9091 \
-            LANTERN_SEARCH_ENABLED=false go run ./server/cmd \
-            > "$RUNNER_TEMP/lantern-dart-search-disabled.log" 2>&1 &
-          echo $! > "$RUNNER_TEMP/lantern-dart-search-disabled.pid"
+          go build -o "$RUNNER_TEMP/lantern" ./server/cmd
+          env LANTERN_PORT=6380 LANTERN_METRICS_ADDR=:9090 \
+            "$RUNNER_TEMP/lantern" > "$RUNNER_TEMP/lantern-dart-enabled.log" 2>&1 &
+          echo $! >> "$RUNNER_TEMP/lantern-dart.pids"
+          env LANTERN_PORT=6381 LANTERN_METRICS_ADDR=:9091 LANTERN_SEARCH_ENABLED=false \
+            "$RUNNER_TEMP/lantern" > "$RUNNER_TEMP/lantern-dart-disabled.log" 2>&1 &
+          echo $! >> "$RUNNER_TEMP/lantern-dart.pids"
+          env LANTERN_PORT=6382 LANTERN_METRICS_ADDR=:9092 LANTERN_SEARCH_POSITIONS=false \
+            "$RUNNER_TEMP/lantern" > "$RUNNER_TEMP/lantern-dart-positions.log" 2>&1 &
+          echo $! >> "$RUNNER_TEMP/lantern-dart.pids"
+          env LANTERN_PORT=6383 LANTERN_METRICS_ADDR=:9093 LANTERN_SEARCH_MAX_QUERY_BYTES=4 \
+            LANTERN_SEARCH_MAX_QUERY_TERMS=4 \
+            "$RUNNER_TEMP/lantern" > "$RUNNER_TEMP/lantern-dart-budget.log" 2>&1 &
+          echo $! >> "$RUNNER_TEMP/lantern-dart.pids"
           for attempt in $(seq 1 60); do
-            if curl --fail --silent --show-error --max-time 2 \
-              -H 'Content-Type: application/json' \
-              -H 'Connect-Protocol-Version: 1' \
-              --data '{}' \
-              http://127.0.0.1:6380/grpc.health.v1.Health/Check >/dev/null && \
+            ready=true
+            for port in 6380 6381 6382 6383; do
               curl --fail --silent --show-error --max-time 2 \
-              -H 'Content-Type: application/json' \
-              -H 'Connect-Protocol-Version: 1' \
-              --data '{}' \
-              http://127.0.0.1:6381/grpc.health.v1.Health/Check >/dev/null; then
-              exit 0
-            fi
+                -H 'Content-Type: application/json' -H 'Connect-Protocol-Version: 1' \
+                --data '{}' "http://127.0.0.1:$port/grpc.health.v1.Health/Check" >/dev/null || ready=false
+            done
+            $ready && exit 0
             sleep 1
           done
-          cat "$RUNNER_TEMP/lantern-dart-server.log" \
-            "$RUNNER_TEMP/lantern-dart-search-disabled.log"
+          cat "$RUNNER_TEMP"/lantern-dart-*.log
           exit 1
 
       - name: Resolve dependencies
@@ -103,6 +112,8 @@ jobs:
         env:
           LANTERN_DART_REAL_WIRE_ENDPOINT: http://127.0.0.1:6380
           LANTERN_DART_SEARCH_DISABLED_ENDPOINT: http://127.0.0.1:6381
+          LANTERN_DART_SEARCH_POSITIONS_DISABLED_ENDPOINT: http://127.0.0.1:6382
+          LANTERN_DART_SEARCH_BUDGET_ENDPOINT: http://127.0.0.1:6383
         run: dart test test/real_wire_test.dart
 
       - name: Build API documentation
@@ -154,11 +165,8 @@ jobs:
         if: always()
         working-directory: .
         run: |
-          if [ -f "$RUNNER_TEMP/lantern-dart-server.pid" ]; then
-            kill "$(cat "$RUNNER_TEMP/lantern-dart-server.pid")" || true
-          fi
-          if [ -f "$RUNNER_TEMP/lantern-dart-search-disabled.pid" ]; then
-            kill "$(cat "$RUNNER_TEMP/lantern-dart-search-disabled.pid")" || true
+          if [ -f "$RUNNER_TEMP/lantern-dart.pids" ]; then
+            xargs kill < "$RUNNER_TEMP/lantern-dart.pids" || true
           fi
 
   minimum-dart:

--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -7,6 +7,10 @@ on:
       - 'sdks/node/**'
       - 'proto/**'
       - 'buf.yaml'
+      - 'core/search/**'
+      - 'core/graphcache/**'
+      - 'server/**'
+      - 'testdata/search/**'
       - '.github/workflows/node-sdk.yml'
     tags:
       - 'sdks/node/v*'
@@ -15,6 +19,10 @@ on:
       - 'sdks/node/**'
       - 'proto/**'
       - 'buf.yaml'
+      - 'core/search/**'
+      - 'core/graphcache/**'
+      - 'server/**'
+      - 'testdata/search/**'
       - '.github/workflows/node-sdk.yml'
 
 defaults:
@@ -39,6 +47,38 @@ jobs:
         node-version: ['20', '22']
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Start production search conformance servers
+        working-directory: .
+        run: |
+          go build -o "$RUNNER_TEMP/lantern" ./server/cmd
+          env LANTERN_PORT=6380 LANTERN_METRICS_ADDR=:9090 \
+            "$RUNNER_TEMP/lantern" > "$RUNNER_TEMP/lantern-node-enabled.log" 2>&1 &
+          echo $! >> "$RUNNER_TEMP/lantern-node.pids"
+          env LANTERN_PORT=6381 LANTERN_METRICS_ADDR=:9091 LANTERN_SEARCH_ENABLED=false \
+            "$RUNNER_TEMP/lantern" > "$RUNNER_TEMP/lantern-node-disabled.log" 2>&1 &
+          echo $! >> "$RUNNER_TEMP/lantern-node.pids"
+          env LANTERN_PORT=6382 LANTERN_METRICS_ADDR=:9092 LANTERN_SEARCH_POSITIONS=false \
+            "$RUNNER_TEMP/lantern" > "$RUNNER_TEMP/lantern-node-positions.log" 2>&1 &
+          echo $! >> "$RUNNER_TEMP/lantern-node.pids"
+          env LANTERN_PORT=6383 LANTERN_METRICS_ADDR=:9093 LANTERN_SEARCH_MAX_QUERY_BYTES=4 \
+            LANTERN_SEARCH_MAX_QUERY_TERMS=4 \
+            "$RUNNER_TEMP/lantern" > "$RUNNER_TEMP/lantern-node-budget.log" 2>&1 &
+          echo $! >> "$RUNNER_TEMP/lantern-node.pids"
+          for attempt in $(seq 1 60); do
+            ready=true
+            for port in 6380 6381 6382 6383; do
+              curl --fail --silent --show-error --max-time 2 \
+                -H 'Content-Type: application/json' -H 'Connect-Protocol-Version: 1' \
+                --data '{}' "http://127.0.0.1:$port/grpc.health.v1.Health/Check" >/dev/null || ready=false
+            done
+            $ready && exit 0
+            sleep 1
+          done
+          cat "$RUNNER_TEMP"/lantern-node-*.log
+          exit 1
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
@@ -74,8 +114,21 @@ jobs:
         run: bun run example:typecheck
       - name: Test
         run: bun test
+        env:
+          LANTERN_NODE_REAL_WIRE_ENDPOINT: http://127.0.0.1:6380
+          LANTERN_NODE_SEARCH_DISABLED_ENDPOINT: http://127.0.0.1:6381
+          LANTERN_NODE_SEARCH_POSITIONS_DISABLED_ENDPOINT: http://127.0.0.1:6382
+          LANTERN_NODE_SEARCH_BUDGET_ENDPOINT: http://127.0.0.1:6383
       - name: Build
         run: bun run build
+
+      - name: Stop production search conformance servers
+        if: always()
+        working-directory: .
+        run: |
+          if [ -f "$RUNNER_TEMP/lantern-node.pids" ]; then
+            xargs kill < "$RUNNER_TEMP/lantern-node.pids" || true
+          fi
 
   publish:
     name: Publish to npm

--- a/core/search/relevance/baseline.go
+++ b/core/search/relevance/baseline.go
@@ -1,8 +1,11 @@
 package relevance
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io/fs"
+	"maps"
 	"os"
 )
 
@@ -20,6 +23,9 @@ type BaselineRun struct {
 	Corpus string `json:"corpus"`
 	// Analyzer describes the engine configuration (e.g. "StandardAnalyzer").
 	Analyzer string `json:"analyzer"`
+	// Blocking marks the stock comparator that defines the required floor.
+	// Non-blocking runs are explicit stretch references.
+	Blocking bool `json:"blocking"`
 	// Results maps query ID → ranked document IDs (top EvalDepth, best first).
 	Results map[string][]string `json:"results"`
 }
@@ -31,14 +37,36 @@ type BaselineRuns struct {
 	Engine string `json:"engine"`
 	// Generated is the RFC3339 timestamp of the run, informational only.
 	Generated string `json:"generated"`
+	// Provenance binds the rankings to the exact corpora and Lantern contract.
+	Provenance BaselineProvenance `json:"provenance"`
 	// Runs holds one entry per (corpus, analyzer) pairing, keyed by a
 	// human-readable name such as "en-standard" or "ja-kuromoji".
 	Runs map[string]BaselineRun `json:"runs"`
 }
 
-// LoadBaselineRuns reads a pinned runs file. Callers that treat the baseline
-// as optional (it may not be regenerated in every checkout) should check
-// os.IsNotExist on the error and skip rather than fail.
+// BaselineProvenance is the reproducibility envelope emitted by the offline
+// runner. A stale/missing field is a CI failure, never a skipped comparison.
+type BaselineProvenance struct {
+	CorpusSHA256          map[string]string `json:"corpus_sha256"`
+	ProjectedFieldsSHA256 string            `json:"projected_fields_sha256"`
+	FixtureFormat         string            `json:"fixture_format"`
+	ProjectionVersion     string            `json:"projection_version"`
+	AnalyzerVersion       string            `json:"analyzer_version"`
+	ScorerConfig          string            `json:"scorer_config"`
+	GenerationCommand     string            `json:"generation_command"`
+}
+
+const (
+	BaselineEngine            = "lucene-9.11.1"
+	BaselineFixtureFormat     = "typed-string-vertex-fields-v1"
+	BaselineProjectionVersion = "vertex-fields-v2"
+	BaselineAnalyzerVersion   = "script-aware-v2"
+	BaselineScorerConfig      = "field-weighted-bm25:k1=1.2,b=0.75,key=1.75,value=1,gram=0.2,proximity=0.3"
+	BaselineGenerationCommand = "testbed/lucene-baseline/run.sh"
+)
+
+// LoadBaselineRuns reads a pinned runs file. Required gates treat any error as
+// fatal; the committed baseline is part of the source contract.
 func LoadBaselineRuns(path string) (BaselineRuns, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
@@ -49,6 +77,93 @@ func LoadBaselineRuns(path string) (BaselineRuns, error) {
 		return BaselineRuns{}, fmt.Errorf("relevance: parsing %s: %w", path, err)
 	}
 	return runs, nil
+}
+
+// CorpusSHA256 returns the lowercase SHA-256 of each canonical embedded corpus
+// file. Hashing raw bytes makes whitespace or document edits invalidate the
+// pinned artifact until it is deliberately regenerated.
+func CorpusSHA256() (map[string]string, error) {
+	hashes := make(map[string]string, len(corporaFiles))
+	for _, name := range corporaFiles {
+		raw, err := fs.ReadFile(corporaFS, name)
+		if err != nil {
+			return nil, fmt.Errorf("relevance: hashing %s: %w", name, err)
+		}
+		sum := sha256.Sum256(raw)
+		hashes[name] = fmt.Sprintf("%x", sum)
+	}
+	return hashes, nil
+}
+
+// ProjectedFieldsSHA256 binds the provider-generated field artifact consumed
+// by the Lucene runner.
+func ProjectedFieldsSHA256() (string, error) {
+	raw, err := fs.ReadFile(corporaFS, "testdata/projected_fields.json")
+	if err != nil {
+		return "", fmt.Errorf("relevance: hashing projected fields: %w", err)
+	}
+	sum := sha256.Sum256(raw)
+	return fmt.Sprintf("%x", sum), nil
+}
+
+// ValidateProvenance rejects a baseline generated from any other corpus or
+// production projection/analyzer/scorer contract.
+func (r BaselineRuns) ValidateProvenance() error {
+	if r.Engine != BaselineEngine {
+		return fmt.Errorf("relevance: baseline engine = %q, want %q", r.Engine, BaselineEngine)
+	}
+	wantHashes, err := CorpusSHA256()
+	if err != nil {
+		return err
+	}
+	p := r.Provenance
+	if !maps.Equal(p.CorpusSHA256, wantHashes) {
+		return fmt.Errorf("relevance: baseline corpus SHA-256 mismatch: got %v, want %v", p.CorpusSHA256, wantHashes)
+	}
+	wantProjected, err := ProjectedFieldsSHA256()
+	if err != nil {
+		return err
+	}
+	if p.ProjectedFieldsSHA256 != wantProjected {
+		return fmt.Errorf("relevance: baseline projected fields SHA-256 = %q, want %q", p.ProjectedFieldsSHA256, wantProjected)
+	}
+	checks := []struct{ name, got, want string }{
+		{"fixture_format", p.FixtureFormat, BaselineFixtureFormat},
+		{"projection_version", p.ProjectionVersion, BaselineProjectionVersion},
+		{"analyzer_version", p.AnalyzerVersion, BaselineAnalyzerVersion},
+		{"scorer_config", p.ScorerConfig, BaselineScorerConfig},
+		{"generation_command", p.GenerationCommand, BaselineGenerationCommand},
+	}
+	for _, check := range checks {
+		if check.got != check.want {
+			return fmt.Errorf("relevance: baseline %s = %q, want %q", check.name, check.got, check.want)
+		}
+	}
+	wantRuns := map[string]struct {
+		corpus   string
+		analyzer string
+		blocking bool
+	}{
+		"en-standard":    {corpus: "en", analyzer: "StandardAnalyzer", blocking: true},
+		"en-english":     {corpus: "en", analyzer: "EnglishAnalyzer", blocking: true},
+		"ja-cjk":         {corpus: "ja", analyzer: "CJKAnalyzer", blocking: true},
+		"ja-kuromoji":    {corpus: "ja", analyzer: "JapaneseAnalyzer"},
+		"mixed-cjk":      {corpus: "mixed", analyzer: "CJKAnalyzer", blocking: true},
+		"mixed-kuromoji": {corpus: "mixed", analyzer: "JapaneseAnalyzer"},
+	}
+	if len(r.Runs) != len(wantRuns) {
+		return fmt.Errorf("relevance: baseline run count = %d, want %d", len(r.Runs), len(wantRuns))
+	}
+	for name, want := range wantRuns {
+		got, ok := r.Runs[name]
+		if !ok {
+			return fmt.Errorf("relevance: baseline missing run %q", name)
+		}
+		if got.Corpus != want.corpus || got.Analyzer != want.analyzer || got.Blocking != want.blocking {
+			return fmt.Errorf("relevance: baseline run %q metadata = (%q, %q, blocking=%t), want (%q, %q, blocking=%t)", name, got.Corpus, got.Analyzer, got.Blocking, want.corpus, want.analyzer, want.blocking)
+		}
+	}
+	return nil
 }
 
 // Evaluate replays one recorded run against its corpus and returns the same

--- a/core/search/relevance/baseline_test.go
+++ b/core/search/relevance/baseline_test.go
@@ -1,6 +1,7 @@
 package relevance
 
 import (
+	"maps"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,10 +13,12 @@ func TestLoadBaselineRuns(t *testing.T) {
 		blob := `{
 			"engine": "lucene-9.11.1",
 			"generated": "2026-07-03T00:00:00Z",
+			"provenance": {},
 			"runs": {
 				"en-standard": {
 					"corpus": "en",
 					"analyzer": "StandardAnalyzer",
+					"blocking": true,
 					"results": {"q1": ["a", "b"]}
 				}
 			}
@@ -28,11 +31,14 @@ func TestLoadBaselineRuns(t *testing.T) {
 			t.Fatalf("LoadBaselineRuns = %v", err)
 		}
 		run, ok := runs.Runs["en-standard"]
-		if !ok || run.Corpus != "en" || run.Analyzer != "StandardAnalyzer" {
+		if !ok || run.Corpus != "en" || run.Analyzer != "StandardAnalyzer" || !run.Blocking {
 			t.Fatalf("parsed run = %+v", run)
 		}
 		if got := run.Results["q1"]; len(got) != 2 || got[0] != "a" {
 			t.Fatalf("parsed results = %v", got)
+		}
+		if err := runs.ValidateProvenance(); err == nil {
+			t.Fatal("empty provenance accepted")
 		}
 	})
 
@@ -50,6 +56,34 @@ func TestLoadBaselineRuns(t *testing.T) {
 		}
 		if _, err := LoadBaselineRuns(path); err == nil {
 			t.Fatal("malformed runs file accepted")
+		}
+	})
+}
+
+func TestBaselineProvenanceMatchesCanonicalCorpora(t *testing.T) {
+	runs, err := LoadBaselineRuns(BaselineRunsFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runs.ValidateProvenance(); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("engine drift", func(t *testing.T) {
+		stale := runs
+		stale.Engine = "lucene-other"
+		if err := stale.ValidateProvenance(); err == nil {
+			t.Fatal("engine drift accepted")
+		}
+	})
+	t.Run("analyzer drift", func(t *testing.T) {
+		stale := runs
+		stale.Runs = maps.Clone(runs.Runs)
+		run := stale.Runs["en-standard"]
+		run.Analyzer = "OtherAnalyzer"
+		stale.Runs["en-standard"] = run
+		if err := stale.ValidateProvenance(); err == nil {
+			t.Fatal("analyzer drift accepted")
 		}
 	})
 }

--- a/core/search/relevance/parity_gate_test.go
+++ b/core/search/relevance/parity_gate_test.go
@@ -13,7 +13,6 @@ package relevance
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -98,19 +97,16 @@ func TestProductionPipelineRelevanceFloors(t *testing.T) {
 	}
 }
 
-// TestLuceneBaselineComparison replays the pinned Lucene rankings (produced
-// offline by testbed/lucene-baseline; CI never runs a JVM) through the same
-// metric functions and ASSERTS the epic's definition of done (#886): the
-// production pipeline scores at least as high as every pinned Lucene run on
-// every metric of every corpus. #888 (script-aware analyzer) is what made
-// this hold; keeping it as an assertion means later ranking work (#889,
-// #890, #891) may reshuffle results but never below Lucene.
-func TestLuceneBaselineComparison(t *testing.T) {
+// TestLuceneBaselineArtifactCoverage keeps the core-owned artifact complete.
+// Exact Lantern-vs-Lucene metric comparison lives in server/provider, where
+// the production vertex projection is available without violating core's leaf
+// dependency boundary.
+func TestLuceneBaselineArtifactCoverage(t *testing.T) {
 	runs, err := LoadBaselineRuns(BaselineRunsFile)
-	if os.IsNotExist(err) {
-		t.Skipf("no pinned baseline at %s — generate it with testbed/lucene-baseline (see testbed/SKILL.md)", BaselineRunsFile)
-	}
 	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runs.ValidateProvenance(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -123,6 +119,7 @@ func TestLuceneBaselineComparison(t *testing.T) {
 		byName[c.Name] = c
 	}
 
+	blocking := make(map[string]int, len(corpora))
 	for name, run := range runs.Runs {
 		t.Run(name, func(t *testing.T) {
 			c, ok := byName[run.Corpus]
@@ -134,31 +131,15 @@ func TestLuceneBaselineComparison(t *testing.T) {
 					t.Fatalf("run %q ranks unknown query %q — regenerate the baseline after editing fixtures", name, qid)
 				}
 			}
-			lucene := run.Evaluate(c)
-
-			idx := productionIndex()
-			c.IndexDocs(idx)
-			lantern := Evaluate(c, RankSearcher(idx))
-
-			t.Logf("%s [%s, %s]: lucene nDCG@10=%.4f MRR=%.4f Recall@50=%.4f | lantern nDCG@10=%.4f MRR=%.4f Recall@50=%.4f",
-				run.Corpus, runs.Engine, run.Analyzer,
-				lucene.NDCG10, lucene.MRR, lucene.Recall50,
-				lantern.NDCG10, lantern.MRR, lantern.Recall50)
-
-			// Both sides are deterministic; the epsilon only forgives the
-			// float-summation ULPs of a legitimate exact tie (ja matches
-			// Lucene's CJK bigrams ranking-for-ranking).
-			const eps = 1e-9
-			if lantern.NDCG10 < lucene.NDCG10-eps {
-				t.Errorf("nDCG@10 %.4f below Lucene %s %.4f", lantern.NDCG10, run.Analyzer, lucene.NDCG10)
-			}
-			if lantern.MRR < lucene.MRR-eps {
-				t.Errorf("MRR %.4f below Lucene %s %.4f", lantern.MRR, run.Analyzer, lucene.MRR)
-			}
-			if lantern.Recall50 < lucene.Recall50-eps {
-				t.Errorf("Recall@50 %.4f below Lucene %s %.4f", lantern.Recall50, run.Analyzer, lucene.Recall50)
+			if run.Blocking {
+				blocking[run.Corpus]++
 			}
 		})
+	}
+	for _, corpus := range corpora {
+		if blocking[corpus.Name] == 0 {
+			t.Errorf("corpus %q has no blocking Lucene comparator", corpus.Name)
+		}
 	}
 }
 

--- a/core/search/relevance/relevance.go
+++ b/core/search/relevance/relevance.go
@@ -62,7 +62,7 @@ func (c Corpus) IndexDocs(idx search.Indexer[string, search.Text]) {
 	}
 }
 
-//go:embed testdata/en.json testdata/ja.json testdata/mixed.json
+//go:embed testdata/en.json testdata/ja.json testdata/mixed.json testdata/projected_fields.json
 var corporaFS embed.FS
 
 // corporaFiles lists the embedded fixtures in the order Corpora returns them.

--- a/core/search/relevance/testdata/lucene_runs.json
+++ b/core/search/relevance/testdata/lucene_runs.json
@@ -1,10 +1,24 @@
 {
   "engine": "lucene-9.11.1",
-  "generated": "2026-07-03T11:45:23.842077045Z",
+  "generated": "2026-07-13T03:15:13.670216Z",
+  "provenance": {
+    "corpus_sha256": {
+      "testdata/en.json": "6fffa87e4f3d99766049f410808ba7c5ab309b226a2d3f52e00a6534ba52ae6f",
+      "testdata/ja.json": "249f049c2f1216b8d1677d85ca02ebf77e99ee313050d935c714afc10920998f",
+      "testdata/mixed.json": "bc290a9cdf40336c8b796ab783a6184078f47ed9897f2f2f0effd302d43d48c9"
+    },
+    "projected_fields_sha256": "a005823993db32ca6727f588a36674b6bb57804c4da4d09c05792f8ac1c90c4a",
+    "fixture_format": "typed-string-vertex-fields-v1",
+    "projection_version": "vertex-fields-v2",
+    "analyzer_version": "script-aware-v2",
+    "scorer_config": "field-weighted-bm25:k1=1.2,b=0.75,key=1.75,value=1,gram=0.2,proximity=0.3",
+    "generation_command": "testbed/lucene-baseline/run.sh"
+  },
   "runs": {
     "en-standard": {
       "corpus": "en",
       "analyzer": "StandardAnalyzer",
+      "blocking": true,
       "results": {
         "q01": [
           "coffee-07",
@@ -65,8 +79,8 @@
           "travel-01"
         ],
         "q14": [
-          "db-04",
-          "db-09"
+          "db-09",
+          "db-04"
         ],
         "q15": [
           "k8s-08",
@@ -88,12 +102,15 @@
           "coffee-03",
           "coffee-05",
           "coffee-04",
+          "coffee-01",
+          "coffee-06",
+          "coffee-07",
+          "coffee-08",
           "misc-04",
           "auth-08",
           "travel-08",
           "k8s-03",
-          "db-02",
-          "coffee-01"
+          "db-02"
         ],
         "q19": [
           "k8s-07",
@@ -124,8 +141,8 @@
           "db-07"
         ],
         "q26": [
-          "coffee-07",
           "coffee-05",
+          "coffee-07",
           "auth-09"
         ],
         "q27": [
@@ -137,6 +154,7 @@
     "en-english": {
       "corpus": "en",
       "analyzer": "EnglishAnalyzer",
+      "blocking": true,
       "results": {
         "q01": [
           "coffee-07",
@@ -202,8 +220,8 @@
           "travel-01"
         ],
         "q14": [
-          "db-04",
-          "db-09"
+          "db-09",
+          "db-04"
         ],
         "q15": [
           "k8s-05",
@@ -226,11 +244,15 @@
           "coffee-05",
           "coffee-02",
           "coffee-03",
-          "coffee-04"
+          "coffee-04",
+          "coffee-01",
+          "coffee-06",
+          "coffee-07",
+          "coffee-08"
         ],
         "q19": [
-          "k8s-01",
           "k8s-07",
+          "k8s-01",
           "k8s-02",
           "k8s-03"
         ],
@@ -261,8 +283,8 @@
           "auth-05"
         ],
         "q26": [
-          "coffee-07",
           "coffee-05",
+          "coffee-07",
           "auth-09"
         ],
         "q27": [
@@ -274,6 +296,7 @@
     "ja-cjk": {
       "corpus": "ja",
       "analyzer": "CJKAnalyzer",
+      "blocking": true,
       "results": {
         "jq01": [
           "ramen-07",
@@ -300,7 +323,6 @@
         ],
         "jq04": [
           "onsen-02",
-          "onsen-07",
           "onsen-06",
           "onsen-03",
           "onsen-01",
@@ -379,25 +401,26 @@
     "ja-kuromoji": {
       "corpus": "ja",
       "analyzer": "JapaneseAnalyzer",
+      "blocking": false,
       "results": {
         "jq01": [
+          "ramen-07",
           "ramen-01",
           "ramen-05",
           "ramen-03",
           "ramen-06",
           "ramen-08",
-          "ramen-02",
-          "ramen-07"
+          "ramen-02"
         ],
         "jq02": [
           "ramen-01",
           "washoku-05",
+          "ramen-07",
           "ramen-05",
           "ramen-03",
           "ramen-06",
           "ramen-08",
-          "ramen-02",
-          "ramen-07"
+          "ramen-02"
         ],
         "jq03": [
           "ramen-03",
@@ -408,7 +431,6 @@
           "onsen-06",
           "onsen-03",
           "onsen-01",
-          "onsen-07",
           "onsen-04"
         ],
         "jq05": [
@@ -435,6 +457,7 @@
         ],
         "jq11": [
           "washoku-02",
+          "washoku-07",
           "ramen-02"
         ],
         "jq12": [
@@ -460,7 +483,6 @@
         ],
         "jq19": [
           "niwa-04",
-          "phone-06",
           "onsen-02"
         ],
         "jq20": [
@@ -480,6 +502,7 @@
     "mixed-cjk": {
       "corpus": "mixed",
       "analyzer": "CJKAnalyzer",
+      "blocking": true,
       "results": {
         "mq01": [
           "mk8s-01",
@@ -501,12 +524,11 @@
         ],
         "mq03": [
           "mdb-02",
-          "mk8s-01",
           "mdb-05",
-          "mdev-04",
+          "mk8s-01",
+          "mdb-06",
           "mfood-02",
-          "prod-04",
-          "mdb-06"
+          "prod-04"
         ],
         "mq04": [
           "mdb-03",
@@ -536,12 +558,10 @@
           "mtrv-06",
           "mk8s-04",
           "mdev-06",
-          "mdb-05",
           "mdb-01"
         ],
         "mq10": [
-          "mdev-01",
-          "mfood-03"
+          "mdev-01"
         ],
         "mq11": [
           "mdev-07",
@@ -581,6 +601,7 @@
     "mixed-kuromoji": {
       "corpus": "mixed",
       "analyzer": "JapaneseAnalyzer",
+      "blocking": false,
       "results": {
         "mq01": [
           "mk8s-01"
@@ -591,8 +612,8 @@
           "mfood-05"
         ],
         "mq03": [
-          "mdb-02",
-          "mdb-05"
+          "mdb-05",
+          "mdb-02"
         ],
         "mq04": [
           "mdb-03",

--- a/core/search/relevance/testdata/projected_fields.json
+++ b/core/search/relevance/testdata/projected_fields.json
@@ -1,0 +1,2923 @@
+{
+  "fixture_format": "typed-string-vertex-fields-v1",
+  "projection_version": "vertex-fields-v2",
+  "corpora": {
+    "en": {
+      "docs": [
+        {
+          "id": "coffee-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "coffee-01"
+            },
+            {
+              "name": "value",
+              "text": "Espresso extraction: 18 g dose, 36 g yield, 27 seconds at 93 degrees."
+            }
+          ]
+        },
+        {
+          "id": "coffee-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "coffee-02"
+            },
+            {
+              "name": "value",
+              "text": "Pour-over brew guide: medium grind, 3 minute total brew time for a V60."
+            }
+          ]
+        },
+        {
+          "id": "coffee-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "coffee-03"
+            },
+            {
+              "name": "value",
+              "text": "French press coffee steeps for four minutes before pressing the plunger."
+            }
+          ]
+        },
+        {
+          "id": "coffee-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "coffee-04"
+            },
+            {
+              "name": "value",
+              "text": "Cold brew concentrate steeps overnight; dilute one to one with water before serving."
+            }
+          ]
+        },
+        {
+          "id": "coffee-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "coffee-05"
+            },
+            {
+              "name": "value",
+              "text": "Café Lumière serves single-origin espresso and hand-brewed filter coffee."
+            }
+          ]
+        },
+        {
+          "id": "coffee-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "coffee-06"
+            },
+            {
+              "name": "value",
+              "text": "Latte art basics: microfoam texture matters more than the pour pattern."
+            }
+          ]
+        },
+        {
+          "id": "coffee-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "coffee-07"
+            },
+            {
+              "name": "value",
+              "text": "espresso"
+            },
+            {
+              "name": "value",
+              "text": "Ethiopia"
+            },
+            {
+              "name": "value",
+              "text": "double"
+            }
+          ]
+        },
+        {
+          "id": "coffee-08",
+          "fields": [
+            {
+              "name": "key",
+              "text": "coffee-08"
+            },
+            {
+              "name": "value",
+              "text": "Decaf espresso beans lose some crema but keep most of the flavor."
+            }
+          ]
+        },
+        {
+          "id": "k8s-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "k8s-01"
+            },
+            {
+              "name": "value",
+              "text": "Kubernetes rolling update: set maxUnavailable to zero for no-downtime deploys."
+            }
+          ]
+        },
+        {
+          "id": "k8s-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "k8s-02"
+            },
+            {
+              "name": "value",
+              "text": "kubectl rollout status watches a deployment until the rolling update completes."
+            }
+          ]
+        },
+        {
+          "id": "k8s-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "k8s-03"
+            },
+            {
+              "name": "value",
+              "text": "Blue-green deployment keeps two environments and switches the router at cutover."
+            }
+          ]
+        },
+        {
+          "id": "k8s-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "k8s-04"
+            },
+            {
+              "name": "value",
+              "text": "Canary release: shift five percent of traffic to the new version and watch error rates."
+            }
+          ]
+        },
+        {
+          "id": "k8s-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "k8s-05"
+            },
+            {
+              "name": "value",
+              "text": "Horizontal pod autoscaler scales replicas on CPU utilization or custom metrics."
+            }
+          ]
+        },
+        {
+          "id": "k8s-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "k8s-06"
+            },
+            {
+              "name": "value",
+              "text": "Init containers run to completion before the app containers start."
+            }
+          ]
+        },
+        {
+          "id": "k8s-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "k8s-07"
+            },
+            {
+              "name": "value",
+              "text": "api:v2"
+            },
+            {
+              "name": "value",
+              "text": "Deployment"
+            },
+            {
+              "name": "value",
+              "text": "RollingUpdate"
+            }
+          ]
+        },
+        {
+          "id": "k8s-08",
+          "fields": [
+            {
+              "name": "key",
+              "text": "k8s-08"
+            },
+            {
+              "name": "value",
+              "text": "Pod disruption budgets protect availability during voluntary node drains."
+            }
+          ]
+        },
+        {
+          "id": "k8s-09",
+          "fields": [
+            {
+              "name": "key",
+              "text": "k8s-09"
+            },
+            {
+              "name": "value",
+              "text": "Helm chart values override image tags per environment."
+            }
+          ]
+        },
+        {
+          "id": "k8s-10",
+          "fields": [
+            {
+              "name": "key",
+              "text": "k8s-10"
+            },
+            {
+              "name": "value",
+              "text": "Liveness probes restart a stuck pod; readiness probes gate traffic."
+            }
+          ]
+        },
+        {
+          "id": "db-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "db-01"
+            },
+            {
+              "name": "value",
+              "text": "Redis is an in-memory key-value store with optional persistence."
+            }
+          ]
+        },
+        {
+          "id": "db-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "db-02"
+            },
+            {
+              "name": "value",
+              "text": "The database index speeds up reads at the cost of slower writes."
+            }
+          ]
+        },
+        {
+          "id": "db-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "db-03"
+            },
+            {
+              "name": "value",
+              "text": "Cache invalidation strategy: write-through keeps the cache and database consistent."
+            }
+          ]
+        },
+        {
+          "id": "db-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "db-04"
+            },
+            {
+              "name": "value",
+              "text": "PostgreSQL vacuum reclaims storage occupied by dead tuples."
+            }
+          ]
+        },
+        {
+          "id": "db-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "db-05"
+            },
+            {
+              "name": "value",
+              "text": "A B-tree index keeps keys sorted for range scans."
+            }
+          ]
+        },
+        {
+          "id": "db-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "db-06"
+            },
+            {
+              "name": "value",
+              "text": "LRU cache eviction drops the least recently used entry when full."
+            }
+          ]
+        },
+        {
+          "id": "db-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "db-07"
+            },
+            {
+              "name": "value",
+              "text": "Time-to-live expiry: cached entries decay after their TTL elapses."
+            }
+          ]
+        },
+        {
+          "id": "db-08",
+          "fields": [
+            {
+              "name": "key",
+              "text": "db-08"
+            },
+            {
+              "name": "value",
+              "text": "Sharding splits the dataset across nodes by key range or hash."
+            }
+          ]
+        },
+        {
+          "id": "db-09",
+          "fields": [
+            {
+              "name": "key",
+              "text": "db-09"
+            },
+            {
+              "name": "value",
+              "text": "postgres"
+            }
+          ]
+        },
+        {
+          "id": "db-10",
+          "fields": [
+            {
+              "name": "key",
+              "text": "db-10"
+            },
+            {
+              "name": "value",
+              "text": "Write-ahead log durability: every commit is flushed before acknowledgment."
+            }
+          ]
+        },
+        {
+          "id": "ir-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ir-01"
+            },
+            {
+              "name": "value",
+              "text": "Full-text search ranks documents with BM25 term weighting."
+            }
+          ]
+        },
+        {
+          "id": "ir-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ir-02"
+            },
+            {
+              "name": "value",
+              "text": "The inverted index maps each term to the documents containing it."
+            }
+          ]
+        },
+        {
+          "id": "ir-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ir-03"
+            },
+            {
+              "name": "value",
+              "text": "A training data set of labeled queries improves ranking evaluation."
+            }
+          ]
+        },
+        {
+          "id": "ir-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ir-04"
+            },
+            {
+              "name": "value",
+              "text": "Database systems and search engines optimize very different workloads."
+            }
+          ]
+        },
+        {
+          "id": "ir-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ir-05"
+            },
+            {
+              "name": "value",
+              "text": "Tokenization splits text into terms before indexing."
+            }
+          ]
+        },
+        {
+          "id": "ir-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ir-06"
+            },
+            {
+              "name": "value",
+              "text": "Stop words like the and of are dropped to shrink the index."
+            }
+          ]
+        },
+        {
+          "id": "ir-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ir-07"
+            },
+            {
+              "name": "value",
+              "text": "Recall measures how many relevant documents the search surfaced."
+            }
+          ]
+        },
+        {
+          "id": "ir-08",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ir-08"
+            },
+            {
+              "name": "value",
+              "text": "The research team published a survey of neural ranking models."
+            }
+          ]
+        },
+        {
+          "id": "ir-09",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ir-09"
+            },
+            {
+              "name": "value",
+              "text": "Set the data retention policy to ninety days."
+            }
+          ]
+        },
+        {
+          "id": "bike-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "bike-01"
+            },
+            {
+              "name": "value",
+              "text": "Road bike tire pressure: 80 psi front, 85 rear for a 70 kg rider."
+            }
+          ]
+        },
+        {
+          "id": "bike-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "bike-02"
+            },
+            {
+              "name": "value",
+              "text": "Fix a flat tire: lever the bead off, patch the tube, reseat and inflate."
+            }
+          ]
+        },
+        {
+          "id": "bike-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "bike-03"
+            },
+            {
+              "name": "value",
+              "text": "Chain maintenance: degrease, lube, and wipe every 300 km."
+            }
+          ]
+        },
+        {
+          "id": "bike-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "bike-04"
+            },
+            {
+              "name": "value",
+              "text": "Gravel bikes take wider tires than road bikes for rough terrain."
+            }
+          ]
+        },
+        {
+          "id": "bike-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "bike-05"
+            },
+            {
+              "name": "value",
+              "text": "Clipless pedals improve pedaling efficiency on long climbs."
+            }
+          ]
+        },
+        {
+          "id": "bike-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "bike-06"
+            },
+            {
+              "name": "value",
+              "text": "Disc brakes outperform rim brakes in wet weather."
+            }
+          ]
+        },
+        {
+          "id": "bike-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "bike-07"
+            },
+            {
+              "name": "value",
+              "text": "gravel"
+            }
+          ]
+        },
+        {
+          "id": "bike-08",
+          "fields": [
+            {
+              "name": "key",
+              "text": "bike-08"
+            },
+            {
+              "name": "value",
+              "text": "Bike fitting: saddle height set by the heel-on-pedal method."
+            }
+          ]
+        },
+        {
+          "id": "pasta-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "pasta-01"
+            },
+            {
+              "name": "value",
+              "text": "Carbonara uses eggs, guanciale, and pecorino — never cream."
+            }
+          ]
+        },
+        {
+          "id": "pasta-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "pasta-02"
+            },
+            {
+              "name": "value",
+              "text": "Salt the pasta water generously; it should taste like the sea."
+            }
+          ]
+        },
+        {
+          "id": "pasta-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "pasta-03"
+            },
+            {
+              "name": "value",
+              "text": "Fresh pasta dough rests thirty minutes before rolling."
+            }
+          ]
+        },
+        {
+          "id": "pasta-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "pasta-04"
+            },
+            {
+              "name": "value",
+              "text": "Cacio e pepe emulsifies pecorino with starchy pasta water."
+            }
+          ]
+        },
+        {
+          "id": "pasta-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "pasta-05"
+            },
+            {
+              "name": "value",
+              "text": "Dried spaghetti cooks al dente in about nine minutes."
+            }
+          ]
+        },
+        {
+          "id": "pasta-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "pasta-06"
+            },
+            {
+              "name": "value",
+              "text": "Tomato sauce base: garlic, olive oil, canned San Marzano tomatoes."
+            }
+          ]
+        },
+        {
+          "id": "pasta-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "pasta-07"
+            },
+            {
+              "name": "value",
+              "text": "Gnocchi float to the surface when they are done."
+            }
+          ]
+        },
+        {
+          "id": "pasta-08",
+          "fields": [
+            {
+              "name": "key",
+              "text": "pasta-08"
+            },
+            {
+              "name": "value",
+              "text": "carbonara"
+            }
+          ]
+        },
+        {
+          "id": "astro-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "astro-01"
+            },
+            {
+              "name": "value",
+              "text": "Jupiter is the largest planet in the solar system."
+            }
+          ]
+        },
+        {
+          "id": "astro-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "astro-02"
+            },
+            {
+              "name": "value",
+              "text": "A total solar eclipse occurs when the moon fully covers the sun."
+            }
+          ]
+        },
+        {
+          "id": "astro-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "astro-03"
+            },
+            {
+              "name": "value",
+              "text": "The James Webb telescope observes in the infrared spectrum."
+            }
+          ]
+        },
+        {
+          "id": "astro-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "astro-04"
+            },
+            {
+              "name": "value",
+              "text": "Mars rovers search for signs of ancient water."
+            }
+          ]
+        },
+        {
+          "id": "astro-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "astro-05"
+            },
+            {
+              "name": "value",
+              "text": "A light year is the distance light travels in one year."
+            }
+          ]
+        },
+        {
+          "id": "astro-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "astro-06"
+            },
+            {
+              "name": "value",
+              "text": "Saturn's rings are mostly water ice with some rock."
+            }
+          ]
+        },
+        {
+          "id": "astro-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "astro-07"
+            },
+            {
+              "name": "value",
+              "text": "Neutron stars pack a solar mass into a city-sized sphere."
+            }
+          ]
+        },
+        {
+          "id": "astro-08",
+          "fields": [
+            {
+              "name": "key",
+              "text": "astro-08"
+            },
+            {
+              "name": "value",
+              "text": "The Milky Way and Andromeda will merge in about four billion years."
+            }
+          ]
+        },
+        {
+          "id": "auth-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "auth-01"
+            },
+            {
+              "name": "value",
+              "text": "OAuth 2.0 authorization code flow exchanges a code for an access token."
+            }
+          ]
+        },
+        {
+          "id": "auth-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "auth-02"
+            },
+            {
+              "name": "value",
+              "text": "Refresh tokens rotate on every use to limit replay."
+            }
+          ]
+        },
+        {
+          "id": "auth-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "auth-03"
+            },
+            {
+              "name": "value",
+              "text": "TOTP two-factor authentication generates a six-digit code every 30 seconds."
+            }
+          ]
+        },
+        {
+          "id": "auth-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "auth-04"
+            },
+            {
+              "name": "value",
+              "text": "Password hashing uses argon2id with a per-user salt."
+            }
+          ]
+        },
+        {
+          "id": "auth-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "auth-05"
+            },
+            {
+              "name": "value",
+              "text": "JWT access tokens carry signed claims and expire quickly."
+            }
+          ]
+        },
+        {
+          "id": "auth-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "auth-06"
+            },
+            {
+              "name": "value",
+              "text": "mTLS authenticates both client and server with certificates."
+            }
+          ]
+        },
+        {
+          "id": "auth-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "auth-07"
+            },
+            {
+              "name": "value",
+              "text": "client_credentials"
+            },
+            {
+              "name": "value",
+              "text": "read:vertices"
+            }
+          ]
+        },
+        {
+          "id": "auth-08",
+          "fields": [
+            {
+              "name": "key",
+              "text": "auth-08"
+            },
+            {
+              "name": "value",
+              "text": "API keys are stored hashed and shown only once at creation."
+            }
+          ]
+        },
+        {
+          "id": "auth-09",
+          "fields": [
+            {
+              "name": "key",
+              "text": "auth-09"
+            },
+            {
+              "name": "value",
+              "text": "Single sign-on delegates login to the identity provider via SAML or OIDC."
+            }
+          ]
+        },
+        {
+          "id": "garden-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "garden-01"
+            },
+            {
+              "name": "value",
+              "text": "Tomato seedlings need six hours of direct sun daily."
+            }
+          ]
+        },
+        {
+          "id": "garden-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "garden-02"
+            },
+            {
+              "name": "value",
+              "text": "Compost turns kitchen scraps into nutrient-rich soil."
+            }
+          ]
+        },
+        {
+          "id": "garden-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "garden-03"
+            },
+            {
+              "name": "value",
+              "text": "Prune roses in late winter before new growth starts."
+            }
+          ]
+        },
+        {
+          "id": "garden-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "garden-04"
+            },
+            {
+              "name": "value",
+              "text": "Basil grows fast in warm weather; pinch flowers to keep leaves tender."
+            }
+          ]
+        },
+        {
+          "id": "garden-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "garden-05"
+            },
+            {
+              "name": "value",
+              "text": "Raised beds drain better and warm earlier in spring."
+            }
+          ]
+        },
+        {
+          "id": "garden-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "garden-06"
+            },
+            {
+              "name": "value",
+              "text": "Mulch keeps soil moisture in and weeds down."
+            }
+          ]
+        },
+        {
+          "id": "garden-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "garden-07"
+            },
+            {
+              "name": "value",
+              "text": "Succulents rot in soggy soil; water only when dry."
+            }
+          ]
+        },
+        {
+          "id": "garden-08",
+          "fields": [
+            {
+              "name": "key",
+              "text": "garden-08"
+            },
+            {
+              "name": "value",
+              "text": "basil"
+            },
+            {
+              "name": "value",
+              "text": "full"
+            },
+            {
+              "name": "value",
+              "text": "daily"
+            }
+          ]
+        },
+        {
+          "id": "travel-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "travel-01"
+            },
+            {
+              "name": "value",
+              "text": "Narita Express runs from the airport to Tokyo Station in about an hour."
+            }
+          ]
+        },
+        {
+          "id": "travel-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "travel-02"
+            },
+            {
+              "name": "value",
+              "text": "Check-in closes 45 minutes before international departures."
+            }
+          ]
+        },
+        {
+          "id": "travel-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "travel-03"
+            },
+            {
+              "name": "value",
+              "text": "A transit visa is not required for connections under 24 hours."
+            }
+          ]
+        },
+        {
+          "id": "travel-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "travel-04"
+            },
+            {
+              "name": "value",
+              "text": "Carry-on liquids are limited to 100 ml containers in a clear bag."
+            }
+          ]
+        },
+        {
+          "id": "travel-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "travel-05"
+            },
+            {
+              "name": "value",
+              "text": "The airport shuttle leaves every 20 minutes from terminal two."
+            }
+          ]
+        },
+        {
+          "id": "travel-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "travel-06"
+            },
+            {
+              "name": "value",
+              "text": "Jet lag eases if you shift sleep two hours before flying east."
+            }
+          ]
+        },
+        {
+          "id": "travel-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "travel-07"
+            },
+            {
+              "name": "value",
+              "text": "10:25"
+            },
+            {
+              "name": "value",
+              "text": "NH105"
+            },
+            {
+              "name": "value",
+              "text": "52"
+            }
+          ]
+        },
+        {
+          "id": "travel-08",
+          "fields": [
+            {
+              "name": "key",
+              "text": "travel-08"
+            },
+            {
+              "name": "value",
+              "text": "Lounge access with a priority pass includes showers at most hubs."
+            }
+          ]
+        },
+        {
+          "id": "misc-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "misc-01"
+            },
+            {
+              "name": "value",
+              "text": "The stone arch bridge has stood for two hundred years."
+            }
+          ]
+        },
+        {
+          "id": "misc-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "misc-02"
+            },
+            {
+              "name": "value",
+              "text": "Architecture reviews happen every Thursday afternoon."
+            }
+          ]
+        },
+        {
+          "id": "misc-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "misc-03"
+            },
+            {
+              "name": "value",
+              "text": "Monarch butterflies migrate thousands of kilometers each autumn."
+            }
+          ]
+        },
+        {
+          "id": "misc-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "misc-04"
+            },
+            {
+              "name": "value",
+              "text": "user:profile:9f2c settings cached at edge nodes"
+            }
+          ]
+        },
+        {
+          "id": "misc-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "misc-05"
+            },
+            {
+              "name": "value",
+              "text": "TOKYO office headcount grows to forty this quarter."
+            }
+          ]
+        },
+        {
+          "id": "en-prox-scatter",
+          "fields": [
+            {
+              "name": "key",
+              "text": "en-prox-scatter"
+            },
+            {
+              "name": "value",
+              "text": "zephyr marlin pewter granite quokka"
+            }
+          ]
+        },
+        {
+          "id": "en-prox-tight",
+          "fields": [
+            {
+              "name": "key",
+              "text": "en-prox-tight"
+            },
+            {
+              "name": "value",
+              "text": "marlin pewter granite zephyr quokka"
+            }
+          ]
+        }
+      ]
+    },
+    "ja": {
+      "docs": [
+        {
+          "id": "ramen-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ramen-01"
+            },
+            {
+              "name": "value",
+              "text": "東京の醤油ラーメンは鶏ガラスープが基本です。"
+            }
+          ]
+        },
+        {
+          "id": "ramen-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ramen-02"
+            },
+            {
+              "name": "value",
+              "text": "札幌の味噌ラーメンにはコーンとバターをのせる店が多い。"
+            }
+          ]
+        },
+        {
+          "id": "ramen-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ramen-03"
+            },
+            {
+              "name": "value",
+              "text": "博多の豚骨ラーメンは細麺で替え玉ができる。"
+            }
+          ]
+        },
+        {
+          "id": "ramen-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ramen-04"
+            },
+            {
+              "name": "value",
+              "text": "つけ麺は濃厚な魚介豚骨スープに麺を浸して食べる。"
+            }
+          ]
+        },
+        {
+          "id": "ramen-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ramen-05"
+            },
+            {
+              "name": "value",
+              "text": "家系ラーメンはほうれん草と海苔とチャーシューが定番。"
+            }
+          ]
+        },
+        {
+          "id": "ramen-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ramen-06"
+            },
+            {
+              "name": "value",
+              "text": "インスタントラーメンに卵とネギを加えると格段においしくなる。"
+            }
+          ]
+        },
+        {
+          "id": "ramen-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ramen-07"
+            },
+            {
+              "name": "value",
+              "text": "ラーメン"
+            },
+            {
+              "name": "value",
+              "text": "麺屋一番"
+            },
+            {
+              "name": "value",
+              "text": "新宿"
+            }
+          ]
+        },
+        {
+          "id": "ramen-08",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ramen-08"
+            },
+            {
+              "name": "value",
+              "text": "塩ラーメンは澄んだスープで素材の味が際立つ。"
+            }
+          ]
+        },
+        {
+          "id": "onsen-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "onsen-01"
+            },
+            {
+              "name": "value",
+              "text": "箱根の温泉は東京から電車で九十分の人気日帰り先。"
+            }
+          ]
+        },
+        {
+          "id": "onsen-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "onsen-02"
+            },
+            {
+              "name": "value",
+              "text": "露天風呂から雪景色を眺める冬の温泉旅行は格別だ。"
+            }
+          ]
+        },
+        {
+          "id": "onsen-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "onsen-03"
+            },
+            {
+              "name": "value",
+              "text": "草津温泉の湯畑は夜のライトアップが美しい。"
+            }
+          ]
+        },
+        {
+          "id": "onsen-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "onsen-04"
+            },
+            {
+              "name": "value",
+              "text": "温泉の泉質は硫黄泉や炭酸水素塩泉など十種類に分かれる。"
+            }
+          ]
+        },
+        {
+          "id": "onsen-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "onsen-05"
+            },
+            {
+              "name": "value",
+              "text": "旅館の会席料理は地元の山菜と川魚が中心だった。"
+            }
+          ]
+        },
+        {
+          "id": "onsen-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "onsen-06"
+            },
+            {
+              "name": "value",
+              "text": "足湯なら無料で楽しめる温泉街も多い。"
+            }
+          ]
+        },
+        {
+          "id": "onsen-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "onsen-07"
+            },
+            {
+              "name": "value",
+              "text": "山吹旅館"
+            },
+            {
+              "name": "value",
+              "text": "かけ流し"
+            },
+            {
+              "name": "value",
+              "text": "和室10畳"
+            }
+          ]
+        },
+        {
+          "id": "onsen-08",
+          "fields": [
+            {
+              "name": "key",
+              "text": "onsen-08"
+            },
+            {
+              "name": "value",
+              "text": "別府の地獄めぐりは源泉の噴気を見学する観光コース。"
+            }
+          ]
+        },
+        {
+          "id": "ml-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ml-01"
+            },
+            {
+              "name": "value",
+              "text": "機械学習モデルの過学習は正則化とデータ拡張で抑える。"
+            }
+          ]
+        },
+        {
+          "id": "ml-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ml-02"
+            },
+            {
+              "name": "value",
+              "text": "ニューラルネットワークの学習率は最初に調整すべき超パラメータだ。"
+            }
+          ]
+        },
+        {
+          "id": "ml-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ml-03"
+            },
+            {
+              "name": "value",
+              "text": "教師あり学習にはラベル付きの訓練データが必要になる。"
+            }
+          ]
+        },
+        {
+          "id": "ml-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ml-04"
+            },
+            {
+              "name": "value",
+              "text": "勾配降下法は損失関数を最小化する基本の最適化手法。"
+            }
+          ]
+        },
+        {
+          "id": "ml-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ml-05"
+            },
+            {
+              "name": "value",
+              "text": "交差検証でモデルの汎化性能を見積もる。"
+            }
+          ]
+        },
+        {
+          "id": "ml-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ml-06"
+            },
+            {
+              "name": "value",
+              "text": "自然言語処理では形態素解析で文を単語に分割する。"
+            }
+          ]
+        },
+        {
+          "id": "ml-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ml-07"
+            },
+            {
+              "name": "value",
+              "text": "分類器"
+            }
+          ]
+        },
+        {
+          "id": "ml-08",
+          "fields": [
+            {
+              "name": "key",
+              "text": "ml-08"
+            },
+            {
+              "name": "value",
+              "text": "深層学習の推論はGPUで大幅に高速化できる。"
+            }
+          ]
+        },
+        {
+          "id": "train-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "train-01"
+            },
+            {
+              "name": "value",
+              "text": "新幹線のぞみ号は東京大阪間を約二時間半で結ぶ。"
+            }
+          ]
+        },
+        {
+          "id": "train-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "train-02"
+            },
+            {
+              "name": "value",
+              "text": "青春18きっぷは普通列車が一日乗り放題になる。"
+            }
+          ]
+        },
+        {
+          "id": "train-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "train-03"
+            },
+            {
+              "name": "value",
+              "text": "山手線は環状運転で主要駅を一周する。"
+            }
+          ]
+        },
+        {
+          "id": "train-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "train-04"
+            },
+            {
+              "name": "value",
+              "text": "寝台特急サンライズ出雲は数少ない定期夜行列車だ。"
+            }
+          ]
+        },
+        {
+          "id": "train-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "train-05"
+            },
+            {
+              "name": "value",
+              "text": "ICカードは全国の鉄道とバスで相互利用できる。"
+            }
+          ]
+        },
+        {
+          "id": "train-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "train-06"
+            },
+            {
+              "name": "value",
+              "text": "ローカル線の車窓から田園風景をのんびり眺める旅もいい。"
+            }
+          ]
+        },
+        {
+          "id": "train-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "train-07"
+            },
+            {
+              "name": "value",
+              "text": "東京-高尾"
+            },
+            {
+              "name": "value",
+              "text": "約60分"
+            },
+            {
+              "name": "value",
+              "text": "中央線"
+            }
+          ]
+        },
+        {
+          "id": "train-08",
+          "fields": [
+            {
+              "name": "key",
+              "text": "train-08"
+            },
+            {
+              "name": "value",
+              "text": "駅弁は地域の名物を詰めた鉄道旅の楽しみのひとつ。"
+            }
+          ]
+        },
+        {
+          "id": "washoku-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "washoku-01"
+            },
+            {
+              "name": "value",
+              "text": "出汁は昆布と鰹節でとるのが和食の基本。"
+            }
+          ]
+        },
+        {
+          "id": "washoku-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "washoku-02"
+            },
+            {
+              "name": "value",
+              "text": "味噌汁の具は豆腐とわかめが定番だ。"
+            }
+          ]
+        },
+        {
+          "id": "washoku-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "washoku-03"
+            },
+            {
+              "name": "value",
+              "text": "天ぷらは衣を薄くして高温で短時間揚げる。"
+            }
+          ]
+        },
+        {
+          "id": "washoku-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "washoku-04"
+            },
+            {
+              "name": "value",
+              "text": "寿司の酢飯は米酢と砂糖と塩で味を調える。"
+            }
+          ]
+        },
+        {
+          "id": "washoku-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "washoku-05"
+            },
+            {
+              "name": "value",
+              "text": "肉じゃがは醤油とみりんで甘辛く煮る家庭料理。"
+            }
+          ]
+        },
+        {
+          "id": "washoku-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "washoku-06"
+            },
+            {
+              "name": "value",
+              "text": "茶碗蒸しは弱火で蒸すと滑らかに仕上がる。"
+            }
+          ]
+        },
+        {
+          "id": "washoku-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "washoku-07"
+            },
+            {
+              "name": "value",
+              "text": "鯖の塩焼き"
+            },
+            {
+              "name": "value",
+              "text": "味噌汁"
+            },
+            {
+              "name": "value",
+              "text": "焼き魚定食"
+            }
+          ]
+        },
+        {
+          "id": "washoku-08",
+          "fields": [
+            {
+              "name": "key",
+              "text": "washoku-08"
+            },
+            {
+              "name": "value",
+              "text": "漬物は野菜を塩や糠で発酵させた保存食。"
+            }
+          ]
+        },
+        {
+          "id": "soccer-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "soccer-01"
+            },
+            {
+              "name": "value",
+              "text": "ワールドカップ予選で日本代表が逆転勝ちした。"
+            }
+          ]
+        },
+        {
+          "id": "soccer-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "soccer-02"
+            },
+            {
+              "name": "value",
+              "text": "オフサイドは守備側の最終ラインより前でパスを受けると成立する。"
+            }
+          ]
+        },
+        {
+          "id": "soccer-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "soccer-03"
+            },
+            {
+              "name": "value",
+              "text": "ペナルティキックは十二ヤード地点から蹴る。"
+            }
+          ]
+        },
+        {
+          "id": "soccer-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "soccer-04"
+            },
+            {
+              "name": "value",
+              "text": "リーグ戦は勝ち点で順位が決まり得失点差が次の基準になる。"
+            }
+          ]
+        },
+        {
+          "id": "soccer-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "soccer-05"
+            },
+            {
+              "name": "value",
+              "text": "海外移籍した若手選手の活躍が期待される。"
+            }
+          ]
+        },
+        {
+          "id": "soccer-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "soccer-06"
+            },
+            {
+              "name": "value",
+              "text": "2-1"
+            },
+            {
+              "name": "value",
+              "text": "国立競技場"
+            },
+            {
+              "name": "value",
+              "text": "決勝"
+            }
+          ]
+        },
+        {
+          "id": "soccer-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "soccer-07"
+            },
+            {
+              "name": "value",
+              "text": "ゴールキーパーはペナルティエリア内でだけ手を使える。"
+            }
+          ]
+        },
+        {
+          "id": "book-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "book-01"
+            },
+            {
+              "name": "value",
+              "text": "図書館の本は二週間借りられて一回だけ延長できる。"
+            }
+          ]
+        },
+        {
+          "id": "book-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "book-02"
+            },
+            {
+              "name": "value",
+              "text": "夏目漱石の坊っちゃんは中学生でも読みやすい名作だ。"
+            }
+          ]
+        },
+        {
+          "id": "book-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "book-03"
+            },
+            {
+              "name": "value",
+              "text": "電子書籍は端末ひとつで数千冊持ち歩ける。"
+            }
+          ]
+        },
+        {
+          "id": "book-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "book-04"
+            },
+            {
+              "name": "value",
+              "text": "推理小説の伏線が最終章で一気に回収された。"
+            }
+          ]
+        },
+        {
+          "id": "book-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "book-05"
+            },
+            {
+              "name": "value",
+              "text": "絵本の読み聞かせは語彙の発達に良い影響がある。"
+            }
+          ]
+        },
+        {
+          "id": "book-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "book-06"
+            },
+            {
+              "name": "value",
+              "text": "雪国"
+            },
+            {
+              "name": "value",
+              "text": "川端康成"
+            }
+          ]
+        },
+        {
+          "id": "book-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "book-07"
+            },
+            {
+              "name": "value",
+              "text": "古本市で絶版の写真集を安く手に入れた。"
+            }
+          ]
+        },
+        {
+          "id": "phone-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "phone-01"
+            },
+            {
+              "name": "value",
+              "text": "スマートフォンのバッテリーは残量二割で充電すると長持ちする。"
+            }
+          ]
+        },
+        {
+          "id": "phone-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "phone-02"
+            },
+            {
+              "name": "value",
+              "text": "機種変更ではデータ移行アプリで写真も連絡先も引き継げる。"
+            }
+          ]
+        },
+        {
+          "id": "phone-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "phone-03"
+            },
+            {
+              "name": "value",
+              "text": "画面割れの修理費用は保証プランで大きく変わる。"
+            }
+          ]
+        },
+        {
+          "id": "phone-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "phone-04"
+            },
+            {
+              "name": "value",
+              "text": "格安SIMに乗り換えて通信費が月三千円下がった。"
+            }
+          ]
+        },
+        {
+          "id": "phone-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "phone-05"
+            },
+            {
+              "name": "value",
+              "text": "カメラの夜景モードは手持ちでも明るく撮れる。"
+            }
+          ]
+        },
+        {
+          "id": "phone-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "phone-06"
+            },
+            {
+              "name": "value",
+              "text": "128GB"
+            },
+            {
+              "name": "value",
+              "text": "Pixel"
+            },
+            {
+              "name": "value",
+              "text": "黒"
+            }
+          ]
+        },
+        {
+          "id": "phone-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "phone-07"
+            },
+            {
+              "name": "value",
+              "text": "ながらスマホは歩行中の事故につながり危険だ。"
+            }
+          ]
+        },
+        {
+          "id": "weather-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "weather-01"
+            },
+            {
+              "name": "value",
+              "text": "台風が接近すると気圧が下がり頭痛を訴える人が増える。"
+            }
+          ]
+        },
+        {
+          "id": "weather-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "weather-02"
+            },
+            {
+              "name": "value",
+              "text": "梅雨前線が停滞して一週間雨が続いた。"
+            }
+          ]
+        },
+        {
+          "id": "weather-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "weather-03"
+            },
+            {
+              "name": "value",
+              "text": "真夏日は最高気温三十度以上、猛暑日は三十五度以上を指す。"
+            }
+          ]
+        },
+        {
+          "id": "weather-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "weather-04"
+            },
+            {
+              "name": "value",
+              "text": "花粉の飛散は二月下旬のスギから始まる。"
+            }
+          ]
+        },
+        {
+          "id": "weather-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "weather-05"
+            },
+            {
+              "name": "value",
+              "text": "初雪の便りが北海道から届いた。"
+            }
+          ]
+        },
+        {
+          "id": "weather-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "weather-06"
+            },
+            {
+              "name": "value",
+              "text": "晴れのち曇り"
+            },
+            {
+              "name": "value",
+              "text": "東京"
+            }
+          ]
+        },
+        {
+          "id": "weather-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "weather-07"
+            },
+            {
+              "name": "value",
+              "text": "雷が鳴ったら建物の中に避難するのが安全だ。"
+            }
+          ]
+        },
+        {
+          "id": "niwa-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "niwa-01"
+            },
+            {
+              "name": "value",
+              "text": "朝顔の種は五月に蒔くと夏休みに花が咲く。"
+            }
+          ]
+        },
+        {
+          "id": "niwa-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "niwa-02"
+            },
+            {
+              "name": "value",
+              "text": "トマトの脇芽は早めに摘むと実が大きく育つ。"
+            }
+          ]
+        },
+        {
+          "id": "niwa-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "niwa-03"
+            },
+            {
+              "name": "value",
+              "text": "観葉植物は直射日光を避けて明るい日陰に置く。"
+            }
+          ]
+        },
+        {
+          "id": "niwa-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "niwa-04"
+            },
+            {
+              "name": "value",
+              "text": "紫陽花の色は土の酸性度で青にも桃色にも変わる。"
+            }
+          ]
+        },
+        {
+          "id": "niwa-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "niwa-05"
+            },
+            {
+              "name": "value",
+              "text": "多肉植物は乾燥に強く水やりは月に数回でよい。"
+            }
+          ]
+        },
+        {
+          "id": "niwa-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "niwa-06"
+            },
+            {
+              "name": "value",
+              "text": "良好"
+            },
+            {
+              "name": "value",
+              "text": "バジル"
+            },
+            {
+              "name": "value",
+              "text": "毎日"
+            }
+          ]
+        },
+        {
+          "id": "niwa-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "niwa-07"
+            },
+            {
+              "name": "value",
+              "text": "芝生は春と秋に肥料を与えると密に育つ。"
+            }
+          ]
+        }
+      ]
+    },
+    "mixed": {
+      "docs": [
+        {
+          "id": "mk8s-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mk8s-01"
+            },
+            {
+              "name": "value",
+              "text": "Kubernetesのローリングアップデートは無停止でPodを入れ替える。"
+            }
+          ]
+        },
+        {
+          "id": "mk8s-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mk8s-02"
+            },
+            {
+              "name": "value",
+              "text": "kubectl applyでマニフェストの差分だけ適用される。"
+            }
+          ]
+        },
+        {
+          "id": "mk8s-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mk8s-03"
+            },
+            {
+              "name": "value",
+              "text": "本番環境のdeploymentはreplicas三つで冗長化している。"
+            }
+          ]
+        },
+        {
+          "id": "mk8s-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mk8s-04"
+            },
+            {
+              "name": "value",
+              "text": "Helmチャートでステージング環境の設定を上書きする。"
+            }
+          ]
+        },
+        {
+          "id": "mk8s-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mk8s-05"
+            },
+            {
+              "name": "value",
+              "text": "api-gateway"
+            },
+            {
+              "name": "value",
+              "text": "production"
+            }
+          ]
+        },
+        {
+          "id": "mk8s-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mk8s-06"
+            },
+            {
+              "name": "value",
+              "text": "Podのliveness probeが失敗すると自動で再起動される。"
+            }
+          ]
+        },
+        {
+          "id": "mk8s-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mk8s-07"
+            },
+            {
+              "name": "value",
+              "text": "ノードのメンテナンスはdrainしてから行う。"
+            }
+          ]
+        },
+        {
+          "id": "mdb-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mdb-01"
+            },
+            {
+              "name": "value",
+              "text": "Redisクラスタはシャーディングでスループットを伸ばす。"
+            }
+          ]
+        },
+        {
+          "id": "mdb-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mdb-02"
+            },
+            {
+              "name": "value",
+              "text": "PostgreSQLのバックアップは毎晩S3へ転送している。"
+            }
+          ]
+        },
+        {
+          "id": "mdb-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mdb-03"
+            },
+            {
+              "name": "value",
+              "text": "インメモリキャッシュのTTLは既定で三百秒に設定。"
+            }
+          ]
+        },
+        {
+          "id": "mdb-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mdb-04"
+            },
+            {
+              "name": "value",
+              "text": "レプリケーション遅延が五秒を超えたらアラートを出す。"
+            }
+          ]
+        },
+        {
+          "id": "mdb-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mdb-05"
+            },
+            {
+              "name": "value",
+              "text": "postgres"
+            }
+          ]
+        },
+        {
+          "id": "mdb-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mdb-06"
+            },
+            {
+              "name": "value",
+              "text": "スロークエリログでインデックス不足を特定した。"
+            }
+          ]
+        },
+        {
+          "id": "mdb-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mdb-07"
+            },
+            {
+              "name": "value",
+              "text": "グラフデータベースは頂点とエッジで関係を表現する。"
+            }
+          ]
+        },
+        {
+          "id": "prod-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "prod-01"
+            },
+            {
+              "name": "value",
+              "text": "ワイヤレスイヤホン Pro 2は最大八時間再生できる。"
+            }
+          ]
+        },
+        {
+          "id": "prod-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "prod-02"
+            },
+            {
+              "name": "value",
+              "text": "コーヒーメーカー"
+            },
+            {
+              "name": "value",
+              "text": "CM-500"
+            }
+          ]
+        },
+        {
+          "id": "prod-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "prod-03"
+            },
+            {
+              "name": "value",
+              "text": "4Kモニター27インチはUSB-C給電に対応。"
+            }
+          ]
+        },
+        {
+          "id": "prod-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "prod-04"
+            },
+            {
+              "name": "value",
+              "text": "電動アシスト自転車のバッテリーは一回の充電で約60km走る。"
+            }
+          ]
+        },
+        {
+          "id": "prod-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "prod-05"
+            },
+            {
+              "name": "value",
+              "text": "ロボット掃除機は畳もフローリングも自動で判別する。"
+            }
+          ]
+        },
+        {
+          "id": "prod-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "prod-06"
+            },
+            {
+              "name": "value",
+              "text": "キーボード"
+            },
+            {
+              "name": "value",
+              "text": "US"
+            },
+            {
+              "name": "value",
+              "text": "茶軸"
+            }
+          ]
+        },
+        {
+          "id": "prod-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "prod-07"
+            },
+            {
+              "name": "value",
+              "text": "スマートウォッチで睡眠の質をスコア化できる。"
+            }
+          ]
+        },
+        {
+          "id": "mtrv-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mtrv-01"
+            },
+            {
+              "name": "value",
+              "text": "Tokyo Metroの24時間券は外国人観光客に人気だ。"
+            }
+          ]
+        },
+        {
+          "id": "mtrv-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mtrv-02"
+            },
+            {
+              "name": "value",
+              "text": "羽田空港のTerminal 3は国際線専用ターミナル。"
+            }
+          ]
+        },
+        {
+          "id": "mtrv-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mtrv-03"
+            },
+            {
+              "name": "value",
+              "text": "新宿駅のJR東口からBic Cameraまで徒歩三分。"
+            }
+          ]
+        },
+        {
+          "id": "mtrv-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mtrv-04"
+            },
+            {
+              "name": "value",
+              "text": "15:00"
+            },
+            {
+              "name": "value",
+              "text": "パークホテル東京"
+            },
+            {
+              "name": "value",
+              "text": "汐留"
+            }
+          ]
+        },
+        {
+          "id": "mtrv-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mtrv-05"
+            },
+            {
+              "name": "value",
+              "text": "京都のバス一日券は600円で市内観光に便利。"
+            }
+          ]
+        },
+        {
+          "id": "mtrv-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mtrv-06"
+            },
+            {
+              "name": "value",
+              "text": "Suicaはコンビニでもチャージできる。"
+            }
+          ]
+        },
+        {
+          "id": "mtrv-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mtrv-07"
+            },
+            {
+              "name": "value",
+              "text": "成田エクスプレスはNarita Airportと都心を結ぶ。"
+            }
+          ]
+        },
+        {
+          "id": "mdev-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mdev-01"
+            },
+            {
+              "name": "value",
+              "text": "コードレビューはPull Requestごとに二名の承認が必要。"
+            }
+          ]
+        },
+        {
+          "id": "mdev-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mdev-02"
+            },
+            {
+              "name": "value",
+              "text": "CIのビルドはmainブランチへのpushで自動実行される。"
+            }
+          ]
+        },
+        {
+          "id": "mdev-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mdev-03"
+            },
+            {
+              "name": "value",
+              "text": "リリースノートはCHANGELOGから自動生成している。"
+            }
+          ]
+        },
+        {
+          "id": "mdev-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mdev-04"
+            },
+            {
+              "name": "value",
+              "text": "main"
+            },
+            {
+              "name": "value",
+              "text": "lantern"
+            },
+            {
+              "name": "value",
+              "text": "必須"
+            }
+          ]
+        },
+        {
+          "id": "mdev-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mdev-05"
+            },
+            {
+              "name": "value",
+              "text": "障害対応のポストモーテムは非難なしで事実に集中する。"
+            }
+          ]
+        },
+        {
+          "id": "mdev-06",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mdev-06"
+            },
+            {
+              "name": "value",
+              "text": "フィーチャーフラグで新機能を段階的に公開する。"
+            }
+          ]
+        },
+        {
+          "id": "mdev-07",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mdev-07"
+            },
+            {
+              "name": "value",
+              "text": "APIのレート制限は毎分六十リクエストまで。"
+            }
+          ]
+        },
+        {
+          "id": "mfood-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mfood-01"
+            },
+            {
+              "name": "value",
+              "text": "抹茶ラテはミルクの温度を六十度に保つと甘みが出る。"
+            }
+          ]
+        },
+        {
+          "id": "mfood-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mfood-02"
+            },
+            {
+              "name": "value",
+              "text": "クラフトビールのIPAはホップの苦味が特徴。"
+            }
+          ]
+        },
+        {
+          "id": "mfood-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mfood-03"
+            },
+            {
+              "name": "value",
+              "text": "カレーライス"
+            },
+            {
+              "name": "value",
+              "text": "中辛"
+            }
+          ]
+        },
+        {
+          "id": "mfood-04",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mfood-04"
+            },
+            {
+              "name": "value",
+              "text": "コンビニのカフェラテは100円台でも十分おいしい。"
+            }
+          ]
+        },
+        {
+          "id": "mfood-05",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mfood-05"
+            },
+            {
+              "name": "value",
+              "text": "タピオカミルクティーの再ブームが来ている。"
+            }
+          ]
+        },
+        {
+          "id": "mmisc-01",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mmisc-01"
+            },
+            {
+              "name": "value",
+              "text": "ＴＯＫＹＯマラソンの抽選倍率は十倍を超える。"
+            }
+          ]
+        },
+        {
+          "id": "mmisc-02",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mmisc-02"
+            },
+            {
+              "name": "value",
+              "text": "ｷｬｯｼｭﾚｽ決済のポイント還元が今月で終了する。"
+            }
+          ]
+        },
+        {
+          "id": "mmisc-03",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mmisc-03"
+            },
+            {
+              "name": "value",
+              "text": "Wi-Fiルーターの設置場所は家の中心が理想。"
+            }
+          ]
+        },
+        {
+          "id": "mprox-scatter",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mprox-scatter"
+            },
+            {
+              "name": "value",
+              "text": "marimba cinder plinth obsidian gable"
+            }
+          ]
+        },
+        {
+          "id": "mprox-tight",
+          "fields": [
+            {
+              "name": "key",
+              "text": "mprox-tight"
+            },
+            {
+              "name": "value",
+              "text": "cinder plinth obsidian marimba gable"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/sdks/dart/test/real_wire_test.dart
+++ b/sdks/dart/test/real_wire_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io' as io;
 import 'dart:typed_data';
 
@@ -637,6 +638,157 @@ void main() {
       expect(update.hits.map((hit) => hit.key), ['${searchPrefix}a']);
     },
   );
+
+  test('shared production search conformance manifest', () async {
+    final manifest =
+        jsonDecode(
+              io.File(
+                '../../testdata/search/conformance.json',
+              ).readAsStringSync(),
+            )
+            as Map<String, dynamic>;
+    expect(manifest['version'], 'search-conformance-v1');
+
+    SearchOptions options(Map<String, dynamic> raw) {
+      final mode = switch (raw['match_mode']) {
+        'any' => SearchMatchMode.any,
+        'all' => SearchMatchMode.all,
+        'min-should' => SearchMatchMode.minShouldMatch,
+        _ => null,
+      };
+      return SearchOptions(
+        limit: (raw['limit'] as num?)?.toInt() ?? 0,
+        prefix: raw['prefix'] as String? ?? '',
+        matchMode: mode,
+        minShouldMatch: (raw['min_should_match'] as num?)?.toInt(),
+        phrase: raw['phrase'] as bool?,
+        fuzziness: (raw['fuzziness'] as num?)?.toInt(),
+        prefixTerms: raw['prefix_terms'] as bool?,
+      );
+    }
+
+    final vertices = (manifest['vertices'] as List<dynamic>)
+        .cast<Map<String, dynamic>>()
+        .map(
+          (vertex) => VertexInput(
+            key: vertex['key'] as String,
+            value: VertexValue.string(vertex['value'] as String),
+          ),
+        )
+        .toList();
+    await client.putVertices(vertices);
+
+    for (final fixture
+        in (manifest['queries'] as List<dynamic>)
+            .cast<Map<String, dynamic>>()) {
+      final result = await client.searchVertices(
+        fixture['query'] as String,
+        searchOptions: options(
+          (fixture['options'] as Map<dynamic, dynamic>).cast<String, dynamic>(),
+        ),
+      );
+      expect(result, isA<SearchEnabled>(), reason: fixture['name'] as String);
+      expect(
+        (result as SearchEnabled).hits.map((hit) => hit.key).toList(),
+        (fixture['want_keys'] as List<dynamic>).cast<String>(),
+        reason: fixture['name'] as String,
+      );
+      expect(result.hits.every((hit) => hit.score.isFinite), isTrue);
+    }
+
+    for (final fixture
+        in (manifest['invalid'] as List<dynamic>)
+            .cast<Map<String, dynamic>>()) {
+      await expectLater(
+        client.searchVertices(
+          fixture['query'] as String,
+          searchOptions: options(
+            (fixture['options'] as Map<dynamic, dynamic>)
+                .cast<String, dynamic>(),
+          ),
+        ),
+        throwsA(isA<LanternInvalidArgumentException>()),
+        reason: fixture['name'] as String,
+      );
+    }
+
+    final cancellation = (manifest['cancellation'] as Map<dynamic, dynamic>)
+        .cast<String, dynamic>();
+    final cancellationToken = LanternCancellationToken()
+      ..cancel('shared conformance pre-canceled');
+    await expectLater(
+      client.searchVertices(
+        cancellation['query'] as String,
+        searchOptions: options(
+          (cancellation['options'] as Map<dynamic, dynamic>)
+              .cast<String, dynamic>(),
+        ),
+        options: LanternCallOptions(cancellation: cancellationToken),
+      ),
+      throwsA(isA<LanternCanceledException>()),
+      reason: cancellation['name'] as String,
+    );
+
+    final errorEndpoints = <String, String?>{
+      'disabled':
+          io.Platform.environment['LANTERN_DART_SEARCH_DISABLED_ENDPOINT'],
+      'positions-disabled': io
+          .Platform
+          .environment['LANTERN_DART_SEARCH_POSITIONS_DISABLED_ENDPOINT'],
+      'query-budget':
+          io.Platform.environment['LANTERN_DART_SEARCH_BUDGET_ENDPOINT'],
+    };
+    for (final fixture
+        in (manifest['typed_errors'] as List<dynamic>)
+            .cast<Map<String, dynamic>>()) {
+      final environment = fixture['environment'] as String;
+      final errorEndpoint = errorEndpoints[environment];
+      expect(errorEndpoint, isNotNull, reason: '$environment endpoint missing');
+      final errorClient = LanternClient.connect(
+        Uri.parse(errorEndpoint!),
+        allowInsecure: errorEndpoint.startsWith('http://'),
+      );
+      addTearDown(errorClient.close);
+      final call = errorClient.searchVertices(
+        fixture['query'] as String,
+        searchOptions: options(
+          (fixture['options'] as Map<dynamic, dynamic>).cast<String, dynamic>(),
+        ),
+      );
+      switch (fixture['reason']) {
+        case 'search-disabled':
+          expect(await call, isA<SearchDisabled>());
+        case 'positions-disabled':
+          await expectLater(
+            call,
+            throwsA(
+              isA<LanternFailedPreconditionException>().having(
+                (error) => error.searchReason,
+                'searchReason',
+                SearchErrorReason.searchPositionsDisabled,
+              ),
+            ),
+          );
+        case 'query_bytes':
+          await expectLater(
+            call,
+            throwsA(
+              isA<LanternResourceExhaustedException>()
+                  .having(
+                    (error) => error.searchReason,
+                    'searchReason',
+                    SearchErrorReason.searchWorkBudgetExhausted,
+                  )
+                  .having(
+                    (error) => error.searchWorkKind,
+                    'searchWorkKind',
+                    'query_bytes',
+                  ),
+            ),
+          );
+      }
+    }
+  });
 
   test(
     'all traversal families preserve family sentinels and Edge TTL',

--- a/sdks/node/test/search-conformance.test.ts
+++ b/sdks/node/test/search-conformance.test.ts
@@ -1,0 +1,142 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+import {
+  FailedPreconditionError,
+  InvalidArgumentError,
+  ResourceExhaustedError,
+  SearchErrorReason,
+  connect,
+  type Lantern,
+  type SearchOptions,
+} from "../src/index.js";
+
+interface ManifestOptions {
+  limit?: number;
+  prefix?: string;
+  match_mode?: "any" | "all" | "min-should";
+  min_should_match?: number;
+  phrase?: boolean;
+  fuzziness?: number;
+  prefix_terms?: boolean;
+}
+
+interface ManifestCase {
+  name: string;
+  query: string;
+  options: ManifestOptions;
+  want_keys?: string[];
+  environment?: string;
+  reason?: string;
+}
+
+interface Manifest {
+  version: string;
+  vertices: { key: string; value: string }[];
+  queries: ManifestCase[];
+  invalid: ManifestCase[];
+  cancellation: ManifestCase;
+  typed_errors: ManifestCase[];
+}
+
+const manifest = JSON.parse(
+  readFileSync(new URL("../../../testdata/search/conformance.json", import.meta.url), "utf8"),
+) as Manifest;
+
+const endpoints = {
+  enabled: process.env.LANTERN_NODE_REAL_WIRE_ENDPOINT,
+  disabled: process.env.LANTERN_NODE_SEARCH_DISABLED_ENDPOINT,
+  "positions-disabled": process.env.LANTERN_NODE_SEARCH_POSITIONS_DISABLED_ENDPOINT,
+  "query-budget": process.env.LANTERN_NODE_SEARCH_BUDGET_ENDPOINT,
+};
+
+function options(input: ManifestOptions): SearchOptions {
+  return {
+    limit: input.limit,
+    prefix: input.prefix,
+    matchMode: input.match_mode,
+    minShouldMatch: input.min_should_match,
+    phrase: input.phrase,
+    fuzziness: input.fuzziness,
+    prefixTerms: input.prefix_terms,
+  };
+}
+
+if (Object.values(endpoints).some((endpoint) => !endpoint)) {
+  test("shared search conformance requires all real-wire endpoints", () => {
+    expect(manifest.version).toBe("search-conformance-v1");
+  });
+} else {
+  describe("shared production search conformance", () => {
+    let client: Lantern;
+
+    beforeAll(async () => {
+      client = connect(endpoints.enabled!);
+      await client.putVertices(manifest.vertices);
+    });
+
+    afterAll(() => client.close());
+
+    for (const fixture of manifest.queries) {
+      test(fixture.name, async () => {
+        const hits = await client.searchVertices(fixture.query, options(fixture.options));
+        expect(hits.map((hit) => hit.key)).toEqual(fixture.want_keys ?? []);
+        expect(hits.every((hit) => Number.isFinite(hit.score))).toBe(true);
+      });
+    }
+
+    for (const fixture of manifest.invalid) {
+      test(`invalid/${fixture.name}`, async () => {
+        await expect(
+          client.searchVertices(fixture.query, options(fixture.options)),
+        ).rejects.toBeInstanceOf(InvalidArgumentError);
+      });
+    }
+
+    test(`cancellation/${manifest.cancellation.name}`, async () => {
+      const controller = new AbortController();
+      controller.abort();
+      await expect(
+        client.searchVertices(
+          manifest.cancellation.query,
+          options(manifest.cancellation.options),
+          controller.signal,
+        ),
+      ).rejects.toBeDefined();
+    });
+
+    for (const fixture of manifest.typed_errors) {
+      test(`typed/${fixture.name}`, async () => {
+        const errorClient = connect(endpoints[fixture.environment as keyof typeof endpoints]!);
+        try {
+          await errorClient.searchVertices(fixture.query, options(fixture.options));
+          expect.unreachable("search should reject");
+        } catch (error) {
+          switch (fixture.reason) {
+            case "search-disabled":
+              expect(error).toBeInstanceOf(FailedPreconditionError);
+              expect((error as FailedPreconditionError).reason).toBe(
+                SearchErrorReason.SEARCH_DISABLED,
+              );
+              break;
+            case "positions-disabled":
+              expect(error).toBeInstanceOf(FailedPreconditionError);
+              expect((error as FailedPreconditionError).reason).toBe(
+                SearchErrorReason.SEARCH_POSITIONS_DISABLED,
+              );
+              break;
+            case "query_bytes":
+              expect(error).toBeInstanceOf(ResourceExhaustedError);
+              expect((error as ResourceExhaustedError).reason).toBe(
+                SearchErrorReason.SEARCH_WORK_BUDGET_EXHAUSTED,
+              );
+              expect((error as ResourceExhaustedError).workKind).toBe("query_bytes");
+              break;
+          }
+        } finally {
+          errorClient.close();
+        }
+      });
+    }
+  });
+}

--- a/server/provider/search_test.go
+++ b/server/provider/search_test.go
@@ -1,15 +1,101 @@
 package provider
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"os"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/search"
+	"github.com/anaregdesign/lantern/core/search/relevance"
 	v1 "github.com/anaregdesign/lantern/pb/graph/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+const projectedFieldsFixturePath = "../../core/search/relevance/testdata/projected_fields.json"
+const luceneBaselinePath = "../../core/search/relevance/testdata/lucene_runs.json"
+
+type projectedFieldsFixture struct {
+	FixtureFormat     string                     `json:"fixture_format"`
+	ProjectionVersion string                     `json:"projection_version"`
+	Corpora           map[string]projectedCorpus `json:"corpora"`
+}
+
+type projectedCorpus struct {
+	Docs []projectedDoc `json:"docs"`
+}
+
+type projectedDoc struct {
+	ID     string           `json:"id"`
+	Fields []projectedField `json:"fields"`
+}
+
+type projectedField struct {
+	Name string `json:"name"`
+	Text string `json:"text"`
+}
+
+func canonicalProjectedFieldsFixture(t *testing.T) projectedFieldsFixture {
+	t.Helper()
+	corpora, err := relevance.Corpora()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture := projectedFieldsFixture{
+		FixtureFormat:     relevance.BaselineFixtureFormat,
+		ProjectionVersion: relevance.BaselineProjectionVersion,
+		Corpora:           make(map[string]projectedCorpus, len(corpora)),
+	}
+	for _, corpus := range corpora {
+		projected := projectedCorpus{Docs: make([]projectedDoc, 0, len(corpus.Docs))}
+		for _, doc := range corpus.Docs {
+			vertex := &v1.Vertex{Key: doc.ID, Value: &v1.Vertex_String_{String_: doc.Text}}
+			fields := vertexSearchDocument(doc.ID, vertex).(vertexSearchProjection).SearchFields()
+			out := projectedDoc{ID: doc.ID, Fields: make([]projectedField, len(fields))}
+			for i, field := range fields {
+				name := "value"
+				if field.ID == search.FieldKey {
+					name = "key"
+				}
+				out.Fields[i] = projectedField{Name: name, Text: field.Text}
+			}
+			projected.Docs = append(projected.Docs, out)
+		}
+		fixture.Corpora[corpus.Name] = projected
+	}
+	return fixture
+}
+
+func projectedFixtureBytes(t *testing.T, fixture projectedFieldsFixture) []byte {
+	t.Helper()
+	raw, err := json.MarshalIndent(fixture, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return append(raw, '\n')
+}
+
+func TestVertexSearchProjectionFixture(t *testing.T) {
+	want := projectedFixtureBytes(t, canonicalProjectedFieldsFixture(t))
+	if os.Getenv("UPDATE_SEARCH_PROJECTION_FIXTURE") == "1" {
+		if err := os.WriteFile(projectedFieldsFixturePath, want, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	got, err := os.ReadFile(projectedFieldsFixturePath)
+	if err != nil {
+		t.Fatalf("read fixture (regenerate with cd server && UPDATE_SEARCH_PROJECTION_FIXTURE=1 go test ./provider -run TestVertexSearchProjectionFixture): %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatal("production search projection fixture is stale; regenerate with cd server && UPDATE_SEARCH_PROJECTION_FIXTURE=1 go test ./provider -run TestVertexSearchProjectionFixture")
+	}
+}
 
 func TestVertexSearchDocument(t *testing.T) {
 	tests := []struct {
@@ -48,14 +134,51 @@ func TestVertexSearchDocument(t *testing.T) {
 			want:   "blob",
 		},
 		{
+			name:   "float64 value formatted",
+			vertex: &v1.Vertex{Key: "f64", Value: &v1.Vertex_Float64{Float64: 1.25}},
+			want:   "f64 1.25",
+		},
+		{
+			name:   "float32 value formatted",
+			vertex: &v1.Vertex{Key: "f32", Value: &v1.Vertex_Float32{Float32: 2.5}},
+			want:   "f32 2.5",
+		},
+		{
+			name:   "int32 value formatted decimally",
+			vertex: &v1.Vertex{Key: "i32", Value: &v1.Vertex_Int32{Int32: -42}},
+			want:   "i32 -42",
+		},
+		{
 			name:   "int64 value formatted decimally",
 			vertex: &v1.Vertex{Key: "count", Value: &v1.Vertex_Int64{Int64: 42}},
 			want:   "count 42",
 		},
 		{
+			name:   "uint32 value formatted decimally",
+			vertex: &v1.Vertex{Key: "u32", Value: &v1.Vertex_Uint32{Uint32: 42}},
+			want:   "u32 42",
+		},
+		{
+			name:   "uint64 value formatted decimally",
+			vertex: &v1.Vertex{Key: "u64", Value: &v1.Vertex_Uint64{Uint64: 18446744073709551615}},
+			want:   "u64 18446744073709551615",
+		},
+		{
 			name:   "bool value rendered",
 			vertex: &v1.Vertex{Key: "flag", Value: &v1.Vertex_Bool{Bool: true}},
 			want:   "flag true",
+		},
+		{
+			name: "timestamp value uses RFC3339Nano",
+			vertex: &v1.Vertex{Key: "when", Value: &v1.Vertex_Timestamp{Timestamp: timestamppb.New(
+				time.Date(2026, 7, 13, 1, 2, 3, 456000000, time.UTC),
+			)}},
+			want: "when 2026-07-13T01:02:03.456Z",
+		},
+		{
+			name:   "duration value uses Go form",
+			vertex: &v1.Vertex{Key: "elapsed", Value: &v1.Vertex_Duration{Duration: durationpb.New(12*time.Second + 345*time.Millisecond)}},
+			want:   "elapsed 12.345s",
 		},
 		{
 			name:   "json object string value drops field names and non-strings",
@@ -223,5 +346,72 @@ func TestNewSearchConfig(t *testing.T) {
 	c := &Config{Search: SearchConfig{Enabled: true, DefaultLimit: 7, MaxLimit: 9}}
 	if got := NewSearchConfig(c); got != c.Search {
 		t.Errorf("NewSearchConfig = %+v, want %+v", got, c.Search)
+	}
+}
+
+// TestProductionProjectionRelevanceGate is deliberately separate from core's
+// analyzer-only floor. It feeds canonical typed string vertices through the
+// exact provider projection and production GraphCache composition, so key/value
+// field drift changes these measured rankings.
+func TestProductionProjectionRelevanceGate(t *testing.T) {
+	corpora, err := relevance.Corpora()
+	if err != nil {
+		t.Fatal(err)
+	}
+	floors := map[string]relevance.Metrics{
+		"en":    {NDCG10: 0.934, MRR: 1.000, Recall50: 0.969},
+		"ja":    {NDCG10: 0.908, MRR: 1.000, Recall50: 0.722},
+		"mixed": {NDCG10: 0.955, MRR: 1.000, Recall50: 0.770},
+	}
+	measured := make(map[string]relevance.Metrics, len(corpora))
+	byName := make(map[string]relevance.Corpus, len(corpora))
+	for _, corpus := range corpora {
+		byName[corpus.Name] = corpus
+		t.Run(corpus.Name, func(t *testing.T) {
+			cache := NewGraphCache(CacheConfig{TTL: time.Hour}, SearchConfig{Enabled: true, Positions: true})
+			expiration := time.Now().Add(time.Hour)
+			for _, doc := range corpus.Docs {
+				vertex := &v1.Vertex{Key: doc.ID, Value: &v1.Vertex_String_{String_: doc.Text}}
+				if err := cache.PutVertexWithExpiration(doc.ID, vertex, expiration); err != nil {
+					t.Fatalf("index %s: %v", doc.ID, err)
+				}
+			}
+			metrics := relevance.Evaluate(corpus, func(query relevance.Query) []string {
+				results := cache.SearchVertices(query.Text, relevance.EvalDepth, "")
+				ids := make([]string, len(results))
+				for i, result := range results {
+					ids[i] = result.ID
+				}
+				return ids
+			})
+			measured[corpus.Name] = metrics
+			t.Logf("production projection: nDCG@10=%.4f MRR=%.4f Recall@50=%.4f", metrics.NDCG10, metrics.MRR, metrics.Recall50)
+			floor := floors[corpus.Name]
+			if metrics.NDCG10 < floor.NDCG10 || metrics.MRR < floor.MRR || metrics.Recall50 < floor.Recall50 {
+				t.Fatalf("metrics %+v below floor %+v", metrics, floor)
+			}
+		})
+	}
+	runs, err := relevance.LoadBaselineRuns(luceneBaselinePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runs.ValidateProvenance(); err != nil {
+		t.Fatal(err)
+	}
+	for name, run := range runs.Runs {
+		if !run.Blocking {
+			continue
+		}
+		t.Run("lucene/"+name, func(t *testing.T) {
+			corpus := byName[run.Corpus]
+			lucene := run.Evaluate(corpus)
+			lantern := measured[run.Corpus]
+			t.Logf("%s [%s]: Lucene=%+v Lantern=%+v", runs.Engine, run.Analyzer, lucene, lantern)
+			const epsilon = 1e-9
+			if lantern.NDCG10 < lucene.NDCG10-epsilon || lantern.MRR < lucene.MRR-epsilon || lantern.Recall50 < lucene.Recall50-epsilon {
+				t.Fatalf("production projection metrics %+v below blocking Lucene %s %+v", lantern, run.Analyzer, lucene)
+			}
+		})
 	}
 }

--- a/testbed/SKILL.md
+++ b/testbed/SKILL.md
@@ -122,23 +122,29 @@ docker compose logs lantern --no-color \
 
 ## Lucene relevance baseline (#887)
 
-`lucene-baseline/` regenerates the pinned Lucene rankings the search-relevance
-harness compares against (`core/search/relevance`, gate
-`TestLuceneBaselineComparison`). CI never runs a JVM: the runner executes
-offline here, and only its output — `core/search/relevance/testdata/lucene_runs.json`
-— is committed.
+`lucene-baseline/` regenerates the pinned Lucene rankings that the exact
+production projection gate compares against. CI never runs a JVM: the runner
+executes offline here. Both the provider-generated `projected_fields.json`
+input and the runner's `lucene_runs.json` output are committed under
+`core/search/relevance/testdata/`.
 
 ```bash
+(
+  cd server
+  UPDATE_SEARCH_PROJECTION_FIXTURE=1 \
+    go test ./provider -run TestVertexSearchProjectionFixture
+)
 testbed/lucene-baseline/run.sh   # docker build + run; rewrites lucene_runs.json
-(cd core && go test ./search/relevance/ -v -run TestLuceneBaselineComparison)
+(cd core && go test ./search/relevance/ -run 'Test(BaselineProvenanceMatchesCanonicalCorpora|LuceneBaselineArtifactCoverage)')
+(cd server && go test ./provider -run 'Test(VertexSearchProjectionFixture|ProductionProjectionRelevanceGate)')
 ```
 
 Rules:
 
-- **Regenerate whenever a corpus fixture changes** (`testdata/{en,ja,mixed}.json`)
-  and commit the refreshed runs file in the same PR — the gate fails on runs
-  that rank a query the fixtures no longer define, but it cannot detect a
-  stale ranking for an *edited* document text.
+- **Regenerate whenever a corpus fixture or production search
+  projection/analyzer/scorer version changes** and commit the refreshed runs
+  file in the same PR. The artifact carries raw corpus SHA-256 values and
+  contract versions; a missing or stale artifact fails CI.
 - The engine config is deliberately stock (BM25 defaults, escaped plain-text
   queries, default-OR QueryParser, StandardAnalyzer / EnglishAnalyzer /
   CJKAnalyzer / kuromoji per corpus) — #886's definition of done is measured

--- a/testbed/lucene-baseline/src/main/java/dev/lantern/baseline/BaselineRunner.java
+++ b/testbed/lucene-baseline/src/main/java/dev/lantern/baseline/BaselineRunner.java
@@ -17,6 +17,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.queryparser.classic.MultiFieldQueryParser;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -31,20 +32,23 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
 /**
- * BaselineRunner replays the golden relevance corpora
- * (core/search/relevance/testdata/{en,ja,mixed}.json) through stock Lucene
- * BM25 and records, for every query, the top-K document ids in ranked order.
- * The Go side (core/search/relevance, TestLuceneBaselineComparison) computes
- * the metrics from these runs with the exact same metric functions Lantern is
- * scored with, so the two engines can never drift apart formula-wise.
+ * BaselineRunner indexes the provider-generated key/value fields for the
+ * golden relevance corpora through stock Lucene BM25 and records, for every
+ * query, the top-K document ids in ranked order. The Go side validates the
+ * artifact provenance and computes both engines' metrics with the exact same
+ * functions; the production comparison lives in server/provider so it can
+ * invoke the unexported vertex projection without breaking core's leaf
+ * dependency boundary.
  *
  * <p>Engine configuration is deliberately "what you get out of the box":
  * default BM25Similarity (k1 = 1.2, b = 0.75), the classic QueryParser with
@@ -69,31 +73,53 @@ public final class BaselineRunner {
 
         Map<String, List<AnalyzerSpec>> plan = new LinkedHashMap<>();
         plan.put("en", List.of(
-                new AnalyzerSpec("standard", "StandardAnalyzer", StandardAnalyzer::new),
-                new AnalyzerSpec("english", "EnglishAnalyzer", EnglishAnalyzer::new)));
+                new AnalyzerSpec("standard", "StandardAnalyzer", true, StandardAnalyzer::new),
+                new AnalyzerSpec("english", "EnglishAnalyzer", true, EnglishAnalyzer::new)));
         plan.put("ja", List.of(
-                new AnalyzerSpec("cjk", "CJKAnalyzer", CJKAnalyzer::new),
-                new AnalyzerSpec("kuromoji", "JapaneseAnalyzer", JapaneseAnalyzer::new)));
+                new AnalyzerSpec("cjk", "CJKAnalyzer", true, CJKAnalyzer::new),
+                new AnalyzerSpec("kuromoji", "JapaneseAnalyzer", false, JapaneseAnalyzer::new)));
         plan.put("mixed", List.of(
-                new AnalyzerSpec("cjk", "CJKAnalyzer", CJKAnalyzer::new),
-                new AnalyzerSpec("kuromoji", "JapaneseAnalyzer", JapaneseAnalyzer::new)));
+                new AnalyzerSpec("cjk", "CJKAnalyzer", true, CJKAnalyzer::new),
+                new AnalyzerSpec("kuromoji", "JapaneseAnalyzer", false, JapaneseAnalyzer::new)));
 
         Gson gson = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
+        Path projectedPath = dataDir.resolve("projected_fields.json");
+        ProjectedFixture projectedFixture = gson.fromJson(
+                Files.readString(projectedPath, StandardCharsets.UTF_8), ProjectedFixture.class);
 
         Map<String, Object> out = new LinkedHashMap<>();
         out.put("engine", "lucene-" + Version.LATEST);
         out.put("generated", Instant.now().toString());
+        Map<String, String> hashes = new LinkedHashMap<>();
+        for (String corpusName : plan.keySet()) {
+            Path path = dataDir.resolve(corpusName + ".json");
+            hashes.put("testdata/" + corpusName + ".json", sha256(path));
+        }
+        Map<String, Object> provenance = new LinkedHashMap<>();
+        provenance.put("corpus_sha256", hashes);
+        provenance.put("projected_fields_sha256", sha256(projectedPath));
+        provenance.put("fixture_format", "typed-string-vertex-fields-v1");
+        provenance.put("projection_version", "vertex-fields-v2");
+        provenance.put("analyzer_version", "script-aware-v2");
+        provenance.put("scorer_config", "field-weighted-bm25:k1=1.2,b=0.75,key=1.75,value=1,gram=0.2,proximity=0.3");
+        provenance.put("generation_command", "testbed/lucene-baseline/run.sh");
+        out.put("provenance", provenance);
         Map<String, Object> runs = new LinkedHashMap<>();
         out.put("runs", runs);
 
         for (Map.Entry<String, List<AnalyzerSpec>> entry : plan.entrySet()) {
             String corpusName = entry.getKey();
             Corpus corpus = readCorpus(gson, dataDir.resolve(corpusName + ".json"));
+            ProjectedCorpus projected = projectedFixture.corpora.get(corpusName);
+            if (projected == null) {
+                throw new IOException("projected fixture missing corpus: " + corpusName);
+            }
             for (AnalyzerSpec spec : entry.getValue()) {
-                Map<String, List<String>> results = rank(corpus, spec.analyzer.get());
+                Map<String, List<String>> results = rank(corpus, projected, spec.analyzer.get());
                 Map<String, Object> run = new LinkedHashMap<>();
                 run.put("corpus", corpusName);
                 run.put("analyzer", spec.label);
+                run.put("blocking", spec.blocking);
                 run.put("results", results);
                 runs.put(corpusName + "-" + spec.name, run);
                 System.err.printf("ran %s-%s: %d queries%n", corpusName, spec.name, results.size());
@@ -105,15 +131,18 @@ public final class BaselineRunner {
     }
 
     /** rank indexes the corpus and returns each query's top-K doc ids. */
-    private static Map<String, List<String>> rank(Corpus corpus, Analyzer analyzer) throws Exception {
+    private static Map<String, List<String>> rank(
+            Corpus corpus, ProjectedCorpus projected, Analyzer analyzer) throws Exception {
         try (Directory dir = new ByteBuffersDirectory()) {
             IndexWriterConfig cfg = new IndexWriterConfig(analyzer);
             cfg.setSimilarity(new BM25Similarity());
             try (IndexWriter writer = new IndexWriter(dir, cfg)) {
-                for (Doc d : corpus.docs) {
+                for (ProjectedDoc d : projected.docs) {
                     Document doc = new Document();
                     doc.add(new StringField("id", d.id, Field.Store.YES));
-                    doc.add(new TextField("text", d.text, Field.Store.NO));
+                    for (ProjectedField field : d.fields) {
+                        doc.add(new TextField(field.name, field.text, Field.Store.NO));
+                    }
                     writer.addDocument(doc);
                 }
             }
@@ -121,7 +150,9 @@ public final class BaselineRunner {
                 IndexSearcher searcher = new IndexSearcher(reader);
                 searcher.setSimilarity(new BM25Similarity());
                 StoredFields stored = reader.storedFields();
-                QueryParser parser = new QueryParser("text", analyzer);
+                Map<String, Float> boosts = Map.of("key", 1.75f, "value", 1.0f);
+                QueryParser parser = new MultiFieldQueryParser(
+                        new String[]{"key", "value"}, analyzer, boosts);
 
                 Map<String, List<String>> results = new LinkedHashMap<>();
                 for (QueryDef q : corpus.queries) {
@@ -141,6 +172,12 @@ public final class BaselineRunner {
         }
     }
 
+    private static String sha256(Path path) throws Exception {
+        byte[] raw = Files.readAllBytes(path);
+        return HexFormat.of().formatHex(
+                MessageDigest.getInstance("SHA-256").digest(raw));
+    }
+
     private static Corpus readCorpus(Gson gson, Path path) throws IOException {
         Corpus corpus = gson.fromJson(Files.readString(path, StandardCharsets.UTF_8), Corpus.class);
         if (corpus == null || corpus.docs == null || corpus.queries == null) {
@@ -153,11 +190,13 @@ public final class BaselineRunner {
     private static final class AnalyzerSpec {
         final String name;
         final String label;
+        final boolean blocking;
         final Supplier<Analyzer> analyzer;
 
-        AnalyzerSpec(String name, String label, Supplier<Analyzer> analyzer) {
+        AnalyzerSpec(String name, String label, boolean blocking, Supplier<Analyzer> analyzer) {
             this.name = name;
             this.label = label;
+            this.blocking = blocking;
             this.analyzer = analyzer;
         }
     }
@@ -176,6 +215,24 @@ public final class BaselineRunner {
 
     private static final class QueryDef {
         String id;
+        String text;
+    }
+
+    private static final class ProjectedFixture {
+        Map<String, ProjectedCorpus> corpora;
+    }
+
+    private static final class ProjectedCorpus {
+        List<ProjectedDoc> docs;
+    }
+
+    private static final class ProjectedDoc {
+        String id;
+        List<ProjectedField> fields;
+    }
+
+    private static final class ProjectedField {
+        String name;
         String text;
     }
 

--- a/testdata/search/conformance.json
+++ b/testdata/search/conformance.json
@@ -1,0 +1,41 @@
+{
+  "version": "search-conformance-v1",
+  "vertices": [
+    {"key": "search-conformance/order/a", "value": "stabletoken"},
+    {"key": "search-conformance/order/b", "value": "stabletoken"},
+    {"key": "search-conformance/boolean/all", "value": "alpha bravo"},
+    {"key": "search-conformance/boolean/alpha", "value": "alpha charlie"},
+    {"key": "search-conformance/phrase/exact", "value": "delta echo"},
+    {"key": "search-conformance/phrase/reverse", "value": "echo delta"},
+    {"key": "search-conformance/fuzzy/doc", "value": "kubernetes"},
+    {"key": "search-conformance/prefix/doc", "value": "lantern"},
+    {"key": "search-conformance/scope/in", "value": "scopeterm"},
+    {"key": "outside-scope", "value": "scopeterm"}
+  ],
+  "queries": [
+    {"name": "server-default-order", "query": "stabletoken", "options": {"prefix": "search-conformance/order/"}, "want_keys": ["search-conformance/order/a", "search-conformance/order/b"]},
+    {"name": "explicit-any-order", "query": "stabletoken", "options": {"prefix": "search-conformance/order/", "match_mode": "any"}, "want_keys": ["search-conformance/order/a", "search-conformance/order/b"]},
+    {"name": "all", "query": "alpha bravo", "options": {"prefix": "search-conformance/boolean/", "match_mode": "all"}, "want_keys": ["search-conformance/boolean/all"]},
+    {"name": "min-should", "query": "delta echo zulu", "options": {"prefix": "search-conformance/phrase/", "match_mode": "min-should", "min_should_match": 2}, "want_keys": ["search-conformance/phrase/exact", "search-conformance/phrase/reverse"]},
+    {"name": "phrase", "query": "delta echo", "options": {"prefix": "search-conformance/phrase/", "phrase": true}, "want_keys": ["search-conformance/phrase/exact"]},
+    {"name": "fuzzy", "query": "kubernets", "options": {"prefix": "search-conformance/fuzzy/", "fuzziness": 1}, "want_keys": ["search-conformance/fuzzy/doc"]},
+    {"name": "prefix-terms", "query": "lant", "options": {"prefix": "search-conformance/prefix/", "prefix_terms": true}, "want_keys": ["search-conformance/prefix/doc"]},
+    {"name": "prefix-scope", "query": "scopeterm", "options": {"prefix": "search-conformance/scope/"}, "want_keys": ["search-conformance/scope/in"]},
+    {"name": "limit", "query": "stabletoken", "options": {"prefix": "search-conformance/order/", "limit": 1}, "want_keys": ["search-conformance/order/a"]},
+    {"name": "empty", "query": "", "options": {}, "want_keys": []}
+  ],
+  "invalid": [
+    {"name": "min-should-without-mode", "query": "alpha", "options": {"min_should_match": 1}},
+    {"name": "min-should-with-any", "query": "alpha", "options": {"match_mode": "any", "min_should_match": 1}},
+    {"name": "phrase-with-all", "query": "alpha bravo", "options": {"match_mode": "all", "phrase": true}},
+    {"name": "phrase-with-fuzzy", "query": "alpha bravo", "options": {"phrase": true, "fuzziness": 1}},
+    {"name": "phrase-with-prefix-terms", "query": "alpha bravo", "options": {"phrase": true, "prefix_terms": true}},
+    {"name": "fuzziness-too-high", "query": "alpha", "options": {"fuzziness": 3}}
+  ],
+  "cancellation": {"name": "pre-canceled", "query": "stabletoken", "options": {"prefix": "search-conformance/order/"}},
+  "typed_errors": [
+    {"name": "disabled", "environment": "disabled", "query": "alpha", "options": {}, "reason": "search-disabled"},
+    {"name": "positions-disabled", "environment": "positions-disabled", "query": "alpha bravo", "options": {"phrase": true}, "reason": "positions-disabled"},
+    {"name": "query-budget", "environment": "query-budget", "query": "12345", "options": {}, "reason": "query_bytes"}
+  ]
+}

--- a/tests/integration/search_vertices_test.go
+++ b/tests/integration/search_vertices_test.go
@@ -3,10 +3,12 @@ package integration_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
 	"math/rand"
+	"os"
 	"slices"
 	"sort"
 	"strings"
@@ -21,6 +23,7 @@ import (
 
 	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/search"
+	"github.com/anaregdesign/lantern/core/search/relevance"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
 	client "github.com/anaregdesign/lantern/sdks/go"
@@ -28,18 +31,112 @@ import (
 	"github.com/anaregdesign/lantern/server/service"
 )
 
-// searchVertexDocument mirrors the production provider projection
-// (server/provider/search.go) closely enough for the wire test: it folds
-// the key together with the string value so a query matches either. The
-// integration suite cannot import the unexported provider helper, and the
-// exact value-type rendering is covered by the provider unit test — here we
-// only need a live index behind the RPC.
-func searchVertexDocument(key string, v *pb.Vertex) search.Document {
-	fields := search.Fields{{ID: search.FieldKey, Text: key}}
-	if v != nil && v.GetString_() != "" {
-		fields = append(fields, search.DocumentField{ID: search.FieldValue, Text: v.GetString_()})
+type searchConformanceManifest struct {
+	Version      string                    `json:"version"`
+	Vertices     []searchConformanceVertex `json:"vertices"`
+	Queries      []searchConformanceCase   `json:"queries"`
+	Invalid      []searchConformanceCase   `json:"invalid"`
+	Cancellation searchConformanceCase     `json:"cancellation"`
+	TypedErrors  []searchConformanceError  `json:"typed_errors"`
+}
+
+type searchConformanceVertex struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type searchConformanceCase struct {
+	Name     string                   `json:"name"`
+	Query    string                   `json:"query"`
+	Options  searchConformanceOptions `json:"options"`
+	WantKeys []string                 `json:"want_keys"`
+}
+
+type searchConformanceOptions struct {
+	Limit          uint32 `json:"limit"`
+	Prefix         string `json:"prefix"`
+	MatchMode      string `json:"match_mode"`
+	MinShouldMatch uint32 `json:"min_should_match"`
+	Phrase         bool   `json:"phrase"`
+	Fuzziness      uint32 `json:"fuzziness"`
+	PrefixTerms    bool   `json:"prefix_terms"`
+}
+
+type searchConformanceError struct {
+	Name        string                   `json:"name"`
+	Environment string                   `json:"environment"`
+	Query       string                   `json:"query"`
+	Options     searchConformanceOptions `json:"options"`
+	Reason      string                   `json:"reason"`
+}
+
+func loadSearchConformanceManifest(t *testing.T) searchConformanceManifest {
+	t.Helper()
+	raw, err := os.ReadFile("../../testdata/search/conformance.json")
+	if err != nil {
+		t.Fatal(err)
 	}
-	return fields
+	var manifest searchConformanceManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Version != "search-conformance-v1" || len(manifest.Vertices) == 0 || len(manifest.Queries) == 0 || len(manifest.Invalid) == 0 || manifest.Cancellation.Name == "" || len(manifest.TypedErrors) == 0 {
+		t.Fatalf("invalid search conformance manifest: %+v", manifest)
+	}
+	return manifest
+}
+
+func conformancePBOptions(options searchConformanceOptions) *pb.SearchOptions {
+	mode := pb.MatchMode_MATCH_MODE_UNSPECIFIED
+	switch options.MatchMode {
+	case "any":
+		mode = pb.MatchMode_MATCH_MODE_ANY
+	case "all":
+		mode = pb.MatchMode_MATCH_MODE_ALL
+	case "min-should":
+		mode = pb.MatchMode_MATCH_MODE_MIN_SHOULD
+	}
+	if mode == pb.MatchMode_MATCH_MODE_UNSPECIFIED && options.MinShouldMatch == 0 && !options.Phrase && options.Fuzziness == 0 && !options.PrefixTerms {
+		return nil
+	}
+	return &pb.SearchOptions{MatchMode: mode, MinShouldMatch: options.MinShouldMatch, Phrase: options.Phrase, Fuzziness: options.Fuzziness, PrefixTerms: options.PrefixTerms}
+}
+
+func conformanceSDKOptions(options searchConformanceOptions) []client.SearchOption {
+	var out []client.SearchOption
+	if options.Limit != 0 {
+		out = append(out, client.WithSearchLimit(options.Limit))
+	}
+	if options.Prefix != "" {
+		out = append(out, client.WithSearchPrefix(options.Prefix))
+	}
+	switch options.MatchMode {
+	case "any":
+		out = append(out, client.WithMatchMode(client.MatchAny))
+	case "all":
+		out = append(out, client.WithMatchMode(client.MatchAll))
+	case "min-should":
+		out = append(out, client.WithMatchMode(client.MatchMinShould))
+	}
+	if options.MinShouldMatch != 0 {
+		out = append(out, client.WithMinShouldMatch(options.MinShouldMatch))
+	}
+	if options.Phrase {
+		out = append(out, client.WithPhrase())
+	}
+	if options.Fuzziness != 0 {
+		out = append(out, client.WithFuzziness(options.Fuzziness))
+	}
+	if options.PrefixTerms {
+		out = append(out, client.WithPrefixTerms())
+	}
+	return out
+}
+
+func newProductionSearchCache(ttl time.Duration, enabled, positions bool, limits search.SearchAnalysisLimits) *graphcache.GraphCache[string, *pb.Vertex] {
+	return provider.NewGraphCache(provider.CacheConfig{TTL: ttl}, provider.SearchConfig{
+		Enabled: enabled, Positions: positions, AnalysisLimits: limits,
+	})
 }
 
 func wireSearchErrorReason(t *testing.T, err error) pb.SearchErrorReason {
@@ -82,11 +179,7 @@ func newSearchRawClient(t *testing.T, enabled bool) graphv1connect.LanternServic
 
 func newSearchRawClientWithLimits(t *testing.T, limits service.SearchLimits) graphv1connect.LanternServiceClient {
 	t.Helper()
-	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
-	cache.EnablePrefixIndex(func(k string) string { return k })
-	if limits.Enabled {
-		cache.EnableSearchIndex(searchVertexDocument, strings.Compare, graphcache.WithSearchAnalysisLimits(limits.AnalysisLimits))
-	}
+	cache := newProductionSearchCache(time.Minute, limits.Enabled, limits.PositionsEnabled, limits.AnalysisLimits)
 	svc := service.NewLanternService(cache).WithSearchLimits(limits)
 	srv := newConnectTestServer(t, svc, nil)
 	return graphv1connect.NewLanternServiceClient(h2cClient(), srv.url)
@@ -133,9 +226,7 @@ func TestSearchIndexRestoreConvergenceOverWire(t *testing.T) {
 		MaxLiveTerms: 20, MaxLivePostings: 20, MaxPositionEntries: 20,
 		CompactionRatio: 2, CompactionMinRetired: 1,
 	}
-	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
-	cache.EnablePrefixIndex(func(key string) string { return key })
-	cache.EnableSearchIndex(searchVertexDocument, strings.Compare, graphcache.WithSearchAnalysisLimits(analysis))
+	cache := newProductionSearchCache(time.Minute, true, true, analysis)
 	svc := service.NewLanternService(cache).WithSearchLimits(service.SearchLimits{Enabled: true, PositionsEnabled: true, DefaultLimit: 10, MaxLimit: 100, AnalysisLimits: analysis})
 	exp := timestamppb.New(time.Now().Add(time.Hour))
 	if _, err := svc.RestoreVertices(context.Background(), &pb.PutVerticesRequest{Vertices: []*pb.Vertex{{Key: "legacy", Value: &pb.Vertex_String_{String_: "oversized"}, Expiration: exp}}}); err != nil {
@@ -466,9 +557,7 @@ func TestSearchVertices_ExpirationOverWire(t *testing.T) {
 }
 
 func TestSearchVertices_CancellationAndAdmissionOverWire(t *testing.T) {
-	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
-	cache.EnablePrefixIndex(func(k string) string { return k })
-	cache.EnableSearchIndex(searchVertexDocument, strings.Compare)
+	cache := newProductionSearchCache(time.Minute, true, true, search.SearchAnalysisLimits{})
 	expiration := time.Now().Add(time.Hour)
 	items := make([]graphcache.VertexItem[string, *pb.Vertex], 15_000)
 	for i := range items {
@@ -560,9 +649,7 @@ func TestSearchVertices_CancellationAndAdmissionOverWire(t *testing.T) {
 }
 
 func TestSearchVertices_PrefixCandidatePushdownOverRealH2C(t *testing.T) {
-	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Hour)
-	cache.EnablePrefixIndex(func(key string) string { return key })
-	cache.EnableSearchIndex(searchVertexDocument, strings.Compare)
+	cache := newProductionSearchCache(time.Hour, true, true, search.SearchAnalysisLimits{})
 	expiration := time.Now().Add(time.Hour)
 	items := make([]graphcache.VertexItem[string, *pb.Vertex], 0, 2010)
 	for i := 0; i < 2000; i++ {
@@ -687,15 +774,215 @@ func TestSearchVertices_ProductionStructuredFieldsOverRealH2C(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := status.Msg.GetSearch().GetProjectionVersion(); got != "vertex-fields-v2" {
+	if got := status.Msg.GetSearch().GetProjectionVersion(); got != relevance.BaselineProjectionVersion {
 		t.Fatalf("projection version = %q", got)
 	}
-	if got := status.Msg.GetSearch().GetAnalyzerVersion(); got != "script-aware-v2" {
+	if got := status.Msg.GetSearch().GetAnalyzerVersion(); got != relevance.BaselineAnalyzerVersion {
 		t.Fatalf("analyzer version = %q", got)
 	}
 	if got := status.Msg.GetSearch().GetConfigFingerprint(); len(got) != 64 {
 		t.Fatalf("config fingerprint = %q, want 64 hex chars", got)
 	}
+}
+
+func TestSearchVertices_SharedConformanceManifest(t *testing.T) {
+	manifest := loadSearchConformanceManifest(t)
+	newClients := func(searchConfig provider.SearchConfig, limits service.SearchLimits) (graphv1connect.LanternServiceClient, *client.Lantern) {
+		cache := provider.NewGraphCache(provider.CacheConfig{TTL: time.Hour}, searchConfig)
+		svc := service.NewLanternService(cache).WithSearchLimits(limits)
+		srv := newConnectTestServer(t, svc, nil)
+		return graphv1connect.NewLanternServiceClient(h2cClient(), srv.url), newConnectClientFor(t, srv.url)
+	}
+	limits := service.SearchLimits{Enabled: true, PositionsEnabled: true, DefaultLimit: 100, MaxLimit: 1000}
+	raw, sdk := newClients(provider.SearchConfig{Enabled: true, Positions: true}, limits)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	expiration := timestamppb.New(time.Now().Add(time.Hour))
+	vertices := make([]*pb.Vertex, len(manifest.Vertices))
+	for i, fixture := range manifest.Vertices {
+		vertices[i] = &pb.Vertex{Key: fixture.Key, Value: &pb.Vertex_String_{String_: fixture.Value}, Expiration: expiration}
+	}
+	if _, err := raw.PutVertices(ctx, connect.NewRequest(&pb.PutVerticesRequest{Vertices: vertices})); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range manifest.Queries {
+		t.Run(tc.Name, func(t *testing.T) {
+			response, err := raw.SearchVertices(ctx, connect.NewRequest(&pb.SearchVerticesRequest{
+				Query: tc.Query, Limit: tc.Options.Limit, Prefix: tc.Options.Prefix, Options: conformancePBOptions(tc.Options),
+			}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			rawKeys := make([]string, len(response.Msg.GetHits()))
+			for i, hit := range response.Msg.GetHits() {
+				rawKeys[i] = hit.GetKey()
+			}
+			if !slices.Equal(rawKeys, tc.WantKeys) {
+				t.Fatalf("raw keys = %v, want %v", rawKeys, tc.WantKeys)
+			}
+			sdkHits, err := sdk.SearchVertices(ctx, tc.Query, conformanceSDKOptions(tc.Options)...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sdkKeys := make([]string, len(sdkHits))
+			for i, hit := range sdkHits {
+				sdkKeys[i] = hit.Key
+				if math.Float64bits(hit.Score) != math.Float64bits(response.Msg.GetHits()[i].GetScore()) {
+					t.Fatalf("score bits at %d differ: raw=%v SDK=%v", i, response.Msg.GetHits()[i].GetScore(), hit.Score)
+				}
+			}
+			if !slices.Equal(sdkKeys, tc.WantKeys) {
+				t.Fatalf("SDK keys = %v, want %v", sdkKeys, tc.WantKeys)
+			}
+		})
+	}
+	for _, tc := range manifest.Invalid {
+		t.Run("invalid/"+tc.Name, func(t *testing.T) {
+			_, rawErr := raw.SearchVertices(ctx, connect.NewRequest(&pb.SearchVerticesRequest{
+				Query: tc.Query, Limit: tc.Options.Limit, Prefix: tc.Options.Prefix, Options: conformancePBOptions(tc.Options),
+			}))
+			if connect.CodeOf(rawErr) != connect.CodeInvalidArgument {
+				t.Fatalf("raw error = %v, want InvalidArgument", rawErr)
+			}
+			_, sdkErr := sdk.SearchVertices(ctx, tc.Query, conformanceSDKOptions(tc.Options)...)
+			if !errors.Is(sdkErr, client.ErrInvalidArgument) {
+				t.Fatalf("SDK error = %v, want ErrInvalidArgument", sdkErr)
+			}
+		})
+	}
+	t.Run("cancellation/"+manifest.Cancellation.Name, func(t *testing.T) {
+		canceled, stop := context.WithCancel(context.Background())
+		stop()
+		tc := manifest.Cancellation
+		_, rawErr := raw.SearchVertices(canceled, connect.NewRequest(&pb.SearchVerticesRequest{
+			Query: tc.Query, Limit: tc.Options.Limit, Prefix: tc.Options.Prefix, Options: conformancePBOptions(tc.Options),
+		}))
+		if connect.CodeOf(rawErr) != connect.CodeCanceled {
+			t.Fatalf("raw cancellation error = %v, want Canceled", rawErr)
+		}
+		_, sdkErr := sdk.SearchVertices(canceled, tc.Query, conformanceSDKOptions(tc.Options)...)
+		if connect.CodeOf(sdkErr) != connect.CodeCanceled {
+			t.Fatalf("SDK cancellation error = %v, want Canceled", sdkErr)
+		}
+	})
+
+	for _, tc := range manifest.TypedErrors {
+		t.Run("typed/"+tc.Name, func(t *testing.T) {
+			searchConfig := provider.SearchConfig{Enabled: true, Positions: true}
+			errorLimits := limits
+			switch tc.Environment {
+			case "disabled":
+				searchConfig.Enabled = false
+				errorLimits.Enabled = false
+			case "positions-disabled":
+				searchConfig.Positions = false
+				errorLimits.PositionsEnabled = false
+			case "query-budget":
+				errorLimits.MaxQueryBytes = 4
+			}
+			_, errorSDK := newClients(searchConfig, errorLimits)
+			_, err := errorSDK.SearchVertices(ctx, tc.Query, conformanceSDKOptions(tc.Options)...)
+			switch tc.Reason {
+			case "search-disabled":
+				if !errors.Is(err, client.ErrSearchDisabled) {
+					t.Fatalf("error = %v, want search disabled", err)
+				}
+			case "positions-disabled":
+				if !errors.Is(err, client.ErrSearchPositionsDisabled) {
+					t.Fatalf("error = %v, want positions disabled", err)
+				}
+			case "query_bytes":
+				if !errors.Is(err, client.ErrSearchWorkBudget) || client.SearchFailureWorkKind(err) != "query_bytes" {
+					t.Fatalf("error = %v, want query_bytes budget", err)
+				}
+			}
+		})
+	}
+}
+
+func TestSearchVertices_LifecycleConvergenceOverProductionComposition(t *testing.T) {
+	cache := newProductionSearchCache(time.Minute, true, true, search.SearchAnalysisLimits{})
+	svc := service.NewLanternService(cache).WithSearchLimits(service.SearchLimits{
+		Enabled: true, PositionsEnabled: true, DefaultLimit: 100, MaxLimit: 1000,
+	})
+	srv := newConnectTestServer(t, svc, nil)
+	raw := graphv1connect.NewLanternServiceClient(h2cClient(), srv.url)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	expiration := timestamppb.New(time.Now().Add(time.Hour))
+
+	searchKeys := func(query string) []string {
+		t.Helper()
+		response, err := raw.SearchVertices(ctx, connect.NewRequest(&pb.SearchVerticesRequest{
+			Query: query, Limit: 100, Options: &pb.SearchOptions{MatchMode: pb.MatchMode_MATCH_MODE_ALL},
+		}))
+		if err != nil {
+			t.Fatalf("SearchVertices(%q): %v", query, err)
+		}
+		keys := make([]string, len(response.Msg.GetHits()))
+		for i, hit := range response.Msg.GetHits() {
+			keys[i] = hit.GetKey()
+		}
+		return keys
+	}
+	assertKeys := func(query string, want ...string) {
+		t.Helper()
+		if got := searchKeys(query); !slices.Equal(got, want) {
+			t.Fatalf("SearchVertices(%q) keys = %v, want %v", query, got, want)
+		}
+	}
+
+	vertices := []*pb.Vertex{
+		{Key: "lifecycle/overwrite", Value: &pb.Vertex_String_{String_: "oldlifecycletoken"}, Expiration: expiration},
+		{Key: "lifecycle/delete-one", Value: &pb.Vertex_String_{String_: "singledeletetoken"}, Expiration: expiration},
+		{Key: "lifecycle/delete-batch/a", Value: &pb.Vertex_String_{String_: "batchdeletetoken"}, Expiration: expiration},
+		{Key: "lifecycle/delete-batch/b", Value: &pb.Vertex_String_{String_: "batchdeletetoken"}, Expiration: expiration},
+		{Key: "lifecycle/delete-prefix/a", Value: &pb.Vertex_String_{String_: "prefixdeletetoken"}, Expiration: expiration},
+		{Key: "lifecycle/delete-prefix/b", Value: &pb.Vertex_String_{String_: "prefixdeletetoken"}, Expiration: expiration},
+	}
+	if _, err := raw.PutVertices(ctx, connect.NewRequest(&pb.PutVerticesRequest{Vertices: vertices})); err != nil {
+		t.Fatal(err)
+	}
+	assertKeys("oldlifecycletoken", "lifecycle/overwrite")
+	if _, err := raw.PutVertex(ctx, connect.NewRequest(&pb.PutVertexRequest{Vertex: &pb.Vertex{
+		Key: "lifecycle/overwrite", Value: &pb.Vertex_String_{String_: "newlifecycletoken"}, Expiration: expiration,
+	}})); err != nil {
+		t.Fatal(err)
+	}
+	assertKeys("oldlifecycletoken")
+	assertKeys("newlifecycletoken", "lifecycle/overwrite")
+
+	if _, err := raw.DeleteVertex(ctx, connect.NewRequest(&pb.DeleteVertexRequest{Key: "lifecycle/delete-one"})); err != nil {
+		t.Fatal(err)
+	}
+	assertKeys("singledeletetoken")
+	if _, err := raw.DeleteVertices(ctx, connect.NewRequest(&pb.DeleteVerticesRequest{Keys: []string{
+		"lifecycle/delete-batch/a", "lifecycle/delete-batch/b",
+	}})); err != nil {
+		t.Fatal(err)
+	}
+	assertKeys("batchdeletetoken")
+	deleted, err := raw.DeleteVerticesByPrefix(ctx, connect.NewRequest(&pb.DeleteVerticesByPrefixRequest{Prefix: "lifecycle/delete-prefix/"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted.Msg.GetDeleted() != 2 {
+		t.Fatalf("DeleteVerticesByPrefix deleted = %d, want 2", deleted.Msg.GetDeleted())
+	}
+	assertKeys("prefixdeletetoken")
+
+	origin := []byte("search-replica01")
+	replicated := &pb.Vertex{
+		Key: "lifecycle/replicated", Value: &pb.Vertex_String_{String_: "replicatedapplytoken"}, Expiration: expiration,
+	}
+	if err := svc.ApplyMutation(ctx, &pb.Mutation{
+		Seq: 1, Origin: origin,
+		Hlc: &pb.HLCTimestamp{WallNs: time.Now().UnixNano(), NodeId: origin},
+		Op:  &pb.MutationOp{Op: &pb.MutationOp_PutVertex{PutVertex: &pb.PutVertexRequest{Vertex: replicated}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertKeys("replicatedapplytoken", "lifecycle/replicated")
 }
 
 func searchHitsContain(hits []client.SearchHit, key string) bool {
@@ -713,11 +1000,7 @@ func searchHitsContain(hits []client.SearchHit, key string) bool {
 // white-box request/response tests.
 func newSearchSDKClient(t *testing.T, enabled bool) *client.Lantern {
 	t.Helper()
-	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
-	cache.EnablePrefixIndex(func(k string) string { return k })
-	if enabled {
-		cache.EnableSearchIndex(searchVertexDocument, strings.Compare)
-	}
+	cache := newProductionSearchCache(time.Minute, enabled, enabled, search.SearchAnalysisLimits{})
 	svc := service.NewLanternService(cache).WithSearchLimits(service.SearchLimits{
 		Enabled:          enabled,
 		PositionsEnabled: enabled,
@@ -962,9 +1245,7 @@ func TestSearchVertices_SDKForwarder(t *testing.T) {
 }
 
 func TestSearchVertices_SDKExecutionError(t *testing.T) {
-	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
-	cache.EnablePrefixIndex(func(k string) string { return k })
-	cache.EnableSearchIndex(searchVertexDocument, strings.Compare)
+	cache := newProductionSearchCache(time.Minute, true, true, search.SearchAnalysisLimits{})
 	svc := service.NewLanternService(cache).WithSearchLimits(service.SearchLimits{
 		Enabled:          true,
 		PositionsEnabled: true,
@@ -1271,9 +1552,7 @@ func TestSearchVertices_DeterministicAcrossHistories(t *testing.T) {
 // reinterpret phrase=true as an unordered AND query.
 func TestSearchVertices_PositionsOff(t *testing.T) {
 	// Build a search-enabled service whose cache index tracks no positions.
-	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
-	cache.EnablePrefixIndex(func(k string) string { return k })
-	cache.EnableSearchIndex(searchVertexDocument, strings.Compare, graphcache.WithoutSearchPositions())
+	cache := newProductionSearchCache(time.Minute, true, false, search.SearchAnalysisLimits{})
 	svc := service.NewLanternService(cache).WithSearchLimits(service.SearchLimits{
 		Enabled:          true,
 		PositionsEnabled: false,


### PR DESCRIPTION
## Summary
- bind Lucene rankings to corpus, exact provider-generated projection, analyzer, scorer, engine, and analyzer plan provenance
- replace the integration-only projector with production provider composition and cover lifecycle convergence over real Connect/h2c
- run one shared search manifest through raw wire, Go, Node, and Dart, including ordering, all options, invalid combinations, cancellation, and typed failures
- trigger Node and Dart real-wire conformance for server/core search changes

## Validation
- go test ./... in root, pb, core, sdks/go, server, and mcp modules
- Node lint, format, typecheck, 168 tests with four real server variants, and build
- Dart format, analyze, package tests, 17 real-wire tests, and Flutter example analyze/test
- Node and Dart generated-stub drift checks
- Lucene runner javac compile and committed provenance/projection gates

Closes #1066