### PR TITLE
fix(deploy): suppress GKE startup log noise

### DIFF
--- a/deploy/helm/lantern/README.md
+++ b/deploy/helm/lantern/README.md
@@ -61,6 +61,7 @@ can be disabled via `podDisruptionBudget.enabled=false`.
 | `replicaCount`                              | `2`                    | Minimal HA default (full-replica store).           |
 | `image.repository`                          | `ghcr.io/anaregdesign/lantern` | Override for private mirrors.              |
 | `image.tag`                                 | `.Chart.AppVersion`    | Pin to a specific release tag in production.       |
+| `enableServiceLinks`                        | `false`                | Disable unused Kubernetes ServiceLink env injection; enable only for legacy ServiceLink discovery. |
 | `service.port`                              | `6380`                 | gRPC.                                              |
 | `metrics.port`                              | `9090`                 | `/metrics`, `/healthz`, `/readyz`.                 |
 | `replication.discovery.mode`                | `dns`                  | `static` falls back to `LANTERN_PEERS`.            |

--- a/deploy/helm/lantern/templates/admin-deployment.yaml
+++ b/deploy/helm/lantern/templates/admin-deployment.yaml
@@ -23,6 +23,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/lantern/templates/mcp-deployment.yaml
+++ b/deploy/helm/lantern/templates/mcp-deployment.yaml
@@ -23,6 +23,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/lantern/templates/statefulset.yaml
+++ b/deploy/helm/lantern/templates/statefulset.yaml
@@ -28,6 +28,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "lantern.serviceAccountName" . }}
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/lantern/values.yaml
+++ b/deploy/helm/lantern/values.yaml
@@ -17,6 +17,13 @@ image:
 
 imagePullSecrets: []
 
+# Lantern discovers peers and sibling services through DNS, so Kubernetes
+# ServiceLink environment variables are unnecessary. Keep them disabled to
+# avoid namespace-dependent LANTERN_* variables colliding with the server's
+# strict config validation. Set true only for a workload that explicitly
+# depends on legacy ServiceLink discovery.
+enableServiceLinks: false
+
 nameOverride: ""
 fullnameOverride: ""
 

--- a/server/provider/provider.go
+++ b/server/provider/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"math"
 	"net"
@@ -380,7 +381,12 @@ func NewConfig() (*Config, error) {
 		CORS:        loadCORSConfig(),
 		Backup:      loadBackupConfig(),
 	}
