### PR TITLE
fix(deploy): restore GKE HA observability

### DIFF
--- a/.github/workflows/_deploy-gke.yml
+++ b/.github/workflows/_deploy-gke.yml
@@ -88,7 +88,11 @@ jobs:
           helm upgrade --install "$RELEASE" deploy/helm/lantern \
             --namespace "$NAMESPACE" \
             --set image.tag="$PURE_TAG" \
+            --set metrics.podMonitoring.enabled=true \
             --wait --timeout 10m --debug
+          kubectl wait "podmonitoring/$RELEASE" \
+            --namespace "$NAMESPACE" \
+            --for=condition=ConfigurationCreateSuccess --timeout=2m
           kubectl rollout status "statefulset/$RELEASE" \
             --namespace "$NAMESPACE" --timeout=10m
 
@@ -104,6 +108,7 @@ jobs:
           kubectl get pods --namespace "$NAMESPACE" --selector "$selector" -o wide
           kubectl describe pods --namespace "$NAMESPACE" --selector "$selector"
           kubectl get pvc --namespace "$NAMESPACE" -o wide
+          kubectl get podmonitoring "$RELEASE" --namespace "$NAMESPACE" -o yaml
           kubectl get events --namespace "$NAMESPACE" \
             --sort-by='.lastTimestamp' | tail -n 200
           while IFS= read -r pod; do

--- a/deploy/helm/lantern/README.md
+++ b/deploy/helm/lantern/README.md
@@ -44,15 +44,16 @@ helm lint deploy/helm/lantern
 
 The pump reads `LANTERN_PEER_DISCOVERY=dns` and resolves the headless
 `Service` FQDN to obtain peer IPs. `LocalIPSet()` in the server filters
-the pod's own IP so the supervisor never dials itself.
+the pod's own IP so the supervisor never dials itself. The headless Service
+publishes not-ready addresses so peers can discover one another during a cold
+start; the separate client Service continues to exclude unready pods.
 
 ## Single-instance fallback
 
-For dev / single-instance topologies set `replicaCount=1` and either
-keep `replication.discovery.mode=dns` (the DNSSource will resolve to
-just the local pod and filter it out — pump becomes a no-op) or set
-`replication.discovery.mode=static` with `replication.peers=[]`. PDB
-can be disabled via `podDisruptionBudget.enabled=false`.
+For dev / single-instance topologies set `replicaCount=1`,
+`replication.discovery.mode=static`, and `replication.peers=[]`. DNS discovery
+selects HA readiness mode and therefore intentionally waits for a peer. PDB can
+be disabled via `podDisruptionBudget.enabled=false`.
 
 ## Tuning
 

--- a/deploy/helm/lantern/templates/service.yaml
+++ b/deploy/helm/lantern/templates/service.yaml
@@ -8,7 +8,9 @@ metadata:
     lantern.anaregdesign.io/role: peer-discovery
 spec:
   clusterIP: None
-  publishNotReadyAddresses: false
+  # Peer DNS must include bootstrapping pods; the separate client Service
+  # remains readiness-gated and never routes application traffic to them.
+  publishNotReadyAddresses: true
   selector:
     {{- include "lantern.selectorLabels" . | nindent 4 }}
   ports:

