### PR TITLE
fix(ha): preserve implicit edge endpoints across gap recovery

### DIFF
--- a/docs/ha-runbook.md
+++ b/docs/ha-runbook.md
@@ -683,6 +683,14 @@ increments; the server replies `FailedPrecondition` (reason
 transition` line with `transition="snapshot_start" reason="gapped"`,
 then re-snapshots on its own. No manual action needed.
 
+An edge-only working set is valid Snapshot input: endpoint vertices created
+implicitly by `PutEdge*` / `AddEdge*` are carried as concrete nil-valued
+Vertex frames. A peer repeatedly logging `snapshot_failed` with
+`snapshot: nil vertex payload` is therefore not normal gap pressure; it means
+the responder is an incompatible pre-fix build or the stream is corrupt.
+Finish the rolling upgrade (or remove the incompatible responder) before
+increasing the log capacity.
+
 If overflow is **chronic**, write rate has outgrown
 `mutation_log_capacity`. Bump
 `LANTERN_MUTATION_LOG_CAPACITY` or add cluster capacity.

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -492,6 +492,14 @@ Framing contract:
   causal barriers. Pump and anti-entropy consumers reject count mismatches,
   duplicate/missing header/footer frames, or any out-of-order body frame before
   advancing resume watermarks.
+- Every live vertex frame is self-describing and non-nil. In particular,
+  endpoint vertices auto-created by `PutEdge*` / `AddEdge*` are serialized as a
+  concrete `Vertex` carrying the endpoint key, expiration, and `nil` value arm;
+  the internal `*Vertex == nil` sentinel is never exposed on the wire. A nil
+  `SnapshotVertex.vertex` is a truncated/corrupt frame and consumers fail
+  closed. This invariant is load-bearing for gap recovery because edge-only
+  working sets contain implicit endpoints even when no `PutVertex*` call has
+  occurred.
 - Retained Put causal barriers are streamed **before live entries**.
   They use explicit `SnapshotVertexCausalBarrier` and
   `SnapshotEdgeCausalBarrier` oneof arms, never overloaded live
@@ -528,8 +536,9 @@ Implementation notes:
   the retained barrier maps. Capturing barriers and live state in separate
   lock passes is forbidden: TTL/GC could move a floor between the passes and
   make the snapshot omit both representations. The completed owned slices are
-  then streamed frame-by-frame, honouring `stream.Context()` cancellation
-  between sends.
+  then streamed frame-by-frame, canonicalizing implicit nil-valued endpoint
+  vertices at the service boundary and honouring `stream.Context()`
+  cancellation between sends.
 - v1 materialises the full snapshot in memory. Bootstrap is a bounded,
   one-peer-at-a-time operation, so the O(N+E) overhead is acceptable.
   Cursor-based / chunked snapshotting is a follow-up once the bootstrap

--- a/server/service/replication.go
+++ b/server/service/replication.go
@@ -370,7 +370,7 @@ func (s *LanternReplicationService) Snapshot(ctx context.Context, _ *pb.Snapshot
 		entry := &pb.SnapshotResponse{
 			Entry: &pb.SnapshotResponse_Vertex{
 				Vertex: &pb.SnapshotVertex{
-					Vertex: v.Value,
+					Vertex: replicationSnapshotVertex(v),
 					Hlc:    hlcToProto(v.HLC),
 				},
 			},
@@ -422,6 +422,26 @@ func (s *LanternReplicationService) Snapshot(ctx context.Context, _ *pb.Snapshot
 		},
 	}
 	return stream.Send(footer)
+}
+
+// replicationSnapshotVertex converts GraphCache's nil value sentinel into the
+// public Vertex nil-value arm. Edge writes auto-create endpoint vertices with a
+// nil *pb.Vertex payload, but a SnapshotVertex wire frame must remain
+// self-describing: the receiver needs both the key and expiration and rejects a
+// nil payload as a truncated/corrupt frame. Non-nil values already carry their
+// exact public representation and can be streamed unchanged.
+func replicationSnapshotVertex(v graphcache.SnapshotVertex[string, *pb.Vertex]) *pb.Vertex {
+	if v.Value != nil {
+		return v.Value
+	}
+	vertex := &pb.Vertex{
+		Key:   v.Key,
+		Value: &pb.Vertex_Nil{Nil: true},
+	}
+	if !v.Expiration.IsZero() {
+		vertex.Expiration = timestamppb.New(v.Expiration)
+	}
+	return vertex
 }
 
 // PeerStatus implements pb.LanternReplicationServiceServer.

--- a/server/service/replication_test.go
+++ b/server/service/replication_test.go
@@ -1,0 +1,102 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/anaregdesign/lantern/core/graphcache"
+	"github.com/anaregdesign/lantern/core/hlc"
+	pb "github.com/anaregdesign/lantern/pb/graph/v1"
+)
+
+type replicationSnapshotRecorder struct {
+	frames []*pb.SnapshotResponse
+}
+
+func (s *replicationSnapshotRecorder) Send(frame *pb.SnapshotResponse) error {
+	s.frames = append(s.frames, frame)
+	return nil
+}
+
+type replicationSnapshotCounter struct {
+	frames int
+}
+
+func (s *replicationSnapshotCounter) Send(*pb.SnapshotResponse) error {
+	s.frames++
+	return nil
+}
+
+func TestLanternReplicationService_SnapshotCanonicalizesImplicitVertices(t *testing.T) {
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Hour)
+	expiration := time.Now().Add(time.Hour).Round(0)
+	ts := hlc.Timestamp{WallNs: 10, NodeID: hlc.NodeID{0x01}}
+	if !cache.PutEdgeWithExpirationHLC("implicit-tail", "implicit-head", 2, expiration, ts) {
+		t.Fatal("PutEdgeWithExpirationHLC rejected seed edge")
+	}
+
+	replication := NewLanternReplicationService(nil, cache, hlc.New(hlc.NodeID{0x02}, hlc.Options{}))
+	recorder := &replicationSnapshotRecorder{}
+	if err := replication.Snapshot(context.Background(), &pb.SnapshotRequest{}, recorder); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	vertices := make(map[string]*pb.Vertex)
+	var edges int
+	for _, frame := range recorder.frames {
+		switch entry := frame.GetEntry().(type) {
+		case *pb.SnapshotResponse_Vertex:
+			if entry.Vertex == nil || entry.Vertex.GetVertex() == nil {
+				t.Fatalf("Snapshot emitted nil vertex payload: %+v", entry.Vertex)
+			}
+			vertex := entry.Vertex.GetVertex()
+			vertices[vertex.GetKey()] = vertex
+		case *pb.SnapshotResponse_Edge:
+			edges++
+		}
+	}
+	for _, key := range []string{"implicit-tail", "implicit-head"} {
+		vertex := vertices[key]
+		if vertex == nil {
+			t.Fatalf("Snapshot omitted implicit endpoint %q", key)
+		}
+		if !vertex.GetNil() {
+			t.Fatalf("implicit endpoint %q value = %T, want Vertex.nil", key, vertex.GetValue())
+		}
+		if got := vertex.GetExpiration().AsTime(); !got.Equal(expiration) {
+			t.Fatalf("implicit endpoint %q expiration = %v, want %v", key, got, expiration)
+		}
+	}
+	if edges != 1 {
+		t.Fatalf("Snapshot edge frames = %d, want 1", edges)
+	}
+}
+
+// BenchmarkLanternReplicationService_SnapshotPutEdges is the focused local
+// counterpart to broad_mutate: it materializes the same bounded 2,000-edge
+// Put-only working set with implicit endpoints and drains a full replication
+// Snapshot without retaining response frames.
+func BenchmarkLanternReplicationService_SnapshotPutEdges(b *testing.B) {
+	cache := graphcache.NewGraphCache[string, *pb.Vertex](time.Hour)
+	items := make([]graphcache.EdgeItem[string], 2000)
+	for i := range items {
+		items[i] = graphcache.EdgeItem[string]{
+			Tail: fmt.Sprintf("m-%d", i), Head: "m-h", Weight: 1,
+		}
+	}
+	cache.PutEdgesWithExpirationHLC(items, hlc.Timestamp{WallNs: 10, NodeID: hlc.NodeID{0x01}})
+	replication := NewLanternReplicationService(nil, cache, hlc.New(hlc.NodeID{0x02}, hlc.Options{}))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		counter := &replicationSnapshotCounter{}
+		if err := replication.Snapshot(context.Background(), &pb.SnapshotRequest{}, counter); err != nil {
+			b.Fatal(err)
+		}
+		if counter.frames == 0 {
+			b.Fatal("Snapshot emitted no frames")
+		}
+	}
+}

--- a/tests/integration/peer_pump_test.go
+++ b/tests/integration/peer_pump_test.go
@@ -165,6 +165,34 @@ func waitForEdge(t *testing.T, cache *graphcache.GraphCache[string, *pb.Vertex],
 	return w, ok
 }
 
+// waitForWireEdge is the real Connect/h2c sibling used by gap-recovery tests
+// whose contract is externally observable through GetEdge. NotFound is the
+// expected convergence state; any other RPC error is terminal.
+func waitForWireEdge(t *testing.T, ctx context.Context, raw graphv1connect.LanternServiceClient, tail, head string, want float32, timeout time.Duration) (float32, bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		response, err := raw.GetEdge(ctx, connect.NewRequest(&pb.GetEdgeRequest{Tail: tail, Head: head}))
+		if err == nil {
+			weight := response.Msg.GetEdge().GetWeight()
+			if weight == want {
+				return weight, true
+			}
+		} else if connect.CodeOf(err) != connect.CodeNotFound {
+			t.Fatalf("GetEdge %s->%s: %v", tail, head, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	response, err := raw.GetEdge(ctx, connect.NewRequest(&pb.GetEdgeRequest{Tail: tail, Head: head}))
+	if err != nil {
+		if connect.CodeOf(err) != connect.CodeNotFound {
+			t.Fatalf("GetEdge %s->%s: %v", tail, head, err)
+		}
+		return 0, false
+	}
+	return response.Msg.GetEdge().GetWeight(), true
+}
+
 // TestPeerPump_E2E_ThreeNodeConvergence wires three peers in a full
 // mesh (A↔B↔C) and asserts that a write to any one node is observed
 // on every other node within a short polling window. This exercises
@@ -494,4 +522,177 @@ func TestPeerPump_GapRecoverySnapshot(t *testing.T) {
 	if got := waitForSearchConvergence(t, ctx, "snapshot barrier", exactAll, primary.raw, follower.raw); len(got) != 0 {
 		t.Fatalf("causal barrier identities became searchable: %+v", got)
 	}
+}
+
+// TestPeerPump_OutcomeAwarePutEdgesGapRecovery is the #1206 regression for
+// the real broad_mutate failure: outcome-aware edge Puts filled a tiny log,
+// a third node attached through a relay after the retained window had moved,
+// and Snapshot had to restore endpoint vertices that edge writes had created
+// implicitly. Those endpoints are represented internally by nil *pb.Vertex
+// values, but the replication wire must carry canonical nil-valued Vertex
+// messages rather than a nil SnapshotVertex payload.
+func TestPeerPump_OutcomeAwarePutEdgesGapRecovery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping three-node gap-recovery test in short mode")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const logCapacity = 8
+	a := newPumpNodeWithSearch(t, hlc.NodeID{0xC1}, logCapacity, true)
+	b := newPumpNodeWithSearch(t, hlc.NodeID{0xC2}, logCapacity, true)
+	c := newPumpNodeWithSearch(t, hlc.NodeID{0xC3}, logCapacity, true)
+
+	// A and B replicate directly while C is partitioned. B therefore becomes
+	// a relay whose tiny local log contains mutations from both origins.
+	a.startPump(ctx, t, []string{b.url})
+	b.startPump(ctx, t, []string{a.url})
+	time.Sleep(150 * time.Millisecond)
+
+	type expectedEdge struct {
+		tail, head string
+		weight     float32
+	}
+	var expected []expectedEdge
+	writeSet := func(name string, node *pumpNode, baseWeight float32) {
+		t.Helper()
+		for i := 0; i < 4; i++ {
+			tail := fmt.Sprintf("gap/%s/singular/%d", name, i)
+			weight := baseWeight + float32(i)
+			outcome, err := node.sdk.PutEdge(ctx, tail, "gap/head", weight, time.Hour)
+			if err != nil {
+				t.Fatalf("%s PutEdge[%d]: %v", name, i, err)
+			}
+			if outcome != client.PutOutcomeAppliedAndLive {
+				t.Fatalf("%s PutEdge[%d] outcome = %s, want APPLIED_AND_LIVE", name, i, outcome)
+			}
+			expected = append(expected, expectedEdge{tail: tail, head: "gap/head", weight: weight})
+		}
+		for batch := 0; batch < 4; batch++ {
+			inputs := make([]client.EdgeInput, 0, 2)
+			for item := 0; item < 2; item++ {
+				tail := fmt.Sprintf("gap/%s/plural/%d/%d", name, batch, item)
+				weight := baseWeight + 10 + float32(2*batch+item)
+				inputs = append(inputs, client.EdgeInput{
+					Tail: tail, Head: "gap/head", Weight: weight,
+					Expiration: time.Now().Add(time.Hour),
+				})
+				expected = append(expected, expectedEdge{tail: tail, head: "gap/head", weight: weight})
+			}
+			results, err := node.sdk.PutEdges(ctx, inputs)
+			if err != nil {
+				t.Fatalf("%s PutEdges[%d]: %v", name, batch, err)
+			}
+			for i, result := range results {
+				if result.Outcome != client.PutOutcomeAppliedAndLive {
+					t.Fatalf("%s PutEdges[%d][%d] outcome = %s, want APPLIED_AND_LIVE", name, batch, i, result.Outcome)
+				}
+			}
+		}
+	}
+	writeSet("a", a, 100)
+	writeSet("b", b, 200)
+
+	// An accepted-expired Put is absent from the live graph but must survive
+	// gap recovery as a causal floor. This stays Put-only: mixed Put/Add on one
+	// identity belongs to the reset-aware contribution contract in #1203.
+	expiredOutcome, err := a.sdk.PutEdgeAt(
+		ctx, "gap/expired", "gap/head", 999, time.Now().Add(-time.Second),
+	)
+	if err != nil {
+		t.Fatalf("a born-expired PutEdgeAt: %v", err)
+	}
+	if expiredOutcome != client.PutOutcomeExpired {
+		t.Fatalf("a born-expired PutEdgeAt outcome = %s, want EXPIRED", expiredOutcome)
+	}
+
+	for _, edge := range expected {
+		for _, node := range []*pumpNode{a, b} {
+			if got, ok := waitForEdge(t, node.cache, edge.tail, edge.head, edge.weight, 5*time.Second); !ok || got != edge.weight {
+				t.Fatalf("pre-gap %x edge %s->%s = (%v,%v), want (%v,true)", node.nodeID[0], edge.tail, edge.head, got, ok, edge.weight)
+			}
+		}
+	}
+	barrierDeadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(barrierDeadline) {
+		_, edgeBarriers := b.cache.CausalBarrierCounts()
+		if edgeBarriers == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, edgeBarriers := b.cache.CausalBarrierCounts(); edgeBarriers != 1 {
+		t.Fatalf("relay edge causal barriers = %d, want 1 before gap recovery", edgeBarriers)
+	}
+
+	// More cluster mutations than B's ring capacity make a local-seq=1
+	// Subscribe deterministically gapped. This is the same real Connect/h2c
+	// surface the pump uses, asserted explicitly before C starts recovery.
+	relayReplication := newReplicationRawClient(t, b.url)
+	gapStream, err := relayReplication.Subscribe(ctx, connect.NewRequest(&pb.SubscribeRequest{FromLocalSeq: 1}))
+	if err == nil {
+		if gapStream.Receive() {
+			t.Fatal("gapped direct Subscribe unexpectedly delivered a mutation")
+		}
+		err = gapStream.Err()
+		_ = gapStream.Close()
+	}
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Fatalf("direct Subscribe gap error = %v (code %v), want FailedPrecondition", err, connect.CodeOf(err))
+	}
+
+	metrics := &observedSearchConfigMetrics{
+		gate: readiness.NewGate(100, true, nil), observations: make(chan bool, 1),
+	}
+	c.startPumpWithMetrics(ctx, t, []string{b.url}, metrics)
+	for _, edge := range expected {
+		if got, ok := waitForWireEdge(t, ctx, c.raw, edge.tail, edge.head, edge.weight, 8*time.Second); !ok || got != edge.weight {
+			t.Fatalf("snapshot relay edge %s->%s = (%v,%v), want (%v,true)", edge.tail, edge.head, got, ok, edge.weight)
+		}
+	}
+	snapshotDeadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(snapshotDeadline) && metrics.snapshots.Load() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := metrics.snapshots.Load(); got != 1 {
+		t.Fatalf("completed snapshot count = %d, want exactly 1", got)
+	}
+	if _, edgeBarriers := c.cache.CausalBarrierCounts(); edgeBarriers != 1 {
+		t.Fatalf("snapshot edge causal barriers = %d, want 1", edgeBarriers)
+	}
+	if c.cache.PutEdgeWithExpirationHLC(
+		"gap/expired", "gap/head", 1, time.Now().Add(time.Hour),
+		hlc.Timestamp{WallNs: 1, NodeID: hlc.NodeID{0x01}},
+	) {
+		t.Fatal("snapshot lost born-expired edge causal floor")
+	}
+
+	// Prove the Snapshot cutoff stitched to the live Subscribe tail on the
+	// same relay, for both singular and plural outcome-aware Put forms.
+	postSingular := expectedEdge{tail: "gap/post/singular", head: "gap/head", weight: 301}
+	if outcome, err := a.sdk.PutEdge(ctx, postSingular.tail, postSingular.head, postSingular.weight, time.Hour); err != nil || outcome != client.PutOutcomeAppliedAndLive {
+		t.Fatalf("post-snapshot PutEdge = (%s,%v), want (APPLIED_AND_LIVE,nil)", outcome, err)
+	}
+	postPlural := []expectedEdge{
+		{tail: "gap/post/plural/0", head: "gap/head", weight: 302},
+		{tail: "gap/post/plural/1", head: "gap/head", weight: 303},
+	}
+	results, err := b.sdk.PutEdges(ctx, []client.EdgeInput{
+		{Tail: postPlural[0].tail, Head: postPlural[0].head, Weight: postPlural[0].weight, Expiration: time.Now().Add(time.Hour)},
+		{Tail: postPlural[1].tail, Head: postPlural[1].head, Weight: postPlural[1].weight, Expiration: time.Now().Add(time.Hour)},
+	})
+	if err != nil || len(results) != 2 || results[0].Outcome != client.PutOutcomeAppliedAndLive || results[1].Outcome != client.PutOutcomeAppliedAndLive {
+		t.Fatalf("post-snapshot PutEdges = (%+v,%v), want two APPLIED_AND_LIVE outcomes", results, err)
+	}
+	expected = append(expected, postSingular)
+	expected = append(expected, postPlural...)
+
+	for _, edge := range expected {
+		for _, node := range []*pumpNode{a, b, c} {
+			if got, ok := waitForWireEdge(t, ctx, node.raw, edge.tail, edge.head, edge.weight, 5*time.Second); !ok || got != edge.weight {
+				t.Errorf("final %x edge %s->%s = (%v,%v), want (%v,true)", node.nodeID[0], edge.tail, edge.head, got, ok, edge.weight)
+			}
+		}
+	}
+	waitForSearchConvergence(t, ctx, "gap", nil, a.raw, b.raw, c.raw)
 }


### PR DESCRIPTION
Closes #1206

## Summary

- canonicalize GraphCache implicit endpoint sentinels as concrete nil-valued wire vertices in replication Snapshot
- preserve barrier-first and fail-closed replay semantics
- add deterministic 3-node tiny-log gap/Snapshot/Subscribe recovery coverage over real Connect/h2c
- document the wire invariant and operator symptom

## Verification

- all six Go modules: format, vet, build, and race/shuffle tests
- deterministic integration regression: 20 consecutive passes
- server lint: 0 issues
- focused 2,000-edge Snapshot benchmark: 2.08 ms/op, 3.12 MB/op, 40,047 allocs/op
- independent review: P0/P1/P2 = 0