### PR TITLE
feat: improve search guidance and make Ops metrics scannable

### DIFF
--- a/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.module.css
+++ b/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.module.css
@@ -82,6 +82,12 @@
   flex-wrap: wrap;
 }
 
+.searchParameter {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingVerticalXXS, 2px);
+}
+
 .searchOptionsMode {
   min-width: 180px;
 }

--- a/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.tsx
+++ b/admin/app/components/browse-vertices/BrowseVerticesPage/BrowseVerticesPage.tsx
@@ -48,6 +48,7 @@ import { useLanternClient } from "~/lib/client/infrastructure/api/use-lantern-cl
 import { ValueCell } from "../ValueCell/ValueCell";
 import { ExpirationCell } from "../ExpirationCell/ExpirationCell";
 import { Pager } from "../Pager/Pager";
+import { SearchParameterLabel } from "../SearchParameterLabel/SearchParameterLabel";
 import styles from "./BrowseVerticesPage.module.css";
 
 /**
@@ -66,6 +67,24 @@ const MATCH_MODE_LABELS: Record<SearchMatchMode, string> = {
   all: "All words (AND)",
   "min-should": "At least N words",
 };
+
+/** Supplemental explanations shared by every Data > Content search control. */
+const SEARCH_PARAMETER_HELP = {
+  query:
+    "Required full-text input. Lantern analyzes the words and ranks matching live vertices by BM25 relevance.",
+  match:
+    "Controls how analyzed query words qualify a result. Server default uses this endpoint's advertised search configuration.",
+  minimumWords:
+    "With At least N words, requires this many distinct analyzed query words to match. The value must be a positive integer.",
+  prefix:
+    "Restricts candidates to vertex keys in this namespace before ranking. Leave empty to search every key.",
+  fuzziness:
+    "Maximum edit distance for typo matching: 0 is exact, 1 or 2 expands to nearby dictionary terms. It cannot combine with Phrase.",
+  prefixTerms:
+    'Also matches dictionary terms that extend a query word, such as "lan" matching "lantern". It cannot combine with Phrase.',
+  phrase:
+    "Requires adjacent, ordered words within one key, value, or JSON string field. It needs positional postings, Server default match, fuzziness 0, and Prefix terms off.",
+} as const;
 
 /** A vertex row normalised across both find modes. */
 interface VertexRow {
@@ -201,15 +220,22 @@ export function BrowseVerticesPage() {
 
       <section className={styles.controls}>
         {searching ? (
-          <Field label="Query" className={styles.prefixField}>
+          <div className={`${styles.searchParameter} ${styles.prefixField}`}>
+            <SearchParameterLabel
+              controlId="content-search-query"
+              label="Query"
+              description={SEARCH_PARAMETER_HELP.query}
+              testId="search-query-help"
+            />
             <Input
+              id="content-search-query"
               value={query}
               onChange={(_, data) => setQuery(data.value)}
               placeholder="e.g. distributed systems"
               contentBefore={<Search20Regular />}
               data-testid="search-query-input"
             />
-          </Field>
+          </div>
         ) : (
           <Field label="Key prefix" className={styles.prefixField}>
             <Input
@@ -268,13 +294,19 @@ export function BrowseVerticesPage() {
 
       {searching ? (
         <section className={styles.searchOptions} data-testid="search-options">
-          <Field label="Match">
+          <div className={styles.searchParameter}>
+            <SearchParameterLabel
+              controlId="content-search-match"
+              label="Match"
+              description={SEARCH_PARAMETER_HELP.match}
+              testId="search-mode-help"
+            />
             <Dropdown
+              id="content-search-match"
               className={styles.searchOptionsMode}
               selectedOptions={[matchMode]}
               value={MATCH_MODE_LABELS[matchMode]}
               disabled={phrase}
-              title="Controls query-word membership; Server default defers to this endpoint's advertised configuration."
               onOptionSelect={(_, data) =>
                 setMatchMode((data.optionValue as SearchMatchMode) ?? "server")
               }
@@ -293,10 +325,17 @@ export function BrowseVerticesPage() {
                 At least N words
               </Option>
             </Dropdown>
-          </Field>
+          </div>
           {matchMode === "min-should" ? (
-            <Field label="Minimum words">
+            <div className={styles.searchParameter}>
+              <SearchParameterLabel
+                controlId="content-search-minimum-words"
+                label="Minimum words"
+                description={SEARCH_PARAMETER_HELP.minimumWords}
+                testId="search-min-should-help"
+              />
               <Input
+                id="content-search-minimum-words"
                 type="number"
                 min={1}
                 step={1}
@@ -310,23 +349,35 @@ export function BrowseVerticesPage() {
                 }}
                 data-testid="search-min-should"
               />
-            </Field>
+            </div>
           ) : null}
-          <Field label="Key namespace prefix">
+          <div className={styles.searchParameter}>
+            <SearchParameterLabel
+              controlId="content-search-prefix"
+              label="Key namespace prefix"
+              description={SEARCH_PARAMETER_HELP.prefix}
+              testId="search-prefix-help"
+            />
             <Input
+              id="content-search-prefix"
               value={searchPrefix}
               onChange={(_, data) => setSearchPrefix(data.value)}
               placeholder="e.g. user:"
-              title="Restricts membership to vertex keys in this namespace before ranking."
               data-testid="search-prefix"
             />
-          </Field>
-          <Field label="Fuzziness">
+          </div>
+          <div className={styles.searchParameter}>
+            <SearchParameterLabel
+              controlId="content-search-fuzziness"
+              label="Fuzziness"
+              description={SEARCH_PARAMETER_HELP.fuzziness}
+              testId="search-fuzzy-help"
+            />
             <Dropdown
+              id="content-search-fuzziness"
               selectedOptions={[String(fuzziness)]}
               value={String(fuzziness)}
               disabled={phrase}
-              title="Also visits dictionary terms within this edit distance; phrase mode does not compose with fuzziness."
               onOptionSelect={(_, data) =>
                 setFuzziness(Number(data.optionValue ?? 0) as SearchFuzziness)
               }
@@ -336,21 +387,33 @@ export function BrowseVerticesPage() {
               <Option value="1">1 edit</Option>
               <Option value="2">2 edits</Option>
             </Dropdown>
-          </Field>
-          <Switch
-            label="Prefix terms"
-            checked={prefixTerms}
-            disabled={phrase}
-            title="Also matches dictionary terms extending a query word; phrase mode does not compose with this expansion."
-            onChange={(_, data) => setPrefixTerms(data.checked)}
-            data-testid="search-prefix-terms"
-          />
-          <div>
+          </div>
+          <div className={styles.searchParameter}>
+            <SearchParameterLabel
+              controlId="content-search-prefix-terms"
+              label="Prefix terms"
+              description={SEARCH_PARAMETER_HELP.prefixTerms}
+              testId="search-prefix-terms-help"
+            />
             <Switch
+              id="content-search-prefix-terms"
+              checked={prefixTerms}
+              disabled={phrase}
+              onChange={(_, data) => setPrefixTerms(data.checked)}
+              data-testid="search-prefix-terms"
+            />
+          </div>
+          <div className={styles.searchParameter}>
+            <SearchParameterLabel
+              controlId="content-search-phrase"
               label="Phrase"
+              description={SEARCH_PARAMETER_HELP.phrase}
+              testId="search-phrase-help"
+            />
+            <Switch
+              id="content-search-phrase"
               checked={phrase}
               disabled={positionsEnabled !== true || !phraseCompatible}
-              title="Requires adjacent, ordered words inside one key, value, or JSON string-leaf field."
               onChange={(_, data) => setPhrase(data.checked)}
               data-testid="search-phrase"
             />

--- a/admin/app/components/browse-vertices/SearchParameterLabel/SearchParameterLabel.module.css
+++ b/admin/app/components/browse-vertices/SearchParameterLabel/SearchParameterLabel.module.css
@@ -1,0 +1,6 @@
+.root {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacingHorizontalXXS, 2px);
+  min-height: 24px;
+}

--- a/admin/app/components/browse-vertices/SearchParameterLabel/SearchParameterLabel.tsx
+++ b/admin/app/components/browse-vertices/SearchParameterLabel/SearchParameterLabel.tsx
@@ -1,0 +1,39 @@
+import { Button, Label, Tooltip } from "@fluentui/react-components";
+import { Info16Regular } from "@fluentui/react-icons";
+
+import styles from "./SearchParameterLabel.module.css";
+
+export interface SearchParameterLabelProps {
+  controlId: string;
+  label: string;
+  description: string;
+  testId: string;
+}
+
+/**
+ * Visible form label plus a keyboard- and pointer-discoverable explanation.
+ * The label stays associated with its control; the Tooltip contains only
+ * supplemental contract detail, never validation or required instructions.
+ */
+export function SearchParameterLabel({
+  controlId,
+  label,
+  description,
+  testId,
+}: SearchParameterLabelProps) {
+  return (
+    <span className={styles.root}>
+      <Label htmlFor={controlId}>{label}</Label>
+      <Tooltip content={description} relationship="description" withArrow>
+        <Button
+          type="button"
+          appearance="transparent"
+          size="small"
+          icon={<Info16Regular />}
+          aria-label={`About ${label}`}
+          data-testid={testId}
+        />
+      </Tooltip>
+    </span>
+  );
+}

--- a/admin/app/components/ops/MetricsSection/MetricPanel.tsx
+++ b/admin/app/components/ops/MetricsSection/MetricPanel.tsx
@@ -36,7 +36,7 @@ export function MetricPanel({ panel, state, aliases }: MetricPanelProps) {
   return (
     <Card className={styles.panel} data-testid={testId}>
       <header className={styles.head}>
-        <h3 className={styles.title}>{panel.title}</h3>
+        <h4 className={styles.title}>{panel.title}</h4>
         <p className={styles.description}>{panel.description}</p>
       </header>
       {pending && <Spinner size="tiny" label="Loading…" />}

--- a/admin/app/components/ops/MetricsSection/MetricsSection.module.css
+++ b/admin/app/components/ops/MetricsSection/MetricsSection.module.css
@@ -34,15 +34,27 @@
 .group {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--colorNeutralStroke2);
+}
+
+.groupHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
 }
 
 .groupTitle {
   margin: 0;
-  font-size: 0.8rem;
+  font-size: 1.05rem;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  color: var(--colorNeutralForeground1);
+}
+
+.groupDescription {
+  margin: 0;
+  font-size: 0.85rem;
   color: var(--colorNeutralForeground3);
 }
 

--- a/admin/app/components/ops/MetricsSection/MetricsSection.tsx
+++ b/admin/app/components/ops/MetricsSection/MetricsSection.tsx
@@ -129,6 +129,7 @@ export function MetricsSection({ pollMs, refreshNonce }: MetricsSectionProps) {
           <MetricGroup
             key={group.id}
             label={group.label}
+            description={group.description}
             groupId={group.id}
             panels={panels}
             state={state.panels}
@@ -142,6 +143,7 @@ export function MetricsSection({ pollMs, refreshNonce }: MetricsSectionProps) {
 
 interface MetricGroupProps {
   label: string;
+  description: string;
   groupId: PanelGroup;
   panels: typeof METRIC_PANELS;
   state: Record<string, PanelState>;
@@ -150,14 +152,26 @@ interface MetricGroupProps {
 
 function MetricGroup({
   label,
+  description,
   groupId,
   panels,
   state,
   aliases,
 }: MetricGroupProps) {
+  const headingId = `ops-metrics-heading-${groupId}`;
+
   return (
-    <div className={styles.group} data-testid={`ops-metrics-group-${groupId}`}>
-      <h3 className={styles.groupTitle}>{label}</h3>
+    <section
+      className={styles.group}
+      data-testid={`ops-metrics-group-${groupId}`}
+      aria-labelledby={headingId}
+    >
+      <header className={styles.groupHeader}>
+        <h3 id={headingId} className={styles.groupTitle}>
+          {label}
+        </h3>
+        <p className={styles.groupDescription}>{description}</p>
+      </header>
       <div className={styles.grid}>
         {panels.map((panel) => {
           const panelState = state[panel.id];
@@ -174,6 +188,6 @@ function MetricGroup({
           );
         })}
       </div>
-    </div>
+    </section>
   );
 }

--- a/admin/app/lib/cli/types.ts
+++ b/admin/app/lib/cli/types.ts
@@ -18,7 +18,7 @@
 // axis picker (#464, #975). Since #975 the family is a first-class verb, so these
 // are the verb names (`ppr` was renamed to `pagerank` per the user's preference).
 export type AlgorithmName = "bfs" | "pagerank" | "community";
-export type HelpTopic = "" | AlgorithmName;
+export type HelpTopic = "" | "search" | AlgorithmName;
 export type ReductionName = "none" | "mst" | "spt";
 export type ObjectiveName = "min" | "max";
 export type WeightingName = "raw" | "tfidf" | "bm25";

--- a/admin/app/lib/cli/verbs.test.ts
+++ b/admin/app/lib/cli/verbs.test.ts
@@ -234,8 +234,8 @@ describe("parseHelp (#436 — help verb)", () => {
     }
   });
 
-  test("recognises exactly the documented traversal topics", () => {
-    expect(HELP_TOPICS).toEqual(["bfs", "pagerank", "community"]);
+  test("recognises exactly the documented focused topics", () => {
+    expect(HELP_TOPICS).toEqual(["search", "bfs", "pagerank", "community"]);
     for (const topic of HELP_TOPICS) {
       const r = parseHelp([topic.toUpperCase()]);
       expect(r.ok).toBe(true);
@@ -265,8 +265,31 @@ describe("parseHelp (#436 — help verb)", () => {
       ]) {
         expect(text).toContain(heading);
       }
-      expect(text).toContain(`${topic} <seed>`);
+      expect(text).toContain(
+        topic === "search" ? "search <query>" : `${topic} <seed>`,
+      );
       expect(text).not.toContain("Lantern CLI grammar:");
+    }
+  });
+
+  test("documents every content-search parameter and compatibility rule", () => {
+    const text = helpTextFor("search");
+    for (const parameter of [
+      "query:",
+      "limit:",
+      "prefix:",
+      "mode:",
+      "min_should:",
+      "phrase:",
+      "fuzziness:",
+      "prefix_terms:",
+      "cursor:",
+      "all:",
+      "projection:",
+      "format:",
+      "Compatibility:",
+    ]) {
+      expect(text).toContain(parameter);
     }
   });
 });

--- a/admin/app/lib/cli/verbs.ts
+++ b/admin/app/lib/cli/verbs.ts
@@ -874,7 +874,7 @@ export const HELP_TEXT = [
   "             [weighting={raw|tfidf|bm25}] default=raw",
   "             [prefix=<string>]           default=all keys",
   "             defaults: max_size=0 (sweep decides)",
-  "  help [bfs|pagerank|community]",
+  "  help [search|bfs|pagerank|community]",
   "  exit",
   "",
   "Search contract: https://github.com/anaregdesign/lantern/blob/main/docs/search.md",
@@ -905,8 +905,8 @@ export interface CliCommandDoc {
   readonly summary: string;
   /** A concrete, runnable example (must parse — bound by `verbs.test.ts`). */
   readonly example: string;
-  /** Scoped help fields for the traversal families, when applicable. */
-  readonly familyHelp?: {
+  /** Focused help fields for commands whose parameters need a full reference. */
+  readonly scopedHelp?: {
     readonly defaults: readonly string[];
     readonly domains: readonly string[];
     readonly meaning: string;
@@ -1024,10 +1024,48 @@ export const CLI_COMMAND_REFERENCE: readonly CliCommandDoc[] = [
     group: "Browse",
     verb: "search",
     signature:
-      "search <query> [limit=...] [mode=...] [phrase=...] [all=...] [format=...]",
+      "search <query> [limit=<uint32>] [prefix=<string>] [mode=server|any|all|min-should] [min_should=<uint32>] [phrase=<bool>] [fuzziness=0|1|2] [prefix_terms=<bool>] [cursor=<base64url>] [all=<bool>] [projection=key-score|full-vertex] [format=json|ndjson|tsv]",
     summary:
       "BM25 content search with cursor paging. One page is lossless JSON; all=true follows the bounded search session. Canonical contract: https://github.com/anaregdesign/lantern/blob/main/docs/search.md",
     example: 'search "rolling update" mode=all limit=20',
+    scopedHelp: {
+      defaults: [
+        "limit=0 (endpoint default)",
+        "prefix=all keys",
+        "mode=server (endpoint default)",
+        "min_should=0 (endpoint default when mode=min-should)",
+        "phrase=false",
+        "fuzziness=0 (exact terms)",
+        "prefix_terms=false",
+        "cursor=first page",
+        "all=false",
+        "projection=key-score",
+        "format=json (all=true defaults to ndjson)",
+      ],
+      domains: [
+        "query: required full-text input analyzed and ranked by BM25 relevance",
+        "limit: maximum hits per page; 0 uses the endpoint default and the endpoint applies its cap",
+        "prefix: candidate vertex-key namespace; empty searches every key",
+        "mode: server defers to endpoint config; any=OR; all=AND; min-should requires N distinct words",
+        "min_should: positive word threshold used only with mode=min-should",
+        "phrase: adjacent ordered words within one key, value, or JSON string field",
+        "fuzziness: maximum dictionary-term edit distance 0|1|2",
+        "prefix_terms: include dictionary terms extending a query word (lan matches lantern)",
+        "cursor: opaque unpadded URL-safe base64 continuation from the same request and endpoint",
+        "all: lazily follow the bounded endpoint-sticky cursor session",
+        "projection: key-score or the exact selection-time full-vertex value/TTL snapshot",
+        "format: lossless page JSON, per-hit NDJSON, or quoted TSV",
+        "Compatibility: phrase=true requires mode=server, fuzziness=0, prefix_terms=false, and endpoint positional postings; all=true requires ndjson or tsv",
+      ],
+      meaning:
+        "Search live vertex keys and values by relevance without treating the derived index as a source of truth. See https://github.com/anaregdesign/lantern/blob/main/docs/search.md.",
+      examples: [
+        'search "rolling update" mode=all limit=20',
+        'search "release notes" phrase=true',
+        "search serach fuzziness=1",
+        "search espresso limit=20 all=true format=ndjson",
+      ],
+    },
   },
   {
     group: "Explore",
@@ -1037,7 +1075,7 @@ export const CLI_COMMAND_REFERENCE: readonly CliCommandDoc[] = [
     summary:
       "Greedy per-hop top-k breadth-first walk from a seed (step hops, fan_out neighbours per hop; defaults 5/3). reduction=mst|spt renders the neighbourhood as a spanning / shortest-path tree (#961); objective steers the pruning and reduction direction.",
     example: "bfs alice 2 5 reduction=mst",
-    familyHelp: {
+    scopedHelp: {
       defaults: [
         "step=5",
         "fan_out=3",
@@ -1064,7 +1102,7 @@ export const CLI_COMMAND_REFERENCE: readonly CliCommandDoc[] = [
     summary:
       "Personalized PageRank relevance star from a seed (top_n by mass, default 10). restart_prob (α) and epsilon (ε) tune locality; both default to the server's 0.15 / 1e-4.",
     example: "pagerank alice 15 restart_prob=0.25",
-    familyHelp: {
+    scopedHelp: {
       defaults: [
         "top_n=10",
         "restart_prob=0 (server α=0.15)",
@@ -1093,7 +1131,7 @@ export const CLI_COMMAND_REFERENCE: readonly CliCommandDoc[] = [
     summary:
       "Conductance-optimal local community around a seed (#845; max_size upper bound, default 0 = the sweep decides). restart_prob/epsilon tune locality; reduction renders a tree view.",
     example: "community alice 20 reduction=mst",
-    familyHelp: {
+    scopedHelp: {
       defaults: [
         "max_size=0 (sweep decides)",
         "restart_prob=0 (server α=0.15)",
@@ -1120,9 +1158,9 @@ export const CLI_COMMAND_REFERENCE: readonly CliCommandDoc[] = [
   {
     group: "Session",
     verb: "help",
-    signature: "help [bfs|pagerank|community]",
+    signature: "help [search|bfs|pagerank|community]",
     summary:
-      "Print the grammar overview or focused traversal-family reference into the terminal.",
+      "Print the grammar overview or a focused search/traversal reference into the terminal.",
     example: "help",
   },
   {
@@ -1135,19 +1173,19 @@ export const CLI_COMMAND_REFERENCE: readonly CliCommandDoc[] = [
   },
 ];
 
-/** Traversal-family topics derive from the same docs that render the drawer. */
+/** Focused topics derive from the same docs that render the drawer. */
 export const HELP_TOPICS = CLI_COMMAND_REFERENCE.filter(
-  (doc) => doc.familyHelp !== undefined,
+  (doc) => doc.scopedHelp !== undefined,
 ).map((doc) => doc.verb) as readonly Exclude<HelpTopic, "">[];
 
-/** Returns the overview or a family-only reference rendered from the drawer registry. */
+/** Returns the overview or a command-only reference rendered from the drawer registry. */
 export function helpTextFor(topic: HelpTopic): string {
   if (topic === "") return HELP_TEXT;
   const doc = CLI_COMMAND_REFERENCE.find(
     (candidate) => candidate.verb === topic,
   );
-  if (doc?.familyHelp === undefined) return HELP_TEXT;
-  const help = doc.familyHelp;
+  if (doc?.scopedHelp === undefined) return HELP_TEXT;
+  const help = doc.scopedHelp;
   return [
     topic,
     "",
@@ -1168,12 +1206,15 @@ export function helpTextFor(topic: HelpTopic): string {
   ].join("\n");
 }
 
-/** Parses the optional focused traversal-family help topic. */
+/** Parses the optional focused command help topic. */
 export function parseHelp(rest: string[]): ParseResult {
   if (rest.length === 0)
     return { ok: true, command: { verb: "help", topic: "" } };
   if (rest.length !== 1) {
-    return { ok: false, usage: "usage: help [bfs|pagerank|community]" };
+    return {
+      ok: false,
+      usage: "usage: help [search|bfs|pagerank|community]",
+    };
   }
   const topic = rest[0].toLowerCase();
   if (!HELP_TOPICS.includes(topic as Exclude<HelpTopic, "">)) {

--- a/admin/app/lib/client/usecase/ops/metrics/catalog.test.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/catalog.test.ts
@@ -65,10 +65,10 @@ describe("METRIC_PANELS", () => {
   });
 
   it("covers search outcomes, p99 phases, index health, and retention", () => {
-    const searchPanels = METRIC_PANELS.filter(
-      (panel) => panel.group === "search",
+    const searchPanels = METRIC_PANELS.filter((panel) =>
+      panel.queries.some((query) => query.expr.includes("lantern_search_")),
     );
-    expect(searchPanels.length).toBeGreaterThanOrEqual(8);
+    expect(searchPanels.length).toBeGreaterThanOrEqual(16);
     const expressions = searchPanels.flatMap((panel) =>
       panel.queries.map((query) => query.expr),
     );
@@ -97,8 +97,8 @@ describe("METRIC_PANELS", () => {
       "state",
       "peer",
     ]);
-    for (const panel of METRIC_PANELS.filter(
-      (candidate) => candidate.group === "search",
+    for (const panel of METRIC_PANELS.filter((candidate) =>
+      candidate.queries.some((query) => query.expr.includes("lantern_search_")),
     )) {
       for (const query of panel.queries) {
         for (const label of query.by ?? []) {
@@ -106,6 +106,117 @@ describe("METRIC_PANELS", () => {
           expect(label).not.toMatch(/query|prefix|key|value/);
         }
       }
+    }
+  });
+
+  it("splits Illuminate outcomes by family and suppresses pre-warmed zero series", () => {
+    const panels = METRIC_PANELS.filter((panel) =>
+      panel.id.startsWith("illuminate-outcomes-"),
+    );
+    expect(panels.map((panel) => panel.id)).toEqual([
+      "illuminate-outcomes-bfs",
+      "illuminate-outcomes-ppr",
+      "illuminate-outcomes-community",
+    ]);
+    expect(
+      METRIC_PANELS.some((panel) => panel.id === "traversal-outcomes"),
+    ).toBe(false);
+
+    for (const [panel, algorithm] of panels.map(
+      (panel, index) => [panel, ["bfs", "ppr", "community"][index]] as const,
+    )) {
+      expect(panel.queries).toHaveLength(1);
+      const query = panel.queries[0];
+      expect(query.expr).toContain(`algorithm="${algorithm}"`);
+      expect(query.expr).toEndWith(") > 0");
+      expect(query.by).toEqual(["phase", "code"]);
+      expect(query.legend).toBe("{{phase}} · {{code}}");
+    }
+  });
+
+  it("splits mixed high-cardinality panels by operational decision", () => {
+    const ids = new Set(METRIC_PANELS.map((panel) => panel.id));
+
+    for (const retired of [
+      "rpc-throughput",
+      "traversal-latency",
+      "search-outcomes",
+      "search-latency",
+      "search-phase-latency",
+      "search-work",
+      "search-index-health",
+      "search-index-population",
+      "search-index-structures",
+      "rejections",
+    ]) {
+      expect(ids.has(retired)).toBe(false);
+    }
+
+    for (const focused of [
+      "rpc-read-throughput",
+      "rpc-write-throughput",
+      "rpc-query-throughput",
+      "rpc-status-throughput",
+      "illuminate-latency",
+      "scan-latency",
+      "search-successes",
+      "search-interruptions",
+      "search-refusals",
+      "search-internal-failures",
+      "search-analysis-latency",
+      "search-expansion-latency",
+      "search-selection-latency",
+      "search-query-work",
+      "search-expansion-work",
+      "search-index-work",
+      "search-candidate-work",
+      "search-index-state",
+      "search-config-agreement",
+      "search-index-documents",
+      "search-expiration-backlog",
+      "search-index-dictionary",
+      "search-index-positions",
+      "replication-apply",
+      "replication-drops",
+      "validation-rejections",
+      "rate-limit-rejections",
+      "tombstone-clamp-rejections",
+    ]) {
+      expect(ids.has(focused)).toBe(true);
+    }
+  });
+
+  it("filters pre-warmed counter series out of dense legends", () => {
+    for (const id of [
+      "rpc-read-throughput",
+      "rpc-write-throughput",
+      "rpc-query-throughput",
+      "rpc-status-throughput",
+      "search-successes",
+      "search-interruptions",
+      "search-refusals",
+      "search-internal-failures",
+      "search-rejections",
+      "replication-apply",
+      "replication-drops",
+      "validation-rejections",
+    ]) {
+      const panel = METRIC_PANELS.find((candidate) => candidate.id === id);
+      expect(panel).toBeDefined();
+      expect(
+        panel?.queries.every((query) => query.expr.endsWith(") > 0")),
+      ).toBe(true);
+    }
+  });
+
+  it("covers every read scan method in the focused RPC panel", () => {
+    const panel = METRIC_PANELS.find(
+      (candidate) => candidate.id === "rpc-read-throughput",
+    );
+    expect(panel).toBeDefined();
+    const expression = panel?.queries[0].expr ?? "";
+    for (const method of ["ScanVertices", "ScanVertexKeys", "ScanEdges"]) {
+      expect(expression).toContain(method);
     }
   });
 });
@@ -121,5 +232,22 @@ describe("PANEL_GROUPS", () => {
   it("has unique group ids", () => {
     const ids = PANEL_GROUPS.map((g) => g.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("provides operator-oriented labels and descriptions", () => {
+    expect(PANEL_GROUPS.map((group) => group.label)).toEqual([
+      "Store inventory",
+      "Request traffic",
+      "Illuminate",
+      "Search requests",
+      "Search index",
+      "Maintenance",
+      "Replication",
+      "Guardrails",
+      "Process / Go runtime",
+    ]);
+    for (const group of PANEL_GROUPS) {
+      expect(group.description.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/admin/app/lib/client/usecase/ops/metrics/catalog.ts
+++ b/admin/app/lib/client/usecase/ops/metrics/catalog.ts
@@ -16,14 +16,14 @@
 
 /** Logical grouping used to lay panels out under section headings. */
 export type PanelGroup =
-  | "cache"
-  | "throughput"
-  | "latency"
-  | "search"
-  | "ttl"
-  | "backpressure"
+  | "storage"
+  | "requests"
+  | "illuminate"
+  | "search-requests"
+  | "search-index"
+  | "maintenance"
   | "replication"
-  | "rejections"
+  | "guardrails"
   | "runtime";
 
 /**
@@ -76,17 +76,58 @@ export interface PanelSpec {
   queries: PanelQuery[];
 }
 
-/** Section groups in display order, with human-readable headings. */
-export const PANEL_GROUPS: ReadonlyArray<{ id: PanelGroup; label: string }> = [
-  { id: "cache", label: "Cache" },
-  { id: "throughput", label: "Throughput" },
-  { id: "latency", label: "Latency" },
-  { id: "search", label: "Search" },
-  { id: "ttl", label: "TTL reaping" },
-  { id: "backpressure", label: "Back-pressure" },
-  { id: "replication", label: "Replication" },
-  { id: "rejections", label: "Rejections" },
-  { id: "runtime", label: "Process / Go runtime" },
+/** Section groups in display order, with operator-oriented headings. */
+export const PANEL_GROUPS: ReadonlyArray<{
+  id: PanelGroup;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "storage",
+    label: "Store inventory",
+    description: "Current graph volume and the objects that occupy memory.",
+  },
+  {
+    id: "requests",
+    label: "Request traffic",
+    description: "RPC volume and latency, separated by operational workload.",
+  },
+  {
+    id: "illuminate",
+    label: "Illuminate",
+    description: "Traversal latency and terminal outcomes for each algorithm.",
+  },
+  {
+    id: "search-requests",
+    label: "Search requests",
+    description: "Search outcomes, latency, result volume, and bounded work.",
+  },
+  {
+    id: "search-index",
+    label: "Search index",
+    description:
+      "Index readiness, population, structures, and memory retention.",
+  },
+  {
+    id: "maintenance",
+    label: "Maintenance",
+    description: "TTL cleanup and graph-cache garbage collection.",
+  },
+  {
+    id: "replication",
+    label: "Replication",
+    description: "Mutation-log pressure, peer health, lag, applies, and drops.",
+  },
+  {
+    id: "guardrails",
+    label: "Guardrails",
+    description: "Rejected work separated by the subsystem that refused it.",
+  },
+  {
+    id: "runtime",
+    label: "Process / Go runtime",
+    description: "Process memory and scheduler load.",
+  },
 ];
 
 /**
@@ -95,7 +136,7 @@ export const PANEL_GROUPS: ReadonlyArray<{ id: PanelGroup; label: string }> = [
 export const METRIC_PANELS: readonly PanelSpec[] = [
   {
     id: "cache-size",
-    group: "cache",
+    group: "storage",
     title: "Cache size",
     description: "Live vertices and edges currently held in the store.",
     unit: "count",
@@ -106,7 +147,7 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
   },
   {
     id: "write-throughput",
-    group: "throughput",
+    group: "requests",
     title: "Write throughput",
     description: "Mutation-log appends per second.",
     unit: "rate",
@@ -118,37 +159,108 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
     ],
   },
   {
-    id: "rpc-throughput",
-    group: "throughput",
-    title: "RPC throughput",
-    description: "Completed RPCs per second, by method.",
+    id: "rpc-read-throughput",
+    group: "requests",
+    title: "Read RPC throughput",
+    description: "Point reads, scans, counts, and degree queries by method.",
     unit: "rate",
     queries: [
       {
-        expr: "rate(grpc_server_handled_total[$__rate])",
+        expr: 'rate(grpc_server_handled_total{grpc_method=~"Get(Vertex|Vertices|Edge|Edges)|ScanVertices|ScanVertexKeys|ScanEdges|CountVerticesByPrefix|TopVerticesByDegree"}[$__rate]) > 0',
         by: ["grpc_method"],
         legend: "{{grpc_method}}",
       },
     ],
   },
   {
-    id: "traversal-outcomes",
-    group: "throughput",
-    title: "Illuminate outcomes",
-    description:
-      "Successful, failed, and timed-out traversals by family, phase, and Connect code.",
+    id: "rpc-write-throughput",
+    group: "requests",
+    title: "Write RPC throughput",
+    description: "Put, add, and delete operations by method.",
     unit: "rate",
     queries: [
       {
-        expr: "rate(lantern_illuminate_calls_total[$__rate])",
-        by: ["algorithm", "phase", "code"],
-        legend: "{{algorithm}} · {{phase}} · {{code}}",
+        expr: 'rate(grpc_server_handled_total{grpc_method=~"Put.*|Add.*|Delete.*"}[$__rate]) > 0',
+        by: ["grpc_method"],
+        legend: "{{grpc_method}}",
+      },
+    ],
+  },
+  {
+    id: "rpc-query-throughput",
+    group: "requests",
+    title: "Query RPC throughput",
+    description: "Illuminate and SearchVertices completions by method.",
+    unit: "rate",
+    queries: [
+      {
+        expr: 'rate(grpc_server_handled_total{grpc_method=~"Illuminate|SearchVertices"}[$__rate]) > 0',
+        by: ["grpc_method"],
+        legend: "{{grpc_method}}",
+      },
+    ],
+  },
+  {
+    id: "rpc-status-throughput",
+    group: "requests",
+    title: "Status RPC throughput",
+    description: "Server and replication status probes by method.",
+    unit: "rate",
+    queries: [
+      {
+        expr: 'rate(grpc_server_handled_total{grpc_method=~"GetServerStatus|GetReplicationStatus"}[$__rate]) > 0',
+        by: ["grpc_method"],
+        legend: "{{grpc_method}}",
+      },
+    ],
+  },
+  {
+    id: "illuminate-outcomes-bfs",
+    group: "illuminate",
+    title: "Illuminate outcomes · BFS",
+    description: "Non-zero terminal BFS outcomes by phase and Connect code.",
+    unit: "rate",
+    queries: [
+      {
+        expr: 'rate(lantern_illuminate_calls_total{algorithm="bfs"}[$__rate]) > 0',
+        by: ["phase", "code"],
+        legend: "{{phase}} · {{code}}",
+      },
+    ],
+  },
+  {
+    id: "illuminate-outcomes-ppr",
+    group: "illuminate",
+    title: "Illuminate outcomes · PageRank",
+    description:
+      "Non-zero terminal Personalized PageRank outcomes by phase and Connect code.",
+    unit: "rate",
+    queries: [
+      {
+        expr: 'rate(lantern_illuminate_calls_total{algorithm="ppr"}[$__rate]) > 0',
+        by: ["phase", "code"],
+        legend: "{{phase}} · {{code}}",
+      },
+    ],
+  },
+  {
+    id: "illuminate-outcomes-community",
+    group: "illuminate",
+    title: "Illuminate outcomes · Community",
+    description:
+      "Non-zero terminal local-community outcomes by phase and Connect code.",
+    unit: "rate",
+    queries: [
+      {
+        expr: 'rate(lantern_illuminate_calls_total{algorithm="community"}[$__rate]) > 0',
+        by: ["phase", "code"],
+        legend: "{{phase}} · {{code}}",
       },
     ],
   },
   {
     id: "rpc-latency",
-    group: "latency",
+    group: "requests",
     title: "RPC latency (p50 / p99)",
     description: "Server handling-time quantiles across all methods.",
     unit: "seconds",
@@ -166,17 +278,26 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
     ],
   },
   {
-    id: "traversal-latency",
-    group: "latency",
-    title: "Illuminate & scan latency (p99)",
-    description: "99th-percentile traversal and scan durations.",
+    id: "illuminate-latency",
+    group: "illuminate",
+    title: "Illuminate latency (p99)",
+    description: "99th-percentile end-to-end traversal duration.",
     unit: "seconds",
     queries: [
       {
         expr: "rate(lantern_illuminate_duration_seconds_bucket[$__rate])",
         agg: { quantile: 0.99 },
-        legend: "illuminate",
+        legend: "p99",
       },
+    ],
+  },
+  {
+    id: "scan-latency",
+    group: "requests",
+    title: "Scan latency (p99)",
+    description: "99th-percentile scan duration by operation.",
+    unit: "seconds",
+    queries: [
       {
         expr: "rate(lantern_scan_duration_seconds_bucket[$__rate])",
         by: ["op"],
@@ -187,7 +308,7 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
   },
   {
     id: "gc-duration",
-    group: "latency",
+    group: "maintenance",
     title: "GC duration (p99)",
     description: "99th-percentile graph-cache GC sweep duration.",
     unit: "seconds",
@@ -200,35 +321,98 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
     ],
   },
   {
-    id: "search-outcomes",
-    group: "search",
-    title: "Search outcomes",
-    description:
-      "Terminal SearchVertices attempts by bounded mode, outcome, and reason.",
+    id: "search-successes",
+    group: "search-requests",
+    title: "Search successes",
+    description: "Successful and zero-hit searches by matching mode.",
     unit: "rate",
     queries: [
       {
-        expr: "rate(lantern_search_calls_total[$__rate])",
-        by: ["mode", "outcome", "reason"],
-        legend: "{{mode}} · {{outcome}} · {{reason}}",
+        expr: 'rate(lantern_search_calls_total{outcome="ok"}[$__rate]) > 0',
+        by: ["mode", "reason"],
+        legend: "{{mode}} · {{reason}}",
       },
     ],
   },
   {
-    id: "search-latency",
-    group: "search",
-    title: "Search latency (p50 / p99)",
-    description: "End-to-end SearchVertices latency by mode and outcome.",
+    id: "search-interruptions",
+    group: "search-requests",
+    title: "Search interruptions",
+    description: "Canceled and deadline-exceeded searches by mode.",
+    unit: "rate",
+    queries: [
+      {
+        expr: 'rate(lantern_search_calls_total{outcome=~"canceled|deadline_exceeded"}[$__rate]) > 0',
+        by: ["mode", "outcome"],
+        legend: "{{mode}} · {{outcome}}",
+      },
+    ],
+  },
+  {
+    id: "search-refusals",
+    group: "search-requests",
+    title: "Search refusals",
+    description:
+      "Invalid, unavailable, and budget-exhausted searches by reason.",
+    unit: "rate",
+    queries: [
+      {
+        expr: 'rate(lantern_search_calls_total{outcome=~"invalid_argument|failed_precondition|resource_exhausted"}[$__rate]) > 0',
+        by: ["outcome", "reason"],
+        legend: "{{outcome}} · {{reason}}",
+      },
+    ],
+  },
+  {
+    id: "search-internal-failures",
+    group: "search-requests",
+    title: "Search internal failures",
+    description: "Unexpected internal failures by matching mode.",
+    unit: "rate",
+    queries: [
+      {
+        expr: 'rate(lantern_search_calls_total{outcome="internal"}[$__rate]) > 0',
+        by: ["mode"],
+        legend: "{{mode}}",
+      },
+    ],
+  },
+  {
+    id: "search-success-latency",
+    group: "search-requests",
+    title: "Successful search latency (p50 / p99)",
+    description: "End-to-end latency for successful searches by mode.",
     unit: "seconds",
     queries: [
       {
-        expr: "rate(lantern_search_duration_seconds_bucket[$__rate])",
+        expr: 'rate(lantern_search_duration_seconds_bucket{outcome="ok"}[$__rate])',
+        by: ["mode"],
+        agg: { quantile: 0.5 },
+        legend: "p50 · {{mode}}",
+      },
+      {
+        expr: 'rate(lantern_search_duration_seconds_bucket{outcome="ok"}[$__rate])',
+        by: ["mode"],
+        agg: { quantile: 0.99 },
+        legend: "p99 · {{mode}}",
+      },
+    ],
+  },
+  {
+    id: "search-failure-latency",
+    group: "search-requests",
+    title: "Failed search latency (p50 / p99)",
+    description: "End-to-end latency for non-success outcomes by mode.",
+    unit: "seconds",
+    queries: [
+      {
+        expr: 'rate(lantern_search_duration_seconds_bucket{outcome!="ok"}[$__rate])',
         by: ["mode", "outcome"],
         agg: { quantile: 0.5 },
         legend: "p50 · {{mode}} · {{outcome}}",
       },
       {
-        expr: "rate(lantern_search_duration_seconds_bucket[$__rate])",
+        expr: 'rate(lantern_search_duration_seconds_bucket{outcome!="ok"}[$__rate])',
         by: ["mode", "outcome"],
         agg: { quantile: 0.99 },
         legend: "p99 · {{mode}} · {{outcome}}",
@@ -236,52 +420,80 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
     ],
   },
   {
-    id: "search-phase-latency",
-    group: "search",
-    title: "Search phase latency (p99)",
-    description:
-      "Analysis, expansion, and selection time separated for slow-query triage.",
+    id: "search-analysis-latency",
+    group: "search-requests",
+    title: "Search analysis latency (p99)",
+    description: "Query analysis time by matching mode.",
     unit: "seconds",
     queries: [
       {
-        expr: "rate(lantern_search_phase_duration_seconds_bucket[$__rate])",
-        by: ["mode", "phase"],
+        expr: 'rate(lantern_search_phase_duration_seconds_bucket{phase="analysis"}[$__rate])',
+        by: ["mode"],
         agg: { quantile: 0.99 },
-        legend: "{{mode}} · {{phase}}",
+        legend: "{{mode}}",
+      },
+    ],
+  },
+  {
+    id: "search-expansion-latency",
+    group: "search-requests",
+    title: "Search expansion latency (p99)",
+    description: "Dictionary and fuzzy-expansion time by matching mode.",
+    unit: "seconds",
+    queries: [
+      {
+        expr: 'rate(lantern_search_phase_duration_seconds_bucket{phase="expansion"}[$__rate])',
+        by: ["mode"],
+        agg: { quantile: 0.99 },
+        legend: "{{mode}}",
+      },
+    ],
+  },
+  {
+    id: "search-selection-latency",
+    group: "search-requests",
+    title: "Search selection latency (p99)",
+    description: "Candidate scoring and selection time by matching mode.",
+    unit: "seconds",
+    queries: [
+      {
+        expr: 'rate(lantern_search_phase_duration_seconds_bucket{phase="selection"}[$__rate])',
+        by: ["mode"],
+        agg: { quantile: 0.99 },
+        legend: "{{mode}}",
       },
     ],
   },
   {
     id: "search-hits",
-    group: "search",
-    title: "Search hits per query (p50 / p99)",
-    description: "Returned hit-count distribution by mode and outcome.",
+    group: "search-requests",
+    title: "Successful search hits (p50 / p99)",
+    description: "Returned hit-count distribution for successful searches.",
     unit: "count",
     queries: [
       {
-        expr: "rate(lantern_search_results_bucket[$__rate])",
-        by: ["mode", "outcome"],
+        expr: 'rate(lantern_search_results_bucket{outcome="ok"}[$__rate])',
+        by: ["mode"],
         agg: { quantile: 0.5 },
-        legend: "p50 · {{mode}} · {{outcome}}",
+        legend: "p50 · {{mode}}",
       },
       {
-        expr: "rate(lantern_search_results_bucket[$__rate])",
-        by: ["mode", "outcome"],
+        expr: 'rate(lantern_search_results_bucket{outcome="ok"}[$__rate])',
+        by: ["mode"],
         agg: { quantile: 0.99 },
-        legend: "p99 · {{mode}} · {{outcome}}",
+        legend: "p99 · {{mode}}",
       },
     ],
   },
   {
-    id: "search-work",
-    group: "search",
-    title: "Search work (p99)",
-    description:
-      "Deterministic analysis, expansion, posting, position, and selection work.",
+    id: "search-query-work",
+    group: "search-requests",
+    title: "Search query work (p99)",
+    description: "Query bytes, tokens, clauses, and terms by matching mode.",
     unit: "count",
     queries: [
       {
-        expr: "rate(lantern_search_work_bucket[$__rate])",
+        expr: 'rate(lantern_search_work_bucket{kind=~"query_bytes|query_tokens|query_clauses|query_terms"}[$__rate])',
         by: ["mode", "kind"],
         agg: { quantile: 0.99 },
         legend: "{{mode}} · {{kind}}",
@@ -289,33 +501,85 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
     ],
   },
   {
-    id: "search-index-health",
-    group: "search",
-    title: "Search index health",
-    description:
-      "One-hot local index state and search-config agreement with each peer.",
+    id: "search-expansion-work",
+    group: "search-requests",
+    title: "Search expansion work (p99)",
+    description: "Dictionary visits and retained expansions by matching mode.",
+    unit: "count",
+    queries: [
+      {
+        expr: 'rate(lantern_search_work_bucket{kind=~"dictionary_visits|expansion_retained"}[$__rate])',
+        by: ["mode", "kind"],
+        agg: { quantile: 0.99 },
+        legend: "{{mode}} · {{kind}}",
+      },
+    ],
+  },
+  {
+    id: "search-index-work",
+    group: "search-requests",
+    title: "Search index work (p99)",
+    description: "Posting, position, and expiration visits by matching mode.",
+    unit: "count",
+    queries: [
+      {
+        expr: 'rate(lantern_search_work_bucket{kind=~"posting_visits|position_visits|expiration_visits"}[$__rate])',
+        by: ["mode", "kind"],
+        agg: { quantile: 0.99 },
+        legend: "{{mode}} · {{kind}}",
+      },
+    ],
+  },
+  {
+    id: "search-candidate-work",
+    group: "search-requests",
+    title: "Search candidate work (p99)",
+    description: "Candidate visits and skips by matching mode.",
+    unit: "count",
+    queries: [
+      {
+        expr: 'rate(lantern_search_work_bucket{kind=~"candidate_visits|candidate_skips"}[$__rate])',
+        by: ["mode", "kind"],
+        agg: { quantile: 0.99 },
+        legend: "{{mode}} · {{kind}}",
+      },
+    ],
+  },
+  {
+    id: "search-index-state",
+    group: "search-index",
+    title: "Index state",
+    description: "One-hot local index readiness state.",
     unit: "count",
     queries: [
       {
         expr: "lantern_search_index_state",
         by: ["state"],
         agg: "max",
-        legend: "index {{state}}",
-      },
-      {
-        expr: "lantern_search_config_match",
-        by: ["peer"],
-        agg: "min",
-        legend: "config {{peer}}",
+        legend: "{{state}}",
       },
     ],
   },
   {
-    id: "search-index-population",
-    group: "search",
-    title: "Search index population",
-    description:
-      "Logical, physical, and expired documents retained by the index.",
+    id: "search-config-agreement",
+    group: "search-index",
+    title: "Search config agreement",
+    description: "Whether each peer reports the same search configuration.",
+    unit: "count",
+    queries: [
+      {
+        expr: "lantern_search_config_match",
+        by: ["peer"],
+        agg: "min",
+        legend: "{{peer}}",
+      },
+    ],
+  },
+  {
+    id: "search-index-documents",
+    group: "search-index",
+    title: "Index documents",
+    description: "Live graph vertices and logical/physical index documents.",
     unit: "count",
     queries: [
       { expr: "lantern_vertices", legend: "live vertices" },
@@ -324,6 +588,15 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
         expr: "lantern_search_index_physical_documents",
         legend: "physical documents",
       },
+    ],
+  },
+  {
+    id: "search-expiration-backlog",
+    group: "search-index",
+    title: "Index expiration backlog",
+    description: "Expired documents retained and queued for cleanup.",
+    unit: "count",
+    queries: [
       {
         expr: "lantern_search_index_expired_documents",
         legend: "expired documents",
@@ -335,14 +608,23 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
     ],
   },
   {
-    id: "search-index-structures",
-    group: "search",
-    title: "Search index structures",
-    description: "Live terms, postings, positions, and retained ordinals.",
+    id: "search-index-dictionary",
+    group: "search-index",
+    title: "Index dictionary",
+    description: "Live terms and posting-list entries.",
     unit: "count",
     queries: [
       { expr: "lantern_search_index_terms", legend: "live terms" },
       { expr: "lantern_search_index_postings", legend: "postings" },
+    ],
+  },
+  {
+    id: "search-index-positions",
+    group: "search-index",
+    title: "Index positions",
+    description: "Position entries and retained document ordinals.",
+    unit: "count",
+    queries: [
       {
         expr: "lantern_search_index_position_entries",
         legend: "positions",
@@ -355,7 +637,7 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
   },
   {
     id: "search-index-memory",
-    group: "search",
+    group: "search-index",
     title: "Search index memory",
     description: "Estimated live and retained bytes held by the derived index.",
     unit: "bytes",
@@ -372,7 +654,7 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
   },
   {
     id: "search-index-retention",
-    group: "search",
+    group: "search-index",
     title: "Search retention ratio",
     description:
       "Retained-to-live index bytes; sustained growth indicates compaction pressure.",
@@ -387,13 +669,13 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
   },
   {
     id: "search-rejections",
-    group: "search",
+    group: "guardrails",
     title: "Search rejections",
     description: "Rejected SearchVertices attempts by bounded reason.",
     unit: "rate",
     queries: [
       {
-        expr: "rate(lantern_search_rejections_total[$__rate])",
+        expr: "rate(lantern_search_rejections_total[$__rate]) > 0",
         by: ["reason"],
         legend: "{{reason}}",
       },
@@ -401,7 +683,7 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
   },
   {
     id: "ttl-reaping",
-    group: "ttl",
+    group: "maintenance",
     title: "TTL reaping",
     description: "Expired vertices and edges reaped per second, by kind.",
     unit: "rate",
@@ -415,7 +697,7 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
   },
   {
     id: "mutation-log-fill",
-    group: "backpressure",
+    group: "replication",
     title: "Mutation-log fill ratio",
     description: "Fraction of the mutation-log ring buffer in use (0–1).",
     unit: "ratio",
@@ -425,7 +707,7 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
   },
   {
     id: "mutation-log-eviction",
-    group: "backpressure",
+    group: "replication",
     title: "Mutation-log eviction rate",
     description: "Entries evicted from the mutation log per second.",
     unit: "rate",
@@ -438,7 +720,7 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
   },
   {
     id: "subscribe-streams",
-    group: "backpressure",
+    group: "replication",
     title: "Active subscribe streams",
     description: "Open replication Subscribe streams.",
     unit: "count",
@@ -471,46 +753,72 @@ export const METRIC_PANELS: readonly PanelSpec[] = [
   {
     id: "replication-apply",
     group: "replication",
-    title: "Replication apply / drop rate",
+    title: "Replication apply rate",
     // The apply counter also carries an `op` label (11 RPC kinds). Breaking
     // the panel down by `op` multiplies by replica count (33+ lines here) and
     // is illegible as a legend; per-op apply rates belong in an ad-hoc query,
     // not an at-a-glance health panel. We sum over `op` to show one applied
-    // line per replica, and keep the low-cardinality `reason` split on drops
-    // (where "why" is the actionable signal — e.g. self_echo suppression).
-    description: "Remote mutations applied per replica, and drops by reason.",
+    // line per replica; drop reasons have their own focused panel below.
+    description: "Remote mutations applied per replica, summed over operation.",
     unit: "rate",
     queries: [
       {
-        expr: "rate(lantern_replication_apply_total[$__rate])",
+        expr: "rate(lantern_replication_apply_total[$__rate]) > 0",
         legend: "applied",
-      },
-      {
-        expr: "rate(lantern_replication_dropped_total[$__rate])",
-        by: ["reason"],
-        legend: "dropped {{reason}}",
       },
     ],
   },
   {
-    id: "rejections",
-    group: "rejections",
-    title: "Rejections",
-    description:
-      "Validation, rate-limit, and tombstone-clamp rejections per second.",
+    id: "replication-drops",
+    group: "replication",
+    title: "Replication drop rate",
+    description: "Remote mutations dropped per second by bounded reason.",
     unit: "rate",
     queries: [
       {
-        expr: "rate(lantern_validation_rejected_total[$__rate])",
-        legend: "validation",
+        expr: "rate(lantern_replication_dropped_total[$__rate]) > 0",
+        by: ["reason"],
+        legend: "{{reason}}",
       },
+    ],
+  },
+  {
+    id: "validation-rejections",
+    group: "guardrails",
+    title: "Validation rejections",
+    description: "Requests rejected by input validation, separated by reason.",
+    unit: "rate",
+    queries: [
+      {
+        expr: "rate(lantern_validation_rejected_total[$__rate]) > 0",
+        by: ["reason"],
+        legend: "{{reason}}",
+      },
+    ],
+  },
+  {
+    id: "rate-limit-rejections",
+    group: "guardrails",
+    title: "Rate-limit rejections",
+    description: "Requests refused by the process-wide token bucket.",
+    unit: "rate",
+    queries: [
       {
         expr: "rate(lantern_rate_limit_rejected_total[$__rate])",
-        legend: "rate limit",
+        legend: "rejected",
       },
+    ],
+  },
+  {
+    id: "tombstone-clamp-rejections",
+    group: "guardrails",
+    title: "Tombstone-clamp rejections",
+    description: "Causally late replicated mutations rejected by LWW guards.",
+    unit: "rate",
+    queries: [
       {
         expr: "rate(lantern_tombstone_clamp_rejected_total[$__rate])",
-        legend: "tombstone clamp",
+        legend: "rejected",
       },
     ],
   },

--- a/admin/test/cli-grammar/verbs.json
+++ b/admin/test/cli-grammar/verbs.json
@@ -545,6 +545,11 @@
       "expected": { "topic": "" }
     },
     {
+      "input": "help search",
+      "comment": "#1129: focused content-search parameter help",
+      "expected": { "topic": "search" }
+    },
+    {
       "input": "help bfs",
       "comment": "#995: focused BFS help",
       "expected": { "topic": "bfs" }

--- a/admin/tests/e2e/browse.spec.ts
+++ b/admin/tests/e2e/browse.spec.ts
@@ -256,6 +256,39 @@ test.describe("/vertices — content search (#650)", () => {
     ).toHaveCount(0);
   });
 
+  test("every content-search parameter explains itself by pointer and keyboard (#1129)", async ({
+    page,
+  }) => {
+    await page.goto("/vertices");
+    await page.getByRole("tab", { name: "Content search" }).click();
+
+    const guidance = [
+      ["search-query-help", "analyzes the words"],
+      ["search-mode-help", "query words qualify"],
+      ["search-prefix-help", "before ranking"],
+      ["search-fuzzy-help", "edit distance"],
+      ["search-prefix-terms-help", "extend a query word"],
+      ["search-phrase-help", "adjacent, ordered words"],
+    ] as const;
+
+    for (const [testId, text] of guidance) {
+      const trigger = page.getByTestId(testId);
+      await expect(trigger).toBeVisible();
+      await trigger.hover();
+      await expect(page.getByRole("tooltip")).toContainText(text);
+      await page.mouse.move(0, 0);
+      await expect(page.getByRole("tooltip")).toHaveCount(0);
+    }
+
+    await page.getByTestId("search-mode").click();
+    await page.getByRole("option", { name: "At least N words" }).click();
+    const minimumHelp = page.getByTestId("search-min-should-help");
+    await minimumHelp.focus();
+    await expect(page.getByRole("tooltip")).toContainText(
+      "distinct analyzed query words",
+    );
+  });
+
   test("Illuminate action seeds the CLI explorer with the hit key", async ({
     page,
   }) => {

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -1115,6 +1115,35 @@ test.describe("/cli", () => {
     await expect(entry).not.toContainText("pagerank <seed>");
   });
 
+  test("scoped search help explains every parameter (#1129)", async ({
+    page,
+  }) => {
+    await page.goto("/cli");
+    const input = page.getByTestId("cli-input");
+    await input.fill("help search");
+    await input.press("Enter");
+    const entry = page.getByTestId("cli-entry-info").last();
+    await expect(entry).toContainText("search <query>");
+    for (const parameter of [
+      "query:",
+      "limit:",
+      "prefix:",
+      "mode:",
+      "min_should:",
+      "phrase:",
+      "fuzziness:",
+      "prefix_terms:",
+      "cursor:",
+      "all:",
+      "projection:",
+      "format:",
+      "Compatibility:",
+    ]) {
+      await expect(entry).toContainText(parameter);
+    }
+    await expect(entry).not.toContainText("bfs <seed>");
+  });
+
   // #945 — pasting a multi-line script into the prompt runs each line in
   // order through the pending-command queue instead of flattening the
   // newlines into one uneditable line. Synthesize a real paste event (with

--- a/admin/tests/e2e/ops-metrics.spec.ts
+++ b/admin/tests/e2e/ops-metrics.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+import { CONNECT_URL, STORAGE_KEY } from "./helpers";
+
 /**
  * Ops Metrics (#524) — the Prometheus time-series half of the Ops page.
  *
@@ -53,6 +55,13 @@ function multiInstanceEnvelope(
 }
 
 test.describe("Ops metrics section", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(
+      ({ key, value }) => window.localStorage.setItem(key, value),
+      { key: STORAGE_KEY, value: CONNECT_URL },
+    );
+  });
+
   test("renders the metrics section below the status cards", async ({
     page,
   }) => {
@@ -118,6 +127,7 @@ test.describe("Ops metrics section", () => {
     });
 
     await page.goto("/ops");
+    const section = page.getByTestId("ops-metrics-section");
     // The degraded banner must NOT appear once panels resolve.
     await expect(page.getByTestId("ops-metrics-degraded")).toHaveCount(0);
     // The cache-size panel is the first catalog entry; it renders a summary
@@ -126,14 +136,51 @@ test.describe("Ops metrics section", () => {
     await expect(
       page.getByTestId("ops-metric-cache-size-summary"),
     ).toBeVisible();
-    await expect(page.getByTestId("ops-metrics-group-search")).toBeVisible();
-    await expect(page.getByTestId("ops-metric-search-outcomes")).toBeVisible();
     await expect(
-      page.getByTestId("ops-metric-search-outcomes-summary"),
+      page.getByTestId("ops-metric-illuminate-outcomes-bfs-summary"),
     ).toBeVisible();
     await expect(
-      page.getByTestId("ops-metric-search-index-health-summary"),
+      page.getByTestId("ops-metric-illuminate-outcomes-ppr-summary"),
     ).toBeVisible();
+    await expect(
+      page.getByTestId("ops-metric-illuminate-outcomes-community-summary"),
+    ).toBeVisible();
+    await expect(page.getByTestId("ops-metric-traversal-outcomes")).toHaveCount(
+      0,
+    );
+    for (const heading of [
+      "Store inventory",
+      "Request traffic",
+      "Illuminate",
+      "Search requests",
+      "Search index",
+      "Maintenance",
+      "Replication",
+      "Guardrails",
+      "Process / Go runtime",
+    ]) {
+      await expect(
+        section.getByRole("heading", { level: 3, name: heading }),
+      ).toBeVisible();
+    }
+    await expect(
+      page.getByTestId("ops-metrics-group-search-requests"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("ops-metrics-group-search-index"),
+    ).toBeVisible();
+    await expect(page.getByTestId("ops-metric-search-successes")).toBeVisible();
+    await expect(
+      page.getByTestId("ops-metric-search-successes-summary"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("ops-metric-search-index-state-summary"),
+    ).toBeVisible();
+    await expect(page.getByTestId("ops-metric-search-outcomes")).toHaveCount(0);
+    await expect(
+      page.getByTestId("ops-metric-replication-drops"),
+    ).toBeVisible();
+    await expect(page.getByTestId("ops-metric-rejections")).toHaveCount(0);
   });
 
   test("keeps absent search metrics local to the search panels", async ({
@@ -154,7 +201,7 @@ test.describe("Ops metrics section", () => {
 
     await page.goto("/ops");
     await expect(
-      page.getByTestId("ops-metric-search-outcomes-empty"),
+      page.getByTestId("ops-metric-search-successes-empty"),
     ).toBeVisible();
     await expect(page.getByTestId("ops-metrics-degraded")).toHaveCount(0);
     await expect(
@@ -162,7 +209,7 @@ test.describe("Ops metrics section", () => {
     ).toBeVisible();
   });
 
-  test("keeps the search status card readable on a narrow viewport", async ({
+  test("keeps status and metric sections readable on a narrow viewport", async ({
     page,
   }) => {
     await page.setViewportSize({ width: 390, height: 844 });
@@ -170,6 +217,12 @@ test.describe("Ops metrics section", () => {
     await expect(page.getByTestId("ops-search-card")).toBeVisible();
     await expect(
       page.getByText("Query budgets", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { level: 3, name: "Search requests" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { level: 4, name: "Search successes" }),
     ).toBeVisible();
     const overflow = await page.evaluate(
       () => document.documentElement.scrollWidth - window.innerWidth,

--- a/cli/cmd/bfs.go
+++ b/cli/cmd/bfs.go
@@ -20,7 +20,7 @@ var (
 var bfsCmd = &cobra.Command{
 	Use:   "bfs <seed>",
 	Short: "Greedy per-hop top-k breadth-first walk from <seed>",
-	Long:  familyHelpText("bfs"),
+	Long:  scopedHelpText("bfs"),
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := rejectMixedFamilyGrammar(cmd, args); err != nil {

--- a/cli/cmd/community.go
+++ b/cli/cmd/community.go
@@ -21,7 +21,7 @@ var (
 var communityCmd = &cobra.Command{
 	Use:   "community <seed>",
 	Short: "Conductance-optimal local community around <seed>",
-	Long:  familyHelpText("community"),
+	Long:  scopedHelpText("community"),
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := rejectMixedFamilyGrammar(cmd, args); err != nil {

--- a/cli/cmd/help_text.go
+++ b/cli/cmd/help_text.go
@@ -7,21 +7,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// familyHelpText gives Cobra the same structured topic rendering the REPL
-// prints for `help <family>`. Cobra adds each command's flag table after this
-// text, retaining normal flag discoverability without duplicating grammar,
+// scopedHelpText gives Cobra the same structured topic rendering the REPL
+// prints for `help <topic>`. Cobra adds each command's flag table after this
+// text, retaining normal flag discoverability without duplicating signatures,
 // defaults, domains, meaning, or examples.
-func familyHelpText(topic string) string {
+func scopedHelpText(topic string) string {
 	text, ok := parser.HelpTextFor(topic)
 	if !ok {
-		panic("unknown family help topic: " + topic)
+		panic("unknown scoped help topic: " + topic)
 	}
 	return text
 }
 
 // helpCmd restores Cobra's conventional `lantern-cli help <command>` entry
-// point. It delegates to the target command's Help method, so the structured
-// family text above and Cobra's generated flag table are both retained.
+// point. It delegates to the target command's Help method, so structured topic
+// text and Cobra's generated flag table are both retained.
 var helpCmd = &cobra.Command{
 	Use:   "help [command]",
 	Short: "Help about any command",
@@ -32,7 +32,7 @@ var helpCmd = &cobra.Command{
 		}
 		target, _, err := rootCmd.Find(args)
 		if err != nil || target == rootCmd || target.Name() == "help" {
-			return fmt.Errorf("unknown command %q (try: bfs, pagerank, community, or --help)", args[0])
+			return fmt.Errorf("unknown command %q (try: search, bfs, pagerank, community, or --help)", args[0])
 		}
 		return target.Help()
 	},

--- a/cli/cmd/help_text_test.go
+++ b/cli/cmd/help_text_test.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScopedHelpText_SearchDocumentsEveryParameter(t *testing.T) {
+	text := scopedHelpText("search")
+	for _, want := range []string{
+		"query:", "limit:", "prefix:", "mode:", "min_should:",
+		"phrase:", "fuzziness:", "prefix_terms:", "cursor:", "all:",
+		"projection:", "format:", "Compatibility:",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("search help missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestScopedHelpText_RejectsUnknownTopic(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("scopedHelpText(unknown) did not panic")
+		}
+	}()
+	_ = scopedHelpText("unknown")
+}

--- a/cli/cmd/pagerank.go
+++ b/cli/cmd/pagerank.go
@@ -19,7 +19,7 @@ var (
 var pagerankCmd = &cobra.Command{
 	Use:   "pagerank <seed>",
 	Short: "Personalized PageRank relevance star from <seed>",
-	Long:  familyHelpText("pagerank"),
+	Long:  scopedHelpText("pagerank"),
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := rejectMixedFamilyGrammar(cmd, args); err != nil {

--- a/cli/cmd/repl.go
+++ b/cli/cmd/repl.go
@@ -164,7 +164,7 @@ EXAMPLE
 			case errors.Is(err, service.ErrCommunity):
 				fmt.Println("Usage: community <seed: string> [max_size: int] [restart_prob=<float>] [epsilon=<float>] [reduction=none|mst|spt] [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>]")
 			case errors.Is(err, service.ErrHelp):
-				fmt.Println("Usage: help [bfs|pagerank|community]")
+				fmt.Println("Usage: help [search|bfs|pagerank|community]")
 			case errors.Is(err, service.ErrInvalidVerb):
 				fmt.Println("Usage: { get | put | delete | add | scan | count | delete-prefix | keys | bfs | pagerank | community | help | exit } ...")
 			case errors.Is(err, service.ErrInvalidObjective):

--- a/cli/cmd/search.go
+++ b/cli/cmd/search.go
@@ -43,53 +43,10 @@ func searchCommandModel(query string) parser.Search {
 var searchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Full-text search vertices by content relevance (BM25)",
-	Long: `Search vertices by relevance-ranked full-text over their key and value.
-
-This command uses the same Search model, validation, request construction, and
-output implementation as "search ..." in the interactive REPL. Admin /cli
-accepts the same key=value grammar.
-
-One page defaults to a lossless JSON object containing hits, next_cursor,
-effective_limit, truncated, and continuation_limited. --format=ndjson emits one
-hit per line. --format=tsv uses a real TSV encoder (fields containing tabs,
-newlines, or quotes are quoted); its columns are key, score, projection_status,
-and vertex JSON. --all follows the endpoint-sticky cursor without collecting an
-unbounded array and defaults to NDJSON. Explicit --all --format=json is refused
-so cancellation can never leave a partial JSON document. Completed NDJSON/TSV
-records may remain visible if a later page is cancelled or fails.
-
-By default the server chooses how query words combine. Override it with:
-
-  --mode server         defer to LANTERN_SEARCH_DEFAULT_MODE (default)
-  --mode all            require every query word (AND)
-  --mode min-should --min-should N   require at least N distinct query words
-  --phrase              require the words to occur adjacently, in order
-  --fuzziness 1|2       also match terms within that edit distance (typos)
-  --prefix-terms        also match terms that extend a query word ("lan"→"lantern")
-
---prefix scopes hits to a key namespace; --limit caps each page (0 lets the
-server apply its configured default). --projection full-vertex includes each
-hit's exact selection-time value/TTL snapshot. --cursor accepts the unpadded
-URL-safe base64 next_cursor from a previous page; every other option and the
-serving endpoint must remain unchanged.
+	Long: scopedHelpText("search") + `
 
 CANONICAL CONTRACT
   https://github.com/anaregdesign/lantern/blob/main/docs/search.md
-
-REPL EQUIVALENT
-  search "rolling update" mode=all limit=20 format=json
-  search espresso limit=20 all=true
-
-EXAMPLES
-  lantern-cli search "calm concise"
-  lantern-cli search "rolling update" --mode all
-  lantern-cli search "rolling update" --phrase
-  lantern-cli search serach --fuzziness 1
-  lantern-cli search lan --prefix-terms
-  lantern-cli --address host:6380 search espresso --prefix user. --limit 20
-  lantern-cli search espresso --limit 20 --all
-  lantern-cli search espresso --projection full-vertex
-  lantern-cli search espresso --format tsv
 `,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -105,16 +62,16 @@ EXAMPLES
 
 func init() {
 	f := searchCmd.Flags()
-	f.Uint32Var(&searchLimit, "limit", 0, "maximum hits per page (0 = server default)")
-	f.StringVar(&searchPrefix, "prefix", "", "restrict hits to vertices whose key carries this prefix")
-	f.StringVar(&searchMode, "mode", "server", "term combination: server|any|all|min-should")
+	f.Uint32Var(&searchLimit, "limit", 0, "maximum hits per page (0 = endpoint default, capped by endpoint max)")
+	f.StringVar(&searchPrefix, "prefix", "", "restrict candidates to vertex keys in this namespace before ranking")
+	f.StringVar(&searchMode, "mode", "server", "query-word membership: server|any|all|min-should (server defers to endpoint default)")
 	f.Uint32Var(&searchMinShould, "min-should", 0, "minimum distinct query words a hit must carry (with --mode min-should)")
 	f.Uint32Var(&searchFuzziness, "fuzziness", 0, "maximum edit distance for fuzzy term matching (0-2)")
 	f.BoolVar(&searchPrefixTerms, "prefix-terms", false, "also match dictionary terms that extend a query word")
 	f.BoolVar(&searchPhrase, "phrase", false, "require the query's words to occur adjacently, in order")
 	f.StringVar(&searchCursor, "cursor", "", "unpadded URL-safe base64 cursor returned by the previous page")
-	f.BoolVar(&searchAll, "all", false, "lazily follow all retained pages (default output: NDJSON)")
-	f.StringVar(&searchProjection, "projection", "key-score", "hit payload: key-score|full-vertex")
-	f.StringVar(&searchFormat, "format", "", "output: json|ndjson|tsv (default json; --all defaults ndjson)")
+	f.BoolVar(&searchAll, "all", false, "lazily follow the bounded endpoint-sticky cursor session (default output: NDJSON)")
+	f.StringVar(&searchProjection, "projection", "key-score", "hit payload: key-score or exact selection-time full-vertex snapshot")
+	f.StringVar(&searchFormat, "format", "", "output: json|ndjson|tsv (one page defaults json; --all defaults ndjson)")
 	rootCmd.AddCommand(searchCmd)
 }

--- a/cli/cmd/search_test.go
+++ b/cli/cmd/search_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/anaregdesign/lantern/cli/parser"
@@ -72,5 +73,18 @@ func TestSearchCommandRegistered(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("search command not registered on rootCmd")
+	}
+}
+
+func TestSearchCommandHelpExplainsTheSearchContract(t *testing.T) {
+	for _, want := range []string{
+		"query:", "limit:", "prefix:", "mode:", "min_should:",
+		"phrase:", "fuzziness:", "prefix_terms:", "cursor:", "all:",
+		"projection:", "format:", "Compatibility:",
+		"https://github.com/anaregdesign/lantern/blob/main/docs/search.md",
+	} {
+		if !strings.Contains(searchCmd.Long, want) {
+			t.Errorf("search command help missing %q:\n%s", want, searchCmd.Long)
+		}
 	}
 }

--- a/cli/parser/help.go
+++ b/cli/parser/help.go
@@ -5,10 +5,9 @@ import (
 	"strings"
 )
 
-// HelpTopic is the structured source for family-scoped help. The REPL renders
-// it directly and Cobra consumes the same rendered text for `bfs --help`,
-// `pagerank --help`, and `community --help`, so signatures, defaults, domains,
-// meaning, and examples cannot drift between those Go surfaces.
+// HelpTopic is the structured source for command-scoped help. The REPL renders
+// it directly and Cobra consumes the same rendered text, so signatures,
+// defaults, domains, meaning, and examples cannot drift between Go surfaces.
 type HelpTopic struct {
 	Name      string
 	Signature string
@@ -19,6 +18,40 @@ type HelpTopic struct {
 }
 
 var helpTopics = []HelpTopic{
+	{
+		Name:      "search",
+		Signature: "search <query> [limit=<uint32>] [prefix=<string>] [mode=server|any|all|min-should] [min_should=<uint32>] [phrase=<bool>] [fuzziness=0|1|2] [prefix_terms=<bool>] [cursor=<base64url>] [all=<bool>] [projection=key-score|full-vertex] [format=json|ndjson|tsv]",
+		Defaults: []string{
+			"limit=0 (endpoint default)",
+			"prefix=all keys",
+			"mode=server (endpoint default)",
+			"min_should=0 (endpoint default when mode=min-should)",
+			"phrase=false",
+			"fuzziness=0 (exact terms)",
+			"prefix_terms=false",
+			"cursor=first page",
+			"all=false",
+			"projection=key-score",
+			"format=json (all=true defaults to ndjson)",
+		},
+		Domains: []string{
+			"query: required full-text input analyzed and ranked by BM25 relevance",
+			"limit: maximum hits per page; 0 uses the endpoint default and the endpoint applies its cap",
+			"prefix: candidate vertex-key namespace; empty searches every key",
+			"mode: server defers to endpoint config; any=OR; all=AND; min-should requires N distinct words",
+			"min_should: positive word threshold used only with mode=min-should",
+			"phrase: adjacent ordered words within one key, value, or JSON string field",
+			"fuzziness: maximum dictionary-term edit distance 0|1|2",
+			"prefix_terms: include dictionary terms extending a query word (lan matches lantern)",
+			"cursor: opaque unpadded URL-safe base64 continuation from the same request and endpoint",
+			"all: lazily follow the bounded endpoint-sticky cursor session",
+			"projection: key-score or the exact selection-time full-vertex value/TTL snapshot",
+			"format: lossless page JSON, per-hit NDJSON, or quoted TSV",
+			"Compatibility: phrase=true requires mode=server, fuzziness=0, prefix_terms=false, and endpoint positional postings; all=true requires ndjson or tsv",
+		},
+		Meaning:  "Search live vertex keys and values by relevance without treating the derived index as a source of truth. See https://github.com/anaregdesign/lantern/blob/main/docs/search.md.",
+		Examples: []string{`search "rolling update" mode=all limit=20`, `search "release notes" phrase=true`, "search serach fuzziness=1", "search espresso limit=20 all=true format=ndjson"},
+	},
 	{
 		Name:      "bfs",
 		Signature: "bfs <seed> [step] [fan_out] [reduction=none|mst|spt] [objective=min|max] [weighting=raw|tfidf|bm25] [prefix=<string>]",
@@ -84,7 +117,7 @@ const HelpText = `Lantern CLI grammar:
              [weighting={raw|tfidf|bm25}] default=raw
              [prefix=<string>]           default=all keys
              defaults: max_size=0 (sweep decides)
-  help [bfs|pagerank|community]
+  help [search|bfs|pagerank|community]
   exit
 
 Search contract: https://github.com/anaregdesign/lantern/blob/main/docs/search.md
@@ -92,7 +125,7 @@ Search contract: https://github.com/anaregdesign/lantern/blob/main/docs/search.m
 Quoting: "double" with C-style escapes (\" \\ \n \r \t); 'single' verbatim.
 Verb/objective case-insensitive; argument values preserve case.`
 
-// HelpParam parses the optional family topic. Unknown topics and excess
+// HelpParam parses the optional focused command topic. Unknown topics and excess
 // arguments are rejected so operators get an actionable candidate list rather
 // than silently receiving unrelated global help.
 func HelpParam(s *Source) (*Help, error) {
@@ -123,7 +156,7 @@ func HelpTopicNames() []string {
 }
 
 // HelpTextFor renders the overview for an empty topic or the structured
-// family-only reference for a known topic. Callers that parse user input should
+// command-only reference for a known topic. Callers that parse user input should
 // use HelpParam first; the bool accommodates Cobra's static construction.
 func HelpTextFor(topic string) (string, bool) {
 	if topic == "" {

--- a/cli/parser/help_test.go
+++ b/cli/parser/help_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// HelpText is consumed by bare `help`; HelpTextFor powers family-scoped REPL
+// HelpText is consumed by bare `help`; HelpTextFor powers command-scoped REPL
 // and Cobra help. The TypeScript port mirrors both contracts.
 
 func TestHelpText_EnumeratesFamilyKwargs(t *testing.T) {
@@ -45,7 +45,7 @@ func TestHelpText_ListsEveryVerb(t *testing.T) {
 }
 
 func TestValidate_HelpVerb(t *testing.T) {
-	for _, in := range []string{"help", "HELP", "help bfs", "help PAGERANK", "help community", "  help  "} {
+	for _, in := range []string{"help", "HELP", "help search", "help bfs", "help PAGERANK", "help community", "  help  "} {
 		if err := Validate(in); err != nil {
 			t.Errorf("Validate(%q) returned %v; want nil", in, err)
 		}
@@ -63,6 +63,7 @@ func TestHelpParamAndScopedText(t *testing.T) {
 		topic string
 	}{
 		{"help", ""},
+		{"help search", "search"},
 		{"help bfs", "bfs"},
 		{"help PAGERANK", "pagerank"},
 		{"help community", "community"},
@@ -94,5 +95,21 @@ func TestHelpParamAndScopedText(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestHelpTextFor_SearchDocumentsEveryParameter(t *testing.T) {
+	text, ok := HelpTextFor("search")
+	if !ok {
+		t.Fatal("search help topic was not renderable")
+	}
+	for _, want := range []string{
+		"query:", "limit:", "prefix:", "mode:", "min_should:",
+		"phrase:", "fuzziness:", "prefix_terms:", "cursor:", "all:",
+		"projection:", "format:", "Compatibility:",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("search help missing %q:\n%s", want, text)
+		}
 	}
 }

--- a/cli/parser/validate_test.go
+++ b/cli/parser/validate_test.go
@@ -11,7 +11,7 @@ import "testing"
 func FuzzValidate(f *testing.F) {
 	seeds := []string{
 		// Valid forms (mirrors the "valid" arm of the shared fixture).
-		"exit", "help", "help bfs", "help pagerank", "help community",
+		"exit", "help", "help search", "help bfs", "help pagerank", "help community",
 		"get vertex alice", "get edge alice bob",
 		"put vertex alice Alice", "put vertex alice Alice 60",
 		"put vertex price 1234 type=int", "put vertex name 007 type=string",

--- a/tests/integration/search_vertices_test.go
+++ b/tests/integration/search_vertices_test.go
@@ -1160,6 +1160,23 @@ func TestSearchCLISharedGrammarOverRealH2C(t *testing.T) {
 		return graphv1connect.NewLanternServiceClient(h2cClient(), srv.url), newConnectClientFor(t, srv.url)
 	}
 
+	t.Run("built CLI help explains every search parameter", func(t *testing.T) {
+		binary := buildLanternCLI(t)
+		stdout, stderr, exitCode := runLanternCLI(t, binary, "127.0.0.1:1", "search", "--help")
+		if exitCode != 0 || stderr != "" {
+			t.Fatalf("search --help exit=%d stderr=%q", exitCode, stderr)
+		}
+		for _, want := range []string{
+			"query:", "limit:", "prefix:", "mode:", "min_should:",
+			"phrase:", "fuzziness:", "prefix_terms:", "cursor:", "all:",
+			"projection:", "format:", "Compatibility:",
+		} {
+			if !strings.Contains(stdout, want) {
+				t.Errorf("search --help missing %q:\n%s", want, stdout)
+			}
+		}
+	})
+
 	t.Run("Cobra model and raw REPL grammar return the same request result", func(t *testing.T) {
 		raw, sdk := newCLI(t, service.SearchLimits{
 			Enabled: true, PositionsEnabled: true, DefaultLimit: 1, MaxLimit: 1,


### PR DESCRIPTION
## What changed

- Added accessible, hover/focus Tooltips to every **Data > Content search** parameter while preserving visible labels and control associations.
- Added one canonical search-parameter reference to the root Cobra CLI, Go REPL, and Admin `/cli`, including defaults, domains, cursor/output behavior, and compatibility constraints.
- Reorganized Ops metrics into nine operator-oriented sections with a real heading hierarchy.
- Split dense or mixed charts by operational decision: RPC workload, Illuminate algorithm, Search outcome/phase/work, Search index subsystem, replication apply/drop, and rejection source.
- Filtered pre-warmed zero counter series from dense legends and retained per-replica / cluster-sum behavior.
- Added unit, real-wire CLI, and Playwright coverage, including keyboard Tooltips and 390px Ops layout.

## Why

Content-search controls exposed behavior without consistently explaining it, and the CLI surfaces did not provide one focused parameter reference. Ops charts also combined unrelated or high-cardinality series, making legends difficult to scan during incident triage.

## User and operator impact

Search options are now discoverable in-place and described consistently across UI and CLI. Ops metrics can be scanned section-by-section, with each chart limited to signals used for the same operational decision.

## Validation

- `gofmt -l .`
- `go test ./...` (root, including real h2c integration)
- `go test ./...` in `core`, `mcp`, `pb`, `sdks/go`, and `server`
- `go vet ./...` in `server`
- golangci-lint v2.12.2: 0 issues introduced from `main`
- Dart SDK: format, locked pub get, analyze, test, dartdoc link validation, publish dry-run
- Flutter example: format, locked pub get, analyze, test
- Admin: Prettier, ESLint, typecheck, 842 unit/grammar tests, production build
- Playwright: 79/79 full suite; affected Tooltip/Ops suites rerun after the final build (22/22)

Closes #1129