### PR TITLE
test(sdks/dart): record physical mobile release gate

### DIFF
--- a/.github/workflows/dart-sdk.yml
+++ b/.github/workflows/dart-sdk.yml
@@ -290,7 +290,7 @@ jobs:
         run: |
           flutter pub get --enforce-lockfile
           dart format --output=none --set-exit-if-changed \
-            lib test integration_test
+            lib test integration_test test_driver
           flutter analyze --no-pub
           flutter test --no-pub
 

--- a/sdks/dart/example/integration_test/local_network_denied_test.dart
+++ b/sdks/dart/example/integration_test/local_network_denied_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:lantern_client/lantern_client.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('iOS Local Network denial fails closed', (tester) async {
+    const endpointValue = String.fromEnvironment('LANTERN_ENDPOINT');
+    expect(endpointValue, isNotEmpty, reason: 'pass LANTERN_ENDPOINT');
+    final client = LanternClient.connect(
+      Uri.parse(endpointValue),
+      allowInsecure: true,
+      retryPolicy: const RetryPolicy(maxAttempts: 1),
+    );
+    addTearDown(client.close);
+
+    try {
+      await client.ping();
+      fail('Local Network denial unexpectedly allowed the request');
+    } on LanternUnavailableException catch (error) {
+      final cause = '${error.cause}';
+      // ignore: avoid_print
+      print('LOCAL_NETWORK_DENIED ${error.cause.runtimeType}: $cause');
+      expect(cause, contains('No route to host'));
+    }
+  });
+}

--- a/sdks/dart/example/integration_test/mobile_smoke_test.dart
+++ b/sdks/dart/example/integration_test/mobile_smoke_test.dart
@@ -76,5 +76,9 @@ void main() {
       ),
       isA<Graph>(),
     );
+    // ignore: avoid_print
+    print(
+      'MOBILE_SMOKE_PASS vertices=${inputs.length} edge=1 scan=true bfs=true',
+    );
   });
 }

