### PR TITLE
perf(admin): defer and batch graph rendering

### DIFF
--- a/admin/app/components/cli/CliPage/CliPage.tsx
+++ b/admin/app/components/cli/CliPage/CliPage.tsx
@@ -1,6 +1,14 @@
 import { Button, Spinner } from "@fluentui/react-components";
 import { BookQuestionMark20Regular } from "@fluentui/react-icons";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useSearchParams } from "react-router";
 import {
   CLI_CLICK_AXIS_DEFAULTS,
@@ -15,8 +23,13 @@ import { CliAxisPicker } from "~/components/cli/CliAxisPicker/CliAxisPicker";
 import { CliCommandReference } from "~/components/cli/CliCommandReference/CliCommandReference";
 import { JsonView } from "~/components/cli/JsonView/JsonView";
 import { TraversalResultCompanion } from "~/components/cli/TraversalResultCompanion/TraversalResultCompanion";
-import { IlluminateCanvas } from "~/components/illuminate/IlluminateCanvas/IlluminateCanvas";
 import styles from "./CliPage.module.css";
+
+const IlluminateCanvas = lazy(async () => {
+  const module =
+    await import("~/components/illuminate/IlluminateCanvas/IlluminateCanvas");
+  return { default: module.IlluminateCanvas };
+});
 
 /**
  * The /cli admin route. A Fluent UI command-line panel shared with the
@@ -29,6 +42,7 @@ import styles from "./CliPage.module.css";
  */
 export function CliPage() {
   const cli = useCli();
+  const { enqueueScript, runRaw } = cli;
   const [searchParams] = useSearchParams();
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -70,10 +84,10 @@ export function CliPage() {
   // the controller's identity changes between renders.
   const seedParam = searchParams.get("seed") ?? "";
   const seedHandoffRef = useRef<string | null>(null);
-  const runRawRef = useRef(cli.runRaw);
+  const runRawRef = useRef(runRaw);
   useEffect(() => {
-    runRawRef.current = cli.runRaw;
-  }, [cli.runRaw]);
+    runRawRef.current = runRaw;
+  }, [runRaw]);
   useEffect(() => {
     // URLSearchParams has already decoded this value exactly once. Decoding
     // again corrupts literal percent escapes in valid vertex keys, e.g.
@@ -109,9 +123,9 @@ export function CliPage() {
       const text = e.clipboardData.getData("text");
       if (!text.includes("\n")) return;
       e.preventDefault();
-      cli.enqueueScript(text.split("\n"));
+      enqueueScript(text.split("\n"));
     },
-    [cli],
+    [enqueueScript],
   );
 
   // Click-to-illuminate (#439, #464). Writes the picker-formatted
@@ -124,9 +138,9 @@ export function CliPage() {
   const onNodeClick = useCallback(
     (key: string) => {
       if (!axisPickerCommandValidRef.current) return;
-      cli.runRaw(formatFamilyClick(key, axisPicker.axes));
+      runRaw(formatFamilyClick(key, axisPicker.axes));
     },
-    [cli, axisPicker.axes],
+    [runRaw, axisPicker.axes],
   );
 
   const onKeyDown = useCallback(
@@ -376,20 +390,22 @@ export function CliPage() {
               </span>
             </div>
             <div className={styles.canvasBody}>
-              <IlluminateCanvas
-                nodes={cli.latestGraph.view.nodes}
-                edges={cli.latestGraph.view.edges}
-                latestExpansionOrigin={
-                  cli.latestGraph.view.latestExpansionOrigin
-                }
-                latestResultVertexKeys={
-                  cli.latestGraph.view.latestResultVertexKeys
-                }
-                latestResultEdgeIds={cli.latestGraph.view.latestResultEdgeIds}
-                onNodeClick={onNodeClick}
-                isBusy={cli.busy}
-                fill
-              />
+              <Suspense fallback={<Spinner label="Loading graph renderer" />}>
+                <IlluminateCanvas
+                  nodes={cli.latestGraph.view.nodes}
+                  edges={cli.latestGraph.view.edges}
+                  latestExpansionOrigin={
+                    cli.latestGraph.view.latestExpansionOrigin
+                  }
+                  latestResultVertexKeys={
+                    cli.latestGraph.view.latestResultVertexKeys
+                  }
+                  latestResultEdgeIds={cli.latestGraph.view.latestResultEdgeIds}
+                  onNodeClick={onNodeClick}
+                  isBusy={cli.busy}
+                  fill
+                />
+              </Suspense>
             </div>
             <TraversalResultCompanion
               graph={cli.latestGraph}

--- a/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
+++ b/admin/app/components/illuminate/IlluminateCanvas/IlluminateCanvas.tsx
@@ -23,6 +23,7 @@ import {
   diffRenderSets,
 } from "~/lib/client/usecase/illuminate/reconcile";
 import {
+  COLD_LAYOUT_FRAME_BUDGET_MS,
   FORCE_ALPHA,
   FORCE_ALPHA_COLD,
   type ForceLink,
@@ -220,7 +221,7 @@ export function IlluminateCanvas({
   /**
    * Snapshot of the node IDs the graph held at the end of the previous
    * reconcile. Diffing against the next reconcile's IDs tells us whether
-   * this is a cold mount (empty → populated, full synchronous layout),
+   * this is a cold mount (empty → populated, bounded batched layout),
    * an incremental expansion (animated easing, #483), or a no-op
    * structural delta (just re-apply the hide filter).
    */
@@ -332,6 +333,30 @@ export function IlluminateCanvas({
     // ramp itself, plus its larger size and pinned position (#500).
     (node: { hopDistance: number }) => colorForHop(node.hopDistance, palette),
     [palette],
+  );
+  const renderTargets = useMemo(
+    () =>
+      selectRenderTargets({
+        nodes,
+        edges,
+        latestResultVertexKeys,
+        latestResultEdgeIds,
+      }),
+    [nodes, edges, latestResultVertexKeys, latestResultEdgeIds],
+  );
+  const hasExpiringElements = useMemo(
+    () =>
+      nodes.some(
+        (node) =>
+          renderTargets.nodeIds.has(node.id) &&
+          node.vertex.expiration !== undefined,
+      ) ||
+      edges.some(
+        (edge) =>
+          renderTargets.edgeIds.has(edge.id) &&
+          edge.edge.expiration !== undefined,
+      ),
+    [nodes, edges, renderTargets],
   );
 
   // #483 continuous d3-force layout lifecycle — the live simulation
@@ -1274,6 +1299,7 @@ export function IlluminateCanvas({
   // aggregate. The warning-window red tint sweeps over 60 s so it
   // remains visually obvious without a higher refresh rate.
   useEffect(() => {
+    if (!hasExpiringElements) return;
     let intervalId: ReturnType<typeof setInterval> | null = null;
     const sigma = sigmaRef.current;
     const tick = () => {
@@ -1313,7 +1339,7 @@ export function IlluminateCanvas({
       stop();
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, []);
+  }, [hasExpiringElements]);
   // === end #459 ==========================================================
 
   // Reconcile the graph with the latest view model. The canvas renders
@@ -1331,12 +1357,7 @@ export function IlluminateCanvas({
     // membership rule (latest-result-or-full-accumulator fallback) is
     // owned by the pure `selectRenderTargets` selector so the reconcile
     // diff and the hop legend can never disagree about what's on screen.
-    const { nodeIds: nextNodeIds, edgeIds: nextEdgeIds } = selectRenderTargets({
-      nodes,
-      edges,
-      latestResultVertexKeys,
-      latestResultEdgeIds,
-    });
+    const { nodeIds: nextNodeIds, edgeIds: nextEdgeIds } = renderTargets;
 
     // Per-reconcile diff used to choose the layout regime below (#483).
     // We compute it BEFORE mutating the graph so the counts reflect the
@@ -1500,14 +1521,14 @@ export function IlluminateCanvas({
       });
     }
 
-    // Cold (or full reseed: no survivors) settles synchronously so the
-    // first paint is already a sensible layout. An incremental expansion
-    // refreshes ONCE at t=0 (survivors render at their EXACT prior
-    // position — no snap) and then eases on rAF. A pure attribute or
-    // weight change just refreshes and leaves any running animation
-    // alone. The decision is pure (#495 batch 3): `decideLayoutRegime`
-    // owns the cold/incremental/static branch; the component maps the
-    // chosen regime to the heat constant + the imperative sim calls.
+    // Cold (or full reseed: no survivors) paints its seeded positions and
+    // settles in bounded rAF batches so large graphs cannot monopolize the
+    // main thread. An incremental expansion refreshes ONCE at t=0 (survivors
+    // render at their EXACT prior position — no snap) and then eases one tick
+    // per rAF. A pure attribute or weight change just refreshes and leaves any
+    // running animation alone. The decision is pure (#495 batch 3):
+    // `decideLayoutRegime` owns the cold/incremental/static branch; the
+    // component maps the regime to heat + scheduling policy.
     const regime = decideLayoutRegime({
       nextNodeCount: nextNodeIds.size,
       forceNodeCount: forceNodes.length,
@@ -1517,7 +1538,8 @@ export function IlluminateCanvas({
     });
     if (regime === "cold") {
       beginLayout(forceNodes, forceLinks, FORCE_ALPHA_COLD);
-      settleLayout();
+      sigma?.refresh();
+      startLayoutLoop(COLD_LAYOUT_FRAME_BUDGET_MS);
     } else if (regime === "incremental") {
       beginLayout(forceNodes, forceLinks, FORCE_ALPHA);
       // Paint survivors at their exact prior position before the first
@@ -1539,10 +1561,9 @@ export function IlluminateCanvas({
     // (x:0.5, y:0.5, ratio:1); with sigma's autoRescale + autoCenter that
     // frames the whole rendered graph. Gated on the structural regimes +
     // a non-empty result so a TTL tick, theme flip, or hover ("static",
-    // or an empty Clear) never yanks the viewport. For `cold` the layout
-    // has already settled synchronously; for `incremental` autoRescale
-    // re-normalises every eased frame, so resetting to the default still
-    // frames the whole graph as it relaxes.
+    // or an empty Clear) never yanks the viewport. For both `cold` and
+    // `incremental`, autoRescale re-normalises every eased frame, so resetting
+    // to the default still frames the whole graph as it relaxes.
     if (
       (regime === "cold" || regime === "incremental") &&
       forceNodes.length > 0
@@ -1557,12 +1578,10 @@ export function IlluminateCanvas({
     nodes,
     edges,
     latestExpansionOrigin,
-    latestResultVertexKeys,
-    latestResultEdgeIds,
+    renderTargets,
     palette,
     pickFill,
     beginLayout,
-    settleLayout,
     startLayoutLoop,
     stopLayout,
   ]);
@@ -1602,16 +1621,10 @@ export function IlluminateCanvas({
           color: palette.hopUnreachable,
         },
       };
-    const { nodeIds } = selectRenderTargets({
-      nodes,
-      edges,
-      latestResultVertexKeys,
-      latestResultEdgeIds,
-    });
-    return selectHopBucketCounts(nodes, nodeIds)
+    return selectHopBucketCounts(nodes, renderTargets.nodeIds)
       .filter((b) => b.count > 0)
       .map((b) => ({ ...b, ...presentation[b.key] }));
-  }, [nodes, edges, palette, latestResultVertexKeys, latestResultEdgeIds]);
+  }, [nodes, palette, renderTargets]);
 
   return (
     <div className={wrapperClass} data-testid="illuminate-canvas">

--- a/admin/app/lib/client/usecase/illuminate/force-layout.test.ts
+++ b/admin/app/lib/client/usecase/illuminate/force-layout.test.ts
@@ -6,6 +6,7 @@ import {
   FORCE_COLLIDE_PADDING,
   collideRadius,
   createForceSimulation,
+  tickSimulationFrame,
   type ForceLink,
   type ForceNode,
 } from "./force-layout";
@@ -138,5 +139,32 @@ describe("createForceSimulation", () => {
     };
     // ...and only the fully-resolvable link survives.
     expect(linkForce.links()).toHaveLength(1);
+  });
+});
+
+describe("tickSimulationFrame", () => {
+  test("advances exactly one tick when no batch budget is requested", () => {
+    const nodes: ForceNode[] = [
+      { id: "a", size: 4, x: 0, y: 0 },
+      { id: "b", size: 4, x: 10, y: 0 },
+    ];
+    const simulation = createForceSimulation(nodes, []);
+    const before = simulation.alpha();
+
+    expect(tickSimulationFrame(simulation, 0, () => 0)).toBe(1);
+    expect(simulation.alpha()).toBeLessThan(before);
+  });
+
+  test("yields after consuming the cold-layout frame budget", () => {
+    const nodes: ForceNode[] = [
+      { id: "a", size: 4, x: 0, y: 0 },
+      { id: "b", size: 4, x: 10, y: 0 },
+    ];
+    const simulation = createForceSimulation(nodes, []);
+    const samples = [0, 1, 4];
+    const now = () => samples.shift() ?? 4;
+
+    expect(tickSimulationFrame(simulation, 4, now)).toBe(2);
+    expect(simulation.alpha()).toBeGreaterThan(FORCE_ALPHA_MIN);
   });
 });

--- a/admin/app/lib/client/usecase/illuminate/force-layout.ts
+++ b/admin/app/lib/client/usecase/illuminate/force-layout.ts
@@ -12,11 +12,10 @@
  *      fully recomputed or skipped.
  *
  * #483 replaces FA2 with a continuous, velocity-Verlet d3-force
- * simulation that the component drives one `tick()` at a time inside a
- * `requestAnimationFrame` loop. The same engine is used for the cold
- * start (run synchronously to completion) and for incremental
- * expansions (animated), so the whole canvas lives in ONE coordinate
- * system and never rescales between the two paths.
+ * simulation that the component drives inside a `requestAnimationFrame`
+ * loop. The same engine is used for cold starts (bounded batches per frame)
+ * and incremental expansions (one tick per frame), so the whole canvas lives
+ * in ONE coordinate system and never rescales between the two paths.
  *
  * This module is deliberately free of React, sigma, and graphology so it
  * stays trivially unit-testable: it owns the force *recipe* and the
@@ -101,10 +100,16 @@ export const FORCE_CENTER_STRENGTH = 0.03;
 export const FORCE_ALPHA = 0.5;
 /**
  * Initial alpha for a *cold* start (empty → populated). Full heat so a
- * from-scratch layout reaches a clean equilibrium; the cold pass runs
- * synchronously so the user never sees the warm-up.
+ * from-scratch layout reaches a clean equilibrium; the cold pass advances in
+ * bounded animation-frame batches so it cannot become one long task.
  */
 export const FORCE_ALPHA_COLD = 1;
+/**
+ * Maximum main-thread time spent advancing a cold layout in one animation
+ * frame. One force tick cannot be preempted, but subsequent ticks yield once
+ * this budget is consumed so large graphs never settle in one long task.
+ */
+export const COLD_LAYOUT_FRAME_BUDGET_MS = 8;
 /**
  * Per-tick cooling factor. `alpha *= (1 - decay)` each tick, so the
  * simulation reaches {@link FORCE_ALPHA_MIN} in a bounded number of
@@ -222,8 +227,33 @@ export function createForceSimulation(
     .alphaMin(FORCE_ALPHA_MIN)
     .alpha(options.alpha ?? FORCE_ALPHA);
 
-  // We tick manually from a rAF loop (or synchronously for cold start);
-  // stop d3's built-in timer so nothing runs until we ask.
+  // We tick manually from the controller's rAF loop (batched for cold
+  // starts); stop d3's internal timer so nothing runs until we ask.
   simulation.stop();
   return simulation;
+}
+
+/**
+ * Advance a simulation for one animation frame. A zero budget preserves the
+ * incremental-layout contract of exactly one tick per frame; a positive
+ * budget lets cold starts batch cheap ticks while yielding before the next
+ * frame once the budget is consumed.
+ */
+export function tickSimulationFrame(
+  simulation: Simulation<ForceNode, ForceLink>,
+  frameBudgetMs: number,
+  now: () => number = () => performance.now(),
+): number {
+  const budget = Math.max(0, frameBudgetMs);
+  const startedAt = now();
+  let ticks = 0;
+  do {
+    simulation.tick();
+    ticks += 1;
+  } while (
+    budget > 0 &&
+    simulation.alpha() > FORCE_ALPHA_MIN &&
+    now() - startedAt < budget
+  );
+  return ticks;
 }

--- a/admin/app/lib/client/usecase/illuminate/reconcile.ts
+++ b/admin/app/lib/client/usecase/illuminate/reconcile.ts
@@ -77,8 +77,8 @@ export function diffRenderSets(
  * Which d3-force layout regime a reconcile should run (#483):
  *
  * - `"cold"`: empty → populated, or a full reseed with NO survivors. The
- *   component settles the simulation synchronously so the first paint is
- *   already a clean layout (full heat, `FORCE_ALPHA_COLD`).
+ *   component starts at full heat (`FORCE_ALPHA_COLD`) and settles in bounded
+ *   animation-frame batches so large graphs do not create one long task.
  * - `"incremental"`: at least one survivor carried over AND something
  *   structural changed (a node was added/dropped, or the edge set changed
  *   — #500). The component eases the new frame in on rAF (`FORCE_ALPHA`),

--- a/admin/app/lib/client/usecase/illuminate/use-illuminate-canvas.ts
+++ b/admin/app/lib/client/usecase/illuminate/use-illuminate-canvas.ts
@@ -29,6 +29,7 @@ import {
   FORCE_ALPHA,
   FORCE_ALPHA_MIN,
   createForceSimulation,
+  tickSimulationFrame,
   type ForceLink,
   type ForceNode,
 } from "./force-layout";
@@ -45,6 +46,7 @@ export interface LayoutState {
   forceNodes: ForceNode[];
   nodeById: Map<string, ForceNode>;
   raf: number | null;
+  frameBudgetMs: number;
 }
 
 /**
@@ -68,16 +70,20 @@ export interface IlluminateCanvasController {
   /**
    * Replace the current simulation with a fresh one over the supplied
    * visible nodes/links, seeded from their current positions. Does NOT
-   * start the loop — the caller decides whether to animate (incremental)
-   * or settle synchronously (cold).
+   * start the loop — the caller chooses one-tick incremental animation or
+   * bounded cold-start batches.
    */
   beginLayout: (
     forceNodes: ForceNode[],
     forceLinks: ForceLink[],
     alpha: number,
   ) => void;
-  /** Schedule the animation loop unless it is already running or paused. */
-  startLayoutLoop: () => void;
+  /**
+   * Schedule the animation loop unless it is already running or paused.
+   * Passing a budget batches cold-start ticks; omitting it preserves the
+   * current simulation's mode.
+   */
+  startLayoutLoop: (frameBudgetMs?: number) => void;
   /** Cancel any in-flight animation frame and drop the simulation. */
   stopLayout: () => void;
   /** Rebuild + reheat the simulation over the live graph (drag release). */
@@ -158,7 +164,7 @@ export function useIlluminateCanvas({
       layout.raf = null;
       return;
     }
-    layout.simulation.tick();
+    tickSimulationFrame(layout.simulation, layout.frameBudgetMs);
     writeBackLayoutPositions();
     sigmaRef.current?.refresh();
     if (layout.simulation.alpha() <= FORCE_ALPHA_MIN) {
@@ -169,17 +175,24 @@ export function useIlluminateCanvas({
   }, [writeBackLayoutPositions, stopLayout, sigmaRef]);
 
   /** Schedule the animation loop unless it is already running or paused. */
-  const startLayoutLoop = useCallback(() => {
-    const layout = layoutRef.current;
-    if (!layout || layout.raf != null || layoutPausedRef.current) return;
-    layout.raf = requestAnimationFrame(runLayoutFrame);
-  }, [runLayoutFrame]);
+  const startLayoutLoop = useCallback(
+    (frameBudgetMs?: number) => {
+      const layout = layoutRef.current;
+      if (!layout) return;
+      if (frameBudgetMs !== undefined) {
+        layout.frameBudgetMs = Math.max(0, frameBudgetMs);
+      }
+      if (layout.raf != null || layoutPausedRef.current) return;
+      layout.raf = requestAnimationFrame(runLayoutFrame);
+    },
+    [runLayoutFrame],
+  );
 
   /**
    * Replace the current simulation with a fresh one over the supplied
    * visible nodes/links, seeded from their current positions. Does NOT
-   * start the loop — the caller decides whether to animate (incremental)
-   * or settle synchronously (cold).
+   * start the loop — the caller chooses one-tick incremental animation or
+   * bounded cold-start batches.
    */
   const beginLayout = useCallback(
     (forceNodes: ForceNode[], forceLinks: ForceLink[], alpha: number) => {
@@ -189,7 +202,13 @@ export function useIlluminateCanvas({
         alpha,
       });
       const nodeById = new Map(forceNodes.map((n) => [n.id, n] as const));
-      layoutRef.current = { simulation, forceNodes, nodeById, raf: null };
+      layoutRef.current = {
+        simulation,
+        forceNodes,
+        nodeById,
+        raf: null,
+        frameBudgetMs: 0,
+      };
     },
     [],
   );
@@ -265,8 +284,8 @@ export function useIlluminateCanvas({
 
   /**
    * Run the simulation to rest synchronously (bounded by `maxTicks`),
-   * write back, refresh, and drop it. Used for the cold-start layout and
-   * by the e2e to freeze positions before camera assertions.
+   * write back, refresh, and drop it. Kept for the deterministic test bridge
+   * that freezes positions before spacing and camera assertions.
    */
   const settleLayout = useCallback(
     (maxTicks = 500): number => {

--- a/admin/tests/e2e/canvas.spec.ts
+++ b/admin/tests/e2e/canvas.spec.ts
@@ -186,6 +186,27 @@ test.describe("/cli canvas", () => {
     expect(contrastReport.ratio).toBeGreaterThanOrEqual(4.5);
   });
 
+  test("Non-expiring graphs do not schedule periodic renderer refreshes (#1145)", async ({
+    page,
+  }) => {
+    await renderHub(page);
+
+    type Bridge = { tickCount: () => number };
+    await page.waitForFunction(() => {
+      const win = window as Window & { __illuminateCanvas?: Bridge };
+      return !!win.__illuminateCanvas?.tickCount;
+    });
+    const ticks = (): Promise<number> =>
+      page.evaluate(() => {
+        const win = window as Window & { __illuminateCanvas?: Bridge };
+        return win.__illuminateCanvas?.tickCount() ?? -1;
+      });
+
+    const before = await ticks();
+    await page.waitForTimeout(1200);
+    expect(await ticks()).toBe(before);
+  });
+
   // #517 — the operator can independently hide vertex and edge labels.
   // The toggles drive Sigma's renderLabels / renderEdgeLabels settings,
   // surfaced for assertion through the canvas bridge.

--- a/admin/tests/e2e/cli.spec.ts
+++ b/admin/tests/e2e/cli.spec.ts
@@ -310,6 +310,14 @@ test.describe("/cli", () => {
     await input.press("Enter");
     const panel = page.getByTestId("cli-canvas-panel");
     await expect(panel).toBeVisible();
+    await page.waitForFunction(() => {
+      const win = window as Window & {
+        __illuminateCanvas?: {
+          getNodePosition: (key: string) => unknown;
+        };
+      };
+      return win.__illuminateCanvas?.getNodePosition("cli:quoted key") != null;
+    });
 
     const clicked = await page.evaluate(() => {
       const win = window as Window & {


### PR DESCRIPTION
## Summary

- lazy-load the Sigma renderer only after graph results exist
- distribute cold-start simulation across animation frames with an 8 ms work budget
- reuse render-target membership and skip the 1 Hz refresh loop when no visible item can expire
- add regression coverage for bounded simulation, idle refresh gating, and lazy-canvas readiness

## Performance

- initial `/cli` JavaScript: 289.98 kB / 78.58 kB gzip → 94.82 kB / 28.60 kB gzip
- deferred renderer chunk: 198.91 kB / 51.83 kB gzip
- 2,000-node cold layout: one 727.3 ms task → 59 animation-frame batches; largest measured force batch 16.2 ms

Closes #1145