### PR TITLE
fix(bench): eliminate broad rw concurrent write failures (#1101)

### DIFF
--- a/testbed/bench/report/render.go
+++ b/testbed/bench/report/render.go
@@ -427,8 +427,8 @@ func RenderReport(w io.Writer, in Input) error {
 	if len(in.GhzFiles) == 0 {
 		bw.printf("_no ghz artifacts found_\n\n")
 	} else {
-		bw.printf("| file | count | rps | avg ms | p99 ms | non-OK |\n")
-		bw.printf("| --- | ---: | ---: | ---: | ---: | ---: |\n")
+		bw.printf("| file | count | rps | avg ms | p99 ms | non-OK | non-OK statuses |\n")
+		bw.printf("| --- | ---: | ---: | ---: | ---: | ---: | --- |\n")
 		sawStream := false
 		for _, g := range in.GhzFiles {
 			// ghz reports server-streaming RPCs (file prefix `ghz_sub_`)
@@ -440,6 +440,7 @@ func RenderReport(w io.Writer, in Input) error {
 			// issue #258, item 4.
 			isStream := strings.HasPrefix(g.Name, "ghz_sub_")
 			nonOKCell := "—"
+			statusCell := "—"
 			if !isStream {
 				nonOK := 0
 				for code, n := range g.Summary.StatusCodeDistribution {
@@ -448,16 +449,18 @@ func RenderReport(w io.Writer, in Input) error {
 					}
 				}
 				nonOKCell = fmt.Sprintf("%d", nonOK)
+				statusCell = nonOKStatusSummary(g.Summary.StatusCodeDistribution)
 			} else {
 				sawStream = true
 			}
-			bw.printf("| `%s` | %d | %.1f | %.2f | %.2f | %s |\n",
+			bw.printf("| `%s` | %d | %.1f | %.2f | %.2f | %s | %s |\n",
 				g.Name,
 				g.Summary.Count,
 				g.Summary.Rps,
 				nsToMs(g.Summary.Average),
 				nsToMs(percentileNs(g.Summary, 99)),
 				nonOKCell,
+				statusCell,
 			)
 		}
 		bw.printf("\n")
@@ -495,6 +498,24 @@ func RenderReport(w io.Writer, in Input) error {
 	bw.printf("   `go tool pprof -http=:0 -base <pre> <post>`\n")
 	bw.printf("3. For elevated tail latency, cross-reference the matching Prom histogram query with `<replica>__post__goroutine.pb.gz` (look for blocked stacks).\n")
 	return bw.err
+}
+
+// nonOKStatusSummary keeps hosted failures actionable without copying ghz's
+// unbounded error strings into the durable report. Connect/gRPC status names
+// form a small fixed vocabulary; sort them so report diffs are deterministic.
+func nonOKStatusSummary(distribution map[string]int) string {
+	statuses := make([]string, 0, len(distribution))
+	for status, count := range distribution {
+		if status == "OK" || count <= 0 {
+			continue
+		}
+		statuses = append(statuses, fmt.Sprintf("`%s=%d`", status, count))
+	}
+	if len(statuses) == 0 {
+		return "—"
+	}
+	sort.Strings(statuses)
+	return strings.Join(statuses, ", ")
 }
 
 func semanticGateVerdict(pre, post *SemanticGate) string {

--- a/testbed/bench/report/render_test.go
+++ b/testbed/bench/report/render_test.go
@@ -79,7 +79,7 @@ func TestRenderReport_AllSectionsAndVerdict(t *testing.T) {
 		"| 12 / 240000 |", // vertexHLC entries (drained) / high-water (peak)
 		"50.00",           // p99 ms
 		"`ghz_steady_localhost_6380.json`",
-		"| 10 |", // non-OK column
+		"| 10 | `DEADLINE_EXCEEDED=10` |",
 		"`go_goroutines` → `prom/q_01.json`",
 		"`pprof/localhost_9390__post__heap.pb.gz`",
 		"## Drill-down",
@@ -88,9 +88,6 @@ func TestRenderReport_AllSectionsAndVerdict(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("report missing %q\n---\n%s", want, out)
 		}
-	}
-	if strings.Contains(out, "DEADLINE_EXCEEDED") {
-		t.Errorf("report should not name individual non-OK codes:\n%s", out)
 	}
 }
 
@@ -120,10 +117,10 @@ func TestRenderReport_StreamingGhzRowsMaskNonOK(t *testing.T) {
 		t.Fatalf("RenderReport: %v", err)
 	}
 	out := buf.String()
-	if !strings.Contains(out, "| `ghz_steady_localhost_6380.json` | 100 | 100.0 | 0.00 | 0.00 | 5 |") {
+	if !strings.Contains(out, "| `ghz_steady_localhost_6380.json` | 100 | 100.0 | 0.00 | 0.00 | 5 | `Unavailable=5` |") {
 		t.Errorf("steady row should report numeric non-OK; got:\n%s", out)
 	}
-	if !strings.Contains(out, "| `ghz_sub_1.json` | 130000 | 433.0 | 0.00 | 0.00 | — |") {
+	if !strings.Contains(out, "| `ghz_sub_1.json` | 130000 | 433.0 | 0.00 | 0.00 | — | — |") {
 		t.Errorf("streaming row should mask non-OK with \"—\"; got:\n%s", out)
 	}
 	if !strings.Contains(out, "`ghz_sub_*` rows show `—` for non-OK") {

--- a/testbed/bench/scenarios/broad_rw.yaml
+++ b/testbed/bench/scenarios/broad_rw.yaml
@@ -11,6 +11,11 @@
 #       twice (steady 2m). Key spaces are chosen so every call returns codes.OK
 #       (non-OK ~ 0): plural reads return OK + a `missing` list rather than
 #       NotFound; AddEdge is additive; DeleteVertex targets a monotonic space.
+#       Search is disabled for this scenario because a mutation-log gap can
+#       trigger snapshot restore on a saturated hosted runner; the derived
+#       index then correctly fails strict local Put* with SEARCH_INDEX_INCOMPLETE
+#       while it rebuilds. search_churn owns that lifecycle contract, whereas
+#       broad_rw requires every RPC-surface producer to remain codes.OK (#1101).
 #
 # Ordering: calls[0] (PutVertex over k-*) is what warmup replays — run.sh warms
 #           ONLY calls[0] — so it must be the working-set filler. The AddEdge
@@ -18,6 +23,8 @@
 #           owns a separate, verified topology preflight (#994), so no release
 #           scenario ordering depends on these incidental edges.
 name: broad_rw
+cluster:
+  search_enabled: false
 phases:
   warmup:   { duration: 15s, concurrency: 16, rps: 1000 }
   steady:   { duration: 2m,  concurrency: 16, rps: 12000 }

--- a/testbed/bench/scenarios_gate_test.go
+++ b/testbed/bench/scenarios_gate_test.go
@@ -120,6 +120,42 @@ func TestBroadIlluminateScenarioTopologyContract(t *testing.T) {
 	}
 }
 
+// TestBroadRWScenarioSeparatesSearchRecovery keeps its codes.OK RPC-surface
+// contract independent from the derived-index rebuild lifecycle. Hosted
+// mutation-log gap recovery may rebuild Search; search_churn owns that proof.
+func TestBroadRWScenarioSeparatesSearchRecovery(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("scenarios", "broad_rw.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Cluster struct {
+			SearchEnabled *bool `yaml:"search_enabled"`
+		} `yaml:"cluster"`
+		Target struct {
+			Calls []scenarioCall `yaml:"calls"`
+		} `yaml:"target"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse broad_rw: %v", err)
+	}
+	if doc.Cluster.SearchEnabled == nil || *doc.Cluster.SearchEnabled {
+		t.Fatal("broad_rw must disable Search so snapshot rebuilds cannot reject its codes.OK Put producers")
+	}
+	methods := make(map[string]bool, len(doc.Target.Calls))
+	for _, call := range doc.Target.Calls {
+		methods[call.Call] = true
+	}
+	for _, method := range []string{
+		"graph.v1.LanternService/PutVertex",
+		"graph.v1.LanternService/PutVertices",
+	} {
+		if !methods[method] {
+			t.Errorf("broad_rw lost required write producer %s", method)
+		}
+	}
+}
+
 // TestSearchChurnScenarioGateContract keeps #1063's blocking search proof
 // honest: every advanced producer is independently ratcheted, semantic probes
 // run on every replica, and the derived-index gauges have real pre/post gates.


### PR DESCRIPTION
## Summary
- surface bounded non-OK Connect status categories in durable bench reports
- keep `broad_rw` focused on its 12 codes.OK RPC-surface producers by disabling the derived Search index only for this scenario
- pin that PutVertex/PutVertices coverage remains while Search recovery stays isolated to `search_churn`

## Root cause
Hosted diagnostic run 29296049712 identified the failures:
- PutVertex: `FailedPrecondition=675`
- PutVertices: `FailedPrecondition=1877`
- other producers: only bounded end-of-duration `Unavailable`

For these strict vertex writes, FailedPrecondition is `SEARCH_INDEX_INCOMPLETE`. On a saturated hosted runner the 10k mutation-log ring can gap, snapshot restore rebuilds the derived Search index, and writes correctly fail closed during that rebuild. `broad_rw` promised codes.OK but was unintentionally mixing in Search recovery. `search_churn` already owns semantic, lifecycle, admission, and metric proof for Search.

## Validation
- reporter and scenario contract unit tests
- local fresh `broad_rw`: pass; PutVertex 119,994 OK and PutVertices 119,984 OK, zero FailedPrecondition
- hosted final one-scenario run 29296651489: leak+perf pass, 3867.8 aggregate rps, 0.011% non-OK
- hosted PutVertex: only `Canceled=5`; PutVertices: 37,262/37,262 OK; zero FailedPrecondition
- full root and all Go submodule tests
- server go vet
- Dart format/analyze/test/doc/publish dry-run
- Flutter example format/analyze/test

Diagnostic run: https://github.com/anaregdesign/lantern/actions/runs/29296049712
Final hosted validation: https://github.com/anaregdesign/lantern/actions/runs/29296651489

Closes #1101
