### PR TITLE
fix(bench): stabilize search release cooldown

### DIFF
--- a/testbed/bench/scenarios/search_qualification.yaml
+++ b/testbed/bench/scenarios/search_qualification.yaml
@@ -10,7 +10,10 @@ phases:
   # makes the pre probe prove expiration rather than merely presence.
   warmup:   { duration: 12s, concurrency: 4, rps: 100 }
   steady:   { duration: 20s, concurrency: 8, rps: 300 }
-  cooldown: 15s
+  # Hosted runners can delay replication and the 2s expiration sweep under
+  # image-build contention. Match the established TTL-churn settle window so
+  # the post snapshot measures a drained index rather than scheduler timing.
+  cooldown: 60s
 semantic_gate:
   kind: search
 target:

--- a/testbed/bench/scenarios_gate_test.go
+++ b/testbed/bench/scenarios_gate_test.go
@@ -311,12 +311,22 @@ func TestSearchQualificationScenarioGateContract(t *testing.T) {
 		t.Fatal(err)
 	}
 	var doc struct {
+		Phases struct {
+			Cooldown string `yaml:"cooldown"`
+		} `yaml:"phases"`
 		MetricGate struct {
 			Metrics map[string]map[string]float64 `yaml:"metrics"`
 		} `yaml:"metric_gate"`
 	}
 	if err := yaml.Unmarshal(raw, &doc); err != nil {
 		t.Fatalf("parse search_qualification: %v", err)
+	}
+	cooldown, err := time.ParseDuration(doc.Phases.Cooldown)
+	if err != nil {
+		t.Fatalf("parse search_qualification cooldown: %v", err)
+	}
+	if cooldown < time.Minute {
+		t.Errorf("search qualification cooldown = %s, want at least 1m for TTL index quiescence", cooldown)
 	}
 	for _, metric := range []string{
 		"lantern_search_index_retained_term_slots",


### PR DESCRIPTION
The v0.33.0 blocking Search qualification failed only its metric gate on a hosted runner: after the fixed 15-second cooldown, the writer replica still retained 232 TTL-expired index documents and queue entries. Semantic, leak, and perf gates all passed, and the same tagged image/scenario passed locally.

This change uses the established 60-second TTL-churn settle window and adds a scenario contract test so future edits cannot shorten the release qualification below one minute.

Verification:

- exact search_qualification scenario: all four gates pass
- full monorepo local quality gate
- Dart publish dry-run: 0 warnings

Refs #1118