### PR TITLE
refactor(sdks/go): restore pb-only Subscribe boundary

### DIFF
--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -207,6 +207,10 @@ A few SDK-only types remain and are intentional, not redundant:
   (`map[string]*Vertex`, `map[string]map[string]float32`) that is more
   convenient for client-side traversal than `pb.Graph`'s flat slice shape.
   This is a deliberate shape transformation, not a duplicate data definition.
+- **`ChangeOrigin` / `ChangeCursor`** — comparable SDK-local cursor keys for
+  Subscribe's fixed 16-byte mutation origins. `ChangeEvent` remains a true
+  alias of the generated `pb.Mutation`; the SDK therefore stays `pb`-only
+  without creating a parallel mutation model or importing `core/hlc`.
 
 See [issue #106](https://github.com/anaregdesign/lantern/issues/106) for the
 design discussion.
@@ -224,6 +228,12 @@ design discussion.
 | Replication | `Subscribe` (server-stream iter.Seq2) | — |
 | Status | `Ping`, `GetServerStatus`, `GetReplicationStatus` | — |
 | Backup | — | `Backup` / `Restore` |
+
+`Subscribe` accepts a `ChangeCursor` whose values are the next sequence
+expected per origin and yields `*ChangeEvent` mutations directly. Use
+`ChangeOriginFromBytes(event.GetOrigin())` to obtain the comparable cursor key;
+`ChangeOrigin.String()` returns the canonical 32-character hex form used on
+the wire and in diagnostics.
 
 `AddEdge` is **additive** (multiple calls add weight, each contribution
 carries its own TTL); `PutEdge` is **idempotent replace** (single weight,

--- a/sdks/go/doc.go
+++ b/sdks/go/doc.go
@@ -99,6 +99,7 @@
 //   - Reduction    = pb.Reduction    (see client.go)
 //   - Objective    = pb.Objective    (see client.go)
 //   - Weighting    = pb.Weighting    (see client.go)
+//   - ChangeEvent  = pb.Mutation     (see subscribe.go)
 //
 // Because these are true aliases (declared with `type X = pb.X`, not
 // `type X pb.X`), client.Vertex and pb.Vertex are the same type and
@@ -129,6 +130,11 @@
 //     client-side traversal than pb.Graph's flat slice shape. This is
 //     a deliberate shape transformation, not a duplicate data
 //     definition.
+//
+//   - ChangeOrigin / ChangeCursor
+//     Comparable SDK cursor keys for the wire's fixed 16-byte mutation
+//     origin. Proto map keys cannot be bytes, and importing core/hlc here
+//     would violate the SDK's pb-only module boundary.
 //
 // See https://github.com/anaregdesign/lantern/issues/106 for the
 // design discussion.

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -4,7 +4,6 @@ go 1.26
 
 require (
 	connectrpc.com/connect v1.20.0
-	github.com/anaregdesign/lantern/core v0.18.1
 	github.com/anaregdesign/lantern/pb v0.12.0
 	golang.org/x/net v0.57.0
 	google.golang.org/protobuf v1.36.11

--- a/sdks/go/go.sum
+++ b/sdks/go/go.sum
@@ -1,7 +1,5 @@
 connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=
 connectrpc.com/connect v1.20.0/go.mod h1:A2ygJrukXwWy32vkCAAHNVguZrqZ+jeZ9rGRnGR4dN4=
-github.com/anaregdesign/lantern/core v0.18.1 h1:Y5SUtX5MAQyHMgZewJF2WiAxdXmIwOnYiFxFO7NZVuA=
-github.com/anaregdesign/lantern/core v0.18.1/go.mod h1:TjajZVWzKxo8eKAOTCKMEX/DalGmLSY4nFd4Lblf8II=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=

--- a/sdks/go/module_boundary_gate_test.go
+++ b/sdks/go/module_boundary_gate_test.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestModuleBoundaryGate(t *testing.T) {
+	const modulePrefix = "github.com/anaregdesign/lantern/"
+	forbidden := []string{modulePrefix + "core", modulePrefix + "server"}
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".go" {
+			continue
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), entry.Name(), nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", entry.Name(), err)
+		}
+		for _, spec := range file.Imports {
+			path, err := strconv.Unquote(spec.Path.Value)
+			if err != nil {
+				t.Fatalf("unquote import in %s: %v", entry.Name(), err)
+			}
+			for _, prefix := range forbidden {
+				if path == prefix || strings.HasPrefix(path, prefix+"/") {
+					t.Errorf("%s imports forbidden Lantern module %q", entry.Name(), path)
+				}
+			}
+		}
+	}
+
+	goMod, err := os.ReadFile("go.mod")
+	if err != nil {
+		t.Fatalf("read go.mod: %v", err)
+	}
+	for _, module := range forbidden {
+		if strings.Contains(string(goMod), module) {
+			t.Errorf("go.mod references forbidden Lantern module %q", module)
+		}
+	}
+}

--- a/sdks/go/subscribe.go
+++ b/sdks/go/subscribe.go
@@ -10,19 +10,65 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"iter"
 
 	"connectrpc.com/connect"
 
-	"github.com/anaregdesign/lantern/core/hlc"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
 	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
 )
 
