### PR TITLE
fix(bench): align retained-ratio gate with compaction floor (#1094)

### DIFF
--- a/testbed/bench/scenarios/search_churn.yaml
+++ b/testbed/bench/scenarios/search_churn.yaml
@@ -26,6 +26,10 @@
 # forward; healthy must remain exactly 1. The semantic gate independently
 # checks a persistent hit, deleted/expired absence, stable ordering, key prefix,
 # phrase, fuzzy-1/2, prefix terms, ALL, and MIN_SHOULD before and after load.
+# retained_ratio is intentionally a no-growth pre/post gate instead of an
+# absolute ceiling: production compaction allows fewer than 10,000 retired
+# entries to remain, so a small live denominator can legitimately produce a
+# ratio above 3 while every absolute retained-size gauge stays bounded.
 #
 # The bench cluster runs search on by default (LANTERN_SEARCH_ENABLED=true).
 # The explicit expiration template below is required: omitting Vertex.expiration
@@ -132,7 +136,7 @@ metric_gate:
     lantern_search_index_postings: { max_increase: 2048, max_ratio: 1.5 }
     lantern_search_index_position_entries: { max_increase: 4096, max_ratio: 1.5 }
     lantern_search_index_estimated_retained_bytes: { max_increase: 67108864, max_ratio: 2 }
-    lantern_search_index_retained_ratio: { max_post: 3 }
+    lantern_search_index_retained_ratio: { max_increase: 0, max_ratio: 1 }
     lantern_search_index_healthy: { min_post: 1, max_post: 1 }
 # The producer mix changed for #1049, so these are deliberately loose first-
 # night ratchets with ample headroom. Tighten from several green nightly runs;

--- a/testbed/bench/scenarios_gate_test.go
+++ b/testbed/bench/scenarios_gate_test.go
@@ -181,6 +181,16 @@ func TestSearchChurnScenarioGateContract(t *testing.T) {
 			t.Errorf("metric %s has no threshold", metric)
 		}
 	}
+	retainedRatio := doc.MetricGate.Metrics["lantern_search_index_retained_ratio"]
+	if increase, ok := retainedRatio["max_increase"]; !ok || increase != 0 {
+		t.Errorf("retained ratio max_increase = %v, present %t; want 0, true", increase, ok)
+	}
+	if ratio, ok := retainedRatio["max_ratio"]; !ok || ratio != 1 {
+		t.Errorf("retained ratio max_ratio = %v, present %t; want 1, true", ratio, ok)
+	}
+	if _, ok := retainedRatio["max_post"]; ok {
+		t.Error("retained ratio must not use an absolute max_post")
+	}
 
 	calls := make(map[string]string, len(doc.Target.Calls))
 	totalRPS := 0


### PR DESCRIPTION
Closes #1094

## Summary
- replace the absolute retained-ratio ceiling with a no-growth pre/post contract
- preserve every absolute retained-size and index-health gate
- pin the ratio contract in the scenario quality gate

## Evidence
- the failed local search_churn run now passes the complete metric gate
- retained ratio decreased on all replicas (1.0676→1, 29.8107→22.0384, 29.7716→1)
- `go test ./testbed/bench/...`
- full repository pre-push quality gate (all Go modules, go vet, Dart SDK, Flutter example)