### PR TITLE
fix(bench): make search semantic verification deterministic (#1093)

### DIFF
--- a/testbed/bench/report/render.go
+++ b/testbed/bench/report/render.go
@@ -154,6 +154,7 @@ type SemanticGateReplica struct {
 	Endpoint string `json:"endpoint"`
 	Checks   int    `json:"checks"`
 	Verdict  string `json:"verdict"`
+	Failure  string `json:"failure,omitempty"`
 }
 
 // GhzSummary captures the subset of fields ghz writes that the report uses.
@@ -374,15 +375,19 @@ func RenderReport(w io.Writer, in Input) error {
 	if in.SemanticPre == nil && in.SemanticPost == nil {
 		bw.printf("_not configured_\n\n")
 	} else {
-		bw.printf("The bounded report records only phase/check counts; query text, prefixes, keys, and values are omitted.\n\n")
-		bw.printf("| phase | replica | checks | verdict |\n")
-		bw.printf("| --- | --- | ---: | --- |\n")
+		bw.printf("The bounded report records only phase/check counts and a non-sensitive failed-check category; query text, prefixes, keys, and values are omitted.\n\n")
+		bw.printf("| phase | replica | checks | verdict | failed check |\n")
+		bw.printf("| --- | --- | ---: | --- | --- |\n")
 		for _, gate := range []*SemanticGate{in.SemanticPre, in.SemanticPost} {
 			if gate == nil {
 				continue
 			}
 			for _, replica := range gate.Replicas {
-				bw.printf("| `%s` | `%s` | %d | `%s` |\n", gate.Phase, replica.Endpoint, replica.Checks, replica.Verdict)
+				failure := "—"
+				if replica.Failure != "" {
+					failure = fmt.Sprintf("`%s`", replica.Failure)
+				}
+				bw.printf("| `%s` | `%s` | %d | `%s` | %s |\n", gate.Phase, replica.Endpoint, replica.Checks, replica.Verdict, failure)
 			}
 		}
 		bw.printf("\n")

--- a/testbed/bench/report/render_test.go
+++ b/testbed/bench/report/render_test.go
@@ -189,7 +189,7 @@ func TestRenderReport_ShowsMetricAndSemanticGates(t *testing.T) {
 		Ratio:    &ratio,
 		Verdict:  "pass",
 	}}}
-	semanticPre := &SemanticGate{Phase: "pre", Verdict: "pass", Replicas: []SemanticGateReplica{{Endpoint: "http://localhost:6380", Checks: 11, Verdict: "pass"}}}
+	semanticPre := &SemanticGate{Phase: "pre", Verdict: "fail", Replicas: []SemanticGateReplica{{Endpoint: "http://localhost:6380", Checks: 11, Verdict: "fail", Failure: "deep_pagination"}}}
 	semanticPost := &SemanticGate{Phase: "post", Verdict: "pass", Replicas: []SemanticGateReplica{{Endpoint: "http://localhost:6380", Checks: 11, Verdict: "pass"}}}
 
 	var buf bytes.Buffer
@@ -199,12 +199,13 @@ func TestRenderReport_ShowsMetricAndSemanticGates(t *testing.T) {
 	out := buf.String()
 	for _, want := range []string{
 		"**Metric gate verdict:** `pass`",
-		"**Semantic gate verdict:** `pass`",
+		"**Semantic gate verdict:** `fail`",
 		"## Metric gate",
 		"`lantern_search_index_docs`",
 		"100 | 105 | 5 | 1.05",
 		"## Semantic gate",
-		"| `pre` | `http://localhost:6380` | 11 | `pass` |",
+		"| `pre` | `http://localhost:6380` | 11 | `fail` | `deep_pagination` |",
+		"| `post` | `http://localhost:6380` | 11 | `pass` | — |",
 		"query text, prefixes, keys, and values are omitted",
 	} {
 		if !strings.Contains(out, want) {

--- a/testbed/bench/run.sh
+++ b/testbed/bench/run.sh
@@ -97,6 +97,14 @@ TS="$(date -u +%Y%m%dT%H%M%SZ)"
 OUTDIR="$HERE/out/${SCENARIO_NAME}/${TS}"
 mkdir -p "$OUTDIR/prom" "$OUTDIR/pprof"
 
+render_report() {
+  (
+    cd "$REPO_ROOT"
+    go run ./testbed/bench/report -dir "$OUTDIR" -scenario "$SCENARIO_NAME" -timestamp "$TS"
+  ) > "$OUTDIR/report.md"
+  log "report: $OUTDIR/report.md"
+}
+
 # Parse common scenario fields up-front.
 warmup_duration="$(yq -r '.phases.warmup.duration' "$SCENARIO_FILE")"
 warmup_conc="$(yq -r '.phases.warmup.concurrency' "$SCENARIO_FILE")"
@@ -376,9 +384,15 @@ warm_data="$(yq -r '.target.data_template // .target.calls[0].data_template' "$S
 run_ghz warmup "${endpoints[0]}" "$warm_call" "$warm_data" "$warmup_conc" "$warmup_rps" "$warmup_duration" >/dev/null
 
 # ----- PRE snapshot (after warmup) -------------------------------------------
+semantic_verdict="skipped"
 if [[ "$semantic_kind" == "search" ]]; then
   log "semantic gate: verify every replica before steady load"
-  run_search_probe verify pre
+  if ! run_search_probe verify pre; then
+    semantic_verdict="fail"
+    render_report
+    exit 1
+  fi
+  semantic_verdict="pass"
 fi
 snapshot_runtime "$OUTDIR/runtime_pre.json"
 if [[ "${LEAK_GATE_ONLY:-0}" != "1" ]]; then
@@ -491,7 +505,9 @@ sleep "${cooldown%s}"
 # ----- POST snapshot ---------------------------------------------------------
 if [[ "$semantic_kind" == "search" ]]; then
   log "semantic gate: verify every replica after cooldown"
-  run_search_probe verify post
+  if ! run_search_probe verify post; then
+    semantic_verdict="fail"
+  fi
 fi
 snapshot_runtime "$OUTDIR/runtime_post.json"
 
@@ -694,13 +710,9 @@ fi
 log "perf gate verdict: $perf_verdict"
 
 # ----- Render report ---------------------------------------------------------
-(
-  cd "$REPO_ROOT"
-  go run ./testbed/bench/report -dir "$OUTDIR" -scenario "$SCENARIO_NAME" -timestamp "$TS"
-) > "$OUTDIR/report.md"
-log "report: $OUTDIR/report.md"
+render_report
 
 # ----- Teardown --------------------------------------------------------------
 cleanup
 
-if [[ "$verdict" == "pass" && "$metric_verdict" != "fail" && "$perf_verdict" != "fail" ]]; then exit 0; else exit 1; fi
+if [[ "$verdict" == "pass" && "$metric_verdict" != "fail" && "$semantic_verdict" != "fail" && "$perf_verdict" != "fail" ]]; then exit 0; else exit 1; fi

--- a/testbed/bench/scenarios_gate_test.go
+++ b/testbed/bench/scenarios_gate_test.go
@@ -229,6 +229,15 @@ func TestSearchChurnScenarioGateContract(t *testing.T) {
 	if !strings.Contains(string(runScript), `any(.producer_results[]; .verdict == "fail")`) {
 		t.Error("perf gate does not conjunctively fold named producer failures")
 	}
+	for _, fragment := range []string{
+		`if ! run_search_probe verify pre; then`,
+		`if ! run_search_probe verify post; then`,
+		`semantic_verdict" != "fail"`,
+	} {
+		if !strings.Contains(string(runScript), fragment) {
+			t.Errorf("semantic gate failure path missing %q", fragment)
+		}
+	}
 }
 
 // TestSearchReleaseQualificationIsBlocking pins the release dependency rather

--- a/testbed/bench/searchprobe/main.go
+++ b/testbed/bench/searchprobe/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	client "github.com/anaregdesign/lantern/sdks/go"
@@ -22,6 +23,7 @@ const (
 	alphaKey   = "bench:search:probe:01"
 	betaKey    = "bench:search:probe:02"
 	gammaKey   = "bench:search:probe:03"
+	pagePrefix = "bench:search:page:"
 )
 
 type writer interface {
@@ -33,6 +35,13 @@ type searcher interface {
 	SearchVertices(context.Context, string, ...client.SearchOption) ([]client.SearchHit, error)
 	SearchVerticesPage(context.Context, string, ...client.SearchOption) (client.SearchPage, error)
 }
+
+type searchClient interface {
+	searcher
+	Close() error
+}
+
+type searchDialer func(string) (searchClient, error)
 
 type check struct {
 	Name     string
@@ -47,6 +56,7 @@ type replicaReport struct {
 	Endpoint string `json:"endpoint"`
 	Checks   int    `json:"checks"`
 	Verdict  string `json:"verdict"`
+	Failure  string `json:"failure,omitempty"`
 }
 
 type probeReport struct {
@@ -86,23 +96,9 @@ func main() {
 		if *phase != "pre" && *phase != "post" {
 			fatalf("verify mode requires -phase pre or -phase post")
 		}
-		rep := probeReport{Phase: *phase, Verdict: "pass"}
-		for _, endpoint := range endpoints {
-			lantern, err := client.NewLantern(endpoint)
-			if err != nil {
-				rep.Verdict = "fail"
-				rep.Replicas = append(rep.Replicas, replicaReport{Endpoint: endpoint, Verdict: "fail"})
-				continue
-			}
-			err = waitForChecks(ctx, lantern)
-			_ = lantern.Close()
-			if err != nil {
-				rep.Verdict = "fail"
-				rep.Replicas = append(rep.Replicas, replicaReport{Endpoint: endpoint, Checks: searchCheckCount(), Verdict: "fail"})
-				continue
-			}
-			rep.Replicas = append(rep.Replicas, replicaReport{Endpoint: endpoint, Checks: searchCheckCount(), Verdict: "pass"})
-		}
+		rep := verifyReplicas(ctx, *phase, endpoints, func(endpoint string) (searchClient, error) {
+			return client.NewLantern(endpoint)
+		})
 		writeReport(*reportPath, rep)
 		if rep.Verdict != "pass" {
 			fatalf("semantic verification failed; see bounded report")
@@ -123,7 +119,7 @@ func seed(ctx context.Context, w writer, now time.Time) error {
 	}
 	for i := range 9 {
 		inputs = append(inputs, client.VertexInput{
-			Key:   fmt.Sprintf("bench:search:page:%02d", i),
+			Key:   fmt.Sprintf("%s%02d", pagePrefix, i),
 			Value: "deeppaginationbeacon",
 		})
 	}
@@ -138,6 +134,44 @@ func seed(ctx context.Context, w writer, now time.Time) error {
 		return errors.New("delete sentinel was not written")
 	}
 	return nil
+}
+
+// verifyReplicas starts every replica check under the same bounded context.
+// A permanently unsatisfied contract on one replica therefore cannot consume
+// the whole probe budget before the other replicas produce useful evidence.
+func verifyReplicas(ctx context.Context, phase string, endpoints []string, dial searchDialer) probeReport {
+	reports := make([]replicaReport, len(endpoints))
+	var wg sync.WaitGroup
+	for i, endpoint := range endpoints {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			report := replicaReport{Endpoint: endpoint, Checks: searchCheckCount(), Verdict: "pass"}
+			lantern, err := dial(endpoint)
+			if err != nil {
+				report.Verdict = "fail"
+				report.Failure = "dial"
+				reports[i] = report
+				return
+			}
+			defer func() { _ = lantern.Close() }()
+			if err := waitForChecks(ctx, lantern); err != nil {
+				report.Verdict = "fail"
+				report.Failure = semanticFailureName(err)
+			}
+			reports[i] = report
+		}()
+	}
+	wg.Wait()
+
+	rep := probeReport{Phase: phase, Verdict: "pass", Replicas: reports}
+	for _, report := range reports {
+		if report.Verdict != "pass" {
+			rep.Verdict = "fail"
+			break
+		}
+	}
+	return rep
 }
 
 func searchCheckCount() int { return len(searchChecks()) + 1 }
@@ -168,7 +202,7 @@ func waitForChecks(ctx context.Context, s searcher) error {
 	var last error
 	for {
 		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("semantic checks did not converge: %v: %w", last, err)
+			return convergenceFailure(last, err)
 		}
 		last = verifyOnce(ctx, s)
 		if last == nil {
@@ -177,45 +211,75 @@ func waitForChecks(ctx context.Context, s searcher) error {
 		select {
 		case <-time.After(250 * time.Millisecond):
 		case <-ctx.Done():
-			return fmt.Errorf("semantic checks did not converge: %v: %w", last, ctx.Err())
+			return convergenceFailure(last, ctx.Err())
 		}
 	}
+}
+
+type semanticFailure struct {
+	name string
+	err  error
+}
+
+func (e *semanticFailure) Error() string { return fmt.Sprintf("%s: %v", e.name, e.err) }
+func (e *semanticFailure) Unwrap() error { return e.err }
+
+func newSemanticFailure(name string, err error) error {
+	return &semanticFailure{name: name, err: err}
+}
+
+func semanticFailureName(err error) string {
+	var failure *semanticFailure
+	if errors.As(err, &failure) && failure.name != "" {
+		return failure.name
+	}
+	return "unknown"
+}
+
+func convergenceFailure(last, cause error) error {
+	return newSemanticFailure(
+		semanticFailureName(last),
+		fmt.Errorf("semantic checks did not converge: %v: %w", last, cause),
+	)
 }
 
 func verifyOnce(ctx context.Context, s searcher) error {
 	for _, c := range searchChecks() {
 		hits, err := c.Run(ctx, s)
 		if err != nil {
-			return fmt.Errorf("%s: %w", c.Name, err)
+			return newSemanticFailure(c.Name, err)
 		}
 		got := make([]string, len(hits))
 		for i, hit := range hits {
 			got[i] = hit.Key
 		}
 		if c.Want != nil && !slices.Equal(got, c.Want) {
-			return fmt.Errorf("%s: ordered keys = %v, want %v", c.Name, got, c.Want)
+			return newSemanticFailure(c.Name, fmt.Errorf("ordered keys = %v, want %v", got, c.Want))
 		}
 		if len(got) < len(c.Top) || !slices.Equal(got[:len(c.Top)], c.Top) {
-			return fmt.Errorf("%s: top ordered keys do not match", c.Name)
+			return newSemanticFailure(c.Name, errors.New("top ordered keys do not match"))
 		}
 		for _, key := range c.Contains {
 			if !slices.Contains(got, key) {
-				return fmt.Errorf("%s: required key is absent", c.Name)
+				return newSemanticFailure(c.Name, errors.New("required key is absent"))
 			}
 		}
 		for _, key := range c.Excludes {
 			if slices.Contains(got, key) {
-				return fmt.Errorf("%s: forbidden key is present", c.Name)
+				return newSemanticFailure(c.Name, errors.New("forbidden key is present"))
 			}
 		}
 	}
-	return verifyDeepPagination(ctx, s)
+	if err := verifyDeepPagination(ctx, s); err != nil {
+		return newSemanticFailure("deep_pagination", err)
+	}
+	return nil
 }
 
 func verifyDeepPagination(ctx context.Context, s searcher) error {
 	want := make([]string, 9)
 	for i := range want {
-		want[i] = fmt.Sprintf("bench:search:page:%02d", i)
+		want[i] = fmt.Sprintf("%s%02d", pagePrefix, i)
 	}
 	var got []string
 	var cursor []byte
@@ -225,6 +289,7 @@ func verifyDeepPagination(ctx context.Context, s searcher) error {
 			ctx,
 			"deeppaginationbeacon",
 			client.WithSearchLimit(2),
+			client.WithSearchPrefix(pagePrefix),
 			client.WithFullVertex(),
 			client.WithSearchCursor(cursor),
 		)

--- a/testbed/bench/searchprobe/main_test.go
+++ b/testbed/bench/searchprobe/main_test.go
@@ -171,7 +171,7 @@ func TestVerifyDeepPaginationScopesEveryPage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer lantern.Close()
+	defer func() { _ = lantern.Close() }()
 	if err := verifyDeepPagination(context.Background(), lantern); err != nil {
 		t.Fatal(err)
 	}

--- a/testbed/bench/searchprobe/main_test.go
+++ b/testbed/bench/searchprobe/main_test.go
@@ -3,12 +3,17 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"connectrpc.com/connect"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
 	client "github.com/anaregdesign/lantern/sdks/go"
 )
 
@@ -36,6 +41,8 @@ func (f *fakeSearcher) SearchVerticesPage(context.Context, string, ...client.Sea
 	f.pageCall++
 	return page, nil
 }
+
+func (f *fakeSearcher) Close() error { return nil }
 
 func successfulPaginationPages() []client.SearchPage {
 	pages := make([]client.SearchPage, 0, 5)
@@ -111,6 +118,114 @@ func TestVerifyOnce(t *testing.T) {
 	})
 }
 
+type paginationCapture struct {
+	graphv1connect.UnimplementedLanternServiceHandler
+	requests []*pb.SearchVerticesRequest
+}
+
+func (c *paginationCapture) SearchVertices(_ context.Context, req *connect.Request[pb.SearchVerticesRequest]) (*connect.Response[pb.SearchVerticesResponse], error) {
+	c.requests = append(c.requests, req.Msg)
+	start := 0
+	if cursor := req.Msg.GetCursor(); len(cursor) > 0 {
+		start = int(cursor[0])
+	}
+	end := min(start+2, 9)
+	hits := make([]*pb.SearchHit, 0, end-start)
+	for i := start; i < end; i++ {
+		key := fmt.Sprintf("%s%02d", pagePrefix, i)
+		hits = append(hits, &pb.SearchHit{
+			Key: key,
+			Vertex: &pb.Vertex{
+				Key:   key,
+				Value: &pb.Vertex_String_{String_: "deeppaginationbeacon"},
+			},
+			ProjectionStatus: pb.SearchHitProjectionStatus_SEARCH_HIT_PROJECTION_STATUS_SNAPSHOT,
+		})
+	}
+	var next []byte
+	if end < 9 {
+		next = []byte{byte(end)}
+	}
+	return connect.NewResponse(&pb.SearchVerticesResponse{
+		Hits:           hits,
+		NextCursor:     next,
+		EffectiveLimit: 2,
+		Truncated:      end < 9,
+	}), nil
+}
+
+func TestVerifyDeepPaginationScopesEveryPage(t *testing.T) {
+	capture := &paginationCapture{}
+	path, handler := graphv1connect.NewLanternServiceHandler(capture)
+	mux := http.NewServeMux()
+	mux.Handle(path, handler)
+	server := httptest.NewUnstartedServer(mux)
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+	server.Config.Protocols = protocols
+	server.Start()
+	defer server.Close()
+
+	lantern, err := client.NewLantern(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lantern.Close()
+	if err := verifyDeepPagination(context.Background(), lantern); err != nil {
+		t.Fatal(err)
+	}
+	if len(capture.requests) != 5 {
+		t.Fatalf("requests = %d, want 5", len(capture.requests))
+	}
+	for i, request := range capture.requests {
+		if request.GetPrefix() != pagePrefix {
+			t.Errorf("request %d prefix = %q, want %q", i+1, request.GetPrefix(), pagePrefix)
+		}
+	}
+}
+
+type blockingSearchClient struct {
+	started chan<- struct{}
+}
+
+func (b *blockingSearchClient) SearchVertices(ctx context.Context, _ string, _ ...client.SearchOption) ([]client.SearchHit, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	b.started <- struct{}{}
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (b *blockingSearchClient) SearchVerticesPage(context.Context, string, ...client.SearchOption) (client.SearchPage, error) {
+	return client.SearchPage{}, nil
+}
+
+func (b *blockingSearchClient) Close() error { return nil }
+
+func TestVerifyReplicasRunsConcurrentlyAndReportsCheckCategory(t *testing.T) {
+	started := make(chan struct{}, 3)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	report := verifyReplicas(ctx, "pre", []string{"a", "b", "c"}, func(string) (searchClient, error) {
+		return &blockingSearchClient{started: started}, nil
+	})
+	if len(started) != 3 {
+		t.Fatalf("started replicas = %d, want 3", len(started))
+	}
+	if report.Verdict != "fail" || len(report.Replicas) != 3 {
+		t.Fatalf("report = %+v", report)
+	}
+	for _, replica := range report.Replicas {
+		if replica.Verdict != "fail" || replica.Failure != "live_sentinel" {
+			t.Errorf("replica = %+v", replica)
+		}
+	}
+}
+
 func TestWaitForChecksPreservesSemanticFailureAtDeadline(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
@@ -129,6 +244,7 @@ func TestFailureReportIsBounded(t *testing.T) {
 			Endpoint: "http://localhost:6380",
 			Checks:   searchCheckCount(),
 			Verdict:  "fail",
+			Failure:  "deep_pagination",
 		}},
 	})
 	raw, err := os.ReadFile(path)
@@ -139,6 +255,9 @@ func TestFailureReportIsBounded(t *testing.T) {
 		if strings.Contains(string(raw), forbidden) {
 			t.Errorf("bounded report contains fixture data %q: %s", forbidden, raw)
 		}
+	}
+	if !strings.Contains(string(raw), `"failure": "deep_pagination"`) {
+		t.Fatalf("bounded report omitted failure category: %s", raw)
 	}
 }
 


### PR DESCRIPTION
Closes #1093

## Summary

- scope every deep-pagination cursor request to the dedicated `bench:search:page:` fixture namespace
- verify all replicas concurrently under one bounded deadline, so one non-converging replica cannot consume the evidence budget before the others run
- preserve a non-sensitive failed-check category in semantic JSON and rendered reports, including pre-steady failures that previously exited before `report.md` existed

## Root cause

The query `deeppaginationbeacon` also matched non-page `bench:search:*` fixtures through analyzer grams. Every replica returned 13 hits while the probe expected exactly 9 page-fixture hits, so it retried the unchanged mismatch until the 90-second deadline. Applying the page-key prefix to the initial request and every cursor continuation produces the intended 9-hit snapshot.

## Validation

- regression test fails when the prefix option is removed and passes with it
- `go test -race ./testbed/bench/searchprobe -count=10`
- `go test ./testbed/bench/... -count=10`
- fresh three-replica real-wire run: pre/post semantic gate passed 12 checks on all replicas; leak and perf gates passed
- `gofmt -l .`
- `go test ./...` in the root, `pb`, `core`, `sdks/go`, `server`, and `mcp` modules
- `go vet ./...` in `server`
- Dart SDK format, locked dependency resolution, analyze, test, dartdoc link validation, and publish dry-run
- Flutter example format, locked dependency resolution, analyze, and test

## Follow-up discovered by the complete run

The run's only remaining failure was the separate retained-ratio metric contract tracked in #1094: the production compaction floor allows a small, shrinking below-floor retained state that the unconditional ratio ceiling rejects. That scenario change remains out of this PR.