+// ChangeOriginSize is the fixed byte width of every replication origin.
+const ChangeOriginSize = 16
+
+// ErrInvalidChangeOrigin reports a malformed replication origin.
+var ErrInvalidChangeOrigin = errors.New("invalid change origin")
+
+// ErrInvalidChangeEvent reports a Subscribe frame without a mutation.
+var ErrInvalidChangeEvent = errors.New("invalid change event")
+
+// ChangeOrigin identifies the node that originally accepted a mutation.
+// It is deliberately SDK-local: the Go client depends on pb only and does
+// not expose core/hlc types across its public boundary.
+type ChangeOrigin [ChangeOriginSize]byte
+
+// ChangeCursor stores the next sequence number expected from each origin.
+// A nil or empty cursor asks Subscribe for every retained mutation.
+type ChangeCursor map[ChangeOrigin]uint64
+
+// ChangeEvent is the generated mutation value delivered by Subscribe. It is
+// a true alias rather than a parallel SDK model.
+type ChangeEvent = pb.Mutation
+
+// ChangeOriginFromBytes validates and copies a wire mutation origin into the
+// comparable SDK cursor key type.
+func ChangeOriginFromBytes(origin []byte) (ChangeOrigin, error) {
+	if len(origin) != ChangeOriginSize {
+		return ChangeOrigin{}, fmt.Errorf("%w: must be %d bytes, got %d", ErrInvalidChangeOrigin, ChangeOriginSize, len(origin))
+	}
+	var result ChangeOrigin
+	copy(result[:], origin)
+	return result, nil
+}
+
+// ParseChangeOrigin decodes the 32-character lowercase hexadecimal form used
+// by SubscribeRequest map keys and replication diagnostics.
+func ParseChangeOrigin(origin string) (ChangeOrigin, error) {
+	decoded, err := hex.DecodeString(origin)
+	if err != nil {
+		return ChangeOrigin{}, fmt.Errorf("%w: decode hex: %v", ErrInvalidChangeOrigin, err)
+	}
+	return ChangeOriginFromBytes(decoded)
+}
+
+// String returns the canonical lowercase hexadecimal representation.
+func (o ChangeOrigin) String() string { return hex.EncodeToString(o[:]) }
+
 // Subscribe opens a server-stream against the replication service and
-// returns an iter.Seq2 yielding successive *SubscribeResponse frames
-// until the stream closes.
+// returns an iter.Seq2 yielding successive mutation events until the stream
+// closes.
 //
 // Under the leaderless Subscribe contract (#415), the cluster's full
 // mutation stream is visible from every replica; cursor selects the
