### PR TITLE
fix(deploy): bound GMP ingestion cost

### DIFF
--- a/deploy/helm/lantern/README.md
+++ b/deploy/helm/lantern/README.md
@@ -90,6 +90,37 @@ be disabled via `podDisruptionBudget.enabled=false`.
 See [`values.yaml`](values.yaml) for the full set including probes,
 resources, security context, anti-affinity, and `extraEnv`.
 
+## GMP cost guard
+
+[Managed Service for Prometheus bills primarily by ingested
+samples](https://cloud.google.com/stackdriver/docs/managed-prometheus/cost-controls).
+The default `PodMonitoring.metricRelabeling` therefore keeps the production
+signals used for HA, readiness, backups, capacity/resource health,
+search-index health, validation, subscriptions, and gRPC RED monitoring. It
+drops the high-cardinality Illuminate and detailed search/scan/batch families
+from GMP only; Lantern's local `/metrics` endpoint remains complete for
+short-lived diagnosis or a self-managed Prometheus.
+
+The July 2026 two-pod production sample exposed 14,604 total series. At a
+60-second interval that is an upper bound of 630,892,800 samples per 30-day
+month. The default allowlist retained 425 series on the busier pod, reducing
+the two-pod upper bound to approximately 36.7 million samples per month (about
+94% fewer). Histogram billing can be lower because GMP counts only populated
+buckets, so treat these figures as conservative planning bounds. Re-measure
+after adding labels or metric families.
+
+To ingest the full surface deliberately, override the list:
+
+```shell
+helm upgrade --install lantern deploy/helm/lantern \
+  --set metrics.podMonitoring.enabled=true \
+  --set-json 'metrics.podMonitoring.metricRelabeling=[]'
+```
+
+Increasing `metrics.podMonitoring.interval` reduces sample cost linearly but
+also delays short HA signals. The maintained production profile keeps `60s`
+and controls cost by cardinality instead.
+
 ## Admin UI (`admin.enabled=true`)
 
 The browser-facing admin SPA (`lantern-admin`) ships as part of this

--- a/deploy/helm/lantern/values.yaml
+++ b/deploy/helm/lantern/values.yaml
@@ -107,19 +107,18 @@ metrics:
     interval: 60s
     labels: {}
     # GMP metricRelabeling applied to scraped samples (Prometheus
-    # metric_relabel_configs semantics). The default keeps the signals this
-    # deployment actually consumes — every lantern_* family, the grpc_server_*
-    # RPC RED metrics (rate/errors/latency; emitted lazily on the first unary
-    # call), and a minimal runtime set (scrape up, goroutines, heap-in-use,
-    # RSS, CPU) — and drops the generic go_*/process_*/promhttp_* collectors
-    # that carry no Lantern-specific signal. This is signal curation, not a
-    # major cost lever: lantern_* (its illuminate/scan histograms) is ~95% of
-    # the live series count, so the dropped collectors are only a small slice.
-    # Set to [] to ingest every scraped series.
+    # metric_relabel_configs semantics). GMP bills primarily per ingested
+    # sample, so the default is a production allowlist: HA/readiness, backup,
+    # capacity/resource, search-index health, validation, subscription, and
+    # gRPC RED signals. It intentionally excludes the high-cardinality
+    # lantern_illuminate_*, detailed lantern_search_* histograms, scan, and
+    # batch families; gRPC RED metrics retain request rate/error/latency while
+    # logs provide detailed RCA. The complete /metrics endpoint is unchanged.
+    # Set to [] only when a full scrape is intentional and budgeted.
     metricRelabeling:
       - action: keep
         sourceLabels: [__name__]
-        regex: lantern_.*|grpc_server_.*|up|go_goroutines|go_memstats_heap_inuse_bytes|process_resident_memory_bytes|process_cpu_seconds_total
+        regex: up|go_goroutines|go_memstats_heap_inuse_bytes|process_resident_memory_bytes|process_cpu_seconds_total|grpc_server_.*|lantern_(anti_entropy_.*|auth_rejected_total|backup_.*|build_info|capacity_limit|edge_contrib_deduped_total|edges|get_(edge|vertex)_(hits|misses)_total|gc_duration_seconds_.*|mutation_log_.*|mutationlog_subscriber_dropped_total|origin_states_count|peer_connected|rate_limit_rejected_total|replication_.*|restore_.*|search_calls_total|search_config_.*|search_index_.*|search_rejections_total|snapshot_.*|subscribe_.*|subscription_.*|tombstone_clamp_rejected_total|ttl_expirations_total|validation_rejected_total|vertex_hlc_.*|vertices)
 
 # Replication / peer discovery. See docs/replication.md §9.1.
 replication:

--- a/tests/integration/docs_gate_test.go
+++ b/tests/integration/docs_gate_test.go
@@ -437,6 +437,43 @@ func TestGKEDeployRecoveryWorkflow(t *testing.T) {
 	if !regexp.MustCompile(`(?m)^enableServiceLinks:\s+false$`).Match(values) {
 		t.Error("Helm defaults must disable Kubernetes ServiceLinks")
 	}
+	metricKeep := regexp.MustCompile(`(?m)^\s*regex:\s*(.+)$`).FindSubmatch(values)
+	if len(metricKeep) != 2 {
+		t.Fatal("Helm defaults must define one GMP metric allowlist")
+	}
+	keep, err := regexp.Compile("^(?:" + strings.TrimSpace(string(metricKeep[1])) + ")$")
+	if err != nil {
+		t.Fatalf("compile GMP metric allowlist: %v", err)
+	}
+	for _, metric := range []string{
+		"grpc_server_handling_seconds_bucket",
+		"lantern_anti_entropy_cycles_total",
+		"lantern_anti_entropy_gaps_found_total",
+		"lantern_replication_lag_seq",
+		"lantern_replication_dropped_total",
+		"lantern_search_config_match",
+		"lantern_search_index_healthy",
+		"lantern_snapshot_replayed_total",
+		"lantern_backup_failures_total",
+		"lantern_vertices",
+		"process_resident_memory_bytes",
+	} {
+		if !keep.MatchString(metric) {
+			t.Errorf("GMP metric allowlist drops required signal %q", metric)
+		}
+	}
+	for _, metric := range []string{
+		"lantern_illuminate_calls_total",
+		"lantern_illuminate_duration_seconds_bucket",
+		"lantern_search_duration_seconds_bucket",
+		"lantern_scan_duration_seconds_bucket",
+		"lantern_batch_size_bucket",
+		"go_memstats_mallocs_total",
+	} {
+		if keep.MatchString(metric) {
+			t.Errorf("GMP metric allowlist retains high-volume signal %q", metric)
+		}
+	}
 	headlessService, err := os.ReadFile(filepath.Join(chartDir, "templates", "service.yaml"))
 	if err != nil {
 		t.Fatalf("read Helm headless Service template: %v", err)


### PR DESCRIPTION
## Summary

- replace the broad GMP keep rule with an explicit production allowlist for HA, readiness, backup, resource, search-index, validation, subscription, and gRPC RED signals
- leave the local /metrics surface unchanged while excluding high-cardinality Illuminate and detailed search/scan/batch families from managed ingestion
- add a contract test for required and intentionally dropped metric families
- document the measured cardinality and conservative 30-day sample estimate

## Cost impact

- current full surface: 14,604 series across two production pods, up to 630,892,800 samples per 30-day month at 60-second scraping
- allowlist: 425 series on lantern-0 and 283 on lantern-1, approximately 94% lower upper-bound ingestion
- the 60-second interval remains unchanged so HA signal resolution is preserved

## Validation

- live allowlist evaluation against both production /metrics endpoints
- helm lint and rendered PodMonitoring inspection
- gofmt and go test ./... in root plus pb, core, sdks/go, server, and mcp modules
- Dart SDK format/pub get/analyze/test
- Flutter example format/pub get/analyze/test

Closes #1136