### PR TITLE
test(ha-search): gate derived-index convergence across recovery paths

### DIFF
--- a/core/graphcache/search.go
+++ b/core/graphcache/search.go
@@ -129,6 +129,32 @@ func (c *GraphCache[S, T]) RebuildSearchIndex() error {
 	return c.rebuildSearchIndexLocked()
 }
 
+// BeginSearchIndexRecovery makes search fail closed before a bulk recovery
+// path starts mutating the graph. Replication snapshot and backup restore use
+// this boundary so a partially replayed derived index is never advertised as
+// healthy or queried for partial results.
+func (c *GraphCache[S, T]) BeginSearchIndexRecovery() {
+	c.searchCommitMu.Lock()
+	defer c.searchCommitMu.Unlock()
+	c.mu.RLock()
+	index := c.searchIndex
+	c.mu.RUnlock()
+	if index != nil {
+		index.MarkIncomplete()
+	}
+}
+
+// CompleteSearchIndexRecovery rebuilds the complete derived index from the
+// live graph and marks it healthy only after the atomic replacement succeeds.
+// A limit error leaves the graph intact and the index incomplete.
+func (c *GraphCache[S, T]) CompleteSearchIndexRecovery() error {
+	c.searchCommitMu.Lock()
+	defer c.searchCommitMu.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.rebuildSearchIndexLocked()
+}
+
 func (c *GraphCache[S, T]) rebuildSearchIndexLocked() error {
 	if c.searchIndex == nil {
 		return nil

--- a/core/graphcache/search_test.go
+++ b/core/graphcache/search_test.go
@@ -103,6 +103,33 @@ func TestGraphCacheSearchAnalysisLimits(t *testing.T) {
 			t.Fatalf("automatic bounded rebuild health = %q", got)
 		}
 	})
+
+	t.Run("bulk recovery stays incomplete until exact rebuild", func(t *testing.T) {
+		c := newCache()
+		expiration := time.Now().Add(time.Minute)
+		if err := c.PutVertexWithExpiration("before", "alpha", expiration); err != nil {
+			t.Fatal(err)
+		}
+		c.BeginSearchIndexRecovery()
+		if got := c.SearchIndexMemoryStats().Health; got != search.IndexIncomplete {
+			t.Fatalf("health during recovery = %q", got)
+		}
+		if _, _, err := c.SearchVerticesMatchContext(context.Background(), "alpha", 10, "", search.MatchOptions{}, false, search.Budget{}); !errors.Is(err, search.ErrIndexIncomplete) {
+			t.Fatalf("search during recovery err = %v", err)
+		}
+		if applied := c.PutVertexWithExpirationHLC("during", "beta", expiration, hlc.Timestamp{WallNs: 2}); !applied {
+			t.Fatal("recovery write was rejected")
+		}
+		if err := c.CompleteSearchIndexRecovery(); err != nil {
+			t.Fatalf("CompleteSearchIndexRecovery: %v", err)
+		}
+		if got := c.SearchIndexMemoryStats().Health; got != search.IndexHealthy {
+			t.Fatalf("health after recovery = %q", got)
+		}
+		if got := keys(c.SearchVertices("alpha beta", 10, "")); !reflect.DeepEqual(got, []string{"before", "during"}) {
+			t.Fatalf("rebuilt results = %v", got)
+		}
+	})
 }
 
 // keys returns just the IDs of a ranked result set, in rank order, for terse

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -33,6 +33,14 @@ leaderless-replication invariant.
 - **Restore** replays the newest valid dump through the normal write path, so
   absolute expirations and HLC ordering are honoured; an entry whose TTL has
   already elapsed since the dump is **not** resurrected.
+- **Derived search recovery** marks the index `INCOMPLETE` before replay,
+  restores the live graph, then rebuilds the exact index before it can become
+  `HEALTHY`. A bounded rebuild failure leaves graph restore intact but search
+  fails closed as `INCOMPLETE`; `DISABLED` remains distinct.
+- **Restore accounting** reports actual `PutVerticesResponse.written` /
+  `PutEdgesResponse.written`, not input frame counts. Consequently
+  `lantern_restore_vertices`, `lantern_restore_edges`, and restore logs exclude
+  born-expired or otherwise skipped rows.
 - **Per-instance files.** Each writer owns files named
   `lantern-backup-<instance>-<nanos>.lbk` (`instance` defaults to the
   hostname). Writes are atomic (temp file + `rename`); a half-written file is

--- a/docs/ha-runbook.md
+++ b/docs/ha-runbook.md
@@ -269,6 +269,8 @@ exact Prometheus series.
 | `lantern_replication_dropped_total{peer,reason}` | counter | Replication frames or peer interactions dropped. `reason` is `self_echo` / `subscribe_failed` / `snapshot_failed` / `dial_failed` / `peerstatus_failed` / `catchup_failed` / `clean` / `ctx_cancel`. A persistent non-zero rate (excluding `self_echo` / `clean`) signals an unreachable or stuck peer. |
 | `lantern_anti_entropy_cycles_total` | counter | Anti-entropy ticks. Should advance at `LANTERN_ANTI_ENTROPY_INTERVAL_MS` cadence. |
 | `lantern_anti_entropy_gaps_found_total{peer,origin}` | counter | Non-zero = real divergence detected and being repaired. Spiking after a partition heal = expected. Persistently incrementing in steady state = open a bug. |
+| `lantern_search_config_match{peer}` | gauge | `1` means the peer's search capability fingerprint exactly matches this pod; `0` means missing/mismatched and keeps readiness `NOT_SERVING`. |
+| `lantern_search_config_mismatch_total{peer}` | counter | Pump/anti-entropy observations of missing or mismatched search config. A rising counter means the topology is still heterogeneous. |
 | `lantern_mutation_log_entries_total` | counter | Total mutations ever logged on this pod. |
 | `lantern_mutation_log_capacity` | gauge | Ring buffer capacity. If sustained `rate(mutation_log_entries) × subscribe_lag_seconds > capacity`, slow peers will fall off and re-snapshot. |
 | `lantern_subscribe_active_streams` | gauge | Inbound subscribers (peers + external CDC). Drop = peer disconnect or CDC consumer crash. |