--- a/sdks/dart/example/integration_test/physical_api_matrix_test.dart
+++ b/sdks/dart/example/integration_test/physical_api_matrix_test.dart
@@ -1,0 +1,285 @@
+import 'dart:io' as io;
+import 'dart:typed_data';
+
+import 'package:connectrpc/connect.dart' as connect;
+import 'package:connectrpc/io.dart' as connect_io;
+import 'package:connectrpc/protobuf.dart';
+import 'package:connectrpc/protocol/connect.dart' as connect_protocol;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:lantern_client/lantern_client.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const endpointValue = String.fromEnvironment('LANTERN_ENDPOINT');
+  const allowInsecure = bool.fromEnvironment('LANTERN_ALLOW_INSECURE');
+  const oldToken = String.fromEnvironment('LANTERN_OLD_TOKEN');
+  const newToken = String.fromEnvironment('LANTERN_NEW_TOKEN');
+  final endpoint = Uri.parse(endpointValue);
+  final prefix = 'physical-api:${DateTime.now().microsecondsSinceEpoch}:';
+  late LanternClient client;
+  var clientInitialized = false;
+
+  setUpAll(() async {
+    expect(endpointValue, isNotEmpty, reason: 'pass LANTERN_ENDPOINT');
+    expect(oldToken, isNotEmpty, reason: 'pass LANTERN_OLD_TOKEN');
+    expect(newToken, isNotEmpty, reason: 'pass LANTERN_NEW_TOKEN');
+    client = LanternClient.connect(
+      endpoint,
+      token: newToken,
+      allowInsecure: allowInsecure,
+      retryPolicy: const RetryPolicy(),
+      idempotentAdds: true,
+    );
+    clientInitialized = true;
+    await client.ping();
+  });
+
+  tearDownAll(() {
+    if (clientInitialized) client.close();
+  });
+
+  test('missing and rotated runtime tokens', () async {
+    String? currentToken;
+    final rotating = LanternClient.connect(
+      endpoint,
+      tokenProvider: () async => currentToken,
+      allowInsecure: allowInsecure,
+    );
+    addTearDown(rotating.close);
+
+    await expectLater(
+      rotating.scanVertexKeys(prefix: prefix),
+      throwsA(isA<LanternUnauthenticatedException>()),
+    );
+    currentToken = oldToken;
+    expect(await rotating.scanVertexKeys(prefix: prefix), isA<Page<String>>());
+    currentToken = newToken;
+    expect(await rotating.scanVertexKeys(prefix: prefix), isA<Page<String>>());
+  });
+
+  test('every Vertex oneof preserves its exact value', () async {
+    final timestamp = DateTime.parse('2026-07-12T01:02:03Z');
+    const duration = Duration(seconds: -12, microseconds: -345);
+    final inputs = <VertexInput>[
+      VertexInput(key: '${prefix}f64', value: VertexValue.float64(1.25)),
+      VertexInput(key: '${prefix}f32', value: VertexValue.float32(2.5)),
+      VertexInput(key: '${prefix}i32', value: VertexValue.int32(-0x80000000)),
+      VertexInput(
+        key: '${prefix}i64',
+        value: VertexValue.int64(-0x8000000000000000),
+      ),
+      VertexInput(key: '${prefix}u32', value: VertexValue.uint32(0xffffffff)),
+      VertexInput(
+        key: '${prefix}u64',
+        value: VertexValue.uint64((BigInt.one << 64) - BigInt.one),
+      ),
+      VertexInput(key: '${prefix}bool', value: VertexValue.boolean(true)),
+      VertexInput(key: '${prefix}string', value: VertexValue.string('lantern')),
+      VertexInput(
+        key: '${prefix}bytes',
+        value: VertexValue.bytes(Uint8List.fromList([0, 1, 255])),
+      ),
+      VertexInput(
+        key: '${prefix}timestamp',
+        value: VertexValue.timestamp(timestamp),
+      ),
+      VertexInput(
+        key: '${prefix}duration',
+        value: VertexValue.duration(duration),
+      ),
+      VertexInput(key: '${prefix}nil', value: VertexValue.nil()),
+      VertexInput(key: '${prefix}unset', value: VertexValue.unset()),
+    ];
+
+    expect(
+      (await _withTransportDiagnostics(
+        client.putVertices(inputs, batchSize: 4),
+      )).written,
+      13,
+    );
+    final result = await client.getVertices(
+      inputs.map((input) => input.key),
+      batchSize: 3,
+    );
+    expect(result.missing, isEmpty);
+    final values = {
+      for (final vertex in result.vertices) vertex.key: vertex.value,
+    };
+    expect((values['${prefix}f64'] as Float64Value).value, 1.25);
+    expect((values['${prefix}f32'] as Float32Value).value, 2.5);
+    expect((values['${prefix}i32'] as Int32Value).value, -0x80000000);
+    expect((values['${prefix}i64'] as Int64Value).value, -0x8000000000000000);
+    expect((values['${prefix}u32'] as Uint32Value).value, 0xffffffff);
+    expect(
+      (values['${prefix}u64'] as Uint64Value).value,
+      (BigInt.one << 64) - BigInt.one,
+    );
+    expect((values['${prefix}bool'] as BoolValue).value, isTrue);
+    expect((values['${prefix}string'] as StringValue).value, 'lantern');
+    expect((values['${prefix}bytes'] as BytesValue).value, [0, 1, 255]);
+    expect((values['${prefix}timestamp'] as TimestampValue).value, timestamp);
+    expect((values['${prefix}duration'] as DurationValue).value, duration);
+    expect(values['${prefix}nil'], isA<NilValue>());
+    expect(values['${prefix}unset'], isA<UnsetValue>());
+  });
+
+  test('cursor pages stay bounded and partial failure is explicit', () async {
+    final pagePrefix = '${prefix}page:';
+    const count = 75;
+    await _withTransportDiagnostics(
+      client.putVertices(
+        List.generate(
+          count,
+          (index) => VertexInput(
+            key: '$pagePrefix${index.toString().padLeft(3, '0')}',
+            value: VertexValue.int32(index),
+          ),
+        ),
+        batchSize: count,
+      ),
+    );
+
+    ScanCursor? cursor;
+    var seen = 0;
+    do {
+      final page = await client.scanVertexKeys(
+        prefix: pagePrefix,
+        limit: 25,
+        cursor: cursor,
+      );
+      expect(page.items.length, lessThanOrEqualTo(25));
+      seen += page.items.length;
+      cursor = page.nextCursor;
+    } while (cursor != null);
+    expect(seen, count);
+
+    final committedKey = '${prefix}partial-ok';
+    final invalidKey = List.filled(2048, 'x').join();
+    await expectLater(
+      client.putVertices([
+        VertexInput(key: committedKey, value: VertexValue.nil()),
+        VertexInput(key: invalidKey, value: VertexValue.nil()),
+      ], batchSize: 1),
+      throwsA(
+        isA<BatchException>()
+            .having((error) => error.committed, 'committed', 1)
+            .having(
+              (error) => error.cause,
+              'cause',
+              isA<LanternInvalidArgumentException>(),
+            ),
+      ),
+    );
+    expect((await client.getVertex(committedKey)).key, committedKey);
+  });
+
+  test(
+    'committed Add response loss retries exactly one contribution',
+    () async {
+      final fault = _CommittedResponseLossTransport(
+        endpoint,
+        '/graph.v1.LanternService/AddEdges',
+      );
+      final retrying = LanternClient.connect(
+        endpoint,
+        token: newToken,
+        allowInsecure: allowInsecure,
+        transport: fault,
+        onClose: fault.close,
+        idempotentAdds: true,
+        retryPolicy: const RetryPolicy(
+          maxAttempts: 3,
+          baseDelay: Duration(milliseconds: 1),
+          maxDelay: Duration(milliseconds: 2),
+        ),
+      );
+      addTearDown(retrying.close);
+      final ref = EdgeRef('${prefix}retry-tail', '${prefix}retry-head');
+
+      expect(
+        await _withTransportDiagnostics(
+          retrying.addEdge(
+            EdgeInput(tail: ref.tail, head: ref.head, weight: 2),
+          ),
+        ),
+        2,
+      );
+      expect((await client.getEdge(ref)).weight, 2);
+      expect(fault.requestsFor('/graph.v1.LanternService/AddEdges'), 2);
+    },
+  );
+}
+
+Future<T> _withTransportDiagnostics<T>(Future<T> operation) async {
+  try {
+    return await operation;
+  } on Object catch (error) {
+    printOnFailure('transport cause: ${_causeChain(error).join(' -> ')}');
+    rethrow;
+  }
+}
+
+List<Object> _causeChain(Object error) {
+  final chain = <Object>[error];
+  Object? current = error;
+  while (true) {
+    current = switch (current) {
+      BatchException(:final cause) => cause,
+      LanternRetryExhaustedException(:final cause) => cause,
+      LanternException(:final cause) => cause,
+      connect.ConnectException(:final cause) => cause,
+      _ => null,
+    };
+    if (current == null || identical(current, chain.last)) return chain;
+    chain.add(current);
+  }
+}
+
+final class _CommittedResponseLossTransport implements connect.Transport {
+  _CommittedResponseLossTransport(Uri endpoint, this._loseProcedure) {
+    _httpClient = io.HttpClient();
+    _inner = connect_protocol.Transport(
+      baseUrl: endpoint.toString(),
+      codec: const ProtoCodec(),
+      httpClient: connect_io.createHttpClient(_httpClient),
+    );
+  }
+
+  late final io.HttpClient _httpClient;
+  late final connect.Transport _inner;
+  final String _loseProcedure;
+  final Map<String, int> _requests = {};
+  var _lossPending = true;
+
+  int requestsFor(String procedure) => _requests[procedure] ?? 0;
+
+  Future<void> close() async => _httpClient.close(force: true);
+
+  @override
+  Future<connect.UnaryResponse<I, O>> unary<I extends Object, O extends Object>(
+    connect.Spec<I, O> spec,
+    I input, [
+    connect.CallOptions? options,
+  ]) async {
+    _requests.update(spec.procedure, (value) => value + 1, ifAbsent: () => 1);
+    final response = await _inner.unary(spec, input, options);
+    if (_lossPending && spec.procedure == _loseProcedure) {
+      _lossPending = false;
+      throw connect.ConnectException(
+        connect.Code.unavailable,
+        'simulated committed response loss',
+      );
+    }
+    return response;
+  }
+
+  @override
+  Future<connect.StreamResponse<I, O>>
+  stream<I extends Object, O extends Object>(
+    connect.Spec<I, O> spec,
+    Stream<I> input, [
+    connect.CallOptions? options,
+  ]) => _inner.stream(spec, input, options);
+}

