### PR TITLE
fix(deploy): guard slow restores with startup probe

### DIFF
--- a/deploy/helm/lantern/README.md
+++ b/deploy/helm/lantern/README.md
@@ -77,6 +77,7 @@ be disabled via `podDisruptionBudget.enabled=false`.
 | `backup.persistence.size`                   | `1Gi`                  | Per-pod PVC size for dumps.                        |
 | `backup.persistence.existingClaim`          | `""`                   | Set to a pre-provisioned RWX claim for a shared dump volume. |
 | `resources.requests` / `.limits`            | `250m` CPU / `512Mi`   | requests == limits (Autopilot Guaranteed QoS). 250m is the Autopilot min; 512Mi the server floor. |
+| `probes.startup`                            | 60s initial delay, 5s period, 36 failures | Gives restore-on-start about four minutes before restart; liveness/readiness stay disabled until it succeeds. |
 | `metrics.serviceMonitor.enabled`            | `false`                | Requires the prometheus-operator CRD.              |
 | `metrics.podMonitoring.enabled`             | `false`                | GKE Managed Service for Prometheus (GMP). Requires the `monitoring.googleapis.com/v1` PodMonitoring CRD (default on GKE). |
 | `metrics.podMonitoring.interval`            | `60s`                  | GMP scrape interval.                               |

--- a/deploy/helm/lantern/templates/statefulset.yaml
+++ b/deploy/helm/lantern/templates/statefulset.yaml
@@ -145,6 +145,14 @@ spec:
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/helm/lantern/values.yaml
+++ b/deploy/helm/lantern/values.yaml
@@ -173,8 +173,15 @@ backup:
     accessModes: ["ReadWriteOnce"]
     size: 1Gi
 
-# Liveness/readiness probes.
+# Startup/liveness/readiness probes. The metrics listener starts only after a
+# restore-on-start backup has been loaded, so startup gets its own budget and
+# suppresses liveness/readiness until the restore is complete.
 probes:
+  startup:
+    initialDelaySeconds: 60
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 36
   liveness:
     initialDelaySeconds: 10
     periodSeconds: 10

--- a/docs/ha-runbook.md
+++ b/docs/ha-runbook.md
@@ -110,13 +110,14 @@ bootstrapping.
 The chart strips the peer env entirely; you get single-instance
 mode (§2.1) with k8s scheduling and probes intact.
 
-**Probes.** Liveness and readiness both hit the metrics port (9090),
-paths `/healthz` and `/readyz`. The readiness probe is intentionally
-slow (`initialDelaySeconds: 5`, `periodSeconds: 10`,
-`failureThreshold: 6` = ~60 s window) so a freshly-scaled-up pod can
-finish anti-entropy bootstrap without being restarted as "not ready
-fast enough". **Brief 503s on `/readyz` immediately after a scale-up
-are expected**, not a bug.
+**Probes.** Startup, liveness, and readiness all hit the metrics port
+(9090). Startup and liveness use `/healthz`; readiness uses `/readyz`.
+The startup probe waits 60 seconds before its first check, then allows 36
+failures at five-second intervals, giving restore-on-start about four minutes
+before Kubernetes restarts the container. Liveness and readiness do not run
+until startup succeeds. Readiness then checks every five seconds; **brief 503s
+on `/readyz` while anti-entropy establishes the peer baseline are expected**
+and remove the pod from the client Service without restarting it.
 
 **Probe-port gotcha.** Probes are on the metrics port (9090), not the
 Lantern RPC port (6380). The RPC port serves the `grpc.health.v1`

--- a/tests/integration/docs_gate_test.go
+++ b/tests/integration/docs_gate_test.go
@@ -481,6 +481,31 @@ func TestGKEDeployRecoveryWorkflow(t *testing.T) {
 	if !regexp.MustCompile(`(?m)^\s*publishNotReadyAddresses:\s+true$`).Match(headlessService) {
 		t.Error("Helm peer-discovery Service must publish bootstrapping pods")
 	}
+	statefulSet, err := os.ReadFile(filepath.Join(chartDir, "templates", "statefulset.yaml"))
+	if err != nil {
+		t.Fatalf("read Helm StatefulSet template: %v", err)
+	}
+	for _, contract := range []string{
+		"startupProbe:",
+		"initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}",
+		"periodSeconds: {{ .Values.probes.startup.periodSeconds }}",
+		"timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}",
+		"failureThreshold: {{ .Values.probes.startup.failureThreshold }}",
+	} {
+		if !strings.Contains(string(statefulSet), contract) {
+			t.Errorf("Helm StatefulSet is missing startup guard %q", contract)
+		}
+	}
+	for _, contract := range []string{
+		"  startup:",
+		"    initialDelaySeconds: 60",
+		"    periodSeconds: 5",
+		"    failureThreshold: 36",
+	} {
+		if !strings.Contains(string(values), contract) {
+			t.Errorf("Helm defaults are missing startup budget %q", contract)
+		}
+	}
 	for _, name := range []string{"statefulset.yaml", "admin-deployment.yaml", "mcp-deployment.yaml"} {
 		template, err := os.ReadFile(filepath.Join(chartDir, "templates", name))
 		if err != nil {


### PR DESCRIPTION
## Summary

- add a configurable `/healthz` startupProbe before liveness/readiness begin
- give restore-on-start a bounded four-minute startup budget based on the 43-second production restore observed during v0.34.3
- align Helm and HA runbook probe documentation
- enforce the startup guard in the deployment contract test

## Validation

- `helm lint deploy/helm/lantern`
- `helm template lantern deploy/helm/lantern --set metrics.podMonitoring.enabled=true`
- `go test ./...` in root, pb, core, sdks/go, server, and mcp
- Dart format/analyze/test gate
- Flutter example format/analyze/test gate

Closes #1138