--- a/docs/ha-runbook.md
+++ b/docs/ha-runbook.md
@@ -97,8 +97,9 @@ kubectl get statefulset,svc,pdb -l app.kubernetes.io/instance=lantern
 ```
 
 **Why two Services?** The headless Service (`*-headless`,
-`clusterIP: None`, `publishNotReadyAddresses: false`) is what the
-DNS pump resolves — its A records are the live pod IPs. The
+`clusterIP: None`, `publishNotReadyAddresses: true`) is what the
+DNS pump resolves — its A records include bootstrapping pod IPs so a
+simultaneous cold start cannot deadlock behind readiness. The
 `ClusterIP` Service is what clients hit; they get a stable VIP and
 kube-proxy spreads load across the backing pods. Splitting them means
 client traffic never accidentally targets a pod that's still
@@ -266,7 +267,7 @@ exact Prometheus series.
 |---|---|---|
 | `lantern_replication_lag_seq{peer,origin}` | gauge | How many mutation log entries this pod is behind `peer` for that `origin`. **The single most important HA signal.** |
 | `lantern_replication_applied_total{origin}` | counter | Remote mutations from `origin` (the originating writer node) that landed in the local cache. `rate()` ≈ steady-state replication throughput per origin. |
-| `lantern_replication_dropped_total{peer,reason}` | counter | Replication frames or peer interactions dropped. `reason` is `self_echo` / `subscribe_failed` / `snapshot_failed` / `dial_failed` / `peerstatus_failed` / `catchup_failed` / `clean` / `ctx_cancel`. A persistent non-zero rate (excluding `self_echo` / `clean`) signals an unreachable or stuck peer. |
+| `lantern_replication_dropped_total{peer,reason}` | counter | Replication frames or peer interactions dropped. `reason` is `self_echo` / `subscribe_failed` / `snapshot_failed` / `dial_failed` / `peerstatus_failed` / `catchup_failed` / `discovery_failed` / `clean` / `ctx_cancel`. A persistent non-zero rate (excluding `self_echo` / `clean`) signals an unreachable or stuck peer. |
 | `lantern_anti_entropy_cycles_total` | counter | Anti-entropy ticks. Should advance at `LANTERN_ANTI_ENTROPY_INTERVAL_MS` cadence. |
 | `lantern_anti_entropy_gaps_found_total{peer,origin}` | counter | Non-zero = real divergence detected and being repaired. Spiking after a partition heal = expected. Persistently incrementing in steady state = open a bug. |
 | `lantern_search_config_match{peer}` | gauge | `1` means the peer's search capability fingerprint exactly matches this pod; `0` means missing/mismatched and keeps readiness `NOT_SERVING`. |
@@ -650,10 +651,9 @@ Walk the bootstrap flow:
    - Check `LANTERN_PEER_DISCOVERY` env values.
    - From inside the pod, `getent hosts <discovery-dns-name>` should
      return one A record per other pod.
-   - The headless Service has `publishNotReadyAddresses: false`; if
-     **all** pods restart simultaneously, no pod is "ready" yet so
-     the headless Service publishes nothing. **Boot one pod at a
-     time** in this case.
+   - Confirm the headless Service has `publishNotReadyAddresses: true` so
+     bootstrapping pods are discoverable. The separate client Service remains
+     readiness-gated.
 3. If snapshot succeeds but `/readyz` stays 503: lag is above
    threshold. Check `lantern_replication_lag_seq`. Either wait
    (steady-state catch-up) or bump `LANTERN_MAX_REPLICATION_LAG`.
@@ -693,10 +693,11 @@ A short checklist to walk before opening an incident:
       for you; custom manifests must.
 - [ ] **Probes on wrong port:** `/healthz` and `/readyz` are on the
       **metrics** port (9090), not the gRPC port (6380).
-- [ ] **`publishNotReadyAddresses: false` deadlock:** if every pod
-      restarts simultaneously, none is "ready", the headless Service
-      publishes nothing, and nobody bootstraps. Roll pods one at a
-      time, or temporarily flip the flag.
+- [ ] **`publishNotReadyAddresses: false` deadlock:** if every pod restarts
+      simultaneously, none is "ready", the headless Service publishes
+      nothing, and nobody bootstraps. The maintained Helm chart sets this to
+      `true`; custom manifests must do the same for peer discovery while
+      keeping the client-facing Service readiness-gated.
 - [ ] **OSS nginx as a Lantern LB:** the `resolve` keyword on
       `upstream server` is nginx-plus only. Use an HTTP/2-aware
       reverse proxy (Envoy, Caddy, Traefik) or kube-proxy via a

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -229,7 +229,7 @@ a leader. Grouped by concern:
   fresh or gapped pod re-seeded, and how expensive it was.
 - **Dropped frames (RCA).** `lantern_replication_dropped_total{peer,reason}`
   (reasons: `self_echo`, `subscribe_failed`, `snapshot_failed`, `dial_failed`,
-  `peerstatus_failed`, `catchup_failed`, `ctx_cancel`, `clean`),
+  `peerstatus_failed`, `catchup_failed`, `discovery_failed`, `ctx_cancel`, `clean`),
   `lantern_origin_states_count` (distinct writers ever seen ≈ peer-set size).
 
 ### 5.5 In-process pub/sub (client CDC) — "are local subscribers keeping up?"

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -52,8 +52,9 @@ is required for either reads or writes.
    whenever replication lag exceeds `LANTERN_MAX_REPLICATION_LAG` or an
    observed peer reports a different search config fingerprint, so the load
    balancer drains the instance. Graph replication continues across a search
-   mismatch for repair and diagnosis. **Single-instance mode** (empty
-   `LANTERN_PEERS`) bypasses this gate.
+   mismatch for repair and diagnosis. **Single-instance mode** (static
+   discovery with empty `LANTERN_PEERS`) bypasses this gate; DNS discovery
+   selects peer mode even before the first peer resolves.
 5. **No leader, no Raft, no external storage.** v1 is intentionally
    ephemeral. Single-pod loss recovers from peers; total-cluster loss is
    accepted data loss **unless snapshot backups are configured**
@@ -472,7 +473,7 @@ new pod boots
   └── /healthz/ready flips SERVING when:
         - lag(P) < LANTERN_MAX_REPLICATION_LAG and observed peer search
           fingerprints match, OR
-        - single-instance mode (LANTERN_PEERS empty)
+        - single-instance mode (static discovery and LANTERN_PEERS empty)
 ```
 
 Target steady-state flush latency: **< 100 ms** intra-DC at 1k mut/s.