--- a/sdks/dart/example/integration_test/physical_ui_matrix_test.dart
+++ b/sdks/dart/example/integration_test/physical_ui_matrix_test.dart
@@ -1,0 +1,206 @@
+import 'dart:io' as io;
+import 'dart:typed_data';
+
+import 'package:connectrpc/connect.dart' as connect;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:lantern_client/lantern_client.dart';
+import 'package:lantern_example/main.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('physical UI values, discovery, and navigation cancellation', (
+    tester,
+  ) async {
+    const endpointValue = String.fromEnvironment('LANTERN_ENDPOINT');
+    const tokenEndpointValue = String.fromEnvironment('LANTERN_TOKEN_ENDPOINT');
+    const token = String.fromEnvironment('LANTERN_TOKEN');
+    const allowInsecure = bool.fromEnvironment('LANTERN_ALLOW_INSECURE');
+    expect(endpointValue, isNotEmpty, reason: 'pass LANTERN_ENDPOINT');
+    expect(
+      tokenEndpointValue,
+      isNotEmpty,
+      reason: 'pass LANTERN_TOKEN_ENDPOINT',
+    );
+    expect(token, isNotEmpty, reason: 'pass LANTERN_TOKEN');
+    final endpoint = Uri.parse(endpointValue);
+    await _preflightTokenEndpoint(tester, Uri.parse(tokenEndpointValue));
+    final client = LanternClient.connect(
+      endpoint,
+      token: token,
+      allowInsecure: allowInsecure,
+    );
+    addTearDown(client.close);
+
+    tester.printToConsole('UI_MATRIX seed oneofs');
+    final timestamp = DateTime.parse('2026-07-12T01:02:03Z');
+    const duration = Duration(seconds: -12, microseconds: -345);
+    await _withTransportDiagnostics(
+      client.putVertices([
+        VertexInput(
+          key: 'flutter-demo:00-f64',
+          value: VertexValue.float64(1.25),
+        ),
+        VertexInput(
+          key: 'flutter-demo:01-f32',
+          value: VertexValue.float32(2.5),
+        ),
+        VertexInput(
+          key: 'flutter-demo:02-i32',
+          value: VertexValue.int32(-0x80000000),
+        ),
+        VertexInput(
+          key: 'flutter-demo:03-i64',
+          value: VertexValue.int64(-0x8000000000000000),
+        ),
+        VertexInput(
+          key: 'flutter-demo:04-u32',
+          value: VertexValue.uint32(0xffffffff),
+        ),
+        VertexInput(
+          key: 'flutter-demo:05-u64',
+          value: VertexValue.uint64((BigInt.one << 64) - BigInt.one),
+        ),
+        VertexInput(
+          key: 'flutter-demo:06-bool',
+          value: VertexValue.boolean(true),
+        ),
+        VertexInput(
+          key: 'flutter-demo:07-string',
+          value: VertexValue.string('line\n"quoted"'),
+        ),
+        VertexInput(
+          key: 'flutter-demo:08-bytes',
+          value: VertexValue.bytes(Uint8List.fromList([0, 1, 255])),
+        ),
+        VertexInput(
+          key: 'flutter-demo:09-timestamp',
+          value: VertexValue.timestamp(timestamp),
+        ),
+        VertexInput(
+          key: 'flutter-demo:10-duration',
+          value: VertexValue.duration(duration),
+        ),
+        VertexInput(key: 'flutter-demo:11-nil', value: VertexValue.nil()),
+        VertexInput(key: 'flutter-demo:12-unset', value: VertexValue.unset()),
+      ]),
+    );
+    tester.printToConsole('UI_MATRIX seed complete');
+
+    await tester.pumpWidget(
+      LanternExampleApp(
+        configuration: DemoConfiguration(
+          endpoint: endpoint,
+          tokenEndpoint: Uri.parse(tokenEndpointValue),
+          allowInsecure: allowInsecure,
+        ),
+      ),
+    );
+    tester.printToConsole('UI_MATRIX widget attached');
+    await _pumpUntilState(tester, 'ready: Visible page data');
+    tester.printToConsole('UI_MATRIX discovery ready');
+
+    final exactUint64 = find.textContaining('uint64=18446744073709551615');
+    await tester.scrollUntilVisible(
+      exactUint64,
+      250,
+      scrollable: find.byType(Scrollable).last,
+    );
+    expect(exactUint64, findsOneWidget);
+    final exactBytes = find.textContaining('bytes=base64:AAH/');
+    await tester.scrollUntilVisible(
+      exactBytes,
+      250,
+      scrollable: find.byType(Scrollable).last,
+    );
+    expect(exactBytes, findsOneWidget);
+    final exactDuration = find.textContaining('duration_us=-12000345');
+    await tester.scrollUntilVisible(
+      exactDuration,
+      250,
+      scrollable: find.byType(Scrollable).last,
+    );
+    expect(exactDuration, findsOneWidget);
+    tester.printToConsole('UI_MATRIX exact values visible');
+
+    await tester.tap(find.text('Seed CRUD'));
+    await _pumpUntilState(tester, 'ready: Visible page data');
+    tester.printToConsole('UI_MATRIX CRUD ready');
+    await tester.enterText(find.byKey(const Key('search-field')), 'quiet cafe');
+    await _pumpUntilState(tester, 'ready: Latest search results');
+    tester.printToConsole('UI_MATRIX incremental search ready');
+
+    await tester.tap(find.text('BFS'));
+    await _pumpUntilState(tester, 'ready: BfsOptions graph');
+    expect(find.textContaining('expires='), findsWidgets);
+    await tester.tap(find.text('PPR'));
+    await _pumpUntilState(tester, 'ready: PprOptions graph');
+    await tester.tap(find.text('Community'));
+    await _pumpUntilState(tester, 'ready: LocalCommunityOptions graph');
+    tester.printToConsole('UI_MATRIX traversal families ready');
+
+    await tester.enterText(find.byKey(const Key('search-field')), 'quiet');
+    await tester.pump(const Duration(milliseconds: 20));
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(seconds: 1));
+    expect(tester.takeException(), isNull);
+    tester.printToConsole('UI_MATRIX navigation cancellation ready');
+  });
+}
+
+Future<void> _preflightTokenEndpoint(WidgetTester tester, Uri endpoint) async {
+  final http = io.HttpClient()..connectionTimeout = const Duration(seconds: 5);
+  try {
+    final request = await http
+        .getUrl(endpoint)
+        .timeout(const Duration(seconds: 5));
+    final response = await request.close().timeout(const Duration(seconds: 5));
+    await response.drain<void>().timeout(const Duration(seconds: 5));
+    expect(response.statusCode, io.HttpStatus.ok);
+    tester.printToConsole('UI_MATRIX token BFF preflight ready');
+  } finally {
+    http.close(force: true);
+  }
+}
+
+Future<T> _withTransportDiagnostics<T>(Future<T> operation) async {
+  try {
+    return await operation;
+  } on Object catch (error) {
+    printOnFailure('transport cause: ${_causeChain(error).join(' -> ')}');
+    rethrow;
+  }
+}
+
+List<Object> _causeChain(Object error) {
+  final chain = <Object>[error];
+  Object? current = error;
+  while (true) {
+    current = switch (current) {
+      BatchException(:final cause) => cause,
+      LanternRetryExhaustedException(:final cause) => cause,
+      LanternException(:final cause) => cause,
+      connect.ConnectException(:final cause) => cause,
+      _ => null,
+    };
+    if (current == null || identical(current, chain.last)) return chain;
+    chain.add(current);
+  }
+}
+
+Future<void> _pumpUntilState(
+  WidgetTester tester,
+  String expected, {
+  int attempts = 150,
+}) async {
+  for (var attempt = 0; attempt < attempts; attempt++) {
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 100)),
+    );
+    await tester.pump();
+    if (find.text(expected).evaluate().isNotEmpty) return;
+  }
+  fail('timed out waiting for UI state: $expected');
+}

