### PR TITLE
fix(bench): block releases on truthful search gates

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -1,15 +1,17 @@
 name: Bench (nightly leak gate)
 
-# Nightly BLOCKING leak + perf gate. Runs the same compact scenario sweep as
+# Nightly BLOCKING leak + metric + semantic + perf gate. Runs the same compact scenario sweep as
 # the release-time bench (testbed/bench/release-scenarios.txt) against a
 # freshly-built lantern:local image, but — unlike the release bench, which is
 # deliberately `continue-on-error` so a hiccup can never block shipping
 # (#256, #394) — this job has NO continue-on-error. release.sh exits non-zero
-# when any scenario's goroutine/heap leak gate trips OR any scenario's
-# perf_gate floors (min steady rps / max p99 / max non-OK ratio, #935) are
-# breached, so a leak or step-change performance regression fails this
+# when any scenario's goroutine/heap leak gate, lifecycle metric gate,
+# semantic probe, or perf floor trips. Per-producer Search gates prevent fast
+# Put traffic from hiding a slow Search family, so a correctness, retention,
+# or step-change performance regression fails this
 # nightly check rather than merely warning in an advisory artifact.
-# This is the enforcement half of #716 (leaks) and #935 (perf floors).
+# This is the enforcement half of #716 (leaks), #935 (perf floors), and #1063
+# (Search qualification).
 #
 # It also runs with RELEASE_BENCH_BUDGET_SECONDS=0 (the sweep's graceful
 # wall-clock cutoff disabled), so every scenario runs to completion and no leak
@@ -70,6 +72,12 @@ jobs:
             "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
           sudo chmod +x /usr/local/bin/yq
           yq --version
+      - name: Run deterministic advanced Search wire contracts
+        # search_churn covers positions-on plus every advanced producer. This
+        # real-h2c test adds the positions-off fail-closed contract without
+        # relying on shared-runner timing.
+        run: |
+          go test ./tests/integration -run 'TestSearchVertices_(OptionsContract|PositionsOff)$'
       - name: Build lantern:local image
         run: |
           docker build \

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,8 +21,178 @@ jobs:
   verify:
     uses: ./.github/workflows/_verify.yml
 
-  build:
+  search-qualification:
+    name: Search release qualification
     needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout tagged commit
