### PR TITLE
fix(search): preserve recovery lock order (#1089)

### DIFF
--- a/core/graphcache/search.go
+++ b/core/graphcache/search.go
@@ -134,24 +134,29 @@ func (c *GraphCache[S, T]) RebuildSearchIndex() error {
 // this boundary so a partially replayed derived index is never advertised as
 // healthy or queried for partial results.
 func (c *GraphCache[S, T]) BeginSearchIndexRecovery() {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.searchIndex == nil {
+		return
+	}
+	// Preserve the graph -> search lock order used by every vertex writer.
+	// Snapshot recovery runs concurrently with local writes, so taking these
+	// locks in the opposite order can deadlock a writer that already owns mu.
 	c.searchCommitMu.Lock()
 	defer c.searchCommitMu.Unlock()
-	c.mu.RLock()
-	index := c.searchIndex
-	c.mu.RUnlock()
-	if index != nil {
-		index.MarkIncomplete()
-	}
+	c.searchIndex.MarkIncomplete()
 }
 
 // CompleteSearchIndexRecovery rebuilds the complete derived index from the
 // live graph and marks it healthy only after the atomic replacement succeeds.
 // A limit error leaves the graph intact and the index incomplete.
 func (c *GraphCache[S, T]) CompleteSearchIndexRecovery() error {
-	c.searchCommitMu.Lock()
-	defer c.searchCommitMu.Unlock()
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	// Match the graph -> search lock order used by vertex writes. Recovery is
+	// reachable from replication while those writes remain active.
+	c.searchCommitMu.Lock()
+	defer c.searchCommitMu.Unlock()
 	return c.rebuildSearchIndexLocked()
 }
 

--- a/core/graphcache/search_test.go
+++ b/core/graphcache/search_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"math/rand"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -128,6 +129,71 @@ func TestGraphCacheSearchAnalysisLimits(t *testing.T) {
 		}
 		if got := keys(c.SearchVertices("alpha beta", 10, "")); !reflect.DeepEqual(got, []string{"before", "during"}) {
 			t.Fatalf("rebuilt results = %v", got)
+		}
+	})
+}
+
+func TestGraphCache_SearchRecoveryLockOrder(t *testing.T) {
+	newCache := func() *GraphCache[string, string] {
+		c := NewGraphCache[string, string](time.Minute)
+		c.EnableSearchIndex(textExtract, compareStringID)
+		return c
+	}
+	assertGraphLockFirst := func(t *testing.T, c *GraphCache[string, string], recover func() error) {
+		t.Helper()
+		// Hold the graph lock so recovery must wait at its first acquisition.
+		// If recovery takes searchCommitMu first, TryRLock observes the reversed
+		// order before we release mu, without leaving a deadlocked goroutine.
+		c.mu.Lock()
+		started := make(chan struct{})
+		done := make(chan error, 1)
+		go func() {
+			close(started)
+			done <- recover()
+		}()
+		<-started
+
+		searchLockedFirst := false
+		for range 1_000 {
+			runtime.Gosched()
+			if !c.searchCommitMu.TryRLock() {
+				searchLockedFirst = true
+				break
+			}
+			c.searchCommitMu.RUnlock()
+		}
+		c.mu.Unlock()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("recovery: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("recovery did not complete after graph lock release")
+		}
+		if searchLockedFirst {
+			t.Fatal("recovery acquired searchCommitMu while GraphCache.mu was unavailable")
+		}
+	}
+
+	t.Run("begin", func(t *testing.T) {
+		c := newCache()
+		assertGraphLockFirst(t, c, func() error {
+			c.BeginSearchIndexRecovery()
+			return nil
+		})
+		if got := c.SearchIndexMemoryStats().Health; got != search.IndexIncomplete {
+			t.Fatalf("health after begin = %q", got)
+		}
+	})
+
+	t.Run("complete", func(t *testing.T) {
+		c := newCache()
+		c.BeginSearchIndexRecovery()
+		assertGraphLockFirst(t, c, c.CompleteSearchIndexRecovery)
+		if got := c.SearchIndexMemoryStats().Health; got != search.IndexHealthy {
+			t.Fatalf("health after complete = %q", got)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- preserve the canonical `GraphCache.mu -> searchCommitMu` order in both search-index recovery boundaries
- keep the index fail-closed while snapshot or restore replay is in progress
- add a deterministic lock-order regression test for both begin and complete

## Root cause

The post-merge nightly run wedged one replica during `broad_rw`: goroutines grew from 34 to 321 and then 609 while vertex writes and scans timed out. Normal vertex writes acquire `GraphCache.mu` before `searchCommitMu`, but the recovery methods introduced by #1083 acquired them in the opposite order. The benchmark intentionally drives mutation-log gaps and snapshot recovery concurrently with writes, exposing the lock cycle.

The new test holds `GraphCache.mu` and proves recovery does not acquire `searchCommitMu` while waiting. It fails for both methods on the old implementation and passes repeatedly with this change.

## Validation

- `go test ./graphcache -run 'TestGraphCache_(SearchRecoveryLockOrder|SearchAnalysisLimits)$' -count=100`
- `go test -race ./graphcache -run 'TestGraphCache_(SearchRecoveryLockOrder|SearchAnalysisLimits)$' -count=10`
- `go test ./tests/integration -run 'Test(SearchIndexRestoreConvergenceOverWire|Snapshot_E2E_PrimaryToFollower)$' -count=10`
- `go test ./...` from root and every Go submodule
- `go vet ./...` in `server/`
- Dart exact format, analyze, and test gates

Closes #1089