--- a/sdks/dart/example/integration_test/untrusted_tls_test.dart
+++ b/sdks/dart/example/integration_test/untrusted_tls_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:lantern_client/lantern_client.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('native mobile rejects an untrusted TLS certificate', (
+    tester,
+  ) async {
+    const endpointValue = String.fromEnvironment('LANTERN_ENDPOINT');
+    expect(endpointValue, isNotEmpty, reason: 'pass LANTERN_ENDPOINT');
+    final client = LanternClient.connect(
+      Uri.parse(endpointValue),
+      retryPolicy: const RetryPolicy(maxAttempts: 1),
+    );
+    addTearDown(client.close);
+
+    try {
+      await client.ping();
+      fail('untrusted TLS certificate unexpectedly passed verification');
+    } on LanternUnavailableException catch (error) {
+      final cause = '${error.cause}';
+      // ignore: avoid_print
+      print('UNTRUSTED_TLS_REJECTED ${error.cause.runtimeType}: $cause');
+      expect(cause, contains('CERTIFICATE_VERIFY_FAILED'));
+    }
+  });
+}

--- a/sdks/dart/example/lib/main.dart
+++ b/sdks/dart/example/lib/main.dart
@@ -5,6 +5,25 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:lantern_client/lantern_client.dart';
 
