### PR TITLE
fix(sdks/dart/offline): isolate shared read cancellation

### DIFF
--- a/sdks/dart/CHANGELOG.md
+++ b/sdks/dart/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Expose detachable, fan-out-safe `LanternCancellationToken.listen` lifecycle
+  notifications so companion packages can isolate shared work from individual
+  callers without polling.
+
 ## 0.1.3
 
 - Resolve the package lock without descending into the Flutter example on the

--- a/sdks/dart/lib/src/client.dart
+++ b/sdks/dart/lib/src/client.dart
@@ -74,19 +74,48 @@ final class LanternCancellationToken {
     if (_isCanceled) return;
     _isCanceled = true;
     _reason = reason;
-    for (final listener in _listeners.toList(growable: false)) {
-      listener(reason);
-    }
+    final listeners = _listeners.toList(growable: false);
     _listeners.clear();
+    final failures = <({Object error, StackTrace stackTrace})>[];
+    for (final listener in listeners) {
+      try {
+        listener(reason);
+      } catch (error, stackTrace) {
+        failures.add((error: error, stackTrace: stackTrace));
+      }
+    }
+    final zone = Zone.current;
+    for (final failure in failures) {
+      scheduleMicrotask(
+        () => zone.handleUncaughtError(failure.error, failure.stackTrace),
+      );
+    }
   }
 
-  void Function() _listen(void Function(Object?) listener) {
-    if (_isCanceled) {
-      scheduleMicrotask(() => listener(_reason));
-      return () {};
+  /// Registers [listener] to run once when this token is canceled.
+  ///
+  /// The returned callback detaches the listener and is safe to call more than
+  /// once. When this token is already canceled, delivery is scheduled in a
+  /// microtask so callers can still detach before the callback runs. A listener
+  /// failure is reported asynchronously after every listener has been offered
+  /// the cancellation signal.
+  void Function() listen(void Function(Object?) listener) {
+    var detached = false;
+    void notify(Object? reason) {
+      if (detached) return;
+      listener(reason);
     }
-    _listeners.add(listener);
-    return () => _listeners.remove(listener);
+
+    if (_isCanceled) {
+      scheduleMicrotask(() => notify(_reason));
+    } else {
+      _listeners.add(notify);
+    }
+    return () {
+      if (detached) return;
+      detached = true;
+      _listeners.remove(notify);
+    };
   }
 }
 
@@ -898,7 +927,7 @@ final class _CallSignal implements connect.AbortSignal {
         _timer = Timer(remaining, _expire);
       }
     }
-    _removeCancellationListener = cancellation?._listen(_cancelFromCaller);
+    _removeCancellationListener = cancellation?.listen(_cancelFromCaller);
   }
 
   final Completer<connect.ConnectException> _completer = Completer();

