### PR TITLE
test(bench): re-baseline broad_illuminate gates (#1090)

### DIFF
--- a/testbed/bench/scenarios/broad_illuminate.yaml
+++ b/testbed/bench/scenarios/broad_illuminate.yaml
@@ -68,20 +68,23 @@ target:
 leak_gate:
   goroutine_max_delta: 25
   heap_alloc_max_delta_mb: 32
-# Re-baselined locally on 2026-07-11 after replacing the linear k-* fixture
-# with the real topology: aggregate 2094 RPS, worst p99 219.43 ms, worst
-# heap_alloc delta 1.16 MiB, zero goroutine growth. Floors retain >2× RPS and
-# >4× latency/heap headroom; the first nightly runs refresh the canonical
-# shared-runner record. Individual gates prevent a cheap raw BFS producer from
-# masking a regression in PPR, community, or the depth-3/fan-out-64 path.
+# Re-baselined from hosted ubuntu-latest runs after replacing the linear k-*
+# fixture with the verified topology. The 2026-07-12 run (29205455324) and
+# 2026-07-13 rerun attempt 2 (29279299107) measured 342.4-347.8 aggregate RPS
+# and 2226.99-2238.62 ms worst p99. Per-producer minima/maxima across those
+# runs were: raw 50.3/997.17, arborescence 85.6/563.77, SPT 57.0/838.52,
+# depth-3 14.3/2238.62, PPR 79.6/607.59, and community 37.2/1226.10.
+# Floors keep >2x headroom below the lowest hosted throughput; ceilings keep
+# >=2x headroom above the highest hosted p99. Individual gates prevent a cheap
+# raw BFS producer from masking PPR, community, or depth-3 regressions.
 perf_gate:
-  min_steady_rps_total: 1000
-  max_p99_ms: 1000
+  min_steady_rps_total: 150
+  max_p99_ms: 5000
   max_non_ok_ratio: 0.02
   producers:
-    bfs_raw: { min_steady_rps: 50, max_p99_ms: 1000, max_non_ok_ratio: 0.02 }
-    bfs_arborescence_min: { min_steady_rps: 50, max_p99_ms: 1000, max_non_ok_ratio: 0.02 }
-    bfs_spt_tfidf: { min_steady_rps: 50, max_p99_ms: 1000, max_non_ok_ratio: 0.02 }
-    bfs_depth3_fanout64: { min_steady_rps: 50, max_p99_ms: 1000, max_non_ok_ratio: 0.02 }
-    ppr_tuned: { min_steady_rps: 50, max_p99_ms: 1000, max_non_ok_ratio: 0.02 }
-    community_arborescence_min: { min_steady_rps: 50, max_p99_ms: 1000, max_non_ok_ratio: 0.02 }
+    bfs_raw: { min_steady_rps: 20, max_p99_ms: 2000, max_non_ok_ratio: 0.02 }
+    bfs_arborescence_min: { min_steady_rps: 40, max_p99_ms: 1250, max_non_ok_ratio: 0.02 }
+    bfs_spt_tfidf: { min_steady_rps: 25, max_p99_ms: 2000, max_non_ok_ratio: 0.02 }
+    bfs_depth3_fanout64: { min_steady_rps: 6, max_p99_ms: 5000, max_non_ok_ratio: 0.02 }
+    ppr_tuned: { min_steady_rps: 35, max_p99_ms: 1500, max_non_ok_ratio: 0.02 }
+    community_arborescence_min: { min_steady_rps: 15, max_p99_ms: 3000, max_non_ok_ratio: 0.02 }

--- a/testbed/bench/scenarios/broad_illuminate.yaml
+++ b/testbed/bench/scenarios/broad_illuminate.yaml
@@ -69,11 +69,11 @@ leak_gate:
   goroutine_max_delta: 25
   heap_alloc_max_delta_mb: 32
 # Re-baselined from hosted ubuntu-latest runs after replacing the linear k-*
-# fixture with the verified topology. The 2026-07-12 run (29205455324) and
-# 2026-07-13 rerun attempt 2 (29279299107) measured 342.4-347.8 aggregate RPS
-# and 2226.99-2238.62 ms worst p99. Per-producer minima/maxima across those
-# runs were: raw 50.3/997.17, arborescence 85.6/563.77, SPT 57.0/838.52,
-# depth-3 14.3/2238.62, PPR 79.6/607.59, and community 37.2/1226.10.
+# fixture with the verified topology. Runs 29205455324, 29279299107 (attempt
+# 2), and 29283812783 measured 342.4-380.1 aggregate RPS and 2226.99-2301.95
+# ms worst p99. Per-producer minima/maxima across those runs were: raw
+# 50.3/997.17, arborescence 85.6/563.77, SPT 57.0/838.52, depth-3
+# 14.0/2301.95, PPR 79.6/607.59, and community 37.2/1226.10.
 # Floors keep >2x headroom below the lowest hosted throughput; ceilings keep
 # >=2x headroom above the highest hosted p99. Individual gates prevent a cheap
 # raw BFS producer from masking PPR, community, or depth-3 regressions.


### PR DESCRIPTION
Closes #1090

## Summary

- re-baseline `broad_illuminate` aggregate and named-producer perf gates from comparable `ubuntu-latest` reports over the verified topology
- retain more than 2x throughput headroom below the lowest hosted sample and at least 2x latency headroom above the highest hosted sample
- preserve topology preflight, leak gates, non-OK gates, and an independent gate for every BFS, PPR, and community producer

## Hosted evidence

- run 29205455324: 342.4 aggregate RPS, 2238.62 ms worst p99
- run 29279299107 attempt 2: 347.8 aggregate RPS, 2226.99 ms worst p99
- run 29283812783: 380.1 aggregate RPS, 2301.95 ms worst p99
- final full release sweep [29297043528](https://github.com/anaregdesign/lantern/actions/runs/29297043528) on integrated commit `f1e4ecc`: all seven scenarios pass; `broad_illuminate` records 381.5 aggregate RPS, 2403.12 ms worst p99, and 0.00159 non-OK ratio
- every named `broad_illuminate` producer passes its throughput, p99, and non-OK gate; leak deltas are 0 goroutines and at most +0.7 MiB live heap across replicas

## Validation

- final untruncated full nightly/release sweep: leak and perf gates pass for all seven scenarios; `search_churn` metric and semantic gates also pass
- `go test ./testbed/bench/... -count=1`
- `gofmt -l .`
- `go test ./...` in the root, `pb`, `core`, `sdks/go`, `server`, and `mcp` modules
- `go vet ./...` in `server`
- Dart SDK format, locked dependency resolution, analyze, test, dartdoc link validation, and publish dry-run
- Flutter example format, locked dependency resolution, analyze, and test

## Trade-off

The former 1000 RPS / 1000 ms values came from a single local run after #1015 materially changed the workload. The new values intentionally detect step-change regressions on shared runners rather than normal hosted-runner jitter, following `testbed/bench/README.md`.