+/// Lossless, type-labelled text used by the example's value list.
+String formatVertexValue(VertexValue value) => switch (value) {
+  Float64Value(value: final number) => 'float64=$number',
+  Float32Value(value: final number) => 'float32=$number',
+  Int32Value(value: final number) => 'int32=$number',
+  Int64Value(value: final number) => 'int64=$number',
+  Uint32Value(value: final number) => 'uint32=$number',
+  Uint64Value(value: final number) => 'uint64=$number',
+  BoolValue(value: final boolean) => 'bool=$boolean',
+  StringValue(value: final string) => 'string=${jsonEncode(string)}',
+  BytesValue(value: final bytes) => 'bytes=base64:${base64Encode(bytes)}',
+  TimestampValue(value: final timestamp) =>
+    'timestamp=${timestamp.toUtc().toIso8601String()}',
+  DurationValue(value: final duration) =>
+    'duration_us=${duration.inMicroseconds}',
+  NilValue() => 'nil',
+  UnsetValue() => 'unset',
+};
+
 void main() {
   runApp(LanternExampleApp(configuration: DemoConfiguration.fromEnvironment()));
 }
@@ -253,7 +272,7 @@ final class _DiscoveryScreenState extends State<_DiscoveryScreen> {
         ...keys.items.map((key) => 'key $key'),
         ...vertices.items.map(
           (vertex) =>
-              'value ${vertex.key}: ${vertex.value.runtimeType} '
+              'value ${vertex.key}: ${formatVertexValue(vertex.value)} '
               'expires=${vertex.expiration?.toIso8601String() ?? 'never'}',
         ),
       ]);

