### PR TITLE
fix(ci): isolate Dart publish lock resolution

### DIFF
--- a/.github/workflows/dart-sdk.yml
+++ b/.github/workflows/dart-sdk.yml
@@ -524,7 +524,9 @@ jobs:
           echo "VERSION=$tag_version" >> "$GITHUB_ENV"
 
       - name: Resolve exact lockfile
-        run: dart pub get --enforce-lockfile
+        # The publish runner intentionally installs Dart only. Resolve the
+        # package lock without descending into the maintained Flutter example.
+        run: dart pub get --enforce-lockfile --no-example
 
       - name: Check pub.dev package/version state
         run: |

--- a/sdks/dart/CHANGELOG.md
+++ b/sdks/dart/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.3
+
+- Resolve the package lock without descending into the Flutter example on the
+  pure-Dart pub.dev OIDC runner. This patch changes release automation only;
+  the SDK API and runtime behavior are unchanged from 0.1.2.
+
 ## 0.1.2
 
 - Bootstrap pub.dev authentication with the official `dart-lang/setup-dart`

--- a/sdks/dart/example/pubspec.lock
+++ b/sdks/dart/example/pubspec.lock
@@ -120,7 +120,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.2"
+    version: "0.1.3"
   leak_tracker:
     dependency: transitive
     description:

--- a/sdks/dart/pubspec.yaml
+++ b/sdks/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lantern_client
 description: Pure Dart client SDK for Lantern, an in-memory graph key-vertex store with TTL-aware vertices and edges.
-version: 0.1.2
+version: 0.1.3
 repository: https://github.com/anaregdesign/lantern
 homepage: https://github.com/anaregdesign/lantern/tree/main/sdks/dart
 issue_tracker: https://github.com/anaregdesign/lantern/issues

--- a/tests/integration/docs_gate_test.go
+++ b/tests/integration/docs_gate_test.go
@@ -125,6 +125,7 @@ func TestDartPublishingContractGate(t *testing.T) {
 		"timeout-minutes: 15",
 		"id-token: write",
 		"uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1",
+		"dart pub get --enforce-lockfile --no-example",
 		"dart pub publish --force",
 		`gh release create "$TAG" --title "$TAG"`,
 	} {


### PR DESCRIPTION
## Summary

- resolve the package lock with --no-example on the pure-Dart pub.dev OIDC runner
- preserve Flutter example validation in the dedicated Android and iOS jobs
- cut immutable replacement version 0.1.3 because failed tags are never moved
- gate the publish-specific resolution contract

## Verification

- full Go workspace tests and server vet
- Dart format/analyze/test/dartdoc/publish dry-run (0 warnings)
- Flutter example format/analyze/test

Refs #1118