### PR TITLE
feat(cli/search): add shared REPL grammar and lossless structured output

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,10 @@ scan   edges    <tail-prefix> [limit] [head=<prefix>] [all=true]
 count  vertices <prefix>
 delete-prefix vertices <prefix> [limit=<int>] [confirm=yes|dry_run=true]
 keys   <prefix> [limit]
+search <query> [limit=<n>] [prefix=<string>] [mode=server|any|all|min-should] \
+       [min_should=<n>] [phrase=true] [fuzziness=0|1|2] [prefix_terms=true] \
+       [cursor=<base64url>] [all=true] [projection=key-score|full-vertex] \
+       [format=json|ndjson|tsv]
 bfs        <seed> [step] [fan_out] [reduction=none|mst|spt] [objective=min|max] \
            [weighting=raw|tfidf|bm25] [prefix=<string>]
 pagerank   <seed> [top_n] [restart_prob=<float>] [epsilon=<float>] \
@@ -681,10 +685,13 @@ exit
 lantern-cli put vertex alice '{"name":"Alice"}' type=json
 lantern-cli delete vertex alice bob carol
 lantern-cli scan vertices users/ all=true > snap.json
+lantern-cli search "desk lamp" mode=all limit=20
 lantern-cli delete-prefix vertices tmp/ dry_run=true
 
-# Outside the grammar: search, streamed bulk load, and whole-graph backup.
-lantern-cli search "desk lamp" --mode all --limit 20
+# Cobra flags are an equivalent facade over the same shared search model.
+lantern-cli search "desk lamp" --mode all --limit 20 --format json
+
+# Outside the grammar: streamed bulk load and whole-graph backup.
 cat edges.ndjson | lantern-cli bulk edges add -
 lantern-cli dump graph.pb && lantern-cli restore graph.pb
 
@@ -696,7 +703,8 @@ lantern-cli --token "$LANTERN_TOKEN" get vertex alice
 Every subcommand has long-form help (`lantern-cli <cmd> --help`, or
 `lantern-cli help <cmd>`); the REPL/Admin `help bfs|pagerank|community` shows
 only that family's signature, defaults, domains, meaning, and examples. Reads
-emit JSON on stdout, writes print `OK`. Exit codes: `0` success, `1` local/parse
+emit JSON on stdout by default; search additionally supports streamed NDJSON
+and explicitly selected, RFC-style escaped TSV. Writes print `OK`. Exit codes: `0` success, `1` local/parse
 error, `2` RPC error. Values quote C-style with `"…"` (escapes) or
 verbatim with `'…'`.
 

--- a/admin/app/lib/cli/complete.test.ts
+++ b/admin/app/lib/cli/complete.test.ts
@@ -24,6 +24,7 @@ describe("completeCommandLine — verbs (slot 0)", () => {
       "scan",
       "count",
       "keys",
+      "search",
       "bfs",
       "pagerank",
       "community",
@@ -250,6 +251,33 @@ describe("completeCommandLine — family option kwargs (slot ≥ 2)", () => {
     expect(
       completeCommandLine("community alice epsilon=", KEYS).candidates,
     ).toEqual([]);
+  });
+});
+
+describe("completeCommandLine — search option kwargs", () => {
+  test("offers every search option after the query", () => {
+    expect(completeCommandLine("search alpha ", KEYS).candidates).toEqual([
+      "limit=",
+      "prefix=",
+      "mode=",
+      "min_should=",
+      "phrase=",
+      "fuzziness=",
+      "prefix_terms=",
+      "cursor=",
+      "all=",
+      "projection=",
+      "format=",
+    ]);
+  });
+
+  test("completes closed search option values", () => {
+    expect(completeCommandLine("search alpha mode=m", KEYS).candidates).toEqual(
+      ["mode=min-should"],
+    );
+    expect(
+      completeCommandLine("search alpha format=", KEYS).candidates,
+    ).toEqual(["format=json", "format=ndjson", "format=tsv"]);
   });
 });
 

--- a/admin/app/lib/cli/complete.ts
+++ b/admin/app/lib/cli/complete.ts
@@ -38,6 +38,7 @@ const VERBS: readonly string[] = [
   "scan",
   "count",
   "keys",
+  "search",
   "bfs",
   "pagerank",
   "community",
@@ -65,6 +66,20 @@ const FAMILY_OPTION_KEYS: Record<string, readonly string[]> = {
     "prefix",
   ],
 };
+
+const SEARCH_OPTION_KEYS = [
+  "limit",
+  "prefix",
+  "mode",
+  "min_should",
+  "phrase",
+  "fuzziness",
+  "prefix_terms",
+  "cursor",
+  "all",
+  "projection",
+  "format",
+] as const;
 
 /** Cap on how many key candidates we surface, so the hint stays compact. */
 const MAX_KEY_CANDIDATES = 50;