--- a/sdks/dart/example/physical-device-smoke.md
+++ b/sdks/dart/example/physical-device-smoke.md
@@ -17,21 +17,137 @@ flutter test integration_test/mobile_smoke_test.dart -d <device-id> \
 Run the example UI separately with `flutter run` to exercise lifecycle and
 failure-state scenarios that the compact smoke does not automate.
 
+When Flutter classifies a cabled iOS device as wirelessly tethered, use the
+checked-in host driver with `flutter drive --publish-port`,
+`--driver=test_driver/integration_test.dart`, and
+`--target=integration_test/mobile_smoke_test.dart`. If mDNS discovery is
+unavailable, build the same integration-test target in profile mode, install it
+with `xcrun devicectl device install app`, and launch it with CoreDevice. Keep
+the server trace as the real-wire evidence.
+
 ## Required matrix
 
 | Scenario | Physical Android | Physical iOS |
 | --- | --- | --- |
-| Platform-trusted TLS succeeds | Not yet recorded | Not yet recorded |
-| Untrusted/hostname-mismatched TLS fails closed | Not yet recorded | Not yet recorded |
-| Missing and rotated short-lived token | Not yet recorded | Not yet recorded |
-| Airplane/offline, then resume and explicit refetch | Not yet recorded | Not yet recorded |
-| Background/Doze-like pause, then resume/refetch | Not yet recorded | Not yet recorded |
-| Navigation cancels page and incremental-search work | Not yet recorded | Not yet recorded |
-| Large cursor pages and partial batch failure stay bounded | Not yet recorded | Not yet recorded |
-| Add retry preserves exactly one contribution | Not yet recorded | Not yet recorded |
-| Every Vertex oneof renders exactly | Not yet recorded | Not yet recorded |
-| iOS local-network privacy prompt/denial/retry | N/A | Not yet recorded |
+| Platform-trusted TLS succeeds | Passed, 2026-07-18 UTC | Passed, 2026-07-18 UTC |
+| Untrusted/hostname-mismatched TLS fails closed | Passed, 2026-07-18 UTC | Passed, 2026-07-18 UTC |
+| Missing and rotated short-lived token | Passed, 2026-07-18 UTC | Passed, 2026-07-18 UTC |
+| Airplane/offline, then resume and explicit refetch | Passed, 2026-07-18 UTC | Passed, 2026-07-18 UTC |
+| Background/Doze-like pause, then resume/refetch | Passed, 2026-07-18 UTC | Passed, 2026-07-18 UTC |
+| Navigation cancels page and incremental-search work | Passed, 2026-07-18 UTC | Passed, 2026-07-18 UTC |
+| Large cursor pages and partial batch failure stay bounded | Passed, 2026-07-18 UTC | Passed, 2026-07-18 UTC |
+| Add retry preserves exactly one contribution | Passed, 2026-07-18 UTC | Passed, 2026-07-18 UTC |
+| Every Vertex oneof renders exactly | Passed, 2026-07-18 UTC | Passed, 2026-07-18 UTC |
+| iOS local-network privacy prompt/denial/retry | N/A | Passed, 2026-07-18 UTC |
 
 For each completed column, add the UTC date, device/OS, Flutter revision,
 Lantern revision, network topology, commands, and sanitized logs. Never include
 tokens, private keys, device identifiers, or user data.
