### PR TITLE
ci(dart): make iOS app-launch stalls observable

### DIFF
--- a/.github/workflows/dart-sdk.yml
+++ b/.github/workflows/dart-sdk.yml
@@ -593,7 +593,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.full == 'true'
     runs-on: macos-15
-    timeout-minutes: 30
+    # Two bounded 10-minute attempts plus fresh-device creation must leave
+    # enough margin for setup/build, diagnostics upload, and mandatory cleanup.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
 
@@ -666,39 +668,92 @@ jobs:
           echo "DEVICE_ID=$device" >> "$GITHUB_ENV"
           cat "$RUNNER_TEMP/ios-simulator-boot.log"
 
-      - name: Run iOS native smoke
-        id: ios_smoke
+      - name: Run classified iOS native smoke
+        id: ios_smoke_initial
+        if: success()
         continue-on-error: true
-        timeout-minutes: 8
+        timeout-minutes: 10
         working-directory: sdks/dart/example
-        run: |
-          flutter test --no-pub integration_test/mobile_smoke_test.dart -d "$DEVICE_ID" \
-            --reporter=expanded --timeout=3m \
-            --dart-define=LANTERN_ENDPOINT=http://127.0.0.1:6380 \
-            --dart-define=LANTERN_ALLOW_INSECURE=true
+        env:
+          IOS_SMOKE_LAUNCH_TIMEOUT_SECONDS: 90
+          IOS_SMOKE_TOTAL_TIMEOUT_SECONDS: 480
+        run: >-
+          bash tool/ios_smoke_ci.sh run-attempt "$DEVICE_ID" initial
+          "$RUNNER_TEMP/ios-smoke-diagnostics"
 
-      # Flutter's test timeout does not cover a stalled iOS app launch.
-      - name: Reboot iOS simulator after a failed smoke attempt
-        if: steps.ios_smoke.outcome == 'failure'
+      # Only a silent post-build/pre-body launch stall is infrastructure.
+      # Assertion, RPC, build, and post-body failures never enter this path.
+      - name: Create independently clean retry simulator
+        id: ios_fresh_device
+        if: steps.ios_smoke_initial.outputs.classification == 'launch_stall'
+        timeout-minutes: 3
+        working-directory: sdks/dart/example
         run: |
           xcrun simctl shutdown "$DEVICE_ID" || true
-          xcrun simctl erase "$DEVICE_ID"
-          xcrun simctl boot "$DEVICE_ID"
-          xcrun simctl bootstatus "$DEVICE_ID" -b
+          bash tool/ios_smoke_ci.sh create-retry-device \
+            "$DEVICE_ID" "$RUNNER_TEMP/ios-retry-device-id" \
+            "$RUNNER_TEMP/ios-smoke-diagnostics"
+          retry_device=$(cat "$RUNNER_TEMP/ios-retry-device-id")
+          test -n "$retry_device"
+          test "$retry_device" != "$DEVICE_ID"
+          echo "RETRY_DEVICE_ID=$retry_device" >> "$GITHUB_ENV"
 
-      - name: Retry iOS native smoke
+      - name: Retry classified iOS native smoke on fresh simulator
         id: ios_smoke_retry
-        if: steps.ios_smoke.outcome == 'failure'
-        timeout-minutes: 8
+        if: >-
+          steps.ios_smoke_initial.outputs.classification == 'launch_stall' &&
+          steps.ios_fresh_device.outcome == 'success'
+        continue-on-error: true
+        timeout-minutes: 10
         working-directory: sdks/dart/example
