### PR TITLE
ci(dart): reduce workflow latency without weakening gates

### DIFF
--- a/.github/workflows/dart-sdk.yml
+++ b/.github/workflows/dart-sdk.yml
@@ -155,7 +155,9 @@ jobs:
           exit 1
 
       - name: Resolve dependencies
-        run: dart pub get --enforce-lockfile
+        # The Flutter example resolves in the blocking Android job. Keeping it
+        # out of this pure-Dart job avoids requiring a second Flutter install.
+        run: dart pub get --enforce-lockfile --no-example
 
       - name: Regenerate and check drift
         if: needs.changes.outputs.full == 'true'

--- a/.github/workflows/dart-sdk.yml
+++ b/.github/workflows/dart-sdk.yml
@@ -172,7 +172,9 @@ jobs:
           lib/lantern_client.dart lib/src/*.dart test
 
       - name: Analyze
-        run: dart analyze
+        # The standalone Dart SDK intentionally does not resolve the Flutter
+        # example. Android and iOS jobs analyze that package with Flutter.
+        run: dart analyze lib test
 
       - name: Test
         run: dart test

--- a/.github/workflows/dart-sdk.yml
+++ b/.github/workflows/dart-sdk.yml
@@ -15,6 +15,7 @@ on:
       - "core/graphcache/**"
       - "server/**"
       - "testdata/search/**"
+      - "docs/decisions/0001-dart-mobile-transport.md"
       - ".github/workflows/dart-sdk.yml"
   pull_request:
     paths:
@@ -27,6 +28,7 @@ on:
       - "core/graphcache/**"
       - "server/**"
       - "testdata/search/**"
+      - "docs/decisions/0001-dart-mobile-transport.md"
       - ".github/workflows/dart-sdk.yml"
 
 permissions:
@@ -37,8 +39,68 @@ concurrency:
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
+  changes:
+    name: Classify changes
+    runs-on: ubuntu-latest
+    outputs:
+      full: ${{ steps.scope.outputs.full }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # Backend-only changes still exercise the pure-Dart client over the real
+      # wire. The complete toolchain and mobile matrix is reserved for changes
+      # that can alter the generated/package/platform surfaces, and for tags.
+      - name: Select required gate scope
+        id: scope
+        shell: bash
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          full=false
+
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            full=true
+          else
+            if [[ "$GITHUB_EVENT_NAME" == pull_request ]]; then
+              base=$PR_BASE_SHA
+              head=$PR_HEAD_SHA
+              range="$base...$head"
+            else
+              base=$PUSH_BEFORE_SHA
+              head=$GITHUB_SHA
+              if [[ "$base" =~ ^0+$ ]]; then
+                full=true
+                range=
+              else
+                range="$base..$head"
+              fi
+            fi
+
+            if [[ "$full" == false ]]; then
+              while IFS= read -r path; do
+                case "$path" in
+                  sdks/dart/* | proto/* | buf.yaml | buf.gen.yaml | generate.go | \
+                    docs/decisions/0001-dart-mobile-transport.md | \
+                    .github/workflows/dart-sdk.yml)
+                    full=true
+                    break
+                    ;;
+                esac
+              done < <(git diff --name-only "$range")
+            fi
+          fi
+
+          echo "full=$full" >> "$GITHUB_OUTPUT"
+          echo "Full Dart/mobile matrix: $full" >> "$GITHUB_STEP_SUMMARY"
+
   test:
     name: Generate, analyze, and test
+    needs: changes
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -51,12 +113,16 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Set up Flutter
-        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+      - name: Set up current supported Dart
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
         with:
-          channel: stable
-          flutter-version: 3.44.6
-          cache: true
+          sdk: 3.12.2
+
+      - name: Set up Buf
+        if: needs.changes.outputs.full == 'true'
+        uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
+        with:
+          version: 1.71.0
 
       - name: Start Lantern real-wire server
         working-directory: .
@@ -92,6 +158,7 @@ jobs:
         run: dart pub get --enforce-lockfile
 
       - name: Regenerate and check drift
+        if: needs.changes.outputs.full == 'true'
         working-directory: .
         run: |
           sdks/dart/scripts/codegen.sh
@@ -117,6 +184,7 @@ jobs:
         run: dart test test/real_wire_test.dart
 
       - name: Build API documentation
+        if: needs.changes.outputs.full == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -129,9 +197,11 @@ jobs:
           fi
 
       - name: Validate package shape
+        if: needs.changes.outputs.full == 'true'
         run: dart pub publish --dry-run
 
       - name: Generate pana quality report
+        if: needs.changes.outputs.full == 'true'
         working-directory: .
         run: |
           package_dir="$RUNNER_TEMP/lantern-client-package"
@@ -142,24 +212,12 @@ jobs:
             > "$RUNNER_TEMP/lantern-client-pana.json"
 
       - name: Upload pana quality report
+        if: needs.changes.outputs.full == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: lantern-client-pana
           path: ${{ runner.temp }}/lantern-client-pana.json
           if-no-files-found: error
-
-      - name: Resolve Flutter example
-        working-directory: sdks/dart/example
-        run: flutter pub get --enforce-lockfile
-
-      - name: Check Flutter example
-        working-directory: sdks/dart/example
-        run: |
-          dart format --output=none --set-exit-if-changed \
-            lib test integration_test
-          flutter analyze
-          flutter test
-          flutter build apk --debug
 
       - name: Stop Lantern real-wire server
         if: always()
@@ -171,6 +229,8 @@ jobs:
 
   minimum-dart:
     name: Minimum Dart 3.11
+    needs: changes
+    if: needs.changes.outputs.full == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -195,6 +255,8 @@ jobs:
 
   android:
     name: Android emulator real-wire example
+    needs: changes
+    if: needs.changes.outputs.full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -219,6 +281,15 @@ jobs:
             "$RUNNER_TEMP/lantern" > "$RUNNER_TEMP/android-server.log" 2>&1 &
           echo $! > "$RUNNER_TEMP/android-server.pid"
 
+      - name: Check Flutter example
+        working-directory: sdks/dart/example
+        run: |
+          flutter pub get --enforce-lockfile
+          dart format --output=none --set-exit-if-changed \
+            lib test integration_test
+          flutter analyze --no-pub
+          flutter test --no-pub
+
       - name: Enable KVM access
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
@@ -233,8 +304,8 @@ jobs:
           arch: x86_64
           profile: pixel_6
           script: >-
-            cd sdks/dart/example && flutter pub get --enforce-lockfile &&
-            flutter test integration_test/mobile_smoke_test.dart -d emulator-5554
+            cd sdks/dart/example &&
+            flutter test --no-pub integration_test/mobile_smoke_test.dart -d emulator-5554
             --reporter=expanded --timeout=3m
             --dart-define=LANTERN_ENDPOINT=http://10.0.2.2:6380
             --dart-define=LANTERN_ALLOW_INSECURE=true
@@ -247,6 +318,8 @@ jobs:
 
   ios:
     name: iOS simulator real-wire example
+    needs: changes
+    if: needs.changes.outputs.full == 'true'
     runs-on: macos-15
     timeout-minutes: 30
     steps:
@@ -264,6 +337,26 @@ jobs:
           flutter-version: 3.44.6
           cache: true
 
+      - name: Start iOS simulator boot
+        run: |
+          boot_simulator() {
+            set -euo pipefail
+            device=$(xcrun simctl list devices available -j | \
+              jq -r '[.devices[][] | select(.name | startswith("iPhone"))][0].udid')
+            test -n "$device"
+            echo "$device" > "$RUNNER_TEMP/ios-device-id"
+            xcrun simctl boot "$device" || true
+            xcrun simctl bootstatus "$device" -b
+          }
+          (
+            if boot_simulator; then
+              touch "$RUNNER_TEMP/ios-simulator-ready"
+            else
+              touch "$RUNNER_TEMP/ios-simulator-failed"
+            fi
+          ) > "$RUNNER_TEMP/ios-simulator-boot.log" 2>&1 &
+          echo $! > "$RUNNER_TEMP/ios-simulator-boot.pid"
+
       - name: Start Lantern
         run: |
           go build -o "$RUNNER_TEMP/lantern" ./server/cmd
@@ -271,21 +364,35 @@ jobs:
             "$RUNNER_TEMP/lantern" > "$RUNNER_TEMP/ios-server.log" 2>&1 &
           echo $! > "$RUNNER_TEMP/ios-server.pid"
 
-      - name: Boot iOS simulator
-        run: |
-          device=$(xcrun simctl list devices available -j | \
-            jq -r '[.devices[][] | select(.name | startswith("iPhone"))][0].udid')
-          test -n "$device"
-          xcrun simctl boot "$device" || true
-          xcrun simctl bootstatus "$device" -b
-          echo "DEVICE_ID=$device" >> "$GITHUB_ENV"
-
       - name: Check and build iOS example
         working-directory: sdks/dart/example
         run: |
           flutter pub get --enforce-lockfile
-          flutter analyze
-          flutter build ios --debug --no-codesign
+          flutter analyze --no-pub
+          flutter build ios --debug --no-codesign --no-pub
+
+      - name: Wait for iOS simulator
+        timeout-minutes: 5
+        run: |
+          for attempt in $(seq 1 300); do
+            if [[ -f "$RUNNER_TEMP/ios-simulator-ready" ]]; then
+              break
+            fi
+            if [[ -f "$RUNNER_TEMP/ios-simulator-failed" ]]; then
+              cat "$RUNNER_TEMP/ios-simulator-boot.log"
+              exit 1
+            fi
+            sleep 1
+          done
+          if [[ ! -f "$RUNNER_TEMP/ios-simulator-ready" ]]; then
+            cat "$RUNNER_TEMP/ios-simulator-boot.log"
+            echo "::error::iOS simulator did not become ready"
+            exit 1
+          fi
+          device=$(cat "$RUNNER_TEMP/ios-device-id")
+          test -n "$device"
+          echo "DEVICE_ID=$device" >> "$GITHUB_ENV"
+          cat "$RUNNER_TEMP/ios-simulator-boot.log"
 
       - name: Run iOS native smoke
         id: ios_smoke
@@ -293,7 +400,7 @@ jobs:
         timeout-minutes: 8
         working-directory: sdks/dart/example
         run: |
-          flutter test integration_test/mobile_smoke_test.dart -d "$DEVICE_ID" \
+          flutter test --no-pub integration_test/mobile_smoke_test.dart -d "$DEVICE_ID" \
             --reporter=expanded --timeout=3m \
             --dart-define=LANTERN_ENDPOINT=http://127.0.0.1:6380 \
             --dart-define=LANTERN_ALLOW_INSECURE=true
@@ -312,7 +419,7 @@ jobs:
         timeout-minutes: 8
         working-directory: sdks/dart/example
         run: |
-          flutter test integration_test/mobile_smoke_test.dart -d "$DEVICE_ID" \
+          flutter test --no-pub integration_test/mobile_smoke_test.dart -d "$DEVICE_ID" \
             --reporter=expanded --timeout=3m \
             --dart-define=LANTERN_ENDPOINT=http://127.0.0.1:6380 \
             --dart-define=LANTERN_ALLOW_INSECURE=true
@@ -322,13 +429,59 @@ jobs:
         run: |
           cat "$RUNNER_TEMP/ios-server.log" 2>/dev/null || true
           kill "$(cat "$RUNNER_TEMP/ios-server.pid")" 2>/dev/null || true
-          if [[ -n ${DEVICE_ID:-} ]]; then
-            xcrun simctl shutdown "$DEVICE_ID" || true
+          if [[ -f "$RUNNER_TEMP/ios-simulator-boot.pid" ]]; then
+            kill "$(cat "$RUNNER_TEMP/ios-simulator-boot.pid")" 2>/dev/null || true
           fi
+          device=${DEVICE_ID:-}
+          if [[ -z "$device" && -f "$RUNNER_TEMP/ios-device-id" ]]; then
+            device=$(cat "$RUNNER_TEMP/ios-device-id")
+          fi
+          if [[ -n "$device" ]]; then
+            xcrun simctl shutdown "$device" || true
+          fi
+
+  gate:
+    name: Gate
+    if: always()
+    needs: [changes, test, minimum-dart, android, ios]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        shell: bash
+        env:
+          FULL: ${{ needs.changes.outputs.full }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          MINIMUM_DART_RESULT: ${{ needs.minimum-dart.result }}
+          ANDROID_RESULT: ${{ needs.android.result }}
+          IOS_RESULT: ${{ needs.ios.result }}
+        run: |
+          set -euo pipefail
+          require_result() {
+            local job=$1 actual=$2 expected=$3
+            if [[ "$actual" != "$expected" ]]; then
+              echo "::error::$job result is $actual; expected $expected"
+              exit 1
+            fi
+          }
+
+          require_result changes "$CHANGES_RESULT" success
+          require_result test "$TEST_RESULT" success
+          if [[ "$FULL" == true ]]; then
+            require_result minimum-dart "$MINIMUM_DART_RESULT" success
+            require_result android "$ANDROID_RESULT" success
+            require_result ios "$IOS_RESULT" success
+          else
+            require_result minimum-dart "$MINIMUM_DART_RESULT" skipped
+            require_result android "$ANDROID_RESULT" skipped
+            require_result ios "$IOS_RESULT" skipped
+          fi
+
+          echo "Full Dart/mobile matrix: $FULL" >> "$GITHUB_STEP_SUMMARY"
 
   publish:
     name: Publish lantern_client
-    needs: [test, minimum-dart, android, ios]
+    needs: [gate]
     if: startsWith(github.ref, 'refs/tags/sdks/dart/v')
     runs-on: ubuntu-latest
     environment:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,11 @@ The Dart SDK is outside `go.work`; its format/analyze/test gate is therefore
 separate too. When `proto/` changes, run `sdks/dart/scripts/codegen.sh` and commit
 the regenerated `sdks/dart/lib/src/gen/**` files. The supported toolchain source of
 truth is `docs/decisions/0001-dart-mobile-transport.md`; the workflow pins mirror that
-decision and also runs the package at its declared minimum Dart floor.
+decision and also runs the package at its declared minimum Dart floor. The workflow
+routes backend/search-only changes through the current-Dart unit and real-wire gates;
+Dart SDK, proto, codegen/toolchain, workflow, and release-tag changes run the complete
+minimum/current Dart, package-quality, Android, and iOS matrix. The stable `Gate` job
+checks the required result set for either scope.
 
 ## Coverage floor (ratchet)
 

--- a/tests/integration/docs_gate_test.go
+++ b/tests/integration/docs_gate_test.go
@@ -158,6 +158,7 @@ func TestDartWorkflowGate(t *testing.T) {
 		"name: Classify changes",
 		"docs/decisions/0001-dart-mobile-transport.md",
 		"name: Generate, analyze, and test",
+		"dart pub get --enforce-lockfile --no-example",
 		"if: needs.changes.outputs.full == 'true'",
 		"bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99",
 		"version: 1.71.0",

--- a/tests/integration/docs_gate_test.go
+++ b/tests/integration/docs_gate_test.go
@@ -139,6 +139,94 @@ func TestDartFirstReleaseBlockerGate(t *testing.T) {
 	}
 }
 
+// TestDartWorkflowGate keeps the change-scoped fast path from weakening the
+// release and SDK-surface matrix. Backend-only changes may skip platform work,
+// but the stable aggregate gate must require every full-matrix job when Dart,
+// proto, toolchain, workflow, or release inputs change.
+func TestDartWorkflowGate(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+
+	workflow, err := os.ReadFile(filepath.Join(repoRoot, ".github", "workflows", "dart-sdk.yml"))
+	if err != nil {
+		t.Fatalf("read Dart SDK workflow: %v", err)
+	}
+	text := string(workflow)
+	for _, contract := range []string{
+		"name: Classify changes",
+		"docs/decisions/0001-dart-mobile-transport.md",
+		"name: Generate, analyze, and test",
+		"if: needs.changes.outputs.full == 'true'",
+		"bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99",
+		"version: 1.71.0",
+		"name: Minimum Dart 3.11",
+		"name: Build API documentation",
+		"dart pub publish --dry-run",
+		"dart pub global run pana --json",
+		"name: Check Flutter example",
+		"flutter test --no-pub integration_test/mobile_smoke_test.dart -d emulator-5554",
+		"name: Start iOS simulator boot",
+		"name: Wait for iOS simulator",
+		"flutter build ios --debug --no-codesign --no-pub",
+		"name: Gate",
+		"needs: [changes, test, minimum-dart, android, ios]",
+		"require_result minimum-dart \"$MINIMUM_DART_RESULT\" success",
+		"require_result android \"$ANDROID_RESULT\" success",
+		"require_result ios \"$IOS_RESULT\" success",
+		"needs: [gate]",
+	} {
+		if !strings.Contains(text, contract) {
+			t.Errorf("Dart SDK workflow is missing scoped-gate contract %q", contract)
+		}
+	}
+	if strings.Contains(text, "flutter build apk --debug") {
+		t.Error("Dart SDK workflow duplicates the APK build already performed by the Android native smoke")
+	}
+
+	iosStart := strings.Index(text, "\n  ios:\n")
+	if iosStart < 0 {
+		t.Fatal("Dart SDK workflow is missing the iOS job")
+	}
+	gateOffset := strings.Index(text[iosStart:], "\n  gate:\n")
+	if gateOffset < 0 {
+		t.Fatal("Dart SDK workflow is missing the aggregate gate after the iOS job")
+	}
+	ios := text[iosStart : iosStart+gateOffset]
+	last := -1
+	for _, step := range []string{
+		"name: Start iOS simulator boot",
+		"name: Start Lantern",
+		"name: Check and build iOS example",
+		"name: Wait for iOS simulator",
+		"name: Run iOS native smoke",
+	} {
+		index := strings.Index(ios, step)
+		if index < 0 {
+			t.Fatalf("iOS job is missing %q", step)
+		}
+		if index <= last {
+			t.Fatalf("iOS step %q is out of order", step)
+		}
+		last = index
+	}
+
+	contributing, err := os.ReadFile(filepath.Join(repoRoot, "CONTRIBUTING.md"))
+	if err != nil {
+		t.Fatalf("read CONTRIBUTING.md: %v", err)
+	}
+	for _, contract := range []string{
+		"routes backend/search-only changes through the current-Dart unit and real-wire gates",
+		"stable `Gate` job",
+		"required result set for either scope",
+	} {
+		if !strings.Contains(string(contributing), contract) {
+			t.Errorf("CONTRIBUTING.md is missing Dart workflow contract %q", contract)
+		}
+	}
+}
+
 // TestSearchDocumentationGate keeps the canonical search guide synchronized
 // with the wire schema and every maintained user-facing surface. Tables remain
 // readable hand-written prose, while descriptor reflection makes a new option,

--- a/tests/integration/docs_gate_test.go
+++ b/tests/integration/docs_gate_test.go
@@ -159,6 +159,7 @@ func TestDartWorkflowGate(t *testing.T) {
 		"docs/decisions/0001-dart-mobile-transport.md",
 		"name: Generate, analyze, and test",
 		"dart pub get --enforce-lockfile --no-example",
+		"dart analyze lib test",
 		"if: needs.changes.outputs.full == 'true'",
 		"bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99",
 		"version: 1.71.0",


### PR DESCRIPTION
Closes #1108

## Summary

- classify Dart workflow triggers into backend/search-only and full Dart/mobile scopes
- keep current-Dart unit and real-wire coverage blocking for every triggered run
- retain minimum Dart, codegen drift, dartdoc, publish dry-run, pana, Flutter example, Android, and iOS gates for Dart/proto/toolchain/release changes
- replace the general job's 1.6 GB Flutter setup with exact Dart 3.12.2
- install pinned Buf 1.71.0 instead of compiling the CLI through the codegen fallback
- remove the duplicate standalone Android APK build while retaining the native smoke that builds, installs, and executes the debug app
- overlap iOS simulator boot with the server and device build while preserving the bounded retry
- add a stable aggregate Gate job plus a repository contract test and contributor documentation

## Why

Recent successful runs put the Dart workflow on the repository critical path:

- full workflow: 8m04s, 15m53s, and 8m28s
- latest Go critical path: 5m30s
- iOS boot was serialized for 2m08s before a 2m24s device build
- the same Android debug APK was compiled in both the general and emulator jobs
- Dart codegen spent about 51s in the `go run ...buf` fallback

The quality checks themselves are comparatively cheap, so this changes orchestration and relevance rather than removing signals.

## Validation

- `gofmt -l .`
- `go test ./...` in root, `pb`, `core`, `sdks/go`, `server`, and `mcp`
- `go vet ./...` in `server`
- pinned `actionlint` on `.github/workflows/dart-sdk.yml`
- Dart codegen regeneration and generated-stub drift check with Buf 1.71.0
- Dart locked resolution, exact format, analyze, 74 tests, warning-free dartdoc, and publish dry-run
- Flutter example locked resolution, exact format, analyze, and widget test
- Dart real-wire suite against all four CI server configurations: 17 tests passed
- focused Dart workflow/release contract tests

## Hosted verification

The complete matrix passed on [PR run 29631243554](https://github.com/anaregdesign/lantern/actions/runs/29631243554), including the aggregate `Gate`.

Compared with the latest successful [main run 29588721518](https://github.com/anaregdesign/lantern/actions/runs/29588721518):

- current-Dart/codegen/docs/publish/pana: 7m42s → 1m37s (79% faster)
- Android example/native smoke: 5m54s → 5m33s (6% faster)
- minimum Dart: 24s → 23s
- iOS: 11m51s → 14m47s in this sample; simulator boot no longer adds 1m28s to the critical path and the Xcode build improved from 5m18s to 4m50s, but the hosted runner's Go build (37s → 3m24s) and native smoke (2m30s → 4m31s) were slower

The remaining full-matrix bottleneck is therefore Xcode/simulator execution and runner variance, not Dart SDK installation. Backend/search-only changes now skip all three mobile/minimum jobs while keeping the 1m37s current-Dart unit and real-wire job blocking.