### PR TITLE
fix(deploy): bound restore memory below pod limit

### DIFF
--- a/deploy/helm/lantern/README.md
+++ b/deploy/helm/lantern/README.md
@@ -77,6 +77,7 @@ be disabled via `podDisruptionBudget.enabled=false`.
 | `backup.persistence.size`                   | `1Gi`                  | Per-pod PVC size for dumps.                        |
 | `backup.persistence.existingClaim`          | `""`                   | Set to a pre-provisioned RWX claim for a shared dump volume. |
 | `resources.requests` / `.limits`            | `250m` CPU / `512Mi`   | requests == limits (Autopilot Guaranteed QoS). 250m is the Autopilot min; 512Mi the server floor. |
+| `runtime.goMemoryLimit`                     | `384MiB`                | Sets `GOMEMLIMIT` below the 512Mi container limit; override it together with `resources.limits.memory`. |
 | `probes.startup`                            | 60s initial delay, 5s period, 36 failures | Gives restore-on-start about four minutes before restart; liveness/readiness stay disabled until it succeeds. |
 | `metrics.serviceMonitor.enabled`            | `false`                | Requires the prometheus-operator CRD.              |
 | `metrics.podMonitoring.enabled`             | `false`                | GKE Managed Service for Prometheus (GMP). Requires the `monitoring.googleapis.com/v1` PodMonitoring CRD (default on GKE). |
@@ -90,6 +91,15 @@ be disabled via `podDisruptionBudget.enabled=false`.
 
 See [`values.yaml`](values.yaml) for the full set including probes,
 resources, security context, anti-affinity, and `extraEnv`.
+
+`runtime.goMemoryLimit` is a Go runtime soft limit, not a Kubernetes resource
+request. Keeping it below `resources.limits.memory` makes GC react to transient
+backup-restore and replication-catch-up allocations before the kernel OOM
+killer acts, while preserving headroom for thread stacks and non-Go memory.
+The default keeps the Autopilot request at 512Mi, so it adds no recurring
+compute cost. When sizing a larger graph, change both values deliberately;
+set `runtime.goMemoryLimit: ""` only when another runtime memory controller is
+in place.
 
 ## GMP cost guard
 

--- a/deploy/helm/lantern/templates/statefulset.yaml
+++ b/deploy/helm/lantern/templates/statefulset.yaml
@@ -90,6 +90,10 @@ spec:
               value: {{ .Values.log.level | quote }}
             - name: LANTERN_LOG_FORMAT
               value: {{ .Values.log.format | quote }}
+            {{- with .Values.runtime.goMemoryLimit }}
+            - name: GOMEMLIMIT
+              value: {{ . | quote }}
+            {{- end }}
             - name: LANTERN_DEFAULT_TTL_SECONDS
               value: {{ .Values.cache.defaultTtlSeconds | quote }}
             - name: LANTERN_PEER_DISCOVERY

--- a/deploy/helm/lantern/values.yaml
+++ b/deploy/helm/lantern/values.yaml
@@ -208,6 +208,15 @@ resources:
     cpu: 250m
     memory: 512Mi
 
+# Keep the Go-managed working set below the container limit so transient
+# backup restore + replication catch-up allocations trigger GC instead of a
+# kernel OOM kill. This is intentionally below the 512Mi default limit to
+# leave headroom for the binary, thread stacks, and non-Go memory. Override
+# this together with resources.limits.memory; set "" only when the runtime
+# should have no explicit soft limit.
+runtime:
+  goMemoryLimit: 384MiB
+
 # Extra environment variables (raw env list, appended after the
 # templated ones). Useful for TLS_* / RATE_LIMIT_* / LOG_* tweaks.
 extraEnv: []

--- a/docs/ha-runbook.md
+++ b/docs/ha-runbook.md
@@ -423,8 +423,12 @@ write burst faster than TTL decay fails fast instead:
 - Alert on fill ratio: `lantern_vertices / lantern_capacity_limit{kind="vertex"} > 0.8`
   (same for edges). `lantern_validation_rejected_total{reason="capacity"}`
   counts rejected writes.
-- Keep `GOMEMLIMIT` (set below `resources.limits.memory`) as the second
-  line of defense — the caps bound entry counts, not bytes.
+- Keep `GOMEMLIMIT` below `resources.limits.memory` as the second line of
+  defense — the caps bound entry counts, not bytes. The Helm chart defaults
+  `runtime.goMemoryLimit` to `384MiB` under its `512Mi` container limit so a
+  restore plus replication catch-up triggers Go GC before a kernel OOM kill,
+  without increasing the billed GKE Autopilot request. Override both values
+  together and retain headroom for stacks and non-Go memory.
 
 **Securing the cluster (#850) — decision table:**
 

--- a/tests/integration/docs_gate_test.go
+++ b/tests/integration/docs_gate_test.go
@@ -486,6 +486,9 @@ func TestGKEDeployRecoveryWorkflow(t *testing.T) {
 		t.Fatalf("read Helm StatefulSet template: %v", err)
 	}
 	for _, contract := range []string{
+		"{{- with .Values.runtime.goMemoryLimit }}",
+		"- name: GOMEMLIMIT",
+		"value: {{ . | quote }}",
 		"startupProbe:",
 		"initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}",
 		"periodSeconds: {{ .Values.probes.startup.periodSeconds }}",
@@ -497,6 +500,8 @@ func TestGKEDeployRecoveryWorkflow(t *testing.T) {
 		}
 	}
 	for _, contract := range []string{
+		"runtime:",
+		"  goMemoryLimit: 384MiB",
 		"  startup:",
 		"    initialDelaySeconds: 60",
 		"    periodSeconds: 5",


### PR DESCRIPTION
Closes #1141

## Summary

- render a configurable `GOMEMLIMIT` from `runtime.goMemoryLimit`
- default to `384MiB` under the existing `512Mi` container request/limit
- document GC headroom, coupled overrides, and the zero recurring Autopilot cost change
- pin the Helm memory contract in the GKE integration documentation gate

## Production evidence

The v0.34.4 rollout restored 9,916 vertices / 15,776 edges and then caught up a 422-entry peer gap. `lantern-0` was OOMKilled three times at 512Mi. Once stable, the two pods used only 244–319Mi; direct metrics showed 275MB RSS, 223MB heap in-use, and 28.8MB Search retained bytes on lantern-0. This supports bounding transient Go memory instead of raising the billed Autopilot request.

## Verification

- `helm lint deploy/helm/lantern`
- rendered StatefulSet contains `GOMEMLIMIT: "384MiB"`
- `TestGKEDeployRecoveryWorkflow` passes with `GOMEMLIMIT=384MiB`
- `gofmt -l .` clean
- root + pb + core + sdks/go + server + mcp tests pass; server `go vet ./...` passes
- Dart format/pub/analyze/test/doc/publish dry-run gate passes
- Flutter example format/pub/analyze/test gate passes

A post-merge patch release will verify both production replica restores at zero restarts before this incident is marked done.