### PR TITLE
fix(ci): bootstrap Dart pub OIDC

### DIFF
--- a/.github/workflows/dart-sdk.yml
+++ b/.github/workflows/dart-sdk.yml
@@ -488,6 +488,7 @@ jobs:
     needs: [gate]
     if: startsWith(github.ref, 'refs/tags/sdks/dart/v')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: pub.dev
       url: https://pub.dev/packages/lantern_client
@@ -502,12 +503,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Flutter
-        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+      # setup-dart also mints and configures the GitHub OIDC credential that
+      # pub.dev's automated publisher consumes. A Flutter-only setup silently
+      # falls back to interactive Google OAuth in a headless runner.
+      - name: Set up current supported Dart and pub.dev OIDC
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
         with:
-          channel: stable
-          flutter-version: 3.44.6
-          cache: true
+          sdk: 3.12.2
 
       - name: Verify tag, package version, and changelog
         env:

--- a/sdks/dart/CHANGELOG.md
+++ b/sdks/dart/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.2
+
+- Bootstrap pub.dev authentication with the official `dart-lang/setup-dart`
+  GitHub OIDC flow so headless releases cannot fall back to interactive Google
+  OAuth.
+- Bound the publish job with a hard timeout. This patch changes release
+  automation only; the SDK API and runtime behavior are unchanged from 0.1.1.
+
 ## 0.1.1
 
 - Accept the Dart offline contract and set an official, opt-in

--- a/sdks/dart/example/pubspec.lock
+++ b/sdks/dart/example/pubspec.lock
@@ -120,7 +120,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.1"
+    version: "0.1.2"
   leak_tracker:
     dependency: transitive
     description:

--- a/sdks/dart/pubspec.yaml
+++ b/sdks/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lantern_client
 description: Pure Dart client SDK for Lantern, an in-memory graph key-vertex store with TTL-aware vertices and edges.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/anaregdesign/lantern
 homepage: https://github.com/anaregdesign/lantern/tree/main/sdks/dart
 issue_tracker: https://github.com/anaregdesign/lantern/issues

--- a/tests/integration/docs_gate_test.go
+++ b/tests/integration/docs_gate_test.go
@@ -113,14 +113,21 @@ func TestDartPublishingContractGate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read Dart SDK workflow: %v", err)
 	}
+	publishStart := strings.Index(string(workflow), "\n  publish:\n")
+	if publishStart == -1 {
+		t.Fatal("Dart SDK workflow is missing the publish job")
+	}
+	publishWorkflow := string(workflow)[publishStart:]
 
 	for _, contract := range []string{
 		"startsWith(github.ref, 'refs/tags/sdks/dart/v')",
+		"timeout-minutes: 15",
 		"id-token: write",
+		"uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1",
 		"dart pub publish --force",
 		`gh release create "$TAG" --title "$TAG"`,
 	} {
-		if !strings.Contains(string(workflow), contract) {
+		if !strings.Contains(publishWorkflow, contract) {
 			t.Errorf("Dart SDK workflow is missing publishing contract %q", contract)
 		}
 	}


### PR DESCRIPTION
## Summary
- replace the Flutter-only publish setup with the pinned official `dart-lang/setup-dart` OIDC bootstrap
- add a 15-minute publish timeout and enforce both contracts in the integration gate
- prepare immutable Dart patch release `0.1.2` because `sdks/dart/v0.1.1` was already pushed but never published

## Evidence
The cancelled `sdks/dart/v0.1.1` job log reached interactive Google OAuth and waited indefinitely. The official Dart automated-publishing documentation states that `dart-lang/setup-dart` creates and configures the temporary GitHub OIDC token consumed by `dart pub publish`.

## Verification
- full root and per-module Go quality gate
- Dart format/analyze/test, warning-free dartdoc, clean-tree publish dry-run (0 warnings)
- Flutter example format/analyze/test

Refs #1118