### PR TITLE
fix(sdks/dart/offline): validate durable store graphs at commit

### DIFF
--- a/docs/decisions/0002-dart-offline-repository-contract.md
+++ b/docs/decisions/0002-dart-offline-repository-contract.md
@@ -64,11 +64,33 @@ confirmed. Replay is foreground-only through explicit `drain`, `start`, or
 production adapters must preserve its serializable transaction, defensive-byte,
 partition-generation, durable FIFO ordinal, capacity, renewable lease,
 operation/dead-letter retention, and codec semantics. They can execute
-`runStoreConformanceSuite` in their own test runner against an empty adapter.
+`runStoreConformanceSuite` in their own test runner against an empty adapter,
+with the required `reopen` callback exercising the adapter's real close/reopen
+boundary under the same limits.
 The reusable contract also requires globally unique retained operation/record
 identities, sealed transaction objects after either commit or rollback,
 defensive byte ownership, bounded notification resources, and indexed bounded
 deadline queries used by lazy expiration.
+
+Every successful `OfflineStore.transaction` validates the complete durable
+graph for each changed partition and for durable-only mutations such as
+`touchCache`. Commit validation precedes version advancement, state publication,
+and change notification. A contradiction rolls back the whole transaction as
+`OfflineDurableGraphException` with no change event. Snapshot decode continues
+to report persisted corruption as `OfflineCodecException`; this distinction is
+intentional.
+
+The graph requires cache partition/generation ownership, exact
+`OfflineEntityKey` ↔ embedded Vertex/Edge identity, and a negative-marker
+`missingUntil` at or after `validatedAt`. Each enqueue operation—including
+born-expired items omitted from the retained outbox—must have one exact
+request-index-aligned aggregate. Retained outbox lifecycle, attempts, and
+diagnostics match its aggregate item, and record IDs have exactly one operation
+owner. Claim, expired-lease recovery, retry, dead-letter, confirmation, and
+expiration update both sides in one transaction. `wipePartition` is an explicit
+generation barrier that cancels earlier enqueue obligations within that same
+transaction. The conformance suite proves invalid commits are typed and atomic,
+then requires every accepted state to reopen under identical limits.
 
 The package has no storage key API and makes no encryption claim. Applications
 must provide at-rest encryption and key lifecycle policy in their store adapter.
@@ -78,8 +100,10 @@ malformed record bytes or v1/v2/v3/v4/v5 reference snapshots must fail closed as
 snapshot schema v5 persists the exact dead-letter transition time, operation
 aggregates, and durable auth pause. Opening schema v1, v2, or v3 quarantines
 legacy Add as an inspectable terminal `unsupported_add` dead letter and applies
-a conservative dead-letter transition-time fallback; schema v4 and later fail
-closed on Add. Opening schema v1-v4 recovers auth pause from durable operation
+a conservative dead-letter transition-time fallback. Schema v4 fails closed on
+Add; schema v5 accepts only the exact terminal `unsupported_add` shape produced
+by that migration, while every live or noncanonical Add fails closed.
+Opening schema v1-v4 recovers auth pause from durable operation
 metadata. Schema v1 also reconstructs active operation metadata and marks
 outcomes no longer present in the legacy outbox as `outcomeUnknown`. Cache and
 outbox capacity failures use

--- a/sdks/dart/offline/README.md
+++ b/sdks/dart/offline/README.md
@@ -60,8 +60,10 @@ Snapshots written by the earlier experimental Add implementation remain
 readable for migration only. Opening snapshot schema v1, v2, or v3 converts
 every legacy Add item to an inspectable terminal dead letter with diagnostic
 `unsupported_add`, without incrementing its attempt count, overlaying it on
-reads, or invoking the remote. Schema v4 and later fail closed if they contain
-Add. `retryDeadLetter` rejects a migrated item with
+reads, or invoking the remote. Schema v4 fails closed on Add. Schema v5 accepts
+only the exact terminal `unsupported_add` shape produced by that migration;
+every live or noncanonical Add still fails closed. `retryDeadLetter`
+rejects a migrated item with
 `OfflineUnsupportedOperationException`; applications may inspect it through
 their authorization callback and then retain or delete it. Durable Add can be
 considered again only after #1115 supplies server-authoritative operation
@@ -136,13 +138,28 @@ to admit a new write.
 `InMemoryOfflineStore` is useful for deterministic tests and examples only; it
 does not survive process termination. Production adapters must preserve the
 `OfflineStore` transaction, generation, byte-accounting, lease, and canonical
-codec contracts. Adapter packages can invoke `runStoreConformanceSuite` from
-their own tests. `exportSnapshot` and `InMemoryOfflineStore.fromSnapshot` exist
+codec contracts. Every changed partition—and every durably mutated partition
+such as an LRU-only `touchCache`—must form a complete cache/outbox/operation
+graph before commit. Invalid graphs fail atomically with
+`OfflineDurableGraphException`, publish no state or change notification, and
+must not strand capacity. Cache keys must match their embedded Vertex or Edge,
+negative markers must not end before validation, and every retained outbox item
+must have a request-index-aligned aggregate status whose lifecycle matches.
+Claim/recovery and aggregate status transitions therefore commit together;
+`wipePartition` is the explicit barrier that cancels earlier enqueue
+obligations in the same transaction.
+
+Adapter packages must invoke `runStoreConformanceSuite` from their own tests and
+provide its required `reopen` callback. That callback crosses the adapter's real
+close/reopen persistence boundary under identical limits; every accepted
+commit must survive it. `exportSnapshot` and
+`InMemoryOfflineStore.fromSnapshot` exist
 only for deterministic fresh-process conformance tests; snapshot schema v5
 persists operation aggregates, exact dead-letter transition time, and durable
 auth pause. Restore transactionally reconstructs active v1 metadata, recovers
 auth pause from v1-v4 durable metadata, quarantines legacy Add records only
-from v1-v3, migrates v1-v3 outbox retention metadata conservatively, and fails
+from v1-v3, reopens only that exact terminal quarantine in v5, migrates v1-v3
+outbox retention metadata conservatively, and fails
 closed when cache, outbox, operation, ordinal, generation, lease, or state
 relationships contradict each other. Transaction objects are sealed after both
 commit and rollback. The reference snapshot is not a persistence adapter. The

--- a/sdks/dart/offline/lib/src/conformance.dart
+++ b/sdks/dart/offline/lib/src/conformance.dart
@@ -10,12 +10,24 @@ import 'types.dart';
 /// Creates one empty store instance for the reusable adapter conformance suite.
 typedef OfflineStoreFactory = FutureOr<OfflineStore> Function();
 
+/// Closes and reopens [store] through the adapter's real durable boundary.
+///
+/// The returned store must use the same configured limits and contain exactly
+/// the state committed by [store]. The reference adapter implements this with
+/// its canonical snapshot; a production adapter must close and reopen its own
+/// database.
+typedef OfflineStoreReopener =
+    FutureOr<OfflineStore> Function(OfflineStore store);
+
 /// Runs the storage-neutral transaction, ordering, lease, and wipe contract.
 ///
 /// Adapter packages should invoke this function from their own test runner. It
 /// throws [StateError] with a content-free contract label on any mismatch.
