### PR TITLE
fix(search): bound recovery rebuild memory

### DIFF
--- a/core/graphcache/bench_test.go
+++ b/core/graphcache/bench_test.go
@@ -488,6 +488,48 @@ func BenchmarkPutVertex_Search(b *testing.B) {
 	})
 }
 
+// BenchmarkSearchIndexRecovery measures only the derived-index rebuild phase
+// after a restore has populated the source-of-truth graph. The recovery path
+// must retain at most one bounded prepared batch rather than a second analyzed
+// representation of the complete corpus; alloc_B/doc is the headline metric.
+func BenchmarkSearchIndexRecovery(b *testing.B) {
+	const documents = 10_000
+	expiration := time.Now().Add(time.Hour)
+	b.ReportAllocs()
+	for range b.N {
+		b.StopTimer()
+		c := NewGraphCache[string, string](time.Hour)
+		c.EnableSearchIndex(keyValueExtract, compareStringID)
+		c.BeginSearchIndexRecovery()
+		c.mu.Lock()
+		for i := range documents {
+			c.upsertVertexStorageLocked(
+				makeKey("recovery", i, 24),
+				benchSearchCorpus[i%len(benchSearchCorpus)],
+				expiration,
+			)
+		}
+		c.mu.Unlock()
+		runtime.GC()
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+		b.StartTimer()
+
+		if err := c.CompleteSearchIndexRecovery(); err != nil {
+			b.Fatal(err)
+		}
+
+		b.StopTimer()
+		runtime.ReadMemStats(&after)
+		b.ReportMetric(float64(after.TotalAlloc-before.TotalAlloc)/documents, "alloc_B/doc")
+		if got := c.SearchIndexMemoryStats().Documents; got != documents {
+			b.Fatalf("indexed documents = %d, want %d", got, documents)
+		}
+		runtime.KeepAlive(c)
+		b.StartTimer()
+	}
+}
+
 // BenchmarkScanEdgesByPrefix measures the edge-prefix scan after #742 moved the
 // visitor out of the read lock: matching rows are snapshotted under c.mu.RLock
 // and the visitor replays after release. The headline cost surfaced here is the

--- a/core/graphcache/search.go
+++ b/core/graphcache/search.go
@@ -121,8 +121,10 @@ func (c *GraphCache[S, T]) EnableSearchIndex(extract func(S, T) search.Document,
 }
 
 // RebuildSearchIndex re-analyzes the complete live graph under the configured
-// limits and atomically replaces an incomplete index. It fails without
-// changing health when any current vertex still exceeds a bound.
+// limits and atomically replaces an incomplete index. The replacement is built
+// through bounded batches so recovery memory does not scale with a second
+// corpus-wide PreparedItem slice. It fails without changing health when any
+// current vertex still exceeds a bound.
 func (c *GraphCache[S, T]) RebuildSearchIndex() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -164,21 +166,14 @@ func (c *GraphCache[S, T]) rebuildSearchIndexLocked() error {
 	if c.searchIndex == nil {
 		return nil
 	}
-	items := make([]search.PreparedItem[S], 0, c.vertices.Count())
-	var firstErr error
-	c.vertices.Range(func(key S, value T, expiration time.Time) bool {
-		prepared, _, err := c.searchIndex.Prepare(c.searchExtract(key, value))
-		if err != nil {
-			firstErr = err
-			return false
-		}
-		items = append(items, search.PreparedItem[S]{ID: key, Prepared: prepared, Expiration: expiration})
-		return true
-	})
-	if firstErr != nil {
+	return c.searchIndex.RebuildDocuments(func(yield func(S, search.Document, time.Time) error) error {
+		var firstErr error
+		c.vertices.Range(func(key S, value T, expiration time.Time) bool {
+			firstErr = yield(key, c.searchExtract(key, value), expiration)
+			return firstErr == nil
+		})
 		return firstErr
-	}
-	return c.searchIndex.RebuildPrepared(items)
+	})
 }
 
 func (c *GraphCache[S, T]) rebuildIncompleteSearchLocked() {

--- a/core/graphcache/search_test.go
+++ b/core/graphcache/search_test.go
@@ -105,7 +105,7 @@ func TestGraphCacheSearchAnalysisLimits(t *testing.T) {
 		}
 	})
 
