### PR TITLE
docs(search): publish canonical search contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,10 @@ vertex key and value fields as the content-addressed counterpart to prefix
 scans. Phrase/proximity never cross key/value or JSON string-leaf boundaries;
 edge-created endpoint vertices are immediately searchable by key. Hits use the
 stable total order `(score DESC, raw key ASC)` and make
-natural seeds for a follow-up `bfs`, `pagerank`, or `community` walk:
+natural seeds for a follow-up `bfs`, `pagerank`, or `community` walk. The
+[canonical SearchVertices contract](docs/search.md) defines projection,
+Unicode analysis, membership, ranking, typed errors, TTL consistency, bounded
+pagination, and HA behavior for every surface.
 
 The production analyzer uses Unicode full case folding and canonical NFC,
 preserves meaningful Thai/Indic/accent marks, and keeps emoji/Unicode symbols
@@ -285,55 +288,16 @@ lantern-cli search espresso --limit 20 --all     # stream retained pages as NDJS
 lantern-cli search espresso --projection full-vertex
 ```
 
-The index is maintained server-side and is on by default
-(`LANTERN_SEARCH_ENABLED`). Phrase search additionally requires positional
-postings (`LANTERN_SEARCH_POSITIONS`, also on by default). A server without
-positions rejects `phrase=true` with the typed reason
-`SEARCH_POSITIONS_DISABLED`; it never silently returns unordered AND matches.
-`GetServerStatus.search` exposes these capabilities, their defaults and limits,
-implementation versions, and a configuration fingerprint.
+The index is maintained server-side. Read `GetServerStatus.search` before
+offering phrase or expansion controls: it reports availability, defaults,
+budgets, implementation versions, index health, and the HA configuration
+fingerprint. `FULL_VERTEX` returns the exact selection-time value/TTL snapshot;
+cursor pages retain that snapshot and must remain on one endpoint.
 
-Search pages are immutable, bounded snapshots in `(score DESC, raw key ASC)`
-order. A one-page response reports `effective_limit`, `truncated`, an opaque
-`next_cursor`, and `continuation_limited`; no approximate count is presented as
-an exact total. Repeat the same query, options, projection, and endpoint with
-the returned cursor. Tampered or mismatched cursors are typed
-`INVALID_ARGUMENT` / `SEARCH_CURSOR_INVALID`; expired or evicted sessions are
-typed `ABORTED` / `SEARCH_CURSOR_STALE` and must restart explicitly from page
-one. Sessions are endpoint-sticky and bounded by the discoverable
-`LANTERN_SEARCH_CURSOR_TTL_SECONDS`, `LANTERN_SEARCH_MAX_SESSIONS`,
-`LANTERN_SEARCH_MAX_SESSION_HITS`, and `LANTERN_SEARCH_MAX_SESSION_BYTES`.
-
-The default `KEY_SCORE` projection remains lightweight. `FULL_VERTEX` carries
-the exact value/TTL snapshot selected under the same barrier as ranking, so a
-caller does not need a racy `GetVertices` hydration pass. Writes, deletes, and
-TTL expiry after page one do not change the retained snapshot. See
-[ADR 0008](docs/decisions/0008-bounded-search-pagination-sessions.md) for the
-churn measurement and session decision.
-
-Every search has a server deadline, bounded query/analyzed-term/dictionary/
-posting/position work, and an in-flight admission slot. Cancellation or a
-deadline returns no partial hits. `SEARCH_WORK_BUDGET_EXHAUSTED` includes a
-stable `work_kind`; `SEARCH_ADMISSION_SATURATED` is distinct so clients can
-apply jittered backoff. Canceled, deadline, and work-budget failures are
-terminal for that attempt—interactive/incremental clients should discard it
-and issue only the newest input, not replay stale queries. A budget failure
-usually calls for a narrower query or fewer expansion options; only admission
-saturation is normally worth retrying unchanged.
-
-Search option interpretation is identical on every surface:
-
-| Request | Membership behavior |
-| --- | --- |
-| options omitted, or `match_mode=UNSPECIFIED` | Always use `LANTERN_SEARCH_DEFAULT_MODE`, even when fuzziness or prefix terms are set |
-| explicit `ANY` / `ALL` / `MIN_SHOULD` | Override the server default |
-| `MIN_SHOULD` with `min_should_match=0` | Use `LANTERN_SEARCH_DEFAULT_MIN_SHOULD` |
-| non-zero `min_should_match` with any other mode | `INVALID_ARGUMENT` |
-| phrase plus an explicit mode, fuzziness, or prefix terms | `INVALID_ARGUMENT` until those compositions are implemented |
-
-Unknown enum values, fuzziness outside `0..2`, and option fields that would be
-ignored are rejected rather than clamped or silently reinterpreted. Go, Node,
-and Dart validate the same combinations locally before issuing an RPC.
+Search is local/eventual under replication. During lag, corpus membership and
+BM25 scores may differ between replicas, and cursor sessions are never
+portable. Serving replicas must have the same `config_fingerprint`; see the
+[HA contract](docs/search.md#replication-failover-and-cursors).
 
 ---
 

--- a/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.tsx
+++ b/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.tsx
@@ -174,6 +174,19 @@ export function BrowseVerticesPage() {
           {searching
             ? "Full-text search over indexed vertex content, ranked by relevance."
             : `Scan vertices by key prefix. Page size is ${DEFAULT_VERTEX_PAGE_SIZE}; expired or expiring rows are highlighted.`}
+          {searching ? (
+            <>
+              {" "}
+              <a
+                href="https://github.com/anaregdesign/lantern/blob/main/docs/search.md"
+                target="_blank"
+                rel="noreferrer"
+                data-testid="search-contract-link"
+              >
+                Search contract
+              </a>
+            </>
+          ) : null}
         </p>
       </header>
 
@@ -261,6 +274,7 @@ export function BrowseVerticesPage() {
               selectedOptions={[matchMode]}
               value={MATCH_MODE_LABELS[matchMode]}
               disabled={phrase}
+              title="Controls query-word membership; Server default defers to this endpoint's advertised configuration."
               onOptionSelect={(_, data) =>
                 setMatchMode((data.optionValue as SearchMatchMode) ?? "server")
               }
@@ -303,6 +317,7 @@ export function BrowseVerticesPage() {
               value={searchPrefix}
               onChange={(_, data) => setSearchPrefix(data.value)}
               placeholder="e.g. user:"
+              title="Restricts membership to vertex keys in this namespace before ranking."
               data-testid="search-prefix"
             />
           </Field>
@@ -311,6 +326,7 @@ export function BrowseVerticesPage() {
               selectedOptions={[String(fuzziness)]}
               value={String(fuzziness)}
               disabled={phrase}
+              title="Also visits dictionary terms within this edit distance; phrase mode does not compose with fuzziness."
               onOptionSelect={(_, data) =>
                 setFuzziness(Number(data.optionValue ?? 0) as SearchFuzziness)
               }
@@ -325,6 +341,7 @@ export function BrowseVerticesPage() {
             label="Prefix terms"
             checked={prefixTerms}
             disabled={phrase}
+            title="Also matches dictionary terms extending a query word; phrase mode does not compose with this expansion."
             onChange={(_, data) => setPrefixTerms(data.checked)}
             data-testid="search-prefix-terms"
           />
@@ -333,6 +350,7 @@ export function BrowseVerticesPage() {
               label="Phrase"
               checked={phrase}
               disabled={positionsEnabled !== true || !phraseCompatible}
+              title="Requires adjacent, ordered words inside one key, value, or JSON string-leaf field."
               onChange={(_, data) => setPhrase(data.checked)}
               data-testid="search-phrase"
             />

--- a/admin/app/components/ops/SearchStatusCard/SearchStatusCard.tsx
+++ b/admin/app/components/ops/SearchStatusCard/SearchStatusCard.tsx
@@ -50,7 +50,15 @@ export function SearchStatusCard({
       </div>
       <p className={styles.lead}>
         Capability, budgets, and current index health from{" "}
-        <code>GetServerStatus</code>.
+        <code>GetServerStatus</code>.{" "}
+        <a
+          href="https://github.com/anaregdesign/lantern/blob/main/docs/search.md"
+          target="_blank"
+          rel="noreferrer"
+          data-testid="ops-search-contract-link"
+        >
+          Search contract
+        </a>
       </p>
       {status === "loading" && <Spinner size="tiny" label="Loading…" />}
       {status === "error" && error && (

--- a/admin/app/lib/cli/verbs.ts
+++ b/admin/app/lib/cli/verbs.ts
@@ -877,6 +877,8 @@ export const HELP_TEXT = [
   "  help [bfs|pagerank|community]",
   "  exit",
   "",
+  "Search contract: https://github.com/anaregdesign/lantern/blob/main/docs/search.md",
+  "",
   'Quoting: "double" with C-style escapes (\\" \\\\ \\n \\r \\t); \'single\' verbatim.',
   "Verb/objective case-insensitive; argument values preserve case.",
 ].join("\n");
@@ -1024,7 +1026,7 @@ export const CLI_COMMAND_REFERENCE: readonly CliCommandDoc[] = [
     signature:
       "search <query> [limit=...] [mode=...] [phrase=...] [all=...] [format=...]",
     summary:
-      "BM25 content search with cursor paging. One page is lossless JSON; all=true follows the bounded search session.",
+      "BM25 content search with cursor paging. One page is lossless JSON; all=true follows the bounded search session. Canonical contract: https://github.com/anaregdesign/lantern/blob/main/docs/search.md",
     example: 'search "rolling update" mode=all limit=20',
   },
   {

--- a/admin/tests/e2e/browse.spec.ts
+++ b/admin/tests/e2e/browse.spec.ts
@@ -166,6 +166,10 @@ test.describe("/vertices — content search (#650)", () => {
 
     await expect(page.getByTestId("search-idle")).toBeVisible();
     await expect(page.getByTestId("search-results-table")).toHaveCount(0);
+    await expect(page.getByTestId("search-contract-link")).toHaveAttribute(
+      "href",
+      "https://github.com/anaregdesign/lantern/blob/main/docs/search.md",
+    );
   });
 
   test("ranks the strongest content matches to the top", async ({ page }) => {

--- a/cli/cmd/search.go
+++ b/cli/cmd/search.go
@@ -73,6 +73,9 @@ hit's exact selection-time value/TTL snapshot. --cursor accepts the unpadded
 URL-safe base64 next_cursor from a previous page; every other option and the
 serving endpoint must remain unchanged.
 
+CANONICAL CONTRACT
+  https://github.com/anaregdesign/lantern/blob/main/docs/search.md
+
 REPL EQUIVALENT
   search "rolling update" mode=all limit=20 format=json
   search espresso limit=20 all=true

--- a/cli/parser/help.go
+++ b/cli/parser/help.go
@@ -87,6 +87,8 @@ const HelpText = `Lantern CLI grammar:
   help [bfs|pagerank|community]
   exit
 