+        id: checkout
+        continue-on-error: true
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        id: setup-go
+        continue-on-error: true
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.5'
+          check-latest: true
+
+      - name: Verify checked-out tag SHA
+        id: tag-sha
+        continue-on-error: true
+        run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+
+      - name: Qualify request-boundary decisions
+        id: request-boundary
+        continue-on-error: true
+        run: |
+          go test ./server/service -run 'TestSearchVertices_(PhraseWithoutPositionsFailsClosed|RejectsInvalidOptionsBeforeBackend|AcceptsOptionsDecisionTable)$'
+
+      - name: Qualify production wire semantics
+        id: wire-semantics
+        continue-on-error: true
+        run: |
+          go test ./tests/integration -run 'TestSearchVertices_(OptionsContract|ProductionStructuredFieldsOverRealH2C|LifecycleConvergenceOverProductionComposition|PositionsOff)$'
+
+      - name: Qualify HA Search convergence
+        id: ha-convergence
+        continue-on-error: true
+        run: |
+          go test ./tests/integration -run 'Test(PeerPump_SearchPartitionHealConvergence|AntiEntropy_GappedLogRebuildsExactSearchIndex)$'
+
+      - name: Install bench prerequisites
+        id: bench-prerequisites
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          GHZ_VERSION="0.121.0"
+          curl -fsSL -o /tmp/ghz.tgz \
+            "https://github.com/bojand/ghz/releases/download/v${GHZ_VERSION}/ghz-linux-x86_64.tar.gz"
+          sudo tar -xzf /tmp/ghz.tgz -C /usr/local/bin ghz
+          sudo chmod +x /usr/local/bin/ghz
+          YQ_VERSION="v4.45.4"
+          sudo curl -fsSL -o /usr/local/bin/yq \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          sudo chmod +x /usr/local/bin/yq
+          ghz --version
+          yq --version
+
+      - name: Build tagged lantern:local image
+        id: qualification-image
+        continue-on-error: true
+        run: |
+          docker build \
+            --build-arg VERSION=${{ github.ref_name }} \
+            --build-arg COMMIT=${{ github.sha }} \
+            -t lantern:local .
+
+      - name: Run short Search qualification scenario
+        id: qualification-scenario
+        continue-on-error: true
+        env:
+          COMPOSE_PROJECT_NAME: lantern-search-qualification
+          LANTERN_IMAGE: lantern:local
+          LEAK_GATE_ONLY: "1"
+        run: ./testbed/bench/run.sh search_qualification
+
+      - name: Record qualification stages
+        if: always()
+        env:
+          CHECKOUT: ${{ steps.checkout.outcome }}
+          SETUP_GO: ${{ steps.setup-go.outcome }}
+          TAG_SHA: ${{ steps.tag-sha.outcome }}
+          REQUEST_BOUNDARY: ${{ steps.request-boundary.outcome }}
+          WIRE_SEMANTICS: ${{ steps.wire-semantics.outcome }}
+          HA_CONVERGENCE: ${{ steps.ha-convergence.outcome }}
+          BENCH_PREREQUISITES: ${{ steps.bench-prerequisites.outcome }}
+          QUALIFICATION_IMAGE: ${{ steps.qualification-image.outcome }}
+          QUALIFICATION_SCENARIO: ${{ steps.qualification-scenario.outcome }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg tag "$GITHUB_REF_NAME" \
+            --arg sha "$GITHUB_SHA" \
+            --arg checkout "$CHECKOUT" \
+            --arg setup_go "$SETUP_GO" \
+            --arg tag_sha "$TAG_SHA" \
+            --arg request_boundary "$REQUEST_BOUNDARY" \
+            --arg wire_semantics "$WIRE_SEMANTICS" \
+            --arg ha_convergence "$HA_CONVERGENCE" \
+            --arg bench_prerequisites "$BENCH_PREREQUISITES" \
+            --arg qualification_image "$QUALIFICATION_IMAGE" \
+            --arg qualification_scenario "$QUALIFICATION_SCENARIO" '
+              def status($outcome):
+                if $outcome == "success" then "pass"
+                elif $outcome == "skipped" then "skipped"
+                else "fail"
+                end;
+              [
+                {name:"checkout", status:status($checkout)},
+                {name:"setup_go", status:status($setup_go)},
+                {name:"verify_tag_sha", status:status($tag_sha)},
+                {name:"request_boundary", status:status($request_boundary)},
+                {name:"production_wire_semantics", status:status($wire_semantics)},
+                {name:"ha_search_convergence", status:status($ha_convergence)},
+                {name:"bench_prerequisites", status:status($bench_prerequisites)},
+                {name:"build_tagged_image", status:status($qualification_image)},
+                {name:"search_qualification_scenario", status:status($qualification_scenario)}
+              ] as $stages |
+              [{name:"search_qualification", status:status($qualification_scenario)}] as $scenarios |
+              {
+                tag:$tag,
+                commit_sha:$sha,
+                stages:$stages,
+                scenarios:$scenarios,
+                verdict:(if all($stages[]; .status == "pass") then "pass" else "fail" end)
+              }
+            ' > qualification-report.json
+          {
+            echo '# Search release qualification'
+            echo
+            echo "- Tag: \`$GITHUB_REF_NAME\`"
+            echo "- Commit SHA: \`$GITHUB_SHA\`"
+            echo "- Verdict: \`$(jq -r .verdict qualification-report.json)\`"
+            echo
+            echo '| stage | status |'
+            echo '| --- | --- |'
+            jq -r '.stages[] | "| `\(.name)` | `\(.status)` |"' qualification-report.json
+            echo
+            echo '| scenario | status |'
+            echo '| --- | --- |'
+            jq -r '.scenarios[] | "| `\(.name)` | `\(.status)` |"' qualification-report.json
+          } > qualification-report.md
+          scenario_report="$(find testbed/bench/out/search_qualification -name report.md -type f 2>/dev/null | sort | tail -1 || true)"
+          if [[ -n "$scenario_report" ]]; then
+            cp "$scenario_report" qualification-scenario-report.md
+          fi
+
+      - name: Upload Search qualification report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: search-qualification-${{ github.sha }}
+          path: |
+            qualification-report.json
+            qualification-report.md
+            qualification-scenario-report.md
+            testbed/bench/out/search_qualification/**/semantic_*.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Enforce Search qualification
+        if: always()
+        run: test "$(jq -r .verdict qualification-report.json)" = pass
+
+  build:
+    # The multi-arch image must never publish from a tag whose deterministic
+    # Search qualification failed or was skipped. GitHub Release depends on
+    # this job, so the same gate also blocks release publication.
+    needs: [verify, search-qualification]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -100,12 +270,13 @@ jobs:
     # Release-time benchmark sweep. Runs the compact scenario set
     # listed in testbed/bench/release-scenarios.txt against a freshly-built
     # local image and uploads a fixed-format bench-report.md for the release
-    # job to splice into the release notes. Non-blocking: a leak-gate
+    # job to splice into the release notes. Non-blocking: a lifecycle/perf
     # failure or harness hiccup must not prevent a release from shipping
-    # (the deliberate design of #256, #394). Leak ENFORCEMENT instead lives in
+    # (the deliberate design of #256, #394). This full profiling sweep is
+    # separate from the short blocking search-qualification job above.
+    # Scheduled lifecycle/perf ENFORCEMENT also lives in
     # the nightly blocking run (.github/workflows/bench-nightly.yml), which
-    # runs this same sweep WITHOUT continue-on-error so a goroutine/heap-leak
-    # regression fails a required check rather than just warning here (#716).
+    # runs this same sweep WITHOUT continue-on-error (#716, #1063).
     name: Release-time benchmark
     needs: verify
     runs-on: ubuntu-latest
@@ -166,7 +337,9 @@ jobs:
 
   binaries:
     name: Build CLI + server binaries
-    needs: verify
+    # GoReleaser may also publish Homebrew casks, so it shares the blocking
+    # Search qualification with the container image and GitHub Release.
+    needs: [verify, search-qualification]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,11 +265,17 @@ Tag order matters because each downstream module pins its upstream tag:
    VCS, so there is no artifact to push.
 4. Bump the matching `require`/`replace` lines in the root `go.mod` to the freshly-tagged
    versions.
-5. Root `vX.Y.Z` — triggers `docker-publish.yml` (multi-arch buildx + cosign keyless),
-   which also runs the release-time bench sweep and splices a report into the notes. The
-   bench job is **non-blocking**: if it fails or is cancelled the release still ships
-   with a placeholder bench section (the `release` job's `needs:` deliberately excludes
-   `bench`, because Actions treats `cancelled` as neither success nor failure).
+5. Root `vX.Y.Z` — triggers `docker-publish.yml`. Before any multi-arch image or GitHub
+   Release can publish, the tagged SHA must pass the short blocking Search qualification:
+   request-boundary tests, production real-h2c semantics, HA convergence, and the fresh
+   three-replica `search_qualification` scenario. Its artifact records the tag, full SHA,
+   and an explicit pass/fail/skipped status for every stage and scenario; any non-success
+   blocks the image and GoReleaser jobs. The workflow separately runs the full
+   release-time bench sweep and splices its report into the notes. That profiling bench
+   remains **non-blocking**: if it fails
+   or is cancelled the release still uses a placeholder bench section (the `release`
+   job's `needs:` deliberately excludes `bench`, because Actions treats `cancelled` as
+   neither success nor failure).
 
 The root release also builds the `lantern` (server) and `lantern-cli` binaries via
 GoReleaser and pushes Homebrew casks to

--- a/testbed/bench/README.md
+++ b/testbed/bench/README.md
@@ -2,20 +2,24 @@
 
 Reusable performance + memory-leak harness for the HA `docker compose`
 cluster (see `deploy/compose/`). Drives the cluster with [`ghz`][ghz],
-captures Prometheus range queries + Go pprof snapshots, applies a
-per-scenario leak gate, and renders a Markdown report.
+captures Prometheus range queries + Go pprof snapshots, applies per-scenario
+leak / lifecycle-metric / semantic / producer-performance gates, and renders a
+Markdown report.
 
-> **PR CI does not run this harness.** Per the parent epic [#237], the
-> default PR pipeline runs only fast functional checks; this harness is a
-> local / on-demand tool meant to be used by maintainers when investigating
-> performance or leak regressions. Its outputs (under `testbed/bench/out/`)
-> are git-ignored.
+> **PR CI does not run the wall-clock scenarios.** The default PR pipeline
+> runs their schema/contract tests, but not a Compose load run. On a root
+> `vX.Y.Z` tag, however, `docker-publish.yml` runs the short
+> `search_qualification` scenario plus targeted real-h2c Search tests as a
+> blocking qualification. A failed or skipped stage prevents image and GitHub
+> Release publication. Its bounded artifact records the tag, full commit SHA,
+> every stage status, and the scenario report.
 >
 > **Release CI runs a compact canonical sweep.** On every `vX.Y.Z` tag
 > push, the `Release` workflow runs `./testbed/bench/release.sh` — a
 > driver that sweeps the scenarios listed in `release-scenarios.txt`. To
-> keep wall-time bounded without losing coverage, the sweep is six
-> scenarios: two fan-out scenarios (`broad_rw`, `broad_illuminate`) that
+> keep wall-time bounded without losing coverage, the sweep is seven
+> scenarios: three fan-out scenarios (`broad_rw`, `broad_mutate`,
+> `broad_illuminate`) that
 > exercise many call paths inside a single steady window (read / write /
 > batch / scan / edge / delete / ScanVertexKeys / CountVerticesByPrefix /
 > idempotent AddEdge, and the Illuminate algorithm/reduction × objective ×
@@ -23,13 +27,15 @@ per-scenario leak gate, and renders a Markdown report.
 > / thread-safety under churn, #703), and `replication_apply_churn`
 > (vertexHLC map regression gate, #700 / #705). It produces a
 > fixed-format `bench-report.md` that is spliced into the GitHub Release
-> notes. The bench job is `continue-on-error`, so a noisy runner cannot
-> block a release. See issues [#256], [#262], [#573], [#708].
+> notes. This full profiling sweep remains `continue-on-error`, so a noisy
+> runner cannot block a release; it is separate from the short blocking Search
+> qualification above. See issues [#256], [#262], [#573], [#708], [#1063].
 
 [#256]: https://github.com/anaregdesign/lantern/issues/256
 [#262]: https://github.com/anaregdesign/lantern/issues/262
 [#573]: https://github.com/anaregdesign/lantern/issues/573
 [#708]: https://github.com/anaregdesign/lantern/issues/708
+[#1063]: https://github.com/anaregdesign/lantern/issues/1063
 
 ## Prerequisites
 
@@ -64,10 +70,9 @@ SKIP_UP=1 KEEP_UP=1 ./testbed/bench/run.sh mixed_rw
 PPROF_CPU=1 ./testbed/bench/run.sh addedge_contention
 ```
 
-The exit code folds together the leak-gate verdict and — when the
-scenario declares a `perf_gate:` block — the perf-gate verdict
-(`0` = both pass, `1` = either failed). Run artifacts are written under
-`testbed/bench/out/<scenario>/<UTC-timestamp>/`.
+The exit code folds together the leak gate and any declared metric, semantic,
+and perf gates (`0` = all pass, `1` = at least one failed). Run artifacts are
+written under `testbed/bench/out/<scenario>/<UTC-timestamp>/`.
 
 ## Scenarios
 
@@ -84,7 +89,8 @@ scenario declares a `perf_gate:` block — the perf-gate verdict
 | `replication_soak.yaml`   | producer on r0, `Subscribe` consumers on r1/r2 for 10m |
 | `chaos_kill_replica.yaml` | mid-load `docker kill` + restart of one replica |
 | `many_subscribers.yaml`   | N concurrent `Subscribe` streams across replicas (#240 pubsub probe) |
-| `search_churn.yaml`       | PutVertex (short TTL) + parallel SearchVertices; asserts search-index decays (#703) |
+| `search_churn.yaml`       | PutVertex (short TTL) + all advanced SearchVertices families; per-producer perf plus semantic/index-decay gates (#1048) |
+| `search_qualification.yaml` | short fresh-cluster tag-SHA gate; deterministic Search semantics, TTL cleanup, metric, leak, and producer perf contracts (#1063) |
 | `prefix_surface.yaml`     | ScanVertexKeys + ScanEdges + CountVerticesByPrefix + DeleteVerticesByPrefix fan-out (#704) |
 | `replication_apply_churn.yaml` | replicated write churn; asserts `lantern_vertex_hlc_entries` returns to baseline (#700, #705) |
 | `edge_contrib_idempotent.yaml` | AddEdge/AddEdges with repeated ContribIDs; verifies at-most-once dedup stays bounded (#706) |
@@ -101,6 +107,11 @@ live memory rather than span-level allocator headroom. The legacy field
 name `heap_inuse_max_delta_mb` is still accepted for backward
 compatibility but produced false-positive verdicts under sustained
 churn — see issue #248.
+
+For fan-out targets, each `target.calls[]` entry may declare its own positive
+integer `rps`. Otherwise the phase RPS is divided equally. Use explicit RPS
+when one producer must not borrow throughput from another; `search_churn` does
+this so a fast `PutVertex` cannot conceal a slow Search family.
 
 RPC benchmark payloads that omit `Vertex.expiration` / `Edge.expiration`
 write permanent entries. `cluster.default_ttl_seconds` configures the server's
@@ -157,6 +168,40 @@ perf_gate:
 All named producer gates are conjunctive with the aggregate gate and appear
 as separate rows in `perf_gate.json` and the rendered report.
 
+### Lifecycle metric gate (`metric_gate:` block)
+
+`metric_gate.metrics` compares each replica's unlabeled gauge in the pre/post
+runtime snapshots. Thresholds on a metric are conjunctive:
+
+```yaml
+metric_gate:
+  metrics:
+    lantern_search_index_docs:
+      max_increase: 256
+      max_ratio: 1.25
+    lantern_search_index_expiration_purged:
+      min_increase: 1
+    lantern_search_index_healthy:
+      min_post: 1
+      max_post: 1
+```
+
+Available comparisons are `max_increase`, `max_ratio`, `min_increase`,
+`min_post`, and `max_post`. Missing or non-finite samples fail closed. Ratio
+growth from a zero baseline also fails when post is positive; pair ratio and
+absolute limits intentionally rather than using ratio as a noise filter. The
+verdict is written to `metric_gate.json` and folds into `run.sh`'s exit code.
+
+### Search semantic gate (`semantic_gate:` block)
+
+`semantic_gate.kind: search` seeds a deterministic fixture before warmup and
+checks every replica both before and after steady load. It proves a persistent
+hit, deleted/expired absence, stable ordering, key-prefix filtering, phrase,
+fuzzy-1/2, prefix-term, ALL, and MIN_SHOULD behavior. An HTTP-OK response with
+empty hits therefore fails. The bounded `semantic_pre.json` and
+`semantic_post.json` artifacts contain only phase, replica endpoint, check
+count, and verdict—never query text, prefixes, keys, or values.
+
 Sizing rules (all seven release scenarios carry a block sized this way):
 
 - Floors are **ratchet floors with ≥2x headroom** over the worst nightly
@@ -169,9 +214,10 @@ Sizing rules (all seven release scenarios carry a block sized this way):
   queue-depth p99 — observed varying 7x night-over-night — so they gate rps
   and non-OK only.
 - **Re-baseline after changing a scenario's mix.** Adding/removing a
-  `target.calls` entry re-splits per-call rps and shifts every observed
-  metric; drop the affected ceilings in the same PR and restore them (from
-  fresh nightly numbers, with headroom) after a few green nightlies.
+  `target.calls` entry re-splits RPS for entries without an explicit `rps` and
+  always shifts the offered mix; drop the affected ceilings in the same PR and
+  restore them (from fresh nightly numbers, with headroom) after a few green
+  nightlies.
 - When a perf floor legitimately moves (accepted throughput/latency
   trade-off), adjust it **in the same PR** and say so in the PR body — same
   contract as the coverage-floor ratchet in CONTRIBUTING.md.
@@ -182,8 +228,10 @@ Sizing rules (all seven release scenarios carry a block sized this way):
 testbed/bench/out/<scenario>/<ts>/
 ├── report.md                       # rendered summary (start here)
 ├── leak_gate.json                  # verdict + per-replica deltas + thresholds
+├── metric_gate.json                # per-replica pre/post gauge contracts (when declared)
+├── semantic_{pre,post}.json        # bounded Search semantic verdicts (when declared)
 ├── perf_gate.json                  # perf verdict + thresholds + observed (only when perf_gate: declared)
-├── runtime_pre.json                # per-replica go_goroutines + heap_alloc/heap_inuse/heap_objects, after warmup
+├── runtime_pre.json                # runtime values + unlabeled lifecycle gauges, after warmup
 ├── runtime_post.json               # same, after cooldown
 ├── ghz_warmup_<endpoint>.json      # raw ghz results, one per invocation
 ├── ghz_steady_<...>.json
@@ -223,14 +271,15 @@ testbed/bench/out/<scenario>/<ts>/
    `lantern_subscription_dropped_total` and
    `lantern_subscription_queue_depth_bucket` queries in `prom/`.
 
-## Why not in CI?
+## Why only the short qualification is blocking
 
-This harness needs real wall-clock time (multi-minute steady phases, a
-10-minute soak), a healthy Docker daemon, and stable host conditions to
-produce trustworthy numbers. Running it in CI would be both slow and
-flaky. The parent epic ([#237]) explicitly carves out this harness as a
-maintainer-driven tool; functional regressions are covered by the
-existing unit + integration suites that CI already runs.
+The full sweep needs multi-minute steady phases, a 10-minute soak, pprof and
+Prometheus capture, a healthy Docker daemon, and stable host conditions. It is
+therefore advisory at release time and blocking only in the untruncated
+nightly. Root tags additionally run the deliberately short, tolerant
+`search_qualification` scenario: deterministic semantic and lifecycle
+failures block, while loose throughput/p99 ratchets reject only step changes
+and tolerate normal hosted-runner jitter.
 
 [ghz]: https://ghz.sh/
 [yq]: https://github.com/mikefarah/yq

--- a/testbed/bench/capture/prom_queries_search.txt
+++ b/testbed/bench/capture/prom_queries_search.txt
@@ -1,0 +1,25 @@
+# Additional PromQL range queries captured only for scenarios with
+# semantic_gate.kind: search. Keeping this separate prevents Search diagnostics
+# from multiplying capture overhead across every unrelated release scenario.
+# Labels are bounded enums; query text, prefixes, keys, and values are absent.
+
+histogram_quantile(0.99, sum by (le) (rate(lantern_search_duration_seconds_bucket[30s])))
+sum by (instance, outcome, reason) (rate(lantern_search_calls_total[30s]))
+histogram_quantile(0.99, sum by (le, kind) (rate(lantern_search_work_bucket[30s])))
+histogram_quantile(0.99, sum by (le) (rate(lantern_search_results_bucket[30s])))
+max by (instance) (lantern_search_index_docs)
+max by (instance) (lantern_search_index_terms)
+max by (instance) (lantern_search_index_physical_documents)
+max by (instance) (lantern_search_index_expired_documents)
+max by (instance) (lantern_search_index_expiration_queue_entries)
+max by (instance) (lantern_search_index_expiration_purged)
+max by (instance) (lantern_search_index_last_expiration_purge_duration_seconds)
+max by (instance) (lantern_search_index_retained_term_slots)
+max by (instance) (lantern_search_index_retained_ordinals)
+max by (instance) (lantern_search_index_postings)
+max by (instance) (lantern_search_index_position_entries)
+max by (instance) (lantern_search_index_estimated_live_bytes)
+max by (instance) (lantern_search_index_estimated_retained_bytes)
+max by (instance) (lantern_search_index_rebuild_count)
+max by (instance) (lantern_search_index_last_rebuild_duration_seconds)
+max by (instance) (lantern_search_index_healthy)

--- a/testbed/bench/metricgate/main.go
+++ b/testbed/bench/metricgate/main.go
@@ -1,0 +1,259 @@
+// metricgate evaluates scenario-declared pre/post Prometheus metric contracts.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+type threshold struct {
+	MaxIncrease *float64 `json:"max_increase,omitempty" yaml:"max_increase"`
+	MaxRatio    *float64 `json:"max_ratio,omitempty" yaml:"max_ratio"`
+	MinIncrease *float64 `json:"min_increase,omitempty" yaml:"min_increase"`
+	MinPost     *float64 `json:"min_post,omitempty" yaml:"min_post"`
+	MaxPost     *float64 `json:"max_post,omitempty" yaml:"max_post"`
+}
+
+type scenarioDocument struct {
+	MetricGate struct {
+		Metrics map[string]threshold `yaml:"metrics"`
+	} `yaml:"metric_gate"`
+}
+
+type snapshotReplica struct {
+	Endpoint string              `json:"endpoint"`
+	Metrics  map[string]*float64 `json:"metrics"`
+}
+
+type result struct {
+	Endpoint   string    `json:"endpoint"`
+	Metric     string    `json:"metric"`
+	Thresholds threshold `json:"thresholds"`
+	Pre        *float64  `json:"pre,omitempty"`
+	Post       *float64  `json:"post,omitempty"`
+	Delta      *float64  `json:"delta,omitempty"`
+	Ratio      *float64  `json:"ratio,omitempty"`
+	Failures   []string  `json:"failures,omitempty"`
+	Verdict    string    `json:"verdict"`
+}
+
+type report struct {
+	Verdict string   `json:"verdict"`
+	Results []result `json:"results"`
+}
+
+func main() {
+	scenarioPath := flag.String("scenario", "", "scenario YAML containing metric_gate.metrics")
+	prePath := flag.String("pre", "", "pre-run runtime snapshot JSON")
+	postPath := flag.String("post", "", "post-run runtime snapshot JSON")
+	outPath := flag.String("out", "", "write the metric-gate report to this path")
+	flag.Parse()
+
+	if *scenarioPath == "" || *prePath == "" || *postPath == "" || *outPath == "" {
+		fatalf("-scenario, -pre, -post, and -out are required")
+	}
+	thresholds, err := loadThresholds(*scenarioPath)
+	if err != nil {
+		fatalf("load scenario: %v", err)
+	}
+	pre, err := loadSnapshot(*prePath)
+	if err != nil {
+		fatalf("load pre snapshot: %v", err)
+	}
+	post, err := loadSnapshot(*postPath)
+	if err != nil {
+		fatalf("load post snapshot: %v", err)
+	}
+
+	rep := evaluate(thresholds, pre, post)
+	encoded, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		fatalf("encode report: %v", err)
+	}
+	if err := os.WriteFile(*outPath, append(encoded, '\n'), 0o644); err != nil {
+		fatalf("write report: %v", err)
+	}
+	if rep.Verdict != "pass" {
+		os.Exit(1)
+	}
+}
+
+func loadThresholds(path string) (map[string]threshold, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var doc scenarioDocument
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, err
+	}
+	if len(doc.MetricGate.Metrics) == 0 {
+		return nil, errors.New("metric_gate.metrics is empty")
+	}
+	for name, t := range doc.MetricGate.Metrics {
+		if name == "" {
+			return nil, errors.New("metric name must not be empty")
+		}
+		if err := validateThreshold(t); err != nil {
+			return nil, fmt.Errorf("metric %s: %w", name, err)
+		}
+	}
+	return doc.MetricGate.Metrics, nil
+}
+
+func validateThreshold(t threshold) error {
+	if t.MaxIncrease == nil && t.MaxRatio == nil && t.MinIncrease == nil && t.MinPost == nil && t.MaxPost == nil {
+		return errors.New("at least one threshold is required")
+	}
+	for name, value := range map[string]*float64{
+		"max_increase": t.MaxIncrease,
+		"max_ratio":    t.MaxRatio,
+		"min_increase": t.MinIncrease,
+		"min_post":     t.MinPost,
+		"max_post":     t.MaxPost,
+	} {
+		if value != nil && (math.IsNaN(*value) || math.IsInf(*value, 0)) {
+			return fmt.Errorf("%s must be finite", name)
+		}
+	}
+	if t.MaxIncrease != nil && *t.MaxIncrease < 0 {
+		return errors.New("max_increase must be non-negative")
+	}
+	if t.MaxRatio != nil && *t.MaxRatio < 1 {
+		return errors.New("max_ratio must be at least 1")
+	}
+	if t.MinIncrease != nil && *t.MinIncrease < 0 {
+		return errors.New("min_increase must be non-negative")
+	}
+	if t.MinPost != nil && t.MaxPost != nil && *t.MinPost > *t.MaxPost {
+		return errors.New("min_post must not exceed max_post")
+	}
+	return nil
+}
+
+func loadSnapshot(path string) ([]snapshotReplica, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var snapshot []snapshotReplica
+	if err := json.Unmarshal(raw, &snapshot); err != nil {
+		return nil, err
+	}
+	if len(snapshot) == 0 {
+		return nil, errors.New("snapshot has no replicas")
+	}
+	return snapshot, nil
+}
+
+func evaluate(thresholds map[string]threshold, pre, post []snapshotReplica) report {
+	rep := report{Verdict: "pass"}
+	postByEndpoint := make(map[string]snapshotReplica, len(post))
+	for _, replica := range post {
+		postByEndpoint[replica.Endpoint] = replica
+	}
+	metricNames := make([]string, 0, len(thresholds))
+	for name := range thresholds {
+		metricNames = append(metricNames, name)
+	}
+	sort.Strings(metricNames)
+	preSorted := append([]snapshotReplica(nil), pre...)
+	sort.Slice(preSorted, func(i, j int) bool { return preSorted[i].Endpoint < preSorted[j].Endpoint })
+
+	for _, before := range preSorted {
+		after, ok := postByEndpoint[before.Endpoint]
+		for _, name := range metricNames {
+			row := result{Endpoint: before.Endpoint, Metric: name, Thresholds: thresholds[name], Verdict: "pass"}
+			if !ok {
+				row.Failures = append(row.Failures, "replica missing from post snapshot")
+			} else {
+				row.Pre = before.Metrics[name]
+				row.Post = after.Metrics[name]
+				row.evaluate()
+			}
+			if len(row.Failures) > 0 {
+				row.Verdict = "fail"
+				rep.Verdict = "fail"
+			}
+			rep.Results = append(rep.Results, row)
+		}
+	}
+	if len(postByEndpoint) != len(preSorted) {
+		preEndpoints := make(map[string]bool, len(preSorted))
+		for _, replica := range preSorted {
+			preEndpoints[replica.Endpoint] = true
+		}
+		for endpoint := range postByEndpoint {
+			if !preEndpoints[endpoint] {
+				rep.Verdict = "fail"
+				rep.Results = append(rep.Results, result{
+					Endpoint: endpoint,
+					Metric:   "*",
+					Failures: []string{"replica missing from pre snapshot"},
+					Verdict:  "fail",
+				})
+			}
+		}
+	}
+	return rep
+}
+
+func (r *result) evaluate() {
+	if r.Pre == nil {
+		r.Failures = append(r.Failures, "metric missing from pre snapshot")
+	}
+	if r.Post == nil {
+		r.Failures = append(r.Failures, "metric missing from post snapshot")
+	}
+	if r.Pre == nil || r.Post == nil {
+		return
+	}
+	if !finite(*r.Pre) || !finite(*r.Post) {
+		r.Failures = append(r.Failures, "metric sample must be finite")
+		return
+	}
+	delta := *r.Post - *r.Pre
+	r.Delta = &delta
+	if *r.Pre == 0 {
+		if *r.Post == 0 {
+			ratio := 1.0
+			r.Ratio = &ratio
+		}
+	} else {
+		ratio := *r.Post / *r.Pre
+		r.Ratio = &ratio
+	}
+	if t := r.Thresholds.MaxIncrease; t != nil && delta > *t {
+		r.Failures = append(r.Failures, fmt.Sprintf("increase %.6g exceeds %.6g", delta, *t))
+	}
+	if t := r.Thresholds.MinIncrease; t != nil && delta < *t {
+		r.Failures = append(r.Failures, fmt.Sprintf("increase %.6g is below %.6g", delta, *t))
+	}
+	if t := r.Thresholds.MaxRatio; t != nil {
+		if r.Ratio == nil {
+			r.Failures = append(r.Failures, "ratio is unbounded from a zero baseline")
+		} else if *r.Ratio > *t {
+			r.Failures = append(r.Failures, fmt.Sprintf("ratio %.6g exceeds %.6g", *r.Ratio, *t))
+		}
+	}
+	if t := r.Thresholds.MinPost; t != nil && *r.Post < *t {
+		r.Failures = append(r.Failures, fmt.Sprintf("post %.6g is below %.6g", *r.Post, *t))
+	}
+	if t := r.Thresholds.MaxPost; t != nil && *r.Post > *t {
+		r.Failures = append(r.Failures, fmt.Sprintf("post %.6g exceeds %.6g", *r.Post, *t))
+	}
+}
+
+func finite(v float64) bool { return !math.IsNaN(v) && !math.IsInf(v, 0) }
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "metricgate: "+format+"\n", args...)
+	os.Exit(2)
+}

--- a/testbed/bench/metricgate/main_test.go
+++ b/testbed/bench/metricgate/main_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func ptr(v float64) *float64 { return &v }
+
+func TestEvaluateMetricGate(t *testing.T) {
+	t.Run("baseline tolerances pass", func(t *testing.T) {
+		pre := []snapshotReplica{{Endpoint: "r0", Metrics: map[string]*float64{"docs": ptr(100), "healthy": ptr(1)}}}
+		post := []snapshotReplica{{Endpoint: "r0", Metrics: map[string]*float64{"docs": ptr(105), "healthy": ptr(1)}}}
+		rep := evaluate(map[string]threshold{
+			"docs":    {MaxIncrease: ptr(10), MaxRatio: ptr(1.1)},
+			"healthy": {MinPost: ptr(1), MaxPost: ptr(1)},
+		}, pre, post)
+		if rep.Verdict != "pass" {
+			t.Fatalf("verdict = %s, results = %+v", rep.Verdict, rep.Results)
+		}
+	})
+
+	t.Run("broken cleanup fails", func(t *testing.T) {
+		pre := []snapshotReplica{{Endpoint: "r0", Metrics: map[string]*float64{"docs": ptr(100)}}}
+		post := []snapshotReplica{{Endpoint: "r0", Metrics: map[string]*float64{"docs": ptr(1000)}}}
+		rep := evaluate(map[string]threshold{"docs": {MaxIncrease: ptr(20), MaxRatio: ptr(1.5)}}, pre, post)
+		if rep.Verdict != "fail" || len(rep.Results) != 1 {
+			t.Fatalf("verdict = %s, results = %+v", rep.Verdict, rep.Results)
+		}
+		failures := strings.Join(rep.Results[0].Failures, " ")
+		if !strings.Contains(failures, "increase") || !strings.Contains(failures, "ratio") {
+			t.Fatalf("failures = %q", failures)
+		}
+	})
+
+	t.Run("missing sample fails closed", func(t *testing.T) {
+		pre := []snapshotReplica{{Endpoint: "r0", Metrics: map[string]*float64{"docs": nil}}}
+		post := []snapshotReplica{{Endpoint: "r0", Metrics: map[string]*float64{"docs": ptr(0)}}}
+		rep := evaluate(map[string]threshold{"docs": {MaxIncrease: ptr(0)}}, pre, post)
+		if rep.Verdict != "fail" || !strings.Contains(strings.Join(rep.Results[0].Failures, " "), "missing") {
+			t.Fatalf("report = %+v", rep)
+		}
+	})
+}
+
+func TestValidateThreshold(t *testing.T) {
+	if err := validateThreshold(threshold{}); err == nil {
+		t.Fatal("empty threshold should fail")
+	}
+	if err := validateThreshold(threshold{MaxRatio: ptr(0.5)}); err == nil {
+		t.Fatal("ratio below one should fail")
+	}
+	if err := validateThreshold(threshold{MinPost: ptr(2), MaxPost: ptr(1)}); err == nil {
+		t.Fatal("inverted post range should fail")
+	}
+}

--- a/testbed/bench/release-scenarios.txt
+++ b/testbed/bench/release-scenarios.txt
@@ -3,15 +3,16 @@
 # Lines starting with `#` and blank lines are ignored.
 #
 # This is the canonical release-time signal. The release bench job is
-# `continue-on-error` (non-blocking) so a leak-gate hiccup or slow runner can
-# never block a release (the deliberate design of #256, #394). The SAME sweep
+# `continue-on-error` (non-blocking) so a profiling hiccup or slow runner can
+# never block a release (the deliberate design of #256, #394). Root tags have
+# a separate short blocking search_qualification job (#1063). The SAME sweep
 # ALSO runs nightly via `.github/workflows/bench-nightly.yml` WITHOUT
 # continue-on-error and with RELEASE_BENCH_BUDGET_SECONDS=0 (no truncation), so
-# a goroutine/heap-leak regression (#716) or a perf-floor breach (each scenario
-# below carries a `perf_gate:` block — see testbed/bench/README.md, #935) fails
-# a nightly check there rather than merely warning in an advisory artifact. Rather than run ~16
-# single-call scenarios (which paid per-scenario fixed overhead — warmup +
-# pre/post runtime+pprof snapshots + cooldown + 12 Prometheus range queries +
+# a leak, metric, semantic, or perf-gate breach (each scenario carries the
+# relevant blocks — see testbed/bench/README.md, #716/#935/#1063) fails
+# a nightly check there rather than merely warning in an advisory artifact.
+# Rather than run ~16 single-call scenarios (which paid per-scenario fixed overhead — warmup +
+# pre/post runtime+pprof snapshots + cooldown + Prometheus range queries +
 # report render — for each call path), the sweep is compacted to SEVEN
 # scenarios, THREE of which fan out across many call paths inside a single
 # steady window (see the `target.calls` fan-out rule in run.sh). This keeps
@@ -34,7 +35,7 @@
 # broad_illuminate 150s + broad_mutate 165s + ttl_churn 210s +
 # many_subscribers 180s + search_churn 210s + replication_apply_churn 300s
 # = ~23 min total. On top of that, EACH scenario pays per-scenario CAPTURE
-# overhead — two pprof snapshots (24 curls, up to 60s each) + 12 Prometheus
+# overhead — two pprof snapshots (24 curls, up to 60s each) + Prometheus
 # range queries (up to 30s each) — which on a contended ubuntu-latest runner
 # adds ~5-10 min/scenario, so the FULL-capture sweep runs ~55-65 min, not the
 # ~25 min an earlier revision of this comment assumed (see #727).
@@ -97,8 +98,11 @@ ttl_churn
 # leaderless Subscribe fan-out across replicas
 many_subscribers
 
-# search index lifecycle: churn PutVertex (short TTL) + parallel SearchVertices
-# asserts lantern_search_index_* returns to baseline after cooldown (#703)
+# search index lifecycle: churn PutVertex (short TTL) + independent exact,
+# scoped, fuzzy-1/2, prefix, cap-overflow, ALL, MIN_SHOULD, and phrase Search
+# producers. Semantic probes reject empty-OK behavior; per-replica metric gates
+# require index decay/health and per-producer perf gates prevent Put throughput
+# from hiding slow Search (#703, #1048, #1063).
 search_churn
 
 # replicated write churn: asserts lantern_vertex_hlc_entries returns to baseline

--- a/testbed/bench/release/main.go
+++ b/testbed/bench/release/main.go
@@ -1,7 +1,7 @@
 // Package main is the release-time bench aggregator.
 //
 // It consumes the per-scenario artifacts produced by testbed/bench/run.sh
-// (one run directory per scenario, each containing leak_gate.json,
+// (one run directory per scenario, containing its configured gate JSON,
 // ghz_*.json, and a pre-rendered report.md) and emits a single fixed-format
 // Markdown document suitable for appending to a GitHub Release body.
 //
@@ -14,7 +14,7 @@
 //	- Captured: <UTC timestamp>
 //
 //	## Summary
-//	| scenario | leak gate | rps | p99 (ms) | non-OK |
+//	| scenario | leak gate | metric gate | semantic gate | perf gate | rps | p99 (ms) | non-OK |
 //	| ... |
 //
 //	## <scenario>
@@ -62,6 +62,18 @@ type perfGate struct {
 	Verdict string `json:"verdict"`
 }
 
+// metricGate mirrors the generic lifecycle metric gate verdict. Detailed
+// per-replica values remain in each scenario's nested report.
+type metricGate struct {
+	Verdict string `json:"verdict"`
+}
+
+// semanticGate mirrors one bounded Search probe phase. A scenario that
+// declares this gate requires both its pre and post phases to pass.
+type semanticGate struct {
+	Verdict string `json:"verdict"`
+}
+
 // ghzSummary mirrors the subset of testbed/bench/report.GhzSummary that
 // the summary table needs.
 type ghzSummary struct {
@@ -84,11 +96,13 @@ type scenarioInput struct {
 
 // summaryRow is the rendered values for one row in the Summary table.
 type summaryRow struct {
-	Verdict     string // "pass", "fail", or "(failed)" if artifacts are missing
-	PerfVerdict string // "pass", "fail", or "—" when the scenario gates no perf metric
-	Rps         string // pre-formatted, e.g. "5000.0" or "—"
-	P99ms       string // pre-formatted, e.g. "0.89" or "—"
-	NonOK       string // pre-formatted, e.g. "0" or "—"
+	Verdict         string // "pass", "fail", or "(failed)" if artifacts are missing
+	MetricVerdict   string // "pass", "fail", or "—" when no metric gate is configured
+	SemanticVerdict string // "pass", "fail", or "—" when no semantic gate is configured
+	PerfVerdict     string // "pass", "fail", or "—" when the scenario gates no perf metric
+	Rps             string // pre-formatted, e.g. "5000.0" or "—"
+	P99ms           string // pre-formatted, e.g. "0.89" or "—"
+	NonOK           string // pre-formatted, e.g. "0" or "—"
 }
 
 // Header carries the fixed-format report header fields.
@@ -100,7 +114,15 @@ type Header struct {
 }
 
 func loadScenario(name, dir string) scenarioInput {
-	in := scenarioInput{Name: name, Dir: dir, Row: summaryRow{Verdict: "(failed)", PerfVerdict: "—", Rps: "—", P99ms: "—", NonOK: "—"}}
+	in := scenarioInput{Name: name, Dir: dir, Row: summaryRow{
+		Verdict:         "(failed)",
+		MetricVerdict:   "—",
+		SemanticVerdict: "—",
+		PerfVerdict:     "—",
+		Rps:             "—",
+		P99ms:           "—",
+		NonOK:           "—",
+	}}
 	if dir == "" {
 		return in
 	}
@@ -118,6 +140,33 @@ func loadScenario(name, dir string) scenarioInput {
 		var pg perfGate
 		if err := json.Unmarshal(b, &pg); err == nil && pg.Verdict != "" {
 			in.Row.PerfVerdict = pg.Verdict
+		}
+	}
+
+	// Generic lifecycle metric-gate verdict (optional artifact).
+	if b, err := os.ReadFile(filepath.Join(dir, "metric_gate.json")); err == nil {
+		var mg metricGate
+		if err := json.Unmarshal(b, &mg); err == nil && mg.Verdict != "" {
+			in.Row.MetricVerdict = mg.Verdict
+		}
+	}
+
+	// If either semantic phase exists, both phases must exist and pass.
+	var semanticVerdicts []string
+	for _, artifact := range []string{"semantic_pre.json", "semantic_post.json"} {
+		if b, err := os.ReadFile(filepath.Join(dir, artifact)); err == nil {
+			var sg semanticGate
+			if err := json.Unmarshal(b, &sg); err == nil {
+				semanticVerdicts = append(semanticVerdicts, sg.Verdict)
+			} else {
+				semanticVerdicts = append(semanticVerdicts, "fail")
+			}
+		}
+	}
+	if len(semanticVerdicts) > 0 {
+		in.Row.SemanticVerdict = "fail"
+		if len(semanticVerdicts) == 2 && semanticVerdicts[0] == "pass" && semanticVerdicts[1] == "pass" {
+			in.Row.SemanticVerdict = "pass"
 		}
 	}
 
@@ -211,11 +260,12 @@ func Render(w io.Writer, h Header, scenarios []scenarioInput) error {
 	bw.printf("- Captured: `%s`\n\n", h.Captured)
 
 	bw.printf("## Summary\n\n")
-	bw.printf("| scenario | leak gate | perf gate | rps | p99 (ms) | non-OK |\n")
-	bw.printf("| --- | --- | --- | ---: | ---: | ---: |\n")
+	bw.printf("| scenario | leak gate | metric gate | semantic gate | perf gate | rps | p99 (ms) | non-OK |\n")
+	bw.printf("| --- | --- | --- | --- | --- | ---: | ---: | ---: |\n")
 	for _, s := range scenarios {
-		bw.printf("| `%s` | `%s` | `%s` | %s | %s | %s |\n",
-			s.Name, s.Row.Verdict, s.Row.PerfVerdict, s.Row.Rps, s.Row.P99ms, s.Row.NonOK)
+		bw.printf("| `%s` | `%s` | `%s` | `%s` | `%s` | %s | %s | %s |\n",
+			s.Name, s.Row.Verdict, s.Row.MetricVerdict, s.Row.SemanticVerdict,
+			s.Row.PerfVerdict, s.Row.Rps, s.Row.P99ms, s.Row.NonOK)
 	}
 	bw.printf("\n")
 

--- a/testbed/bench/release/main_test.go
+++ b/testbed/bench/release/main_test.go
@@ -34,7 +34,7 @@ func TestLoadScenario_MissingDir(t *testing.T) {
 	if s.Row.Verdict != "(failed)" {
 		t.Errorf("missing dir verdict: %q", s.Row.Verdict)
 	}
-	if s.Row.PerfVerdict != "—" || s.Row.Rps != "—" || s.Row.P99ms != "—" || s.Row.NonOK != "—" {
+	if s.Row.MetricVerdict != "—" || s.Row.SemanticVerdict != "—" || s.Row.PerfVerdict != "—" || s.Row.Rps != "—" || s.Row.P99ms != "—" || s.Row.NonOK != "—" {
 		t.Errorf("missing dir row: %+v", s.Row)
 	}
 }
@@ -42,6 +42,9 @@ func TestLoadScenario_MissingDir(t *testing.T) {
 func TestLoadScenario_PopulatesRowAndDetail(t *testing.T) {
 	dir := t.TempDir()
 	writeJSON(t, filepath.Join(dir, "leak_gate.json"), map[string]any{"verdict": "pass"})
+	writeJSON(t, filepath.Join(dir, "metric_gate.json"), map[string]any{"verdict": "pass"})
+	writeJSON(t, filepath.Join(dir, "semantic_pre.json"), map[string]any{"verdict": "pass"})
+	writeJSON(t, filepath.Join(dir, "semantic_post.json"), map[string]any{"verdict": "pass"})
 	writeJSON(t, filepath.Join(dir, "perf_gate.json"), map[string]any{"verdict": "fail"})
 	writeJSON(t, filepath.Join(dir, "ghz_steady_localhost_6380.json"), map[string]any{
 		"count":                  1000,
@@ -60,6 +63,9 @@ func TestLoadScenario_PopulatesRowAndDetail(t *testing.T) {
 	if s.Row.PerfVerdict != "fail" {
 		t.Errorf("perf verdict: %q", s.Row.PerfVerdict)
 	}
+	if s.Row.MetricVerdict != "pass" || s.Row.SemanticVerdict != "pass" {
+		t.Errorf("lifecycle verdicts: %+v", s.Row)
+	}
 	if s.Row.Rps != "4995.5" {
 		t.Errorf("rps: %q", s.Row.Rps)
 	}
@@ -71,6 +77,17 @@ func TestLoadScenario_PopulatesRowAndDetail(t *testing.T) {
 	}
 	if !strings.Contains(s.Detail, "### Inner") || !strings.Contains(s.Detail, "#### Section") {
 		t.Errorf("detail not demoted: %q", s.Detail)
+	}
+}
+
+func TestLoadScenario_SemanticGateFailsClosedWhenPostMissing(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, "leak_gate.json"), map[string]any{"verdict": "pass"})
+	writeJSON(t, filepath.Join(dir, "semantic_pre.json"), map[string]any{"verdict": "pass"})
+
+	s := loadScenario("search_churn", dir)
+	if s.Row.SemanticVerdict != "fail" {
+		t.Fatalf("semantic verdict = %q, want fail", s.Row.SemanticVerdict)
 	}
 }
 
@@ -112,11 +129,11 @@ func TestRender_FixedFormat(t *testing.T) {
 		{
 			Name:   "smoke_write_heavy",
 			Detail: "### Bench report — `smoke_write_heavy`\nbody\n",
-			Row:    summaryRow{Verdict: "pass", PerfVerdict: "pass", Rps: "5000.0", P99ms: "1.23", NonOK: "0"},
+			Row:    summaryRow{Verdict: "pass", MetricVerdict: "pass", SemanticVerdict: "pass", PerfVerdict: "pass", Rps: "5000.0", P99ms: "1.23", NonOK: "0"},
 		},
 		{
 			Name: "smoke_read_heavy",
-			Row:  summaryRow{Verdict: "(failed)", PerfVerdict: "—", Rps: "—", P99ms: "—", NonOK: "—"},
+			Row:  summaryRow{Verdict: "(failed)", MetricVerdict: "—", SemanticVerdict: "—", PerfVerdict: "—", Rps: "—", P99ms: "—", NonOK: "—"},
 		},
 	}
 	var buf bytes.Buffer
@@ -131,9 +148,9 @@ func TestRender_FixedFormat(t *testing.T) {
 		"- Runner: `linux/amd64`",
 		"- Captured: `20260101T000000Z`",
 		"## Summary",
-		"| scenario | leak gate | perf gate | rps | p99 (ms) | non-OK |",
-		"| `smoke_write_heavy` | `pass` | `pass` | 5000.0 | 1.23 | 0 |",
-		"| `smoke_read_heavy` | `(failed)` | `—` | — | — | — |",
+		"| scenario | leak gate | metric gate | semantic gate | perf gate | rps | p99 (ms) | non-OK |",
+		"| `smoke_write_heavy` | `pass` | `pass` | `pass` | `pass` | 5000.0 | 1.23 | 0 |",
+		"| `smoke_read_heavy` | `(failed)` | `—` | `—` | `—` | — | — | — |",
 		"## smoke_write_heavy",
 		"### Bench report — `smoke_write_heavy`",
 		"## smoke_read_heavy",

--- a/testbed/bench/report/render.go
+++ b/testbed/bench/report/render.go
@@ -3,10 +3,13 @@
 // It consumes the JSON artifacts emitted by testbed/bench/run.sh under
 // out/<scenario>/<timestamp>/ and writes a Markdown summary to stdout:
 //
-//   - leak_gate.json            -> Leak Gate section + verdict header
-//   - ghz_*.json                -> Per-phase / per-call latency tables
-//   - prom/_index.ndjson        -> Indexed list of Prom range queries
-//   - pprof/                    -> Inventory of captured pprof profiles
+//   - leak_gate.json                 -> Leak Gate section + verdict header
+//   - metric_gate.json               -> Per-replica lifecycle gauge contracts
+//   - semantic_{pre,post}.json       -> Bounded Search correctness probes
+//   - perf_gate.json                 -> Aggregate and named-producer ratchets
+//   - ghz_*.json                     -> Per-phase / per-call latency tables
+//   - prom/_index.ndjson             -> Indexed list of Prom range queries
+//   - pprof/                         -> Inventory of captured pprof profiles
 //
 // The renderer is intentionally side-effect free aside from reading the
 // run directory and writing Markdown to its writer, so it round-trips
@@ -112,6 +115,47 @@ type PerfProducerResult struct {
 	Verdict string `json:"verdict"`
 }
 
+// MetricGate mirrors metricgate's generic pre/post gauge report.
+type MetricGate struct {
+	Verdict string             `json:"verdict"`
+	Results []MetricGateResult `json:"results"`
+}
+
+// MetricGateResult is one metric on one replica. Threshold values are
+// pointers because every scenario chooses the dimensions appropriate for the
+// gauge (absolute growth, ratio, activity floor, or final-state bounds).
+type MetricGateResult struct {
+	Endpoint   string `json:"endpoint"`
+	Metric     string `json:"metric"`
+	Thresholds struct {
+		MaxIncrease *float64 `json:"max_increase"`
+		MaxRatio    *float64 `json:"max_ratio"`
+		MinIncrease *float64 `json:"min_increase"`
+		MinPost     *float64 `json:"min_post"`
+		MaxPost     *float64 `json:"max_post"`
+	} `json:"thresholds"`
+	Pre      *float64 `json:"pre"`
+	Post     *float64 `json:"post"`
+	Delta    *float64 `json:"delta"`
+	Ratio    *float64 `json:"ratio"`
+	Failures []string `json:"failures"`
+	Verdict  string   `json:"verdict"`
+}
+
+// SemanticGate is one bounded search-probe phase. It intentionally contains
+// no query text, prefixes, keys, or values.
+type SemanticGate struct {
+	Phase    string                `json:"phase"`
+	Verdict  string                `json:"verdict"`
+	Replicas []SemanticGateReplica `json:"replicas"`
+}
+
+type SemanticGateReplica struct {
+	Endpoint string `json:"endpoint"`
+	Checks   int    `json:"checks"`
+	Verdict  string `json:"verdict"`
+}
+
 // GhzSummary captures the subset of fields ghz writes that the report uses.
 // All durations are nanoseconds as serialised by ghz --format json.
 type GhzSummary struct {
@@ -138,13 +182,16 @@ type PromIndexEntry struct {
 // Input is the rendered report's input model. All fields are optional —
 // missing artifacts produce "(not captured)" sections rather than errors.
 type Input struct {
-	Scenario  string
-	Timestamp string
-	LeakGate  *LeakGate
-	PerfGate  *PerfGate
-	GhzFiles  []GhzFile
-	PromIndex []PromIndexEntry
-	PprofList []string
+	Scenario     string
+	Timestamp    string
+	LeakGate     *LeakGate
+	MetricGate   *MetricGate
+	SemanticPre  *SemanticGate
+	SemanticPost *SemanticGate
+	PerfGate     *PerfGate
+	GhzFiles     []GhzFile
+	PromIndex    []PromIndexEntry
+	PprofList    []string
 }
 
 // GhzFile is one ghz JSON output paired with its source filename so the
@@ -177,6 +224,31 @@ func LoadInput(dir, scenario, ts string) (Input, error) {
 		in.PerfGate = &pg
 	} else if !errors.Is(err, fs.ErrNotExist) {
 		return in, err
+	}
+
+	if b, err := os.ReadFile(filepath.Join(dir, "metric_gate.json")); err == nil {
+		var mg MetricGate
+		if err := json.Unmarshal(b, &mg); err != nil {
+			return in, fmt.Errorf("parse metric_gate.json: %w", err)
+		}
+		in.MetricGate = &mg
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return in, err
+	}
+
+	for name, target := range map[string]**SemanticGate{
+		"semantic_pre.json":  &in.SemanticPre,
+		"semantic_post.json": &in.SemanticPost,
+	} {
+		if b, err := os.ReadFile(filepath.Join(dir, name)); err == nil {
+			var gate SemanticGate
+			if err := json.Unmarshal(b, &gate); err != nil {
+				return in, fmt.Errorf("parse %s: %w", name, err)
+			}
+			*target = &gate
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return in, err
+		}
 	}
 
 	entries, err := os.ReadDir(dir)
@@ -242,8 +314,15 @@ func RenderReport(w io.Writer, in Input) error {
 	if in.PerfGate != nil {
 		perfVerdict = in.PerfGate.Verdict
 	}
+	metricVerdict := "(no metric gate configured)"
+	if in.MetricGate != nil {
+		metricVerdict = in.MetricGate.Verdict
+	}
+	semanticVerdict := semanticGateVerdict(in.SemanticPre, in.SemanticPost)
 	bw.printf("# Bench report — `%s` @ `%s`\n\n", in.Scenario, in.Timestamp)
 	bw.printf("**Leak gate verdict:** `%s`\n\n", verdict)
+	bw.printf("**Metric gate verdict:** `%s`\n\n", metricVerdict)
+	bw.printf("**Semantic gate verdict:** `%s`\n\n", semanticVerdict)
 	bw.printf("**Perf gate verdict:** `%s`\n\n", perfVerdict)
 
 	bw.printf("## Leak gate\n\n")
@@ -272,6 +351,39 @@ func RenderReport(w io.Writer, in Input) error {
 				r.HeapObjectsPre, r.HeapObjectsPost, r.HeapObjectsDelta,
 				r.VertexHLCEntriesPost, r.VertexHLCHighWaterPost,
 			)
+		}
+		bw.printf("\n")
+	}
+
+	bw.printf("## Metric gate\n\n")
+	if in.MetricGate == nil {
+		bw.printf("_not configured_\n\n")
+	} else {
+		bw.printf("Every configured threshold is conjunctive. Missing/non-finite samples fail closed; `—` means the ratio is undefined from a zero baseline.\n\n")
+		bw.printf("| replica | metric | verdict | pre | post | delta | ratio |\n")
+		bw.printf("| --- | --- | --- | ---: | ---: | ---: | ---: |\n")
+		for _, row := range in.MetricGate.Results {
+			bw.printf("| `%s` | `%s` | `%s` | %s | %s | %s | %s |\n",
+				row.Endpoint, row.Metric, row.Verdict,
+				optionalFloat(row.Pre), optionalFloat(row.Post), optionalFloat(row.Delta), optionalFloat(row.Ratio))
+		}
+		bw.printf("\n")
+	}
+
+	bw.printf("## Semantic gate\n\n")
+	if in.SemanticPre == nil && in.SemanticPost == nil {
+		bw.printf("_not configured_\n\n")
+	} else {
+		bw.printf("The bounded report records only phase/check counts; query text, prefixes, keys, and values are omitted.\n\n")
+		bw.printf("| phase | replica | checks | verdict |\n")
+		bw.printf("| --- | --- | ---: | --- |\n")
+		for _, gate := range []*SemanticGate{in.SemanticPre, in.SemanticPost} {
+			if gate == nil {
+				continue
+			}
+			for _, replica := range gate.Replicas {
+				bw.printf("| `%s` | `%s` | %d | `%s` |\n", gate.Phase, replica.Endpoint, replica.Checks, replica.Verdict)
+			}
 		}
 		bw.printf("\n")
 	}
@@ -378,6 +490,23 @@ func RenderReport(w io.Writer, in Input) error {
 	bw.printf("   `go tool pprof -http=:0 -base <pre> <post>`\n")
 	bw.printf("3. For elevated tail latency, cross-reference the matching Prom histogram query with `<replica>__post__goroutine.pb.gz` (look for blocked stacks).\n")
 	return bw.err
+}
+
+func semanticGateVerdict(pre, post *SemanticGate) string {
+	if pre == nil && post == nil {
+		return "(no semantic gate configured)"
+	}
+	if pre == nil || post == nil || pre.Verdict != "pass" || post.Verdict != "pass" {
+		return "fail"
+	}
+	return "pass"
+}
+
+func optionalFloat(v *float64) string {
+	if v == nil {
+		return "—"
+	}
+	return fmt.Sprintf("%.6g", *v)
 }
 
 // perfThreshold renders an optional perf-gate threshold: nil (metric not

--- a/testbed/bench/report/render_test.go
+++ b/testbed/bench/report/render_test.go
@@ -178,6 +178,41 @@ func TestRenderReport_ShowsIndependentProducerGates(t *testing.T) {
 	}
 }
 
+func TestRenderReport_ShowsMetricAndSemanticGates(t *testing.T) {
+	pre, post, delta, ratio := 100.0, 105.0, 5.0, 1.05
+	mg := &MetricGate{Verdict: "pass", Results: []MetricGateResult{{
+		Endpoint: "localhost:9390",
+		Metric:   "lantern_search_index_docs",
+		Pre:      &pre,
+		Post:     &post,
+		Delta:    &delta,
+		Ratio:    &ratio,
+		Verdict:  "pass",
+	}}}
+	semanticPre := &SemanticGate{Phase: "pre", Verdict: "pass", Replicas: []SemanticGateReplica{{Endpoint: "http://localhost:6380", Checks: 11, Verdict: "pass"}}}
+	semanticPost := &SemanticGate{Phase: "post", Verdict: "pass", Replicas: []SemanticGateReplica{{Endpoint: "http://localhost:6380", Checks: 11, Verdict: "pass"}}}
+
+	var buf bytes.Buffer
+	if err := RenderReport(&buf, Input{Scenario: "search", Timestamp: "t", MetricGate: mg, SemanticPre: semanticPre, SemanticPost: semanticPost}); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"**Metric gate verdict:** `pass`",
+		"**Semantic gate verdict:** `pass`",
+		"## Metric gate",
+		"`lantern_search_index_docs`",
+		"100 | 105 | 5 | 1.05",
+		"## Semantic gate",
+		"| `pre` | `http://localhost:6380` | 11 | `pass` |",
+		"query text, prefixes, keys, and values are omitted",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in report:\n%s", want, out)
+		}
+	}
+}
+
 func TestLoadInput_AssemblesFromDisk(t *testing.T) {
 	dir := t.TempDir()
 
@@ -192,6 +227,11 @@ func TestLoadInput_AssemblesFromDisk(t *testing.T) {
 	pg.Thresholds.MaxP99Ms = &maxP99
 	pg.Observed.P99WorstMs = 900
 	mustWriteJSON(t, filepath.Join(dir, "perf_gate.json"), pg)
+
+	mg := MetricGate{Verdict: "pass"}
+	mustWriteJSON(t, filepath.Join(dir, "metric_gate.json"), mg)
+	mustWriteJSON(t, filepath.Join(dir, "semantic_pre.json"), SemanticGate{Phase: "pre", Verdict: "pass"})
+	mustWriteJSON(t, filepath.Join(dir, "semantic_post.json"), SemanticGate{Phase: "post", Verdict: "pass"})
 
 	gh := GhzSummary{Count: 42, Rps: 1, Average: 1_000_000,
 		StatusCodeDistribution: map[string]int{"OK": 42},
@@ -227,6 +267,12 @@ func TestLoadInput_AssemblesFromDisk(t *testing.T) {
 		in.PerfGate.Thresholds.MaxP99Ms == nil || *in.PerfGate.Thresholds.MaxP99Ms != 250 ||
 		in.PerfGate.Thresholds.MinSteadyRpsTotal != nil {
 		t.Errorf("perf gate not loaded: %+v", in.PerfGate)
+	}
+	if in.MetricGate == nil || in.MetricGate.Verdict != "pass" {
+		t.Errorf("metric gate not loaded: %+v", in.MetricGate)
+	}
+	if in.SemanticPre == nil || in.SemanticPre.Phase != "pre" || in.SemanticPost == nil || in.SemanticPost.Phase != "post" {
+		t.Errorf("semantic gates not loaded: pre=%+v post=%+v", in.SemanticPre, in.SemanticPost)
 	}
 	if len(in.GhzFiles) != 1 || in.GhzFiles[0].Summary.Count != 42 {
 		t.Errorf("ghz files: %+v", in.GhzFiles)

--- a/testbed/bench/run.sh
+++ b/testbed/bench/run.sh
@@ -20,8 +20,8 @@
 #                     nightly leak gate sets this so the un-truncated sweep fits a
 #                     sane CI timeout; the advisory release bench leaves it unset.
 #
-# Exits 0 if the leak gate verdict is "pass" AND the perf gate (when the
-# scenario declares a `perf_gate:` block — see below) did not fail; exits 1
+# Exits 0 if the leak gate verdict is "pass" AND declared metric, semantic,
+# and perf gates pass; exits 1
 # otherwise. Exits 2 on misuse.
 #
 # Prerequisites: bash 4+, docker, docker compose v2, ghz, yq (v4+), jq, curl,
@@ -39,12 +39,45 @@ COMPOSE_FILES=(
 )
 export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-lantern-bench}"
 PROM_URL="${PROM_URL:-http://localhost:9091}"
+COMPOSE_STARTED=0
 
 REPLICA_METRICS_PORTS=(9390 9391 9392)
 REPLICA_GRPC_PORTS=(6380 6381 6382)
 
+# Always include the search derived-index lifecycle in the lightweight runtime
+# snapshots, including LEAK_GATE_ONLY runs. These are unlabeled gauges, so this
+# list has fixed cardinality and cannot capture request/user data. Scenario
+# metric_gate keys are added below after the YAML has been resolved.
+RUNTIME_METRIC_NAMES=(
+  lantern_search_index_docs
+  lantern_search_index_terms
+  lantern_search_index_physical_documents
+  lantern_search_index_expired_documents
+  lantern_search_index_expiration_queue_entries
+  lantern_search_index_expiration_purged
+  lantern_search_index_last_expiration_purge_duration_seconds
+  lantern_search_index_retained_term_slots
+  lantern_search_index_retained_ordinals
+  lantern_search_index_postings
+  lantern_search_index_position_entries
+  lantern_search_index_estimated_live_bytes
+  lantern_search_index_estimated_retained_bytes
+  lantern_search_index_rebuild_count
+  lantern_search_index_last_rebuild_duration_seconds
+  lantern_search_index_healthy
+)
+
 die() { echo "run.sh: $*" >&2; exit 1; }
 log() { printf '[%s] %s\n' "$(date -u +%H:%M:%SZ)" "$*"; }
+
+cleanup() {
+  if [[ "$COMPOSE_STARTED" == "1" && "${KEEP_UP:-0}" != "1" ]]; then
+    log "compose down -v"
+    docker compose "${COMPOSE_FILES[@]}" down -v >/dev/null 2>&1 || true
+    COMPOSE_STARTED=0
+  fi
+}
+trap cleanup EXIT
 
 need() { command -v "$1" >/dev/null 2>&1 || die "missing required tool: $1"; }
 need docker
@@ -116,6 +149,7 @@ if [[ "${SKIP_UP:-0}" != "1" ]]; then
   # Since #435 the canonical compose declares three explicit lantern-{0,1,2}
   # services with pinned host ports, so `--scale lantern=3` is no longer
   # needed (and would in fact fail — there is no `lantern` service).
+  COMPOSE_STARTED=1
   docker compose "${COMPOSE_FILES[@]}" up -d --wait
 fi
 
@@ -154,6 +188,15 @@ SCENARIO_FILE="$SCENARIO_RESOLVED"
 # Re-parse fields that depend on endpoints after substitution.
 endpoints=( $(yq -r '.target.endpoints[]' "$SCENARIO_FILE") )
 
+# A generic metric_gate may name another unlabeled gauge. Add it once while
+# retaining the fixed built-in search catalogue above.
+while IFS= read -r metric_name; do
+  [[ -z "$metric_name" ]] && continue
+  if [[ " ${RUNTIME_METRIC_NAMES[*]} " != *" ${metric_name} "* ]]; then
+    RUNTIME_METRIC_NAMES+=( "$metric_name" )
+  fi
+done < <(yq -r '.metric_gate.metrics // {} | keys | .[]' "$SCENARIO_FILE")
+
 wait_ready() {
   local p
   for p in "${REPLICA_METRICS_PORTS[@]}"; do
@@ -166,6 +209,41 @@ wait_ready() {
   done
 }
 wait_ready
+
+semantic_kind="$(yq -r '.semantic_gate.kind // ""' "$SCENARIO_FILE")"
+semantic_endpoints=""
+for port in "${REPLICA_GRPC_PORTS[@]}"; do
+  if [[ -n "$semantic_endpoints" ]]; then semantic_endpoints+=","; fi
+  semantic_endpoints+="http://localhost:${port}"
+done
+
+run_search_probe() {
+  local mode="$1" phase="${2:-}"
+  local report="$OUTDIR/semantic_${mode}.json"
+  local args=( -mode "$mode" )
+  if [[ "$mode" == "verify" ]]; then
+    report="$OUTDIR/semantic_${phase}.json"
+    args+=( -phase "$phase" )
+  fi
+  args+=(
+    -endpoints "$semantic_endpoints"
+    -report "$report"
+    -timeout "${SEARCH_PROBE_TIMEOUT:-90s}"
+  )
+  (
+    cd "$REPO_ROOT"
+    go run ./testbed/bench/searchprobe "${args[@]}"
+  )
+}
+
+case "$semantic_kind" in
+  "") ;;
+  search)
+    log "semantic gate: seed deterministic search fixture"
+    run_search_probe seed
+    ;;
+  *) die "unknown semantic_gate.kind $semantic_kind in $SCENARIO_FILE" ;;
+esac
 
 # ----- optional semantic topology preflight ---------------------------------
 # A schema-valid ghz template can still benchmark an empty or accidentally
@@ -196,7 +274,7 @@ esac
 # ----- helpers ---------------------------------------------------------------
 
 # Extract a single Prom metric value from a /metrics text exposition.
-# $1 metric name, $2 raw text -> echoes numeric value or "0".
+# $1 metric name, $2 raw text -> echoes the numeric value or nothing.
 prom_scalar() {
   local name="$1" text="$2"
   awk -v n="$name" '$1 == n { print $2; exit }' <<<"$text"
@@ -254,11 +332,22 @@ snapshot_runtime() {
       if [[ -z "$vhe"     || "$rvhe" -lt "$vhe"    ]]; then vhe="$rvhe"; fi
       if [[ -z "$vhw"     || "$rvhw" -gt "$vhw"    ]]; then vhw="$rvhw"; fi
     done
+    local metric_samples='{}' metric_name metric_value
+    for metric_name in "${RUNTIME_METRIC_NAMES[@]}"; do
+      metric_value="$(prom_scalar "$metric_name" "$text")"
+      if [[ -z "$metric_value" ]]; then
+        metric_samples="$(jq -c --arg name "$metric_name" '.[$name] = null' <<<"$metric_samples")"
+      else
+        metric_samples="$(jq -c --arg name "$metric_name" --arg value "$metric_value" \
+          '.[$name] = ($value | tonumber)' <<<"$metric_samples")"
+      fi
+    done
     samples+=( "$(jq -nc --arg ep "localhost:${port}" \
         --argjson g "$g" \
         --argjson hi "$h_inuse" --argjson ha "$h_alloc" --argjson ho "$h_objs" \
         --argjson vhe "$vhe" --argjson vhw "$vhw" \
-      '{endpoint: $ep, goroutines: $g, heap_inuse_bytes: $hi, heap_alloc_bytes: $ha, heap_objects: $ho, vertex_hlc_entries: $vhe, vertex_hlc_high_water: $vhw}')" )
+        --argjson metrics "$metric_samples" \
+      '{endpoint: $ep, goroutines: $g, heap_inuse_bytes: $hi, heap_alloc_bytes: $ha, heap_objects: $ho, vertex_hlc_entries: $vhe, vertex_hlc_high_water: $vhw, metrics: $metrics}')" )
   done
   printf '%s\n' "${samples[@]}" | jq -s '.' > "$out"
 }
@@ -286,6 +375,10 @@ warm_data="$(yq -r '.target.data_template // .target.calls[0].data_template' "$S
 run_ghz warmup "${endpoints[0]}" "$warm_call" "$warm_data" "$warmup_conc" "$warmup_rps" "$warmup_duration" >/dev/null
 
 # ----- PRE snapshot (after warmup) -------------------------------------------
+if [[ "$semantic_kind" == "search" ]]; then
+  log "semantic gate: verify every replica before steady load"
+  run_search_probe verify pre
+fi
 snapshot_runtime "$OUTDIR/runtime_pre.json"
 if [[ "${LEAK_GATE_ONLY:-0}" != "1" ]]; then
   "$CAPTURE_DIR/pprof.sh" "$OUTDIR/pprof" pre || log "pprof pre snapshot reported warnings"
@@ -359,10 +452,15 @@ if [[ "$calls_len" != "0" && "$calls_len" != "null" ]]; then
     call="$(yq -r ".target.calls[$i].call" "$SCENARIO_FILE")"
     data="$(yq -r ".target.calls[$i].data_template" "$SCENARIO_FILE")"
     name="$(yq -r ".target.calls[$i].name // \"producer-$i\"" "$SCENARIO_FILE")"
+    producer_rps="$(yq -r ".target.calls[$i].rps // 0" "$SCENARIO_FILE")"
+    if [[ "$producer_rps" == "0" || "$producer_rps" == "null" ]]; then
+      producer_rps="$per_rps"
+    fi
+    [[ "$producer_rps" =~ ^[1-9][0-9]*$ ]] || die "target.calls[$i].rps must be a positive integer"
     ep="${endpoints[$(( i % ${#endpoints[@]} ))]}"
     f="$OUTDIR/ghz_steady_${i}_${ep//[:.]/_}.json"
     ghz --insecure \
-      --call "$call" -c "$steady_conc" --rps "$per_rps" -z "$steady_duration" \
+      --call "$call" -c "$steady_conc" --rps "$producer_rps" -z "$steady_duration" \
       -d "$data" --format json -o "$f" "$ep" >/dev/null 2>&1 &
     prod_pids+=( "$!" )
     prod_files+=( "$f" )
@@ -390,6 +488,10 @@ log "cooldown: ${cooldown}"
 sleep "${cooldown%s}"
 
 # ----- POST snapshot ---------------------------------------------------------
+if [[ "$semantic_kind" == "search" ]]; then
+  log "semantic gate: verify every replica after cooldown"
+  run_search_probe verify post
+fi
 snapshot_runtime "$OUTDIR/runtime_post.json"
 
 # pprof captures + Prometheus range queries are throughput/diagnostic extras the
@@ -404,21 +506,27 @@ else
 
   # ----- Prom range queries --------------------------------------------------
   log "capturing Prometheus range queries from $PROM_URL"
+  prom_query_files=( "$CAPTURE_DIR/prom_queries.txt" )
+  if [[ "$semantic_kind" == "search" ]]; then
+    prom_query_files+=( "$CAPTURE_DIR/prom_queries_search.txt" )
+  fi
   i=0
-  while IFS= read -r line; do
-    q="${line%%#*}"; q="${q#"${q%%[![:space:]]*}"}"; q="${q%"${q##*[![:space:]]}"}"
-    [[ -z "$q" ]] && continue
-    i=$(( i + 1 ))
-    out="$OUTDIR/prom/q_$(printf '%02d' "$i").json"
-    curl -fsS --max-time 30 -G "$PROM_URL/api/v1/query_range" \
-      --data-urlencode "query=$q" \
-      --data-urlencode "start=$steady_start_epoch" \
-      --data-urlencode "end=$steady_end_epoch" \
-      --data-urlencode "step=5s" \
-      > "$out" || log "prom query failed: $q"
-    jq -nc --arg q "$q" --arg f "$(basename "$out")" '{query:$q, file:$f}' \
-      >> "$OUTDIR/prom/_index.ndjson"
-  done < "$CAPTURE_DIR/prom_queries.txt"
+  for prom_query_file in "${prom_query_files[@]}"; do
+    while IFS= read -r line; do
+      q="${line%%#*}"; q="${q#"${q%%[![:space:]]*}"}"; q="${q%"${q##*[![:space:]]}"}"
+      [[ -z "$q" ]] && continue
+      i=$(( i + 1 ))
+      out="$OUTDIR/prom/q_$(printf '%02d' "$i").json"
+      curl -fsS --max-time 30 -G "$PROM_URL/api/v1/query_range" \
+        --data-urlencode "query=$q" \
+        --data-urlencode "start=$steady_start_epoch" \
+        --data-urlencode "end=$steady_end_epoch" \
+        --data-urlencode "step=5s" \
+        > "$out" || log "prom query failed: $q"
+      jq -nc --arg q "$q" --arg f "$(basename "$out")" '{query:$q, file:$f}' \
+        >> "$OUTDIR/prom/_index.ndjson"
+    done < "$prom_query_file"
+  done
 fi
 
 # ----- Leak gate -------------------------------------------------------------
@@ -467,6 +575,28 @@ leak_json="$(jq -n \
 printf '%s\n' "$leak_json" > "$OUTDIR/leak_gate.json"
 verdict="$(jq -r '.verdict' "$OUTDIR/leak_gate.json")"
 log "leak gate verdict: $verdict"
+
+# ----- Metric gate -----------------------------------------------------------
+# Generic pre/post contracts over the unlabeled gauges captured in every
+# runtime snapshot. The Go evaluator fails closed on missing/non-finite samples
+# and is unit-tested with a deliberately broken cleanup fixture.
+metric_count="$(yq -r '.metric_gate.metrics // {} | length' "$SCENARIO_FILE")"
+metric_verdict="skipped"
+if [[ "$metric_count" != "0" && "$metric_count" != "null" ]]; then
+  if (
+    cd "$REPO_ROOT"
+    go run ./testbed/bench/metricgate \
+      -scenario "$SCENARIO_FILE" \
+      -pre "$OUTDIR/runtime_pre.json" \
+      -post "$OUTDIR/runtime_post.json" \
+      -out "$OUTDIR/metric_gate.json"
+  ); then
+    metric_verdict="pass"
+  else
+    metric_verdict="fail"
+  fi
+fi
+log "metric gate verdict: $metric_verdict"
 
 # ----- Perf gate --------------------------------------------------------------
 # Optional per-scenario floors over the steady-phase producers (#935). Same
@@ -570,9 +700,6 @@ log "perf gate verdict: $perf_verdict"
 log "report: $OUTDIR/report.md"
 
 # ----- Teardown --------------------------------------------------------------
-if [[ "${KEEP_UP:-0}" != "1" ]]; then
-  log "compose down -v"
-  docker compose "${COMPOSE_FILES[@]}" down -v >/dev/null
-fi
+cleanup
 
-if [[ "$verdict" == "pass" && "$perf_verdict" != "fail" ]]; then exit 0; else exit 1; fi
+if [[ "$verdict" == "pass" && "$metric_verdict" != "fail" && "$perf_verdict" != "fail" ]]; then exit 0; else exit 1; fi

--- a/testbed/bench/scenarios/search_churn.yaml
+++ b/testbed/bench/scenarios/search_churn.yaml
@@ -10,11 +10,10 @@
 # - consistency: SearchVertices purges vertices whose TTL has expired but whose
 #   Flush has not yet run, so BM25 stats and vocabulary use the returned live
 #   corpus rather than merely hiding dead keys (#1057).
-# - execution budgets: separate broad-posting, prefix-scoped, fuzzy-dictionary,
-#   and broad-phrase producers exercise every dominant read-work family, including
-#   expiration_visits as short TTLs mature, while the writer p99 exposes
-#   index-lock delay. The harness captures CPU, alloc, mutex, and block profiles
-#   around the same steady window (#1049, #1057).
+# - execution budgets: named exact, prefix-scoped, fuzzy-1, fuzzy-2,
+#   prefix-term, cap-overflow, ALL, MIN_SHOULD, and phrase producers exercise
+#   every advanced option and dominant read-work family. Every producer has its
+#   own throughput/p99/error floor, so Put throughput cannot hide a slow Search.
 # - expansion: one two-clause query drives both semantic cap-overflow paths:
 #   `topic` prefix-expands over the live unique-term set, while `fuzz000`
 #   fuzzy-expands over 100 live neighbours at edit distance <= 2. Both exceed
@@ -22,11 +21,11 @@
 #   selection rather than an exact-only dictionary lookup (#1056).
 #
 # steady >= 2m so the leak window brackets the GC sweep repeatedly.
-# Assert lantern_search_index_terms/docs plus physical_documents,
-# expired_documents, expiration_queue_entries, expiration_purged,
-# retained_term_slots, retained_ordinals, and estimated_retained_bytes return
-# to ~baseline after cooldown (the #1050 compaction and #1057 bounded-purge
-# claims, not merely result filtering).
+# The metric gate below compares every replica's pre/post baseline for live and
+# retained search structures. The cumulative expiration_purged gauge must move
+# forward; healthy must remain exactly 1. The semantic gate independently
+# checks a persistent hit, deleted/expired absence, stable ordering, key prefix,
+# phrase, fuzzy-1/2, prefix terms, ALL, and MIN_SHOULD before and after load.
 #
 # The bench cluster runs search on by default (LANTERN_SEARCH_ENABLED=true).
 # The explicit expiration template below is required: omitting Vertex.expiration
@@ -37,12 +36,14 @@ cluster:
   gc_interval_seconds: 10
 phases:
   warmup:   { duration: 30s, concurrency: 16, rps: 500 }
-  steady:   { duration: 2m,  concurrency: 32, rps: 2000 }
+  steady:   { duration: 2m,  concurrency: 16, rps: 1600 }
   cooldown: 60s
+semantic_gate:
+  kind: search
 target:
   endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
-  # Five parallel streams per fan-out rule: one writer plus broad-posting,
-  # prefix-scoped, fuzzy-dictionary, and broad-phrase reads. per_rps = 400 rps each.
+  # Producer-owned rps keeps the writer at the intended 500 rps while each
+  # advanced Search family receives an independent realistic load.
   calls:
     # [0] short-TTL string vertex. The 50k key space is larger than the
     #     ~7.5k live set at 500 writes/s with 15s expirations, so keys are not
@@ -52,36 +53,86 @@ target:
     #     fuzz000. The shared phrase makes broad posting and phrase verification
     #     inspect the whole live set while the writer's p99 measures lock delay.
     - name: writer
+      rps: 500
       call: graph.v1.LanternService/PutVertex
       data_template: |
         {"vertex":{"key":"search-{{mod .RequestNumber 50000}}","string":"shared phrase topic{{ printf `%05d` (mod .RequestNumber 50000) }} fuzz{{ printf `%03d` (mod .RequestNumber 100) }}","expiration":"{{ now | dateModify `15s` | date `2006-01-02T15:04:05.999999999Z07:00` }}"}}
     # [1] Broad exact posting/proximity work over every live document.
     - name: broad_posting
+      rps: 200
       call: graph.v1.LanternService/SearchVertices
       data_template: |
         {"query":"shared","limit":20}
     # [2] A selective key scope exercises radix -> bounded retrieval pushdown.
     #     Candidate visits must track this subtree, not the global live corpus.
     - name: prefix_scoped
+      rps: 200
       call: graph.v1.LanternService/SearchVertices
       data_template: |
         {"query":"shared","limit":20,"prefix":"search-000"}
-    # [3] Both query clauses overflow the 50-term expansion cap independently:
+    # [3] Fuzzy-1 over the bounded fuzz000..fuzz099 family.
+    - name: fuzzy_1
+      rps: 100
+      call: graph.v1.LanternService/SearchVertices
+      data_template: |
+        {"query":"fuzz000","limit":20,"options":{"fuzziness":1}}
+    # [4] Fuzzy-2 independently covers its wider dictionary walk.
+    - name: fuzzy_2
+      rps: 100
+      call: graph.v1.LanternService/SearchVertices
+      data_template: |
+        {"query":"fuzz000","limit":20,"options":{"fuzziness":2}}
+    # [5] Prefix terms over the live high-cardinality topic dictionary.
+    - name: prefix_terms
+      rps: 100
+      call: graph.v1.LanternService/SearchVertices
+      data_template: |
+        {"query":"topic","limit":20,"options":{"prefixTerms":true}}
+    # [6] Both query clauses overflow the 50-term expansion cap independently:
     #     topic matches every live topicNNNNN by prefix, and fuzz000 reaches all
     #     fuzz000..fuzz099 with fuzziness=2. Auxiliary grams still exercise the
     #     production script-aware ranking path around those word clauses.
     - name: prefix_fuzzy_cap_overflow
+      rps: 100
       call: graph.v1.LanternService/SearchVertices
       data_template: |
         {"query":"topic fuzz000","limit":20,"options":{"prefixTerms":true,"fuzziness":2}}
-    # [4] Broad positional intersection and adjacency verification.
+    # [7] Explicit ALL membership.
+    - name: match_all
+      rps: 100
+      call: graph.v1.LanternService/SearchVertices
+      data_template: |
+        {"query":"shared phrase","limit":20,"options":{"matchMode":2}}
+    # [8] Explicit MIN_SHOULD membership (two of three clauses).
+    - name: min_should
+      rps: 100
+      call: graph.v1.LanternService/SearchVertices
+      data_template: |
+        {"query":"shared phrase fuzz000","limit":20,"options":{"matchMode":3,"minShouldMatch":2}}
+    # [9] Positions-enabled broad adjacency verification. The blocking tag
+    #     qualification separately runs the production positions-off contract.
     - name: broad_phrase
+      rps: 100
       call: graph.v1.LanternService/SearchVertices
       data_template: |
         {"query":"shared phrase","limit":20,"options":{"phrase":true}}
 leak_gate:
   goroutine_max_delta: 20
   heap_alloc_max_delta_mb: 32
+metric_gate:
+  metrics:
+    lantern_search_index_docs: { max_increase: 256, max_ratio: 1.25 }
+    lantern_search_index_terms: { max_increase: 1024, max_ratio: 1.5 }
+    lantern_search_index_physical_documents: { max_increase: 256, max_ratio: 1.25 }
+    lantern_search_index_expired_documents: { max_increase: 64, max_ratio: 2 }
+    lantern_search_index_expiration_queue_entries: { max_increase: 256, max_ratio: 1.25 }
+    lantern_search_index_expiration_purged: { min_increase: 1 }
+    lantern_search_index_retained_term_slots: { max_increase: 100000, max_ratio: 2 }
+    lantern_search_index_retained_ordinals: { max_increase: 100000, max_ratio: 2 }
+    lantern_search_index_postings: { max_increase: 2048, max_ratio: 1.5 }
+    lantern_search_index_position_entries: { max_increase: 4096, max_ratio: 1.5 }
+    lantern_search_index_estimated_retained_bytes: { max_increase: 67108864, max_ratio: 2 }
+    lantern_search_index_healthy: { min_post: 1, max_post: 1 }
 # The producer mix changed for #1049, so these are deliberately loose first-
 # night ratchets with ample headroom. Tighten from several green nightly runs;
 # writer p99 is the explicit lock-delay signal, while the harness profiles
@@ -91,8 +142,13 @@ perf_gate:
   max_p99_ms: 4000
   max_non_ok_ratio: 0.02
   producers:
-    writer: { max_p99_ms: 2000, max_non_ok_ratio: 0.02 }
-    broad_posting: { max_p99_ms: 4000, max_non_ok_ratio: 0.02 }
-    prefix_scoped: { max_p99_ms: 2000, max_non_ok_ratio: 0.02 }
-    prefix_fuzzy_cap_overflow: { max_p99_ms: 4000, max_non_ok_ratio: 0.02 }
-    broad_phrase: { max_p99_ms: 4000, max_non_ok_ratio: 0.02 }
+    writer: { min_steady_rps: 100, max_p99_ms: 2000, max_non_ok_ratio: 0.02 }
+    broad_posting: { min_steady_rps: 20, max_p99_ms: 4000, max_non_ok_ratio: 0.02 }
+    prefix_scoped: { min_steady_rps: 20, max_p99_ms: 2000, max_non_ok_ratio: 0.02 }
+    fuzzy_1: { min_steady_rps: 20, max_p99_ms: 4000, max_non_ok_ratio: 0.02 }
+    fuzzy_2: { min_steady_rps: 20, max_p99_ms: 4000, max_non_ok_ratio: 0.02 }
+    prefix_terms: { min_steady_rps: 20, max_p99_ms: 4000, max_non_ok_ratio: 0.02 }
+    prefix_fuzzy_cap_overflow: { min_steady_rps: 20, max_p99_ms: 4000, max_non_ok_ratio: 0.02 }
+    match_all: { min_steady_rps: 20, max_p99_ms: 4000, max_non_ok_ratio: 0.02 }
+    min_should: { min_steady_rps: 20, max_p99_ms: 4000, max_non_ok_ratio: 0.02 }
+    broad_phrase: { min_steady_rps: 20, max_p99_ms: 4000, max_non_ok_ratio: 0.02 }

--- a/testbed/bench/scenarios/search_qualification.yaml
+++ b/testbed/bench/scenarios/search_qualification.yaml
@@ -1,0 +1,67 @@
+# search_qualification is the short, deterministic tag-SHA gate. It is kept
+# outside release-scenarios.txt: docker-publish.yml runs it against a fresh
+# three-replica cluster and refuses to publish an image when any semantic,
+# lifecycle, leak, or producer-owned perf contract fails.
+name: search_qualification
+cluster:
+  gc_interval_seconds: 2
+phases:
+  # The semantic fixture has one 10-second TTL sentinel. A 12-second warmup
+  # makes the pre probe prove expiration rather than merely presence.
+  warmup:   { duration: 12s, concurrency: 4, rps: 100 }
+  steady:   { duration: 20s, concurrency: 8, rps: 300 }
+  cooldown: 15s
+semantic_gate:
+  kind: search
+target:
+  endpoints: ["localhost:6380", "localhost:6381", "localhost:6382"]
+  calls:
+    - name: writer
+      rps: 100
+      call: graph.v1.LanternService/PutVertex
+      data_template: |
+        {"vertex":{"key":"qualification-{{mod .RequestNumber 10000}}","string":"shared phrase topic{{ printf `%05d` (mod .RequestNumber 10000) }} fuzz{{ printf `%03d` (mod .RequestNumber 100) }}","expiration":"{{ now | dateModify `5s` | date `2006-01-02T15:04:05.999999999Z07:00` }}"}}
+    - name: broad_posting
+      rps: 100
+      call: graph.v1.LanternService/SearchVertices
+      data_template: |
+        {"query":"shared","limit":20}
+    - name: prefix_scoped
+      rps: 50
+      call: graph.v1.LanternService/SearchVertices
+      data_template: |
+        {"query":"shared","limit":20,"prefix":"qualification-000"}
+    - name: fuzzy_prefix
+      rps: 50
+      call: graph.v1.LanternService/SearchVertices
+      data_template: |
+        {"query":"topic fuzz000","limit":20,"options":{"prefixTerms":true,"fuzziness":2}}
+leak_gate:
+  goroutine_max_delta: 20
+  heap_alloc_max_delta_mb: 32
+metric_gate:
+  metrics:
+    lantern_search_index_docs: { max_increase: 128, max_ratio: 1.5 }
+    lantern_search_index_terms: { max_increase: 512, max_ratio: 2 }
+    lantern_search_index_physical_documents: { max_increase: 128, max_ratio: 1.5 }
+    lantern_search_index_expired_documents: { max_increase: 64, max_ratio: 2 }
+    lantern_search_index_expiration_queue_entries: { max_increase: 128, max_ratio: 1.5 }
+    lantern_search_index_expiration_purged: { min_increase: 1 }
+    lantern_search_index_retained_term_slots: { max_increase: 20000, max_ratio: 3 }
+    lantern_search_index_retained_ordinals: { max_increase: 20000, max_ratio: 3 }
+    lantern_search_index_postings: { max_increase: 1024, max_ratio: 2 }
+    lantern_search_index_position_entries: { max_increase: 2048, max_ratio: 2 }
+    lantern_search_index_estimated_retained_bytes: { max_increase: 33554432, max_ratio: 3 }
+    lantern_search_index_healthy: { min_post: 1, max_post: 1 }
+# Wide ratchets reject step changes while tolerating ordinary hosted-runner
+# jitter. Each Search producer is independent, so writer throughput cannot
+# conceal an unexpectedly slow or empty Search path.
+perf_gate:
+  min_steady_rps_total: 100
+  max_p99_ms: 4000
+  max_non_ok_ratio: 0.02
+  producers:
+    writer: { min_steady_rps: 20, max_p99_ms: 2000, max_non_ok_ratio: 0.02 }
+    broad_posting: { min_steady_rps: 20, max_p99_ms: 4000, max_non_ok_ratio: 0.02 }
+    prefix_scoped: { min_steady_rps: 10, max_p99_ms: 3000, max_non_ok_ratio: 0.02 }
+    fuzzy_prefix: { min_steady_rps: 10, max_p99_ms: 4000, max_non_ok_ratio: 0.02 }

--- a/testbed/bench/scenarios_gate_test.go
+++ b/testbed/bench/scenarios_gate_test.go
@@ -120,6 +120,156 @@ func TestBroadIlluminateScenarioTopologyContract(t *testing.T) {
 	}
 }
 
+// TestSearchChurnScenarioGateContract keeps #1063's blocking search proof
+// honest: every advanced producer is independently ratcheted, semantic probes
+// run on every replica, and the derived-index gauges have real pre/post gates.
+func TestSearchChurnScenarioGateContract(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("scenarios", "search_churn.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		SemanticGate struct {
+			Kind string `yaml:"kind"`
+		} `yaml:"semantic_gate"`
+		Target struct {
+			Calls []struct {
+				Name         string `yaml:"name"`
+				Call         string `yaml:"call"`
+				DataTemplate string `yaml:"data_template"`
+				RPS          int    `yaml:"rps"`
+			} `yaml:"calls"`
+		} `yaml:"target"`
+		Phases struct {
+			Steady struct {
+				RPS int `yaml:"rps"`
+			} `yaml:"steady"`
+		} `yaml:"phases"`
+		MetricGate struct {
+			Metrics map[string]map[string]float64 `yaml:"metrics"`
+		} `yaml:"metric_gate"`
+		PerfGate struct {
+			Producers map[string]struct {
+				MinSteadyRPS *float64 `yaml:"min_steady_rps"`
+				MaxP99MS     *float64 `yaml:"max_p99_ms"`
+				MaxNonOK     *float64 `yaml:"max_non_ok_ratio"`
+			} `yaml:"producers"`
+		} `yaml:"perf_gate"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse search_churn: %v", err)
+	}
+	if doc.SemanticGate.Kind != "search" {
+		t.Fatalf("semantic_gate.kind = %q, want search", doc.SemanticGate.Kind)
+	}
+	for _, metric := range []string{
+		"lantern_search_index_docs",
+		"lantern_search_index_terms",
+		"lantern_search_index_physical_documents",
+		"lantern_search_index_expired_documents",
+		"lantern_search_index_expiration_queue_entries",
+		"lantern_search_index_expiration_purged",
+		"lantern_search_index_retained_term_slots",
+		"lantern_search_index_retained_ordinals",
+		"lantern_search_index_postings",
+		"lantern_search_index_position_entries",
+		"lantern_search_index_estimated_retained_bytes",
+		"lantern_search_index_healthy",
+	} {
+		if len(doc.MetricGate.Metrics[metric]) == 0 {
+			t.Errorf("metric %s has no threshold", metric)
+		}
+	}
+
+	calls := make(map[string]string, len(doc.Target.Calls))
+	totalRPS := 0
+	for _, call := range doc.Target.Calls {
+		if call.Name == "" || call.RPS <= 0 {
+			t.Errorf("producer has invalid name/rps: %+v", call)
+			continue
+		}
+		totalRPS += call.RPS
+		calls[call.Name] = strings.TrimSpace(call.DataTemplate)
+		gate, ok := doc.PerfGate.Producers[call.Name]
+		if !ok || gate.MinSteadyRPS == nil || gate.MaxP99MS == nil || gate.MaxNonOK == nil {
+			t.Errorf("producer %q lacks independent rps+p99/non-OK gate", call.Name)
+		}
+	}
+	if totalRPS != doc.Phases.Steady.RPS {
+		t.Errorf("producer rps sum = %d, steady rps = %d", totalRPS, doc.Phases.Steady.RPS)
+	}
+	for name, fragments := range map[string][]string{
+		"writer":                    {`"expiration"`},
+		"broad_posting":             {`"query":"shared"`},
+		"prefix_scoped":             {`"prefix":"search-000"`},
+		"fuzzy_1":                   {`"fuzziness":1`},
+		"fuzzy_2":                   {`"fuzziness":2`},
+		"prefix_terms":              {`"prefixTerms":true`},
+		"prefix_fuzzy_cap_overflow": {`"prefixTerms":true`, `"fuzziness":2`},
+		"match_all":                 {`"matchMode":2`},
+		"min_should":                {`"matchMode":3`, `"minShouldMatch":2`},
+		"broad_phrase":              {`"phrase":true`},
+	} {
+		template, ok := calls[name]
+		if !ok {
+			t.Errorf("missing advanced producer %q", name)
+			continue
+		}
+		for _, fragment := range fragments {
+			if !strings.Contains(template, fragment) {
+				t.Errorf("%s template missing %q: %s", name, fragment, template)
+			}
+		}
+	}
+	runScript, err := os.ReadFile("run.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(runScript), `any(.producer_results[]; .verdict == "fail")`) {
+		t.Error("perf gate does not conjunctively fold named producer failures")
+	}
+}
+
+// TestSearchReleaseQualificationIsBlocking pins the release dependency rather
+// than merely checking that a qualification job exists. A failed or skipped
+// stage must produce a fail verdict, and image publication must need that job.
+func TestSearchReleaseQualificationIsBlocking(t *testing.T) {
+	releaseWorkflow, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", "docker-publish.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	release := string(releaseWorkflow)
+	for _, contract := range []string{
+		"search-qualification:",
+		"go test ./server/service -run",
+		"go test ./tests/integration -run",
+		"./testbed/bench/run.sh search_qualification",
+		`all($stages[]; .status == "pass")`,
+		`scenarios:$scenarios`,
+		"needs: [verify, search-qualification]",
+		`test "$(jq -r .verdict qualification-report.json)" = pass`,
+	} {
+		if !strings.Contains(release, contract) {
+			t.Errorf("release workflow missing blocking contract %q", contract)
+		}
+	}
+
+	nightlyWorkflow, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", "bench-nightly.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	nightly := string(nightlyWorkflow)
+	for _, contract := range []string{
+		"Run deterministic advanced Search wire contracts",
+		"TestSearchVertices_(OptionsContract|PositionsOff)",
+		"RELEASE_BENCH_BUDGET_SECONDS: \"0\"",
+	} {
+		if !strings.Contains(nightly, contract) {
+			t.Errorf("nightly workflow missing Search contract %q", contract)
+		}
+	}
+}
+
 // calls flattens every (call, data_template) pair in the document, tagged
 // with where it came from so failures point at the offending YAML path.
 func (d scenarioDoc) calls() map[string]scenarioCall {

--- a/testbed/bench/searchprobe/main.go
+++ b/testbed/bench/searchprobe/main.go
@@ -1,0 +1,219 @@
+// searchprobe seeds and verifies the benchmark's deterministic search fixture.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+const (
+	liveKey    = "bench:search:probe:live"
+	deletedKey = "bench:search:probe:deleted"
+	expiredKey = "bench:search:probe:expired"
+	alphaKey   = "bench:search:probe:01"
+	betaKey    = "bench:search:probe:02"
+	gammaKey   = "bench:search:probe:03"
+)
+
+type writer interface {
+	PutVertices(context.Context, []client.VertexInput) error
+	DeleteVertex(context.Context, string) (bool, error)
+}
+
+type searcher interface {
+	SearchVertices(context.Context, string, ...client.SearchOption) ([]client.SearchHit, error)
+}
+
+type check struct {
+	Name     string
+	Run      func(context.Context, searcher) ([]client.SearchHit, error)
+	Want     []string
+	Top      []string
+	Contains []string
+	Excludes []string
+}
+
+type replicaReport struct {
+	Endpoint string `json:"endpoint"`
+	Checks   int    `json:"checks"`
+	Verdict  string `json:"verdict"`
+}
+
+type probeReport struct {
+	Phase    string          `json:"phase"`
+	Verdict  string          `json:"verdict"`
+	Replicas []replicaReport `json:"replicas"`
+}
+
+func main() {
+	mode := flag.String("mode", "", "seed or verify")
+	phase := flag.String("phase", "", "report phase for verify mode (pre or post)")
+	endpointsFlag := flag.String("endpoints", "http://localhost:6380", "comma-separated Lantern h2c endpoints")
+	reportPath := flag.String("report", "", "write a bounded semantic report to this path")
+	timeout := flag.Duration("timeout", 90*time.Second, "maximum time for replication and TTL convergence")
+	flag.Parse()
+
+	endpoints := strings.Split(*endpointsFlag, ",")
+	if len(endpoints) == 0 || endpoints[0] == "" || *reportPath == "" {
+		fatalf("at least one endpoint and -report are required")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	switch *mode {
+	case "seed":
+		lantern, err := client.NewLantern(endpoints[0])
+		if err != nil {
+			fatalf("dial writer: %v", err)
+		}
+		if err := seed(ctx, lantern, time.Now()); err != nil {
+			_ = lantern.Close()
+			fatalf("seed: %v", err)
+		}
+		_ = lantern.Close()
+		writeReport(*reportPath, probeReport{Phase: "seed", Verdict: "pass"})
+	case "verify":
+		if *phase != "pre" && *phase != "post" {
+			fatalf("verify mode requires -phase pre or -phase post")
+		}
+		rep := probeReport{Phase: *phase, Verdict: "pass"}
+		for _, endpoint := range endpoints {
+			lantern, err := client.NewLantern(endpoint)
+			if err != nil {
+				rep.Verdict = "fail"
+				rep.Replicas = append(rep.Replicas, replicaReport{Endpoint: endpoint, Verdict: "fail"})
+				continue
+			}
+			err = waitForChecks(ctx, lantern)
+			_ = lantern.Close()
+			if err != nil {
+				rep.Verdict = "fail"
+				rep.Replicas = append(rep.Replicas, replicaReport{Endpoint: endpoint, Checks: len(searchChecks()), Verdict: "fail"})
+				continue
+			}
+			rep.Replicas = append(rep.Replicas, replicaReport{Endpoint: endpoint, Checks: len(searchChecks()), Verdict: "pass"})
+		}
+		writeReport(*reportPath, rep)
+		if rep.Verdict != "pass" {
+			fatalf("semantic verification failed; see bounded report")
+		}
+	default:
+		fatalf("-mode must be seed or verify")
+	}
+}
+
+func seed(ctx context.Context, w writer, now time.Time) error {
+	inputs := []client.VertexInput{
+		{Key: liveKey, Value: "persistentbeacon lantern sentinel"},
+		{Key: deletedKey, Value: "discardedtoken lantern sentinel"},
+		{Key: expiredKey, Value: "fleetingtoken lantern sentinel", Expiration: now.Add(10 * time.Second)},
+		{Key: alphaKey, Value: "quick brown fox ember"},
+		{Key: betaKey, Value: "quick blue fox embers"},
+		{Key: gammaKey, Value: "quick brown dog cinder"},
+	}
+	if err := w.PutVertices(ctx, inputs); err != nil {
+		return err
+	}
+	existed, err := w.DeleteVertex(ctx, deletedKey)
+	if err != nil {
+		return err
+	}
+	if !existed {
+		return errors.New("delete sentinel was not written")
+	}
+	return nil
+}
+
+func searchChecks() []check {
+	return []check{
+		{Name: "live_sentinel", Run: query("persistentbeacon"), Contains: []string{liveKey}},
+		{Name: "deleted_sentinel", Run: query("discardedtoken"), Excludes: []string{deletedKey}},
+		{Name: "expired_sentinel", Run: query("fleetingtoken"), Excludes: []string{expiredKey}},
+		{Name: "exact", Run: query("quick"), Want: []string{alphaKey, betaKey, gammaKey}},
+		{Name: "key_prefix", Run: query("quick", client.WithSearchPrefix(betaKey)), Want: []string{betaKey}},
+		{Name: "phrase", Run: query("quick brown", client.WithPhrase()), Want: []string{alphaKey, gammaKey}},
+		{Name: "fuzzy_1", Run: query("ember", client.WithFuzziness(1)), Top: []string{alphaKey, betaKey}},
+		{Name: "fuzzy_2", Run: query("embee", client.WithFuzziness(2)), Top: []string{alphaKey, betaKey}},
+		{Name: "prefix_terms", Run: query("embe", client.WithPrefixTerms()), Top: []string{alphaKey, betaKey}},
+		{Name: "match_all", Run: query("quick fox", client.WithMatchMode(client.MatchAll)), Want: []string{alphaKey, betaKey}},
+		{Name: "min_should", Run: query("quick brown fox", client.WithMatchMode(client.MatchMinShould), client.WithMinShouldMatch(2)), Want: []string{alphaKey, gammaKey, betaKey}},
+	}
+}
+
+func query(q string, opts ...client.SearchOption) func(context.Context, searcher) ([]client.SearchHit, error) {
+	return func(ctx context.Context, s searcher) ([]client.SearchHit, error) {
+		return s.SearchVertices(ctx, q, append([]client.SearchOption{client.WithSearchLimit(20)}, opts...)...)
+	}
+}
+
+func waitForChecks(ctx context.Context, s searcher) error {
+	var last error
+	for {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("semantic checks did not converge: %v: %w", last, err)
+		}
+		last = verifyOnce(ctx, s)
+		if last == nil {
+			return nil
+		}
+		select {
+		case <-time.After(250 * time.Millisecond):
+		case <-ctx.Done():
+			return fmt.Errorf("semantic checks did not converge: %v: %w", last, ctx.Err())
+		}
+	}
+}
+
+func verifyOnce(ctx context.Context, s searcher) error {
+	for _, c := range searchChecks() {
+		hits, err := c.Run(ctx, s)
+		if err != nil {
+			return fmt.Errorf("%s: %w", c.Name, err)
+		}
+		got := make([]string, len(hits))
+		for i, hit := range hits {
+			got[i] = hit.Key
+		}
+		if c.Want != nil && !slices.Equal(got, c.Want) {
+			return fmt.Errorf("%s: ordered keys = %v, want %v", c.Name, got, c.Want)
+		}
+		if len(got) < len(c.Top) || !slices.Equal(got[:len(c.Top)], c.Top) {
+			return fmt.Errorf("%s: top ordered keys do not match", c.Name)
+		}
+		for _, key := range c.Contains {
+			if !slices.Contains(got, key) {
+				return fmt.Errorf("%s: required key is absent", c.Name)
+			}
+		}
+		for _, key := range c.Excludes {
+			if slices.Contains(got, key) {
+				return fmt.Errorf("%s: forbidden key is present", c.Name)
+			}
+		}
+	}
+	return nil
+}
+
+func writeReport(path string, rep probeReport) {
+	encoded, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		fatalf("encode report: %v", err)
+	}
+	if err := os.WriteFile(path, append(encoded, '\n'), 0o644); err != nil {
+		fatalf("write report: %v", err)
+	}
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "searchprobe: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/testbed/bench/searchprobe/main_test.go
+++ b/testbed/bench/searchprobe/main_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+type fakeSearcher struct {
+	responses [][]client.SearchHit
+	call      int
+}
+
+func (f *fakeSearcher) SearchVertices(context.Context, string, ...client.SearchOption) ([]client.SearchHit, error) {
+	if f.call >= len(f.responses) {
+		return []client.SearchHit{}, nil
+	}
+	response := f.responses[f.call]
+	f.call++
+	return response, nil
+}
+
+type fakeWriter struct {
+	inputs     []client.VertexInput
+	deletedKey string
+}
+
+func (f *fakeWriter) PutVertices(_ context.Context, inputs []client.VertexInput) error {
+	f.inputs = append([]client.VertexInput(nil), inputs...)
+	return nil
+}
+
+func (f *fakeWriter) DeleteVertex(_ context.Context, key string) (bool, error) {
+	f.deletedKey = key
+	return true, nil
+}
+
+func TestVerifyOnce(t *testing.T) {
+	t.Run("expected semantic matrix passes", func(t *testing.T) {
+		checks := searchChecks()
+		responses := make([][]client.SearchHit, 0, len(checks))
+		for _, c := range checks {
+			keys := append(append(append([]string(nil), c.Want...), c.Top...), c.Contains...)
+			hits := make([]client.SearchHit, len(keys))
+			for i, key := range keys {
+				hits[i].Key = key
+			}
+			responses = append(responses, hits)
+		}
+		if err := verifyOnce(context.Background(), &fakeSearcher{responses: responses}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("HTTP OK with empty hits fails closed", func(t *testing.T) {
+		err := verifyOnce(context.Background(), &fakeSearcher{})
+		if err == nil || !strings.Contains(err.Error(), "live_sentinel") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+}
+
+func TestWaitForChecksPreservesSemanticFailureAtDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	err := waitForChecks(ctx, &fakeSearcher{})
+	if err == nil || !strings.Contains(err.Error(), "live_sentinel") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestFailureReportIsBounded(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "semantic_pre.json")
+	writeReport(path, probeReport{
+		Phase:   "pre",
+		Verdict: "fail",
+		Replicas: []replicaReport{{
+			Endpoint: "http://localhost:6380",
+			Checks:   len(searchChecks()),
+			Verdict:  "fail",
+		}},
+	})
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{liveKey, "persistentbeacon", "quick brown"} {
+		if strings.Contains(string(raw), forbidden) {
+			t.Errorf("bounded report contains fixture data %q: %s", forbidden, raw)
+		}
+	}
+}
+
+func TestSeedWritesLifecycleSentinels(t *testing.T) {
+	now := time.Unix(1000, 0)
+	w := &fakeWriter{}
+	if err := seed(context.Background(), w, now); err != nil {
+		t.Fatal(err)
+	}
+	if len(w.inputs) != 6 || w.deletedKey != deletedKey {
+		t.Fatalf("inputs = %d, deleted = %q", len(w.inputs), w.deletedKey)
+	}
+	var expiration time.Time
+	for _, input := range w.inputs {
+		if input.Key == expiredKey {
+			expiration = input.Expiration
+		}
+	}
+	if want := now.Add(10 * time.Second); !expiration.Equal(want) {
+		t.Fatalf("expiration = %v, want %v", expiration, want)
+	}
+}


### PR DESCRIPTION
## Summary

- add fail-closed lifecycle metric gates and a deterministic semantic Search probe for every replica
- make the advanced Search churn scenario producer-aware so Put throughput cannot hide slow or incorrect Search variants
- add a short tag-SHA Search qualification that blocks container, binary, and GitHub Release publication when any stage fails or is skipped
- surface metric/semantic verdicts in benchmark and release reports, and document the qualification contract

## Validation

- `go test ./...` in the root, `pb/`, `core/`, `sdks/go/`, `server/`, and `mcp/` modules
- targeted request-boundary, production Connect/h2c, positions-off, and HA Search convergence tests
- full Node SDK and Admin lint/format/typecheck/test/build gates
- Dart SDK and Flutter example format/analyze/test gates, dartdoc link validation, and publish dry-run
- `actionlint` and scoped `golangci-lint`
- local `search_qualification` Compose run: ~300 RPS, 0 non-OK, worst p99 13.32 ms, all four gates pass
- local full `search_churn` Compose run: ~1329 RPS observed across ten producers, 0.0144% non-OK, all four gates pass

Closes #1063