@@ -121,6 +136,13 @@ export function completeCommandLine(
   if (isFamilyVerb && slotIndex >= 2) {
     return {
       candidates: completeFamilyOption(verb, tokens, token),
+      start,
+      token,
+    };
+  }
+  if (verb === "search" && slotIndex >= 2) {
+    return {
+      candidates: completeSearchOption(tokens, token),
       start,
       token,
     };
@@ -261,6 +283,40 @@ function completeFamilyOption(
   return values
     .filter((v) => v.startsWith(valuePrefix))
     .map((v) => `${kw}=${v}`);
+}
+
+function completeSearchOption(
+  tokens: readonly string[],
+  token: string,
+): string[] {
+  const eq = token.indexOf("=");
+  if (eq === -1) {
+    const used = new Set(
+      tokens.slice(2).map((value) => value.split("=")[0].toLowerCase()),
+    );
+    return filterByPrefix(
+      SEARCH_OPTION_KEYS.filter((key) => !used.has(key)).map(
+        (key) => `${key}=`,
+      ),
+      token,
+    );
+  }
+  const key = token.slice(0, eq).toLowerCase();
+  const values: Record<string, readonly string[]> = {
+    mode: ["server", "any", "all", "min-should"],
+    phrase: ["true", "false"],
+    fuzziness: ["0", "1", "2"],
+    prefix_terms: ["true", "false"],
+    all: ["true", "false"],
+    projection: ["key-score", "full-vertex"],
+    format: ["json", "ndjson", "tsv"],
+  };
+  const candidates = values[key];
+  if (candidates === undefined) return [];
+  const prefix = token.slice(eq + 1).toLowerCase();
+  return candidates
+    .filter((value) => value.startsWith(prefix))
+    .map((value) => `${key}=${value}`);
 }
 
 /** The enum values for a family option keyword, or null if unknown. */

--- a/admin/app/lib/cli/parser.ts
+++ b/admin/app/lib/cli/parser.ts
@@ -27,10 +27,11 @@ import {
   parsePagerank,
   parsePut,
   parseScan,
+  parseSearch,
 } from "./verbs";
 
 const VERB_LIST_USAGE =
-  "usage: { get | put | delete | delete-prefix | add | scan | count | keys | bfs | pagerank | community | help | exit } ...";
+  "usage: { get | put | delete | delete-prefix | add | scan | count | keys | search | bfs | pagerank | community | help | exit } ...";
 
 const VERBS = new Set([
   "exit",
@@ -43,6 +44,7 @@ const VERBS = new Set([
   "scan",
   "count",
   "keys",
+  "search",
   "bfs",
   "pagerank",
   "community",
@@ -86,6 +88,8 @@ export function parse(input: string): ParseResult {
       return parseDeletePrefix(rest);
     case "keys":
       return parseKeys(rest);
+    case "search":
+      return parseSearch(rest);
     case "bfs":
       return parseBfs(rest);
     case "pagerank":

--- a/admin/app/lib/cli/types.ts
+++ b/admin/app/lib/cli/types.ts
@@ -22,6 +22,9 @@ export type HelpTopic = "" | AlgorithmName;
 export type ReductionName = "none" | "mst" | "spt";
 export type ObjectiveName = "min" | "max";
 export type WeightingName = "raw" | "tfidf" | "bm25";
+export type SearchMatchMode = "server" | "any" | "all" | "min-should";
+export type SearchProjection = "key-score" | "full-vertex";
+export type SearchOutputFormat = "" | "json" | "ndjson" | "tsv";
 
 export type Command =
   | { verb: "exit" }
@@ -93,6 +96,23 @@ export type Command =
       all: boolean;
     }
   | { verb: "keys"; prefix: string; limit: number }
+  | {
+      /** Shared BM25 content-search grammar (#1068). */
+      verb: "search";
+      query: string;
+      limit: number;
+      prefix: string;
+      mode: SearchMatchMode;
+      minShould: number;
+      phrase: boolean;
+      fuzziness: 0 | 1 | 2;
+      prefixTerms: boolean;
+      cursor: string;
+      all: boolean;
+      projection: SearchProjection;
+      /** Empty means contextual default: json for one page, ndjson for all. */
+      format: SearchOutputFormat;
+    }
   | { verb: "count"; objective: "vertices"; prefix: string }
   | {
       verb: "delete-prefix";

--- a/admin/app/lib/cli/verbs.test.ts
+++ b/admin/app/lib/cli/verbs.test.ts
@@ -42,6 +42,7 @@ const CANONICAL_VERBS = [
   "scan",
   "count",
   "keys",
+  "search",
   "bfs",
   "pagerank",
   "community",

--- a/admin/app/lib/cli/verbs.ts
+++ b/admin/app/lib/cli/verbs.ts
@@ -5,10 +5,14 @@
  */
 
 import type {
+  Command,
   HelpTopic,
   ObjectiveName,
   ParseResult,
   ReductionName,
+  SearchMatchMode,
+  SearchOutputFormat,
+  SearchProjection,
   WeightingName,
 } from "./types";
 
@@ -449,6 +453,143 @@ export function parseDeletePrefix(rest: string[]): ParseResult {
   };
 }
 
+/** Parse the cross-language `search <query> key=value...` grammar (#1068). */
+export function parseSearch(rest: string[]): ParseResult {
+  if (rest.length === 0) {
+    return { ok: false, usage: searchUsage() };
+  }
+  const command: Extract<Command, { verb: "search" }> = {
+    verb: "search",
+    query: rest[0],
+    limit: 0,
+    prefix: "",
+    mode: "server",
+    minShould: 0,
+    phrase: false,
+    fuzziness: 0,
+    prefixTerms: false,
+    cursor: "",
+    all: false,
+    projection: "key-score",
+    format: "",
+  };
+  const seen = new Set<string>();
+  for (const token of rest.slice(1)) {
+    const eq = token.indexOf("=");
+    if (eq <= 0) {
+      return { ok: false, usage: searchUsage() };
+    }
+    const key = token.slice(0, eq).toLowerCase();
+    const value = token.slice(eq + 1);
+    if (seen.has(key)) {
+      return { ok: false, usage: searchUsage() };
+    }
+    seen.add(key);
+    switch (key) {
+      case "limit": {
+        const n = parseFamilyUint32(value);
+        if (n === null) return { ok: false, usage: searchUsage() };
+        command.limit = n;
+        break;
+      }
+      case "prefix":
+        command.prefix = value;
+        break;
+      case "mode": {
+        const mode = value.toLowerCase();
+        if (
+          !(["server", "any", "all", "min-should"] as const).includes(
+            mode as SearchMatchMode,
+          )
+        ) {
+          return { ok: false, usage: searchUsage() };
+        }
+        command.mode = mode as SearchMatchMode;
+        break;
+      }
+      case "min_should": {
+        const n = parseFamilyUint32(value);
+        if (n === null) return { ok: false, usage: searchUsage() };
+        command.minShould = n;
+        break;
+      }
+      case "phrase": {
+        const bool = parseBoolStrict(value);
+        if (bool === null) return { ok: false, usage: searchUsage() };
+        command.phrase = bool;
+        break;
+      }
+      case "fuzziness": {
+        const n = parseFamilyUint32(value);
+        if (n === null || n > 2) return { ok: false, usage: searchUsage() };
+        command.fuzziness = n as 0 | 1 | 2;
+        break;
+      }
+      case "prefix_terms": {
+        const bool = parseBoolStrict(value);
+        if (bool === null) return { ok: false, usage: searchUsage() };
+        command.prefixTerms = bool;
+        break;
+      }
+      case "cursor":
+        command.cursor = value;
+        break;
+      case "all": {
+        const bool = parseBoolStrict(value);
+        if (bool === null) return { ok: false, usage: searchUsage() };
+        command.all = bool;
+        break;
+      }
+      case "projection": {
+        const projection = value.toLowerCase();
+        if (
+          !(["key-score", "full-vertex"] as const).includes(
+            projection as SearchProjection,
+          )
+        ) {
+          return { ok: false, usage: searchUsage() };
+        }
+        command.projection = projection as SearchProjection;
+        break;
+      }
+      case "format": {
+        const format = value.toLowerCase();
+        if (
+          !(["json", "ndjson", "tsv"] as const).includes(
+            format as Exclude<SearchOutputFormat, "">,
+          )
+        ) {
+          return { ok: false, usage: searchUsage() };
+        }
+        command.format = format as Exclude<SearchOutputFormat, "">;
+        break;
+      }
+      default:
+        return { ok: false, usage: searchUsage() };
+    }
+  }
+  if (command.minShould !== 0 && command.mode !== "min-should") {
+    return { ok: false, usage: searchUsage() };
+  }
+  if (
+    command.phrase &&
+    (command.mode !== "server" ||
+      command.minShould !== 0 ||
+      command.fuzziness !== 0 ||
+      command.prefixTerms)
+  ) {
+    return { ok: false, usage: searchUsage() };
+  }
+  if (command.all && command.format === "json") {
+    return { ok: false, usage: searchUsage() };
+  }
+  return { ok: true, command };
+}
+
+function searchUsage(): string {
+  return "usage: search <query: string> [limit=<uint32>] [prefix=<string>] [mode=server|any|all|min-should] [min_should=<uint32>] [phrase=<bool>] [fuzziness=0|1|2] [prefix_terms=<bool>] [cursor=<base64url>] [all=<bool>] [projection=key-score|full-vertex] [format=json|ndjson|tsv]";
+}
+
 export function parseBfs(rest: string[]): ParseResult {
   const usage =
     "usage: bfs <seed: string> [step: int] [fan_out: int] [reduction=none|mst|spt] [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>]";
@@ -712,6 +853,7 @@ export const HELP_TEXT = [
   "  count  vertices <prefix: string>",
   "  delete-prefix vertices <prefix: string> [limit=<int>] [confirm=yes|dry_run=true]",
   "  keys   <prefix: string> [<limit: int>]",
+  "  search <query: string> [limit=<uint32>] [prefix=<string>] [mode=server|any|all|min-should] [min_should=<uint32>] [phrase=<bool>] [fuzziness=0|1|2] [prefix_terms=<bool>] [cursor=<base64url>] [all=<bool>] [projection=key-score|full-vertex] [format=json|ndjson|tsv]",
   "  bfs        <seed: string> [step: int] [fan_out: int]",
   "             [reduction={none|mst|spt}]  default=none",
   "             [objective={min|max}]       default=max",
@@ -875,6 +1017,15 @@ export const CLI_COMMAND_REFERENCE: readonly CliCommandDoc[] = [
     signature: "count vertices <prefix>",
     summary: "Count vertices whose key starts with a prefix.",
     example: "count vertices user:",
+  },
+  {
+    group: "Browse",
+    verb: "search",
+    signature:
+      "search <query> [limit=...] [mode=...] [phrase=...] [all=...] [format=...]",
+    summary:
+      "BM25 content search with cursor paging. One page is lossless JSON; all=true follows the bounded search session.",
+    example: 'search "rolling update" mode=all limit=20',
   },
   {
     group: "Explore",

--- a/admin/app/lib/client/infrastructure/api/error.test.ts
+++ b/admin/app/lib/client/infrastructure/api/error.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { FailedPreconditionError, SearchErrorReason } from "lantern-sdk/web";
+import {
+  FailedPreconditionError,
+  InvalidArgumentError,
+  SearchContinuationLimitedError,
+  SearchCursorStaleError,
+  SearchErrorReason,
+} from "lantern-sdk/web";
 
 import { LanternApiError } from "./error";
 
@@ -28,5 +34,35 @@ describe("LanternApiError search reasons", () => {
   it("does not guess from an untyped FAILED_PRECONDITION", () => {
     const generic = new FailedPreconditionError("another precondition");
     expect(LanternApiError.isDisabled(generic)).toBe(false);
+  });
+
+  it("preserves invalid-cursor, stale-cursor, and continuation reasons", () => {
+    const cases = [
+      {
+        input: new InvalidArgumentError("invalid cursor", {
+          reason: SearchErrorReason.SEARCH_CURSOR_INVALID,
+        }),
+        code: "invalid_argument",
+        reason: SearchErrorReason.SEARCH_CURSOR_INVALID,
+      },
+      {
+        input: new SearchCursorStaleError("stale cursor"),
+        code: "aborted",
+        reason: SearchErrorReason.SEARCH_CURSOR_STALE,
+      },
+      {
+        input: new SearchContinuationLimitedError(),
+        code: "resource_exhausted",
+        reason: SearchErrorReason.SEARCH_CONTINUATION_LIMITED,
+      },
+    ];
+    for (const testCase of cases) {
+      const error = LanternApiError.fromUnknown(
+        "SearchVertices",
+        testCase.input,
+      ) as LanternApiError;
+      expect(error.code).toBe(testCase.code);
+      expect(error.searchReason).toBe(testCase.reason);
+    }
   });
 });

--- a/admin/app/lib/client/infrastructure/api/error.ts
+++ b/admin/app/lib/client/infrastructure/api/error.ts
@@ -5,6 +5,8 @@ import {
   NotFoundError,
   ResourceExhaustedError,
   SearchErrorReason,
+  SearchContinuationLimitedError,
+  SearchCursorStaleError,
 } from "lantern-sdk/web";
 
 /**
@@ -53,15 +55,36 @@ export class LanternApiError extends Error {
       return new LanternApiError(rpc, "not_found", err.message);
     }
     if (err instanceof InvalidArgumentError) {
-      return new LanternApiError(rpc, "invalid_argument", err.message);
+      return new LanternApiError(
+        rpc,
+        "invalid_argument",
+        err.message,
+        err.reason,
+      );
     }
     if (err instanceof ResourceExhaustedError) {
-      return new LanternApiError(rpc, "resource_exhausted", err.message);
+      return new LanternApiError(
+        rpc,
+        "resource_exhausted",
+        err.message,
+        err.reason,
+      );
     }
     if (err instanceof FailedPreconditionError) {
       return new LanternApiError(
         rpc,
         "failed_precondition",
+        err.message,
+        err.reason,
+      );
+    }
+    if (err instanceof SearchCursorStaleError) {
+      return new LanternApiError(rpc, "aborted", err.message, err.reason);
+    }
+    if (err instanceof SearchContinuationLimitedError) {
+      return new LanternApiError(
+        rpc,
+        "resource_exhausted",
         err.message,
         err.reason,
       );

--- a/admin/app/lib/client/infrastructure/api/search-vertices.test.ts
+++ b/admin/app/lib/client/infrastructure/api/search-vertices.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { LanternClient } from "./lantern-client";
-import { searchVertices } from "./search-vertices";
+import { searchAllVertices, searchVertices } from "./search-vertices";
 
 describe("searchVertices adapter", () => {
   it("uses FULL_VERTEX paging and maps the exact SDK snapshot", async () => {
@@ -65,5 +65,33 @@ describe("searchVertices adapter", () => {
     ]);
     expect(response.nextCursor).toBe(nextCursor);
     expect(response.truncated).toBe(true);
+  });
+
+  it("uses the SDK iterator for bounded all-page search", async () => {
+    let captured: Record<string, unknown> | undefined;
+    const client = {
+      async *searchVerticesIter(
+        _query: string,
+        options: Record<string, unknown>,
+      ) {
+        captured = options;
+        yield { key: "doc/1", score: 2, projectionStatus: "key-score" };
+        yield { key: "doc/2", score: 1, projectionStatus: "key-score" };
+      },
+    } as unknown as LanternClient;
+
+    const hits = await searchAllVertices(client, {
+      query: "alpha",
+      limit: 1,
+      cursor: new Uint8Array([1]),
+      projection: "key-score",
+    });
+
+    expect(captured).toMatchObject({
+      limit: 1,
+      cursor: new Uint8Array([1]),
+      projection: "key-score",
+    });
+    expect(hits.map((hit) => hit.key)).toEqual(["doc/1", "doc/2"]);
   });
 });

--- a/admin/app/lib/client/infrastructure/api/search-vertices.ts
+++ b/admin/app/lib/client/infrastructure/api/search-vertices.ts
@@ -35,31 +35,10 @@ export async function searchVertices(
   try {
     const page = await client.searchVerticesPage(
       request.query,
-      {
-        limit: request.limit ?? 0,
-        prefix: request.prefix ?? "",
-        matchMode:
-          request.matchMode === "server" ? undefined : request.matchMode,
-        minShouldMatch:
-          request.matchMode === "min-should"
-            ? request.minShouldMatch
-            : undefined,
-        phrase: request.phrase,
-        fuzziness: request.fuzziness,
-        prefixTerms: request.prefixTerms,
-        cursor: request.cursor,
-        projection: request.projection,
-      },
+      sdkSearchOptions(request),
       init?.signal,
     );
-    const hits: SearchHit[] = page.hits.map((hit) => ({
-      key: hit.key,
-      score: hit.score,
-      ...(hit.vertex ? { vertex: sdkVertexToFlat(hit.vertex) } : {}),
-      ...(hit.projectionStatus
-        ? { projectionStatus: hit.projectionStatus }
-        : {}),
-    }));
+    const hits: SearchHit[] = page.hits.map(toAdminSearchHit);
     return {
       hits,
       nextCursor: page.nextCursor,
@@ -70,4 +49,57 @@ export async function searchVertices(
   } catch (err) {
     throw LanternApiError.fromUnknown("SearchVertices", err);
   }
+}
+
+/**
+ * Follow the maintained Node SDK's bounded search iterator. The iterator owns
+ * cursor propagation and raises its typed continuation error after the final
+ * retained hit; this adapter only maps SDK vertices into Admin's flat shape.
+ */
+export async function searchAllVertices(
+  client: LanternClient,
+  request: SearchVerticesRequest,
+  init?: { signal?: AbortSignal },
+): Promise<SearchHit[]> {
+  try {
+    const hits: SearchHit[] = [];
+    for await (const hit of client.searchVerticesIter(
+      request.query,
+      sdkSearchOptions(request),
+      init?.signal,
+    )) {
+      hits.push(toAdminSearchHit(hit));
+    }
+    return hits;
+  } catch (err) {
+    throw LanternApiError.fromUnknown("SearchVertices", err);
+  }
+}
+
+type SdkSearchHit = Awaited<
+  ReturnType<LanternClient["searchVertices"]>
+>[number];
+
+function toAdminSearchHit(hit: SdkSearchHit): SearchHit {
+  return {
+    key: hit.key,
+    score: hit.score,
+    ...(hit.vertex ? { vertex: sdkVertexToFlat(hit.vertex) } : {}),
+    ...(hit.projectionStatus ? { projectionStatus: hit.projectionStatus } : {}),
+  };
+}
+
+function sdkSearchOptions(request: SearchVerticesRequest) {
+  return {
+    limit: request.limit ?? 0,
+    prefix: request.prefix ?? "",
+    matchMode: request.matchMode === "server" ? undefined : request.matchMode,
+    minShouldMatch:
+      request.matchMode === "min-should" ? request.minShouldMatch : undefined,
+    phrase: request.phrase,
+    fuzziness: request.fuzziness,
+    prefixTerms: request.prefixTerms,
+    cursor: request.cursor,
+    projection: request.projection,
+  };
 }

--- a/admin/app/lib/client/usecase/cli/dispatcher.test.ts
+++ b/admin/app/lib/client/usecase/cli/dispatcher.test.ts
@@ -74,6 +74,24 @@ class FakeLanternClient {
   ): unknown {
     return this.invoke("scanVertexKeys", [prefix, opts, signal]);
   }
+  searchVerticesPage(
+    query: string,
+    opts?: unknown,
+    signal?: AbortSignal,
+  ): unknown {
+    return this.invoke("searchVerticesPage", [query, opts, signal]);
+  }
+  searchVerticesIter(
+    query: string,
+    opts?: unknown,
+    signal?: AbortSignal,
+  ): AsyncIterable<unknown> {
+    return this.invoke("searchVerticesIter", [
+      query,
+      opts,
+      signal,
+    ]) as AsyncIterable<unknown>;
+  }
   countVerticesByPrefix(prefix: string, signal?: AbortSignal): unknown {
     return this.invoke("countVerticesByPrefix", [prefix, signal]);
   }
@@ -797,5 +815,88 @@ describe("dispatch family verbs map to the per-family oneofs (#975)", () => {
     });
     expect(opts.community).toBeUndefined();
     expect(opts.ppr).toBeUndefined();
+  });
+});
+
+describe("dispatch search (#1068 shared request semantics)", () => {
+  test("maps every grammar option onto one Node SDK page request", async () => {
+    const fake = new FakeLanternClient();
+    fake.stub("searchVerticesPage", () => ({
+      hits: [{ key: "利用者/one", score: 2.5, projectionStatus: "key-score" }],
+      nextCursor: new Uint8Array([4, 5]),
+      effectiveLimit: 17,
+      truncated: true,
+      continuationLimited: false,
+    }));
+    const parsed = parse(
+      'search "静かな rolling update" limit=17 prefix=利用者/ mode=min-should min_should=2 fuzziness=1 prefix_terms=true cursor=AQID projection=key-score format=json',
+    );
+    if (!parsed.ok) throw new Error(parsed.usage);
+
+    const result = await dispatch({
+      client: asClient(fake),
+      command: parsed.command,
+    });
+
+    expect(fake.calls).toHaveLength(1);
+    const [query, opts] = fake.calls[0].args as [
+      string,
+      {
+        limit: number;
+        prefix: string;
+        matchMode: string;
+        minShouldMatch: number;
+        fuzziness: number;
+        prefixTerms: boolean;
+        cursor: Uint8Array;
+        projection: string;
+      },
+    ];
+    expect(query).toBe("静かな rolling update");
+    expect(opts).toMatchObject({
+      limit: 17,
+      prefix: "利用者/",
+      matchMode: "min-should",
+      minShouldMatch: 2,
+      fuzziness: 1,
+      prefixTerms: true,
+      projection: "key-score",
+    });
+    expect(Array.from(opts.cursor)).toEqual([1, 2, 3]);
+    expect(result).toMatchObject({
+      hits: [{ key: "利用者/one", score: 2.5 }],
+      nextCursor: "BAU",
+      effectiveLimit: 17,
+      truncated: true,
+    });
+  });
+
+  test("all=true follows the bounded cursor chain", async () => {
+    const fake = new FakeLanternClient();
+    fake.stub("searchVerticesIter", async function* () {
+      yield { key: "a", score: 2 };
+      yield { key: "b", score: 1 };
+    });
+    const parsed = parse("search alpha limit=1 all=true");
+    if (!parsed.ok) throw new Error(parsed.usage);
+    const result = (await dispatch({
+      client: asClient(fake),
+      command: parsed.command,
+    })) as { hits: Array<{ key: string }> };
+    expect(result.hits.map((hit) => hit.key)).toEqual(["a", "b"]);
+    expect(fake.calls).toHaveLength(1);
+    expect(fake.calls[0].method).toBe("searchVerticesIter");
+    const opts = fake.calls[0].args[1] as { cursor: Uint8Array };
+    expect(Array.from(opts.cursor)).toEqual([]);
+  });
+
+  test("rejects a malformed cursor before the SDK call", async () => {
+    const fake = new FakeLanternClient();
+    const parsed = parse("search alpha cursor=not+base64");
+    if (!parsed.ok) throw new Error(parsed.usage);
+    await expect(
+      dispatch({ client: asClient(fake), command: parsed.command }),
+    ).rejects.toThrow("unpadded URL-safe base64");
+    expect(fake.calls).toHaveLength(0);
   });
 });

--- a/admin/app/lib/client/usecase/cli/dispatcher.ts
+++ b/admin/app/lib/client/usecase/cli/dispatcher.ts
@@ -51,6 +51,10 @@ import { putVertex } from "~/lib/client/infrastructure/api/put-vertex";
 import { scanEdges } from "~/lib/client/infrastructure/api/scan-edges";
 import { scanVertexKeys } from "~/lib/client/infrastructure/api/scan-vertex-keys";
 import { scanVertices } from "~/lib/client/infrastructure/api/scan-vertices";
+import {
+  searchAllVertices,
+  searchVertices,
+} from "~/lib/client/infrastructure/api/search-vertices";
 import type { Edge, Vertex } from "~/lib/client/infrastructure/api/types";
 import type {
   Command,
@@ -291,6 +295,8 @@ export async function dispatch(input: DispatchInput): Promise<unknown> {
         { prefix: command.prefix, limit: command.limit },
         { signal },
       );
+    case "search":
+      return dispatchSearch(client, command, signal);
     case "bfs":
       return illuminate(
         client,
@@ -342,6 +348,73 @@ export async function dispatch(input: DispatchInput): Promise<unknown> {
 // ----------------------------------------------------------------------------
 // Internals
 // ----------------------------------------------------------------------------
+
+type SearchCommand = Extract<Command, { verb: "search" }>;
+
+/**
+ * Execute the shared search model through the maintained Node SDK adapter.
+ * Admin scrollback is intrinsically JSON, so `format` affects the Go machine
+ * surface only; the browser always returns a safely serialisable page object.
+ * all=true follows the bounded server search session and collects at most that
+ * retained session into one scrollback entry (the same bounded compromise the
+ * existing scan all=true dispatcher uses).
+ */
+async function dispatchSearch(
+  client: LanternClient,
+  command: SearchCommand,
+  signal?: AbortSignal,
+): Promise<Record<string, unknown>> {
+  const request = {
+    query: command.query,
+    limit: command.limit,
+    prefix: command.prefix,
+    matchMode: command.mode,
+    minShouldMatch: command.minShould,
+    phrase: command.phrase,
+    fuzziness: command.fuzziness,
+    prefixTerms: command.prefixTerms,
+    cursor: decodeSearchCursor(command.cursor),
+    projection: command.projection,
+  } as const;
+  if (command.all) {
+    return { hits: await searchAllVertices(client, request, { signal }) };
+  }
+  const page = await searchVertices(client, request, { signal });
+  return {
+    hits: page.hits,
+    nextCursor: encodeSearchCursor(page.nextCursor),
+    effectiveLimit: page.effectiveLimit,
+    truncated: page.truncated,
+    continuationLimited: page.continuationLimited,
+  };
+}
+
+function decodeSearchCursor(value: string): Uint8Array {
+  if (value === "") return new Uint8Array();
+  if (!/^[A-Za-z0-9_-]+$/.test(value) || value.length % 4 === 1) {
+    throw new Error("search: cursor must be unpadded URL-safe base64");
+  }
+  const padded =
+    value.replaceAll("-", "+").replaceAll("_", "/") +
+    "=".repeat((4 - (value.length % 4)) % 4);
+  let binary: string;
+  try {
+    binary = atob(padded);
+  } catch {
+    throw new Error("search: cursor must be unpadded URL-safe base64");
+  }
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+function encodeSearchCursor(cursor: Uint8Array): string {
+  if (cursor.length === 0) return "";
+  let binary = "";
+  for (const byte of cursor) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
 
 // Page through every `scan vertices` result so `all=true` renders the
 // full set (mirrors the Go REPL's ScanVerticesAll loop). The infra

--- a/admin/test/cli-grammar/grammar.test.ts
+++ b/admin/test/cli-grammar/grammar.test.ts
@@ -74,6 +74,21 @@ function normalizeFamilyCommand(command: Command): Record<string, unknown> {
         weighting: command.weighting,
         prefix: command.vertexPrefix,
       };
+    case "search":
+      return {
+        query: command.query,
+        limit: command.limit,
+        prefix: command.prefix,
+        mode: command.mode,
+        min_should: command.minShould,
+        phrase: command.phrase,
+        fuzziness: command.fuzziness,
+        prefix_terms: command.prefixTerms,
+        cursor: command.cursor,
+        all: command.all,
+        projection: command.projection,
+        format: command.format,
+      };
     default:
       throw new Error(`expected family command, got ${command.verb}`);
   }
@@ -89,7 +104,9 @@ describe("CLI grammar fixture (#411) — valid inputs", () => {
         );
       }
       expect(result.ok).toBe(true);
-      if (["bfs", "pagerank", "community"].includes(result.command.verb)) {
+      if (
+        ["bfs", "pagerank", "community", "search"].includes(result.command.verb)
+      ) {
         if (c.expected === undefined) {
           throw new Error(
             `family fixture ${JSON.stringify(c.input)} is missing its expected normalized AST`,

--- a/admin/test/cli-grammar/verbs.json
+++ b/admin/test/cli-grammar/verbs.json
@@ -486,6 +486,60 @@
       "comment": "#438: quoted key works in non-put positions too"
     },
     {
+      "input": "search \"静かな rolling update\" limit=17 prefix=Users/ mode=min-should min_should=2 fuzziness=1 prefix_terms=true cursor=AQID all=true projection=full-vertex format=ndjson",
+      "comment": "#1068: Unicode multi-word query plus every composable option",
+      "expected": {
+        "query": "静かな rolling update",
+        "limit": 17,
+        "prefix": "Users/",
+        "mode": "min-should",
+        "min_should": 2,
+        "phrase": false,
+        "fuzziness": 1,
+        "prefix_terms": true,
+        "cursor": "AQID",
+        "all": true,
+        "projection": "full-vertex",
+        "format": "ndjson"
+      }
+    },
+    {
+      "input": "search \"exact phrase\" phrase=true",
+      "comment": "#1068: phrase is valid with server-owned match defaults",
+      "expected": {
+        "query": "exact phrase",
+        "limit": 0,
+        "prefix": "",
+        "mode": "server",
+        "min_should": 0,
+        "phrase": true,
+        "fuzziness": 0,
+        "prefix_terms": false,
+        "cursor": "",
+        "all": false,
+        "projection": "key-score",
+        "format": ""
+      }
+    },
+    {
+      "input": "search alpha format=tsv",
+      "comment": "#1068: explicit lossless TSV output",
+      "expected": {
+        "query": "alpha",
+        "limit": 0,
+        "prefix": "",
+        "mode": "server",
+        "min_should": 0,
+        "phrase": false,
+        "fuzziness": 0,
+        "prefix_terms": false,
+        "cursor": "",
+        "all": false,
+        "projection": "key-score",
+        "format": "tsv"
+      }
+    },
+    {
       "input": "help",
       "comment": "#995: bare help prints the complete grammar",
       "expected": { "topic": "" }
@@ -509,6 +563,61 @@
   "invalid": [
     { "input": "", "comment": "empty input" },
     { "input": "nonsense", "comment": "unknown verb" },
+    { "input": "search", "comment": "#1068: search requires a query token" },
+    {
+      "input": "search alpha 10",
+      "comment": "#1068: options require key=value"
+    },
+    { "input": "search alpha limit=-1", "comment": "#1068: unsigned limit" },
+    {
+      "input": "search alpha limit=4294967296",
+      "comment": "#1068: limit must fit uint32"
+    },
+    {
+      "input": "search alpha fuzziness=3",
+      "comment": "#1068: fuzziness range"
+    },
+    {
+      "input": "search alpha min_should=1",
+      "comment": "#1068: minimum requires min-should mode"
+    },
+    {
+      "input": "search alpha phrase=true mode=any",
+      "comment": "#1068: phrase cannot compose with explicit mode"
+    },
+    {
+      "input": "search alpha phrase=true fuzziness=1",
+      "comment": "#1068: phrase cannot compose with fuzziness"
+    },
+    {
+      "input": "search alpha phrase=true prefix_terms=true",
+      "comment": "#1068: phrase cannot compose with prefix terms"
+    },
+    {
+      "input": "search alpha all=true format=json",
+      "comment": "#1068: exhaustive JSON collection is refused"
+    },
+    {
+      "input": "search alpha mode=bogus",
+      "comment": "#1068: closed match mode"
+    },
+    {
+      "input": "search alpha projection=bogus",
+      "comment": "#1068: closed projection"
+    },
+    {
+      "input": "search alpha format=yaml",
+      "comment": "#1068: closed output format"
+    },
+    { "input": "search alpha all=maybe", "comment": "#1068: boolean syntax" },
+    {
+      "input": "search alpha limit=1 limit=2",
+      "comment": "#1068: duplicate options are rejected"
+    },
+    {
+      "input": "search alpha unknown=value",
+      "comment": "#1068: unknown options are rejected"
+    },
     { "input": "help me", "comment": "#995: unknown help topic" },
     { "input": "help bfs pagerank", "comment": "#995: only one help topic" },
     { "input": "get", "comment": "missing objective" },

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -167,6 +167,18 @@ test.describe("/cli", () => {
     await expect(ok.last()).toContainText("first");
   });
 
+  test("search uses the shared grammar and safely renders JSON", async ({
+    page,
+  }) => {
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    await input.fill("search first prefix=cli: limit=5");
+    await input.press("Enter");
+    const ok = page.getByTestId("cli-entry-ok").last();
+    await expect(ok).toContainText("cli:alpha");
+    await expect(ok.getByTestId("cli-json")).toBeVisible();
+  });
+
   test("invalid verb surfaces the parser usage hint", async ({ page }) => {
     await page.goto("/cli");
     const input = page.getByTestId("cli-input");

--- a/cli/cmd/grammar.go
+++ b/cli/cmd/grammar.go
@@ -19,12 +19,15 @@ import (
 //	lantern-cli delete edge   <tail> <head>
 //	lantern-cli scan   vertices <prefix> [limit]
 //	lantern-cli scan   edges    <tail-prefix> [limit]
+//	lantern-cli search <query> [limit=<n>] [mode=server|any|all|min-should] [...]
 //
 // These commands intentionally share ONE grammar and ONE dispatcher with
 // the REPL: each forwards its argv to service.CLIService.RunArgs, the same
 // entry point the REPL uses per typed line. The verb-first grammar is the
-// single CLI surface; `bulk` (NDJSON load) and the global TLS/gzip flags
-// cover what the grammar deliberately does not.
+// single CLI surface. Search keeps a dedicated Cobra facade for idiomatic
+// --flags, but it maps those flags into parser.Search and calls the same
+// CLIService.RunSearch as this grammar. `bulk` (NDJSON load) and the global
+// TLS/gzip flags cover what the grammar deliberately does not.
 //
 // Flag-parsing note: each verb sets SetInterspersed(false) so a value
 // beginning with '-' (e.g. a negative edge weight, `add edge a b -1.5`) is

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -67,7 +67,7 @@ WHAT LANTERN IS
 COMMAND LAYOUT
   Verb-first grammar (one-liners — identical to the "lantern-cli repl" prompt and
   the admin web /cli):
-    get / put / add / delete / scan / count / delete-prefix / keys
+    get / put / add / delete / scan / count / delete-prefix / keys / search
       e.g. "lantern-cli get vertex alice", "lantern-cli scan vertices users/ all=true",
       "lantern-cli count vertices users/", "lantern-cli keys user:" (Redis-style KEYS)
   bfs         greedy per-hop top-k BFS walk from a seed
@@ -96,8 +96,9 @@ GLOBAL CONNECTION FLAGS
       --chunk-size   batch chunk size for multi-key write/delete (default 1000)
 
 OUTPUT
-  All read commands print JSON on stdout. All write commands print a single
-  "OK" line on stdout when they succeed. Errors go to stderr.
+  Read commands print JSON on stdout by default. Search additionally supports
+  streamed NDJSON and explicit, losslessly encoded TSV. All write commands
+  print a single "OK" line on stdout when they succeed. Errors go to stderr.
 
 EXIT CODES
   0  success
@@ -116,6 +117,7 @@ EXAMPLES
   lantern-cli delete vertex alice bob carol        # variadic batch delete
   lantern-cli delete-prefix vertices tmp/ dry_run=true
   lantern-cli keys user: 100                       # Redis-style KEYS (vertex keys under a prefix)
+  lantern-cli search "rolling update" mode=all limit=20
   lantern-cli bfs alice 2 5 reduction=spt objective=max
 
   # NDJSON bulk load (streamed)

--- a/cli/cmd/search.go
+++ b/cli/cmd/search.go
@@ -1,13 +1,8 @@
 package cmd
 
 import (
-	"encoding/base64"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"strings"
-
-	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/anaregdesign/lantern/cli/parser"
+	"github.com/anaregdesign/lantern/cli/service"
 	"github.com/spf13/cobra"
 )
 
@@ -22,79 +17,27 @@ var (
 	searchCursor      string
 	searchAll         bool
 	searchProjection  string
+	searchFormat      string
 )
 
-// parseSearchMode maps the --mode flag onto a client.MatchMode.
-func parseSearchMode(s string) (client.MatchMode, error) {
-	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", "server", "default", "unset":
-		return client.MatchServerDefault, nil
-	case "any":
-		return client.MatchAny, nil
-	case "all":
-		return client.MatchAll, nil
-	case "min-should", "minshould", "min_should":
-		return client.MatchMinShould, nil
-	default:
-		return 0, fmt.Errorf("unknown --mode %q (want server|any|all|min-should)", s)
+// searchCommandModel is the Cobra-to-shared-grammar boundary. Request
+// construction, validation, paging, and output all live in CLIService, which
+// is also what the REPL calls after parsing `search ...` (#1068).
+func searchCommandModel(query string) parser.Search {
+	return parser.Search{
+		Query:       query,
+		Limit:       searchLimit,
+		Prefix:      searchPrefix,
+		Mode:        searchMode,
+		MinShould:   searchMinShould,
+		Phrase:      searchPhrase,
+		Fuzziness:   searchFuzziness,
+		PrefixTerms: searchPrefixTerms,
+		Cursor:      searchCursor,
+		All:         searchAll,
+		Projection:  searchProjection,
+		Format:      searchFormat,
 	}
-}
-
-func parseSearchProjection(s string) (client.SearchProjection, error) {
-	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", "key-score", "key_score", "keyscore":
-		return client.SearchProjectionKeyScore, nil
-	case "full-vertex", "full_vertex", "fullvertex":
-		return client.SearchProjectionFullVertex, nil
-	default:
-		return 0, fmt.Errorf("unknown --projection %q (want key-score|full-vertex)", s)
-	}
-}
-
-type searchHitOutput struct {
-	Key              string          `json:"key"`
-	Score            float64         `json:"score"`
-	Vertex           json.RawMessage `json:"vertex,omitempty"`
-	ProjectionStatus string          `json:"projection_status"`
-}
-
-type searchPageOutput struct {
-	Hits                []searchHitOutput `json:"hits"`
-	NextCursor          string            `json:"next_cursor"`
-	EffectiveLimit      uint32            `json:"effective_limit"`
-	Truncated           bool              `json:"truncated"`
-	ContinuationLimited bool              `json:"continuation_limited"`
-}
-
-func searchProjectionStatusString(status client.SearchHitProjectionStatus) string {
-	switch status {
-	case client.SearchHitProjectionKeyScore:
-		return "key-score"
-	case client.SearchHitProjectionSnapshot:
-		return "snapshot"
-	case client.SearchHitProjectionMissing:
-		return "missing"
-	case client.SearchHitProjectionReplaced:
-		return "replaced"
-	default:
-		return "unspecified"
-	}
-}
-
-func searchHitForOutput(hit client.SearchHit) (searchHitOutput, error) {
-	out := searchHitOutput{
-		Key:              hit.Key,
-		Score:            hit.Score,
-		ProjectionStatus: searchProjectionStatusString(hit.ProjectionStatus),
-	}
-	if hit.Vertex != nil {
-		vertex, err := client.MarshalVertexJSON(hit.Vertex)
-		if err != nil {
-			return searchHitOutput{}, fmt.Errorf("marshal projected vertex %q: %w", hit.Key, err)
-		}
-		out.Vertex = vertex
-	}
-	return out, nil
 }
 
 var searchCmd = &cobra.Command{
@@ -102,28 +45,37 @@ var searchCmd = &cobra.Command{
 	Short: "Full-text search vertices by content relevance (BM25)",
 	Long: `Search vertices by relevance-ranked full-text over their key and value.
 
-This is the content counterpart to "scan vertices" (a lexicographic key walk):
-search by remembered topic words instead of an exact key prefix. One page prints
-a JSON object with hits, next_cursor, effective_limit, truncated, and
-continuation_limited. --all lazily follows the endpoint-sticky cursor and emits
-one hit JSON object per NDJSON line; it never accumulates an unbounded array.
-A query that matches nothing succeeds. Requires the server's search index
-(LANTERN_SEARCH_ENABLED, on by default).
+This command uses the same Search model, validation, request construction, and
+output implementation as "search ..." in the interactive REPL. Admin /cli
+accepts the same key=value grammar.
+
+One page defaults to a lossless JSON object containing hits, next_cursor,
+effective_limit, truncated, and continuation_limited. --format=ndjson emits one
+hit per line. --format=tsv uses a real TSV encoder (fields containing tabs,
+newlines, or quotes are quoted); its columns are key, score, projection_status,
+and vertex JSON. --all follows the endpoint-sticky cursor without collecting an
+unbounded array and defaults to NDJSON. Explicit --all --format=json is refused
+so cancellation can never leave a partial JSON document. Completed NDJSON/TSV
+records may remain visible if a later page is cancelled or fails.
 
 By default the server chooses how query words combine. Override it with:
 
-	--mode server         defer to LANTERN_SEARCH_DEFAULT_MODE (default)
+  --mode server         defer to LANTERN_SEARCH_DEFAULT_MODE (default)
   --mode all            require every query word (AND)
   --mode min-should --min-should N   require at least N distinct query words
   --phrase              require the words to occur adjacently, in order
   --fuzziness 1|2       also match terms within that edit distance (typos)
   --prefix-terms        also match terms that extend a query word ("lan"→"lantern")
 
---prefix scopes hits to a key namespace; --limit caps the ranked-hit count
-(0 lets the server apply its configured default). --projection full-vertex
-includes each hit's exact selection-time value/TTL snapshot. --cursor accepts
-the URL-safe base64 next_cursor from a previous page; every other option and
-the serving endpoint must remain unchanged.
+--prefix scopes hits to a key namespace; --limit caps each page (0 lets the
+server apply its configured default). --projection full-vertex includes each
+hit's exact selection-time value/TTL snapshot. --cursor accepts the unpadded
+URL-safe base64 next_cursor from a previous page; every other option and the
+serving endpoint must remain unchanged.
+
+REPL EQUIVALENT
+  search "rolling update" mode=all limit=20 format=json
+  search espresso limit=20 all=true
 
 EXAMPLES
   lantern-cli search "calm concise"
@@ -132,131 +84,34 @@ EXAMPLES
   lantern-cli search serach --fuzziness 1
   lantern-cli search lan --prefix-terms
   lantern-cli --address host:6380 search espresso --prefix user. --limit 20
-	lantern-cli search espresso --limit 20 --all
-	lantern-cli search espresso --projection full-vertex
+  lantern-cli search espresso --limit 20 --all
+  lantern-cli search espresso --projection full-vertex
+  lantern-cli search espresso --format tsv
 `,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		mode, err := parseSearchMode(searchMode)
-		if err != nil {
-			return err
-		}
-		projection, err := parseSearchProjection(searchProjection)
-		if err != nil {
-			return err
-		}
-		var cursor []byte
-		if searchCursor != "" {
-			cursor, err = base64.RawURLEncoding.DecodeString(searchCursor)
-			if err != nil {
-				return fmt.Errorf("--cursor must be URL-safe base64 without padding: %w", err)
-			}
-		}
-
-		opts := []client.SearchOption{
-			client.WithSearchLimit(searchLimit),
-			client.WithSearchPrefix(searchPrefix),
-			client.WithSearchProjection(projection),
-			client.WithSearchCursor(cursor),
-		}
-		if mode != client.MatchServerDefault {
-			opts = append(opts, client.WithMatchMode(mode))
-		}
-		if searchMinShould > 0 {
-			opts = append(opts, client.WithMinShouldMatch(searchMinShould))
-		}
-		if searchFuzziness > 0 {
-			opts = append(opts, client.WithFuzziness(searchFuzziness))
-		}
-		if searchPrefixTerms {
-			opts = append(opts, client.WithPrefixTerms())
-		}
-		if searchPhrase {
-			opts = append(opts, client.WithPhrase())
-		}
-		if err := client.ValidateSearchOptions(opts...); err != nil {
-			return err
-		}
-
+		model := searchCommandModel(args[0])
 		cli, err := dial()
 		if err != nil {
 			return err
 		}
 		defer func() { _ = cli.Close() }()
-
-		encoder := json.NewEncoder(cmd.OutOrStdout())
-		encoder.SetEscapeHTML(false)
-		if searchAll {
-			for hit, iterErr := range cli.SearchVerticesIter(cmd.Context(), args[0], opts...) {
-				if iterErr != nil {
-					return actionableSearchError(iterErr)
-				}
-				out, outputErr := searchHitForOutput(hit)
-				if outputErr != nil {
-					return outputErr
-				}
-				if outputErr := encoder.Encode(out); outputErr != nil {
-					return fmt.Errorf("write search result: %w", outputErr)
-				}
-			}
-			return nil
-		}
-
-		page, err := cli.SearchVerticesPage(cmd.Context(), args[0], opts...)
-		if err != nil {
-			return actionableSearchError(err)
-		}
-		hits := make([]searchHitOutput, 0, len(page.Hits))
-		for _, hit := range page.Hits {
-			out, outputErr := searchHitForOutput(hit)
-			if outputErr != nil {
-				return outputErr
-			}
-			hits = append(hits, out)
-		}
-		if err := encoder.Encode(searchPageOutput{
-			Hits:                hits,
-			NextCursor:          base64.RawURLEncoding.EncodeToString(page.NextCursor),
-			EffectiveLimit:      page.EffectiveLimit,
-			Truncated:           page.Truncated,
-			ContinuationLimited: page.ContinuationLimited,
-		}); err != nil {
-			return fmt.Errorf("write search page: %w", err)
-		}
-		return nil
+		return service.NewCLIService(cli, service.WithOutput(cmd.OutOrStdout())).RunSearch(cmd.Context(), model)
 	},
-}
-
-func actionableSearchError(err error) error {
-	switch {
-	case errors.Is(err, client.ErrSearchPositionsDisabled):
-		return fmt.Errorf("phrase search is unavailable: restart the server with LANTERN_SEARCH_POSITIONS=true or omit --phrase: %w", err)
-	case errors.Is(err, client.ErrSearchDisabled):
-		return fmt.Errorf("content search is unavailable: restart the server with LANTERN_SEARCH_ENABLED=true: %w", err)
-	case errors.Is(err, client.ErrSearchIndexIncomplete):
-		return fmt.Errorf("content search is unavailable: the local index is incomplete and requires a bounded rebuild: %w", err)
-	case errors.Is(err, client.ErrSearchCursorStale):
-		return fmt.Errorf("search cursor is stale: restart explicitly from page 1 on the same endpoint: %w", err)
-	case errors.Is(err, client.ErrSearchCursorInvalid):
-		return fmt.Errorf("search cursor is invalid for this query, option set, projection, config, or endpoint: %w", err)
-	case errors.Is(err, client.ErrSearchContinuationLimited):
-		return fmt.Errorf("search continuation reached the server's bounded session cap; narrow the query or raise the server session limits: %w", err)
-	default:
-		return err
-	}
 }
 
 func init() {
 	f := searchCmd.Flags()
-	f.Uint32Var(&searchLimit, "limit", 0, "maximum hits to return (0 = server default)")
+	f.Uint32Var(&searchLimit, "limit", 0, "maximum hits per page (0 = server default)")
 	f.StringVar(&searchPrefix, "prefix", "", "restrict hits to vertices whose key carries this prefix")
 	f.StringVar(&searchMode, "mode", "server", "term combination: server|any|all|min-should")
 	f.Uint32Var(&searchMinShould, "min-should", 0, "minimum distinct query words a hit must carry (with --mode min-should)")
 	f.Uint32Var(&searchFuzziness, "fuzziness", 0, "maximum edit distance for fuzzy term matching (0-2)")
 	f.BoolVar(&searchPrefixTerms, "prefix-terms", false, "also match dictionary terms that extend a query word")
 	f.BoolVar(&searchPhrase, "phrase", false, "require the query's words to occur adjacently, in order")
-	f.StringVar(&searchCursor, "cursor", "", "URL-safe base64 cursor returned by the previous page")
-	f.BoolVar(&searchAll, "all", false, "lazily follow all retained pages and emit NDJSON hits")
+	f.StringVar(&searchCursor, "cursor", "", "unpadded URL-safe base64 cursor returned by the previous page")
+	f.BoolVar(&searchAll, "all", false, "lazily follow all retained pages (default output: NDJSON)")
 	f.StringVar(&searchProjection, "projection", "key-score", "hit payload: key-score|full-vertex")
+	f.StringVar(&searchFormat, "format", "", "output: json|ndjson|tsv (default json; --all defaults ndjson)")
 	rootCmd.AddCommand(searchCmd)
 }

--- a/cli/cmd/search_test.go
+++ b/cli/cmd/search_test.go
@@ -1,138 +1,71 @@
 package cmd
 
 import (
-	"encoding/json"
-	"errors"
-	"strings"
+	"reflect"
 	"testing"
 
-	client "github.com/anaregdesign/lantern/sdks/go"
+	"github.com/anaregdesign/lantern/cli/parser"
 )
 
-func TestParseSearchMode(t *testing.T) {
-	cases := []struct {
-		in      string
-		want    client.MatchMode
-		wantErr bool
-	}{
-		{"", client.MatchServerDefault, false},
-		{"server", client.MatchServerDefault, false},
-		{"default", client.MatchServerDefault, false},
-		{"unset", client.MatchServerDefault, false},
-		{"any", client.MatchAny, false},
-		{"ANY", client.MatchAny, false},
-		{"all", client.MatchAll, false},
-		{"min-should", client.MatchMinShould, false},
-		{"minshould", client.MatchMinShould, false},
-		{"bogus", client.MatchAny, true},
-	}
-	for _, c := range cases {
-		got, err := parseSearchMode(c.in)
-		if c.wantErr {
-			if err == nil {
-				t.Errorf("parseSearchMode(%q) err = nil, want error", c.in)
-			}
-			continue
-		}
-		if err != nil {
-			t.Errorf("parseSearchMode(%q) err = %v", c.in, err)
-		}
-		if got != c.want {
-			t.Errorf("parseSearchMode(%q) = %v, want %v", c.in, got, c.want)
-		}
-	}
-}
-
-func TestParseSearchProjection(t *testing.T) {
-	for _, tc := range []struct {
-		input string
-		want  client.SearchProjection
-	}{
-		{"key-score", client.SearchProjectionKeyScore},
-		{"KEY_SCORE", client.SearchProjectionKeyScore},
-		{"full-vertex", client.SearchProjectionFullVertex},
-		{"full_vertex", client.SearchProjectionFullVertex},
-	} {
-		got, err := parseSearchProjection(tc.input)
-		if err != nil || got != tc.want {
-			t.Errorf("parseSearchProjection(%q) = (%v, %v), want (%v, nil)", tc.input, got, err, tc.want)
-		}
-	}
-	if _, err := parseSearchProjection("everything"); err == nil {
-		t.Fatal("parseSearchProjection(everything) = nil error")
-	}
-}
-
-func TestSearchHitForOutputPreservesProjectedVertex(t *testing.T) {
-	projected, err := client.UnmarshalVertexJSON([]byte(`{"key":"doc/1","type":"string","value":"alpha"}`))
-	if err != nil {
-		t.Fatal(err)
-	}
-	hit, err := searchHitForOutput(client.SearchHit{
-		Key:              "doc/1",
-		Score:            3.5,
-		Vertex:           projected,
-		ProjectionStatus: client.SearchHitProjectionSnapshot,
+// TestSearchCommandModelMatchesREPL proves the top-level Cobra flag surface
+// produces the same shared model as the REPL grammar. Both paths then call the
+// single CLIService.RunSearch request/output implementation (#1068).
+func TestSearchCommandModelMatchesREPL(t *testing.T) {
+	old := searchCommandModel("")
+	t.Cleanup(func() {
+		searchLimit = old.Limit
+		searchPrefix = old.Prefix
+		searchMode = old.Mode
+		searchMinShould = old.MinShould
+		searchPhrase = old.Phrase
+		searchFuzziness = old.Fuzziness
+		searchPrefixTerms = old.PrefixTerms
+		searchCursor = old.Cursor
+		searchAll = old.All
+		searchProjection = old.Projection
+		searchFormat = old.Format
 	})
+
+	searchLimit = 17
+	searchPrefix = "利用者/"
+	searchMode = "min-should"
+	searchMinShould = 2
+	searchPhrase = false
+	searchFuzziness = 1
+	searchPrefixTerms = true
+	searchCursor = "AQID"
+	searchAll = true
+	searchProjection = "full-vertex"
+	searchFormat = "ndjson"
+
+	wantSource, err := parser.NewSource(`search "静かな rolling update" limit=17 prefix=利用者/ mode=min-should min_should=2 fuzziness=1 prefix_terms=true cursor=AQID all=true projection=full-vertex format=ndjson`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	var vertex map[string]any
-	if err := json.Unmarshal(hit.Vertex, &vertex); err != nil {
+	if _, err := parser.Verb(wantSource); err != nil {
 		t.Fatal(err)
 	}
-	if hit.ProjectionStatus != "snapshot" || vertex["key"] != "doc/1" || vertex["value"] != "alpha" {
-		t.Fatalf("output = %#v, vertex = %#v", hit, vertex)
+	want, err := parser.SearchParam(wantSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := searchCommandModel("静かな rolling update")
+	if !reflect.DeepEqual(got, *want) {
+		t.Fatalf("Cobra model = %#v\nREPL model = %#v", got, *want)
 	}
 }
 
-func TestSearchFlagOptionsValidateBeforeDial(t *testing.T) {
-	tests := []struct {
-		name string
-		opts []client.SearchOption
-	}{
-		{"minimum without min mode", []client.SearchOption{client.WithMinShouldMatch(1)}},
-		{"phrase with explicit mode", []client.SearchOption{client.WithPhrase(), client.WithMatchMode(client.MatchAny)}},
-		{"phrase with fuzzy", []client.SearchOption{client.WithPhrase(), client.WithFuzziness(1)}},
-		{"fuzziness outside range", []client.SearchOption{client.WithFuzziness(3)}},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := client.ValidateSearchOptions(tc.opts...); !errors.Is(err, client.ErrInvalidArgument) {
-				t.Fatalf("ValidateSearchOptions = %v, want ErrInvalidArgument", err)
-			}
-		})
-	}
-}
-
-func TestActionableSearchError(t *testing.T) {
-	positions := actionableSearchError(errors.Join(client.ErrFailedPrecondition, client.ErrSearchPositionsDisabled))
-	for _, want := range []string{"LANTERN_SEARCH_POSITIONS=true", "omit --phrase"} {
-		if !strings.Contains(positions.Error(), want) {
-			t.Errorf("positions error %q does not contain %q", positions, want)
-		}
-	}
-	disabled := actionableSearchError(errors.Join(client.ErrFailedPrecondition, client.ErrSearchDisabled))
-	if !strings.Contains(disabled.Error(), "LANTERN_SEARCH_ENABLED=true") {
-		t.Errorf("disabled error is not actionable: %q", disabled)
-	}
-	incomplete := actionableSearchError(errors.Join(client.ErrFailedPrecondition, client.ErrSearchIndexIncomplete))
-	if !strings.Contains(incomplete.Error(), "bounded rebuild") {
-		t.Errorf("incomplete error is not actionable: %q", incomplete)
-	}
-}
-
-// TestSearchCommandRegistered guards that search is a top-level command with the
-// full option flag set (#892).
+// TestSearchCommandRegistered guards that search is a top-level command with
+// the full structured output/cursor option set.
 func TestSearchCommandRegistered(t *testing.T) {
 	var found bool
-	for _, c := range rootCmd.Commands() {
-		if c.Name() != "search" {
+	for _, command := range rootCmd.Commands() {
+		if command.Name() != "search" {
 			continue
 		}
 		found = true
-		for _, name := range []string{"mode", "phrase", "fuzziness", "prefix-terms", "min-should", "limit", "prefix", "cursor", "all", "projection"} {
-			if c.Flags().Lookup(name) == nil {
+		for _, name := range []string{"mode", "phrase", "fuzziness", "prefix-terms", "min-should", "limit", "prefix", "cursor", "all", "projection", "format"} {
+			if command.Flags().Lookup(name) == nil {
 				t.Errorf("search command missing --%s flag", name)
 			}
 		}

--- a/cli/parser/grammar_fixture_test.go
+++ b/cli/parser/grammar_fixture_test.go
@@ -78,7 +78,7 @@ func TestSharedGrammarFixture_Invalid(t *testing.T) {
 	}
 }
 
-func TestSharedGrammarFixture_FamilyNormalizedAST(t *testing.T) {
+func TestSharedGrammarFixture_NormalizedAST(t *testing.T) {
 	fx := loadFixture(t)
 	for _, tc := range fx.Valid {
 		s, err := parser.NewSource(tc.Input)
@@ -89,7 +89,7 @@ func TestSharedGrammarFixture_FamilyNormalizedAST(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Verb(%q): %v", tc.Input, err)
 		}
-		if verb != "bfs" && verb != "pagerank" && verb != "community" && verb != "help" {
+		if verb != "bfs" && verb != "pagerank" && verb != "community" && verb != "search" && verb != "help" {
 			continue
 		}
 		t.Run(tc.Input, func(t *testing.T) {
@@ -144,6 +144,17 @@ func normalizedFamilyAST(input string) (map[string]any, error) {
 			"family": "bfs", "seed": p.Seed, "step": p.Step, "fan_out": p.FanOut,
 			"reduction": p.Reduction, "objective": p.Objective, "weighting": p.Weighting, "prefix": p.Prefix,
 		}, nil
+	case "search":
+		p, err := parser.SearchParam(s)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{
+			"query": p.Query, "limit": p.Limit, "prefix": p.Prefix, "mode": p.Mode,
+			"min_should": p.MinShould, "phrase": p.Phrase, "fuzziness": p.Fuzziness,
+			"prefix_terms": p.PrefixTerms, "cursor": p.Cursor, "all": p.All,
+			"projection": p.Projection, "format": p.Format,
+		}, nil
 	case "pagerank":
 		p, err := parser.PagerankParam(s)
 		if err != nil {
@@ -165,6 +176,6 @@ func normalizedFamilyAST(input string) (map[string]any, error) {
 			"reduction": p.Reduction, "objective": p.Objective, "weighting": p.Weighting, "prefix": p.Prefix,
 		}, nil
 	default:
-		return nil, fmt.Errorf("%q is not a family verb", verb)
+		return nil, fmt.Errorf("%q has no normalized fixture AST", verb)
 	}
 }

--- a/cli/parser/help.go
+++ b/cli/parser/help.go
@@ -63,6 +63,7 @@ const HelpText = `Lantern CLI grammar:
   count  vertices <prefix: string>
   delete-prefix vertices <prefix: string> [limit=<int>] [confirm=yes|dry_run=true]
   keys   <prefix: string> [<limit: int>]
+  search <query: string> [limit=<uint32>] [prefix=<string>] [mode=server|any|all|min-should] [min_should=<uint32>] [phrase=<bool>] [fuzziness=0|1|2] [prefix_terms=<bool>] [cursor=<base64url>] [all=<bool>] [projection=key-score|full-vertex] [format=json|ndjson|tsv]
   bfs        <seed: string> [step: int] [fan_out: int]
              [reduction={none|mst|spt}]  default=none
              [objective={min|max}]       default=max

--- a/cli/parser/model.go
+++ b/cli/parser/model.go
@@ -152,6 +152,33 @@ type Keys struct {
 	Limit  int
 }
 
+// Search backs the shared content-search grammar used by the Go REPL,
+// verb-first Cobra command, and Admin /cli (#1068):
+//
+//	search <query> [limit=<uint32>] [prefix=<string>] [mode=server|any|all|min-should]
+//	       [min_should=<uint32>] [phrase=<bool>] [fuzziness=0|1|2]
+//	       [prefix_terms=<bool>] [cursor=<base64url>] [all=<bool>]
+//	       [projection=key-score|full-vertex] [format=json|ndjson|tsv]
+//
+// Cursor remains opaque at the grammar boundary and is decoded only by the
+// service that builds SDK options. Format is empty when omitted so the output
+// layer can resolve the contextual default (json for one page, ndjson for
+// all=true) without losing whether the operator selected a format explicitly.
+type Search struct {
+	Query       string
+	Limit       uint32
+	Prefix      string
+	Mode        string
+	MinShould   uint32
+	Phrase      bool
+	Fuzziness   uint32
+	PrefixTerms bool
+	Cursor      string
+	All         bool
+	Projection  string
+	Format      string
+}
+
 // CountVertices backs `count vertices <prefix>` — the prefix-cardinality
 // verb migrated from the former `vertex count` subcommand.
 type CountVertices struct {

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -20,6 +20,7 @@ var (
 		"count",
 		"delete-prefix",
 		"keys",
+		"search",
 		"bfs",
 		"pagerank",
 		"community",
@@ -808,6 +809,97 @@ func contains(set []string, v string) bool {
 		}
 	}
 	return false
+}
+
+// SearchParam parses the shared search grammar. The query is the sole
+// positional operand (quote it when it contains whitespace); every remaining
+// token is a key=value option so the grammar stays lossless across shells,
+// the raw REPL tokenizer, and the TypeScript port used by Admin /cli.
+func SearchParam(s *Source) (*Search, error) {
+	m := &Search{Mode: "server", Projection: "key-score"}
+	var err error
+	if m.Query, err = String(s); err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{})
+	for s.HasNext() {
+		tok, err := String(s)
+		if err != nil {
+			return nil, err
+		}
+		key, value, ok := splitKeyValue(tok)
+		if !ok || key == "" {
+			return nil, fmt.Errorf("search: unexpected token %q (options use key=value)", tok)
+		}
+		key = strings.ToLower(key)
+		if _, duplicate := seen[key]; duplicate {
+			return nil, fmt.Errorf("search: duplicate option %q", key)
+		}
+		seen[key] = struct{}{}
+		switch key {
+		case "limit":
+			m.Limit, err = familyUint32(value)
+			if err != nil {
+				return nil, fmt.Errorf("search: limit=%s (want a uint32)", value)
+			}
+		case "prefix":
+			m.Prefix = value
+		case "mode":
+			m.Mode = strings.ToLower(value)
+			if !contains([]string{"server", "any", "all", "min-should"}, m.Mode) {
+				return nil, fmt.Errorf("search: mode=%s (want server|any|all|min-should)", value)
+			}
+		case "min_should":
+			m.MinShould, err = familyUint32(value)
+			if err != nil {
+				return nil, fmt.Errorf("search: min_should=%s (want a uint32)", value)
+			}
+		case "phrase":
+			m.Phrase, err = strconv.ParseBool(value)
+			if err != nil {
+				return nil, fmt.Errorf("search: phrase=%s (want bool)", value)
+			}
+		case "fuzziness":
+			m.Fuzziness, err = familyUint32(value)
+			if err != nil || m.Fuzziness > 2 {
+				return nil, fmt.Errorf("search: fuzziness=%s (want 0|1|2)", value)
+			}
+		case "prefix_terms":
+			m.PrefixTerms, err = strconv.ParseBool(value)
+			if err != nil {
+				return nil, fmt.Errorf("search: prefix_terms=%s (want bool)", value)
+			}
+		case "cursor":
+			m.Cursor = value
+		case "all":
+			m.All, err = strconv.ParseBool(value)
+			if err != nil {
+				return nil, fmt.Errorf("search: all=%s (want bool)", value)
+			}
+		case "projection":
+			m.Projection = strings.ToLower(value)
+			if !contains([]string{"key-score", "full-vertex"}, m.Projection) {
+				return nil, fmt.Errorf("search: projection=%s (want key-score|full-vertex)", value)
+			}
+		case "format":
+			m.Format = strings.ToLower(value)
+			if !contains([]string{"json", "ndjson", "tsv"}, m.Format) {
+				return nil, fmt.Errorf("search: format=%s (want json|ndjson|tsv)", value)
+			}
+		default:
+			return nil, fmt.Errorf("search: unknown option %q", key)
+		}
+	}
+	if m.MinShould != 0 && m.Mode != "min-should" {
+		return nil, errors.New("search: min_should requires mode=min-should")
+	}
+	if m.Phrase && (m.Mode != "server" || m.MinShould != 0 || m.Fuzziness != 0 || m.PrefixTerms) {
+		return nil, errors.New("search: phrase cannot combine with mode, min_should, fuzziness, or prefix_terms")
+	}
+	if m.All && m.Format == "json" {
+		return nil, errors.New("search: all=true requires format=ndjson or format=tsv")
+	}
+	return m, nil
 }
 
 // ScanVerticesParam parses `scan vertices <prefix> [limit]`. The objective

--- a/cli/parser/validate.go
+++ b/cli/parser/validate.go
@@ -14,7 +14,7 @@ func Validate(input string) error {
 	}
 	v, err := Verb(s)
 	if err != nil {
-		return errors.New("usage: { get | put | delete | add | scan | count | delete-prefix | keys | bfs | pagerank | community | help | exit } ... ")
+		return errors.New("usage: { get | put | delete | add | scan | count | delete-prefix | keys | search | bfs | pagerank | community | help | exit } ... ")
 	}
 
 	switch v {
@@ -133,6 +133,10 @@ func Validate(input string) error {
 		if _, err := KeysParam(s); err != nil {
 			return errors.New("usage: keys <prefix: string> [<limit: int>]")
 		}
+	case "search":
+		if _, err := SearchParam(s); err != nil {
+			return fmt.Errorf("usage: search <query: string> [limit=<uint32>] [prefix=<string>] [mode=server|any|all|min-should] [min_should=<uint32>] [phrase=<bool>] [fuzziness=0|1|2] [prefix_terms=<bool>] [cursor=<base64url>] [all=<bool>] [projection=key-score|full-vertex] [format=json|ndjson|tsv]: %w", err)
+		}
 	case "bfs":
 		if _, err := BfsParam(s); err != nil {
 			return errors.New("usage: bfs <seed: string> [step: int] [fan_out: int] [reduction=none|mst|spt] [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>]")
@@ -154,7 +158,7 @@ func Validate(input string) error {
 	case "exit":
 
 	default:
-		return errors.New("usage: { get | put | delete | add | scan | count | delete-prefix | keys | bfs | pagerank | community | help | exit } ... ")
+		return errors.New("usage: { get | put | delete | add | scan | count | delete-prefix | keys | search | bfs | pagerank | community | help | exit } ... ")
 	}
 	return nil
 }

--- a/cli/service/cli_service.go
+++ b/cli/service/cli_service.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/anaregdesign/lantern/cli/parser"
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+// CLIService owns the shared REPL/one-shot dispatcher and its output sink.
+// Feature-specific execution stays in coherent siblings such as search.go.
+type CLIService struct {
+	client *client.Lantern
+	out    io.Writer
+}
+
+// Option configures CLIService without splitting the REPL and one-shot
+// execution paths. WithOutput is primarily used by Cobra and tests; the REPL
+// keeps stdout as its default.
+type Option func(*CLIService)
+
+func WithOutput(w io.Writer) Option {
+	return func(service *CLIService) {
+		if w != nil {
+			service.out = w
+		}
+	}
+}
+
+func NewCLIService(client *client.Lantern, opts ...Option) *CLIService {
+	service := &CLIService{
+		client: client,
+		out:    os.Stdout,
+	}
+	for _, apply := range opts {
+		apply(service)
+	}
+	return service
+}
+
+func (c *CLIService) Run(ctx context.Context, str string) error {
+	s, err := parser.NewSource(str)
+	if err != nil {
+		fmt.Printf("Error: %s\n", err)
+		return ErrInvalidVerb
+	}
+	return c.runSource(ctx, s)
+}
+
+// RunArgs dispatches an already-split token stream (verb + arguments)
+// through the same grammar the REPL parses from a raw line. The one-shot
+// verb-first CLI commands (`lantern-cli get vertex <key>`, …) call this with
+// cobra's argv so the one-liner surface and the REPL share exactly one
+// grammar and one dispatcher (#672).
+func (c *CLIService) RunArgs(ctx context.Context, args []string) error {
+	return c.runSource(ctx, parser.NewSourceFromTokens(args))
+}

--- a/cli/service/search.go
+++ b/cli/service/search.go
@@ -1,0 +1,311 @@
+package service
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/anaregdesign/lantern/cli/parser"
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+type searchClient interface {
+	SearchVerticesPage(context.Context, string, ...client.SearchOption) (client.SearchPage, error)
+}
+
+type searchHitOutput struct {
+	Key              string          `json:"key"`
+	Score            float64         `json:"score"`
+	Vertex           json.RawMessage `json:"vertex,omitempty"`
+	ProjectionStatus string          `json:"projection_status"`
+}
+
+type searchPageOutput struct {
+	Hits                []searchHitOutput `json:"hits"`
+	NextCursor          string            `json:"next_cursor"`
+	EffectiveLimit      uint32            `json:"effective_limit"`
+	Truncated           bool              `json:"truncated"`
+	ContinuationLimited bool              `json:"continuation_limited"`
+}
+
+// RunSearch is the one request/output implementation shared by the raw REPL
+// grammar and the top-level Cobra search command. JSON is a single bounded
+// page document; all=true resolves to NDJSON unless the caller explicitly
+// selected TSV, so exhaustive output is streamed rather than accumulated.
+func (c *CLIService) RunSearch(ctx context.Context, command parser.Search) error {
+	if c == nil || c.client == nil {
+		return fmt.Errorf("%w: client is nil", ErrSearch)
+	}
+	return runSearch(ctx, c.client, command, c.out)
+}
+
+func runSearch(ctx context.Context, searcher searchClient, command parser.Search, out io.Writer) error {
+	opts, format, err := searchOptions(command)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrSearch, err)
+	}
+	if out == nil {
+		return fmt.Errorf("%w: output is nil", ErrSearch)
+	}
+
+	if !command.All {
+		page, err := searcher.SearchVerticesPage(ctx, command.Query, opts...)
+		if err != nil {
+			return actionableSearchError(err)
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return writeSearchPage(out, page, format)
+	}
+
+	return streamSearchPages(ctx, searcher, command.Query, opts, format, out)
+}
+
+func searchOptions(command parser.Search) ([]client.SearchOption, string, error) {
+	mode := strings.ToLower(strings.TrimSpace(command.Mode))
+	if mode == "" {
+		mode = "server"
+	}
+	projection := strings.ToLower(strings.TrimSpace(command.Projection))
+	if projection == "" {
+		projection = "key-score"
+	}
+	format := strings.ToLower(strings.TrimSpace(command.Format))
+	if format == "" {
+		if command.All {
+			format = "ndjson"
+		} else {
+			format = "json"
+		}
+	}
+	if format != "json" && format != "ndjson" && format != "tsv" {
+		return nil, "", fmt.Errorf("unknown search format %q (want json|ndjson|tsv)", command.Format)
+	}
+	if command.All && format == "json" {
+		return nil, "", errors.New("all=true requires format=ndjson or format=tsv")
+	}
+
+	var cursor []byte
+	var err error
+	if command.Cursor != "" {
+		cursor, err = base64.RawURLEncoding.DecodeString(command.Cursor)
+		if err != nil {
+			return nil, "", fmt.Errorf("cursor must be URL-safe base64 without padding: %w", err)
+		}
+	}
+
+	var projectionValue client.SearchProjection
+	switch projection {
+	case "key-score":
+		projectionValue = client.SearchProjectionKeyScore
+	case "full-vertex":
+		projectionValue = client.SearchProjectionFullVertex
+	default:
+		return nil, "", fmt.Errorf("unknown search projection %q (want key-score|full-vertex)", command.Projection)
+	}
+
+	opts := []client.SearchOption{
+		client.WithSearchLimit(command.Limit),
+		client.WithSearchPrefix(command.Prefix),
+		client.WithSearchProjection(projectionValue),
+		client.WithSearchCursor(cursor),
+	}
+	switch mode {
+	case "server":
+	case "any":
+		opts = append(opts, client.WithMatchMode(client.MatchAny))
+	case "all":
+		opts = append(opts, client.WithMatchMode(client.MatchAll))
+	case "min-should":
+		opts = append(opts, client.WithMatchMode(client.MatchMinShould))
+	default:
+		return nil, "", fmt.Errorf("unknown search mode %q (want server|any|all|min-should)", command.Mode)
+	}
+	if command.MinShould != 0 {
+		opts = append(opts, client.WithMinShouldMatch(command.MinShould))
+	}
+	if command.Fuzziness != 0 {
+		opts = append(opts, client.WithFuzziness(command.Fuzziness))
+	}
+	if command.PrefixTerms {
+		opts = append(opts, client.WithPrefixTerms())
+	}
+	if command.Phrase {
+		opts = append(opts, client.WithPhrase())
+	}
+	if err := client.ValidateSearchOptions(opts...); err != nil {
+		return nil, "", err
+	}
+	return opts, format, nil
+}
+
+func streamSearchPages(ctx context.Context, searcher searchClient, query string, opts []client.SearchOption, format string, out io.Writer) error {
+	var tsv *csv.Writer
+	if format == "tsv" {
+		tsv = csv.NewWriter(out)
+		tsv.Comma = '\t'
+	}
+	cursor := []byte(nil)
+	for {
+		pageOpts := append([]client.SearchOption(nil), opts...)
+		if cursor != nil {
+			pageOpts = append(pageOpts, client.WithSearchCursor(cursor))
+		}
+		page, err := searcher.SearchVerticesPage(ctx, query, pageOpts...)
+		if err != nil {
+			return actionableSearchError(err)
+		}
+		for _, hit := range page.Hits {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			encoded, err := searchHitForOutput(hit)
+			if err != nil {
+				return err
+			}
+			if err := writeSearchHit(out, tsv, encoded, format); err != nil {
+				return err
+			}
+		}
+		if len(page.NextCursor) == 0 {
+			if tsv != nil {
+				tsv.Flush()
+				if err := tsv.Error(); err != nil {
+					return fmt.Errorf("write search TSV: %w", err)
+				}
+			}
+			if page.ContinuationLimited {
+				return actionableSearchError(client.ErrSearchContinuationLimited)
+			}
+			return nil
+		}
+		cursor = append(cursor[:0], page.NextCursor...)
+	}
+}
+
+func writeSearchPage(out io.Writer, page client.SearchPage, format string) error {
+	hits := make([]searchHitOutput, 0, len(page.Hits))
+	for _, hit := range page.Hits {
+		encoded, err := searchHitForOutput(hit)
+		if err != nil {
+			return err
+		}
+		hits = append(hits, encoded)
+	}
+	if format == "json" {
+		encoder := json.NewEncoder(out)
+		encoder.SetEscapeHTML(false)
+		if err := encoder.Encode(searchPageOutput{
+			Hits:                hits,
+			NextCursor:          base64.RawURLEncoding.EncodeToString(page.NextCursor),
+			EffectiveLimit:      page.EffectiveLimit,
+			Truncated:           page.Truncated,
+			ContinuationLimited: page.ContinuationLimited,
+		}); err != nil {
+			return fmt.Errorf("write search page: %w", err)
+		}
+		return nil
+	}
+	var tsv *csv.Writer
+	if format == "tsv" {
+		tsv = csv.NewWriter(out)
+		tsv.Comma = '\t'
+	}
+	for _, hit := range hits {
+		if err := writeSearchHit(out, tsv, hit, format); err != nil {
+			return err
+		}
+	}
+	if tsv != nil {
+		tsv.Flush()
+		if err := tsv.Error(); err != nil {
+			return fmt.Errorf("write search TSV: %w", err)
+		}
+	}
+	return nil
+}
+
+func writeSearchHit(out io.Writer, tsv *csv.Writer, hit searchHitOutput, format string) error {
+	switch format {
+	case "ndjson":
+		encoder := json.NewEncoder(out)
+		encoder.SetEscapeHTML(false)
+		if err := encoder.Encode(hit); err != nil {
+			return fmt.Errorf("write search NDJSON: %w", err)
+		}
+	case "tsv":
+		if tsv == nil {
+			return errors.New("search TSV encoder is nil")
+		}
+		if err := tsv.Write([]string{hit.Key, strconv.FormatFloat(hit.Score, 'g', -1, 64), hit.ProjectionStatus, string(hit.Vertex)}); err != nil {
+			return fmt.Errorf("write search TSV: %w", err)
+		}
+		// csv.Writer owns an internal buffer. Flush each complete record so
+		// all=true remains genuinely streaming; RFC-style quoting still keeps
+		// embedded tabs/newlines lossless for a real TSV reader.
+		tsv.Flush()
+		if err := tsv.Error(); err != nil {
+			return fmt.Errorf("write search TSV: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported streaming search format %q", format)
+	}
+	return nil
+}
+
+func searchProjectionStatusString(status client.SearchHitProjectionStatus) string {
+	switch status {
+	case client.SearchHitProjectionKeyScore:
+		return "key-score"
+	case client.SearchHitProjectionSnapshot:
+		return "snapshot"
+	case client.SearchHitProjectionMissing:
+		return "missing"
+	case client.SearchHitProjectionReplaced:
+		return "replaced"
+	default:
+		return "unspecified"
+	}
+}
+
+func searchHitForOutput(hit client.SearchHit) (searchHitOutput, error) {
+	out := searchHitOutput{
+		Key:              hit.Key,
+		Score:            hit.Score,
+		ProjectionStatus: searchProjectionStatusString(hit.ProjectionStatus),
+	}
+	if hit.Vertex != nil {
+		vertex, err := client.MarshalVertexJSON(hit.Vertex)
+		if err != nil {
+			return searchHitOutput{}, fmt.Errorf("marshal projected vertex %q: %w", hit.Key, err)
+		}
+		out.Vertex = vertex
+	}
+	return out, nil
+}
+
+func actionableSearchError(err error) error {
+	switch {
+	case errors.Is(err, client.ErrSearchPositionsDisabled):
+		return fmt.Errorf("phrase search is unavailable: restart the server with LANTERN_SEARCH_POSITIONS=true or omit phrase: %w", err)
+	case errors.Is(err, client.ErrSearchDisabled):
+		return fmt.Errorf("content search is unavailable: restart the server with LANTERN_SEARCH_ENABLED=true: %w", err)
+	case errors.Is(err, client.ErrSearchIndexIncomplete):
+		return fmt.Errorf("content search is unavailable: the local index is incomplete and requires a bounded rebuild: %w", err)
+	case errors.Is(err, client.ErrSearchCursorStale):
+		return fmt.Errorf("search cursor is stale: restart explicitly from page 1 on the same endpoint: %w", err)
+	case errors.Is(err, client.ErrSearchCursorInvalid):
+		return fmt.Errorf("search cursor is invalid for this query, option set, projection, config, or endpoint: %w", err)
+	case errors.Is(err, client.ErrSearchContinuationLimited):
+		return fmt.Errorf("search continuation reached the server's bounded session cap; narrow the query or raise the server session limits: %w", err)
+	default:
+		return err
+	}
+}

--- a/cli/service/search_test.go
+++ b/cli/service/search_test.go
@@ -1,0 +1,166 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/anaregdesign/lantern/cli/parser"
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+type fakeSearchClient struct {
+	pages []client.SearchPage
+	err   error
+	calls int
+	after func()
+}
+
+func (fake *fakeSearchClient) SearchVerticesPage(context.Context, string, ...client.SearchOption) (client.SearchPage, error) {
+	fake.calls++
+	if fake.after != nil {
+		fake.after()
+	}
+	if fake.err != nil {
+		return client.SearchPage{}, fake.err
+	}
+	if len(fake.pages) == 0 {
+		return client.SearchPage{}, errors.New("unexpected SearchVerticesPage call")
+	}
+	page := fake.pages[0]
+	fake.pages = fake.pages[1:]
+	return page, nil
+}
+
+func TestRunSearchJSONIsLosslessAndBounded(t *testing.T) {
+	projected, err := client.UnmarshalVertexJSON([]byte(`{"key":"doc/1","type":"string","value":"alpha"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := "tab\tnewline\nquote\"slash\\"
+	fake := &fakeSearchClient{pages: []client.SearchPage{{
+		Hits: []client.SearchHit{{
+			Key: key, Score: 3.5, Vertex: projected,
+			ProjectionStatus: client.SearchHitProjectionSnapshot,
+		}},
+		NextCursor: []byte{1, 2, 3}, EffectiveLimit: 25, Truncated: true,
+	}}}
+	var out bytes.Buffer
+	if err := runSearch(context.Background(), fake, parser.Search{Query: "alpha", Mode: "server", Projection: "full-vertex"}, &out); err != nil {
+		t.Fatal(err)
+	}
+	var page searchPageOutput
+	if err := json.Unmarshal(out.Bytes(), &page); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	if len(page.Hits) != 1 || page.Hits[0].Key != key || page.NextCursor != "AQID" || !page.Truncated {
+		t.Fatalf("page = %#v", page)
+	}
+	var vertex map[string]any
+	if err := json.Unmarshal(page.Hits[0].Vertex, &vertex); err != nil {
+		t.Fatal(err)
+	}
+	if vertex["value"] != "alpha" {
+		t.Fatalf("vertex = %#v", vertex)
+	}
+}
+
+func TestRunSearchNDJSONStreamsEveryPage(t *testing.T) {
+	fake := &fakeSearchClient{pages: []client.SearchPage{
+		{Hits: []client.SearchHit{{Key: "a", Score: 2, ProjectionStatus: client.SearchHitProjectionKeyScore}}, NextCursor: []byte{1}},
+		{Hits: []client.SearchHit{{Key: "b", Score: 1, ProjectionStatus: client.SearchHitProjectionKeyScore}}},
+	}}
+	var out bytes.Buffer
+	if err := runSearch(context.Background(), fake, parser.Search{Query: "x", All: true}, &out); err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(&out)
+	var keys []string
+	for {
+		var hit searchHitOutput
+		if err := decoder.Decode(&hit); errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		keys = append(keys, hit.Key)
+	}
+	if strings.Join(keys, ",") != "a,b" || fake.calls != 2 {
+		t.Fatalf("keys=%v calls=%d", keys, fake.calls)
+	}
+}
+
+func TestRunSearchTSVUsesRealEscaping(t *testing.T) {
+	key := "tab\tnewline\nquote\"slash\\"
+	fake := &fakeSearchClient{pages: []client.SearchPage{{Hits: []client.SearchHit{{
+		Key: key, Score: 1.25, ProjectionStatus: client.SearchHitProjectionKeyScore,
+	}}}}}
+	var out bytes.Buffer
+	if err := runSearch(context.Background(), fake, parser.Search{Query: "x", Format: "tsv"}, &out); err != nil {
+		t.Fatal(err)
+	}
+	reader := csv.NewReader(&out)
+	reader.Comma = '\t'
+	record, err := reader.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(record) != 4 || record[0] != key || record[1] != "1.25" || record[2] != "key-score" {
+		t.Fatalf("record = %#v", record)
+	}
+}
+
+func TestRunSearchCancellationDoesNotWritePartialJSON(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	fake := &fakeSearchClient{
+		pages: []client.SearchPage{{Hits: []client.SearchHit{{Key: "too-late"}}}},
+		after: cancel,
+	}
+	var out bytes.Buffer
+	err := runSearch(ctx, fake, parser.Search{Query: "x"}, &out)
+	if !errors.Is(err, context.Canceled) || out.Len() != 0 {
+		t.Fatalf("err=%v output=%q", err, out.String())
+	}
+}
+
+func TestSearchOptionsValidateBeforeRPC(t *testing.T) {
+	fake := &fakeSearchClient{}
+	for _, command := range []parser.Search{
+		{Query: "x", Mode: "any", MinShould: 1},
+		{Query: "x", Phrase: true, Fuzziness: 1},
+		{Query: "x", Fuzziness: 3},
+		{Query: "x", All: true, Format: "json"},
+		{Query: "x", Cursor: "not+base64"},
+	} {
+		var out bytes.Buffer
+		if err := runSearch(context.Background(), fake, command, &out); err == nil {
+			t.Fatalf("runSearch(%#v) accepted invalid command", command)
+		}
+	}
+	if fake.calls != 0 {
+		t.Fatalf("invalid commands made %d RPCs", fake.calls)
+	}
+}
+
+func TestActionableSearchError(t *testing.T) {
+	for _, tc := range []struct {
+		err  error
+		want string
+	}{
+		{errors.Join(client.ErrFailedPrecondition, client.ErrSearchPositionsDisabled), "LANTERN_SEARCH_POSITIONS=true"},
+		{errors.Join(client.ErrFailedPrecondition, client.ErrSearchDisabled), "LANTERN_SEARCH_ENABLED=true"},
+		{client.ErrSearchIndexIncomplete, "bounded rebuild"},
+		{client.ErrSearchCursorStale, "restart explicitly"},
+		{client.ErrSearchCursorInvalid, "option set"},
+		{client.ErrSearchContinuationLimited, "bounded session cap"},
+	} {
+		if got := actionableSearchError(tc.err); !strings.Contains(got.Error(), tc.want) || !errors.Is(got, tc.err) {
+			t.Errorf("actionableSearchError(%v) = %v, want %q and wrapped sentinel", tc.err, got, tc.want)
+		}
+	}
+}

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -29,40 +29,13 @@ var (
 	ErrCount            = errors.New("count error")
 	ErrDeletePrefix     = errors.New("delete-prefix error")
 	ErrKeys             = errors.New("keys error")
+	ErrSearch           = errors.New("search error")
 	ErrBFS              = errors.New("bfs error")
 	ErrPagerank         = errors.New("pagerank error")
 	ErrCommunity        = errors.New("community error")
 	ErrHelp             = errors.New("help error")
 	ErrConnection       = errors.New("connection error")
 )
-
-type CLIService struct {
-	client *client.Lantern
-}
-
-func NewCLIService(client *client.Lantern) *CLIService {
-	return &CLIService{
-		client: client,
-	}
-}
-
-func (c *CLIService) Run(ctx context.Context, str string) error {
-	s, err := parser.NewSource(str)
-	if err != nil {
-		fmt.Printf("Error: %s\n", err)
-		return ErrInvalidVerb
-	}
-	return c.runSource(ctx, s)
-}
-
-// RunArgs dispatches an already-split token stream (verb + arguments)
-// through the same grammar the REPL parses from a raw line. The one-shot
-// verb-first CLI commands (`lantern-cli get vertex <key>`, …) call this with
-// cobra's argv so the one-liner surface and the REPL share exactly one
-// grammar and one dispatcher (#672).
-func (c *CLIService) RunArgs(ctx context.Context, args []string) error {
-	return c.runSource(ctx, parser.NewSourceFromTokens(args))
-}
 
 // runSource is the shared verb dispatcher behind both Run (a raw line from
 // the REPL) and RunArgs (pre-split argv from the one-shot verbs).
@@ -428,6 +401,13 @@ func (c *CLIService) runSource(ctx context.Context, s *parser.Source) error {
 			fmt.Println(k)
 		}
 		return nil
+
+	case "search":
+		p, err := parser.SearchParam(s)
+		if err != nil {
+			return fmt.Errorf("%w: %w", ErrSearch, err)
+		}
+		return c.RunSearch(ctx, *p)
 
 	case "bfs":
 		p, err := parser.BfsParam(s)

--- a/tests/integration/search_vertices_test.go
+++ b/tests/integration/search_vertices_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"math/rand"
 	"net/http/httptest"
@@ -24,6 +25,8 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/anaregdesign/lantern/cli/parser"
+	cliservice "github.com/anaregdesign/lantern/cli/service"
 	"github.com/anaregdesign/lantern/core/graphcache"
 	"github.com/anaregdesign/lantern/core/search"
 	"github.com/anaregdesign/lantern/core/search/relevance"
@@ -1132,6 +1135,145 @@ func TestSearchVertices_EndToEnd(t *testing.T) {
 	if got := empty.Msg.GetHits(); len(got) != 0 {
 		t.Fatalf("empty-query hits = %d, want 0", len(got))
 	}
+}
+
+func TestSearchCLISharedGrammarOverRealH2C(t *testing.T) {
+	type pageOutput struct {
+		Hits []struct {
+			Key string `json:"key"`
+		} `json:"hits"`
+		NextCursor string `json:"next_cursor"`
+	}
+	decodePage := func(t *testing.T, output []byte) pageOutput {
+		t.Helper()
+		var page pageOutput
+		if err := json.Unmarshal(output, &page); err != nil {
+			t.Fatalf("decode CLI page %q: %v", output, err)
+		}
+		return page
+	}
+	newCLI := func(t *testing.T, limits service.SearchLimits) (graphv1connect.LanternServiceClient, *client.Lantern) {
+		t.Helper()
+		cache := newProductionSearchCache(time.Minute, limits.Enabled, limits.PositionsEnabled, search.SearchAnalysisLimits{})
+		svc := service.NewLanternService(cache).WithSearchLimits(limits)
+		srv := newConnectTestServer(t, svc, nil)
+		return graphv1connect.NewLanternServiceClient(h2cClient(), srv.url), newConnectClientFor(t, srv.url)
+	}
+
+	t.Run("Cobra model and raw REPL grammar return the same request result", func(t *testing.T) {
+		raw, sdk := newCLI(t, service.SearchLimits{
+			Enabled: true, PositionsEnabled: true, DefaultLimit: 1, MaxLimit: 1,
+			CursorTTL: time.Minute, MaxSessions: 8, MaxSessionHits: 16, MaxSessionBytes: 1 << 20,
+		})
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		expiration := timestamppb.New(time.Now().Add(time.Hour))
+		losslessKey := "eq/tab\tnewline\nquote\"slash\\"
+		vertices := []*pb.Vertex{
+			{Key: losslessKey, Value: &pb.Vertex_String_{String_: "cliequalitytoken"}, Expiration: expiration},
+			{Key: "stream/01", Value: &pb.Vertex_String_{String_: "clistreamtoken"}, Expiration: expiration},
+			{Key: "stream/02", Value: &pb.Vertex_String_{String_: "clistreamtoken"}, Expiration: expiration},
+			{Key: "stream/03", Value: &pb.Vertex_String_{String_: "clistreamtoken"}, Expiration: expiration},
+		}
+		if _, err := raw.PutVertices(ctx, connect.NewRequest(&pb.PutVerticesRequest{Vertices: vertices})); err != nil {
+			t.Fatal(err)
+		}
+
+		model := parser.Search{Query: "cliequalitytoken", Limit: 1, Prefix: "eq/", Mode: "server", Projection: "full-vertex"}
+		var cobraOut bytes.Buffer
+		if err := cliservice.NewCLIService(sdk, cliservice.WithOutput(&cobraOut)).RunSearch(ctx, model); err != nil {
+			t.Fatal(err)
+		}
+		var replOut bytes.Buffer
+		if err := cliservice.NewCLIService(sdk, cliservice.WithOutput(&replOut)).Run(ctx, "search cliequalitytoken limit=1 prefix=eq/ mode=server projection=full-vertex"); err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(cobraOut.Bytes(), replOut.Bytes()) {
+			t.Fatalf("Cobra-model output = %s\nREPL output = %s", cobraOut.Bytes(), replOut.Bytes())
+		}
+		page := decodePage(t, replOut.Bytes())
+		if len(page.Hits) != 1 || page.Hits[0].Key != losslessKey {
+			t.Fatalf("lossless CLI page = %+v", page)
+		}
+
+		var allOut bytes.Buffer
+		if err := cliservice.NewCLIService(sdk, cliservice.WithOutput(&allOut)).Run(ctx, "search clistreamtoken prefix=stream/ limit=1 all=true"); err != nil {
+			t.Fatal(err)
+		}
+		decoder := json.NewDecoder(&allOut)
+		var got []string
+		for {
+			var hit struct {
+				Key string `json:"key"`
+			}
+			if err := decoder.Decode(&hit); errors.Is(err, io.EOF) {
+				break
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			got = append(got, hit.Key)
+		}
+		if !slices.Equal(got, []string{"stream/01", "stream/02", "stream/03"}) {
+			t.Fatalf("streamed keys = %v", got)
+		}
+
+		var emptyOut bytes.Buffer
+		if err := cliservice.NewCLIService(sdk, cliservice.WithOutput(&emptyOut)).Run(ctx, `search ""`); err != nil {
+			t.Fatal(err)
+		}
+		if hits := decodePage(t, emptyOut.Bytes()).Hits; len(hits) != 0 {
+			t.Fatalf("no-hit output = %+v", hits)
+		}
+
+		var invalidOut bytes.Buffer
+		err := cliservice.NewCLIService(sdk, cliservice.WithOutput(&invalidOut)).Run(ctx, "search alpha phrase=true fuzziness=1")
+		if !errors.Is(err, cliservice.ErrSearch) || invalidOut.Len() != 0 {
+			t.Fatalf("invalid combination err=%v output=%q", err, invalidOut.String())
+		}
+
+		canceled, cancelNow := context.WithCancel(ctx)
+		cancelNow()
+		var canceledOut bytes.Buffer
+		err = cliservice.NewCLIService(sdk, cliservice.WithOutput(&canceledOut)).Run(canceled, "search cliequalitytoken")
+		if !errors.Is(err, context.Canceled) || canceledOut.Len() != 0 {
+			t.Fatalf("canceled JSON err=%v output=%q", err, canceledOut.String())
+		}
+	})
+
+	t.Run("disabled and stale errors stay typed and actionable", func(t *testing.T) {
+		_, disabled := newCLI(t, service.SearchLimits{Enabled: false, DefaultLimit: 1, MaxLimit: 1})
+		var disabledOut bytes.Buffer
+		err := cliservice.NewCLIService(disabled, cliservice.WithOutput(&disabledOut)).Run(context.Background(), "search alpha")
+		if !errors.Is(err, client.ErrSearchDisabled) || !strings.Contains(err.Error(), "LANTERN_SEARCH_ENABLED=true") || disabledOut.Len() != 0 {
+			t.Fatalf("disabled err=%v output=%q", err, disabledOut.String())
+		}
+
+		raw, sdk := newCLI(t, service.SearchLimits{
+			Enabled: true, PositionsEnabled: true, DefaultLimit: 1, MaxLimit: 1,
+			CursorTTL: time.Second, MaxSessions: 4, MaxSessionHits: 8, MaxSessionBytes: 1 << 20,
+		})
+		expiration := timestamppb.New(time.Now().Add(time.Hour))
+		if _, err := raw.PutVertices(context.Background(), connect.NewRequest(&pb.PutVerticesRequest{Vertices: []*pb.Vertex{
+			{Key: "stale/a", Value: &pb.Vertex_String_{String_: "clicursorstaletoken"}, Expiration: expiration},
+			{Key: "stale/b", Value: &pb.Vertex_String_{String_: "clicursorstaletoken"}, Expiration: expiration},
+		}})); err != nil {
+			t.Fatal(err)
+		}
+		var firstOut bytes.Buffer
+		if err := cliservice.NewCLIService(sdk, cliservice.WithOutput(&firstOut)).Run(context.Background(), "search clicursorstaletoken limit=1"); err != nil {
+			t.Fatal(err)
+		}
+		cursor := decodePage(t, firstOut.Bytes()).NextCursor
+		if cursor == "" {
+			t.Fatal("first CLI page did not return a cursor")
+		}
+		time.Sleep(1100 * time.Millisecond)
+		var staleOut bytes.Buffer
+		err = cliservice.NewCLIService(sdk, cliservice.WithOutput(&staleOut)).Run(context.Background(), "search clicursorstaletoken limit=1 cursor="+cursor)
+		if !errors.Is(err, client.ErrSearchCursorStale) || !strings.Contains(err.Error(), "restart explicitly") || staleOut.Len() != 0 {
+			t.Fatalf("stale err=%v output=%q", err, staleOut.String())
+		}
+	})
 }
 
 // TestSearchVertices_PluralWriteVisibilityOverWire pins #1051's batch


### PR DESCRIPTION
Closes #1068

## What changed

- adds a shared `parser.Search` grammar/model for quoted Unicode queries and every maintained SearchVertices option
- routes both the Go REPL and Cobra `search` facade through one `CLIService.RunSearch` request/output implementation
- makes one-page output a lossless JSON envelope carrying the #1065 cursor/truncation metadata, with streaming NDJSON and real escaped TSV plus bounded `all=true` pagination
- adds actionable typed search errors and guarantees cancellation cannot leave a partial JSON document
- ports the same grammar to Admin `/cli`, dispatches through the maintained Node SDK page/iterator APIs, and renders serialisable JSON safely
- removes README/help wording that described search as outside the shared grammar

The issue's original pre-#1065 plan called the default a JSON array. The now-stable cursor contract needs `next_cursor`, `effective_limit`, `truncated`, and `continuation_limited`, so the default is the bounded JSON envelope established by #1065 instead.

## Impact

Operators can now use the same structured SearchVertices semantics from one-shot Cobra, the Go REPL, and Admin `/cli`. Arbitrary legal keys remain lossless, scripts can stream retained pages without collecting them, and local/server capability failures are explicit.

## Validation

- `gofmt -l .`
- `go vet ./...` in all six Go modules
- `go build ./...` in all six Go modules
- `go test ./...` in all six Go modules
- `go test -race -shuffle=on ./cli/... ./tests/integration`
- CI-equivalent generation drift check (`GOWORK=off go generate ./...` plus env docs)
- `bun run format`
- `bun run test` (835 pass)
- `bun run typecheck`
- `bun run lint` (clean except one pre-existing exhaustive-deps warning)
- `bun run build`
- `bun run test:e2e --workers=1` (77 pass)
- `dart analyze`
- `dart test`

Parallel Playwright runs passed the new search test but exposed existing shared-fixture CRUD flakes in two different tests; the complete single-worker suite is green.