### PR TITLE
chore(release): pin core v0.18.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpchealth v1.5.0
-	github.com/anaregdesign/lantern/core v0.18.0
+	github.com/anaregdesign/lantern/core v0.18.1
 	github.com/anaregdesign/lantern/mcp v0.0.0-00010101000000-000000000000
 	github.com/anaregdesign/lantern/pb v0.12.0
 	github.com/anaregdesign/lantern/sdks/go v0.24.0


### PR DESCRIPTION
## Summary

- pin the root release module to the newly tagged `core/v0.18.1`
- prepare the patched server/container release `v0.33.2`

## Verification

Full local quality gate passed after the version pin: root and all Go modules, server vet, Dart SDK format/analyze/test/dartdoc/publish dry-run, and Flutter example format/analyze/test.

Refs #1118
Refs #1126