+
+## v0.1.0 recorded environment
+
+- UTC date: 2026-07-18.
+- Android: Pixel 9a, Android 17 (API 37).
+- iOS: iPhone 16 Pro, iOS 26.5.2 (23F84).
+- Host: MacBook Pro, macOS 26.5.2; Ethernet on the phones' private LAN.
+- Flutter: 3.44.6, Dart 3.12.2, framework revision
+  `ee80f08bbf97172ec030b8751ceab557177a34a6`.
+- Lantern: `31537f49d16c1db3230fae6fc992a7ac5833b058`.
+- Topology: both phones used Wi-Fi on the host's router. Platform-trusted HTTPS
+  used an ephemeral public-CA Cloudflare Quick Tunnel to a local authenticated
+  Lantern server. Local-network privacy and lifecycle tests used the host's LAN
+  address. Runtime credentials were synthetic, short-lived test values.
+
+## Android evidence
+
+Representative sanitized commands:
+
+```bash
+flutter test integration_test/mobile_smoke_test.dart -d <pixel-id> --no-pub \
+  --dart-define=LANTERN_ENDPOINT=https://<public-ca-tunnel>
+
+flutter test integration_test/physical_api_matrix_test.dart -d <pixel-id> \
+  --plain-name '<one physical API contract>' --no-pub \
+  --dart-define=LANTERN_ENDPOINT=https://<public-ca-tunnel> \
+  --dart-define=LANTERN_OLD_TOKEN=<synthetic-old-token> \
+  --dart-define=LANTERN_NEW_TOKEN=<synthetic-new-token>
+
+flutter test integration_test/physical_ui_matrix_test.dart -d <pixel-id> \
+  --no-pub --dart-define=LANTERN_ENDPOINT=http://<host-lan-address>:<auth-port> \
+  --dart-define=LANTERN_TOKEN_ENDPOINT=http://<host-lan-address>:<bff-port>/token \
+  --dart-define=LANTERN_TOKEN=<synthetic-token> \
+  --dart-define=LANTERN_ALLOW_INSECURE=true
+```
+
+Sanitized observations:
+
+```text
+All tests passed!  # mobile smoke
+All tests passed!  # missing -> old -> new runtime token rotation
+All tests passed!  # all 13 Vertex oneofs preserve exact values
+All tests passed!  # 75 items in three bounded cursor pages; partial failure explicit
+All tests passed!  # two committed-response-loss retries; final edge weight = 2
+UI_MATRIX discovery ready
+UI_MATRIX exact values visible
+UI_MATRIX CRUD ready
+UI_MATRIX incremental search ready
+UI_MATRIX traversal families ready
+UI_MATRIX navigation cancellation ready
+All tests passed!
+```
+
+The platform-trusted tunnel completed every RPC. The untrusted-certificate run
+failed with `CERTIFICATE_VERIFY_FAILED` and no accepted RPC. Airplane mode made
+the LAN `Network is unreachable`; after restoring Wi-Fi, token fetch and
+`ScanVertexKeys` / `ScanVertices` succeeded. A real screen-off forced Doze
+reported `IDLE`; after `unforce`, unlock, and foreground resume, both scans
+again completed with `grpc.code=ok`. Airplane mode, Wi-Fi, Private DNS, and the
+device VPN were restored after testing.
+
+## iOS evidence
+
+Representative sanitized commands:
+
+```bash
+flutter test integration_test/local_network_denied_test.dart -d <iphone-id> \
+  --no-pub --dart-define=LANTERN_ENDPOINT=http://<host-lan-address>:<open-port>
+
+flutter build ios --profile --no-pub \
+  --target=integration_test/mobile_smoke_test.dart \
+  --dart-define=LANTERN_ENDPOINT=http://<host-lan-address>:<open-port> \
+  --dart-define=LANTERN_ALLOW_INSECURE=true
+xcrun devicectl device install app --device <iphone-id> \
+  build/ios/iphoneos/Runner.app
+xcrun devicectl device process launch --device <iphone-id> \
+  --terminate-existing com.anaregdesign.lanternExample
+```
+
+Sanitized observations:
+
+```text
+LOCAL_NETWORK_DENIED SocketException: No route to host (errno = 65)
+All tests passed!
+PutVertices                  grpc.code=ok  # 13 Vertex oneofs
+GetVertices                  grpc.code=ok
+AddEdges                     grpc.code=ok
+ScanVertexKeys               grpc.code=ok
+Illuminate family=bfs        grpc.code=ok
+TLS handshake error from <iphone-lan-address>: EOF  # self-signed endpoint
+```
+
+The public-CA HTTPS API matrix passed all four contracts in one physical run:
+missing/rotated runtime tokens, exact 13-oneof round-trip, 75-item bounded
+cursor paging plus explicit partial failure, and committed Add response loss
+with one final contribution. The physical UI matrix passed runtime-token BFF,
+lossless `uint64` / bytes / duration rendering, CRUD, incremental search,
+BFS/PPR/community, edge expiration, and navigation cancellation.
+
+With Local Network permission off, the SDK failed closed with `No route to
+host`; after the system prompt was allowed, the complete mobile smoke RPC set
+completed with `grpc.code=ok`. A dedicated self-signed TLS test accepted only a
+cause containing `CERTIFICATE_VERIFY_FAILED`; the server observed an immediate
+handshake EOF and zero RPCs. A real Home gesture followed by reopening the app
+triggered successful scans. Airplane mode produced the bounded
+`retryExhausted` UI state and zero server RPCs; after restoring Airplane mode,
+Wi-Fi, and foreground state, `ScanVertexKeys`, `ScanVertices`, and
+`TopVerticesByDegree` completed with `grpc.code=ok`.

--- a/sdks/dart/example/pubspec.lock
+++ b/sdks/dart/example/pubspec.lock
@@ -42,7 +42,7 @@ packages:
     source: hosted
     version: "1.19.1"
   connectrpc:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: connectrpc
       sha256: a1dbf301d0dfa189bb879a9f15bbe72f31dbac581f385035a10fcc2d31a93a18

