### PR TITLE
chore(sdks/dart): prepare 0.2.0 release

### DIFF
--- a/sdks/dart/CHANGELOG.md
+++ b/sdks/dart/CHANGELOG.md
@@ -1,16 +1,22 @@
 # Changelog
 
-## Unreleased
+## 0.2.0
 
-- Return bounded, server-clock-authoritative per-item outcomes from every
-  Vertex/Edge Put facade, with consistent immutable Lists for plural calls and
-  fail-closed unknown/length handling.
+- Return bounded, server-clock-authoritative per-item `PutOutcome` values from
+  every Vertex/Edge Put facade, replacing the earlier aggregate/bool return
+  shapes. Plural calls now return request-aligned immutable Lists and fail
+  closed on unknown or length-misaligned outcomes.
 - Expose detachable, fan-out-safe `LanternCancellationToken.listen` lifecycle
   notifications so companion packages can isolate shared work from individual
   callers without polling.
 - Add the per-call `LanternCallOptions.retry` override so a higher-level durable
   coordinator can suppress the client's retry policy. Each RPC is attempted at
   most once, while a chunked plural logical call may still issue multiple RPCs.
+- Add optional causal-metadata capacity and retention snapshots to
+  `ServerStatus`, while preserving `null` as the signal that an older server
+  does not support the status surface.
+- Make the pub.dev archive dependency-closed: exclude the repository-only
+  Flutter/offline packages and retain a standalone online example.
 
 ## 0.1.3
 

--- a/sdks/dart/example/pubspec.lock
+++ b/sdks/dart/example/pubspec.lock
@@ -120,7 +120,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.3"
+    version: "0.2.0"
   lantern_client_offline:
     dependency: "direct main"
     description:

--- a/sdks/dart/offline/pubspec.lock
+++ b/sdks/dart/offline/pubspec.lock
@@ -159,7 +159,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.3"
+    version: "0.2.0"
   lints:
     dependency: "direct dev"
     description:

--- a/sdks/dart/pubspec.yaml
+++ b/sdks/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lantern_client
 description: Pure Dart client SDK for Lantern, an in-memory graph key-vertex store with TTL-aware vertices and edges.
-version: 0.1.3
+version: 0.2.0
 repository: https://github.com/anaregdesign/lantern
 homepage: https://github.com/anaregdesign/lantern/tree/main/sdks/dart
 issue_tracker: https://github.com/anaregdesign/lantern/issues


### PR DESCRIPTION
## Summary

- version `lantern_client` at 0.2.0 for the breaking PutOutcome, cancellation-listener, and per-call retry surfaces required by the hosted offline package
- record causal-metadata status and dependency-closed archive changes in the exact release changelog
- refresh both repository path dependents’ lockfiles without enabling offline publication

## Verification

- parent Dart format/analyze and 85 unit tests
- real Connect/h2c suite: 17/17
- warning-free dartdoc
- clean publish dry-run: 0 warnings
- exact isolated archive resolve/analyze/test; no offline package or path dependency
- pana: 140/160
- independent P0-P2 release review: clear

This PR does not create a tag, publish a package, or complete #1162. After merge, `sdks/dart/v0.2.0` publication must be separately authorized and verified before the offline package can convert its dependency to hosted `^0.2.0`.

Refs #1162