+Search contract: https://github.com/anaregdesign/lantern/blob/main/docs/search.md
+
 Quoting: "double" with C-style escapes (\" \\ \n \r \t); 'single' verbatim.
 Verb/objective case-insensitive; argument values preserve case.`
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -8,6 +8,8 @@ back to its default; an unknown `LANTERN_*` name logs a typo warning; with
 `LANTERN_STRICT_CONFIG=true` either condition fails boot. An explicitly empty
 value is treated as unset for the non-string kinds. The MCP server's
 `LANTERN_MCP_*` namespace belongs to that process and is not listed here.
+Search projection, membership, error, TTL, cursor, and HA semantics are
+canonical in the [SearchVertices contract](search.md).
 
 | Variable | Type | Default | Description |
 |---|---|---|---|

--- a/docs/ha-runbook.md
+++ b/docs/ha-runbook.md
@@ -291,6 +291,14 @@ Search has both a local derived index and a cluster-wide configuration
 contract. Check both before attributing a search incident to ordinary RPC
 latency:
 
+**Do not serve mixed search configuration.** Every search-affecting setting
+must produce the same `GetServerStatus.search.config_fingerprint` on every
+member. A mismatch correctly keeps readiness `NOT_SERVING` while replication
+continues. Search reads remain local/eventual, and BM25 scores are relative to
+the local corpus; do not compare scores across lagging replicas or unrelated
+queries. The [canonical SearchVertices contract](search.md) defines projection,
+typed errors, TTL consistency, cursor affinity, and failover behavior.
+
 | Metric | What it tells you |
 |---|---|
 | `lantern_search_index_state{state}` | One-hot local state. `healthy=1` serves searches; `incomplete=1` rejects them until a bounded rebuild succeeds; `disabled=1` is intentional only when Search is disabled. |
@@ -463,6 +471,10 @@ typed `SEARCH_CURSOR_INVALID` or `SEARCH_CURSOR_STALE` and must restart from
 page one—never resume the cursor on another replica. Tune the session count,
 hit, and aggregate-byte caps together with replica memory, and alert on clients
 that repeatedly restart deep page chains.
+
+One-page failover is also a new local/eventual read, not continuation of the
+lost replica's snapshot. Its membership and numeric scores may legitimately
+differ until graph state and `config_fingerprint` converge.
 
 | Mutation type | Partition-time behaviour | Post-heal |
 |---|---|---|
@@ -714,6 +726,8 @@ A short checklist to walk before opening an incident:
       `LANTERN_SEARCH_POSITIONS=false` rejects `phrase=true` with
       `SEARCH_POSITIONS_DISABLED` while a positions-enabled replica executes
       the phrase query.
+      See the [canonical search HA contract](search.md#replication-failover-and-cursors)
+      before changing routing, cursor affinity, or any search setting.
 
 ---
 

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -104,9 +104,15 @@ or a partition, membership, document frequency, BM25 scores, and top-k order
 may differ across replicas; a client-side failover can therefore return a
 different response. Once replicas have the same live graph and identical
 `search.config_fingerprint`, they return the same ordered hits and score bits.
+BM25 scores are query- and corpus-relative, so clients must not compare their
+numeric values across lagging replicas or unrelated queries. Mixed
+search-affecting configuration is prohibited on serving members: fingerprint
+mismatch keeps readiness `NOT_SERVING` even though replication continues.
 Snapshot bootstrap, anti-entropy snapshot repair, and backup restore mark the
 local search index `INCOMPLETE` before replay and rebuild it from the complete
 live graph before reporting `HEALTHY`. `DISABLED` remains a separate state.
+The canonical projection, error, cursor, and failover rules are in the
+[SearchVertices contract](search.md#replication-failover-and-cursors).
 
 ## 5. Hybrid Logical Clock
 
@@ -541,7 +547,9 @@ Lantern is **AP** in CAP terms. During a partition:
 - `SearchVertices` remains available but is local/eventual. Corpus membership,
   BM25 statistics, scores, and top-k order may differ until mutation streaming
   or anti-entropy repairs the graph; clients must not interpret a partition-time
-  response as a cluster-wide snapshot.
+  response as a cluster-wide snapshot or compare its numeric score with another
+  replica. Cursor sessions and signing keys are endpoint-local; failover must
+  discard a continuation and restart from page one.
 - `Add*` writes on both sides combine cleanly when the partition heals
   (G-Set union). No data is lost.
 - `Put*` writes on both sides converge to the higher-HLC value. The losing

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,0 +1,304 @@
+# SearchVertices contract
+
+This is the canonical contract for Lantern content search. It defines what is
+indexed, how membership and ranking work, which failures are machine-readable,
+and what changes in a replicated deployment. The RPC schema lives in
+[`graph.proto`](../proto/graph/v1/graph.proto); this guide is the normative
+developer and operator interpretation of that schema.
+
+Search is a derived, in-memory index over the same live vertices served by the
+KVS. It is not a second source of truth. Prefix scans answer “which keys begin
+with this prefix?”; `SearchVertices` answers “which live vertices are most
+relevant to this analyzed query?”
+
+## Discover the serving endpoint first
+
+Read `GetServerStatus.search` instead of hard-coding deployment assumptions.
+The response reports whether search and positional postings are enabled, the
+effective defaults and limits, implementation versions, current index health,
+and a `config_fingerprint`. The fingerprint covers search-affecting settings
+and must be identical across serving replicas.
+
+The `SearchCapabilities` fields are:
+
+| Field | Contract |
+| --- | --- |
+| `enabled` | Whether this endpoint accepts content-search requests. |
+| `positions_enabled` | Whether phrase adjacency and proximity evidence are available. |
+| `default_limit` / `max_limit` | Page-size default and hard ceiling. |
+| `default_match_mode` / `default_min_should_match` | Membership defaults when the request defers to the server. |
+| `max_fuzziness` | Largest accepted edit distance. |
+| `analyzer_version` / `projection_version` | Stable identifiers for the text analyzer and vertex-to-document projection. |
+| `config_fingerprint` | SHA-256 fingerprint used to detect heterogeneous HA members and bind cursors. |
+| `timeout_ms` | Server execution deadline for a page-one search attempt. |
+| `max_query_bytes` / `max_query_terms` | Query input and analyzed-term limits. |
+| `max_dictionary_visits` / `max_posting_visits` / `max_position_visits` | Deterministic per-query work budgets. |
+| `max_in_flight` | Endpoint-local admission slots. |
+| `max_document_bytes` / `max_document_tokens` / `max_document_terms` | Per-document indexing limits. |
+| `max_live_terms` / `max_live_postings` / `max_position_entries` | Aggregate live-index capacity limits. |
+| `compaction_ratio` / `compaction_min_retired` | Retained-to-live compaction trigger. |
+| `index_stats` | Current `SearchIndexStats`, including health, logical/physical size, expiration, rebuild, and generation diagnostics. |
+| `max_expiration_visits` | Maximum expired documents synchronously purged by one search attempt. |
+| `cursor_ttl_seconds` | Lifetime of an endpoint-local retained search session. |
+| `max_sessions` / `max_session_hits` / `max_session_bytes` | Endpoint-local retained-session bounds. |
+
+The server environment variables behind these fields are generated in
+[`env.md`](env.md). A client should treat the status response, not those
+documented defaults, as authoritative for the endpoint it reached.
+
+## Index lifecycle and document projection
+
+When `enabled=false`, no content index is built and calls fail with
+`SEARCH_DISABLED`. When enabled, the server publishes store and index changes
+through one commit barrier. `positions_enabled=false` omits positions to save
+memory; ordinary search still works, while phrase search fails explicitly with
+`SEARCH_POSITIONS_DISABLED`.
+
+Every live vertex produces one search document with a key field and zero or
+more value-field instances. The current versions are discoverable rather than
+inferred; at the time of writing they are `vertex-fields-v2` and
+`script-aware-v2`.
+
+| Vertex value | Indexed value text |
+| --- | --- |
+| `string` | A plain or malformed-JSON string is indexed verbatim. A valid JSON object/array contributes only its non-empty string leaves. Object keys and non-string scalars are not indexed. Each leaf is a separate field instance, visited in sorted object-key order for deterministic projection. |
+| `bytes` | Indexed only when the bytes are valid UTF-8. Opaque binary contributes no value text. |
+| signed / unsigned integer | Base-10 representation. |
+| float | Stable shortest decimal representation. |
+| `bool` | `true` or `false`. |
+| timestamp | RFC 3339 with nanosecond precision. |
+| duration | Go duration text such as `1h30m0s`. |
+| nil / unset | No value text. |
+
+The vertex key is always its own field. Phrase and proximity evidence never
+cross the key/value boundary or two JSON string leaves. Key matches receive a
+higher field weight than value matches. Vertices created implicitly as edge
+endpoints have no value, but their keys are immediately searchable.
+
+A write whose projected document exceeds a per-document or aggregate index
+capacity limit fails atomically with `SEARCH_INDEX_BUDGET_EXHAUSTED`; the graph
+and index do not diverge. An unhealthy derived index reports
+`SEARCH_INDEX_HEALTH_INCOMPLETE` and search fails closed with
+`SEARCH_INDEX_INCOMPLETE` until a bounded rebuild succeeds.
+`SEARCH_INDEX_HEALTH_DISABLED` means indexing is intentionally off,
+`SEARCH_INDEX_HEALTH_HEALTHY` is the only serving index state, and
+`SEARCH_INDEX_HEALTH_UNSPECIFIED` means the endpoint supplied no recognized
+health value.
+
+## Unicode analysis and ranking
+
+The analyzer applies width folding, canonical NFC normalization, Unicode full
+case folding, and removal of emoji text/presentation selectors. It preserves
+meaningful combining marks, Unicode symbols, and emoji. Punctuation separates
+runs; symbols remain searchable rather than disappearing.
+
+Word-like runs contribute a whole-word term plus lower-weight intra-word
+bigrams. Unbounded scripts such as CJK use bigrams as their primary terms. A
+two-rune non-CJK query also enters the auxiliary infix channel, so `ar` can
+recall `search`, while exact whole-word evidence remains stronger. Analyzer
+behavior is versioned by `analyzer_version`; changing it is a configuration
+change, not silent query drift.
+
+Candidates are scored with field-local BM25 plus positional proximity when
+positions are enabled. Results have the stable total order
+`(score DESC, raw key ASC)`. BM25 scores are relative to the query and the
+endpoint's current corpus: do not compare numeric scores across unrelated
+queries, changing corpora, or replicas that have not converged. Given the same
+live graph and identical search configuration, replicas converge to the same
+ordered hits and score bits.
+
+## Request membership and validation
+
+`SearchVerticesRequest` carries:
+
+| Field | Contract |
+| --- | --- |
+| `query` | UTF-8 search input. Empty or unanalysable input succeeds with no hits. |
+| `limit` | Page size. Zero selects `default_limit`; larger values clamp to `max_limit`. |
+| `prefix` | Optional raw vertex-key namespace restriction, applied to membership. |
+| `options` | Optional relevance and membership controls below. Omission preserves every server default. |
+| `cursor` | Opaque endpoint-sticky continuation. Empty starts a new snapshot. |
+| `projection` | `SEARCH_PROJECTION_KEY_SCORE` by default, or `SEARCH_PROJECTION_FULL_VERTEX`. |
+
+`SearchOptions` carries:
+
+| Field | Contract |
+| --- | --- |
+| `match_mode` | `MATCH_MODE_UNSPECIFIED` defers to `default_match_mode`; `MATCH_MODE_ANY`, `MATCH_MODE_ALL`, and `MATCH_MODE_MIN_SHOULD` explicitly override it. |
+| `min_should_match` | With `MATCH_MODE_MIN_SHOULD`, zero selects `default_min_should_match`; a positive value sets the threshold. Invalid with every other mode. |
+| `phrase` | Requires word terms to occur adjacently and in order within one field instance. Requires positions. |
+| `fuzziness` | Dictionary edit distance from zero through `max_fuzziness` (currently at most 2). |
+| `prefix_terms` | Also match dictionary terms that extend a query word, so `lan` can match `lantern`. |
+
+Membership is OR for `MATCH_MODE_ANY`, AND for `MATCH_MODE_ALL`, and “at least
+N distinct analyzed query word terms” for `MATCH_MODE_MIN_SHOULD`. Auxiliary
+infix grams improve recall and ranking; they do not inflate the distinct-word
+threshold.
+
+Phrase currently cannot compose with an explicit `match_mode`, a non-zero
+`min_should_match`, `fuzziness`, or `prefix_terms`. Unknown enum values,
+fuzziness outside the reported range, thresholds under the wrong mode, and
+other ignored/ambiguous combinations fail as `INVALID_ARGUMENT`; the server
+does not silently reinterpret them.
+
+## TTL, writes, and snapshot consistency
+
+One search attempt captures a single logical `now`. A vertex that expired at
+that instant is excluded even if background GC has not physically removed it.
+Ranking and `FULL_VERTEX` hydration use that same liveness instant and the same
+commit barrier.
+
+Batch writes and deletes are search-atomic: a search observes the state before
+or after the batch, never its midpoint. A concurrent single-key overwrite can
+appear on either side of the barrier, but never as a score from one version
+hydrated with the unrelated value of another. `FULL_VERTEX` therefore removes
+the racy `SearchVertices` then `GetVertices` pattern.
+
+Once page one creates a retained session, later writes, deletes, TTL expiry,
+or compaction do not change that session's ranked membership or exact vertex
+snapshots. New page-one searches observe the current live graph.
+
+## Projection and page response
+
+`SEARCH_PROJECTION_UNSPECIFIED` normalizes to the lightweight default.
+`SEARCH_PROJECTION_KEY_SCORE` returns only `key`, `score`, and
+`SEARCH_HIT_PROJECTION_STATUS_KEY_SCORE`. It is the lightweight default.
+
+`SEARCH_PROJECTION_FULL_VERTEX` carries the exact selection-time value and TTL
+with `SEARCH_HIT_PROJECTION_STATUS_SNAPSHOT`. A backend that cannot prove that
+snapshot fails closed per hit with `SEARCH_HIT_PROJECTION_STATUS_MISSING` or
+`SEARCH_HIT_PROJECTION_STATUS_REPLACED`; it never attaches an unrelated value.
+`SEARCH_HIT_PROJECTION_STATUS_UNSPECIFIED` is reserved for compatibility with
+an endpoint that did not report a status.
+
+`SearchVerticesResponse` carries:
+
+| Field | Contract |
+| --- | --- |
+| `hits` | The ordered page of projected search hits. |
+| `next_cursor` | Opaque continuation; empty means there is no admitted next page. |
+| `effective_limit` | Server-selected page size after defaulting/clamping. |
+| `truncated` | More ranked hits existed beyond this page. It is not an exact total. |
+| `continuation_limited` | A bounded session retained only a prefix of all matches. SDK iterators surface this after the final retained hit. |
+
+Lantern intentionally does not return an approximate count as an exact total.
+Use `next_cursor`, `truncated`, and `continuation_limited` to describe what is
+available.
+
+Repeat the exact query, limit, prefix, options, projection, and endpoint for
+each cursor page. Cursors are signed and bound to the request, configuration,
+and endpoint. Treat them as opaque and never persist them beyond
+`cursor_ttl_seconds`.
+
+## Typed failures, budgets, and retry decisions
+
+Transport status is the broad category; `SearchErrorDetail.reason` is the
+stable search-specific branch. Every defined `SearchErrorReason` is listed
+here so a proto addition requires a documentation update:
+
+| Reason | Status and action |
+| --- | --- |
+| `SEARCH_ERROR_REASON_UNSPECIFIED` | No recognized search detail. Branch on the transport status only. |
+| `SEARCH_DISABLED` | `FAILED_PRECONDITION`. Render search as unavailable or use key scans. |
+| `SEARCH_POSITIONS_DISABLED` | `FAILED_PRECONDITION`. Disable phrase UI or issue a non-phrase query explicitly. |
+| `SEARCH_WORK_BUDGET_EXHAUSTED` | `RESOURCE_EXHAUSTED`. `work_kind` is one of `query_bytes`, `query_terms`, `dictionary_visits`, `posting_visits`, or `position_visits`; narrow the query, namespace, fuzziness, or prefix expansion. |
+| `SEARCH_ADMISSION_SATURATED` | `RESOURCE_EXHAUSTED`. A short jittered retry of the unchanged newest query is reasonable. |
+| `SEARCH_INDEX_INCOMPLETE` | `FAILED_PRECONDITION`. Rebuild/repair the local derived index before serving it. |
+| `SEARCH_INDEX_BUDGET_EXHAUSTED` | `RESOURCE_EXHAUSTED` on a write. Increase index capacity or reduce/index less content; the write was not partially applied. |
+| `SEARCH_CURSOR_STALE` | `ABORTED`. The endpoint-local session expired or was evicted; restart from page one. |
+| `SEARCH_CURSOR_INVALID` | `INVALID_ARGUMENT`. The cursor was altered or used with a different request, endpoint, or config; restart from page one and fix routing/request reuse. |
+| `SEARCH_CONTINUATION_LIMITED` | Terminal iterator/stream condition after the final retained hit when `continuation_limited=true`; narrow the query or increase bounded session capacity. |
+
+Ordinary option validation is `INVALID_ARGUMENT` and may have no search
+reason. Caller cancellation and deadline expiry are `CANCELED` and
+`DEADLINE_EXCEEDED`; both return no partial page. A work-budget failure is also
+terminal for that attempt. Incremental clients should cancel superseded work,
+drop stale replies, and issue only the newest input instead of replaying old
+queries.
+
+The endpoint limits query bytes/terms, dictionary/posting/position visits,
+in-flight work, document size/tokens/terms, aggregate index cardinality,
+expiration cleanup, and retained sessions. This containment is part of the
+public contract. Inspect capabilities and
+[`lantern_search_*` metrics](observability.md#57-query-subsystems--illuminate--scan--search)
+before changing a limit.
+
+## Replication, failover, and cursors
+
+Search is a local, eventual read. It does not wait for peer convergence and
+does not perform read repair. During replication lag, membership, BM25 corpus
+statistics, scores, and pagination snapshots can differ between replicas;
+after graph and configuration convergence, deterministic analysis and ordering
+converge too.
+
+Running serving replicas with different search-affecting configuration is
+prohibited. Readiness becomes `NOT_SERVING` on a fingerprint mismatch, but
+replication continues so operators can repair configuration without losing
+events. Compare `GetServerStatus.search.config_fingerprint` across every member.
+
+Cursor sessions and signing keys are endpoint-local. Keep a cursor chain on
+one endpoint with load-balancer affinity at least as long as
+`cursor_ttl_seconds`. Static SDK failover may select another endpoint for page
+one, but it must not migrate a non-empty cursor. On failover or a stale/invalid
+cursor, discard the chain and restart from page one; the new replica may
+legitimately return a different one-page result until convergence.
+
+See the [replication RFC](replication.md#read-consistency-contract),
+[HA runbook](ha-runbook.md#43-search-health-and-replica-consistency), and
+[bounded pagination ADR](decisions/0008-bounded-search-pagination-sessions.md)
+for the underlying operational decisions.
+
+## Maintained examples and command surfaces
+
+The maintained SDK examples compile in CI and cover capability discovery,
+one-shot namespace search, phrase/typo options, bounded pagination, typed
+disabled handling, cancellation, and incremental latest-query-wins search:
+
+- [Go search example](../sdks/go/example/search.go)
+- [Node search example](../sdks/node/example/search.ts)
+- [Dart/Flutter search example](../sdks/dart/example/lib/main.dart)
+
+CLI and Admin `/cli` use the same grammar. The standalone command uses flags
+with the same meanings (`--mode`, `--min-should`, `--phrase`, `--fuzziness`,
+`--prefix-terms`, `--prefix`, `--limit`, `--all`, and `--projection`). One-page
+JSON is a lossless response envelope; `all=true`/`--all` streams bounded pages
+as NDJSON by default. TSV is an explicit presentation format.
+
+The following commands are parsed by the production grammar in the docs drift
+gate:
+
+<!-- search-cli-grammar:start -->
+```text
+search "rolling update" mode=all limit=20
+search "quiet cafe" prefix=place: projection=full-vertex
+search "release notes" phrase=true
+search serach fuzziness=1
+search lan prefix_terms=true
+search espresso limit=20 all=true format=ndjson
+```
+<!-- search-cli-grammar:end -->
+
+The Admin Vertices page exposes the same membership and expansion controls and
+disables phrase mode unless the endpoint reports positional postings. The Ops
+page shows the discoverable capability, budget, fingerprint, and index-health
+snapshot. Surface wording should link back here rather than restating a
+partial contract.
+
+## Observability checklist
+
+Before declaring search healthy:
+
+1. `GetServerStatus.search.enabled` is true and `index_stats.health` is
+   `SEARCH_INDEX_HEALTH_HEALTHY` on every serving member.
+2. `config_fingerprint`, `analyzer_version`, and `projection_version` match
+   across replicas.
+3. Search call latency, terminal outcomes/reasons, work visits, admission
+   saturation, index capacity, expiration cleanup, sessions, and compaction
+   are within the [documented SLOs](observability.md#57-query-subsystems--illuminate--scan--search).
+4. Load balancing preserves cursor affinity and operational probes exercise
+   both an ordinary query and phrase behavior when positions are enabled.
+
+The integration docs gate reflects the proto descriptors for
+`SearchOptions`, `SearchVerticesRequest`, `SearchVerticesResponse`, and
+`SearchErrorReason`. Adding or renaming a wire option, response field, or
+reason without updating this guide fails the ordinary root test suite.

--- a/sdks/dart/README.md
+++ b/sdks/dart/README.md
@@ -115,6 +115,14 @@ caps one call only. The SDK never retries or silently loops prefix Delete.
 
 ## Search, discovery, and traversal
 
+The [canonical SearchVertices contract](https://github.com/anaregdesign/lantern/blob/main/docs/search.md)
+is authoritative
+for document projection, Unicode analysis, relative BM25 scoring, TTL
+consistency, budgets, typed reasons, endpoint-sticky cursors, and HA. The
+maintained [Flutter example](https://github.com/anaregdesign/lantern/blob/main/sdks/dart/example/lib/main.dart)
+compiles both one-shot and incremental flows, including capability discovery,
+phrase/typo options, pagination, disabled handling, and cancellation.
+
 `searchVertices` exposes prefix scope, limit, any/all/min-should-match modes,
 phrase matching, fuzziness, and prefix-term expansion. Nullable relevance
 fields preserve the distinction between omitted server defaults and explicit

--- a/sdks/dart/example/lib/main.dart
+++ b/sdks/dart/example/lib/main.dart
@@ -305,6 +305,7 @@ final class _DiscoveryScreenState extends State<_DiscoveryScreen> {
         EdgeRef('${_prefix}alice', '${_prefix}bob'),
         options: _callOptions,
       );
+      await _runSearchContractExamples();
       await widget.client.putVertex(
         VertexInput(key: '${_prefix}temporary', value: VertexValue.nil()),
         options: _callOptions,
@@ -316,6 +317,73 @@ final class _DiscoveryScreenState extends State<_DiscoveryScreen> {
       await _refresh();
     } catch (error) {
       _showFailure(error);
+    }
+  }
+
+  /// Maintained one-shot counterpart to the screen-owned incremental search
+  /// created in [initState]. Flutter analyze/test compile both paths.
+  Future<void> _runSearchContractExamples() async {
+    final status = await widget.client.getServerStatus(options: _callOptions);
+    final capability = status.search;
+    _appendRows([
+      'search enabled=${capability.enabled} '
+          'positions=${capability.positionsEnabled} '
+          'analyzer=${capability.analyzerVersion} '
+          'projection=${capability.projectionVersion} '
+          'fingerprint=${capability.configFingerprint}',
+    ]);
+
+    final oneShot = await widget.client.searchVertices(
+      'quiet cafe',
+      searchOptions: const SearchOptions(
+        prefix: _prefix,
+        matchMode: SearchMatchMode.all,
+        limit: 10,
+      ),
+      options: _callOptions,
+    );
+    switch (oneShot) {
+      case SearchDisabled():
+        _appendRows(['Search is disabled on this endpoint']);
+        return;
+      case SearchEnabled(:final hits):
+        _appendRows(hits.map((hit) => 'one-shot ${hit.key} ${hit.score}'));
+    }
+
+    if (capability.positionsEnabled) {
+      await widget.client.searchVertices(
+        'quiet cafe',
+        searchOptions: const SearchOptions(prefix: _prefix, phrase: true),
+        options: _callOptions,
+      );
+    }
+    await widget.client.searchVertices(
+      'serach',
+      searchOptions: const SearchOptions(prefix: _prefix, fuzziness: 1),
+      options: _callOptions,
+    );
+
+    await for (final hit in widget.client.searchVerticesStream(
+      'quiet cafe',
+      searchOptions: const SearchOptions(
+        prefix: _prefix,
+        limit: 2,
+        projection: SearchProjection.fullVertex,
+      ),
+      options: _callOptions,
+    )) {
+      _appendRows(['paged ${hit.key} ${hit.vertex?.expiration}']);
+    }
+
+    final cancellation = LanternCancellationToken()..cancel('example');
+    try {
+      await widget.client.searchVerticesPage(
+        'quiet cafe',
+        searchOptions: const SearchOptions(prefix: _prefix),
+        options: LanternCallOptions(cancellation: cancellation),
+      );
+    } on LanternCanceledException {
+      _appendRows(['search cancelled without a partial page']);
     }
   }
 

--- a/sdks/dart/lib/lantern_client.dart
+++ b/sdks/dart/lib/lantern_client.dart
@@ -2,6 +2,10 @@
 ///
 /// Generated service and replication internals remain private to the package;
 /// CRUD and query facades are layered on the reusable [LanternClient].
+///
+/// Search projection, analysis, ranking, TTL, typed-error, cursor, and HA
+/// semantics are canonical at
+/// https://github.com/anaregdesign/lantern/blob/main/docs/search.md.
 library;
 
 export 'src/client.dart'

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -269,6 +269,12 @@ the exact value/TTL snapshot selected with ranking and removes a racy follow-up
 cursor is sent only to the current endpoint because sessions are not portable
 between replicas.
 
+The [canonical SearchVertices contract](../../docs/search.md) is authoritative
+for document projection, Unicode analysis, ranking, TTL consistency, budgets,
+typed reasons, and HA. The maintained
+[`example/search.go`](example/search.go) compiles one-shot, capability,
+phrase/typo, pagination, disabled, cancellation, and incremental flows in CI.
+
 `Illuminate` accepts at most one traversal family option (`WithBFS`,
 `WithPPR`, or `WithLocalCommunity`). Combining them returns a local error that
 matches both `ErrInvalidArgument` and `ErrConflictingIlluminateFamilies` before

--- a/sdks/go/doc.go
+++ b/sdks/go/doc.go
@@ -46,6 +46,16 @@
 // Shared axes such as WithWeighting and WithVertexPrefix remain freely
 // composable with the one family option.
 //
+// # Content search
+//
+// SearchVertices, SearchVerticesPage, SearchVerticesIter, and
+// NewIncrementalSearch share the canonical projection, Unicode analysis,
+// membership, ranking, TTL, typed-error, cursor, and HA contract documented at
+// https://github.com/anaregdesign/lantern/blob/main/docs/search.md. The
+// compiling example/search.go demonstrates capability discovery, one-shot and
+// incremental search, phrase/typo options, bounded pagination, cancellation,
+// and a disabled endpoint.
+//
 // # Retry policy
 //
 // Retries are opt-in and off by default — a zero-config client behaves

--- a/sdks/go/example/main.go
+++ b/sdks/go/example/main.go
@@ -59,6 +59,10 @@ func main() {
 		log.Fatal(err)
 	}
 
+	if err := runSearchExamples(ctx, cli); err != nil {
+		log.Fatal(err)
+	}
+
 	/*
 		GetVertex:
 	*/

--- a/sdks/go/example/search.go
+++ b/sdks/go/example/search.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	client "github.com/anaregdesign/lantern/sdks/go"
+)
+
+// runSearchExamples is the maintained SearchVertices contract example. It is
+// called by main after the sample vertices exist, so ordinary `go build` keeps
+// one-shot, paging, cancellation, and incremental API usage compiling.
+func runSearchExamples(ctx context.Context, cli *client.Lantern) error {
+	status, err := cli.GetServerStatus(ctx)
+	if err != nil {
+		return fmt.Errorf("discover search capabilities: %w", err)
+	}
+	search := status.GetSearch()
+	log.Printf("search enabled=%t positions=%t analyzer=%s projection=%s fingerprint=%s",
+		search.GetEnabled(), search.GetPositionsEnabled(), search.GetAnalyzerVersion(),
+		search.GetProjectionVersion(), search.GetConfigFingerprint())
+
+	// One-shot namespace search. A disabled index is a calm, typed state rather
+	// than an error string applications need to parse.
+	hits, err := cli.SearchVertices(ctx, "A",
+		client.WithSearchPrefix("string"),
+		client.WithMatchMode(client.MatchAll),
+		client.WithSearchLimit(10),
+	)
+	if errors.Is(err, client.ErrSearchDisabled) {
+		log.Printf("search unavailable: %s", client.SearchFailureReason(err))
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("one-shot search: %w", err)
+	}
+	log.Printf("one-shot search returned %d hits", len(hits))
+
+	// Phrase is issued only when the endpoint advertises positions. Fuzziness
+	// is a separate request because phrase and expansion options do not compose.
+	if search.GetPositionsEnabled() {
+		if _, err := cli.SearchVertices(ctx, "quiet cafe", client.WithPhrase()); err != nil {
+			return fmt.Errorf("phrase search: %w", err)
+		}
+	}
+	if _, err := cli.SearchVertices(ctx, "serach", client.WithFuzziness(1)); err != nil {
+		return fmt.Errorf("typo search: %w", err)
+	}
+
+	// The iterator follows the endpoint-sticky bounded snapshot lazily and
+	// requests exact value/TTL snapshots with each ranked hit.
+	for hit, err := range cli.SearchVerticesIter(ctx, "A",
+		client.WithSearchLimit(2), client.WithFullVertex()) {
+		if err != nil {
+			return fmt.Errorf("search pagination: %w", err)
+		}
+		log.Printf("paged search hit key=%s score=%f status=%s", hit.Key, hit.Score, hit.ProjectionStatus)
+	}
+
+	// Per-call cancellation is terminal and never returns a partial page.
+	cancelled, cancel := context.WithCancel(ctx)
+	cancel()
+	if _, err := cli.SearchVertices(cancelled, "A"); err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("cancelled search returned unexpected error: %w", err)
+	}
+
+	// IncrementalSearch debounces inputs, cancels superseded RPCs, and only
+	// publishes the newest query. Its options are the same one-shot options.
+	incrementalCtx, stopIncremental := context.WithCancel(ctx)
+	incremental := cli.NewIncrementalSearch(incrementalCtx,
+		client.WithDebounce(0),
+		client.WithIncrementalSearchLimit(10),
+		client.WithIncrementalSearchOptions(client.WithPrefixTerms()),
+	)
+	incremental.Search("lan")
+	select {
+	case update := <-incremental.Updates():
+		if update.Err != nil {
+			stopIncremental()
+			_ = incremental.Close()
+			return fmt.Errorf("incremental search: %w", update.Err)
+		}
+		log.Printf("incremental query=%q hits=%d", update.Query, len(update.Hits))
+	case <-time.After(2 * time.Second):
+		stopIncremental()
+		_ = incremental.Close()
+		return errors.New("incremental search timed out")
+	}
+	stopIncremental()
+	return incremental.Close()
+}

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -298,13 +298,16 @@ you want the `EdgeInput[]` without sending it.
 _content_ (key + value) — unlike `scanVertices`, which is a lexicographic
 key-prefix walk. It returns `{ key, score }` hits in stable `(score DESC, raw
 key ASC)` order: the seed candidates to pick before an `illuminate` traversal,
-where `score` doubles as the seed's initial weight. Hits carry only the key and
-score, so hydrate value/TTL with a follow-up `getVertices`, preserving rank
-order.
+where `score` doubles as the seed's initial weight. Use
+`projection: "full-vertex"` when the exact selection-time value/TTL is needed;
+a follow-up `getVertices` hydration is racy under concurrent writes.
 
 ```ts
-const hits = await client.searchVertices("quarterly revenue", { limit: 10, prefix: "doc/" });
-const { found } = await client.getVertices(hits.map((h) => h.key));
+const hits = await client.searchVertices("quarterly revenue", {
+  limit: 10,
+  prefix: "doc/",
+  projection: "full-vertex",
+});
 ```
 
 An empty or unmatched query resolves to `[]` (not an error). When the
@@ -330,6 +333,12 @@ sentinel. Invalid integers/ranges, a non-zero threshold under another mode,
 and phrase combined with an explicit mode/fuzziness/prefix terms reject locally
 with `InvalidArgumentError` before transport. `incrementalSearch` accepts and
 forwards the same complete `SearchOptions` set as one-shot search.
+
+The [canonical SearchVertices contract](../../docs/search.md) defines document
+projection, Unicode analysis, relative BM25 scoring, TTL consistency, budgets,
+typed reasons, endpoint-sticky cursors, and HA. The maintained
+[`example/search.ts`](example/search.ts) compiles one-shot, capability,
+phrase/typo, pagination, disabled, cancellation, and incremental flows in CI.
 
 ## Backup & restore
 

--- a/sdks/node/example/main.ts
+++ b/sdks/node/example/main.ts
@@ -1,4 +1,5 @@
 import { Objective, Reduction, Weighting, connect, type Graph } from "lantern-sdk";
+import { runSearchExamples } from "./search.js";
 
 function printGraph(name: string, graph: Graph): void {
   console.log(`${name}: vertices=${graph.vertices.size}`);
@@ -22,6 +23,8 @@ async function main(): Promise<void> {
     await client.putVertex({ key: "time", value: new Date(), ttlSeconds: 60 });
     await client.putVertex({ key: "bytes", value: new Uint8Array([0x41]), ttlSeconds: 60 });
     await client.putVertex({ key: "nil", value: null, ttlSeconds: 60 });
+
+    await runSearchExamples(client);
 
     // GetVertex
     const v = await client.getVertex("string");

--- a/sdks/node/example/search.ts
+++ b/sdks/node/example/search.ts
@@ -1,0 +1,77 @@
+import { FailedPreconditionError, SearchErrorReason, type Lantern } from "lantern-sdk";
+
+/**
+ * Maintained SearchVertices contract example. `bun run example:typecheck`
+ * compiles this file together with the SDK and the executable main example.
+ */
+export async function runSearchExamples(client: Lantern): Promise<void> {
+  const status = await client.getServerStatus();
+  const capability = status.search;
+  console.log(
+    `search enabled=${capability?.enabled ?? false} positions=${capability?.positionsEnabled ?? false} ` +
+      `analyzer=${capability?.analyzerVersion ?? "unknown"} ` +
+      `projection=${capability?.projectionVersion ?? "unknown"} ` +
+      `fingerprint=${capability?.configFingerprint ?? "unknown"}`,
+  );
+
+  // One-shot search, scoped to a key namespace and with explicit membership.
+  // A disabled index is a typed UI state, not a message-string comparison.
+  try {
+    const hits = await client.searchVertices("A", {
+      prefix: "string",
+      limit: 10,
+      matchMode: "all",
+    });
+    console.log(`one-shot search returned ${hits.length} hits`);
+  } catch (error) {
+    if (
+      error instanceof FailedPreconditionError &&
+      error.reason === SearchErrorReason.SEARCH_DISABLED
+    ) {
+      console.log("search is disabled on this endpoint");
+      return;
+    }
+    throw error;
+  }
+
+  // Phrase and fuzzy expansion are separate because those options do not
+  // compose. Capability discovery prevents a known phrase precondition error.
+  if (capability?.positionsEnabled) {
+    await client.searchVertices("quiet cafe", { phrase: true });
+  }
+  await client.searchVertices("serach", { fuzziness: 1 });
+
+  // This iterator follows an endpoint-sticky bounded snapshot lazily and asks
+  // for the exact value/TTL snapshot selected with each score.
+  for await (const hit of client.searchVerticesIter("A", {
+    limit: 2,
+    projection: "full-vertex",
+  })) {
+    console.log("paged search hit", hit.key, hit.score, hit.vertex);
+  }
+
+  // AbortSignal cancellation is terminal and returns no partial page.
+  const controller = new AbortController();
+  controller.abort();
+  try {
+    await client.searchVertices("A", {}, controller.signal);
+  } catch (error) {
+    console.log("cancelled search", error);
+  }
+
+  // Incremental search forwards the same one-shot options, cancels superseded
+  // calls, and publishes only the newest input.
+  const incremental = client.incrementalSearch({
+    debounceMs: 0,
+    limit: 10,
+    prefixTerms: true,
+  });
+  const iterator = incremental[Symbol.asyncIterator]();
+  incremental.search("lan");
+  const update = await iterator.next();
+  if (!update.done) {
+    if (update.value.error) throw update.value.error;
+    console.log(`incremental query=${update.value.query} hits=${update.value.hits.length}`);
+  }
+  incremental.close();
+}

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -21,6 +21,10 @@
  * subpath ships `connectWeb()` and a bundle that excludes
  * `@connectrpc/connect-node`.
  *
+ * Search projection, analysis, ranking, TTL, typed-error, cursor, and HA
+ * semantics are canonical at
+ * https://github.com/anaregdesign/lantern/blob/main/docs/search.md.
+ *
  * @packageDocumentation
  */
 

--- a/server/README.md
+++ b/server/README.md
@@ -9,9 +9,10 @@ gRPC-Web all multiplexed on the same h2c port). The pre-#347 split
 (separate grpc-gateway listener + additive Connect listener) is gone —
 everything serves on the single `LANTERN_PORT` socket.
 
-See the [repo README](../README.md) for the end-user usage walkthrough; this
-file documents the **server module itself** (layout, providers, env vars,
-observability endpoints).
+See the [repo README](../README.md) for the end-user usage walkthrough and the
+[canonical SearchVertices contract](../docs/search.md) for index, budget,
+error, TTL, cursor, and HA semantics. This file documents the **server module
+itself** (layout, providers, env vars, observability endpoints).
 
 ## Install / run
 

--- a/server/internal/envdoc/envdoc.go
+++ b/server/internal/envdoc/envdoc.go
@@ -169,7 +169,9 @@ func Render(specs []envconfig.Spec) (string, error) {
 	b.WriteString("back to its default; an unknown `LANTERN_*` name logs a typo warning; with\n")
 	b.WriteString("`LANTERN_STRICT_CONFIG=true` either condition fails boot. An explicitly empty\n")
 	b.WriteString("value is treated as unset for the non-string kinds. The MCP server's\n")
-	b.WriteString("`LANTERN_MCP_*` namespace belongs to that process and is not listed here.\n\n")
+	b.WriteString("`LANTERN_MCP_*` namespace belongs to that process and is not listed here.\n")
+	b.WriteString("Search projection, membership, error, TTL, cursor, and HA semantics are\n")
+	b.WriteString("canonical in the [SearchVertices contract](search.md).\n\n")
 	b.WriteString("| Variable | Type | Default | Description |\n")
 	b.WriteString("|---|---|---|---|\n")
 	for _, s := range sorted {

--- a/server/internal/envdoc/envdoc_test.go
+++ b/server/internal/envdoc/envdoc_test.go
@@ -26,7 +26,12 @@ func TestRenderCoversFullRegistry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
-	for _, want := range []string{"| `LANTERN_PORT` |", "| `LANTERN_STRICT_CONFIG` |", "GENERATED FILE"} {
+	for _, want := range []string{
+		"| `LANTERN_PORT` |",
+		"| `LANTERN_STRICT_CONFIG` |",
+		"GENERATED FILE",
+		"[SearchVertices contract](search.md)",
+	} {
 		if !strings.Contains(doc, want) {
 			t.Fatalf("rendered doc missing %q", want)
 		}

--- a/tests/integration/docs_gate_test.go
+++ b/tests/integration/docs_gate_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/anaregdesign/lantern/cli/parser"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 // TestTraversalDocumentationGate keeps the maintained consumer examples and
@@ -137,6 +139,121 @@ func TestDartFirstReleaseBlockerGate(t *testing.T) {
 	}
 }
 
+// TestSearchDocumentationGate keeps the canonical search guide synchronized
+// with the wire schema and every maintained user-facing surface. Tables remain
+// readable hand-written prose, while descriptor reflection makes a new option,
+// response field, capability, or typed reason fail the ordinary root suite
+// until its contract is documented (#1069).
+func TestSearchDocumentationGate(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	read := func(path string) string {
+		t.Helper()
+		contents, readErr := os.ReadFile(filepath.Join(repoRoot, path))
+		if readErr != nil {
+			t.Fatalf("read %s: %v", path, readErr)
+		}
+		return string(contents)
+	}
+
+	guide := read("docs/search.md")
+	file := pb.File_graph_v1_graph_proto
+	for _, name := range []string{
+		"SearchOptions",
+		"SearchVerticesRequest",
+		"SearchVerticesResponse",
+		"SearchCapabilities",
+	} {
+		message := file.Messages().ByName(protoreflect.Name(name))
+		if message == nil {
+			t.Fatalf("proto descriptor is missing %s", name)
+		}
+		for i := 0; i < message.Fields().Len(); i++ {
+			field := message.Fields().Get(i)
+			want := "`" + string(field.Name()) + "`"
+			if !strings.Contains(guide, want) {
+				t.Errorf("docs/search.md is missing %s.%s as %s", name, field.Name(), want)
+			}
+		}
+	}
+	for _, name := range []string{
+		"MatchMode",
+		"SearchProjection",
+		"SearchHitProjectionStatus",
+		"SearchErrorReason",
+		"SearchIndexHealth",
+	} {
+		enum := file.Enums().ByName(protoreflect.Name(name))
+		if enum == nil {
+			t.Fatalf("proto descriptor is missing %s", name)
+		}
+		for i := 0; i < enum.Values().Len(); i++ {
+			value := enum.Values().Get(i)
+			want := "`" + string(value.Name()) + "`"
+			if !strings.Contains(guide, want) {
+				t.Errorf("docs/search.md is missing %s.%s as %s", name, value.Name(), want)
+			}
+		}
+	}
+
+	linkChecks := map[string]string{
+		"README.md":                         "docs/search.md",
+		"server/README.md":                  "docs/search.md",
+		"docs/env.md":                       "SearchVertices contract](search.md)",
+		"docs/replication.md":               "SearchVertices contract](search.md",
+		"docs/ha-runbook.md":                "SearchVertices contract](search.md)",
+		"sdks/go/README.md":                 "docs/search.md",
+		"sdks/go/doc.go":                    "docs/search.md",
+		"sdks/node/README.md":               "docs/search.md",
+		"sdks/node/src/index.ts":            "docs/search.md",
+		"sdks/dart/README.md":               "docs/search.md",
+		"sdks/dart/lib/lantern_client.dart": "docs/search.md",
+		"cli/cmd/search.go":                 "docs/search.md",
+		"cli/parser/help.go":                "docs/search.md",
+		"admin/app/lib/cli/verbs.ts":        "docs/search.md",
+		"admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.tsx": "docs/search.md",
+		"admin/app/components/ops/SearchStatusCard/SearchStatusCard.tsx":                 "docs/search.md",
+	}
+	for path, want := range linkChecks {
+		if !strings.Contains(read(path), want) {
+			t.Errorf("%s is missing canonical search contract link %q", path, want)
+		}
+	}
+
+	examples := map[string][]string{
+		"sdks/go/example/search.go":       {"SearchVertices(", "NewIncrementalSearch("},
+		"sdks/node/example/search.ts":     {"searchVertices(", "incrementalSearch("},
+		"sdks/dart/example/lib/main.dart": {"searchVertices(", "incrementalSearch("},
+	}
+	for path, required := range examples {
+		contents := read(path)
+		for _, want := range required {
+			if !strings.Contains(contents, want) {
+				t.Errorf("%s is missing compiling search example %q", path, want)
+			}
+		}
+	}
+
+	const start = "<!-- search-cli-grammar:start -->"
+	const end = "<!-- search-cli-grammar:end -->"
+	startAt := strings.Index(guide, start)
+	endAt := strings.Index(guide, end)
+	if startAt < 0 || endAt < 0 || endAt <= startAt {
+		t.Fatal("docs/search.md is missing ordered search CLI grammar markers")
+	}
+	for _, line := range strings.Split(guide[startAt+len(start):endAt], "\n") {
+		command := strings.TrimSpace(line)
+		if command == "" || strings.HasPrefix(command, "```") {
+			continue
+		}
+		t.Run(command, func(t *testing.T) {
+			parseSearchDocumentationCommand(t, command)
+		})
+	}
+}
+
 func parseTraversalDocumentationCommand(t *testing.T, command string) {
 	t.Helper()
 	command = strings.TrimPrefix(command, "lantern-cli ")
@@ -159,6 +276,27 @@ func parseTraversalDocumentationCommand(t *testing.T, command string) {
 		t.Fatalf("unexpected traversal verb %q", verb)
 	}
 	if err != nil {
+		t.Fatalf("parse %q: %v", command, err)
+	}
+	if err := parser.EOF(source); err != nil {
+		t.Fatalf("trailing token in %q: %v", command, err)
+	}
+}
+
+func parseSearchDocumentationCommand(t *testing.T, command string) {
+	t.Helper()
+	source, err := parser.NewSource(command)
+	if err != nil {
+		t.Fatalf("tokenise %q: %v", command, err)
+	}
+	verb, err := parser.Verb(source)
+	if err != nil {
+		t.Fatalf("parse verb in %q: %v", command, err)
+	}
+	if verb != "search" {
+		t.Fatalf("unexpected search documentation verb %q", verb)
+	}
+	if _, err := parser.SearchParam(source); err != nil {
 		t.Fatalf("parse %q: %v", command, err)
 	}
 	if err := parser.EOF(source); err != nil {


### PR DESCRIPTION
## Summary
- publish `docs/search.md` as the canonical projection, analyzer, ranking, TTL, pagination, error, budget, observability, and HA contract
- link CLI, Admin, server, and all maintained SDK package docs back to that contract
- add compile-checked Go, Node, and Dart/Flutter one-shot and incremental examples
- add a proto-descriptor documentation drift gate for search options, capabilities, response fields, enums, and typed reasons

## Validation
- `gofmt -l .`
- `go test ./...` plus `go test ./...` in `core`, `mcp`, `pb`, `sdks/go`, and `server`
- `go vet ./...` in `server`
- Node format, typecheck, example typecheck, lint, build, and 153 tests
- Admin typecheck, lint, production build, 835 unit tests, and targeted Playwright search-contract link test
- Dart package format, locked dependency resolution, analyze, 74 tests, warning-free dartdoc link validation, and publish dry-run
- Flutter example format, locked dependency resolution, analyze, and widget test

Closes #1069