### PR TITLE
fix(bench): align search qualification gate

### DIFF
--- a/testbed/bench/scenarios/search_qualification.yaml
+++ b/testbed/bench/scenarios/search_qualification.yaml
@@ -52,8 +52,11 @@ metric_gate:
     lantern_search_index_postings: { max_increase: 1024, max_ratio: 2 }
     lantern_search_index_position_entries: { max_increase: 2048, max_ratio: 2 }
     lantern_search_index_estimated_retained_bytes: { max_increase: 33554432, max_ratio: 3 }
-    lantern_search_index_retained_ratio: { max_post: 3 }
     lantern_search_index_healthy: { min_post: 1, max_post: 1 }
+# retained_ratio is intentionally not gated: the short TTL workload can shrink
+# the live-byte denominator below the compaction floor while retained slots are
+# still bounded by the absolute gauges above. A fixed ratio ceiling would turn
+# that expected state into a false release failure (#1105).
 # Wide ratchets reject step changes while tolerating ordinary hosted-runner
 # jitter. Each Search producer is independent, so writer throughput cannot
 # conceal an unexpectedly slow or empty Search path.

--- a/testbed/bench/scenarios_gate_test.go
+++ b/testbed/bench/scenarios_gate_test.go
@@ -301,6 +301,37 @@ func TestSearchChurnScenarioGateContract(t *testing.T) {
 	}
 }
 
+// TestSearchQualificationScenarioGateContract keeps the short-TTL release
+// qualification from treating the diagnostic retained/live ratio as a leak.
+// Production intentionally waits for the compaction floor before rebuilding
+// retained index structures, so the ratio can rise as live documents expire.
+func TestSearchQualificationScenarioGateContract(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("scenarios", "search_qualification.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		MetricGate struct {
+			Metrics map[string]map[string]float64 `yaml:"metrics"`
+		} `yaml:"metric_gate"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse search_qualification: %v", err)
+	}
+	for _, metric := range []string{
+		"lantern_search_index_retained_term_slots",
+		"lantern_search_index_retained_ordinals",
+		"lantern_search_index_estimated_retained_bytes",
+	} {
+		if len(doc.MetricGate.Metrics[metric]) == 0 {
+			t.Errorf("metric %s has no threshold", metric)
+		}
+	}
+	if _, ok := doc.MetricGate.Metrics["lantern_search_index_retained_ratio"]; ok {
+		t.Error("retained ratio must not be gated while the live denominator decays")
+	}
+}
+
 // TestSearchReleaseQualificationIsBlocking pins the release dependency rather
 // than merely checking that a qualification job exists. A failed or skipped
 // stage must produce a fail verdict, and image publication must need that job.


### PR DESCRIPTION
Closes #1105

## Summary

- remove the fixed `lantern_search_index_retained_ratio` ceiling from the short-TTL Search qualification
- retain bounded retained-slot and retained-byte lifecycle gates
- add a scenario contract test preventing the false gate from returning

## Root cause

The compaction floor intentionally leaves fewer than 10,000 retired slots in place. When short-TTL documents expire, the live-byte denominator can shrink and make the diagnostic retained/live ratio exceed a fixed ceiling even while retained bytes decline.

## Validation

- `gofmt -l` (clean)
- `go test ./...` from root and every Go submodule
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test` (one real-wire test skipped because no endpoint was configured)
- `LEAK_GATE_ONLY=1 ./testbed/bench/run.sh search_qualification` — leak, metric, semantic, and perf gates pass