--- a/server/cmd/wire.go
+++ b/server/cmd/wire.go
@@ -31,6 +31,7 @@ func initializeApp() (*App, error) {
 		provider.NewReplicationConfig,
 		provider.NewReadinessConfig,
 		provider.NewPeerConfig,
+		provider.NewPeerResolver,
 		provider.NewAntiEntropyConfig,
 		provider.NewHLCClock,
 		provider.NewMutationLog,

--- a/server/cmd/wire_gen.go
+++ b/server/cmd/wire_gen.go
@@ -59,17 +59,18 @@ func initializeApp() (*App, error) {
 	lanternServer := service.NewLanternServer(lanternListener, logger, lifecycleConfig, healthChecker, graphCache, lanternService, lanternReplicationService)
 	readinessConfig := provider.NewReadinessConfig(config)
 	peerConfig := provider.NewPeerConfig(config)
-	gate := provider.NewReadinessGate(readinessConfig, peerConfig, healthChecker)
+	peerResolver := provider.NewPeerResolver(peerConfig, logger)
+	gate := provider.NewReadinessGate(readinessConfig, peerConfig, peerResolver, healthChecker)
 	metricsServer := provider.NewMetricsServer(observabilityConfig, registry, gate, logger)
 	tracing, err := provider.NewTracing(logger)
 	if err != nil {
 		return nil, err
 	}
 	metrics := provider.NewPumpMetrics(domainMetrics, gate)
-	pump := provider.NewReplicationPump(peerConfig, replicationConfig, authConfig, lanternService, graphCache, metrics, logger)
+	pump := provider.NewReplicationPump(peerConfig, peerResolver, replicationConfig, authConfig, lanternService, graphCache, metrics, logger)
 	antiEntropyConfig := provider.NewAntiEntropyConfig(config)
 	antiEntropyMetrics := provider.NewAntiEntropyMetrics(domainMetrics, gate)
-	antiEntropy := provider.NewAntiEntropyDriver(peerConfig, replicationConfig, antiEntropyConfig, authConfig, lanternService, graphCache, pump, antiEntropyMetrics, logger)
+	antiEntropy := provider.NewAntiEntropyDriver(peerConfig, peerResolver, replicationConfig, antiEntropyConfig, authConfig, lanternService, graphCache, pump, antiEntropyMetrics, logger)
 	backupConfig := provider.NewBackupConfig(config)
 	backupper := provider.NewBackupper(backupConfig, lanternService, registry, logger)
 	llmConfig := provider.NewLLMConfig(config)

--- a/server/provider/antientropy.go
+++ b/server/provider/antientropy.go
@@ -48,11 +48,12 @@ func loadAntiEntropyConfig() AntiEntropyConfig {
 // bounded Subscribe-or-Snapshot catch-up when the peer's own
 // origin watermark exceeds the local one.
 //
-// Empty PeerConfig.Peers or a zero Interval yields a driver whose
-// Run is a no-op (returns immediately), so the same wire graph
+// Neither static peers nor a dynamic resolver, or a zero Interval, yields a
+// driver whose Run is a no-op (returns immediately), so the same wire graph
 // supports single-instance, pump-only, and full-HA topologies.
 func NewAntiEntropyDriver(
 	pc PeerConfig,
+	resolver *PeerResolver,
 	rc ReplicationConfig,
 	ac AntiEntropyConfig,
 	auth AuthConfig,
@@ -63,9 +64,14 @@ func NewAntiEntropyDriver(
 	logger *slog.Logger,
 ) *replication.AntiEntropy {
 	_ = pump // forces wire to construct the pump before the driver
+	var source replication.PeerSource
+	if resolver != nil {
+		source = resolver.Source
+	}
 	return replication.NewAntiEntropy(replication.AntiEntropyConfig{
 		NodeID:                  rc.NodeID,
 		Peers:                   pc.Peers,
+		Source:                  source,
 		Interval:                ac.Interval,
 		SubscribeTimeout:        ac.SubscribeTimeout,
 		GapWarnThreshold:        ac.GapWarnThreshold,

--- a/server/provider/peer_source.go
+++ b/server/provider/peer_source.go
@@ -1,0 +1,40 @@
+package provider
+
+import (
+	"log/slog"
+
+	"github.com/anaregdesign/lantern/server/replication"
+)
+
+// PeerResolver owns the optional dynamic PeerSource shared by the replication
+// Pump and AntiEntropy driver. Static deployments leave Source nil and both
+// consumers continue to use PeerConfig.Peers directly.
+type PeerResolver struct {
+	Source replication.PeerSource
+}
+
+// NewPeerResolver constructs the dynamic resolver once so every replication
+// subsystem observes the same discovery semantics and self-filter set.
+func NewPeerResolver(pc PeerConfig, logger *slog.Logger) *PeerResolver {
+	resolver := &PeerResolver{}
+	if pc.Discovery != "dns" || pc.DNSName == "" {
+		return resolver
+	}
+
+	selfIPs, err := replication.LocalIPSet()
+	if err != nil {
+		logger.Warn("replication: failed to enumerate local IPs for DNS self-filter",
+			slog.Any("err", err))
+		selfIPs = nil
+	}
+	resolver.Source = &replication.DNSSource{
+		Name:    pc.DNSName,
+		Port:    pc.DefaultPort,
+		SelfIPs: selfIPs,
+	}
+	logger.Info("replication: DNS peer discovery enabled",
+		slog.String("dns_name", pc.DNSName),
+		slog.String("default_port", pc.DefaultPort),
+		slog.Duration("interval", pc.DiscoveryInterval))
+	return resolver
+}

--- a/server/provider/peer_source_test.go
+++ b/server/provider/peer_source_test.go
@@ -1,0 +1,40 @@
+package provider
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/anaregdesign/lantern/server/replication"
+)
+
+func TestNewPeerResolver(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("static leaves dynamic source disabled", func(t *testing.T) {
+		got := NewPeerResolver(PeerConfig{
+			Discovery: "static",
+			Peers:     []string{"peer:6380"},
+		}, logger)
+		if got.Source != nil {
+			t.Fatalf("static Source = %T, want nil", got.Source)
+		}
+	})
+
+	t.Run("dns constructs shared source", func(t *testing.T) {
+		got := NewPeerResolver(PeerConfig{
+			Discovery:         "dns",
+			DNSName:           "lantern-headless.default.svc.cluster.local",
+			DefaultPort:       "6380",
+			DiscoveryInterval: 10 * time.Second,
+		}, logger)
+		dns, ok := got.Source.(*replication.DNSSource)
+		if !ok {
+			t.Fatalf("DNS Source = %T, want *replication.DNSSource", got.Source)
+		}
+		if dns.Name != "lantern-headless.default.svc.cluster.local" || dns.Port != "6380" {
+			t.Fatalf("DNS Source = %+v", dns)
+		}
+	})
+}

--- a/server/provider/pump.go
+++ b/server/provider/pump.go
@@ -84,6 +84,7 @@ func loadPeerConfig() PeerConfig {
 // generic specialisation — it sees only the SnapshotApplier surface.
 func NewReplicationPump(
 	pc PeerConfig,
+	resolver *PeerResolver,
 	rc ReplicationConfig,
 	ac AuthConfig,
 	svc *service.LanternService,
@@ -102,22 +103,8 @@ func NewReplicationPump(
 		AuthToken:               firstToken(ac.Tokens),
 		SearchConfigFingerprint: svc.SearchConfigFingerprint(),
 	}
-	if pc.Discovery == "dns" && pc.DNSName != "" {
-		selfIPs, err := replication.LocalIPSet()
-		if err != nil {
-			logger.Warn("replication pump: failed to enumerate local IPs for DNS self-filter",
-				slog.Any("err", err))
-			selfIPs = nil
-		}
-		cfg.Source = &replication.DNSSource{
-			Name:    pc.DNSName,
-			Port:    pc.DefaultPort,
-			SelfIPs: selfIPs,
-		}
-		logger.Info("replication pump: DNS peer discovery enabled",
-			slog.String("dns_name", pc.DNSName),
-			slog.String("default_port", pc.DefaultPort),
-			slog.Duration("interval", pc.DiscoveryInterval))
+	if resolver != nil {
+		cfg.Source = resolver.Source
 	}
 	return replication.NewPump(cfg, svc, cache)
 }

--- a/server/provider/readiness.go
+++ b/server/provider/readiness.go
@@ -14,7 +14,7 @@ import (
 //   - LANTERN_MAX_REPLICATION_LAG       maximum tolerated per-(peer, origin)
 //     lag in mutation-seq units before the overall ("") gRPC health entry
 //     flips to NOT_SERVING. Default 10000. Single-instance deployments
-//     (empty LANTERN_PEERS) bypass gating entirely.
+//     (no static peers and no dynamic discovery) bypass gating entirely.
 type ReadinessConfig struct {
 	MaxLag uint64
 }
@@ -31,11 +31,11 @@ func loadReadinessConfig() ReadinessConfig {
 }
 
 // NewReadinessGate constructs the readiness Gate that drives the overall
-// ("") gRPC health entry. The peer-mode flag is derived from PeerConfig:
-// empty LANTERN_PEERS yields a permanently-ready gate that bypasses lag
-// gating, matching the single-instance startup contract.
-func NewReadinessGate(rc ReadinessConfig, pc PeerConfig, hc *HealthChecker) *readiness.Gate {
-	return readiness.NewGate(rc.MaxLag, len(pc.Peers) > 0, hc)
+// ("") gRPC health entry. Either static peers or a dynamic resolver selects
+// peer mode; only a topology with neither bypasses lag gating.
+func NewReadinessGate(rc ReadinessConfig, pc PeerConfig, resolver *PeerResolver, hc *HealthChecker) *readiness.Gate {
+	hasDynamicPeers := resolver != nil && resolver.Source != nil
+	return readiness.NewGate(rc.MaxLag, len(pc.Peers) > 0 || hasDynamicPeers, hc)
 }
 
 // pumpMetricsFanOut delegates replication.Metrics events to both

--- a/server/provider/readiness_test.go
+++ b/server/provider/readiness_test.go
@@ -1,0 +1,35 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/anaregdesign/lantern/server/replication"
+)
+
+func TestNewReadinessGate(t *testing.T) {
+	t.Run("single instance starts ready", func(t *testing.T) {
+		gate := NewReadinessGate(ReadinessConfig{MaxLag: 100}, PeerConfig{}, &PeerResolver{}, NewHealthChecker())
+		if !gate.Ready() {
+			t.Fatal("single-instance readiness gate must start ready")
+		}
+	})
+
+	t.Run("static peers require bootstrap", func(t *testing.T) {
+		gate := NewReadinessGate(ReadinessConfig{MaxLag: 100}, PeerConfig{Peers: []string{"peer:6380"}}, &PeerResolver{}, NewHealthChecker())
+		if gate.Ready() {
+			t.Fatal("static-peer readiness gate must wait for bootstrap")
+		}
+	})
+
+	t.Run("dynamic peers require bootstrap", func(t *testing.T) {
+		resolver := &PeerResolver{Source: replication.StaticSource{Peers: []string{"peer:6380"}}}
+		gate := NewReadinessGate(ReadinessConfig{MaxLag: 100}, PeerConfig{}, resolver, NewHealthChecker())
+		if gate.Ready() {
+			t.Fatal("dynamic-peer readiness gate must wait for bootstrap")
+		}
+		gate.OnPumpConnect("peer:6380")
+		if !gate.Ready() {
+			t.Fatal("dynamic-peer readiness gate must become ready after bootstrap")
+		}
+	})
+}

--- a/server/replication/antientropy.go
+++ b/server/replication/antientropy.go
@@ -81,16 +81,21 @@ func (nopAntiEntropyMetrics) OnAntiEntropyError(string, string)            {}
 func (nopAntiEntropyMetrics) OnSearchConfig(string, bool)                  {}
 
 // AntiEntropyConfig groups the driver's inputs. All fields except
-// Peers / Interval are optional; NewAntiEntropy fills defaults.
+// Peers / Source / Interval are optional; NewAntiEntropy fills defaults.
 type AntiEntropyConfig struct {
 	// NodeID is the local node's HLC NodeID. Used to skip
 	// PeerStatus rows where self_origin == local NodeID (the
 	// peer should never be ahead of us on our OWN origin).
 	NodeID hlc.NodeID
 
-	// Peers is the static list of peer addresses to poll. Empty
-	// (or nil) yields a no-op driver — Run returns immediately.
+	// Peers is the static list of peer addresses to poll. Empty (or nil)
+	// yields a no-op driver only when Source is also nil.
 	Peers []string
+
+	// Source, when non-nil, takes precedence over Peers and is resolved on
+	// every anti-entropy cycle. This keeps periodic repair aligned with a
+	// dynamic Pump topology such as Kubernetes headless-Service DNS.
+	Source PeerSource
 
 	// Interval is the tick cadence. 0 disables the driver
 	// entirely (Run returns immediately). A negative value is
@@ -135,8 +140,8 @@ type AntiEntropyConfig struct {
 
 // AntiEntropy is the periodic convergence driver. Construct with
 // NewAntiEntropy and start with Run(ctx). Run blocks until ctx is
-// cancelled (or returns immediately when Peers is empty or Interval
-// is 0), so it is meant to run alongside the Connect listener and
+// cancelled (or returns immediately when both Peers and Source are empty, or
+// Interval is 0), so it is meant to run alongside the Connect listener and
 // pump in an errgroup.
 type AntiEntropy struct {
 	cfg         AntiEntropyConfig
@@ -176,16 +181,19 @@ func NewAntiEntropy(cfg AntiEntropyConfig, local LocalStateProvider, apply Mutat
 
 // Run starts the periodic tick loop and blocks until ctx is
 // cancelled. Returns nil after all in-flight ticks have completed.
-// A driver with no peers or zero interval is a no-op.
+// A driver with neither peers nor a Source, or with a zero interval, is a
+// no-op.
 func (a *AntiEntropy) Run(ctx context.Context) error {
-	if len(a.cfg.Peers) == 0 || a.cfg.Interval == 0 {
+	if (len(a.cfg.Peers) == 0 && a.cfg.Source == nil) || a.cfg.Interval == 0 {
 		a.cfg.Logger.Info("anti-entropy: disabled",
 			slog.Int("peers", len(a.cfg.Peers)),
+			slog.Bool("dynamic_source", a.cfg.Source != nil),
 			slog.Duration("interval", a.cfg.Interval))
 		return nil
 	}
 	a.cfg.Logger.Info("anti-entropy: starting",
 		slog.Int("peers", len(a.cfg.Peers)),
+		slog.Bool("dynamic_source", a.cfg.Source != nil),
 		slog.Duration("interval", a.cfg.Interval))
 
 	t := time.NewTicker(a.cfg.Interval)
@@ -206,8 +214,18 @@ func (a *AntiEntropy) Run(ctx context.Context) error {
 // anti-entropy is best-effort.
 func (a *AntiEntropy) tickAll(ctx context.Context) {
 	a.cfg.Metrics.OnAntiEntropyCycle()
+	peers := a.cfg.Peers
+	if a.cfg.Source != nil {
+		resolved, err := a.cfg.Source.Resolve(ctx)
+		if err != nil {
+			a.cfg.Logger.Warn("anti-entropy: peer discovery failed", slog.Any("err", err))
+			a.cfg.Metrics.OnAntiEntropyError("discovery", "discovery_failed")
+			return
+		}
+		peers = resolved
+	}
 	var wg sync.WaitGroup
-	for _, addr := range a.cfg.Peers {
+	for _, addr := range peers {
 		wg.Add(1)
 		go func(addr string) {
 			defer wg.Done()

--- a/tests/integration/antientropy_test.go
+++ b/tests/integration/antientropy_test.go
@@ -2,8 +2,10 @@ package integration_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,6 +19,69 @@ import (
 	"github.com/anaregdesign/lantern/server/replication"
 	"github.com/anaregdesign/lantern/server/service"
 )
+
+type mutableAntiEntropyPeerSource struct {
+	mu    sync.RWMutex
+	peers []string
+	err   error
+}
+
+func (s *mutableAntiEntropyPeerSource) Resolve(context.Context) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.err != nil {
+		return nil, s.err
+	}
+	return append([]string(nil), s.peers...), nil
+}
+
+func (s *mutableAntiEntropyPeerSource) set(peers []string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.peers = append([]string(nil), peers...)
+	s.err = err
+}
+
+type antiEntropyMetricRecorder struct {
+	mu              sync.Mutex
+	cycles          int
+	ticks           map[string]int
+	discoveryErrors int
+}
+
+func newAntiEntropyMetricRecorder() *antiEntropyMetricRecorder {
+	return &antiEntropyMetricRecorder{ticks: make(map[string]int)}
+}
+
+func (m *antiEntropyMetricRecorder) OnAntiEntropyCycle() {
+	m.mu.Lock()
+	m.cycles++
+	m.mu.Unlock()
+}
+
+func (m *antiEntropyMetricRecorder) OnAntiEntropyTick(peer string) {
+	m.mu.Lock()
+	m.ticks[peer]++
+	m.mu.Unlock()
+}
+
+func (*antiEntropyMetricRecorder) OnAntiEntropyBehind(string, string, uint64)   {}
+func (*antiEntropyMetricRecorder) OnAntiEntropyCaughtUp(string, string, uint64) {}
+func (m *antiEntropyMetricRecorder) OnAntiEntropyError(peer, reason string) {
+	if peer != "discovery" || reason != "discovery_failed" {
+		return
+	}
+	m.mu.Lock()
+	m.discoveryErrors++
+	m.mu.Unlock()
+}
+func (*antiEntropyMetricRecorder) OnSearchConfig(string, bool) {}
+
+func (m *antiEntropyMetricRecorder) snapshot(peer string) (cycles, ticks, discoveryErrors int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.cycles, m.ticks[peer], m.discoveryErrors
+}
 
 // antiEntropyNode is a deliberately stripped-down variant of pumpNode
 // that wires WithOriginStates on the replication service so PeerStatus
@@ -214,6 +279,85 @@ func TestAntiEntropy_DriverConvergesWithoutPump(t *testing.T) {
 	}
 	if got := waitForSearchConvergence(t, ctx, "ae-current", exactAll, b.raw, c.raw); len(got) != 1 {
 		t.Fatalf("anti-entropy current query = %+v", got)
+	}
+}
+
+// TestAntiEntropy_DynamicPeerSource follows the production DNS-discovery
+// contract over real h2c: membership changes are picked up on later cycles, a
+// transient resolver failure does not stop the driver, and a removed peer is
+// no longer polled.
+func TestAntiEntropy_DynamicPeerSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping dynamic anti-entropy convergence test in short mode")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	b := newAntiEntropyNode(t, hlc.NodeID{0xDB})
+	c := newAntiEntropyNode(t, hlc.NodeID{0xDC})
+	follower := newAntiEntropyNode(t, hlc.NodeID{0xDD})
+	source := &mutableAntiEntropyPeerSource{}
+	source.set([]string{b.url}, nil)
+	metrics := newAntiEntropyMetricRecorder()
+	ae := replication.NewAntiEntropy(replication.AntiEntropyConfig{
+		NodeID:                  follower.nodeID,
+		Source:                  source,
+		Interval:                25 * time.Millisecond,
+		SubscribeTimeout:        2 * time.Second,
+		HTTPClient:              h2cClient(),
+		Metrics:                 metrics,
+		SearchConfigFingerprint: follower.svc.SearchConfigFingerprint(),
+	}, follower.svc, follower.svc, follower.cache)
+	aeCtx, cancelAE := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() { _ = ae.Run(aeCtx); close(done) }()
+	t.Cleanup(func() {
+		cancelAE()
+		<-done
+	})
+
+	if err := b.sdk.PutVertex(ctx, "dynamic-b", "from-b", time.Minute); err != nil {
+		t.Fatalf("b.PutVertex: %v", err)
+	}
+	if !waitForVertex(t, follower.cache, "dynamic-b", 3*time.Second) {
+		t.Fatal("dynamic source never converged the initial peer")
+	}
+
+	cyclesBeforeError, _, _ := metrics.snapshot(b.url)
+	source.set(nil, errors.New("transient DNS failure"))
+	time.Sleep(100 * time.Millisecond)
+	cyclesAfterError, _, discoveryErrors := metrics.snapshot(b.url)
+	if cyclesAfterError <= cyclesBeforeError {
+		t.Fatalf("cycles stalled across discovery error: before=%d after=%d", cyclesBeforeError, cyclesAfterError)
+	}
+	if discoveryErrors == 0 {
+		t.Fatal("discovery failure was not exposed through anti-entropy metrics")
+	}
+
+	source.set([]string{c.url}, nil)
+	if err := c.sdk.PutVertex(ctx, "dynamic-c", "from-c", time.Minute); err != nil {
+		t.Fatalf("c.PutVertex: %v", err)
+	}
+	if !waitForVertex(t, follower.cache, "dynamic-c", 3*time.Second) {
+		t.Fatal("dynamic source never converged the added peer")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		_, cTicks, _ := metrics.snapshot(c.url)
+		if cTicks >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("dynamic source did not poll the replacement peer twice")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	_, bTicks, _ := metrics.snapshot(b.url)
+	time.Sleep(100 * time.Millisecond)
+	_, bTicksLater, _ := metrics.snapshot(b.url)
+	if bTicksLater != bTicks {
+		t.Fatalf("removed peer kept receiving ticks: before=%d after=%d", bTicks, bTicksLater)
 	}
 }
 

--- a/tests/integration/docs_gate_test.go
+++ b/tests/integration/docs_gate_test.go
@@ -404,9 +404,12 @@ func TestGKEDeployRecoveryWorkflow(t *testing.T) {
 		"google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3",
 		"azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5",
 		"helm upgrade --install",
+		"--set metrics.podMonitoring.enabled=true",
+		"--for=condition=ConfigurationCreateSuccess --timeout=2m",
 		"--wait --timeout 10m --debug",
 		"if: failure()",
 		"kubectl describe statefulset",
+		"kubectl get podmonitoring",
 		"kubectl get events",
 		"--all-containers --previous --tail=200",
 	} {
@@ -433,6 +436,13 @@ func TestGKEDeployRecoveryWorkflow(t *testing.T) {
 	}
 	if !regexp.MustCompile(`(?m)^enableServiceLinks:\s+false$`).Match(values) {
 		t.Error("Helm defaults must disable Kubernetes ServiceLinks")
+	}
+	headlessService, err := os.ReadFile(filepath.Join(chartDir, "templates", "service.yaml"))
+	if err != nil {
+		t.Fatalf("read Helm headless Service template: %v", err)
+	}
+	if !regexp.MustCompile(`(?m)^\s*publishNotReadyAddresses:\s+true$`).Match(headlessService) {
+		t.Error("Helm peer-discovery Service must publish bootstrapping pods")
 	}
 	for _, name := range []string{"statefulset.yaml", "admin-deployment.yaml", "mcp-deployment.yaml"} {
 		template, err := os.ReadFile(filepath.Join(chartDir, "templates", name))


### PR DESCRIPTION
## Summary

- enable GKE Managed Service for Prometheus PodMonitoring in the production release workflow and wait for configuration acceptance
- share DNS peer discovery across Pump, AntiEntropy, and readiness so periodic repair and HA gating work in the default Helm topology
- publish bootstrapping pods only through the headless peer Service to avoid cold-start readiness deadlocks
- expose DNS resolution failures through the existing replication dropped metric and update the HA/observability runbooks

## Validation

- gofmt -l: clean
- go test ./...: root plus pb, core, sdks/go, server, and mcp modules
- dart format, dart pub get --enforce-lockfile, dart analyze, dart test
- Flutter example format, pub get, analyze, and test
- helm lint and helm template with PodMonitoring enabled

Closes #1133
Closes #1134