--- a/sdks/dart/example/pubspec.yaml
+++ b/sdks/dart/example/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
     path: ..
 
 dev_dependencies:
+  connectrpc: 1.0.0
   flutter_test:
     sdk: flutter
   integration_test:

--- a/sdks/dart/example/test/widget_test.dart
+++ b/sdks/dart/example/test/widget_test.dart
@@ -1,5 +1,8 @@
+import 'dart:typed_data';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lantern_client/lantern_client.dart';
 import 'package:lantern_example/main.dart';
 
 void main() {
@@ -10,5 +13,48 @@ void main() {
 
     expect(find.byKey(const Key('configuration-help')), findsOneWidget);
     expect(find.textContaining('LANTERN_ALLOW_INSECURE'), findsOneWidget);
+  });
+
+  test('formats every Vertex oneof without losing type or precision', () {
+    final timestamp = DateTime.parse('2026-07-12T01:02:03Z');
+    const duration = Duration(seconds: -12, microseconds: -345);
+
+    expect(formatVertexValue(VertexValue.float64(1.25)), 'float64=1.25');
+    expect(formatVertexValue(VertexValue.float32(2.5)), 'float32=2.5');
+    expect(
+      formatVertexValue(VertexValue.int32(-0x80000000)),
+      'int32=-2147483648',
+    );
+    expect(
+      formatVertexValue(VertexValue.int64(-0x8000000000000000)),
+      'int64=-9223372036854775808',
+    );
+    expect(
+      formatVertexValue(VertexValue.uint32(0xffffffff)),
+      'uint32=4294967295',
+    );
+    expect(
+      formatVertexValue(VertexValue.uint64((BigInt.one << 64) - BigInt.one)),
+      'uint64=18446744073709551615',
+    );
+    expect(formatVertexValue(VertexValue.boolean(true)), 'bool=true');
+    expect(
+      formatVertexValue(VertexValue.string('line\n"quoted"')),
+      r'string="line\n\"quoted\""',
+    );
+    expect(
+      formatVertexValue(VertexValue.bytes(Uint8List.fromList([0, 1, 255]))),
+      'bytes=base64:AAH/',
+    );
+    expect(
+      formatVertexValue(VertexValue.timestamp(timestamp)),
+      'timestamp=2026-07-12T01:02:03.000Z',
+    );
+    expect(
+      formatVertexValue(VertexValue.duration(duration)),
+      'duration_us=-12000345',
+    );
+    expect(formatVertexValue(VertexValue.nil()), 'nil');
+    expect(formatVertexValue(VertexValue.unset()), 'unset');
   });
 }

--- a/sdks/dart/example/test_driver/integration_test.dart
+++ b/sdks/dart/example/test_driver/integration_test.dart
@@ -1,0 +1,3 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();

--- a/sdks/dart/pubspec.lock
+++ b/sdks/dart/pubspec.lock
@@ -418,4 +418,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"


### PR DESCRIPTION
## What changed

- records the completed physical Pixel and iPhone release matrix with sanitized commands and observations
- adds repeatable mobile integration targets for token rotation, all Vertex oneofs, bounded paging and partial failure, deduplicated Add retry, UI flows, iOS Local Network denial, and untrusted TLS
- renders every Vertex value losslessly in the maintained Flutter example and covers the formatter with a widget test
- adds the standard Flutter integration-test host driver and includes it in the CI format gate
- updates lock metadata to the repository's minimum supported Dart 3.11 floor

## Why

`lantern_client` v0.1.0 requires real Android and iOS evidence before its first pub.dev publish. Simulator and emulator CI cannot establish iOS Local Network privacy behavior, actual radio transitions, or Android Doze recovery.

## Impact

The package API is unchanged. The maintained example now displays exact typed values and keeps reusable physical-device test targets for future releases.

## Validation

- Physical Pixel 9a / Android 17 matrix: passed
- Physical iPhone 16 Pro / iOS 26.5.2 matrix: passed
- `dart format`, `dart analyze`, `dart test`: passed (74 tests; configured real-wire suite run separately)
- four-server real-wire suite: passed (17 tests)
- Flutter format, analyze, and widget tests: passed
- Android debug APK and iOS debug no-codesign builds: passed
- generated Dart stub drift: none
- dartdoc link validation: 0 warnings, 0 errors
- publish dry-run from a clean checkout: 0 warnings
- pana 0.23.14: 140/160; only generated-stub lint and the intentional protobuf major constraint reduce the score
- `gofmt` and `go test ./...` in root, pb, core, sdks/go, server, and mcp: passed

Closes #1017