-	if err := validateEnv(os.Environ()); err != nil {
+	// Config validation runs before Wire can construct and install the
+	// process-wide logger. Build the same configured logger here so bootstrap
+	// records are structured (and keep their severity in collectors such as
+	// GKE Cloud Logging) instead of falling back to slog's plain-text stderr
+	// handler.
+	if err := validateEnv(os.Environ(), newLogger(cfg.Observability, os.Stderr)); err != nil {
 		return nil, err
 	}
 	// Unlike the malformed/unknown-variable findings (warn, and only fail under
@@ -483,12 +489,10 @@ var foreignEnvPrefixes = []string{"LANTERN_MCP_", "LANTERN_TOKEN"}
 
 // validateEnv is the boot-time config validation pass (#847). It runs after
 // every loader has registered its variables, so the envconfig registry is
-// the complete env contract at this point. It reports through slog.Default()
-// (the structured logger replaces the default later in the wire graph; these
-// lines still land on stderr) and fails only under LANTERN_STRICT_CONFIG.
-func validateEnv(environ []string) error {
+// the complete env contract at this point. It reports through the bootstrap
+// logger supplied by NewConfig and fails only under LANTERN_STRICT_CONFIG.
+func validateEnv(environ []string, log *slog.Logger) error {
 	strict := envconfig.Bool("LANTERN_STRICT_CONFIG", false)
-	log := slog.Default()
 
 	findings := envconfig.Findings()
 	for _, f := range findings {
@@ -553,16 +557,20 @@ func NewSearchConfig(c *Config) SearchConfig               { return c.Search }
 // NewLogger builds the process-wide structured logger and installs it as the
 // slog default so any package-level slog.* call inherits the same handler.
 func NewLogger(o ObservabilityConfig) *slog.Logger {
+	l := newLogger(o, os.Stderr)
+	slog.SetDefault(l)
+	return l
+}
+
+func newLogger(o ObservabilityConfig, w io.Writer) *slog.Logger {
 	opts := &slog.HandlerOptions{Level: o.LogLevel}
 	var h slog.Handler
 	if strings.EqualFold(o.LogFormat, "text") {
-		h = slog.NewTextHandler(os.Stderr, opts)
+		h = slog.NewTextHandler(w, opts)
 	} else {
-		h = slog.NewJSONHandler(os.Stderr, opts)
+		h = slog.NewJSONHandler(w, opts)
 	}
-	l := slog.New(h).With(slog.String("service", "lantern"))
-	slog.SetDefault(l)
-	return l
+	return slog.New(h).With(slog.String("service", "lantern"))
 }
 
 func NewGraphCache(c CacheConfig, sc SearchConfig) *graphcache.GraphCache[string, *v1.Vertex] {

--- a/server/provider/provider_test.go
+++ b/server/provider/provider_test.go
@@ -70,6 +70,35 @@ func TestWireCacheGCHooks_EmitsTickSummary(t *testing.T) {
 // failure happens inside NewConfig — the first provider wire constructs — so
 // a refused boot never reaches listener construction.
 func TestNewConfigValidation(t *testing.T) {
+	t.Run("bootstrap validation uses configured JSON logger", func(t *testing.T) {
+		envconfig.ResetForTesting()
+		t.Setenv("LANTERN_STRICT_CONFIG", "false")
+		var buf bytes.Buffer
+		logger := newLogger(ObservabilityConfig{
+			LogLevel:  slog.LevelInfo,
+			LogFormat: "json",
+		}, &buf)
+
+		if err := validateEnv([]string{"LANTERN_NOT_REAL=1"}, logger); err != nil {
+			t.Fatalf("validateEnv: %v", err)
+		}
+		recs := decodeRecords(t, &buf)
+		if len(recs) != 2 {
+			t.Fatalf("bootstrap records = %d, want 2: %v", len(recs), recs)
+		}
+		warn := recs[0]
+		if warn["level"] != "WARN" || warn["msg"] != "config: unknown LANTERN_* variable" {
+			t.Fatalf("bootstrap warning severity/message = %v/%v, want WARN/unknown-variable", warn["level"], warn["msg"])
+		}
+		if warn["service"] != "lantern" || warn["key"] != "LANTERN_NOT_REAL" {
+			t.Fatalf("bootstrap warning fields = %v", warn)
+		}
+		info := recs[1]
+		if info["level"] != "INFO" || info["msg"] != "config: environment overrides active" {
+			t.Fatalf("bootstrap summary severity/message = %v/%v, want INFO/environment-summary", info["level"], info["msg"])
+		}
+	})
+
 	t.Run("traversal safety defaults are finite", func(t *testing.T) {
 		envconfig.ResetForTesting()
 		for _, key := range []string{

--- a/tests/integration/docs_gate_test.go
+++ b/tests/integration/docs_gate_test.go
@@ -425,6 +425,24 @@ func TestGKEDeployRecoveryWorkflow(t *testing.T) {
 			t.Errorf("reusable GKE deployment workflow does not pin %s to a 40-character commit SHA", action)
 		}
 	}
+
+	chartDir := filepath.Join(repoRoot, "deploy", "helm", "lantern")
+	values, err := os.ReadFile(filepath.Join(chartDir, "values.yaml"))
+	if err != nil {
+		t.Fatalf("read Helm values: %v", err)
+	}
+	if !regexp.MustCompile(`(?m)^enableServiceLinks:\s+false$`).Match(values) {
+		t.Error("Helm defaults must disable Kubernetes ServiceLinks")
+	}
+	for _, name := range []string{"statefulset.yaml", "admin-deployment.yaml", "mcp-deployment.yaml"} {
+		template, err := os.ReadFile(filepath.Join(chartDir, "templates", name))
+		if err != nil {
+			t.Fatalf("read Helm template %s: %v", name, err)
+		}
+		if !strings.Contains(string(template), "enableServiceLinks: {{ .Values.enableServiceLinks }}") {
+			t.Errorf("Helm template %s does not apply the ServiceLink policy", name)
+		}
+	}
 }
 
 func parseTraversalDocumentationCommand(t *testing.T, command string) {


### PR DESCRIPTION
## Summary

- disable unused Kubernetes ServiceLinks in every Helm-managed Pod template so Service-generated `LANTERN_*` variables do not collide with strict server config validation
- use the configured structured logger for boot-time config validation before Wire installs the process-wide logger
- gate the Helm default/rendering contract and JSON bootstrap severity with tests

## GKE evidence

In the seven-day window ending 2026-07-20T02:58Z, Cloud Logging classified 788 Lantern records as `ERROR`; 740 were ServiceLink warnings and 37 were startup INFO summaries written as plain text to stderr. The remaining OOM incident was already fixed by #1126/#1127 and current v0.34.0 pods are healthy.

## Verification

- `gofmt -l .`
- root and all six Go module test suites; `go vet ./...` in `server/`
- Dart SDK format/pub get/analyze/test/dartdoc/publish dry-run
- Flutter example format/pub get/analyze/test
- `helm lint deploy/helm/lantern`
- default + Admin + MCP `helm template` renders three `enableServiceLinks: false` Pod specs
- targeted provider and GKE deployment-contract tests

Additional local `make lint` reached only pre-existing findings in installed `node_modules/flatted` and `cli/cmd/grammar_test.go`; no changed file was reported.

Closes #1131