+        env:
+          IOS_SMOKE_LAUNCH_TIMEOUT_SECONDS: 90
+          IOS_SMOKE_TOTAL_TIMEOUT_SECONDS: 480
+        run: >-
+          bash tool/ios_smoke_ci.sh run-attempt "$RETRY_DEVICE_ID" retry
+          "$RUNNER_TEMP/ios-smoke-diagnostics"
+
+      - name: Finalize bounded iOS launch diagnostics
+        id: ios_diagnostics_finalize
+        if: always()
+        timeout-minutes: 2
+        working-directory: sdks/dart/example
+        run: >-
+          bash tool/ios_smoke_ci.sh finalize-diagnostics
+          "$RUNNER_TEMP/ios-smoke-diagnostics"
+
+      - name: Upload bounded iOS launch diagnostics
+        if: always() && steps.ios_diagnostics_finalize.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: lantern-ios-smoke-diagnostics-${{ github.sha }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/ios-smoke-diagnostics
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Require classified iOS smoke success
+        if: always()
+        env:
+          INITIAL_CLASSIFICATION: ${{ steps.ios_smoke_initial.outputs.classification }}
+          FRESH_DEVICE_OUTCOME: ${{ steps.ios_fresh_device.outcome }}
+          RETRY_CLASSIFICATION: ${{ steps.ios_smoke_retry.outputs.classification }}
         run: |
-          flutter test --no-pub integration_test/mobile_smoke_test.dart -d "$DEVICE_ID" \
-            --reporter=expanded --timeout=3m \
-            --dart-define=LANTERN_ENDPOINT=http://127.0.0.1:6380 \
-            --dart-define=LANTERN_ALLOW_INSECURE=true
+          set -euo pipefail
+          if [[ "$INITIAL_CLASSIFICATION" == success ]]; then
+            echo "SMOKE_DEVICE_ID=$DEVICE_ID" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          if [[ "$INITIAL_CLASSIFICATION" == launch_stall && \
+                "$FRESH_DEVICE_OUTCOME" == success && \
+                "$RETRY_CLASSIFICATION" == success ]]; then
+            echo "SMOKE_DEVICE_ID=$RETRY_DEVICE_ID" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          echo "::error::iOS smoke failed: initial=$INITIAL_CLASSIFICATION fresh=$FRESH_DEVICE_OUTCOME retry=$RETRY_CLASSIFICATION"
+          exit 1
 
       - name: Record exact iOS revision evidence
-        if: steps.ios_smoke.outcome == 'success' || steps.ios_smoke_retry.outcome == 'success'
+        if: success()
         shell: bash
         run: |
           set -euo pipefail
@@ -708,7 +763,7 @@ jobs:
             sdks/dart/example/ios/Runner.xcodeproj/project.pbxproj
           flutter_json=$(cd sdks/dart/example && flutter --version --machine)
           simulator=$(xcrun simctl list devices available -j | jq -er \
-            --arg id "$DEVICE_ID" \
+            --arg id "$SMOKE_DEVICE_ID" \
             '.devices | first(to_entries[] | .key as $runtime | .value[] | select(.udid == $id) | [$runtime, .name] | @tsv)')
           simulator_runtime=${simulator%%$'\t'*}
           simulator_name=${simulator#*$'\t'}
@@ -782,7 +837,7 @@ jobs:
           ' "$evidence/ios.json" >/dev/null
 
       - name: Upload sanitized iOS revision evidence
-        if: steps.ios_smoke.outcome == 'success' || steps.ios_smoke_retry.outcome == 'success'
+        if: success()
         uses: actions/upload-artifact@v7
         with:
           name: lantern-ios-revision-${{ github.sha }}
@@ -803,6 +858,16 @@ jobs:
           fi
           if [[ -n "$device" ]]; then
             xcrun simctl shutdown "$device" || true
+          fi
+
+      - name: Delete fresh retry simulator
+        if: always()
+        timeout-minutes: 2
+        run: |
+          if [[ -f "$RUNNER_TEMP/ios-retry-device-id" ]]; then
+            retry_device=$(cat "$RUNNER_TEMP/ios-retry-device-id")
+            xcrun simctl shutdown "$retry_device" || true
+            xcrun simctl delete "$retry_device" || true
           fi
 
   gate:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,18 @@ archive. CI uses Dart Pub's own archive builder, unpacks the resulting tarball
 outside the checkout, resolves every included `pubspec.yaml` with an isolated
 cache, then runs analysis, tests, and `pana` against the unpacked artifact.
 
+The iOS job classifies the native smoke instead of treating every outer timeout
+as retryable infrastructure. Its helper bounds the full attempt and separately
+bounds the phase after `Xcode build done.` but before the explicit integration
+test-body marker. Only that silent `launch_stall` may retry, once, on a newly
+created simulator with the same runtime/device type and a different UDID.
+Build failures, assertions, RPC failures, and post-body stalls fail the blocking
+`Gate` directly. Bounded, redacted process/simulator/app diagnostics are always
+uploaded; the temporary retry simulator is always deleted. Flutter's integration
+test command rebuilds on the fresh simulator because it has no stable install-
+without-build test path; reusing the potentially wedged device or build state is
+less reliable than the one bounded rebuild.
+
 ## Coverage floor (ratchet)
 
 The `Build & Test` job measures per-module coverage (`-covermode=atomic`), merges the

--- a/sdks/dart/example/integration_test/mobile_smoke_test.dart
+++ b/sdks/dart/example/integration_test/mobile_smoke_test.dart
@@ -10,6 +10,10 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('native mobile real-wire smoke', (tester) async {
+    // This explicit phase marker lets CI distinguish an app-launch stall from
+    // an assertion or RPC failure after the integration test body has begun.
+    // ignore: avoid_print
+    print('MOBILE_SMOKE_BODY_STARTED');
     const endpointValue = String.fromEnvironment('LANTERN_ENDPOINT');
     expect(endpointValue, isNotEmpty, reason: 'pass LANTERN_ENDPOINT');
     final endpoint = Uri.parse(endpointValue);

--- a/sdks/dart/example/test/ios_smoke_ci_test.dart
+++ b/sdks/dart/example/test/ios_smoke_ci_test.dart
@@ -151,6 +151,8 @@ echo 'bounded process snapshot'
       environment: {
         ...Platform.environment,
         'IOS_SMOKE_XCRUN_BIN': fakeXcrun.path,
+        'GITHUB_RUN_ID': 'local',
+        'GITHUB_RUN_ATTEMPT': '1',
       },
     );
 

--- a/sdks/dart/example/test/ios_smoke_ci_test.dart
+++ b/sdks/dart/example/test/ios_smoke_ci_test.dart
@@ -1,0 +1,274 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory sandbox;
+  late File fakeFlutter;
+  late File fakeXcrun;
+  late File xcrunCalls;
+
+  setUp(() async {
+    sandbox = await Directory.systemTemp.createTemp('lantern-ios-smoke-');
+    fakeFlutter = File('${sandbox.path}/flutter');
+    fakeXcrun = File('${sandbox.path}/xcrun');
+    xcrunCalls = File('${sandbox.path}/xcrun-calls.txt');
+    await _writeExecutable(fakeXcrun, '''#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "\$*" >> '${xcrunCalls.path}'
+if [[ "\$*" == 'simctl list devices available -j' ]]; then
+  cat <<'JSON'
+{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-18-6":[{"name":"iPhone 16 Pro","udid":"SOURCE-DEVICE","deviceTypeIdentifier":"com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro"}]}}
+JSON
+elif [[ "\${1:-}" == simctl && "\${2:-}" == create ]]; then
+  printf '%s\\n' 'A1B2C3D4-E5F6-47A8-90AB-CDEF12345678'
+else
+  echo 'Authorization: Bearer top-secret-token https://private.example.test/path'
+  echo 'mobile-smoke:private-key-value'
+fi
+''');
+  });
+
+  tearDown(() async {
+    if (await sandbox.exists()) await sandbox.delete(recursive: true);
+  });
+
+  test('reports success only after body and terminal pass markers', () async {
+    await _writeExecutable(fakeFlutter, '''#!/usr/bin/env bash
+echo 'Running Xcode build...'
+echo 'Xcode build done. 1.0s'
+echo 'MOBILE_SMOKE_BODY_STARTED'
+echo 'MOBILE_SMOKE_PASS vertices=13'
+echo 'All tests passed!'
+''');
+
+    final result = await _runAttempt(sandbox, fakeFlutter, fakeXcrun);
+
+    expect(result.exitCode, 0, reason: result.stderr.toString());
+    expect(await _classification(sandbox), 'success');
+  });
+
+  test('bounds a post-build launch stall and redacts diagnostics', () async {
+    final githubOutput = File('${sandbox.path}/github-output');
+    await _writeExecutable(fakeFlutter, '''#!/usr/bin/env bash
+echo 'Running Xcode build...'
+echo 'Xcode build done. 1.0s'
+echo 'Authorization: Bearer flutter-secret https://flutter.private.test/path'
+echo 'mobile-smoke:flutter-private-value'
+sleep 30
+''');
+    final stopwatch = Stopwatch()..start();
+
+    final result = await _runAttempt(
+      sandbox,
+      fakeFlutter,
+      fakeXcrun,
+      extraEnvironment: {'GITHUB_OUTPUT': githubOutput.path},
+    );
+
+    stopwatch.stop();
+    expect(result.exitCode, isNonZero);
+    expect(await _classification(sandbox), 'launch_stall');
+    expect(
+      await githubOutput.readAsString(),
+      contains('classification=launch_stall\n'),
+    );
+    expect(stopwatch.elapsed, lessThan(const Duration(seconds: 12)));
+    final diagnostics = await _diagnosticText(sandbox);
+    expect(diagnostics, isNot(contains('top-secret-token')));
+    expect(diagnostics, isNot(contains('private.example.test')));
+    expect(diagnostics, isNot(contains('private-key-value')));
+    expect(diagnostics, isNot(contains('flutter-secret')));
+    expect(diagnostics, isNot(contains('flutter.private.test')));
+    expect(diagnostics, isNot(contains('flutter-private-value')));
+    expect(diagnostics, contains('<redacted>'));
+    expect(diagnostics, contains('<redacted-url>'));
+    for (final file in await _diagnosticFiles(sandbox)) {
+      expect(
+        await file.length(),
+        lessThanOrEqualTo(262144),
+        reason: '${file.path} exceeded the per-file diagnostic bound',
+      );
+    }
+  });
+
+  test(
+    'does not classify a test-body assertion failure as retryable',
+    () async {
+      await _writeExecutable(fakeFlutter, '''#!/usr/bin/env bash
+echo 'Running Xcode build...'
+echo 'Xcode build done. 1.0s'
+echo 'MOBILE_SMOKE_BODY_STARTED'
+echo 'Expected: true Actual: false'
+exit 1
+''');
+
+      final result = await _runAttempt(sandbox, fakeFlutter, fakeXcrun);
+
+      expect(result.exitCode, isNonZero);
+      expect(await _classification(sandbox), 'test_failure');
+    },
+  );
+
+  test('does not retry a launch failure that exits during capture', () async {
+    final fakePs = File('${sandbox.path}/ps');
+    await _writeExecutable(fakeFlutter, '''#!/usr/bin/env bash
+echo 'Running Xcode build...'
+echo 'Xcode build done. 1.0s'
+sleep 2
+exit 1
+''');
+    await _writeExecutable(fakePs, '''#!/usr/bin/env bash
+sleep 2
+echo 'bounded process snapshot'
+''');
+
+    final result = await _runAttempt(
+      sandbox,
+      fakeFlutter,
+      fakeXcrun,
+      extraEnvironment: {'IOS_SMOKE_PS_BIN': fakePs.path},
+    );
+
+    expect(result.exitCode, isNonZero);
+    expect(await _classification(sandbox), 'launch_failure');
+  });
+
+  test('creates a fresh retry device with the same runtime and type', () async {
+    final output = File('${sandbox.path}/retry-device-id');
+    final diagnostics = Directory('${sandbox.path}/diagnostics');
+    final result = await Process.run(
+      'bash',
+      [
+        _scriptPath,
+        'create-retry-device',
+        'SOURCE-DEVICE',
+        output.path,
+        diagnostics.path,
+      ],
+      workingDirectory: Directory.current.path,
+      environment: {
+        ...Platform.environment,
+        'IOS_SMOKE_XCRUN_BIN': fakeXcrun.path,
+      },
+    );
+
+    expect(result.exitCode, 0, reason: result.stderr.toString());
+    expect(
+      (await output.readAsString()).trim(),
+      'A1B2C3D4-E5F6-47A8-90AB-CDEF12345678',
+    );
+    final calls = await xcrunCalls.readAsString();
+    expect(
+      calls,
+      contains(
+        'simctl create Lantern CI retry local-1 '
+        'com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro '
+        'com.apple.CoreSimulator.SimRuntime.iOS-18-6',
+      ),
+    );
+    expect(calls, contains('simctl boot A1B2C3D4-E5F6-47A8-90AB-CDEF12345678'));
+    expect(
+      calls,
+      contains('simctl bootstatus A1B2C3D4-E5F6-47A8-90AB-CDEF12345678 -b'),
+    );
+  });
+
+  test('finalizes an interrupted raw log before artifact upload', () async {
+    final diagnostics = Directory('${sandbox.path}/interrupted');
+    await diagnostics.create();
+    final flutterLog = File('${diagnostics.path}/flutter.log');
+    await flutterLog.writeAsString(
+      '${'x' * 300000}\n'
+      'Authorization: Bearer interrupted-secret '
+      'https://interrupted.private.test/path\n',
+    );
+    await File('${diagnostics.path}/partial.raw').writeAsString('raw-secret');
+
+    final result = await Process.run('bash', [
+      _scriptPath,
+      'finalize-diagnostics',
+      diagnostics.path,
+    ], workingDirectory: Directory.current.path);
+
+    expect(result.exitCode, 0, reason: result.stderr.toString());
+    expect(await flutterLog.length(), lessThanOrEqualTo(262144));
+    final text = await flutterLog.readAsString();
+    expect(text, isNot(contains('interrupted-secret')));
+    expect(text, isNot(contains('interrupted.private.test')));
+    expect(text, contains('<redacted>'));
+    expect(text, contains('<redacted-url>'));
+    expect(File('${diagnostics.path}/partial.raw').existsSync(), isFalse);
+    expect(
+      await File('${diagnostics.path}/finalized.txt').readAsString(),
+      'bounded=true redacted=true\n',
+    );
+  });
+}
+
+String get _scriptPath => '${Directory.current.path}/tool/ios_smoke_ci.sh';
+
+Future<void> _writeExecutable(File file, String contents) async {
+  await file.writeAsString(contents);
+  final chmod = await Process.run('chmod', ['+x', file.path]);
+  if (chmod.exitCode != 0) {
+    throw ProcessException(
+      'chmod',
+      ['+x', file.path],
+      '${chmod.stderr}',
+      chmod.exitCode,
+    );
+  }
+}
+
+Future<ProcessResult> _runAttempt(
+  Directory sandbox,
+  File flutter,
+  File xcrun, {
+  Map<String, String> extraEnvironment = const {},
+}) => Process.run(
+  'bash',
+  [
+    _scriptPath,
+    'run-attempt',
+    'SOURCE-DEVICE',
+    'initial',
+    '${sandbox.path}/diagnostics',
+  ],
+  workingDirectory: Directory.current.path,
+  environment: {
+    ...Platform.environment,
+    'IOS_SMOKE_FLUTTER_BIN': flutter.path,
+    'IOS_SMOKE_XCRUN_BIN': xcrun.path,
+    'IOS_SMOKE_LAUNCH_TIMEOUT_SECONDS': '1',
+    'IOS_SMOKE_TOTAL_TIMEOUT_SECONDS': '12',
+    'IOS_SMOKE_POLL_INTERVAL_SECONDS': '1',
+    'IOS_SMOKE_DIAGNOSTIC_TIMEOUT_SECONDS': '1',
+    ...extraEnvironment,
+  },
+);
+
+Future<String> _classification(Directory sandbox) async => (await File(
+  '${sandbox.path}/diagnostics/initial/classification.txt',
+).readAsString()).trim();
+
+Future<String> _diagnosticText(Directory sandbox) async {
+  final output = StringBuffer();
+  for (final file in await _diagnosticFiles(sandbox)) {
+    output.writeln(await file.readAsString(encoding: utf8));
+  }
+  return output.toString();
+}
+
+Future<List<File>> _diagnosticFiles(Directory sandbox) async {
+  final files = <File>[];
+  final directory = Directory('${sandbox.path}/diagnostics/initial');
+  await for (final entity in directory.list(recursive: true)) {
+    if (entity is File &&
+        (entity.path.endsWith('.txt') || entity.path.endsWith('.log'))) {
+      files.add(entity);
+    }
+  }
+  return files;
+}

--- a/sdks/dart/example/tool/ios_smoke_ci.sh
+++ b/sdks/dart/example/tool/ios_smoke_ci.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly bundle_id="com.anaregdesign.lanternExample"
+readonly flutter_bin="${IOS_SMOKE_FLUTTER_BIN:-flutter}"
+readonly xcrun_bin="${IOS_SMOKE_XCRUN_BIN:-xcrun}"
+readonly ps_bin="${IOS_SMOKE_PS_BIN:-ps}"
+readonly launch_timeout="${IOS_SMOKE_LAUNCH_TIMEOUT_SECONDS:-90}"
+readonly total_timeout="${IOS_SMOKE_TOTAL_TIMEOUT_SECONDS:-480}"
+readonly poll_interval="${IOS_SMOKE_POLL_INTERVAL_SECONDS:-1}"
+readonly diagnostic_timeout="${IOS_SMOKE_DIAGNOSTIC_TIMEOUT_SECONDS:-10}"
+readonly max_diagnostic_bytes=262144
+
+require_positive_integer() {
+  local name=$1 value=$2
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "invalid $name: $value" >&2
+    exit 64
+  fi
+}
+
+redact_text() {
+  local source=$1 destination=$2
+  sed -E \
+    -e 's#https?://[^[:space:]<>]+#<redacted-url>#g' \
+    -e 's#(Authorization:?[[:space:]]*(Bearer[[:space:]]*)?)[^[:space:]]+#\1<redacted>#Ig' \
+    -e 's#((LANTERN_)?TOKEN|token)[=:][^[:space:]]+#\1=<redacted>#g' \
+    -e 's#mobile-smoke:[^[:space:]]+#mobile-smoke:<redacted>#g' \
+    -e 's#[A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{12,}#<redacted-jwt>#g' \
+    "$source" > "$destination"
+}
+
+capture_bounded() {
+  local destination=$1
+  shift
+  local raw
+  raw=$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/lantern-ios-diagnostic.XXXXXX")
+  local pid polls=0 status=0
+  local max_polls=$((diagnostic_timeout * 10))
+  "$@" > "$raw" 2>&1 &
+  pid=$!
+  while kill -0 "$pid" 2>/dev/null; do
+    if (( polls >= max_polls )); then
+      kill -TERM "$pid" 2>/dev/null || true
+      sleep 1
+      kill -KILL "$pid" 2>/dev/null || true
+      break
+    fi
+    sleep 0.1
+    polls=$((polls + 1))
+  done
+  wait "$pid" || status=$?
+  LC_ALL=C head -c "$max_diagnostic_bytes" "$raw" > "${raw}.bounded"
+  redact_text "${raw}.bounded" "$destination"
+  rm -f "$raw" "${raw}.bounded"
+  return "$status"
+}
+
+capture_diagnostics() {
+  local device=$1 destination=$2
+  mkdir -p "$destination"
+  capture_bounded "$destination/simctl-devices.txt" \
+    "$xcrun_bin" simctl list devices || true
+  capture_bounded "$destination/installed-apps.txt" \
+    "$xcrun_bin" simctl listapps "$device" || true
+  capture_bounded "$destination/app-container.txt" \
+    "$xcrun_bin" simctl get_app_container "$device" "$bundle_id" app || true
+  capture_bounded "$destination/process-tree.txt" \
+    "$ps_bin" -axo pid,ppid,state,etime,command || true
+  capture_bounded "$destination/simulator.log" \
+    "$xcrun_bin" simctl spawn "$device" log show --last 5m --style compact \
+    --predicate 'process == "Runner" OR process == "SpringBoard" OR subsystem BEGINSWITH "com.apple.FrontBoard"' || true
+}
+
+descendants_of() {
+  local parent=$1 child
+  for child in $(pgrep -P "$parent" 2>/dev/null || true); do
+    descendants_of "$child"
+    echo "$child"
+  done
+}
+
+terminate_process_tree() {
+  local root=$1 child
+  local descendants=""
+  descendants=$(descendants_of "$root")
+  for child in $descendants; do
+    kill -TERM "$child" 2>/dev/null || true
+  done
+  kill -TERM "$root" 2>/dev/null || true
+  sleep 2
+  for child in $descendants; do
+    kill -KILL "$child" 2>/dev/null || true
+  done
+  kill -KILL "$root" 2>/dev/null || true
+}
+
+record_classification() {
+  local classification=$1 destination=$2
+  printf '%s\n' "$classification" > "$destination/classification.txt"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    printf 'classification=%s\n' "$classification" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+sanitize_bounded_file() {
+  local source=$1 bounded sanitized
+  bounded=$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/lantern-ios-bounded.XXXXXX")
+  sanitized=$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/lantern-ios-sanitized.XXXXXX")
+  LC_ALL=C tail -c "$max_diagnostic_bytes" "$source" > "$bounded"
+  redact_text "$bounded" "$sanitized"
+  mv "$sanitized" "$source"
+  rm -f "$bounded" "$sanitized"
+}
+
+finalize_diagnostics() {
+  local root=$1 file size finalized
+  local count=0 total=0
+  mkdir -p "$root"
+  if find "$root" -mindepth 1 ! -type d ! -type f -print -quit | grep -q .; then
+    echo "diagnostics contain a non-regular entry" >&2
+    return 1
+  fi
+  while IFS= read -r -d '' file; do
+    case "$file" in
+      *.raw | *.bounded | *.sanitized)
+        rm -f "$file"
+        continue
+        ;;
+    esac
+    sanitize_bounded_file "$file"
+    size=$(wc -c < "$file")
+    count=$((count + 1))
+    total=$((total + size))
+    if (( count > 32 || total > 2097152 )); then
+      echo "diagnostics exceed the aggregate artifact bound" >&2
+      return 1
+    fi
+  done < <(find "$root" -type f -print0)
+  finalized="$root/finalized.txt"
+  printf 'bounded=true redacted=true\n' > "$finalized"
+  size=$(wc -c < "$finalized")
+  count=$((count + 1))
+  total=$((total + size))
+  if (( count > 32 || total > 2097152 )); then
+    rm -f "$finalized"
+    echo "diagnostics exceed the aggregate artifact bound" >&2
+    return 1
+  fi
+}
+
+run_attempt() {
+  local device=$1 attempt=$2 diagnostics_root=$3
+  local destination="$diagnostics_root/$attempt"
+  local log="$destination/flutter.log"
+  local started_at=$SECONDS build_done_at=-1 body_started=false
+  local classification=pre_body_failure status=0
+
+  require_positive_integer IOS_SMOKE_LAUNCH_TIMEOUT_SECONDS "$launch_timeout"
+  require_positive_integer IOS_SMOKE_TOTAL_TIMEOUT_SECONDS "$total_timeout"
+  require_positive_integer IOS_SMOKE_POLL_INTERVAL_SECONDS "$poll_interval"
+  require_positive_integer IOS_SMOKE_DIAGNOSTIC_TIMEOUT_SECONDS "$diagnostic_timeout"
+  [[ "$attempt" =~ ^[a-z0-9_-]+$ ]] || {
+    echo "invalid attempt label: $attempt" >&2
+    return 64
+  }
+  mkdir -p "$destination"
+  : > "$log"
+
+  (
+    set -o pipefail
+    "$flutter_bin" test --no-pub integration_test/mobile_smoke_test.dart \
+      -d "$device" --reporter=expanded --timeout=3m \
+      --dart-define=LANTERN_ENDPOINT=http://127.0.0.1:6380 \
+      --dart-define=LANTERN_ALLOW_INSECURE=true 2>&1 | tee -a "$log"
+  ) &
+  local runner_pid=$!
+
+  while kill -0 "$runner_pid" 2>/dev/null; do
+    if [[ "$body_started" == false ]] && \
+      grep -Fq 'MOBILE_SMOKE_BODY_STARTED' "$log"; then
+      body_started=true
+    fi
+    if (( build_done_at < 0 )) && grep -Fq 'Xcode build done.' "$log"; then
+      build_done_at=$SECONDS
+    fi
+    if (( build_done_at >= 0 )) && [[ "$body_started" == false ]] && \
+      (( SECONDS - build_done_at >= launch_timeout )); then
+      if grep -Fq 'MOBILE_SMOKE_BODY_STARTED' "$log"; then
+        body_started=true
+        continue
+      fi
+      mkdir -p "$destination/diagnostics"
+      capture_bounded "$destination/diagnostics/process-tree-before-stop.txt" \
+        "$ps_bin" -axo pid,ppid,state,etime,command || true
+      if grep -Fq 'MOBILE_SMOKE_BODY_STARTED' "$log"; then
+        body_started=true
+        continue
+      fi
+      if ! kill -0 "$runner_pid" 2>/dev/null; then
+        break
+      fi
+      terminate_process_tree "$runner_pid"
+      wait "$runner_pid" || true
+      capture_diagnostics "$device" "$destination/diagnostics"
+      sanitize_bounded_file "$log"
+      record_classification launch_stall "$destination"
+      return 70
+    fi
+    if (( SECONDS - started_at >= total_timeout )); then
+      if grep -Fq 'MOBILE_SMOKE_BODY_STARTED' "$log"; then
+        body_started=true
+      fi
+      if [[ "$body_started" == true ]]; then
+        classification=test_body_stall
+      elif (( build_done_at >= 0 )); then
+        classification=launch_stall
+      elif grep -Fq 'Running Xcode build...' "$log"; then
+        classification=build_stall
+      else
+        classification=pre_body_stall
+      fi
+      mkdir -p "$destination/diagnostics"
+      capture_bounded "$destination/diagnostics/process-tree-before-stop.txt" \
+        "$ps_bin" -axo pid,ppid,state,etime,command || true
+      if grep -Fq 'MOBILE_SMOKE_BODY_STARTED' "$log"; then
+        body_started=true
+        classification=test_body_stall
+      fi
+      if ! kill -0 "$runner_pid" 2>/dev/null; then
+        break
+      fi
+      terminate_process_tree "$runner_pid"
+      wait "$runner_pid" || true
+      capture_diagnostics "$device" "$destination/diagnostics"
+      sanitize_bounded_file "$log"
+      record_classification "$classification" "$destination"
+      return 71
+    fi
+    sleep "$poll_interval"
+  done
+
+  wait "$runner_pid" || status=$?
+  if grep -Fq 'MOBILE_SMOKE_BODY_STARTED' "$log"; then
+    body_started=true
+  fi
+  if (( status == 0 )) && grep -Fq 'MOBILE_SMOKE_PASS ' "$log" && \
+    grep -Fq 'All tests passed!' "$log"; then
+    sanitize_bounded_file "$log"
+    record_classification success "$destination"
+    return 0
+  fi
+  if [[ "$body_started" == true ]]; then
+    classification=test_failure
+  elif grep -Fq 'Xcode build done.' "$log"; then
+    classification=launch_failure
+  elif grep -Fq 'Running Xcode build...' "$log"; then
+    classification=build_failure
+  fi
+  capture_diagnostics "$device" "$destination/diagnostics"
+  sanitize_bounded_file "$log"
+  record_classification "$classification" "$destination"
+  return 72
+}
+
+create_retry_device() {
+  local source_device=$1 output_file=$2 diagnostics_root=$3
+  local record runtime device_type retry_device name boot_status=0 boot_log
+  mkdir -p "$diagnostics_root"
+  record=$(
+    "$xcrun_bin" simctl list devices available -j | jq -er \
+      --arg id "$source_device" \
+      '.devices | to_entries[] | .key as $runtime | .value[] |
+       select(.udid == $id) | [$runtime, .deviceTypeIdentifier] | @tsv'
+  )
+  runtime=${record%%$'\t'*}
+  device_type=${record#*$'\t'}
+  [[ -n "$runtime" && -n "$device_type" && "$runtime" != "$device_type" ]]
+  name="Lantern CI retry ${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}"
+  retry_device=$(
+    "$xcrun_bin" simctl create "$name" "$device_type" "$runtime"
+  )
+  [[ "$retry_device" =~ ^[0-9A-Fa-f-]{8,}$ ]]
+  [[ "$retry_device" != "$source_device" ]]
+  printf '%s\n' "$retry_device" > "$output_file"
+  boot_log=$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/lantern-ios-retry-boot.XXXXXX")
+  "$xcrun_bin" simctl boot "$retry_device" \
+    > "$boot_log" 2>&1 || boot_status=$?
+  if (( boot_status == 0 )); then
+    "$xcrun_bin" simctl bootstatus "$retry_device" -b \
+      >> "$boot_log" 2>&1 || boot_status=$?
+  fi
+  sanitize_bounded_file "$boot_log"
+  mv "$boot_log" "$diagnostics_root/retry-device-boot.log"
+  (( boot_status == 0 )) || return "$boot_status"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    printf 'device_id=%s\n' "$retry_device" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+usage() {
+  echo "usage: $0 run-attempt <device> <label> <diagnostics-root>" >&2
+  echo "       $0 create-retry-device <source-device> <output-file> <diagnostics-root>" >&2
+  echo "       $0 finalize-diagnostics <diagnostics-root>" >&2
+  exit 64
+}
+
+case "${1:-}" in
+  run-attempt)
+    [[ $# -eq 4 ]] || usage
+    run_attempt "$2" "$3" "$4"
+    ;;
+  create-retry-device)
+    [[ $# -eq 4 ]] || usage
+    create_retry_device "$2" "$3" "$4"
+    ;;
+  finalize-diagnostics)
+    [[ $# -eq 2 ]] || usage
+    finalize_diagnostics "$2"
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/tests/integration/docs_gate_test.go
+++ b/tests/integration/docs_gate_test.go
@@ -216,6 +216,13 @@ func TestDartWorkflowGate(t *testing.T) {
 		"name: Start iOS simulator boot",
 		"name: Wait for iOS simulator",
 		"flutter build ios --debug --no-codesign --no-pub",
+		"name: Run classified iOS native smoke",
+		`bash tool/ios_smoke_ci.sh run-attempt "$DEVICE_ID" initial`,
+		"name: Create independently clean retry simulator",
+		"name: Retry classified iOS native smoke on fresh simulator",
+		"name: Finalize bounded iOS launch diagnostics",
+		"name: Upload bounded iOS launch diagnostics",
+		"name: Require classified iOS smoke success",
 		"name: Record exact Android revision evidence",
 		"name: Record exact iOS revision evidence",
 		`--arg commit "$GITHUB_SHA"`,
@@ -278,7 +285,12 @@ func TestDartWorkflowGate(t *testing.T) {
 		"name: Start Lantern",
 		"name: Check and build iOS example",
 		"name: Wait for iOS simulator",
-		"name: Run iOS native smoke",
+		"name: Run classified iOS native smoke",
+		"name: Create independently clean retry simulator",
+		"name: Retry classified iOS native smoke on fresh simulator",
+		"name: Finalize bounded iOS launch diagnostics",
+		"name: Upload bounded iOS launch diagnostics",
+		"name: Require classified iOS smoke success",
 	} {
 		index := strings.Index(ios, step)
 		if index < 0 {
@@ -289,11 +301,64 @@ func TestDartWorkflowGate(t *testing.T) {
 		}
 		last = index
 	}
+	for _, contract := range []string{
+		"timeout-minutes: 45",
+		"IOS_SMOKE_LAUNCH_TIMEOUT_SECONDS: 90",
+		"IOS_SMOKE_TOTAL_TIMEOUT_SECONDS: 480",
+		"steps.ios_smoke_initial.outputs.classification == 'launch_stall'",
+		`test "$retry_device" != "$DEVICE_ID"`,
+		"if: always()",
+		"lantern-ios-smoke-diagnostics-${{ github.sha }}-${{ github.run_attempt }}",
+		"if: always() && steps.ios_diagnostics_finalize.outcome == 'success'",
+		`echo "SMOKE_DEVICE_ID=$RETRY_DEVICE_ID"`,
+		`--arg id "$SMOKE_DEVICE_ID"`,
+		`xcrun simctl delete "$retry_device"`,
+		"- name: Record exact iOS revision evidence\n        if: success()",
+		"- name: Upload sanitized iOS revision evidence\n        if: success()",
+	} {
+		if !strings.Contains(ios, contract) {
+			t.Errorf("iOS job is missing classified launch contract %q", contract)
+		}
+	}
+	if strings.Contains(ios, `simctl erase "$DEVICE_ID"`) {
+		t.Error("iOS launch retry still erases and reuses the wedged simulator")
+	}
+
+	helper, err := os.ReadFile(filepath.Join(repoRoot, "sdks", "dart", "example", "tool", "ios_smoke_ci.sh"))
+	if err != nil {
+		t.Fatalf("read iOS smoke helper: %v", err)
+	}
+	helperText := string(helper)
+	for _, contract := range []string{
+		"MOBILE_SMOKE_BODY_STARTED",
+		"Xcode build done.",
+		"record_classification launch_stall",
+		"classification=test_failure",
+		"capture_diagnostics",
+		"finalize_diagnostics",
+		"count > 32 || total > 2097152",
+		"simctl listapps",
+		"simctl get_app_container",
+		"log show --last 5m",
+		"<redacted-url>",
+		"simctl create",
+		`[[ "$retry_device" != "$source_device" ]]`,
+	} {
+		if !strings.Contains(helperText, contract) {
+			t.Errorf("iOS smoke helper is missing contract %q", contract)
+		}
+	}
+	if got := strings.Count(helperText, `if ! kill -0 "$runner_pid" 2>/dev/null; then`); got != 2 {
+		t.Errorf("iOS smoke helper must recheck runner liveness before both timeout kills; got %d checks", got)
+	}
 
 	for _, contract := range []string{
 		"routes backend/search-only changes through the current-Dart unit and real-wire gates",
 		"stable `Gate` job",
 		"required result set for either scope",
+		"Only that silent `launch_stall` may retry",
+		"newly\ncreated simulator",
+		"diagnostics are always\nuploaded",
 	} {
 		if !strings.Contains(string(contributing), contract) {
 			t.Errorf("CONTRIBUTING.md is missing Dart workflow contract %q", contract)


### PR DESCRIPTION
Closes #1202

## Summary
- classify iOS native smoke phases and retry only a silent post-build launch stall
- retry once on a newly created simulator with the same runtime/device type and a different UDID
- always finalize bounded, redacted diagnostics and bind revision evidence to the simulator that passed
- add regression coverage for boundary races, output classification, cleanup, and interrupted logs

## Validation
- all six Go modules: test, build, vet
- parent Dart format, analyze, and 85 tests (one listener-unset skip)
- Flutter example analyze and 14 tests
- actionlint, shell syntax, docs workflow gate, diff check
- local real Lantern + iOS simulator smoke passed

The helper rebuilds on the fresh simulator because Flutter has no stable install-without-build integration-test path.