@@ -406,6 +408,12 @@ Operational notes:
 Lantern is **AP**. Both sides of a partition keep accepting reads and
 writes. See RFC §[10](replication.md#10-partition--split-brain-analysis)
 for the full analysis. The operational summary:
+
+`SearchVertices` is also available on both sides, but it is explicitly
+local/eventual: document membership, BM25 statistics, scores, and top-k order
+can differ until heal. Static SDK failover may therefore change a search
+response. Route user traffic only to ready replicas and wait for lag plus
+search-config signals to converge before comparing exact results.
 
 | Mutation type | Partition-time behaviour | Post-heal |
 |---|---|---|
@@ -647,10 +655,13 @@ A short checklist to walk before opening an incident:
       `lantern_hlc_skew_clamped_total` if/when present, or just keep
       NTP healthy.
 - [ ] **Heterogeneous search configuration.** Keep every `LANTERN_SEARCH_*`
-      value identical across replicas. Query `GetServerStatus` directly on
-      each pod and compare `search.config_fingerprint`; any mismatch means
-      clients can observe different search results or capabilities depending
-      on which replica serves the call. In particular, a replica with
+      value identical across replicas. Pump and anti-entropy compare
+      `PeerStatus.search_config_fingerprint` automatically; a mismatch sets
+      `lantern_search_config_match{peer}=0`, increments
+      `lantern_search_config_mismatch_total{peer}`, logs both fingerprints,
+      and keeps readiness `NOT_SERVING` while graph replication continues.
+      `GetServerStatus.search.config_fingerprint` remains the direct per-pod
+      diagnostic. In particular, a replica with
       `LANTERN_SEARCH_POSITIONS=false` rejects `phrase=true` with
       `SEARCH_POSITIONS_DISABLED` while a positions-enabled replica executes
       the phrase query.
@@ -671,6 +682,7 @@ operator actions.
 | NTP skew > 500 ms | `lantern_hlc_skew_clamped_total` (planned — #180/#182; until then watch NTP) | Fix NTP. Convergence preserved, but the drifted peer's stamps land behind real wall time. |
 | Network partition < tombstone TTL | `replication_lag_seq` spike; `anti_entropy_gaps_found_total` non-zero after heal | Auto-converges. No action. |
 | Network partition > tombstone TTL | Same signals + possible resurrection | Force re-snapshot from the side you trust ([§9.1](#91-force-a-re-snapshot)). Consider extending tombstone TTL. |
+| Search config mismatch | `search_config_match{peer}=0`, readiness 503 | Make search-affecting env identical; graph replication is intentionally still active. |
 
 ---
 

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -43,12 +43,16 @@ is required for either reads or writes.
    to seed its in-memory state. `SnapshotHeader.cutoff_seq_per_origin`
    carries the per-origin watermark the snapshot was materialised against;
    the bootstrapping peer resumes by opening `Subscribe(from_seq_per_origin
-   = {origin: seq + 1 for each (origin, seq) in cutoff_seq_per_origin})`
-   so the snapshot and the live tail stitch without gap or overlap. See
-   #415 (Reading B) and the wire types in §8.2/§8.3.
+   = {origin: seq + 1 for each (origin, seq) in cutoff_seq_per_origin},
+   from_local_seq = cutoff_local_seq + 1)` against the same responder, so the
+   snapshot and live tail stitch without gap or overlap while portable
+   per-origin cursors still detect an evicted replay window. See #415
+   (Reading B) and the wire types in §8.2/§8.3.
 4. **Readiness gates traffic.** `/healthz/ready` returns `NOT_SERVING`
-   whenever replication lag exceeds `LANTERN_MAX_REPLICATION_LAG`, so the
-   load balancer drains the instance. **Single-instance mode** (empty
+   whenever replication lag exceeds `LANTERN_MAX_REPLICATION_LAG` or an
+   observed peer reports a different search config fingerprint, so the load
+   balancer drains the instance. Graph replication continues across a search
+   mismatch for repair and diagnosis. **Single-instance mode** (empty
    `LANTERN_PEERS`) bypasses this gate.
 5. **No leader, no Raft, no external storage.** v1 is intentionally
    ephemeral. Single-pod loss recovers from peers; total-cluster loss is
@@ -90,10 +94,19 @@ whether re-applying an already-seen mutation is a no-op.
 | `DeleteVertex(es)` | Tombstone (LWW) | A tombstone is itself an entry with HLC. Any `Put*` / `Add*` whose HLC < tombstone HLC is dropped. Tombstone TTL = D4. |
 | `DeleteEdge(s)` | Tombstone (LWW) on `(tail, head)` | Same as vertex tombstone. |
 
-Reads (`GetVertex(es)`, `GetEdge(s)`, `Illuminate`) are local-only — they
-never block on peers and never read-repair. Read-after-write across nodes is
-**eventual**, bounded by the readiness gate (invariant 4) plus the pump's
-flush latency target (§9).
+Reads (`GetVertex(es)`, `GetEdge(s)`, `Illuminate`, `SearchVertices`) are
+local-only — they never block on peers and never read-repair. Read-after-write
+across nodes is **eventual**, bounded by the readiness gate (invariant 4) plus
+the pump's flush latency target (§9).
+
+`SearchVertices` is derived from each replica's local live graph. During lag
+or a partition, membership, document frequency, BM25 scores, and top-k order
+may differ across replicas; a client-side failover can therefore return a
+different response. Once replicas have the same live graph and identical
+`search.config_fingerprint`, they return the same ordered hits and score bits.
+Snapshot bootstrap, anti-entropy snapshot repair, and backup restore mark the
+local search index `INCOMPLETE` before replay and rebuild it from the complete
+live graph before reporting `HEALTHY`. `DISABLED` remains a separate state.
 
 ## 5. Hybrid Logical Clock
 
@@ -315,17 +328,18 @@ Consequence:
   writer stamps it atomically at `Log.Append` time via the
   `SeqStamper` callback (see `core/mutationlog`).
 
-The internal peer pump uses the same RPC but with an empty cursor and
-relies on `ApplyMutation`'s watermark CAS to dedup duplicate hops; it
-still performs input-side self-echo suppression (`Mutation.Origin ==
-local NodeID → drop`) as defence-in-depth.
+The internal peer pump uses the same RPC. Ordinary sessions start with an
+empty portable cursor and rely on `ApplyMutation`'s watermark CAS to dedup
+duplicate hops; snapshot recovery resumes with both header-derived origin and
+same-responder local cursors. It still performs input-side self-echo
+suppression (`Mutation.Origin == local NodeID → drop`) as defence-in-depth.
 
 Back-pressure: server terminates the stream with `FAILED_PRECONDITION`
-(`gapped`) if either (a) the ring has been truncated below the
-oldest seq the cursor could match, or (b) the consumer's send buffer
+(`gapped`) if either (a) the ring has been truncated below the requested
+responder-local replay position, or (b) the consumer's send buffer
 overflows. In both cases the consumer must re-bootstrap via
 `Snapshot` and resume `Subscribe` with the
-`cutoff_seq_per_origin` returned by `SnapshotHeader`.
+`cutoff_seq_per_origin` and `cutoff_local_seq` returned by `SnapshotHeader`.
 
 Handler implementation notes (issue #180):
 
@@ -337,11 +351,9 @@ Handler implementation notes (issue #180):
   with the reason `"gapped"`, both at subscribe time (initial check) and
   when the in-flight channel is closed by the log's slow-subscriber
   eviction. This matches the wire contract above.
-- The handler shallow-copies the buffered `*pb.Mutation` into the
-  outbound `SubscribeResponse.Mutation` while overwriting `Seq` with
-  `entry.Seq`. The write path stores `Seq=0` on the buffered Mutation;
-  only Subscribe stamps it. Peer-pump apply (`#182`) must therefore
-  read `Seq` from the streamed envelope.
+- The handler forwards the buffered `*pb.Mutation` with its originating
+  writer's `Mutation.Seq` intact. A relay's replica-local `entry.Seq` is a
+  separate transport cursor and must never overwrite the portable origin seq.
 - Health: a separate service name `graph.v1.LanternReplicationService`
   is registered with the grpc health server and flipped to
   `NOT_SERVING` on shutdown alongside `LanternService`.
@@ -356,7 +368,7 @@ rpc Snapshot(SnapshotRequest) returns (stream SnapshotResponse);
 
 message SnapshotResponse {
   oneof entry {
-    SnapshotHeader header = 1;   // first frame: cutoff_seq_per_origin + cutoff_hlc
+    SnapshotHeader header = 1;   // first frame: origin/local cutoffs + cutoff_hlc
     SnapshotVertex vertex = 2;   // body: live vertex with stored HLC
     SnapshotEdge   edge   = 3;   // body: edge with per-contribution payloads
     SnapshotFooter footer = 4;   // last frame: streamed vertex/edge counts
@@ -370,6 +382,7 @@ message SnapshotHeader {
   // applied from that origin. Empty when the cluster is cold.
   map<string, uint64> cutoff_seq_per_origin = 1;
   HLCTimestamp cutoff_hlc = 2;
+  uint64 cutoff_local_seq = 3; // same-responder log position
 }
 
 message SnapshotEdge {
@@ -395,7 +408,10 @@ Framing contract:
   `logMutation`). `cutoff_hlc` is the primary's `clock.Now()` at
   snapshot-open time. The consumer Subscribes with
   `from_seq_per_origin = {origin: seq + 1 for each (origin, seq) in
-  cutoff_seq_per_origin}` to stitch the snapshot and the live tail.
+  cutoff_seq_per_origin}` and `from_local_seq = cutoff_local_seq + 1`
+  against that same responder to stitch the snapshot and the live tail.
+  `cutoff_local_seq` is deliberately not portable across replicas; the
+  per-origin map remains the portable CDC/failover watermark.
   An empty map means the primary has not yet applied any origin
   (cold cluster); the consumer should pass an empty Subscribe cursor.
 - The **footer** is always the last frame. It reports the actually
@@ -435,17 +451,21 @@ new pod boots
   │
   ├── for each peer P (in parallel; first to respond wins):
   │     stream = P.Snapshot(SnapshotRequest{})
-  │     header  = stream.Recv()      // {cutoff_seq_per_origin, cutoff_hlc}
+  │     header  = stream.Recv()      // per-origin + responder-local cutoffs
+  │     mark local search index INCOMPLETE
   │     apply  body frames → local cache
   │     footer = last frame          // assert counts match
+  │     rebuild exact local search index; only then mark HEALTHY
   │
   ├── for each peer P:
-  │     go pump(P)                  // Subscribe sends an empty cursor;
-  │                                  // the local watermark CAS dedups
-  │                                  // anything the snapshot already covered
+  │     compare PeerStatus.search_config_fingerprint
+  │     go pump(P)                  // Subscribe resumes at
+  │                                  // origin cutoffs + 1 and this
+  │                                  // responder's local cutoff + 1
   │
   └── /healthz/ready flips SERVING when:
-        - lag(P) < LANTERN_MAX_REPLICATION_LAG for all peers, OR
+        - lag(P) < LANTERN_MAX_REPLICATION_LAG and observed peer search
+          fingerprints match, OR
         - single-instance mode (LANTERN_PEERS empty)
 ```
 
@@ -518,6 +538,10 @@ Helm chart.
 Lantern is **AP** in CAP terms. During a partition:
 
 - Each side accepts both reads and writes (no quorum).
+- `SearchVertices` remains available but is local/eventual. Corpus membership,
+  BM25 statistics, scores, and top-k order may differ until mutation streaming
+  or anti-entropy repairs the graph; clients must not interpret a partition-time
+  response as a cluster-wide snapshot.
 - `Add*` writes on both sides combine cleanly when the partition heals
   (G-Set union). No data is lost.
 - `Put*` writes on both sides converge to the higher-HLC value. The losing
@@ -538,6 +562,7 @@ The [HA runbook](ha-runbook.md) describes detection (`lantern_replication_lag_se
 |---|---|---|
 | Single pod crash | k8s probe / Compose healthcheck | k8s/Compose restarts pod → bootstraps from peers. |
 | Pod falls behind > buffer | `Subscribe` returns `FailedPrecondition` (reason `gapped`) | Pump auto re-snapshots and resumes. |
+| Search config differs across replicas | `lantern_search_config_match{peer}=0`, mismatch counter/log, readiness `NOT_SERVING` | Make every search-affecting `LANTERN_SEARCH_*` value homogeneous, then wait for the next pump/anti-entropy comparison. |
 | All peers unreachable on boot | `Snapshot` fails on every peer | Pod stays `NOT_SERVING`; operator alert on readiness. |
 | Total-cluster loss | every replica down | **Accepted data loss** (D1) — bring the cluster back empty, *or* run snapshot backups (`LANTERN_BACKUP_*`, [backup.md](backup.md)) so each node restores its newest dump on boot. |
 | NTP skew > 500ms | `lantern_hlc_skew_clamped_total > 0` (planned — #180/#182) | Fix NTP. Mutations from the drifted peer keep applying (their HLC wall is clamped, §5.3); convergence is preserved but the drifted peer's stamps land behind real wall time until it heals. |

--- a/pb/graph/v1/graphv1connect/replication.connect.go
+++ b/pb/graph/v1/graphv1connect/replication.connect.go
@@ -48,10 +48,11 @@ const (
 // LanternReplicationServiceClient is a client for the graph.v1.LanternReplicationService service.
 type LanternReplicationServiceClient interface {
 	// Subscribe streams replicated mutations to a peer (or CDC consumer)
-	// starting at `from_seq` (inclusive). The server replays any in-buffer
-	// entries first, then streams live mutations as they are appended.
+	// starting at the supplied per-origin cursor. A same-responder snapshot
+	// resume also supplies `from_local_seq`; the server replays retained entries
+	// from that local position first, then streams live mutations.
 	//
-	// If `from_seq` is below the server's first available seq the call
+	// If the requested replica-local replay window has been evicted, the call
 	// fails with FAILED_PRECONDITION ("gapped") and the caller must
 	// snapshot + resubscribe. Slow consumers whose channel backs up may
 	// also have the stream terminated with FAILED_PRECONDITION — the
@@ -63,14 +64,15 @@ type LanternReplicationServiceClient interface {
 	Subscribe(context.Context, *connect.Request[v1.SubscribeRequest]) (*connect.ServerStreamForClient[v1.SubscribeResponse], error)
 	// Snapshot streams a point-in-time, causally-consistent dump of every
 	// live vertex and edge to a bootstrapping peer. The first frame is a
-	// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_hlc) the
-	// server used to materialise the snapshot; the last frame is a
+	// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_local_seq,
+	// cutoff_hlc) the server used to materialise the snapshot; the last frame is a
 	// SnapshotFooter with the actual vertex / edge counts streamed.
 	//
 	// Bootstrap stitch contract: after receiving the SnapshotFooter the
 	// peer MUST call `Subscribe(from_seq_per_origin = {origin: seq+1 for
-	// each (origin, seq) in cutoff_seq_per_origin})` to pick up the live
-	// tail. Without that the snapshot and the live stream cannot be glued
+	// each (origin, seq) in cutoff_seq_per_origin}, from_local_seq =
+	// cutoff_local_seq+1)` against the same responder to pick up the live tail.
+	// Without that the snapshot and live stream cannot be glued
 	// together without gap or overlap.
 	//
 	// No HTTP gateway annotation (parity with Subscribe).
@@ -154,10 +156,11 @@ func (c *lanternReplicationServiceClient) PeerStatus(ctx context.Context, req *c
 // service.
 type LanternReplicationServiceHandler interface {
 	// Subscribe streams replicated mutations to a peer (or CDC consumer)
-	// starting at `from_seq` (inclusive). The server replays any in-buffer
-	// entries first, then streams live mutations as they are appended.
+	// starting at the supplied per-origin cursor. A same-responder snapshot
+	// resume also supplies `from_local_seq`; the server replays retained entries
+	// from that local position first, then streams live mutations.
 	//
-	// If `from_seq` is below the server's first available seq the call
+	// If the requested replica-local replay window has been evicted, the call
 	// fails with FAILED_PRECONDITION ("gapped") and the caller must
 	// snapshot + resubscribe. Slow consumers whose channel backs up may
 	// also have the stream terminated with FAILED_PRECONDITION — the
@@ -169,14 +172,15 @@ type LanternReplicationServiceHandler interface {
 	Subscribe(context.Context, *connect.Request[v1.SubscribeRequest], *connect.ServerStream[v1.SubscribeResponse]) error
 	// Snapshot streams a point-in-time, causally-consistent dump of every
 	// live vertex and edge to a bootstrapping peer. The first frame is a
-	// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_hlc) the
-	// server used to materialise the snapshot; the last frame is a
+	// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_local_seq,
+	// cutoff_hlc) the server used to materialise the snapshot; the last frame is a
 	// SnapshotFooter with the actual vertex / edge counts streamed.
 	//
 	// Bootstrap stitch contract: after receiving the SnapshotFooter the
 	// peer MUST call `Subscribe(from_seq_per_origin = {origin: seq+1 for
-	// each (origin, seq) in cutoff_seq_per_origin})` to pick up the live
-	// tail. Without that the snapshot and the live stream cannot be glued
+	// each (origin, seq) in cutoff_seq_per_origin}, from_local_seq =
+	// cutoff_local_seq+1)` against the same responder to pick up the live tail.
+	// Without that the snapshot and live stream cannot be glued
 	// together without gap or overlap.
 	//
 	// No HTTP gateway annotation (parity with Subscribe).

--- a/pb/graph/v1/replication.pb.go
+++ b/pb/graph/v1/replication.pb.go
@@ -456,8 +456,14 @@ type SubscribeRequest struct {
 	// 16-byte HLC NodeID; values are the next local `seq` the consumer
 	// expects from that origin.
 	FromSeqPerOrigin map[string]uint64 `protobuf:"bytes,1,rep,name=from_seq_per_origin,json=fromSeqPerOrigin,proto3" json:"from_seq_per_origin,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// Next entry in this responder's replica-local mutation log. This is only
+	// valid when resuming against the SAME responder that emitted
+	// SnapshotHeader.cutoff_local_seq; zero uses the portable per-origin path.
+	// Keeping the two sequence domains separate prevents a stale per-origin
+	// cursor from bypassing ring-buffer gap detection.
+	FromLocalSeq  uint64 `protobuf:"varint,2,opt,name=from_local_seq,json=fromLocalSeq,proto3" json:"from_local_seq,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SubscribeRequest) Reset() {
@@ -495,6 +501,13 @@ func (x *SubscribeRequest) GetFromSeqPerOrigin() map[string]uint64 {
 		return x.FromSeqPerOrigin
 	}
 	return nil
+}
+
+func (x *SubscribeRequest) GetFromLocalSeq() uint64 {
+	if x != nil {
+		return x.FromLocalSeq
+	}
+	return 0
 }
 
 // SubscribeResponse carries one replicated mutation per message.
@@ -586,11 +599,12 @@ func (*SnapshotRequest) Descriptor() ([]byte, []int) {
 // freezes the per-origin watermark and the snapshot-open HLC the server
 // used to materialise the snapshot.
 //
-// A bootstrapping peer MUST persist `cutoff_seq_per_origin` and
-// `cutoff_hlc` before applying any payload entries and MUST resume
-// `Subscribe` with `from_seq_per_origin = {origin: seq+1 for each
-// (origin, seq) in cutoff_seq_per_origin}` so the snapshot and the
-// live tail stitch without gap or overlap.
+// A bootstrapping peer MUST persist `cutoff_seq_per_origin`,
+// `cutoff_local_seq`, and `cutoff_hlc` before applying any payload entries and
+// MUST resume Subscribe against the SAME responder with both
+// `from_seq_per_origin = {origin: seq+1 for each (origin, seq) in
+// cutoff_seq_per_origin}` and `from_local_seq = cutoff_local_seq+1` so the
+// snapshot and the live tail stitch without gap or overlap.
 //
 // Keys in `cutoff_seq_per_origin` are 32-char lowercase hex of the
 // 16-byte HLC NodeID, matching `SubscribeRequest.from_seq_per_origin`.
@@ -602,8 +616,12 @@ type SnapshotHeader struct {
 	state              protoimpl.MessageState `protogen:"open.v1"`
 	CutoffSeqPerOrigin map[string]uint64      `protobuf:"bytes,1,rep,name=cutoff_seq_per_origin,json=cutoffSeqPerOrigin,proto3" json:"cutoff_seq_per_origin,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
 	CutoffHlc          *HLCTimestamp          `protobuf:"bytes,2,opt,name=cutoff_hlc,json=cutoffHlc,proto3" json:"cutoff_hlc,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// Replica-local mutation-log position at snapshot open. It is deliberately
+	// separate from the portable per-origin watermarks and only resumes a tail
+	// against the same responder.
+	CutoffLocalSeq uint64 `protobuf:"varint,3,opt,name=cutoff_local_seq,json=cutoffLocalSeq,proto3" json:"cutoff_local_seq,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *SnapshotHeader) Reset() {
@@ -648,6 +666,13 @@ func (x *SnapshotHeader) GetCutoffHlc() *HLCTimestamp {
 		return x.CutoffHlc
 	}
 	return nil
+}
+
+func (x *SnapshotHeader) GetCutoffLocalSeq() uint64 {
+	if x != nil {
+		return x.CutoffLocalSeq
+	}
+	return 0
 }
 
 // SnapshotFooter is always the LAST SnapshotResponse on the wire. It carries
@@ -1137,11 +1162,15 @@ func (x *OriginState) GetLastHlc() *HLCTimestamp {
 // anti-entropy callers can pick out the row that represents this
 // peer's own writes without having to pre-configure peer NodeIDs.
 type PeerStatusResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	SelfOrigin    []byte                 `protobuf:"bytes,1,opt,name=self_origin,json=selfOrigin,proto3" json:"self_origin,omitempty"`
-	Origins       []*OriginState         `protobuf:"bytes,2,rep,name=origins,proto3" json:"origins,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	SelfOrigin []byte                 `protobuf:"bytes,1,opt,name=self_origin,json=selfOrigin,proto3" json:"self_origin,omitempty"`
+	Origins    []*OriginState         `protobuf:"bytes,2,rep,name=origins,proto3" json:"origins,omitempty"`
+	// Fingerprint of every search setting that can change capabilities or
+	// ordered results. Replicas compare this before declaring themselves ready;
+	// empty means the responder cannot prove search-config compatibility.
+	SearchConfigFingerprint string `protobuf:"bytes,3,opt,name=search_config_fingerprint,json=searchConfigFingerprint,proto3" json:"search_config_fingerprint,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *PeerStatusResponse) Reset() {
@@ -1188,6 +1217,13 @@ func (x *PeerStatusResponse) GetOrigins() []*OriginState {
 	return nil
 }
 
+func (x *PeerStatusResponse) GetSearchConfigFingerprint() string {
+	if x != nil {
+		return x.SearchConfigFingerprint
+	}
+	return ""
+}
+
 var File_graph_v1_replication_proto protoreflect.FileDescriptor
 
 const file_graph_v1_replication_proto_rawDesc = "" +
@@ -1219,19 +1255,21 @@ const file_graph_v1_replication_proto_rawDesc = "" +
 	"\x03seq\x18\x01 \x01(\x04R\x03seq\x12(\n" +
 	"\x03hlc\x18\x02 \x01(\v2\x16.graph.v1.HLCTimestampR\x03hlc\x12\x16\n" +
 	"\x06origin\x18\x03 \x01(\fR\x06origin\x12$\n" +
-	"\x02op\x18\x04 \x01(\v2\x14.graph.v1.MutationOpR\x02op\"\xb8\x01\n" +
+	"\x02op\x18\x04 \x01(\v2\x14.graph.v1.MutationOpR\x02op\"\xde\x01\n" +
 	"\x10SubscribeRequest\x12_\n" +
-	"\x13from_seq_per_origin\x18\x01 \x03(\v20.graph.v1.SubscribeRequest.FromSeqPerOriginEntryR\x10fromSeqPerOrigin\x1aC\n" +
+	"\x13from_seq_per_origin\x18\x01 \x03(\v20.graph.v1.SubscribeRequest.FromSeqPerOriginEntryR\x10fromSeqPerOrigin\x12$\n" +
+	"\x0efrom_local_seq\x18\x02 \x01(\x04R\ffromLocalSeq\x1aC\n" +
 	"\x15FromSeqPerOriginEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x04R\x05value:\x028\x01\"C\n" +
 	"\x11SubscribeResponse\x12.\n" +
 	"\bmutation\x18\x01 \x01(\v2\x12.graph.v1.MutationR\bmutation\"\x11\n" +
-	"\x0fSnapshotRequest\"\xf3\x01\n" +
+	"\x0fSnapshotRequest\"\x9d\x02\n" +
 	"\x0eSnapshotHeader\x12c\n" +
 	"\x15cutoff_seq_per_origin\x18\x01 \x03(\v20.graph.v1.SnapshotHeader.CutoffSeqPerOriginEntryR\x12cutoffSeqPerOrigin\x125\n" +
 	"\n" +
-	"cutoff_hlc\x18\x02 \x01(\v2\x16.graph.v1.HLCTimestampR\tcutoffHlc\x1aE\n" +
+	"cutoff_hlc\x18\x02 \x01(\v2\x16.graph.v1.HLCTimestampR\tcutoffHlc\x12(\n" +
+	"\x10cutoff_local_seq\x18\x03 \x01(\x04R\x0ecutoffLocalSeq\x1aE\n" +
 	"\x17CutoffSeqPerOriginEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x04R\x05value:\x028\x01\"R\n" +
@@ -1264,11 +1302,12 @@ const file_graph_v1_replication_proto_rawDesc = "" +
 	"\vOriginState\x12\x16\n" +
 	"\x06origin\x18\x01 \x01(\fR\x06origin\x12\x19\n" +
 	"\blast_seq\x18\x02 \x01(\x04R\alastSeq\x121\n" +
-	"\blast_hlc\x18\x03 \x01(\v2\x16.graph.v1.HLCTimestampR\alastHlc\"f\n" +
+	"\blast_hlc\x18\x03 \x01(\v2\x16.graph.v1.HLCTimestampR\alastHlc\"\xa2\x01\n" +
 	"\x12PeerStatusResponse\x12\x1f\n" +
 	"\vself_origin\x18\x01 \x01(\fR\n" +
 	"selfOrigin\x12/\n" +
-	"\aorigins\x18\x02 \x03(\v2\x15.graph.v1.OriginStateR\aorigins2\xf1\x01\n" +
+	"\aorigins\x18\x02 \x03(\v2\x15.graph.v1.OriginStateR\aorigins\x12:\n" +
+	"\x19search_config_fingerprint\x18\x03 \x01(\tR\x17searchConfigFingerprint2\xf1\x01\n" +
 	"\x19LanternReplicationService\x12F\n" +
 	"\tSubscribe\x12\x1a.graph.v1.SubscribeRequest\x1a\x1b.graph.v1.SubscribeResponse0\x01\x12C\n" +
 	"\bSnapshot\x12\x19.graph.v1.SnapshotRequest\x1a\x1a.graph.v1.SnapshotResponse0\x01\x12G\n" +

--- a/proto/graph/v1/replication.proto
+++ b/proto/graph/v1/replication.proto
@@ -98,6 +98,12 @@ message SubscribeRequest {
   // 16-byte HLC NodeID; values are the next local `seq` the consumer
   // expects from that origin.
   map<string, uint64> from_seq_per_origin = 1;
+  // Next entry in this responder's replica-local mutation log. This is only
+  // valid when resuming against the SAME responder that emitted
+  // SnapshotHeader.cutoff_local_seq; zero uses the portable per-origin path.
+  // Keeping the two sequence domains separate prevents a stale per-origin
+  // cursor from bypassing ring-buffer gap detection.
+  uint64 from_local_seq = 2;
 }
 
 // SubscribeResponse carries one replicated mutation per message.
@@ -115,11 +121,12 @@ message SnapshotRequest {}
 // freezes the per-origin watermark and the snapshot-open HLC the server
 // used to materialise the snapshot.
 //
-// A bootstrapping peer MUST persist `cutoff_seq_per_origin` and
-// `cutoff_hlc` before applying any payload entries and MUST resume
-// `Subscribe` with `from_seq_per_origin = {origin: seq+1 for each
-// (origin, seq) in cutoff_seq_per_origin}` so the snapshot and the
-// live tail stitch without gap or overlap.
+// A bootstrapping peer MUST persist `cutoff_seq_per_origin`,
+// `cutoff_local_seq`, and `cutoff_hlc` before applying any payload entries and
+// MUST resume Subscribe against the SAME responder with both
+// `from_seq_per_origin = {origin: seq+1 for each (origin, seq) in
+// cutoff_seq_per_origin}` and `from_local_seq = cutoff_local_seq+1` so the
+// snapshot and the live tail stitch without gap or overlap.
 //
 // Keys in `cutoff_seq_per_origin` are 32-char lowercase hex of the
 // 16-byte HLC NodeID, matching `SubscribeRequest.from_seq_per_origin`.
@@ -130,6 +137,10 @@ message SnapshotRequest {}
 message SnapshotHeader {
   map<string, uint64> cutoff_seq_per_origin = 1;
   HLCTimestamp cutoff_hlc = 2;
+  // Replica-local mutation-log position at snapshot open. It is deliberately
+  // separate from the portable per-origin watermarks and only resumes a tail
+  // against the same responder.
+  uint64 cutoff_local_seq = 3;
 }
 
 // SnapshotFooter is always the LAST SnapshotResponse on the wire. It carries
@@ -208,10 +219,11 @@ message SnapshotResponse {
 // part of #178's implementation in docs/replication.md.
 service LanternReplicationService {
   // Subscribe streams replicated mutations to a peer (or CDC consumer)
-  // starting at `from_seq` (inclusive). The server replays any in-buffer
-  // entries first, then streams live mutations as they are appended.
+  // starting at the supplied per-origin cursor. A same-responder snapshot
+  // resume also supplies `from_local_seq`; the server replays retained entries
+  // from that local position first, then streams live mutations.
   //
-  // If `from_seq` is below the server's first available seq the call
+  // If the requested replica-local replay window has been evicted, the call
   // fails with FAILED_PRECONDITION ("gapped") and the caller must
   // snapshot + resubscribe. Slow consumers whose channel backs up may
   // also have the stream terminated with FAILED_PRECONDITION — the
@@ -224,14 +236,15 @@ service LanternReplicationService {
 
   // Snapshot streams a point-in-time, causally-consistent dump of every
   // live vertex and edge to a bootstrapping peer. The first frame is a
-  // SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_hlc) the
-  // server used to materialise the snapshot; the last frame is a
+  // SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_local_seq,
+  // cutoff_hlc) the server used to materialise the snapshot; the last frame is a
   // SnapshotFooter with the actual vertex / edge counts streamed.
   //
   // Bootstrap stitch contract: after receiving the SnapshotFooter the
   // peer MUST call `Subscribe(from_seq_per_origin = {origin: seq+1 for
-  // each (origin, seq) in cutoff_seq_per_origin})` to pick up the live
-  // tail. Without that the snapshot and the live stream cannot be glued
+  // each (origin, seq) in cutoff_seq_per_origin}, from_local_seq =
+  // cutoff_local_seq+1)` against the same responder to pick up the live tail.
+  // Without that the snapshot and live stream cannot be glued
   // together without gap or overlap.
   //
   // No HTTP gateway annotation (parity with Subscribe).
@@ -283,4 +296,8 @@ message OriginState {
 message PeerStatusResponse {
   bytes self_origin = 1;
   repeated OriginState origins = 2;
+  // Fingerprint of every search setting that can change capabilities or
+  // ordered results. Replicas compare this before declaring themselves ready;
+  // empty means the responder cannot prove search-config compatibility.
+  string search_config_fingerprint = 3;
 }

--- a/sdks/dart/lib/src/gen/graph/v1/replication.connect.client.dart
+++ b/sdks/dart/lib/src/gen/graph/v1/replication.connect.client.dart
@@ -20,9 +20,10 @@ import "replication.connect.spec.dart" as specs;
 /// part of #178's implementation in docs/replication.md.
 extension type LanternReplicationServiceClient (connect.Transport _transport) {
   /// Subscribe streams replicated mutations to a peer (or CDC consumer)
-  /// starting at `from_seq` (inclusive). The server replays any in-buffer
-  /// entries first, then streams live mutations as they are appended.
-  /// If `from_seq` is below the server's first available seq the call
+  /// starting at the supplied per-origin cursor. A same-responder snapshot
+  /// resume also supplies `from_local_seq`; the server replays retained entries
+  /// from that local position first, then streams live mutations.
+  /// If the requested replica-local replay window has been evicted, the call
   /// fails with FAILED_PRECONDITION ("gapped") and the caller must
   /// snapshot + resubscribe. Slow consumers whose channel backs up may
   /// also have the stream terminated with FAILED_PRECONDITION — the
@@ -49,13 +50,14 @@ extension type LanternReplicationServiceClient (connect.Transport _transport) {
 
   /// Snapshot streams a point-in-time, causally-consistent dump of every
   /// live vertex and edge to a bootstrapping peer. The first frame is a
-  /// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_hlc) the
-  /// server used to materialise the snapshot; the last frame is a
+  /// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_local_seq,
+  /// cutoff_hlc) the server used to materialise the snapshot; the last frame is a
   /// SnapshotFooter with the actual vertex / edge counts streamed.
   /// Bootstrap stitch contract: after receiving the SnapshotFooter the
   /// peer MUST call `Subscribe(from_seq_per_origin = {origin: seq+1 for
-  /// each (origin, seq) in cutoff_seq_per_origin})` to pick up the live
-  /// tail. Without that the snapshot and the live stream cannot be glued
+  /// each (origin, seq) in cutoff_seq_per_origin}, from_local_seq =
+  /// cutoff_local_seq+1)` against the same responder to pick up the live tail.
+  /// Without that the snapshot and live stream cannot be glued
   /// together without gap or overlap.
   /// No HTTP gateway annotation (parity with Subscribe).
   Stream<graphv1replication.SnapshotResponse> snapshot(

--- a/sdks/dart/lib/src/gen/graph/v1/replication.connect.spec.dart
+++ b/sdks/dart/lib/src/gen/graph/v1/replication.connect.spec.dart
@@ -22,9 +22,10 @@ abstract final class LanternReplicationService {
   static const name = 'graph.v1.LanternReplicationService';
 
   /// Subscribe streams replicated mutations to a peer (or CDC consumer)
-  /// starting at `from_seq` (inclusive). The server replays any in-buffer
-  /// entries first, then streams live mutations as they are appended.
-  /// If `from_seq` is below the server's first available seq the call
+  /// starting at the supplied per-origin cursor. A same-responder snapshot
+  /// resume also supplies `from_local_seq`; the server replays retained entries
+  /// from that local position first, then streams live mutations.
+  /// If the requested replica-local replay window has been evicted, the call
   /// fails with FAILED_PRECONDITION ("gapped") and the caller must
   /// snapshot + resubscribe. Slow consumers whose channel backs up may
   /// also have the stream terminated with FAILED_PRECONDITION — the
@@ -41,13 +42,14 @@ abstract final class LanternReplicationService {
 
   /// Snapshot streams a point-in-time, causally-consistent dump of every
   /// live vertex and edge to a bootstrapping peer. The first frame is a
-  /// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_hlc) the
-  /// server used to materialise the snapshot; the last frame is a
+  /// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_local_seq,
+  /// cutoff_hlc) the server used to materialise the snapshot; the last frame is a
   /// SnapshotFooter with the actual vertex / edge counts streamed.
   /// Bootstrap stitch contract: after receiving the SnapshotFooter the
   /// peer MUST call `Subscribe(from_seq_per_origin = {origin: seq+1 for
-  /// each (origin, seq) in cutoff_seq_per_origin})` to pick up the live
-  /// tail. Without that the snapshot and the live stream cannot be glued
+  /// each (origin, seq) in cutoff_seq_per_origin}, from_local_seq =
+  /// cutoff_local_seq+1)` against the same responder to pick up the live tail.
+  /// Without that the snapshot and live stream cannot be glued
   /// together without gap or overlap.
   /// No HTTP gateway annotation (parity with Subscribe).
   static const snapshot = connect.Spec(

--- a/sdks/dart/lib/src/gen/graph/v1/replication.pb.dart
+++ b/sdks/dart/lib/src/gen/graph/v1/replication.pb.dart
@@ -526,10 +526,12 @@ class SubscribeRequest extends $pb.GeneratedMessage {
   factory SubscribeRequest({
     $core.Iterable<$core.MapEntry<$core.String, $fixnum.Int64>>?
         fromSeqPerOrigin,
+    $fixnum.Int64? fromLocalSeq,
   }) {
     final result = create();
     if (fromSeqPerOrigin != null)
       result.fromSeqPerOrigin.addEntries(fromSeqPerOrigin);
+    if (fromLocalSeq != null) result.fromLocalSeq = fromLocalSeq;
     return result;
   }
 
@@ -552,6 +554,9 @@ class SubscribeRequest extends $pb.GeneratedMessage {
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OU6,
         packageName: const $pb.PackageName('graph.v1'))
+    ..a<$fixnum.Int64>(
+        2, _omitFieldNames ? '' : 'fromLocalSeq', $pb.PbFieldType.OU6,
+        defaultOrMaker: $fixnum.Int64.ZERO)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -580,6 +585,20 @@ class SubscribeRequest extends $pb.GeneratedMessage {
   /// expects from that origin.
   @$pb.TagNumber(1)
   $pb.PbMap<$core.String, $fixnum.Int64> get fromSeqPerOrigin => $_getMap(0);
+
+  /// Next entry in this responder's replica-local mutation log. This is only
+  /// valid when resuming against the SAME responder that emitted
+  /// SnapshotHeader.cutoff_local_seq; zero uses the portable per-origin path.
+  /// Keeping the two sequence domains separate prevents a stale per-origin
+  /// cursor from bypassing ring-buffer gap detection.
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get fromLocalSeq => $_getI64(1);
+  @$pb.TagNumber(2)
+  set fromLocalSeq($fixnum.Int64 value) => $_setInt64(1, value);
+  @$pb.TagNumber(2)
+  $core.bool hasFromLocalSeq() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearFromLocalSeq() => $_clearField(2);
 }
 
 /// SubscribeResponse carries one replicated mutation per message.
@@ -690,11 +709,12 @@ class SnapshotRequest extends $pb.GeneratedMessage {
 /// freezes the per-origin watermark and the snapshot-open HLC the server
 /// used to materialise the snapshot.
 ///
-/// A bootstrapping peer MUST persist `cutoff_seq_per_origin` and
-/// `cutoff_hlc` before applying any payload entries and MUST resume
-/// `Subscribe` with `from_seq_per_origin = {origin: seq+1 for each
-/// (origin, seq) in cutoff_seq_per_origin}` so the snapshot and the
-/// live tail stitch without gap or overlap.
+/// A bootstrapping peer MUST persist `cutoff_seq_per_origin`,
+/// `cutoff_local_seq`, and `cutoff_hlc` before applying any payload entries and
+/// MUST resume Subscribe against the SAME responder with both
+/// `from_seq_per_origin = {origin: seq+1 for each (origin, seq) in
+/// cutoff_seq_per_origin}` and `from_local_seq = cutoff_local_seq+1` so the
+/// snapshot and the live tail stitch without gap or overlap.
 ///
 /// Keys in `cutoff_seq_per_origin` are 32-char lowercase hex of the
 /// 16-byte HLC NodeID, matching `SubscribeRequest.from_seq_per_origin`.
@@ -707,11 +727,13 @@ class SnapshotHeader extends $pb.GeneratedMessage {
     $core.Iterable<$core.MapEntry<$core.String, $fixnum.Int64>>?
         cutoffSeqPerOrigin,
     HLCTimestamp? cutoffHlc,
+    $fixnum.Int64? cutoffLocalSeq,
   }) {
     final result = create();
     if (cutoffSeqPerOrigin != null)
       result.cutoffSeqPerOrigin.addEntries(cutoffSeqPerOrigin);
     if (cutoffHlc != null) result.cutoffHlc = cutoffHlc;
+    if (cutoffLocalSeq != null) result.cutoffLocalSeq = cutoffLocalSeq;
     return result;
   }
 
@@ -736,6 +758,9 @@ class SnapshotHeader extends $pb.GeneratedMessage {
         packageName: const $pb.PackageName('graph.v1'))
     ..aOM<HLCTimestamp>(2, _omitFieldNames ? '' : 'cutoffHlc',
         subBuilder: HLCTimestamp.create)
+    ..a<$fixnum.Int64>(
+        3, _omitFieldNames ? '' : 'cutoffLocalSeq', $pb.PbFieldType.OU6,
+        defaultOrMaker: $fixnum.Int64.ZERO)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -772,6 +797,18 @@ class SnapshotHeader extends $pb.GeneratedMessage {
   void clearCutoffHlc() => $_clearField(2);
   @$pb.TagNumber(2)
   HLCTimestamp ensureCutoffHlc() => $_ensure(1);
+
+  /// Replica-local mutation-log position at snapshot open. It is deliberately
+  /// separate from the portable per-origin watermarks and only resumes a tail
+  /// against the same responder.
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get cutoffLocalSeq => $_getI64(2);
+  @$pb.TagNumber(3)
+  set cutoffLocalSeq($fixnum.Int64 value) => $_setInt64(2, value);
+  @$pb.TagNumber(3)
+  $core.bool hasCutoffLocalSeq() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearCutoffLocalSeq() => $_clearField(3);
 }
 
 /// SnapshotFooter is always the LAST SnapshotResponse on the wire. It carries
@@ -1388,10 +1425,13 @@ class PeerStatusResponse extends $pb.GeneratedMessage {
   factory PeerStatusResponse({
     $core.List<$core.int>? selfOrigin,
     $core.Iterable<OriginState>? origins,
+    $core.String? searchConfigFingerprint,
   }) {
     final result = create();
     if (selfOrigin != null) result.selfOrigin = selfOrigin;
     if (origins != null) result.origins.addAll(origins);
+    if (searchConfigFingerprint != null)
+      result.searchConfigFingerprint = searchConfigFingerprint;
     return result;
   }
 
@@ -1412,6 +1452,7 @@ class PeerStatusResponse extends $pb.GeneratedMessage {
         1, _omitFieldNames ? '' : 'selfOrigin', $pb.PbFieldType.OY)
     ..pc<OriginState>(2, _omitFieldNames ? '' : 'origins', $pb.PbFieldType.PM,
         subBuilder: OriginState.create)
+    ..aOS(3, _omitFieldNames ? '' : 'searchConfigFingerprint')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -1446,6 +1487,18 @@ class PeerStatusResponse extends $pb.GeneratedMessage {
 
   @$pb.TagNumber(2)
   $pb.PbList<OriginState> get origins => $_getList(1);
+
+  /// Fingerprint of every search setting that can change capabilities or
+  /// ordered results. Replicas compare this before declaring themselves ready;
+  /// empty means the responder cannot prove search-config compatibility.
+  @$pb.TagNumber(3)
+  $core.String get searchConfigFingerprint => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set searchConfigFingerprint($core.String value) => $_setString(2, value);
+  @$pb.TagNumber(3)
+  $core.bool hasSearchConfigFingerprint() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSearchConfigFingerprint() => $_clearField(3);
 }
 
 /// LanternReplicationService carries the peer-to-peer (and CDC) replication
@@ -1466,10 +1519,11 @@ class LanternReplicationServiceApi {
   LanternReplicationServiceApi(this._client);
 
   /// Subscribe streams replicated mutations to a peer (or CDC consumer)
-  /// starting at `from_seq` (inclusive). The server replays any in-buffer
-  /// entries first, then streams live mutations as they are appended.
+  /// starting at the supplied per-origin cursor. A same-responder snapshot
+  /// resume also supplies `from_local_seq`; the server replays retained entries
+  /// from that local position first, then streams live mutations.
   ///
-  /// If `from_seq` is below the server's first available seq the call
+  /// If the requested replica-local replay window has been evicted, the call
   /// fails with FAILED_PRECONDITION ("gapped") and the caller must
   /// snapshot + resubscribe. Slow consumers whose channel backs up may
   /// also have the stream terminated with FAILED_PRECONDITION — the
@@ -1485,14 +1539,15 @@ class LanternReplicationServiceApi {
 
   /// Snapshot streams a point-in-time, causally-consistent dump of every
   /// live vertex and edge to a bootstrapping peer. The first frame is a
-  /// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_hlc) the
-  /// server used to materialise the snapshot; the last frame is a
+  /// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_local_seq,
+  /// cutoff_hlc) the server used to materialise the snapshot; the last frame is a
   /// SnapshotFooter with the actual vertex / edge counts streamed.
   ///
   /// Bootstrap stitch contract: after receiving the SnapshotFooter the
   /// peer MUST call `Subscribe(from_seq_per_origin = {origin: seq+1 for
-  /// each (origin, seq) in cutoff_seq_per_origin})` to pick up the live
-  /// tail. Without that the snapshot and the live stream cannot be glued
+  /// each (origin, seq) in cutoff_seq_per_origin}, from_local_seq =
+  /// cutoff_local_seq+1)` against the same responder to pick up the live tail.
+  /// Without that the snapshot and live stream cannot be glued
   /// together without gap or overlap.
   ///
   /// No HTTP gateway annotation (parity with Subscribe).

--- a/sdks/dart/lib/src/gen/graph/v1/replication.pbjson.dart
+++ b/sdks/dart/lib/src/gen/graph/v1/replication.pbjson.dart
@@ -213,6 +213,7 @@ const SubscribeRequest$json = {
       '6': '.graph.v1.SubscribeRequest.FromSeqPerOriginEntry',
       '10': 'fromSeqPerOrigin'
     },
+    {'1': 'from_local_seq', '3': 2, '4': 1, '5': 4, '10': 'fromLocalSeq'},
   ],
   '3': [SubscribeRequest_FromSeqPerOriginEntry$json],
 };
@@ -231,8 +232,8 @@ const SubscribeRequest_FromSeqPerOriginEntry$json = {
 final $typed_data.Uint8List subscribeRequestDescriptor = $convert.base64Decode(
     'ChBTdWJzY3JpYmVSZXF1ZXN0El8KE2Zyb21fc2VxX3Blcl9vcmlnaW4YASADKAsyMC5ncmFwaC'
     '52MS5TdWJzY3JpYmVSZXF1ZXN0LkZyb21TZXFQZXJPcmlnaW5FbnRyeVIQZnJvbVNlcVBlck9y'
-    'aWdpbhpDChVGcm9tU2VxUGVyT3JpZ2luRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdW'
-    'UYAiABKARSBXZhbHVlOgI4AQ==');
+    'aWdpbhIkCg5mcm9tX2xvY2FsX3NlcRgCIAEoBFIMZnJvbUxvY2FsU2VxGkMKFUZyb21TZXFQZX'
+    'JPcmlnaW5FbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoBFIFdmFsdWU6AjgB');
 
 @$core.Deprecated('Use subscribeResponseDescriptor instead')
 const SubscribeResponse$json = {
@@ -283,6 +284,7 @@ const SnapshotHeader$json = {
       '6': '.graph.v1.HLCTimestamp',
       '10': 'cutoffHlc'
     },
+    {'1': 'cutoff_local_seq', '3': 3, '4': 1, '5': 4, '10': 'cutoffLocalSeq'},
   ],
   '3': [SnapshotHeader_CutoffSeqPerOriginEntry$json],
 };
@@ -302,8 +304,9 @@ final $typed_data.Uint8List snapshotHeaderDescriptor = $convert.base64Decode(
     'Cg5TbmFwc2hvdEhlYWRlchJjChVjdXRvZmZfc2VxX3Blcl9vcmlnaW4YASADKAsyMC5ncmFwaC'
     '52MS5TbmFwc2hvdEhlYWRlci5DdXRvZmZTZXFQZXJPcmlnaW5FbnRyeVISY3V0b2ZmU2VxUGVy'
     'T3JpZ2luEjUKCmN1dG9mZl9obGMYAiABKAsyFi5ncmFwaC52MS5ITENUaW1lc3RhbXBSCWN1dG'
-    '9mZkhsYxpFChdDdXRvZmZTZXFQZXJPcmlnaW5FbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2'
-    'YWx1ZRgCIAEoBFIFdmFsdWU6AjgB');
+    '9mZkhsYxIoChBjdXRvZmZfbG9jYWxfc2VxGAMgASgEUg5jdXRvZmZMb2NhbFNlcRpFChdDdXRv'
+    'ZmZTZXFQZXJPcmlnaW5FbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoBFIFdm'
+    'FsdWU6AjgB');
 
 @$core.Deprecated('Use snapshotFooterDescriptor instead')
 const SnapshotFooter$json = {
@@ -501,13 +504,21 @@ const PeerStatusResponse$json = {
       '6': '.graph.v1.OriginState',
       '10': 'origins'
     },
+    {
+      '1': 'search_config_fingerprint',
+      '3': 3,
+      '4': 1,
+      '5': 9,
+      '10': 'searchConfigFingerprint'
+    },
   ],
 };
 
 /// Descriptor for `PeerStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List peerStatusResponseDescriptor = $convert.base64Decode(
     'ChJQZWVyU3RhdHVzUmVzcG9uc2USHwoLc2VsZl9vcmlnaW4YASABKAxSCnNlbGZPcmlnaW4SLw'
-    'oHb3JpZ2lucxgCIAMoCzIVLmdyYXBoLnYxLk9yaWdpblN0YXRlUgdvcmlnaW5z');
+    'oHb3JpZ2lucxgCIAMoCzIVLmdyYXBoLnYxLk9yaWdpblN0YXRlUgdvcmlnaW5zEjoKGXNlYXJj'
+    'aF9jb25maWdfZmluZ2VycHJpbnQYAyABKAlSF3NlYXJjaENvbmZpZ0ZpbmdlcnByaW50');
 
 const $core.Map<$core.String, $core.dynamic>
     LanternReplicationServiceBase$json = {

--- a/sdks/go/failover.go
+++ b/sdks/go/failover.go
@@ -359,8 +359,10 @@ func (f *Failover) ScanVertexKeys(ctx context.Context, prefix string, opts ...Sc
 }
 
 // SearchVertices forwards to the current endpoint's SearchVertices, failing
-// over on ErrUnavailable. Search runs over the shared replicated keyspace, so
-// a mid-call rotation simply re-runs the query against the next replica.
+// over on ErrUnavailable. Search is local/eventual: during replication lag or
+// a partition, a rotation may change membership, BM25 scores, or result order.
+// Exact cross-endpoint results require the same live graph and homogeneous
+// search config; production traffic should target readiness-gated replicas.
 func (f *Failover) SearchVertices(ctx context.Context, query string, opts ...SearchOption) (hits []SearchHit, err error) {
 	e := f.call(ctx, "SearchVertices", func(l failoverNode) error {
 		var ie error

--- a/sdks/node/src/gen/graph/v1/replication_pb.ts
+++ b/sdks/node/src/gen/graph/v1/replication_pb.ts
@@ -14,7 +14,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file graph/v1/replication.proto.
  */
 export const file_graph_v1_replication: GenFile = /*@__PURE__*/
-  fileDesc("ChpncmFwaC92MS9yZXBsaWNhdGlvbi5wcm90bxIIZ3JhcGgudjEiQQoMSExDVGltZXN0YW1wEg8KB3dhbGxfbnMYASABKAMSDwoHbG9naWNhbBgCIAEoDRIPCgdub2RlX2lkGAMgASgMIqoFCgpNdXRhdGlvbk9wEjAKCnB1dF92ZXJ0ZXgYASABKAsyGi5ncmFwaC52MS5QdXRWZXJ0ZXhSZXF1ZXN0SAASNAoMcHV0X3ZlcnRpY2VzGAIgASgLMhwuZ3JhcGgudjEuUHV0VmVydGljZXNSZXF1ZXN0SAASNgoNZGVsZXRlX3ZlcnRleBgDIAEoCzIdLmdyYXBoLnYxLkRlbGV0ZVZlcnRleFJlcXVlc3RIABI6Cg9kZWxldGVfdmVydGljZXMYBCABKAsyHy5ncmFwaC52MS5EZWxldGVWZXJ0aWNlc1JlcXVlc3RIABJMChlkZWxldGVfdmVydGljZXNfYnlfcHJlZml4GAUgASgLMicuZ3JhcGgudjEuRGVsZXRlVmVydGljZXNCeVByZWZpeFJlcXVlc3RIABIsCghhZGRfZWRnZRgGIAEoCzIYLmdyYXBoLnYxLkFkZEVkZ2VSZXF1ZXN0SAASLgoJYWRkX2VkZ2VzGAcgASgLMhkuZ3JhcGgudjEuQWRkRWRnZXNSZXF1ZXN0SAASLAoIcHV0X2VkZ2UYCCABKAsyGC5ncmFwaC52MS5QdXRFZGdlUmVxdWVzdEgAEi4KCXB1dF9lZGdlcxgJIAEoCzIZLmdyYXBoLnYxLlB1dEVkZ2VzUmVxdWVzdEgAEjIKC2RlbGV0ZV9lZGdlGAogASgLMhsuZ3JhcGgudjEuRGVsZXRlRWRnZVJlcXVlc3RIABI0CgxkZWxldGVfZWRnZXMYCyABKAsyHC5ncmFwaC52MS5EZWxldGVFZGdlc1JlcXVlc3RIABJGChZkZWxldGVfZWRnZXNfYnlfcHJlZml4GAwgASgLMiQuZ3JhcGgudjEuRGVsZXRlRWRnZXNCeVByZWZpeFJlcXVlc3RIAEIECgJvcCJuCghNdXRhdGlvbhILCgNzZXEYASABKAQSIwoDaGxjGAIgASgLMhYuZ3JhcGgudjEuSExDVGltZXN0YW1wEg4KBm9yaWdpbhgDIAEoDBIgCgJvcBgEIAEoCzIULmdyYXBoLnYxLk11dGF0aW9uT3AimgEKEFN1YnNjcmliZVJlcXVlc3QSTQoTZnJvbV9zZXFfcGVyX29yaWdpbhgBIAMoCzIwLmdyYXBoLnYxLlN1YnNjcmliZVJlcXVlc3QuRnJvbVNlcVBlck9yaWdpbkVudHJ5GjcKFUZyb21TZXFQZXJPcmlnaW5FbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAQ6AjgBIjkKEVN1YnNjcmliZVJlc3BvbnNlEiQKCG11dGF0aW9uGAEgASgLMhIuZ3JhcGgudjEuTXV0YXRpb24iEQoPU25hcHNob3RSZXF1ZXN0IsgBCg5TbmFwc2hvdEhlYWRlchJPChVjdXRvZmZfc2VxX3Blcl9vcmlnaW4YASADKAsyMC5ncmFwaC52MS5TbmFwc2hvdEhlYWRlci5DdXRvZmZTZXFQZXJPcmlnaW5FbnRyeRIqCgpjdXRvZmZfaGxjGAIgASgLMhYuZ3JhcGgudjEuSExDVGltZXN0YW1wGjkKF0N1dG9mZlNlcVBlck9yaWdpbkVudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoBDoCOAEiOgoOU25hcHNob3RGb290ZXISFAoMdmVydGV4X2NvdW50GAEgASgEEhIKCmVkZ2VfY291bnQYAiABKAQiVwoOU25hcHNob3RWZXJ0ZXgSIAoGdmVydGV4GAEgASgLMhAuZ3JhcGgudjEuVmVydGV4EiMKA2hsYxgCIAEoCzIWLmdyYXBoLnYxLkhMQ1RpbWVzdGFtcCJuChhTbmFwc2hvdEVkZ2VDb250cmlidXRpb24SDgoGd2VpZ2h0GAEgASgCEi4KCmV4cGlyYXRpb24YAiABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEhIKCmNvbnRyaWJfaWQYAyABKAwiigEKDFNuYXBzaG90RWRnZRIMCgR0YWlsGAEgASgJEgwKBGhlYWQYAiABKAkSIwoDaGxjGAMgASgLMhYuZ3JhcGgudjEuSExDVGltZXN0YW1wEjkKDWNvbnRyaWJ1dGlvbnMYBCADKAsyIi5ncmFwaC52MS5TbmFwc2hvdEVkZ2VDb250cmlidXRpb24ixwEKEFNuYXBzaG90UmVzcG9uc2USKgoGaGVhZGVyGAEgASgLMhguZ3JhcGgudjEuU25hcHNob3RIZWFkZXJIABIqCgZ2ZXJ0ZXgYAiABKAsyGC5ncmFwaC52MS5TbmFwc2hvdFZlcnRleEgAEiYKBGVkZ2UYAyABKAsyFi5ncmFwaC52MS5TbmFwc2hvdEVkZ2VIABIqCgZmb290ZXIYBCABKAsyGC5ncmFwaC52MS5TbmFwc2hvdEZvb3RlckgAQgcKBWVudHJ5IhMKEVBlZXJTdGF0dXNSZXF1ZXN0IlkKC09yaWdpblN0YXRlEg4KBm9yaWdpbhgBIAEoDBIQCghsYXN0X3NlcRgCIAEoBBIoCghsYXN0X2hsYxgDIAEoCzIWLmdyYXBoLnYxLkhMQ1RpbWVzdGFtcCJRChJQZWVyU3RhdHVzUmVzcG9uc2USEwoLc2VsZl9vcmlnaW4YASABKAwSJgoHb3JpZ2lucxgCIAMoCzIVLmdyYXBoLnYxLk9yaWdpblN0YXRlMvEBChlMYW50ZXJuUmVwbGljYXRpb25TZXJ2aWNlEkYKCVN1YnNjcmliZRIaLmdyYXBoLnYxLlN1YnNjcmliZVJlcXVlc3QaGy5ncmFwaC52MS5TdWJzY3JpYmVSZXNwb25zZTABEkMKCFNuYXBzaG90EhkuZ3JhcGgudjEuU25hcHNob3RSZXF1ZXN0GhouZ3JhcGgudjEuU25hcHNob3RSZXNwb25zZTABEkcKClBlZXJTdGF0dXMSGy5ncmFwaC52MS5QZWVyU3RhdHVzUmVxdWVzdBocLmdyYXBoLnYxLlBlZXJTdGF0dXNSZXNwb25zZUJhCgxjb20uZ3JhcGgudjFCEFJlcGxpY2F0aW9uUHJvdG9QAaICA0dYWKoCCEdyYXBoLlYxygIIR3JhcGhcVjHiAhRHcmFwaFxWMVxHUEJNZXRhZGF0YeoCCUdyYXBoOjpWMWIGcHJvdG8z", [file_google_protobuf_timestamp, file_graph_v1_graph]);
+  fileDesc("ChpncmFwaC92MS9yZXBsaWNhdGlvbi5wcm90bxIIZ3JhcGgudjEiQQoMSExDVGltZXN0YW1wEg8KB3dhbGxfbnMYASABKAMSDwoHbG9naWNhbBgCIAEoDRIPCgdub2RlX2lkGAMgASgMIqoFCgpNdXRhdGlvbk9wEjAKCnB1dF92ZXJ0ZXgYASABKAsyGi5ncmFwaC52MS5QdXRWZXJ0ZXhSZXF1ZXN0SAASNAoMcHV0X3ZlcnRpY2VzGAIgASgLMhwuZ3JhcGgudjEuUHV0VmVydGljZXNSZXF1ZXN0SAASNgoNZGVsZXRlX3ZlcnRleBgDIAEoCzIdLmdyYXBoLnYxLkRlbGV0ZVZlcnRleFJlcXVlc3RIABI6Cg9kZWxldGVfdmVydGljZXMYBCABKAsyHy5ncmFwaC52MS5EZWxldGVWZXJ0aWNlc1JlcXVlc3RIABJMChlkZWxldGVfdmVydGljZXNfYnlfcHJlZml4GAUgASgLMicuZ3JhcGgudjEuRGVsZXRlVmVydGljZXNCeVByZWZpeFJlcXVlc3RIABIsCghhZGRfZWRnZRgGIAEoCzIYLmdyYXBoLnYxLkFkZEVkZ2VSZXF1ZXN0SAASLgoJYWRkX2VkZ2VzGAcgASgLMhkuZ3JhcGgudjEuQWRkRWRnZXNSZXF1ZXN0SAASLAoIcHV0X2VkZ2UYCCABKAsyGC5ncmFwaC52MS5QdXRFZGdlUmVxdWVzdEgAEi4KCXB1dF9lZGdlcxgJIAEoCzIZLmdyYXBoLnYxLlB1dEVkZ2VzUmVxdWVzdEgAEjIKC2RlbGV0ZV9lZGdlGAogASgLMhsuZ3JhcGgudjEuRGVsZXRlRWRnZVJlcXVlc3RIABI0CgxkZWxldGVfZWRnZXMYCyABKAsyHC5ncmFwaC52MS5EZWxldGVFZGdlc1JlcXVlc3RIABJGChZkZWxldGVfZWRnZXNfYnlfcHJlZml4GAwgASgLMiQuZ3JhcGgudjEuRGVsZXRlRWRnZXNCeVByZWZpeFJlcXVlc3RIAEIECgJvcCJuCghNdXRhdGlvbhILCgNzZXEYASABKAQSIwoDaGxjGAIgASgLMhYuZ3JhcGgudjEuSExDVGltZXN0YW1wEg4KBm9yaWdpbhgDIAEoDBIgCgJvcBgEIAEoCzIULmdyYXBoLnYxLk11dGF0aW9uT3AisgEKEFN1YnNjcmliZVJlcXVlc3QSTQoTZnJvbV9zZXFfcGVyX29yaWdpbhgBIAMoCzIwLmdyYXBoLnYxLlN1YnNjcmliZVJlcXVlc3QuRnJvbVNlcVBlck9yaWdpbkVudHJ5EhYKDmZyb21fbG9jYWxfc2VxGAIgASgEGjcKFUZyb21TZXFQZXJPcmlnaW5FbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAQ6AjgBIjkKEVN1YnNjcmliZVJlc3BvbnNlEiQKCG11dGF0aW9uGAEgASgLMhIuZ3JhcGgudjEuTXV0YXRpb24iEQoPU25hcHNob3RSZXF1ZXN0IuIBCg5TbmFwc2hvdEhlYWRlchJPChVjdXRvZmZfc2VxX3Blcl9vcmlnaW4YASADKAsyMC5ncmFwaC52MS5TbmFwc2hvdEhlYWRlci5DdXRvZmZTZXFQZXJPcmlnaW5FbnRyeRIqCgpjdXRvZmZfaGxjGAIgASgLMhYuZ3JhcGgudjEuSExDVGltZXN0YW1wEhgKEGN1dG9mZl9sb2NhbF9zZXEYAyABKAQaOQoXQ3V0b2ZmU2VxUGVyT3JpZ2luRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgEOgI4ASI6Cg5TbmFwc2hvdEZvb3RlchIUCgx2ZXJ0ZXhfY291bnQYASABKAQSEgoKZWRnZV9jb3VudBgCIAEoBCJXCg5TbmFwc2hvdFZlcnRleBIgCgZ2ZXJ0ZXgYASABKAsyEC5ncmFwaC52MS5WZXJ0ZXgSIwoDaGxjGAIgASgLMhYuZ3JhcGgudjEuSExDVGltZXN0YW1wIm4KGFNuYXBzaG90RWRnZUNvbnRyaWJ1dGlvbhIOCgZ3ZWlnaHQYASABKAISLgoKZXhwaXJhdGlvbhgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASEgoKY29udHJpYl9pZBgDIAEoDCKKAQoMU25hcHNob3RFZGdlEgwKBHRhaWwYASABKAkSDAoEaGVhZBgCIAEoCRIjCgNobGMYAyABKAsyFi5ncmFwaC52MS5ITENUaW1lc3RhbXASOQoNY29udHJpYnV0aW9ucxgEIAMoCzIiLmdyYXBoLnYxLlNuYXBzaG90RWRnZUNvbnRyaWJ1dGlvbiLHAQoQU25hcHNob3RSZXNwb25zZRIqCgZoZWFkZXIYASABKAsyGC5ncmFwaC52MS5TbmFwc2hvdEhlYWRlckgAEioKBnZlcnRleBgCIAEoCzIYLmdyYXBoLnYxLlNuYXBzaG90VmVydGV4SAASJgoEZWRnZRgDIAEoCzIWLmdyYXBoLnYxLlNuYXBzaG90RWRnZUgAEioKBmZvb3RlchgEIAEoCzIYLmdyYXBoLnYxLlNuYXBzaG90Rm9vdGVySABCBwoFZW50cnkiEwoRUGVlclN0YXR1c1JlcXVlc3QiWQoLT3JpZ2luU3RhdGUSDgoGb3JpZ2luGAEgASgMEhAKCGxhc3Rfc2VxGAIgASgEEigKCGxhc3RfaGxjGAMgASgLMhYuZ3JhcGgudjEuSExDVGltZXN0YW1wInQKElBlZXJTdGF0dXNSZXNwb25zZRITCgtzZWxmX29yaWdpbhgBIAEoDBImCgdvcmlnaW5zGAIgAygLMhUuZ3JhcGgudjEuT3JpZ2luU3RhdGUSIQoZc2VhcmNoX2NvbmZpZ19maW5nZXJwcmludBgDIAEoCTLxAQoZTGFudGVyblJlcGxpY2F0aW9uU2VydmljZRJGCglTdWJzY3JpYmUSGi5ncmFwaC52MS5TdWJzY3JpYmVSZXF1ZXN0GhsuZ3JhcGgudjEuU3Vic2NyaWJlUmVzcG9uc2UwARJDCghTbmFwc2hvdBIZLmdyYXBoLnYxLlNuYXBzaG90UmVxdWVzdBoaLmdyYXBoLnYxLlNuYXBzaG90UmVzcG9uc2UwARJHCgpQZWVyU3RhdHVzEhsuZ3JhcGgudjEuUGVlclN0YXR1c1JlcXVlc3QaHC5ncmFwaC52MS5QZWVyU3RhdHVzUmVzcG9uc2VCYQoMY29tLmdyYXBoLnYxQhBSZXBsaWNhdGlvblByb3RvUAGiAgNHWFiqAghHcmFwaC5WMcoCCEdyYXBoXFYx4gIUR3JhcGhcVjFcR1BCTWV0YWRhdGHqAglHcmFwaDo6VjFiBnByb3RvMw", [file_google_protobuf_timestamp, file_graph_v1_graph]);
 
 /**
  * HLCTimestamp is the wire form of core/hlc.Timestamp. All replicated
@@ -238,6 +238,17 @@ export type SubscribeRequest = Message<"graph.v1.SubscribeRequest"> & {
    * @generated from field: map<string, uint64> from_seq_per_origin = 1;
    */
   fromSeqPerOrigin: { [key: string]: bigint };
+
+  /**
+   * Next entry in this responder's replica-local mutation log. This is only
+   * valid when resuming against the SAME responder that emitted
+   * SnapshotHeader.cutoff_local_seq; zero uses the portable per-origin path.
+   * Keeping the two sequence domains separate prevents a stale per-origin
+   * cursor from bypassing ring-buffer gap detection.
+   *
+   * @generated from field: uint64 from_local_seq = 2;
+   */
+  fromLocalSeq: bigint;
 };
 
 /**
@@ -289,11 +300,12 @@ export const SnapshotRequestSchema: GenMessage<SnapshotRequest> = /*@__PURE__*/
  * freezes the per-origin watermark and the snapshot-open HLC the server
  * used to materialise the snapshot.
  *
- * A bootstrapping peer MUST persist `cutoff_seq_per_origin` and
- * `cutoff_hlc` before applying any payload entries and MUST resume
- * `Subscribe` with `from_seq_per_origin = {origin: seq+1 for each
- * (origin, seq) in cutoff_seq_per_origin}` so the snapshot and the
- * live tail stitch without gap or overlap.
+ * A bootstrapping peer MUST persist `cutoff_seq_per_origin`,
+ * `cutoff_local_seq`, and `cutoff_hlc` before applying any payload entries and
+ * MUST resume Subscribe against the SAME responder with both
+ * `from_seq_per_origin = {origin: seq+1 for each (origin, seq) in
+ * cutoff_seq_per_origin}` and `from_local_seq = cutoff_local_seq+1` so the
+ * snapshot and the live tail stitch without gap or overlap.
  *
  * Keys in `cutoff_seq_per_origin` are 32-char lowercase hex of the
  * 16-byte HLC NodeID, matching `SubscribeRequest.from_seq_per_origin`.
@@ -314,6 +326,15 @@ export type SnapshotHeader = Message<"graph.v1.SnapshotHeader"> & {
    * @generated from field: graph.v1.HLCTimestamp cutoff_hlc = 2;
    */
   cutoffHlc?: HLCTimestamp | undefined;
+
+  /**
+   * Replica-local mutation-log position at snapshot open. It is deliberately
+   * separate from the portable per-origin watermarks and only resumes a tail
+   * against the same responder.
+   *
+   * @generated from field: uint64 cutoff_local_seq = 3;
+   */
+  cutoffLocalSeq: bigint;
 };
 
 /**
@@ -573,6 +594,15 @@ export type PeerStatusResponse = Message<"graph.v1.PeerStatusResponse"> & {
    * @generated from field: repeated graph.v1.OriginState origins = 2;
    */
   origins: OriginState[];
+
+  /**
+   * Fingerprint of every search setting that can change capabilities or
+   * ordered results. Replicas compare this before declaring themselves ready;
+   * empty means the responder cannot prove search-config compatibility.
+   *
+   * @generated from field: string search_config_fingerprint = 3;
+   */
+  searchConfigFingerprint: string;
 };
 
 /**
@@ -601,10 +631,11 @@ export const PeerStatusResponseSchema: GenMessage<PeerStatusResponse> = /*@__PUR
 export const LanternReplicationService: GenService<{
   /**
    * Subscribe streams replicated mutations to a peer (or CDC consumer)
-   * starting at `from_seq` (inclusive). The server replays any in-buffer
-   * entries first, then streams live mutations as they are appended.
+   * starting at the supplied per-origin cursor. A same-responder snapshot
+   * resume also supplies `from_local_seq`; the server replays retained entries
+   * from that local position first, then streams live mutations.
    *
-   * If `from_seq` is below the server's first available seq the call
+   * If the requested replica-local replay window has been evicted, the call
    * fails with FAILED_PRECONDITION ("gapped") and the caller must
    * snapshot + resubscribe. Slow consumers whose channel backs up may
    * also have the stream terminated with FAILED_PRECONDITION — the
@@ -624,14 +655,15 @@ export const LanternReplicationService: GenService<{
   /**
    * Snapshot streams a point-in-time, causally-consistent dump of every
    * live vertex and edge to a bootstrapping peer. The first frame is a
-   * SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_hlc) the
-   * server used to materialise the snapshot; the last frame is a
+   * SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_local_seq,
+   * cutoff_hlc) the server used to materialise the snapshot; the last frame is a
    * SnapshotFooter with the actual vertex / edge counts streamed.
    *
    * Bootstrap stitch contract: after receiving the SnapshotFooter the
    * peer MUST call `Subscribe(from_seq_per_origin = {origin: seq+1 for
-   * each (origin, seq) in cutoff_seq_per_origin})` to pick up the live
-   * tail. Without that the snapshot and the live stream cannot be glued
+   * each (origin, seq) in cutoff_seq_per_origin}, from_local_seq =
+   * cutoff_local_seq+1)` against the same responder to pick up the live tail.
+   * Without that the snapshot and live stream cannot be glued
    * together without gap or overlap.
    *
    * No HTTP gateway annotation (parity with Subscribe).

--- a/server/README.md
+++ b/server/README.md
@@ -152,6 +152,8 @@ runtime, process, and `grpc_server_*` collectors):
 | `lantern_replication_lag_seq` | gauge | `peer`, `origin` | Per-(peer, origin) lag in seq units. |
 | `lantern_anti_entropy_cycles_total` | counter | — | Anti-entropy ticks. |
 | `lantern_anti_entropy_gaps_found_total` | counter | `peer`, `origin` | Ticks observing a non-zero gap. |
+| `lantern_search_config_match` | gauge | `peer` | 1 when the peer reports the exact local search capability fingerprint; 0 keeps replicated readiness degraded. |
+| `lantern_search_config_mismatch_total` | counter | `peer` | Pump/anti-entropy observations of missing or mismatched peer search config. |
 | `lantern_peer_connected` | gauge | `peer` | 1 while the local pump holds a `Subscribe` stream to `peer`; 0 after disconnect. Flips back to 1 on reconnect. |
 | `lantern_replication_apply_total` | counter | `op` | Per-`MutationOp` apply count (`PutVertex`, `PutVertices`, `DeleteVertex`, `DeleteVertices`, `DeleteVerticesByPrefix`, `AddEdge`, `AddEdges`, `PutEdge`, `PutEdges`, `DeleteEdge`, `DeleteEdges`). Unknown ops fold onto `unknown`. Pre-warmed at startup. |
 | `lantern_snapshot_replayed_total` | counter | `peer` | Snapshots fully replayed from `peer` (after initial bootstrap or reconnect). |

--- a/server/backup/backup.go
+++ b/server/backup/backup.go
@@ -85,6 +85,8 @@ type Service interface {
 	BackupSnapshot(ctx context.Context, req *pb.BackupSnapshotRequest, stream service.Sender[pb.BackupSnapshotResponse]) error
 	RestoreVertices(ctx context.Context, req *pb.PutVerticesRequest) (*pb.PutVerticesResponse, error)
 	PutEdges(ctx context.Context, req *pb.PutEdgesRequest) (*pb.PutEdgesResponse, error)
+	BeginSearchIndexRecovery()
+	CompleteSearchIndexRecovery() error
 }
 
 // Stats counts the vertices and edges in a single backup or restore.
@@ -260,19 +262,30 @@ func (b *Backupper) failed() {
 // vertex values.
 func (b *Backupper) apply(ctx context.Context, vertices []*pb.Vertex, edges []*pb.Edge) (Stats, error) {
 	var stats Stats
+	b.svc.BeginSearchIndexRecovery()
 	for i := 0; i < len(vertices); i += restoreChunkSize {
 		end := min(i+restoreChunkSize, len(vertices))
-		if _, err := b.svc.RestoreVertices(ctx, &pb.PutVerticesRequest{Vertices: vertices[i:end]}); err != nil {
+		resp, err := b.svc.RestoreVertices(ctx, &pb.PutVerticesRequest{Vertices: vertices[i:end]})
+		if err != nil {
 			return stats, fmt.Errorf("backup: restore vertices: %w", err)
 		}
-		stats.Vertices += end - i
+		stats.Vertices += int(resp.GetWritten())
 	}
 	for i := 0; i < len(edges); i += restoreChunkSize {
 		end := min(i+restoreChunkSize, len(edges))
-		if _, err := b.svc.PutEdges(ctx, &pb.PutEdgesRequest{Edges: edges[i:end]}); err != nil {
+		resp, err := b.svc.PutEdges(ctx, &pb.PutEdgesRequest{Edges: edges[i:end]})
+		if err != nil {
 			return stats, fmt.Errorf("backup: restore PutEdges: %w", err)
 		}
-		stats.Edges += end - i
+		stats.Edges += int(resp.GetWritten())
+	}
+	if err := b.svc.CompleteSearchIndexRecovery(); err != nil {
+		b.logger.Warn("backup: restored graph but search index remains incomplete",
+			slog.Any("err", err),
+			slog.Int("vertices_attempted", len(vertices)),
+			slog.Int("vertices_written", stats.Vertices),
+			slog.Int("edges_attempted", len(edges)),
+			slog.Int("edges_written", stats.Edges))
 	}
 	return stats, nil
 }

--- a/server/backup/backup_test.go
+++ b/server/backup/backup_test.go
@@ -10,14 +10,21 @@ import (
 
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/server/service"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 // fakeService satisfies the backup Service: BackupSnapshot emits a fixed
 // frame list; PutVertices / PutEdges record what restore replayed.
 type fakeService struct {
-	frames []*pb.BackupSnapshotResponse
-	putV   []*pb.Vertex
-	putE   []*pb.Edge
+	frames             []*pb.BackupSnapshotResponse
+	putV               []*pb.Vertex
+	putE               []*pb.Edge
+	restoreVertexCount func(*pb.PutVerticesRequest) int32
+	restoreEdgeCount   func(*pb.PutEdgesRequest) int32
+	beginRecovery      int
+	completeRecovery   int
+	completeErr        error
 }
 
 func (f *fakeService) BackupSnapshot(_ context.Context, _ *pb.BackupSnapshotRequest, stream service.Sender[pb.BackupSnapshotResponse]) error {
@@ -31,12 +38,26 @@ func (f *fakeService) BackupSnapshot(_ context.Context, _ *pb.BackupSnapshotRequ
 
 func (f *fakeService) RestoreVertices(_ context.Context, req *pb.PutVerticesRequest) (*pb.PutVerticesResponse, error) {
 	f.putV = append(f.putV, req.GetVertices()...)
-	return &pb.PutVerticesResponse{}, nil
+	written := int32(len(req.GetVertices()))
+	if f.restoreVertexCount != nil {
+		written = f.restoreVertexCount(req)
+	}
+	return &pb.PutVerticesResponse{Written: written}, nil
 }
 
 func (f *fakeService) PutEdges(_ context.Context, req *pb.PutEdgesRequest) (*pb.PutEdgesResponse, error) {
 	f.putE = append(f.putE, req.GetEdges()...)
-	return &pb.PutEdgesResponse{}, nil
+	written := int32(len(req.GetEdges()))
+	if f.restoreEdgeCount != nil {
+		written = f.restoreEdgeCount(req)
+	}
+	return &pb.PutEdgesResponse{Written: written}, nil
+}
+
+func (f *fakeService) BeginSearchIndexRecovery() { f.beginRecovery++ }
+func (f *fakeService) CompleteSearchIndexRecovery() error {
+	f.completeRecovery++
+	return f.completeErr
 }
 
 func vFrame(key string) *pb.BackupSnapshotResponse {
@@ -71,6 +92,36 @@ func TestBackupper_RoundTrip(t *testing.T) {
 	}
 	if len(dst.putE) != 1 || dst.putE[0].GetTail() != "a" || dst.putE[0].GetHead() != "b" || dst.putE[0].GetWeight() != 1.5 {
 		t.Fatalf("restored edges = %+v", dst.putE)
+	}
+	if dst.beginRecovery != 1 || dst.completeRecovery != 1 {
+		t.Fatalf("search recovery lifecycle = begin %d complete %d, want 1/1", dst.beginRecovery, dst.completeRecovery)
+	}
+}
+
+func TestBackupper_RestoreCountsActualWrites(t *testing.T) {
+	dir := t.TempDir()
+	src := &fakeService{frames: []*pb.BackupSnapshotResponse{vFrame("live"), vFrame("expired"), eFrame("live", "tail", 1)}}
+	if _, err := New(src, testConfig(dir), nil, nil).backupOnce(context.Background()); err != nil {
+		t.Fatalf("backupOnce: %v", err)
+	}
+	dst := &fakeService{
+		restoreVertexCount: func(*pb.PutVerticesRequest) int32 { return 1 },
+		restoreEdgeCount:   func(*pb.PutEdgesRequest) int32 { return 0 },
+	}
+	reg := prometheus.NewRegistry()
+	b := New(dst, testConfig(dir), reg, nil)
+	stats, err := b.RestoreOnStartup(context.Background())
+	if err != nil {
+		t.Fatalf("RestoreOnStartup: %v", err)
+	}
+	if stats.Vertices != 1 || stats.Edges != 0 {
+		t.Fatalf("actual restore stats = %+v, want {Vertices:1 Edges:0}", stats)
+	}
+	if got := testutil.ToFloat64(b.metrics.restoreVtx); got != 1 {
+		t.Fatalf("lantern_restore_vertices = %v, want 1 actual write", got)
+	}
+	if got := testutil.ToFloat64(b.metrics.restoreEdges); got != 0 {
+		t.Fatalf("lantern_restore_edges = %v, want 0 actual writes", got)
 	}
 }
 

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -225,7 +225,8 @@ func newLanternReplicationService(
 	return service.NewLanternReplicationService(log, backend, clock).
 		WithMetrics(dm).
 		WithLogger(logger).
-		WithOriginStates(svc)
+		WithOriginStates(svc).
+		WithSearchConfig(svc)
 }
 
 func (a *App) Run(ctx context.Context) error {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -67,6 +67,8 @@ type DomainMetrics struct {
 	replicationLag       *prometheus.GaugeVec
 	antiEntropyCycles    prometheus.Counter
 	antiEntropyGapsFound *prometheus.CounterVec
+	searchConfigMatch    *prometheus.GaugeVec
+	searchConfigMismatch *prometheus.CounterVec
 
 	// Replication / mutation-log / back-pressure observability (#221).
 	peerConnected         *prometheus.GaugeVec
@@ -398,6 +400,14 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 			Name: "lantern_anti_entropy_gaps_found_total",
 			Help: "Total anti-entropy ticks that observed a non-zero gap, partitioned by peer address and origin (HLC NodeID, lowercase hex).",
 		}, []string{"peer", "origin"}),
+		searchConfigMatch: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "lantern_search_config_match",
+			Help: "1 when the named peer reports the exact local search capability fingerprint; 0 when missing or mismatched.",
+		}, []string{"peer"}),
+		searchConfigMismatch: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "lantern_search_config_mismatch_total",
+			Help: "Total pump or anti-entropy observations of a missing or mismatched peer search capability fingerprint.",
+		}, []string{"peer"}),
 		illuminateVisitedVertices: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "lantern_illuminate_visited_vertices",
 			Help:    "Vertices in the subgraph returned by Illuminate, partitioned by traversal family (algorithm) + post-traversal reduction + objective + edge weighting (#410, #963).",
@@ -572,6 +582,7 @@ func New(reg prometheus.Registerer, opts Options) *DomainMetrics {
 		m.pubsubQueueDepth, m.pubsubDropped, m.pubsubDispatchDuration,
 		m.replicationApplied, m.replicationDropped, m.replicationLag,
 		m.antiEntropyCycles, m.antiEntropyGapsFound,
+		m.searchConfigMatch, m.searchConfigMismatch,
 		m.illuminateVisitedVertices, m.illuminateVisitedEdges, m.illuminateDuration, m.illuminateCalls,
 		m.scanResults, m.scanDuration, m.batchSize,
 		m.getVertexHits, m.getVertexMisses, m.getEdgeHits, m.getEdgeMisses,
@@ -783,6 +794,20 @@ func (m *DomainMetrics) SetReplicationLag(peer, origin string, lag uint64) {
 // peers).
 func (m *DomainMetrics) OnAntiEntropyCycle() {
 	m.antiEntropyCycles.Inc()
+}
+
+// OnSearchConfig publishes the latest compatibility verdict and counts every
+// mismatch observation. Fingerprints themselves stay in status/logs rather
+// than metric labels to avoid unbounded cardinality.
+func (m *DomainMetrics) OnSearchConfig(peer string, matched bool) {
+	value := 0.0
+	if matched {
+		value = 1
+	}
+	m.searchConfigMatch.WithLabelValues(peer).Set(value)
+	if !matched {
+		m.searchConfigMismatch.WithLabelValues(peer).Inc()
+	}
 }
 
 // OnAntiEntropyGapFound increments

--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -145,6 +145,8 @@ func TestDomainMetrics_ReplicationFamilies(t *testing.T) {
 	m.OnAntiEntropyCycle()
 	m.OnAntiEntropyBehind("peer-a:7000", "aabbccdd", 42)   // gauge=42, gaps=1
 	m.OnAntiEntropyCaughtUp("peer-a:7000", "aabbccdd", 42) // gauge→0
+	m.OnSearchConfig("peer-a:7000", false)
+	m.OnSearchConfig("peer-b:7000", true)
 
 	mfs, err := reg.Gather()
 	if err != nil {
@@ -160,6 +162,8 @@ func TestDomainMetrics_ReplicationFamilies(t *testing.T) {
 		"lantern_replication_lag_seq",
 		"lantern_anti_entropy_cycles_total",
 		"lantern_anti_entropy_gaps_found_total",
+		"lantern_search_config_match",
+		"lantern_search_config_mismatch_total",
 	} {
 		if !names[want] {
 			t.Errorf("metric family %q not registered", want)
@@ -184,6 +188,15 @@ func TestDomainMetrics_ReplicationFamilies(t *testing.T) {
 	// CaughtUp reset the lag back to 0 after the Behind tick set it to 42.
 	if got := testutil.ToFloat64(m.replicationLag.WithLabelValues("peer-a:7000", "aabbccdd")); got != 0 {
 		t.Errorf("replication_lag_seq after CaughtUp = %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(m.searchConfigMatch.WithLabelValues("peer-a:7000")); got != 0 {
+		t.Errorf("search_config_match{peer-a} = %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(m.searchConfigMatch.WithLabelValues("peer-b:7000")); got != 1 {
+		t.Errorf("search_config_match{peer-b} = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.searchConfigMismatch.WithLabelValues("peer-a:7000")); got != 1 {
+		t.Errorf("search_config_mismatch_total{peer-a} = %v, want 1", got)
 	}
 }
 

--- a/server/provider/antientropy.go
+++ b/server/provider/antientropy.go
@@ -64,13 +64,14 @@ func NewAntiEntropyDriver(
 ) *replication.AntiEntropy {
 	_ = pump // forces wire to construct the pump before the driver
 	return replication.NewAntiEntropy(replication.AntiEntropyConfig{
-		NodeID:           rc.NodeID,
-		Peers:            pc.Peers,
-		Interval:         ac.Interval,
-		SubscribeTimeout: ac.SubscribeTimeout,
-		GapWarnThreshold: ac.GapWarnThreshold,
-		Logger:           logger,
-		Metrics:          m,
-		AuthToken:        firstToken(auth.Tokens),
+		NodeID:                  rc.NodeID,
+		Peers:                   pc.Peers,
+		Interval:                ac.Interval,
+		SubscribeTimeout:        ac.SubscribeTimeout,
+		GapWarnThreshold:        ac.GapWarnThreshold,
+		Logger:                  logger,
+		Metrics:                 m,
+		AuthToken:               firstToken(auth.Tokens),
+		SearchConfigFingerprint: svc.SearchConfigFingerprint(),
 	}, svc, svc, cache)
 }

--- a/server/provider/pump.go
+++ b/server/provider/pump.go
@@ -92,14 +92,15 @@ func NewReplicationPump(
 	logger *slog.Logger,
 ) *replication.Pump {
 	cfg := replication.Config{
-		NodeID:            rc.NodeID,
-		Peers:             pc.Peers,
-		BackoffMin:        pc.BackoffMin,
-		BackoffMax:        pc.BackoffMax,
-		Logger:            logger,
-		Metrics:           m,
-		DiscoveryInterval: pc.DiscoveryInterval,
-		AuthToken:         firstToken(ac.Tokens),
+		NodeID:                  rc.NodeID,
+		Peers:                   pc.Peers,
+		BackoffMin:              pc.BackoffMin,
+		BackoffMax:              pc.BackoffMax,
+		Logger:                  logger,
+		Metrics:                 m,
+		DiscoveryInterval:       pc.DiscoveryInterval,
+		AuthToken:               firstToken(ac.Tokens),
+		SearchConfigFingerprint: svc.SearchConfigFingerprint(),
 	}
 	if pc.Discovery == "dns" && pc.DNSName != "" {
 		selfIPs, err := replication.LocalIPSet()

--- a/server/provider/readiness.go
+++ b/server/provider/readiness.go
@@ -78,6 +78,11 @@ func (f *pumpMetricsFanOut) OnPumpSnapshotReplayed(peer string, vertices, edges 
 	f.gate.OnPumpSnapshotReplayed(peer, vertices, edges, duration)
 }
 
+func (f *pumpMetricsFanOut) OnSearchConfig(peer string, matched bool) {
+	f.dm.OnSearchConfig(peer, matched)
+	f.gate.OnSearchConfig(peer, matched)
+}
+
 // antiEntropyMetricsFanOut delegates AntiEntropyMetrics events to both
 // *DomainMetrics and the readiness Gate.
 type antiEntropyMetricsFanOut struct {
@@ -114,4 +119,9 @@ func (f *antiEntropyMetricsFanOut) OnAntiEntropyCaughtUp(peer, origin string, ap
 func (f *antiEntropyMetricsFanOut) OnAntiEntropyError(peer, reason string) {
 	f.dm.OnAntiEntropyError(peer, reason)
 	f.gate.OnAntiEntropyError(peer, reason)
+}
+
+func (f *antiEntropyMetricsFanOut) OnSearchConfig(peer string, matched bool) {
+	f.dm.OnSearchConfig(peer, matched)
+	f.gate.OnSearchConfig(peer, matched)
 }

--- a/server/readiness/gate.go
+++ b/server/readiness/gate.go
@@ -54,6 +54,7 @@ type Gate struct {
 	bootstrapped bool
 	draining     bool
 	lags         map[string]uint64 // key = peer + "\x00" + origin
+	searchConfig map[string]bool   // peer -> fingerprint match
 	current      grpchealth.Status
 
 	// ready is a lock-free mirror of the current status so HTTP probes
@@ -67,11 +68,12 @@ type Gate struct {
 // transitions and may be nil in tests.
 func NewGate(maxLag uint64, hasPeers bool, hs HealthSetter) *Gate {
 	g := &Gate{
-		maxLag:   maxLag,
-		hasPeers: hasPeers,
-		health:   hs,
-		lags:     make(map[string]uint64),
-		current:  grpchealth.StatusNotServing,
+		maxLag:       maxLag,
+		hasPeers:     hasPeers,
+		health:       hs,
+		lags:         make(map[string]uint64),
+		searchConfig: make(map[string]bool),
+		current:      grpchealth.StatusNotServing,
 	}
 	if !hasPeers {
 		// Single-instance: ready immediately. Surface SERVING via the
@@ -145,6 +147,22 @@ func (g *Gate) SetLag(peer, origin string, gap uint64) {
 	g.evaluateLocked()
 }
 
+// SetSearchConfig records whether a peer reports the exact local search
+// capability fingerprint. Any observed mismatch keeps a replicated node out
+// of readiness; single-instance deployments bypass the check.
+func (g *Gate) SetSearchConfig(peer string, matched bool) {
+	if !g.hasPeers {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if previous, ok := g.searchConfig[peer]; ok && previous == matched {
+		return
+	}
+	g.searchConfig[peer] = matched
+	g.evaluateLocked()
+}
+
 // Ready reports the current readiness verdict without taking the lock.
 // Safe to call from HTTP probe handlers on every request.
 func (g *Gate) Ready() bool { return g.ready.Load() }
@@ -163,6 +181,11 @@ func (g *Gate) readyLocked() bool {
 	}
 	for _, v := range g.lags {
 		if v > g.maxLag {
+			return false
+		}
+	}
+	for _, matched := range g.searchConfig {
+		if !matched {
 			return false
 		}
 	}
@@ -208,6 +231,11 @@ func (g *Gate) OnAntiEntropyCaughtUp(peer, origin string, _ uint64) {
 // OnAntiEntropyError is a no-op: transport errors do not by themselves
 // imply staleness — the next successful probe will update lag.
 func (g *Gate) OnAntiEntropyError(string, string) {}
+
+// OnSearchConfig is shared by the pump and anti-entropy metric adapters.
+func (g *Gate) OnSearchConfig(peer string, matched bool) {
+	g.SetSearchConfig(peer, matched)
+}
 
 // --- replication.Metrics (pump) adapter ---
 

--- a/server/readiness/gate_test.go
+++ b/server/readiness/gate_test.go
@@ -104,6 +104,17 @@ func TestGate_PumpAndAntiEntropyAdapters(t *testing.T) {
 		t.Fatalf("expected SERVING after first OnPumpConnect with no lag rows")
 	}
 
+	// A heterogeneous search contract is a hard readiness failure even when
+	// mutation watermarks are caught up.
+	g.OnSearchConfig("peer-a", false)
+	if g.Ready() {
+		t.Fatal("expected NOT_SERVING after search config mismatch")
+	}
+	g.OnSearchConfig("peer-a", true)
+	if !g.Ready() {
+		t.Fatal("expected SERVING after search config match")
+	}
+
 	// AntiEntropy Behind beyond threshold should flip NOT_SERVING.
 	g.OnAntiEntropyBehind("peer-a", "origin-a", 11)
 	if g.Ready() {

--- a/server/replication/antientropy.go
+++ b/server/replication/antientropy.go
@@ -17,9 +17,10 @@ package replication
 // only case anti-entropy can repair via this peer — remote-origin
 // gaps must be healed by talking to the originating node, which is
 // outside the scope of one peer's mutation log), the driver opens
-// a bounded Subscribe(from_seq = local_for_peer + 1) and applies
+// a bounded Subscribe(from_seq_per_origin = local_for_peer + 1) and applies
 // up to the peer-reported target seq. FailedPrecondition triggers
-// a Snapshot replay, after which Subscribe resumes at cutoff+1.
+// a Snapshot replay; later ticks retain that responder's local cutoff so
+// Subscribe can resume the live tail without re-requesting an evicted prefix.
 //
 // LANTERN_ANTI_ENTROPY_INTERVAL controls the tick cadence. The
 // default 30s is a deliberate compromise: short enough that a
@@ -67,6 +68,7 @@ type AntiEntropyMetrics interface {
 	OnAntiEntropyBehind(peer, origin string, gap uint64)
 	OnAntiEntropyCaughtUp(peer, origin string, applied uint64)
 	OnAntiEntropyError(peer, reason string)
+	OnSearchConfig(peer string, matched bool)
 }
 
 type nopAntiEntropyMetrics struct{}
@@ -76,6 +78,7 @@ func (nopAntiEntropyMetrics) OnAntiEntropyTick(string)                     {}
 func (nopAntiEntropyMetrics) OnAntiEntropyBehind(string, string, uint64)   {}
 func (nopAntiEntropyMetrics) OnAntiEntropyCaughtUp(string, string, uint64) {}
 func (nopAntiEntropyMetrics) OnAntiEntropyError(string, string)            {}
+func (nopAntiEntropyMetrics) OnSearchConfig(string, bool)                  {}
 
 // AntiEntropyConfig groups the driver's inputs. All fields except
 // Peers / Interval are optional; NewAntiEntropy fills defaults.
@@ -113,6 +116,11 @@ type AntiEntropyConfig struct {
 	// peers running with LANTERN_AUTH_TOKENS (#850).
 	AuthToken string
 
+	// SearchConfigFingerprint is compared with every PeerStatus response.
+	// Empty disables the comparison for narrow unit-test wiring; production
+	// always supplies the LanternService fingerprint.
+	SearchConfigFingerprint string
+
 	// HTTPClient is the http.Client used to open Connect-Go streams
 	// against each peer. Defaults to defaultH2CClient() (plaintext
 	// HTTP/2 for the in-cluster HA topology).
@@ -131,10 +139,12 @@ type AntiEntropyConfig struct {
 // is 0), so it is meant to run alongside the Connect listener and
 // pump in an errgroup.
 type AntiEntropy struct {
-	cfg   AntiEntropyConfig
-	local LocalStateProvider
-	apply MutationApplier
-	snap  SnapshotApplier
+	cfg         AntiEntropyConfig
+	local       LocalStateProvider
+	apply       MutationApplier
+	snap        SnapshotApplier
+	resumeMu    sync.Mutex
+	resumeLocal map[string]uint64
 }
 
 // NewAntiEntropy constructs the driver. local MUST be the same
@@ -158,7 +168,10 @@ func NewAntiEntropy(cfg AntiEntropyConfig, local LocalStateProvider, apply Mutat
 		cfg.HTTPClient = defaultH2CClient()
 	}
 	cfg.HTTPClient = withAuthToken(cfg.HTTPClient, cfg.AuthToken)
-	return &AntiEntropy{cfg: cfg, local: local, apply: apply, snap: snap}
+	return &AntiEntropy{
+		cfg: cfg, local: local, apply: apply, snap: snap,
+		resumeLocal: make(map[string]uint64),
+	}
 }
 
 // Run starts the periodic tick loop and blocks until ctx is
@@ -222,6 +235,16 @@ func (a *AntiEntropy) tickPeer(ctx context.Context, addr string) {
 		return
 	}
 	msg := resp.Msg
+	if a.cfg.SearchConfigFingerprint != "" {
+		remote := msg.GetSearchConfigFingerprint()
+		matched := remote != "" && remote == a.cfg.SearchConfigFingerprint
+		a.cfg.Metrics.OnSearchConfig(addr, matched)
+		if !matched {
+			log.Error("anti-entropy: search config mismatch",
+				slog.String("local_fingerprint", a.cfg.SearchConfigFingerprint),
+				slog.String("peer_fingerprint", remote))
+		}
+	}
 	if len(msg.GetSelfOrigin()) == 0 {
 		// Peer cannot identify itself — older binary or
 		// replication unwired on the peer side. Nothing to do.
@@ -283,7 +306,7 @@ func (a *AntiEntropy) tickPeer(ctx context.Context, addr string) {
 			slog.Uint64("threshold", a.cfg.GapWarnThreshold))
 	}
 
-	applied, err := a.catchUp(ctx, cli, peerNID, localSeq+1, target)
+	applied, err := a.catchUp(ctx, addr, cli, peerNID, localSeq+1, target)
 	if err != nil {
 		log.Warn("anti-entropy: catch-up failed",
 			slog.Any("err", err), slog.Uint64("applied", applied))
@@ -310,15 +333,18 @@ func (a *AntiEntropy) tickPeer(ctx context.Context, addr string) {
 // drop anyway.
 //
 // Returns the number of mutations applied during this call.
-func (a *AntiEntropy) catchUp(ctx context.Context, cli graphv1connect.LanternReplicationServiceClient, peerNID hlc.NodeID, fromSeq, target uint64) (uint64, error) {
+func (a *AntiEntropy) catchUp(ctx context.Context, addr string, cli graphv1connect.LanternReplicationServiceClient, peerNID hlc.NodeID, fromSeq, target uint64) (uint64, error) {
 	tctx, cancel := context.WithTimeout(ctx, a.cfg.SubscribeTimeout)
 	defer cancel()
 
 	cursor := map[string]uint64{hex.EncodeToString(peerNID[:]): fromSeq}
-	stream, err := cli.Subscribe(tctx, connect.NewRequest(&pb.SubscribeRequest{FromSeqPerOrigin: cursor}))
+	stream, err := cli.Subscribe(tctx, connect.NewRequest(&pb.SubscribeRequest{
+		FromSeqPerOrigin: cursor,
+		FromLocalSeq:     a.snapshotResumeLocal(addr),
+	}))
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodeFailedPrecondition {
-			return 0, a.snapshotFrom(ctx, cli)
+			return 0, a.snapshotFrom(ctx, addr, cli)
 		}
 		return 0, err
 	}
@@ -350,7 +376,7 @@ func (a *AntiEntropy) catchUp(ctx context.Context, cli graphv1connect.LanternRep
 		return applied, nil
 	}
 	if connect.CodeOf(recvErr) == connect.CodeFailedPrecondition {
-		return applied, a.snapshotFrom(ctx, cli)
+		return applied, a.snapshotFrom(ctx, addr, cli)
 	}
 	// Deadline-exceeded from the subscribe timeout is expected
 	// when the catch-up window is shorter than the gap — surface as
@@ -366,17 +392,23 @@ func (a *AntiEntropy) catchUp(ctx context.Context, cli graphv1connect.LanternRep
 // cache. Triggered by FailedPrecondition on Subscribe. After this
 // returns, the next anti-entropy tick will re-probe PeerStatus and
 // resume normal catch-up.
-func (a *AntiEntropy) snapshotFrom(ctx context.Context, cli graphv1connect.LanternReplicationServiceClient) error {
+func (a *AntiEntropy) snapshotFrom(ctx context.Context, addr string, cli graphv1connect.LanternReplicationServiceClient) error {
 	stream, err := cli.Snapshot(ctx, connect.NewRequest(&pb.SnapshotRequest{}))
 	if err != nil {
 		return err
 	}
 	defer func() { _ = stream.Close() }()
+	var recovery searchIndexRecovery
+	if candidate, ok := a.snap.(searchIndexRecovery); ok {
+		recovery = candidate
+		recovery.BeginSearchIndexRecovery()
+	}
+	var header *pb.SnapshotHeader
 	for stream.Receive() {
 		resp := stream.Msg()
 		switch e := resp.GetEntry().(type) {
 		case *pb.SnapshotResponse_Header:
-			// nothing to apply
+			header = e.Header
 		case *pb.SnapshotResponse_Vertex:
 			sv := e.Vertex
 			v := sv.GetVertex()
@@ -406,5 +438,28 @@ func (a *AntiEntropy) snapshotFrom(ctx context.Context, cli graphv1connect.Lante
 	if err := stream.Err(); err != nil && !errors.Is(err, io.EOF) {
 		return err
 	}
+	if recovery != nil {
+		if err := recovery.CompleteSearchIndexRecovery(); err != nil {
+			a.cfg.Logger.Warn("anti-entropy: snapshot rebuilt graph but search index remains incomplete",
+				slog.Any("err", err))
+		}
+	}
+	if marks, ok := a.apply.(snapshotWatermarkApplier); ok && header != nil {
+		if err := marks.ApplySnapshotWatermarks(header.GetCutoffSeqPerOrigin(), snapshotHLC(header.GetCutoffHlc())); err != nil {
+			return err
+		}
+	}
+	if header != nil {
+		resume := resumeAfterSnapshot(header)
+		a.resumeMu.Lock()
+		a.resumeLocal[addr] = resume.local
+		a.resumeMu.Unlock()
+	}
 	return nil
+}
+
+func (a *AntiEntropy) snapshotResumeLocal(addr string) uint64 {
+	a.resumeMu.Lock()
+	defer a.resumeMu.Unlock()
+	return a.resumeLocal[addr]
 }

--- a/server/replication/pump.go
+++ b/server/replication/pump.go
@@ -4,25 +4,25 @@
 // goroutine maintains a long-lived Connect-Go HTTP/2 stream to its peer
 // and, in order:
 //
-//  1. Opens LanternReplicationService.Subscribe(from_seq=N), where N is
-//     the next seq the local node expects from THAT peer (tracked
-//     per-peer across reconnects, starts at 0 on first connect).
+//  1. Verifies PeerStatus search-config compatibility, then opens
+//     LanternReplicationService.Subscribe with an empty portable cursor.
 //  2. If the server replies codes.FailedPrecondition (reason "gapped" —
 //     the canonical bootstrap signal from #180), opens
 //     LanternReplicationService.Snapshot, replays the Header→Vertex→Edge
-//     frames into the local cache, then resumes Subscribe at
-//     header.cutoff_seq + 1.
+//     frames into the local cache, then resumes against the same responder at
+//     both header origin cutoffs + 1 and header.cutoff_local_seq + 1.
 //  3. Applies every received Mutation via the local MutationApplier
-//     (LanternService.ApplyMutation, which bypasses the local mutation
-//     log so replayed writes are NOT re-broadcast).
+//     (LanternService.ApplyMutation). Reading B appends a newly-observed remote
+//     mutation to the local log so any replica can serve the full cluster
+//     stream; the per-origin watermark prevents relay loops.
 //  4. On any other error (connection drop, peer crash, transient
 //     Unavailable) the goroutine reconnects with exponential backoff
 //     capped at BackoffMax.
 //
 // Self-echo suppression: a Mutation whose Origin == local NodeID is
 // dropped on receipt. The replication design is symmetric — every peer
-// streams its OWN appended mutations to every subscriber, so receivers
-// must filter their own writes back out.
+// log carries entries from every cluster origin, so receivers must filter
+// their own writes back out.
 //
 // LANTERN_PEERS="" (the default) yields a no-op pump: Run returns
 // immediately and no goroutines are spawned. This is single-instance
@@ -33,6 +33,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -65,6 +66,15 @@ type SnapshotApplier interface {
 	PutEdgeWithExpirationHLC(tail, head string, w float32, exp time.Time, ts hlc.Timestamp) bool
 }
 
+type searchIndexRecovery interface {
+	BeginSearchIndexRecovery()
+	CompleteSearchIndexRecovery() error
+}
+
+type snapshotWatermarkApplier interface {
+	ApplySnapshotWatermarks(cutoffs map[string]uint64, ts hlc.Timestamp) error
+}
+
 // applySnapshotEdge re-applies one snapshot edge contribution into the local
 // cache via snap. A Put-origin (LWW-Register) contribution carries a zero
 // ContribID: re-applying it through AddEdgeWithExpirationContribHLC hits the
@@ -94,6 +104,7 @@ type Metrics interface {
 	OnPumpApply(peer string)
 	OnPumpDropSelfEcho(peer string)
 	OnPumpSnapshotReplayed(peer string, vertices, edges uint64, duration time.Duration)
+	OnSearchConfig(peer string, matched bool)
 }
 
 type nopMetrics struct{}
@@ -103,6 +114,7 @@ func (nopMetrics) OnPumpDisconnect(string, string)                              
 func (nopMetrics) OnPumpApply(string)                                           {}
 func (nopMetrics) OnPumpDropSelfEcho(string)                                    {}
 func (nopMetrics) OnPumpSnapshotReplayed(string, uint64, uint64, time.Duration) {}
+func (nopMetrics) OnSearchConfig(string, bool)                                  {}
 
 // Config groups the inputs every Pump goroutine needs. All fields
 // except Peers are required to be valid; NewPump fills sensible
@@ -143,6 +155,12 @@ type Config struct {
 	// against peers running with LANTERN_AUTH_TOKENS (#850).
 	AuthToken string
 
+	// SearchConfigFingerprint is the local search capability fingerprint.
+	// When non-empty, every peer session verifies PeerStatus before opening
+	// Subscribe. A mismatch does not block graph replication, but readiness
+	// and metrics remain degraded until every observed peer matches.
+	SearchConfigFingerprint string
+
 	// HTTPClient is the http.Client used to open Connect-Go streams
 	// against each peer. When nil, defaultH2CClient() is used so the
 	// pump talks plain HTTP/2 over the cluster network — sufficient
@@ -177,6 +195,7 @@ type Pump struct {
 	cfg     Config
 	apply   MutationApplier
 	snap    SnapshotApplier
+	marks   snapshotWatermarkApplier
 	tracker *peerTracker
 }
 
@@ -201,7 +220,11 @@ func NewPump(cfg Config, apply MutationApplier, snap SnapshotApplier) *Pump {
 		cfg.HTTPClient = defaultH2CClient()
 	}
 	cfg.HTTPClient = withAuthToken(cfg.HTTPClient, cfg.AuthToken)
-	return &Pump{cfg: cfg, apply: apply, snap: snap, tracker: newPeerTracker()}
+	pump := &Pump{cfg: cfg, apply: apply, snap: snap, tracker: newPeerTracker()}
+	if marks, ok := apply.(snapshotWatermarkApplier); ok {
+		pump.marks = marks
+	}
+	return pump
 }
 
 // Run starts one goroutine per peer and blocks until ctx is
@@ -278,13 +301,12 @@ func (p *Pump) Run(ctx context.Context) error {
 // the loop sleeps for the current backoff (doubling, capped at
 // BackoffMax) and retries until ctx is cancelled.
 //
-// Under the leaderless Subscribe contract (#415, B-2/B-3/B-4) the
-// pump no longer tracks per-peer next-seq state across reconnects:
-// every Subscribe sends an empty per-origin cursor and the local
-// ApplyMutation watermark CAS dedups anything we have already seen
-// via this peer or any other. This trades one full-range scan per
-// reconnect (bounded by the mutation log ring capacity) for a much
-// simpler reconnect path that holds zero authoritative state.
+// Under the leaderless Subscribe contract (#415, B-2/B-3/B-4), ordinary
+// reconnects send an empty per-origin cursor and the local ApplyMutation
+// watermark CAS dedups anything already seen via this peer or any other.
+// A gapped session is different: after replaying a snapshot, the pump resumes
+// from the snapshot header's cutoff so it does not request the same unavailable
+// log prefix again.
 func (p *Pump) runPeer(ctx context.Context, addr string) {
 	log := p.cfg.Logger.With(slog.String("peer", addr))
 	defer p.tracker.removePeer(addr)
@@ -335,12 +357,26 @@ func (p *Pump) session(ctx context.Context, addr string) error {
 	cli := graphv1connect.NewLanternReplicationServiceClient(
 		p.cfg.HTTPClient, peerBaseURL(addr),
 	)
+	if p.cfg.SearchConfigFingerprint != "" {
+		status, err := cli.PeerStatus(ctx, connect.NewRequest(&pb.PeerStatusRequest{}))
+		if err != nil {
+			return fmt.Errorf("peer search-config status: %w", err)
+		}
+		remote := status.Msg.GetSearchConfigFingerprint()
+		matched := remote != "" && remote == p.cfg.SearchConfigFingerprint
+		p.cfg.Metrics.OnSearchConfig(addr, matched)
+		if !matched {
+			log.Error("replication pump: search config mismatch",
+				slog.String("local_fingerprint", p.cfg.SearchConfigFingerprint),
+				slog.String("peer_fingerprint", remote))
+		}
+	}
 
 	p.cfg.Metrics.OnPumpConnect(addr)
 	log.Info("replication pump: peer transition",
 		slog.String("transition", "connect"))
 
-	err := p.subscribe(ctx, cli, addr)
+	err := p.subscribe(ctx, cli, addr, nil, 0)
 	if err == nil {
 		p.cfg.Metrics.OnPumpDisconnect(addr, "clean")
 		log.Info("replication pump: peer transition",
@@ -356,15 +392,14 @@ func (p *Pump) session(ctx context.Context, addr string) error {
 		return nil
 	}
 	if connect.CodeOf(err) == connect.CodeFailedPrecondition {
-		// gapped: snapshot, then resume Subscribe with an empty
-		// cursor again. The local ApplyMutation watermark CAS
-		// (#415, B-3) dedups any entries the snapshot already
-		// covered, so we do not need to thread cutoff_seq_per_origin
-		// through to the Subscribe call.
+		// Gapped: snapshot, then resume after the snapshot cutoffs. Sending
+		// an empty cursor here would request the unavailable log prefix again
+		// and loop through snapshots indefinitely.
 		log.Info("replication pump: peer transition",
 			slog.String("transition", "snapshot_start"),
 			slog.String("reason", "gapped"))
-		if sErr := p.snapshot(ctx, cli, addr); sErr != nil {
+		header, sErr := p.snapshot(ctx, cli, addr)
+		if sErr != nil {
 			p.cfg.Metrics.OnPumpDisconnect(addr, "snapshot_failed")
 			log.Warn("replication pump: peer transition",
 				slog.String("transition", "snapshot_finish"),
@@ -375,7 +410,8 @@ func (p *Pump) session(ctx context.Context, addr string) error {
 		log.Info("replication pump: peer transition",
 			slog.String("transition", "snapshot_finish"),
 			slog.String("reason", "applied"))
-		err = p.subscribe(ctx, cli, addr)
+		resume := resumeAfterSnapshot(header)
+		err = p.subscribe(ctx, cli, addr, resume.origins, resume.local)
 		if err == nil {
 			p.cfg.Metrics.OnPumpDisconnect(addr, "clean")
 			log.Info("replication pump: peer transition",
@@ -397,16 +433,17 @@ func (p *Pump) session(ctx context.Context, addr string) error {
 // Returns any error from Receive / Apply; a clean stream end
 // returns nil.
 //
-// Under the leaderless Subscribe contract (#415) the peer's local
-// log carries mutations from every cluster origin, not just the
-// peer's own writes. The pump intentionally sends an empty cursor
-// (= deliver every retained entry) and relies on the per-origin
-// watermark CAS inside LanternService.ApplyMutation to dedup
-// entries it has already seen via another peer hop. This keeps the
-// reconnect path simple at the price of one full-range scan per
-// reconnect, bounded by the mutation log ring capacity.
-func (p *Pump) subscribe(ctx context.Context, cli graphv1connect.LanternReplicationServiceClient, addr string) error {
-	stream, err := cli.Subscribe(ctx, connect.NewRequest(&pb.SubscribeRequest{}))
+// Under the leaderless Subscribe contract (#415), the peer's local log carries
+// mutations from every cluster origin, not just the peer's own writes. Ordinary
+// reconnects pass an empty cursor (= deliver every retained entry) and rely on
+// LanternService.ApplyMutation's per-origin watermark CAS for deduplication.
+// Snapshot recovery instead passes the header-derived cursor supplied by the
+// caller so the live tail starts after the point-in-time cut.
+func (p *Pump) subscribe(ctx context.Context, cli graphv1connect.LanternReplicationServiceClient, addr string, cursor map[string]uint64, fromLocalSeq uint64) error {
+	stream, err := cli.Subscribe(ctx, connect.NewRequest(&pb.SubscribeRequest{
+		FromSeqPerOrigin: cursor,
+		FromLocalSeq:     fromLocalSeq,
+	}))
 	if err != nil {
 		return err
 	}
@@ -438,20 +475,24 @@ func (p *Pump) subscribe(ctx context.Context, cli graphv1connect.LanternReplicat
 // Returns nil on a clean (header + payload + footer) stream, or any
 // receive / apply error.
 //
-// The header's cutoff_seq_per_origin and cutoff_hlc are intentionally
-// not propagated outwards: the next Subscribe call sends an empty
-// cursor and relies on the local per-origin watermark CAS to dedup
-// any entries that the snapshot already covered, so the pump does not
-// need to thread the cutoff through to the resume call.
-func (p *Pump) snapshot(ctx context.Context, cli graphv1connect.LanternReplicationServiceClient, addr string) error {
+// The returned header supplies the exact per-origin resume cursor and local
+// watermark cut for the live tail. Replaying those cutoffs before Subscribe
+// prevents both duplicate application and an infinite gapped-snapshot loop.
+func (p *Pump) snapshot(ctx context.Context, cli graphv1connect.LanternReplicationServiceClient, addr string) (*pb.SnapshotHeader, error) {
 	stream, err := cli.Snapshot(ctx, connect.NewRequest(&pb.SnapshotRequest{}))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer func() { _ = stream.Close() }()
+	var recovery searchIndexRecovery
+	if candidate, ok := p.snap.(searchIndexRecovery); ok {
+		recovery = candidate
+		recovery.BeginSearchIndexRecovery()
+	}
 	start := time.Now()
 	var (
 		gotHeader    bool
+		header       *pb.SnapshotHeader
 		vertexCount  uint64
 		edgeCount    uint64
 		sawFooter    bool
@@ -462,15 +503,16 @@ func (p *Pump) snapshot(ctx context.Context, cli graphv1connect.LanternReplicati
 		switch e := resp.GetEntry().(type) {
 		case *pb.SnapshotResponse_Header:
 			if gotHeader {
-				return connect.NewError(connect.CodeInternal, errors.New("snapshot: duplicate header frame"))
+				return nil, connect.NewError(connect.CodeInternal, errors.New("snapshot: duplicate header frame"))
 			}
 			gotHeader = true
+			header = e.Header
 		case *pb.SnapshotResponse_Vertex:
 			if !gotHeader {
-				return connect.NewError(connect.CodeInternal, errors.New("snapshot: vertex frame before header"))
+				return nil, connect.NewError(connect.CodeInternal, errors.New("snapshot: vertex frame before header"))
 			}
 			if sawFooter {
-				return connect.NewError(connect.CodeInternal, errors.New("snapshot: vertex frame after footer"))
+				return nil, connect.NewError(connect.CodeInternal, errors.New("snapshot: vertex frame after footer"))
 			}
 			sv := e.Vertex
 			v := sv.GetVertex()
@@ -483,10 +525,10 @@ func (p *Pump) snapshot(ctx context.Context, cli graphv1connect.LanternReplicati
 			}
 		case *pb.SnapshotResponse_Edge:
 			if !gotHeader {
-				return connect.NewError(connect.CodeInternal, errors.New("snapshot: edge frame before header"))
+				return nil, connect.NewError(connect.CodeInternal, errors.New("snapshot: edge frame before header"))
 			}
 			if sawFooter {
-				return connect.NewError(connect.CodeInternal, errors.New("snapshot: edge frame after footer"))
+				return nil, connect.NewError(connect.CodeInternal, errors.New("snapshot: edge frame after footer"))
 			}
 			se := e.Edge
 			edgeHLC := snapshotHLC(se.GetHlc())
@@ -506,13 +548,13 @@ func (p *Pump) snapshot(ctx context.Context, cli graphv1connect.LanternReplicati
 		}
 	}
 	if err := stream.Err(); err != nil && !errors.Is(err, io.EOF) {
-		return err
+		return nil, err
 	}
 	if !gotHeader {
-		return connect.NewError(connect.CodeInternal, errors.New("snapshot: stream ended before header"))
+		return nil, connect.NewError(connect.CodeInternal, errors.New("snapshot: stream ended before header"))
 	}
 	if !sawFooter {
-		return connect.NewError(connect.CodeInternal, errors.New("snapshot: stream ended before footer"))
+		return nil, connect.NewError(connect.CodeInternal, errors.New("snapshot: stream ended before footer"))
 	}
 	if footerCounts.v != vertexCount || footerCounts.e != edgeCount {
 		// Count mismatch is a soft warning, not a hard error — the
@@ -525,8 +567,46 @@ func (p *Pump) snapshot(ctx context.Context, cli graphv1connect.LanternReplicati
 			slog.Uint64("edges_applied", edgeCount),
 			slog.Uint64("edges_footer", footerCounts.e))
 	}
+	if recovery != nil {
+		if err := recovery.CompleteSearchIndexRecovery(); err != nil {
+			p.cfg.Logger.Warn("replication pump: snapshot rebuilt graph but search index remains incomplete",
+				slog.String("peer", addr), slog.Any("err", err))
+		}
+	}
+	if p.marks != nil {
+		if err := p.marks.ApplySnapshotWatermarks(header.GetCutoffSeqPerOrigin(), snapshotHLC(header.GetCutoffHlc())); err != nil {
+			return nil, err
+		}
+	}
 	p.cfg.Metrics.OnPumpSnapshotReplayed(addr, vertexCount, edgeCount, time.Since(start))
-	return nil
+	return header, nil
+}
+
+type snapshotResumeCursor struct {
+	origins map[string]uint64
+	local   uint64
+}
+
+func resumeAfterSnapshot(header *pb.SnapshotHeader) snapshotResumeCursor {
+	if header == nil {
+		return snapshotResumeCursor{}
+	}
+	resume := snapshotResumeCursor{
+		origins: make(map[string]uint64, len(header.GetCutoffSeqPerOrigin())),
+	}
+	for origin, cutoff := range header.GetCutoffSeqPerOrigin() {
+		if cutoff == ^uint64(0) {
+			resume.origins[origin] = cutoff
+			continue
+		}
+		resume.origins[origin] = cutoff + 1
+	}
+	if cutoff := header.GetCutoffLocalSeq(); cutoff == ^uint64(0) {
+		resume.local = cutoff
+	} else {
+		resume.local = cutoff + 1
+	}
+	return resume
 }
 
 // isSelfEcho returns true when mu was originated by the local node.

--- a/server/replication/pump_test.go
+++ b/server/replication/pump_test.go
@@ -119,3 +119,33 @@ func TestApplySnapshotEdgeIdempotent(t *testing.T) {
 		}
 	})
 }
+
+func TestResumeAfterSnapshot(t *testing.T) {
+	t.Run("empty header has no cursor", func(t *testing.T) {
+		if got := resumeAfterSnapshot(nil); got.origins != nil || got.local != 0 {
+			t.Fatalf("resumeAfterSnapshot(nil) = %+v, want zero cursor", got)
+		}
+	})
+
+	t.Run("cutoffs advance to the next origin sequence", func(t *testing.T) {
+		header := &pb.SnapshotHeader{
+			CutoffSeqPerOrigin: map[string]uint64{"origin-a": 7, "origin-b": 12},
+			CutoffLocalSeq:     20,
+		}
+		got := resumeAfterSnapshot(header)
+		if got.origins["origin-a"] != 8 || got.origins["origin-b"] != 13 || got.local != 21 {
+			t.Fatalf("resume cursor = %+v, want origin-a=8 origin-b=13 local=21", got)
+		}
+	})
+
+	t.Run("maximum cutoff does not wrap", func(t *testing.T) {
+		header := &pb.SnapshotHeader{
+			CutoffSeqPerOrigin: map[string]uint64{"origin-max": ^uint64(0)},
+			CutoffLocalSeq:     ^uint64(0),
+		}
+		got := resumeAfterSnapshot(header)
+		if got.origins["origin-max"] != ^uint64(0) || got.local != ^uint64(0) {
+			t.Fatalf("maximum cutoffs resumed at %+v, want no wrap", got)
+		}
+	})
+}

--- a/server/service/replication.go
+++ b/server/service/replication.go
@@ -54,6 +54,13 @@ type OriginStatesProvider interface {
 	OriginStates() []OriginState
 }
 
+// SearchConfigFingerprintProvider supplies the search contract carried by
+// PeerStatus. *LanternService satisfies it with the same fingerprint exposed
+// through GetServerStatus.
+type SearchConfigFingerprintProvider interface {
+	SearchConfigFingerprint() string
+}
+
 // LanternReplicationService is the in-process implementation of the
 // graph.v1.LanternReplicationService surface. It exposes the
 // mutation log as a resumable, back-pressured server-streaming RPC
@@ -69,6 +76,7 @@ type LanternReplicationService struct {
 	metrics SubscribeMetrics
 	logger  *slog.Logger
 	origins OriginStatesProvider
+	search  SearchConfigFingerprintProvider
 }
 
 // NewLanternReplicationService constructs the service. log MUST be the same
@@ -113,6 +121,14 @@ func (s *LanternReplicationService) WithOriginStates(p OriginStatesProvider) *La
 	return s
 }
 
+// WithSearchConfig wires the search fingerprint published by PeerStatus.
+// Nil leaves the field empty, which callers must treat as unverified rather
+// than compatible.
+func (s *LanternReplicationService) WithSearchConfig(p SearchConfigFingerprintProvider) *LanternReplicationService {
+	s.search = p
+	return s
+}
+
 // Subscribe streams every mutation log entry whose (origin, seq)
 // satisfies the per-origin resume cursor in req.FromSeqPerOrigin to
 // the supplied Sender, honouring ctx cancellation throughout.
@@ -125,9 +141,10 @@ func (s *LanternReplicationService) WithOriginStates(p OriginStatesProvider) *La
 // does not require deduplication or seq remapping.
 //
 // Flow:
-//  1. Open a log subscription at seq 1 so the dispatcher hands us
-//     every retained entry. Per-origin filtering happens entirely at
-//     this layer — the log itself is origin-agnostic.
+//  1. Open a log subscription at req.FromLocalSeq when a snapshot consumer
+//     resumes against the same responder; otherwise start at local seq 1 so
+//     ring eviction remains a detectable gap. Per-origin sequence is unrelated
+//     to this replica-local position and filtering happens at this layer.
 //  2. For each entry, filter by the per-origin cursor: deliver only
 //     when mu.Seq >= cursor[origin]. Origins absent from the cursor
 //     are delivered from the oldest retained entry — this lets a
@@ -136,8 +153,8 @@ func (s *LanternReplicationService) WithOriginStates(p OriginStatesProvider) *La
 //     mu.Seq carries the originating writer's seq (stamped at
 //     logMutation / preserved across relay), NOT the forwarding
 //     replica's local log seq.
-//  3. ErrGapped from the log layer (the log was truncated below seq
-//     1, which only happens if the ring evicted entries) surfaces as
+//  3. ErrGapped from the log layer (the ring was truncated below the
+//     requested local position) surfaces as
 //     FailedPrecondition + reason "gapped" so the client knows to
 //     snapshot and resubscribe (RFC §8.2).
 //  4. If the channel is closed mid-stream the subscriber fell behind
@@ -152,12 +169,16 @@ func (s *LanternReplicationService) Subscribe(ctx context.Context, req *pb.Subsc
 		return connect.NewError(connect.CodeUnavailable, errors.New("replication is not enabled on this server"))
 	}
 	cursor := req.GetFromSeqPerOrigin()
-	ch, cancel, err := s.log.Subscribe(1)
+	fromLocalSeq := req.GetFromLocalSeq()
+	if fromLocalSeq == 0 {
+		fromLocalSeq = 1
+	}
+	ch, cancel, err := s.log.Subscribe(fromLocalSeq)
 	if err != nil {
 		if errors.Is(err, mutationlog.ErrGapped) {
 			s.metrics.OnSubscribeDropped("gapped")
 			return connect.NewError(connect.CodeFailedPrecondition,
-				errors.New("gapped: log truncated below seq 1; snapshot and resubscribe"))
+				fmt.Errorf("gapped: log truncated below requested local seq %d; snapshot and resubscribe", fromLocalSeq))
 		}
 		return connect.NewError(connect.CodeUnavailable, fmt.Errorf("subscribe failed: %w", err))
 	}
@@ -259,11 +280,16 @@ func (s *LanternReplicationService) Snapshot(ctx context.Context, _ *pb.Snapshot
 	if s.clock != nil {
 		cutoffHLC = s.clock.Now()
 	}
+	var cutoffLocalSeq uint64
+	if s.log != nil {
+		cutoffLocalSeq, _ = s.log.LastSeq()
+	}
 	header := &pb.SnapshotResponse{
 		Entry: &pb.SnapshotResponse_Header{
 			Header: &pb.SnapshotHeader{
 				CutoffSeqPerOrigin: cutoffPerOrigin,
 				CutoffHlc:          hlcToProto(cutoffHLC),
+				CutoffLocalSeq:     cutoffLocalSeq,
 			},
 		},
 	}
@@ -352,6 +378,9 @@ func (s *LanternReplicationService) PeerStatus(ctx context.Context, _ *pb.PeerSt
 	}
 	rows := s.origins.OriginStates()
 	out := &pb.PeerStatusResponse{Origins: make([]*pb.OriginState, 0, len(rows))}
+	if s.search != nil {
+		out.SearchConfigFingerprint = s.search.SearchConfigFingerprint()
+	}
 	if s.clock != nil {
 		nid := s.clock.NodeID()
 		out.SelfOrigin = append([]byte(nil), nid[:]...)

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -473,6 +474,34 @@ func (s *LanternService) LocalSeq(origin hlc.NodeID) uint64 {
 	return s.origins.LocalSeq(origin)
 }
 
+// ApplySnapshotWatermarks advances the per-origin dedup table to a completed
+// snapshot's cutoff. This lets the next Subscribe resume at cutoff+1 instead
+// of repeatedly falling back to the same snapshot, and makes PeerStatus
+// truthful immediately after bootstrap.
+func (s *LanternService) ApplySnapshotWatermarks(cutoffs map[string]uint64, ts hlc.Timestamp) error {
+	if s.origins == nil {
+		return nil
+	}
+	type cutoff struct {
+		origin hlc.NodeID
+		seq    uint64
+	}
+	validated := make([]cutoff, 0, len(cutoffs))
+	for encoded, seq := range cutoffs {
+		decoded, err := hex.DecodeString(encoded)
+		if err != nil || len(decoded) != len(hlc.NodeID{}) {
+			return fmt.Errorf("snapshot cutoff origin %q is not a 16-byte hex NodeID", encoded)
+		}
+		var origin hlc.NodeID
+		copy(origin[:], decoded)
+		validated = append(validated, cutoff{origin: origin, seq: seq})
+	}
+	for _, item := range validated {
+		s.origins.Record(item.origin, item.seq, ts)
+	}
+	return nil
+}
+
 // OriginStatesCount returns the number of distinct origins currently
 // recorded in the per-origin watermark table, or 0 when the tracker is
 // unwired. Used by provider/metrics to sample lantern_origin_states_count.
@@ -481,6 +510,30 @@ func (s *LanternService) OriginStatesCount() int {
 		return 0
 	}
 	return s.origins.OriginCount()
+}
+
+type searchIndexRecoveryBackend interface {
+	BeginSearchIndexRecovery()
+	CompleteSearchIndexRecovery() error
+}
+
+// BeginSearchIndexRecovery marks an optional derived index incomplete before
+// snapshot or restore bulk replay. Backends without search support remain a
+// no-op so the service's narrow fake seams stay source-compatible.
+func (s *LanternService) BeginSearchIndexRecovery() {
+	if recovery, ok := s.cache.(searchIndexRecoveryBackend); ok {
+		recovery.BeginSearchIndexRecovery()
+	}
+}
+
+// CompleteSearchIndexRecovery rebuilds the optional derived index from the
+// complete live graph. Graph convergence is preserved even when the rebuild
+// returns a configured search-limit error; callers decide how to surface it.
+func (s *LanternService) CompleteSearchIndexRecovery() error {
+	if recovery, ok := s.cache.(searchIndexRecoveryBackend); ok {
+		return recovery.CompleteSearchIndexRecovery()
+	}
+	return nil
 }
 
 // logMutation appends op to the mutation log after a local commit. The HLC

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
@@ -29,6 +30,35 @@ func newTestService(t *testing.T) *LanternService {
 
 func futureTs(d time.Duration) *timestamppb.Timestamp {
 	return timestamppb.New(time.Now().Add(d))
+}
+
+func TestLanternService_ApplySnapshotWatermarks(t *testing.T) {
+	svc := newTestService(t)
+	origin := hlc.NodeID{0x11, 0x22, 0x33}
+	ts := hlc.Timestamp{WallNs: 42, Logical: 7, NodeID: origin}
+
+	if err := svc.ApplySnapshotWatermarks(map[string]uint64{
+		hex.EncodeToString(origin[:]): 9,
+	}, ts); err != nil {
+		t.Fatalf("ApplySnapshotWatermarks: %v", err)
+	}
+	if got := svc.LocalSeq(origin); got != 9 {
+		t.Fatalf("LocalSeq = %d, want 9", got)
+	}
+
+	other := hlc.NodeID{0x44}
+	if err := svc.ApplySnapshotWatermarks(map[string]uint64{
+		hex.EncodeToString(other[:]): 10,
+		"not-hex":                    11,
+	}, ts); err == nil {
+		t.Fatal("ApplySnapshotWatermarks accepted a malformed origin")
+	}
+	if got := svc.LocalSeq(origin); got != 9 {
+		t.Fatalf("malformed cutoff changed LocalSeq to %d, want 9", got)
+	}
+	if got := svc.LocalSeq(other); got != 0 {
+		t.Fatalf("partially validated cutoff changed other LocalSeq to %d, want 0", got)
+	}
 }
 
 func TestLanternService_PutAndGetVertex(t *testing.T) {

--- a/server/service/status.go
+++ b/server/service/status.go
@@ -191,6 +191,13 @@ func (s *LanternService) searchCapabilities() *pb.SearchCapabilities {
 	return capabilities
 }
 
+// SearchConfigFingerprint returns the stable search-capability fingerprint
+// published by GetServerStatus. The replication PeerStatus surface uses the
+// same value so HA members compare exactly the contract clients discover.
+func (s *LanternService) SearchConfigFingerprint() string {
+	return s.searchCapabilities().GetConfigFingerprint()
+}
+
 // statusVersion returns the configured version string, falling back to
 // the VCS-stamped main module version baked in by `go build` (modern
 // Go embeds it in runtime/debug.BuildInfo). When neither is available

--- a/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/replication.connect.client.dart
+++ b/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/replication.connect.client.dart
@@ -20,9 +20,10 @@ import "replication.connect.spec.dart" as specs;
 /// part of #178's implementation in docs/replication.md.
 extension type LanternReplicationServiceClient (connect.Transport _transport) {
   /// Subscribe streams replicated mutations to a peer (or CDC consumer)
-  /// starting at `from_seq` (inclusive). The server replays any in-buffer
-  /// entries first, then streams live mutations as they are appended.
-  /// If `from_seq` is below the server's first available seq the call
+  /// starting at the supplied per-origin cursor. A same-responder snapshot
+  /// resume also supplies `from_local_seq`; the server replays retained entries
+  /// from that local position first, then streams live mutations.
+  /// If the requested replica-local replay window has been evicted, the call
   /// fails with FAILED_PRECONDITION ("gapped") and the caller must
   /// snapshot + resubscribe. Slow consumers whose channel backs up may
   /// also have the stream terminated with FAILED_PRECONDITION — the
@@ -49,13 +50,14 @@ extension type LanternReplicationServiceClient (connect.Transport _transport) {
 
   /// Snapshot streams a point-in-time, causally-consistent dump of every
   /// live vertex and edge to a bootstrapping peer. The first frame is a
-  /// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_hlc) the
-  /// server used to materialise the snapshot; the last frame is a
+  /// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_local_seq,
+  /// cutoff_hlc) the server used to materialise the snapshot; the last frame is a
   /// SnapshotFooter with the actual vertex / edge counts streamed.
   /// Bootstrap stitch contract: after receiving the SnapshotFooter the
   /// peer MUST call `Subscribe(from_seq_per_origin = {origin: seq+1 for
-  /// each (origin, seq) in cutoff_seq_per_origin})` to pick up the live
-  /// tail. Without that the snapshot and the live stream cannot be glued
+  /// each (origin, seq) in cutoff_seq_per_origin}, from_local_seq =
+  /// cutoff_local_seq+1)` against the same responder to pick up the live tail.
+  /// Without that the snapshot and live stream cannot be glued
   /// together without gap or overlap.
   /// No HTTP gateway annotation (parity with Subscribe).
   Stream<graphv1replication.SnapshotResponse> snapshot(

--- a/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/replication.connect.spec.dart
+++ b/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/replication.connect.spec.dart
@@ -22,9 +22,10 @@ abstract final class LanternReplicationService {
   static const name = 'graph.v1.LanternReplicationService';
 
   /// Subscribe streams replicated mutations to a peer (or CDC consumer)
-  /// starting at `from_seq` (inclusive). The server replays any in-buffer
-  /// entries first, then streams live mutations as they are appended.
-  /// If `from_seq` is below the server's first available seq the call
+  /// starting at the supplied per-origin cursor. A same-responder snapshot
+  /// resume also supplies `from_local_seq`; the server replays retained entries
+  /// from that local position first, then streams live mutations.
+  /// If the requested replica-local replay window has been evicted, the call
   /// fails with FAILED_PRECONDITION ("gapped") and the caller must
   /// snapshot + resubscribe. Slow consumers whose channel backs up may
   /// also have the stream terminated with FAILED_PRECONDITION — the
@@ -41,13 +42,14 @@ abstract final class LanternReplicationService {
 
   /// Snapshot streams a point-in-time, causally-consistent dump of every
   /// live vertex and edge to a bootstrapping peer. The first frame is a
-  /// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_hlc) the
-  /// server used to materialise the snapshot; the last frame is a
+  /// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_local_seq,
+  /// cutoff_hlc) the server used to materialise the snapshot; the last frame is a
   /// SnapshotFooter with the actual vertex / edge counts streamed.
   /// Bootstrap stitch contract: after receiving the SnapshotFooter the
   /// peer MUST call `Subscribe(from_seq_per_origin = {origin: seq+1 for
-  /// each (origin, seq) in cutoff_seq_per_origin})` to pick up the live
-  /// tail. Without that the snapshot and the live stream cannot be glued
+  /// each (origin, seq) in cutoff_seq_per_origin}, from_local_seq =
+  /// cutoff_local_seq+1)` against the same responder to pick up the live tail.
+  /// Without that the snapshot and live stream cannot be glued
   /// together without gap or overlap.
   /// No HTTP gateway annotation (parity with Subscribe).
   static const snapshot = connect.Spec(

--- a/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/replication.pb.dart
+++ b/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/replication.pb.dart
@@ -526,10 +526,12 @@ class SubscribeRequest extends $pb.GeneratedMessage {
   factory SubscribeRequest({
     $core.Iterable<$core.MapEntry<$core.String, $fixnum.Int64>>?
         fromSeqPerOrigin,
+    $fixnum.Int64? fromLocalSeq,
   }) {
     final result = create();
     if (fromSeqPerOrigin != null)
       result.fromSeqPerOrigin.addEntries(fromSeqPerOrigin);
+    if (fromLocalSeq != null) result.fromLocalSeq = fromLocalSeq;
     return result;
   }
 
@@ -552,6 +554,9 @@ class SubscribeRequest extends $pb.GeneratedMessage {
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OU6,
         packageName: const $pb.PackageName('graph.v1'))
+    ..a<$fixnum.Int64>(
+        2, _omitFieldNames ? '' : 'fromLocalSeq', $pb.PbFieldType.OU6,
+        defaultOrMaker: $fixnum.Int64.ZERO)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -580,6 +585,20 @@ class SubscribeRequest extends $pb.GeneratedMessage {
   /// expects from that origin.
   @$pb.TagNumber(1)
   $pb.PbMap<$core.String, $fixnum.Int64> get fromSeqPerOrigin => $_getMap(0);
+
+  /// Next entry in this responder's replica-local mutation log. This is only
+  /// valid when resuming against the SAME responder that emitted
+  /// SnapshotHeader.cutoff_local_seq; zero uses the portable per-origin path.
+  /// Keeping the two sequence domains separate prevents a stale per-origin
+  /// cursor from bypassing ring-buffer gap detection.
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get fromLocalSeq => $_getI64(1);
+  @$pb.TagNumber(2)
+  set fromLocalSeq($fixnum.Int64 value) => $_setInt64(1, value);
+  @$pb.TagNumber(2)
+  $core.bool hasFromLocalSeq() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearFromLocalSeq() => $_clearField(2);
 }
 
 /// SubscribeResponse carries one replicated mutation per message.
@@ -690,11 +709,12 @@ class SnapshotRequest extends $pb.GeneratedMessage {
 /// freezes the per-origin watermark and the snapshot-open HLC the server
 /// used to materialise the snapshot.
 ///
-/// A bootstrapping peer MUST persist `cutoff_seq_per_origin` and
-/// `cutoff_hlc` before applying any payload entries and MUST resume
-/// `Subscribe` with `from_seq_per_origin = {origin: seq+1 for each
-/// (origin, seq) in cutoff_seq_per_origin}` so the snapshot and the
-/// live tail stitch without gap or overlap.
+/// A bootstrapping peer MUST persist `cutoff_seq_per_origin`,
+/// `cutoff_local_seq`, and `cutoff_hlc` before applying any payload entries and
+/// MUST resume Subscribe against the SAME responder with both
+/// `from_seq_per_origin = {origin: seq+1 for each (origin, seq) in
+/// cutoff_seq_per_origin}` and `from_local_seq = cutoff_local_seq+1` so the
+/// snapshot and the live tail stitch without gap or overlap.
 ///
 /// Keys in `cutoff_seq_per_origin` are 32-char lowercase hex of the
 /// 16-byte HLC NodeID, matching `SubscribeRequest.from_seq_per_origin`.
@@ -707,11 +727,13 @@ class SnapshotHeader extends $pb.GeneratedMessage {
     $core.Iterable<$core.MapEntry<$core.String, $fixnum.Int64>>?
         cutoffSeqPerOrigin,
     HLCTimestamp? cutoffHlc,
+    $fixnum.Int64? cutoffLocalSeq,
   }) {
     final result = create();
     if (cutoffSeqPerOrigin != null)
       result.cutoffSeqPerOrigin.addEntries(cutoffSeqPerOrigin);
     if (cutoffHlc != null) result.cutoffHlc = cutoffHlc;
+    if (cutoffLocalSeq != null) result.cutoffLocalSeq = cutoffLocalSeq;
     return result;
   }
 
@@ -736,6 +758,9 @@ class SnapshotHeader extends $pb.GeneratedMessage {
         packageName: const $pb.PackageName('graph.v1'))
     ..aOM<HLCTimestamp>(2, _omitFieldNames ? '' : 'cutoffHlc',
         subBuilder: HLCTimestamp.create)
+    ..a<$fixnum.Int64>(
+        3, _omitFieldNames ? '' : 'cutoffLocalSeq', $pb.PbFieldType.OU6,
+        defaultOrMaker: $fixnum.Int64.ZERO)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -772,6 +797,18 @@ class SnapshotHeader extends $pb.GeneratedMessage {
   void clearCutoffHlc() => $_clearField(2);
   @$pb.TagNumber(2)
   HLCTimestamp ensureCutoffHlc() => $_ensure(1);
+
+  /// Replica-local mutation-log position at snapshot open. It is deliberately
+  /// separate from the portable per-origin watermarks and only resumes a tail
+  /// against the same responder.
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get cutoffLocalSeq => $_getI64(2);
+  @$pb.TagNumber(3)
+  set cutoffLocalSeq($fixnum.Int64 value) => $_setInt64(2, value);
+  @$pb.TagNumber(3)
+  $core.bool hasCutoffLocalSeq() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearCutoffLocalSeq() => $_clearField(3);
 }
 
 /// SnapshotFooter is always the LAST SnapshotResponse on the wire. It carries
@@ -1388,10 +1425,13 @@ class PeerStatusResponse extends $pb.GeneratedMessage {
   factory PeerStatusResponse({
     $core.List<$core.int>? selfOrigin,
     $core.Iterable<OriginState>? origins,
+    $core.String? searchConfigFingerprint,
   }) {
     final result = create();
     if (selfOrigin != null) result.selfOrigin = selfOrigin;
     if (origins != null) result.origins.addAll(origins);
+    if (searchConfigFingerprint != null)
+      result.searchConfigFingerprint = searchConfigFingerprint;
     return result;
   }
 
@@ -1412,6 +1452,7 @@ class PeerStatusResponse extends $pb.GeneratedMessage {
         1, _omitFieldNames ? '' : 'selfOrigin', $pb.PbFieldType.OY)
     ..pc<OriginState>(2, _omitFieldNames ? '' : 'origins', $pb.PbFieldType.PM,
         subBuilder: OriginState.create)
+    ..aOS(3, _omitFieldNames ? '' : 'searchConfigFingerprint')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -1446,6 +1487,18 @@ class PeerStatusResponse extends $pb.GeneratedMessage {
 
   @$pb.TagNumber(2)
   $pb.PbList<OriginState> get origins => $_getList(1);
+
+  /// Fingerprint of every search setting that can change capabilities or
+  /// ordered results. Replicas compare this before declaring themselves ready;
+  /// empty means the responder cannot prove search-config compatibility.
+  @$pb.TagNumber(3)
+  $core.String get searchConfigFingerprint => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set searchConfigFingerprint($core.String value) => $_setString(2, value);
+  @$pb.TagNumber(3)
+  $core.bool hasSearchConfigFingerprint() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSearchConfigFingerprint() => $_clearField(3);
 }
 
 /// LanternReplicationService carries the peer-to-peer (and CDC) replication
@@ -1466,10 +1519,11 @@ class LanternReplicationServiceApi {
   LanternReplicationServiceApi(this._client);
 
   /// Subscribe streams replicated mutations to a peer (or CDC consumer)
-  /// starting at `from_seq` (inclusive). The server replays any in-buffer
-  /// entries first, then streams live mutations as they are appended.
+  /// starting at the supplied per-origin cursor. A same-responder snapshot
+  /// resume also supplies `from_local_seq`; the server replays retained entries
+  /// from that local position first, then streams live mutations.
   ///
-  /// If `from_seq` is below the server's first available seq the call
+  /// If the requested replica-local replay window has been evicted, the call
   /// fails with FAILED_PRECONDITION ("gapped") and the caller must
   /// snapshot + resubscribe. Slow consumers whose channel backs up may
   /// also have the stream terminated with FAILED_PRECONDITION — the
@@ -1485,14 +1539,15 @@ class LanternReplicationServiceApi {
 
   /// Snapshot streams a point-in-time, causally-consistent dump of every
   /// live vertex and edge to a bootstrapping peer. The first frame is a
-  /// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_hlc) the
-  /// server used to materialise the snapshot; the last frame is a
+  /// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_local_seq,
+  /// cutoff_hlc) the server used to materialise the snapshot; the last frame is a
   /// SnapshotFooter with the actual vertex / edge counts streamed.
   ///
   /// Bootstrap stitch contract: after receiving the SnapshotFooter the
   /// peer MUST call `Subscribe(from_seq_per_origin = {origin: seq+1 for
-  /// each (origin, seq) in cutoff_seq_per_origin})` to pick up the live
-  /// tail. Without that the snapshot and the live stream cannot be glued
+  /// each (origin, seq) in cutoff_seq_per_origin}, from_local_seq =
+  /// cutoff_local_seq+1)` against the same responder to pick up the live tail.
+  /// Without that the snapshot and live stream cannot be glued
   /// together without gap or overlap.
   ///
   /// No HTTP gateway annotation (parity with Subscribe).

--- a/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/replication.pbjson.dart
+++ b/testbed/dart-transport-probe/connect/lib/src/gen/graph/v1/replication.pbjson.dart
@@ -213,6 +213,7 @@ const SubscribeRequest$json = {
       '6': '.graph.v1.SubscribeRequest.FromSeqPerOriginEntry',
       '10': 'fromSeqPerOrigin'
     },
+    {'1': 'from_local_seq', '3': 2, '4': 1, '5': 4, '10': 'fromLocalSeq'},
   ],
   '3': [SubscribeRequest_FromSeqPerOriginEntry$json],
 };
@@ -231,8 +232,8 @@ const SubscribeRequest_FromSeqPerOriginEntry$json = {
 final $typed_data.Uint8List subscribeRequestDescriptor = $convert.base64Decode(
     'ChBTdWJzY3JpYmVSZXF1ZXN0El8KE2Zyb21fc2VxX3Blcl9vcmlnaW4YASADKAsyMC5ncmFwaC'
     '52MS5TdWJzY3JpYmVSZXF1ZXN0LkZyb21TZXFQZXJPcmlnaW5FbnRyeVIQZnJvbVNlcVBlck9y'
-    'aWdpbhpDChVGcm9tU2VxUGVyT3JpZ2luRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdW'
-    'UYAiABKARSBXZhbHVlOgI4AQ==');
+    'aWdpbhIkCg5mcm9tX2xvY2FsX3NlcRgCIAEoBFIMZnJvbUxvY2FsU2VxGkMKFUZyb21TZXFQZX'
+    'JPcmlnaW5FbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoBFIFdmFsdWU6AjgB');
 
 @$core.Deprecated('Use subscribeResponseDescriptor instead')
 const SubscribeResponse$json = {
@@ -283,6 +284,7 @@ const SnapshotHeader$json = {
       '6': '.graph.v1.HLCTimestamp',
       '10': 'cutoffHlc'
     },
+    {'1': 'cutoff_local_seq', '3': 3, '4': 1, '5': 4, '10': 'cutoffLocalSeq'},
   ],
   '3': [SnapshotHeader_CutoffSeqPerOriginEntry$json],
 };
@@ -302,8 +304,9 @@ final $typed_data.Uint8List snapshotHeaderDescriptor = $convert.base64Decode(
     'Cg5TbmFwc2hvdEhlYWRlchJjChVjdXRvZmZfc2VxX3Blcl9vcmlnaW4YASADKAsyMC5ncmFwaC'
     '52MS5TbmFwc2hvdEhlYWRlci5DdXRvZmZTZXFQZXJPcmlnaW5FbnRyeVISY3V0b2ZmU2VxUGVy'
     'T3JpZ2luEjUKCmN1dG9mZl9obGMYAiABKAsyFi5ncmFwaC52MS5ITENUaW1lc3RhbXBSCWN1dG'
-    '9mZkhsYxpFChdDdXRvZmZTZXFQZXJPcmlnaW5FbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2'
-    'YWx1ZRgCIAEoBFIFdmFsdWU6AjgB');
+    '9mZkhsYxIoChBjdXRvZmZfbG9jYWxfc2VxGAMgASgEUg5jdXRvZmZMb2NhbFNlcRpFChdDdXRv'
+    'ZmZTZXFQZXJPcmlnaW5FbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoBFIFdm'
+    'FsdWU6AjgB');
 
 @$core.Deprecated('Use snapshotFooterDescriptor instead')
 const SnapshotFooter$json = {
@@ -501,13 +504,21 @@ const PeerStatusResponse$json = {
       '6': '.graph.v1.OriginState',
       '10': 'origins'
     },
+    {
+      '1': 'search_config_fingerprint',
+      '3': 3,
+      '4': 1,
+      '5': 9,
+      '10': 'searchConfigFingerprint'
+    },
   ],
 };
 
 /// Descriptor for `PeerStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List peerStatusResponseDescriptor = $convert.base64Decode(
     'ChJQZWVyU3RhdHVzUmVzcG9uc2USHwoLc2VsZl9vcmlnaW4YASABKAxSCnNlbGZPcmlnaW4SLw'
-    'oHb3JpZ2lucxgCIAMoCzIVLmdyYXBoLnYxLk9yaWdpblN0YXRlUgdvcmlnaW5z');
+    'oHb3JpZ2lucxgCIAMoCzIVLmdyYXBoLnYxLk9yaWdpblN0YXRlUgdvcmlnaW5zEjoKGXNlYXJj'
+    'aF9jb25maWdfZmluZ2VycHJpbnQYAyABKAlSF3NlYXJjaENvbmZpZ0ZpbmdlcnByaW50');
 
 const $core.Map<$core.String, $core.dynamic>
     LanternReplicationServiceBase$json = {

--- a/testbed/dart-transport-probe/grpc/lib/src/gen/graph/v1/replication.pb.dart
+++ b/testbed/dart-transport-probe/grpc/lib/src/gen/graph/v1/replication.pb.dart
@@ -546,10 +546,12 @@ class SubscribeRequest extends $pb.GeneratedMessage {
   factory SubscribeRequest({
     $core.Iterable<$core.MapEntry<$core.String, $fixnum.Int64>>?
         fromSeqPerOrigin,
+    $fixnum.Int64? fromLocalSeq,
   }) {
     final result = create();
     if (fromSeqPerOrigin != null)
       result.fromSeqPerOrigin.addEntries(fromSeqPerOrigin);
+    if (fromLocalSeq != null) result.fromLocalSeq = fromLocalSeq;
     return result;
   }
 
@@ -572,6 +574,9 @@ class SubscribeRequest extends $pb.GeneratedMessage {
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OU6,
         packageName: const $pb.PackageName('graph.v1'))
+    ..a<$fixnum.Int64>(
+        2, _omitFieldNames ? '' : 'fromLocalSeq', $pb.PbFieldType.OU6,
+        defaultOrMaker: $fixnum.Int64.ZERO)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -598,6 +603,20 @@ class SubscribeRequest extends $pb.GeneratedMessage {
   /// expects from that origin.
   @$pb.TagNumber(1)
   $pb.PbMap<$core.String, $fixnum.Int64> get fromSeqPerOrigin => $_getMap(0);
+
+  /// Next entry in this responder's replica-local mutation log. This is only
+  /// valid when resuming against the SAME responder that emitted
+  /// SnapshotHeader.cutoff_local_seq; zero uses the portable per-origin path.
+  /// Keeping the two sequence domains separate prevents a stale per-origin
+  /// cursor from bypassing ring-buffer gap detection.
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get fromLocalSeq => $_getI64(1);
+  @$pb.TagNumber(2)
+  set fromLocalSeq($fixnum.Int64 value) => $_setInt64(1, value);
+  @$pb.TagNumber(2)
+  $core.bool hasFromLocalSeq() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearFromLocalSeq() => $_clearField(2);
 }
 
 /// SubscribeResponse carries one replicated mutation per message.
@@ -704,11 +723,12 @@ class SnapshotRequest extends $pb.GeneratedMessage {
 /// freezes the per-origin watermark and the snapshot-open HLC the server
 /// used to materialise the snapshot.
 ///
-/// A bootstrapping peer MUST persist `cutoff_seq_per_origin` and
-/// `cutoff_hlc` before applying any payload entries and MUST resume
-/// `Subscribe` with `from_seq_per_origin = {origin: seq+1 for each
-/// (origin, seq) in cutoff_seq_per_origin}` so the snapshot and the
-/// live tail stitch without gap or overlap.
+/// A bootstrapping peer MUST persist `cutoff_seq_per_origin`,
+/// `cutoff_local_seq`, and `cutoff_hlc` before applying any payload entries and
+/// MUST resume Subscribe against the SAME responder with both
+/// `from_seq_per_origin = {origin: seq+1 for each (origin, seq) in
+/// cutoff_seq_per_origin}` and `from_local_seq = cutoff_local_seq+1` so the
+/// snapshot and the live tail stitch without gap or overlap.
 ///
 /// Keys in `cutoff_seq_per_origin` are 32-char lowercase hex of the
 /// 16-byte HLC NodeID, matching `SubscribeRequest.from_seq_per_origin`.
@@ -721,11 +741,13 @@ class SnapshotHeader extends $pb.GeneratedMessage {
     $core.Iterable<$core.MapEntry<$core.String, $fixnum.Int64>>?
         cutoffSeqPerOrigin,
     HLCTimestamp? cutoffHlc,
+    $fixnum.Int64? cutoffLocalSeq,
   }) {
     final result = create();
     if (cutoffSeqPerOrigin != null)
       result.cutoffSeqPerOrigin.addEntries(cutoffSeqPerOrigin);
     if (cutoffHlc != null) result.cutoffHlc = cutoffHlc;
+    if (cutoffLocalSeq != null) result.cutoffLocalSeq = cutoffLocalSeq;
     return result;
   }
 
@@ -750,6 +772,9 @@ class SnapshotHeader extends $pb.GeneratedMessage {
         packageName: const $pb.PackageName('graph.v1'))
     ..aOM<HLCTimestamp>(2, _omitFieldNames ? '' : 'cutoffHlc',
         subBuilder: HLCTimestamp.create)
+    ..a<$fixnum.Int64>(
+        3, _omitFieldNames ? '' : 'cutoffLocalSeq', $pb.PbFieldType.OU6,
+        defaultOrMaker: $fixnum.Int64.ZERO)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -784,6 +809,18 @@ class SnapshotHeader extends $pb.GeneratedMessage {
   void clearCutoffHlc() => $_clearField(2);
   @$pb.TagNumber(2)
   HLCTimestamp ensureCutoffHlc() => $_ensure(1);
+
+  /// Replica-local mutation-log position at snapshot open. It is deliberately
+  /// separate from the portable per-origin watermarks and only resumes a tail
+  /// against the same responder.
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get cutoffLocalSeq => $_getI64(2);
+  @$pb.TagNumber(3)
+  set cutoffLocalSeq($fixnum.Int64 value) => $_setInt64(2, value);
+  @$pb.TagNumber(3)
+  $core.bool hasCutoffLocalSeq() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearCutoffLocalSeq() => $_clearField(3);
 }
 
 /// SnapshotFooter is always the LAST SnapshotResponse on the wire. It carries
@@ -1393,10 +1430,13 @@ class PeerStatusResponse extends $pb.GeneratedMessage {
   factory PeerStatusResponse({
     $core.List<$core.int>? selfOrigin,
     $core.Iterable<OriginState>? origins,
+    $core.String? searchConfigFingerprint,
   }) {
     final result = create();
     if (selfOrigin != null) result.selfOrigin = selfOrigin;
     if (origins != null) result.origins.addAll(origins);
+    if (searchConfigFingerprint != null)
+      result.searchConfigFingerprint = searchConfigFingerprint;
     return result;
   }
 
@@ -1417,6 +1457,7 @@ class PeerStatusResponse extends $pb.GeneratedMessage {
         1, _omitFieldNames ? '' : 'selfOrigin', $pb.PbFieldType.OY)
     ..pPM<OriginState>(2, _omitFieldNames ? '' : 'origins',
         subBuilder: OriginState.create)
+    ..aOS(3, _omitFieldNames ? '' : 'searchConfigFingerprint')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -1449,6 +1490,18 @@ class PeerStatusResponse extends $pb.GeneratedMessage {
 
   @$pb.TagNumber(2)
   $pb.PbList<OriginState> get origins => $_getList(1);
+
+  /// Fingerprint of every search setting that can change capabilities or
+  /// ordered results. Replicas compare this before declaring themselves ready;
+  /// empty means the responder cannot prove search-config compatibility.
+  @$pb.TagNumber(3)
+  $core.String get searchConfigFingerprint => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set searchConfigFingerprint($core.String value) => $_setString(2, value);
+  @$pb.TagNumber(3)
+  $core.bool hasSearchConfigFingerprint() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSearchConfigFingerprint() => $_clearField(3);
 }
 
 const $core.bool _omitFieldNames =

--- a/testbed/dart-transport-probe/grpc/lib/src/gen/graph/v1/replication.pbgrpc.dart
+++ b/testbed/dart-transport-probe/grpc/lib/src/gen/graph/v1/replication.pbgrpc.dart
@@ -46,10 +46,11 @@ class LanternReplicationServiceClient extends $grpc.Client {
       {super.options, super.interceptors});
 
   /// Subscribe streams replicated mutations to a peer (or CDC consumer)
-  /// starting at `from_seq` (inclusive). The server replays any in-buffer
-  /// entries first, then streams live mutations as they are appended.
+  /// starting at the supplied per-origin cursor. A same-responder snapshot
+  /// resume also supplies `from_local_seq`; the server replays retained entries
+  /// from that local position first, then streams live mutations.
   ///
-  /// If `from_seq` is below the server's first available seq the call
+  /// If the requested replica-local replay window has been evicted, the call
   /// fails with FAILED_PRECONDITION ("gapped") and the caller must
   /// snapshot + resubscribe. Slow consumers whose channel backs up may
   /// also have the stream terminated with FAILED_PRECONDITION — the
@@ -69,14 +70,15 @@ class LanternReplicationServiceClient extends $grpc.Client {
 
   /// Snapshot streams a point-in-time, causally-consistent dump of every
   /// live vertex and edge to a bootstrapping peer. The first frame is a
-  /// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_hlc) the
-  /// server used to materialise the snapshot; the last frame is a
+  /// SnapshotHeader carrying the (cutoff_seq_per_origin, cutoff_local_seq,
+  /// cutoff_hlc) the server used to materialise the snapshot; the last frame is a
   /// SnapshotFooter with the actual vertex / edge counts streamed.
   ///
   /// Bootstrap stitch contract: after receiving the SnapshotFooter the
   /// peer MUST call `Subscribe(from_seq_per_origin = {origin: seq+1 for
-  /// each (origin, seq) in cutoff_seq_per_origin})` to pick up the live
-  /// tail. Without that the snapshot and the live stream cannot be glued
+  /// each (origin, seq) in cutoff_seq_per_origin}, from_local_seq =
+  /// cutoff_local_seq+1)` against the same responder to pick up the live tail.
+  /// Without that the snapshot and live stream cannot be glued
   /// together without gap or overlap.
   ///
   /// No HTTP gateway annotation (parity with Subscribe).

--- a/testbed/dart-transport-probe/grpc/lib/src/gen/graph/v1/replication.pbjson.dart
+++ b/testbed/dart-transport-probe/grpc/lib/src/gen/graph/v1/replication.pbjson.dart
@@ -210,6 +210,7 @@ const SubscribeRequest$json = {
       '6': '.graph.v1.SubscribeRequest.FromSeqPerOriginEntry',
       '10': 'fromSeqPerOrigin'
     },
+    {'1': 'from_local_seq', '3': 2, '4': 1, '5': 4, '10': 'fromLocalSeq'},
   ],
   '3': [SubscribeRequest_FromSeqPerOriginEntry$json],
 };
@@ -228,8 +229,8 @@ const SubscribeRequest_FromSeqPerOriginEntry$json = {
 final $typed_data.Uint8List subscribeRequestDescriptor = $convert.base64Decode(
     'ChBTdWJzY3JpYmVSZXF1ZXN0El8KE2Zyb21fc2VxX3Blcl9vcmlnaW4YASADKAsyMC5ncmFwaC'
     '52MS5TdWJzY3JpYmVSZXF1ZXN0LkZyb21TZXFQZXJPcmlnaW5FbnRyeVIQZnJvbVNlcVBlck9y'
-    'aWdpbhpDChVGcm9tU2VxUGVyT3JpZ2luRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdW'
-    'UYAiABKARSBXZhbHVlOgI4AQ==');
+    'aWdpbhIkCg5mcm9tX2xvY2FsX3NlcRgCIAEoBFIMZnJvbUxvY2FsU2VxGkMKFUZyb21TZXFQZX'
+    'JPcmlnaW5FbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoBFIFdmFsdWU6AjgB');
 
 @$core.Deprecated('Use subscribeResponseDescriptor instead')
 const SubscribeResponse$json = {
@@ -280,6 +281,7 @@ const SnapshotHeader$json = {
       '6': '.graph.v1.HLCTimestamp',
       '10': 'cutoffHlc'
     },
+    {'1': 'cutoff_local_seq', '3': 3, '4': 1, '5': 4, '10': 'cutoffLocalSeq'},
   ],
   '3': [SnapshotHeader_CutoffSeqPerOriginEntry$json],
 };
@@ -299,8 +301,9 @@ final $typed_data.Uint8List snapshotHeaderDescriptor = $convert.base64Decode(
     'Cg5TbmFwc2hvdEhlYWRlchJjChVjdXRvZmZfc2VxX3Blcl9vcmlnaW4YASADKAsyMC5ncmFwaC'
     '52MS5TbmFwc2hvdEhlYWRlci5DdXRvZmZTZXFQZXJPcmlnaW5FbnRyeVISY3V0b2ZmU2VxUGVy'
     'T3JpZ2luEjUKCmN1dG9mZl9obGMYAiABKAsyFi5ncmFwaC52MS5ITENUaW1lc3RhbXBSCWN1dG'
-    '9mZkhsYxpFChdDdXRvZmZTZXFQZXJPcmlnaW5FbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2'
-    'YWx1ZRgCIAEoBFIFdmFsdWU6AjgB');
+    '9mZkhsYxIoChBjdXRvZmZfbG9jYWxfc2VxGAMgASgEUg5jdXRvZmZMb2NhbFNlcRpFChdDdXRv'
+    'ZmZTZXFQZXJPcmlnaW5FbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoBFIFdm'
+    'FsdWU6AjgB');
 
 @$core.Deprecated('Use snapshotFooterDescriptor instead')
 const SnapshotFooter$json = {
@@ -498,10 +501,18 @@ const PeerStatusResponse$json = {
       '6': '.graph.v1.OriginState',
       '10': 'origins'
     },
+    {
+      '1': 'search_config_fingerprint',
+      '3': 3,
+      '4': 1,
+      '5': 9,
+      '10': 'searchConfigFingerprint'
+    },
   ],
 };
 
 /// Descriptor for `PeerStatusResponse`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List peerStatusResponseDescriptor = $convert.base64Decode(
     'ChJQZWVyU3RhdHVzUmVzcG9uc2USHwoLc2VsZl9vcmlnaW4YASABKAxSCnNlbGZPcmlnaW4SLw'
-    'oHb3JpZ2lucxgCIAMoCzIVLmdyYXBoLnYxLk9yaWdpblN0YXRlUgdvcmlnaW5z');
+    'oHb3JpZ2lucxgCIAMoCzIVLmdyYXBoLnYxLk9yaWdpblN0YXRlUgdvcmlnaW5zEjoKGXNlYXJj'
+    'aF9jb25maWdfZmluZ2VycHJpbnQYAyABKAlSF3NlYXJjaENvbmZpZ0ZpbmdlcnByaW50');

--- a/tests/integration/antientropy_test.go
+++ b/tests/integration/antientropy_test.go
@@ -2,14 +2,17 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"testing"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
 	client "github.com/anaregdesign/lantern/sdks/go"
 	"github.com/anaregdesign/lantern/server/replication"
 	"github.com/anaregdesign/lantern/server/service"
@@ -28,17 +31,28 @@ type antiEntropyNode struct {
 	log    *mutationlog.Log
 	svc    *service.LanternService
 	sdk    *client.Lantern
+	raw    graphv1connect.LanternServiceClient
 	nodeID hlc.NodeID
 }
 
 func newAntiEntropyNode(t *testing.T, nodeID hlc.NodeID) *antiEntropyNode {
+	return newAntiEntropyNodeWithCapacity(t, nodeID, 1024)
+}
+
+func newAntiEntropyNodeWithCapacity(t *testing.T, nodeID hlc.NodeID, logCapacity int) *antiEntropyNode {
 	t.Helper()
-	mlog := mutationlog.New(mutationlog.Options{Capacity: 1024, SubscriberBuffer: 1024})
+	mlog := mutationlog.New(mutationlog.Options{Capacity: logCapacity, SubscriberBuffer: 1024})
 	t.Cleanup(func() { _ = mlog.Close() })
 	clock := hlc.New(nodeID, hlc.Options{})
-	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
-	svc := service.NewLanternService(cache).WithReplication(mlog, clock, nil)
-	rep := service.NewLanternReplicationService(mlog, cache, clock).WithOriginStates(svc)
+	limits := productionSearchLimits(true, true)
+	cache := newProductionSearchCache(time.Minute, true, true, limits.AnalysisLimits)
+	svc := service.NewLanternService(cache).
+		WithSearchLimits(limits).
+		WithTombstoneTTL(time.Hour).
+		WithReplication(mlog, clock, nil)
+	rep := service.NewLanternReplicationService(mlog, cache, clock).
+		WithOriginStates(svc).
+		WithSearchConfig(svc)
 	srv := newConnectTestServer(t, svc, rep)
 
 	sdk := newConnectClientFor(t, srv.url)
@@ -48,7 +62,76 @@ func newAntiEntropyNode(t *testing.T, nodeID hlc.NodeID) *antiEntropyNode {
 	}
 	return &antiEntropyNode{
 		addr: u.Host, url: srv.url, cache: cache, clock: clock,
-		log: mlog, svc: svc, sdk: sdk, nodeID: nodeID,
+		log: mlog, svc: svc, sdk: sdk,
+		raw: graphv1connect.NewLanternServiceClient(h2cClient(), srv.url), nodeID: nodeID,
+	}
+}
+
+func TestAntiEntropy_GappedLogRebuildsExactSearchIndex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping anti-entropy snapshot search test in short mode")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	source := newAntiEntropyNodeWithCapacity(t, hlc.NodeID{0xB1}, 4)
+	follower := newAntiEntropyNode(t, hlc.NodeID{0xC1})
+	inputs := make([]client.VertexInput, 12)
+	for i := range inputs {
+		inputs[i] = client.VertexInput{
+			Key:        fmt.Sprintf("ae-gap-%02d", i),
+			Value:      fmt.Sprintf("anti snapshot common-%02d", i),
+			Expiration: time.Now().Add(time.Hour),
+		}
+	}
+	for _, input := range inputs {
+		if err := source.sdk.PutVertexAt(ctx, input.Key, input.Value, input.Expiration); err != nil {
+			t.Fatalf("source PutVertexAt(%q): %v", input.Key, err)
+		}
+	}
+	if first, ok := source.log.FirstSeq(); !ok || first <= 1 {
+		t.Fatalf("source log did not evict: first=%d ok=%v", first, ok)
+	}
+
+	ae := replication.NewAntiEntropy(replication.AntiEntropyConfig{
+		NodeID:                  follower.nodeID,
+		Peers:                   []string{source.url},
+		Interval:                25 * time.Millisecond,
+		SubscribeTimeout:        2 * time.Second,
+		HTTPClient:              h2cClient(),
+		SearchConfigFingerprint: follower.svc.SearchConfigFingerprint(),
+	}, follower.svc, follower.svc, follower.cache)
+	aeCtx, cancelAE := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = ae.Run(aeCtx)
+	}()
+	t.Cleanup(func() {
+		cancelAE()
+		<-done
+	})
+
+	got := waitForSearchConvergence(t, ctx, "anti snapshot", &pb.SearchOptions{MatchMode: pb.MatchMode_MATCH_MODE_ALL}, source.raw, follower.raw)
+	if len(got) != len(inputs) {
+		t.Fatalf("anti-entropy snapshot search hits = %d, want %d", len(got), len(inputs))
+	}
+	status, err := follower.raw.GetServerStatus(ctx, connect.NewRequest(&pb.GetServerStatusRequest{}))
+	if err != nil {
+		t.Fatalf("follower GetServerStatus: %v", err)
+	}
+	stats := status.Msg.GetSearch().GetIndexStats()
+	if stats.GetHealth() != pb.SearchIndexHealth_SEARCH_INDEX_HEALTH_HEALTHY || stats.GetDocuments() != uint64(len(inputs)) {
+		t.Fatalf("anti-entropy snapshot search stats = %+v", stats)
+	}
+
+	// The remembered same-responder local cutoff lets the next repair use the
+	// retained tail instead of falling back to another snapshot immediately.
+	if err := source.sdk.PutVertex(ctx, "ae-gap-tail", "anti snapshot tail", time.Hour); err != nil {
+		t.Fatalf("source tail PutVertex: %v", err)
+	}
+	if got := waitForSearchConvergence(t, ctx, "anti snapshot tail", &pb.SearchOptions{MatchMode: pb.MatchMode_MATCH_MODE_ALL}, source.raw, follower.raw); len(got) != 1 {
+		t.Fatalf("anti-entropy post-snapshot tail = %+v", got)
 	}
 }
 
@@ -75,11 +158,12 @@ func TestAntiEntropy_DriverConvergesWithoutPump(t *testing.T) {
 	// HTTPClient is supplied so the driver speaks h2c against the
 	// httptest server (replication.defaultH2CClient is unexported).
 	ae := replication.NewAntiEntropy(replication.AntiEntropyConfig{
-		NodeID:           c.nodeID,
-		Peers:            []string{b.url},
-		Interval:         50 * time.Millisecond,
-		SubscribeTimeout: 2 * time.Second,
-		HTTPClient:       h2cClient(),
+		NodeID:                  c.nodeID,
+		Peers:                   []string{b.url},
+		Interval:                50 * time.Millisecond,
+		SubscribeTimeout:        2 * time.Second,
+		HTTPClient:              h2cClient(),
+		SearchConfigFingerprint: c.svc.SearchConfigFingerprint(),
 	}, c.svc, c.svc, c.cache)
 	aeCtx, cancelAE := context.WithCancel(ctx)
 	done := make(chan struct{})
@@ -96,7 +180,7 @@ func TestAntiEntropy_DriverConvergesWithoutPump(t *testing.T) {
 	// Write to B; C has no pump, so until the first anti-entropy tick
 	// fires, C MUST NOT see it. After the first tick (and at most one
 	// catch-up Subscribe round-trip), C MUST see it.
-	if err := b.sdk.PutVertex(ctx, "ae-key", "ae-val", time.Minute); err != nil {
+	if err := b.sdk.PutVertex(ctx, "ae-key", "common ae-old", time.Minute); err != nil {
 		t.Fatalf("b.PutVertex: %v", err)
 	}
 	if _, err := b.sdk.AddEdge(ctx, "ae-key", "ae-head", 2.5, time.Minute); err != nil {
@@ -108,6 +192,28 @@ func TestAntiEntropy_DriverConvergesWithoutPump(t *testing.T) {
 	}
 	if w, ok := waitForEdge(t, c.cache, "ae-key", "ae-head", 2.5, 3*time.Second); !ok || w != 2.5 {
 		t.Errorf("c edge ae-key->ae-head: got w=%v ok=%v want 2.5/true", w, ok)
+	}
+	waitForSearchConvergence(t, ctx, "common", nil, b.raw, c.raw)
+
+	if err := b.sdk.PutVertices(ctx, []client.VertexInput{
+		{Key: "ae-key", Value: "common ae-current", Expiration: time.Now().Add(time.Hour)},
+		{Key: "ae-delete", Value: "ae-deleted", Expiration: time.Now().Add(time.Hour)},
+		{Key: "ae-expire", Value: "ae-expired", Expiration: time.Now().Add(150 * time.Millisecond)},
+	}); err != nil {
+		t.Fatalf("anti-entropy lifecycle PutVertices: %v", err)
+	}
+	if _, err := b.sdk.DeleteVertex(ctx, "ae-delete"); err != nil {
+		t.Fatalf("anti-entropy DeleteVertex: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond)
+	exactAll := &pb.SearchOptions{MatchMode: pb.MatchMode_MATCH_MODE_ALL}
+	for _, query := range []string{"ae-old", "ae-deleted", "ae-expired"} {
+		if got := waitForSearchConvergence(t, ctx, query, exactAll, b.raw, c.raw); len(got) != 0 {
+			t.Errorf("anti-entropy retired query %q = %+v", query, got)
+		}
+	}
+	if got := waitForSearchConvergence(t, ctx, "ae-current", exactAll, b.raw, c.raw); len(got) != 1 {
+		t.Fatalf("anti-entropy current query = %+v", got)
 	}
 }
 

--- a/tests/integration/backup_test.go
+++ b/tests/integration/backup_test.go
@@ -141,10 +141,12 @@ func TestBackupper_ServerInternal_RoundTrip_E2E(t *testing.T) {
 	val := provider.NewValidationInterceptor(defaultIntegrationValidationLimits())
 
 	// Source service, seeded via the SDK.
-	srcCache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
-	srcSvc := service.NewLanternService(srcCache)
+	searchLimits := productionSearchLimits(true, true)
+	srcCache := newProductionSearchCache(time.Minute, true, true, searchLimits.AnalysisLimits)
+	srcSvc := service.NewLanternService(srcCache).WithSearchLimits(searchLimits)
 	srcSrv := newConnectTestServer(t, srcSvc, nil, val.ConnectInterceptor())
 	srcSDK := newConnectClientFor(t, srcSrv.url)
+	srcRaw := graphv1connect.NewLanternServiceClient(h2cClient(), srcSrv.url)
 
 	const bigInt = int64(9007199254740993) // 2^53 + 1
 	if err := srcSDK.PutVertex(ctx, "alice", "Alice", time.Minute); err != nil {
@@ -156,15 +158,20 @@ func TestBackupper_ServerInternal_RoundTrip_E2E(t *testing.T) {
 	if _, err := srcSDK.AddEdge(ctx, "alice", "num", 1.5, time.Minute); err != nil {
 		t.Fatal(err)
 	}
+	expiresBeforeRestore := time.Now().Add(500 * time.Millisecond)
+	if err := srcSDK.PutVertexAt(ctx, "expired-during-restart", "restore-expired-term", expiresBeforeRestore); err != nil {
+		t.Fatal(err)
+	}
 
 	// Server-internal dump (same path as the periodic loop).
 	if _, err := backup.New(srcSvc, cfg, nil, nil).BackupNow(ctx); err != nil {
 		t.Fatalf("BackupNow: %v", err)
 	}
+	time.Sleep(time.Until(expiresBeforeRestore) + 25*time.Millisecond)
 
 	// Fresh service, restored on startup from the dump.
-	dstCache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
-	dstSvc := service.NewLanternService(dstCache)
+	dstCache := newProductionSearchCache(time.Minute, true, true, searchLimits.AnalysisLimits)
+	dstSvc := service.NewLanternService(dstCache).WithSearchLimits(searchLimits)
 	dstSrv := newConnectTestServer(t, dstSvc, nil, val.ConnectInterceptor())
 	dstRaw := graphv1connect.NewLanternServiceClient(h2cClient(), dstSrv.url)
 
@@ -186,6 +193,20 @@ func TestBackupper_ServerInternal_RoundTrip_E2E(t *testing.T) {
 	}
 	if e := es["alice->num"]; e == nil || e.GetWeight() != 1.5 {
 		t.Errorf("restored edge alice->num = %v, want weight 1.5", e)
+	}
+	if _, ok := vs["expired-during-restart"]; ok {
+		t.Errorf("born-expired restore resurrected expired vertex: %v", vs)
+	}
+	waitForSearchConvergence(t, ctx, "Alice", nil, srcRaw, dstRaw)
+	if got, err := wireSearchSignature(ctx, dstRaw, "restore-expired-term", nil); err != nil || len(got) != 0 {
+		t.Fatalf("expired restore search = %+v err=%v", got, err)
+	}
+	status, err := dstRaw.GetServerStatus(ctx, connect.NewRequest(&pb.GetServerStatusRequest{}))
+	if err != nil {
+		t.Fatalf("GetServerStatus after restore: %v", err)
+	}
+	if got := status.Msg.GetSearch().GetIndexStats(); got.GetHealth() != pb.SearchIndexHealth_SEARCH_INDEX_HEALTH_HEALTHY || got.GetDocuments() != 2 {
+		t.Fatalf("restored search stats = %+v, want healthy with two documents", got)
 	}
 }
 

--- a/tests/integration/convergence_gate_test.go
+++ b/tests/integration/convergence_gate_test.go
@@ -33,7 +33,9 @@ func newConvergenceNode(t *testing.T, nodeID hlc.NodeID, tombstoneTTL time.Durat
 	svc := service.NewLanternService(cache).
 		WithReplication(log, clock, nil).
 		WithTombstoneTTL(tombstoneTTL)
-	rep := service.NewLanternReplicationService(log, cache, clock)
+	rep := service.NewLanternReplicationService(log, cache, clock).
+		WithOriginStates(svc).
+		WithSearchConfig(svc)
 	srv := newConnectTestServer(t, svc, rep)
 
 	return &pumpNode{

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -3,9 +3,11 @@ package integration_test
 import (
 	"context"
 	"crypto/tls"
+	"math"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
@@ -13,12 +15,103 @@ import (
 	"golang.org/x/net/http2"
 
 	"github.com/anaregdesign/lantern/core/graphcache"
+	"github.com/anaregdesign/lantern/core/search"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
 	client "github.com/anaregdesign/lantern/sdks/go"
 	"github.com/anaregdesign/lantern/server/provider"
 	"github.com/anaregdesign/lantern/server/service"
 )
+
+func productionSearchAnalysisLimits() search.SearchAnalysisLimits {
+	return search.SearchAnalysisLimits{
+		MaxDocumentBytes:     1 << 20,
+		MaxDocumentTokens:    250_000,
+		MaxDocumentTerms:     100_000,
+		MaxLiveTerms:         5_000_000,
+		MaxLivePostings:      50_000_000,
+		MaxPositionEntries:   50_000_000,
+		CompactionRatio:      2,
+		CompactionMinRetired: 10_000,
+	}
+}
+
+func productionSearchLimits(enabled, positions bool) service.SearchLimits {
+	return service.SearchLimits{
+		Enabled:          enabled,
+		PositionsEnabled: enabled && positions,
+		DefaultLimit:     100,
+		MaxLimit:         1000,
+		DefaultMode:      search.MatchAny,
+		DefaultMinShould: 1,
+		Timeout:          5 * time.Second,
+		MaxQueryBytes:    16 * 1024,
+		WorkBudget: search.Budget{
+			MaxQueryTerms:       1024,
+			MaxDictionaryVisits: 1_000_000,
+			MaxPostingVisits:    10_000_000,
+			MaxPositionVisits:   10_000_000,
+			MaxExpirationVisits: 100_000,
+		},
+		MaxInFlight:    32,
+		AnalysisLimits: productionSearchAnalysisLimits(),
+	}
+}
+
+func newProductionSearchCache(ttl time.Duration, enabled, positions bool, limits search.SearchAnalysisLimits) *graphcache.GraphCache[string, *pb.Vertex] {
+	return provider.NewGraphCache(provider.CacheConfig{TTL: ttl}, provider.SearchConfig{
+		Enabled: enabled, Positions: positions, AnalysisLimits: limits,
+	})
+}
+
+type searchHitSignature struct {
+	key       string
+	scoreBits uint64
+}
+
+func wireSearchSignature(ctx context.Context, raw graphv1connect.LanternServiceClient, query string, options *pb.SearchOptions) ([]searchHitSignature, error) {
+	resp, err := raw.SearchVertices(ctx, connect.NewRequest(&pb.SearchVerticesRequest{
+		Query: query, Limit: 1000, Options: options,
+	}))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]searchHitSignature, len(resp.Msg.GetHits()))
+	for i, hit := range resp.Msg.GetHits() {
+		out[i] = searchHitSignature{key: hit.GetKey(), scoreBits: math.Float64bits(hit.GetScore())}
+	}
+	return out, nil
+}
+
+func waitForSearchConvergence(t *testing.T, ctx context.Context, query string, options *pb.SearchOptions, raws ...graphv1connect.LanternServiceClient) []searchHitSignature {
+	t.Helper()
+	if len(raws) < 2 {
+		t.Fatal("waitForSearchConvergence requires at least two replicas")
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	var latest [][]searchHitSignature
+	for time.Now().Before(deadline) {
+		latest = latest[:0]
+		converged := true
+		for _, raw := range raws {
+			signature, err := wireSearchSignature(ctx, raw, query, options)
+			if err != nil {
+				converged = false
+				break
+			}
+			latest = append(latest, signature)
+			if len(latest) > 1 && !reflect.DeepEqual(latest[0], signature) {
+				converged = false
+			}
+		}
+		if converged {
+			return latest[0]
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("search %q did not converge exactly: %+v", query, latest)
+	return nil
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers — Connect-on-h2c in-process harness

--- a/tests/integration/peer_pump_test.go
+++ b/tests/integration/peer_pump_test.go
@@ -3,14 +3,18 @@ package integration_test
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
 	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/anaregdesign/lantern/server/readiness"
 	"github.com/anaregdesign/lantern/server/replication"
 	"github.com/anaregdesign/lantern/server/service"
 )
@@ -28,18 +32,29 @@ type pumpNode struct {
 	log    *mutationlog.Log
 	svc    *service.LanternService
 	sdk    *client.Lantern
+	raw    graphv1connect.LanternServiceClient
 	pump   *replication.Pump
 	nodeID hlc.NodeID
 }
 
 func newPumpNode(t *testing.T, nodeID hlc.NodeID) *pumpNode {
+	return newPumpNodeWithSearch(t, nodeID, 1024, true)
+}
+
+func newPumpNodeWithSearch(t *testing.T, nodeID hlc.NodeID, logCapacity int, positions bool) *pumpNode {
 	t.Helper()
-	log := mutationlog.New(mutationlog.Options{Capacity: 1024, SubscriberBuffer: 1024})
+	log := mutationlog.New(mutationlog.Options{Capacity: logCapacity, SubscriberBuffer: 1024})
 	t.Cleanup(func() { _ = log.Close() })
 	clock := hlc.New(nodeID, hlc.Options{})
-	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
-	svc := service.NewLanternService(cache).WithReplication(log, clock, nil)
-	rep := service.NewLanternReplicationService(log, cache, clock)
+	limits := productionSearchLimits(true, positions)
+	cache := newProductionSearchCache(time.Minute, true, positions, limits.AnalysisLimits)
+	svc := service.NewLanternService(cache).
+		WithSearchLimits(limits).
+		WithTombstoneTTL(time.Hour).
+		WithReplication(log, clock, nil)
+	rep := service.NewLanternReplicationService(log, cache, clock).
+		WithOriginStates(svc).
+		WithSearchConfig(svc)
 
 	// Connect-on-h2c httptest.Server — same pattern as
 	// newConnectTestServer but the URL form is what the pump
@@ -54,6 +69,7 @@ func newPumpNode(t *testing.T, nodeID hlc.NodeID) *pumpNode {
 		log:    log,
 		svc:    svc,
 		sdk:    newConnectClientFor(t, srv.url),
+		raw:    graphv1connect.NewLanternServiceClient(h2cClient(), srv.url),
 		nodeID: nodeID,
 	}
 }
@@ -61,13 +77,19 @@ func newPumpNode(t *testing.T, nodeID hlc.NodeID) *pumpNode {
 // startPump attaches a Pump to the node aimed at the supplied peer
 // URLs (or "host:port" — replication.peerBaseURL coerces both).
 func (n *pumpNode) startPump(ctx context.Context, t *testing.T, peers []string) {
+	n.startPumpWithMetrics(ctx, t, peers, nil)
+}
+
+func (n *pumpNode) startPumpWithMetrics(ctx context.Context, t *testing.T, peers []string, metrics replication.Metrics) {
 	t.Helper()
 	p := replication.NewPump(replication.Config{
-		NodeID:     n.nodeID,
-		Peers:      peers,
-		BackoffMin: 20 * time.Millisecond,
-		BackoffMax: 200 * time.Millisecond,
-		HTTPClient: h2cClient(),
+		NodeID:                  n.nodeID,
+		Peers:                   peers,
+		BackoffMin:              20 * time.Millisecond,
+		BackoffMax:              200 * time.Millisecond,
+		HTTPClient:              h2cClient(),
+		SearchConfigFingerprint: n.svc.SearchConfigFingerprint(),
+		Metrics:                 metrics,
 	}, n.svc, n.cache)
 	n.pump = p
 	pumpCtx, cancel := context.WithCancel(ctx)
@@ -84,6 +106,34 @@ func (n *pumpNode) startPump(ctx context.Context, t *testing.T, peers []string) 
 			t.Logf("pump %x did not stop within 2s", n.nodeID[:4])
 		}
 	})
+}
+
+type observedSearchConfigMetrics struct {
+	gate         *readiness.Gate
+	observations chan bool
+	snapshots    atomic.Int32
+}
+
+func (m *observedSearchConfigMetrics) OnPumpConnect(peer string) {
+	m.gate.OnPumpConnect(peer)
+}
+func (m *observedSearchConfigMetrics) OnPumpDisconnect(peer, reason string) {
+	m.gate.OnPumpDisconnect(peer, reason)
+}
+func (m *observedSearchConfigMetrics) OnPumpApply(peer string) { m.gate.OnPumpApply(peer) }
+func (m *observedSearchConfigMetrics) OnPumpDropSelfEcho(peer string) {
+	m.gate.OnPumpDropSelfEcho(peer)
+}
+func (m *observedSearchConfigMetrics) OnPumpSnapshotReplayed(peer string, vertices, edges uint64, duration time.Duration) {
+	m.snapshots.Add(1)
+	m.gate.OnPumpSnapshotReplayed(peer, vertices, edges, duration)
+}
+func (m *observedSearchConfigMetrics) OnSearchConfig(peer string, matched bool) {
+	m.gate.OnSearchConfig(peer, matched)
+	select {
+	case m.observations <- matched:
+	default:
+	}
 }
 
 // waitForVertex polls cache.GetVertex until the key appears or the
@@ -201,6 +251,120 @@ func TestPeerPump_E2E_ThreeNodeConvergence(t *testing.T) {
 	if last, ok := c.log.LastSeq(); !ok || last != wantClusterWrites {
 		t.Errorf("c.log.LastSeq=%d ok=%v want %d", last, ok, wantClusterWrites)
 	}
+	waitForSearchConvergence(t, ctx, "from", nil, a.raw, b.raw, c.raw)
+}
+
+// TestPeerPump_SearchPartitionHealConvergence starts a follower only after a
+// production-search corpus has changed on the primary, then exercises the live
+// Subscribe tail across overwrite, singular/batch/prefix delete, tombstones,
+// TTL, structured/typed values, and implicit edge endpoints. Homogeneous
+// replicas must converge to identical key order and score bits.
+func TestPeerPump_SearchPartitionHealConvergence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping search partition-heal test in short mode")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	primary := newPumpNode(t, hlc.NodeID{0xD1})
+	follower := newPumpNode(t, hlc.NodeID{0xD2})
+	if err := primary.sdk.PutVertices(ctx, []client.VertexInput{
+		{Key: "search/keep", Value: "common lantern alpha", Expiration: time.Now().Add(time.Hour)},
+		{Key: "search/overwrite", Value: "common retiredterm", Expiration: time.Now().Add(time.Hour)},
+		{Key: "search/delete-one", Value: "common deletedterm", Expiration: time.Now().Add(time.Hour)},
+		{Key: "search/delete-batch-a", Value: "common batchterm", Expiration: time.Now().Add(time.Hour)},
+		{Key: "search/delete-batch-b", Value: "common batchterm", Expiration: time.Now().Add(time.Hour)},
+		{Key: "search/delete-prefix/a", Value: "common prefixterm", Expiration: time.Now().Add(time.Hour)},
+		{Key: "search/delete-prefix/b", Value: "common prefixterm", Expiration: time.Now().Add(time.Hour)},
+		{Key: "search/json", Value: `{"title":"common structuredvalue","ignored":42}`, Expiration: time.Now().Add(time.Hour)},
+		{Key: "search/int", Value: int64(4242), Expiration: time.Now().Add(time.Hour)},
+		{Key: "search/ttl", Value: "common expiredterm", Expiration: time.Now().Add(250 * time.Millisecond)},
+	}); err != nil {
+		t.Fatalf("seed PutVertices: %v", err)
+	}
+	if _, err := primary.sdk.AddEdge(ctx, "search/implicit-tail", "search/implicit-head", 1, time.Hour); err != nil {
+		t.Fatalf("seed implicit endpoints: %v", err)
+	}
+	// Born-expired input is accepted as an idempotent no-op and must never
+	// enter either graph or derived index.
+	if err := primary.sdk.PutVertexAt(ctx, "search/born-expired", "bornexpiredterm", time.Now().Add(-time.Second)); err != nil {
+		t.Fatalf("born-expired PutVertexAt: %v", err)
+	}
+
+	// The follower was partitioned for every seed mutation. Starting its pump
+	// now heals through the retained Subscribe tail rather than shared memory.
+	follower.startPump(ctx, t, []string{primary.url})
+	waitForSearchConvergence(t, ctx, "common", nil, primary.raw, follower.raw)
+
+	if err := primary.sdk.PutVertex(ctx, "search/overwrite", "common currentterm", time.Hour); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	if _, err := primary.sdk.DeleteVertex(ctx, "search/delete-one"); err != nil {
+		t.Fatalf("DeleteVertex: %v", err)
+	}
+	if _, err := primary.sdk.DeleteVertices(ctx, []string{"search/delete-batch-a", "search/delete-batch-b"}); err != nil {
+		t.Fatalf("DeleteVertices: %v", err)
+	}
+	if _, err := primary.sdk.DeleteVerticesByPrefix(ctx, "search/delete-prefix/"); err != nil {
+		t.Fatalf("DeleteVerticesByPrefix: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+
+	exactAll := &pb.SearchOptions{MatchMode: pb.MatchMode_MATCH_MODE_ALL}
+	for _, retired := range []string{"retiredterm", "deletedterm", "batchterm", "prefixterm", "expiredterm", "bornexpiredterm"} {
+		if got := waitForSearchConvergence(t, ctx, retired, exactAll, primary.raw, follower.raw); len(got) != 0 {
+			t.Errorf("retired query %q still matched: %+v", retired, got)
+		}
+	}
+	for _, live := range []string{"currentterm", "structuredvalue", "4242", "implicit"} {
+		if got := waitForSearchConvergence(t, ctx, live, exactAll, primary.raw, follower.raw); len(got) == 0 {
+			t.Errorf("live query %q returned no hits", live)
+		}
+	}
+	if got := waitForSearchConvergence(t, ctx, "common", exactAll, primary.raw, follower.raw); len(got) != 3 {
+		t.Fatalf("final common corpus = %+v, want three live documents", got)
+	}
+}
+
+func TestPeerPump_SearchConfigMismatchBlocksReadiness(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	primary := newPumpNodeWithSearch(t, hlc.NodeID{0xE1}, 1024, true)
+	follower := newPumpNodeWithSearch(t, hlc.NodeID{0xE2}, 1024, false)
+	if err := primary.sdk.PutVertex(ctx, "mismatch-proof", "graph still converges", time.Hour); err != nil {
+		t.Fatalf("primary PutVertex: %v", err)
+	}
+
+	peerStatus, err := newReplicationRawClient(t, primary.url).PeerStatus(ctx, connect.NewRequest(&pb.PeerStatusRequest{}))
+	if err != nil {
+		t.Fatalf("PeerStatus: %v", err)
+	}
+	remoteFingerprint := peerStatus.Msg.GetSearchConfigFingerprint()
+	if remoteFingerprint == "" || remoteFingerprint != primary.svc.SearchConfigFingerprint() {
+		t.Fatalf("peer search fingerprint = %q, primary = %q", remoteFingerprint, primary.svc.SearchConfigFingerprint())
+	}
+	if remoteFingerprint == follower.svc.SearchConfigFingerprint() {
+		t.Fatal("positions mismatch produced identical search fingerprints")
+	}
+
+	gate := readiness.NewGate(100, true, nil)
+	metrics := &observedSearchConfigMetrics{gate: gate, observations: make(chan bool, 1)}
+	follower.startPumpWithMetrics(ctx, t, []string{primary.url}, metrics)
+	select {
+	case matched := <-metrics.observations:
+		if matched {
+			t.Fatal("pump reported mismatched search configs as compatible")
+		}
+	case <-ctx.Done():
+		t.Fatal("pump did not publish search config comparison")
+	}
+	if !waitForVertex(t, follower.cache, "mismatch-proof", 3*time.Second) {
+		t.Fatal("graph replication stopped on a search config mismatch")
+	}
+	if gate.Ready() {
+		t.Fatal("heterogeneous search config masqueraded as ready")
+	}
 }
 
 // TestPeerPump_EmptyPeers_NoOp asserts that an empty peer list yields
@@ -236,7 +400,7 @@ func TestPeerPump_GapRecoverySnapshot(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	primary := newPumpNode(t, hlc.NodeID{0xA1})
+	primary := newPumpNodeWithSearch(t, hlc.NodeID{0xA1}, 4, true)
 	// Pre-populate the primary BEFORE the follower attaches. With a
 	// small ring buffer the follower's effective request (empty
 	// cursor → server starts at oldest = 1) will be below firstSeq
@@ -249,7 +413,10 @@ func TestPeerPump_GapRecoverySnapshot(t *testing.T) {
 	}
 
 	follower := newPumpNode(t, hlc.NodeID{0xA2})
-	follower.startPump(ctx, t, []string{primary.url})
+	metrics := &observedSearchConfigMetrics{
+		gate: readiness.NewGate(100, true, nil), observations: make(chan bool, 1),
+	}
+	follower.startPumpWithMetrics(ctx, t, []string{primary.url}, metrics)
 
 	// Snapshot should replay all 16 pre-existing vertices.
 	for i := 0; i < 16; i++ {
@@ -271,4 +438,10 @@ func TestPeerPump_GapRecoverySnapshot(t *testing.T) {
 	if !waitForVertex(t, follower.cache, "post-snapshot", 3*time.Second) {
 		t.Errorf("follower did not receive post-snapshot vertex via resubscribe")
 	}
+	time.Sleep(100 * time.Millisecond)
+	if got := metrics.snapshots.Load(); got != 1 {
+		t.Fatalf("snapshot replay count = %d, want exactly 1 before live tail", got)
+	}
+	waitForSearchConvergence(t, ctx, "pre", nil, primary.raw, follower.raw)
+	waitForSearchConvergence(t, ctx, "post snapshot", nil, primary.raw, follower.raw)
 }

--- a/tests/integration/search_vertices_test.go
+++ b/tests/integration/search_vertices_test.go
@@ -133,12 +133,6 @@ func conformanceSDKOptions(options searchConformanceOptions) []client.SearchOpti
 	return out
 }
 
-func newProductionSearchCache(ttl time.Duration, enabled, positions bool, limits search.SearchAnalysisLimits) *graphcache.GraphCache[string, *pb.Vertex] {
-	return provider.NewGraphCache(provider.CacheConfig{TTL: ttl}, provider.SearchConfig{
-		Enabled: enabled, Positions: positions, AnalysisLimits: limits,
-	})
-}
-
 func wireSearchErrorReason(t *testing.T, err error) pb.SearchErrorReason {
 	t.Helper()
 	return wireSearchErrorDetail(t, err).GetReason()

--- a/tests/integration/snapshot_test.go
+++ b/tests/integration/snapshot_test.go
@@ -28,6 +28,7 @@ type snapshotPeer struct {
 	clock *hlc.Clock
 	log   *mutationlog.Log
 	sdk   *client.Lantern
+	raw   graphv1connect.LanternServiceClient
 	repl  graphv1connect.LanternReplicationServiceClient
 }
 
@@ -43,10 +44,14 @@ func newSnapshotPeer(t *testing.T, nodeID hlc.NodeID) *snapshotPeer {
 	log := mutationlog.New(mutationlog.Options{Capacity: 1024, SubscriberBuffer: 1024})
 	t.Cleanup(func() { _ = log.Close() })
 	clock := hlc.New(nodeID, hlc.Options{})
-	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
-	svc := service.NewLanternService(cache).WithReplication(log, clock, nil)
+	limits := productionSearchLimits(true, true)
+	cache := newProductionSearchCache(time.Minute, true, true, limits.AnalysisLimits)
+	svc := service.NewLanternService(cache).
+		WithSearchLimits(limits).
+		WithReplication(log, clock, nil)
 	rep := service.NewLanternReplicationService(log, cache, clock).
-		WithOriginStates(svc)
+		WithOriginStates(svc).
+		WithSearchConfig(svc)
 	srv := newConnectTestServer(t, svc, rep, vi.ConnectInterceptor())
 
 	return &snapshotPeer{
@@ -54,6 +59,7 @@ func newSnapshotPeer(t *testing.T, nodeID hlc.NodeID) *snapshotPeer {
 		clock: clock,
 		log:   log,
 		sdk:   newConnectClientFor(t, srv.url),
+		raw:   graphv1connect.NewLanternServiceClient(h2cClient(), srv.url),
 		repl:  newReplicationRawClient(t, srv.url),
 	}
 }
@@ -63,10 +69,9 @@ func newSnapshotPeer(t *testing.T, nodeID hlc.NodeID) *snapshotPeer {
 // with a mix of vertices and additive edges, replays every frame
 // into its own cache via the HLC + ContribID seams, and observes the
 // same Illuminate answers as the primary. The header's per-origin
-// cutoff is also asserted to equal the primary's local writes
-// watermark at snapshot-open time so that downstream
-// `Subscribe(from_seq_per_origin = {origin: seq+1})` is guaranteed
-// to stitch cleanly (#415, B-4).
+// origin and responder-local cutoffs are asserted at snapshot-open time so a
+// downstream Subscribe carrying both +1 cursors is guaranteed to stitch
+// cleanly (#415, B-4).
 func TestSnapshot_E2E_PrimaryToFollower(t *testing.T) {
 	primary := newSnapshotPeer(t, hlc.NodeID{0x01})
 	follower := newSnapshotPeer(t, hlc.NodeID{0x02})
@@ -132,6 +137,9 @@ func TestSnapshot_E2E_PrimaryToFollower(t *testing.T) {
 	if hdr.GetCutoffHlc() == nil {
 		t.Errorf("cutoff_hlc is nil; expected the primary clock's current Now()")
 	}
+	if got := hdr.GetCutoffLocalSeq(); got != wantSeq {
+		t.Errorf("cutoff_local_seq=%d want %d", got, wantSeq)
+	}
 
 	// Stream body: apply each frame to the follower using the HLC +
 	// ContribID seams. Footer MUST be the very last frame.
@@ -140,6 +148,14 @@ func TestSnapshot_E2E_PrimaryToFollower(t *testing.T) {
 		gotEdgeCount   uint64
 		footer         *pb.SnapshotFooter
 	)
+	follower.cache.BeginSearchIndexRecovery()
+	recovering, err := follower.raw.GetServerStatus(ctx, connect.NewRequest(&pb.GetServerStatusRequest{}))
+	if err != nil {
+		t.Fatalf("follower GetServerStatus during snapshot: %v", err)
+	}
+	if got := recovering.Msg.GetSearch().GetIndexStats().GetHealth(); got != pb.SearchIndexHealth_SEARCH_INDEX_HEALTH_INCOMPLETE {
+		t.Fatalf("follower search health during snapshot = %v", got)
+	}
 	for stream.Receive() {
 		entry := stream.Msg()
 		switch e := entry.GetEntry().(type) {
@@ -196,6 +212,9 @@ func TestSnapshot_E2E_PrimaryToFollower(t *testing.T) {
 	if got := uint64(5); footer.GetEdgeCount() != got {
 		t.Errorf("edge_count=%d want %d", footer.GetEdgeCount(), got)
 	}
+	if err := follower.cache.CompleteSearchIndexRecovery(); err != nil {
+		t.Fatalf("follower CompleteSearchIndexRecovery: %v", err)
+	}
 
 	// Verify convergence: every (tail, head) pair has the same weight
 	// on both peers and every vertex round-trips.
@@ -221,6 +240,14 @@ func TestSnapshot_E2E_PrimaryToFollower(t *testing.T) {
 		if !pok || !fok {
 			t.Errorf("vertex %s presence mismatch: primary=%v follower=%v", key, pok, fok)
 		}
+	}
+	waitForSearchConvergence(t, ctx, "val", nil, primary.raw, follower.raw)
+	healthy, err := follower.raw.GetServerStatus(ctx, connect.NewRequest(&pb.GetServerStatusRequest{}))
+	if err != nil {
+		t.Fatalf("follower GetServerStatus after snapshot: %v", err)
+	}
+	if got := healthy.Msg.GetSearch().GetIndexStats().GetHealth(); got != pb.SearchIndexHealth_SEARCH_INDEX_HEALTH_HEALTHY {
+		t.Fatalf("follower search health after snapshot = %v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- run production-equivalent search indexing through real Connect/h2c HA fixtures and compare exact hit order plus score bits after live replication, partition heal, pump snapshot+tail, anti-entropy snapshot repair, TTL/delete/overwrite convergence, and backup restore
- mark the derived search index incomplete during snapshot/restore replay, rebuild it from the complete live graph before healthy status, and report restore metrics from actual written responses
- publish the search config fingerprint through PeerStatus, block replicated readiness on mismatches, and expose bounded-cardinality compatibility metrics
- stitch snapshots to the live mutation tail with an explicit same-responder local-log cutoff while keeping portable per-origin cursors gap-safe
- document SearchVertices as local/eventual during lag and failover, plus the recovery and operator contracts

## Root cause

The existing HA and backup fixtures used search-disabled caches, so graph convergence could pass while the derived index diverged. Snapshot/restore replay also had no explicit incomplete/rebuild lifecycle, restore accounting counted attempted rows, and search-affecting config was invisible to peer readiness. While adding the gap gate, the test also exposed that the pump re-requested local seq 1 after every snapshot and could loop forever.

## Impact

Homogeneous replicas with the same live graph now converge to identical ordered search responses. During lag, partition, config mismatch, or incomplete recovery, status/readiness and SearchVertices fail-closed behavior make the local state explicit instead of presenting partial results as converged.

## Validation

- `gofmt -l .` and `go test ./...` in root, `pb`, `core`, `sdks/go`, `server`, and `mcp`
- Node SDK format, lint, typecheck, example typecheck, 149 tests, and build
- Dart SDK scoped format check, analyze, and 69 tests
- Flutter example analyze and test
- Go, Dart, and TypeScript protobuf regeneration drift checks

Closes #1062