-	t.Run("bulk recovery stays incomplete until exact rebuild", func(t *testing.T) {
+	t.Run("bulk recovery stays incomplete until bounded exact rebuild", func(t *testing.T) {
 		c := newCache()
 		expiration := time.Now().Add(time.Minute)
 		if err := c.PutVertexWithExpiration("before", "alpha", expiration); err != nil {
@@ -126,6 +126,9 @@ func TestGraphCacheSearchAnalysisLimits(t *testing.T) {
 		}
 		if got := c.SearchIndexMemoryStats().Health; got != search.IndexHealthy {
 			t.Fatalf("health after recovery = %q", got)
+		}
+		if got := c.SearchIndexMemoryStats().RebuildCount; got != 1 {
+			t.Fatalf("rebuild count = %d, want 1", got)
 		}
 		if got := keys(c.SearchVertices("alpha beta", 10, "")); !reflect.DeepEqual(got, []string{"before", "during"}) {
 			t.Fatalf("rebuilt results = %v", got)

--- a/core/search/inverted_index.go
+++ b/core/search/inverted_index.go
@@ -83,6 +83,13 @@ type InvertedIndex[S comparable, D Document] struct {
 	generation            uint64
 }
 
+// rebuildBatchSize bounds the transient analyzed representation retained while
+// reconstructing an index. RebuildDocuments publishes only after the complete
+// replacement passes every limit, so this batch is an implementation detail:
+// it trades a small number of write-lock acquisitions for a corpus-independent
+// memory ceiling during restore and replication recovery.
+const rebuildBatchSize = 256
+
 // classPostings is one token class's slice of the index: its term dictionary,
 // its postings, and the class-scoped corpus statistics BM25 length
 // normalization and IDF need. Keeping them per class is what stops auxiliary
@@ -744,17 +751,73 @@ func (idx *InvertedIndex[S, D]) Compact() {
 // and swaps it in only after every aggregate limit succeeds. A failed rebuild
 // leaves the prior (possibly incomplete) index untouched and unhealthy.
 func (idx *InvertedIndex[S, D]) RebuildPrepared(items []PreparedItem[S]) error {
+	tmp := idx.emptyClone()
+	start := time.Now()
+	if err := tmp.IndexManyPrepared(items); err != nil {
+		return err
+	}
+	idx.publishRebuild(tmp, start)
+	return nil
+}
+
+// RebuildDocuments constructs a complete replacement through bounded batches
+// and publishes it atomically. visit must call yield for each document in the
+// desired final corpus. Analysis and aggregate-limit validation happen against
+// the replacement; an error discards it and leaves the prior index unchanged.
+//
+// Unlike RebuildPrepared, this path never retains the analyzed representation
+// of the whole corpus. It is intended for recovery code that already owns the
+// source-of-truth graph and can enumerate it while searches fail closed.
+func (idx *InvertedIndex[S, D]) RebuildDocuments(visit func(yield func(S, D, time.Time) error) error) error {
+	if visit == nil {
+		panic("search: RebuildDocuments visit must not be nil")
+	}
+	tmp := idx.emptyClone()
+	start := time.Now()
+	batch := make([]PreparedItem[S], 0, rebuildBatchSize)
+	flush := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		if err := tmp.IndexManyPrepared(batch); err != nil {
+			return err
+		}
+		clear(batch)
+		batch = batch[:0]
+		return nil
+	}
+	yield := func(id S, doc D, expiration time.Time) error {
+		prepared, _, err := tmp.Prepare(doc)
+		if err != nil {
+			return err
+		}
+		batch = append(batch, PreparedItem[S]{ID: id, Prepared: prepared, Expiration: expiration})
+		if len(batch) == cap(batch) {
+			return flush()
+		}
+		return nil
+	}
+	if err := visit(yield); err != nil {
+		return err
+	}
+	if err := flush(); err != nil {
+		return err
+	}
+	idx.publishRebuild(tmp, start)
+	return nil
+}
+
+func (idx *InvertedIndex[S, D]) emptyClone() *InvertedIndex[S, D] {
 	var opts []IndexOption
 	if idx.positions {
 		opts = append(opts, WithPositions())
 	}
 	opts = append(opts, WithProximityWeight(idx.proximityWeight), WithAnalysisLimits(idx.limits))
 	opts = append(opts, WithIndexClock(idx.clock))
-	tmp := NewInvertedIndex[S, D](idx.analyzer, idx.scorer, idx.compareID, opts...)
-	start := time.Now()
-	if err := tmp.IndexManyPrepared(items); err != nil {
-		return err
-	}
+	return NewInvertedIndex[S, D](idx.analyzer, idx.scorer, idx.compareID, opts...)
+}
+
+func (idx *InvertedIndex[S, D]) publishRebuild(tmp *InvertedIndex[S, D], start time.Time) {
 	idx.lockWrite()
 	defer idx.mu.Unlock()
 	idx.classes, idx.ords, idx.docs, idx.expirations = tmp.classes, tmp.ords, tmp.docs, tmp.expirations
@@ -763,7 +826,6 @@ func (idx *InvertedIndex[S, D]) RebuildPrepared(items []PreparedItem[S]) error {
 	idx.rebuildCount++
 	idx.generation++
 	idx.lastRebuildDuration = time.Since(start)
-	return nil
 }
 
 func (idx *InvertedIndex[S, D]) compactIfNeededLocked() {

--- a/core/search/inverted_index_test.go
+++ b/core/search/inverted_index_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 // fakeAnalyzer is a whitespace-splitting, case-folding analyzer used to
@@ -225,6 +226,67 @@ func TestInvertedIndexCompactionAndHealth(t *testing.T) {
 	if got := idx.MemoryStats().Health; got != IndexHealthy {
 		t.Fatalf("health = %q", got)
 	}
+}
+
+func TestInvertedIndexRebuildDocuments(t *testing.T) {
+	t.Run("publishes complete replacement atomically", func(t *testing.T) {
+		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID)
+		if err := idx.Index("old", Text("alpha")); err != nil {
+			t.Fatal(err)
+		}
+
+		err := idx.RebuildDocuments(func(yield func(string, Text, time.Time) error) error {
+			for i := range rebuildBatchSize {
+				if err := yield(fmt.Sprintf("new-%03d", i), Text("beta"), time.Time{}); err != nil {
+					return err
+				}
+			}
+			// One internal batch has already been applied to the replacement,
+			// but publication must still leave readers on the prior index.
+			if got := idsOf(idx.Search("alpha")); !slices.Equal(got, []string{"old"}) {
+				t.Fatalf("index changed before rebuild publication: %v", got)
+			}
+			return yield("new-final", Text("gamma"), time.Time{})
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := idsOf(idx.Search("alpha")); len(got) != 0 {
+			t.Fatalf("retired document survived rebuild: %v", got)
+		}
+		if got := idsOf(idx.Search("gamma")); !slices.Equal(got, []string{"new-final"}) {
+			t.Fatalf("rebuilt final document = %v", got)
+		}
+		stats := idx.MemoryStats()
+		if stats.Health != IndexHealthy || stats.RebuildCount != 1 || stats.Documents != rebuildBatchSize+1 {
+			t.Fatalf("rebuild stats = %+v", stats)
+		}
+	})
+
+	t.Run("limit failure retains prior index", func(t *testing.T) {
+		idx := NewInvertedIndex[string, Text](fakeAnalyzer{}, nil, compareStringID,
+			WithAnalysisLimits(SearchAnalysisLimits{MaxLiveTerms: 1}))
+		if err := idx.Index("old", Text("alpha")); err != nil {
+			t.Fatal(err)
+		}
+		err := idx.RebuildDocuments(func(yield func(string, Text, time.Time) error) error {
+			for i := range rebuildBatchSize {
+				if err := yield(fmt.Sprintf("new-%03d", i), Text("beta"), time.Time{}); err != nil {
+					return err
+				}
+			}
+			return yield("new-final", Text("gamma"), time.Time{})
+		})
+		if !isAnalysisLimit(err, LimitLiveTerms) {
+			t.Fatalf("rebuild err = %v", err)
+		}
+		if got := idsOf(idx.Search("alpha")); !slices.Equal(got, []string{"old"}) {
+			t.Fatalf("prior index after rejected rebuild = %v", got)
+		}
+		if got := idx.MemoryStats(); got.RebuildCount != 0 || got.Documents != 1 {
+			t.Fatalf("stats after rejected rebuild = %+v", got)
+		}
+	})
 }
 
 func TestInvertedIndexConcurrentSearchWriteCompaction(t *testing.T) {

--- a/docs/decisions/0003-bounded-search-index-convergence.md
+++ b/docs/decisions/0003-bounded-search-index-convergence.md
@@ -27,10 +27,12 @@ marks it `incomplete`. `SearchVertices` then fails closed with
 `SEARCH_INDEX_INCOMPLETE`; point reads, scans, traversal, replication, and
 backup remain available.
 
-A bounded rebuild analyzes every live vertex into a replacement index and
-swaps it atomically only after all limits succeed. It restores `healthy` state.
-Removing or resizing the offending values is therefore required before a
-rebuild can succeed.
+A bounded rebuild analyzes every live vertex into a replacement index through
+fixed-size batches and swaps it atomically only after all limits succeed. The
+rebuild retains one analyzed batch, not a second corpus-wide prepared copy, so
+transient analysis memory is bounded independently of the vertex count. It
+restores `healthy` state. Removing or resizing the offending values is therefore
+required before a rebuild can succeed.
 
 Valid UTF-8 byte values are eligible for text indexing and share the projected
 document byte limit. Arbitrary binary values are stored normally but contribute


### PR DESCRIPTION
## Summary

- rebuild the derived search index through fixed-size prepared batches
- preserve atomic publication, fail-closed health, expiration, and aggregate limits
- add recovery contract coverage and a 10,000-document rebuild benchmark
- keep the Helm default at 512Mi instead of hiding the regression with a resource increase

## Production evidence

The v0.33.1 GKE pod completed restore of 7,783 vertices and 14,465 edges, then was OOM-killed at about 522MiB RSS. The prior implementation retained the complete analyzed corpus while constructing its replacement index. With the bounded path, the 10,000-document GC trace peaked around 39MiB in the rebuild benchmark.

## Verification

- gofmt clean
- go test ./... in root, core, mcp, pb, sdks/go, server
- go vet ./... in server
- Dart format/analyze/test/dartdoc/publish dry-run
- Flutter example format/analyze/test

Closes #1126
Refs #1118