### PR TITLE
chore(release): prepare Go SDK v0.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.5.0
-	github.com/anaregdesign/lantern/core v0.17.0
+	github.com/anaregdesign/lantern/core v0.18.0
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
-	github.com/anaregdesign/lantern/pb v0.11.0
+	github.com/anaregdesign/lantern/pb v0.12.0
 	github.com/anaregdesign/lantern/sdks/go v0.22.0
 	github.com/anaregdesign/lantern/server v0.0.0-00010101000000-000000000000
 	github.com/manifoldco/promptui v0.9.0

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -4,8 +4,8 @@ go 1.26
 
 require (
 	connectrpc.com/connect v1.20.0
-	github.com/anaregdesign/lantern/core v0.17.0
-	github.com/anaregdesign/lantern/pb v0.11.0
+	github.com/anaregdesign/lantern/core v0.18.0
+	github.com/anaregdesign/lantern/pb v0.12.0
 	golang.org/x/net v0.57.0
 	google.golang.org/protobuf v1.36.11
 )

--- a/sdks/go/go.sum
+++ b/sdks/go/go.sum
@@ -1,7 +1,7 @@
 connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=
 connectrpc.com/connect v1.20.0/go.mod h1:A2ygJrukXwWy32vkCAAHNVguZrqZ+jeZ9rGRnGR4dN4=
-github.com/anaregdesign/lantern/core v0.17.0 h1:lOvIsxoXjqafHbaaq/WrgXZX4n5OGAeiCwXLHyCiwzI=
-github.com/anaregdesign/lantern/core v0.17.0/go.mod h1:P9G9uYZ+hIlt2/6Yd9t/WSZqGN+4w22AOqjOSo2ZS4A=
+github.com/anaregdesign/lantern/core v0.18.0 h1:70zg6YuFY5ZTh7RkBCLhdQlzRAhc8DrPWMLUxjJOLNU=
+github.com/anaregdesign/lantern/core v0.18.0/go.mod h1:TjajZVWzKxo8eKAOTCKMEX/DalGmLSY4nFd4Lblf8II=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=


### PR DESCRIPTION
Pins the Go SDK and root module to the freshly released pb/v0.12.0 and core/v0.18.0 module tags, then refreshes the Go SDK checksums. The root leaf pins are required for the GOWORK=off generation gate and follow the documented release dependency order.

Local release gate passed across the root and all Go modules, the Dart SDK, and the Flutter example. GOWORK=off go generate ./... also passes without generated drift.

Closes #1117