-Future<void> runStoreConformanceSuite(OfflineStoreFactory factory) async {
-  final store = await factory();
+Future<void> runStoreConformanceSuite(
+  OfflineStoreFactory factory, {
+  required OfflineStoreReopener reopen,
+}) async {
+  var store = await factory();
   final now = DateTime.utc(2026, 1, 1);
   const partitionId = 'conformance';
   const operationId = 'operation';
@@ -60,6 +72,165 @@ Future<void> runStoreConformanceSuite(OfflineStoreFactory factory) async {
   } on OfflineTransactionClosedException {
     // Required: an escaped transaction cannot mutate or observe later state.
   }
+
+  await _requireInvalidCommit(
+    store,
+    partitionId,
+    (transaction) => transaction.enqueue(
+      _record(
+        recordId: 'bare-record',
+        operationId: 'bare-operation',
+        itemIndex: 0,
+        key: 'bare',
+        now: now,
+      ),
+    ),
+    'bare_enqueue_graph',
+    (transaction) => transaction.getOutbox(partitionId, 'bare-record') == null,
+  );
+
+  await _requireInvalidCommit(
+    store,
+    partitionId,
+    (transaction) => transaction.putCache(
+      partitionId,
+      OfflineCacheRecord.value(
+        partitionId: partitionId,
+        generation: 0,
+        key: const OfflineEntityKey.vertex('expected'),
+        entity: Vertex(
+          key: 'different',
+          value: VertexValue.nil(),
+          expiration: null,
+        ),
+        validatedAt: now,
+        lastAccessAt: now,
+      ),
+    ),
+    'cache_vertex_identity_graph',
+    (transaction) =>
+        transaction.getCache(
+          partitionId,
+          const OfflineEntityKey.vertex('expected'),
+        ) ==
+        null,
+  );
+  await _requireInvalidCommit(
+    store,
+    partitionId,
+    (transaction) => transaction.putCache(
+      partitionId,
+      OfflineCacheRecord.value(
+        partitionId: partitionId,
+        generation: 0,
+        key: const OfflineEntityKey.edge('tail', 'head'),
+        entity: Edge(
+          tail: 'tail',
+          head: 'different',
+          weight: 1,
+          expiration: null,
+        ),
+        validatedAt: now,
+        lastAccessAt: now,
+      ),
+    ),
+    'cache_edge_identity_graph',
+    (transaction) =>
+        transaction.getCache(
+          partitionId,
+          const OfflineEntityKey.edge('tail', 'head'),
+        ) ==
+        null,
+  );
+  await _requireInvalidCommit(
+    store,
+    partitionId,
+    (transaction) => transaction.putCache(
+      partitionId,
+      OfflineCacheRecord.missing(
+        partitionId: partitionId,
+        generation: 0,
+        key: const OfflineEntityKey.vertex('missing-order'),
+        validatedAt: now,
+        lastAccessAt: now,
+        missingUntil: now.subtract(const Duration(microseconds: 1)),
+      ),
+    ),
+    'cache_missing_order_graph',
+    (transaction) =>
+        transaction.getCache(
+          partitionId,
+          const OfflineEntityKey.vertex('missing-order'),
+        ) ==
+        null,
+  );
+
+  Future<void> requireInvalidExpiredAggregate({
+    required String suffix,
+    required int statusAttemptCount,
+    String? recordDiagnostic,
+    String? statusDiagnostic,
+    required DateTime updatedAt,
+  }) async {
+    final recordId = 'expired-$suffix-record';
+    final expiredOperationId = 'expired-$suffix-operation';
+    await _requireInvalidCommit(
+      store,
+      partitionId,
+      (transaction) {
+        final assigned = transaction.enqueue(
+          _expiredRecord(
+            recordId: recordId,
+            operationId: expiredOperationId,
+            now: now,
+            attemptCount: 2,
+            diagnosticCode: recordDiagnostic,
+          ),
+        );
+        transaction.putOperation(
+          OfflineOperationRecord(
+            partitionId: partitionId,
+            generation: 0,
+            operationId: expiredOperationId,
+            items: <OfflineWriteStatus>[
+              OfflineWriteStatus(
+                recordId: assigned.recordId,
+                operationId: assigned.operationId,
+                itemIndex: assigned.itemIndex,
+                state: OfflineWriteState.expired,
+                attemptCount: statusAttemptCount,
+                diagnosticCode: statusDiagnostic,
+              ),
+            ],
+            updatedAt: updatedAt,
+            terminalAt: updatedAt,
+          ),
+        );
+      },
+      'expired_${suffix}_graph',
+      (transaction) =>
+          transaction.getOutbox(partitionId, recordId) == null &&
+          transaction.getOperation(partitionId, expiredOperationId) == null,
+    );
+  }
+
+  await requireInvalidExpiredAggregate(
+    suffix: 'attempt_mismatch',
+    statusAttemptCount: 1,
+    updatedAt: now,
+  );
+  await requireInvalidExpiredAggregate(
+    suffix: 'diagnostic_mismatch',
+    statusAttemptCount: 2,
+    recordDiagnostic: 'expired_input',
+    statusDiagnostic: 'different',
+    updatedAt: now,
+  );
+  await requireInvalidExpiredAggregate(
+    suffix: 'updated_before_enqueue',
+    statusAttemptCount: 2,
+    updatedAt: now.subtract(const Duration(microseconds: 1)),
+  );
 
   final assigned = await store.transaction((transaction) {
     final records = transaction.enqueueAll(<OfflineOutboxRecord>[
@@ -251,6 +422,29 @@ Future<void> runStoreConformanceSuite(OfflineStoreFactory factory) async {
     return value.value.first == 1;
   });
   _require(ownsBytes, 'defensive_byte_ownership');
+  final touchAt = now.add(const Duration(microseconds: 1));
+  final touchChanges = <OfflineStoreChange>[];
+  final touchSubscription = store.changes(partitionId).listen(touchChanges.add);
+  try {
+    await store.transaction<void>(
+      (transaction) => transaction.touchCache(
+        partitionId,
+        const OfflineEntityKey.vertex('bytes'),
+        touchAt,
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+    final touched = await store.transaction(
+      (transaction) =>
+          transaction
+              .getCache(partitionId, const OfflineEntityKey.vertex('bytes'))!
+              .lastAccessAt ==
+          touchAt,
+    );
+    _require(touched && touchChanges.isEmpty, 'durable_touch_without_change');
+  } finally {
+    await touchSubscription.cancel();
+  }
   _requireClosed(
     () => committed!.deleteOutbox(partitionId, assigned.first.recordId),
     'sealed_commit_mutation',
@@ -390,6 +584,109 @@ Future<void> runStoreConformanceSuite(OfflineStoreFactory factory) async {
   _require(incompleteRolledBack, 'incomplete_operation_rollback');
 
   try {
+    await store.transaction<void>((transaction) {
+      final current = transaction.getOutbox(
+        partitionId,
+        assigned.first.recordId,
+      )!;
+      transaction.updateOutbox(
+        current.copyWith(
+          state: OfflineOutboxState.sending,
+          leaseOwner: 'mismatched-owner',
+          leaseUntil: now.add(const Duration(seconds: 1)),
+        ),
+      );
+    });
+    _require(false, 'outbox_status_mismatch_graph');
+  } on OfflineDurableGraphException {
+    // Required: the outbox lifecycle and operation item are one graph.
+  }
+  final mismatchRolledBack = await store.transaction((transaction) {
+    final record = transaction.getOutbox(partitionId, assigned.first.recordId)!;
+    final operation = transaction.getOperation(partitionId, operationId)!;
+    return record.state == OfflineOutboxState.enqueued &&
+        operation.items.first.state == OfflineWriteState.locallyCommitted;
+  });
+  _require(mismatchRolledBack, 'outbox_status_mismatch_rollback');
+
+  await _requireInvalidCommit(
+    store,
+    partitionId,
+    (transaction) {
+      final current = transaction.getOutbox(
+        partitionId,
+        assigned.first.recordId,
+      )!;
+      transaction.updateOutbox(
+        current.copyWith(diagnosticCode: 'unauthenticated'),
+      );
+      final operation = transaction.getOperation(partitionId, operationId)!;
+      final items = operation.items.toList(growable: false);
+      items[current.itemIndex] = OfflineWriteStatus(
+        recordId: current.recordId,
+        operationId: current.operationId,
+        itemIndex: current.itemIndex,
+        state: OfflineWriteState.pausedForAuth,
+        attemptCount: current.attemptCount,
+        diagnosticCode: 'unauthenticated',
+      );
+      transaction.putOperation(
+        OfflineOperationRecord(
+          partitionId: operation.partitionId,
+          generation: operation.generation,
+          operationId: operation.operationId,
+          items: items,
+          updatedAt: now,
+        ),
+      );
+    },
+    'auth_marker_without_pause_graph',
+    (transaction) {
+      final record = transaction.getOutbox(
+        partitionId,
+        assigned.first.recordId,
+      )!;
+      final operation = transaction.getOperation(partitionId, operationId)!;
+      return !transaction.replayPausedForAuth(partitionId) &&
+          record.diagnosticCode == null &&
+          operation.items.first.state == OfflineWriteState.locallyCommitted;
+    },
+  );
+
+  await _requireInvalidCommit(
+    store,
+    partitionId,
+    (transaction) {
+      final operation = transaction.getOperation(partitionId, operationId)!;
+      final items = operation.items.toList(growable: false);
+      final current = items.first;
+      items[0] = OfflineWriteStatus(
+        recordId: current.recordId,
+        operationId: current.operationId,
+        itemIndex: current.itemIndex,
+        state: OfflineWriteState.pausedForAuth,
+        attemptCount: current.attemptCount,
+      );
+      transaction.putOperation(
+        OfflineOperationRecord(
+          partitionId: operation.partitionId,
+          generation: operation.generation,
+          operationId: operation.operationId,
+          items: items,
+          updatedAt: now,
+        ),
+      );
+    },
+    'auth_state_without_pause_graph',
+    (transaction) {
+      final operation = transaction.getOperation(partitionId, operationId)!;
+      return !transaction.replayPausedForAuth(partitionId) &&
+          operation.items.first.state == OfflineWriteState.locallyCommitted &&
+          operation.items.first.diagnosticCode == null;
+    },
+  );
+
+  try {
     await store.transaction<void>(
       (transaction) => transaction.deleteOperation(partitionId, operationId),
     );
@@ -433,16 +730,108 @@ Future<void> runStoreConformanceSuite(OfflineStoreFactory factory) async {
     );
   });
 
-  final claimed = await store.transaction(
-    (transaction) => transaction.claim(
+  await store.transaction<void>((transaction) {
+    final retry = _enqueueOperation(
+      transaction,
+      _record(
+        recordId: 'retry-record',
+        operationId: 'retry-operation',
+        itemIndex: 0,
+        key: 'retry',
+        now: now,
+      ),
+      now,
+    );
+    transaction.updateOutbox(
+      retry.copyWith(
+        attemptCount: 1,
+        nextAttemptAt: now.add(const Duration(milliseconds: 250)),
+        diagnosticCode: 'unavailable',
+      ),
+    );
+    _putMatchingStatus(
+      transaction,
+      retry,
+      OfflineWriteState.retryScheduled,
+      attemptCount: 1,
+      diagnosticCode: 'unavailable',
+      now: now,
+    );
+
+    final deadLetter = _enqueueOperation(
+      transaction,
+      _record(
+        recordId: 'dead-letter-record',
+        operationId: 'dead-letter-operation',
+        itemIndex: 0,
+        key: 'dead-letter',
+        now: now,
+      ),
+      now,
+    );
+    final terminalAt = now.add(const Duration(microseconds: 1));
+    transaction.updateOutbox(
+      deadLetter.copyWith(
+        state: OfflineOutboxState.deadLetter,
+        deadLetteredAt: terminalAt,
+        diagnosticCode: 'permanent',
+      ),
+    );
+    _putMatchingStatus(
+      transaction,
+      deadLetter,
+      OfflineWriteState.deadLetter,
+      attemptCount: 0,
+      diagnosticCode: 'permanent',
+      now: terminalAt,
+    );
+
+    for (final transition in <({String id, OfflineWriteState state})>[
+      (id: 'confirmed', state: OfflineWriteState.confirmed),
+      (id: 'expired', state: OfflineWriteState.expired),
+    ]) {
+      final record = _enqueueOperation(
+        transaction,
+        _record(
+          recordId: '${transition.id}-record',
+          operationId: '${transition.id}-operation',
+          itemIndex: 0,
+          key: transition.id,
+          now: now,
+        ),
+        now,
+      );
+      _putMatchingStatus(
+        transaction,
+        record,
+        transition.state,
+        attemptCount: 1,
+        now: terminalAt,
+      );
+      transaction.deleteOutbox(partitionId, record.recordId);
+    }
+  });
+
+  final claimed = await store.transaction((transaction) {
+    final records = transaction.claim(
       partitionId,
       owner: 'owner',
       now: now,
       maxAge: const Duration(days: 1),
       leaseDuration: const Duration(seconds: 1),
       limit: 3,
-    ),
-  );
+    );
+    for (final record in records) {
+      _putMatchingStatus(
+        transaction,
+        record,
+        OfflineWriteState.sending,
+        attemptCount: record.attemptCount,
+        now: now,
+      );
+    }
+    return records;
+  });
   _require(claimed.length == 2, 'independent_key_claim');
   final renewed = await store.transaction(
     (transaction) => transaction.renewLease(
@@ -455,6 +844,68 @@ Future<void> runStoreConformanceSuite(OfflineStoreFactory factory) async {
     ),
   );
   _require(renewed, 'lease_cas');
+
+  final recoveryAt = now.add(const Duration(seconds: 2));
+  final recovered = await store.transaction((transaction) {
+    final expiredLeases = transaction
+        .outbox(partitionId)
+        .where(
+          (record) =>
+              record.state == OfflineOutboxState.sending &&
+              record.leaseUntil != null &&
+              !recoveryAt.isBefore(record.leaseUntil!),
+        )
+        .toList(growable: false);
+    for (final record in expiredLeases) {
+      _putMatchingStatus(
+        transaction,
+        record,
+        OfflineWriteState.locallyCommitted,
+        attemptCount: record.attemptCount,
+        now: recoveryAt,
+      );
+    }
+    final reclaimed = transaction.claim(
+      partitionId,
+      owner: 'recovered-owner',
+      now: recoveryAt,
+      maxAge: const Duration(days: 1),
+      leaseDuration: const Duration(seconds: 1),
+      limit: 4,
+    );
+    for (final record in reclaimed) {
+      _putMatchingStatus(
+        transaction,
+        record,
+        OfflineWriteState.sending,
+        attemptCount: record.attemptCount,
+        now: recoveryAt,
+      );
+    }
+    return (expired: expiredLeases, reclaimed: reclaimed);
+  });
+  _require(
+    recovered.expired.length == 2 && recovered.reclaimed.length == 3,
+    'expired_lease_recovery_and_retry_reclaim',
+  );
+
+  store = await reopen(store);
+  final restartSafe = await store.transaction((transaction) {
+    final cache = transaction.getCache(
+      partitionId,
+      const OfflineEntityKey.vertex('bytes'),
+    );
+    final operation = transaction.getOperation(partitionId, operationId);
+    return cache != null &&
+        cache.lastAccessAt == touchAt &&
+        operation != null &&
+        transaction.getOutbox(partitionId, 'dead-letter-record')?.state ==
+            OfflineOutboxState.deadLetter &&
+        transaction.getOutbox(partitionId, 'confirmed-record') == null &&
+        transaction.getOutbox(partitionId, 'expired-record') == null &&
+        transaction.outbox(partitionId).length == 5;
+  });
+  _require(restartSafe, 'successful_commits_reopen_same_limits');
 
   await store.transaction<void>(
     (transaction) => transaction.setReplayPausedForAuth(partitionId, true),
@@ -512,6 +963,96 @@ OfflineOutboxRecord _record({
   generation: 0,
 );
 
+OfflineOutboxRecord _expiredRecord({
+  required String recordId,
+  required String operationId,
+  required DateTime now,
+  required int attemptCount,
+  String? diagnosticCode,
+}) => OfflineOutboxRecord(
+  recordId: recordId,
+  operationId: operationId,
+  itemIndex: 0,
+  partitionId: 'conformance',
+  intent: OfflinePutVertexIntent(
+    Vertex(key: recordId, value: VertexValue.nil(), expiration: now),
+  ),
+  enqueuedAt: now,
+  ordinal: 0,
+  state: OfflineOutboxState.expired,
+  attemptCount: attemptCount,
+  generation: 0,
+  diagnosticCode: diagnosticCode,
+);
+
+OfflineOutboxRecord _enqueueOperation(
+  OfflineStoreTransaction transaction,
+  OfflineOutboxRecord record,
+  DateTime now,
+) {
+  final assigned = transaction.enqueue(record);
+  transaction.putOperation(
+    OfflineOperationRecord(
+      partitionId: assigned.partitionId,
+      generation: assigned.generation,
+      operationId: assigned.operationId,
+      items: <OfflineWriteStatus>[
+        OfflineWriteStatus(
+          recordId: assigned.recordId,
+          operationId: assigned.operationId,
+          itemIndex: assigned.itemIndex,
+          state: OfflineWriteState.locallyCommitted,
+          attemptCount: assigned.attemptCount,
+        ),
+      ],
+      updatedAt: now,
+    ),
+  );
+  return assigned;
+}
+
+void _putMatchingStatus(
+  OfflineStoreTransaction transaction,
+  OfflineOutboxRecord outbox,
+  OfflineWriteState state, {
+  required int attemptCount,
+  required DateTime now,
+  String? diagnosticCode,
+}) {
+  final operation = transaction.getOperation(
+    outbox.partitionId,
+    outbox.operationId,
+  )!;
+  final items = operation.items.toList(growable: false);
+  items[outbox.itemIndex] = OfflineWriteStatus(
+    recordId: outbox.recordId,
+    operationId: outbox.operationId,
+    itemIndex: outbox.itemIndex,
+    state: state,
+    attemptCount: attemptCount,
+    diagnosticCode: diagnosticCode,
+  );
+  final status = OfflineOperationStatus(
+    operationId: operation.operationId,
+    items: items,
+  );
+  final updatedAt = <DateTime>[
+    operation.updatedAt,
+    outbox.enqueuedAt,
+    now,
+  ].reduce((latest, value) => value.isAfter(latest) ? value : latest);
+  transaction.putOperation(
+    OfflineOperationRecord(
+      partitionId: operation.partitionId,
+      generation: operation.generation,
+      operationId: operation.operationId,
+      items: items,
+      updatedAt: updatedAt,
+      terminalAt: status.isTerminal ? operation.terminalAt ?? updatedAt : null,
+    ),
+  );
+}
+
 void _require(bool condition, String label) {
   if (!condition) throw StateError('offline_store_conformance:$label');
 }
@@ -527,4 +1068,41 @@ void _requireClosed(void Function() action, String label) {
 
 final class _ConformanceRollback implements Exception {
   const _ConformanceRollback();
+}
+
+Future<void> _requireInvalidCommit(
+  OfflineStore store,
+  String partitionId,
+  void Function(OfflineStoreTransaction transaction) mutate,
+  String label,
+  bool Function(OfflineStoreTransaction transaction) unchanged,
+) async {
+  final before = await store.transaction(
+    (transaction) => (
+      generation: transaction.generation(partitionId),
+      outboxCount: transaction.outbox(partitionId).length,
+      operationCount: transaction.operations(partitionId).length,
+    ),
+  );
+  final changes = <OfflineStoreChange>[];
+  final subscription = store.changes(partitionId).listen(changes.add);
+  try {
+    try {
+      await store.transaction<void>(mutate);
+      _require(false, label);
+    } on OfflineDurableGraphException {
+      // Required.
+    }
+    await Future<void>.delayed(Duration.zero);
+    final preserved = await store.transaction(
+      (transaction) =>
+          unchanged(transaction) &&
+          transaction.generation(partitionId) == before.generation &&
+          transaction.outbox(partitionId).length == before.outboxCount &&
+          transaction.operations(partitionId).length == before.operationCount,
+    );
+    _require(preserved && changes.isEmpty, '${label}_atomic');
+  } finally {
+    await subscription.cancel();
+  }
 }

--- a/sdks/dart/offline/lib/src/errors.dart
+++ b/sdks/dart/offline/lib/src/errors.dart
@@ -71,6 +71,15 @@ final class OfflineTransactionClosedException extends OfflineException {
   const OfflineTransactionClosedException() : super('transaction_closed');
 }
 
+/// A successful transaction callback produced an inconsistent durable graph.
+///
+/// Stores must reject the entire commit without publishing state or change
+/// notifications when this failure is raised.
+final class OfflineDurableGraphException extends OfflineException {
+  /// Creates a fail-closed durable-graph failure.
+  const OfflineDurableGraphException() : super('durable_graph');
+}
+
 /// A caller is not authorized to inspect a sensitive dead-letter intent.
 final class OfflineAuthorizationException extends OfflineException {
   /// Creates an authorization failure.

--- a/sdks/dart/offline/lib/src/memory_store.dart
+++ b/sdks/dart/offline/lib/src/memory_store.dart
@@ -105,6 +105,17 @@ final class InMemoryOfflineStore implements OfflineStore {
       } finally {
         transaction._seal();
       }
+      for (final partitionId in <String>{
+        ...transaction._changedPartitions,
+        ...transaction._mutatedPartitions,
+      }) {
+        final partition = state.partition(partitionId);
+        _validateCommittedPartition(
+          partitionId,
+          partition,
+          transaction._enqueuedOperations[partitionId] ?? const {},
+        );
+      }
       for (final partitionId in transaction._changedPartitions) {
         final partition = state.partition(partitionId);
         partition.version = _checkedIncrement(partition.version);
@@ -143,6 +154,9 @@ final class _MemoryTransaction implements OfflineStoreTransaction {
   final _MemoryState _state;
   final OfflineStoreLimits _limits;
   final Set<String> _changedPartitions = <String>{};
+  final Set<String> _mutatedPartitions = <String>{};
+  final Map<String, Map<String, List<OfflineOutboxRecord>>>
+  _enqueuedOperations = <String, Map<String, List<OfflineOutboxRecord>>>{};
   var _sealed = false;
 
   void _seal() => _sealed = true;
@@ -227,6 +241,7 @@ final class _MemoryTransaction implements OfflineStoreTransaction {
     final record = partition.cache[key.canonical];
     if (record != null) {
       partition.cache[key.canonical] = record.accessedAt(accessedAt);
+      _mutatedPartitions.add(partitionId);
     }
   }
 
@@ -400,9 +415,15 @@ final class _MemoryTransaction implements OfflineStoreTransaction {
     final operationId = records.first.operationId;
     _validatePartition(partitionId);
     final partition = _state.partition(partitionId);
+    final pendingOperations = _enqueuedOperations[partitionId];
+    final pendingRecordIds = pendingOperations?.values
+        .expand((records) => records)
+        .map((record) => record.recordId)
+        .toSet();
     final recordIds = <String>{};
     if (partition.operations.containsKey(operationId) ||
-        (partition.outboxByOperation[operationId]?.isNotEmpty ?? false)) {
+        (partition.outboxByOperation[operationId]?.isNotEmpty ?? false) ||
+        (pendingOperations?.containsKey(operationId) ?? false)) {
       throw const OfflineIdentityConflictException(
         OfflineIdentityKind.operation,
       );
@@ -413,6 +434,7 @@ final class _MemoryTransaction implements OfflineStoreTransaction {
         throw const OfflineUnsupportedOperationException();
       }
       if (_recordIdExists(partition, record.recordId) ||
+          (pendingRecordIds?.contains(record.recordId) ?? false) ||
           !recordIds.add(record.recordId)) {
         throw const OfflineIdentityConflictException(
           OfflineIdentityKind.record,
@@ -469,6 +491,10 @@ final class _MemoryTransaction implements OfflineStoreTransaction {
     for (final record in retained) {
       partition.putOutbox(record);
     }
+    (_enqueuedOperations[partitionId] ??=
+        <String, List<OfflineOutboxRecord>>{})[operationId] = assigned
+        .map(_copyOutboxRecord)
+        .toList(growable: false);
     _changedPartitions.add(partitionId);
     return assigned.map(_copyOutboxRecord).toList(growable: false);
   }
@@ -656,6 +682,8 @@ final class _MemoryTransaction implements OfflineStoreTransaction {
   T _atomicMutation<T>(T Function() action) {
     final previousState = _state.copy();
     final previousChanges = Set<String>.of(_changedPartitions);
+    final previousMutations = Set<String>.of(_mutatedPartitions);
+    final previousEnqueues = _copyEnqueuedOperations(_enqueuedOperations);
     try {
       return action();
     } catch (_) {
@@ -665,6 +693,12 @@ final class _MemoryTransaction implements OfflineStoreTransaction {
       _changedPartitions
         ..clear()
         ..addAll(previousChanges);
+      _mutatedPartitions
+        ..clear()
+        ..addAll(previousMutations);
+      _enqueuedOperations
+        ..clear()
+        ..addAll(previousEnqueues);
       rethrow;
     }
   }
@@ -701,7 +735,6 @@ final class _MemoryTransaction implements OfflineStoreTransaction {
       throw const OfflineArgumentException();
     }
     final leaseUntil = _durableDeadline(now, leaseDuration);
-    if (leaseUntil == null) return const <OfflineOutboxRecord>[];
     _validateLeaseOwnerCapacity(owner, _limits);
     final partition = _state.partition(partitionId);
     if (partition.replayPausedForAuth) {
@@ -717,9 +750,14 @@ final class _MemoryTransaction implements OfflineStoreTransaction {
           state: OfflineOutboxState.enqueued,
           clearLeaseOwner: true,
           clearLeaseUntil: true,
+          clearDiagnosticCode: true,
         );
         changed = true;
       }
+    }
+    if (leaseUntil == null) {
+      if (changed) _changedPartitions.add(partitionId);
+      return const <OfflineOutboxRecord>[];
     }
     final live = partition.outbox.values.toList()..sort(_compareOutbox);
     final blockedKeys = <String>{};
@@ -750,6 +788,7 @@ final class _MemoryTransaction implements OfflineStoreTransaction {
         clearNextAttemptAt: true,
         leaseOwner: owner,
         leaseUntil: leaseUntil,
+        clearDiagnosticCode: true,
       );
       _validateOutboxLifecycleCapacity(claimedRecord, _limits);
       partition.outbox[record.recordId] = claimedRecord;
@@ -814,6 +853,7 @@ final class _MemoryTransaction implements OfflineStoreTransaction {
         _MemoryPartition(generation: _checkedIncrement(previous.generation))
           ..version = previous.version
           ..nextOrdinal = previous.nextOrdinal;
+    _enqueuedOperations.remove(partitionId);
     _changedPartitions.add(partitionId);
   }
 
@@ -1729,7 +1769,10 @@ _MemoryState _decodeMemoryState(String source, OfflineStoreLimits limits) {
       var largestOrdinal = 0;
       for (final item in outbox) {
         final decodedRecord = OfflineCodec.decodeOutboxRecord(item);
-        if (schema >= 4 && decodedRecord.intent is OfflineAddEdgeIntent) {
+        if (decodedRecord.intent is OfflineAddEdgeIntent &&
+            (schema == 4 ||
+                (schema == InMemoryOfflineStore.snapshotSchemaVersion &&
+                    !_isQuarantinedLegacyAdd(decodedRecord)))) {
           throw const OfflineCodecException();
         }
         final record = schema < 4
@@ -1781,6 +1824,8 @@ _MemoryState _decodeMemoryState(String source, OfflineStoreLimits limits) {
       if (schema < InMemoryOfflineStore.snapshotSchemaVersion) {
         _migrateReplayAuthPause(partition);
       }
+      _validateCacheGraph(partitionId, partition);
+      _validateCurrentPartitionIdentity(partitionId, partition);
       _validatePartitionGraph(partition, legacySnapshot: schema < 4);
       if (schema == InMemoryOfflineStore.snapshotSchemaVersion &&
           !partition.replayPausedForAuth &&
@@ -1899,6 +1944,137 @@ void _validatePartitionGraph(
   }
 }
 
+void _validateCommittedPartition(
+  String partitionId,
+  _MemoryPartition partition,
+  Map<String, List<OfflineOutboxRecord>> enqueuedOperations,
+) {
+  try {
+    _validateCacheGraph(partitionId, partition);
+    _validateCurrentPartitionIdentity(partitionId, partition);
+    _validatePartitionGraph(partition, legacySnapshot: false);
+    _validateEnqueuedTopologies(partition, enqueuedOperations);
+    if (!partition.replayPausedForAuth &&
+        _hasReplayAuthPauseMarker(partition)) {
+      throw const OfflineCodecException();
+    }
+  } on OfflineDurableGraphException {
+    rethrow;
+  } catch (_) {
+    throw const OfflineDurableGraphException();
+  }
+}
+
+void _validateEnqueuedTopologies(
+  _MemoryPartition partition,
+  Map<String, List<OfflineOutboxRecord>> enqueuedOperations,
+) {
+  for (final entry in enqueuedOperations.entries) {
+    final operation = partition.operations[entry.key];
+    final records = entry.value;
+    if (operation == null || operation.items.length != records.length) {
+      throw const OfflineCodecException();
+    }
+    for (var index = 0; index < records.length; index++) {
+      final record = records[index];
+      final item = operation.items[index];
+      if (record.itemIndex != index ||
+          item.recordId != record.recordId ||
+          item.operationId != record.operationId ||
+          item.itemIndex != index ||
+          operation.updatedAt.isBefore(record.enqueuedAt) ||
+          (operation.terminalAt?.isBefore(record.enqueuedAt) ?? false) ||
+          (record.state == OfflineOutboxState.expired &&
+              (item.state != OfflineWriteState.expired ||
+                  item.attemptCount != record.attemptCount ||
+                  item.diagnosticCode != record.diagnosticCode))) {
+        throw const OfflineCodecException();
+      }
+    }
+  }
+}
+
+Map<String, Map<String, List<OfflineOutboxRecord>>> _copyEnqueuedOperations(
+  Map<String, Map<String, List<OfflineOutboxRecord>>> source,
+) => source.map(
+  (partitionId, operations) => MapEntry(
+    partitionId,
+    operations.map(
+      (operationId, records) => MapEntry(
+        operationId,
+        records.map(_copyOutboxRecord).toList(growable: false),
+      ),
+    ),
+  ),
+);
+
+void _validateCacheGraph(String partitionId, _MemoryPartition partition) {
+  for (final entry in partition.cache.entries) {
+    final record = entry.value;
+    if (entry.key != record.key.canonical ||
+        record.partitionId != partitionId ||
+        record.generation != partition.generation) {
+      throw const OfflineCodecException();
+    }
+    final vertex = record.vertex;
+    final edge = record.edge;
+    if (record.isMissing) {
+      if (vertex != null ||
+          edge != null ||
+          record.missingUntil!.isBefore(record.validatedAt)) {
+        throw const OfflineCodecException();
+      }
+      continue;
+    }
+    final identityMatches = switch (record.key.kind) {
+      OfflineEntityKind.vertex =>
+        vertex != null && edge == null && record.key.vertexKey == vertex.key,
+      OfflineEntityKind.edge =>
+        edge != null &&
+            vertex == null &&
+            record.key.tail == edge.tail &&
+            record.key.head == edge.head,
+    };
+    if (!identityMatches) throw const OfflineCodecException();
+  }
+}
+
+void _validateCurrentPartitionIdentity(
+  String partitionId,
+  _MemoryPartition partition,
+) {
+  for (final entry in partition.outbox.entries) {
+    final record = entry.value;
+    if (entry.key != record.recordId ||
+        record.partitionId != partitionId ||
+        record.generation != partition.generation ||
+        record.ordinal > partition.nextOrdinal) {
+      throw const OfflineCodecException();
+    }
+    if (record.intent is OfflineAddEdgeIntent &&
+        !_isQuarantinedLegacyAdd(record)) {
+      throw const OfflineCodecException();
+    }
+  }
+  for (final entry in partition.operations.entries) {
+    final operation = entry.value;
+    if (entry.key != operation.operationId ||
+        operation.partitionId != partitionId ||
+        operation.generation != partition.generation) {
+      throw const OfflineCodecException();
+    }
+  }
+}
+
+bool _isQuarantinedLegacyAdd(OfflineOutboxRecord record) =>
+    record.intent is OfflineAddEdgeIntent &&
+    record.state == OfflineOutboxState.deadLetter &&
+    record.nextAttemptAt == null &&
+    record.leaseOwner == null &&
+    record.leaseUntil == null &&
+    record.deadLetteredAt != null &&
+    record.diagnosticCode == 'unsupported_add';
+
 bool _terminalWriteState(OfflineWriteState state) =>
     state == OfflineWriteState.confirmed ||
     state == OfflineWriteState.deadLetter ||
@@ -1922,7 +2098,8 @@ bool _outboxStatusMatches(
               (record.nextAttemptAt != null) &&
           (status.state == OfflineWriteState.locallyCommitted ||
               status.state == OfflineWriteState.retryScheduled ||
-              status.state == OfflineWriteState.pausedForAuth),
+              (status.state == OfflineWriteState.pausedForAuth &&
+                  record.diagnosticCode == 'unauthenticated')),
     OfflineOutboxState.sending => status.state == OfflineWriteState.sending,
     OfflineOutboxState.deadLetter =>
       status.state == OfflineWriteState.deadLetter,
@@ -1963,8 +2140,7 @@ bool _hasReplayAuthPauseMarker(_MemoryPartition partition) {
     }
     final status = operation.items[record.itemIndex];
     if (record.diagnosticCode == 'unauthenticated' ||
-        (status.state == OfflineWriteState.pausedForAuth &&
-            status.diagnosticCode == 'unauthenticated')) {
+        status.state == OfflineWriteState.pausedForAuth) {
       return true;
     }
   }

--- a/sdks/dart/offline/lib/src/store.dart
+++ b/sdks/dart/offline/lib/src/store.dart
@@ -6,12 +6,19 @@ import 'types.dart';
 /// Storage-neutral transaction port used by [OfflineLanternRepository].
 ///
 /// Implementations must serialize transactions and expose their effects only
-/// after the callback completes successfully. A transaction must provide
-/// defensive ownership for mutable bytes. Partition identifiers are local
-/// persistence namespaces; adapters must never treat them as server-side auth
-/// or tenant boundaries.
+/// after the callback completes successfully. Before publishing any changed
+/// partition, implementations must validate its complete cache/outbox/operation
+/// graph and reject an inconsistent commit atomically with
+/// [OfflineDurableGraphException]. A transaction must provide defensive
+/// ownership for mutable bytes. Partition identifiers are local persistence
+/// namespaces; adapters must never treat them as server-side auth or tenant
+/// boundaries.
 abstract interface class OfflineStore {
   /// Runs [action] against one serializable transaction.
+  ///
+  /// A callback that returns successfully can still fail at commit with
+  /// [OfflineDurableGraphException]. In that case no state or change event may
+  /// escape the transaction.
   Future<T> transaction<T>(
     FutureOr<T> Function(OfflineStoreTransaction transaction) action,
   );
@@ -152,6 +159,9 @@ abstract interface class OfflineStoreTransaction {
 
   /// Claims FIFO-ready records on independent ordering keys with bounded leases.
   /// The public [owner] is subject to the adapter's explicit UTF-8 byte bound.
+  /// The same transaction must advance each claimed aggregate item to
+  /// [OfflineWriteState.sending], and must advance any expired lease recovered
+  /// by the call back to a matching non-terminal status before commit.
   List<OfflineOutboxRecord> claim(
     String partitionId, {
     required String owner,
@@ -173,6 +183,8 @@ abstract interface class OfflineStoreTransaction {
   });
 
   /// Transactionally deletes every partition record and increments generation.
+  /// This is an explicit barrier that cancels enqueue-topology obligations
+  /// created earlier in the same transaction.
   void wipePartition(String partitionId);
 }
 

--- a/sdks/dart/offline/lib/src/types.dart
+++ b/sdks/dart/offline/lib/src/types.dart
@@ -133,6 +133,10 @@ final class OfflineEntityKey {
 }
 
 /// A cache record holding either an exact entity or a bounded negative marker.
+///
+/// Constructors validate field shape and durable timestamp representation.
+/// Entity identity and negative-marker ordering are durable graph invariants:
+/// an [OfflineStore] must validate them atomically at commit.
 final class OfflineCacheRecord {
   /// Creates an exact confirmed cache record.
   OfflineCacheRecord.value({

--- a/sdks/dart/offline/test/memory_store_test.dart
+++ b/sdks/dart/offline/test/memory_store_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
@@ -26,6 +27,87 @@ void main() {
     generation: 0,
   );
 
+  void putInitialOperation(
+    OfflineStoreTransaction transaction,
+    List<OfflineOutboxRecord> records, {
+    List<OfflineWriteState>? states,
+  }) {
+    final writeStates =
+        states ??
+        List<OfflineWriteState>.filled(
+          records.length,
+          OfflineWriteState.locallyCommitted,
+        );
+    final items = <OfflineWriteStatus>[
+      for (var index = 0; index < records.length; index++)
+        OfflineWriteStatus(
+          recordId: records[index].recordId,
+          operationId: records[index].operationId,
+          itemIndex: records[index].itemIndex,
+          state: writeStates[index],
+          attemptCount: records[index].attemptCount,
+        ),
+    ];
+    final status = OfflineOperationStatus(
+      operationId: records.first.operationId,
+      items: items,
+    );
+    transaction.putOperation(
+      OfflineOperationRecord(
+        partitionId: records.first.partitionId,
+        generation: records.first.generation,
+        operationId: records.first.operationId,
+        items: items,
+        updatedAt: now,
+        terminalAt: status.isTerminal ? now : null,
+      ),
+    );
+  }
+
+  OfflineOutboxRecord enqueueOperation(
+    OfflineStoreTransaction transaction,
+    OfflineOutboxRecord input,
+  ) {
+    final assigned = transaction.enqueue(input);
+    putInitialOperation(transaction, <OfflineOutboxRecord>[assigned]);
+    return assigned;
+  }
+
+  void putStatus(
+    OfflineStoreTransaction transaction,
+    OfflineOutboxRecord record,
+    OfflineWriteState state, {
+    required DateTime updatedAt,
+  }) {
+    final operation = transaction.getOperation(
+      record.partitionId,
+      record.operationId,
+    )!;
+    final items = operation.items.toList(growable: false);
+    items[record.itemIndex] = OfflineWriteStatus(
+      recordId: record.recordId,
+      operationId: record.operationId,
+      itemIndex: record.itemIndex,
+      state: state,
+      attemptCount: record.attemptCount,
+      diagnosticCode: record.diagnosticCode,
+    );
+    final status = OfflineOperationStatus(
+      operationId: operation.operationId,
+      items: items,
+    );
+    transaction.putOperation(
+      OfflineOperationRecord(
+        partitionId: operation.partitionId,
+        generation: operation.generation,
+        operationId: operation.operationId,
+        items: items,
+        updatedAt: updatedAt,
+        terminalAt: status.isTerminal ? updatedAt : null,
+      ),
+    );
+  }
+
   test('transactions are atomic and assign monotone ordinals', () async {
     final store = InMemoryOfflineStore();
     await expectLater(
@@ -40,7 +122,7 @@ void main() {
       isEmpty,
     );
     final assigned = await store.transaction(
-      (transaction) => transaction.enqueue(record('kept', 'a')),
+      (transaction) => enqueueOperation(transaction, record('kept', 'a')),
     );
     expect(assigned.ordinal, 1);
   });
@@ -50,7 +132,7 @@ void main() {
     late OfflineStoreTransaction escaped;
     await store.transaction<void>((transaction) {
       escaped = transaction;
-      transaction.enqueue(record('committed', 'a'));
+      enqueueOperation(transaction, record('committed', 'a'));
     });
 
     expect(
@@ -106,20 +188,29 @@ void main() {
     () async {
       final store = InMemoryOfflineStore();
       await store.transaction((transaction) {
-        transaction.enqueue(record('one', 'a'));
-        transaction.enqueue(record('two', 'a'));
-        transaction.enqueue(record('three', 'b'));
+        enqueueOperation(transaction, record('one', 'a'));
+        enqueueOperation(transaction, record('two', 'a'));
+        enqueueOperation(transaction, record('three', 'b'));
       });
-      final first = await store.transaction(
-        (transaction) => transaction.claim(
+      final first = await store.transaction((transaction) {
+        final claimed = transaction.claim(
           'p',
           owner: 'owner',
           now: now,
           maxAge: const Duration(days: 1),
           leaseDuration: const Duration(seconds: 1),
           limit: 2,
-        ),
-      );
+        );
+        for (final record in claimed) {
+          putStatus(
+            transaction,
+            record,
+            OfflineWriteState.sending,
+            updatedAt: now,
+          );
+        }
+        return claimed;
+      });
       expect(first.map((item) => item.recordId), <String>['one', 'three']);
       final blocked = await store.transaction(
         (transaction) => transaction.claim(
@@ -132,31 +223,78 @@ void main() {
         ),
       );
       expect(blocked, isEmpty);
-      final recovered = await store.transaction(
-        (transaction) => transaction.claim(
+      final recovered = await store.transaction((transaction) {
+        final recoveredAt = now.add(const Duration(seconds: 1));
+        for (final record
+            in transaction
+                .outbox('p')
+                .where(
+                  (record) => record.state == OfflineOutboxState.sending,
+                )) {
+          putStatus(
+            transaction,
+            record,
+            OfflineWriteState.locallyCommitted,
+            updatedAt: recoveredAt,
+          );
+        }
+        final claimed = transaction.claim(
           'p',
           owner: 'recovered',
-          now: now.add(const Duration(seconds: 1)),
+          now: recoveredAt,
           maxAge: const Duration(days: 1),
           leaseDuration: const Duration(seconds: 1),
           limit: 2,
-        ),
-      );
+        );
+        for (final record in claimed) {
+          putStatus(
+            transaction,
+            record,
+            OfflineWriteState.sending,
+            updatedAt: recoveredAt,
+          );
+        }
+        return claimed;
+      });
       expect(recovered.map((item) => item.recordId), <String>['one', 'three']);
       await store.transaction((transaction) {
+        final first = transaction.getOutbox('p', 'one')!;
+        final third = transaction.getOutbox('p', 'three')!;
+        putStatus(
+          transaction,
+          first,
+          OfflineWriteState.confirmed,
+          updatedAt: now.add(const Duration(seconds: 1)),
+        );
+        putStatus(
+          transaction,
+          third,
+          OfflineWriteState.confirmed,
+          updatedAt: now.add(const Duration(seconds: 1)),
+        );
         transaction.deleteOutbox('p', 'one');
         transaction.deleteOutbox('p', 'three');
       });
-      final next = await store.transaction(
-        (transaction) => transaction.claim(
+      final next = await store.transaction((transaction) {
+        final claimedAt = now.add(const Duration(seconds: 2));
+        final claimed = transaction.claim(
           'p',
           owner: 'next',
-          now: now.add(const Duration(seconds: 2)),
+          now: claimedAt,
           maxAge: const Duration(days: 1),
           leaseDuration: const Duration(seconds: 1),
           limit: 2,
-        ),
-      );
+        );
+        for (final record in claimed) {
+          putStatus(
+            transaction,
+            record,
+            OfflineWriteState.sending,
+            updatedAt: claimedAt,
+          );
+        }
+        return claimed;
+      });
       expect(next.single.recordId, 'two');
     },
   );
@@ -325,20 +463,33 @@ void main() {
       isTrue,
     );
     expect(
-      await store.transaction(
-        (transaction) => transaction.claim(
+      await store.transaction((transaction) {
+        final current = transaction.getOutbox('p', assigned.recordId)!;
+        putStatus(
+          transaction,
+          current,
+          OfflineWriteState.locallyCommitted,
+          updatedAt: maximum,
+        );
+        return transaction.claim(
           'p',
           owner: 'other',
           now: maximum,
           maxAge: const Duration(days: 1),
           leaseDuration: const Duration(seconds: 1),
           limit: 1,
-        ),
-      ),
+        );
+      }),
       isEmpty,
     );
     final snapshot = await store.exportSnapshot();
-    expect(() => InMemoryOfflineStore.fromSnapshot(snapshot), returnsNormally);
+    final reopened = InMemoryOfflineStore.fromSnapshot(snapshot);
+    expect(
+      await reopened.transaction(
+        (transaction) => transaction.getOutbox('p', assigned.recordId)!.state,
+      ),
+      OfflineOutboxState.enqueued,
+    );
   });
 
   test(
@@ -383,7 +534,7 @@ void main() {
             lastAccessAt: now.add(const Duration(seconds: 1)),
           ),
         );
-        transaction.enqueue(record('one', 'one'));
+        enqueueOperation(transaction, record('one', 'one'));
       });
       expect(
         await store.transaction(
@@ -841,7 +992,7 @@ void main() {
       isNull,
     );
     await store.transaction((transaction) {
-      transaction.enqueue(
+      final assigned = transaction.enqueue(
         OfflineOutboxRecord(
           recordId: 'a',
           operationId: 'op-a',
@@ -857,6 +1008,7 @@ void main() {
           generation: 0,
         ),
       );
+      putInitialOperation(transaction, <OfflineOutboxRecord>[assigned]);
     });
     await expectLater(
       store.transaction((transaction) {
@@ -905,12 +1057,14 @@ void main() {
       attemptCount: 0,
       generation: 0,
     );
-    final assigned = await store.transaction(
-      (transaction) => transaction.enqueueAll(<OfflineOutboxRecord>[
+    final assigned = await store.transaction((transaction) {
+      final records = transaction.enqueueAll(<OfflineOutboxRecord>[
         item(0, 'a'),
         item(1, 'b'),
-      ]),
-    );
+      ]);
+      putInitialOperation(transaction, records);
+      return records;
+    });
     expect(assigned.map((record) => record.ordinal), everyElement(1));
     expect(assigned.map((record) => record.itemIndex), <int>[0, 1]);
 
@@ -929,70 +1083,239 @@ void main() {
     );
   });
 
-  test('new legacy Add enqueue and schema-v4+ restore fail closed', () async {
-    final legacy = OfflineOutboxRecord(
-      recordId: 'legacy-add-rejected',
-      operationId: 'legacy-add-operation',
-      itemIndex: 0,
+  test('commit validation retains full expired enqueue topology', () async {
+    OfflineOutboxRecord item(
+      String recordId,
+      String operationId,
+      int itemIndex,
+      OfflineOutboxState state,
+    ) => OfflineOutboxRecord(
+      recordId: recordId,
+      operationId: operationId,
+      itemIndex: itemIndex,
       partitionId: 'p',
-      intent: OfflineAddEdgeIntent(
-        Edge(tail: 'a', head: 'b', weight: 1, expiration: null),
-        Uint8List.fromList(List<int>.filled(24, 1)),
+      intent: OfflinePutVertexIntent(
+        Vertex(
+          key: recordId,
+          value: VertexValue.nil(),
+          expiration: state == OfflineOutboxState.expired ? now : null,
+        ),
       ),
       enqueuedAt: now,
-      ordinal: 1,
-      state: OfflineOutboxState.enqueued,
+      ordinal: 0,
+      state: state,
       attemptCount: 0,
       generation: 0,
     );
-    final operation = OfflineOperationRecord(
-      partitionId: 'p',
-      generation: 0,
-      operationId: legacy.operationId,
-      items: <OfflineWriteStatus>[
-        OfflineWriteStatus(
-          recordId: legacy.recordId,
-          operationId: legacy.operationId,
-          itemIndex: 0,
-          state: OfflineWriteState.locallyCommitted,
-          attemptCount: 0,
-        ),
-      ],
-      updatedAt: now,
-    );
+
     final store = InMemoryOfflineStore();
     final before = await store.exportSnapshot();
     await expectLater(
-      store.transaction<void>((transaction) => transaction.enqueue(legacy)),
-      throwsA(isA<OfflineUnsupportedOperationException>()),
+      store.transaction<void>((transaction) {
+        final records = transaction.enqueueAll(<OfflineOutboxRecord>[
+          item('mixed-live', 'mixed', 0, OfflineOutboxState.enqueued),
+          item('mixed-expired', 'mixed', 1, OfflineOutboxState.expired),
+        ]);
+        putInitialOperation(
+          transaction,
+          records.take(1).toList(growable: false),
+        );
+      }),
+      throwsA(isA<OfflineDurableGraphException>()),
     );
     expect(await store.exportSnapshot(), before);
 
-    final encoded =
-        jsonDecode(
-              encodeLegacySnapshot(
-                schema: 3,
-                outbox: <OfflineOutboxRecord>[legacy],
-                operations: <OfflineOperationRecord>[operation],
-              ),
-            )
-            as Map<String, Object?>;
-    for (final schema in <int>[4, InMemoryOfflineStore.snapshotSchemaVersion]) {
-      final candidate = jsonDecode(jsonEncode(encoded)) as Map<String, Object?>;
-      candidate['schema'] = schema;
-      if (schema == InMemoryOfflineStore.snapshotSchemaVersion) {
-        final partition =
-            (candidate['partitions']! as List<Object?>).single!
-                as Map<String, Object?>;
-        partition['replayPausedForAuth'] = false;
-      }
-      expect(
-        () => InMemoryOfflineStore.fromSnapshot(jsonEncode(candidate)),
-        throwsA(isA<OfflineCodecException>()),
-        reason: 'schema v$schema must never migrate Add',
+    await expectLater(
+      store.transaction<void>((transaction) {
+        transaction.enqueueAll(<OfflineOutboxRecord>[
+          item('all-expired-0', 'all-expired', 0, OfflineOutboxState.expired),
+          item('all-expired-1', 'all-expired', 1, OfflineOutboxState.expired),
+        ]);
+      }),
+      throwsA(isA<OfflineDurableGraphException>()),
+    );
+    expect(await store.exportSnapshot(), before);
+
+    final assigned = await store.transaction((transaction) {
+      final records = transaction.enqueueAll(<OfflineOutboxRecord>[
+        item('valid-live', 'valid', 0, OfflineOutboxState.enqueued),
+        item('valid-expired', 'valid', 1, OfflineOutboxState.expired),
+      ]);
+      putInitialOperation(
+        transaction,
+        records,
+        states: const <OfflineWriteState>[
+          OfflineWriteState.locallyCommitted,
+          OfflineWriteState.expired,
+        ],
       );
-    }
+      return records;
+    });
+    expect(assigned, hasLength(2));
+    expect(
+      await store.transaction((transaction) => transaction.outbox('p')),
+      hasLength(1),
+    );
+    final snapshot = await store.exportSnapshot();
+    expect(() => InMemoryOfflineStore.fromSnapshot(snapshot), returnsNormally);
   });
+
+  test('pending expired enqueue identities cannot be replaced', () async {
+    OfflineOutboxRecord expired(
+      String recordId,
+      String operationId,
+      int itemIndex,
+    ) => OfflineOutboxRecord(
+      recordId: recordId,
+      operationId: operationId,
+      itemIndex: itemIndex,
+      partitionId: 'p',
+      intent: OfflinePutVertexIntent(
+        Vertex(key: recordId, value: VertexValue.nil(), expiration: now),
+      ),
+      enqueuedAt: now,
+      ordinal: 0,
+      state: OfflineOutboxState.expired,
+      attemptCount: 0,
+      generation: 0,
+    );
+
+    final operationStore = InMemoryOfflineStore();
+    final operationBefore = await operationStore.exportSnapshot();
+    await expectLater(
+      operationStore.transaction<void>((transaction) {
+        transaction.enqueueAll(<OfflineOutboxRecord>[
+          expired('first-record', 'duplicate-operation', 0),
+        ]);
+        transaction.enqueueAll(<OfflineOutboxRecord>[
+          expired('replacement-record', 'duplicate-operation', 0),
+        ]);
+      }),
+      throwsA(
+        isA<OfflineIdentityConflictException>().having(
+          (error) => error.kind,
+          'kind',
+          OfflineIdentityKind.operation,
+        ),
+      ),
+    );
+    expect(await operationStore.exportSnapshot(), operationBefore);
+
+    final recordStore = InMemoryOfflineStore();
+    final recordBefore = await recordStore.exportSnapshot();
+    await expectLater(
+      recordStore.transaction<void>((transaction) {
+        transaction.enqueueAll(<OfflineOutboxRecord>[
+          expired('duplicate-record', 'first-operation', 0),
+        ]);
+        transaction.enqueueAll(<OfflineOutboxRecord>[
+          expired('duplicate-record', 'second-operation', 0),
+        ]);
+      }),
+      throwsA(
+        isA<OfflineIdentityConflictException>().having(
+          (error) => error.kind,
+          'kind',
+          OfflineIdentityKind.record,
+        ),
+      ),
+    );
+    expect(await recordStore.exportSnapshot(), recordBefore);
+  });
+
+  test('wipe is an explicit barrier for earlier enqueue obligations', () async {
+    final store = InMemoryOfflineStore();
+    final assigned = await store.transaction((transaction) {
+      final result = transaction.enqueue(record('before-wipe', 'before-wipe'));
+      transaction.wipePartition('p');
+      return result;
+    });
+    expect(assigned.recordId, 'before-wipe');
+    final wiped = await store.transaction(
+      (transaction) => (
+        generation: transaction.generation('p'),
+        outbox: transaction.outbox('p'),
+        operations: transaction.operations('p'),
+      ),
+    );
+    expect(wiped.generation, 1);
+    expect(wiped.outbox, isEmpty);
+    expect(wiped.operations, isEmpty);
+    final snapshot = await store.exportSnapshot();
+    expect(() => InMemoryOfflineStore.fromSnapshot(snapshot), returnsNormally);
+  });
+
+  test(
+    'new Add enqueue and non-quarantined schema-v4+ restore fail closed',
+    () async {
+      final legacy = OfflineOutboxRecord(
+        recordId: 'legacy-add-rejected',
+        operationId: 'legacy-add-operation',
+        itemIndex: 0,
+        partitionId: 'p',
+        intent: OfflineAddEdgeIntent(
+          Edge(tail: 'a', head: 'b', weight: 1, expiration: null),
+          Uint8List.fromList(List<int>.filled(24, 1)),
+        ),
+        enqueuedAt: now,
+        ordinal: 1,
+        state: OfflineOutboxState.enqueued,
+        attemptCount: 0,
+        generation: 0,
+      );
+      final operation = OfflineOperationRecord(
+        partitionId: 'p',
+        generation: 0,
+        operationId: legacy.operationId,
+        items: <OfflineWriteStatus>[
+          OfflineWriteStatus(
+            recordId: legacy.recordId,
+            operationId: legacy.operationId,
+            itemIndex: 0,
+            state: OfflineWriteState.locallyCommitted,
+            attemptCount: 0,
+          ),
+        ],
+        updatedAt: now,
+      );
+      final store = InMemoryOfflineStore();
+      final before = await store.exportSnapshot();
+      await expectLater(
+        store.transaction<void>((transaction) => transaction.enqueue(legacy)),
+        throwsA(isA<OfflineUnsupportedOperationException>()),
+      );
+      expect(await store.exportSnapshot(), before);
+
+      final encoded =
+          jsonDecode(
+                encodeLegacySnapshot(
+                  schema: 3,
+                  outbox: <OfflineOutboxRecord>[legacy],
+                  operations: <OfflineOperationRecord>[operation],
+                ),
+              )
+              as Map<String, Object?>;
+      for (final schema in <int>[
+        4,
+        InMemoryOfflineStore.snapshotSchemaVersion,
+      ]) {
+        final candidate =
+            jsonDecode(jsonEncode(encoded)) as Map<String, Object?>;
+        candidate['schema'] = schema;
+        if (schema == InMemoryOfflineStore.snapshotSchemaVersion) {
+          final partition =
+              (candidate['partitions']! as List<Object?>).single!
+                  as Map<String, Object?>;
+          partition['replayPausedForAuth'] = false;
+        }
+        expect(
+          () => InMemoryOfflineStore.fromSnapshot(jsonEncode(candidate)),
+          throwsA(isA<OfflineCodecException>()),
+          reason: 'schema v$schema must never migrate Add',
+        );
+      }
+    },
+  );
 
   test('operation and record identity collisions fail atomically', () async {
     final store = InMemoryOfflineStore();
@@ -1244,9 +1567,9 @@ void main() {
 
   test('schema v1 migration rejects sparse allocation amplification', () async {
     final seed = InMemoryOfflineStore();
-    await seed.transaction<void>(
-      (transaction) => transaction.enqueue(record('sparse', 'sparse')),
-    );
+    await seed.transaction<void>((transaction) {
+      enqueueOperation(transaction, record('sparse', 'sparse'));
+    });
     final canonical =
         jsonDecode(await seed.exportSnapshot()) as Map<String, Object?>;
 
@@ -1589,6 +1912,14 @@ void main() {
           generation: 0,
         ),
       ]);
+      putInitialOperation(
+        transaction,
+        records,
+        states: const <OfflineWriteState>[
+          OfflineWriteState.confirmed,
+          OfflineWriteState.locallyCommitted,
+        ],
+      );
       transaction.deleteOutbox('p', records.first.recordId);
     });
     final v2 = jsonDecode(await store.exportSnapshot()) as Map<String, Object?>;
@@ -1650,6 +1981,14 @@ void main() {
                 generation: 0,
               ),
           ]);
+          putInitialOperation(
+            transaction,
+            records,
+            states: const <OfflineWriteState>[
+              OfflineWriteState.confirmed,
+              OfflineWriteState.locallyCommitted,
+            ],
+          );
           transaction.deleteOutbox('p', records.first.recordId);
         });
       }
@@ -1925,20 +2264,75 @@ void main() {
       expect(migrated.operation.items.single.diagnosticCode, 'unsupported_add');
       expect(migrated.operation.isTerminal, isTrue);
       expect(migrated.claimed, isEmpty);
+      final migratedSnapshot = await restored.exportSnapshot();
       expect(
-        (jsonDecode(await restored.exportSnapshot())
-            as Map<String, Object?>)['schema'],
+        (jsonDecode(migratedSnapshot) as Map<String, Object?>)['schema'],
         InMemoryOfflineStore.snapshotSchemaVersion,
       );
+      final reopened = InMemoryOfflineStore.fromSnapshot(migratedSnapshot);
+      final reopenedState = await reopened.transaction((transaction) {
+        return (
+          record: transaction.getOutbox('p', 'legacy-add')!,
+          operation: transaction.getOperation('p', 'legacy-add-operation')!,
+        );
+      });
+      expect(reopenedState.record.state, OfflineOutboxState.deadLetter);
+      expect(reopenedState.record.diagnosticCode, 'unsupported_add');
+      expect(reopenedState.operation.status.isTerminal, isTrue);
     },
   );
 
   test(
     'reference store passes the reusable adapter conformance suite',
     () async {
-      await runStoreConformanceSuite(InMemoryOfflineStore.new);
+      const limits = OfflineStoreLimits(
+        maxCacheRecords: 128,
+        maxOutboxRecords: 128,
+        maxOperationRecords: 128,
+      );
+      await runStoreConformanceSuite(
+        () => InMemoryOfflineStore(limits: limits),
+        reopen: (store) async {
+          final reference = store as InMemoryOfflineStore;
+          return InMemoryOfflineStore.fromSnapshot(
+            await reference.exportSnapshot(),
+            limits: reference.limits,
+          );
+        },
+      );
     },
   );
+
+  test('conformance reaches every known broken graph family', () async {
+    const labels = <String>[
+      'bare_enqueue_graph',
+      'cache_vertex_identity_graph',
+      'cache_edge_identity_graph',
+      'cache_missing_order_graph',
+      'expired_attempt_mismatch_graph',
+      'expired_diagnostic_mismatch_graph',
+      'expired_updated_before_enqueue_graph',
+      'outbox_status_mismatch_graph',
+      'auth_marker_without_pause_graph',
+      'auth_state_without_pause_graph',
+    ];
+    for (var index = 0; index < labels.length; index++) {
+      await expectLater(
+        runStoreConformanceSuite(
+          () => _BrokenGraphStore(index + 1),
+          reopen: (store) => store,
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains(labels[index]),
+          ),
+        ),
+        reason: labels[index],
+      );
+    }
+  });
 
   test(
     'operation capacity evicts terminal metadata but never active status',
@@ -2124,4 +2518,33 @@ void main() {
     expect(observed.map((change) => change.version), <int>[1, 2, 3]);
     expect(observed.map((change) => change.generation), <int>[0, 0, 1]);
   });
+}
+
+final class _BrokenGraphStore implements OfflineStore {
+  _BrokenGraphStore(this.suppressedFailure);
+
+  final int suppressedFailure;
+  final InMemoryOfflineStore _delegate = InMemoryOfflineStore();
+  var _graphFailures = 0;
+
+  @override
+  Stream<OfflineStoreChange> changes(String partitionId) =>
+      _delegate.changes(partitionId);
+
+  @override
+  Future<T> transaction<T>(
+    FutureOr<T> Function(OfflineStoreTransaction transaction) action,
+  ) async {
+    late T callbackResult;
+    try {
+      return await _delegate.transaction((transaction) async {
+        callbackResult = await action(transaction);
+        return callbackResult;
+      });
+    } on OfflineDurableGraphException {
+      _graphFailures += 1;
+      if (_graphFailures == suppressedFailure) return callbackResult;
+      rethrow;
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- validate the complete cache/outbox/operation graph before every successful OfflineStore transaction commits
- roll invalid mutations back atomically with a typed OfflineDurableGraphException and no change notification
- require adapter conformance to reopen the same durable state under the same limits and exercise every lifecycle transition
- preserve born-expired plural topology, auth pause, cache identity, and exact legacy Add quarantine across canonical restart
- document the production adapter contract in the Offline README and ADR 0002

## Verification

- all six Go modules: go test ./...
- server: go vet ./...
- Dart parent: format, analyze, 84 tests (1 environment-only real-wire skip), dartdoc, publish dry-run
- Dart offline: format, analyze, 130 tests (5 environment-only real-wire skips), dartdoc, performance probe
- Flutter example: format, analyze, 8 tests
- independent review: P0/P1/P2 = 0

Closes #1198