--- a/sdks/dart/lib/src/scan.dart
+++ b/sdks/dart/lib/src/scan.dart
@@ -342,7 +342,7 @@ Stream<Page<T>> _scanPageStream<T>({
 
   controller = StreamController<Page<T>>(
     onListen: () {
-      unlinkCaller = callerCancellation?._listen((reason) {
+      unlinkCaller = callerCancellation?.listen((reason) {
         streamCancellation.cancel(reason ?? 'caller canceled scan');
         // A caller token must also wake a stream paused between page RPCs so
         // the pump can observe cancellation without starting another request.

--- a/sdks/dart/offline/CHANGELOG.md
+++ b/sdks/dart/offline/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Preserve typed cancellation through the online adapter, isolate same-key
+  single-flight waiters, cancel transport only after the final waiter leaves,
+  and close idle watches immediately without missing initial store changes.
+
 ## 0.1.0
 
 - Initial experimental storage-neutral offline Repository core.

--- a/sdks/dart/offline/README.md
+++ b/sdks/dart/offline/README.md
@@ -63,7 +63,11 @@ No stale policy serves a value at or after its Lantern expiration.
 Distinct remote reads, queued reads, active watchers, per-partition watchers,
 and watcher-owning partitions all have explicit bounds. Queued cancellation
 does not consume a remote permit, and lifecycle cancellation closes a watch
-without surfacing a cancellation error as application failure.
+without surfacing a cancellation error as application failure. Same-key reads
+share one remote flight while retaining per-caller cancellation; the underlying
+call is canceled only after its final waiter leaves. Watches subscribe to local
+changes before their initial snapshot and reconcile any mutation that arrives
+during that handoff.
 
 Replay is never inferred from network type. Call `drain`, `start`, or `resume`
 from explicit foreground work, or `probeAndDrain` to require a successful real

--- a/sdks/dart/offline/lib/src/remote.dart
+++ b/sdks/dart/offline/lib/src/remote.dart
@@ -231,13 +231,19 @@ final class LanternClientOfflineRemote implements OfflineRemote {
   }
 }
 
-OfflineRemoteFailure _mapFailure(Object error) {
+Exception _mapFailure(Object error) {
   if (error is OfflineRemoteFailure) return error;
-  return OfflineRemoteFailure(switch (error) {
+  if (error is OfflineCanceledException) return error;
+  final classified = error is LanternRetryExhaustedException
+      ? error.cause
+      : error;
+  if (classified is LanternCanceledException) {
+    return const OfflineCanceledException();
+  }
+  return OfflineRemoteFailure(switch (classified) {
     LanternUnavailableException() => OfflineRemoteErrorKind.unavailable,
     LanternUnauthenticatedException() => OfflineRemoteErrorKind.unauthenticated,
     LanternInvalidArgumentException() => OfflineRemoteErrorKind.invalidArgument,
-    LanternCanceledException() => OfflineRemoteErrorKind.canceled,
     LanternResourceExhaustedException() =>
       OfflineRemoteErrorKind.resourceExhausted,
     LanternPermissionDeniedException() ||

--- a/sdks/dart/offline/lib/src/repository.dart
+++ b/sdks/dart/offline/lib/src/repository.dart
@@ -42,8 +42,9 @@ final class OfflineLanternRepository {
   _writeStatuses = <_WriteStatusKey, StreamController<OfflineWriteStatus>>{};
   final Map<_WriteStatusKey, OfflineWriteStatus> _latestWriteStatuses =
       <_WriteStatusKey, OfflineWriteStatus>{};
-  final Map<_ReadFlightKey, Future<Object>> _singleFlights =
-      <_ReadFlightKey, Future<Object>>{};
+  final Map<_ReadFlightKey, _ReadFlight> _singleFlights =
+      <_ReadFlightKey, _ReadFlight>{};
+  final Set<_ReadFlightWaiter> _deferredReadWaiters = <_ReadFlightWaiter>{};
   late final _ReadLimiter _readLimiter;
   final Map<String, int> _activeWatchers = <String, int>{};
   int _activeWatcherCount = 0;
@@ -72,12 +73,13 @@ final class OfflineLanternRepository {
     );
     return _singleFlight(
       flightKey,
-      () => _readVertex(
+      cancellation,
+      (flightCancellation) => _readVertex(
         partitionId,
         key,
         policy: policy,
         allowStale: allowStale,
-        cancellation: cancellation,
+        cancellation: flightCancellation,
       ),
     );
   }
@@ -104,12 +106,13 @@ final class OfflineLanternRepository {
     );
     return _singleFlight(
       flightKey,
-      () => _readEdge(
+      cancellation,
+      (flightCancellation) => _readEdge(
         partitionId,
         edge,
         policy: policy,
         allowStale: allowStale,
-        cancellation: cancellation,
+        cancellation: flightCancellation,
       ),
     );
   }
@@ -129,12 +132,12 @@ final class OfflineLanternRepository {
     return _watchSnapshots<Vertex>(
       partitionId,
       initialPolicy: initialPolicy,
-      load: (policy) => readVertex(
+      load: (policy, watchCancellation) => readVertex(
         partitionId,
         key,
         policy: policy,
         allowStale: allowStale,
-        cancellation: cancellation,
+        cancellation: watchCancellation,
       ),
       equals: _vertexSnapshotEquals,
       cancellation: cancellation,
@@ -157,12 +160,12 @@ final class OfflineLanternRepository {
     return _watchSnapshots<Edge>(
       partitionId,
       initialPolicy: initialPolicy,
-      load: (policy) => readEdge(
+      load: (policy, watchCancellation) => readEdge(
         partitionId,
         edge,
         policy: policy,
         allowStale: allowStale,
-        cancellation: cancellation,
+        cancellation: watchCancellation,
       ),
       equals: _edgeSnapshotEquals,
       cancellation: cancellation,
@@ -781,17 +784,27 @@ final class OfflineLanternRepository {
     );
   }
 
-  /// Releases process-local watchers and prevents new repository work.
-  ///
-  /// Callers remain responsible for canceling tokens supplied to active remote
-  /// calls before disposal.
+  /// Cancels owned reads, releases process-local watchers, and prevents work.
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;
     final controllers = _writeStatuses.values.toList(growable: false);
     _writeStatuses.clear();
     _latestWriteStatuses.clear();
+    final flights = _singleFlights.values.toSet().toList(growable: false);
     _singleFlights.clear();
+    final deferredReadWaiters = _deferredReadWaiters.toList(growable: false);
+    _deferredReadWaiters.clear();
+    for (final waiter in deferredReadWaiters) {
+      waiter.removeCancellationRegistration();
+      waiter.completeError(
+        const OfflineDisposedException(),
+        StackTrace.current,
+      );
+    }
+    for (final flight in flights) {
+      flight.cancel(const OfflineDisposedException());
+    }
     _readLimiter.dispose();
     final watchers = _watchDisposers.toList(growable: false);
     _watchDisposers.clear();
@@ -811,16 +824,26 @@ final class OfflineLanternRepository {
   Stream<OfflineSnapshot<T>> _watchSnapshots<T>(
     String partitionId, {
     required OfflineReadPolicy initialPolicy,
-    required Future<OfflineSnapshot<T>> Function(OfflineReadPolicy policy) load,
+    required Future<OfflineSnapshot<T>> Function(
+      OfflineReadPolicy policy,
+      LanternCancellationToken cancellation,
+    )
+    load,
     required bool Function(OfflineSnapshot<T>, OfflineSnapshot<T>) equals,
     required LanternCancellationToken? cancellation,
   }) {
     _ensureActive();
     OfflineSnapshot<T>? previous;
     StreamSubscription<OfflineStoreChange>? changes;
+    final watchCancellation = LanternCancellationToken();
+    void Function()? removeCancellationListener;
     var canceled = false;
     var registered = false;
+    var paused = false;
+    var initialComplete = false;
+    var pendingChange = false;
     var changeTail = Future<void>.value();
+    Future<void>? closing;
     late final StreamController<OfflineSnapshot<T>> controller;
     late final Future<void> Function() closeWatch;
 
@@ -832,12 +855,27 @@ final class OfflineLanternRepository {
     }
 
     Future<void> emit(OfflineReadPolicy policy) async {
-      _throwIfCanceled(cancellation);
-      final current = await load(policy);
+      _throwIfCanceled(watchCancellation);
+      final current = await load(policy, watchCancellation);
       if (canceled || controller.isClosed) return;
       if (previous != null && equals(previous!, current)) return;
       previous = current;
       controller.add(current);
+    }
+
+    void enqueueChange() {
+      changeTail = changeTail.then((_) async {
+        if (canceled) return;
+        try {
+          await emit(OfflineReadPolicy.cacheOnly);
+        } catch (error, stackTrace) {
+          if (!canceled &&
+              !controller.isClosed &&
+              error is! OfflineCanceledException) {
+            controller.addError(error, stackTrace);
+          }
+        }
+      });
     }
 
     void subscribeToChanges() {
@@ -845,28 +883,29 @@ final class OfflineLanternRepository {
           .changes(partitionId)
           .listen(
             (_) {
-              changeTail = changeTail.then((_) async {
-                try {
-                  await emit(OfflineReadPolicy.cacheOnly);
-                } catch (error, stackTrace) {
-                  if (!canceled &&
-                      !controller.isClosed &&
-                      error is! OfflineCanceledException) {
-                    controller.addError(error, stackTrace);
-                  }
-                }
-              });
+              if (canceled) return;
+              if (!initialComplete) {
+                pendingChange = true;
+                return;
+              }
+              enqueueChange();
             },
             onError: (Object error, StackTrace stackTrace) {
               if (!canceled && !controller.isClosed) {
                 controller.addError(error, stackTrace);
+                unawaited(closeWatch());
               }
             },
           );
+      if (paused) changes!.pause();
     }
 
     Future<void> startWatching() async {
       try {
+        // Register the change listener before the initial read. Changes that
+        // arrive while the initial snapshot is in flight are reconciled after
+        // that snapshot, so every continuing policy has a no-gap handoff.
+        subscribeToChanges();
         if (initialPolicy == OfflineReadPolicy.cacheFirst) {
           await emit(OfflineReadPolicy.cacheOnly);
           if (canceled) return;
@@ -879,54 +918,77 @@ final class OfflineLanternRepository {
               controller.addError(error, stackTrace);
             }
           }
-          if (canceled) return;
-          subscribeToChanges();
-          await emit(OfflineReadPolicy.cacheOnly);
-          return;
         } else {
           await emit(initialPolicy);
         }
-        if (canceled) return;
-        subscribeToChanges();
       } catch (error, stackTrace) {
         if (error is OfflineCanceledException) {
-          releaseWatcher();
-          if (!controller.isClosed) await controller.close();
+          await closeWatch();
         } else if (!canceled && !controller.isClosed) {
           controller.addError(error, stackTrace);
-          releaseWatcher();
-          await controller.close();
+          await closeWatch();
+        }
+      } finally {
+        initialComplete = true;
+        if (pendingChange && !canceled) {
+          pendingChange = false;
+          enqueueChange();
         }
       }
     }
 
-    closeWatch = () async {
-      canceled = true;
-      await changes?.cancel();
-      releaseWatcher();
-      if (!controller.isClosed) await controller.close();
+    closeWatch = () {
+      final existing = closing;
+      if (existing != null) return existing;
+      final result = () async {
+        canceled = true;
+        watchCancellation.cancel();
+        removeCancellationListener?.call();
+        removeCancellationListener = null;
+        final subscription = changes;
+        changes = null;
+        previous = null;
+        releaseWatcher();
+        try {
+          await subscription?.cancel();
+        } finally {
+          if (!controller.isClosed) await controller.close();
+        }
+      }();
+      closing = result;
+      return result;
     };
     controller = StreamController<OfflineSnapshot<T>>(
       sync: true,
       onListen: () {
         try {
+          _ensureActive();
+          if (cancellation?.isCanceled ?? false) {
+            unawaited(controller.close());
+            return;
+          }
           _registerWatcher(partitionId);
           registered = true;
           _watchDisposers.add(closeWatch);
+          removeCancellationListener = cancellation?.listen((_) {
+            unawaited(closeWatch());
+          });
           unawaited(startWatching());
         } catch (error, stackTrace) {
           controller.addError(error, stackTrace);
           unawaited(controller.close());
         }
       },
-      onCancel: () async {
-        canceled = true;
-        await changes?.cancel();
-        releaseWatcher();
-      },
+      onCancel: closeWatch,
     );
-    controller.onPause = () => changes?.pause();
-    controller.onResume = () => changes?.resume();
+    controller.onPause = () {
+      paused = true;
+      changes?.pause();
+    };
+    controller.onResume = () {
+      paused = false;
+      changes?.resume();
+    };
     return controller.stream;
   }
 
@@ -954,6 +1016,7 @@ final class OfflineLanternRepository {
         cancellation,
         () => remote.getVertex(key, cancellation: cancellation),
       );
+      _throwIfCanceled(cancellation);
       final now = config.clock().toUtc();
       switch (read) {
         case OfflineRemotePresent<Vertex>(:final value):
@@ -1039,6 +1102,9 @@ final class OfflineLanternRepository {
         OfflineReadSource.server,
       );
     } on OfflineRemoteFailure catch (error) {
+      if (error.kind == OfflineRemoteErrorKind.canceled) {
+        throw const OfflineCanceledException();
+      }
       if (policy == OfflineReadPolicy.serverFirst &&
           _eligible(local, allowStale: allowStale)) {
         return local;
@@ -1077,6 +1143,7 @@ final class OfflineLanternRepository {
         cancellation,
         () => remote.getEdge(edge, cancellation: cancellation),
       );
+      _throwIfCanceled(cancellation);
       final now = config.clock().toUtc();
       switch (read) {
         case OfflineRemotePresent<Edge>(:final value):
@@ -1165,6 +1232,9 @@ final class OfflineLanternRepository {
         OfflineReadSource.server,
       );
     } on OfflineRemoteFailure catch (error) {
+      if (error.kind == OfflineRemoteErrorKind.canceled) {
+        throw const OfflineCanceledException();
+      }
       if (policy == OfflineReadPolicy.serverFirst &&
           _eligible(local, allowStale: allowStale)) {
         return local;
@@ -2064,15 +2134,81 @@ final class OfflineLanternRepository {
     }
   }
 
-  Future<T> _singleFlight<T>(_ReadFlightKey key, Future<T> Function() task) {
+  Future<T> _singleFlight<T>(
+    _ReadFlightKey key,
+    LanternCancellationToken? cancellation,
+    Future<T> Function(LanternCancellationToken cancellation) task,
+  ) {
+    if (_disposed) {
+      return Future<T>.error(const OfflineDisposedException());
+    }
+    if (cancellation?.isCanceled ?? false) {
+      return Future<T>.error(const OfflineCanceledException());
+    }
     final existing = _singleFlights[key];
-    if (existing != null) return existing as Future<T>;
-    late final Future<T> future;
-    future = task().whenComplete(() {
-      if (identical(_singleFlights[key], future)) _singleFlights.remove(key);
+    if (existing != null) {
+      if (existing.acceptingWaiters) {
+        return existing.addWaiter<T>(cancellation);
+      }
+      return _waitForReadFlight<T>(key, existing, cancellation, task);
+    }
+    late final _ReadFlight flight;
+    flight = _ReadFlight(
+      task: (flightCancellation) async => task(flightCancellation),
+      onSettled: () {
+        if (identical(_singleFlights[key], flight)) {
+          _singleFlights.remove(key);
+        }
+      },
+    );
+    _singleFlights[key] = flight;
+    final waiter = flight.addWaiter<T>(cancellation);
+    flight.start();
+    return waiter;
+  }
+
+  Future<T> _waitForReadFlight<T>(
+    _ReadFlightKey key,
+    _ReadFlight previous,
+    LanternCancellationToken? cancellation,
+    Future<T> Function(LanternCancellationToken cancellation) task,
+  ) {
+    if (cancellation?.isCanceled ?? false) {
+      return Future<T>.error(const OfflineCanceledException());
+    }
+    final waiter = _TypedReadFlightWaiter<T>();
+    _deferredReadWaiters.add(waiter);
+    waiter.removeCancellationListener = cancellation?.listen((_) {
+      if (!_deferredReadWaiters.remove(waiter)) return;
+      waiter.removeCancellationRegistration();
+      waiter.completeError(
+        const OfflineCanceledException(),
+        StackTrace.current,
+      );
     });
-    _singleFlights[key] = future as Future<Object>;
-    return future;
+    previous.settled.whenComplete(() {
+      if (waiter.isCompleted) {
+        _deferredReadWaiters.remove(waiter);
+        waiter.removeCancellationRegistration();
+        return;
+      }
+      _deferredReadWaiters.remove(waiter);
+      waiter.removeCancellationRegistration();
+      if (_disposed) {
+        waiter.completeError(
+          const OfflineDisposedException(),
+          StackTrace.current,
+        );
+        return;
+      }
+      _singleFlight(key, cancellation, task).then(
+        waiter.complete,
+        onError: (Object error, StackTrace stackTrace) {
+          waiter.completeError(error, stackTrace);
+        },
+      );
+    });
+    return waiter.future;
   }
 
   bool _fresh(DateTime validatedAt, DateTime now) =>
@@ -2353,10 +2489,9 @@ final class _ReadLimiter {
     _queued.add(waiter);
     _queuedByPartition[partitionId] = partitionQueued + 1;
     if (cancellation != null) {
-      waiter.cancellationTimer = Timer.periodic(
-        const Duration(milliseconds: 10),
-        (_) => _removeCanceled(waiter),
-      );
+      waiter.removeCancellationListener = cancellation.listen((_) {
+        _removeCanceled(waiter);
+      });
     }
     _drain();
     return waiter.completer.future;
@@ -2369,7 +2504,7 @@ final class _ReadLimiter {
     _queued.clear();
     _queuedByPartition.clear();
     for (final waiter in queued) {
-      waiter.cancellationTimer?.cancel();
+      waiter.removeCancellationRegistration();
       waiter.completer.completeError(const OfflineDisposedException());
     }
   }
@@ -2405,7 +2540,7 @@ final class _ReadLimiter {
       if (index < 0) return;
       final waiter = _queued.removeAt(index);
       _decrementQueued(waiter.partitionId);
-      waiter.cancellationTimer?.cancel();
+      waiter.removeCancellationRegistration();
       if (waiter.cancellation?.isCanceled ?? false) {
         waiter.completer.completeError(const OfflineCanceledException());
         continue;
@@ -2417,7 +2552,7 @@ final class _ReadLimiter {
   void _removeCanceled(_ReadWaiter waiter) {
     if (!(waiter.cancellation?.isCanceled ?? false)) return;
     final removed = _queued.remove(waiter);
-    waiter.cancellationTimer?.cancel();
+    waiter.removeCancellationRegistration();
     if (!removed) return;
     _decrementQueued(waiter.partitionId);
     waiter.completer.completeError(const OfflineCanceledException());
@@ -2440,7 +2575,12 @@ final class _ReadWaiter {
   final String partitionId;
   final LanternCancellationToken? cancellation;
   final Completer<_ReadPermit> completer = Completer<_ReadPermit>();
-  Timer? cancellationTimer;
+  void Function()? removeCancellationListener;
+
+  void removeCancellationRegistration() {
+    removeCancellationListener?.call();
+    removeCancellationListener = null;
+  }
 }
 
 final class _ReadPermit {
@@ -2578,6 +2718,135 @@ final class _WriteStatusKey {
 
   @override
   int get hashCode => Object.hash(partitionId, recordId);
+}
+
+final class _ReadFlight {
+  _ReadFlight({required this.task, required this.onSettled});
+
+  final Future<Object?> Function(LanternCancellationToken cancellation) task;
+  final void Function() onSettled;
+  final LanternCancellationToken _cancellation = LanternCancellationToken();
+  final Set<_ReadFlightWaiter> _waiters = <_ReadFlightWaiter>{};
+  final Completer<void> _settled = Completer<void>();
+  var _started = false;
+  var _acceptingWaiters = true;
+  var _isSettled = false;
+
+  bool get acceptingWaiters => _acceptingWaiters;
+
+  Future<void> get settled => _settled.future;
+
+  Future<T> addWaiter<T>(LanternCancellationToken? cancellation) {
+    if (!_acceptingWaiters) {
+      return Future<T>.error(const OfflineCanceledException());
+    }
+    if (cancellation?.isCanceled ?? false) {
+      return Future<T>.error(const OfflineCanceledException());
+    }
+    final waiter = _TypedReadFlightWaiter<T>();
+    _waiters.add(waiter);
+    waiter.removeCancellationListener = cancellation?.listen((_) {
+      _cancelWaiter(waiter);
+    });
+    return waiter.future;
+  }
+
+  void start() {
+    if (_started) return;
+    _started = true;
+    unawaited(_run());
+  }
+
+  void cancel(Object error) {
+    if (_isSettled) return;
+    _acceptingWaiters = false;
+    _cancellation.cancel(error);
+    final waiters = _waiters.toList(growable: false);
+    _waiters.clear();
+    for (final waiter in waiters) {
+      waiter.removeCancellationRegistration();
+      waiter.completeError(error, StackTrace.current);
+    }
+  }
+
+  void _cancelWaiter(_ReadFlightWaiter waiter) {
+    if (!_waiters.remove(waiter)) return;
+    waiter.removeCancellationRegistration();
+    waiter.completeError(const OfflineCanceledException(), StackTrace.current);
+    if (_waiters.isEmpty && !_isSettled) {
+      _acceptingWaiters = false;
+      _cancellation.cancel();
+    }
+  }
+
+  Future<void> _run() async {
+    try {
+      final value = await task(_cancellation);
+      final waiters = _waiters.toList(growable: false);
+      _waiters.clear();
+      for (final waiter in waiters) {
+        waiter.removeCancellationRegistration();
+        waiter.complete(value);
+      }
+    } catch (error, stackTrace) {
+      final waiters = _waiters.toList(growable: false);
+      _waiters.clear();
+      for (final waiter in waiters) {
+        waiter.removeCancellationRegistration();
+        waiter.completeError(error, stackTrace);
+      }
+    } finally {
+      _acceptingWaiters = false;
+      _isSettled = true;
+      onSettled();
+      _settled.complete();
+    }
+  }
+}
+
+abstract interface class _ReadFlightWaiter {
+  bool get isCompleted;
+
+  set removeCancellationListener(void Function()? value);
+
+  void removeCancellationRegistration();
+
+  void complete(Object? value);
+
+  void completeError(Object error, StackTrace stackTrace);
+}
+
+final class _TypedReadFlightWaiter<T> implements _ReadFlightWaiter {
+  final Completer<T> _completer = Completer<T>();
+  void Function()? _removeCancellationListener;
+
+  Future<T> get future => _completer.future;
+
+  @override
+  bool get isCompleted => _completer.isCompleted;
+
+  @override
+  set removeCancellationListener(void Function()? value) {
+    _removeCancellationListener = value;
+  }
+
+  @override
+  void removeCancellationRegistration() {
+    _removeCancellationListener?.call();
+    _removeCancellationListener = null;
+  }
+
+  @override
+  void complete(Object? value) {
+    if (!_completer.isCompleted) _completer.complete(value as T);
+  }
+
+  @override
+  void completeError(Object error, StackTrace stackTrace) {
+    if (!_completer.isCompleted) {
+      _completer.completeError(error, stackTrace);
+    }
+  }
 }
 
 final class _ReadFlightKey {

--- a/sdks/dart/offline/test/real_wire_test.dart
+++ b/sdks/dart/offline/test/real_wire_test.dart
@@ -1,6 +1,7 @@
 @TestOn('vm')
 library;
 
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -9,6 +10,87 @@ import 'package:lantern_client_offline/lantern_client_offline.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test('online adapter preserves typed transport cancellation', () async {
+    final requestStarted = Completer<void>();
+    final releaseResponse = Completer<void>();
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() async {
+      if (!releaseResponse.isCompleted) releaseResponse.complete();
+      await server.close(force: true);
+    });
+    server.listen((request) async {
+      if (!requestStarted.isCompleted) requestStarted.complete();
+      await releaseResponse.future;
+      try {
+        request.response.statusCode = HttpStatus.serviceUnavailable;
+        await request.response.close();
+      } on Object {
+        // Caller cancellation may close the request before test teardown.
+      }
+    });
+    final client = LanternClient.connect(
+      Uri.parse('http://${server.address.host}:${server.port}'),
+      allowInsecure: true,
+      defaultTimeout: null,
+    );
+    addTearDown(client.close);
+    final remote = LanternClientOfflineRemote(client);
+    final cancellation = LanternCancellationToken();
+
+    final reading = remote.getVertex('cancel', cancellation: cancellation);
+    await requestStarted.future;
+    cancellation.cancel('screen disposed');
+
+    await expectLater(reading, throwsA(isA<OfflineCanceledException>()));
+  });
+
+  test('online adapter classifies a retry-exhausted typed cause', () async {
+    var attempts = 0;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => server.close(force: true));
+    server.listen((request) async {
+      attempts += 1;
+      request.response
+        ..statusCode = HttpStatus.serviceUnavailable
+        ..headers.contentType = ContentType.json
+        ..write('{"code":"unavailable","message":"down"}');
+      await request.response.close();
+    });
+    final client = LanternClient.connect(
+      Uri.parse('http://${server.address.host}:${server.port}'),
+      allowInsecure: true,
+      retryPolicy: const RetryPolicy(
+        maxAttempts: 2,
+        baseDelay: Duration(microseconds: 1),
+        maxDelay: Duration(microseconds: 1),
+      ),
+    );
+    addTearDown(client.close);
+    final remote = LanternClientOfflineRemote(client);
+
+    await expectLater(
+      remote.getVertex('retry'),
+      throwsA(
+        isA<OfflineRemoteFailure>()
+            .having(
+              (failure) => failure.kind,
+              'kind',
+              OfflineRemoteErrorKind.unavailable,
+            )
+            .having(
+              (failure) => failure.cause,
+              'cause',
+              isA<LanternRetryExhaustedException>().having(
+                (wrapper) => wrapper.cause,
+                'typed cause',
+                isA<LanternUnavailableException>(),
+              ),
+            ),
+      ),
+    );
+    expect(attempts, 2);
+  });
+
   test(
     'real server commit plus response loss replays safe Put and Add',
     () async {

--- a/sdks/dart/offline/test/repository_read_test.dart
+++ b/sdks/dart/offline/test/repository_read_test.dart
@@ -212,6 +212,39 @@ void main() {
     await subscription.cancel();
   });
 
+  test(
+    'watch observes a mutation committed during its initial snapshot',
+    () async {
+      final clock = MutableClock(initial);
+      final store = _GapInjectingStore(
+        injectedAt: initial,
+        injected: Vertex(
+          key: 'watched',
+          value: VertexValue.string('between'),
+          expiration: null,
+        ),
+      )..arm();
+      final repository = OfflineLanternRepository(
+        store: store,
+        remote: FakeOfflineRemote(),
+        config: testConfig(clock),
+      );
+
+      final snapshots = await repository
+          .watchVertex(
+            'p',
+            'watched',
+            initialPolicy: OfflineReadPolicy.cacheOnly,
+          )
+          .take(2)
+          .toList()
+          .timeout(const Duration(seconds: 1));
+
+      expect(snapshots.first.state, OfflineReadState.unknown);
+      expect((snapshots.last.value!.value as StringValue).value, 'between');
+    },
+  );
+
   test('late remote read cannot repopulate a wiped partition', () async {
     final clock = MutableClock(initial);
     final store = InMemoryOfflineStore();
@@ -270,6 +303,154 @@ void main() {
     );
   });
 
+  test('canceling the first same-key caller leaves the second alive', () async {
+    final clock = MutableClock(initial);
+    final remote = _ControlledReadRemote();
+    final repository = OfflineLanternRepository(
+      store: InMemoryOfflineStore(),
+      remote: remote,
+      config: testConfig(clock),
+    );
+    final firstCancellation = LanternCancellationToken();
+    final secondCancellation = LanternCancellationToken();
+    final first = repository.readVertex(
+      'p',
+      'shared',
+      policy: OfflineReadPolicy.serverOnly,
+      cancellation: firstCancellation,
+    );
+    await remote.waitUntilStarted('shared');
+    final second = repository.readVertex(
+      'p',
+      'shared',
+      policy: OfflineReadPolicy.serverOnly,
+      cancellation: secondCancellation,
+    );
+
+    firstCancellation.cancel();
+    await expectLater(first, throwsA(isA<OfflineCanceledException>()));
+    expect(remote.started.where((key) => key == 'shared'), hasLength(1));
+
+    remote.complete('shared');
+    expect((await second).state, OfflineReadState.missing);
+    expect(remote.started.where((key) => key == 'shared'), hasLength(1));
+  });
+
+  test('canceling the second same-key caller leaves the first alive', () async {
+    final clock = MutableClock(initial);
+    final remote = _ControlledReadRemote();
+    final repository = OfflineLanternRepository(
+      store: InMemoryOfflineStore(),
+      remote: remote,
+      config: testConfig(clock),
+    );
+    final firstCancellation = LanternCancellationToken();
+    final secondCancellation = LanternCancellationToken();
+    final first = repository.readVertex(
+      'p',
+      'shared',
+      policy: OfflineReadPolicy.serverOnly,
+      cancellation: firstCancellation,
+    );
+    await remote.waitUntilStarted('shared');
+    final second = repository.readVertex(
+      'p',
+      'shared',
+      policy: OfflineReadPolicy.serverOnly,
+      cancellation: secondCancellation,
+    );
+
+    secondCancellation.cancel();
+    await expectLater(second, throwsA(isA<OfflineCanceledException>()));
+    expect(remote.started.where((key) => key == 'shared'), hasLength(1));
+
+    remote.complete('shared');
+    expect((await first).state, OfflineReadState.missing);
+    expect(remote.started.where((key) => key == 'shared'), hasLength(1));
+  });
+
+  test('the final waiter cancels transport and releases its permit', () async {
+    final clock = MutableClock(initial);
+    final remote = _CancelableReadRemote();
+    final repository = OfflineLanternRepository(
+      store: InMemoryOfflineStore(),
+      remote: remote,
+      config: OfflineConfig(
+        clock: clock.call,
+        idGenerator: testConfig(clock).idGenerator,
+        jitter: (_) => Duration.zero,
+        maxReadConcurrency: 1,
+        maxReadConcurrencyPerPartition: 1,
+      ),
+    );
+    final cancellation = LanternCancellationToken();
+    final canceled = repository.readVertex(
+      'p',
+      'first',
+      policy: OfflineReadPolicy.serverOnly,
+      cancellation: cancellation,
+    );
+    await remote.waitUntilStarted('first');
+
+    cancellation.cancel();
+    await expectLater(canceled, throwsA(isA<OfflineCanceledException>()));
+    await remote.waitUntilCanceled('first');
+
+    final next = repository.readVertex(
+      'p',
+      'next',
+      policy: OfflineReadPolicy.serverOnly,
+    );
+    await remote.waitUntilStarted('next');
+    remote.complete('next');
+    expect((await next).state, OfflineReadState.missing);
+    expect(remote.canceled.where((key) => key == 'first'), hasLength(1));
+  });
+
+  test(
+    'dispose fails a deferred caller even when the prior flight never settles',
+    () async {
+      final clock = MutableClock(initial);
+      final remote = _CancellationIgnoringReadRemote();
+      addTearDown(remote.release);
+      final repository = OfflineLanternRepository(
+        store: InMemoryOfflineStore(),
+        remote: remote,
+        config: testConfig(clock),
+      );
+      final cancellation = LanternCancellationToken();
+      final first = repository.readVertex(
+        'p',
+        'shared',
+        policy: OfflineReadPolicy.serverOnly,
+        cancellation: cancellation,
+      );
+      await remote.started.future;
+
+      cancellation.cancel();
+      await expectLater(first, throwsA(isA<OfflineCanceledException>()));
+      await remote.cancellationObserved.future;
+
+      final deferred = repository.readVertex(
+        'p',
+        'shared',
+        policy: OfflineReadPolicy.serverOnly,
+      );
+      final deferredExpectation = expectLater(
+        deferred.timeout(const Duration(seconds: 1)),
+        throwsA(isA<OfflineDisposedException>()),
+      );
+
+      await repository.dispose().timeout(const Duration(seconds: 1));
+      await deferredExpectation;
+      expect(remote.startCount, 1);
+
+      remote.release();
+      await Future<void>.delayed(Duration.zero);
+      expect(remote.startCount, 1);
+    },
+  );
+
   test(
     'remote reads honor global, partition, queue, and cancellation bounds',
     () async {
@@ -288,6 +469,18 @@ void main() {
           maxQueuedReadsPerPartition: 1,
         ),
       );
+      final preCanceled = LanternCancellationToken()..cancel();
+      await expectLater(
+        repository.readVertex(
+          'p',
+          'pre-canceled',
+          policy: OfflineReadPolicy.serverOnly,
+          cancellation: preCanceled,
+        ),
+        throwsA(isA<OfflineCanceledException>()),
+      );
+      expect(remote.started, isNot(contains('pre-canceled')));
+
       final first = repository.readVertex(
         'p',
         'first',
@@ -387,35 +580,141 @@ void main() {
     },
   );
 
-  test('watch cancellation is not surfaced as a stream error', () async {
+  test('pause, resume, and final cancel release the store listener', () async {
     final clock = MutableClock(initial);
-    final store = InMemoryOfflineStore();
+    final store = _TrackingStore();
     final repository = OfflineLanternRepository(
       store: store,
       remote: FakeOfflineRemote(),
       config: testConfig(clock),
     );
-    final cancellation = LanternCancellationToken();
-    final errors = <Object>[];
+    final initialSnapshot = Completer<void>();
+    final changedSnapshot = Completer<OfflineSnapshot<Vertex>>();
     final subscription = repository
-        .watchVertex(
-          'p',
-          'key',
-          initialPolicy: OfflineReadPolicy.cacheOnly,
-          cancellation: cancellation,
-        )
-        .listen((_) {}, onError: errors.add);
-    await Future<void>.delayed(Duration.zero);
-    cancellation.cancel();
+        .watchVertex('p', 'watched', initialPolicy: OfflineReadPolicy.cacheOnly)
+        .listen((snapshot) {
+          if (!initialSnapshot.isCompleted) {
+            initialSnapshot.complete();
+          } else if (snapshot.hasPendingWrites &&
+              !changedSnapshot.isCompleted) {
+            changedSnapshot.complete(snapshot);
+          }
+        });
+    await initialSnapshot.future.timeout(const Duration(seconds: 1));
+    expect(store.activeChangeSubscriptions, 1);
+
+    subscription.pause();
     await repository.putVertex(
       partitionId: 'p',
-      input: VertexInput(key: 'key', value: VertexValue.string('value')),
+      input: VertexInput(key: 'watched', value: VertexValue.string('changed')),
     );
-    await Future<void>.delayed(const Duration(milliseconds: 10));
+    await Future<void>.delayed(Duration.zero);
+    expect(changedSnapshot.isCompleted, isFalse);
 
-    expect(errors, isEmpty);
+    subscription.resume();
+    expect(
+      (await changedSnapshot.future.timeout(
+        const Duration(seconds: 1),
+      )).hasPendingWrites,
+      isTrue,
+    );
     await subscription.cancel();
+    expect(store.activeChangeSubscriptions, 0);
   });
+
+  test(
+    'delayed failing store cancellation releases watcher capacity first',
+    () async {
+      final clock = MutableClock(initial);
+      final store = _ControlledCancelStore();
+      addTearDown(store.releaseFirstCancellation);
+      final repository = OfflineLanternRepository(
+        store: store,
+        remote: FakeOfflineRemote(),
+        config: OfflineConfig(
+          clock: clock.call,
+          idGenerator: testConfig(clock).idGenerator,
+          jitter: (_) => Duration.zero,
+          maxWatchers: 1,
+          maxWatchersPerPartition: 1,
+          maxActiveWatcherPartitions: 1,
+        ),
+      );
+      final firstInitial = Completer<void>();
+      final first = repository
+          .watchVertex('p', 'first', initialPolicy: OfflineReadPolicy.cacheOnly)
+          .listen((_) => firstInitial.complete());
+      await firstInitial.future.timeout(const Duration(seconds: 1));
+
+      final firstCancellation = expectLater(
+        first.cancel(),
+        throwsA(isA<StateError>()),
+      );
+      await store.firstCancellationStarted.future.timeout(
+        const Duration(seconds: 1),
+      );
+
+      final secondInitial = Completer<void>();
+      final second = repository
+          .watchVertex(
+            'p',
+            'second',
+            initialPolicy: OfflineReadPolicy.cacheOnly,
+          )
+          .listen((_) => secondInitial.complete());
+      await secondInitial.future.timeout(const Duration(seconds: 1));
+
+      store.releaseFirstCancellation();
+      await firstCancellation;
+      await second.cancel();
+      await repository.dispose();
+    },
+  );
+
+  test(
+    'idle watch cancellation closes and releases watcher capacity',
+    () async {
+      final clock = MutableClock(initial);
+      final repository = OfflineLanternRepository(
+        store: InMemoryOfflineStore(),
+        remote: FakeOfflineRemote(),
+        config: OfflineConfig(
+          clock: clock.call,
+          idGenerator: testConfig(clock).idGenerator,
+          jitter: (_) => Duration.zero,
+          maxWatchers: 1,
+          maxWatchersPerPartition: 1,
+          maxActiveWatcherPartitions: 1,
+        ),
+      );
+      final errors = <Object>[];
+      for (var index = 0; index < 3; index++) {
+        final cancellation = LanternCancellationToken();
+        final initialSnapshot = Completer<void>();
+        final done = Completer<void>();
+        repository
+            .watchVertex(
+              'p',
+              'key-$index',
+              initialPolicy: OfflineReadPolicy.cacheOnly,
+              cancellation: cancellation,
+            )
+            .listen(
+              (_) {
+                if (!initialSnapshot.isCompleted) initialSnapshot.complete();
+              },
+              onError: errors.add,
+              onDone: () => done.complete(),
+            );
+        await initialSnapshot.future.timeout(const Duration(seconds: 1));
+
+        cancellation.cancel();
+        await done.future.timeout(const Duration(seconds: 1));
+      }
+
+      expect(errors, isEmpty);
+    },
+  );
 
   test(
     'an oversized confirmed read remains usable and emits capacity diagnostics',
@@ -510,6 +809,223 @@ final class _ControlledReadRemote extends FakeOfflineRemote {
     _active -= 1;
     return const OfflineRemoteMissing<Vertex>();
   }
+}
+
+final class _CancelableReadRemote extends FakeOfflineRemote {
+  final Map<String, Completer<OfflineRemoteRead<Vertex>>> _responses =
+      <String, Completer<OfflineRemoteRead<Vertex>>>{};
+  final Map<String, Completer<void>> _startedSignals =
+      <String, Completer<void>>{};
+  final Map<String, Completer<void>> _canceledSignals =
+      <String, Completer<void>>{};
+  final List<String> canceled = <String>[];
+
+  Future<void> waitUntilStarted(String key) =>
+      _startedSignals.putIfAbsent(key, Completer<void>.new).future;
+
+  Future<void> waitUntilCanceled(String key) =>
+      _canceledSignals.putIfAbsent(key, Completer<void>.new).future;
+
+  void complete(String key) {
+    final response = _responses.putIfAbsent(
+      key,
+      Completer<OfflineRemoteRead<Vertex>>.new,
+    );
+    if (!response.isCompleted) {
+      response.complete(const OfflineRemoteMissing<Vertex>());
+    }
+  }
+
+  @override
+  Future<OfflineRemoteRead<Vertex>> getVertex(
+    String key, {
+    LanternCancellationToken? cancellation,
+  }) async {
+    _startedSignals.putIfAbsent(key, Completer<void>.new).complete();
+    final response = _responses.putIfAbsent(
+      key,
+      Completer<OfflineRemoteRead<Vertex>>.new,
+    );
+    final removeCancellationListener = cancellation?.listen((_) {
+      canceled.add(key);
+      _canceledSignals.putIfAbsent(key, Completer<void>.new).complete();
+      if (!response.isCompleted) {
+        response.completeError(const OfflineCanceledException());
+      }
+    });
+    try {
+      return await response.future;
+    } finally {
+      removeCancellationListener?.call();
+    }
+  }
+}
+
+final class _CancellationIgnoringReadRemote extends FakeOfflineRemote {
+  final Completer<void> started = Completer<void>();
+  final Completer<void> cancellationObserved = Completer<void>();
+  final Completer<OfflineRemoteRead<Vertex>> _response =
+      Completer<OfflineRemoteRead<Vertex>>();
+  var startCount = 0;
+
+  void release() {
+    if (!_response.isCompleted) {
+      _response.complete(const OfflineRemoteMissing<Vertex>());
+    }
+  }
+
+  @override
+  Future<OfflineRemoteRead<Vertex>> getVertex(
+    String key, {
+    LanternCancellationToken? cancellation,
+  }) async {
+    startCount += 1;
+    if (!started.isCompleted) started.complete();
+    final removeCancellationListener = cancellation?.listen((_) {
+      if (!cancellationObserved.isCompleted) cancellationObserved.complete();
+    });
+    try {
+      return await _response.future;
+    } finally {
+      removeCancellationListener?.call();
+    }
+  }
+}
+
+final class _GapInjectingStore implements OfflineStore {
+  _GapInjectingStore({required this.injectedAt, required this.injected});
+
+  final InMemoryOfflineStore _delegate = InMemoryOfflineStore();
+  final DateTime injectedAt;
+  final Vertex injected;
+  var _armed = false;
+  var _injected = false;
+
+  void arm() => _armed = true;
+
+  @override
+  Stream<OfflineStoreChange> changes(String partitionId) =>
+      _delegate.changes(partitionId);
+
+  @override
+  Future<T> transaction<T>(
+    FutureOr<T> Function(OfflineStoreTransaction transaction) action,
+  ) async {
+    final result = await _delegate.transaction(action);
+    if (_armed && !_injected) {
+      _injected = true;
+      await _delegate.transaction((transaction) {
+        transaction.putCache(
+          'p',
+          OfflineCacheRecord.value(
+            partitionId: 'p',
+            generation: 0,
+            key: OfflineEntityKey.vertex(injected.key),
+            entity: injected,
+            validatedAt: injectedAt,
+            lastAccessAt: injectedAt,
+          ),
+        );
+      });
+    }
+    return result;
+  }
+}
+
+final class _TrackingStore implements OfflineStore {
+  final InMemoryOfflineStore _delegate = InMemoryOfflineStore();
+  var activeChangeSubscriptions = 0;
+
+  @override
+  Stream<OfflineStoreChange> changes(String partitionId) {
+    StreamSubscription<OfflineStoreChange>? upstream;
+    var active = false;
+    late final StreamController<OfflineStoreChange> controller;
+
+    Future<void> cancelUpstream() async {
+      if (active) {
+        active = false;
+        activeChangeSubscriptions -= 1;
+      }
+      await upstream?.cancel();
+    }
+
+    controller = StreamController<OfflineStoreChange>(
+      sync: true,
+      onListen: () {
+        active = true;
+        activeChangeSubscriptions += 1;
+        upstream = _delegate
+            .changes(partitionId)
+            .listen(
+              controller.add,
+              onError: controller.addError,
+              onDone: controller.close,
+            );
+      },
+      onPause: () => upstream?.pause(),
+      onResume: () => upstream?.resume(),
+      onCancel: cancelUpstream,
+    );
+    return controller.stream;
+  }
+
+  @override
+  Future<T> transaction<T>(
+    FutureOr<T> Function(OfflineStoreTransaction transaction) action,
+  ) => _delegate.transaction(action);
+}
+
+final class _ControlledCancelStore implements OfflineStore {
+  final InMemoryOfflineStore _delegate = InMemoryOfflineStore();
+  final Completer<void> firstCancellationStarted = Completer<void>();
+  final Completer<void> _releaseFirstCancellation = Completer<void>();
+  var _cancellationCount = 0;
+
+  void releaseFirstCancellation() {
+    if (!_releaseFirstCancellation.isCompleted) {
+      _releaseFirstCancellation.complete();
+    }
+  }
+
+  @override
+  Stream<OfflineStoreChange> changes(String partitionId) {
+    StreamSubscription<OfflineStoreChange>? upstream;
+    late final StreamController<OfflineStoreChange> controller;
+
+    controller = StreamController<OfflineStoreChange>(
+      sync: true,
+      onListen: () {
+        upstream = _delegate
+            .changes(partitionId)
+            .listen(
+              controller.add,
+              onError: controller.addError,
+              onDone: controller.close,
+            );
+      },
+      onPause: () => upstream?.pause(),
+      onResume: () => upstream?.resume(),
+      onCancel: () async {
+        _cancellationCount += 1;
+        if (_cancellationCount == 1) {
+          if (!firstCancellationStarted.isCompleted) {
+            firstCancellationStarted.complete();
+          }
+          await _releaseFirstCancellation.future;
+          await upstream?.cancel();
+          throw StateError('store cancellation failed');
+        }
+        await upstream?.cancel();
+      },
+    );
+    return controller.stream;
+  }
+
+  @override
+  Future<T> transaction<T>(
+    FutureOr<T> Function(OfflineStoreTransaction transaction) action,
+  ) => _delegate.transaction(action);
 }
 
 final class _RecordingDiagnostics implements OfflineDiagnostics {

--- a/sdks/dart/test/client_test.dart
+++ b/sdks/dart/test/client_test.dart
@@ -12,6 +12,70 @@ import 'package:lantern_client/src/gen/graph/v1/graph.pb.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test('cancellation listeners fire once and detach idempotently', () {
+    final cancellation = LanternCancellationToken();
+    final retainedReason = Object();
+    final reasons = <Object?>[];
+    final detachedReasons = <Object?>[];
+    final remove = cancellation.listen(reasons.add);
+    final removeDetached = cancellation.listen(detachedReasons.add);
+
+    removeDetached();
+    removeDetached();
+    cancellation.cancel(retainedReason);
+    cancellation.cancel(Object());
+    remove();
+    remove();
+
+    expect(reasons, hasLength(1));
+    expect(reasons.single, same(retainedReason));
+    expect(detachedReasons, isEmpty);
+  });
+
+  test('a throwing cancellation listener cannot poison fan-out', () async {
+    final cancellation = LanternCancellationToken();
+    final reason = Object();
+    final delivered = <Object?>[];
+    final reported = Completer<Object>();
+
+    runZonedGuarded(
+      () {
+        cancellation.listen((_) => throw StateError('listener failed'));
+        cancellation.listen(delivered.add);
+        cancellation.cancel(reason);
+      },
+      (error, _) {
+        if (!reported.isCompleted) reported.complete(error);
+      },
+    );
+
+    expect(delivered, <Object?>[reason]);
+    expect(await reported.future, isA<StateError>());
+  });
+
+  test('pre-canceled listeners run in a detachable microtask', () async {
+    final cancellation = LanternCancellationToken();
+    final retainedReason = Object();
+    cancellation.cancel(retainedReason);
+    var synchronous = true;
+    final reasons = <Object?>[];
+    final detachedReasons = <Object?>[];
+    cancellation.listen((reason) {
+      expect(synchronous, isFalse);
+      reasons.add(reason);
+    });
+    final removeDetached = cancellation.listen(detachedReasons.add);
+    removeDetached();
+    removeDetached();
+
+    synchronous = false;
+    await Future<void>.delayed(Duration.zero);
+
+    expect(reasons, hasLength(1));
+    expect(reasons.single, same(retainedReason));
+    expect(detachedReasons, isEmpty);
+  });
+
   test('health ping uses auth-exempt Connect JSON and maps status', () async {
     final requests = <io.HttpRequest>[];
     final server = await io.HttpServer.bind('127.0.0.1', 0);


### PR DESCRIPTION
## Summary

- preserve typed cancellation and retry-exhausted causes through the online/offline adapter boundary
- expose detachable, fan-out-safe cancellation listeners without allowing one listener failure to poison transport cancellation
- share same-key read work behind per-caller waiters; cancel only the departing caller and stop transport after the final waiter leaves
- make queued/deferred reads repository-owned so dispose cannot leak or restart work
- subscribe watches before the initial snapshot, close idle watches immediately, and release local capacity even if store cancellation is delayed or fails

## Verification

- full repository pre-push gate across every Go module, parent/offline Dart packages, and Flutter example
- 77 parent Dart tests and 55 offline tests pass
- same-key cancellation in both caller orders, final-waiter transport cancellation, pre-canceled/queued/in-flight cases
- never-settling transport plus dispose, idle repeated watches, no-gap initial mutation, and pause/resume/failing-store cleanup
- actual HTTP/Connect transport cancellation remains `OfflineCanceledException`; retry exhaustion retains its typed inner cause
- warning-free parent/offline dartdoc and parent publish dry-run

Closes #1179