### PR TITLE
build(sdks/dart): make publish archive dependency-closed

### DIFF
--- a/.github/workflows/dart-sdk.yml
+++ b/.github/workflows/dart-sdk.yml
@@ -17,6 +17,7 @@ on:
       - "testdata/search/**"
       - "docs/decisions/0001-dart-mobile-transport.md"
       - "docs/decisions/0002-dart-offline-repository-contract.md"
+      - "CONTRIBUTING.md"
       - ".github/workflows/dart-sdk.yml"
   pull_request:
     paths:
@@ -31,6 +32,7 @@ on:
       - "testdata/search/**"
       - "docs/decisions/0001-dart-mobile-transport.md"
       - "docs/decisions/0002-dart-offline-repository-contract.md"
+      - "CONTRIBUTING.md"
       - ".github/workflows/dart-sdk.yml"
 
 permissions:
@@ -89,6 +91,7 @@ jobs:
                   sdks/dart/* | proto/* | buf.yaml | buf.gen.yaml | generate.go | \
                     docs/decisions/0001-dart-mobile-transport.md | \
                     docs/decisions/0002-dart-offline-repository-contract.md | \
+                    CONTRIBUTING.md | \
                     .github/workflows/dart-sdk.yml)
                     full=true
                     break
@@ -203,17 +206,63 @@ jobs:
             exit 1
           fi
 
-      - name: Validate package shape
+      # `--to-archive` uses Dart Pub's own publish file selection and tarball
+      # builder. Verify that exact artifact outside the repository so a sibling
+      # path cannot make a broken included package look resolvable.
+      - name: Build and verify isolated parent publish archive
         if: needs.changes.outputs.full == 'true'
-        run: dart pub publish --dry-run
+        working-directory: .
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_root="$RUNNER_TEMP/lantern-client-artifact"
+          source_dir="$artifact_root/source"
+          archive="$artifact_root/lantern_client.tar.gz"
+          package_dir="$artifact_root/unpacked/package"
+          isolated_pub_cache="$artifact_root/pub-cache"
+          mkdir -p "$source_dir" "$package_dir" "$isolated_pub_cache"
+
+          git archive HEAD:sdks/dart | tar -x -C "$source_dir"
+          dart pub publish -C "$source_dir" --to-archive="$archive"
+          tar -xzf "$archive" -C "$package_dir"
+
+          mapfile -d '' pubspecs < <(find "$package_dir" -name pubspec.yaml -print0)
+          if [[ "${#pubspecs[@]}" -eq 0 ]]; then
+            echo "::error::parent publish archive contains no pubspec.yaml"
+            exit 1
+          fi
+          if [[ -e "$package_dir/offline" || -e "$package_dir/example/pubspec.yaml" ]]; then
+            echo "::error::parent publish archive contains a repository-only package"
+            exit 1
+          fi
+          if [[ ! -f "$package_dir/example/lantern_client_example.dart" ]]; then
+            echo "::error::parent publish archive lost its standalone online example"
+            exit 1
+          fi
+          if grep -HnE '^[[:space:]]*lantern_client_offline:' "${pubspecs[@]}"; then
+            echo "::error::parent publish archive references lantern_client_offline"
+            exit 1
+          fi
+
+          for pubspec in "${pubspecs[@]}"; do
+            package=$(dirname "$pubspec")
+            (
+              cd "$package"
+              PUB_CACHE="$isolated_pub_cache" dart pub get --no-example
+              PUB_CACHE="$isolated_pub_cache" dart analyze
+            )
+          done
+
+          (
+            cd "$package_dir"
+            PUB_CACHE="$isolated_pub_cache" dart test
+          )
 
       - name: Generate pana quality report
         if: needs.changes.outputs.full == 'true'
         working-directory: .
         run: |
-          package_dir="$RUNNER_TEMP/lantern-client-package"
-          mkdir -p "$package_dir"
-          git archive HEAD:sdks/dart | tar -x -C "$package_dir"
+          package_dir="$RUNNER_TEMP/lantern-client-artifact/unpacked/package"
           dart pub global activate pana 0.23.14
           timeout 15m dart pub global run pana --json "$package_dir" \
             > "$RUNNER_TEMP/lantern-client-pana.json"
@@ -346,24 +395,6 @@ jobs:
             exit 1
           fi
           grep -F 'path source' "$log"
-
-      - name: Prove parent publish archive isolation
-        working-directory: sdks/dart
-        shell: bash
-        run: |
-          set -euo pipefail
-          log="$RUNNER_TEMP/dart-parent-publish.log"
-          dart pub get --enforce-lockfile --no-example
-          dart pub publish --dry-run >"$log" 2>&1
-          if grep -Eq 'offline($|/)' "$log"; then
-            cat "$log"
-            echo "::error::parent lantern_client archive contains the offline package"
-            exit 1
-          fi
-          if dart pub deps --json | grep -F '"lantern_client_offline"'; then
-            echo "::error::parent lantern_client depends on the offline package"
-            exit 1
-          fi
 
       - name: Stop Lantern real-wire server
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ go test ./...                    # root module
   && dart doc --output "$(mktemp -d)" --validate-links \
   && dart pub publish --dry-run)
 (cd sdks/dart/offline && dart format --output=none --set-exit-if-changed \
-  lib test && dart pub get --enforce-lockfile \
+  lib test tool && dart pub get --enforce-lockfile \
   && dart analyze && dart test \
   && dart doc --output "$(mktemp -d)" --validate-links)
 (cd sdks/dart/example && dart format --output=none --set-exit-if-changed \
@@ -126,7 +126,12 @@ Dart, including fresh-process canonical snapshot tests and real-server
 committed-response-loss replay. Its path dependency and `publish_to: none` remain
 intentional until the separate release Issue accepts hosted dependency conversion
 after ADR 0002's physical-device graduation gate; the parent `lantern_client`
-publish archive must continue to exclude `offline/`.
+publish archive must continue to exclude `offline/`. The maintained Flutter app
+under `sdks/dart/example/` is a repository integration fixture because it consumes
+that child by path, so only its standalone online example is included in the parent
+archive. CI uses Dart Pub's own archive builder, unpacks the resulting tarball
+outside the checkout, resolves every included `pubspec.yaml` with an isolated
+cache, then runs analysis, tests, and `pana` against the unpacked artifact.
 
 ## Coverage floor (ratchet)
 
@@ -316,10 +321,10 @@ number rather than force-moving the tag.
   server's `LANTERN_CORS_ALLOWED_ORIGINS` must include the admin origin.
 - `sdks/dart/vX.Y.Z` must match `sdks/dart/pubspec.yaml` version `X.Y.Z` and a
   `CHANGELOG.md` heading `## X.Y.Z`. It triggers `dart-sdk.yml`, which must pass the
-  minimum/current Dart gates, real-wire tests, warning-free docs, publish dry-run,
-  `pana`, and Android/iOS example conformance before publishing `lantern_client` with
-  pub.dev OIDC (`id-token: write`, no token secret). Configure pub.dev automated
-  publishing for repository `anaregdesign/lantern` and tag pattern
+  minimum/current Dart gates, real-wire tests, warning-free docs, isolated publish-
+  archive resolution, `pana`, and Android/iOS example conformance before publishing
+  `lantern_client` with pub.dev OIDC (`id-token: write`, no token secret). Configure
+  pub.dev automated publishing for repository `anaregdesign/lantern` and tag pattern
   `sdks/dart/v{{version}}`. The workflow creates/updates the GitHub Release only after
   pub.dev confirms the version exists; its title is exactly the tag.
 

--- a/sdks/dart/.pubignore
+++ b/sdks/dart/.pubignore
@@ -1,3 +1,8 @@
 .dart_tool/
 build/
+# The maintained Flutter app is a repository integration fixture. Publish only
+# the standalone online example below; every other immediate child (including
+# the nested pubspec and offline path dependency) remains repository-only.
+example/*
+!example/lantern_client_example.dart
 offline/

--- a/sdks/dart/README.md
+++ b/sdks/dart/README.md
@@ -272,8 +272,11 @@ The maintained [Flutter example](https://github.com/anaregdesign/lantern/tree/ma
 demonstrates runtime token refresh,
 secure endpoint configuration, app/screen lifecycle ownership, bounded paging,
 incremental search, traversal, typed failure states, and the physical-device
-smoke checklist. The core SDK has no implicit offline cache or
-background-delivery promise. The accepted
+smoke checklist. The full app is a repository integration fixture rather than
+part of the `lantern_client` publish archive because it also exercises the
+unpublished offline child by path. The archive retains a standalone online
+example while remaining dependency-closed. The core SDK has no implicit offline
+cache or background-delivery promise. The accepted
 [offline Repository and package contract](https://github.com/anaregdesign/lantern/blob/main/docs/decisions/0002-dart-offline-repository-contract.md)
 defines the official opt-in `lantern_client_offline` direction: a
 storage-adapter-driven cache/outbox engine that remains separate from this

--- a/sdks/dart/example/lantern_client_example.dart
+++ b/sdks/dart/example/lantern_client_example.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+
+import 'package:lantern_client/lantern_client.dart';
+
+Future<void> main() async {
+  final client = LanternClient.connect(
+    Uri.parse('https://lantern.example.com'),
+  );
+  try {
+    await client.putVertex(
+      VertexInput(
+        key: 'user:42',
+        value: VertexValue.string('alice'),
+        expiresIn: const Duration(minutes: 30),
+      ),
+    );
+    final vertex = await client.getVertex('user:42');
+    stdout.writeln((vertex.value as StringValue).value);
+  } finally {
+    await client.close();
+  }
+}

--- a/tests/integration/docs_gate_test.go
+++ b/tests/integration/docs_gate_test.go
@@ -178,6 +178,8 @@ func TestDartWorkflowGate(t *testing.T) {
 	for _, contract := range []string{
 		"name: Classify changes",
 		"docs/decisions/0001-dart-mobile-transport.md",
+		"docs/decisions/0002-dart-offline-repository-contract.md",
+		"CONTRIBUTING.md",
 		"name: Generate, analyze, and test",
 		"dart pub get --enforce-lockfile --no-example",
 		"dart analyze lib test",
@@ -186,7 +188,12 @@ func TestDartWorkflowGate(t *testing.T) {
 		"version: 1.71.0",
 		"name: Minimum Dart 3.11",
 		"name: Build API documentation",
-		"dart pub publish --dry-run",
+		"name: Build and verify isolated parent publish archive",
+		`dart pub publish -C "$source_dir" --to-archive="$archive"`,
+		`tar -xzf "$archive" -C "$package_dir"`,
+		`mapfile -d '' pubspecs`,
+		`PUB_CACHE="$isolated_pub_cache" dart pub get --no-example`,
+		`PUB_CACHE="$isolated_pub_cache" dart analyze`,
 		"dart pub global run pana --json",
 		"name: Check Flutter example",
 		"flutter test --no-pub integration_test/mobile_smoke_test.dart -d emulator-5554",
@@ -205,6 +212,28 @@ func TestDartWorkflowGate(t *testing.T) {
 		if !strings.Contains(text, contract) {
 			t.Errorf("Dart SDK workflow is missing scoped-gate contract %q", contract)
 		}
+	}
+
+	pubignore, err := os.ReadFile(filepath.Join(repoRoot, "sdks", "dart", ".pubignore"))
+	if err != nil {
+		t.Fatalf("read parent Dart .pubignore: %v", err)
+	}
+	pubignoreText := "\n" + string(pubignore) + "\n"
+	for _, excluded := range []string{"example/*", "offline/"} {
+		if !strings.Contains(pubignoreText, "\n"+excluded+"\n") {
+			t.Errorf("parent Dart publish archive no longer excludes %q", excluded)
+		}
+	}
+	if !strings.Contains(pubignoreText, "\n!example/lantern_client_example.dart\n") {
+		t.Error("parent Dart publish archive no longer retains its standalone online example")
+	}
+
+	contributing, err := os.ReadFile(filepath.Join(repoRoot, "CONTRIBUTING.md"))
+	if err != nil {
+		t.Fatalf("read CONTRIBUTING.md: %v", err)
+	}
+	if !strings.Contains(string(contributing), "lib test tool && dart pub get --enforce-lockfile") {
+		t.Error("documented offline format gate does not include tool sources")
 	}
 	if strings.Contains(text, "flutter build apk --debug") {
 		t.Error("Dart SDK workflow duplicates the APK build already performed by the Android native smoke")
@@ -237,10 +266,6 @@ func TestDartWorkflowGate(t *testing.T) {
 		last = index
 	}
 
-	contributing, err := os.ReadFile(filepath.Join(repoRoot, "CONTRIBUTING.md"))
-	if err != nil {
-		t.Fatalf("read CONTRIBUTING.md: %v", err)
-	}
 	for _, contract := range []string{
 		"routes backend/search-only changes through the current-Dart unit and real-wire gates",
 		"stable `Gate` job",


### PR DESCRIPTION
## Summary

- build the exact Dart Pub archive and verify it outside the checkout with an isolated package cache
- exclude the repository-only Flutter package and offline child while retaining a standalone online example
- run archive analysis, tests, and pinned pana against the unpacked artifact
- make release-contract inputs and the offline tool formatting contract CI-enforced

## Verification

- full repository pre-push gate across every Go module, parent/offline Dart packages, and Flutter example
- exact archive contains one root `pubspec.yaml`, no nested offline/path package, and the standalone online example
- isolated archive dependency resolution, analysis, and 74 tests pass
- pinned pana remains 140/160 (no example-score regression)
- `TestDartPublishingContractGate` and `TestDartWorkflowGate`

Closes #1181