### PR TITLE
fix(bench): isolate release scenario clusters (#1097)

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -44,7 +44,8 @@ jobs:
     # mid-sweep before it could render a verdict. The fix is NOT a bigger cap but
     # LEAK_GATE_ONLY=1 below, which drops the diagnostic captures the gate never
     # reads (24 pprof + 12 prom curls per scenario); that returns the sweep to
-    # ~deterministic phase time (~23 min) + image build/setup, ~35-40 min total.
+    # ~deterministic phase time plus isolated cluster lifecycles (~25-26 min)
+    # and image build/setup, ~35-40 min total.
     # 50 min leaves headroom for a slow cold build while still bounding a wedged
     # scenario — and is well under the rejected 90 min.
     timeout-minutes: 50

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -281,13 +281,14 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     continue-on-error: true
-    # The compact sweep is ~20 min of scenario loop (see release-scenarios.txt, #573, #708).
+    # The compact sweep is ~25-26 min including the isolated per-scenario
+    # cluster lifecycles (see release-scenarios.txt and #1097).
     # release.sh self-bounds via RELEASE_BENCH_BUDGET_SECONDS (default 27 min) and
     # always aggregates a report before returning, so this `timeout-minutes` is
     # only a hard backstop — sized above the budget plus one scenario's worst-case
     # overshoot plus job overhead (checkout + Go + ghz/yq + docker build + compose)
     # so the script's graceful cutoff fires first and the report is never discarded
-    # by a mid-loop cancellation. See issues #571, #573, and #708.
+    # by a mid-loop cancellation. See issues #571, #573, #708, and #1097.
     timeout-minutes: 45
     permissions:
       contents: read

--- a/testbed/bench/README.md
+++ b/testbed/bench/README.md
@@ -16,7 +16,9 @@ Markdown report.
 >
 > **Release CI runs a compact canonical sweep.** On every `vX.Y.Z` tag
 > push, the `Release` workflow runs `./testbed/bench/release.sh` — a
-> driver that sweeps the scenarios listed in `release-scenarios.txt`. To
+> driver that sweeps the scenarios listed in `release-scenarios.txt`. Each
+> scenario owns a fresh Compose lifecycle so data, retained high-water state,
+> and scenario-specific cluster env cannot leak into its successor (#1097). To
 > keep wall-time bounded without losing coverage, the sweep is seven
 > scenarios: three fan-out scenarios (`broad_rw`, `broad_mutate`,
 > `broad_illuminate`) that
@@ -29,13 +31,15 @@ Markdown report.
 > fixed-format `bench-report.md` that is spliced into the GitHub Release
 > notes. This full profiling sweep remains `continue-on-error`, so a noisy
 > runner cannot block a release; it is separate from the short blocking Search
-> qualification above. See issues [#256], [#262], [#573], [#708], [#1063].
+> qualification above. See issues [#256], [#262], [#573], [#708], [#1063],
+> [#1097].
 
 [#256]: https://github.com/anaregdesign/lantern/issues/256
 [#262]: https://github.com/anaregdesign/lantern/issues/262
 [#573]: https://github.com/anaregdesign/lantern/issues/573
 [#708]: https://github.com/anaregdesign/lantern/issues/708
 [#1063]: https://github.com/anaregdesign/lantern/issues/1063
+[#1097]: https://github.com/anaregdesign/lantern/issues/1097
 
 ## Prerequisites
 

--- a/testbed/bench/release.sh
+++ b/testbed/bench/release.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # release.sh — release-time bench driver.
 #
-# Runs every scenario listed in testbed/bench/release-scenarios.txt against
-# a single shared Compose stack and produces ONE aggregated bench-report.md
-# in the fixed format expected by the release workflow.
+# Runs every scenario listed in testbed/bench/release-scenarios.txt against a
+# fresh Compose stack and produces ONE aggregated bench-report.md in the fixed
+# format expected by the release workflow.
 #
 # Usage:
 #   ./testbed/bench/release.sh [--out PATH]
@@ -27,10 +27,9 @@
 #   2  setup error (missing tools, missing image, etc.)
 #
 # Design notes:
-#   - We DO bring up Compose ourselves once (not inside run.sh) and pass
-#     SKIP_UP=1/KEEP_UP=1 to run.sh for every scenario, so all scenarios
-#     hit the same 3-replica cluster. This keeps wall-time bounded and
-#     ensures every scenario observes the same baseline.
+#   - Each run.sh invocation owns a fresh Compose lifecycle. This prevents
+#     vertices, search high-water state, and scenario-owned cluster overrides
+#     from leaking across measurements while keeping one aggregated report.
 #   - We DO NOT abort on a single scenario failure — the aggregator marks
 #     missing scenarios as `(failed)` rows and the workflow surfaces the
 #     overall verdict via this script's exit code.
@@ -43,10 +42,6 @@ set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$HERE/../.." && pwd)"
-COMPOSE_FILES=(
-  -f "$REPO_ROOT/deploy/compose/docker-compose.yml"
-  -f "$HERE/compose.override.yml"
-)
 export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-lantern-bench-release}"
 
 OUT_PATH="bench-report.md"
@@ -88,11 +83,11 @@ done < "$SCENARIO_LIST"
 # aggregate a partial report and exit cleanly BEFORE the runner hard-kills the
 # job (which would discard the report entirely, leaving the release notes with a
 # placeholder). The default (1620s = 27 min) leaves the compact canonical sweep
-# (~23 min of scenario loop; see release-scenarios.txt, #573, #708, #716)
-# headroom to finish, so it only trips when a runner is abnormally slow or the
-# scenario set grows. Set RELEASE_BENCH_BUDGET_SECONDS=0 to disable (the nightly
-# blocking job in bench-nightly.yml does exactly that so no leak can hide behind
-# a truncated sweep).
+# (~25-26 min including isolated cluster lifecycles; see release-scenarios.txt
+# and #1097) headroom to finish, so it only trips when a runner is abnormally
+# slow or the scenario set grows. Set RELEASE_BENCH_BUDGET_SECONDS=0 to disable
+# (the nightly blocking job in bench-nightly.yml does exactly that so no leak
+# can hide behind a truncated sweep).
 BUDGET_SECONDS="${RELEASE_BENCH_BUDGET_SECONDS:-1620}"
 
 log "release-bench: tag=$TAG commit=$COMMIT_SHORT runner=$RUNNER captured=$CAPTURED"
@@ -105,18 +100,6 @@ if ! docker image inspect "$img" >/dev/null 2>&1; then
   die "docker image $img not found; build it first (e.g. \`docker build -t lantern:local .\`)"
 fi
 export LANTERN_IMAGE="$img"
-
-# Bring up the shared cluster once.
-log "compose up (project=$COMPOSE_PROJECT_NAME, image=$img)"
-# Since #435 the canonical compose declares three explicit lantern-{0,1,2}
-# services, so `--scale lantern=3` is no longer needed.
-docker compose "${COMPOSE_FILES[@]}" up -d --wait
-
-cleanup() {
-  log "compose down"
-  docker compose "${COMPOSE_FILES[@]}" down -v >/dev/null 2>&1 || true
-}
-trap cleanup EXIT
 
 # Track each scenario's output directory and overall verdict.
 scenario_args=()
@@ -147,8 +130,9 @@ for s in "${scenarios[@]}"; do
   # Snapshot existing run directories so we can identify the new one.
   before_listing="$(ls -1 "$before_dir" 2>/dev/null | sort || true)"
 
-  # SKIP_UP=1 + KEEP_UP=1 → run.sh reuses our cluster and leaves it alone.
-  if SKIP_UP=1 KEEP_UP=1 "$HERE/run.sh" "$s"; then
+  # run.sh owns compose up and down -v so every scenario starts without data,
+  # retained high-water state, or cluster env inherited from its predecessor.
+  if "$HERE/run.sh" "$s"; then
     log "scenario $s: PASS"
   else
     log "scenario $s: FAIL (leak gate or harness error)"

--- a/testbed/bench/scenarios_gate_test.go
+++ b/testbed/bench/scenarios_gate_test.go
@@ -290,6 +290,40 @@ func TestSearchReleaseQualificationIsBlocking(t *testing.T) {
 	}
 }
 
+// TestReleaseSweepIsolatesScenarioClusters keeps release measurements from
+// inheriting data, high-water state, or ignored cluster overrides from a prior
+// scenario. run.sh must own the complete Compose lifecycle for every entry.
+func TestReleaseSweepIsolatesScenarioClusters(t *testing.T) {
+	releaseScript, err := os.ReadFile("release.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	release := string(releaseScript)
+	if !strings.Contains(release, `if "$HERE/run.sh" "$s"; then`) {
+		t.Error("release sweep does not invoke the scenario-owned run.sh lifecycle")
+	}
+	for _, sharedClusterContract := range []string{"SKIP_UP=1", "KEEP_UP=1", `docker compose "${COMPOSE_FILES[@]}" up`} {
+		if strings.Contains(release, sharedClusterContract) {
+			t.Errorf("release sweep still contains shared-cluster contract %q", sharedClusterContract)
+		}
+	}
+
+	runScript, err := os.ReadFile("run.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := string(runScript)
+	clusterOverride := strings.Index(run, `cluster_ttl="$(yq -r '.cluster.default_ttl_seconds`)
+	composeUp := strings.Index(run, `docker compose "${COMPOSE_FILES[@]}" up -d --wait`)
+	composeDown := strings.Index(run, `docker compose "${COMPOSE_FILES[@]}" down -v`)
+	if clusterOverride < 0 || composeUp < 0 || clusterOverride > composeUp {
+		t.Error("run.sh must apply scenario cluster overrides before compose up")
+	}
+	if composeDown < 0 {
+		t.Error("run.sh must remove scenario volumes during cleanup")
+	}
+}
+
 // calls flattens every (call, data_template) pair in the document, tagged
 // with where it came from so failures point at the offending YAML path.
 func (d scenarioDoc) calls() map[string]scenarioCall {


### PR DESCRIPTION
Closes #1097

## Summary

- give every release/nightly scenario a fresh `run.sh`-owned Compose lifecycle
- prevent data, search high-water state, and scenario env overrides from leaking across measurements
- preserve aggregate reporting, graceful release budget, and unbounded blocking nightly behavior
- pin the isolation contract and update runtime documentation

## Failure evidence

Run 29288064623 entered `search_churn` with 105,420 search documents inherited from predecessor scenarios, versus the scenario contract of approximately 7.5k live short-TTL documents. Its `cluster.gc_interval_seconds: 10` override was also ignored by the already-running cluster.

## Hosted validation

Run 29290118078 used a fresh cluster for every scenario. `search_churn` started with 6,249 scenario-owned live docs, applied its GC override, passed semantic 12/12 on all replicas, passed leak and every absolute retained-size gate, and completed the full sweep. The independent admission/derived-ratio scenario contracts it exposed are tracked as #1099.

## Validation

- `bash -n testbed/bench/release.sh`
- `go test ./testbed/bench/... -count=1`
- full repository pre-push quality gate (all Go modules, go vet, Dart SDK, Flutter example)
- all PR checks green, including Fuzz and CodeQL
- hosted full release sweep exercised fresh lifecycle for all seven scenarios