@@ -30,21 +76,20 @@ import (
 // asks the server for every entry it still retains, suitable for a
 // new consumer.
 //
-// Keys in the cursor are HLC NodeIDs of every origin the caller has
-// already observed; values are the next seq the caller expects from
-// that origin. Origins absent from the cursor are delivered from the
-// oldest retained entry — see pb.SubscribeRequest for the full
-// semantics.
+// Keys in the cursor are opaque 16-byte origins the caller has already
+// observed; values are the next seq the caller expects from that origin.
+// Origins absent from the cursor are delivered from the oldest retained
+// entry — see pb.SubscribeRequest for the full semantics.
 //
 // Stop conditions: clean EOF, any server error, the supplied ctx being
 // canceled, or the consumer returning false from yield. The underlying
 // *connect.ServerStreamForClient is always closed before iteration
 // ends.
-func (l *Lantern) Subscribe(ctx context.Context, cursor map[hlc.NodeID]uint64) iter.Seq2[*pb.SubscribeResponse, error] {
-	return func(yield func(*pb.SubscribeResponse, error) bool) {
+func (l *Lantern) Subscribe(ctx context.Context, cursor ChangeCursor) iter.Seq2[*ChangeEvent, error] {
+	return func(yield func(*ChangeEvent, error) bool) {
 		wire := make(map[string]uint64, len(cursor))
 		for id, seq := range cursor {
-			wire[hex.EncodeToString(id[:])] = seq
+			wire[id.String()] = seq
 		}
 		rc := graphv1connect.NewLanternReplicationServiceClient(l.httpClient, l.baseURL)
 		stream, err := rc.Subscribe(ctx, connect.NewRequest(&pb.SubscribeRequest{FromSeqPerOrigin: wire}))
@@ -54,7 +99,12 @@ func (l *Lantern) Subscribe(ctx context.Context, cursor map[hlc.NodeID]uint64) i
 		}
 		defer func() { _ = stream.Close() }()
 		for stream.Receive() {
-			if !yield(stream.Msg(), nil) {
+			mutation := stream.Msg().GetMutation()
+			if mutation == nil {
+				yield(nil, fmt.Errorf("%w: subscribe response missing mutation", ErrInvalidChangeEvent))
+				return
+			}
+			if !yield(mutation, nil) {
 				return
 			}
 		}

--- a/sdks/go/subscribe_test.go
+++ b/sdks/go/subscribe_test.go
@@ -1,0 +1,133 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/proto"
+
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	"github.com/anaregdesign/lantern/pb/graph/v1/graphv1connect"
+)
+
+type subscribeTestHandler struct {
+	graphv1connect.UnimplementedLanternReplicationServiceHandler
+	request   *pb.SubscribeRequest
+	responses []*pb.SubscribeResponse
+}
+
+func (h *subscribeTestHandler) Subscribe(
+	_ context.Context,
+	req *connect.Request[pb.SubscribeRequest],
+	stream *connect.ServerStream[pb.SubscribeResponse],
+) error {
+	h.request = proto.Clone(req.Msg).(*pb.SubscribeRequest)
+	for _, response := range h.responses {
+		if err := stream.Send(response); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func newSubscribeTestClient(t *testing.T, handler *subscribeTestHandler) *Lantern {
+	t.Helper()
+	mux := http.NewServeMux()
+	path, connectHandler := graphv1connect.NewLanternReplicationServiceHandler(handler)
+	mux.Handle(path, connectHandler)
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	client, err := NewLantern(server.URL, WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewLantern: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func TestChangeOrigin(t *testing.T) {
+	wire := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f}
+	origin, err := ChangeOriginFromBytes(wire)
+	if err != nil {
+		t.Fatalf("ChangeOriginFromBytes: %v", err)
+	}
+	const encoded = "000102030405060708090a0b0c0d0e0f"
+	if got := origin.String(); got != encoded {
+		t.Fatalf("String() = %q, want %q", got, encoded)
+	}
+
+	parsed, err := ParseChangeOrigin(encoded)
+	if err != nil {
+		t.Fatalf("ParseChangeOrigin: %v", err)
+	}
+	if parsed != origin {
+		t.Fatalf("ParseChangeOrigin() = %v, want %v", parsed, origin)
+	}
+
+	wire[0] = 0xff
+	if origin[0] != 0x00 {
+		t.Fatal("ChangeOriginFromBytes must defensively copy its input")
+	}
+	if _, err := ChangeOriginFromBytes([]byte{1, 2, 3}); !errors.Is(err, ErrInvalidChangeOrigin) {
+		t.Fatalf("short origin: want ErrInvalidChangeOrigin, got %v", err)
+	}
+	if _, err := ParseChangeOrigin("not-hex"); !errors.Is(err, ErrInvalidChangeOrigin) {
+		t.Fatalf("invalid hex origin: want ErrInvalidChangeOrigin, got %v", err)
+	}
+}
+
+func TestSubscribe(t *testing.T) {
+	origin := ChangeOrigin{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	want := []*pb.Mutation{
+		{Seq: 42, Origin: origin[:]},
+		{Seq: 43, Origin: origin[:]},
+	}
+	handler := &subscribeTestHandler{responses: []*pb.SubscribeResponse{
+		{Mutation: want[0]},
+		{Mutation: want[1]},
+	}}
+	client := newSubscribeTestClient(t, handler)
+
+	var got []*ChangeEvent
+	for event, err := range client.Subscribe(context.Background(), ChangeCursor{origin: 42}) {
+		if err != nil {
+			t.Fatalf("Subscribe: %v", err)
+		}
+		got = append(got, event)
+	}
+
+	if handler.request == nil {
+		t.Fatal("Subscribe request was not captured")
+	}
+	if seq := handler.request.GetFromSeqPerOrigin()[origin.String()]; seq != 42 {
+		t.Fatalf("cursor sequence = %d, want 42", seq)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("received %d events, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if !proto.Equal(got[i], want[i]) {
+			t.Fatalf("event %d = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestSubscribeRejectsMissingMutation(t *testing.T) {
+	handler := &subscribeTestHandler{responses: []*pb.SubscribeResponse{{}}}
+	client := newSubscribeTestClient(t, handler)
+
+	var gotErr error
+	for _, err := range client.Subscribe(context.Background(), nil) {
+		gotErr = err
+	}
+	if !errors.Is(gotErr, ErrInvalidChangeEvent) {
+		t.Fatalf("missing mutation: want ErrInvalidChangeEvent, got %v", gotErr)
+	}
+}

--- a/tests/integration/subscribe_test.go
+++ b/tests/integration/subscribe_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/anaregdesign/lantern/core/hlc"
 	"github.com/anaregdesign/lantern/core/mutationlog"
 	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+	client "github.com/anaregdesign/lantern/sdks/go"
 	"github.com/anaregdesign/lantern/server/provider"
 	"github.com/anaregdesign/lantern/server/service"
 )
@@ -199,5 +200,76 @@ func TestSubscribe_PerOriginCursor_Skips(t *testing.T) {
 		if g != want[i] {
 			t.Errorf("entry[%d] got %+v want %+v", i, g, want[i])
 		}
+	}
+}
+
+// TestSubscribeSDK_TypedCursorAndGap exercises the public Go SDK facade over
+// the real Connect/h2c handler. It pins both the typed per-origin cursor happy
+// path and the retained-log gap failure contract introduced by #1182.
+func TestSubscribeSDK_TypedCursorAndGap(t *testing.T) {
+	origin := hlc.NodeID{0x31, 0x32, 0x33, 0x34}
+	log := mutationlog.New(mutationlog.Options{Capacity: 8, SubscriberBuffer: 8})
+	t.Cleanup(func() { _ = log.Close() })
+	clock := hlc.New(origin, hlc.Options{})
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+	svc := service.NewLanternService(cache).WithReplication(log, clock, nil)
+	rep := service.NewLanternReplicationService(log, cache, clock)
+	srv := newConnectTestServer(t, svc, rep, nil)
+	sdk := newConnectClientFor(t, srv.url)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for i := 1; i <= 4; i++ {
+		if err := sdk.PutVertex(ctx, "sdk-cursor-"+itoa(i), "v", time.Minute); err != nil {
+			t.Fatalf("PutVertex[%d]: %v", i, err)
+		}
+	}
+
+	sdkOrigin, err := client.ChangeOriginFromBytes(origin[:])
+	if err != nil {
+		t.Fatalf("ChangeOriginFromBytes: %v", err)
+	}
+	var events []*client.ChangeEvent
+	for event, streamErr := range sdk.Subscribe(ctx, client.ChangeCursor{sdkOrigin: 3}) {
+		if streamErr != nil {
+			t.Fatalf("Subscribe(cursor=3): %v", streamErr)
+		}
+		events = append(events, event)
+		if len(events) == 2 {
+			break
+		}
+	}
+	if len(events) != 2 || events[0].GetSeq() != 3 || events[1].GetSeq() != 4 {
+		t.Fatalf("events = %v, want seqs [3 4]", events)
+	}
+	gotOrigin, err := client.ChangeOriginFromBytes(events[0].GetOrigin())
+	if err != nil {
+		t.Fatalf("event origin: %v", err)
+	}
+	if gotOrigin != sdkOrigin {
+		t.Fatalf("event origin = %s, want %s", gotOrigin, sdkOrigin)
+	}
+
+	gapLog := mutationlog.New(mutationlog.Options{Capacity: 2, SubscriberBuffer: 8})
+	t.Cleanup(func() { _ = gapLog.Close() })
+	gapClock := hlc.New(origin, hlc.Options{})
+	gapCache := graphcache.NewGraphCache[string, *pb.Vertex](time.Minute)
+	gapService := service.NewLanternService(gapCache).WithReplication(gapLog, gapClock, nil)
+	gapReplication := service.NewLanternReplicationService(gapLog, gapCache, gapClock)
+	gapServer := newConnectTestServer(t, gapService, gapReplication, nil)
+	gapSDK := newConnectClientFor(t, gapServer.url)
+	for i := 1; i <= 4; i++ {
+		if err := gapSDK.PutVertex(ctx, "sdk-gap-"+itoa(i), "v", time.Minute); err != nil {
+			t.Fatalf("gap PutVertex[%d]: %v", i, err)
+		}
+	}
+
+	var gapErr error
+	for _, streamErr := range gapSDK.Subscribe(ctx, client.ChangeCursor{sdkOrigin: 1}) {
+		gapErr = streamErr
+		break
+	}
+	if !errors.Is(gapErr, client.ErrFailedPrecondition) {
+		t.Fatalf("Subscribe(cursor=1) error = %v, want ErrFailedPrecondition", gapErr)
 	}
 }


### PR DESCRIPTION
## What changed

- replace the Go SDK's public `core/hlc.NodeID` cursor dependency with SDK-local `ChangeOrigin` and `ChangeCursor`
- expose Subscribe mutations directly through the `ChangeEvent = pb.Mutation` alias
- add origin parsing/validation and malformed-frame errors
- remove the Go SDK module's `core` requirement
- enforce the pb-only module boundary with a cross-cutting gate
- cover typed cursor resume and retained-log gap behavior over real Connect/h2c

## Why

The documented module DAG allows `sdks/go` to depend on `pb` only. The existing Subscribe facade imported `core/hlc`, creating a back-edge and making the SDK non-standalone.

## Impact

This is an intentional pre-v1 API cleanup: Subscribe now accepts `ChangeCursor` and yields `*ChangeEvent` mutations instead of raw `*pb.SubscribeResponse` wrappers.

## Validation

- `gofmt` across all tracked Go files
- `go test ./...` in root, `pb`, `core`, `sdks/go`, `server`, and `mcp`
- standalone `GOWORK=off go test ./...` in `sdks/go`
- `go vet ./...` in `server`
- parent/offline Dart format, analyze, test, dartdoc; parent publish dry-run
- Flutter example format, analyze, and test

Closes #1182
